### PR TITLE
Redesign extension side panel: tabs, page-scoped chat, fixed autofill styling

### DIFF
--- a/extension/entrypoints/sidepanel/App.svelte
+++ b/extension/entrypoints/sidepanel/App.svelte
@@ -34,7 +34,8 @@
   import ToolGroupList from './ToolGroupList.svelte';
   import JobDeck from './JobDeck.svelte';
   import { splitPresentingCalls } from '../../lib/assistant/deck';
-  import { Alert, Badge, Button, EmptyState, Input, Skeleton } from 'freehire-design-system';
+  import { Alert, Badge, Button, EmptyState, Input, Skeleton, TabStrip, tabStripId } from 'freehire-design-system';
+  import { ArrowUp, Square } from '@lucide/svelte';
 
   let chat = $state<ChatState>(initChat());
   // Local action feedback (autofill results, errors) — not part of a turn.
@@ -48,6 +49,13 @@
   // one. Plain refs: neither is rendered directly.
   let sessionId: string | null = null;
   let turn: Turn | null = null;
+
+  // The page the CURRENT conversation is about (see `pageKey`). A job posting's
+  // chat has no reason to carry over to a different page — there is nothing left
+  // to continue — so this is compared against the active tab on every tab switch
+  // and reload, and a mismatch resets the conversation instead of resuming it.
+  // Null until the first page is known.
+  let chatPageKey: string | null = null;
 
   let user = $state<HireUser | null>(null);
   let authBusy = $state(false);
@@ -64,6 +72,13 @@
   let match = $state<JobMatch | null>(null);
   let matchError = $state('');
 
+  // "Match" carries the current page's job info and its page-scoped actions
+  // (Autofill, Add to freehire); "Chat" carries the conversation. Split into tabs
+  // because the chat transcript needs the whole panel height to itself to scroll
+  // — sharing it with the match card left too little room to reach the composer.
+  const PANEL_ID = 'sidepanel-panel';
+  let activeTab = $state<'match' | 'chat'>('match');
+
   onMount(() => {
     // The conversation is created lazily on the first message, so an idle panel
     // starts nothing; a conversation held earlier is repainted here.
@@ -71,8 +86,10 @@
 
     // Re-run the match when the user switches tabs or a page finishes loading,
     // so the card tracks whatever job page is in front — like the reference.
+    // The same event is what notices a genuine page change for the chat: see
+    // `handlePageChange`.
     const refresh = () => {
-      if (user) void loadMatch();
+      if (user) void handlePageChange();
     };
     browser.tabs.onActivated.addListener(refresh);
     const onUpdated = (_id: number, info: { status?: string }) => {
@@ -88,14 +105,60 @@
     };
   });
 
+  /** Identifies the page a conversation is about, for `chatPageKey`. The query
+   *  string is dropped so a tracking-parameter change on the same posting is not
+   *  read as a different one; the path is kept because that is what actually
+   *  distinguishes one job posting's URL from another's, on freehire's own job
+   *  pages and on an ATS's alike. */
+  function pageKey(url: string): string {
+    try {
+      const u = new URL(url);
+      return `${u.origin}${u.pathname}`;
+    } catch {
+      return url;
+    }
+  }
+
+  async function currentPageKey(): Promise<string> {
+    const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+    return pageKey(tab?.url ?? '');
+  }
+
+  /**
+   * Runs on every tab switch and page load. A genuine change of page clears
+   * whatever conversation is on screen — there is nothing on the new page for it
+   * to continue — before the match card is refreshed for the new page. The very
+   * first call (chatPageKey still null) only establishes the baseline; there is
+   * nothing yet to reset it against.
+   *
+   * The clear is local only (`resetChat`, not `newChat`): the page just left
+   * might still have a perfectly good remembered conversation, and switching
+   * away from it is not the user asking to discard it — only the Reset button
+   * and sign-out are. Immediately after, the new page's OWN remembered
+   * conversation (if any) is offered the normal restore path, so tabbing A → B →
+   * A resumes A's conversation rather than finding it erased.
+   */
+  async function handlePageChange() {
+    const key = await currentPageKey();
+    if (chatPageKey !== null && key !== chatPageKey) {
+      resetChat();
+      const token = await getToken();
+      if (token) void restoreConversation(token, key);
+    }
+    chatPageKey = key;
+    void loadMatch();
+  }
+
   async function restoreSession() {
     const token = await getToken();
     if (!token) return;
     user = await fetchMe(token);
     if (!user) return;
     tools.start(token);
+    const key = await currentPageKey();
+    chatPageKey = key;
     void loadMatch();
-    void restoreConversation(token);
+    void restoreConversation(token, key);
   }
 
   /**
@@ -103,22 +166,28 @@
    * through the same reducer a live turn folds through, so history and a running
    * turn cannot render differently.
    *
+   * A remembered conversation about a different page is not repainted here — it
+   * is simply not what this page's chat should show — but it is left in storage
+   * rather than forgotten: it is exactly right for whatever page it WAS about,
+   * and staying there is what lets tabbing back to that page resume it.
+   *
    * A conversation the server no longer has (deleted from the web) is not an error
    * the user can act on from here — forget it and let the next message start a
    * fresh one.
    */
