### PR TITLE
Run the SSR server across four processes, and measure the ceiling first

### DIFF
--- a/perf/k6/README.md
+++ b/perf/k6/README.md
@@ -61,13 +61,55 @@ PROFILE=load PERF_VUS=20 PERF_DURATION=2m k6 run perf/k6/pages.js
 Runs all scenarios concurrently under a ramping-VUs profile (local by default;
 `FORCE_LOAD=1` required off-local).
 
+## Capacity test (`PROFILE=saturation`)
+
+Answers "how many requests per second does this deployment accept before it stops
+keeping up" — the question behind the recurring accept-queue incidents.
+
+```bash
+PROFILE=saturation FORCE_SATURATION=1 \
+  PERF_BASE_URL=http://127.0.0.1:8084 \
+  SATURATION_STEPS=25,50,100,200,400 SATURATION_STEP_SEC=30 \
+  k6 run perf/k6/pages.js
+```
+
+**Why it is not `PROFILE=load`.** `load` is a closed model: a VU waits for its
+response before sending the next request, so a target that slows down slows the
+test with it, and the run settles at whatever the server can serve. That measures
+latency under a fixed audience — it cannot overrun anything. The failure mode in
+production is the opposite: arrivals outpace accepts until the kernel's accept
+queue fills and drops SYNs. `saturation` is an open model — `constant-arrival-rate`
+imposes the rate whether or not the target is coping.
+
+Steps rather than a ramp, each one its own scenario tagged with its rate, so the
+summary carries a clean p95 and error rate **per rate** and the ceiling comes out
+as a number. Ten idle seconds between steps let a queue drain, so no step inherits
+the previous one's backlog.
+
+**Run it against an idle blue/green colour on the prod host, never the live
+origin.** The idle colour has the same data, the same Postgres and the same Meili,
+but no users — while still sharing CPU and page cache with the live colour, which
+is why the profile has its own `FORCE_SATURATION` latch and ignores the
+`IS_LOCAL` exemptions (the intended target is a localhost port *on prod*). Watch
+the live colour's accept queue in another shell and stop if it moves:
+
+```bash
+watch -n1 'ss -ltn "sport = :8083 or sport = :8084"'
+```
+
+`dropped_iterations > 0` invalidates a step: k6 itself could not keep up, so that
+step describes the load generator, not the target. Raise the VU headroom and rerun.
+
 ## Key knobs
 
 | env                    | default                       | purpose                                        |
 | ---------------------- | ----------------------------- | ---------------------------------------------- |
 | `PERF_BASE_URL`        | `http://localhost:8090`       | target origin (fronts SSR + `/api`)            |
 | `ALLOW_NONLOCAL`       | —                             | must be `1` for any non-localhost origin       |
-| `PROFILE`              | `smoke`                       | `smoke` (isolated) or `load` (blended)         |
+| `PROFILE`              | `smoke`                       | `smoke` (isolated), `load` (blended), `saturation` (capacity) |
+| `FORCE_SATURATION`     | —                             | must be `1` to run the capacity profile        |
+| `SATURATION_STEPS`     | `25,50,100,200,400`           | request/sec steps, run back to back            |
+| `SATURATION_STEP_SEC`  | `30`                          | seconds held at each step                      |
 | `AUTH_COOKIE`          | —                             | reuse a `hire_token` instead of logging in     |
 | `QA_EMAIL/QA_PASSWORD` | local QA account              | password login for the authed scenarios        |
 | `MAX_RPS`              | `0` local / `20` off-local    | global request/sec ceiling                     |
