### PR TITLE
Connect the extension's deterministic autofill to screening answers

### DIFF
--- a/extension/entrypoints/sidepanel/App.svelte
+++ b/extension/entrypoints/sidepanel/App.svelte
@@ -22,7 +22,12 @@
     type JobMatch,
     type AutofillProfile,
   } from '../../lib/freehire';
-  import { planLabelFills, looksLikeApplication, scopeToApplication } from '../../lib/form';
+  import {
+    planLabelFills,
+    looksLikeApplication,
+    scopeToApplication,
+    formatAuthorizedCountries,
+  } from '../../lib/form';
   import { ToolChannel } from '../../lib/tools/client';
   import { activeTabPage } from '../../lib/tools/page';
   import MatchCard from './MatchCard.svelte';
@@ -369,6 +374,12 @@
       linkedin: p.linkedin,
       github: p.github,
       portfolio: p.portfolio,
+      authorizedCountries: formatAuthorizedCountries(p.authorized_countries),
+      visaSponsorshipNeeded: p.visa_sponsorship_needed,
+      desiredSalary: p.desired_salary,
+      noticePeriod: p.notice_period,
+      willingToRelocate: p.willing_to_relocate,
+      age18OrOlder: p.age_18_or_older,
     };
   }
 

--- a/extension/lib/form.test.ts
+++ b/extension/lib/form.test.ts
@@ -8,6 +8,7 @@ import {
   fillByLabel,
   looksLikeApplication,
   scopeToApplication,
+  formatAuthorizedCountries,
 } from './form';
 import { must } from './test-utils';
 
@@ -712,6 +713,42 @@ describe('fillByLabel on a group', () => {
     expect(inputs.some((i) => i.checked)).toBe(false);
     expect(outcomes).toEqual([{ label: 'Which countries?', status: 'no_option' }]);
   });
