### PR TITLE
Extension: a visible plan for filling an application form

### DIFF
--- a/docs/superpowers/specs/2026-08-15-extension-apply-plan-design.md
+++ b/docs/superpowers/specs/2026-08-15-extension-apply-plan-design.md
@@ -1,0 +1,156 @@
+# Extension: a visible plan for filling an application form
+
+Date: 2026-08-15
+Status: approved
+
+## Problem
+
+Autofill is a black box. The user presses one button and gets a sentence: *"Autofilled 9
+fields — review before submitting."* Nothing says which fields those were, what is still
+empty, or whether the form is now ready to submit. On a real ATS form — twenty questions
+across two screens — the user has to scroll the whole thing to find out, which is the work
+autofill was supposed to remove.
+
+Two things are missing: a **standing account of the form** (what it asks, what is answered)
+and **visible progress** while the filling happens.
+
+## Solution
+
+The Match tab grows an application-form panel: the form's questions as a checklist, a
+required-fields counter, and an autofill pass that walks the page field by field in view.
+
+```
+Application form                       6/7 · 86%
+▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░
+
+Required
+  ✓ First name          ✓ Email
+  ✓ LinkedIn            – City
+Optional
+  – Website             – X (fka Twitter)
+```
+
+Three behaviours:
+
+1. **The checklist stands on its own.** It appears whenever the open page shows an
+   application form, before anything is filled, and it stays accurate as the user types
+   into the page themselves.
+2. **Autofill is a walk, not a batch.** Each field in turn: the page scrolls to it, the
+   field is outlined, the value lands, the panel ticks it off and the counter moves. The
+   Autofill button becomes **Stop** for the duration.
+3. **The remainder is reachable.** A question autofill could not answer stays in the list
+   as a live target: clicking it scrolls the page there and puts the cursor in it.
+
+### Why a walk
+
+A batch fill is faster in wall-clock and worse to watch: values appear off-screen, and the
+user still has to audit the form afterwards because nothing showed them what changed. The
+walk makes the audit happen as it goes — and it is the only version where "it filled the
+wrong thing" is caught by the person watching rather than after submission.
+
+The pause between fields is ~300 ms. It exists for the eye, and it is the whole reason a
+walk reads as progress rather than as a flicker.
+
+## Architecture
+
+Nothing new crosses the network. The panel already reads the page's form and writes values
+back through the same relay; this feature is the panel using them per-field instead of
+once, plus a checklist rendered from what it reads.
+
+```
+sidepanel/App.svelte
+  └─ ApplyPlan.svelte          the checklist + counter (new)
+        ↑ questions              ↓ fill one / reveal one
+  background.ts (relay, unchanged shape)
+        ↕
+  content.ts
+     ├─ collectQuestions / extractForm      (existing — the read)
+     ├─ fillByLabel                          (existing — the write)
+     ├─ revealField                          (new — scroll + outline + focus)
+     └─ form-change notifier                 (new — user edits reach the panel)
+```
+
+### The unit is the question
+
+`internal` to this design: the list is built from `collectQuestions`, the same unit the
+filler already works in, so a question rendered as 29 checkboxes is one line in the
+checklist and one tick — not 29. The panel addresses a question by its label plus
+`frame`/`form`, exactly as `LabelFill` already does.
+
+### Components
+
+**`ApplyPlan.svelte`** (panel). Renders a `PlanItem[]`: label, required, status
+(`filled` | `empty` | `filling`). Owns no page access — it emits "reveal this one" and
+renders what it is given. Splits Required and Optional; the counter counts required only,
+because that is what gates submission.
+
+**`applyPlan.ts`** (panel lib, pure). Turns `FramedField[]` into `PlanItem[]`: drops
+questions that are not answerable (`hidden`, submit-like), decides `filled` from the
+field's current `value`, and computes the counter. Pure over its input, so it is unit
+tested without a DOM — the same discipline `scraper.ts` and `form.ts` keep.
+
+**`revealField`** (content). Scrolls the question's first control into view
+(`block: 'center'`), outlines it for ~600 ms, and optionally focuses it. The outline is
+inline style on the element, restored afterwards — no stylesheet injected into a page we
+do not own.
+
+**Form-change notifier** (content). One delegated `input`/`change` listener on the
+document, debounced 400 ms, posting `FORM_CHANGED` to the panel, which re-reads the form.
+Delegation, not per-field listeners: an ATS form re-renders constantly, and per-field
+listeners would leak with every re-render.
+
+### Wire additions (`lib/protocol.ts`)
+
+- `REVEAL_FIELD { label, frame, form, focus }` → `REVEAL_RESULT { found }`
+- `FILL_BY_LABEL` gains `reveal?: boolean` — when set, each fill scrolls and outlines
+  before writing. Absent for the agent's own tool-driven fills, which must stay silent.
+- `FORM_CHANGED` — content → panel, no payload; the panel re-reads.
+
+### The walk
+
+The panel already gets its fill plan two ways — the agent's `/me/autofill/run` and the
+deterministic fallback. Both end in a list of `(label, value, frame, form)`. The walk is a
+loop over that list: one `FILL_BY_LABEL` per item with `reveal: true`, then a `300 ms`
+pause, updating the checklist between steps. A `stop` flag checked between steps ends it.
+
+The agent path currently fills the page itself, server-side, through the tool relay. It
+keeps that behaviour: for the agent path the panel walks the **report** it gets back
+(`{filled, deferred, unmapped}`, labels only) rather than re-filling — each reported label
+is matched against the questions the panel just read, revealed, and ticked off. A label the
+page no longer carries is skipped, not an error: the report describes a form that may have
+re-rendered since.
+
+The deterministic path walks its own plan and fills as it goes, where each step carries
+`frame`/`form` and needs no matching.
+
+## Error handling
+
+- **No form on the page** — no panel, no counter. The Match card and Autofill button are
+  unchanged; a page with no application is not a form with zero fields.
+- **A question vanishes mid-walk** (the form re-rendered, or a step moved) — `fillByLabel`
+  already answers `not_found`; the walk marks that item `empty`, does not stop, and the
+  final line names what it missed.
+- **A custom-widget dropdown** — already `deferred_combobox`; it stays in the list as an
+  unfilled required item, reachable by click, and the closing line says how many.
+- **The user navigates away mid-walk** — the panel's existing page-change handler resets
+  the plan, and the walk's stop flag is set from the same place.
+
+## Testing
+
+- `applyPlan.ts` — unit tests over fixture `FramedField[]`: counter arithmetic, required
+  vs optional split, a group counted once, an already-answered field counted as filled.
+- `form.ts` `revealField` — jsdom test that it finds the question and restores the style it
+  changed.
+- The walk's stop/ordering logic — unit tested as a pure reducer over steps, not by
+  driving a real page.
+
+Existing suites (`form.test.ts`, `combobox.test.ts`) must stay green; the fill primitives
+themselves do not change.
+
+## Out of scope
+
+- Asking the user for a missing answer inside the panel (considered, deferred: the
+  remainder is reachable by click, which is enough to finish a form).
+- Writing answers back into the profile for next time.
+- Multi-page ATS flows ("Continue to the next page"): the plan describes the page in front
+  of the user, not the application as a whole.

