### PR TITLE
Estimate JobPosting validThrough for open jobs instead of omitting it

### DIFF
--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -106,6 +106,10 @@ type Fields struct {
 	EnrichedAt    *time.Time
 	CreatedAt     *time.Time
 	UpdatedAt     *time.Time
+	// LastSeenAt is when a re-crawl last confirmed this posting still live (see
+	// docs/agents/job-lifecycle.md) — the freshest "still open" evidence available
+	// for an open job, used to estimate a rolling JobPosting.validThrough.
+	LastSeenAt *time.Time
 }
 
 // Job is the domain aggregate. Its state is unexported: the only ways to obtain a

--- a/internal/job/repository.go
+++ b/internal/job/repository.go
@@ -88,6 +88,7 @@ func jobFromRow(r db.Job) (Job, error) {
 		EnrichedAt:    tsPtr(r.EnrichedAt),
 		CreatedAt:     tsPtr(r.CreatedAt),
 		UpdatedAt:     tsPtr(r.UpdatedAt),
+		LastSeenAt:    tsPtr(r.LastSeenAt),
 	}}, nil
 }
 

--- a/internal/jobview/fromdomain_test.go
+++ b/internal/jobview/fromdomain_test.go
@@ -50,7 +50,7 @@ func TestFromDomain_MatchesFrozenWireShape(t *testing.T) {
 				PostedAt:  ts(2026, 1, 1), CreatedAt: ts(2026, 1, 1), UpdatedAt: ts(2026, 1, 2),
 				ViewCount: 4, AppliedCount: 2,
 			},
