### PR TITLE
Give screening answers its own tab on the profile page

### DIFF
--- a/web/src/routes/my/profile/+page.svelte
+++ b/web/src/routes/my/profile/+page.svelte
@@ -51,13 +51,14 @@
   // referenced by an id the strip doesn't offer.
   const TABS = [
     { id: 'settings', label: 'Settings' },
+    { id: 'screening', label: 'Screening answers' },
     { id: 'skills', label: 'Skills' },
     { id: 'structured', label: 'Profile' },
     { id: 'experience', label: 'Experience' },
     { id: 'readiness', label: 'CV readiness' },
   ] as const;
   const PANEL_ID = 'profile-panel';
-  let tab = $state<'settings' | 'skills' | 'structured' | 'experience' | 'readiness'>('settings');
+  let tab = $state<'settings' | 'screening' | 'skills' | 'structured' | 'experience' | 'readiness'>('settings');
   let modalOpen = $state(false);
   let actionError = $state<string | null>(null);
 
@@ -358,12 +359,6 @@
           {#key profile.updated_at}
             <ProfileForm {profile} {hasCv} onSaved={handleSaved} onCvUploaded={handleCvUploaded} />
           {/key}
-          <!-- Screening answers: a separate concern from the role/skills profile above
-               (facts the candidate states directly, not a targeting profile) — its own
-               heading and its own save action. The component re-seeds its own fields from
-               `answers` on reload (dirty-guarded, same pattern as CandidateContactsEditor),
-               since there is no single identity field here to key a remount on. -->
-          <ScreeningAnswersForm answers={screeningAnswers} onSaved={() => void loadScreeningAnswers()} />
           <!-- Destructive actions live at the foot of the settings tab, out of
                the page header (where they crowded the title on narrow viewports) and
                off the other tabs, which are readings of the market, not account
@@ -380,6 +375,15 @@
             </Button>
             <DeleteAccountButton />
           </div>
+        {:else if tab === 'screening'}
+          <!-- Screening answers: a separate concern from the role/skills profile
+               (facts the candidate states directly, not a targeting profile), and its own
+               tab rather than a section of Settings — the six fields plus the assistant/
+               autofill wiring behind them earn their own place in the nav. The component
+               re-seeds its own fields from `answers` on reload (dirty-guarded, same pattern
+               as CandidateContactsEditor), since there is no single identity field here to
+               key a remount on. -->
+          <ScreeningAnswersForm answers={screeningAnswers} onSaved={() => void loadScreeningAnswers()} />
         {:else if tab === 'skills'}
           <SkillsView />
         {:else if tab === 'structured'}


### PR DESCRIPTION
## Summary
- Follow-up to #1889: moves the "Screening answers" section out from under the Settings tab into its own top-level tab on `/my/profile` (Settings, **Screening answers**, Skills, Profile, Experience, CV readiness).
- No data/API changes — same component, same `GET`/`PUT /me/screening-answers` wiring, just a different place in the nav.

## Test plan
- [x] `pnpm run check` — 0 errors
- [x] Live browser check against a local backend: new tab renders in the strip, clicking it shows the section with the correct heading and fields, Settings tab no longer carries it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added a dedicated **Screening** tab to the profile page.
  * Moved screening questions into the new tab for easier access.
  * Simplified the **Settings** tab to focus on profile details and account actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->