@@ -82,3 +124,9 @@ Runs all scenarios concurrently under a ramping-VUs profile (local by default;
 - `http_req_failed` — connection/5xx rate (global gate `< 2%`).
 - `page_body_bytes{auth:…}` — payload size; authed should exceed anon.
 - `checks` — every page must return `200` + real HTML.
+
+For `PROFILE=saturation`, read `http_req_duration{step:N}` and
+`http_req_failed{step:N}` across steps: the ceiling is the last rate where the
+error rate stays near zero and p95 has not yet turned the corner. Those
+thresholds are deliberately unfailable — they exist only to make k6 print the
+per-step breakdown, so ignore their pass/fail and read the numbers.

--- a/perf/k6/config.js
+++ b/perf/k6/config.js
@@ -42,7 +42,10 @@ if (!IS_LOCAL && env('ALLOW_NONLOCAL', '') !== '1') {
 // Think-time (seconds) between page views. Models a real user reading a page
 // rather than machine-gunning the origin, and — crucially — stops a VU from
 // tight-looping into a request storm when a target starts failing fast.
-export const THINK = Number(env('THINK', 1));
+// Under an arrival-rate executor the pacing is the scenario's job, and a sleep
+// only inflates iteration duration (and so the VU count needed to sustain the
+// rate). Hence the 0 default there; the closed-model profiles keep the 1s.
+export const THINK = Number(env('THINK', env('PROFILE', 'smoke') === 'saturation' ? 0 : 1));
 
 export const PROFILE = env('PROFILE', 'smoke');
 // The blended 'load' profile can generate real pressure; block it off-local
@@ -51,9 +54,44 @@ if (!IS_LOCAL && PROFILE === 'load' && env('FORCE_LOAD', '') !== '1') {
   throw new Error(`PROFILE=load against a non-local origin needs FORCE_LOAD=1 (this stresses live infra).`);
 }
 
+// 'saturation' answers a question the other two profiles structurally cannot:
+// how many requests per second does this deployment accept before it stops
+// keeping up? `load` uses ramping-vus, where a VU waits for its response before
+// issuing the next one — so a slowing target quietly slows the test with it, and
+// the run converges on whatever the server can serve instead of overrunning it.
+// The 2026-08-14 incident was the opposite shape: arrivals outran accepts until
+// the kernel's accept queue filled and dropped SYNs. Reproducing that needs an
+// OPEN model, where the rate is imposed regardless of how the target is coping.
+//
+// Steps, not a ramp: each step is its own constant-arrival-rate scenario tagged
+// with its rate, so the summary carries a clean per-rate p95 and error rate and
+// the breaking point is a specific number rather than a slope to eyeball.
+//
+// Its own latch, and no localhost exemption. The other latches key off IS_LOCAL,
+// which is exactly wrong here — the intended target IS a localhost port on the
+// prod host (the idle blue/green colour), where the danger is real: the idle
+// colour shares CPU, page cache and Postgres with the live one.
+export const SATURATION_STEPS = env('SATURATION_STEPS', '25,50,100,200,400')
+  .split(',')
+  .map((s) => Number(s.trim()))
+  .filter((n) => Number.isFinite(n) && n > 0);
+export const SATURATION_STEP_SEC = Number(env('SATURATION_STEP_SEC', 30));
+if (PROFILE === 'saturation') {
+  if (env('FORCE_SATURATION', '') !== '1') {
+    throw new Error(
+      `PROFILE=saturation drives a target past its capacity on purpose — set FORCE_SATURATION=1. ` +
+        `Point it at an idle colour (http://127.0.0.1:8084), never at the live origin.`,
+    );
+  }
+  if (SATURATION_STEPS.length === 0) throw new Error(`SATURATION_STEPS parsed to nothing`);
+}
+
 // Global request-rate ceiling. Off-local we default to a gentle cap so a smoke
 // against prod stays polite regardless of VU count; local defaults to unlimited.
-export const MAX_RPS = Number(env('MAX_RPS', IS_LOCAL ? 0 : 20));
+// Saturation defaults to no ceiling whatever the origin: a global cap would clamp
+// the very rate the profile exists to impose, and the run would report the cap as
+// the target's capacity. Its own FORCE_SATURATION latch is the safety here.
+export const MAX_RPS = Number(env('MAX_RPS', PROFILE === 'saturation' || IS_LOCAL ? 0 : 20));
 
 // Identifies suite traffic in access logs / analytics so it's separable from
 // real users (and honest about being a bot to any WAF).
@@ -72,6 +110,11 @@ export const CREDS = {
 // it verbatim and setup() skips the login POST — the safe path for prod, where
 // the local QA account doesn't exist and you don't want a password in env.
 export const AUTH_COOKIE = env('AUTH_COOKIE', '');
+
+// A company slug for the company-card scenario, bypassing the live lookup in
+// setup(). Required when the target does not front /api (an SSR process
+// addressed directly by port), optional everywhere else.
+export const COMPANY_SLUG = env('PERF_COMPANY_SLUG', '');
 
 // The two auth modes every page is exercised in. `anon` sends no cookie;
 // `authed` attaches the `hire_token` session, which makes the layout resolve
@@ -115,6 +158,25 @@ const P95 = {
 };
 
 export function thresholds() {
+  // The saturation profile is a measurement, not a gate: every step past the
+  // capacity ceiling is SUPPOSED to fail, and a red threshold there would say
+  // nothing. What it needs instead is a per-step breakdown in the summary — and
+  // k6 only prints a sub-metric that some threshold references. So each step
+  // gets a deliberately unfailable threshold whose only job is to make k6 report
+  // that step's p95 and error rate. Read the numbers; ignore the pass/fail.
+  if (PROFILE === 'saturation') {
+    const t = {};
+    for (const rate of SATURATION_STEPS) {
+      t[`http_req_duration{step:${rate}}`] = ['p(95)>=0'];
+      t[`http_req_failed{step:${rate}}`] = ['rate<=1'];
+    }
+    // Iterations k6 could not start because no VU was free: the load generator
+    // itself fell behind, so numbers above this point describe the test, not the
+    // target. Non-zero here invalidates the step — raise preAllocatedVUs and rerun.
+    t['dropped_iterations'] = [{ threshold: 'count<1', abortOnFail: false }];
+    return t;
+  }
+
   const t = {
     http_req_failed: [{ threshold: 'rate<0.02', abortOnFail: false }],
     checks: ['rate>0.98'],
@@ -134,6 +196,37 @@ export function thresholds() {
 export function buildScenarios() {
   const pages = Object.keys(PAGES);
   const scenarios = {};
+
+  // saturation: one constant-arrival-rate step per target rate, run back to back.
+  // Anonymous only — the traffic this models is crawlers and cold visitors, and
+  // an authed run would measure a session cookie's cost rather than the ceiling.
+  if (PROFILE === 'saturation') {
+    let start = 0;
+    for (const rate of SATURATION_STEPS) {
+      // Headroom for slow iterations: at the ceiling, responses stretch, each
+      // iteration occupies its VU longer, and too few VUs makes k6 miss the rate
+      // and blame the target for the test's own shortfall. 4x the naive
+      // rate x 1s estimate, floored, has covered every observed stretch.
+      const preAllocatedVUs = Math.max(50, rate * 4);
+      scenarios[`saturation_${rate}rps`] = {
+        executor: 'constant-arrival-rate',
+        rate,
+        timeUnit: '1s',
+        duration: `${SATURATION_STEP_SEC}s`,
+        preAllocatedVUs,
+        maxVUs: preAllocatedVUs * 2,
+        startTime: `${start}s`,
+        gracefulStop: '5s',
+        exec: 'run',
+        tags: { step: String(rate), auth: 'anon' },
+      };
+      // A gap between steps so a queue built at one rate drains before the next
+      // begins — otherwise every step inherits the previous one's backlog and
+      // the ceiling reads lower than it is.
+      start += SATURATION_STEP_SEC + 10;
+    }
+    return scenarios;
+  }
 
   if (PROFILE === 'load') {
     const vus = Number(env('PERF_VUS', 15));

--- a/perf/k6/helpers.js
+++ b/perf/k6/helpers.js
@@ -1,7 +1,7 @@
 import http from 'k6/http';
 import { check, sleep } from 'k6';
 import { Trend } from 'k6/metrics';
-import { BASE_URL, USER_AGENT, AUTH_COOKIE, CREDS, THINK } from './config.js';
+import { BASE_URL, USER_AGENT, AUTH_COOKIE, CREDS, THINK, COMPANY_SLUG } from './config.js';
 
 // Body size of every rendered page, tagged by {page, auth}. This makes the
 // "authed pulls more data" claim measurable: in the summary, authed body bytes
@@ -60,6 +60,14 @@ export function resolveSession() {
 // scenario is never hardcoded/brittle. It prefers a company with open jobs so
 // the streamed job list actually does work (the interesting latency path).
 export function pickCompanySlug() {
+  // An explicit slug skips the lookup entirely. That matters when the target is
+  // an SSR process addressed directly (http://127.0.0.1:<port>, the idle colour
+  // during a capacity run) rather than an origin that fronts both SSR and /api:
+  // the lookup 404s there, and the company-card scenario would then be silently
+  // skipped — quietly dropping the heaviest page from a capacity measurement and
+  // overstating the ceiling.
+  if (COMPANY_SLUG) return COMPANY_SLUG;
+
   let res;
   for (let i = 0; i < 3; i++) {
     res = http.get(`${BASE_URL}/api/v1/companies?limit=50`, { headers: { 'User-Agent': USER_AGENT } });

--- a/perf/k6/pages.js
+++ b/perf/k6/pages.js
@@ -33,6 +33,19 @@ export function setup() {
 // and dispatch — no per-scenario boilerplate.
 export function run(data) {
   const name = exec.scenario.name;
+
+  // saturation scenarios are named by rate, not by page: the profile measures how
+  // many requests per second the deployment accepts, and pinning that to one page
+  // would measure that page's render cost instead. Each iteration picks a page in
+  // round-robin so the mix stays even and reproducible — a random pick would make
+  // two runs incomparable, which defeats a before/after capacity test.
+  if (name.startsWith('saturation_')) {
+    const keys = Object.keys(PAGES);
+    const page = keys[exec.scenario.iterationInTest % keys.length];
+    visit(page, PAGES[page].path, 'anon', data);
+    return;
+  }
+
   const sep = name.lastIndexOf('_');
   const page = name.slice(0, sep);
   const auth = name.slice(sep + 1);

--- a/web/cluster.js
+++ b/web/cluster.js
@@ -1,0 +1,38 @@
+// Production entry point: runs the adapter-node server across several processes.
+//
+// `build/index.js` is a single Node process, and Node is single-threaded, so the
+// SSR tier used one of host-2's sixteen cores however busy the box got. Measured
+// on the idle blue/green colour with `perf/k6` at PROFILE=saturation: one process
+// holds ~130 req/s, and past that p95 goes from half a second to twenty-five;
+// four processes hold ~250. The 2026-08-14 peak was 204 req/s, which is why the
+// accept queue kept filling and the watchdog kept restarting the process.
+//
+// cluster forks workers that share one listening socket — the primary accepts and
+// hands connections out — so the port, the systemd unit and the blue/green layout
+// are unchanged. Each worker is a full copy of the server (~370 MB resident), and
+// that memory comes out of the page cache Meilisearch depends on, which is why the
+// default is four rather than one-per-core: eight measured WORSE at 200 req/s
+// (0.87 s vs 0.50 s p95) because the extra workers compete with ingest, Meili and
+// Postgres for the same sixteen cores.
+import cluster from 'node:cluster';
+
+const workers = Number(process.env.WEB_CLUSTER_WORKERS || 4);
+
+if (workers <= 1) {
+  // One worker would add a supervisor process for nothing. Load the server here
+  // so WEB_CLUSTER_WORKERS=1 is a genuine escape hatch back to the old shape.
+  await import('./build/index.js');
+} else if (cluster.isPrimary) {
+  console.log(`cluster primary ${process.pid}: forking ${workers} workers`);
+  for (let i = 0; i < workers; i++) cluster.fork();
+
+  // A worker that dies takes its in-flight requests with it. Replacing it keeps
+  // capacity flat instead of silently decaying towards a single process — which
+  // would look exactly like the problem this file exists to fix.
+  cluster.on('exit', (worker, code, signal) => {
+    console.log(`worker ${worker.process.pid} exited (${signal || code}) — forking a replacement`);
+    cluster.fork();
+  });
+} else {
+  await import('./build/index.js');
+}

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -35,8 +35,10 @@ export default ts.config(
   },
 
   // Standalone scripts (codegen, smoke tests) run in Node, not the browser.
+  // cluster.js is the production entry point systemd starts — same Node globals,
+  // but it belongs beside build/ rather than under scripts/.
   {
-    files: ['scripts/**/*.{js,mjs}'],
+    files: ['scripts/**/*.{js,mjs}', 'cluster.js'],
     languageOptions: { globals: { ...globals.node } },
   },
 


### PR DESCRIPTION
## What

The web tier is the only component that has fallen over — four times — and the reason is structural, not a slow page. `freehire-web@.service` runs `node build/index.js`: **one process**, and Node is single-threaded. The SSR tier used **one of host-2's sixteen cores** however busy the box got, while the Go API beside it has never wedged.

## Measured before changing anything

New k6 profile, run against the **idle blue/green colour on prod** — same data, same Postgres, same Meili, no users. p95 by imposed request rate:

| req/s | 1 process | 4 workers |
|---|---|---|
| 100 | 0.57 s | 0.17 s |
| 150 | **25 s** | 0.16 s |
| 200 | **4.7 s** | 0.50 s |
| 300 | 7.8 s | 4.0 s |

One process holds **~130 req/s**. The 21:00 UTC peak on 2026-08-14 was **204** — production was running past its ceiling, and the accept queue filling was the symptom.

Four full runs never moved the live colour's accept queue off zero and produced no 504s.

## The part worth reviewing: `PROFILE=saturation`

The existing `load` profile uses `ramping-vus` — a **closed** model, where a VU waits for its response before sending the next. A slowing target slows the test with it, so the run converges on whatever the server can serve. It structurally cannot overrun anything — which is exactly the failure being reproduced: arrivals outpacing accepts until the kernel drops SYNs.

`constant-arrival-rate` imposes the rate regardless of how the target copes. Steps rather than a ramp, each tagged with its rate, so every rate yields a clean p95 and the ceiling is a number; ten idle seconds between steps so none inherits the previous one's backlog.

Its thresholds are deliberately unfailable — k6 only prints a sub-metric some threshold references, so they exist to produce the per-step breakdown. `dropped_iterations` is the real gate: non-zero means k6 itself fell behind and that step describes the load generator, not the target.

## Why four workers, not sixteen

Eight measured **worse** at 200 req/s (0.87 s vs 0.50 s): they compete with ingest, Meilisearch and Postgres for the same sixteen cores, and each worker's ~370 MB comes out of the page cache Meili depends on. `WEB_CLUSTER_WORKERS=1` loads the server directly — an escape hatch to the old shape.

The gain is ~2x rather than 4x because past ~250 req/s the limit is no longer Node: Meili holds 93% of disk reads with a 45 GB index on a 30 GB box.

## Deploy order

`web/cluster.js` must be in the **built colour before** the unit's `ExecStart` changes, or that colour fails to start. The ops-side unit edit is a separate change, applied after this merges.

## Test plan

- [x] `go build ./...`, `node --check web/cluster.js`, eslint on the changed files
- [x] `k6 inspect` — scenarios and thresholds build as intended
- [x] Four saturation runs on prod's idle colour (1, 4 and 8 workers); live colour unaffected throughout