### PR TITLE
Fix 8 findings: worker ops, cmd/ workers, and calendar test coverage

### DIFF
--- a/cmd/backfill-company-names/main.go
+++ b/cmd/backfill-company-names/main.go
@@ -71,21 +71,14 @@ func run() int {
 		return 0
 	}
 
-	applied := 0
-	for _, r := range renames {
+	applied, failed := applyRenames(ctx, renames, func(ctx context.Context, r rename) (bool, error) {
 		n, err := queries.RenameSlugCompany(ctx, db.RenameSlugCompanyParams{
 			Name:    r.name,
 			NewSlug: normalize.Slug(r.name),
 			OldSlug: r.oldSlug,
 		})
-		if err != nil {
-			log.Printf("rename %s: %v", r.oldSlug, err)
-			continue
-		}
-		if n > 0 {
-			applied++
-		}
-	}
+		return n > 0, err
+	})
 
 	// jobs now carry the resolved names/slugs; re-key the derived catalogue and
 	// sweep the rows orphaned by the re-key so company pages resolve.
@@ -99,14 +92,34 @@ func run() int {
 		return 1
 	}
 
-	log.Printf("backfill-company-names done: candidates=%d resolved=%d applied=%d no_source=%d rejected=%d companies_orphaned=%d",
-		len(rows), len(renames), applied, stats.noSource, stats.rejected, orphans)
-	return 0
+	log.Printf("backfill-company-names done: candidates=%d resolved=%d applied=%d failed=%d no_source=%d rejected=%d companies_orphaned=%d",
+		len(rows), len(renames), applied, failed, stats.noSource, stats.rejected, orphans)
+	return worker.ExitCode(failed, 0)
 }
 
 type rename struct {
 	oldSlug string
 	name    string
+}
+
+// applyRenames writes each rename via write, counting how many actually
+// changed a row (applied) and how many errored (failed). A single company's
+// write failure (e.g. a unique-constraint collision on the derived slug) must
+// not abort the batch, so the loop always continues; the caller uses failed
+// to decide the process exit code instead.
+func applyRenames(ctx context.Context, renames []rename, write func(context.Context, rename) (bool, error)) (applied, failed int) {
+	for _, r := range renames {
+		ok, err := write(ctx, r)
+		if err != nil {
+			log.Printf("rename %s: %v", r.oldSlug, err)
+			failed++
+			continue
+		}
+		if ok {
+			applied++
+		}
+	}
+	return applied, failed
 }
 
 type resolveStats struct {

--- a/cmd/backfill-company-names/main_test.go
+++ b/cmd/backfill-company-names/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/strelov1/freehire/internal/companyname"
@@ -42,5 +43,51 @@ func TestResolveNames(t *testing.T) {
 	}
 	if stats.rejected != 2 {
 		t.Errorf("rejected = %d, want 2 (kempinski, lbresearch)", stats.rejected)
+	}
+}
+
+// TestApplyRenames_CountsFailures guards the worker's exit-code contract: a
+// per-company write failure must be counted, not just logged and dropped, so
+// the caller can turn it into a non-zero exit via worker.ExitCode and cron
+// actually alerts instead of silently succeeding on a partial batch.
+func TestApplyRenames_CountsFailures(t *testing.T) {
+	renames := []rename{
+		{oldSlug: "afcb", name: "AFC Bournemouth"},
+		{oldSlug: "kempinski", name: "Kempinski Hotels"},
+		{oldSlug: "lbresearch", name: "Centellic"},
+	}
+	applied, failed := applyRenames(context.Background(), renames, func(_ context.Context, r rename) (bool, error) {
+		if r.oldSlug == "kempinski" {
+			return false, errors.New("unique constraint violation")
+		}
+		return true, nil
+	})
+	if applied != 2 {
+		t.Errorf("applied = %d, want 2", applied)
+	}
+	if failed != 1 {
+		t.Errorf("failed = %d, want 1", failed)
+	}
+}
+
+// TestApplyRenames_ContinuesPastAFailure guards that one company's write
+// error doesn't abort the rest of the batch — every rename must still be
+// attempted.
+func TestApplyRenames_ContinuesPastAFailure(t *testing.T) {
+	renames := []rename{
+		{oldSlug: "a", name: "A"},
+		{oldSlug: "b", name: "B"},
+		{oldSlug: "c", name: "C"},
+	}
+	var attempted []string
+	applyRenames(context.Background(), renames, func(_ context.Context, r rename) (bool, error) {
+		attempted = append(attempted, r.oldSlug)
+		if r.oldSlug == "a" {
+			return false, errors.New("boom")
+		}
+		return true, nil
+	})
+	if len(attempted) != 3 {
+		t.Errorf("attempted %d renames, want 3 (a failing must not stop b, c)", len(attempted))
 	}
 }

--- a/cmd/backfill-echojobs/main.go
+++ b/cmd/backfill-echojobs/main.go
@@ -27,14 +27,12 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/strelov1/freehire/internal/backfillpage"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/jobhash"
 	"github.com/strelov1/freehire/internal/sources"
 	"github.com/strelov1/freehire/internal/worker"
 )
-
-// backfillBatchSize bounds how many rows are read per keyset page.
-const backfillBatchSize = 500
 
 // jobStore is the slice of the data layer the backfill needs: page one provider's rows by keyset
 // and rewrite a row's description + content_hash. *db.Queries satisfies it; the test uses a fake.
@@ -80,48 +78,30 @@ func jobHandle(externalID string) string {
 }
 
 // backfillAll pages every echojobs row and rewrites the description of rows whose fetched detail
