### PR TITLE
Probe a board with its own source adapter when no prober exists

### DIFF
--- a/cmd/harvest-boards/adapter_prober.go
+++ b/cmd/harvest-boards/adapter_prober.go
@@ -2,9 +2,42 @@ package main
 
 import (
 	"context"
+	"slices"
+	"sync"
 
 	"github.com/strelov1/freehire/internal/sources"
 )
+
+// proberFor resolves the prober for a provider: the bespoke one when probers names it, else
+// the provider's own source adapter run as a probe.
+//
+// The fallback exists because the two lists drift. probers is hand-maintained and names ~35
+// platforms; internal/sources carries close to a hundred adapters, and a platform missing from
+// the first is not a platform we cannot crawl — it is one whose boards nobody can propose. That
+// gap is what stranded 485 detected boards across 13 platforms in the August 2026 harvest. A
+// bespoke prober is still worth writing (one cheap request instead of a full crawl, and on ~10
+// platforms the employer name that powers the corroboration gate), so it always wins here.
+//
+// Two things the fallback does not inherit: -pace and the refusal counter. The adapter carries
+// its own sources.Client, so its requests bypass the run's paced, counting client — the same
+// blind spot the hand-written adapterProber entries have always had.
+func proberFor(provider string) (prober, bool) {
+	if p, ok := probers[provider]; ok {
+		return p, true
+	}
+	reg := adapterRegistry()
+	src, ok := reg[provider]
+	if !ok || !slices.Contains(sources.BoardKeyedProviders(reg), provider) {
+		return nil, false
+	}
+	return adapterProber{provider: provider, newSource: func() sources.Source { return src }}, true
+}
+
+// adapterRegistry builds the source registry once and shares it across probes, which is how
+// cmd/ingest uses it too — the adapters hold a concurrency-safe client and no per-crawl state.
+var adapterRegistry = sync.OnceValue(func() map[string]sources.Source {
+	return sources.All(sources.NewClient())
+})
 
 // adapterProber validates a board by running the real source adapter and counting the
 // postings it returns. It suits platforms (Taleo, Cornerstone) whose crawl is too stateful

--- a/cmd/harvest-boards/adapter_prober_test.go
+++ b/cmd/harvest-boards/adapter_prober_test.go
@@ -30,3 +30,50 @@ func TestPageupRegistered(t *testing.T) {
 		t.Fatal(`probers["pageup"] missing`)
 	}
 }
+
+func TestProberForPrefersTheBespokeProber(t *testing.T) {
+	p, ok := proberFor("greenhouse")
+	if !ok {
+		t.Fatal(`proberFor("greenhouse") not found`)
+	}
+	if _, fellBack := p.(adapterProber); fellBack {
+		t.Error("greenhouse resolved to the adapter fallback; its own prober (cheaper, and the "+
+			"only one that reports an employer name) must win", p)
+	}
+}
+
+func TestProberForFallsBackToTheProvidersAdapter(t *testing.T) {
+	// Platforms with a board-keyed adapter and no bespoke prober. Before the fallback these
+	// were unharvestable: harvest-boards refused the provider outright.
+	for _, provider := range []string{"rippling", "zohorecruit", "ukg", "manatal", "phenom", "hibob"} {
+		p, ok := proberFor(provider)
+		if !ok {
+			t.Errorf("proberFor(%q) not found; the provider has an adapter and is board-keyed", provider)
+			continue
+		}
+		a, isAdapter := p.(adapterProber)
+		if !isAdapter {
+			t.Errorf("proberFor(%q) = %T, want adapterProber", provider, p)
+			continue
+		}
+		if a.provider != provider {
+			t.Errorf("proberFor(%q).provider = %q", provider, a.provider)
+		}
+	}
+}
+
+func TestProberForRefusesBoardlessProviders(t *testing.T) {
+	// A boardless adapter serves one catalogue whatever board it is handed, so it would
+	// report jobs for a board that does not exist and confirm every candidate put to it.
+	for _, provider := range []string{"echojobs", "jobstash", "ozon"} {
+		if p, ok := proberFor(provider); ok {
+			t.Errorf("proberFor(%q) = %T, want no prober: a boardless adapter cannot refute a board", provider, p)
+		}
+	}
+}
+
+func TestProberForRefusesUnknownProvider(t *testing.T) {
+	if _, ok := proberFor("nosuchplatform"); ok {
+		t.Error(`proberFor("nosuchplatform") found a prober`)
+	}
+}

