### PR TITLE
SEO: page links on the homepage and company listings

### DIFF
--- a/web/src/lib/components/CompanyView.svelte
+++ b/web/src/lib/components/CompanyView.svelte
@@ -19,11 +19,13 @@
     company,
     initial,
     slug,
+    currentPage,
     referralAvailable = false,
   }: {
     company: Company;
     initial: Slice<Job> | null;
     slug: string;
+    currentPage?: number;
     referralAvailable?: boolean;
   } = $props();
 </script>
@@ -46,7 +48,7 @@
 
 <div class="mt-4">
   {#if initial}
-    <JobsView {initial} scope={{ company_slug: slug }} excludeFacets={['source']}>
+    <JobsView {initial} {currentPage} scope={{ company_slug: slug }} excludeFacets={['source']}>
       {#snippet sidebarTop()}
         <CompanyFacts {company} />
         <CompanyAbout {company} />

--- a/web/src/routes/+page.server.ts
+++ b/web/src/routes/+page.server.ts
@@ -1,6 +1,7 @@
 import { serverApi } from '$lib/server/api';
 import { FILTERS_TOUCHED_COOKIE, DEFAULT_JOB_FILTERS } from '$lib/filterStorage';
 import { defaultFilterTarget, isCrawler } from '$lib/firstVisit';
+import { pageOffset, parsePage } from '$lib/pagination';
 import type { PageServerLoad } from './$types';
 
 const LIMIT = 20;
@@ -25,7 +26,18 @@ export const load: PageServerLoad = async ({ url, fetch, cookies, request }) => 
       crawler: isCrawler(request.headers.get('user-agent')),
     }) !== null;
 
-  const params = useDefault ? new URLSearchParams(DEFAULT_JOB_FILTERS) : url.searchParams;
-  const initial = await serverApi(fetch).searchJobs(params, LIMIT, 0);
-  return { initial, filterParams: params.toString() };
+  const params = new URLSearchParams(
+    useDefault ? DEFAULT_JOB_FILTERS : url.searchParams,
+  );
+  // `page` addresses the feed rather than filtering it; the API would ignore it,
+  // and leaving it in would make it part of what the client seeds its filters from.
+  params.delete('page');
+
+  // Serve the page the URL asks for, so the <a href> pagination under the feed
+  // leads somewhere: each of those links has to render its own rows. Note that a
+  // ?page= URL is never the first-visit default case — defaultFilterTarget only
+  // fires on a param-less homepage — so the two never contend.
+  const pageNumber = parsePage(url.searchParams);
+  const initial = await serverApi(fetch).searchJobs(params, LIMIT, pageOffset(pageNumber));
+  return { initial, filterParams: params.toString(), pageNumber };
 };

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -8,7 +8,18 @@
   let { data }: { data: PageData } = $props();
 
   const origin = $derived(page.url.origin);
-  const canonical = $derived(`${origin}/`);
+  // Each paginated page is canonical to itself: pointing them all at `/` would
+  // declare the deeper rows duplicates of the first twenty, which is how the rows
+  // the page links to stop being indexed.
+  const canonical = $derived(
+    data.pageNumber > 1 ? `${origin}/?page=${data.pageNumber}` : `${origin}/`,
+  );
+  // Page 2 onward says so, or every page competes for one SERP entry under one title.
+  const title = $derived(
+    data.pageNumber > 1
+      ? `Tech jobs — page ${data.pageNumber} · freehire`
+      : 'freehire — the open-source search engine for tech jobs',
+  );
   // What the site is (WebSite + the search action that names our own query
   // parameter) and who publishes it (Organization). These describe the site as a
   // whole, so they belong on the URL search engines treat as the site — the
@@ -18,7 +29,7 @@
 </script>
 
 <Seo
-  title="freehire — the open-source search engine for tech jobs"
+  {title}
   description="Search 3M+ tech jobs indexed straight from company career boards — deduplicated and tagged by stack, seniority and location. Free, open source, no walls."
   {canonical}
 />
@@ -34,5 +45,9 @@
        the on-screen title was redundant. sr-only takes no layout space. -->
   <h1 class="sr-only">Tech jobs</h1>
   <h2 class="sr-only">Job listings</h2>
-  <JobsView initial={data.initial} initialParams={data.filterParams} />
+  <JobsView
+    initial={data.initial}
+    initialParams={data.filterParams}
+    currentPage={data.pageNumber}
+  />
 </div>

--- a/web/src/routes/companies/[slug]/+page.server.ts
+++ b/web/src/routes/companies/[slug]/+page.server.ts
@@ -1,5 +1,6 @@
 import { error } from '@sveltejs/kit';
 import { ApiError } from '$lib/api';
+import { pageOffset, parsePage } from '$lib/pagination';
 import { serverApi } from '$lib/server/api';
 import type { PageServerLoad } from './$types';
 
