### PR TITLE
Cache-Control for shared caches, plus a (not-yet-applied) Cloudflare config

### DIFF
--- a/infra/cloudflare/.gitignore
+++ b/infra/cloudflare/.gitignore
@@ -1,0 +1,5 @@
+*.tfstate
+*.tfstate.backup
+.terraform/
+.terraform.lock.hcl
+terraform.tfvars

--- a/infra/cloudflare/README.md
+++ b/infra/cloudflare/README.md
@@ -1,0 +1,77 @@
+# Cloudflare for freehire.me
+
+Puts a shared cache in front of the origin. The site is one Hetzner box in
+Helsinki that also runs the ingest, and most of its traffic is anonymous reads of
+pages that exist to be found in search — the same HTML, rendered again per
+request, competing with the ingest for the buffer cache.
+
+**Not applied yet.** The zone does not exist in the Cloudflare account, and the
+domain's nameservers still point at Namecheap. Steps 1 and 2 below are manual.
+
+## What it does
+
+| | |
+|---|---|
+| DNS | `freehire.me`, `www`, `logo` → the origin, all proxied |
+| TLS | `strict` — the origin already serves a valid public certificate |
+| Transport | HTTP/3, 0-RTT, brotli |
+| Cache | HTML held at the edge **on the origin's terms** |
+| Bypass | `/api/`, `/my/`, `/auth/`, `/moderation`, `/cv/`, anything not GET |
+
+The cache policy itself lives in the application, not here — see
+`web/src/lib/httpCache.ts`. Anonymous public HTML is sent as
+`public, max-age=0, s-maxage=300, stale-while-revalidate=86400`; anything tied to
+a session is `private, no-store`. These rules only make HTML *eligible* for the
+edge and then respect those headers, so there is one place that decides, and a
+mistake in this file cannot leak a signed-in page.
+
+Two independent guards keep sessions out of the shared cache: the origin's
+`private, no-store`, and a cache key that includes the presence of `hire_token`.
+
+### No bot blocking, on purpose
+
+The sibling `telagon` config blocks scrapers by User-Agent (`python`, `curl`,
+`Go-http-client`, `httpx`, …). That must not be copied here: freehire publishes
+an HTTP API, a CLI and a ChatGPT action, so those clients are the intended
+audience. `security_level` stays at `essentially_off` for the same reason — a
+challenge page served to a crawler is a page that does not get indexed.
+
+## Applying it
+
+1. **Add the zone.** Cloudflare dashboard → Add a site → `freehire.me`, Free plan.
+   Cloudflare will show two assigned nameservers.
+
+2. **Repoint the nameservers at Namecheap** (the registrar today — the domain
+   currently answers from `dns1/dns2.registrar-servers.com`). Domain List →
+   Manage → Nameservers → Custom DNS → the two Cloudflare ones. Propagation is
+   usually minutes, and the zone flips to Active on its own.
+
+   Nothing below works until this is done: an inactive zone proxies nothing.
+
+3. **Token.** Create one at [API Tokens](https://dash.cloudflare.com/profile/api-tokens)
+   with `Zone Settings:Edit`, `DNS:Edit` and `Cache Rules:Edit`, scoped to this
+   zone. Then:
+
+   ```bash
+   cd infra/cloudflare
+   cp terraform.tfvars.example terraform.tfvars   # gitignored; paste the token
+   terraform init
+   terraform plan      # read this before applying
+   terraform apply
+   ```
+
+## Checking it afterwards
+
+```bash
+# Served from the edge? (expect cf-cache-status, HIT on the second call)
+curl -sI https://freehire.me/collections/python | grep -i 'cf-cache-status\|cache-control'
+
+# A session must never be cached — expect DYNAMIC/BYPASS and private, no-store
+curl -sI https://freehire.me/ -H 'Cookie: hire_token=whatever' | grep -i 'cf-cache-status\|cache-control'
+
+# The API must not be cached
+curl -sI 'https://freehire.me/api/v1/jobs/search?limit=1' | grep -i 'cf-cache-status'
+```
+
+The second command is the one that matters. If a request carrying `hire_token`
+ever comes back `cf-cache-status: HIT`, stop and fix it before anything else.

--- a/infra/cloudflare/main.tf
+++ b/infra/cloudflare/main.tf
@@ -1,0 +1,142 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}
+
+data "cloudflare_zone" "freehire" {
+  name = var.zone_name
+}
+
+# ==================== DNS ====================
+# Proxied (orange cloud): traffic reaches the origin through Cloudflare, which is
+# the whole point — an unproxied record is DNS only and caches nothing.
+
+resource "cloudflare_record" "root" {
+  zone_id = data.cloudflare_zone.freehire.id
+  name    = "@"
+  content = var.origin_server_ip
+  type    = "A"
+  proxied = true
+  comment = "Hetzner origin — nginx in the web container"
+}
+
+resource "cloudflare_record" "www" {
+  zone_id = data.cloudflare_zone.freehire.id
+  name    = "www"
+  content = var.zone_name
+  type    = "CNAME"
+  proxied = true
+}
+
+# The logo proxy the SPA and OG cards resolve company marks through. Its own
+# subdomain so a long image cache never applies to page HTML.
+resource "cloudflare_record" "logo" {
+  zone_id = data.cloudflare_zone.freehire.id
+  name    = "logo"
+  content = var.origin_server_ip
+  type    = "A"
+  proxied = true
+}
+
+# ==================== Zone settings ====================
+
+resource "cloudflare_zone_settings_override" "freehire" {
+  zone_id = data.cloudflare_zone.freehire.id
+
+  settings {
+    # "strict" (not "full"): the origin serves a valid, publicly-trusted
+    # certificate today, so Cloudflare can verify it rather than accept any cert.
+    ssl              = "strict"
+    always_use_https = "on"
+    # HTTP/3 and 0-RTT cut round trips for visitors far from Helsinki, which is
+    # everyone outside northern Europe — the origin is a single box there.
+    http3    = "on"
+    zero_rtt = "on"
+    brotli   = "on"
+    # Deliberately NOT raised beyond "essentially_off"/"low": this site wants to be
+    # crawled. A challenge page served to a crawler is an unindexed page, and the
+    # public API is consumed by scripts and agents that cannot solve one.
+    security_level = "essentially_off"
+  }
+}
+
+# ==================== Cache ====================
+# The origin already states its own policy per response (web/src/lib/httpCache.ts):
+# anonymous public HTML is `public, s-maxage=300, stale-while-revalidate=86400`,
+# and anything tied to a session is `private, no-store`. These rules make HTML
+# eligible for the edge cache and then RESPECT those headers, so the decision has
+# one home — the application — instead of being restated (and eventually
+# contradicted) here.
+#
+# There is deliberately no bot-blocking ruleset, unlike the sibling telagon config.
+# freehire publishes an HTTP API, a CLI and a ChatGPT action: its legitimate
+# clients ARE `python`, `curl`, `Go-http-client` and `httpx`.
+
+resource "cloudflare_ruleset" "cache" {
+  zone_id = data.cloudflare_zone.freehire.id
+  name    = "freehire cache rules"
+  kind    = "zone"
+  phase   = "http_request_cache_settings"
+
+  # Never cache the API, the account area, or anything that isn't a read. The
+  # origin marks these `private, no-store` already; this is the belt to that
+  # braces, so a caching mistake needs two independent failures.
+  rules {
+    description = "Bypass: API, account routes, non-GET"
+    expression  = <<-EOT
+      (starts_with(http.request.uri.path, "/api/")
+       or starts_with(http.request.uri.path, "/my/")
+       or starts_with(http.request.uri.path, "/auth/")
+       or starts_with(http.request.uri.path, "/moderation")
+       or starts_with(http.request.uri.path, "/cv/")
+       or http.request.method ne "GET")
+    EOT
+    action      = "set_cache_settings"
+    enabled     = true
+
+    action_parameters {
+      cache = false
+    }
+  }
+
+  # Everything else: cacheable, on the origin's terms. A signed-in response says
+  # `private, no-store` and is therefore not stored, which is what keeps one
+  # visitor's page from being replayed to another.
+  rules {
+    description = "Cache HTML per origin headers"
+    expression  = "true"
+    action      = "set_cache_settings"
+    enabled     = true
+
+    action_parameters {
+      cache = true
+
+      edge_ttl {
+        mode = "respect_origin"
+      }
+
+      browser_ttl {
+        mode = "respect_origin"
+      }
+
+      # The session cookie changes the response, so it must change the cache key.
+      cache_key {
+        cache_by_device_type = false
+
+        custom_key {
+          cookie {
+            check_presence = ["hire_token"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/infra/cloudflare/terraform.tfvars.example
+++ b/infra/cloudflare/terraform.tfvars.example
@@ -1,0 +1,4 @@
+# Copy to terraform.tfvars (gitignored) and fill in.
+# Create the token at https://dash.cloudflare.com/profile/api-tokens with
+# Zone:Zone Settings:Edit, Zone:DNS:Edit, Zone:Cache Rules:Edit, scoped to freehire.me.
+cloudflare_api_token = ""

--- a/infra/cloudflare/variables.tf
+++ b/infra/cloudflare/variables.tf
@@ -1,0 +1,17 @@
+variable "cloudflare_api_token" {
+  description = "Cloudflare API token: Zone Settings:Edit, DNS:Edit, Cache Rules:Edit on this zone"
+  type        = string
+  sensitive   = true
+}
+
+variable "zone_name" {
+  description = "Domain name"
+  type        = string
+  default     = "freehire.me"
+}
+
+variable "origin_server_ip" {
+  description = "Hetzner origin the web container is published on"
+  type        = string
+  default     = "89.167.94.146"
+}

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -1,6 +1,9 @@
 import { env } from '$env/dynamic/public';
 import { sequence } from '@sveltejs/kit/hooks';
+import type { Handle } from '@sveltejs/kit';
 import * as Sentry from '@sentry/sveltekit';
+import { hasSessionCookie } from '$lib/authCookie';
+import { cachePolicy } from '$lib/httpCache';
 
 // Same opt-in, env-gated init as the client: no PUBLIC_SENTRY_DSN ⇒ no init, and
 // SSR runs unchanged. Errors-only, PII off. The server reports to the same
@@ -14,8 +17,37 @@ if (env.PUBLIC_SENTRY_DSN) {
   });
 }
 
+// Label server-rendered HTML for shared caches (a CDN, or nginx's own cache):
+// anonymous public pages may be held and replayed, anything tied to a person may
+// not. See $lib/httpCache for why that decision lives in the app rather than only
+// in a CDN rule.
+//
+// Only GET HTML is labelled. A route that set its own Cache-Control is left alone
+// — the sitemaps do this, and their hour-long TTL is a considered choice, not one
+// to overwrite. Non-HTML responses (the OG image endpoints, robots.txt) carry
+// their own semantics and are none of this hook's business.
+const cacheControl: Handle = async ({ event, resolve }) => {
+  const response = await resolve(event);
+  if (event.request.method !== 'GET') return response;
+  if (response.headers.has('cache-control')) return response;
+  if (!response.headers.get('content-type')?.includes('text/html')) return response;
+
+  response.headers.set(
+    'cache-control',
+    cachePolicy({
+      pathname: event.url.pathname,
+      authenticated: hasSessionCookie(event.request.headers.get('cookie')),
+    }),
+  );
+  // The response body differs by session, so a shared cache must key on it. Without
+  // this a CDN could hand an anonymous copy to a signed-in visitor (and, worse, the
+  // reverse) whenever a rule of its own decides to store the response anyway.
+  response.headers.append('vary', 'Cookie');
+  return response;
+};
+
 // sentryHandle scopes each SSR request; it is a passthrough when init was skipped.
-export const handle = sequence(Sentry.sentryHandle());
+export const handle = sequence(Sentry.sentryHandle(), cacheControl);
 
 // Reports uncaught SSR errors to Sentry; inert when init was skipped above.
 export const handleError = Sentry.handleErrorWithSentry();

--- a/web/src/lib/authCookie.test.ts
+++ b/web/src/lib/authCookie.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { hasSessionCookie } from './authCookie';
+
+describe('hasSessionCookie', () => {
+  it('finds the session cookie among others', () => {
+    expect(hasSessionCookie('_ga=GA1.1; hire_token=abc; theme=dark')).toBe(true);
+    expect(hasSessionCookie('hire_token=abc')).toBe(true);
+  });
+
+  it('is false with no cookies at all', () => {
+    expect(hasSessionCookie(null)).toBe(false);
+    expect(hasSessionCookie('')).toBe(false);
+  });
+
+  // Analytics sets a cookie for nearly every first-time visitor, so "has cookies"
+  // is not the question being asked.
+  it('is false when other cookies are present but no session', () => {
+    expect(hasSessionCookie('_ga=GA1.1; theme=dark')).toBe(false);
+  });
+
+  // A substring test would call this a session and mark the response private,
+  // which would quietly disable caching for everyone carrying such a cookie.
+  it('does not mistake a cookie whose name merely ends the same way', () => {
+    expect(hasSessionCookie('not_hire_token=abc')).toBe(false);
+    expect(hasSessionCookie('x=1; not_hire_token=abc')).toBe(false);
+  });
+});

--- a/web/src/lib/authCookie.ts
+++ b/web/src/lib/authCookie.ts
@@ -1,0 +1,18 @@
+// The API owns the session cookie (internal/auth/cookie.go, `CookieName`). It is
+// httpOnly, so nothing here can read its value — only whether it is present.
+
+/** Name of the session cookie the API sets. */
+export const SESSION_COOKIE = 'hire_token';
+
+/** Whether a request's raw `Cookie` header carries a session.
+ *
+ *  Testing for THIS cookie rather than for any cookie is the point: analytics sets
+ *  its own on first-time visitors, so "has cookies" is true for nearly everyone.
+ *  Parsed per-pair rather than by substring so a cookie whose name merely ends in
+ *  the same characters (`not_hire_token=…`) doesn't read as a session. */
+export function hasSessionCookie(header: string | null | undefined): boolean {
+  if (!header) return false;
+  return header
+    .split(';')
+    .some((pair) => pair.trimStart().startsWith(`${SESSION_COOKIE}=`));
+}

--- a/web/src/lib/httpCache.test.ts
+++ b/web/src/lib/httpCache.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { PRIVATE_CACHE, PUBLIC_CACHE, cachePolicy } from './httpCache';
+
+describe('cachePolicy', () => {
+  it('lets a shared cache hold an anonymous public page', () => {
+    expect(cachePolicy({ pathname: '/companies/acme', authenticated: false })).toBe(PUBLIC_CACHE);
+    expect(cachePolicy({ pathname: '/', authenticated: false })).toBe(PUBLIC_CACHE);
+    expect(cachePolicy({ pathname: '/collections/python', authenticated: false })).toBe(PUBLIC_CACHE);
+  });
+
+  // The whole point of the guard. A signed-in response carries that person's
+  // saved jobs, applications and header state; if a CDN stored it under the plain
+  // URL, the next visitor would be served someone else's page.
+  it('never lets a signed-in response be stored', () => {
+    expect(cachePolicy({ pathname: '/companies/acme', authenticated: true })).toBe(PRIVATE_CACHE);
+    expect(cachePolicy({ pathname: '/', authenticated: true })).toBe(PRIVATE_CACHE);
+  });
+
+  // Belt and braces: these are private even to an anonymous request, because an
+  // anonymous hit on them is a sign-in page or a redirect — never something worth
+  // serving to the next person from a shared cache.
+  it('never caches account, auth or moderation routes, signed in or not', () => {
+    for (const pathname of [
+      '/my',
+      '/my/inbox',
+      '/auth/callback',
+      '/moderation',
+      '/delete-account',
+    ]) {
+      expect(cachePolicy({ pathname, authenticated: false })).toBe(PRIVATE_CACHE);
+      expect(cachePolicy({ pathname, authenticated: true })).toBe(PRIVATE_CACHE);
+    }
+  });
+
+  // A route that names one of the private prefixes without being under it.
+  it('matches whole path segments, not string prefixes', () => {
+    expect(cachePolicy({ pathname: '/myths', authenticated: false })).toBe(PUBLIC_CACHE);
+    expect(cachePolicy({ pathname: '/authors', authenticated: false })).toBe(PUBLIC_CACHE);
+  });
+
+  it('states a shared-cache lifetime and a revalidation window', () => {
+    expect(PUBLIC_CACHE).toContain('s-maxage=300');
+    expect(PUBLIC_CACHE).toContain('stale-while-revalidate=');
+    // max-age=0 keeps the BROWSER revalidating: a visitor who signs in must not
+    // be handed their own stale anonymous copy from disk cache.
+    expect(PUBLIC_CACHE).toContain('max-age=0');
+  });
+
+  it('tells a shared cache to store nothing at all for a private response', () => {
+    expect(PRIVATE_CACHE).toContain('no-store');
+    expect(PRIVATE_CACHE).toContain('private');
+  });
+});

--- a/web/src/lib/httpCache.ts
+++ b/web/src/lib/httpCache.ts
@@ -1,0 +1,42 @@
+// Cache-Control for server-rendered HTML.
+//
+// The catalogue is enormous and mostly anonymous — company and collection pages
+// exist to be found in search — so the same HTML is rendered over and over for
+// visitors and crawlers alike, each render costing a search query and a database
+// round trip on a box that is also running the ingest. A shared cache in front of
+// the app answers those repeats without touching the origin.
+//
+// The rule that matters is the negative one: a signed-in response carries that
+// person's saved jobs, applications and header state. Stored under the plain URL
+// by a CDN, it would be served to whoever asked next. That decision lives here, in
+// the app, rather than only in a CDN rule — a misconfigured rule is then a missed
+// optimisation instead of a data leak.
+
+/** Anonymous, public HTML. `max-age=0` keeps the BROWSER revalidating (someone who
+ *  signs in must not be handed their own stale anonymous copy from disk cache),
+ *  while `s-maxage` lets a shared cache serve it for five minutes and
+ *  `stale-while-revalidate` lets it keep serving during the refresh. */
+export const PUBLIC_CACHE = 'public, max-age=0, s-maxage=300, stale-while-revalidate=86400';
+
+/** Anything tied to a person. `no-store` is deliberate over `no-cache`: nothing
+ *  should be written down at all, not even revalidated. */
+export const PRIVATE_CACHE = 'private, no-store';
+
+/** Route trees that are never shared, whoever asks. An anonymous hit here is a
+ *  sign-in screen or a redirect, which is not worth handing to the next visitor. */
+const PRIVATE_ROOTS = new Set(['my', 'auth', 'moderation', 'delete-account']);
+
+/** The Cache-Control an HTML response should carry. */
+export function cachePolicy({
+  pathname,
+  authenticated,
+}: {
+  pathname: string;
+  authenticated: boolean;
+}): string {
+  if (authenticated) return PRIVATE_CACHE;
+  // Compare whole segments: /myths is not under /my.
+  const root = pathname.split('/').find(Boolean);
+  if (root && PRIVATE_ROOTS.has(root)) return PRIVATE_CACHE;
+  return PUBLIC_CACHE;
+}

--- a/web/src/routes/+layout.server.ts
+++ b/web/src/routes/+layout.server.ts
@@ -1,10 +1,7 @@
 import { ApiError } from '$lib/api';
+import { hasSessionCookie } from '$lib/authCookie';
 import { serverApi } from '$lib/server/api';
 import type { LayoutServerLoad } from './$types';
-
-// The API owns this cookie (internal/auth/cookie.go, `CookieName`). It is
-// httpOnly, so the SPA never reads its value — only whether it is there at all.
-const SESSION_COOKIE = 'hire_token';
 
 // Resolve the current user once per full load, forwarding the request's session
 // cookie, so the signed-in/out chrome renders correctly server-side (no /me
@@ -13,12 +10,11 @@ const SESSION_COOKIE = 'hire_token';
 // error page.
 //
 // A request with no session cookie skips the call: it would 401 and render
-// signed-out chrome anyway, and anonymous traffic is most of ours. Testing for
-// THIS cookie rather than for any cookie is the point — analytics sets its own
-// on first-time visitors, so "has cookies" is true for nearly everyone.
+// signed-out chrome anyway, and anonymous traffic is most of ours (see
+// $lib/authCookie for why the test is for THIS cookie, not for any cookie).
 export const load: LayoutServerLoad = async ({ fetch, request }) => {
   const cookie = request.headers.get('cookie');
-  if (!cookie?.includes(`${SESSION_COOKIE}=`)) return { user: null };
+  if (!hasSessionCookie(cookie)) return { user: null };
   try {
     const user = await serverApi(fetch, cookie).me();
     return { user };


### PR DESCRIPTION
Prepares the site to sit behind a CDN, and states the caching policy in the application so a CDN rule can never be the only thing standing between one visitor's page and another's.

The origin is a single Hetzner box in Helsinki that also runs the ingest. Most traffic is anonymous reads of pages that exist to be found in search — the same HTML re-rendered per request, each costing a search query and a database round trip while the ingest evicts the buffer cache (the effect `internal/handler/sitemap.go:38` already documents: the same query measured 0.9s warm and past 60s under load).

## 1. `Cache-Control` on server-rendered HTML

A hook in `hooks.server.ts` labels GET HTML responses:

| | |
|---|---|
| Anonymous public page | `public, max-age=0, s-maxage=300, stale-while-revalidate=86400` |
| Any request carrying `hire_token` | `private, no-store` |
| `/my`, `/auth`, `/moderation`, `/delete-account` | `private, no-store`, signed in or not |

`max-age=0` keeps the **browser** revalidating, so someone who signs in is never handed their own stale anonymous copy from disk cache, while `s-maxage` lets a shared cache serve it for five minutes.

The negative rule is the point. A signed-in response carries that person's saved jobs, applications and header state; a CDN storing it under the plain URL would serve it to whoever asked next. Putting that decision in the app means a misconfigured CDN rule is a missed optimisation instead of a data leak. `Vary: Cookie` backs it up for any cache that stores the response anyway.

Routes that set their own `Cache-Control` are left alone — the sitemaps' hour is a considered choice, not one to overwrite.

**Also removes a duplicated constant:** `+layout.server.ts` and the new hook now share `$lib/authCookie`. Its test covers the trap the old substring check had — `not_hire_token=` must not read as a session, or every visitor carrying such a cookie would silently lose caching.

### Verified on a production build

```
/, /collections/*, /companies/*, /blog   anonymous  -> public, s-maxage=300
the same URLs with a session cookie                 -> private, no-store
/my/inbox, /moderation, /delete-account             -> private, no-store either way
Cookie: not_hire_token=x                            -> still public (no false positive)
/sitemap.xml keeps max-age=3600; robots.txt untouched
```

## 2. `infra/cloudflare/` — configuration, not yet applied

Terraform for the zone: proxied DNS, `strict` TLS (the origin already serves a valid public certificate), HTTP/3 and brotli, and cache rules that make HTML *eligible* for the edge and then **respect the origin's headers**. So the policy has one home — the app — and this file only decides what may be considered.

Two independent guards keep sessions out of the shared cache: the origin's `private, no-store`, and a cache key that includes the presence of `hire_token`.

**Deliberately not copied from the sibling telagon config:** its User-Agent bot blocking (`python`, `curl`, `Go-http-client`, `httpx`, …) and raised security level. freehire publishes an HTTP API, a CLI and a ChatGPT action — those clients *are* the intended audience, and a challenge page served to a crawler is a page that does not get indexed.

**Two manual steps remain** (in the README): the zone doesn't exist in the account yet, and the nameservers still point at Namecheap. Nothing in the Terraform works until the NS move — an inactive zone proxies nothing.

The README also has the post-apply checks. The one that matters: a request carrying `hire_token` must never come back `cf-cache-status: HIT`.

## What this unblocks

- The `await` added in #1967 costs +0.64s once per cache prime rather than per visit.
- `sitemap-jobs` is capped at 15 000 because building more risks the 60s proxy timeout under ingest contention; behind an edge cache it is built hourly, not per crawler request.

## Checks

- `vitest`: **985 passed** (93 files), 10 new
- `svelte-check`: 0 errors · `oxlint`/`eslint`: clean
- `terraform validate`: passes · `terraform fmt`: clean
- `go vet -tags=integration ./...`: passes (no Go touched)