### PR TITLE
Fix 8 findings from the monorepo code review: telegram, enrich, llm, handlers, autofill agent

### DIFF
--- a/internal/autofillagent/agent.go
+++ b/internal/autofillagent/agent.go
@@ -89,9 +89,13 @@ func Run(ctx context.Context, tools Tools, planner Planner, profile Profile) (Re
 	if err != nil {
 		return Report{}, err
 	}
+	// driveWidgets returns whatever it drove before a failure, not just on success:
+	// fillSimple's writes above already landed in the browser, and dropping them
+	// from the report on a later widget's failure would tell the user nothing
+	// succeeded when part of the form is, in fact, already filled.
 	driven, err := driveWidgets(ctx, tools, planner, profile, widgets)
 	if err != nil {
-		return Report{}, err
+		return report(fields, outcomes, driven), err
 	}
 	return report(fields, outcomes, driven), nil
 }
@@ -168,12 +172,17 @@ const (
 // it offers, choose, commit, confirm — and reports what became of each. A step
 // that does not do what it should stops that widget rather than pressing on:
 // nothing is written into a widget whose state is not understood.
+//
+// On a widget's failure it returns what it drove so far alongside the error,
+// rather than discarding it: the earlier widgets in questions already committed
+// their choices in the browser, and the caller (Run) reports that real progress
+// instead of losing it behind the error.
 func driveWidgets(ctx context.Context, tools Tools, planner Planner, profile Profile, questions []Field) (map[string]string, error) {
 	driven := make(map[string]string, len(questions))
 	for _, question := range questions {
 		status, err := driveWidget(ctx, tools, planner, profile, question)
 		if err != nil {
-			return nil, err
+			return driven, err
 		}
 		driven[question.Label] = status
 	}

--- a/internal/autofillagent/agent.go
+++ b/internal/autofillagent/agent.go
@@ -29,10 +29,14 @@ type Field struct {
 }
 
 // Fill is one entry of the plan: the value to write into the control carrying
-// this label.
+// this label. Frame names which of the page's frames the target field was read
+// from (see Field.Frame) — set by splitByKind from the field it resolved the fill
+// against, not by the planner, so a same-labeled control in a different frame is
+// not addressed by a Fill meant for another.
 type Fill struct {
 	Label string `json:"label"`
 	Value string `json:"value"`
+	Frame int    `json:"frame"`
 }
 
 // Profile is the user's canonical autofill fields, keyed as
@@ -104,17 +108,33 @@ func Run(ctx context.Context, tools Tools, planner Planner, profile Profile) (Re
 // widgets that have to be driven. Only widgets the plan named are driven: a form
 // with 27 of them would otherwise cost 27 needless round trips and 27 needless
 // model calls to discover the profile answers none of them.
+//
+// Fields sharing a label are grouped, not deduped to one: a form can carry two
+// controls under the same label — a repeated question in a multi-entry section,
+// or the same label in two different frames, which Field.Frame exists to
+// disambiguate. The plan addresses a fill by label alone (the model has no way to
+// name a frame), so a fill naming that label is routed to EVERY field carrying it,
+// each tagged with its own Frame — never collapsed onto whichever field happened
+// to be last in the page, which is what silently misrouted a plain field's value
+// to a combobox target (or vice versa) whenever the two shared a label.
 func splitByKind(fields []Field, planned []Fill) (typed []Fill, widgets []Field) {
-	byLabel := make(map[string]Field, len(fields))
+	byLabel := make(map[string][]Field, len(fields))
 	for _, field := range fields {
-		byLabel[field.Label] = field
+		byLabel[field.Label] = append(byLabel[field.Label], field)
 	}
 	for _, fill := range planned {
-		if field, ok := byLabel[fill.Label]; ok && field.Combo {
-			widgets = append(widgets, field)
+		matches, ok := byLabel[fill.Label]
+		if !ok {
+			typed = append(typed, fill)
 			continue
 		}
-		typed = append(typed, fill)
+		for _, field := range matches {
+			if field.Combo {
+				widgets = append(widgets, field)
+				continue
+			}
+			typed = append(typed, Fill{Label: fill.Label, Value: fill.Value, Frame: field.Frame})
+		}
 	}
 	return typed, widgets
 }
@@ -184,13 +204,20 @@ func driveWidgets(ctx context.Context, tools Tools, planner Planner, profile Pro
 		if err != nil {
 			return driven, err
 		}
-		driven[question.Label] = status
+		driven[widgetKey(question.Label, question.Frame)] = status
 	}
 	return driven, nil
 }
 
+// widgetKey composite-keys a driven widget's outcome by label and frame, so two
+// widgets sharing a label in different frames (see splitByKind) are tracked as the
+// distinct controls they are instead of one overwriting the other's status.
+func widgetKey(label string, frame int) string {
+	return fmt.Sprintf("%s\x00%d", label, frame)
+}
+
 func driveWidget(ctx context.Context, tools Tools, planner Planner, profile Profile, question Field) (string, error) {
-	opened, err := comboStep(ctx, tools, "combobox.open", question.Label, "")
+	opened, err := comboStep(ctx, tools, "combobox.open", question.Label, "", question.Frame)
 	if err != nil {
 		return "", err
 	}
@@ -198,7 +225,7 @@ func driveWidget(ctx context.Context, tools Tools, planner Planner, profile Prof
 		return opened.Status, nil
 	}
 
-	offered, err := comboStep(ctx, tools, "combobox.options", question.Label, "")
+	offered, err := comboStep(ctx, tools, "combobox.options", question.Label, "", question.Frame)
 	if err != nil {
 		return "", err
 	}
@@ -223,7 +250,7 @@ func driveWidget(ctx context.Context, tools Tools, planner Planner, profile Prof
 		return widgetUngrounded, nil
 	}
 
-	selected, err := comboStep(ctx, tools, "combobox.select", question.Label, choice)
+	selected, err := comboStep(ctx, tools, "combobox.select", question.Label, choice, question.Frame)
 	if err != nil {
 		return "", err
 	}
@@ -233,7 +260,7 @@ func driveWidget(ctx context.Context, tools Tools, planner Planner, profile Prof
 
 	// The commit is only real once the widget says so; `verified` is the single
 	// status the report is allowed to count as filled.
-	verified, err := comboStep(ctx, tools, "combobox.verify", question.Label, choice)
+	verified, err := comboStep(ctx, tools, "combobox.verify", question.Label, choice, question.Frame)
 	if err != nil {
 		return "", err
 	}
@@ -246,8 +273,12 @@ type comboReply struct {
 	Committed string   `json:"committed"`
 }
 
-func comboStep(ctx context.Context, tools Tools, tool, label, value string) (comboReply, error) {
-	raw, err := tools.Call(ctx, tool, map[string]any{"label": label, "value": value})
+// comboStep runs one combobox primitive against the widget carrying label in the
+// given frame — frame is what lets the browser tell apart two same-labeled
+// widgets in different frames/forms (see Field.Frame), the same way it already
+// does for read_form.
+func comboStep(ctx context.Context, tools Tools, tool, label, value string, frame int) (comboReply, error) {
+	raw, err := tools.Call(ctx, tool, map[string]any{"label": label, "value": value, "frame": frame})
 	if err != nil {
 		return comboReply{}, err
 	}
@@ -328,6 +359,10 @@ func normalize(s string) string {
 }
 
 func report(fields []Field, outcomes []outcome, driven map[string]string) Report {
+	// outcomes (fill_simple's reply) carries no frame — the wire's own contract, not
+	// something this function can widen — so a simple (non-combo) field is still
+	// looked up by label alone here. driven (this package's own widget-loop
+	// bookkeeping) has no such limit and is keyed label+frame; see widgetKey.
 	byLabel := make(map[string]string, len(outcomes))
 	for _, o := range outcomes {
 		byLabel[o.Label] = o.Status
@@ -344,7 +379,7 @@ func report(fields []Field, outcomes []outcome, driven map[string]string) Report
 		if strings.TrimSpace(field.Label) == "" {
 			continue
 		}
-		switch place(field, byLabel[field.Label], driven[field.Label]) {
+		switch place(field, byLabel[field.Label], driven[widgetKey(field.Label, field.Frame)]) {
 		case wasFilled:
 			rep.Filled = append(rep.Filled, field.Label)
 		case notFillableYet:

--- a/internal/autofillagent/widget_test.go
+++ b/internal/autofillagent/widget_test.go
@@ -17,6 +17,9 @@ type fakeWidgets struct {
 	offers  map[string][]string // label -> the options the widget reveals once open
 	opens   map[string]string   // label -> combobox.open status, default "opened"
 	commits map[string]string   // label -> what the widget commits, default the selected option
+	// errs fails the named "tool label" call outright (a transport-level error, not
+	// a status reply), so a test can exercise a widget that fails partway through.
+	errs map[string]error
 
 	calls     []string
 	selected  map[string]string
@@ -26,6 +29,10 @@ type fakeWidgets struct {
 func (f *fakeWidgets) Call(_ context.Context, tool string, args any) (json.RawMessage, error) {
 	label, value := readArgs(args)
 	f.calls = append(f.calls, tool+" "+label)
+
+	if err, ok := f.errs[tool+" "+label]; ok {
+		return nil, err
+	}
 
 	switch tool {
 	case "read_form":
@@ -340,5 +347,43 @@ func TestRunNamesAGroupedQuestionOnceInTheReport(t *testing.T) {
 	}
 	if len(rep.Unmapped) != 1 || rep.Unmapped[0] != "Which countries do you anticipate working in?" {
 		t.Fatalf("unmapped = %v, want the question named once", rep.Unmapped)
+	}
+}
+
+// Run must not discard a widget loop's earlier successes when a later widget's
+// tool call fails outright: fillSimple's write and the first widget's commit
+// already happened for real in the browser, and the caller needs to know that
+// even though the run as a whole reports an error.
+func TestRunReturnsThePartialReportWhenAWidgetFails(t *testing.T) {
+	tools := &fakeWidgets{
+		fields: []autofillagent.Field{
+			{Label: "Email", Type: "email"},
+			{Label: "Country", Type: "text", Combo: true},
+			{Label: "Degree", Type: "text", Combo: true},
+		},
+		offers: map[string][]string{"Country": {"Germany"}, "Degree": {"BSc"}},
+		errs:   map[string]error{"combobox.open Degree": errors.New("browser-tool socket hiccup")},
+	}
+	planner := &widgetPlanner{
+		fills: []autofillagent.Fill{
+			{Label: "Email", Value: profile()["email"]},
+			{Label: "Country"},
+			{Label: "Degree"},
+		},
+		choices: map[string]string{"Country": "Germany", "Degree": "BSc"},
+	}
+
+	rep, err := autofillagent.Run(context.Background(), tools, planner, profile())
+	if err == nil {
+		t.Fatal("Run succeeded despite the widget failure")
+	}
+	if !contains(rep.Filled, "Email") {
+		t.Errorf("Filled = %v, want the already-written Email field kept despite the later failure", rep.Filled)
+	}
+	if !contains(rep.Filled, "Country") {
+		t.Errorf("Filled = %v, want the widget driven before the failure kept", rep.Filled)
+	}
+	if contains(rep.Filled, "Degree") {
+		t.Errorf("Filled = %v, the widget whose tool call failed must not be reported as filled", rep.Filled)
 	}
 }

--- a/internal/autofillagent/widget_test.go
+++ b/internal/autofillagent/widget_test.go
@@ -22,13 +22,19 @@ type fakeWidgets struct {
 	errs map[string]error
 
 	calls     []string
+	requested []autofillagent.Fill // what fill_simple was actually asked to write
+	frames    map[string]int       // "tool label" -> the frame arg that call carried
 	selected  map[string]string
 	committed map[string]string
 }
 
 func (f *fakeWidgets) Call(_ context.Context, tool string, args any) (json.RawMessage, error) {
-	label, value := readArgs(args)
+	label, value, frame := readArgs(args)
 	f.calls = append(f.calls, tool+" "+label)
+	if f.frames == nil {
+		f.frames = map[string]int{}
+	}
+	f.frames[tool+" "+label] = frame
 
 	if err, ok := f.errs[tool+" "+label]; ok {
 		return nil, err
@@ -39,6 +45,12 @@ func (f *fakeWidgets) Call(_ context.Context, tool string, args any) (json.RawMe
 		return json.Marshal(map[string]any{"fields": f.fields})
 
 	case "fill_simple":
+		raw, _ := json.Marshal(args)
+		var call struct {
+			Fills []autofillagent.Fill `json:"fills"`
+		}
+		_ = json.Unmarshal(raw, &call)
+		f.requested = call.Fills
 		return json.Marshal(map[string]any{"outcomes": fillOutcomes(args)})
 
 	case "combobox.open":
@@ -83,14 +95,15 @@ func (f *fakeWidgets) Call(_ context.Context, tool string, args any) (json.RawMe
 	}
 }
 
-func readArgs(args any) (label, value string) {
+func readArgs(args any) (label, value string, frame int) {
 	raw, _ := json.Marshal(args)
 	var call struct {
 		Label string `json:"label"`
 		Value string `json:"value"`
+		Frame int    `json:"frame"`
 	}
 	_ = json.Unmarshal(raw, &call)
-	return call.Label, call.Value
+	return call.Label, call.Value, call.Frame
 }
 
 func fillOutcomes(args any) []map[string]string {
@@ -385,5 +398,56 @@ func TestRunReturnsThePartialReportWhenAWidgetFails(t *testing.T) {
 	}
 	if contains(rep.Filled, "Degree") {
 		t.Errorf("Filled = %v, the widget whose tool call failed must not be reported as filled", rep.Filled)
+	}
+}
+
+// A plain field and a combobox sharing a label — e.g. the same "City" in the top
+// frame and inside an ATS iframe — must be routed and reported independently by
+// Field.Frame rather than collapsed onto whichever field happened to be last in
+// the form. Before this fix, byLabel's single-field map meant the LAST field's
+// Combo-ness decided the whole plan entry's routing, so the plain frame-0 field
+// was silently dropped from fill_simple entirely and left unmapped despite the
+// widget having been driven successfully.
+func TestRunRoutesSameLabeledFieldsInDifferentFramesIndependently(t *testing.T) {
+	tools := &fakeWidgets{
+		fields: []autofillagent.Field{
+			{Label: "City", Type: "text", Frame: 0},              // plain field, top frame
+			{Label: "City", Type: "text", Combo: true, Frame: 3}, // widget, an ATS iframe
+		},
+		offers: map[string][]string{"City": {"Berlin"}},
+	}
+	planner := &widgetPlanner{
+		fills:   []autofillagent.Fill{{Label: "City", Value: "Berlin"}},
+		choices: map[string]string{"City": "Berlin"},
+	}
+	p := profile()
+	p["location"] = "Berlin, Germany"
+
+	rep, err := autofillagent.Run(context.Background(), tools, planner, p)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// The plain frame-0 field was actually written, carrying its own frame.
+	if len(tools.requested) != 1 || tools.requested[0].Label != "City" || tools.requested[0].Frame != 0 {
+		t.Fatalf("fill_simple requested %+v, want one City fill tagged frame 0", tools.requested)
+	}
+	// The widget was driven scoped to its own frame, not the plain field's.
+	if got := tools.frames["combobox.open City"]; got != 3 {
+		t.Errorf("combobox.open frame = %d, want 3 (the widget's own frame)", got)
+	}
+	// Both physical fields ended up correctly reported as filled — neither the
+	// widget's success masked the plain field's write, nor the reverse.
+	filled := 0
+	for _, label := range rep.Filled {
+		if label == "City" {
+			filled++
+		}
+	}
+	if filled != 2 {
+		t.Fatalf("Filled = %v, want City reported filled for both fields", rep.Filled)
+	}
+	if len(rep.Unmapped) != 0 {
+		t.Fatalf("Unmapped = %v, want nothing left over", rep.Unmapped)
 	}
 }

--- a/internal/enrich/enrichment.go
+++ b/internal/enrich/enrichment.go
@@ -38,6 +38,17 @@ const (
 	maxSalaryCurrencyRunes = 12
 )
 
+// maxCities and maxCityRunes bound the Cities free-text list the same way: it is
+// extracted from the same attacker-influenced description and served verbatim
+// (jobview.cityFacet, and from there into the Meilisearch document) whenever the
+// deterministic dictionary hasn't pinned a city, so an unbounded model response —
+// e.g. a prompt-injected "list every city in the world, one per line" — would
+// otherwise persist and be served indefinitely.
+const (
+	maxCities    = 20
+	maxCityRunes = 100
+)
+
 // Enrichment is the typed view of a job's enrichment JSONB payload. JSON keys
 // are snake_case to match the existing jobs JSON tags. The blob maps 1:1 to the
 // future search document.
@@ -164,6 +175,7 @@ func (e *Enrichment) Sanitize() {
 	e.Summary = llm.TrimTruncateRunes(e.Summary, maxSummaryRunes)
 	e.TimezoneNote = llm.TrimTruncateRunes(e.TimezoneNote, maxTimezoneNoteRunes)
 	e.SalaryCurrency = llm.TrimTruncateRunes(e.SalaryCurrency, maxSalaryCurrencyRunes)
+	e.Cities = boundCities(e.Cities)
 
 	for _, s := range e.servedScalarEnums() {
 		if *s.ptr != "" && !slices.Contains(s.vocab, *s.ptr) {
@@ -192,6 +204,25 @@ func positiveOrNil(n *int) *int {
 		return n
 	}
 	return nil
+}
+
+// boundCities clips each city to maxCityRunes and the list to maxCities entries, the
+// same free-text bound Sanitize applies to Summary/TimezoneNote/SalaryCurrency,
+// dropping any entry that clips to empty. It returns nil when nothing survives so
+// the field omits cleanly.
+func boundCities(cities []string) []string {
+	if len(cities) > maxCities {
+		cities = cities[:maxCities]
+	}
+	var kept []string
+	for _, c := range cities {
+		c = llm.TrimTruncateRunes(c, maxCityRunes)
+		if c == "" {
+			continue
+		}
+		kept = append(kept, c)
+	}
+	return kept
 }
 
 // keepKnown returns values restricted to those present in vocab, preserving order;

--- a/internal/enrich/enrichment_test.go
+++ b/internal/enrich/enrichment_test.go
@@ -347,3 +347,36 @@ func TestSanitizeBoundsFreeTextFields(t *testing.T) {
 		t.Errorf("SalaryCurrency = %q, want USD unchanged", e2.SalaryCurrency)
 	}
 }
+
+func TestSanitizeBoundsCities(t *testing.T) {
+	t.Run("an over-long city name is clipped", func(t *testing.T) {
+		e := Enrichment{Cities: []string{"  " + strings.Repeat("x", maxCityRunes+50) + "  "}}
+		e.Sanitize()
+		if len(e.Cities) != 1 {
+			t.Fatalf("Cities = %v, want 1 entry", e.Cities)
+		}
+		if got := len([]rune(e.Cities[0])); got != maxCityRunes {
+			t.Errorf("Cities[0] clipped length = %d runes, want %d", got, maxCityRunes)
+		}
+	})
+
+	t.Run("an oversized list is capped, not just each entry", func(t *testing.T) {
+		var cities []string
+		for i := 0; i < maxCities+50; i++ {
+			cities = append(cities, "City")
+		}
+		e := Enrichment{Cities: cities}
+		e.Sanitize()
+		if len(e.Cities) != maxCities {
+			t.Errorf("len(Cities) = %d, want %d", len(e.Cities), maxCities)
+		}
+	})
+
+	t.Run("a normal city list is untouched", func(t *testing.T) {
+		e := Enrichment{Cities: []string{"Kyiv", "Warsaw"}}
+		e.Sanitize()
+		if !reflect.DeepEqual(e.Cities, []string{"Kyiv", "Warsaw"}) {
+			t.Errorf("Cities = %v, want unchanged", e.Cities)
+		}
+	})
+}

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -128,11 +128,12 @@ func (h *authHandlers) register(api fiber.Router, mw middleware) {
 	// Push-token registration is cookie-only for the same reason key management
 	// is: a leaked API key must not be able to redirect another device's push
 	// notifications to itself. The self-test send only ever targets the
-	// caller's own registered token(s) — see TestPushToken.
+	// caller's own registered token(s) — see TestPushToken — and is rate-limited
+	// since it calls out to Expo's push API once per registered device.
 	meGroup.Post("/push-tokens", mw.cookie, h.RegisterPushToken)
 	meGroup.Get("/push-tokens", mw.cookie, h.ListPushTokens)
 	meGroup.Delete("/push-tokens", mw.cookie, h.UnregisterPushToken)
-	meGroup.Post("/push-tokens/test", mw.cookie, h.TestPushToken)
+	meGroup.Post("/push-tokens/test", mw.cookie, testPushTokenLimiter(h.throttler), h.TestPushToken)
 
 	// The in-app notification center: a durable, channel-independent record of
 	// every delivered subscription digest/reminder/nudge. Cookie-only, same

--- a/internal/handler/me_push_tokens.go
+++ b/internal/handler/me_push_tokens.go
@@ -3,12 +3,14 @@ package handler
 import (
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/pushnotify"
+	"github.com/strelov1/freehire/internal/ratelimit"
 )
 
 // registerPushTokenRequest is the POST /me/push-tokens body: the mobile app's
@@ -141,10 +143,29 @@ type testPushTokenResponse struct {
 	Failed  int `json:"failed"`
 }
 
+// testPushTokensPerHour bounds how many self-test sends one caller may trigger per
+// hour. Unlike the rest of this file, TestPushToken fans out one outbound call to
+// Expo's push API per registered device on every hit, so — like every other handler
+// in this package that triggers a metered third-party call (photo uploads, JD
+// resolve, mail recall, speech transcription) — it needs a ceiling: looped by hand or
+// by replaying a valid session cookie, an unbounded route here would spam the
+// caller's own devices and lean on the shared Expo quota for every other user's push
+// delivery too. Twenty is far past a person checking a device works.
+const testPushTokensPerHour = 20
+
+// testPushTokenLimiter throttles the self-test send per authenticated caller, keyed
+// like the sibling limiters elsewhere in this package: an IP key would be lifted by
+// any rotating proxy pool. Mounted AFTER the cookie middleware so the user id is
+// resolved.
+func testPushTokenLimiter(throttler ratelimit.Throttler) fiber.Handler {
+	return ratelimit.Middleware(throttler, ratelimit.KeyByUserOrIP("pushtokentest"), testPushTokensPerHour, time.Hour)
+}
+
 // TestPushToken sends a test push to every one of the caller's own
 // registered tokens — never another user's, and never a caller-supplied
 // destination, so this cannot become a spam/harassment vector disguised as
-// a diagnostic endpoint. Cookie-only.
+// a diagnostic endpoint. Cookie-only, and rate-limited (testPushTokenLimiter):
+// each call fans out one outbound send per device.
 func (h *authHandlers) TestPushToken(c *fiber.Ctx) error {
 	userID, err := requireUserID(c)
 	if err != nil {

--- a/internal/handler/me_push_tokens_test.go
+++ b/internal/handler/me_push_tokens_test.go
@@ -98,3 +98,46 @@ func TestRegisterPushToken_ValidationRejectsBeforeAnyDBCall(t *testing.T) {
 		})
 	}
 }
+
+// TestPushToken fans out one outbound Expo push call per registered device on every
+// hit, unlike the other push-token routes, so it is the one that needs a rate limit —
+// the same posture as photo uploads, JD resolve, mail recall, and speech
+// transcription. Keyed on the user, like those siblings, so it can't be lifted by a
+// rotating proxy pool.
+func TestPushTokenTestLimiter_IsKeyedOnTheUser(t *testing.T) {
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Post("/test", func(c *fiber.Ctx) error {
+		id := int64(1)
+		if c.Get("X-Test-User") == "2" {
+			id = 2
+		}
+		c.Locals("auth.userID", id)
+		return c.Next()
+	}, testPushTokenLimiter(newTestThrottler(t)), func(c *fiber.Ctx) error { return c.SendStatus(fiber.StatusNoContent) })
+
+	post := func(user string) int {
+		req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPost, "/test", nil)
+		req.Header.Set("X-Test-User", user)
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("Test: %v", err)
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	var refused int
+	for i := 0; i < testPushTokensPerHour+5; i++ {
+		if post("1") == fiber.StatusTooManyRequests {
+			refused++
+		}
+	}
+	if refused == 0 {
+		t.Fatalf("user 1 sent %d test-push requests without being throttled", testPushTokensPerHour+5)
+	}
+
+	// A different user is unaffected by the first one's exhausted budget.
+	if got := post("2"); got == fiber.StatusTooManyRequests {
+		t.Error("a second user was throttled by the first user's budget — the key is not the user")
+	}
+}

--- a/internal/llm/credential.go
+++ b/internal/llm/credential.go
@@ -45,8 +45,18 @@ func (c *Client) As(secret string, onRefused func(), tags ...string) *Client {
 
 	clone := *c
 	if secret != "" {
-		// The client's own credential becomes the fallback the retry uses.
-		clone.fallbackKey = c.apiKey
+		// The fallback the retry uses must always be the real service credential,
+		// never another user's secret. c.apiKey is only that when c is itself the
+		// base client; if c is already bound to a per-user credential (c.fallbackKey
+		// != ""), that field already holds the service credential and must be
+		// carried forward as-is — otherwise chaining As twice (base.As(userA).As(userB))
+		// would leave userB's fallback pointing at userA's key, and a refusal for
+		// userB would silently retry, and keep spending, on userA's credential.
+		fallback := c.apiKey
+		if c.fallbackKey != "" {
+			fallback = c.fallbackKey
+		}
+		clone.fallbackKey = fallback
 		clone.apiKey = secret
 		clone.onRefused = onRefused
 	}

--- a/internal/llm/credential_test.go
+++ b/internal/llm/credential_test.go
@@ -237,6 +237,38 @@ func TestARefusedCredentialFallsBackAndReportsItself(t *testing.T) {
 	}
 }
 
+// Chaining As on its own output must not turn a later user's fallback into an
+// earlier user's credential. Nothing calls As twice today (each handler credits the
+// base client held at construction exactly once), but the method has to defend this
+// structurally rather than rely on that discipline holding forever.
+func TestAsChainedTwiceFallsBackToTheServiceCredentialNotAPriorUser(t *testing.T) {
+	proxy := newRefusingProxy(t, "sk-bob")
+	base := proxy.client(t)
+
+	alice := base.As("sk-alice", nil, "feature:tailor")
+	var refused int
+	bob := alice.As("sk-bob", func() { refused++ }, "feature:tailor")
+
+	if _, err := bob.GenerateJSON(context.Background(), "sys", "usr"); err != nil {
+		t.Fatalf("a refused user credential must not fail the call: %v", err)
+	}
+	if refused != 1 {
+		t.Errorf("refusal reported %d times, want once", refused)
+	}
+
+	authz, _ := proxy.seen(t)
+	if len(authz) != 2 {
+		t.Fatalf("proxy served %d requests, want the refused one and the retry", len(authz))
+	}
+	if authz[0] != "Bearer sk-bob" {
+		t.Fatalf("first call carried %q, want bob's credential", authz[0])
+	}
+	if authz[1] != "Bearer sk-service" {
+		t.Errorf("retry carried %q, want the service credential — not alice's, "+
+			"which a double-clone bug would leave as bob's fallback", authz[1])
+	}
+}
+
 // One retry, not a loop: a gateway refusing the service credential too is a
 // misconfiguration, and hammering it would turn one bad key into a request storm.
 func TestARefusalIsRetriedOnlyOnce(t *testing.T) {

--- a/internal/resumeextract/visibility.go
+++ b/internal/resumeextract/visibility.go
@@ -15,12 +15,12 @@ import "strings"
 // placeholder to be reworded later.
 const currentEmployerLabel = "Current employer"
 
-// notEndedLabels mirrors internal/experience/import_resume.go's currentEndLabels (line
-// ~16) exactly: the free-form End labels a CV uses for a role that has not ended. Kept
-// as a separate copy rather than imported — internal/experience already imports this
-// package, so the reverse import would be circular. Keep the two maps in sync if the
-// convention ever changes.
-var notEndedLabels = map[string]bool{"": true, "present": true, "current": true, "now": true, "ongoing": true}
+// notEndedLabels mirrors internal/experience/period_sort.go's isPresentLabel exactly
+// (plus the empty string, which import_resume.go treats as "not ended" too): the
+// free-form End labels a CV uses for a role that has not ended. Kept as a separate
+// copy rather than imported — internal/experience already imports this package, so the
+// reverse import would be circular. Keep the two in sync if the convention ever changes.
+var notEndedLabels = map[string]bool{"": true, "present": true, "current": true, "now": true, "ongoing": true, "today": true}
 
 // isCurrentEntry reports whether an experience entry's End label reads as "not ended",
 // case-insensitively, per notEndedLabels above.

--- a/internal/resumeextract/visibility_test.go
+++ b/internal/resumeextract/visibility_test.go
@@ -107,6 +107,27 @@ func TestAnonymous_MultipleCurrentEntries_AllMasked(t *testing.T) {
 	}
 }
 
+// TestAnonymous_TodayLabelMasked pins notEndedLabels against internal/experience's
+// canonical "not ended" vocabulary (period_sort.go's isPresentLabel): "today" is one of
+// its recognized present labels and must mask here too, or the two would silently
+// disagree on which roles read as ongoing.
+func TestAnonymous_TodayLabelMasked(t *testing.T) {
+	s := fullStructured()
+	s.Experience = []Experience{
+		{Title: "Staff Engineer", Company: "Analytical Engines", Start: "2021-03", End: "Today"},
+	}
+
+	got := s.Anonymous()
+
+	if len(got.Experience) != 1 {
+		t.Fatalf("Experience len = %d, want 1", len(got.Experience))
+	}
+	if got.Experience[0].Company != currentEmployerLabel {
+		t.Errorf("End=%q Experience[0].Company = %q, want masked as %q",
+			"Today", got.Experience[0].Company, currentEmployerLabel)
+	}
+}
+
 func TestAnonymous_DoesNotMutateSource(t *testing.T) {
 	s := fullStructured()
 	s.Experience = oneCurrentExperience()

--- a/internal/telegram/config.go
+++ b/internal/telegram/config.go
@@ -6,6 +6,7 @@ package telegram
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -79,6 +80,11 @@ func ParseConfig(data []byte) (Config, error) {
 
 // Validate checks every entry has a channel, a known kind, and no duplicates, so
 // the crawl command can fail fast instead of silently skipping or double-crawling.
+// The duplicate check is case-insensitive, matching t.me username matching
+// elsewhere in the package (see preview.go's postID): "hrlunapark" and
+// "HRLunapark" name the same channel and would otherwise both pass as distinct
+// entries, crawling and extracting the same posts twice under different
+// external_ids.
 func (c Config) Validate() error {
 	seen := make(map[string]bool, len(c.Channels))
 	for _, e := range c.Channels {
@@ -88,10 +94,11 @@ func (c Config) Validate() error {
 		if e.Kind != KindAuthored && e.Kind != KindBoard {
 			return fmt.Errorf("telegram: channel %q has unknown kind %q", e.Channel, e.Kind)
 		}
-		if seen[e.Channel] {
+		key := strings.ToLower(e.Channel)
+		if seen[key] {
 			return fmt.Errorf("telegram: duplicate channel %q", e.Channel)
 		}
-		seen[e.Channel] = true
+		seen[key] = true
 	}
 	return nil
 }

--- a/internal/telegram/config_test.go
+++ b/internal/telegram/config_test.go
@@ -73,6 +73,17 @@ channels:
 `,
 			want: "duplicate",
 		},
+		{
+			name: "duplicate channel differing only by case",
+			yml: `
+channels:
+  - channel: hrlunapark
+    kind: authored
+  - channel: HRLunapark
+    kind: authored
+`,
+			want: "duplicate",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/telegram/extraction.go
+++ b/internal/telegram/extraction.go
@@ -23,17 +23,37 @@ type Extraction struct {
 	Jobs []ExtractedJob `json:"jobs"`
 }
 
-// Validate rejects a malformed extraction before anything is persisted: every
-// job needs a title and a description. The LLM is not trusted to be correct —
-// an invalid payload is retried and then dead-lettered by the runner.
-func (e Extraction) Validate() error {
+// Validate drops any malformed job — missing title or description — from the
+// extraction and keeps the rest, mutating e.Jobs in place. The LLM is not trusted
+// to be correct, but a KindAuthored post routinely bundles several roles in one
+// message, and Store.Complete already tolerates skipping a single bad draft; an
+// all-or-nothing error here would dead-letter the whole post's well-formed jobs
+// along with the one malformed one. It returns an error only when every job in
+// the extraction was malformed, since a post that named zero jobs to begin with
+// is itself the normal "not a vacancy" outcome.
+func (e *Extraction) Validate() error {
+	if len(e.Jobs) == 0 {
+		return nil
+	}
+	kept := e.Jobs[:0]
+	var firstErr error
 	for i, j := range e.Jobs {
-		if strings.TrimSpace(j.Title) == "" {
-			return fmt.Errorf("telegram: extracted job %d has empty title", i)
+		switch {
+		case strings.TrimSpace(j.Title) == "":
+			if firstErr == nil {
+				firstErr = fmt.Errorf("telegram: extracted job %d has empty title", i)
+			}
+		case strings.TrimSpace(j.Description) == "":
+			if firstErr == nil {
+				firstErr = fmt.Errorf("telegram: extracted job %d (%s) has empty description", i, j.Title)
+			}
+		default:
+			kept = append(kept, j)
 		}
-		if strings.TrimSpace(j.Description) == "" {
-			return fmt.Errorf("telegram: extracted job %d (%s) has empty description", i, j.Title)
-		}
+	}
+	e.Jobs = kept
+	if len(kept) == 0 {
+		return firstErr
 	}
 	return nil
 }

--- a/internal/telegram/extraction_test.go
+++ b/internal/telegram/extraction_test.go
@@ -17,7 +17,8 @@ func validJob() ExtractedJob {
 
 func TestExtractionValidate(t *testing.T) {
 	t.Run("zero jobs is valid (post was not a vacancy)", func(t *testing.T) {
-		if err := (Extraction{}).Validate(); err != nil {
+		e := Extraction{}
+		if err := e.Validate(); err != nil {
 			t.Errorf("empty extraction: %v, want nil", err)
 		}
 	})
@@ -27,12 +28,16 @@ func TestExtractionValidate(t *testing.T) {
 		if err := e.Validate(); err != nil {
 			t.Errorf("valid: %v, want nil", err)
 		}
+		if len(e.Jobs) != 1 {
+			t.Errorf("Jobs = %v, want the one well-formed job kept", e.Jobs)
+		}
 	})
 
 	t.Run("company and location may be empty", func(t *testing.T) {
 		j := validJob()
 		j.Company, j.Location = "", ""
-		if err := (Extraction{Jobs: []ExtractedJob{j}}).Validate(); err != nil {
+		e := Extraction{Jobs: []ExtractedJob{j}}
+		if err := e.Validate(); err != nil {
 			t.Errorf("optional fields empty: %v, want nil", err)
 		}
 	})
@@ -40,7 +45,8 @@ func TestExtractionValidate(t *testing.T) {
 	t.Run("empty title is rejected", func(t *testing.T) {
 		j := validJob()
 		j.Title = "  "
-		err := (Extraction{Jobs: []ExtractedJob{j}}).Validate()
+		e := Extraction{Jobs: []ExtractedJob{j}}
+		err := e.Validate()
 		if err == nil || !strings.Contains(err.Error(), "title") {
 			t.Errorf("err = %v, want a title error", err)
 		}
@@ -49,9 +55,39 @@ func TestExtractionValidate(t *testing.T) {
 	t.Run("empty description is rejected", func(t *testing.T) {
 		j := validJob()
 		j.Description = ""
-		err := (Extraction{Jobs: []ExtractedJob{j}}).Validate()
+		e := Extraction{Jobs: []ExtractedJob{j}}
+		err := e.Validate()
 		if err == nil || !strings.Contains(err.Error(), "description") {
 			t.Errorf("err = %v, want a description error", err)
+		}
+	})
+
+	t.Run("a malformed job is dropped, not the whole extraction", func(t *testing.T) {
+		bad := validJob()
+		bad.Title = ""
+		good1, good2 := validJob(), validJob()
+		good2.Title = "Backend Engineer"
+		e := Extraction{Jobs: []ExtractedJob{good1, bad, good2}}
+		if err := e.Validate(); err != nil {
+			t.Fatalf("err = %v, want nil (some jobs remain valid)", err)
+		}
+		if len(e.Jobs) != 2 {
+			t.Fatalf("Jobs = %v, want the 2 well-formed jobs kept", e.Jobs)
+		}
+		if e.Jobs[0].Title != good1.Title || e.Jobs[1].Title != good2.Title {
+			t.Errorf("Jobs = %v, want [%q, %q]", e.Jobs, good1.Title, good2.Title)
+		}
+	})
+
+	t.Run("all jobs malformed is rejected", func(t *testing.T) {
+		bad1, bad2 := validJob(), validJob()
+		bad1.Title, bad2.Description = "", ""
+		e := Extraction{Jobs: []ExtractedJob{bad1, bad2}}
+		if err := e.Validate(); err == nil {
+			t.Error("err = nil, want an error when nothing survives validation")
+		}
+		if len(e.Jobs) != 0 {
+			t.Errorf("Jobs = %v, want none kept", e.Jobs)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- **internal/telegram/extraction.go**: `Extraction.Validate()` no longer fails a whole post's extraction when one of several jobs is malformed — it now drops only the bad job and keeps the well-formed ones, matching `Store.Complete`'s existing per-job tolerance.
- **internal/telegram/config.go**: the duplicate-channel check in `Config.Validate()` is now case-insensitive, matching t.me username matching elsewhere in the package (`preview.go`'s `postID`), so a casing typo no longer double-crawls a channel.
- **internal/enrich/enrichment.go**: `Sanitize()` now bounds `Cities` (100 runes/entry, 20 entries) the same way it already bounds `Summary`/`TimezoneNote`/`SalaryCurrency`, closing a prompt-injection path into the served/indexed city facet.
- **internal/llm/credential.go**: `Client.As` no longer leaks a prior user's per-user credential as a later `As` call's fallback when chained twice — the fallback now always resolves to the real service credential.
- **internal/resumeextract/visibility.go**: added the missing `"today"` label to `notEndedLabels`, restoring parity with `internal/experience`'s canonical "not ended" vocabulary (`isPresentLabel`) so the Talent Network anonymous page correctly masks a current employer ending with that label.
- **internal/handler/me_push_tokens.go**: `POST /me/push-tokens/test` is now rate-limited (20/hr, keyed on the user), matching every other handler in the package that triggers a metered third-party call.
- **internal/autofillagent/agent.go** (Run's partial Report): `driveWidgets`/`Run` now return whatever was successfully driven/written before a widget's tool call fails, instead of discarding the whole `Report`.
- **internal/autofillagent/agent.go** (frame scoping): the write path (`splitByKind`, `Fill`, `comboStep`) now threads `Field.Frame` through fill_simple and combobox.* calls, and keys widget outcomes by (label, frame), so a same-labeled control in a different frame/form is no longer misrouted or misreported — the backend analogue of the extension's `LabelFill` frame-scoping fix.

## Test plan

- [x] `gofmt -l .` — clean
- [x] `go vet ./...` — clean
- [x] `go vet -tags=integration ./...` — clean
- [x] `go test ./...` — all pass except the pre-existing, unrelated `TestExtractResumeProfile_PDF` failure in `internal/handler` (confirmed failing identically on the base commit before any of these changes)
- [x] Added/extended unit tests for every behavioral fix, following each package's existing test patterns (including a reverted-fix check confirming the new `llm` and `autofillagent` tests actually catch their respective regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)