### PR TITLE
Extension: Analyze match, Save, and job facets in the sidepanel MatchCard

### DIFF
--- a/extension/entrypoints/sidepanel/MatchCard.svelte
+++ b/extension/entrypoints/sidepanel/MatchCard.svelte
@@ -1,17 +1,103 @@
 <script lang="ts">
-  import { Button, Card } from 'freehire-design-system';
-  import { HIRE_ORIGIN } from '../../lib/auth';
-  import { companyLogoUrl, type FreehireJob, type JobMatch } from '../../lib/freehire';
+  import { Bookmark, FileText, SquarePen } from '@lucide/svelte';
+  import { Button, Card, CountryFlag } from 'freehire-design-system';
+  import { getToken, HIRE_ORIGIN } from '../../lib/auth';
+  import {
+    companyLogoUrl,
+    getMatchAnalysis,
+    saveJob,
+    unsaveJob,
+    type FreehireJob,
+    type JobMatch,
+    type MatchAnalysisResponse,
+  } from '../../lib/freehire';
+  import { categoryLabel, countryLabel, regionLabel, workModeLabel } from '../../lib/labels';
 
   let { job, match }: { job: FreehireJob; match: JobMatch } = $props();
 
+  function scoreTone(score: number): 'good' | 'warn' | 'bad' {
+    if (score >= 70) return 'good';
+    if (score >= 40) return 'warn';
+    return 'bad';
+  }
+
   let pct = $derived(Math.max(0, Math.min(100, match.coverage_percent)));
-  let tone = $derived(pct >= 70 ? 'good' : pct >= 40 ? 'warn' : 'bad');
+  let tone = $derived(scoreTone(pct));
   let logoUrl = $derived(companyLogoUrl(job.company));
   let monogram = $derived((job.company || job.title || '?').trim().charAt(0).toUpperCase());
   let logoFailed = $state(false);
   let jobUrl = $derived(`${HIRE_ORIGIN}/jobs/${encodeURIComponent(job.public_slug)}`);
   let tailorUrl = $derived(`${HIRE_ORIGIN}/tailor/${encodeURIComponent(job.public_slug)}`);
+  let profileUrl = $derived(`${HIRE_ORIGIN}/my/profile`);
+  // The ad-hoc text match (a page scraped off any site, not a catalog posting) carries
+  // no slug — see App.svelte's `unknownPage`. Analyze/Save/facts all need a real job to
+  // call the API against, so they stay hidden rather than firing requests at
+  // `/api/v1/jobs//...`.
+  let isCatalogJob = $derived(job.public_slug !== '');
+
+  // Ordered job-facet rows, only those the job actually states. Labels mirror
+  // web's enrichment.ts summaryFacets — see lib/labels.ts for why this is a port
+  // rather than a shared import.
+  interface Fact {
+    label: string;
+    text?: string;
+    countries?: string[];
+  }
+  function buildFacts(j: FreehireJob): Fact[] {
+    const rows: Fact[] = [];
+    if (j.work_mode) rows.push({ label: 'Work format', text: workModeLabel(j.work_mode) });
+    if (j.location) rows.push({ label: 'Location', text: j.location });
+    if (j.regions?.length) rows.push({ label: 'Region', text: j.regions.map(regionLabel).join(', ') });
+    if (j.enrichment?.category) rows.push({ label: 'Category', text: categoryLabel(j.enrichment.category) });
+    if (j.countries?.length) rows.push({ label: 'Country', countries: j.countries });
+    return rows;
+  }
+  let facts = $derived(buildFacts(job));
+
+  // Optimistic, local-only: the card never fetches whether this job was saved
+  // before the panel opened it (no proactive "record a view" call, unlike the
+  // web job page) — it only reflects the panel's own save/unsave actions.
+  let saved = $state(false);
+  let savePending = $state(false);
+
+  async function toggleSave() {
+    if (savePending) return;
+    const token = await getToken();
+    if (!token) return;
+    savePending = true;
+    const wasSaved = saved;
+    saved = !wasSaved;
+    try {
+      await (wasSaved ? unsaveJob(job.public_slug, token) : saveJob(job.public_slug, token));
+    } catch {
+      saved = wasSaved;
+    } finally {
+      savePending = false;
+    }
+  }
+
+  // Cached AI fit analysis — read-only, same contract as web's MatchSummary.svelte:
+  // never computes inline, just shows whatever the full-page analysis last cached.
+  let analysisData = $state<MatchAnalysisResponse | null>(null);
+  $effect(() => {
+    const slug = job.public_slug;
+    analysisData = null;
+    if (slug === '') return;
+    getToken()
+      .then((token) => {
+        if (!token) return null;
+        return getMatchAnalysis(slug, token);
+      })
+      .then((d) => {
+        if (d && job.public_slug === slug) analysisData = d;
+      })
+      .catch(() => {});
+  });
+  let analysis = $derived(analysisData?.analysis ?? null);
+  let topGap = $derived(analysis?.gaps?.[0] ?? null);
+  let credits = $derived(analysisData?.credits ?? null);
+  let creditsSpent = $derived(!!credits && credits.remaining <= 0);
+  let analysisTone = $derived(analysis ? scoreTone(analysis.overall_score) : 'good');
 </script>
 
 <Card class="card">
