### PR TITLE
Fix extension sign-in: "Authorization page could not be loaded"

### DIFF
--- a/internal/auth/AGENTS.md
+++ b/internal/auth/AGENTS.md
@@ -35,11 +35,10 @@ OAuth sign-in (`internal/auth/oauth/`) adds a provider registry (Google/GitHub/L
 ### Browser-extension connect flow
 
 The browser extension signs in with `chrome.identity.launchWebAuthFlow`, which
-opens `GET /api/v1/auth/extension/connect` **in the freehire origin** (so the
-session cookie is present) and waits for a redirect to
-`https://<extension-id>.chromiumapp.org/`. Handlers live in
-`internal/handler/extension_connect.go`, both **cookie-only (`RequireAuth`)** like
-key management — a leaked key must not mint further keys:
+opens `GET /api/v1/auth/extension/connect` **in the freehire origin** and waits for
+a redirect to `https://<extension-id>.chromiumapp.org/`. Handlers live in
+`internal/handler/extension_connect.go`, both **cookie-only** like key management —
+a leaked key must not mint further keys — but mounted on `optionalCookie`:
 
 - `GET` validates `redirect_uri` (`validateExtensionRedirect`: https +
   `<id>.chromiumapp.org` + `<id>` on the allowlist) and renders a consent page.
@@ -47,6 +46,17 @@ key management — a leaked key must not mint further keys:
   (`Issuer.Issue`) and 302s to `redirect_uri#token=…&state=…` — the token rides the
   **fragment**, never the query, so it is not logged or sent in `Referer`. Any
   other decision issues nothing and 302s `#error=access_denied`.
+
+**A sessionless visitor is sent to sign in, not refused.** Chrome's auth window
+does not share the browsing profile's cookie jar, so arriving with no session is
+the normal first run — and a 401 body there is what Chrome reports as
+*"Authorization page could not be loaded"*, with no way forward. Both handlers 302
+to the web app's `/extension/connect` page instead, carrying `redirect_uri` and
+`state`; that page signs the visitor in through the usual `?auth=required` dialog
+and hands the window back with `via=web`. That marker is the loop stop: back here
+with it and still no session, the endpoint answers a plain HTML "not signed in"
+page rather than bouncing again. `redirect_uri` is validated **before** the bounce,
+so a crafted target never rides a sign-in round trip.
 
 The redirect target is bounded by `EXTENSION_REDIRECT_ALLOWLIST` (comma-separated
 extension ids, parsed in `internal/config`); an empty allowlist disables the flow.

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -196,12 +196,16 @@ func (h *authHandlers) register(api fiber.Router, mw middleware) {
 	authGroup.Post("/oauth/exchange", h.OAuthExchange)
 
 	// Browser-extension sign-in ("Sign in with freehire"): the extension opens
-	// this in the freehire origin via launchWebAuthFlow. Cookie-only (RequireAuth)
-	// like key management — a leaked key must not mint further keys. GET shows the
+	// this in the freehire origin via launchWebAuthFlow. Cookie-only — a leaked key
+	// must not mint further keys — but on optionalCookie, like the OAuth callbacks,
+	// because these are browser navigations too: Chrome's auth window has its own
+	// cookie jar, so arriving with no session is the normal first run, and a 401
+	// body there is what it reports as "Authorization page could not be loaded".
+	// Each handler sends a sessionless visitor to sign in instead. GET shows the
 	// consent screen; POST issues a session JWT and redirects the token in the
 	// fragment. Both refuse any redirect outside the configured allowlist.
-	authGroup.Get("/extension/connect", mw.cookie, h.ExtensionConnect)
-	authGroup.Post("/extension/connect", mw.cookie, h.ExtensionConnectSubmit)
+	authGroup.Get("/extension/connect", mw.optionalCookie, h.ExtensionConnect)
+	authGroup.Post("/extension/connect", mw.optionalCookie, h.ExtensionConnectSubmit)
 }
 
 func (h *authHandlers) requireRecentAuth(c *fiber.Ctx) error {

--- a/internal/handler/extension_connect.go
+++ b/internal/handler/extension_connect.go
@@ -59,18 +59,38 @@ func redirectWithFragment(base string, vals url.Values) (string, error) {
 	return u.String() + "#" + vals.Encode(), nil
 }
 
+// signInURL is where an unauthenticated connect request is sent: the web app's own
+// /extension/connect page, which signs the visitor in and returns them here. The
+// extension's parameters ride along verbatim so nothing is lost across the round trip.
+func (h *authHandlers) signInURL(redirectURI, state string) string {
+	q := url.Values{"redirect_uri": {redirectURI}, "state": {state}}
+	return strings.TrimSuffix(h.frontendOrigin, "/") + "/extension/connect?" + q.Encode()
+}
+
 // ExtensionConnect renders the consent screen for the browser-extension sign-in.
-// Cookie-only (RequireAuth): a leaked API key must not drive it. It validates the
-// redirect target before showing anything, so an invalid redirect never reaches a
-// consent step.
+// Cookie-only: a leaked API key must not drive it. It validates the redirect target
+// before showing anything, so an invalid redirect never reaches a consent step — nor
+// gets carried through a sign-in round trip.
+//
+// A signed-out visitor is sent to sign in rather than refused. The extension opens
+// this in Chrome's auth window, whose cookie jar is not the browsing profile's, so
+// arriving without a session is the NORMAL first run — and a 401 body there is what
+// Chrome reports as "Authorization page could not be loaded", with no way forward.
 func (h *authHandlers) ExtensionConnect(c *fiber.Ctx) error {
-	if _, err := requireUserID(c); err != nil {
-		return err
-	}
 	redirectURI := c.Query("redirect_uri")
 	state := c.Query("state")
 	if err := validateExtensionRedirect(redirectURI, h.extensionRedirectAllowlist); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "invalid redirect_uri")
+	}
+	if _, err := requireUserID(c); err != nil {
+		// `via=web` marks a request the web app sent back after signing the visitor in.
+		// It is the loop stop: without it, a session the browsing profile has but this
+		// window cannot see would bounce between the two forever.
+		if c.Query("via") == "web" {
+			c.Type("html")
+			return c.Status(fiber.StatusUnauthorized).SendString(noSessionPage(h.frontendOrigin))
+		}
+		return c.Redirect(h.signInURL(redirectURI, state), fiber.StatusFound)
 	}
 	c.Type("html")
 	return c.SendString(consentPage(redirectURI, state))
@@ -80,16 +100,19 @@ func (h *authHandlers) ExtensionConnect(c *fiber.Ctx) error {
 // session JWT (Issuer.Issue) and 302-redirects the token back in the fragment;
 // on anything else it issues nothing and 302-redirects an error. Cookie-only (RequireAuth).
 func (h *authHandlers) ExtensionConnectSubmit(c *fiber.Ctx) error {
-	userID, err := requireUserID(c)
-	if err != nil {
-		return err
-	}
 	redirectURI := c.FormValue("redirect_uri")
 	state := c.FormValue("state")
 	// Re-validate: never trust that the GET consent step ran, and never redirect
 	// to an unvetted target.
 	if err := validateExtensionRedirect(redirectURI, h.extensionRedirectAllowlist); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "invalid redirect_uri")
+	}
+	userID, err := requireUserID(c)
+	if err != nil {
+		// The session can lapse between the consent screen and the decision. Restart the
+		// flow rather than render JSON into the auth window — the sign-in page brings the
+		// visitor straight back to this same consent.
+		return c.Redirect(h.signInURL(redirectURI, state), fiber.StatusFound)
 	}
 	redirect := func(vals url.Values) error {
 		location, err := redirectWithFragment(redirectURI, vals)
@@ -117,6 +140,22 @@ func (h *authHandlers) ExtensionConnectSubmit(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusInternalServerError, "failed to issue token")
 	}
 	return redirect(url.Values{"token": {token}, "state": {state}})
+}
+
+// noSessionPage is the dead end of the sign-in round trip: the visitor came back from
+// the web app and this window still has no session. It says what to do instead of
+// leaving Chrome to report "Authorization page could not be loaded".
+func noSessionPage(origin string) string {
+	home := strings.TrimSuffix(origin, "/")
+	return fmt.Sprintf(`<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Sign in to connect the extension</title></head>
+<body style="font-family:system-ui,sans-serif;max-width:32rem;margin:4rem auto;padding:0 1rem">
+  <h1>Not signed in</h1>
+  <p>This window could not pick up a freehire session. Sign in at
+     <a href="%s">%s</a>, then press <b>Sign in with freehire</b> in the extension again.</p>
+</body>
+</html>`, html.EscapeString(home), html.EscapeString(home))
 }
 
 // consentPage is the minimal server-rendered approval screen. The redirect and

