### PR TITLE
Let a facet count ask for only the facets it reads

### DIFF
--- a/internal/handler/facets.go
+++ b/internal/handler/facets.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"slices"
 	"sort"
+	"strings"
 
 	"github.com/gofiber/fiber/v2"
 
@@ -55,19 +56,70 @@ var facetsNoDistribution = map[string]bool{"company_slug": true}
 // ones in facetsNoDistribution, plus the extras. Sorted for a deterministic
 // request. This is the single source shared with the search filter vocabulary —
 // a new facet added to search.StringFacets is counted here automatically.
-func facetAttributes() []string {
+//
+// `only` narrows the set to the named public params. Counting a distribution is
+// paid per attribute and the expensive ones are the wide-valued ones: measured on
+// prod against `?work_mode=remote`, the full set costs 284ms and returns 99KB,
+// dropping `cities` takes it to 233ms, dropping `skills` too 148ms, and a single
+// attribute is 10ms. A caller that reads one number off the result — the job
+// page's "see also" block reads exactly one per collection — should not pay for
+// the other twenty-six.
+func facetAttributes(only ...string) []string {
+	var want map[string]bool
+	if len(only) > 0 {
+		want = make(map[string]bool, len(only))
+		for _, p := range only {
+			want[p] = true
+		}
+	}
+	keep := func(param string) bool { return want == nil || want[param] }
+
 	attrs := make([]string, 0, len(search.StringFacets)+len(facetExtraParams))
 	for param, attr := range search.StringFacets {
-		if facetsNoDistribution[param] {
+		if facetsNoDistribution[param] || !keep(param) {
 			continue
 		}
 		attrs = append(attrs, attr)
 	}
-	for _, e := range facetExtraParams {
+	for param, e := range facetExtraParams {
+		if !keep(param) {
+			continue
+		}
 		attrs = append(attrs, e.attr)
 	}
 	sort.Strings(attrs)
 	return attrs
+}
+
+// requestedFacets reads the optional `facets=` param: a comma-separated list of
+// public facet params to count, instead of all of them.
+//
+// An unknown name is an error rather than a silent no-op. The counts this
+// endpoint returns are read by key, so a typo would otherwise surface as a
+// missing count — indistinguishable from a value Meili's per-facet cap dropped,
+// which callers are expected to treat as "unknown" rather than as a bug.
+// company_slug is rejected for the same reason it is absent from the full set:
+// thousands of values, and the UI uses the typeahead instead.
+func requestedFacets(c *fiber.Ctx) ([]string, error) {
+	raw := c.Query("facets")
+	if raw == "" {
+		return nil, nil
+	}
+	params := strings.Split(raw, ",")
+	out := make([]string, 0, len(params))
+	for _, p := range params {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		_, isString := search.StringFacets[p]
+		_, isExtra := facetExtraParams[p]
+		if (!isString && !isExtra) || facetsNoDistribution[p] {
+			return nil, fiber.NewError(fiber.StatusBadRequest, "unknown facet: "+p)
+		}
+		out = append(out, p)
+	}
+	return out, nil
 }
 
 // locationFacetParams are the geography facets that share ONE OR-group in
@@ -140,19 +192,31 @@ func (h *searchHandlers) JobFacets(c *fiber.Ctx) error {
 	}
 
 	q := c.Query("q")
+	only, err := requestedFacets(c)
+	if err != nil {
+		return err
+	}
+
 	var res search.FacetResult
-	var err error
 	if c.QueryBool("disjunctive") {
 		// Disjunctive: each facet counted under the full filter minus its own
 		// selection, so a selected facet still shows its siblings (the live-modal
 		// experience). The total stays the full-filter count.
+		//
+		// `facets=` is refused here rather than ignored. Disjunctive counting
+		// derives one query per facet from the SELECTION, so narrowing the output
+		// set would not save the queries — the caller would pay full price for a
+		// partial answer, which is the opposite of what asking for it means.
+		if len(only) > 0 {
+			return fiber.NewError(fiber.StatusBadRequest, "facets= cannot be combined with disjunctive")
+		}
 		vals := queryValues(c)
 		res, err = h.facets.DisjunctiveFacetCounts(c.Context(), q, facetReqs(vals), search.FilterFromValues(vals))
 	} else {
 		res, err = h.facets.FacetCounts(c.Context(), search.FacetParams{
 			Query:  q,
 			Filter: buildSearchFilter(c),
-			Facets: facetAttributes(),
+			Facets: facetAttributes(only...),
 		})
 	}
 	if err != nil {

--- a/internal/handler/facets_test.go
+++ b/internal/handler/facets_test.go
@@ -251,3 +251,70 @@ func contains(ss []string, want string) bool {
 	}
 	return false
 }
+
+// `facets=` exists because counting is paid per attribute: on prod the full set
+// costs 284ms against ?work_mode=remote (the wide-valued cities/skills
+// distributions dominate) versus 10ms for a single one. The job page's "see
+// also" block reads one key per collection, so it names it.
+func TestJobFacets_FacetsParamNarrowsTheRequest(t *testing.T) {
+	fake := &fakeFacetCounter{}
+	app := facetsApp(fake)
+
+	status, _ := doGet(t, app, "/jobs/facets?work_mode=remote&facets=seniority,regions")
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+
+	want := []string{"enrichment.seniority", "regions"}
+	if len(fake.got.Facets) != len(want) {
+		t.Fatalf("Facets = %v, want exactly %v", fake.got.Facets, want)
+	}
+	for _, w := range want {
+		if !contains(fake.got.Facets, w) {
+			t.Errorf("Facets = %v, missing %q", fake.got.Facets, w)
+		}
+	}
+
+	// Narrowing the counted set must not narrow the FILTER — the counts still
+	// have to be "under ?work_mode=remote", or they answer a different question.
+	groups, ok := fake.got.Filter.([][]string)
+	if !ok {
+		t.Fatalf("Filter = %#v, want [][]string", fake.got.Filter)
+	}
+	if !filterHas(groups, `work_mode = "remote"`) {
+		t.Errorf("Filter lost the request's own filters: %#v", groups)
+	}
+}
+
+// A typo must not read as "that value has no count": callers cannot tell a
+// missing key from a value Meili's per-facet cap dropped, so silence would hide
+// the mistake indefinitely.
+func TestJobFacets_UnknownFacetIsRejected(t *testing.T) {
+	for _, name := range []string{"nonsense", "company_slug"} {
+		fake := &fakeFacetCounter{}
+		app := facetsApp(fake)
+		status, _ := doGet(t, app, "/jobs/facets?facets="+name)
+		if status != fiber.StatusBadRequest {
+			t.Errorf("facets=%s: status = %d, want 400", name, status)
+		}
+		if fake.got.Facets != nil {
+			t.Errorf("facets=%s: reached the counter with %v, want no call", name, fake.got.Facets)
+		}
+	}
+}
+
+// Disjunctive counting derives one query per facet from the SELECTION, so a
+// narrowed output set would not save any of them — the caller would pay full
+// price for a partial answer. Refuse rather than silently ignore.
+func TestJobFacets_FacetsParamRejectedWithDisjunctive(t *testing.T) {
+	fake := &fakeFacetCounter{}
+	app := facetsApp(fake)
+
+	status, _ := doGet(t, app, "/jobs/facets?disjunctive=1&facets=seniority")
+	if status != fiber.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", status)
+	}
+	if fake.gotReqs != nil {
+		t.Errorf("reached the counter with %d reqs, want no call", len(fake.gotReqs))
+	}
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -461,9 +461,18 @@ export function createApi(
    *  Empty `facets`/`stats` are normalized to `{}` so callers never see null. */
   // `disjunctive` asks the endpoint to count each facet under the filter minus its
   // own selection (so a selected facet still shows its siblings) — the live-modal mode.
-  async function facetCounts(params: URLSearchParams, opts?: { disjunctive?: boolean }): Promise<FacetCounts> {
+  /** `facets` narrows the count to the named facet params. Counting is paid per
+   *  facet and the wide-valued ones (cities, skills) dominate — the full default
+   *  set measured 284ms on prod versus 10ms for one attribute — so a caller that
+   *  reads a specific key should name it. Cannot be combined with `disjunctive`,
+   *  which derives its queries from the selection rather than from this list. */
+  async function facetCounts(
+    params: URLSearchParams,
+    opts?: { disjunctive?: boolean; facets?: string[] }
+  ): Promise<FacetCounts> {
     const p = new URLSearchParams(params);
     if (opts?.disjunctive) p.set('disjunctive', '1');
+    if (opts?.facets?.length) p.set('facets', opts.facets.join(','));
     const res = await request<{ data: FacetCounts }>(`/api/v1/jobs/facets?${p}`);
     return { total: res.data.total, facets: res.data.facets ?? {}, stats: res.data.stats ?? {} };
   }

--- a/web/src/routes/jobs/[slug]/+page.server.ts
+++ b/web/src/routes/jobs/[slug]/+page.server.ts
@@ -53,18 +53,27 @@ async function buildSeeAlso(job: Job, api: Api): Promise<SeeAlsoCard[]> {
   const links = relatedCollectionLinks(jobFacetsFromJob(job));
   const resolvedLinks = links.map((link) => ({ link, resolved: collectionBySlug(link.slug) }));
 
-  const filterGroups = new Map<string, Record<string, string>>();
+  // Each group is one facetCounts() call, and every card in it reads exactly one
+  // key off the result — so ask for only the keys this group will read. The
+  // endpoint counts every facet by default, and that default is expensive:
+  // measured on prod, the full set costs 284ms against ?work_mode=remote (the
+  // wide-valued cities/skills distributions dominate) versus 10ms for a single
+  // attribute. This block was ~99% of the job page's render time because of it.
+  const filterGroups = new Map<string, { filter: Record<string, string>; keys: Set<string> }>();
   for (const { resolved } of resolvedLinks) {
     if (!resolved) continue;
-    const { filter } = splitParams(resolved.params);
-    filterGroups.set(new URLSearchParams(filter).toString(), filter);
+    const { filter, lastKey } = splitParams(resolved.params);
+    const groupKey = new URLSearchParams(filter).toString();
+    const group = filterGroups.get(groupKey) ?? { filter, keys: new Set<string>() };
+    group.keys.add(lastKey);
+    filterGroups.set(groupKey, group);
   }
   const groupedFacets = new Map<string, FacetCounts | null>(
     await Promise.all(
       [...filterGroups.entries()].map(
-        async ([groupKey, filter]): Promise<[string, FacetCounts | null]> => [
+        async ([groupKey, { filter, keys }]): Promise<[string, FacetCounts | null]> => [
           groupKey,
-          await api.facetCounts(new URLSearchParams(filter)).catch(() => null),
+          await api.facetCounts(new URLSearchParams(filter), { facets: [...keys] }).catch(() => null),
         ]
       )
     )


### PR DESCRIPTION
## The finding

The job page — the most crawled page on the site — answers in **306 ms**. Measured on prod, per request it makes:

| call | time |
|---|---|
| `getJob` | 2 ms |
| `getSimilarJobs` | 1 ms |
| `getJobCopies` | 1 ms |
| `getApplyForm` | 0 ms |
| **`facetCounts` for the "see also" block** | **311 ms** |

One call is ~99% of the page.

## Why it costs that

`/api/v1/jobs/facets` counts a distribution for **every** facet. Counting is paid per attribute and the wide-valued ones dominate. Against `?work_mode=remote` on prod:

| requested | time | response |
|---|---|---|
| all facets (today) | 284 ms | 99 KB |
| minus `cities` | 233 ms | 82 KB |
| minus `cities` and `skills` | 148 ms | 61 KB |
| **a single attribute** | **10 ms** | 212 B |

`cities` and `skills` return 1200 values each. The "see also" block reads **one number per card**.

## The change

`facets=a,b` narrows the counted set. The job page already groups its cards by filter (one call per group); it now also collects which key each group will read and asks for only those. Expected: 306 ms → ~15 ms on that page.

Two things are refused rather than ignored:
- **an unknown facet name** — a typo would surface as a missing count, and callers already treat a missing count as "Meili's per-facet cap dropped this value", so it would hide indefinitely;
- **`facets=` together with `disjunctive`** — disjunctive derives one query per facet from the *selection*, so narrowing the output set saves none of them; the caller would pay full price for a partial answer.

## Why not defer the block to the client

That was considered. The block is server-rendered deliberately — the code says so — so its internal links land in the initial HTML for crawlers. Deferring it would fix the latency by removing the block from what a crawler sees. At 10 ms there is no reason to make that trade, and it avoids a second code path for signed-in vs anonymous.

## Test plan

- [x] `go build`, `go vet`, `go vet -tags=integration`, `gofmt`
- [x] `go test ./internal/handler/ ./internal/search/`
- [x] new tests: narrowing maps public params to index attributes and does not touch the filter; unknown name and `company_slug` are 400 and never reach the counter; `facets=` + `disjunctive` is 400
- [x] eslint + `svelte-check` on the changed web files (no new errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for requesting counts for specific job facets.
  - Related job collections now display counts using only the relevant facet data.
- **Bug Fixes**
  - Invalid or unsupported facet names now return a clear error.
  - Prevented incompatible combinations of selected facets and disjunctive counting.
  - Preserved existing filtering behavior when selecting facet counts.
- **Documentation**
  - Clarified that named facet counting cannot be combined with disjunctive counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->