### PR TITLE
Trim the commentary on this week's performance work

### DIFF
--- a/internal/handler/facets.go
+++ b/internal/handler/facets.go
@@ -57,22 +57,17 @@ var facetsNoDistribution = map[string]bool{"company_slug": true}
 // request. This is the single source shared with the search filter vocabulary —
 // a new facet added to search.StringFacets is counted here automatically.
 //
-// `only` narrows the set to the named public params. Counting a distribution is
-// paid per attribute and the expensive ones are the wide-valued ones: measured on
-// prod against `?work_mode=remote`, the full set costs 284ms and returns 99KB,
-// dropping `cities` takes it to 233ms, dropping `skills` too 148ms, and a single
-// attribute is 10ms. A caller that reads one number off the result — the job
-// page's "see also" block reads exactly one per collection — should not pay for
-// the other twenty-six.
+// `only` narrows the set to the named public params. A distribution is counted
+// per attribute and the wide-valued ones (cities, skills) dominate — on prod the
+// full set costs 284ms against ?work_mode=remote versus 10ms for one attribute —
+// so a caller that reads a single key should not pay for the other twenty-six.
 func facetAttributes(only ...string) []string {
-	var want map[string]bool
-	if len(only) > 0 {
-		want = make(map[string]bool, len(only))
-		for _, p := range only {
-			want[p] = true
-		}
+	want := make(map[string]bool, len(only))
+	for _, p := range only {
+		want[p] = true
 	}
-	keep := func(param string) bool { return want == nil || want[param] }
+	// No names given ⇒ every param is wanted.
+	keep := func(param string) bool { return len(want) == 0 || want[param] }
 
 	attrs := make([]string, 0, len(search.StringFacets)+len(facetExtraParams))
 	for param, attr := range search.StringFacets {
@@ -91,33 +86,31 @@ func facetAttributes(only ...string) []string {
 	return attrs
 }
 
-// requestedFacets reads the optional `facets=` param: a comma-separated list of
-// public facet params to count, instead of all of them.
+// requestedFacets reads the optional `facets=`: a comma-separated list of public
+// facet params to count instead of all of them.
 //
-// An unknown name is an error rather than a silent no-op. The counts this
-// endpoint returns are read by key, so a typo would otherwise surface as a
-// missing count — indistinguishable from a value Meili's per-facet cap dropped,
-// which callers are expected to treat as "unknown" rather than as a bug.
-// company_slug is rejected for the same reason it is absent from the full set:
-// thousands of values, and the UI uses the typeahead instead.
+// An unknown name is an error, not a silent no-op. Callers read counts by key and
+// already treat a missing one as "Meili's per-facet cap dropped this value", so a
+// typo would hide indefinitely. company_slug is refused for the reason it is
+// absent from the full set: thousands of values, and the UI uses the typeahead.
 func requestedFacets(c *fiber.Ctx) ([]string, error) {
 	raw := c.Query("facets")
 	if raw == "" {
 		return nil, nil
 	}
-	params := strings.Split(raw, ",")
-	out := make([]string, 0, len(params))
-	for _, p := range params {
-		p = strings.TrimSpace(p)
-		if p == "" {
+	names := strings.Split(raw, ",")
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
 			continue
 		}
-		_, isString := search.StringFacets[p]
-		_, isExtra := facetExtraParams[p]
-		if (!isString && !isExtra) || facetsNoDistribution[p] {
-			return nil, fiber.NewError(fiber.StatusBadRequest, "unknown facet: "+p)
+		_, isString := search.StringFacets[name]
+		_, isExtra := facetExtraParams[name]
+		if (!isString && !isExtra) || facetsNoDistribution[name] {
+			return nil, fiber.NewError(fiber.StatusBadRequest, "unknown facet: "+name)
 		}
-		out = append(out, p)
+		out = append(out, name)
 	}
 	return out, nil
 }
@@ -203,10 +196,9 @@ func (h *searchHandlers) JobFacets(c *fiber.Ctx) error {
 		// selection, so a selected facet still shows its siblings (the live-modal
 		// experience). The total stays the full-filter count.
 		//
-		// `facets=` is refused here rather than ignored. Disjunctive counting
-		// derives one query per facet from the SELECTION, so narrowing the output
-		// set would not save the queries — the caller would pay full price for a
-		// partial answer, which is the opposite of what asking for it means.
+		// `facets=` is refused, not ignored: disjunctive derives one query per
+		// facet from the SELECTION, so narrowing the output saves none of them —
+		// full price for a partial answer.
 		if len(only) > 0 {
 			return fiber.NewError(fiber.StatusBadRequest, "facets= cannot be combined with disjunctive")
 		}

--- a/internal/handler/facets_test.go
+++ b/internal/handler/facets_test.go
@@ -252,10 +252,8 @@ func contains(ss []string, want string) bool {
 	return false
 }
 
-// `facets=` exists because counting is paid per attribute: on prod the full set
-// costs 284ms against ?work_mode=remote (the wide-valued cities/skills
-// distributions dominate) versus 10ms for a single one. The job page's "see
-// also" block reads one key per collection, so it names it.
+// Narrowing must map public params to index attributes and count nothing else —
+// that saving is the whole point of the param (see facetAttributes).
 func TestJobFacets_FacetsParamNarrowsTheRequest(t *testing.T) {
 	fake := &fakeFacetCounter{}
 	app := facetsApp(fake)
@@ -275,8 +273,8 @@ func TestJobFacets_FacetsParamNarrowsTheRequest(t *testing.T) {
 		}
 	}
 
-	// Narrowing the counted set must not narrow the FILTER — the counts still
-	// have to be "under ?work_mode=remote", or they answer a different question.
+	// Narrowing what is COUNTED must not narrow what it is counted UNDER, or the
+	// numbers answer a different question.
 	groups, ok := fake.got.Filter.([][]string)
 	if !ok {
 		t.Fatalf("Filter = %#v, want [][]string", fake.got.Filter)
@@ -287,8 +285,7 @@ func TestJobFacets_FacetsParamNarrowsTheRequest(t *testing.T) {
 }
 
 // A typo must not read as "that value has no count": callers cannot tell a
-// missing key from a value Meili's per-facet cap dropped, so silence would hide
-// the mistake indefinitely.
+// missing key from one Meili's per-facet cap dropped, so silence would hide it.
 func TestJobFacets_UnknownFacetIsRejected(t *testing.T) {
 	for _, name := range []string{"nonsense", "company_slug"} {
 		fake := &fakeFacetCounter{}
@@ -303,9 +300,8 @@ func TestJobFacets_UnknownFacetIsRejected(t *testing.T) {
 	}
 }
 
-// Disjunctive counting derives one query per facet from the SELECTION, so a
-// narrowed output set would not save any of them — the caller would pay full
-// price for a partial answer. Refuse rather than silently ignore.
+// Disjunctive derives its queries from the selection, so narrowing the output
+// saves none of them. Refuse rather than silently ignore.
 func TestJobFacets_FacetsParamRejectedWithDisjunctive(t *testing.T) {
 	fake := &fakeFacetCounter{}
 	app := facetsApp(fake)

--- a/perf/k6/config.js
+++ b/perf/k6/config.js
@@ -39,12 +39,10 @@ if (!IS_LOCAL && env('ALLOW_NONLOCAL', '') !== '1') {
   );
 }
 
-// Think-time (seconds) between page views. Models a real user reading a page
-// rather than machine-gunning the origin, and — crucially — stops a VU from
-// tight-looping into a request storm when a target starts failing fast.
-// Under an arrival-rate executor the pacing is the scenario's job, and a sleep
-// only inflates iteration duration (and so the VU count needed to sustain the
-// rate). Hence the 0 default there; the closed-model profiles keep the 1s.
+// Think-time (seconds) between page views. Models a real user reading a page,
+// and stops a VU tight-looping into a request storm when a target fails fast.
+// Zero under an arrival-rate executor, where pacing is the scenario's job and a
+// sleep only inflates the VU count needed to sustain the rate.
 export const THINK = Number(env('THINK', env('PROFILE', 'smoke') === 'saturation' ? 0 : 1));
 
 export const PROFILE = env('PROFILE', 'smoke');
@@ -54,23 +52,19 @@ if (!IS_LOCAL && PROFILE === 'load' && env('FORCE_LOAD', '') !== '1') {
   throw new Error(`PROFILE=load against a non-local origin needs FORCE_LOAD=1 (this stresses live infra).`);
 }
 
-// 'saturation' answers a question the other two profiles structurally cannot:
-// how many requests per second does this deployment accept before it stops
-// keeping up? `load` uses ramping-vus, where a VU waits for its response before
-// issuing the next one — so a slowing target quietly slows the test with it, and
-// the run converges on whatever the server can serve instead of overrunning it.
-// The 2026-08-14 incident was the opposite shape: arrivals outran accepts until
-// the kernel's accept queue filled and dropped SYNs. Reproducing that needs an
-// OPEN model, where the rate is imposed regardless of how the target is coping.
+// 'saturation' answers what the other profiles structurally cannot: how many
+// requests per second does this deployment accept before it stops keeping up?
+// `load` is a CLOSED model — a VU waits for its response before sending the next,
+// so a slowing target slows the test with it and the run converges on whatever
+// the server can serve. It cannot overrun anything, which is the failure being
+// reproduced: arrivals outrunning accepts until the kernel drops SYNs.
 //
-// Steps, not a ramp: each step is its own constant-arrival-rate scenario tagged
-// with its rate, so the summary carries a clean per-rate p95 and error rate and
-// the breaking point is a specific number rather than a slope to eyeball.
+// Steps rather than a ramp, each tagged with its rate, so the breaking point is a
+// number in the summary instead of a slope to eyeball.
 //
-// Its own latch, and no localhost exemption. The other latches key off IS_LOCAL,
-// which is exactly wrong here — the intended target IS a localhost port on the
-// prod host (the idle blue/green colour), where the danger is real: the idle
-// colour shares CPU, page cache and Postgres with the live one.
+// Its own latch, with no localhost exemption: the intended target IS a localhost
+// port on the prod host (the idle colour), which shares CPU, page cache and
+// Postgres with the live one.
 export const SATURATION_STEPS = env('SATURATION_STEPS', '25,50,100,200,400')
   .split(',')
   .map((s) => Number(s.trim()))
@@ -86,11 +80,11 @@ if (PROFILE === 'saturation') {
   if (SATURATION_STEPS.length === 0) throw new Error(`SATURATION_STEPS parsed to nothing`);
 }
 
-// Global request-rate ceiling. Off-local we default to a gentle cap so a smoke
-// against prod stays polite regardless of VU count; local defaults to unlimited.
-// Saturation defaults to no ceiling whatever the origin: a global cap would clamp
-// the very rate the profile exists to impose, and the run would report the cap as
-// the target's capacity. Its own FORCE_SATURATION latch is the safety here.
+// Global request-rate ceiling. Off-local defaults to a gentle cap so a smoke
+// against prod stays polite; local is unlimited. Saturation is uncapped whatever
+// the origin — a ceiling would clamp the rate the profile exists to impose, and
+// the run would report the cap as the target's capacity. FORCE_SATURATION is the
+// safety there.
 export const MAX_RPS = Number(env('MAX_RPS', PROFILE === 'saturation' || IS_LOCAL ? 0 : 20));
 
 // Identifies suite traffic in access logs / analytics so it's separable from
@@ -158,21 +152,19 @@ const P95 = {
 };
 
 export function thresholds() {
-  // The saturation profile is a measurement, not a gate: every step past the
-  // capacity ceiling is SUPPOSED to fail, and a red threshold there would say
-  // nothing. What it needs instead is a per-step breakdown in the summary — and
-  // k6 only prints a sub-metric that some threshold references. So each step
-  // gets a deliberately unfailable threshold whose only job is to make k6 report
-  // that step's p95 and error rate. Read the numbers; ignore the pass/fail.
+  // Saturation is a measurement, not a gate: every step past the ceiling is
+  // SUPPOSED to fail. It needs a per-step breakdown instead, and k6 only prints a
+  // sub-metric some threshold references — hence these unfailable thresholds.
+  // Read the numbers, ignore the pass/fail.
   if (PROFILE === 'saturation') {
     const t = {};
     for (const rate of SATURATION_STEPS) {
       t[`http_req_duration{step:${rate}}`] = ['p(95)>=0'];
       t[`http_req_failed{step:${rate}}`] = ['rate<=1'];
     }
-    // Iterations k6 could not start because no VU was free: the load generator
-    // itself fell behind, so numbers above this point describe the test, not the
-    // target. Non-zero here invalidates the step — raise preAllocatedVUs and rerun.
+    // Iterations k6 could not start for want of a free VU: the generator itself
+    // fell behind, so those numbers describe the test, not the target. Non-zero
+    // invalidates the step — raise preAllocatedVUs and rerun.
     t['dropped_iterations'] = [{ threshold: 'count<1', abortOnFail: false }];
     return t;
   }
@@ -203,10 +195,8 @@ export function buildScenarios() {
   if (PROFILE === 'saturation') {
     let start = 0;
     for (const rate of SATURATION_STEPS) {
-      // Headroom for slow iterations: at the ceiling, responses stretch, each
-      // iteration occupies its VU longer, and too few VUs makes k6 miss the rate
-      // and blame the target for the test's own shortfall. 4x the naive
-      // rate x 1s estimate, floored, has covered every observed stretch.
+      // Headroom: at the ceiling each iteration holds its VU longer, and too few
+      // VUs makes k6 miss the rate and blame the target for its own shortfall.
       const preAllocatedVUs = Math.max(50, rate * 4);
       scenarios[`saturation_${rate}rps`] = {
         executor: 'constant-arrival-rate',

--- a/perf/k6/helpers.js
+++ b/perf/k6/helpers.js
@@ -60,12 +60,10 @@ export function resolveSession() {
 // scenario is never hardcoded/brittle. It prefers a company with open jobs so
 // the streamed job list actually does work (the interesting latency path).
 export function pickCompanySlug() {
-  // An explicit slug skips the lookup entirely. That matters when the target is
-  // an SSR process addressed directly (http://127.0.0.1:<port>, the idle colour
-  // during a capacity run) rather than an origin that fronts both SSR and /api:
-  // the lookup 404s there, and the company-card scenario would then be silently
-  // skipped — quietly dropping the heaviest page from a capacity measurement and
-  // overstating the ceiling.
+  // An explicit slug skips the lookup, which 404s when the target is an SSR
+  // process addressed directly by port (the idle colour during a capacity run)
+  // rather than an origin fronting both SSR and /api. Without it the heaviest
+  // page is silently skipped and the measured ceiling comes out too high.
   if (COMPANY_SLUG) return COMPANY_SLUG;
 
   let res;

--- a/perf/k6/pages.js
+++ b/perf/k6/pages.js
@@ -34,11 +34,9 @@ export function setup() {
 export function run(data) {
   const name = exec.scenario.name;
 
-  // saturation scenarios are named by rate, not by page: the profile measures how
-  // many requests per second the deployment accepts, and pinning that to one page
-  // would measure that page's render cost instead. Each iteration picks a page in
-  // round-robin so the mix stays even and reproducible — a random pick would make
-  // two runs incomparable, which defeats a before/after capacity test.
+  // Saturation scenarios are named by rate, not by page: pinning the run to one
+  // page would measure that page's render cost rather than the deployment's
+  // ceiling. Round-robin rather than random, so two runs stay comparable.
   if (name.startsWith('saturation_')) {
     const keys = Object.keys(PAGES);
     const page = keys[exec.scenario.iterationInTest % keys.length];

--- a/web/cluster.js
+++ b/web/cluster.js
@@ -1,19 +1,15 @@
 // Production entry point: runs the adapter-node server across several processes.
 //
-// `build/index.js` is a single Node process, and Node is single-threaded, so the
-// SSR tier used one of host-2's sixteen cores however busy the box got. Measured
-// on the idle blue/green colour with `perf/k6` at PROFILE=saturation: one process
-// holds ~130 req/s, and past that p95 goes from half a second to twenty-five;
-// four processes hold ~250. The 2026-08-14 peak was 204 req/s, which is why the
-// accept queue kept filling and the watchdog kept restarting the process.
+// `build/index.js` alone is one Node process, and Node is single-threaded, so the
+// SSR tier used one of host-2's sixteen cores however busy the box got — measured
+// with `perf/k6` at PROFILE=saturation, ~130 req/s against a 204 req/s peak. That
+// is what kept filling the accept queue. The workers share one listening socket,
+// so the port, the systemd unit and the blue/green layout are unchanged.
 //
-// cluster forks workers that share one listening socket — the primary accepts and
-// hands connections out — so the port, the systemd unit and the blue/green layout
-// are unchanged. Each worker is a full copy of the server (~370 MB resident), and
-// that memory comes out of the page cache Meilisearch depends on, which is why the
-// default is four rather than one-per-core: eight measured WORSE at 200 req/s
-// (0.87 s vs 0.50 s p95) because the extra workers compete with ingest, Meili and
-// Postgres for the same sixteen cores.
+// Four, not one-per-core: each worker is a full copy of the server (~370 MB), the
+// memory comes out of the page cache Meilisearch lives on, and eight measured
+// WORSE at 200 req/s — they compete with ingest, Meili and Postgres for the same
+// cores.
 import cluster from 'node:cluster';
 
 const workers = Number(process.env.WEB_CLUSTER_WORKERS || 4);
@@ -26,9 +22,8 @@ if (workers <= 1) {
   console.log(`cluster primary ${process.pid}: forking ${workers} workers`);
   for (let i = 0; i < workers; i++) cluster.fork();
 
-  // A worker that dies takes its in-flight requests with it. Replacing it keeps
-  // capacity flat instead of silently decaying towards a single process — which
-  // would look exactly like the problem this file exists to fix.
+  // Replace a dead worker, or capacity decays back towards the single process
+  // this file exists to get away from.
   cluster.on('exit', (worker, code, signal) => {
     console.log(`worker ${worker.process.pid} exited (${signal || code}) — forking a replacement`);
     cluster.fork();

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -461,11 +461,10 @@ export function createApi(
    *  Empty `facets`/`stats` are normalized to `{}` so callers never see null. */
   // `disjunctive` asks the endpoint to count each facet under the filter minus its
   // own selection (so a selected facet still shows its siblings) — the live-modal mode.
-  /** `facets` narrows the count to the named facet params. Counting is paid per
-   *  facet and the wide-valued ones (cities, skills) dominate — the full default
-   *  set measured 284ms on prod versus 10ms for one attribute — so a caller that
-   *  reads a specific key should name it. Cannot be combined with `disjunctive`,
-   *  which derives its queries from the selection rather than from this list. */
+  /** `facets` narrows the count to the named params. Counting is paid per facet
+   *  and the wide-valued ones (cities, skills) dominate, so a caller that reads a
+   *  specific key should name it. Cannot be combined with `disjunctive`, which
+   *  derives its queries from the selection rather than from this list. */
   async function facetCounts(
     params: URLSearchParams,
     opts?: { disjunctive?: boolean; facets?: string[] }

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -53,14 +53,10 @@ const TIME_UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
   ['second', 1],
 ];
 
-// Built once, not per call. Constructing an Intl formatter resolves a locale and
-// loads its data, which dwarfs the cost of formatting with one — 12x on a
-// microbenchmark of the homepage's 32 cards (0.30ms -> 0.03ms per render). That
-// is ~1% of a 29ms render, so this is tidiness rather than a fix for anything:
-// the profile that surfaced it (timeAgo was second among our own functions) also
-// showed the render cost is spread across the page, not concentrated anywhere.
-// The locale is `undefined` — the runtime default — and it does not change within
-// a process or a browser session, so one instance is safe to reuse.
+// Built once: constructing an Intl formatter resolves a locale and loads its
+// data, which dwarfs formatting with one — and the feed calls timeAgo per job
+// card. The locale is the runtime default, which cannot change within a process
+// or a browser session, so one instance is safe to share.
 let relativeTime: Intl.RelativeTimeFormat | undefined;
 
 /** Format an RFC3339 timestamp as a relative "N ago" label (e.g. "13 seconds

--- a/web/src/routes/+layout.server.ts
+++ b/web/src/routes/+layout.server.ts
@@ -2,9 +2,8 @@ import { ApiError } from '$lib/api';
 import { serverApi } from '$lib/server/api';
 import type { LayoutServerLoad } from './$types';
 
-// The session cookie's name. The API owns it (internal/auth/cookie.go,
-// `CookieName`) and it is httpOnly, so the SPA never reads its value — but the
-// layout does need to know whether one is present at all; see below.
+// The API owns this cookie (internal/auth/cookie.go, `CookieName`). It is
+// httpOnly, so the SPA never reads its value — only whether it is there at all.
 const SESSION_COOKIE = 'hire_token';
 
 // Resolve the current user once per full load, forwarding the request's session
@@ -13,14 +12,10 @@ const SESSION_COOKIE = 'hire_token';
 // after login/logout. A missing/expired session is simply signed out — never an
 // error page.
 //
-// A request carrying no session cookie skips the call. Without this, every
-// anonymous page load spent a round trip asking the API who the visitor is, only
-// to be told 401 and render signed-out chrome anyway — measured at 7.7ms of a
-// ~74ms homepage response on prod, where anonymous traffic is the large majority
-// (crawlers alone were 83% of requests). Testing for this cookie specifically,
-// rather than for any cookie, is deliberate: analytics sets its own cookies on
-// first-time visitors, so "has cookies" is true for nearly everyone and would
-// skip nothing.
+// A request with no session cookie skips the call: it would 401 and render
+// signed-out chrome anyway, and anonymous traffic is most of ours. Testing for
+// THIS cookie rather than for any cookie is the point — analytics sets its own
+// on first-time visitors, so "has cookies" is true for nearly everyone.
 export const load: LayoutServerLoad = async ({ fetch, request }) => {
   const cookie = request.headers.get('cookie');
   if (!cookie?.includes(`${SESSION_COOKIE}=`)) return { user: null };

--- a/web/src/routes/jobs/[slug]/+page.server.ts
+++ b/web/src/routes/jobs/[slug]/+page.server.ts
@@ -53,12 +53,9 @@ async function buildSeeAlso(job: Job, api: Api): Promise<SeeAlsoCard[]> {
   const links = relatedCollectionLinks(jobFacetsFromJob(job));
   const resolvedLinks = links.map((link) => ({ link, resolved: collectionBySlug(link.slug) }));
 
-  // Each group is one facetCounts() call, and every card in it reads exactly one
-  // key off the result — so ask for only the keys this group will read. The
-  // endpoint counts every facet by default, and that default is expensive:
-  // measured on prod, the full set costs 284ms against ?work_mode=remote (the
-  // wide-valued cities/skills distributions dominate) versus 10ms for a single
-  // attribute. This block was ~99% of the job page's render time because of it.
+  // Each group is one facetCounts() call and each of its cards reads exactly one
+  // key off the result, so ask for only those keys. Counting every facet — the
+  // endpoint's default — was ~99% of this page's render time.
   const filterGroups = new Map<string, { filter: Record<string, string>; keys: Set<string> }>();
   for (const { resolved } of resolvedLinks) {
     if (!resolved) continue;


### PR DESCRIPTION
A quality pass over the code changed while chasing the SSR capacity ceiling (#1932, #1933, #1935, #1938). **No behaviour changes** — same tests, same output.

The comments had grown into write-ups: the same measurements restated in the handler, the test, the API client and the page that calls it. Each comment now explains why the code is shaped the way it is and stops. The numbers that justified the shape stay in those PRs, where they will not go stale the next time the numbers move.

44 net lines of comment removed across 10 files.

One small code change, in `facetAttributes`: the `only` set no longer needs a nil-vs-empty distinction, because an empty set already means "keep everything" — so the `var`/`if len(only) > 0` preamble collapses into the map build.

## Test plan

- [x] `gofmt`, `go vet`, `go test ./internal/handler/` — green
- [x] eslint on every changed web file
- [x] `k6 inspect` — the saturation scenarios still build
- [x] `node --check web/cluster.js`