### PR TITLE
Add 476 ATS boards found by following company websites

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -8162,3 +8162,11 @@
   board: snackpass
 - company: TransFICC
   board: transficc
+- company: Scholars of Finance
+  board: Scholars of Finance
+- company: Harmonic
+  board: harmonic-ai
+- company: Hashgraph
+  board: hashgraph
+- company: Secureframe
+  board: secureframe

--- a/sources/bamboohr.yml
+++ b/sources/bamboohr.yml
@@ -19047,3 +19047,29 @@
   board: sporttrade
 - company: Yahoo
   board: yahoo
+- company: Ascent Pro Support
+  board: ascentprostaff
+- company: Berners Schober
+  board: bsagb
+- company: DCMN
+  board: dcmn
+- company: EarthShare
+  board: earthshare
+- company: Endeavour Solutions
+  board: endeavoursolutions
+- company: Eventus Systems Inc
+  board: eventussystems
+- company: Faria Education Group
+  board: faria
+- company: fourTheorem
+  board: fourtheorem
+- company: Kalungi
+  board: kalungi
+- company: Mighty Animation
+  board: mighty
+- company: ProducePay
+  board: producepay
+- company: REI Utility Services
+  board: reiutility
+- company: STAT Recovery Services
+  board: statrecoveryservices

--- a/sources/breezy.yml
+++ b/sources/breezy.yml
@@ -3881,3 +3881,25 @@
   board: wersirius
 - company: Harper
   board: harper
+- company: Authentic
+  board: authentic
+- company: Limitlessli
+  board: casm-limitlessli
+- company: Dev Partners
+  board: dev-partners-philippines
+- company: Growth Marketing Pro, LLC
+  board: growth-marketing-pro-llc
+- company: HJ Staffing
+  board: harris-jones-staffing-recruiting-llc
+- company: KARE
+  board: kare-co
+- company: Keystone Advisors
+  board: keystoneadvisors
+- company: ONDEWO
+  board: ondewo
+- company: Pixel Service & Consulting Srl
+  board: pixel-service--consulting-srl
+- company: PsyPhyCare
+  board: psyphycare-7d99d547f19b
+- company: Trueline
+  board: trueline

--- a/sources/careerplug.yml
+++ b/sources/careerplug.yml
@@ -926,3 +926,7 @@
   board: vilna-shul
 - company: GOLF+
   board: golf
+- company: Absolute Elder Care
+  board: elyaman-medical-services-pa
+- company: NATIONMIND LLC
+  board: nationmind-llc

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14335,3 +14335,29 @@
   board: barkleyokrp
 - company: OMG Montreal
   board: omgmontreal
+- company: Alteva RCM
+  board: altevarcm
+- company: Binance
+  board: binance
+- company: Gummicube
+  board: gummicube
+- company: Hearst
+  board: hearst
+- company: MCFT
+  board: mcft
+- company: Montu
+  board: montu
+- company: Nimbus
+  board: nimbus
+- company: Portoro
+  board: portoro
+- company: Propio Language Services
+  board: propiolanguageservices
+- company: ScaleOps
+  board: scaleops
+- company: ScribeConcepts
+  board: scribeconcepts
+- company: Tavily
+  board: tavily
+- company: Aidoc
+  board: aidocmedical

--- a/sources/icims.yml
+++ b/sources/icims.yml
@@ -3853,3 +3853,7 @@
   board: careers.avalara.com
 - company: Q-Centrix (now part of MRO Corporation)
   board: careers-mrocorp.icims.com
+- company: GR8 Global
+  board: gr8affinity
+- company: Tyto Athene
+  board: quantumsky

--- a/sources/jazzhr.yml
+++ b/sources/jazzhr.yml
@@ -8431,3 +8431,35 @@
   board: softjourn
 - company: SWJ TECHNOLOGY, LLC
   board: swjtechnology
+- company: French Consulting
+  board: 20200804095728_jvlqkbyhnxv2jr9t
+- company: SweetRush
+  board: 20210212011927_km2wepjdtq3fzqjf
+- company: City Vision University
+  board: cityvisionuniversity
+- company: Corebridge Solutions
+  board: corebridgesolutions
+- company: Feed My Starving Children
+  board: feedmystarvingchildren
+- company: MainSpring
+  board: gomainspring
+- company: Intra Management Solutions
+  board: intramanagementsolutions
+- company: KMK Consulting, Inc.
+  board: kmkconsultinginc
+- company: Kreato Global
+  board: kreatolanguagegroupllc
+- company: MicroHealth, LLC
+  board: microhealthllc
+- company: MonetizeMore
+  board: monetizem
+- company: Centro.team
+  board: ortnec
+- company: Reflexion
+  board: reflexion
+- company: Simeio
+  board: simeio
+- company: Team Delegate, LLC
+  board: teamdelegate
+- company: Winona Foods
+  board: winonafoods

