### PR TITLE
fix(web): stop keying inert lists by text we do not control

### DIFF
--- a/web/src/lib/components/JobApplyForm.svelte
+++ b/web/src/lib/components/JobApplyForm.svelte
@@ -32,8 +32,14 @@
       <!-- The hint follows the question rather than being pinned to the right edge. On a
            wide viewport that pinning left ~900px of empty space between a question and the
            word describing its answer, which is a long way to travel to read one line. -->
+      <!-- Keyed on index, not on the question text. The text is the employer's, verbatim, and
+           real ATS forms repeat it — Greenhouse and Workable both publish the same screening
+           question twice on some postings. A duplicate key throws each_key_duplicate during
+           Svelte 5 hydration rather than warning, which took the whole job page down. The list
+           is inert (replaced wholesale when `form` changes, never reordered or filtered), so
+           position is a sound identity here. -->
       <ul class="flex max-w-3xl flex-col gap-2">
-        {#each form.questions as question (question.text)}
+        {#each form.questions as question, i (i)}
           <li class="text-sm">
             <span>{question.text}</span>
             {#if question.answer || !question.required}

--- a/web/src/routes/talent-network/[publicId]/+page.svelte
+++ b/web/src/routes/talent-network/[publicId]/+page.svelte
@@ -229,15 +229,18 @@
                     <p class="text-sm leading-relaxed">{job.summary}</p>
                   {/if}
                   {#if job.highlights?.length}
+                    <!-- Index-keyed, like the enclosing list and for the same reason: these come
+                         straight out of the résumé parser, which has no uniqueness contract —
+                         a CV that repeats a bullet verbatim would throw each_key_duplicate. -->
                     <ul class="mt-1 flex list-disc flex-col gap-0.5 pl-4 text-sm leading-relaxed">
-                      {#each job.highlights as highlight (highlight)}
+                      {#each job.highlights as highlight, hi (hi)}
                         <li>{highlight}</li>
                       {/each}
                     </ul>
                   {/if}
                   {#if job.stack?.length}
                     <div class="mt-1 flex flex-wrap gap-1.5">
-                      {#each job.stack as tech (tech)}
+                      {#each job.stack as tech, ti (ti)}
                         <span class="rounded-full border border-border bg-secondary px-2 py-0.5 text-xs"
                           >{tech}</span
                         >
@@ -278,7 +281,10 @@
         <section class="flex flex-col gap-3">
           <h2 class="flex items-center gap-2 text-sm font-semibold"><FolderKanban class="size-4" />Projects</h2>
           <ul class="flex flex-col gap-2">
-            {#each projects as project (project.name ?? project.link ?? '')}
+            <!-- Index-keyed: the previous key fell back to `''` when a project had neither a
+                 name nor a link, so two such projects collided outright — and two projects
+                 sharing a name (a parser reading "Internal tools" twice) collided too. -->
+            {#each projects as project, pi (pi)}
               <li class="flex flex-col gap-1 rounded-xl border border-border bg-card p-4">
                 {#if project.link}
                   <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- a project's own portfolio/repo link, not an internal route -->
@@ -288,7 +294,7 @@
                 {/if}
                 {#if project.highlights?.length}
                   <ul class="flex list-disc flex-col gap-0.5 pl-4 text-sm leading-relaxed">
-                    {#each project.highlights as highlight (highlight)}
+                    {#each project.highlights as highlight, phi (phi)}
                       <li>{highlight}</li>
                     {/each}
                   </ul>
@@ -303,7 +309,9 @@
         <section class="flex flex-col gap-2">
           <h2 class="flex items-center gap-2 text-sm font-semibold"><Languages class="size-4" />Languages</h2>
           <div class="flex flex-wrap gap-2">
-            {#each languages as lang (lang)}
+            <!-- Index-keyed for the same reason as the lists above: résumé-parsed free text
+                 carries no uniqueness guarantee. -->
+            {#each languages as lang, li (li)}
               <span class="rounded-full border border-border bg-secondary px-3 py-1 text-xs">{lang}</span>
             {/each}
           </div>
@@ -314,7 +322,7 @@
         <section class="flex flex-col gap-2">
           <h2 class="flex items-center gap-2 text-sm font-semibold"><Award class="size-4" />Certifications</h2>
           <div class="flex flex-wrap gap-2">
-            {#each certifications as cert (cert)}
+            {#each certifications as cert, ci (ci)}
               <span class="rounded-full border border-border bg-secondary px-3 py-1 text-xs">{cert}</span>
             {/each}
           </div>


### PR DESCRIPTION
## What

A keyed `{#each}` whose key repeats makes Svelte 5 **throw** `each_key_duplicate` rather than warn, so the whole page stops hydrating. Two lists were keyed by free text supplied by someone else, and both repeat in production.

## The job page (the loud one)

`JobApplyForm` keyed the application form's questions by the question text. ATS forms genuinely publish the same screening question twice:

| posting | provider | repeated question |
|---|---|---|
| `facade-engineer-architect-jensen-hughes-6ogltrcd` | workable | "Do you have any relatives or close personal relationships with current employees of Jensen Hughes?" |
| `staff-backend-engineer-second-horizon-us-remote-grafana-labs-am7hwqfu` | greenhouse | "How did you hear about this opportunity at Grafana?" |

Sentry `TG-CATALOG-56` + `TG-CATALOG-62`: **531 events since 3 August**, the single loudest frontend issue.

## The talent-network profile page

Six lists keyed by résumé-parser output, which carries no uniqueness contract. The projects key was the worst — it fell back to `''` when a project had neither a name nor a link, so two such projects collided outright. That page had already learned this lesson for `experience` and `skillChips` (both carry comments explaining it); this finishes the job.

## Fix

Index keys, matching the precedent already in that file. None of these lists reorder or filter — each is replaced wholesale when its source changes — so position is a sound identity, and `svelte/require-each-key` still passes.

## Verification

Headless Chrome against the same job page, live prod vs. this branch:

| | uncaught errors | sections rendered |
|---|---|---|
| prod (`544b6820`) | 1 × `each_key_duplicate` | **0** |
| this branch | 0 | 3 |

The repeated question now renders twice, as the employer wrote it. Also: `svelte-check` 0 errors, `eslint` + `oxlint` clean, 964 unit tests pass.