### PR TITLE
Automate Chrome Web Store publishing on version bump

### DIFF
--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -88,15 +88,52 @@ jobs:
 
       - name: Publish GitHub Release
         if: github.event_name == 'push'
+        id: gh_release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: extension-v${{ steps.version.outputs.version }}
         run: |
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "Release $TAG already exists, skipping."
+            echo "created=false" >> "$GITHUB_OUTPUT"
           else
             gh release create "$TAG" .output/*.zip \
               --repo "$GITHUB_REPOSITORY" \
               --title "extension v${{ steps.version.outputs.version }}" \
               --notes "Automated build from commit $GITHUB_SHA."
+            echo "created=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # Uploads the same zip the GitHub Release just published to the Chrome Web
+      # Store and submits it for review. Gated on the version actually being new
+      # (the store rejects a re-upload of a version it already has, same rule as
+      # extension/docs/chrome-web-store.md's manual checklist) and on the
+      # publish-time secrets existing at all, so this step is a no-op until
+      # someone wires up a Google Cloud OAuth client for the Chrome Web Store API
+      # (see extension/docs/chrome-web-store.md for how to obtain them) and adds
+      # CHROME_WEBSTORE_CLIENT_ID / CHROME_WEBSTORE_CLIENT_SECRET /
+      # CHROME_WEBSTORE_REFRESH_TOKEN as repo secrets. Submitting still queues for
+      # Google's manual review — <all_urls> guarantees that regardless of who
+      # uploads the build.
+      - name: Publish to Chrome Web Store
+        if: github.event_name == 'push' && steps.gh_release.outputs.created == 'true' && env.CHROME_WEBSTORE_CLIENT_ID != ''
+        env:
+          CHROME_WEBSTORE_CLIENT_ID: ${{ secrets.CHROME_WEBSTORE_CLIENT_ID }}
+          CHROME_WEBSTORE_CLIENT_SECRET: ${{ secrets.CHROME_WEBSTORE_CLIENT_SECRET }}
+          CHROME_WEBSTORE_REFRESH_TOKEN: ${{ secrets.CHROME_WEBSTORE_REFRESH_TOKEN }}
+          # The published item's id (chrome.google.com/webstore/devconsole/.../<id>/edit),
+          # not the pinned dev key's id in wxt.config.ts — those are different ids by design.
+          CHROME_WEBSTORE_EXTENSION_ID: ijfaechijopdlikalojadpojmpilplnj
+        run: |
+          zip_path=$(ls .output/*.zip | head -n1)
+          npx --yes chrome-webstore-upload-cli@3 upload \
+            --source "$zip_path" \
+            --extension-id "$CHROME_WEBSTORE_EXTENSION_ID" \
+            --client-id "$CHROME_WEBSTORE_CLIENT_ID" \
+            --client-secret "$CHROME_WEBSTORE_CLIENT_SECRET" \
+            --refresh-token "$CHROME_WEBSTORE_REFRESH_TOKEN"
+          npx --yes chrome-webstore-upload-cli@3 publish \
+            --extension-id "$CHROME_WEBSTORE_EXTENSION_ID" \
+            --client-id "$CHROME_WEBSTORE_CLIENT_ID" \
+            --client-secret "$CHROME_WEBSTORE_CLIENT_SECRET" \
+            --refresh-token "$CHROME_WEBSTORE_REFRESH_TOKEN"

--- a/extension/docs/chrome-web-store.md
+++ b/extension/docs/chrome-web-store.md
@@ -104,3 +104,39 @@ used for creditworthiness or lending.
 The privacy policy at the URL you enter must say the same thing and state
 compliance with the Chrome Web Store limited-use requirements. It has to be
 reachable over HTTPS without a login — the review bot crawls it.
+
+## Automated publishing (after the first manual release)
+
+The Chrome Web Store API only updates an **existing** item — it cannot create the
+first listing, so everything above stays a one-time manual pass. Once that first
+release is live, `.github/workflows/extension.yml` uploads and submits every
+subsequent version bump automatically (gated on the GitHub Release step actually
+having created a new tag, so an unchanged version is never re-uploaded — the
+store rejects that anyway).
+
+It's a no-op until three secrets exist on the repo. One-time setup:
+
+1. [Google Cloud Console](https://console.cloud.google.com/) → new (or existing)
+   project → **APIs & Services → Library** → enable the **Chrome Web Store API**.
+2. **APIs & Services → Credentials** → **Create credentials → OAuth client ID**
+   → Application type **Desktop app**. Note the client id and client secret.
+3. Get a refresh token once, from a machine with a browser (this is the only
+   interactive step): run
+   ```
+   npx --yes chrome-webstore-upload-cli@3 refresh-token \
+     --client-id <CLIENT_ID> --client-secret <CLIENT_SECRET>
+   ```
+   sign in with the **same Google account that owns the Developer Dashboard
+   item**, and copy the refresh token it prints.
+4. Add three repo secrets (Settings → Secrets and variables → Actions):
+   `CHROME_WEBSTORE_CLIENT_ID`, `CHROME_WEBSTORE_CLIENT_SECRET`,
+   `CHROME_WEBSTORE_REFRESH_TOKEN`.
+
+`CHROME_WEBSTORE_EXTENSION_ID` is not a secret — it's hardcoded in the workflow
+as the published item's id (`ijfaechijopdlikalojadpojmpilplnj`, from the
+dashboard URL), which is **not** the same id `wxt.config.ts`'s pinned dev key
+produces locally.
+
+Submitting a build this way still enters Google's normal manual review queue —
+`<all_urls>` guarantees that regardless of who uploads it. Automation removes
+the manual dashboard upload step, not the wait.


### PR DESCRIPTION
## Summary
- Adds a `Publish to Chrome Web Store` step to `.github/workflows/extension.yml`: uploads the release zip via `chrome-webstore-upload-cli` and submits it for review, gated on the version actually bumping (reuses the GitHub Release step's idempotency) and on the OAuth secrets existing.
- Documents the one-time OAuth setup (Google Cloud Console client + refresh token) in `extension/docs/chrome-web-store.md`.

## Test plan
- [ ] Configure `CHROME_WEBSTORE_CLIENT_ID` / `CHROME_WEBSTORE_CLIENT_SECRET` / `CHROME_WEBSTORE_REFRESH_TOKEN` repo secrets per the doc.
- [ ] Bump `extension/package.json` version, push to `main`, confirm the new step uploads and submits the build in the Developer Dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Chrome Web Store publishing for newly created releases when the required configuration is available.
  * Publishing remains inactive when prerequisites are missing or the release already exists.

* **Documentation**
  * Added setup instructions for Chrome Web Store API access, OAuth credentials, repository configuration, and ongoing manual review requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->