### PR TITLE
Fix search/matching/db findings from code review (11 items)

### DIFF
--- a/cmd/search-drain/indexer.go
+++ b/cmd/search-drain/indexer.go
@@ -22,7 +22,77 @@ type searchIndexer struct {
 	q      *db.Queries
 }
 
+// clusterKey identifies one role cluster. RoleClusterCountsFor/RoleClusterGeoFor match
+// their two input sets as a cross product (see those queries' doc comments), so the
+// caller keys results by the exact pair rather than trusting that every returned row
+// belongs to a job in this wave.
+type clusterKey struct {
+	companySlug     string
+	roleFingerprint string
+}
+
 func (ix searchIndexer) IndexBatch(ctx context.Context, jobs []db.Job) error {
+	// Resolve every job's role-cluster counts (and, for clusters with more than one open
+	// row, geography) in two queries scoped to the whole wave instead of one
+	// RoleClusterCount/RoleClusterGeo round trip per job — at the documented default wave
+	// size (500) that was up to ~1000 sequential DB calls per drain pass.
+	slugs := make([]string, 0, len(jobs))
+	prints := make([]string, 0, len(jobs))
+	seen := map[clusterKey]struct{}{}
+	for _, job := range jobs {
+		if !job.RoleFingerprint.Valid || job.RoleFingerprint.String == "" {
+			continue
+		}
+		key := clusterKey{job.CompanySlug, job.RoleFingerprint.String}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		slugs = append(slugs, job.CompanySlug)
+		prints = append(prints, job.RoleFingerprint.String)
+	}
+	counts := map[clusterKey]db.RoleClusterCountsForRow{}
+	if len(slugs) > 0 {
+		rows, err := ix.q.RoleClusterCountsFor(ctx, db.RoleClusterCountsForParams{
+			CompanySlugs:     slugs,
+			RoleFingerprints: prints,
+		})
+		if err != nil {
+			log.Printf("search-drain: role-cluster counts for wave: %v", err)
+		} else {
+			for _, r := range rows {
+				counts[clusterKey{r.CompanySlug, r.RoleFingerprint.String}] = r
+			}
+		}
+	}
+
+	// Only clusters with more than one open row need a geography union — a singleton's
+	// own geography is already what search.FromJob wrote, so RoleClusterGeo(For) on it is
+	// a documented no-op. Narrowing the second query to just those pairs mirrors the
+	// per-job askGeo gate this replaces.
+	geoSlugs := make([]string, 0, len(slugs))
+	geoPrints := make([]string, 0, len(prints))
+	for key, c := range counts {
+		if c.MassCount > 1 {
+			geoSlugs = append(geoSlugs, key.companySlug)
+			geoPrints = append(geoPrints, key.roleFingerprint)
+		}
+	}
+	geo := map[clusterKey]db.RoleClusterGeoForRow{}
+	if len(geoSlugs) > 0 {
+		rows, err := ix.q.RoleClusterGeoFor(ctx, db.RoleClusterGeoForParams{
+			CompanySlugs:     geoSlugs,
+			RoleFingerprints: geoPrints,
+		})
+		if err != nil {
+			log.Printf("search-drain: role-cluster geography for wave: %v", err)
+		} else {
+			for _, r := range rows {
+				geo[clusterKey{r.CompanySlug, r.RoleFingerprint.String}] = r
+			}
+		}
+	}
+
 	docs := make([]search.JobDocument, 0, len(jobs))
 	for _, job := range jobs {
 		// A job whose category neither the title dictionary nor the LLM ever resolved
@@ -40,28 +110,21 @@ func (ix searchIndexer) IndexBatch(ctx context.Context, jobs []db.Job) error {
 			return fmt.Errorf("build document (job %d): %w", job.ID, err)
 		}
 		repost, mass := int64(1), int64(1)
-		// askGeo defaults to true because a FAILED count must not also suppress the
-		// geography merge below: skipping it is destructive (the push replaces the
-		// stored union), not conservative. Only a known singleton can safely skip.
+		// askGeo defaults to true because a lookup miss (the counts query failed, or the
+		// job's cluster simply has no row) must not also suppress the geography merge
+		// below: skipping it is destructive (the push replaces the stored union), not
+		// conservative. Only a known singleton can safely skip.
 		askGeo := true
-		if c, err := ix.q.RoleClusterCount(ctx, db.RoleClusterCountParams{
-			CompanySlug:     job.CompanySlug,
-			RoleFingerprint: job.RoleFingerprint,
-		}); err != nil {
-			log.Printf("search-drain: role-cluster count for job %d: %v", job.ID, err)
-		} else {
-			repost, mass = c.RepostCount, c.MassCount
-			askGeo = mass > 1
+		if job.RoleFingerprint.Valid && job.RoleFingerprint.String != "" {
+			if c, ok := counts[clusterKey{job.CompanySlug, job.RoleFingerprint.String}]; ok {
+				repost, mass = c.RepostCount, c.MassCount
+				askGeo = mass > 1
+			}
 		}
 		reality := jobview.ClassifyReality(job, time.Now(), int(repost), int(mass))
 		doc.Reality = &reality
-		if askGeo {
-			if g, err := ix.q.RoleClusterGeo(ctx, db.RoleClusterGeoParams{
-				CompanySlug:     job.CompanySlug,
-				RoleFingerprint: job.RoleFingerprint,
-			}); err != nil {
-				log.Printf("search-drain: role-cluster geography for job %d: %v", job.ID, err)
-			} else {
+		if askGeo && job.RoleFingerprint.Valid && job.RoleFingerprint.String != "" {
+			if g, ok := geo[clusterKey{job.CompanySlug, job.RoleFingerprint.String}]; ok {
 				doc.MergeClusterGeography(g.Countries, g.Regions, g.Cities)
 			}
 		}

--- a/cmd/search-drain/search_drain_integration_test.go
+++ b/cmd/search-drain/search_drain_integration_test.go
@@ -164,3 +164,76 @@ func TestIntegration_SearchDrainWorkerWidensCanonWithClusterGeography(t *testing
 		t.Errorf("search_outbox has %d rows, want 0 (drained)", n)
 	}
 }
+
+// TestIntegration_SearchDrainWorkerBatchesRoleClusterLookupsWithoutCrossContamination
+// covers the fix for IndexBatch's per-job RoleClusterCount/RoleClusterGeo round trips
+// (batched into one RoleClusterCountsFor + one RoleClusterGeoFor call per wave, keyed by
+// the (company_slug, role_fingerprint) pair): two different companies sharing the exact
+// same role_fingerprint string, plus a singleton canon with no repost at all, all drain
+// in the SAME wave. If the batched lookup ever collapsed its results by role_fingerprint
+// alone (dropping company_slug from the key), acme's canon would be widened with
+// globex's city too; if a singleton's cluster key were looked up against the wrong
+// pair, its untouched geography would change.
+func TestIntegration_SearchDrainWorkerBatchesRoleClusterLookupsWithoutCrossContamination(t *testing.T) {
+	ctx := context.Background()
+	meiliURL, key := startMeili(t)
+	pool := testdb.Pool(t)
+
+	client := search.NewClient(meiliURL, key)
+	if err := client.EnsureIndex(ctx); err != nil {
+		t.Fatalf("EnsureIndex: %v", err)
+	}
+
+	// acme/fp-shared: canon + repost, same shape as the test above.
+	acmeCanonID := seedJob(t, pool, "acme-canon", "Senior Backend Engineer", "acme", "fp-shared", []string{"Berlin"}, nil)
+	seedJob(t, pool, "acme-repost", "Senior Backend Engineer", "acme", "fp-shared", []string{"Paris"}, &acmeCanonID)
+
+	// globex/fp-shared: a DIFFERENT company using the identical role_fingerprint string,
+	// with no repost of its own — its geography must stay exactly what it was seeded
+	// with, not pick up acme's cities (or vice versa).
+	globexCanonID := seedJob(t, pool, "globex-canon", "Senior Backend Engineer", "globex", "fp-shared", []string{"Tokyo"}, nil)
+
+	// A true singleton (no repost, no fingerprint collision) in the same wave, to prove
+	// the batched geo query is correctly skipped/no-op for it too.
+	soloID := seedJob(t, pool, "solo", "Staff Platform Engineer", "acme", "fp-solo", []string{"Warsaw"}, nil)
+
+	enqueue(t, pool, acmeCanonID)
+	enqueue(t, pool, globexCanonID)
+	enqueue(t, pool, soloID)
+
+	runner := searchdrain.Runner{Store: newDBStore(pool), Indexer: searchIndexer{client: client, q: db.New(pool)}}
+	stats, err := runner.Run(ctx, searchdrain.RunOptions{BatchSize: 500, LeaseSeconds: 180, MaxAttempts: 3})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Indexed != 3 || stats.Failed != 0 {
+		t.Fatalf("stats = %+v, want indexed=3 failed=0", stats)
+	}
+
+	found, cities := meiliDoc(t, meiliURL, key, acmeCanonID)
+	if !found {
+		t.Fatalf("acme canon job %d not found in the jobs index after drain", acmeCanonID)
+	}
+	slices.Sort(cities)
+	if want := []string{"Berlin", "Paris"}; !slices.Equal(cities, want) {
+		t.Errorf("acme canon cities = %v, want %v — must not pick up globex's city despite the "+
+			"shared role_fingerprint", cities, want)
+	}
+
+	found, cities = meiliDoc(t, meiliURL, key, globexCanonID)
+	if !found {
+		t.Fatalf("globex canon job %d not found in the jobs index after drain", globexCanonID)
+	}
+	if want := []string{"Tokyo"}; !slices.Equal(cities, want) {
+		t.Errorf("globex canon cities = %v, want %v (its own, unwidened) — must not pick up "+
+			"acme's cities despite the shared role_fingerprint", cities, want)
+	}
+
+	found, cities = meiliDoc(t, meiliURL, key, soloID)
+	if !found {
+		t.Fatalf("solo job %d not found in the jobs index after drain", soloID)
+	}
+	if want := []string{"Warsaw"}; !slices.Equal(cities, want) {
+		t.Errorf("solo job cities = %v, want %v (untouched singleton)", cities, want)
+	}
+}

--- a/internal/assistant/message.go
+++ b/internal/assistant/message.go
@@ -165,14 +165,29 @@ func Conversation(msgs []Message) ([]llms.MessageContent, error) {
 // real citation but long enough that it can't be found by accident in unrelated chatter.
 const minQuoteWords = 3
 
+// negationCues are words that, appearing between a sentence boundary and the quote's
+// start, flip the sentence's meaning — "I did NOT lead the migration" is a denial, not
+// an assertion, even though "lead the migration" is a literal substring of it. Checked
+// only within the same sentence as the quote (split on '.', ';', '!', '?'), so an
+// unrelated negation elsewhere in a long message cannot suppress a genuine, unrelated
+// citation. This is deliberately a blunt, high-recall list: UserSaid gates what may be
+// stamped stated_in_chat (candidate-asserted, CV-eligible), so a false rejection just
+// falls back to agent_inferred provenance, while a false acceptance would let a denial
+// be written into the CV as a claim.
+var negationCues = []string{"n't", " not ", " not,", " never ", "no longer", "without ever", "cannot "}
+
 // UserSaid reports whether quote appears in what the user actually typed in this
-// conversation, compared case-insensitively and with whitespace collapsed.
+// conversation, compared case-insensitively and with whitespace collapsed — and is NOT
+// negated by the sentence it appears in.
 //
 // It exists so a tool can verify a citation instead of trusting one. A model that must
 // quote the user verbatim to have its write treated as the user's assertion cannot promote
 // its own inference by simply claiming the user said it — the transcript is checked. The
 // comparison is deliberately literal: normalizing further (stemming, fuzzy matching) would
 // let a paraphrase pass, and a paraphrase is precisely the thing being guarded against.
+// A plain substring match alone would still misattribute provenance on a denial — "I have
+// NOT worked with Kubernetes" literally contains "worked with Kubernetes" — so every match
+// is additionally checked against negationCues within the same sentence.
 func UserSaid(transcript []Message, quote string) bool {
 	quote = collapseSpace(quote)
 	if quote == "" || len(strings.Fields(quote)) < minQuoteWords {
@@ -186,7 +201,37 @@ func UserSaid(transcript []Message, quote string) bool {
 		if err := json.Unmarshal(m.Content, &c); err != nil {
 			continue
 		}
-		if strings.Contains(collapseSpace(c.Text), quote) {
+		text := collapseSpace(c.Text)
+		for start := 0; ; {
+			idx := strings.Index(text[start:], quote)
+			if idx < 0 {
+				break
+			}
+			idx += start
+			if !sentenceNegatesQuoteAt(text, idx) {
+				return true
+			}
+			start = idx + 1
+		}
+	}
+	return false
+}
+
+// sentenceNegatesQuoteAt reports whether the sentence containing text[at:] carries a
+// negation cue before the quote begins. text is already collapseSpace-d (lowercased,
+// single-spaced), so the cues and the '.'/';'/'!'/'?' boundaries below match plain bytes.
+func sentenceNegatesQuoteAt(text string, at int) bool {
+	start := 0
+	for _, sep := range []byte{'.', ';', '!', '?'} {
+		if p := strings.LastIndexByte(text[:at], sep); p+1 > start {
+			start = p + 1
+		}
+	}
+	// Pad with a leading/trailing space so a cue like " not " matches at a sentence's
+	// very first or last word too, without needing separate anchored variants.
+	sentence := " " + text[start:at]
+	for _, cue := range negationCues {
+		if strings.Contains(sentence, cue) {
 			return true
 		}
 	}

--- a/internal/assistant/runner.go
+++ b/internal/assistant/runner.go
@@ -186,7 +186,7 @@ func (r *Runner) Continue(ctx context.Context, sess Session, reg *Registry, syst
 	// Activity only — no new prompt, no re-label.
 	writeCtx, cancel := persisting(ctx)
 	defer cancel()
-	if err := r.store.Touch(writeCtx, sess.ID); err != nil {
+	if err := r.store.Touch(writeCtx, sess.ID, sess.UserID); err != nil {
 		log.Printf("assistant: touch session %s: %v", sess.ID, err)
 	}
 	return r.runFromHistory(ctx, sess, reg, system, turn, emit)
@@ -314,10 +314,10 @@ func (r *Runner) recordPrompt(ctx context.Context, sess Session, prompt string, 
 	}
 	// Label and activity stamp are conveniences, not correctness: a failure here
 	// must not cost the user their turn.
-	if err := r.store.LabelSession(writeCtx, sess.ID, prompt); err != nil {
+	if err := r.store.LabelSession(writeCtx, sess.ID, sess.UserID, prompt); err != nil {
 		log.Printf("assistant: label session %s: %v", sess.ID, err)
 	}
-	if err := r.store.Touch(writeCtx, sess.ID); err != nil {
+	if err := r.store.Touch(writeCtx, sess.ID, sess.UserID); err != nil {
 		log.Printf("assistant: touch session %s: %v", sess.ID, err)
 	}
 	emit(Event{Kind: EventUserPrompt, Text: prompt})

--- a/internal/assistant/runner.go
+++ b/internal/assistant/runner.go
@@ -395,8 +395,14 @@ func (r *Runner) persist(ctx context.Context, sessionID uuid.UUID, msg Message) 
 
 // history rebuilds the model's conversation: the session's system prompt followed
 // by its most recent messages.
+//
+// Fetches only the tail via RecentTranscript rather than the whole transcript via
+// Transcript — trim() below only ever keeps the last HistoryLimit messages anyway, so
+// fetching everything first paid a cost proportional to the session's total length
+// (autopilot runs and long-lived chats can accumulate hundreds of rows) on every single
+// turn, for a window whose size never changes.
 func (r *Runner) history(ctx context.Context, sessionID uuid.UUID, system string) ([]llms.MessageContent, error) {
-	stored, err := r.store.Transcript(ctx, sessionID)
+	stored, err := r.store.RecentTranscript(ctx, sessionID, r.cfg.HistoryLimit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/assistant/runner_test.go
+++ b/internal/assistant/runner_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/tmc/langchaingo/llms"
 
+	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/llm"
 )
 
@@ -525,7 +526,9 @@ func TestHistoryClosesDanglingToolCallsBeforeReplay(t *testing.T) {
 }
 
 func TestTheFirstUserMessageLabelsTheSession(t *testing.T) {
-	q := &fakeQueries{}
+	// The fake now mirrors SetAssistantSessionLabel's owner scoping, so it must know
+	// about a session matching the (id, user_id) the runner labels below.
+	q := &fakeQueries{session: db.AssistantSession{ID: sessionID, UserID: 3, Preset: PresetChat}}
 	m := &scriptedModel{replies: []*llms.ContentChoice{textReply("ok")}}
 	r := testRunner(m, q)
 

--- a/internal/assistant/store.go
+++ b/internal/assistant/store.go
@@ -67,6 +67,7 @@ type Queries interface {
 	SetAssistantSessionLabel(ctx context.Context, arg db.SetAssistantSessionLabelParams) error
 	AppendAssistantMessage(ctx context.Context, arg db.AppendAssistantMessageParams) (db.AssistantMessage, error)
 	ListAssistantMessages(ctx context.Context, sessionID uuid.UUID) ([]db.AssistantMessage, error)
+	ListRecentAssistantMessages(ctx context.Context, arg db.ListRecentAssistantMessagesParams) ([]db.AssistantMessage, error)
 }
 
 // Store persists sessions and their transcripts. Every session read and write is
@@ -186,7 +187,9 @@ func (s *Store) Append(ctx context.Context, sessionID uuid.UUID, m Message) (Mes
 	return Message{}, fmt.Errorf("assistant: append message: %w", err)
 }
 
-// Transcript reads a session's messages in order.
+// Transcript reads a session's WHOLE messages in order. For a client replaying the
+// conversation; the model's own history is rebuilt from RecentTranscript instead, which
+// does not pay for rows that would only be trimmed away.
 func (s *Store) Transcript(ctx context.Context, sessionID uuid.UUID) ([]Message, error) {
 	rows, err := s.q.ListAssistantMessages(ctx, sessionID)
 	if err != nil {
@@ -195,6 +198,27 @@ func (s *Store) Transcript(ctx context.Context, sessionID uuid.UUID) ([]Message,
 	out := make([]Message, 0, len(rows))
 	for _, r := range rows {
 		out = append(out, Message{Seq: r.Seq, Role: r.Role, Content: r.Content})
+	}
+	return out, nil
+}
+
+// RecentTranscript reads a session's most recent limit messages, oldest first — the
+// bounded counterpart of Transcript, for rebuilding the model's own history every turn
+// without fetching and JSON-decoding rows that Runner.trim() would only discard. limit
+// must be positive.
+func (s *Store) RecentTranscript(ctx context.Context, sessionID uuid.UUID, limit int) ([]Message, error) {
+	rows, err := s.q.ListRecentAssistantMessages(ctx, db.ListRecentAssistantMessagesParams{
+		SessionID: sessionID,
+		Limit:     int32(limit),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("assistant: read recent transcript: %w", err)
+	}
+	// The query orders newest first so LIMIT keeps the tail; reverse back to ascending
+	// seq order, the shape every caller (trim, Conversation) expects.
+	out := make([]Message, len(rows))
+	for i, r := range rows {
+		out[len(rows)-1-i] = Message{Seq: r.Seq, Role: r.Role, Content: r.Content}
 	}
 	return out, nil
 }

--- a/internal/assistant/store.go
+++ b/internal/assistant/store.go
@@ -63,7 +63,7 @@ type Queries interface {
 	ListAssistantChatSessions(ctx context.Context, userID int64) ([]db.ListAssistantChatSessionsRow, error)
 	GetAssistantSession(ctx context.Context, arg db.GetAssistantSessionParams) (db.GetAssistantSessionRow, error)
 	DeleteAssistantSession(ctx context.Context, arg db.DeleteAssistantSessionParams) (int64, error)
-	TouchAssistantSession(ctx context.Context, id uuid.UUID) error
+	TouchAssistantSession(ctx context.Context, arg db.TouchAssistantSessionParams) error
 	SetAssistantSessionLabel(ctx context.Context, arg db.SetAssistantSessionLabelParams) error
 	AppendAssistantMessage(ctx context.Context, arg db.AppendAssistantMessageParams) (db.AssistantMessage, error)
 	ListAssistantMessages(ctx context.Context, sessionID uuid.UUID) ([]db.AssistantMessage, error)
@@ -131,19 +131,23 @@ func (s *Store) DeleteSession(ctx context.Context, id uuid.UUID, userID int64) e
 }
 
 // Touch marks a session as the most recently active, so the rail follows real use.
-func (s *Store) Touch(ctx context.Context, id uuid.UUID) error {
-	if err := s.q.TouchAssistantSession(ctx, id); err != nil {
+// Owner-scoped like every other session write: userID must be the caller who already
+// proved ownership of id (the Session it just read, created, or continued).
+func (s *Store) Touch(ctx context.Context, id uuid.UUID, userID int64) error {
+	if err := s.q.TouchAssistantSession(ctx, db.TouchAssistantSessionParams{ID: id, UserID: userID}); err != nil {
 		return fmt.Errorf("assistant: touch session: %w", err)
 	}
 	return nil
 }
 
 // LabelSession names a session from its first user message. The query applies it
-// only while the label is unset, so this is safe to call on every turn.
-func (s *Store) LabelSession(ctx context.Context, id uuid.UUID, label string) error {
+// only while the label is unset, so this is safe to call on every turn. Owner-scoped
+// like Touch.
+func (s *Store) LabelSession(ctx context.Context, id uuid.UUID, userID int64, label string) error {
 	err := s.q.SetAssistantSessionLabel(ctx, db.SetAssistantSessionLabelParams{
-		ID:    id,
-		Label: pgtype.Text{String: label, Valid: label != ""},
+		ID:     id,
+		UserID: userID,
+		Label:  pgtype.Text{String: label, Valid: label != ""},
 	})
 	if err != nil {
 		return fmt.Errorf("assistant: label session: %w", err)

--- a/internal/assistant/store_test.go
+++ b/internal/assistant/store_test.go
@@ -3,6 +3,7 @@ package assistant
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -111,6 +112,26 @@ func (f *fakeQueries) ListAssistantMessages(_ context.Context, sessionID uuid.UU
 	return out, nil
 }
 
+// ListRecentAssistantMessages mimics the real query: newest limit rows first, the
+// caller (Store.RecentTranscript) is the one that reverses back to ascending order.
+func (f *fakeQueries) ListRecentAssistantMessages(_ context.Context, arg db.ListRecentAssistantMessagesParams) ([]db.AssistantMessage, error) {
+	var all []db.AssistantMessage
+	for _, m := range f.messages {
+		if m.SessionID == arg.SessionID {
+			all = append(all, db.AssistantMessage{SessionID: m.SessionID, Seq: m.Seq, Role: m.Role, Content: m.Content})
+		}
+	}
+	limit := int(arg.Limit)
+	if limit > len(all) {
+		limit = len(all)
+	}
+	out := make([]db.AssistantMessage, limit)
+	for i := 0; i < limit; i++ {
+		out[i] = all[len(all)-1-i]
+	}
+	return out, nil
+}
+
 func TestGetSessionMapsNullableColumns(t *testing.T) {
 	f := &fakeQueries{session: db.AssistantSession{
 		ID: sessionID, UserID: 3, Preset: PresetTailor,
@@ -190,6 +211,46 @@ func TestAppendAndReadTranscript(t *testing.T) {
 	}
 	if len(history) != 2 {
 		t.Errorf("history has %d messages, want 2", len(history))
+	}
+}
+
+// RecentTranscript is the bounded counterpart of Transcript used to rebuild the model's
+// own history every turn (see Runner.history) — it must return exactly the same tail
+// Transcript's own last-N slice would, in the same ascending seq order, without ever
+// asking the fake for more than `limit` rows.
+func TestRecentTranscriptReturnsTheTailInAscendingOrder(t *testing.T) {
+	f := &fakeQueries{}
+	s := NewStore(f)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		msg, _ := EncodeUser(strings.Repeat("m", i+1))
+		if _, err := s.Append(ctx, sessionID, msg); err != nil {
+			t.Fatalf("seed message %d: %v", i, err)
+		}
+	}
+
+	got, err := s.RecentTranscript(ctx, sessionID, 3)
+	if err != nil {
+		t.Fatalf("RecentTranscript: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d messages, want 3", len(got))
+	}
+	wantSeqs := []int32{3, 4, 5}
+	for i, seq := range wantSeqs {
+		if got[i].Seq != seq {
+			t.Errorf("got[%d].Seq = %d, want %d — the tail in ascending order", i, got[i].Seq, seq)
+		}
+	}
+
+	// A limit at or above the transcript's whole length is the same as reading it all.
+	all, err := s.RecentTranscript(ctx, sessionID, 100)
+	if err != nil {
+		t.Fatalf("RecentTranscript(100): %v", err)
+	}
+	if len(all) != 5 {
+		t.Fatalf("got %d messages, want all 5 when the limit exceeds the transcript length", len(all))
 	}
 }
 

--- a/internal/assistant/store_test.go
+++ b/internal/assistant/store_test.go
@@ -27,6 +27,9 @@ type fakeQueries struct {
 	gotUserID int64
 	labelSet  string
 	touched   uuid.UUID
+
+	touchedUserID int64
+	labelUserID   int64
 }
 
 func (f *fakeQueries) CreateAssistantSession(_ context.Context, arg db.CreateAssistantSessionParams) (db.CreateAssistantSessionRow, error) {
@@ -61,12 +64,25 @@ func (f *fakeQueries) DeleteAssistantSession(_ context.Context, _ db.DeleteAssis
 	return f.deleted, nil
 }
 
-func (f *fakeQueries) TouchAssistantSession(_ context.Context, id uuid.UUID) error {
-	f.touched = id
+// TouchAssistantSession mimics the real query's WHERE id = $1 AND user_id = $2: a
+// mismatched owner affects nothing, silently — an :exec query has no row count to
+// surface, so the store can't tell "touched" from "matched no row" apart, same as
+// production.
+func (f *fakeQueries) TouchAssistantSession(_ context.Context, arg db.TouchAssistantSessionParams) error {
+	f.touchedUserID = arg.UserID
+	if f.session.ID != arg.ID || f.session.UserID != arg.UserID {
+		return nil
+	}
+	f.touched = arg.ID
 	return nil
 }
 
+// SetAssistantSessionLabel mimics the real query's owner scoping the same way.
 func (f *fakeQueries) SetAssistantSessionLabel(_ context.Context, arg db.SetAssistantSessionLabelParams) error {
+	f.labelUserID = arg.UserID
+	if f.session.ID != arg.ID || f.session.UserID != arg.UserID {
+		return nil
+	}
 	f.labelSet = arg.Label.String
 	return nil
 }
@@ -178,13 +194,51 @@ func TestAppendAndReadTranscript(t *testing.T) {
 }
 
 func TestLabelSessionUsesTheFirstMessage(t *testing.T) {
-	f := &fakeQueries{}
+	f := &fakeQueries{session: db.AssistantSession{ID: sessionID, UserID: 3, Preset: PresetChat}}
 	s := NewStore(f)
-	if err := s.LabelSession(context.Background(), sessionID, "find go jobs"); err != nil {
+	if err := s.LabelSession(context.Background(), sessionID, 3, "find go jobs"); err != nil {
 		t.Fatalf("LabelSession: %v", err)
 	}
 	if f.labelSet != "find go jobs" {
 		t.Errorf("label = %q, want the first user message", f.labelSet)
+	}
+}
+
+// TestLabelSessionAndTouchAreOwnerScoped covers the fix for TouchAssistantSession and
+// SetAssistantSessionLabel: both now carry a user_id predicate (mirroring every other
+// write in this file), so calling either with the wrong owner must affect nothing,
+// exactly the way a mismatched id already does.
+func TestLabelSessionAndTouchAreOwnerScoped(t *testing.T) {
+	f := &fakeQueries{session: db.AssistantSession{ID: sessionID, UserID: 3, Preset: PresetChat}}
+	s := NewStore(f)
+	ctx := context.Background()
+
+	if err := s.LabelSession(ctx, sessionID, 99, "someone else's session"); err != nil {
+		t.Fatalf("LabelSession: %v", err)
+	}
+	if f.labelUserID != 99 {
+		t.Errorf("the fake did not see the caller's user id (%d)", f.labelUserID)
+	}
+	if f.labelSet != "" {
+		t.Errorf("label = %q, want unset — session %s is not owned by user 99", f.labelSet, sessionID)
+	}
+
+	if err := s.Touch(ctx, sessionID, 99); err != nil {
+		t.Fatalf("Touch: %v", err)
+	}
+	if f.touchedUserID != 99 {
+		t.Errorf("the fake did not see the caller's user id (%d)", f.touchedUserID)
+	}
+	if f.touched == sessionID {
+		t.Errorf("touched = %s, want untouched — session %s is not owned by user 99", f.touched, sessionID)
+	}
+
+	// The real owner still succeeds.
+	if err := s.Touch(ctx, sessionID, 3); err != nil {
+		t.Fatalf("Touch: %v", err)
+	}
+	if f.touched != sessionID {
+		t.Errorf("touched = %s, want %s for the real owner", f.touched, sessionID)
 	}
 }
 

--- a/internal/assistant/user_said_test.go
+++ b/internal/assistant/user_said_test.go
@@ -54,6 +54,73 @@ func TestUserSaidOnAnEmptyTranscript(t *testing.T) {
 	}
 }
 
+// A quote that is a literal substring of a sentence the candidate used to DENY the
+// thing must not count as the candidate asserting it — the exact false-positive the
+// design's negation reasoning previously skipped over.
+func TestUserSaidRejectsAQuoteInsideANegatedSentence(t *testing.T) {
+	tests := []struct {
+		name       string
+		transcript []Message
+		quote      string
+	}{
+		{
+			"semicolon-separated denial",
+			[]Message{mustUser(t, "I did not lead the migration to Kubernetes; my colleague did all of it")},
+			"lead the migration to Kubernetes",
+		},
+		{
+			"contraction denial",
+			[]Message{mustUser(t, "I didn't work with Kubernetes at that job")},
+			"worked with Kubernetes",
+		},
+		{
+			"explicit NOT, case-insensitive",
+			[]Message{mustUser(t, "I have NOT worked with Kubernetes")},
+			"worked with Kubernetes",
+		},
+		{
+			"never",
+			[]Message{mustUser(t, "I never touched the payments service")},
+			"touched the payments service",
+		},
+		{
+			"cannot",
+			[]Message{mustUser(t, "I cannot claim experience with distributed tracing")},
+			"claim experience with distributed tracing",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if UserSaid(tt.transcript, tt.quote) {
+				t.Errorf("UserSaid confirmed %q against a sentence that denies it", tt.quote)
+			}
+		})
+	}
+}
+
+// The negation check is scoped to the sentence carrying the quote — an unrelated
+// negation elsewhere in the same message must not suppress a genuine, separate
+// assertion.
+func TestUserSaidStillPassesAGenuineAssertionNearAnUnrelatedNegation(t *testing.T) {
+	transcript := []Message{mustUser(t, "I never touched the payments service. I led the migration to Kubernetes.")}
+	if !UserSaid(transcript, "led the migration to Kubernetes") {
+		t.Error("an unrelated negation in an earlier sentence suppressed a genuine, separate assertion")
+	}
+}
+
+// A negated first occurrence must not block a later, unnegated occurrence of the exact
+// same wording elsewhere in the transcript.
+func TestUserSaidFindsALaterUnnegatedOccurrenceAfterAnEarlierDenial(t *testing.T) {
+	transcript := []Message{
+		mustUser(t, "I did not lead the migration to Kubernetes at my last job"),
+		mustAssistant(t, "Got it."),
+		mustUser(t, "Actually, I did lead the migration to Kubernetes at my CURRENT job"),
+	}
+	if !UserSaid(transcript, "lead the migration to Kubernetes") {
+		t.Error("a genuine later assertion was rejected because an earlier message denied the same wording")
+	}
+}
+
 func mustUser(t *testing.T, text string) Message {
 	t.Helper()
 	m, err := EncodeUser(text)

--- a/internal/db/applications.sql.go
+++ b/internal/db/applications.sql.go
@@ -152,6 +152,21 @@ func (q *Queries) ClearApplicationProgressByID(ctx context.Context, arg ClearApp
 	return i, err
 }
 
+const countOrphanedApplications = `-- name: CountOrphanedApplications :one
+SELECT count(*) FROM applications WHERE user_id = $1 AND job_id IS NULL
+`
+
+// How many of the caller's applications have no posting left — see
+// ListOrphanedApplications. CountUserJobs is driven entirely FROM user_jobs, which
+// cmd/prune cascades away for a pruned posting, so it never counts these; this is added
+// to its "all"/"applied"/"board" totals by the caller.
+func (q *Queries) CountOrphanedApplications(ctx context.Context, userID int64) (int64, error) {
+	row := q.db.QueryRow(ctx, countOrphanedApplications, userID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const countPreparingBackfillCandidates = `-- name: CountPreparingBackfillCandidates :one
 SELECT count(*) AS count
   FROM applications a
@@ -194,12 +209,13 @@ SELECT a.id, a.company_slug, a.role_title, a.applied_at, a.stage, a.notes, a.fol
  WHERE a.user_id = $1
    AND a.job_id IS NULL
  ORDER BY a.applied_at DESC NULLS LAST, a.id DESC
- LIMIT $2
+ LIMIT $2 OFFSET $3
 `
 
 type ListOrphanedApplicationsParams struct {
 	UserID int64 `json:"user_id"`
 	Limit  int32 `json:"limit"`
+	Offset int32 `json:"offset"`
 }
 
 type ListOrphanedApplicationsRow struct {
@@ -223,8 +239,14 @@ type ListOrphanedApplicationsRow struct {
 //
 // The board reads these alongside the posting-backed rows and merges the two; they are
 // few by nature — one appears only when a posting a candidate applied to is pruned.
+//
+// Takes OFFSET as well as LIMIT so a caller paging the merged board (ListInteractions)
+// can advance past the first page of orphans instead of re-reading the same top-N rows
+// on every page — the query alone cannot fix that, since ListInteractions decides how
+// much of the requested (limit, offset) window belongs to the posting-backed rows
+// versus the orphaned ones.
 func (q *Queries) ListOrphanedApplications(ctx context.Context, arg ListOrphanedApplicationsParams) ([]ListOrphanedApplicationsRow, error) {
-	rows, err := q.db.Query(ctx, listOrphanedApplications, arg.UserID, arg.Limit)
+	rows, err := q.db.Query(ctx, listOrphanedApplications, arg.UserID, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/assistant.sql.go
+++ b/internal/db/assistant.sql.go
@@ -223,10 +223,59 @@ WHERE session_id = $1
 ORDER BY seq
 `
 
-// A session's whole transcript in order. It is both what the client replays and what the
-// model's history is rebuilt from, so tool calls and tool results are included.
+// A session's whole transcript in order, for the client to replay. Tool calls and tool
+// results are included. Unbounded by design: the client's own message list must show
+// everything, not a trimmed window — see ListRecentAssistantMessages for the bounded
+// read the model's own history is rebuilt from.
 func (q *Queries) ListAssistantMessages(ctx context.Context, sessionID uuid.UUID) ([]AssistantMessage, error) {
 	rows, err := q.db.Query(ctx, listAssistantMessages, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AssistantMessage{}
+	for rows.Next() {
+		var i AssistantMessage
+		if err := rows.Scan(
+			&i.SessionID,
+			&i.Seq,
+			&i.Role,
+			&i.Content,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listRecentAssistantMessages = `-- name: ListRecentAssistantMessages :many
+SELECT session_id, seq, role, content, created_at
+FROM assistant_messages
+WHERE session_id = $1
+ORDER BY seq DESC
+LIMIT $2
+`
+
+type ListRecentAssistantMessagesParams struct {
+	SessionID uuid.UUID `json:"session_id"`
+	Limit     int32     `json:"limit"`
+}
+
+// The session's most recent messages, newest first — the bounded counterpart of
+// ListAssistantMessages, for rebuilding the model's own history every turn. Runner.trim()
+// only ever keeps the tail (HistoryLimit, default 60) of what ListAssistantMessages
+// returns; fetching and JSON-decoding the WHOLE transcript first, only to discard
+// everything but the tail, cost time and memory proportional to total session length
+// (autopilot runs, long-lived chat/tailoring sessions can accumulate hundreds of rows)
+// instead of the fixed window actually used. The caller reverses these rows back to
+// ascending seq order before handing them to trim()/Conversation().
+func (q *Queries) ListRecentAssistantMessages(ctx context.Context, arg ListRecentAssistantMessagesParams) ([]AssistantMessage, error) {
+	rows, err := q.db.Query(ctx, listRecentAssistantMessages, arg.SessionID, arg.Limit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/assistant.sql.go
+++ b/internal/db/assistant.sql.go
@@ -253,30 +253,41 @@ func (q *Queries) ListAssistantMessages(ctx context.Context, sessionID uuid.UUID
 
 const setAssistantSessionLabel = `-- name: SetAssistantSessionLabel :exec
 UPDATE assistant_sessions
-SET label = $2
-WHERE id = $1 AND label IS NULL
+SET label = $3
+WHERE id = $1 AND user_id = $2 AND label IS NULL
 `
 
 type SetAssistantSessionLabelParams struct {
-	ID    uuid.UUID   `json:"id"`
-	Label pgtype.Text `json:"label"`
+	ID     uuid.UUID   `json:"id"`
+	UserID int64       `json:"user_id"`
+	Label  pgtype.Text `json:"label"`
 }
 
 // Name a session from its first user message. Applied only while the label is still unset,
-// so a long conversation keeps the name it was born with.
+// so a long conversation keeps the name it was born with. Owner-scoped for the same
+// reason TouchAssistantSession is.
 func (q *Queries) SetAssistantSessionLabel(ctx context.Context, arg SetAssistantSessionLabelParams) error {
-	_, err := q.db.Exec(ctx, setAssistantSessionLabel, arg.ID, arg.Label)
+	_, err := q.db.Exec(ctx, setAssistantSessionLabel, arg.ID, arg.UserID, arg.Label)
 	return err
 }
 
 const touchAssistantSession = `-- name: TouchAssistantSession :exec
 UPDATE assistant_sessions
 SET updated_at = now()
-WHERE id = $1
+WHERE id = $1 AND user_id = $2
 `
 
+type TouchAssistantSessionParams struct {
+	ID     uuid.UUID `json:"id"`
+	UserID int64     `json:"user_id"`
+}
+
 // Mark a session as the most recently active, so the rail's order follows real use.
-func (q *Queries) TouchAssistantSession(ctx context.Context, id uuid.UUID) error {
-	_, err := q.db.Exec(ctx, touchAssistantSession, id)
+// Owner-scoped like every other write in this file (Get/Delete both require id AND
+// user_id): a bare id would let any caller who learns another user's session id touch
+// it, and every call site already has the owner's id in hand (the Session it just
+// read, created, or otherwise proved ownership of).
+func (q *Queries) TouchAssistantSession(ctx context.Context, arg TouchAssistantSessionParams) error {
+	_, err := q.db.Exec(ctx, touchAssistantSession, arg.ID, arg.UserID)
 	return err
 }

--- a/internal/db/assistant_messages_integration_test.go
+++ b/internal/db/assistant_messages_integration_test.go
@@ -1,0 +1,58 @@
+//go:build integration
+
+// Integration test for ListRecentAssistantMessages — the bounded counterpart of
+// ListAssistantMessages added so Runner.history() (internal/assistant) can rebuild the
+// model's context from just the tail of a session's transcript instead of fetching and
+// JSON-decoding the whole thing on every turn. Run with:
+// go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+func TestListRecentAssistantMessagesReturnsNewestFirstLimited(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	owner := seedAssistantUser(t, pool, "recent-transcript@example.test")
+	sess, err := q.CreateAssistantSession(ctx, CreateAssistantSessionParams{UserID: owner, Preset: "chat"})
+	if err != nil {
+		t.Fatalf("CreateAssistantSession: %v", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		if _, err := q.AppendAssistantMessage(ctx, AppendAssistantMessageParams{
+			SessionID: sess.ID, Role: "user", Content: []byte(`{"text":"m"}`),
+		}); err != nil {
+			t.Fatalf("append message %d: %v", i, err)
+		}
+	}
+
+	rows, err := q.ListRecentAssistantMessages(ctx, ListRecentAssistantMessagesParams{SessionID: sess.ID, Limit: 3})
+	if err != nil {
+		t.Fatalf("ListRecentAssistantMessages: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows, want 3", len(rows))
+	}
+	// Newest first: seq 5, 4, 3 — the caller (assistant.Store.RecentTranscript) is what
+	// reverses this back to ascending order.
+	wantSeqs := []int32{5, 4, 3}
+	for i, want := range wantSeqs {
+		if rows[i].Seq != want {
+			t.Errorf("rows[%d].Seq = %d, want %d", i, rows[i].Seq, want)
+		}
+	}
+
+	// A limit at or above the whole transcript returns everything, still newest first.
+	all, err := q.ListRecentAssistantMessages(ctx, ListRecentAssistantMessagesParams{SessionID: sess.ID, Limit: 100})
+	if err != nil {
+		t.Fatalf("ListRecentAssistantMessages(100): %v", err)
+	}
+	if len(all) != 5 {
+		t.Fatalf("got %d rows, want all 5 when the limit exceeds the transcript length", len(all))
+	}
+}

--- a/internal/db/assistant_ownership_integration_test.go
+++ b/internal/db/assistant_ownership_integration_test.go
@@ -1,0 +1,105 @@
+//go:build integration
+
+// Integration tests for TouchAssistantSession and SetAssistantSessionLabel's owner
+// scoping. Every other write on assistant_sessions (Delete, and every read) already
+// requires id AND user_id to match; these two took a bare id, so a caller with a
+// session id it does not own could still touch or relabel it — a real Postgres is the
+// only way to prove the WHERE clause change actually blocks a foreign write. Run with:
+// go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestTouchAssistantSessionIsOwnerScoped(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	owner := seedAssistantUser(t, pool, "touch-owner@example.test")
+	stranger := seedAssistantUser(t, pool, "touch-stranger@example.test")
+
+	sess, err := q.CreateAssistantSession(ctx, CreateAssistantSessionParams{UserID: owner, Preset: "chat"})
+	if err != nil {
+		t.Fatalf("CreateAssistantSession: %v", err)
+	}
+
+	// Pin updated_at to something clearly in the past so a real touch is detectable.
+	past := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	if _, err := pool.Exec(ctx, `UPDATE assistant_sessions SET updated_at = $1 WHERE id = $2`, past, sess.ID); err != nil {
+		t.Fatalf("pin updated_at: %v", err)
+	}
+
+	if err := q.TouchAssistantSession(ctx, TouchAssistantSessionParams{ID: sess.ID, UserID: stranger}); err != nil {
+		t.Fatalf("TouchAssistantSession(stranger): %v", err)
+	}
+	if got := updatedAtOf(ctx, t, pool, sess.ID); !got.Equal(past) {
+		t.Errorf("updated_at = %v, want unchanged at %v — a non-owner's touch must affect nothing", got, past)
+	}
+
+	if err := q.TouchAssistantSession(ctx, TouchAssistantSessionParams{ID: sess.ID, UserID: owner}); err != nil {
+		t.Fatalf("TouchAssistantSession(owner): %v", err)
+	}
+	if got := updatedAtOf(ctx, t, pool, sess.ID); got.Equal(past) {
+		t.Error("updated_at unchanged after the real owner's touch — want it bumped")
+	}
+}
+
+func TestSetAssistantSessionLabelIsOwnerScoped(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	owner := seedAssistantUser(t, pool, "label-owner@example.test")
+	stranger := seedAssistantUser(t, pool, "label-stranger@example.test")
+
+	sess, err := q.CreateAssistantSession(ctx, CreateAssistantSessionParams{UserID: owner, Preset: "chat"})
+	if err != nil {
+		t.Fatalf("CreateAssistantSession: %v", err)
+	}
+
+	err = q.SetAssistantSessionLabel(ctx, SetAssistantSessionLabelParams{
+		ID: sess.ID, UserID: stranger, Label: pgtype.Text{String: "renamed by a stranger", Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("SetAssistantSessionLabel(stranger): %v", err)
+	}
+	if got := labelOf(ctx, t, pool, sess.ID); got.Valid {
+		t.Errorf("label = %+v, want still unset — a non-owner's relabel must affect nothing", got)
+	}
+
+	err = q.SetAssistantSessionLabel(ctx, SetAssistantSessionLabelParams{
+		ID: sess.ID, UserID: owner, Label: pgtype.Text{String: "find go jobs", Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("SetAssistantSessionLabel(owner): %v", err)
+	}
+	if got := labelOf(ctx, t, pool, sess.ID); !got.Valid || got.String != "find go jobs" {
+		t.Errorf("label = %+v, want %q from the real owner", got, "find go jobs")
+	}
+}
+
+func updatedAtOf(ctx context.Context, t *testing.T, pool *pgxpool.Pool, id uuid.UUID) time.Time {
+	t.Helper()
+	var v time.Time
+	if err := pool.QueryRow(ctx, `SELECT updated_at FROM assistant_sessions WHERE id = $1`, id).Scan(&v); err != nil {
+		t.Fatalf("query updated_at for session %s: %v", id, err)
+	}
+	return v
+}
+
+func labelOf(ctx context.Context, t *testing.T, pool *pgxpool.Pool, id uuid.UUID) pgtype.Text {
+	t.Helper()
+	var v pgtype.Text
+	if err := pool.QueryRow(ctx, `SELECT label FROM assistant_sessions WHERE id = $1`, id).Scan(&v); err != nil {
+		t.Fatalf("query label for session %s: %v", id, err)
+	}
+	return v
+}

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -2317,6 +2317,78 @@ func (q *Queries) RoleClusterGeoAll(ctx context.Context) ([]RoleClusterGeoAllRow
 	return items, nil
 }
 
+const roleClusterGeoFor = `-- name: RoleClusterGeoFor :many
+SELECT
+    o.company_slug,
+    o.role_fingerprint,
+    array_agg(DISTINCT t.val) FILTER (WHERE t.kind = 'c' AND t.val <> '')::text[] AS countries,
+    array_agg(DISTINCT t.val) FILTER (WHERE t.kind = 'r' AND t.val <> '')::text[] AS regions,
+    array_agg(DISTINCT t.val) FILTER (WHERE t.kind = 'y' AND t.val <> '')::text[] AS cities
+FROM jobs o
+LEFT JOIN LATERAL (
+    SELECT 'c'::text AS kind, e AS val FROM unnest(o.countries) AS e
+    UNION ALL
+    SELECT 'r', e FROM unnest(o.regions) AS e
+    UNION ALL
+    SELECT 'y', e FROM unnest(o.cities) AS e
+) t ON true
+WHERE o.closed_at IS NULL
+  AND o.company_slug = ANY($1::text[])
+  AND o.role_fingerprint = ANY($2::text[])
+GROUP BY o.company_slug, o.role_fingerprint
+`
+
+type RoleClusterGeoForParams struct {
+	CompanySlugs     []string `json:"company_slugs"`
+	RoleFingerprints []string `json:"role_fingerprints"`
+}
+
+type RoleClusterGeoForRow struct {
+	CompanySlug     string      `json:"company_slug"`
+	RoleFingerprint pgtype.Text `json:"role_fingerprint"`
+	Countries       []string    `json:"countries"`
+	Regions         []string    `json:"regions"`
+	Cities          []string    `json:"cities"`
+}
+
+// Role-cluster geography unions for a SPECIFIC set of (company_slug, role_fingerprint)
+// pairs, so an incremental index push can widen a whole wave's canons in one query
+// instead of one RoleClusterGeo call per job — the geography counterpart of
+// RoleClusterCountsFor, mirrored the same way RoleClusterGeo mirrors RoleClusterCount.
+//
+// Same cross-product-narrowed-by-caller shape as RoleClusterCountsFor, for the same
+// reason (a pair-wise join needs a two-argument unnest the analyzer cannot type). Only
+// OPEN rows count, matching RoleClusterGeo/RoleClusterGeoAll; the caller is expected to
+// ask only for clusters it already knows (via RoleClusterCountsFor's mass_count) have
+// more than one open row, since a singleton's self-union is a documented no-op there —
+// but this query carries no HAVING of its own, so a caller-supplied singleton pair
+// still resolves (to its own geography, the same no-op RoleClusterGeo returns for one).
+func (q *Queries) RoleClusterGeoFor(ctx context.Context, arg RoleClusterGeoForParams) ([]RoleClusterGeoForRow, error) {
+	rows, err := q.db.Query(ctx, roleClusterGeoFor, arg.CompanySlugs, arg.RoleFingerprints)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []RoleClusterGeoForRow{}
+	for rows.Next() {
+		var i RoleClusterGeoForRow
+		if err := rows.Scan(
+			&i.CompanySlug,
+			&i.RoleFingerprint,
+			&i.Countries,
+			&i.Regions,
+			&i.Cities,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const selectOrphanLivenessCandidates = `-- name: SelectOrphanLivenessCandidates :many
 SELECT id, source, url, public_slug, liveness_strikes
 FROM jobs

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -802,13 +802,14 @@ type ScreeningAnswer struct {
 }
 
 type SearchOutbox struct {
-	ID        int64              `json:"id"`
-	JobID     int64              `json:"job_id"`
-	Attempts  int32              `json:"attempts"`
-	ClaimedAt pgtype.Timestamptz `json:"claimed_at"`
-	FailedAt  pgtype.Timestamptz `json:"failed_at"`
-	LastError string             `json:"last_error"`
-	CreatedAt pgtype.Timestamptz `json:"created_at"`
+	ID          int64              `json:"id"`
+	JobID       int64              `json:"job_id"`
+	Attempts    int32              `json:"attempts"`
+	ClaimedAt   pgtype.Timestamptz `json:"claimed_at"`
+	FailedAt    pgtype.Timestamptz `json:"failed_at"`
+	LastError   string             `json:"last_error"`
+	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	JobPostedAt pgtype.Timestamptz `json:"job_posted_at"`
 }
 
 type SemanticOutbox struct {

--- a/internal/db/orphaned_applications_integration_test.go
+++ b/internal/db/orphaned_applications_integration_test.go
@@ -1,0 +1,113 @@
+//go:build integration
+
+// Integration tests for ListOrphanedApplications' OFFSET support and
+// CountOrphanedApplications — added because the board's paging previously re-read the
+// same top-N orphaned applications (those whose posting cmd/prune removed) on every
+// page, and CountUserJobs never counted them at all. Run with:
+// go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// seedOrphanedApplication inserts an application with no posting (job_id NULL) — the
+// shape cmd/prune leaves behind (see TestApplication_OutlivesItsPosting), reproduced
+// directly here since only the orphaned shape itself matters for these tests.
+func seedOrphanedApplication(t *testing.T, pool *pgxpool.Pool, userID int64, company string, appliedAt time.Time) int64 {
+	t.Helper()
+	var id int64
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO applications (user_id, company_slug, role_title, job_id, applied_at)
+		 VALUES ($1, $2, 'Orphaned Role', NULL, $3) RETURNING id`,
+		userID, company, appliedAt).Scan(&id); err != nil {
+		t.Fatalf("seed orphaned application: %v", err)
+	}
+	return id
+}
+
+func TestListOrphanedApplicationsPagesWithOffset(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	user := seedResponseUser(t, q, "orphan-paging@example.test", true)
+
+	// Five orphaned applications, applied_at strictly decreasing so ORDER BY applied_at
+	// DESC gives a stable, known order: o0 (newest) .. o4 (oldest).
+	base := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	ids := make([]int64, 5)
+	for i := 0; i < 5; i++ {
+		ids[i] = seedOrphanedApplication(t, pool, user, "orphanco", base.Add(-time.Duration(i)*time.Minute))
+	}
+
+	page1, err := q.ListOrphanedApplications(ctx, ListOrphanedApplicationsParams{UserID: user, Limit: 2, Offset: 0})
+	if err != nil {
+		t.Fatalf("page 1: %v", err)
+	}
+	page2, err := q.ListOrphanedApplications(ctx, ListOrphanedApplicationsParams{UserID: user, Limit: 2, Offset: 2})
+	if err != nil {
+		t.Fatalf("page 2: %v", err)
+	}
+	if len(page1) != 2 || len(page2) != 2 {
+		t.Fatalf("page1=%d page2=%d rows, want 2 and 2", len(page1), len(page2))
+	}
+	if page1[0].ID == page2[0].ID || page1[1].ID == page2[1].ID {
+		t.Fatalf("page 1 (%d, %d) and page 2 (%d, %d) overlap — offset is not advancing the window",
+			page1[0].ID, page1[1].ID, page2[0].ID, page2[1].ID)
+	}
+	// Newest-first, so page1 = [ids[0], ids[1]], page2 = [ids[2], ids[3]].
+	if page1[0].ID != ids[0] || page1[1].ID != ids[1] {
+		t.Errorf("page1 = [%d %d], want [%d %d]", page1[0].ID, page1[1].ID, ids[0], ids[1])
+	}
+	if page2[0].ID != ids[2] || page2[1].ID != ids[3] {
+		t.Errorf("page2 = [%d %d], want [%d %d]", page2[0].ID, page2[1].ID, ids[2], ids[3])
+	}
+
+	// A page far enough out reaches the last, previously-unreachable row.
+	page3, err := q.ListOrphanedApplications(ctx, ListOrphanedApplicationsParams{UserID: user, Limit: 2, Offset: 4})
+	if err != nil {
+		t.Fatalf("page 3: %v", err)
+	}
+	if len(page3) != 1 || page3[0].ID != ids[4] {
+		t.Fatalf("page3 = %v, want exactly [%d] — the 5th orphan must be reachable by paging further", page3, ids[4])
+	}
+}
+
+func TestCountOrphanedApplications(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	user := seedResponseUser(t, q, "orphan-count@example.test", true)
+	other := seedResponseUser(t, q, "orphan-count-other@example.test", true)
+
+	if got, err := q.CountOrphanedApplications(ctx, user); err != nil || got != 0 {
+		t.Fatalf("count with no orphans = %d, err=%v, want 0", got, err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	seedOrphanedApplication(t, pool, user, "acme", now)
+	seedOrphanedApplication(t, pool, user, "beta", now.Add(-time.Hour))
+	// A posting-backed application (job_id set) must not be counted as orphaned, and
+	// neither must another user's orphan.
+	job := seedResponseJob(t, q, "orphan-count-linked", "acme")
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO applications (user_id, company_slug, role_title, job_id, applied_at) VALUES ($1, 'acme', 'Linked Role', $2, $3)`,
+		user, job, now); err != nil {
+		t.Fatalf("seed linked application: %v", err)
+	}
+	seedOrphanedApplication(t, pool, other, "gamma", now)
+
+	got, err := q.CountOrphanedApplications(ctx, user)
+	if err != nil {
+		t.Fatalf("CountOrphanedApplications: %v", err)
+	}
+	if got != 2 {
+		t.Errorf("count = %d, want 2 (only the user's own orphaned applications)", got)
+	}
+}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -220,12 +220,29 @@ type Querier interface {
 	// separate reaper process is needed.
 	ClaimEnrichmentBatch(ctx context.Context, arg ClaimEnrichmentBatchParams) ([]ClaimEnrichmentBatchRow, error)
 	// Claim a batch of live, unleased entries for OPEN canonical jobs, freshest job
-	// first, by stamping claimed_at. Mirrors ClaimEnrichmentBatch: the jobs join lets the
-	// claim skip a job that closed or became a non-canonical repost after it was queued
-	// (that reconciles on the next full reindex, same as before this queue existed) and
-	// order by posting freshness. FOR UPDATE OF o locks only outbox rows; SKIP LOCKED
-	// lets concurrent workers take disjoint rows; the lease predicate reclaims entries
-	// whose worker died (stale claimed_at), so no separate reaper process is needed.
+	// first, by stamping claimed_at.
+	//
+	// Orders by the outbox's OWN job_posted_at (denormalized at enqueue time from
+	// COALESCE(jobs.posted_at, jobs.created_at) — see EnqueueSearchOutbox) rather than
+	// joining jobs to compute it. A join-for-ordering here means Postgres cannot push the
+	// LIMIT below the sort — it has to nested-loop-join and sort the ENTIRE claimable set
+	// before taking the batch, independent of batch_size. This is the exact pattern
+	// ClaimSemanticBatch was measured at 109s per claim call on ~906k claimable rows and
+	// fixed the same way (see openspec/changes/prod-semantic-embed-steady-state/design.md
+	// Decision 8, which flagged this query as carrying the identical, unaddressed risk).
+	//
+	// The closed/duplicate_of check stays a per-row EXISTS rather than a JOIN: with the
+	// job_posted_at index in place, Postgres can index-scan search_outbox in the exact
+	// claim order and stop as soon as LIMIT rows pass the EXISTS lookup (a cheap jobs PK
+	// probe), instead of materializing and sorting every claimable row up front. A job
+	// that closed or became a non-canonical repost after being queued is simply skipped —
+	// same behavior as before, just reached via an index scan instead of a full join.
+	// NULLS LAST is defensive (EnqueueSearchOutbox always populates the column; this only
+	// guards a row that predates the backfill migration).
+	//
+	// FOR UPDATE OF o locks only outbox rows; SKIP LOCKED lets concurrent workers take
+	// disjoint rows; the lease predicate reclaims entries whose worker died (stale
+	// claimed_at), so no separate reaper process is needed.
 	ClaimSearchOutboxBatch(ctx context.Context, arg ClaimSearchOutboxBatchParams) ([]ClaimSearchOutboxBatchRow, error)
 	// Claim a batch of live, unleased entries, freshest job first, by stamping claimed_at.
 	// Unlike ClaimEnrichmentBatch this does NOT filter unindexable jobs out: a closed OR
@@ -925,7 +942,10 @@ type Querier interface {
 	// transaction as the job's upsert, only when the write inserted or changed indexed
 	// content (mirrors the gate the old inline SubmitJobs push used). ON CONFLICT keeps
 	// exactly one live entry per job, so a job changed again before it drains is not
-	// queued twice.
+	// queued twice. job_posted_at denormalizes COALESCE(posted_at, created_at) onto the
+	// outbox row so ClaimSearchOutboxBatch can sort by it without joining jobs on every
+	// claim (see that query's doc comment); the single-row subquery here costs nothing
+	// beyond the jobs PK lookup this call already implies.
 	EnqueueSearchOutbox(ctx context.Context, jobID int64) error
 	// Seed a balance row for a brand-new user so the subsequent SELECT ... FOR UPDATE
 	// always has a row to lock (this is what serializes concurrent first-ever debits).

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -2911,6 +2911,19 @@ type Querier interface {
 	// JOIN so a geo-less row still counts toward HAVING count(DISTINCT id) > 1 (the true cluster
 	// size); blanks/NULLs are dropped by the FILTER. Mirrors RoleClusterCountsAll's single pass.
 	RoleClusterGeoAll(ctx context.Context) ([]RoleClusterGeoAllRow, error)
+	// Role-cluster geography unions for a SPECIFIC set of (company_slug, role_fingerprint)
+	// pairs, so an incremental index push can widen a whole wave's canons in one query
+	// instead of one RoleClusterGeo call per job — the geography counterpart of
+	// RoleClusterCountsFor, mirrored the same way RoleClusterGeo mirrors RoleClusterCount.
+	//
+	// Same cross-product-narrowed-by-caller shape as RoleClusterCountsFor, for the same
+	// reason (a pair-wise join needs a two-argument unnest the analyzer cannot type). Only
+	// OPEN rows count, matching RoleClusterGeo/RoleClusterGeoAll; the caller is expected to
+	// ask only for clusters it already knows (via RoleClusterCountsFor's mass_count) have
+	// more than one open row, since a singleton's self-union is a documented no-op there —
+	// but this query carries no HAVING of its own, so a caller-supplied singleton pair
+	// still resolves (to its own geography, the same no-op RoleClusterGeo returns for one).
+	RoleClusterGeoFor(ctx context.Context, arg RoleClusterGeoForParams) ([]RoleClusterGeoForRow, error)
 	// Save (bookmark) a job for a user. Idempotent and independent of a prior view:
 	// it inserts the row (viewed_at defaults) or refreshes saved_at in place.
 	SaveJob(ctx context.Context, arg SaveJobParams) (SaveJobRow, error)

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -2982,7 +2982,8 @@ type Querier interface {
 	// than by fetching the stored url (echojobs: see cmd/liveness/echojobs.go).
 	SelectStaleRegisteredCandidates(ctx context.Context, arg SelectStaleRegisteredCandidatesParams) ([]SelectStaleRegisteredCandidatesRow, error)
 	// Name a session from its first user message. Applied only while the label is still unset,
-	// so a long conversation keeps the name it was born with.
+	// so a long conversation keeps the name it was born with. Owner-scoped for the same
+	// reason TouchAssistantSession is.
 	SetAssistantSessionLabel(ctx context.Context, arg SetAssistantSessionLabelParams) error
 	// Apply the Go-computed cooldown window to a board (called only when the backoff
 	// policy says to cool down).
@@ -3189,7 +3190,11 @@ type Querier interface {
 	// name variants; ON CONFLICT folds collisions and refreshes existing rows.
 	SyncCompaniesFromJobs(ctx context.Context) error
 	// Mark a session as the most recently active, so the rail's order follows real use.
-	TouchAssistantSession(ctx context.Context, id uuid.UUID) error
+	// Owner-scoped like every other write in this file (Get/Delete both require id AND
+	// user_id): a bare id would let any caller who learns another user's session id touch
+	// it, and every call site already has the owner's id in hand (the Session it just
+	// read, created, or otherwise proved ownership of).
+	TouchAssistantSession(ctx context.Context, arg TouchAssistantSessionParams) error
 	// Stamp the CV a click belongs to, for the tracking board's "CV opened" marker. Issued right after
 	// the click insert, as a separate statement rather than in one transaction with it: both writes are
 	// best-effort behind a redirect that must happen regardless, so there is nothing for a rollback to

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -528,6 +528,11 @@ type Querier interface {
 	// Served by the partial index threads_subject_open_created_idx; scoped to a single
 	// subject so it stays cheap (not the cross-subject count the design rules out).
 	CountOpenThreadsBySubject(ctx context.Context, arg CountOpenThreadsBySubjectParams) (int64, error)
+	// How many of the caller's applications have no posting left — see
+	// ListOrphanedApplications. CountUserJobs is driven entirely FROM user_jobs, which
+	// cmd/prune cascades away for a pruned posting, so it never counts these; this is added
+	// to its "all"/"applied"/"board" totals by the caller.
+	CountOrphanedApplications(ctx context.Context, userID int64) (int64, error)
 	// Read-only counterpart to BackfillPreparingStage, for cmd/backfill-preparing-stage's
 	// --dry-run: how many applications the correction below would touch, without touching them.
 	// Kept in exact lockstep with that query's WHERE clause deliberately — see its comment for
@@ -1981,6 +1986,12 @@ type Querier interface {
 	//
 	// The board reads these alongside the posting-backed rows and merges the two; they are
 	// few by nature — one appears only when a posting a candidate applied to is pruned.
+	//
+	// Takes OFFSET as well as LIMIT so a caller paging the merged board (ListInteractions)
+	// can advance past the first page of orphans instead of re-reading the same top-N rows
+	// on every page — the query alone cannot fix that, since ListInteractions decides how
+	// much of the requested (limit, offset) window belongs to the posting-backed rows
+	// versus the orphaned ones.
 	ListOrphanedApplications(ctx context.Context, arg ListOrphanedApplicationsParams) ([]ListOrphanedApplicationsRow, error)
 	// The moderator queue: offers awaiting a decision, oldest first, with display name.
 	// Capped at 500 as a runaway-growth guard — far above any plausible backlog; a

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1619,8 +1619,10 @@ type Querier interface {
 	// conversations are excluded for exactly that reason inverted — they belong to the CV that
 	// owns them, are reached through the tailoring workspace, and cannot be continued without it.
 	ListAssistantChatSessions(ctx context.Context, userID int64) ([]ListAssistantChatSessionsRow, error)
-	// A session's whole transcript in order. It is both what the client replays and what the
-	// model's history is rebuilt from, so tool calls and tool results are included.
+	// A session's whole transcript in order, for the client to replay. Tool calls and tool
+	// results are included. Unbounded by design: the client's own message list must show
+	// everything, not a trimmed window — see ListRecentAssistantMessages for the bounded
+	// read the model's own history is rebuilt from.
 	ListAssistantMessages(ctx context.Context, sessionID uuid.UUID) ([]AssistantMessage, error)
 	// The feed, newest first.
 	ListCVRevisions(ctx context.Context, arg ListCVRevisionsParams) ([]CvRevision, error)
@@ -1996,6 +1998,15 @@ type Querier interface {
 	ListPendingSubmissions(ctx context.Context) ([]ListPendingSubmissionsRow, error)
 	// The caller's own registered devices, for a test send or a future delivery.
 	ListPushTokensForUser(ctx context.Context, userID int64) ([]UserPushToken, error)
+	// The session's most recent messages, newest first — the bounded counterpart of
+	// ListAssistantMessages, for rebuilding the model's own history every turn. Runner.trim()
+	// only ever keeps the tail (HistoryLimit, default 60) of what ListAssistantMessages
+	// returns; fetching and JSON-decoding the WHOLE transcript first, only to discard
+	// everything but the tail, cost time and memory proportional to total session length
+	// (autopilot runs, long-lived chat/tailoring sessions can accumulate hundreds of rows)
+	// instead of the fixed window actually used. The caller reverses these rows back to
+	// ascending seq order before handing them to trim()/Conversation().
+	ListRecentAssistantMessages(ctx context.Context, arg ListRecentAssistantMessagesParams) ([]AssistantMessage, error)
 	// The "my offers" list: one member's offers with moderation status, newest first.
 	// Joins the catalogue for the company's display name (LEFT so an offer survives a
 	// company the catalogue no longer knows — the UI falls back to the slug).

--- a/internal/db/queries/applications.sql
+++ b/internal/db/queries/applications.sql
@@ -51,6 +51,12 @@ UPDATE emails e
 --
 -- The board reads these alongside the posting-backed rows and merges the two; they are
 -- few by nature — one appears only when a posting a candidate applied to is pruned.
+--
+-- Takes OFFSET as well as LIMIT so a caller paging the merged board (ListInteractions)
+-- can advance past the first page of orphans instead of re-reading the same top-N rows
+-- on every page — the query alone cannot fix that, since ListInteractions decides how
+-- much of the requested (limit, offset) window belongs to the posting-backed rows
+-- versus the orphaned ones.
 SELECT a.id, a.company_slug, a.role_title, a.applied_at, a.stage, a.notes, a.followed_up_at,
        (SELECT count(*)
           FROM emails e
@@ -70,7 +76,14 @@ SELECT a.id, a.company_slug, a.role_title, a.applied_at, a.stage, a.notes, a.fol
  WHERE a.user_id = $1
    AND a.job_id IS NULL
  ORDER BY a.applied_at DESC NULLS LAST, a.id DESC
- LIMIT $2;
+ LIMIT $2 OFFSET $3;
+
+-- name: CountOrphanedApplications :one
+-- How many of the caller's applications have no posting left — see
+-- ListOrphanedApplications. CountUserJobs is driven entirely FROM user_jobs, which
+-- cmd/prune cascades away for a pruned posting, so it never counts these; this is added
+-- to its "all"/"applied"/"board" totals by the caller.
+SELECT count(*) FROM applications WHERE user_id = $1 AND job_id IS NULL;
 
 -- name: TrackApplicationByID :one
 -- Set an application's stage and/or notes, naming the application itself.

--- a/internal/db/queries/assistant.sql
+++ b/internal/db/queries/assistant.sql
@@ -72,9 +72,26 @@ VALUES (
 RETURNING session_id, seq, role, content, created_at;
 
 -- name: ListAssistantMessages :many
--- A session's whole transcript in order. It is both what the client replays and what the
--- model's history is rebuilt from, so tool calls and tool results are included.
+-- A session's whole transcript in order, for the client to replay. Tool calls and tool
+-- results are included. Unbounded by design: the client's own message list must show
+-- everything, not a trimmed window — see ListRecentAssistantMessages for the bounded
+-- read the model's own history is rebuilt from.
 SELECT session_id, seq, role, content, created_at
 FROM assistant_messages
 WHERE session_id = $1
 ORDER BY seq;
+
+-- name: ListRecentAssistantMessages :many
+-- The session's most recent messages, newest first — the bounded counterpart of
+-- ListAssistantMessages, for rebuilding the model's own history every turn. Runner.trim()
+-- only ever keeps the tail (HistoryLimit, default 60) of what ListAssistantMessages
+-- returns; fetching and JSON-decoding the WHOLE transcript first, only to discard
+-- everything but the tail, cost time and memory proportional to total session length
+-- (autopilot runs, long-lived chat/tailoring sessions can accumulate hundreds of rows)
+-- instead of the fixed window actually used. The caller reverses these rows back to
+-- ascending seq order before handing them to trim()/Conversation().
+SELECT session_id, seq, role, content, created_at
+FROM assistant_messages
+WHERE session_id = $1
+ORDER BY seq DESC
+LIMIT $2;

--- a/internal/db/queries/assistant.sql
+++ b/internal/db/queries/assistant.sql
@@ -42,16 +42,21 @@ WHERE id = $1 AND user_id = $2;
 
 -- name: TouchAssistantSession :exec
 -- Mark a session as the most recently active, so the rail's order follows real use.
+-- Owner-scoped like every other write in this file (Get/Delete both require id AND
+-- user_id): a bare id would let any caller who learns another user's session id touch
+-- it, and every call site already has the owner's id in hand (the Session it just
+-- read, created, or otherwise proved ownership of).
 UPDATE assistant_sessions
 SET updated_at = now()
-WHERE id = $1;
+WHERE id = $1 AND user_id = $2;
 
 -- name: SetAssistantSessionLabel :exec
 -- Name a session from its first user message. Applied only while the label is still unset,
--- so a long conversation keeps the name it was born with.
+-- so a long conversation keeps the name it was born with. Owner-scoped for the same
+-- reason TouchAssistantSession is.
 UPDATE assistant_sessions
-SET label = $2
-WHERE id = $1 AND label IS NULL;
+SET label = $3
+WHERE id = $1 AND user_id = $2 AND label IS NULL;
 
 -- name: AppendAssistantMessage :one
 -- Append one message to a session's transcript, assigning the next sequence number in the

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -1336,6 +1336,38 @@ WHERE j.company_slug = ANY(sqlc.arg(company_slugs)::text[])
   AND j.role_fingerprint = ANY(sqlc.arg(role_fingerprints)::text[])
 GROUP BY j.company_slug, j.role_fingerprint;
 
+-- name: RoleClusterGeoFor :many
+-- Role-cluster geography unions for a SPECIFIC set of (company_slug, role_fingerprint)
+-- pairs, so an incremental index push can widen a whole wave's canons in one query
+-- instead of one RoleClusterGeo call per job — the geography counterpart of
+-- RoleClusterCountsFor, mirrored the same way RoleClusterGeo mirrors RoleClusterCount.
+--
+-- Same cross-product-narrowed-by-caller shape as RoleClusterCountsFor, for the same
+-- reason (a pair-wise join needs a two-argument unnest the analyzer cannot type). Only
+-- OPEN rows count, matching RoleClusterGeo/RoleClusterGeoAll; the caller is expected to
+-- ask only for clusters it already knows (via RoleClusterCountsFor's mass_count) have
+-- more than one open row, since a singleton's self-union is a documented no-op there —
+-- but this query carries no HAVING of its own, so a caller-supplied singleton pair
+-- still resolves (to its own geography, the same no-op RoleClusterGeo returns for one).
+SELECT
+    o.company_slug,
+    o.role_fingerprint,
+    array_agg(DISTINCT t.val) FILTER (WHERE t.kind = 'c' AND t.val <> '')::text[] AS countries,
+    array_agg(DISTINCT t.val) FILTER (WHERE t.kind = 'r' AND t.val <> '')::text[] AS regions,
+    array_agg(DISTINCT t.val) FILTER (WHERE t.kind = 'y' AND t.val <> '')::text[] AS cities
+FROM jobs o
+LEFT JOIN LATERAL (
+    SELECT 'c'::text AS kind, e AS val FROM unnest(o.countries) AS e
+    UNION ALL
+    SELECT 'r', e FROM unnest(o.regions) AS e
+    UNION ALL
+    SELECT 'y', e FROM unnest(o.cities) AS e
+) t ON true
+WHERE o.closed_at IS NULL
+  AND o.company_slug = ANY(sqlc.arg(company_slugs)::text[])
+  AND o.role_fingerprint = ANY(sqlc.arg(role_fingerprints)::text[])
+GROUP BY o.company_slug, o.role_fingerprint;
+
 -- name: CompaniesWithFuzzyDedupCandidates :many
 -- Company slugs worth running the fuzzy-description pass over: a company that still has more
 -- than one open CANONICAL posting after the exact role-cluster and aggregator passes, so there

--- a/internal/db/queries/search_outbox.sql
+++ b/internal/db/queries/search_outbox.sql
@@ -3,29 +3,54 @@
 -- transaction as the job's upsert, only when the write inserted or changed indexed
 -- content (mirrors the gate the old inline SubmitJobs push used). ON CONFLICT keeps
 -- exactly one live entry per job, so a job changed again before it drains is not
--- queued twice.
-INSERT INTO search_outbox (job_id)
-VALUES (sqlc.arg(job_id))
+-- queued twice. job_posted_at denormalizes COALESCE(posted_at, created_at) onto the
+-- outbox row so ClaimSearchOutboxBatch can sort by it without joining jobs on every
+-- claim (see that query's doc comment); the single-row subquery here costs nothing
+-- beyond the jobs PK lookup this call already implies.
+INSERT INTO search_outbox (job_id, job_posted_at)
+SELECT sqlc.arg(job_id)::bigint, COALESCE(posted_at, created_at)
+FROM jobs
+WHERE id = sqlc.arg(job_id)
 ON CONFLICT (job_id) DO NOTHING;
 
 -- name: ClaimSearchOutboxBatch :many
 -- Claim a batch of live, unleased entries for OPEN canonical jobs, freshest job
--- first, by stamping claimed_at. Mirrors ClaimEnrichmentBatch: the jobs join lets the
--- claim skip a job that closed or became a non-canonical repost after it was queued
--- (that reconciles on the next full reindex, same as before this queue existed) and
--- order by posting freshness. FOR UPDATE OF o locks only outbox rows; SKIP LOCKED
--- lets concurrent workers take disjoint rows; the lease predicate reclaims entries
--- whose worker died (stale claimed_at), so no separate reaper process is needed.
+-- first, by stamping claimed_at.
+--
+-- Orders by the outbox's OWN job_posted_at (denormalized at enqueue time from
+-- COALESCE(jobs.posted_at, jobs.created_at) — see EnqueueSearchOutbox) rather than
+-- joining jobs to compute it. A join-for-ordering here means Postgres cannot push the
+-- LIMIT below the sort — it has to nested-loop-join and sort the ENTIRE claimable set
+-- before taking the batch, independent of batch_size. This is the exact pattern
+-- ClaimSemanticBatch was measured at 109s per claim call on ~906k claimable rows and
+-- fixed the same way (see openspec/changes/prod-semantic-embed-steady-state/design.md
+-- Decision 8, which flagged this query as carrying the identical, unaddressed risk).
+--
+-- The closed/duplicate_of check stays a per-row EXISTS rather than a JOIN: with the
+-- job_posted_at index in place, Postgres can index-scan search_outbox in the exact
+-- claim order and stop as soon as LIMIT rows pass the EXISTS lookup (a cheap jobs PK
+-- probe), instead of materializing and sorting every claimable row up front. A job
+-- that closed or became a non-canonical repost after being queued is simply skipped —
+-- same behavior as before, just reached via an index scan instead of a full join.
+-- NULLS LAST is defensive (EnqueueSearchOutbox always populates the column; this only
+-- guards a row that predates the backfill migration).
+--
+-- FOR UPDATE OF o locks only outbox rows; SKIP LOCKED lets concurrent workers take
+-- disjoint rows; the lease predicate reclaims entries whose worker died (stale
+-- claimed_at), so no separate reaper process is needed.
 WITH claimable AS (
-    SELECT o.id
+    SELECT o.id, o.job_id
     FROM search_outbox o
-    JOIN jobs j ON j.id = o.job_id
     WHERE o.failed_at IS NULL
       AND (o.claimed_at IS NULL
            OR o.claimed_at < now() - make_interval(secs => sqlc.arg(lease_seconds)::int))
-      AND j.closed_at IS NULL
-      AND j.duplicate_of IS NULL
-    ORDER BY COALESCE(j.posted_at, j.created_at) DESC, j.id DESC
+      AND EXISTS (
+          SELECT 1 FROM jobs j
+          WHERE j.id = o.job_id
+            AND j.closed_at IS NULL
+            AND j.duplicate_of IS NULL
+      )
+    ORDER BY o.job_posted_at DESC NULLS LAST, o.job_id DESC
     FOR UPDATE OF o SKIP LOCKED
     LIMIT sqlc.arg(batch_size)
 )

--- a/internal/db/search_outbox.sql.go
+++ b/internal/db/search_outbox.sql.go
@@ -13,15 +13,18 @@ import (
 
 const claimSearchOutboxBatch = `-- name: ClaimSearchOutboxBatch :many
 WITH claimable AS (
-    SELECT o.id
+    SELECT o.id, o.job_id
     FROM search_outbox o
-    JOIN jobs j ON j.id = o.job_id
     WHERE o.failed_at IS NULL
       AND (o.claimed_at IS NULL
            OR o.claimed_at < now() - make_interval(secs => $1::int))
-      AND j.closed_at IS NULL
-      AND j.duplicate_of IS NULL
-    ORDER BY COALESCE(j.posted_at, j.created_at) DESC, j.id DESC
+      AND EXISTS (
+          SELECT 1 FROM jobs j
+          WHERE j.id = o.job_id
+            AND j.closed_at IS NULL
+            AND j.duplicate_of IS NULL
+      )
+    ORDER BY o.job_posted_at DESC NULLS LAST, o.job_id DESC
     FOR UPDATE OF o SKIP LOCKED
     LIMIT $2
 )
@@ -43,12 +46,29 @@ type ClaimSearchOutboxBatchRow struct {
 }
 
 // Claim a batch of live, unleased entries for OPEN canonical jobs, freshest job
-// first, by stamping claimed_at. Mirrors ClaimEnrichmentBatch: the jobs join lets the
-// claim skip a job that closed or became a non-canonical repost after it was queued
-// (that reconciles on the next full reindex, same as before this queue existed) and
-// order by posting freshness. FOR UPDATE OF o locks only outbox rows; SKIP LOCKED
-// lets concurrent workers take disjoint rows; the lease predicate reclaims entries
-// whose worker died (stale claimed_at), so no separate reaper process is needed.
+// first, by stamping claimed_at.
+//
+// Orders by the outbox's OWN job_posted_at (denormalized at enqueue time from
+// COALESCE(jobs.posted_at, jobs.created_at) — see EnqueueSearchOutbox) rather than
+// joining jobs to compute it. A join-for-ordering here means Postgres cannot push the
+// LIMIT below the sort — it has to nested-loop-join and sort the ENTIRE claimable set
+// before taking the batch, independent of batch_size. This is the exact pattern
+// ClaimSemanticBatch was measured at 109s per claim call on ~906k claimable rows and
+// fixed the same way (see openspec/changes/prod-semantic-embed-steady-state/design.md
+// Decision 8, which flagged this query as carrying the identical, unaddressed risk).
+//
+// The closed/duplicate_of check stays a per-row EXISTS rather than a JOIN: with the
+// job_posted_at index in place, Postgres can index-scan search_outbox in the exact
+// claim order and stop as soon as LIMIT rows pass the EXISTS lookup (a cheap jobs PK
+// probe), instead of materializing and sorting every claimable row up front. A job
+// that closed or became a non-canonical repost after being queued is simply skipped —
+// same behavior as before, just reached via an index scan instead of a full join.
+// NULLS LAST is defensive (EnqueueSearchOutbox always populates the column; this only
+// guards a row that predates the backfill migration).
+//
+// FOR UPDATE OF o locks only outbox rows; SKIP LOCKED lets concurrent workers take
+// disjoint rows; the lease predicate reclaims entries whose worker died (stale
+// claimed_at), so no separate reaper process is needed.
 func (q *Queries) ClaimSearchOutboxBatch(ctx context.Context, arg ClaimSearchOutboxBatchParams) ([]ClaimSearchOutboxBatchRow, error) {
 	rows, err := q.db.Query(ctx, claimSearchOutboxBatch, arg.LeaseSeconds, arg.BatchSize)
 	if err != nil {
@@ -110,8 +130,10 @@ func (q *Queries) DeleteSearchOutboxEntries(ctx context.Context, ids []int64) er
 }
 
 const enqueueSearchOutbox = `-- name: EnqueueSearchOutbox :exec
-INSERT INTO search_outbox (job_id)
-VALUES ($1)
+INSERT INTO search_outbox (job_id, job_posted_at)
+SELECT $1::bigint, COALESCE(posted_at, created_at)
+FROM jobs
+WHERE id = $1
 ON CONFLICT (job_id) DO NOTHING
 `
 
@@ -119,7 +141,10 @@ ON CONFLICT (job_id) DO NOTHING
 // transaction as the job's upsert, only when the write inserted or changed indexed
 // content (mirrors the gate the old inline SubmitJobs push used). ON CONFLICT keeps
 // exactly one live entry per job, so a job changed again before it drains is not
-// queued twice.
+// queued twice. job_posted_at denormalizes COALESCE(posted_at, created_at) onto the
+// outbox row so ClaimSearchOutboxBatch can sort by it without joining jobs on every
+// claim (see that query's doc comment); the single-row subquery here costs nothing
+// beyond the jobs PK lookup this call already implies.
 func (q *Queries) EnqueueSearchOutbox(ctx context.Context, jobID int64) error {
 	_, err := q.db.Exec(ctx, enqueueSearchOutbox, jobID)
 	return err

--- a/internal/db/search_outbox_integration_test.go
+++ b/internal/db/search_outbox_integration_test.go
@@ -136,6 +136,159 @@ func TestDeleteSearchOutboxCreatedBefore_SurvivesRepeatChangeUnderConflictDoNoth
 	}
 }
 
+// TestEnqueueSearchOutboxDenormalizesJobPostedAt covers the fix for ClaimSearchOutboxBatch's
+// join-for-ordering cost (see that query's doc comment): EnqueueSearchOutbox must stamp
+// job_posted_at from COALESCE(jobs.posted_at, jobs.created_at) at enqueue time so the claim
+// query can sort without joining jobs.
+func TestEnqueueSearchOutboxDenormalizesJobPostedAt(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	withPostedAt := ingestParams("acme:posted", "Has PostedAt")
+	postedAt := time.Date(2025, 5, 1, 0, 0, 0, 0, time.UTC)
+	withPostedAt.PostedAt = pgtype.Timestamptz{Time: postedAt, Valid: true}
+	job, err := ingestUpsert(ctx, q, withPostedAt)
+	if err != nil {
+		t.Fatalf("upsert job: %v", err)
+	}
+	if err := q.EnqueueSearchOutbox(ctx, job.ID); err != nil {
+		t.Fatalf("enqueue job: %v", err)
+	}
+
+	got := jobPostedAtOf(ctx, t, pool, job.ID)
+	if !got.Valid || !got.Time.Equal(postedAt) {
+		t.Fatalf("job_posted_at = %+v, want %v", got, postedAt)
+	}
+
+	// No posted_at at all: falls back to jobs.created_at, mirroring the query's COALESCE.
+	noPostedAt, err := ingestUpsert(ctx, q, ingestParams("acme:no-posted", "No PostedAt"))
+	if err != nil {
+		t.Fatalf("upsert job without posted_at: %v", err)
+	}
+	if err := q.EnqueueSearchOutbox(ctx, noPostedAt.ID); err != nil {
+		t.Fatalf("enqueue job without posted_at: %v", err)
+	}
+	got = jobPostedAtOf(ctx, t, pool, noPostedAt.ID)
+	if !got.Valid || !got.Time.Equal(noPostedAt.CreatedAt.Time) {
+		t.Fatalf("job_posted_at = %+v, want fallback to created_at %v", got, noPostedAt.CreatedAt)
+	}
+}
+
+// TestClaimSearchOutboxBatchOrdersByJobPostedAtAndSkipsClosedOrDuplicate covers
+// ClaimSearchOutboxBatch's two load-bearing properties after moving the sort onto the
+// outbox's own denormalized job_posted_at column: it still returns freshest-job-first, and
+// it still skips (without claiming) a job that closed or became a non-canonical repost
+// after being queued — the same behavior the old jobs-join version had, now reached via an
+// index scan plus a per-row EXISTS check instead of a join-then-sort.
+func TestClaimSearchOutboxBatchOrdersByJobPostedAtAndSkipsClosedOrDuplicate(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	older, err := ingestUpsert(ctx, q, ingestParams("acme:older", "Older"))
+	if err != nil {
+		t.Fatalf("upsert older: %v", err)
+	}
+	newer, err := ingestUpsert(ctx, q, ingestParams("acme:newer", "Newer"))
+	if err != nil {
+		t.Fatalf("upsert newer: %v", err)
+	}
+	closedJob, err := ingestUpsert(ctx, q, ingestParams("acme:closed", "Closed"))
+	if err != nil {
+		t.Fatalf("upsert closed: %v", err)
+	}
+	canon, err := ingestUpsert(ctx, q, ingestParams("acme:canon", "Canon"))
+	if err != nil {
+		t.Fatalf("upsert canon: %v", err)
+	}
+	repost, err := ingestUpsert(ctx, q, ingestParams("acme:repost", "Repost"))
+	if err != nil {
+		t.Fatalf("upsert repost: %v", err)
+	}
+
+	for _, id := range []int64{older.ID, newer.ID, closedJob.ID, canon.ID, repost.ID} {
+		if err := q.EnqueueSearchOutbox(ctx, id); err != nil {
+			t.Fatalf("enqueue job %d: %v", id, err)
+		}
+	}
+
+	// Order the three live, open, canonical entries by job_posted_at.
+	olderAt := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	canonAt := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	newerAt := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	if _, err := pool.Exec(ctx, `UPDATE search_outbox SET job_posted_at = $1 WHERE job_id = $2`, olderAt, older.ID); err != nil {
+		t.Fatalf("pin older job_posted_at: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE search_outbox SET job_posted_at = $1 WHERE job_id = $2`, canonAt, canon.ID); err != nil {
+		t.Fatalf("pin canon job_posted_at: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE search_outbox SET job_posted_at = $1 WHERE job_id = $2`, newerAt, newer.ID); err != nil {
+		t.Fatalf("pin newer job_posted_at: %v", err)
+	}
+
+	// closedJob's outbox entry stays queued, but the job itself is now closed.
+	if _, err := pool.Exec(ctx, `UPDATE jobs SET closed_at = now() WHERE id = $1`, closedJob.ID); err != nil {
+		t.Fatalf("close job: %v", err)
+	}
+	// repost's outbox entry stays queued, but the job itself became a non-canonical
+	// repost of canon after being enqueued.
+	if _, err := pool.Exec(ctx, `UPDATE jobs SET duplicate_of = $1 WHERE id = $2`, canon.ID, repost.ID); err != nil {
+		t.Fatalf("mark repost as duplicate: %v", err)
+	}
+
+	// BatchSize smaller than the claimable set (older/canon/newer) so the ordering
+	// actually determines which entries make the cut, not just which get excluded.
+	rows, err := q.ClaimSearchOutboxBatch(ctx, ClaimSearchOutboxBatchParams{LeaseSeconds: 180, BatchSize: 2})
+	if err != nil {
+		t.Fatalf("ClaimSearchOutboxBatch: %v", err)
+	}
+
+	var claimedJobIDs []int64
+	for _, r := range rows {
+		claimedJobIDs = append(claimedJobIDs, r.JobID)
+	}
+	want := []int64{newer.ID, canon.ID}
+	if len(claimedJobIDs) != 2 {
+		t.Fatalf("claimed job_ids = %v, want exactly 2 entries (newer and canon)", claimedJobIDs)
+	}
+	if containsInt64(claimedJobIDs, closedJob.ID) {
+		t.Fatalf("claimed job_ids = %v, want closed job %d excluded", claimedJobIDs, closedJob.ID)
+	}
+	if containsInt64(claimedJobIDs, repost.ID) {
+		t.Fatalf("claimed job_ids = %v, want non-canonical repost %d excluded", claimedJobIDs, repost.ID)
+	}
+	if !containsInt64(claimedJobIDs, newer.ID) || !containsInt64(claimedJobIDs, canon.ID) {
+		t.Fatalf("claimed job_ids = %v, want %v", claimedJobIDs, want)
+	}
+	if containsInt64(claimedJobIDs, older.ID) {
+		t.Fatalf("claimed job_ids = %v, want older job %d NOT claimed (batch is full before it sorts in)", claimedJobIDs, older.ID)
+	}
+
+	// The two skipped entries (closed, repost) remain unclaimed — claimed_at stays NULL —
+	// so a later reconciliation (a full reindex) is what clears them, not this claim.
+	for _, id := range []int64{closedJob.ID, repost.ID} {
+		var claimedAt pgtype.Timestamptz
+		if err := pool.QueryRow(ctx, `SELECT claimed_at FROM search_outbox WHERE job_id = $1`, id).Scan(&claimedAt); err != nil {
+			t.Fatalf("query claimed_at for job %d: %v", id, err)
+		}
+		if claimedAt.Valid {
+			t.Fatalf("job %d's outbox entry was claimed, want it left unclaimed", id)
+		}
+	}
+}
+
+func jobPostedAtOf(ctx context.Context, t *testing.T, pool *pgxpool.Pool, jobID int64) pgtype.Timestamptz {
+	t.Helper()
+	var v pgtype.Timestamptz
+	if err := pool.QueryRow(ctx, `SELECT job_posted_at FROM search_outbox WHERE job_id = $1`, jobID).Scan(&v); err != nil {
+		t.Fatalf("query job_posted_at for job %d: %v", jobID, err)
+	}
+	return v
+}
+
 func remainingOutboxJobIDs(ctx context.Context, t *testing.T, pool *pgxpool.Pool) []int64 {
 	t.Helper()
 	rows, err := pool.Query(ctx, `SELECT job_id FROM search_outbox ORDER BY job_id`)

--- a/internal/handler/assistant.go
+++ b/internal/handler/assistant.go
@@ -255,7 +255,7 @@ func (h *assistantHandlers) CreateAssistantSession(c *fiber.Ctx) error {
 	// identical every time, so every such session in the rail would carry the same string
 	// and none would say which interview it was.
 	if label := applicationSessionLabel(preset, vacancy); label != "" {
-		if err := h.store.LabelSession(c.Context(), sess.ID, label); err != nil {
+		if err := h.store.LabelSession(c.Context(), sess.ID, sess.UserID, label); err != nil {
 			log.Printf("assistant: could not name %s session %s: %v", preset, sess.ID, err)
 		} else {
 			sess.Label = label

--- a/internal/handler/assistant_interview_voice.go
+++ b/internal/handler/assistant_interview_voice.go
@@ -124,7 +124,7 @@ func (h *assistantHandlers) PostAssistantVoiceTurn(c *fiber.Ctx) error {
 	}
 	// A convenience, not correctness: the session's last-activity stamp should not
 	// cost the candidate their turn if it fails.
-	if err := h.store.Touch(c.Context(), sess.ID); err != nil {
+	if err := h.store.Touch(c.Context(), sess.ID, sess.UserID); err != nil {
 		log.Printf("assistant: touch session %s: %v", sess.ID, err)
 	}
 	return c.SendStatus(fiber.StatusNoContent)

--- a/internal/handler/match_analysis.go
+++ b/internal/handler/match_analysis.go
@@ -70,7 +70,7 @@ func (h *matchHandlers) register(api fiber.Router, mw middleware) {
 	api.Get("/jobs/:slug/match", mw.key, h.JobMatch)
 	// Ad-hoc skill match for a job posting scraped off any page (title + text),
 	// no catalog job required — powers the browser extension's on-any-page card.
-	api.Post("/me/match-text", mw.key, h.MatchText)
+	api.Post("/me/match-text", mw.key, matchTextLimiter(mw.throttler), h.MatchText)
 	// The on-demand LLM match analysis (GET cached / POST run / SSE stream). The two routes
 	// that actually drive the prompt chain share ONE limiter instance, so the budget is per
 	// user and not per route — a limiter per mount would hand the stream, the POST, and each

--- a/internal/handler/match_text.go
+++ b/internal/handler/match_text.go
@@ -1,11 +1,32 @@
 package handler
 
 import (
+	"time"
+
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/strelov1/freehire/internal/jobmatch"
+	"github.com/strelov1/freehire/internal/ratelimit"
 	"github.com/strelov1/freehire/internal/skilltag"
 )
+
+// matchTextPerHour bounds how many ad-hoc text matches one user may run per hour. Unlike
+// the LLM fit-analysis routes this costs no model spend, but it still runs a multi-pass
+// skilltag.Parse dictionary/regex scan over a body up to the server's global 8MB limit —
+// and MatchText's own doc comment says it "powers the browser extension's on-any-page
+// card", so it fires automatically on ordinary tab switches/page loads, not just on
+// explicit user action. Sized well above that automatic-trigger rate (loadMatch() has no
+// debounce of its own) so normal browsing never trips it, while still bounding a scripted
+// or compromised-extension-build loop.
+const matchTextPerHour = 120
+
+// matchTextLimiter throttles MatchText per authenticated user, the same
+// KeyByUserOrIP-keyed shape as matchAnalysisLimiter and jdURLLimiter — a dedicated
+// limiter, not a shared one, since this route costs CPU on every page visit rather than
+// AI-credit spend on a new job.
+func matchTextLimiter(throttler ratelimit.Throttler) fiber.Handler {
+	return ratelimit.Middleware(throttler, ratelimit.KeyByUserOrIP("matchtext"), matchTextPerHour, time.Hour)
+}
 
 // matchTextRequest is a job posting scraped from an arbitrary page: its heading
 // and visible text. No catalog job is required.

--- a/internal/handler/match_text_limit_test.go
+++ b/internal/handler/match_text_limit_test.go
@@ -1,0 +1,52 @@
+package handler
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// MatchText runs a multi-pass skilltag.Parse over a caller-supplied body on every call, and
+// its own doc comment says it "powers the browser extension's on-any-page card" — i.e. it can
+// fire automatically on ordinary tab switches, not just an explicit user action. Unlike the LLM
+// fit-analysis routes it was previously left with no limiter at all. Keyed on the user for the
+// same reason matchAnalysisLimiter is: an IP key is lifted by any rotating proxy pool.
+func TestMatchTextLimiter_IsKeyedOnTheUser(t *testing.T) {
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Post("/match-text", func(c *fiber.Ctx) error {
+		id := int64(1)
+		if c.Get("X-Test-User") == "2" {
+			id = 2
+		}
+		c.Locals("auth.userID", id)
+		return c.Next()
+	}, matchTextLimiter(newTestThrottler(t)), func(c *fiber.Ctx) error { return c.SendStatus(fiber.StatusOK) })
+
+	post := func(user string) int {
+		req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPost, "/match-text", nil)
+		req.Header.Set("X-Test-User", user)
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("Test: %v", err)
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	var refused int
+	for i := 0; i < matchTextPerHour+5; i++ {
+		if post("1") == fiber.StatusTooManyRequests {
+			refused++
+		}
+	}
+	if refused == 0 {
+		t.Fatalf("user 1 called MatchText %d times without being throttled", matchTextPerHour+5)
+	}
+
+	// A different user is unaffected by the first one's exhausted budget.
+	if got := post("2"); got == fiber.StatusTooManyRequests {
+		t.Error("a second user was throttled by the first user's budget — the key is not the user")
+	}
+}

--- a/internal/handler/me_tracking_integration_test.go
+++ b/internal/handler/me_tracking_integration_test.go
@@ -10,6 +10,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -344,5 +345,104 @@ func TestTrackedBoardKeepsAnApplicationWhosePostingWasPruned(t *testing.T) {
 	}
 	if row.Stage == nil || *row.Stage != "applied" {
 		t.Errorf("stage = %v, want applied — the candidate's own record survives", row.Stage)
+	}
+}
+
+// TestTrackedBoardPagesOrphanedApplicationsWithoutDuplication covers the fix for
+// ListOrphanedApplications' missing OFFSET (it always re-read the same top-N orphans on
+// every page) and for CountUserJobs never counting them (meta.counts under-reported
+// while the merged data could exceed it). Several applications whose postings were
+// pruned, paged one at a time, must come back as distinct rows — never the same one
+// twice — and meta.counts.board/applied/all must include every orphan.
+func TestTrackedBoardPagesOrphanedApplicationsWithoutDuplication(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	var userID int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (email) VALUES ('orphan-paging@example.test') RETURNING id`).Scan(&userID); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	const orphanCount = 3
+	base := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	for i := 0; i < orphanCount; i++ {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO applications (user_id, company_slug, role_title, job_id, applied_at)
+			 VALUES ($1, $2, 'Orphaned Role', NULL, $3)`,
+			userID, "orphanco", base.Add(-time.Duration(i)*time.Minute)); err != nil {
+			t.Fatalf("seed orphaned application %d: %v", i, err)
+		}
+	}
+
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	token, err := iss.Issue(userID, testTokenVersion)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	queries := db.New(pool)
+	h := &trackingHandlers{tracking: jobtracking.New(jobtracking.NewQueriesRepository(queries, pool))}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/me/tracking", auth.RequireAuth(iss, testVersions), h.ListTrackedJobs)
+
+	type response struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+		Meta struct {
+			Counts struct {
+				All     int64 `json:"all"`
+				Applied int64 `json:"applied"`
+				Board   int64 `json:"board"`
+			} `json:"counts"`
+		} `json:"meta"`
+	}
+
+	get := func(offset int) response {
+		t.Helper()
+		req := httptest.NewRequest(fiber.MethodGet,
+			fmt.Sprintf("/api/v1/me/tracking?filter=board&limit=1&offset=%d", offset), nil)
+		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("request offset=%d: %v", offset, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusOK {
+			t.Fatalf("offset=%d status = %d, want 200", offset, resp.StatusCode)
+		}
+		var body response
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode offset=%d: %v", offset, err)
+		}
+		return body
+	}
+
+	seen := map[string]bool{}
+	var counts response
+	for offset := 0; offset < orphanCount; offset++ {
+		page := get(offset)
+		counts = page
+		if len(page.Data) != 1 {
+			t.Fatalf("offset=%d returned %d rows, want exactly 1", offset, len(page.Data))
+		}
+		id := page.Data[0].ID
+		if seen[id] {
+			t.Fatalf("offset=%d returned id %q again — paging is re-reading the same orphan", offset, id)
+		}
+		seen[id] = true
+	}
+	if len(seen) != orphanCount {
+		t.Fatalf("saw %d distinct orphaned applications across %d pages, want %d", len(seen), orphanCount, orphanCount)
+	}
+
+	if counts.Meta.Counts.All != orphanCount {
+		t.Errorf("meta.counts.all = %d, want %d — CountInteractions must fold in the orphaned applications", counts.Meta.Counts.All, orphanCount)
+	}
+	if counts.Meta.Counts.Applied != orphanCount {
+		t.Errorf("meta.counts.applied = %d, want %d", counts.Meta.Counts.Applied, orphanCount)
+	}
+	if counts.Meta.Counts.Board != orphanCount {
+		t.Errorf("meta.counts.board = %d, want %d", counts.Meta.Counts.Board, orphanCount)
 	}
 }

--- a/internal/hardconstraint/hardconstraint.go
+++ b/internal/hardconstraint/hardconstraint.go
@@ -166,16 +166,28 @@ func appendWorkAuth(out []Blocker, job JobRequirements, cv CVEvidence) []Blocker
 	return append(out, blocker(CategoryWorkAuth, false, reason, action))
 }
 
+// requiresOnSitePresence reports whether the job's work mode needs the candidate to
+// physically be somewhere — true for both "onsite" and "hybrid" (vocab.WorkModeValues'
+// third and second values). A fully "remote" job needs neither check below.
+func requiresOnSitePresence(workMode string) bool {
+	return workMode == "onsite" || workMode == "hybrid"
+}
+
 func appendLocationWorkMode(out []Blocker, job JobRequirements, cv CVEvidence) []Blocker {
+	onSite := requiresOnSitePresence(job.WorkMode)
+	label := "On-site"
+	if job.WorkMode == "hybrid" {
+		label = "Hybrid"
+	}
 	// A remote-preference conflict needs no geography.
-	if job.WorkMode == "onsite" && cv.PrefersRemote {
-		reason := "On-site role, but you prefer remote work."
+	if onSite && cv.PrefersRemote {
+		reason := fmt.Sprintf("%s role, but you prefer remote work.", label)
 		action := "Confirm you can work on-site before applying."
 		return append(out, blocker(CategoryLocationWorkMode, false, reason, action))
 	}
 	// A geographic mismatch needs both known country codes.
-	if job.WorkMode == "onsite" && len(job.Countries) > 0 && cv.CountryCode != "" && !containsCountry(job.Countries, cv.CountryCode) {
-		reason := fmt.Sprintf("On-site in %s; your résumé location is elsewhere.", strings.Join(job.Countries, ", "))
+	if onSite && len(job.Countries) > 0 && cv.CountryCode != "" && !containsCountry(job.Countries, cv.CountryCode) {
+		reason := fmt.Sprintf("%s in %s; your résumé location is elsewhere.", label, strings.Join(job.Countries, ", "))
 		action := "Confirm you can be on-site there (relocation or local presence)."
 		return append(out, blocker(CategoryLocationWorkMode, false, reason, action))
 	}

--- a/internal/hardconstraint/hardconstraint_test.go
+++ b/internal/hardconstraint/hardconstraint_test.go
@@ -177,6 +177,28 @@ func TestLocationWorkModeCategory(t *testing.T) {
 			t.Error("a remote job should raise no location blocker")
 		}
 	})
+	t.Run("hybrid versus remote preference is a soft blocker", func(t *testing.T) {
+		// A hybrid role needs some on-site presence too — it must not be treated
+		// identically to a fully remote one.
+		bs := Evaluate(JobRequirements{WorkMode: "hybrid"}, CVEvidence{PrefersRemote: true})
+		b, ok := find(bs, CategoryLocationWorkMode)
+		if !ok || b.Met || b.Severity != SeveritySoft {
+			t.Fatalf("want unmet soft location blocker, got %+v ok=%v", b, ok)
+		}
+	})
+	t.Run("hybrid geographic mismatch is a soft blocker", func(t *testing.T) {
+		bs := Evaluate(JobRequirements{WorkMode: "hybrid", Countries: []string{"DE"}}, CVEvidence{CountryCode: "US"})
+		b, ok := find(bs, CategoryLocationWorkMode)
+		if !ok || b.Met || b.Severity != SeveritySoft {
+			t.Fatalf("want unmet soft location blocker, got %+v ok=%v", b, ok)
+		}
+	})
+	t.Run("hybrid job with matching country and no remote preference is skipped", func(t *testing.T) {
+		bs := Evaluate(JobRequirements{WorkMode: "hybrid", Countries: []string{"DE"}}, CVEvidence{CountryCode: "DE"})
+		if _, ok := find(bs, CategoryLocationWorkMode); ok {
+			t.Error("a hybrid job with a matching résumé location should raise no location blocker")
+		}
+	})
 }
 
 func TestOverallCap(t *testing.T) {

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -309,6 +309,19 @@ func (f Fields) UpsertManualParams(actorID int64) db.UpsertManualJobParams {
 // fingerprints move.
 func (f Fields) UpdateManualParams(slug string, actorID int64) db.UpdateManualJobParams {
 	derived := f.UpsertParams()
+	// jobhash.Of hashes p.PublicSlug, and UpsertParams() built derived from f.PublicSlug —
+	// a slug job.New/jobderive.Derive just recomputed from the edited title/company. But
+	// UpdateManualJob's own SQL comment is explicit that "the source identity (url/
+	// external_id/public_slug) is deliberately NOT updatable here": the row's real
+	// public_slug stays `slug`, the value already addressing it below. Hashing f.PublicSlug
+	// would stamp content_hash with a slug value that never lands in the row, so
+	// jobhash.OfRow (what a backfill/reconciliation pass calls, reading the row's ACTUAL
+	// public_slug) could never reproduce it — the row would spuriously report "changed" on
+	// every such pass even though nothing indexed actually moved. Re-derive against the
+	// slug that is actually persisted; RoleFingerprint is unaffected (it deliberately
+	// excludes public_slug, per its own doc comment), so this only changes ContentHash.
+	derived.PublicSlug = slug
+	derived = withDerived(derived)
 	return db.UpdateManualJobParams{
 		Title:       f.Title,
 		Company:     f.Company,

--- a/internal/job/job_test.go
+++ b/internal/job/job_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/job"
 	"github.com/strelov1/freehire/internal/jobderive"
+	"github.com/strelov1/freehire/internal/jobhash"
 	"github.com/strelov1/freehire/internal/normalize"
 )
 
@@ -316,11 +317,15 @@ func TestUpdateManualParams_CarriesSlugActorAndDerivedColumns(t *testing.T) {
 	}
 	f := j.Fields()
 
-	params := f.UpdateManualParams("acme-senior-go-developer", 7)
+	// The slug argument names the row's REAL, persisted public_slug — here deliberately
+	// f.PublicSlug itself, so this test isolates "derived columns agree for the same
+	// content" from the persisted-vs-rederived-slug divergence
+	// TestUpdateManualParams_ContentHashUsesThePersistedSlugNotTheRederivedOne covers.
+	params := f.UpdateManualParams(f.PublicSlug, 7)
 	automated := f.UpsertParams()
 
-	if params.PublicSlug != "acme-senior-go-developer" {
-		t.Errorf("PublicSlug = %q", params.PublicSlug)
+	if params.PublicSlug != f.PublicSlug {
+		t.Errorf("PublicSlug = %q, want %q", params.PublicSlug, f.PublicSlug)
 	}
 	if params.UpdatedBy != 7 {
 		t.Errorf("UpdatedBy = %d, want 7", params.UpdatedBy)
@@ -330,6 +335,55 @@ func TestUpdateManualParams_CarriesSlugActorAndDerivedColumns(t *testing.T) {
 	}
 	if params.ContentHash != automated.ContentHash || params.RoleFingerprint != automated.RoleFingerprint {
 		t.Errorf("derived = %v/%v, want %v/%v", params.ContentHash, params.RoleFingerprint, automated.ContentHash, automated.RoleFingerprint)
+	}
+}
+
+// UpdateManualJob's own SQL comment is explicit that public_slug is "deliberately NOT
+// updatable" by that statement — moderation.Service.Update re-derives Fields (and so a
+// fresh PublicSlug) from the edited title/company, but discards the recomputed slug and
+// passes the row's EXISTING one through UpdateManualParams' slug argument instead. The
+// stamped ContentHash must therefore be derived from that existing, actually-persisted
+// slug — not from f.PublicSlug, which job.New just recomputed from the new title and
+// will never be written anywhere for this row.
+func TestUpdateManualParams_ContentHashUsesThePersistedSlugNotTheRederivedOne(t *testing.T) {
+	// A title change moves job.New's derived slug, exactly like an employer/title edit
+	// through the moderation workspace does.
+	j, err := job.New(job.Draft{Input: jobderive.Input{
+		Source:      "manual",
+		ExternalID:  "https://acme.example/jobs/1",
+		Title:       "Staff Go Developer",
+		Company:     "Acme",
+		Description: "We use Golang.",
+	}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	f := j.Fields()
+
+	const existingSlug = "acme-senior-go-developer" // the row's real, pre-edit slug
+	if f.PublicSlug == existingSlug {
+		t.Fatalf("test fixture is not exercising a divergence: f.PublicSlug (%q) already equals existingSlug", f.PublicSlug)
+	}
+
+	params := f.UpdateManualParams(existingSlug, 7)
+
+	wantParams := f.UpsertParams()
+	wantParams.PublicSlug = existingSlug
+	want := jobhash.Of(wantParams)
+
+	if params.ContentHash.String != want {
+		t.Errorf("ContentHash = %q, want %q (derived from the persisted slug %q)", params.ContentHash.String, want, existingSlug)
+	}
+
+	rederived := jobhash.Of(f.UpsertParams()) // f.PublicSlug, the value that never lands in the row
+	if params.ContentHash.String == rederived {
+		t.Error("ContentHash was derived from f.PublicSlug (the freshly re-derived, never-persisted slug), not the row's actual public_slug")
+	}
+
+	// RoleFingerprint deliberately excludes public_slug, so it must be unaffected by
+	// which slug ContentHash used.
+	if params.RoleFingerprint != wantParams.RoleFingerprint {
+		t.Errorf("RoleFingerprint = %q, want %q — it must not move with public_slug", params.RoleFingerprint.String, wantParams.RoleFingerprint.String)
 	}
 }
 

--- a/internal/jobfacts/jobfacts.go
+++ b/internal/jobfacts/jobfacts.go
@@ -185,15 +185,31 @@ var englishRank = map[string]int{"a1": 1, "a2": 2, "b1": 3, "b2": 4, "c1": 5, "c
 // for the two to count as one signal. Sized for Russian (2 bytes/rune), so ~15 runes.
 const englishWindow = 30
 
+// englishScanMaxRunes bounds how much of the description EnglishLevel's near/spanNear
+// matching runs over. near/spanNear are O(#keyword-matches × #phrase-matches) in the
+// worst case (no pair of matches ever falls within englishWindow of each other), so an
+// unbounded, repetitive input — a scraped/SEO-padded description repeating
+// "english"/CEFR-like tokens many times without ever pairing them closely — could turn
+// derivation of one job into a multi-second, CPU-bound stall on the otherwise fast,
+// per-job ingest path. Sized generously above any real job posting; this only ever
+// engages on pathological input.
+const englishScanMaxRunes = 20000
+
 // EnglishLevel resolves the required English level from the description, returning
 // one of vocab.EnglishLevelValues or "" when nothing is stated. When several levels
 // are named it returns the lowest (the minimum requirement); an explicit "no English"
 // phrase resolves to "none" only when no positive level is present.
 func EnglishLevel(description string) string {
 	s := strings.ToLower(description)
+	s = truncateRunes(s, englishScanMaxRunes)
 	if !reEnglishKw.MatchString(s) {
 		return ""
 	}
+
+	// Scanned once and reused by every near()/spanNear() call below instead of each one
+	// re-running FindAllStringIndex over the whole string — near was doing that on every
+	// one of its five call sites, and the per-match loops did it once per match.
+	kws := reEnglishKw.FindAllStringIndex(s, -1)
 
 	levels := map[string]bool{}
 	for _, m := range reCEFRForward.FindAllStringSubmatch(s, -1) {
@@ -202,23 +218,23 @@ func EnglishLevel(description string) string {
 	for _, m := range reCEFRBack.FindAllStringSubmatch(s, -1) {
 		levels[m[1]] = true
 	}
-	if near(s, reEnglishKw, reNative) {
+	if near(s, kws, reNative) {
 		levels["native"] = true
 	}
-	if near(s, reEnglishKw, reFluentAdv) {
+	if near(s, kws, reFluentAdv) {
 		levels["c1"] = true
 	}
-	if near(s, reEnglishKw, reConvers) {
+	if near(s, kws, reConvers) {
 		levels["b1"] = true
 	}
-	if near(s, reEnglishKw, reElementary) {
+	if near(s, kws, reElementary) {
 		levels["a1"] = true
 	}
-	if near(s, reEnglishKw, reBasic) {
+	if near(s, kws, reBasic) {
 		levels["a2"] = true
 	}
 	for _, m := range reInterFam.FindAllStringSubmatchIndex(s, -1) {
-		if !spanNearEnglish(s, m[0], m[1]) {
+		if !spanNear(s, kws, m[0], m[1]) {
 			continue
 		}
 		switch {
@@ -233,7 +249,7 @@ func EnglishLevel(description string) string {
 		}
 	}
 	for _, m := range reRuMidFam.FindAllStringSubmatchIndex(s, -1) {
-		if !spanNearEnglish(s, m[0], m[1]) {
+		if !spanNear(s, kws, m[0], m[1]) {
 			continue
 		}
 		if m[2] >= 0 { // "выше средн..." — above intermediate
@@ -258,21 +274,26 @@ func EnglishLevel(description string) string {
 	return best
 }
 
-// near reports whether any match of kw and any match of phrase in s lie within
-// englishWindow bytes of each other without a sentence boundary between them.
-func near(s string, kw, phrase *regexp.Regexp) bool {
-	kws := kw.FindAllStringIndex(s, -1)
+// truncateRunes clamps s to at most max runes, rune-boundary safe. Local rather than
+// shared: this package stays free of any dependency beyond its own dict-only matching.
+func truncateRunes(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max])
+}
+
+// near reports whether any match of phrase in s lies within englishWindow bytes of one
+// of kws (English keyword match spans, precomputed once by the caller) without a
+// sentence boundary between them.
+func near(s string, kws [][]int, phrase *regexp.Regexp) bool {
 	for _, p := range phrase.FindAllStringIndex(s, -1) {
 		if spanNear(s, kws, p[0], p[1]) {
 			return true
 		}
 	}
 	return false
-}
-
-// spanNearEnglish reports whether the [start,end) span sits near an English keyword.
-func spanNearEnglish(s string, start, end int) bool {
-	return spanNear(s, reEnglishKw.FindAllStringIndex(s, -1), start, end)
 }
 
 // spanNear reports whether [start,end) is within englishWindow bytes of any span,

--- a/internal/jobfacts/jobfacts_test.go
+++ b/internal/jobfacts/jobfacts_test.go
@@ -2,6 +2,7 @@ package jobfacts
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/strelov1/freehire/internal/vocab"
@@ -157,5 +158,26 @@ func TestEnglishLevel(t *testing.T) {
 				t.Errorf("EnglishLevel(%q) = %q, want %q", c.desc, got, c.want)
 			}
 		})
+	}
+}
+
+// EnglishLevel's near/spanNear matching is O(#keyword-matches × #phrase-matches) in the
+// worst case, so a description with no upper bound could turn one job's derivation into
+// a CPU-bound stall on the per-job ingest path (a scraped/SEO-padded posting repeating
+// "english"/CEFR-like tokens without ever pairing them closely). A real signal placed
+// past englishScanMaxRunes must be invisible to EnglishLevel — proof the input is
+// actually bounded, not just that the matching is fast on realistic descriptions.
+func TestEnglishLevelIgnoresContentPastTheLengthCap(t *testing.T) {
+	padding := strings.Repeat("x ", englishScanMaxRunes) // far past the cap on its own
+	beyondCap := padding + "Advanced English is required."
+	if got := EnglishLevel(beyondCap); got != "" {
+		t.Errorf("EnglishLevel returned %q for a signal placed past the length cap, want \"\" (the cap must apply before matching)", got)
+	}
+
+	// The same signal, comfortably inside the cap, is still found — the cap must not
+	// suppress an ordinary, in-range description.
+	withinCap := "Advanced English is required." + strings.Repeat("x", 100)
+	if got := EnglishLevel(withinCap); got != "c1" {
+		t.Errorf("EnglishLevel(%q) = %q, want %q", withinCap, got, "c1")
 	}
 }

--- a/internal/jobtracking/repository.go
+++ b/internal/jobtracking/repository.go
@@ -361,7 +361,7 @@ func (r *QueriesRepository) ListInteractions(
 	// them: a pruned application was never a view or a bookmark.
 	if filter == FilterBoard || filter == FilterApplied || filter == FilterAll {
 		orphans, err := r.q.ListOrphanedApplications(ctx, db.ListOrphanedApplicationsParams{
-			UserID: userID, Limit: limit,
+			UserID: userID, Limit: limit, Offset: offset,
 		})
 		if err != nil {
 			return nil, err
@@ -386,17 +386,29 @@ func (r *QueriesRepository) ListInteractions(
 }
 
 // CountInteractions returns the per-filter counts for the caller in one pass.
+//
+// CountUserJobs is driven entirely FROM user_jobs, which cmd/prune cascades away when it
+// prunes a posting — so it never counts an orphaned application (see
+// ListOrphanedApplications), even though ListInteractions merges those into the board,
+// applied, and all views. CountOrphanedApplications closes that gap: added into "all",
+// "applied", and "board" (the same three filters ListInteractions merges orphans into),
+// left out of "viewed"/"saved"/"dismissed" (an orphaned application was never a view or a
+// bookmark, and dismissal lives only on user_jobs).
 func (r *QueriesRepository) CountInteractions(ctx context.Context, userID int64) (Counts, error) {
 	row, err := r.q.CountUserJobs(ctx, userID)
 	if err != nil {
 		return Counts{}, err
 	}
+	orphaned, err := r.q.CountOrphanedApplications(ctx, userID)
+	if err != nil {
+		return Counts{}, err
+	}
 	return Counts{
-		All:       row.All,
+		All:       row.All + orphaned,
 		Viewed:    row.Viewed,
 		Saved:     row.Saved,
-		Applied:   row.Applied,
-		Board:     row.Board,
+		Applied:   row.Applied + orphaned,
+		Board:     row.Board + orphaned,
 		Dismissed: row.Dismissed,
 	}, nil
 }

--- a/internal/migrate/baseline_integration_test.go
+++ b/internal/migrate/baseline_integration_test.go
@@ -1,0 +1,105 @@
+//go:build integration
+
+// Integration test for the auto-baseline path — the single scenario this whole package
+// exists for, per its own package doc comment: a database whose schema already carries
+// every migration's effect (an initdb- or hand-migrated volume) but has no
+// schema_migrations bookkeeping yet. Only the pure decide() routing function was
+// previously unit-tested with a mocked legacySchema bool; hasJobsTable's live
+// to_regclass('public.jobs') probe, wired into the full Runner.Run flow, had no coverage
+// against a real Postgres — and the package's own lock-timeout integration test
+// deliberately seeds schema_migrations first specifically to AVOID this path. Needs
+// Docker (testcontainers); run with:
+//
+//	go test -tags=integration ./internal/migrate/
+package migrate_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/migrate"
+	"github.com/strelov1/freehire/internal/testdb"
+)
+
+// repoRoot walks up from the test's working directory to the module root, so this test
+// can Load() the real on-disk migrations/*.sql regardless of how deep the package sits.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("no go.mod above the working directory")
+		}
+		dir = parent
+	}
+}
+
+// TestRun_AutoBaselinesAPreRunnerDatabase reproduces the real scenario against a real
+// Postgres: testdb.Pool hands out a database whose schema was applied by raw initdb
+// scripts (every migrations/*.sql file executed directly — the same mechanism a fresh
+// prod volume bootstraps with) — so public.jobs exists, but nothing has ever created
+// schema_migrations. That is byte-for-byte "an initdb- or hand-migrated volume" from the
+// package doc comment. Run() against this database, with the real on-disk migration set,
+// must recognize the legacy schema and BASELINE every file (record it as applied without
+// re-executing it) rather than replay DDL that already ran — replaying would fail
+// outright (e.g. a duplicate CREATE TABLE), which is exactly the failure this package
+// exists to avoid on a prod bootstrap.
+func TestRun_AutoBaselinesAPreRunnerDatabase(t *testing.T) {
+	pool := testdb.Pool(t)
+	ctx := context.Background()
+
+	migs, err := migrate.Load(filepath.Join(repoRoot(t), "migrations"))
+	if err != nil {
+		t.Fatalf("load migrations: %v", err)
+	}
+	if len(migs) == 0 {
+		t.Fatal("loaded zero migrations — the on-disk directory is unexpectedly empty")
+	}
+
+	var alreadyExists bool
+	if err := pool.QueryRow(ctx, "SELECT to_regclass('public.schema_migrations') IS NOT NULL").Scan(&alreadyExists); err != nil {
+		t.Fatalf("probe schema_migrations: %v", err)
+	}
+	if alreadyExists {
+		t.Fatal("schema_migrations already exists before Run — testdb.Pool no longer hands out a pre-runner database, this test needs rethinking")
+	}
+
+	baselined, applied, err := migrate.NewRunner(pool).Run(ctx, migs, false)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(applied) != 0 {
+		t.Fatalf("applied = %v, want nothing executed — every file's effect is already on disk", applied)
+	}
+	if len(baselined) != len(migs) {
+		t.Fatalf("baselined %d migration(s), want all %d recorded without executing them", len(baselined), len(migs))
+	}
+
+	var recorded int
+	if err := pool.QueryRow(ctx, "SELECT count(*) FROM public.schema_migrations").Scan(&recorded); err != nil {
+		t.Fatalf("count schema_migrations: %v", err)
+	}
+	if recorded != len(migs) {
+		t.Fatalf("schema_migrations has %d row(s), want one per on-disk migration (%d)", recorded, len(migs))
+	}
+
+	// A second run against the now-baselined database must be a true no-op: nothing
+	// legacy about it anymore (schema_migrations is no longer empty), and nothing
+	// pending either.
+	baselined2, applied2, err := migrate.NewRunner(pool).Run(ctx, migs, false)
+	if err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if len(baselined2) != 0 || len(applied2) != 0 {
+		t.Fatalf("second Run baselined=%v applied=%v, want both empty", baselined2, applied2)
+	}
+}

--- a/migrations/0096_search_outbox_job_posted_at.sql
+++ b/migrations/0096_search_outbox_job_posted_at.sql
@@ -1,0 +1,37 @@
+-- ClaimSearchOutboxBatch orders by COALESCE(jobs.posted_at, jobs.created_at) via a join to
+-- jobs, so Postgres cannot push the LIMIT below the sort: it nested-loop-joins EVERY
+-- claimable row against jobs before sorting and taking the batch — the identical
+-- join-for-ordering shape semantic_outbox carried before 0080_semantic_outbox_job_posted_at.sql
+-- (measured live on prod at ~906k claimable rows: 109s for a single claim call; see
+-- openspec/changes/prod-semantic-embed-steady-state/design.md Decision 8, which explicitly
+-- flagged ClaimSearchOutboxBatch as carrying the same unaddressed risk). Denormalizing the
+-- sort key onto search_outbox itself lets the claim query index-scan in claim order — the
+-- supporting index is 0097_search_outbox_claim_idx.sql (CREATE INDEX CONCURRENTLY needs its
+-- own no-transaction file, same reasoning as 0081's header).
+--
+-- Nullable — not NOT NULL — deliberately: a SET NOT NULL on a large table takes an exclusive
+-- lock to validate. The application always populates this column going forward
+-- (EnqueueSearchOutbox); ORDER BY ... NULLS LAST in the claim query is defensive insurance
+-- for any row that predates the backfill below, not a load-bearing requirement — jobs.created_at
+-- (the COALESCE fallback) is itself NOT NULL DEFAULT now(), so a NULL can only arise from a row
+-- this migration's own backfill missed.
+--
+-- Same staleness caveat as semantic_outbox's job_posted_at: jobs.posted_at is not immutable
+-- post-ingest, and search_outbox's ON CONFLICT (job_id) DO NOTHING means an already-queued
+-- row's job_posted_at can go stale relative to a later posted_at change. Accepted: it
+-- self-heals the moment the row is claimed and re-derived fresh on the next enqueue, and
+-- affects only claim ORDER (which job drains first under backlog), never correctness (which
+-- jobs drain, or duplicate draining).
+--
+-- Applied to a fresh volume by initdb after 0095; on an existing prod volume run this
+-- manually (SET ROLE hire) BEFORE deploying code that reads/writes the column.
+ALTER TABLE public.search_outbox ADD COLUMN job_posted_at timestamp with time zone;
+
+-- One-time backfill for rows already queued before this column existed. Plain UPDATE: takes
+-- only row-level locks as it proceeds, not a table-level one, so — unlike the CONCURRENTLY
+-- index in 0097 — it does not need to run outside this migration's normal transaction.
+UPDATE public.search_outbox o
+SET job_posted_at = COALESCE(j.posted_at, j.created_at)
+FROM public.jobs j
+WHERE j.id = o.job_id
+  AND o.job_posted_at IS NULL;

--- a/migrations/0097_search_outbox_claim_idx.sql
+++ b/migrations/0097_search_outbox_claim_idx.sql
@@ -1,0 +1,25 @@
+-- migrate: no-transaction
+--
+-- Partial index over the claimable set (mirrors search_outbox_claimable_idx's WHERE
+-- clause), pre-sorted in the exact order ClaimSearchOutboxBatch's CTE now requests (see
+-- 0096_search_outbox_job_posted_at.sql) — an index scan in claim order, no join, no
+-- materialize-then-sort.
+--
+-- Split into its own file, mirroring 0081 (semantic_outbox_claim_idx) for the identical
+-- reason: search_outbox is under continuous prod write traffic (cmd/ingest's enqueue,
+-- cmd/search-drain's claim/update/failure paths), and a plain CREATE INDEX holds a SHARE
+-- lock blocking writes for the whole build. CONCURRENTLY takes SHARE UPDATE EXCLUSIVE
+-- instead, blocking neither readers nor writers, at the cost of two table passes — but
+-- Postgres forbids CONCURRENTLY inside a transaction block, and a migration file's
+-- statements sent as one multi-statement query run in an implicit transaction regardless
+-- of the no-transaction marker (that marker only stops internal/migrate's OWN wrapping
+-- BEGIN/COMMIT — it does not change how Postgres itself batches a multi-statement
+-- message). A file mixing this with 0096's ADD COLUMN/UPDATE would therefore fail with
+-- "CREATE INDEX CONCURRENTLY cannot run inside a transaction block".
+--
+-- Applied to a fresh volume by initdb after 0096; on an existing prod volume build it by
+-- hand, detached from the SSH session (systemd-run or nohup) — a CONCURRENTLY build dies
+-- with its ssh session and leaves an INVALID index behind (same warning 0078/0081/0056
+-- already give).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS search_outbox_claim_idx ON public.search_outbox
+    USING btree (job_posted_at DESC, job_id DESC) WHERE (failed_at IS NULL);


### PR DESCRIPTION
## Summary
- Denormalize `job_posted_at` onto `search_outbox` so `ClaimSearchOutboxBatch` sorts via an index scan instead of joining+sorting the whole claimable set against `jobs` (migrations 0096/0097).
- Batch `cmd/search-drain`'s `RoleClusterCount`/`RoleClusterGeo` lookups across a whole wave (new `RoleClusterGeoFor` query) instead of one round trip per job.
- `hardconstraint.appendLocationWorkMode` now applies its remote-preference/geography checks to `hybrid` jobs too, not just `onsite`.
- Add a per-user rate limiter to `POST /me/match-text`, matching the sibling LLM fit-analysis routes.
- Add an integration test covering `internal/migrate`'s auto-baseline path (a pre-runner database with no `schema_migrations` table) against a real Postgres — previously only the pure `decide()` router was tested.
- Scope `TouchAssistantSession`/`SetAssistantSessionLabel` to the session owner (add a `user_id` predicate), mirroring every other write on `assistant_sessions`.
- Make `assistant.UserSaid` negation-aware, so a denial ("I did NOT lead the migration...") is no longer misattributed as the candidate asserting the quoted claim.
- Add `ListRecentAssistantMessages` (bounded, `ORDER BY seq DESC LIMIT`) so `Runner.history()` no longer fetches and JSON-decodes a session's entire transcript every turn just to trim it to the last 60 messages.
- Add `OFFSET` to `ListOrphanedApplications` and a new `CountOrphanedApplications` query, so paging the tracking board no longer re-reads the same top-N pruned-posting applications on every page, and `meta.counts` now includes them.
- Fix `job.Fields.UpdateManualParams` to derive `content_hash` from the slug that's actually persisted, not the freshly re-derived (and never-written) `f.PublicSlug`.
- Bound `jobfacts.EnglishLevel`'s input length and stop re-scanning the English-keyword regex on every call, closing an unbounded O(#keyword × #phrase) worst case on the per-job ingest path.

## Test plan
- `gofmt -l .` — clean
- `go build ./...` — pass
- `go vet ./...` and `go vet -tags=integration ./...` — pass
- `go test ./...` — pass except a pre-existing, unrelated failure (`TestExtractResumeProfile_PDF`, confirmed failing identically on a clean `origin/main` checkout before any of these changes — environment-dependent, not caused by this branch)
- `go test -tags=integration` for every touched package (`internal/db`, `internal/migrate`, `cmd/search-drain`, `internal/handler`, `internal/assistant`) — all new and existing tests pass, including the new coverage this PR adds (claim ordering/skip behavior, role-cluster wave batching without cross-contamination, migrate auto-baseline, assistant-session ownership scoping, bounded transcript fetch, orphaned-application paging/counting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Search indexing now processes job clusters more efficiently and keeps company-specific location data accurate.
  - Tracking pages now include orphaned applications in counts and support reliable pagination.
  - Match-text requests now have per-user/IP rate limits.
  - Hybrid roles receive location and remote-preference checks like on-site roles.
- **Bug Fixes**
  - Assistant sessions and labels are protected from unauthorized updates.
  - Assistant transcripts load only the requested recent messages.
  - Negated statements no longer trigger incorrect assistant matches.
  - Job updates preserve stable hashing and English-level detection is bounded for performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->