### PR TITLE
Read Greenhouse's employer-configured Employment Type metadata field

### DIFF
--- a/internal/sources/greenhouse.go
+++ b/internal/sources/greenhouse.go
@@ -2,9 +2,11 @@ package sources
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"html"
 	"strconv"
+	"strings"
 )
 
 // greenhouseBaseURL is the Greenhouse public boards API root. Unlike Lever, Greenhouse
@@ -58,6 +60,20 @@ type GreenhousePosting struct {
 	Location    struct {
 		Name string `json:"name"`
 	} `json:"location"`
+	// Metadata carries the employer's own custom application-question fields — most
+	// boards set none (null), some carry unrelated ones ("Headcount #"), and a minority
+	// configure an "Employment Type" field read by greenhouseMetadataEmploymentType.
+	Metadata []GreenhouseMetadataField `json:"metadata"`
+}
+
+// GreenhouseMetadataField is one employer-configured custom field on a posting.
+// Value is decoded lazily (raw JSON) because it varies by field: a plain string for
+// a single_select/short_text field, null when unset, or an empty array for an unset
+// multi-select — greenhouseMetadataEmploymentType treats every shape but "a string"
+// as absent rather than guessing.
+type GreenhouseMetadataField struct {
+	Name  string          `json:"name"`
+	Value json.RawMessage `json:"value"`
 }
 
 // MapGreenhousePosting maps a Greenhouse boards-API posting into a Job, so the board
