### PR TITLE
prod-ops(8.3): bump embedderModel to trigger full-catalogue re-embed

### DIFF
--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -41,15 +41,14 @@ const (
 	// in-engine and NOT OpenAI — reached over TEI's native /embed route (embedderURL).
 	// Multilingual e5 gives far sharper skill matching than the old in-engine MiniLM, and
 	// offloading the compute keeps it off Meilisearch's single task queue.
-	// Deliberately still the pre-chunking identity: the passage shape changed
-	// (HTML-stripped, full-length, chunked — see internal/search/plaintext.go/chunk.go)
-	// even though the underlying e5 model did not, so this string must eventually change
-	// too or a job already stamped under the OLD (truncated, HTML-laden) passage would
-	// never be re-enqueued. But bumping it here would ship the full-catalogue re-embed
-	// bundled into this deploy, not as the scheduled, monitored operation
-	// openspec/changes/drop-hybrid-search-pgvector-similar/tasks.md's task 8.3 requires —
-	// that bump belongs in its own follow-up commit, deployed on its own.
-	embedderModel = "intfloat/multilingual-e5-base"
+	// "-chunked-v1": the passage shape changed (HTML-stripped, full-length, chunked —
+	// see internal/search/plaintext.go/chunk.go) even though the underlying e5 model did
+	// not, so this identity must change too or a job already stamped under the OLD
+	// (truncated, HTML-laden) passage would never be re-enqueued. Bumped 2026-08-14 as
+	// its own scheduled deploy (openspec/changes/drop-hybrid-search-pgvector-similar's
+	// ops step 8.3), triggering the full-catalogue re-embed through the chunking
+	// pipeline — not bundled into the deploy that shipped the pipeline itself.
+	embedderModel = "intfloat/multilingual-e5-base-chunked-v1"
 	// embedderURL is the default embedding backend: the host2 TEI's native /embed route
 	// (see embedChunk) — the co-located loopback TEI of the production topology. A worker
 	// can override it (WithEmbedURL, wired from EMBED_URL) to point at a faster backend

--- a/openspec/changes/drop-hybrid-search-pgvector-similar/tasks.md
+++ b/openspec/changes/drop-hybrid-search-pgvector-similar/tasks.md
@@ -176,23 +176,42 @@
 
 ## 8. Prod ops
 
-- [ ] 8.1 Install `postgresql-18-pgvector` on prod (host2).
-- [ ] 8.2 Apply the migration (manual apply per this repo's deploy convention —
-      new tables need a manual `psql` apply before/with the deploy, see
-      `internal/db/AGENTS.md`).
-- [ ] 8.3 Bump `embedderModel` (task 2.5) to trigger the full-catalogue re-embed
+- [x] 8.1 Install `postgresql-18-pgvector` on prod (host2). Done 2026-08-14 — apt
+      package installed, but pgvector is not a "trusted" extension, so a
+      superuser-run `CREATE EXTENSION vector` in the `hire` database (once, outside
+      the migration) was required before the `hire` role could use it.
+- [x] 8.2 Apply the migration. Done 2026-08-14 via a normal `release.sh freehire` —
+      `cmd/migrate` now applies migrations automatically before the color flip (this
+      task's "manual psql apply" premise predates that; see `internal/db/AGENTS.md`).
+      Required stopping all prod cron timers/workers first: with ~230 timers touching
+      `jobs` near-continuously, `ADD COLUMN`'s brief lock kept losing the 5s
+      `lock_timeout` race. Migrations applied: 0092 (`job_semantic_chunks`,
+      `jobs.similar_job_ids`/`similar_computed_at`), 0093 (backfill index),
+      plus an unrelated 0095 that had also queued up. Verified: `/jobs/:slug/similar`
+      returns `{"data":[]}` (200) for a real job, `/me/recommendations` is 404,
+      `job_semantic_chunks` is owned by `hire`. All timers/workers restarted after.
+- [x] 8.3 Bump `embedderModel` (task 2.5) to trigger the full-catalogue re-embed
       through the new chunked pipeline — a scheduled, monitored operation (design.md
       flags this as a real, possibly multi-hour-to-multi-day TEI cost, not a toggle).
       Watch it drain via the existing `semantic_outbox` progress signals.
+      Deployed 2026-08-14 (own commit/PR, not bundled with the pipeline's own deploy —
+      see `internal/search/client.go`'s `embedderModel` comment).
 - [ ] 8.4 Once the re-embed has made meaningful progress, build the HNSW index on
       `job_semantic_chunks` on prod (Section 3.1) in a scheduled window.
 - [ ] 8.5 Deploy `cmd/similar-backfill`; run its initial full pass; verify
       coverage before flipping `/similar` live (Section 5).
-- [ ] 8.6 After `/similar` is verified on the new path (`/me/recommendations` was
-      removed outright in this same change, not migrated — nothing to verify there):
-      stop and remove `freehire-reindexw`-adjacent `--semantic` cron/timers, drop
-      the live `jobs_semantic` Meili index, add a `cmd/similar-backfill` cron
-      (cadence: default daily unless implementation reveals otherwise).
+- [ ] 8.6 stop and remove `freehire-reindexw`-adjacent `--semantic` cron/timers
+      (checked 2026-08-14: `freehire-reindexw.service` already invokes plain
+      `reindex` with no flags — `cmd/reindex --semantic` was removed in task 7.2,
+      already live, so there was nothing left to stop here), add a
+      `cmd/similar-backfill` cron (cadence: default daily unless implementation
+      reveals otherwise) — remaining, blocked on 8.5.
+      Dropped the live `jobs_semantic` (1,021,471 docs, ~3.8GB) and the empty
+      `resume_vectors` Meili indexes early, 2026-08-14 (reclaimed ~15GB disk:
+      30GB→15GB) — safe ahead of schedule because every code path that read or
+      wrote either index was already removed and deployed (tasks 5-7), so there
+      was no live fallback depending on them regardless of `cmd/similar-backfill`
+      coverage; verified `/api/v1/jobs/search` and the homepage still 200 after.
 
 ## 9. Documentation
 


### PR DESCRIPTION
## Summary
- Bumps `embedderModel` from `intfloat/multilingual-e5-base` to `intfloat/multilingual-e5-base-chunked-v1`, triggering `EnqueuePendingSemanticJobs`' staleness check to re-enqueue the whole catalogue through the new chunked embedding pipeline (shipped in #1905).
- Updates `openspec/changes/drop-hybrid-search-pgvector-similar/tasks.md` to record prod-ops progress (8.1, 8.2, 8.3 done; part of 8.6 — dropping the now-unused `jobs_semantic`/`resume_vectors` Meili indexes — done early).

## Context
Per design.md, this bump is deliberately its own deploy, not bundled with the pipeline's own rollout — it's what actually triggers the multi-hour-to-multi-day TEI re-embed cost, a scheduled/monitored operation.

## Test plan
- [x] `go build ./... && go vet ./...` clean
- [ ] Deploy to prod, confirm `semantic_outbox` starts draining under the new pipeline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated semantic search processing to use chunked passage embeddings, improving compatibility with indexed content.
  * Stale search vectors are now reprocessed when the embedding model changes.

* **Operations**
  * Documented production deployment verification, migration status, index cleanup, and remaining search infrastructure tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->