### PR TITLE
Build timeAgo's Intl formatter once instead of per call

### DIFF
--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -53,6 +53,16 @@ const TIME_UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
   ['second', 1],
 ];
 
+// Built once, not per call. Constructing an Intl formatter resolves a locale and
+// loads its data, which dwarfs the cost of formatting with one — 12x on a
+// microbenchmark of the homepage's 32 cards (0.30ms -> 0.03ms per render). That
+// is ~1% of a 29ms render, so this is tidiness rather than a fix for anything:
+// the profile that surfaced it (timeAgo was second among our own functions) also
+// showed the render cost is spread across the page, not concentrated anywhere.
+// The locale is `undefined` — the runtime default — and it does not change within
+// a process or a browser session, so one instance is safe to reuse.
+let relativeTime: Intl.RelativeTimeFormat | undefined;
+
 /** Format an RFC3339 timestamp as a relative "N ago" label (e.g. "13 seconds
  *  ago", "2 days ago"); '' for null/invalid. How recently a job was posted is a
  *  key signal, so the list card shows it relative rather than as a bare date. */
@@ -61,7 +71,7 @@ export function timeAgo(ts: string | null | undefined): string {
   const d = new Date(ts);
   if (Number.isNaN(d.getTime())) return '';
   const seconds = Math.round((Date.now() - d.getTime()) / 1000);
-  const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+  const rtf = (relativeTime ??= new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' }));
   for (const [unit, span] of TIME_UNITS) {
     if (Math.abs(seconds) >= span || unit === 'second') {
       return rtf.format(-Math.round(seconds / span), unit);


### PR DESCRIPTION
Profiling the SSR render on prod (see #1932 for why we were looking) put `timeAgo` second among our own functions. It constructs `Intl.RelativeTimeFormat` **inside** the function, and the feed calls it once per job card — 32 on the homepage. Constructing an Intl formatter resolves a locale and loads its data; formatting with an existing one is nearly free.

**Measured:** 12x faster on a microbenchmark of that exact workload — 0.30 ms → 0.03 ms per page render. Output verified identical.

**Honest framing:** that is ~1% of a 29 ms render, so this does not move the capacity ceiling. The same profile showed the cost is spread across components rather than concentrated in any one place:

| | share of render |
|---|---|
| our render code | 33% |
| Node runtime (HTTP, parsing) | 23% |
| Sentry | 10% |
| V8 | 10% |
| GC | 6% |

The real lever is page size — 191 KB of HTML, ~6 KB per card — and caching anonymous renders, both separate pieces of work. A Sentry change was measured too (`registerEsmLoaderHooks: false`, `skipOpenTelemetrySetup: true`, dropping `sentryHandle`) and **deliberately not included**: each variant moved the render by 1-2 ms, within run-to-run noise, which is not worth trading observability for.

## Test plan

- [x] eslint on the changed file
- [x] `svelte-check` — no new errors (the 37 on main are pre-existing)
- [x] microbenchmark, old vs new, identical output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved relative-time display efficiency while preserving existing formatting and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->