### PR TITLE
Fix 8 findings from the monorepo code review

### DIFF
--- a/internal/collections/register.go
+++ b/internal/collections/register.go
@@ -192,9 +192,14 @@ func AllOf(gates ...func(Company, Record) bool) func(Company, Record) bool {
 // a register that simply cannot disambiguate would delete its every duplicate,
 // and the geography rules are the real defence in that case.
 func DropAmbiguous(records []Record, identityKey string) []Record {
+	// RegisterSlug does a non-trivial Unicode transliteration; computed once per record
+	// here and reused below instead of recomputed in the filter loop, which matters on
+	// the UK register's ~120k rows.
+	slugs := make([]string, len(records))
 	identities := make(map[string]map[string]struct{}, len(records))
-	for _, r := range records {
+	for i, r := range records {
 		slug := RegisterSlug(r.Name)
+		slugs[i] = slug
 		if slug == "" {
 			continue
 		}
@@ -205,8 +210,8 @@ func DropAmbiguous(records []Record, identityKey string) []Record {
 	}
 
 	out := make([]Record, 0, len(records))
-	for _, r := range records {
-		if len(identities[RegisterSlug(r.Name)]) > 1 {
+	for i, r := range records {
+		if len(identities[slugs[i]]) > 1 {
 			continue
 		}
 		out = append(out, r)

--- a/internal/cv/autopilot_store.go
+++ b/internal/cv/autopilot_store.go
@@ -43,21 +43,32 @@ func SanitizeAutopilotReport(entries []AutopilotEntry) ([]AutopilotEntry, error)
 
 	out := make([]AutopilotEntry, 0, len(entries))
 	for i, e := range entries {
-		requirement := strings.TrimSpace(e.Requirement)
-		if requirement == "" {
-			return nil, fmt.Errorf("entry %d names no requirement — copy the requirement text from cv_context", i)
+		clean, err := sanitizeAutopilotEntry(e)
+		if err != nil {
+			return nil, fmt.Errorf("entry %d %w", i, err)
 		}
-		if !validAutopilotStatus(e.Status) {
-			return nil, fmt.Errorf("entry %d has status %q; valid statuses are %s",
-				i, e.Status, strings.Join(AutopilotStatuses, ", "))
-		}
-		out = append(out, AutopilotEntry{
-			Requirement: clip(requirement, maxAutopilotRequirement),
-			Status:      e.Status,
-			Note:        clip(e.Note, maxAutopilotNote),
-		})
+		out = append(out, clean)
 	}
 	return out, nil
+}
+
+// sanitizeAutopilotEntry validates and clips ONE entry — the rule both SanitizeAutopilotReport
+// (a whole report) and MergeAutopilotEntry (the one entry it is about to fold in) apply before
+// anything reaches the database.
+func sanitizeAutopilotEntry(e AutopilotEntry) (AutopilotEntry, error) {
+	requirement := strings.TrimSpace(e.Requirement)
+	if requirement == "" {
+		return AutopilotEntry{}, errors.New("names no requirement — copy the requirement text from cv_context")
+	}
+	if !validAutopilotStatus(e.Status) {
+		return AutopilotEntry{}, fmt.Errorf("has status %q; valid statuses are %s",
+			e.Status, strings.Join(AutopilotStatuses, ", "))
+	}
+	return AutopilotEntry{
+		Requirement: clip(requirement, maxAutopilotRequirement),
+		Status:      e.Status,
+		Note:        clip(e.Note, maxAutopilotNote),
+	}, nil
 }
 
 func validAutopilotStatus(s AutopilotStatus) bool {
@@ -98,25 +109,29 @@ func (s *Store) SetAutopilotReport(ctx context.Context, id uuid.UUID, userID int
 // This is what lets cv_edit report the requirement it just closed in the SAME call as the
 // edit, rather than depending on a separate tailor_report call the model may not remember
 // to make once the requirement is no longer the one it is thinking about.
+//
+// The merge itself runs as a single statement on the repository (MergeCVAutopilotEntry),
+// not as a Get here followed by a SetAutopilotReport: reading the report and writing it back
+// as two separate calls leaves a gap for another merge to land in between, and whichever call
+// commits last would overwrite the whole column with its own stale view — silently dropping
+// the other call's entry rather than just delaying it.
 func (s *Store) MergeAutopilotEntry(ctx context.Context, id uuid.UUID, userID int64, entry AutopilotEntry) error {
-	rec, err := s.Get(ctx, id, userID)
+	clean, err := sanitizeAutopilotEntry(entry)
 	if err != nil {
 		return err
 	}
-	entries := rec.AutopilotReport
-	target := strings.ToLower(strings.TrimSpace(entry.Requirement))
-	replaced := false
-	for i, e := range entries {
-		if strings.ToLower(strings.TrimSpace(e.Requirement)) == target {
-			entries[i] = entry
-			replaced = true
-			break
-		}
+	blob, err := json.Marshal(clean)
+	if err != nil {
+		return err
 	}
-	if !replaced {
-		entries = append(entries, entry)
+	n, err := s.repo.MergeAutopilotEntry(ctx, id, userID, blob)
+	if err != nil {
+		return err
 	}
-	return s.SetAutopilotReport(ctx, id, userID, entries)
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
 }
 
 // decodeAutopilotReport reads the stored report, tolerating an absent one. A stored report

--- a/internal/cv/autopilot_test.go
+++ b/internal/cv/autopilot_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -175,6 +176,59 @@ func TestMergeAutopilotEntryIsOwnerScoped(t *testing.T) {
 		Requirement: "Kafka", Status: AutopilotClosedBank,
 	}); !errors.Is(err, ErrNotFound) {
 		t.Errorf("foreign merge = %v, want ErrNotFound", err)
+	}
+}
+
+// Two concurrent merges for DIFFERENT requirements (a duplicate tool call, or two requests
+// racing during a run) must both land. A read-modify-write built from a plain Get followed by
+// a plain SetAutopilotReport has no lock between the two calls: both would read the same
+// starting report, and whichever commits last would overwrite the column with its own view,
+// silently losing the other's entry. Run with -race to catch a data race in the fake itself.
+func TestMergeAutopilotEntrySurvivesConcurrentMerges(t *testing.T) {
+	repo := newFakeRepo()
+	s := NewStore(repo)
+	ctx := context.Background()
+
+	meta, err := s.Create(ctx, 3, "Tailored", "classic-ats", Document{Summary: "mine"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	requirements := []string{"Kafka in production", "Team leadership"}
+	for i, requirement := range requirements {
+		wg.Add(1)
+		go func(i int, requirement string) {
+			defer wg.Done()
+			errs[i] = s.MergeAutopilotEntry(ctx, meta.ID, 3, AutopilotEntry{
+				Requirement: requirement, Status: AutopilotClosedBank,
+			})
+		}(i, requirement)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("merge %d: %v", i, err)
+		}
+	}
+
+	rec, err := s.Get(ctx, meta.ID, 3)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(rec.AutopilotReport) != 2 {
+		t.Fatalf("report has %d entries, want 2 — a concurrent merge lost the other's entry: %+v",
+			len(rec.AutopilotReport), rec.AutopilotReport)
+	}
+	seen := map[string]bool{}
+	for _, e := range rec.AutopilotReport {
+		seen[e.Requirement] = true
+	}
+	for _, requirement := range requirements {
+		if !seen[requirement] {
+			t.Errorf("report is missing %q: %+v", requirement, rec.AutopilotReport)
+		}
 	}
 }
 

--- a/internal/cv/store.go
+++ b/internal/cv/store.go
@@ -86,6 +86,10 @@ type Repository interface {
 	SetTracerLinks(ctx context.Context, id uuid.UUID, userID int64, enabled bool) (int64, error)
 	ListTailored(ctx context.Context, userID int64) ([]db.ListTailoredCVsByUserRow, error)
 	SetAutopilotReport(ctx context.Context, id uuid.UUID, userID int64, report []byte) (int64, error)
+	// MergeAutopilotEntry folds one requirement's outcome into the run report in a single
+	// statement — see MergeCVAutopilotEntry's own comment for why this cannot be a Get then a
+	// SetAutopilotReport.
+	MergeAutopilotEntry(ctx context.Context, id uuid.UUID, userID int64, entry []byte) (int64, error)
 	GetTailoredForJob(ctx context.Context, userID, jobID int64) (db.GetTailoredCVForJobRow, error)
 }
 
@@ -426,6 +430,10 @@ func (r queriesRepository) ListTailored(ctx context.Context, userID int64) ([]db
 
 func (r queriesRepository) SetAutopilotReport(ctx context.Context, id uuid.UUID, userID int64, report []byte) (int64, error) {
 	return r.q.SetCVAutopilotReport(ctx, db.SetCVAutopilotReportParams{ID: id, UserID: userID, AutopilotReport: report})
+}
+
+func (r queriesRepository) MergeAutopilotEntry(ctx context.Context, id uuid.UUID, userID int64, entry []byte) (int64, error) {
+	return r.q.MergeCVAutopilotEntry(ctx, db.MergeCVAutopilotEntryParams{ID: id, UserID: userID, Entry: entry})
 }
 
 func (r queriesRepository) GetTailoredForJob(ctx context.Context, userID, jobID int64) (db.GetTailoredCVForJobRow, error) {

--- a/internal/cv/store_test.go
+++ b/internal/cv/store_test.go
@@ -2,6 +2,7 @@ package cv
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"reflect"
 	"strings"
@@ -354,6 +355,48 @@ func (f *fakeRepo) SetAutopilotReport(_ context.Context, id uuid.UUID, userID in
 		return 0, nil
 	}
 	r.report = report
+	f.rows[id] = r
+	return 1, nil
+}
+
+// MergeAutopilotEntry does the read, the match-or-append and the write inside ONE critical
+// section, the same way the real MergeCVAutopilotEntry query does it inside one statement —
+// unlike SetAutopilotReport above, which is safe to call as a separate step only because
+// Store.MergeAutopilotEntry no longer does that; see its own comment.
+func (f *fakeRepo) MergeAutopilotEntry(_ context.Context, id uuid.UUID, userID int64, entry []byte) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r, ok := f.rows[id]
+	if !ok || r.userID != userID {
+		return 0, nil
+	}
+	var incoming AutopilotEntry
+	if err := json.Unmarshal(entry, &incoming); err != nil {
+		return 0, err
+	}
+	var entries []AutopilotEntry
+	if len(r.report) > 0 {
+		if err := json.Unmarshal(r.report, &entries); err != nil {
+			return 0, err
+		}
+	}
+	target := strings.ToLower(strings.TrimSpace(incoming.Requirement))
+	replaced := false
+	for i, e := range entries {
+		if strings.ToLower(strings.TrimSpace(e.Requirement)) == target {
+			entries[i] = incoming
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		entries = append(entries, incoming)
+	}
+	blob, err := json.Marshal(entries)
+	if err != nil {
+		return 0, err
+	}
+	r.report = blob
 	f.rows[id] = r
 	return 1, nil
 }

--- a/internal/cvedit/editor.go
+++ b/internal/cvedit/editor.go
@@ -97,6 +97,10 @@ type Tx interface {
 // or a batch that never edited this CV.
 var ErrNothingToUndo = errors.New("cvedit: nothing to undo")
 
+// ErrCommitDocumentAgentUnsupported is returned when CommitDocument is asked to record a
+// whole-document save on the agent's behalf. See CommitDocument's own comment for why.
+var ErrCommitDocumentAgentUnsupported = errors.New("cvedit: CommitDocument does not support the agent actor")
+
 // ErrCannotUndo is returned when a revision's inverse no longer applies — the place it would
 // restore is gone. Handlers render it as a conflict, because it is a fact about the document
 // now, not a malformed request.
@@ -336,8 +340,21 @@ func samePaths(a, b []Op) bool {
 //
 // A save that changes nothing commits nothing and returns the CV as it stands: autosave
 // fires on a timer, and a revision per timer tick would bury the feed.
+//
+// Unlike Commit, authorize() runs INSIDE the locked transaction here, because the operations
+// it checks do not exist until Diff has compared the incoming document against the state the
+// lock protects — there is nothing to authorize before that. Commit's ordering exists to keep
+// the evidence gate's bank read (a second pooled connection) from running while the CV row is
+// locked, which is the shape of a pool-exhaustion deadlock under load; requireEvidence only
+// ever makes that read for ActorAgent. So this refuses the agent actor outright rather than
+// trusting every future caller to keep passing ActorCandidate/ActorSystem, which is what made
+// today's ordering safe by convention rather than by construction.
 func (e *Editor) CommitDocument(ctx context.Context, cvID uuid.UUID, userID int64,
 	actor Actor, origin Origin, next State) (cv.Meta, Revision, error) {
+
+	if actor == ActorAgent {
+		return cv.Meta{}, Revision{}, ErrCommitDocumentAgentUnsupported
+	}
 
 	var (
 		meta cv.Meta
@@ -371,8 +388,8 @@ func (e *Editor) CommitDocument(ctx context.Context, cvID uuid.UUID, userID int6
 		}
 		change := Change{Actor: actor, Origin: origin, Ops: ops}
 		// The operations are derived here, so this is the first moment they can be checked.
-		// The candidate is the only actor that reaches this path and the gate does not apply
-		// to them, so no bank read happens under the lock.
+		// The actor guard above guarantees ActorAgent never reaches this call, and the gate
+		// does not apply to candidate or system, so no bank read ever happens under the lock.
 		if err := e.authorize(ctx, userID, change); err != nil {
 			return err
 		}

--- a/internal/cvedit/editor.go
+++ b/internal/cvedit/editor.go
@@ -87,6 +87,9 @@ type Tx interface {
 	Amend(ctx context.Context, id uuid.UUID, ops []Op, title, note string) (Revision, error)
 	MarkReverted(ctx context.Context, id uuid.UUID) (bool, error)
 	InBatch(ctx context.Context, batchID uuid.UUID) ([]Revision, error)
+	// Feed is the CV's revision log, newest first, up to limit — what undo reads to check
+	// whether a foreign edit has reshaped a list since the revision(s) it is about to reverse.
+	Feed(ctx context.Context, limit int32) ([]Revision, error)
 	Trim(ctx context.Context, keep int32) error
 }
 

--- a/internal/cvedit/editor_test.go
+++ b/internal/cvedit/editor_test.go
@@ -328,6 +328,27 @@ func TestCommitDocumentDerivesTheOperations(t *testing.T) {
 	}
 }
 
+// CommitDocument authorizes INSIDE the locked transaction, unlike Commit — it needs Diff's
+// output to know what it is authorizing, and Diff needs the locked row's own state. That
+// ordering is only safe because requireEvidence's bank read never runs for anything but
+// ActorAgent, and every real caller passes ActorCandidate or ActorSystem; refusing the agent
+// actor here makes that a guarantee instead of a convention no signature enforces.
+func TestCommitDocumentRefusesTheAgentActor(t *testing.T) {
+	repo := newFakeRepo()
+	e, _ := newEditor(repo, nil)
+
+	next := sample()
+	next.Summary = "Distributed systems"
+
+	_, _, err := e.CommitDocument(context.Background(), repo.cvID, 1, ActorAgent, OriginTailorAgent, next)
+	if !errors.Is(err, ErrCommitDocumentAgentUnsupported) {
+		t.Fatalf("CommitDocument(agent) = %v, want ErrCommitDocumentAgentUnsupported", err)
+	}
+	if repo.saves != 0 || len(repo.revisions) != 0 {
+		t.Fatal("a refused whole-document save wrote something")
+	}
+}
+
 func TestCommitDocumentWithNothingChangedRecordsNothing(t *testing.T) {
 	repo := newFakeRepo()
 	e, _ := newEditor(repo, nil)

--- a/internal/cvedit/editor_test.go
+++ b/internal/cvedit/editor_test.go
@@ -118,6 +118,14 @@ func (r *fakeRepo) InBatch(_ context.Context, batchID uuid.UUID) ([]Revision, er
 	return out, nil
 }
 
+func (r *fakeRepo) Feed(_ context.Context, limit int32) ([]Revision, error) {
+	out := make([]Revision, 0, len(r.revisions))
+	for i := len(r.revisions) - 1; i >= 0 && len(out) < int(limit); i-- {
+		out = append(out, r.revisions[i])
+	}
+	return out, nil
+}
+
 func (r *fakeRepo) Trim(_ context.Context, keep int32) error {
 	if extra := len(r.revisions) - int(keep); extra > 0 {
 		r.revisions = r.revisions[extra:]

--- a/internal/cvedit/repository.go
+++ b/internal/cvedit/repository.go
@@ -186,6 +186,14 @@ func (t *queriesTx) InBatch(ctx context.Context, batchID uuid.UUID) ([]Revision,
 	return revisionsFromRows(rows)
 }
 
+func (t *queriesTx) Feed(ctx context.Context, limit int32) ([]Revision, error) {
+	rows, err := t.q.ListCVRevisions(ctx, db.ListCVRevisionsParams{CvID: t.cvID, UserID: t.userID, Limit: limit})
+	if err != nil {
+		return nil, err
+	}
+	return revisionsFromRows(rows)
+}
+
 func (t *queriesTx) Trim(ctx context.Context, keep int32) error {
 	_, err := t.q.TrimCVRevisions(ctx, db.TrimCVRevisionsParams{CvID: t.cvID, Limit: keep})
 	return err

--- a/internal/cvedit/undo.go
+++ b/internal/cvedit/undo.go
@@ -3,6 +3,8 @@ package cvedit
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -89,6 +91,20 @@ func (e *Editor) undo(ctx context.Context, tx Tx, cvID uuid.UUID, inverse []Op,
 		return cv.Meta{}, Revision{}, err
 	}
 
+	// BaseVersion is journalling, not a lock: nothing stops another actor's edit from landing
+	// between the revision(s) being undone and this moment. Apply's own bound check only
+	// refuses an index past the end of the CURRENT list, which an interleaving insert or
+	// remove on the same list does not trip — it just changes what the stored index now means,
+	// so the inverse would land in range but on the wrong element.
+	feed, err := tx.Feed(ctx, feedLimit)
+	if err != nil {
+		return cv.Meta{}, Revision{}, err
+	}
+	if interleaved(feed, reverted) {
+		return cv.Meta{}, Revision{}, fmt.Errorf(
+			"%w: another edit has changed the same list since; refresh and try again", ErrCannotUndo)
+	}
+
 	applied, applyRedo, err := Apply(before, inverse)
 	if err != nil {
 		// The place the inverse would restore is gone. This is a fact about the document as
@@ -133,4 +149,85 @@ func (e *Editor) undo(ctx context.Context, tx Tx, cvID uuid.UUID, inverse []Op,
 		return cv.Meta{}, Revision{}, err
 	}
 	return meta, rev, nil
+}
+
+// interleaved reports whether some revision NOT among `targets` has reshaped a list any of
+// their operations addresses, since the earliest of them was recorded.
+//
+// A foreign insert, remove or move shifts every later position in its list, which invalidates
+// an index-based inverse computed before the shift without ever taking it out of range — the
+// only thing Apply itself checks. A foreign set does not: it never changes what index a
+// sibling sits at, so it is not counted.
+//
+// A revision that has itself been reverted is excluded, and so is the revision that reverted
+// it, when what it undid also falls inside the window: the pair cancels exactly, leaving the
+// list precisely where it was, which is what lets a run's own edits interleave with its own
+// undo and with each other's reverts.
+func interleaved(feed []Revision, targets []uuid.UUID) bool {
+	byID := make(map[uuid.UUID]Revision, len(feed))
+	for _, rev := range feed {
+		byID[rev.ID] = rev
+	}
+
+	inSet := make(map[uuid.UUID]bool, len(targets))
+	shapes := make(map[string]bool)
+	var earliest time.Time
+	for i, id := range targets {
+		inSet[id] = true
+		rev, ok := byID[id]
+		if !ok {
+			continue
+		}
+		if i == 0 || rev.CreatedAt.Before(earliest) {
+			earliest = rev.CreatedAt
+		}
+		addListShapes(rev.Ops, shapes)
+		addListShapes(rev.Inverse, shapes)
+	}
+	// Nothing being undone addresses a list position, so there is nothing an interleaving
+	// insert or remove could have misaligned.
+	if len(shapes) == 0 {
+		return false
+	}
+
+	for _, rev := range feed {
+		if inSet[rev.ID] || rev.Reverted() || !rev.CreatedAt.After(earliest) {
+			continue
+		}
+		if rev.RevertsID != uuid.Nil {
+			if undone, ok := byID[rev.RevertsID]; ok && undone.CreatedAt.After(earliest) {
+				continue // cancels exactly what it undid; nothing else sat between them
+			}
+		}
+		for _, op := range rev.Ops {
+			if op.Kind != OpInsert && op.Kind != OpRemove && op.Kind != OpMove {
+				continue
+			}
+			if shape, ok := listShape(op.Path); ok && shapes[shape] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// listShape reports the list a path sits in, stripped of its own position —
+// `experience[0].bullets[3]` becomes `experience[0].bullets`. It is what lets an operation on
+// one index be recognised as sharing a list with an operation on another: two operations at
+// different positions can still reshape the same underlying slice.
+func listShape(p Path) (string, bool) {
+	s := string(p)
+	open := strings.LastIndexByte(s, '[')
+	if open < 0 || !strings.HasSuffix(s, "]") {
+		return "", false
+	}
+	return s[:open], true
+}
+
+func addListShapes(ops []Op, shapes map[string]bool) {
+	for _, op := range ops {
+		if shape, ok := listShape(op.Path); ok {
+			shapes[shape] = true
+		}
+	}
 }

--- a/internal/cvedit/undo_test.go
+++ b/internal/cvedit/undo_test.go
@@ -3,6 +3,7 @@ package cvedit
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 	"time"
 
@@ -251,5 +252,53 @@ func TestUndoingAMoveLeavesLaterEditsAlone(t *testing.T) {
 	}
 	if got := repo.state.Experience[0].Role; got != "Staff Engineer" {
 		t.Fatalf("role = %q, want the later edit to have survived the undo", got)
+	}
+}
+
+// A foreign edit that lands between two calls of the same run and reshapes the list they both
+// address must refuse the run's undo rather than silently misplace what it restores: the
+// batch's stored inverse still names a position in the list as it stood before the foreign
+// insert, and that position is in range for the list's new shape too — just not the same
+// element anymore.
+func TestRevertBatchRefusesWhenAForeignEditReshapedTheSameList(t *testing.T) {
+	repo := newFakeRepo()
+	e, c := newEditor(repo, nil)
+	cvID := repo.cvID
+	batch := uuid.New()
+
+	// The run's first call: drop the second bullet.
+	c.at = c.at.Add(time.Minute)
+	if _, _, err := e.Commit(context.Background(), cvID, 1, Change{
+		Actor: ActorAgent, Origin: OriginTailorAgent, BatchID: batch,
+		Ops: []Op{{Kind: OpRemove, Path: mustParse(t, "experience[0].bullets[1]")}},
+	}); err != nil {
+		t.Fatalf("Commit(remove): %v", err)
+	}
+
+	// A foreign edit lands between the run's two calls, inserting ahead of the position the
+	// run's next call and its own earlier inverse both address.
+	c.at = c.at.Add(time.Minute)
+	if _, _, err := e.Commit(context.Background(), cvID, 1, Change{
+		Actor: ActorCandidate, Origin: OriginEditor,
+		Ops: []Op{{Kind: OpInsert, Path: mustParse(t, "experience[0].bullets[0]"), Value: "Candidate's own line"}},
+	}); err != nil {
+		t.Fatalf("Commit(foreign insert): %v", err)
+	}
+
+	// The run's second call: it reads the fresh state, so this write itself lands correctly.
+	c.at = c.at.Add(time.Minute)
+	if _, _, err := e.Commit(context.Background(), cvID, 1, Change{
+		Actor: ActorAgent, Origin: OriginTailorAgent, BatchID: batch,
+		Ops: []Op{{Kind: OpSet, Path: mustParse(t, "experience[0].bullets[0]"), Value: "Shipped it, tailored"}},
+	}); err != nil {
+		t.Fatalf("Commit(set): %v", err)
+	}
+	before := append([]string(nil), repo.state.Experience[0].Bullets...)
+
+	if _, err := e.RevertBatch(context.Background(), cvID, 1, batch); !errors.Is(err, ErrCannotUndo) {
+		t.Fatalf("RevertBatch = %v, want ErrCannotUndo", err)
+	}
+	if !reflect.DeepEqual(repo.state.Experience[0].Bullets, before) {
+		t.Fatalf("a refused undo changed the document: %v", repo.state.Experience[0].Bullets)
 	}
 }

--- a/internal/db/cvs.sql.go
+++ b/internal/db/cvs.sql.go
@@ -356,6 +356,47 @@ func (q *Queries) ListTailoredCVsByUser(ctx context.Context, userID int64) ([]Li
 	return items, nil
 }
 
+const mergeCVAutopilotEntry = `-- name: MergeCVAutopilotEntry :execrows
+UPDATE cvs
+SET autopilot_report = CASE
+    WHEN EXISTS (
+      SELECT 1 FROM jsonb_array_elements(COALESCE(autopilot_report, '[]'::jsonb)) elem
+      WHERE lower(trim(elem ->> 'requirement')) = lower(trim($3::jsonb ->> 'requirement'))
+    )
+    THEN (
+      SELECT jsonb_agg(
+        CASE WHEN lower(trim(elem ->> 'requirement')) = lower(trim($3::jsonb ->> 'requirement'))
+             THEN $3::jsonb ELSE elem END
+      )
+      FROM jsonb_array_elements(COALESCE(autopilot_report, '[]'::jsonb)) elem
+    )
+    ELSE COALESCE(autopilot_report, '[]'::jsonb) || jsonb_build_array($3::jsonb)
+  END
+WHERE id = $1 AND user_id = $2
+`
+
+type MergeCVAutopilotEntryParams struct {
+	ID     uuid.UUID `json:"id"`
+	UserID int64     `json:"user_id"`
+	Entry  []byte    `json:"entry"`
+}
+
+// Fold ONE requirement's outcome into the run report: replace the entry whose requirement
+// matches case- and whitespace-insensitively, or append when none does. Done as one UPDATE
+// expression rather than a read-modify-write from Go, because a read-modify-write has no lock
+// between its two calls — two concurrent merges (a duplicate tool call, two requests racing
+// during a run) can both read the same starting report and each overwrite the other's entry.
+// The CASE here evaluates against one row snapshot under Postgres's own row-level lock for the
+// UPDATE, so nothing else can observe or write the row mid-merge. Owner-scoped: 0 rows for a
+// foreign id.
+func (q *Queries) MergeCVAutopilotEntry(ctx context.Context, arg MergeCVAutopilotEntryParams) (int64, error) {
+	result, err := q.db.Exec(ctx, mergeCVAutopilotEntry, arg.ID, arg.UserID, arg.Entry)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const setCVAutopilotReport = `-- name: SetCVAutopilotReport :execrows
 UPDATE cvs
 SET autopilot_report = $3

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -2253,6 +2253,15 @@ type Querier interface {
 	// Cursor write: mark a rotated file applied. Idempotent — a concurrent/rerun mark
 	// is a no-op, so the file is never double-applied.
 	MarkViewLogFileProcessed(ctx context.Context, arg MarkViewLogFileProcessedParams) error
+	// Fold ONE requirement's outcome into the run report: replace the entry whose requirement
+	// matches case- and whitespace-insensitively, or append when none does. Done as one UPDATE
+	// expression rather than a read-modify-write from Go, because a read-modify-write has no lock
+	// between its two calls — two concurrent merges (a duplicate tool call, two requests racing
+	// during a run) can both read the same starting report and each overwrite the other's entry.
+	// The CASE here evaluates against one row snapshot under Postgres's own row-level lock for the
+	// UPDATE, so nothing else can observe or write the row mid-merge. Owner-scoped: 0 rows for a
+	// foreign id.
+	MergeCVAutopilotEntry(ctx context.Context, arg MergeCVAutopilotEntryParams) (int64, error)
 	// Atomically update the keep and delete the loser. The UPDATE is the transaction: the
 	// DELETE only lands when the update did, so a keep that vanished between Store.MergeAtoms'
 	// ownership check and this call (a concurrent delete/merge) yields no row and deletes

--- a/internal/db/queries/cvs.sql
+++ b/internal/db/queries/cvs.sql
@@ -96,6 +96,32 @@ UPDATE cvs
 SET autopilot_report = $3
 WHERE id = $1 AND user_id = $2;
 
+-- name: MergeCVAutopilotEntry :execrows
+-- Fold ONE requirement's outcome into the run report: replace the entry whose requirement
+-- matches case- and whitespace-insensitively, or append when none does. Done as one UPDATE
+-- expression rather than a read-modify-write from Go, because a read-modify-write has no lock
+-- between its two calls — two concurrent merges (a duplicate tool call, two requests racing
+-- during a run) can both read the same starting report and each overwrite the other's entry.
+-- The CASE here evaluates against one row snapshot under Postgres's own row-level lock for the
+-- UPDATE, so nothing else can observe or write the row mid-merge. Owner-scoped: 0 rows for a
+-- foreign id.
+UPDATE cvs
+SET autopilot_report = CASE
+    WHEN EXISTS (
+      SELECT 1 FROM jsonb_array_elements(COALESCE(autopilot_report, '[]'::jsonb)) elem
+      WHERE lower(trim(elem ->> 'requirement')) = lower(trim(sqlc.arg(entry)::jsonb ->> 'requirement'))
+    )
+    THEN (
+      SELECT jsonb_agg(
+        CASE WHEN lower(trim(elem ->> 'requirement')) = lower(trim(sqlc.arg(entry)::jsonb ->> 'requirement'))
+             THEN sqlc.arg(entry)::jsonb ELSE elem END
+      )
+      FROM jsonb_array_elements(COALESCE(autopilot_report, '[]'::jsonb)) elem
+    )
+    ELSE COALESCE(autopilot_report, '[]'::jsonb) || jsonb_build_array(sqlc.arg(entry)::jsonb)
+  END
+WHERE id = $1 AND user_id = $2;
+
 -- name: GetTailoredCVForJob :one
 -- The user's existing tailored copy for one vacancy, newest first. The tailoring bootstrap is
 -- reached by an address (/tailor/<slug>) that carries no CV reference, so a reload runs the

--- a/internal/handler/assistant_cv_tools_test.go
+++ b/internal/handler/assistant_cv_tools_test.go
@@ -92,6 +92,43 @@ func (r *cvRepo) SetAutopilotReport(_ context.Context, id uuid.UUID, userID int6
 	return 1, nil
 }
 
+func (r *cvRepo) MergeAutopilotEntry(_ context.Context, id uuid.UUID, userID int64, entry []byte) (int64, error) {
+	if r.autopilotErr != nil {
+		return 0, r.autopilotErr
+	}
+	if id != r.id || userID != r.userID {
+		return 0, nil
+	}
+	var incoming cv.AutopilotEntry
+	if err := json.Unmarshal(entry, &incoming); err != nil {
+		return 0, err
+	}
+	var entries []cv.AutopilotEntry
+	if len(r.report) > 0 {
+		if err := json.Unmarshal(r.report, &entries); err != nil {
+			return 0, err
+		}
+	}
+	target := strings.ToLower(strings.TrimSpace(incoming.Requirement))
+	replaced := false
+	for i, e := range entries {
+		if strings.ToLower(strings.TrimSpace(e.Requirement)) == target {
+			entries[i] = incoming
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		entries = append(entries, incoming)
+	}
+	blob, err := json.Marshal(entries)
+	if err != nil {
+		return 0, err
+	}
+	r.report = blob
+	return 1, nil
+}
+
 // testCVID is the CV every case in this file addresses. Fixed so a failure names a
 // stable value rather than a fresh random one.
 var testCVID = uuid.MustParse("55555555-5555-4555-8555-555555555555")

--- a/internal/handler/assistant_cv_tools_test.go
+++ b/internal/handler/assistant_cv_tools_test.go
@@ -228,6 +228,14 @@ func (m *memRevisions) InBatch(_ context.Context, batchID uuid.UUID) ([]cvedit.R
 	return out, nil
 }
 
+func (m *memRevisions) Feed(_ context.Context, limit int32) ([]cvedit.Revision, error) {
+	out := make([]cvedit.Revision, 0, len(m.revisions))
+	for i := len(m.revisions) - 1; i >= 0 && len(out) < int(limit); i-- {
+		out = append(out, m.revisions[i])
+	}
+	return out, nil
+}
+
 func (m *memRevisions) Trim(context.Context, int32) error { return nil }
 
 const oneExperienceCV = `{"header":{"full_name":"Ada Lovelace","email":"ada@example.com"},` +

--- a/internal/jdresolve/jdresolve.go
+++ b/internal/jdresolve/jdresolve.go
@@ -75,7 +75,7 @@ func New(q Queries, importer Importer, private PrivateWriter) *Resolver {
 func (r *Resolver) Resolve(ctx context.Context, userID int64, req Request) (string, error) {
 	switch {
 	case req.JobSlug != "":
-		return r.resolveSlug(ctx, req.JobSlug)
+		return r.resolveSlug(ctx, userID, req.JobSlug)
 	case req.URL != "":
 		return r.resolveURL(ctx, userID, req.URL)
 	default:
@@ -83,13 +83,23 @@ func (r *Resolver) Resolve(ctx context.Context, userID int64, req Request) (stri
 	}
 }
 
-func (r *Resolver) resolveSlug(ctx context.Context, slug string) (string, error) {
+// resolveSlug is the only JobSlug-passthrough path, and the package doc's claim that a
+// private job is "visible only to its creator, through GetJobBySlug" is otherwise just a
+// comment: GetJobBySlug itself has no is_private predicate (see the query — jobs.sql:106),
+// and other callers rely on it for public jobs, so the ownership check belongs HERE rather
+// than in the shared query. A private job whose slug leaked through some side channel (a
+// screenshot, a log line — its 8-char SHA-256-derived shortcode gives it real entropy, but
+// is not an authorization check) must not resolve for anyone but the user who created it.
+func (r *Resolver) resolveSlug(ctx context.Context, userID int64, slug string) (string, error) {
 	j, err := r.q.GetJobBySlug(ctx, slug)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return "", ErrJobNotFound
 	}
 	if err != nil {
 		return "", fmt.Errorf("jdresolve: get job by slug: %w", err)
+	}
+	if j.IsPrivate && (!j.CreatedBy.Valid || j.CreatedBy.Int64 != userID) {
+		return "", ErrJobNotFound
 	}
 	return j.PublicSlug, nil
 }

--- a/internal/jdresolve/resolve_integration_test.go
+++ b/internal/jdresolve/resolve_integration_test.go
@@ -128,6 +128,43 @@ func TestResolve_UnknownJobSlugIsNotFound(t *testing.T) {
 	}
 }
 
+// The package doc promises a private job is "visible only to its creator, through
+// GetJobBySlug" — this is the test that actually exercises that promise across a user
+// boundary, rather than trusting the public_slug's own entropy to stand in for it.
+func TestResolve_PrivateJobSlugIsRefusedForAnotherUser(t *testing.T) {
+	pool := testdb.Pool(t)
+	q := db.New(pool)
+	ctx := context.Background()
+
+	owner := seedUser(t, pool, "private-owner@example.test")
+	stranger := seedUser(t, pool, "private-stranger@example.test")
+
+	pw := privatejob.NewWriter(q)
+	r := jdresolve.New(q, linkimport.New(pool, q, nil, pageClient{}, nil, nil), pw)
+
+	slug, err := r.Resolve(ctx, owner, jdresolve.Request{
+		Text:  "We are hiring a backend engineer with Go experience.",
+		Title: "Backend Engineer",
+	})
+	if err != nil {
+		t.Fatalf("seed private job: %v", err)
+	}
+
+	if _, err := r.Resolve(ctx, stranger, jdresolve.Request{JobSlug: slug}); !errors.Is(err, jdresolve.ErrJobNotFound) {
+		t.Errorf("resolving another user's private job err = %v, want ErrJobNotFound", err)
+	}
+
+	// The creator themselves must still be able to reopen it — this is the tailoring
+	// workspace's own reload path.
+	got, err := r.Resolve(ctx, owner, jdresolve.Request{JobSlug: slug})
+	if err != nil {
+		t.Fatalf("owner's own Resolve: %v", err)
+	}
+	if got != slug {
+		t.Errorf("Resolve = %q, want the same slug %q", got, slug)
+	}
+}
+
 func TestResolve_RecognizedATSURLBecomesAPublicJob(t *testing.T) {
 	pool := testdb.Pool(t)
 	q := db.New(pool)

--- a/internal/location/eligibility.go
+++ b/internal/location/eligibility.go
@@ -23,10 +23,87 @@ var usOnlyPhrases = []string{
 // dictionary could not pin to a country (see jobderive): a bare-"Remote" posting
 // that resolved to the global bucket but requires US citizenship is US-restricted,
 // not open-anywhere. It never guesses — an absent phrase yields false.
+//
+// A phrase found in a sentence that also denies it ("does not require US citizenship",
+// "no US citizenship required") is not a match: an unanchored Contains would read the
+// denial as the assertion, which is the opposite mistake this function exists to avoid —
+// the same precision-over-recall rule the phrase list itself follows.
 func USOnlyFromDescription(desc string) bool {
 	lower := strings.ToLower(desc)
 	for _, p := range usOnlyPhrases {
-		if strings.Contains(lower, p) {
+		if phraseAsserted(lower, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// negationWindow bounds how far a sentence boundary search looks in each direction from a
+// phrase match, so one long unpunctuated block of text cannot pull an unrelated paragraph's
+// wording into the check.
+const negationWindow = 80
+
+// negationWords cancel the eligibility signal a phrase would otherwise assert. Checked as
+// whole words (or, for "n't"/"non-", as a suffix/prefix of one) against the sentence the
+// phrase sits in, not the phrase itself — "does not require US citizenship" denies the
+// signal from three words away.
+var negationWords = map[string]bool{
+	"not": true, "no": true, "cannot": true, "never": true,
+	"without": true, "except": true, "unless": true, "excluding": true,
+}
+
+// phraseAsserted reports whether p occurs in lower at least once outside a sentence that
+// denies it. A phrase can appear more than once — a denied mention earlier in the text must
+// not hide a genuine assertion later.
+func phraseAsserted(lower, p string) bool {
+	for offset := 0; ; {
+		i := strings.Index(lower[offset:], p)
+		if i < 0 {
+			return false
+		}
+		start := offset + i
+		end := start + len(p)
+		if !negatedSentence(sentenceAround(lower, start, end)) {
+			return true
+		}
+		offset = end
+	}
+}
+
+// sentenceAround returns the text around lower[start:end], trimmed to the nearest sentence
+// boundary (., !, ?, or newline) on each side, capped at negationWindow bytes in each
+// direction.
+func sentenceAround(lower string, start, end int) string {
+	lo := start - negationWindow
+	if lo < 0 {
+		lo = 0
+	}
+	if i := strings.LastIndexAny(lower[lo:start], ".!?\n"); i >= 0 {
+		lo += i + 1
+	}
+	hi := end + negationWindow
+	if hi > len(lower) {
+		hi = len(lower)
+	}
+	if i := strings.IndexAny(lower[end:hi], ".!?\n"); i >= 0 {
+		hi = end + i
+	}
+	return lower[lo:hi]
+}
+
+// negatedSentence reports whether a sentence carries a negation word, checked whole-word so
+// "notable" or "cannot deploy without approval" style incidental substrings of unrelated
+// words don't misfire the way an unanchored Contains would.
+//
+// The check is sentence-wide, not clause-scoped to the phrase: a sentence that negates
+// something else entirely ("Applicants must not have unresolved conflicts and must be a US
+// Citizen") suppresses the match too. That is the safe side of the same precision-over-recall
+// trade this file already makes elsewhere — missing a real US-only signal costs less than
+// mislabeling a globally-open role as US-restricted.
+func negatedSentence(sentence string) bool {
+	for _, word := range strings.Fields(sentence) {
+		word = strings.Trim(word, ".,;:!?()\"'")
+		if negationWords[word] || strings.HasSuffix(word, "n't") || strings.HasPrefix(word, "non-") {
 			return true
 		}
 	}

--- a/internal/location/eligibility_test.go
+++ b/internal/location/eligibility_test.go
@@ -27,6 +27,15 @@ func TestUSOnlyFromDescription(t *testing.T) {
 		{"generic security clearance", "A UK SC security clearance is a plus.", false},
 		{"worldwide", "Open to candidates anywhere in the world.", false},
 		{"empty", "", false},
+
+		// Negated mentions — the phrase is present, but the sentence denies it.
+		{"does not require citizenship", "This role does not require US citizenship; applicants worldwide are welcome.", false},
+		{"no clearance required", "No Secret clearance is required for this position.", false},
+		{"non-us citizens welcome", "We welcome non-US citizens to apply for this fully remote role.", false},
+		{"cannot sponsor but no citizenship needed", "We cannot sponsor visas, and US citizenship is not required.", false},
+
+		// A denial elsewhere must not hide a genuine assertion in a later sentence.
+		{"negation in an earlier unrelated sentence", "This is not a contractor role. US citizenship is required.", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/skilltag/dictionaries.go
+++ b/internal/skilltag/dictionaries.go
@@ -1191,13 +1191,27 @@ var nonCorroboratingPhrases = map[string]bool{
 	"ticket-resolution":    true,
 }
 
-// nonEngineeringCanonicals is derived from professionalPhraseAliases, never written by
-// hand: a term added to that list is non-engineering by construction, so the two cannot
-// drift apart.
+// nonEngineeringBareCanonicals are non-engineering disciplines whose canonical also has a
+// BARE, single-word alias in wordAliases ("seo", "ecommerce") rather than only a multi-word
+// phrase. professionalPhraseAliases covers the multi-word marketing/business phrases
+// (technical-seo, link-building, content-marketing, …); these two canonicals fall through
+// that derivation entirely and, unlisted, would read as unrecognised — which HasEngineering
+// treats as engineering — for a discipline the dictionary in fact recognises.
+var nonEngineeringBareCanonicals = map[string]bool{
+	"seo":       true,
+	"ecommerce": true,
+}
+
+// nonEngineeringCanonicals is derived from professionalPhraseAliases plus
+// nonEngineeringBareCanonicals, never written by hand beyond those two sources: a term added
+// to either cannot drift out of sync with this set.
 var nonEngineeringCanonicals = func() map[string]bool {
-	out := make(map[string]bool, len(professionalPhraseAliases))
+	out := make(map[string]bool, len(professionalPhraseAliases)+len(nonEngineeringBareCanonicals))
 	for _, p := range professionalPhraseAliases {
 		out[p.canonical] = true
+	}
+	for c := range nonEngineeringBareCanonicals {
+		out[c] = true
 	}
 	return out
 }()

--- a/internal/skilltag/dictionaries_test.go
+++ b/internal/skilltag/dictionaries_test.go
@@ -100,6 +100,10 @@ func TestHasEngineering(t *testing.T) {
 		{"pure sales", []string{"account-executive", "pipeline-management", "lead-generation"}, false},
 		{"pure support", []string{"help-desk", "ticket-resolution"}, false},
 		{"pure customer success renewal", []string{"renewal-management"}, false},
+		// The bare-word canonicals "seo" and "ecommerce" have no multi-word phrase alias,
+		// so they fall outside professionalPhraseAliases; they must still read as
+		// non-engineering, same as every other marketing/business discipline above.
+		{"pure marketing seo", []string{"seo", "ecommerce"}, false},
 		// One engineering canonical is enough — the board has posted something technical.
 		{"recruiter who also names a stack", []string{"talent-sourcing", "python"}, true},
 		{"plain engineering", []string{"kubernetes"}, true},

--- a/internal/skilltag/dictionaries_test.go
+++ b/internal/skilltag/dictionaries_test.go
@@ -104,6 +104,10 @@ func TestHasEngineering(t *testing.T) {
 		// so they fall outside professionalPhraseAliases; they must still read as
 		// non-engineering, same as every other marketing/business discipline above.
 		{"pure marketing seo", []string{"seo", "ecommerce"}, false},
+		// The exact tag set Parse produces for "SEO Specialist using Ahrefs and SEMrush" —
+		// a purely non-technical marketing posting must not be read as having posted
+		// "something technical".
+		{"seo specialist with tools", []string{"ahrefs", "semrush", "seo"}, false},
 		// One engineering canonical is enough — the board has posted something technical.
 		{"recruiter who also names a stack", []string{"talent-sourcing", "python"}, true},
 		{"plain engineering", []string{"kubernetes"}, true},


### PR DESCRIPTION
## Summary

- **internal/cvedit/undo.go:71** — `Revert`/`RevertBatch` replayed a revision's stored inverse ops against whatever the current document looked like, with no check that the addressed list hadn't been reshaped by an interleaving edit since. An in-range but stale index could silently land content at the wrong position. `undo()` now refuses (`ErrCannotUndo`) when a foreign, still-standing revision created after the earliest one being reverted carries an insert/remove/move on the same list any of the reverted ops address.
- **internal/cv/autopilot_store.go:101** — `MergeAutopilotEntry` was an unlocked read-modify-write (`Get` then `SetAutopilotReport`), so two concurrent merges could silently lose one's entries. Replaced with a single atomic `UPDATE` (`MergeCVAutopilotEntry`) that matches-or-appends inside the database, evaluated under Postgres's own row lock.
- **internal/cvedit/editor.go:373** — `CommitDocument` authorized inside the locked transaction (unlike `Commit`, which authorizes before locking to keep the evidence gate's bank read off the pool while the row is held). Now refuses the agent actor outright (`ErrCommitDocumentAgentUnsupported`), making the "no bank read under the lock" invariant a guarantee instead of a convention every caller had to keep.
- **internal/location/eligibility.go:26** — `USOnlyFromDescription` did unanchored substring matching with no negation handling, so "does not require US citizenship" read the same as an actual requirement. Matches are now checked against the sentence they sit in for a whole-word negation cue before counting as an assertion.
- **internal/skilltag/dictionaries.go:637 / skilltag.go:253** — The bare-word canonicals `seo`/`ecommerce` had no multi-word phrase alias, so they fell outside `nonEngineeringCanonicals`'s derivation and read as engineering evidence, causing `HasEngineering` to wrongly treat a pure-marketing/SEO tag set as technical.
- **internal/jdresolve/jdresolve.go:86** — `resolveSlug` had no ownership/`is_private` check, so a private job's slug (if it ever leaked) could be resolved by any authenticated user. Now refuses with `ErrJobNotFound` when the job is private and not owned by the caller.
- **internal/collections/register.go:195** — `DropAmbiguous` computed `RegisterSlug(r.Name)` twice per record; now computed once and reused, halving CPU on the ~120k-row UK register.

## Test plan

- [x] `gofmt -l .` — clean
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test ./...` — all pass except `TestExtractResumeProfile_PDF`, which fails identically on `origin/main` (pre-existing, unrelated to this branch)
- [x] `go test -race ./internal/cv/... -run Autopilot` — new concurrent-merge regression test passes under `-race`
- [x] `go test -tags=integration ./internal/jdresolve/...` — new private-job cross-user boundary test passes (Docker/testcontainers)
- [x] `go test -tags=integration ./internal/handler/... -run "TestCV|TestAutopilot|TestUndo|TestRevert"` — undo/revert, autopilot merge, and CommitDocument-related handler flows all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
