### PR TITLE
Fix 9 review findings: extension assistant + web routes

### DIFF
--- a/extension/entrypoints/sidepanel/App.svelte
+++ b/extension/entrypoints/sidepanel/App.svelte
@@ -128,14 +128,24 @@
     }
   }
 
-  async function loadCatalog(slug: string, token: string) {
+  // Bumped at the start of every loadMatch() call; a stale call checks its own
+  // captured id against the current one before writing shared state, so an
+  // earlier in-flight load (e.g. a slow ad-hoc text match) can never clobber a
+  // newer one's result after the user has already tabbed or navigated again.
+  let matchRequestId = 0;
+
+  async function loadCatalog(slug: string, token: string, requestId: number): Promise<boolean> {
     const [job, m] = await Promise.all([getJob(slug, token), getMatch(slug, token)]);
+    if (requestId !== matchRequestId) return false;
     matchJob = job;
     match = m;
+    return true;
   }
 
   async function loadMatch() {
+    const requestId = ++matchRequestId;
     const token = await getToken();
+    if (requestId !== matchRequestId) return;
     if (!token) {
       matchStatus = 'empty';
       matchJob = null;
@@ -143,6 +153,7 @@
       return;
     }
     const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+    if (requestId !== matchRequestId) return;
     const url = tab?.url ?? '';
 
     matchStatus = 'loading';
@@ -151,7 +162,7 @@
       // Freehire's own job page → curated slug directly.
       const directSlug = freehireSlugFromUrl(url);
       if (directSlug) {
-        await loadCatalog(directSlug, token);
+        if (!(await loadCatalog(directSlug, token, requestId))) return;
         matchStatus = 'ready';
         return;
       }
@@ -159,14 +170,18 @@
       // Any other page: recognise it as a catalog job from its URL (curated
       // card), else read the page and match against the scraped posting text.
       const catalogSlug = await findJob(url, token);
+      if (requestId !== matchRequestId) return;
       const snap = catalogSlug ? null : await readSnapshot();
+      if (requestId !== matchRequestId) return;
       const headline = snap?.headline || snap?.title || '';
 
       if (catalogSlug) {
-        await loadCatalog(catalogSlug, token);
+        if (!(await loadCatalog(catalogSlug, token, requestId))) return;
       } else if (snap?.text) {
         const t = headline || 'This page';
-        match = await getMatchText(t, snap.text, token);
+        const m = await getMatchText(t, snap.text, token);
+        if (requestId !== matchRequestId) return;
+        match = m;
         matchJob = { public_slug: '', title: t, company: hostOf(url), location: '' };
       } else {
         matchStatus = 'empty';
@@ -174,6 +189,7 @@
       }
       matchStatus = 'ready';
     } catch (err) {
+      if (requestId !== matchRequestId) return;
       matchError = err instanceof Error ? err.message : 'Could not load match';
       matchStatus = 'error';
     }

--- a/extension/lib/assistant/tool-formatters.test.ts
+++ b/extension/lib/assistant/tool-formatters.test.ts
@@ -68,10 +68,15 @@ describe('callLine', () => {
     );
   });
 