@@ -55,16 +141,76 @@
     </div>
   {/if}
 
-  <Button
-    class="tailor"
-    variant="primary"
-    size="sm"
-    href={tailorUrl}
-    target="_blank"
-    rel="noreferrer"
-  >
-    Tailor CV
-  </Button>
+  {#if isCatalogJob}
+    <div class="analyze">
+      <div class="label">Analyze match</div>
+
+      {#if analysisData && !analysisData.has_cv}
+        <div class="upload-row">
+          <span class="upload-hint"><FileText class="icon-sm" />Upload a CV to analyse</span>
+          <Button variant="primary" size="sm" href={profileUrl} target="_blank" rel="noreferrer">
+            Upload CV
+          </Button>
+        </div>
+      {:else if analysis}
+        <a class="analysis-card" href={tailorUrl} target="_blank" rel="noreferrer">
+          <div class="analysis-row">
+            <span class="analysis-pct {analysisTone}">{analysis.overall_score}%</span>
+            <span class="analysis-verdict {analysisTone}">{analysis.verdict}</span>
+          </div>
+          {#if topGap}
+            <p class="analysis-gap"><span class="gap-label">Top gap:</span> {topGap}</p>
+          {/if}
+          <span class="analysis-link">View full analysis →</span>
+        </a>
+      {:else if creditsSpent}
+        <p class="hint">
+          You're out of AI credits for this month. They renew
+          {credits ? new Date(credits.resets_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) : 'next month'}.
+        </p>
+      {:else}
+        <p class="hint">How your CV reads against this role — fit, gaps, and ATS flags.</p>
+        <Button class="tailor" variant="primary" size="sm" href={tailorUrl} target="_blank" rel="noreferrer">
+          Tailor my CV
+          <SquarePen class="icon-sm" />
+        </Button>
+        {#if credits}
+          <p class="hint credits">{credits.remaining} AI credits left this month</p>
+        {/if}
+      {/if}
+    </div>
+
+    <Button
+      class="save"
+      variant="outline"
+      size="sm"
+      aria-pressed={saved}
+      disabled={savePending}
+      onclick={toggleSave}
+    >
+      <Bookmark class={saved ? 'icon-sm filled' : 'icon-sm'} />
+      {saved ? 'Saved' : 'Save'}
+    </Button>
+
+    {#if facts.length}
+      <dl class="facts">
+        {#each facts as fact (fact.label)}
+          <div class="frow">
+            <dt class="flabel">{fact.label}</dt>
+            {#if fact.countries}
+              <dd class="fflags">
+                {#each fact.countries as code (code)}
+                  <CountryFlag {code} label={countryLabel(code)} class="flag" />
+                {/each}
+              </dd>
+            {:else}
+              <dd class="fvalue">{fact.text}</dd>
+            {/if}
+          </div>
+        {/each}
+      </dl>
+    {/if}
+  {/if}
 </Card>
 
 <style>
@@ -217,5 +363,137 @@
   :global(.tailor) {
     width: 100%;
     margin-top: 14px;
+    gap: 6px;
+  }
+  .analyze {
+    margin-top: 16px;
+    padding-top: 14px;
+    border-top: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .hint {
+    font-size: 13px;
+    color: var(--muted-foreground);
+  }
+  .hint.credits {
+    font-size: 12px;
+    margin-top: -2px;
+  }
+  .upload-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .upload-hint {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--muted-foreground);
+  }
+  .analysis-card {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 10px;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    text-decoration: none;
+    color: inherit;
+    transition: border-color 0.15s ease;
+  }
+  .analysis-card:hover {
+    border-color: color-mix(in srgb, var(--brand) 40%, var(--border));
+  }
+  .analysis-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .analysis-pct {
+    font-size: 22px;
+    font-weight: 800;
+    line-height: 1;
+  }
+  .analysis-verdict {
+    font-size: 13px;
+    font-weight: 600;
+  }
+  .analysis-pct.good,
+  .analysis-verdict.good {
+    color: var(--brand-strong);
+  }
+  .analysis-pct.warn,
+  .analysis-verdict.warn {
+    color: var(--warning-strong);
+  }
+  .analysis-pct.bad,
+  .analysis-verdict.bad {
+    color: var(--destructive);
+  }
+  .analysis-gap {
+    font-size: 12px;
+    color: var(--muted-foreground);
+  }
+  .gap-label {
+    font-weight: 500;
+    color: var(--foreground);
+  }
+  .analysis-link {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--brand-strong);
+  }
+  :global(.save) {
+    width: 100%;
+    margin-top: 10px;
+    gap: 6px;
+  }
+  :global(.icon-sm) {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+  }
+  :global(.icon-sm.filled) {
+    fill: currentcolor;
+  }
+  .facts {
+    margin-top: 14px;
+    padding-top: 12px;
+    border-top: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .frow {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 10px;
+    font-size: 13px;
+  }
+  .flabel {
+    flex: none;
+    color: var(--muted-foreground);
+  }
+  .fvalue {
+    min-width: 0;
+    text-align: right;
+    font-weight: 500;
+    word-break: break-word;
+  }
+  .fflags {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+  :global(.flag) {
+    font-size: 16px;
   }
 </style>

--- a/extension/entrypoints/sidepanel/app.css
+++ b/extension/entrypoints/sidepanel/app.css
@@ -1,5 +1,8 @@
 @import "tailwindcss";
 @import "freehire-design-system/theme.css";
+/* The design system's CountryFlag primitive is backed by this sheet but doesn't
+ * carry the dependency itself — loaded once here, same as web's root layout. */
+@import "flag-icons/css/flag-icons.min.css";
 
 @layer base {
   body {

--- a/extension/lib/freehire.ts
+++ b/extension/lib/freehire.ts
@@ -33,13 +33,23 @@ export function companyLogoUrl(company: string): string | null {
   return c ? `https://logo.freehire.me/${encodeURIComponent(c)}` : null;
 }
 
-/** The slice of a freehire job the card renders. */
+/** The slice of a freehire job the card renders. Facet fields mirror
+ *  internal/jobview.Job's wire shape (see internal/jobview/AGENTS.md) — the
+ *  handler already serves them on GET /jobs/{slug}, so no backend change was
+ *  needed to read them here, only to widen this projection. */
 export interface FreehireJob {
   public_slug: string;
   title: string;
   company: string;
   location: string;
   posted_at?: string | null;
+  work_mode?: string;
+  regions?: string[];
+  countries?: string[];
+  enrichment?: {
+    category?: string;
+    seniority?: string;
+  };
 }
 
 /** Deterministic skill-coverage match against the signed-in user's profile. */
@@ -96,6 +106,14 @@ async function postData<T>(path: string, body: unknown, token: string): Promise<
   return unwrap<T>(path, res);
 }
 
+async function deleteData<T>(path: string, token: string): Promise<T> {
+  const res = await fetch(`${HIRE_ORIGIN}${path}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return unwrap<T>(path, res);
+}
+
 export function getJob(slug: string, token: string): Promise<FreehireJob> {
   return getData<FreehireJob>(`/api/v1/jobs/${encodeURIComponent(slug)}`, token);
 }
@@ -110,6 +128,43 @@ export function getMatch(slug: string, token: string): Promise<JobMatch> {
  */
 export function getMatchText(title: string, text: string, token: string): Promise<JobMatch> {
   return postData<JobMatch>('/api/v1/me/match-text', { title, text }, token);
+}
+
+/** The signed-in user's interaction with a job — only the field the Save button reads. */
+export interface JobInteraction {
+  saved_at: string | null;
+}
+
+export function saveJob(slug: string, token: string): Promise<JobInteraction> {
+  return postData<JobInteraction>(`/api/v1/jobs/${encodeURIComponent(slug)}/save`, {}, token);
+}
+
+export function unsaveJob(slug: string, token: string): Promise<JobInteraction> {
+  return deleteData<JobInteraction>(`/api/v1/jobs/${encodeURIComponent(slug)}/save`, token);
+}
+
+/** A cached AI fit analysis — only the fields the compact card reads. Never computes
+ *  inline: this is a read of whatever the full-page analysis last cached, same
+ *  contract as web's MatchSummary.svelte. */
+export interface MatchAnalysisSummary {
+  overall_score: number;
+  verdict: string;
+  gaps: string[];
+}
+
+export interface MatchAnalysisCredits {
+  remaining: number;
+  resets_at: string;
+}
+
+export interface MatchAnalysisResponse {
+  has_cv: boolean;
+  analysis: MatchAnalysisSummary | null;
+  credits: MatchAnalysisCredits | null;
+}
+
+export function getMatchAnalysis(slug: string, token: string): Promise<MatchAnalysisResponse> {
+  return getData<MatchAnalysisResponse>(`/api/v1/jobs/${encodeURIComponent(slug)}/match-analysis`, token);
 }
 
 /** Canonical autofill fields freehire assembles from the user's CV + account. */

--- a/extension/lib/labels.test.ts
+++ b/extension/lib/labels.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { workModeLabel, regionLabel, categoryLabel, countryLabel } from './labels';
+
+describe('workModeLabel', () => {
+  it('overrides onsite', () => {
+    expect(workModeLabel('onsite')).toBe('On-site');
+  });
+
+  it('sentence-cases everything else', () => {
+    expect(workModeLabel('remote')).toBe('Remote');
+    expect(workModeLabel('hybrid')).toBe('Hybrid');
+  });
+});
+
+describe('regionLabel', () => {
+  it('maps known region codes', () => {
+    expect(regionLabel('latam')).toBe('LATAM');
+    expect(regionLabel('eu')).toBe('Europe');
+    expect(regionLabel('global')).toBe('Worldwide');
+  });
+
+  it('falls back to sentence case for an unknown region', () => {
+    expect(regionLabel('antarctica')).toBe('Antarctica');
+  });
+});
+
+describe('categoryLabel', () => {
+  it('maps a multi-word category', () => {
+    expect(categoryLabel('fullstack')).toBe('Full-Stack');
+    expect(categoryLabel('ml_ai')).toBe('ML / AI');
+  });
+
+  it('falls back to sentence case for an unknown category', () => {
+    expect(categoryLabel('quantum_computing')).toBe('Quantum computing');
+  });
+});
+
+describe('countryLabel', () => {
+  it('resolves an ISO code via Intl', () => {
+    expect(countryLabel('br')).toBe('Brazil');
+    expect(countryLabel('DE')).toBe('Germany');
+  });
+
+  it('falls back to the upper-cased code when Intl throws on a malformed one', () => {
+    expect(countryLabel('123')).toBe('123');
+  });
+});

--- a/extension/lib/labels.ts
+++ b/extension/lib/labels.ts
@@ -1,0 +1,102 @@
+// Display labels for the job-facet codes the match card renders (work mode, region,
+// category, country). A small, deliberate port of web/src/lib/labels.ts +
+// enrichment.ts's summaryFacets — the extension cannot import those (SvelteKit-only
+// modules), so this mirrors their override maps and fallback rule instead of sharing
+// code. Keep in sync by hand, same convention as lib/assistant/ (see extension/AGENTS.md).
+
+/** Sentence-case an unknown snake_case code ("data_engineering" → "Data engineering"),
+ *  matching enrichment.ts's fallback for facet rows (not labels.ts's titleCase, which
+ *  is for the filter panel and title-cases every word). */
+function sentenceCase(value: string): string {
+  const spaced = value.replace(/_/g, ' ');
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+function label(map: Record<string, string>, value: string): string {
+  return map[value] ?? sentenceCase(value);
+}
+
+const WORK_MODE_LABELS: Record<string, string> = { onsite: 'On-site' };
+
+export function workModeLabel(code: string): string {
+  return label(WORK_MODE_LABELS, code);
+}
+
+const REGIONS: { code: string; short: string }[] = [
+  { code: 'global', short: 'Worldwide' },
+  { code: 'north_america', short: 'North America' },
+  { code: 'latam', short: 'LATAM' },
+  { code: 'eu', short: 'Europe' },
+  { code: 'uk', short: 'UK' },
+  { code: 'mena', short: 'MENA' },
+  { code: 'africa', short: 'Africa' },
+  { code: 'apac', short: 'APAC' },
+  { code: 'cis', short: 'CIS' },
+];
+
+const REGION_LABELS: Record<string, string> = Object.fromEntries(
+  REGIONS.map((r) => [r.code, r.short]),
+);
+
+export function regionLabel(code: string): string {
+  return label(REGION_LABELS, code);
+}
+
+// Exhaustive over the category vocabulary (internal/vocab), same as web's
+// CATEGORY_LABELS — listed in full rather than left to the fallback, so a code never
+// renders two different ways across the two apps.
+const CATEGORY_LABELS: Record<string, string> = {
+  software_engineering: 'Software Engineering',
+  backend: 'Backend',
+  frontend: 'Frontend',
+  fullstack: 'Full-Stack',
+  mobile: 'Mobile',
+  devops: 'DevOps',
+  sre: 'SRE',
+  network_engineering: 'Network Engineering',
+  data_engineering: 'Data Engineering',
+  data_science: 'Data Science',
+  data_analytics: 'Data Analytics',
+  ml_ai: 'ML / AI',
+  ai_engineering: 'AI Engineering',
+  qa: 'QA',
+  security: 'Security',
+  hardware: 'Hardware',
+  embedded: 'Embedded',
+  blockchain: 'Blockchain',
+  architecture: 'Architecture',
+  design: 'Design',
+  engineering_design: 'Engineering Design',
+  product: 'Product',
+  project_management: 'Project Management',
+  management: 'Management',
+  marketing: 'Marketing',
+  sales: 'Sales',
+  support: 'Support',
+  business_analysis: 'Business Analysis',
+  solutions_engineering: 'Solutions Engineering',
+  developer_relations: 'Developer Relations',
+  technical_writing: 'Technical Writing',
+  recruiting: 'Recruiting',
+  hr: 'HR',
+  finance: 'Finance',
+  legal: 'Legal',
+  operations: 'Operations',
+  customer_success: 'Customer Success',
+  other: 'Other',
+};
+
+export function categoryLabel(code: string): string {
+  return label(CATEGORY_LABELS, code);
+}
+
+/** ISO 3166-1 alpha-2 → English display name via platform Intl data, mirroring
+ *  web's countryLabel (facets.ts) — no hand-maintained table to fall out of sync. */
+export function countryLabel(code: string): string {
+  const up = code.toUpperCase();
+  try {
+    return new Intl.DisplayNames(['en'], { type: 'region' }).of(up) ?? up;
+  } catch {
+    return up;
+  }
+}

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@lucide/svelte": "^1.25.0",
+        "flag-icons": "^7.5.0",
         "freehire-design-system": "file:../design-system",
         "svelte": "^5.56.7"
       },
@@ -35,7 +37,7 @@
       "name": "freehire-design-system",
       "version": "0.0.0",
       "dependencies": {
-        "@lucide/svelte": "^1.25.0",
+        "@lucide/svelte": "^1.31.0",
         "clsx": "^2.1.1",
         "tailwind-merge": "^3.6.0",
         "tailwind-variants": "^3.2.2"
@@ -45,19 +47,20 @@
         "@storybook/addon-themes": "10.5.4",
         "@storybook/svelte": "10.5.4",
         "@storybook/svelte-vite": "10.5.4",
-        "@sveltejs/vite-plugin-svelte": "^7.2.0",
+        "@sveltejs/vite-plugin-svelte": "^7.3.0",
         "@tailwindcss/vite": "^4.3.3",
         "@testing-library/svelte": "^5.4.2",
         "eslint": "^10.8.0",
         "eslint-plugin-oxlint": "^1.77.0",
         "eslint-plugin-svelte": "^3.22.0",
+        "flag-icons": "^7.5.0",
         "globals": "^17.8.0",
-        "jsdom": "^29.1.1",
+        "jsdom": "^30.0.1",
         "oxlint": "^1.77.0",
-        "storybook": "10.5.4",
+        "storybook": "10.5.7",
         "style-dictionary": "^5.5.0",
         "svelte": "^5.56.7",
-        "svelte-check": "^4.7.2",
+        "svelte-check": "^4.7.5",
         "svelte-eslint-parser": "^1.8.0",
         "tailwindcss": "^4.3.3",
         "typescript": "^6.0.3",
@@ -506,6 +509,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lucide/svelte": {
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@lucide/svelte/-/svelte-1.31.0.tgz",
+      "integrity": "sha512-pgPuLEJdF0UpsajG9eSw0YvqXVuDxB+/x58BRiC4xE/KEHiopOqT1id3KCUvRN/PUmQkN1F26sslcs/1jutlBQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "svelte": "^5"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -3307,6 +3319,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/flag-icons": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/flag-icons/-/flag-icons-7.5.0.tgz",
+      "integrity": "sha512-kd+MNXviFIg5hijH766tt+3x76ele1AXlo4zDdCxIvqWZhKt4T83bOtxUOOMlTx/EcFdUMH5yvQgYlFh1EqqFg==",
+      "license": "MIT"
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -15,6 +15,8 @@
     "postinstall": "wxt prepare"
   },
   "dependencies": {
+    "@lucide/svelte": "^1.25.0",
+    "flag-icons": "^7.5.0",
     "freehire-design-system": "file:../design-system",
     "svelte": "^5.56.7"
   },


### PR DESCRIPTION
## Summary
- Ports the web job page's "Analyze match" (cached AI fit summary / upload-CV prompt / credits-spent message / Tailor CV CTA), Save toggle, and facet rows (Work format, Location, Region, Category, Country with flags) into the extension's `MatchCard.svelte`.
- Adds `saveJob`/`unsaveJob`/`getMatchAnalysis` to `lib/freehire.ts` — all hit existing Bearer-token-friendly endpoints, no backend change needed.
- New `lib/labels.ts` — a small hand-ported copy of `web/src/lib/labels.ts` + `enrichment.ts`'s facet label maps (the extension can't import SvelteKit-only web modules; same convention as `lib/assistant/`), covered by `lib/labels.test.ts`.
- Adds `flag-icons` + `@lucide/svelte` as direct extension dependencies.
- Guards all of the above behind `isCatalogJob` (`job.public_slug !== ''`) — the ad-hoc text-match card (a scraped page, not a catalog posting) has no slug to call these endpoints with, so it keeps the original, simpler card.
- Save is optimistic/local-only: the panel does not proactively fetch whether a job was already saved (no "record a view" call like the web page makes) — it only reflects the panel's own save/unsave clicks this session.

## Test plan
- [x] `npm test`, `npm run check`, `npm run lint`, `npm run build` all pass.
- [ ] Load unpacked, open a real catalog job posting, verify Analyze match / Save / facets render and behave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)