-// body differs from what is stored. It pages by keyset (id > last seen) so concurrent writes
-// cannot skip or repeat rows. A row whose detail fetch fails is counted (failed) and skipped.
+// body differs from what is stored. The keyset walk itself (id > last seen, so concurrent writes
+// cannot skip or repeat rows) is shared with the sibling source backfills via backfillpage.Rows.
+// A row whose detail fetch fails is counted (failed) and skipped.
 func backfillAll(ctx context.Context, store jobStore, fetch descriptionFetcher) (scanned, updated, failed int, err error) {
-	var afterID int64
-	for {
-		jobs, err := store.ListJobsBySourceAfter(ctx, db.ListJobsBySourceAfterParams{
-			Source:    "echojobs",
-			AfterID:   afterID,
-			BatchSize: backfillBatchSize,
-		})
-		if err != nil {
-			return scanned, updated, failed, err
+	err = backfillpage.Rows(ctx, store.ListJobsBySourceAfter, "echojobs", func(j db.Job) error {
+		scanned++
+		desc, ok := fetch(ctx, jobHandle(j.ExternalID))
+		if !ok {
+			failed++
+			return nil
 		}
-		if len(jobs) == 0 {
-			break
+		if desc == j.Description {
+			return nil // already current — idempotent skip
 		}
-		afterID = jobs[len(jobs)-1].ID
-
-		for _, j := range jobs {
-			scanned++
-			desc, ok := fetch(ctx, jobHandle(j.ExternalID))
-			if !ok {
-				failed++
-				continue
-			}
-			if desc == j.Description {
-				continue // already current — idempotent skip
-			}
-			hash := jobhash.OfRow(j, desc)
-			if _, err := store.UpdateJobDescription(ctx, db.UpdateJobDescriptionParams{
-				ID:          j.ID,
-				Description: desc,
-				ContentHash: pgtype.Text{String: hash, Valid: true},
-			}); err != nil {
-				return scanned, updated, failed, err
-			}
-			updated++
+		hash := jobhash.OfRow(j, desc)
+		if _, err := store.UpdateJobDescription(ctx, db.UpdateJobDescriptionParams{
+			ID:          j.ID,
+			Description: desc,
+			ContentHash: pgtype.Text{String: hash, Valid: true},
+		}); err != nil {
+			return err
 		}
-
-		if len(jobs) < backfillBatchSize {
-			break
-		}
-	}
-	return scanned, updated, failed, nil
+		updated++
+		return nil
+	})
+	return scanned, updated, failed, err
 }

--- a/cmd/backfill-himalayas-companyname/main.go
+++ b/cmd/backfill-himalayas-companyname/main.go
@@ -24,15 +24,13 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/strelov1/freehire/internal/backfillpage"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/jobhash"
 	"github.com/strelov1/freehire/internal/normalize"
 	"github.com/strelov1/freehire/internal/sources"
 	"github.com/strelov1/freehire/internal/worker"
 )
-
-// backfillBatchSize bounds how many rows are read per keyset page.
-const backfillBatchSize = 500
 
 // companySlugPath pulls the company slug out of a canonical Himalayas job URL
 // (https://himalayas.app/companies/<slug>/jobs/...), same pattern the adapter's live fallback
@@ -68,57 +66,39 @@ func run() int {
 }
 
 // backfillAll pages every himalayas row and rewrites company/company_slug on rows still
-// carrying HimalayasCompanyNameSentinel. It pages by keyset (id > last seen) so concurrent
-// writes cannot skip or repeat rows. A sentinel row whose url yields no slug is counted
-// (unresolved) and skipped, never aborting the run.
+// carrying HimalayasCompanyNameSentinel. The keyset walk itself (id > last seen, so concurrent
+// writes cannot skip or repeat rows) is shared with the sibling source backfills via
+// backfillpage.Rows. A sentinel row whose url yields no slug is counted (unresolved) and
+// skipped, never aborting the run.
 func backfillAll(ctx context.Context, store jobStore) (total, updated, unresolved int, err error) {
-	var afterID int64
-	for {
-		jobs, err := store.ListJobsBySourceAfter(ctx, db.ListJobsBySourceAfterParams{
-			Source:    "himalayas",
-			AfterID:   afterID,
-			BatchSize: backfillBatchSize,
-		})
-		if err != nil {
-			return total, updated, unresolved, err
+	err = backfillpage.Rows(ctx, store.ListJobsBySourceAfter, "himalayas", func(j db.Job) error {
+		total++
+		if j.Company != sources.HimalayasCompanyNameSentinel {
+			return nil
 		}
-		if len(jobs) == 0 {
-			break
+		m := companySlugPath.FindStringSubmatch(j.URL)
+		if m == nil {
+			unresolved++
+			return nil
 		}
-		afterID = jobs[len(jobs)-1].ID
+		company := m[1]
+		companySlug := normalize.Slug(company)
 
-		for _, j := range jobs {
-			total++
-			if j.Company != sources.HimalayasCompanyNameSentinel {
-				continue
-			}
-			m := companySlugPath.FindStringSubmatch(j.URL)
-			if m == nil {
-				unresolved++
-				continue
-			}
-			company := m[1]
-			companySlug := normalize.Slug(company)
+		row := j
+		row.Company = company
+		row.CompanySlug = companySlug
+		hash := jobhash.OfRow(row, j.Description)
 
-			row := j
-			row.Company = company
-			row.CompanySlug = companySlug
-			hash := jobhash.OfRow(row, j.Description)
-
-			if _, err := store.UpdateJobCompany(ctx, db.UpdateJobCompanyParams{
-				ID:          j.ID,
-				Company:     company,
-				CompanySlug: companySlug,
-				ContentHash: pgtype.Text{String: hash, Valid: true},
-			}); err != nil {
-				return total, updated, unresolved, err
-			}
-			updated++
+		if _, err := store.UpdateJobCompany(ctx, db.UpdateJobCompanyParams{
+			ID:          j.ID,
+			Company:     company,
+			CompanySlug: companySlug,
+			ContentHash: pgtype.Text{String: hash, Valid: true},
+		}); err != nil {
+			return err
 		}
-
-		if len(jobs) < backfillBatchSize {
-			break
-		}
-	}
-	return total, updated, unresolved, nil
+		updated++
+		return nil
+	})
+	return total, updated, unresolved, err
 }

--- a/cmd/backfill-justjoin/main.go
+++ b/cmd/backfill-justjoin/main.go
@@ -18,14 +18,12 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/strelov1/freehire/internal/backfillpage"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/jobhash"
 	"github.com/strelov1/freehire/internal/sources"
 	"github.com/strelov1/freehire/internal/worker"
 )
-
-// backfillBatchSize bounds how many rows are read per keyset page.
-const backfillBatchSize = 500
 
 // jobStore is the slice of the data layer the backfill needs: page one provider's rows by keyset
 // and rewrite a row's description + content_hash. *db.Queries satisfies it; the test uses a fake.
@@ -65,48 +63,30 @@ func run() int {
 }
 
 // backfillAll pages every justjoin row and rewrites the description of rows whose fetched detail
-// body differs from what is stored. It pages by keyset (id > last seen) so concurrent writes
-// cannot skip or repeat rows. A row whose detail fetch fails is counted (failed) and skipped.
+// body differs from what is stored. The keyset walk itself (id > last seen, so concurrent writes
+// cannot skip or repeat rows) is shared with the sibling source backfills via backfillpage.Rows.
+// A row whose detail fetch fails is counted (failed) and skipped.
 func backfillAll(ctx context.Context, store jobStore, fetch descriptionFetcher) (scanned, updated, failed int, err error) {
-	var afterID int64
-	for {
-		jobs, err := store.ListJobsBySourceAfter(ctx, db.ListJobsBySourceAfterParams{
-			Source:    "justjoin",
-			AfterID:   afterID,
-			BatchSize: backfillBatchSize,
-		})
-		if err != nil {
-			return scanned, updated, failed, err
+	err = backfillpage.Rows(ctx, store.ListJobsBySourceAfter, "justjoin", func(j db.Job) error {
+		scanned++
+		desc, ok := fetch(ctx, j.URL)
+		if !ok {
+			failed++
+			return nil
 		}
-		if len(jobs) == 0 {
-			break
+		if desc == j.Description {
+			return nil // already current — idempotent skip
 		}
-		afterID = jobs[len(jobs)-1].ID
-
-		for _, j := range jobs {
-			scanned++
-			desc, ok := fetch(ctx, j.URL)
-			if !ok {
-				failed++
-				continue
-			}
-			if desc == j.Description {
-				continue // already current — idempotent skip
-			}
-			hash := jobhash.OfRow(j, desc)
-			if _, err := store.UpdateJobDescription(ctx, db.UpdateJobDescriptionParams{
-				ID:          j.ID,
-				Description: desc,
-				ContentHash: pgtype.Text{String: hash, Valid: true},
-			}); err != nil {
-				return scanned, updated, failed, err
-			}
-			updated++
+		hash := jobhash.OfRow(j, desc)
+		if _, err := store.UpdateJobDescription(ctx, db.UpdateJobDescriptionParams{
+			ID:          j.ID,
+			Description: desc,
+			ContentHash: pgtype.Text{String: hash, Valid: true},
+		}); err != nil {
+			return err
 		}
-
-		if len(jobs) < backfillBatchSize {
-			break
-		}
-	}
-	return scanned, updated, failed, nil
+		updated++
+		return nil
+	})
+	return scanned, updated, failed, err
 }

--- a/cmd/import-collections/main.go
+++ b/cmd/import-collections/main.go
@@ -46,6 +46,17 @@ import (
 // fetchTimeout bounds each dataset download so a stalled endpoint can't hang the run.
 const fetchTimeout = 60 * time.Second
 
+// maxDatasetBody bounds how many bytes fetchDataset reads from any one dataset
+// response. Every dataset here is a company directory or register (yc-oss,
+// unicorn list, the UK/NL/US sponsor registers) — a few MiB at most — but the
+// URL can be operator-overridden per collection via <SLUG>_DATASET_URL, and
+// several collections resolve theirs dynamically (Dataset.ResolveURL) from a
+// third-party site (e.g. the monthly-republished GOV.UK register). A
+// misconfigured override, a redirect to an unexpectedly large resource, or a
+// misbehaving upstream host must not be able to buffer an unbounded response
+// into memory on a run that otherwise executes unattended on a schedule.
+const maxDatasetBody = 32 << 20 // 32 MiB
+
 // dryRun resolves, matches, and gates exactly as a real run does, reports what it
 // would write, and writes nothing.
 var (
@@ -431,5 +442,14 @@ func fetchDataset(ctx context.Context, client *http.Client, url string) ([]byte,
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("dataset %s: status %d", url, resp.StatusCode)
 	}
-	return io.ReadAll(resp.Body)
+	// Capped on the read, not on Content-Length: that header is the server's
+	// claim, not a promise about what the stream delivers.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxDatasetBody+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxDatasetBody {
+		return nil, fmt.Errorf("dataset %s: body exceeds %d bytes", url, maxDatasetBody)
+	}
+	return body, nil
 }

--- a/cmd/import-collections/main_test.go
+++ b/cmd/import-collections/main_test.go
@@ -441,3 +441,36 @@ func TestProxiedClient_ErrorsOnAnUnparseableSOURCES_PROXY_URL(t *testing.T) {
 		t.Error("proxiedClient accepted an invalid SOURCES_PROXY_URL")
 	}
 }
+
+// TestFetchDataset_RejectsOversizeBody guards against an unbounded read: a
+// misconfigured <SLUG>_DATASET_URL override or a misbehaving/compromised
+// upstream returning a huge body must fail cleanly instead of buffering the
+// whole response into memory on an unattended scheduled run.
+func TestFetchDataset_RejectsOversizeBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(make([]byte, maxDatasetBody+1))
+	}))
+	defer srv.Close()
+
+	if _, err := fetchDataset(context.Background(), srv.Client(), srv.URL); err == nil {
+		t.Error("fetchDataset accepted a body over maxDatasetBody, want an error")
+	}
+}
+
+// TestFetchDataset_AcceptsBodyAtTheCap guards the boundary: a body of exactly
+// maxDatasetBody bytes is a complete, legitimate dataset and must not be
+// rejected as oversize.
+func TestFetchDataset_AcceptsBodyAtTheCap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(make([]byte, maxDatasetBody))
+	}))
+	defer srv.Close()
+
+	body, err := fetchDataset(context.Background(), srv.Client(), srv.URL)
+	if err != nil {
+		t.Fatalf("fetchDataset: %v", err)
+	}
+	if len(body) != maxDatasetBody {
+		t.Errorf("len(body) = %d, want %d", len(body), maxDatasetBody)
+	}
+}

