### PR TITLE
Fix duplicate timezone key and drop injected-script noise from Sentry

### DIFF
--- a/web/src/hooks.client.ts
+++ b/web/src/hooks.client.ts
@@ -12,6 +12,13 @@ if (env.PUBLIC_SENTRY_DSN) {
     environment: env.PUBLIC_SENTRY_ENVIRONMENT || 'development',
     tracesSampleRate: 0,
     sendDefaultPii: false,
+    // A Safari extension reads our JSON-LD and throws on a block that carries no
+    // "@context" — inline, so the frame points at our own document and neither
+    // denyUrls nor the third-party filter sees it as foreign. Nothing on the
+    // client reads "@context" (seo.ts only serializes it server-side), so the
+    // key alone identifies the injected script. Errors-only on a 5k/month quota
+    // means noise like this is paid for in dropped real errors.
+    ignoreErrors: [/\[['"]@context['"]\]\.toLowerCase/],
   });
 }
 

--- a/web/src/lib/components/AccountTimezone.svelte
+++ b/web/src/lib/components/AccountTimezone.svelte
@@ -15,10 +15,14 @@
   // lists Area/Location names) even though it's a real IANA zone Go's
   // time.LoadLocation accepts — prepend it so a stored/detected "UTC" has a
   // matching <option>, since a <select> silently shows nothing selected
-  // otherwise.
+  // otherwise. Newer engines (Chrome 118+, Safari 17+) DO list "UTC", so the
+  // Set collapses the prepend into their entry rather than keying two
+  // identical <option>s off it.
   const ZONES: string[] = [
-    'UTC',
-    ...(typeof Intl.supportedValuesOf === 'function' ? Intl.supportedValuesOf('timeZone') : []),
+    ...new Set([
+      'UTC',
+      ...(typeof Intl.supportedValuesOf === 'function' ? Intl.supportedValuesOf('timeZone') : []),
+    ]),
   ];
 
   let detected = '';


### PR DESCRIPTION
Two client-side issues from the new `diffray/freehire-web` Sentry project.

### `each_key_duplicate` on the profile page (FREEHIRE-WEB-4)

`AccountTimezone` prepended `'UTC'` to `Intl.supportedValuesOf('timeZone')` because older engines omitted it. Chrome 118+ and Safari 17+ list it, so the option appeared twice and the keyed `{#each ZONES as zone (zone)}` threw — that section of the profile page broke for anyone on a current browser. Collapsed with a `Set`.

### Injected-script noise (FREEHIRE-WEB-3)

`TypeError: undefined is not an object (evaluating 'r["@context"].toLowerCase')` — a Safari extension reading our JSON-LD and hitting a block with no `@context`. It injects inline, so the frame points at `https://freehire.me/` and is flagged in-app; neither `denyUrls` nor the third-party filter treats it as foreign. Nothing on the client reads `@context` (`seo.ts` only serializes it server-side), so the key alone identifies the injected script.

Worth filtering rather than ignoring: the project is errors-only on a 5k/month quota, and dropped-by-quota is how real errors go missing.

### Verification

`eslint` clean on both files. No behaviour change beyond the two above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented Safari extension-related errors from appearing in error monitoring.
  - Removed duplicate `UTC` entries from account timezone selection lists.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->