-  it('shows the patch op a CV edit applied', () => {
-    expect(callLine(call('cv_edit', { patch: { op: 'add_bullet', experience: 0 } }))).toBe(
-      'Updating your CV: add_bullet',
+  // cv_edit takes a batch, so the useful detail is how much it changed at once — there are no
+  // named ops any more to report.
+  it('shows how many edits a CV change carried', () => {
+    expect(callLine(call('cv_edit', { ops: [{ kind: 'set', path: 'summary' }] }))).toBe(
+      'Updating your CV: 1 edit',
     );
+    expect(
+      callLine(call('cv_edit', { ops: [{ kind: 'set', path: 'summary' }, { kind: 'remove', path: 'skills[0]' }] })),
+    ).toBe('Updating your CV: 2 edits');
   });
 
   it('shows the label alone when there is nothing identifying to add', () => {

--- a/extension/lib/assistant/tool-formatters.ts
+++ b/extension/lib/assistant/tool-formatters.ts
@@ -81,7 +81,7 @@ function callDetail(call: ToolCall): string | null {
     case 'my_jobs':
       return readField(call.input, 'filter');
     case 'cv_edit':
-      return readNested(call.input, 'patch', 'op');
+      return editCount(call.input);
     default:
       return null;
   }
@@ -152,8 +152,10 @@ function readList(input: unknown, key: string): string | null {
   return parts.length > 0 ? truncate(parts.join(', '), 60) : null;
 }
 
-function readNested(input: unknown, outer: string, inner: string): string | null {
+/** How many edits one cv_edit call carried — the tool takes a batch, not a single patch. */
+function editCount(input: unknown): string | null {
   if (!input || typeof input !== 'object') return null;
-  const nested = (input as Record<string, unknown>)[outer];
-  return readField(nested, inner);
+  const ops = (input as Record<string, unknown>).ops;
+  if (!Array.isArray(ops) || ops.length === 0) return null;
+  return ops.length === 1 ? '1 edit' : `${ops.length} edits`;
 }

--- a/web/src/lib/assistant/AssistantChat.svelte
+++ b/web/src/lib/assistant/AssistantChat.svelte
@@ -149,7 +149,6 @@
   // events, so scrolling up mid-turn holds position and scrolling back resumes
   // following with no further ceremony.
   let stickToBottom = $state(true);
-  let textareaEl = $state<HTMLTextAreaElement | null>(null);
 
   // Messages typed while a turn is in flight, drained one by one when it ends.
   let queue = $state<{ id: string; text: string }[]>([]);
@@ -213,16 +212,6 @@
   /** The conversation the host is currently being navigated to, or null. Held until the
    *  `session` prop catches up, so a switch we started is never undone by the stale URL. */
   let navigatingTo = $state<string | null>(null);
-
-  // Auto-grow the composer textarea up to a cap (px).
-  const COMPOSER_CAP = 200;
-  $effect(() => {
-    void draft;
-    const el = textareaEl;
-    if (!el) return;
-    el.style.height = 'auto';
-    el.style.height = `${Math.min(el.scrollHeight, COMPOSER_CAP)}px`;
-  });
 
   // --- Streaming spinner / thinking timers ---------------------------------
   const SPINNER_GLYPHS = ['·', '✢', '✳', '✶', '✻', '✽'] as const;

--- a/web/src/lib/assistant/AssistantChat.svelte
+++ b/web/src/lib/assistant/AssistantChat.svelte
@@ -392,6 +392,16 @@
   // every later address change, which is Forward appearing to do nothing.
   async function openSession(id: string, fromAddress = false) {
     if (activeId === id && chat.messages.length > 0) return;
+    // A message typed while the current turn was streaming sits in `queue`, waiting
+    // for the turn to finish so endTurn() can drain it — cancelTurn() below stops the
+    // turn but never drains the queue, so switching here would otherwise wipe out
+    // whatever the user just typed with no trace and no way back.
+    if (
+      queue.length > 0 &&
+      !confirm('You have an unsent message waiting in this chat. Switch chats and discard it?')
+    ) {
+      return;
+    }
     switching = true;
     cancelTurn();
     // Navigating away from a session must end its call rather than silently carry it

--- a/web/src/lib/assistant/jobCache.test.ts
+++ b/web/src/lib/assistant/jobCache.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Job } from '$lib/types';
+
+const getJob = vi.fn<(slug: string) => Promise<Job>>();
+
+vi.mock('$lib/api', () => ({
+  api: { getJob: (slug: string) => getJob(slug) },
+}));
+
+const job = (slug: string): Job => ({ public_slug: slug }) as Job;
+
+// jobCache is a plain module-level Map, so each test needs its own fresh instance
+// rather than sharing state through the module cache vitest keeps between tests.
+async function freshCache() {
+  vi.resetModules();
+  return import('./jobCache');
+}
+
+beforeEach(() => {
+  getJob.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('loadJob', () => {
+  it('dedupes concurrent calls for the same slug to one fetch', async () => {
+    const { loadJob } = await freshCache();
+    getJob.mockResolvedValue(job('go-dev-acme'));
+
+    const [a, b] = await Promise.all([loadJob('go-dev-acme'), loadJob('go-dev-acme')]);
+
+    expect(a).toEqual(b);
+    expect(getJob).toHaveBeenCalledTimes(1);
+  });
+
+  it('evicts a rejected fetch so a later call retries', async () => {
+    const { loadJob } = await freshCache();
+    getJob.mockRejectedValueOnce(new Error('down'));
+    await expect(loadJob('go-dev-acme')).rejects.toThrow('down');
+
+    getJob.mockResolvedValueOnce(job('go-dev-acme'));
+    await expect(loadJob('go-dev-acme')).resolves.toEqual(job('go-dev-acme'));
+    expect(getJob).toHaveBeenCalledTimes(2);
+  });
+
+  // The cache used to hold every resolved entry for the rest of the session — only
+  // a failed fetch was ever evicted. A long session (many search results, many job
+  // decks) could name far more slugs than are worth keeping, so the cache now caps
+  // its size and drops the least-recently-used entry rather than growing forever.
+  it('caps the cache size, evicting the least-recently-used slug first', async () => {
+    const { loadJob, MAX_ENTRIES } = await freshCache();
+    getJob.mockImplementation((slug: string) => Promise.resolve(job(slug)));
+
+    // Calling loadJob is what inserts into the cache (synchronously, before the
+    // fetch resolves), so issuing all MAX_ENTRIES calls up front and awaiting them
+    // together still inserts slug-0..slug-(N-1) in that order.
+    await Promise.all(Array.from({ length: MAX_ENTRIES }, (_, i) => loadJob(`slug-${i}`)));
+    expect(getJob).toHaveBeenCalledTimes(MAX_ENTRIES);
+
+    // One more distinct slug pushes the cache past its cap.
+    await loadJob('slug-overflow');
+    getJob.mockClear();
+
+    // The oldest entry (slug-0) was evicted, so it is fetched again...
+    await loadJob('slug-0');
+    expect(getJob).toHaveBeenCalledTimes(1);
+
+    // ...while a slug that was still resident is served from the cache.
+    getJob.mockClear();
+    await loadJob('slug-overflow');
+    expect(getJob).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/assistant/jobCache.ts
+++ b/web/src/lib/assistant/jobCache.ts
@@ -6,19 +6,37 @@
 import { api } from '$lib/api';
 import type { Job } from '$lib/types';
 
+// A long-running session (many turns, each surfacing its own search results and
+// job decks) can name far more distinct slugs than are worth holding onto at
+// once. Only a failed fetch was ever evicted, so a resolved entry sat in the map
+// for the rest of the session — capping the size and evicting the
+// least-recently-used entry keeps this a cache rather than an unbounded log of
+// every job the chat has ever shown.
+export const MAX_ENTRIES = 200;
+
 const cache = new Map<string, Promise<Job>>();
 
 /** Fetch a job's structured jobview by slug, deduped by slug. A rejected fetch
  *  is evicted so a later render can retry instead of being stuck on the link
  *  fallback for the whole session. */
 export function loadJob(slug: string): Promise<Job> {
-  let p = cache.get(slug);
-  if (!p) {
-    p = api.getJob(slug);
-    p.catch(() => {
-      if (cache.get(slug) === p) cache.delete(slug);
-    });
-    cache.set(slug, p);
+  const existing = cache.get(slug);
+  if (existing) {
+    // Re-insert to mark it most-recently-used — Map iterates in insertion order,
+    // which is what the eviction below relies on.
+    cache.delete(slug);
+    cache.set(slug, existing);
+    return existing;
   }
+
+  const p = api.getJob(slug);
+  p.catch(() => {
+    if (cache.get(slug) === p) cache.delete(slug);
+  });
+  if (cache.size >= MAX_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  cache.set(slug, p);
   return p;
 }

--- a/web/src/lib/server/community.ts
+++ b/web/src/lib/server/community.ts
@@ -1,0 +1,26 @@
+import { error } from '@sveltejs/kit';
+import { ApiError } from '$lib/api';
+import { serverApi } from './api';
+import { threadMatchesSubject } from './threadSubject';
+
+/** Fetch a community thread for its detail page, scoped to the subject the route
+ *  actually names — a thread that resolves to the wrong subject 404s the same as
+ *  an id that resolves to nothing at all. Both discussion/[threadId] routes
+ *  (companies/ and jobs/) share this. */
+export async function loadThread(
+  fetchImpl: typeof fetch,
+  subjectType: 'company' | 'job',
+  params: { slug: string; threadId: string },
+) {
+  const id = Number(params.threadId);
+  if (!Number.isInteger(id)) error(404, 'Thread not found');
+  const api = serverApi(fetchImpl);
+  try {
+    const { thread, replies, nextCursor } = await api.getThread(id);
+    if (!threadMatchesSubject(thread, subjectType, params.slug)) error(404, 'Thread not found');
+    return { slug: params.slug, thread, replies, nextCursor };
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 404) error(404, 'Thread not found');
+    throw e;
+  }
+}

--- a/web/src/lib/server/insights.ts
+++ b/web/src/lib/server/insights.ts
@@ -1,0 +1,11 @@
+import type { InsightRole } from '$lib/api';
+import { serverApi } from './api';
+
+/** The global roles ranking that gates every insights landing page — the hub, the
+ *  three per-category pages (salary/roles/skills), and the sitemap all decide what
+ *  to show (or 404) from the same `coveredCategories`/`isCovered` read over this
+ *  set, so they all fetch it identically: `limit: 200` and no other filter. Shared
+ *  so the five call sites can't quietly drift onto different limits. */
+export function loadInsightsGate(fetchImpl: typeof fetch): Promise<InsightRole[]> {
+  return serverApi(fetchImpl).insightsRoles({ limit: 200 });
+}

--- a/web/src/lib/server/og/card.ts
+++ b/web/src/lib/server/og/card.ts
@@ -17,6 +17,7 @@ import { OG_HEIGHT, OG_WIDTH, brandFooter, chipMarkup, esc, logoBox, type Chip }
 
 const SKILL_LIMIT = 3;
 const LOGO_SIZE = 96;
+const TITLE_LINE_CLAMP = 3;
 
 /** Title font size shrinks as the title grows; a 3-line clamp catches the rest. */
 function titleFontSize(title: string): number {
@@ -59,7 +60,7 @@ export function buildCard(job: Job, opts: { logo: string | null }): string {
     ${logoBox(opts.logo, job.company, LOGO_SIZE)}
     <div style="display:flex;font-size:28px;font-weight:600;color:#404040;overflow:hidden">${esc(job.company)}</div>
   </div>
-  <div style="display:flex;font-size:${titleSize}px;font-weight:700;letter-spacing:-0.03em;line-height:1.05;overflow:hidden">${esc(job.title)}</div>
+  <div style="display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:${TITLE_LINE_CLAMP};text-overflow:ellipsis;overflow:hidden;font-size:${titleSize}px;font-weight:700;letter-spacing:-0.03em;line-height:1.05">${esc(job.title)}</div>
   <div style="display:flex;flex-wrap:wrap;gap:12px">${chipRow}</div>
   ${brandFooter()}
 </div>`.trim();

--- a/web/src/lib/server/threadSubject.test.ts
+++ b/web/src/lib/server/threadSubject.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { threadMatchesSubject } from './threadSubject';
+
+describe('threadMatchesSubject', () => {
+  it('matches when both the subject kind and slug agree with the URL', () => {
+    const thread = { subject_type: 'company', subject_slug: 'acme' };
+    expect(threadMatchesSubject(thread, 'company', 'acme')).toBe(true);
+  });
+
+  it('rejects a thread that resolves under a different slug of the same kind', () => {
+    // A syntactically valid threadId can name a real thread that belongs to a
+    // DIFFERENT company than the one in the URL — getThread(id) alone has no way
+    // to know that.
+    const thread = { subject_type: 'company', subject_slug: 'other-co' };
+    expect(threadMatchesSubject(thread, 'company', 'acme')).toBe(false);
+  });
+
+  it('rejects a thread that resolves under the other subject kind entirely', () => {
+    // Thread ids are not namespaced per subject kind, so a job's thread id can
+    // collide with a company detail page's [threadId] param.
+    const thread = { subject_type: 'job', subject_slug: 'acme' };
+    expect(threadMatchesSubject(thread, 'company', 'acme')).toBe(false);
+  });
+});

--- a/web/src/lib/server/threadSubject.ts
+++ b/web/src/lib/server/threadSubject.ts
@@ -1,0 +1,16 @@
+import type { CommunityThread } from '$lib/types';
+
+/** Whether a resolved thread actually belongs to the subject its detail-page URL
+ *  names. `getThread` resolves by id alone, so a syntactically valid id that
+ *  belongs to a different company, a different job, or the other subject kind
+ *  entirely would otherwise "load" fine under that URL — the route's own params
+ *  never factor into the lookup at all. Kept in its own dependency-free module
+ *  (no `$env`, no `serverApi`) so this one piece of actual logic stays
+ *  unit-testable without the SvelteKit server plumbing around it. */
+export function threadMatchesSubject(
+  thread: Pick<CommunityThread, 'subject_type' | 'subject_slug'>,
+  subjectType: 'company' | 'job',
+  subjectSlug: string,
+): boolean {
+  return thread.subject_type === subjectType && thread.subject_slug === subjectSlug;
+}

--- a/web/src/routes/companies/[slug]/discussion/[threadId]/+page.server.ts
+++ b/web/src/routes/companies/[slug]/discussion/[threadId]/+page.server.ts
@@ -1,17 +1,4 @@
-import { error } from '@sveltejs/kit';
-import { ApiError } from '$lib/api';
-import { serverApi } from '$lib/server/api';
+import { loadThread } from '$lib/server/community';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ params, fetch }) => {
-  const id = Number(params.threadId);
-  if (!Number.isInteger(id)) error(404, 'Thread not found');
-  const api = serverApi(fetch);
-  try {
-    const { thread, replies, nextCursor } = await api.getThread(id);
-    return { slug: params.slug, thread, replies, nextCursor };
-  } catch (e) {
-    if (e instanceof ApiError && e.status === 404) error(404, 'Thread not found');
-    throw e;
-  }
-};
+export const load: PageServerLoad = async ({ params, fetch }) => loadThread(fetch, 'company', params);

--- a/web/src/routes/insights/+page.server.ts
+++ b/web/src/routes/insights/+page.server.ts
@@ -1,4 +1,4 @@
-import { serverApi } from '$lib/server/api';
+import { loadInsightsGate } from '$lib/server/insights';
 import { coveredCategories } from '$lib/insights';
 import type { PageServerLoad } from './$types';
 
@@ -6,7 +6,7 @@ import type { PageServerLoad } from './$types';
 // pages, so crawlers reach them from one indexable page. Covered set is derived
 // from the global roles ranking (the gate). SSR-live + CDN cache window.
 export const load: PageServerLoad = async ({ fetch, setHeaders }) => {
-  const globalRoles = await serverApi(fetch).insightsRoles({ limit: 200 });
+  const globalRoles = await loadInsightsGate(fetch);
   setHeaders({ 'cache-control': 'public, max-age=0, s-maxage=3600' });
   return { covered: coveredCategories(globalRoles) };
 };

--- a/web/src/routes/insights/roles/[category]/+page.server.ts
+++ b/web/src/routes/insights/roles/[category]/+page.server.ts
@@ -1,5 +1,6 @@
 import { error } from '@sveltejs/kit';
 import { serverApi } from '$lib/server/api';
+import { loadInsightsGate } from '$lib/server/insights';
 import { coveredCategories, isCovered, rolesIntro } from '$lib/insights';
 import { categoryLabel } from '$lib/labels';
 import type { PageServerLoad } from './$types';
@@ -12,7 +13,7 @@ export const load: PageServerLoad = async ({ params, fetch, setHeaders }) => {
   const category = params.category;
   const api = serverApi(fetch);
 
-  const globalRoles = await api.insightsRoles({ limit: 200 });
+  const globalRoles = await loadInsightsGate(fetch);
   if (!isCovered(globalRoles, category)) error(404, 'No role insights for this category yet');
 
   const roles = await api.insightsRoles({ category, sort: 'open', limit: 20 });

--- a/web/src/routes/insights/salary/[category]/+page.server.ts
+++ b/web/src/routes/insights/salary/[category]/+page.server.ts
@@ -1,5 +1,6 @@
 import { error } from '@sveltejs/kit';
 import { serverApi } from '$lib/server/api';
+import { loadInsightsGate } from '$lib/server/insights';
 import { coveredCategories, isCovered, sortBandsBySeniority, salaryIntro } from '$lib/insights';
 import { categoryLabel } from '$lib/labels';
 import type { PageServerLoad } from './$types';
@@ -12,7 +13,7 @@ export const load: PageServerLoad = async ({ params, fetch, setHeaders }) => {
   const category = params.category;
   const api = serverApi(fetch);
 
-  const globalRoles = await api.insightsRoles({ limit: 200 });
+  const globalRoles = await loadInsightsGate(fetch);
   if (!isCovered(globalRoles, category)) error(404, 'No salary insights for this category yet');
 
   const bands = sortBandsBySeniority(await api.insightsSalaryByCategory(category));

--- a/web/src/routes/insights/skills/[category]/+page.server.ts
+++ b/web/src/routes/insights/skills/[category]/+page.server.ts
@@ -1,5 +1,6 @@
 import { error } from '@sveltejs/kit';
 import { serverApi } from '$lib/server/api';
+import { loadInsightsGate } from '$lib/server/insights';
 import { coveredCategories, isCovered, skillsIntro } from '$lib/insights';
 import { categoryLabel } from '$lib/labels';
 import type { PageServerLoad } from './$types';
@@ -10,7 +11,7 @@ export const load: PageServerLoad = async ({ params, fetch, setHeaders }) => {
   const category = params.category;
   const api = serverApi(fetch);
 
-  const globalRoles = await api.insightsRoles({ limit: 200 });
+  const globalRoles = await loadInsightsGate(fetch);
   if (!isCovered(globalRoles, category)) error(404, 'No skill insights for this category yet');
 
   const skills = await api.insightsSkills({ category, sort: 'open', limit: 40 });

--- a/web/src/routes/jobs/[slug]/discussion/[threadId]/+page.server.ts
+++ b/web/src/routes/jobs/[slug]/discussion/[threadId]/+page.server.ts
@@ -1,17 +1,4 @@
-import { error } from '@sveltejs/kit';
-import { ApiError } from '$lib/api';
-import { serverApi } from '$lib/server/api';
+import { loadThread } from '$lib/server/community';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ params, fetch }) => {
-  const id = Number(params.threadId);
-  if (!Number.isInteger(id)) error(404, 'Thread not found');
-  const api = serverApi(fetch);
-  try {
-    const { thread, replies, nextCursor } = await api.getThread(id);
-    return { slug: params.slug, thread, replies, nextCursor };
-  } catch (e) {
-    if (e instanceof ApiError && e.status === 404) error(404, 'Thread not found');
-    throw e;
-  }
-};
+export const load: PageServerLoad = async ({ params, fetch }) => loadThread(fetch, 'job', params);

--- a/web/src/routes/my/tracking/[id]/+page.server.ts
+++ b/web/src/routes/my/tracking/[id]/+page.server.ts
@@ -11,7 +11,8 @@ import type { PageServerLoad } from './$types';
 export const load: PageServerLoad = async ({ parent, params, url, fetch, request }) => {
   const { user } = await parent();
   if (!user) {
-    redirect(302, `/?auth=required&redirect=${encodeURIComponent(url.pathname)}`);
+    const target = url.pathname + url.search;
+    redirect(302, `/?auth=required&redirect=${encodeURIComponent(target)}`);
   }
   return { id: params.id, board: await loadBoard(fetch, request.headers.get('cookie')) };
 };

--- a/web/src/routes/sitemap-insights.xml/+server.ts
+++ b/web/src/routes/sitemap-insights.xml/+server.ts
@@ -1,4 +1,4 @@
-import { serverApi } from '$lib/server/api';
+import { loadInsightsGate } from '$lib/server/insights';
 import { coveredCategories } from '$lib/insights';
 import { insightsPaths, urlsetXml, xmlResponse } from '$lib/sitemap';
 import type { RequestHandler } from './$types';
@@ -8,7 +8,7 @@ import type { RequestHandler } from './$types';
 // so a thin/gated-out category never appears — matching what the pages actually
 // serve (uncovered → 404).
 export const GET: RequestHandler = async ({ url, fetch }) => {
-  const roles = await serverApi(fetch).insightsRoles({ limit: 200 });
+  const roles = await loadInsightsGate(fetch);
   const categories = coveredCategories(roles).map((c) => c.category);
   const entries = insightsPaths(categories).map((path) => ({ loc: `${url.origin}${path}` }));
   return xmlResponse(urlsetXml(entries));


### PR DESCRIPTION
## Summary

- extension/lib/assistant/tool-formatters.ts:84 — the cv_edit tool-call detail formatter read the retired `input.patch.op`; ports the web app's `editCount` (`input.ops.length`) verbatim, keeping the two copies aligned per extension/AGENTS.md.
- extension/entrypoints/sidepanel/App.svelte:137 — `loadMatch()` had no request-id guard, so an earlier in-flight match load could overwrite state after a newer one completed; adds a `matchRequestId` counter checked before every state write.
- web/src/lib/assistant/AssistantChat.svelte:414 — switching sessions mid-turn unconditionally cleared the queued-but-unsent message array; now confirms before discarding a non-empty queue, matching `removeChat`'s existing confirm() pattern.
- web/src/lib/server/og/card.ts:21 — the doc comment claimed a 3-line clamp that never existed; adds the satori `-webkit-box`/`-webkit-line-clamp`/`text-overflow:ellipsis` combo actually needed to clamp it.
- web/src/lib/assistant/AssistantChat.svelte:152 — removed the orphaned `textareaEl` state and its dead auto-grow `$effect`, both leftovers from before the composer was extracted into Composer.svelte.
- web/src/lib/assistant/jobCache.ts:9 — the job cache never evicted successfully-resolved entries; adds a `MAX_ENTRIES` cap with least-recently-used eviction.
- web/src/routes/companies/[slug]/discussion/[threadId]/+page.server.ts:11 (and the identical gap in jobs/[slug]'s sibling) — `load()` never checked the resolved thread's `subject_type`/`subject_slug` against the URL; both routes now share a `loadThread` helper (`$lib/server/community.ts`) that 404s a thread resolving to the wrong subject.
- web/src/routes/my/tracking/[id]/+page.server.ts:14 — the sign-in redirect dropped `url.search`, unlike its four sibling routes; now carries `url.pathname + url.search` like the rest.
- web/src/routes/insights/roles/[category]/+page.server.ts:15 — the identical `insightsRoles({limit:200})` gate call, duplicated verbatim across 5 insights routes, is now a shared `loadInsightsGate` helper in `$lib/server/insights.ts` (mirrors the existing `$lib/server/tracking.ts` pattern).

One commit per finding; see individual commit messages for root-cause detail.

## Test plan

- [x] `extension/`: `npm run check` (0 errors), `npm run lint` (only pre-existing warnings), `npm test` (219/219 passing)
- [x] `web/`: `pnpm run check` (0 errors), `pnpm run lint` (only pre-existing warnings), `pnpm test` (963/963 passing, incl. new tests for jobCache eviction and thread-subject matching)
- [x] OG card title clamp verified visually via `scripts/og-smoke.mjs` plus an ad-hoc longer-title render (before: overflowed 5 lines; after: clamps at 3 with ellipsis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)