--- a/sources/jobvite.yml
+++ b/sources/jobvite.yml
@@ -286,3 +286,9 @@
   board: probablymonsters
 - company: Quantum Health
   board: quantum-health
+- company: Conair LLC
+  board: conair
+- company: Mercy Corps
+  board: mercycorps
+- company: Sikich
+  board: sikichcareers

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4451,3 +4451,25 @@
   board: turgon-ai
 - company: WISE INTEGRATION
   board: wise-integration
+- company: Alignable
+  board: Alignable
+- company: Anlatan
+  board: Anlatan
+- company: BlackCloak
+  board: BlackCloak
+- company: Diversified Radiology
+  board: DiversifiedRadiology
+- company: Gurobi Optimization
+  board: GurobiOptimization
+- company: HDVI
+  board: HDVI
+- company: RouteThis
+  board: RouteThis
+- company: Trend Health Partners
+  board: Trend-Health-Partners
+- company: Zadara
+  board: Zadara
+- company: Common Future
+  board: commonfuture
+- company: Signup Expert
+  board: signup-expert

--- a/sources/neogov.yml
+++ b/sources/neogov.yml
@@ -31,3 +31,5 @@
   board: schooljobs.com/bhcedu
 - company: Carteret Community College
   board: schooljobs.com/carteretcc
+- company: State of Washington
+  board: governmentjobs.com/washington

--- a/sources/oracle.yml
+++ b/sources/oracle.yml
@@ -1286,3 +1286,129 @@
   board: fa-exxm-saasfaprod1.fa.ocs.oraclecloud.com/CX_2
 - company: Cheniere Energy
   board: hcgi.fa.us2.oraclecloud.com/CX_2
