### PR TITLE
harvest-boards: fold case in SmartRecruiters dedup, reject non-numeric apploi slugs

### DIFF
--- a/cmd/harvest-boards/boardfile_test.go
+++ b/cmd/harvest-boards/boardfile_test.go
@@ -50,6 +50,12 @@ func TestDedupKeyOf(t *testing.T) {
 	if dedupKeyOf(ashbyProber{})("Ramp") != "ramp" {
 		t.Error("ashby key must fold case")
 	}
+	// SmartRecruiters' postings API is case-insensitive too (confirmed live twice, #1884/#1888:
+	// a name-derived candidate slipped past dedup because it only differed in case from an
+	// existing board), so the dedup key folds case like the others.
+	if dedupKeyOf(smartRecruitersProber{})("ArchirodonGroup") != "archirodongroup" {
+		t.Error("smartrecruiters key must fold case")
+	}
 }
 
 func TestWorkdayBoardID(t *testing.T) {

--- a/cmd/harvest-boards/prober.go
+++ b/cmd/harvest-boards/prober.go
@@ -429,6 +429,12 @@ func (smartRecruitersProber) probe(ctx context.Context, c httpClient, slug strin
 	return meta.Name, n, nil
 }
 
+// dedupKey folds a SmartRecruiters board id to lower case, like Workday's, Greenhouse's and
+// Ashby's. Without this, a name-derived candidate that only differs in case from an existing
+// entry (e.g. "archirodongroup" vs the stored "ArchirodonGroup") reads as new — confirmed live
+// twice (see #1884, #1888) — even though SmartRecruiters' API treats the two identically.
+func (smartRecruitersProber) dedupKey(boardID string) string { return strings.ToLower(boardID) }
+
 // recruiteeProber probes the Recruitee per-subdomain offers API. A non-empty offers array is
 // a live board, and each offer carries the employer's own name, so the board can be gated
 // against the name the seed expected rather than accepted on liveness alone.
@@ -812,7 +818,18 @@ func (p isolvedProber) probe(ctx context.Context, c httpClient, slug string) (st
 // postings means a live board. The employer name comes from the seed.
 type apploiProber struct{}
 
+// apploiNumericSlugRE matches apploi's own employer-id shape: digits only. A name-derived
+// candidate (e.g. "101-edu") is never a valid employer id, but api.apploi.com doesn't error on
+// one — it silently ignores an `employer` value it can't parse and answers with a non-empty,
+// "live" jobs list regardless. Fed a 5,216-candidate name-derived seed, that read as a 100%
+// hit rate (confirmed live — see #1884). Reject non-numeric slugs up front rather than trust
+// the API to say no.
+var apploiNumericSlugRE = regexp.MustCompile(`^\d+$`)
+
 func (apploiProber) probe(ctx context.Context, c httpClient, slug string) (string, int, error) {
+	if !apploiNumericSlugRE.MatchString(slug) {
+		return "", 0, nil
+	}
 	var resp struct {
 		Data []struct {
 			Published bool `json:"published"`

--- a/cmd/harvest-boards/prober_test.go
+++ b/cmd/harvest-boards/prober_test.go
@@ -416,3 +416,28 @@ func TestNameReportingProbers(t *testing.T) {
 		}
 	})
 }
+
+// TestApploiProberRejectsNonNumericSlug guards the fix for a confirmed live false-positive
+// (see #1884): api.apploi.com/v1/jobs?employer=<slug> answers a non-empty, "live" jobs list
+// even when slug isn't a real employer id — it silently ignores a value it can't parse. The
+// canned response below WOULD read as a live board if the guard were missing and the request
+// went out at all, so this test fails loudly if the numeric-slug check regresses.
+func TestApploiProberRejectsNonNumericSlug(t *testing.T) {
+	getter := fakeGetter{
+		"https://api.apploi.com/v1/jobs?employer=101-edu&limit=100": `{"data":[{"published":true,"archived":false}]}`,
+	}
+	if _, n, err := (apploiProber{}).probe(context.Background(), getter, "101-edu"); err != nil || n != 0 {
+		t.Errorf("got (%d,%v), want (0,nil) for a non-numeric slug", n, err)
+	}
+}
+
+// TestApploiProberAcceptsNumericSlug confirms the guard doesn't also reject apploi's real
+// board-id shape.
+func TestApploiProberAcceptsNumericSlug(t *testing.T) {
+	getter := fakeGetter{
+		"https://api.apploi.com/v1/jobs?employer=55591&limit=100": `{"data":[{"published":true,"archived":false},{"published":false,"archived":true}]}`,
+	}
+	if _, n, err := (apploiProber{}).probe(context.Background(), getter, "55591"); err != nil || n != 1 {
+		t.Errorf("got (%d,%v), want (1,nil) for a numeric slug", n, err)
+	}
+}


### PR DESCRIPTION
## Summary
Two dev-tool bugs surfaced live while onboarding echojobs orphan companies (#1884, #1888):

- **SmartRecruiters dedup was case-sensitive.** Greenhouse/Ashby/Workday already fold board-id case before comparing against existing entries; SmartRecruiters didn't, so a name-derived candidate differing only in case from an already-onboarded board (`archirodongroup` vs the stored `ArchirodonGroup`) read as new and got appended. Happened twice — 14 duplicates in #1884, 6 more in #1888 — caught both times by CI's `validate-sources` and dropped by hand before merge. Now `smartRecruitersProber` implements `dedupKey` like the other three.
- **apploi's prober trusted a slug it shouldn't have.** Its own doc comment says board = numeric employer id, but nothing enforced that — fed a name-derived candidate, `api.apploi.com/v1/jobs?employer=<slug>` silently ignores a value it can't parse and answers a non-empty "live" jobs list regardless. A 5,216-candidate name-derived seed read as a **100% hit rate**, confirmed live and reverted before commit in #1884 (never reached prod). Now rejects any non-numeric slug before making the request.

## Test plan
- [x] `go test ./cmd/harvest-boards/...`
- [x] New tests: `TestDedupKeyOf` extended for smartrecruiters; `TestApploiProberRejectsNonNumericSlug` / `TestApploiProberAcceptsNumericSlug` added — the reject test uses a canned response that WOULD read as a live board if the guard regressed, so it fails loudly rather than passing vacuously.
- [x] `go vet ./...`, `gofmt -l .` clean.

Follow-up from #1761/#1758.