### PR TITLE
Move the profile-alert toggle to Search alerts

### DIFF
--- a/openspec/changes/profile-alert-toggle/design.md
+++ b/openspec/changes/profile-alert-toggle/design.md
@@ -46,11 +46,15 @@ This document nails down the exact API/DB shape against the real code
   violation. The client is expected to check its own already-loaded
   `savedSearches` store before calling create (avoiding the round trip in
   the common case), so this 409 path is a race guard, not the primary flow.
-- **Default channel resolution reuses `internal/reminder`'s existing
-  fallback shape** ("current `notification_settings.channels`, or
-  `['email']` if the row is absent/empty") — read via the same
-  `reminder.Service.GetSettings` the notification-settings endpoint already
-  calls, so the toggle needs no new settings read path.
+- **The subscription always goes out on the email channel, not the
+  account's preferred one.** The original design reused
+  `notification_settings.channels[0]`, but that array can list telegram or
+  push before the user ever links them — a code-review finding caught that
+  this created a silently undeliverable alert with no error surfaced.
+  Email needs no linking step, so it is always deliverable; the user can add
+  another channel from the same Search alerts page afterward. If the
+  subscribe call still fails, the just-created search is deleted so the
+  toggle never ends up "on" for a search nothing is subscribed to.
 - **Deleting the search is the disable path — no soft "paused" state.**
   Matches `saved-searches`' existing `DELETE /me/searches/:id` semantics
   exactly (cascades the subscription via the FK already in place for manual
@@ -58,15 +62,23 @@ This document nails down the exact API/DB shape against the real code
 
 ## Web flow
 
-- `/my/profile`'s Settings tab renders a toggle whose `on` state is
+- `/my/notifications/searches` (`SavedSearchesView.svelte`, right after the
+  Telegram connection card) renders the toggle, gated on the account having
+  a candidate profile (`profileStore.profile`) — nothing to derive filters
+  from otherwise. Its `on` state is
   `savedSearches.items.some(s => s.derived_from_profile)` — no separate
-  fetch, since the store is already loaded for the page's other uses.
-- **Enable**: `filtersFromProfile(profile)` → `toSearchString()` → `api.createSavedSearch(name, query, { derived_from_profile: true })`
-  → `api.subscribe(search.id, defaultChannel)`.
+  fetch, since both stores are already loaded for the page's other uses.
+  (Originally placed on `/my/profile`'s Settings tab; moved here per
+  user feedback post-ship — Search alerts is where every other
+  saved-search/subscription control already lives, and a second copy on the
+  profile page would need to stay in permanent sync with this one.)
+- **Enable**: `filtersFromProfile(profile)` → `filtersToParams(...).toString()` → `api.createSavedSearch(name, query, true)`
+  → `api.createSubscription(search.id, 'email')`.
 - **Disable**: `api.deleteSavedSearch(search.id)`.
-- **Sync**: `ProfileForm`'s existing `onSaved` callback (already fired after
-  a successful profile PUT) additionally recomputes the query and calls
-  `api.updateSavedSearch(search.id, { query })` when the toggle is on.
+- **Sync**: `/my/profile`'s existing `handleSaved` callback (already fired
+  after a successful profile PUT, regardless of where the toggle UI lives)
+  additionally recomputes the query and calls `api.updateSavedSearch(search.id, { query })`
+  when a profile-derived search exists.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/profile-alert-toggle/specs/profile-alert-toggle/spec.md
+++ b/openspec/changes/profile-alert-toggle/specs/profile-alert-toggle/spec.md
@@ -2,21 +2,24 @@
 
 ### Requirement: Profile alert toggle
 
-`/my/profile` SHALL present a toggle, "Notify me about jobs matching my
-profile." Enabling it SHALL create a saved search from the current profile
-(using the same filter-derivation the "Apply my profile" filters control
-already uses) marked as profile-derived, and subscribe it on the account's
-default notification channel. Disabling it SHALL remove that saved search
-(and its subscription with it). The toggle's shown state SHALL reflect
-whether a profile-derived saved search currently exists for the account,
-not a separately stored flag.
+`/my/notifications/searches` (the Search alerts page) SHALL present a
+toggle, "Notify me about jobs matching my profile," shown only for an
+account that has a candidate profile to derive filters from. Enabling it
+SHALL create a saved search from the current profile (using the same
+filter-derivation the "Apply my profile" filters control already uses)
+marked as profile-derived, and subscribe it on the email channel — always
+deliverable, unlike telegram/push, which the account's notification
+settings may list as preferred without the user ever having linked them.
+Disabling it SHALL remove that saved search (and its subscription with it).
+The toggle's shown state SHALL reflect whether a profile-derived saved
+search currently exists for the account, not a separately stored flag.
 
 #### Scenario: Enabling creates a search and subscribes it
 
 - **WHEN** a signed-in user with a candidate profile and no profile-derived
   saved search enables the toggle
 - **THEN** a saved search is created from their current profile's filters,
