### PR TITLE
SEO: serve assets from nginx, put company jobs in the HTML, fix Google Jobs location data

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -47,7 +47,11 @@ RUN pnpm prune --prod
 
 # --- runtime stage ---
 FROM node:22-alpine
-RUN apk add --no-cache nginx
+# nginx-mod-http-brotli brings ngx_brotli (filter + static). Alpine's nginx.conf
+# includes /etc/nginx/modules/*.conf, so installing the package is all the wiring
+# the load_module lines need. Without it, `brotli`/`brotli_static` in nginx.conf
+# are unknown directives and nginx refuses to start.
+RUN apk add --no-cache nginx nginx-mod-http-brotli
 WORKDIR /app
 COPY --from=build /src/build ./build
 COPY --from=build /src/node_modules ./node_modules

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -25,6 +25,16 @@ server {
     gzip_min_length 1024;
     gzip_vary on;
 
+    # Brotli for the same response types (ngx_brotli, installed in web/Dockerfile).
+    # A browser offers `br, gzip`; nginx picks brotli when both are on, which is
+    # ~20% smaller than gzip on our SSR HTML. Without this module nginx could only
+    # answer an Accept-Encoding of exactly `br` with an UNCOMPRESSED body — it has
+    # no brotli encoder — so the pre-compressed .br assets below were dead weight.
+    brotli on;
+    brotli_comp_level 5;
+    brotli_types application/json application/javascript text/css text/plain application/xml application/rss+xml image/svg+xml;
+    brotli_min_length 1024;
+
     # Resolve the backend hostname at request time, not at startup — so the web
     # container boots even if `app` is briefly down/unresolved instead of nginx
     # refusing to start. The literal Node upstream needs no resolver.
@@ -60,6 +70,34 @@ server {
     location = /health {
         set $backend http://app:8080;
         proxy_pass $backend;
+    }
+
+    # Hashed build assets, served from disk instead of proxied to Node. Every name
+    # under _app/immutable/ carries a content hash, so the bytes for a given URL never
+    # change and the long immutable cache is safe.
+    #
+    # Two reasons this is not left to adapter-node's sirv. It puts every asset byte
+    # through the same event loop that renders pages, so a burst of asset requests
+    # queues behind SSR (and vice versa); and nginx proxies with `gzip on`, which
+    # re-compresses sirv's output as gzip, so the .br files `vite build` writes were
+    # never sent — a client asking for `br` got the file UNCOMPRESSED (144 KB of CSS
+    # against 26 KB pre-compressed). brotli_static/gzip_static serve those files
+    # directly, which is what they were built for.
+    #
+    # `root` (not `alias`) because the request URI already starts with the path that
+    # exists under build/client. The security headers are repeated here on purpose:
+    # an add_header anywhere in a location REPLACES the inherited server-level set
+    # rather than adding to it, so without them these responses would ship none.
+    location /_app/immutable/ {
+        root /app/build/client;
+        brotli_static on;
+        gzip_static on;
+        access_log off;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     }
 
     # Everything else → the SvelteKit Node SSR server (adapter-node) in this

--- a/web/src/lib/components/CompanyView.svelte
+++ b/web/src/lib/components/CompanyView.svelte
@@ -8,13 +8,13 @@
   import CompanyFacts from './CompanyFacts.svelte';
   import ReferralBlock from './ReferralBlock.svelte';
 
-  // The company entity is server-rendered (route `load`), so the header is in the
-  // initial HTML. The job list is *streamed*: `initial` is a promise the route
-  // returns unresolved, so the header shows immediately and the list fills in
-  // behind a skeleton rather than blocking the whole navigation on the (slower)
-  // search. The list reuses the same filterable, counted search view as /jobs,
-  // pinned to this company: `company_slug` is fixed (not a selectable facet) and
-  // the Source facet is hidden, since a single company's postings share one source.
+  // Both the company entity and its first page of jobs are server-rendered (route
+  // `load`), so the header AND the job rows — with their /jobs/<slug> links — are in
+  // the initial HTML for crawlers. The list reuses the same filterable, counted
+  // search view as /jobs, pinned to this company: `company_slug` is fixed (not a
+  // selectable facet) and the Source facet is hidden, since a single company's
+  // postings share one source. `initial` is null when the search call failed; the
+  // rest of the page still renders (see the route's load).
   let {
     company,
     initial,
@@ -22,7 +22,7 @@
     referralAvailable = false,
   }: {
     company: Company;
-    initial: Promise<Slice<Job>>;
+    initial: Slice<Job> | null;
     slug: string;
     referralAvailable?: boolean;
   } = $props();
@@ -45,16 +45,14 @@
 </div>
 
 <div class="mt-4">
-  {#await initial}
-    <States state="loading" />
-  {:then slice}
-    <JobsView initial={slice} scope={{ company_slug: slug }} excludeFacets={['source']}>
+  {#if initial}
+    <JobsView {initial} scope={{ company_slug: slug }} excludeFacets={['source']}>
       {#snippet sidebarTop()}
         <CompanyFacts {company} />
         <CompanyAbout {company} />
       {/snippet}
     </JobsView>
-  {:catch}
+  {:else}
     <States state="error" message="Couldn't load jobs for this company." />
-  {/await}
+  {/if}
 </div>

--- a/web/src/lib/labels.ts
+++ b/web/src/lib/labels.ts
@@ -23,29 +23,21 @@ export function titleCase(value: string): string {
 }
 
 // Region code → display names, one row per vocab.RegionValues entry. `short`
-// is the compact UI label (filter pills, facet rows); `long` is the full place
-// name schema.org gets for applicantLocationRequirements. `global` has no
-// `long` — a worldwide reach intentionally carries no location requirement.
-export const REGIONS: { code: string; short: string; long?: string }[] = [
+// is the compact UI label (filter pills, facet rows).
+export const REGIONS: { code: string; short: string }[] = [
   { code: 'global', short: 'Worldwide' },
-  { code: 'north_america', short: 'North America', long: 'North America' },
-  { code: 'latam', short: 'LATAM', long: 'Latin America' },
-  { code: 'eu', short: 'Europe', long: 'European Union' },
-  { code: 'uk', short: 'UK', long: 'United Kingdom' },
-  { code: 'mena', short: 'MENA', long: 'MENA' },
-  { code: 'africa', short: 'Africa', long: 'Africa' },
-  { code: 'apac', short: 'APAC', long: 'Asia-Pacific' },
-  { code: 'cis', short: 'CIS', long: 'CIS' },
+  { code: 'north_america', short: 'North America' },
+  { code: 'latam', short: 'LATAM' },
+  { code: 'eu', short: 'Europe' },
+  { code: 'uk', short: 'UK' },
+  { code: 'mena', short: 'MENA' },
+  { code: 'africa', short: 'Africa' },
+  { code: 'apac', short: 'APAC' },
+  { code: 'cis', short: 'CIS' },
 ];
 
 export const REGION_LABELS: Record<string, string> = Object.fromEntries(
   REGIONS.map((r) => [r.code, r.short]),
-);
-
-// Full place names for schema.org (seo.ts); codes without one omit the
-// location requirement.
-export const REGION_NAMES: Record<string, string> = Object.fromEntries(
-  REGIONS.flatMap((r) => (r.long ? [[r.code, r.long]] : [])),
 );
 
 export const SENIORITY_LABELS: Record<string, string> = { c_level: 'C-level' };

--- a/web/src/lib/seo.test.ts
+++ b/web/src/lib/seo.test.ts
@@ -329,6 +329,53 @@ describe('jobPostingJsonLd', () => {
     expect(ld).not.toHaveProperty('jobLocation');
   });
 
+  // Google accepts Country and State under applicantLocationRequirements and
+  // geocodes the name; a supranational bloc is neither, so "North America" or
+  // "APAC" is a value it cannot resolve — which leaves TELECOMMUTE without the
+  // companion it requires. Every emitted name must be a real country.
+  it('states applicantLocationRequirements as countries, never a region bloc', () => {
+    const ld = jobPostingJsonLd(
+      postingJob({ work_mode: 'remote', regions: ['north_america'] }),
+      ORIGIN
+    );
+    // Sorted by name so the emitted order is stable across runs (the map this
+    // expands is keyed by ISO code, whose iteration order is an implementation
+    // detail we don't want a golden test to pin).
+    expect(ld.applicantLocationRequirements).toEqual([
+      { '@type': 'Country', name: 'Canada' },
+      { '@type': 'Country', name: 'United States' },
+    ]);
+  });
+
+  it('prefers the posting\'s own countries over expanding its region', () => {
+    // countries is the precise fact (this posting is US-only); the region is the
+    // coarse facet it rolls up to. Expanding north_america would wrongly claim
+    // Canada is in scope.
+    const ld = jobPostingJsonLd(
+      postingJob({ work_mode: 'remote', regions: ['north_america'], countries: ['us'] }),
+      ORIGIN
+    );
+    expect(ld.jobLocationType).toBe('TELECOMMUTE');
+    expect(ld.applicantLocationRequirements).toEqual({ '@type': 'Country', name: 'United States' });
+  });
+
+  it('emits a single object, not an array, for a one-country requirement', () => {
+    const ld = jobPostingJsonLd(postingJob({ work_mode: 'remote', regions: ['uk'] }), ORIGIN);
+    expect(ld.applicantLocationRequirements).toEqual({
+      '@type': 'Country',
+      name: 'United Kingdom',
+    });
+  });
+
+  it('ignores a worldwide reach, which names no country to require', () => {
+    const ld = jobPostingJsonLd(
+      postingJob({ work_mode: 'remote', regions: ['global'], location: 'Anywhere' }),
+      ORIGIN
+    );
+    expect(ld).not.toHaveProperty('jobLocationType');
+    expect(ld).not.toHaveProperty('applicantLocationRequirements');
+  });
+
   it('falls back to a plain jobLocation when a remote posting has no resolved region but does have a location string', () => {
     // Google requires applicantLocationRequirements whenever jobLocationType is
     // TELECOMMUTE — asserting TELECOMMUTE with no region to back it up would be an

--- a/web/src/lib/seo.test.ts
+++ b/web/src/lib/seo.test.ts
@@ -5,6 +5,7 @@ import {
   collectionPageJsonLd,
   companyListItems,
   companyMetaDescription,
+  companyPageTitle,
   datasetJsonLd,
   jobListItems,
   jobPostingJsonLd,
@@ -405,6 +406,23 @@ describe('jobPostingJsonLd', () => {
       '@type': 'Place',
       address: { '@type': 'PostalAddress', addressLocality: 'Berlin', addressCountry: 'DE' },
     });
+  });
+});
+
+describe('companyPageTitle', () => {
+  it('states the open-role count, comma-grouped', () => {
+    expect(companyPageTitle('Amazon', 6531)).toBe('Amazon — 6,531 open jobs · freehire');
+  });
+
+  it('uses the singular for a lone opening', () => {
+    expect(companyPageTitle('Agiliway', 1)).toBe('Agiliway — 1 open job · freehire');
+  });
+
+  // A company with nothing open, or whose count never arrived (the search call
+  // failed), gets the plain title rather than a "0 open jobs" boast.
+  it('falls back to the bare name without a usable count', () => {
+    expect(companyPageTitle('Acme', 0)).toBe('Acme · freehire');
+    expect(companyPageTitle('Acme', undefined)).toBe('Acme · freehire');
   });
 });
 

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -72,6 +72,24 @@ export function jobPageTitle(job: Job): string {
   return `${lead} · ${SITE}`;
 }
 
+/** "<name> — <n> open jobs · freehire" for a company page's document title.
+ *
+ *  The bare "<name> · freehire" it replaces ran as short as 18 characters, which
+ *  left most of the SERP title width unused and read identically whether the
+ *  company had one opening or six thousand. The count is the fact a searcher is
+ *  actually weighing, and it is the same live total the page's own heading shows.
+ *
+ *  No count (search failed) or a zero one falls back to the bare name: a company
+ *  page still exists when nothing is open, and "0 open jobs" in a search result
+ *  is an argument against clicking. */
+export function companyPageTitle(name: string, total: number | undefined): string {
+  if (!total) return `${name} · ${SITE}`;
+  // Pinned locale, like collectionHeading: this is crawler-visible metadata, so
+  // SSR and the client recompute must group digits identically.
+  const roles = `${total.toLocaleString('en-US')} open ${total === 1 ? 'job' : 'jobs'}`;
+  return `${name} — ${roles} · ${SITE}`;
+}
+
 /** "<total> <title> jobs" — a collection's heading with its live open-job
  *  count, comma-grouped. Falls back to the plain "<title> jobs" when no count
  *  is available (the count is optional on the underlying job-search response). */

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -136,14 +136,17 @@ const COUNTRY_DISPLAY = new Intl.DisplayNames(['en'], { type: 'region' });
 
 function countryName(iso: string): string | undefined {
   const code = iso.toUpperCase();
-  let name: string | undefined;
   try {
-    name = COUNTRY_DISPLAY.of(code);
+    const name = COUNTRY_DISPLAY.of(code);
+    // `of` echoes an unknown code back rather than failing; that is not a name.
+    return !name || name === code ? undefined : name;
   } catch {
+    // Malformed input (not a region code at all) — Intl throws rather than echoes.
     return undefined;
   }
-  return name && name !== code ? name : undefined;
 }
+
+type CountryRef = { '@type': 'Country'; name: string };
 
 // Google resolves applicantLocationRequirements at Country or State level and
 // geocodes the name, so a supranational bloc ("North America", "APAC") is a value
@@ -152,7 +155,10 @@ function countryName(iso: string): string | undefined {
 // them (the precise fact), else the countries its region groups. A worldwide
 // reach ('global') groups none and states no requirement, which is correct — it
 // restricts nobody.
-function applicantRegions(regions?: string[], countries?: string[]): unknown {
+function applicantRegions(
+  regions?: string[],
+  countries?: string[]
+): CountryRef | CountryRef[] | undefined {
   const iso = countries?.length
     ? countries
     : (regions ?? []).flatMap((r) => REGION_COUNTRIES[r] ?? []);
@@ -160,7 +166,9 @@ function applicantRegions(regions?: string[], countries?: string[]): unknown {
     ...new Set(iso.map(countryName).filter((n): n is string => Boolean(n))),
   ].toSorted();
   if (named.length === 0) return undefined;
-  const entries = named.map((name) => ({ '@type': 'Country', name }));
+  const entries: CountryRef[] = named.map((name) => ({ '@type': 'Country', name }));
+  // schema.org reads a lone object and a one-element array alike; emit the object
+  // so the common single-country case stays readable in the page source.
   return entries.length === 1 ? entries[0] : entries;
 }
 

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -4,7 +4,7 @@
 
 import type { PostMeta } from './blog';
 import { countryLabel } from './facets';
-import { REGION_NAMES } from './labels';
+import { COUNTRY_REGION_MAP } from './generated/contracts';
 import { companyLogoUrl } from './logo';
 import type { Company, Enrichment, Job } from './types';
 
@@ -100,9 +100,52 @@ const SALARY_UNIT: Record<string, string> = {
   year: 'YEAR',
 };
 
-// Full region names for applicantLocationRequirements come from the shared
-// REGIONS table (labels.ts). Broad or worldwide reaches ('global') carry no
-// name there and intentionally omit a requirement.
+// Countries of a region, inverted from the generated country→region map (the
+// same grouping internal/location keys the facet on). Built once at module load.
+const REGION_COUNTRIES: Record<string, string[]> = (() => {
+  const out: Record<string, string[]> = {};
+  for (const [code, region] of Object.entries(COUNTRY_REGION_MAP)) {
+    (out[region] ??= []).push(code);
+  }
+  return out;
+})();
+
+// ISO 3166-1 alpha-2 → English country name. Intl carries the list, so there is
+// no country table to keep in sync here; a code it doesn't know (e.g. the 'xk'
+// user-assigned code for Kosovo) comes back unchanged and is dropped rather than
+// emitted as a two-letter "name".
+const COUNTRY_DISPLAY = new Intl.DisplayNames(['en'], { type: 'region' });
+
+function countryName(iso: string): string | undefined {
+  const code = iso.toUpperCase();
+  let name: string | undefined;
+  try {
+    name = COUNTRY_DISPLAY.of(code);
+  } catch {
+    return undefined;
+  }
+  return name && name !== code ? name : undefined;
+}
+
+// Google resolves applicantLocationRequirements at Country or State level and
+// geocodes the name, so a supranational bloc ("North America", "APAC") is a value
+// it cannot place — and TELECOMMUTE without a usable companion is an invalid
+// combination. Emit countries instead: the posting's own `countries` when it has
+// them (the precise fact), else the countries its region groups. A worldwide
+// reach ('global') groups none and states no requirement, which is correct — it
+// restricts nobody.
+function applicantRegions(regions?: string[], countries?: string[]): unknown {
+  const iso = countries?.length
+    ? countries
+    : (regions ?? []).flatMap((r) => REGION_COUNTRIES[r] ?? []);
+  const named = [
+    ...new Set(iso.map(countryName).filter((n): n is string => Boolean(n))),
+  ].toSorted();
+  if (named.length === 0) return undefined;
+  const entries = named.map((name) => ({ '@type': 'Country', name }));
+  return entries.length === 1 ? entries[0] : entries;
+}
+
 function baseSalary(e: Enrichment): Record<string, unknown> {
   const value: Record<string, unknown> = { '@type': 'QuantitativeValue' };
   if (e.salary_min != null) value.minValue = e.salary_min;
@@ -113,15 +156,6 @@ function baseSalary(e: Enrichment): Record<string, unknown> {
     currency: e.salary_currency || 'USD',
     value,
   };
-}
-
-function applicantRegions(regions?: string[]): unknown {
-  const named = (regions ?? [])
-    .map((r) => REGION_NAMES[r])
-    .filter((name): name is string => Boolean(name))
-    .map((name) => ({ '@type': 'Country', name }));
-  if (named.length === 0) return undefined;
-  return named.length === 1 ? named[0] : named;
 }
 
 // schema.org jobLocation from the raw location string: Google accepts a
@@ -224,7 +258,7 @@ export function jobPostingJsonLd(job: Job, origin: string): Record<string, unkno
   if (empType) ld.employmentType = empType;
 
   if (job.work_mode === 'remote') {
-    const regions = applicantRegions(job.regions);
+    const regions = applicantRegions(job.regions, job.countries);
     if (regions) {
       // Google requires applicantLocationRequirements whenever jobLocationType is
       // TELECOMMUTE — set them together, never TELECOMMUTE alone.

--- a/web/src/lib/sitemap.test.ts
+++ b/web/src/lib/sitemap.test.ts
@@ -42,13 +42,30 @@ describe('collectionPaths', () => {
 });
 
 describe('blogPaths', () => {
-  it('includes the /blog index followed by one path per post', () => {
-    const paths = blogPaths([{ slug: 'first' }, { slug: 'second' }]);
-    expect(paths).toEqual(['/blog', '/blog/first', '/blog/second']);
+  it('includes the /blog index followed by one entry per post', () => {
+    const paths = blogPaths([
+      { slug: 'first', date: '2026-01-02' },
+      { slug: 'second', date: '2026-01-05' },
+    ]);
+    expect(paths).toEqual([
+      // The index changes whenever its newest post does.
+      { path: '/blog', lastmod: '2026-01-05' },
+      { path: '/blog/first', lastmod: '2026-01-02' },
+      { path: '/blog/second', lastmod: '2026-01-05' },
+    ]);
   });
 
-  it('is just the index when there are no posts', () => {
-    expect(blogPaths([])).toEqual(['/blog']);
+  it('dates the index from the newest post regardless of input order', () => {
+    const paths = blogPaths([
+      { slug: 'older', date: '2025-11-30' },
+      { slug: 'newest', date: '2026-03-01' },
+      { slug: 'middle', date: '2026-01-15' },
+    ]);
+    expect(paths[0]).toEqual({ path: '/blog', lastmod: '2026-03-01' });
+  });
+
+  it('is just the index, undated, when there are no posts', () => {
+    expect(blogPaths([])).toEqual([{ path: '/blog', lastmod: undefined }]);
   });
 });
 

--- a/web/src/lib/sitemap.ts
+++ b/web/src/lib/sitemap.ts
@@ -45,11 +45,21 @@ export function collectionPaths(): string[] {
   return collectionSlugs().map((slug) => `/collections/${slug}`);
 }
 
-/** Sitemap paths for the blog: the index (`/blog`) plus one path per published
- *  post. Takes the posts (from `listPosts()`) rather than reading them itself, so
- *  it stays pure/testable — the glob-backed loader is called by the route. */
-export function blogPaths(posts: { slug: string }[]): string[] {
-  return ['/blog', ...posts.map((post) => `/blog/${post.slug}`)];
+/** Sitemap entries for the blog: the index (`/blog`) plus one per published post,
+ *  each dated with the post's own publish date. Takes the posts (from
+ *  `listPosts()`) rather than reading them itself, so it stays pure/testable — the
+ *  glob-backed loader is called by the route.
+ *
+ *  The dates matter: without a `lastmod` a crawler has nothing to tell an edited
+ *  or newly published post from one it already has, and re-reads the whole set on
+ *  its own schedule. The index carries the newest post's date, since that is
+ *  exactly when its content last changed. */
+export function blogPaths(posts: { slug: string; date: string }[]): PathEntry[] {
+  const newest = posts.map((post) => post.date).toSorted().at(-1);
+  return [
+    { path: '/blog', lastmod: newest },
+    ...posts.map((post) => ({ path: `/blog/${post.slug}`, lastmod: post.date })),
+  ];
 }
 
 /** Sitemap paths for the insights pages: the hub plus salary/skills/roles for each
@@ -61,6 +71,15 @@ export function insightsPaths(categories: string[]): string[] {
     paths.push(`/insights/salary/${c}`, `/insights/skills/${c}`, `/insights/roles/${c}`);
   }
   return paths;
+}
+
+/** A sitemap path with the date its content last changed, before an origin is
+ *  prefixed. `lastmod` is undefined when there is no honest date to state — a
+ *  guessed one is worse than none, since a crawler that learns the dates are
+ *  noise stops using them. */
+export interface PathEntry {
+  path: string;
+  lastmod?: string;
 }
 
 export interface UrlEntry {

--- a/web/src/routes/companies/[slug]/+page.server.ts
+++ b/web/src/routes/companies/[slug]/+page.server.ts
@@ -5,37 +5,45 @@ import type { PageServerLoad } from './$types';
 
 const LIMIT = 20;
 
-// Server-render the company entity and stream its first page of search results.
-// The job list is search-backed and scoped to this company (company_slug), so it
-// carries a true total (the vacancy count) and supports the same URL filters as
-// /jobs. The company entity is fetched separately because search returns only jobs.
+// Server-render the company entity AND its first page of search results. The job
+// list is search-backed and scoped to this company (company_slug), so it carries a
+// true total (the vacancy count) and supports the same URL filters as /jobs. The
+// company entity is fetched separately because search returns only jobs.
 //
-// Only the company entity is awaited — it drives the header and SEO, and is cheap.
-// The job search is the slow call, so it is returned as an *unresolved* promise
-// that SvelteKit streams: the navigation completes as soon as the company resolves
-// and CompanyView renders a skeleton until the jobs land. A 404 (unknown company)
-// becomes a SvelteKit 404; other company failures bubble to the 500 page, and a
-// failed search surfaces in CompanyView's {:catch}.
+// Both are awaited, so the rows — and the /jobs/<slug> links on them — are in the
+// initial HTML. This list used to stream as an unresolved promise, which kept the
+// header fast but left the markup with no job links at all: the data arrived as a
+// trailing JSON chunk that only client-side JS turns into anchors. Link discovery
+// happens when a crawler parses HTML, so ~200k company pages advertised none of
+// their vacancies, and these pages exist mainly to be found in search. The two
+// calls still run concurrently, so the cost is the slower of the two rather than
+// their sum (measured: +0.64s median TTFB, +1.28s worst).
+//
+// A 404 (unknown company) becomes a SvelteKit 404; other company failures bubble
+// to the 500 page. A failed SEARCH must not take the page down with it — the
+// header, About and facts are still worth serving — so it resolves to null and
+// CompanyView renders the error state in place of the list.
 export const load: PageServerLoad = async ({ params, url, fetch }) => {
   const client = serverApi(fetch);
   const facets = new URLSearchParams(url.searchParams);
   facets.set('company_slug', params.slug);
 
-  // Start the search now so it runs concurrently with the company fetch, but
-  // don't await it — it streams to the client.
-  const initial = client.searchJobs(facets, LIMIT, 0);
+  // Start the search first so it overlaps the company fetch below.
+  const search = client.searchJobs(facets, LIMIT, 0).catch(() => null);
 
   try {
-    // Only `company` is used (the list comes from `initial`), so the returned job
+    // Only `company` is used (the list comes from `search`), so the returned job
     // is discarded. We can't ask for zero jobs: the API clamps `limit` to >= 1
     // (pageParams), so limit=1 is already the minimal fetch. Trimming this fully
     // needs a backend company-entity-only path — deferred to the latency follow-up.
     const { company, referral_available } = await client.getCompany(params.slug, 1, 0);
-    return { company, initial, slug: params.slug, referralAvailable: referral_available };
+    return {
+      company,
+      initial: await search,
+      slug: params.slug,
+      referralAvailable: referral_available,
+    };
   } catch (e) {
-    // The company load failed; mark the abandoned search promise handled so its
-    // eventual rejection isn't an unhandled rejection on the server.
-    initial.catch(() => {});
     if (e instanceof ApiError && e.status === 404) {
       error(404, 'Company not found');
     }

--- a/web/src/routes/companies/[slug]/+page.server.ts
+++ b/web/src/routes/companies/[slug]/+page.server.ts
@@ -11,13 +11,12 @@ const LIMIT = 20;
 // company entity is fetched separately because search returns only jobs.
 //
 // Both are awaited, so the rows — and the /jobs/<slug> links on them — are in the
-// initial HTML. This list used to stream as an unresolved promise, which kept the
-// header fast but left the markup with no job links at all: the data arrived as a
-// trailing JSON chunk that only client-side JS turns into anchors. Link discovery
-// happens when a crawler parses HTML, so ~200k company pages advertised none of
-// their vacancies, and these pages exist mainly to be found in search. The two
-// calls still run concurrently, so the cost is the slower of the two rather than
-// their sum (measured: +0.64s median TTFB, +1.28s worst).
+// initial HTML. The list used to stream as an unresolved promise, which arrived as
+// a trailing JSON chunk only client-side JS turns into anchors; since crawlers
+// discover links by parsing HTML, ~200k company pages advertised none of their
+// vacancies, and these pages exist mainly to be found in search. The two calls
+// still start together, so this costs the slower of the two rather than their sum
+// (measured: +0.64s median TTFB, +1.28s worst).
 //
 // A 404 (unknown company) becomes a SvelteKit 404; other company failures bubble
 // to the 500 page. A failed SEARCH must not take the page down with it — the

--- a/web/src/routes/companies/[slug]/+page.svelte
+++ b/web/src/routes/companies/[slug]/+page.svelte
@@ -2,7 +2,13 @@
   import { page } from '$app/state';
   import CompanyView from '$lib/components/CompanyView.svelte';
   import Seo from '$lib/components/Seo.svelte';
-  import { breadcrumbJsonLd, companyMetaDescription, jsonLdScript, organizationJsonLd } from '$lib/seo';
+  import {
+    breadcrumbJsonLd,
+    companyMetaDescription,
+    companyPageTitle,
+    jsonLdScript,
+    organizationJsonLd,
+  } from '$lib/seo';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
@@ -23,7 +29,7 @@
 </script>
 
 <Seo
-  title={`${data.company.name} · freehire`}
+  title={companyPageTitle(data.company.name, data.initial?.total)}
   {description}
   {canonical}
   image={`${origin}/companies/${data.slug}/og.png`}

--- a/web/src/routes/sitemap-pages.xml/+server.ts
+++ b/web/src/routes/sitemap-pages.xml/+server.ts
@@ -1,11 +1,20 @@
 import { listPosts } from '$lib/blogPosts';
 import { STATIC_PATHS, blogPaths, collectionPaths, urlsetXml, xmlResponse } from '$lib/sitemap';
+import type { PathEntry } from '$lib/sitemap';
 import type { RequestHandler } from './$types';
 
 // Sub-sitemap for the site's static pages plus the curated collection landing
 // pages and the blog (index + published posts), referenced by the sitemap index.
+//
+// Only the blog carries a lastmod: a post has a real publish date, while a static
+// page changes with a deploy and a collection with the catalogue behind it —
+// neither has a date we can state honestly, and a made-up one teaches crawlers to
+// ignore the field everywhere.
 export const GET: RequestHandler = ({ url }) => {
-  const paths = [...STATIC_PATHS, ...collectionPaths(), ...blogPaths(listPosts())];
-  const entries = paths.map((path) => ({ loc: `${url.origin}${path}` }));
+  const undated: PathEntry[] = [...STATIC_PATHS, ...collectionPaths()].map((path) => ({ path }));
+  const entries = [...undated, ...blogPaths(listPosts())].map(({ path, lastmod }) => ({
+    loc: `${url.origin}${path}`,
+    lastmod,
+  }));
   return xmlResponse(urlsetXml(entries));
 };


### PR DESCRIPTION
Six changes from an SEO audit of freehire.me. Each was verified against a production build rather than reasoned about; the numbers below are measured.

## What's here

**1. Hashed assets served from nginx, with brotli** (`web/nginx.conf`, `web/Dockerfile`)

`vite build` writes 817 `.br` files that were never sent. adapter-node's sirv served every asset through the same event loop that renders pages, and nginx re-compressed its output as gzip — so a client asking for `br` got the file *uncompressed*.

| Accept-Encoding: br | before | after |
|---|---|---|
| `0.Ck9I_yPY.css` | 144 376 B | **20 503 B** |
| `entry/start.js` | 497 B | 286 B |

Also installs `ngx_brotli` so nginx can encode SSR HTML (previously it answered an `Accept-Encoding` of exactly `br` with an uncompressed body).

The security headers are repeated inside the new `location` on purpose: an `add_header` there *replaces* the inherited server-level set rather than adding to it. Verified all four still ship.

**2. `applicantLocationRequirements` states countries, not region blocs** (`web/src/lib/seo.ts`)

We emitted `{"@type":"Country","name":"North America"}` — and likewise `Latin America`, `APAC`, `MENA`, `CIS`. Google resolves this property at Country or State level and geocodes the name, so none of those can be placed, which leaves `TELECOMMUTE` without the companion it requires.

Now expands to real countries from the generated `COUNTRY_REGION_MAP` (single-sourced with `internal/location`, so it stays dict-only), with names from `Intl` — no country table to maintain. A posting's own `countries` wins over its region, so a US-only remote role no longer claims Canada by rolling up to `north_america`.

**3. A company's job rows are server-rendered** (`companies/[slug]/+page.server.ts`, `CompanyView.svelte`)

The list was returned as an unresolved promise and streamed, arriving as a trailing JSON chunk that only client-side JS turns into anchors. Crawlers discover links by parsing HTML, so ~200k company pages advertised none of their vacancies — and these pages exist mainly to be found in search.

Measured on a production build with SSR pointed at the public API:

| | before | after |
|---|---|---|
| `<a href="/jobs/…">` on `/companies/amazon` | **0** | **20** |
| `<h3>` job titles | **0** | **20** |

Cost: **+0.64s median TTFB, +1.28s worst** — both calls still start together, so it is the slower of the two, not their sum. `/collections/*`, the homepage, and a company with no openings are unchanged.

A failed search no longer had a `{:catch}` to land in, so it resolves to `null` and the error state renders in place of the list — the header, facts and About are still worth serving when only search is down.

**4. Blog entries carry a `lastmod`** (`web/src/lib/sitemap.ts`)

All 196 URLs in `sitemap-pages.xml` were undated. Posts have a real publish date; the `/blog` index takes its newest post's. Static pages and collections stay undated on purpose — any date there would be invented, and a crawler that learns the field is noise stops reading it where it is real. Verified: 77 of 196 entries dated.

**5. Company titles state the open-role count** (`web/src/lib/seo.ts`)

`Agiliway · freehire` is 18 characters and read the same whether a company had one opening or six thousand. The count only became available to the title once the search moved server-side in (3).

```
Amazon · freehire    ->  Amazon — 6,979 open jobs · freehire
Agiliway · freehire  ->  Agiliway — 1 open job · freehire
```

Zero or a missing count keeps the bare name — "0 open jobs" in a search result argues against clicking.

**6. Refactor pass** — no behavior change: tighter control flow in the country-name helper, a real return type instead of `unknown`.

## Checks

- `vitest`: **975 passed** (91 files), including 7 new tests
- `svelte-check`: 0 errors
- `oxlint`/`eslint`: clean on changed files
- `go vet -tags=integration ./...`: passes (no Go touched)

## Two findings that need no code

- **`/similar` returns nothing** on all 8 postings I sampled. The block is implemented and awaited; the pgvector migration's `cmd/similar-backfill` looks like it hasn't been run on prod. Operational, not a code fix.
- **Prod appears to lag `main`.** Company meta descriptions were fixed on 9 Aug (`c4b5d967`) and the nginx security headers have been in the config since 15 Jun, but neither is present in production responses. Worth checking before expecting results from this PR.

## Not included, deliberately

- `Cache-Control` on HTML — `s-maxage` does nothing without a CDN in front
- `sitemap-jobs` is capped at 15 000 of ~1.1M open jobs; the cap is tuned to a 60s proxy timeout, so raising it needs the chunked/cursored treatment companies already have
- Location in the slug/title of multi-location postings (~5% of sampled URLs are near-duplicates) — changes every job URL, needs redirects