### PR TITLE
Onboard first-party ATS boards via domain-following for echojobs orphans

### DIFF
--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14463,3 +14463,5 @@
   board: sironamedical
 - company: Terakeet
   board: terakeet
+- company: Echo Neurotechnologies
+  board: echo

--- a/sources/jazzhr.yml
+++ b/sources/jazzhr.yml
@@ -8411,3 +8411,5 @@
   board: pearlconsultinggroup
 - company: Quality Consulting Group
   board: qualityconsultinggroup
+- company: Key Capture Energy, LLC
+  board: 20230417161904_8clld49cklrdhnma

--- a/sources/oracle.yml
+++ b/sources/oracle.yml
@@ -1276,3 +1276,13 @@
 # --- from the contribution queue (2026-08-07, live-validated) ---
 - company: PicPay
   board: epdm.fa.la1.oraclecloud.com/PicPay
+- company: Worthington Steel
+  board: cbdt.fa.us2.oraclecloud.com/CX
+- company: Abt Global
+  board: egpy.fa.us2.oraclecloud.com/JoinAbt
+- company: East Tennessee State University
+  board: fa-evyu-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Summit Companies
+  board: fa-exxm-saasfaprod1.fa.ocs.oraclecloud.com/CX_2
+- company: Cheniere Energy
+  board: hcgi.fa.us2.oraclecloud.com/CX_2

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -2121,3 +2121,43 @@
 # link contribution, validated live 2026-08-11
 - company: Lago
   board: lago-1
+- company: AMAX
+  board: amax-1
+- company: C4 Planning Solutions, LLC
+  board: c4-planning-solutions-llc
+- company: CLMI Group, LLC
+  board: clmi-group-llc
+- company: CloudShare
+  board: cloudshare
+- company: Crazy Maple Studio
+  board: crazymaplestudio
+- company: FlowX.AI
+  board: flowxai
+- company: Granite State Manufacturing
+  board: granite-state-manufacturing
+- company: Kids in the Game
+  board: kids-in-the-game
+- company: Meteor Education
+  board: meteor-education
+- company: Nextern
+  board: nextern
+- company: Printfresh LLC
+  board: printfresh
+- company: Procon Consulting
+  board: procon-consulting
+- company: Rimkus
+  board: rimkus
+- company: Rockford
+  board: rockford
+- company: Security Risk Advisors
+  board: securityriskadvisors
+- company: Shift Robotics
+  board: shift-robotics
+- company: Shinesty
+  board: shinesty
+- company: Spartech
+  board: spartech
+- company: Stanbridge University
+  board: stanbridge
+- company: WEBIT Services
+  board: webitservices

--- a/sources/workday.yml
+++ b/sources/workday.yml
@@ -12931,3 +12931,9 @@
   board: materialise.wd103.myworkdayjobs.com/Materialise_Jobs
 
 # link contribution, validated live 2026-08-11
+- company: Impact Advisors
+  board: impactadvisors.wd501.myworkdayjobs.com/impactadvisors
+- company: NextDecade
+  board: nextdecade.wd501.myworkdayjobs.com/GlobalCareers
+- company: Shriners Children's
+  board: shrinerschildrens.wd12.myworkdayjobs.com/Shriners


### PR DESCRIPTION
## Summary
Follow-up to #1884. Of the echojobs-only orphans left after that PR, 329 had a known homepage on file (`companies.company_info->>'homepage'`). Ran the existing domain-following harvest (`cmd/harvest-ats resolve`) against them — follows each company's own site to its careers page and reads the ATS link actually embedded there, instead of guessing a board slug from the company name.

- 30 new boards across 5 providers: workable +20, workday +3, oracle +5, greenhouse +1, jazzhr +1.
- Notably reaches **workday** and **oracle** — tenant-id-keyed platforms `harvest-boards`' name-guessing can never seed (see #1884's exclusion list). This is the first time this batch of orphans got tried against those platforms at all.

## Notable findings
- All 6 smartrecruiters candidates this run surfaced were the same case-variant duplicate bug as #1884 (`harvest-boards`' existing-board dedup compares board ids as exact strings) — dropped before commit, zero net new smartrecruiters boards here.
- `jibe`, `radancy`, `rippling` also got detected as ATS links on 3 more candidate sites (9 boards total) but `harvest-boards` has no prober for those providers yet, so they're unvalidated and left out of this PR.

## Test plan
- [x] `go run ./cmd/validate-sources` passes.
- [x] Reviewed the diff for each provider file.
- [ ] Re-ingest the 5 touched board files and confirm first-party postings land (same as #1884's step 3).

Part of #1761, #1758.