### PR TITLE
Fix 9 accounts/notifications/referral findings from the monorepo code review

### DIFF
--- a/internal/accountdelete/accountdelete.go
+++ b/internal/accountdelete/accountdelete.go
@@ -73,13 +73,27 @@ func New(repo Repository, blobs blobstore.Store, revoke RevokeFunc) *Service {
 
 // Delete erases the account and everything it owns, permanently.
 //
-// The order is deliberate. Object keys are collected first, because the mail and
-// referral-proof keys are only knowable through rows that are about to disappear.
-// Objects are then erased BEFORE the rows: if that fails, nothing has been deleted
-// and the member can retry, whereas the reverse order would strand their CV and raw
-// mail in the bucket with no key left to find them by. Object deletes are idempotent,
-// so a retry after a partial run is safe.
+// The order is deliberate: every step that can still hard-fail runs BEFORE the one
+// irrecoverable step, object deletion. Apple grants go first because a failure there
+// must abort deletion (the row is ON DELETE RESTRICT'd by apple_grants) — and it must
+// abort before anything unrecoverable has happened, not after. Object keys are
+// collected next, because the mail and referral-proof keys are only knowable through
+// rows that are about to disappear. Objects are then erased BEFORE the rows: if that
+// fails, nothing has been deleted and the member can retry, whereas the reverse order
+// would strand their CV and raw mail in the bucket with no key left to find them by.
+// Object deletes are idempotent, so a retry after a partial run is safe.
 func (s *Service) Delete(ctx context.Context, userID int64) error {
+	// Apple grants block the row itself (ON DELETE RESTRICT), so releasing them must
+	// happen before DeleteUser regardless — and, unlike the best-effort steps below, a
+	// failure here stops deletion instead of surfacing as a raw FK violation out of
+	// DeleteUser. It runs first of all so that a hard failure here leaves the account
+	// (and its objects) completely untouched, rather than aborting after the objects —
+	// which cannot be un-deleted — are already gone.
+	if s.appleGrants != nil {
+		if err := s.appleGrants(ctx, userID); err != nil {
+			return fmt.Errorf("accountdelete: release apple grants: %w", err)
+		}
+	}
 	if s.blobs != nil {
 		keys, err := s.repo.BlobKeys(ctx, userID)
 		if err != nil {
@@ -109,14 +123,6 @@ func (s *Service) Delete(ctx context.Context, userID int64) error {
 	if s.blockKey != nil {
 		if err := s.blockKey(ctx, userID); err != nil {
 			log.Printf("accountdelete: block gateway credential for user %d: %v", userID, err)
-		}
-	}
-	// Apple grants block the row itself (ON DELETE RESTRICT), so releasing them
-	// happens last and, unlike the best-effort steps above, a failure here stops
-	// deletion instead of surfacing as a raw FK violation out of DeleteUser.
-	if s.appleGrants != nil {
-		if err := s.appleGrants(ctx, userID); err != nil {
-			return fmt.Errorf("accountdelete: release apple grants: %w", err)
 		}
 	}
 	return s.repo.DeleteUser(ctx, userID)

--- a/internal/accountdelete/accountdelete_test.go
+++ b/internal/accountdelete/accountdelete_test.go
@@ -237,3 +237,29 @@ func TestDelete_AppleGrantsFailureBlocksDeletion(t *testing.T) {
 		t.Error("rows were deleted despite the FK still being blocked")
 	}
 }
+
+// The blob objects are irrecoverable once deleted; a step that can still hard-fail
+// (Apple grant release) must run before them, so a failure there leaves the objects —
+// and the account — completely untouched rather than stranding dangling object keys
+// on a row that survives because DeleteUser was never reached.
+func TestDelete_AppleGrantsFailureLeavesObjectsUntouched(t *testing.T) {
+	var calls []string
+	repo := &fakeRepo{keys: []string{"resumes/7"}, calls: &calls}
+	blobs := &fakeBlobs{calls: &calls}
+	svc := New(repo, blobs, nil).WithAppleGrants(func(context.Context, int64) error {
+		return errors.New("still has an active apple grant")
+	})
+
+	if err := svc.Delete(context.Background(), 7); err == nil {
+		t.Fatal("Delete succeeded despite a failed apple grant release")
+	}
+	if len(calls) != 0 {
+		t.Errorf("calls = %v, want no object-storage or row calls before the apple grant release fails", calls)
+	}
+	if len(blobs.deleted) != 0 {
+		t.Errorf("deleted objects = %v, want none deleted", blobs.deleted)
+	}
+	if repo.deleteSeen {
+		t.Error("rows were deleted despite the FK still being blocked")
+	}
+}

--- a/internal/auth/mobileauth/identities.go
+++ b/internal/auth/mobileauth/identities.go
@@ -35,9 +35,15 @@ func (s *Store) ListIdentities(ctx context.Context, userID int64) (IdentityList,
 	if err := s.pool.QueryRow(ctx, `SELECT password_hash IS NOT NULL FROM users WHERE id=$1`, userID).Scan(&out.HasPassword); err != nil {
 		return out, err
 	}
+	// bool_or, not bool_and: unlinkIdentityOnce (store.go) counts a provider as active if
+	// ANY of its identity rows is active, so a provider with one active row and one
+	// revocation_pending row (e.g. mid-drain of an earlier unlink) is a usable sign-in
+	// method there. Aggregating with bool_and instead would report that provider as
+	// non-active here, undercounting active providers and showing CanUnlink=false for a
+	// last-method check the backend would actually pass.
 	rows, err := s.pool.Query(ctx, `
 		SELECT provider,min(created_at),
-		       CASE WHEN bool_and(status='active') THEN 'active' ELSE 'revocation_pending' END
+		       CASE WHEN bool_or(status='active') THEN 'active' ELSE 'revocation_pending' END
 		FROM user_identities WHERE user_id=$1
 		GROUP BY provider ORDER BY provider`, userID)
 	if err != nil {

--- a/internal/auth/mobileauth/store_integration_test.go
+++ b/internal/auth/mobileauth/store_integration_test.go
@@ -112,6 +112,54 @@ func TestUnlinkCountsProviderAsOneUsableMethod(t *testing.T) {
 	}
 }
 
+// TestListIdentitiesActiveAggregationMatchesUnlinkGate reproduces the review finding:
+// ListIdentities used bool_and across a provider's rows to decide "active", while
+// unlinkIdentityOnce counts a provider as active if ANY of its rows is active. A provider
+// with one active identity and one still draining a prior unlink (revocation_pending) is
+// active by the backend's own rule, so the displayed CanUnlink hint must agree with what
+// UnlinkIdentity will actually accept.
+func TestListIdentitiesActiveAggregationMatchesUnlinkGate(t *testing.T) {
+	ctx, userID, store := seedAuthUser(t, false)
+	pool := store.pool
+	if _, err := pool.Exec(ctx, `INSERT INTO user_identities(provider,provider_user_id,user_id,status) VALUES('apple','apple-active',$1,'active')`, userID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO user_identities(provider,provider_user_id,user_id,status) VALUES('apple','apple-pending',$1,'revocation_pending')`, userID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO user_identities(provider,provider_user_id,user_id) VALUES('google','google-one',$1)`, userID); err != nil {
+		t.Fatal(err)
+	}
+
+	list, err := store.ListIdentities(ctx, userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var google Identity
+	found := false
+	for _, i := range list.Identities {
+		if i.Provider == "google" {
+			google, found = i, true
+		}
+	}
+	if !found {
+		t.Fatal("google identity missing from list")
+	}
+	if !google.CanUnlink {
+		t.Fatal("CanUnlink=false for google, want true: apple has an active row so it counts as a second usable method")
+	}
+
+	// The backend's own gate must agree with the hint just asserted above.
+	sessionHash := bytes.Repeat([]byte{9}, 32)
+	proof, _, err := recentauth.NewStore(pool, 0).Issue(ctx, userID, 1, sessionHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = store.UnlinkIdentity(ctx, userID, 1, sessionHash, "google", proof); err != nil {
+		t.Fatalf("UnlinkIdentity disagreed with the CanUnlink hint it should match: %v", err)
+	}
+}
+
 func TestFinalizeAppleGrantCannotOverwritePendingUnlink(t *testing.T) {
 	ctx, userID, store := seedAuthUser(t, true)
 	const subject, clientID = "apple-race-subject", "me.freehire.mobile"

--- a/internal/community/community.go
+++ b/internal/community/community.go
@@ -49,6 +49,9 @@ var (
 	ErrThreadNotFound = errors.New("community: thread not found")
 	// ErrThreadClosed is a reply to a thread a moderator has closed (409).
 	ErrThreadClosed = errors.New("community: thread is closed")
+	// ErrInvalidParentReply is a reply nested under a parentReplyID that does not
+	// belong to the thread being replied to (400).
+	ErrInvalidParentReply = errors.New("community: parent reply does not belong to this thread")
 	// ErrEmptyBody is a thread or reply submitted with no body text (422).
 	ErrEmptyBody = errors.New("community: body is required")
 	// ErrEmptyTitle is a thread submitted with no title (422).

--- a/internal/community/repository.go
+++ b/internal/community/repository.go
@@ -143,8 +143,11 @@ func (r *QueriesRepository) InsertReply(ctx context.Context, threadID, parentRep
 	}
 	row, err := r.q.InsertThreadReply(ctx, db.InsertThreadReplyParams{
 		ThreadID: threadID, ParentReplyID: parent,
-		AuthorUserID: pgtype.Int8{Int64: authorUserID, Valid: true}, Body: body,
+		AuthorUserID: authorUserID, Body: body,
 	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Reply{}, ErrInvalidParentReply
+	}
 	if err != nil {
 		return Reply{}, err
 	}

--- a/internal/community/service_test.go
+++ b/internal/community/service_test.go
@@ -95,6 +95,20 @@ func (f *fakeRepo) CloseThread(_ context.Context, id int64) error {
 }
 
 func (f *fakeRepo) InsertReply(_ context.Context, threadID, parentReplyID, author int64, body string) (Reply, error) {
+	// Mirrors InsertThreadReply's SQL guard: a non-zero parentReplyID must name a
+	// reply that belongs to this same threadID, not just any reply anywhere.
+	if parentReplyID != 0 {
+		found := false
+		for _, r := range f.replies[threadID] {
+			if r.ID == parentReplyID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return Reply{}, ErrInvalidParentReply
+		}
+	}
 	f.nextReply++
 	r := Reply{ID: f.nextReply, ThreadID: threadID, ParentID: parentReplyID, Body: body}
 	f.replies[threadID] = append(f.replies[threadID], r)
@@ -250,6 +264,28 @@ func TestReplyFlow(t *testing.T) {
 	}
 	if got := repo.threads[th.ID].ReplyCount; got != 1 {
 		t.Fatalf("reply_count = %d, want 1", got)
+	}
+}
+
+// A reply cannot be nested under a parent from a DIFFERENT thread — the review
+// finding: parentReplyID was passed straight to InsertReply with no check that it
+// belongs to threadID, so a caller could nest a reply under an unrelated thread's
+// reply.
+func TestReplyRejectsParentFromAnotherThread(t *testing.T) {
+	repo := newFakeRepo()
+	svc := newService(repo, "company/acme", "company/other")
+	threadA, _ := svc.CreateThread(context.Background(), CreateThreadInput{
+		UserID: 1, SubjectType: SubjectCompany, SubjectSlug: "acme", Title: "t", Body: "b"})
+	threadB, _ := svc.CreateThread(context.Background(), CreateThreadInput{
+		UserID: 1, SubjectType: SubjectCompany, SubjectSlug: "other", Title: "t2", Body: "b2"})
+
+	parent, err := svc.Reply(context.Background(), threadA.ID, 0, 2, "top level in A")
+	if err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+
+	if _, err := svc.Reply(context.Background(), threadB.ID, parent.ID, 3, "nested under A's reply"); !errors.Is(err, ErrInvalidParentReply) {
+		t.Fatalf("Reply across threads = %v, want ErrInvalidParentReply", err)
 	}
 }
 

--- a/internal/companyfeedback/companyfeedback.go
+++ b/internal/companyfeedback/companyfeedback.go
@@ -344,7 +344,12 @@ func (s *Service) Hide(ctx context.Context, feedbackID int64) error {
 	defer func() { _ = tx.Rollback(ctx) }()
 	q := s.q.WithTx(tx)
 
-	slug, err := q.HideCompanyFeedback(ctx, feedbackID)
+	// Read the company slug WITHOUT locking the feedback row (GetCompanyFeedbackSlug
+	// is a plain SELECT), so the company row can be locked BEFORE the feedback row is
+	// touched — the same order Upsert/Delete already use. Locking the feedback row
+	// first, the way HideCompanyFeedback's UPDATE would on its own, risks a deadlock
+	// against those paths' opposite order.
+	slug, err := q.GetCompanyFeedbackSlug(ctx, feedbackID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return ErrNotFound
@@ -352,6 +357,14 @@ func (s *Service) Hide(ctx context.Context, feedbackID int64) error {
 		return err
 	}
 	if err := q.LockCompanyForVote(ctx, slug); err != nil {
+		return err
+	}
+	if _, err := q.HideCompanyFeedback(ctx, feedbackID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// Deleted between the read above and this update — same outcome as
+			// never having existed.
+			return ErrNotFound
+		}
 		return err
 	}
 	if _, err := q.RecountCompanyFeedback(ctx, slug); err != nil {

--- a/internal/companyfeedback/companyfeedback_integration_test.go
+++ b/internal/companyfeedback/companyfeedback_integration_test.go
@@ -1,0 +1,122 @@
+//go:build integration
+
+// Integration tests for internal/companyfeedback's SQL-backed writes — Service is
+// bound directly to *db.Queries/*pgxpool.Pool with no fake seam, so these behaviors
+// can only be verified against a real Postgres. Run with:
+// go test -tags=integration ./internal/companyfeedback/
+package companyfeedback
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/testdb"
+	"github.com/strelov1/freehire/internal/vocab"
+)
+
+// fakePersonas hands out one fixed handle — Hide doesn't need a real persona
+// resolver, and Upsert only needs SOME handle to mint a feedback row through.
+type fakePersonas struct{}
+
+func (fakePersonas) PersonaFor(context.Context, int64) (string, error) { return "quiet-otter", nil }
+
+func insertCompany(t *testing.T, pool *pgxpool.Pool, slug, name string) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO companies (slug, name, job_count) VALUES ($1, $2, 1)`, slug, name); err != nil {
+		t.Fatalf("insert company %q: %v", slug, err)
+	}
+}
+
+func insertUser(t *testing.T, pool *pgxpool.Pool, email string) int64 {
+	t.Helper()
+	var id int64
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO users (email) VALUES ($1) RETURNING id`, email).Scan(&id); err != nil {
+		t.Fatalf("insert user %q: %v", email, err)
+	}
+	return id
+}
+
+func newTestService(t *testing.T) (*Service, *pgxpool.Pool) {
+	t.Helper()
+	pool := testdb.Pool(t)
+	if _, err := pool.Exec(context.Background(),
+		`TRUNCATE company_feedback, company_feedback_reports, companies, users RESTART IDENTITY CASCADE`); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	return New(db.New(pool), pool, fakePersonas{}, Config{}), pool
+}
+
+// Hide now reads the company slug (GetCompanyFeedbackSlug, unlocked) BEFORE locking
+// the company row, instead of locking the feedback row first via HideCompanyFeedback's
+// UPDATE — the fix for the lock-order mismatch against Upsert/Delete, which both lock
+// the company row first. This exercises the resulting call sequence end-to-end: a
+// hidden review stops counting toward the company's materialized counters and drops
+// out of the public list, in the same transaction.
+func TestHideRecomputesCountersAndDropsFromTheList(t *testing.T) {
+	svc, pool := newTestService(t)
+	insertCompany(t, pool, "acme", "Acme Corp")
+	ctx := context.Background()
+	reviewer := insertUser(t, pool, "reviewer1@example.test")
+
+	fb, summary, err := svc.Upsert(ctx, reviewer, "acme", 5, vocab.CompanyFeedbackTypeValues[0], "Great place to work")
+	if err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if summary.Count != 1 {
+		t.Fatalf("summary after upsert: count=%d, want 1", summary.Count)
+	}
+
+	if err := svc.Hide(ctx, fb.ID); err != nil {
+		t.Fatalf("Hide: %v", err)
+	}
+
+	list, err := svc.List(ctx, "acme", 10, 0)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 0 {
+		t.Errorf("List after Hide = %v, want empty (hidden reviews are excluded)", list)
+	}
+	count, err := svc.Count(ctx, "acme")
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("Count after Hide = %d, want 0", count)
+	}
+}
+
+// Hide is idempotent: hiding an already-hidden review is a no-op, not an error, since
+// HideCompanyFeedback's UPDATE matches on id alone (no status predicate).
+func TestHideIsIdempotent(t *testing.T) {
+	svc, pool := newTestService(t)
+	insertCompany(t, pool, "acme", "Acme Corp")
+	ctx := context.Background()
+	reviewer := insertUser(t, pool, "reviewer2@example.test")
+
+	fb, _, err := svc.Upsert(ctx, reviewer, "acme", 4, vocab.CompanyFeedbackTypeValues[0], "Solid team")
+	if err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if err := svc.Hide(ctx, fb.ID); err != nil {
+		t.Fatalf("first Hide: %v", err)
+	}
+	if err := svc.Hide(ctx, fb.ID); err != nil {
+		t.Errorf("second Hide (already hidden): %v, want nil", err)
+	}
+}
+
+func TestHideUnknownIDReturnsErrNotFound(t *testing.T) {
+	svc, pool := newTestService(t)
+	insertCompany(t, pool, "acme", "Acme Corp")
+
+	if err := svc.Hide(context.Background(), 999999); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Hide unknown id: err=%v, want ErrNotFound", err)
+	}
+}

--- a/internal/db/community.sql.go
+++ b/internal/db/community.sql.go
@@ -207,19 +207,33 @@ func (q *Queries) InsertThread(ctx context.Context, arg InsertThreadParams) (Thr
 }
 
 const insertThreadReply = `-- name: InsertThreadReply :one
+WITH validated AS (
+    SELECT $1::bigint AS thread_id,
+           $2::bigint AS parent_reply_id,
+           $3::bigint AS author_user_id,
+           $4::text AS body
+    WHERE $2::bigint IS NULL OR EXISTS (
+        SELECT 1 FROM thread_replies p
+        WHERE p.id = $2::bigint AND p.thread_id = $1::bigint
+    )
+)
 INSERT INTO thread_replies (thread_id, parent_reply_id, author_user_id, body)
-VALUES ($1, $2, $3, $4)
+SELECT thread_id, parent_reply_id, author_user_id, body FROM validated
 RETURNING id, thread_id, parent_reply_id, author_user_id, is_ai, body, created_at
 `
 
 type InsertThreadReplyParams struct {
 	ThreadID      int64       `json:"thread_id"`
 	ParentReplyID pgtype.Int8 `json:"parent_reply_id"`
-	AuthorUserID  pgtype.Int8 `json:"author_user_id"`
+	AuthorUserID  int64       `json:"author_user_id"`
 	Body          string      `json:"body"`
 }
 
-// parent_reply_id is NULL for a top-level reply, or another reply's id to nest under it.
+// parent_reply_id is NULL for a top-level reply, or another reply's id to nest under it
+// — constrained to a reply that belongs to the SAME thread_id, since the FK alone only
+// requires the parent row to exist somewhere in thread_replies, not in this thread. No
+// row is inserted (pgx.ErrNoRows) when parent_reply_id is set but names a reply outside
+// this thread.
 func (q *Queries) InsertThreadReply(ctx context.Context, arg InsertThreadReplyParams) (ThreadReply, error) {
 	row := q.db.QueryRow(ctx, insertThreadReply,
 		arg.ThreadID,

--- a/internal/db/community_author_deletion_integration_test.go
+++ b/internal/db/community_author_deletion_integration_test.go
@@ -42,13 +42,13 @@ func TestDeleteUserKeepsAuthoredCommunityContent(t *testing.T) {
 		t.Fatalf("insert thread: %v", err)
 	}
 	authorReply, err := q.InsertThreadReply(ctx, InsertThreadReplyParams{
-		ThreadID: thread.ID, AuthorUserID: pgtype.Int8{Int64: author, Valid: true}, Body: "Bumping my own question",
+		ThreadID: thread.ID, AuthorUserID: author, Body: "Bumping my own question",
 	})
 	if err != nil {
 		t.Fatalf("insert author reply: %v", err)
 	}
 	responderReply, err := q.InsertThreadReply(ctx, InsertThreadReplyParams{
-		ThreadID: thread.ID, AuthorUserID: pgtype.Int8{Int64: responder, Valid: true}, Body: "Four rounds over two weeks",
+		ThreadID: thread.ID, AuthorUserID: responder, Body: "Four rounds over two weeks",
 	})
 	if err != nil {
 		t.Fatalf("insert responder reply: %v", err)

--- a/internal/db/community_reply_parent_integration_test.go
+++ b/internal/db/community_reply_parent_integration_test.go
@@ -1,0 +1,74 @@
+//go:build integration
+
+// Integration test for InsertThreadReply's cross-thread parent guard — the review
+// finding: Reply()'s client-supplied parentReplyID was passed straight to
+// InsertReply with no check that it belongs to threadID, and the FK alone only
+// requires the parent row to exist SOMEWHERE in thread_replies, not in the same
+// thread. Only a real Postgres can verify the WITH-validated INSERT actually blocks
+// (and doesn't over-block) this. Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestInsertThreadReplyRejectsParentFromAnotherThread(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	if _, err := pool.Exec(ctx, "TRUNCATE threads, thread_replies, community_personas, users RESTART IDENTITY CASCADE"); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	author := insertUser(t, pool, "reply-author@example.test")
+
+	threadA, err := q.InsertThread(ctx, InsertThreadParams{
+		SubjectType: "company", SubjectRef: "acme", Title: "Thread A", Body: "body",
+		AuthorUserID: pgtype.Int8{Int64: author, Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("insert thread A: %v", err)
+	}
+	threadB, err := q.InsertThread(ctx, InsertThreadParams{
+		SubjectType: "company", SubjectRef: "acme", Title: "Thread B", Body: "body",
+		AuthorUserID: pgtype.Int8{Int64: author, Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("insert thread B: %v", err)
+	}
+
+	parentInA, err := q.InsertThreadReply(ctx, InsertThreadReplyParams{
+		ThreadID: threadA.ID, AuthorUserID: author, Body: "top level in A",
+	})
+	if err != nil {
+		t.Fatalf("insert top-level reply in A: %v", err)
+	}
+
+	// Same-thread nesting must still work.
+	if _, err := q.InsertThreadReply(ctx, InsertThreadReplyParams{
+		ThreadID: threadA.ID, ParentReplyID: pgtype.Int8{Int64: parentInA.ID, Valid: true}, AuthorUserID: author, Body: "nested in A",
+	}); err != nil {
+		t.Errorf("same-thread nested reply rejected: %v, want it to succeed", err)
+	}
+
+	// Cross-thread nesting (thread B's reply naming thread A's reply as parent) must
+	// be rejected — pgx.ErrNoRows, since the WHERE-validated INSERT inserts zero rows.
+	_, err = q.InsertThreadReply(ctx, InsertThreadReplyParams{
+		ThreadID: threadB.ID, ParentReplyID: pgtype.Int8{Int64: parentInA.ID, Valid: true}, AuthorUserID: author, Body: "nested under A's reply from B",
+	})
+	if !errors.Is(err, pgx.ErrNoRows) {
+		t.Errorf("cross-thread nested reply err = %v, want pgx.ErrNoRows", err)
+	}
+	var count int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM thread_replies WHERE thread_id = $1`, threadB.ID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Errorf("thread B reply count = %d, want 0 (the rejected insert must not land a row)", count)
+	}
+}

--- a/internal/db/company_feedback.sql.go
+++ b/internal/db/company_feedback.sql.go
@@ -71,6 +71,21 @@ func (q *Queries) DeleteCompanyFeedback(ctx context.Context, arg DeleteCompanyFe
 	return err
 }
 
+const getCompanyFeedbackSlug = `-- name: GetCompanyFeedbackSlug :one
+SELECT company_slug FROM company_feedback WHERE id = $1
+`
+
+// The company_slug for a review id, read (unlocked) BEFORE HideCompanyFeedback so
+// Service.Hide can take LockCompanyForVote before it touches the feedback row —
+// the same company-then-feedback lock order Upsert/Delete already use, needed to
+// avoid a lock-order deadlock with those paths. pgx.ErrNoRows on an unknown id.
+func (q *Queries) GetCompanyFeedbackSlug(ctx context.Context, id int64) (string, error) {
+	row := q.db.QueryRow(ctx, getCompanyFeedbackSlug, id)
+	var company_slug string
+	err := row.Scan(&company_slug)
+	return company_slug, err
+}
+
 const getMyCompanyFeedback = `-- name: GetMyCompanyFeedback :one
 SELECT id, user_id, company_slug, rating, feedback_type, body, created_at, updated_at, status FROM company_feedback WHERE user_id = $1 AND company_slug = $2
 `

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -3493,6 +3493,13 @@ type Querier interface {
 	// normalized by the service; excluded_skills may be empty; location_preferences is a
 	// validated JSONB block or NULL (no preferences).
 	UpsertUserProfile(ctx context.Context, arg UpsertUserProfileParams) (UserProfile, error)
+	// Same write as UpsertUserProfile, guarded on the row's updated_at still matching what the
+	// caller read. Used by MergeSkills, whose merge (which fields to keep, which skills to add)
+	// is computed in Go from a prior Get, outside any transaction: a Save() landing in that gap
+	// must not be silently clobbered by a write built from a now-stale snapshot. No matching row
+	// (updated_at moved, or the profile was deleted) returns zero rows; the caller re-reads and
+	// retries rather than overwriting blind.
+	UpsertUserProfileIfUnchanged(ctx context.Context, arg UpsertUserProfileIfUnchangedParams) (UserProfile, error)
 	// Apply one yc-oss directory entry, matched by slug. A new slug is inserted as a
 	// reference row (is_reference = true) with no jobs; an existing slug (job-backed or a
 	// prior reference) has its company-info columns plus the curated yc_batch/yc_status

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1080,6 +1080,11 @@ type Querier interface {
 	// the table grows columns (e.g. collections); an explicit subset makes sqlc emit a
 	// distinct row type and breaks the company-detail handler on every new column.
 	GetCompany(ctx context.Context, slug string) (Company, error)
+	// The company_slug for a review id, read (unlocked) BEFORE HideCompanyFeedback so
+	// Service.Hide can take LockCompanyForVote before it touches the feedback row —
+	// the same company-then-feedback lock order Upsert/Delete already use, needed to
+	// avoid a lock-order deadlock with those paths. pgx.ErrNoRows on an unknown id.
+	GetCompanyFeedbackSlug(ctx context.Context, id int64) (string, error)
 	// The observable application counts for one company. A company with no row has no
 	// observable applications at all, which the caller must treat as "not enough data"
 	// rather than as a zero response rate.

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1495,7 +1495,11 @@ type Querier interface {
 	// Open a thread. The author's handle is filled by the service from the minted
 	// persona, so no join is needed here.
 	InsertThread(ctx context.Context, arg InsertThreadParams) (Thread, error)
-	// parent_reply_id is NULL for a top-level reply, or another reply's id to nest under it.
+	// parent_reply_id is NULL for a top-level reply, or another reply's id to nest under it
+	// — constrained to a reply that belongs to the SAME thread_id, since the FK alone only
+	// requires the parent row to exist somewhere in thread_replies, not in this thread. No
+	// row is inserted (pgx.ErrNoRows) when parent_reply_id is set but names a reply outside
+	// this thread.
 	InsertThreadReply(ctx context.Context, arg InsertThreadReplyParams) (ThreadReply, error)
 	// Cursor read: has this rotated file (by content signature) been applied? The
 	// signature is stable across rename and gzip, so a re-run recognizes the same file.

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -2605,11 +2605,19 @@ type Querier interface {
 	// so a failed entry is never reprocessed within the same run. Mirrors
 	// RecordEnrichmentFailure.
 	RecordSemanticFailure(ctx context.Context, arg RecordSemanticFailureParams) (RecordSemanticFailureRow, error)
-	// Record that a job matched a subscription. The PK (subscription_id, job_id) makes
-	// this idempotent — re-scanning an already-recorded match is a no-op — so the
-	// worker can re-scan recent jobs freely without ever delivering twice. Returns the
-	// affected row count (1 = newly recorded, 0 = already known).
-	RecordSubscriptionMatch(ctx context.Context, arg RecordSubscriptionMatchParams) (int64, error)
+	// Record that a batch of (subscription, job) pairs matched, one round trip for
+	// however many pairs one query's search hits produced across every subscription that
+	// shares it — a popular query with many subscribers no longer costs one sequential
+	// INSERT per (hit, subscription) pair. The PK (subscription_id, job_id) makes this
+	// idempotent — re-scanning an already-recorded match is a no-op — so the worker can
+	// re-scan recent jobs freely without ever delivering twice. Returns the affected row
+	// count (newly recorded pairs; already-known pairs are silently skipped).
+	//
+	// Two same-length unnest calls in the SELECT list, not a two-argument unnest(a, b): the
+	// query analyzer cannot type the latter (see jobs.sql's MarkFuzzyDuplicatesForCompany,
+	// same pattern for the same reason); Postgres runs same-length SELECT-list set-returning
+	// functions in lockstep, pairing subscription_ids[i] with job_ids[i].
+	RecordSubscriptionMatches(ctx context.Context, arg RecordSubscriptionMatchesParams) (int64, error)
 	// Count a failed attempt: bump attempts, record the error, and dead-letter (set
 	// failed_at) once attempts reach the max. The lease (claimed_at) is intentionally
 	// left in place — its expiry gates the retry to a later run and doubles as the

--- a/internal/db/queries/community.sql
+++ b/internal/db/queries/community.sql
@@ -66,9 +66,23 @@ WHERE subject_type = $1 AND subject_ref = $2 AND status = 'open';
 UPDATE threads SET status = 'closed' WHERE id = $1;
 
 -- name: InsertThreadReply :one
--- parent_reply_id is NULL for a top-level reply, or another reply's id to nest under it.
+-- parent_reply_id is NULL for a top-level reply, or another reply's id to nest under it
+-- — constrained to a reply that belongs to the SAME thread_id, since the FK alone only
+-- requires the parent row to exist somewhere in thread_replies, not in this thread. No
+-- row is inserted (pgx.ErrNoRows) when parent_reply_id is set but names a reply outside
+-- this thread.
+WITH validated AS (
+    SELECT sqlc.arg(thread_id)::bigint AS thread_id,
+           sqlc.narg(parent_reply_id)::bigint AS parent_reply_id,
+           sqlc.arg(author_user_id)::bigint AS author_user_id,
+           sqlc.arg(body)::text AS body
+    WHERE sqlc.narg(parent_reply_id)::bigint IS NULL OR EXISTS (
+        SELECT 1 FROM thread_replies p
+        WHERE p.id = sqlc.narg(parent_reply_id)::bigint AND p.thread_id = sqlc.arg(thread_id)::bigint
+    )
+)
 INSERT INTO thread_replies (thread_id, parent_reply_id, author_user_id, body)
-VALUES ($1, $2, $3, $4)
+SELECT thread_id, parent_reply_id, author_user_id, body FROM validated
 RETURNING *;
 
 -- name: IncrementThreadReplyCount :exec

--- a/internal/db/queries/company_feedback.sql
+++ b/internal/db/queries/company_feedback.sql
@@ -60,6 +60,13 @@ RETURNING feedback_count, feedback_rating_avg;
 -- grows on genuine new-company writes.
 SELECT count(*) FROM company_feedback WHERE user_id = $1 AND created_at >= $2;
 
+-- name: GetCompanyFeedbackSlug :one
+-- The company_slug for a review id, read (unlocked) BEFORE HideCompanyFeedback so
+-- Service.Hide can take LockCompanyForVote before it touches the feedback row —
+-- the same company-then-feedback lock order Upsert/Delete already use, needed to
+-- avoid a lock-order deadlock with those paths. pgx.ErrNoRows on an unknown id.
+SELECT company_slug FROM company_feedback WHERE id = $1;
+
 -- name: HideCompanyFeedback :one
 -- The moderator lever: hide a specific review (idempotent — hiding an already-
 -- hidden row is a no-op). Returns the company_slug so the caller can recompute

--- a/internal/db/queries/subscriptions.sql
+++ b/internal/db/queries/subscriptions.sql
@@ -44,13 +44,22 @@ FROM subscriptions s
 JOIN saved_searches ss ON ss.id = s.saved_search_id
 WHERE s.active;
 
--- name: RecordSubscriptionMatch :execrows
--- Record that a job matched a subscription. The PK (subscription_id, job_id) makes
--- this idempotent — re-scanning an already-recorded match is a no-op — so the
--- worker can re-scan recent jobs freely without ever delivering twice. Returns the
--- affected row count (1 = newly recorded, 0 = already known).
+-- name: RecordSubscriptionMatches :execrows
+-- Record that a batch of (subscription, job) pairs matched, one round trip for
+-- however many pairs one query's search hits produced across every subscription that
+-- shares it — a popular query with many subscribers no longer costs one sequential
+-- INSERT per (hit, subscription) pair. The PK (subscription_id, job_id) makes this
+-- idempotent — re-scanning an already-recorded match is a no-op — so the worker can
+-- re-scan recent jobs freely without ever delivering twice. Returns the affected row
+-- count (newly recorded pairs; already-known pairs are silently skipped).
+--
+-- Two same-length unnest calls in the SELECT list, not a two-argument unnest(a, b): the
+-- query analyzer cannot type the latter (see jobs.sql's MarkFuzzyDuplicatesForCompany,
+-- same pattern for the same reason); Postgres runs same-length SELECT-list set-returning
+-- functions in lockstep, pairing subscription_ids[i] with job_ids[i].
 INSERT INTO subscription_matches (subscription_id, job_id)
-VALUES ($1, $2)
+SELECT unnest(sqlc.arg(subscription_ids)::bigint[]) AS subscription_id,
+       unnest(sqlc.arg(job_ids)::bigint[]) AS job_id
 ON CONFLICT (subscription_id, job_id) DO NOTHING;
 
 -- name: ClaimSubscriptionMatches :many

--- a/internal/db/queries/user_profiles.sql
+++ b/internal/db/queries/user_profiles.sql
@@ -20,6 +20,22 @@ SET specializations      = EXCLUDED.specializations,
     updated_at           = now()
 RETURNING *;
 
+-- name: UpsertUserProfileIfUnchanged :one
+-- Same write as UpsertUserProfile, guarded on the row's updated_at still matching what the
+-- caller read. Used by MergeSkills, whose merge (which fields to keep, which skills to add)
+-- is computed in Go from a prior Get, outside any transaction: a Save() landing in that gap
+-- must not be silently clobbered by a write built from a now-stale snapshot. No matching row
+-- (updated_at moved, or the profile was deleted) returns zero rows; the caller re-reads and
+-- retries rather than overwriting blind.
+UPDATE user_profiles
+SET specializations      = $2,
+    skills               = $3,
+    excluded_skills      = $4,
+    location_preferences = $5,
+    updated_at           = now()
+WHERE user_id = $1 AND updated_at = $6
+RETURNING *;
+
 -- name: DeleteUserProfile :execrows
 -- Remove the caller's profile. Returns the affected row count (0 when none existed); the
 -- handler treats delete as idempotent (204 either way).

--- a/internal/db/subscriptions.sql.go
+++ b/internal/db/subscriptions.sql.go
@@ -434,23 +434,32 @@ func (q *Queries) RecordMatchDeliveryFailure(ctx context.Context, arg RecordMatc
 	return err
 }
 
-const recordSubscriptionMatch = `-- name: RecordSubscriptionMatch :execrows
+const recordSubscriptionMatches = `-- name: RecordSubscriptionMatches :execrows
 INSERT INTO subscription_matches (subscription_id, job_id)
-VALUES ($1, $2)
+SELECT unnest($1::bigint[]) AS subscription_id,
+       unnest($2::bigint[]) AS job_id
 ON CONFLICT (subscription_id, job_id) DO NOTHING
 `
 
-type RecordSubscriptionMatchParams struct {
-	SubscriptionID int64 `json:"subscription_id"`
-	JobID          int64 `json:"job_id"`
+type RecordSubscriptionMatchesParams struct {
+	SubscriptionIds []int64 `json:"subscription_ids"`
+	JobIds          []int64 `json:"job_ids"`
 }
 
-// Record that a job matched a subscription. The PK (subscription_id, job_id) makes
-// this idempotent — re-scanning an already-recorded match is a no-op — so the
-// worker can re-scan recent jobs freely without ever delivering twice. Returns the
-// affected row count (1 = newly recorded, 0 = already known).
-func (q *Queries) RecordSubscriptionMatch(ctx context.Context, arg RecordSubscriptionMatchParams) (int64, error) {
-	result, err := q.db.Exec(ctx, recordSubscriptionMatch, arg.SubscriptionID, arg.JobID)
+// Record that a batch of (subscription, job) pairs matched, one round trip for
+// however many pairs one query's search hits produced across every subscription that
+// shares it — a popular query with many subscribers no longer costs one sequential
+// INSERT per (hit, subscription) pair. The PK (subscription_id, job_id) makes this
+// idempotent — re-scanning an already-recorded match is a no-op — so the worker can
+// re-scan recent jobs freely without ever delivering twice. Returns the affected row
+// count (newly recorded pairs; already-known pairs are silently skipped).
+//
+// Two same-length unnest calls in the SELECT list, not a two-argument unnest(a, b): the
+// query analyzer cannot type the latter (see jobs.sql's MarkFuzzyDuplicatesForCompany,
+// same pattern for the same reason); Postgres runs same-length SELECT-list set-returning
+// functions in lockstep, pairing subscription_ids[i] with job_ids[i].
+func (q *Queries) RecordSubscriptionMatches(ctx context.Context, arg RecordSubscriptionMatchesParams) (int64, error) {
+	result, err := q.db.Exec(ctx, recordSubscriptionMatches, arg.SubscriptionIds, arg.JobIds)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/subscriptions_integration_test.go
+++ b/internal/db/subscriptions_integration_test.go
@@ -40,6 +40,17 @@ func truncateSubs(t *testing.T, pool *pgxpool.Pool) {
 	}
 }
 
+// recordMatch records a single (subscription, job) match via the batched insert
+// RecordSubscriptionMatches replaced RecordSubscriptionMatch with, returning the
+// affected row count (1 = newly recorded, 0 = already known) for tests exercising the
+// single-pair case.
+func recordMatch(ctx context.Context, q *Queries, sub, job int64) (int64, error) {
+	return q.RecordSubscriptionMatches(ctx, RecordSubscriptionMatchesParams{
+		SubscriptionIds: []int64{sub},
+		JobIds:          []int64{job},
+	})
+}
+
 func TestSubscriptionCreate(t *testing.T) {
 	pool := startPostgres(t)
 	q := New(pool)
@@ -145,13 +156,46 @@ func TestSubscriptionMatchLedger(t *testing.T) {
 		sub := seed("ledger@example.test")
 		job := insertJob(t, pool, "j1")
 
-		first, err := q.RecordSubscriptionMatch(ctx, RecordSubscriptionMatchParams{SubscriptionID: sub, JobID: job})
+		first, err := recordMatch(ctx, q, sub, job)
 		if err != nil || first != 1 {
 			t.Fatalf("first record: rows=%d err=%v, want 1", first, err)
 		}
-		second, err := q.RecordSubscriptionMatch(ctx, RecordSubscriptionMatchParams{SubscriptionID: sub, JobID: job})
+		second, err := recordMatch(ctx, q, sub, job)
 		if err != nil || second != 0 {
 			t.Errorf("second record: rows=%d err=%v, want 0 (already recorded)", second, err)
+		}
+	})
+
+	// The batched insert (RecordSubscriptionMatches) is the actual fix: one round trip
+	// for a whole query's (subscription, job) pairs instead of one INSERT per pair.
+	// This exercises it with more than one pair, a mix of new and already-known ones.
+	t.Run("batched recording inserts new pairs and skips known ones", func(t *testing.T) {
+		truncateSubs(t, pool)
+		subA := seed("batch-a@example.test")
+		subB := seed("batch-b@example.test")
+		j1 := insertJob(t, pool, "b1")
+		j2 := insertJob(t, pool, "b2")
+
+		if _, err := recordMatch(ctx, q, subA, j1); err != nil {
+			t.Fatalf("seed known pair: %v", err)
+		}
+
+		n, err := q.RecordSubscriptionMatches(ctx, RecordSubscriptionMatchesParams{
+			SubscriptionIds: []int64{subA, subA, subB},
+			JobIds:          []int64{j1, j2, j1},
+		})
+		if err != nil {
+			t.Fatalf("batched record: %v", err)
+		}
+		if n != 2 {
+			t.Errorf("newly recorded = %d, want 2 (subA/j1 was already known)", n)
+		}
+		var total int
+		if err := pool.QueryRow(ctx, "SELECT count(*) FROM subscription_matches").Scan(&total); err != nil {
+			t.Fatal(err)
+		}
+		if total != 3 {
+			t.Errorf("total matches = %d, want 3 (1 seeded + 2 newly batched)", total)
 		}
 	})
 
@@ -161,7 +205,7 @@ func TestSubscriptionMatchLedger(t *testing.T) {
 		j1 := insertJob(t, pool, "c1")
 		j2 := insertJob(t, pool, "c2")
 		for _, j := range []int64{j1, j2} {
-			if _, err := q.RecordSubscriptionMatch(ctx, RecordSubscriptionMatchParams{SubscriptionID: sub, JobID: j}); err != nil {
+			if _, err := recordMatch(ctx, q, sub, j); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -186,7 +230,7 @@ func TestSubscriptionMatchLedger(t *testing.T) {
 		truncateSubs(t, pool)
 		sub := seed("stale@example.test")
 		job := insertJob(t, pool, "s1")
-		if _, err := q.RecordSubscriptionMatch(ctx, RecordSubscriptionMatchParams{SubscriptionID: sub, JobID: job}); err != nil {
+		if _, err := recordMatch(ctx, q, sub, job); err != nil {
 			t.Fatal(err)
 		}
 		if c, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 3600, BatchSize: 10}); err != nil || len(c) != 1 {
@@ -204,7 +248,7 @@ func TestSubscriptionMatchLedger(t *testing.T) {
 		truncateSubs(t, pool)
 		sub := seed("notified@example.test")
 		job := insertJob(t, pool, "n1")
-		if _, err := q.RecordSubscriptionMatch(ctx, RecordSubscriptionMatchParams{SubscriptionID: sub, JobID: job}); err != nil {
+		if _, err := recordMatch(ctx, q, sub, job); err != nil {
 			t.Fatal(err)
 		}
 		if _, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 3600, BatchSize: 10}); err != nil {
@@ -224,7 +268,7 @@ func TestSubscriptionMatchLedger(t *testing.T) {
 		truncateSubs(t, pool)
 		sub := seed("dead@example.test")
 		job := insertJob(t, pool, "d1")
-		if _, err := q.RecordSubscriptionMatch(ctx, RecordSubscriptionMatchParams{SubscriptionID: sub, JobID: job}); err != nil {
+		if _, err := recordMatch(ctx, q, sub, job); err != nil {
 			t.Fatal(err)
 		}
 		fail := RecordMatchDeliveryFailureParams{SubscriptionID: sub, JobIds: []int64{job}, LastError: "boom", MaxAttempts: 2}
@@ -253,7 +297,7 @@ func TestSubscriptionMatchLedger(t *testing.T) {
 			t.Fatal(err)
 		}
 		job := insertJob(t, pool, "i1")
-		if _, err := q.RecordSubscriptionMatch(ctx, RecordSubscriptionMatchParams{SubscriptionID: sub.ID, JobID: job}); err != nil {
+		if _, err := recordMatch(ctx, q, sub.ID, job); err != nil {
 			t.Fatal(err)
 		}
 		if _, err := q.SetSubscriptionActive(ctx, SetSubscriptionActiveParams{Active: false, ID: sub.ID, UserID: uid}); err != nil {
@@ -273,7 +317,7 @@ func TestSubscriptionMatchLedger(t *testing.T) {
 			t.Fatal(err)
 		}
 		job := insertJob(t, pool, "x1")
-		if _, err := q.RecordSubscriptionMatch(ctx, RecordSubscriptionMatchParams{SubscriptionID: sub.ID, JobID: job}); err != nil {
+		if _, err := recordMatch(ctx, q, sub.ID, job); err != nil {
 			t.Fatal(err)
 		}
 		rows, err := q.DeleteSubscription(ctx, DeleteSubscriptionParams{ID: sub.ID, UserID: uid})

--- a/internal/db/user_profiles.sql.go
+++ b/internal/db/user_profiles.sql.go
@@ -8,6 +8,8 @@ package db
 import (
 	"context"
 	"encoding/json"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const deleteUserProfile = `-- name: DeleteUserProfile :execrows
@@ -79,6 +81,54 @@ func (q *Queries) UpsertUserProfile(ctx context.Context, arg UpsertUserProfilePa
 		arg.Skills,
 		arg.ExcludedSkills,
 		arg.LocationPreferences,
+	)
+	var i UserProfile
+	err := row.Scan(
+		&i.UserID,
+		&i.Skills,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Specializations,
+		&i.LocationPreferences,
+		&i.ExcludedSkills,
+	)
+	return i, err
+}
+
+const upsertUserProfileIfUnchanged = `-- name: UpsertUserProfileIfUnchanged :one
+UPDATE user_profiles
+SET specializations      = $2,
+    skills               = $3,
+    excluded_skills      = $4,
+    location_preferences = $5,
+    updated_at           = now()
+WHERE user_id = $1 AND updated_at = $6
+RETURNING user_id, skills, created_at, updated_at, specializations, location_preferences, excluded_skills
+`
+
+type UpsertUserProfileIfUnchangedParams struct {
+	UserID              int64              `json:"user_id"`
+	Specializations     []string           `json:"specializations"`
+	Skills              []string           `json:"skills"`
+	ExcludedSkills      []string           `json:"excluded_skills"`
+	LocationPreferences json.RawMessage    `json:"location_preferences"`
+	UpdatedAt           pgtype.Timestamptz `json:"updated_at"`
+}
+
+// Same write as UpsertUserProfile, guarded on the row's updated_at still matching what the
+// caller read. Used by MergeSkills, whose merge (which fields to keep, which skills to add)
+// is computed in Go from a prior Get, outside any transaction: a Save() landing in that gap
+// must not be silently clobbered by a write built from a now-stale snapshot. No matching row
+// (updated_at moved, or the profile was deleted) returns zero rows; the caller re-reads and
+// retries rather than overwriting blind.
+func (q *Queries) UpsertUserProfileIfUnchanged(ctx context.Context, arg UpsertUserProfileIfUnchangedParams) (UserProfile, error) {
+	row := q.db.QueryRow(ctx, upsertUserProfileIfUnchanged,
+		arg.UserID,
+		arg.Specializations,
+		arg.Skills,
+		arg.ExcludedSkills,
+		arg.LocationPreferences,
+		arg.UpdatedAt,
 	)
 	var i UserProfile
 	err := row.Scan(

--- a/internal/handler/community.go
+++ b/internal/handler/community.go
@@ -274,6 +274,8 @@ func communityError(err error) error {
 		return fiber.NewError(fiber.StatusNotFound, "thread not found")
 	case errors.Is(err, community.ErrThreadClosed):
 		return fiber.NewError(fiber.StatusConflict, "thread is closed")
+	case errors.Is(err, community.ErrInvalidParentReply):
+		return fiber.NewError(fiber.StatusBadRequest, "parent reply does not belong to this thread")
 	case errors.Is(err, community.ErrEmptyTitle):
 		return fiber.NewError(fiber.StatusUnprocessableEntity, "title is required")
 	case errors.Is(err, community.ErrEmptyBody):

--- a/internal/handler/me_profile_test.go
+++ b/internal/handler/me_profile_test.go
@@ -43,6 +43,13 @@ func (f *fakeProfileRepo) Upsert(_ context.Context, userID int64, specialization
 	f.upserted = profileUpsert{UserID: userID, Specializations: specializations, Skills: skills, ExcludedSkills: excludedSkills, LocationPreferences: locationPreferences}
 	return f.upsertRet, nil
 }
+
+// UpsertIfUnchanged is exercised by userprofile's own tests (MergeSkills' retry loop);
+// no handler here calls MergeSkills, so this fake just satisfies the interface.
+func (f *fakeProfileRepo) UpsertIfUnchanged(_ context.Context, userID int64, specializations, skills, excludedSkills []string, locationPreferences json.RawMessage, _ time.Time) (userprofile.Profile, error) {
+	f.upserted = profileUpsert{UserID: userID, Specializations: specializations, Skills: skills, ExcludedSkills: excludedSkills, LocationPreferences: locationPreferences}
+	return f.upsertRet, nil
+}
 func (f *fakeProfileRepo) Delete(context.Context, int64) error { return f.delErr }
 
 // profileApp mounts the singleton profile endpoints behind RequireAuth on a handler whose

--- a/internal/handler/referrals.go
+++ b/internal/handler/referrals.go
@@ -139,6 +139,8 @@ func referralError(err error) error {
 	case errors.Is(err, referral.ErrProofRequired),
 		errors.Is(err, referral.ErrInvalidLinkedIn),
 		errors.Is(err, referral.ErrNoContact),
+		errors.Is(err, referral.ErrContactTooLong),
+		errors.Is(err, referral.ErrNoteTooLong),
 		errors.Is(err, referral.ErrInvalidCVChoice),
 		errors.Is(err, referral.ErrNoResume):
 		return fiber.NewError(fiber.StatusUnprocessableEntity, err.Error())

--- a/internal/notify/match.go
+++ b/internal/notify/match.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/url"
 	"time"
@@ -55,6 +56,11 @@ func (r *Runner) matchQuery(ctx context.Context, query string, subs []db.ListAct
 		return err
 	}
 
+	// Collect every (subscription, job) pair this query's hits produced across every
+	// subscription that shares it, then record the whole batch in one round trip —
+	// a popular query with many subscribers no longer costs one sequential INSERT per
+	// (hit, subscription) pair.
+	var subIDs, jobIDs []int64
 	for _, hit := range res.Hits {
 		created, ok := hitCreatedAt(hit)
 		if !ok {
@@ -69,17 +75,21 @@ func (r *Runner) matchQuery(ctx context.Context, query string, subs []db.ListAct
 			if created.Before(s.StartAt.Time) {
 				continue
 			}
-			n, err := r.store.RecordSubscriptionMatch(ctx, db.RecordSubscriptionMatchParams{
-				SubscriptionID: s.ID,
-				JobID:          hit.ID,
-			})
-			if err != nil {
-				log.Printf("notify: record match sub=%d job=%d: %v", s.ID, hit.ID, err)
-				continue
-			}
-			stats.Matched += int(n) // n is 1 for a newly recorded match, 0 if already known
+			subIDs = append(subIDs, s.ID)
+			jobIDs = append(jobIDs, hit.ID)
 		}
 	}
+	if len(subIDs) == 0 {
+		return nil
+	}
+	n, err := r.store.RecordSubscriptionMatches(ctx, db.RecordSubscriptionMatchesParams{
+		SubscriptionIds: subIDs,
+		JobIds:          jobIDs,
+	})
+	if err != nil {
+		return fmt.Errorf("record matches: %w", err)
+	}
+	stats.Matched += int(n) // n is the count of newly recorded pairs; already-known pairs are skipped
 	return nil
 }
 

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -87,7 +87,7 @@ type Searcher interface {
 // Store is the persistence the engine needs. *db.Queries satisfies it directly.
 type Store interface {
 	ListActiveSubscriptions(ctx context.Context) ([]db.ListActiveSubscriptionsRow, error)
-	RecordSubscriptionMatch(ctx context.Context, arg db.RecordSubscriptionMatchParams) (int64, error)
+	RecordSubscriptionMatches(ctx context.Context, arg db.RecordSubscriptionMatchesParams) (int64, error)
 	ClaimSubscriptionMatches(ctx context.Context, arg db.ClaimSubscriptionMatchesParams) ([]db.ClaimSubscriptionMatchesRow, error)
 	GetSubscriptionForDelivery(ctx context.Context, id int64) (db.GetSubscriptionForDeliveryRow, error)
 	GetJobsForDigest(ctx context.Context, jobIds []int64) ([]db.GetJobsForDigestRow, error)

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -36,11 +36,12 @@ func (f *fakeSearcher) Search(_ context.Context, p search.SearchParams) (search.
 type recordedMatch struct{ sub, job int64 }
 
 type fakeStore struct {
-	active     []db.ListActiveSubscriptionsRow
-	recorded   []recordedMatch
-	claimed    []db.ClaimSubscriptionMatchesRow
-	delivery   map[int64]db.GetSubscriptionForDeliveryRow
-	digestJobs map[int64]db.GetJobsForDigestRow
+	active      []db.ListActiveSubscriptionsRow
+	recorded    []recordedMatch
+	recordCalls int // how many times RecordSubscriptionMatches was called, not how many pairs
+	claimed     []db.ClaimSubscriptionMatchesRow
+	delivery    map[int64]db.GetSubscriptionForDeliveryRow
+	digestJobs  map[int64]db.GetJobsForDigestRow
 
 	notified   []db.MarkMatchesNotifiedParams
 	failures   []db.RecordMatchDeliveryFailureParams
@@ -55,14 +56,25 @@ func (s *fakeStore) ListActiveSubscriptions(context.Context) ([]db.ListActiveSub
 	return s.active, nil
 }
 
-func (s *fakeStore) RecordSubscriptionMatch(_ context.Context, a db.RecordSubscriptionMatchParams) (int64, error) {
-	for _, m := range s.recorded {
-		if m.sub == a.SubscriptionID && m.job == a.JobID {
-			return 0, nil // already recorded → idempotent no-op
+func (s *fakeStore) RecordSubscriptionMatches(_ context.Context, a db.RecordSubscriptionMatchesParams) (int64, error) {
+	s.recordCalls++
+	var n int64
+	for i, subID := range a.SubscriptionIds {
+		jobID := a.JobIds[i]
+		known := false
+		for _, m := range s.recorded {
+			if m.sub == subID && m.job == jobID {
+				known = true // already recorded → idempotent no-op
+				break
+			}
 		}
+		if known {
+			continue
+		}
+		s.recorded = append(s.recorded, recordedMatch{subID, jobID})
+		n++
 	}
-	s.recorded = append(s.recorded, recordedMatch{a.SubscriptionID, a.JobID})
-	return 1, nil
+	return n, nil
 }
 
 func (s *fakeStore) ClaimSubscriptionMatches(context.Context, db.ClaimSubscriptionMatchesParams) ([]db.ClaimSubscriptionMatchesRow, error) {
@@ -155,6 +167,41 @@ func TestMatch_SharedQueryHitsIndexOnce(t *testing.T) {
 	// Both subscriptions on the shared query get the match.
 	if len(store.recorded) != 2 {
 		t.Fatalf("recorded matches = %d, want 2", len(store.recorded))
+	}
+}
+
+// One query, many subscribers, many hits: the review finding was that matchQuery issued
+// one sequential RecordSubscriptionMatch round trip per (hit, subscription) pair. It must
+// now record the whole batch in a single call, regardless of how many pairs that is.
+func TestMatch_BatchesMatchesIntoOneCallPerQuery(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	store := &fakeStore{
+		active: []db.ListActiveSubscriptionsRow{
+			{ID: 1, Query: "seniority=senior", StartAt: ts(base)},
+			{ID: 2, Query: "seniority=senior", StartAt: ts(base)},
+			{ID: 3, Query: "seniority=senior", StartAt: ts(base)},
+		},
+	}
+	searcher := &fakeSearcher{results: []search.SearchResult{
+		{Hits: []search.JobDocument{
+			hit(100, base.Add(time.Hour)),
+			hit(101, base.Add(2*time.Hour)),
+		}},
+	}}
+	r := New(store, searcher, &fakeNotifier{}, DefaultConfig())
+
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store.recordCalls != 1 {
+		t.Errorf("RecordSubscriptionMatches calls = %d, want 1 for 3 subscribers x 2 hits", store.recordCalls)
+	}
+	if len(store.recorded) != 6 {
+		t.Fatalf("recorded matches = %d, want 6 (3 subscriptions x 2 hits)", len(store.recorded))
+	}
+	if stats.Matched != 6 {
+		t.Errorf("stats.Matched = %d, want 6", stats.Matched)
 	}
 }
 

--- a/internal/pushnotify/pushnotify.go
+++ b/internal/pushnotify/pushnotify.go
@@ -224,6 +224,7 @@ func (n *ExpoNotifier) CheckReceipts(ctx context.Context) error {
 	}
 
 	processed := make([]int64, 0, len(due))
+	var pruneErrs []error
 	for _, t := range due {
 		r, ok := receipts[t.TicketID]
 		if !ok {
@@ -236,14 +237,26 @@ func (n *ExpoNotifier) CheckReceipts(ctx context.Context) error {
 		}
 		if r.Details.Error == deviceNotRegistered {
 			if err := n.pruner.PruneDeadPushToken(ctx, t.Token); err != nil {
-				return fmt.Errorf("pushnotify: prune dead token: %w", err)
+				// Keep going rather than returning here: an earlier ticket in
+				// this same batch may already be fully resolved, and bailing
+				// out now would discard that work by never reaching the
+				// DeletePushTickets call below. This ticket itself is left
+				// out of processed, so it stays queued and the prune is
+				// retried on the next scheduled pass.
+				pruneErrs = append(pruneErrs, fmt.Errorf("prune dead token: %w", err))
+				continue
 			}
 		}
 		processed = append(processed, t.ID)
 	}
 
-	if err := n.tickets.DeletePushTickets(ctx, processed); err != nil {
-		return fmt.Errorf("pushnotify: delete processed tickets: %w", err)
+	if len(processed) > 0 {
+		if err := n.tickets.DeletePushTickets(ctx, processed); err != nil {
+			return fmt.Errorf("pushnotify: delete processed tickets: %w", err)
+		}
+	}
+	if err := errors.Join(pruneErrs...); err != nil {
+		return fmt.Errorf("pushnotify: %w", err)
 	}
 	return nil
 }

--- a/internal/pushnotify/pushnotify_test.go
+++ b/internal/pushnotify/pushnotify_test.go
@@ -11,11 +11,17 @@ import (
 
 // fakePruner records which tokens were pruned, so tests can assert the
 // notifier calls it exactly when Expo reports a token permanently dead.
+// errFor lets a test make a specific token's prune call fail, to exercise
+// CheckReceipts' handling of a partial-batch prune failure.
 type fakePruner struct {
 	pruned []string
+	errFor map[string]error
 }
 
 func (p *fakePruner) PruneDeadPushToken(ctx context.Context, token string) error {
+	if err := p.errFor[token]; err != nil {
+		return err
+	}
 	p.pruned = append(p.pruned, token)
 	return nil
 }
@@ -367,5 +373,35 @@ func TestExpoNotifier_CheckReceipts_TicketAbsentFromResponseIsLeftQueued(t *test
 	}
 	if len(store.deleted) != 1 || store.deleted[0] != 1 {
 		t.Errorf("deleted ticket ids = %v, want [1] — only the answered ticket", store.deleted)
+	}
+}
+
+// A PruneDeadPushToken failure partway through a batch must not discard the
+// cleanup already done for tickets processed earlier in the same run: those
+// still get deleted from the outbox, and only the ticket whose prune call
+// failed stays queued for retry on the next scheduled pass.
+func TestExpoNotifier_CheckReceipts_PartialPruneFailureKeepsEarlierProgress(t *testing.T) {
+	srv := stubExpoReceipts(t, map[string]map[string]any{
+		"ticket-ok-first":  {"status": "error", "message": "not delivered", "details": map[string]any{"error": "DeviceNotRegistered"}},
+		"ticket-prune-err": {"status": "error", "message": "not delivered", "details": map[string]any{"error": "DeviceNotRegistered"}},
+	})
+	pruneErr := errors.New("transient db error")
+	pruner := &fakePruner{errFor: map[string]error{"ExponentPushToken[prune-err]": pruneErr}}
+	store := &fakeTicketStore{due: []Ticket{
+		{ID: 1, Token: "ExponentPushToken[ok-first]", TicketID: "ticket-ok-first"},
+		{ID: 2, Token: "ExponentPushToken[prune-err]", TicketID: "ticket-prune-err"},
+	}}
+	n := newTestNotifier(pruner, &fakeQueuer{}, store)
+	n.receiptsURL = srv.URL
+
+	err := n.CheckReceipts(context.Background())
+	if err == nil {
+		t.Fatal("CheckReceipts: want an error surfaced from the failed prune")
+	}
+	if len(pruner.pruned) != 1 || pruner.pruned[0] != "ExponentPushToken[ok-first]" {
+		t.Errorf("pruned = %v, want [ExponentPushToken[ok-first]]", pruner.pruned)
+	}
+	if len(store.deleted) != 1 || store.deleted[0] != 1 {
+		t.Errorf("deleted ticket ids = %v, want [1] — the ticket whose prune failed stays queued for retry", store.deleted)
 	}
 }

--- a/internal/referral/referral.go
+++ b/internal/referral/referral.go
@@ -93,6 +93,26 @@ var (
 	// ErrNotAuthorized is a referrer acting on / viewing a request for a company they are not
 	// an approved referrer of (403).
 	ErrNotAuthorized = errors.New("referral: not an approved referrer for this company")
+	// ErrNoteTooLong is a request note over maxNoteLen (422).
+	ErrNoteTooLong = errors.New("referral: note is too long")
+	// ErrContactTooLong is a Telegram handle or email over maxContactLen (422).
+	ErrContactTooLong = errors.New("referral: contact is too long")
+)
+
+// Free-text length bounds (the content-field convention: report.maxDetailsLen,
+// companyfeedback.maxBodyRunes), applied where sibling packages already cap their
+// equivalent user-supplied text — this package had been the gap.
+const (
+	// maxNoteLen bounds a request's free-text note.
+	maxNoteLen = 5000
+	// maxContactLen bounds ContactTelegram and ContactEmail — generous for either shape
+	// (a Telegram handle/t.me link or an email address, RFC 5321's own 254-byte cap)
+	// while still bounding what a request can carry.
+	maxContactLen = 254
+	// maxLinkedInURLLen bounds LinkedInURL (on both OfferInput and RequestInput, via
+	// validLinkedInURL below) — generous for a real linkedin.com/in/<handle> URL,
+	// including a country subdomain and a trailing query/fragment, while still bounded.
+	maxLinkedInURLLen = 500
 )
 
 // Offer is a stored referral offer, decoupled from the generated db row. The pointer
@@ -320,6 +340,9 @@ func (s *Service) CreateRequest(ctx context.Context, in RequestInput) (Request, 
 	if !validLinkedInURL(in.LinkedInURL) {
 		return Request{}, ErrInvalidLinkedIn
 	}
+	if len(strings.TrimSpace(in.Note)) > maxNoteLen {
+		return Request{}, ErrNoteTooLong
+	}
 	if err := validateCVChoice(in); err != nil {
 		return Request{}, err
 	}
@@ -433,19 +456,29 @@ func (s *Service) notifyReferrers(ctx context.Context, companySlug string) {
 	}
 }
 
-// validateContact requires at least one non-blank contact channel.
+// validateContact requires at least one non-blank contact channel, and bounds whichever
+// channels are given.
 func validateContact(in RequestInput) error {
-	if strings.TrimSpace(in.ContactTelegram) == "" && strings.TrimSpace(in.ContactEmail) == "" {
+	telegram, email := strings.TrimSpace(in.ContactTelegram), strings.TrimSpace(in.ContactEmail)
+	if telegram == "" && email == "" {
 		return ErrNoContact
+	}
+	if len(telegram) > maxContactLen || len(email) > maxContactLen {
+		return ErrContactTooLong
 	}
 	return nil
 }
 
 // validLinkedInURL reports whether s is a LinkedIn personal-profile URL: an http(s) URL on
-// linkedin.com (optionally a country/www subdomain) whose path is /in/<handle>. This is a
-// shape check, not a liveness check — it only asserts the link is the right kind of thing.
+// linkedin.com (optionally a country/www subdomain) whose path is /in/<handle>, no longer
+// than maxLinkedInURLLen. This is a shape check, not a liveness check — it only asserts the
+// link is the right kind of thing (and not an unbounded payload riding along as one).
 func validLinkedInURL(s string) bool {
-	u, err := url.Parse(strings.TrimSpace(s))
+	s = strings.TrimSpace(s)
+	if len(s) > maxLinkedInURLLen {
+		return false
+	}
+	u, err := url.Parse(s)
 	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
 		return false
 	}

--- a/internal/referral/referral_test.go
+++ b/internal/referral/referral_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/google/uuid"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -224,6 +225,9 @@ func TestValidLinkedInURL(t *testing.T) {
 	invalid := []string{
 		"", "   ", "linkedin.com/in/jane", "https://linkedin.com/", "https://linkedin.com/company/acme",
 		"https://notlinkedin.com/in/jane", "https://linkedin.com.evil.com/in/jane", "ftp://linkedin.com/in/jane",
+		// Otherwise well-formed, but past maxLinkedInURLLen — an unbounded payload
+		// riding along inside a field with no explicit length check before this.
+		"https://www.linkedin.com/in/" + strings.Repeat("j", maxLinkedInURLLen),
 	}
 	for _, s := range invalid {
 		if validLinkedInURL(s) {
@@ -334,6 +338,10 @@ func TestCreateRequestValidation(t *testing.T) {
 		{"original with cv id", withCV(base, CVOriginal, cvID(testCVID)), ErrInvalidCVChoice},
 		{"built without cv id", withCV(base, CVBuilt, nil), ErrInvalidCVChoice},
 		{"unknown kind", withCV(base, "weird", nil), ErrInvalidCVChoice},
+		{"note too long", withNote(base, strings.Repeat("n", maxNoteLen+1)), ErrNoteTooLong},
+		{"telegram contact too long", withTelegram(base, strings.Repeat("t", maxContactLen+1)), ErrContactTooLong},
+		{"email contact too long", withEmail(base, strings.Repeat("e", maxContactLen+1)+"@x.test"), ErrContactTooLong},
+		{"linkedin url too long", withLinkedIn(base, "https://www.linkedin.com/in/"+strings.Repeat("j", maxLinkedInURLLen)), ErrInvalidLinkedIn},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -489,5 +497,29 @@ func TestAuthorizeCVAccess(t *testing.T) {
 func withCV(in RequestInput, kind string, id *uuid.UUID) RequestInput {
 	in.CVKind = kind
 	in.CVID = id
+	return in
+}
+
+// withNote returns a copy of in with Note replaced.
+func withNote(in RequestInput, note string) RequestInput {
+	in.Note = note
+	return in
+}
+
+// withTelegram returns a copy of in with ContactTelegram replaced.
+func withTelegram(in RequestInput, telegram string) RequestInput {
+	in.ContactTelegram = telegram
+	return in
+}
+
+// withEmail returns a copy of in with ContactEmail replaced.
+func withEmail(in RequestInput, email string) RequestInput {
+	in.ContactEmail = email
+	return in
+}
+
+// withLinkedIn returns a copy of in with LinkedInURL replaced.
+func withLinkedIn(in RequestInput, url string) RequestInput {
+	in.LinkedInURL = url
 	return in
 }

--- a/internal/savedsearch/savedsearch.go
+++ b/internal/savedsearch/savedsearch.go
@@ -26,6 +26,8 @@ var (
 	ErrNotFound = errors.New("savedsearch: not found")
 	// ErrInvalidAuthorLabel is an over-long board author label (mapped to 400).
 	ErrInvalidAuthorLabel = errors.New("savedsearch: author label must be at most 60 characters")
+	// ErrQueryTooLong is a query string over maxQueryLen (mapped to 400).
+	ErrQueryTooLong = errors.New("savedsearch: query is too long")
 	// ErrSlugTaken is a public-slug UNIQUE collision on share. It is an internal retry
 	// signal (Share regenerates the suffix and tries again), not a client-facing status.
 	ErrSlugTaken = errors.New("savedsearch: public slug already taken")
@@ -42,6 +44,14 @@ const (
 	maxPerUser = 50
 	// maxAuthorLabelLen bounds a board's optional author label.
 	maxAuthorLabelLen = 60
+	// maxQueryLen bounds the stored query string, the same way maxNameLen bounds name.
+	// query is a URL-encoded SPA filter state (facet params, not prose), so real values
+	// run to a few hundred characters even with many facets selected; 2000 leaves
+	// generous headroom while keeping a stored query far short of the point where
+	// re-parsing it on every internal/notify pass (url.ParseQuery, once per distinct
+	// query per pass) becomes the cost this bound exists to avoid. The migration's
+	// CHECK is the backstop.
+	maxQueryLen = 2000
 )
 
 // SavedSearch is a stored named filter snapshot: the package domain type, decoupled from
@@ -117,6 +127,9 @@ func (s *Service) Create(ctx context.Context, userID int64, name, query string, 
 	if err != nil {
 		return SavedSearch{}, err
 	}
+	if err := validQuery(query); err != nil {
+		return SavedSearch{}, err
+	}
 	count, err := s.repo.Count(ctx, userID)
 	if err != nil {
 		return SavedSearch{}, err
@@ -139,6 +152,11 @@ func (s *Service) Update(ctx context.Context, userID, id int64, name, query *str
 		}
 		name = &valid
 	}
+	if query != nil {
+		if err := validQuery(*query); err != nil {
+			return SavedSearch{}, err
+		}
+	}
 	return s.repo.Update(ctx, id, userID, name, query)
 }
 
@@ -157,4 +175,14 @@ func validName(name string) (string, error) {
 		return "", ErrInvalidName
 	}
 	return name, nil
+}
+
+// validQuery enforces the maxQueryLen bound (counted in runes, matching validName and
+// the DB CHECK's character semantics). Unlike name, an empty query is valid — it is the
+// unfiltered "show all" view — so this only ever rejects an over-long value.
+func validQuery(query string) error {
+	if utf8.RuneCountInString(query) > maxQueryLen {
+		return ErrQueryTooLong
+	}
+	return nil
 }

--- a/internal/savedsearch/savedsearch_test.go
+++ b/internal/savedsearch/savedsearch_test.go
@@ -210,6 +210,31 @@ func TestCreate_NameLengthCountsRunes(t *testing.T) {
 	}
 }
 
+// The query is a client-supplied URL-encoded filter string, re-parsed on every
+// internal/notify pass — the review finding was that, unlike name, it carried no
+// length bound anywhere.
+func TestCreate_RejectsOverLongQuery(t *testing.T) {
+	repo := &fakeRepo{}
+	_, err := savedsearch.New(repo).Create(context.Background(), 7, "Huge query", strings.Repeat("q", 2001), false)
+	if !errors.Is(err, savedsearch.ErrQueryTooLong) {
+		t.Errorf("err = %v, want ErrQueryTooLong", err)
+	}
+	if repo.createCalled {
+		t.Error("repo.Create should not be called on an over-long query")
+	}
+}
+
+func TestCreate_AcceptsQueryAtTheLengthCap(t *testing.T) {
+	repo := &fakeRepo{createRet: savedsearch.SavedSearch{ID: 1}}
+	_, err := savedsearch.New(repo).Create(context.Background(), 7, "At the cap", strings.Repeat("q", 2000), false)
+	if err != nil {
+		t.Errorf("query at the 2000-char cap: err = %v, want nil", err)
+	}
+	if !repo.createCalled {
+		t.Error("repo.Create should be called for a query at the cap")
+	}
+}
+
 func TestCreate_EnforcesCap(t *testing.T) {
 	repo := &fakeRepo{count: 50} // already at the cap
 	_, err := savedsearch.New(repo).Create(context.Background(), 7, "One more", "", false)
@@ -283,6 +308,18 @@ func TestUpdate_RejectsInvalidName(t *testing.T) {
 	}
 	if repo.updateCalled {
 		t.Error("repo.Update should not be called on an invalid name")
+	}
+}
+
+func TestUpdate_RejectsOverLongQuery(t *testing.T) {
+	repo := &fakeRepo{}
+	huge := strings.Repeat("q", 2001)
+	_, err := savedsearch.New(repo).Update(context.Background(), 7, 5, nil, &huge)
+	if !errors.Is(err, savedsearch.ErrQueryTooLong) {
+		t.Errorf("err = %v, want ErrQueryTooLong", err)
+	}
+	if repo.updateCalled {
+		t.Error("repo.Update should not be called on an over-long query")
 	}
 }
 

--- a/internal/userprofile/repository.go
+++ b/internal/userprofile/repository.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/pgconv"
@@ -47,6 +49,26 @@ func (r *QueriesRepository) Upsert(ctx context.Context, userID int64, specializa
 		ExcludedSkills:      excludedSkills,
 		LocationPreferences: locationPreferences,
 	})
+	if err != nil {
+		return Profile{}, err
+	}
+	return profileFromRow(row), nil
+}
+
+// UpsertIfUnchanged behaves like Upsert but only writes when the row's updated_at still
+// matches expectedUpdatedAt, mapping no matching row to ErrConflict.
+func (r *QueriesRepository) UpsertIfUnchanged(ctx context.Context, userID int64, specializations, skills, excludedSkills []string, locationPreferences json.RawMessage, expectedUpdatedAt time.Time) (Profile, error) {
+	row, err := r.q.UpsertUserProfileIfUnchanged(ctx, db.UpsertUserProfileIfUnchangedParams{
+		UserID:              userID,
+		Specializations:     specializations,
+		Skills:              skills,
+		ExcludedSkills:      excludedSkills,
+		LocationPreferences: locationPreferences,
+		UpdatedAt:           pgtype.Timestamptz{Time: expectedUpdatedAt, Valid: true},
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Profile{}, ErrConflict
+	}
 	if err != nil {
 		return Profile{}, err
 	}

--- a/internal/userprofile/userprofile.go
+++ b/internal/userprofile/userprofile.go
@@ -36,7 +36,17 @@ var (
 	// ErrNotFound is the caller having no profile yet (mapped to a null payload on GET,
 	// 404 on the verdict/ATS sub-resources).
 	ErrNotFound = errors.New("userprofile: not found")
+	// ErrConflict is a guarded write (UpsertIfUnchanged) landing after the row it read
+	// changed underneath it — used internally by MergeSkills' retry loop, never
+	// returned to a Save() caller.
+	ErrConflict = errors.New("userprofile: profile changed concurrently")
 )
+
+// mergeSkillsMaxAttempts bounds MergeSkills' read-merge-write retry when a concurrent
+// Save() keeps winning the race. MergeSkills is a background courtesy sync (see its own
+// doc comment) with no user waiting on it, so giving up quietly after a few attempts is
+// the right failure mode, not an unbounded retry loop.
+const mergeSkillsMaxAttempts = 3
 
 // maxSpecializations caps how many specializations one profile may combine; the
 // migration's cardinality CHECK is the backstop.
@@ -83,6 +93,12 @@ type Profile struct {
 type Repository interface {
 	Get(ctx context.Context, userID int64) (Profile, error)
 	Upsert(ctx context.Context, userID int64, specializations, skills, excludedSkills []string, locationPreferences json.RawMessage) (Profile, error)
+	// UpsertIfUnchanged behaves like Upsert but writes only when the row's updated_at
+	// still equals expectedUpdatedAt — the guard MergeSkills needs because its merge is
+	// computed from a prior Get outside any transaction, so a Save() landing in that
+	// gap must not be silently overwritten by a write built from a now-stale snapshot.
+	// No matching row (updated_at moved, or the profile was deleted) maps to ErrConflict.
+	UpsertIfUnchanged(ctx context.Context, userID int64, specializations, skills, excludedSkills []string, locationPreferences json.RawMessage, expectedUpdatedAt time.Time) (Profile, error)
 	Delete(ctx context.Context, userID int64) error
 }
 
@@ -143,7 +159,28 @@ func (s *Service) Delete(ctx context.Context, userID int64) error {
 // skill, overwrites specializations, excluded_skills or location preferences, or errors
 // past the skill cap — it silently adds only as many of the new skills as still fit,
 // mirroring how a manual claim behaves when the profile is near the limit.
+//
+// The merge (which skills still fit, what the rest of the profile currently holds) is
+// computed in Go from a Get read outside any transaction, so a concurrent Save() landing
+// in that gap must not be silently reverted by a write built from that now-stale
+// snapshot. The write is guarded on the row's updated_at (UpsertIfUnchanged); a
+// concurrent write in the gap is retried from a fresh read up to mergeSkillsMaxAttempts
+// times before giving up quietly — the same courtesy-update posture as the rest of this
+// method, just extended to the race as well as to the skill cap.
 func (s *Service) MergeSkills(ctx context.Context, userID int64, skills []string) error {
+	var err error
+	for attempt := 0; attempt < mergeSkillsMaxAttempts; attempt++ {
+		err = s.mergeSkillsOnce(ctx, userID, skills)
+		if !errors.Is(err, ErrConflict) {
+			return err
+		}
+	}
+	return err
+}
+
+// mergeSkillsOnce is one read-merge-write attempt of MergeSkills. It returns ErrConflict
+// when the guarded write lost a race to a concurrent Save(), for the caller to retry.
+func (s *Service) mergeSkillsOnce(ctx context.Context, userID int64, skills []string) error {
 	profile, err := s.repo.Get(ctx, userID)
 	if errors.Is(err, ErrNotFound) {
 		return nil
@@ -155,7 +192,15 @@ func (s *Service) MergeSkills(ctx context.Context, userID int64, skills []string
 	if !changed {
 		return nil
 	}
-	_, err = s.repo.Upsert(ctx, userID, profile.Specializations, merged, profile.ExcludedSkills, profile.LocationPreferences)
+	if profile.UpdatedAt == nil {
+		// No version to guard the write on — write unconditionally, same as before
+		// this fix. A profile read from the real Repository always carries a non-nil
+		// UpdatedAt (updated_at is NOT NULL); this only happens against a Repository
+		// fake that leaves it unset.
+		_, err = s.repo.Upsert(ctx, userID, profile.Specializations, merged, profile.ExcludedSkills, profile.LocationPreferences)
+		return err
+	}
+	_, err = s.repo.UpsertIfUnchanged(ctx, userID, profile.Specializations, merged, profile.ExcludedSkills, profile.LocationPreferences, *profile.UpdatedAt)
 	return err
 }
 

--- a/internal/userprofile/userprofile_integration_test.go
+++ b/internal/userprofile/userprofile_integration_test.go
@@ -1,0 +1,64 @@
+//go:build integration
+
+// Integration test for QueriesRepository.UpsertIfUnchanged — the fix for MergeSkills'
+// read-then-blind-upsert race: the guarded write must land when updated_at still
+// matches what was read, and must report ErrConflict (no row) when it doesn't. Only a
+// real Postgres can verify the SQL's WHERE guard actually behaves this way. Run with:
+// go test -tags=integration ./internal/userprofile/
+package userprofile_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/testdb"
+	"github.com/strelov1/freehire/internal/userprofile"
+)
+
+func TestUpsertIfUnchanged_GuardsOnUpdatedAt(t *testing.T) {
+	pool := testdb.Pool(t)
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, `TRUNCATE user_profiles, users RESTART IDENTITY CASCADE`); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	var userID int64
+	if err := pool.QueryRow(ctx, `INSERT INTO users (email) VALUES ($1) RETURNING id`, "profile-race@example.test").Scan(&userID); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+
+	repo := userprofile.NewQueriesRepository(db.New(pool))
+	created, err := repo.Upsert(ctx, userID, []string{"backend"}, []string{"go"}, []string{}, nil)
+	if err != nil {
+		t.Fatalf("seed Upsert: %v", err)
+	}
+	if created.UpdatedAt == nil {
+		t.Fatal("seeded profile has no updated_at")
+	}
+
+	// A guarded write against the just-read updated_at must land.
+	updated, err := repo.UpsertIfUnchanged(ctx, userID, []string{"backend"}, []string{"go", "docker"}, []string{}, nil, *created.UpdatedAt)
+	if err != nil {
+		t.Fatalf("UpsertIfUnchanged against a matching updated_at: %v", err)
+	}
+	if len(updated.Skills) != 2 {
+		t.Errorf("Skills = %v, want [go docker]", updated.Skills)
+	}
+
+	// A second guarded write against the now-STALE updated_at (the row moved on the
+	// write above) must be rejected as a conflict, not silently applied.
+	_, err = repo.UpsertIfUnchanged(ctx, userID, []string{"backend"}, []string{"go", "docker", "kubernetes"}, []string{}, nil, *created.UpdatedAt)
+	if !errors.Is(err, userprofile.ErrConflict) {
+		t.Errorf("UpsertIfUnchanged against a stale updated_at: err=%v, want ErrConflict", err)
+	}
+
+	// The rejected write must not have landed.
+	current, err := repo.Get(ctx, userID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(current.Skills) != 2 {
+		t.Errorf("Skills after rejected conflicting write = %v, want unchanged [go docker]", current.Skills)
+	}
+}

--- a/internal/userprofile/userprofile_test.go
+++ b/internal/userprofile/userprofile_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/strelov1/freehire/internal/userprofile"
 )
@@ -21,6 +22,13 @@ type upsertArgs struct {
 	LocationPreferences json.RawMessage
 }
 
+// guardedUpsertArgs is upsertArgs plus the expectedUpdatedAt UpsertIfUnchanged guards
+// its write on.
+type guardedUpsertArgs struct {
+	upsertArgs
+	ExpectedUpdatedAt time.Time
+}
+
 // fakeRepo records the params it is handed and returns canned profiles/errors, so the
 // service tests run without a database (the searchprofile_test.go precedent).
 type fakeRepo struct {
@@ -29,7 +37,16 @@ type fakeRepo struct {
 	upsertErr    error
 	upsertRet    userprofile.Profile
 
+	// guardedUpserted/guardedUpsertCalls record UpsertIfUnchanged's calls; guardedUpsertErrs
+	// lets a test script a different result per call (e.g. ErrConflict then success), so
+	// MergeSkills' retry loop can be exercised deterministically.
+	guardedUpserted    guardedUpsertArgs
+	guardedUpsertCalls int
+	guardedUpsertErrs  []error
+	guardedUpsertRet   userprofile.Profile
+
 	getUserID int64
+	getCalls  int
 	getRet    userprofile.Profile
 	getErr    error
 
@@ -40,6 +57,7 @@ type fakeRepo struct {
 
 func (f *fakeRepo) Get(_ context.Context, userID int64) (userprofile.Profile, error) {
 	f.getUserID = userID
+	f.getCalls++
 	return f.getRet, f.getErr
 }
 
@@ -47,6 +65,19 @@ func (f *fakeRepo) Upsert(_ context.Context, userID int64, specializations, skil
 	f.upserted = upsertArgs{UserID: userID, Specializations: specializations, Skills: skills, ExcludedSkills: excludedSkills, LocationPreferences: locationPreferences}
 	f.upsertCalled = true
 	return f.upsertRet, f.upsertErr
+}
+
+func (f *fakeRepo) UpsertIfUnchanged(_ context.Context, userID int64, specializations, skills, excludedSkills []string, locationPreferences json.RawMessage, expectedUpdatedAt time.Time) (userprofile.Profile, error) {
+	f.guardedUpserted = guardedUpsertArgs{
+		upsertArgs{UserID: userID, Specializations: specializations, Skills: skills, ExcludedSkills: excludedSkills, LocationPreferences: locationPreferences},
+		expectedUpdatedAt,
+	}
+	idx := f.guardedUpsertCalls
+	f.guardedUpsertCalls++
+	if idx < len(f.guardedUpsertErrs) && f.guardedUpsertErrs[idx] != nil {
+		return userprofile.Profile{}, f.guardedUpsertErrs[idx]
+	}
+	return f.guardedUpsertRet, nil
 }
 
 func (f *fakeRepo) Delete(_ context.Context, userID int64) error {
@@ -173,6 +204,72 @@ func TestMergeSkills_NeverExceedsCap(t *testing.T) {
 	}
 	if repo.upserted.Skills[199] != "new-a" {
 		t.Errorf("Skills[199] = %q, want the first skill that fit under the cap", repo.upserted.Skills[199])
+	}
+}
+
+// A profile read WITH a known updated_at must write through the guarded
+// UpsertIfUnchanged, not the unconditional Upsert — this is the fix itself: a merge
+// computed outside a transaction must not blindly clobber a concurrent Save().
+func TestMergeSkills_UsesGuardedWriteWhenUpdatedAtKnown(t *testing.T) {
+	updatedAt := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	repo := &fakeRepo{getRet: userprofile.Profile{
+		UserID: 7, Skills: []string{"go"}, Specializations: []string{"backend"}, UpdatedAt: &updatedAt,
+	}}
+	err := userprofile.New(repo).MergeSkills(context.Background(), 7, []string{"docker"})
+	if err != nil {
+		t.Fatalf("MergeSkills: %v", err)
+	}
+	if repo.upsertCalled {
+		t.Error("repo.Upsert (unguarded) should not be called when updated_at is known")
+	}
+	if repo.guardedUpsertCalls != 1 {
+		t.Fatalf("guarded upsert calls = %d, want 1", repo.guardedUpsertCalls)
+	}
+	if !repo.guardedUpserted.ExpectedUpdatedAt.Equal(updatedAt) {
+		t.Errorf("guarded write's expectedUpdatedAt = %v, want %v", repo.guardedUpserted.ExpectedUpdatedAt, updatedAt)
+	}
+	wantSkills := []string{"go", "docker"}
+	if strings.Join(repo.guardedUpserted.Skills, ",") != strings.Join(wantSkills, ",") {
+		t.Errorf("Skills = %v, want %v", repo.guardedUpserted.Skills, wantSkills)
+	}
+}
+
+// The race the review flagged: a concurrent Save() commits between MergeSkills' Get and
+// its write, so the guarded write reports ErrConflict once. MergeSkills re-reads and
+// retries rather than giving up or (worse) silently reverting the concurrent Save().
+func TestMergeSkills_RetriesOnConflictThenSucceeds(t *testing.T) {
+	updatedAt := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	repo := &fakeRepo{
+		getRet:            userprofile.Profile{UserID: 7, Skills: []string{"go"}, UpdatedAt: &updatedAt},
+		guardedUpsertErrs: []error{userprofile.ErrConflict, nil},
+	}
+	err := userprofile.New(repo).MergeSkills(context.Background(), 7, []string{"docker"})
+	if err != nil {
+		t.Fatalf("MergeSkills: %v", err)
+	}
+	if repo.guardedUpsertCalls != 2 {
+		t.Errorf("guarded upsert calls = %d, want 2 (one conflict, one success)", repo.guardedUpsertCalls)
+	}
+	if repo.getCalls != 2 {
+		t.Errorf("Get calls = %d, want 2 — a retry must re-read the profile, not reuse the stale snapshot", repo.getCalls)
+	}
+}
+
+// A concurrent writer that keeps winning the race exhausts MergeSkills' bounded retry:
+// it gives up and reports ErrConflict rather than retrying forever or, worse, forcing a
+// write that would revert whatever kept winning.
+func TestMergeSkills_GivesUpAfterRepeatedConflicts(t *testing.T) {
+	updatedAt := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	repo := &fakeRepo{
+		getRet:            userprofile.Profile{UserID: 7, Skills: []string{"go"}, UpdatedAt: &updatedAt},
+		guardedUpsertErrs: []error{userprofile.ErrConflict, userprofile.ErrConflict, userprofile.ErrConflict},
+	}
+	err := userprofile.New(repo).MergeSkills(context.Background(), 7, []string{"docker"})
+	if !errors.Is(err, userprofile.ErrConflict) {
+		t.Errorf("err = %v, want ErrConflict after exhausting retries", err)
+	}
+	if repo.guardedUpsertCalls != 3 {
+		t.Errorf("guarded upsert calls = %d, want 3 (mergeSkillsMaxAttempts)", repo.guardedUpsertCalls)
 	}
 }
 

--- a/migrations/0096_saved_searches_query_length.sql
+++ b/migrations/0096_saved_searches_query_length.sql
@@ -1,0 +1,15 @@
+-- Bound saved_searches.query the same way name has been bounded since 0001
+-- (saved_searches_name_check): the query column had no length limit anywhere, Go or
+-- SQL, even though it is client-supplied and internal/notify's matching pass re-parses
+-- every distinct query (url.ParseQuery) on every scheduled run. internal/savedsearch
+-- now rejects a query over maxQueryLen (2000) before it reaches SQL; this CHECK is the
+-- backstop for any other writer.
+--
+-- NOT VALID for the same reason 0056 used it for user_profiles' skill-cardinality
+-- backstop: it enforces the bound on every INSERT/UPDATE from here on without a
+-- validation scan or a lengthy lock, and cannot fail the migration on a legacy row
+-- written before the application-side cap existed. To promote it later, once prod is
+-- known clean: ALTER TABLE public.saved_searches VALIDATE CONSTRAINT saved_searches_query_check.
+ALTER TABLE public.saved_searches
+    ADD CONSTRAINT saved_searches_query_check
+    CHECK (length(query) <= 2000) NOT VALID;


### PR DESCRIPTION
## Summary

- **userprofile.MergeSkills concurrency:** read-then-blind-upsert with no version guard could silently revert a concurrent `Save()`. Adds an `updated_at`-guarded `UpsertUserProfileIfUnchanged` query and a bounded read-merge-write retry loop in `MergeSkills`, mirroring `internal/experience`'s `MergeAtoms` fix.
- **accountdelete ordering:** S3 objects were erased before the `appleGrants` release step, which can still hard-fail — leaving an irrecoverable object loss ahead of an abortable step. Apple grants now release first.
- **mobileauth.ListIdentities aggregation:** used `bool_and` to decide a provider is "active" while the actual unlink gate (`unlinkIdentityOnce`) uses OR-across-rows — switched to `bool_or` so the displayed `CanUnlink` hint agrees with what the backend accepts.
- **savedsearch query length:** `query` had no length bound anywhere (Go or SQL), unlike `name`. Adds a 2000-rune Go-side bound plus a `NOT VALID` DB `CHECK` backstop (migration 0096).
- **notify match recording:** `RecordSubscriptionMatch` was called once per (hit, subscription) pair in a loop. Replaced with a single batched `RecordSubscriptionMatches` insert over parallel `unnest` arrays.
- **pushnotify.CheckReceipts partial failure:** a `PruneDeadPushToken` error mid-batch discarded already-resolved tickets' cleanup by returning before `DeletePushTickets`. Now keeps processing, still deletes what resolved, and joins/reports prune errors after.
- **companyfeedback.Hide lock order:** locked the feedback row before the company row, while `Upsert`/`Delete` lock company-then-feedback — a deadlock risk. Adds `GetCompanyFeedbackSlug` (unlocked read) so `Hide` can lock the company row first too.
- **community.Reply parent-thread check:** `parentReplyID` was never checked against `threadID`, so a reply could nest under a different thread's reply. `InsertThreadReply` now validates parent membership in a CTE; a mismatch maps to a new `ErrInvalidParentReply` (400).
- **referral RequestInput free-text bounds:** `Note`/`ContactTelegram`/`ContactEmail`/`LinkedInURL` had no length bound, unlike sibling packages (`report.maxDetailsLen`, `companyfeedback.maxBodyRunes`). Adds bounded validation and two new sentinel errors (422).

## Test plan

- [x] `gofmt -l .` — clean
- [x] `go vet ./...` — clean
- [x] `go vet -tags=integration ./...` — clean
- [x] `go test ./...` — all pass except one pre-existing, unrelated failure (`TestExtractResumeProfile_PDF`, reproduced on a clean `origin/main` checkout before any of these changes)
- [x] `go test -tags=integration ./internal/db/...`, `./internal/auth/mobileauth/...`, `./internal/companyfeedback/...`, `./internal/userprofile/...` — all new/modified integration tests pass against real Postgres (Docker/testcontainers)
- [x] Unit tests added/extended for every behavioral fix (guarded-write retry, lock-order via `Hide`, cross-thread reply rejection, batched match recording, partial prune-failure handling, length bounds, active-aggregation mismatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)