### PR TITLE
fix(security): bump nanoid override to 3.3.18

### DIFF
--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   cookie@<0.7.0: 0.7.2
   postcss@<8.5.23: 8.5.23
-  nanoid@<3.3.17: 3.3.17
+  nanoid@<3.3.18: 3.3.18
   dompurify@<3.4.13: 3.4.13
 
 importers:
@@ -2138,8 +2138,8 @@ packages:
     resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
     engines: {node: '>= 0.4'}
 
-  baseline-browser-mapping@2.11.13:
-    resolution: {integrity: sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==}
+  baseline-browser-mapping@2.11.14:
+    resolution: {integrity: sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -3204,8 +3204,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -6124,7 +6124,7 @@ snapshots:
 
   base64-js@0.0.8: {}
 
-  baseline-browser-mapping@2.11.13: {}
+  baseline-browser-mapping@2.11.14: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -6144,7 +6144,7 @@ snapshots:
 
   browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.11.13
+      baseline-browser-mapping: 2.11.14
       caniuse-lite: 1.0.30001809
       electron-to-chromium: 1.5.405
       node-releases: 2.0.53
@@ -7212,7 +7212,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -7352,7 +7352,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -18,8 +18,10 @@ overrides:
   # arbitrary local .map files. Pulled in transitively by vite/eslint-plugin-svelte.
   postcss@<8.5.23: 8.5.23
   # GHSA-qrpm-p2h7-hrv2: nanoid's custom-alphabet generator can loop forever
-  # when passed size 0. Pulled in transitively by postcss.
-  nanoid@<3.3.17: 3.3.17
+  # when passed size 0. Pulled in transitively by postcss. 3.3.17 (the prior
+  # pin) turned out not to fully close it — the advisory's fixed version is
+  # 3.3.18.
+  nanoid@<3.3.18: 3.3.18
   # GHSA-jjrf-c9pj-88w6: DOMPurify's IN_PLACE hook path leaves a detached DOM
   # subtree with executable content, allowing XSS despite sanitization.
   # isomorphic-dompurify is used directly for XSS sanitization in this app.


### PR DESCRIPTION
## Summary
- Dependabot alert #21 (GHSA-qrpm-p2h7-hrv2, high): nanoid's custom-alphabet generator can loop forever on size 0.
- `web/pnpm-workspace.yaml` already carried an override for this exact advisory, but pinned to `3.3.17` — the advisory's fixed version is `3.3.18`. Bumped the pin and re-resolved the lockfile.
- Transitive only (pulled in by `postcss`, itself only reached through devDependencies — eslint-plugin-svelte, vite, svelte-check). Never ships in the built app or server bundle, so exploitability was already low; fixing it anyway since the pin should mean what it says.

## Test plan
- [x] `pnpm install` re-resolves `nanoid` to `3.3.18` in `web/pnpm-lock.yaml`
- [x] `pnpm exec svelte-check` — 0 errors
- [x] `pnpm run build` — production build succeeds