+- company: Zeus
+  board: cbhm.fa.us2.oraclecloud.com/CX_1
+- company: Onity Group Inc.
+  board: ebhz.fa.us2.oraclecloud.com/Onity
+- company: BDO USA
+  board: ebqb.fa.us2.oraclecloud.com/BDOExperiencedCareers
+- company: Presbyterian Medical Services
+  board: echs.fa.us2.oraclecloud.com/CX
+- company: McDermott
+  board: edsv.fa.us2.oraclecloud.com/CX_1
+- company: ICU Medical
+  board: eduu.fa.us2.oraclecloud.com/CX_1
+- company: The Hackett Group
+  board: eeih.fa.us2.oraclecloud.com/CX_6
+- company: GP Strategies Corporation
+  board: eetz.fa.us6.oraclecloud.com/CX_2001
+- company: CDS Global
+  board: eevd.fa.us6.oraclecloud.com/CDS-Global
+- company: iCrossing
+  board: eevd.fa.us6.oraclecloud.com/CX_18
+- company: FDB
+  board: eevd.fa.us6.oraclecloud.com/CX_4
+- company: NOV
+  board: egay.fa.us6.oraclecloud.com/CX_2001
+- company: Children's Nebraska
+  board: egnx.fa.us2.oraclecloud.com/CX
+- company: Camden
+  board: ehap.fa.us2.oraclecloud.com/CX
+- company: TrueBlue
+  board: ehnn.fa.us2.oraclecloud.com/CX_3001
+- company: Resideo
+  board: ehtl.fa.us6.oraclecloud.com/CX
+- company: Datavail
+  board: eifn.fa.us6.oraclecloud.com/CX_2001
+- company: CosmoProf
+  board: eigx.fa.us6.oraclecloud.com/CX_9
+- company: Travelport
+  board: ejzg.fa.us6.oraclecloud.com/CX_1
+- company: UnitedLex
+  board: ekkk.fa.us6.oraclecloud.com/CX
+- company: KLDiscovery
+  board: ekug.fa.us6.oraclecloud.com/CX_2001
+- company: Bupa
+  board: elvh.fa.em2.oraclecloud.com/CX_2001
+- company: Envision Healthcare
+  board: eney.fa.us2.oraclecloud.com/CX_1001
+- company: BNY
+  board: eofe.fa.us2.oraclecloud.com/BNY-Careers
+- company: Tata Capital
+  board: eofh.fa.em2.oraclecloud.com/CX
+- company: Clean Harbors
+  board: epyc.fa.us2.oraclecloud.com/CLH-US
+- company: Franciscan Missionaries of Our Lady Health System
+  board: eqtm.fa.us2.oraclecloud.com/fmolhs-careers
+- company: McLeod Software
+  board: erym.fa.us6.oraclecloud.com/CX_1
+- company: Bank Street College of Education
+  board: fa-emlm-saasfaprod1.fa.ocs.oraclecloud.com/CX
+- company: Calabrio
+  board: fa-epcb-saasfaprod1.fa.ocs.oraclecloud.com/CX
+- company: Omega Healthcare Management Services
+  board: fa-equm-saasfaprod1.fa.ocs.oraclecloud.com/CX_1001
+- company: Crawford & Company
+  board: fa-esau-saasfaprod1.fa.ocs.oraclecloud.com/crawco-jobs
+- company: First Solar
+  board: fa-esbv-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Hoya Vision Care
+  board: fa-esta-saasfaprod1.fa.ocs.oraclecloud.com/CX_1001
+- company: The University of Chicago Medicine
+  board: fa-etnf-saasfaprod1.fa.ocs.oraclecloud.com/CX_1001
+- company: HealthPartners
+  board: fa-etnv-saasfaprod1.fa.ocs.oraclecloud.com/healthpartners
+- company: Alorica
+  board: fa-euxw-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Penske
+  board: fa-euyk-saasfaprod1.fa.ocs.oraclecloud.com/PenskeCareers
+- company: Novotech
+  board: fa-euzi-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Action for Children
+  board: fa-evrg-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Startek
+  board: fa-evuf-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: eClerx
+  board: fa-ewji-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Milestone Systems
+  board: fa-ewto-saasfaprod1.fa.ocs.oraclecloud.com/CX_1001
+- company: Nexi Group
+  board: fa-ewwx-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Westfield
+  board: fa-exdv-saasfaprod1.fa.ocs.oraclecloud.com/Careers
+- company: RBGlobal
+  board: fa-exew-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Staples
+  board: fa-exhh-saasfaprod1.fa.ocs.oraclecloud.com/StaplesInc
+- company: Virtuos
+  board: fa-exhj-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Intertek
+  board: hcog.fa.em2.oraclecloud.com/CX_2001
+- company: Cozen O'Connor
+  board: hctq.fa.us2.oraclecloud.com/CX_1
+- company: T.EN Career Site
+  board: hcxg.fa.em2.oraclecloud.com/CX_1
+- company: Lucy Group Ltd
+  board: hdga.fa.em3.oraclecloud.com/Lucygroupheadoffice
+- company: Quest Diagnostics
+  board: hdox.fa.us6.oraclecloud.com/CX_1
+- company: Mauser Packaging Solutions
+  board: hdpn.fa.us6.oraclecloud.com/CX_1
+- company: Telstra Health
+  board: iaaktz.fa.ocs.oraclecloud.com/CX_1
+- company: Icertis
+  board: iaaviz.fa.ocs.oraclecloud.com/Jobs-at-Icertis
+- company: Convergint Federal Solutions
+  board: iaaxhs.fa.ocs.oraclecloud.com/CX_1001
+- company: Cytel
+  board: iblyjb.fa.ocs.oraclecloud.com/cytel
+- company: Brookdale
+  board: ibmwjb.fa.ocs.oraclecloud.com/CX_1
+- company: Ralliant
+  board: ibwujb.fa.ocs.oraclecloud.com/CX_1
+- company: Medusind
+  board: medusind-ibzajb.fa.ocs.oraclecloud.com/MedusindCareers
+- company: Tulane University
+  board: tulane-ibqejb.fa.ocs.oraclecloud.com/CX_1001
+- company: University of Tulsa
+  board: utulsa-ibvjjb.fa.ocs.oraclecloud.com/CX_1

--- a/sources/pageup.yml
+++ b/sources/pageup.yml
@@ -39,3 +39,5 @@
   board: "885"
 - company: Flight Centre
   board: "889"
+- company: World Vision Australia
+  board: "530"

--- a/sources/personio.yml
+++ b/sources/personio.yml
@@ -8155,3 +8155,31 @@
   board: trg
 - company: HyperHeat
   board: hyperheat
+- company: Adbaker GmbH
+  board: adbaker-gmbh
+- company: Advidera GmbH & Co. KG
+  board: advidera-gmbh-co-kg
+- company: Beilmann Marketing GmbH
+  board: beilmann-marketing-gmbh
+- company: DOLATEL GmbH
+  board: dolatel
+- company: hepster
+  board: hepster
+- company: i22 Digitalagentur GmbH
+  board: i22
+- company: Kiron Open Higher Education gGmbH
+  board: kiron
+- company: Maharishi Foundation International
+  board: maharishi-foundation
+- company: mailo AG
+  board: mailo-ag
+- company: Moore TK
+  board: moore-tk
+- company: nugrow
+  board: nugrow
+- company: talentspring
+  board: suhm-ventures
+- company: Invox Medical
+  board: vocali
+- company: We Love X
+  board: we-love-x

