### PR TITLE
Restore skills as an enrichment discovery facet

### DIFF
--- a/docs/superpowers/plans/2026-08-14-restore-skills-discovery.md
+++ b/docs/superpowers/plans/2026-08-14-restore-skills-discovery.md
@@ -1,0 +1,406 @@
+# Restore Skills Discovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-request `skills` in the enrichment LLM prompt/schema so `Enrichment.Skills` starts populating again, as a raw discovery signal for future `internal/skilltag` dictionary expansion.
+
+**Architecture:** Two-line-ish edit to `internal/enrich/langchain.go` (prompt) and `internal/enrich/schema.go` (request schema), plus a comment fix in `internal/enrich/enrichment.go`. No new files, no struct/DB change, no `enrich.Version` bump.
+
+**Tech Stack:** Go, `internal/enrich` package (existing LLM structured-output pipeline).
+
+## Global Constraints
+
+- Forward-only: do NOT bump `enrich.Version`; do NOT write any backfill/re-enrichment code. (proposal.md, design.md)
+- Reuse the existing `Enrichment.Skills []string` field (`json:"skills"`) — do NOT add a new field, table, or JSON key. (design.md)
+- Only `skills` is restored. Do NOT re-add `work_mode`, `seniority`, `category`, `employment_type`, `education_level`, `english_level`, `posting_language`, or `experience_years_min` to the prompt or schema. (proposal.md)
+- No aggregation/dedup pipeline in this change — only the raw-capture restart. (design.md)
+- OpenSpec change `restore-skills-discovery` (already committed at `f2fb432d`) is the spec of record; `openspec change validate restore-skills-discovery --strict` must keep passing after code changes land.
+
+---
+
+### Task 1: Prompt — re-request `skills` in `buildSystemPrompt`
+
+**Files:**
+- Modify: `internal/enrich/langchain.go:128-134` (the "Other keys" line inside `buildSystemPrompt`)
+- Test: `internal/enrich/langchain_test.go`
+
+**Interfaces:**
+- Consumes: nothing new — `buildSystemPrompt(askGeo bool) string` keeps its existing signature.
+- Produces: the string returned by `buildSystemPrompt` now contains the substring `"skills"` (and the fuller phrase `"skills (array of lowercase tokens, e.g. go, postgresql)"`) regardless of `askGeo`. `Task 2` and `Task 3` depend on this exact phrase existing in the prompt.
+
+- [ ] **Step 1: Edit `TestSystemPromptOmitsDictBackedFacets` to drop `skills`**
+
+Current test body (`internal/enrich/langchain_test.go:60-71`):
+
+```go
+func TestSystemPromptOmitsDictBackedFacets(t *testing.T) {
+	p := buildSystemPrompt(true)
+	for _, f := range []string{
+		"work_mode", "seniority", "category", "skills",
+		"employment_type", "education_level", "english_level",
+		"posting_language", "experience_years_min",
+	} {
+		if strings.Contains(p, f) {
+			t.Errorf("prompt must not request dict-backed facet %q (served from dictionaries), got:\n%s", f, p)
+		}
+	}
+}
+```
+
+Replace the field list (drop `"skills"` — it is no longer a dict-backed-and-unrequested facet):
+
+```go
+func TestSystemPromptOmitsDictBackedFacets(t *testing.T) {
+	p := buildSystemPrompt(true)
+	for _, f := range []string{
+		"work_mode", "seniority", "category",
+		"employment_type", "education_level", "english_level",
+		"posting_language", "experience_years_min",
+	} {
+		if strings.Contains(p, f) {
+			t.Errorf("prompt must not request dict-backed facet %q (served from dictionaries), got:\n%s", f, p)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Add `skills` to `TestSystemPromptKeepsServedAndHybridFields`**
+
+Current test body (`internal/enrich/langchain_test.go:78-96`):
+
+```go
+func TestSystemPromptKeepsServedAndHybridFields(t *testing.T) {
+	p := buildSystemPrompt(true)
+	for _, f := range []string{
+		"summary",
+		"salary_min", "salary_max", "salary_currency", "salary_period",
+		"visa_sponsorship", "timezone_note",
+		"company_type", "company_size", "domains",
+		"relocation", "countries", "regions",
+	} {
+		if !strings.Contains(p, f) {
+			t.Errorf("prompt must still request served/hybrid field %q, got:\n%s", f, p)
+		}
+	}
+	if !strings.Contains(p, "exactly one of the allowed values") {
+		t.Errorf("served enum fields must keep the strict instruction")
+	}
+	if !strings.Contains(p, "concise lowercase label of your own") {
+		t.Errorf("countries/regions must keep the novel own-label allowance")
+	}
+}
+```
+
+Add `"skills"` to the field list:
+
+```go
+func TestSystemPromptKeepsServedAndHybridFields(t *testing.T) {
+	p := buildSystemPrompt(true)
+	for _, f := range []string{
+		"summary",
+		"salary_min", "salary_max", "salary_currency", "salary_period",
+		"visa_sponsorship", "timezone_note",
+		"company_type", "company_size", "domains",
+		"relocation", "countries", "regions", "skills",
+	} {
+		if !strings.Contains(p, f) {
+			t.Errorf("prompt must still request served/hybrid field %q, got:\n%s", f, p)
+		}
+	}
+	if !strings.Contains(p, "exactly one of the allowed values") {
+		t.Errorf("served enum fields must keep the strict instruction")
+	}
+	if !strings.Contains(p, "concise lowercase label of your own") {
+		t.Errorf("countries/regions must keep the novel own-label allowance")
+	}
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `go test ./internal/enrich/... -run TestSystemPromptOmitsDictBackedFacets -v` — Expected: PASS (skills was never in the prompt yet, so its absence still holds; this one should already pass, confirming step 1 didn't break anything).
+
+Run: `go test ./internal/enrich/... -run TestSystemPromptKeepsServedAndHybridFields -v` — Expected: FAIL with `prompt must still request served/hybrid field "skills"`.
+
+- [ ] **Step 4: Edit `buildSystemPrompt` to re-request `skills`**
+
+In `internal/enrich/langchain.go`, find this block (currently lines 128-134):
+
+```go
+	b.WriteString("\nOther keys (null when unstated): ")
+	b.WriteString("visa_sponsorship (boolean), ")
+	if askGeo {
+		b.WriteString("countries (array of ISO 3166-1 alpha-2), ")
+	}
+	b.WriteString("cities (array of strings), timezone_note (string), ")
+	b.WriteString("salary_min (int), salary_max (int), salary_currency (ISO 4217).\n")
+```
+
+Replace the last line to add `skills` after the salary fields (matching the pre-`enrich-prompt-trim` wording exactly):
+
+```go
+	b.WriteString("\nOther keys (null when unstated): ")
+	b.WriteString("visa_sponsorship (boolean), ")
+	if askGeo {
+		b.WriteString("countries (array of ISO 3166-1 alpha-2), ")
+	}
+	b.WriteString("cities (array of strings), timezone_note (string), ")
+	b.WriteString("salary_min (int), salary_max (int), salary_currency (ISO 4217), ")
+	b.WriteString("skills (array of lowercase tokens, e.g. go, postgresql).\n")
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `go test ./internal/enrich/... -run 'TestSystemPromptOmitsDictBackedFacets|TestSystemPromptKeepsServedAndHybridFields' -v`
+
+Expected: both PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/i_strelov/Projects/hire
+git add internal/enrich/langchain.go internal/enrich/langchain_test.go
+git commit -m "enrich: re-request skills in the LLM prompt as a discovery facet"
+```
+
+---
+
+### Task 2: Schema — stop omitting `skills` from the request schema
+
+**Files:**
+- Modify: `internal/enrich/schema.go:23-27` (`unaskedFields`)
+- Test: `internal/enrich/schema_test.go`
+
+**Interfaces:**
+- Consumes: `requestSchema(askGeo bool) (llmschema.Schema, string, error)` (unchanged signature) and `schemaProps(t *testing.T, askGeo bool) map[string]any` test helper (unchanged, `internal/enrich/schema_test.go:10-23`).
+- Produces: `schemaProps(t, true)["skills"]` now exists. `unaskedFields` no longer contains `"skills"` — `Task 3`'s comment fix references this list.
+
+- [ ] **Step 1: Add `skills` to `TestRequestSchema_CarriesTheFieldsThePromptAsksFor`**
+
+Current test body (`internal/enrich/schema_test.go:67-80`):
+
+```go
+func TestRequestSchema_CarriesTheFieldsThePromptAsksFor(t *testing.T) {
+	props := schemaProps(t, true)
+
+	for _, field := range []string{
+		"summary", "relocation", "visa_sponsorship", "cities", "timezone_note",
+		"salary_min", "salary_max", "salary_currency", "salary_period",
+		"domains", "company_type", "company_size", "regions", "countries",
+	} {
+		if _, ok := props[field]; !ok {
+			t.Errorf("schema is missing %q, so the model would stop returning it", field)
+		}
+	}
+}
+```
+
+Add `"skills"` to the field list:
+
+```go
+func TestRequestSchema_CarriesTheFieldsThePromptAsksFor(t *testing.T) {
+	props := schemaProps(t, true)
+
+	for _, field := range []string{
+		"summary", "relocation", "visa_sponsorship", "cities", "timezone_note",
+		"salary_min", "salary_max", "salary_currency", "salary_period",
+		"domains", "company_type", "company_size", "regions", "countries", "skills",
+	} {
+		if _, ok := props[field]; !ok {
+			t.Errorf("schema is missing %q, so the model would stop returning it", field)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/enrich/... -run TestRequestSchema_CarriesTheFieldsThePromptAsksFor -v`
+
+Expected: FAIL with `schema is missing "skills"`.
+
+- [ ] **Step 3: Remove `skills` from `unaskedFields`**
+
+In `internal/enrich/schema.go`, current:
+
+```go
+var unaskedFields = []string{
+	"work_mode", "employment_type",
+	"seniority", "english_level", "education_level", "skills",
+	"category", "experience_years_min", "posting_language",
+}
+```
+
+Replace with:
+
+```go
+var unaskedFields = []string{
+	"work_mode", "employment_type",
+	"seniority", "english_level", "education_level",
+	"category", "experience_years_min", "posting_language",
+}
+```
+
+- [ ] **Step 4: Run the full schema test file to verify everything still passes**
+
+Run: `go test ./internal/enrich/... -run TestRequestSchema -v`
+
+Expected: PASS, including `TestRequestSchema_DoesNotAskForDictionaryCoveredFacets` (it iterates `unaskedFields` directly, so removing `"skills"` from that slice automatically stops it being checked there — no edit needed to that test) and the newly-updated `TestRequestSchema_CarriesTheFieldsThePromptAsksFor`.
+
+- [ ] **Step 5: Confirm `unaskedFields`'s doc comment needs no wording change**
+
+Read `internal/enrich/schema.go:18-22` — the comment above `unaskedFields`:
+
+```go
+// unaskedFields are contract fields the prompt deliberately does not request, so the
+// schema must not either. Under strict mode every property is required — leaving one
+// in would order the model to produce a value that `jobview` then discards, which is
+// the token burn `enrich-prompt-trim` removed. They are served from the deterministic
+// dictionaries (`internal/jobderive`), not the LLM.
+```
+
+This comment describes the slice generically and never names `skills` (unlike
+`enrichment.go`'s `Validate` comment, fixed in Task 3) — it stays accurate once
+`skills` is removed from the slice in Step 3, describing the eight remaining fields.
+No edit needed here; this step exists so the change is a deliberate "checked, no
+action" rather than a silently skipped one.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/i_strelov/Projects/hire
+git add internal/enrich/schema.go internal/enrich/schema_test.go
+git commit -m "enrich: stop omitting skills from the request schema"
+```
+
+---
+
+### Task 3: Comment fix — `Validate`'s doc comment no longer describes `skills` as unrequested
+
+**Files:**
+- Modify: `internal/enrich/enrichment.go:113-121` (the doc comment on `Validate`)
+
+**Interfaces:**
+- Consumes: nothing (comment-only change).
+- Produces: nothing new — no behavior, signature, or test changes. `Validate`'s actual logic is untouched (it already never validates `skills`, which stays correct).
+
+This task has no RED/GREEN cycle — it is a comment-only fix with nothing to assert in a test. Verify by reading, not running.
+
+- [ ] **Step 1: Confirm the current wording is now stale**
+
+Read `internal/enrich/enrichment.go:113-121`:
+
+```go
+// Validate checks every SERVED enum field against its controlled vocabulary and
+// returns an error identifying the first offending field. Empty (absent) fields
+// pass — every field is optional. Non-enum fields (ISO codes, free text, numbers,
+// skills) are unconstrained here. The dictionary-covered facets (work_mode,
+// seniority, category, regions, employment_type, education_level, english_level,
+// plus the non-enum countries/skills) are deliberately NOT validated: they are served from
+// the deterministic dictionaries (dict-only), so the LLM's values for them are
+// unserved discovery material and an out-of-vocabulary value is captured raw
+// rather than rejected.
+func (e Enrichment) Validate() error {
+```
+
+After Task 1/Task 2, `skills` IS requested from the LLM again (it is no longer "dict-only" in the sense this comment implies for the other six facets it's grouped with). Left as-is, a reader would wrongly conclude `skills` is never sent to the model.
+
+- [ ] **Step 2: Replace the comment**
+
+Replace lines 113-121 with:
+
+```go
+// Validate checks every SERVED enum field against its controlled vocabulary and
+// returns an error identifying the first offending field. Empty (absent) fields
+// pass — every field is optional. Non-enum fields (ISO codes, free text, numbers,
+// skills) are unconstrained here. The dictionary-covered facets (work_mode,
+// seniority, category, regions, employment_type, education_level, english_level,
+// plus the non-enum countries) are deliberately NOT validated: they are served from
+// the deterministic dictionaries (dict-only), so the LLM's values for them are
+// unserved discovery material and an out-of-vocabulary value is captured raw
+// rather than rejected. skills is requested from the LLM too (restore-skills-discovery)
+// but is likewise never validated — it has no closed vocabulary to check against, so
+// whatever the model returns is captured raw, same as countries/regions.
+func (e Enrichment) Validate() error {
+```
+
+- [ ] **Step 3: Sweep for any other stale `skills` reference**
+
+Run: `grep -n "skills" internal/enrich/*.go | grep -v _test.go`
+
+Expected matches, all already correct after Steps 1-2 and Task 2, nothing else:
+
+- `internal/enrich/enrichment_unmarshal.go:107` — the `Skills sliceOrWrap` unmarshal
+  field (unrelated to this change, always correct).
+- `internal/enrich/enrichment.go:79` — the `Skills []string` struct field itself.
+- Two lines inside the new `Validate` comment from Step 2 (the "numbers, skills)
+  are unconstrained" line and the new "skills is requested from the LLM too" line).
+- **`internal/enrich/schema.go` must have ZERO matches** — `unaskedFields` no
+  longer contains `"skills"` (Task 2 Step 3) and its doc comment never named
+  `skills` (Task 2 Step 5), so nothing in that file should mention it.
+
+If any other file/line mentions `skills` in a way that still claims it is
+dict-only/unrequested, fix it the same way as Step 2 before moving on — this step
+exists to catch anything this plan's authoring pass missed.
+
+- [ ] **Step 4: Verify the package still builds**
+
+Run: `go build ./internal/enrich/... && go vet ./internal/enrich/...`
+
+Expected: no errors (comment-only change).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/i_strelov/Projects/hire
+git add internal/enrich/enrichment.go
+git commit -m "enrich: fix Validate's doc comment now that skills is requested again"
+```
+
+---
+
+### Task 4: Full verification and OpenSpec sync check
+
+**Files:** none modified — verification only.
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Run the full `internal/enrich` package test suite**
+
+Run: `go test ./internal/enrich/... -v`
+
+Expected: all tests PASS, including every test named in Tasks 1-2 plus the untouched tests (`TestValidateAcceptsOutOfVocabDiscoveryFacets`, `TestSanitizeDropsOutOfVocabValues`, etc. in `enrichment_test.go`) — none of those should need edits, since `Sanitize`/`Validate` behavior is unchanged.
+
+- [ ] **Step 2: Run the whole-repo build and vet**
+
+Run: `go build ./... && go vet ./...`
+
+Expected: no errors.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `go test ./...`
+
+Expected: all packages PASS. (If any unrelated package fails for reasons unconnected to this change, note it but do not attempt to fix it as part of this task — out of scope per the design's Non-Goals.)
+
+- [ ] **Step 4: Re-validate the OpenSpec change**
+
+Run: `openspec change validate restore-skills-discovery --strict` (from `/Users/i_strelov/Projects/hire`)
+
+Expected: `Change "restore-skills-discovery" is valid` (already confirmed once when the proposal was written; re-run now that code matches the spec).
+
+- [ ] **Step 5: Confirm no version bump or backfill code was introduced**
+
+Run: `git diff f2fb432d..HEAD --stat` (from `/Users/i_strelov/Projects/hire`) and confirm the file list is exactly: `internal/enrich/langchain.go`, `internal/enrich/langchain_test.go`, `internal/enrich/schema.go`, `internal/enrich/schema_test.go`, `internal/enrich/enrichment.go`.
+
+Also run: `git diff f2fb432d..HEAD -- internal/enrich/enrichment.go internal/enrich | grep -n "Version"`
+
+Expected: no output (or only unrelated matches unconnected to `enrich.Version`) —
+confirms the Global Constraint ("do NOT bump `enrich.Version`; do NOT write any
+backfill/re-enrichment code") held throughout implementation.
+
+- [ ] **Step 6: Final commit / wrap-up**
+
+Confirm `git log --oneline -5` shows the three commits from Tasks 1-3 plus the earlier proposal commit (`f2fb432d`), all still on the current branch (`harvest-echojobs-orphans-retry-ratelimited` at plan-writing time — confirm this is still the intended branch before pushing, per the note already raised with the user about the branch name).
+
+No further commit needed at this step — it is a verification-only task.

--- a/internal/enrich/enrichment.go
+++ b/internal/enrich/enrichment.go
@@ -115,10 +115,12 @@ func (e *Enrichment) servedScalarEnums() []scalarEnum {
 // pass — every field is optional. Non-enum fields (ISO codes, free text, numbers,
 // skills) are unconstrained here. The dictionary-covered facets (work_mode,
 // seniority, category, regions, employment_type, education_level, english_level,
-// plus the non-enum countries/skills) are deliberately NOT validated: they are served from
+// plus the non-enum countries) are deliberately NOT validated: they are served from
 // the deterministic dictionaries (dict-only), so the LLM's values for them are
 // unserved discovery material and an out-of-vocabulary value is captured raw
-// rather than rejected.
+// rather than rejected. skills is requested from the LLM too (restore-skills-discovery)
+// but is likewise never validated — it has no closed vocabulary to check against, so
+// whatever the model returns is captured raw, same as countries/regions.
 func (e Enrichment) Validate() error {
 	// Single-value SERVED enum fields. Value receiver, so take the address of the
 	// local copy to reuse the shared field set.

--- a/internal/enrich/langchain.go
+++ b/internal/enrich/langchain.go
@@ -131,7 +131,8 @@ func buildSystemPrompt(askGeo bool) string {
 		b.WriteString("countries (array of ISO 3166-1 alpha-2), ")
 	}
 	b.WriteString("cities (array of strings), timezone_note (string), ")
-	b.WriteString("salary_min (int), salary_max (int), salary_currency (ISO 4217).\n")
+	b.WriteString("salary_min (int), salary_max (int), salary_currency (ISO 4217), ")
+	b.WriteString("skills (array of lowercase tokens, e.g. go, postgresql).\n")
 
 	// Salary guard: the model, told the field is an int, otherwise decimal-strips a
 	// fractional hourly rate ($26.08 -> 2608), inflating it 100x. A concrete

--- a/internal/enrich/langchain_test.go
+++ b/internal/enrich/langchain_test.go
@@ -60,7 +60,7 @@ func TestSystemPromptIncludesRegionVocabulary(t *testing.T) {
 func TestSystemPromptOmitsDictBackedFacets(t *testing.T) {
 	p := buildSystemPrompt(true)
 	for _, f := range []string{
-		"work_mode", "seniority", "category", "skills",
+		"work_mode", "seniority", "category",
 		"employment_type", "education_level", "english_level",
 		"posting_language", "experience_years_min",
 	} {
@@ -82,7 +82,7 @@ func TestSystemPromptKeepsServedAndHybridFields(t *testing.T) {
 		"salary_min", "salary_max", "salary_currency", "salary_period",
 		"visa_sponsorship", "timezone_note",
 		"company_type", "company_size", "domains",
-		"relocation", "countries", "regions",
+		"relocation", "countries", "regions", "skills",
 	} {
 		if !strings.Contains(p, f) {
 			t.Errorf("prompt must still request served/hybrid field %q, got:\n%s", f, p)

--- a/internal/enrich/schema.go
+++ b/internal/enrich/schema.go
@@ -22,7 +22,7 @@ const (
 // dictionaries (`internal/jobderive`), not the LLM.
 var unaskedFields = []string{
 	"work_mode", "employment_type",
-	"seniority", "english_level", "education_level", "skills",
+	"seniority", "english_level", "education_level",
 	"category", "experience_years_min", "posting_language",
 }
 

--- a/internal/enrich/schema_test.go
+++ b/internal/enrich/schema_test.go
@@ -70,7 +70,7 @@ func TestRequestSchema_CarriesTheFieldsThePromptAsksFor(t *testing.T) {
 	for _, field := range []string{
 		"summary", "relocation", "visa_sponsorship", "cities", "timezone_note",
 		"salary_min", "salary_max", "salary_currency", "salary_period",
-		"domains", "company_type", "company_size", "regions", "countries",
+		"domains", "company_type", "company_size", "regions", "countries", "skills",
 	} {
 		if _, ok := props[field]; !ok {
 			t.Errorf("schema is missing %q, so the model would stop returning it", field)

--- a/openspec/changes/restore-skills-discovery/design.md
+++ b/openspec/changes/restore-skills-discovery/design.md
@@ -1,0 +1,80 @@
+## Context
+
+`internal/enrich/langchain.go:buildSystemPrompt` currently asks the LLM for a
+subset of the `Enrichment` contract; `internal/enrich/schema.go:unaskedFields`
+mirrors that subset into the strict JSON request schema. Both were narrowed by
+`enrich-prompt-trim` (#659), which correctly identified that `work_mode`,
+`seniority`, `category`, `skills`, `employment_type`, `education_level`,
+`english_level`, `posting_language`, and `experience_years_min` are all served
+to readers from deterministic dictionaries (`internal/jobderive`), so the LLM's
+copies were pure discovery material with no serving path — and paid-for output
+tokens regardless.
+
+The `Enrichment.Skills []string` field (`internal/enrich/enrichment.go`) was
+never removed from the struct; it simply reads back empty on every enrichment
+since #659, because nothing asks the model to populate it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Resume collecting the LLM's raw `skills` guess into the existing
+  `Enrichment.Skills` field, going forward, as a discovery signal for future
+  `internal/skilltag` dictionary expansion.
+- Touch only what's needed to re-request and re-accept `skills` — no change to
+  how `skills` is served today (`internal/skilltag` dict-based tagging is
+  untouched and remains the sole served source).
+
+**Non-Goals:**
+- Reverting any of the other eight fields `enrich-prompt-trim` dropped. Their
+  taxonomies are closed and slow-changing (grade levels, employment types,
+  education levels, …); discovery has near-zero marginal value there, so
+  re-requesting them would reintroduce the exact waste #659 fixed for no
+  offsetting benefit.
+- Building a pipeline that aggregates/dedupes raw `skills` values into
+  `internal/skilltag` dictionary candidates. This change restarts raw capture
+  only; someone will eventually need to read `jobs.enrichment->>'skills'`
+  across the catalogue and decide what's missing from the dictionary, but that
+  read/aggregation step is separate follow-up work, not part of this change.
+- A new field, table, or JSON key. `Enrichment.Skills` / `"skills"` already
+  exists in the contract and is already exempted from validation (see
+  `enrichment.go`'s existing "non-enum countries/skills… deliberately NOT
+  validated" comment) — reusing it is strictly smaller than adding
+  `raw_skills` alongside it, and avoids two similarly-named fields.
+
+## Decisions
+
+- **Prompt-only + schema-only edit.** `buildSystemPrompt` regains the
+  `skills (array of lowercase tokens, e.g. go, postgresql)` line in "Other
+  keys", worded exactly as it was pre-#659. `unaskedFields` in `schema.go`
+  drops `"skills"`. `Validate`/`Sanitize` need NO code change — `skills` was
+  already carved out of `servedScalarEnums` and already documented as
+  unvalidated discovery material; that behavior is exactly what's needed once
+  the model starts populating it again.
+- **Comment cleanup, not behavior change.** Three comments currently assert
+  `skills` is dict-only/unrequested (`schema.go`'s `unaskedFields` doc comment,
+  `enrichment.go`'s `servedScalarEnums`/`Validate` doc comments). They get
+  reworded to reflect that `skills` is a requested discovery facet again,
+  alongside `countries`/`regions` — no logic in those functions changes.
+- **No version bump, no backfill.** Consistent with the forward-only
+  convention `enrich-prompt-trim` itself established for this exact class of
+  change: existing enrichment payloads keep an empty `skills` array; only new
+  or re-run enrichments populate it.
+
+## Risks / Trade-offs
+
+- **Renewed per-call token cost.** Every enrichment call now pays for a
+  `skills` array in the output again. Accepted: it's one field of the nine
+  #659 removed, and it's the one field in that set with an active, stated
+  future use (dictionary discovery) rather than none.
+- **No consumer yet.** Until a follow-up change reads and aggregates the raw
+  `skills` values, this collects data nobody looks at — same shape of
+  criticism #659 leveled at the original nine-field discovery capture.
+  Accepted deliberately: the user wants collection to resume now so the
+  backlog of raw signal starts accumulating (forward-only, no backfill) ahead
+  of the aggregation work, rather than losing weeks of signal waiting for the
+  aggregation design to land first.
+- **Budget-model prompt sensitivity.** Same caution `enrich-prompt-trim` noted
+  in reverse: adding a key back changes prompt length/order. Tests must assert
+  the full expected key set (previously-retained keys still present, `skills`
+  now present, the other eight still absent) rather than just checking
+  `skills` in isolation.

--- a/openspec/changes/restore-skills-discovery/proposal.md
+++ b/openspec/changes/restore-skills-discovery/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+`enrich-prompt-trim` (#659) stopped asking the LLM for nine dict-backed fields —
+`work_mode`, `seniority`, `category`, `skills`, `employment_type`,
+`education_level`, `english_level`, `posting_language`, `experience_years_min` —
+because `jobview` serves all of them from the deterministic dictionaries, so the
+LLM's copies were paid-for output tokens nobody read.
+
+`skills` is different from the other eight: `internal/skilltag`'s dictionary
+covers a genuinely open-ended domain (new frameworks/tools/languages appear
+continuously), unlike the other eight closed, slow-changing taxonomies. Before
+#659, `skills` was one of the discovery facets the prompt deliberately let the
+model answer outside the dictionary, specifically to surface vocabulary the
+dictionary is missing. We want that discovery signal back to drive future
+`internal/skilltag` dictionary expansion — the other eight stay dropped, since
+none of their taxonomies benefit from discovery the way an open skills
+vocabulary does.
+
+## What Changes
+
+- Re-request `skills` in the enrichment system prompt
+  (`internal/enrich/langchain.go`, `buildSystemPrompt`): restore the
+  `skills (array of lowercase tokens, e.g. go, postgresql)` entry to the "Other
+  keys" line, exactly as worded before #659.
+- Re-include `skills` in the LLM request schema (`internal/enrich/schema.go`):
+  remove it from `unaskedFields`, so the strict JSON schema stops omitting it.
+- Update the comments in `schema.go` and `enrichment.go` that currently describe
+  `skills` as dict-only/unasked — they no longer hold once this ships.
+- **Reuse the existing `Enrichment.Skills []string` field** (`json:"skills"`) —
+  it was never removed from the contract by #659, only left permanently empty.
+  No new field, no struct change, no DB/migration change.
+- **No contract version change and no re-enrichment.** `enrich.Version` is NOT
+  bumped; existing (empty) `skills` payloads are NOT backfilled. New and
+  re-enriched jobs pick it up going forward, matching the forward-only
+  convention `enrich-prompt-trim` itself established.
+- **Not in scope:** the other eight fields `enrich-prompt-trim` dropped stay
+  dropped — no revert for `work_mode`, `seniority`, `category`,
+  `employment_type`, `education_level`, `english_level`, `posting_language`,
+  `experience_years_min`. Also not in scope: any aggregation/dedup pipeline that
+  turns raw `skills` values into `internal/skilltag` dictionary candidates —
+  this change only restarts the raw capture; mining it into dictionary
+  additions is a separate future change.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `ai-enrichment`: "Unserved discovery facets are captured raw, not validated"
+  narrows again — `skills` re-joins `countries`/`regions` as a facet the prompt
+  DOES request and MAY answer outside its (nonexistent) closed vocabulary,
+  captured raw and unvalidated. The other eight fields named in that
+  requirement are unaffected and stay unrequested.
+
+## Impact
+
+- Affected code: `internal/enrich/langchain.go`, `internal/enrich/schema.go`,
+  `internal/enrich/enrichment.go` (comments only).
+- Affected spec: `openspec/specs/ai-enrichment/spec.md`, requirement "Unserved
+  discovery facets are captured raw, not validated".
+- Cost: one array field re-added to LLM output per enrichment call (a small
+  fraction of the nine-field output `enrich-prompt-trim` removed).
+- No schema/migration/frontend change. `jobview`'s served `skills` projection
+  (from `internal/skilltag`) is unchanged — this only restarts collection of the
+  LLM's raw, unserved copy.

--- a/openspec/changes/restore-skills-discovery/specs/ai-enrichment/spec.md
+++ b/openspec/changes/restore-skills-discovery/specs/ai-enrichment/spec.md
@@ -1,0 +1,94 @@
+# ai-enrichment
+
+## MODIFIED Requirements
+
+### Requirement: Description fields are mapped into the contract
+
+The system SHALL define a `Provider` abstraction in `internal/enrich` that, given a
+job's source fields (at minimum `title`, `company`, `location`, `remote`,
+`description`), returns a populated `Enrichment` value. The provider SHALL instruct
+the LLM with the controlled vocabularies from the phase-1 contract so that the enum
+fields it is asked for are constrained to their allowed values. The provider SHALL
+NOT ask the LLM for the dictionary-covered facets that the read layer serves from the
+deterministic dictionaries (see "Unserved discovery facets are captured raw, not
+validated"); those are derived by `internal/jobderive`, not the LLM. Fields not
+determinable from the input SHALL be omitted, not guessed.
+
+#### Scenario: Description fields are mapped into the contract
+
+- **WHEN** the provider is given a job whose description states "Senior Go engineer,
+  fully remote, €70k–90k/year, Go and PostgreSQL"
+- **THEN** it returns an `Enrichment` with `salary_min=70000`, `salary_max=90000`,
+  `salary_currency=EUR`, `salary_period=year`, and `skills=["go", "postgresql"]`
+- **AND** it does not populate `seniority` or `work_mode` from the LLM — those are
+  derived by the deterministic dictionaries, not requested in the prompt
+
+#### Scenario: Unstated fields are omitted
+
+- **WHEN** a job description says nothing about visa sponsorship or company size
+- **THEN** the returned `Enrichment` leaves `visa_sponsorship`, `company_size`, and
+  every other unstated field absent rather than filled with a guess
+
+### Requirement: Unserved discovery facets are captured raw, not validated
+
+The enrichment prompt SHALL NOT request the dictionary-covered facets `work_mode`, `seniority`, `category`, `employment_type`, `education_level`, or `english_level`, nor the non-enum dict-derived `posting_language` and `experience_years_min` — the read layer serves all of these from the deterministic dictionaries (`internal/jobderive`), so the LLM's copies are never served and paying output tokens for them is waste.
+
+The prompt SHALL request `countries`, `regions`, and `skills` as discovery facets —
+`countries`/`regions` as the dict-then-LLM hybrid where the LLM fills only the
+unpinned geographic bucket via `jobview.geoFacet`, and `skills` as an open,
+unconstrained array with no closed vocabulary to defer to — and for `countries`/
+`regions` it MAY permit a concise lowercase label of the model's own when no allowed
+value fits.
+
+For any discovery value that is present (from the requested `countries`/`regions`/
+`skills` facets, or a pre-existing payload), the worker SHALL capture it raw:
+`Sanitize` SHALL NOT blank or filter an out-of-vocabulary `work_mode`, `seniority`,
+`category`, `regions`, or any `skills` entry, and `Validate` SHALL NOT reject the
+payload for an out-of-vocabulary value in those facets. The served enum fields
+(`relocation`, `salary_period`, `company_type`, `company_size`, `domains`) SHALL
+still be sanitized and validated, and salary clamping is unchanged. Re-requesting
+`skills` applies going forward only — `enrich.Version` MUST NOT be bumped and
+existing payloads MUST NOT be re-enriched; a payload from before this change simply
+keeps its empty `skills` array until the job is next (re-)enriched.
+
+#### Scenario: The prompt does not request the closed dict-covered facets
+
+- **WHEN** the enrichment system prompt is built
+- **THEN** it contains no request for `work_mode`, `seniority`, `category`,
+  `posting_language`, `experience_years_min`, `employment_type`, `education_level`,
+  or `english_level`
+- **AND** a new enrichment payload for a job whose description states "Senior Go
+  engineer" leaves those fields absent
+
+#### Scenario: The prompt requests skills as an open discovery facet
+
+- **WHEN** the enrichment system prompt is built
+- **THEN** it contains a request for `skills` as an array of lowercase tokens, with
+  no enum/vocabulary constraint in either the prompt text or the request JSON schema
+
+#### Scenario: A still-requested discovery value is persisted raw
+
+- **WHEN** the LLM returns `regions=["antarctica"]` (not a defined value) for a job
+- **THEN** `Sanitize` keeps it, `Validate` passes, and it is written to the job's
+  `enrichment` JSONB
+
+#### Scenario: Raw skills are persisted without a serving path
+
+- **WHEN** the LLM returns `skills=["rust", "some-brand-new-framework"]` for a job
+- **THEN** `Sanitize` keeps the array as-is and `Validate` passes, and it is written
+  to the job's `enrichment` JSONB
+- **AND** the job's served `skills` facet (from `internal/skilltag`) is unaffected —
+  the raw LLM array is discovery material only, not a serving source
+
+#### Scenario: An out-of-vocabulary served value is still rejected
+
+- **WHEN** the LLM returns `company_type="conglomerate"` (not a defined value)
+- **THEN** `Sanitize` blanks it, so no out-of-vocabulary value reaches the served
+  `company_type`
+
+#### Scenario: The discovery values do not reach the served object
+
+- **WHEN** a job's `enrichment` carries a raw `seniority="staff_plus"` discovery value
+  (e.g. from an older payload)
+- **THEN** the served job object's `seniority` is the dictionary value (or empty),
+  never the raw LLM discovery value

--- a/openspec/changes/restore-skills-discovery/tasks.md
+++ b/openspec/changes/restore-skills-discovery/tasks.md
@@ -1,0 +1,53 @@
+# Tasks
+
+## 1. Re-request `skills` in the prompt and schema
+
+- [ ] 1.1 **RED** — In `internal/enrich/langchain_test.go`:
+  - Drop `"skills"` from the hardcoded list in
+    `TestSystemPromptOmitsDictBackedFacets` (it must keep asserting the other
+    eight dict-backed facets are absent).
+  - Add `"skills (array of lowercase tokens"` (or the field name `"skills"`) to
+    the fields `TestSystemPromptKeepsServedAndHybridFields` asserts are
+    present in the built prompt.
+  Confirm both fail against the current prompt (skills still absent).
+- [ ] 1.2 **RED** — In `internal/enrich/schema_test.go`, add an assertion
+  (either inside `TestRequestSchema_CarriesTheFieldsThePromptAsksFor` or a new
+  test) that `schemaProps(t, true)` contains `"skills"`. Confirm it fails.
+- [ ] 1.3 **GREEN** — Edit `buildSystemPrompt` in
+  `internal/enrich/langchain.go`: add `skills (array of lowercase tokens, e.g.
+  go, postgresql), ` back into the "Other keys" line, in the same position it
+  held before #659 (immediately after the salary fields).
+- [ ] 1.4 **GREEN** — Edit `unaskedFields` in `internal/enrich/schema.go`:
+  remove `"skills"` from the slice.
+- [ ] 1.5 **Verify green** — `go test ./internal/enrich/...`. All four tests
+  from 1.1/1.2 pass; no other test in the package regresses.
+
+## 2. Reconcile comments that now describe stale behavior
+
+- [ ] 2.1 In `internal/enrich/schema.go`, reword the `unaskedFields` doc
+  comment: it currently lists `skills` among the dict-served/unasked fields —
+  drop it from that list and note it is requested again as a discovery facet.
+- [ ] 2.2 In `internal/enrich/enrichment.go`, reword the `servedScalarEnums`
+  and `Validate` doc comments: both currently describe `skills` as dict-only
+  alongside `countries`. Update the wording so `skills` reads as an active
+  discovery facet (like `countries`/`regions`), still deliberately unvalidated
+  — no change to `Validate`'s actual logic, comment-only.
+- [ ] 2.3 `go build ./... && go vet ./...` — confirm no other reference to the
+  old wording (e.g. package-level doc comments quoting the same field list)
+  was missed. `grep -rn "skills" internal/enrich/*.go` and eyeball every hit.
+
+## 3. Spec sync
+
+- [ ] 3.1 Confirm `openspec/changes/restore-skills-discovery/specs/ai-enrichment/spec.md`
+  (already written alongside this proposal) matches the shipped prompt/schema
+  wording exactly — field lists in the spec's "Unserved discovery facets are
+  captured raw, not validated" requirement must name `skills` alongside
+  `countries`/`regions` as requested, and the other eight as still unrequested.
+- [ ] 3.2 `openspec change validate restore-skills-discovery --strict` (or the
+  project's equivalent openspec validation command) passes.
+
+## 4. Final check
+
+- [ ] 4.1 Full suite: `go test ./...`.
+- [ ] 4.2 Confirm no `enrich.Version` bump and no backfill/migration code was
+  added anywhere in the diff — this ships forward-only, per the design.


### PR DESCRIPTION
## Summary

- Re-requests `skills` in the LLM enrichment prompt (`internal/enrich/langchain.go`), reversing just this one field from `enrich-prompt-trim` (#659), which had dropped it along with eight other now-dict-served facets.
- `skills` is different from the other eight: `internal/skilltag`'s dictionary covers a genuinely open-ended domain (new tools/frameworks appear continuously), so the LLM's raw output is a discovery signal for future dictionary expansion — the other eight stay dropped.
- Removes `skills` from the request schema's `unaskedFields` omit-list so structured-output strict mode actually allows the model to return it.
- Fixes a doc comment on `Enrichment.Validate()` that had drifted stale (it described `skills` as dict-only/unrequested, which stopped being true).
- Reuses the existing `Enrichment.Skills []string` field — no new field, no schema/DB change, no `enrich.Version` bump, no backfill/re-enrichment.
- Full OpenSpec proposal, design doc, and spec delta: `openspec/changes/restore-skills-discovery/`.

## Test Plan

- [x] `go test ./internal/enrich/...` — all tests pass (including two updated tests asserting `skills` is now requested/schema-permitted)
- [x] `go build ./... && go vet ./...` — clean
- [x] `go test ./...` (full repo) — 154 packages `ok`, 0 failures
- [x] `openspec change validate restore-skills-discovery --strict` — valid
- [x] Verified no `enrich.Version` bump and no backfill code anywhere in the diff