-  marked profile-derived, and subscribed on the account's default channel
+  marked profile-derived, and subscribed on the email channel
 
 #### Scenario: Disabling removes the search
 
@@ -28,13 +31,21 @@ not a separately stored flag.
 
 - **WHEN** a signed-in user manually deletes their profile-derived saved
   search from the search-alerts list
-- **THEN** the profile page's toggle shows as off
+- **THEN** the toggle on the same page shows as off
 
-#### Scenario: Default channel when none configured
+#### Scenario: Hidden without a candidate profile
 
-- **WHEN** a signed-in user enables the toggle with no notification
-  channels ever configured
-- **THEN** the created search is subscribed on the email channel
+- **WHEN** a signed-in user with no candidate profile visits the Search
+  alerts page
+- **THEN** the toggle is not shown, since there is no profile to derive
+  filters from
+
+#### Scenario: Subscribing over an unlinked preferred channel is avoided
+
+- **WHEN** a signed-in user enables the toggle while their account's
+  notification settings prefer telegram or push
+- **THEN** the created search is still subscribed on the email channel, not
+  the unlinked preferred channel
 
 ### Requirement: Profile-derived search stays in sync
 

--- a/openspec/changes/profile-alert-toggle/tasks.md
+++ b/openspec/changes/profile-alert-toggle/tasks.md
@@ -27,7 +27,7 @@
 - [x] 5.2 `web/src/lib/api.ts`: `createSavedSearch` accepts an optional `derived_from_profile` param (default omitted/false); no other client signature changes (`updateSavedSearch`/`deleteSavedSearch` already take what's needed).
 - [x] 5.3 New component (or a small addition to an existing profile-settings card, matching `AccountTimezone.svelte`'s autosave-card style): reads `savedSearches.items` for an existing `derived_from_profile` row to determine on/off; enable computes `filtersFromProfile(profile)` → `toSearchString()` → create (flagged) → subscribe default channel (`notification_settings.channels`, falling back to `['email']`); disable deletes the row.
 - [x] 5.4 `ProfileForm.svelte`'s `onSaved` path (or the page-level `handleSaved` in `/my/profile/+page.svelte`): after a successful profile save, if a `derived_from_profile` search exists, recompute its query and `PATCH` it — fire-and-forget, best-effort (log-only on failure, never blocks/rolls back the profile save).
-- [x] 5.5 Wire the toggle into `/my/profile`'s Settings tab, near `AccountTimezone`.
+- [x] 5.5 Wire the toggle into `/my/notifications/searches` (`SavedSearchesView.svelte`, after the Telegram card, gated on a candidate profile existing) — relocated from `/my/profile`'s Settings tab per post-ship user feedback; see design.md.
 - [x] 5.6 Unit tests for the sync/enable/disable logic (`web/src/lib/*.test.ts`, DB-free — fake API client).
 
 ## 6. Verification

--- a/web/src/lib/components/SavedSearchesView.svelte
+++ b/web/src/lib/components/SavedSearchesView.svelte
@@ -6,21 +6,26 @@
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import { savedSearches } from '$lib/savedSearches.svelte';
   import { notifications } from '$lib/notifications.svelte';
+  import { profileStore } from '$lib/profile.svelte';
   import type { SavedSearch } from '$lib/types';
   import { Button, Input } from '$lib/ui';
   import { toSearchString } from '$lib/urlSearchString';
   import { ProviderIcon } from '$lib/ui';
   import AlertChannels from './filters/AlertChannels.svelte';
+  import ProfileAlertToggle from './ProfileAlertToggle.svelte';
   import States from './States.svelte';
 
   // The account page for saved searches and their alerts: the Telegram connection at
-  // the top, then each saved search as a card with its actions (open / rename / share /
-  // delete) and its per-channel alert toggles (the shared AlertChannels). Merges the
-  // former separate Notifications page — a subscription is always tied to a saved
-  // search, so it's managed per-row.
+  // the top, then the built-in "notify me about jobs matching my profile" toggle (needs
+  // a candidate profile to derive filters from — hidden for an account with none), then
+  // each saved search as a card with its actions (open / rename / share / delete) and
+  // its per-channel alert toggles (the shared AlertChannels). Merges the former separate
+  // Notifications page — a subscription is always tied to a saved search, so it's
+  // managed per-row.
 
   let status = $state<'loading' | 'error' | 'ready'>('loading');
   const items = $derived(savedSearches.items);
+  const profile = $derived(profileStore.profile);
 
   // Telegram connection (moved here from the standalone notifications page).
   const telegram = $derived(notifications.telegram);
@@ -79,7 +84,11 @@
   async function load() {
     status = 'loading';
     try {
-      await Promise.all([savedSearches.ensureLoaded(), notifications.ensureLoaded()]);
+      await Promise.all([
+        savedSearches.ensureLoaded(),
+        notifications.ensureLoaded(),
+        profileStore.ensureLoaded(),
+      ]);
       status = 'ready';
     } catch {
       status = 'error';
@@ -235,6 +244,10 @@
           {/if}
         {/if}
       </section>
+
+      {#if profile}
+        <ProfileAlertToggle {profile} />
+      {/if}
 
       {#if items.length === 0}
         <States

--- a/web/src/routes/my/profile/+page.svelte
+++ b/web/src/routes/my/profile/+page.svelte
@@ -16,7 +16,6 @@
   import FilterSummary from '$lib/components/filters/FilterSummary.svelte';
   import FilterModal from '$lib/components/filters/FilterModal.svelte';
   import FilterEdgeTab from '$lib/components/FilterEdgeTab.svelte';
-  import ProfileAlertToggle from '$lib/components/ProfileAlertToggle.svelte';
   import ProfileForm from '$lib/components/ProfileForm.svelte';
   import ScreeningAnswersForm from '$lib/components/ScreeningAnswersForm.svelte';
   import SkillsView from '$lib/components/SkillsView.svelte';
@@ -229,10 +228,10 @@
   }
 
   // Keep the profile-derived saved search (the "notify me about jobs matching my
-  // profile" toggle, ProfileAlertToggle) in step with a changed role/skills/location —
-  // otherwise it would keep alerting on the profile as it stood when first enabled.
-  // Best-effort: a failure here never blocks or rolls back the profile save itself,
-  // it just leaves the alert stale until the next successful save.
+  // profile" toggle, on the Search alerts page — ProfileAlertToggle) in step with a
+  // changed role/skills/location — otherwise it would keep alerting on the profile as it
+  // stood when first enabled. Best-effort: a failure here never blocks or rolls back the
+  // profile save itself, it just leaves the alert stale until the next successful save.
   async function syncProfileAlert() {
     const p = profileStore.profile;
     if (!p) return;
@@ -392,8 +391,7 @@
           {#key profile.updated_at}
             <ProfileForm {profile} {hasCv} onSaved={handleSaved} onCvUploaded={handleCvUploaded} />
           {/key}
-          <div class="mt-6 flex flex-col gap-4">
-            <ProfileAlertToggle {profile} />
+          <div class="mt-6">
             <AccountTimezone />
           </div>
           <!-- Destructive actions live at the foot of the settings tab, out of


### PR DESCRIPTION
## Summary
- Follow-up to #1911: moves the "Jobs matching my profile" toggle from `/my/profile`'s Settings tab to `/my/notifications/searches` (right after the Telegram connection card), per user feedback — it belongs alongside every other saved-search/subscription control, not buried in profile settings.
- The toggle now shows only when the account has a candidate profile (nothing to derive filters from otherwise).
- Sync-on-profile-save stays wired in `/my/profile` (that's where the save event fires, independent of where the toggle UI lives).
- Updated `openspec/changes/profile-alert-toggle`'s design/spec/tasks docs to match (this change hasn't been archived yet).

## Test plan
- [x] `svelte-check` (0 errors), `eslint`, design-system token-coverage ratchet, `go build/vet`, full web `vitest` suite all green
- [x] Manual browser smoke test: toggle now renders on `/my/notifications/searches` and no longer on `/my/profile`; enabling it there creates the saved search + email subscription; editing the profile still syncs its query; disabling it removes both rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a profile alert toggle to the Search alerts page.
  * The toggle appears only when a candidate profile is available.
  * Enabling creates an email-based saved search alert; disabling removes it.
* **Bug Fixes**
  * Profile-derived alerts no longer use unrelated Telegram or push channels.
  * Failed alert setup now cleans up the newly created saved search.
  * Profile changes synchronize with the associated search alert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->