--- a/sources/pinpoint.yml
+++ b/sources/pinpoint.yml
@@ -1497,3 +1497,21 @@
   board: impruvon
 - company: Peninsula
   board: peninsula360
+- company: Eventbase
+  board: eventbase
+- company: Orangutech
+  board: orangutech
+- company: O.R. Colan Associates
+  board: orcolan
+- company: Receptive
+  board: receptive
+- company: Rutter Mills, LLP
+  board: ruttermills
+- company: SANS Institute
+  board: sans
+- company: Theiagen Genomics
+  board: theiagen
+- company: Thought Logic Consulting
+  board: thoughtlogic
+- company: WellPsyche Medical Group
+  board: wellpsyche

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -4077,3 +4077,29 @@
   board: vegaintellisoft
 - company: JUST ONE
   board: justone
+- company: DemoUp Cliplister
+  board: demoupcliplister
+- company: DVT
+  board: dvtcareers
+- company: E&C
+  board: ecconsultants
+- company: EMERSE SALES US INC
+  board: emersesalesusinc
+- company: FULL Creative
+  board: fullcreative
+- company: BALLY’S INTRALOT SA
+  board: intralot
+- company: Jane Goodall Institute
+  board: janegoodall
+- company: LegionellaDossier
+  board: legionelladossierjobs
+- company: MemberBoost Consulting GmbH
+  board: memberboost
+- company: Petal
+  board: petalmd
+- company: solreco GmbH
+  board: solrecogmbh
+- company: SW Digital Tax GmbH
+  board: swdigitaltaxgmbh
+- company: Trimetis Services
+  board: trimetis

--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -6773,3 +6773,17 @@
   board: seekthermalinc
 - company: Trident Consulting Inc
   board: tridentconsultinginc2
+- company: Coinscope
+  board: Coinscope
+- company: DHIS2
+  board: DHIS2
+- company: Population Services International
+  board: HealthXPartners
+- company: IN-VR
+  board: IN-VR
+- company: Insights Learning & Development Ltd
+  board: InsightsLearningDevelopmentLtd
+- company: Key Cyber Solutions
+  board: KeyCyberSolutions
+- company: Rigilog AG
+  board: RigilogAG

--- a/sources/taleo.yml
+++ b/sources/taleo.yml
@@ -40,3 +40,7 @@
   board: aa165.taleo.net/gc_external_career_site
 - company: Temple University
   board: temple.taleo.net/tu_ex_staff
+- company: Agnico Eagle
+  board: agnicoeagle.taleo.net/2
+- company: University Hospitals
+  board: uhhospitals.taleo.net/2

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -3367,3 +3367,143 @@
   board: work.doctorswithoutborders.ca
 - company: Mangopay
   board: career.mangopay.com
