### PR TITLE
Fix Dockerfile: drop stale cmd/backfill-company-info reference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/hire ./cmd/server
  && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/ \
       ./cmd/ingest ./cmd/enrich ./cmd/reindex ./cmd/tg-ingest ./cmd/tg-extract \
       ./cmd/backfill-derive ./cmd/liveness ./cmd/notify ./cmd/import-collections \
-      ./cmd/recount-companies ./cmd/migrate ./cmd/backfill-company-info
+      ./cmd/recount-companies ./cmd/migrate
 
 # --- typst stage: fetch the pinned, statically-linked typst binary used to render CV
 # PDFs (internal/cv). The musl build is fully static, so it runs on distroless/static;
@@ -48,7 +48,7 @@ RUN apt-get update \
  && groupadd --system --gid 65532 nonroot \
  && useradd --system --uid 65532 --gid nonroot --home-dir /app nonroot \
  && pdftotext -v
-COPY --from=build /out/hire /out/ingest /out/enrich /out/reindex /out/tg-ingest /out/tg-extract /out/backfill-derive /out/liveness /out/notify /out/import-collections /out/recount-companies /out/migrate /out/backfill-company-info /app/
+COPY --from=build /out/hire /out/ingest /out/enrich /out/reindex /out/tg-ingest /out/tg-extract /out/backfill-derive /out/liveness /out/notify /out/import-collections /out/recount-companies /out/migrate /app/
 # The migration runner reads its *.sql files from the image (WORKDIR /app, default
 # -dir migrations), so /app/migrate works the same as `go run ./cmd/migrate` on the host.
 COPY --from=build /src/migrations /app/migrations


### PR DESCRIPTION
## Summary
- `main` is currently broken: #1945 removed `cmd/backfill-company-info` (and other retired one-time backfill workers) but the Dockerfile's multi-binary build still referenced it, so the image build fails (`stat /src/cmd/backfill-company-info: directory not found`) — breaking `pr-smoke` on every open PR and blocking prod deploys via `release.sh`.
- Drops the two stale `backfill-company-info` mentions from the build `RUN` and the final-stage `COPY`.

## Test plan
- [x] `go build ./...`
- [x] `docker build --target build .` — now completes; previously failed at the same step CI hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)