### PR TITLE
Cap notification bell dropdown to 5, use profile icon for alert toggle

### DIFF
--- a/web/src/lib/components/NotificationBell.svelte
+++ b/web/src/lib/components/NotificationBell.svelte
@@ -14,10 +14,13 @@
   // treatment. Hidden entirely for signed-out visitors — there is nothing to show.
   // The full, paginated list lives at /my/notifications (the notification
   // center's History tab); this panel is a recent-first glance, not the only
-  // way to reach older notifications.
+  // way to reach older notifications — capped to 5 rows here so it stays a
+  // glance, with "View all" below for the rest.
+  const DROPDOWN_LIMIT = 5;
 
   let open = $state(false);
   let root = $state<HTMLElement | null>(null);
+  const visibleItems = $derived(notificationCenter.items.slice(0, DROPDOWN_LIMIT));
 
   // Load once the session is confirmed (boot-time /me may still be in flight); drop
   // the cached page on sign-out so the next user on this tab loads their own.
@@ -112,7 +115,7 @@
           </div>
         {:else}
           <ul>
-            {#each notificationCenter.items as item (item.id)}
+            {#each visibleItems as item (item.id)}
               <li>
                 <NotificationCard {item} onactivate={() => (open = false)} />
               </li>

--- a/web/src/lib/components/ProfileAlertToggle.svelte
+++ b/web/src/lib/components/ProfileAlertToggle.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Check, Sparkles } from '@lucide/svelte';
+  import { Check, User } from '@lucide/svelte';
   import { api, ApiError } from '$lib/api';
   import { filtersFromProfile, filtersToParams } from '$lib/filters';
   import { savedSearches } from '$lib/savedSearches.svelte';
@@ -85,7 +85,7 @@
 <section class="rounded-xl border border-border bg-card p-4">
   <div class="flex items-center gap-3">
     <div class="grid size-9 shrink-0 place-items-center rounded-lg bg-brand-muted text-brand-strong">
-      <Sparkles class="size-4.5" aria-hidden="true" />
+      <User class="size-4.5" aria-hidden="true" />
     </div>
     <div class="min-w-0 flex-1">
       <h2 class="text-sm font-semibold leading-tight">Jobs matching my profile</h2>


### PR DESCRIPTION
## Summary
- The header bell dropdown now shows only the 5 most recent notifications, with the existing "View all notifications" link covering the rest and "Mark all read" unchanged at the top — neither of those needed touching, only the rendered list is capped. The unread badge count is unaffected (still the server's full unread total).
- Swaps the "Jobs matching my profile" toggle's icon from a generic sparkle to the `User` icon already used for Profile elsewhere in the account nav, per feedback.

## Test plan
- [x] `svelte-check` (0 errors), `eslint`, design-system token ratchet, full web `vitest` suite all green
- [x] Manual browser check: seeded 8 test notifications, confirmed the dropdown shows exactly the 5 newest while the bell badge still reads 8; confirmed the new icon renders on the toggle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notification dropdowns now show up to five recent notifications for a quicker overview.
  * A “View all notifications” link remains available to access older notifications.

* **Style**
  * Updated the profile alert toggle icon for clearer visual representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->