### PR TITLE
Fix 15 high-severity findings from the monorepo code review

### DIFF
--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -9,6 +9,7 @@ import {
   type ComboboxReply,
 } from '../lib/protocol';
 import { mergeComboboxReplies, mergeFrameOutcomes } from '../lib/tools/executor';
+import { fillsForFrame } from '../lib/form';
 
 /**
  * Service worker. Three jobs, all thin:
@@ -77,15 +78,20 @@ async function readFramedForm(): Promise<RuntimeMessage> {
 }
 
 /**
- * Offers the fills to every frame and folds the answers together. A frame that
- * does not hold the field reports `not_found`, so the merge keeps whichever
- * frame actually did something with it.
+ * Offers each frame only the fills addressed to it (`fillsForFrame`) and folds
+ * the answers together. A fill naming a frame is withheld from every other one,
+ * so a same-labeled control there cannot absorb it the way a page-wide
+ * broadcast would; a fill naming none — a `fill_simple` tool call — still goes
+ * to every frame, and a frame that does not hold it reports `not_found`.
  */
 async function fillAcrossFrames(fills: LabelFill[]): Promise<RuntimeMessage> {
   const perFrame: FillOutcome[][] = [];
-  await eachFrame({ kind: 'FILL_BY_LABEL', fills }, (reply) => {
-    if (reply?.kind === 'FILL_OUTCOMES') perFrame.push(reply.outcomes);
-  });
+  await eachFrame(
+    (frame) => ({ kind: 'FILL_BY_LABEL', fills: fillsForFrame(fills, frame) }),
+    (reply) => {
+      if (reply?.kind === 'FILL_OUTCOMES') perFrame.push(reply.outcomes);
+    },
+  );
   return { kind: 'FILL_OUTCOMES', outcomes: mergeFrameOutcomes(perFrame) };
 }
 
@@ -102,17 +108,23 @@ async function comboboxAcrossFrames(step: ComboboxStep): Promise<RuntimeMessage>
   return { kind: 'COMBOBOX_REPLY', reply: mergeComboboxReplies(replies) };
 }
 
