### PR TITLE
Fix 6 misc/PII/security findings from the monorepo code review

### DIFF
--- a/internal/blobstore/blobstore.go
+++ b/internal/blobstore/blobstore.go
@@ -7,6 +7,7 @@ package blobstore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -21,6 +22,18 @@ type Store interface {
 	Put(ctx context.Context, key, contentType string, r io.Reader, size int64) error
 	Get(ctx context.Context, key string) (io.ReadCloser, error)
 	Delete(ctx context.Context, key string) error
+}
+
+// IsNotFound reports whether err — from Get, or from reading/stat-ing the io.ReadCloser
+// it returned — means the object does not exist in the bucket, as opposed to a real
+// backend failure (network, auth, bucket gone). Get's read is lazy (see its doc comment),
+// so a missing object can surface from either call site; check both with this helper
+// instead of string-matching the provider's error text. Uses errors.As rather than
+// minio.ToErrorResponse's plain type switch, so it still recognizes the error through a
+// Get/Put/Delete wrapper's %w chain.
+func IsNotFound(err error) bool {
+	var resp minio.ErrorResponse
+	return errors.As(err, &resp) && resp.Code == minio.NoSuchKey
 }
 
 // Config is the generic S3 connection settings, read from the environment. Any

--- a/internal/blobstore/blobstore_test.go
+++ b/internal/blobstore/blobstore_test.go
@@ -1,6 +1,12 @@
 package blobstore
 
