### PR TITLE
fix: correct NULLS ordering on semantic_outbox/search_outbox claim indexes

### DIFF
--- a/migrations/0098_semantic_outbox_claim_idx_drop.sql
+++ b/migrations/0098_semantic_outbox_claim_idx_drop.sql
@@ -1,0 +1,23 @@
+-- migrate: no-transaction
+--
+-- 0081_semantic_outbox_claim_idx.sql declared `job_posted_at DESC` without an explicit
+-- NULLS LAST — Postgres defaults a DESC column to NULLS FIRST, but ClaimSemanticBatch's
+-- ORDER BY explicitly asks for `job_posted_at DESC NULLS LAST` (defensive insurance for
+-- rows predating the backfill). That mismatch means the planner can never use the index
+-- to satisfy the ORDER BY — confirmed live on prod: even with a VALID index in place,
+-- EXPLAIN still chose a Parallel Seq Scan + Sort over the whole claimable set, the exact
+-- cost the index existed to avoid. (Separately, prod's copy of this index was ALSO
+-- invalid — an interrupted CONCURRENTLY build from 2026-08-09 — but fixing the null-order
+-- mismatch is required regardless of that; a validly-built copy of 0081's definition
+-- would carry this same defect.)
+--
+-- Drop it here so 0099 can recreate it with the correct column order — DROP INDEX
+-- CONCURRENTLY needs its own no-transaction file for the same reason CREATE INDEX
+-- CONCURRENTLY does (see 0081/0097's headers): Postgres forbids CONCURRENTLY inside a
+-- transaction block, and a multi-statement migration file runs as one implicit
+-- transaction regardless of the no-transaction marker.
+--
+-- Applied to a fresh volume by initdb after 0081 (immediately superseding it); on an
+-- existing prod volume already carrying 0081, run this by hand, detached from the SSH
+-- session (systemd-run or nohup) — the same warning 0081/0097 already give.
+DROP INDEX CONCURRENTLY IF EXISTS semantic_outbox_claim_idx;

--- a/migrations/0099_semantic_outbox_claim_idx_recreate.sql
+++ b/migrations/0099_semantic_outbox_claim_idx_recreate.sql
@@ -1,0 +1,15 @@
+-- migrate: no-transaction
+--
+-- Recreates semantic_outbox_claim_idx with the null-order fix 0098 dropped it for:
+-- `job_posted_at DESC NULLS LAST` now matches ClaimSemanticBatch's ORDER BY exactly, so
+-- the query planner can index-scan in claim order instead of a seq scan + sort over the
+-- whole claimable set. Verified live on prod (2026-08-15): EXPLAIN on the exact claim
+-- query shape went from a Parallel Seq Scan + Sort (cost ~49700) to a plain Index Scan
+-- (cost ~4.9) against ~950k claimable rows.
+--
+-- Same CONCURRENTLY-needs-its-own-file reasoning as 0098/0081/0097; applied to a fresh
+-- volume by initdb immediately after 0098; on an existing prod volume, build it by hand,
+-- detached from the SSH session (systemd-run or nohup) — a CONCURRENTLY build dies with
+-- its ssh session and leaves an INVALID index behind.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS semantic_outbox_claim_idx ON public.semantic_outbox
+    USING btree (job_posted_at DESC NULLS LAST, job_id DESC) WHERE (failed_at IS NULL);

--- a/migrations/0100_search_outbox_claim_idx_drop.sql
+++ b/migrations/0100_search_outbox_claim_idx_drop.sql
@@ -1,0 +1,17 @@
+-- migrate: no-transaction
+--
+-- 0097_search_outbox_claim_idx.sql copied 0081_semantic_outbox_claim_idx.sql's shape
+-- verbatim, including its bug: `job_posted_at DESC` without an explicit NULLS LAST.
+-- Postgres defaults a DESC column to NULLS FIRST, but ClaimSearchOutboxBatch's ORDER BY
+-- explicitly asks for `job_posted_at DESC NULLS LAST` — so the planner can never use the
+-- index to satisfy the ORDER BY. Confirmed live on prod: EXPLAIN on the real claim query
+-- shape chose a Seq Scan + Sort even with a valid copy of 0097's index in place — see
+-- 0098/0099's fix for the semantic_outbox twin of this same defect.
+--
+-- Drop it here so 0101 can recreate it with the correct column order — DROP INDEX
+-- CONCURRENTLY needs its own no-transaction file, same reasoning as 0098/0081/0097.
+--
+-- Applied to a fresh volume by initdb after 0097 (immediately superseding it); on an
+-- existing prod volume already carrying 0097, run this by hand, detached from the SSH
+-- session — the same warning 0097/0081 already give.
+DROP INDEX CONCURRENTLY IF EXISTS search_outbox_claim_idx;

--- a/migrations/0101_search_outbox_claim_idx_recreate.sql
+++ b/migrations/0101_search_outbox_claim_idx_recreate.sql
@@ -1,0 +1,14 @@
+-- migrate: no-transaction
+--
+-- Recreates search_outbox_claim_idx with the null-order fix 0100 dropped it for:
+-- `job_posted_at DESC NULLS LAST` now matches ClaimSearchOutboxBatch's ORDER BY exactly,
+-- so the query planner can index-scan in claim order instead of a seq scan + sort over
+-- the whole claimable set. Verified live on prod (2026-08-15): EXPLAIN on the exact
+-- claim query shape went from a Seq Scan + Sort to a plain Index Scan.
+--
+-- Same CONCURRENTLY-needs-its-own-file reasoning as 0100/0097/0081; applied to a fresh
+-- volume by initdb immediately after 0100; on an existing prod volume, build it by hand,
+-- detached from the SSH session — a CONCURRENTLY build dies with its ssh session and
+-- leaves an INVALID index behind.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS search_outbox_claim_idx ON public.search_outbox
+    USING btree (job_posted_at DESC NULLS LAST, job_id DESC) WHERE (failed_at IS NULL);


### PR DESCRIPTION
## Summary
- `0081_semantic_outbox_claim_idx.sql` declared `job_posted_at DESC` without an explicit `NULLS LAST`. Postgres defaults a bare `DESC` column to `NULLS FIRST`, but `ClaimSemanticBatch`'s `ORDER BY` explicitly requests `job_posted_at DESC NULLS LAST` — so the index could never satisfy that ordering, regardless of whether it was built successfully.
- `0097_search_outbox_claim_idx.sql` copied the same shape (and the same bug) for `ClaimSearchOutboxBatch`.
- Fixed by dropping and recreating both indexes with the correct `NULLS LAST` clause (each `CONCURRENTLY` statement in its own no-transaction migration file, matching this repo's established convention).

## Found while
Investigating a live prod report that `semantic_outbox_claim_idx` was `indisvalid=false` (an interrupted `CREATE INDEX CONCURRENTLY` from 2026-08-09, dropped SSH session). Confirmed and fixed the invalid-build issue live on prod, then discovered the deeper problem: even a validly-built copy of either index's original definition still couldn't serve the claim queries' `ORDER BY`.

## Verified live on prod (2026-08-15)
- `EXPLAIN` on `ClaimSemanticBatch`'s exact query shape: `Parallel Seq Scan + Sort` (cost ~49700) → `Index Scan` (cost ~4.9) against ~950k claimable rows.
- `EXPLAIN` on `ClaimSearchOutboxBatch`'s exact query shape: `Seq Scan + Sort` → `Index Scan`.
- Both indexes rebuilt detached (`systemd-run`) so a dropped SSH session can't repeat the original incident; confirmed `indisvalid=true` for both afterward.

## Test plan
- [x] `go test -tags=integration ./internal/migrate/...` — fresh-volume apply (137 migrations) clean.
- [x] `go test -tags=integration ./internal/db/... ./cmd/embed/... ./cmd/search-drain/...` clean.
- [x] `go build/vet ./...`, `gofmt -l .` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the ordering and consistency of background job processing.
  - Ensured pending jobs are prioritized by posting time, with stable handling for ties.
  - Excluded failed jobs from active processing queues.

- **Reliability**
  - Updated processing indexes online to minimize service disruption during deployment.
  - Improved performance and predictability when claiming pending search and semantic processing tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->