--- a/internal/handler/extension_connect_integration_test.go
+++ b/internal/handler/extension_connect_integration_test.go
@@ -54,8 +54,12 @@ func TestExtensionConnectEndToEnd(t *testing.T) {
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	cookieAuth := auth.RequireAuth(iss, testVersions)
 	keyAuth := auth.RequireAuthOrKey(iss, testVersions, apiKeys{queries})
-	app.Get("/api/v1/auth/extension/connect", cookieAuth, h.ExtensionConnect)
-	app.Post("/api/v1/auth/extension/connect", cookieAuth, h.ExtensionConnectSubmit)
+	// optionalCookie, exactly as authHandlers.register mounts it: the flow runs in a
+	// browser window, so a sessionless visitor is sent to sign in rather than refused.
+	// Mounting RequireAuth here would test a route that does not exist.
+	optionalCookie := auth.OptionalCookieAuth(iss, testVersions)
+	app.Get("/api/v1/auth/extension/connect", optionalCookie, h.ExtensionConnect)
+	app.Post("/api/v1/auth/extension/connect", optionalCookie, h.ExtensionConnectSubmit)
 	app.Get("/api/v1/me/api-keys", cookieAuth, h.ListAPIKeys)
 	app.Delete("/api/v1/me/api-keys/:id", cookieAuth, h.RevokeAPIKey)
 	app.Post("/api/v1/jobs/:slug/apply", keyAuth, th.MarkApplied)
@@ -79,20 +83,67 @@ func TestExtensionConnectEndToEnd(t *testing.T) {
 		return len(rows)
 	}
 
-	// 4.1 Session-only: no cookie and Bearer-only are both rejected; nothing minted.
-	t.Run("anonymous GET is rejected", func(t *testing.T) {
-		resp, _ := app.Test(httptest.NewRequest(fiber.MethodGet, connectPath+"?redirect_uri="+url.QueryEscape(redirectURI), nil))
+	// 4.1 Session-only, but a browser navigation: a sessionless caller is sent to sign in
+	// (Chrome's auth window has its own cookie jar, so this is the normal first run) and
+	// a Bearer is still no session — neither issues anything.
+	t.Run("anonymous GET is sent to sign in", func(t *testing.T) {
+		resp, _ := app.Test(httptest.NewRequest(fiber.MethodGet, connectPath+"?redirect_uri="+url.QueryEscape(redirectURI)+"&state=s1", nil))
+		if resp.StatusCode != fiber.StatusFound {
+			t.Fatalf("status = %d, want 302", resp.StatusCode)
+		}
+		loc, err := url.Parse(resp.Header.Get("Location"))
+		if err != nil {
+			t.Fatalf("parse Location %q: %v", resp.Header.Get("Location"), err)
+		}
+		if loc.Path != "/extension/connect" {
+			t.Fatalf("sign-in path = %q, want /extension/connect", loc.Path)
+		}
+		// The extension's parameters survive the round trip, or the visitor comes back
+		// signed in to a flow that no longer knows where to send the token.
+		if got := loc.Query().Get("redirect_uri"); got != redirectURI {
+			t.Fatalf("redirect_uri = %q, want %q", got, redirectURI)
+		}
+		if got := loc.Query().Get("state"); got != "s1" {
+			t.Fatalf("state = %q, want s1", got)
+		}
+	})
+
+	// The loop stop: back from the web app and still no session. Bouncing again would
+	// spin forever, so this says so instead.
+	t.Run("anonymous GET back from the web app is refused, not bounced", func(t *testing.T) {
+		resp, _ := app.Test(httptest.NewRequest(fiber.MethodGet, connectPath+"?redirect_uri="+url.QueryEscape(redirectURI)+"&via=web", nil))
 		if resp.StatusCode != fiber.StatusUnauthorized {
 			t.Fatalf("status = %d, want 401", resp.StatusCode)
 		}
 	})
-	t.Run("bearer-only POST is rejected and mints nothing", func(t *testing.T) {
+
+	// An unlisted redirect is refused before the sign-in bounce: a crafted link must not
+	// ride a sign-in round trip, and a 302 would tell the caller it is a valid target.
+	t.Run("anonymous GET with an unlisted redirect is rejected", func(t *testing.T) {
+		resp, _ := app.Test(httptest.NewRequest(fiber.MethodGet, connectPath+"?redirect_uri="+url.QueryEscape("https://evil.example.com/"), nil))
+		if resp.StatusCode != fiber.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", resp.StatusCode)
+		}
+	})
+
+	t.Run("bearer-only POST issues nothing", func(t *testing.T) {
 		before := keyCount()
 		r := form(url.Values{"redirect_uri": {redirectURI}, "decision": {"allow"}})
 		r.Header.Set("Authorization", "Bearer some-key-value")
 		resp, _ := app.Test(r)
-		if resp.StatusCode != fiber.StatusUnauthorized {
-			t.Fatalf("status = %d, want 401", resp.StatusCode)
+		// Sent to sign in, like any other sessionless navigation — and to the web app,
+		// never to the extension's own redirect, so no token can ride along.
+		if resp.StatusCode != fiber.StatusFound {
+			t.Fatalf("status = %d, want 302", resp.StatusCode)
+		}
+		loc, err := url.Parse(resp.Header.Get("Location"))
+		if err != nil {
+			t.Fatalf("parse Location %q: %v", resp.Header.Get("Location"), err)
+		}
+		// The extension's own redirect only ever appears as a parameter to carry through
+		// the sign-in, never as the destination — and nothing rides the fragment.
+		if loc.Host != "" || loc.Path != "/extension/connect" || loc.Fragment != "" {
+			t.Fatalf("sessionless POST redirected to %q, want the sign-in page", resp.Header.Get("Location"))
 		}
 		if after := keyCount(); after != before {
 			t.Fatalf("keys changed %d -> %d, want no mint", before, after)

--- a/web/src/routes/extension/connect/+page.server.ts
+++ b/web/src/routes/extension/connect/+page.server.ts
@@ -1,0 +1,33 @@
+import { error, redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+// The sign-in stop on the browser-extension connect flow.
+//
+// The extension opens the API's /auth/extension/connect in Chrome's auth window, whose
+// cookie jar is not the browsing profile's — so the usual first run arrives with no
+// session at all. The API sends that visitor here rather than refusing it: this page
+// signs them in (the same ?auth=required dialog every guarded page uses) and hands the
+// window straight back, now carrying a session cookie.
+//
+// The handoff is a real navigation from the browser (see +page.svelte), not a redirect
+// from this load: the target is the Go API, not a route this app knows, and only a full
+// navigation is guaranteed to leave the client router.
+export const load: PageServerLoad = async ({ parent, url }) => {
+  const redirectUri = url.searchParams.get('redirect_uri');
+  const state = url.searchParams.get('state') ?? '';
+  // Reached without the extension's parameters — nothing to connect.
+  if (!redirectUri) {
+    error(400, 'This page is opened by the freehire browser extension.');
+  }
+
+  const { user } = await parent();
+  if (!user) {
+    const target = url.pathname + url.search;
+    redirect(302, `/?auth=required&redirect=${encodeURIComponent(target)}`);
+  }
+
+  // `via=web` tells the API this request already came through here: if it still cannot
+  // see a session it must say so rather than send the window back for another round.
+  const params = new URLSearchParams({ redirect_uri: redirectUri, state, via: 'web' });
+  return { apiUrl: `/api/v1/auth/extension/connect?${params}` };
+};

--- a/web/src/routes/extension/connect/+page.svelte
+++ b/web/src/routes/extension/connect/+page.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  // A full navigation, not goto(): the target is the Go API rather than a route of this
+  // app, and the session cookie has to ride the request. The load already established
+  // that there is a session, so this is a handoff, not a gate.
+  onMount(() => {
+    window.location.href = data.apiUrl;
+  });
+</script>
+
+<svelte:head><title>Connect the extension · freehire</title></svelte:head>
+
+<div class="mx-auto max-w-md py-16 text-center">
+  <p class="text-sm text-muted-foreground">Connecting the freehire extension…</p>
+</div>


### PR DESCRIPTION
Reported from the Web Store build: pressing **Sign in with freehire** in the side panel fails with Chrome's *"Authorization page could not be loaded."*

## What was happening

`launchWebAuthFlow` opens `GET /api/v1/auth/extension/connect` in Chrome's auth window, and that window does not share the browsing profile's cookie jar — so the normal first run arrives with **no session**. The endpoint was cookie-only (`RequireAuth`) and answered `401 {"error":"not authenticated"}`. Chrome cannot render that as an authorization page, so it reports the generic failure and the user is stuck with nothing to press.

Confirmed against production:

```
curl "https://freehire.me/api/v1/auth/extension/connect?redirect_uri=…&state=…"  → 401
```

The extension id from the store (`ijfaechij…`) *is* on `EXTENSION_REDIRECT_ALLOWLIST`, so this was never the allowlist.

## The fix

Both handlers move to `optionalCookie` — the same middleware the OAuth callbacks use, and for the same reason: these are browser navigations, where a 401 renders JSON into the address bar instead of moving the user forward.

- A sessionless visitor is **302'd to the web app's new `/extension/connect` page**, carrying `redirect_uri` and `state`.
- That page guards on the user like every other private page (`/?auth=required&redirect=…`, the existing sign-in dialog), then hands the window back to the API with `via=web` via a full navigation, so the freshly set cookie rides along.
- `via=web` is the **loop stop**: back here with it and still no session, the endpoint answers a plain HTML "not signed in" page naming what to do, rather than bouncing forever.

Security kept where it was:

- `redirect_uri` is validated **before** the bounce, so a crafted target never rides a sign-in round trip and a 302 never doubles as "this target is valid".
- A sessionless `POST` redirects to the **web app**, never to the extension's own redirect — no token can ride along. Covered by a test.
- Still cookie-only: an API key cannot drive the flow.

No nginx change needed — `/extension/connect` is a SvelteKit page, and `location /` already serves the SPA.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — clean
- `go vet -tags=integration ./...` — clean
- `go test -tags=integration ./internal/handler/ -run TestExtensionConnectEndToEnd` — passes against real Postgres, including the four new cases (bounce to sign-in with parameters preserved, `via=web` refusal, unlisted redirect still 400, sessionless POST issues nothing)
- web: `npm run check` 0 errors, `npm run build` clean

Needs a deploy to take effect for the store build.