### PR TITLE
Extension: show the apply checklist where it was missing, and lead with it

### DIFF
--- a/extension/AGENTS.md
+++ b/extension/AGENTS.md
@@ -105,9 +105,29 @@ content --PAGE_SNAPSHOT--> background --> panel --> relay --> the agent, mid-tur
   it reported without re-writing anything.
 - **The plan is the panel's standing account of the form**, computed by
   `buildPlan` from what the page reported and rebuilt on every page change, after
-  every walk step, and on `FORM_CHANGED` — the page's own debounced notice that
-  someone typed into it. It counts REQUIRED questions only (they are what gates
+  a walk, on `FORM_CHANGED`, on returning to the Match tab and on the panel
+  regaining focus. It counts REQUIRED questions only (they are what gates
   submission) and is null for a page showing no application form.
+- **Two different tests for "this is an application".** `looksLikeApplication`
+  (a CV upload) gates the FILLER — it is what stops a job-alert signup being
+  written into. `showsApplicationForm` gates the CHECKLIST and is deliberately
+  looser: an upload, OR four labelled questions, OR a form the panel has already
+  written into. The upload sits on step ONE of a multi-step ATS form, and every
+  step after it — the screening questions — has none, which is why the strict
+  test showed no checklist where it was most wanted. Nothing is written on the
+  strength of the looser one.
+- **`PlanItem.key` is `frame:index`, never the label.** Two questions on one form
+  can carry the same label, and a keyed `{#each}` over a duplicate throws
+  `each_key_duplicate` — which takes the whole card down and looks, from the
+  panel, like the feature simply not existing. That was the real reason the
+  checklist never appeared on a live ATS form.
+- **Form reads are serialised, not raced.** A request-id guard (the
+  `matchRequestId` pattern) starves here: an ATS page announces DOM changes
+  continuously, so every read finds its id already superseded and returns before
+  assigning. One read at a time with a re-read queued behind it cannot starve and
+  cannot land stale. For the same reason the page announces a mutation only when
+  the NUMBER of controls changes — typing is covered by the input/change
+  listeners, where it does not.
 - **`revealField` borrows the page's style and gives it back.** The outline is
   inline style, restored after ~600ms: the extension runs on pages freehire does
   not own, where an injected class can collide with the ATS's own and a stylesheet

--- a/extension/entrypoints/content.ts
+++ b/extension/entrypoints/content.ts
@@ -79,25 +79,37 @@ export default defineContentScript({
     // listeners would have to be re-attached on every render (and leak the ones
     // they replaced). The panel is told only that something changed — it re-reads
     // the form, which is the one account that cannot drift.
-    const announce = debounce(() => {
+    const notifyPanel = () => {
       void browser.runtime.sendMessage({ kind: 'FORM_CHANGED' } satisfies RuntimeMessage).catch(() => {
         // No panel listening (it is closed, or this frame outlived it). Nothing
         // to do: the next open re-reads the form anyway.
       });
-    }, FORM_CHANGE_QUIET_MS);
+    };
+    const announce = debounce(notifyPanel, FORM_CHANGE_QUIET_MS);
     document.addEventListener('input', announce, true);
     document.addEventListener('change', announce, true);
 
     // A form the page renders later — the next step of an ATS application, an
     // "Apply" button expanding one in place — arrives with no page load and no
     // typing, so neither the panel's tab listeners nor the two above would ever
-    // notice it. Watching for controls entering or leaving the document covers
-    // both, through the same debounce, so a burst of DOM churn is one notice.
+    // notice it.
+    //
+    // Only a change in HOW MANY controls the page holds is announced. A React ATS
+    // form re-renders its inputs constantly, and announcing every re-render kept
+    // the panel re-reading the form without pause — which is what starved its
+    // reads and left the checklist permanently absent. Typing is already covered
+    // by the two listeners above, where the count does not change.
+    let controlCount = document.querySelectorAll('input, select, textarea').length;
+    const announceIfCountChanged = debounce(() => {
+      const count = document.querySelectorAll('input, select, textarea').length;
+      if (count === controlCount) return;
+      controlCount = count;
+      notifyPanel();
+    }, FORM_CHANGE_QUIET_MS);
     new MutationObserver((records) => {
       for (const record of records) {
-        const touched = [...record.addedNodes, ...record.removedNodes];
-        if (touched.some(holdsControl)) {
-          announce();
+        if ([...record.addedNodes, ...record.removedNodes].some(holdsControl)) {
+          announceIfCountChanged();
           return;
         }
       }

--- a/extension/entrypoints/content.ts
+++ b/extension/entrypoints/content.ts
@@ -8,6 +8,14 @@ import type { RuntimeMessage } from '../lib/protocol';
  *  changed. One re-read when the user pauses, not one per keystroke. */
 const FORM_CHANGE_QUIET_MS = 400;
 
+/** Whether a node is, or contains, something the panel would ask about. Keeps the
+ *  observer below from waking the panel for every unrelated re-render — an ATS
+ *  page swaps nodes constantly. */
+function holdsControl(node: Node): boolean {
+  if (!(node instanceof Element)) return false;
+  return node.matches('input, select, textarea') || node.querySelector('input, select, textarea') !== null;
+}
+
 /**
  * Injected into every page, and into every frame of it — apply forms are
  * routinely served from an ATS iframe, so a top-document-only script would see
@@ -79,5 +87,20 @@ export default defineContentScript({
     }, FORM_CHANGE_QUIET_MS);
     document.addEventListener('input', announce, true);
     document.addEventListener('change', announce, true);
+
+    // A form the page renders later — the next step of an ATS application, an
+    // "Apply" button expanding one in place — arrives with no page load and no
+    // typing, so neither the panel's tab listeners nor the two above would ever
+    // notice it. Watching for controls entering or leaving the document covers
+    // both, through the same debounce, so a burst of DOM churn is one notice.
+    new MutationObserver((records) => {
+      for (const record of records) {
+        const touched = [...record.addedNodes, ...record.removedNodes];
+        if (touched.some(holdsControl)) {
+          announce();
+          return;
+        }
+      }
+    }).observe(document.documentElement, { childList: true, subtree: true });
   },
 });

--- a/extension/entrypoints/sidepanel/App.svelte
+++ b/extension/entrypoints/sidepanel/App.svelte
@@ -27,7 +27,7 @@
     scopeToApplication,
     formatAuthorizedCountries,
   } from '../../lib/form';
-  import { buildPlan, markAnswered, type ApplyPlan, type PlanItem } from '../../lib/applyPlan';
+  import { buildPlan, markAnswered, showsApplicationForm, type ApplyPlan, type PlanItem } from '../../lib/applyPlan';
   import { startWalk, nextStep, applyStep, skipStep, stopWalk, type Walk } from '../../lib/walk';
   import { ToolChannel } from '../../lib/tools/client';
   import { activeTabPage } from '../../lib/tools/page';
@@ -469,13 +469,17 @@
       kind: 'GET_FRAMED_FORM',
     } satisfies RuntimeMessage)) as RuntimeMessage | undefined;
     if (requestId !== planRequestId) return;
-    if (reply?.kind !== 'FRAMED_FORM' || !looksLikeApplication(reply.uploads)) {
+    if (reply?.kind !== 'FRAMED_FORM' || !showsApplicationForm(reply.fields, reply.uploads)) {
       plan = null;
       return;
     }
-    // One form, not every question on the page: an application and a job-alert
-    // signup each have their own "Email" — the same scoping the filler uses.
-    plan = buildPlan(scopeToApplication(reply.fields, reply.uploads));
+    // Scoped to the one form the upload identifies, where there is one: an
+    // application and a job-alert signup each have their own "Email". With no
+    // upload to scope by — every step of an ATS form after the first — the page's
+    // questions ARE the form.
+    plan = buildPlan(
+      reply.uploads.length > 0 ? scopeToApplication(reply.fields, reply.uploads) : reply.fields,
+    );
   }
 
   /** Sends the user to one question: the page scrolls there and takes the cursor. */
@@ -616,6 +620,10 @@
     autofilling = true;
     walkStop = false;
     try {
+      // Read the form first: the walk ticks questions off the plan, and a page
+      // whose form arrived after the last read (an ATS step change, which fires
+      // no page load) would otherwise be walked with nothing to tick.
+      await refreshPlan();
       const report = await runAgentAutofill(token);
       // The agent filled the page itself, server-side. Play its report back so
       // the user watches what changed rather than finding it later.
@@ -628,9 +636,6 @@
       );
       if (report.deferred.length > 0) {
         notices.push(`Not fillable yet (custom dropdowns): ${nameSome(report.deferred)}.`);
-      }
-      if (report.unmapped.length > 0) {
-        notices.push(`Left for you: ${nameSome(report.unmapped)}.`);
       }
     } catch (err) {
       // The server's own sentence, not just the status: /me/autofill/run answers
@@ -705,19 +710,14 @@
       }
       const walk = await walkFills(fills);
       const n = walk.done.length;
+      // What was left unanswered is not listed here: the checklist above shows
+      // exactly which questions those are, and naming thirty of them in a notice
+      // is the wall of text this feature replaced.
       notices.push(
         walk.stopped
           ? `Stopped after ${n} field${n === 1 ? '' : 's'} — what was filled stays.`
           : `✓ Autofilled ${n} field${n === 1 ? '' : 's'} — review before submitting.`,
       );
-
-      // A question the walk could not write: a custom-widget combobox (which
-      // commits whatever its own listbox highlights, so the simple filler
-      // declines it rather than writing a wrong value), or one the form dropped
-      // while the walk was running.
-      if (walk.skipped.length > 0) {
-        notices.push(`Left for you: ${nameSome(walk.skipped.map((f) => f.label))}.`);
-      }
     } catch (err) {
       notices.push(`Autofill failed: ${err instanceof Error ? err.message : 'error'}`);
     }
@@ -808,7 +808,13 @@
                  does not carry a posting for, and the checklist is just as useful
                  there. -->
             {#if plan}
-              <ApplyPlanCard {plan} filling={fillingLabel} onReveal={revealItem} />
+              <ApplyPlanCard
+                {plan}
+                filling={fillingLabel}
+                walking={autofilling}
+                onReveal={revealItem}
+                onCancel={() => (walkStop = true)}
+              />
             {/if}
 
             {#each notices as notice, i (i)}

--- a/extension/entrypoints/sidepanel/App.svelte
+++ b/extension/entrypoints/sidepanel/App.svelte
@@ -601,7 +601,7 @@
         (frame === undefined || i.frame === frame) &&
         (form === undefined || i.form === form),
     );
-    if (item) plan = markAnswered(plan, item);
+    if (item) plan = markAnswered(plan, item.key);
   }
 
   /**

--- a/extension/entrypoints/sidepanel/App.svelte
+++ b/extension/entrypoints/sidepanel/App.svelte
@@ -108,12 +108,20 @@
     };
     browser.runtime.onMessage.addListener(onPageMessage);
 
+    // The panel regaining focus is the other moment worth re-reading on: the user
+    // has just been on the page, quite possibly answering a question there.
+    const onFocus = () => {
+      if (user) void refreshPlan();
+    };
+    window.addEventListener('focus', onFocus);
+
     return () => {
       turn?.cancel();
       tools.stop();
       browser.tabs.onActivated.removeListener(refresh);
       browser.tabs.onUpdated.removeListener(onUpdated);
       browser.runtime.onMessage.removeListener(onPageMessage);
+      window.removeEventListener('focus', onFocus);
     };
   });
 
@@ -460,6 +468,10 @@
    *  otherwise replace the current form's plan with the previous one's. Same
    *  pattern as `matchRequestId`. */
   let planRequestId = 0;
+  /** How many labelled questions the last read found, whether or not they added
+   *  up to an application. It is what the panel says when it shows no checklist,
+   *  so "nothing appeared" can be told from "nothing was found". */
+  let questionsSeen = $state(0);
   /** True once a walk has written into this page's form. It outranks every guess
    *  about whether the page is showing an application: it accepted values. Reset
    *  by a page change, with the plan. */
@@ -474,6 +486,7 @@
       kind: 'GET_FRAMED_FORM',
     } satisfies RuntimeMessage)) as RuntimeMessage | undefined;
     if (requestId !== planRequestId) return;
+    questionsSeen = reply?.kind === 'FRAMED_FORM' ? reply.fields.filter((f) => f.label.trim() !== '').length : 0;
     if (
       reply?.kind !== 'FRAMED_FORM' ||
       !showsApplicationForm(reply.fields, reply.uploads, { filled: formFilled })
@@ -744,6 +757,10 @@
       <span class="brand">
         <img src="/icon/32.png" alt="" class="brand-mark" width="18" height="18" />
         <strong>freehire</strong>
+        <!-- The build, in the one place both of us can see it: a side panel keeps
+             its script until it is closed, so "did the reload take?" is otherwise
+             unanswerable from a screenshot. -->
+        <span class="build">v{browser.runtime.getManifest().version}</span>
       </span>
       <Badge variant={sending ? 'brand' : 'outline'}>
         {sending ? 'working…' : user ? 'ready' : 'offline'}
@@ -771,7 +788,13 @@
       { id: 'chat', label: 'Chat' },
     ]}
     active={activeTab}
