### PR TITLE
Never emit TELECOMMUTE without applicantLocationRequirements

### DIFF
--- a/web/src/lib/seo.test.ts
+++ b/web/src/lib/seo.test.ts
@@ -321,6 +321,44 @@ describe('jobPostingJsonLd', () => {
   it('omits validThrough for an open posting with no date evidence at all', () => {
     expect(jobPostingJsonLd(postingJob(), ORIGIN)).not.toHaveProperty('validThrough');
   });
+
+  it('sets TELECOMMUTE with applicantLocationRequirements when the region resolves', () => {
+    const ld = jobPostingJsonLd(postingJob({ work_mode: 'remote', regions: ['eu'] }), ORIGIN);
+    expect(ld.jobLocationType).toBe('TELECOMMUTE');
+    expect(ld.applicantLocationRequirements).toBeDefined();
+    expect(ld).not.toHaveProperty('jobLocation');
+  });
+
+  it('falls back to a plain jobLocation when a remote posting has no resolved region but does have a location string', () => {
+    // Google requires applicantLocationRequirements whenever jobLocationType is
+    // TELECOMMUTE — asserting TELECOMMUTE with no region to back it up would be an
+    // invalid combination, worse than the plain-jobLocation fallback.
+    const ld = jobPostingJsonLd(
+      postingJob({ work_mode: 'remote', regions: [], location: 'Farnborough, Hampshire' }),
+      ORIGIN
+    );
+    expect(ld).not.toHaveProperty('jobLocationType');
+    expect(ld).not.toHaveProperty('applicantLocationRequirements');
+    expect(ld.jobLocation).toEqual({
+      '@type': 'Place',
+      address: { '@type': 'PostalAddress', addressLocality: 'Farnborough, Hampshire' },
+    });
+  });
+
+  it('omits location entirely for a remote posting with no region and no location text', () => {
+    const ld = jobPostingJsonLd(postingJob({ work_mode: 'remote', regions: [], location: '' }), ORIGIN);
+    expect(ld).not.toHaveProperty('jobLocationType');
+    expect(ld).not.toHaveProperty('applicantLocationRequirements');
+    expect(ld).not.toHaveProperty('jobLocation');
+  });
+
+  it('adds addressCountry to jobLocation when the geo dictionary pinned a country', () => {
+    const ld = jobPostingJsonLd(postingJob({ location: 'Berlin', countries: ['de'] }), ORIGIN);
+    expect(ld.jobLocation).toEqual({
+      '@type': 'Place',
+      address: { '@type': 'PostalAddress', addressLocality: 'Berlin', addressCountry: 'DE' },
+    });
+  });
 });
 
 describe('collectionPageJsonLd', () => {

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -124,6 +124,20 @@ function applicantRegions(regions?: string[]): unknown {
   return named.length === 1 ? named[0] : named;
 }
 
+// schema.org jobLocation from the raw location string: Google accepts a
+// PostalAddress with just locality; add the ISO country code when the geo
+// dictionary pinned one (job.countries is alpha-2), never a made-up street/postal
+// code — mismatched structured data is a ranking liability. Shared by a non-remote
+// posting and a remote one whose region never resolved (see jobPostingJsonLd).
+function jobLocationFromText(location: string, countries?: string[]): Record<string, unknown> {
+  const address: Record<string, unknown> = {
+    '@type': 'PostalAddress',
+    addressLocality: location,
+  };
+  if (countries?.[0]) address.addressCountry = countries[0].toUpperCase();
+  return { '@type': 'Place', address };
+}
+
 // schema.org educationRequirements.credentialCategory, from the enrich
 // education_level vocabulary ("none"/"bachelor"/"master"/"phd"). "none" and any
 // unmapped value carry no requirement and are omitted.
@@ -210,19 +224,24 @@ export function jobPostingJsonLd(job: Job, origin: string): Record<string, unkno
   if (empType) ld.employmentType = empType;
 
   if (job.work_mode === 'remote') {
-    ld.jobLocationType = 'TELECOMMUTE';
     const regions = applicantRegions(job.regions);
-    if (regions) ld.applicantLocationRequirements = regions;
+    if (regions) {
+      // Google requires applicantLocationRequirements whenever jobLocationType is
+      // TELECOMMUTE — set them together, never TELECOMMUTE alone.
+      ld.jobLocationType = 'TELECOMMUTE';
+      ld.applicantLocationRequirements = regions;
+    } else if (job.location) {
+      // No resolved region to state a location *requirement* from (the geo
+      // dictionary and the LLM fallback both came up empty — a real, if raw,
+      // location string still reached the posting). Asserting TELECOMMUTE without
+      // its required companion would be worse than not asserting it: fall back to
+      // the same plain jobLocation a non-remote posting gets.
+      ld.jobLocation = jobLocationFromText(job.location, job.countries);
+    }
+    // Neither a resolved region nor any location text at all: nothing honest to
+    // state, so location is omitted rather than guessed.
   } else if (job.location) {
-    // Google accepts a PostalAddress with just locality; add the ISO country code
-    // when the geo dictionary pinned one (job.countries is alpha-2), never a made-up
-    // street/postal code — mismatched structured data is a ranking liability.
-    const address: Record<string, unknown> = {
-      '@type': 'PostalAddress',
-      addressLocality: job.location,
-    };
-    if (job.countries?.[0]) address.addressCountry = job.countries[0].toUpperCase();
-    ld.jobLocation = { '@type': 'Place', address };
+    ld.jobLocation = jobLocationFromText(job.location, job.countries);
   }
 
   if (e.salary_min != null || e.salary_max != null) {


### PR DESCRIPTION
## Summary
- Google Search Console (real crawl data, not the earlier 4-page manual sample) flagged `jobLocation` and `applicantLocationRequirements` as **absent — critical, blocks Job rich results**.
- Root cause: `jobPostingJsonLd` always set `jobLocationType: 'TELECOMMUTE'` for a remote posting, but `applicantLocationRequirements` only when `job.regions` resolved to a named region. Google requires the latter whenever the former is present — a remote posting with an unresolved region shipped **TELECOMMUTE with no eligible-country claim behind it**, and got no `jobLocation` either (that branch only ran for non-remote postings). Confirmed live against a real affected page: `jobLocationType: "TELECOMMUTE"`, `applicantLocationRequirements: null`, `jobLocation: null`.
- Live-verified scope: **~8,646 open remote postings** currently have an unresolved region (`work_mode=remote & regions=none`) — not the "1 element" the Search Console UI's sample table suggested.

## Fix
- `jobLocationType`/`applicantLocationRequirements` are now only ever set together.
- When the region doesn't resolve but the posting still carries a raw `location` string (the geo dictionary and the LLM fallback both missed it, yet text reached the posting — e.g. `"Farnborough, Hampshire"`), fall back to the same plain `jobLocation` a non-remote posting gets. Extracted the address-building logic into `jobLocationFromText`, now shared by both call sites instead of duplicated.
- When there is no location signal at all (no region, no location text), location is omitted entirely rather than asserting a claim we can't back up — matches the project's existing "never guess" dictionary convention.

## Test plan
- [x] New `jobPostingJsonLd` test cases: TELECOMMUTE+applicantLocationRequirements set together when a region resolves; falls back to plain `jobLocation` when a remote posting has location text but no region; omits location entirely when neither is present; `addressCountry` still added when the geo dictionary pinned a country
- [x] `pnpm vitest run` — 956/956 passing
- [x] `pnpm run check` (svelte-check) — 0 errors
- [x] Fetched a real affected production page before writing the fix to confirm the exact invalid combination described above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job posting metadata for remote roles, including resolved regions and fallback location text.
  * Added country information to job location details where available.
  * Prevented incomplete remote location requirements from appearing when no region data exists.

* **Tests**
  * Added coverage for remote postings with resolved, textual, and missing location data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->