+- company: Aidn
+  board: aidn.teamtailor.com
+- company: ApprovalMax
+  board: approvalmax.teamtailor.com
+- company: Axmed
+  board: axmed.teamtailor.com
+- company: B3 Consulting Poland
+  board: b3consultingpoland.teamtailor.com
+- company: Abundo
+  board: careers.abundolive.se
+- company: Access Partnership
+  board: careers.accesspartnership.com
+- company: Accutrainee
+  board: careers.accutrainee.com
+- company: AppAgent
+  board: careers.appagent.com
+- company: BC Platforms
+  board: careers.bcplatforms.com
+- company: Cafeyn
+  board: careers.cafeyn.co
+- company: Chalhoub Group
+  board: careers.chalhoubgroup.com
+- company: CyberVadis
+  board: careers.cybervadis.com
+- company: Dotdigital
+  board: careers.dotdigital.com
+- company: Ensto
+  board: careers.ensto.com
+- company: Harrison Leisure UK
+  board: careers.harrisonholidays.com
+- company: Keepit
+  board: careers.keepit.com
+- company: Once For All
+  board: careers.onceforall.com
+- company: Pet Media Group
+  board: careers.petmediagroup.com
+- company: Sage
+  board: careers.sagepub.com
+- company: Spotter Labs
+  board: careers.spotter.ai
+- company: TQA
+  board: careers.tqa.ai
+- company: Videndum
+  board: careers.videndum.com
+- company: Growth Acceleration Partners
+  board: careers.wearegap.com
+- company: Exposant 3
+  board: carriere.exposant3.com
+- company: Consat
+  board: consat.teamtailor.com
+- company: Corndel
+  board: corndel.teamtailor.com
+- company: CybelAngel
+  board: cybelangel.teamtailor.com
+- company: Directio Sp. z o.o.
+  board: directio.teamtailor.com
+- company: Dotworld
+  board: dotworld.teamtailor.com
+- company: Emperor
+  board: emperor.teamtailor.com
+- company: Floowi
+  board: floowi.na.teamtailor.com
+- company: IKUE
+  board: ikue.teamtailor.com
+- company: Imaginary Cloud
+  board: imaginarycloud.com
+- company: IMSM
+  board: imsm.teamtailor.com
+- company: Isentia
+  board: isentia-1732508121.teamtailor.com
+- company: Free2move
+  board: jobs.free2move.com
+- company: Lingokids
+  board: jobs.lingokids.com
+- company: Little Dot Studios
+  board: jobs.littledotstudios.com
+- company: matteria
+  board: jobs.matteria.co
+- company: Remote People
+  board: jobs.remotepeople.com
+- company: Sweet Communication
+  board: jobs.sweet-communication.com
+- company: Launchmetrics
+  board: launchmetrics.teamtailor.com
+- company: Maritime & Healthcare Group
+  board: maritimeandhealthcaregroup.teamtailor.com
+- company: Netenders
+  board: netendersholding.teamtailor.com
+- company: Nordic Operation Center
+  board: nordicoperationcenter.teamtailor.com
+- company: Oliva
+  board: olivahealth.teamtailor.com
+- company: OpenNebula Systems
+  board: opennebula.teamtailor.com
+- company: Opera
+  board: opera.com
+- company: Pearster
+  board: pearster-1746721541.na.teamtailor.com
+- company: QbD Group
+  board: qbdbv.teamtailor.com
+- company: RQI Partners, LLC
+  board: rqipartners-demo.na.teamtailor.com
+- company: Sales Gravy
+  board: salesgravy-1748472865.na.teamtailor.com
+- company: Sellers Dorsey
+  board: sellersdorsey.na.teamtailor.com
+- company: Sonergia
+  board: sonergia-1732699776.teamtailor.com
+- company: SprintRay
+  board: sprintray.com
+- company: Sully.ai
+  board: sullyai.teamtailor.com
+- company: TeamViewer
+  board: teamviewer.teamtailor.com
+- company: Tenpo
+  board: tenpo.teamtailor.com
+- company: Tilt Collective
+  board: tiltcollective.teamtailor.com
+- company: TINET
+  board: tinet.teamtailor.com
+- company: Tomorrow's Talent
+  board: tomorrowstalent.na.teamtailor.com
+- company: Trader Interactive
+  board: traderinteractive.na.teamtailor.com
+- company: Tribe Wellness Sales, Inc.
+  board: tribebuilders.teamtailor.com
+- company: Valsea Technologies
+  board: valsea.teamtailor.com
+- company: VFX Financial
+  board: vfxfinancial.teamtailor.com
+- company: Wagepoint
+  board: wagepoint.teamtailor.com
+- company: Webmastery
+  board: webmasterybv.teamtailor.com
+- company: Workin Group
+  board: workinquebec.teamtailor.com
+- company: Worldia
+  board: worldia.teamtailor.com
+- company: Zanders
+  board: zanders.teamtailor.com

--- a/sources/trakstar.yml
+++ b/sources/trakstar.yml
@@ -1316,3 +1316,5 @@
   board: silk
 - company: Vistar Media
   board: vistarmedia
+- company: HappyFox
+  board: happyfox

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -2169,3 +2169,407 @@
   board: gismart
 - company: vLex
   board: vlex
