### PR TITLE
Pace the later onboarding mails from the greeting, not from signup

### DIFF
--- a/internal/db/onboarding.sql.go
+++ b/internal/db/onboarding.sql.go
@@ -16,7 +16,7 @@ JOIN onboarding_emails w ON w.user_id = u.id AND w.step = 'welcome'
 LEFT JOIN notification_settings ns ON ns.user_id = u.id
 WHERE u.email_verified
   AND u.created_at > now() - make_interval(days => $1::int)
-  AND u.created_at < now() - make_interval(days => $2::int)
+  AND w.sent_at < now() - make_interval(days => $2::int)
   AND COALESCE(ns.enabled, true)
   AND NOT EXISTS (
       SELECT 1 FROM subscriptions s WHERE s.user_id = u.id AND s.active
@@ -40,11 +40,14 @@ type ListNoAlertCandidatesRow struct {
 	Email string `json:"email"`
 }
 
-// Accounts old enough to have settled in, greeted already, and still without an
-// active alert — the one action the product is built around.
+// Greeted a while ago, and still without an active alert — the one action the
+// product is built around.
 //
-// It requires the welcome row rather than only the age: a person whose greeting
-// never went out should not receive a follow-up referring to a mail they never saw.
+// The wait is measured from the greeting (w.sent_at), not from signup. Measuring it
+// from signup breaks on the very first run: every account older than the delay is
+// instantly eligible for both steps, so the same person gets "hi, I'm Ilya" and then
+// "you signed up a few days ago and still have no alert" an hour apart. From two
+// mails in an hour, a stranger is indistinguishable from a spammer.
 func (q *Queries) ListNoAlertCandidates(ctx context.Context, arg ListNoAlertCandidatesParams) ([]ListNoAlertCandidatesRow, error) {
 	rows, err := q.db.Query(ctx, listNoAlertCandidates, arg.WindowDays, arg.AfterDays, arg.MaxRows)
 	if err != nil {
@@ -72,7 +75,7 @@ JOIN onboarding_emails w ON w.user_id = u.id AND w.step = 'welcome'
 LEFT JOIN notification_settings ns ON ns.user_id = u.id
 WHERE u.email_verified
   AND u.created_at > now() - make_interval(days => $1::int)
-  AND u.created_at < now() - make_interval(days => $2::int)
+  AND w.sent_at < now() - make_interval(days => $2::int)
   AND COALESCE(ns.enabled, true)
   AND NOT EXISTS (
       SELECT 1 FROM onboarding_emails oe
@@ -96,6 +99,9 @@ type ListOpenSourceCandidatesRow struct {
 // Everyone greeted and past the wait, whether or not they set up an alert: this
 // step asks for a star and a Discord visit, which is worth asking of a browser as
 // much as of a regular.
+//
+// The wait runs from the greeting, for the same reason it does above: paced from
+// signup, a two-week-old account would receive the whole sequence in one afternoon.
 func (q *Queries) ListOpenSourceCandidates(ctx context.Context, arg ListOpenSourceCandidatesParams) ([]ListOpenSourceCandidatesRow, error) {
 	rows, err := q.db.Query(ctx, listOpenSourceCandidates, arg.WindowDays, arg.AfterDays, arg.MaxRows)
 	if err != nil {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1985,15 +1985,21 @@ type Querier interface {
 	// reviewed it under — the write dialog's "which categories have I already
 	// used" read. Not filtered by status, same reasoning as GetMyCompanyFeedback.
 	ListMyCompanyFeedback(ctx context.Context, arg ListMyCompanyFeedbackParams) ([]CompanyFeedback, error)
-	// Accounts old enough to have settled in, greeted already, and still without an
-	// active alert — the one action the product is built around.
+	// Greeted a while ago, and still without an active alert — the one action the
+	// product is built around.
 	//
-	// It requires the welcome row rather than only the age: a person whose greeting
-	// never went out should not receive a follow-up referring to a mail they never saw.
+	// The wait is measured from the greeting (w.sent_at), not from signup. Measuring it
+	// from signup breaks on the very first run: every account older than the delay is
+	// instantly eligible for both steps, so the same person gets "hi, I'm Ilya" and then
+	// "you signed up a few days ago and still have no alert" an hour apart. From two
+	// mails in an hour, a stranger is indistinguishable from a spammer.
 	ListNoAlertCandidates(ctx context.Context, arg ListNoAlertCandidatesParams) ([]ListNoAlertCandidatesRow, error)
 	// Everyone greeted and past the wait, whether or not they set up an alert: this
 	// step asks for a star and a Discord visit, which is worth asking of a browser as
 	// much as of a regular.
+	//
+	// The wait runs from the greeting, for the same reason it does above: paced from
+	// signup, a two-week-old account would receive the whole sequence in one afternoon.
 	ListOpenSourceCandidates(ctx context.Context, arg ListOpenSourceCandidatesParams) ([]ListOpenSourceCandidatesRow, error)
 	// Keyset continuation: rows strictly older than the cursor (created_at, id). No
 	// OFFSET, so deep pages never scan skipped rows.

--- a/internal/db/queries/onboarding.sql
+++ b/internal/db/queries/onboarding.sql
@@ -29,18 +29,21 @@ ORDER BY u.created_at
 LIMIT sqlc.arg(max_rows)::int;
 
 -- name: ListNoAlertCandidates :many
--- Accounts old enough to have settled in, greeted already, and still without an
--- active alert — the one action the product is built around.
+-- Greeted a while ago, and still without an active alert — the one action the
+-- product is built around.
 --
--- It requires the welcome row rather than only the age: a person whose greeting
--- never went out should not receive a follow-up referring to a mail they never saw.
+-- The wait is measured from the greeting (w.sent_at), not from signup. Measuring it
+-- from signup breaks on the very first run: every account older than the delay is
+-- instantly eligible for both steps, so the same person gets "hi, I'm Ilya" and then
+-- "you signed up a few days ago and still have no alert" an hour apart. From two
+-- mails in an hour, a stranger is indistinguishable from a spammer.
 SELECT u.id, u.email
 FROM users u
 JOIN onboarding_emails w ON w.user_id = u.id AND w.step = 'welcome'
 LEFT JOIN notification_settings ns ON ns.user_id = u.id
 WHERE u.email_verified
   AND u.created_at > now() - make_interval(days => sqlc.arg(window_days)::int)
-  AND u.created_at < now() - make_interval(days => sqlc.arg(after_days)::int)
+  AND w.sent_at < now() - make_interval(days => sqlc.arg(after_days)::int)
   AND COALESCE(ns.enabled, true)
   AND NOT EXISTS (
       SELECT 1 FROM subscriptions s WHERE s.user_id = u.id AND s.active
@@ -56,13 +59,16 @@ LIMIT sqlc.arg(max_rows)::int;
 -- Everyone greeted and past the wait, whether or not they set up an alert: this
 -- step asks for a star and a Discord visit, which is worth asking of a browser as
 -- much as of a regular.
+--
+-- The wait runs from the greeting, for the same reason it does above: paced from
+-- signup, a two-week-old account would receive the whole sequence in one afternoon.
 SELECT u.id, u.email
 FROM users u
 JOIN onboarding_emails w ON w.user_id = u.id AND w.step = 'welcome'
 LEFT JOIN notification_settings ns ON ns.user_id = u.id
 WHERE u.email_verified
   AND u.created_at > now() - make_interval(days => sqlc.arg(window_days)::int)
-  AND u.created_at < now() - make_interval(days => sqlc.arg(after_days)::int)
+  AND w.sent_at < now() - make_interval(days => sqlc.arg(after_days)::int)
   AND COALESCE(ns.enabled, true)
   AND NOT EXISTS (
       SELECT 1 FROM onboarding_emails oe

--- a/internal/onboarding/runner_test.go
+++ b/internal/onboarding/runner_test.go
@@ -200,3 +200,26 @@ func TestRun_EachStepHasItsOwnSubjectAndBothBodies(t *testing.T) {
 		seen[m.subject] = true
 	}
 }
+
+// The delay for later steps is measured from the previous mail, not from signup.
+// Measured from signup, the first ever run would fire the whole sequence at any
+// account older than ten days within the same hour — the query enforces this, and
+// this test states the intent the query is expected to keep.
+func TestRun_LaterStepsArePacedFromTheGreeting(t *testing.T) {
+	store := &fakeStore{}
+	if _, err := newRunner(store, &fakeSender{}).Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	cfg := onboarding.DefaultConfig()
+	if store.noAlertParams.AfterDays != cfg.NoAlertAfterDays {
+		t.Fatalf("no_alert delay = %d, want %d", store.noAlertParams.AfterDays, cfg.NoAlertAfterDays)
+	}
+	if cfg.NoAlertAfterDays >= cfg.OpenSourceAfterDays {
+		t.Errorf("step delays must increase: no_alert %d, open_source %d",
+			cfg.NoAlertAfterDays, cfg.OpenSourceAfterDays)
+	}
+	if cfg.OpenSourceAfterDays >= cfg.WindowDays {
+		t.Errorf("open_source at day %d never fires inside a %d-day window",
+			cfg.OpenSourceAfterDays, cfg.WindowDays)
+	}
+}


### PR DESCRIPTION
A follow-up to #1969, found while checking what the first production run would actually do.

## The bug

Steps 2 and 3 selected candidates by **account age**. That reads fine until the first run: every account already older than the delay is instantly eligible for every step, so one person gets

- `welcome` — "Hi, I'm Ilya…"
- an hour later, `no_alert` — "You signed up a few days ago but haven't set up an alert yet"

Two mails in an hour from someone you have never heard from is indistinguishable from spam. Production has **179 accounts** in exactly that state right now, so this would have fired on the first pass.

## The fix

The delay is measured from the greeting's own `sent_at`. That is also what the copy already claims — "a few days ago" means a few days after the first letter arrived, not after signup.

The 14-day window still uses `created_at`: that guard is about not mailing the historical table, which is a separate question from pacing.

## Test

`TestRun_LaterStepsArePacedFromTheGreeting` states the intent the query has to keep, and asserts the delays are ordered and fit inside the window — an `open_source` delay longer than the window would silently never fire.

## Verification

`gofmt`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...` — clean.