### PR TITLE
Extension: Save button reflects real saved state

### DIFF
--- a/extension/entrypoints/sidepanel/MatchCard.svelte
+++ b/extension/entrypoints/sidepanel/MatchCard.svelte
@@ -12,6 +12,7 @@
     type MatchAnalysisResponse,
   } from '../../lib/freehire';
   import { categoryLabel, countryLabel, regionLabel, workModeLabel } from '../../lib/labels';
+  import { ensureSavedLoaded, isSaved, markSaved, markUnsaved } from '../../lib/savedJobs';
 
   let { job, match }: { job: FreehireJob; match: JobMatch } = $props();
 
@@ -54,11 +55,23 @@
   }
   let facts = $derived(buildFacts(job));
 
-  // Optimistic, local-only: the card never fetches whether this job was saved
-  // before the panel opened it (no proactive "record a view" call, unlike the
-  // web job page) — it only reflects the panel's own save/unsave actions.
+  // The saved set loads once per panel session (lib/savedJobs.ts) and is kept in
+  // sync locally by this card's own save/unsave clicks — the same
+  // cross-reference-instead-of-per-job-read the web app uses, not a proactive
+  // "record a view" call.
   let saved = $state(false);
   let savePending = $state(false);
+
+  $effect(() => {
+    if (!isCatalogJob) return;
+    const slug = job.public_slug;
+    getToken()
+      .then((token) => (token ? ensureSavedLoaded(token) : undefined))
+      .then(() => {
+        if (job.public_slug === slug) saved = isSaved(slug);
+      })
+      .catch(() => {});
+  });
 
   async function toggleSave() {
     if (savePending) return;
@@ -69,6 +82,8 @@
     saved = !wasSaved;
     try {
       await (wasSaved ? unsaveJob(job.public_slug, token) : saveJob(job.public_slug, token));
+      if (wasSaved) markUnsaved(job.public_slug);
+      else markSaved(job.public_slug);
     } catch {
       saved = wasSaved;
     } finally {

--- a/extension/lib/freehire.ts
+++ b/extension/lib/freehire.ts
@@ -143,6 +143,16 @@ export function unsaveJob(slug: string, token: string): Promise<JobInteraction> 
   return deleteData<JobInteraction>(`/api/v1/jobs/${encodeURIComponent(slug)}/save`, token);
 }
 
+/**
+ * Every public job slug the caller has saved. Read-only and side-effect-free —
+ * the same endpoint the web app cross-references client-side to render an
+ * already-filled save toggle, rather than recording a view per job (see
+ * lib/savedJobs.ts).
+ */
+export function listSavedSlugs(token: string): Promise<string[]> {
+  return getData<string[]>('/api/v1/me/tracking/saved', token);
+}
+
 /** A cached AI fit analysis — only the fields the compact card reads. Never computes
  *  inline: this is a read of whatever the full-page analysis last cached, same
  *  contract as web's MatchSummary.svelte. */

--- a/extension/lib/savedJobs.test.ts
+++ b/extension/lib/savedJobs.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./freehire', () => ({ listSavedSlugs: vi.fn() }));
+
+const { listSavedSlugs } = await import('./freehire');
+const { ensureSavedLoaded, isSaved, markSaved, markUnsaved } = await import('./savedJobs');
+
+describe('savedJobs', () => {
+  beforeEach(() => {
+    vi.mocked(listSavedSlugs).mockReset();
+  });
+
+  it('is empty before the set has loaded', () => {
+    expect(isSaved('never-fetched')).toBe(false);
+  });
+
+  it('loads the saved set once and reports membership', async () => {
+    vi.mocked(listSavedSlugs).mockResolvedValueOnce(['backend-engineer-acme']);
+    await ensureSavedLoaded('token');
+    expect(isSaved('backend-engineer-acme')).toBe(true);
+    expect(isSaved('some-other-job')).toBe(false);
+  });
+
+  it('does not refetch on a second call', async () => {
+    await ensureSavedLoaded('token');
+    expect(listSavedSlugs).not.toHaveBeenCalled();
+  });
+
+  it('reflects a local save immediately', () => {
+    markSaved('freshly-saved-job');
+    expect(isSaved('freshly-saved-job')).toBe(true);
+  });
+
+  it('reflects a local unsave immediately', () => {
+    markSaved('to-be-unsaved');
+    markUnsaved('to-be-unsaved');
+    expect(isSaved('to-be-unsaved')).toBe(false);
+  });
+
+  it('degrades to empty when the load fails, without throwing', async () => {
+    vi.resetModules();
+    vi.doMock('./freehire', () => ({
+      listSavedSlugs: vi.fn().mockRejectedValue(new Error('network down')),
+    }));
+    const fresh = await import('./savedJobs');
+    await expect(fresh.ensureSavedLoaded('token')).resolves.toBeUndefined();
+    expect(fresh.isSaved('anything')).toBe(false);
+  });
+});

--- a/extension/lib/savedJobs.ts
+++ b/extension/lib/savedJobs.ts
@@ -1,0 +1,42 @@
+// Tracks which jobs the signed-in user has saved, so the match card can render
+// its Save button already filled without recording a view per job. A small port
+// of web/src/lib/savedJobs.svelte.ts's cross-referencing: the set loads once
+// from GET /me/tracking/saved (side-effect-free) and is kept in sync locally by
+// the panel's own save/unsave clicks, same as the web app's markSaved/markUnsaved.
+
+import { listSavedSlugs } from './freehire';
+
+let loaded = false;
+let loading: Promise<void> | null = null;
+const slugs = new Set<string>();
+
+/** Loads the saved set once per panel session; a second call while loading or
+ *  after success is a no-op. A failed load leaves the set empty — nothing shows
+ *  filled, which is the correct degraded state, not a retry loop. */
+export function ensureSavedLoaded(token: string): Promise<void> {
+  if (loaded) return Promise.resolve();
+  if (!loading) {
+    loading = listSavedSlugs(token)
+      .then((fetched) => {
+        for (const slug of fetched) slugs.add(slug);
+        loaded = true;
+      })
+      .catch(() => {})
+      .finally(() => {
+        loading = null;
+      });
+  }
+  return loading;
+}
+
+export function isSaved(slug: string): boolean {
+  return slugs.has(slug);
+}
+
+export function markSaved(slug: string): void {
+  slugs.add(slug);
+}
+
+export function markUnsaved(slug: string): void {
+  slugs.delete(slug);
+}

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freehire-extension",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freehire-extension",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "hasInstallScript": true,
       "dependencies": {
         "@lucide/svelte": "^1.25.0",


### PR DESCRIPTION
## Summary
- The MatchCard's Save button previously only tracked clicks made in that panel session — it always started as "Save", even for a job already saved (from the website or an earlier panel session).
- Fixes it by reusing `GET /me/tracking/saved` (already used by the web app to cross-reference the browse list's save toggle client-side) instead of the job-detail page's approach, which piggybacks on `POST /jobs/:slug/view` and would record a view for every job the panel happens to render.
- `extension/lib/savedJobs.ts` — small port of `web/src/lib/savedJobs.svelte.ts`'s load-once-then-cross-reference pattern (load the saved set once per panel session, `markSaved`/`markUnsaved` keep it in sync locally on the panel's own actions), covered by `savedJobs.test.ts`.
- No backend change — the read-only endpoint already existed for exactly this purpose.
- Version intentionally **not** bumped in this PR — 0.1.1 is still pending Chrome Web Store review; this will ship in the next version bump.

## Test plan
- [x] `npm test`, `npm run check`, `npm run lint`, `npm run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Saved job status is now loaded when the side panel opens, so previously saved jobs are shown correctly.
  * Saving or unsaving a job updates its status consistently across the panel.
  * Saved job changes are reflected immediately after successful actions.

* **Bug Fixes**
  * Improved handling when saved-job information cannot be loaded; the panel remains usable without displaying an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->