### PR TITLE
Onboard first-party ATS boards extracted from stored echojobs URLs

### DIFF
--- a/cmd/harvest-boards/boardfile_test.go
+++ b/cmd/harvest-boards/boardfile_test.go
@@ -50,6 +50,12 @@ func TestDedupKeyOf(t *testing.T) {
 	if dedupKeyOf(ashbyProber{})("Ramp") != "ramp" {
 		t.Error("ashby key must fold case")
 	}
+	// SmartRecruiters' postings API is case-insensitive too (confirmed live twice, #1884/#1888:
+	// a name-derived candidate slipped past dedup because it only differed in case from an
+	// existing board), so the dedup key folds case like the others.
+	if dedupKeyOf(smartRecruitersProber{})("ArchirodonGroup") != "archirodongroup" {
+		t.Error("smartrecruiters key must fold case")
+	}
 }
 
 func TestWorkdayBoardID(t *testing.T) {

--- a/cmd/harvest-boards/prober.go
+++ b/cmd/harvest-boards/prober.go
@@ -429,6 +429,12 @@ func (smartRecruitersProber) probe(ctx context.Context, c httpClient, slug strin
 	return meta.Name, n, nil
 }
 
+// dedupKey folds a SmartRecruiters board id to lower case, like Workday's, Greenhouse's and
+// Ashby's. Without this, a name-derived candidate that only differs in case from an existing
+// entry (e.g. "archirodongroup" vs the stored "ArchirodonGroup") reads as new — confirmed live
+// twice (see #1884, #1888) — even though SmartRecruiters' API treats the two identically.
+func (smartRecruitersProber) dedupKey(boardID string) string { return strings.ToLower(boardID) }
+
 // recruiteeProber probes the Recruitee per-subdomain offers API. A non-empty offers array is
 // a live board, and each offer carries the employer's own name, so the board can be gated
 // against the name the seed expected rather than accepted on liveness alone.
@@ -812,7 +818,18 @@ func (p isolvedProber) probe(ctx context.Context, c httpClient, slug string) (st
 // postings means a live board. The employer name comes from the seed.
 type apploiProber struct{}
 
+// apploiNumericSlugRE matches apploi's own employer-id shape: digits only. A name-derived
+// candidate (e.g. "101-edu") is never a valid employer id, but api.apploi.com doesn't error on
+// one — it silently ignores an `employer` value it can't parse and answers with a non-empty,
+// "live" jobs list regardless. Fed a 5,216-candidate name-derived seed, that read as a 100%
+// hit rate (confirmed live — see #1884). Reject non-numeric slugs up front rather than trust
+// the API to say no.
+var apploiNumericSlugRE = regexp.MustCompile(`^\d+$`)
+
 func (apploiProber) probe(ctx context.Context, c httpClient, slug string) (string, int, error) {
+	if !apploiNumericSlugRE.MatchString(slug) {
+		return "", 0, nil
+	}
 	var resp struct {
 		Data []struct {
 			Published bool `json:"published"`

--- a/cmd/harvest-boards/prober_test.go
+++ b/cmd/harvest-boards/prober_test.go
@@ -416,3 +416,28 @@ func TestNameReportingProbers(t *testing.T) {
 		}
 	})
 }
+
+// TestApploiProberRejectsNonNumericSlug guards the fix for a confirmed live false-positive
+// (see #1884): api.apploi.com/v1/jobs?employer=<slug> answers a non-empty, "live" jobs list
+// even when slug isn't a real employer id — it silently ignores a value it can't parse. The
+// canned response below WOULD read as a live board if the guard were missing and the request
+// went out at all, so this test fails loudly if the numeric-slug check regresses.
+func TestApploiProberRejectsNonNumericSlug(t *testing.T) {
+	getter := fakeGetter{
+		"https://api.apploi.com/v1/jobs?employer=101-edu&limit=100": `{"data":[{"published":true,"archived":false}]}`,
+	}
+	if _, n, err := (apploiProber{}).probe(context.Background(), getter, "101-edu"); err != nil || n != 0 {
+		t.Errorf("got (%d,%v), want (0,nil) for a non-numeric slug", n, err)
+	}
+}
+
+// TestApploiProberAcceptsNumericSlug confirms the guard doesn't also reject apploi's real
+// board-id shape.
+func TestApploiProberAcceptsNumericSlug(t *testing.T) {
+	getter := fakeGetter{
+		"https://api.apploi.com/v1/jobs?employer=55591&limit=100": `{"data":[{"published":true,"archived":false},{"published":false,"archived":true}]}`,
+	}
+	if _, n, err := (apploiProber{}).probe(context.Background(), getter, "55591"); err != nil || n != 1 {
+		t.Errorf("got (%d,%v), want (1,nil) for a numeric slug", n, err)
+	}
+}

--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -8178,3 +8178,7 @@
   board: offstream
 - company: Spur
   board: spur
+- company: Quizlet
+  board: quizlet-inc
+- company: Mural Group
+  board: themuralgroup

--- a/sources/gem.yml
+++ b/sources/gem.yml
@@ -484,3 +484,9 @@
   board: stratarobot-com
 - company: Think Company
   board: think-company
+- company: Lutra AI
+  board: lutra
+- company: ocient-inc-
+  board: ocient-inc-
+- company: We Are Overwatch
+  board: overwatch

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14465,3 +14465,9 @@
   board: terakeet
 - company: Echo Neurotechnologies
   board: echo
+- company: Age of Learning, Inc.
+  board: ageoflearninginc
+- company: Gridmatic Inc
+  board: gridmaticinc
+- company: MX Build Technologies India Private Limited
+  board: mxbuildtechnologiesindiaprivatelimited

--- a/sources/jazzhr.yml
+++ b/sources/jazzhr.yml
@@ -8413,3 +8413,21 @@
   board: qualityconsultinggroup
 - company: Key Capture Energy, LLC
   board: 20230417161904_8clld49cklrdhnma
+- company: CloudIT  LLC
+  board: cloudit1
+- company: Dashing Diva
+  board: dashingdiva
+- company: EDAG Mexico
+  board: edagmexico
+- company: Forms+Surfaces Inc
+  board: formssurfaces
+- company: Illumination Health + Home
+  board: illuminationfoundation
+- company: Indico Data
+  board: indico
+- company: Smash CR
+  board: smashcr
+- company: Softjourn
+  board: softjourn
+- company: SWJ TECHNOLOGY, LLC
+  board: swjtechnology

--- a/sources/personio.yml
+++ b/sources/personio.yml
@@ -8147,3 +8147,9 @@
   board: viva-fitness
 - company: Holidu
   board: holidu
+- company: fuljoyment
+  board: fuljoyment-ag
+- company: onchain
+  board: onchain
+- company: Customlytics GmbH
+  board: trg

--- a/sources/pinpoint.yml
+++ b/sources/pinpoint.yml
@@ -1489,3 +1489,11 @@
   board: synopsys
 - company: We Are 54
   board: weare54
+- company: Blue Sentry Cloud
+  board: bluesentry
+- company: Desmos
+  board: desmos
+- company: Impruv On Health
+  board: impruvon
+- company: Peninsula
+  board: peninsula360

--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -6755,3 +6755,21 @@
   board: virtualenterprisearchitects
 - company: Vix Technology
   board: vixtechnology
+- company: Alten CAL Software Labs
+  board: altencalsoftlabs1
+- company: CocoTech
+  board: cocotechoes
+- company: ControlTec
+  board: controltecllc
+- company: Crossmark
+  board: crossmark1
+- company: Moralis
+  board: moralisweb3technology
+- company: Nimbyx Philippines, Inc.
+  board: nimbyxphilippinesinc
+- company: Pioneer Data Systems
+  board: pioneerdatasystems1
+- company: Seek Thermal
+  board: seekthermalinc
+- company: Trident Consulting Inc
+  board: tridentconsultinginc2

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -3275,3 +3275,93 @@
   board: careers.paystack.com
 - company: Nextlane
   board: nextlane.teamtailor.com
+- company: AESG
+  board: aesg.teamtailor.com
+- company: Agileday Oy
+  board: agiledayoy.teamtailor.com
+- company: AIRTIFICIAL
+  board: airtificial.teamtailor.com
+- company: AniCura Group
+  board: anicuraglobal.teamtailor.com
+- company: Antare Technology
+  board: antaretechnology-1748341798.teamtailor.com
+- company: Ardonagh Specialty
+  board: ardonaghspeciality.teamtailor.com
+- company: Callen-Lenz
+  board: callenlenz.teamtailor.com
+- company: Tecknuovo
+  board: careers-tecknuovo.teamtailor.com
+- company: EIDEL
+  board: eidel.teamtailor.com
+- company: Electrify
+  board: electrify.teamtailor.com
+- company: Tripstack
+  board: etraveligroup-tripstack.teamtailor.com
+- company: Fabric Group
+  board: fabricgroup-1734393624.teamtailor.com
+- company: Flagship Group
+  board: flagshipgroup.teamtailor.com
+- company: Harcour
+  board: harcour.teamtailor.com
+- company: Huawei Ireland Research Centre
+  board: huaweiireland.teamtailor.com
+- company: Huawei Technologies CBG
+  board: huaweitechnologiescbg.teamtailor.com
+- company: Huawei Technologies Italia
+  board: huaweitechnologiesitalia.teamtailor.com
+- company: Huawei R&amp;D UK
+  board: huaweiuk.teamtailor.com
+- company: Institute for Human Rights &amp; Business
+  board: ihrb.teamtailor.com
+- company: J&B Hopkins
+  board: jbhopkins.teamtailor.com
+- company: Kolsquare
+  board: kolsquareteamblue.teamtailor.com
+- company: Legendz
+  board: legendz.teamtailor.com
+- company: Harnest
+  board: mazzeigroup-1750399679-mazzei-group.teamtailor.com
+- company: Mindwork
+  board: mindwork.teamtailor.com
+- company: Mintos
+  board: mintos.teamtailor.com
+- company: Stillfront Group
+  board: moonfroglabsbystillfront.teamtailor.com
+- company: MR. D.I.Y.
+  board: mrdiytradingsdnbhdlive-demo-mr-diy-international.teamtailor.com
+- company: New Moon Production
+  board: newmoonproduction.teamtailor.com
+- company: Ocado Retail
+  board: ocadoretail.teamtailor.com
+- company: Ogilvy Paris
+  board: ogilvyparis.teamtailor.com
+- company: Omnicom Media Group Norway
+  board: omgno.teamtailor.com
+- company: Öresund IT
+  board: oresundit.teamtailor.com
+- company: Procentia
+  board: procentia.teamtailor.com
+- company: Quicke
+  board: quicke.teamtailor.com
+- company: Reading Students&#39; Union
+  board: readingstudentsunion.teamtailor.com
+- company: Stillfront Group
+  board: sandboxinteractive.teamtailor.com
+- company: SET Europa
+  board: seteuropa-1732014925.teamtailor.com
+- company: Shellworks
+  board: shellworks.teamtailor.com
+- company: Skybound Wealth Management
+  board: skyboundwealthmanagement.teamtailor.com
+- company: Solevo Group
+  board: solevo-1695109387.teamtailor.com
+- company: The Crown Estate
+  board: thecrownestate.teamtailor.com
+- company: thyssenkrupp Bilstein Sibiu
+  board: thyssenkruppromania.teamtailor.com
+- company: VaccinDirekt
+  board: vaccindirektisverigeab.teamtailor.com
+- company: Veoneer Romania Safety Systems
+  board: veoneerro.teamtailor.com
+- company: Zotefoams
+  board: zotefoams-1734537268.teamtailor.com

--- a/sources/workday.yml
+++ b/sources/workday.yml
@@ -12937,3 +12937,23 @@
   board: nextdecade.wd501.myworkdayjobs.com/GlobalCareers
 - company: Shriners Children's
   board: shrinerschildrens.wd12.myworkdayjobs.com/Shriners
+- company: Challenge Manufacturing
+  board: challengemfg.wd503.myworkdayjobs.com/challenge-mfg_careers
+- company: Crystalsugar
+  board: crystalsugar.wd501.myworkdayjobs.com/crystalcareers
+- company: Fidelity National Financial
+  board: fntg.wd5.myworkdayjobs.com/FNF-Careers
+- company: Welcome to Hayward Residential and Commercial Pool Products
+  board: hayward.wd1.myworkdayjobs.com/External
+- company: Interpublic Group
+  board: interpublic.wd5.myworkdayjobs.com/OMC
+- company: Marcus & Millichap
+  board: marcusmillichap.wd108.myworkdayjobs.com/MarcusMillichap
+- company: PROCEPT BioRobotics
+  board: proceptbiorobotics.wd108.myworkdayjobs.com/PROCEPT
+- company: Where Innovation Meets Sustainable Impact
+  board: seh.wd503.myworkdayjobs.com/SoutheastHealth
+- company: Ssrmining
+  board: ssrmining.wd108.myworkdayjobs.com/ssr_mining_careers
+- company: Tokyo Electron
+  board: tel.wd3.myworkdayjobs.com/tet_career


### PR DESCRIPTION
## Summary
A better signal than #1884/#1888's slug-guessing or domain-following: many still-orphaned echojobs companies already carry a genuine employer ATS link in `jobs.url` — echojobs's own JSON API, before its Aug 13 retirement, stored the real employer link directly; only the sitemap+ld+json rewrite (#1872) lost it going forward. Ran every non-echojobs.io URL already on file for a current orphan through `internal/atsboard.Recognize` (pure URL parsing, no guessing, no network) and validated the ~1,350 candidates it resolved via `cmd/harvest-boards`.

**Hit rate confirms the signal is real:** workday 10/10, personio 3/5, pinpoint 4/4, teamtailor 45/45 — near-total, because the URL is one our own crawler already fetched successfully at some point, not a guess.

- **88 new boards across 9 providers:** teamtailor +45, workday +10, jazzhr +9, smartrecruiters +9, pinpoint +4, gem +3, greenhouse +3, personio +3, ashby +2.
- lever/jobvite/bamboohr candidates resolved fine but none passed the name-match gate or were already-known — a legitimate zero, not a miss.
- Includes cherry-picked #1891 (SmartRecruiters case-fold dedup + apploi numeric-slug guard) — needed it live to avoid re-hitting the same case-variant duplicate bug this run surfaced (32 of them, confirmed then dropped via the fix instead of by hand).
- `workable` (210 URL-derived candidates) was still running at commit time — unusually slow again even at this much smaller scale; will follow up separately if it produces anything once it finishes.

## Test plan
- [x] `go run ./cmd/validate-sources` passes.
- [x] Reviewed the diff for each provider file.
- [ ] Re-ingest the 9 touched board files and confirm first-party postings land.

Part of #1761, #1758.