@@ -26,9 +27,14 @@ export const load: PageServerLoad = async ({ params, url, fetch }) => {
   const client = serverApi(fetch);
   const facets = new URLSearchParams(url.searchParams);
   facets.set('company_slug', params.slug);
+  // `page` addresses the feed, it is not a search facet.
+  facets.delete('page');
 
+  // Serve the page the URL asks for: the <a href> pagination under the feed is
+  // what makes a large employer's later postings reachable by link at all.
+  const pageNumber = parsePage(url.searchParams);
   // Start the search first so it overlaps the company fetch below.
-  const search = client.searchJobs(facets, LIMIT, 0).catch(() => null);
+  const search = client.searchJobs(facets, LIMIT, pageOffset(pageNumber)).catch(() => null);
 
   try {
     // Only `company` is used (the list comes from `search`), so the returned job
@@ -40,6 +46,7 @@ export const load: PageServerLoad = async ({ params, url, fetch }) => {
       company,
       initial: await search,
       slug: params.slug,
+      pageNumber,
       referralAvailable: referral_available,
     };
   } catch (e) {

--- a/web/src/routes/companies/[slug]/+page.svelte
+++ b/web/src/routes/companies/[slug]/+page.svelte
@@ -14,22 +14,33 @@
   let { data }: { data: PageData } = $props();
 
   const origin = $derived(page.url.origin);
-  const canonical = $derived(`${origin}/companies/${data.slug}`);
+  const base = $derived(`${origin}/companies/${data.slug}`);
+  // Each paginated page is canonical to itself; pointing them all at page one
+  // would declare the later postings duplicates of the first twenty.
+  const canonical = $derived(data.pageNumber > 1 ? `${base}?page=${data.pageNumber}` : base);
   const description = $derived(companyMetaDescription(data.company));
+  // Page 2 onward says so, or every page of a large employer's postings competes
+  // for one SERP entry under an identical title.
+  const listingTitle = $derived(companyPageTitle(data.company.name, data.initial?.total));
+  const pageTitle = $derived(
+    data.pageNumber > 1
+      ? `${data.company.name} — page ${data.pageNumber} · freehire`
+      : listingTitle,
+  );
   const jsonLd = $derived(
     jsonLdScript([
       organizationJsonLd(data.company, origin),
       breadcrumbJsonLd([
         { name: 'freehire', url: `${origin}/` },
         { name: 'Companies', url: `${origin}/companies` },
-        { name: data.company.name, url: canonical },
+        { name: data.company.name, url: base },
       ]),
     ])
   );
 </script>
 
 <Seo
-  title={companyPageTitle(data.company.name, data.initial?.total)}
+  title={pageTitle}
   {description}
   {canonical}
   image={`${origin}/companies/${data.slug}/og.png`}
@@ -47,6 +58,7 @@
       company={data.company}
       initial={data.initial}
       slug={data.slug}
+      currentPage={data.pageNumber}
       referralAvailable={data.referralAvailable}
     />
   {/key}


### PR DESCRIPTION
Stacked on #1974 — **base is `seo/html-pagination`, not `main`.** Merge that one first; this diff is only the two extra routes.

Same treatment as collections, now that the mechanism exists: `?page=N` is served, each page is canonical to itself and titles itself, and the `<a href>` nav under the feed makes the rows reachable by link.

Worth doing because these are the two biggest listings on the site. The homepage feed is the whole catalogue, and a large employer's page runs to thousands — `/companies/amazon` reports ~6,900 open roles and advertised twenty of them.

## The homepage's first-visit default is untouched

`defaultFilterTarget` only fires on a param-less homepage, so a `?page=` URL never contends with it, and crawlers stay exempt from the default exactly as before. Verified both paths:

```
first visit  -> filterParams: work_mode=remote&regions=global
Googlebot UA -> filterParams: (empty)
```

## Verified on a production build

| | pages 1/2/3 share jobs | canonical | title |
|---|---|---|---|
| `/` | none | self | "Tech jobs — page N" |
| `/companies/amazon` | none | self | "Amazon — page N" |
| `/collections/python` | none | self | "N Python jobs — page N" |

Plus: a company with a single opening renders no nav; `?page=501` clamps to 500; `?page=abc` and `?page=0` fall back to page one with the bare canonical.

In the browser (SSR + a proxy so the client has a real API): SSR rows and the hydrated DOM agree, and the nav keeps the page you are on.

One note from testing, not a defect: on the homepage the SSR and DOM rows can differ if you compare them seconds apart. The feed is newest-first over a catalogue that ingests continuously, so the offset window genuinely moves. Company listings are quiet enough to compare directly, and there they match exactly.

## Checks

- `vitest`: **991 passed** · `svelte-check`: 0 errors · `oxlint`/`eslint`: clean