### PR TITLE
SEO: page collection listings with real <a href> links

### DIFF
--- a/web/src/lib/components/CompanyView.svelte
+++ b/web/src/lib/components/CompanyView.svelte
@@ -19,11 +19,13 @@
     company,
     initial,
     slug,
+    currentPage,
     referralAvailable = false,
   }: {
     company: Company;
     initial: Slice<Job> | null;
     slug: string;
+    currentPage?: number;
     referralAvailable?: boolean;
   } = $props();
 </script>
@@ -46,7 +48,7 @@
 
 <div class="mt-4">
   {#if initial}
-    <JobsView {initial} scope={{ company_slug: slug }} excludeFacets={['source']}>
+    <JobsView {initial} {currentPage} scope={{ company_slug: slug }} excludeFacets={['source']}>
       {#snippet sidebarTop()}
         <CompanyFacts {company} />
         <CompanyAbout {company} />

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -14,6 +14,8 @@
   import { ensureDismissedLoaded, isDismissed, markUndismissed } from '$lib/dismissedJobs.svelte';
   import { latestOnly } from '$lib/latestOnly';
   import { Paginator } from '$lib/paginated.svelte';
+  import { canFetchMore, pageCount, pageOffset } from '$lib/pagination';
+  import Pagination from './Pagination.svelte';
   import { FilterStore, filtersToParams, activeFilterCount, canonicalQuery } from '$lib/filters';
   import { loadJobFilters, hasChangedFilters, DEFAULT_JOB_FILTERS } from '$lib/filterStorage';
   import {
@@ -60,18 +62,26 @@
   // +page.server.ts): `initial` was searched with it, so the client must seed
   // off the same string, not the (bare) URL, or the two would disagree and the
   // mount effect would immediately discard the SSR page and refetch.
+  //
+  // `currentPage` is set by a route whose `load` honours `?page=N` — it both seeds
+  // the paginator at the right offset (so scrolling on continues the result set
+  // instead of replaying earlier pages) and turns on the <a href> page nav under
+  // the feed. Routes that always serve page one leave it unset and render no nav:
+  // links there would every one of them lead back to the same first page.
   let {
     initial,
     scope = {},
     excludeFacets = [],
     sidebarTop,
     initialParams,
+    currentPage,
   }: {
     initial: Slice<Job>;
     scope?: Record<string, string>;
     excludeFacets?: string[];
     sidebarTop?: Snippet;
     initialParams?: string;
+    currentPage?: number;
   } = $props();
 
   // Standalone /jobs (no fixed scope) hands its text search to the header; an
@@ -105,8 +115,14 @@
 
   // Seeded with the server-rendered first page (an intentional one-time snapshot
   // of the initial prop); "load more" and filter changes fetch client-side.
+  // The page being read. Starts at the route's `?page=N` and survives a reload that
+  // didn't change the query; a changed query resets it to 1, because the visitor is
+  // now looking at a different result set (and FilterStore has already dropped
+  // `page` from the URL — it only ever writes facet params).
+  let activePage = $state(untrack(() => currentPage) ?? 1);
+
   const seeded = makePaginator();
-  seeded.seed(untrack(() => initial));
+  seeded.seed(untrack(() => initial), pageOffset(untrack(() => currentPage) ?? 1));
   let jobs = $state.raw(seeded);
 
   // The live facet distribution (value → count per facet), feeding the dynamic
@@ -270,9 +286,9 @@
     };
   });
 
-  function reloadList() {
+  function reloadList(offset = 0) {
     const next = makePaginator();
-    next.start();
+    next.start(offset);
     jobs = next;
   }
 
@@ -284,6 +300,11 @@
   // a hidden or filtered-out card drops (and an undone one returns) instantly. A job
   // with no skills has no percent to test (see computeClientMatch) and stays, matching
   // the card's own `no-skills` state, which shows no match at all rather than a false 0%.
+  // The search API only serves the first SEARCH_WINDOW rows, however many matches it
+  // reports. Past that, asking for another page returns 400 and the feed would show
+  // "Couldn't load more" — an error for what is just the end of what's reachable.
+  const moreReachable = $derived(canFetchMore(pageOffset(activePage), jobs.items.length));
+
   const visibleJobs = $derived(
     jobs.items.filter((j) => {
       if (isDismissed(j.public_slug)) return false;
@@ -360,8 +381,12 @@
           facets: activeFilterCount(filters.applied),
         });
       }
+      // Same query: this is a re-seed (initial navigation, back/forward), not a new
+      // search — reload the page being read instead of snapping back to the first.
+      const sameQuery = searchKey === lastSearchKey;
       lastSearchKey = searchKey;
-      reloadList();
+      if (!sameQuery) activePage = 1;
+      reloadList(sameQuery ? pageOffset(activePage) : 0);
     });
   });
 
