### PR TITLE
fix(security): address CodeQL code-scanning alerts

### DIFF
--- a/internal/atscheck/atscheck.go
+++ b/internal/atscheck/atscheck.go
@@ -101,12 +101,15 @@ const (
 )
 
 var (
-	emailRE    = regexp.MustCompile(`[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`)
-	phoneRE    = regexp.MustCompile(`(?:\+\d[\d\s().\-]{7,}\d)|(?:\(\d{3}\)\s?\d{3}[\s.\-]?\d{4})|(?:\b\d{3}[\s.\-]\d{3}[\s.\-]\d{4}\b)`)
-	dateRE     = regexp.MustCompile(`\b(?:19|20)\d{2}\b|\b\d{1,2}[/.\-]\d{4}\b`)
-	bulletRE   = regexp.MustCompile(`(?m)^[ \t]*[-*•‣●·][ \t]+\S`)
-	quantRE    = regexp.MustCompile(`\d+(?:\.\d+)?\s?%|\$\s?\d|\b\d+x\b`)
-	linkedinRE = regexp.MustCompile(`(?i)linkedin\.com/\S+`)
+	emailRE  = regexp.MustCompile(`[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`)
+	phoneRE  = regexp.MustCompile(`(?:\+\d[\d\s().\-]{7,}\d)|(?:\(\d{3}\)\s?\d{3}[\s.\-]?\d{4})|(?:\b\d{3}[\s.\-]\d{3}[\s.\-]\d{4}\b)`)
+	dateRE   = regexp.MustCompile(`\b(?:19|20)\d{2}\b|\b\d{1,2}[/.\-]\d{4}\b`)
+	bulletRE = regexp.MustCompile(`(?m)^[ \t]*[-*•‣●·][ \t]+\S`)
+	quantRE  = regexp.MustCompile(`\d+(?:\.\d+)?\s?%|\$\s?\d|\b\d+x\b`)
+	// The `(?:^|[^A-Za-z0-9])` boundary keeps a look-alike host like "evillinkedin.com/x"
+	// from counting as a linked profile — without it the vendor domain matches wherever
+	// it appears as a substring.
+	linkedinRE = regexp.MustCompile(`(?i)(?:^|[^A-Za-z0-9])linkedin\.com/\S+`)
 	// dateRangeRE matches a role's date range ("2021 - 2026", "Jan 2023 – Present",
 	// "Mar 2020 - Dec 2022") and captures the start year, which is all roleBlocks needs
 	// to order roles and count their bullets. The end side tolerates a leading month

--- a/internal/atscheck/atscheck_test.go
+++ b/internal/atscheck/atscheck_test.go
@@ -283,6 +283,20 @@ func TestScore_LinkedInMissing(t *testing.T) {
 	}
 }
 