-/** Sends a message to each injectable frame of the active tab, in parallel. */
+/**
+ * Sends a message to each injectable frame of the active tab, in parallel. The
+ * message can be built per frame — `fillAcrossFrames` uses that to withhold a
+ * frame-addressed fill from every frame but its own — or given fixed, for a
+ * request every frame answers the same way.
+ */
 async function eachFrame(
-  message: RuntimeMessage,
+  message: RuntimeMessage | ((frame: number) => RuntimeMessage),
   take: (reply: RuntimeMessage | undefined, frame: number) => void,
 ): Promise<void> {
   const tabId = await activeTabId();
   if (tabId == null) return;
+  const forFrame = typeof message === 'function' ? message : () => message;
   await Promise.all(
     (await frameIds(tabId)).map(async (frameId) => {
       try {
-        take((await browser.tabs.sendMessage(tabId, message, { frameId })) as RuntimeMessage, frameId);
+        take((await browser.tabs.sendMessage(tabId, forFrame(frameId), { frameId })) as RuntimeMessage, frameId);
       } catch {
         // No content script in that frame (about:blank, a restricted origin) —
         // it simply contributes nothing.

--- a/extension/lib/assistant/chat.test.ts
+++ b/extension/lib/assistant/chat.test.ts
@@ -85,7 +85,15 @@ describe('reduceTurnEvent', () => {
     expect(s.messages[1]?.streaming).toBe(true);
   });
 
-  it('ignores a result with no open turn instead of creating a message', () => {
+  it('surfaces an empty errored assistant when a turn fails before any reply', () => {
+    let s = reduceTurnEvent(initChat(), { type: 'user_prompt', text: 'hi' });
+    s = reduceTurnEvent(s, { type: 'result', stop_reason: 'error', is_error: true });
+    expect(s.messages).toHaveLength(2);
+    expect(s.messages[1]?.role).toBe('assistant');
+    expect(s.messages[1]?.errored).toBe(true);
+  });
+
+  it('ignores a successful result with no open turn instead of creating a message', () => {
     const s = reduceTurnEvent(initChat(), {
       type: 'result',
       stop_reason: 'end_turn',

--- a/extension/lib/assistant/chat.ts
+++ b/extension/lib/assistant/chat.ts
@@ -45,8 +45,23 @@ export function reduceTurnEvent(prev: ChatState, event: TurnEvent): ChatState {
       }));
     case 'tool_result':
       return upsertAssistant(prev, (m) => ({ ...m, tools: attachResult(m.tools, event) }));
-    case 'result':
-      return closeAssistant(prev, event.is_error ?? false);
+    case 'result': {
+      const next = closeAssistant(prev, event.is_error ?? false);
+      // A failure before any assistant frame left only the user prompt — still surface an
+      // errored assistant so the Retry control has somewhere to sit.
+      if (event.is_error) {
+        const last = next.messages[next.messages.length - 1];
+        if (!last || last.role !== 'assistant' || !last.errored) {
+          return {
+            messages: [
+              ...next.messages,
+              { role: 'assistant', text: '', thinking: '', tools: [], streaming: false, errored: true },
+            ],
+          };
+        }
+      }
+      return next;
+    }
     default:
       // usage, and anything not in the union — ignored.
       return prev;

--- a/extension/lib/form.test.ts
+++ b/extension/lib/form.test.ts
@@ -4,6 +4,7 @@ import {
   extractUploads,
   matchFieldKey,
   planLabelFills,
+  fillsForFrame,
   fillByLabel,
   looksLikeApplication,
   scopeToApplication,
@@ -218,6 +219,31 @@ describe('planLabelFills', () => {
       { label: 'Email', value: 'ilya@example.com' },
     ]);
   });
+
+  it("carries the field's frame and form onto the fill, so it can be scoped later", () => {
+    expect(planLabelFills([{ label: 'First Name', frame: 18, form: 0 }], values)).toEqual([
+      { label: 'First Name', value: 'Ilya', frame: 18, form: 0 },
+    ]);
+  });
+});
+
+describe('fillsForFrame', () => {
+  const fills = [
+    { label: 'First Name', value: 'Ilya', frame: 18, form: 0 },
+    { label: 'Email', value: 'ilya@example.com', frame: 0, form: 1 },
+    { label: 'Referral code', value: 'ABC' },
+  ];
+
+  it('keeps only the fills addressed to the frame, plus the frame-agnostic ones', () => {
+    expect(fillsForFrame(fills, 18)).toEqual([
+      { label: 'First Name', value: 'Ilya', frame: 18, form: 0 },
+      { label: 'Referral code', value: 'ABC' },
+    ]);
+  });
+
+  it('withholds a frame-addressed fill from every other frame', () => {
+    expect(fillsForFrame(fills, 7)).toEqual([{ label: 'Referral code', value: 'ABC' }]);
+  });
 });
 
 describe('extractForm combo flag', () => {
@@ -369,6 +395,35 @@ describe('fillByLabel', () => {
       { label: 'Favourite colour', status: 'not_found' },
       { label: 'Country', status: 'no_option' },
     ]);
+  });
+
+  it('writes only the target form when two forms share a label', () => {
+    // Roku carries both an application and a job-alert signup, each asking for
+    // an "Email"; a fill scoped to the application form must not spill into
+    // the signup's same-labeled control sitting right next to it.
+    const application = formWith('application', ['Email']);
+    const signup = formWith('signup', ['Email']);
+    const applicationInput = must(application.querySelector<HTMLInputElement>('input'));
+    const signupInput = must(signup.querySelector<HTMLInputElement>('input'));
+
+    const outcomes = fillByLabel(document, [{ label: 'Email', value: 'ilya@example.com', form: 0 }]);
+
+    expect(applicationInput.value).toBe('ilya@example.com');
+    expect(signupInput.value).toBe('');
+    expect(outcomes).toEqual([{ label: 'Email', status: 'filled' }]);
+  });
+
+  it('reports not_found rather than fall back to an out-of-form match', () => {
+    // The target form (0) exists, but only the other form (1) carries this
+    // label — the fill must not silently land there.
+    formWith('application', ['First Name']);
+    const signup = formWith('signup', ['Email']);
+    const signupInput = must(signup.querySelector<HTMLInputElement>('input'));
+
+    const outcomes = fillByLabel(document, [{ label: 'Email', value: 'ilya@example.com', form: 0 }]);
+
+    expect(signupInput.value).toBe('');
+    expect(outcomes).toEqual([{ label: 'Email', status: 'not_found' }]);
   });
 });
 

--- a/extension/lib/form.ts
+++ b/extension/lib/form.ts
@@ -424,17 +424,32 @@ export function scopeToApplication<T extends { frame: number; form: number }>(
  * question carrying a label, so the repeats only pad the wire. Pure over its
  * input; the page is not touched here.
  */
-export function planLabelFills(fields: { label: string }[], values: Record<string, string>): LabelFill[] {
+export function planLabelFills(
+  fields: { label: string; frame?: number; form?: number }[],
+  values: Record<string, string>,
+): LabelFill[] {
   const asked = new Set<string>();
   const fills: LabelFill[] = [];
-  for (const { label } of fields) {
+  for (const { label, frame, form } of fields) {
     const key = matchFieldKey(label);
     const value = key ? (values[key] ?? '') : '';
     if (!value || asked.has(normalizeLabel(label))) continue;
     asked.add(normalizeLabel(label));
-    fills.push({ label, value });
+    fills.push({ label, value, frame, form });
   }
   return fills;
+}
+
+/**
+ * The fills a given frame should act on: those addressed to it by
+ * `deterministicAutofill`, plus any fill naming no frame at all — a
+ * `fill_simple` tool call, which is still offered to every frame as before
+ * frame scoping existed. Used by the background relay to stop broadcasting a
+ * frame-addressed fill to frames that do not hold the target control, which is
+ * what let a same-labeled field in another frame's form get filled instead.
+ */
+export function fillsForFrame(fills: LabelFill[], frame: number): LabelFill[] {
+  return fills.filter((f) => f.frame === undefined || f.frame === frame);
 }
 
 /**
@@ -443,17 +458,36 @@ export function planLabelFills(fields: { label: string }[], values: Record<strin
  * between an agent's observation and its fills cannot drift the target the way a
  * positional index does. Every requested fill gets an outcome; custom-widget
  * comboboxes are reported as deferred rather than written into.
+ *
+ * A fill naming a `form` only matches a question inside that form — the frame's
+ * own signup form sharing a label ("Email") with the application form must not
+ * absorb a fill meant for the other. A fill naming none matches the first
+ * question carrying the label, as `fillByLabel` always has.
  */
 export function fillByLabel(doc: Document, fills: LabelFill[]): FillOutcome[] {
   const questions = collectQuestions(doc);
-  return fills.map(({ label, value }) => {
-    const question = questions.find((q) => normalizeLabel(q.label) === normalizeLabel(label));
+  const forms = Array.from(doc.querySelectorAll('form'));
+  return fills.map(({ label, value, form }) => {
+    const question = findQuestion(questions, forms, label, form);
     if (!question) return { label, status: 'not_found' as const };
     if (question.controls.length === 1 && isComboWidget(question.controls[0])) {
       return { label, status: 'deferred_combobox' as const };
     }
     return { label, status: answerQuestion(question, value) ? ('filled' as const) : ('no_option' as const) };
   });
+}
+
+/** The question a fill addresses, narrowed to `form` when the fill names one. */
+function findQuestion(
+  questions: Question[],
+  forms: HTMLFormElement[],
+  label: string,
+  form: number | undefined,
+): Question | undefined {
+  const target = normalizeLabel(label);
+  const matches = questions.filter((q) => normalizeLabel(q.label) === target);
+  if (form === undefined) return matches[0];
+  return matches.find((q) => formIndex(q.controls[0], forms) === form);
 }
 
 /**

--- a/extension/lib/protocol.ts
+++ b/extension/lib/protocol.ts
@@ -74,10 +74,19 @@ export interface FramedUpload extends Upload {
 /**
  * A value to write into the question carrying `label` (see `fillByLabel`). For a
  * grouped question the value is one of the options it offers, not free text.
+ *
+ * `frame`/`form` scope the write to the question the fill was planned from —
+ * `deterministicAutofill` sets both, carried over from the `FramedField` that
+ * justified the fill, so a same-labeled control outside that frame or form is
+ * left alone. Undefined for a `fill_simple` tool call, whose label the agent
+ * names on its own with no field to read them from; such a fill still matches
+ * the first question carrying the label, as before frame/form scoping existed.
  */
 export interface LabelFill {
   label: string;
   value: string;
+  frame?: number;
+  form?: number;
 }
 
 /**

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/strelov1/freehire
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.2

--- a/internal/browsertools/caller.go
+++ b/internal/browsertools/caller.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
 	"sync"
 )
 
@@ -21,7 +20,6 @@ type Caller struct {
 	user int64
 
 	mu      sync.Mutex
-	seq     int64
 	pending map[string]chan []byte
 	leave   func()
 }
@@ -105,12 +103,11 @@ func (c *Caller) Call(ctx context.Context, tool string, args any) (json.RawMessa
 }
 
 func (c *Caller) register() (string, chan []byte) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.seq++
-	id := strconv.FormatInt(c.seq, 10)
+	id := c.hub.NextCallID()
 	ch := make(chan []byte, 1)
+	c.mu.Lock()
 	c.pending[id] = ch
+	c.mu.Unlock()
 	return id, ch
 }
 

--- a/internal/browsertools/caller_test.go
+++ b/internal/browsertools/caller_test.go
@@ -139,10 +139,12 @@ func TestStaleAnswerForAnEvictedCallerDoesNotResolveASuccessorsCall(t *testing.T
 
 	var mu sync.Mutex
 	var frames [][]byte
+	sent := make(chan struct{}, 2)
 	extension := senderFunc(func(frame []byte) error {
 		mu.Lock()
 		frames = append(frames, frame)
 		mu.Unlock()
+		sent <- struct{}{}
 		return nil // never answers; the caller's call times out
 	})
 	hub.Join(7, browsertools.RoleExtension, extension)
@@ -155,6 +157,7 @@ func TestStaleAnswerForAnEvictedCallerDoesNotResolveASuccessorsCall(t *testing.T
 		t.Fatal("callerA.Call succeeded; want it to time out since the extension never answers")
 	}
 	callerA.Close()
+	<-sent
 
 	mu.Lock()
 	idA := frameID(t, frames[0])
@@ -173,14 +176,14 @@ func TestStaleAnswerForAnEvictedCallerDoesNotResolveASuccessorsCall(t *testing.T
 		res, err := callerB.Call(context.Background(), "fill_simple", nil)
 		done <- callResult{res, err}
 	}()
-	// Let callerB's call register and reach the extension before the stale
-	// answer arrives.
-	time.Sleep(50 * time.Millisecond)
-
-	// A late answer for A's evicted call arrives from the extension. Routed by
-	// role, it lands on whichever Caller currently holds RoleHarness — B — and
-	// must not be mistaken for an answer to B's own pending call.
-	hub.Forward(7, browsertools.RoleExtension, []byte(`{"id":"`+idA+`","result":"stale"}`))
+	// Wait for callerB's request to actually reach the extension (proving it
+	// registered its pending call) before delivering any answer — a bounded
+	// wait rather than a fixed sleep, so this cannot flake under scheduler delay.
+	select {
+	case <-sent:
+	case <-time.After(2 * time.Second):
+		t.Fatal("callerB request did not reach the extension")
+	}
 
 	mu.Lock()
 	idB := frameID(t, frames[len(frames)-1])
@@ -189,6 +192,10 @@ func TestStaleAnswerForAnEvictedCallerDoesNotResolveASuccessorsCall(t *testing.T
 		t.Fatalf("callerA and callerB both minted call id %q; ids must be unique per hub", idA)
 	}
 
+	// A late answer for A's evicted call arrives from the extension. Routed by
+	// role, it lands on whichever Caller currently holds RoleHarness — B — and
+	// must not be mistaken for an answer to B's own pending call.
+	hub.Forward(7, browsertools.RoleExtension, []byte(`{"id":"`+idA+`","result":"stale"}`))
 	hub.Forward(7, browsertools.RoleExtension, []byte(`{"id":"`+idB+`","result":"fresh"}`))
 
 	select {

--- a/internal/browsertools/caller_test.go
+++ b/internal/browsertools/caller_test.go
@@ -3,6 +3,7 @@ package browsertools_test
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 	"time"
 
@@ -131,6 +132,87 @@ func TestCallerMatchesEachAnswerToItsOwnCall(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("first call never resolved")
 	}
+}
+
+func TestStaleAnswerForAnEvictedCallerDoesNotResolveASuccessorsCall(t *testing.T) {
+	hub := browsertools.New()
+
+	var mu sync.Mutex
+	var frames [][]byte
+	extension := senderFunc(func(frame []byte) error {
+		mu.Lock()
+		frames = append(frames, frame)
+		mu.Unlock()
+		return nil // never answers; the caller's call times out
+	})
+	hub.Join(7, browsertools.RoleExtension, extension)
+
+	// Caller A's first call times out and is closed, exactly as a retry would.
+	callerA := hub.NewCaller(7)
+	ctxA, cancelA := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancelA()
+	if _, err := callerA.Call(ctxA, "read_form", nil); err == nil {
+		t.Fatal("callerA.Call succeeded; want it to time out since the extension never answers")
+	}
+	callerA.Close()
+
+	mu.Lock()
+	idA := frameID(t, frames[0])
+	mu.Unlock()
+
+	// Caller B replaces A as the harness end and issues its own call.
+	callerB := hub.NewCaller(7)
+	defer callerB.Close()
+
+	type callResult struct {
+		res json.RawMessage
+		err error
+	}
+	done := make(chan callResult, 1)
+	go func() {
+		res, err := callerB.Call(context.Background(), "fill_simple", nil)
+		done <- callResult{res, err}
+	}()
+	// Let callerB's call register and reach the extension before the stale
+	// answer arrives.
+	time.Sleep(50 * time.Millisecond)
+
+	// A late answer for A's evicted call arrives from the extension. Routed by
+	// role, it lands on whichever Caller currently holds RoleHarness — B — and
+	// must not be mistaken for an answer to B's own pending call.
+	hub.Forward(7, browsertools.RoleExtension, []byte(`{"id":"`+idA+`","result":"stale"}`))
+
+	mu.Lock()
+	idB := frameID(t, frames[len(frames)-1])
+	mu.Unlock()
+	if idA == idB {
+		t.Fatalf("callerA and callerB both minted call id %q; ids must be unique per hub", idA)
+	}
+
+	hub.Forward(7, browsertools.RoleExtension, []byte(`{"id":"`+idB+`","result":"fresh"}`))
+
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("callerB.Call: %v", r.err)
+		}
+		if string(r.res) != `"fresh"` {
+			t.Fatalf("callerB.Call result = %s, want its own answer, not the stale one delivered for A's call", r.res)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("callerB.Call never resolved")
+	}
+}
+
+func frameID(t *testing.T, frame []byte) string {
+	t.Helper()
+	var call struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(frame, &call); err != nil {
+		t.Fatalf("frame is not JSON: %v", err)
+	}
+	return call.ID
 }
 
 // senderFunc adapts a function to browsertools.Socket.

--- a/internal/browsertools/hub.go
+++ b/internal/browsertools/hub.go
@@ -10,7 +10,9 @@ package browsertools
 
 import (
 	"encoding/json"
+	"strconv"
 	"sync"
+	"sync/atomic"
 )
 
 // Role names one end of a user's channel.
@@ -44,10 +46,21 @@ type Socket interface {
 type Hub struct {
 	mu       sync.Mutex
 	channels map[int64]map[Role]Socket
+	callSeq  atomic.Int64
 }
 
 func New() *Hub {
 	return &Hub{channels: make(map[int64]map[Role]Socket)}
+}
+
+// NextCallID returns a call id unique across every Caller this Hub has ever
+// hosted. Callers must draw ids from here rather than a local counter: two
+// Callers for the same user (a retry after Close, say) would otherwise both
+// mint "1" for their first call, and a late answer meant for the first —
+// closed and gone — could then be delivered to the second's pending call of
+// the same id.
+func (h *Hub) NextCallID() string {
+	return strconv.FormatInt(h.callSeq.Add(1), 10)
 }
 
 // Join attaches a socket as one end of a user's channel and returns the function

--- a/internal/calsync/worker.go
+++ b/internal/calsync/worker.go
@@ -191,18 +191,21 @@ func (w *Worker) syncUser(ctx context.Context, u Connection) error {
 	}
 
 	for _, ev := range events {
+		if ev.Cancelled {
+			// Ahead of the match gate, not behind it: Google guarantees only the
+			// provider's own id for a cancelled event, never the iCalUID Resolve keys
+			// on, so gating on Resolve first would drop every cancellation whose UID
+			// didn't survive. Marking beats storing: the row may already exist, and an
+			// organiser who called a meeting off has not scheduled a new one.
+			if err := w.store.CancelInterview(ctx, u.UserID, cancelKey(ev)); err != nil {
+				return fmt.Errorf("cancel %s: %w", cancelKey(ev), err)
+			}
+			continue
+		}
 		match := calmatch.Resolve(calmatch.Event{UID: ev.UID}, candidates)
 		if match.ApplicationID == 0 {
 			// Not this candidate's business with us. It is not stored, not logged, and
 			// not counted — the window was read into memory and is discarded with it.
-			continue
-		}
-		if ev.Cancelled {
-			// Marking beats storing: the row may already exist, and an organiser who
-			// called a meeting off has not scheduled a new one.
-			if err := w.store.CancelInterview(ctx, u.UserID, cancelKey(ev)); err != nil {
-				return fmt.Errorf("cancel %s: %w", ev.UID, err)
-			}
 			continue
 		}
 		if !match.Tier.Links() {

--- a/internal/calsync/worker_test.go
+++ b/internal/calsync/worker_test.go
@@ -160,6 +160,29 @@ func TestRunOnceMarksACancelledMeeting(t *testing.T) {
 	}
 }
 
+// Google only guarantees `id` for a cancelled event or occurrence — the iCalUID Resolve
+// keys on may not survive deletion at all. A cancellation like that must still reach
+// CancelInterview, keyed on the provider id, without ever going through the match gate.
+func TestRunOnceMarksACancelledMeetingWithNoUID(t *testing.T) {
+	store := &fakeStore{
+		connections: []Connection{{UserID: 7}},
+		candidates:  map[int64][]calmatch.Candidate{7: {{ApplicationID: 11, UIDs: []string{"derq@ashbyhq.com"}}}},
+	}
+	reader := fakeReader{meetings: []Meeting{
+		{ProviderID: "evt-minimal", Cancelled: true},
+	}}
+
+	if err := newTestWorker(store, reader).RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if len(store.cancelled) != 1 || store.cancelled[0] != "evt-minimal" {
+		t.Errorf("cancelled %v, want the provider id alone since Resolve can never key on an empty UID", store.cancelled)
+	}
+	if len(store.stored) != 0 {
+		t.Errorf("a cancelled meeting was also stored as current: %+v", store.stored)
+	}
+}
+
 // One candidate's revoked grant is not the fleet's problem: mark it, carry on, and let
 // the exit code say the run was not wholly clean.
 func TestRunOnceMarksAFailingGrantAndKeepsGoing(t *testing.T) {

--- a/internal/collections/register.go
+++ b/internal/collections/register.go
@@ -37,15 +37,29 @@ var legalSuffixes = map[string]struct{}{
 // empty slug, because an empty slug silently matches nothing while a bad register
 // row is worth leaving visible.
 func RegisterSlug(name string) string {
-	fields := strings.Fields(name)
-	if len(fields) < 2 {
+	fields := significantFields(name)
+	if len(fields) == 0 {
 		// Nothing to strip without erasing the name entirely.
 		return normalize.Slug(name)
 	}
-	if _, isSuffix := legalSuffixes[letters(fields[len(fields)-1])]; !isSuffix {
-		return normalize.Slug(name)
+	return normalize.Slug(strings.Join(fields, " "))
+}
+
+// significantFields splits name on whitespace and drops one trailing legal-form
+// token, the same strip RegisterSlug applies before slugging. Shared so that
+// token-counting (RequireCountry) agrees with what RegisterSlug considers the
+// name's actual content, rather than re-deriving it from the slug — which has
+// already collapsed internal punctuation ("T-Mobile" -> "t-mobile") into the same
+// hyphen it uses as a field separator.
+func significantFields(name string) []string {
+	fields := strings.Fields(name)
+	if len(fields) < 2 {
+		return fields
 	}
-	return normalize.Slug(strings.Join(fields[:len(fields)-1], " "))
+	if _, isSuffix := legalSuffixes[letters(fields[len(fields)-1])]; !isSuffix {
+		return fields
+	}
+	return fields[:len(fields)-1]
 }
 
 // letters lowercases a token down to its ASCII letters, so the punctuated and bare
@@ -93,7 +107,7 @@ func RequireCountry(code string) func(Company, Record) bool {
 		if !hasCountry(co.Countries, code) {
 			return false
 		}
-		if strings.Contains(RegisterSlug(r.Name), "-") {
+		if len(significantFields(r.Name)) > 1 {
 			return true // multi-token: the country facet carries it
 		}
 		return countryMatches(co.HQCountry, code)

--- a/internal/collections/register_test.go
+++ b/internal/collections/register_test.go
@@ -113,9 +113,10 @@ func TestRequireCountry_SingleTokenNameNeedsAMatchingHeadquarters(t *testing.T) 
 }
 
 func TestRequireCountry_PunctuatedSingleTokenNameNeedsAMatchingHeadquarters(t *testing.T) {
-	// "T-Mobile Inc" is one token by whitespace, but RegisterSlug's internal-hyphen
-	// collapsing ("t-mobile") must not make it look multi-token and skip the
-	// headquarters check.
+	// "T-Mobile Inc" has two whitespace tokens. After significantFields strips the
+	// trailing legal form, "T-Mobile" is the one significant token left; its
+	// internal hyphen must not make RequireCountry treat it as multi-token and
+	// skip the headquarters check.
 	gate := RequireCountry("GB")
 
 	elsewhere := Company{Slug: "t-mobile", Countries: []string{"GB", "US"}, HQCountry: "US"}

--- a/internal/collections/register_test.go
+++ b/internal/collections/register_test.go
@@ -112,6 +112,23 @@ func TestRequireCountry_SingleTokenNameNeedsAMatchingHeadquarters(t *testing.T) 
 	}
 }
 
+func TestRequireCountry_PunctuatedSingleTokenNameNeedsAMatchingHeadquarters(t *testing.T) {
+	// "T-Mobile Inc" is one token by whitespace, but RegisterSlug's internal-hyphen
+	// collapsing ("t-mobile") must not make it look multi-token and skip the
+	// headquarters check.
+	gate := RequireCountry("GB")
+
+	elsewhere := Company{Slug: "t-mobile", Countries: []string{"GB", "US"}, HQCountry: "US"}
+	if gate(elsewhere, Record{Name: "T-Mobile Inc"}) {
+		t.Error("a punctuated single-token name was admitted on the country facet alone")
+	}
+
+	uk := Company{Slug: "t-mobile", Countries: []string{"GB"}, HQCountry: "GB"}
+	if !gate(uk, Record{Name: "T-Mobile Inc"}) {
+		t.Error("a UK-headquartered punctuated single-token company was rejected")
+	}
+}
+
 func TestRequireCountry_SingleTokenWithNoHeadquartersIsRejected(t *testing.T) {
 	// An unknown hq_country is not evidence of a UK headquarters. Never guess.
 	gate := RequireCountry("GB")

--- a/internal/cv/store.go
+++ b/internal/cv/store.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/pgerr"
 	"github.com/strelov1/freehire/internal/resumeextract"
 )
 
@@ -324,6 +325,16 @@ func (s *Store) Tailor(ctx context.Context, userID, jobID int64, tailoredTitle s
 	doc, _ := Align(base.Document, preferred)
 	tailored, err := s.CreateTailored(ctx, userID, jobID, tailoredTitle, base.TemplateID, doc)
 	if err != nil {
+		// A concurrent call for the same vacancy can win the insert between our SELECT above
+		// and this one: cvs_user_id_job_id_tailored_uniq_idx (0091) turns the loser into a
+		// unique violation instead of a duplicate row. Re-fetch and return the winner's copy.
+		if pgerr.IsUniqueViolation(err) {
+			existing, ferr := s.tailoredForJob(ctx, userID, jobID)
+			if ferr != nil {
+				return Meta{}, Meta{}, false, ferr
+			}
+			return base.Meta, existing, false, nil
+		}
 		return Meta{}, Meta{}, false, err
 	}
 	return base.Meta, tailored, true, nil

--- a/internal/cv/store_tailor_test.go
+++ b/internal/cv/store_tailor_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"sync"
+	"sync/atomic"
 	"testing"
 
+	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/resumeextract"
 )
 
@@ -143,6 +146,77 @@ func TestStoreTailorReturnsTheExistingCopyForTheSameVacancy(t *testing.T) {
 	}
 	if other.ID == first.ID {
 		t.Error("a second vacancy reused the first vacancy's tailored CV")
+	}
+}
+
+// racingGetTailoredRepo wraps fakeRepo to force the exact race Store.Tailor's check-then-insert
+// leaves open: the first two GetTailoredForJob calls (Tailor's pre-insert existence check, one
+// per concurrent caller) rendezvous before either returns, so both callers observe "no existing
+// copy" and both proceed to CreateTailored — instead of the race depending on goroutine
+// scheduling ever lining the two calls up. Any later call (the re-fetch a caller makes after
+// losing the unique-violation race) passes straight through.
+type racingGetTailoredRepo struct {
+	*fakeRepo
+	gate  sync.WaitGroup
+	calls int32
+}
+
+func (r *racingGetTailoredRepo) GetTailoredForJob(ctx context.Context, userID, jobID int64) (db.GetTailoredCVForJobRow, error) {
+	row, err := r.fakeRepo.GetTailoredForJob(ctx, userID, jobID)
+	if atomic.AddInt32(&r.calls, 1) <= 2 {
+		r.gate.Done()
+		r.gate.Wait()
+	}
+	return row, err
+}
+
+// Two concurrent Tailor() calls for the same vacancy must land on exactly one tailored CV —
+// the race that shipped the production incident TestStoreTailorReturnsTheExistingCopyForTheSameVacancy
+// documents. The fake's CreateTailored enforces the same uniqueness cvs_user_id_job_id_tailored_uniq_idx
+// (migrations/0091) does in Postgres, and Store.Tailor must resolve the resulting collision by
+// re-fetching rather than surfacing it as an error.
+func TestStoreTailorRacesToOneTailoredCopy(t *testing.T) {
+	repo := &racingGetTailoredRepo{fakeRepo: newFakeRepo()}
+	s := NewStore(repo)
+	ctx := context.Background()
+
+	if _, err := s.Create(ctx, 7, "My CV", DefaultTemplateID, Document{Summary: "base"}); err != nil {
+		t.Fatalf("seed base: %v", err)
+	}
+
+	repo.gate.Add(2)
+	var wg sync.WaitGroup
+	results := make([]Meta, 2)
+	errs := make([]error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, tailored, _, err := s.Tailor(ctx, 7, 100, "Tailored", fakeSeeder{ok: false}, nil)
+			results[i], errs[i] = tailored, err
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("tailor call %d: %v", i, err)
+		}
+	}
+	if results[0].ID != results[1].ID {
+		t.Errorf("concurrent Tailor() calls landed on different rows: %s vs %s", results[0].ID, results[1].ID)
+	}
+
+	repo.mu.Lock()
+	tailoredCount := 0
+	for _, r := range repo.rows {
+		if r.jobID == 100 {
+			tailoredCount++
+		}
+	}
+	repo.mu.Unlock()
+	if tailoredCount != 1 {
+		t.Errorf("stored tailored CVs for job 100 = %d, want 1", tailoredCount)
 	}
 }
 

--- a/internal/cv/store_test.go
+++ b/internal/cv/store_test.go
@@ -5,17 +5,23 @@ import (
 	"errors"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/db"
 )
 
-// fakeRepo is an in-memory owner-scoped Repository for unit-testing Store without a DB.
+// fakeRepo is an in-memory owner-scoped Repository for unit-testing Store without a DB. mu
+// guards every access to rows/writes so it is also safe under the concurrent Tailor() calls
+// TestStoreTailorRacesToOneTailoredCopy makes — that test exists to exercise exactly the
+// race the real cvs_user_id_job_id_tailored_uniq_idx (0091) closes.
 type fakeRepo struct {
+	mu   sync.Mutex
 	rows map[uuid.UUID]fakeRow
 	// writes counts insertions, so a row can record the order it arrived in.
 	writes int
@@ -45,6 +51,8 @@ func newFakeRepo() *fakeRepo { return &fakeRepo{rows: map[uuid.UUID]fakeRow{}} }
 func stamp() pgtype.Timestamptz { return pgtype.Timestamptz{Valid: true} }
 
 func (f *fakeRepo) Create(_ context.Context, userID int64, title, templateID string, data []byte) (db.CreateCVRow, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	id := uuid.New()
 	f.writes++
 	f.rows[id] = fakeRow{seq: f.writes, userID: userID, title: title, templateID: templateID, data: data}
@@ -52,6 +60,8 @@ func (f *fakeRepo) Create(_ context.Context, userID int64, title, templateID str
 }
 
 func (f *fakeRepo) List(_ context.Context, userID int64) ([]db.ListCVsByUserRow, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	var out []db.ListCVsByUserRow
 	for id, r := range f.rows {
 		if r.userID == userID {
@@ -62,6 +72,8 @@ func (f *fakeRepo) List(_ context.Context, userID int64) ([]db.ListCVsByUserRow,
 }
 
 func (f *fakeRepo) Get(_ context.Context, id uuid.UUID, userID int64) (db.GetCVByIDRow, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	r, ok := f.rows[id]
 	if !ok || r.userID != userID {
 		return db.GetCVByIDRow{}, pgx.ErrNoRows
@@ -70,6 +82,8 @@ func (f *fakeRepo) Get(_ context.Context, id uuid.UUID, userID int64) (db.GetCVB
 }
 
 func (f *fakeRepo) SetSession(_ context.Context, id uuid.UUID, userID int64, sessionID string) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	r, ok := f.rows[id]
 	if !ok || r.userID != userID {
 		return 0, nil
@@ -80,6 +94,8 @@ func (f *fakeRepo) SetSession(_ context.Context, id uuid.UUID, userID int64, ses
 }
 
 func (f *fakeRepo) SetTracerLinks(_ context.Context, id uuid.UUID, userID int64, enabled bool) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	r, ok := f.rows[id]
 	if !ok || r.userID != userID {
 		return 0, nil
@@ -90,6 +106,8 @@ func (f *fakeRepo) SetTracerLinks(_ context.Context, id uuid.UUID, userID int64,
 }
 
 func (f *fakeRepo) ListTailored(_ context.Context, userID int64) ([]db.ListTailoredCVsByUserRow, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	var out []db.ListTailoredCVsByUserRow
 	for id, r := range f.rows {
 		if r.userID == userID && r.jobID != 0 {
@@ -104,6 +122,8 @@ func (f *fakeRepo) ListTailored(_ context.Context, userID int64) ([]db.ListTailo
 }
 
 func (f *fakeRepo) Update(_ context.Context, id uuid.UUID, userID int64, title, templateID string, data []byte) (db.UpdateCVRow, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	r, ok := f.rows[id]
 	if !ok || r.userID != userID {
 		return db.UpdateCVRow{}, pgx.ErrNoRows
@@ -113,6 +133,8 @@ func (f *fakeRepo) Update(_ context.Context, id uuid.UUID, userID int64, title, 
 }
 
 func (f *fakeRepo) Delete(_ context.Context, id uuid.UUID, userID int64) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if r, ok := f.rows[id]; !ok || r.userID != userID {
 		return 0, nil
 	}
@@ -121,6 +143,8 @@ func (f *fakeRepo) Delete(_ context.Context, id uuid.UUID, userID int64) (int64,
 }
 
 func (f *fakeRepo) GetBase(_ context.Context, userID int64) (db.GetBaseCVByUserRow, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	// Newest base CV = the most recently written of the user's non-tailored rows.
 	var bestID uuid.UUID
 	best := 0
@@ -136,9 +160,20 @@ func (f *fakeRepo) GetBase(_ context.Context, userID int64) (db.GetBaseCVByUserR
 	return db.GetBaseCVByUserRow{ID: bestID, Title: r.title, TemplateID: r.templateID, Data: r.data, CreatedAt: stamp(), UpdatedAt: stamp()}, nil
 }
 
+// CreateTailored mimics cvs_user_id_job_id_tailored_uniq_idx (migrations/0091): a second
+// insert for a (userID, jobID) that already has a tailored row fails exactly as Postgres
+// would, with a 23505 pgconn.PgError, instead of silently minting a duplicate.
 func (f *fakeRepo) CreateTailored(_ context.Context, userID, jobID int64, title, templateID string, data []byte) (db.CreateTailoredCVRow, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, r := range f.rows {
+		if r.userID == userID && r.jobID == jobID && jobID != 0 {
+			return db.CreateTailoredCVRow{}, &pgconn.PgError{Code: "23505"}
+		}
+	}
 	id := uuid.New()
-	f.rows[id] = fakeRow{userID: userID, title: title, templateID: templateID, data: data, jobID: jobID}
+	f.writes++
+	f.rows[id] = fakeRow{seq: f.writes, userID: userID, title: title, templateID: templateID, data: data, jobID: jobID}
 	return db.CreateTailoredCVRow{ID: id, Title: title, TemplateID: templateID, CreatedAt: stamp(), UpdatedAt: stamp()}, nil
 }
 
@@ -312,6 +347,8 @@ func TestStoreDeleteThenGetIsNotFound(t *testing.T) {
 }
 
 func (f *fakeRepo) SetAutopilotReport(_ context.Context, id uuid.UUID, userID int64, report []byte) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	r, ok := f.rows[id]
 	if !ok || r.userID != userID {
 		return 0, nil
@@ -322,6 +359,8 @@ func (f *fakeRepo) SetAutopilotReport(_ context.Context, id uuid.UUID, userID in
 }
 
 func (f *fakeRepo) GetTailoredForJob(_ context.Context, userID, jobID int64) (db.GetTailoredCVForJobRow, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	// Newest by insertion order, mirroring the query's `updated_at DESC, id DESC`.
 	var bestID uuid.UUID
 	var best *fakeRow

--- a/internal/db/job_reports.sql.go
+++ b/internal/db/job_reports.sql.go
@@ -11,6 +11,28 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const countReportsFiledSince = `-- name: CountReportsFiledSince :one
+SELECT count(*) FROM job_reports
+WHERE reported_by = $1::bigint
+  AND created_at >= $2::timestamptz
+`
+
+type CountReportsFiledSinceParams struct {
+	ReportedBy int64              `json:"reported_by"`
+	Since      pgtype.Timestamptz `json:"since"`
+}
+
+// How many reports this account has filed since a cutoff, for the daily cap
+// (ghost_reports.CountGhostReportsSince's counterpart for this queue). Counts every status,
+// not just pending: a report already resolved or dismissed still consumed the reporter's
+// daily allowance, so excluding it would let a decided report be re-filed for free.
+func (q *Queries) CountReportsFiledSince(ctx context.Context, arg CountReportsFiledSinceParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countReportsFiledSince, arg.ReportedBy, arg.Since)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createReport = `-- name: CreateReport :one
 INSERT INTO job_reports (
     reported_by, job_id, reason, details, contact_telegram

--- a/internal/db/nudges.sql.go
+++ b/internal/db/nudges.sql.go
@@ -84,6 +84,7 @@ SELECT n.id, n.user_id, n.job_id, n.kind,
        COALESCE(ns.enabled, false)::bool AS notifications_enabled,
        COALESCE(ns.channels, '{}'::text[]) AS channels,
        a.stage,
+       (a.user_id IS NOT NULL)::bool AS application_exists,
        GREATEST(a.applied_at, mail.newest_mail_at)::timestamptz AS last_activity_at,
        COALESCE(mail.suggestion_pending, false)::boolean AS has_pending_suggestion,
        u.email AS account_email,
@@ -119,6 +120,7 @@ type GetNudgeForDeliveryRow struct {
 	NotificationsEnabled bool               `json:"notifications_enabled"`
 	Channels             []string           `json:"channels"`
 	Stage                pgtype.Text        `json:"stage"`
+	ApplicationExists    bool               `json:"application_exists"`
 	LastActivityAt       pgtype.Timestamptz `json:"last_activity_at"`
 	HasPendingSuggestion bool               `json:"has_pending_suggestion"`
 	AccountEmail         string             `json:"account_email"`
@@ -132,7 +134,10 @@ type GetNudgeForDeliveryRow struct {
 // live destinations, and the application's CURRENT stage/last-activity/pending-
 // suggestion so the worker can recompute the triggering condition rather than
 // trust what MATCH saw. job_open lets the worker cancel a nudge for a job that
-// has since closed.
+// has since closed. application_exists distinguishes "no applications row at
+// all" (untracked since MATCH) from "row exists with a NULL stage" — the LEFT
+// JOIN alone leaves stage NULL in both cases, which would otherwise be judged
+// as the active `applied` stage by userjob.SilenceThresholdDays.
 func (q *Queries) GetNudgeForDelivery(ctx context.Context, id int64) (GetNudgeForDeliveryRow, error) {
 	row := q.db.QueryRow(ctx, getNudgeForDelivery, id)
 	var i GetNudgeForDeliveryRow
@@ -149,6 +154,7 @@ func (q *Queries) GetNudgeForDelivery(ctx context.Context, id int64) (GetNudgeFo
 		&i.NotificationsEnabled,
 		&i.Channels,
 		&i.Stage,
+		&i.ApplicationExists,
 		&i.LastActivityAt,
 		&i.HasPendingSuggestion,
 		&i.AccountEmail,

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1147,7 +1147,10 @@ type Querier interface {
 	// live destinations, and the application's CURRENT stage/last-activity/pending-
 	// suggestion so the worker can recompute the triggering condition rather than
 	// trust what MATCH saw. job_open lets the worker cancel a nudge for a job that
-	// has since closed.
+	// has since closed. application_exists distinguishes "no applications row at
+	// all" (untracked since MATCH) from "row exists with a NULL stage" — the LEFT
+	// JOIN alone leaves stage NULL in both cases, which would otherwise be judged
+	// as the active `applied` stage by userjob.SilenceThresholdDays.
 	GetNudgeForDelivery(ctx context.Context, id int64) (GetNudgeForDeliveryRow, error)
 	// Public read of a shared board by its slug — no auth, no owner-scoping. Exposes only
 	// the board's display fields; owner columns (user_id) are never selected. A NULL slug

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -520,6 +520,11 @@ type Querier interface {
 	CountRecentUserJobAnalyses(ctx context.Context, arg CountRecentUserJobAnalysesParams) (int64, error)
 	// How many requests a seeker has created since a cutoff — the per-day cap check.
 	CountReferralRequestsSince(ctx context.Context, arg CountReferralRequestsSinceParams) (int64, error)
+	// How many reports this account has filed since a cutoff, for the daily cap
+	// (ghost_reports.CountGhostReportsSince's counterpart for this queue). Counts every status,
+	// not just pending: a report already resolved or dismissed still consumed the reporter's
+	// daily allowance, so excluding it would let a decided report be re-filed for free.
+	CountReportsFiledSince(ctx context.Context, arg CountReportsFiledSinceParams) (int64, error)
 	// How many saved searches a user has — the per-user cap is enforced against this in
 	// the service before a create.
 	CountSavedSearches(ctx context.Context, userID int64) (int64, error)

--- a/internal/db/queries/job_reports.sql
+++ b/internal/db/queries/job_reports.sql
@@ -59,3 +59,12 @@ SET status        = 'dismissed',
     review_reason = sqlc.arg(review_reason)
 WHERE id = sqlc.arg(id) AND status = 'pending'
 RETURNING *;
+
+-- name: CountReportsFiledSince :one
+-- How many reports this account has filed since a cutoff, for the daily cap
+-- (ghost_reports.CountGhostReportsSince's counterpart for this queue). Counts every status,
+-- not just pending: a report already resolved or dismissed still consumed the reporter's
+-- daily allowance, so excluding it would let a decided report be re-filed for free.
+SELECT count(*) FROM job_reports
+WHERE reported_by = sqlc.arg(reported_by)::bigint
+  AND created_at >= sqlc.arg(since)::timestamptz;

--- a/internal/db/queries/nudges.sql
+++ b/internal/db/queries/nudges.sql
@@ -91,13 +91,17 @@ RETURNING n.id;
 -- live destinations, and the application's CURRENT stage/last-activity/pending-
 -- suggestion so the worker can recompute the triggering condition rather than
 -- trust what MATCH saw. job_open lets the worker cancel a nudge for a job that
--- has since closed.
+-- has since closed. application_exists distinguishes "no applications row at
+-- all" (untracked since MATCH) from "row exists with a NULL stage" — the LEFT
+-- JOIN alone leaves stage NULL in both cases, which would otherwise be judged
+-- as the active `applied` stage by userjob.SilenceThresholdDays.
 SELECT n.id, n.user_id, n.job_id, n.kind,
        j.title, j.company, j.public_slug, j.url,
        (j.closed_at IS NULL)::bool AS job_open,
        COALESCE(ns.enabled, false)::bool AS notifications_enabled,
        COALESCE(ns.channels, '{}'::text[]) AS channels,
        a.stage,
+       (a.user_id IS NOT NULL)::bool AS application_exists,
        GREATEST(a.applied_at, mail.newest_mail_at)::timestamptz AS last_activity_at,
        COALESCE(mail.suggestion_pending, false)::boolean AS has_pending_suggestion,
        u.email AS account_email,

--- a/internal/gmailsync/worker.go
+++ b/internal/gmailsync/worker.go
@@ -111,10 +111,12 @@ func (w *Worker) syncUser(ctx context.Context, u Connection) {
 
 	// fetch persists one message, deduping by id, tracking the watermark, and
 	// recording its thread for expansion. The user's own in-thread replies are
-	// skipped — the inbox stores inbound mail only. Once any message in the wave
-	// fails, the watermark stops advancing (fetching still proceeds best-effort)
-	// so the next run's cursor-filtered query still surfaces the failed message
-	// instead of it being silently skipped by a watermark that moved past it.
+	// skipped — the inbox stores inbound mail only. newest tracks the highest
+	// ReceivedAt seen regardless of order; once any message in the wave fails,
+	// it is reset to u.Cursor right before SetSynced (below) rather than merely
+	// frozen at whatever it last reached — a newer message can easily succeed
+	// (and advance newest) BEFORE an older sibling in the same wave fails, and
+	// freezing in place would still let the watermark jump past the failed one.
 	fetch := func(id string) {
 		if seen[id] {
 			return
@@ -138,10 +140,8 @@ func (w *Worker) syncUser(ctx context.Context, u Connection) {
 			sawFailure = true
 			return
 		}
-		if !sawFailure {
-			if ts := msg.ReceivedAt.Unix(); ts > newest {
-				newest = ts
-			}
+		if ts := msg.ReceivedAt.Unix(); ts > newest {
+			newest = ts
 		}
 	}
 
@@ -162,6 +162,9 @@ func (w *Worker) syncUser(ctx context.Context, u Connection) {
 		}
 	}
 
+	if sawFailure {
+		newest = u.Cursor
+	}
 	if err := w.store.SetSynced(ctx, u.UserID, newest); err != nil {
 		log.Printf("gmail-sync: user %d: set synced: %v", u.UserID, err)
 	}

--- a/internal/gmailsync/worker.go
+++ b/internal/gmailsync/worker.go
@@ -104,13 +104,17 @@ func (w *Worker) syncUser(ctx context.Context, u Connection) {
 	}
 
 	newest := u.Cursor
+	sawFailure := false
 	seen := make(map[string]bool)
 	seenThread := make(map[string]bool)
 	var threadIDs []string
 
 	// fetch persists one message, deduping by id, tracking the watermark, and
 	// recording its thread for expansion. The user's own in-thread replies are
-	// skipped — the inbox stores inbound mail only.
+	// skipped — the inbox stores inbound mail only. Once any message in the wave
+	// fails, the watermark stops advancing (fetching still proceeds best-effort)
+	// so the next run's cursor-filtered query still surfaces the failed message
+	// instead of it being silently skipped by a watermark that moved past it.
 	fetch := func(id string) {
 		if seen[id] {
 			return
@@ -119,6 +123,7 @@ func (w *Worker) syncUser(ctx context.Context, u Connection) {
 		msg, err := reader.GetMessage(ctx, id)
 		if err != nil {
 			log.Printf("gmail-sync: user %d: get %s: %v", u.UserID, id, err)
+			sawFailure = true
 			return
 		}
 		if msg.ThreadID != "" && !seenThread[msg.ThreadID] {
@@ -130,10 +135,13 @@ func (w *Worker) syncUser(ctx context.Context, u Connection) {
 		}
 		if err := w.store.UpsertEmail(ctx, StoredEmail{UserID: u.UserID, Message: msg}); err != nil {
 			log.Printf("gmail-sync: user %d: store %s: %v", u.UserID, id, err)
+			sawFailure = true
 			return
 		}
-		if ts := msg.ReceivedAt.Unix(); ts > newest {
-			newest = ts
+		if !sawFailure {
+			if ts := msg.ReceivedAt.Unix(); ts > newest {
+				newest = ts
+			}
 		}
 	}
 

--- a/internal/gmailsync/worker_test.go
+++ b/internal/gmailsync/worker_test.go
@@ -138,7 +138,10 @@ func TestRunOnceExpandsThread(t *testing.T) {
 // message in a wave stops the watermark from advancing past it, even when a
 // later-processed message in the same wave is newer and stores fine — otherwise
 // the failed message's timestamp falls at-or-before the next run's cursor filter
-// and is never retried.
+// and is never retried. In this specific ordering (the failure is processed
+// before any success) newest never left u.Cursor in the first place, so it does
+// not by itself distinguish "freeze in place" from "rewind to u.Cursor" — see
+// TestRunOnceRewindsWatermarkWhenASuccessPrecedesAFailure for that.
 func TestRunOnceFreezesWatermarkOnFailure(t *testing.T) {
 	c := testCipher(t)
 	enc, _ := c.Encrypt("refresh-token")
@@ -169,6 +172,73 @@ func TestRunOnceFreezesWatermarkOnFailure(t *testing.T) {
 	}
 	if store.syncedCursor >= t1.Unix() {
 		t.Errorf("cursor = %d, want < %d (m1's timestamp) so the failed message is retried next run", store.syncedCursor, t1.Unix())
+	}
+}
+
+// TestRunOnceRewindsWatermarkWhenASuccessPrecedesAFailure covers the ordering
+// ListATSMessageIDs actually returns in production (newest first): a newer
+// message stores fine and advances newest, then an older sibling in the same
+// wave fails. A watermark that was merely frozen at whatever it last reached
+// would still persist the newer message's timestamp — past the failed one —
+// so the fix must rewind newest to u.Cursor, not just stop advancing it.
+func TestRunOnceRewindsWatermarkWhenASuccessPrecedesAFailure(t *testing.T) {
+	c := testCipher(t)
+	enc, _ := c.Encrypt("refresh-token")
+	store := &fakeStore{
+		conns:        []Connection{{UserID: 7, Email: "u@gmail.com", Cursor: 0}},
+		encToken:     enc,
+		upsertErrIDs: map[string]bool{"m1": true},
+	}
+	t1 := time.Unix(1_700_000_100, 0) // older, fails to store, processed SECOND
+	t2 := time.Unix(1_700_000_500, 0) // newer, stores fine, processed FIRST
+	reader := &fakeReader{
+		ids: []string{"m2", "m1"}, // newest-first, as the real Gmail list API returns
+		byID: map[string]Message{
+			"m1": {ID: "m1", Subject: "Thank you for applying to Acme", ReceivedAt: t1},
+			"m2": {ID: "m2", Subject: "Thank you for applying to Widget Co", ReceivedAt: t2},
+		},
+	}
+	w := NewWorker(store, c, func(context.Context, string, []string) GmailReader { return reader })
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if len(store.upserted) != 1 || store.upserted[0].Message.ID != "m2" {
+		t.Fatalf("upserted = %v, want only m2 (m1 fails)", store.upserted)
+	}
+	if store.syncedCursor != 0 {
+		t.Errorf("cursor = %d, want 0 (u.Cursor): a success before the failure must not leave the watermark past it", store.syncedCursor)
+	}
+}
+
+// TestRunOnceRewindsWatermarkOnAFailedThreadSibling covers a failure reached
+// only through thread expansion, after the main wave already advanced newest.
+func TestRunOnceRewindsWatermarkOnAFailedThreadSibling(t *testing.T) {
+	c := testCipher(t)
+	enc, _ := c.Encrypt("refresh-token")
+	store := &fakeStore{
+		conns:        []Connection{{UserID: 7, Email: "me@gmail.com", Cursor: 0}},
+		encToken:     enc,
+		upsertErrIDs: map[string]bool{"m3": true},
+	}
+	reader := &fakeReader{
+		ids: []string{"m1"},
+		byID: map[string]Message{
+			"m1": {ID: "m1", ThreadID: "t1", FromAddr: "no-reply@ashbyhq.com", Subject: "Thanks for applying", ReceivedAt: time.Unix(1_700_000_100, 0)},
+			"m3": {ID: "m3", ThreadID: "t1", FromAddr: "recruiter@acme-personal.com", Subject: "Re: a few questions", ReceivedAt: time.Unix(1_700_000_300, 0)},
+		},
+		threads: map[string][]string{"t1": {"m1", "m3"}},
+	}
+	w := NewWorker(store, c, func(context.Context, string, []string) GmailReader { return reader })
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if len(store.upserted) != 1 || store.upserted[0].Message.ID != "m1" {
+		t.Fatalf("upserted = %v, want only m1 (thread sibling m3 fails)", store.upserted)
+	}
+	if store.syncedCursor != 0 {
+		t.Errorf("cursor = %d, want 0 (u.Cursor): a thread-sibling failure must still rewind the watermark", store.syncedCursor)
 	}
 }
 

--- a/internal/gmailsync/worker_test.go
+++ b/internal/gmailsync/worker_test.go
@@ -23,6 +23,7 @@ type fakeStore struct {
 	conns          []Connection
 	encToken       string
 	upserted       []StoredEmail
+	upsertErrIDs   map[string]bool // message ids on which UpsertEmail fails
 	syncedCursor   int64
 	syncedCalled   bool
 	reconsentUsers []int64
@@ -31,6 +32,9 @@ type fakeStore struct {
 func (f *fakeStore) ListConnected(context.Context) ([]Connection, error) { return f.conns, nil }
 func (f *fakeStore) RefreshToken(context.Context, int64) (string, error) { return f.encToken, nil }
 func (f *fakeStore) UpsertEmail(_ context.Context, e StoredEmail) error {
+	if f.upsertErrIDs[e.Message.ID] {
+		return errors.New("store: transient failure")
+	}
 	f.upserted = append(f.upserted, e)
 	return nil
 }
@@ -127,6 +131,44 @@ func TestRunOnceExpandsThread(t *testing.T) {
 	}
 	if len(store.upserted) != 2 {
 		t.Errorf("upserted = %d, want 2 (m1, m3; no dupes)", len(store.upserted))
+	}
+}
+
+// TestRunOnceFreezesWatermarkOnFailure locks in that a transient failure on one
+// message in a wave stops the watermark from advancing past it, even when a
+// later-processed message in the same wave is newer and stores fine — otherwise
+// the failed message's timestamp falls at-or-before the next run's cursor filter
+// and is never retried.
+func TestRunOnceFreezesWatermarkOnFailure(t *testing.T) {
+	c := testCipher(t)
+	enc, _ := c.Encrypt("refresh-token")
+	store := &fakeStore{
+		conns:        []Connection{{UserID: 7, Email: "u@gmail.com", Cursor: 0}},
+		encToken:     enc,
+		upsertErrIDs: map[string]bool{"m1": true},
+	}
+	t1 := time.Unix(1_700_000_100, 0) // older, fails to store
+	t2 := time.Unix(1_700_000_500, 0) // newer, stores fine
+	reader := &fakeReader{
+		ids: []string{"m1", "m2"},
+		byID: map[string]Message{
+			"m1": {ID: "m1", Subject: "Thank you for applying to Acme", ReceivedAt: t1},
+			"m2": {ID: "m2", Subject: "Thank you for applying to Widget Co", ReceivedAt: t2},
+		},
+	}
+	w := NewWorker(store, c, func(context.Context, string, []string) GmailReader { return reader })
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if len(store.upserted) != 1 || store.upserted[0].Message.ID != "m2" {
+		t.Fatalf("upserted = %v, want only m2 (m1 fails)", store.upserted)
+	}
+	if !store.syncedCalled {
+		t.Fatal("SetSynced not called")
+	}
+	if store.syncedCursor >= t1.Unix() {
+		t.Errorf("cursor = %d, want < %d (m1's timestamp) so the failed message is retried next run", store.syncedCursor, t1.Unix())
 	}
 }
 

--- a/internal/handler/match_analysis_stream.go
+++ b/internal/handler/match_analysis_stream.go
@@ -16,6 +16,7 @@ import (
 	"github.com/valyala/fasthttp"
 
 	"github.com/strelov1/freehire/internal/credits"
+	"github.com/strelov1/freehire/internal/hardconstraint"
 	"github.com/strelov1/freehire/internal/jobmatch"
 	"github.com/strelov1/freehire/internal/matchanalysis"
 )
@@ -55,8 +56,12 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 	profile, _ := h.userProfile.Get(c.Context(), userID)
 
 	// Compute the hard-constraint blockers exactly as the POST path does: the unmet
-	// ones ground the prompt. The served-score cap needs no handling here — the cache
-	// holds the uncapped analysis and GET recomputes the cap on read.
+	// ones ground the prompt, and the same list caps the `final` event below. Unlike
+	// GET, a stream reader never comes back for a recompute-on-read — this event IS
+	// the served response — so the ceiling has to be applied here, not skipped on the
+	// assumption a later GET will do it. The cache still holds the uncapped analysis,
+	// exactly as the POST path leaves it, so a dictionary change still takes effect
+	// on a later GET with no cache invalidation.
 	blockers := h.jobBlockers(c.Context(), userID, job, profile)
 
 	// Bound before the stream opens: minting a credential is a network call, and making
@@ -122,7 +127,7 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 
 		analysis, err := analyzer.AnalyzeStream(ctx, input, func(e matchanalysis.Event) {
 			events++
-			stream.event(string(e.Kind), e)
+			stream.event(string(e.Kind), capFinalEvent(e, blockers))
 		})
 		stopHeartbeat()
 		if err != nil {
@@ -142,6 +147,27 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 		log.Printf("matchanalysis: stream DONE user=%d job=%d dur=%s events=%d overall=%d", userID, job.ID, time.Since(start).Round(time.Millisecond), events, analysis.OverallScore)
 	}))
 	return nil
+}
+
+// capFinalEvent applies the caller's hard-constraint blockers to the audited `final`
+// event's analysis before it goes out over the wire — the same ceiling GetMatchAnalysis
+// (capServedAnalysis) and PostMatchAnalysis (applyBlockers) apply, so a stream reader
+// never sees an uncapped, blocker-free score just because a GET recompute never runs for
+// them. Every other event kind passes through unchanged.
+//
+// It caps a COPY of the analysis rather than the one e.Analysis points to: that pointer
+// is the same object AnalyzeStream returns to the caller, which still feeds
+// h.cacheAnalysis right after and must stay uncapped there, exactly as the POST path's
+// cache write does — so a later dictionary change still takes effect on a GET with no
+// cache invalidation.
+func capFinalEvent(e matchanalysis.Event, blockers []hardconstraint.Blocker) matchanalysis.Event {
+	if e.Kind != matchanalysis.EventFinal || e.Analysis == nil {
+		return e
+	}
+	served := *e.Analysis
+	applyBlockers(&served, blockers)
+	e.Analysis = &served
+	return e
 }
 
 // reportStreamFault sends a fault that surfaced AFTER the response body began streaming

--- a/internal/handler/match_analysis_stream_test.go
+++ b/internal/handler/match_analysis_stream_test.go
@@ -14,7 +14,65 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/hardconstraint"
+	"github.com/strelov1/freehire/internal/matchanalysis"
+	"github.com/strelov1/freehire/internal/resumeextract"
+	"github.com/strelov1/freehire/internal/userprofile"
 )
+
+// TestCapFinalEvent_CapsTheStreamedFinalEventByUnmetHardConstraint mirrors
+// hardconstraint_e2e_test.go's TestServedAnalysisCappedByUnmetHardConstraint, but for the
+// Stream path: it drives the same real blocker-evaluation chain (build inputs from the
+// job + résumé, evaluate blockers) and asserts capFinalEvent — what StreamMatchAnalysis
+// applies to the `final` SSE event right before writing it — caps the over-optimistic
+// score and surfaces the blocker, exactly as GET/POST already do for their own served
+// copies.
+func TestCapFinalEvent_CapsTheStreamedFinalEventByUnmetHardConstraint(t *testing.T) {
+	job := db.Job{Description: "Requires an active PMP certification."}
+	cv := resumeextract.Structured{Certifications: []string{"AWS Certified Solutions Architect"}} // lists certs, not PMP
+	jr, ev := buildHardConstraintInputs(job, cv.Professional(), userprofile.LocationPreferences{}, nil)
+	blockers := hardconstraint.Evaluate(jr, ev)
+
+	uncapped := &matchanalysis.Analysis{OverallScore: 88, Verdict: "Strong Fit"}
+	final := matchanalysis.Event{Kind: matchanalysis.EventFinal, Analysis: uncapped}
+
+	served := capFinalEvent(final, blockers)
+
+	if served.Analysis.OverallScore != 60 { // certification score-cap
+		t.Errorf("streamed overall_score = %d, want 60 (capped by unmet PMP)", served.Analysis.OverallScore)
+	}
+	var sawCert bool
+	for _, b := range served.Analysis.Blockers {
+		if b.Category == hardconstraint.CategoryCertification && !b.Met {
+			sawCert = true
+		}
+	}
+	if !sawCert {
+		t.Error("streamed final event should surface the unmet certification blocker")
+	}
+
+	// The object AnalyzeStream returns to StreamMatchAnalysis — the one h.cacheAnalysis
+	// upserts right after — must stay uncapped, exactly as PostMatchAnalysis leaves the
+	// cache: capFinalEvent must cap a copy, never the caller's own Analysis.
+	if uncapped.OverallScore != 88 {
+		t.Errorf("the analysis fed to h.cacheAnalysis was mutated: overall_score = %d, want 88 (uncapped)", uncapped.OverallScore)
+	}
+	if len(uncapped.Blockers) != 0 {
+		t.Errorf("the analysis fed to h.cacheAnalysis carries blockers = %v, want none (uncapped, cache-side copy)", uncapped.Blockers)
+	}
+}
+
+// A non-final event (stage_start, thinking, ...) must pass through untouched — the cap
+// only ever applies to the audited final analysis.
+func TestCapFinalEvent_NoOpForNonFinalEvents(t *testing.T) {
+	e := matchanalysis.Event{Kind: matchanalysis.EventStageStart, Stage: 1, Label: "Extract & Match"}
+	got := capFinalEvent(e, []hardconstraint.Blocker{{Category: hardconstraint.CategoryCertification}})
+	if got.Kind != e.Kind || got.Stage != e.Stage || got.Label != e.Label || got.Analysis != e.Analysis {
+		t.Errorf("capFinalEvent altered a non-final event: got %+v, want unchanged %+v", got, e)
+	}
+}
 
 // stalledConn models the socket of a reader that stopped reading: writes block until the
 // write deadline the caller set, then fail the way a real one does. With no deadline set

--- a/internal/handler/reports.go
+++ b/internal/handler/reports.go
@@ -107,6 +107,8 @@ func reportError(err error) error {
 		return fiber.NewError(fiber.StatusConflict, "report already decided")
 	case errors.Is(err, report.ErrInvalid):
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	case errors.Is(err, report.ErrRateLimited):
+		return fiber.NewError(fiber.StatusTooManyRequests, "too many reports today")
 	default:
 		return err
 	}

--- a/internal/linksource/boardcoverage.go
+++ b/internal/linksource/boardcoverage.go
@@ -98,7 +98,7 @@ func ResolveOnBoard(ctx context.Context, reg map[string]sources.Source, source, 
 		return sources.Job{}, false, nil
 	}
 
-	jobs, err := adapter.Fetch(ctx, sources.CompanyEntry{Provider: source, Board: board})
+	jobs, err := fetchForResolve(ctx, adapter, sources.CompanyEntry{Provider: source, Board: board}, raw)
 	if err != nil {
 		return sources.Job{}, false, err
 	}
@@ -111,6 +111,26 @@ func ResolveOnBoard(ctx context.Context, reg map[string]sources.Source, source, 
 	// board dedups onto the row this import writes instead of adding a second posting.
 	job.ExternalID = sources.NamespaceExternalID(board, job.ExternalID)
 	return job, true, nil
+}
+
+// fetchForResolve fetches a board through the adapter, preferring a HydratingSource's FetchNew
+// over Fetch: for such an adapter Fetch hydrates every posting (e.g. workday.Fetch), so resolving
+// one pasted link would otherwise trigger a full multi-thousand-posting hydration crawl. FetchNew
+// takes a seen predicate; supplying one that reports every posting EXCEPT the one raw points at as
+// already seen limits hydration to just that posting — the mirror image of how
+// pipeline.Runner.fetchBoard uses the same predicate to skip postings the store already has. The
+// target's external id is guessed from raw's path segments, the same heuristic pickPosting's id
+// fallback uses to identify a posting once the board is in hand.
+func fetchForResolve(ctx context.Context, adapter sources.Source, e sources.CompanyEntry, raw string) ([]sources.Job, error) {
+	hs, hydrating := adapter.(sources.HydratingSource)
+	if !hydrating {
+		return adapter.Fetch(ctx, e)
+	}
+	want := pathSegmentsFromEnd(raw)
+	seen := func(externalID string) bool {
+		return !slices.Contains(want, externalID)
+	}
+	return hs.FetchNew(ctx, e, seen)
 }
 
 // pickPosting finds the posting a link refers to among a board's postings. It tries the URL

--- a/internal/linksource/boardcoverage_test.go
+++ b/internal/linksource/boardcoverage_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"testing"
 
 	"github.com/strelov1/freehire/internal/sources"
@@ -167,6 +168,64 @@ func TestBoardCoverageMatchesAVacancyByAnIDBeforeTheSlug(t *testing.T) {
 	}
 	if job.Title != "Senior Go" {
 		t.Errorf("resolved %q, want Senior Go", job.Title)
+	}
+}
+
+// fakeHydratingBoard is a stand-in for a HydratingSource ingest adapter (e.g. workday): FetchNew
+// hydrates full detail only for the postings its seen predicate reports as new, recording which
+// ones so a test can pin exactly what got hydrated. Fetch is the list-only fallback and records
+// whether it was called at all — ResolveOnBoard must prefer FetchNew.
+type fakeHydratingBoard struct {
+	provider string
+	jobs     []sources.Job
+	fetched  bool
+	hydrated []string
+}
+
+func (f *fakeHydratingBoard) Provider() string { return f.provider }
+
+func (f *fakeHydratingBoard) Fetch(_ context.Context, _ sources.CompanyEntry) ([]sources.Job, error) {
+	f.fetched = true
+	return f.jobs, nil
+}
+
+func (f *fakeHydratingBoard) FetchNew(_ context.Context, _ sources.CompanyEntry, seen func(externalID string) bool) ([]sources.Job, error) {
+	out := make([]sources.Job, 0, len(f.jobs))
+	for _, j := range f.jobs {
+		if seen(j.ExternalID) {
+			out = append(out, sources.Job{ExternalID: j.ExternalID, URL: j.URL, Title: j.Title, SeenRefresh: true})
+			continue
+		}
+		f.hydrated = append(f.hydrated, j.ExternalID)
+		out = append(out, j)
+	}
+	return out, nil
+}
+
+func TestResolveOnBoardHydratesOnlyTheTargetPostingOnAHydratingSource(t *testing.T) {
+	board := &fakeHydratingBoard{
+		provider: "workday",
+		jobs: []sources.Job{
+			{ExternalID: "111", URL: "https://acme.wd1.myworkdayjobs.com/en-US/careers/job/111", Title: "Junior Go", Description: "full detail 111"},
+			{ExternalID: "222", URL: "https://acme.wd1.myworkdayjobs.com/en-US/careers/job/222", Title: "Senior Go", Description: "full detail 222"},
+			{ExternalID: "333", URL: "https://acme.wd1.myworkdayjobs.com/en-US/careers/job/333", Title: "Staff Go", Description: "full detail 333"},
+		},
+	}
+	reg := map[string]sources.Source{"workday": board}
+
+	raw := "https://acme.wd1.myworkdayjobs.com/en-US/careers/job/222"
+	job, ok, err := ResolveOnBoard(context.Background(), reg, "workday", "acme", raw)
+	if err != nil || !ok {
+		t.Fatalf("ResolveOnBoard = (ok %v, err %v), want the linked vacancy", ok, err)
+	}
+	if job.Title != "Senior Go" || job.Description != "full detail 222" {
+		t.Errorf("resolved %+v, want the fully hydrated Senior Go posting", job)
+	}
+	if board.fetched {
+		t.Error("Fetch was called — ResolveOnBoard must prefer FetchNew for a HydratingSource, to avoid hydrating the whole board")
+	}
+	if want := []string{"222"}; !slices.Equal(board.hydrated, want) {
+		t.Errorf("hydrated postings = %v, want only %v — resolving one link must not hydrate the rest of the board", board.hydrated, want)
 	}
 }
 

--- a/internal/location/dictionaries.go
+++ b/internal/location/dictionaries.go
@@ -368,6 +368,31 @@ var subdivisionToCountry = map[string]string{
 	"yukon": "ca", "nunavut": "ca",
 }
 
+// collidingSubdivisions is the subset of subdivisionToCountry's two-letter codes
+// that also spell a curated country's ISO 3166-1 alpha-2 code: "il" (Illinois vs
+// Israel), "la" (Louisiana vs Laos), "pa" (Pennsylvania vs Panama), "mn"
+// (Minnesota vs Mongolia), "sk" (Saskatchewan vs Slovakia), and about a dozen
+// more. resolveSubdivision only accepts the US/CA reading for one of these when
+// the neighbouring city token names a recognized US/CA place (subdivisionAccepted
+// in location.go); otherwise the bare-country-code interpretation wins. Computed
+// rather than hand-listed so it can never drift from the two source tables. "ca"
+// is deliberately excluded — see subdivisionToCountry's comment above: "City, CA"
+// stays California.
+var collidingSubdivisions = computeCollidingSubdivisions()
+
+func computeCollidingSubdivisions() map[string]struct{} {
+	out := map[string]struct{}{}
+	for code := range subdivisionToCountry {
+		if len(code) != 2 || code == "ca" {
+			continue
+		}
+		if _, isCountryCode := countryToRegion[code]; isCountryCode {
+			out[code] = struct{}{}
+		}
+	}
+	return out
+}
+
 // cityOverrides pins a curated canonical display name for aliases where the
 // generated GeoNames name (cityDict, from cmd/gen-cities) differs from the clean
 // English form we want in the `cities` facet. It is applied over the generated base

--- a/internal/location/location.go
+++ b/internal/location/location.go
@@ -57,6 +57,10 @@ func Parse(location string) Geo {
 	// then merged into the result.
 	tokCountry := map[string]struct{}{}
 	tokRegion := map[string]struct{}{}
+	// prevTok is the previous comma-token, after the same stripping, and is the
+	// disambiguating context resolveGeoToken needs for a colliding subdivision code
+	// ("Tel Aviv, IL" vs "Chicago, IL"). Updated at the end of the loop body.
+	prevTok := ""
 	for _, tok := range strings.Split(s, ",") {
 		tok = strings.TrimSpace(tok)
 		if tok == "" {
@@ -74,7 +78,12 @@ func Parse(location string) Geo {
 		// Curated geography first, into the scratch sets (authoritative for country/region).
 		clear(tokCountry)
 		clear(tokRegion)
-		resolved := resolveGeoToken(tok, tokCountry, tokRegion)
+		resolved := resolveGeoToken(tok, prevTok, tokCountry, tokRegion)
+		// Recorded now, before any of the branches below (including the early
+		// "continue" on a resolved token) that would otherwise skip past the
+		// end-of-loop assignment and leave the next token's collision check
+		// looking at a stale or empty prevTok.
+		prevTok = tok
 		// City facet from the generated dictionary (cmd/gen-cities). cityDict supplies the
 		// canonical display NAME only — never a country/region — so an ambiguous city name
 		// ("Birmingham") can never *guess* a geography here; the country/region stay the
@@ -124,7 +133,10 @@ func Parse(location string) Geo {
 			}
 			lead := strings.TrimSpace(segs[0])
 			if !resolveGeoName(lead, countrySet, regionSet) && tailResolved {
-				resolveGeoToken(lead, countrySet, regionSet)
+				// No preceding comma-token to disambiguate a colliding lead code against
+				// (it's the first dash segment), so "" makes a colliding code fall back to
+				// its country-code reading here rather than risk the wrong subdivision.
+				resolveGeoToken(lead, "", countrySet, regionSet)
 			}
 		}
 	}
@@ -152,8 +164,12 @@ func Parse(location string) Geo {
 // resolveGeoToken resolves one already-normalized token to a country and/or
 // region, writing into the sets, and reports whether anything matched. Order: a
 // country/city name, a macro-region name, a US/Canada subdivision, then a bare
-// ISO 3166-1 alpha-2 country code (last, so a same-spelled subdivision wins).
-func resolveGeoToken(tok string, countrySet, regionSet map[string]struct{}) bool {
+// ISO 3166-1 alpha-2 country code (last, so a same-spelled subdivision wins) —
+// except for a colliding subdivision code, where resolveSubdivision itself defers
+// to prevTok and, unconfirmed, leaves the bare-code fallback to win instead.
+// prevTok is the preceding comma-token (already stripped; "" when none), the
+// context that confirms a colliding code as a real US/CA subdivision reading.
+func resolveGeoToken(tok, prevTok string, countrySet, regionSet map[string]struct{}) bool {
 	if tok == "" {
 		return false
 	}
@@ -168,7 +184,7 @@ func resolveGeoToken(tok string, countrySet, regionSet map[string]struct{}) bool
 		regionSet[r] = struct{}{}
 		return true
 	}
-	if code, ok := resolveSubdivision(tok); ok {
+	if code, ok := resolveSubdivision(tok, prevTok); ok {
 		countrySet[code] = struct{}{}
 		if r, ok := countryToRegion[code]; ok {
 			regionSet[r] = struct{}{}
@@ -262,8 +278,20 @@ func stripCityPrefix(tok string) string {
 // multi-word token ("austin tx"); and a standalone US ZIP ("94105") as a us
 // signal. It returns ("", false) for anything it cannot resolve — it never
 // guesses past the curated subdivision table.
-func resolveSubdivision(tok string) (string, bool) {
+//
+// A direct or trailing-code match that lands on a collidingSubdivisions code (a
+// code that also spells a curated country, e.g. "il") is accepted only when
+// prevTok — the city portion, either the preceding comma-token for a direct match
+// or the token's own leading words for a trailing-code match — names a recognized
+// US/CA place (subdivisionAccepted); otherwise it is rejected here so the caller
+// falls through to the bare-country-code reading ("Tel Aviv, IL" -> Israel, not
+// Illinois). The ZIP-preceded branch is never gated: a ZIP code is a US signal on
+// its own, so "il 60601" is unambiguous regardless of context.
+func resolveSubdivision(tok, prevTok string) (string, bool) {
 	if code, ok := subdivisionToCountry[tok]; ok {
+		if !subdivisionAccepted(tok, prevTok) {
+			return "", false
+		}
 		return code, true
 	}
 	fields := strings.Fields(tok)
@@ -284,9 +312,41 @@ func resolveSubdivision(tok string) (string, bool) {
 		return "us", true
 	}
 	if code, ok := subdivisionToCountry[last]; ok {
+		leading := strings.Join(fields[:len(fields)-1], " ")
+		if !subdivisionAccepted(last, leading) {
+			return "", false
+		}
 		return code, true
 	}
 	return "", false
+}
+
+// subdivisionAccepted reports whether a matched subdivision code should win over
+// its identically-spelled country-code reading. A code outside
+// collidingSubdivisions is unambiguous and always accepted; a colliding one is
+// accepted only when cityTok is isRecognizedUSCACity.
+func subdivisionAccepted(code, cityTok string) bool {
+	if _, ambiguous := collidingSubdivisions[code]; !ambiguous {
+		return true
+	}
+	return isRecognizedUSCACity(cityTok)
+}
+
+// isRecognizedUSCACity reports whether tok names a place the parser already knows
+// is in the US or Canada — checked directly against nameToCountry and cityDict
+// (not through resolveGeoToken), so a long-tail GeoNames beacon like "Baton Rouge"
+// counts just as much as a curated one like "Minneapolis". This is the signal that
+// disambiguates a colliding subdivision code from its identically-spelled country
+// code: "Baton Rouge, LA" stays Louisiana because "baton rouge" resolves here to
+// us, while "Vientiane, LA" does not, so "la" falls back to the country code Laos.
+func isRecognizedUSCACity(tok string) bool {
+	if code, ok := nameToCountry[tok]; ok {
+		return code == "us" || code == "ca"
+	}
+	if ce, ok := cityDict[tok]; ok {
+		return ce.Country == "us" || ce.Country == "ca"
+	}
+	return false
 }
 
 // isUSZip reports whether s is a US ZIP code: five digits, optionally followed by

--- a/internal/location/location.go
+++ b/internal/location/location.go
@@ -133,10 +133,12 @@ func Parse(location string) Geo {
 			}
 			lead := strings.TrimSpace(segs[0])
 			if !resolveGeoName(lead, countrySet, regionSet) && tailResolved {
-				// No preceding comma-token to disambiguate a colliding lead code against
-				// (it's the first dash segment), so "" makes a colliding code fall back to
-				// its country-code reading here rather than risk the wrong subdivision.
-				resolveGeoToken(lead, "", countrySet, regionSet)
+				// The dash-tail is the context that confirms a colliding lead code
+				// ("il" in "IL-Cupertino") as a real US/CA subdivision, the same role
+				// the preceding comma-token plays for "City, XX" — without it, tailResolved
+				// having already added "us" via the tail's own city-name match would leave
+				// the lead's country-code reading (Israel) alongside it, garbling the result.
+				resolveGeoToken(lead, strings.Join(segs[1:], " "), countrySet, regionSet)
 			}
 		}
 	}

--- a/internal/location/location_test.go
+++ b/internal/location/location_test.go
@@ -314,6 +314,52 @@ func TestParseNorthAmerica(t *testing.T) {
 	}
 }
 
+// TestParseSubdivisionCountryCodeCollision covers the ~16 US/Canada subdivision
+// postal codes that are also a curated country's ISO code ("il" Illinois/Israel,
+// "la" Louisiana/Laos, "pa" Pennsylvania/Panama, …). The subdivision reading must
+// only win when the preceding city is a recognized US/CA place; otherwise the bare
+// country code wins, so a foreign city sharing a code with a US state does not get
+// mislabeled as that state.
+func TestParseSubdivisionCountryCodeCollision(t *testing.T) {
+	tests := []struct {
+		name     string
+		location string
+		want     Geo
+	}{
+		{
+			name:     "Tel Aviv, IL is Israel, not Illinois",
+			location: "Tel Aviv, IL",
+			want:     Geo{Countries: []string{"il"}, Regions: []string{"mena"}, Cities: []string{"Tel Aviv"}},
+		},
+		{
+			name:     "Vientiane, LA is Laos, not Louisiana",
+			location: "Vientiane, LA",
+			want:     Geo{Countries: []string{"la"}, Regions: []string{"apac"}, Cities: []string{"Vientiane"}},
+		},
+		{
+			name:     "Panama City, PA is Panama, not Pennsylvania",
+			location: "Panama City, PA",
+			want:     Geo{Countries: []string{"pa"}, Regions: []string{"latam"}, Cities: []string{"Panama City"}},
+		},
+		{
+			// Regression guard: a genuine US city still wins its colliding state code
+			// when the preceding token corroborates it.
+			name:     "Chicago, IL stays Illinois, not Israel",
+			location: "Chicago, IL",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}, Cities: []string{"Chicago"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Parse(tt.location)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Parse(%q) = %+v, want %+v", tt.location, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestParseCyrillic covers the RU-segment ATS data, whose location fields are in
 // Cyrillic ("Москва"), sometimes prefixed with the Russian city marker "г"
 // ("г Москва"), and which name a remote/hybrid mode in Russian ("Удалённо").

--- a/internal/location/location_test.go
+++ b/internal/location/location_test.go
@@ -348,6 +348,13 @@ func TestParseSubdivisionCountryCodeCollision(t *testing.T) {
 			location: "Chicago, IL",
 			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}, Cities: []string{"Chicago"}},
 		},
+		{
+			// Same collision, dash-delimited instead of comma-delimited: the lead
+			// segment's context is the resolved TAIL, not a preceding comma-token.
+			name:     "IL-Cupertino is California, not Israel",
+			location: "IL-Cupertino",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/nudge/nudge.go
+++ b/internal/nudge/nudge.go
@@ -353,7 +353,7 @@ func (r *Runner) actionable(info db.GetNudgeForDeliveryRow) bool {
 	}
 	switch info.Kind {
 	case KindFollowUp:
-		if !info.JobOpen {
+		if !info.JobOpen || !info.ApplicationExists {
 			return false
 		}
 		days := 0
@@ -362,8 +362,11 @@ func (r *Runner) actionable(info db.GetNudgeForDeliveryRow) bool {
 		}
 		return userjob.SilenceStateFor(stage, days, info.HasPendingSuggestion) == userjob.SilenceSilent
 	case KindInterviewPrep:
-		return info.JobOpen && stage == "interview"
+		return info.JobOpen && info.ApplicationExists && stage == "interview"
 	case KindJobClosed:
+		if !info.ApplicationExists {
+			return false
+		}
 		_, active := userjob.SilenceThresholdDays(stage)
 		return active
 	default:

--- a/internal/nudge/nudge_test.go
+++ b/internal/nudge/nudge_test.go
@@ -259,7 +259,8 @@ func deliveryRow(kind string, stage string, daysSilent int, notificationsEnabled
 		ID: 1, JobID: 2, Kind: kind,
 		Title: "Go Dev", Company: "Acme", PublicSlug: "go-dev-acme", URL: "https://ats/x",
 		JobOpen: jobOpen, NotificationsEnabled: notificationsEnabled, Channels: channels,
-		Stage: pgtype.Text{String: stage, Valid: stage != ""},
+		Stage:             pgtype.Text{String: stage, Valid: stage != ""},
+		ApplicationExists: true,
 		LastActivityAt: pgtype.Timestamptz{
 			Time: fixedNow.Add(-time.Duration(daysSilent) * 24 * time.Hour), Valid: true,
 		},
@@ -412,6 +413,46 @@ func TestDeliver_CancelsWhenJobClosed(t *testing.T) {
 	}
 	if len(store.cancelled) != 1 {
 		t.Errorf("closed job must be cancelled, cancelled = %v", store.cancelled)
+	}
+}
+
+// untrackedRow simulates a nudge whose application row was deleted (by
+// UntrackJob/UntrackApplicationByID) between MATCH and DELIVER: the LEFT JOIN
+// leaves Stage invalid, same as a row that exists with a NULL stage, but
+// ApplicationExists is false only for the former.
+func untrackedRow(kind string) db.GetNudgeForDeliveryRow {
+	chat := int64(555)
+	row := deliveryRow(kind, "", 25, true, true, []string{"telegram"}, &chat, "")
+	row.ApplicationExists = false
+	return row
+}
+
+func TestActionable_FailsClosedWhenApplicationGone(t *testing.T) {
+	for _, kind := range []string{KindFollowUp, KindInterviewPrep, KindJobClosed} {
+		t.Run(kind, func(t *testing.T) {
+			r := newRunner(&fakeStore{}, &fakeNotifier{})
+			if r.actionable(untrackedRow(kind)) {
+				t.Errorf("actionable() = true for an untracked application, want false (fail closed)")
+			}
+		})
+	}
+}
+
+func TestDeliver_CancelsWhenApplicationGone(t *testing.T) {
+	// Stage.Valid=false with ApplicationExists=false must not be read as the
+	// active `applied` stage, the way an invalid-but-still-tracked stage is.
+	store := &fakeStore{due: []int64{1}, row: untrackedRow(KindFollowUp)}
+	notifier := &fakeNotifier{}
+	r := newRunner(store, notifier)
+
+	if _, err := r.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(notifier.sent) != 0 {
+		t.Errorf("must not send once the application is untracked, sent %v", notifier.sent)
+	}
+	if len(store.cancelled) != 1 {
+		t.Errorf("must cancel at fire, cancelled = %v", store.cancelled)
 	}
 }
 

--- a/internal/nudge/nudge_test.go
+++ b/internal/nudge/nudge_test.go
@@ -431,7 +431,14 @@ func TestActionable_FailsClosedWhenApplicationGone(t *testing.T) {
 	for _, kind := range []string{KindFollowUp, KindInterviewPrep, KindJobClosed} {
 		t.Run(kind, func(t *testing.T) {
 			r := newRunner(&fakeStore{}, &fakeNotifier{})
-			if r.actionable(untrackedRow(kind)) {
+			row := untrackedRow(kind)
+			if kind == KindInterviewPrep {
+				// Satisfy the pre-existing stage=="interview" check too, so this
+				// case actually exercises the ApplicationExists gate rather than
+				// passing on the stage check alone regardless of it.
+				row.Stage = pgtype.Text{String: "interview", Valid: true}
+			}
+			if r.actionable(row) {
 				t.Errorf("actionable() = true for an untracked application, want false (fail closed)")
 			}
 		})

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -28,11 +28,19 @@ var (
 	// ErrInvalid is a content-validation failure (mapped to 400); its message is
 	// user-facing.
 	ErrInvalid = errors.New("report: invalid")
+	// ErrRateLimited is a filing past the daily cap (mapped to 429).
+	ErrRateLimited = errors.New("report: too many reports today")
 )
 
 // maxDetailsLen bounds the free-text explanation so a single report cannot carry an
 // unbounded payload (the content-field convention).
 const maxDetailsLen = 5000
+
+// DailyCap bounds how many reports one account may file per rolling 24h window
+// (ghostreport.DailyCap's counterpart for this queue). A real job seeker does not have more
+// than a handful of postings to flag in a day, so the cap costs them nothing while bounding
+// what one account can do to the moderation queue.
+const DailyCap = 20
 
 // validReasons is the closed reason vocabulary, mirrored by the migration's CHECK and the
 // SPA. The service re-validates against it so an out-of-vocabulary value is a clean 400
@@ -109,6 +117,9 @@ type Repository interface {
 	ListPending(ctx context.Context) ([]ReportDetail, error)
 	MarkResolved(ctx context.Context, id, reviewedBy int64, note string) (Report, error)
 	MarkDismissed(ctx context.Context, id, reviewedBy int64, reviewReason string) (Report, error)
+	// CountFiledSince backs the daily cap: how many reports reportedBy has filed since the
+	// given cutoff.
+	CountFiledSince(ctx context.Context, reportedBy int64, since time.Time) (int, error)
 }
 
 // JobCloser soft-closes one job. The QueriesRepository satisfies it (over CloseJobByID);
@@ -168,11 +179,19 @@ func (s *Service) WithNotifier(n ReporterNotifier) *Service {
 
 // File validates the content and stores a pending report owned by reportedBy against
 // jobID. A second open report of the same job by the same user surfaces ErrDuplicateOpen
-// (the repository maps the unique violation).
+// (the repository maps the unique violation); a reportedBy already at DailyCap for the
+// rolling 24h window surfaces ErrRateLimited.
 func (s *Service) File(ctx context.Context, reportedBy, jobID int64, in FileInput) (Report, error) {
 	v, err := in.validate()
 	if err != nil {
 		return Report{}, err
+	}
+	filed, err := s.repo.CountFiledSince(ctx, reportedBy, time.Now().Add(-24*time.Hour))
+	if err != nil {
+		return Report{}, err
+	}
+	if filed >= DailyCap {
+		return Report{}, ErrRateLimited
 	}
 	return s.repo.Create(ctx, reportedBy, jobID, v.Reason, v.Details, v.ContactTelegram)
 }

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/strelov1/freehire/internal/report"
 )
@@ -51,6 +52,9 @@ type fakeRepo struct {
 	dismissCalled bool
 	dismissErr    error
 	dismissRet    report.Report
+
+	filedToday int
+	countErr   error
 }
 
 func (f *fakeRepo) Create(_ context.Context, reportedBy, jobID int64, reason, details, contactTelegram string) (report.Report, error) {
@@ -75,6 +79,10 @@ func (f *fakeRepo) MarkResolved(_ context.Context, id, reviewedBy int64, note st
 func (f *fakeRepo) MarkDismissed(_ context.Context, id, reviewedBy int64, reviewReason string) (report.Report, error) {
 	f.dismissed, f.dismissCalled = dismissArgs{ID: id, ReviewedBy: reviewedBy, ReviewReason: reviewReason}, true
 	return f.dismissRet, f.dismissErr
+}
+
+func (f *fakeRepo) CountFiledSince(_ context.Context, _ int64, _ time.Time) (int, error) {
+	return f.filedToday, f.countErr
 }
 
 // fakeCloser stands in for the job-lifecycle soft-close: it records the close call.
@@ -175,6 +183,29 @@ func TestFile_AcceptsEveryReason(t *testing.T) {
 		if _, err := report.New(repo, &fakeCloser{}).File(context.Background(), 1, 1, in); err != nil {
 			t.Errorf("reason %q rejected: %v", reason, err)
 		}
+	}
+}
+
+// A real job seeker does not have more than a handful of postings to flag in a day; the
+// cap bounds what one account can do to the moderation queue (ghostreport's precedent).
+func TestFile_RefusesPastTheDailyCap(t *testing.T) {
+	repo := &fakeRepo{filedToday: report.DailyCap}
+	_, err := report.New(repo, &fakeCloser{}).File(context.Background(), 7, 1, validInput())
+	if !errors.Is(err, report.ErrRateLimited) {
+		t.Errorf("err = %v, want ErrRateLimited", err)
+	}
+	if repo.createCalled {
+		t.Error("the capped request still reached the repository")
+	}
+}
+
+func TestFile_AllowsTheLastFilingUnderTheCap(t *testing.T) {
+	repo := &fakeRepo{filedToday: report.DailyCap - 1, createRet: report.Report{ID: 1}}
+	if _, err := report.New(repo, &fakeCloser{}).File(context.Background(), 7, 1, validInput()); err != nil {
+		t.Errorf("File at cap-1: %v, want it allowed", err)
+	}
+	if !repo.createCalled {
+		t.Error("a filing under the cap should reach the repository")
 	}
 }
 

--- a/internal/report/repository.go
+++ b/internal/report/repository.go
@@ -3,8 +3,10 @@ package report
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/pgconv"
@@ -131,6 +133,15 @@ func (r *QueriesRepository) MarkDismissed(ctx context.Context, id, reviewedBy in
 func (r *QueriesRepository) Close(ctx context.Context, jobID int64) error {
 	_, err := r.q.CloseJobByID(ctx, jobID)
 	return err
+}
+
+// CountFiledSince backs the daily cap.
+func (r *QueriesRepository) CountFiledSince(ctx context.Context, reportedBy int64, since time.Time) (int, error) {
+	n, err := r.q.CountReportsFiledSince(ctx, db.CountReportsFiledSinceParams{
+		ReportedBy: reportedBy,
+		Since:      pgtype.Timestamptz{Time: since, Valid: true},
+	})
+	return int(n), err
 }
 
 // fromRow maps the generated db row to the package domain type, dropping the internal

--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -746,6 +746,16 @@ func (c *Client) RecommendByVector(ctx context.Context, vector []float64, filter
 		if errors.As(err, &meiliErr) && meiliErr.MeilisearchApiError.Code == semanticIndexMissingCode {
 			return SearchResult{}, nil
 		}
+		// A cancelled/expired context surfaces here wrapped in a Meilisearch
+		// communication error that does NOT chain to context.Canceled (the SDK's
+		// *Error has no Unwrap), so re-raise the context sentinel directly to keep
+		// errors.Is working upstream — mirrors Search (above).
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return SearchResult{}, fmt.Errorf("search: recommend: %w", ctxErr)
+		}
+		if isBadRequest(err) {
+			return SearchResult{}, fmt.Errorf("search: recommend: %w: %v", ErrBadQuery, err)
+		}
 		return SearchResult{}, fmt.Errorf("search: recommend: %w", err)
 	}
 	var hits []JobDocument

--- a/internal/search/client_test.go
+++ b/internal/search/client_test.go
@@ -1,0 +1,50 @@
+package search
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/meilisearch/meilisearch-go"
+)
+
+// fakeSearchIndex stubs meilisearch.IndexManager for unit tests that only need to
+// control SearchWithContext: embedding the interface satisfies every other method
+// (unused by these tests, so a nil call would simply never happen).
+type fakeSearchIndex struct {
+	meilisearch.IndexManager
+	searchFn func(ctx context.Context, query string, req *meilisearch.SearchRequest) (*meilisearch.SearchResponse, error)
+}
+
+func (f fakeSearchIndex) SearchWithContext(ctx context.Context, query string, req *meilisearch.SearchRequest) (*meilisearch.SearchResponse, error) {
+	return f.searchFn(ctx, query, req)
+}
+
+// A cancelled context must re-raise the context sentinel, not the SDK's opaque
+// communication error, so a client disconnect is not misreported upstream as a fault.
+func TestRecommendByVector_CancelledContextReRaisesSentinel(t *testing.T) {
+	c := &Client{semantic: fakeSearchIndex{searchFn: func(context.Context, string, *meilisearch.SearchRequest) (*meilisearch.SearchResponse, error) {
+		return nil, errors.New("meilisearch: could not perform request: context canceled")
+	}}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := c.RecommendByVector(ctx, []float64{0.1, 0.2}, nil, 10, 0)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}
+
+// A Meili 400 (malformed filter) must map to ErrBadQuery so the handler can render
+// it as a client mistake and skip Sentry.
+func TestRecommendByVector_BadRequestMapsToErrBadQuery(t *testing.T) {
+	c := &Client{semantic: fakeSearchIndex{searchFn: func(context.Context, string, *meilisearch.SearchRequest) (*meilisearch.SearchResponse, error) {
+		return nil, &meilisearch.Error{StatusCode: http.StatusBadRequest}
+	}}}
+
+	_, err := c.RecommendByVector(context.Background(), []float64{0.1, 0.2}, nil, 10, 0)
+	if !errors.Is(err, ErrBadQuery) {
+		t.Fatalf("err = %v, want ErrBadQuery", err)
+	}
+}

--- a/internal/search/facets.go
+++ b/internal/search/facets.go
@@ -45,6 +45,16 @@ func (c *Client) FacetCounts(ctx context.Context, p FacetParams) (FacetResult, e
 		Limit:  0,
 	})
 	if err != nil {
+		// A cancelled/expired context surfaces here wrapped in a Meilisearch
+		// communication error that does NOT chain to context.Canceled (the SDK's
+		// *Error has no Unwrap), so re-raise the context sentinel directly to keep
+		// errors.Is working upstream — mirrors Search (client.go).
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return FacetResult{}, fmt.Errorf("search: facet query: %w", ctxErr)
+		}
+		if isBadRequest(err) {
+			return FacetResult{}, fmt.Errorf("search: facet query: %w: %v", ErrBadQuery, err)
+		}
 		return FacetResult{}, fmt.Errorf("search: facet query: %w", err)
 	}
 	return buildFacetResult(resp)
@@ -97,6 +107,15 @@ func disjunctiveFacetCounts(ctx context.Context, query string, reqs []FacetReq, 
 	run(func() error {
 		resp, err := search(ctx, query, totalFilter, nil)
 		if err != nil {
+			// Mirrors Search's classification (client.go): a cancelled/expired context
+			// re-raises the sentinel (the SDK's comm error has no Unwrap to it), and a
+			// Meili 400 tags ErrBadQuery so callers can render it as a client mistake.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return fmt.Errorf("search: disjunctive total: %w", ctxErr)
+			}
+			if isBadRequest(err) {
+				return fmt.Errorf("search: disjunctive total: %w: %v", ErrBadQuery, err)
+			}
 			return fmt.Errorf("search: disjunctive total: %w", err)
 		}
 		mu.Lock()
@@ -110,6 +129,12 @@ func disjunctiveFacetCounts(ctx context.Context, query string, reqs []FacetReq, 
 		run(func() error {
 			resp, err := search(ctx, query, r.Filter, []string{r.Attr})
 			if err != nil {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return fmt.Errorf("search: disjunctive facet %s: %w", r.Attr, ctxErr)
+				}
+				if isBadRequest(err) {
+					return fmt.Errorf("search: disjunctive facet %s: %w: %v", r.Attr, ErrBadQuery, err)
+				}
 				return fmt.Errorf("search: disjunctive facet %s: %w", r.Attr, err)
 			}
 			fr, err := buildFacetResult(resp)

--- a/internal/search/facets_test.go
+++ b/internal/search/facets_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strconv"
 	"sync"
 	"testing"
@@ -70,6 +71,63 @@ func TestDisjunctiveFacetCounts_ErrorPropagates(t *testing.T) {
 	}
 	if _, err := disjunctiveFacetCounts(context.Background(), "", []FacetReq{{Attr: "a", Filter: "f"}}, "full", searcher); err == nil {
 		t.Fatal("expected error to propagate")
+	}
+}
+
+// A cancelled context must re-raise the context sentinel, not the SDK's opaque
+// communication error, so a client disconnect is not misreported upstream as a
+// fault — mirrors Search's classification (client.go).
+func TestDisjunctiveFacetCounts_CancelledContextReRaisesSentinel(t *testing.T) {
+	searcher := func(context.Context, string, any, []string) (*meilisearch.SearchResponse, error) {
+		return nil, errors.New("meilisearch: could not perform request: context canceled")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := disjunctiveFacetCounts(ctx, "", []FacetReq{{Attr: "a", Filter: "f"}}, "full", searcher)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}
+
+// A Meili 400 (malformed filter) must map to ErrBadQuery so the handler can render
+// it as a client mistake and skip Sentry.
+func TestDisjunctiveFacetCounts_BadRequestMapsToErrBadQuery(t *testing.T) {
+	searcher := func(context.Context, string, any, []string) (*meilisearch.SearchResponse, error) {
+		return nil, &meilisearch.Error{StatusCode: http.StatusBadRequest}
+	}
+
+	_, err := disjunctiveFacetCounts(context.Background(), "", []FacetReq{{Attr: "a", Filter: "f"}}, "full", searcher)
+	if !errors.Is(err, ErrBadQuery) {
+		t.Fatalf("err = %v, want ErrBadQuery", err)
+	}
+}
+
+// A cancelled context must re-raise the context sentinel — mirrors Search
+// (client.go).
+func TestFacetCounts_CancelledContextReRaisesSentinel(t *testing.T) {
+	c := &Client{facet: fakeSearchIndex{searchFn: func(context.Context, string, *meilisearch.SearchRequest) (*meilisearch.SearchResponse, error) {
+		return nil, errors.New("meilisearch: could not perform request: context canceled")
+	}}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := c.FacetCounts(ctx, FacetParams{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}
+
+// A Meili 400 (malformed filter) must map to ErrBadQuery so the handler can render
+// it as a client mistake and skip Sentry.
+func TestFacetCounts_BadRequestMapsToErrBadQuery(t *testing.T) {
+	c := &Client{facet: fakeSearchIndex{searchFn: func(context.Context, string, *meilisearch.SearchRequest) (*meilisearch.SearchResponse, error) {
+		return nil, &meilisearch.Error{StatusCode: http.StatusBadRequest}
+	}}}
+
+	_, err := c.FacetCounts(context.Background(), FacetParams{})
+	if !errors.Is(err, ErrBadQuery) {
+		t.Fatalf("err = %v, want ErrBadQuery", err)
 	}
 }
 

--- a/internal/worker/metrics.go
+++ b/internal/worker/metrics.go
@@ -86,6 +86,16 @@ freehire_worker_last_run_success{%[1]s} %[4]d
 func runInstance(args []string) string {
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
+		if arg == "--" {
+			// The POSIX end-of-options marker: everything after it is positional,
+			// so it must not be treated as a bare flag whose "value" (the board
+			// path itself) gets skipped by the generic rule below.
+			if i+1 < len(args) {
+				base := filepath.Base(args[i+1])
+				return strings.TrimSuffix(base, filepath.Ext(base))
+			}
+			return ""
+		}
 		if !strings.HasPrefix(arg, "-") {
 			base := filepath.Base(arg)
 			return strings.TrimSuffix(base, filepath.Ext(base))

--- a/internal/worker/metrics.go
+++ b/internal/worker/metrics.go
@@ -74,14 +74,25 @@ freehire_worker_last_run_success{%[1]s} %[4]d
 	}
 }
 
-// runInstance derives a metric instance label from a worker's trailing
-// command-line argument, when it looks like a path (cmd/ingest's
-// `sources/<board>.yml`). Returns "" for a worker invoked with no arguments
-// (embed, search-drain, reindex), which then reports under job alone.
+// runInstance derives a metric instance label from a worker's command-line
+// arguments, when one looks like a path (cmd/ingest's `sources/<board>.yml`).
+// It scans for the first non-flag argument rather than assuming the last one,
+// since a flag can trail the path (`ingest sources/eightfold.yml --shard=1/6`).
+// A bare (non-"=") flag's space-separated value (`reindex --posted-within
+// 168h`) is skipped along with the flag itself, so it isn't mistaken for a
+// board path. Returns "" when no non-flag argument is present (embed,
+// search-drain, reindex, or reindex --posted-within 168h), which then reports
+// under job alone.
 func runInstance(args []string) string {
-	if len(args) == 0 {
-		return ""
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if !strings.HasPrefix(arg, "-") {
+			base := filepath.Base(arg)
+			return strings.TrimSuffix(base, filepath.Ext(base))
+		}
+		if !strings.Contains(arg, "=") && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+			i++
+		}
 	}
-	base := filepath.Base(args[len(args)-1])
-	return strings.TrimSuffix(base, filepath.Ext(base))
+	return ""
 }

--- a/internal/worker/metrics_test.go
+++ b/internal/worker/metrics_test.go
@@ -19,6 +19,8 @@ func TestRunInstance(t *testing.T) {
 		{"path-like board file", []string{"/opt/freehire/src/hire-current/sources/eightfold.yml"}, "eightfold"},
 		{"trailing flag after board file", []string{"sources/eightfold.yml", "--shard=1/6"}, "eightfold"},
 		{"flag only", []string{"--posted-within", "168h"}, ""},
+		{"end-of-options marker before board file", []string{"--", "sources/eightfold.yml"}, "eightfold"},
+		{"end-of-options marker alone", []string{"--"}, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/worker/metrics_test.go
+++ b/internal/worker/metrics_test.go
@@ -17,6 +17,8 @@ func TestRunInstance(t *testing.T) {
 		{"no args", nil, ""},
 		{"bare board file", []string{"eightfold.yml"}, "eightfold"},
 		{"path-like board file", []string{"/opt/freehire/src/hire-current/sources/eightfold.yml"}, "eightfold"},
+		{"trailing flag after board file", []string{"sources/eightfold.yml", "--shard=1/6"}, "eightfold"},
+		{"flag only", []string{"--posted-within", "168h"}, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/migrations/0091_cvs_tailored_unique_idx.sql
+++ b/migrations/0091_cvs_tailored_unique_idx.sql
@@ -1,0 +1,12 @@
+-- Store.Tailor was a non-transactional check-then-insert: look up the user's existing tailored
+-- copy for a vacancy, and if none, insert one. Nothing in the schema stopped two concurrent
+-- calls for the same (user, job) from both missing the check and both inserting — the
+-- production incident TestStoreTailorReturnsTheExistingCopyForTheSameVacancy documents. This
+-- index turns the second insert into a unique violation, which Store.Tailor now catches and
+-- resolves by re-fetching the row the first call created.
+--
+-- Partial on is_tailored, not job_id IS NOT NULL: a tailored CV whose vacancy is later pruned
+-- keeps is_tailored true but loses job_id (see 0058), and by then this index no longer applies
+-- to it anyway — job_id NULL cannot collide with anything.
+CREATE UNIQUE INDEX IF NOT EXISTS cvs_user_id_job_id_tailored_uniq_idx
+    ON public.cvs (user_id, job_id) WHERE is_tailored;

--- a/migrations/0091_cvs_tailored_unique_idx.sql
+++ b/migrations/0091_cvs_tailored_unique_idx.sql
@@ -18,13 +18,19 @@
 -- dropped — cv_revisions and assistant_sessions cascade-delete on cvs, so deleting a loser
 -- outright would silently erase real revision history and strand a live chat session, exactly
 -- the harm the underlying race already did once.
-CREATE TEMP TABLE cv_tailor_dupes_ranked ON COMMIT DROP AS
+-- Plain TEMP tables, not ON COMMIT DROP: this file has no explicit BEGIN/COMMIT of its own
+-- (matching every other migration here), and a fresh initdb volume applies it by feeding the
+-- whole file to psql, which autocommits each statement as its own transaction absent one — an
+-- ON COMMIT DROP table would then vanish right after the statement that created it, before the
+-- next statement could read it. Session-scoped is enough: both are gone once this connection
+-- closes, and are dropped explicitly below regardless.
+CREATE TEMP TABLE cv_tailor_dupes_ranked AS
 SELECT id, user_id, job_id,
        row_number() OVER (PARTITION BY user_id, job_id ORDER BY updated_at DESC, id DESC) AS rn
 FROM public.cvs
 WHERE is_tailored AND job_id IS NOT NULL;
 
-CREATE TEMP TABLE cv_tailor_dupes_canonical ON COMMIT DROP AS
+CREATE TEMP TABLE cv_tailor_dupes_canonical AS
 SELECT loser.id AS loser_id, canonical.id AS canonical_id
 FROM cv_tailor_dupes_ranked loser
 JOIN cv_tailor_dupes_ranked canonical
@@ -77,6 +83,9 @@ WHERE t.cv_id = d.loser_id;
 DELETE FROM public.cvs c
 USING cv_tailor_dupes_canonical d
 WHERE c.id = d.loser_id;
+
+DROP TABLE cv_tailor_dupes_canonical;
+DROP TABLE cv_tailor_dupes_ranked;
 
 -- APPLY TO PROD MANUALLY BEFORE DEPLOY (SET ROLE hire), per this repo's convention for a
 -- migration that writes existing rows rather than only adding schema — see 0045/0053's own

--- a/migrations/0091_cvs_tailored_unique_idx.sql
+++ b/migrations/0091_cvs_tailored_unique_idx.sql
@@ -8,5 +8,79 @@
 -- Partial on is_tailored, not job_id IS NOT NULL: a tailored CV whose vacancy is later pruned
 -- keeps is_tailored true but loses job_id (see 0058), and by then this index no longer applies
 -- to it anyway — job_id NULL cannot collide with anything.
+--
+-- Because the race this closes is real and has already happened at least once in production,
+-- an existing (user_id, job_id) duplicate among is_tailored rows is expected, not hypothetical
+-- — CREATE UNIQUE INDEX would otherwise fail outright on such a volume. The block below
+-- reconciles any duplicates first: for each (user_id, job_id) group, the row
+-- GetTailoredCVForJob already serves today (ORDER BY updated_at DESC, id DESC LIMIT 1) is kept
+-- as canonical, and every dependent reference on a loser row is redirected to it rather than
+-- dropped — cv_revisions and assistant_sessions cascade-delete on cvs, so deleting a loser
+-- outright would silently erase real revision history and strand a live chat session, exactly
+-- the harm the underlying race already did once.
+CREATE TEMP TABLE cv_tailor_dupes_ranked ON COMMIT DROP AS
+SELECT id, user_id, job_id,
+       row_number() OVER (PARTITION BY user_id, job_id ORDER BY updated_at DESC, id DESC) AS rn
+FROM public.cvs
+WHERE is_tailored AND job_id IS NOT NULL;
+
+CREATE TEMP TABLE cv_tailor_dupes_canonical ON COMMIT DROP AS
+SELECT loser.id AS loser_id, canonical.id AS canonical_id
+FROM cv_tailor_dupes_ranked loser
+JOIN cv_tailor_dupes_ranked canonical
+    ON canonical.user_id = loser.user_id
+   AND canonical.job_id = loser.job_id
+   AND canonical.rn = 1
+WHERE loser.rn > 1;
+
+-- Redirect the tailoring conversation itself, so it keeps talking about the CV that survives
+-- instead of one about to be deleted.
+UPDATE public.assistant_sessions a
+SET cv_id = d.canonical_id
+FROM cv_tailor_dupes_canonical d
+WHERE a.cv_id = d.loser_id;
+
+-- Redirect the loser's edit history onto the canonical row rather than losing it.
+UPDATE public.cv_revisions r
+SET cv_id = d.canonical_id
+FROM cv_tailor_dupes_canonical d
+WHERE r.cv_id = d.loser_id;
+
+-- referral_requests.cv_id is ON DELETE SET NULL, so this is not strictly required for the
+-- delete below to succeed, but redirecting preserves the reference instead of silently
+-- clearing it.
+UPDATE public.referral_requests rr
+SET cv_id = d.canonical_id
+FROM cv_tailor_dupes_canonical d
+WHERE rr.cv_id = d.loser_id;
+
+-- cv_tracer_links carries its own UNIQUE (cv_id, source_path, destination_hash): two duplicate
+-- tailored copies of the same document plausibly minted an identical link at the same
+-- source_path, so redirecting every loser link would collide with the canonical's own. Drop
+-- only the ones that would collide; the rest redirect same as everything else above.
+DELETE FROM public.cv_tracer_links t
+USING cv_tailor_dupes_canonical d
+WHERE t.cv_id = d.loser_id
+  AND EXISTS (
+      SELECT 1 FROM public.cv_tracer_links existing
+      WHERE existing.cv_id = d.canonical_id
+        AND existing.source_path = t.source_path
+        AND existing.destination_hash = t.destination_hash
+  );
+
+UPDATE public.cv_tracer_links t
+SET cv_id = d.canonical_id
+FROM cv_tailor_dupes_canonical d
+WHERE t.cv_id = d.loser_id;
+
+-- Every dependent reference now points at the canonical row; the losers are safe to drop.
+DELETE FROM public.cvs c
+USING cv_tailor_dupes_canonical d
+WHERE c.id = d.loser_id;
+
+-- APPLY TO PROD MANUALLY BEFORE DEPLOY (SET ROLE hire), per this repo's convention for a
+-- migration that writes existing rows rather than only adding schema — see 0045/0053's own
+-- notes. This one in particular deletes rows and redirects foreign keys; run it against a
+-- current backup or during a maintenance window, not casually.
 CREATE UNIQUE INDEX IF NOT EXISTS cvs_user_id_job_id_tailored_uniq_idx
     ON public.cvs (user_id, job_id) WHERE is_tailored;

--- a/migrations/0092_jobs_fk_indexes.sql
+++ b/migrations/0092_jobs_fk_indexes.sql
@@ -1,0 +1,36 @@
+-- Mirrors 0043_jobs_user_fk_idx.sql, but for FKs into jobs instead of users. cmd/prune
+-- (internal/db/queries/pruning.sql) is the only hard-delete path for jobs, and every
+-- table below references jobs.id ON DELETE CASCADE/SET NULL with no index whose leading
+-- column is the referencing one, so each row cmd/prune deletes runs one sequential scan
+-- per such table for the referential-integrity query.
+--
+-- user_jobs.job_id is the case the review flagged directly: it carries two indexes
+-- (0040, 0055) but both are partial on an unrelated column (vote, applied_at), so
+-- neither covers the rows excluded by that predicate. job_reminders.job_id (0034),
+-- ghost_reports.job_id (0053), and application_nudges.job_id (0083) have the same
+-- shape — a leading-column index that is partial on status/retracted_at rather than on
+-- job_id itself — so the RI query still scans for the rows the predicate excludes
+-- (delivered/cancelled reminders, retracted ghost reports).
+--
+-- Same nullability split as 0043: NOT NULL/CASCADE columns get a plain index; nullable
+-- SET NULL columns get a partial index on IS NOT NULL, which is exactly the set an RI
+-- query can match and keeps the index near-empty on the columns that are barely populated.
+--
+-- On a fresh initdb volume these plain CREATE INDEX statements are fine; on the live
+-- prod DB they must be applied manually as CREATE INDEX CONCURRENTLY (this migration
+-- runner wraps each file in a transaction, which CONCURRENTLY cannot run inside).
+
+CREATE INDEX job_reports_job_id_idx ON public.job_reports (job_id);
+CREATE INDEX subscription_matches_job_id_idx ON public.subscription_matches (job_id);
+CREATE INDEX user_jobs_job_id_idx ON public.user_jobs (job_id);
+CREATE INDEX user_job_analysis_job_id_idx ON public.user_job_analysis (job_id);
+CREATE INDEX job_reminders_job_id_idx ON public.job_reminders (job_id);
+CREATE INDEX application_nudges_job_id_idx ON public.application_nudges (job_id);
+CREATE INDEX ghost_reports_job_id_idx ON public.ghost_reports (job_id);
+
+CREATE INDEX job_submissions_job_id_idx ON public.job_submissions (job_id) WHERE job_id IS NOT NULL;
+CREATE INDEX cvs_job_id_idx ON public.cvs (job_id) WHERE job_id IS NOT NULL;
+CREATE INDEX referral_requests_job_id_idx ON public.referral_requests (job_id) WHERE job_id IS NOT NULL;
+CREATE INDEX assistant_sessions_job_id_idx ON public.assistant_sessions (job_id) WHERE job_id IS NOT NULL;
+CREATE INDEX applications_job_id_idx ON public.applications (job_id) WHERE job_id IS NOT NULL;
+CREATE INDEX application_events_job_id_idx ON public.application_events (job_id) WHERE job_id IS NOT NULL;

--- a/migrations/0092_jobs_fk_indexes.sql
+++ b/migrations/0092_jobs_fk_indexes.sql
@@ -15,6 +15,14 @@
 -- Same nullability split as 0043: NOT NULL/CASCADE columns get a plain index; nullable
 -- SET NULL columns get a partial index on IS NOT NULL, which is exactly the set an RI
 -- query can match and keeps the index near-empty on the columns that are barely populated.
+-- A partial index cannot back a foreign-key CONSTRAINT (it isn't the referenced side of
+-- one here — these all sit on the referencing side), and general Postgres guidance is
+-- mixed on whether the planner always picks a partial index for an RI trigger's scan. This
+-- codebase already has the answer for this exact shape: 0043 shipped WHERE ... IS NOT NULL
+-- indexes to fix a real production DELETE-FROM-users timeout, and that fix held — if the
+-- planner were not using them, the timeout would have persisted. Mirrored here rather than
+-- switched to full indexes, which would double their size for coverage the IS NOT NULL
+-- predicate already logically guarantees (job_id = $1 for any real $1 implies NOT NULL).
 --
 -- On a fresh initdb volume these plain CREATE INDEX statements are fine; on the live
 -- prod DB they must be applied manually as CREATE INDEX CONCURRENTLY (this migration


### PR DESCRIPTION
## Summary

Full codebase audit surfaced 92 confirmed findings (17 high / 45 medium / 30 low) across 30 domain areas — backend Go, `web/`, `design-system/`, and the browser extension. This PR fixes the 17 **high-severity** findings, minus two that collapsed into one shared migration (missing FK indexes) — 15 commits, one per fix, each independently verified against the actual code and covered by a new/adjusted test.

- **extension** — silent turn failure now surfaces an errored assistant message (ported from web); autofill writes are now scoped to the matched frame/form instead of broadcasting across the whole page
- **internal/cv** — `Tailor()` no longer mints duplicate tailored CVs under concurrent calls (new unique index + conflict handling)
- **internal/calsync** — a cancelled calendar event with no iCalUID now reaches its cancellation instead of being dropped by the match gate
- **internal/collections** — `RequireCountry`'s single/multi-token detection no longer misreads punctuated single-token names as multi-token
- **migrations** — missing FK-into-`jobs.id` indexes added (mirrors the earlier `users` FK index fix), closing a sequential-scan-on-delete gap
- **internal/location** — US/Canada subdivision codes that collide with a curated country's ISO code (`IL`, `LA`, `PA`, …) are now disambiguated by the preceding city token
- **internal/browsertools** — call ids are now unique per `Hub`, so a late answer for an evicted `Caller` can't misdeliver into a successor's pending call
- **internal/gmailsync** — the sync watermark no longer advances past a wave's first failure, so a transiently-failed message is retried instead of silently lost forever
- **internal/handler** — `StreamMatchAnalysis`'s SSE `final` event is now capped by unmet hard constraints, matching GET/POST
- **internal/nudge** — nudge delivery now fails closed when the tracked application no longer exists, instead of treating "deleted" the same as "stage unset"
- **internal/linksource** — resolving one pasted link on a `HydratingSource` board (e.g. Workday) no longer triggers a full board crawl
- **internal/report** — job-report filing is now rate-limited (20/day), matching every sibling package in this area
- **internal/search** — facet/recommend queries now classify cancelled-context and bad-request errors the same way `Search`/`SearchCompanies` already do
- **internal/worker** — the Prometheus instance label is now derived from the first non-flag argument, not blindly the last one

One related high-severity finding (`search_outbox.sql`'s join-for-ordering perf issue) is intentionally **not** included — the team already flagged it out of scope in an existing openspec design decision.

## Test plan

- [x] `gofmt -l .` — clean
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — clean (one pre-existing, unrelated failure: `TestExtractResumeProfile_PDF`, reproduced on `main` too)
- [x] extension: `npx vitest run` (211 tests), `tsc --noEmit`, `eslint` — all clean
- [x] Each fix reviewed by hand against the actual diff (not just agent self-reports) — race conditions, id-collision, and watermark fixes specifically verified with concurrency/failure-injection tests that reproduce the original bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Autofill now targets the correct frame and form, preventing similarly labeled fields from being filled incorrectly.
  - Added a daily limit of 20 reports, with a clear rate-limit response.
- **Bug Fixes**
  - Failed assistant turns now offer retry controls.
  - Cancelled calendar events are removed reliably, even without a calendar UID.
  - Gmail sync retries messages that previously failed.
  - Match scores now reflect unmet hard requirements in streamed results.
  - Nudges are cancelled when their application no longer exists.
  - Improved location parsing and search error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->