-  async function restoreConversation(token: string) {
+  async function restoreConversation(token: string, key: string) {
     const remembered = await recallSession();
     if (!remembered) return;
+    if (remembered.pageKey !== key) return;
     restoring = true;
     try {
-      const { messages } = await getSession(remembered, token);
+      const { messages } = await getSession(remembered.id, token);
       // The composer unlocks as soon as the user is known, so a message can be
       // sent while this read is in flight — and that message created its own
       // conversation. Adopting the remembered one now would point the panel at A
       // while storage holds B, and lose the exchange the user just watched.
       if (sessionId) return;
-      sessionId = remembered;
+      sessionId = remembered.id;
       for (const event of eventsFromTranscript(messages)) {
         chat = reduceTurnEvent(chat, event);
       }
@@ -269,6 +338,7 @@
       if (!user) authError = 'Signed in, but could not load your account.';
       else {
         tools.start(token);
+        chatPageKey = await currentPageKey();
         void loadMatch();
       }
     } catch (err) {
@@ -286,6 +356,9 @@
     // Forget the conversation so a later sign-in never resumes the previous
     // user's, and clear what is on screen.
     await newChat();
+    // No page is "current" while signed out — re-established by restoreSession
+    // or handleSignIn on the next sign-in, same as on first mount.
+    chatPageKey = null;
   }
 
   /**
@@ -311,8 +384,10 @@
     }
     try {
       if (!sessionId) {
+        const key = chatPageKey ?? (await currentPageKey());
         sessionId = (await createSession(token)).id;
-        await rememberSession(sessionId);
+        await rememberSession(sessionId, key);
+        chatPageKey = key;
       }
       turn = sendTurn(sessionId, text, token, (event) => {
         chat = reduceTurnEvent(chat, event);
@@ -343,15 +418,25 @@
     turn?.cancel();
   }
 
-  /** Start over. The old conversation stays on the server — it is in the web's
-   *  session rail — so this forgets it rather than deleting it. */
-  async function newChat() {
+  /** Clears what the panel is showing, without touching the remembered session in
+   *  storage — used where the underlying conversation may still be worth keeping
+   *  (a page change; see `handlePageChange`). `newChat` below is the same clear
+   *  plus the deliberate forget. */
+  function resetChat() {
     if (sending) stopTurn();
     sessionId = null;
-    await forgetSession();
     chat = initChat();
     notices = [];
     chatError = '';
+  }
+
+  /** Start over — the Reset button. The old conversation stays on the server — it
+   *  is in the web's session rail — so this forgets the panel's local pointer to
+   *  it rather than deleting it. chatPageKey is left as-is: the button does not
+   *  navigate anywhere, so the current page is still the current page. */
+  async function newChat() {
+    resetChat();
+    await forgetSession();
   }
 
   function sendMessage() {
@@ -513,7 +598,10 @@
 <div class="app">
   <header>
     <div class="top">
-      <strong>freehire</strong>
+      <span class="brand">
+        <img src="/icon/32.png" alt="" class="brand-mark" width="18" height="18" />
+        <strong>freehire</strong>
+      </span>
       <Badge variant={sending ? 'brand' : 'outline'}>
         {sending ? 'working…' : user ? 'ready' : 'offline'}
       </Badge>
@@ -533,99 +621,146 @@
     {/if}
   </header>
 
-  {#if user}
-    {#if matchStatus === 'ready' && matchJob && match}
-      <MatchCard job={matchJob} {match} />
-    {:else if matchStatus === 'loading'}
-      <div class="match-skeleton">
-        <Skeleton class="h-9 w-9 rounded-lg" />
-        <div class="match-skeleton-lines">
-          <Skeleton class="h-3 w-2/3 rounded" />
-          <Skeleton class="h-3 w-1/3 rounded" />
-        </div>
-      </div>
-    {:else if matchStatus === 'error'}
-      <EmptyState title="Match unavailable" description={matchError}>
-        {#snippet action()}
-          <Button variant="outline" size="sm" onclick={loadMatch}>Retry</Button>
-        {/snippet}
-      </EmptyState>
-    {:else if matchStatus === 'empty'}
-      <EmptyState title="No match yet" description="Open a job posting to see your match.">
-        {#snippet action()}
-          <Button variant="outline" size="sm" onclick={loadMatch}>Refresh</Button>
-        {/snippet}
-      </EmptyState>
-    {/if}
-    {#if unknownPage}
-      <p class="match-hint">
-        freehire doesn't have this posting.
-        <button class="link" onclick={contributePage} disabled={contributing}>
-          {contributing ? 'Adding…' : 'Add to freehire'}
-        </button>
-      </p>
-    {/if}
-  {/if}
+  <TabStrip
+    class="tab-strip"
+    tabs={[
+      { id: 'match', label: 'Match' },
+      { id: 'chat', label: 'Chat' },
+    ]}
+    active={activeTab}
+    onSelect={(id) => (activeTab = id)}
+    label="Panel sections"
+    panelId={PANEL_ID}
+  />
 
-  <div class="messages">
-    {#each chat.messages as message, mi (mi)}
-      {@const split = splitPresentingCalls(message.tools, message.streaming)}
-      {#each split.decks as slot, di (di)}
-        <JobDeck {slot} />
-      {/each}
-      {#if split.rest.length > 0}
-        <ToolGroupList calls={split.rest} />
-      {/if}
-      {#if message.text || message.streaming}
-        <div class="message {message.role}" class:errored={message.errored}>
-          {message.text}{#if message.streaming && !message.text}<span class="dots">…</span>{/if}
-        </div>
-      {/if}
-    {/each}
-    {#each notices as notice, i (i)}
-      <div class="message system">{notice}</div>
-    {/each}
-    {#if overrideFill}
-      <div class="message system">
-        <button class="link" onclick={runOverrideFill} disabled={autofilling}>Fill it anyway</button>
-      </div>
-    {/if}
-    {#if chatError}
-      <div class="message system err">{chatError}</div>
-    {/if}
-    {#if chat.messages.length === 0 && notices.length === 0}
-      <p class="empty">
-        {#if restoring}
-          Loading your conversation…
-        {:else if user}
-          Ask about the page you're on — the agent can read it.
+  <div class="tab-panel" role="tabpanel" id={PANEL_ID} aria-labelledby={tabStripId(PANEL_ID, activeTab)}>
+    {#if activeTab === 'match'}
+      <div class="match-panel">
+        {#if user}
+          {#if matchStatus === 'ready' && matchJob && match}
+            <MatchCard job={matchJob} {match} />
+          {:else if matchStatus === 'loading'}
+            <div class="match-skeleton">
+              <Skeleton class="h-9 w-9 rounded-lg" />
+              <div class="match-skeleton-lines">
+                <Skeleton class="h-3 w-2/3 rounded" />
+                <Skeleton class="h-3 w-1/3 rounded" />
+              </div>
+            </div>
+          {:else if matchStatus === 'error'}
+            <EmptyState title="Match unavailable" description={matchError}>
+              {#snippet action()}
+                <Button variant="outline" size="sm" onclick={loadMatch}>Retry</Button>
+              {/snippet}
+            </EmptyState>
+          {:else if matchStatus === 'empty'}
+            <EmptyState title="No match yet" description="Open a job posting to see your match.">
+              {#snippet action()}
+                <Button variant="outline" size="sm" onclick={loadMatch}>Refresh</Button>
+              {/snippet}
+            </EmptyState>
+          {/if}
+          {#if unknownPage}
+            <p class="match-hint">
+              freehire doesn't have this posting.
+              <button class="link" onclick={contributePage} disabled={contributing}>
+                {contributing ? 'Adding…' : 'Add to freehire'}
+              </button>
+            </p>
+          {/if}
+
+          <Button
+            class="w-full !h-16 !text-base !font-semibold"
+            variant="primary"
+            size="lg"
+            onclick={autofill}
+            disabled={autofilling}
+          >
+            {autofilling ? 'Filling…' : 'Autofill'}
+          </Button>
+
+          {#each notices as notice, i (i)}
+            <div class="message system">{notice}</div>
+          {/each}
+          {#if overrideFill}
+            <div class="message system">
+              <button class="link" onclick={runOverrideFill} disabled={autofilling}>Fill it anyway</button>
+            </div>
+          {/if}
         {:else}
-          Sign in to chat with the agent.
+          <p class="empty">Sign in to see your match for this page.</p>
         {/if}
-      </p>
-    {/if}
-  </div>
-
-  <div class="composer">
-    {#if user}
-      <Button variant="secondary" size="sm" onclick={autofill} disabled={autofilling}>
-        {autofilling ? 'Filling…' : 'Autofill'}
-      </Button>
-    {/if}
-    {#if user && chat.messages.length > 0}
-      <Button variant="secondary" size="sm" onclick={newChat} disabled={sending}>New chat</Button>
-    {/if}
-    <Input
-      class="flex-1"
-      placeholder={user ? 'Message the agent…' : 'Sign in to chat'}
-      bind:value={draft}
-      disabled={!user || sending}
-      onkeydown={(e) => e.key === 'Enter' && sendMessage()}
-    />
-    {#if sending}
-      <Button variant="primary" size="sm" onclick={stopTurn}>Stop</Button>
+      </div>
     {:else}
-      <Button variant="primary" size="sm" onclick={sendMessage} disabled={!user}>Send</Button>
+      <div class="chat-panel">
+        {#if user}
+          <div class="chat-toolbar">
+            <Button variant="ghost" size="sm" onclick={newChat} disabled={sending}>Reset</Button>
+          </div>
+        {/if}
+        <div class="messages">
+          {#each chat.messages as message, mi (mi)}
+            {@const split = splitPresentingCalls(message.tools, message.streaming)}
+            {#each split.decks as slot, di (di)}
+              <JobDeck {slot} />
+            {/each}
+            {#if split.rest.length > 0}
+              <ToolGroupList calls={split.rest} />
+            {/if}
+            {#if message.text || message.streaming}
+              <div class="message {message.role}" class:errored={message.errored}>
+                {message.text}{#if message.streaming && !message.text}<span class="dots">…</span>{/if}
+              </div>
+            {/if}
+          {/each}
+          {#if chatError}
+            <div class="message system err">{chatError}</div>
+          {/if}
+          {#if chat.messages.length === 0}
+            <p class="empty">
+              {#if restoring}
+                Loading your conversation…
+              {:else if user}
+                Ask about the page you're on — the agent can read it.
+              {:else}
+                Sign in to chat with the agent.
+              {/if}
+            </p>
+          {/if}
+        </div>
+
+        <div class="composer">
+          <Input
+            class="flex-1"
+            placeholder={user ? 'Message the agent…' : 'Sign in to chat'}
+            bind:value={draft}
+            disabled={!user || sending}
+            onkeydown={(e) => e.key === 'Enter' && sendMessage()}
+          />
+          {#if sending}
+            <Button
+              class="rounded-full"
+              variant="primary"
+              size="icon"
+              aria-label="Stop the assistant"
+              onclick={stopTurn}
+            >
+              <Square class="size-3.5" fill="currentColor" />
+            </Button>
+          {:else}
+            <Button
+              class="rounded-full"
+              variant="primary"
+              size="icon"
+              aria-label="Send message"
+              onclick={sendMessage}
+              disabled={!user}
+            >
+              <ArrowUp class="size-4" strokeWidth={2.5} />
+            </Button>
+          {/if}
+        </div>
+      </div>
     {/if}
   </div>
 </div>
@@ -635,6 +770,7 @@
     display: flex;
     flex-direction: column;
     height: 100vh;
+    overflow: hidden;
     font-size: 14px;
   }
 
@@ -643,13 +779,22 @@
     flex-direction: column;
     gap: 6px;
     padding: 10px 12px;
-    border-bottom: 1px solid var(--border);
   }
 
   .top {
     display: flex;
     align-items: center;
     justify-content: space-between;
+  }
+
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .brand-mark {
+    border-radius: 4px;
   }
 
   .auth {
@@ -677,17 +822,53 @@
     padding: 0;
   }
 
+  /* :global — `class="tab-strip"` is forwarded onto TabStrip's own root element,
+   * which carries that component's scoping hash, not App.svelte's; a scoped
+   * selector here would silently match nothing, which is exactly what dropped
+   * the strip's inset. */
+  :global(.tab-strip) {
+    padding: 0 12px;
+    flex-shrink: 0;
+  }
+
+  /* The panel that actually has to fill the space between the tab strip and the
+   * viewport's bottom edge — min-height: 0 overrides a flex item's default of
+   * shrinking no further than its content, which is what silently broke internal
+   * scrolling here: without it this item grew to fit the transcript instead of
+   * scrolling it, pushing the composer off screen. */
+  .tab-panel {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .match-panel {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .chat-panel {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
   .match-hint {
     font-size: 12px;
     color: var(--muted-foreground);
-    margin: 12px;
   }
 
   .match-skeleton {
     display: flex;
     align-items: center;
     gap: 10px;
-    margin: 12px;
   }
 
   .match-skeleton-lines {
@@ -699,6 +880,7 @@
 
   .messages {
     flex: 1;
+    min-height: 0;
     overflow-y: auto;
     padding: 12px;
     display: flex;
@@ -750,6 +932,13 @@
 
   .dots {
     opacity: 0.5;
+  }
+
+  .chat-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    padding: 6px 10px 0;
+    flex-shrink: 0;
   }
 
   .composer {

--- a/extension/entrypoints/sidepanel/App.svelte
+++ b/extension/entrypoints/sidepanel/App.svelte
@@ -22,7 +22,12 @@
     type JobMatch,
     type AutofillProfile,
   } from '../../lib/freehire';
-  import { planLabelFills, looksLikeApplication, scopeToApplication } from '../../lib/form';
+  import {
+    planLabelFills,
+    looksLikeApplication,
+    scopeToApplication,
+    formatAuthorizedCountries,
+  } from '../../lib/form';
   import { ToolChannel } from '../../lib/tools/client';
   import { activeTabPage } from '../../lib/tools/page';
   import MatchCard from './MatchCard.svelte';
@@ -369,6 +374,12 @@
       linkedin: p.linkedin,
       github: p.github,
       portfolio: p.portfolio,
+      authorizedCountries: formatAuthorizedCountries(p.authorized_countries),
+      visaSponsorshipNeeded: p.visa_sponsorship_needed,
+      desiredSalary: p.desired_salary,
+      noticePeriod: p.notice_period,
+      willingToRelocate: p.willing_to_relocate,
+      age18OrOlder: p.age_18_or_older,
     };
   }
 

--- a/extension/entrypoints/sidepanel/MatchCard.svelte
+++ b/extension/entrypoints/sidepanel/MatchCard.svelte
@@ -229,9 +229,15 @@
 </Card>
 
 <style>
+  /* No margin here: the card's outer inset comes from the sidepanel's own
+   * `.match-panel` padding, same as every other element it sits next to (the
+   * Autofill button, the "Add to freehire" hint). A margin here on top of that
+   * padding used to double the card's inset to 24px while its siblings stayed at
+   * 12px — visible as the card's content looking normally spaced and the
+   * Autofill button looking edge-to-edge by contrast, when neither actually had
+   * zero padding. */
   :global(.card) {
     padding: 14px;
-    margin: 12px;
   }
   .job {
     display: flex;

--- a/extension/lib/assistant/session.ts
+++ b/extension/lib/assistant/session.ts
@@ -1,28 +1,36 @@
 /**
- * Which conversation the panel is holding, remembered across openings.
- *
- * Only the id is kept. The transcript lives on the server, where the web app can
- * continue the same conversation — caching messages here would give one exchange
- * two sources of truth. Shaped like `auth.ts`'s token helpers, and thin for the
- * same reason: it is storage plumbing, not logic.
+ * Which conversation the panel is holding, remembered across openings — and which
+ * page it was about, so a conversation started on one job posting is never resumed
+ * on another. Only the id and the page key are kept: the transcript lives on the
+ * server, where the web app can continue the same conversation — caching messages
+ * here would give one exchange two sources of truth. Shaped like `auth.ts`'s token
+ * helpers, and thin for the same reason: it is storage plumbing, not logic.
  */
 
 import { browser } from 'wxt/browser';
 
-const SESSION_KEY = 'assistantSessionId';
+const SESSION_KEY = 'assistantSession';
+
+export interface StoredSession {
+  id: string;
+  /** The page key (see App.svelte's `pageKey`) the conversation was started on. */
+  pageKey: string;
+}
 
 /** The conversation to resume, or null if the panel is starting fresh. */
-export async function recallSession(): Promise<string | null> {
+export async function recallSession(): Promise<StoredSession | null> {
   const stored = await browser.storage.local.get(SESSION_KEY);
-  return (stored[SESSION_KEY] as string) ?? null;
+  const raw = stored[SESSION_KEY];
+  return raw && typeof raw === 'object' ? (raw as StoredSession) : null;
 }
 
-/** Remember the conversation the panel is now holding. */
-export async function rememberSession(id: string): Promise<void> {
-  await browser.storage.local.set({ [SESSION_KEY]: id });
+/** Remember the conversation the panel is now holding, and the page it is about. */
+export async function rememberSession(id: string, pageKey: string): Promise<void> {
+  await browser.storage.local.set({ [SESSION_KEY]: { id, pageKey } satisfies StoredSession });
 }
 
-/** Forget it — on sign-out, on "new chat", and when the server no longer has it. */
+/** Forget it — on sign-out, on reset, when the page changes, and when the server no
+ *  longer has it. */
 export async function forgetSession(): Promise<void> {
   await browser.storage.local.remove(SESSION_KEY);
 }

--- a/extension/lib/form.test.ts
+++ b/extension/lib/form.test.ts
@@ -8,6 +8,7 @@ import {
   fillByLabel,
   looksLikeApplication,
   scopeToApplication,
+  formatAuthorizedCountries,
 } from './form';
 import { must } from './test-utils';
 
@@ -712,6 +713,42 @@ describe('fillByLabel on a group', () => {
     expect(inputs.some((i) => i.checked)).toBe(false);
     expect(outcomes).toEqual([{ label: 'Which countries?', status: 'no_option' }]);
   });
+
+  it('fills a country checkbox group from the profile ISO-code value once formatted', () => {
+    // screeninganswers.AutofillFields serves "US, DE" — the group's own options are
+    // full country names, so the raw codes must go through formatAuthorizedCountries
+    // first or nothing would ever match.
+    const countries = checkboxGroup('Which countries are you authorized to work in?', [
+      'United States',
+      'Germany',
+      'Canada',
+    ]);
+    const us = must(countries[0]);
+    const de = must(countries[1]);
+    const ca = must(countries[2]);
+
+    const outcomes = fillByLabel(document, [
+      {
+        label: 'Which countries are you authorized to work in?',
+        value: formatAuthorizedCountries('US, DE'),
+      },
+    ]);
+
+    expect([us.checked, de.checked, ca.checked]).toEqual([true, true, false]);
+    expect(outcomes).toEqual([
+      { label: 'Which countries are you authorized to work in?', status: 'filled' },
+    ]);
+  });
+});
+
+describe('formatAuthorizedCountries', () => {
+  it('turns ISO codes into the country names a checkbox group carries as options', () => {
+    expect(formatAuthorizedCountries('US, DE')).toBe('United States, Germany');
+  });
+
+  it('is empty for an empty value, rather than an empty-string entry', () => {
+    expect(formatAuthorizedCountries('')).toBe('');
+  });
 });
 
 describe('matchFieldKey', () => {
@@ -745,5 +782,23 @@ describe('matchFieldKey', () => {
 
   it('does not match a longer word that merely starts the same way', () => {
     expect(matchFieldKey('Citywide preference')).toBeNull();
+  });
+
+  it('maps screening-answer questions to their canonical keys', () => {
+    expect(matchFieldKey('Which countries are you authorized to work in?')).toBe('authorizedCountries');
+    expect(
+      matchFieldKey('Will you now or in the future require sponsorship to work in this country?'),
+    ).toBe('visaSponsorshipNeeded');
+    expect(matchFieldKey('Desired salary')).toBe('desiredSalary');
+    expect(matchFieldKey('What is your notice period?')).toBe('noticePeriod');
+    expect(matchFieldKey('Are you willing to relocate?')).toBe('willingToRelocate');
+    expect(matchFieldKey('Are you at least 18 years of age?')).toBe('age18OrOlder');
+  });
+
+  it('leaves a plain work-authorization Yes/No question unmatched', () => {
+    // That question has no boolean field in the profile — only a list of
+    // authorized countries — so answering it would put the wrong shape of
+    // value into a Yes/No control. See the Roku case above.
+    expect(matchFieldKey('Are you authorized to work in this country?')).toBeNull();
   });
 });

--- a/extension/lib/form.ts
+++ b/extension/lib/form.ts
@@ -10,6 +10,7 @@
  */
 
 import type { FieldTag, FormField, LabelFill, FillOutcome, Upload } from './protocol';
+import { countryLabel } from './labels';
 
 type Fillable = HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
 
@@ -342,7 +343,72 @@ const FIELD_SYNONYMS: Record<string, string[]> = {
   linkedin: ['linkedin'],
   github: ['github'],
   portfolio: ['portfolio', 'website', 'personal site'],
+  // The candidate's own screening answers (internal/screeninganswers), not a
+  // boolean "are you authorized to work" question — that asks something the
+  // profile does not carry an answer to, so it stays unmatched rather than
+  // being fed a country list where a Yes/No answer belongs.
+  authorizedCountries: [
+    'which countries are you authorized to work in',
+    'in which countries are you authorized to work',
+    'in which countries are you legally authorized to work',
+    'countries you are authorized to work in',
+    'list the countries you are authorized to work in',
+  ],
+  visaSponsorshipNeeded: [
+    'will you now or in the future require sponsorship',
+    'do you now or will you in the future require sponsorship',
+    'will you require sponsorship',
+    'do you require visa sponsorship',
+    'do you need visa sponsorship',
+    'will you need visa sponsorship',
+  ],
+  desiredSalary: [
+    'desired salary',
+    'desired compensation',
+    'expected salary',
+    'salary expectation',
+    'salary expectations',
+    'what are your salary expectations',
+    'compensation expectations',
+  ],
+  noticePeriod: [
+    'notice period',
+    'current notice period',
+    'what is your notice period',
+    'how much notice',
+  ],
+  willingToRelocate: [
+    'are you willing to relocate',
+    'would you be willing to relocate',
+    'willing to relocate',
+    'are you open to relocating',
+    'open to relocation',
+  ],
+  age18OrOlder: [
+    'are you at least 18 years',
+    'are you 18 years of age or older',
+    'are you over the age of 18',
+    'are you 18 or older',
+    'will you be 18 years of age',
+  ],
 };
+
+/**
+ * The profile's authorized-countries field arrives as comma-joined ISO codes ("US, DE" —
+ * screeninganswers.AutofillFields' wire format), but the question it answers is almost
+ * always a checkbox group whose options are full country names ("United States"), matched
+ * option-by-option against this value by `chosenOptions` below. Left as codes, the value
+ * would never match any option and the group would silently stay unchecked.
+ */
+export function formatAuthorizedCountries(codes: string): string {
+  if (!codes) return '';
+  return codes
+    .split(',')
+    .map((c) => c.trim())
+    .filter(Boolean)
+    .map(countryLabel)
+    .join(', ');
+}
 
 /**
  * Comparison form of a label: case-, whitespace- and required-marker-insensitive,

--- a/extension/lib/freehire.ts
+++ b/extension/lib/freehire.ts
@@ -177,7 +177,9 @@ export function getMatchAnalysis(slug: string, token: string): Promise<MatchAnal
   return getData<MatchAnalysisResponse>(`/api/v1/jobs/${encodeURIComponent(slug)}/match-analysis`, token);
 }
 
-/** Canonical autofill fields freehire assembles from the user's CV + account. */
+/** Canonical autofill fields freehire assembles from the user's CV + account,
+ *  plus the candidate's own screening answers (internal/screeninganswers) —
+ *  empty when the caller has stated nothing, never guessed. */
 export interface AutofillProfile {
   full_name: string;
   first_name: string;
@@ -188,6 +190,12 @@ export interface AutofillProfile {
   linkedin: string;
   github: string;
   portfolio: string;
+  authorized_countries: string;
+  visa_sponsorship_needed: string;
+  desired_salary: string;
+  notice_period: string;
+  willing_to_relocate: string;
+  age_18_or_older: string;
 }
 
 export function getAutofillProfile(token: string): Promise<AutofillProfile> {

--- a/openspec/changes/archive/2026-08-14-connect-screening-answers-autofill/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-14-connect-screening-answers-autofill/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/archive/2026-08-14-connect-screening-answers-autofill/design.md
+++ b/openspec/changes/archive/2026-08-14-connect-screening-answers-autofill/design.md
@@ -1,0 +1,58 @@
+## Context
+
+The extension already has two autofill paths sharing one server-assembled profile block
+(`GET /api/v1/me/autofill-profile`, `internal/handler/autofill_profile.go`): an agent-driven
+path (`POST /api/v1/me/autofill/run`) that already grounds its plan in screening answers, and
+a deterministic fallback filler (`extension/lib/form.ts`) that label-matches question text
+against a fixed synonym table (`FIELD_SYNONYMS`) and writes values from a flat `Record<string,
+string>` (`extension/entrypoints/sidepanel/App.svelte`'s `profileToValues`). The server side of
+this wiring predates this change; only the extension's TS type, value mapping and synonym
+table were missing the six screening fields. See proposal.md - Why.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Extend the existing three extension-side seams (type, value mapping, synonym table) to
+  carry the six screening fields through the same mechanism identity fields already use.
+- Preserve the existing rule that an unstated field is left blank, never guessed.
+
+**Non-Goals:**
+- No backend change — `internal/screeninganswers` and both autofill endpoints already serve/
+  consume these fields.
+- No change to the agent-driven autofill path, which already has this data.
+- No attempt to make the label-matcher fuzzy or ML-based; it stays the same
+  front-anchored-prefix synonym match the identity fields use, just with more entries.
+
+## Decisions
+
+- **Reuse `FIELD_SYNONYMS`/`matchFieldKey` rather than a parallel table.** The six new
+  fields are conceptually the same kind of thing the existing nine are: one canonical key,
+  a handful of real-world label phrasings, one flat value. A second mechanism for "screening"
+  fields would duplicate `planLabelFills`/`fillByLabel` for no behavioral gain.
+- **Do not map a generic "are you authorized to work" Yes/No question to
+  `authorizedCountries`.** The stored answer is a joined country-code list
+  (`screeninganswers.AutofillFields` — "US, DE"), not a boolean. `fillField`'s checkbox/radio
+  path only recognizes `"yes"`/`"true"`/`"1"` for a single control, and a grouped Yes/No radio
+  pair matches by comparing the value against each option's own label — neither path can turn
+  a country list into a Yes/No answer. Synonyms are restricted to phrasings that literally ask
+  *which* countries ("which countries are you authorized to work in"), matching the existing
+  `extension-autofill` spec's Roku-derived test case, which asserts the boolean phrasing stays
+  unmatched.
+- **Values arrive pre-formatted from the server, except authorized countries.**
+  `screeninganswers.AutofillFields()` already renders booleans as `"yes"`/`"no"` and composes
+  the salary string, so the extension routes those straight through. Authorized countries is
+  the one exception: the server serves comma-joined ISO codes ("US, DE"), but the checkbox
+  groups that question is almost always rendered as offer full country names ("United
+  States") as their options, and `chosenOptions` (`extension/lib/form.ts`) matches the value
+  against each option's own label text. Left as codes, the value would never match any
+  option and the group would silently stay unchecked — caught in review, not in the original
+  pass. `formatAuthorizedCountries` converts each code via the same `countryLabel`
+  (`extension/lib/labels.ts`, `Intl.DisplayNames`) the extension already uses for job-facet
+  country codes, so the two matching sides agree on country naming.
+
+## Risks / Trade-offs
+
+- [Front-anchored prefix matching misses some real ATS phrasings the identity fields don't
+  already cover as densely] → Accepted: this is the existing mechanism's known shape (see
+  `matchFieldKey`'s doc comment), and it degrades to "left blank" rather than a wrong answer.
+  Widening coverage further is a follow-up, not a blocker for connecting what already exists.

--- a/openspec/changes/archive/2026-08-14-connect-screening-answers-autofill/proposal.md
+++ b/openspec/changes/archive/2026-08-14-connect-screening-answers-autofill/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+The profile now has a screening-answers questionnaire (`internal/screeninganswers`: authorized
+countries, visa sponsorship, desired salary, notice period, willingness to relocate, 18+), and
+the server already folds those answers into the autofill profile the browser extension reads.
+The agent-driven autofill path already grounds its plan in them. The extension's deterministic
+fallback filler — the one that runs when the agent path is unavailable (no LLM configured, no
+browser-tool channel attached, or the agent finds no fillable fields) — did not: its profile
+type and its label-matching table both stopped at the nine identity fields, so a candidate who
+relies on the fallback got a form with visa/salary/notice/relocation/age questions left blank
+even though they had already answered them once in their profile.
+
+## What Changes
+
+- Extend the extension's `AutofillProfile` type with the six screening-answer fields the
+  server already serves from `GET /api/v1/me/autofill-profile`.
+- Map those six fields into the values the deterministic filler plans fills from.
+- Add label-matching synonyms for the real-world ATS phrasings of each screening question
+  ("which countries are you authorized to work in", "will you now or in the future require
+  sponsorship", "desired salary", "notice period", "are you willing to relocate", "are you at
+  least 18 years of age").
+- Deliberately exclude a generic "are you authorized to work" Yes/No phrasing from the
+  authorized-countries match: that question is boolean, the stored answer is a country list,
+  and the profile carries no boolean field to answer it with — filling it would put the wrong
+  shape of value into a Yes/No control.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `extension-autofill`: the deterministic fallback filler now also recognizes and fills
+  screening-answer questions (authorized countries, visa sponsorship, desired salary, notice
+  period, willingness to relocate, 18+), in addition to the identity contact block it already
+  filled. The canonical profile block it reads from gains the corresponding six fields.
+
+## Impact
+
+- `extension/lib/freehire.ts` — `AutofillProfile` interface.
+- `extension/entrypoints/sidepanel/App.svelte` — `profileToValues()`.
+- `extension/lib/form.ts` — `FIELD_SYNONYMS`.
+- `extension/lib/form.test.ts` — coverage for the new mappings and the deliberate exclusion.
+- No backend change: `internal/screeninganswers` and the `/me/autofill-profile` /
+  `/me/autofill/run` endpoints already served/consumed these fields before this change.

--- a/openspec/changes/archive/2026-08-14-connect-screening-answers-autofill/specs/extension-autofill/spec.md
+++ b/openspec/changes/archive/2026-08-14-connect-screening-answers-autofill/specs/extension-autofill/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: The autofill profile also carries the candidate's screening answers
+
+The autofill profile block SHALL, in addition to the identity contact fields, carry the
+candidate's own screening answers (`internal/screeninganswers`): `authorized_countries`,
+`visa_sponsorship_needed`, `desired_salary`, `notice_period`, `willing_to_relocate` and
+`age_18_or_older`. A field the candidate has not stated SHALL be empty rather than guessed,
+on the same terms as an unstated identity field.
+
+These fields are independent of the identity contact block: there is exactly one
+screening-answers store, so there is no multi-source precedence to resolve for them the way
+there is for name/email/phone.
+
+#### Scenario: Screening answers ride alongside the identity fields
+
+- **WHEN** an authenticated caller reads the autofill profile and has stated their desired
+  salary and their willingness to relocate, but no other screening answer
+- **THEN** the response carries those two values and empty strings for the other four
+  screening fields, alongside whatever identity fields the CV/résumé/account state
+
+### Requirement: The deterministic fallback filler answers screening questions
+
+When the browser extension's deterministic fallback filler is in use — the path taken when
+the agent-driven autofill is unavailable — it SHALL recognize application-form questions
+asking about work-authorized countries, visa sponsorship, desired salary, notice period,
+willingness to relocate, and age (18+), and fill them from the caller's screening answers
+using the same label-matching mechanism it already uses for identity fields. A question the
+caller has not answered in their profile SHALL be left blank rather than filled with a
+guess, matching the existing rule for identity fields.
+
+#### Scenario: A notice-period question is filled from the profile
+
+- **WHEN** the deterministic filler is planning fills for a form asking "What is your notice
+  period?" and the caller's screening answers state a 30-day notice period
+- **THEN** the plan fills that question with "30 days"
+
+#### Scenario: An unanswered screening question is left blank
+
+- **WHEN** the deterministic filler is planning fills for a form asking about desired salary
+  and the caller has not stated one
+- **THEN** the plan leaves that question unfilled
+
+#### Scenario: An authorized-countries checkbox group is filled by country name, not by code
+
+- **WHEN** a form asks "Which countries are you authorized to work in?" as a checkbox group
+  offering full country names, and the caller's screening answers state authorization in the
+  US and Germany
+- **THEN** the plan checks the "United States" and "Germany" options, not a literal "US, DE"
+  that would match neither
+
+### Requirement: A boolean work-authorization question is not answered from the country list
+
+A plain Yes/No "are you authorized to work [here]?" question SHALL NOT be matched to the
+authorized-countries screening answer. That answer is a list of country codes, not a
+boolean, and the profile carries no boolean field stating plain work authorization — filling
+the question would put the wrong shape of value into a Yes/No control.
+
+This does not apply to a question that itself asks *which* countries the candidate is
+authorized to work in (a list question), which the previous requirement covers.
+
+#### Scenario: A boolean work-authorization question stays unmatched
+
+- **WHEN** an application form asks "Are you authorized to work in this country?" as a
+  Yes/No question
+- **THEN** the deterministic filler does not match it to any screening answer and leaves it
+  for the caller

--- a/openspec/changes/archive/2026-08-14-connect-screening-answers-autofill/tasks.md
+++ b/openspec/changes/archive/2026-08-14-connect-screening-answers-autofill/tasks.md
@@ -1,0 +1,28 @@
+## 1. Profile type and value mapping
+
+- [x] 1.1 Add the six screening-answer fields to `AutofillProfile` in `extension/lib/freehire.ts`
+- [x] 1.2 Map those six fields into `profileToValues()` in `extension/entrypoints/sidepanel/App.svelte`
+
+## 2. Label matching
+
+- [x] 2.1 Add `authorizedCountries`, `visaSponsorshipNeeded`, `desiredSalary`, `noticePeriod`,
+      `willingToRelocate`, `age18OrOlder` entries to `FIELD_SYNONYMS` in `extension/lib/form.ts`
+      with real-world ATS phrasings for each
+- [x] 2.2 Confirm the boolean "are you authorized to work" phrasing is not matched to
+      `authorizedCountries` (semantic mismatch: boolean question, list-shaped answer)
+- [x] 2.3 Fix (found by review): `authorized_countries` arrives as comma-joined ISO codes
+      ("US, DE"), but the checkbox-group questions it answers offer full country names
+      ("United States") as options, and `chosenOptions` matches option-by-option — so raw
+      codes never matched and the group silently stayed unchecked. Added
+      `formatAuthorizedCountries` (`extension/lib/form.ts`, using `countryLabel` from
+      `extension/lib/labels.ts`) and wired it into `profileToValues()`.
+
+## 3. Tests and verification
+
+- [x] 3.1 Add `matchFieldKey` test coverage for the six new mappings in `extension/lib/form.test.ts`
+- [x] 3.2 Add a regression test asserting the plain work-authorization Yes/No question stays unmatched
+- [x] 3.3 Add unit tests for `formatAuthorizedCountries` and an end-to-end `fillByLabel` test
+      against a country checkbox group, covering the 2.3 fix
+- [x] 3.4 Run `npx vitest run` (230/230 passing)
+- [x] 3.5 Run `npm run check` (svelte-check, 0 errors)
+- [x] 3.6 Run `npx eslint` on touched files (clean)

--- a/openspec/specs/extension-autofill/spec.md
+++ b/openspec/specs/extension-autofill/spec.md
@@ -5,10 +5,12 @@
 The contact block the browser extension writes into application forms: which fields it
 carries, which sources answer for them and in what order, and what an absent source yields.
 
-It covers the candidate's identity only — name, address, phone, place and links. The
-substance of an application (summary, work history, skills) is not here, and neither is the
-CV file itself: the extension has no upload primitive, so the document is downloaded by
-hand from the CV surface.
+It covers the candidate's identity — name, address, phone, place and links — plus their own
+screening answers (authorized countries, visa sponsorship, desired salary, notice period,
+willingness to relocate, 18+), which ride alongside the identity fields without a
+multi-source precedence of their own. The substance of an application (summary, work
+history, skills) is not here, and neither is the CV file itself: the extension has no upload
+primitive, so the document is downloaded by hand from the CV surface.
 
 Not to be confused with `cv-autofill`, which pre-fills the onboarding wizard and the profile
 form from an uploaded résumé.
@@ -136,4 +138,75 @@ migration breaks autofill when a user opens a form rather than when the project 
 - **WHEN** a column the autofill block reads is renamed in a migration and the queries are
   regenerated
 - **THEN** the project fails to build, rather than compiling and failing at request time
+
+### Requirement: The autofill profile also carries the candidate's screening answers
+
+The autofill profile block SHALL, in addition to the identity contact fields, carry the
+candidate's own screening answers (`internal/screeninganswers`): `authorized_countries`,
+`visa_sponsorship_needed`, `desired_salary`, `notice_period`, `willing_to_relocate` and
+`age_18_or_older`. A field the candidate has not stated SHALL be empty rather than guessed,
+on the same terms as an unstated identity field.
+
+These fields are independent of the identity contact block: there is exactly one
+screening-answers store, so there is no multi-source precedence to resolve for them the way
+there is for name/email/phone.
+
+#### Scenario: Screening answers ride alongside the identity fields
+
+- **WHEN** an authenticated caller reads the autofill profile and has stated their desired
+  salary and their willingness to relocate, but no other screening answer
+- **THEN** the response carries those two values and empty strings for the other four
+  screening fields, alongside whatever identity fields the CV/résumé/account state
+
+### Requirement: The deterministic fallback filler answers screening questions
+
+When the browser extension's deterministic fallback filler is in use — the path taken when
+the agent-driven autofill is unavailable — it SHALL recognize application-form questions
+asking about work-authorized countries, visa sponsorship, desired salary, notice period,
+willingness to relocate, and age (18+), and fill them from the caller's screening answers
+using the same label-matching mechanism it already uses for identity fields. A question the
+caller has not answered in their profile SHALL be left blank rather than filled with a
+guess, matching the existing rule for identity fields.
+
+A checkbox-group question naming several countries SHALL be answered by the country names
+its options carry, not by the raw ISO codes the profile states — the group's options are
+matched against the value option-by-option, so a code that names no option would leave the
+group unanswered even when the candidate has stated an answer.
+
+#### Scenario: A notice-period question is filled from the profile
+
+- **WHEN** the deterministic filler is planning fills for a form asking "What is your notice
+  period?" and the caller's screening answers state a 30-day notice period
+- **THEN** the plan fills that question with "30 days"
+
+#### Scenario: An unanswered screening question is left blank
+
+- **WHEN** the deterministic filler is planning fills for a form asking about desired salary
+  and the caller has not stated one
+- **THEN** the plan leaves that question unfilled
+
+#### Scenario: An authorized-countries checkbox group is filled by country name, not by code
+
+- **WHEN** a form asks "Which countries are you authorized to work in?" as a checkbox group
+  offering full country names, and the caller's screening answers state authorization in the
+  US and Germany
+- **THEN** the plan checks the "United States" and "Germany" options, not a literal "US, DE"
+  that would match neither
+
+### Requirement: A boolean work-authorization question is not answered from the country list
+
+A plain Yes/No "are you authorized to work [here]?" question SHALL NOT be matched to the
+authorized-countries screening answer. That answer is a list of country codes, not a
+boolean, and the profile carries no boolean field stating plain work authorization — filling
+the question would put the wrong shape of value into a Yes/No control.
+
+This does not apply to a question that itself asks *which* countries the candidate is
+authorized to work in (a list question), which the previous requirement covers.
+
+#### Scenario: A boolean work-authorization question stays unmatched
+
+- **WHEN** an application form asks "Are you authorized to work in this country?" as a
+  Yes/No question
+- **THEN** the deterministic filler does not match it to any screening answer and leaves it
+  for the caller
 


### PR DESCRIPTION
## Summary
- Splits the side panel into **Match** / **Chat** tabs — the chat transcript couldn't scroll before (a flex-item `min-height` bug pinned the composer off-screen); each tab now gets the full panel height.
- **Autofill** is now a large, prominent primary button on the Match tab (was a small button squeezed into the chat composer row).
- **Chat is now scoped to the job page/link**: the remembered conversation is tagged with the page it was started on. Switching tabs clears the on-screen view but does *not* delete the old page's remembered session — tabbing back to it resumes it. Only the explicit **Reset** button (now at the top of the Chat tab, replacing the old "New chat" button) and sign-out actually forget a conversation.
- Send/Stop are now circular icon buttons (matching the web app's assistant composer style — the web component itself is SvelteKit-only and can't be imported into the extension, so this mirrors it with the shared design-system `Button` primitive instead).
- Fixed two scoped-CSS misses: a `class` forwarded onto a child component's own root element doesn't inherit the parent's Svelte style scope, which silently dropped the tab strip's padding and (via `MatchCard`'s own redundant margin stacking on top of the panel's padding) made the Autofill button look inconsistently inset next to the match card.
- Added a small freehire logo mark next to the header title.

## Test plan
- [x] `npx vitest run` — 230/230 passing
- [x] `npm run check` (svelte-check) — 0 errors
- [x] `npx eslint` on touched files — clean
- [x] Verified live in a real loaded-unpacked Chrome build (not just headless): tab switching, internal scroll with a long transcript (composer stays pinned), tab-strip/button padding measured via `getComputedStyle`/bounding rects to confirm the CSS-scoping fixes actually take effect.
- [ ] Live sign-in walkthrough (job-scoped chat resume across a real tab switch) — needs a real account; the requester is doing this pass manually against the built unpacked extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)