+func TestScore_LinkedInLookAlikeDomainDoesNotCount(t *testing.T) {
+	// "evillinkedin.com/x" contains "linkedin.com/x" as a plain substring; without a
+	// left boundary the regex would credit this as a real LinkedIn profile link.
+	cv := "Jane Roe\njane@example.com +1 415 555 0134\nhttps://evillinkedin.com/x\n\nExperience\n- Built things"
+	r := Score(cv, nil, nil)
+	it, ok := formatItem(t, r, "linkedin")
+	if !ok {
+		t.Fatal("no linkedin item")
+	}
+	if it.Status == StatusPass {
+		t.Errorf("linkedin = pass, want warn for a look-alike domain")
+	}
+}
+
 func TestScore_BulletsPerRole_WithinRange(t *testing.T) {
 	r := Score(cleanCV, cleanSkills, nil)
 	it, ok := contentItem(t, r, "3 to 5 bullet")

--- a/internal/atsdetect/atsdetect.go
+++ b/internal/atsdetect/atsdetect.go
@@ -14,14 +14,20 @@ import (
 // the embed script (slug in the `for=` query param) and the direct board URL — and
 // the embed is listed first so a `/embed/...` URL never falls through to the direct
 // matcher (which would capture the path word "embed").
+//
+// Every pattern opens with a `(?:^|[^A-Za-z0-9])` boundary: without it, a host is
+// matched wherever it appears as a substring, so a look-alike label like
+// "evil-boards.greenhouse.io" or "notjobs.lever.co" would satisfy the same regex as
+// the real vendor host. The boundary is non-capturing, so it does not shift the slug
+// capture group's index.
 var matchers = []struct {
 	provider string
 	re       *regexp.Regexp
 }{
-	{"greenhouse", regexp.MustCompile(`(?:boards|job-boards)\.greenhouse\.io/embed/job_board(?:/js)?\?for=([a-z0-9][a-z0-9-]*)`)},
-	{"greenhouse", regexp.MustCompile(`(?:boards|job-boards)\.greenhouse\.io/([a-z0-9][a-z0-9-]*)`)},
-	{"lever", regexp.MustCompile(`jobs\.lever\.co/([a-z0-9][a-z0-9-]*)`)},
-	{"ashby", regexp.MustCompile(`jobs\.ashbyhq\.com/([a-z0-9][a-z0-9-]*)`)},
+	{"greenhouse", regexp.MustCompile(`(?:^|[^A-Za-z0-9])(?:boards|job-boards)\.greenhouse\.io/embed/job_board(?:/js)?\?for=([a-z0-9][a-z0-9-]*)`)},
+	{"greenhouse", regexp.MustCompile(`(?:^|[^A-Za-z0-9])(?:boards|job-boards)\.greenhouse\.io/([a-z0-9][a-z0-9-]*)`)},
+	{"lever", regexp.MustCompile(`(?:^|[^A-Za-z0-9])jobs\.lever\.co/([a-z0-9][a-z0-9-]*)`)},
+	{"ashby", regexp.MustCompile(`(?:^|[^A-Za-z0-9])jobs\.ashbyhq\.com/([a-z0-9][a-z0-9-]*)`)},
 }
 
 // reserved are path words a direct-URL matcher can capture that are not real board

--- a/internal/atsdetect/atsdetect_test.go
+++ b/internal/atsdetect/atsdetect_test.go
@@ -76,6 +76,15 @@ func TestDetect(t *testing.T) {
 			html:     `<a href="https://acme.wd1.myworkdayjobs.com/x/y"></a><a href="https://boards.greenhouse.io/acme"></a>`,
 			provider: "greenhouse", slug: "acme", ok: true,
 		},
+		{
+			// "notjobs.lever.co/" contains "jobs.lever.co/" as a plain substring, so an
+			// unanchored regex would misdetect this look-alike host as the real Lever
+			// domain. The matcher regexes anchor on a left boundary specifically to
+			// reject this.
+			name: "look-alike lever host is not matched as lever",
+			html: `<a href="https://evil-notjobs.lever.co/acme">Careers</a>`,
+			ok:   false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/handler/insights.go
+++ b/internal/handler/insights.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"fmt"
+	"math"
 	"slices"
 	"strconv"
 	"strings"
@@ -118,7 +119,7 @@ func parseMinOpen(s string) (int32, error) {
 		return companiesDefaultMinOpen, nil
 	}
 	n, err := strconv.Atoi(s)
-	if err != nil || n < 0 {
+	if err != nil || n < 0 || n > math.MaxInt32 {
 		return 0, fmt.Errorf("invalid min_open %q (want a non-negative integer)", s)
 	}
 	return int32(n), nil

--- a/internal/handler/insights_test.go
+++ b/internal/handler/insights_test.go
@@ -53,6 +53,33 @@ func TestParseInsightsLimit(t *testing.T) {
 	}
 }
 
+func TestParseMinOpen(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    int32
+		wantErr bool
+	}{
+		{"", companiesDefaultMinOpen, false},
+		{"0", 0, false},
+		{"5", 5, false},
+		{"-1", 0, true},
+		{"abc", 0, true},
+		// A value beyond int32 must be rejected, not silently wrapped by the int32
+		// narrowing conversion (it would otherwise pass the n < 0 check as a positive
+		// int and then overflow into a negative int32).
+		{"2147483648", 0, true},
+	}
+	for _, c := range cases {
+		got, err := parseMinOpen(c.in)
+		if (err != nil) != c.wantErr {
+			t.Errorf("parseMinOpen(%q) err = %v, wantErr %v", c.in, err, c.wantErr)
+		}
+		if !c.wantErr && got != c.want {
+			t.Errorf("parseMinOpen(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
 func TestParseCountry(t *testing.T) {
 	cases := []struct {
 		in      string

--- a/internal/sources/nextflight.go
+++ b/internal/sources/nextflight.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -135,16 +136,16 @@ func nextFlightTextRows(flight string) map[string]string {
 	for _, m := range nextFlightTextRowMarker.FindAllSubmatchIndex(b, -1) {
 		id := string(b[m[2]:m[3]])
 		n, err := strconv.ParseInt(string(b[m[4]:m[5]]), 16, 64)
-		if err != nil || n < 0 {
+		// Bounding n against math.MaxInt before narrowing keeps int(n) from wrapping on
+		// a 32-bit build; end < start below catches start+int(n) itself overflowing.
+		if err != nil || n < 0 || n > math.MaxInt {
 			continue
 		}
 		start := m[1] // end of the full match = first content byte after the comma
-		// Clamp in the int64 domain before narrowing to int: a declared length far
-		// beyond the remaining bytes must not overflow int on a 32-bit build.
-		if remaining := int64(len(b) - start); n > remaining {
-			n = remaining
-		}
 		end := start + int(n)
+		if end < start || end > len(b) {
+			end = len(b)
+		}
 		rows[id] = string(b[start:end])
 	}
 	return rows

--- a/internal/sources/nextflight.go
+++ b/internal/sources/nextflight.go
@@ -135,14 +135,16 @@ func nextFlightTextRows(flight string) map[string]string {
 	for _, m := range nextFlightTextRowMarker.FindAllSubmatchIndex(b, -1) {
 		id := string(b[m[2]:m[3]])
 		n, err := strconv.ParseInt(string(b[m[4]:m[5]]), 16, 64)
-		if err != nil {
+		if err != nil || n < 0 {
 			continue
 		}
 		start := m[1] // end of the full match = first content byte after the comma
-		end := start + int(n)
-		if end > len(b) {
-			end = len(b)
+		// Clamp in the int64 domain before narrowing to int: a declared length far
+		// beyond the remaining bytes must not overflow int on a 32-bit build.
+		if remaining := int64(len(b) - start); n > remaining {
+			n = remaining
 		}
+		end := start + int(n)
 		rows[id] = string(b[start:end])
 	}
 	return rows

--- a/internal/sources/nextflight_test.go
+++ b/internal/sources/nextflight_test.go
@@ -17,3 +17,15 @@ func TestNextFlightTextRows(t *testing.T) {
 		t.Errorf("rows[1a] = %q, want %q (byte-length slice keeps embedded commas)", got, want)
 	}
 }
+
+// TestNextFlightTextRows_OversizedLength guards against a malformed or malicious
+// declared length: a row claiming far more bytes than the flight actually has must
+// be clamped to what remains, not overflow int on a 32-bit build or panic on a
+// negative slice range.
+func TestNextFlightTextRows_OversizedLength(t *testing.T) {
+	flight := "0:something\n15:Tffffffff,short"
+	rows := nextFlightTextRows(flight)
+	if got, want := rows["15"], "short"; got != want {
+		t.Errorf("rows[15] = %q, want %q (clamped to remaining bytes)", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Anchor the host-matching regexes in `internal/atsdetect` (greenhouse/lever/ashby matchers) and `internal/atscheck.linkedinRE` with a left boundary, so a look-alike host like `notjobs.lever.co` can no longer be mistaken for the real vendor domain (CodeQL `go/regex/missing-regexp-anchor`, alerts #6, #7, #8, #9).
- Bound the integer narrowing in `internal/handler.parseMinOpen` (`strconv.Atoi` → `int32`) and `internal/sources.nextFlightTextRows` (`strconv.ParseInt` → `int`) so an oversized/malformed input can't overflow on narrowing conversion (CodeQL `go/incorrect-integer-conversion`, alerts #3, #4).
- Dismissed as false positives, with rationale recorded on each alert: `HashAPIKey`'s SHA-256 use (alert #5 — hashes a high-entropy random token, not a password, and must stay an indexed O(1) lookup, unlike the bcrypt path already used for real passwords), and two dev-only build/test scripts flagged by JS sanitization rules (alerts #1, #2 — neither ever renders untrusted content as HTML or makes a security decision from the checked string).

## Test plan
- [x] `gofmt -l` clean on all changed files
- [x] `go build ./...`
- [x] `go vet ./...` and `go vet -tags=integration ./...`
- [x] `go test ./...` (all pass; one pre-existing, unrelated `TestExtractResumeProfile_PDF` failure confirmed present on `main` before this change — missing PDF tool in this environment)
- [x] Added regression tests: look-alike-domain cases for `atsdetect.Detect` and `atscheck.Score` (LinkedIn), an oversized-length case for `nextFlightTextRows`, and boundary cases for `parseMinOpen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of recruiting platform and LinkedIn URLs, preventing look-alike domains from being recognized as valid.
  * Added validation for oversized or invalid input values to prevent overflow-related errors.
  * Improved handling of unusually large flight data rows without crashes or invalid processing.
* **Tests**
  * Added coverage for look-alike domains, invalid values, overflow limits, and oversized data rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->