--- a/cmd/import-yc/main.go
+++ b/cmd/import-yc/main.go
@@ -34,7 +34,7 @@ const (
 
 // store is the slice of the data layer the loader needs; *db.Queries satisfies it.
 type store interface {
-	CompanyExists(ctx context.Context, slug string) (bool, error)
+	ListCompanySlugs(ctx context.Context) ([]string, error)
 	CompanyJobCountBySlug(ctx context.Context, slug string) (int32, error)
 	UpsertYCCompany(ctx context.Context, arg db.UpsertYCCompanyParams) error
 }
@@ -109,6 +109,18 @@ type loadStats struct{ matched, inserted, collisions, skipped int }
 // reference vs skipped-collision (a matched company that dwarfs the YC entry — a
 // homonym) vs skipped blank names.
 func load(ctx context.Context, s store, entries []ycdir.Entry) (loadStats, error) {
+	// Load the existing slug set once — a plain SELECT, not one CompanyExists
+	// round trip per (entry × current-plus-former-slug candidate) — the yc-oss
+	// dataset runs several thousand entries deep.
+	slugs, err := s.ListCompanySlugs(ctx)
+	if err != nil {
+		return loadStats{}, err
+	}
+	existing := make(map[string]bool, len(slugs))
+	for _, slug := range slugs {
+		existing[slug] = true
+	}
+
 	var stats loadStats
 	for _, e := range entries {
 		rec, ok := ycdir.Map(e)
@@ -118,10 +130,7 @@ func load(ctx context.Context, s store, entries []ycdir.Entry) (loadStats, error
 		}
 		// Resolve to an existing company by current-name slug or any former-name
 		// slug (first match wins); otherwise insert under the current-name slug.
-		target, matched, err := resolveTarget(ctx, s, rec)
-		if err != nil {
-			return stats, err
-		}
+		target, matched := resolveTarget(existing, rec)
 		if matched {
 			// Homonym guard: a well-known non-YC company can share a normalized name
 			// with a small YC startup. If the matched company holds far more open jobs
@@ -159,18 +168,15 @@ func isCollision(jobCount, teamSize int) bool {
 
 // resolveTarget returns the slug to upsert under and whether it matched an existing
 // company: the current-name slug if it exists, else the first former-name slug that
-// exists, else the current-name slug (a new reference row).
-func resolveTarget(ctx context.Context, s store, rec ycdir.Record) (string, bool, error) {
+// exists, else the current-name slug (a new reference row). existing is the whole
+// companies table's slug set, loaded once by the caller.
+func resolveTarget(existing map[string]bool, rec ycdir.Record) (string, bool) {
 	for _, slug := range append([]string{rec.Slug}, rec.FormerSlugs...) {
-		exists, err := s.CompanyExists(ctx, slug)
-		if err != nil {
-			return "", false, err
-		}
-		if exists {
-			return slug, true, nil
+		if existing[slug] {
+			return slug, true
 		}
 	}
-	return rec.Slug, false, nil
+	return rec.Slug, false
 }
 
 // recordToParams maps a mapped directory record to upsert params: empty scalars

--- a/cmd/import-yc/main_test.go
+++ b/cmd/import-yc/main_test.go
@@ -16,8 +16,14 @@ type fakeStore struct {
 	calls     []db.UpsertYCCompanyParams
 }
 
-func (f *fakeStore) CompanyExists(_ context.Context, slug string) (bool, error) {
-	return f.exists[slug], nil
+func (f *fakeStore) ListCompanySlugs(context.Context) ([]string, error) {
+	var slugs []string
+	for slug, ok := range f.exists {
+		if ok {
+			slugs = append(slugs, slug)
+		}
+	}
+	return slugs, nil
 }
 
 func (f *fakeStore) CompanyJobCountBySlug(_ context.Context, slug string) (int32, error) {
@@ -98,5 +104,23 @@ func TestLoad(t *testing.T) {
 	}
 	if newco.Subindustry.Valid {
 		t.Errorf("newco subindustry = %+v, want NULL (no subindustry given)", newco.Subindustry)
+	}
+}
+
+// TestResolveTarget exercises the in-memory slug resolution directly (no store):
+// current-name slug wins first, a former-name slug wins if the current one is
+// absent, and an entry with no match at all resolves to its own current-name
+// slug as a new reference row.
+func TestResolveTarget(t *testing.T) {
+	existing := map[string]bool{"stripe": true, "facebook": true}
+
+	if slug, matched := resolveTarget(existing, ycdir.Record{Slug: "stripe"}); slug != "stripe" || !matched {
+		t.Errorf("resolveTarget(stripe) = %q, %v; want stripe, true", slug, matched)
+	}
+	if slug, matched := resolveTarget(existing, ycdir.Record{Slug: "meta", FormerSlugs: []string{"facebook"}}); slug != "facebook" || !matched {
+		t.Errorf("resolveTarget(meta, former facebook) = %q, %v; want facebook, true", slug, matched)
+	}
+	if slug, matched := resolveTarget(existing, ycdir.Record{Slug: "new-co"}); slug != "new-co" || matched {
+		t.Errorf("resolveTarget(new-co) = %q, %v; want new-co, false", slug, matched)
 	}
 }

--- a/internal/backfillpage/backfillpage.go
+++ b/internal/backfillpage/backfillpage.go
@@ -1,0 +1,55 @@
+// Package backfillpage holds the keyset-pagination walk shared by the one-off
+// per-source repair workers (cmd/backfill-echojobs, cmd/backfill-justjoin,
+// cmd/backfill-himalayas-companyname, ...): page every row for one source (id
+// > last seen, so concurrent writes cannot skip or repeat rows), stopping once
+// a page comes back short of the batch size. Only that walk is shared — each
+// worker's actual repair (re-fetch a detail body, parse a stored URL, ...)
+// differs enough that factoring it in too would cost more clarity than it
+// saves.
+package backfillpage
+
+import (
+	"context"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// BatchSize bounds how many rows are read per keyset page.
+const BatchSize = 500
+
+// Lister pages one source's rows by keyset; *db.Queries's ListJobsBySourceAfter
+// satisfies it.
+type Lister func(ctx context.Context, arg db.ListJobsBySourceAfterParams) ([]db.Job, error)
+
+// Rows walks every row for source in keyset batches, calling visit once per
+// row. visit's own error aborts the whole walk immediately — for a failure
+// the caller wants to count and skip instead (a single row's detail fetch or
+// URL parse failing, say), visit must handle that itself and return nil.
+func Rows(ctx context.Context, list Lister, source string, visit func(db.Job) error) error {
+	var afterID int64
+	for {
+		jobs, err := list(ctx, db.ListJobsBySourceAfterParams{
+			Source:    source,
+			AfterID:   afterID,
+			BatchSize: BatchSize,
+		})
+		if err != nil {
+			return err
+		}
+		if len(jobs) == 0 {
+			break
+		}
+		afterID = jobs[len(jobs)-1].ID
+
+		for _, j := range jobs {
+			if err := visit(j); err != nil {
+				return err
+			}
+		}
+
+		if len(jobs) < BatchSize {
+			break
+		}
+	}
+	return nil
+}

--- a/internal/backfillpage/backfillpage_test.go
+++ b/internal/backfillpage/backfillpage_test.go
@@ -1,0 +1,92 @@
+package backfillpage
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// fakeLister serves rows keyed off AfterID, standing in for the real keyset
+// query so Rows' paging can be exercised without a database.
+func fakeLister(all []db.Job) Lister {
+	return func(_ context.Context, arg db.ListJobsBySourceAfterParams) ([]db.Job, error) {
+		var page []db.Job
+		for _, j := range all {
+			if j.ID > arg.AfterID {
+				page = append(page, j)
+				if int32(len(page)) == arg.BatchSize {
+					break
+				}
+			}
+		}
+		return page, nil
+	}
+}
+
+// TestRows_WalksEveryRowAcrossMultiplePages guards the pagination loop itself:
+// a source with more rows than fit in one page must still have every row
+// visited, advancing the keyset cursor page over page.
+func TestRows_WalksEveryRowAcrossMultiplePages(t *testing.T) {
+	all := make([]db.Job, 0, BatchSize*2+3)
+	for i := int64(1); i <= int64(BatchSize)*2+3; i++ {
+		all = append(all, db.Job{ID: i, Source: "x"})
+	}
+
+	var visited []int64
+	err := Rows(context.Background(), fakeLister(all), "x", func(j db.Job) error {
+		visited = append(visited, j.ID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Rows: %v", err)
+	}
+	if len(visited) != len(all) {
+		t.Fatalf("visited %d rows, want %d (every row across %d+ pages)", len(visited), len(all), 3)
+	}
+	for i, id := range visited {
+		if id != all[i].ID {
+			t.Fatalf("visited[%d] = %d, want %d (rows out of keyset order)", i, id, all[i].ID)
+		}
+	}
+}
+
+// TestRows_AbortsOnVisitError guards that a visit error (a real write failure
+// the worker needs to surface, not a per-row failure it counts and skips)
+// stops the walk immediately rather than continuing past it.
+func TestRows_AbortsOnVisitError(t *testing.T) {
+	all := []db.Job{{ID: 1, Source: "x"}, {ID: 2, Source: "x"}, {ID: 3, Source: "x"}}
+	boom := errors.New("boom")
+
+	var visited []int64
+	err := Rows(context.Background(), fakeLister(all), "x", func(j db.Job) error {
+		visited = append(visited, j.ID)
+		if j.ID == 2 {
+			return boom
+		}
+		return nil
+	})
+	if !errors.Is(err, boom) {
+		t.Fatalf("Rows err = %v, want %v", err, boom)
+	}
+	if len(visited) != 2 {
+		t.Fatalf("visited %d rows before abort, want 2 (must stop at the failing row)", len(visited))
+	}
+}
+
+// TestRows_EmptySourceVisitsNothing guards the zero-row case: no page at all
+// must not error and must not call visit.
+func TestRows_EmptySourceVisitsNothing(t *testing.T) {
+	called := false
+	err := Rows(context.Background(), fakeLister(nil), "x", func(db.Job) error {
+		called = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Rows: %v", err)
+	}
+	if called {
+		t.Error("visit was called for an empty source")
+	}
+}

--- a/internal/calsync/calendarapi_test.go
+++ b/internal/calsync/calendarapi_test.go
@@ -29,18 +29,27 @@ const eventsJSON = `{"items":[
 func readerAgainst(t *testing.T, body string) (*APIReader, *string) {
 	t.Helper()
 	var gotQuery string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	reader := readerAgainstFunc(t, func(w http.ResponseWriter, r *http.Request) {
 		gotQuery = r.URL.RawQuery
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(body))
-	}))
+	})
+	return reader, &gotQuery
+}
+
+// readerAgainstFunc is readerAgainst generalized to a per-request handler, for tests where
+// the response must depend on which request is being served — pagination, chiefly, where a
+// fixed body (readerAgainst) cannot distinguish the first page's request from the second's.
+func readerAgainstFunc(t *testing.T, handler http.HandlerFunc) *APIReader {
+	t.Helper()
+	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
 	reader := NewAPIReader(srv.Client())
 	// Point the reader at the stub by rewriting the request host through a transport,
 	// so the production URL constant stays the one under test.
 	reader.client = &http.Client{Transport: rewriteHost{to: srv.URL, base: srv.Client().Transport}}
-	return reader, &gotQuery
+	return reader
 }
 
 type rewriteHost struct {
@@ -107,5 +116,64 @@ func TestListEventsAsksForTheWindowItNeeds(t *testing.T) {
 		if !strings.Contains(*query, want) {
 			t.Errorf("request query %q is missing %q", *query, want)
 		}
+	}
+}
+
+// TestListEventsAssemblesMultiplePages guards the reason maxEvents bounds one page, not the
+// window (see its doc comment): a page that came back full must trigger a follow-up request
+// carrying NextPageToken, and the assembled result must hold every page's items, in order —
+// not just the first page's, which would silently truncate the FUTURE end of the window.
+func TestListEventsAssemblesMultiplePages(t *testing.T) {
+	pages := map[string]string{
+		"": `{"items":[{"iCalUID":"page1@google.com","summary":"First","status":"confirmed",
+		      "start":{"dateTime":"2026-08-13T09:00:00Z"},"end":{"dateTime":"2026-08-13T10:00:00Z"}}],
+		     "nextPageToken":"page2"}`,
+		"page2": `{"items":[{"iCalUID":"page2@google.com","summary":"Second","status":"confirmed",
+		      "start":{"dateTime":"2026-08-14T09:00:00Z"},"end":{"dateTime":"2026-08-14T10:00:00Z"}}]}`,
+	}
+	var requestedTokens []string
+	reader := readerAgainstFunc(t, func(w http.ResponseWriter, r *http.Request) {
+		token := r.URL.Query().Get("pageToken")
+		requestedTokens = append(requestedTokens, token)
+		body, ok := pages[token]
+		if !ok {
+			t.Fatalf("unexpected pageToken %q", token)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	})
+
+	got, err := reader.ListEvents(context.Background(), time.Now(), time.Now().AddDate(0, 3, 0))
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(requestedTokens) != 2 || requestedTokens[1] != "page2" {
+		t.Fatalf("requested pageTokens = %v, want [\"\", \"page2\"] (one request per page)", requestedTokens)
+	}
+	if len(got) != 2 {
+		t.Fatalf("read %d meetings across pages, want 2 (one per page)", len(got))
+	}
+	if got[0].UID != "page1@google.com" || got[1].UID != "page2@google.com" {
+		t.Errorf("meetings = %+v, want page1's event then page2's, in order", got)
+	}
+}
+
+// TestListEventsStopsAtMaxPages guards the maxPages cap: a calendar (or a broken server)
+// that keeps returning a NextPageToken forever must not spin ListEvents forever — the walk
+// stops after exactly maxPages requests and returns what it has, rather than erroring or
+// hanging.
+func TestListEventsStopsAtMaxPages(t *testing.T) {
+	var requests int
+	reader := readerAgainstFunc(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[],"nextPageToken":"more"}`))
+	})
+
+	if _, err := reader.ListEvents(context.Background(), time.Now(), time.Now().AddDate(0, 3, 0)); err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if requests != maxPages {
+		t.Errorf("made %d requests, want exactly maxPages=%d", requests, maxPages)
 	}
 }

--- a/internal/db/companies.sql.go
+++ b/internal/db/companies.sql.go
@@ -561,6 +561,34 @@ func (q *Queries) ListCompanySitemap(ctx context.Context, arg ListCompanySitemap
 	return items, nil
 }
 
+const listCompanySlugs = `-- name: ListCompanySlugs :many
+SELECT slug FROM companies
+`
+
+// Every company slug, unfiltered. cmd/import-yc loads this once into an
+// in-memory set to resolve each yc-oss directory entry's current-name and
+// former-name slug candidates, instead of one CompanyExists round trip per
+// candidate per entry (the dataset runs several thousand entries deep).
+func (q *Queries) ListCompanySlugs(ctx context.Context) ([]string, error) {
+	rows, err := q.db.Query(ctx, listCompanySlugs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var slug string
+		if err := rows.Scan(&slug); err != nil {
+			return nil, err
+		}
+		items = append(items, slug)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listSlugLikeCompaniesForBackfill = `-- name: ListSlugLikeCompaniesForBackfill :many
 SELECT DISTINCT ON (company_slug)
        company_slug AS slug,

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1695,6 +1695,11 @@ type Querier interface {
 	// (0057), which covers the predicate, the order and updated_at — without it the
 	// predicate alone sends every candidate row to the heap.
 	ListCompanySitemap(ctx context.Context, arg ListCompanySitemapParams) ([]ListCompanySitemapRow, error)
+	// Every company slug, unfiltered. cmd/import-yc loads this once into an
+	// in-memory set to resolve each yc-oss directory entry's current-name and
+	// former-name slug candidates, instead of one CompanyExists round trip per
+	// candidate per entry (the dataset runs several thousand entries deep).
+	ListCompanySlugs(ctx context.Context) ([]string, error)
 	// Drives the sync worker: every connection still authorized AND holding a mailbox.
 	//
 	// The address is the test, and it is not decoration. Since the calendar consent exists,

--- a/internal/db/queries/companies.sql
+++ b/internal/db/queries/companies.sql
@@ -229,6 +229,13 @@ WHERE NOT c.is_reference
 -- upsert itself is blind to which path (insert or update) it took.
 SELECT EXISTS(SELECT 1 FROM companies WHERE slug = $1);
 
+-- name: ListCompanySlugs :many
+-- Every company slug, unfiltered. cmd/import-yc loads this once into an
+-- in-memory set to resolve each yc-oss directory entry's current-name and
+-- former-name slug candidates, instead of one CompanyExists round trip per
+-- candidate per entry (the dataset runs several thousand entries deep).
+SELECT slug FROM companies;
+
 -- name: UpsertCompanyInfo :exec
 -- Apply one external-dataset company-info record, matched by slug. A new slug is
 -- inserted as a reference row (is_reference = true) with no jobs; an existing slug

--- a/internal/discordbot/token.go
+++ b/internal/discordbot/token.go
@@ -1,12 +1,10 @@
 package discordbot
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/base64"
-	"encoding/binary"
 	"errors"
 	"time"
+
+	"github.com/strelov1/freehire/internal/linktoken"
 )
 
 // ErrInvalidToken is returned for a link token that is malformed, has a bad
@@ -22,58 +20,32 @@ const DiscordLinkTTL = 10 * time.Minute
 // signed for another purpose with the same secret cannot pass here.
 const linkTokenPurpose = "discord-link"
 
-// linkTokenMACLen truncates the HMAC to 16 bytes (128 bits) — ample for a
-// short-lived token — to keep the encoded token small.
-const linkTokenMACLen = 16
-
-// linkTokenPayloadLen is the fixed payload: 8-byte user id + 8-byte expiry unix.
-const linkTokenPayloadLen = 16
-
 // DiscordLinkTokens mints and verifies the short, stateless token a user
-// carries from the web app into the bot's /link slash command. Same shape as
-// telegramnotify.LinkTokens: a base64url(payload‖MAC) blob, not a JWT — no
-// server-side store needed, and it stays short enough to paste as a command
-// argument.
+// carries from the web app into the bot's /link slash command: a
+// base64url(payload‖MAC) blob, not a JWT — no server-side store needed, and
+// it stays short enough to paste as a command argument. The encode/sign/verify
+// logic itself lives in internal/linktoken, shared with
+// telegramnotify.LinkTokens — only the purpose tag and sentinel error differ.
 type DiscordLinkTokens struct {
-	secret []byte
-	ttl    time.Duration
+	tokens *linktoken.Tokens
 }
 
 // NewDiscordLinkTokens returns a DiscordLinkTokens signing with secret (reuse
 // JWT_SECRET) and expiring each token after ttl.
 func NewDiscordLinkTokens(secret string, ttl time.Duration) *DiscordLinkTokens {
-	return &DiscordLinkTokens{secret: []byte(secret), ttl: ttl}
+	return &DiscordLinkTokens{tokens: linktoken.New(secret, linkTokenPurpose, ttl)}
 }
 
 // Issue returns a /link token for userID, expiring after the configured TTL.
 func (l *DiscordLinkTokens) Issue(userID int64) (string, error) {
-	payload := make([]byte, linkTokenPayloadLen)
-	binary.BigEndian.PutUint64(payload[0:8], uint64(userID))
-	binary.BigEndian.PutUint64(payload[8:16], uint64(time.Now().Add(l.ttl).Unix()))
-	token := append(payload, l.mac(payload)...)
-	return base64.RawURLEncoding.EncodeToString(token), nil
+	return l.tokens.Issue(userID), nil
 }
 
 // Parse verifies a token's signature and expiry and returns its user id.
 func (l *DiscordLinkTokens) Parse(token string) (int64, error) {
-	raw, err := base64.RawURLEncoding.DecodeString(token)
-	if err != nil || len(raw) != linkTokenPayloadLen+linkTokenMACLen {
+	userID, ok := l.tokens.Parse(token)
+	if !ok {
 		return 0, ErrInvalidToken
 	}
-	payload, mac := raw[:linkTokenPayloadLen], raw[linkTokenPayloadLen:]
-	if !hmac.Equal(mac, l.mac(payload)) {
-		return 0, ErrInvalidToken
-	}
-	if exp := int64(binary.BigEndian.Uint64(payload[8:16])); time.Now().Unix() > exp {
-		return 0, ErrInvalidToken
-	}
-	return int64(binary.BigEndian.Uint64(payload[0:8])), nil
-}
-
-// mac is the truncated HMAC-SHA256 over the purpose tag and payload.
-func (l *DiscordLinkTokens) mac(payload []byte) []byte {
-	h := hmac.New(sha256.New, l.secret)
-	h.Write([]byte(linkTokenPurpose))
-	h.Write(payload)
-	return h.Sum(nil)[:linkTokenMACLen]
+	return userID, nil
 }

--- a/internal/linktoken/linktoken.go
+++ b/internal/linktoken/linktoken.go
@@ -1,0 +1,71 @@
+// Package linktoken implements the short, stateless deep-link token shared by
+// every "carry a user id from the web app into a chat bot" flow (Telegram,
+// Discord, ...): a base64url(payload‖truncated-HMAC-SHA256) blob, not a JWT,
+// so it survives being pasted as a deep-link start param or slash-command
+// argument. Each caller wraps Tokens with its own purpose tag (for domain
+// separation) and its own sentinel error, so this package carries only the
+// encode/sign/verify logic — not the public API either caller exposes.
+package linktoken
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"time"
+)
+
+// MACLen truncates the HMAC to 16 bytes (128 bits) — ample for a short-lived
+// token — to keep the encoded token small.
+const MACLen = 16
+
+// PayloadLen is the fixed payload: 8-byte user id + 8-byte expiry unix.
+const PayloadLen = 16
+
+// Tokens mints and verifies a purpose-scoped link token.
+type Tokens struct {
+	secret  []byte
+	purpose string
+	ttl     time.Duration
+}
+
+// New returns Tokens signing with secret (reuse JWT_SECRET), scoped to
+// purpose (mixed into the MAC so a token signed for another purpose with the
+// same secret cannot pass verification here), expiring each token after ttl.
+func New(secret, purpose string, ttl time.Duration) *Tokens {
+	return &Tokens{secret: []byte(secret), purpose: purpose, ttl: ttl}
+}
+
+// Issue returns a token for userID, expiring after the configured TTL.
+func (t *Tokens) Issue(userID int64) string {
+	payload := make([]byte, PayloadLen)
+	binary.BigEndian.PutUint64(payload[0:8], uint64(userID))
+	binary.BigEndian.PutUint64(payload[8:16], uint64(time.Now().Add(t.ttl).Unix()))
+	token := append(payload, t.mac(payload)...)
+	return base64.RawURLEncoding.EncodeToString(token)
+}
+
+// Parse verifies a token's signature and expiry and returns its user id. ok
+// is false for a malformed, mis-signed, or expired token.
+func (t *Tokens) Parse(token string) (userID int64, ok bool) {
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil || len(raw) != PayloadLen+MACLen {
+		return 0, false
+	}
+	payload, mac := raw[:PayloadLen], raw[PayloadLen:]
+	if !hmac.Equal(mac, t.mac(payload)) {
+		return 0, false
+	}
+	if exp := int64(binary.BigEndian.Uint64(payload[8:16])); time.Now().Unix() > exp {
+		return 0, false
+	}
+	return int64(binary.BigEndian.Uint64(payload[0:8])), true
+}
+
+// mac is the truncated HMAC-SHA256 over the purpose tag and payload.
+func (t *Tokens) mac(payload []byte) []byte {
+	h := hmac.New(sha256.New, t.secret)
+	h.Write([]byte(t.purpose))
+	h.Write(payload)
+	return h.Sum(nil)[:MACLen]
+}

--- a/internal/linktoken/linktoken_test.go
+++ b/internal/linktoken/linktoken_test.go
@@ -1,0 +1,50 @@
+package linktoken
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTokens_RoundTrip(t *testing.T) {
+	tk := New("secret", "purpose-a", 10*time.Minute)
+	tok := tk.Issue(42)
+	userID, ok := tk.Parse(tok)
+	if !ok || userID != 42 {
+		t.Errorf("Parse = %d, %v; want 42, true", userID, ok)
+	}
+}
+
+func TestTokens_Expired(t *testing.T) {
+	tk := New("secret", "purpose-a", -time.Minute) // already expired
+	tok := tk.Issue(1)
+	if _, ok := tk.Parse(tok); ok {
+		t.Error("Parse(expired) ok = true, want false")
+	}
+}
+
+func TestTokens_WrongSecretRejected(t *testing.T) {
+	tok := New("real", "purpose-a", time.Minute).Issue(1)
+	if _, ok := New("forged", "purpose-a", time.Minute).Parse(tok); ok {
+		t.Error("Parse with wrong secret ok = true, want false")
+	}
+}
+
+// TestTokens_PurposeIsolated guards the domain-separation property both
+// telegramnotify.LinkTokens and discordbot.DiscordLinkTokens depend on: a
+// token minted for one purpose must not verify under another, even with the
+// same secret, so the two callers' tokens can never be cross-accepted.
+func TestTokens_PurposeIsolated(t *testing.T) {
+	tok := New("secret", "purpose-a", time.Minute).Issue(1)
+	if _, ok := New("secret", "purpose-b", time.Minute).Parse(tok); ok {
+		t.Error("Parse under a different purpose ok = true, want false")
+	}
+}
+
+func TestTokens_GarbageRejected(t *testing.T) {
+	tk := New("secret", "purpose-a", time.Minute)
+	for _, bad := range []string{"", "not-base64-!!!", "short", "/start"} {
+		if _, ok := tk.Parse(bad); ok {
+			t.Errorf("Parse(%q) ok = true, want false", bad)
+		}
+	}
+}

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -40,6 +40,27 @@ func Init(dsn, environment string) (flush func(), err error) {
 	return func() { sentry.Flush(flushTimeout) }, nil
 }
 
+// metricsServerTimeout bounds every phase of a connection to the metrics
+// listener (header read, full read, write, and idle keep-alive), so a client
+// that opens a connection and stalls cannot hold it — and the goroutines and
+// file descriptors backing it — open indefinitely.
+const metricsServerTimeout = 10 * time.Second
+
+// metricsServer builds the *http.Server StartMetricsServer runs, split out so
+// its timeout configuration is unit-testable without opening a real listener.
+func metricsServer(port string) *http.Server {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	return &http.Server{
+		Addr:              ":" + port,
+		Handler:           mux,
+		ReadHeaderTimeout: metricsServerTimeout,
+		ReadTimeout:       metricsServerTimeout,
+		WriteTimeout:      metricsServerTimeout,
+		IdleTimeout:       metricsServerTimeout,
+	}
+}
+
 // StartMetricsServer serves Prometheus /metrics on its own listener, separate
 // from the main API port. A dedicated port (rather than a route on the public
 // API) means a firewall rule scoped to a scraper's IP exposes only metrics,
@@ -48,10 +69,9 @@ func StartMetricsServer(port string) {
 	if port == "" {
 		return
 	}
-	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.Handler())
+	srv := metricsServer(port)
 	go func() {
-		if err := http.ListenAndServe(":"+port, mux); err != nil {
+		if err := srv.ListenAndServe(); err != nil {
 			log.Printf("metrics server on :%s stopped: %v", port, err)
 		}
 	}()

--- a/internal/observability/observability_test.go
+++ b/internal/observability/observability_test.go
@@ -2,6 +2,25 @@ package observability
 
 import "testing"
 
+// StartMetricsServer's listener must bound every phase of a connection, or a
+// client that opens one and stalls (slow-loris-style) can hold it open
+// indefinitely with no code-level backstop — see metricsServerTimeout's doc.
+func TestMetricsServerHasTimeouts(t *testing.T) {
+	srv := metricsServer("9999")
+	if srv.ReadHeaderTimeout <= 0 {
+		t.Error("ReadHeaderTimeout is unset; want a positive bound")
+	}
+	if srv.ReadTimeout <= 0 {
+		t.Error("ReadTimeout is unset; want a positive bound")
+	}
+	if srv.WriteTimeout <= 0 {
+		t.Error("WriteTimeout is unset; want a positive bound")
+	}
+	if srv.IdleTimeout <= 0 {
+		t.Error("IdleTimeout is unset; want a positive bound")
+	}
+}
+
 // Without a DSN the integration must stay dormant: Init reports no error and
 // returns a callable no-op flush, so an unconfigured deployment runs unchanged.
 func TestInitDisabledWithoutDSN(t *testing.T) {

--- a/internal/telegramnotify/token.go
+++ b/internal/telegramnotify/token.go
@@ -6,12 +6,10 @@
 package telegramnotify
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/base64"
-	"encoding/binary"
 	"errors"
 	"time"
+
+	"github.com/strelov1/freehire/internal/linktoken"
 )
 
 // ErrInvalidToken is returned for a link token that is malformed, has a bad
@@ -22,59 +20,34 @@ var ErrInvalidToken = errors.New("telegramnotify: invalid or expired link token"
 // for another purpose with the same secret cannot pass here.
 const linkTokenPurpose = "tg-link"
 
-// linkTokenMACLen truncates the HMAC to 16 bytes (128 bits) — ample for a
-// short-lived token — to keep the encoded token small.
-const linkTokenMACLen = 16
-
-// linkTokenPayloadLen is the fixed payload: 8-byte user id + 8-byte expiry unix.
-const linkTokenPayloadLen = 16
-
 // LinkTokens mints and verifies the short, stateless token a user carries into the
 // bot via the t.me deep link. The encoding is deliberately NOT a JWT: Telegram's
 // deep-link `start` parameter allows only 1–64 chars from [A-Za-z0-9_-], which a
 // JWT (dotted, ~200 chars) violates. This token is a base64url(payload‖MAC) blob
 // of ~43 chars using exactly that alphabet, so it survives the deep link intact.
+// The encode/sign/verify logic itself lives in internal/linktoken, shared with
+// discordbot.DiscordLinkTokens — only the purpose tag and sentinel error differ.
 type LinkTokens struct {
-	secret []byte
-	ttl    time.Duration
+	tokens *linktoken.Tokens
 }
 
 // NewLinkTokens returns a LinkTokens signing with secret (reuse JWT_SECRET) and
 // expiring each token after ttl (a short window, e.g. 10 minutes).
 func NewLinkTokens(secret string, ttl time.Duration) *LinkTokens {
-	return &LinkTokens{secret: []byte(secret), ttl: ttl}
+	return &LinkTokens{tokens: linktoken.New(secret, linkTokenPurpose, ttl)}
 }
 
 // Issue returns a deep-link token for userID, expiring after the configured TTL.
 // The result is base64url (no padding) so it is safe as a Telegram start param.
 func (l *LinkTokens) Issue(userID int64) (string, error) {
-	payload := make([]byte, linkTokenPayloadLen)
-	binary.BigEndian.PutUint64(payload[0:8], uint64(userID))
-	binary.BigEndian.PutUint64(payload[8:16], uint64(time.Now().Add(l.ttl).Unix()))
-	token := append(payload, l.mac(payload)...)
-	return base64.RawURLEncoding.EncodeToString(token), nil
+	return l.tokens.Issue(userID), nil
 }
 
 // Parse verifies a token's signature and expiry and returns its user id.
 func (l *LinkTokens) Parse(token string) (int64, error) {
-	raw, err := base64.RawURLEncoding.DecodeString(token)
-	if err != nil || len(raw) != linkTokenPayloadLen+linkTokenMACLen {
+	userID, ok := l.tokens.Parse(token)
+	if !ok {
 		return 0, ErrInvalidToken
 	}
-	payload, mac := raw[:linkTokenPayloadLen], raw[linkTokenPayloadLen:]
-	if !hmac.Equal(mac, l.mac(payload)) {
-		return 0, ErrInvalidToken
-	}
-	if exp := int64(binary.BigEndian.Uint64(payload[8:16])); time.Now().Unix() > exp {
-		return 0, ErrInvalidToken
-	}
-	return int64(binary.BigEndian.Uint64(payload[0:8])), nil
-}
-
-// mac is the truncated HMAC-SHA256 over the purpose tag and payload.
-func (l *LinkTokens) mac(payload []byte) []byte {
-	h := hmac.New(sha256.New, l.secret)
-	h.Write([]byte(linkTokenPurpose))
-	h.Write(payload)
-	return h.Sum(nil)[:linkTokenMACLen]
+	return userID, nil
 }

--- a/internal/viewlog/parse.go
+++ b/internal/viewlog/parse.go
@@ -1,9 +1,10 @@
 // Package viewlog aggregates nginx access-log lines into per-job view counts. It
 // runs off the request path: a scheduled worker (cmd/rollup-views) feeds it a
-// day's log and it returns per-job unique views, deduplicated by hashed IP+UA so
-// a visitor counts at most once per job per day. Two request shapes are counted —
-// the SSR detail page GET /jobs/<slug> (bot-filtered) and the API read
-// GET /api/v1/jobs/<slug> (not bot-filtered) — every other line is ignored.
+// day's log and it returns per-job unique views, deduplicated by the raw IP+UA
+// tuple (NUL-joined, no hashing) so a visitor counts at most once per job per
+// day. Two request shapes are counted — the SSR detail page GET /jobs/<slug>
+// (bot-filtered) and the API read GET /api/v1/jobs/<slug> (not bot-filtered) —
+// every other line is ignored.
 package viewlog
 
 import (


### PR DESCRIPTION
## Summary

- Extract duplicated MAC/token issue-parse logic (`internal/discordbot/token.go`, `internal/telegramnotify/token.go`) into a shared `internal/linktoken` package, keeping each caller's own public API, sentinel error, and purpose tag.
- Add connection timeouts to the Prometheus metrics HTTP listener (`internal/observability/observability.go`), which previously ran a bare `http.ListenAndServe`.
- Correct `internal/viewlog/parse.go`'s package doc comment, which claimed the dedup key is "hashed IP+UA" when the code (and `AGENTS.md`) has always used the raw NUL-joined tuple.
- Count per-company rename failures in `cmd/backfill-company-names/main.go` so the worker exits non-zero on a partial batch instead of always exiting 0.
- Resolve `cmd/import-yc`'s yc-oss directory entries against a bulk-loaded company-slug set (new `ListCompanySlugs` query) instead of one `CompanyExists` round trip per candidate.
- Cap `cmd/import-collections`' `fetchDataset` response read at 32 MiB instead of an unbounded `io.ReadAll`.
- Extract the shared keyset-pagination walk out of `cmd/backfill-echojobs`, `cmd/backfill-justjoin`, and `cmd/backfill-himalayas-companyname` into `internal/backfillpage.Rows`.
- Add test coverage for `internal/calsync`'s `ListEvents` multi-page pagination and its `maxPages` cap, previously untested (`readerAgainst` always served one fixed body).

## Test plan

- [x] `gofmt -l .` empty for all touched Go files
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test ./...` — all touched packages pass; two unrelated pre-existing failures confirmed environmental (missing `pdftotext` binary for `internal/handler`'s PDF-extraction test; a timing-flaky `internal/worker` heartbeat test that passes in isolation) — neither package touched by this branch
- [x] New/extended unit tests per finding: `internal/linktoken`, `internal/observability`, `cmd/backfill-company-names`, `cmd/import-yc`, `cmd/import-collections`, `internal/backfillpage`, `internal/calsync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)