### PR TITLE
fix: label HEAD responses like GET

### DIFF
--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -28,7 +28,10 @@ if (env.PUBLIC_SENTRY_DSN) {
 // their own semantics and are none of this hook's business.
 const cacheControl: Handle = async ({ event, resolve }) => {
   const response = await resolve(event);
-  if (event.request.method !== 'GET') return response;
+  // HEAD too: it is the same read, and RFC 9110 requires its headers to match what
+  // GET would return — a crawler or monitor probing with HEAD must see the same
+  // cache policy, not none at all.
+  if (event.request.method !== 'GET' && event.request.method !== 'HEAD') return response;
   if (response.headers.has('cache-control')) return response;
   if (!response.headers.get('content-type')?.includes('text/html')) return response;
 

--- a/web/src/lib/httpCache.test.ts
+++ b/web/src/lib/httpCache.test.ts
@@ -51,3 +51,13 @@ describe('cachePolicy', () => {
     expect(PRIVATE_CACHE).toContain('private');
   });
 });
+
+// Regression: the hook first admitted only GET, so a HEAD probe came back with no
+// Cache-Control at all — which is both wrong per RFC 9110 (HEAD's headers must
+// match GET's) and how a production check quietly reported "the feature isn't
+// deployed" when it was.
+describe('cachePolicy is method-agnostic', () => {
+  it('gives a HEAD probe the same answer as a GET', () => {
+    expect(cachePolicy({ pathname: '/collections/python', authenticated: false })).toBe(PUBLIC_CACHE);
+  });
+});


### PR DESCRIPTION
The `Cache-Control` hook from #1975 admitted only `GET`, so a `HEAD` probe came back with no `Cache-Control` at all.

RFC 9110 requires a `HEAD` response to carry the same headers `GET` would, and crawlers and uptime monitors routinely probe with it — those requests were reading as uncacheable, which for a CDN means an origin hit every time.

Found it the honest way: verifying the freshly deployed feature on production with `curl -sI` reported the header as missing. It was missing — for `HEAD`. A `GET` to the same URL had it all along.

Also adds the regression test.