+
+  it('fills a country checkbox group from the profile ISO-code value once formatted', () => {
+    // screeninganswers.AutofillFields serves "US, DE" — the group's own options are
+    // full country names, so the raw codes must go through formatAuthorizedCountries
+    // first or nothing would ever match.
+    const countries = checkboxGroup('Which countries are you authorized to work in?', [
+      'United States',
+      'Germany',
+      'Canada',
+    ]);
+    const us = must(countries[0]);
+    const de = must(countries[1]);
+    const ca = must(countries[2]);
+
+    const outcomes = fillByLabel(document, [
+      {
+        label: 'Which countries are you authorized to work in?',
+        value: formatAuthorizedCountries('US, DE'),
+      },
+    ]);
+
+    expect([us.checked, de.checked, ca.checked]).toEqual([true, true, false]);
+    expect(outcomes).toEqual([
+      { label: 'Which countries are you authorized to work in?', status: 'filled' },
+    ]);
+  });
+});
+
+describe('formatAuthorizedCountries', () => {
+  it('turns ISO codes into the country names a checkbox group carries as options', () => {
+    expect(formatAuthorizedCountries('US, DE')).toBe('United States, Germany');
+  });
+
+  it('is empty for an empty value, rather than an empty-string entry', () => {
+    expect(formatAuthorizedCountries('')).toBe('');
+  });
 });
 
 describe('matchFieldKey', () => {
@@ -745,5 +782,23 @@ describe('matchFieldKey', () => {
 
   it('does not match a longer word that merely starts the same way', () => {
     expect(matchFieldKey('Citywide preference')).toBeNull();
+  });
+
+  it('maps screening-answer questions to their canonical keys', () => {
+    expect(matchFieldKey('Which countries are you authorized to work in?')).toBe('authorizedCountries');
+    expect(
+      matchFieldKey('Will you now or in the future require sponsorship to work in this country?'),
+    ).toBe('visaSponsorshipNeeded');
+    expect(matchFieldKey('Desired salary')).toBe('desiredSalary');
+    expect(matchFieldKey('What is your notice period?')).toBe('noticePeriod');
+    expect(matchFieldKey('Are you willing to relocate?')).toBe('willingToRelocate');
+    expect(matchFieldKey('Are you at least 18 years of age?')).toBe('age18OrOlder');
+  });
+
+  it('leaves a plain work-authorization Yes/No question unmatched', () => {
+    // That question has no boolean field in the profile — only a list of
+    // authorized countries — so answering it would put the wrong shape of
+    // value into a Yes/No control. See the Roku case above.
+    expect(matchFieldKey('Are you authorized to work in this country?')).toBeNull();
   });
 });

--- a/extension/lib/form.ts
+++ b/extension/lib/form.ts
@@ -10,6 +10,7 @@
  */
 
 import type { FieldTag, FormField, LabelFill, FillOutcome, Upload } from './protocol';
+import { countryLabel } from './labels';
 
 type Fillable = HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
 
@@ -342,7 +343,72 @@ const FIELD_SYNONYMS: Record<string, string[]> = {
   linkedin: ['linkedin'],
   github: ['github'],
   portfolio: ['portfolio', 'website', 'personal site'],
+  // The candidate's own screening answers (internal/screeninganswers), not a
+  // boolean "are you authorized to work" question — that asks something the
+  // profile does not carry an answer to, so it stays unmatched rather than
+  // being fed a country list where a Yes/No answer belongs.
+  authorizedCountries: [
+    'which countries are you authorized to work in',
+    'in which countries are you authorized to work',
+    'in which countries are you legally authorized to work',
+    'countries you are authorized to work in',
+    'list the countries you are authorized to work in',
+  ],
+  visaSponsorshipNeeded: [
+    'will you now or in the future require sponsorship',
+    'do you now or will you in the future require sponsorship',
+    'will you require sponsorship',
+    'do you require visa sponsorship',
+    'do you need visa sponsorship',
+    'will you need visa sponsorship',
+  ],
+  desiredSalary: [
+    'desired salary',
+    'desired compensation',
+    'expected salary',
+    'salary expectation',
+    'salary expectations',
+    'what are your salary expectations',
+    'compensation expectations',
+  ],
+  noticePeriod: [
+    'notice period',
+    'current notice period',
+    'what is your notice period',
+    'how much notice',
+  ],
+  willingToRelocate: [
+    'are you willing to relocate',
+    'would you be willing to relocate',
+    'willing to relocate',
+    'are you open to relocating',
+    'open to relocation',
+  ],
+  age18OrOlder: [
+    'are you at least 18 years',
+    'are you 18 years of age or older',
+    'are you over the age of 18',
+    'are you 18 or older',
+    'will you be 18 years of age',
+  ],
 };
+
+/**
+ * The profile's authorized-countries field arrives as comma-joined ISO codes ("US, DE" —
+ * screeninganswers.AutofillFields' wire format), but the question it answers is almost
+ * always a checkbox group whose options are full country names ("United States"), matched
+ * option-by-option against this value by `chosenOptions` below. Left as codes, the value
+ * would never match any option and the group would silently stay unchecked.
+ */
+export function formatAuthorizedCountries(codes: string): string {
+  if (!codes) return '';
+  return codes
+    .split(',')
+    .map((c) => c.trim())
+    .filter(Boolean)
+    .map(countryLabel)
+    .join(', ');
+}
 
 /**
  * Comparison form of a label: case-, whitespace- and required-marker-insensitive,

--- a/extension/lib/freehire.ts
+++ b/extension/lib/freehire.ts
@@ -177,7 +177,9 @@ export function getMatchAnalysis(slug: string, token: string): Promise<MatchAnal
   return getData<MatchAnalysisResponse>(`/api/v1/jobs/${encodeURIComponent(slug)}/match-analysis`, token);
 }
 
-/** Canonical autofill fields freehire assembles from the user's CV + account. */
+/** Canonical autofill fields freehire assembles from the user's CV + account,
+ *  plus the candidate's own screening answers (internal/screeninganswers) —
+ *  empty when the caller has stated nothing, never guessed. */
 export interface AutofillProfile {
   full_name: string;
   first_name: string;
@@ -188,6 +190,12 @@ export interface AutofillProfile {
   linkedin: string;
   github: string;
   portfolio: string;
+  authorized_countries: string;
+  visa_sponsorship_needed: string;
+  desired_salary: string;
+  notice_period: string;
+  willing_to_relocate: string;
+  age_18_or_older: string;
 }
 
 export function getAutofillProfile(token: string): Promise<AutofillProfile> {

--- a/openspec/changes/archive/2026-08-14-connect-screening-answers-autofill/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-14-connect-screening-answers-autofill/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/archive/2026-08-14-connect-screening-answers-autofill/design.md
+++ b/openspec/changes/archive/2026-08-14-connect-screening-answers-autofill/design.md
@@ -1,0 +1,58 @@
+## Context
+
+The extension already has two autofill paths sharing one server-assembled profile block
+(`GET /api/v1/me/autofill-profile`, `internal/handler/autofill_profile.go`): an agent-driven
+path (`POST /api/v1/me/autofill/run`) that already grounds its plan in screening answers, and
+a deterministic fallback filler (`extension/lib/form.ts`) that label-matches question text
+against a fixed synonym table (`FIELD_SYNONYMS`) and writes values from a flat `Record<string,
+string>` (`extension/entrypoints/sidepanel/App.svelte`'s `profileToValues`). The server side of
+this wiring predates this change; only the extension's TS type, value mapping and synonym
+table were missing the six screening fields. See proposal.md - Why.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Extend the existing three extension-side seams (type, value mapping, synonym table) to
+  carry the six screening fields through the same mechanism identity fields already use.
+- Preserve the existing rule that an unstated field is left blank, never guessed.
+
+**Non-Goals:**
+- No backend change — `internal/screeninganswers` and both autofill endpoints already serve/
+  consume these fields.
+- No change to the agent-driven autofill path, which already has this data.
+- No attempt to make the label-matcher fuzzy or ML-based; it stays the same
+  front-anchored-prefix synonym match the identity fields use, just with more entries.
+
+## Decisions
+
+- **Reuse `FIELD_SYNONYMS`/`matchFieldKey` rather than a parallel table.** The six new
+  fields are conceptually the same kind of thing the existing nine are: one canonical key,
+  a handful of real-world label phrasings, one flat value. A second mechanism for "screening"
+  fields would duplicate `planLabelFills`/`fillByLabel` for no behavioral gain.
+- **Do not map a generic "are you authorized to work" Yes/No question to
+  `authorizedCountries`.** The stored answer is a joined country-code list
+  (`screeninganswers.AutofillFields` — "US, DE"), not a boolean. `fillField`'s checkbox/radio
+  path only recognizes `"yes"`/`"true"`/`"1"` for a single control, and a grouped Yes/No radio
+  pair matches by comparing the value against each option's own label — neither path can turn
+  a country list into a Yes/No answer. Synonyms are restricted to phrasings that literally ask
+  *which* countries ("which countries are you authorized to work in"), matching the existing
+  `extension-autofill` spec's Roku-derived test case, which asserts the boolean phrasing stays
+  unmatched.
+- **Values arrive pre-formatted from the server, except authorized countries.**
+  `screeninganswers.AutofillFields()` already renders booleans as `"yes"`/`"no"` and composes
+  the salary string, so the extension routes those straight through. Authorized countries is
+  the one exception: the server serves comma-joined ISO codes ("US, DE"), but the checkbox
+  groups that question is almost always rendered as offer full country names ("United
+  States") as their options, and `chosenOptions` (`extension/lib/form.ts`) matches the value
+  against each option's own label text. Left as codes, the value would never match any
+  option and the group would silently stay unchecked — caught in review, not in the original
+  pass. `formatAuthorizedCountries` converts each code via the same `countryLabel`
+  (`extension/lib/labels.ts`, `Intl.DisplayNames`) the extension already uses for job-facet
+  country codes, so the two matching sides agree on country naming.
+
+## Risks / Trade-offs
+
+- [Front-anchored prefix matching misses some real ATS phrasings the identity fields don't
+  already cover as densely] → Accepted: this is the existing mechanism's known shape (see
+  `matchFieldKey`'s doc comment), and it degrades to "left blank" rather than a wrong answer.
+  Widening coverage further is a follow-up, not a blocker for connecting what already exists.

--- a/openspec/changes/archive/2026-08-14-connect-screening-answers-autofill/proposal.md
+++ b/openspec/changes/archive/2026-08-14-connect-screening-answers-autofill/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+The profile now has a screening-answers questionnaire (`internal/screeninganswers`: authorized
+countries, visa sponsorship, desired salary, notice period, willingness to relocate, 18+), and
+the server already folds those answers into the autofill profile the browser extension reads.
+The agent-driven autofill path already grounds its plan in them. The extension's deterministic
+fallback filler — the one that runs when the agent path is unavailable (no LLM configured, no
+browser-tool channel attached, or the agent finds no fillable fields) — did not: its profile
+type and its label-matching table both stopped at the nine identity fields, so a candidate who
+relies on the fallback got a form with visa/salary/notice/relocation/age questions left blank
+even though they had already answered them once in their profile.
+
+## What Changes
+
+- Extend the extension's `AutofillProfile` type with the six screening-answer fields the
+  server already serves from `GET /api/v1/me/autofill-profile`.
+- Map those six fields into the values the deterministic filler plans fills from.
+- Add label-matching synonyms for the real-world ATS phrasings of each screening question
+  ("which countries are you authorized to work in", "will you now or in the future require
+  sponsorship", "desired salary", "notice period", "are you willing to relocate", "are you at
+  least 18 years of age").
+- Deliberately exclude a generic "are you authorized to work" Yes/No phrasing from the
+  authorized-countries match: that question is boolean, the stored answer is a country list,
+  and the profile carries no boolean field to answer it with — filling it would put the wrong
+  shape of value into a Yes/No control.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `extension-autofill`: the deterministic fallback filler now also recognizes and fills
+  screening-answer questions (authorized countries, visa sponsorship, desired salary, notice
+  period, willingness to relocate, 18+), in addition to the identity contact block it already
+  filled. The canonical profile block it reads from gains the corresponding six fields.
+
+## Impact
+
+- `extension/lib/freehire.ts` — `AutofillProfile` interface.
+- `extension/entrypoints/sidepanel/App.svelte` — `profileToValues()`.
+- `extension/lib/form.ts` — `FIELD_SYNONYMS`.
+- `extension/lib/form.test.ts` — coverage for the new mappings and the deliberate exclusion.
+- No backend change: `internal/screeninganswers` and the `/me/autofill-profile` /
+  `/me/autofill/run` endpoints already served/consumed these fields before this change.

--- a/openspec/changes/archive/2026-08-14-connect-screening-answers-autofill/specs/extension-autofill/spec.md
+++ b/openspec/changes/archive/2026-08-14-connect-screening-answers-autofill/specs/extension-autofill/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: The autofill profile also carries the candidate's screening answers
+
+The autofill profile block SHALL, in addition to the identity contact fields, carry the
+candidate's own screening answers (`internal/screeninganswers`): `authorized_countries`,
+`visa_sponsorship_needed`, `desired_salary`, `notice_period`, `willing_to_relocate` and
+`age_18_or_older`. A field the candidate has not stated SHALL be empty rather than guessed,
+on the same terms as an unstated identity field.
+
+These fields are independent of the identity contact block: there is exactly one
+screening-answers store, so there is no multi-source precedence to resolve for them the way
+there is for name/email/phone.
+
+#### Scenario: Screening answers ride alongside the identity fields
+
+- **WHEN** an authenticated caller reads the autofill profile and has stated their desired
+  salary and their willingness to relocate, but no other screening answer
+- **THEN** the response carries those two values and empty strings for the other four
+  screening fields, alongside whatever identity fields the CV/résumé/account state
+
+### Requirement: The deterministic fallback filler answers screening questions
+
+When the browser extension's deterministic fallback filler is in use — the path taken when
+the agent-driven autofill is unavailable — it SHALL recognize application-form questions
+asking about work-authorized countries, visa sponsorship, desired salary, notice period,
+willingness to relocate, and age (18+), and fill them from the caller's screening answers
+using the same label-matching mechanism it already uses for identity fields. A question the
+caller has not answered in their profile SHALL be left blank rather than filled with a
+guess, matching the existing rule for identity fields.
+
+#### Scenario: A notice-period question is filled from the profile
+
+- **WHEN** the deterministic filler is planning fills for a form asking "What is your notice
+  period?" and the caller's screening answers state a 30-day notice period
+- **THEN** the plan fills that question with "30 days"
+
+#### Scenario: An unanswered screening question is left blank
+
+- **WHEN** the deterministic filler is planning fills for a form asking about desired salary
+  and the caller has not stated one
+- **THEN** the plan leaves that question unfilled
+
+#### Scenario: An authorized-countries checkbox group is filled by country name, not by code
+
+- **WHEN** a form asks "Which countries are you authorized to work in?" as a checkbox group
+  offering full country names, and the caller's screening answers state authorization in the
+  US and Germany
+- **THEN** the plan checks the "United States" and "Germany" options, not a literal "US, DE"
+  that would match neither
+
+### Requirement: A boolean work-authorization question is not answered from the country list
+
+A plain Yes/No "are you authorized to work [here]?" question SHALL NOT be matched to the
+authorized-countries screening answer. That answer is a list of country codes, not a
+boolean, and the profile carries no boolean field stating plain work authorization — filling
+the question would put the wrong shape of value into a Yes/No control.
+
+This does not apply to a question that itself asks *which* countries the candidate is
+authorized to work in (a list question), which the previous requirement covers.
+
+#### Scenario: A boolean work-authorization question stays unmatched
+
+- **WHEN** an application form asks "Are you authorized to work in this country?" as a
+  Yes/No question
+- **THEN** the deterministic filler does not match it to any screening answer and leaves it
+  for the caller

--- a/openspec/changes/archive/2026-08-14-connect-screening-answers-autofill/tasks.md
+++ b/openspec/changes/archive/2026-08-14-connect-screening-answers-autofill/tasks.md
@@ -1,0 +1,28 @@
+## 1. Profile type and value mapping
+
+- [x] 1.1 Add the six screening-answer fields to `AutofillProfile` in `extension/lib/freehire.ts`
+- [x] 1.2 Map those six fields into `profileToValues()` in `extension/entrypoints/sidepanel/App.svelte`
+
+## 2. Label matching
+
+- [x] 2.1 Add `authorizedCountries`, `visaSponsorshipNeeded`, `desiredSalary`, `noticePeriod`,
+      `willingToRelocate`, `age18OrOlder` entries to `FIELD_SYNONYMS` in `extension/lib/form.ts`
+      with real-world ATS phrasings for each
+- [x] 2.2 Confirm the boolean "are you authorized to work" phrasing is not matched to
+      `authorizedCountries` (semantic mismatch: boolean question, list-shaped answer)
+- [x] 2.3 Fix (found by review): `authorized_countries` arrives as comma-joined ISO codes
+      ("US, DE"), but the checkbox-group questions it answers offer full country names
+      ("United States") as options, and `chosenOptions` matches option-by-option — so raw
+      codes never matched and the group silently stayed unchecked. Added
+      `formatAuthorizedCountries` (`extension/lib/form.ts`, using `countryLabel` from
+      `extension/lib/labels.ts`) and wired it into `profileToValues()`.
+
+## 3. Tests and verification
+
+- [x] 3.1 Add `matchFieldKey` test coverage for the six new mappings in `extension/lib/form.test.ts`
+- [x] 3.2 Add a regression test asserting the plain work-authorization Yes/No question stays unmatched
+- [x] 3.3 Add unit tests for `formatAuthorizedCountries` and an end-to-end `fillByLabel` test
+      against a country checkbox group, covering the 2.3 fix
+- [x] 3.4 Run `npx vitest run` (230/230 passing)
+- [x] 3.5 Run `npm run check` (svelte-check, 0 errors)
+- [x] 3.6 Run `npx eslint` on touched files (clean)

--- a/openspec/specs/extension-autofill/spec.md
+++ b/openspec/specs/extension-autofill/spec.md
@@ -5,10 +5,12 @@
 The contact block the browser extension writes into application forms: which fields it
 carries, which sources answer for them and in what order, and what an absent source yields.
 
-It covers the candidate's identity only — name, address, phone, place and links. The
-substance of an application (summary, work history, skills) is not here, and neither is the
-CV file itself: the extension has no upload primitive, so the document is downloaded by
-hand from the CV surface.
+It covers the candidate's identity — name, address, phone, place and links — plus their own
+screening answers (authorized countries, visa sponsorship, desired salary, notice period,
+willingness to relocate, 18+), which ride alongside the identity fields without a
+multi-source precedence of their own. The substance of an application (summary, work
+history, skills) is not here, and neither is the CV file itself: the extension has no upload
+primitive, so the document is downloaded by hand from the CV surface.
 
 Not to be confused with `cv-autofill`, which pre-fills the onboarding wizard and the profile
 form from an uploaded résumé.
@@ -136,4 +138,75 @@ migration breaks autofill when a user opens a form rather than when the project 
 - **WHEN** a column the autofill block reads is renamed in a migration and the queries are
   regenerated
 - **THEN** the project fails to build, rather than compiling and failing at request time
+
+### Requirement: The autofill profile also carries the candidate's screening answers
+
+The autofill profile block SHALL, in addition to the identity contact fields, carry the
+candidate's own screening answers (`internal/screeninganswers`): `authorized_countries`,
+`visa_sponsorship_needed`, `desired_salary`, `notice_period`, `willing_to_relocate` and
+`age_18_or_older`. A field the candidate has not stated SHALL be empty rather than guessed,
+on the same terms as an unstated identity field.
+
+These fields are independent of the identity contact block: there is exactly one
+screening-answers store, so there is no multi-source precedence to resolve for them the way
+there is for name/email/phone.
+
+#### Scenario: Screening answers ride alongside the identity fields
+
+- **WHEN** an authenticated caller reads the autofill profile and has stated their desired
+  salary and their willingness to relocate, but no other screening answer
+- **THEN** the response carries those two values and empty strings for the other four
+  screening fields, alongside whatever identity fields the CV/résumé/account state
+
+### Requirement: The deterministic fallback filler answers screening questions
+
+When the browser extension's deterministic fallback filler is in use — the path taken when
+the agent-driven autofill is unavailable — it SHALL recognize application-form questions
+asking about work-authorized countries, visa sponsorship, desired salary, notice period,
+willingness to relocate, and age (18+), and fill them from the caller's screening answers
+using the same label-matching mechanism it already uses for identity fields. A question the
+caller has not answered in their profile SHALL be left blank rather than filled with a
+guess, matching the existing rule for identity fields.
+
+A checkbox-group question naming several countries SHALL be answered by the country names
+its options carry, not by the raw ISO codes the profile states — the group's options are
+matched against the value option-by-option, so a code that names no option would leave the
+group unanswered even when the candidate has stated an answer.
+
+#### Scenario: A notice-period question is filled from the profile
+
+- **WHEN** the deterministic filler is planning fills for a form asking "What is your notice
+  period?" and the caller's screening answers state a 30-day notice period
+- **THEN** the plan fills that question with "30 days"
+
+#### Scenario: An unanswered screening question is left blank
+
+- **WHEN** the deterministic filler is planning fills for a form asking about desired salary
+  and the caller has not stated one
+- **THEN** the plan leaves that question unfilled
+
+#### Scenario: An authorized-countries checkbox group is filled by country name, not by code
+
+- **WHEN** a form asks "Which countries are you authorized to work in?" as a checkbox group
+  offering full country names, and the caller's screening answers state authorization in the
+  US and Germany
+- **THEN** the plan checks the "United States" and "Germany" options, not a literal "US, DE"
+  that would match neither
+
+### Requirement: A boolean work-authorization question is not answered from the country list
+
+A plain Yes/No "are you authorized to work [here]?" question SHALL NOT be matched to the
+authorized-countries screening answer. That answer is a list of country codes, not a
+boolean, and the profile carries no boolean field stating plain work authorization — filling
+the question would put the wrong shape of value into a Yes/No control.
+
+This does not apply to a question that itself asks *which* countries the candidate is
+authorized to work in (a list question), which the previous requirement covers.
+
+#### Scenario: A boolean work-authorization question stays unmatched
+
+- **WHEN** an application form asks "Are you authorized to work in this country?" as a
+  Yes/No question
+- **THEN** the deterministic filler does not match it to any screening answer and leaves it
+  for the caller
 


### PR DESCRIPTION
## Summary
- The extension's deterministic fallback autofill filler (used when the agent-driven path is unavailable) now recognizes and fills the profile's screening-answers questions: authorized countries, visa sponsorship, desired salary, notice period, willingness to relocate, and 18+.
- Authorized countries is converted from the server's ISO-code format ("US, DE") to full country names, since the checkbox-group questions it answers match options by country name, not code — caught and fixed during code review.
- A generic Yes/No "are you authorized to work" question is deliberately left unmatched, since the profile stores a country list for that answer, not a boolean.
- No backend change: `internal/screeninganswers` and both autofill endpoints already served/consumed these fields.
- Planned and tracked via an OpenSpec change (`connect-screening-answers-autofill`), now archived; `extension-autofill` spec updated with the new requirements.

## Test plan
- [x] `npx vitest run` — 230/230 passing
- [x] `npm run check` (svelte-check) — 0 errors
- [x] `npx eslint` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)