### PR TITLE
Associate the development signing team too

### DIFF
--- a/web/static/.well-known/apple-app-site-association
+++ b/web/static/.well-known/apple-app-site-association
@@ -3,7 +3,7 @@
     "apps": [],
     "details": [
       {
-        "appIDs": ["25U9HN34VM.me.freehire.mobile"],
+        "appIDs": ["25U9HN34VM.me.freehire.mobile", "WYHG3T94Q4.me.freehire.mobile"],
         "components": [
           { "/": "/jobs/*" },
           { "/": "/auth/mobile-callback*" }
@@ -12,6 +12,6 @@
     ]
   },
   "webcredentials": {
-    "apps": ["25U9HN34VM.me.freehire.mobile"]
+    "apps": ["25U9HN34VM.me.freehire.mobile", "WYHG3T94Q4.me.freehire.mobile"]
   }
 }


### PR DESCRIPTION
Third and last piece of the mobile OAuth return leg (after #1936 and #1942), found by running the flow in the simulator.

The association named only the EAS team, `25U9HN34VM`. A build produced by Xcode or `expo run:ios` is signed with the personal team `WYHG3T94Q4`, so the OS refused it — `swcd` matched the domain, found no entry for that app id, and the auth session died with:

```
Application with identifier me.freehire.mobile is not associated with domain freehire.me
```

Both teams own the same bundle id and both are ours, so the file now lists both. Exact app ids, no wildcard — a local development build can finish the OAuth return, and nothing else gains access.

Together with the two earlier PRs the return leg is complete: the path is claimed, `webcredentials` is present, nginx serves the file as `application/json` (that fix lives in freehire-ops), and both signing identities are recognised.