### PR TITLE
Add the webcredentials association for the mobile OAuth callback

### DIFF
--- a/web/static/.well-known/apple-app-site-association
+++ b/web/static/.well-known/apple-app-site-association
@@ -10,5 +10,8 @@
         ]
       }
     ]
+  },
+  "webcredentials": {
+    "apps": ["25U9HN34VM.me.freehire.mobile"]
   }
 }


### PR DESCRIPTION
Follow-up to #1936, found by running the flow on a device.

Tapping "Continue with Google" in the mobile app did nothing: the browser opened and died immediately. The simulator log said exactly why:

```
Error Domain=com.apple.AuthenticationServices.WebAuthenticationSession Code=1
Application with identifier me.freehire.mobile is not associated with domain freehire.me.
Using HTTPS callbacks requires Associated Domains using the `webcredentials`
service type for freehire.me.
```

`ASWebAuthenticationSession` will not accept an HTTPS callback on the strength of `applinks` alone — the domain has to vouch for the app under `webcredentials` as well. The two service types do different jobs: `applinks` decides which *paths* open the app, `webcredentials` decides whether the app may terminate an auth session on this domain at all.

So the file gains a `webcredentials` section naming the same app id. Paths stay where they are, under `applinks`.

The app declares both service types in its own entitlement (`freehire-mobile`, separate commit).

## Verification

The JSON parses and keeps both sections. The handoff itself only becomes testable once this is deployed — Apple fetches the file per install, so the device needs a reinstall against the updated file. That check is the reason this bug surfaced at all, and it stays on the release path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apple web credentials association for the mobile app.
  * Retained existing universal link support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->