@@ -68,11 +84,53 @@ type GreenhousePosting struct {
 // can point at a board the crawl config does not list).
 func MapGreenhousePosting(j GreenhousePosting) Job {
 	return Job{
-		URL:         j.AbsoluteURL,
-		Title:       j.Title,
-		Location:    j.Location.Name,
-		Description: sanitizeHTML(html.UnescapeString(j.Content)),
-		Remote:      isRemote(j.Location.Name),
-		PostedAt:    parseRFC3339(j.UpdatedAt),
+		URL:            j.AbsoluteURL,
+		Title:          j.Title,
+		Location:       j.Location.Name,
+		Description:    sanitizeHTML(html.UnescapeString(j.Content)),
+		Remote:         isRemote(j.Location.Name),
+		PostedAt:       parseRFC3339(j.UpdatedAt),
+		EmploymentType: greenhouseMetadataEmploymentType(j.Metadata),
+	}
+}
+
+// greenhouseMetadataEmploymentType reads the employer-configured "Employment Type"
+// custom field a minority of Greenhouse boards carry (confirmed live: 1800contacts,
+// solidpower, carrotfertility all set it to "Full-time") — a genuine structured
+// signal, not a free-text guess: the employer explicitly labeled and typed this
+// value, the same trust level as Lever's commitment or SmartRecruiters'
+// typeOfEmployment. Most boards carry no such field at all.
+func greenhouseMetadataEmploymentType(metadata []GreenhouseMetadataField) string {
+	for _, m := range metadata {
+		if !strings.EqualFold(strings.TrimSpace(m.Name), "Employment Type") {
+			continue
+		}
+		var value string
+		if json.Unmarshal(m.Value, &value) != nil {
+			return "" // null, an empty array (unset multi-select), or another shape
+		}
+		return greenhouseEmploymentType(value)
+	}
+	return ""
+}
+
+// greenhouseEmploymentType maps the "Employment Type" field's free-text value (e.g.
+// "Full-time", "Part-Time", "1099 Contractor") onto the freehire vocabulary via
+// keyword containment — the same style as leverEmploymentType, since the field is
+// employer-typed free text, not a fixed enum. "" for an unrecognized value, so the
+// description parser decides rather than a guess here.
+func greenhouseEmploymentType(value string) string {
+	v := strings.ToLower(value)
+	switch {
+	case strings.Contains(v, "intern"):
+		return "internship"
+	case strings.Contains(v, "part-time") || strings.Contains(v, "part time"):
+		return "part_time"
+	case strings.Contains(v, "full-time") || strings.Contains(v, "full time"):
+		return "full_time"
+	case strings.Contains(v, "contract") || strings.Contains(v, "temporary") || strings.Contains(v, "seasonal"):
+		return "contract"
+	default:
+		return ""
 	}
 }

--- a/internal/sources/greenhouse_test.go
+++ b/internal/sources/greenhouse_test.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -97,5 +98,76 @@ func TestGreenhouseFetch(t *testing.T) {
 	}
 	if j.PostedAt == nil {
 		t.Error("PostedAt = nil, want parsed updated_at")
+	}
+}
+
+// Live-verified shapes (2026-08-13): 1800contacts/solidpower/carrotfertility all
+// carry an "Employment Type" metadata field; coherentsolutions carries one with an
+// empty-array value (unset); most boards (e.g. 1910genetics) carry metadata: null.
+func TestGreenhouseMetadataEmploymentType(t *testing.T) {
+	cases := []struct {
+		name     string
+		metadata []GreenhouseMetadataField
+		want     string
+	}{
+		{"no metadata field", nil, ""},
+		{
+			"unrelated field only",
+			[]GreenhouseMetadataField{{Name: "Headcount #", Value: json.RawMessage(`null`)}},
+			"",
+		},
+		{
+			"Full-time value",
+			[]GreenhouseMetadataField{{Name: "Employment Type", Value: json.RawMessage(`"Full-time"`)}},
+			"full_time",
+		},
+		{
+			"case/whitespace-insensitive field name",
+			[]GreenhouseMetadataField{{Name: " employment type ", Value: json.RawMessage(`"Part-Time"`)}},
+			"part_time",
+		},
+		{
+			"empty-array value (unset multi-select) reads as absent",
+			[]GreenhouseMetadataField{{Name: "Employment Type", Value: json.RawMessage(`[]`)}},
+			"",
+		},
+		{
+			"unrecognized value maps to empty, not a guess",
+			[]GreenhouseMetadataField{{Name: "Employment Type", Value: json.RawMessage(`"Variable Hour"`)}},
+			"",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := greenhouseMetadataEmploymentType(c.metadata); got != c.want {
+				t.Errorf("greenhouseMetadataEmploymentType() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestGreenhouseFetchReadsEmploymentTypeMetadata(t *testing.T) {
+	fake := &fakeHTTP{body: `{
+		"jobs": [
+			{
+				"id": 1,
+				"title": "Accountant",
+				"location": {"name": "Remote"},
+				"content": "",
+				"metadata": [
+					{"id": 1, "name": "Employment Type", "value": "Full-time", "value_type": "single_select"}
+				]
+			}
+		]
+	}`}
+
+	jobs, err := NewGreenhouse(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "greenhouse", Board: "acme",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if got := jobs[0].EmploymentType; got != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time", got)
 	}
 }

--- a/web/src/lib/seo.test.ts
+++ b/web/src/lib/seo.test.ts
@@ -8,6 +8,7 @@ import {
   datasetJsonLd,
   jobListItems,
   jobPostingJsonLd,
+  metaDescription,
   organizationJsonLd,
 } from './seo';
 import { companyLogoUrl } from './logo';
@@ -49,6 +50,27 @@ function company(overrides: Partial<Company> = {}): Company {
 }
 
 const ORIGIN = 'https://freehire.me';
+
+describe('metaDescription', () => {
+  it('strips tags and collapses whitespace without truncating short text', () => {
+    expect(metaDescription('<p>Build  <b>great</b>\nthings.</p>')).toBe('Build great things.');
+  });
+
+  it('defaults to ~160 chars and cuts at the last whole word, not mid-word', () => {
+    const word = 'lorem ';
+    const text = word.repeat(40).trim(); // well past 160 chars, all whole words
+    const got = metaDescription(text);
+    expect(got.length).toBeLessThanOrEqual(160);
+    expect(got.endsWith('…')).toBe(true);
+    expect(got.slice(0, -1).endsWith(' ')).toBe(false); // cut, not a trailing space before the ellipsis
+    expect(text.startsWith(got.slice(0, -1))).toBe(true); // the kept prefix is whole words of the source
+  });
+
+  it('respects an explicit max, e.g. the 220-char list-card budget', () => {
+    const text = 'a'.repeat(300);
+    expect(metaDescription(text, 220)).toBe(`${'a'.repeat(219)}…`); // no spaces to cut at: falls back to a hard cut
+  });
+});
 
 describe('collectionHeading', () => {
   it('includes the exact live count, comma-grouped', () => {

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -18,14 +18,20 @@ const SITE_GITHUB = 'https://github.com/strelov1/freehire';
 export type FaqItem = { question: string; answer: string };
 
 /** Plain-text, length-capped description for `<meta name="description">` and OG,
- *  derived from the job's sanitized HTML body. */
-export function metaDescription(html: string, max = 200): string {
+ *  derived from the job's sanitized HTML body. Cuts at the last whole word within
+ *  the budget rather than mid-word, and defaults to ~155-160 chars — Google's own
+ *  typical search-snippet width, beyond which it truncates the snippet itself and
+ *  we lose control of where the cut lands. */
+export function metaDescription(html: string, max = 160): string {
   const text = html
     .replace(/<[^>]*>/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
   if (text.length <= max) return text;
-  return `${text.slice(0, max - 1).trimEnd()}…`;
+  const cut = text.slice(0, max - 1);
+  const lastSpace = cut.lastIndexOf(' ');
+  const truncated = lastSpace > 0 ? cut.slice(0, lastSpace) : cut;
+  return `${truncated.trimEnd()}…`;
 }
 
 /** Plain-text, length-capped `<meta name="description">` for a company page.


### PR DESCRIPTION
## Summary
- SEO audit found `employmentType` inconsistently populated in `JobPosting` JSON-LD (Medium priority). Investigated: Greenhouse's public boards API carries no fixed employment-type field at all — but a sample of real boards, checked live, shows a minority of employers configure one anyway via Greenhouse's custom application-question/metadata mechanism, consistently named "Employment Type" (`1800contacts`, `solidpower`, `carrotfertility` all confirmed live with value `"Full-time"`; a random 60-board sample found the field on ~5%).
- This is genuine structured signal, not a guess: the employer explicitly labeled and typed the value, the same trust level as Lever's `commitment` field or SmartRecruiters' `typeOfEmployment` enum, both already captured. `greenhouseMetadataEmploymentType` reads it; `greenhouseEmploymentType` maps the free-text value onto freehire's vocabulary via keyword containment, mirroring `leverEmploymentType`'s existing style (the field is employer-typed free text, not a fixed enum).
- An unset field, an empty-array value (an unset multi-select — seen live on `coherentsolutions`), or an unrecognized value all map to `""`, same as before this change — nothing here starts guessing; it still falls through to `jobderive`'s existing description-text parser unchanged.
- `baseSalary` and the rest of `employmentType`'s gap (most postings simply never state it, structured or not) is genuine data sparsity per the project's "never guess" dictionary convention, not a bug — tracked separately, not touched here.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`
- [x] New table-driven `TestGreenhouseMetadataEmploymentType` (field absent, unrelated field, matched value, case/whitespace-insensitive name, empty-array unset value, unrecognized value) + `TestGreenhouseFetchReadsEmploymentTypeMetadata` end-to-end through `Fetch`
- [x] Ran the real adapter live against `1800contacts`/`solidpower`/`carrotfertility` (100% of their jobs now carry `employment_type`) and `1910genetics` (no metadata field — still empty, unchanged)
- [x] `go run ./cmd/validate-sources sources/` — 203 files OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Greenhouse job postings now recognize supported employment types from employer-provided metadata, including full-time, part-time, contract, temporary, seasonal, and internship roles.
* **Bug Fixes**
  * Improved search-engine descriptions by limiting them to 160 characters by default and truncating at complete words where possible.
  * HTML is removed and spacing is normalized before descriptions are shortened, producing cleaner previews in search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->