--- a/extension/AGENTS.md
+++ b/extension/AGENTS.md
@@ -33,8 +33,9 @@ extension/            WXT + Svelte MV3 extension (npm-managed; the repo's other
     background.ts     service worker: opens the panel, relays panel <-> content
     content.ts        injected everywhere; reads the page into a PageSnapshot
     sidepanel/        Svelte chat app (owns the relay WebSocket)
-      App.svelte      chat UI + match card + page intake + Autofill
+      App.svelte      chat UI + match card + apply plan + page intake + Autofill
       MatchCard.svelte  profile-match card
+      ApplyPlan.svelte  the open form's questions, answered or not, + the counter
       ToolGroupList.svelte  what the agent is doing, mid-turn
       JobDeck.svelte / JobDeckCard.svelte  the `present_jobs` cards
       app.css         Tailwind + freehire-design-system/theme.css import
@@ -50,7 +51,10 @@ extension/            WXT + Svelte MV3 extension (npm-managed; the repo's other
     freehire.ts       hire API reads (job, match, autofill profile)
     protocol.ts       in-extension RuntimeMessage contract (+ test)
     scraper.ts        DOM -> PageSnapshot, pure over its Document arg (+ test)
-    form.ts           form observe/map/act for Autofill (+ test)
+    form.ts           form observe/map/act/reveal for Autofill (+ test)
+    applyPlan.ts      form fields -> the panel's checklist + required counter (+ test)
+    walk.ts           the order an autofill works through the form, as a value (+ test)
+    debounce.ts       one call after a burst goes quiet (+ test)
     combobox.ts       drives custom-widget comboboxes (open/options/select/verify);
                       pure over its Document like form.ts, but async (+ test)
   wxt.config.ts       manifest (permissions, side_panel, host_permissions) +
@@ -92,6 +96,22 @@ content --PAGE_SNAPSHOT--> background --> panel --> relay --> the agent, mid-tur
   (panel <-> background <-> content, discriminated by `kind`). Neither the chat's
   wire nor the browser-tool wire is here: they are `lib/assistant/wire.ts` and
   `lib/tools/wire.ts`, each mirroring a contract hire owns.
+- **Autofill is watched, not batched.** The panel walks the form one question at a
+  time (`lib/walk.ts` holds the order as a value; App.svelte supplies the ~300ms
+  pauses), each fill carrying `reveal` so the page scrolls to the question and
+  outlines it as the value lands. The pause is for the eye — the walk IS the audit
+  the user would otherwise have to do afterwards. The agent path fills server-side
+  as before and the panel plays its report back over the page, revealing each label
+  it reported without re-writing anything.
+- **The plan is the panel's standing account of the form**, computed by
+  `buildPlan` from what the page reported and rebuilt on every page change, after
+  every walk step, and on `FORM_CHANGED` — the page's own debounced notice that
+  someone typed into it. It counts REQUIRED questions only (they are what gates
+  submission) and is null for a page showing no application form.
+- **`revealField` borrows the page's style and gives it back.** The outline is
+  inline style, restored after ~600ms: the extension runs on pages freehire does
+  not own, where an injected class can collide with the ATS's own and a stylesheet
+  outlives our interest in the element.
 - **The agent's reading is bounded, and visible.** `read_page` refuses any tab that
   is not `http(s)` (`lib/tools/readable.ts`), decided from the url before the page
   is read — this extension is the only side that sees a url before scraping it. The

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -99,16 +99,21 @@ async function fillAcrossFrames(fills: LabelFill[], reveal?: boolean): Promise<R
 }
 
 /**
- * Offers one reveal to every frame. Like a widget step, the question lives in
- * exactly one of them; a frame that does not hold it answers `found: false`, and
- * the panel needs to hear a yes from ANY frame — so the answers are folded with
- * "some frame found it", not by whichever replied first.
+ * Reveals one question. A request naming its frame goes to that frame alone —
+ * two frames carrying the same label would otherwise both scroll and both take
+ * the cursor. A request naming none (the agent's report carries labels only) is
+ * offered to every frame, and the answers are folded with "some frame found it"
+ * rather than by whichever replied first.
  */
 async function revealAcrossFrames(request: RevealRequest): Promise<RuntimeMessage> {
   let found = false;
-  await eachFrame({ kind: 'REVEAL_FIELD', request }, (reply) => {
-    if (reply?.kind === 'REVEAL_RESULT' && reply.found) found = true;
-  });
+  await eachFrame(
+    { kind: 'REVEAL_FIELD', request },
+    (reply) => {
+      if (reply?.kind === 'REVEAL_RESULT' && reply.found) found = true;
+    },
+    request.frame,
+  );
   return { kind: 'REVEAL_RESULT', found };
 }
 
@@ -134,12 +139,16 @@ async function comboboxAcrossFrames(step: ComboboxStep): Promise<RuntimeMessage>
 async function eachFrame(
   message: RuntimeMessage | ((frame: number) => RuntimeMessage),
   take: (reply: RuntimeMessage | undefined, frame: number) => void,
+  /** Restricts the fan-out to one frame, for a request that names the frame it
+   *  belongs to. Everything else still reaches every frame. */
+  onlyFrame?: number,
 ): Promise<void> {
   const tabId = await activeTabId();
   if (tabId == null) return;
   const forFrame = typeof message === 'function' ? message : () => message;
+  const frames = onlyFrame === undefined ? await frameIds(tabId) : [onlyFrame];
   await Promise.all(
-    (await frameIds(tabId)).map(async (frameId) => {
+    frames.map(async (frameId) => {
       try {
         take((await browser.tabs.sendMessage(tabId, forFrame(frameId), { frameId })) as RuntimeMessage, frameId);
       } catch {

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -7,6 +7,7 @@ import {
   type FillOutcome,
   type ComboboxStep,
   type ComboboxReply,
+  type RevealRequest,
 } from '../lib/protocol';
 import { mergeComboboxReplies, mergeFrameOutcomes } from '../lib/tools/executor';
 import { fillsForFrame } from '../lib/form';
@@ -32,7 +33,9 @@ export default defineBackground(() => {
       case 'GET_FRAMED_FORM':
         return readFramedForm();
       case 'FILL_BY_LABEL':
-        return fillAcrossFrames(message.fills);
+        return fillAcrossFrames(message.fills, message.reveal);
+      case 'REVEAL_FIELD':
+        return revealAcrossFrames(message.request);
       case 'COMBOBOX_STEP':
         return comboboxAcrossFrames(message.step);
       default:
@@ -84,15 +87,29 @@ async function readFramedForm(): Promise<RuntimeMessage> {
  * broadcast would; a fill naming none — a `fill_simple` tool call — still goes
  * to every frame, and a frame that does not hold it reports `not_found`.
  */
-async function fillAcrossFrames(fills: LabelFill[]): Promise<RuntimeMessage> {
+async function fillAcrossFrames(fills: LabelFill[], reveal?: boolean): Promise<RuntimeMessage> {
   const perFrame: FillOutcome[][] = [];
   await eachFrame(
-    (frame) => ({ kind: 'FILL_BY_LABEL', fills: fillsForFrame(fills, frame) }),
+    (frame) => ({ kind: 'FILL_BY_LABEL', fills: fillsForFrame(fills, frame), reveal }),
     (reply) => {
       if (reply?.kind === 'FILL_OUTCOMES') perFrame.push(reply.outcomes);
     },
   );
   return { kind: 'FILL_OUTCOMES', outcomes: mergeFrameOutcomes(perFrame) };
+}
+
+/**
+ * Offers one reveal to every frame. Like a widget step, the question lives in
+ * exactly one of them; a frame that does not hold it answers `found: false`, and
+ * the panel needs to hear a yes from ANY frame — so the answers are folded with
+ * "some frame found it", not by whichever replied first.
+ */
+async function revealAcrossFrames(request: RevealRequest): Promise<RuntimeMessage> {
+  let found = false;
+  await eachFrame({ kind: 'REVEAL_FIELD', request }, (reply) => {
+    if (reply?.kind === 'REVEAL_RESULT' && reply.found) found = true;
+  });
+  return { kind: 'REVEAL_RESULT', found };
 }
 
 /**

--- a/extension/entrypoints/content.ts
+++ b/extension/entrypoints/content.ts
@@ -1,7 +1,12 @@
 import { extractSnapshot } from '../lib/scraper';
-import { extractForm, extractUploads, fillByLabel } from '../lib/form';
+import { extractForm, extractUploads, fillByLabel, revealField } from '../lib/form';
 import { runStep } from '../lib/combobox';
+import { debounce } from '../lib/debounce';
 import type { RuntimeMessage } from '../lib/protocol';
+
+/** How long the page waits for typing to stop before telling the panel its form
+ *  changed. One re-read when the user pauses, not one per keystroke. */
+const FORM_CHANGE_QUIET_MS = 400;
 
 /**
  * Injected into every page, and into every frame of it — apply forms are
@@ -32,9 +37,22 @@ export default defineContentScript({
             uploads: extractUploads(document),
           });
         case 'FILL_BY_LABEL':
+          // A revealed fill scrolls to each question and outlines it as the value
+          // lands — the panel's walk, watched. The reveal runs first so the user
+          // is looking at the control before it changes.
+          if (message.reveal) {
+            for (const fill of message.fills) {
+              revealField(document, { label: fill.label, form: fill.form });
+            }
+          }
           return Promise.resolve<RuntimeMessage>({
             kind: 'FILL_OUTCOMES',
             outcomes: fillByLabel(document, message.fills),
+          });
+        case 'REVEAL_FIELD':
+          return Promise.resolve<RuntimeMessage>({
+            kind: 'REVEAL_RESULT',
+            found: revealField(document, message.request),
           });
         case 'COMBOBOX_STEP':
           // The only asynchronous handler here: a widget re-renders when its
@@ -46,5 +64,20 @@ export default defineContentScript({
           return undefined;
       }
     });
+
+    // Answers the user types themselves must move the panel's counter, or it
+    // reports a form as less finished than it is. One delegated listener rather
+    // than one per control: an ATS form re-renders constantly, and per-control
+    // listeners would have to be re-attached on every render (and leak the ones
+    // they replaced). The panel is told only that something changed — it re-reads
+    // the form, which is the one account that cannot drift.
+    const announce = debounce(() => {
+      void browser.runtime.sendMessage({ kind: 'FORM_CHANGED' } satisfies RuntimeMessage).catch(() => {
+        // No panel listening (it is closed, or this frame outlived it). Nothing
+        // to do: the next open re-reads the form anyway.
+      });
+    }, FORM_CHANGE_QUIET_MS);
+    document.addEventListener('input', announce, true);
+    document.addEventListener('change', announce, true);
   },
 });

--- a/extension/entrypoints/sidepanel/App.svelte
+++ b/extension/entrypoints/sidepanel/App.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { browser } from 'wxt/browser';
-  import { type RuntimeMessage } from '../../lib/protocol';
+  import { type RuntimeMessage, type LabelFill } from '../../lib/protocol';
   import { createSession, getSession, SessionNotFound } from '../../lib/assistant/api';
   import { sendTurn, type Turn } from '../../lib/assistant/client';
   import { initChat, reduceTurnEvent, type ChatState } from '../../lib/assistant/chat';
@@ -27,9 +27,12 @@
     scopeToApplication,
     formatAuthorizedCountries,
   } from '../../lib/form';
+  import { buildPlan, markAnswered, type ApplyPlan, type PlanItem } from '../../lib/applyPlan';
+  import { startWalk, nextStep, applyStep, skipStep, stopWalk, type Walk } from '../../lib/walk';
   import { ToolChannel } from '../../lib/tools/client';
   import { activeTabPage } from '../../lib/tools/page';
   import MatchCard from './MatchCard.svelte';
+  import ApplyPlanCard from './ApplyPlan.svelte';
   import ToolGroupList from './ToolGroupList.svelte';
   import JobDeck from './JobDeck.svelte';
   import { splitPresentingCalls } from '../../lib/assistant/deck';
@@ -96,11 +99,21 @@
     };
     browser.tabs.onUpdated.addListener(onUpdated);
 
+    // An answer the user types on the page themselves has to move the panel's
+    // counter, or the plan reports the form as less finished than it is. The page
+    // says only that something changed (debounced there); the plan is rebuilt from
+    // a fresh read, which is the one account that cannot drift.
+    const onPageMessage = (message: RuntimeMessage) => {
+      if (message.kind === 'FORM_CHANGED') void refreshPlan();
+    };
+    browser.runtime.onMessage.addListener(onPageMessage);
+
     return () => {
       turn?.cancel();
       tools.stop();
       browser.tabs.onActivated.removeListener(refresh);
       browser.tabs.onUpdated.removeListener(onUpdated);
+      browser.runtime.onMessage.removeListener(onPageMessage);
     };
   });
 
@@ -160,6 +173,7 @@
     }
     chatPageKey = key;
     void loadMatch();
+    void refreshPlan();
   }
 
   async function restoreSession() {
@@ -171,6 +185,7 @@
     const key = await currentPageKey();
     chatPageKey = key;
     void loadMatch();
+    void refreshPlan();
     void restoreConversation(token, key);
   }
 
@@ -320,6 +335,7 @@
         tools.start(token);
         chatPageKey = await currentPageKey();
         void loadMatch();
+        void refreshPlan();
       }
     } catch (err) {
       authError = err instanceof Error ? err.message : 'Sign-in failed';
@@ -428,6 +444,44 @@
 
   let autofilling = $state(false);
 
+  // ── The application-form plan ──────────────────────────────────────────────
+  //
+  // The panel's standing account of the form in front of the user: what it asks,
+  // what is answered, how far the required questions are along. It exists before
+  // any fill and outlives every one, which is the difference from the notices —
+  // those describe one action and are gone by the next.
+
+  let plan = $state<ApplyPlan | null>(null);
+  /** The question a walk is filling right now, by label. */
+  let fillingLabel = $state<string | null>(null);
+
+  /** Reads the page's form and rebuilds the plan, or clears it for a page that
+   *  is not showing an application. */
+  async function refreshPlan() {
+    if (!user) return;
+    const reply = (await browser.runtime.sendMessage({
+      kind: 'GET_FRAMED_FORM',
+    } satisfies RuntimeMessage)) as RuntimeMessage | undefined;
+    if (reply?.kind !== 'FRAMED_FORM' || !looksLikeApplication(reply.uploads)) {
+      plan = null;
+      return;
+    }
+    // One form, not every question on the page: an application and a job-alert
+    // signup each have their own "Email" — the same scoping the filler uses.
+    plan = buildPlan(scopeToApplication(reply.fields, reply.uploads));
+  }
+
+  /** Sends the user to one question: the page scrolls there and takes the cursor. */
+  async function revealItem(item: PlanItem) {
+    const reply = (await browser.runtime.sendMessage({
+      kind: 'REVEAL_FIELD',
+      request: { label: item.label, form: item.form, focus: true },
+    } satisfies RuntimeMessage)) as RuntimeMessage | undefined;
+    if (reply?.kind === 'REVEAL_RESULT' && !reply.found) {
+      notices.push(`"${item.label}" is no longer on this page — the form may have moved on.`);
+    }
+  }
+
   function profileToValues(p: AutofillProfile): Record<string, string> {
     return {
       fullName: p.full_name,
@@ -465,12 +519,89 @@
     return `${trimmed.slice(0, shown).join(', ')} and ${trimmed.length - shown} more`;
   }
 
+  /** How long each filled question stays in view before the walk moves on. It is
+   *  there for the eye: without it the walk is a flicker, which is the batch fill
+   *  this replaced. */
+  const WALK_STEP_MS = 300;
+
+  /** Set while a walk runs, so Stop can end it between steps. */
+  let walkStop = $state(false);
+
+  function pause(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /**
+   * Works through `fills` one question at a time, each one revealed as its value
+   * lands, ticking the plan off as it goes. Returns what it managed — the caller
+   * owns the closing sentence, because the two callers reach the walk from
+   * different places (its own plan, or the agent's report).
+   */
+  async function walkFills(fills: LabelFill[]): Promise<Walk> {
+    let walk = startWalk(fills.map((f) => f.label));
+    try {
+      // `nextStep` is the continuation test — it ends the walk both when the list
+      // runs out and when Stop has been pressed. The fill for the step is the one
+      // at the walk's own position, since the walk was started from these fills.
+      while (nextStep(walk) !== null) {
+        const fill = fills[walk.at];
+        if (!fill) break;
+        fillingLabel = fill.label;
+        const applied = (await browser.runtime.sendMessage({
+          kind: 'FILL_BY_LABEL',
+          fills: [fill],
+          reveal: true,
+        } satisfies RuntimeMessage)) as RuntimeMessage | undefined;
+        const outcome = applied?.kind === 'FILL_OUTCOMES' ? applied.outcomes[0] : undefined;
+        if (outcome?.status === 'filled') {
+          walk = applyStep(walk, fill.label);
+          // Ticked off from what we just wrote, not from a fresh read: the page's
+          // own change notice is debounced, so re-reading here would move the
+          // counter a step behind the value the user is looking at.
+          if (plan) plan = markAnswered(plan, fill.label);
+        } else {
+          walk = skipStep(walk, fill.label);
+        }
+        if (walkStop) return stopWalk(walk);
+        await pause(WALK_STEP_MS);
+      }
+      return walk;
+    } finally {
+      fillingLabel = null;
+    }
+  }
+
+  /** Plays a list of labels the agent says it filled back over the page, so the
+   *  user sees what changed. Nothing is written — the agent already did that. */
+  async function walkReported(labels: string[]) {
+    try {
+      for (const label of labels) {
+        if (walkStop) return;
+        fillingLabel = label;
+        await browser.runtime.sendMessage({
+          kind: 'REVEAL_FIELD',
+          request: { label },
+        } satisfies RuntimeMessage);
+        if (plan) plan = markAnswered(plan, label);
+        await pause(WALK_STEP_MS);
+      }
+    } finally {
+      // Whatever ended the walk — the list, Stop, or a throw — no question is
+      // being filled once it is over, and a stuck spinner would say otherwise.
+      fillingLabel = null;
+    }
+  }
+
   async function autofill() {
     const token = await getToken();
     if (!token || autofilling) return;
     autofilling = true;
+    walkStop = false;
     try {
       const report = await runAgentAutofill(token);
+      // The agent filled the page itself, server-side. Play its report back so
+      // the user watches what changed rather than finding it later.
+      await walkReported(report.filled);
       const filled = report.filled.length;
       notices.push(
         filled > 0
@@ -554,19 +685,20 @@
         notices.push('Nothing matched your profile on this form.');
         return;
       }
-      const applied = (await browser.runtime.sendMessage({
-        kind: 'FILL_BY_LABEL',
-        fills,
-      } satisfies RuntimeMessage)) as RuntimeMessage | undefined;
-      const outcomes = applied?.kind === 'FILL_OUTCOMES' ? applied.outcomes : [];
-      const n = outcomes.filter((o) => o.status === 'filled').length;
-      notices.push(`✓ Autofilled ${n} field${n === 1 ? '' : 's'} — review before submitting.`);
+      const walk = await walkFills(fills);
+      const n = walk.done.length;
+      notices.push(
+        walk.stopped
+          ? `Stopped after ${n} field${n === 1 ? '' : 's'} — what was filled stays.`
+          : `✓ Autofilled ${n} field${n === 1 ? '' : 's'} — review before submitting.`,
+      );
 
-      // A custom-widget combobox commits whatever its own listbox highlights, so
-      // the simple filler declines it rather than writing a wrong value.
-      const deferred = outcomes.filter((o) => o.status === 'deferred_combobox').map((o) => o.label);
-      if (deferred.length > 0) {
-        notices.push(`Not fillable yet (custom dropdowns): ${nameSome(deferred)}.`);
+      // A question the walk could not write: a custom-widget combobox (which
+      // commits whatever its own listbox highlights, so the simple filler
+      // declines it rather than writing a wrong value), or one the form dropped
+      // while the walk was running.
+      if (walk.skipped.length > 0) {
+        notices.push(`Left for you: ${nameSome(walk.skipped)}.`);
       }
     } catch (err) {
       notices.push(`Autofill failed: ${err instanceof Error ? err.message : 'error'}`);
@@ -653,6 +785,14 @@
               </Card>
             {/if}
 
+            <!-- The account of the form the user is standing in front of. It is
+                 independent of the match: a page can show an application freehire
+                 does not carry a posting for, and the checklist is just as useful
+                 there. -->
+            {#if plan}
+              <ApplyPlanCard {plan} filling={fillingLabel} onReveal={revealItem} />
+            {/if}
+
             {#each notices as notice, i (i)}
               <div class="message system">{notice}</div>
             {/each}
@@ -668,10 +808,21 @@
 
         {#if user && matchStatus === 'ready' && matchJob && matchJob.public_slug !== ''}
           <div class="match-footer">
-            <Button class="w-full" variant="primary" size="lg" onclick={autofill} disabled={autofilling}>
-              {autofilling ? 'Filling…' : 'Autofill'}
-              <RectangleEllipsis class="size-4" />
-            </Button>
+            {#if autofilling}
+              <!-- The same button, not a second one beside it: while a walk runs
+                   there is exactly one thing to do with it, and a disabled
+                   "Filling…" left the user watching something they could not
+                   call off. -->
+              <Button class="w-full" variant="outline" size="lg" onclick={() => (walkStop = true)} disabled={walkStop}>
+                {walkStop ? 'Stopping…' : 'Stop'}
+                <Square class="size-4" />
+              </Button>
+            {:else}
+              <Button class="w-full" variant="primary" size="lg" onclick={autofill}>
+                Autofill
+                <RectangleEllipsis class="size-4" />
+              </Button>
+            {/if}
           </div>
         {/if}
       </div>

--- a/extension/entrypoints/sidepanel/App.svelte
+++ b/extension/entrypoints/sidepanel/App.svelte
@@ -454,14 +454,21 @@
   let plan = $state<ApplyPlan | null>(null);
   /** The question a walk is filling right now, by label. */
   let fillingLabel = $state<string | null>(null);
+  /** Guards against an older read landing after a newer one — a page change and
+   *  the page's own FORM_CHANGED both start a read, and the slower answer would
+   *  otherwise replace the current form's plan with the previous one's. Same
+   *  pattern as `matchRequestId`. */
+  let planRequestId = 0;
 
   /** Reads the page's form and rebuilds the plan, or clears it for a page that
    *  is not showing an application. */
   async function refreshPlan() {
     if (!user) return;
+    const requestId = ++planRequestId;
     const reply = (await browser.runtime.sendMessage({
       kind: 'GET_FRAMED_FORM',
     } satisfies RuntimeMessage)) as RuntimeMessage | undefined;
+    if (requestId !== planRequestId) return;
     if (reply?.kind !== 'FRAMED_FORM' || !looksLikeApplication(reply.uploads)) {
       plan = null;
       return;
@@ -475,7 +482,7 @@
   async function revealItem(item: PlanItem) {
     const reply = (await browser.runtime.sendMessage({
       kind: 'REVEAL_FIELD',
-      request: { label: item.label, form: item.form, focus: true },
+      request: { label: item.label, frame: item.frame, form: item.form, focus: true },
     } satisfies RuntimeMessage)) as RuntimeMessage | undefined;
     if (reply?.kind === 'REVEAL_RESULT' && !reply.found) {
       notices.push(`"${item.label}" is no longer on this page — the form may have moved on.`);
@@ -558,7 +565,11 @@
           // Ticked off from what we just wrote, not from a fresh read: the page's
           // own change notice is debounced, so re-reading here would move the
           // counter a step behind the value the user is looking at.
-          if (plan) plan = markAnswered(plan, fill.label);
+          // By address, not by label alone: two forms on one page can each ask
+          // "Email", and ticking both would report progress that is not there.
+          if (plan && fill.frame !== undefined && fill.form !== undefined) {
+            plan = markAnswered(plan, { label: fill.label, frame: fill.frame, form: fill.form });
+          }
         } else {
           walk = skipStep(walk, fill.label);
         }
@@ -582,7 +593,10 @@
           kind: 'REVEAL_FIELD',
           request: { label },
         } satisfies RuntimeMessage);
-        if (plan) plan = markAnswered(plan, label);
+        // The agent's report carries labels only, so this ticks off the item at
+        // that label — there is no address to be more precise with.
+        const item = plan?.items.find((i) => i.label === label);
+        if (plan && item) plan = markAnswered(plan, item);
         await pause(WALK_STEP_MS);
       }
     } finally {

--- a/extension/entrypoints/sidepanel/App.svelte
+++ b/extension/entrypoints/sidepanel/App.svelte
@@ -538,21 +538,32 @@
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
+  /** Ticks one question off the plan, narrowed by whatever address the caller
+   *  has: a fill knows its frame and form, the agent's report knows the label
+   *  alone. An address that matches nothing leaves the plan as it was. */
+  function tickOff(label: string, frame?: number, form?: number) {
+    if (!plan) return;
+    const item = plan.items.find(
+      (i) =>
+        i.label === label &&
+        (frame === undefined || i.frame === frame) &&
+        (form === undefined || i.form === form),
+    );
+    if (item) plan = markAnswered(plan, item);
+  }
+
   /**
    * Works through `fills` one question at a time, each one revealed as its value
    * lands, ticking the plan off as it goes. Returns what it managed — the caller
    * owns the closing sentence, because the two callers reach the walk from
    * different places (its own plan, or the agent's report).
    */
-  async function walkFills(fills: LabelFill[]): Promise<Walk> {
-    let walk = startWalk(fills.map((f) => f.label));
+  async function walkFills(fills: LabelFill[]): Promise<Walk<LabelFill>> {
+    let walk = startWalk(fills);
     try {
-      // `nextStep` is the continuation test — it ends the walk both when the list
-      // runs out and when Stop has been pressed. The fill for the step is the one
-      // at the walk's own position, since the walk was started from these fills.
-      while (nextStep(walk) !== null) {
-        const fill = fills[walk.at];
-        if (!fill) break;
+      // `nextStep` is the continuation test: it ends the walk both when the list
+      // runs out and when Stop has been pressed.
+      for (let fill = nextStep(walk); fill !== null; fill = nextStep(walk)) {
         fillingLabel = fill.label;
         const applied = (await browser.runtime.sendMessage({
           kind: 'FILL_BY_LABEL',
@@ -561,17 +572,13 @@
         } satisfies RuntimeMessage)) as RuntimeMessage | undefined;
         const outcome = applied?.kind === 'FILL_OUTCOMES' ? applied.outcomes[0] : undefined;
         if (outcome?.status === 'filled') {
-          walk = applyStep(walk, fill.label);
-          // Ticked off from what we just wrote, not from a fresh read: the page's
-          // own change notice is debounced, so re-reading here would move the
-          // counter a step behind the value the user is looking at.
-          // By address, not by label alone: two forms on one page can each ask
-          // "Email", and ticking both would report progress that is not there.
-          if (plan && fill.frame !== undefined && fill.form !== undefined) {
-            plan = markAnswered(plan, { label: fill.label, frame: fill.frame, form: fill.form });
-          }
+          walk = applyStep(walk, fill);
+          // Ticked off from what was just written, not from a fresh read: the
+          // page's own change notice is debounced, so re-reading here would leave
+          // the counter a step behind the value on screen.
+          tickOff(fill.label, fill.frame, fill.form);
         } else {
-          walk = skipStep(walk, fill.label);
+          walk = skipStep(walk, fill);
         }
         if (walkStop) return stopWalk(walk);
         await pause(WALK_STEP_MS);
@@ -593,10 +600,7 @@
           kind: 'REVEAL_FIELD',
           request: { label },
         } satisfies RuntimeMessage);
-        // The agent's report carries labels only, so this ticks off the item at
-        // that label — there is no address to be more precise with.
-        const item = plan?.items.find((i) => i.label === label);
-        if (plan && item) plan = markAnswered(plan, item);
+        tickOff(label);
         await pause(WALK_STEP_MS);
       }
     } finally {
@@ -712,7 +716,7 @@
       // declines it rather than writing a wrong value), or one the form dropped
       // while the walk was running.
       if (walk.skipped.length > 0) {
-        notices.push(`Left for you: ${nameSome(walk.skipped)}.`);
+        notices.push(`Left for you: ${nameSome(walk.skipped.map((f) => f.label))}.`);
       }
     } catch (err) {
       notices.push(`Autofill failed: ${err instanceof Error ? err.message : 'error'}`);

--- a/extension/entrypoints/sidepanel/ApplyPlan.svelte
+++ b/extension/entrypoints/sidepanel/ApplyPlan.svelte
@@ -22,6 +22,13 @@
     onReveal: (item: PlanItem) => void;
   } = $props();
 
+  /** What the icon says, for a reader that cannot see it — the icon itself is
+   *  aria-hidden, so without this the state never reaches a screen reader. */
+  function itemState(item: PlanItem): string {
+    if (filling === item.label) return 'filling now';
+    return item.answered ? 'answered' : 'not answered';
+  }
+
   let required = $derived(plan.items.filter((i) => i.required));
   let optional = $derived(plan.items.filter((i) => !i.required));
 </script>
@@ -32,7 +39,13 @@
     <ul>
       {#each items as item (`${item.frame}:${item.form}:${item.label}`)}
         <li>
-          <button type="button" class="item" class:answered={item.answered} onclick={() => onReveal(item)}>
+          <button
+            type="button"
+            class="item"
+            class:answered={item.answered}
+            aria-label="{item.label}: {itemState(item)}"
+            onclick={() => onReveal(item)}
+          >
             <span class="mark" aria-hidden="true">
               {#if filling === item.label}
                 <Loader class="size-3 spin" />

--- a/extension/entrypoints/sidepanel/ApplyPlan.svelte
+++ b/extension/entrypoints/sidepanel/ApplyPlan.svelte
@@ -1,0 +1,189 @@
+<script lang="ts">
+  import { Check, Loader, MapPin } from '@lucide/svelte';
+  import { Card } from 'freehire-design-system';
+  import type { ApplyPlan, PlanItem } from '../../lib/applyPlan';
+
+  /**
+   * The panel's account of the application form in front of the user: what it
+   * asks, what is answered, and how far the required questions are along.
+   *
+   * It reaches the page through nobody — `onReveal` is the one thing it asks for,
+   * and App.svelte decides what that means. The plan itself is computed in
+   * `lib/applyPlan.ts`, so this file has no arithmetic to get wrong.
+   */
+  let {
+    plan,
+    /** The question being filled right now, by label — the walk's cursor. */
+    filling = null,
+    onReveal,
+  }: {
+    plan: ApplyPlan;
+    filling?: string | null;
+    onReveal: (item: PlanItem) => void;
+  } = $props();
+
+  let required = $derived(plan.items.filter((i) => i.required));
+  let optional = $derived(plan.items.filter((i) => !i.required));
+</script>
+
+{#snippet group(heading: string, items: PlanItem[])}
+  {#if items.length > 0}
+    <p class="group">{heading}</p>
+    <ul>
+      {#each items as item (`${item.frame}:${item.form}:${item.label}`)}
+        <li>
+          <button type="button" class="item" class:answered={item.answered} onclick={() => onReveal(item)}>
+            <span class="mark" aria-hidden="true">
+              {#if filling === item.label}
+                <Loader class="size-3 spin" />
+              {:else if item.answered}
+                <Check class="size-3" />
+              {:else}
+                <MapPin class="size-3" />
+              {/if}
+            </span>
+            <span class="label">{item.label}</span>
+          </button>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+{/snippet}
+
+<Card class="apply-plan">
+  <div class="head">
+    <span class="title">Application form</span>
+    {#if plan.required}
+      <span class="count">{plan.required.answered}/{plan.required.total} · {plan.required.percent}%</span>
+    {/if}
+  </div>
+
+  {#if plan.required}
+    <!-- The bar states the same figure as the count beside it, so it carries no
+         label of its own; the count is what a screen reader reads out. -->
+    <div class="bar" role="presentation">
+      <div class="fill" style="width: {plan.required.percent}%"></div>
+    </div>
+  {/if}
+
+
+  {@render group('Required', required)}
+  {@render group('Optional', optional)}
+</Card>
+
+<style>
+  /* Same inset as MatchCard, for the same reason: the panel's own padding is the
+   * card's outer margin, so a margin here would double it. */
+  :global(.apply-plan) {
+    padding: 14px;
+  }
+
+  .head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  .title {
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  .count {
+    font-size: 12px;
+    color: var(--muted-foreground);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .bar {
+    margin-top: 8px;
+    height: 6px;
+    border-radius: 999px;
+    background: var(--muted);
+    overflow: hidden;
+  }
+
+  .fill {
+    height: 100%;
+    background: var(--brand);
+    transition: width 200ms ease-out;
+  }
+
+  .group {
+    margin: 12px 0 4px;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--muted-foreground);
+  }
+
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  /* Every item is actionable, answered or not: going back to a question you have
+   * already answered is how you check what went into it. */
+  .item {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 6px;
+    border: 0;
+    border-radius: 6px;
+    background: none;
+    text-align: left;
+    font: inherit;
+    font-size: 13px;
+    color: var(--muted-foreground);
+    cursor: pointer;
+  }
+
+  .item:hover {
+    background: var(--accent);
+  }
+
+  .item.answered {
+    color: var(--foreground);
+  }
+
+  .mark {
+    flex: none;
+    display: flex;
+    width: 16px;
+    height: 16px;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    color: var(--muted-foreground);
+  }
+
+  .item.answered .mark {
+    background: var(--brand);
+    border-color: var(--brand);
+    color: var(--brand-foreground);
+  }
+
+  .label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  :global(.spin) {
+    animation: spin 1s linear infinite;
+  }
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+</style>

--- a/extension/lib/applyPlan.test.ts
+++ b/extension/lib/applyPlan.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildPlan } from './applyPlan';
+import { buildPlan, markAnswered } from './applyPlan';
 import type { FramedField } from './protocol';
 
 /** A question as the page reported it. Overrides say what the case is about. */
@@ -97,5 +97,36 @@ describe('buildPlan', () => {
 
     expect(plan.items.map((i) => i.label)).toEqual(['Email']);
     expect(plan.required).toEqual({ answered: 0, total: 1, percent: 0 });
+  });
+});
+
+describe('markAnswered', () => {
+  it('ticks one item off and moves the counter', () => {
+    const plan = buildPlan([
+      field('First name', { required: true, value: 'Igor' }),
+      field('Email', { required: true }),
+    ]);
+
+    const after = markAnswered(plan, 'Email');
+
+    expect(after.items.map((i) => i.answered)).toEqual([true, true]);
+    expect(after.required).toEqual({ answered: 2, total: 2, percent: 100 });
+  });
+
+  // The walk ticks off what it wrote. A label the plan does not carry (the agent
+  // reported a question this page no longer asks) changes nothing rather than
+  // inventing a row.
+  it('leaves a plan that does not carry the label alone', () => {
+    const plan = buildPlan([field('Email', { required: true })]);
+
+    expect(markAnswered(plan, 'Gone')).toEqual(plan);
+  });
+
+  it('does not touch the optional side of the counter', () => {
+    const plan = buildPlan([field('Email', { required: true }), field('Website')]);
+
+    const after = markAnswered(plan, 'Website');
+
+    expect(after.required).toEqual({ answered: 0, total: 1, percent: 0 });
   });
 });

--- a/extension/lib/applyPlan.test.ts
+++ b/extension/lib/applyPlan.test.ts
@@ -107,7 +107,7 @@ describe('markAnswered', () => {
       field('Email', { required: true }),
     ]);
 
-    const after = markAnswered(plan, 'Email');
+    const after = markAnswered(plan, { label: 'Email', frame: 0, form: 0 });
 
     expect(after.items.map((i) => i.answered)).toEqual([true, true]);
     expect(after.required).toEqual({ answered: 2, total: 2, percent: 100 });
@@ -119,13 +119,29 @@ describe('markAnswered', () => {
   it('leaves a plan that does not carry the label alone', () => {
     const plan = buildPlan([field('Email', { required: true })]);
 
-    expect(markAnswered(plan, 'Gone')).toEqual(plan);
+    expect(markAnswered(plan, { label: 'Gone', frame: 0, form: 0 })).toEqual(plan);
+  });
+
+  // Two questions can carry the same label in different forms or frames — an
+  // application and a job-alert signup each have their own "Email". Ticking one
+  // off must not tick the other, or the counter reports progress that is not
+  // there.
+  it('ticks off the question at that address only', () => {
+    const plan = buildPlan([
+      field('Email', { required: true, frame: 0, form: 0 }),
+      field('Email', { required: true, frame: 1, form: 0 }),
+    ]);
+
+    const after = markAnswered(plan, { label: 'Email', frame: 1, form: 0 });
+
+    expect(after.items.map((i) => i.answered)).toEqual([false, true]);
+    expect(after.required).toEqual({ answered: 1, total: 2, percent: 50 });
   });
 
   it('does not touch the optional side of the counter', () => {
     const plan = buildPlan([field('Email', { required: true }), field('Website')]);
 
-    const after = markAnswered(plan, 'Website');
+    const after = markAnswered(plan, { label: 'Website', frame: 0, form: 0 });
 
     expect(after.required).toEqual({ answered: 0, total: 1, percent: 0 });
   });

--- a/extension/lib/applyPlan.test.ts
+++ b/extension/lib/applyPlan.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { buildPlan } from './applyPlan';
+import type { FramedField } from './protocol';
+
+/** A question as the page reported it. Overrides say what the case is about. */
+function field(label: string, over: Partial<FramedField> = {}): FramedField {
+  return {
+    frame: 0,
+    index: 0,
+    form: 0,
+    tag: 'input',
+    type: 'text',
+    label,
+    name: label.toLowerCase().replace(/\s+/g, '_'),
+    required: false,
+    value: '',
+    combo: false,
+    ...over,
+  };
+}
+
+describe('buildPlan', () => {
+  it('carries one item per question, in the order the page asks them', () => {
+    const plan = buildPlan([field('First name'), field('Email'), field('City')]);
+
+    expect(plan.items.map((i) => i.label)).toEqual(['First name', 'Email', 'City']);
+  });
+
+  // The page reports a question, not a control: a legend over 29 country checkboxes
+  // arrives as ONE field carrying their labels as options, and must stay one line.
+  it('keeps a grouped question as a single item', () => {
+    const plan = buildPlan([
+      field('Which countries do you anticipate working in?', {
+        options: ['Germany', 'Poland', 'Spain'],
+        value: 'Germany',
+      }),
+    ]);
+
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]?.answered).toBe(true);
+  });
+
+  it('counts a question the page already answered as answered', () => {
+    const plan = buildPlan([field('Email', { value: 'a@b.test' }), field('City')]);
+
+    expect(plan.items.map((i) => i.answered)).toEqual([true, false]);
+  });
+
+  // Whitespace is not an answer: an ATS that seeds a field with a space would
+  // otherwise report a form as further along than it is.
+  it('does not count whitespace as an answer', () => {
+    const plan = buildPlan([field('City', { value: '   ' })]);
+
+    expect(plan.items[0]?.answered).toBe(false);
+  });
+
+  it('counts required questions only', () => {
+    const plan = buildPlan([
+      field('First name', { required: true, value: 'Igor' }),
+      field('Email', { required: true, value: 'a@b.test' }),
+      field('City', { required: true }),
+      field('Website', { value: 'https://example.test' }),
+    ]);
+
+    expect(plan.required).toEqual({ answered: 2, total: 3, percent: 67 });
+  });
+
+  // A percentage over zero required questions states nothing, so there is nothing
+  // to show — the checklist still is.
+  it('reports no counter when the form marks nothing required', () => {
+    const plan = buildPlan([field('Website'), field('X (fka Twitter)')]);
+
+    expect(plan.required).toBeNull();
+    expect(plan.items).toHaveLength(2);
+  });
+
+  it('is empty for a page with no fields', () => {
+    const plan = buildPlan([]);
+
+    expect(plan.items).toEqual([]);
+    expect(plan.required).toBeNull();
+  });
+
+  // The panel addresses a question the way a fill does — by label plus the frame and
+  // form it was read from — so an item carries them verbatim.
+  it('carries the frame and form each question was read from', () => {
+    const plan = buildPlan([field('Email', { frame: 2, form: 1 })]);
+
+    expect(plan.items[0]).toMatchObject({ label: 'Email', frame: 2, form: 1 });
+  });
+
+  // A question with no label cannot be addressed by label, and reads as an anonymous
+  // row in the checklist. Dropping it is honest: the counter would otherwise promise
+  // an item the panel cannot reach.
+  it('drops a question the page gave no label', () => {
+    const plan = buildPlan([field(''), field('  '), field('Email', { required: true })]);
+
+    expect(plan.items.map((i) => i.label)).toEqual(['Email']);
+    expect(plan.required).toEqual({ answered: 0, total: 1, percent: 0 });
+  });
+});

--- a/extension/lib/applyPlan.ts
+++ b/extension/lib/applyPlan.ts
@@ -12,15 +12,21 @@
 
 import type { FramedField } from './protocol';
 
-/** One question in the checklist, addressed the way a fill addresses it. */
-export interface PlanItem {
+/**
+ * Which question, exactly. The label alone does not say: an application and a
+ * job-alert signup on the same page each have their own "Email", and an ATS
+ * serves the application from its own frame — so both narrowings travel with it.
+ */
+export interface FieldAddress {
   label: string;
-  required: boolean;
-  answered: boolean;
-  /** The frame and form the question was read from — a fill and a reveal need both
-   *  to reach the same question when a page carries more than one form. */
   frame: number;
   form: number;
+}
+
+/** One question in the checklist, addressed the way a fill addresses it. */
+export interface PlanItem extends FieldAddress {
+  required: boolean;
+  answered: boolean;
 }
 
 /** How far along the questions that gate submission are. */
@@ -46,9 +52,10 @@ export interface ApplyPlan {
  * when the page's own change notice arrives. A label the plan does not carry
  * changes nothing.
  */
-export function markAnswered(plan: ApplyPlan, label: string): ApplyPlan {
-  if (!plan.items.some((i) => i.label === label && !i.answered)) return plan;
-  return recount(plan.items.map((i) => (i.label === label ? { ...i, answered: true } : i)));
+export function markAnswered(plan: ApplyPlan, at: FieldAddress): ApplyPlan {
+  const isTarget = (i: PlanItem) => i.label === at.label && i.frame === at.frame && i.form === at.form;
+  if (!plan.items.some((i) => isTarget(i) && !i.answered)) return plan;
+  return recount(plan.items.map((i) => (isTarget(i) ? { ...i, answered: true } : i)));
 }
 
 /** The plan for the questions the page reported, in the order it asks them. */

--- a/extension/lib/applyPlan.ts
+++ b/extension/lib/applyPlan.ts
@@ -1,0 +1,67 @@
+/**
+ * The panel's account of the application form in front of the user: the questions
+ * the page asks, which of them are answered, and how far along the required ones
+ * are.
+ *
+ * Pure over the fields the page reported — no DOM, no messaging — so the counter
+ * arithmetic and the answered rule are testable on their own, the same discipline
+ * `scraper.ts` and `form.ts` keep. The unit is the QUESTION the page reported, not
+ * the control: a legend over 29 country checkboxes arrives as one field and stays
+ * one line here.
+ */
+
+import type { FramedField } from './protocol';
+
+/** One question in the checklist, addressed the way a fill addresses it. */
+export interface PlanItem {
+  label: string;
+  required: boolean;
+  answered: boolean;
+  /** The frame and form the question was read from — a fill and a reveal need both
+   *  to reach the same question when a page carries more than one form. */
+  frame: number;
+  form: number;
+}
+
+/** How far along the questions that gate submission are. */
+export interface RequiredProgress {
+  answered: number;
+  total: number;
+  /** Rounded to whole percent — the panel shows a figure, not a measurement. */
+  percent: number;
+}
+
+export interface ApplyPlan {
+  items: PlanItem[];
+  /** Null when the form marks nothing required: a percentage over zero required
+   *  questions states nothing, so there is no counter to show. */
+  required: RequiredProgress | null;
+}
+
+/** The plan for the questions the page reported, in the order it asks them. */
+export function buildPlan(fields: FramedField[]): ApplyPlan {
+  const items: PlanItem[] = fields
+    // A question with no label cannot be addressed by label, which is how both the
+    // fill and the reveal reach one. Counting it would promise a row the panel
+    // cannot act on.
+    .filter((f) => f.label.trim() !== '')
+    .map((f) => ({
+      label: f.label,
+      required: f.required,
+      answered: f.value.trim() !== '',
+      frame: f.frame,
+      form: f.form,
+    }));
+
+  const required = items.filter((i) => i.required);
+  if (required.length === 0) return { items, required: null };
+  const answered = required.filter((i) => i.answered).length;
+  return {
+    items,
+    required: {
+      answered,
+      total: required.length,
+      percent: Math.round((answered / required.length) * 100),
+    },
+  };
+}

--- a/extension/lib/applyPlan.ts
+++ b/extension/lib/applyPlan.ts
@@ -38,6 +38,19 @@ export interface ApplyPlan {
   required: RequiredProgress | null;
 }
 
+/**
+ * The plan with one question ticked off, by label.
+ *
+ * A walk knows what it just wrote, so it says so directly rather than re-reading
+ * the whole page per step — the counter moves with the value, not 400ms later
+ * when the page's own change notice arrives. A label the plan does not carry
+ * changes nothing.
+ */
+export function markAnswered(plan: ApplyPlan, label: string): ApplyPlan {
+  if (!plan.items.some((i) => i.label === label && !i.answered)) return plan;
+  return recount(plan.items.map((i) => (i.label === label ? { ...i, answered: true } : i)));
+}
+
 /** The plan for the questions the page reported, in the order it asks them. */
 export function buildPlan(fields: FramedField[]): ApplyPlan {
   const items: PlanItem[] = fields
@@ -53,6 +66,12 @@ export function buildPlan(fields: FramedField[]): ApplyPlan {
       form: f.form,
     }));
 
+  return recount(items);
+}
+
+/** The counter, derived from the items. The one place the arithmetic lives, so a
+ *  plan built from a fresh read and one ticked off in place agree. */
+function recount(items: PlanItem[]): ApplyPlan {
   const required = items.filter((i) => i.required);
   if (required.length === 0) return { items, required: null };
   const answered = required.filter((i) => i.answered).length;

--- a/extension/lib/debounce.test.ts
+++ b/extension/lib/debounce.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { debounce } from './debounce';
+
+describe('debounce', () => {
+  it('calls once for a burst, after the quiet period', async () => {
+    vi.useFakeTimers();
+    const calls: number[] = [];
+    const fn = debounce(() => calls.push(1), 400);
+
+    fn();
+    fn();
+    fn();
+    expect(calls).toHaveLength(0);
+
+    vi.advanceTimersByTime(399);
+    expect(calls).toHaveLength(0);
+    vi.advanceTimersByTime(1);
+    expect(calls).toHaveLength(1);
+
+    vi.useRealTimers();
+  });
+
+  // An ATS form fires input events for as long as the user types. Each keystroke
+  // must push the call out, or a slow typist gets one re-read mid-word and none
+  // at the end.
+  it('restarts the wait on every call', () => {
+    vi.useFakeTimers();
+    const calls: number[] = [];
+    const fn = debounce(() => calls.push(1), 400);
+
+    fn();
+    vi.advanceTimersByTime(300);
+    fn();
+    vi.advanceTimersByTime(300);
+    expect(calls).toHaveLength(0);
+
+    vi.advanceTimersByTime(100);
+    expect(calls).toHaveLength(1);
+
+    vi.useRealTimers();
+  });
+
+  it('runs again for a later burst', () => {
+    vi.useFakeTimers();
+    const calls: number[] = [];
+    const fn = debounce(() => calls.push(1), 100);
+
+    fn();
+    vi.advanceTimersByTime(100);
+    fn();
+    vi.advanceTimersByTime(100);
+
+    expect(calls).toHaveLength(2);
+    vi.useRealTimers();
+  });
+});

--- a/extension/lib/debounce.ts
+++ b/extension/lib/debounce.ts
@@ -1,0 +1,17 @@
+/**
+ * Calls `fn` once a burst of calls has gone quiet for `waitMs`.
+ *
+ * The page's form fires an event per keystroke; the panel wants one re-read when
+ * the user stops, not sixty while they type. Split out of the content script so
+ * the timing is testable without a page.
+ */
+export function debounce(fn: () => void, waitMs: number): () => void {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return () => {
+    if (timer !== undefined) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = undefined;
+      fn();
+    }, waitMs);
+  };
+}

--- a/extension/lib/form.test.ts
+++ b/extension/lib/form.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
+  revealField,
   extractForm,
   extractUploads,
   matchFieldKey,
@@ -800,5 +801,66 @@ describe('matchFieldKey', () => {
     // authorized countries — so answering it would put the wrong shape of
     // value into a Yes/No control. See the Roku case above.
     expect(matchFieldKey('Are you authorized to work in this country?')).toBeNull();
+  });
+});
+
+describe('revealField', () => {
+  beforeEach(reset);
+
+  /** A form whose control carries an inline style of its own, so a reveal that
+   *  fails to restore it is visible. */
+  function labelled(label: string, style = 'color: rebeccapurple') {
+    const form = document.createElement('form');
+    const el = document.createElement('input');
+    el.type = 'text';
+    el.id = 'reveal-target';
+    el.setAttribute('style', style);
+    const lab = document.createElement('label');
+    lab.setAttribute('for', el.id);
+    lab.textContent = label;
+    form.append(lab, el);
+    document.body.append(form);
+    return el;
+  }
+
+  it('scrolls the question it names into view', () => {
+    const el = labelled('Email');
+    let scrolled: ScrollIntoViewOptions | undefined;
+    el.scrollIntoView = (opts?: boolean | ScrollIntoViewOptions) => {
+      scrolled = opts as ScrollIntoViewOptions;
+    };
+
+    expect(revealField(document, { label: 'Email' })).toBe(true);
+    expect(scrolled?.block).toBe('center');
+  });
+
+  it('reports a label the page does not carry, and touches nothing', () => {
+    labelled('Email');
+
+    expect(revealField(document, { label: 'Favourite colour' })).toBe(false);
+  });
+
+  // The outline is written onto a page freehire does not own, so it has to leave
+  // the element exactly as it found it — including an inline style of its own.
+  it('restores the inline style it borrowed', async () => {
+    const el = labelled('Email', 'color: rebeccapurple');
+    el.scrollIntoView = () => {};
+
+    revealField(document, { label: 'Email', outlineMs: 5 });
+    expect(el.getAttribute('style')).not.toBe('color: rebeccapurple');
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(el.getAttribute('style')).toBe('color: rebeccapurple');
+  });
+
+  it('focuses the control only when asked', () => {
+    const el = labelled('Email');
+    el.scrollIntoView = () => {};
+
+    revealField(document, { label: 'Email' });
+    expect(document.activeElement).not.toBe(el);
+
+    revealField(document, { label: 'Email', focus: true });
+    expect(document.activeElement).toBe(el);
   });
 });

--- a/extension/lib/form.test.ts
+++ b/extension/lib/form.test.ts
@@ -864,3 +864,30 @@ describe('revealField', () => {
     expect(document.activeElement).toBe(el);
   });
 });
+
+describe('revealField, revealed twice', () => {
+  beforeEach(reset);
+
+  // Two reveals of the same control inside the outline's lifetime: without a
+  // per-control record of what was borrowed, the second call saves the FIRST
+  // call's outline as the original and restores it for good.
+  it('still gives the page its own style back', async () => {
+    const form = document.createElement('form');
+    const el = document.createElement('input');
+    el.type = 'text';
+    el.id = 'twice';
+    el.setAttribute('style', 'color: rebeccapurple');
+    const lab = document.createElement('label');
+    lab.setAttribute('for', el.id);
+    lab.textContent = 'Email';
+    form.append(lab, el);
+    document.body.append(form);
+    el.scrollIntoView = () => {};
+
+    revealField(document, { label: 'Email', outlineMs: 30 });
+    revealField(document, { label: 'Email', outlineMs: 30 });
+
+    await new Promise((r) => setTimeout(r, 80));
+    expect(el.getAttribute('style')).toBe('color: rebeccapurple');
+  });
+});

--- a/extension/lib/form.ts
+++ b/extension/lib/form.ts
@@ -553,16 +553,30 @@ export function revealField(
 
   const el = question.controls[0];
   el.scrollIntoView({ block: 'center', behavior: 'smooth' });
-  const borrowed = el.getAttribute('style');
+
+  // Revealing the same control twice inside the outline's lifetime must not make
+  // the outline the style we give back: the first reveal's record wins, and its
+  // timer is replaced rather than left to fire against a control the second
+  // reveal is still outlining.
+  const open = outlined.get(el);
+  if (open) clearTimeout(open.timer);
+  const borrowed = open ? open.borrowed : el.getAttribute('style');
   el.style.outline = '2px solid #4f46e5';
   el.style.outlineOffset = '2px';
-  setTimeout(() => {
+  const timer = setTimeout(() => {
+    outlined.delete(el);
     if (borrowed === null) el.removeAttribute('style');
     else el.setAttribute('style', borrowed);
   }, outlineMs);
+  outlined.set(el, { borrowed, timer });
+
   if (focus) el.focus({ preventScroll: true });
   return true;
 }
+
+/** Controls currently wearing a borrowed outline, and the style each one had
+ *  before it. Weak so a control the page discards is not held alive by it. */
+const outlined = new WeakMap<Element, { borrowed: string | null; timer: ReturnType<typeof setTimeout> }>();
 
 export function fillByLabel(doc: Document, fills: LabelFill[]): FillOutcome[] {
   const questions = collectQuestions(doc);

--- a/extension/lib/form.ts
+++ b/extension/lib/form.ts
@@ -9,7 +9,7 @@
  * which a position in the list does.
  */
 
-import type { FieldTag, FormField, LabelFill, FillOutcome, Upload } from './protocol';
+import type { FieldTag, FormField, LabelFill, FillOutcome, RevealRequest, Upload } from './protocol';
 import { countryLabel } from './labels';
 
 type Fillable = HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
@@ -530,6 +530,40 @@ export function fillsForFrame(fills: LabelFill[], frame: number): LabelFill[] {
  * absorb a fill meant for the other. A fill naming none matches the first
  * question carrying the label, as `fillByLabel` always has.
  */
+/** How long the borrowed outline stays on a revealed control. Long enough to
+ *  follow by eye, short enough that a walk's next step does not overlap it. */
+const REVEAL_OUTLINE_MS = 600;
+
+/**
+ * Brings one question into view: scrolls its first control to the middle of the
+ * viewport, outlines it briefly, and focuses it when asked. Reports whether the
+ * question was there at all — the panel says so rather than doing nothing.
+ *
+ * The outline is written as inline style and the previous inline style is put
+ * back: this runs on a page freehire does not own, where an injected class could
+ * collide with the ATS's own and a stylesheet would outlive our interest in the
+ * element.
+ */
+export function revealField(
+  doc: Document,
+  { label, form, focus = false, outlineMs = REVEAL_OUTLINE_MS }: RevealRequest,
+): boolean {
+  const question = findQuestion(collectQuestions(doc), Array.from(doc.querySelectorAll('form')), label, form);
+  if (!question) return false;
+
+  const el = question.controls[0];
+  el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+  const borrowed = el.getAttribute('style');
+  el.style.outline = '2px solid #4f46e5';
+  el.style.outlineOffset = '2px';
+  setTimeout(() => {
+    if (borrowed === null) el.removeAttribute('style');
+    else el.setAttribute('style', borrowed);
+  }, outlineMs);
+  if (focus) el.focus({ preventScroll: true });
+  return true;
+}
+
 export function fillByLabel(doc: Document, fills: LabelFill[]): FillOutcome[] {
   const questions = collectQuestions(doc);
   const forms = Array.from(doc.querySelectorAll('form'));

--- a/extension/lib/protocol.ts
+++ b/extension/lib/protocol.ts
@@ -146,6 +146,11 @@ export interface ComboboxReply {
  */
 export interface RevealRequest {
   label: string;
+  /** The frame the question was read from. Without it the reveal is offered to
+   *  every frame, and two frames carrying the same label would both scroll — and
+   *  both take the cursor. Undefined only where the caller has no frame to name
+   *  (the agent's report carries labels alone). */
+  frame?: number;
   form?: number;
   focus?: boolean;
   outlineMs?: number;

--- a/extension/lib/protocol.ts
+++ b/extension/lib/protocol.ts
@@ -135,6 +135,22 @@ export interface ComboboxReply {
   committed?: string;
 }
 
+/**
+ * Which question to bring into view, addressed exactly as a fill addresses one —
+ * by label, narrowed to a `form` when the page carries more than one. `focus`
+ * hands the cursor over, which is what the panel wants when the user is being
+ * sent to a question to answer it themselves, and not what a fill wants (taking
+ * focus mid-walk would fight the user typing elsewhere).
+ *
+ * `outlineMs` is the borrowed outline's lifetime; only tests set it.
+ */
+export interface RevealRequest {
+  label: string;
+  form?: number;
+  focus?: boolean;
+  outlineMs?: number;
+}
+
 /** Messages passed inside the extension via chrome.runtime. */
 export type RuntimeMessage =
   | { kind: 'GET_PAGE_SNAPSHOT' }
@@ -146,8 +162,20 @@ export type RuntimeMessage =
   // by whichever frame replied first — in practice the empty one.
   | { kind: 'GET_FRAMED_FORM' }
   | { kind: 'FRAMED_FORM'; fields: FramedField[]; uploads: FramedUpload[] }
-  | { kind: 'FILL_BY_LABEL'; fills: LabelFill[] }
+  // `reveal` makes a fill visible: the page scrolls to the question and outlines
+  // it as the value lands, which is how the panel's walk is watched. Absent for
+  // the agent's own tool-driven fills, which must stay silent.
+  | { kind: 'FILL_BY_LABEL'; fills: LabelFill[]; reveal?: boolean }
   | { kind: 'FILL_OUTCOMES'; outcomes: FillOutcome[] }
+  // Sending the user to one question — the panel's checklist acting on an item
+  // it could not answer. `found` is false when the page no longer carries it, so
+  // the panel can say so rather than appear to do nothing.
+  | { kind: 'REVEAL_FIELD'; request: RevealRequest }
+  | { kind: 'REVEAL_RESULT'; found: boolean }
+  // The page telling the panel that its form changed — the user typed an answer
+  // themselves. Carries nothing: the panel re-reads the form, which is the only
+  // account that cannot drift.
+  | { kind: 'FORM_CHANGED' }
   // Driving a custom-widget combobox: one step, offered to every frame, since
   // only the frame holding the widget can answer for it.
   | { kind: 'COMBOBOX_STEP'; step: ComboboxStep }

--- a/extension/lib/walk.test.ts
+++ b/extension/lib/walk.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { startWalk, nextStep, applyStep, skipStep, stopWalk } from './walk';
+
+describe('walk', () => {
+  it('offers the labels in the order it was given them', () => {
+    let walk = startWalk(['First name', 'Email', 'City']);
+
+    const seen: string[] = [];
+    for (;;) {
+      const step = nextStep(walk);
+      if (!step) break;
+      seen.push(step);
+      walk = applyStep(walk, step);
+    }
+
+    expect(seen).toEqual(['First name', 'Email', 'City']);
+  });
+
+  it('is done once every label has been applied', () => {
+    let walk = startWalk(['Email']);
+    walk = applyStep(walk, 'Email');
+
+    expect(nextStep(walk)).toBeNull();
+    expect(walk.done).toEqual(['Email']);
+  });
+
+  // The user pressed Stop. What is already on the page stays there — this ends the
+  // walk, it does not undo it.
+  it('offers nothing more once stopped, and keeps what it applied', () => {
+    let walk = startWalk(['First name', 'Email', 'City']);
+    walk = applyStep(walk, 'First name');
+    walk = applyStep(walk, 'Email');
+    walk = stopWalk(walk);
+
+    expect(nextStep(walk)).toBeNull();
+    expect(walk.done).toEqual(['First name', 'Email']);
+    expect(walk.stopped).toBe(true);
+  });
+
+  // A form re-renders mid-walk and drops a question. Skipping it is not the end of
+  // the walk — the questions after it are still there to answer.
+  it('records a skip and carries on', () => {
+    let walk = startWalk(['First name', 'Gone', 'City']);
+    walk = applyStep(walk, 'First name');
+    walk = skipStep(walk, 'Gone');
+
+    expect(nextStep(walk)).toBe('City');
+    walk = applyStep(walk, 'City');
+    expect(walk.done).toEqual(['First name', 'City']);
+    expect(walk.skipped).toEqual(['Gone']);
+  });
+
+  it('has nothing to offer for an empty plan', () => {
+    const walk = startWalk([]);
+
+    expect(nextStep(walk)).toBeNull();
+    expect(walk.done).toEqual([]);
+  });
+});

--- a/extension/lib/walk.ts
+++ b/extension/lib/walk.ts
@@ -8,45 +8,50 @@
  * pauses and the wire.
  */
 
-export interface Walk {
-  /** The labels to work through, in order. */
-  labels: string[];
+export interface Walk<T> {
+  /** The steps to work through, in order. */
+  steps: T[];
   /** How far along the list the walk has got. */
   at: number;
-  /** Labels whose value was written. */
-  done: string[];
-  /** Labels the page no longer carried when their turn came. */
-  skipped: string[];
+  /** Steps whose value was written. */
+  done: T[];
+  /** Steps the page no longer carried when their turn came. */
+  skipped: T[];
   stopped: boolean;
 }
 
-/** A walk over these labels, at the start. */
-export function startWalk(labels: string[]): Walk {
-  return { labels, at: 0, done: [], skipped: [], stopped: false };
+/**
+ * A walk over these steps, at the start. Generic in the step so the caller keeps
+ * whatever it needs to act on — a fill carries the value and the frame it
+ * belongs to, the agent's report carries a bare label — instead of the walk
+ * holding labels and the caller indexing back into its own list to find the rest.
+ */
+export function startWalk<T>(steps: T[]): Walk<T> {
+  return { steps, at: 0, done: [], skipped: [], stopped: false };
 }
 
-/** The label to work on now, or null when the walk is over or stopped. */
-export function nextStep(walk: Walk): string | null {
-  if (walk.stopped || walk.at >= walk.labels.length) return null;
-  return walk.labels[walk.at] ?? null;
+/** The step to work on now, or null when the walk is over or stopped. */
+export function nextStep<T>(walk: Walk<T>): T | null {
+  if (walk.stopped || walk.at >= walk.steps.length) return null;
+  return walk.steps[walk.at] ?? null;
 }
 
-/** Records that `label` was written, and moves on. */
-export function applyStep(walk: Walk, label: string): Walk {
-  return { ...walk, at: walk.at + 1, done: [...walk.done, label] };
+/** Records that the step was written, and moves on. */
+export function applyStep<T>(walk: Walk<T>, step: T): Walk<T> {
+  return { ...walk, at: walk.at + 1, done: [...walk.done, step] };
 }
 
 /**
- * Records that `label` was not there to write, and moves on. A question that
+ * Records that the step was not there to write, and moves on. A question that
  * vanished mid-walk (the form re-rendered, a step collapsed) does not end the
  * walk: the questions after it are still worth answering.
  */
-export function skipStep(walk: Walk, label: string): Walk {
-  return { ...walk, at: walk.at + 1, skipped: [...walk.skipped, label] };
+export function skipStep<T>(walk: Walk<T>, step: T): Walk<T> {
+  return { ...walk, at: walk.at + 1, skipped: [...walk.skipped, step] };
 }
 
 /** Ends the walk. What it already wrote stays on the page — this stops, it does
  *  not undo. */
-export function stopWalk(walk: Walk): Walk {
+export function stopWalk<T>(walk: Walk<T>): Walk<T> {
   return { ...walk, stopped: true };
 }

--- a/extension/lib/walk.ts
+++ b/extension/lib/walk.ts
@@ -1,0 +1,52 @@
+/**
+ * The order an autofill works through the form, as a value.
+ *
+ * The panel fills one question at a time so the user can watch it happen, which
+ * means the sequence has state: where it is, what it applied, what it had to
+ * skip, and whether the user stopped it. Keeping that state here — pure, with no
+ * timers and no messaging — is what makes it testable; App.svelte supplies the
+ * pauses and the wire.
+ */
+
+export interface Walk {
+  /** The labels to work through, in order. */
+  labels: string[];
+  /** How far along the list the walk has got. */
+  at: number;
+  /** Labels whose value was written. */
+  done: string[];
+  /** Labels the page no longer carried when their turn came. */
+  skipped: string[];
+  stopped: boolean;
+}
+
+/** A walk over these labels, at the start. */
+export function startWalk(labels: string[]): Walk {
+  return { labels, at: 0, done: [], skipped: [], stopped: false };
+}
+
+/** The label to work on now, or null when the walk is over or stopped. */
+export function nextStep(walk: Walk): string | null {
+  if (walk.stopped || walk.at >= walk.labels.length) return null;
+  return walk.labels[walk.at] ?? null;
+}
+
+/** Records that `label` was written, and moves on. */
+export function applyStep(walk: Walk, label: string): Walk {
+  return { ...walk, at: walk.at + 1, done: [...walk.done, label] };
+}
+
+/**
+ * Records that `label` was not there to write, and moves on. A question that
+ * vanished mid-walk (the form re-rendered, a step collapsed) does not end the
+ * walk: the questions after it are still worth answering.
+ */
+export function skipStep(walk: Walk, label: string): Walk {
+  return { ...walk, at: walk.at + 1, skipped: [...walk.skipped, label] };
+}
+
+/** Ends the walk. What it already wrote stays on the page — this stops, it does
+ *  not undo. */
+export function stopWalk(walk: Walk): Walk {
+  return { ...walk, stopped: true };
+}

--- a/openspec/changes/add-apply-form-plan/.openspec.yaml
+++ b/openspec/changes/add-apply-form-plan/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/openspec/changes/add-apply-form-plan/design.md
+++ b/openspec/changes/add-apply-form-plan/design.md
@@ -1,0 +1,105 @@
+## Context
+
+The side panel already has both halves of what this needs: it reads a page's form
+(`GET_FRAMED_FORM` → `FramedField[]`, carrying label, `required`, current `value`, `frame`
+and `form`) and writes values back (`FILL_BY_LABEL` → `fillByLabel`), both addressing a
+*question* rather than a control. What it lacks is any standing account of that form — the
+result of an autofill is three sentences of notices, discarded on the next action.
+
+The full design narrative, agreed with the user before this change was opened, is in
+`docs/superpowers/specs/2026-08-15-extension-apply-plan-design.md`. This document records
+the decisions that shape the implementation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A checklist of the form's questions, standing on its own before anything is filled.
+- Autofill visible as it happens: scroll, outline, tick off, advance.
+- An unanswered question reachable from the panel in one action.
+- A counter that stays honest while the user types on the page.
+
+**Non-Goals:**
+
+- Asking for a missing answer inside the panel (the click-to-reach remainder is enough to
+  finish a form; the panel prompt is a later change if it earns itself).
+- Persisting answers back into the profile.
+- Modelling a multi-page ATS application. The plan describes the page in front of the user.
+- Any change to what autofill may write, or to the server's autofill profile.
+
+## Decisions
+
+### The plan is a projection, computed in one pure function
+
+`lib/applyPlan.ts` turns `FramedField[]` into `PlanItem[]` plus a counter. It is pure over
+its input — no DOM, no messaging — so the counter arithmetic, the required/optional split
+and "already answered" are unit tested directly, the same discipline `scraper.ts`,
+`form.ts` and `combobox.ts` keep. `ApplyPlan.svelte` renders what it is given and emits
+intent; it holds no page access of its own.
+
+*Alternative rejected:* computing the plan inside the component. It would put the only
+interesting logic in the one place this codebase cannot test without a browser.
+
+### The walk lives in the panel, not in the page or the agent
+
+The panel already owns the sequence: it has the plan, it can pause between steps, and it
+renders the progress. Driving the walk from the content script would need a second copy of
+the plan there; driving it from the agent would put a UI pace loop on the far side of the
+network.
+
+The agent path keeps filling server-side. The panel plays its report back: for each label
+in `filled`, match against the questions it just read, reveal it, tick it off. A label the
+page no longer carries is skipped — the report describes a form that may have re-rendered.
+
+### Reveal is a page-side primitive, restored after itself
+
+`revealField(doc, {label, form, focus})` scrolls the question's first control into view
+(`block: 'center'`), sets an inline outline for ~600 ms, restores the previous inline style,
+and focuses when asked. Inline style rather than an injected stylesheet: the page is not
+ours, a class could collide with the ATS's own, and a stylesheet outlives the extension's
+interest in the element.
+
+`FILL_BY_LABEL` gains `reveal?: boolean` rather than a second message, so a fill and its
+reveal cannot separate. The agent's own tool-driven fills leave it unset and stay silent.
+
+### The page tells the panel when the form changes
+
+One delegated `input`/`change` listener on the document, debounced 400 ms, posts
+`FORM_CHANGED`; the panel re-reads the form and recomputes. Delegation, not per-control
+listeners: an ATS form re-renders constantly and per-control listeners would be re-attached
+(or leak) on every render. Polling was the alternative — cheaper to write, and it either
+lags the user or re-walks the DOM on a timer forever.
+
+### The checklist renders where the match card already is
+
+The Match tab, above the pinned Autofill footer. It appears when the page shows an
+application form (`looksLikeApplication`, already used to guard the deterministic filler),
+so the panel does not decorate a job description with an empty account of a form that is
+not there.
+
+## Risks / Trade-offs
+
+- **A long form makes a long checklist** → The list is grouped (required first) and scrolls
+  with the panel's existing scroll container; no truncation, because hiding a required
+  question is exactly the failure this change exists to remove.
+- **`FORM_CHANGED` chatter on a busy ATS form** → Debounced at 400 ms and coalesced into one
+  re-read; the read is a DOM walk the panel already does per page.
+- **The 300 ms pause makes autofill slower** → Deliberate: the walk is the audit. A form
+  where the user does not want to watch is the one they leave alone; the values still land
+  in the same order.
+- **`required` is only as good as the page's markup** → Some ATS forms mark required in the
+  label text rather than the attribute. Those questions land in Optional and undercount the
+  counter. Accepted for now; the alternative is parsing the asterisk out of label text,
+  which guesses.
+
+## Migration Plan
+
+No server change, no schema, no permission. It ships with the next extension build; an older
+panel against the same page keeps working because every addition to the wire is optional
+(`reveal` absent = today's behaviour) and the new messages are ignored by a content script
+that does not know them.
+
+## Open Questions
+
+None outstanding. The panel-prompt-for-missing-answers idea was considered and explicitly
+deferred (see Non-Goals).

--- a/openspec/changes/add-apply-form-plan/proposal.md
+++ b/openspec/changes/add-apply-form-plan/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+Autofill in the side panel is a black box: the user presses one button and gets a sentence
+("Autofilled 9 fields — review before submitting"). Nothing says which questions those were,
+what is still unanswered, or whether the form can be submitted — so the user scrolls the
+whole ATS form to find out, which is the work autofill was meant to remove.
+
+## What Changes
+
+- The Match tab gains an **application-form checklist**: every question the open page asks,
+  split into required and optional, each marked answered or not, with a counter and progress
+  bar over the required ones.
+- **Autofill becomes a walk**: the page scrolls to each question in turn, the control is
+  outlined while its value lands, and the panel ticks the item off as it goes. The Autofill
+  button reads **Stop** while a walk is running.
+- **Unanswered questions stay reachable**: clicking one in the checklist scrolls the page to
+  it and puts the cursor in it.
+- The counter **follows the user's own typing** — a question they answer by hand on the page
+  ticks itself off in the panel.
+- The panel's fill primitives gain the page-side affordances this needs: reveal a question
+  (scroll + outline + optional focus), fill with reveal, and a change notification from the
+  page.
+
+No new server endpoint, no new permission, and no change to what autofill is allowed to
+write. The agent keeps filling the form server-side; the panel plays back its report.
+
+## Capabilities
+
+### New Capabilities
+
+- `extension-apply-plan`: what the side panel shows about the application form on the open
+  page — the checklist of questions, the required-fields counter, the field-by-field walk
+  during autofill, and reaching an unanswered question from the panel.
+
+### Modified Capabilities
+
+<!-- None. `extension-autofill` describes the contact block the server assembles; this change
+     adds no field to it and alters no requirement of it. -->
+
+## Impact
+
+- `extension/entrypoints/sidepanel/` — a new `ApplyPlan.svelte`, wired into the Match tab of
+  `App.svelte`; the autofill handler becomes a walk with a stop flag.
+- `extension/lib/applyPlan.ts` (new) — the pure projection from read form fields to checklist
+  items plus the counter.
+- `extension/lib/form.ts` — a `revealField` primitive (scroll, outline, optional focus).
+- `extension/entrypoints/content.ts` — handles reveal, fills with reveal, and notifies the
+  panel when the page's form changes.
+- `extension/lib/protocol.ts` — `REVEAL_FIELD` / `REVEAL_RESULT` / `FORM_CHANGED` messages and
+  a `reveal` flag on `FILL_BY_LABEL`.
+
+Design already agreed and recorded in
+`docs/superpowers/specs/2026-08-15-extension-apply-plan-design.md`.

--- a/openspec/changes/add-apply-form-plan/specs/extension-apply-plan/spec.md
+++ b/openspec/changes/add-apply-form-plan/specs/extension-apply-plan/spec.md
@@ -1,0 +1,114 @@
+## ADDED Requirements
+
+### Requirement: The panel accounts for the application form on the open page
+
+The side panel SHALL show a checklist of the questions the open page's application form
+asks, built from the same question unit the filler works in — a question rendered as
+several controls (a legend over 29 country checkboxes) SHALL appear once, not once per
+control.
+
+Each item SHALL carry the question's own label, whether the form marks it required, and
+whether it is currently answered. An answered question is one whose control already holds
+a value, whoever put it there: the panel, the agent, the page's own prefill, or the user.
+
+The checklist SHALL be shown only where the page actually offers an application form; a
+page with no form SHALL show no checklist rather than an empty one.
+
+#### Scenario: The checklist describes the form before anything is filled
+
+- **WHEN** the panel is open on a page whose application form asks eight questions, three of
+  them already carrying values from the page's own prefill
+- **THEN** the checklist lists eight items, marks those three answered, and marks the rest
+  unanswered
+
+#### Scenario: A grouped question is one item
+
+- **WHEN** the form asks one question rendered as a group of checkboxes under a single legend
+- **THEN** the checklist carries one item for it, labelled by the legend
+
+#### Scenario: A page with no application form shows no checklist
+
+- **WHEN** the panel is open on a page that offers no application form
+- **THEN** no checklist and no counter are shown
+
+### Requirement: The counter measures what gates submission
+
+The panel SHALL show how many of the form's REQUIRED questions are answered, as a count and
+as a percentage, with a progress bar over the same figure. Optional questions SHALL be
+listed but SHALL NOT count toward it.
+
+A form that marks no question required SHALL show no counter — a percentage over zero
+required questions states nothing.
+
+#### Scenario: The counter counts required questions only
+
+- **WHEN** the form asks seven required questions of which six are answered, plus four
+  optional ones of which none are
+- **THEN** the panel shows six of seven, 86%
+
+#### Scenario: A form with no required questions shows no counter
+
+- **WHEN** every question on the form is optional
+- **THEN** the checklist is shown and no counter is
+
+### Requirement: Autofill walks the form in view
+
+When autofill runs, the panel SHALL work through the questions one at a time rather than in
+one silent batch. For each question it fills, the page SHALL scroll that question into view
+and the control SHALL be outlined while its value is written, and the panel SHALL mark the
+item answered and advance the counter before moving to the next.
+
+The walk SHALL be interruptible: while it runs, the autofill control SHALL offer to stop it,
+and stopping SHALL leave every value already written in place.
+
+A question that has disappeared from the page since the plan was made SHALL be skipped
+without ending the walk.
+
+#### Scenario: Each filled question is shown as it is filled
+
+- **WHEN** autofill has three questions to answer
+- **THEN** the page scrolls to each in turn, each is outlined as its value is written, and
+  the checklist ticks each one off before the next is started
+
+#### Scenario: The walk can be stopped
+
+- **WHEN** the user stops a walk after two of five questions have been answered
+- **THEN** the walk ends, those two values remain on the page, and the checklist shows two
+  answered
+
+#### Scenario: A question that vanished mid-walk is skipped
+
+- **WHEN** the form re-renders during a walk and drops a question the plan named
+- **THEN** that item is left unanswered, the walk continues with the next question, and the
+  closing summary names what it could not answer
+
+### Requirement: An unanswered question is reachable from the panel
+
+The panel SHALL let the user jump to any question in the checklist: acting on an item SHALL
+scroll the page to that question and place the cursor in it, so a question autofill could
+not answer can be answered by hand without hunting for it.
+
+#### Scenario: Acting on an unanswered item goes to it
+
+- **WHEN** the user acts on an unanswered checklist item
+- **THEN** the page scrolls that question into view and its control takes focus
+
+#### Scenario: A question the page no longer has reports itself
+
+- **WHEN** the user acts on an item whose question is no longer on the page
+- **THEN** the panel says so rather than silently doing nothing
+
+### Requirement: The account follows what the user types
+
+The checklist and the counter SHALL reflect answers the user enters on the page themselves,
+without the user returning to the panel to refresh it.
+
+#### Scenario: Typing on the page ticks the item off
+
+- **WHEN** the user types an answer into a question the panel listed as unanswered
+- **THEN** the checklist marks it answered and the counter advances
+
+#### Scenario: Clearing an answer counts it back
+
+- **WHEN** the user empties a question the panel listed as answered
+- **THEN** the checklist marks it unanswered and the counter falls

--- a/openspec/changes/add-apply-form-plan/tasks.md
+++ b/openspec/changes/add-apply-form-plan/tasks.md
@@ -13,20 +13,20 @@
 
 ## 3. The checklist in the panel
 
-- [ ] 3.1 `extension/entrypoints/sidepanel/ApplyPlan.svelte`: renders an `ApplyPlan` — counter + progress bar (hidden when there are no required questions), Required and Optional groups, per-item answered/unanswered/filling state, and an action per item that emits "reveal this one". Design-system primitives only.
-- [ ] 3.2 `App.svelte`: read the page's form when the Match tab opens and on `FORM_CHANGED`, build the plan, render `ApplyPlan` when the page shows an application form (`looksLikeApplication`), and clear it on page change.
-- [ ] 3.3 `App.svelte`: item action → `REVEAL_FIELD` with focus; a `found: false` answer says so in the panel rather than doing nothing.
+- [x] 3.1 `extension/entrypoints/sidepanel/ApplyPlan.svelte`: renders an `ApplyPlan` — counter + progress bar (hidden when there are no required questions), Required and Optional groups, per-item answered/unanswered/filling state, and an action per item that emits "reveal this one". Design-system primitives only.
+- [x] 3.2 `App.svelte`: read the page's form when the Match tab opens and on `FORM_CHANGED`, build the plan, render `ApplyPlan` when the page shows an application form (`looksLikeApplication`), and clear it on page change.
+- [x] 3.3 `App.svelte`: item action → `REVEAL_FIELD` with focus; a `found: false` answer says so in the panel rather than doing nothing.
 
 ## 4. The walk
 
-- [ ] 4.1 `extension/lib/walk.ts`: the pure step reducer — given a plan and a list of labels to work through, yield the next step, apply an outcome, and honour a stop. No timers, no messaging.
-- [ ] 4.2 `walk.test.ts`: order is preserved, a stop ends it with values kept, a label absent from the plan is skipped without ending the walk, and the counter advances per applied step.
-- [ ] 4.3 `App.svelte`: drive the deterministic filler through the walk — one `FILL_BY_LABEL` with `reveal` per step, ~300 ms between steps, ticking the checklist as it goes.
-- [ ] 4.4 `App.svelte`: play the agent's report back through the same walk — match each reported label against the questions just read, reveal, tick; skip a label the page no longer carries.
-- [ ] 4.5 `App.svelte`: the Autofill button becomes Stop while a walk runs; stopping ends the walk and leaves written values in place. The closing summary names what could not be answered.
+- [x] 4.1 `extension/lib/walk.ts`: the pure step reducer — given a plan and a list of labels to work through, yield the next step, apply an outcome, and honour a stop. No timers, no messaging.
+- [x] 4.2 `walk.test.ts`: order is preserved, a stop ends it with values kept, a label absent from the plan is skipped without ending the walk, and the counter advances per applied step.
+- [x] 4.3 `App.svelte`: drive the deterministic filler through the walk — one `FILL_BY_LABEL` with `reveal` per step, ~300 ms between steps, ticking the checklist as it goes.
+- [x] 4.4 `App.svelte`: play the agent's report back through the same walk — match each reported label against the questions just read, reveal, tick; skip a label the page no longer carries.
+- [x] 4.5 `App.svelte`: the Autofill button becomes Stop while a walk runs; stopping ends the walk and leaves written values in place. The closing summary names what could not be answered.
 
 ## 5. Verification
 
-- [ ] 5.1 `npm run test` (extension), `npx svelte-check`, `npm run lint`, `npm run build` — all clean.
+- [x] 5.1 `npm run test` (extension), `npx svelte-check`, `npm run lint`, `npm run build` — all clean.
 - [ ] 5.2 Load the built extension and walk a real ATS application form end to end (Greenhouse or Ashby): checklist appears, walk scrolls and ticks, stop works, an unanswered item scrolls and focuses, typing on the page moves the counter.
-- [ ] 5.3 Update `extension/AGENTS.md` — the panel's layout list and the wire contract now include the plan, the walk and the three new messages.
+- [x] 5.3 Update `extension/AGENTS.md` — the panel's layout list and the wire contract now include the plan, the walk and the three new messages.

--- a/openspec/changes/add-apply-form-plan/tasks.md
+++ b/openspec/changes/add-apply-form-plan/tasks.md
@@ -1,0 +1,32 @@
+## 1. The plan projection
+
+- [ ] 1.1 `extension/lib/applyPlan.ts`: `PlanItem` + `buildPlan(fields: FramedField[]): ApplyPlan` — one item per question, required/optional split, `answered` from the field's current value, and the required counter (count, total, percent). Pure; no DOM, no messaging.
+- [ ] 1.2 `applyPlan.test.ts`: a grouped question counts once, an already-answered field counts answered, the counter counts required only, a form with no required questions yields no counter, an empty form yields an empty plan.
+
+## 2. Page-side primitives
+
+- [ ] 2.1 `extension/lib/protocol.ts`: `REVEAL_FIELD { label, frame, form, focus }` / `REVEAL_RESULT { found }` / `FORM_CHANGED`, and an optional `reveal` on `FILL_BY_LABEL`. Document each in the wire contract's own idiom.
+- [ ] 2.2 `extension/lib/form.ts`: `revealField(doc, {label, form, focus})` — find the question (reusing `findQuestion`), scroll its first control into view centred, outline it inline for ~600 ms, restore the previous inline style, focus when asked. Returns whether it found the question.
+- [ ] 2.3 `form.test.ts`: reveal finds a question by label, restores the inline style it changed, focuses only when asked, and reports `found: false` for a label the document does not carry.
+- [ ] 2.4 `extension/entrypoints/content.ts`: handle `REVEAL_FIELD`; honour `reveal` on `FILL_BY_LABEL` (reveal, then fill).
+- [ ] 2.5 `extension/entrypoints/content.ts`: one delegated `input`/`change` listener, debounced 400 ms, posting `FORM_CHANGED` to the panel. Extract the debounce so it is testable.
+
+## 3. The checklist in the panel
+
+- [ ] 3.1 `extension/entrypoints/sidepanel/ApplyPlan.svelte`: renders an `ApplyPlan` — counter + progress bar (hidden when there are no required questions), Required and Optional groups, per-item answered/unanswered/filling state, and an action per item that emits "reveal this one". Design-system primitives only.
+- [ ] 3.2 `App.svelte`: read the page's form when the Match tab opens and on `FORM_CHANGED`, build the plan, render `ApplyPlan` when the page shows an application form (`looksLikeApplication`), and clear it on page change.
+- [ ] 3.3 `App.svelte`: item action → `REVEAL_FIELD` with focus; a `found: false` answer says so in the panel rather than doing nothing.
+
+## 4. The walk
+
+- [ ] 4.1 `extension/lib/walk.ts`: the pure step reducer — given a plan and a list of labels to work through, yield the next step, apply an outcome, and honour a stop. No timers, no messaging.
+- [ ] 4.2 `walk.test.ts`: order is preserved, a stop ends it with values kept, a label absent from the plan is skipped without ending the walk, and the counter advances per applied step.
+- [ ] 4.3 `App.svelte`: drive the deterministic filler through the walk — one `FILL_BY_LABEL` with `reveal` per step, ~300 ms between steps, ticking the checklist as it goes.
+- [ ] 4.4 `App.svelte`: play the agent's report back through the same walk — match each reported label against the questions just read, reveal, tick; skip a label the page no longer carries.
+- [ ] 4.5 `App.svelte`: the Autofill button becomes Stop while a walk runs; stopping ends the walk and leaves written values in place. The closing summary names what could not be answered.
+
+## 5. Verification
+
+- [ ] 5.1 `npm run test` (extension), `npx svelte-check`, `npm run lint`, `npm run build` — all clean.
+- [ ] 5.2 Load the built extension and walk a real ATS application form end to end (Greenhouse or Ashby): checklist appears, walk scrolls and ticks, stop works, an unanswered item scrolls and focuses, typing on the page moves the counter.
+- [ ] 5.3 Update `extension/AGENTS.md` — the panel's layout list and the wire contract now include the plan, the walk and the three new messages.

--- a/openspec/changes/add-apply-form-plan/tasks.md
+++ b/openspec/changes/add-apply-form-plan/tasks.md
@@ -1,15 +1,15 @@
 ## 1. The plan projection
 
-- [ ] 1.1 `extension/lib/applyPlan.ts`: `PlanItem` + `buildPlan(fields: FramedField[]): ApplyPlan` — one item per question, required/optional split, `answered` from the field's current value, and the required counter (count, total, percent). Pure; no DOM, no messaging.
-- [ ] 1.2 `applyPlan.test.ts`: a grouped question counts once, an already-answered field counts answered, the counter counts required only, a form with no required questions yields no counter, an empty form yields an empty plan.
+- [x] 1.1 `extension/lib/applyPlan.ts`: `PlanItem` + `buildPlan(fields: FramedField[]): ApplyPlan` — one item per question, required/optional split, `answered` from the field's current value, and the required counter (count, total, percent). Pure; no DOM, no messaging.
+- [x] 1.2 `applyPlan.test.ts`: a grouped question counts once, an already-answered field counts answered, the counter counts required only, a form with no required questions yields no counter, an empty form yields an empty plan.
 
 ## 2. Page-side primitives
 
-- [ ] 2.1 `extension/lib/protocol.ts`: `REVEAL_FIELD { label, frame, form, focus }` / `REVEAL_RESULT { found }` / `FORM_CHANGED`, and an optional `reveal` on `FILL_BY_LABEL`. Document each in the wire contract's own idiom.
-- [ ] 2.2 `extension/lib/form.ts`: `revealField(doc, {label, form, focus})` — find the question (reusing `findQuestion`), scroll its first control into view centred, outline it inline for ~600 ms, restore the previous inline style, focus when asked. Returns whether it found the question.
-- [ ] 2.3 `form.test.ts`: reveal finds a question by label, restores the inline style it changed, focuses only when asked, and reports `found: false` for a label the document does not carry.
-- [ ] 2.4 `extension/entrypoints/content.ts`: handle `REVEAL_FIELD`; honour `reveal` on `FILL_BY_LABEL` (reveal, then fill).
-- [ ] 2.5 `extension/entrypoints/content.ts`: one delegated `input`/`change` listener, debounced 400 ms, posting `FORM_CHANGED` to the panel. Extract the debounce so it is testable.
+- [x] 2.1 `extension/lib/protocol.ts`: `REVEAL_FIELD { label, frame, form, focus }` / `REVEAL_RESULT { found }` / `FORM_CHANGED`, and an optional `reveal` on `FILL_BY_LABEL`. Document each in the wire contract's own idiom.
+- [x] 2.2 `extension/lib/form.ts`: `revealField(doc, {label, form, focus})` — find the question (reusing `findQuestion`), scroll its first control into view centred, outline it inline for ~600 ms, restore the previous inline style, focus when asked. Returns whether it found the question.
+- [x] 2.3 `form.test.ts`: reveal finds a question by label, restores the inline style it changed, focuses only when asked, and reports `found: false` for a label the document does not carry.
+- [x] 2.4 `extension/entrypoints/content.ts`: handle `REVEAL_FIELD`; honour `reveal` on `FILL_BY_LABEL` (reveal, then fill).
+- [x] 2.5 `extension/entrypoints/content.ts`: one delegated `input`/`change` listener, debounced 400 ms, posting `FORM_CHANGED` to the panel. Extract the debounce so it is testable.
 
 ## 3. The checklist in the panel
 


### PR DESCRIPTION
Autofill was a black box: one button, one sentence ("Autofilled 9 fields — review before submitting"), and a form the user still had to scroll end to end to see what happened. This gives the panel a standing account of the form and makes the filling watchable.

OpenSpec change: `openspec/changes/add-apply-form-plan/`. Agreed design: `docs/superpowers/specs/2026-08-15-extension-apply-plan-design.md`.

## What lands

**A checklist that stands on its own.** Every question the open application form asks, Required first, each marked answered or not, with a counter and bar over the required ones — the only ones that gate submission. A form marking nothing required gets the list and no counter, because a percentage over zero states nothing.

**Autofill walks the form in view.** Each question scrolls to centre and is outlined as its value lands; the item ticks off and the counter moves before the next step. ~300ms between steps, on purpose: the walk IS the audit the user would otherwise do afterwards. The button becomes **Stop** while it runs, and stopping keeps what was written.

**The remainder is reachable.** Acting on any item scrolls the page to that question and takes the cursor, so a question autofill could not answer is answered without hunting for it. A question the page no longer carries says so instead of doing nothing.

**The counter follows the user's own typing** — one delegated, debounced listener in the content script tells the panel the form changed, and the plan is rebuilt from a fresh read.

## Notable decisions

- **The unit is the question, not the control.** A legend over 29 country checkboxes is one line and one tick — the same unit the filler already works in.
- **A walk ticks off from what it wrote,** not from a re-read: the page's change notice is debounced 400ms, so re-reading per step would leave the counter a step behind the value on screen. `FORM_CHANGED` remains the reconciler.
- **The agent path is unchanged in what it writes.** It still fills server-side through the tool relay; the panel plays its report back (reveal + tick, no re-fill). A label the page has since dropped is skipped.
- **`revealField` borrows the page's inline style and gives it back.** This runs on pages freehire does not own, where an injected class can collide with the ATS's own.
- **Every wire addition is optional** — `reveal` absent is today's silent fill, which is what the agent's own tool calls want.

## Verification

- `npx vitest run` — 254 passed (23 files), including new suites for the plan projection, the walk reducer and the debounce
- `npx svelte-check` — 0 errors, 0 warnings
- `npm run lint` — no new issues; `npm run build` — clean
- Rendered the panel from the built CSS to check the layout (screenshot in the thread)

**Not yet done:** an end-to-end pass against a live ATS application form (task 5.2 in the change) — that needs the built extension loaded in a browser, which is a manual step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Match-tab checklist for application-form questions.
  * Added required-field progress tracking with answered and pending states.
  * Autofill now processes fields sequentially with scrolling, highlighting, visible progress, and a Stop control.
  * Checklist items can reveal and focus corresponding form fields.
  * Manual edits automatically refresh checklist status.

* **Documentation**
  * Added specifications and implementation guidance for the application-form checklist and autofill experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->