+- company: 1-StopAsia
+  board: 1-stopasia
+- company: 3SS
+  board: 3ss
+- company: Anvilogic Inc
+  board: anvilogic-inc
+- company: ARCOS
+  board: arcos
+- company: ArcSite
+  board: arcsite
+- company: Asso.subsea
+  board: assogroup
+- company: Aux
+  board: aux
+- company: Avint
+  board: avint
+- company: Avomind
+  board: avomind
+- company: Bedrock Learning
+  board: bedrock-learning
+- company: Betabox
+  board: betabox
+- company: Biomapas
+  board: biomapas
+- company: BizCover
+  board: bizcover-1
+- company: Blackline Safety
+  board: blacklinesafety
+- company: Blue Altair
+  board: blue-altair
+- company: Boldr
+  board: boldr-1
+- company: Branching Minds
+  board: branchingminds
+- company: BrandBastion
+  board: brandbastion
+- company: BusRight
+  board: busright
+- company: CallMiner
+  board: callminer
+- company: CarbonPlan
+  board: carbonplan
+- company: CareAcross
+  board: careacross
+- company: CEQUENS
+  board: cequens
+- company: Chaos Theory
+  board: chaos-theory
+- company: CirrusMD
+  board: cirrusmd
+- company: Claritas Rx
+  board: claritasrx
+- company: Cleafy
+  board: cleafy
+- company: Clear Digital, Inc.
+  board: cleardigital
+- company: Clickatell
+  board: clickatell
+- company: ClickView
+  board: clickview
+- company: CloudFactory
+  board: cloudfactory
+- company: Commify
+  board: commify
+- company: Complexio
+  board: complexio
+- company: Compound Growth Marketing
+  board: compound-growth-marketing
+- company: Concord Servicing
+  board: concord-servicing
+- company: Conjointly
+  board: conjointly
+- company: ConnectAd
+  board: connectad
+- company: Continuity Global Solutions
+  board: continuity-global-solutions
+- company: Corcentric
+  board: corcentric
+- company: CrewAI
+  board: crewai
+- company: Critical Manufacturing
+  board: critical-manufacturing
+- company: Crowd Favorite
+  board: crowd-favorite
+- company: Cuso International
+  board: cuso-international
+- company: Delta Exchange
+  board: deltaexchange
+- company: Digify
+  board: digifycareers
+- company: DMS
+  board: digitalmediaservices
+- company: DISCO
+  board: disco
+- company: Dispel
+  board: dispel
+- company: Distalmotion SA
+  board: distalmotion
+- company: Donna
+  board: donna
+- company: DotActiv
+  board: dotactiv
+- company: Drug Hunter
+  board: drug-hunter
+- company: Dry Farm Wines
+  board: dry-farm-wines-1
+- company: Echo360 Inc
+  board: echo360-inc
+- company: ECP
+  board: ecp-123
+- company: Education Perfect
+  board: education-perfect
+- company: eJam
+  board: ejam
+- company: ELVTR
+  board: elvtrcom
+- company: EnsoData
+  board: ensodata
+- company: EQL Tech
+  board: eqltech
+- company: Equus Software
+  board: equus-software
+- company: eVisit
+  board: evisit
+- company: Fabulous
+  board: fabulousco
+- company: Finexio
+  board: finexio
+- company: Firefly Health
+  board: firefly-health
+- company: Flexcompute Inc.
+  board: flexcompute
+- company: Flourish Research
+  board: flourishresearch
+- company: FormAssembly Inc.
+  board: formassembly
+- company: FusionTek
+  board: fusiontek
+- company: Future Caucus
+  board: futurecaucus
+- company: GBG
+  board: gbg
+- company: Gemmo
+  board: gemmo
+- company: GetResponse
+  board: getresponse
+- company: GRF CPAs & Advisors
+  board: grf-cpas-and-advisors
+- company: GXA
+  board: gxa-it
+- company: Hanna Interpreting Services LLC
+  board: hanna-interpreting-services-llc
+- company: Hireframe
+  board: hireframe
+- company: ICBD
+  board: icbd-holdings
+- company: ihateironing
+  board: ihateironing
+- company: Impact Clients
+  board: impact-clients
+- company: Indeavor
+  board: indeavor
+- company: InfoTrack US
+  board: infotrack-us
+- company: Inspiroz
+  board: inspiroz1
+- company: IntelliShift
+  board: intellishift
+- company: International Water Management Institute
+  board: international-water-management-institute
+- company: iPullRank
+  board: ipullrank
+- company: iT1
+  board: it1
+- company: JBPro
+  board: jbpro-1
+- company: JeffreyM Consulting
+  board: jeffreym-consulting
+- company: K1X
+  board: k1x
+- company: Kasama
+  board: kasama
+- company: Keycafe
+  board: keycafe
+- company: Kilter Group
+  board: kilter-group
+- company: Kody
+  board: kody
+- company: Kora
+  board: koracareers
+- company: Laundryheap
+  board: laundryheap-2
+- company: Learner Education
+  board: learner-education
+- company: LendingOne
+  board: lendingone
+- company: LifeMD
+  board: lifemdcareers
+- company: LRN Corporation
+  board: lrn-corporation
+- company: Lucidya
+  board: lucidya
+- company: M-Files
+  board: m-files
+- company: Mangone Law Firm
+  board: mangonelawfirm
+- company: Manila Recruitment
+  board: manilarecruitment
+- company: March Networks
+  board: march-networks
+- company: Mark III Construction
+  board: mark-iii-construction
+- company: Master-Works
+  board: masterworksco
+- company: Mat3ra
+  board: mat3ra
+- company: Mathspace
+  board: mathspace
+- company: MavTek
+  board: mavtek
+- company: Maxwell Energy System Pvt Ltd
+  board: maxwellenergy
+- company: May Street
+  board: maystreet
+- company: Measured
+  board: measured
+- company: MediaRadar
+  board: mediaradar
+- company: Medical Guardian
+  board: medical-guardian
+- company: Momentum IO
+  board: momentumdesinglab
+- company: Monterail
+  board: monterail
+- company: Murmuration
+  board: murmuration
+- company: MySigrid
+  board: mysigrid
+- company: Navarro Inc.
+  board: navarro-inc
+- company: Ndax Canada Inc.
+  board: ndax
+- company: NeuGroup
+  board: neugroup
+- company: New Energy Nexus
+  board: newenergynexus
+- company: NoGood
+  board: nogood
+- company: O'Hagan Meyer
+  board: ohagan-meyer
+- company: Ohalo
+  board: ohalo
+- company: Onyx Capital Group Limited
+  board: onyx-capital-group
+- company: Ottimate
+  board: ottimate
+- company: Passion.io
+  board: passionio
+- company: Phoenix Software
+  board: phoenix-software
+- company: PlanetArt
+  board: planetart
+- company: Portfolio BI
+  board: portfoliobi
+- company: ProArch
+  board: proarch-3
+- company: ProgressSoft
+  board: progressoft
+- company: Prominence Advisors
+  board: prominence-advisors
+- company: Protera
+  board: protera
+- company: Raspberry Pi Foundation
+  board: raspberrypifoundation
+- company: REAL DEV INC
+  board: real-dev-inc
+- company: REDspace
+  board: redspace
+- company: REE Medical
+  board: ree-medical
+- company: Resource Guru
+  board: resource-guru
+- company: ResPro Health
+  board: respro-health
+- company: Rezilient Health
+  board: rezilient
+- company: Riverside Insights
+  board: riverside-insights
+- company: RTM Business Group
+  board: rtm-business-group
+- company: Rydoo
+  board: rydoo
+- company: Salvo Software
+  board: salvo-software
+- company: Sama
+  board: samacoaching
+- company: Satoshi Energy
+  board: satoshi-energy
+- company: Schoox, LLC
+  board: schoox
+- company: Searoutes
+  board: searoutes
+- company: SenseOn
+  board: senseon
+- company: Sentec
+  board: sentec
+- company: Sharetru
+  board: sharetru
+- company: SHIELD
+  board: shield-1
+- company: Skylight
+  board: skylight-frame
+- company: SmartFlower Solar LLC
+  board: smartflower-solar-llc
+- company: SmartLogic
+  board: smartlogic
+- company: SMB Team
+  board: smb-team
+- company: Soar With Us
+  board: soar-with-us
+- company: Softeta
+  board: softeta
+- company: SORACOM
+  board: soracom
+- company: Spate
+  board: spate
+- company: Genki
+  board: staygenki
+- company: Steer Health
+  board: steer-health
+- company: Stio
+  board: stio
+- company: Street Child
+  board: streetchildcareers
+- company: Stronger Consulting
+  board: stronger-consulting
+- company: Sunlighten
+  board: sunlighten
+- company: Sweat Pants Agency
+  board: sweat-pants-agency
+- company: Symmetrio
+  board: symmetrio
+- company: T45 Labs
+  board: t45-labs
+- company: Tactiq
+  board: tactiq
+- company: TAT Technologies Ltd
+  board: tat-technologies-ltd
+- company: Ten Group
+  board: ten-group
+- company: testRigor
+  board: testrigor
+- company: TetraScience
+  board: tetrascience
+- company: Thaloz
+  board: thaloz
+- company: Thanks
+  board: thanks-co
+- company: The Brydon Group
+  board: the-brydon-group
+- company: ThoughtFull™ World
+  board: thoughtfull-world
+- company: Trade Nation
+  board: trade-nation
+- company: Treantly
+  board: treantly
+- company: Treatwell
+  board: treatwell
+- company: TrustEngine
+  board: trustengine
+- company: Twoconnect
+  board: twoconnect-careers
+- company: uMed
+  board: umed
+- company: UnboundEd
+  board: unbounded
+- company: UN/COMMON
+  board: uncommonagency
+- company: Uni Systems
+  board: uni-systems
+- company: Valatam
+  board: valatam
+- company: Verneek
+  board: verneek
+- company: Vestd
+  board: vestd
+- company: VIGILINT
+  board: vigilint
+- company: WarrCloud
+  board: warrcloud
+- company: WaterConnect
+  board: waterconnect
+- company: The KK Group
+  board: wearekk
+- company: Whip Around
+  board: whiparound
+- company: Wider Circle
+  board: wider-circle
+- company: WiFi Tribe
+  board: wifi-tribe
+- company: Wowza Media Systems
+  board: wowza-media-systems
+- company: Zicasso
+  board: zicasso

