### PR TITLE
Detect Polish English-level requirements in EnglishLevel

### DIFF
--- a/internal/jobfacts/jobfacts.go
+++ b/internal/jobfacts/jobfacts.go
@@ -162,30 +162,39 @@ func ExperienceYearsMin(description string) *int {
 }
 
 // English-level detection. Precision-first like the matchers above: it resolves an
-// explicit CEFR code or a well-known level phrase (EN + RU, since the Telegram
-// sources are Russian-heavy) and emits "" when nothing is stated. Every signal must
-// sit near an English keyword, so a bare "B2"/"advanced"/"native" is not misread out
-// of context ("B2B SaaS", "advanced degree", "native macOS app"). Values are members
-// of vocab.EnglishLevelValues.
+// explicit CEFR code or a well-known level phrase (EN + RU + PL — the Telegram
+// sources are Russian-heavy, and Polish boards like NoFluffJobs/JustJoinIT state the
+// requirement in Polish, e.g. "Angielski na poziomie min. B2+") and emits "" when
+// nothing is stated. Every signal must sit near an English keyword, so a bare
+// "B2"/"advanced"/"native" is not misread out of context ("B2B SaaS", "advanced
+// degree", "native macOS app"). Values are members of vocab.EnglishLevelValues.
 var (
 	// reEnglishKw gates the whole parse and anchors every phrase: english_level is
 	// about English, so a description that never names it yields nothing.
-	reEnglishKw = regexp.MustCompile(`english|английск`)
+	reEnglishKw = regexp.MustCompile(`english|английск|angielsk`)
 	// A CEFR code counts only adjacent (either order) to an English keyword.
 	reCEFRForward = regexp.MustCompile(`(?:english|английск\w*)[^.\n]{0,20}\b([abc][12])\b`)
 	reCEFRBack    = regexp.MustCompile(`\b([abc][12])\b[^.\n]{0,20}(?:english|английск\w*)`)
+	// Polish CEFR proximity tolerates one interior "." that the EN/RU gap above
+	// disallows: Polish postings near-universally phrase the requirement as "na
+	// poziomie min. B2" — the abbreviation dot in "min." would otherwise break the
+	// EN/RU-style no-period gap and hide an otherwise unambiguous, adjacent CEFR code.
+	reCEFRForwardPl = regexp.MustCompile(`angielsk\w*[^.\n]{0,20}\.?[^.\n]{0,10}\b([abc][12])\b`)
+	reCEFRBackPl    = regexp.MustCompile(`\b([abc][12])\b[^.\n]{0,10}\.?[^.\n]{0,20}angielsk\w*`)
 
 	// Level phrases (checked for English proximity via near). The intermediate family
 	// carries its prefix so "upper-intermediate"→b2 and "pre-intermediate"→a2 resolve
-	// without a lookbehind (RE2 has none); the Russian "средн" family mirrors it.
+	// without a lookbehind (RE2 has none); the Russian "средн" and Polish "średni"
+	// families mirror it via their own "above this level" prefix.
 	reNative     = regexp.MustCompile(`\bnative\b|родн\w*|носител\w*`)
-	reFluentAdv  = regexp.MustCompile(`fluen\w*|\badvanced\b|свободн\w*|продвинут\w*`)
+	reFluentAdv  = regexp.MustCompile(`fluen\w*|\badvanced\b|свободн\w*|продвинут\w*|biegł\w*|zaawansowan\w*`)
 	reInterFam   = regexp.MustCompile(`\b(upper[\s-]?|pre[\s-]?)?intermediate\b`)
 	reRuMidFam   = regexp.MustCompile(`(выше\s+)?средн\w*`)
-	reConvers    = regexp.MustCompile(`\bconversational\b|разговорн\w*`)
-	reElementary = regexp.MustCompile(`\belementary\b|\bbeginner\b|начальн\w*`)
-	reBasic      = regexp.MustCompile(`\bbasic\b|базов\w*`)
-	reNoEnglish  = regexp.MustCompile(`no english|english (?:is )?not required|without english|без английск\w*`)
+	rePlMidFam   = regexp.MustCompile(`(wyższy\s+)?średni\w*`)
+	reConvers    = regexp.MustCompile(`\bconversational\b|разговорн\w*|komunikatywn\w*`)
+	reElementary = regexp.MustCompile(`\belementary\b|\bbeginner\b|начальн\w*|początkując\w*`)
+	reBasic      = regexp.MustCompile(`\bbasic\b|базов\w*|podstawow\w*`)
+	reNoEnglish  = regexp.MustCompile(`no english|english (?:is )?not required|without english|без английск\w*|bez angielsk\w*`)
 )
 
 // englishRank orders the vocabulary lowest→highest so the minimum named level is
