### PR TITLE
Fix 10 design-system/web review findings: races, a11y, recursion, encoding

### DIFF
--- a/design-system/src/avatar.svelte
+++ b/design-system/src/avatar.svelte
@@ -43,7 +43,8 @@
   let initials = $derived(
     name
       ? name
-          .split(' ')
+          .trim()
+          .split(/\s+/)
           .slice(0, 2)
           .map((w) => w[0]?.toUpperCase() ?? '')
           .join('')

--- a/design-system/src/avatar.test.ts
+++ b/design-system/src/avatar.test.ts
@@ -89,6 +89,14 @@ describe('Avatar', () => {
     expect(circle('Prince').textContent?.trim()).toBe('P');
   });
 
+  // A pasted résumé/profile field is a common source of stray whitespace; the split
+  // must not turn it into a leading empty "initial".
+  it('ignores leading, trailing, and repeated whitespace when deriving initials', () => {
+    expect(circle(' Ada Lovelace').textContent?.trim()).toBe('AL');
+    expect(circle('Ada Lovelace ').textContent?.trim()).toBe('AL');
+    expect(circle('Ada  Lovelace').textContent?.trim()).toBe('AL');
+  });
+
   it('leaves a photo undescribed when there is no name to describe it with', () => {
     const { container } = render(Avatar, { src: 'https://example.test/a.png' });
 

--- a/design-system/src/button.svelte
+++ b/design-system/src/button.svelte
@@ -47,14 +47,22 @@
     size = 'md',
     class: className,
     href,
+    target,
+    rel,
     children,
     ...rest
   }: Props = $props();
+
+  // A target="_blank" anchor keeps a window.opener handle back to this page unless
+  // rel says otherwise — the reverse-tabnabbing gap. Fill in the safe default once,
+  // here, rather than relying on every call site to remember it; an explicit `rel`
+  // from the caller still wins.
+  const effectiveRel = $derived(target === '_blank' ? (rel ?? 'noopener noreferrer') : rel);
 </script>
 
 {#if href}
   <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- generic link primitive; href may be external — e.g. a job's apply URL — so the caller owns resolving internal routes -->
-  <a {href} class={cn(buttonVariants({ variant, size }), className)} {...rest}>
+  <a {href} {target} rel={effectiveRel} class={cn(buttonVariants({ variant, size }), className)} {...rest}>
     {@render children()}
   </a>
 {:else}

--- a/design-system/src/button.test.ts
+++ b/design-system/src/button.test.ts
@@ -74,6 +74,44 @@ describe('Button', () => {
     expect(queryByRole('button')).toBeNull();
   });
 
+  // Reverse-tabnabbing guard: a target="_blank" anchor must not keep a window.opener
+  // handle back to this page, and a caller must not have to remember rel by hand.
+  it('adds rel=noopener noreferrer by default when opened in a new tab', () => {
+    // `target` doubles as a testing-library render option, so it — and every prop
+    // alongside it — has to go under `props` explicitly here.
+    const { getByRole } = render(Button, {
+      props: {
+        href: 'https://example.com',
+        target: '_blank',
+        children: slot('Go'),
+      },
+    });
+
+    expect(getByRole('link').getAttribute('rel')).toBe('noopener noreferrer');
+  });
+
+  it('lets a caller override the default rel', () => {
+    const { getByRole } = render(Button, {
+      props: {
+        href: 'https://example.com',
+        target: '_blank',
+        rel: 'noopener',
+        children: slot('Go'),
+      },
+    });
+
+    expect(getByRole('link').getAttribute('rel')).toBe('noopener');
+  });
+
+  it('leaves rel unset for a same-tab link', () => {
+    const { getByRole } = render(Button, {
+      href: '/jobs',
+      children: slot('Go'),
+    });
+
+    expect(getByRole('link').getAttribute('rel')).toBeNull();
+  });
+
   // Every call site that passes a class assumes it wins. It only does because cn
   // runs tailwind-merge — plain concatenation would leave both in the list and
   // let source order in the stylesheet decide.

--- a/design-system/src/tab-strip.svelte
+++ b/design-system/src/tab-strip.svelte
@@ -66,6 +66,11 @@
   $effect(() => {
     const el = strip;
     if (!el) return;
+    // Re-run whenever `tabs` changes, not just on mount: the buttons are DOM
+    // children, which Svelte's dependency tracking can't see, so `tabs` has to be
+    // read explicitly to re-observe the (by then re-rendered) button set — otherwise
+    // a tab added after mount is never watched and the overflow mask can't react to it.
+    void tabs;
     measure();
     const observer = new ResizeObserver(measure);
     observer.observe(el);

--- a/design-system/src/tab-strip.test.ts
+++ b/design-system/src/tab-strip.test.ts
@@ -90,6 +90,43 @@ describe('TabStrip', () => {
 
     expect(getByRole('tablist').getAttribute('aria-label')).toBe('Profile sections');
   });
+
+  // The regression: the ResizeObserver effect only tracked `strip`, so a tab added
+  // after mount was never observed and the overflow fade mask could never react to it.
+  it('re-observes a tab added after mount', async () => {
+    const observed: Element[] = [];
+    const originalRO = globalThis.ResizeObserver;
+    class SpyResizeObserver {
+      observe(el: Element) {
+        observed.push(el);
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+    globalThis.ResizeObserver = SpyResizeObserver as unknown as typeof ResizeObserver;
+
+    try {
+      const onSelect = vi.fn();
+      const { getAllByRole, rerender } = render(TabStrip, {
+        tabs: TABS,
+        active: 'one',
+        onSelect,
+        label: 'Demo sections',
+        panelId: 'demo-panel',
+      });
+      // The strip element itself plus one entry per tab button.
+      expect(observed.length).toBe(TABS.length + 1);
+      observed.length = 0;
+
+      const grown = [...TABS, { id: 'four', label: 'Four' }];
+      await rerender({ tabs: grown, active: 'one', onSelect, label: 'Demo sections', panelId: 'demo-panel' });
+
+      const newTab = must(getAllByRole('tab')[3]);
+      expect(observed).toContain(newTab);
+    } finally {
+      globalThis.ResizeObserver = originalRO;
+    }
+  });
 });
 
 async function fireArrow(el: HTMLElement, key: 'ArrowLeft' | 'ArrowRight' | 'Home' | 'End') {

--- a/design-system/src/tooltip.svelte
+++ b/design-system/src/tooltip.svelte
@@ -17,6 +17,29 @@
   let visible = $state(false);
   let triggerEl: HTMLElement | undefined = $state();
 
+  // The floating content sits outside the wrapper's own layout box (it's
+  // `position: absolute`, offset by the `positions` margin below), so the pointer
+  // crosses a real gap — not a descendant of the wrapper — on its way from the
+  // trigger to the content. A bare mouseleave fires the instant the pointer enters
+  // that gap, closing the tooltip before it arrives. Delaying the hide, and
+  // cancelling the delay if the pointer lands back inside the wrapper (trigger or
+  // content — both are covered by its mouseenter) within the grace period, is what
+  // actually satisfies the "hoverable" guarantee below.
+  const HIDE_DELAY_MS = 150;
+  let hideTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function show() {
+    clearTimeout(hideTimer);
+    visible = true;
+  }
+
+  function scheduleHide() {
+    clearTimeout(hideTimer);
+    hideTimer = setTimeout(() => {
+      visible = false;
+    }, HIDE_DELAY_MS);
+  }
+
   const uid = $props.id();
   const tooltipId = `${uid}-tooltip`;
 
@@ -37,8 +60,16 @@
   // moving the pointer. Hovering keeps it dismissed until the pointer leaves
   // and comes back, which is the intent.
   function dismiss(e: KeyboardEvent) {
-    if (e.key === 'Escape') visible = false;
+    if (e.key === 'Escape') hide();
   }
+
+  function hide() {
+    clearTimeout(hideTimer);
+    visible = false;
+  }
+
+  // A pending hide left running past unmount would set state on a dead component.
+  $effect(() => () => clearTimeout(hideTimer));
 
   const positions = {
     top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
@@ -58,10 +89,10 @@
 <span
   class="relative inline-flex"
   bind:this={triggerEl}
-  onmouseenter={() => (visible = true)}
-  onmouseleave={() => (visible = false)}
-  onfocusin={() => (visible = true)}
-  onfocusout={() => (visible = false)}
+  onmouseenter={show}
+  onmouseleave={scheduleHide}
+  onfocusin={show}
+  onfocusout={hide}
 >
   {@render children()}
   {#if visible}

--- a/design-system/src/tooltip.test.ts
+++ b/design-system/src/tooltip.test.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/svelte';
 import { createRawSnippet } from 'svelte';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import Tooltip from './tooltip.svelte';
 import { must } from './test-utils';
 
@@ -46,14 +46,45 @@ describe('Tooltip', () => {
 
   // Leaving the attribute behind would point at an id that no longer exists,
   // which reads as no description at all.
-  it('drops the description again when it closes', async () => {
-    const { wrapper, trigger, queryByRole } = setup();
+  it('drops the description again once the close delay elapses', async () => {
+    vi.useFakeTimers();
+    try {
+      const { wrapper, trigger, queryByRole } = setup();
 
-    await fireEvent.mouseEnter(wrapper);
-    await fireEvent.mouseLeave(wrapper);
+      await fireEvent.mouseEnter(wrapper);
+      await fireEvent.mouseLeave(wrapper);
+      // The hide is deferred (see below), so it isn't gone the instant the pointer leaves.
+      expect(queryByRole('tooltip')).not.toBeNull();
 
-    expect(queryByRole('tooltip')).toBeNull();
-    expect(trigger.getAttribute('aria-describedby')).toBeNull();
+      await vi.runAllTimersAsync();
+
+      expect(queryByRole('tooltip')).toBeNull();
+      expect(trigger.getAttribute('aria-describedby')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // The regression: mouseleave used to close the tooltip the instant the pointer left
+  // the trigger's own layout box, which doesn't cover the gap to the floating content —
+  // so moving the pointer toward a link inside the tooltip closed it before arriving.
+  // A grace period, cancelled by re-entering (trigger or content) in time, fixes that.
+  it('keeps the tooltip open if the pointer returns before the close delay elapses', async () => {
+    vi.useFakeTimers();
+    try {
+      const { wrapper, queryByRole } = setup();
+
+      await fireEvent.mouseEnter(wrapper);
+      await fireEvent.mouseLeave(wrapper);
+      await vi.advanceTimersByTimeAsync(50); // still mid-gap, well under the delay
+      await fireEvent.mouseEnter(wrapper); // pointer arrived at the content
+
+      await vi.runAllTimersAsync();
+
+      expect(queryByRole('tooltip')).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('dismisses on Escape without moving the pointer (WCAG 2.1 SC 1.4.13)', async () => {

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -55,6 +55,38 @@ describe('createApi request timeout', () => {
   });
 });
 
+describe('job path segment encoding', () => {
+  // getJob/saveJob/recordJobView/voteJob/reportJob used to interpolate `slug` raw,
+  // unlike their siblings a few hundred lines away (trackApplication,
+  // getFollowUpDraft, recordFollowUp) which already wrap it in encodeURIComponent.
+  // Slugs are dictionary-safe today, so this was latent — but a slug containing a
+  // reserved character would silently mis-route the request.
+  it('encodes a slug with reserved characters instead of splicing it into the path raw', async () => {
+    const urls: string[] = [];
+    const fetcher = ((url: string) => {
+      urls.push(url);
+      return Promise.resolve(new Response('{"data":null}', { status: 200 }));
+    }) as unknown as typeof fetch;
+    const client = createApi(fetcher);
+    const slug = 'a/b?c#d';
+    const encoded = encodeURIComponent(slug);
+
+    await client.getJob(slug);
+    await client.saveJob(slug);
+    await client.recordJobView(slug);
+    await client.voteJob(slug, 'up');
+    await client.reportJob(slug, { reason: 'other' });
+
+    expect(urls).toEqual([
+      `/api/v1/jobs/${encoded}`,
+      `/api/v1/jobs/${encoded}/save`,
+      `/api/v1/jobs/${encoded}/view`,
+      `/api/v1/jobs/${encoded}/vote`,
+      `/api/v1/jobs/${encoded}/reports`,
+    ]);
+  });
+});
+
 describe('recent authentication adapters', () => {
   it('sends password reauthentication to the v2 cookie endpoint', async () => {
     let seenURL = '';

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -359,7 +359,7 @@ export function createApi(
   }
 
   async function getJob(slug: string): Promise<Job> {
-    return requestData<Job>(`/api/v1/jobs/${slug}`);
+    return requestData<Job>(`/api/v1/jobs/${encodeURIComponent(slug)}`);
   }
 
   /** Jobs semantically nearest to the one addressed by `slug` — the "Similar jobs"
@@ -760,7 +760,7 @@ export function createApi(
     action: 'view' | 'apply' | 'save' | 'stage' | 'track' | 'dismiss',
     method: 'POST' | 'DELETE' = 'POST',
   ): Promise<UserJob> {
-    return requestData<UserJob>(`/api/v1/jobs/${slug}/${action}`, { method });
+    return requestData<UserJob>(`/api/v1/jobs/${encodeURIComponent(slug)}/${action}`, { method });
   }
 
   /** Record that the current user viewed a job; returns their interaction
@@ -778,7 +778,7 @@ export function createApi(
    *  is decided entirely by the account's notification settings — there is no
    *  per-job override. */
   function saveJob(slug: string): Promise<UserJob> {
-    return requestData<UserJob>(`/api/v1/jobs/${slug}/save`, { method: 'POST' });
+    return requestData<UserJob>(`/api/v1/jobs/${encodeURIComponent(slug)}/save`, { method: 'POST' });
   }
 
   /** Set a job's application stage and/or notes (partial update — omit a field to
@@ -828,7 +828,7 @@ export function createApi(
   /** Cast a thumbs vote on a job (toggle/flip). Returns the job's resulting public
    *  counters and the caller's own vote. Requires a session — gate on auth first. */
   function voteJob(slug: string, dir: 'up' | 'down'): Promise<VoteResult> {
-    return requestData<VoteResult>(`/api/v1/jobs/${slug}/vote`, jsonBody('POST', { vote: dir }));
+    return requestData<VoteResult>(`/api/v1/jobs/${encodeURIComponent(slug)}/vote`, jsonBody('POST', { vote: dir }));
   }
 
   /** Clear the caller's thumbs vote on a job. Idempotent (no-op when none). */
@@ -1497,7 +1497,7 @@ export function createApi(
 
   /** Report a problem with a live vacancy (by slug). Returns the pending report. */
   async function reportJob(slug: string, input: ReportInput): Promise<Report> {
-    return requestData<Report>(`/api/v1/jobs/${slug}/reports`, jsonBody('POST', input));
+    return requestData<Report>(`/api/v1/jobs/${encodeURIComponent(slug)}/reports`, jsonBody('POST', input));
   }
 
   /** File a ghost-signal claim: applied on this date, never answered. Unlike

--- a/web/src/lib/asyncData.svelte.ts
+++ b/web/src/lib/asyncData.svelte.ts
@@ -10,18 +10,28 @@ export class AsyncData<T> {
   // raw skips the deep-proxy overhead — same rule as Paginator's items.
   value = $state.raw<T>() as T;
 
+  // Bumped on every run() so a slower earlier call can't overwrite a newer one —
+  // the same reqToken/gen guard as HeaderSearch/SwipeDeck, applied here since a call
+  // site can retry (or re-run on mount) while a prior run() is still in flight.
+  #generation = 0;
+
   constructor(initial: T) {
     this.value = initial;
   }
 
   /** Fetch once, tracking status. A failure flips to 'error' and keeps the current
-   *  value (usually the initial empty/default state). */
+   *  value (usually the initial empty/default state). A run() superseded by a later
+   *  one before it resolves is discarded instead of overwriting the fresher result. */
   async run(fetch: () => Promise<T>): Promise<void> {
+    const mine = ++this.#generation;
     this.status = 'loading';
     try {
-      this.value = await fetch();
+      const value = await fetch();
+      if (mine !== this.#generation) return; // superseded by a newer run()
+      this.value = value;
       this.status = 'ready';
     } catch {
+      if (mine !== this.#generation) return;
       this.status = 'error';
     }
   }

--- a/web/src/lib/components/CompanyPicker.svelte
+++ b/web/src/lib/components/CompanyPicker.svelte
@@ -20,6 +20,11 @@
   let picked = $state<{ slug: string; name: string } | null>(null);
   let timer: ReturnType<typeof setTimeout> | undefined;
 
+  // Bumped on every onInput — including the too-short-query dismissal — so a
+  // response for a superseded keystroke can't overwrite a fresher one (mirrors
+  // reqToken in HeaderSearch.svelte / gen in facets/RemoteSearchSelect.svelte).
+  let reqToken = 0;
+
   const DEBOUNCE_MS = 200;
   const LIMIT = 8;
 
@@ -33,19 +38,23 @@
     clearTimeout(timer);
     const q = query.trim();
     if (q.length < 2) {
+      reqToken++;
       results = [];
       loading = false;
       return;
     }
     loading = true;
+    const mine = ++reqToken;
     timer = setTimeout(async () => {
       try {
         const slice = await api.listCompanies(q, LIMIT, 0);
+        if (mine !== reqToken) return; // superseded by a newer query
         results = slice.items;
       } catch {
+        if (mine !== reqToken) return;
         results = [];
       }
-      loading = false;
+      if (mine === reqToken) loading = false;
     }, DEBOUNCE_MS);
   }
 

--- a/web/src/lib/components/SwipeDeck.svelte
+++ b/web/src/lib/components/SwipeDeck.svelte
@@ -144,6 +144,10 @@
     dragging = false;
     dragX = dir * (window.innerWidth + 200);
     last = { job, kind };
+    // Snapshot the reload generation: a resetDeck() mid-flight bumps `gen` and
+    // replaces `queue` wholesale, so the deferred slice below must not touch a
+    // queue that no longer belongs to this swipe.
+    const myGen = gen;
 
     const send = kind === 'save' ? api.saveJob(job.public_slug) : api.dismissJob(job.public_slug);
     send.catch(() => {
@@ -160,6 +164,7 @@
     // slug), so it mounts centered at dragX 0 — no slide from the edge — and plays
     // the grow-in keyframe on mount.
     setTimeout(() => {
+      if (myGen !== gen) return; // resetDeck() already replaced the queue and its own state
       queue = queue.slice(1);
       dragX = 0;
       exiting = false;

--- a/web/src/lib/components/community/ReplyNode.svelte
+++ b/web/src/lib/components/community/ReplyNode.svelte
@@ -152,7 +152,7 @@
     margin: 0;
   }
   .node__depth-limit {
-    color: var(--muted-foreground, #6b7280);
+    color: var(--muted-foreground);
     font-size: 0.8rem;
     margin: 0.5rem 0;
   }

--- a/web/src/lib/components/community/ReplyNode.svelte
+++ b/web/src/lib/components/community/ReplyNode.svelte
@@ -27,8 +27,16 @@
 
   // Direct children of this reply, oldest first (the flat list is already ordered).
   const children = $derived(replies.filter((r) => r.parent_id === reply.id));
+  // A reply chain is a user-controlled parent_id graph with no server-side depth
+  // limit, so recursing through <Self> for every level is unbounded: a thread where
+  // each reply is authored as a child of the previous one would mount one nested
+  // ReplyNode per level. Cap actual recursion at the same depth the indent already
+  // caps — nothing deeper reads any differently anyway, since the indent stops
+  // growing there too.
+  const MAX_DEPTH = 6;
   // Indentation is capped so deep chains don't march off the right edge.
-  const indent = $derived(Math.min(depth, 6) * 16);
+  const indent = $derived(Math.min(depth, MAX_DEPTH) * 16);
+  const atMaxDepth = $derived(depth >= MAX_DEPTH);
 
   let replying = $state(false);
   let body = $state('');
@@ -81,9 +89,15 @@
   {/if}
 </div>
 
-{#each children as child (child.id)}
-  <Self reply={child} {replies} {threadId} {closed} depth={depth + 1} {addReply} />
-{/each}
+{#if !atMaxDepth}
+  {#each children as child (child.id)}
+    <Self reply={child} {replies} {threadId} {closed} depth={depth + 1} {addReply} />
+  {/each}
+{:else if children.length > 0}
+  <p class="node__depth-limit" style={`margin-left:${indent}px`}>
+    {children.length} more {children.length === 1 ? 'reply' : 'replies'} nested deeper — not shown.
+  </p>
+{/if}
 
 <style>
   .node {
@@ -136,5 +150,10 @@
     color: var(--destructive, #dc2626);
     font-size: 0.8rem;
     margin: 0;
+  }
+  .node__depth-limit {
+    color: var(--muted-foreground, #6b7280);
+    font-size: 0.8rem;
+    margin: 0.5rem 0;
   }
 </style>

--- a/web/src/lib/saveSearchAlert.test.ts
+++ b/web/src/lib/saveSearchAlert.test.ts
@@ -95,16 +95,23 @@ describe('ensureSaved', () => {
     expect(createCalls).toHaveLength(0);
   });
 
-  it('reuses a concurrently-created same-query set on a 409', async () => {
-    const items = [search(7, 'category=backend')];
+  it('reuses a concurrently-created same-query set discovered only after the 409', async () => {
+    // Empty at call time, so the pre-create check (matchedSavedSearch before create())
+    // finds nothing and ensureSaved proceeds to create() — unlike a items-seeded setup,
+    // which would satisfy the pre-create check and never reach create() or the catch
+    // block at all.
+    const items: SavedSearch[] = [];
     const port: SavedSearchesPort = {
       ensureLoaded: async () => {},
       get items() {
         return items;
       },
-      // Pretend another tab already created it just before us: matchedSavedSearch finds
-      // id 7, so create is never reached — but if a 409 races in, the raced re-check wins.
+      // Simulate another tab's concurrent create landing between our pre-create check
+      // and our own create() call: by the time our create() rejects with 409, the
+      // racing item is already visible in `items`, so it's the catch block's raced
+      // re-check — not the pre-create check — that must find it.
       create: async () => {
+        items.push(search(7, 'category=backend'));
         throw new ApiError(409, 'duplicate name');
       },
     };


### PR DESCRIPTION
## Summary

- **Tooltip** (`design-system/src/tooltip.svelte:58`): mouseleave now defers hiding by a short grace period, cancelled if the pointer lands back on the trigger or content in time — the floating content sits outside the wrapper's own layout box, so the pointer previously crossed a real gap that closed the tooltip before it arrived, defeating the WCAG 2.1 SC 1.4.13 "hoverable" guarantee.
- **TabStrip** (`design-system/src/tab-strip.svelte:66`): the ResizeObserver effect now also reads `tabs`, so it re-observes the button set whenever tabs are added after mount instead of only on first mount.
- **Avatar** (`design-system/src/avatar.svelte:43`): initials now derive from `name.trim().split(/\s+/)` instead of a bare `split(' ')`, so leading/trailing/double spaces no longer produce a wrong (empty) first initial.
- **Button** (`design-system/src/button.svelte:55`): `target="_blank"` now defaults `rel` to `noopener noreferrer` (an explicit caller `rel` still wins), closing the reverse-tabnabbing gap for future call sites.
- **CompanyPicker** (`web/src/lib/components/CompanyPicker.svelte:41`): the typeahead now carries a `reqToken` generation guard (the same pattern as `HeaderSearch.svelte`/`RemoteSearchSelect.svelte`), so a slower earlier search response can no longer overwrite a fresher one.
- **SwipeDeck** (`web/src/lib/components/SwipeDeck.svelte:162`): `judge()`'s deferred queue update now captures the reload generation and bails out if `resetDeck()` has superseded it mid-flight, so a filter change no longer drops the wrong card from a freshly loaded deck.
- **ReplyNode** (`web/src/lib/components/community/ReplyNode.svelte:84`): recursion now stops at the same depth the visual indent already caps, with a plain "N more replies nested deeper" note instead of unbounded `<Self>` recursion over a user-controlled parent_id chain.
- **saveSearchAlert** (`web/src/lib/saveSearchAlert.ts:62`): the 409-race test now actually reaches the `raced` recovery branch (previously the seeded `items` made the pre-create check succeed first, so `create()` — and the catch block — were never exercised).
- **AsyncData** (`web/src/lib/asyncData.svelte.ts:19`): `run()` now mints a generation token per call and discards a result superseded by a later `run()`, matching this codebase's other async-loading primitives.
- **api.ts** (`web/src/lib/api.ts:360`): `getJob`, `saveJob`, `recordJobView` (via the shared `jobInteraction` helper), `voteJob`, and `reportJob` now `encodeURIComponent` their slug path segment, matching sibling helpers that already did.

## Test plan

- [x] `design-system/`: `pnpm run check`, `pnpm run lint`, `pnpm test` — 0 errors, 121/121 tests pass (pre-existing warnings only).
- [x] `web/`: `pnpm run check`, `pnpm run lint`, `pnpm test` — 0 errors, 958/958 tests pass (pre-existing warnings only).
- [x] New/extended tests added for Tooltip (grace-period open/close, fake timers), TabStrip (re-observes a tab added after mount), Avatar (whitespace normalization), Button (default + overridable `rel`), the `ensureSaved` 409-race branch, and `api.ts`'s path encoding.
- [ ] No test infra exists in `web/` for rendering `.svelte` components or rune-bearing `.svelte.ts` modules (`vitest.config.ts`'s own comment: "no runes... so no Svelte compilation is needed here"; `Paginator`'s equivalent class-level methods are likewise untested, only its extracted pure helpers are) — so CompanyPicker, SwipeDeck, ReplyNode, and AsyncData's fixes are unit-verified by inspection/manual reasoning rather than a new automated test, consistent with existing project precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)