--- a/sources/workday.yml
+++ b/sources/workday.yml
@@ -12963,3 +12963,39 @@
   board: withum.wd108.myworkdayjobs.com/Withum_Careers_Page
 - company: General Mills
   board: genmills.wd1.myworkdayjobs.com/GMI_External_Careers
+- company: Alvotech
+  board: alvotech.wd103.myworkdayjobs.com/Alvotech_Careers
+- company: Marigold
+  board: campaignmonitor.wd5.myworkdayjobs.com/marigold
+- company: Cloudflight
+  board: cloudflight.wd103.myworkdayjobs.com/external_career_site
+- company: Cor Partners
+  board: corpartners.wd5.myworkdayjobs.com/COR
+- company: CrossVue
+  board: crossvue.wd1.myworkdayjobs.com/youbelongatCrossVue
+- company: InterVarsity Press, LLC
+  board: intervarsity.wd1.myworkdayjobs.com/InterVarsity_Press_Careers
+- company: OneDigital
+  board: onedigital.wd504.myworkdayjobs.com/OneDigital
+- company: Embla Medical
+  board: ossur.wd3.myworkdayjobs.com/EmblaMedicalCareersGlobal
+- company: Otis Elevator Co.
+  board: otis.wd504.myworkdayjobs.com/REC_Ext_Gateway
+- company: LinkUp Teletherapy
+  board: pointquestgroup.wd108.myworkdayjobs.com/careerspointquestgroup
+- company: Innovior
+  board: probegroup.wd3.myworkdayjobs.com/Innovior_Careers
+- company: Recurrent Energy
+  board: recurrentenergy.wd12.myworkdayjobs.com/RecurrentEnergy
+- company: Sagility
+  board: sagility.wd1.myworkdayjobs.com/SagilityUSA
+- company: EWS Group
+  board: talentmanagementsolution.wd3.myworkdayjobs.com/EfficientWorkflowSolutions-Careers
+- company: Talking Rain
+  board: talkingrain.wd1.myworkdayjobs.com/TR
+- company: The Community Solution Education System
+  board: tcsedsystem.wd1.myworkdayjobs.com/SaybrookUniversityCareers
+- company: TCS Education
+  board: tcsedsystem.wd1.myworkdayjobs.com/TCSES
+- company: Vetsource
+  board: vetsource.wd504.myworkdayjobs.com/vetsource_careers


