### PR TITLE
Cut meta description at the last whole word, default to ~160 chars

### DIFF
--- a/web/src/lib/seo.test.ts
+++ b/web/src/lib/seo.test.ts
@@ -8,6 +8,7 @@ import {
   datasetJsonLd,
   jobListItems,
   jobPostingJsonLd,
+  metaDescription,
   organizationJsonLd,
 } from './seo';
 import { companyLogoUrl } from './logo';
@@ -49,6 +50,27 @@ function company(overrides: Partial<Company> = {}): Company {
 }
 
 const ORIGIN = 'https://freehire.me';
+
+describe('metaDescription', () => {
+  it('strips tags and collapses whitespace without truncating short text', () => {
+    expect(metaDescription('<p>Build  <b>great</b>\nthings.</p>')).toBe('Build great things.');
+  });
+
+  it('defaults to ~160 chars and cuts at the last whole word, not mid-word', () => {
+    const word = 'lorem ';
+    const text = word.repeat(40).trim(); // well past 160 chars, all whole words
+    const got = metaDescription(text);
+    expect(got.length).toBeLessThanOrEqual(160);
+    expect(got.endsWith('…')).toBe(true);
+    expect(got.slice(0, -1).endsWith(' ')).toBe(false); // cut, not a trailing space before the ellipsis
+    expect(text.startsWith(got.slice(0, -1))).toBe(true); // the kept prefix is whole words of the source
+  });
+
+  it('respects an explicit max, e.g. the 220-char list-card budget', () => {
+    const text = 'a'.repeat(300);
+    expect(metaDescription(text, 220)).toBe(`${'a'.repeat(219)}…`); // no spaces to cut at: falls back to a hard cut
+  });
+});
 
 describe('collectionHeading', () => {
   it('includes the exact live count, comma-grouped', () => {

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -18,14 +18,20 @@ const SITE_GITHUB = 'https://github.com/strelov1/freehire';
 export type FaqItem = { question: string; answer: string };
 
 /** Plain-text, length-capped description for `<meta name="description">` and OG,
- *  derived from the job's sanitized HTML body. */
-export function metaDescription(html: string, max = 200): string {
+ *  derived from the job's sanitized HTML body. Cuts at the last whole word within
+ *  the budget rather than mid-word, and defaults to ~155-160 chars — Google's own
+ *  typical search-snippet width, beyond which it truncates the snippet itself and
+ *  we lose control of where the cut lands. */
+export function metaDescription(html: string, max = 160): string {
   const text = html
     .replace(/<[^>]*>/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
   if (text.length <= max) return text;
-  return `${text.slice(0, max - 1).trimEnd()}…`;
+  const cut = text.slice(0, max - 1);
+  const lastSpace = cut.lastIndexOf(' ');
+  const truncated = lastSpace > 0 ? cut.slice(0, lastSpace) : cut;
+  return `${truncated.trimEnd()}…`;
 }
 
 /** Plain-text, length-capped `<meta name="description">` for a company page.


### PR DESCRIPTION
## Summary
- SEO audit finding (Low-Medium): the job detail page's `<meta name="description">` was built from the raw job description via `metaDescription()` at its 200-char default, which cut mid-word — losing control over exactly where the search-result snippet breaks, and running past Google's typical ~155-160 char snippet width anyway.
- `metaDescription()` now defaults to 160 chars and, when truncating, backs up to the last whole word within budget before appending the ellipsis (falls back to a hard cut only when there's no space to back up to, e.g. one long unbroken token).
- The list-card call site's explicit 220-char budget (`JobRow.svelte`) is untouched by the default change and picks up the same word-boundary improvement for free.

This is one of three remaining items from the same SEO audit (validThrough already shipped in #1890, company-name-as-id in #1887). The other two — `baseSalary`/`employmentType` — turned out to need a product-policy call rather than a code fix; tracked separately.

## Test plan
- [x] New `metaDescription` test cases: strips tags/whitespace without truncating short text; defaults to ~160 chars and cuts at a whole word; respects an explicit `max` (220) and falls back to a hard cut when there's no space to back up to
- [x] `pnpm vitest run` — 952/952 passing
- [x] `pnpm run check` (svelte-check) — 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SEO meta descriptions by removing HTML and normalizing whitespace.
  * Limited default descriptions to 160 characters, truncating at complete words with an ellipsis.
  * Added support for explicit maximum lengths with hard truncation when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->