-    onSelect={(id) => (activeTab = id)}
+    onSelect={(id) => {
+      activeTab = id;
+      // Coming back to Match is a moment the user expects the panel to be current:
+      // the form may have moved on (a step, an expanded Apply) while they were in
+      // the chat, and nothing else would have told us.
+      if (id === 'match') void refreshPlan();
+    }}
     label="Panel sections"
     panelId={PANEL_ID}
   />
@@ -820,6 +843,15 @@
                  independent of the match: a page can show an application freehire
                  does not carry a posting for, and the checklist is just as useful
                  there. -->
+            {#if !plan && questionsSeen > 0}
+              <!-- The page asks questions but they did not add up to an
+                   application. Saying so beats an empty space the user has to
+                   guess about. -->
+              <p class="no-plan">
+                {questionsSeen} field{questionsSeen === 1 ? '' : 's'} on this page — not enough to
+                read as an application form.
+              </p>
+            {/if}
             {#if plan}
               <ApplyPlanCard
                 {plan}
@@ -1127,6 +1159,17 @@
    * would squash individual messages instead of just scrolling past them. */
   .messages > :global(*) {
     flex-shrink: 0;
+  }
+
+  .build {
+    font-size: 11px;
+    color: var(--muted-foreground);
+  }
+
+  .no-plan {
+    font-size: 12px;
+    color: var(--muted-foreground);
+    padding: 0 2px;
   }
 
   .empty {

--- a/extension/entrypoints/sidepanel/App.svelte
+++ b/extension/entrypoints/sidepanel/App.svelte
@@ -463,15 +463,20 @@
   let plan = $state<ApplyPlan | null>(null);
   /** The question a walk is filling right now, by label. */
   let fillingLabel = $state<string | null>(null);
-  /** Guards against an older read landing after a newer one — a page change and
-   *  the page's own FORM_CHANGED both start a read, and the slower answer would
-   *  otherwise replace the current form's plan with the previous one's. Same
-   *  pattern as `matchRequestId`. */
-  let planRequestId = 0;
+  // Reads of the form are serialised rather than raced. A request id (the
+  // `matchRequestId` pattern) was the first attempt and it deadlocked on a real
+  // ATS page: the page announces changes continuously, so every read found its id
+  // already superseded by the next one and returned before assigning anything —
+  // the checklist never appeared at all. One read at a time, with a re-read queued
+  // if anything arrived meanwhile, cannot starve and cannot land stale.
+  let planReading = false;
+  let planStale = false;
   /** How many labelled questions the last read found, whether or not they added
    *  up to an application. It is what the panel says when it shows no checklist,
    *  so "nothing appeared" can be told from "nothing was found". */
   let questionsSeen = $state(0);
+  /** Why the last read produced nothing, when it failed outright. */
+  let planError = $state('');
   /** True once a walk has written into this page's form. It outranks every guess
    *  about whether the page is showing an application: it accepted values. Reset
    *  by a page change, with the plan. */
@@ -481,16 +486,38 @@
    *  is not showing an application. */
   async function refreshPlan() {
     if (!user) return;
-    const requestId = ++planRequestId;
-    const reply = (await browser.runtime.sendMessage({
-      kind: 'GET_FRAMED_FORM',
-    } satisfies RuntimeMessage)) as RuntimeMessage | undefined;
-    if (requestId !== planRequestId) return;
-    questionsSeen = reply?.kind === 'FRAMED_FORM' ? reply.fields.filter((f) => f.label.trim() !== '').length : 0;
-    if (
-      reply?.kind !== 'FRAMED_FORM' ||
-      !showsApplicationForm(reply.fields, reply.uploads, { filled: formFilled })
-    ) {
+    if (planReading) {
+      planStale = true;
+      return;
+    }
+    planReading = true;
+    try {
+      do {
+        planStale = false;
+        const reply = (await browser.runtime.sendMessage({
+          kind: 'GET_FRAMED_FORM',
+        } satisfies RuntimeMessage)) as RuntimeMessage | undefined;
+        applyRead(reply);
+      } while (planStale);
+    } catch (err) {
+      // A read that could not happen is not a page without a form: say so rather
+      // than clearing a checklist the user is looking at.
+      planError = err instanceof Error ? err.message : 'could not read the form';
+    } finally {
+      planReading = false;
+    }
+  }
+
+  /** Turns one form read into the plan, or into the reason there is none. */
+  function applyRead(reply: RuntimeMessage | undefined) {
+    planError = '';
+    if (reply?.kind !== 'FRAMED_FORM') {
+      questionsSeen = 0;
+      plan = null;
+      return;
+    }
+    questionsSeen = reply.fields.filter((f) => f.label.trim() !== '').length;
+    if (!showsApplicationForm(reply.fields, reply.uploads, { filled: formFilled })) {
       plan = null;
       return;
     }
@@ -843,7 +870,9 @@
                  independent of the match: a page can show an application freehire
                  does not carry a posting for, and the checklist is just as useful
                  there. -->
-            {#if !plan && questionsSeen > 0}
+            {#if !plan && planError}
+              <p class="no-plan">Could not read this page's form: {planError}</p>
+            {:else if !plan && questionsSeen > 0}
               <!-- The page asks questions but they did not add up to an
                    application. Saying so beats an empty space the user has to
                    guess about. -->

--- a/extension/entrypoints/sidepanel/App.svelte
+++ b/extension/entrypoints/sidepanel/App.svelte
@@ -166,6 +166,7 @@
    */
   async function handlePageChange() {
     const key = await currentPageKey();
+    formFilled = false;
     if (chatPageKey !== null && key !== chatPageKey) {
       resetChat();
       const token = await getToken();
@@ -459,6 +460,10 @@
    *  otherwise replace the current form's plan with the previous one's. Same
    *  pattern as `matchRequestId`. */
   let planRequestId = 0;
+  /** True once a walk has written into this page's form. It outranks every guess
+   *  about whether the page is showing an application: it accepted values. Reset
+   *  by a page change, with the plan. */
+  let formFilled = $state(false);
 
   /** Reads the page's form and rebuilds the plan, or clears it for a page that
    *  is not showing an application. */
@@ -469,7 +474,10 @@
       kind: 'GET_FRAMED_FORM',
     } satisfies RuntimeMessage)) as RuntimeMessage | undefined;
     if (requestId !== planRequestId) return;
-    if (reply?.kind !== 'FRAMED_FORM' || !showsApplicationForm(reply.fields, reply.uploads)) {
+    if (
+      reply?.kind !== 'FRAMED_FORM' ||
+      !showsApplicationForm(reply.fields, reply.uploads, { filled: formFilled })
+    ) {
       plan = null;
       return;
     }
@@ -577,6 +585,7 @@
         const outcome = applied?.kind === 'FILL_OUTCOMES' ? applied.outcomes[0] : undefined;
         if (outcome?.status === 'filled') {
           walk = applyStep(walk, fill);
+          formFilled = true;
           // Ticked off from what was just written, not from a fresh read: the
           // page's own change notice is debounced, so re-reading here would leave
           // the counter a step behind the value on screen.
@@ -627,6 +636,7 @@
       const report = await runAgentAutofill(token);
       // The agent filled the page itself, server-side. Play its report back so
       // the user watches what changed rather than finding it later.
+      if (report.filled.length > 0) formFilled = true;
       await walkReported(report.filled);
       const filled = report.filled.length;
       notices.push(
@@ -709,6 +719,9 @@
         return;
       }
       const walk = await walkFills(fills);
+      // The form has now accepted values, which is stronger evidence than
+      // anything its markup says — so read it again and let the checklist appear.
+      await refreshPlan();
       const n = walk.done.length;
       // What was left unanswered is not listed here: the checklist above shows
       // exactly which questions those are, and naming thirty of them in a notice

--- a/extension/entrypoints/sidepanel/ApplyPlan.svelte
+++ b/extension/entrypoints/sidepanel/ApplyPlan.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Check, Loader, MapPin } from '@lucide/svelte';
+  import { Check, Loader, Minus } from '@lucide/svelte';
   import { Card } from 'freehire-design-system';
   import type { ApplyPlan, PlanItem } from '../../lib/applyPlan';
 
@@ -15,11 +15,17 @@
     plan,
     /** The question being filled right now, by label — the walk's cursor. */
     filling = null,
+    /** True while a walk is running: the card's own heading takes over, since
+     *  that is where the user is looking while the page scrolls past. */
+    walking = false,
     onReveal,
+    onCancel,
   }: {
     plan: ApplyPlan;
     filling?: string | null;
+    walking?: boolean;
     onReveal: (item: PlanItem) => void;
+    onCancel: () => void;
   } = $props();
 
   /** What the icon says, for a reader that cannot see it — the icon itself is
@@ -52,7 +58,7 @@
               {:else if item.answered}
                 <Check class="size-3" />
               {:else}
-                <MapPin class="size-3" />
+                <Minus class="size-3" />
               {/if}
             </span>
             <span class="label">{item.label}</span>
@@ -65,9 +71,15 @@
 
 <Card class="apply-plan">
   <div class="head">
-    <span class="title">Application form</span>
+    <span class="title">{walking ? 'Autofilling…' : 'Application form'}</span>
     {#if plan.required}
       <span class="count">{plan.required.answered}/{plan.required.total} · {plan.required.percent}%</span>
+    {/if}
+    {#if walking}
+      <!-- Cancel belongs beside the progress it cancels, not pinned at the far
+           end of the panel: while a walk runs, this card is what the user is
+           watching. -->
+      <button type="button" class="cancel" onclick={onCancel}>Cancel</button>
     {/if}
   </div>
 
@@ -101,6 +113,21 @@
   .title {
     font-size: 13px;
     font-weight: 600;
+  }
+
+  .cancel {
+    border: 0;
+    background: none;
+    padding: 0;
+    font: inherit;
+    font-size: 12px;
+    color: var(--muted-foreground);
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .cancel:hover {
+    color: var(--foreground);
   }
 
   .count {
@@ -145,7 +172,7 @@
   .item {
     width: 100%;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 8px;
     padding: 4px 6px;
     border: 0;
@@ -168,6 +195,7 @@
 
   .mark {
     flex: none;
+    margin-top: 1px;
     display: flex;
     width: 16px;
     height: 16px;
@@ -185,9 +213,7 @@
   }
 
   .label {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    min-width: 0;
   }
 
   :global(.spin) {

--- a/extension/entrypoints/sidepanel/ApplyPlan.svelte
+++ b/extension/entrypoints/sidepanel/ApplyPlan.svelte
@@ -43,7 +43,7 @@
   {#if items.length > 0}
     <p class="group">{heading}</p>
     <ul>
-      {#each items as item (`${item.frame}:${item.form}:${item.label}`)}
+      {#each items as item (item.key)}
         <li>
           <button
             type="button"

--- a/extension/lib/applyPlan.test.ts
+++ b/extension/lib/applyPlan.test.ts
@@ -98,6 +98,21 @@ describe('buildPlan', () => {
     expect(plan.items.map((i) => i.label)).toEqual(['Email']);
     expect(plan.required).toEqual({ answered: 0, total: 1, percent: 0 });
   });
+
+  // Svelte keys the checklist by this, and a duplicate key is a hard render error
+  // — the whole card disappears. Two questions on one form CAN carry the same
+  // label (an ATS repeats "Years" under several headings, or leaves labels off
+  // and the page falls back to the same text), so the key cannot be the label.
+  it('gives every item a key of its own, even when labels repeat', () => {
+    const plan = buildPlan([
+      field('Years', { index: 0, frame: 0, form: 0 }),
+      field('Years', { index: 1, frame: 0, form: 0 }),
+      field('Years', { index: 0, frame: 1, form: 0 }),
+    ]);
+
+    const keys = plan.items.map((i) => i.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
 });
 
 describe('markAnswered', () => {

--- a/extension/lib/applyPlan.test.ts
+++ b/extension/lib/applyPlan.test.ts
@@ -176,6 +176,12 @@ describe('showsApplicationForm', () => {
     expect(showsApplicationForm(login, [])).toBe(false);
   });
 
+  // The walk has just written into it: whatever the markup says, this page is
+  // asking an application's worth of questions.
+  it('is true for a form the panel has just filled', () => {
+    expect(showsApplicationForm([field('Email')], [], { filled: true })).toBe(true);
+  });
+
   // A search box, a newsletter field, a cookie preference: pages ask short
   // questions everywhere, and a checklist over them is noise.
   it('is false for a page asking nothing in particular', () => {
@@ -183,11 +189,19 @@ describe('showsApplicationForm', () => {
     expect(showsApplicationForm([], [])).toBe(false);
   });
 
-  // Required is the signal that something is being submitted. A long page of
-  // optional fields is a settings screen, not an application.
-  it('is false for a long form that requires nothing', () => {
-    const optional = ['One', 'Two', 'Three', 'Four', 'Five'].map((l) => field(l));
+  // Plenty of ATS forms mark a question required with an asterisk in its label
+  // and nothing in the markup. Demanding `required` in the DOM is why a real
+  // application — eleven fields, filled successfully — showed no checklist at all.
+  it('is true for a long questionnaire that marks nothing required in the markup', () => {
+    const questions = ['One', 'Two', 'Three', 'Four', 'Five'].map((l) => field(l));
 
-    expect(showsApplicationForm(optional, [])).toBe(false);
+    expect(showsApplicationForm(questions, [])).toBe(true);
+  });
+
+  // Three fields is a sign-in, a search box with a filter, a newsletter row.
+  it('is false just below the questionnaire threshold', () => {
+    const few = ['One', 'Two', 'Three'].map((l) => field(l));
+
+    expect(showsApplicationForm(few, [])).toBe(false);
   });
 });

--- a/extension/lib/applyPlan.test.ts
+++ b/extension/lib/applyPlan.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { buildPlan, markAnswered, showsApplicationForm } from './applyPlan';
 import type { FramedField } from './protocol';
+import { must } from './test-utils';
 
 /** A question as the page reported it. Overrides say what the case is about. */
 function field(label: string, over: Partial<FramedField> = {}): FramedField {
@@ -118,11 +119,11 @@ describe('buildPlan', () => {
 describe('markAnswered', () => {
   it('ticks one item off and moves the counter', () => {
     const plan = buildPlan([
-      field('First name', { required: true, value: 'Igor' }),
-      field('Email', { required: true }),
+      field('First name', { required: true, value: 'Igor', index: 0 }),
+      field('Email', { required: true, index: 1 }),
     ]);
 
-    const after = markAnswered(plan, { label: 'Email', frame: 0, form: 0 });
+    const after = markAnswered(plan, must(plan.items[1]).key);
 
     expect(after.items.map((i) => i.answered)).toEqual([true, true]);
     expect(after.required).toEqual({ answered: 2, total: 2, percent: 100 });
@@ -134,29 +135,29 @@ describe('markAnswered', () => {
   it('leaves a plan that does not carry the label alone', () => {
     const plan = buildPlan([field('Email', { required: true })]);
 
-    expect(markAnswered(plan, { label: 'Gone', frame: 0, form: 0 })).toEqual(plan);
+    expect(markAnswered(plan, '9:9')).toEqual(plan);
   });
 
-  // Two questions can carry the same label in different forms or frames — an
-  // application and a job-alert signup each have their own "Email". Ticking one
-  // off must not tick the other, or the counter reports progress that is not
-  // there.
-  it('ticks off the question at that address only', () => {
+  // Two questions can carry the same label — an application and a job-alert
+  // signup each have their own "Email", and one ATS form repeats "Years" under
+  // several headings. Ticking one off must not tick the other, or the counter
+  // reports progress that is not there.
+  it('ticks off that question only, where labels repeat', () => {
     const plan = buildPlan([
-      field('Email', { required: true, frame: 0, form: 0 }),
-      field('Email', { required: true, frame: 1, form: 0 }),
+      field('Email', { required: true, frame: 0, index: 0 }),
+      field('Email', { required: true, frame: 1, index: 0 }),
     ]);
 
-    const after = markAnswered(plan, { label: 'Email', frame: 1, form: 0 });
+    const after = markAnswered(plan, must(plan.items[1]).key);
 
     expect(after.items.map((i) => i.answered)).toEqual([false, true]);
     expect(after.required).toEqual({ answered: 1, total: 2, percent: 50 });
   });
 
   it('does not touch the optional side of the counter', () => {
-    const plan = buildPlan([field('Email', { required: true }), field('Website')]);
+    const plan = buildPlan([field('Email', { required: true, index: 0 }), field('Website', { index: 1 })]);
 
-    const after = markAnswered(plan, { label: 'Website', frame: 0, form: 0 });
+    const after = markAnswered(plan, must(plan.items[1]).key);
 
     expect(after.required).toEqual({ answered: 0, total: 1, percent: 0 });
   });

--- a/extension/lib/applyPlan.test.ts
+++ b/extension/lib/applyPlan.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildPlan, markAnswered } from './applyPlan';
+import { buildPlan, markAnswered, showsApplicationForm } from './applyPlan';
 import type { FramedField } from './protocol';
 
 /** A question as the page reported it. Overrides say what the case is about. */
@@ -144,5 +144,50 @@ describe('markAnswered', () => {
     const after = markAnswered(plan, { label: 'Website', frame: 0, form: 0 });
 
     expect(after.required).toEqual({ answered: 0, total: 1, percent: 0 });
+  });
+});
+
+describe('showsApplicationForm', () => {
+  const upload = { frame: 0, form: 0 };
+
+  it('is true for a form offering a CV upload, however short', () => {
+    expect(showsApplicationForm([field('Email', { required: true })], [upload])).toBe(true);
+  });
+
+  // The upload is what marks an application for the FILLER, and it is gone by the
+  // second step of a multi-step ATS form — where the questions the panel most
+  // needs to account for are. A questionnaire that long is an application whether
+  // or not it still offers a file field.
+  it('is true for a long questionnaire with no upload', () => {
+    const questions = [
+      field('First name', { required: true }),
+      field('Email', { required: true }),
+      field('Years of experience', { required: true }),
+      field('Notice period'),
+      field('Expected compensation', { required: true }),
+    ];
+
+    expect(showsApplicationForm(questions, [])).toBe(true);
+  });
+
+  it('is false for a sign-in form', () => {
+    const login = [field('Email', { required: true }), field('Password', { required: true })];
+
+    expect(showsApplicationForm(login, [])).toBe(false);
+  });
+
+  // A search box, a newsletter field, a cookie preference: pages ask short
+  // questions everywhere, and a checklist over them is noise.
+  it('is false for a page asking nothing in particular', () => {
+    expect(showsApplicationForm([field('Search jobs')], [])).toBe(false);
+    expect(showsApplicationForm([], [])).toBe(false);
+  });
+
+  // Required is the signal that something is being submitted. A long page of
+  // optional fields is a settings screen, not an application.
+  it('is false for a long form that requires nothing', () => {
+    const optional = ['One', 'Two', 'Three', 'Four', 'Five'].map((l) => field(l));
+
+    expect(showsApplicationForm(optional, [])).toBe(false);
   });
 });

--- a/extension/lib/applyPlan.ts
+++ b/extension/lib/applyPlan.ts
@@ -12,19 +12,17 @@
 
 import type { FramedField } from './protocol';
 
-/**
- * Which question, exactly. The label alone does not say: an application and a
- * job-alert signup on the same page each have their own "Email", and an ATS
- * serves the application from its own frame — so both narrowings travel with it.
- */
-export interface FieldAddress {
+/** One question in the checklist, addressed the way a fill addresses it. */
+export interface PlanItem {
+  /**
+   * Where the question is, for a fill or a reveal to reach it. The label alone
+   * does not say: an application and a job-alert signup on the same page each
+   * have their own "Email", and an ATS serves the application from its own frame
+   * — so both narrowings travel with it.
+   */
   label: string;
   frame: number;
   form: number;
-}
-
-/** One question in the checklist, addressed the way a fill addresses it. */
-export interface PlanItem extends FieldAddress {
   /**
    * Identity for rendering. NOT the address: two questions on one form can carry
    * the same label — an ATS repeats "Years" under several headings, and a page
@@ -54,17 +52,16 @@ export interface ApplyPlan {
 }
 
 /**
- * The plan with one question ticked off, by label.
+ * The plan with one question ticked off, named by its key.
  *
  * A walk knows what it just wrote, so it says so directly rather than re-reading
  * the whole page per step — the counter moves with the value, not 400ms later
- * when the page's own change notice arrives. A label the plan does not carry
+ * when the page's own change notice arrives. A key the plan does not carry
  * changes nothing.
  */
-export function markAnswered(plan: ApplyPlan, at: FieldAddress): ApplyPlan {
-  const isTarget = (i: PlanItem) => i.label === at.label && i.frame === at.frame && i.form === at.form;
-  if (!plan.items.some((i) => isTarget(i) && !i.answered)) return plan;
-  return recount(plan.items.map((i) => (isTarget(i) ? { ...i, answered: true } : i)));
+export function markAnswered(plan: ApplyPlan, key: string): ApplyPlan {
+  if (!plan.items.some((i) => i.key === key && !i.answered)) return plan;
+  return recount(plan.items.map((i) => (i.key === key ? { ...i, answered: true } : i)));
 }
 
 /**

--- a/extension/lib/applyPlan.ts
+++ b/extension/lib/applyPlan.ts
@@ -58,6 +58,33 @@ export function markAnswered(plan: ApplyPlan, at: FieldAddress): ApplyPlan {
   return recount(plan.items.map((i) => (isTarget(i) ? { ...i, answered: true } : i)));
 }
 
+/**
+ * How many questions a page has to ask before it counts as an application on the
+ * strength of the questions alone. Below it sit the forms every site has — a
+ * sign-in, a search box, a newsletter field.
+ */
+const QUESTIONNAIRE_SIZE = 4;
+
+/**
+ * Whether the page is showing an application worth accounting for.
+ *
+ * A CV upload settles it: that is what `looksLikeApplication` keys on, and it is
+ * what lets the FILLER tell an application from a job-alert signup before writing
+ * anything. But the upload sits on the FIRST step of a multi-step ATS form, and
+ * the steps after it — the ones full of screening questions the candidate most
+ * needs an account of — offer no file field at all. Requiring one there is why a
+ * form full of questions showed no checklist.
+ *
+ * So a long questionnaire that requires answers counts too. This decides only
+ * what to SHOW; nothing is written on the strength of it, which is what makes the
+ * looser test safe here and wrong in the filler.
+ */
+export function showsApplicationForm(fields: FramedField[], uploads: unknown[]): boolean {
+  if (uploads.length > 0) return true;
+  const questions = fields.filter((f) => f.label.trim() !== '');
+  return questions.length >= QUESTIONNAIRE_SIZE && questions.some((f) => f.required);
+}
+
 /** The plan for the questions the page reported, in the order it asks them. */
 export function buildPlan(fields: FramedField[]): ApplyPlan {
   const items: PlanItem[] = fields

--- a/extension/lib/applyPlan.ts
+++ b/extension/lib/applyPlan.ts
@@ -25,6 +25,15 @@ export interface FieldAddress {
 
 /** One question in the checklist, addressed the way a fill addresses it. */
 export interface PlanItem extends FieldAddress {
+  /**
+   * Identity for rendering. NOT the address: two questions on one form can carry
+   * the same label — an ATS repeats "Years" under several headings, and a page
+   * that labels nothing falls back to the same text for each — and a list keyed
+   * by a duplicate is a hard render error in Svelte, which takes the whole card
+   * down with it. The page's own question index, scoped by frame, is unique by
+   * construction and stable between reads of an unchanged form.
+   */
+  key: string;
   required: boolean;
   answered: boolean;
 }
@@ -103,6 +112,7 @@ export function buildPlan(fields: FramedField[]): ApplyPlan {
     // cannot act on.
     .filter((f) => f.label.trim() !== '')
     .map((f) => ({
+      key: `${f.frame}:${f.index}`,
       label: f.label,
       required: f.required,
       answered: f.value.trim() !== '',

--- a/extension/lib/applyPlan.ts
+++ b/extension/lib/applyPlan.ts
@@ -75,14 +75,24 @@ const QUESTIONNAIRE_SIZE = 4;
  * needs an account of — offer no file field at all. Requiring one there is why a
  * form full of questions showed no checklist.
  *
- * So a long questionnaire that requires answers counts too. This decides only
- * what to SHOW; nothing is written on the strength of it, which is what makes the
- * looser test safe here and wrong in the filler.
+ * So the length of the questionnaire counts too — on its own, without asking for
+ * `required` in the markup. Plenty of ATS forms mark a question required with an
+ * asterisk in its label and nothing a parser can read, and demanding the
+ * attribute is why a real application of eleven fields, filled successfully,
+ * showed no checklist at all.
+ *
+ * This decides only what to SHOW; nothing is written on the strength of it, which
+ * is what makes the looser test safe here and wrong in the filler.
  */
-export function showsApplicationForm(fields: FramedField[], uploads: unknown[]): boolean {
-  if (uploads.length > 0) return true;
-  const questions = fields.filter((f) => f.label.trim() !== '');
-  return questions.length >= QUESTIONNAIRE_SIZE && questions.some((f) => f.required);
+export function showsApplicationForm(
+  fields: FramedField[],
+  uploads: unknown[],
+  /** `filled` says the panel has just written into this form. Whatever its markup
+   *  claims, a page that accepted an autofill is asking an application. */
+  evidence: { filled?: boolean } = {},
+): boolean {
+  if (uploads.length > 0 || evidence.filled) return true;
+  return fields.filter((f) => f.label.trim() !== '').length >= QUESTIONNAIRE_SIZE;
 }
 
 /** The plan for the questions the page reported, in the order it asks them. */

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "freehire-extension",
   "description": "Browser extension: a job-application agent side panel, on any page.",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "freehire-extension",
   "description": "Browser extension: a job-application agent side panel, on any page.",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "freehire-extension",
   "description": "Browser extension: a job-application agent side panel, on any page.",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "scripts": {
     "dev": "wxt",


### PR DESCRIPTION
Follow-up to #1960, from a real ATS run: the walk worked — fields filled — but **no checklist appeared at all**, and the panel could not say why.

## The real cause, found last

Two questions on the form carried the **same label**. The checklist's keyed `{#each}` hit a duplicate and Svelte threw `each_key_duplicate`, which takes the whole card down — silently, as far as the panel is concerned. An item now carries its own key (`frame:index`), unique by construction and stable across reads.

Three other genuine problems were found on the way there, each of which would have kept the checklist away on its own:

1. **The upload gate.** The checklist was gated on `looksLikeApplication`, which keys on a CV upload — right for the *filler* (it is what stops a job-alert signup being written into) and wrong for *showing* an account of the form: the upload sits on step one of a multi-step ATS application, and the screening-question steps after it have none. `showsApplicationForm` is the looser test: upload, or four labelled questions, or a form the panel has already written into. Nothing is written on its strength.
2. **Starved reads.** A request-id guard (the `matchRequestId` pattern) deadlocked: an ATS page announces DOM changes continuously, so every read found its id superseded and returned before assigning anything. Reads are serialised now — one at a time, one re-read queued behind.
3. **A shouting page.** The mutation observer fired on every re-render of an input. It now announces only when the *number* of controls changes; typing is already covered by the input/change listeners.

## Also in here

- **The card leads while a walk runs** — heading becomes *Autofilling…* with **Cancel** beside the count, as asked.
- **A form that arrives later is noticed** (next step, Apply expanding in place), and the plan is re-read on returning to Match and on panel focus.
- **No more wall of text.** The leftovers are not named in a notice — the checklist shows exactly which questions are unanswered.
- **Long questions wrap** instead of truncating to one meaningless line.
- **The panel can be diagnosed from a screenshot**: the build version sits in the header (a side panel keeps its script until closed), and where a page asks questions that did not add up to an application, it says how many it saw.

## Verification

- `npx vitest run` — 264 passed (23 files); new cases cover the show/hide decision, key uniqueness under repeated labels, and ticking off by key
- `npx svelte-check` — 0 errors; `npm run lint` — no new issues; `npm run build` — clean
- Loaded unpacked and exercised against a live ATS application form