### PR DESCRIPTION
## What

476 new ATS boards across 21 `sources/*.yml` files, every one probed live before it was written.

| provider | added | | provider | added |
|---|---:|---|---|---:|
| workable | 202 | | smartrecruiters | 7 |
| teamtailor | 70 | | ashby | 4 |
| oracle | 63 | | jobvite | 3 |
| workday | 18 | | taleo / icims / careerplug | 2 each |
| jazzhr | 16 | | trakstar / pageup / neogov / greenhouse | 1 each |
| personio | 14 | | | |
| recruitee / bamboohr | 13 each | | | |
| lever / breezy | 11 each | | | |
| pinpoint | 9 | | | |

## How

A worklist of 9,158 employers with live postings, each carrying its own website, went through
`cmd/harvest-ats resolve`: fetch the homepage, walk to the careers page, detect the linked
board. That produced 4,501 candidates across 40 providers. `cmd/harvest-boards` then probed
each one against the platform's own public API and kept only boards answering with live
postings — so what lands here is our own validated fact set, not a redistributed dataset.

Two other angles were tried and are recorded here so nobody repeats them:

- **Posting descriptions carry no ATS links.** One link in 639 MB across 17 platform hosts.
- **Guessing board slugs from company names barely pays.** 14,385 probes against greenhouse
  returned 12 boards. The website walk is an order of magnitude better per request.

## Gates

The name-corroboration gate rejected 49 live boards whose employer disagreed with the seed —
the usual short-slug collisions (`athena` belongs to Athena Group Advisors, not Athena).

Duplicate audit over all 21 touched files (~52k entries): **no repeated board id**, exact or
case-variant — `harvest-boards` subtracts existing entries by each provider's own dedup key
before probing. 30 additions name an employer that already had a board in the same file; 23 of
those are Oracle, where one employer routinely runs several sites on its tenant (`CX`, `CX_1`,
`CX_2001`). The rest were checked by hand: the two ashby `Harmonic` boards are two different
companies of the same name (no job overlap), and recruitee `dvtcareers` is the live board
replacing a `dvt` that no longer answers.

## Not included

~500 further detections on providers `harvest-boards` has no prober for (rippling,
zohorecruit, ukg, manatal, phenom, radancy, peopleforce, hibob, jibe, catsone, factorial,
inhire, quickin). They were found on real careers pages but nothing could confirm them, so
they stay out until those providers can be probed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded career and job-board coverage across 22 recruitment platforms.
  * Added hundreds of newly validated employer listings spanning technology, healthcare, finance, education, consulting, and other sectors.
  * Improved access to opportunities from newly supported companies on platforms including Workable, Teamtailor, Oracle Recruiting Cloud, Greenhouse, JazzHR, BambooHR, and others.
  * Added support for additional regional, public-sector, and custom-domain career pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->