### PR TITLE
Resolve real company names for boards left with a numeric platform id

### DIFF
--- a/cmd/backfill-company-names/main.go
+++ b/cmd/backfill-company-names/main.go
@@ -148,7 +148,7 @@ func resolveNames(ctx context.Context, rows []db.ListSlugLikeCompaniesForBackfil
 				log.Printf("resolve %s (%s): %v", row.Slug, row.Source, err)
 				return nil // a single board failing must not abort the run
 			}
-			name, ok := companyname.Accept(row.Name, candidate)
+			name, ok := companyname.Accept(row.Source, row.Name, candidate)
 			mu.Lock()
 			defer mu.Unlock()
 			if !ok {

--- a/cmd/backfill-company-names/main.go
+++ b/cmd/backfill-company-names/main.go
@@ -136,7 +136,7 @@ func resolveNames(ctx context.Context, rows []db.ListSlugLikeCompaniesForBackfil
 			stats.noSource++
 			continue
 		}
-		board, ok := companyname.BoardFromURL(row.Source, row.URL)
+		board, ok := companyname.Board(row.Source, row.Name, row.URL)
 		if !ok {
 			stats.noSource++
 			continue

--- a/internal/companyname/board.go
+++ b/internal/companyname/board.go
@@ -5,6 +5,22 @@ import (
 	"strings"
 )
 
+// Board returns the ATS board identifier to resolve a company's real name for.
+// Most sources embed it in a representative job URL (BoardFromURL). join.com is
+// the exception: its job URL carries the company's URL-slug domain, not its
+// numeric company id, so the id can't be recovered from the URL at all — but
+// when name is itself a numeric placeholder (see NumericPlaceholder), that
+// placeholder IS the join company id, verbatim, because that's how it got
+// written into the company field in the first place. Using it directly needs
+// no URL parsing and can't be spoofed by an unrelated numeric-looking name from
+// another source, since this path only fires for join.
+func Board(source, name, rawURL string) (string, bool) {
+	if source == "join" && NumericPlaceholder(name) {
+		return name, true
+	}
+	return BoardFromURL(source, rawURL)
+}
+
 // BoardFromURL extracts the ATS board identifier from a representative job URL
 // for the given source, matching the host/path shape each resolver fetches
 // against. It returns ("", false) for unknown sources or unparseable URLs so the

--- a/internal/companyname/board_test.go
+++ b/internal/companyname/board_test.go
@@ -28,3 +28,27 @@ func TestBoardFromURL(t *testing.T) {
 		}
 	}
 }
+
+func TestBoard(t *testing.T) {
+	cases := []struct {
+		source, name, url string
+		want              string
+		wantOK            bool
+	}{
+		// join: the board is the numeric placeholder name itself — its job URL
+		// carries the company's slug domain, not the numeric id, so it can't be
+		// recovered from the URL at all.
+		{"join", "175014", "https://join.com/companies/goodweekcom/16575727-x", "175014", true},
+		// A join company whose name already got resolved has nothing to backfill.
+		{"join", "Goodweek", "https://join.com/companies/goodweekcom/16575727-x", "", false},
+		// Non-join sources are untouched — still fall through to BoardFromURL.
+		{"pinpoint", "lbresearch", "https://lbresearch.pinpointhq.com/en/postings/78ba", "lbresearch", true},
+	}
+	for _, c := range cases {
+		got, ok := Board(c.source, c.name, c.url)
+		if got != c.want || ok != c.wantOK {
+			t.Errorf("Board(%q, %q, %q) = (%q, %v), want (%q, %v)",
+				c.source, c.name, c.url, got, ok, c.want, c.wantOK)
+		}
+	}
+}

--- a/internal/companyname/gate.go
+++ b/internal/companyname/gate.go
@@ -31,7 +31,9 @@ var (
 )
 
 // SlugLike reports whether name is still a squished slug rather than a real
-// display name — a single lowercase token with at least one letter.
+// display name — a single lowercase token with at least one letter — or a bare
+// numeric platform ID (e.g. a join.com company id written straight into the
+// company field by a harvest that never resolved the tenant's name).
 func SlugLike(name string) bool {
 	if name == "" || strings.ContainsFunc(name, unicode.IsSpace) {
 		return false
@@ -45,7 +47,27 @@ func SlugLike(name string) bool {
 			hasLetter = true
 		}
 	}
-	return hasLetter
+	if hasLetter {
+		return true
+	}
+	return NumericPlaceholder(name)
+}
+
+// NumericPlaceholder reports whether name is nothing but digits — the shape a
+// board id takes when a harvest writes it into the company field verbatim
+// instead of a resolved display name. Unlike a squished slug, a numeric id
+// shares no text with the real name by construction, so Accept's usual
+// substring/acronym confidence check does not apply to it.
+func NumericPlaceholder(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		if !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
 }
 
 // ExtractTitleName pulls a company name out of a Pinpoint careers-page <title>: the shapes
@@ -98,7 +120,10 @@ func clean(s string) string {
 
 // Accept decodes and validates a candidate name against the slug. It returns the
 // cleaned name and true only when the candidate is non-junk and confidently
-// related to the slug (shares a substring or a multi-letter acronym).
+// related to the slug (shares a substring or a multi-letter acronym) — except
+// when slug is a bare numeric platform id, where no text relation is possible
+// by construction and trust instead comes from the resolver having looked the
+// candidate up by that exact id against the platform's own API.
 func Accept(slug, candidate string) (string, bool) {
 	candidate = strings.TrimSpace(html.UnescapeString(candidate))
 	// An empty or still-slug-like candidate is no improvement over what's stored,
@@ -113,7 +138,7 @@ func Accept(slug, candidate string) (string, bool) {
 			return "", false
 		}
 	}
-	if !confident(slug, candidate) {
+	if !NumericPlaceholder(slug) && !confident(slug, candidate) {
 		return "", false
 	}
 	return candidate, true

--- a/internal/companyname/gate.go
+++ b/internal/companyname/gate.go
@@ -121,10 +121,12 @@ func clean(s string) string {
 // Accept decodes and validates a candidate name against the slug. It returns the
 // cleaned name and true only when the candidate is non-junk and confidently
 // related to the slug (shares a substring or a multi-letter acronym) — except
-// when slug is a bare numeric platform id, where no text relation is possible
-// by construction and trust instead comes from the resolver having looked the
-// candidate up by that exact id against the platform's own API.
-func Accept(slug, candidate string) (string, bool) {
+// for join, whose numeric slug is looked up by that exact id against the
+// platform's own API, so no text relation to check is possible or needed. A
+// numeric slug from any other source still requires the confidence match: its
+// resolver reaches a candidate by scraping a board derived from the URL, not by
+// an id-exact lookup, so an unrelated page title could otherwise slip through.
+func Accept(source, slug, candidate string) (string, bool) {
 	candidate = strings.TrimSpace(html.UnescapeString(candidate))
 	// An empty or still-slug-like candidate is no improvement over what's stored,
 	// so reject it: applying it would be a no-op write that also keeps the company
@@ -138,7 +140,8 @@ func Accept(slug, candidate string) (string, bool) {
 			return "", false
 		}
 	}
-	if !NumericPlaceholder(slug) && !confident(slug, candidate) {
+	authoritative := source == "join" && NumericPlaceholder(slug)
+	if !authoritative && !confident(slug, candidate) {
 		return "", false
 	}
 	return candidate, true

--- a/internal/companyname/gate_test.go
+++ b/internal/companyname/gate_test.go
@@ -71,39 +71,45 @@ func TestExtractTitleName(t *testing.T) {
 
 func TestAccept(t *testing.T) {
 	cases := []struct {
+		source    string
 		slug      string
 		candidate string
 		wantName  string
 		wantOK    bool
 	}{
 		// Accepted: candidate is a spaced-out form of the slug (substring match).
-		{"afcb", "AFC Bournemouth", "AFC Bournemouth", true},
-		{"gs1ca", "GS1 Canada", "GS1 Canada", true},
-		{"bathspa", "Bath Spa University", "Bath Spa University", true},
+		{"pinpoint", "afcb", "AFC Bournemouth", "AFC Bournemouth", true},
+		{"pinpoint", "gs1ca", "GS1 Canada", "GS1 Canada", true},
+		{"pinpoint", "bathspa", "Bath Spa University", "Bath Spa University", true},
 		// Accepted with HTML-entity decode.
-		{"bobsredmill", "Bob&#39;s Red Mill", "Bob's Red Mill", true},
-		{"aspireallergy", "Aspire Allergy &amp; Sinus", "Aspire Allergy & Sinus", true},
+		{"pinpoint", "bobsredmill", "Bob&#39;s Red Mill", "Bob's Red Mill", true},
+		{"pinpoint", "aspireallergy", "Aspire Allergy &amp; Sinus", "Aspire Allergy & Sinus", true},
 		// Rejected: unrelated name (recruiter / rebrand / wrong subdomain).
-		{"kempinski", "Elena - Meta Recruitment", "", false},
-		{"mountainwarehouse", "Mountain Group", "", false},
-		{"nxcus", "NexCore", "", false},        // single-letter acronym is not enough
-		{"lbresearch", "Centellic", "", false}, // rebrand shares nothing with slug
+		{"pinpoint", "kempinski", "Elena - Meta Recruitment", "", false},
+		{"pinpoint", "mountainwarehouse", "Mountain Group", "", false},
+		{"pinpoint", "nxcus", "NexCore", "", false},        // single-letter acronym is not enough
+		{"pinpoint", "lbresearch", "Centellic", "", false}, // rebrand shares nothing with slug
 		// Rejected: empty / junk.
-		{"anything", "", "", false},
-		{"joe-testing", "Joe's Test Platform", "", false},
+		{"pinpoint", "anything", "", "", false},
+		{"pinpoint", "joe-testing", "Joe's Test Platform", "", false},
 		// Rejected: candidate is itself a slug — no improvement, and applying it
 		// would keep the company slug-like (non-idempotent re-runs).
-		{"osapiens", "osapiens", "", false},
+		{"pinpoint", "osapiens", "osapiens", "", false},
 		// Accepted despite sharing no text: slug is a bare numeric platform id
-		// (join.com company id), so the confidence check is bypassed — trust
-		// comes from the resolver's authoritative id lookup, not text overlap.
-		{"175014", "Goodweek", "Goodweek", true},
+		// resolved by join's authoritative exact-id lookup, so the confidence
+		// check is bypassed — trust comes from the id match, not text overlap.
+		{"join", "175014", "Goodweek", "Goodweek", true},
+		// Rejected even though the slug is numeric: a non-join source's resolver
+		// reaches its candidate by scraping a board derived from the URL, not by
+		// an id-exact lookup, so an unrelated numeric-slug company must still
+		// pass the confidence check like any other candidate.
+		{"pinpoint", "175014", "Goodweek", "", false},
 	}
 	for _, c := range cases {
-		gotName, gotOK := Accept(c.slug, c.candidate)
+		gotName, gotOK := Accept(c.source, c.slug, c.candidate)
 		if gotOK != c.wantOK || gotName != c.wantName {
-			t.Errorf("Accept(%q, %q) = (%q, %v), want (%q, %v)",
-				c.slug, c.candidate, gotName, gotOK, c.wantName, c.wantOK)
+			t.Errorf("Accept(%q, %q, %q) = (%q, %v), want (%q, %v)",
+				c.source, c.slug, c.candidate, gotName, gotOK, c.wantName, c.wantOK)
 		}
 	}
 }

--- a/internal/companyname/gate_test.go
+++ b/internal/companyname/gate_test.go
@@ -16,11 +16,29 @@ func TestSlugLike(t *testing.T) {
 		{"Centellic", false},       // has uppercase
 		{"Bob's Red Mill", false},  // has spaces
 		{"", false},                // nothing to work with
-		{"123", false},             // no letter
+		{"123", true},              // bare numeric platform id, e.g. a join.com company id
 	}
 	for _, c := range cases {
 		if got := SlugLike(c.name); got != c.want {
 			t.Errorf("SlugLike(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestNumericPlaceholder(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"175014", true},
+		{"0", true},
+		{"", false},
+		{"175014a", false},
+		{"gs1ca", false},
+	}
+	for _, c := range cases {
+		if got := NumericPlaceholder(c.name); got != c.want {
+			t.Errorf("NumericPlaceholder(%q) = %v, want %v", c.name, got, c.want)
 		}
 	}
 }
@@ -76,6 +94,10 @@ func TestAccept(t *testing.T) {
 		// Rejected: candidate is itself a slug — no improvement, and applying it
 		// would keep the company slug-like (non-idempotent re-runs).
 		{"osapiens", "osapiens", "", false},
+		// Accepted despite sharing no text: slug is a bare numeric platform id
+		// (join.com company id), so the confidence check is bypassed — trust
+		// comes from the resolver's authoritative id lookup, not text overlap.
+		{"175014", "Goodweek", "Goodweek", true},
 	}
 	for _, c := range cases {
 		gotName, gotOK := Accept(c.slug, c.candidate)

--- a/internal/companyname/resolver.go
+++ b/internal/companyname/resolver.go
@@ -12,6 +12,20 @@ type textGetter interface {
 	GetText(ctx context.Context, url string) (string, error)
 }
 
+// jsonGetter fetches and decodes a URL's JSON body. Matches sources.JSONGetter
+// so the production sources.Client satisfies it.
+type jsonGetter interface {
+	GetJSON(ctx context.Context, url string, v any) error
+}
+
+// httpGetter is everything NewRegistry's resolvers need from the shared HTTP
+// client — one param type so a single sources.Client satisfies both the
+// title-scrape resolvers (textGetter) and join's API resolver (jsonGetter).
+type httpGetter interface {
+	textGetter
+	jsonGetter
+}
+
 // Resolver resolves a raw display-name candidate for a board from an ATS's own
 // source. It returns "" (not an error) when the source yields no usable name;
 // an error is reserved for transport failures. The candidate is unvalidated —
@@ -46,11 +60,18 @@ type Registry map[string]Resolver
 // the tenant's name — cmd/harvest-boards' bamboohrProber reached the same conclusion and
 // falls back to the slug rather than trying. A resolver wired here would always return ""
 // while looking like it was attempting something; leaving it out is the honest answer.
-func NewRegistry(text textGetter) Registry {
+//
+// join is the odd one out: its board (used by Board, not BoardFromURL — see board.go) is
+// the company's numeric join.com id, and join's own public API resolves that id straight
+// to a display name (no title-scrape needed): GET
+// https://join.com/api/public/companies/{id} -> {"name": "..."}. Confirmed live against
+// id 175014 -> "Goodweek".
+func NewRegistry(http httpGetter) Registry {
 	return Registry{
-		"pinpoint": newTitleResolver(text, "https://%s.pinpointhq.com", ExtractTitleName),
-		"lever":    newTitleResolver(text, "https://jobs.lever.co/%s", ExtractBareTitle),
-		"ashby": newTitleResolver(text, "https://jobs.ashbyhq.com/%s", func(title string) string {
+		"pinpoint": newTitleResolver(http, "https://%s.pinpointhq.com", ExtractTitleName),
+		"lever":    newTitleResolver(http, "https://jobs.lever.co/%s", ExtractBareTitle),
+		"join":     newJoinResolver(http),
+		"ashby": newTitleResolver(http, "https://jobs.ashbyhq.com/%s", func(title string) string {
 			return ExtractSuffixName(title, " Jobs")
 		}),
 	}
@@ -78,4 +99,24 @@ func (r *titleResolver) Name(ctx context.Context, board string) (string, error) 
 		return "", nil
 	}
 	return r.extract(m[1]), nil
+}
+
+const joinCompanyURL = "https://join.com/api/public/companies/%s"
+
+// joinCompanyResp is the subset of join.com's public company-profile response
+// this package needs. board is the numeric join company id.
+type joinCompanyResp struct {
+	Name string `json:"name"`
+}
+
+type joinResolver struct{ http jsonGetter }
+
+func newJoinResolver(http jsonGetter) *joinResolver { return &joinResolver{http: http} }
+
+func (r *joinResolver) Name(ctx context.Context, board string) (string, error) {
+	var resp joinCompanyResp
+	if err := r.http.GetJSON(ctx, fmt.Sprintf(joinCompanyURL, board), &resp); err != nil {
+		return "", err
+	}
+	return resp.Name, nil
 }

--- a/internal/companyname/resolver_test.go
+++ b/internal/companyname/resolver_test.go
@@ -2,12 +2,30 @@ package companyname
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 )
 
 type fakeText map[string]string
 
 func (f fakeText) GetText(_ context.Context, url string) (string, error) { return f[url], nil }
+
+// GetJSON lets fakeText double as an httpGetter for tests that never need it —
+// NewRegistry takes one combined interface for both title-scrape and API resolvers.
+func (f fakeText) GetJSON(context.Context, string, any) error { return nil }
+
+// fakeJSON serves canned JSON bodies keyed by URL, for resolvers that call GetJSON.
+type fakeJSON map[string]string
+
+func (f fakeJSON) GetText(context.Context, string) (string, error) { return "", nil }
+
+func (f fakeJSON) GetJSON(_ context.Context, url string, v any) error {
+	body, ok := f[url]
+	if !ok {
+		return nil
+	}
+	return json.Unmarshal([]byte(body), v)
+}
 
 func TestTitleResolver(t *testing.T) {
 	getter := fakeText{
@@ -48,9 +66,21 @@ func TestAshbyResolverUsesTheJobsSuffix(t *testing.T) {
 	}
 }
 
+// Live-verified against join.com's public company-profile endpoint:
+// GET https://join.com/api/public/companies/175014 -> {"name":"Goodweek",...}.
+func TestJoinResolverUsesTheCompanyProfileAPI(t *testing.T) {
+	getter := fakeJSON{
+		"https://join.com/api/public/companies/175014": `{"id":175014,"name":"Goodweek","domain":"goodweekcom"}`,
+	}
+	reg := NewRegistry(getter)
+	if got, _ := reg["join"].Name(context.Background(), "175014"); got != "Goodweek" {
+		t.Errorf("Name(175014) = %q, want Goodweek", got)
+	}
+}
+
 func TestRegistryLookup(t *testing.T) {
 	reg := NewRegistry(fakeText{})
-	for _, src := range []string{"pinpoint", "lever", "ashby"} {
+	for _, src := range []string{"pinpoint", "lever", "ashby", "join"} {
 		if _, ok := reg[src]; !ok {
 			t.Errorf("registry missing %s resolver", src)
 		}

--- a/sources/bamboohr.yml
+++ b/sources/bamboohr.yml
@@ -367,7 +367,7 @@
   board: 3yourmind
 - company: 401auto
   board: 401auto
-- company: "415"
+- company: 415 Group
   board: "415"
 - company: 4medica
   board: 4medica

--- a/sources/join.yml
+++ b/sources/join.yml
@@ -33,7 +33,7 @@
   board: "100590"
 - company: KOMET FRANCE
   board: "100620"
-- company: "100658"
+- company: La Casita de Ingles
   board: "100658"
 - company: 3S.tax Steuerberatung
   board: "100736"
@@ -71,31 +71,31 @@
   board: "101820"
 - company: Babasport
   board: "101830"
-- company: "101853"
+- company: The Little One - Family.Concept.Store.
   board: "101853"
-- company: "101877"
+- company: FINE DINE Verlags GmbH
   board: "101877"
 - company: TELA MULTICOURSES
   board: "101909"
 - company: Rimas-Care GmbH ambulanter Pflegedienst
   board: "101920"
-- company: "102159"
+- company: MDS Raumsysteme GmbH
   board: "102159"
-- company: "102169"
+- company: Muzi-Berlin Immobilien & Finanzdienst e.K.
   board: "102169"
 - company: AFIANSYS (Waayo Servicios Informáticos SL)
   board: "102223"
 - company: Mibau Stema Deutschland GmbH
   board: "102229"
-- company: "102357"
+- company: Schenk Tanktransport GmbH
   board: "102357"
-- company: "102420"
+- company: Excellcium
   board: "102420"
-- company: "102644"
+- company: DIVISION TELECOM
   board: "102644"
 - company: GRUPO PROTECCION EUROPEA
   board: "102698"
-- company: "10281"
+- company: Physio Service GmbH
   board: "10281"
 - company: Avenir Auto Contrôle Technique Obringer
   board: "102889"
@@ -103,195 +103,195 @@
   board: "102920"
 - company: Huisartsenpraktijk de Boog
   board: "102934"
-- company: "102965"
+- company: EPC Emballages
   board: "102965"
-- company: "102998"
+- company: ARTHURIMMO.COM PRADES LE LEZ
   board: "102998"
 - company: L&M et Associés
   board: "103127"
-- company: "103291"
+- company: MGRP
   board: "103291"
 - company: Mebrutec GmbH
   board: "10330"
 - company: DATAGROUP
   board: "10338"
-- company: "103391"
+- company: KONCEPTING
   board: "103391"
 - company: SWOM (Sociaal Welzijn Op Maat)
   board: "103561"
-- company: "103621"
+- company: Fondation Erik et Odette Bocké
   board: "103621"
 - company: Dalmulder Fijnmetaal
   board: "103627"
 - company: Nutrimaine
   board: "103684"
-- company: "103740"
+- company: PPA
   board: "103740"
-- company: "103813"
+- company: haarmacher kg
   board: "103813"
 - company: Janine Dräger
   board: "103899"
-- company: "103992"
+- company: Riggersa Construcciones S.L
   board: "103992"
-- company: "104027"
+- company: sera Werke Heimtierbedarf J. Ravnak GmbH & Co.KG
   board: "104027"
 - company: C2NR
   board: "104057"
-- company: "104137"
+- company: De Barbecue en Buffettenboer
   board: "104137"
-- company: "104148"
+- company: KAPITAN
   board: "104148"
-- company: "104303"
+- company: Centre de dermatologie Nice Azur
   board: "104303"
-- company: "104343"
+- company: SPH Cleaning Bv
   board: "104343"
-- company: "104460"
+- company: BGS Beta-Gamma-Service GmbH & Co. KG
   board: "104460"
-- company: "104734"
+- company: Peter Kuhnert&Sohn GmbH
   board: "104734"
 - company: GUITTON MENUISERIE
   board: "104850"
-- company: "104862"
+- company: C'EST NET
   board: "104862"
 - company: Circulab
   board: "104882"
-- company: "104935"
+- company: BeMyNounou
   board: "104935"
-- company: "105012"
+- company: ANOVA IMMOBILIER
   board: "105012"
-- company: "105126"
+- company: Ô Choupissons
   board: "105126"
 - company: RT Finanzberatung
   board: "105128"
 - company: GTL Taxi Lyonnnais
   board: "105148"
-- company: "105204"
+- company: SV MIROITERIE
   board: "105204"
-- company: "105423"
+- company: Maison et Architecture
   board: "105423"
-- company: "105425"
+- company: MERCASERVEIS CATALUNYA, S.A.
   board: "105425"
-- company: "105440"
+- company: Skoda Group Austria GmbH
   board: "105440"
 - company: BüroBuddy
   board: "105530"
-- company: "105610"
+- company: Nebuter Proyectos S.L.
   board: "105610"
-- company: "105621"
+- company: TOPONOVA EXTREMADURA S.L.
   board: "105621"
-- company: "105670"
+- company: Checkmyguest
   board: "105670"
-- company: "105737"
+- company: Les Délices d'Alpage
   board: "105737"
-- company: "105756"
+- company: Grupo Q
   board: "105756"
-- company: "105992"
+- company: Warwick GmbH & Co. Music Equipment KG
   board: "105992"
 - company: e-France
   board: "106029"
-- company: "106162"
+- company: Sorienter Ensemble
   board: "106162"
 - company: Peter Müller GmbH
   board: "106195"
 - company: Olives & Beurre salé
   board: "106208"
-- company: "106328"
+- company: MoSa GmbH
   board: "106328"
-- company: "10655"
+- company: CAPcargo AG
   board: "10655"
 - company: Groupe Soloc
   board: "106637"
-- company: "106656"
+- company: Mon Chat mon Amour
   board: "106656"
-- company: "1067"
+- company: Accenture
   board: "1067"
 - company: Tokimo
   board: "106725"
-- company: "106727"
+- company: ERA Agence de Juvisy
   board: "106727"
-- company: "10719"
+- company: www.handy-games.com GmbH
   board: "10719"
-- company: "107195"
+- company: Gassert GmbH
   board: "107195"
-- company: "1074"
+- company: SUXXEED Sales for your Success GmbH
   board: "1074"
 - company: Musikschule Emotio
   board: "107471"
-- company: "107494"
+- company: GONDER Group
   board: "107494"
-- company: "107496"
+- company: Matco Chemicals B.V.
   board: "107496"
-- company: "107530"
+- company: SDL - Soziale Dienste Laer
   board: "107530"
 - company: EHPAD PUBLIC BEAUMONT DE LOMAGNE
   board: "107601"
-- company: "107706"
+- company: Azur Sérénité
   board: "107706"
 - company: Institut Français de la Mode
   board: "107723"
-- company: "107759"
+- company: Javaanse Meisjes
   board: "107759"
-- company: "107801"
+- company: Reijn Retro
   board: "107801"
 - company: CesGensLaB
   board: "107895"
 - company: MCM Research
   board: "107980"
-- company: "1080"
+- company: Alteos GmbH
   board: "1080"
-- company: "108121"
+- company: Klinik Solequelle Kemper GmbH
   board: "108121"
-- company: "108420"
+- company: Bootshaus Cologne GmbH
   board: "108420"
 - company: Sorst Streckmetall GmbH
   board: "108448"
-- company: "108482"
+- company: IFA by Lopesan Hotels
   board: "108482"
-- company: "108702"
+- company: Edelmut Media GmbH
   board: "108702"
-- company: "108744"
+- company: Nextcloud
   board: "108744"
-- company: "108849"
+- company: Facilitaire Support Organisatie B.V.
   board: "108849"
-- company: "108924"
+- company: mazas maquinaria sl
   board: "108924"
 - company: Stay Unique
   board: "109070"
-- company: "109152"
+- company: Recruiting Sonia
   board: "109152"
-- company: "109169"
+- company: Urologie im Medicum PartG
   board: "109169"
-- company: "109406"
+- company: Oudendijk Oils B.V.
   board: "109406"
-- company: "109544"
+- company: iX-tech GmbH
   board: "109544"
-- company: "109585"
+- company: 4fores
   board: "109585"
 - company: Trade4less GmbH
   board: "109736"
-- company: "11013"
+- company: Vulpius Klinik GmbH
   board: "11013"
-- company: "110168"
+- company: Die Zwei Physiotherapie
   board: "110168"
-- company: "110443"
+- company: petaFuel GmbH
   board: "110443"
-- company: "110556"
+- company: Del Arte Avranches
   board: "110556"
-- company: "110571"
+- company: Raison
   board: "110571"
 - company: SCB GmbH & Co.KG
   board: "110592"
-- company: "110601"
+- company: neoBIM GmbH
   board: "110601"
-- company: "110686"
+- company: CABINET CETI IMMOBILIER
   board: "110686"
-- company: "11081"
+- company: Hotel - Restaurant zur Post ***S
   board: "11081"
 - company: pritidenta GmbH
   board: "110827"
-- company: "11089"
+- company: KWB Koordinierungsstelle Weiterbildung und Beschäftigung e. V.
   board: "11089"
-- company: "110933"
+- company: SERRALLERIA METADA
   board: "110933"
 - company: Bim&Beyond
   board: "111001"
@@ -301,303 +301,303 @@
   board: "111079"
 - company: Mairie de Soisy-sur-Seine
   board: "111125"
-- company: "111165"
+- company: SARBEL VERTICAL
   board: "111165"
-- company: "111185"
+- company: AJG MENUISERIE
   board: "111185"
-- company: "111244"
+- company: Loopario
   board: "111244"
-- company: "111287"
+- company: HealthclubNU Abcoude
   board: "111287"
 - company: EBI Computerlösungen
   board: "11143"
-- company: "111470"
+- company: JACIR
   board: "111470"
-- company: "111768"
+- company: FysioZwolle
   board: "111768"
-- company: "111786"
+- company: Der Holzwurm GmbH
   board: "111786"
-- company: "111837"
+- company: ENERDOMO Würzburg, Kitzingen, Ochsenfurt und Marktheidenfeld
   board: "111837"
-- company: "11185"
+- company: SIERA Alliance
   board: "11185"
-- company: "111857"
+- company: Kigen IT-Systemhaus
   board: "111857"
-- company: "111877"
+- company: SchwarzPartners
   board: "111877"
-- company: "111933"
+- company: AUSBAU STRASMANN
   board: "111933"
-- company: "111980"
+- company: E-Capinfo
   board: "111980"
-- company: "112310"
+- company: Zyam Equipamientos, S.L.
   board: "112310"
 - company: Werner Otto GmbH
   board: "112387"
-- company: "112459"
+- company: Vos Transport Group
   board: "112459"
 - company: La Scaleta
   board: "112547"
-- company: "112649"
+- company: Hanse Psychotherapie
   board: "112649"
 - company: Global Aviation Co
   board: "112813"
-- company: "112936"
+- company: SMOBY TOYS
   board: "112936"
 - company: ML INDUSTRIE
   board: "113241"
-- company: "113400"
+- company: AIR CULINAIRE WORLDWIDE FRANCE
   board: "113400"
-- company: "113759"
+- company: Gelukkig Lijf Nijmegen
   board: "113759"
-- company: "113840"
+- company: STACIA CONSULTORES
   board: "113840"
-- company: "113946"
+- company: Leder Reinhardt GmbH
   board: "113946"
 - company: KERN & SOHN GmbH
   board: "113964"
-- company: "114134"
+- company: MySales Consulting GmbH
   board: "114134"
-- company: "114135"
+- company: Euro Freight GmbH
   board: "114135"
 - company: Med-X-Press GmbH
   board: "11439"
-- company: "114608"
+- company: Novares Ibérica Automotive
   board: "114608"
-- company: "114832"
+- company: Lödige Industries GmbH
   board: "114832"
-- company: "114920"
+- company: Future Job Institute
   board: "114920"
-- company: "115052"
+- company: Dental-Technik Freiseis GmbH
   board: "115052"
-- company: "115595"
+- company: ADDOCEO
   board: "115595"
 - company: Foo Seng
   board: "115627"
-- company: "115798"
+- company: Bigfish.nl
   board: "115798"
-- company: "115802"
+- company: Zahn- und Prophylaxezentrum Dr. Thonke & Kollegen
   board: "115802"
-- company: "115875"
+- company: SoFreshSoClean
   board: "115875"
-- company: "115932"
+- company: Bayerwaldzahn MVZ GmbH
   board: "115932"
-- company: "116007"
+- company: agrupa energia
   board: "116007"
-- company: "116232"
+- company: St. George's School Cologne
   board: "116232"
-- company: "11660"
+- company: Quaker Houghton
   board: "11660"
 - company: TVS SCS Italia
   board: "116616"
 - company: MGID
   board: "11672"
-- company: "116905"
+- company: M.Gleser GmbH
   board: "116905"
-- company: "116986"
+- company: Godesberger Privatschule ab Klasse 8
   board: "116986"
 - company: Arena Invest
   board: "117379"
 - company: Green Vision Germany GmbH
   board: "117410"
-- company: "117478"
+- company: Wok Inn Hardenberg B.V.
   board: "117478"
-- company: "117506"
+- company: Johannsen Rechtsanwälte PartG mbB
   board: "117506"
-- company: "117919"
+- company: HYDR8 GmbH
   board: "117919"
 - company: DataNova Technologies
   board: "117980"
-- company: "118089"
+- company: 3B Wonen
   board: "118089"
 - company: Reinigungstechnik Robert Drescher
   board: "118141"
-- company: "118583"
+- company: Loisirs Culture Vacances
   board: "118583"
 - company: LASER MIMAR 2000, S.L.
   board: "118716"
-- company: "118785"
+- company: SBR International GmbH
   board: "118785"
-- company: "118845"
+- company: Bistro LOFT
   board: "118845"
-- company: "119604"
+- company: Restaurant Azie
   board: "119604"
-- company: "119822"
+- company: OPPA Almelo B.V.
   board: "119822"
-- company: "119828"
+- company: aconnic
   board: "119828"
 - company: Stichting Nederlandse Datakluis
   board: "119909"
-- company: "11992"
+- company: Diaverum Deutschland GmbH
   board: "11992"
 - company: Process& GmbH
   board: "12004"
-- company: "120057"
+- company: BlueLemon24
   board: "120057"
-- company: "120080"
+- company: American Village
   board: "120080"
-- company: "120082"
+- company: Geosurvey & topography
   board: "120082"
-- company: "120089"
+- company: Allocator One Group
   board: "120089"
 - company: Fleischerei Gerd Hucke Schinken & Wurst GmbH
   board: "120123"
-- company: "120156"
+- company: SONIMA GmbH
   board: "120156"
-- company: "120325"
+- company: Ambulant Betreutes Wohnen Ostler GmbH & Co. KG
   board: "120325"
-- company: "120394"
+- company: Lagupres
   board: "120394"
-- company: "120433"
+- company: Zahnzentrum Riedstadt
   board: "120433"
-- company: "120479"
+- company: Splash Bildung
   board: "120479"
-- company: "120642"
+- company: Consul Infra Goup B.V.
   board: "120642"
-- company: "120675"
+- company: TOMMASI INDUSTRIES
   board: "120675"
-- company: "121121"
+- company: re-green
   board: "121121"
 - company: Het wapen van Renesse B.V.
   board: "121208"
-- company: "121678"
+- company: Gebr. Lotter KG | Abteilung Betonstahl
   board: "121678"
 - company: SOLFY RENEWABLES, S.L.
   board: "121790"
 - company: Creetion B.V.
   board: "122069"
-- company: "12207"
+- company: Nova GmbH
   board: "12207"
-- company: "122464"
+- company: WENS Hotel
   board: "122464"
-- company: "122491"
+- company: Mikos GmbH
   board: "122491"
 - company: ADMANUM Dentalzentrum GmbH
   board: "122510"
-- company: "122758"
+- company: Nordseebad Spiekeroog GmbH
   board: "122758"
-- company: "122912"
+- company: Connected Car Services Limited
   board: "122912"
-- company: "123019"
+- company: KinderKosmos e.V.
   board: "123019"
 - company: KZWO GmbH
   board: "123031"
-- company: "123069"
+- company: Conservatoire National Supérieur Musique et Danse - CNSMD Lyon
   board: "123069"
-- company: "123449"
+- company: leonardo
   board: "123449"
 - company: Agrar- und Umweltservice Möllers GmbH & Co.KG
   board: "123529"
-- company: "123635"
+- company: Wilgenhaege
   board: "123635"
-- company: "123652"
+- company: WALUTEC Germany GmbH
   board: "123652"
-- company: "123699"
+- company: ATHISA MEDIOAMBIENTE
   board: "123699"
-- company: "123755"
+- company: Emaform AG
   board: "123755"
-- company: "123842"
+- company: Physio Squad
   board: "123842"
-- company: "124018"
+- company: CASA Media GmbH
   board: "124018"
 - company: ATHESI
   board: "124057"
-- company: "124207"
+- company: cardiologie interventionnelle et imagerie cardiaque
   board: "124207"
 - company: Music Eggert GmbH
   board: "124215"
-- company: "124292"
+- company: The DJ Company
   board: "124292"
-- company: "124448"
+- company: Ergotherapie Zimolong
   board: "124448"
-- company: "124663"
+- company: Interad Software GmbH
   board: "124663"
-- company: "124723"
+- company: Microbal. Asesoría Alimentaria S.A.
   board: "124723"
 - company: Showroom of Premium Cars GmbH - SHOWROOM das AUTOHAUS
   board: "12480"
-- company: "124804"
+- company: Gantze Therapie- und Trainingszentrum
   board: "124804"
 - company: Zahnarztpraxis Drebka
   board: "124883"
 - company: Wagenpfeil GmbH
   board: "124960"
-- company: "124969"
+- company: TAGGRS
   board: "124969"
-- company: "124970"
+- company: Proxia Software AG
   board: "124970"
-- company: "124983"
+- company: Werner Gerdau Handelsgesellschaft für Einbauküchen mbH
   board: "124983"
-- company: "125108"
+- company: ZENTROKIT MOBILIARIO
   board: "125108"
-- company: "125613"
+- company: Seiwert GmbH
   board: "125613"
 - company: Schreinerei Zezelj GmbH
   board: "125666"
 - company: Uhl Werbeagentur GmbH
   board: "125793"
-- company: "125811"
+- company: ZAHN | MUND | KIEFER
   board: "125811"
-- company: "125827"
+- company: Janert Textilpflege
   board: "125827"
-- company: "125918"
+- company: Boulangerie la pompadour
   board: "125918"
-- company: "126084"
+- company: SoFine Foods
   board: "126084"
-- company: "126119"
+- company: Verzuimdata B.V.
   board: "126119"
 - company: AMYT
   board: "126272"
 - company: FLEISCHEREI Bachmann GmbH
   board: "126341"
-- company: "126473"
+- company: Maestria Conseil
   board: "126473"
-- company: "12652"
+- company: Omnora GmbH
   board: "12652"
-- company: "126550"
+- company: M.R.S. CLEANING
   board: "126550"
-- company: "126799"
+- company: ELIT-TECHNOLOGIES
   board: "126799"
-- company: "126900"
+- company: Hotel Villa Flora
   board: "126900"
-- company: "127217"
+- company: stücker! Büroeinrichtungs GmbH
   board: "127217"
-- company: "127247"
+- company: Ezoncs Beauty Salon Amsterdam
   board: "127247"
-- company: "127429"
+- company: Meilenstein Therapie und Training GmbH & Co. KG
   board: "127429"
 - company: Andrea Gietl-Coaching für Familien und Einzelne
   board: "127609"
-- company: "127802"
+- company: Mimuse
   board: "127802"
-- company: "127888"
+- company: gip assessors i projectes tecnics sl
   board: "127888"
-- company: "127992"
+- company: Opera GmbH & Co. KG
   board: "127992"
 - company: GGW GmbH
   board: "128052"
-- company: "12817"
+- company: prognum Automotive GmbH
   board: "12817"
-- company: "128195"
+- company: sms zürichsee AG
   board: "128195"
 - company: Die Notfallmamas GmbH
   board: "12821"
-- company: "128232"
+- company: Fytac
   board: "128232"
-- company: "128364"
+- company: METRIC
   board: "128364"
 - company: Zorg uit Handen B.V.
   board: "128481"
-- company: "128636"
+- company: REPARBAR
   board: "128636"
 - company: Kaisermühle Gänheim Otmar Kaiser GmbH
   board: "128677"
-- company: "128737"
+- company: Extensionamia
   board: "128737"
-- company: "128740"
+- company: Green & Away
   board: "128740"
-- company: "129132"
+- company: Grand-Cafe De Oude School
   board: "129132"
-- company: "129152"
+- company: KeyOne
   board: "129152"
 - company: ODE International GmbH
   board: "129199"
@@ -605,41 +605,41 @@
   board: "129701"
 - company: GMP Ingenieure Stuttgart GmbH
   board: "129839"
-- company: "13018"
+- company: Berndt Mobilitätsprodukte GmbH
   board: "13018"
 - company: EFS-AG Vertriebsdirektion Knapp
   board: "130196"
-- company: "1303"
+- company: IONOS SE
   board: "1303"
 - company: BEK Service GmbH
   board: "13033"
-- company: "130656"
+- company: L ELYSEE ST HONORE
   board: "130656"
-- company: "130721"
+- company: Justen & Geller Immobilienverwaltung GmbH & Co. KG
   board: "130721"
-- company: "131025"
+- company: MODYN design that moves
   board: "131025"
-- company: "131083"
+- company: PVC ESPAI LINE SL
   board: "131083"
-- company: "131107"
+- company: Apiterra
   board: "131107"
-- company: "131368"
+- company: Moonscale
   board: "131368"
-- company: "131422"
+- company: Magontec GmbH
   board: "131422"
-- company: "131428"
+- company: Brettmeier Steuerberatungsgesellschaft mbH
   board: "131428"
-- company: "131450"
+- company: Valence School
   board: "131450"
-- company: "131568"
+- company: Ballpoint
   board: "131568"
-- company: "131780"
+- company: Th. Niehues GmbH
   board: "131780"
-- company: "131925"
+- company: Nedatec Consulting, S.l.
   board: "131925"
-- company: "132022"
+- company: Lichtner Beton Brandenburg GmbH & Co. KG
   board: "132022"
-- company: "132029"
+- company: ART 32 Dr. Kristina Varga & Kollegen
   board: "132029"
 - company: de chinese muur winterswijk bv
   board: "132290"
@@ -649,35 +649,35 @@
   board: "132461"
 - company: Rebeca Gutierrez
   board: "132771"
-- company: "132815"
+- company: ITM Power
   board: "132815"
-- company: "132825"
+- company: Lux Academy
   board: "132825"
-- company: "132864"
+- company: House of Hair
   board: "132864"
-- company: "132868"
+- company: HTS - HandballTalentSchmiede
   board: "132868"
 - company: Valencia Mountain Enthusiasts
   board: "132890"
 - company: Prise Direct
   board: "132891"
-- company: "132950"
+- company: ECOBL
   board: "132950"
-- company: "133244"
+- company: info@wiro.nl
   board: "133244"
-- company: "133261"
+- company: GROUPE SANIEZ
   board: "133261"
-- company: "133283"
+- company: PAM OI
   board: "133283"
-- company: "133324"
+- company: Priva Building Intelligence GmbH
   board: "133324"
-- company: "133431"
+- company: Zahnkultur by Dr. Joachim Kraus
   board: "133431"
-- company: "133576"
+- company: Bifrost Studios
   board: "133576"
-- company: "133602"
+- company: GROUPEMENT D'AGENTS INTERBAILLEURS CONTRE LES DESORDRES ET LES ABUS
   board: "133602"
-- company: "133604"
+- company: Peoples Post
   board: "133604"
 - company: In-Dividu
   board: "133659"
@@ -685,85 +685,85 @@
   board: "133724"
 - company: BSI Merch GmbH
   board: "133884"
-- company: "133971"
+- company: Heizma
   board: "133971"
-- company: "134012"
+- company: MUTH & PARTNER mbB
   board: "134012"
-- company: "134021"
+- company: SIFORM Impression
   board: "134021"
 - company: Verband Deutscher Eisenbahnfachschulen e. V. (VDEF)
   board: "13407"
-- company: "134152"
+- company: Step into Learning
   board: "134152"
-- company: "134203"
+- company: HydroMapper GmbH
   board: "134203"
 - company: Tier- und Naturschutzbund Berlin-Brandenburg e.V. - Tierlebenshof Nauen
   board: "13437"
-- company: "134498"
+- company: Interwebmedia GmbH
   board: "134498"
-- company: "134516"
+- company: Restaurant Vivo
   board: "134516"
 - company: TOVIDIS
   board: "134554"
-- company: "134774"
+- company: OTTO HEIL Bau GmbH & Co. KG
   board: "134774"
-- company: "134960"
+- company: Keolis
   board: "134960"
-- company: "135012"
+- company: Afpro Filters
   board: "135012"
 - company: Top Agent
   board: "135127"
 - company: AQUANORD ICHTUS
   board: "135193"
-- company: "135583"
+- company: Associate Allied Chemicals India Pvt Ltd
   board: "135583"
 - company: Global Hospitality Solution
   board: "135585"
-- company: "13563"
+- company: Reifenhaus Caspar Wrede GmbH
   board: "13563"
-- company: "135649"
+- company: Broco
   board: "135649"
-- company: "135706"
+- company: Arztpraxis Dr. Ana Georgescu
   board: "135706"
-- company: "135733"
+- company: Pace Media
   board: "135733"
-- company: "135742"
+- company: Sahayak Associates
   board: "135742"
-- company: "135756"
+- company: Sylviane SIMOND immobilier
   board: "135756"
 - company: FLOW Physiotherapie
   board: "135925"
-- company: "13607"
+- company: BB-Obst Gruppe
   board: "13607"
-- company: "136196"
+- company: L'EFFET STANDING
   board: "136196"
 - company: AB APARTMENT BARCELONA ( COME2BCN S.L)
   board: "136262"
 - company: Südwest Presse Neckar-Alb GmbH & Co. KG
   board: "136317"
-- company: "136325"
+- company: MAJESTICFILATURES
   board: "136325"
-- company: "136442"
+- company: Werkia
   board: "136442"
-- company: "136605"
+- company: DISCIMUS Deutsch-Chinesisches Institut für Bildung
   board: "136605"
-- company: "136630"
+- company: Innovi
   board: "136630"
-- company: "136744"
+- company: IVAL
   board: "136744"
-- company: "137114"
+- company: INOVSYS
   board: "137114"
-- company: "137230"
+- company: SFMD OBJECTIF GARD
   board: "137230"
-- company: "137257"
+- company: merenov
   board: "137257"
-- company: "137293"
+- company: Nettosol
   board: "137293"
-- company: "137619"
+- company: LPB CRECHES
   board: "137619"
-- company: "137707"
+- company: Sas Dedale and Co
   board: "137707"
-- company: "137929"
+- company: Association Vie Paisible
   board: "137929"
 - company: EHPAD Château Gardères
   board: "138012"
@@ -773,21 +773,21 @@
   board: "138230"
 - company: SAS CAP MER ET LOISIRS
   board: "138350"
-- company: "138379"
+- company: LES FILMS DE LA ROBE ROUGE
   board: "138379"
-- company: "138421"
+- company: B&T Physiotherapie GmbH
   board: "138421"
 - company: Glamellina
   board: "138456"
-- company: "138630"
+- company: AJANTA LABELS CO. PVT. LTD.
   board: "138630"
-- company: "138693"
+- company: Orthopädiezentrum Schmargendorf
   board: "138693"
 - company: PflegeEngel mit Herz auf Tour GmbH
   board: "138695"
-- company: "138763"
+- company: ETHIK INVESTMENT
   board: "138763"
-- company: "138786"
+- company: sreesha enterprises
   board: "138786"
 - company: Inaveo
   board: "138875"
@@ -795,171 +795,171 @@
   board: "138985"
 - company: frechekoepfe GmbH
   board: "139139"
-- company: "139317"
+- company: Via Mobility
   board: "139317"
-- company: "139368"
+- company: Storz am Mark GmbH
   board: "139368"
-- company: "139778"
+- company: Aginum Thermae
   board: "139778"
-- company: "139907"
+- company: Relais-Control GmbH & Co. KG
   board: "139907"
-- company: "139971"
+- company: DOCURE Berlin
   board: "139971"
-- company: "14006"
+- company: Microganic GmbH
   board: "14006"
-- company: "14014"
+- company: Cavator Bauausführung GmbH
   board: "14014"
-- company: "140244"
+- company: Poelier van Ledden
   board: "140244"
-- company: "140340"
+- company: Atithi Indian Restaurant, Netherlands
   board: "140340"
-- company: "140477"
+- company: UMEG
   board: "140477"
 - company: Margret und Paul Louis Bäckerei, Konditorei, Caféhaus GmbH
   board: "140637"
-- company: "140673"
+- company: Luxera Energy GmbH
   board: "140673"
-- company: "140747"
+- company: AI FLOM
   board: "140747"
 - company: COMNET Naval Communication GmbH
   board: "140804"
 - company: Melody Care
   board: "140814"
-- company: "140837"
+- company: XMandarin
   board: "140837"
-- company: "140902"
+- company: Polyflame Germany GmbH
   board: "140902"
 - company: GEIQ AIDE A DOMICLE CENTRE VAL DE LOIRE
   board: "140919"
-- company: "140945"
+- company: Parangon Patrimoine
   board: "140945"
-- company: "140958"
+- company: AEP International
   board: "140958"
 - company: Seith Energietechnik GmbH & Co. KG
   board: "140981"
-- company: "141172"
+- company: Auditorium Works
   board: "141172"
-- company: "141289"
+- company: HSt trade & service GmbH
   board: "141289"
-- company: "141328"
+- company: Ernst Hähnlein Bau-GmbH
   board: "141328"
 - company: Sadebo Apartments GmbH
   board: "141504"
-- company: "141575"
+- company: ISOR MEDITERRANEE
   board: "141575"
-- company: "141833"
+- company: INSTATIQ
   board: "141833"
-- company: "141984"
+- company: Autohaus Pöllot GmbH
   board: "141984"
 - company: Profectus Films GmbH
   board: "142030"
 - company: Zahnarztpraxis Dr. Sven Kahlke
   board: "142122"
-- company: "142222"
+- company: Tu Super
   board: "142222"
-- company: "142400"
+- company: Actabyte
   board: "142400"
-- company: "142407"
+- company: HopLunch Grenoble
   board: "142407"
-- company: "142485"
+- company: Fleur de lavande
   board: "142485"
 - company: Albert GmbH & Co. KG
   board: "14256"
-- company: "142578"
+- company: m71 - Zahnärzte am Markt
   board: "142578"
-- company: "14267"
+- company: Kögel Bau GmbH & Co. KG
   board: "14267"
-- company: "142706"
+- company: adjusted flow
   board: "142706"
-- company: "142728"
+- company: SproClub
   board: "142728"
 - company: Micordec
   board: "142831"
-- company: "142914"
+- company: Deutsche Technoplast GmbH
   board: "142914"
-- company: "14309"
+- company: Augletics GmbH
   board: "14309"
-- company: "143180"
+- company: WOB - Wessling Oberflächenveredelung GmbH
   board: "143180"
-- company: "143201"
+- company: Health Bloom Wellness Clinics
   board: "143201"
-- company: "143297"
+- company: Autohaus Willi Klaus GmbH
   board: "143297"
-- company: "143356"
+- company: Hettinger und Partner GmbH Wirtschaftsprüfungsgesellschaft
   board: "143356"
-- company: "143428"
+- company: Checkfox Service GmbH
   board: "143428"
-- company: "143588"
+- company: SAS CHAPUIS CHARLES
   board: "143588"
-- company: "143667"
+- company: Zahnarztpraxis Jaeger
   board: "143667"
 - company: DoKas GmbH
   board: "143798"
 - company: GrantLift GmbH
   board: "143996"
-- company: "144119"
+- company: STAN AI
   board: "144119"
-- company: "144152"
+- company: hyprquest GmbH
   board: "144152"
 - company: Narravero GmbH
   board: "144272"
 - company: Taguss GmbH
   board: "144382"
-- company: "144424"
+- company: Sixisland Das Beauty Konzept
   board: "144424"
-- company: "14459"
+- company: Hirsch + Ille
   board: "14459"
-- company: "145009"
+- company: 45 VERT NATURE
   board: "145009"
-- company: "145051"
+- company: dieBauingenieure + Bertsch Architekten GmbH
   board: "145051"
-- company: "14506"
+- company: Oxolo GmbH
   board: "14506"
-- company: "145084"
+- company: HTM Hydro Technology Motors GmbH
   board: "145084"
 - company: Miry 24 Logistik GmbH
   board: "145136"
-- company: "145141"
+- company: Return
   board: "145141"
 - company: Kanal Institut AG
   board: "145391"
-- company: "145481"
+- company: Metallbau Müller GmbH & Co. KG
   board: "145481"
-- company: "145509"
+- company: Valcon
   board: "145509"
-- company: "145542"
+- company: Autohaus Cassau GmbH
   board: "145542"
 - company: Dreps GmbH
   board: "145576"
 - company: Bayonne Restobar
   board: "145809"
-- company: "145849"
+- company: COUTUME CAFÉ D'EXCEPTION
   board: "145849"
-- company: "14592"
+- company: Holzhey-Consulting GmbH
   board: "14592"
-- company: "145928"
+- company: Neurawork GmbH & Co. KG
   board: "145928"
-- company: "14611"
+- company: IWTH Steuerberatung
   board: "14611"
-- company: "146136"
+- company: FlexBase Service AG
   board: "146136"
-- company: "146191"
+- company: TPK Solutions GmbH
   board: "146191"
-- company: "146226"
+- company: Becker + Partner
   board: "146226"
-- company: "146326"
+- company: Conscienta FSW Prechtl Kindermann Zoller & Partner Steuerberatungsgesellschaft mbB
   board: "146326"
 - company: dr-apfel it-lösungen
   board: "146393"
-- company: "146408"
+- company: Atithi Indian Restaurants B.V.
   board: "146408"
-- company: "146412"
+- company: Atithi Indian Restaurant, The Netherlands
   board: "146412"
-- company: "146496"
+- company: Hôtel restaurant Le France
   board: "146496"
-- company: "146531"
+- company: Mamas Karlsruhe Gastro GmbH
   board: "146531"
-- company: "146532"
+- company: Polipost Business Ltd
   board: "146532"
 - company: creaonline gmbh
   board: "146604"
@@ -969,45 +969,45 @@
   board: "146660"
 - company: dwp Service GmbH
   board: "146890"
-- company: "146893"
+- company: Prins Group
   board: "146893"
-- company: "146948"
+- company: ACM AIR CHARTER Luftfahrtgesellschaft mbH
   board: "146948"
 - company: Nexus Deutschland
   board: "147094"
-- company: "147221"
+- company: Era Maresol Immobilier
   board: "147221"
-- company: "147288"
+- company: Bernd und Christian Drechsler GbR
   board: "147288"
-- company: "147296"
+- company: GABFOODS FINE HANDMADE FOOD SL
   board: "147296"
-- company: "147539"
+- company: steinberg pharma ag
   board: "147539"
-- company: "147541"
+- company: Riedel Bau Firmengruppe
   board: "147541"
 - company: Zahnarztpraxis Verberg Dres. Nesbach, Schreiber
   board: "147577"
-- company: "147735"
+- company: Hegauwerke GmbH
   board: "147735"
 - company: path digital
   board: "147736"
 - company: Prius Auto IIndustries
   board: "147845"
-- company: "147846"
+- company: Groupe EndLess
   board: "147846"
-- company: "147871"
+- company: ventureon GmbH
   board: "147871"
-- company: "147874"
+- company: IBEB Initiative für Bildung und Erziehung Berlin gGmbH
   board: "147874"
-- company: "147894"
+- company: Combo Logistics GmbH
   board: "147894"
-- company: "148188"
+- company: Cryoviva Biotech Pvt Ltd
   board: "148188"
-- company: "148312"
+- company: Sachverständigenbüro Winter
   board: "148312"
-- company: "148327"
+- company: ErgoZwolle
   board: "148327"
-- company: "148338"
+- company: aurixus GmbH I DigitalCheckIn I SCRIPTOMAT
   board: "148338"
 - company: Sand & Sky
   board: "148345"
@@ -1015,389 +1015,389 @@
   board: "148400"
 - company: NINETTE
   board: "148492"
-- company: "148563"
+- company: cursum ag
   board: "148563"
-- company: "148677"
+- company: Hostly
   board: "148677"
-- company: "148726"
+- company: Zahnarzpraxis Montasem
   board: "148726"
 - company: ALLO ALARME
   board: "148858"
-- company: "1490"
+- company: Die Lernhilfe
   board: "1490"
-- company: "149067"
+- company: Ned Creatives
   board: "149067"
-- company: "149118"
+- company: DB POWER
   board: "149118"
-- company: "149172"
+- company: SINUS Messtechnik GmbH
   board: "149172"
-- company: "149254"
+- company: DWLBohrung GmbH
   board: "149254"
-- company: "149313"
+- company: Lime Gmbh
   board: "149313"
 - company: monday marketing GmbH
   board: "149480"
-- company: "149532"
+- company: Cargo Floor
   board: "149532"
 - company: Tiffani Homes
   board: "149576"
-- company: "149732"
+- company: BURKHARDT+WEBER Fertigungssysteme GmbH
   board: "149732"
 - company: ING + ARCH Partnerschaft mbB
   board: "149912"
 - company: Atithi Indian Restaurants BV
   board: "149995"
-- company: "15003"
+- company: SC Media House
   board: "15003"
-- company: "150200"
+- company: Gollmann Kommissioniersysteme GmbH
   board: "150200"
-- company: "150247"
+- company: Pratham Education Foundation
   board: "150247"
-- company: "150285"
+- company: Direction des douanes de Normandie
   board: "150285"
-- company: "150348"
+- company: Intersektion
   board: "150348"
-- company: "150423"
+- company: Clinica Grado
   board: "150423"
 - company: EMS FVK-Profile GmbH
   board: "150443"
-- company: "150473"
+- company: STRATOS Technologies Ltd.
   board: "150473"
 - company: Landgard Service GmbH
   board: "150604"
-- company: "150693"
+- company: Medienvertrieb Delmenhorst
   board: "150693"
 - company: K & R Beratungs- u. Projektmanagement UG
   board: "150755"
-- company: "150854"
+- company: Domnick+Müller GmbH + Co. KG
   board: "150854"
-- company: "151240"
+- company: ALTUS.EVENTS
   board: "151240"
-- company: "151466"
+- company: SOUS
   board: "151466"
 - company: The Real Estate CONNECT
   board: "151577"
-- company: "151602"
+- company: DOMAINE DE PERETTI DELLA ROCCA
   board: "151602"
-- company: "151637"
+- company: Gastro-Beratung.de
   board: "151637"
-- company: "151649"
+- company: FOQUS Fellbach GbR
   board: "151649"
-- company: "151761"
+- company: MindLabs Systems Pvt Ltd
   board: "151761"
-- company: "151852"
+- company: Clera-AI
   board: "151852"
 - company: Moonverse Digital
   board: "151870"
 - company: global Training Formation
   board: "151890"
-- company: "151898"
+- company: LADYBIRD GROUND SERVICES
   board: "151898"
 - company: LANtana Gesellschaft für angewandte Daten- und Netzwerktechnik mbH
   board: "15206"
-- company: "152064"
+- company: Appentus Technology
   board: "152064"
-- company: "152262"
+- company: Podologische Fachpraxis Natürlich gut zu Fuß
   board: "152262"
-- company: "152379"
+- company: Boekstiegel Allfinanz DVAG
   board: "152379"
-- company: "152496"
+- company: NAVAYUGA ENGINEERING COMPANY LIMITED
   board: "152496"
-- company: "152498"
+- company: RAFA NADAL ACADEMY
   board: "152498"
-- company: "152535"
+- company: Mühlenkamp GmbH und Co. KG
   board: "152535"
-- company: "152638"
+- company: Stage Works
   board: "152638"
-- company: "152758"
+- company: Pfadt-Busreisen GmbH
   board: "152758"
-- company: "152767"
+- company: Mendato GmbH
   board: "152767"
-- company: "152976"
+- company: Swiss Life Select - Andreas Klämbt
   board: "152976"
-- company: "153022"
+- company: SNS SQUARE
   board: "153022"
 - company: Cosmea Pflege
   board: "153058"
 - company: Theobald Software GmbH
   board: "153067"
-- company: "153133"
+- company: betterPortrait AG
   board: "153133"
 - company: Eduard Lutz Schrauben-Werkzeuge GmbH
   board: "1532"
 - company: Biohof Elmengrund
   board: "153205"
-- company: "153206"
+- company: DEPILASER
   board: "153206"
-- company: "153253"
+- company: Kai Ingenbleek - Provinzial Versicherung
   board: "153253"
-- company: "153436"
+- company: RM Immobilien GmbH
   board: "153436"
-- company: "153465"
+- company: Zahnarztpraxis MUDr. Peter Scholze
   board: "153465"
-- company: "153553"
+- company: WAAGERECHT Beteiligungs- und Beratungsgesellschaft mbH
   board: "153553"
 - company: Artclub Mixed Media GmbH
   board: "153613"
 - company: Khizar Tandoori B.V.
   board: "153626"
-- company: "153649"
+- company: Fuji Electric Europe GmbH
   board: "153649"
-- company: "153989"
+- company: BEG Bürkle GmbH & Co. KG
   board: "153989"
-- company: "154021"
+- company: Löwen Gastronomie GmbH
   board: "154021"
 - company: Banxware GmbH
   board: "15406"
 - company: Intermedics Healthcare LLP
   board: "154114"
-- company: "154122"
+- company: STARVANCE
   board: "154122"
-- company: "154175"
+- company: Galvanek Energiesysteme
   board: "154175"
-- company: "154355"
+- company: RESIDEAL ANTIBES
   board: "154355"
-- company: "154448"
+- company: Allianz Versicherung Bell und Lambrecht OHG
   board: "154448"
 - company: BT ENERGY
   board: "154464"
-- company: "154615"
+- company: SOWEFUND
   board: "154615"
-- company: "154673"
+- company: RESCON Resistant-Concrete GmbH
   board: "154673"
-- company: "154710"
+- company: Körpernahr Training & Therapie
   board: "154710"
-- company: "154739"
+- company: Preis Property Services
   board: "154739"
 - company: Apex Defence GmbH
   board: "154772"
-- company: "154859"
+- company: ACID Café
   board: "154859"
-- company: "154874"
+- company: J & K Group
   board: "154874"
-- company: "154918"
+- company: Dedi agency
   board: "154918"
-- company: "154919"
+- company: BK International
   board: "154919"
-- company: "154981"
+- company: GT courtage automobile
   board: "154981"
-- company: "155028"
+- company: ZenDo Kaufering
   board: "155028"
-- company: "155038"
+- company: rombro ag
   board: "155038"
 - company: Container Love
   board: "155239"
-- company: "155288"
+- company: DRF ELECTRONICA
   board: "155288"
-- company: "155318"
+- company: Weber Agrar Robotik GmbH
   board: "155318"
 - company: Förderverein adventistischer Schulen in Bayern e.V.
   board: "155324"
 - company: DIE MACHER. Wasser Wärme Klimatechnik. GmbH
   board: "155357"
-- company: "155525"
+- company: Make Sense
   board: "155525"
 - company: Schulze Marketing
   board: "155606"
-- company: "155649"
+- company: eclara
   board: "155649"
-- company: "155670"
+- company: Ingenieurbüro Hillebrand GmbH
   board: "155670"
-- company: "155742"
+- company: Gustav Meyer GmbH
   board: "155742"
-- company: "155817"
+- company: Elis (Suisse) AG
   board: "155817"
-- company: "155903"
+- company: NAO Skalierung GmbH
   board: "155903"
-- company: "155962"
+- company: Aumiller Brandschutz GmbH
   board: "155962"
 - company: Qurinomsolutions private limited
   board: "156034"
-- company: "156095"
+- company: BAUR & GUT GmbH
   board: "156095"
 - company: Madurai Masala cafe
   board: "156186"
-- company: "156215"
+- company: CERES PARTNERS
   board: "156215"
-- company: "156342"
+- company: Réunir
   board: "156342"
 - company: ea.R Energieanlagen Ramonat
   board: "15645"
-- company: "156473"
+- company: RePower Solution GmbH
   board: "156473"
 - company: Palettenpool Deutschland
   board: "156542"
-- company: "156547"
+- company: MTH Elektro GmbH
   board: "156547"
 - company: Nain Trading GmbH
   board: "15655"
-- company: "156615"
+- company: Oscar Mobility B.V.
   board: "156615"
-- company: "156673"
+- company: SRsolutions GmbH
   board: "156673"
-- company: "156702"
+- company: Kathmandu Kitchen
   board: "156702"
-- company: "156751"
+- company: Andrys Advisory GmbH
   board: "156751"
-- company: "157093"
+- company: Get Impulse Bad Oeynhausen GmbH
   board: "157093"
 - company: costdata GmbH
   board: "15715"
-- company: "157172"
+- company: Alpen Energie GmbH
   board: "157172"
-- company: "157319"
+- company: quali Swiss Solution FM & Services GmbH
   board: "157319"
-- company: "157330"
+- company: Vox AI
   board: "157330"
-- company: "157380"
+- company: ADVANTA GmbH Wirtschaftsprüfungsgesellschaft
   board: "157380"
-- company: "157430"
+- company: ECHO Urban Design
   board: "157430"
 - company: Zahnärzte edelweiss
   board: "157440"
 - company: HORBACH Wirtschaftsberatung GmbH | Diana Kling
   board: "157476"
-- company: "157613"
+- company: Behn Getränke GmbH
   board: "157613"
-- company: "157700"
+- company: MLP Finanzberatung SE
   board: "157700"
 - company: INP Deutschland GmbH
   board: "157721"
 - company: Omnisent
   board: "157757"
-- company: "15777"
+- company: Vogt GmbH
   board: "15777"
-- company: "157945"
+- company: RIONE Gastro OG
   board: "157945"
-- company: "158194"
+- company: Gesundheitspraxis Claudia Renard
   board: "158194"
-- company: "15827"
+- company: RHG Lichte eG
   board: "15827"
 - company: Viato GmbH
   board: "158285"
-- company: "158287"
+- company: United Infrastructure
   board: "158287"
-- company: "158329"
+- company: GROUPE BONNEFON
   board: "158329"
-- company: "158450"
+- company: TRIGO ADR Germany GmbH
   board: "158450"
-- company: "158507"
+- company: Reaktiv Sprenkel
   board: "158507"
-- company: "158584"
+- company: Werner & Habermalz GmbH & Co. KG
   board: "158584"
-- company: "15866"
+- company: Brand Upgrade GmbH
   board: "15866"
-- company: "158685"
+- company: ERDEBOT
   board: "158685"
 - company: BOSG Bochumer Steuerberatungsgesellschaft mbH
   board: "158713"
 - company: Smile.club Mauléon
   board: "158818"
-- company: "158960"
+- company: Helm Sicherheitstechnik GmbH
   board: "158960"
 - company: Estheclinic
   board: "159025"
-- company: "15904"
+- company: dieBauingenieure - Zertifizierung GmbH
   board: "15904"
 - company: SEMLORE
   board: "159068"
 - company: getolo GmbH
   board: "1592"
-- company: "159212"
+- company: W. Hustert GmbH
   board: "159212"
-- company: "159246"
+- company: Kanzlei FORKERT
   board: "159246"
-- company: "159444"
+- company: TwoWay
   board: "159444"
-- company: "159542"
+- company: Klinik Teufen Group
   board: "159542"
-- company: "159570"
+- company: Always Friday
   board: "159570"
-- company: "1596"
+- company: Work In Progress Textilhandels GmbH
   board: "1596"
-- company: "159690"
+- company: Klimatechnik Wagner GmbH
   board: "159690"
-- company: "159741"
+- company: Me Group Switzerland
   board: "159741"
-- company: "159787"
+- company: Clean-Tec GmbH
   board: "159787"
 - company: JANDA ANLAGENBAU GmbH
   board: "159810"
-- company: "159833"
+- company: Mia Couture
   board: "159833"
-- company: "159842"
+- company: Brust+Partner
   board: "159842"
-- company: "159860"
+- company: enshift AG
   board: "159860"
 - company: Dualis Institut GmbH
   board: "159873"
-- company: "159953"
+- company: Winkow PartG mbB
   board: "159953"
-- company: "159971"
+- company: Eleo Technologies B.V.
   board: "159971"
 - company: Cirrus Real Estate GmbH
   board: "159989"
-- company: "159995"
+- company: Strasser GmbH
   board: "159995"
-- company: "160002"
+- company: Les Ateliers de Fabrication Ferroviaire
   board: "160002"
-- company: "160004"
+- company: Alliance Catering Concept GmbH
   board: "160004"
-- company: "160029"
+- company: People Places Performance
   board: "160029"
-- company: "160107"
+- company: Smytten
   board: "160107"
 - company: GSB Gebäude Schadenservice Bayern
   board: "16011"
 - company: Aristander.AI UG
   board: "160150"
-- company: "160157"
+- company: Parkview Invest AG
   board: "160157"
-- company: "160174"
+- company: Nordik-Care Unternehmensgruppe
   board: "160174"
 - company: Römergarten Residenzen
   board: "160183"
-- company: "160184"
+- company: meromix - (merocare GmbH)
   board: "160184"
-- company: "160188"
+- company: Geisler Care Services
   board: "160188"
-- company: "160218"
+- company: Kinderarztpraxis Elke Köchy
   board: "160218"
-- company: "160309"
+- company: Koewal Jugendhilfe
   board: "160309"
-- company: "160348"
+- company: Weflow
   board: "160348"
 - company: Mariposa Multiservice
   board: "160457"
-- company: "16057"
+- company: MICO GmbH
   board: "16057"
 - company: Nova Alhama SL
   board: "160645"
-- company: "160759"
+- company: Cyql BV
   board: "160759"
 - company: Lungenzentrum Ulm
   board: "16076"
-- company: "160771"
+- company: Eloquendo GmbH
   board: "160771"
-- company: "160776"
+- company: WorldChanger
   board: "160776"
-- company: "160845"
+- company: EUROPEA DE CONTENEDORES S.A.
   board: "160845"
 - company: consultaas
   board: "160986"
 - company: Zahntechnik Christian Schmidt
   board: "160997"
-- company: "161010"
+- company: Haut- und Laserzentrum Stuttgart
   board: "161010"
-- company: "161234"
+- company: pimpertz
   board: "161234"
-- company: "161247"
+- company: My English House Valdespartera
   board: "161247"
-- company: "16157"
+- company: Ritter von Kempski Privathotels
   board: "16157"
-- company: "161612"
+- company: Sendent B.V.
   board: "161612"
-- company: "161625"
+- company: Nyko
   board: "161625"
 - company: Ostdeutsche Baugesellschaft mbH
   board: "161815"
@@ -1405,95 +1405,95 @@
   board: "161893"
 - company: inca
   board: "162190"
-- company: "162216"
+- company: Detralev
   board: "162216"
-- company: "162372"
+- company: Therapie & Reha Zentrum Estenfeld - AktivFit
   board: "162372"
-- company: "162378"
+- company: EF Fitness GmbH
   board: "162378"
-- company: "162474"
+- company: challenge ARENA GmbH
   board: "162474"
-- company: "162479"
+- company: Bricks.co
   board: "162479"
-- company: "162487"
+- company: Texplor GmbH
   board: "162487"
-- company: "162555"
+- company: Landgut Seebühne
   board: "162555"
-- company: "162580"
+- company: Van Draeckeburgh
   board: "162580"
-- company: "162658"
+- company: Zemanek Smile
   board: "162658"
 - company: Kalle GmbH
   board: "162675"
-- company: "162740"
+- company: Computer Bildung Berlin
   board: "162740"
-- company: "162790"
+- company: Wohnwaltung Immobilienverwaltung
   board: "162790"
-- company: "162811"
+- company: VALENCIA FORMACION
   board: "162811"
 - company: MySpa Service GmbH
   board: "16289"
-- company: "162895"
+- company: Peaceful Properties GbR
   board: "162895"
-- company: "163044"
+- company: Dentis Bavaria MVZ GmbH
   board: "163044"
 - company: Tele-Mobil Götz GmbH
   board: "16306"
-- company: "163142"
+- company: Voltrac SL
   board: "163142"
 - company: DP Markets GmbH
   board: "163163"
-- company: "16343"
+- company: Bäckerei Engel
   board: "16343"
 - company: ARTIC Technologies BV
   board: "163502"
-- company: "163518"
+- company: Cubus Medien Verlag GmbH
   board: "163518"
-- company: "163577"
+- company: EBELevator
   board: "163577"
-- company: "163580"
+- company: Sport BSO Mook B.V.
   board: "163580"
 - company: Gen24 Flybiz
   board: "163638"
-- company: "16365"
+- company: PTG Consulting AG
   board: "16365"
-- company: "163702"
+- company: bay one GmbH
   board: "163702"
 - company: homie
   board: "163823"
-- company: "163836"
+- company: Carepage
   board: "163836"
 - company: auto-birne GmbH
   board: "163948"
 - company: Sumasearch
   board: "16420"
-- company: "164267"
+- company: Christian Dunkel GmbH
   board: "164267"
-- company: "164269"
+- company: Neilsoft GmbH
   board: "164269"
-- company: "164346"
+- company: The Restaurant Data Company
   board: "164346"
-- company: "164383"
+- company: HYFATECH GmbH
   board: "164383"
-- company: "164399"
+- company: Cycliq
   board: "164399"
-- company: "164564"
+- company: Seniorcare GmbH
   board: "164564"
-- company: "164644"
+- company: Lebensnahe GmbH
   board: "164644"
-- company: "164938"
+- company: Gambers Ambulante Pflege
   board: "164938"
-- company: "164986"
+- company: FOY Life GmbH
   board: "164986"
-- company: "165025"
+- company: Machete
   board: "165025"
-- company: "16507"
+- company: FISKAGROUP
   board: "16507"
 - company: SwiftCargo24
   board: "165100"
-- company: "165229"
+- company: Engel & Völkers im Ruhrgebiet
   board: "165229"
-- company: "1653"
+- company: Consultport
   board: "1653"
 - company: Plotdesk GmbH
   board: "165630"
@@ -1501,161 +1501,161 @@
   board: "165650"
 - company: berneis natürlich-aktiv GmbH
   board: "165693"
-- company: "165703"
+- company: MAS GmbH
   board: "165703"
-- company: "165865"
+- company: Limpiezas Laso
   board: "165865"
 - company: LBO GmbH
   board: "166000"
-- company: "166053"
+- company: Yasu
   board: "166053"
 - company: TheraTree Ergo - und PhysioTherapie
   board: "166282"
-- company: "166357"
+- company: Prolabs
   board: "166357"
-- company: "166358"
+- company: Uniclub Auslandssemester
   board: "166358"
-- company: "16651"
+- company: GTK Ginster Theis Klein & Partner mbB Wirtschaftsprüfer Steuerberater Rechtsanwälte
   board: "16651"
 - company: Media Mediagroep
   board: "166605"
-- company: "166632"
+- company: Neptuned GmbH
   board: "166632"
-- company: "166667"
+- company: Kanal
   board: "166667"
-- company: "166723"
+- company: MADEMOISELLE JULIE
   board: "166723"
-- company: "166937"
+- company: Indian Accent B.V.
   board: "166937"
-- company: "166964"
+- company: stalkingfree
   board: "166964"
-- company: "16707"
+- company: Bella Vitalis GmbH
   board: "16707"
-- company: "167094"
+- company: AdventureRooms GmbH
   board: "167094"
-- company: "167151"
+- company: Kruse Brickenstein & Partner Steuerberatungsgesellschaft mbB
   board: "167151"
 - company: Subway
   board: "16724"
-- company: "167407"
+- company: SARL Laurencin
   board: "167407"
 - company: Schreinerei Mathias Haas
   board: "167408"
-- company: "167476"
+- company: PHYSIO die therapeuten
   board: "167476"
 - company: MSRT GmbH
   board: "167523"
-- company: "167644"
+- company: ALMA ATA SALUD SL
   board: "167644"
 - company: Global Distirbution GmbH & Co. KG
   board: "167647"
-- company: "167671"
+- company: Yachtservice Burkard
   board: "167671"
-- company: "16779"
+- company: Gelateria Leonardo
   board: "16779"
-- company: "167803"
+- company: Desch Digital GmbH
   board: "167803"
-- company: "167815"
+- company: Ärztegemeinschaft Oranienburg MVZ GmbH
   board: "167815"
-- company: "167857"
+- company: CAMBRIDGE EXAMS PS
   board: "167857"
 - company: Nord-Ostsee-Automobile SE & Co. KG
   board: "167983"
-- company: "168063"
+- company: Immobilien- & Hausverwaltung Lessmann Gmbh
   board: "168063"
 - company: Learnrithm Ai
   board: "168101"
-- company: "168131"
+- company: Boolment Software Development Pvt. Ltd
   board: "168131"
-- company: "168137"
+- company: Arbeiterwohlfahrt - Kreisverband Salzgitter - Wolfenbüttel e.V.
   board: "168137"
-- company: "168148"
+- company: Designer Diamonds
   board: "168148"
 - company: Schlecht GmbH - Metallverarbeitung
   board: "168184"
-- company: "168316"
+- company: CSE Airbus Atlantic Rochefort
   board: "168316"
 - company: Jürgen Hohnen GmbH
   board: "168570"
-- company: "168664"
+- company: Yami Studios UG
   board: "168664"
-- company: "168686"
+- company: Safe House Psychology
   board: "168686"
-- company: "168691"
+- company: Alquileres Peñiscola 1
   board: "168691"
-- company: "168697"
+- company: Berlin Metropolitan School
   board: "168697"
-- company: "168741"
+- company: Hauskrankenpflege Stolley GmbH
   board: "168741"
 - company: koteya
   board: "168819"
-- company: "168925"
+- company: Cosimo Lippe
   board: "168925"
 - company: Wizzvet
   board: "168956"
-- company: "168994"
+- company: Lambertus Apotheke
   board: "168994"
-- company: "169057"
+- company: Steuerkanzlei Freyboth, Marx & Partner
   board: "169057"
-- company: "169129"
+- company: K2 Messebau GmbH
   board: "169129"
 - company: The Brew Factory
   board: "169146"
 - company: Heizmüller GmbH
   board: "169288"
-- company: "169361"
+- company: Disapo Apotheke
   board: "169361"
-- company: "169489"
+- company: Elevion Energy Solutions GmbH
   board: "169489"
-- company: "169548"
+- company: Singhania Tableting
   board: "169548"
-- company: "169684"
+- company: CULINARY AGENCY
   board: "169684"
-- company: "169687"
+- company: Stay@home GmbH
   board: "169687"
-- company: "169690"
+- company: SEOCZAR IT SERVICES PVT LTD
   board: "169690"
-- company: "169704"
+- company: SOPG Consulting
   board: "169704"
-- company: "169779"
+- company: wokplaza wieringerwerf
   board: "169779"
-- company: "169797"
+- company: Cosmos callcenter
   board: "169797"
 - company: J. Brar B.V.
   board: "169925"
-- company: "169926"
+- company: Diffly
   board: "169926"
 - company: Heal In Bolanden GmbH
   board: "169971"
-- company: "170089"
+- company: TechPaten GbR
   board: "170089"
-- company: "170098"
+- company: Stützle-Späth GmbH & Co. KG
   board: "170098"
-- company: "170101"
+- company: Inspire Technologies GmbH
   board: "170101"
-- company: "170148"
+- company: 1ER GEST
   board: "170148"
 - company: Magoya B.V.
   board: "170206"
-- company: "170263"
+- company: Riesa Brands GmbH
   board: "170263"
-- company: "170472"
+- company: MySpirulina GmbH
   board: "170472"
-- company: "170608"
+- company: Wingest Audit & Expertise
   board: "170608"
-- company: "170700"
+- company: MICRO CRECHE LES BILINGUES
   board: "170700"
-- company: "170764"
+- company: OOOVATION
   board: "170764"
-- company: "170779"
+- company: TIERS LIEU SUD TOURAINE TIERS LIEU SUD TOURAINE
   board: "170779"
-- company: "170826"
+- company: Reformas Martin e Hijos, S.L
   board: "170826"
 - company: Indian Food Factory BV
   board: "170872"
-- company: "170907"
+- company: Youkoso B.V.
   board: "170907"
-- company: "170929"
+- company: INT Informatik Nachrichtentechnik GmbH
   board: "170929"
 - company: Donhauser & Partner mbB
   board: "170930"
@@ -1663,29 +1663,29 @@
   board: "170939"
 - company: Chinees Indisch Restaurant De Lange Muur Bedum
   board: "170941"
-- company: "17106"
+- company: Autohaus Royal GmbH
   board: "17106"
 - company: Fong Fou
   board: "171092"
 - company: Burkhardt Handel & Services
   board: "171159"
-- company: "17116"
+- company: Brüning-Carport GmbH
   board: "17116"
-- company: "171180"
+- company: Blue Sakura BV
   board: "171180"
-- company: "171285"
+- company: NewKing B.V.
   board: "171285"
-- company: "171366"
+- company: Xin & Hao BV
   board: "171366"
-- company: "171370"
+- company: FASTR
   board: "171370"
-- company: "171380"
+- company: PARASHOP
   board: "171380"
-- company: "171421"
+- company: Mello
   board: "171421"
-- company: "171492"
+- company: Frontplan Facadus GmbH
   board: "171492"
-- company: "171513"
+- company: Hart van India
   board: "171513"
 - company: Mara Care AG
   board: "171610"
@@ -1693,29 +1693,29 @@
   board: "171611"
 - company: AZ & R
   board: "171622"
-- company: "171649"
+- company: DA Hautarzt - Praxis für Dermatologie
   board: "171649"
-- company: "171651"
+- company: Vinera
   board: "171651"
-- company: "171744"
+- company: Leven Nutzfahrzeuge GmbH & Co. KG
   board: "171744"
 - company: E-Service-Check
   board: "171764"
-- company: "171863"
+- company: 6Gorilla's
   board: "171863"
-- company: "171893"
+- company: GRUPO TICE INGENIEROS SL
   board: "171893"
-- company: "171920"
+- company: ELMI Power GmbH
   board: "171920"
 - company: medic-alpes
   board: "171958"
-- company: "172094"
+- company: Stippt
   board: "172094"
-- company: "172095"
+- company: DEED BV
   board: "172095"
-- company: "172098"
+- company: Agatha WirtschaftsTreuhand GmbH & Co. KG Steuerberatungsgesellschaft
   board: "172098"
-- company: "172110"
+- company: Business Angels Deutschland (BAND) e.V.
   board: "172110"
 - company: Fonds de dotation BESTIOLES
   board: "172150"
@@ -1723,123 +1723,123 @@
   board: "172163"
 - company: REVOLIB HCR
   board: "172209"
-- company: "172279"
+- company: Karl Laux Heizung Sanitär
   board: "172279"
-- company: "172298"
+- company: Lumeo Energies
   board: "172298"
-- company: "172302"
+- company: Medux Deutschland
   board: "172302"
-- company: "172317"
+- company: Bayreuther Brauhaus Frankfurt
   board: "172317"
-- company: "172344"
+- company: Allied Digital Services Limited
   board: "172344"
 - company: ASB Mannheim/Rhein-Neckar Ambulanter Pflegedienst Schriesheim
   board: "172392"
 - company: 3iMedia GmbH
   board: "172399"
-- company: "172427"
+- company: Pro Bono Uganda.
   board: "172427"
-- company: "172458"
+- company: Integral Services GmbH
   board: "172458"
-- company: "172490"
+- company: Animal Resort Wesel
   board: "172490"
-- company: "172670"
+- company: ACCEL
   board: "172670"
-- company: "172711"
+- company: awi consulting gmbh
   board: "172711"
 - company: Apnabusinez.com
   board: "172717"
-- company: "172726"
+- company: QUICK
   board: "172726"
 - company: AA Hospitality LLP
   board: "172860"
-- company: "172863"
+- company: GLDC
   board: "172863"
-- company: "172880"
+- company: Westhafen Leipzig
   board: "172880"
-- company: "172933"
+- company: Mavinz Consultancy Private Limited
   board: "172933"
 - company: WINDWARD
   board: "172935"
-- company: "172936"
+- company: LES SAULES
   board: "172936"
-- company: "173071"
+- company: Noise
   board: "173071"
-- company: "173074"
+- company: Darwaza
   board: "173074"
 - company: DOIGNIES
   board: "173089"
-- company: "173117"
+- company: Vardhan Ayurvedic & Herbals Medicines Pvt. Ltd.
   board: "173117"
-- company: "173172"
+- company: Centre Orientaly's
   board: "173172"
-- company: "173183"
+- company: Miri Mary Amsterdam
   board: "173183"
 - company: P-AIME GOETTMANN ENVIREAUSOL
   board: "173225"
-- company: "173269"
+- company: ERIA
   board: "173269"
-- company: "173286"
+- company: Respond Right Education
   board: "173286"
-- company: "173296"
+- company: Inrext Pvt Ltd
   board: "173296"
-- company: "173302"
+- company: Maison Pétrichor
   board: "173302"
-- company: "173308"
+- company: SPI
   board: "173308"
-- company: "173462"
+- company: ituma
   board: "173462"
-- company: "173477"
+- company: SODAIC LOGISTIQUE
   board: "173477"
-- company: "173482"
+- company: Bilanzheld GmbH
   board: "173482"
-- company: "173531"
+- company: CABINET TRECOM
   board: "173531"
 - company: aperli
   board: "173551"
-- company: "173620"
+- company: banneton boulangerie
   board: "173620"
-- company: "173681"
+- company: dachsteingroup - private wealth advisors
   board: "173681"
-- company: "173698"
+- company: Boulouris Immobilier
   board: "173698"
 - company: TRIATOS Capital GmbH
   board: "173749"
 - company: CleanCare UG
   board: "173758"
-- company: "173759"
+- company: Mikaelian
   board: "173759"
-- company: "173794"
+- company: Silver Spoons BV
   board: "173794"
 - company: Die Pflegeunion Gruppe
   board: "173830"
-- company: "173861"
+- company: TR2E
   board: "173861"
 - company: Büscher-Heizung-Sanitär
   board: "173866"
-- company: "173918"
+- company: SAOYA
   board: "173918"
-- company: "173925"
+- company: Shabutogo Zeist
   board: "173925"
-- company: "173952"
+- company: Cirql One GmbH
   board: "173952"
-- company: "173989"
+- company: Das Alpenglühn Hotel & Restauran
   board: "173989"
 - company: SIDEXTIN, S.L.
   board: "174020"
-- company: "174083"
+- company: Vitalcenter Naturium
   board: "174083"
-- company: "174096"
+- company: BM.CULTURA GmbH
   board: "174096"
-- company: "174157"
+- company: Heid Fertigungstechnik GmbH & Co. KG
   board: "174157"
-- company: "174180"
+- company: Arbeitsgemeinschaft AgrarMarketing Sachsen GbR
   board: "174180"
-- company: "174181"
+- company: Maxthomasbois
   board: "174181"
-- company: "174214"
+- company: Diabos Gmbh
   board: "174214"
-- company: "174215"
+- company: CDDS AG
   board: "174215"
 - company: Wolfgang Synagowitz GmbH & Co.KG
   board: "174220"
@@ -1847,217 +1847,217 @@
   board: "174225"
 - company: WorkMatePro
   board: "174246"
-- company: "174378"
+- company: Utonomy
   board: "174378"
 - company: YTTP
   board: "174478"
-- company: "17448"
+- company: Select Alternative Investments
   board: "17448"
-- company: "174489"
+- company: Gestione Mare Srl
   board: "174489"
 - company: Pero Sosa Bauüberwachung
   board: "174497"
-- company: "174602"
+- company: LBPascual Information Technology Solutions Corporation (LITS)
   board: "174602"
-- company: "174618"
+- company: AWP Animal Wellness Products GmbH
   board: "174618"
 - company: Tonis Lackierfachbetrieb GmbH
   board: "174629"
-- company: "174653"
+- company: Wirtschaftsvereinigung der Grünen e.V.
   board: "174653"
-- company: "174655"
+- company: SN MOLUDO
   board: "174655"
 - company: PT. HHM ENGINEERING SOLUTIONS
   board: "174700"
-- company: "174719"
+- company: Connect And Heal
   board: "174719"
-- company: "174736"
+- company: Fusion Plaza Almelo
   board: "174736"
-- company: "174748"
+- company: Big Rabbit Enschede
   board: "174748"
-- company: "174782"
+- company: Xin Chao
   board: "174782"
-- company: "174784"
+- company: Erfolgsimmo GmbH
   board: "174784"
-- company: "174790"
+- company: Indiaas Restaurant Namaskar
   board: "174790"
-- company: "174968"
+- company: Asiania
   board: "174968"
 - company: Mirash Overseas Studies
   board: "175009"
-- company: "175035"
+- company: ETS DOLAY
   board: "175035"
 - company: Kampfmittelbergung Zimmermann GmbH
   board: "175037"
-- company: "175038"
+- company: Evolution Autos
   board: "175038"
-- company: "175053"
+- company: BLEU DU SUD
   board: "175053"
 - company: GetonGlobal
   board: "175094"
 - company: MCI
   board: "175126"
-- company: "175144"
+- company: Falk Defence GmbH
   board: "175144"
 - company: IERA Solutions d'entreprises
   board: "175159"
-- company: "175175"
+- company: CARTONNAGE ORLEANAIS
   board: "175175"
-- company: "175193"
+- company: Zentrum für Ergotherapie
   board: "175193"
-- company: "175198"
+- company: SCHMITZ Elektrotechnik GmbH & Co. KG
   board: "175198"
-- company: "175209"
+- company: HURRICANE GROUP
   board: "175209"
-- company: "175241"
+- company: Vyapar Tech India
   board: "175241"
-- company: "175246"
+- company: Paanduv Applications
   board: "175246"
-- company: "175260"
+- company: Human asset consultancy
   board: "175260"
-- company: "175295"
+- company: Portner Systems GmbH
   board: "175295"
-- company: "175302"
+- company: Schuppner Consulting GmbH
   board: "175302"
 - company: Sacred Byte GmbH
   board: "175306"
-- company: "175318"
+- company: Softnotions Technologies Private Limited
   board: "175318"
 - company: Lead Height
   board: "175338"
-- company: "175420"
+- company: Petit Verdot Zwolle
   board: "175420"
-- company: "175462"
+- company: Zulueta Corporación para la Naturaleza S.A.
   board: "175462"
-- company: "175470"
+- company: 0NLU
   board: "175470"
-- company: "175476"
+- company: La Maison Des Travaux Saint-Brieuc
   board: "175476"
-- company: "175492"
+- company: Minami
   board: "175492"
-- company: "175501"
+- company: Michelle Walter
   board: "175501"
-- company: "175505"
+- company: Aki beheer B.V.
   board: "175505"
 - company: Lotus Brielle B.V.
   board: "175506"
-- company: "175509"
+- company: Anak Depok
   board: "175509"
-- company: "175528"
+- company: ers Energie & Kältetechnik GmbH
   board: "175528"
 - company: Minari
   board: "175540"
 - company: G&N Gruppe
   board: "175551"
-- company: "175554"
+- company: Avery
   board: "175554"
 - company: Izumi Venlo
   board: "175583"
-- company: "175598"
+- company: Kanex Fire Solutions Limited
   board: "175598"
-- company: "175616"
+- company: EPMS MARIE DU MERLE
   board: "175616"
 - company: pridegle
   board: "175621"
-- company: "175679"
+- company: oku bv
   board: "175679"
-- company: "175683"
+- company: Li’s palace
   board: "175683"
-- company: "175684"
+- company: Petit Verdot Nunspeet
   board: "175684"
 - company: Mr Li
   board: "175691"
 - company: Rama's Indian Restaurant
   board: "175789"
-- company: "175790"
+- company: Wok inn
   board: "175790"
-- company: "175792"
+- company: renomoov
   board: "175792"
 - company: PST - professional support technologies GmbH
   board: "175813"
 - company: Kam hoo
   board: "175857"
-- company: "175885"
+- company: Sevinc Protection Service
   board: "175885"
 - company: Kunststofftechnik Wiesmayer
   board: "175923"
-- company: "175941"
+- company: Wattano
   board: "175941"
-- company: "175959"
+- company: FEEDBACKPEOPLE Managementberatung GmbH
   board: "175959"
-- company: "175987"
+- company: FRIES-Gruppe
   board: "175987"
-- company: "176021"
+- company: Faircheck Schadenservice Deutschland GmbH
   board: "176021"
-- company: "176142"
+- company: ALERT'INCENDIE
   board: "176142"
-- company: "176153"
+- company: SWAP ENERGIA
   board: "176153"
 - company: Kloster-Kraul GmbH & Co. KG
   board: "176169"
-- company: "176182"
+- company: Little Asia
   board: "176182"
-- company: "176223"
+- company: Ginger Media Group
   board: "176223"
-- company: "176252"
+- company: Chinees Indisch Restaurant De Iris
   board: "176252"
-- company: "176313"
+- company: Inner Fit Research Labs Pvt. Ltd.
   board: "176313"
-- company: "176335"
+- company: Gaillard Agencement SA
   board: "176335"
-- company: "176343"
+- company: UMC Utrecht
   board: "176343"
-- company: "176367"
+- company: Optik Holinka e.K
   board: "176367"
-- company: "176405"
+- company: Gremoba
   board: "176405"
 - company: Drixler Energietechnik GmbH
   board: "176465"
-- company: "176472"
+- company: Prudent Partners LLP
   board: "176472"
-- company: "176490"
+- company: NEET STARS
   board: "176490"
 - company: Northbound
   board: "176516"
-- company: "176526"
+- company: Restaurant Samen B.V.
   board: "176526"
-- company: "176527"
+- company: Wakalase
   board: "176527"
-- company: "176528"
+- company: Chili Immo GmbH
   board: "176528"
 - company: KoCoS Messtechnik AG
   board: "176543"
 - company: EPICU
   board: "176636"
-- company: "176637"
+- company: BERS
   board: "176637"
-- company: "176643"
+- company: Horbach Wirtschaftsberatung Dresden
   board: "176643"
-- company: "176667"
+- company: HOPITAL PRIVE JACQUES CARTIER
   board: "176667"
-- company: "176727"
+- company: Lighthouse Properties
   board: "176727"
 - company: Peking Garden
   board: "176747"
-- company: "176751"
+- company: TherapiePunkt Gesundheits GbR
   board: "176751"
-- company: "176786"
+- company: Manifesta 16 Ruhr gGmbH
   board: "176786"
-- company: "176819"
+- company: Madhura Foods BV (Krishna Vilas and Anjappar Hoofddorp)
   board: "176819"
-- company: "176838"
+- company: BR Balaji LLP
   board: "176838"
-- company: "176868"
+- company: GALLEGO
   board: "176868"
 - company: Extern-isc
   board: "176890"
-- company: "176899"
+- company: Restaurant Zheng
   board: "176899"
-- company: "176901"
+- company: Jumpstart Healthcare Services
   board: "176901"
-- company: "176920"
+- company: Solution Energy GmbH
   board: "176920"
-- company: "176955"
+- company: All around food B.v
   board: "176955"
 - company: Well & Wonder S.L.
   board: "176957"
@@ -2065,51 +2065,51 @@
   board: "176994"
 - company: cs capital synergy
   board: "177020"
-- company: "177041"
+- company: ESLC SERVICES
   board: "177041"
-- company: "177047"
+- company: B:O:S Engergieberatung
   board: "177047"
-- company: "177064"
+- company: China Garden Delft
   board: "177064"
-- company: "177261"
+- company: Shushu sushi & wok to go
   board: "177261"
 - company: Werbeagentur Focus
   board: "177314"
-- company: "177321"
+- company: cyclomedia
   board: "177321"
-- company: "177365"
+- company: Plaschka Planung und Beratung GmbH
   board: "177365"
-- company: "177434"
+- company: Skischule Tuxertal
   board: "177434"
 - company: Francke & Partner mbB
   board: "177474"
-- company: "177491"
+- company: ILMOTRONICS GmbH
   board: "177491"
 - company: Simon Autohaus GmbH
   board: "177526"
 - company: Holub Elektrotechnik GmbH
   board: "177572"
-- company: "177591"
+- company: ENI Station Zeiler
   board: "177591"
-- company: "177605"
+- company: Auto & Service am Stadtwald GmbH
   board: "177605"
-- company: "177610"
+- company: Unisource GmbH
   board: "177610"
-- company: "177646"
+- company: Pôle Funéraire Public deStrasbourg
   board: "177646"
-- company: "177690"
+- company: FAMILLE MARY
   board: "177690"
-- company: "177696"
+- company: GIMEX INTERNATIONAL
   board: "177696"
-- company: "177751"
+- company: AKTIVITA Gesundheitszentrum
   board: "177751"
-- company: "177788"
+- company: OES Optik Experts und Service GmbH
   board: "177788"
-- company: "177816"
+- company: Private Frauenarztpraxis Dr. Schwaiberger
   board: "177816"
 - company: Optimal Finanzplanung GmbH
   board: "177879"
-- company: "177881"
+- company: mika
   board: "177881"
 - company: Manfred Breuer Ingenieurgesellschaft mbH & Co. KG
   board: "177888"
@@ -2117,207 +2117,207 @@
   board: "177897"
 - company: junglück
   board: "177987"
-- company: "177989"
+- company: Fae Beauty
   board: "177989"
-- company: "178096"
+- company: Baumschule Spiess
   board: "178096"
-- company: "178246"
+- company: WiCHMANN GmbH
   board: "178246"
-- company: "178249"
+- company: ESCT
   board: "178249"
 - company: Brilliant Classics B.V.
   board: "178258"
-- company: "178290"
+- company: HB Body Group
   board: "178290"
-- company: "178468"
+- company: weareDNA
   board: "178468"
-- company: "178512"
+- company: LUTFI Plastische Chirurgie
   board: "178512"
-- company: "178534"
+- company: ULTRAVIEW AG
   board: "178534"
-- company: "178535"
+- company: FLC-GROUP
   board: "178535"
-- company: "178547"
+- company: Görrissen Projekt GmbH
   board: "178547"
 - company: Horbach Dresden
   board: "178589"
-- company: "178591"
+- company: Steadbase GmbH
   board: "178591"
 - company: Zahnarztpraxis Hassenrück-Schmidt
   board: "178663"
-- company: "178673"
+- company: Hupsi Leberkas GmbH
   board: "178673"
 - company: Sorella UG
   board: "178674"
-- company: "178675"
+- company: BPG Projekt und Beteiligungs GmbH
   board: "178675"
-- company: "178701"
+- company: Wandmanufaktur - Thomas Beideck
   board: "178701"
-- company: "178713"
+- company: Göhler GmbH & Co. KG, Anlagentechnik
   board: "178713"
-- company: "178715"
+- company: LexMind GmbH
   board: "178715"
-- company: "178720"
+- company: Gesundheit Physiotherapie Sport Bremen UG
   board: "178720"
-- company: "178721"
+- company: Metallbau Huber GmbH & Co.KG
   board: "178721"
-- company: "178743"
+- company: ALPINA CLASSIC
   board: "178743"
-- company: "178754"
+- company: BAUER BLUMEN GmbH & Co. KG
   board: "178754"
-- company: "178767"
+- company: Sociallab Markets Gmbh
   board: "178767"
 - company: Stefanie Spiegel - Goldschmiedemeisterin
   board: "178791"
-- company: "178814"
+- company: PalliVIVO GmbH
   board: "178814"
-- company: "178856"
+- company: Solaga UG (haftungsbeschränkt)
   board: "178856"
 - company: COSYNAP
   board: "178957"
 - company: Chinees-Indisch restaurant Lotus
   board: "178999"
-- company: "17919"
+- company: Every.
   board: "17919"
-- company: "179238"
+- company: Otto Wöltinger Tief- und Rohrleitungsbau GmbH & Co. KG
   board: "179238"
 - company: Tuchlaube GmbH
   board: "179274"
 - company: Cold Matcha
   board: "179277"
-- company: "179287"
+- company: Stiftung Halden · Wohnen & Leben im Alter
   board: "179287"
-- company: "179363"
+- company: Flexus AG
   board: "179363"
-- company: "179393"
+- company: Fifteen-Love GbR
   board: "179393"
-- company: "179412"
+- company: Vetter Consulting GmbH
   board: "179412"
-- company: "179435"
+- company: L&R Kältetechnik GmbH & Co. KG
   board: "179435"
-- company: "179438"
+- company: Xaga Creatividad Interactiva SA
   board: "179438"
-- company: "179453"
+- company: Elli und Kurt Immobilien GmbH
   board: "179453"
-- company: "179459"
+- company: DLM
   board: "179459"
-- company: "179482"
+- company: Integrative Medizin Kraft
   board: "179482"
 - company: Hornung Baustoffe GmbH & Co. KG
   board: "179539"
 - company: Tierarztpraxis im Areal Böhler
   board: "179621"
-- company: "17969"
+- company: mammaly
   board: "17969"
-- company: "179700"
+- company: BST Media GmbH
   board: "179700"
 - company: IVS Oberflächenbearbeitung Horst Scheffler e. K.
   board: "179875"
-- company: "179944"
+- company: atelier Sennedra
   board: "179944"
 - company: TF Wettkampfservices GmbH
   board: "179996"
-- company: "180021"
+- company: Uniiqo Naturstein
   board: "180021"
-- company: "180100"
+- company: Ferry Porsche Congress Center
   board: "180100"
 - company: Garage Vonlanthen AG
   board: "180103"
-- company: "180104"
+- company: Friedhelm Schaffrath GmbH & Co. KG
   board: "180104"
-- company: "180132"
+- company: Physio-Fly-GmbH
   board: "180132"
 - company: Novamedi Harsewinkel GmbH
   board: "180158"
-- company: "180190"
+- company: Nutzfahrzeuge Bargeshagen GmbH
   board: "180190"
-- company: "180217"
+- company: Finnofleet GmbH
   board: "180217"
-- company: "180228"
+- company: Verlagshaus Schlosser
   board: "180228"
 - company: Lemongrass
   board: "180244"
-- company: "180266"
+- company: GSS German Security Service GmbH
   board: "180266"
-- company: "180315"
+- company: Otto Golze & Söhne GmbH
   board: "180315"
-- company: "180378"
+- company: Geomines
   board: "180378"
-- company: "180485"
+- company: EQUIP & Co
   board: "180485"
 - company: SAG Süddeutsche Abwasserreinigungs-Ingenieur GmbH
   board: "180535"
-- company: "180576"
+- company: Innovative Energie für Pullach GmbH
   board: "180576"
 - company: Löwenzahn Organics GmbH
   board: "180642"
-- company: "180776"
+- company: VIMA Hausverwaltung GmbH
   board: "180776"
-- company: "181016"
+- company: Sushi-moment
   board: "181016"
-- company: "181025"
+- company: Seßner GmbH
   board: "181025"
 - company: Feefa Buitenpost BV
   board: "181403"
 - company: Bikeleasing-Service GmbH & Co. KG
   board: "18220"
-- company: "182333"
+- company: Dynamic Dreamz
   board: "182333"
 - company: "182363"
   board: "182363"
-- company: "182392"
+- company: Friends For Life Bedford
   board: "182392"
-- company: "182405"
+- company: TECHNOVISION
   board: "182405"
-- company: "182407"
+- company: Envirotec Gesellschaft für Umwelt- und Verfahrenstechnik mbH
   board: "182407"
-- company: "182440"
+- company: Moto K-Team GmbH
   board: "182440"
 - company: Cotrainer
   board: "182460"
 - company: Pallet
   board: "182494"
-- company: "182509"
+- company: Umaizo
   board: "182509"
 - company: PH Immobiliengesellschaft mbH
   board: "18253"
-- company: "182539"
+- company: Buitenplaats Overveen
   board: "182539"
-- company: "182542"
+- company: Chin. Ind. Rest. Shanghai
   board: "182542"
 - company: "182599"
   board: "182599"
-- company: "182623"
+- company: De Huizengids B.V.
   board: "182623"
-- company: "182729"
+- company: Sushi Vandaag Sittard
   board: "182729"
-- company: "182807"
+- company: Tokyo Lounge B.V.
   board: "182807"
-- company: "182868"
+- company: Lightspring
   board: "182868"
 - company: AD AETERNAM
   board: "182880"
-- company: "182883"
+- company: MOREL
   board: "182883"
-- company: "182928"
+- company: Groupe CADDAC
   board: "182928"
-- company: "183004"
+- company: Lawfy & co
   board: "183004"
-- company: "183005"
+- company: Graine de lascars
   board: "183005"
-- company: "183010"
+- company: LA FRANCILIENNE DE SERVICES
   board: "183010"
-- company: "183025"
+- company: CENTRE HOSPITALIER FH MANHES
   board: "183025"
 - company: "183046"
   board: "183046"
-- company: "183071"
+- company: Straub & Baumann Energy GmbH
   board: "183071"
-- company: "183074"
+- company: Zellerbäck Friedrichshafen
   board: "183074"
-- company: "18330"
+- company: Alexander Thamm GmbH
   board: "18330"
-- company: "18348"
+- company: Gesundheitsrondell GmbH
   board: "18348"
 - company: Dörr-Gruppe
   board: "18411"
@@ -2325,207 +2325,207 @@
   board: "18501"
 - company: Praxis für Chirurgie & Unfallchirurgie
   board: "18584"
-- company: "18764"
+- company: Zahnarztpraxis MundGesund Krefeld MVZ
   board: "18764"
 - company: DialogDirect
   board: "18862"
 - company: Trainingsinsel GmbH & Co. KG
   board: "18961"
-- company: "19000"
+- company: Musikschule Oktave
   board: "19000"
-- company: "19054"
+- company: GERG GmbH
   board: "19054"
 - company: Acumen International Media
   board: "1910"
 - company: ADDVANCE Consumer Health Group GmbH
   board: "1913"
-- company: "19269"
+- company: isLOGIC AG
   board: "19269"
-- company: "19299"
+- company: TELCAT IT SERVICES GmbH
   board: "19299"
-- company: "19389"
+- company: LINGNER.COM
   board: "19389"
 - company: TIM Company GmbH
   board: "1946"
-- company: "195"
+- company: Prime21 AG
   board: "195"
-- company: "19529"
+- company: Feuerschutz Jockel GmbH & Co. KG
   board: "19529"
-- company: "19600"
+- company: Fronda Kälte- und Klimatechnik
   board: "19600"
-- company: "19615"
+- company: Amacuro GmbH
   board: "19615"
-- company: "1964"
+- company: Zahnarztpraxis D. Grossmann
   board: "1964"
-- company: "19675"
+- company: HEAD IT Solutions
   board: "19675"
 - company: Ambulante Intensivpflege Becker
   board: "19811"
-- company: "19827"
+- company: Rapid Pioneers
   board: "19827"
-- company: "19944"
+- company: RW Technischer Gebäudeservice GmbH
   board: "19944"
-- company: "20265"
+- company: MV Dresden Zustellservice GmbH
   board: "20265"
 - company: Flexxter GmbH
   board: "20269"
 - company: Easelink GmbH
   board: "20323"
-- company: "20401"
+- company: I.V.K. GmbH
   board: "20401"
-- company: "20579"
+- company: Büro Knoblich GmbH Landschaftsarchitekten
   board: "20579"
-- company: "20794"
+- company: Titolo AG
   board: "20794"
-- company: "20865"
+- company: PASSGENAU unterstützen UG
   board: "20865"
-- company: "20945"
+- company: Nienstedt GmbH
   board: "20945"
 - company: pechschwarz GmbH
   board: "21194"
-- company: "21207"
+- company: Dental Team Deutschland GmbH
   board: "21207"
 - company: SPARRKS
   board: "21246"
 - company: Cura-Med Süd-Warndt Zentrum GmbH
   board: "21359"
-- company: "21401"
+- company: Project Bay GmbH
   board: "21401"
-- company: "21463"
+- company: Berliner Verlag GmbH
   board: "21463"
-- company: "21562"
+- company: Vertical Technik AG
   board: "21562"
-- company: "21669"
+- company: Klapp Cosmetics GmbH
   board: "21669"
 - company: ETA PLUS GmbH
   board: "21680"
-- company: "21792"
+- company: net-sol GmbH
   board: "21792"
-- company: "21873"
+- company: Qrago GmbH
   board: "21873"
-- company: "21911"
+- company: Sparkasse Passau
   board: "21911"
-- company: "2222"
+- company: MILES Mobility
   board: "2222"
-- company: "22251"
+- company: Medikom Consulting GmbH
   board: "22251"
-- company: "22316"
+- company: DATAGROUP Köln GmbH
   board: "22316"
-- company: "22408"
+- company: Doceins GmbH
   board: "22408"
 - company: Kallies Automobile e.K.
   board: "22505"
-- company: "22533"
+- company: BVCOM (BV-comOffice GmbH)
   board: "22533"
 - company: Anderbrügge Sport Konzept GmbH
   board: "2262"
-- company: "22633"
+- company: HopLunch Holding SAS
   board: "22633"
 - company: Ocono VACUFLEX GmbH
   board: "22759"
-- company: "22870"
+- company: Dein Assistenzdienst GmbH
   board: "22870"
 - company: Hello People GmbH
   board: "22964"
 - company: Omnicon Group
   board: "23138"
-- company: "23333"
+- company: Hanseranking GmbH
   board: "23333"
-- company: "23400"
+- company: Markt Haag i.OB
   board: "23400"
-- company: "23482"
+- company: Patronus
   board: "23482"
 - company: Deutsche Gesellschaft für Versicherungsoptimierung mbH & Co. KG
   board: "23488"
-- company: "23645"
+- company: SMARTANA GmbH
   board: "23645"
-- company: "23655"
+- company: MaCon GmbH & Co KG
   board: "23655"
-- company: "24032"
+- company: ScanHaus Marlow GmbH
   board: "24032"
 - company: Swiss Life Select Herford Oliver Walkenhorst
   board: "24072"
 - company: AnkerTeam GmbH
   board: "24121"
-- company: "24130"
+- company: eSKa GmbH
   board: "24130"
 - company: Akademie für Pflege und Soziales (APS)
   board: "24164"
-- company: "24221"
+- company: Setting HQ
   board: "24221"
-- company: "24382"
+- company: EGS-plan Ingenieurgesellschaft für Energie-, Gebäude- und Solartechnik mbH
   board: "24382"
-- company: "24401"
+- company: greenventory GmbH
   board: "24401"
-- company: "24706"
+- company: Frey Küchenzentrum-Innenausbau GmbH
   board: "24706"
-- company: "24799"
+- company: Reha Team Halle
   board: "24799"
-- company: "24925"
+- company: ZweiDigital GmbH
   board: "24925"
-- company: "24990"
+- company: Boost Media GmbH
   board: "24990"
 - company: INLOGY GmbH
   board: "25168"
 - company: Ogaenics
   board: "25398"
-- company: "25446"
+- company: Pano Brot & Kaffee
   board: "25446"
-- company: "25476"
+- company: Everest Systems GmbH
   board: "25476"
-- company: "25564"
+- company: GFN GmbH
   board: "25564"
-- company: "25733"
+- company: Wenkemann Malerbetrieb GmbH
   board: "25733"
-- company: "25951"
+- company: Geotechnisches Ingenieurbüro Dipl.-Ing. A. Pampel GmbH
   board: "25951"
 - company: Lebenshilfe Aachen FeD GmbH
   board: "25968"
-- company: "26078"
+- company: Blink AG
   board: "26078"
-- company: "26123"
+- company: PGM Portgermany Metall GmbH&Co.KG
   board: "26123"
 - company: AGICAP Deutschland
   board: "26174"
-- company: "2632"
+- company: trafficdesign GmbH
   board: "2632"
-- company: "2645"
+- company: DaVita Deutschland AG
   board: "2645"
-- company: "26457"
+- company: Nexoya
   board: "26457"
-- company: "26513"
+- company: Gesundheitshaus Heiden & Dömer
   board: "26513"
-- company: "26550"
+- company: visuSolution GmbH
   board: "26550"
 - company: Schwentine-Haus Wohnungsbaugesellschaft mbH
   board: "26838"
-- company: "27011"
+- company: HORBACH Center Frankfurt
   board: "27011"
-- company: "27043"
+- company: etalytics GmbH
   board: "27043"
-- company: "27045"
+- company: LV digital GmbH
   board: "27045"
 - company: WSB Steuerberatungsgesellschaft mbB
   board: "27134"
-- company: "27355"
+- company: Dannien Roller Architekten + Partner
   board: "27355"
-- company: "27378"
+- company: Wüstenrot & Württembergische AG - Vertriebsdirektion Augsburg
   board: "27378"
 - company: BHM INGENIEURE - Engineering & Consulting GmbH
   board: "27716"
-- company: "27736"
+- company: PS Marketing GmbH
   board: "27736"
-- company: "27887"
+- company: Clostermann & Jasper Partnerschaft
   board: "27887"
 - company: Reh Kendermann GmbH Weinkellerei
   board: "27954"
-- company: "28081"
+- company: Leoprinting GmbH
   board: "28081"
-- company: "28110"
+- company: clever fit Schweiz
   board: "28110"
 - company: Levata
   board: "28699"
-- company: "28883"
+- company: KUNZMANN'S Hotel | Spa
   board: "28883"
 - company: HISB Btreuungsdienst Potsdam GmbH&Co.KG
   board: "29136"
@@ -2535,605 +2535,605 @@
   board: "29182"
 - company: Rochus Mummert digital GmbH
   board: "29360"
-- company: "29387"
+- company: JC Eckardt GmbH
   board: "29387"
-- company: "29516"
+- company: GMA Gesellschaft für Markt und Absatzforschung mbH
   board: "29516"
-- company: "29582"
+- company: hellomateo
   board: "29582"
-- company: "30063"
+- company: Schunk Mobilraum GmbH
   board: "30063"
-- company: "30103"
+- company: oculai
   board: "30103"
-- company: "30107"
+- company: 1KOMMA5˚
   board: "30107"
-- company: "30160"
+- company: Incoretex GmbH
   board: "30160"
 - company: Gut Haferkorn GmbH
   board: "30163"
-- company: "30177"
+- company: MSW Kunststoffe GmbH
   board: "30177"
-- company: "30182"
+- company: PMS Perfect Media Solutions GmbH
   board: "30182"
 - company: Schaffitzel Holzindustrie GmbH + Co. KG
   board: "30184"
-- company: "30197"
+- company: everii Group GmbH
   board: "30197"
-- company: "3030"
+- company: LOOMA GmbH
   board: "3030"
-- company: "30355"
+- company: PK Projekt-Kompakt GmbH
   board: "30355"
 - company: PHK professional housekeeping
   board: "30483"
-- company: "30594"
+- company: Verein für Erziehungshilfen
   board: "30594"
-- company: "3078"
+- company: OBC Europe GmbH
   board: "3078"
-- company: "30946"
+- company: AXISCADES Technologies Ltd.
   board: "30946"
-- company: "30955"
+- company: Bahn.Elektro.Planung. (B.E.P.) GmbH
   board: "30955"
-- company: "31063"
+- company: Radio Fantasy GmbH
   board: "31063"
-- company: "31076"
+- company: Urban Connect AG
   board: "31076"
-- company: "31231"
+- company: Leucht & Meckel GmbH
   board: "31231"
 - company: NKuber Consulting
   board: "31286"
-- company: "31349"
+- company: ECE Marketplaces GmbH & Co. KG
   board: "31349"
-- company: "31442"
+- company: Caiz
   board: "31442"
 - company: web&IT Solutions e.K.
   board: "31445"
-- company: "31496"
+- company: Little Eataly Berlin
   board: "31496"
-- company: "31516"
+- company: Urologie Volksdorf
   board: "31516"
-- company: "31579"
+- company: enua Pharma GmbH
   board: "31579"
-- company: "31650"
+- company: Fritz Köllemann GmbH
   board: "31650"
-- company: "31770"
+- company: claimbird GmbH
   board: "31770"
 - company: SWAN GmbH
   board: "31801"
-- company: "3209"
+- company: binderholz
   board: "3209"
-- company: "32240"
+- company: AIRIS GmbH
   board: "32240"
 - company: GD Optical Competence GmbH
   board: "32289"
 - company: The Filmevent
   board: "3229"
-- company: "32363"
+- company: Gesellschaft für Jugend- und Familienhilfe
   board: "32363"
 - company: TELUS Digital
   board: "32605"
 - company: Pink & Wagner GmbH - Stahlservice Dillingen
   board: "32686"
-- company: "32777"
+- company: Sylatech GmbH
   board: "32777"
-- company: "32787"
+- company: ProChema GmbH
   board: "32787"
-- company: "32901"
+- company: Therapiezentrum Bischofferode
   board: "32901"
-- company: "33032"
+- company: Art & Science Node Berlin (ASN)
   board: "33032"
-- company: "33098"
+- company: RIZM
   board: "33098"
 - company: EDEKA Krombholz
   board: "33312"
-- company: "33412"
+- company: Sonnett Vertriebs GmbH
   board: "33412"
-- company: "33444"
+- company: IST GmbH Innovation Systems Technology
   board: "33444"
-- company: "33475"
+- company: Greif Concept
   board: "33475"
-- company: "33541"
+- company: embelly
   board: "33541"
-- company: "33589"
+- company: Fixkraft-Futtermittel GmbH
   board: "33589"
-- company: "33711"
+- company: EB IMMOBILIENMANAGEMENT GmbH
   board: "33711"
 - company: BAG Allgäu-Oberschwaben eG
   board: "33784"
-- company: "33829"
+- company: Miryam Alt GmbH
   board: "33829"
 - company: AutoGyro GmbH
   board: "33839"
-- company: "3384"
+- company: ZECH
   board: "3384"
-- company: "33941"
+- company: LEGUNA GmbH
   board: "33941"
-- company: "34028"
+- company: Reger Zahntechnik
   board: "34028"
-- company: "34366"
+- company: BucherInvest AG
   board: "34366"
-- company: "34439"
+- company: DAP – Deutscher Ambulanter Pflegedienst GmbH
   board: "34439"
 - company: CleanMaster GmbH
   board: "34766"
-- company: "3490"
+- company: p.l.i. solutions GmbH
   board: "3490"
-- company: "35109"
+- company: Strässer & Reitmeir GmbH
   board: "35109"
-- company: "35321"
+- company: Gellert GmbH Malermeister
   board: "35321"
 - company: Western Union Retail Services Germany GmbH
   board: "35521"
 - company: BG-Graspointner GmbH
   board: "35599"
-- company: "35804"
+- company: Matera GmbH
   board: "35804"
-- company: "35893"
+- company: coolback GmbH
   board: "35893"
-- company: "35927"
+- company: Management A & P GmbH
   board: "35927"
 - company: Workist GmbH
   board: "35933"
-- company: "35965"
+- company: Remmert GmbH
   board: "35965"
-- company: "36024"
+- company: geo-FENNEL GmbH
   board: "36024"
 - company: Dorst Technologies GmbH
   board: "36168"
-- company: "36176"
+- company: Magnosphere
   board: "36176"
-- company: "36196"
+- company: SurveyCircle
   board: "36196"
 - company: Praxis 360°zahn MVZ
   board: "36220"
 - company: DIE SCHULE DES SPRECHENS GMBH
   board: "36236"
-- company: "36403"
+- company: MAUDERLI AG
   board: "36403"
-- company: "3643"
+- company: sera Gruppe
   board: "3643"
-- company: "36527"
+- company: Leeser & Will Schädlingsbekämpfung GmbH
   board: "36527"
-- company: "36576"
+- company: KoRo Handels GmbH
   board: "36576"
 - company: Getränkeland Heidebrecht GmbH & Co. KG
   board: "36650"
-- company: "36700"
+- company: Hotel DER LINDENHOF
   board: "36700"
-- company: "36845"
+- company: TRUST Treuhand- und Steuerberatung GmbH
   board: "36845"
-- company: "37392"
+- company: Wasserverband Wittlage
   board: "37392"
-- company: "37428"
+- company: Panem Backstube GmbH
   board: "37428"
 - company: BAUSANI
   board: "37505"
 - company: NOZ Medienvertrieb Osnabrück
   board: "37644"
-- company: "37668"
+- company: Fresh Nuts GmbH
   board: "37668"
-- company: "37754"
+- company: Arivo - digitales Parkraummanagement
   board: "37754"
 - company: Sonnenschein Personenbeförderung GmbH
   board: "37864"
 - company: combine Consulting GmbH
   board: "38143"
-- company: "3818"
+- company: Zattoo
   board: "3818"
-- company: "38297"
+- company: Oper
   board: "38297"
-- company: "38337"
+- company: VERSUS SPORTWETTEN GMBH
   board: "38337"
-- company: "3856"
+- company: Handicap International e.V.
   board: "3856"
 - company: Panik City Betriebs GmbH
   board: "3866"
-- company: "38682"
+- company: Michelsen Gebäude- und Liegenschaftsmanagement GmbH
   board: "38682"
-- company: "38709"
+- company: Clera AI
   board: "38709"
-- company: "38779"
+- company: Lern Konzept
   board: "38779"
-- company: "38782"
+- company: ABTF SARL
   board: "38782"
-- company: "38943"
+- company: Getränke Tiefel
   board: "38943"
 - company: Securitas AG, Regionaldirektion Zürich
   board: "39020"
 - company: ÖHMI Service GmbH
   board: "39041"
-- company: "39188"
+- company: Peter Park System GmbH
   board: "39188"
-- company: "39222"
+- company: Melexis GmbH
   board: "39222"
 - company: facts and fiction GmbH
   board: "39258"
-- company: "39380"
+- company: BIA Akademie GmbH
   board: "39380"
 - company: Phoneklinik
   board: "39393"
-- company: "39444"
+- company: House of Tales
   board: "39444"
-- company: "39518"
+- company: Sektkellerei Hans Sartor GmbH & Co KG
   board: "39518"
-- company: "39523"
+- company: Shopfully
   board: "39523"
-- company: "39549"
+- company: Kaffeesaurus
   board: "39549"
-- company: "39605"
+- company: alliantis GmbH
   board: "39605"
-- company: "39607"
+- company: Ligentec SA
   board: "39607"
-- company: "39736"
+- company: Van der Valk Exclusief Deutschland GmbH
   board: "39736"
 - company: Griptech GmbH
   board: "39872"
-- company: "39888"
+- company: deepeye Medical GmbH
   board: "39888"
-- company: "39968"
+- company: Brauereigasthof Hotel Aying / Franz Inselkammer KG
   board: "39968"
 - company: The Information Lab Deutschland GmbH
   board: "40019"
-- company: "40091"
+- company: Accept Reisen
   board: "40091"
 - company: Schloss Hugenpoet GmbH & Co. KG
   board: "40142"
-- company: "40363"
+- company: Schwarz Landschaftsbau GmbH
   board: "40363"
-- company: "40370"
+- company: Landwehr Wassertechnik GmbH
   board: "40370"
-- company: "40498"
+- company: Element Materials Technology
   board: "40498"
 - company: Buena
   board: "4051"
 - company: mechaSYS GmbH
   board: "40542"
-- company: "40580"
+- company: Logopädie im Bärenkeller
   board: "40580"
-- company: "40601"
+- company: Deutscher Wach-und Schutzhund-Service-GmbH
   board: "40601"
 - company: Oxford PV Germany GmbH
   board: "4063"
-- company: "40642"
+- company: Petite Amélie
   board: "40642"
-- company: "40720"
+- company: Fahrschule Stratmann
   board: "40720"
 - company: Rohrleitungsbau Münster GmbH
   board: "40765"
-- company: "40831"
+- company: OVS Veranstaltungs- Service GmbH
   board: "40831"
-- company: "4092"
+- company: endios GmbH
   board: "4092"
-- company: "41141"
+- company: NINJAS.jetzt
   board: "41141"
-- company: "41166"
+- company: Zündel Kunststofftechnik GmbH
   board: "41166"
-- company: "41267"
+- company: NF-Bike GmbH
   board: "41267"
 - company: Sozialwerk Heuser
   board: "41343"
-- company: "41417"
+- company: Camperland J. Bong Vertriebs GmbH
   board: "41417"
-- company: "41480"
+- company: Autohaus Wormser GmbH
   board: "41480"
-- company: "41527"
+- company: A. Schweiger GmbH
   board: "41527"
 - company: I-SEC Academy GmbH & CO. KG
   board: "41789"
-- company: "41867"
+- company: Hotel Alpenhof*** Unterbäch
   board: "41867"
-- company: "41926"
+- company: IMR Huck GmbH
   board: "41926"
 - company: Hotel Deimann
   board: "42025"
 - company: Sperlingshof
   board: "42046"
-- company: "42137"
+- company: RST-SYSTEMTRANS
   board: "42137"
-- company: "42368"
+- company: Soleo Aktiv GmbH
   board: "42368"
-- company: "42382"
+- company: DELTAgroup Security & Services AG
   board: "42382"
-- company: "42517"
+- company: Coyooco
   board: "42517"
-- company: "42744"
+- company: STI Group
   board: "42744"
-- company: "4283"
+- company: logarithmo GmbH & Co. KG
   board: "4283"
 - company: TRU Fitness Holding GmbH
   board: "42938"
-- company: "42999"
+- company: Specific-Group Germany GmbH
   board: "42999"
-- company: "43408"
+- company: Swiss Protection Service AG
   board: "43408"
-- company: "4348"
+- company: TAUBER Unternehmensgruppe
   board: "4348"
-- company: "43519"
+- company: Aquasport Wasserwelten H. B. GmbH
   board: "43519"
 - company: IBA Dosimetry GmbH
   board: "43576"
-- company: "43782"
+- company: ProfeS Gesellschaft für Bildung und Kommunikation mbH
   board: "43782"
-- company: "43806"
+- company: Velocity
   board: "43806"
 - company: A. & P. Drekopf GmbH & Co. KG
   board: "43836"
-- company: "43837"
+- company: Großbecker & Nordt Bürotechnik- Handels GmbH
   board: "43837"
-- company: "43909"
+- company: Hans Timm Fensterbau GmbH& Co.KG
   board: "43909"
 - company: Intecso AG
   board: "43933"
-- company: "44003"
+- company: Creditreform Bremen Dahlke KG
   board: "44003"
-- company: "44329"
+- company: La Cocina - Die Kochschulen
   board: "44329"
 - company: TAURUS Sicherheitstechnik GmbH
   board: "44394"
-- company: "4444"
+- company: LBS Süd
   board: "4444"
-- company: "4445"
+- company: aha! Agentur für Handelsmarketing
   board: "4445"
-- company: "44526"
+- company: Integral e.V.
   board: "44526"
-- company: "44531"
+- company: Goldwechselhaus GmbH
   board: "44531"
-- company: "44563"
+- company: SafeNow
   board: "44563"
-- company: "44704"
+- company: Gulde & Partner Patent- & Rechtsanwaltskanzlei
   board: "44704"
 - company: Bilanzbuchhaltungsgesellschaft Frohnleiten
   board: "44877"
-- company: "44882"
+- company: beebuzz media
   board: "44882"
-- company: "45254"
+- company: Radisson Blu Hotel Hamburg Airport
   board: "45254"
-- company: "45282"
+- company: Team Felix
   board: "45282"
 - company: PEM Motion GmbH
   board: "4554"
 - company: Care Companion GmbH
   board: "4556"
-- company: "45680"
+- company: Computerra Hard- und Software GmbH
   board: "45680"
-- company: "45741"
+- company: ReproCourier
   board: "45741"
-- company: "45770"
+- company: Triviar Education GmbH
   board: "45770"
 - company: Trescal GmbH
   board: "45781"
-- company: "45821"
+- company: Zara
   board: "45821"
-- company: "45870"
+- company: Volksbank Raiffeisenbank Fürstenfeldbruck eG
   board: "45870"
-- company: "46328"
+- company: GPH Steuerberatungsgesellschaft mbH
   board: "46328"
-- company: "46410"
+- company: Berninger Sanitär- & Wärmetechnik GmbH
   board: "46410"
 - company: JUNG&BANSE GmbH
   board: "46416"
-- company: "46420"
+- company: Pro-Pac Ostendorf Plastic Thermoformfolien und Verpackungen GmbH & Co. KG
   board: "46420"
-- company: "46460"
+- company: Seegold Gastro
   board: "46460"
-- company: "46666"
+- company: OS-Overseas & Services GmbH
   board: "46666"
-- company: "4667"
+- company: Stellantis &You Deutschland GmbH
   board: "4667"
 - company: KSGOC - Kühn & Sellinger Group of Companies
   board: "47028"
 - company: Scherzer GmbH
   board: "47045"
-- company: "47158"
+- company: Welcome Hotel Bad Arolsen Betriebsgesellschaft mbH & CO. KG
   board: "47158"
 - company: XLYNE GmbH
   board: "4716"
-- company: "47434"
+- company: LAUDO Designagentur GmbH
   board: "47434"
-- company: "47461"
+- company: Lang Consulting GmbH
   board: "47461"
 - company: Datadiorama GmbH
   board: "47484"
 - company: Das KATSCHBERG, Katschberghof GmbH
   board: "47625"
-- company: "47626"
+- company: econex verkehrsconsult GmbH
   board: "47626"
 - company: HH-Promotion
   board: "47656"
 - company: ETL-Heimfarth & Kollegen GmbH
   board: "47672"
-- company: "48003"
+- company: Baschinger GmbH
   board: "48003"
-- company: "48031"
+- company: Rentokil Initial GmbH
   board: "48031"
-- company: "48047"
+- company: dean&david Franchise GmbH
   board: "48047"
-- company: "48082"
+- company: VANTOPIA GmbH
   board: "48082"
-- company: "48132"
+- company: timpla by Renggli
   board: "48132"
-- company: "48202"
+- company: wiwi consult GmbH & Co. KG
   board: "48202"
-- company: "48272"
+- company: SAMSON AGRO
   board: "48272"
 - company: Spiel-Bau GmbH
   board: "48416"
-- company: "48685"
+- company: Neugebauer Maler & Trockenbau GmbH
   board: "48685"
-- company: "48769"
+- company: Folker Dr. Kieser
   board: "48769"
-- company: "49171"
+- company: Kältetechnik Ollbrink GmbH
   board: "49171"
 - company: Bi PHiT
   board: "49189"
-- company: "49258"
+- company: Ankercloud GmbH
   board: "49258"
-- company: "4928"
+- company: Intermate Media GmbH
   board: "4928"
 - company: Brevalia AG
   board: "4936"
-- company: "49405"
+- company: Momenterie
   board: "49405"
-- company: "49496"
+- company: CareUnit Service GmbH
   board: "49496"
-- company: "49585"
+- company: ALFA Sportclub Innsbruck
   board: "49585"
-- company: "49690"
+- company: AQUACHEM GmbH Separationstechnik
   board: "49690"
-- company: "4973"
+- company: pflege.de | web care LBJ GmbH
   board: "4973"
 - company: TaxIt Consulting GmbH
   board: "49764"
 - company: Senioren- und Therapiezentrum Haus Schleusberg GmbH
   board: "49889"
-- company: "49990"
+- company: W3 digital brands GmbH
   board: "49990"
 - company: Immobilien Sollmann + Zagel GmbH (ISZ)
   board: "50290"
-- company: "50383"
+- company: Metro Boutiques AG
   board: "50383"
-- company: "50384"
+- company: Baumgartner & Co. Business Consultants GmbH
   board: "50384"
-- company: "50446"
+- company: Zill GmbH & Co. KG
   board: "50446"
-- company: "50645"
+- company: Trinity Music GmbH
   board: "50645"
 - company: Babor Cologne
   board: "50804"
-- company: "51066"
+- company: Ludwig Schierer GmbH
   board: "51066"
 - company: Helpling GmbH & Co. KG
   board: "513"
 - company: Heinrich Huber Steuerkanzlei
   board: "51455"
-- company: "51626"
+- company: Nelles Gastronomie GmbH & Co. KG
   board: "51626"
-- company: "51636"
+- company: Senioren- und Therapiezentrum Barsbüttel GmbH
   board: "51636"
-- company: "51675"
+- company: Little Dot Studios Deutschland
   board: "51675"
-- company: "517"
+- company: adlicious
   board: "517"
-- company: "5176"
+- company: Kursfreunde GmbH
   board: "5176"
-- company: "51872"
+- company: pmOne AG
   board: "51872"
-- company: "51951"
+- company: DJ Solar Energie GmbH
   board: "51951"
-- company: "52008"
+- company: Kluck fahrzeugbau GmbH
   board: "52008"
 - company: Senioren- und Therapiezentrum Eichenhof/Stockelsdorf GmbH
   board: "52201"
 - company: Senioren- und Therapiezentrum Am Herrenhaus Sickte GmbH
   board: "52214"
-- company: "52247"
+- company: Eggersmann - Gruppe
   board: "52247"
-- company: "52376"
+- company: Humanistische Vereinigung K.d.ö.R.
   board: "52376"
-- company: "52399"
+- company: Dental Team am Inn MVZ
   board: "52399"
-- company: "52613"
+- company: Senioren- und Therapiezentrum Halstenbek GmbH
   board: "52613"
 - company: WMC Media GmbH
   board: "52632"
-- company: "52958"
+- company: Lab Event
   board: "52958"
-- company: "53141"
+- company: Autorecycling Kempers GmbH
   board: "53141"
-- company: "53241"
+- company: TWK
   board: "53241"
-- company: "53268"
+- company: MONDIALFEU
   board: "53268"
-- company: "5330"
+- company: Mini-Lernkreis Nachhilfe Inh. Ralf Helmut Hertle
   board: "5330"
 - company: Haeger Consulting GmbH
   board: "53395"
 - company: ImmoConcept GmbH
   board: "53401"
-- company: "53426"
+- company: PLAIN IT AG
   board: "53426"
 - company: qtec Kunststofftechnik GmbH Quedlinburg
   board: "53539"
-- company: "53576"
+- company: elandia Fulfillment GmbH
   board: "53576"
 - company: Mairie de Stains
   board: "53593"
-- company: "53632"
+- company: Liquid-Universum GmbH
   board: "53632"
-- company: "53637"
+- company: Family sphere fripouilles services
   board: "53637"
-- company: "53855"
+- company: TAUW GmbH
   board: "53855"
-- company: "53892"
+- company: Tierheim Oekoven
   board: "53892"
 - company: Breitenbach GmbH
   board: "53908"
-- company: "54112"
+- company: IAF-Radioökologie GmbH
   board: "54112"
-- company: "54355"
+- company: Radweg-Reisen GmbH
   board: "54355"
-- company: "54421"
+- company: V&V Consulting AG
   board: "54421"
 - company: Live Reply GmbH
   board: "54589"
-- company: "54628"
+- company: mitPlan
   board: "54628"
-- company: "54630"
+- company: VADcare-Gruppe
   board: "54630"
-- company: "54731"
+- company: GROUPE M SERVICE
   board: "54731"
-- company: "5474"
+- company: Gothaer Bildungsgesellschaft mbH
   board: "5474"
-- company: "54780"
+- company: Schlossgastronomie Herten
   board: "54780"
 - company: MEDECINS DU LEMAN
   board: "54794"
 - company: H&G Hansen & Gieraths EDV Vertriebsgesellschaft mbH
   board: "54797"
-- company: "55036"
+- company: Expert Media Mobil Erfurt
   board: "55036"
-- company: "55051"
+- company: HAD DES VIGNES ET DES RIVIERES
   board: "55051"
-- company: "55234"
+- company: Heinrich Hamelmann GmbH
   board: "55234"
-- company: "55311"
+- company: Smart Property Services GmbH
   board: "55311"
-- company: "55384"
+- company: AZURREO
   board: "55384"
 - company: Krieger + Schramm
   board: "5539"
-- company: "55626"
+- company: NORMA Lebensmittelfilialbetrieb Stiftung & Co. KG NL Kerpen
   board: "55626"
-- company: "55784"
+- company: Sirius Facilities GmbH
   board: "55784"
-- company: "55871"
+- company: Großhandel Jakobs GmbH
   board: "55871"
 - company: Cakefriends Franchise
   board: "55893"
 - company: IGF Ingenieure GmbH
   board: "55924"
-- company: "55963"
+- company: REEL GmbH
   board: "55963"
-- company: "56002"
+- company: Zur letzten Instanz Sperling OHG
   board: "56002"
-- company: "56057"
+- company: Les Maisons du Clair de la Plume
   board: "56057"
-- company: "56102"
+- company: DIOPTIC GmbH
   board: "56102"
-- company: "56218"
+- company: Predium Technology GmbH
   board: "56218"
-- company: "56346"
+- company: Founders Bay
   board: "56346"
-- company: "56390"
+- company: PICARD Lederwaren GmbH & Co. KG
   board: "56390"
-- company: "5644"
+- company: REDDOXX GmbH
   board: "5644"
-- company: "56440"
+- company: AACCES QUALITE
   board: "56440"
-- company: "56587"
+- company: Restaurant Don Weber
   board: "56587"
 - company: Hotel und Restaurant Grüsch
   board: "56624"
-- company: "56929"
+- company: Axess Intelligence GmbH
   board: "56929"
 - company: Sutterlüty Handels GmbH
   board: "56954"
@@ -3143,37 +3143,37 @@
   board: "57031"
 - company: REIF Bauunternehmung GmbH & Co. KG
   board: "57175"
-- company: "57301"
+- company: Bershka Deutschland B.V & Co. KG
   board: "57301"
-- company: "57329"
+- company: Stowasserplan GmbH & Co. KG
   board: "57329"
-- company: "57383"
+- company: Wunschlachen Berlin
   board: "57383"
 - company: Taurus SA
   board: "5743"
-- company: "57472"
+- company: Hartmann International GmbH & Co. KG
   board: "57472"
-- company: "57593"
+- company: Roller'n Co
   board: "57593"
-- company: "57611"
+- company: Tipico
   board: "57611"
-- company: "57629"
+- company: ainavio GmbH
   board: "57629"
-- company: "57848"
+- company: Hausmeisterservice Brüggen
   board: "57848"
-- company: "5796"
+- company: NetFederation GmbH
   board: "5796"
 - company: SolarEnergieWest GmbH
   board: "58094"
-- company: "5816"
+- company: gGiS mbH
   board: "5816"
-- company: "58192"
+- company: SBS Kühltechnik GmbH
   board: "58192"
-- company: "58202"
+- company: Seminargo GmbH
   board: "58202"
-- company: "58214"
+- company: Headstart Collective GmbH
   board: "58214"
-- company: "58247"
+- company: Weisser Bock Hotel & Restaurant / Kulturbrauerei Heidelberg AG
   board: "58247"
 - company: syte GmbH
   board: "58280"
@@ -3183,99 +3183,99 @@
   board: "58458"
 - company: Aratice
   board: "58538"
-- company: "58593"
+- company: GKL Marketing Marktforschung GmbH & Co.KG
   board: "58593"
-- company: "58693"
+- company: LANG Bau GmbH & Co. KG
   board: "58693"
-- company: "58699"
+- company: ivoflow GmbH
   board: "58699"
-- company: "58861"
+- company: KLGmbH
   board: "58861"
 - company: Münchner Kindl Facility Management GmbH
   board: "58879"
 - company: ACTIO
   board: "58962"
-- company: "59003"
+- company: QUANTEC Engineering GmbH
   board: "59003"
-- company: "59090"
+- company: Uni-Prof.de
   board: "59090"
 - company: TRANSPORTS GRANET
   board: "59128"
-- company: "59133"
+- company: SEGUIGNE ET RUIZ
   board: "59133"
-- company: "59179"
+- company: Lussi Tavola AG
   board: "59179"
-- company: "59405"
+- company: DIGITECK
   board: "59405"
-- company: "59504"
+- company: IMMO PROLÉMAN
   board: "59504"
-- company: "59565"
+- company: FTMS CONCEPT
   board: "59565"
-- company: "59613"
+- company: Benetics AI
   board: "59613"
-- company: "59655"
+- company: MHG Telekommunikation GmbH
   board: "59655"
 - company: DPS24 / Die Promill Streife
   board: "59677"
-- company: "5978"
+- company: LeeGroup GmbH
   board: "5978"
-- company: "6008"
+- company: "[dersteg] gGmbH"
   board: "6008"
-- company: "60253"
+- company: Paceheads
   board: "60253"
 - company: Getränke Hnyk
   board: "60261"
-- company: "60287"
+- company: Spotissime
   board: "60287"
-- company: "60312"
+- company: achermann ict-services ag
   board: "60312"
-- company: "6037"
+- company: EMIL Group GmbH
   board: "6037"
-- company: "60483"
+- company: Liebscher & Bracht Schmerzfrei GmbH
   board: "60483"
-- company: "6062"
+- company: Solactive AG
   board: "6062"
 - company: AQUATONIC
   board: "60628"
-- company: "60636"
+- company: Gemmyo
   board: "60636"
-- company: "60736"
+- company: GTG Logistics GmbH
   board: "60736"
-- company: "60780"
+- company: LIFA Logistik GmbH
   board: "60780"
 - company: PUCEST protect GmbH
   board: "6094"
-- company: "60990"
+- company: Teaching Socials
   board: "60990"
 - company: CAMPAIGNS & TECHNOLOGY
   board: "61135"
-- company: "61139"
+- company: ERA CAP OCEAN
   board: "61139"
 - company: Relais Mini-Schools
   board: "61245"
 - company: Kohler Holztreppen GmbH
   board: "61357"
-- company: "61376"
+- company: Wurst-Basar Konrad Hinsemann GmbH
   board: "61376"
-- company: "61537"
+- company: La Plenitude Arena
   board: "61537"
-- company: "61601"
+- company: Lumix Solar
   board: "61601"
-- company: "61832"
+- company: Anwaltsbüro Lehrter
   board: "61832"
-- company: "61875"
+- company: immoWIR UG (haftungsbeschränkt)
   board: "61875"
 - company: PLAZA Hotelgroup
   board: "61946"
-- company: "62163"
+- company: Das Zahnkonzept
   board: "62163"
-- company: "62185"
+- company: Bellevue Residenz
   board: "62185"
-- company: "62207"
+- company: Hotel Strandperle Duhnen GmbH & Co. KG
   board: "62207"
-- company: "62316"
+- company: myDartpfeil
   board: "62316"
-- company: "62703"
+- company: Fobe.me GmbH
   board: "62703"
 - company: Gerdes Reisen
   board: "62800"
@@ -3283,393 +3283,393 @@
   board: "62802"
 - company: Hair-City
   board: "62841"
-- company: "62920"
+- company: Falkhofen Steuerberatungs mbH
   board: "62920"
 - company: Milano Vice / Gaudy Foods
   board: "63006"
 - company: Jamy's Burger
   board: "6301"
-- company: "63072"
+- company: MBS Equipment Germany GmbH
   board: "63072"
-- company: "63160"
+- company: Walter und Karl-Heinz Blum Fischspezialitäten oHG
   board: "63160"
-- company: "6331"
+- company: Sunny Side Up
   board: "6331"
-- company: "63475"
+- company: Impuls Energy Trading GmbH
   board: "63475"
-- company: "6361"
+- company: Idana AG
   board: "6361"
-- company: "63648"
+- company: Amplitudes
   board: "63648"
-- company: "63740"
+- company: MCE Marine Surveyors B.V.
   board: "63740"
-- company: "63932"
+- company: Zahnarztpraxis Dr. Marisa Schippers
   board: "63932"
-- company: "63965"
+- company: Kieferorthopädie Nagold
   board: "63965"
-- company: "6405"
+- company: Therapiezentrum Mandala
   board: "6405"
-- company: "64060"
+- company: Livable
   board: "64060"
 - company: twomynds
   board: "64143"
-- company: "64236"
+- company: Megekko
   board: "64236"
 - company: PAYSAGES CATALANS
   board: "64298"
-- company: "64391"
+- company: Freie Waldorfschule Berlin-Mitte
   board: "64391"
-- company: "64411"
+- company: AWO Kreisverband Nordsachsen e.V.
   board: "64411"
-- company: "64491"
+- company: Arztpraxis Greten & Kollegen
   board: "64491"
 - company: Praxis für Krankengymnastik und Massage Ute Roth
   board: "64560"
 - company: Praktijk Voor Tandheelkunde Op Dubbeldam
   board: "64767"
-- company: "64897"
+- company: SKONTI Buchungs GmbH
   board: "64897"
-- company: "65009"
+- company: La Compagnie des Familles GRENOBLE
   board: "65009"
-- company: "65011"
+- company: Code Couleur
   board: "65011"
-- company: "65298"
+- company: Kozijnshop.nl B.V.
   board: "65298"
 - company: Burger King Antibes
   board: "65431"
-- company: "65460"
+- company: Vermessungsbüro SCHWINDT
   board: "65460"
 - company: GROUPE CAMPUS
   board: "65552"
-- company: "65683"
+- company: Connection Wolhusen
   board: "65683"
 - company: DELAGE AERO INDUSTRIES
   board: "65946"
 - company: Matuschek Design & Management
   board: "65955"
-- company: "65967"
+- company: Driver Reifen und Kfz.-Technik GmbH
   board: "65967"
-- company: "65990"
+- company: bachert&partner
   board: "65990"
-- company: "66193"
+- company: Elektro Böing GmbH
   board: "66193"
-- company: "66266"
+- company: Vakantiepark De Groote Vliet
   board: "66266"
-- company: "66273"
+- company: PETEC Verbindungstechnik GmbH
   board: "66273"
-- company: "66320"
+- company: EVIDENT Europe GmbH
   board: "66320"
-- company: "66389"
+- company: LOS-Verbund
   board: "66389"
-- company: "66461"
+- company: solvi GmbH
   board: "66461"
-- company: "66537"
+- company: Triconor Distribution B.V.
   board: "66537"
-- company: "66557"
+- company: LA BRASS
   board: "66557"
-- company: "66651"
+- company: BOAS
   board: "66651"
 - company: LuTV Rackl GmbH
   board: "66678"
-- company: "66717"
+- company: Zahnarztpraxis Dr. med. dent. Strößner + Team
   board: "66717"
-- company: "66723"
+- company: EMAX ENERGIA
   board: "66723"
-- company: "66987"
+- company: OverLab® GmbH
   board: "66987"
-- company: "67054"
+- company: C.O.R. Coppelmans Ontstoppingen en Reinigingen B.V.
   board: "67054"
-- company: "67080"
+- company: Kloek Zorg B.V.
   board: "67080"
 - company: Melody PsyCare GGZ
   board: "67112"
 - company: farbebunt e.V. Verein für Kinder- und Jugendhilfe
   board: "67463"
-- company: "67542"
+- company: LSM GmbH
   board: "67542"
 - company: Workeer
   board: "67592"
-- company: "67674"
+- company: My  Room
   board: "67674"
-- company: "67679"
+- company: Droppery
   board: "67679"
-- company: "67724"
+- company: Smartmind
   board: "67724"
 - company: Landessportverband für das Saarland
   board: "67725"
-- company: "67730"
+- company: Praxis Wehrhan
   board: "67730"
 - company: NaskorSports
   board: "67881"
-- company: "67908"
+- company: Fischer Umweltschutz GmbH
   board: "67908"
 - company: Van der Linden Hillegom BV
   board: "68080"
 - company: Dienstleistungsgesellschaft Taunus (DGT gGmbH)
   board: "68171"
-- company: "68230"
+- company: Thermeleon B.V.
   board: "68230"
 - company: MAIA
   board: "68279"
-- company: "6845"
+- company: omobi GmbH
   board: "6845"
-- company: "68466"
+- company: Kinderopvang Piccolini
   board: "68466"
-- company: "68475"
+- company: Jack Styles
   board: "68475"
-- company: "68477"
+- company: Rosenhof Görlitz
   board: "68477"
-- company: "68500"
+- company: PEAJ
   board: "68500"
-- company: "68593"
+- company: What Sub GmbH
   board: "68593"
 - company: nPlan GmbH
   board: "68618"
-- company: "68670"
+- company: Radiologie Filstal
   board: "68670"
-- company: "68856"
+- company: Arckin BV
   board: "68856"
-- company: "690"
+- company: Wellnow Health GmbH
   board: "690"
-- company: "69087"
+- company: MKM Transport BV
   board: "69087"
 - company: R+S Group Regeltechnik und Schaltanlagenbau GmbH
   board: "69127"
-- company: "69198"
+- company: COOP Ivry Habitat
   board: "69198"
-- company: "69213"
+- company: Hot ITem Groep
   board: "69213"
-- company: "69483"
+- company: WoonInvest
   board: "69483"
-- company: "69505"
+- company: Laforêt Saint-Brieuc
   board: "69505"
 - company: VIVIANUM Holding GmbH
   board: "6976"
 - company: USTARIA DI A ROTA
   board: "69800"
-- company: "69994"
+- company: GAVIANO ASSURANCES
   board: "69994"
-- company: "7004"
+- company: games & more GmbH
   board: "7004"
-- company: "70103"
+- company: RGT Treuhand GmbH
   board: "70103"
 - company: Autohaus Wegener
   board: "70117"
 - company: TIE International
   board: "70261"
-- company: "70585"
+- company: Cross Your Borders
   board: "70585"
-- company: "70727"
+- company: Dick’s Hairstyle
   board: "70727"
-- company: "70763"
+- company: RusHour
   board: "70763"
 - company: Área de Servicio Calahorra, S.A.
   board: "70821"
 - company: Inkassier B.V.
   board: "70876"
-- company: "70919"
+- company: PRONTIA LOGISTICA
   board: "70919"
-- company: "70921"
+- company: Playayfiesta.com
   board: "70921"
-- company: "71042"
+- company: Clínicas eFISIO
   board: "71042"
 - company: Interdistri
   board: "71168"
-- company: "71200"
+- company: MAMICHE
   board: "71200"
-- company: "71223"
+- company: Chateauform'
   board: "71223"
-- company: "71241"
+- company: Koers BV
   board: "71241"
-- company: "71287"
+- company: Fraai Projecten BV
   board: "71287"
-- company: "71402"
+- company: ShanX Medtech BV
   board: "71402"
 - company: Graines de fermiers
   board: "71446"
-- company: "71458"
+- company: COENCAD
   board: "71458"
-- company: "71557"
+- company: AUBADE
   board: "71557"
-- company: "71565"
+- company: G&W Software AG
   board: "71565"
-- company: "71622"
+- company: MAG Management Assistance GmbH
   board: "71622"
-- company: "71635"
+- company: SOGEMEDIA
   board: "71635"
 - company: bikosigma GmbH
   board: "71686"
-- company: "72103"
+- company: ASB Monitoring BV
   board: "72103"
-- company: "72385"
+- company: HOLDING OMNIPHAR
   board: "72385"
-- company: "72411"
+- company: Spartrans GmbH
   board: "72411"
-- company: "72472"
+- company: KION
   board: "72472"
 - company: PILATES ESPACIO62
   board: "72576"
-- company: "72631"
+- company: Aparthotel Adagio Vienna, Newcity Aparthotel BetriebsgmbH
   board: "72631"
-- company: "72662"
+- company: Eye Logistics GmbH
   board: "72662"
-- company: "72671"
+- company: Clínica de Fisioterapia Castilla
   board: "72671"
-- company: "72848"
+- company: Attesa Coffee
   board: "72848"
-- company: "72882"
+- company: Arbeitsschutz Zentrum Petrich
   board: "72882"
-- company: "72996"
+- company: VALENCIANA DE PORTEROS S.L.
   board: "72996"
-- company: "73027"
+- company: Entikal Fisioterapia y Pilates
   board: "73027"
-- company: "73570"
+- company: L. Buck & Sohn (GmbH & Co.) KG
   board: "73570"
-- company: "73826"
+- company: Script Communications GmbH
   board: "73826"
 - company: Notare Hamburg-Rahlstedt
   board: "73902"
 - company: SEBASTIEN BENARD
   board: "73947"
-- company: "74049"
+- company: JDNET LAVEURDECARREAUX.COM
   board: "74049"
 - company: Kinder- und Jugendarztpraxis Dr. Petra Zieriacks
   board: "74136"
-- company: "74384"
+- company: a-energen GmbH
   board: "74384"
-- company: "74500"
+- company: Ruder Verpackungen GmbH
   board: "74500"
 - company: IMMECOL IBERICA
   board: "74504"
 - company: Académie Younus
   board: "74513"
-- company: "74608"
+- company: KLEIN kindercentra
   board: "74608"
-- company: "74640"
+- company: E&S Gebäudereinigung
   board: "74640"
-- company: "74672"
+- company: Deltares
   board: "74672"
 - company: Velmon MPC
   board: "74690"
-- company: "74789"
+- company: Echt Nederlands
   board: "74789"
-- company: "74869"
+- company: Home Instead Landkreis München
   board: "74869"
 - company: thePower
   board: "74922"
 - company: INNOVELEC INDUSTRIE
   board: "74927"
-- company: "74934"
+- company: Pirlet und Partner Ingenieurgesellschaft mbH
   board: "74934"
-- company: "74960"
+- company: Montessori Kinderopvang
   board: "74960"
-- company: "75173"
+- company: AV Werving & Selectie
   board: "75173"
 - company: Van Puffelen
   board: "75207"
-- company: "75306"
+- company: Holland Bikes
   board: "75306"
-- company: "75353"
+- company: So Bang
   board: "75353"
-- company: "75476"
+- company: Pebetero S.L.
   board: "75476"
 - company: Hazienda
   board: "75594"
-- company: "75674"
+- company: SMW Service und Pumpentechnik GmbH
   board: "75674"
-- company: "75735"
+- company: ASG Gastronomie GmbH
   board: "75735"
 - company: SAS RENAUD VIANDES
   board: "75743"
-- company: "75773"
+- company: Waldhotel Berghof
   board: "75773"
 - company: Essentielle
   board: "75881"
-- company: "75905"
+- company: GERMAN RETROFIT
   board: "75905"
-- company: "75929"
+- company: VISPIRON GmbH
   board: "75929"
 - company: Say Digital GmbH
   board: "75930"
-- company: "75945"
+- company: MSL Formacion S.L.
   board: "75945"
-- company: "75955"
+- company: MTAE
   board: "75955"
-- company: "75984"
+- company: FLASH RENOV - BAILLEUL
   board: "75984"
-- company: "76073"
+- company: Praxis Dr. Lindörfer - Moderne Zahnheilkunde
   board: "76073"
-- company: "76161"
+- company: SCAM
   board: "76161"
-- company: "76266"
+- company: P&P Group
   board: "76266"
 - company: HERMANOS JIMENEZ GOMEZ S.L.
   board: "76292"
-- company: "76304"
+- company: SÜSS Beratende Ingenieure
   board: "76304"
-- company: "76397"
+- company: ERA BAYONNE
   board: "76397"
 - company: Updent Fachärzte für Zahnmedizin & Prophylaxe - Dr. Karl Schwaninger
   board: "7641"
-- company: "76434"
+- company: Staffplanning B.V.
   board: "76434"
-- company: "76521"
+- company: GROUPE NADIA
   board: "76521"
 - company: Warmako
   board: "76628"
-- company: "76678"
+- company: ADMR ENTRE MOSELLE ET MEURTHE
   board: "76678"
-- company: "76826"
+- company: Boulangerie le Pain des Pistes
   board: "76826"
 - company: EL LUNES CIERRO EL PICO, S.L.U.
   board: "76909"
-- company: "76951"
+- company: MONTAJES Y SERVICIOS INDUSTRIALES GUICAR S.L.
   board: "76951"
 - company: HUN.nu
   board: "77023"
-- company: "77030"
+- company: TREBAUL COUVERTURE
   board: "77030"
-- company: "77043"
+- company: Shiso Burger GmbH
   board: "77043"
-- company: "77139"
+- company: Juristen Arbeidsrecht Nederland
   board: "77139"
-- company: "77179"
+- company: Inntaler Transporte GmbH
   board: "77179"
 - company: POK UG
   board: "77217"
 - company: Laboratoires Jerodia
   board: "77264"
-- company: "77354"
+- company: Direction Interrégionale des Douanes Auvergne-Rhône-Alpes
   board: "77354"
-- company: "77384"
+- company: Customeyes
   board: "77384"
 - company: Centre de gestion de la fonction publique territoriale de l'Oise
   board: "77481"
 - company: Apotheek Emmerhout
   board: "77555"
-- company: "77573"
+- company: Bryder BV
   board: "77573"
-- company: "77606"
+- company: Vapiano Leipzig
   board: "77606"
-- company: "77653"
+- company: LOU op de Hoek
   board: "77653"
-- company: "77723"
+- company: JobMotion B.V.
   board: "77723"
 - company: 113 Zelfmoordpreventie
   board: "77744"
-- company: "78024"
+- company: Wessel Juristen
   board: "78024"
-- company: "78028"
+- company: SOGINOV
   board: "78028"
-- company: "7803"
+- company: XIAO Beteiligungsgesellschaft mbH
   board: "7803"
-- company: "78217"
+- company: Otherside at Work
   board: "78217"
-- company: "78223"
+- company: De Bazaar
   board: "78223"
-- company: "78228"
+- company: Digital Friend
   board: "78228"
-- company: "78232"
+- company: Nickel
   board: "78232"
 - company: Imanes Bakery
   board: "78262"
@@ -3677,177 +3677,177 @@
   board: "7839"
 - company: Buess+Partner Architekten GmbH
   board: "78442"
-- company: "78462"
+- company: Lohnsteuerhilfeverein Vereinigte Lohnsteuerhilfe e.V.
   board: "78462"
-- company: "78491"
+- company: CONSTATIMMO
   board: "78491"
-- company: "78550"
+- company: eep Energieconsulting GmbH
   board: "78550"
-- company: "78702"
+- company: LES AMIS DU MUSEE GRATALOUP
   board: "78702"
-- company: "78746"
+- company: CASH FLOW POSITIF
   board: "78746"
-- company: "78769"
+- company: Bloss schoonheidsinstituut
   board: "78769"
 - company: Pluxbox BV
   board: "78995"
-- company: "78998"
+- company: Bellevue Dolmetscherservice gGmbH
   board: "78998"
-- company: "79051"
+- company: DI MARTINO GESTION PRIVEE
   board: "79051"
-- company: "79066"
+- company: Vulcanus-Stahl & Maschinenbau GmbH
   board: "79066"
 - company: KEDER DESIGN SL
   board: "79174"
 - company: CONCEPT AUDIT
   board: "79180"
-- company: "79215"
+- company: Basil Thai Restaurant
   board: "79215"
-- company: "79249"
+- company: PROMOTRANS FPC ARRAS
   board: "79249"
-- company: "79469"
+- company: PROPAHER
   board: "79469"
-- company: "79714"
+- company: softgate
   board: "79714"
 - company: TRANSFRIO RÍAS BAIXAS , S.L.
   board: "79764"
-- company: "79799"
+- company: ENERDOMO Oldenburg, Wilhelmshafen, Bremerhaven, Leer, Emden
   board: "79799"
 - company: 404 Programación S.L.
   board: "80026"
-- company: "80460"
+- company: PERISCOPE
   board: "80460"
 - company: Dijkstra Trappen
   board: "80814"
-- company: "80999"
+- company: Atithi Indian Restaurant
   board: "80999"
-- company: "81078"
+- company: Futurised GmbH
   board: "81078"
 - company: Lumi Parts B.V.
   board: "81170"
-- company: "8136"
+- company: Bencis Capital Partners
   board: "8136"
-- company: "81503"
+- company: ESTUGO
   board: "81503"
-- company: "81519"
+- company: Neue Energien Ingenieurplanungen GmbH
   board: "81519"
-- company: "81957"
+- company: Autohaus Lampa GmbH
   board: "81957"
-- company: "81996"
+- company: OE Service GmbH
   board: "81996"
 - company: Horn Glass Industries AG
   board: "8202"
 - company: BTR SUMUS MARQUARDT, SCHRÖDER UND TENSFELDT PARTNERSCHAFT STEUERBERATUNGSGESELLSCHAFT
   board: "82054"
-- company: "82056"
+- company: CARASOIE
   board: "82056"
-- company: "82092"
+- company: BEST OPTION MEDIA
   board: "82092"
-- company: "82124"
+- company: Aina Zorg B.v
   board: "82124"
-- company: "8215"
+- company: Radisson Hotel Group
   board: "8215"
-- company: "82171"
+- company: PS Sports & More
   board: "82171"
-- company: "8218"
+- company: onval AG
   board: "8218"
-- company: "82378"
+- company: BBF Herold Ingenieurgesellschaft für Garten- und Landschaftsbau mbH
   board: "82378"
 - company: Medialine EuroTrade AG
   board: "8242"
-- company: "82685"
+- company: Raabe Sanitär GmbH
   board: "82685"
 - company: EUR COORDOGEC
   board: "82726"
-- company: "82769"
+- company: Deepidoo
   board: "82769"
-- company: "82776"
+- company: AXA & DBV Versicherung - Meyer, Schwarz & Grauli oHG
   board: "82776"
-- company: "82878"
+- company: UNITY Operations AG
   board: "82878"
-- company: "82927"
+- company: S-IB Schütz Industriebedarf GmbH
   board: "82927"
 - company: Architektur Line AG
   board: "83056"
-- company: "8322"
+- company: P.A.C. GmbH
   board: "8322"
-- company: "83253"
+- company: IMMOTHEP
   board: "83253"
-- company: "8343"
+- company: Motorsport Arena Oschersleben GmbH
   board: "8343"
 - company: Buro Happold
   board: "83519"
-- company: "83554"
+- company: Immobilien-Cluster GmbH
   board: "83554"
 - company: Speedflirting GmbH
   board: "83590"
-- company: "83600"
+- company: Peakconcepts GmbH
   board: "83600"
-- company: "83770"
+- company: FAMILY PARK
   board: "83770"
-- company: "83790"
+- company: ZÜRCHER STAHLBAU GmbH
   board: "83790"
-- company: "83889"
+- company: DOMICILE CLEAN RENNES
   board: "83889"
 - company: CINEMA LE PARADSISIO
   board: "83939"
 - company: Montres Norqain SA
   board: "8404"
-- company: "84183"
+- company: BorBäcker Siebers
   board: "84183"
 - company: CuramuS Pflegedienst GmbH
   board: "84192"
 - company: Rain for Rent International
   board: "84242"
-- company: "84427"
+- company: Herzhaus Berlin
   board: "84427"
-- company: "84459"
+- company: tbs-pack GmbH
   board: "84459"
-- company: "84550"
+- company: Sanitätshaus Brockers GmbH
   board: "84550"
 - company: Kaisersaal Gastronomie- & Veranstaltungs GmbH
   board: "84579"
-- company: "84584"
+- company: SMD Group
   board: "84584"
-- company: "84590"
+- company: Becker Veranstaltungstechnik GmbH
   board: "84590"
-- company: "84620"
+- company: ELLII
   board: "84620"
-- company: "84621"
+- company: Blockhütte GmbH
   board: "84621"
-- company: "84704"
+- company: Swello
   board: "84704"
 - company: LES PETITS CHAPERONS ROUGES
   board: "84706"
-- company: "84751"
+- company: expert Warenvertrieb GmbH
   board: "84751"
-- company: "84753"
+- company: ACT.agency
   board: "84753"
-- company: "85051"
+- company: Mairie de La Mure
   board: "85051"
-- company: "85227"
+- company: Le Faham
   board: "85227"
-- company: "85278"
+- company: PREIS GmbH
   board: "85278"
 - company: De Westkaap
   board: "85293"
-- company: "85439"
+- company: Binz AG, Transporte & Logistik
   board: "85439"
-- company: "85463"
+- company: aflexio GmbH
   board: "85463"
-- company: "85532"
+- company: I-Advise AG WPG
   board: "85532"
 - company: "85577"
   board: "85577"
 - company: PEPPIT
   board: "85624"
-- company: "85744"
+- company: GEODIS FF FRANCE
   board: "85744"
-- company: "85798"
+- company: DIGITALWERK (The Accelerate Company GmbH)
   board: "85798"
-- company: "85966"
+- company: New Wind Viscoelástica Española, S.L
   board: "85966"
-- company: "86077"
+- company: SSP Deutschland GmbH
   board: "86077"
 - company: Restaurant Rozemarijn
   board: "86256"
@@ -3855,135 +3855,135 @@
   board: "86396"
 - company: Glow25 (by Primal State Performance GmbH)
   board: "8679"
-- company: "86828"
+- company: VIVOOD Landscape Hotels
   board: "86828"
-- company: "86885"
+- company: Heym GmbH
   board: "86885"
-- company: "87109"
+- company: Green-Got
   board: "87109"
-- company: "87177"
+- company: FIBRA Y SISTEMAS S.L
   board: "87177"
-- company: "87271"
+- company: Egga Betriebs GmbH
   board: "87271"
-- company: "87370"
+- company: FFG FINANZCHECK Finanzportale GmbH
   board: "87370"
-- company: "87498"
+- company: Quadient
   board: "87498"
-- company: "87527"
+- company: Knödler electronic solutions GmbH
   board: "87527"
 - company: WayCon Positionsmesstechnik GmbH
   board: "87645"
-- company: "87689"
+- company: Bijsmaak Handelsonderneming
   board: "87689"
-- company: "87723"
+- company: horntools GmbH
   board: "87723"
-- company: "87798"
+- company: PROCONCEPT SERVICE
   board: "87798"
 - company: Mercer Nederland
   board: "88098"
 - company: La Figolette
   board: "88228"
-- company: "88522"
+- company: Planted Foods GmbH
   board: "88522"
 - company: 3BTP
   board: "88579"
-- company: "88624"
+- company: Feu Vert Ibérica
   board: "88624"
-- company: "88719"
+- company: Nachhilfe Lernfit
   board: "88719"
 - company: Domaine du château de Viviers
   board: "88863"
-- company: "88940"
+- company: INTERMARCHE SAINT-PIERRE-DES-FLEURS
   board: "88940"
-- company: "88955"
+- company: TirolinasGo Madrid
   board: "88955"
 - company: RegioVision GmbH Schwerin
   board: "89017"
-- company: "89033"
+- company: TGA Fellner GmbH
   board: "89033"
-- company: "89240"
+- company: Caritative Dienste Augsburg Nord-West gGmbH
   board: "89240"
-- company: "89381"
+- company: PARIS CANAL
   board: "89381"
 - company: Ingenieurbüro Sulzer GmbH & Co. KG
   board: "89390"
-- company: "89402"
+- company: MOBIAN
   board: "89402"
 - company: MIVEG GmbH
   board: "89408"
-- company: "89443"
+- company: Ingenieurbüro SPETTMANN + KAHR
   board: "89443"
-- company: "89487"
+- company: Nachhilfe Einstein Köln
   board: "89487"
-- company: "89600"
+- company: RECOMAR, S.A.
   board: "89600"
-- company: "89636"
+- company: Medicalthree GmbH
   board: "89636"
-- company: "89719"
+- company: WORKBB
   board: "89719"
-- company: "89811"
+- company: Lernwerk GmbH
   board: "89811"
-- company: "90286"
+- company: NapaWine AG
   board: "90286"
-- company: "90398"
+- company: ULTREIA FRANCE
   board: "90398"
 - company: Lievens & Co
   board: "90399"
-- company: "90574"
+- company: VIJ Verein für Internationale Jugendarbeit e. V.
   board: "90574"
 - company: AIXTY IMMOBILIER
   board: "90689"
-- company: "90698"
+- company: Fouta 619
   board: "90698"
 - company: Muscularia GmbH
   board: "90824"
 - company: Kuttenberger Immobilien
   board: "90868"
-- company: "90954"
+- company: Comet Meetings
   board: "90954"
-- company: "90994"
+- company: Bredenoord
   board: "90994"
-- company: "91023"
+- company: PIERsoBAT
   board: "91023"
 - company: Randstad Digital Germany AG
   board: "91032"
-- company: "91298"
+- company: Fußballverband Niederrhein
   board: "91298"
-- company: "91457"
+- company: IR-SERV
   board: "91457"
-- company: "9149"
+- company: ORENDT STUDIOS GmbH
   board: "9149"
-- company: "91549"
+- company: Realetee
   board: "91549"
 - company: JFA Yachts
   board: "91695"
-- company: "91696"
+- company: Karl Wolf Präzision³ e.K.
   board: "91696"
-- company: "91733"
+- company: Atithi Indian Restaurants
   board: "91733"
-- company: "91752"
+- company: Maximo Nivel
   board: "91752"
-- company: "9184"
+- company: ADKL Abels Decker Kuhfuß & Partner mbB
   board: "9184"
 - company: bedrop
   board: "91967"
 - company: AM.PM Europe GmbH
   board: "92004"
-- company: "92077"
+- company: etimark GmbH & Co. KG
   board: "92077"
-- company: "924"
+- company: DECORAMI GmbH
   board: "924"
-- company: "92515"
+- company: GEODE GEOMETRES-EXPERTS
   board: "92515"
-- company: "92527"
+- company: IFBM et Qualtech Groupe
   board: "92527"
 - company: Supermarché Bi1 - Morbier
   board: "92725"
-- company: "92748"
+- company: NBB Controls + Components GmbH
   board: "92748"
-- company: "92762"
+- company: Berghotel Eisenach
   board: "92762"
-- company: "92876"
+- company: Slidor
   board: "92876"
 - company: PLING GmbH - for smart decisions
   board: "93047"
@@ -3993,111 +3993,111 @@
   board: "93620"
 - company: Interlang
   board: "93675"
-- company: "9379"
+- company: Pallit
   board: "9379"
-- company: "93853"
+- company: AWAQE Global GmbH
   board: "93853"
-- company: "94065"
+- company: Aphos Gesellschaft für IT-Sicherheit mbH
   board: "94065"
-- company: "94379"
+- company: AN Immo GmbH
   board: "94379"
-- company: "94390"
+- company: Make Me Stay
   board: "94390"
-- company: "9444"
+- company: Instant Service AG
   board: "9444"
-- company: "94471"
+- company: Profile Car- & Tyreservice Roosendaal
   board: "94471"
-- company: "94482"
+- company: Punjabi Food BV
   board: "94482"
-- company: "94520"
+- company: Association Siel Bleu
   board: "94520"
-- company: "94682"
+- company: OLIMA, S.L.
   board: "94682"
-- company: "94815"
+- company: NovoServe
   board: "94815"
-- company: "9484"
+- company: PlantaCorp GmbH
   board: "9484"
 - company: ISARTAX GmbH Wirtschaftsprüfungsgesellschaft Steuerberatungsgesellschaft
   board: "94919"
-- company: "95010"
+- company: modologie
   board: "95010"
 - company: Ratisbona Consulting GmbH
   board: "95075"
-- company: "95102"
+- company: Pronux GmbH
   board: "95102"
 - company: ACR PATRIMOINE
   board: "95142"
 - company: NARR Isoliersysteme GmbH
   board: "95197"
-- company: "95419"
+- company: Gelukkig Lijf BV
   board: "95419"
-- company: "95446"
+- company: Little Soho
   board: "95446"
 - company: Zahnarztpraxis Hahn & Hahn
   board: "95528"
-- company: "95538"
+- company: Zahnarztpraxis Mein Zahn
   board: "95538"
-- company: "9555"
+- company: Deutsche Investment Kapitalverwaltung AG
   board: "9555"
-- company: "95600"
+- company: Hilpert AG
   board: "95600"
 - company: MBB Change
   board: "95721"
 - company: CORTECA  Bernd Schmid
   board: "95734"
-- company: "9609"
+- company: UMAMI AG
   board: "9609"
-- company: "96110"
+- company: PERFACCT GmbH
   board: "96110"
 - company: Jansen Beton und Granitwerke GmbH
   board: "96135"
-- company: "96256"
+- company: MAM
   board: "96256"
-- company: "96303"
+- company: Grand Lord Bus, S.L.
   board: "96303"
-- company: "96401"
+- company: Eurorealtors
   board: "96401"
-- company: "96523"
+- company: InterThera Physiotherapie
   board: "96523"
-- company: "9653"
+- company: CARIFY
   board: "9653"
 - company: Decker Group GmbH
   board: "96600"
-- company: "96719"
+- company: Grand Hotel Huis ter Duin
   board: "96719"
-- company: "96773"
+- company: Sport dans la ville
   board: "96773"
 - company: follow red people
   board: "96781"
-- company: "96804"
+- company: SFEI SARRAT
   board: "96804"
-- company: "96931"
+- company: Werbeagentur Fellner
   board: "96931"
-- company: "96935"
+- company: GORNATION GmbH
   board: "96935"
 - company: Restaurant Mai Thai
   board: "96963"
-- company: "97046"
+- company: Groupe ABYSSE
   board: "97046"
-- company: "97071"
+- company: Extraterrien
   board: "97071"
 - company: ocumeda GmbH
   board: "97364"
-- company: "9756"
+- company: PROMATIS software GmbH
   board: "9756"
-- company: "97649"
+- company: Amsterdam Nightlife
   board: "97649"
-- company: "97801"
+- company: YOelijo autoescuela
   board: "97801"
-- company: "97816"
+- company: Naresh I Technologies
   board: "97816"
-- company: "97885"
+- company: Impuls Verschleißtechnik GmbH
   board: "97885"
-- company: "97933"
+- company: aqualevante
   board: "97933"
-- company: "98027"
+- company: Giga Meubel
   board: "98027"
-- company: "98114"
+- company: Stradivarius
   board: "98114"
 - company: RoomRaccoon
   board: "98247"
@@ -4111,31 +4111,31 @@
   board: "98665"
 - company: ALGOE
   board: "98673"
-- company: "9877"
+- company: MénageSimple SA
   board: "9877"
-- company: "98826"
+- company: Tidoudou
   board: "98826"
-- company: "98985"
+- company: DR AGRI
   board: "98985"
-- company: "99054"
+- company: Bela Living GmbH
   board: "99054"
-- company: "99063"
+- company: KJS NRW
   board: "99063"
-- company: "99072"
+- company: Phidra Accountants & Adviseurs
   board: "99072"
-- company: "99209"
+- company: Regina Hotel Madrid
   board: "99209"
-- company: "99285"
+- company: Next Level Seguridad y Emergencia
   board: "99285"
-- company: "99321"
+- company: Kirchhoff Fysio
   board: "99321"
-- company: "99477"
+- company: GRUPO OSMOS
   board: "99477"
-- company: "99591"
+- company: myVesta
   board: "99591"
 - company: rauschenberg ingenieure gmbh
   board: "99820"
-- company: "99988"
+- company: Kieferstellwerk
   board: "99988"
 - company: 3M HABITAT
   board: "99995"
@@ -4181,7 +4181,7 @@
   board: "100873"
 - company: DIVISEGUR S.L.
   board: "100947"
-- company: "101084"
+- company: MNV Mantenimiento SL
   board: "101084"
 - company: SERYCUB VALENCIA
   board: "101271"
@@ -4195,7 +4195,7 @@
   board: "101467"
 - company: Synflow
   board: "101607"
-- company: "101649"
+- company: BTS Befestigungselemente - Technik und Vertrieb Gesellschaft mbH
   board: "101649"
 - company: Bellerose SA Belgium
   board: "101726"
@@ -4203,7 +4203,7 @@
   board: "101911"
 - company: Clínica Kemana
   board: "102001"
-- company: "102277"
+- company: Tophome Anlagenbetreuung
   board: "102277"
 - company: LIMPINK SERVICIO DE LAVANDERÍA, S.L.
   board: "102303"
@@ -4213,15 +4213,15 @@
   board: "102493"
 - company: ENGLISH FOR TODAY
   board: "102495"
-- company: "102647"
+- company: BOSS Immobilien GmbH
   board: "102647"
 - company: Masajes SVQ
   board: "102740"
-- company: "102786"
+- company: Clinica dentale Cappellin S.r.l. Società Benefit
   board: "102786"
-- company: "103017"
+- company: SISTEMAS FENIX 2010
   board: "103017"
-- company: "103142"
+- company: msg Plaut Austria
   board: "103142"
 - company: Tenne Bad & Fliesen
   board: "103255"
@@ -4229,27 +4229,27 @@
   board: "103267"
 - company: ESVISA FOODS, S.L.
   board: "103425"
-- company: "103544"
+- company: Bloooming Life GmbH
   board: "103544"
-- company: "103619"
+- company: Maison de thé LUPICIA
   board: "103619"
-- company: "103782"
+- company: HOLIDAY GYM
   board: "103782"
 - company: Apotheke zum heiligen Leopold
   board: "103787"
-- company: "103795"
+- company: Previse Systems AG
   board: "103795"
-- company: "10380"
+- company: Amanda Nails GmbH
   board: "10380"
-- company: "103800"
+- company: MORGANCAR
   board: "103800"
 - company: Fides Treasury Services AG
   board: "103909"
-- company: "103979"
+- company: Servicios Hosteleros en Transporte Público S.L
   board: "103979"
 - company: BBQ Store Eisenstadt
   board: "104049"
-- company: "104117"
+- company: GAMA
   board: "104117"
 - company: JUHU! Jugend Hilfswerk der Familie Umek
   board: "104146"
@@ -4257,139 +4257,139 @@
   board: "104352"
 - company: Grupo Interbus
   board: "104408"
-- company: "104762"
+- company: MAQUISUR 1999, S.L.U.
   board: "104762"
-- company: "104816"
+- company: HIJOS DE A. GASPAR ROSA, S.L.
   board: "104816"
 - company: Protiberia
   board: "104952"
-- company: "105093"
+- company: REHAVITAL
   board: "105093"
-- company: "105144"
+- company: CUNEF S.L.
   board: "105144"
-- company: "105149"
+- company: NOVAC-SOLUTIONS GmbH
   board: "105149"
-- company: "105219"
+- company: RainSwiss Clean AG
   board: "105219"
-- company: "105272"
+- company: Ramatech Systems
   board: "105272"
-- company: "105384"
+- company: Estudio Fuenlabrada Ferrocarril
   board: "105384"
-- company: "105386"
+- company: Grupo Inova
   board: "105386"
-- company: "105401"
+- company: AureusDrive AG
   board: "105401"
-- company: "105431"
+- company: Juggers Sécurité SA
   board: "105431"
-- company: "105438"
+- company: NonStop Consulting
   board: "105438"
-- company: "105525"
+- company: Fusion Arena Basel
   board: "105525"
-- company: "105711"
+- company: ILEROD INGENIERIA E INSTALACIONES S.L.U
   board: "105711"
-- company: "105850"
+- company: dectria
   board: "105850"
-- company: "106098"
+- company: Kuhn Schweiz AG
   board: "106098"
-- company: "106167"
+- company: REIWAG Facility Services GmbH
   board: "106167"
-- company: "106275"
+- company: RS Limousines Salzburg
   board: "106275"
 - company: Le Room Service
   board: "106361"
-- company: "106396"
+- company: Relais Termal
   board: "106396"
 - company: MOVISAT TECNOMOVILIDAD,S.L.
   board: "106524"
 - company: Abogados ABM
   board: "106596"
-- company: "106610"
+- company: Babyshop Dr. Riedl
   board: "106610"
 - company: BON SELEC
   board: "106695"
 - company: Klangwelt Toggenburg
   board: "106783"
-- company: "106799"
+- company: AFEDAZ
   board: "106799"
-- company: "106804"
+- company: The Green Wildman GmbH
   board: "106804"
-- company: "106966"
+- company: Neomat AG
   board: "106966"
-- company: "106984"
+- company: Grillen Garage AG
   board: "106984"
-- company: "107045"
+- company: Tierklinik Steyr
   board: "107045"
-- company: "107134"
+- company: Koch AG, Strassen- & Tiefbau, Kies & Beton
   board: "107134"
-- company: "107200"
+- company: General Laser
   board: "107200"
-- company: "10726"
+- company: Infra-Com Swiss AG
   board: "10726"
-- company: "107347"
+- company: AUDIOPTICA SOCIAL
   board: "107347"
-- company: "107521"
+- company: Risem GmbH
   board: "107521"
 - company: Foreus Intelligence GmbH
   board: "107531"
-- company: "107616"
+- company: Glacier
   board: "107616"
 - company: BOHO NAILS ART, S.L.
   board: "107680"
 - company: Balandrino Gastronómica S.L.
   board: "107690"
-- company: "107734"
+- company: Residencia Ntra Sra Perpetuo Socorro
   board: "107734"
-- company: "107812"
+- company: KIDAN
   board: "107812"
-- company: "107844"
+- company: CLISOL CLIMATIZACIÓN S.L.U.
   board: "107844"
 - company: Blumen Lechner Karin & Michael GnbR
   board: "107849"
-- company: "108238"
+- company: advantus
   board: "108238"
-- company: "108240"
+- company: DIMINOX
   board: "108240"
-- company: "108301"
+- company: Pilates UP
   board: "108301"
-- company: "108306"
+- company: Doris Reinisch GmbH
   board: "108306"
-- company: "108399"
+- company: CULTO Alta Peluquería
   board: "108399"
 - company: Places to be Fundraising
   board: "108408"
-- company: "108562"
+- company: Renova Systems
   board: "108562"
 - company: European Handball Federation
   board: "10857"
 - company: Fler
   board: "108650"
-- company: "10881"
+- company: Culinarius Gruppe
   board: "10881"
-- company: "108848"
+- company: globalsa conservación, s.l.
   board: "108848"
-- company: "10907"
+- company: Rychiger AG
   board: "10907"
 - company: Formadistancia
   board: "109141"
-- company: "109198"
+- company: Tobelhof Gastronomie AG
   board: "109198"
-- company: "109357"
+- company: Sprad Software GmbH
   board: "109357"
-- company: "109399"
+- company: Naturhouse
   board: "109399"
-- company: "109456"
+- company: Praxis Für Physikalische Therapie Zürich GmbH
   board: "109456"
-- company: "109475"
+- company: Notz Plastics AG
   board: "109475"
-- company: "109651"
+- company: PROJECTING
   board: "109651"
-- company: "110151"
+- company: Gestión de Residencias (GdR)
   board: "110151"
-- company: "110205"
+- company: R2R Consulting Inmobiliario S.L
   board: "110205"
-- company: "110345"
+- company: wordbird OG (ehemals biz.talk)
   board: "110345"
-- company: "110459"
+- company: Autocontrol Sistemas
   board: "110459"
 - company: Home 36 GmbH
   board: "110473"
@@ -4397,61 +4397,61 @@
   board: "110691"
 - company: Timeconsult AG
   board: "110739"
-- company: "110797"
+- company: Nueva Cocina Mediterránea 2002 S.L.
   board: "110797"
-- company: "110950"
+- company: Hotel Albergue Monte do Gozo
   board: "110950"
-- company: "111072"
+- company: Disgraf Servei S.L
   board: "111072"
 - company: Planfactory GmbH
   board: "111088"
-- company: "111182"
+- company: Stuhlberger IT GmbH
   board: "111182"
-- company: "111227"
+- company: ECOASFALT
   board: "111227"
-- company: "11130"
+- company: sanu future learning ag
   board: "11130"
 - company: Clap Educación Activa SL
   board: "111610"
-- company: "111630"
+- company: CIPIF
   board: "111630"
-- company: "111658"
+- company: ALTERTEC RENOVABLES
   board: "111658"
-- company: "111680"
+- company: Weihrich Informatik GmbH
   board: "111680"
-- company: "111683"
+- company: con10com
   board: "111683"
-- company: "111781"
+- company: Packyard BE
   board: "111781"
-- company: "111789"
+- company: Eissport Errichtungs- Betriebs- und Management GmbH.
   board: "111789"
-- company: "112050"
+- company: IRIS PRODUCTS
   board: "112050"
 - company: Salona Consulting GmbH
   board: "112059"
-- company: "112073"
+- company: Contena-Ochsner AG
   board: "112073"
 - company: Origin
   board: "112153"
 - company: ESTUDI GRAFIC EL PRAT
   board: "112221"
-- company: "112320"
+- company: LASERTALL, S.L.
   board: "112320"
-- company: "112532"
+- company: Baldauf Gebäudetechnik GmbH
   board: "112532"
-- company: "112560"
+- company: Haerter & Partner AG
   board: "112560"
 - company: Hotel Landhaus Moserhof
   board: "112655"
-- company: "112706"
+- company: Skischool GO!
   board: "112706"
-- company: "112715"
+- company: Adler Installations-Bau-Sanierungs Elite GmbH
   board: "112715"
-- company: "112869"
+- company: ASIDMA SERVICIOS SOCIALES
   board: "112869"
-- company: "112887"
+- company: Antonio Estrella
   board: "112887"
-- company: "112888"
+- company: Heinrichs Gruppe
   board: "112888"
 - company: Sonnberg Biofleisch GmbH
   board: "112975"
@@ -4459,133 +4459,133 @@
   board: "112986"
 - company: Marpe Marcos S.L.
   board: "113066"
-- company: "113094"
+- company: Pizzeria De Icco
   board: "113094"
-- company: "113580"
+- company: Zeiserl Bier GmbH
   board: "113580"
-- company: "113670"
+- company: FE SEGUROS
   board: "113670"
 - company: industrias de serigrafia y marcajes versal, s.l.
   board: "113702"
 - company: Clinica Dental Maestro
   board: "113739"
-- company: "113789"
+- company: Zillertal Bier
   board: "113789"
-- company: "113805"
+- company: TEFRALUX
   board: "113805"
-- company: "114071"
+- company: Calfri
   board: "114071"
 - company: Thalmann Steger Architekten AG
   board: "114138"
 - company: sigmavista it consulting gmbh
   board: "11419"
-- company: "114364"
+- company: Münger Treuhand & Immobilien AG
   board: "114364"
-- company: "114536"
+- company: CASADEMONT MEAT 1956, S.L
   board: "114536"
-- company: "114582"
+- company: INGEMATIS, S.L.
   board: "114582"
-- company: "114650"
+- company: campos peluqueros
   board: "114650"
-- company: "114695"
+- company: Olimpo Gourmet S.L
   board: "114695"
-- company: "114756"
+- company: Proyect Arte Producciones S.L
   board: "114756"
 - company: itesys AG
   board: "114846"
-- company: "114932"
+- company: Barimueble
   board: "114932"
-- company: "114963"
+- company: SUITEC FENIX
   board: "114963"
-- company: "115025"
+- company: Schubert System Elektronik GmbH
   board: "115025"
-- company: "115092"
+- company: IBOD Wand & Boden
   board: "115092"
-- company: "115177"
+- company: Duran Carasso
   board: "115177"
-- company: "115268"
+- company: JOAQUIN SEGURA GUBERN
   board: "115268"
-- company: "115423"
+- company: CAMPING NATURA
   board: "115423"
 - company: Road Stop Cafe
   board: "115456"
-- company: "115511"
+- company: Occlutech GmbH
   board: "115511"
 - company: Specific Group Austria
   board: "11553"
-- company: "11556"
+- company: Glartek
   board: "11556"
-- company: "115691"
+- company: AVINCLA BELLAVISTA, S.L.
   board: "115691"
-- company: "115706"
+- company: RIGAZ SERVIRADIO SLU
   board: "115706"
 - company: mjuks GmbH
   board: "115744"
-- company: "115762"
+- company: minusplus
   board: "115762"
-- company: "115797"
+- company: ALERCE CENTRO DE PSICOLOGIA Y LOGOPEDIA
   board: "115797"
-- company: "115916"
+- company: Vinothèque La passion du vin SA
   board: "115916"
 - company: GERMANÍA DE INSTALACIONES Y SERVICIOS SL
   board: "115951"
-- company: "115976"
+- company: Italk Sprachschule
   board: "115976"
-- company: "116036"
+- company: DOCENDO OCIO EDUCATIVO SL
   board: "116036"
 - company: DRIVERVAN
   board: "116386"
 - company: DIALGASA SL
   board: "116421"
-- company: "116725"
+- company: TALLERES LOSAN
   board: "116725"
-- company: "116765"
+- company: ERGONIA BUSINESS SOLUTIONS SL
   board: "116765"
-- company: "116835"
+- company: Unterschwarzachhof
   board: "116835"
-- company: "116917"
+- company: vyzn
   board: "116917"
-- company: "116948"
+- company: ORION Pharma GmbH
   board: "116948"
-- company: "116955"
+- company: excent AG
   board: "116955"
-- company: "117142"
+- company: cecocs sl
   board: "117142"
-- company: "117246"
+- company: CONTROLVIG SEGURIDAD
   board: "117246"
 - company: Multidiomas Languge School
   board: "117259"
 - company: Flip Lab FlexCo & Co KG
   board: "117377"
-- company: "117456"
+- company: ADILY HOTELS,S.L.
   board: "117456"
-- company: "117540"
+- company: PROCONSULT
   board: "117540"
-- company: "117569"
+- company: Senhor Vinho - Das portugiesische Restaurant in Wien.
   board: "117569"
-- company: "11761"
+- company: CS-Computing GmbH
   board: "11761"
-- company: "117654"
+- company: NORD-3000 ASSESSORS, S.L.
   board: "117654"
-- company: "117716"
+- company: Dynamipool
   board: "117716"
-- company: "117856"
+- company: Freely Handustry
   board: "117856"
 - company: AVA Verlagsauslieferung AG
   board: "117922"
-- company: "117951"
+- company: IRUNTEL S.L.
   board: "117951"
-- company: "118000"
+- company: LARTEC
   board: "118000"
-- company: "118075"
+- company: Fisio-especialistas
   board: "118075"
 - company: SANO GRANADA
   board: "118086"
-- company: "11809"
+- company: BaXian AG
   board: "11809"
-- company: "118139"
+- company: INMOBILIARIAS ENCUENTRO
   board: "118139"
-- company: "11820"
+- company: HTP-Gutzwiller GmbH
   board: "11820"
 - company: Elgeadi Traumatología
   board: "118381"
@@ -4595,131 +4595,131 @@
   board: "118595"
 - company: MARS INTELLIGENCE
   board: "118622"
-- company: "118677"
+- company: ESCUELA INFANTIL EL AZAHAR SOC. COOPERATIVA
   board: "118677"
-- company: "118788"
+- company: IFA Rügen Hotel & Ferienpark
   board: "118788"
-- company: "118790"
+- company: INSTITUTO DE RESONANCIA MAGNETICA DRA. GUIRADO, S.L.P.
   board: "118790"
-- company: "118791"
+- company: IFA Hotels Kleinwalsertal
   board: "118791"
 - company: Solarenergie Küng GmbH
   board: "118895"
-- company: "119041"
+- company: Desconecta
   board: "119041"
-- company: "119074"
+- company: SCALTA ARQUITECTURA
   board: "119074"
-- company: "11911"
+- company: BVG, Bau- und Verwaltungs - Gesellschaft AG
   board: "11911"
-- company: "119359"
+- company: Planet Matters GmbH
   board: "119359"
 - company: SQUIRREL MEDIA, SA
   board: "119383"
-- company: "119467"
+- company: PIDSO - Propagation Ideas & Solutions GmbH
   board: "119467"
-- company: "119496"
+- company: LIHOS
   board: "119496"
-- company: "119555"
+- company: Sole Hörgertshausen GmbH
   board: "119555"
-- company: "119566"
+- company: Kosmetik Sabine Sauberer
   board: "119566"
 - company: Casseroles Catering
   board: "119573"
-- company: "119577"
+- company: ATREVIA
   board: "119577"
-- company: "119646"
+- company: Snapbau
   board: "119646"
-- company: "119727"
+- company: DELTA SEGURIDAD
   board: "119727"
 - company: Un Viaje a los 90s
   board: "119745"
-- company: "119819"
+- company: Notariat Mag. Philipp Fiala
   board: "119819"
 - company: Berkshire Hathaway HomeServices Costa Blanca
   board: "119894"
 - company: Plaza
   board: "119938"
-- company: "120140"
+- company: RICC EUROPE GmbH
   board: "120140"
-- company: "120193"
+- company: engitec AG
   board: "120193"
-- company: "120683"
+- company: Grupo Zola Educación
   board: "120683"
-- company: "12096"
+- company: sevogelgroup ag
   board: "12096"
-- company: "120985"
+- company: Odoo DE GmbH
   board: "120985"
-- company: "121024"
+- company: Fergygom Vigo S.L.
   board: "121024"
-- company: "121056"
+- company: Clanser
   board: "121056"
 - company: JG Automotive S.A.
   board: "121278"
-- company: "121280"
+- company: AUTEIMA, S.L.
   board: "121280"
-- company: "121481"
+- company: reframe
   board: "121481"
 - company: HURTADO RIVAS S.L
   board: "121629"
-- company: "121707"
+- company: Seringlobal
   board: "121707"
-- company: "121800"
+- company: VIGUESA DE GRANALLADOS S.L
   board: "121800"
-- company: "121855"
+- company: Helvetic Trust AG
   board: "121855"
 - company: Herzog-Elmiger AG
   board: "122098"
 - company: Paolo Bortolotti
   board: "122154"
-- company: "122286"
+- company: Tsankova Hairstylist and Color Artist
   board: "122286"
-- company: "122374"
+- company: LAVANDERIA DEL CAMPO
   board: "122374"
 - company: ASTAC - A. Stachl
   board: "122434"
-- company: "122567"
+- company: TECNOLOGÍAS AVANZADAS AGRÍCOLAS, S.L. TAVAN
   board: "122567"
-- company: "122732"
+- company: Exceltic
   board: "122732"
-- company: "122794"
+- company: TRAIN GROUP CONSULTORES DE INGENIERIA SL
   board: "122794"
-- company: "122852"
+- company: INSTITUTO EUROPEO DE FORMACION
   board: "122852"
-- company: "122854"
+- company: Direktion Morph @iAdvise
   board: "122854"
 - company: GRUPO SUMAN
   board: "122981"
-- company: "123126"
+- company: HOSTELERÍA LA SIMA, S.L.U.
   board: "123126"
-- company: "123138"
+- company: QUALITY SECURE CORREDURIA DE SEGUROS SL
   board: "123138"
-- company: "123149"
+- company: Easi
   board: "123149"
 - company: Hasenauer GmbH
   board: "123319"
-- company: "123470"
+- company: SAVEFORCE
   board: "123470"
-- company: "123474"
+- company: IO Insurance Brokers GmbH
   board: "123474"
-- company: "123487"
+- company: Golden Wash
   board: "123487"
-- company: "123519"
+- company: Universität Innsbruck
   board: "123519"
-- company: "12354"
+- company: rk-management GmbH
   board: "12354"
-- company: "123556"
+- company: PELICAN
   board: "123556"
 - company: JOYERIA LORENA
   board: "123563"
-- company: "123656"
+- company: Kreuzer Günter e.U.
   board: "123656"
-- company: "123729"
+- company: MERTEL Events Vienna
   board: "123729"
-- company: "123744"
+- company: Obst & Gemüse Schätzl OG
   board: "123744"
-- company: "123780"
+- company: Sidma Integrations GmbH
   board: "123780"
-- company: "123835"
+- company: SUP BOX
   board: "123835"
 - company: J&M Bauer GmbH
   board: "123912"
@@ -4727,209 +4727,209 @@
   board: "123920"
 - company: ACADEMIA NUEVA CASTILLA
   board: "124158"
-- company: "124381"
+- company: UROLOGIE11 - Dr. Nike Morakis
   board: "124381"
-- company: "124411"
+- company: TELEINFORMATICA Y COMUNICACIONES LA PALM
   board: "124411"
-- company: "124484"
+- company: ESTUDIO FONDO SL
   board: "124484"
 - company: Servihogar S.L
   board: "124616"
 - company: WINPARK Businesspark Wiener Neustadt
   board: "124658"
-- company: "124778"
+- company: Innovadora de Servicios
   board: "124778"
-- company: "124857"
+- company: Dealflow
   board: "124857"
-- company: "124928"
+- company: Ebi Mini Kitchen Gmbh
   board: "124928"
 - company: AMARE TURISMO NÁUTICO SL
   board: "125030"
-- company: "125155"
+- company: vesecon gmbh
   board: "125155"
-- company: "125397"
+- company: HIDRAULICA REHINS
   board: "125397"
-- company: "125452"
+- company: Furrer Schweiz AG
   board: "125452"
-- company: "125461"
+- company: aruncy.com
   board: "125461"
-- company: "125466"
+- company: GRUPO MONTAJES
   board: "125466"
-- company: "125671"
+- company: MERIDIANO SEGUROS
   board: "125671"
-- company: "125705"
+- company: Gasthaus zum Schiff / Rhygarte
   board: "125705"
 - company: Martin&Klein GmbH
   board: "125744"
-- company: "125814"
+- company: O.K. Online Agency
   board: "125814"
-- company: "125842"
+- company: KGB GmbH Markus Blach
   board: "125842"
-- company: "125967"
+- company: MULTISEARCH Gesellschaft für internationale Markt- und Serviceforschung mbH
   board: "125967"
 - company: DUROFLEX Distribution GmbH
   board: "126075"
-- company: "126125"
+- company: Deuser (Indra Group)
   board: "126125"
-- company: "126126"
+- company: CONSTRUCCIONES URDECON S.A.
   board: "126126"
-- company: "126130"
+- company: Holi Indian Restaurant
   board: "126130"
 - company: pro.media Studiokonzept GmbH
   board: "126180"
 - company: CONTRACT Controlling & Business Solutions - Angerer KG
   board: "12621"
-- company: "126385"
+- company: DESCALE, S.L.
   board: "126385"
-- company: "126648"
+- company: Regulars
   board: "126648"
-- company: "126712"
+- company: ANYFES
   board: "126712"
-- company: "126742"
+- company: M&M Ingeniería y Montaje Navarra S.L.
   board: "126742"
 - company: Clinical Trainers
   board: "126778"
-- company: "126883"
+- company: Knapp GmbH Österreich
   board: "126883"
 - company: AGREMIA
   board: "126908"
 - company: Kids&Us Sant Andreu de la Barca
   board: "126963"
-- company: "126973"
+- company: UNITAS-SOLIDARIS Wirtschaftstreuhandgesellschaft mbH
   board: "126973"
-- company: "126998"
+- company: Woodtex
   board: "126998"
 - company: Die Personalexpertin
   board: "127140"
-- company: "127297"
+- company: DAVID - Facility Service GmbH
   board: "127297"
-- company: "127441"
+- company: Fundación Santuario Vegan
   board: "127441"
-- company: "127509"
+- company: Good Karma Gastro GmbH & Co KG
   board: "127509"
 - company: HOTEL MyPALACE
   board: "127533"
-- company: "127594"
+- company: Hotel Salzburgerhof
   board: "127594"
-- company: "127619"
+- company: I-PROYECTA ARQUITECTURA INGENIERÍA Y URBANISMO SLP
   board: "127619"
-- company: "127660"
+- company: elkatec Consult Engineering gmbh
   board: "127660"
-- company: "127680"
+- company: GRUPO NALLAM
   board: "127680"
-- company: "127754"
+- company: provital Physiotherapie Gravitytraining
   board: "127754"
 - company: Praxis Knotenpunkt
   board: "127774"
 - company: PLANTA INTERCOMARCAL DEL RECICLATGE, S.A.
   board: "127775"
-- company: "127978"
+- company: Trainext Sport and Health
   board: "127978"
-- company: "127986"
+- company: Grupo Segurymat
   board: "127986"
-- company: "128030"
+- company: Fersa sistemas de sguridad
   board: "128030"
-- company: "128219"
+- company: IJES SOLAR S.L.
   board: "128219"
-- company: "128229"
+- company: kopfart / friseure in wien
   board: "128229"
-- company: "128407"
+- company: Uselect BV
   board: "128407"
-- company: "128423"
+- company: Kast Ingenieure GmbH
   board: "128423"
-- company: "128444"
+- company: Nestor Company
   board: "128444"
 - company: EUBOLAR
   board: "128600"
-- company: "128688"
+- company: GESNAER CONSULTING
   board: "128688"
 - company: Applinet
   board: "128752"
 - company: Kolping Österreich
   board: "128941"
-- company: "128977"
+- company: SI landschaftsarchitektur ZT
   board: "128977"
 - company: Que Cocine Peter
   board: "129368"
-- company: "129448"
+- company: TALLERES Y NEUMATICOS JONAS SL
   board: "129448"
-- company: "12966"
+- company: Tisvol
   board: "12966"
-- company: "129756"
+- company: Nutraresearch
   board: "129756"
-- company: "129883"
+- company: Tor.support West GmbH
   board: "129883"
-- company: "130286"
+- company: Matchspace (Music) AG
   board: "130286"
 - company: Selise Group AG
   board: "13034"
-- company: "130375"
+- company: OFIBERIA OFICINA TÉCNICA S.L.
   board: "130375"
 - company: Swiss Startup Association
   board: "13039"
-- company: "130525"
+- company: MK PERSONS
   board: "130525"
-- company: "130532"
+- company: Loyal Real Estate
   board: "130532"
-- company: "130695"
+- company: HIERROS CANTÓN S.L.
   board: "130695"
-- company: "130841"
+- company: Flotus Stand Up Paddling
   board: "130841"
-- company: "130844"
+- company: ParetoLabs
   board: "130844"
-- company: "130941"
+- company: Wiric vzw
   board: "130941"
-- company: "131072"
+- company: CATRO Personalberatung und Media GmbH
   board: "131072"
-- company: "131151"
+- company: CARE systems mobile Pflege und Betreuung gemn. GmbH
   board: "131151"
-- company: "131349"
+- company: VEYAN
   board: "131349"
-- company: "131425"
+- company: GF Haustechnik GmbH
   board: "131425"
-- company: "131454"
+- company: Predimed Margem Sul
   board: "131454"
-- company: "131565"
+- company: e-therapykids institute sl
   board: "131565"
-- company: "131943"
+- company: EGOM
   board: "131943"
 - company: Racerfish
   board: "13207"
-- company: "132153"
+- company: A.ö. Krankenhaus St. Josef Braunau GmbH
   board: "132153"
 - company: Escuela Europea Parasanitaria ESPS
   board: "132201"
 - company: Centro MovimienTOs
   board: "132270"
-- company: "132272"
+- company: Trimando Solutions GmbH
   board: "132272"
-- company: "132299"
+- company: Dominik Moser GmbH
   board: "132299"
-- company: "132419"
+- company: JK House of Beauty GmbH
   board: "132419"
 - company: NEOYOU CLINIC
   board: "132426"
 - company: The Aurora Ärztezentrum
   board: "132464"
-- company: "132567"
+- company: Kafi Florence
   board: "132567"
-- company: "132651"
+- company: GUTIERREZ LOZANO ASOCIADOS
   board: "132651"
-- company: "132802"
+- company: iDocta
   board: "132802"
-- company: "133025"
+- company: WIS
   board: "133025"
 - company: INELCA
   board: "133087"
-- company: "133130"
+- company: ASERHCO
   board: "133130"
-- company: "133143"
+- company: Miphai Collection
   board: "133143"
-- company: "133176"
+- company: boanva canarias
   board: "133176"
-- company: "133242"
+- company: Aquadra SA
   board: "133242"
-- company: "133554"
+- company: hashcap gmbh
   board: "133554"
 - company: Input Projektentwicklung
   board: "133618"
@@ -4937,277 +4937,277 @@
   board: "133796"
 - company: PlanRadar GmbH
   board: "13391"
-- company: "133911"
+- company: Yummy Publishing GmbH
   board: "133911"
-- company: "133968"
+- company: alestetics® GmbH
   board: "133968"
-- company: "134003"
+- company: GRUPO AL TUNTÚN
   board: "134003"
 - company: Transformación Envases Polivalentes s.L.
   board: "134080"
-- company: "134118"
+- company: Martin Bucher Immobilien-Treuhand AG
   board: "134118"
-- company: "134170"
+- company: CONSULTER ASESORES
   board: "134170"
-- company: "134237"
+- company: Tumodo
   board: "134237"
-- company: "134245"
+- company: Seety
   board: "134245"
 - company: Bell Food Group
   board: "134316"
 - company: CONSMEDEL. S.L.
   board: "134324"
-- company: "134374"
+- company: MONTAZAR
   board: "134374"
-- company: "134467"
+- company: Gripmode GmbH
   board: "134467"
-- company: "134520"
+- company: ELECTRO ELITE MADRID
   board: "134520"
-- company: "134524"
+- company: Ivan Soler
   board: "134524"
-- company: "134694"
+- company: SBS Schweiz AG
   board: "134694"
-- company: "134780"
+- company: INOV Expat
   board: "134780"
-- company: "135089"
+- company: LaModula GmbH
   board: "135089"
-- company: "135125"
+- company: Complan Architektur AG
   board: "135125"
-- company: "135194"
+- company: Tiresur SL
   board: "135194"
 - company: La Boutique d'Or
   board: "135556"
 - company: Cargo Wine
   board: "135637"
-- company: "135693"
+- company: Roberto Revuelta
   board: "135693"
 - company: Las Colinas Golf and Country Club
   board: "135815"
-- company: "135899"
+- company: Rudder
   board: "135899"
-- company: "136008"
+- company: orderBilly
   board: "136008"
-- company: "136061"
+- company: LIBRERÍA SANZ Y TORRES S.L.
   board: "136061"
-- company: "136064"
+- company: GRUPO PEISA
   board: "136064"
-- company: "136128"
+- company: Studio Raphaël Lutz
   board: "136128"
-- company: "136548"
+- company: Wohnio
   board: "136548"
 - company: SAD ASSISTENCIAL
   board: "136655"
-- company: "136675"
+- company: FRIGORÍFICOS GARVI S.L.
   board: "136675"
 - company: Proffetional Group
   board: "136695"
 - company: Haus des Kindes
   board: "136726"
-- company: "136801"
+- company: CENTRE MEDIC MOLLET
   board: "136801"
-- company: "13683"
+- company: Vetsch Gebäudehüllen AG
   board: "13683"
-- company: "137004"
+- company: Start it @KBC / Start it @CBC / Start it Accelerate
   board: "137004"
-- company: "137132"
+- company: K3HOMES
   board: "137132"
-- company: "137192"
+- company: PINTURAS COBALTO
   board: "137192"
-- company: "137319"
+- company: eTennis SaaS GmbH
   board: "137319"
-- company: "137498"
+- company: Vital Bath
   board: "137498"
 - company: ibwellness b&f
   board: "137519"
-- company: "137720"
+- company: Johannes Resetar
   board: "137720"
 - company: DIPELECTRIC SL
   board: "137789"
-- company: "137826"
+- company: Yanmar Compact Equipment EMEA
   board: "137826"
-- company: "137892"
+- company: AQUILIA ARQUITECTOS, SL
   board: "137892"
-- company: "137924"
+- company: Nacher ETILISMES
   board: "137924"
 - company: EXMATRA,SA
   board: "137940"
-- company: "138015"
+- company: Corporación Auditiva InnoAudio
   board: "138015"
-- company: "138022"
+- company: IRISO Bau AG
   board: "138022"
 - company: Multimina S.L.
   board: "138226"
-- company: "138271"
+- company: AFONSO ASESORES
   board: "138271"
 - company: Burger King Österreich
   board: "138503"
-- company: "138593"
+- company: GRUPO MAREIN 73 SL,
   board: "138593"
-- company: "138731"
+- company: Residex (Servicio Integral de Peluquería)
   board: "138731"
 - company: DuoKey
   board: "138834"
-- company: "138949"
+- company: RODRIGUEZ LOPEZ AUTO
   board: "138949"
-- company: "138959"
+- company: Garten Becker KG
   board: "138959"
-- company: "139000"
+- company: ROSA'S ENGLISH LESSONS
   board: "139000"
 - company: Acicla
   board: "139028"
-- company: "139032"
+- company: Reisner GmbH
   board: "139032"
-- company: "139040"
+- company: Goas Fisioterapia
   board: "139040"
-- company: "139082"
+- company: Casa Taberna
   board: "139082"
-- company: "139150"
+- company: NTI Deutschland GmbH
   board: "139150"
-- company: "139158"
+- company: Industrias Auxiliares Marteñas
   board: "139158"
 - company: Casa Hortensia
   board: "139238"
-- company: "139307"
+- company: GESCAB
   board: "139307"
-- company: "139668"
+- company: OSS Tennis & Padel barcelone
   board: "139668"
-- company: "139682"
+- company: Praxis Hwang AG
   board: "139682"
-- company: "139695"
+- company: Gatt Transport & Logistik GmbH
   board: "139695"
 - company: Greening Group Deutschland
   board: "139703"
-- company: "139707"
+- company: Ambio
   board: "139707"
-- company: "139864"
+- company: Fahrschule SULI
   board: "139864"
-- company: "140094"
+- company: Espacio Finca Alegría
   board: "140094"
-- company: "140124"
+- company: CLINICA WELLCARE MEDICA
   board: "140124"
-- company: "140424"
+- company: Internationale Künstleragentur Hollaender-Calix
   board: "140424"
 - company: ALAVA LASCARAY
   board: "140552"
 - company: CATTS CAMERA
   board: "140558"
-- company: "140697"
+- company: econair ag
   board: "140697"
-- company: "140748"
+- company: Robotec & Packing
   board: "140748"
-- company: "140992"
+- company: Simage
   board: "140992"
 - company: Jadition
   board: "141052"
 - company: BIMEXPERTS GmbH
   board: "141087"
-- company: "141113"
+- company: ALBAY CONSULTORIA Y FORMACION S.L.
   board: "141113"
-- company: "141136"
+- company: B&K Ziviltechniker GmbH
   board: "141136"
-- company: "141206"
+- company: Alterszentrum und Spitex Neuhausen
   board: "141206"
-- company: "141324"
+- company: AFS Austauschprogramme für interkulturelles Lernen
   board: "141324"
-- company: "141451"
+- company: Capital English School
   board: "141451"
-- company: "141576"
+- company: Gabriel Gorbach GmbH
   board: "141576"
-- company: "141590"
+- company: Arce Clima
   board: "141590"
 - company: SM Finance GmbH
   board: "141626"
-- company: "141693"
+- company: HARPER HAIR
   board: "141693"
-- company: "141785"
+- company: hofmann & neffe gmbh
   board: "141785"
-- company: "141882"
+- company: D.Burkhard Bäckerei-Konditorei
   board: "141882"
 - company: Mattig Präzision GmbH
   board: "141893"
-- company: "142217"
+- company: MZ Akademie für individuelle Weiterentwicklung GmbH
   board: "142217"
-- company: "142275"
+- company: Botnar Institute of Immune Engineering - BIIE
   board: "142275"
-- company: "142500"
+- company: Austria Pet Food
   board: "142500"
-- company: "142561"
+- company: Holiday Best Gulf
   board: "142561"
 - company: zukunft.bahnhof
   board: "142683"
-- company: "142699"
+- company: NetCero
   board: "142699"
-- company: "142746"
+- company: SoPost
   board: "142746"
-- company: "142810"
+- company: Rp Asesores & Abogados
   board: "142810"
-- company: "142878"
+- company: Massilia Betriebs GmbH
   board: "142878"
-- company: "142976"
+- company: PROJEKTIL
   board: "142976"
 - company: Advokaturgemeinschaft
   board: "143103"
-- company: "143254"
+- company: Konditorei-Kaffee Zauner GmbH & Co.KG
   board: "143254"
 - company: Ingenieurbüro Lang GmbH
   board: "143286"
-- company: "143408"
+- company: Let's Go Mexico!
   board: "143408"
-- company: "143735"
+- company: Digifun AG
   board: "143735"
 - company: Robert Huber AG
   board: "143768"
-- company: "143891"
+- company: Quantonomics
   board: "143891"
-- company: "144135"
+- company: "Innosolve GmbH (Marke: fyl)"
   board: "144135"
 - company: PsiqAT Apoyo Psicoterapéutico
   board: "144149"
-- company: "144154"
+- company: Roter Bären
   board: "144154"
-- company: "144170"
+- company: MehrWeb GmbH
   board: "144170"
-- company: "144430"
+- company: Grupo La Fábrica
   board: "144430"
 - company: MULTISER, S.L.
   board: "144508"
-- company: "144545"
+- company: Angelique Beautysalon
   board: "144545"
-- company: "144547"
+- company: Center´s Auto
   board: "144547"
-- company: "144596"
+- company: Hartmann SHF GmbH & Co. KG
   board: "144596"
-- company: "144799"
+- company: Vollpension
   board: "144799"
-- company: "145238"
+- company: TECH.CON GmbH
   board: "145238"
 - company: Herz- und Gefässzentrum Wallisellen
   board: "145300"
-- company: "145360"
+- company: PTOLEMUS SRL
   board: "145360"
-- company: "145676"
+- company: mobilcom ICT Gmbh
   board: "145676"
-- company: "14574"
+- company: Traxxeo
   board: "14574"
-- company: "145822"
+- company: AQA WELLNESS SL
   board: "145822"
-- company: "145851"
+- company: blueworks AG
   board: "145851"
 - company: Praxis Dr. Maroof
   board: "145869"
 - company: FANCLIMA S.L.
   board: "145933"
-- company: "145981"
+- company: Lifestyle Company AG
   board: "145981"
 - company: LOS VIENTOS
   board: "146003"
-- company: "146045"
+- company: TRANSPORTES BECONSA
   board: "146045"
 - company: Furore Kanalservice GmbH
   board: "146065"
-- company: "146097"
+- company: Antigua Farmacia de La Estrella
   board: "146097"
-- company: "146147"
+- company: Diálogo Neurologopedia
   board: "146147"
 - company: SMD-Pharmaceutical GmbH
   board: "146149"
@@ -5215,165 +5215,165 @@
   board: "146291"
 - company: ACADEMIA SELECTIVIDAD
   board: "146346"
-- company: "146356"
+- company: Wonderwerk Consulting GmbH
   board: "146356"
 - company: ARCOMEX.
   board: "146413"
-- company: "146444"
+- company: Chift
   board: "146444"
-- company: "146469"
+- company: FERNANDEZ Y TERZADO ASOCIADOS  SL
   board: "146469"
-- company: "146476"
+- company: TW1 Management AG
   board: "146476"
-- company: "146551"
+- company: Koster AG
   board: "146551"
-- company: "146656"
+- company: Neubauer GmbH
   board: "146656"
-- company: "146699"
+- company: BALNEARIO DE FITERO, S.A.
   board: "146699"
-- company: "146725"
+- company: People Recruitment Tools Europe
   board: "146725"
-- company: "146771"
+- company: Escola Ramon Pont
   board: "146771"
-- company: "146791"
+- company: Samantha Vallejo Nájera Catering
   board: "146791"
-- company: "146796"
+- company: Anne Modes GmbH
   board: "146796"
-- company: "146823"
+- company: MediBlist Schweiz
   board: "146823"
-- company: "146824"
+- company: Institut für Schilddrüsendiagnostik und Nuklearmedizin
   board: "146824"
-- company: "146852"
+- company: Privesta GmbH
   board: "146852"
 - company: EMH-IT GmbH
   board: "146940"
-- company: "146951"
+- company: ANDALUSIA TOUR TRAVEL SL
   board: "146951"
-- company: "146998"
+- company: UpGrid
   board: "146998"
-- company: "147036"
+- company: Immobilienentwicklungs- und Investmentgesellschaft in Zürich
   board: "147036"
-- company: "147248"
+- company: soportes plasticos pincho,s.l
   board: "147248"
-- company: "147267"
+- company: STARBIEN 2012 SL
   board: "147267"
 - company: FISIOKID ATENCIÓN TEMPRANA
   board: "147331"
-- company: "1476"
+- company: Carvolution AG
   board: "1476"
-- company: "147676"
+- company: ON PRO GmbH
   board: "147676"
 - company: Aromadream GmbH
   board: "147726"
-- company: "147878"
+- company: OSTWERK
   board: "147878"
 - company: Gliders Force - Delorean
   board: "147883"
-- company: "147952"
+- company: Wolly
   board: "147952"
-- company: "147969"
+- company: Espacio Terapéutico Gaia
   board: "147969"
-- company: "148000"
+- company: Domi Vélez Bakery
   board: "148000"
-- company: "148074"
+- company: Vietha Luong
   board: "148074"
-- company: "14814"
+- company: Retter Bio-Natur-Resort
   board: "14814"
-- company: "148393"
+- company: MATEX LAB Germany GmbH
   board: "148393"
 - company: Zentner Scherer GmbH
   board: "148491"
 - company: Blumen ERIC GmbH
   board: "148612"
-- company: "148901"
+- company: Home Center Spain
   board: "148901"
-- company: "148903"
+- company: Eterna Concept Store
   board: "148903"
-- company: "148985"
+- company: Nabucco Möbel GmbH
   board: "148985"
 - company: digitalgurus AG
   board: "149509"
-- company: "149588"
+- company: Hauptstadt Möblerei
   board: "149588"
-- company: "149662"
+- company: Vanguardia Legal
   board: "149662"
-- company: "149775"
+- company: IBAAN ELECTRIC CORPORATION
   board: "149775"
-- company: "149781"
+- company: Saint-Charles International School Switzerland
   board: "149781"
-- company: "149906"
+- company: HeyTeam
   board: "149906"
-- company: "150213"
+- company: Nebily GmbH
   board: "150213"
 - company: CityZ
   board: "150385"
-- company: "150547"
+- company: SAIBELA
   board: "150547"
 - company: LBPascual Information Technology Solutions
   board: "150849"
-- company: "150897"
+- company: Vilalara Grand Hotel Algarve
   board: "150897"
-- company: "150923"
+- company: Grupo Finca Canarias Aloe Vera
   board: "150923"
-- company: "151028"
+- company: Simpat Tech
   board: "151028"
 - company: Pilatumed
   board: "151291"
-- company: "151313"
+- company: Royal-Reinigung GmbH
   board: "151313"
-- company: "151345"
+- company: CONSTRUCCIONES GARCÍA ADAMEZ
   board: "151345"
 - company: Mineraliengrosshandel Hausen GmbH
   board: "151406"
 - company: Casablanca
   board: "151603"
-- company: "151642"
+- company: THE PALM EXPERIENCE
   board: "151642"
 - company: Codimar
   board: "151698"
 - company: Ibérica de Aparellajes S.L
   board: "151783"
-- company: "151808"
+- company: LENTEC GmbH
   board: "151808"
-- company: "151933"
+- company: Sitemark
   board: "151933"
-- company: "151986"
+- company: Fitness & Racket Park
   board: "151986"
-- company: "152024"
+- company: good bed gmbh
   board: "152024"
-- company: "152474"
+- company: U-Power Group
   board: "152474"
 - company: Peak Property Solutions AG
   board: "152572"
-- company: "152626"
+- company: Helu.io GmbH
   board: "152626"
-- company: "152665"
+- company: Rasthaus Rohrhaus
   board: "152665"
-- company: "152698"
+- company: Furrer+Frey
   board: "152698"
-- company: "152713"
+- company: Tichy Glas Ges.m.b.H
   board: "152713"
-- company: "152724"
+- company: NovaMetal Industrial Service SL
   board: "152724"
-- company: "152788"
+- company: Hugosbox
   board: "152788"
-- company: "152936"
+- company: Eat Butter First
   board: "152936"
-- company: "152984"
+- company: Avecla Realty
   board: "152984"
 - company: FONTANERIA Y SANEAMIENTO MARTIN DONAT SL
   board: "152991"
-- company: "153103"
+- company: Motorlam
   board: "153103"
-- company: "153214"
+- company: Sappi Germany GmbH
   board: "153214"
-- company: "153470"
+- company: inyser
   board: "153470"
 - company: Sarita Die Works Pvt Ltd
   board: "153523"
-- company: "153563"
+- company: mvet.ch
   board: "153563"
-- company: "153639"
+- company: Lonio
   board: "153639"
 - company: DAS Netzwerktechnik GmbH
   board: "153665"
@@ -5381,39 +5381,39 @@
   board: "153709"
 - company: Academia Opostal
   board: "153838"
-- company: "153887"
+- company: INDUSTRIAS REBOLLO
   board: "153887"
-- company: "153938"
+- company: Senergy GmbH
   board: "153938"
 - company: Markus Flühmann AG
   board: "153946"
-- company: "153949"
+- company: Zettasecure GMBH
   board: "153949"
-- company: "153969"
+- company: ZEO TECHNOLOGY
   board: "153969"
-- company: "154"
+- company: 3Brain AG
   board: "154"
-- company: "154148"
+- company: EMPRESA VALENCIANA ACTIVIDADES S.L.
   board: "154148"
-- company: "154292"
+- company: Neuherz-Geier Seniorenheim GmbH
   board: "154292"
-- company: "154364"
+- company: Solarzen
   board: "154364"
-- company: "154394"
+- company: Halal Certification Services
   board: "154394"
-- company: "154409"
+- company: Elifab Solutions
   board: "154409"
-- company: "154494"
+- company: Binder Alu-Stahlbau GmbH
   board: "154494"
-- company: "154501"
+- company: Ligabue S.p.A.
   board: "154501"
-- company: "154574"
+- company: LEVEL TAX asesores
   board: "154574"
 - company: JP BURGENER SA
   board: "154610"
-- company: "154631"
+- company: Squire
   board: "154631"
-- company: "154703"
+- company: Landenberghaus GmbH
   board: "154703"
 - company: ESTATE IMMOBILIEN
   board: "154737"
@@ -5421,157 +5421,157 @@
   board: "154768"
 - company: Alshalal Transport
   board: "154958"
-- company: "154983"
+- company: MARKETING AROMATICO SL
   board: "154983"
-- company: "155066"
+- company: Mat Exakta, S.L.
   board: "155066"
-- company: "155156"
+- company: aqua alta DI Gabriel Bodi Ingenieurbüro für Kulturtechnik & Wasserwirtschaft e.U.
   board: "155156"
-- company: "155328"
+- company: Tirolinas Go
   board: "155328"
 - company: Plauschevents
   board: "155352"
-- company: "155487"
+- company: AK PROJEKTE Gruppe
   board: "155487"
-- company: "155571"
+- company: SCHAPER GmbH Schädlingsmanagement
   board: "155571"
-- company: "155641"
+- company: Audilogik
   board: "155641"
-- company: "155739"
+- company: V&A INVESTMENT FAMILY, S.L.
   board: "155739"
 - company: Hotel Peter
   board: "155763"
-- company: "155792"
+- company: LUZCO Iluminación
   board: "155792"
-- company: "155795"
+- company: Paul der Wirt
   board: "155795"
-- company: "155851"
+- company: Logopedia a Domicilio
   board: "155851"
-- company: "155862"
+- company: WIMTECH
   board: "155862"
 - company: Garage Cafe Bar AG
   board: "155889"
-- company: "155977"
+- company: HO-Matic AG
   board: "155977"
-- company: "156162"
+- company: mimodo AG
   board: "156162"
-- company: "156221"
+- company: Addmore One Lda
   board: "156221"
-- company: "156222"
+- company: Origami Salud SL
   board: "156222"
 - company: Q ARQUITECTOS
   board: "156275"
-- company: "156351"
+- company: Alberto Palatchi
   board: "156351"
-- company: "156508"
+- company: Hnuta Spezialitäten GmbH
   board: "156508"
 - company: Pintu Design GmbH
   board: "156671"
 - company: RCD Espanyol SAD
   board: "156683"
-- company: "156771"
+- company: Build4you GmbH
   board: "156771"
-- company: "156821"
+- company: Thomas Rafferseder
   board: "156821"
 - company: fantime.io
   board: "157052"
-- company: "157260"
+- company: Arctic GM
   board: "157260"
-- company: "157360"
+- company: "\"Erik Esbjerg\" Walcher & Schönfeld Gesellschaft m.b.H. & Co. OHG."
   board: "157360"
-- company: "157371"
+- company: Jirka GmbH & Co KG
   board: "157371"
-- company: "157456"
+- company: Complimmo AG
   board: "157456"
-- company: "157475"
+- company: Bäckerei Schefer
   board: "157475"
-- company: "157618"
+- company: Kern Beherbergungsbetriebs GmbH
   board: "157618"
 - company: ECOSUN AG
   board: "157645"
-- company: "157664"
+- company: Pizzeria Mergellina
   board: "157664"
-- company: "157691"
+- company: Sub Winterthur GmbH
   board: "157691"
-- company: "157808"
+- company: Mubiride sl
   board: "157808"
 - company: cdg Beratungen
   board: "158106"
-- company: "158148"
+- company: Elegtro GmbH
   board: "158148"
 - company: Ergotherapie Balance AG
   board: "158193"
-- company: "158208"
+- company: Schick Gebäudetechnik
   board: "158208"
-- company: "158280"
+- company: Labor Prof. Bettelheim
   board: "158280"
-- company: "158334"
+- company: La Fontana
   board: "158334"
 - company: Pick N Drive
   board: "158355"
 - company: Hummingbird Flexco
   board: "158399"
-- company: "158410"
+- company: AlgarveCycling
   board: "158410"
-- company: "158428"
+- company: Co.Mark
   board: "158428"
-- company: "158433"
+- company: TDB ASSESSORIA I GESTIO EMPRESARIAL SL
   board: "158433"
-- company: "158455"
+- company: Lukas Pesendorfer
   board: "158455"
-- company: "158491"
+- company: van Beveren
   board: "158491"
-- company: "158714"
+- company: Gestiona Consultores & Asesores
   board: "158714"
-- company: "158797"
+- company: Gesundheits- und Notfallpraxis Schübelbach
   board: "158797"
 - company: Samira's Sport Bistro
   board: "158808"
 - company: PILATES STUDIO VERONIKA KOVACS
   board: "158844"
-- company: "158864"
+- company: Altura Stone and Tile
   board: "158864"
 - company: Catering Cal Blay
   board: "158866"
 - company: Aispomur
   board: "158922"
-- company: "158964"
+- company: GAUDI Logopedia y Psicología
   board: "158964"
-- company: "159065"
+- company: WT Wien Ticket GmbH
   board: "159065"
-- company: "159133"
+- company: Outsider.Architecture SA
   board: "159133"
-- company: "159178"
+- company: alunir
   board: "159178"
-- company: "159221"
+- company: wheels International spain s.l.
   board: "159221"
-- company: "159320"
+- company: Histoire Sans Faim Suisse
   board: "159320"
-- company: "159337"
+- company: Bewy
   board: "159337"
-- company: "159338"
+- company: reebuild GmbH
   board: "159338"
-- company: "159376"
+- company: Grolimund Gartenbau AG
   board: "159376"
-- company: "159452"
+- company: Maritime Ventures
   board: "159452"
 - company: Novacard
   board: "159477"
-- company: "159518"
+- company: ARENAL DE SEVILLA
   board: "159518"
-- company: "15965"
+- company: corplife
   board: "15965"
-- company: "159693"
+- company: Claude FAVRE SA
   board: "159693"
-- company: "159694"
+- company: Ki Baleares SLU
   board: "159694"
 - company: Julius Kamber & Co. AG
   board: "159709"
 - company: EUCO Rail Services GmbH
   board: "159839"
-- company: "159850"
+- company: iReparatur.ch / remarket.ch
   board: "159850"
-- company: "160151"
+- company: GONZÁLEZ ABOGADOS & ASESORES
   board: "160151"
 - company: Weingut Özelt GnbR
   board: "160439"
@@ -5579,125 +5579,125 @@
   board: "160446"
 - company: Ros Roca
   board: "160648"
-- company: "160787"
+- company: Diventus GmbH
   board: "160787"
-- company: "160793"
+- company: MASSI MILANO
   board: "160793"
-- company: "160940"
+- company: Fuchshuber Steuerberatung GmbH
   board: "160940"
-- company: "161015"
+- company: MedSanté Sàrl
   board: "161015"
-- company: "161048"
+- company: delfort wattenspapier
   board: "161048"
 - company: Saneamientos Pereda
   board: "161150"
-- company: "161211"
+- company: Optimind GmbH
   board: "161211"
-- company: "161377"
+- company: BEIJER REF Deutschland GmbH
   board: "161377"
-- company: "161497"
+- company: Sabine Kirchgatterer e.U.
   board: "161497"
 - company: LEAP PARTNERS
   board: "161646"
-- company: "161657"
+- company: DRS-Motorsport
   board: "161657"
-- company: "161714"
+- company: Sozialtherapeutische Kinderschutz WG PIA GmbH
   board: "161714"
-- company: "161720"
+- company: Elemaster Germany GmbH
   board: "161720"
 - company: RestoManager
   board: "161723"
-- company: "161870"
+- company: sandan AI
   board: "161870"
-- company: "162"
+- company: b2venture GmbH
   board: "162"
-- company: "162054"
+- company: M and M Group
   board: "162054"
-- company: "162167"
+- company: Elite Experience EC Gmbh
   board: "162167"
-- company: "162174"
+- company: LA MARIPOSA BLANCA
   board: "162174"
-- company: "162180"
+- company: Cashfeed
   board: "162180"
-- company: "162374"
+- company: Puertas Sevillano
   board: "162374"
-- company: "162389"
+- company: The Mood Travel
   board: "162389"
 - company: Zurich, Generalagentur Marcel Böni
   board: "162585"
-- company: "162698"
+- company: Nierenpraxis und Dialyse Wattwil
   board: "162698"
-- company: "162702"
+- company: Seilbahnen International Verlag GmbH
   board: "162702"
-- company: "162770"
+- company: Chagrimm
   board: "162770"
 - company: Hotel City Karin Strickner GmbH
   board: "162777"
 - company: Palang Chiwit
   board: "162852"
-- company: "162925"
+- company: Tamara's Haircreation Inh. Tamara Zaccaria
   board: "162925"
-- company: "162926"
+- company: Offline Agency
   board: "162926"
-- company: "162977"
+- company: Talent Class
   board: "162977"
 - company: Qemetica Deutschland GmbH
   board: "163079"
-- company: "163111"
+- company: HOLD Modevertriebs GmbH
   board: "163111"
-- company: "163145"
+- company: Hintsteiner Group GmbH
   board: "163145"
-- company: "163205"
+- company: Ceelgroup GmbH
   board: "163205"
-- company: "163242"
+- company: Physiokandil
   board: "163242"
 - company: Touchideas
   board: "163269"
-- company: "163327"
+- company: Volkswagen M.Conde
   board: "163327"
 - company: ASKG Steuerberatungs GmbH
   board: "163512"
 - company: ESPINOSA
   board: "163515"
-- company: "163574"
+- company: Diplomatic SOCIETY Magazin
   board: "163574"
-- company: "163605"
+- company: epmedia Werbeagentur GmbH
   board: "163605"
-- company: "163679"
+- company: Bioenergiezentrum GmbH
   board: "163679"
-- company: "1642"
+- company: aspaara AG
   board: "1642"
-- company: "164219"
+- company: HAYA LOGISTICA
   board: "164219"
-- company: "164237"
+- company: SCHWAPe Shared Service GmbH
   board: "164237"
-- company: "164247"
+- company: AQUA SWIM
   board: "164247"
-- company: "164251"
+- company: Peter & Peter Gmbh
   board: "164251"
 - company: Everleaf GmbH
   board: "164293"
 - company: SENECTUTE 24 GmbH
   board: "164465"
-- company: "164495"
+- company: Simplycure
   board: "164495"
-- company: "164496"
+- company: Stealth
   board: "164496"
-- company: "164570"
+- company: Ballsaal Wien
   board: "164570"
-- company: "164606"
+- company: Etech Mörth Infrastructure GmbH
   board: "164606"
 - company: Goldigä Schnitt
   board: "164629"
-- company: "164684"
+- company: Kleiderkarussell
   board: "164684"
-- company: "164756"
+- company: Net-Zero Gmbh
   board: "164756"
-- company: "164759"
+- company: GS-Installationen GmbH
   board: "164759"
-- company: "164834"
+- company: CONTEN
   board: "164834"
-- company: "164842"
+- company: Femedica
   board: "164842"
 - company: Cachalot Media House GmbH
   board: "164859"
@@ -5705,509 +5705,509 @@
   board: "164997"
 - company: Agha-Schantl Speaking & Training GmbH
   board: "165036"
-- company: "165158"
+- company: Vielfalt Greisslerei
   board: "165158"
-- company: "165294"
+- company: mal ehrlich AG
   board: "165294"
-- company: "165323"
+- company: Kells College
   board: "165323"
-- company: "165461"
+- company: EAPartner
   board: "165461"
-- company: "165513"
+- company: Balder Instalaciones SL
   board: "165513"
 - company: Fürgast Betriebsgastronomie GmbH
   board: "165686"
-- company: "165770"
+- company: heycreate GmbH
   board: "165770"
 - company: Hotel Elisabeth Betriebs GmbH
   board: "165809"
 - company: goInsure AG
   board: "165863"
-- company: "165955"
+- company: harmony event life
   board: "165955"
-- company: "165993"
+- company: Vhamba Transportation Services
   board: "165993"
-- company: "166110"
+- company: boesch energy GmbH
   board: "166110"
-- company: "166189"
+- company: WET Water GmbH
   board: "166189"
-- company: "166202"
+- company: Yonex GmbH
   board: "166202"
 - company: Coworked
   board: "166294"
-- company: "166344"
+- company: IAGng Gas Analytics GmbH
   board: "166344"
-- company: "166363"
+- company: Positive Carbon
   board: "166363"
-- company: "166415"
+- company: Kinderhort "La Cicogna"
   board: "166415"
 - company: Sartiq
   board: "166508"
-- company: "166516"
+- company: F.estate
   board: "166516"
-- company: "166534"
+- company: Blattwerkmalerei GmbH
   board: "166534"
-- company: "166684"
+- company: RODRIGUEZ LOPEZ AUTO.- GRUPO ITURRI
   board: "166684"
-- company: "166810"
+- company: Surf Eye
   board: "166810"
-- company: "166898"
+- company: A&M Duraes Reinigung + Hauswartung GmbH
   board: "166898"
 - company: Bois et design
   board: "166903"
-- company: "166962"
+- company: EXZESS Gentlemen-Club Vienna
   board: "166962"
-- company: "166975"
+- company: BOREAS CONSULTORIA TECNICA, S.L.
   board: "166975"
-- company: "166989"
+- company: EFA ORETANA
   board: "166989"
-- company: "167007"
+- company: Roy C. Hitchman Executive Search AG
   board: "167007"
-- company: "167026"
+- company: Zahnarzt DDr. Reinisch
   board: "167026"
 - company: niederwieser
   board: "167121"
 - company: Urban Palladium, S.L.
   board: "167194"
-- company: "167276"
+- company: MK Reinigung GmbH
   board: "167276"
-- company: "167321"
+- company: Tasin's Fahrdienst AG
   board: "167321"
 - company: Pimcore GmbH
   board: "167362"
-- company: "167430"
+- company: Nejo
   board: "167430"
 - company: Virtual Reality Real Estate
   board: "167475"
-- company: "167556"
+- company: Spaeth-Wiesner GmbH
   board: "167556"
-- company: "167766"
+- company: Mag. August Schulz
   board: "167766"
-- company: "167805"
+- company: SPS Technik GmbH
   board: "167805"
-- company: "167896"
+- company: Omega Impianti SRL
   board: "167896"
 - company: Plasounig Technik GmbH
   board: "167937"
 - company: Schwimmsport Gemeinschaft Basel
   board: "168065"
-- company: "168098"
+- company: Zahnarzt Dr. Thomas Kauer
   board: "168098"
-- company: "168315"
+- company: CDG Car.Driver.Guide Services OG
   board: "168315"
-- company: "168339"
+- company: mygrid AG
   board: "168339"
-- company: "168369"
+- company: FireStart
   board: "168369"
 - company: Contigo im Senhor Vinho
   board: "168383"
-- company: "168393"
+- company: EURO TECHNOLOGIES
   board: "168393"
-- company: "168450"
+- company: Trokoló, Ocio y Educación
   board: "168450"
-- company: "168455"
+- company: LABER HOSPITALES
   board: "168455"
 - company: Garcia Select AG
   board: "168478"
 - company: SAXONBY, S.L.
   board: "168622"
-- company: "168634"
+- company: Fundacion Tomillo
   board: "168634"
-- company: "168643"
+- company: Lebenshilfe Region Judenburg
   board: "168643"
-- company: "168699"
+- company: AVIS Finance GmbH
   board: "168699"
-- company: "168720"
+- company: Laupe Huus
   board: "168720"
-- company: "168756"
+- company: Ristozi FC
   board: "168756"
-- company: "168868"
+- company: CONSULTANCY X3 SL
   board: "168868"
-- company: "168917"
+- company: Feel your Mind AG
   board: "168917"
-- company: "168962"
+- company: GIRP - European Healthcare Distribution Association
   board: "168962"
-- company: "169069"
+- company: DS Data GmbH
   board: "169069"
-- company: "169126"
+- company: Loban GmbH & Co KG
   board: "169126"
 - company: Oniro - realized by Ioanna
   board: "169159"
 - company: Liechtenstein Schloss Wilfersdorf
   board: "169198"
-- company: "169207"
+- company: Sinta Haustechnik OG
   board: "169207"
-- company: "169246"
+- company: Stil-Laden
   board: "169246"
-- company: "169250"
+- company: LINZKREATIV.AT
   board: "169250"
-- company: "169256"
+- company: Vertus Energy
   board: "169256"
 - company: Nathalie Sameli
   board: "169422"
-- company: "169478"
+- company: Bodegas Centro Españolas
   board: "169478"
-- company: "169680"
+- company: Serveis Municipals de Sant Esteve Sesrovires, SLU
   board: "169680"
-- company: "169717"
+- company: Divine Nails & Beauty
   board: "169717"
 - company: DIGITAL ENERGY
   board: "169834"
 - company: Wayalia Alcorcón
   board: "169968"
-- company: "170040"
+- company: CTS INGENIERIA & SERVICIOS
   board: "170040"
-- company: "170052"
+- company: Luxbell
   board: "170052"
 - company: Albarda 2011 SL
   board: "170142"
-- company: "170157"
+- company: upVolt GmbH
   board: "170157"
-- company: "170162"
+- company: Publicit
   board: "170162"
-- company: "170180"
+- company: GROPYUS Technologies GmbH
   board: "170180"
-- company: "170183"
+- company: Nevora Matos Fernandes
   board: "170183"
-- company: "170289"
+- company: Concept One Properties LLC
   board: "170289"
-- company: "170321"
+- company: FISIODERMIC
   board: "170321"
-- company: "170352"
+- company: Lassie
   board: "170352"
-- company: "170367"
+- company: Zermatt Consulting & Coaching GmbH
   board: "170367"
 - company: INSPIRAFISIOTERAPIA
   board: "170386"
 - company: Grupo M Conde
   board: "170512"
-- company: "170536"
+- company: JESFRAN ENERGIA S.L
   board: "170536"
-- company: "170562"
+- company: My Lost Box GmbH
   board: "170562"
-- company: "170601"
+- company: MOYSEAFOOD SA
   board: "170601"
-- company: "170604"
+- company: DS Fleisch und Wurstwaren GmbH
   board: "170604"
 - company: CF Transport GMbH
   board: "170669"
-- company: "170759"
+- company: Trae Home
   board: "170759"
-- company: "170765"
+- company: Grupo Euro-CENTER Insurance Broker
   board: "170765"
-- company: "170780"
+- company: Taxiunternehmen Sven Mayer
   board: "170780"
-- company: "170822"
+- company: Künzli Deutschland GmbH
   board: "170822"
 - company: Fit2go GmbH
   board: "171028"
-- company: "171050"
+- company: b.it³ Business Software + IT GmbH
   board: "171050"
 - company: Millennium Thai Massage
   board: "171108"
-- company: "171131"
+- company: ICONO SPAIN
   board: "171131"
-- company: "171169"
+- company: Atelier Arti GmbH
   board: "171169"
-- company: "171182"
+- company: Minor Hotels Europe & Americas
   board: "171182"
 - company: WERO Systembetreuung - Ing. Jürgen Wehinger
   board: "171200"
 - company: THQ Nordic GmbH
   board: "171220"
-- company: "171258"
+- company: CONMETAD, S.L.
   board: "171258"
-- company: "171272"
+- company: Danfoss GmbH
   board: "171272"
-- company: "171556"
+- company: RPT-Service GmbH
   board: "171556"
-- company: "171734"
+- company: Kontron Austria GmbH
   board: "171734"
-- company: "171753"
+- company: E. Bösch Getränke GmbH
   board: "171753"
-- company: "171829"
+- company: ALTERA real estate GmbH
   board: "171829"
-- company: "171870"
+- company: Morada Uno
   board: "171870"
-- company: "171879"
+- company: GuardMatch
   board: "171879"
 - company: chinees indisch restaurant Happygarden
   board: "171969"
 - company: Fu Swiss GmbH
   board: "171984"
-- company: "172123"
+- company: Segelschule Neusiedl GmbH
   board: "172123"
 - company: INSTITUTO RAIMON GAJA
   board: "172186"
-- company: "172223"
+- company: Linoq AG
   board: "172223"
-- company: "172254"
+- company: AZIMUT INTEGRAL SOLUTIONS S.L.
   board: "172254"
-- company: "172406"
+- company: UTRECAR SL
   board: "172406"
 - company: ILR GmbH
   board: "172420"
-- company: "172441"
+- company: Trust FIN GmbH
   board: "172441"
-- company: "172531"
+- company: Die Vinothek
   board: "172531"
-- company: "172564"
+- company: SEMILLERO SL
   board: "172564"
-- company: "172626"
+- company: Medvital
   board: "172626"
-- company: "172637"
+- company: Tapedesign WO GmbH
   board: "172637"
-- company: "172721"
+- company: Rodimecsa DRUMROLL
   board: "172721"
-- company: "172831"
+- company: MELLER BRAND
   board: "172831"
-- company: "172846"
+- company: Retail Innovation Partners AG
   board: "172846"
 - company: FLG Gastro GmbH
   board: "172909"
-- company: "172910"
+- company: Academia Axia
   board: "172910"
 - company: Kaby
   board: "172940"
-- company: "172950"
+- company: IPE Energietechnik GmbH
   board: "172950"
-- company: "172952"
+- company: TGUS Salzburg
   board: "172952"
 - company: Dr. med. univ. Alexander Haim
   board: "172962"
-- company: "172998"
+- company: VITEN SEGURIDAD
   board: "172998"
 - company: Monbusiness advertising SL
   board: "173002"
 - company: ARBORISTAS DEL SUR SL
   board: "173012"
-- company: "173069"
+- company: SARA PRODUCTOS CASEROS
   board: "173069"
-- company: "173174"
+- company: Food Investiment Corner, S.L.
   board: "173174"
-- company: "173175"
+- company: CMR GmbH Nahversorger Waltendorf
   board: "173175"
-- company: "173198"
+- company: Ratememore
   board: "173198"
-- company: "173203"
+- company: REFORVEN GALICIA SL.
   board: "173203"
-- company: "173229"
+- company: Zahnteam Alpin
   board: "173229"
-- company: "173232"
+- company: LEADING DOCUMENT SOLUTIONS SLU
   board: "173232"
-- company: "173235"
+- company: Klimatec GmbH
   board: "173235"
 - company: Gasthof Kleefeld Hotel GmbH
   board: "173299"
-- company: "173388"
+- company: CASVAL REAL ESTATE
   board: "173388"
 - company: COSVIC TECH SL
   board: "173389"
-- company: "173400"
+- company: ComercialFP
   board: "173400"
-- company: "173414"
+- company: NOku / nobody knows us
   board: "173414"
-- company: "173435"
+- company: Elektrotechnik Voglhuber GmbH
   board: "173435"
-- company: "173466"
+- company: PCS IT-Trading
   board: "173466"
 - company: CRECERGESTION
   board: "173480"
 - company: DISTRIBUCIONES CASASIN, S.A.
   board: "173580"
-- company: "173600"
+- company: TARA Zowa
   board: "173600"
-- company: "173610"
+- company: WiEmJo Gastronomie GmbH
   board: "173610"
-- company: "173629"
+- company: Psychotherapie Weinberg
   board: "173629"
 - company: IMMgroup GmbH
   board: "173638"
-- company: "173661"
+- company: Clayground.ai
   board: "173661"
-- company: "173671"
+- company: Primarstufe Binningen
   board: "173671"
-- company: "173761"
+- company: fluxguide
   board: "173761"
-- company: "173779"
+- company: SN INDUSTRIAL 2019
   board: "173779"
-- company: "173885"
+- company: Dera Handel GmbH
   board: "173885"
-- company: "173902"
+- company: Classic Fit
   board: "173902"
 - company: Caldema industrias
   board: "173910"
-- company: "173927"
+- company: LBS ROTULOS
   board: "173927"
-- company: "173940"
+- company: Mitterbauer Stahlbau GmbH
   board: "173940"
 - company: NOIRRAC
   board: "173977"
-- company: "174006"
+- company: UNOX Schweiz
   board: "174006"
-- company: "174007"
+- company: sarl vignoble hinderer et wolff
   board: "174007"
-- company: "174017"
+- company: Boga Tasca Restaurante
   board: "174017"
 - company: Mario Weiermayer
   board: "174046"
-- company: "174064"
+- company: atempocare
   board: "174064"
-- company: "174095"
+- company: AM Gastro GmbH
   board: "174095"
-- company: "174118"
+- company: Bestattung Dussmann
   board: "174118"
 - company: Tobien Trading GmbH
   board: "17412"
-- company: "174135"
+- company: Braingineering GmbH
   board: "174135"
-- company: "174161"
+- company: Gärtnerei Urs Keller AG
   board: "174161"
-- company: "174171"
+- company: Faerch Ravensburg GmbH
   board: "174171"
-- company: "174175"
+- company: Make Group
   board: "174175"
 - company: TeDaLoS GmbH
   board: "174192"
 - company: CENTRO NEMO MURCIA, S.L.
   board: "174226"
-- company: "174250"
+- company: Smart Energy Link AG
   board: "174250"
 - company: Malerei Lumetsberger GmbH
   board: "174251"
 - company: Restaurant Lötschberg Bern
   board: "174271"
-- company: "174291"
+- company: G&R Gelateria GmbH
   board: "174291"
-- company: "174326"
+- company: Fourlead GmbH
   board: "174326"
 - company: irion undgruen
   board: "174361"
-- company: "174372"
+- company: ARE LIMPIEZAS INTEGRALES SL
   board: "174372"
-- company: "174391"
+- company: MAXION
   board: "174391"
-- company: "174408"
+- company: Oberleitner & Eder WT GmbH
   board: "174408"
-- company: "174422"
+- company: STO.ASERVITECO SUR 2000 S.L
   board: "174422"
-- company: "174425"
+- company: THE DOCTOR CATALUNYA S.L.
   board: "174425"
-- company: "174427"
+- company: Eurofitness Sant Cugat
   board: "174427"
-- company: "174439"
+- company: LA ESCUELA DE LANCASTER
   board: "174439"
-- company: "174474"
+- company: ZKP ZT GmbH
   board: "174474"
-- company: "174507"
+- company: Krumpeck GmbH
   board: "174507"
-- company: "174528"
+- company: Komposch Steuerberatung GmbH
   board: "174528"
 - company: EMAYOR SYNERSIGHT TECHNOLOGIES SL
   board: "174544"
 - company: ETIFOODS S.L
   board: "174548"
-- company: "174558"
+- company: FABU TRANSPORT GMBH
   board: "174558"
-- company: "174589"
+- company: Cultcaffe
   board: "174589"
-- company: "174619"
+- company: Eurocasa
   board: "174619"
-- company: "174641"
+- company: COSTA TELDE SERVICIOS INMOBILIARIOS
   board: "174641"
 - company: Taj Technology
   board: "174649"
-- company: "174698"
+- company: Tower 10 Hospitality
   board: "174698"
 - company: INVALL, s.a.
   board: "174705"
-- company: "174777"
+- company: MKS4U IT-Beratungs GmbH
   board: "174777"
 - company: F. Segura Deutschland GmbH
   board: "174803"
 - company: FACULTY Consulting
   board: "174812"
-- company: "174820"
+- company: MIGLOT Parfums
   board: "174820"
-- company: "174859"
+- company: Tennisclub Altmünster
   board: "174859"
-- company: "174893"
+- company: credicand suscripcion de riesgos
   board: "174893"
-- company: "174896"
+- company: Garage A. Ventre GmbH
   board: "174896"
-- company: "174916"
+- company: Ikebana Eventos
   board: "174916"
 - company: Huwag Nutzfahrzeuge AG
   board: "174923"
-- company: "175004"
+- company: 1A PA Betreuung & Familienservice GmbH
   board: "175004"
-- company: "175013"
+- company: MEDIFINCAS
   board: "175013"
-- company: "175014"
+- company: Goodweek
   board: "175014"
-- company: "175026"
+- company: ISODECO REVESTIMIENTOS S.L.
   board: "175026"
 - company: OnMind
   board: "175044"
-- company: "175103"
+- company: Mag. Kogler DeineNachhilfe
   board: "175103"
-- company: "175133"
+- company: SAMPOL INGENIERIA Y OBRA
   board: "175133"
-- company: "175139"
+- company: Sendify AB
   board: "175139"
-- company: "175154"
+- company: christoph eigentler architektur
   board: "175154"
 - company: Emme Gerüste GmbH
   board: "175234"
-- company: "175273"
+- company: Treeless AG
   board: "175273"
-- company: "175290"
+- company: IBW IngenieurBüro Wachter GmbH
   board: "175290"
-- company: "175292"
+- company: MoreBit Technologies GmbH
   board: "175292"
-- company: "175296"
+- company: Benibeca
   board: "175296"
-- company: "175323"
+- company: mario widmer baubegleitung GmbH
   board: "175323"
-- company: "175326"
+- company: VTI Global Vertical Transportation Systems Consultant L.L.C
   board: "175326"
-- company: "175346"
+- company: Psychologische Beratung  Foscolo
   board: "175346"
 - company: Klinik Barmelweid
   board: "175349"
-- company: "175370"
+- company: Gran Ballo Italiano
   board: "175370"
-- company: "175374"
+- company: Influumad S.L.
   board: "175374"
-- company: "175479"
+- company: Auditax Steuerberatungs GmbH
   board: "175479"
 - company: pomali
   board: "175495"
 - company: Bäckerei Konditorei Zeller AG
   board: "175496"
-- company: "175533"
+- company: Hofbauer GmbH & Co.KG
   board: "175533"
-- company: "175567"
+- company: LVPRO Ingeniería
   board: "175567"
-- company: "175671"
+- company: PAZ MENTAL
   board: "175671"
-- company: "175734"
+- company: chinees indische restaurant hongkong
   board: "175734"
-- company: "175761"
+- company: Seegasthof Breineder
   board: "175761"
-- company: "175763"
+- company: Markus Schmid AG
   board: "175763"
-- company: "17581"
+- company: Flowline AG
   board: "17581"
-- company: "175810"
+- company: CEASFOR BARCELONA
   board: "175810"
 - company: UTOPIA CLINIQUE
   board: "175832"
 - company: Schreinerei Roy Jakober GmbH
   board: "175846"
-- company: "175858"
+- company: Lumina Software
   board: "175858"
-- company: "175906"
+- company: ALL SPORT ALTERNATIVAS DEPORTIVAS SL
   board: "175906"
 - company: Mas-Social
   board: "175917"
@@ -6215,129 +6215,129 @@
   board: "175990"
 - company: ELEMENTS OUTDOOR SERVICES SL
   board: "175991"
-- company: "175993"
+- company: arxada
   board: "175993"
-- company: "176007"
+- company: San Marzano - Autentica Pizza Napoletana
   board: "176007"
-- company: "176014"
+- company: PAEZ GRUPO ASESOR SLU
   board: "176014"
-- company: "17602"
+- company: EAM Systems GmbH
   board: "17602"
-- company: "176035"
+- company: SÍA Studios
   board: "176035"
-- company: "176066"
+- company: NS Management
   board: "176066"
 - company: NADALUX INGENIEROS, S.L.
   board: "176073"
-- company: "176079"
+- company: Vinos y bebidas Nistal
   board: "176079"
-- company: "176105"
+- company: Falstaff LIVING Verlags GmbH
   board: "176105"
-- company: "176127"
+- company: Lifthing
   board: "176127"
-- company: "176134"
+- company: Productores de Sonrisas
   board: "176134"
-- company: "176141"
+- company: La Rambla Del Saler S.L
   board: "176141"
 - company: HISPANIA DE IMPORTACIÓN Y VENTAS S.L
   board: "176187"
-- company: "176198"
+- company: Mocker GmbH & Co.KG
   board: "176198"
-- company: "176212"
+- company: 9Altitudes Nederland
   board: "176212"
-- company: "176213"
+- company: Bonaparte
   board: "176213"
-- company: "176260"
+- company: Selectpro by TM Consulting
   board: "176260"
-- company: "176305"
+- company: CLIMAGAR CLIMATIZACION, S.L.
   board: "176305"
 - company: Emax Consulting
   board: "176424"
 - company: COMPLUTEL COMUNICACIONES
   board: "176499"
-- company: "176510"
+- company: Colombier International BV
   board: "176510"
 - company: Optiwi Solutions Group
   board: "176538"
-- company: "176545"
+- company: Marktgemeinde St. Martin im Innkreis
   board: "176545"
 - company: SEO-Küche Austria GmbH
   board: "176558"
-- company: "176598"
+- company: PATOCEMETE S.L
   board: "176598"
-- company: "176704"
+- company: Parkosecure GmbH
   board: "176704"
-- company: "17671"
+- company: Guestnet
   board: "17671"
-- company: "176728"
+- company: CIOMAR,S.L.
   board: "176728"
-- company: "176730"
+- company: Gemma Sans Mediano
   board: "176730"
-- company: "176735"
+- company: RhyGaze AG
   board: "176735"
-- company: "176754"
+- company: Home Montagu
   board: "176754"
-- company: "176757"
+- company: Boden Outlet
   board: "176757"
 - company: DLOG TECHNOLOGY AND EV SLU AND EV SLU
   board: "176762"
-- company: "176769"
+- company: HG Hoteles
   board: "176769"
-- company: "176780"
+- company: bloom society
   board: "176780"
 - company: Smack Technologies
   board: "176811"
-- company: "176829"
+- company: FRISUN
   board: "176829"
 - company: Double Barrel Roasters, Inc.
   board: "176903"
-- company: "176932"
+- company: 2F-Leuchten Ges.m.b.H
   board: "176932"
 - company: TST
   board: "176983"
 - company: Sportcenter Schumacher
   board: "177125"
-- company: "177167"
+- company: Dentalpraxis Nidau
   board: "177167"
-- company: "177177"
+- company: ASO Gastro GmbH
   board: "177177"
-- company: "177215"
+- company: IBS Ges.m.b.H
   board: "177215"
-- company: "177233"
+- company: Max Louzada Brazilian Coffee Company GmbH
   board: "177233"
 - company: GLS Bau und Montage GmbH
   board: "177243"
-- company: "177301"
+- company: FUSE Dating UG
   board: "177301"
-- company: "177361"
+- company: Ayus Medical Group AG
   board: "177361"
 - company: VA TECH WABAG GmbH
   board: "177530"
-- company: "177542"
+- company: innoscripta Austria GmbH
   board: "177542"
-- company: "177613"
+- company: Cleanup Saladin GmbH
   board: "177613"
-- company: "177664"
+- company: AXS Germany GmbH
   board: "177664"
-- company: "177864"
+- company: QAI Ventures AG
   board: "177864"
-- company: "177961"
+- company: Fristads GmbH
   board: "177961"
-- company: "177980"
+- company: PAWELA TREUHAND GmbH
   board: "177980"
-- company: "178041"
+- company: La Palma
   board: "178041"
-- company: "178165"
+- company: Two Next GmbH
   board: "178165"
-- company: "178332"
+- company: Knobel Schuleinrichtungen AG
   board: "178332"
-- company: "178421"
+- company: suiBelag GmbH
   board: "178421"
-- company: "178480"
+- company: Cuidados & Ternura
   board: "178480"
-- company: "178519"
+- company: Swan Medico Ltd.
   board: "178519"
-- company: "178538"
+- company: Energie Makler Graz
   board: "178538"
 - company: Spirit Zug
   board: "178606"
@@ -6347,401 +6347,401 @@
   board: "178670"
 - company: Olai Interactive
   board: "178742"
-- company: "178775"
+- company: We Care More GmbH
   board: "178775"
-- company: "178812"
+- company: wedosocial
   board: "178812"
-- company: "178837"
+- company: Hotel Alpinjuwel
   board: "178837"
-- company: "178913"
+- company: EYEDEA Werbe GMBH
   board: "178913"
-- company: "178917"
+- company: Hauer & Kopal GmbH
   board: "178917"
-- company: "178954"
+- company: Bark & Co
   board: "178954"
-- company: "179068"
+- company: Indasol GmbH
   board: "179068"
-- company: "179072"
+- company: elektroplan Buchs & Grossen AG
   board: "179072"
-- company: "179099"
+- company: TRANSPORTES Y PESCADOS LOS ALEGRES SL
   board: "179099"
 - company: Tethys Robotics AG
   board: "179102"
-- company: "179130"
+- company: laboral2@santiagoyalonsoasesores.es
   board: "179130"
 - company: Unter Wien IG
   board: "179143"
-- company: "179169"
+- company: Single Family Office
   board: "179169"
-- company: "179225"
+- company: Iudex Non Calculat
   board: "179225"
 - company: Lucerne Clinic
   board: "179262"
 - company: Scalstrm
   board: "179281"
-- company: "179282"
+- company: AMICIS Parndorf GmbH
   board: "179282"
-- company: "179302"
+- company: Preteq CNC Solutions AG
   board: "179302"
-- company: "179345"
+- company: motion tools GmbH
   board: "179345"
-- company: "179389"
+- company: Pingvite
   board: "179389"
-- company: "179427"
+- company: Sicherheitstag Gmbh
   board: "179427"
-- company: "179431"
+- company: Hightec MC AG
   board: "179431"
 - company: Mariella Leydolt
   board: "179602"
 - company: Joaia - AI Local Guides
   board: "179657"
-- company: "179828"
+- company: AIOAYO GmbH
   board: "179828"
-- company: "179831"
+- company: Montron GmbH
   board: "179831"
-- company: "179832"
+- company: Markus Sarg
   board: "179832"
 - company: Österreichischer Apothekerverband
   board: "179840"
-- company: "179870"
+- company: Daddy Food GmbH
   board: "179870"
-- company: "179874"
+- company: Kramis Gartenbau AG
   board: "179874"
-- company: "179902"
+- company: MSN Group GMBH
   board: "179902"
-- company: "179921"
+- company: Grill Heaven GmbH
   board: "179921"
-- company: "179922"
+- company: Maliqinelli HLKS GmbH
   board: "179922"
 - company: Tom's Training & Physio
   board: "179924"
-- company: "179938"
+- company: digital gizmo GmbH
   board: "179938"
-- company: "179953"
+- company: Brunwig GmbH
   board: "179953"
-- company: "179969"
+- company: Bergardi GmbH
   board: "179969"
 - company: Jekko Deutschland GmbH
   board: "179995"
 - company: Hausfeen.at
   board: "180034"
-- company: "180068"
+- company: Sakana
   board: "180068"
-- company: "180074"
+- company: EVRi - Defence & Boxing for Evribody
   board: "180074"
-- company: "180078"
+- company: RAETIA Vermögensmanagement AG
   board: "180078"
-- company: "180084"
+- company: Heilbronnlebt.de
   board: "180084"
-- company: "180201"
+- company: Helios Solar Energie GmbH
   board: "180201"
 - company: Stiehl & Keltner RAe GbR
   board: "180202"
 - company: Fixzone GmbH
   board: "180226"
-- company: "180254"
+- company: Double T Oilfield Services
   board: "180254"
-- company: "180340"
+- company: LA Clip GmbH
   board: "180340"
-- company: "180433"
+- company: Theut Products
   board: "180433"
 - company: Mavi Gastronomiebetriebs GmbH/ Deli am Naschmarkt
   board: "180465"
-- company: "180484"
+- company: LinVerwaltung AG
   board: "180484"
-- company: "180486"
+- company: Rafters GmbH
   board: "180486"
-- company: "180520"
+- company: Ordination für Allgemeinmedizin Dr. Maryam Radon
   board: "180520"
-- company: "180661"
+- company: transporto singular s.l
   board: "180661"
-- company: "180859"
+- company: RA Dr. Felix Meller
   board: "180859"
-- company: "181074"
+- company: Sanet Nettoyages SA
   board: "181074"
-- company: "181126"
+- company: Euro Finanz Servie AG - Büro Mariahilferstraße
   board: "181126"
 - company: Elektrolyse AG
   board: "181296"
-- company: "181331"
+- company: Aplitech Biolab Life Science Technologies, S.L.
   board: "181331"
-- company: "181339"
+- company: SALVS
   board: "181339"
 - company: Origin Aesthetics AG
   board: "181424"
-- company: "181740"
+- company: PeakPrivacy - Swiss AI Platform
   board: "181740"
-- company: "181954"
+- company: ET-SL Gmbh
   board: "181954"
-- company: "182017"
+- company: Swiss Solar Group AG
   board: "182017"
-- company: "182052"
+- company: Gutsverwaltung Dr. Heinrich Birnleitner Aistersheim
   board: "182052"
-- company: "182373"
+- company: rueeger media GmbH
   board: "182373"
 - company: BORIS 45
   board: "182498"
 - company: Procustos Sicherheitsdienste-Security
   board: "182535"
-- company: "182546"
+- company: Physioland
   board: "182546"
-- company: "182587"
+- company: Kia Autopista Sur
   board: "182587"
 - company: Ästhetikzentrum Dr. Harald Beck
   board: "182617"
-- company: "182639"
+- company: Richfox Capital
   board: "182639"
 - company: Productbay OG
   board: "182654"
-- company: "182682"
+- company: Gebäudetechnik Engelhardt GmbH & Co KG
   board: "182682"
-- company: "182687"
+- company: Aplex Bio
   board: "182687"
-- company: "182718"
+- company: TITAN ROCK, S.L
   board: "182718"
-- company: "182720"
+- company: Dyna-Mix GmbH.
   board: "182720"
-- company: "182732"
+- company: Ing. Mag. Dr. Roland Hansely
   board: "182732"
 - company: Michael Hofer GmbH&Co Kg
   board: "182735"
 - company: LSK AG
   board: "182737"
-- company: "182761"
+- company: YAPPA coffee
   board: "182761"
-- company: "182769"
+- company: Nodo Restaurante
   board: "182769"
 - company: "182780"
   board: "182780"
-- company: "182786"
+- company: Subatron GmbH
   board: "182786"
-- company: "182789"
+- company: RESIDENCIAS CG
   board: "182789"
-- company: "182799"
+- company: Url Agrar GmbH
   board: "182799"
-- company: "182800"
+- company: Rydera AG
   board: "182800"
-- company: "182801"
+- company: ANKA Transport GmbH
   board: "182801"
-- company: "182804"
+- company: JORDI PUJOL ALEMANY S.L.
   board: "182804"
 - company: Boutique Jelen
   board: "182814"
-- company: "182829"
+- company: CENTURY 21
   board: "182829"
-- company: "182837"
+- company: BOOM AEC S.L.
   board: "182837"
 - company: Tecnia Madera
   board: "182893"
-- company: "182897"
+- company: Massaro Elektroinstallationen GmbH
   board: "182897"
-- company: "182932"
+- company: Managed-Office IT Services GmbH
   board: "182932"
-- company: "182945"
+- company: Stauffacher Apotheke
   board: "182945"
 - company: Fisios Islas21
   board: "182954"
-- company: "182965"
+- company: Unabhängige Beschwerdestelle für das Alter UBA
   board: "182965"
-- company: "183001"
+- company: Frima-Pac AG
   board: "183001"
-- company: "183007"
+- company: ASESUR COMUNICACIONES
   board: "183007"
-- company: "183009"
+- company: ARG BOTTLING
   board: "183009"
-- company: "183028"
+- company: Schweizer Baumuster-Centrale Zürich
   board: "183028"
 - company: Marsalada Mojácar
   board: "183031"
 - company: LS Cologne Investment GmbH
   board: "183042"
-- company: "183044"
+- company: Assurance PV
   board: "183044"
-- company: "183063"
+- company: GRAND JBME GmbH
   board: "183063"
-- company: "19016"
+- company: HiFi Klubben Deutschland GmbH
   board: "19016"
 - company: foodways
   board: "1931"
-- company: "1971"
+- company: Rabattcorner
   board: "1971"
-- company: "19896"
+- company: Viewpointsystem GmbH
   board: "19896"
 - company: TOWA - the digital growth company
   board: "20875"
-- company: "21429"
+- company: PIRMIN JUNG Deutschland GmbH
   board: "21429"
 - company: The Body Factory
   board: "21829"
-- company: "22170"
+- company: Cibes Lift Deutschland GmbH
   board: "22170"
 - company: Inspiranto GmbH
   board: "22212"
 - company: StepChange Consulting
   board: "22641"
-- company: "22776"
+- company: Hotel Grimsel Passhöhe
   board: "22776"
-- company: "22840"
+- company: Bamboo Food Service GmbH
   board: "22840"
 - company: Samariterbund Wien
   board: "22902"
-- company: "23179"
+- company: Sonderegger AG
   board: "23179"
-- company: "23437"
+- company: Waldhauser + Hermann AG
   board: "23437"
-- company: "23692"
+- company: Sancovia Gruppe
   board: "23692"
-- company: "23928"
+- company: Marchi Group Deutschland GmbH
   board: "23928"
-- company: "24254"
+- company: HKT-Alphatec GmbH
   board: "24254"
-- company: "24269"
+- company: DIGGERS & MORE GmbH
   board: "24269"
-- company: "25007"
+- company: Ascot
   board: "25007"
-- company: "25401"
+- company: Six Sigma Tools
   board: "25401"
-- company: "25814"
+- company: Menhir AI
   board: "25814"
-- company: "26103"
+- company: Lukas Domeisen AG
   board: "26103"
-- company: "26245"
+- company: Delta 24 AG
   board: "26245"
 - company: Audia Akustik GmbH
   board: "26262"
-- company: "26327"
+- company: Innerspace GmbH
   board: "26327"
-- company: "26369"
+- company: Pestalozzi-Stiftung
   board: "26369"
 - company: NOSERLIGHT AG
   board: "26532"
-- company: "26613"
+- company: W flowers
   board: "26613"
 - company: Yeastup AG
   board: "26736"
-- company: "26743"
+- company: SAVVY® Telematic Systems AG
   board: "26743"
 - company: Parcel Perform
   board: "2676"
-- company: "26825"
+- company: Advanced Buying AG
   board: "26825"
-- company: "26827"
+- company: Kyocera Unimerco Tooling GmbH
   board: "26827"
 - company: Nothelfer am Bahnhof
   board: "26856"
-- company: "26920"
+- company: PSK Security
   board: "26920"
 - company: hairbooster - Medical Beauty Clinic by Humi
   board: "26940"
-- company: "27005"
+- company: Hotel Berghof | St. Johann in Salzburg
   board: "27005"
-- company: "27325"
+- company: Primark Mode Ltd. & Co. KG
   board: "27325"
-- company: "27503"
+- company: NRP Ingenieure AG
   board: "27503"
-- company: "27697"
+- company: 8tree
   board: "27697"
 - company: Pricenow
   board: "27951"
-- company: "27993"
+- company: K.Hartwall GmbH
   board: "27993"
-- company: "28013"
+- company: Domenig & Partner Rechtsanwälte AG
   board: "28013"
-- company: "28042"
+- company: Kuster+Hager Ingenieurbüro AG Uznach / Pfäffikon
   board: "28042"
-- company: "28046"
+- company: Madame Sum
   board: "28046"
 - company: Küffer Elektro-Technik AG
   board: "28126"
-- company: "28190"
+- company: Responsibly
   board: "28190"
-- company: "28585"
+- company: Market Control
   board: "28585"
-- company: "29256"
+- company: Calzedonia Österreich GmbH
   board: "29256"
-- company: "29583"
+- company: LEVL GmbH
   board: "29583"
-- company: "29714"
+- company: transLink.ch AG
   board: "29714"
 - company: Currybag AG
   board: "29721"
-- company: "305"
+- company: jim & jim
   board: "305"
-- company: "30520"
+- company: Interactive Paper
   board: "30520"
-- company: "30697"
+- company: Prägebüro GmbH
   board: "30697"
 - company: adRom Media Marketing GmbH
   board: "30714"
-- company: "31302"
+- company: gbd Holding ZT GmbH
   board: "31302"
-- company: "3144"
+- company: Wistar Informatik AG
   board: "3144"
 - company: HELFERLINE GmbH
   board: "31551"
 - company: SBG Spurny GmbH
   board: "31808"
-- company: "31818"
+- company: ASE (Analysis Simulation Engineering AG)
   board: "31818"
-- company: "3184"
+- company: EFS Euro-Finanz-Service Vermittlungs AG - Direktion Josef Bauer (Wien)
   board: "3184"
-- company: "31997"
+- company: Frasers Hospitality Germany
   board: "31997"
-- company: "32009"
+- company: AEB Sicherheitsdienst GmbH
   board: "32009"
-- company: "32118"
+- company: Home of Coworking GmbH
   board: "32118"
-- company: "3215"
+- company: Steakhouse La Fenice
   board: "3215"
 - company: Breakthrough Service GmbH
   board: "32155"
 - company: der grabmüller
   board: "32222"
-- company: "32437"
+- company: Goldhaus Luzern
   board: "32437"
-- company: "3244"
+- company: Alpenhaus Hotels & Resorts
   board: "3244"
-- company: "32831"
+- company: Xelon AG
   board: "32831"
-- company: "33352"
+- company: SeneCura Kliniken- und HeimebetriebsgmbH
   board: "33352"
-- company: "3337"
+- company: Forward Creatives GmbH
   board: "3337"
-- company: "33487"
+- company: PCS Professional Clinical Software GmbH
   board: "33487"
-- company: "33619"
+- company: CP Immo Solutions GmbH
   board: "33619"
 - company: Skischule Tuxertal
   board: "33769"
-- company: "33884"
+- company: zh-technologies
   board: "33884"
-- company: "33904"
+- company: TG-Security GmbH
   board: "33904"
 - company: HTC Textile Application Consulting GmbH
   board: "33909"
-- company: "33964"
+- company: Hotel Kolping GesmbH - Stadtoase Kolping
   board: "33964"
-- company: "34030"
+- company: Reitter Bau GmbH
   board: "34030"
-- company: "34115"
+- company: Koliya
   board: "34115"
-- company: "34119"
+- company: Schatz GmbH
   board: "34119"
-- company: "34297"
+- company: Coiffeur Studio Senna
   board: "34297"
 - company: Riklin AG
   board: "34324"
-- company: "34399"
+- company: Schlosshotel Mondsee GmbH
   board: "34399"
 - company: Gasthof Kreuz Egerkingen AG
   board: "34480"
-- company: "34774"
+- company: Mag. Helmut Wasserbacher Wirtschaftstreuhand und Steuerberatungsgesellschaft m.b.H.
   board: "34774"
-- company: "35155"
+- company: Audiokanzlei
   board: "35155"
-- company: "35221"
+- company: VIBES FITNESS
   board: "35221"
-- company: "35317"
+- company: Immosolution Immobilien und Facility Management GmbH
   board: "35317"
 - company: SCHMID GROUP AG
   board: "354"
@@ -6749,289 +6749,289 @@
   board: "35413"
 - company: New Fluence
   board: "35458"
-- company: "35529"
+- company: Voquz IT-Solutions GmbH
   board: "35529"
-- company: "35549"
+- company: Hisense Gorenje Austria GmbH
   board: "35549"
 - company: Optotune
   board: "3568"
-- company: "3574"
+- company: DocMorris
   board: "3574"
-- company: "35833"
+- company: Gehmacher
   board: "35833"
-- company: "35868"
+- company: Heliotherm Wärmepumpentechnik Ges.m.b.H.
   board: "35868"
-- company: "35976"
+- company: PetCo GmbH
   board: "35976"
-- company: "35999"
+- company: Perspektive Handel Caritas gGmbH
   board: "35999"
 - company: Bring! Labs AG
   board: "36"
 - company: Posthotel & Lifehotel GmbH & CoKG
   board: "36238"
-- company: "36256"
+- company: Sprachschule Aktiv GmbH
   board: "36256"
-- company: "36266"
+- company: TOP LEARNING
   board: "36266"
-- company: "3641"
+- company: FERCAM Austria GmbH
   board: "3641"
 - company: Schilift Zentrum Gerlos GmbH
   board: "36574"
-- company: "36586"
+- company: Mediaplanet Verlag Deutschland GmbH
   board: "36586"
-- company: "36643"
+- company: Hotel des Glücks
   board: "36643"
-- company: "37056"
+- company: Montafon Tourismus GmbH
   board: "37056"
 - company: Verein Grüner Kreis
   board: "37120"
-- company: "37153"
+- company: RTG Dr. Rümmele Steuerberatung & Wirtschaftsprüfung GmbH & Co KG
   board: "37153"
-- company: "37427"
+- company: EBE Railway Systems GmbH
   board: "37427"
 - company: ZIB Training GmbH
   board: "37506"
-- company: "37703"
+- company: Physiotherapie Glattbrugg
   board: "37703"
-- company: "37735"
+- company: B2G ARCHITEKTEN
   board: "37735"
 - company: L1 ARCHITEKTEN AG
   board: "37760"
 - company: beef & glory. Steakerei GmbH
   board: "37765"
-- company: "37799"
+- company: Ein Herz für Menschen
   board: "37799"
-- company: "37909"
+- company: SOM GROUPE AG
   board: "37909"
-- company: "37995"
+- company: Hotel Restaurant Apres ski Hexenalm
   board: "37995"
-- company: "38139"
+- company: Weibel AG
   board: "38139"
-- company: "3832"
+- company: Langl & Partner og
   board: "3832"
-- company: "3841"
+- company: AmRest (authorisierter Lizenznehmer von Starbucks EMEA Ltd)
   board: "3841"
-- company: "38424"
+- company: roomart-Design GmbH
   board: "38424"
-- company: "38456"
+- company: König Maschinen GmbH
   board: "38456"
-- company: "38511"
+- company: Ritzenhof - Hotel und Spa am See
   board: "38511"
-- company: "38590"
+- company: ZUCKERO - Eis, Cafe, Torte
   board: "38590"
 - company: Sport Tritscher GmbH
   board: "38654"
-- company: "38815"
+- company: Tischlerei Höck GmbH
   board: "38815"
-- company: "38837"
+- company: Speedtech Metallbearbeitung GmbH
   board: "38837"
-- company: "38924"
+- company: ISOTEC-Ochoa (Abdichtungssysteme Dipl. Ing. Ochoa AG)
   board: "38924"
-- company: "38957"
+- company: Genusshandwerk GmbH
   board: "38957"
 - company: Makaro GmbH
   board: "38975"
-- company: "38988"
+- company: Abies Real Estate Investment GmbH
   board: "38988"
-- company: "38996"
+- company: Turek Moden
   board: "38996"
-- company: "39143"
+- company: ENOVA GmbH
   board: "39143"
 - company: Luya Foods AG
   board: "39283"
-- company: "39311"
+- company: Amicum Capital AG
   board: "39311"
 - company: PAV Persönliche Assistenz gem. GmbH
   board: "39473"
 - company: Dirneder Zaun & Garten GmbH
   board: "39492"
-- company: "39709"
+- company: Civediamo Bar
   board: "39709"
-- company: "39725"
+- company: Golf Tech Golfartikelvertriebs GmbH
   board: "39725"
-- company: "40067"
+- company: Zentro GmbH
   board: "40067"
-- company: "40185"
+- company: Wiesinger GmbH & Co KG
   board: "40185"
-- company: "40480"
+- company: Arena S.p.A.
   board: "40480"
 - company: Black Tusk GmbH
   board: "40543"
-- company: "40730"
+- company: PhoneStore Communications GmbH
   board: "40730"
-- company: "40746"
+- company: Gieni AG
   board: "40746"
-- company: "40782"
+- company: Kristall-Klar GmbH
   board: "40782"
-- company: "40832"
+- company: Hotel Joopi
   board: "40832"
 - company: Zum Wohl
   board: "4096"
-- company: "41138"
+- company: talsee AG
   board: "41138"
-- company: "41149"
+- company: Mattig Sport AG
   board: "41149"
-- company: "41203"
+- company: RNC Solutions
   board: "41203"
 - company: mobile nachhilfe - Mag. Kügerl Bildungsmanagement GmbH
   board: "41320"
 - company: CAME SPA
   board: "41337"
-- company: "41369"
+- company: DialogDirect Marketing GmbH
   board: "41369"
-- company: "41494"
+- company: Thai Food - Kitchen 41
   board: "41494"
-- company: "41515"
+- company: Delegate Technology GmbH
   board: "41515"
-- company: "41646"
+- company: Hotel Restaurant Bergkranz
   board: "41646"
-- company: "41651"
+- company: Lugar Installateur GesmbH
   board: "41651"
 - company: Speck Genuss AG
   board: "41835"
-- company: "41965"
+- company: SOVIS AG
   board: "41965"
-- company: "42469"
+- company: Rosendahl Nextrom GmbH
   board: "42469"
-- company: "42505"
+- company: Hotel Garni Forelle mit Gästehaus
   board: "42505"
 - company: Josko Fenster und Türen GmbH
   board: "4268"
-- company: "4270"
+- company: hello again GmbH
   board: "4270"
 - company: Schullin
   board: "43106"
-- company: "43169"
+- company: plenos - Agentur für Kommunikation GmbH
   board: "43169"
-- company: "43241"
+- company: Schönheitsoase Viktora
   board: "43241"
-- company: "43286"
+- company: Admonter Holzindustrie AG
   board: "43286"
-- company: "43362"
+- company: wab kurs
   board: "43362"
-- company: "43397"
+- company: STUBAI ZMV GmbH
   board: "43397"
 - company: Restaurant Hermannseck
   board: "43412"
-- company: "43513"
+- company: EK MedCenter
   board: "43513"
-- company: "43649"
+- company: Lucky Car  (Venom Carrosserie & Autospritzwerk AG)
   board: "43649"
-- company: "43810"
+- company: The DEAR Foundation, Switzerland
   board: "43810"
-- company: "43827"
+- company: Immo-Company Haas & Urban Immobilien GmbH
   board: "43827"
 - company: Coray Management AG
   board: "43913"
 - company: Rius Cruise
   board: "43925"
-- company: "43952"
+- company: TEKPOINT GmbH
   board: "43952"
-- company: "44091"
+- company: Hotel-Restaurant Wetterhorn
   board: "44091"
 - company: Jurata
   board: "44110"
 - company: Credisa GmbH
   board: "44169"
-- company: "4423"
+- company: byrd technologies GmbH
   board: "4423"
-- company: "44287"
+- company: Stauffer Schallschutz + Akustik
   board: "44287"
-- company: "44304"
+- company: Hans Gasteiger GmbH
   board: "44304"
-- company: "44374"
+- company: MEHLER Elektrotechnik Ges.m.b.H.
   board: "44374"
-- company: "44473"
+- company: Transporte Panzl
   board: "44473"
-- company: "44523"
+- company: CAPITAL TRUSTEES AG
   board: "44523"
-- company: "44562"
+- company: Ristorante Da Angela
   board: "44562"
-- company: "44649"
+- company: Fassbinderei Schön Austria
   board: "44649"
 - company: Gärtnerei Holzhacker
   board: "44675"
-- company: "44755"
+- company: Kaisergarten Nier GmbH
   board: "44755"
-- company: "44778"
+- company: Bernhart Steuerberatungs GmbH
   board: "44778"
 - company: ONTEC AG
   board: "44817"
 - company: Ubitec GmbH
   board: "44891"
-- company: "44944"
+- company: TouchBed City Apartments
   board: "44944"
-- company: "44964"
+- company: JobRad Österreich GmbH
   board: "44964"
-- company: "45020"
+- company: nanoTRONIC AG
   board: "45020"
-- company: "45026"
+- company: Tom's Original
   board: "45026"
-- company: "45181"
+- company: BeautySpace Kosmetik GmbH
   board: "45181"
-- company: "45232"
+- company: GFW Transportservice
   board: "45232"
-- company: "45274"
+- company: Ristorante il Cortile
   board: "45274"
-- company: "45374"
+- company: vonMedia AG
   board: "45374"
 - company: HALLE FÜR KUNST Steiermark
   board: "45576"
-- company: "45622"
+- company: MECHATRONIK AUSTRIA GmbH
   board: "45622"
 - company: MAILODY GmbH
   board: "45771"
-- company: "45811"
+- company: MIKKA GmbH
   board: "45811"
 - company: The Golden Tree - Wien
   board: "45853"
-- company: "45926"
+- company: Verein gemeinsam wachsen
   board: "45926"
-- company: "45931"
+- company: Jet Tankstelle Thomas Frühwirth e.U.
   board: "45931"
 - company: Gasthof Löwen Fraubrunnen
   board: "45954"
 - company: Prutti Betriebs GmbH
   board: "45969"
-- company: "46044"
+- company: Auto Speedy AG
   board: "46044"
-- company: "46064"
+- company: Kitzbüheler Wirtschaftstreuhand Mag. Dr. Hedwig Bendler  Dr. Karl Koller KG
   board: "46064"
-- company: "4610"
+- company: First Mountain Hotel GmbH
   board: "4610"
-- company: "46229"
+- company: planlicht GmbH & Co KG
   board: "46229"
-- company: "46235"
+- company: Adriana Reinigungsservice e.U.
   board: "46235"
-- company: "46417"
+- company: Daikin Refrigerants Frankfurt GmbH
   board: "46417"
-- company: "46501"
+- company: Eisperle GmbH
   board: "46501"
-- company: "46522"
+- company: Sport Salner GmbH
   board: "46522"
 - company: EDV - Solution GmbH
   board: "46555"
-- company: "46565"
+- company: MCI Deutschland GmbH
   board: "46565"
 - company: Autohaus Aschauer GmbH
   board: "46621"
-- company: "46638"
+- company: Franky's BBQ
   board: "46638"
-- company: "46694"
+- company: Alpengasthof Hotel Gruberhof
   board: "46694"
-- company: "46783"
+- company: Gebr. Haas Metallbau GmbH
   board: "46783"
-- company: "46831"
+- company: Sozial Medizinischer Dienst Österreich
   board: "46831"
 - company: SNS - Saturn Networking Solutions GmbH
   board: "46939"
-- company: "46977"
+- company: GUTsHAUS Raum für Gesundheit
   board: "46977"
-- company: "47055"
+- company: Natureispalast Erler GmbH
   board: "47055"
-- company: "47149"
+- company: Transporte Braunshofer.at
   board: "47149"
-- company: "47177"
+- company: Der Eissalon
   board: "47177"
 - company: Koidl Vergnügungsbetriebe GmbH
   board: "47281"
@@ -7039,53 +7039,53 @@
   board: "47326"
 - company: Möseralm
   board: "47543"
-- company: "47635"
+- company: HEAL Augenpraxis Dr. Herrmann
   board: "47635"
-- company: "47845"
+- company: Infinity Media GmbH & Co KG
   board: "47845"
 - company: scc EDV-Beratung AG
   board: "47928"
 - company: Zillertaler Trachtenwelt
   board: "48467"
-- company: "48533"
+- company: Aepsy
   board: "48533"
-- company: "48638"
+- company: Digital Architects Zurich
   board: "48638"
-- company: "48669"
+- company: Lorenz Consult ZT GmbH
   board: "48669"
-- company: "48710"
+- company: Hotel Kohlerhof Heim KG
   board: "48710"
-- company: "48764"
+- company: Sporthotel Bachmann
   board: "48764"
-- company: "48861"
+- company: Schippel Stahl und Alubau GmbH
   board: "48861"
-- company: "48864"
+- company: Agnostic Intelligence AG
   board: "48864"
-- company: "48942"
+- company: Fleischerei Loschy
   board: "48942"
-- company: "49019"
+- company: Graf Reinigung
   board: "49019"
-- company: "49159"
+- company: Fliesen Trinker GmbH
   board: "49159"
-- company: "49213"
+- company: Friedrich Neidhart Ges.m.b.H.
   board: "49213"
 - company: Confiserie Heindl
   board: "49223"
-- company: "49237"
+- company: Ärzte ohne Grenzen / Médecins Sans Frontières (MSF) Austria
   board: "49237"
-- company: "49272"
+- company: Proovo Eiprodukte GmbH
   board: "49272"
-- company: "49374"
+- company: Bossard & Geiser GmbH
   board: "49374"
 - company: Portec AG
   board: "49407"
-- company: "49565"
+- company: Shape Your Body
   board: "49565"
-- company: "49570"
+- company: Marionnaud Switzerland AG
   board: "49570"
-- company: "49576"
+- company: Pantex AG
   board: "49576"
-- company: "49583"
+- company: Euroe-Com Trading GmbH
   board: "49583"
 - company: Dufour Aerospace
   board: "49689"
@@ -7093,291 +7093,291 @@
   board: "49852"
 - company: HautSinn Natural Cosmetics GmbH
   board: "49854"
-- company: "50142"
+- company: akari taste GmbH
   board: "50142"
-- company: "50479"
+- company: European Society of Radiology
   board: "50479"
-- company: "5055"
+- company: Diakonie de La Tour
   board: "5055"
 - company: K+G Wakeboardanlagenbetriebs KG
   board: "50587"
-- company: "50637"
+- company: CFO Belgium SRL
   board: "50637"
-- company: "50707"
+- company: Mangolds
   board: "50707"
-- company: "50843"
+- company: Gschwandtl & Lindlbauer ZT GmbH
   board: "50843"
-- company: "50978"
+- company: Amadys Telecom Austria GmbH
   board: "50978"
-- company: "50995"
+- company: Senioren- und Therapiezentrum Haus an der Stör GmbH
   board: "50995"
-- company: "51011"
+- company: UmweltBildungAustria - Grüne Insel
   board: "51011"
 - company: Espressomobil Service GmbH & CoKG
   board: "51107"
-- company: "51492"
+- company: Personal-Basis Management GmbH
   board: "51492"
-- company: "51761"
+- company: First Sécurité et Prévention
   board: "51761"
-- company: "51819"
+- company: Marmot Investment AG
   board: "51819"
-- company: "51855"
+- company: rabel.at e.U.
   board: "51855"
 - company: Flip Lab Millennium City FlexCo & Co KG
   board: "51898"
-- company: "52135"
+- company: ProDomis GmbH
   board: "52135"
-- company: "52174"
+- company: Talentir GmbH
   board: "52174"
-- company: "52262"
+- company: Gasthaus St. Meinrad AG
   board: "52262"
 - company: GUURU
   board: "52329"
-- company: "52408"
+- company: Lovely Brows GmbH
   board: "52408"
 - company: SalzburgerLand Tourismus GmbH
   board: "52506"
 - company: Alladean Warenhandels GmbH
   board: "52563"
-- company: "52618"
+- company: Michael Fuchs Transporte
   board: "52618"
-- company: "52745"
+- company: d'Ambrosio GmbH
   board: "52745"
-- company: "52919"
+- company: SC Cosmetics Handels GmbH
   board: "52919"
-- company: "52952"
+- company: Gemeinnützige Gesellschaft Zug
   board: "52952"
 - company: faircheck Schadenservice GmbH
   board: "52968"
-- company: "53"
+- company: GENEXT AG
   board: "53"
-- company: "53140"
+- company: Kieferorthopädie DDr. Hanzely
   board: "53140"
-- company: "53387"
+- company: Sportstätten Klosterneuburg GmbH
   board: "53387"
-- company: "53417"
+- company: azb ag (arbeitsmedizinisches zentrum basel)
   board: "53417"
-- company: "53429"
+- company: Thermoform & gastroALLround
   board: "53429"
 - company: HD-Engineering Consulting- und PlanungsgesmbH
   board: "53526"
 - company: Kremslehner Hotels Wien
   board: "53534"
-- company: "5354"
+- company: FenX AG
   board: "5354"
-- company: "53651"
+- company: Grischa Gerüste AG
   board: "53651"
 - company: Hotel Liebmann GmbH & Co KG
   board: "53696"
-- company: "5370"
+- company: International kids group „kids gallery Vienna „
   board: "5370"
-- company: "53713"
+- company: Clitec GmbH
   board: "53713"
-- company: "53769"
+- company: Wüst Metallbau AG
   board: "53769"
-- company: "53835"
+- company: Ertl GmbH
   board: "53835"
-- company: "53850"
+- company: mobilVET Tierärzte
   board: "53850"
-- company: "54219"
+- company: Frischgemüse Zinöcker
   board: "54219"
 - company: Ristorante L' Ulivo
   board: "54369"
-- company: "54374"
+- company: Ambulatorium Auersperg GmbH
   board: "54374"
-- company: "54391"
+- company: Christophe Livache
   board: "54391"
-- company: "54410"
+- company: Hotel-Garni Hubertus
   board: "54410"
 - company: Hotel Engelberg
   board: "54608"
-- company: "54634"
+- company: FPG Fusion Promotion GmbH
   board: "54634"
 - company: Chicken Club by JoPa GmbH
   board: "54699"
 - company: HESA Saatengroßhandlung GmbH & Co Nfg KG
   board: "54751"
-- company: "54919"
+- company: Holz-und Glaswerkstätten Staudt
   board: "54919"
-- company: "55054"
+- company: IPH Institut "Prüffeld für elektrische Hochleistungstechnik" GmbH
   board: "55054"
-- company: "55107"
+- company: KOSME Gesellschaft mbH
   board: "55107"
-- company: "55277"
+- company: OBSTKREIS
   board: "55277"
-- company: "55350"
+- company: MANNA INNSBRUCK Delikatessencafe
   board: "55350"
-- company: "55493"
+- company: Kreier Mechanik GmbH
   board: "55493"
-- company: "55611"
+- company: Joineer
   board: "55611"
-- company: "55673"
+- company: enet GmbH
   board: "55673"
-- company: "55759"
+- company: KEEGO Technologies GmbH
   board: "55759"
-- company: "55788"
+- company: PRI Tours GmbH
   board: "55788"
 - company: Safrans Lounge
   board: "55903"
 - company: Spiezer Restaurant & Lounge
   board: "55906"
-- company: "55932"
+- company: Stanglwirt GmbH
   board: "55932"
-- company: "56085"
+- company: Shyfter.co
   board: "56085"
-- company: "56169"
+- company: SPV Printmedien GmbH
   board: "56169"
 - company: ARIAN GmbH
   board: "56171"
-- company: "56190"
+- company: Luftraum Klima-Lüftung-Alternativenergien GmbH.
   board: "56190"
-- company: "56305"
+- company: Business Solution
   board: "56305"
 - company: Vienna House Easy by Wyndham Landsberg
   board: "56402"
 - company: Hotel Jennys Schlössl
   board: "5642"
-- company: "56561"
+- company: HTK-Vent GmbH
   board: "56561"
-- company: "56627"
+- company: Erlebnis-Hotel-Appartements Pi
   board: "56627"
-- company: "56652"
+- company: DODI
   board: "56652"
-- company: "56664"
+- company: easyLOOP GmbH
   board: "56664"
-- company: "56764"
+- company: Infracom Solutions GmbH
   board: "56764"
 - company: Stritzinger Import-Export
   board: "56778"
-- company: "56832"
+- company: Crea-Glass GmbH
   board: "56832"
 - company: Biely Rechtsanwälte OG
   board: "56850"
-- company: "56899"
+- company: COOEE alpin Hotels
   board: "56899"
-- company: "57017"
+- company: OMV/Badido Cafe-Restaurant
   board: "57017"
-- company: "57072"
+- company: Subway Liezen SUB320 GmbH
   board: "57072"
 - company: triply GmbH
   board: "57082"
-- company: "57085"
+- company: CORDAG AG
   board: "57085"
 - company: Rottbeck Spedition GmbH
   board: "57144"
-- company: "57303"
+- company: Bellwald Sportbahnen AG
   board: "57303"
-- company: "57309"
+- company: Seniorenpension Bad Schönau
   board: "57309"
-- company: "57359"
+- company: Schrankerl GmbH
   board: "57359"
-- company: "57372"
+- company: InformaQuik sarl
   board: "57372"
-- company: "57407"
+- company: Velvet Catering GmbH
   board: "57407"
-- company: "57410"
+- company: MDigital AG
   board: "57410"
-- company: "57426"
+- company: Heiss & Süß
   board: "57426"
-- company: "57551"
+- company: You Will Like It Group GmbH
   board: "57551"
 - company: Marcus Krapfenbauer Betriebs GmbH
   board: "57565"
 - company: Nadine Braun KG
   board: "57705"
-- company: "57719"
+- company: mobileup
   board: "57719"
-- company: "57776"
+- company: TriLite Technologies GmbH
   board: "57776"
-- company: "57850"
+- company: Global Car Trading AG
   board: "57850"
-- company: "57898"
+- company: KG Massimo Dutti Deutschland BV & Co.
   board: "57898"
 - company: Hairdesign by Vanja Sekulic
   board: "58052"
 - company: Workheld GmbH
   board: "58114"
-- company: "5855"
+- company: PhysioMur
   board: "5855"
-- company: "58769"
+- company: Senkels
   board: "58769"
 - company: HYE GmbH
   board: "58782"
 - company: Citytrans GmbH
   board: "58813"
-- company: "58988"
+- company: Entech Alliance GmbH Entertainment Technicians
   board: "58988"
-- company: "59100"
+- company: TopMiet ImmobilienverwertungsGmbH
   board: "59100"
-- company: "59368"
+- company: Heimwerkertools HandelsGmbH
   board: "59368"
-- company: "59390"
+- company: INTERMAPS GmbH
   board: "59390"
-- company: "59600"
+- company: Fröling Heizkessel- und Behälterbau GmbH
   board: "59600"
-- company: "59639"
+- company: PISQU
   board: "59639"
 - company: Yoordi AG
   board: "59974"
-- company: "59989"
+- company: Sennhütte - Fachinstitution für Suchttherapie
   board: "59989"
-- company: "60042"
+- company: Haupt Chemicals GmbH
   board: "60042"
-- company: "60445"
+- company: Trafficon
   board: "60445"
 - company: ActiLingua Academy
   board: "60555"
-- company: "60676"
+- company: Bäckerei Pfyl AG
   board: "60676"
-- company: "60677"
+- company: Arche Noah Brocki
   board: "60677"
-- company: "60922"
+- company: ELHO Wärmetechnik GmbH
   board: "60922"
-- company: "60944"
+- company: Bäckerei Kern
   board: "60944"
-- company: "60979"
+- company: Bevy Express
   board: "60979"
 - company: SOFACOMPANY
   board: "6102"
-- company: "61110"
+- company: Pull&Bear
   board: "61110"
-- company: "61121"
+- company: Ströck Gastronomiebetriebs GmbH
   board: "61121"
 - company: VAYA Group
   board: "61161"
-- company: "61204"
+- company: Tourismusverband Region Wels
   board: "61204"
 - company: Ferienhotel Knollhof
   board: "61299"
-- company: "61413"
+- company: Architekt Scheibenreif ZT GmbH
   board: "61413"
-- company: "61512"
+- company: Mrs.Sporty im 3. Bezirk (Landstraßeii)
   board: "61512"
-- company: "61559"
+- company: MALOUM
   board: "61559"
-- company: "61598"
+- company: MusiProf IE
   board: "61598"
-- company: "6165"
+- company: sps-west gmbh
   board: "6165"
-- company: "61714"
+- company: Party Spass Events - Alexander Stemer
   board: "61714"
 - company: THV-Reisen GmbH
   board: "61834"
-- company: "61853"
+- company: StarApps
   board: "61853"
-- company: "61954"
+- company: DeliBrot GmbH
   board: "61954"
-- company: "62073"
+- company: ZuklinBus GmbH
   board: "62073"
 - company: infoWERK Medien & Technik GmbH
   board: "62426"
-- company: "62548"
+- company: ZARA HOME Deutschland B.V. & Co.. KG
   board: "62548"
-- company: "62656"
+- company: Burger King Schweiz
   board: "62656"
-- company: "62736"
+- company: Adelsberger & Thaler Steuerberatungs OG
   board: "62736"
-- company: "62791"
+- company: BRAINTEC GmbH
   board: "62791"
 - company: Thomas Prommegger GmbH/ Hotel Alpina
   board: "62849"
@@ -7385,169 +7385,169 @@
   board: "62935"
 - company: VAC SYSTEMS AG
   board: "62972"
-- company: "63067"
+- company: mimacom ag
   board: "63067"
-- company: "63069"
+- company: Schreinerei Luchsinger AG
   board: "63069"
-- company: "63200"
+- company: Packari.com GmbH
   board: "63200"
-- company: "63228"
+- company: saluto
   board: "63228"
 - company: Grupo Jabel
   board: "63364"
-- company: "63413"
+- company: Escola GmbH
   board: "63413"
-- company: "63428"
+- company: Kinderdagverblijf Windekind
   board: "63428"
-- company: "63505"
+- company: NEWRY GLOBAL MEDIA
   board: "63505"
-- company: "63537"
+- company: Austrian Business Cars
   board: "63537"
-- company: "63563"
+- company: Téxum
   board: "63563"
-- company: "63683"
+- company: SG FRANCE DISTRIBUTION
   board: "63683"
-- company: "63695"
+- company: ristl.IT GmbH
   board: "63695"
-- company: "63738"
+- company: Robert Steiner GmbH - Steiner Familyentertainment
   board: "63738"
-- company: "64073"
+- company: COOR GmbH
   board: "64073"
 - company: AHG Holding AG (ahg group)
   board: "64251"
-- company: "64373"
+- company: MOOI
   board: "64373"
 - company: Laserhaarentfernung by the laser station AG
   board: "64497"
-- company: "64499"
+- company: Berber Transporte KG
   board: "64499"
-- company: "6457"
+- company: gemeinnützige kreativ Campus Potsdam GmbH
   board: "6457"
-- company: "64582"
+- company: GIWA Security AG
   board: "64582"
 - company: CURA Cosmetics Group
   board: "64745"
-- company: "64749"
+- company: Ing. Dr. Omar Hamid MSc Zahnarzt
   board: "64749"
-- company: "64982"
+- company: Jehle engros AG
   board: "64982"
 - company: RegioData Research GmbH
   board: "65119"
-- company: "65233"
+- company: Carrosserie Baldinger AG
   board: "65233"
-- company: "65369"
+- company: BIGBANG GMBH
   board: "65369"
-- company: "65594"
+- company: marti+dietschweiler ag
   board: "65594"
-- company: "65595"
+- company: Transped Gruppe
   board: "65595"
 - company: Boa-Bao
   board: "65644"
-- company: "65826"
+- company: EYYES GmbH
   board: "65826"
 - company: CRS Management & Service AG
   board: "65828"
-- company: "65882"
+- company: LOA BRAND COMMUNICATION GMBH
   board: "65882"
-- company: "65885"
+- company: Freudenthaler GmbH & Co KG
   board: "65885"
-- company: "659"
+- company: Tango Analytics
   board: "659"
 - company: Bauschutz GmbH & CO KG
   board: "66237"
-- company: "66264"
+- company: Camiral
   board: "66264"
-- company: "66269"
+- company: Am Hof 8
   board: "66269"
-- company: "66399"
+- company: Grupo Ginestar
   board: "66399"
 - company: puntosingular
   board: "66435"
 - company: Inventsys AG
   board: "66478"
-- company: "66530"
+- company: Biotta AG
   board: "66530"
-- company: "66596"
+- company: Ergo und Physio HDFB
   board: "66596"
-- company: "66661"
+- company: ALBIRO AG
   board: "66661"
-- company: "66677"
+- company: CONTAX Witschaftstreuhand GmbH
   board: "66677"
-- company: "66757"
+- company: SPS Germany GmbH
   board: "66757"
 - company: Egos! The Education Company
   board: "66831"
 - company: GLAS PETZKA e.U.
   board: "66964"
-- company: "67035"
+- company: Borealis Innovation
   board: "67035"
-- company: "67155"
+- company: EIBIR gemeinnützige GmbH
   board: "67155"
-- company: "67161"
+- company: BaW Gastro AG, Bar am Wasser
   board: "67161"
-- company: "67378"
+- company: HAHN media group ag.
   board: "67378"
 - company: Visia Solutions S.L.
   board: "67387"
-- company: "67578"
+- company: Holzinger Steuerberatung GmbH
   board: "67578"
-- company: "67760"
+- company: Msoluciona Alcala
   board: "67760"
 - company: Centimeter
   board: "67814"
-- company: "67900"
+- company: sur canal s.l.
   board: "67900"
 - company: HealthclubNU
   board: "67915"
-- company: "68044"
+- company: Baskonia Kirol Hiria S.L.U.
   board: "68044"
 - company: Magicmodels
   board: "68160"
-- company: "68348"
+- company: everyday Werbeagentur GmbH
   board: "68348"
-- company: "68350"
+- company: Britenglishschool.com
   board: "68350"
-- company: "68430"
+- company: TRANSPORTES Y LOGISTICA CIBEA, S.L.
   board: "68430"
-- company: "68458"
+- company: FTS Food Technology Services AG
   board: "68458"
-- company: "68473"
+- company: House Hunting
   board: "68473"
-- company: "68619"
+- company: Stonebock AG
   board: "68619"
-- company: "68682"
+- company: Vimantik Soluciones Tecnológicas, S.L.
   board: "68682"
 - company: Limpiezas Milladoiro SL
   board: "68710"
 - company: Ilunion facilitys services
   board: "68786"
-- company: "68813"
+- company: BERING Time GmbH
   board: "68813"
 - company: Paxedra AG
   board: "68942"
-- company: "68993"
+- company: AZAMO 2006 S.L.
   board: "68993"
-- company: "69"
+- company: bexio ag
   board: "69"
 - company: RESIDENCIA DON BOSCO
   board: "69098"
-- company: "69204"
+- company: Popp & Kretschmer Modehandels GmbH
   board: "69204"
-- company: "69205"
+- company: TULASER CLINIC
   board: "69205"
-- company: "69208"
+- company: Ortopedias Mundo Dependencia
   board: "69208"
-- company: "69517"
+- company: LernFamilie
   board: "69517"
-- company: "69566"
+- company: Limpiezas La Aurora
   board: "69566"
-- company: "69776"
+- company: iNet Technolgoies GmbH
   board: "69776"
-- company: "69808"
+- company: Boulangerie Chocolaterie Heiz SA
   board: "69808"
-- company: "69832"
+- company: Camfil BV
   board: "69832"
-- company: "70034"
+- company: Stieg & Böhm Korrosionsschutz GmbH
   board: "70034"
 - company: Hidrotek Levante Srl
   board: "70082"
@@ -7555,247 +7555,247 @@
   board: "70192"
 - company: Home Life Immobilien AG
   board: "70248"
-- company: "70488"
+- company: Gabinete Senda
   board: "70488"
-- company: "7054"
+- company: Emirates Holidays
   board: "7054"
-- company: "70714"
+- company: RECUBRIMIENTOS INDUSTRIALES CONTINENTALES, S.L.
   board: "70714"
-- company: "70764"
+- company: Aula Intercultural
   board: "70764"
-- company: "70813"
+- company: AKSA Würenlos AG
   board: "70813"
-- company: "70944"
+- company: Fundació KREAS
   board: "70944"
-- company: "70953"
+- company: SkiLL OG
   board: "70953"
-- company: "71217"
+- company: KIDS&US LES GARRIGUES
   board: "71217"
 - company: Convit Central GmbH
   board: "71528"
 - company: Aurora
   board: "71861"
-- company: "71884"
+- company: Hotel UTO KULM AG
   board: "71884"
 - company: Zenova
   board: "72000"
-- company: "72010"
+- company: Romedius Gastroplaner GmbH
   board: "72010"
-- company: "72016"
+- company: Webkönig AG
   board: "72016"
-- company: "72203"
+- company: CLINICA DENTAL DRA JAUME
   board: "72203"
-- company: "72412"
+- company: CONTROL Y GEOLOGIA, S.A.
   board: "72412"
-- company: "72593"
+- company: Ingenieurbüro Kainz PlanungsgmbH
   board: "72593"
-- company: "72618"
+- company: DECUS Immobilien GmbH
   board: "72618"
-- company: "72628"
+- company: SympaSol AG
   board: "72628"
 - company: Anwaltssocietät Sattlegger, Dorninger, Steiner & Partner
   board: "72649"
 - company: Seguranautics
   board: "72800"
-- company: "7301"
+- company: Axelra AG
   board: "7301"
-- company: "73105"
+- company: Playhair
   board: "73105"
-- company: "73248"
+- company: KD Pharma
   board: "73248"
-- company: "73422"
+- company: Ardenne Dental
   board: "73422"
 - company: afreshed GmbH
   board: "73476"
-- company: "73556"
+- company: actiVIEties Rooms GmbH
   board: "73556"
-- company: "73748"
+- company: Information Factory
   board: "73748"
 - company: MONTESALUD, S.A.
   board: "73762"
-- company: "73771"
+- company: Lixt AG
   board: "73771"
-- company: "73846"
+- company: AutomationX GmbH
   board: "73846"
-- company: "73909"
+- company: Ki Reply GmbH
   board: "73909"
-- company: "74095"
+- company: DIE BIBLIOTHEKARE
   board: "74095"
 - company: ALAZAN
   board: "74130"
-- company: "74349"
+- company: Pinturas y Tarimas Ideas
   board: "74349"
-- company: "74421"
+- company: Steuerleute Steuerberatung e.U.
   board: "74421"
-- company: "74655"
+- company: SuisseMaids
   board: "74655"
 - company: Alta Engineering AG
   board: "74713"
-- company: "74817"
+- company: Gasthaus Hofwiesen
   board: "74817"
 - company: Enterprise Bot
   board: "749"
-- company: "75109"
+- company: Kindergruppe Horizont
   board: "75109"
-- company: "75138"
+- company: IGP INGESA
   board: "75138"
-- company: "75152"
+- company: TPV CANARIAS, S.L.
   board: "75152"
 - company: DRIVERS SERVICIOS LOGISTICOS SL
   board: "75161"
-- company: "75230"
+- company: YAVER
   board: "75230"
-- company: "75268"
+- company: H. Läuchli AG
   board: "75268"
-- company: "75536"
+- company: Tania Orellana Diaz
   board: "75536"
 - company: Edime Ingeniería
   board: "75537"
 - company: Casino Davos AG
   board: "75599"
-- company: "75633"
+- company: Bluespace
   board: "75633"
 - company: Horwin Europe GmbH
   board: "75846"
-- company: "75875"
+- company: impetus Personalberatung
   board: "75875"
-- company: "75903"
+- company: SHIVAPLATA S.L
   board: "75903"
-- company: "76115"
+- company: Zenit Topografia y Cartografia SL
   board: "76115"
-- company: "76226"
+- company: Art-Montagen GmbH
   board: "76226"
-- company: "76284"
+- company: GERMAN VIZCAINO S.L.
   board: "76284"
-- company: "76360"
+- company: ek-trans GmbH
   board: "76360"
-- company: "76609"
+- company: Centro Médico Isomedic
   board: "76609"
 - company: Asetra Balnearios y Spa
   board: "76904"
-- company: "77162"
+- company: Vita Nova
   board: "77162"
 - company: GRUPO GOMUR
   board: "77273"
-- company: "7732"
+- company: M.Bolli GmbH
   board: "7732"
-- company: "77459"
+- company: Prozis
   board: "77459"
-- company: "77489"
+- company: A FAN OF
   board: "77489"
 - company: Cleanova GmbH
   board: "77545"
-- company: "77830"
+- company: Seprotec Traducción e Interpretación
   board: "77830"
-- company: "77856"
+- company: X-Wood concept GmbH
   board: "77856"
-- company: "77886"
+- company: Nidecker Group
   board: "77886"
 - company: Dropon
   board: "77923"
-- company: "78006"
+- company: Sigmaplan AG
   board: "78006"
-- company: "78290"
+- company: Schülerhilfe Forchheim und Hirschaid
   board: "78290"
-- company: "78314"
+- company: Q-Drives GmbH
   board: "78314"
 - company: Ortopedia Juan Bravo
   board: "78347"
-- company: "78372"
+- company: Agrupación Cultural El Pilo ( La LLoma)
   board: "78372"
-- company: "78636"
+- company: Hotel Nova GmbH
   board: "78636"
 - company: Schulverein der Dominikanerinnen
   board: "78645"
-- company: "78695"
+- company: HOTEL RURAL & SPA LOS ANADES - EL ANADE REAL
   board: "78695"
 - company: Skischule Kirschner Werner&Kollegen GmbH
   board: "78704"
-- company: "78934"
+- company: Sysmex Austria GmbH
   board: "78934"
-- company: "79052"
+- company: CONSTRUCCIONES NIDEKER SL
   board: "79052"
-- company: "79114"
+- company: Silidur AG
   board: "79114"
-- company: "79136"
+- company: Pinturas Broch, S.L.
   board: "79136"
 - company: GOBAI GROUP SOLUTIONS SL
   board: "79206"
-- company: "79229"
+- company: Curlish GmbH
   board: "79229"
 - company: BeSync AG
   board: "79235"
-- company: "79246"
+- company: Portalia Ferrer, S.L.
   board: "79246"
-- company: "79433"
+- company: Volkshilfe Österreich
   board: "79433"
-- company: "79470"
+- company: Medisport Q AG
   board: "79470"
 - company: Schülerhilfe Bonn-Duisdorf
   board: "79487"
-- company: "79502"
+- company: STUWER - Neues Wiener Beisl
   board: "79502"
-- company: "79600"
+- company: Augenblick Beauty factory
   board: "79600"
-- company: "79747"
+- company: Clínicas Cleardent
   board: "79747"
-- company: "79970"
+- company: Smartbody
   board: "79970"
 - company: GESTIONA ON GROUP
   board: "80098"
-- company: "80280"
+- company: Fidas Innsbruck Steuerberatung GmbH & Co KG
   board: "80280"
-- company: "80565"
+- company: GRUPO GCBE
   board: "80565"
-- company: "80643"
+- company: CONSULTRANS
   board: "80643"
 - company: Electro expert Ceballos, S.L.
   board: "80681"
-- company: "80811"
+- company: Oratek SA
   board: "80811"
-- company: "80840"
+- company: Aptiv Services Deutschland GmbH
   board: "80840"
-- company: "80848"
+- company: SCHWARZ-Außenwerbung GmbH
   board: "80848"
-- company: "80867"
+- company: Lassmann International GmbH
   board: "80867"
-- company: "80891"
+- company: LAVIS GmbH
   board: "80891"
-- company: "80913"
+- company: Mecanizados Calibres y Prototipos SL
   board: "80913"
-- company: "80919"
+- company: Glatt Broker AG
   board: "80919"
 - company: Residencia Ntra Sra. del Perpetuo Socorro
   board: "80953"
-- company: "80964"
+- company: MORLOPIN, S.L.
   board: "80964"
-- company: "80984"
+- company: Pedalo-Radreisefreunde GmbH
   board: "80984"
 - company: Gastro Portal
   board: "81128"
 - company: WITTMANN Steuerberatung GmbH
   board: "81286"
-- company: "81812"
+- company: Grupo MT
   board: "81812"
-- company: "81883"
+- company: Scheidweg-Garage AG
   board: "81883"
-- company: "81953"
+- company: Praxispartner Herzogenburg
   board: "81953"
-- company: "82069"
+- company: ROTULOS SYSTEM S.L.
   board: "82069"
-- company: "82079"
+- company: TERRA INGENIEROS SL
   board: "82079"
-- company: "82186"
+- company: Berggasthof Edelweiss
   board: "82186"
 - company: Best Logistik GmbH
   board: "82193"
-- company: "82312"
+- company: F. + M. Konstantin Logistik AG
   board: "82312"
-- company: "82449"
+- company: Steinbacher Energie GmbH
   board: "82449"
-- company: "82529"
+- company: Microcaps AG
   board: "82529"
-- company: "82623"
+- company: Edelsegger Metals GmbH
   board: "82623"
 - company: Tropeninstitut Wien 1060
   board: "82695"
@@ -7803,29 +7803,29 @@
   board: "82712"
 - company: ANDERMATT MUSIC
   board: "82733"
-- company: "82805"
+- company: Delivery Friends GmbH
   board: "82805"
 - company: Visual Entidad de Gestión de Artistas Plásticos
   board: "82896"
-- company: "82932"
+- company: Salzgeber Metallbau AG
   board: "82932"
-- company: "82981"
+- company: CLINICA ASTURIAS
   board: "82981"
-- company: "83075"
+- company: Archify AG
   board: "83075"
-- company: "83133"
+- company: Light for the World International
   board: "83133"
-- company: "83202"
+- company: PIPOCA SOLUCIONES
   board: "83202"
-- company: "83337"
+- company: HÄUPL SpeditionsgesmbH
   board: "83337"
-- company: "83387"
+- company: Lighthouse Business & IT Solutions GmbH
   board: "83387"
-- company: "83441"
+- company: Chirpies Snack AG
   board: "83441"
-- company: "83580"
+- company: ITV SONSECA
   board: "83580"
-- company: "83604"
+- company: Max Schilling AG
   board: "83604"
 - company: Ordination Dr. Papp Dr. Jungmann
   board: "83690"
@@ -7835,373 +7835,373 @@
   board: "83823"
 - company: EDIBON
   board: "83948"
-- company: "84161"
+- company: Eatable Adventures
   board: "84161"
-- company: "84260"
+- company: MERINERO S.A.
   board: "84260"
 - company: AUTOCARES MUÑOZ GARCIA
   board: "84406"
-- company: "84437"
+- company: Tecnica Group Ski Excellence Center Austria
   board: "84437"
-- company: "84446"
+- company: AMBULANCIAS VALLADA SLU
   board: "84446"
-- company: "84604"
+- company: KPTN
   board: "84604"
 - company: Adolf Kuhn AG
   board: "84687"
 - company: Esthetic KG
   board: "84798"
-- company: "8483"
+- company: ERP-Solutions GmbH
   board: "8483"
-- company: "84851"
+- company: JANYFLOR, S.L.
   board: "84851"
-- company: "84927"
+- company: Autistenzentrum Arche Noah Verein zur beruflichen und sozialen Rehabilitation und Integration von Autisten und Menschen mit anderer Behinderung
   board: "84927"
-- company: "84946"
+- company: Conducciones y Montajes Suroeste SL
   board: "84946"
-- company: "84986"
+- company: KING REGAL, S.A
   board: "84986"
-- company: "84987"
+- company: Dr. Krug MCS GmbH
   board: "84987"
-- company: "85078"
+- company: Hapimag Resort Zell am See
   board: "85078"
-- company: "85106"
+- company: Zorn & Nowy ZT-GmbH
   board: "85106"
 - company: Gourmet Domizil
   board: "85122"
-- company: "85261"
+- company: Cometal
   board: "85261"
 - company: GRUPO ISONOR
   board: "85303"
-- company: "85315"
+- company: Kita Perlä
   board: "85315"
-- company: "85332"
+- company: Lithos Natural GmbH
   board: "85332"
 - company: GRÀCIACALBET
   board: "85338"
-- company: "85621"
+- company: HOTEL BAZTAN ***
   board: "85621"
 - company: Bergbahnen Hochkössen
   board: "85645"
-- company: "85668"
+- company: policlinica los rosales sl (CLINICA BERROCAL)
   board: "85668"
-- company: "85812"
+- company: marsdigital,sl
   board: "85812"
-- company: "85816"
+- company: DI Hubert Leibl
   board: "85816"
-- company: "85990"
+- company: Sheepnsons GmbH
   board: "85990"
-- company: "86018"
+- company: Heritsch Media GmbH
   board: "86018"
-- company: "86286"
+- company: ZUGKRAFT
   board: "86286"
-- company: "86356"
+- company: Softwaro GmbH
   board: "86356"
-- company: "86440"
+- company: Swiss Watches Outlet - Goozy AG
   board: "86440"
-- company: "86444"
+- company: Riversa Postformados La Ribera
   board: "86444"
-- company: "86534"
+- company: ESPHOUSES
   board: "86534"
-- company: "86569"
+- company: OY AYUDAS MÁS SLU
   board: "86569"
 - company: Geotrade Tiefbauprodukte GmbH
   board: "86641"
-- company: "86810"
+- company: Greenyard Fresh Germany
   board: "86810"
-- company: "86842"
+- company: Ärztepraxis Kern
   board: "86842"
-- company: "86846"
+- company: GDWFLEX
   board: "86846"
 - company: Donau Touristik GmbH
   board: "86970"
 - company: Optiml
   board: "87049"
-- company: "87162"
+- company: FDUK OpenTheDoor OG
   board: "87162"
-- company: "87293"
+- company: QUALIPHARMA, S.L.
   board: "87293"
-- company: "87468"
+- company: Policlinica VESALIO
   board: "87468"
-- company: "87497"
+- company: NECOBUFFET
   board: "87497"
-- company: "87559"
+- company: sur4colores
   board: "87559"
 - company: Abicht Gruppe
   board: "87661"
 - company: FeelGood Onco
   board: "87775"
-- company: "87854"
+- company: CARLIN
   board: "87854"
 - company: 2 OPEN CHINA ECOMMERCE
   board: "87944"
-- company: "88062"
+- company: Alfa Trainers
   board: "88062"
-- company: "88086"
+- company: Eissalon Leonardelli
   board: "88086"
-- company: "88239"
+- company: RE/MAX Donau-City-Immobilien, Fetscher & Partner GmbH & CO KG
   board: "88239"
-- company: "88347"
+- company: Sabo + Mandl & Tomaschek Immobilien GmbH
   board: "88347"
-- company: "88553"
+- company: RECAMBIOS CENTRO S.A.
   board: "88553"
-- company: "88568"
+- company: ESBAIN
   board: "88568"
-- company: "88791"
+- company: TRANSPORTES LEVANTE Y BAÑULS,S.L.
   board: "88791"
-- company: "88875"
+- company: Seminar- & Eventhotel Krainerhütte
   board: "88875"
 - company: Weinberger & Gabmayer ZT-GmbH
   board: "89008"
-- company: "89023"
+- company: PALFINGER Ibérica
   board: "89023"
 - company: Bachl Nachhilfe Wels
   board: "89194"
-- company: "89244"
+- company: VICI AG International
   board: "89244"
-- company: "89356"
+- company: ECOBABY
   board: "89356"
-- company: "89368"
+- company: Lenbox Fitness Boxing
   board: "89368"
-- company: "8942"
+- company: Cashare AG
   board: "8942"
 - company: MICROINVEST - Micro Beteiligungs GmbH
   board: "89691"
-- company: "89898"
+- company: Smart-Study GmbH
   board: "89898"
 - company: RESIDENCIA VILLA DE LEDESMA
   board: "89958"
 - company: TB Obkircher Plus
   board: "90006"
-- company: "90021"
+- company: Bakery Bakery AG
   board: "90021"
-- company: "90102"
+- company: Kälte AG
   board: "90102"
-- company: "90143"
+- company: aPlus Energiekonzept
   board: "90143"
-- company: "90206"
+- company: SEPPELEC, S.L.
   board: "90206"
 - company: Medvisit SL
   board: "90219"
-- company: "90280"
+- company: 42 Vienna GmbH
   board: "90280"
 - company: Dog Promotion GmbH
   board: "9030"
 - company: sweet skin Hautzentrum AG
   board: "90322"
-- company: "90349"
+- company: MONTAJES METALICOS PAN AÑON SL
   board: "90349"
 - company: Stoffhuus
   board: "90538"
-- company: "90540"
+- company: CC Compact Cleaning GmbH
   board: "90540"
-- company: "90609"
+- company: GEOX RESPIRA
   board: "90609"
-- company: "90746"
+- company: GRUAS AGUILAR SLU
   board: "90746"
-- company: "90752"
+- company: Academia ENFAF
   board: "90752"
-- company: "91022"
+- company: Crocodile Sports Outdoor Erlebnisse GmbH
   board: "91022"
-- company: "91160"
+- company: THE THAI, Take Away & Catering AG
   board: "91160"
 - company: LSH Feuerfest GmbH
   board: "91174"
-- company: "91193"
+- company: JOAQUÍN AYORA SAU
   board: "91193"
-- company: "91235"
+- company: Sol Lunamar Palmanova Apartments
   board: "91235"
-- company: "91414"
+- company: iQ-home.net
   board: "91414"
-- company: "91488"
+- company: Homecare die Alltagshelfer Halver
   board: "91488"
 - company: Flashpoint
   board: "91503"
 - company: iAdvise Financial Services
   board: "91611"
-- company: "91801"
+- company: Instalaciones C.E.F.A., S.L.
   board: "91801"
-- company: "91823"
+- company: DEALER Y SERVICIO POSTVENTA S.A
   board: "91823"
-- company: "91848"
+- company: NUBRA S.L.
   board: "91848"
-- company: "91987"
+- company: EXCLUSIVAS VILA S.L.
   board: "91987"
 - company: Prestige Hotels
   board: "91990"
-- company: "92065"
+- company: Marjal Técnicas de Ingeniería, S.L.
   board: "92065"
-- company: "92171"
+- company: Knapp GmbH Niederlassung Deutschland
   board: "92171"
-- company: "92241"
+- company: DZB Diagnosezentrum Brigittenau
   board: "92241"
-- company: "92300"
+- company: Clínica Veterinaria La Gloria Campo de Gibraltar
   board: "92300"
-- company: "92335"
+- company: MobilWelt GmbH
   board: "92335"
 - company: Putzfrauenagentur Gnehm GmbH
   board: "9241"
-- company: "92489"
+- company: ALBA Sourdough Pizza
   board: "92489"
-- company: "92543"
+- company: SOLUCIONES APLICADAS INNOVA VENDING, S.L.
   board: "92543"
-- company: "92564"
+- company: Nuscamps
   board: "92564"
 - company: JIVITA AG
   board: "92623"
 - company: HERME PLUS SL
   board: "92706"
-- company: "92712"
+- company: VSZ Versorgungs- und Servicezentrum für medizinischen Bedarf GmbH
   board: "92712"
-- company: "92790"
+- company: E&C, Ingenieurbüro für Maschinen- und Anlagenbau GmbH
   board: "92790"
-- company: "92871"
+- company: Xiringuito L'Escora S.L.
   board: "92871"
 - company: Alentis Therapeutics
   board: "92907"
-- company: "92927"
+- company: Kingspan GmbH
   board: "92927"
-- company: "92940"
+- company: Noema Pharma
   board: "92940"
-- company: "92986"
+- company: Create IT
   board: "92986"
-- company: "93083"
+- company: btd Proyectos
   board: "93083"
-- company: "93092"
+- company: Plachetka&Partner SteuerberatungsGmbH
   board: "93092"
-- company: "93207"
+- company: W&W Immo Informatik AG
   board: "93207"
-- company: "93250"
+- company: GRUPOIDEA SERVICIOS VENTA DIRECTA
   board: "93250"
-- company: "93280"
+- company: VERDIFRESH ARANDA
   board: "93280"
 - company: Schafer Assurances SA
   board: "93294"
-- company: "93326"
+- company: ASOCIACIÓN EDAD DORADA MENSAJEROS DE LA PAZ CYL
   board: "93326"
-- company: "93391"
+- company: Eurofloor GmbH
   board: "93391"
 - company: Barzegar Grünbau GmbH
   board: "93468"
 - company: Hotel Hispania
   board: "93571"
-- company: "93659"
+- company: Starrag Service Center GmbH & Co. KG
   board: "93659"
-- company: "93731"
+- company: Topografía Radian
   board: "93731"
-- company: "93742"
+- company: 21bitcoin
   board: "93742"
 - company: CARGO MONTERREY S DE R L DE CV
   board: "93937"
-- company: "94023"
+- company: AMERICAN TECH
   board: "94023"
 - company: Winwinner
   board: "94176"
-- company: "94579"
+- company: Dispa Cedrés, SL
   board: "94579"
-- company: "94584"
+- company: Morgenstern GmbH
   board: "94584"
-- company: "94618"
+- company: SAVE Store Iberia
   board: "94618"
-- company: "94663"
+- company: M&M Handels GmbH
   board: "94663"
-- company: "94724"
+- company: GRUAS SAEZ
   board: "94724"
 - company: Grand Hotel Zell am See
   board: "94808"
-- company: "94938"
+- company: ON-POINT Connect GmbH
   board: "94938"
 - company: Österreichische Provinz
   board: "95110"
-- company: "95191"
+- company: Komet Reisen GesmbH
   board: "95191"
 - company: Group Golden
   board: "95555"
-- company: "95575"
+- company: Niatsu
   board: "95575"
-- company: "95706"
+- company: Weinkellerei P. Meraner GmbH
   board: "95706"
-- company: "95826"
+- company: Easysea srl
   board: "95826"
-- company: "96009"
+- company: Nanke & Partner Versicherungsmakler GmbH
   board: "96009"
 - company: Umbrail Golf Import AG
   board: "96243"
-- company: "96268"
+- company: TTQ de Monterrey
   board: "96268"
-- company: "96273"
+- company: AMPCO Metal Deutschland GmbH
   board: "96273"
-- company: "96284"
+- company: VALORACIÓN Y PERITAJES MÉDICOS
   board: "96284"
 - company: informatica y soporte tecnico reyga s.l.u.
   board: "96307"
-- company: "96323"
+- company: Trudill
   board: "96323"
-- company: "96368"
+- company: ACP Salud
   board: "96368"
-- company: "96728"
+- company: Tecsys GmbH
   board: "96728"
-- company: "96790"
+- company: Bollhalder Systemabdichtungen AG
   board: "96790"
 - company: JENSEN GmbH
   board: "96853"
-- company: "96942"
+- company: Flückiger + Bosshard AG
   board: "96942"
 - company: Al Capone Barbershop
   board: "97080"
 - company: Realbüro Leitner OG
   board: "97117"
-- company: "97185"
+- company: Atempocare
   board: "97185"
-- company: "97217"
+- company: L'Olivera - Masia Can Calopa de Dalt
   board: "97217"
-- company: "97233"
+- company: Demaq Galicia, S.L.U.
   board: "97233"
 - company: Cambridge Examination
   board: "97250"
-- company: "97283"
+- company: Limantecon
   board: "97283"
-- company: "97603"
+- company: OneSecond GmbH
   board: "97603"
-- company: "97658"
+- company: MONTAJES MECANICOS Y PUESTAS EN MARCHA JR, SLU
   board: "97658"
-- company: "97675"
+- company: Finc
   board: "97675"
 - company: Swiss4net Holding AG
   board: "97678"
 - company: XHAUER Media GmbH
   board: "97804"
-- company: "97834"
+- company: Musikinstitut Cantus
   board: "97834"
-- company: "97847"
+- company: ECOMBEAT
   board: "97847"
-- company: "97875"
+- company: Zell Materials GmbH
   board: "97875"
-- company: "98192"
+- company: YOUNG ENTERPRISES MEDIA GMBH
   board: "98192"
-- company: "98219"
+- company: Almacén Frigorífico Dispoll S.A.
   board: "98219"
-- company: "98276"
+- company: CONTRATOS Y DISEÑOS S.A
   board: "98276"
-- company: "98372"
+- company: Visual Fresh Producciones, S.L
   board: "98372"
-- company: "9838"
+- company: Zentrum für Chinesische Medizin
   board: "9838"
-- company: "98481"
+- company: ASOCIACION NUEVO FUTURO
   board: "98481"
 - company: Odne AG
   board: "987"
-- company: "98806"
+- company: acelera Labs
   board: "98806"
-- company: "98980"
+- company: MICLIJOR Group
   board: "98980"
-- company: "99009"
+- company: Mevaco
   board: "99009"
-- company: "99047"
+- company: ARQUEBIO S.L.
   board: "99047"
 - company: ASOCIACION DE PADRES DE PERSONAS CON AUTISMO
   board: "99152"
-- company: "99183"
+- company: SISTEMAS INTEGRALES DE AGUAS RESIDUALES SL
   board: "99183"
 - company: SATECRIS  S.L.
   board: "99193"
@@ -8209,19 +8209,19 @@
   board: "99269"
 - company: PSP gemeinnützige GmbH
   board: "99297"
-- company: "99317"
+- company: IAS Technologies AG
   board: "99317"
-- company: "99336"
+- company: BEHULAN MAQUINARIA, S.L.
   board: "99336"
 - company: UNIPRECIO
   board: "99438"
-- company: "99460"
+- company: Exclusivas Confort Vallés s.l.
   board: "99460"
-- company: "99643"
+- company: JoSchi Hochkar GmbH
   board: "99643"
-- company: "99703"
+- company: LA TRAJERIA
   board: "99703"
-- company: "99734"
+- company: CLÍNICAS VITALFISIO
   board: "99734"
 - company: Elephant Company
   board: 119183


### PR DESCRIPTION
## Summary
- SEO audit flagged that some job pages show the company as a raw internal id (e.g. `175014`) instead of a real name — visible in the page `<title>`, JSON-LD `hiringOrganization.name`, and the UI.
- Root cause: onboarding join.com boards left `company` as the bare numeric join.com company id whenever the harvest never resolved it — 2918 rows in `sources/join.yml` (plus one `bamboohr` straggler at board `415`).
- `companyname.SlugLike` now also flags a bare numeric id (it previously required a letter, so these placeholders were invisible to the existing auto-resolve backfill). `Accept` trusts a resolved name for a numeric id without demanding text overlap with the id — there is none by construction — trusting instead the new `join` resolver's authoritative lookup by that exact id against join.com's own public company-profile API (`GET /api/public/companies/{id}` → `{"name": ...}`).
- Data fix: 2913/2918 join.com boards resolved live and rewritten in `sources/join.yml`; 5 ids 404/410 on join.com's own API (company gone from the platform — left as-is, flagged for a follow-up decision on whether to prune those boards). `bamboohr` board `415` resolved to "415 Group" from its own job description.
- Left un-fixed, flagged for review rather than guessed: `breezy` board `6037` and `bamboohr` board `350` (both dead, 0 jobs), `personio` board `540` (a demo/test tenant, not a real company), `greenhouse` board `1910genetics` (no live confirmation of the full name), `teamtailor` board `500stockholm...` (platform's own registered name is genuinely "500" — may not be a bug at all).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/companyname/... ./cmd/backfill-company-names/...`
- [x] `go run ./cmd/validate-sources sources/` — 203 files OK
- [x] `python3 -c "import yaml; yaml.safe_load(open('sources/join.yml'))"` — still valid YAML after the bulk rewrite
- [x] Spot-checked the original bug report's vacancy (join company id `175014`) now resolves to `Goodweek`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved company name resolution for Join listings using platform profile information.
  - Numeric platform identifiers can now be matched to verified company names.

- **Bug Fixes**
  - Improved ATS board detection for numeric placeholder names.
  - Updated BambooHR’s company display name to “415 Group” while preserving its board identifier.
  - Prevented resolved company names from being incorrectly treated as board identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->