--- a/cmd/harvest-boards/main.go
+++ b/cmd/harvest-boards/main.go
@@ -15,6 +15,9 @@
 //
 // The id is the stronger claim — it identifies the board by evidence rather than by a name
 // resemblance — and is what makes a slug derived offline safe to propose at all.
+//
+// A platform with no prober of its own is probed by running its source adapter, so every
+// board-keyed platform we can crawl is one we can also harvest (see proberFor).
 package main
 
 import (
@@ -56,10 +59,18 @@ func run() int {
 		return 2
 	}
 
-	p, ok := probers[provider]
+	p, ok := proberFor(provider)
 	if !ok {
-		log.Printf("harvest-boards: no prober for provider %q", provider)
+		log.Printf("harvest-boards: no prober for provider %q, and no board-keyed adapter to fall "+
+			"back on", provider)
 		return 2
+	}
+	if a, viaAdapter := p.(adapterProber); viaAdapter {
+		// Say so: an adapter probe costs a whole crawl per candidate rather than one request,
+		// it publishes no employer name (so the corroboration gate stands down and liveness is
+		// the only evidence), and it answers outside the run's paced, counting client.
+		log.Printf("harvest-boards: %s has no prober of its own — probing by running its source "+
+			"adapter; no name gate, no pacing", a.provider)
 	}
 
 	ctx := context.Background()

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -59,6 +59,22 @@ func AggregatorProviders(reg map[string]Source) []string {
 	return out
 }
 
+// BoardKeyedProviders returns the sorted provider names in reg whose adapter is addressed by
+// a board id — every adapter that is not boardless. A caller that wants to say something about
+// ONE board (cmd/harvest-boards validating a candidate) needs this: a boardless adapter serves
+// the same catalogue whatever board it is handed, so it would answer for a board that does not
+// exist, and confirm every candidate put to it.
+func BoardKeyedProviders(reg map[string]Source) []string {
+	var out []string
+	for name, src := range reg {
+		if _, boardless := src.(boardless); !boardless {
+			out = append(out, name)
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
 // FilterableProviders returns the sorted provider keys the source facet offers.
 func FilterableProviders() []string { return filterableProviders(Taxonomy()) }
 

--- a/internal/sources/source_test.go
+++ b/internal/sources/source_test.go
@@ -111,6 +111,20 @@ func TestAggregatorProvidersListsOnlyAggregators(t *testing.T) {
 	}
 }
 
+func TestBoardKeyedProvidersExcludesBoardless(t *testing.T) {
+	got := BoardKeyedProviders(reg(
+		fakeSource{"greenhouse"},         // board-based ATS → listed
+		fakeSource{"workable"},           // board-based ATS → listed
+		fakeBoardlessSource{"ozon"},      // single-company boardless → excluded
+		fakeAggregatorSource{"jobstash"}, // boardless aggregator → excluded
+	))
+
+	want := []string{"greenhouse", "workable"}
+	if !slices.Equal(got, want) {
+		t.Errorf("BoardKeyedProviders() = %v, want %v", got, want)
+	}
+}
+
 func TestSweepGraceWindowsListsOnlyDeclaringProviders(t *testing.T) {
 	got := SweepGraceWindows(reg(
 		fakeSource{"greenhouse"},                         // board-based, no window → absent (default applies)

--- a/sources/hibob.yml
+++ b/sources/hibob.yml
@@ -39,3 +39,43 @@
   board: unique
 - company: Entrepreneur First
   board: entrepreneursfirst
+- company: BVGroup
+  board: bvgroup
+- company: CloudNC
+  board: cloudnc
+- company: CompassMSP
+  board: compassmsp
+- company: GetGo Technologies Pte Ltd
+  board: getgotechnologies
+- company: Gresham Technologies PLC
+  board: gresham
+- company: Hyve Group
+  board: hyvegroup
+- company: JUMO
+  board: jumo
+- company: K2 Integrity
+  board: k2integrity
+- company: Kiteworks
+  board: kiteworks
+- company: MPLC
+  board: mplc
+- company: ONWARD Medical
+  board: onwardmedical
+- company: SecurityBridge
+  board: securitybridge
+- company: Semarchy
+  board: semarchy
+- company: Snowplow
+  board: snowplow
+- company: Synpulse
+  board: synpulse
+- company: The Arena Group
+  board: thearenagroup
+- company: Tracsis
+  board: tracsis
+- company: WINT
+  board: wint
+- company: Zenzero Solutions Ltd
+  board: zenzero
+- company: Zepz
+  board: zepz

--- a/sources/jibe.yml
+++ b/sources/jibe.yml
@@ -27,3 +27,19 @@
   board: careers.ulta.com
 - company: Booking.com
   board: jobs.booking.com
+- company: Emory University
+  board: careers.emory.edu
+- company: ibex
+  board: careers.ibex.co
+- company: medpace
+  board: careers.medpace.com
+- company: Noble Health Services
+  board: careers.noblehealthservices.com
+- company: Sarnova
+  board: careers.sarnova.com
+- company: Sterling Pointe Veterinary Clinic
+  board: careers.vetcor.com
+- company: West Coast University, Inc.
+  board: careers.westcoastuniversity.edu
+- company: Oregon Health & Science University
+  board: jobs.ohsu.edu

--- a/sources/manatal.yml
+++ b/sources/manatal.yml
@@ -55,3 +55,155 @@
   board: initiumsoft
 - company: Keppri
   board: keppri
+- company: ADDENDUM
+  board: addendum-group-2
+- company: Advantage
+  board: advantage-rg
+- company: AMZ Advisers
+  board: amzadvisers
+- company: Aprende Institute
+  board: aprende-institute
+- company: Arajet
+  board: arajetjobs
+- company: Arkansas Talent Group
+  board: arkansas-talent-group
+- company: Arthan
+  board: arthan
+- company: Ataraxis Management
+  board: ataraxismgmt
+- company: Blossom HR
+  board: blossomhrjobs
+- company: Bravo Global Staffing
+  board: bravo-global-staffing
+- company: Btechnical Group
+  board: btechnical-group
+- company: Castelion Corporation
+  board: castelion-corporation
+- company: Citrus Systems
+  board: citrus-system
+- company: Computacenter
+  board: computacenter-asia
+- company: CY RECRUITMENT
+  board: cy-recruitment
+- company: Decision Inc.
+  board: decision-inc-3
+- company: Eagle Partners (International) Co., Limited
+  board: eagle-partners-international-co-limited
+- company: EyeCarePro
+  board: ecp
+- company: Elan Solutions LLC
+  board: elan-solutions-llc
+- company: EMCD
+  board: emcd
+- company: Epik
+  board: epik
+- company: Filinvest Group
+  board: filinvest-development-corp
+- company: FOUR SQUARED SOLUTIONS
+  board: four-squared-solutions
+- company: Fyfe
+  board: fyfe-2
+- company: GCO Partners
+  board: gco
+- company: Great Bay Staffing Group
+  board: great-bay-staffing-group
+- company: HR Plus (Talent) Limited
+  board: hr-plus-talent-limited
+- company: HR Ways
+  board: hr-ways-3
+- company: Humana International Group
+  board: humana
+- company: Interlingva, Inc.
+  board: interlingva
+- company: JDS Energy & Mining
+  board: jds-energy-mining
+- company: Joint Academy
+  board: joint-academy
+- company: JUARA IT SOLUTIONS
+  board: juara-it-solutions
+- company: Komforce
+  board: komforce
+- company: AltoVita
+  board: kravluxe
+- company: Krisvconsulting Services Pte Ltd
+  board: krisvconsulting-services-pte-ltd
+- company: Kubegrade
+  board: kubegrade
+- company: Lange Recruiting
+  board: lange-recruiting
+- company: Language Bear
+  board: languagebear
+- company: Link Compliance
+  board: link-compliance-pte-ltd
+- company: Lumiere Systems
+  board: lumieresystems
+- company: LUZA Group
+  board: luza-group
+- company: MINDFREE Consulting | Insurance Talent Hub
+  board: mfc-ith
+- company: Munich Ventures
+  board: munich-ventures-2
+- company: Nathan HR Human Resources
+  board: nathanhr
+- company: Next Move Healthcare
+  board: next-move-healthcare
+- company: NexusSearch International Limited
+  board: nexussearch
+- company: New Jersey Tribeca Group
+  board: njtg
+- company: Oak Ridge Legal Search LLC
+  board: oakridge-search
+- company: Christopher O'Keeffe CPA LLC
+  board: okeeffecpa-associates
+- company: One HR Hub
+  board: one-hr-hub
+- company: Open Look Business Solutions Inc.
+  board: open-look-business-solutions-inc
+- company: Orascom Investment Holding
+  board: orascom-investment-holding
+- company: Origo BPO
+  board: origo-bpo
+- company: Orion Placement
+  board: orionplacement
+- company: OneTeamAnywhere
+  board: ota
+- company: Presto
+  board: presto-phoenix-inc
+- company: PROCESIA
+  board: procesia
+- company: Prospect Rock Partners
+  board: prospectrockpartners
+- company: Pyramid Global Technologies
+  board: pyramid-global-technologies
+- company: Remi Recruiting
+  board: remi-jobs
+- company: Ruth Maskell Recruitment
+  board: ruth-maskell-recruitment
+- company: MD Staffing Services Inc.
+  board: schyma-md-staffing-inc
+- company: SDL Search Partners
+  board: sdl-search-partners
+- company: S&K HR Consulting
+  board: snk-hr-vacancies
+- company: STELO
+  board: stelogroup
+- company: Surgo PTY Ltd
+  board: surgo-pty-ltd
+- company: TalentCloud Group
+  board: talentcloud-recruitment-group-jobs
+- company: Outsource Accelerator
+  board: team-oa
+- company: TheHiveCareers
+  board: thehivecareers
+- company: Tokalent
+  board: tokalent
+- company: Vectra Search Pte. Ltd.
+  board: vectra-search-pte-ltd
+- company: Vertis Digital
+  board: vertis-digital
+- company: Virco Talent
+  board: virco-talent-2
+- company: watton hall
+  board: watton-hall
+- company: Waterfall Technology Consulting Partners
+  board: wtcpstaffing

--- a/sources/peopleforce.yml
+++ b/sources/peopleforce.yml
@@ -136,3 +136,23 @@
   board: arctic7
 - company: Rootstrap
   board: rootstrap
+- company: Digitalchemy
+  board: digitalchemy
+- company: DocuSketch
+  board: docusketch
+- company: Kagi Inc
+  board: kagi
+- company: Kendoo
+  board: kendoo
+- company: Kernelics
+  board: kernelics
+- company: TalentCross
+  board: talentcross
+- company: Taxes for Expats
+  board: tfx
+- company: Un Ensayo para Mí
+  board: unensayoparami
+- company: Unipesa
+  board: unipesa
+- company: VILLACARTE GROUP
+  board: villacarte

--- a/sources/phenom.yml
+++ b/sources/phenom.yml
@@ -113,3 +113,39 @@
 # Phenom tenant from the contribution queue (2026-08-07, refineSearch 362 postings)
 - company: UCB
   board: careers.ucb.com
+- company: AmerisourceBergen
+  board: careers.cencora.com
+- company: Clarivate
+  board: careers.clarivate.com
+- company: CONMED
+  board: careers.conmed.com
+- company: Dutch Bros Coffee
+  board: careers.dutchbros.com
+- company: EverCommerce
+  board: careers.evercommerce.com
+- company: FOX Rehabilitation
+  board: careers.foxrehab.org
+- company: GE Aerospace
+  board: careers.geaerospace.com
+- company: GE HealthCare
+  board: careers.gehealthcare.com
+- company: KBR, Inc.
+  board: careers.kbr.com
+- company: Mercy Health
+  board: careers.mercy.com
+- company: Oshkosh Corporation
+  board: careers.oshkoshcorp.com
+- company: Probe Group
+  board: careers.probecx.com
+- company: Seattle Children's
+  board: careers.seattlechildrens.org
+- company: Siemens Healthineers
+  board: careers.siemens-healthineers.com
+- company: Sonova Group
+  board: careers.sonova.com
+- company: Thales
+  board: careers.thalesgroup.com
+- company: Yale University
+  board: careers.yale.edu
+- company: Bureau Veritas
+  board: jobs.bureauveritas.com

--- a/sources/quickin.yml
+++ b/sources/quickin.yml
@@ -8,3 +8,5 @@
   board: botcity
 - company: Igma
   board: igma
+- company: Druid
+  board: druid

--- a/sources/radancy.yml
+++ b/sources/radancy.yml
@@ -11,3 +11,23 @@
   board: careers.moodys.com
 - company: Cedars-Sinai
   board: careers.cshs.org
+- company: SharkNinja
+  board: careers.sharkninja.com
+- company: TUI
+  board: careers.tuigroup.com
+- company: The Walt Disney Company
+  board: disneycareers.com
+- company: Baxter International Inc.
+  board: jobs.baxter.com
+- company: Carnival Corporation
+  board: jobs.carnival.com
+- company: Carnival Corporation & plc
+  board: jobs.carnivalcorp.com
+- company: Parexel
+  board: jobs.parexel.com
+- company: PerkinElmer
+  board: jobs.perkinelmer.com
+- company: Shiseido
+  board: jobs.shiseidoamericas.com
+- company: Takeda
+  board: jobs.takeda.com

--- a/sources/rippling.yml
+++ b/sources/rippling.yml
@@ -183,3 +183,277 @@
 # migrated from lever.yml — board moved off Lever (issue #1529), live-verified 2026-08-11
 - company: Battle Creek Church
   board: battlecreekchurch
+- company: 1nhealth
+  board: 1nhealth
+- company: Association of Asian Pacific Community Health Organizations
+  board: aapcho
+- company: AbsenceSoft, LLC
+  board: absencesoft
+- company: Accelint
+  board: accelintjobboardtest
+- company: Accommodations Plus International
+  board: accommodations-plus-international
+- company: Advanced Energy United
+  board: advanced-energy-united-career-opportunities
+- company: Aerwave
+  board: aerwavecareers
+- company: AgelessRx
+  board: agelessrx
+- company: Agora
+  board: agora
+- company: AI Technology Partners, Inc.
+  board: aitp
+- company: Ampersand Brands
+  board: ampersandbrands
+- company: Anthony & Sylvan Pools
+  board: anthony-sylvan-pools
+- company: Azira
+  board: azira-careers-page
+- company: Balto
+  board: balto
+- company: Bamboo Health
+  board: bamboo-health-careers
+- company: Bluefin Payment Systems
+  board: bluefin-payment-systems
+- company: Bodwé Group
+  board: bodwe-professional-services-group-companies
+- company: Bonusly
+  board: bonusly
+- company: BookNook
+  board: booknook-inc
+- company: BoomPop
+  board: boompop
+- company: Bowery Valuation
+  board: bowery-valuation
+- company: Bridge Defense
+  board: bridge-defense
+- company: Brightscout
+  board: brightscout
+- company: Button
+  board: button
+- company: Buxton
+  board: buxtoncocareers
+- company: CallRevu
+  board: callrevu
+- company: Capacity
+  board: capacity
+- company: Mindset Care
+  board: career-opportunities-at-mindset
+- company: Harver
+  board: careers-at-harver
+- company: Quartile
+  board: careers-quartile
+- company: CBTS
+  board: cbts
+- company: CData Software
+  board: cdata-software
+- company: ClearStar
+  board: clearstar
+- company: Clicklease
+  board: clicklease
+- company: Climate Power
+  board: climatepower
+- company: CommandLink
+  board: commandlink
+- company: Community Phone
+  board: community-phone-careers
+- company: Conductor
+  board: conductor
+- company: Corva
+  board: corva
+- company: Coterie Insurance
+  board: coterie-careers
+- company: Create Music Group
+  board: createmusicgroup
+- company: CrucialLogics
+  board: cruciallogics
+- company: Demand Chain
+  board: demand-chain
+- company: DemandPDX
+  board: demandpdx
+- company: Dental Intelligence
+  board: dental-intelligence-careers
+- company: DGR Systems LLC
+  board: dgrsystems
+- company: DLS Engineering Associates, Inc.
+  board: dlsengineering
+- company: eHouse Studio
+  board: ehouse-studio-llc
+- company: Element Risk Management
+  board: element-risk-management
+- company: Encamp
+  board: encamp
+- company: Escalon Services, LLC.
+  board: escalon-services
+- company: Everfi
+  board: everfi
+- company: Everflow Technologies Inc.
+  board: everflow
+- company: Gamesight
+  board: gamesight
+- company: Get Engaged
+  board: get-engaged
+- company: Graphite
+  board: gfg-career-page
+- company: Go Fish Digital
+  board: gofishdigital
+- company: Grifin, LLC
+  board: grifin
+- company: Growth Signals
+  board: growth-signals
+- company: Halborn
+  board: halborn-inc
+- company: Indivisible Project
+  board: indivisible-project-careers
+- company: InVita Healthcare Technologies
+  board: invita-healthcare-technologies
+- company: IP House
+  board: ip-house
+- company: Tuesday Health
+  board: jobs-at-tuesday-health
+- company: Johnson Lambert
+  board: johnson-lambert-careers
+- company: Root, Inc.
+  board: joinroot
+- company: Knotch
+  board: knotch-inc
+- company: Lavu
+  board: lavu-inc
+- company: LawVu
+  board: lawvu-careers
+- company: Lilac Solutions
+  board: lilac-solutions
+- company: Lisinski Law Firm
+  board: lisinski-law-firm
+- company: LocateAI
+  board: locateai
+- company: Lynx Software Technologies
+  board: lynx-software-technologies
+- company: Martello Re Limited
+  board: martello-re
+- company: Modern Campus
+  board: moderncampus
+- company: MoxiWorks
+  board: moxiworks-careers
+- company: N3XT
+  board: n3xt-jobs
+- company: nesto
+  board: nesto
+- company: Netwrix
+  board: netwrix-corporation
+- company: NOCD
+  board: nocd
+- company: O3 Solutions
+  board: o3-solutions
+- company: Obie
+  board: obie
+- company: OrthoPediatrics
+  board: orthopediatrics
+- company: Packetlabs Ltd.
+  board: packetlabs
+- company: ParentSquare
+  board: parentsquare
+- company: PDQ
+  board: pdq
+- company: Phase2 Technology
+  board: phase2-careers
+- company: Power TakeOff
+  board: power-takeoff-careers
+- company: Primary Diagnostics, Inc.
+  board: primary-diagnostics-inc
+- company: Pythian
+  board: pythian
+- company: Radian Generation
+  board: radian-generation
+- company: Rentsync
+  board: rentsync_careers
+- company: Resource Monitor
+  board: resourcemonitor
+- company: RightCrowd
+  board: rightcrowdcareers
+- company: Ritual
+  board: ritual
+- company: Robbins Research International
+  board: robbins-research-international
+- company: Roberts Civil Engineering, LLC
+  board: roberts-civil-engineering-careers
+- company: Routeware, Inc.
+  board: routeware-careers
+- company: RSA Security
+  board: rsa-security
+- company: Scentbird
+  board: scentbird
+- company: Scratch Financial
+  board: scratch-financial
+- company: SheerID
+  board: sheerid
+- company: SHELTER, Inc.
+  board: shelter-inc
+- company: Shiji Group
+  board: shiji-us-careers
+- company: Shipium
+  board: shipium
+- company: Sketchy Group LLC
+  board: sketchy
+- company: Sparq
+  board: sparq
+- company: SpreeAI
+  board: spreeai
+- company: Steno
+  board: steno-careers-page
+- company: Swoop
+  board: swoopishiring
+- company: Tenpoint Therapeutics GmbH
+  board: tenpointtx
+- company: Terra Energy
+  board: terra-energy
+- company: TheGuarantors
+  board: theguarantors-open-positions
+- company: Thrive Scholars
+  board: thrive-scholars-jobs
+- company: Tive
+  board: tive-careers
+- company: Tort Experts
+  board: tort-experts
+- company: TrueComp
+  board: truecomp
+- company: Unchained Capital, Inc.
+  board: unchained
+- company: UniUni Logistics
+  board: uniuni
+- company: Origin
+  board: useorigin
+- company: Vimachem
+  board: vimachem
+- company: Visio Lending
+  board: visio-lending-careers
+- company: Vouch Insurance
+  board: vouch-inc
+- company: Wanta Thome
+  board: wanta-thome
+- company: WarriorBabe
+  board: warriorbabe-careers
+- company: WellRight
+  board: wellright
+- company: Wenrix
+  board: wenrix
+- company: Workshop Digital
+  board: workshopdigital
+- company: WorkSpan
+  board: workspan-inc
+- company: WovenX Health
+  board: wovenx-health-inc
+- company: XWP
+  board: xwp
+- company: Youth Civic Accelerator
+  board: yca
+- company: Yembo
+  board: yembo
+- company: Young Americans for Liberty
+  board: young-americans-for-liberty
+- company: Zivian Health
+  board: zivian-health-inc
+- company: ZRG Partners LLC
+  board: zrg-partners-careers
+- company: Zymeworks
+  board: zymeworks-careers

--- a/sources/zohorecruit.yml
+++ b/sources/zohorecruit.yml
@@ -2216,3 +2216,161 @@
   board: solutionstobias.zohorecruit.com
 - company: LINDERA GmbH
   board: lindera.zohorecruit.eu
+- company: aKube Inc
+  board: akubeinc.zohorecruit.com
+- company: Aspire, Jordan
+  board: aspire.zohorecruit.com
+- company: BFFWH
+  board: bffwh.zohorecruit.com
+- company: Bickert Management Inc.
+  board: bickertmanagement.zohorecruit.com
+- company: BizFirst
+  board: bizfirst.zohorecruit.com
+- company: Black & White
+  board: blackwhite.zohorecruit.com
+- company: Blue Pearl
+  board: bluepearl.zohorecruit.com
+- company: BluZinc
+  board: bluzinc.zohorecruit.com
+- company: Bridge Talent Management
+  board: bridgetalentgroup.zohorecruit.com
+- company: Brilliant Computers
+  board: brilliantccit.zohorecruit.com
+- company: Cardinal Delta
+  board: cardinaldelta.zohorecruit.com
+- company: Cause Capacity
+  board: cause-capacity.zohorecruit.com
+- company: Contractor Foreman
+  board: contractorforeman.zohorecruit.com
+- company: Copper Quail Global
+  board: cquail.zohorecruit.com
+- company: Delbridge Solutions
+  board: delbridge.zohorecruit.ca
+- company: Dhaka Technologies Limited Company
+  board: dhakatech.zohorecruit.com
+- company: Digita Global Marketing Ltd.
+  board: digitaglobal.zohorecruit.com
+- company: Elidel Prestige Limited
+  board: elidelprestige.zohorecruit.com
+- company: Ellit Groups
+  board: ellitgroups.zohorecruit.com
+- company: ellow
+  board: ellow.zohorecruit.in
+- company: eNamix
+  board: enamix.zohorecruit.com
+- company: Endurance IT Services
+  board: endurance-it.zohorecruit.com
+- company: Estoras Group of Companies
+  board: estorasgroup.zohorecruit.com
+- company: Execo
+  board: execo.zohorecruit.com
+- company: Expert VA
+  board: expertva.zohorecruit.com
+- company: Finkraft
+  board: finkraft.zohorecruit.com
+- company: flexwork
+  board: flexwork.zohorecruit.eu
+- company: Fundacion Capital
+  board: fundacioncapital.zohorecruit.com
+- company: Fusion Growth Partners
+  board: growwithfusion.zohorecruit.com
+- company: Tars
+  board: hellotars.zohorecruit.com
+- company: Infinity Business Services
+  board: ibsforyou.zohorecruit.com
+- company: iCareManager
+  board: icaremanager.zohorecruit.com
+- company: IDBC Kft
+  board: idbc.zohorecruit.com
+- company: iForce Connect
+  board: iforce.zohorecruit.eu
+- company: IKERD
+  board: ikerd.zohorecruit.com
+- company: ImEx Cargo
+  board: imexcargo.zohorecruit.com
+- company: Inbound Talent
+  board: inboundtalent.zohorecruit.eu
+- company: Intecfy
+  board: intecfy.zohorecruit.eu
+- company: IPV Advisors Pvt Ltd
+  board: ipventures.zohorecruit.in
+- company: Izenso
+  board: izenso.zohorecruit.com
+- company: Mackin Talent
+  board: mackintalent.zohorecruit.com
+- company: hrEdge
+  board: myhredge.zohorecruit.com
+- company: OTSI
+  board: otsi-global.zohorecruit.com
+- company: PCOS Sisters Telehealth Clinic
+  board: pcossisters.zohorecruit.com
+- company: Piedmont Global
+  board: piedmontglobal.zohorecruit.com
+- company: Precision Medical Billing
+  board: precisionmedicalbilling.zohorecruit.com
+- company: R2i
+  board: r2i.zohorecruit.com
+- company: Red Ember Recruitment (PTY) Ltd
+  board: redember-recruitment.zohorecruit.com
+- company: Remote Office
+  board: remoteoffice.zohorecruit.com
+- company: RKS Design
+  board: rksdesign.zohorecruit.com
+- company: S5 Stratos
+  board: s5stratos.zohorecruit.com
+- company: ScalableOS
+  board: scalableos.zohorecruit.com
+- company: Scalein
+  board: scaleinafrica.zohorecruit.com
+- company: Scopic
+  board: scopicsoftware.zohorecruit.com
+- company: SiFi
+  board: sifi.zohorecruit.sa
+- company: SKILLs HR Experts GmbH
+  board: skills-experts.zohorecruit.eu
+- company: Slang
+  board: slangapp.zohorecruit.com
+- company: SoftSnow
+  board: softsnow.zohorecruit.com
+- company: Southwest Adventure Tours
+  board: southwestadventuretours.zohorecruit.com
+- company: Spassu
+  board: spassu.zohorecruit.com
+- company: Spatial
+  board: spatial.zohorecruit.com
+- company: Staff Domain Inc.
+  board: staffdomains.zohorecruit.com
+- company: Sumara Technology
+  board: sumaratechnology.zohorecruit.com
+- company: Symbiotic Services
+  board: symbioticservices.zohorecruit.com
+- company: TalentRemedy
+  board: talentremedy.zohorecruit.com
+- company: Team Up Services
+  board: team-up.zohorecruit.com
+- company: Technopride Ltd
+  board: technopride.zohorecruit.eu
+- company: Tejjy Inc.
+  board: tejjy.zohorecruit.com
+- company: 4thwheel
+  board: the4thwheel.zohorecruit.in
+- company: Theater Outsource Inc.
+  board: theateroutsource.zohorecruit.com
+- company: ThinkBAC Consulting
+  board: thinkbac.zohorecruit.com
+- company: Centre de santé Tulattavik de l'Ungava
+  board: tulattavik.zohorecruit.com
+- company: Unit21
+  board: unit21.zohorecruit.com
+- company: Virtual Rockstar
+  board: unlockhba.zohorecruit.com
+- company: VELAIO
+  board: velaio.zohorecruit.com
+- company: Virtual Coworker
+  board: virtualcoworker.zohorecruit.com
+- company: AppMySite
+  board: wishacloud.zohorecruit.com
+- company: Ziffity Solutions
+  board: ziffity.zohorecruit.com
+- company: Talent Booster Costa Rica
+  board: zylker.zohorecruit.com


### PR DESCRIPTION
## Why

`harvest-boards` resolved a provider through `probers`, a hand-maintained map of ~35 platforms.
`internal/sources` carries close to a hundred adapters, so a platform absent from that map was
never one we cannot crawl — it was one whose boards nobody could propose. The tool exited 2 and
said "no prober for provider".

That gap is what stranded 485 detected boards across 13 platforms in the website-walk harvest
(#1963): the boards were found on real careers pages, but nothing could confirm them.

## What

`proberFor` falls back to running the provider's own source adapter as the probe — which is
exactly what the hand-written `cornerstone`/`taleo`/`neogov` entries already did, one platform
at a time. A bespoke prober still wins the lookup: it costs one request instead of a whole
crawl, and on ~10 platforms it reports the employer name the corroboration gate needs.

The fallback **refuses a boardless adapter**. Those serve one catalogue whatever board they are
handed, so they would report jobs for a board that does not exist and confirm every candidate
put to them — the same phantom class the Workable name gate exists for. `sources.BoardKeyedProviders`
is the exported test for that, mirroring the `AggregatorProviders`/`FullCatalogProviders` helpers
next to it.

A run that falls back says so, naming what it gives up: no name gate, no `-pace`.

## Harvested with it

359 boards across 9 platforms, from the seeds the website walk had already produced:

| platform | boards | | platform | boards |
|---|---:|---|---|---:|
| rippling | 137 | | peopleforce | 10 |
| zohorecruit | 79 | | radancy | 10 |
| manatal | 76 | | jibe | 8 |
| hibob | 20 | | quickin | 1 |
| phenom | 18 | | | |

No duplicate board id, exact or case-variant, in any touched file.

## Left as found

Four platforms yielded nothing because the **detector spells their board id differently from the
adapter**: `harvest-ats` proposes a bare ukg tenant code (`ADV1023AVR`) where the adapter keys on
`<sub>.rec.pro.ukg.net/<tenant>/<uuid>`, and a bare `ctl` where catsone keys on `ctl.catsone.com`.
87 ukg candidates and a handful of others sit behind that. It is a change to `internal/atsdetect`,
not to the prober, so it is not in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added career-board sources across HiBob, Jibe, Manatal, PeopleForce, Phenom, Quickin, Radancy, Rippling, and Zoho Recruit.
  - Added support for probing board-based providers through their source adapter when a dedicated prober is unavailable.
  - Added clearer probing feedback and limitations for adapter-based checks.

- **Bug Fixes**
  - Improved provider selection by prioritizing dedicated probers and rejecting unsupported boardless or unknown providers.

- **Tests**
  - Added coverage for provider selection and board-keyed source classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->