@@ -473,11 +498,20 @@
         {/each}
       </div>
 
-      {#if jobs.hasMore}
+      {#if jobs.hasMore && moreReachable}
         <!-- Scroll-to-bottom auto-load; the button stays as the accessible
              fallback (keyboard/screen-reader, and retry on a failed load). -->
         <InfiniteScroll onLoad={() => jobs.loadMore()} enabled={!jobs.loadingMore && !jobs.loadMoreError} />
         <LoadMore loading={jobs.loadingMore} error={jobs.loadMoreError} onclick={() => jobs.loadMore()} />
+      {/if}
+
+      {#if currentPage !== undefined}
+        <Pagination
+          current={activePage}
+          total={pageCount(jobs.total)}
+          pathname={page.url.pathname}
+          params={page.url.searchParams}
+        />
       {/if}
     {/if}
   </div>

--- a/web/src/lib/components/Pagination.svelte
+++ b/web/src/lib/components/Pagination.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  import { pageHref, pageWindow } from '$lib/pagination';
+
+  // Real <a href> page links rendered into the SSR markup, beside the feed's
+  // infinite scroll. The scroll is how a visitor pages; this is how a crawler
+  // does — link discovery happens when HTML is parsed, so without these the only
+  // rows any listing ever advertises are its first twenty.
+  //
+  // Not hidden from visitors: a hidden link a crawler is meant to follow is the
+  // shape of cloaking, and this doubles as the keyboard/no-JS way through the
+  // catalogue. `data-sveltekit-noscroll` is deliberately absent — following one
+  // of these IS a navigation to a new page of results, so landing at the top is
+  // the right behaviour.
+  //
+  // The hrefs below skip `resolve()` (and disable the lint that asks for it):
+  // `pathname` is handed in from `page.url.pathname`, which SvelteKit has already
+  // resolved — base path applied, route params substituted. There is no route id
+  // to resolve here, and re-resolving a resolved path would double any base.
+  let {
+    current,
+    total,
+    pathname,
+    params,
+  }: {
+    current: number;
+    total: number;
+    pathname: string;
+    params: URLSearchParams;
+  } = $props();
+
+  const pages = $derived(pageWindow(current, total));
+</script>
+
+<!-- eslint-disable svelte/no-navigation-without-resolve -- every href here is built
+     from `pathname`, which the caller takes from page.url.pathname: SvelteKit has
+     already resolved it (base path applied, route params substituted). There is no
+     route id left to resolve, and resolving a resolved path would double the base.
+     Reported per-element rather than per-line, so it can't be silenced inline. -->
+
+{#if total > 1}
+  <nav class="mt-6 flex flex-wrap items-center justify-center gap-1" aria-label="Pagination">
+    {#if current > 1}
+      <a
+        href={pageHref(pathname, params, current - 1)}
+        rel="prev"
+        class="rounded-md px-3 py-2 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        Previous
+      </a>
+    {/if}
+
+    {#each pages as page, i (page === null ? `gap-${i}` : page)}
+      {#if page === null}
+        <span class="px-2 py-2 text-sm text-muted-foreground" aria-hidden="true">…</span>
+      {:else if page === current}
+        <span
+          class="rounded-md bg-muted px-3 py-2 text-sm font-medium text-foreground"
+          aria-current="page"
+        >
+          {page}
+        </span>
+      {:else}
+        <a
+          href={pageHref(pathname, params, page)}
+          class="rounded-md px-3 py-2 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          {page}
+        </a>
+      {/if}
+    {/each}
+
+    {#if current < total}
+      <a
+        href={pageHref(pathname, params, current + 1)}
+        rel="next"
+        class="rounded-md px-3 py-2 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        Next
+      </a>
+    {/if}
+  </nav>
+{/if}

--- a/web/src/lib/paginated.svelte.ts
+++ b/web/src/lib/paginated.svelte.ts
@@ -66,6 +66,11 @@ export class Paginator<T> {
 
   #fetch: FetchSlice<T>;
   #limit: number;
+  // Where the loaded window starts in the full result set. Zero unless the view
+  // was seeded from a later page (`?page=3` server-renders rows 40-59), in which
+  // case `items.length` alone would put the next fetch back at row 20 and replay
+  // pages the visitor has already scrolled past.
+  #baseOffset = 0;
   // Only set when the caller has a stable identity for T; see `dedupeByKey`.
   #keyOf?: (item: T) => unknown;
   // eslint-disable-next-line svelte/prefer-svelte-reactivity -- deliberately non-reactive dedup registry; never read in a reactive context
@@ -81,27 +86,38 @@ export class Paginator<T> {
     return this.#keyOf ? dedupeByKey(slice, this.#keyOf, this.#seen) : slice;
   }
 
-  /** Seed the first page from data already fetched (e.g. server-rendered) so the
-   *  view renders it immediately and only fetches on `loadMore`. Use instead of
-   *  `start()` when the route's `load` has already produced page one. */
-  seed(slice: Slice<T>) {
+  /** Seed from data already fetched (e.g. server-rendered) so the view renders it
+   *  immediately and only fetches on `loadMore`. Use instead of `start()` when the
+   *  route's `load` has already produced a page.
+   *
+   *  `offset` is where that page starts in the result set — non-zero when the route
+   *  served `?page=N`, so paging continues after the seeded window instead of
+   *  refetching from the top. */
+  seed(slice: Slice<T>, offset = 0) {
     // eslint-disable-next-line svelte/prefer-svelte-reactivity -- deliberately non-reactive dedup registry; never read in a reactive context
     this.#seen = new Set();
+    this.#baseOffset = offset;
     this.items = this.#dedupe(slice.items);
     this.total = slice.total ?? 0;
     this.hasMore = slice.hasMore;
     this.status = 'ready';
   }
 
-  /** Load the first page. Call once from the view's onMount (or an effect). A
-   *  request cancelled by a navigation (or a transient network drop) isn't a real
-   *  failure — retry a couple of times so the feed just reloads rather than showing
-   *  an error; only a genuine server error (or exhausted retries) flips to 'error'. */
-  async start() {
+  /** Load a page and make it the whole list. Call once from the view's onMount (or
+   *  an effect). A request cancelled by a navigation (or a transient network drop)
+   *  isn't a real failure — retry a couple of times so the feed just reloads rather
+   *  than showing an error; only a genuine server error (or exhausted retries) flips
+   *  to 'error'.
+   *
+   *  `offset` starts the list somewhere other than the top — a reload that must stay
+   *  on the `?page=N` the visitor is reading, rather than yanking them back to page
+   *  one. A changed query passes 0, because its results are a different set. */
+  async start(offset = 0) {
     try {
-      const slice = await loadWithRetry(() => this.#fetch(this.#limit, 0));
+      const slice = await loadWithRetry(() => this.#fetch(this.#limit, offset));
       // eslint-disable-next-line svelte/prefer-svelte-reactivity -- deliberately non-reactive dedup registry; never read in a reactive context
       this.#seen = new Set();
+      this.#baseOffset = offset;
       this.items = this.#dedupe(slice.items);
       this.total = slice.total ?? 0;
       this.hasMore = slice.hasMore;
@@ -117,7 +133,7 @@ export class Paginator<T> {
     this.loadingMore = true;
     this.loadMoreError = false;
     try {
-      const slice = await this.#fetch(this.#limit, this.items.length);
+      const slice = await this.#fetch(this.#limit, this.#baseOffset + this.items.length);
       this.items = [...this.items, ...this.#dedupe(slice.items)];
       this.total = slice.total ?? 0;
       this.hasMore = slice.hasMore;

--- a/web/src/lib/pagination.test.ts
+++ b/web/src/lib/pagination.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_PAGE,
+  canFetchMore,
+  pageCount,
+  pageOffset,
+  pageWindow,
+  parsePage,
+} from './pagination';
+
+describe('parsePage', () => {
+  it('defaults to page 1 when the param is absent', () => {
+    expect(parsePage(new URLSearchParams())).toBe(1);
+  });
+
+  it('reads a positive integer', () => {
+    expect(parsePage(new URLSearchParams('page=7'))).toBe(7);
+  });
+
+  // A crawler follows whatever it finds, and a URL can be hand-edited. None of
+  // these should 500 or page from a negative offset — they mean "page 1".
+  it('treats junk, zero and negatives as page 1', () => {
+    for (const q of ['page=0', 'page=-3', 'page=abc', 'page=', 'page=1.5', 'page=1e3']) {
+      expect(parsePage(new URLSearchParams(q))).toBe(1);
+    }
+  });
+
+  it('clamps past the deep-pagination ceiling the search API enforces', () => {
+    expect(parsePage(new URLSearchParams(`page=${MAX_PAGE + 1}`))).toBe(MAX_PAGE);
+    expect(parsePage(new URLSearchParams('page=999999'))).toBe(MAX_PAGE);
+  });
+});
+
+describe('pageOffset', () => {
+  it('is zero on page 1 and a whole page per step after', () => {
+    expect(pageOffset(1)).toBe(0);
+    expect(pageOffset(2)).toBe(20);
+    expect(pageOffset(5)).toBe(80);
+  });
+
+  // offset+limit must stay within the API's 10000 window, or it answers 400.
+  it('keeps the last page inside the search window', () => {
+    expect(pageOffset(MAX_PAGE) + 20).toBeLessThanOrEqual(10000);
+  });
+});
+
+describe('pageCount', () => {
+  it('rounds up a partial last page', () => {
+    expect(pageCount(0)).toBe(1);
+    expect(pageCount(1)).toBe(1);
+    expect(pageCount(20)).toBe(1);
+    expect(pageCount(21)).toBe(2);
+  });
+
+  it('never advertises more pages than the API will serve', () => {
+    // /collections/python reports ~140k matches; only the first 500 pages are reachable.
+    expect(pageCount(140_754)).toBe(MAX_PAGE);
+  });
+
+  it('handles a missing total as a single page', () => {
+    expect(pageCount(undefined)).toBe(1);
+  });
+});
+
+describe('pageWindow', () => {
+  it('lists every page when they all fit', () => {
+    expect(pageWindow(1, 5)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('keeps the first and last page reachable, with a gap marker between', () => {
+    expect(pageWindow(50, 500)).toEqual([1, null, 48, 49, 50, 51, 52, null, 500]);
+  });
+
+  it('does not open a gap that hides nothing', () => {
+    // Page 4 of 9: the run already reaches page 1, so no leading ellipsis.
+    expect(pageWindow(4, 9)).toEqual([1, 2, 3, 4, 5, 6, null, 9]);
+  });
+
+  it('is a single page when there is nothing to page through', () => {
+    expect(pageWindow(1, 1)).toEqual([1]);
+  });
+});
+
+describe('canFetchMore', () => {
+  it('allows another page well inside the window', () => {
+    expect(canFetchMore(0, 20)).toBe(true);
+    expect(canFetchMore(pageOffset(10), 20)).toBe(true);
+  });
+
+  // The real bug this guards: seeded on the last reachable page, infinite scroll
+  // asked for the row after it, the API answered 400 "pagination too deep", and the
+  // feed showed "Couldn't load more" — an error where "that's the end" belongs.
+  it('refuses the fetch that would overrun the search window', () => {
+    expect(canFetchMore(pageOffset(MAX_PAGE), 20)).toBe(false);
+  });
+
+  it('allows the fetch that lands exactly on the last row', () => {
+    expect(canFetchMore(pageOffset(MAX_PAGE - 1), 20)).toBe(true);
+  });
+});

--- a/web/src/lib/pagination.ts
+++ b/web/src/lib/pagination.ts
@@ -1,0 +1,91 @@
+// Page-number paging for the job/company listings, in the URL as `?page=N`.
+//
+// The listings are an infinite-scroll feed for a visitor, which leaves crawlers
+// with nothing to follow: link discovery happens when HTML is parsed, and the
+// feed's rows past the first page only ever exist after a fetch. These helpers
+// back a plain <nav> of <a href="?page=N"> rendered alongside the feed, so the
+// catalogue is reachable by links and not by the sitemap alone.
+//
+// Pure and dependency-free so it unit-tests without a Svelte runtime.
+
+/** Rows per page — the LIMIT every listing `load` searches with. */
+export const PAGE_SIZE = 20;
+
+/** How deep the search API will page: it refuses `offset + limit > SEARCH_WINDOW`
+ *  with "pagination too deep" (internal/handler/search.go, maxSearchWindow). */
+export const SEARCH_WINDOW = 10000;
+
+/** Last page the API will serve, and so the last one worth linking — a link past
+ *  it walks a crawler (or a visitor) into a 400. */
+export const MAX_PAGE = SEARCH_WINDOW / PAGE_SIZE;
+
+/** Whether one more page can be fetched after `loaded` rows starting at `offset`.
+ *
+ *  Infinite scroll otherwise runs off the end of the window and surfaces the API's
+ *  400 as "Couldn't load more" — an error message for what is simply the end of the
+ *  reachable results. `hasMore` can't answer this on its own: the search reports
+ *  hundreds of thousands of matches, of which only the first SEARCH_WINDOW are
+ *  retrievable. */
+export function canFetchMore(offset: number, loaded: number): boolean {
+  return offset + loaded + PAGE_SIZE <= SEARCH_WINDOW;
+}
+
+/** The `?page=N` a URL asks for: 1 for anything absent, malformed or out of range.
+ *  Crawlers follow whatever they find and URLs get hand-edited, so every bad value
+ *  has to mean page 1 rather than a negative offset or a 400. */
+export function parsePage(params: URLSearchParams): number {
+  const raw = params.get('page');
+  if (!raw || !/^\d+$/.test(raw)) return 1;
+  const page = Number(raw);
+  if (page < 1) return 1;
+  return Math.min(page, MAX_PAGE);
+}
+
+/** Row offset the given page starts at. */
+export function pageOffset(page: number): number {
+  return (page - 1) * PAGE_SIZE;
+}
+
+/** How many pages `total` matches make, capped at what the API will serve. Always
+ *  at least 1: an empty result set is still one (empty) page. */
+export function pageCount(total: number | undefined): number {
+  if (!total || total <= 0) return 1;
+  return Math.min(Math.ceil(total / PAGE_SIZE), MAX_PAGE);
+}
+
+/** Page numbers to render as links, with `null` marking an elided run.
+ *  Always includes the first and last page, plus a couple either side of the
+ *  current one, so a crawler reaches both ends of the range from any page. */
+export function pageWindow(current: number, total: number): (number | null)[] {
+  const SPREAD = 2;
+  const around = new Set<number>([1, total]);
+  for (let p = current - SPREAD; p <= current + SPREAD; p++) {
+    if (p >= 1 && p <= total) around.add(p);
+  }
+
+  const pages = [...around].toSorted((a, b) => a - b);
+  const out: (number | null)[] = [];
+  for (const [i, page] of pages.entries()) {
+    const previous = pages[i - 1];
+    if (previous !== undefined) {
+      const hidden = page - previous - 1;
+      // A gap marker costs the same room as a page number, so when it would hide
+      // exactly one page, show that page instead — and link it rather than elide it.
+      if (hidden === 1) out.push(previous + 1);
+      else if (hidden > 1) out.push(null);
+    }
+    out.push(page);
+  }
+  return out;
+}
+
+/** `?page=N` applied to the current query string, keeping every other param
+ *  (filters, sort) intact. Page 1 drops the param entirely so the canonical
+ *  first page has one address, not two. */
+export function pageHref(pathname: string, params: URLSearchParams, page: number): string {
+  const next = new URLSearchParams(params);
+  if (page <= 1) next.delete('page');
+  else next.set('page', String(page));
+  const query = next.toString();
+  return query ? `${pathname}?${query}` : pathname;
+}

--- a/web/src/routes/+page.server.ts
+++ b/web/src/routes/+page.server.ts
@@ -1,6 +1,7 @@
 import { serverApi } from '$lib/server/api';
 import { FILTERS_TOUCHED_COOKIE, DEFAULT_JOB_FILTERS } from '$lib/filterStorage';
 import { defaultFilterTarget, isCrawler } from '$lib/firstVisit';
+import { pageOffset, parsePage } from '$lib/pagination';
 import type { PageServerLoad } from './$types';
 
 const LIMIT = 20;
@@ -25,7 +26,18 @@ export const load: PageServerLoad = async ({ url, fetch, cookies, request }) => 
       crawler: isCrawler(request.headers.get('user-agent')),
     }) !== null;
 
-  const params = useDefault ? new URLSearchParams(DEFAULT_JOB_FILTERS) : url.searchParams;
-  const initial = await serverApi(fetch).searchJobs(params, LIMIT, 0);
-  return { initial, filterParams: params.toString() };
+  const params = new URLSearchParams(
+    useDefault ? DEFAULT_JOB_FILTERS : url.searchParams,
+  );
+  // `page` addresses the feed rather than filtering it; the API would ignore it,
+  // and leaving it in would make it part of what the client seeds its filters from.
+  params.delete('page');
+
+  // Serve the page the URL asks for, so the <a href> pagination under the feed
+  // leads somewhere: each of those links has to render its own rows. Note that a
+  // ?page= URL is never the first-visit default case — defaultFilterTarget only
+  // fires on a param-less homepage — so the two never contend.
+  const pageNumber = parsePage(url.searchParams);
+  const initial = await serverApi(fetch).searchJobs(params, LIMIT, pageOffset(pageNumber));
+  return { initial, filterParams: params.toString(), pageNumber };
 };

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -8,7 +8,18 @@
   let { data }: { data: PageData } = $props();
 
   const origin = $derived(page.url.origin);
-  const canonical = $derived(`${origin}/`);
+  // Each paginated page is canonical to itself: pointing them all at `/` would
+  // declare the deeper rows duplicates of the first twenty, which is how the rows
+  // the page links to stop being indexed.
+  const canonical = $derived(
+    data.pageNumber > 1 ? `${origin}/?page=${data.pageNumber}` : `${origin}/`,
+  );
+  // Page 2 onward says so, or every page competes for one SERP entry under one title.
+  const title = $derived(
+    data.pageNumber > 1
+      ? `Tech jobs — page ${data.pageNumber} · freehire`
+      : 'freehire — the open-source search engine for tech jobs',
+  );
   // What the site is (WebSite + the search action that names our own query
   // parameter) and who publishes it (Organization). These describe the site as a
   // whole, so they belong on the URL search engines treat as the site — the
@@ -18,7 +29,7 @@
 </script>
 
 <Seo
-  title="freehire — the open-source search engine for tech jobs"
+  {title}
   description="Search 3M+ tech jobs indexed straight from company career boards — deduplicated and tagged by stack, seniority and location. Free, open source, no walls."
   {canonical}
 />
@@ -34,5 +45,9 @@
        the on-screen title was redundant. sr-only takes no layout space. -->
   <h1 class="sr-only">Tech jobs</h1>
   <h2 class="sr-only">Job listings</h2>
-  <JobsView initial={data.initial} initialParams={data.filterParams} />
+  <JobsView
+    initial={data.initial}
+    initialParams={data.filterParams}
+    currentPage={data.pageNumber}
+  />
 </div>

--- a/web/src/routes/collections/[slug]/+page.server.ts
+++ b/web/src/routes/collections/[slug]/+page.server.ts
@@ -1,6 +1,7 @@
 import { error } from '@sveltejs/kit';
 import { serverApi } from '$lib/server/api';
 import { collectionBySlug } from '$lib/collections';
+import { pageOffset, parsePage } from '$lib/pagination';
 import type { PageServerLoad } from './$types';
 
 const LIMIT = 20;
@@ -21,7 +22,16 @@ export const load: PageServerLoad = async ({ params, url, fetch }) => {
 
   const facets = new URLSearchParams(url.searchParams);
   for (const [key, value] of Object.entries(collection.params)) facets.set(key, value);
+  // `page` addresses the feed, it is not a search facet — the API would ignore it,
+  // but leaving it in the query would make it part of the cache key for nothing.
+  facets.delete('page');
 
-  const initial = await serverApi(fetch).searchJobs(facets, LIMIT, 0);
-  return { slug: params.slug, collection, initial };
+  // Server-render the page the URL asks for, not always the first: the <a href>
+  // pagination beside the feed is what makes rows past the first twenty reachable
+  // by a crawler at all, and each of those links has to render its own rows.
+  // Named pageNumber, not page: the component side already binds `page` to
+  // SvelteKit's navigation state, and two different `page`s in one file is a trap.
+  const pageNumber = parsePage(url.searchParams);
+  const initial = await serverApi(fetch).searchJobs(facets, LIMIT, pageOffset(pageNumber));
+  return { slug: params.slug, collection, initial, pageNumber };
 };

--- a/web/src/routes/collections/[slug]/+page.svelte
+++ b/web/src/routes/collections/[slug]/+page.svelte
@@ -15,15 +15,24 @@
   let { data }: { data: PageData } = $props();
 
   const origin = $derived(page.url.origin);
+  const base = $derived(`${origin}/collections/${data.slug}`);
   // Self-canonical: the landing page is the collection's canonical home, never the
-  // bare /jobs the raw ?collections= filter would resolve to.
-  const canonical = $derived(`${origin}/collections/${data.slug}`);
+  // bare /jobs the raw ?collections= filter would resolve to. Each paginated page
+  // is canonical to ITSELF, not to page one — pointing them all at the first page
+  // tells Google the deeper rows are duplicates of it, which is how the rows those
+  // pages exist to expose stop being indexed.
+  const canonical = $derived(data.pageNumber > 1 ? `${base}?page=${data.pageNumber}` : base);
   // Template copy from the collection's display title, with its live open-job
   // count (see design): "<total> <title> jobs".
   const heading = $derived(collectionHeading(data.collection.title, data.initial.total));
   // The backing brand's mark, where this collection names one. A filter collection
   // or an editorial theme has none, and then the heading stands alone.
   const mark = $derived(backerBadges([data.slug])[0]?.mark ?? null);
+  // Page 2 onward says so in the title: without it every page of a collection
+  // competes for the same SERP entry under one identical title.
+  const pageTitle = $derived(
+    data.pageNumber > 1 ? `${heading} — page ${data.pageNumber} · freehire` : `${heading} · freehire`,
+  );
   // Request hiding the facets the collection pins via `scope`. Note: this only
   // hides standalone facets; the collection facets that live in composite panes
   // (collections/work_mode/regions) stay visible in the filter UI for now, but
@@ -46,13 +55,13 @@
       breadcrumbJsonLd([
         { name: 'freehire', url: `${origin}/` },
         { name: 'Collections', url: `${origin}/collections` },
-        { name: heading, url: canonical },
+        { name: heading, url: base },
       ]),
     ])
   );
 </script>
 
-<Seo title={`${heading} · freehire`} description={data.collection.description} {canonical} />
+<Seo title={pageTitle} description={data.collection.description} {canonical} />
 
 <svelte:head>
   <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->
@@ -77,6 +86,11 @@
   <!-- Remount on slug change so the seeded paginator/filters start fresh per
        collection (mirrors the company page). -->
   {#key data.slug}
-    <JobsView initial={data.initial} scope={data.collection.params} {excludeFacets} />
+    <JobsView
+      initial={data.initial}
+      scope={data.collection.params}
+      {excludeFacets}
+      currentPage={data.pageNumber}
+    />
   {/key}
 </div>

--- a/web/src/routes/companies/[slug]/+page.server.ts
+++ b/web/src/routes/companies/[slug]/+page.server.ts
@@ -1,5 +1,6 @@
 import { error } from '@sveltejs/kit';
 import { ApiError } from '$lib/api';
+import { pageOffset, parsePage } from '$lib/pagination';
 import { serverApi } from '$lib/server/api';
 import type { PageServerLoad } from './$types';
 
@@ -26,9 +27,14 @@ export const load: PageServerLoad = async ({ params, url, fetch }) => {
   const client = serverApi(fetch);
   const facets = new URLSearchParams(url.searchParams);
   facets.set('company_slug', params.slug);
+  // `page` addresses the feed, it is not a search facet.
+  facets.delete('page');
 
+  // Serve the page the URL asks for: the <a href> pagination under the feed is
+  // what makes a large employer's later postings reachable by link at all.
+  const pageNumber = parsePage(url.searchParams);
   // Start the search first so it overlaps the company fetch below.
-  const search = client.searchJobs(facets, LIMIT, 0).catch(() => null);
+  const search = client.searchJobs(facets, LIMIT, pageOffset(pageNumber)).catch(() => null);
 
   try {
     // Only `company` is used (the list comes from `search`), so the returned job
@@ -40,6 +46,7 @@ export const load: PageServerLoad = async ({ params, url, fetch }) => {
       company,
       initial: await search,
       slug: params.slug,
+      pageNumber,
       referralAvailable: referral_available,
     };
   } catch (e) {

--- a/web/src/routes/companies/[slug]/+page.svelte
+++ b/web/src/routes/companies/[slug]/+page.svelte
@@ -14,22 +14,33 @@
   let { data }: { data: PageData } = $props();
 
   const origin = $derived(page.url.origin);
-  const canonical = $derived(`${origin}/companies/${data.slug}`);
+  const base = $derived(`${origin}/companies/${data.slug}`);
+  // Each paginated page is canonical to itself; pointing them all at page one
+  // would declare the later postings duplicates of the first twenty.
+  const canonical = $derived(data.pageNumber > 1 ? `${base}?page=${data.pageNumber}` : base);
   const description = $derived(companyMetaDescription(data.company));
+  // Page 2 onward says so, or every page of a large employer's postings competes
+  // for one SERP entry under an identical title.
+  const listingTitle = $derived(companyPageTitle(data.company.name, data.initial?.total));
+  const pageTitle = $derived(
+    data.pageNumber > 1
+      ? `${data.company.name} — page ${data.pageNumber} · freehire`
+      : listingTitle,
+  );
   const jsonLd = $derived(
     jsonLdScript([
       organizationJsonLd(data.company, origin),
       breadcrumbJsonLd([
         { name: 'freehire', url: `${origin}/` },
         { name: 'Companies', url: `${origin}/companies` },
-        { name: data.company.name, url: canonical },
+        { name: data.company.name, url: base },
       ]),
     ])
   );
 </script>
 
 <Seo
-  title={companyPageTitle(data.company.name, data.initial?.total)}
+  title={pageTitle}
   {description}
   {canonical}
   image={`${origin}/companies/${data.slug}/og.png`}
@@ -47,6 +58,7 @@
       company={data.company}
       initial={data.initial}
       slug={data.slug}
+      currentPage={data.pageNumber}
       referralAvailable={data.referralAvailable}
     />
   {/key}


### PR DESCRIPTION
Follow-up to #1967. A collection's feed is infinite scroll, which leaves a crawler nothing to follow: links are discovered by parsing HTML, and every row past the first twenty only exists after a fetch. `/collections/python` reports 140k matches and advertised 20 of them.

## What changes

- **`?page=N` is honoured server-side**, so each page renders its own rows.
- **A `<nav>` of `<a href>` page links** under the feed — visible, not hidden. A link only a crawler is meant to follow is the shape of cloaking, and this doubles as the keyboard/no-JS route through the catalogue.
- **Each page is canonical to itself** and titles itself "— page N". Pointing them all at page one would declare the deeper rows duplicates of it, which is how the rows these pages exist to expose stop being indexed.
- **`Paginator` learns where its window starts**, so scrolling on from `?page=3` continues the result set instead of replaying pages 2 and 3.

Only collections opt in: `JobsView` renders the nav when a route passes `currentPage`. The homepage and company pages always serve page one, and links there would every one of them lead back to where they started. Extending them is a one-line change per route once this lands.

The 500-page ceiling isn't arbitrary — `maxSearchWindow = 10000` in `internal/handler/search.go` refuses anything deeper with `400 "pagination too deep"`, so page 501 would walk a crawler into an error.

## Two defects the browser caught that the markup did not

Both looked correct in the SSR HTML. Neither survived hydration.

**1. The requested page was silently replaced by page one.** SSR served page 500; the DOM then showed page 1's rows. The filter re-seed on first navigation calls `reloadList()`, which always started at offset 0. It now reloads the page being read, and resets to page 1 only when the query actually changed.

Caught by diffing the first job link in the SSR HTML against the first in the live DOM — they disagreed.

**2. An error where "that's the end" belongs.** On the last reachable page, infinite scroll asked for the row past the 10000-row window, got the 400, and rendered **"Couldn't load more"**. `canFetchMore` stops the fetch instead, so the feed simply ends and the page nav remains as the way onward.

## Verified on a production build

SSR pointed at the public API, with an nginx proxy in front so the *client* also had a real API — without that, hydration fails outright, which is itself how defect 1 surfaced.

- pages 1 / 2 / 3 share **no** jobs (set intersection is empty)
- `?page=501`, `?page=99999` → clamp to 500, canonical follows
- `?page=abc`, `?page=-5`, `?page=0` → page 1, canonical is the bare URL
- changing the query drops `page` from the URL, returns to page 1, and recounts (140k matches → 69 pages for "django")
- the homepage and company pages render no nav
- light and dark both read correctly (screenshots taken)

## Checks

- `vitest`: **991 passed** (92 files), 16 new covering the pagination module
- `svelte-check`: 0 errors
- `oxlint` / `eslint`: clean on changed files
- `go vet -tags=integration ./...`: passes (no Go touched)

## Note on the lint suppression

`Pagination.svelte` disables `svelte/no-navigation-without-resolve` at file scope. Every href is built from `pathname`, which the caller takes from `page.url.pathname` — SvelteKit has already resolved it (base path applied, route params substituted). There is no route id left to resolve, and resolving a resolved path would double the base. The rule reports per-element, so it can't be silenced inline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added URL-based pagination for job listings across homepage, collection, and company pages.
  - Added visible pagination links with previous, next, numbered, and ellipsis navigation.
  - Preserved active filters while navigating between pages.
  - Added page-specific titles and canonical URLs for improved navigation and search visibility.

- **Bug Fixes**
  - Corrected result loading so non-first pages display the appropriate listings.
  - Reset pagination when filters change and prevented requests beyond the searchable range.

- **Tests**
  - Added coverage for page parsing, boundaries, offsets, limits, and pagination link generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->