### PR TITLE
Claim the mobile OAuth return path for the app

### DIFF
--- a/docs/auth-mobile-v2-runbook.md
+++ b/docs/auth-mobile-v2-runbook.md
@@ -27,7 +27,7 @@ state, PKCE verifier, or session cookie in Git, CI output, logs, or PR text.
 | Variable | Meaning |
 |---|---|
 | `AUTH_V2_ENABLED` | Registers `/api/v2/auth/*`; default `false`. |
-| `MOBILE_AUTH_CALLBACKS` | Comma-separated `platform=https://verified/path` allowlist. Include `web=https://<host>/my/reauth`; add `ios=` and/or `android=` only when each verified-link target is live. |
+| `MOBILE_AUTH_CALLBACKS` | Comma-separated `platform=https://verified/path` allowlist. Include `web=https://<host>/my/reauth`; add `ios=https://<host>/auth/mobile-callback` and `android=` likewise once the verified-link target is live. Browser providers stay hidden from `/api/v2/auth/providers` until one of them is set, so the mobile app shows only Apple. |
 | `RECENT_AUTH_TTL` | Recent-auth proof lifetime; default `10m`, allowed `1m` to `1h`. |
 | `APPLE_NATIVE_CLIENT_ID` | Native iOS bundle/client ID, separate from the web Services ID. |
 | `OAUTH_APPLE_TEAM_ID` | Existing Apple developer Team ID. |
@@ -46,6 +46,21 @@ reauthentication, add `/api/v2/auth/oauth/apple/callback` to the Services ID's
 return URLs alongside the existing v1 callback. These provider-console redirect
 URIs are separate from `MOBILE_AUTH_CALLBACKS`, which contains only FreeHire's
 final completion targets.
+
+## Mobile verified links
+
+The app's completion target is `/auth/mobile-callback`, served by `web/` and
+claimed by the app through `/.well-known/apple-app-site-association` (iOS) and
+`/.well-known/assetlinks.json` (Android). Both files must list the path before
+`ios=`/`android=` goes into `MOBILE_AUTH_CALLBACKS`, or the browser will land on
+the web page instead of handing the code to the app.
+
+The client sends `callback_target=ios|android` — the platform name, never a URL.
+The server appends `?code=` to the URL it holds for that key, so the mobile app
+cannot influence where the code is delivered.
+
+Apple caches the association file, so a device may keep an old copy for hours.
+Reinstalling the app forces a refresh during testing.
 
 ## Key rotation
 

--- a/web/src/routes/auth/mobile-callback/+page.svelte
+++ b/web/src/routes/auth/mobile-callback/+page.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { page } from '$app/state';
+
+  // Where the mobile v2 OAuth handshake lands. On a phone with the app
+  // installed the universal link never reaches this page — iOS and Android hand
+  // the URL straight to freehire-mobile, which exchanges the code with the PKCE
+  // verifier it alone holds. Reaching the page therefore means the app could not
+  // take the link: a desktop browser, or a device without the app.
+  //
+  // The code is deliberately not exchanged here. It is bound to a verifier that
+  // lives only in the app, so a web exchange could not succeed — and echoing it
+  // into the page would put a single-use credential into history and referrers.
+  const failed = page.url.searchParams.has('auth_error');
+</script>
+
+<svelte:head>
+  <title>Return to the app · freehire</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<div class="mx-auto max-w-md py-16 text-center">
+  {#if failed}
+    <h1 class="text-lg font-semibold">Sign-in did not complete</h1>
+    <p class="mt-2 text-sm text-muted-foreground">
+      Open the freehire app and try signing in again.
+    </p>
+  {:else}
+    <h1 class="text-lg font-semibold">Finishing sign-in…</h1>
+    <p class="mt-2 text-sm text-muted-foreground">
+      If this page stays open, the freehire app is not installed on this device.
+      Sign-in has to finish in the app — open it and try again.
+    </p>
+  {/if}
+</div>

--- a/web/static/.well-known/apple-app-site-association
+++ b/web/static/.well-known/apple-app-site-association
@@ -5,7 +5,8 @@
       {
         "appIDs": ["25U9HN34VM.me.freehire.mobile"],
         "components": [
-          { "/": "/jobs/*" }
+          { "/": "/jobs/*" },
+          { "/": "/auth/mobile-callback*" }
         ]
       }
     ]


### PR DESCRIPTION
The mobile app's v2 browser sign-in could not complete against a real deployment. Two halves, this PR is the backend/web one.

## What was wrong

`/api/v2/auth/oauth/<provider>/start` answers `400 invalid_callback_target` for the app, and `/api/v2/auth/providers` advertises Apple alone — so Google, GitHub and LinkedIn silently vanished from the mobile sign-in sheet after the app moved to v2.

Neither is a bug here. `ListProvidersV2` hides browser providers until `MOBILE_AUTH_CALLBACKS` names `ios=` or `android=`, exactly as the runbook intends. The app was the side sending a URL where the server expects a platform name; that fix ships separately in `freehire-mobile`.

What this repo was missing is the target itself.

## Changes

- **`apple-app-site-association`** claimed only `/jobs/*`, so the completion URL could never reach the app even once `ios=` is configured. Adds `/auth/mobile-callback*`. `assetlinks.json` already covers all URLs, so Android needs nothing.
- **`/auth/mobile-callback` page.** On a phone with the app installed the universal link never renders it — the OS hands the URL straight to the app. Reaching it means the app could not take the link (desktop, or app not installed), so it says that plainly. It deliberately does **not** exchange the code: the code is bound to a PKCE verifier held only by the app, so a web exchange cannot succeed, and echoing it into the page would put a single-use credential into history and referrers.
- **Runbook**: documents the `callback_target=ios|android` contract, the verified-link prerequisite, and why browser providers stay hidden until the variable is set.

## Deploy step this does not do

`MOBILE_AUTH_CALLBACKS` still needs `ios=https://freehire.me/auth/mobile-callback` in production. Until then the mobile sheet keeps showing Apple only — which is the safe state, since the return leg would not resolve.

Order matters: ship this so the association file and page are live, let Apple's CDN pick the file up, then set the variable.

## Verification

`svelte-check` clean. The universal-link handoff itself cannot be verified from CI — it needs the file live on freehire.me and a device build, so it stays on the release checklist.