### PR TITLE
fix(embed): batch InsertJobSemanticChunks across the whole wave, not per job

### DIFF
--- a/cmd/embed/embed_integration_test.go
+++ b/cmd/embed/embed_integration_test.go
@@ -239,6 +239,52 @@ func TestIntegration_EmbedWorkerChunksLongDescriptionIntoMultipleRows(t *testing
 	}
 }
 
+// TestIntegration_EmbedWorkerBatchInsertDoesNotCrossContaminateJobs proves the batched
+// InsertJobSemanticChunks call — which flattens every job's chunks in the wave into
+// three parallel arrays and inserts them in ONE round trip rather than one INSERT per
+// job (the fix for a real prior incident where a per-job insert loop made a fast GPU
+// embedder Postgres-bound, not GPU-bound) — assigns each chunk row to the correct job.
+// A flattening bug (e.g. a job-id/chunk-index offset mismatch) would show up here as
+// one job stealing another's chunk rows or ending up with a broken index sequence.
+func TestIntegration_EmbedWorkerBatchInsertDoesNotCrossContaminateJobs(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	client := newTestClient(t)
+
+	para := "<p>We build large-scale distributed systems in Go, Postgres, and Kubernetes. " +
+		"You will own services end to end, from design through on-call.</p>"
+	shortID := seedJobWithDescription(t, pool, "batch-short", "Junior Engineer", para, false, true)
+	mediumID := seedJobWithDescription(t, pool, "batch-medium", "Mid Engineer", strings.Repeat(para, 20), false, true)
+	longID := seedJobWithDescription(t, pool, "batch-long", "Staff Engineer", strings.Repeat(para, 60), false, true)
+
+	runner := embed.Runner{Store: newDBStore(pool), Indexer: searchIndexer{client: client}}
+	// A single wave covering all three jobs — the scenario that actually exercises the
+	// flattened multi-job insert; three separate one-job waves would prove nothing new.
+	if _, err := runner.Run(ctx, embed.RunOptions{
+		TargetModel: search.CurrentEmbedderModel(), BatchSize: 500, LeaseSeconds: 300, MaxAttempts: 3,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	shortCount := jobChunkCount(t, pool, shortID)
+	mediumCount := jobChunkCount(t, pool, mediumID)
+	longCount := jobChunkCount(t, pool, longID)
+	if !(shortCount < mediumCount && mediumCount < longCount) {
+		t.Fatalf("chunk counts = short:%d medium:%d long:%d, want strictly increasing with description length",
+			shortCount, mediumCount, longCount)
+	}
+
+	for name, id := range map[string]int64{"short": shortID, "medium": mediumID, "long": longID} {
+		indices := jobChunkIndices(t, pool, id)
+		for i, idx := range indices {
+			if int(idx) != i {
+				t.Fatalf("%s job chunk indices = %v, want a clean 0..%d sequence (cross-contaminated by the flattened batch insert)",
+					name, indices, len(indices)-1)
+			}
+		}
+	}
+}
+
 // TestIntegration_EmbedWorkerReplacesChunksOnReembedNotAppend proves a re-embed (content
 // changed, so semantic_embedded_hash goes stale) REPLACES a job's chunk rows rather than
 // appending to them — a job must never end up with a mix of old and new chunk vectors.

--- a/cmd/embed/store.go
+++ b/cmd/embed/store.go
@@ -69,24 +69,28 @@ func (s *dbStore) CompleteOpen(ctx context.Context, entries []embed.Claimed, mod
 		if err := qtx.DeleteJobSemanticChunks(ctx, jobIDs); err != nil {
 			return fmt.Errorf("delete chunks: %w", err)
 		}
+		// Flatten every entry's chunks into three parallel arrays across the WHOLE
+		// wave, then insert them all in ONE round trip — not one INSERT per job. A
+		// per-job loop here was exactly what made a prior HF GPU bulk-embed
+		// Postgres-bound instead of GPU-bound (see InsertJobSemanticChunks' comment).
+		var flatJobIDs []int64
+		var flatIndices []int16
+		var flatEmbeddings []string
 		for _, e := range entries {
-			cs := chunks[e.JobID]
-			if len(cs) == 0 {
-				continue
+			for _, c := range chunks[e.JobID] {
+				flatJobIDs = append(flatJobIDs, e.JobID)
+				flatIndices = append(flatIndices, c.ChunkIndex)
+				// Each vector travels as pgvector literal TEXT (e.g. "[0.1,0.2,...]"),
+				// not a native array element — see InsertJobSemanticChunks' comment
+				// for why (no OID codec registered for an array of vectors).
+				flatEmbeddings = append(flatEmbeddings, pgvector.NewVector(c.Vector).String())
 			}
-			indices := make([]int16, len(cs))
-			embeddings := make([]string, len(cs))
-			for i, c := range cs {
-				indices[i] = c.ChunkIndex
-				// InsertJobSemanticChunks takes each vector as pgvector literal TEXT
-				// (e.g. "[0.1,0.2,...]"), not a native array element — see that query's
-				// comment for why (no OID codec registered for an array of vectors).
-				embeddings[i] = pgvector.NewVector(c.Vector).String()
-			}
+		}
+		if len(flatJobIDs) > 0 {
 			if err := qtx.InsertJobSemanticChunks(ctx, db.InsertJobSemanticChunksParams{
-				JobID: e.JobID, ChunkIndices: indices, Embeddings: embeddings,
+				JobIds: flatJobIDs, ChunkIndices: flatIndices, Embeddings: flatEmbeddings,
 			}); err != nil {
-				return fmt.Errorf("insert chunks (job %d): %w", e.JobID, err)
+				return fmt.Errorf("insert chunks: %w", err)
 			}
 		}
 		// A re-embed's fresh chunk set makes any precomputed similar_job_ids stale (or

--- a/cmd/similar-backfill/similar_backfill_integration_test.go
+++ b/cmd/similar-backfill/similar_backfill_integration_test.go
@@ -53,14 +53,16 @@ func insertTestJob(t *testing.T, pool *pgxpool.Pool, externalID, companySlug str
 
 func insertTestChunks(t *testing.T, q *db.Queries, jobID int64, dims []int) {
 	t.Helper()
+	jobIDs := make([]int64, len(dims))
 	indices := make([]int16, len(dims))
 	embeddings := make([]string, len(dims))
 	for i, d := range dims {
+		jobIDs[i] = jobID
 		indices[i] = int16(i)
 		embeddings[i] = unitVector768(d)
 	}
 	if err := q.InsertJobSemanticChunks(context.Background(), db.InsertJobSemanticChunksParams{
-		JobID: jobID, ChunkIndices: indices, Embeddings: embeddings,
+		JobIds: jobIDs, ChunkIndices: indices, Embeddings: embeddings,
 	}); err != nil {
 		t.Fatalf("insert chunks for job %d: %v", jobID, err)
 	}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1434,17 +1434,25 @@ type Querier interface {
 	// Store a message received at a hosted mailbox, idempotent by
 	// (user_id, source, external_id) with source fixed to 'hosted'.
 	InsertHostedMessage(ctx context.Context, arg InsertHostedMessageParams) error
-	// Batch-insert one job's freshly-embedded chunks. chunk_indices and embeddings are
-	// positionally paired parallel arrays (element i of one belongs with element i of the
-	// other) — unnested separately and rejoined WITH ORDINALITY because sqlc cannot infer
-	// the types of a multi-argument unnest over query parameters (same pattern as
-	// pruning.sql's bulk job delete/archive). embeddings travels as vector literal TEXT
-	// (e.g. "[0.1,0.2,...]"), not a native vector(768)[] array: pgx's driver.Valuer/
-	// sql.Scanner fallback for pgvector.Vector (this repo registers no custom OID codec
-	// for it) only covers a single scalar column value, not an array of them, so each
-	// element casts to vector(768) individually in the SELECT instead. Always run
-	// immediately after DeleteJobSemanticChunks in the same transaction as the embed
-	// stamp — see that query's comment.
+	// Batch-insert EVERY job's freshly-embedded chunks in the wave in one round trip, not
+	// one call per job: job_ids/chunk_indices/embeddings are positionally paired parallel
+	// arrays FLATTENED across the whole batch (one element per chunk, not per job — a job
+	// contributing 3 chunks repeats its id 3 times at the matching offsets) — unnested
+	// separately and rejoined WITH ORDINALITY because sqlc cannot infer the types of a
+	// multi-argument unnest over query parameters (same pattern as pruning.sql's bulk job
+	// delete/archive). embeddings travels as vector literal TEXT (e.g. "[0.1,0.2,...]"),
+	// not a native vector(768)[] array: pgx's driver.Valuer/sql.Scanner fallback for
+	// pgvector.Vector (this repo registers no custom OID codec for it) only covers a
+	// single scalar column value, not an array of them, so each element casts to
+	// vector(768) individually in the SELECT instead. Always run immediately after
+	// DeleteJobSemanticChunks in the same transaction as the embed stamp — see that
+	// query's comment.
+	//
+	// One call for the whole wave, not one per job, for the same reason
+	// DeleteJobSemanticChunks/StampSemanticEmbeddedBatch already are: a per-job round trip
+	// here was exactly what made a prior HF GPU bulk-embed Postgres-bound instead of
+	// GPU-bound (~19 docs/s against a GPU embedding a wave in ~7s) — see
+	// hire-semantic-vectors-in-pg's "THE REAL BOTTLENECK IS POSTGRES, NOT THE GPU" note.
 	InsertJobSemanticChunks(ctx context.Context, arg InsertJobSemanticChunksParams) error
 	// Claim an address for a user. May raise a unique violation on user_id (already
 	// has a mailbox) or address (taken) — the allocation service handles both: it

--- a/internal/db/queries/semantic.sql
+++ b/internal/db/queries/semantic.sql
@@ -172,20 +172,29 @@ DELETE FROM job_semantic_chunks
 WHERE job_id = ANY(sqlc.arg(job_ids)::bigint[]);
 
 -- name: InsertJobSemanticChunks :exec
--- Batch-insert one job's freshly-embedded chunks. chunk_indices and embeddings are
--- positionally paired parallel arrays (element i of one belongs with element i of the
--- other) — unnested separately and rejoined WITH ORDINALITY because sqlc cannot infer
--- the types of a multi-argument unnest over query parameters (same pattern as
--- pruning.sql's bulk job delete/archive). embeddings travels as vector literal TEXT
--- (e.g. "[0.1,0.2,...]"), not a native vector(768)[] array: pgx's driver.Valuer/
--- sql.Scanner fallback for pgvector.Vector (this repo registers no custom OID codec
--- for it) only covers a single scalar column value, not an array of them, so each
--- element casts to vector(768) individually in the SELECT instead. Always run
--- immediately after DeleteJobSemanticChunks in the same transaction as the embed
--- stamp — see that query's comment.
+-- Batch-insert EVERY job's freshly-embedded chunks in the wave in one round trip, not
+-- one call per job: job_ids/chunk_indices/embeddings are positionally paired parallel
+-- arrays FLATTENED across the whole batch (one element per chunk, not per job — a job
+-- contributing 3 chunks repeats its id 3 times at the matching offsets) — unnested
+-- separately and rejoined WITH ORDINALITY because sqlc cannot infer the types of a
+-- multi-argument unnest over query parameters (same pattern as pruning.sql's bulk job
+-- delete/archive). embeddings travels as vector literal TEXT (e.g. "[0.1,0.2,...]"),
+-- not a native vector(768)[] array: pgx's driver.Valuer/sql.Scanner fallback for
+-- pgvector.Vector (this repo registers no custom OID codec for it) only covers a
+-- single scalar column value, not an array of them, so each element casts to
+-- vector(768) individually in the SELECT instead. Always run immediately after
+-- DeleteJobSemanticChunks in the same transaction as the embed stamp — see that
+-- query's comment.
+--
+-- One call for the whole wave, not one per job, for the same reason
+-- DeleteJobSemanticChunks/StampSemanticEmbeddedBatch already are: a per-job round trip
+-- here was exactly what made a prior HF GPU bulk-embed Postgres-bound instead of
+-- GPU-bound (~19 docs/s against a GPU embedding a wave in ~7s) — see
+-- hire-semantic-vectors-in-pg's "THE REAL BOTTLENECK IS POSTGRES, NOT THE GPU" note.
 INSERT INTO job_semantic_chunks (job_id, chunk_index, embedding)
-SELECT sqlc.arg(job_id)::bigint, idx.chunk_index, emb.embedding::vector(768)
-FROM unnest(sqlc.arg(chunk_indices)::smallint[]) WITH ORDINALITY AS idx(chunk_index, n)
+SELECT ids.job_id, idx.chunk_index, emb.embedding::vector(768)
+FROM unnest(sqlc.arg(job_ids)::bigint[]) WITH ORDINALITY AS ids(job_id, n)
+JOIN unnest(sqlc.arg(chunk_indices)::smallint[]) WITH ORDINALITY AS idx(chunk_index, n) USING (n)
 JOIN unnest(sqlc.arg(embeddings)::text[]) WITH ORDINALITY AS emb(embedding, n) USING (n);
 
 -- name: ClearSimilarComputedAtBatch :exec

--- a/internal/db/semantic.sql.go
+++ b/internal/db/semantic.sql.go
@@ -336,30 +336,39 @@ func (q *Queries) GetJobsByIDs(ctx context.Context, ids []int64) ([]Job, error) 
 
 const insertJobSemanticChunks = `-- name: InsertJobSemanticChunks :exec
 INSERT INTO job_semantic_chunks (job_id, chunk_index, embedding)
-SELECT $1::bigint, idx.chunk_index, emb.embedding::vector(768)
-FROM unnest($2::smallint[]) WITH ORDINALITY AS idx(chunk_index, n)
+SELECT ids.job_id, idx.chunk_index, emb.embedding::vector(768)
+FROM unnest($1::bigint[]) WITH ORDINALITY AS ids(job_id, n)
+JOIN unnest($2::smallint[]) WITH ORDINALITY AS idx(chunk_index, n) USING (n)
 JOIN unnest($3::text[]) WITH ORDINALITY AS emb(embedding, n) USING (n)
 `
 
 type InsertJobSemanticChunksParams struct {
-	JobID        int64    `json:"job_id"`
+	JobIds       []int64  `json:"job_ids"`
 	ChunkIndices []int16  `json:"chunk_indices"`
 	Embeddings   []string `json:"embeddings"`
 }
 
-// Batch-insert one job's freshly-embedded chunks. chunk_indices and embeddings are
-// positionally paired parallel arrays (element i of one belongs with element i of the
-// other) — unnested separately and rejoined WITH ORDINALITY because sqlc cannot infer
-// the types of a multi-argument unnest over query parameters (same pattern as
-// pruning.sql's bulk job delete/archive). embeddings travels as vector literal TEXT
-// (e.g. "[0.1,0.2,...]"), not a native vector(768)[] array: pgx's driver.Valuer/
-// sql.Scanner fallback for pgvector.Vector (this repo registers no custom OID codec
-// for it) only covers a single scalar column value, not an array of them, so each
-// element casts to vector(768) individually in the SELECT instead. Always run
-// immediately after DeleteJobSemanticChunks in the same transaction as the embed
-// stamp — see that query's comment.
+// Batch-insert EVERY job's freshly-embedded chunks in the wave in one round trip, not
+// one call per job: job_ids/chunk_indices/embeddings are positionally paired parallel
+// arrays FLATTENED across the whole batch (one element per chunk, not per job — a job
+// contributing 3 chunks repeats its id 3 times at the matching offsets) — unnested
+// separately and rejoined WITH ORDINALITY because sqlc cannot infer the types of a
+// multi-argument unnest over query parameters (same pattern as pruning.sql's bulk job
+// delete/archive). embeddings travels as vector literal TEXT (e.g. "[0.1,0.2,...]"),
+// not a native vector(768)[] array: pgx's driver.Valuer/sql.Scanner fallback for
+// pgvector.Vector (this repo registers no custom OID codec for it) only covers a
+// single scalar column value, not an array of them, so each element casts to
+// vector(768) individually in the SELECT instead. Always run immediately after
+// DeleteJobSemanticChunks in the same transaction as the embed stamp — see that
+// query's comment.
+//
+// One call for the whole wave, not one per job, for the same reason
+// DeleteJobSemanticChunks/StampSemanticEmbeddedBatch already are: a per-job round trip
+// here was exactly what made a prior HF GPU bulk-embed Postgres-bound instead of
+// GPU-bound (~19 docs/s against a GPU embedding a wave in ~7s) — see
+// hire-semantic-vectors-in-pg's "THE REAL BOTTLENECK IS POSTGRES, NOT THE GPU" note.
 func (q *Queries) InsertJobSemanticChunks(ctx context.Context, arg InsertJobSemanticChunksParams) error {
-	_, err := q.db.Exec(ctx, insertJobSemanticChunks, arg.JobID, arg.ChunkIndices, arg.Embeddings)
+	_, err := q.db.Exec(ctx, insertJobSemanticChunks, arg.JobIds, arg.ChunkIndices, arg.Embeddings)
 	return err
 }
 

--- a/internal/db/semantic_chunks_integration_test.go
+++ b/internal/db/semantic_chunks_integration_test.go
@@ -46,6 +46,16 @@ func unitVector768(dim int) string {
 	return pgvector.NewVector(v).String()
 }
 
+// repeatJobID builds the flattened job_ids array InsertJobSemanticChunks now takes: one
+// element per chunk (not per job), so a single job's n chunks repeat its id n times.
+func repeatJobID(id int64, n int) []int64 {
+	ids := make([]int64, n)
+	for i := range ids {
+		ids[i] = id
+	}
+	return ids
+}
+
 // jobSemanticChunkIndices returns a job's stored chunk_index values, ascending — used to
 // assert the delete/insert replace round trip landed the expected rows.
 func jobSemanticChunkIndices(t *testing.T, pool *pgxpool.Pool, jobID int64) []int16 {
@@ -77,7 +87,7 @@ func TestJobSemanticChunksReplace(t *testing.T) {
 		j := insertChunkTestJob(t, pool, "replace", "acme")
 
 		if err := q.InsertJobSemanticChunks(ctx, InsertJobSemanticChunksParams{
-			JobID:        j,
+			JobIds:       repeatJobID(j, 2),
 			ChunkIndices: []int16{0, 1},
 			Embeddings:   []string{unitVector768(0), unitVector768(1)},
 		}); err != nil {
@@ -94,7 +104,7 @@ func TestJobSemanticChunksReplace(t *testing.T) {
 			t.Fatalf("delete: %v", err)
 		}
 		if err := q.InsertJobSemanticChunks(ctx, InsertJobSemanticChunksParams{
-			JobID:        j,
+			JobIds:       repeatJobID(j, 1),
 			ChunkIndices: []int16{0},
 			Embeddings:   []string{unitVector768(2)},
 		}); err != nil {
@@ -120,7 +130,7 @@ func TestJobSemanticChunksReplace(t *testing.T) {
 		truncate(t, pool)
 		j := insertChunkTestJob(t, pool, "closepath", "acme")
 		if err := q.InsertJobSemanticChunks(ctx, InsertJobSemanticChunksParams{
-			JobID:        j,
+			JobIds:       repeatJobID(j, 1),
 			ChunkIndices: []int16{0},
 			Embeddings:   []string{unitVector768(0)},
 		}); err != nil {
@@ -134,13 +144,43 @@ func TestJobSemanticChunksReplace(t *testing.T) {
 		}
 	})
 
+	t.Run("batched insert assigns each job its own chunks, no cross-contamination", func(t *testing.T) {
+		truncate(t, pool)
+		j1 := insertChunkTestJob(t, pool, "flat-1", "acme")
+		j2 := insertChunkTestJob(t, pool, "flat-2", "acme")
+		// One call across BOTH jobs, flattened: j1 contributes 2 chunks, j2 contributes 1
+		// — the shape a real embed wave produces (variable chunk count per job).
+		if err := q.InsertJobSemanticChunks(ctx, InsertJobSemanticChunksParams{
+			JobIds:       []int64{j1, j1, j2},
+			ChunkIndices: []int16{0, 1, 0},
+			Embeddings:   []string{unitVector768(0), unitVector768(1), unitVector768(2)},
+		}); err != nil {
+			t.Fatalf("batched insert: %v", err)
+		}
+
+		if got := jobSemanticChunkIndices(t, pool, j1); len(got) != 2 || got[0] != 0 || got[1] != 1 {
+			t.Fatalf("job1 chunk indices = %v, want [0 1]", got)
+		}
+		if got := jobSemanticChunkIndices(t, pool, j2); len(got) != 1 || got[0] != 0 {
+			t.Fatalf("job2 chunk indices = %v, want [0]", got)
+		}
+		var j2Emb pgvector.Vector
+		if err := pool.QueryRow(ctx,
+			"SELECT embedding FROM job_semantic_chunks WHERE job_id = $1 AND chunk_index = 0", j2).Scan(&j2Emb); err != nil {
+			t.Fatalf("read job2 embedding: %v", err)
+		}
+		if j2Emb.Slice()[2] != 1 {
+			t.Errorf("job2 embedding = %v, want dim 2 set to 1 (its own vector, not job1's)", j2Emb.Slice()[:3])
+		}
+	})
+
 	t.Run("batched delete clears multiple jobs' chunks in one call", func(t *testing.T) {
 		truncate(t, pool)
 		j1 := insertChunkTestJob(t, pool, "batch-1", "acme")
 		j2 := insertChunkTestJob(t, pool, "batch-2", "acme")
 		for _, j := range []int64{j1, j2} {
 			if err := q.InsertJobSemanticChunks(ctx, InsertJobSemanticChunksParams{
-				JobID:        j,
+				JobIds:       repeatJobID(j, 1),
 				ChunkIndices: []int16{0},
 				Embeddings:   []string{unitVector768(0)},
 			}); err != nil {
@@ -173,7 +213,7 @@ func TestNearestJobsToJob(t *testing.T) {
 			embeddings[i] = unitVector768(d)
 		}
 		if err := q.InsertJobSemanticChunks(ctx, InsertJobSemanticChunksParams{
-			JobID: jobID, ChunkIndices: indices, Embeddings: embeddings,
+			JobIds: repeatJobID(jobID, len(indices)), ChunkIndices: indices, Embeddings: embeddings,
 		}); err != nil {
 			t.Fatalf("insert chunks for job %d: %v", jobID, err)
 		}


### PR DESCRIPTION
## Summary
- `cmd/embed`'s `CompleteOpen` called `InsertJobSemanticChunks` once per job in the wave (N round trips per batch). This is exactly the shape that made a prior HF GPU bulk-embed Postgres-bound instead of GPU-bound (~19 docs/s against a GPU embedding a wave in ~7s — see the `hire-semantic-vectors-in-pg` postmortem).
- Flattens every job's chunks in the wave into three parallel arrays (`job_ids`/`chunk_indices`/`embeddings`, one element per chunk) and inserts them all in **one** round trip.
- Motivated by spinning up a fast HF GPU inference endpoint for the ongoing prod re-embed (openspec `drop-hybrid-search-pgvector-similar` task 8.3) — this needs to land first so Postgres doesn't reintroduce the bottleneck a fast embedder is meant to remove.

## Test plan
- [x] New integration test `TestIntegration_EmbedWorkerBatchInsertDoesNotCrossContaminateJobs` — 3 jobs with different chunk counts in one wave, asserts no cross-contamination and clean per-job index sequences.
- [x] New `internal/db` subtest — direct multi-job `InsertJobSemanticChunks` call, asserts each job's chunk rows/vectors are correctly attributed.
- [x] Updated existing `internal/db` and `cmd/similar-backfill` integration tests for the new `JobIds` (flattened) param shape.
- [x] `go build/vet ./...`, `go vet -tags=integration ./...`, full `go test -tags=integration ./...`, `go test ./...`, `gofmt -l .` all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved semantic chunk storage by inserting chunks from multiple jobs in a single database operation.
  * Reduced database round trips during embedding processing.

* **Bug Fixes**
  * Ensured chunks remain correctly associated with their source jobs and retain valid sequential indexes.
  * Prevented cross-job contamination during batched processing.

* **Tests**
  * Added coverage for multi-job batch insertion, chunk ownership, ordering, replacement, deletion, and nearest-job searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->