### PR TITLE
Reap search_outbox entries the drain can never claim

### DIFF
--- a/cmd/search-drain/store.go
+++ b/cmd/search-drain/store.go
@@ -46,6 +46,10 @@ func (s *dbStore) Complete(ctx context.Context, entries []searchdrain.Claimed) e
 	return s.q.DeleteSearchOutboxEntries(ctx, ids)
 }
 
+func (s *dbStore) Reap(ctx context.Context, maxRows int) (int64, error) {
+	return s.q.DeleteIneligibleSearchOutbox(ctx, int32(maxRows))
+}
+
 func (s *dbStore) Fail(ctx context.Context, outboxID int64, errMsg string, maxAttempts int) (bool, error) {
 	row, err := s.q.RecordSearchOutboxFailure(ctx, db.RecordSearchOutboxFailureParams{
 		LastError:   errMsg,

--- a/docs/superpowers/specs/2026-08-15-ingest-observability-design.md
+++ b/docs/superpowers/specs/2026-08-15-ingest-observability-design.md
@@ -206,15 +206,23 @@ number is stale, and the number itself stays readable.
 
 ### Deliberately not alerted
 
-`freehire_queue_oldest_age_seconds{queue="search_outbox"}` is graphed but never
-alerted, because it is structurally unbounded. `ClaimSearchOutboxBatch`
-(`internal/db/queries/search_outbox.sql:53`) orders `job_posted_at DESC` — freshest
-first — so entries for jobs with an old `posted_at` sink to the tail and are never
-claimed while fresher work keeps arriving. The purge that would remove them,
-`DeleteSearchOutboxCreatedBefore`, additionally requires `j.updated_at < before`
-(lines 84-86), and ingest keeps touching those jobs, so their `updated_at` stays recent
-and the purge skips them. 5,309 such rows were measured, all with `attempts = 0` — never
-even claimed once. See "Known defect" below.
+`freehire_queue_oldest_age_seconds{queue="search_outbox"}` is graphed but never alerted,
+because a persistent tail sat in that queue.
+
+**Correction — the cause below is not what this document first claimed.** The first
+diagnosis blamed `ClaimSearchOutboxBatch`'s `job_posted_at DESC` ordering starving old
+postings. Checked against prod afterwards and that was wrong: of the entries older than a
+day, **zero** belonged to an open canonical job. 631 were behind a `duplicate_of` and 138
+behind a closed job. The claim skips exactly those — correctly, there is nothing to index
+— and nothing deleted them. `DeleteSearchOutboxCreatedBefore` does not, because it also
+requires `jobs.updated_at` to predate the run, and a job demoted to a duplicate is still
+in its board's feed, so ingest keeps touching it. 1,618 such rows in total, the oldest
+queued eight days earlier.
+
+Fixed by `DeleteIneligibleSearchOutbox`, which the drain runs once per pass before
+claiming. Dead-lettered entries are deliberately exempt — `failed_at` is the record
+`freehire_queue_dead_letters` reports, so reaping those would erase the evidence rather
+than the garbage.
 
 Depth alerts on `enrichment_outbox` and `semantic_outbox` are also omitted. Both are
 structurally underwater — enrichment against a billing-capped LLM key pool, embedding
@@ -248,14 +256,21 @@ It deliberately leaves its own `freehire-pipeline.prom` in place on failure rath
 deleting it, for the reasons under "Alert rules" above. The worker holds no locks and
 writes nothing to the database, so a hung run cannot block ingest, drain, or reindex.
 
-## Known defect, out of scope
+## Known defect — found here, fixed separately
 
-The `search_outbox` tail described above is a real defect: 5,309 entries that no code
-path will ever process. It follows from two individually reasonable decisions — index
-the freshest first, and do not purge what changed after the reindex began — meeting at
-an edge neither anticipated. It is pre-existing and unrelated to this change, and fixing
-it here would widen the scope past observability into queue semantics. It should be
-raised separately.
+The `search_outbox` tail was a real defect: entries no code path would ever process,
+1,618 of them, the oldest eight days old. It followed from two individually reasonable
+decisions — skip what cannot be indexed, and do not purge what changed after the reindex
+began — meeting at an edge neither anticipated: a job demoted to a duplicate is skipped
+by the claim forever *and* kept fresh by ingest, so neither side ever removes it.
+
+Fixed by `DeleteIneligibleSearchOutbox`, run by the drain before each pass.
+
+Worth recording how it was nearly mis-fixed. The first diagnosis, written into this
+document, blamed the claim's `job_posted_at DESC` ordering for starving old postings. It
+was plausible and wrong, and a fix built on it would have changed claim ordering — real
+risk, no benefit. What settled it was one query: of the entries older than a day, how
+many belonged to an open canonical job? **Zero.** The ordering was never involved.
 
 ## Out of scope
 

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -732,6 +732,24 @@ type Querier interface {
 	// aged out.
 	DeleteExpiredTracerClicks(ctx context.Context, maxAge pgtype.Interval) (int64, error)
 	DeleteGmailConnection(ctx context.Context, userID int64) error
+	// Reap live entries ClaimSearchOutboxBatch can never take: their job has closed, become
+	// a non-canonical repost, or gone. That query's EXISTS requires open AND canonical, so
+	// these rows are correctly skipped — there is nothing left to index — but until this
+	// existed nothing deleted them either, and they accumulated.
+	//
+	// DeleteSearchOutboxCreatedBefore does not cover them. It additionally requires
+	// jobs.updated_at to predate the reindex, and a job demoted to a duplicate is still in
+	// its board's feed, so ingest keeps touching it and its updated_at keeps moving. Measured
+	// on prod 2026-08-15: 1,618 such rows, 631 of the day-old ones behind a duplicate_of and
+	// 138 behind a closed job, the oldest queued eight days earlier.
+	//
+	// Dead-lettered rows (failed_at set) are deliberately left alone: they are a deliberate
+	// record of repeated failure and are surfaced as freehire_queue_dead_letters, so reaping
+	// them here would erase the evidence rather than the garbage.
+	//
+	// Bounded by max_rows so one drain run cannot turn into an unbounded delete on the first
+	// pass over a long-accumulated backlog; the next run takes the next slice.
+	DeleteIneligibleSearchOutbox(ctx context.Context, maxRows int32) (int64, error)
 	// ---------------------------------------------------------------------------
 	// job_semantic_chunks: pgvector-backed per-chunk embeddings (see migration 0092
 	// and openspec/changes/drop-hybrid-search-pgvector-similar/design.md Decisions 1/5).

--- a/internal/db/queries/search_outbox.sql
+++ b/internal/db/queries/search_outbox.sql
@@ -85,6 +85,34 @@ WHERE o.job_id = j.id
   AND o.created_at < sqlc.arg(before)
   AND j.updated_at < sqlc.arg(before);
 
+-- name: DeleteIneligibleSearchOutbox :execrows
+-- Reap live entries ClaimSearchOutboxBatch can never take: their job has closed, become
+-- a non-canonical repost, or gone. That query's EXISTS requires open AND canonical, so
+-- these rows are correctly skipped — there is nothing left to index — but until this
+-- existed nothing deleted them either, and they accumulated.
+--
+-- DeleteSearchOutboxCreatedBefore does not cover them. It additionally requires
+-- jobs.updated_at to predate the reindex, and a job demoted to a duplicate is still in
+-- its board's feed, so ingest keeps touching it and its updated_at keeps moving. Measured
+-- on prod 2026-08-15: 1,618 such rows, 631 of the day-old ones behind a duplicate_of and
+-- 138 behind a closed job, the oldest queued eight days earlier.
+--
+-- Dead-lettered rows (failed_at set) are deliberately left alone: they are a deliberate
+-- record of repeated failure and are surfaced as freehire_queue_dead_letters, so reaping
+-- them here would erase the evidence rather than the garbage.
+--
+-- Bounded by max_rows so one drain run cannot turn into an unbounded delete on the first
+-- pass over a long-accumulated backlog; the next run takes the next slice.
+DELETE FROM search_outbox
+WHERE id IN (
+    SELECT o.id
+    FROM search_outbox o
+    LEFT JOIN jobs j ON j.id = o.job_id
+    WHERE o.failed_at IS NULL
+      AND (j.id IS NULL OR j.closed_at IS NOT NULL OR j.duplicate_of IS NOT NULL)
+    LIMIT sqlc.arg(max_rows)
+);
+
 -- name: RecordSearchOutboxFailure :one
 -- Count a failed attempt: bump attempts, record the error, and dead-letter (set
 -- failed_at) once attempts reach the max. The lease (claimed_at) is intentionally

--- a/internal/db/search_outbox.sql.go
+++ b/internal/db/search_outbox.sql.go
@@ -89,6 +89,43 @@ func (q *Queries) ClaimSearchOutboxBatch(ctx context.Context, arg ClaimSearchOut
 	return items, nil
 }
 
+const deleteIneligibleSearchOutbox = `-- name: DeleteIneligibleSearchOutbox :execrows
+DELETE FROM search_outbox
+WHERE id IN (
+    SELECT o.id
+    FROM search_outbox o
+    LEFT JOIN jobs j ON j.id = o.job_id
+    WHERE o.failed_at IS NULL
+      AND (j.id IS NULL OR j.closed_at IS NOT NULL OR j.duplicate_of IS NOT NULL)
+    LIMIT $1
+)
+`
+
+// Reap live entries ClaimSearchOutboxBatch can never take: their job has closed, become
+// a non-canonical repost, or gone. That query's EXISTS requires open AND canonical, so
+// these rows are correctly skipped — there is nothing left to index — but until this
+// existed nothing deleted them either, and they accumulated.
+//
+// DeleteSearchOutboxCreatedBefore does not cover them. It additionally requires
+// jobs.updated_at to predate the reindex, and a job demoted to a duplicate is still in
+// its board's feed, so ingest keeps touching it and its updated_at keeps moving. Measured
+// on prod 2026-08-15: 1,618 such rows, 631 of the day-old ones behind a duplicate_of and
+// 138 behind a closed job, the oldest queued eight days earlier.
+//
+// Dead-lettered rows (failed_at set) are deliberately left alone: they are a deliberate
+// record of repeated failure and are surfaced as freehire_queue_dead_letters, so reaping
+// them here would erase the evidence rather than the garbage.
+//
+// Bounded by max_rows so one drain run cannot turn into an unbounded delete on the first
+// pass over a long-accumulated backlog; the next run takes the next slice.
+func (q *Queries) DeleteIneligibleSearchOutbox(ctx context.Context, maxRows int32) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteIneligibleSearchOutbox, maxRows)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const deleteSearchOutboxCreatedBefore = `-- name: DeleteSearchOutboxCreatedBefore :execrows
 DELETE FROM search_outbox o
 USING jobs j

--- a/internal/db/search_outbox_integration_test.go
+++ b/internal/db/search_outbox_integration_test.go
@@ -11,6 +11,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -182,6 +183,129 @@ func TestEnqueueSearchOutboxDenormalizesJobPostedAt(t *testing.T) {
 // it still skips (without claiming) a job that closed or became a non-canonical repost
 // after being queued — the same behavior the old jobs-join version had, now reached via an
 // index scan plus a per-row EXISTS check instead of a join-then-sort.
+func TestDeleteIneligibleSearchOutboxReapsWhatClaimCanNeverTake(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	open, err := ingestUpsert(ctx, q, ingestParams("acme:open", "Open"))
+	if err != nil {
+		t.Fatalf("upsert open: %v", err)
+	}
+	canon, err := ingestUpsert(ctx, q, ingestParams("acme:canon", "Canon"))
+	if err != nil {
+		t.Fatalf("upsert canon: %v", err)
+	}
+	closedJob, err := ingestUpsert(ctx, q, ingestParams("acme:closed", "Closed"))
+	if err != nil {
+		t.Fatalf("upsert closed: %v", err)
+	}
+	repost, err := ingestUpsert(ctx, q, ingestParams("acme:repost", "Repost"))
+	if err != nil {
+		t.Fatalf("upsert repost: %v", err)
+	}
+	deadLettered, err := ingestUpsert(ctx, q, ingestParams("acme:dead", "Dead"))
+	if err != nil {
+		t.Fatalf("upsert dead: %v", err)
+	}
+
+	for _, id := range []int64{open.ID, canon.ID, closedJob.ID, repost.ID, deadLettered.ID} {
+		if err := q.EnqueueSearchOutbox(ctx, id); err != nil {
+			t.Fatalf("enqueue job %d: %v", id, err)
+		}
+	}
+	if _, err := pool.Exec(ctx, `UPDATE jobs SET closed_at = now() WHERE id = $1`, closedJob.ID); err != nil {
+		t.Fatalf("close job: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE jobs SET duplicate_of = $1 WHERE id = $2`, canon.ID, repost.ID); err != nil {
+		t.Fatalf("mark repost as duplicate: %v", err)
+	}
+	// A dead-lettered entry whose job ALSO closed: it is ineligible on both counts, and
+	// must still survive — failed_at is the record of repeated failure that
+	// freehire_queue_dead_letters reports, so reaping it would erase the evidence
+	// rather than the garbage.
+	if _, err := pool.Exec(ctx,
+		`UPDATE jobs SET closed_at = now() WHERE id = $1`, deadLettered.ID); err != nil {
+		t.Fatalf("close dead-lettered job: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE search_outbox SET failed_at = now() WHERE job_id = $1`, deadLettered.ID); err != nil {
+		t.Fatalf("dead-letter entry: %v", err)
+	}
+
+	reaped, err := q.DeleteIneligibleSearchOutbox(ctx, 100)
+	if err != nil {
+		t.Fatalf("DeleteIneligibleSearchOutbox: %v", err)
+	}
+	if reaped != 2 {
+		t.Errorf("reaped %d rows, want 2 (the closed job's and the repost's)", reaped)
+	}
+
+	var surviving []int64
+	rows, err := pool.Query(ctx, `SELECT job_id FROM search_outbox ORDER BY job_id`)
+	if err != nil {
+		t.Fatalf("list surviving: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		surviving = append(surviving, id)
+	}
+
+	for _, id := range []int64{open.ID, canon.ID, deadLettered.ID} {
+		if !containsInt64(surviving, id) {
+			t.Errorf("job %d's entry was reaped; only entries claim can never take may go", id)
+		}
+	}
+	for _, id := range []int64{closedJob.ID, repost.ID} {
+		if containsInt64(surviving, id) {
+			t.Errorf("job %d's entry survived; claim skips it forever, so nothing else would ever remove it", id)
+		}
+	}
+}
+
+func TestDeleteIneligibleSearchOutboxRespectsItsBound(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	// Five reapable entries, reaped two at a time: one drain run must not turn into an
+	// unbounded delete over a backlog that accumulated for weeks.
+	for i := range 5 {
+		job, err := ingestUpsert(ctx, q, ingestParams(fmt.Sprintf("acme:closed-%d", i), "Closed"))
+		if err != nil {
+			t.Fatalf("upsert %d: %v", i, err)
+		}
+		if err := q.EnqueueSearchOutbox(ctx, job.ID); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+		if _, err := pool.Exec(ctx, `UPDATE jobs SET closed_at = now() WHERE id = $1`, job.ID); err != nil {
+			t.Fatalf("close %d: %v", i, err)
+		}
+	}
+
+	first, err := q.DeleteIneligibleSearchOutbox(ctx, 2)
+	if err != nil {
+		t.Fatalf("first reap: %v", err)
+	}
+	if first != 2 {
+		t.Errorf("first reap removed %d rows, want exactly the 2 it was bounded to", first)
+	}
+
+	var left int64
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM search_outbox`).Scan(&left); err != nil {
+		t.Fatalf("count remaining: %v", err)
+	}
+	if left != 3 {
+		t.Errorf("%d entries left, want 3 — the next run takes the next slice", left)
+	}
+}
+
 func TestClaimSearchOutboxBatchOrdersByJobPostedAtAndSkipsClosedOrDuplicate(t *testing.T) {
 	pool := startPostgres(t)
 	q := New(pool)
@@ -268,7 +392,9 @@ func TestClaimSearchOutboxBatchOrdersByJobPostedAtAndSkipsClosedOrDuplicate(t *t
 	}
 
 	// The two skipped entries (closed, repost) remain unclaimed — claimed_at stays NULL —
-	// so a later reconciliation (a full reindex) is what clears them, not this claim.
+	// so something else has to clear them. That used to be assumed to be the full
+	// reindex; it was not (see DeleteIneligibleSearchOutbox), and they accumulated for
+	// weeks. The drain now reaps them.
 	for _, id := range []int64{closedJob.ID, repost.ID} {
 		var claimedAt pgtype.Timestamptz
 		if err := pool.QueryRow(ctx, `SELECT claimed_at FROM search_outbox WHERE job_id = $1`, id).Scan(&claimedAt); err != nil {

--- a/internal/searchdrain/runner.go
+++ b/internal/searchdrain/runner.go
@@ -13,8 +13,15 @@
 // It mirrors internal/embed: the batch/fallback logic is unit-tested with fakes of
 // the Store + Indexer ports and cmd/search-drain wires the real adapters. Unlike
 // embed there is no open/closed split — a job that closed or became a non-canonical
-// repost after being queued is simply not claimed (see ClaimSearchOutboxBatch); that
-// reconciles on the next full reindex, same as before this queue existed.
+// repost after being queued is simply not claimed (see ClaimSearchOutboxBatch), since
+// there is nothing left to index.
+//
+// Those skipped entries used to be described here as reconciling "on the next full
+// reindex". They did not. The reindex purge also requires jobs.updated_at to predate
+// the run, and a job demoted to a duplicate is still in its board's feed, so ingest
+// keeps touching it and its updated_at keeps moving — the row was skipped by the claim
+// forever and deleted by nothing. Measured on prod 2026-08-15: 1,618 such rows, the
+// oldest queued eight days earlier. Each run now reaps them first (Store.Reap).
 package searchdrain
 
 import (
@@ -47,6 +54,9 @@ type Store interface {
 	Complete(ctx context.Context, entries []Claimed) error
 	// Fail records a failed attempt for one entry; it reports whether it dead-lettered.
 	Fail(ctx context.Context, outboxID int64, errMsg string, maxAttempts int) (deadLettered bool, err error)
+	// Reap deletes up to maxRows live entries Claim can never take (their job closed,
+	// became a non-canonical repost, or is gone), returning how many it removed.
+	Reap(ctx context.Context, maxRows int) (int64, error)
 }
 
 // Indexer pushes a batch of jobs into the live facet index.
@@ -72,7 +82,17 @@ type Stats struct {
 	Indexed      int
 	Failed       int
 	DeadLettered int
+	// Reaped counts entries deleted because Claim could never take them — housekeeping,
+	// not indexing work.
+	Reaped int
 }
+
+// reapLimit bounds how many ineligible entries one run deletes. The backlog these
+// accumulate into is measured in thousands (1,618 on prod when this was written, the
+// oldest queued eight days earlier), so an unbounded first pass would turn a two-minute
+// drain tick into a long delete holding row locks the claim then waits on. A few runs
+// clearing it is fine; the queue is not urgent, only unbounded.
+const reapLimit = 2000
 
 // Runner drains the queue wave by wave until no claimable entries remain.
 type Runner struct {
@@ -84,6 +104,18 @@ type Runner struct {
 // entry is recorded and never aborts the run.
 func (r Runner) Run(ctx context.Context, opt RunOptions) (Stats, error) {
 	rn := &run{store: r.Store, indexer: r.Indexer, opt: opt}
+
+	// Reap BEFORE claiming: these entries are pure garbage to the claim query, which
+	// pays an EXISTS probe per row only to skip them, and they inflate
+	// freehire_queue_depth with work nobody will ever do. Best-effort — housekeeping
+	// must never be the reason the queue stops draining.
+	if n, err := r.Store.Reap(ctx, reapLimit); err != nil {
+		log.Printf("search-drain: reap ineligible entries (continuing): %v", err)
+	} else if n > 0 {
+		rn.stats.Reaped = int(n)
+		log.Printf("search-drain: reaped %d entries whose job closed or became a repost", n)
+	}
+
 	_, err := outbox.RunBatch(ctx, r.Store, outbox.RunOptions{
 		BatchSize:    opt.BatchSize,
 		LeaseSeconds: opt.LeaseSeconds,

--- a/internal/searchdrain/runner_test.go
+++ b/internal/searchdrain/runner_test.go
@@ -27,6 +27,10 @@ type fakeStore struct {
 	completed       []int64   // all job ids Complete'd
 	failCalls       []failCall
 	attempts        map[int64]int // outbox id -> attempts so far
+
+	reapCalls []int // max_rows per Reap call
+	reaped    int64 // rows Reap reports removed
+	reapErr   error
 }
 
 type failCall struct {
@@ -96,6 +100,58 @@ func (s *fakeStore) Fail(_ context.Context, outboxID int64, msg string, maxAttem
 	return s.attempts[outboxID] >= maxAttempts, nil
 }
 
+func (s *fakeStore) Reap(_ context.Context, maxRows int) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reapCalls = append(s.reapCalls, maxRows)
+	return s.reaped, s.reapErr
+}
+
+func TestRunnerReapsIneligibleEntriesBeforeDraining(t *testing.T) {
+	store := newFakeStore()
+	store.reaped = 7
+	ix := newFakeIndexer()
+	seed(store, 1, 2)
+
+	stats, err := Runner{Store: store, Indexer: ix}.Run(context.Background(), opt())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(store.reapCalls) != 1 {
+		t.Fatalf("Reap called %d times, want exactly once per run", len(store.reapCalls))
+	}
+	if stats.Reaped != 7 {
+		t.Errorf("stats.Reaped = %d, want 7", stats.Reaped)
+	}
+	// Reaping first means the claim does not have to scan past rows it would only
+	// skip, and the depth gauge stops counting work nobody will ever do.
+	if stats.Indexed != 2 {
+		t.Errorf("stats.Indexed = %d, want 2 — reaping must not disturb the drain", stats.Indexed)
+	}
+}
+
+func TestRunnerDrainsEvenWhenReapFails(t *testing.T) {
+	store := newFakeStore()
+	store.reapErr = errors.New("deadlock detected")
+	ix := newFakeIndexer()
+	seed(store, 1, 2, 3)
+
+	stats, err := Runner{Store: store, Indexer: ix}.Run(context.Background(), opt())
+
+	// Reaping is housekeeping. Letting it fail the run would trade a queue that is
+	// merely untidy for one that is not being drained at all.
+	if err != nil {
+		t.Fatalf("Run returned %v, want the reap failure to be logged and the drain to continue", err)
+	}
+	if stats.Indexed != 3 {
+		t.Errorf("stats.Indexed = %d, want 3", stats.Indexed)
+	}
+	if stats.Reaped != 0 {
+		t.Errorf("stats.Reaped = %d, want 0 when the reap failed", stats.Reaped)
+	}
+}
+
 // fakeIndexer records IndexBatch calls. batchFails makes any multi-job IndexBatch
 // fail (to exercise the per-item fallback); indexErr fails a specific job.
 type fakeIndexer struct {
@@ -143,6 +199,14 @@ func (ix *fakeIndexer) IndexBatch(ctx context.Context, jobs []db.Job) error {
 
 func opt() RunOptions {
 	return RunOptions{BatchSize: 500, LeaseSeconds: 300, MaxAttempts: 3}
+}
+
+// seed queues one claimable entry per job id, with the job row to match.
+func seed(s *fakeStore, ids ...int64) {
+	for _, id := range ids {
+		s.jobs[id] = db.Job{ID: id}
+		s.pending = append(s.pending, Claimed{OutboxID: id * 10, JobID: id})
+	}
 }
 
 func has(ids []int64, id int64) bool {

--- a/openspec/changes/pipeline-queue-metrics/design.md
+++ b/openspec/changes/pipeline-queue-metrics/design.md
@@ -112,14 +112,18 @@ per minute regardless of scrape activity. If it proves measurable against host-2
 existing I/O pressure, the timer interval is the single tuning knob and lives in
 `freehire-ops`.
 
-**`freehire_queue_oldest_age_seconds` for `search_outbox` is structurally unbounded, so
-it looks like a broken metric** → It is published and graphed but deliberately never
-alerted on, and the reason is recorded in the cross-repo design. `ClaimSearchOutboxBatch`
-(`internal/db/queries/search_outbox.sql:53`) orders `job_posted_at DESC`, so entries for
-jobs with an old `posted_at` sink to the tail and are never claimed while fresher work
-arrives; `DeleteSearchOutboxCreatedBefore` additionally requires `j.updated_at < before`
-(lines 84-86), and ingest keeps touching those jobs, so the purge skips them. 5,309 such
-rows were measured, all with `attempts = 0`. The metric is honest; the queue is not.
+**`freehire_queue_oldest_age_seconds` for `search_outbox` reads implausibly high, so it
+looks like a broken metric** → It is published and graphed but never alerted on. The
+metric was honest; the queue was not.
+
+*Post-ship correction.* This paragraph originally blamed `ClaimSearchOutboxBatch`'s
+`job_posted_at DESC` ordering for starving old postings. Checked against prod afterwards
+and that was wrong: of the entries older than a day, **zero** belonged to an open
+canonical job — 631 sat behind a `duplicate_of` and 138 behind a closed job. The claim
+skips exactly those, correctly, and nothing deleted them;
+`DeleteSearchOutboxCreatedBefore` also requires `jobs.updated_at` to predate the run, and
+a job demoted to a duplicate stays in its board's feed so ingest keeps touching it.
+Fixed by `DeleteIneligibleSearchOutbox`, which the drain runs before each pass.
 
 **The metric names become a contract with a repository that cannot enforce it** → A
 golden test over the rendered text pins the exact names, label sets, and `# HELP`/`# TYPE`


### PR DESCRIPTION
Found while shipping the pipeline metrics (#1964): `search_outbox` carried a tail of entries nothing would ever process — **1,618** of them on prod, the oldest queued eight days earlier.

## The defect

`ClaimSearchOutboxBatch` only claims entries whose job is open **and** canonical. A job that closes, or gets demoted to a non-canonical repost, after being queued is skipped — correctly, there is nothing left to index. But nothing deleted those entries.

`DeleteSearchOutboxCreatedBefore` looks like it should, and does not: it additionally requires `jobs.updated_at` to predate the reindex, and a job demoted to a duplicate is still in its board's feed, so ingest keeps touching it and `updated_at` keeps moving. Skipped by the claim forever, kept fresh by ingest, deleted by neither.

Measured on prod, entries older than a day:

| | |
|---|---|
| behind a `duplicate_of` | 631 |
| behind a closed job | 138 |
| belonging to an open canonical job | **0** |

## How it was nearly mis-fixed

The first diagnosis — written into the design doc for #1964 before this was checked — blamed the claim's `job_posted_at DESC` ordering for starving old postings. Plausible, and wrong. A fix built on it would have changed claim ordering: real risk, no benefit.

One query settled it: *of the entries older than a day, how many belong to an open canonical job?* Zero. The ordering was never involved. This PR also corrects that claim everywhere it was written down — the package doc, the design doc, and a test comment that had asserted these rows "reconcile on the next full reindex".

## The fix

`DeleteIneligibleSearchOutbox`, run once per drain pass **before** claiming — those rows are pure cost to the claim query, which pays an `EXISTS` probe per row only to skip them, and they inflate `freehire_queue_depth` with work nobody will ever do.

- **Bounded** at 2,000 per run. An unbounded first pass over a weeks-old backlog would turn a two-minute drain tick into a long delete holding row locks the claim then waits on.
- **Best-effort.** A failed reap is logged and the drain continues — trading an untidy queue for one that is not draining at all is a bad deal.
- **Dead letters are exempt.** `failed_at` is the record of repeated failure that `freehire_queue_dead_letters` reports; reaping those would erase the evidence rather than the garbage.

## Verification

- `gofmt` clean, `go vet ./...` and `go vet -tags=integration ./...` clean, `go test ./...` no failures
- `go test -tags=integration ./internal/db/ ./cmd/search-drain/` passes
- Integration tests cover the reap set, the dead-letter exemption, and the bound
- **Mutation-checked**: dropping the `failed_at IS NULL` guard makes the suite fail (`reaped 3 rows, want 2`), so the dead-letter exemption is genuinely asserted rather than incidentally true
- Unit tests cover the runner wiring: reap runs once per pass, is reported in `Stats`, and a reap failure does not abort the drain


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically removes stale search queue entries for missing, closed, or duplicate jobs.
  * Preserves failed entries for troubleshooting while preventing ineligible entries from accumulating.
  * Limits cleanup batches to maintain reliable queue processing.
  * Continues draining search work even if cleanup encounters an error.
* **Monitoring**
  * Drain activity now reports how many stale entries were removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->