-			want: `{"public_slug":"senior-go-developer-acme-1","source":"greenhouse","manually_added":true,"external_id":"acme:1","url":"http://x.test?utm_source=freehire.me","title":"Senior Go Developer","company":"Acme","company_slug":"acme","location":"Berlin, Germany","description":"","countries":["de"],"regions":[],"work_mode":"onsite","skills":["go","postgresql"],"cities":["Berlin"],"collections":["bigtech","yc"],"posted_at":"2026-01-01T00:00:00Z","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-02T00:00:00Z","closed_at":null,"enrichment":{"summary":"Great role","employment_type":"full_time","salary_min":100000,"salary_currency":"EUR","seniority":"senior","experience_years_min":5,"english_level":"c1","education_level":"bachelor","category":"backend","posting_language":"en"},"enriched_at":"2026-01-03T00:00:00Z","enrichment_version":1,"view_count":4,"applied_count":2,"upvote_count":0,"downvote_count":0,"my_vote":0}`,
+			want: `{"public_slug":"senior-go-developer-acme-1","source":"greenhouse","manually_added":true,"external_id":"acme:1","url":"http://x.test?utm_source=freehire.me","title":"Senior Go Developer","company":"Acme","company_slug":"acme","location":"Berlin, Germany","description":"","countries":["de"],"regions":[],"work_mode":"onsite","skills":["go","postgresql"],"cities":["Berlin"],"collections":["bigtech","yc"],"posted_at":"2026-01-01T00:00:00Z","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-02T00:00:00Z","last_seen_at":null,"closed_at":null,"enrichment":{"summary":"Great role","employment_type":"full_time","salary_min":100000,"salary_currency":"EUR","seniority":"senior","experience_years_min":5,"english_level":"c1","education_level":"bachelor","category":"backend","posting_language":"en"},"enriched_at":"2026-01-03T00:00:00Z","enrichment_version":1,"view_count":4,"applied_count":2,"upvote_count":0,"downvote_count":0,"my_vote":0}`,
 		},
 		"unenriched, empty facets": {
 			row: db.Job{
@@ -58,7 +58,7 @@ func TestFromDomain_MatchesFrozenWireShape(t *testing.T) {
 				Company: "Beta", CompanySlug: "beta", PublicSlug: "engineer-beta-2",
 				CreatedAt: ts(2026, 1, 5),
 			},
-			want: `{"public_slug":"engineer-beta-2","source":"lever","manually_added":false,"external_id":"beta:2","url":"","title":"Engineer","company":"Beta","company_slug":"beta","location":"","description":"","countries":[],"regions":[],"skills":[],"cities":[],"collections":[],"posted_at":"2026-01-05T00:00:00Z","created_at":"2026-01-05T00:00:00Z","updated_at":null,"closed_at":null,"enrichment":{},"enriched_at":null,"enrichment_version":0,"view_count":0,"applied_count":0,"upvote_count":0,"downvote_count":0,"my_vote":0}`,
+			want: `{"public_slug":"engineer-beta-2","source":"lever","manually_added":false,"external_id":"beta:2","url":"","title":"Engineer","company":"Beta","company_slug":"beta","location":"","description":"","countries":[],"regions":[],"skills":[],"cities":[],"collections":[],"posted_at":"2026-01-05T00:00:00Z","created_at":"2026-01-05T00:00:00Z","updated_at":null,"last_seen_at":null,"closed_at":null,"enrichment":{},"enriched_at":null,"enrichment_version":0,"view_count":0,"applied_count":0,"upvote_count":0,"downvote_count":0,"my_vote":0}`,
 		},
 		"closed posting": {
 			row: db.Job{
@@ -66,7 +66,7 @@ func TestFromDomain_MatchesFrozenWireShape(t *testing.T) {
 				CompanySlug: "gamma", PublicSlug: "dev-gamma-3",
 				CreatedAt: ts(2026, 1, 4), ClosedAt: ts(2026, 2, 1),
 			},
-			want: `{"public_slug":"dev-gamma-3","source":"ashby","manually_added":false,"external_id":"g:3","url":"","title":"Dev","company":"Gamma","company_slug":"gamma","location":"","description":"","countries":[],"regions":[],"skills":[],"cities":[],"collections":[],"posted_at":"2026-01-04T00:00:00Z","created_at":"2026-01-04T00:00:00Z","updated_at":null,"closed_at":"2026-02-01T00:00:00Z","enrichment":{},"enriched_at":null,"enrichment_version":0,"view_count":0,"applied_count":0,"upvote_count":0,"downvote_count":0,"my_vote":0}`,
+			want: `{"public_slug":"dev-gamma-3","source":"ashby","manually_added":false,"external_id":"g:3","url":"","title":"Dev","company":"Gamma","company_slug":"gamma","location":"","description":"","countries":[],"regions":[],"skills":[],"cities":[],"collections":[],"posted_at":"2026-01-04T00:00:00Z","created_at":"2026-01-04T00:00:00Z","updated_at":null,"last_seen_at":null,"closed_at":"2026-02-01T00:00:00Z","enrichment":{},"enriched_at":null,"enrichment_version":0,"view_count":0,"applied_count":0,"upvote_count":0,"downvote_count":0,"my_vote":0}`,
 		},
 		"geo hybrid: dict unpinned, LLM restricts": {
 			row: db.Job{
@@ -77,7 +77,7 @@ func TestFromDomain_MatchesFrozenWireShape(t *testing.T) {
 				Enrichment: json.RawMessage(`{"countries":["es"],"regions":["europe"]}`),
 				CreatedAt:  ts(2026, 1, 6),
 			},
-			want: `{"public_slug":"remote-dev-delta-4","source":"manual","manually_added":false,"external_id":"d:4","url":"","title":"Remote Dev","company":"Delta","company_slug":"delta","location":"","description":"","countries":["es"],"regions":["europe"],"work_mode":"remote","skills":[],"cities":[],"collections":[],"posted_at":"2026-01-06T00:00:00Z","created_at":"2026-01-06T00:00:00Z","updated_at":null,"closed_at":null,"enrichment":{},"enriched_at":null,"enrichment_version":0,"view_count":0,"applied_count":0,"upvote_count":0,"downvote_count":0,"my_vote":0}`,
+			want: `{"public_slug":"remote-dev-delta-4","source":"manual","manually_added":false,"external_id":"d:4","url":"","title":"Remote Dev","company":"Delta","company_slug":"delta","location":"","description":"","countries":["es"],"regions":["europe"],"work_mode":"remote","skills":[],"cities":[],"collections":[],"posted_at":"2026-01-06T00:00:00Z","created_at":"2026-01-06T00:00:00Z","updated_at":null,"last_seen_at":null,"closed_at":null,"enrichment":{},"enriched_at":null,"enrichment_version":0,"view_count":0,"applied_count":0,"upvote_count":0,"downvote_count":0,"my_vote":0}`,
 		},
 	}
 

--- a/internal/jobview/jobview.go
+++ b/internal/jobview/jobview.go
@@ -78,6 +78,11 @@ type Job struct {
 	PostedAt  *string `json:"posted_at"`
 	CreatedAt *string `json:"created_at"`
 	UpdatedAt *string `json:"updated_at"`
+	// LastSeenAt is when a re-crawl last confirmed this posting still live — see
+	// docs/agents/job-lifecycle.md. The SPA uses it to estimate a rolling
+	// JobPosting.validThrough for an open job (seo.ts), since most sources carry
+	// no real listing-expiry date of their own.
+	LastSeenAt *string `json:"last_seen_at"`
 	// ClosedAt is non-null when the posting is no longer open. Lists and the
 	// search index never contain closed jobs; only the detail endpoint serves
 	// them, and the SPA renders the closed state from this field.
@@ -181,6 +186,7 @@ func FromDomain(j job.Job, x job.Extras) (Job, error) {
 		PostedAt:          rfc3339Ptr(effectivePosted(f.PostedAt, f.CreatedAt, now)),
 		CreatedAt:         rfc3339Ptr(f.CreatedAt),
 		UpdatedAt:         rfc3339Ptr(f.UpdatedAt),
+		LastSeenAt:        rfc3339Ptr(f.LastSeenAt),
 		ClosedAt:          rfc3339Ptr(f.ClosedAt),
 		Enrichment:        e,
 		EnrichedAt:        rfc3339Ptr(f.EnrichedAt),

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -205,6 +205,13 @@ export interface Job {
   created_at?: string;
   updated_at?: string;
   /**
+   * LastSeenAt is when a re-crawl last confirmed this posting still live — see
+   * docs/agents/job-lifecycle.md. The SPA uses it to estimate a rolling
+   * JobPosting.validThrough for an open job (seo.ts), since most sources carry
+   * no real listing-expiry date of their own.
+   */
+  last_seen_at?: string;
+  /**
    * ClosedAt is non-null when the posting is no longer open. Lists and the
    * search index never contain closed jobs; only the detail endpoint serves
    * them, and the SPA renders the closed state from this field.

--- a/web/src/lib/seo.test.ts
+++ b/web/src/lib/seo.test.ts
@@ -271,6 +271,34 @@ describe('jobPostingJsonLd', () => {
     const ld = jobPostingJsonLd(postingJob({ external_id: ':https://x.dev/jobs/1' }), ORIGIN);
     expect((ld.identifier as Record<string, unknown>).value).toBe('https://x.dev/jobs/1');
   });
+
+  it('sets validThrough to the close time for a closed posting', () => {
+    const ld = jobPostingJsonLd(
+      postingJob({ closed_at: '2026-02-01T00:00:00Z', last_seen_at: '2026-01-30T00:00:00Z' }),
+      ORIGIN
+    );
+    expect(ld.validThrough).toBe('2026-02-01T00:00:00Z');
+  });
+
+  it('estimates validThrough 30 days out from last_seen_at for an open posting', () => {
+    const ld = jobPostingJsonLd(postingJob({ last_seen_at: '2026-01-01T00:00:00Z' }), ORIGIN);
+    expect(ld.validThrough).toBe('2026-01-31T00:00:00.000Z');
+  });
+
+  it('falls back to posted_at, then created_at, when last_seen_at is absent', () => {
+    const byPosted = jobPostingJsonLd(
+      postingJob({ posted_at: '2026-01-01T00:00:00Z', created_at: '2025-01-01T00:00:00Z' }),
+      ORIGIN
+    );
+    expect(byPosted.validThrough).toBe('2026-01-31T00:00:00.000Z');
+
+    const byCreated = jobPostingJsonLd(postingJob({ created_at: '2026-01-01T00:00:00Z' }), ORIGIN);
+    expect(byCreated.validThrough).toBe('2026-01-31T00:00:00.000Z');
+  });
+
+  it('omits validThrough for an open posting with no date evidence at all', () => {
+    expect(jobPostingJsonLd(postingJob(), ORIGIN)).not.toHaveProperty('validThrough');
+  });
 });
 
 describe('collectionPageJsonLd', () => {

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -127,9 +127,33 @@ const EDUCATION_CREDENTIAL: Record<string, string> = {
   phd: 'postgraduate degree',
 };
 
+// Days added on top of the freshest "still open" evidence to estimate how much
+// longer an open posting is likely valid. Most sources carry no real listing-
+// expiry date, and without validThrough Google assumes one itself (~30 days)
+// and drops the posting from Google Jobs even while it's still open — this
+// buffer matches that default, but keeps rolling forward on every recrawl
+// instead of freezing at first sight. Comfortably above the 48h unseen-sweep
+// grace (docs/agents/job-lifecycle.md) so an ordinary recrawl gap never reads
+// as expired.
+const VALID_THROUGH_BUFFER_DAYS = 30;
+
+/** Estimated validThrough for an OPEN job: the freshest "still open" evidence
+ *  (last_seen_at, falling back to the posting date for a job never re-crawled,
+ *  e.g. a manual import) plus the buffer above. undefined when there's no date
+ *  to estimate from at all. */
+function estimatedValidThrough(job: Job): string | undefined {
+  const evidence = job.last_seen_at ?? job.posted_at ?? job.created_at;
+  if (!evidence) return undefined;
+  const d = new Date(evidence);
+  d.setUTCDate(d.getUTCDate() + VALID_THROUGH_BUFFER_DAYS);
+  return d.toISOString();
+}
+
 /** schema.org JobPosting for a job-detail page, eligible for Google Jobs. A
  *  closed posting sets `validThrough` to its close time so it reads as expired,
- *  not open. `origin` is the absolute site origin (e.g. https://freehire.me). */
+ *  not open; an open one gets a rolling estimate (see estimatedValidThrough) so
+ *  Google doesn't apply its own ~30-day default and drop it while still live.
+ *  `origin` is the absolute site origin (e.g. https://freehire.me). */
 export function jobPostingJsonLd(job: Job, origin: string): Record<string, unknown> {
   const e = job.enrichment ?? {};
   // Our logo proxy resolves a logo from the company name (404s for unknown
@@ -153,8 +177,15 @@ export function jobPostingJsonLd(job: Job, origin: string): Record<string, unkno
   // so fall back to created_at (the ingest time; always set) rather than omit it.
   const datePosted = job.posted_at ?? job.created_at;
   if (datePosted) ld.datePosted = datePosted;
-  // A closed posting is no longer accepting applications: mark it expired.
-  if (job.closed_at) ld.validThrough = job.closed_at;
+  // A closed posting is no longer accepting applications: mark it expired. An
+  // open one gets a rolling estimate instead of nothing, so Google doesn't
+  // apply its own default expiry assumption to a posting that's still live.
+  if (job.closed_at) {
+    ld.validThrough = job.closed_at;
+  } else {
+    const validThrough = estimatedValidThrough(job);
+    if (validThrough) ld.validThrough = validThrough;
+  }
 
   // identifier is the hiring org's own posting id (Google-recommended): external_id
   // is the source's stable job id, so Google dedupes the vacancy across boards


### PR DESCRIPTION
## Summary
- SEO audit finding (High priority, ~15k URLs in sitemap-jobs.xml): `validThrough` was `null` on every open posting's `JobPosting` JSON-LD. Without it, Google assumes its own ~30-day default and drops the listing from Google for Jobs rich results even while it's genuinely still open — the audit called this the single highest-leverage fix for Google for Jobs traffic.
- Most ATS sources carry no real listing-expiry date, but `jobs.last_seen_at` (stamped on every recrawl that confirms a posting is still live — see `docs/agents/job-lifecycle.md`) was already tracked in Postgres and simply never reached the public wire shape.
- Threaded `LastSeenAt` through `job.Fields` → `jobview.Job` (`last_seen_at`, regenerated in `contracts.ts`) → `seo.ts`, which now estimates `validThrough` as `last_seen_at + 30 days` for an open job (falling back to `posted_at`/`created_at` when a job has never been re-crawled, e.g. a manual import).
- The estimate rolls forward on every recrawl instead of freezing at first sight, and the 30-day buffer sits comfortably above the 48h unseen-sweep grace so an ordinary recrawl gap never makes a live posting read as expired. A closed job is unaffected — `validThrough` still comes from `closed_at`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`
- [x] Updated the frozen wire-shape golden fixtures in `internal/jobview/fromdomain_test.go` for the new field
- [x] `go run ./cmd/gen-contracts` — regenerated `contracts.ts`, diff reviewed
- [x] New `seo.test.ts` cases: closed posting still uses `closed_at`; open posting estimates from `last_seen_at`; falls back to `posted_at`/`created_at`; omits the field entirely when there's no date evidence at all
- [x] `pnpm vitest run` — 949/949 passing
- [x] `pnpm run check` (svelte-check) — 0 errors