### PR TITLE
Put a name on the From header of every mail

### DIFF
--- a/internal/emailnotify/authmailer.go
+++ b/internal/emailnotify/authmailer.go
@@ -26,7 +26,7 @@ type AuthMailer struct {
 // site origin the branded shell links back to, so a recipient can tell which product
 // mailed them.
 func NewAuthMailer(sender Sender, from, baseURL string) *AuthMailer {
-	return &AuthMailer{sender: sender, from: from, layout: mailtpl.New(baseURL)}
+	return &AuthMailer{sender: sender, from: From(productName, from), layout: mailtpl.New(baseURL)}
 }
 
 // codeMail is the data both templates render from.

--- a/internal/emailnotify/authmailer_test.go
+++ b/internal/emailnotify/authmailer_test.go
@@ -36,8 +36,10 @@ func TestAuthMailer_SendsTheVerificationCode(t *testing.T) {
 	if sender.to != "user@example.test" {
 		t.Errorf("to = %q, want the account's address", sender.to)
 	}
-	if sender.from != "no-reply@freehire.me" {
-		t.Errorf("from = %q, want the configured sender", sender.from)
+	// The header carries a display name over the configured address: a message list
+	// showing a bare address renders it as "no-reply", which identifies nobody.
+	if !strings.Contains(sender.from, "no-reply@freehire.me") || !strings.Contains(sender.from, "freehire") {
+		t.Errorf("from = %q, want the configured address behind a readable name", sender.from)
 	}
 	if !strings.Contains(sender.text, "123456") {
 		t.Errorf("plain-text body does not carry the code: %q", sender.text)

--- a/internal/emailnotify/from.go
+++ b/internal/emailnotify/from.go
@@ -1,0 +1,29 @@
+package emailnotify
+
+import "net/mail"
+
+// From builds the From header value a mail client shows in its message list:
+// `Name <address@example.com>`.
+//
+// It exists because the list is the only thing most people read before deciding
+// whether to open. A bare address renders as its local part — "notifications" —
+// which says nothing about who is writing or why, and looks the same as every other
+// service that never set one.
+//
+// The address argument may itself already carry a display name (a deployment is
+// free to set NOTIFY_EMAIL_FROM to `freehire <notifications@freehire.me>`); the
+// address is extracted from it so the name given here always wins. An unparseable
+// value is passed through untouched: a malformed From is the operator's to fix, and
+// silently rewriting it would hide the mistake.
+// productName is the sender every automated mail shows: a digest, a reminder and a
+// verification code all come from the product, not from a person. The founder
+// sequence overrides it with a human name — see internal/onboarding.
+const productName = "freehire"
+
+func From(name, address string) string {
+	parsed, err := mail.ParseAddress(address)
+	if err != nil || name == "" {
+		return address
+	}
+	return (&mail.Address{Name: name, Address: parsed.Address}).String()
+}

--- a/internal/emailnotify/from_test.go
+++ b/internal/emailnotify/from_test.go
@@ -1,0 +1,24 @@
+package emailnotify_test
+
+import (
+	"testing"
+
+	"github.com/strelov1/freehire/internal/emailnotify"
+)
+
+func TestFrom(t *testing.T) {
+	for _, tc := range []struct {
+		name, display, address, want string
+	}{
+		{"bare address gains a name", "freehire", "notifications@freehire.me", `"freehire" <notifications@freehire.me>`},
+		{"existing name is replaced", "Ilya from freehire", `freehire <notifications@freehire.me>`, `"Ilya from freehire" <notifications@freehire.me>`},
+		{"no name leaves the address alone", "", "notifications@freehire.me", "notifications@freehire.me"},
+		{"unparseable value passes through", "freehire", "not-an-address", "not-an-address"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := emailnotify.From(tc.display, tc.address); got != tc.want {
+				t.Errorf("From(%q, %q) = %q, want %q", tc.display, tc.address, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/emailnotify/notifier.go
+++ b/internal/emailnotify/notifier.go
@@ -41,7 +41,7 @@ type Notifier struct {
 // rooted at jobBaseURL (the frontend origin).
 func NewNotifier(sender Sender, from, jobBaseURL string) *Notifier {
 	base := strings.TrimRight(jobBaseURL, "/")
-	return &Notifier{sender: sender, from: from, jobBaseURL: base, layout: mailtpl.New(base)}
+	return &Notifier{sender: sender, from: From(productName, from), jobBaseURL: base, layout: mailtpl.New(base)}
 }
 
 // Send renders the digest and delivers it to the email address in dest. The

--- a/internal/emailnotify/notifier_test.go
+++ b/internal/emailnotify/notifier_test.go
@@ -110,8 +110,12 @@ func TestNotifier_Send(t *testing.T) {
 	if fs.calls != 1 {
 		t.Fatalf("sender calls = %d, want 1", fs.calls)
 	}
-	if fs.from != "notifications@freehire.me" || fs.to != "user@acme.com" {
-		t.Errorf("from/to = %q/%q, want notifications@freehire.me/user@acme.com", fs.from, fs.to)
+	// From carries a display name over the configured address — see emailnotify.From.
+	if !strings.Contains(fs.from, "notifications@freehire.me") || !strings.Contains(fs.from, "freehire") {
+		t.Errorf("from = %q, want the configured address behind a readable name", fs.from)
+	}
+	if fs.to != "user@acme.com" {
+		t.Errorf("to = %q, want the subscriber's address", fs.to)
 	}
 	if !strings.HasPrefix(fs.subject, "3 new jobs for") {
 		t.Errorf("subject = %q", fs.subject)

--- a/internal/nudge/transports.go
+++ b/internal/nudge/transports.go
@@ -14,6 +14,10 @@ import (
 	"github.com/strelov1/freehire/internal/telegramnotify"
 )
 
+// senderName is the display name on these mails: they are the product speaking,
+// not a person, so a message list should say so.
+const senderName = "freehire"
+
 // Compile-time proof the transports satisfy the engine's Notifier seam.
 var (
 	_ Notifier = (*TelegramNotifier)(nil)
@@ -81,7 +85,7 @@ type EmailNotifier struct {
 // links rooted at origin.
 func NewEmailNotifier(sender emailnotify.Sender, from, origin string) *EmailNotifier {
 	base := strings.TrimRight(origin, "/")
-	return &EmailNotifier{sender: sender, from: from, origin: base, layout: mailtpl.New(base)}
+	return &EmailNotifier{sender: sender, from: emailnotify.From(senderName, from), origin: base, layout: mailtpl.New(base)}
 }
 
 // Send renders the nudge and delivers it to the address in dest.

--- a/internal/onboarding/from_test.go
+++ b/internal/onboarding/from_test.go
@@ -1,0 +1,25 @@
+package onboarding_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/onboarding"
+)
+
+// The message list is the only thing most people read before deciding to open, and
+// a bare address renders there as "notifications".
+func TestSenderCarriesAHumanName(t *testing.T) {
+	sender := &fakeSender{}
+	m := onboarding.NewMailer(sender, "notifications@freehire.me", "ilya@example.test", "https://freehire.me")
+	if err := m.Send(context.Background(), onboarding.StepWelcome, "someone@example.com"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if !strings.Contains(sender.sent[0].from, "Ilya") {
+		t.Errorf("From = %q, want a person's name in it", sender.sent[0].from)
+	}
+	if !strings.Contains(sender.sent[0].from, "notifications@freehire.me") {
+		t.Errorf("From = %q, want the sending address preserved", sender.sent[0].from)
+	}
+}

--- a/internal/onboarding/mailer.go
+++ b/internal/onboarding/mailer.go
@@ -22,6 +22,7 @@ import (
 	"html/template"
 	"strings"
 
+	"github.com/strelov1/freehire/internal/emailnotify"
 	"github.com/strelov1/freehire/internal/mailtpl"
 )
 
@@ -67,8 +68,19 @@ type Mailer struct {
 // caller is expected to catch, not something this type papers over.
 func NewMailer(sender Sender, from, replyTo, baseURL string) *Mailer {
 	base := strings.TrimRight(baseURL, "/")
-	return &Mailer{sender: sender, from: from, replyTo: replyTo, baseURL: base, layout: mailtpl.New(base)}
+	return &Mailer{
+		sender:  sender,
+		from:    emailnotify.From(senderName, from),
+		replyTo: replyTo,
+		baseURL: base,
+		layout:  mailtpl.New(base),
+	}
 }
+
+// senderName is what the recipient's message list shows. These letters are from a
+// person and say so in the first line, so the sender reads as one too — "freehire"
+// would set up a reply to a company that no one intends to answer.
+const senderName = "Ilya from freehire"
 
 // Send delivers one step to one address.
 func (m *Mailer) Send(ctx context.Context, step Step, to string) error {

--- a/internal/reminder/transports.go
+++ b/internal/reminder/transports.go
@@ -14,6 +14,10 @@ import (
 	"github.com/strelov1/freehire/internal/telegramnotify"
 )
 
+// senderName is the display name on these mails: they are the product speaking,
+// not a person, so a message list should say so.
+const senderName = "freehire"
+
 // Compile-time proof the transports satisfy the engine's Notifier seam.
 var (
 	_ Notifier = (*TelegramNotifier)(nil)
@@ -66,7 +70,7 @@ type EmailNotifier struct {
 // the job link rooted at jobBaseURL.
 func NewEmailNotifier(sender emailnotify.Sender, from, jobBaseURL string) *EmailNotifier {
 	base := strings.TrimRight(jobBaseURL, "/")
-	return &EmailNotifier{sender: sender, from: from, jobBaseURL: base, layout: mailtpl.New(base)}
+	return &EmailNotifier{sender: sender, from: emailnotify.From(senderName, from), jobBaseURL: base, layout: mailtpl.New(base)}
 }
 
 // emailTemplate renders the body from a mailtpl.Job. The saved job leads, drawn by

--- a/internal/reminder/transports_test.go
+++ b/internal/reminder/transports_test.go
@@ -24,8 +24,13 @@ func TestEmailNotifier_RendersSubjectAndOnPlatformLink(t *testing.T) {
 	if err := n.Send(context.Background(), "email", "u@x.com", msg); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
-	if sender.to != "u@x.com" || sender.from != "jobs@freehire.me" {
-		t.Errorf("envelope from=%q to=%q", sender.from, sender.to)
+	// From carries a display name over the configured address, so a message list
+	// shows "freehire" rather than the address's local part.
+	if sender.to != "u@x.com" {
+		t.Errorf("to = %q, want the recipient", sender.to)
+	}
+	if !strings.Contains(sender.from, "jobs@freehire.me") || !strings.Contains(sender.from, "freehire") {
+		t.Errorf("from = %q, want the configured address behind a readable name", sender.from)
 	}
 	if !strings.Contains(sender.subject, "Go Dev") || !strings.Contains(sender.subject, "Acme") {
 		t.Errorf("subject = %q, want job + company", sender.subject)

--- a/internal/report/notifier.go
+++ b/internal/report/notifier.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"html/template"
+	"net/mail"
 	"strings"
 	"unicode/utf8"
 
@@ -35,7 +36,19 @@ type MailNotifier struct {
 // site origin the reported job is linked under.
 func NewMailNotifier(sender EmailSender, from, baseURL string) *MailNotifier {
 	base := strings.TrimRight(baseURL, "/")
-	return &MailNotifier{sender: sender, from: from, baseURL: base, layout: mailtpl.New(base)}
+	return &MailNotifier{sender: sender, from: senderFrom(from), baseURL: base, layout: mailtpl.New(base)}
+}
+
+// senderFrom puts the product's name on the From header. It is spelled out here
+// rather than imported from emailnotify because this package deliberately does not
+// depend on that one (see EmailSender above) — one duplicated word is cheaper than
+// dragging the AWS dependency graph into moderation.
+func senderFrom(address string) string {
+	parsed, err := mail.ParseAddress(address)
+	if err != nil {
+		return address
+	}
+	return (&mail.Address{Name: "freehire", Address: parsed.Address}).String()
 }
 
 // maxQuotedDetails bounds how much of the original report is quoted back. The reporter wrote

--- a/internal/report/notifier_test.go
+++ b/internal/report/notifier_test.go
@@ -54,8 +54,12 @@ func TestNotice_ResolvedWithTheJobClosed(t *testing.T) {
 	d.Note = "You were right, we took it down"
 	got := notice(t, d)
 
-	if got.to != "lina@example.test" || got.from != "hi@freehire.me" {
-		t.Errorf("envelope = %q -> %q", got.from, got.to)
+	// From carries a display name over the configured address — see senderFrom.
+	if got.to != "lina@example.test" {
+		t.Errorf("to = %q, want the reporter's address", got.to)
+	}
+	if !strings.Contains(got.from, "hi@freehire.me") || !strings.Contains(got.from, "freehire") {
+		t.Errorf("from = %q, want the configured address behind a readable name", got.from)
 	}
 	if !strings.Contains(strings.ToLower(got.subject), "removed") {
 		t.Errorf("subject = %q, want it to say the job was removed", got.subject)


### PR DESCRIPTION
In a message list, the mails showed up as **"notifications"** — the local part of the sending address. That line is the one thing most people read before deciding whether to open, and it said neither who was writing nor why.

| | Sends as |
|---|---|
| Digest, reminder, nudge, verification code, report outcome | `freehire` |
| Founder signup sequence | `Ilya from freehire` |

The sequence gets a human name deliberately: those letters are written in the first person, say so in their opening line, and ask for a reply. A corporate sender would be inviting an answer nobody intends to give.

## `emailnotify.From`

Assembles the header and extracts the address from a value that **already** carries a display name, so a deployment that sets `NOTIFY_EMAIL_FROM` to `freehire <notifications@freehire.me>` does not end up with the name twice.

An unparseable address passes through untouched. A malformed From is the operator's to fix, and rewriting it silently would hide the mistake — this is the rule the test caught me getting wrong, since the first version happily produced `<not-an-address@>`.

`internal/report` spells the name out instead of importing `emailnotify`: it declares its own sender interface specifically to stay off the AWS dependency graph, and one duplicated word is cheaper than dragging that in for a constant.

## Tests

Two existing tests asserted `From` equalled the configured address exactly. They now assert the address is present *behind a readable name* — the thing they were pinning is the thing being changed, so the assertion moved with it rather than being deleted.

## Verification

`gofmt`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...` — clean.

## Note

Separately from this PR: the domain's SPF does not include Amazon SES and there is no DMARC record. Verification rates by provider suggest it costs delivery — gmail 98%, outlook 71%. Worth fixing in DNS regardless of what the From header says.