-import "testing"
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/minio/minio-go/v7"
+)
 
 func TestResumeKey_DerivedFromUserID(t *testing.T) {
 	if got := ResumeKey(7); got != "resumes/7" {
@@ -37,6 +43,31 @@ func TestNew_UnconfiguredReturnsNilStore(t *testing.T) {
 		if store != nil {
 			t.Errorf("case %d: unconfigured New should return nil store, got %T", i, store)
 		}
+	}
+}
+
+func TestIsNotFound(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"NoSuchKey", minio.ErrorResponse{Code: minio.NoSuchKey}, true},
+		{
+			"NoSuchKey wrapped by Get/Put/Delete's %w",
+			fmt.Errorf("blobstore: get resumes/7: %w", minio.ErrorResponse{Code: minio.NoSuchKey}),
+			true,
+		},
+		{"a different S3 error code", minio.ErrorResponse{Code: "AccessDenied"}, false},
+		{"a non-minio error", errors.New("connection reset"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsNotFound(tc.err); got != tc.want {
+				t.Errorf("IsNotFound(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/flexjson/flexjson.go
+++ b/internal/flexjson/flexjson.go
@@ -28,11 +28,7 @@ import (
 type Int int
 
 func (f *Int) UnmarshalJSON(b []byte) error {
-	n, err := decodeNumber(b)
-	if err != nil {
-		return err
-	}
-	*f = Int(int(math.Round(n)))
+	*f = Int(int(math.Round(decodeNumber(b))))
 	return nil
 }
 
@@ -40,11 +36,7 @@ func (f *Int) UnmarshalJSON(b []byte) error {
 type Int64 int64
 
 func (f *Int64) UnmarshalJSON(b []byte) error {
-	n, err := decodeNumber(b)
-	if err != nil {
-		return err
-	}
-	*f = Int64(int64(math.Round(n)))
+	*f = Int64(int64(math.Round(decodeNumber(b))))
 	return nil
 }
 
@@ -53,11 +45,7 @@ func (f *Int64) UnmarshalJSON(b []byte) error {
 type Float float64
 
 func (f *Float) UnmarshalJSON(b []byte) error {
-	n, err := decodeNumber(b)
-	if err != nil {
-		return err
-	}
-	*f = Float(n)
+	*f = Float(decodeNumber(b))
 	return nil
 }
 
@@ -91,32 +79,36 @@ func (f *Bool) UnmarshalJSON(b []byte) error {
 	}
 	var n float64
 	if err := json.Unmarshal(b, &n); err != nil {
-		return err
+		// A syntactically valid but out-of-range numeric literal (e.g. 1e400) fails here
+		// too; unrecognized input is false, same as the string branch above.
+		*f = false
+		return nil
 	}
 	*f = Bool(n != 0)
 	return nil
 }
 
 // decodeNumber extracts a float64 from a JSON number or a string carrying a leading
-// numeric token. Empty, null, or non-numeric input yields 0 (not an error), so a single
-// unparseable field never aborts the surrounding record.
-func decodeNumber(b []byte) (float64, error) {
+// numeric token. Empty, null, non-numeric, or out-of-range input (e.g. a bare 1e400,
+// which is syntactically valid JSON but overflows float64) yields 0, never an error, so a
+// single unparseable field never aborts the surrounding record.
+func decodeNumber(b []byte) float64 {
 	b = bytes.TrimSpace(b)
 	if len(b) == 0 || string(b) == "null" {
-		return 0, nil
+		return 0
 	}
 	if b[0] == '"' {
 		var s string
 		if err := json.Unmarshal(b, &s); err != nil {
-			return 0, err
+			return 0
 		}
-		return leadingFloat(s), nil
+		return leadingFloat(s)
 	}
 	var n float64
 	if err := json.Unmarshal(b, &n); err != nil {
-		return 0, err
+		return 0
 	}
-	return n, nil
+	return n
 }
 
 // leadingFloat parses the leading numeric token of s (optional sign, digits, one decimal

--- a/internal/flexjson/flexjson_test.go
+++ b/internal/flexjson/flexjson_test.go
@@ -18,6 +18,7 @@ func TestInt_NumberOrString(t *testing.T) {
 		`"n/a"`:   0,
 		`null`:    0,
 		`"  12 "`: 12,
+		`1e400`:   0, // syntactically valid JSON number, overflows float64
 	}
 	for raw, want := range cases {
 		var v Int
@@ -38,6 +39,7 @@ func TestInt64_NumberOrString(t *testing.T) {
 		`"none"`: 0,
 		`""`:     0,
 		`null`:   0,
+		`1e400`:  0, // syntactically valid JSON number, overflows float64
 	}
 	for raw, want := range cases {
 		var v Int64
@@ -62,6 +64,7 @@ func TestFloat_NumberOrString(t *testing.T) {
 		`null`:     0,
 		`"85%"`:    85,
 		`"0.9 ok"`: 0.9,
+		`1e400`:    0, // syntactically valid JSON number, overflows float64
 	}
 	for raw, want := range cases {
 		var v Float
@@ -89,6 +92,7 @@ func TestBool_BoolStringOrNumber(t *testing.T) {
 		`"no"`:    false,
 		`""`:      false,
 		`null`:    false,
+		`1e400`:   false, // syntactically valid JSON number, overflows float64
 	}
 	for raw, want := range cases {
 		var v Bool

--- a/internal/handler/resume_storage_test.go
+++ b/internal/handler/resume_storage_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/minio/minio-go/v7"
 
 	"github.com/strelov1/freehire/internal/auth"
 	"github.com/strelov1/freehire/internal/db"
@@ -39,7 +39,9 @@ func (f *fakeResumeBlobs) Put(_ context.Context, key, _ string, r io.Reader, _ i
 func (f *fakeResumeBlobs) Get(_ context.Context, key string) (io.ReadCloser, error) {
 	b, ok := f.objs[key]
 	if !ok {
-		return nil, errors.New("not found")
+		// Mirrors the shape blobstore.IsNotFound actually recognizes, so this fake
+		// exercises the real translation to ErrNotStored rather than a stand-in error.
+		return nil, minio.ErrorResponse{Code: minio.NoSuchKey}
 	}
 	return io.NopCloser(bytes.NewReader(b)), nil
 }

--- a/internal/headshot/headshot.go
+++ b/internal/headshot/headshot.go
@@ -116,11 +116,19 @@ func (s *Store) Get(ctx context.Context, userID int64) ([]byte, error) {
 	}
 	rc, err := s.blobs.Get(ctx, ptr.PhotoObjectKey.String)
 	if err != nil {
+		if blobstore.IsNotFound(err) {
+			return nil, ErrNotStored
+		}
 		return nil, err
 	}
 	defer rc.Close()
 	data, err := io.ReadAll(rc)
 	if err != nil {
+		// The S3 client's Get is lazy: a missing object typically surfaces here, on the
+		// first read, rather than from Get itself.
+		if blobstore.IsNotFound(err) {
+			return nil, ErrNotStored
+		}
 		return nil, fmt.Errorf("headshot: read object: %w", err)
 	}
 	return data, nil

--- a/internal/headshot/store_test.go
+++ b/internal/headshot/store_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/minio/minio-go/v7"
 
 	"github.com/strelov1/freehire/internal/db"
 )
@@ -47,7 +48,9 @@ func (f *fakeBlobs) Get(_ context.Context, key string) (io.ReadCloser, error) {
 	}
 	data, ok := f.objects[key]
 	if !ok {
-		return nil, errors.New("no such object")
+		// Mirrors the shape blobstore.IsNotFound actually recognizes, so this fake
+		// exercises the real translation to ErrNotStored rather than a stand-in error.
+		return nil, minio.ErrorResponse{Code: minio.NoSuchKey}
 	}
 	return io.NopCloser(bytes.NewReader(data)), nil
 }
@@ -182,6 +185,16 @@ func TestStore_GetReturnsStoredBytes(t *testing.T) {
 
 func TestStore_GetWithoutAHeadshot(t *testing.T) {
 	s := New(newFakeBlobs(), &fakeRepo{})
+	if _, err := s.Get(context.Background(), 42); !errors.Is(err, ErrNotStored) {
+		t.Errorf("Get error = %v, want ErrNotStored", err)
+	}
+}
+
+func TestStore_GetMissingObjectIsNotStored(t *testing.T) {
+	// Pointer present but the bucket object is gone (e.g. a recreated MinIO volume) — the
+	// blobstore-level not-found error must translate to ErrNotStored, not a raw 500.
+	repo := &fakeRepo{key: "photos/42", uploadedAt: time.Now().UTC()}
+	s := New(newFakeBlobs(), repo)
 	if _, err := s.Get(context.Background(), 42); !errors.Is(err, ErrNotStored) {
 		t.Errorf("Get error = %v, want ErrNotStored", err)
 	}

--- a/internal/htmltext/htmltext.go
+++ b/internal/htmltext/htmltext.go
@@ -5,26 +5,125 @@
 package htmltext
 
 import (
+	"container/list"
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+
 	htmltomarkdown "github.com/JohannesKaufmann/html-to-markdown/v2"
 	"github.com/jaytaylor/html2text"
 )
 
+// maxInputRunes bounds the HTML a single call converts. The only caller today
+// (internal/handler's AgentSearchJobs) feeds it a job's full, untruncated Postgres
+// description — up to tens of KB for a source that captures full descriptions — and
+// neither third-party converter bounds its own work, so an unbounded input reprocessed
+// on every request is unbounded conversion cost. Truncating first caps it.
+const maxInputRunes = 50_000
+
+// cacheCapacity bounds the memory each per-format result cache can hold. A description
+// rarely changes, so the same content is very likely to be converted again — the same
+// job appears across multiple search-result pages, and AgentSearchJobs is public and
+// unauthenticated. Caching by content hash rather than by job id means a changed
+// description is simply a cache miss, with no invalidation to get wrong.
+const cacheCapacity = 128
+
+var (
+	textCache = newCache(cacheCapacity)
+	mdCache   = newCache(cacheCapacity)
+)
+
 // ToText renders HTML as plain text with tags removed. On a conversion error it
-// returns the input unchanged.
+// returns the (possibly truncated) input unchanged.
 func ToText(html string) string {
-	out, err := html2text.FromString(html, html2text.Options{OmitLinks: true})
-	if err != nil {
-		return html
-	}
-	return out
+	return convert(html, textCache, func(s string) (string, error) {
+		return html2text.FromString(s, html2text.Options{OmitLinks: true})
+	})
 }
 
 // ToMarkdown converts HTML to Markdown, preserving block structure such as lists
-// and headings. On a conversion error it returns the input unchanged.
+// and headings. On a conversion error it returns the (possibly truncated) input
+// unchanged.
 func ToMarkdown(html string) string {
-	out, err := htmltomarkdown.ConvertString(html)
+	return convert(html, mdCache, func(s string) (string, error) {
+		return htmltomarkdown.ConvertString(s)
+	})
+}
+
+// convert bounds html to maxInputRunes, serves a cached result for identical input when
+// one exists, and otherwise runs fn and caches a successful result.
+func convert(html string, cache *resultCache, fn func(string) (string, error)) string {
+	html = truncateRunes(html, maxInputRunes)
+	key := hashOf(html)
+	if out, ok := cache.get(key); ok {
+		return out
+	}
+	out, err := fn(html)
 	if err != nil {
 		return html
 	}
+	cache.put(key, out)
 	return out
+}
+
+// truncateRunes clamps s to at most limit runes without splitting one.
+func truncateRunes(s string, limit int) string {
+	r := []rune(s)
+	if len(r) <= limit {
+		return s
+	}
+	return string(r[:limit])
+}
+
+func hashOf(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// resultCache is a fixed-capacity, concurrency-safe LRU keyed by content hash.
+type resultCache struct {
+	mu       sync.Mutex
+	capacity int
+	order    *list.List
+	items    map[string]*list.Element
+}
+
+type cacheEntry struct {
+	key   string
+	value string
+}
+
+func newCache(capacity int) *resultCache {
+	return &resultCache{
+		capacity: capacity,
+		order:    list.New(),
+		items:    make(map[string]*list.Element, capacity),
+	}
+}
+
+func (c *resultCache) get(key string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	el, ok := c.items[key]
+	if !ok {
+		return "", false
+	}
+	c.order.MoveToFront(el)
+	return el.Value.(*cacheEntry).value, true
+}
+
+func (c *resultCache) put(key, value string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if el, ok := c.items[key]; ok {
+		el.Value.(*cacheEntry).value = value
+		c.order.MoveToFront(el)
+		return
+	}
+	c.items[key] = c.order.PushFront(&cacheEntry{key: key, value: value})
+	if c.order.Len() > c.capacity {
+		oldest := c.order.Back()
+		c.order.Remove(oldest)
+		delete(c.items, oldest.Value.(*cacheEntry).key)
+	}
 }

--- a/internal/htmltext/htmltext_test.go
+++ b/internal/htmltext/htmltext_test.go
@@ -1,6 +1,9 @@
 package htmltext
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestToText_StripsTags(t *testing.T) {
 	got := ToText("<p>Hello <strong>world</strong></p>")
@@ -26,6 +29,54 @@ func TestToMarkdown_PreservesListStructure(t *testing.T) {
 	}
 	if containsAngle(got) {
 		t.Errorf("ToMarkdown left HTML tags: %q", got)
+	}
+}
+
+func TestToText_BoundsVeryLargeInput(t *testing.T) {
+	// Far larger (by rune count, ignoring markup) than maxInputRunes.
+	huge := "<p>" + strings.Repeat("word ", maxInputRunes) + "</p>"
+	got := ToText(huge)
+	if n := len([]rune(got)); n > maxInputRunes {
+		t.Errorf("ToText output has %d runes, want <= %d (maxInputRunes)", n, maxInputRunes)
+	}
+}
+
+func TestTruncateRunes(t *testing.T) {
+	cases := []struct {
+		name  string
+		in    string
+		limit int
+		want  string
+	}{
+		{"under limit", "hello", 10, "hello"},
+		{"exact limit", "hello", 5, "hello"},
+		{"over limit", "hello world", 5, "hello"},
+		{"does not split a multi-byte rune", "h→llo", 2, "h→"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := truncateRunes(tc.in, tc.limit); got != tc.want {
+				t.Errorf("truncateRunes(%q, %d) = %q, want %q", tc.in, tc.limit, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResultCache_EvictsLeastRecentlyUsedOverCapacity(t *testing.T) {
+	c := newCache(2)
+	c.put("a", "1")
+	c.put("b", "2")
+	c.get("a")      // "a" is now more recently used than "b"
+	c.put("c", "3") // over capacity: evicts "b", the least recently used
+
+	if _, ok := c.get("b"); ok {
+		t.Error("expected \"b\" to have been evicted")
+	}
+	if v, ok := c.get("a"); !ok || v != "1" {
+		t.Errorf("get(a) = %q, %v; want 1, true", v, ok)
+	}
+	if v, ok := c.get("c"); !ok || v != "3" {
+		t.Errorf("get(c) = %q, %v; want 3, true", v, ok)
 	}
 }
 

--- a/internal/pii/redactor.go
+++ b/internal/pii/redactor.go
@@ -90,12 +90,33 @@ func Build(ctx context.Context, text string, known Contacts, d Detector) (*Redac
 			boundarySafe[v] = ok
 		}
 	}
-	add(known.FullName, KindName)
-	add(known.Email, KindEmail)
-	add(known.Phone, KindPhone)
-	add(known.Location, KindAddress)
+	// A known value never passes through the spans loop above, so boundarySafe has no
+	// entry for it unless the identical value also happened to be detected. Without one,
+	// wordish(v) && wordyKind[kind] && boundarySafe[v] is always false for it, so a known
+	// NAME/ADDRESS falls back to plain substring replacement even when every literal
+	// occurrence in text is boundary-complete — the over-redaction the \b-anchored path
+	// exists to avoid. Scan text directly for the value and apply the same completeness
+	// rule the spans loop uses, so a known contact gets the identical boundary-aware
+	// treatment a detected one does. A value absent from text is left out of boundarySafe
+	// entirely (not even set to false): both replacement strategies are a no-op for it, and
+	// adding it would make the fail-closed self-check below spuriously fail on a value that
+	// was never there to redact — "known contacts are always maskable" holds regardless.
+	addKnown := func(v, kind string) {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			return
+		}
+		add(v, kind)
+		if _, ok := boundarySafe[v]; !ok && strings.Contains(text, v) {
+			boundarySafe[v] = valueBoundarySafe(text, v)
+		}
+	}
+	addKnown(known.FullName, KindName)
+	addKnown(known.Email, KindEmail)
+	addKnown(known.Phone, KindPhone)
+	addKnown(known.Location, KindAddress)
 	for _, l := range known.Links {
-		add(l, KindLink)
+		addKnown(l, KindLink)
 	}
 
 	counts := make(map[string]int)
@@ -235,6 +256,25 @@ func wordish(v string) bool {
 
 func isWord(c byte) bool {
 	return c == '_' || (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+// valueBoundarySafe reports whether every literal occurrence of v in text sits between
+// non-word characters — the same completeness check the spans loop applies per detected
+// span, but by scanning text directly for v instead of relying on a supplied span. Callers
+// must only invoke it when v is known to occur in text at least once.
+func valueBoundarySafe(text, v string) bool {
+	safe := true
+	for start := 0; ; {
+		i := strings.Index(text[start:], v)
+		if i < 0 {
+			return safe
+		}
+		s, e := start+i, start+i+len(v)
+		if !((s == 0 || !isWord(text[s-1])) && (e == len(text) || !isWord(text[e]))) {
+			safe = false
+		}
+		start = e
+	}
 }
 
 // sanitizeSpans drops model spans with out-of-range or inverted offsets.

--- a/internal/pii/redactor.go
+++ b/internal/pii/redactor.go
@@ -270,7 +270,7 @@ func valueBoundarySafe(text, v string) bool {
 			return safe
 		}
 		s, e := start+i, start+i+len(v)
-		if !((s == 0 || !isWord(text[s-1])) && (e == len(text) || !isWord(text[e]))) {
+		if (s != 0 && isWord(text[s-1])) || (e != len(text) && isWord(text[e])) {
 			safe = false
 		}
 		start = e

--- a/internal/pii/redactor_test.go
+++ b/internal/pii/redactor_test.go
@@ -163,3 +163,30 @@ func TestWordBoundaryAvoidsOverRedaction(t *testing.T) {
 		t.Fatalf("standalone name not masked: %s", masked)
 	}
 }
+
+func TestKnownOnlyValueAvoidsOverRedaction(t *testing.T) {
+	// Same shape as TestWordBoundaryAvoidsOverRedaction, but "Mark" arrives only via known
+	// Contacts — never detected as a span. redactor.go:112 never populated boundarySafe for
+	// a known-only value, so it always fell back to plain substring replacement and would
+	// have mangled "benchmark" into a partially-redacted fragment.
+	text := "Mark shipped the benchmark on Mark's branch"
+	r := mustBuild(t, text, Contacts{FullName: "Mark"}, spansDetector{})
+	masked := r.Redact(text)
+	if !strings.Contains(masked, "benchmark") {
+		t.Fatalf("over-redacted 'benchmark' from a known-only value: %s", masked)
+	}
+	if strings.Contains(masked, "Mark shipped") {
+		t.Fatalf("standalone known name not masked: %s", masked)
+	}
+}
+
+func TestKnownContactAbsentFromTextDoesNotFailBuild(t *testing.T) {
+	// "Known contacts are always maskable... even when they do not appear verbatim in the
+	// text Build read" (package doc). A known value with zero occurrences must not trip the
+	// fail-closed self-check, which only makes sense for a value that was actually there.
+	text := "Backend engineer with distributed systems experience"
+	known := Contacts{FullName: "Priya Shah", Location: "Berlin"}
+	if _, err := Build(context.Background(), text, known, spansDetector{}); err != nil {
+		t.Fatalf("Build returned an error for a known contact absent from text: %v", err)
+	}
+}

--- a/internal/resume/resume.go
+++ b/internal/resume/resume.go
@@ -384,7 +384,7 @@ func (s *Store) Text(ctx context.Context, userID int64) (string, error) {
 	}
 	rc, err := s.blobs.Get(ctx, ptr.ResumeObjectKey.String)
 	if err != nil {
-		if isMissingObject(err) {
+		if blobstore.IsNotFound(err) {
 			return "", ErrNotStored
 		}
 		return "", err
@@ -393,25 +393,12 @@ func (s *Store) Text(ctx context.Context, userID int64) (string, error) {
 	data, err := io.ReadAll(rc)
 	if err != nil {
 		// MinIO/S3 GetObject is lazy: a missing key often surfaces only on the first read.
-		if isMissingObject(err) {
+		if blobstore.IsNotFound(err) {
 			return "", ErrNotStored
 		}
 		return "", fmt.Errorf("resume: read object: %w", err)
 	}
 	return extractText(data)
-}
-
-// isMissingObject reports whether err means the résumé bytes are gone while the
-// pointer may still be present (recreated LocalStack/MinIO volume, bucket wipe, …).
-func isMissingObject(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "nosuchkey") ||
-		strings.Contains(msg, "no such key") ||
-		strings.Contains(msg, "the specified key does not exist") ||
-		strings.Contains(msg, "not found")
 }
 
 // Delete removes the stored object and clears the pointer.

--- a/internal/resume/resume_test.go
+++ b/internal/resume/resume_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/minio/minio-go/v7"
 
 	"github.com/strelov1/freehire/internal/blobstore"
 	"github.com/strelov1/freehire/internal/db"
@@ -32,7 +33,9 @@ func (f *fakeBlobs) Put(_ context.Context, key, _ string, r io.Reader, _ int64) 
 func (f *fakeBlobs) Get(_ context.Context, key string) (io.ReadCloser, error) {
 	data, ok := f.objs[key]
 	if !ok {
-		return nil, errors.New("not found")
+		// Mirrors the shape blobstore.IsNotFound actually recognizes, so this fake
+		// exercises the real translation to ErrNotStored rather than a stand-in error.
+		return nil, minio.ErrorResponse{Code: minio.NoSuchKey}
 	}
 	return io.NopCloser(bytes.NewReader(data)), nil
 }
@@ -242,24 +245,6 @@ func TestStore_TextMissingObjectIsNotStored(t *testing.T) {
 	s := New(newFakeBlobs(), repo)
 	if _, err := s.Text(context.Background(), 7); !errors.Is(err, ErrNotStored) {
 		t.Fatalf("Text err = %v, want ErrNotStored", err)
-	}
-}
-
-func TestIsMissingObject(t *testing.T) {
-	cases := []struct {
-		err  error
-		want bool
-	}{
-		{nil, false},
-		{errors.New("not found"), true},
-		{errors.New("NoSuchKey"), true},
-		{errors.New("The specified key does not exist."), true},
-		{errors.New("timeout waiting for peer"), false},
-	}
-	for _, tc := range cases {
-		if got := isMissingObject(tc.err); got != tc.want {
-			t.Errorf("isMissingObject(%v) = %v, want %v", tc.err, got, tc.want)
-		}
 	}
 }
 

--- a/internal/resumeextract/pii_test.go
+++ b/internal/resumeextract/pii_test.go
@@ -36,6 +36,15 @@ func (failDetector) Detect(context.Context, string) ([]pii.Span, error) {
 	return nil, errors.New("detector down")
 }
 
+// recordingDetector reports no spans but records how much text (in runes) it was asked
+// to detect over, so a test can assert on what actually reached the detector.
+type recordingDetector struct{ textRunes int }
+
+func (d *recordingDetector) Detect(_ context.Context, text string) ([]pii.Span, error) {
+	d.textRunes = len([]rune(text))
+	return nil, nil
+}
+
 // recordingModel captures the user prompt so a test can assert on what reaches the model.
 type recordingModel struct {
 	resp   string
@@ -132,6 +141,22 @@ func TestExtract_NoAddressSpanLeavesLocationEmpty(t *testing.T) {
 	}
 	if got.Location != "" {
 		t.Errorf("Location = %q, want empty when detection found no ADDRESS (model value must not win)", got.Location)
+	}
+}
+
+func TestExtract_BoundsCVTextBeforeReachingTheDetector(t *testing.T) {
+	// Far larger than maxCVRunes. Only the eventual prompt was bounded (via userPrompt's
+	// clip); the detector — an HTTP round trip whose cost scales with input size — used to
+	// see the whole, unclipped text.
+	huge := strings.Repeat("word ", maxCVRunes*2)
+	m := &recordingModel{resp: `{"summary":"ok"}`}
+	det := &recordingDetector{}
+
+	if _, err := NewExtractor(llm.NewWithModel(m), det).Extract(context.Background(), huge); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if det.textRunes > maxCVRunes {
+		t.Errorf("detector saw %d runes, want <= %d (maxCVRunes): cvText must be bounded before pii.Build, not just before the prompt", det.textRunes, maxCVRunes)
 	}
 }
 

--- a/internal/resumeextract/resumeextract.go
+++ b/internal/resumeextract/resumeextract.go
@@ -67,6 +67,11 @@ func (e *Extractor) Extract(ctx context.Context, cvText string) (Structured, err
 	if !e.Enabled() {
 		return Structured{}, ErrDisabled
 	}
+	// Bound the CV text before any work runs on it, not just before it reaches the model:
+	// pii.Build calls out to the PII-filter service and its cost scales with input size, and
+	// nothing beyond maxCVRunes will ever reach the prompt anyway (userPrompt clips again,
+	// belt-and-suspenders, since redaction can slightly lengthen text via its placeholders).
+	cvText = clip(cvText, maxCVRunes)
 	// De-identify the CV before it reaches the LLM. Fail-closed: a detector error means no
 	// CV is sent (the caller degrades best-effort, persisting no structured résumé).
 	red, err := pii.Build(ctx, cvText, pii.Contacts{}, e.detector)

--- a/services/pii-filter/detector.py
+++ b/services/pii-filter/detector.py
@@ -66,10 +66,14 @@ class Model:
         from tokenizers import Tokenizer
 
         self._np = np
-        self._max = max_tokens
         cfg = json.load(open(os.path.join(model_dir, "config.json")))
         self._id2label = {int(k): v for k, v in cfg["id2label"].items()}
         self._tok = Tokenizer.from_file(os.path.join(model_dir, "tokenizer.json"))
+        # Truncate inside the tokenizer itself rather than encoding the whole input and
+        # slicing ids/offsets afterward: encode() then stops at max_tokens tokens instead of
+        # tokenizing text we would only throw away, and the cut is token-aware from the
+        # start rather than an after-the-fact slice.
+        self._tok.enable_truncation(max_length=max_tokens)
         self._sess = ort.InferenceSession(
             os.path.join(model_dir, "onnx", "model_q4.onnx"),
             providers=["CPUExecutionProvider"],
@@ -78,8 +82,8 @@ class Model:
 
     def detect(self, text: str):
         enc = self._tok.encode(text)
-        ids = enc.ids[: self._max]
-        offsets = enc.offsets[: self._max]
+        ids = enc.ids
+        offsets = enc.offsets
         feed = {"input_ids": self._np.array([ids], dtype=self._np.int64)}
         if "attention_mask" in self._inputs:
             feed["attention_mask"] = self._np.ones((1, len(ids)), dtype=self._np.int64)

--- a/services/pii-filter/server.py
+++ b/services/pii-filter/server.py
@@ -10,14 +10,37 @@ PII_FILTER_ADDR (default 127.0.0.1:8099). The model loads once at startup.
 import json
 import os
 import sys
+import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 from detector import Model
 
 MODEL = None  # set in main()
 
+# This service is reached only by the trusted internal Go backend (see README/AGENTS.md),
+# but it still sits on the CV-processing path and decodes whatever a client sends — these
+# bounds are defense-in-depth, not a trust boundary of their own.
+MAX_BODY_BYTES = 2_000_000  # generous for any real CV text; bounds a runaway/bad client
+REQUEST_TIMEOUT_SECONDS = 30  # per-connection socket read/write deadline
+MAX_CONCURRENT_REQUESTS = 32  # ThreadingHTTPServer spawns one thread per connection
+
+
+def body_too_large(content_length):
+    """Whether a declared Content-Length exceeds MAX_BODY_BYTES. A pure predicate so the
+    cap itself is unit-testable without a running server."""
+    return content_length > MAX_BODY_BYTES
+
 
 class Handler(BaseHTTPRequestHandler):
+    # Read by BaseHTTPRequestHandler.setup() indirectly through our own override below —
+    # http.server does not apply this automatically, unlike socketserver's single-request
+    # handle_request(); a per-connection deadline needs setting on the raw socket.
+    timeout = REQUEST_TIMEOUT_SECONDS
+
+    def setup(self):
+        self.request.settimeout(self.timeout)
+        super().setup()
+
     def _json(self, code, payload):
         body = json.dumps(payload).encode("utf-8")
         self.send_response(code)
@@ -38,6 +61,9 @@ class Handler(BaseHTTPRequestHandler):
             return
         try:
             length = int(self.headers.get("Content-Length", 0))
+            if body_too_large(length):
+                self._json(413, {"error": "request body too large"})
+                return
             req = json.loads(self.rfile.read(length) or b"{}")
             spans = MODEL.detect(req.get("text", ""))
             # Observability without leaking PII: log the span COUNT only, never the text.
@@ -50,12 +76,34 @@ class Handler(BaseHTTPRequestHandler):
         pass
 
 
+class BoundedThreadingHTTPServer(ThreadingHTTPServer):
+    """ThreadingHTTPServer spawns one unbounded thread per accepted connection — a slow or
+    numerous-enough client can exhaust threads/memory with no defense-in-depth bound. A
+    semaphore caps how many requests are handled concurrently: process_request (called
+    serially from the accept loop) blocks once the cap is reached, so excess connections
+    queue in the listen backlog instead of each getting their own thread immediately."""
+
+    def __init__(self, *args, max_concurrent_requests=MAX_CONCURRENT_REQUESTS, **kwargs):
+        self._concurrency = threading.BoundedSemaphore(max_concurrent_requests)
+        super().__init__(*args, **kwargs)
+
+    def process_request(self, request, client_address):
+        self._concurrency.acquire()
+        super().process_request(request, client_address)
+
+    def process_request_thread(self, request, client_address):
+        try:
+            super().process_request_thread(request, client_address)
+        finally:
+            self._concurrency.release()
+
+
 def main():
     global MODEL
     model_dir = os.environ["PII_FILTER_MODEL_DIR"]
     host, _, port = os.environ.get("PII_FILTER_ADDR", "127.0.0.1:8099").partition(":")
     MODEL = Model(model_dir)
-    ThreadingHTTPServer((host, int(port)), Handler).serve_forever()
+    BoundedThreadingHTTPServer((host, int(port)), Handler).serve_forever()
 
 
 if __name__ == "__main__":

--- a/services/pii-filter/test_server.py
+++ b/services/pii-filter/test_server.py
@@ -1,0 +1,73 @@
+import socketserver
+import unittest
+from unittest.mock import patch
+
+from server import (
+    MAX_BODY_BYTES,
+    REQUEST_TIMEOUT_SECONDS,
+    BoundedThreadingHTTPServer,
+    Handler,
+    body_too_large,
+)
+
+
+class BodyTooLargeTest(unittest.TestCase):
+    def test_within_cap(self):
+        self.assertFalse(body_too_large(0))
+        self.assertFalse(body_too_large(MAX_BODY_BYTES))
+
+    def test_over_cap(self):
+        self.assertTrue(body_too_large(MAX_BODY_BYTES + 1))
+
+
+class HandlerTimeoutTest(unittest.TestCase):
+    def test_handler_sets_a_positive_socket_read_timeout(self):
+        # A per-connection deadline (set on the raw socket in setup()), distinct from
+        # socketserver's own server-level select() timeout — this is what bounds a client
+        # that opens a connection and then trickles, or never sends, its body.
+        self.assertEqual(Handler.timeout, REQUEST_TIMEOUT_SECONDS)
+        self.assertGreater(Handler.timeout, 0)
+
+
+class BoundedThreadingHTTPServerTest(unittest.TestCase):
+    def _server(self, cap):
+        server = BoundedThreadingHTTPServer(
+            ("127.0.0.1", 0), Handler, max_concurrent_requests=cap
+        )
+        self.addCleanup(server.server_close)
+        return server
+
+    def test_limits_concurrent_requests(self):
+        cap = 2
+        server = self._server(cap)
+        # Simulate `cap` requests already in flight.
+        for _ in range(cap):
+            self.assertTrue(server._concurrency.acquire(blocking=False))
+        # A (cap + 1)th concurrent request must not be admitted immediately — it should
+        # queue in the listen backlog instead of getting its own thread right away.
+        self.assertFalse(server._concurrency.acquire(blocking=False))
+
+    def test_process_request_thread_releases_its_slot_on_success(self):
+        server = self._server(1)
+        server._concurrency.acquire()
+        with patch.object(socketserver.ThreadingMixIn, "process_request_thread", lambda self, *a: None):
+            server.process_request_thread(object(), ("127.0.0.1", 0))
+        # The slot freed up, so a next request can be admitted.
+        self.assertTrue(server._concurrency.acquire(blocking=False))
+
+    def test_process_request_thread_releases_its_slot_on_error(self):
+        server = self._server(1)
+        server._concurrency.acquire()
+
+        def boom(self, *a):
+            raise RuntimeError("simulated handler failure")
+
+        with patch.object(socketserver.ThreadingMixIn, "process_request_thread", boom):
+            with self.assertRaises(RuntimeError):
+                server.process_request_thread(object(), ("127.0.0.1", 0))
+        # A failed request must not leak its slot.
+        self.assertTrue(server._concurrency.acquire(blocking=False))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `internal/flexjson/flexjson.go:116` — `decodeNumber` (and `Bool`'s numeric branch) propagated the raw `json.Unmarshal` error for a syntactically valid but out-of-range number (e.g. `1e400`), aborting the whole record instead of degrading to the zero value the package exists to guarantee. Now always falls back to 0.
- `internal/blobstore/blobstore.go:94` — `Store.Get` had no sentinel for "object doesn't exist" vs a real backend failure, so `internal/headshot` did no translation at all (a missing headshot surfaced as a raw 500) while `internal/resume` reinvented detection with its own string-matching. Adds `blobstore.IsNotFound(err)` (via `errors.As` on `minio.ErrorResponse`, robust through a `%w` wrapper) and wires it into both consumers.
- `internal/htmltext/htmltext.go:14` — `ToText`/`ToMarkdown` had no input size cap and no caching, so `AgentSearchJobs` (public, up to 100 hits/page) reprocessed each hit's full, untruncated description through two third-party converters on every request. Input is now clamped to 50k runes, and each converter keeps a small fixed-capacity LRU keyed by content hash (no invalidation needed — an edited description is just a cache miss).
- `internal/pii/redactor.go:112` — a contact known only via `Build`'s `known Contacts` argument (never detected as a span) never got a `boundarySafe` entry, so it always fell back to plain substring replacement — over-redacting every literal occurrence of a short/common known value (e.g. a 2-letter location code) anywhere in the text, including inside unrelated words. Known values now get the same boundary-completeness check the spans loop applies, scanned directly against the text; a value absent from the text is left out of `boundarySafe` so the fail-closed self-check doesn't spuriously reject that (documented, common) case.
- `services/pii-filter/server.py:40` — `/detect` had no request-body size cap, no per-connection socket read timeout, and `ThreadingHTTPServer` spawned one unbounded thread per connection — no defense-in-depth bound for a service on the CV-processing path. Adds a 2MB body cap (413 over it), a 30s socket timeout (`Handler.setup()`), and a `BoundedThreadingHTTPServer` that gates concurrent handling behind a semaphore (32 by default).
- `services/pii-filter/detector.py:80` — `Model.detect()` tokenized the entire input before truncating to `max_tokens`; now uses `Tokenizer.enable_truncation()` so the cut happens inside the tokenizer itself. On the Go side, `resumeextract.Extract` passed the raw, unclipped `cvText` into `pii.Build` (which calls out to this same detector) and only clipped afterward for the LLM prompt; `cvText` is now clipped to `maxCVRunes` before any work runs on it.

## Test plan

- [x] `gofmt -l .` — empty
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — full suite green
- [x] `go vet -tags=integration ./...` — full module, clean
- [x] `python3 -m unittest discover` in `services/pii-filter/` — 10/10 passing (installed `tokenizers` standalone to verify the `enable_truncation` API and smoke-tested it directly against a toy tokenizer; `onnxruntime>=1.24` isn't installable in this sandbox's Python 3.9, so `Model` itself — already excluded from this package's automated tests per its own docstring, "heavy weights are not in CI" — wasn't exercised end-to-end)
- [x] Added/extended table-driven Go tests and `unittest` Python tests alongside each behavioral fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)