### PR TITLE
Bump extension to 0.1.1, document it in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,16 @@ new provider before any code.
 A Svelte SPA lives under `web/` and consumes the API (same-origin; a dev Vite
 proxy forwards `/api` to the backend).
 
+## Browser extension
+
+A Chrome extension puts the job-application agent in a side panel next to
+whatever posting you're on: it reads the page when you ask it something, shows
+a deterministic skill-coverage match against your freehire profile, and can
+fill the application form for you. Source lives under `extension/`
+([extension/AGENTS.md](extension/AGENTS.md)).
+
+**[Install it from the Chrome Web Store →](https://chromewebstore.google.com/detail/freehire/ijfaechijopdlikalojadpojmpilplnj?hl=en-US&utm_source=ext_sidebar)**
+
 ## Contributing
 
 **Contributions are welcome, and issues and PRs are open to everyone.** No

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "freehire-extension",
   "description": "Browser extension: a job-application agent side panel, on any page.",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "wxt",


### PR DESCRIPTION
## Summary
- Bumps `extension/package.json` version to 0.1.1 so `.github/workflows/extension.yml`'s version-gated GitHub Release + Chrome Web Store publish steps actually fire — the previous merge (Analyze match/Save/facets, #1914) built and tested cleanly but both were silently skipped since 0.1.0 was already released.
- Adds a "Browser extension" section to the root README (matching the "Frontend" section's format) with a description and the Chrome Web Store listing link.

## Test plan
- [x] `npm run zip` locally produces a 0.1.1 build with the CountryFlag/flag-icons assets present (1.34 MB), confirming the version bump sits on top of the merged feature, not a stale tree.
- [ ] After merge, confirm the `extension` workflow creates GitHub Release `extension-v0.1.1` and the Chrome Web Store publish step succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)