@@ -229,6 +238,12 @@ func EnglishLevel(description string) string {
 	for _, m := range reCEFRBack.FindAllStringSubmatch(s, -1) {
 		levels[m[1]] = true
 	}
+	for _, m := range reCEFRForwardPl.FindAllStringSubmatch(s, -1) {
+		levels[m[1]] = true
+	}
+	for _, m := range reCEFRBackPl.FindAllStringSubmatch(s, -1) {
+		levels[m[1]] = true
+	}
 	if near(s, kws, reNative) {
 		levels["native"] = true
 	}
@@ -264,6 +279,16 @@ func EnglishLevel(description string) string {
 			continue
 		}
 		if m[2] >= 0 { // "выше средн..." — above intermediate
+			levels["b2"] = true
+		} else {
+			levels["b1"] = true
+		}
+	}
+	for _, m := range rePlMidFam.FindAllStringSubmatchIndex(s, -1) {
+		if !spanNear(s, kws, m[0], m[1]) {
+			continue
+		}
+		if m[2] >= 0 { // "wyższy średni..." — upper-intermediate
 			levels["b2"] = true
 		} else {
 			levels["b1"] = true

--- a/internal/jobfacts/jobfacts_test.go
+++ b/internal/jobfacts/jobfacts_test.go
@@ -152,6 +152,17 @@ func TestEnglishLevel(t *testing.T) {
 		{"russian above-average -> b2", "Английский выше среднего.", "b2"},
 		{"russian average -> b1", "Английский на среднем уровне.", "b1"},
 		{"russian basic -> a2", "Базовый английский достаточно.", "a2"},
+		// Phrase levels (PL) — Polish boards (NoFluffJobs, JustJoinIT) state English
+		// requirements in Polish; "angielski" is Polish for "English".
+		{"polish cefr b2", "Angielski na poziomie min. B2+ -> międzynarodowa współpraca", "b2"},
+		{"polish fluent -> c1", "Biegły angielski jest wymagany.", "c1"},
+		{"polish advanced -> c1", "Zaawansowana znajomość języka angielskiego.", "c1"},
+		{"polish upper-intermediate -> b2", "Wyższy średniozaawansowany angielski.", "b2"},
+		{"polish intermediate -> b1", "Średniozaawansowany angielski wystarczy.", "b1"},
+		{"polish conversational -> b1", "Komunikatywny angielski.", "b1"},
+		{"polish beginner -> a1", "Początkujący angielski jest ok.", "a1"},
+		{"polish basic -> a2", "Podstawowa znajomość angielskiego.", "a2"},
+		{"polish no english -> none", "Bez angielskiego.", "none"},
 		// Minimum-of-several and explicit none.
 		{"range takes the floor", "English from intermediate to advanced.", "b1"},
 		{"explicit no english -> none", "No English required for this role.", "none"},


### PR DESCRIPTION
<!--
Do not open a PR unless a maintainer has approved you with `lgtm` on an issue.
PRs from unapproved contributors are auto-closed. Open an issue first.
-->

## What and why

<!-- What does this change do, and why does it matter? Link the approved issue. -->

Closes #

## Checklist

- [ ] I understand this code and can explain how it interacts with the rest of the system.
- [ ] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [ ] `go test ./...` passes (and `go test -tags=integration ./...` if I touched DB/handlers).
- [ ] I regenerated committed artifacts when their source changed (`make sqlc` for SQL/migrations, `make gen-contracts` for contract types).
- [ ] For `design-system/` changes: `pnpm run check` and `pnpm run build` pass.
- [ ] For `web/` changes: `pnpm run check` and `pnpm run build` pass.
- [ ] This stays within freehire's core/extension boundary (see CONTRIBUTING.md) — it does not bloat the core.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved English proficiency detection for Polish-language job postings.
  * Recognizes Polish terms for CEFR levels, fluency, advanced, intermediate, conversational, beginner, and basic proficiency.

* **Bug Fixes**
  * Improved handling of Polish CEFR phrases and varied wording to provide more accurate language-level extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->