### PR TITLE
Scope local/CI checks to what actually changed, add design-system + govulncheck to pre-commit

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,11 +3,23 @@ name: CodeQL
 # First-party static analysis (SQL/command injection, XSS, taint tracking, ...).
 # Dependency vulnerabilities are covered separately: govulncheck.yml (Go),
 # snyk.yml (JS lockfiles).
+# Not a required status check, so a paths filter here is safe (unlike ci.yml's
+# backend/web jobs or perf.yml's pr-smoke — see AGENTS.md / lefthook.yml for
+# why those can't use one without leaving unrelated PRs stuck on "Expected").
 on:
   push:
     branches: [main]
+    paths: &codeql-paths
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - "web/**"
+      - "extension/**"
+      - "design-system/**"
+      - ".github/workflows/codeql.yml"
   pull_request:
     branches: [main]
+    paths: *codeql-paths
   schedule:
     - cron: '13 4 * * 1'
   workflow_dispatch:

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -5,6 +5,10 @@ on:
     - cron: '23 6 * * *'
   pull_request:
     branches: [main]
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
   workflow_dispatch:
 
 permissions:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,6 +18,23 @@ pre-commit:
     golangci-lint:
       glob: "*.go"
       run: golangci-lint run --new-from-rev=HEAD --allow-parallel-runners ./...
+    # Warn-only: govulncheck currently fails against HEAD from Go-toolchain
+    # stdlib CVEs (e.g. GO-2026-6088, fixed only in go1.26.6 — go.mod pins
+    # 1.25.12), not from anything a commit's diff introduces, so it can't
+    # hard-block yet without blocking every Go commit repo-wide. Flip to a
+    # failing command once the toolchain is bumped past the fix. Mirrors the
+    # path scope of .github/workflows/govulncheck.yml's pull_request trigger.
+    govulncheck:
+      glob:
+        - "**/*.go"
+        - "go.mod"
+        - "go.sum"
+      run: |
+        if ! command -v govulncheck >/dev/null 2>&1; then
+          echo "govulncheck not installed (go install golang.org/x/vuln/cmd/govulncheck@latest) - skipping"
+          exit 0
+        fi
+        govulncheck ./... || echo "govulncheck reported findings above (non-blocking for now, see lefthook.yml)"
     web-lint:
       root: "web/"
       glob: "web/**/*.{js,ts,svelte}"
@@ -26,7 +43,54 @@ pre-commit:
       root: "extension/"
       glob: "extension/**/*.{js,ts,svelte}"
       run: pnpm exec eslint {staged_files}
+    # The remaining design-system-* commands mirror the fast checks from the
+    # `design-system` CI job (see .github/workflows/ci.yml) so a broken commit
+    # fails locally instead of burning a CI run. build-storybook and its CSS
+    # assertion are deliberately left out — too slow for pre-commit — so CI
+    # still catches those for anyone who skips hooks.
     design-system-lint:
       root: "design-system/"
       glob: "design-system/**/*.{js,ts,svelte}"
-      run: pnpm exec eslint {staged_files}
+      run: pnpm run lint
+    design-system-check:
+      root: "design-system/"
+      glob: "design-system/**/*.{svelte,ts}"
+      run: pnpm run check
+    design-system-test:
+      root: "design-system/"
+      glob:
+        - "design-system/src/**"
+        - "design-system/scripts/**"
+      run: pnpm run test
+    # check:dist rebuilds tokens/*.json -> dist/ and diffs — catches a token
+    # edited without `pnpm build`, which otherwise ships stale CSS with every
+    # check green.
+    design-system-dist:
+      root: "design-system/"
+      glob:
+        - "design-system/tokens/**"
+        - "design-system/scripts/build-tokens.mjs"
+        - "design-system/dist/**"
+      run: pnpm run check:dist
+    design-system-docs:
+      root: "design-system/"
+      glob:
+        - "design-system/docs/**"
+        - "design-system/src/**/*.svelte"
+        - "design-system/src/*.stories.ts"
+      run: pnpm run validate:docs
+    # check:tokens and check:adoption also have a radius over ../web/src (a
+    # colour literal or an unreachable primitive can be introduced from either
+    # side), so both trigger on web/src changes too, not just design-system/.
+    design-system-tokens:
+      root: "design-system/"
+      glob:
+        - "design-system/src/**/*.svelte"
+        - "web/src/**/*.{svelte,ts,js}"
+      run: pnpm run check:tokens
+    design-system-adoption:
+      root: "design-system/"
+      glob:
+        - "design-system/src/index.ts"
+        - "web/src/**/*.{svelte,ts,js}"
+      run: pnpm run check:adoption


### PR DESCRIPTION
## Summary
- Add the fast half of the `design-system` CI job (lint, check, test, check:dist, validate:docs, check:tokens, check:adoption) to lefthook's pre-commit, so a broken commit fails locally instead of burning a CI run. `build-storybook` stays CI-only (too slow for pre-commit).
- Add `govulncheck` to pre-commit, warn-only for now: it currently fails against `HEAD` from Go-toolchain stdlib CVEs (fixed only in go1.26.6, `go.mod` pins 1.25.12), not from anything a commit's diff introduces, so it can't hard-block without stopping every Go commit repo-wide.
- Add a `paths:` filter to `govulncheck.yml` and `codeql.yml`'s `pull_request` triggers so they stop running on PRs that touch no relevant code. `ci.yml`'s `backend`/`web` jobs and `perf.yml`'s `pr-smoke` are left unscoped on purpose — they're required status checks, and a paths filter there would leave unrelated PRs stuck on "Expected" forever (`perf.yml` already documents this and works around it with an in-job diff skip instead).

## Test plan
- [x] `pnpm run lint/check/test/check:dist/validate:docs/check:tokens/check:adoption` all pass locally in `design-system/`
- [x] `govulncheck ./...` runs and reports (non-blocking) findings tied to the Go toolchain version, not this diff
- [x] `lefthook.yml`, `govulncheck.yml`, `codeql.yml` all parse as valid YAML
- [ ] CI green on `backend`/`web`/`pr-smoke` (unaffected by these changes, still unscoped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)