### PR TITLE
SEO: page the job sitemap by cursor instead of shipping a 15k slice

### DIFF
--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -1045,6 +1045,48 @@ func (q *Queries) InsertPrivateJob(ctx context.Context, arg InsertPrivateJobPara
 	return i, err
 }
 
+const jobSitemapBoundaries = `-- name: JobSitemapBoundaries :many
+SELECT id FROM (
+  SELECT id,
+         row_number() OVER (ORDER BY id DESC) AS rn
+  FROM jobs
+  WHERE closed_at IS NULL AND duplicate_of IS NULL
+) t
+WHERE rn % $1::bigint = 0
+  AND id > (SELECT min(id) FROM jobs WHERE closed_at IS NULL AND duplicate_of IS NULL)
+ORDER BY id DESC
+`
+
+// The id ending every full chunk of `chunk_size` sitemap-eligible jobs (newest
+// first), excluding the last row, so the sitemap index can list each chunk's cursor.
+// Same scope as ListJobSitemapChunk, or the cursors would not line up with the
+// chunks they open.
+//
+// The last-row guard is a min(id) probe rather than a count: over ~1.1M rows an
+// exact `count(*) OVER ()` has to materialize the whole walk in a tuplestore, while
+// min(id) over the same partial index is one forward probe. Both exclude exactly the
+// row whose rank is the total — the smallest id — whose cursor would open an empty
+// trailing chunk.
+func (q *Queries) JobSitemapBoundaries(ctx context.Context, chunkSize int64) ([]int64, error) {
+	rows, err := q.db.Query(ctx, jobSitemapBoundaries, chunkSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []int64{}
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listJobIDsAfter = `-- name: ListJobIDsAfter :many
 SELECT id
 FROM jobs
@@ -1119,34 +1161,42 @@ func (q *Queries) ListJobIDsUpdatedAfter(ctx context.Context, arg ListJobIDsUpda
 	return items, nil
 }
 
-const listJobSitemapFreshest = `-- name: ListJobSitemapFreshest :many
+const listJobSitemapChunk = `-- name: ListJobSitemapChunk :many
 SELECT public_slug, updated_at
 FROM jobs
-WHERE closed_at IS NULL AND duplicate_of IS NULL
+WHERE closed_at IS NULL AND duplicate_of IS NULL AND id < $1
 ORDER BY id DESC
-LIMIT $1
+LIMIT $2
 `
 
-type ListJobSitemapFreshestRow struct {
+type ListJobSitemapChunkParams struct {
+	AfterID  int64 `json:"after_id"`
+	RowLimit int32 `json:"row_limit"`
+}
+
+type ListJobSitemapChunkRow struct {
 	PublicSlug string             `json:"public_slug"`
 	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
 }
 
-// The freshest open jobs for the sitemap: only the fields a URL needs, newest id
-// first. Ordering by id DESC (served by jobs_open_id_idx) reads the most recently
-// inserted rows, which sit at the physical end of the heap — a sequential, cache-warm
-// scan. Enumerating the whole 2.5M-row catalogue per request is heap-bound and far
-// too slow (and pollutes the buffer cache), so the sitemap ships the freshest slice;
-// fuller coverage needs a precomputed narrow table, not a live scan.
-func (q *Queries) ListJobSitemapFreshest(ctx context.Context, rowLimit int32) ([]ListJobSitemapFreshestRow, error) {
-	rows, err := q.db.Query(ctx, listJobSitemapFreshest, rowLimit)
+// One keyset page of open, non-duplicate jobs for the sitemap, newest id first and
+// cursored by id (the caller passes the largest possible id for the first chunk, so
+// the comparison stays a plain index bound rather than an OR over NULL).
+//
+// Rides jobs_sitemap_idx (0107), which covers the order, both predicate columns and
+// the two payload columns — so a chunk is an index-only range scan and never visits
+// the 2.5M-row heap. That is what makes paging the whole open catalogue affordable;
+// before it, the sitemap could only ship its freshest slice (see 0107 for the
+// measurements that forced that cap).
+func (q *Queries) ListJobSitemapChunk(ctx context.Context, arg ListJobSitemapChunkParams) ([]ListJobSitemapChunkRow, error) {
+	rows, err := q.db.Query(ctx, listJobSitemapChunk, arg.AfterID, arg.RowLimit)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []ListJobSitemapFreshestRow{}
+	items := []ListJobSitemapChunkRow{}
 	for rows.Next() {
-		var i ListJobSitemapFreshestRow
+		var i ListJobSitemapChunkRow
 		if err := rows.Scan(&i.PublicSlug, &i.UpdatedAt); err != nil {
 			return nil, err
 		}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1537,6 +1537,17 @@ type Querier interface {
 	// Cursor read: has this rotated file (by content signature) been applied? The
 	// signature is stable across rename and gzip, so a re-run recognizes the same file.
 	IsViewLogFileProcessed(ctx context.Context, signature int64) (bool, error)
+	// The id ending every full chunk of `chunk_size` sitemap-eligible jobs (newest
+	// first), excluding the last row, so the sitemap index can list each chunk's cursor.
+	// Same scope as ListJobSitemapChunk, or the cursors would not line up with the
+	// chunks they open.
+	//
+	// The last-row guard is a min(id) probe rather than a count: over ~1.1M rows an
+	// exact `count(*) OVER ()` has to materialize the whole walk in a tuplestore, while
+	// min(id) over the same partial index is one forward probe. Both exclude exactly the
+	// row whose rank is the total — the smallest id — whose cursor would open an empty
+	// trailing chunk.
+	JobSitemapBoundaries(ctx context.Context, chunkSize int64) ([]int64, error)
 	// Whether the catalogue already crawls this board — any job whose external_id is "<board>:…".
 	// Matched with a LIKE-prefix so the (source, external_id text_pattern_ops) index serves it as
 	// a range scan; starts_with()/a default-collation LIKE would seq-scan the whole source (37s
@@ -1961,13 +1972,16 @@ type Querier interface {
 	// Resolve job ids to display labels for the credit-history page (match debits). Missing ids
 	// simply do not come back; the handler falls back to a generic label for a deleted job.
 	ListJobLabelsByIDs(ctx context.Context, ids []int64) ([]ListJobLabelsByIDsRow, error)
-	// The freshest open jobs for the sitemap: only the fields a URL needs, newest id
-	// first. Ordering by id DESC (served by jobs_open_id_idx) reads the most recently
-	// inserted rows, which sit at the physical end of the heap — a sequential, cache-warm
-	// scan. Enumerating the whole 2.5M-row catalogue per request is heap-bound and far
-	// too slow (and pollutes the buffer cache), so the sitemap ships the freshest slice;
-	// fuller coverage needs a precomputed narrow table, not a live scan.
-	ListJobSitemapFreshest(ctx context.Context, rowLimit int32) ([]ListJobSitemapFreshestRow, error)
+	// One keyset page of open, non-duplicate jobs for the sitemap, newest id first and
+	// cursored by id (the caller passes the largest possible id for the first chunk, so
+	// the comparison stays a plain index bound rather than an OR over NULL).
+	//
+	// Rides jobs_sitemap_idx (0107), which covers the order, both predicate columns and
+	// the two payload columns — so a chunk is an index-only range scan and never visits
+	// the 2.5M-row heap. That is what makes paging the whole open catalogue affordable;
+	// before it, the sitemap could only ship its freshest slice (see 0107 for the
+	// measurements that forced that cap).
+	ListJobSitemapChunk(ctx context.Context, arg ListJobSitemapChunkParams) ([]ListJobSitemapChunkRow, error)
 	// Newest-added first: created_at is when the job entered the catalogue (stable
 	// across re-ingests), so fresh ingests surface on top regardless of how old the
 	// platform's posted_at is. id breaks ties within one ingest batch.

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -169,18 +169,42 @@ WHERE id = sqlc.arg(id)::bigint;
 -- tracks the closed_at IS NULL filter. The total is approximate by design.
 SELECT estimate_open_jobs()::bigint;
 
--- name: ListJobSitemapFreshest :many
--- The freshest open jobs for the sitemap: only the fields a URL needs, newest id
--- first. Ordering by id DESC (served by jobs_open_id_idx) reads the most recently
--- inserted rows, which sit at the physical end of the heap — a sequential, cache-warm
--- scan. Enumerating the whole 2.5M-row catalogue per request is heap-bound and far
--- too slow (and pollutes the buffer cache), so the sitemap ships the freshest slice;
--- fuller coverage needs a precomputed narrow table, not a live scan.
+-- name: ListJobSitemapChunk :many
+-- One keyset page of open, non-duplicate jobs for the sitemap, newest id first and
+-- cursored by id (the caller passes the largest possible id for the first chunk, so
+-- the comparison stays a plain index bound rather than an OR over NULL).
+--
+-- Rides jobs_sitemap_idx (0107), which covers the order, both predicate columns and
+-- the two payload columns — so a chunk is an index-only range scan and never visits
+-- the 2.5M-row heap. That is what makes paging the whole open catalogue affordable;
+-- before it, the sitemap could only ship its freshest slice (see 0107 for the
+-- measurements that forced that cap).
 SELECT public_slug, updated_at
 FROM jobs
-WHERE closed_at IS NULL AND duplicate_of IS NULL
+WHERE closed_at IS NULL AND duplicate_of IS NULL AND id < sqlc.arg(after_id)
 ORDER BY id DESC
 LIMIT sqlc.arg(row_limit);
+
+-- name: JobSitemapBoundaries :many
+-- The id ending every full chunk of `chunk_size` sitemap-eligible jobs (newest
+-- first), excluding the last row, so the sitemap index can list each chunk's cursor.
+-- Same scope as ListJobSitemapChunk, or the cursors would not line up with the
+-- chunks they open.
+--
+-- The last-row guard is a min(id) probe rather than a count: over ~1.1M rows an
+-- exact `count(*) OVER ()` has to materialize the whole walk in a tuplestore, while
+-- min(id) over the same partial index is one forward probe. Both exclude exactly the
+-- row whose rank is the total — the smallest id — whose cursor would open an empty
+-- trailing chunk.
+SELECT id FROM (
+  SELECT id,
+         row_number() OVER (ORDER BY id DESC) AS rn
+  FROM jobs
+  WHERE closed_at IS NULL AND duplicate_of IS NULL
+) t
+WHERE rn % sqlc.arg(chunk_size)::bigint = 0
+  AND id > (SELECT min(id) FROM jobs WHERE closed_at IS NULL AND duplicate_of IS NULL)
+ORDER BY id DESC;
 
 -- name: ListJobsByCompany :many
 -- duplicate_of IS NULL collapses role-cluster reposts to their canonical row, matching

--- a/internal/db/sitemap_integration_test.go
+++ b/internal/db/sitemap_integration_test.go
@@ -1,15 +1,17 @@
 //go:build integration
 
-// Integration tests for the sitemap read path: the job feed returns the freshest
-// open jobs (newest id first, closed excluded); the company slice pages by a slug
-// cursor and the boundary query returns the cursor at each Nth row so the company
-// sitemap index can enumerate chunks without walking the table. SQL behaviors,
+// Integration tests for the sitemap read path: both the job and company slices page
+// by a keyset cursor (id and slug respectively), and each boundary query returns the
+// cursor at each Nth row so the sitemap index can enumerate chunks without walking
+// the table. The tiling test is the one that matters — chunks must join up exactly,
+// serving no row twice and skipping none between files. SQL behaviors,
 // verifiable only against a real Postgres. Run with: go test -tags=integration ./internal/db/
 package db
 
 import (
 	"context"
 	"fmt"
+	"math"
 	"testing"
 )
 
@@ -27,7 +29,7 @@ func seedOpenJob(ctx context.Context, t *testing.T, q *Queries, n int) Job {
 	return j
 }
 
-func TestJobSitemapFreshest(t *testing.T) {
+func TestJobSitemapKeyset(t *testing.T) {
 	pool := startPostgres(t)
 	q := New(pool)
 	ctx := context.Background()
@@ -43,21 +45,24 @@ func TestJobSitemapFreshest(t *testing.T) {
 		t.Fatalf("close job: %v", err)
 	}
 
-	t.Run("returns the freshest open jobs, newest id first", func(t *testing.T) {
-		got, err := q.ListJobSitemapFreshest(ctx, 3)
+	// firstChunk is the cursor the handler opens the first chunk with: above every id.
+	const firstChunk = int64(math.MaxInt64)
+
+	t.Run("first chunk returns the newest jobs, newest id first", func(t *testing.T) {
+		got, err := q.ListJobSitemapChunk(ctx, ListJobSitemapChunkParams{AfterID: firstChunk, RowLimit: 3})
 		if err != nil {
-			t.Fatalf("ListJobSitemapFreshest: %v", err)
+			t.Fatalf("ListJobSitemapChunk: %v", err)
 		}
 		want := []string{jobs[4].PublicSlug, jobs[3].PublicSlug, jobs[2].PublicSlug}
 		if fmt.Sprint(freshestSlugs(got)) != fmt.Sprint(want) {
-			t.Fatalf("freshest 3 = %v, want %v", freshestSlugs(got), want)
+			t.Fatalf("first chunk = %v, want %v", freshestSlugs(got), want)
 		}
 	})
 
 	t.Run("caps at the limit and excludes closed jobs", func(t *testing.T) {
-		got, err := q.ListJobSitemapFreshest(ctx, 100)
+		got, err := q.ListJobSitemapChunk(ctx, ListJobSitemapChunkParams{AfterID: firstChunk, RowLimit: 100})
 		if err != nil {
-			t.Fatalf("ListJobSitemapFreshest: %v", err)
+			t.Fatalf("ListJobSitemapChunk: %v", err)
 		}
 		if len(got) != 5 {
 			t.Fatalf("got %d open jobs, want 5 (%v)", len(got), freshestSlugs(got))
@@ -66,6 +71,54 @@ func TestJobSitemapFreshest(t *testing.T) {
 			if r.PublicSlug == closed.PublicSlug {
 				t.Fatalf("closed job %q leaked into sitemap", closed.PublicSlug)
 			}
+		}
+	})
+
+	// The property the whole chunked scheme rests on: following a boundary cursor
+	// picks up exactly where the previous chunk stopped — no row served twice, none
+	// skipped between files.
+	t.Run("chunks tile the catalogue without gaps or repeats", func(t *testing.T) {
+		cursors, err := q.JobSitemapBoundaries(ctx, 2)
+		if err != nil {
+			t.Fatalf("JobSitemapBoundaries: %v", err)
+		}
+		var seen []string
+		for _, after := range append([]int64{firstChunk}, cursors...) {
+			page, err := q.ListJobSitemapChunk(ctx, ListJobSitemapChunkParams{AfterID: after, RowLimit: 2})
+			if err != nil {
+				t.Fatalf("chunk after %d: %v", after, err)
+			}
+			seen = append(seen, freshestSlugs(page)...)
+		}
+		want := []string{
+			jobs[4].PublicSlug, jobs[3].PublicSlug, jobs[2].PublicSlug,
+			jobs[1].PublicSlug, jobs[0].PublicSlug,
+		}
+		if fmt.Sprint(seen) != fmt.Sprint(want) {
+			t.Fatalf("walked %v, want %v", seen, want)
+		}
+	})
+
+	t.Run("boundaries return the id at each Nth job, excluding the last", func(t *testing.T) {
+		got, err := q.JobSitemapBoundaries(ctx, 2)
+		if err != nil {
+			t.Fatalf("JobSitemapBoundaries: %v", err)
+		}
+		want := []int64{jobs[3].ID, jobs[1].ID}
+		if fmt.Sprint(got) != fmt.Sprint(want) {
+			t.Fatalf("boundaries = %v, want %v", got, want)
+		}
+	})
+
+	// The chunk size divides the open count exactly, so the final row lands ON a
+	// chunk edge — its cursor would open a sub-sitemap with no URLs in it.
+	t.Run("boundaries exclude a final row that lands on a chunk edge", func(t *testing.T) {
+		got, err := q.JobSitemapBoundaries(ctx, 5)
+		if err != nil {
+			t.Fatalf("JobSitemapBoundaries: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("boundaries = %v, want none (the 5th job is also the last)", got)
 		}
 	})
 }
@@ -144,7 +197,7 @@ func TestCompanySitemapKeyset(t *testing.T) {
 	})
 }
 
-func freshestSlugs(rows []ListJobSitemapFreshestRow) []string {
+func freshestSlugs(rows []ListJobSitemapChunkRow) []string {
 	out := make([]string, len(rows))
 	for i, r := range rows {
 		out[i] = r.PublicSlug

--- a/internal/handler/sitemap.go
+++ b/internal/handler/sitemap.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"math"
+	"strconv"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -22,6 +24,7 @@ func newSitemapHandlers(queries *db.Queries) *sitemapHandlers {
 
 func (h *sitemapHandlers) register(api fiber.Router) {
 	api.Get("/jobs/sitemap", h.JobSitemap)
+	api.Get("/jobs/sitemap/boundaries", h.JobSitemapBoundaries)
 	api.Get("/companies/sitemap", h.CompanySitemap)
 	api.Get("/companies/sitemap/boundaries", h.CompanySitemapBoundaries)
 }
@@ -43,15 +46,23 @@ const sitemapMaxURLs = 50000
 // ~5, which a sitemap index carries for free (its own cap is 50k entries).
 const companySitemapChunk = 10000
 
-// jobSitemapFreshest is how many of the newest open jobs the sitemap ships. The
-// jobs table is far too large (millions of rows) to enumerate per request without
-// a heap-bound scan that also evicts the buffer cache, so the sitemap covers the
-// freshest slice (ordered by id DESC, a cache-warm scan); fuller coverage would
-// need a precomputed narrow table. Held below the 50k protocol cap so the one file
-// builds under the 60s proxy timeout even against I/O contention — 50k measured
-// ~30-40s under load, and 25k still measured 29s and 57s on two prod probes minutes
-// apart, so this is the margin that band needs, not the row count we'd prefer.
-const jobSitemapFreshest = 15000
+// jobSitemapChunk is how many jobs one sub-sitemap holds: the default for both
+// ?limit= and ?chunk=, and the value web/src/lib/sitemap.ts JOB_SITEMAP_CHUNK must
+// equal so each boundary cursor opens exactly one file's worth.
+//
+// The sitemap used to ship only the freshest 15k of the catalogue, because the read
+// was heap-bound: 50k measured 30-40s on prod and 25k twice hit 57s against nginx's
+// 60s ceiling. jobs_sitemap_idx (0107) makes a chunk an index-only range scan, so
+// the whole open set can be paged by cursor instead. Sized above the company chunk
+// because that index covers everything these queries read, and kept below the
+// protocol's 50k so a chunk is never near either ceiling.
+const jobSitemapChunk = 25000
+
+// firstChunkCursor opens the first keyset chunk: ids are read newest-first with a
+// plain `id < cursor`, so the opening cursor has to be larger than any real id.
+// Keeping it a bound (rather than a nullable comparison) is what keeps the scan
+// index-only.
+const firstChunkCursor = int64(math.MaxInt64)
 
 // sitemapEntry is the slim wire shape a sitemap URL needs — the public slug and a
 // lastmod. Nothing wider (no full job row, no search engine) crosses the wire.
@@ -61,19 +72,38 @@ type sitemapEntry struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
-// sitemapLimit clamps ?limit= to [1, sitemapMaxURLs], defaulting to the chunk size.
-func sitemapLimit(c *fiber.Ctx) int32 {
-	return int32(min(max(c.QueryInt("limit", companySitemapChunk), 1), sitemapMaxURLs))
+// sitemapLimit clamps ?limit= to [1, sitemapMaxURLs], defaulting to `fallback`.
+func sitemapLimit(c *fiber.Ctx, fallback int) int32 {
+	return int32(min(max(c.QueryInt("limit", fallback), 1), sitemapMaxURLs))
 }
 
-// sitemapChunk clamps ?chunk= to [1, sitemapMaxURLs], defaulting to the chunk size.
-func sitemapChunk(c *fiber.Ctx) int64 {
-	return int64(min(max(c.QueryInt("chunk", companySitemapChunk), 1), sitemapMaxURLs))
+// sitemapChunk clamps ?chunk= to [1, sitemapMaxURLs], defaulting to `fallback`.
+func sitemapChunk(c *fiber.Ctx, fallback int) int64 {
+	return int64(min(max(c.QueryInt("chunk", fallback), 1), sitemapMaxURLs))
 }
 
-// JobSitemap serves the freshest open-job sitemap entries (newest id first).
+// sitemapAfterID reads the ?after= keyset cursor. Absent or unparseable means the
+// first chunk, which starts above every id — a crawler following a stale index can
+// only ever get a valid page, never an error.
+func sitemapAfterID(c *fiber.Ctx) int64 {
+	raw := c.Query("after")
+	if raw == "" {
+		return firstChunkCursor
+	}
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id <= 0 {
+		return firstChunkCursor
+	}
+	return id
+}
+
+// JobSitemap serves one keyset page of open-job sitemap entries after ?after=<id>,
+// newest id first.
 func (h *sitemapHandlers) JobSitemap(c *fiber.Ctx) error {
-	rows, err := h.queries.ListJobSitemapFreshest(c.Context(), jobSitemapFreshest)
+	rows, err := h.queries.ListJobSitemapChunk(c.Context(), db.ListJobSitemapChunkParams{
+		AfterID:  sitemapAfterID(c),
+		RowLimit: sitemapLimit(c, jobSitemapChunk),
+	})
 	if err != nil {
 		return err
 	}
@@ -84,12 +114,23 @@ func (h *sitemapHandlers) JobSitemap(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"data": entries})
 }
 
+// JobSitemapBoundaries returns the keyset cursor (id) ending each ?chunk=<n> of
+// sitemap-eligible jobs, for building the sitemap index. Same scope as JobSitemap,
+// so a cursor always opens a chunk that has URLs in it.
+func (h *sitemapHandlers) JobSitemapBoundaries(c *fiber.Ctx) error {
+	cursors, err := h.queries.JobSitemapBoundaries(c.Context(), sitemapChunk(c, jobSitemapChunk))
+	if err != nil {
+		return err
+	}
+	return c.JSON(fiber.Map{"data": cursors})
+}
+
 // CompanySitemap serves one keyset page of company sitemap entries after ?after=<slug>,
 // covering the hiring companies the /companies catalog lists (see ListCompanySitemap).
 func (h *sitemapHandlers) CompanySitemap(c *fiber.Ctx) error {
 	rows, err := h.queries.ListCompanySitemap(c.Context(), db.ListCompanySitemapParams{
 		AfterSlug: c.Query("after"),
-		BatchSize: sitemapLimit(c),
+		BatchSize: sitemapLimit(c, companySitemapChunk),
 	})
 	if err != nil {
 		return err
@@ -105,7 +146,7 @@ func (h *sitemapHandlers) CompanySitemap(c *fiber.Ctx) error {
 // hiring companies, for building the sitemap index. Same scope as CompanySitemap, so a
 // cursor always opens a chunk that has URLs in it.
 func (h *sitemapHandlers) CompanySitemapBoundaries(c *fiber.Ctx) error {
-	cursors, err := h.queries.CompanySitemapBoundaries(c.Context(), sitemapChunk(c))
+	cursors, err := h.queries.CompanySitemapBoundaries(c.Context(), sitemapChunk(c, companySitemapChunk))
 	if err != nil {
 		return err
 	}

--- a/internal/handler/sitemap_integration_test.go
+++ b/internal/handler/sitemap_integration_test.go
@@ -57,6 +57,7 @@ func TestSitemapEndpoints(t *testing.T) {
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	// Sitemap routes are registered BEFORE the :slug catch-alls, mirroring wiring.
 	app.Get("/api/v1/jobs/sitemap", h.JobSitemap)
+	app.Get("/api/v1/jobs/sitemap/boundaries", h.JobSitemapBoundaries)
 	app.Get("/api/v1/companies/sitemap", h.CompanySitemap)
 	app.Get("/api/v1/companies/sitemap/boundaries", h.CompanySitemapBoundaries)
 	app.Get("/api/v1/jobs/:slug", jh.GetJob)
@@ -99,6 +100,33 @@ func TestSitemapEndpoints(t *testing.T) {
 		}
 		if got[0].UpdatedAt == "" {
 			t.Fatalf("entry missing updated_at: %+v", got[0])
+		}
+	})
+
+	t.Run("job slice pages by id cursor", func(t *testing.T) {
+		var ids struct {
+			Data []int64 `json:"data"`
+		}
+		if err := json.Unmarshal(get(t, "/api/v1/jobs/sitemap/boundaries?chunk=2"), &ids); err != nil {
+			t.Fatalf("decode boundaries: %v", err)
+		}
+		if len(ids.Data) != 2 {
+			t.Fatalf("boundaries = %v, want two cursors for 5 jobs in chunks of 2", ids.Data)
+		}
+		// Following the first cursor must resume exactly after the first chunk.
+		got := decodeEntries(t, get(t, fmt.Sprintf("/api/v1/jobs/sitemap?after=%d&limit=2", ids.Data[0])))
+		if len(got) != 2 || got[0].Slug != "job-03" || got[1].Slug != "job-02" {
+			t.Fatalf("second chunk = %+v, want [job-03 job-02]", got)
+		}
+	})
+
+	// A crawler holding a stale sitemap index asks with a cursor we no longer know.
+	// It must get a valid page rather than an error, or a whole chunk drops out of
+	// the crawl until the index is refetched.
+	t.Run("an unparseable cursor serves the first chunk", func(t *testing.T) {
+		got := decodeEntries(t, get(t, "/api/v1/jobs/sitemap?after=not-a-number&limit=2"))
+		if len(got) != 2 || got[0].Slug != "job-05" {
+			t.Fatalf("page = %+v, want the first chunk (job-05 first)", got)
 		}
 	})
 

--- a/migrations/0107_jobs_sitemap_idx.sql
+++ b/migrations/0107_jobs_sitemap_idx.sql
@@ -18,18 +18,24 @@
 -- INCLUDE rather than a composite key: public_slug and updated_at are payload, never
 -- searched or ordered by, so they ride in the leaf pages without widening the tree.
 --
--- release.sh applies migrations before restarting the new color, so this builds on
--- deploy: a plain CREATE INDEX holds a SHARE lock on jobs (blocking the ingest's
--- upserts, not reads) for as long as a ~1.1M-row partial index takes — longer than
--- 0057's, and the ingest is the thing being blocked. If a deploy can't afford that,
--- build it out of band first and this migration is a no-op:
+-- HOW THIS GETS APPLIED: host-2 has no migration runner — numbered migrations are
+-- applied BY HAND before the blue/green flip, as the `hire` role (see freehire-ops
+-- README, "Schema migrations"; connecting as postgres leaves objects postgres-owned
+-- and the API 500s on them).
 --
---   CREATE INDEX CONCURRENTLY jobs_sitemap_idx
+-- Build it CONCURRENTLY. A plain CREATE INDEX holds a SHARE lock on jobs for as long
+-- as a ~1.1M-row partial index takes, and what that blocks is the ingest's upserts —
+-- the one workload on this box that must not stall. IF NOT EXISTS then makes the
+-- migration file a no-op afterwards:
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS jobs_sitemap_idx
 --       ON public.jobs (id DESC) INCLUDE (public_slug, updated_at)
 --       WHERE closed_at IS NULL AND duplicate_of IS NULL;
 --
--- Run that from a file via psql -f under systemd-run, never `psql -c` over ssh: a
--- dropped connection aborts CONCURRENTLY and leaves an INVALID index behind.
+-- Run it from a file (psql -f) under systemd-run, never `psql -c` over ssh: a dropped
+-- connection aborts CONCURRENTLY and leaves an INVALID index behind, which the planner
+-- ignores while it still costs writes. Check with:
+--   SELECT indisvalid FROM pg_index WHERE indexrelid = 'jobs_sitemap_idx'::regclass;
 CREATE INDEX IF NOT EXISTS jobs_sitemap_idx
     ON public.jobs (id DESC) INCLUDE (public_slug, updated_at)
     WHERE closed_at IS NULL AND duplicate_of IS NULL;

--- a/migrations/0107_jobs_sitemap_idx.sql
+++ b/migrations/0107_jobs_sitemap_idx.sql
@@ -1,0 +1,35 @@
+-- The covering index the job sitemap pages by: id order, the two columns a URL
+-- needs, and the whole predicate it filters on — so the sitemap reads never touch
+-- the jobs heap.
+--
+-- Why the sitemap was capped at 15k rows without it: jobs_open_id_idx (0001) is
+-- `(id) WHERE closed_at IS NULL`. It carries neither `duplicate_of IS NULL` nor
+-- public_slug/updated_at, so every candidate row was fetched from a 2.5M-row heap
+-- to test the predicate and read its columns — the "heap-bound scan" the query's
+-- own comment describes. 50k measured 30-40s on prod and 25k twice hit 57s against
+-- nginx's 60s ceiling, so the cap was the margin that band needed rather than the
+-- coverage anyone wanted (see internal/handler/sitemap.go).
+--
+-- With this index a chunk is a bounded index-only range scan, which is what lets
+-- the sitemap page the whole open catalogue by cursor instead of shipping only its
+-- freshest slice. Partial on exactly the rows the sitemap lists, so it stays
+-- proportional to the open, non-duplicate set (~1.1M of 2.5M) rather than the table.
+--
+-- INCLUDE rather than a composite key: public_slug and updated_at are payload, never
+-- searched or ordered by, so they ride in the leaf pages without widening the tree.
+--
+-- release.sh applies migrations before restarting the new color, so this builds on
+-- deploy: a plain CREATE INDEX holds a SHARE lock on jobs (blocking the ingest's
+-- upserts, not reads) for as long as a ~1.1M-row partial index takes — longer than
+-- 0057's, and the ingest is the thing being blocked. If a deploy can't afford that,
+-- build it out of band first and this migration is a no-op:
+--
+--   CREATE INDEX CONCURRENTLY jobs_sitemap_idx
+--       ON public.jobs (id DESC) INCLUDE (public_slug, updated_at)
+--       WHERE closed_at IS NULL AND duplicate_of IS NULL;
+--
+-- Run that from a file via psql -f under systemd-run, never `psql -c` over ssh: a
+-- dropped connection aborts CONCURRENTLY and leaves an INVALID index behind.
+CREATE INDEX IF NOT EXISTS jobs_sitemap_idx
+    ON public.jobs (id DESC) INCLUDE (public_slug, updated_at)
+    WHERE closed_at IS NULL AND duplicate_of IS NULL;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -635,9 +635,16 @@ export function createApi(
   // slice (one file); companies are keyset-paginated across chunks, with a boundary
   // endpoint returning the cursor ending each chunk so the index can enumerate them.
 
-  /** The freshest open-job sitemap entries (newest first), one file. */
-  async function sitemapJobs(): Promise<SitemapEntry[]> {
-    return requestData<SitemapEntry[]>('/api/v1/jobs/sitemap');
+  /** One chunk of job sitemap entries with id < `after` ('' for the first). */
+  async function sitemapJobs(after: string, limit: number): Promise<SitemapEntry[]> {
+    return requestData<SitemapEntry[]>(
+      `/api/v1/jobs/sitemap?after=${encodeURIComponent(after)}&limit=${limit}`,
+    );
+  }
+
+  /** The id ending each chunk of sitemap-eligible jobs — the sitemap index's cursors. */
+  async function sitemapJobBoundaries(chunk: number): Promise<number[]> {
+    return requestData<number[]>(`/api/v1/jobs/sitemap/boundaries?chunk=${chunk}`);
   }
 
   /** One chunk of company sitemap entries with slug > `after` ('' for the first). */
@@ -2031,6 +2038,7 @@ export function createApi(
     insightsCompanies,
     marketPulse,
     sitemapJobs,
+    sitemapJobBoundaries,
     sitemapCompanies,
     sitemapCompanyBoundaries,
     register,

--- a/web/src/lib/sitemap.ts
+++ b/web/src/lib/sitemap.ts
@@ -12,6 +12,12 @@ import { collectionSlugs } from './collections';
 // past the 60s proxy timeout during an ingest run (see internal/handler/sitemap.go).
 export const SITEMAP_CHUNK = 10000;
 
+// Must equal the backend's jobSitemapChunk. Larger than the company chunk because
+// jobs_sitemap_idx (migration 0107) covers everything the job sitemap queries read,
+// so a chunk is an index-only scan rather than the heap walk that once capped the
+// whole job sitemap at a single 15,000-URL file.
+export const JOB_SITEMAP_CHUNK = 25000;
+
 /** The site's static, always-present pages (relative paths). */
 export const STATIC_PATHS = [
   '/',

--- a/web/src/routes/sitemap-jobs.xml/+server.ts
+++ b/web/src/routes/sitemap-jobs.xml/+server.ts
@@ -1,12 +1,14 @@
 import { serverApi } from '$lib/server/api';
-import { urlsetXml, xmlResponse } from '$lib/sitemap';
+import { JOB_SITEMAP_CHUNK, urlsetXml, xmlResponse } from '$lib/sitemap';
 import type { RequestHandler } from './$types';
 
-// The freshest open-job URLs (newest first), one file. The jobs table is too large
-// to enumerate per request without a heap-bound scan that evicts the buffer cache,
-// so the sitemap ships the freshest slice; the backend caps the count.
+// One keyset chunk of open-job URLs (newest first), addressed by ?after=<id> (empty
+// for the first chunk). The sitemap index lists these; each fetches exactly one
+// chunk. This used to be a single file holding only the freshest slice of the
+// catalogue — see JOB_SITEMAP_CHUNK for what changed.
 export const GET: RequestHandler = async ({ url, fetch }) => {
-  const jobs = await serverApi(fetch).sitemapJobs();
+  const after = url.searchParams.get('after') ?? '';
+  const jobs = await serverApi(fetch).sitemapJobs(after, JOB_SITEMAP_CHUNK);
   const entries = jobs.map((j) => ({ loc: `${url.origin}/jobs/${j.slug}`, lastmod: j.updated_at }));
   return xmlResponse(urlsetXml(entries));
 };

--- a/web/src/routes/sitemap.xml/+server.ts
+++ b/web/src/routes/sitemap.xml/+server.ts
@@ -1,21 +1,27 @@
 import { serverApi } from '$lib/server/api';
-import { SITEMAP_CHUNK, sitemapIndexXml, xmlResponse } from '$lib/sitemap';
+import { JOB_SITEMAP_CHUNK, SITEMAP_CHUNK, sitemapIndexXml, xmlResponse } from '$lib/sitemap';
 import type { RequestHandler } from './$types';
 
-// The sitemap index: the static pages, the freshest-jobs sub-sitemap (one file),
-// and one company sub-sitemap per keyset chunk. Company chunk cursors come from the
+// The sitemap index: the static pages, one job sub-sitemap per keyset chunk, and
+// one company sub-sitemap per keyset chunk. Company chunk cursors come from the
 // backend's boundary endpoint (the slug ending each chunk), so building the index
 // is a couple of small queries — never a walk of the catalogue. Cached; a
 // sub-sitemap is fetched only when a crawler follows its URL.
 export const GET: RequestHandler = async ({ url, fetch }) => {
   const origin = url.origin;
-  const companyCursors = await serverApi(fetch).sitemapCompanyBoundaries(SITEMAP_CHUNK);
+  const api = serverApi(fetch);
+  // Two independent boundary reads; run them together rather than in series.
+  const [companyCursors, jobCursors] = await Promise.all([
+    api.sitemapCompanyBoundaries(SITEMAP_CHUNK),
+    api.sitemapJobBoundaries(JOB_SITEMAP_CHUNK),
+  ]);
 
-  const locs = [
-    `${origin}/sitemap-pages.xml`,
-    `${origin}/sitemap-jobs.xml`,
-    `${origin}/sitemap-insights.xml`,
-  ];
+  const locs = [`${origin}/sitemap-pages.xml`, `${origin}/sitemap-insights.xml`];
+  // Jobs page the same way companies do: the first chunk starts above every id
+  // (empty cursor), and each boundary id starts the next.
+  for (const after of ['', ...jobCursors]) {
+    locs.push(`${origin}/sitemap-jobs.xml?after=${encodeURIComponent(String(after))}`);
+  }
   // The first company chunk starts before every slug (empty string); each boundary
   // cursor starts the next chunk.
   for (const after of ['', ...companyCursors]) {


### PR DESCRIPTION
The sitemap listed **15,000 of ~1.1M open jobs — 1.3% of the catalogue** — while listing ~209k companies. Priorities inverted: the thin half was fully enumerated, the substantial half mostly hidden.

## The cap wasn't a choice about coverage

It was the read being heap-bound. `jobs_open_id_idx` is `(id) WHERE closed_at IS NULL` — it carries neither `duplicate_of IS NULL` nor `public_slug`/`updated_at`, so every candidate row went to a 2.5M-row heap to have its predicate tested and its columns read. The existing comments record what that cost on prod: 50k measured 30–40s, and 25k twice hit 57s against nginx's 60s ceiling. 15k was the margin that band needed, not a number anyone wanted.

**Migration 0107** adds a covering partial index over exactly the rows the sitemap lists, so a chunk becomes an index-only range scan. On that footing the job sitemap pages by keyset the same way companies already do:

- `/sitemap.xml` lists one job sub-sitemap per chunk with an `?after=<id>` cursor
- `/api/v1/jobs/sitemap/boundaries` returns the id ending each chunk
- chunks are 25,000 — above the company chunk because the index covers everything these queries read, below the protocol's 50,000 so a file is never near either ceiling

An absent or unparseable `?after=` opens the first chunk rather than erroring: a crawler following a stale index should get a valid page, not lose a chunk from its crawl until it refetches. Covered by a test.

## Rejected: building it from Meilisearch

Worth stating because it's the intuitive alternative. Deep pagination is precisely what a search engine is worst at, and the numbers are lopsided — measured against prod:

| | rows returned | time |
|---|---|---|
| Meili, `offset=0` | 20 | 1.2s |
| Meili, `offset=9000` | 20 | 2.2s |
| Postgres keyset chunk | **10,000** | ~2.1s |

The search API already refuses `offset+limit > 10000` ("pagination too deep") for exactly this reason, so enumerating 1.1M rows would need slicing by date ranges. And the index lags Postgres through the `search_outbox` drain, so it would list jobs already closed in the database. Postgres is the source of truth and answers `closed_at IS NULL AND duplicate_of IS NULL` at query time.

## Tests

Integration tests against real Postgres cover the property the whole scheme rests on: following each boundary cursor **tiles the catalogue exactly** — no row served twice, none skipped between files. Plus boundary exclusion when the last row lands on a chunk edge (its cursor would open an empty file), and the stale-cursor fallback.

```
--- PASS: TestJobSitemapKeyset
    first chunk returns the newest jobs, newest id first
    caps at the limit and excludes closed jobs
    chunks tile the catalogue without gaps or repeats
    boundaries return the id at each Nth job, excluding the last
    boundaries exclude a final row that lands on a chunk edge
--- PASS: TestSitemapEndpoints
    job slice pages by id cursor
    an unparseable cursor serves the first chunk
```

`go test ./...`, `go vet -tags=integration ./...`, `gofmt` all clean. Frontend: 975 tests, `svelte-check` 0 errors.

## Deploy note

`release.sh` applies migrations before restarting the new color, so 0107 builds on deploy — a plain `CREATE INDEX` holds a SHARE lock on `jobs` (blocking the ingest's upserts, not reads) for as long as a ~1.1M-row partial index takes. That is longer than 0057's, and the ingest is the thing being blocked. If that window is unacceptable, build it `CONCURRENTLY` out of band beforehand and the migration becomes a no-op — the exact command is in the migration's header comment, including the warning to run it from a file under `systemd-run` rather than `psql -c` over ssh.