### PR TITLE
Recognize UKG and CatsOne boards in the shape their adapters crawl

### DIFF
--- a/internal/atsboard/board.go
+++ b/internal/atsboard/board.go
@@ -56,6 +56,12 @@ const (
 	// numeric institution id, so its localisation and section segments (/cw/en/search) are not
 	// boards — reading one as a board names an institution that does not exist.
 	modePathNumeric = "pathnumeric"
+	// hosttenantboard: board = "<host>/<tenant>/<guid>" from <host>/<tenant>/JobBoard/<guid>/….
+	// UKG addresses a board by all three: the host carries the data-residency TLD, the tenant is
+	// its customer code and the guid picks one of the tenant's boards. The adapter needs the same
+	// three (internal/sources/ukg.go), so anything less is not a shorter board id — it is one the
+	// crawl rejects outright.
+	modeHostTenantBoard = "hosttenantboard"
 )
 
 // atsBoards lists the supported multi-tenant ATS: a host (exact or subdomain-suffix match) →
@@ -79,7 +85,6 @@ var atsBoards = []struct{ host, source, mode string }{
 	{"careers.pageuppeople.com", "pageup", modePathNumeric},
 	{"oportunidades.mindsight.com.br", "mindsight", modePath},
 	{"careers.hireology.com", "hireology", modePath},
-	{"recruiting.ultipro.com", "ukg", modePath},
 	// Manatal's hosted career-page domain is PATH-based (careers-page.com/<tenant>/job/<id>),
 	// not a tenant subdomain, and its source is manatal: careerspage.yml is deliberately empty
 	// because every careers-page.com tenant is served by the Manatal adapter.
@@ -107,7 +112,6 @@ var atsBoards = []struct{ host, source, mode string }{
 	{"applicantpro.com", "applicantpro", modeSubdomain},
 	{"isolvedhire.com", "isolvedhire", modeSubdomain},
 	{"careerplug.com", "careerplug", modeSubdomain},
-	{"catsone.com", "catsone", modeSubdomain},
 	{"csod.com", "cornerstone", modeSubdomain},
 	{"enlizt.me", "enlizt", modeSubdomain},
 	{"hurma.work", "hurma", modeSubdomain},
@@ -128,9 +132,23 @@ var atsBoards = []struct{ host, source, mode string }{
 	{"teamtailor", "teamtailor", modeHost}, // <tenant>.teamtailor.com; custom-domain career sites are absent (not URL-derivable)
 	{"factorial", "factorial", modeHost},   // <tenant>.factorial.<tld>
 	{"factorialhr", "factorial", modeHost}, // the .com.br/.pt/… base-domain variant — ONE ingest adapter serves both, and it reports "factorial"
+	// CatsOne's adapter fetches https://<board>/careers, so the board is the whole host, exactly
+	// as catsone.yml stores it. It was listed as a subdomain, which yields the bare label — a
+	// board no crawl can resolve. (Its custom-domain tenants, e.g. jobs.evoplay.com.ua, stay
+	// underivable from a URL, like every other custom-domain ATS here.)
+	{"catsone", "catsone", modeHost},
 
 	// --- hostpath: board = "<host>/<site>" (Workday tenant host + first-path-segment site) ---
 	{"myworkdayjobs.com", "workday", modeHostPath},
+
+	// --- hosttenantboard: board = "<host>/<tenant>/<guid>" (UKG) ---
+	// All four host families, because the board id embeds the host: two US pods, the Canadian
+	// data-residency TLD, and the per-tenant rec.pro host. The catalogue holds 2166 boards on
+	// *.ultipro.com, 709 on *.rec.pro.ukg.net and 164 on *.ultipro.ca; a rule naming one host
+	// leaves the other three unrecognised.
+	{"ultipro.com", "ukg", modeHostTenantBoard},
+	{"ultipro.ca", "ukg", modeHostTenantBoard},
+	{"rec.pro.ukg.net", "ukg", modeHostTenantBoard},
 }
 
 // apiBoards lists each ATS's OWN API host, where the board sits behind a fixed path prefix
@@ -233,6 +251,26 @@ func Recognize(rawURL string) (source, board, canonical string, ok bool) {
 		u.RawQuery, u.Fragment = "", ""
 		u.Path = "/" + site
 		return src, host + "/" + site, u.String(), true
+
+	case modeHostTenantBoard:
+		// UKG: <host>/<tenant>/JobBoard/<guid>/… → board "<host>/<tenant>/<guid>". The literal
+		// "JobBoard" segment between the two is what proves the URL names a board at all; without
+		// it the path is some other part of the tenant's site (a login, an OpportunityDetail
+		// shortlink) and there is no guid to take. Declining is the only safe reading — the
+		// tenant alone is a board id the adapter rejects, and a rejected board still costs a
+		// contribution row and a crawl slot.
+		tenant, guid, ok := ukgTenantBoard(u)
+		if !ok {
+			return "", "", "", false
+		}
+		// Lower-cased: UKG answers either spelling (verified live against a real tenant, upper and
+		// lower, both 200) and every board in the catalogue is stored lower-case, so keeping a
+		// link's own casing would file a board we already crawl as a new one. This is the opposite
+		// of Workday above, whose site segment is a human-chosen name the ingest stores verbatim.
+		board = strings.ToLower(host + "/" + tenant + "/" + guid)
+		u.RawQuery, u.Fragment = "", ""
+		u.Path = "/" + tenant + "/JobBoard/" + guid
+		return src, board, u.String(), true
 
 	case modePathPortal:
 		// SmartRecruiters' Apply button leads to a one-click form under the product's own
@@ -409,6 +447,21 @@ var localeSegment = regexp.MustCompile(`^[a-z]{2}-[A-Za-z]{2}$`)
 // firstSegmentAfterLocale returns the first path segment that isn't a leading xx-XX locale — the
 // tenant board in ats.rippling.com/<locale?>/<board>/… (Rippling) or the site in a Workday
 // host/<locale?>/<site> URL. "" when the path is empty or carries only a locale.
+// ukgTenantBoard pulls the tenant and board guid out of a UKG path,
+// "<tenant>/JobBoard/<guid>[/…]". ok is false unless all three parts are present and in that
+// order: the "JobBoard" marker is the only thing that distinguishes a board URL from the rest
+// of a tenant's site, and both ids must be non-empty.
+func ukgTenantBoard(u *url.URL) (tenant, guid string, ok bool) {
+	segs := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(segs) < 3 || !strings.EqualFold(segs[1], "JobBoard") {
+		return "", "", false
+	}
+	if segs[0] == "" || segs[2] == "" {
+		return "", "", false
+	}
+	return segs[0], segs[2], true
+}
+
 func firstSegmentAfterLocale(u *url.URL) string {
 	p := strings.Trim(u.Path, "/")
 	if p == "" {

--- a/internal/atsboard/board_test.go
+++ b/internal/atsboard/board_test.go
@@ -100,8 +100,30 @@ func TestRecognize(t *testing.T) {
 		// Workday's public URL may prefix the site with an xx-XX locale the CXS API omits — skip it
 		{"workday locale-prefixed site", "https://gm.wd5.myworkdayjobs.com/en-US/Careers_GM/job/x/Eng_JR-1", "workday", "gm.wd5.myworkdayjobs.com/Careers_GM", "https://gm.wd5.myworkdayjobs.com/Careers_GM", true},
 
+		// CatsOne's adapter fetches "https://<board>/careers", so the board is the WHOLE host —
+		// the same shape catsone.yml stores. Reading the leftmost label instead handed back
+		// "authoritypartnersinc", which no crawl can resolve.
+		{"catsone vacancy", "https://authoritypartnersinc.catsone.com/careers/12345-senior-engineer", "catsone", "authoritypartnersinc.catsone.com", "https://authoritypartnersinc.catsone.com", true},
+		{"catsone board listing", "https://bfc.catsone.com/careers", "catsone", "bfc.catsone.com", "https://bfc.catsone.com", true},
+
+		// host+tenant+board mode — UKG: the board is "<host>/<tenant>/<guid>", the three parts
+		// the adapter needs to reach LoadSearchResults. The old rule took the first path segment
+		// alone, which the adapter rejects outright ("board must be <host>/<tenant>/<guid>"), and
+		// pinned one of the four host families. Codes are folded to lower case: UKG answers either
+		// spelling (verified live) and the catalogue holds them lower-case, so preserving a link's
+		// upper-case spelling would file a board we already crawl as a new one.
+		{"ukg vacancy", "https://recruiting.ultipro.com/AAL1000AIPSA/JobBoard/90e3e14e-26e3-46c0-affc-329a34699e20/OpportunityDetail?opportunityId=5d5", "ukg", "recruiting.ultipro.com/aal1000aipsa/90e3e14e-26e3-46c0-affc-329a34699e20", "https://recruiting.ultipro.com/AAL1000AIPSA/JobBoard/90e3e14e-26e3-46c0-affc-329a34699e20", true},
+		{"ukg board listing", "https://recruiting.ultipro.com/aam1000aam/JobBoard/c5a88c41-a6d1-4e5d-bf94-4d0432a0df30", "ukg", "recruiting.ultipro.com/aam1000aam/c5a88c41-a6d1-4e5d-bf94-4d0432a0df30", "https://recruiting.ultipro.com/aam1000aam/JobBoard/c5a88c41-a6d1-4e5d-bf94-4d0432a0df30", true},
+		{"ukg second us pod", "https://recruiting2.ultipro.com/abc1000abc/JobBoard/11111111-2222-3333-4444-555555555555/OpportunityDetail", "ukg", "recruiting2.ultipro.com/abc1000abc/11111111-2222-3333-4444-555555555555", "https://recruiting2.ultipro.com/abc1000abc/JobBoard/11111111-2222-3333-4444-555555555555", true},
+		{"ukg canadian residency host", "https://recruiting.ultipro.ca/CAN5000/JobBoard/1f3e7f92-2b60-4b8d-a893-c948a630e8a8", "ukg", "recruiting.ultipro.ca/can5000/1f3e7f92-2b60-4b8d-a893-c948a630e8a8", "https://recruiting.ultipro.ca/CAN5000/JobBoard/1f3e7f92-2b60-4b8d-a893-c948a630e8a8", true},
+		{"ukg per-tenant rec.pro host", "https://accessiblespace.rec.pro.ukg.net/acc1507asei/JobBoard/1f3e7f92-2b60-4b8d-a893-c948a630e8a8/OpportunityDetail?opportunityId=9", "ukg", "accessiblespace.rec.pro.ukg.net/acc1507asei/1f3e7f92-2b60-4b8d-a893-c948a630e8a8", "https://accessiblespace.rec.pro.ukg.net/acc1507asei/JobBoard/1f3e7f92-2b60-4b8d-a893-c948a630e8a8", true},
+
 		// declined
 		{"workday bare host no site", "https://generalmotors.wd5.myworkdayjobs.com", "", "", "", false},
+		// A UKG URL that names no board: the tenant alone is not enough for the adapter, so a
+		// tenant-only link must decline rather than hand back a board id the crawl will reject.
+		{"ukg tenant without a board guid", "https://recruiting.ultipro.com/AAL1000AIPSA", "", "", "", false},
+		{"ukg bare host", "https://recruiting.ultipro.com", "", "", "", false},
 		// a URL carrying only a locale has no derivable site — unrecognized, not a false "en-US" board
 		{"workday locale only no site", "https://salesforce.wd12.myworkdayjobs.com/en-US", "", "", "", false},
 		// Both halves of these were wrong before atsdetect.FromURL was folded into this table:

--- a/sources/catsone.yml
+++ b/sources/catsone.yml
@@ -10,3 +10,37 @@
   board: jobs.evoplay.com.ua
 - company: Sphere Partners
   board: sphereinc.catsone.com
+- company: 3 Key Consulting
+  board: 3kc.catsone.com
+- company: Avid Technology Professionals
+  board: atp.catsone.com
+- company: Astute Business Solutions
+  board: beastute.catsone.com
+- company: Brains Workgroup, Inc.
+  board: brainsworkgroup.catsone.com
+- company: Canidium
+  board: canidium.catsone.com
+- company: ClearFocus Technologies
+  board: clearfocustechnologies.catsone.com
+- company: CTL Information Technology
+  board: ctl.catsone.com
+- company: emergiTEL Inc.
+  board: emergitel.catsone.com
+- company: Health Information Partners
+  board: hipinc.catsone.com
+- company: Intermedia Group, Inc.
+  board: intermediagroup.catsone.com
+- company: Kappa Executive Search
+  board: kappaexecutive.catsone.com
+- company: KOMMLINk
+  board: kommlink.catsone.com
+- company: People Consulting
+  board: peopleconsult.catsone.com
+- company: Planet Green Search
+  board: planetgreen.catsone.com
+- company: The Class Consulting Group
+  board: theclass.catsone.com
+- company: The Timberline Group
+  board: timberlinegrp.catsone.com
+- company: Tygart Technology, Inc.
+  board: tygart1.catsone.com

--- a/sources/ukg.yml
+++ b/sources/ukg.yml
@@ -6082,3 +6082,119 @@
 # Plesk hires under its parent WebPros (Plesk/cPanel/WHMCS) on this shared UKG board. Validated
 # live (endpoint 200) but currently 0 open postings — the lone exception to the ">0" rule above;
 # ingests nothing until WebPros posts. Labelled Plesk so the eastern-roots `plesk` slug tags it.
+- company: Advarra
+  board: recruiting.ultipro.com/adv1023avr/6051d363-03fe-4650-945e-f836306a8388
+- company: African Wildlife Foundation
+  board: recruiting.ultipro.com/afr1000afwi/20e4eecc-c532-4e6a-bb5f-39ea79059f29
+- company: American Public University System
+  board: recruiting.ultipro.com/ame1070/711bd40f-864c-42db-8c62-3c62f2edc13f
+- company: A.N. Deringer.com
+  board: recruiting.ultipro.com/and1007ander/030925a7-6a27-6b61-9c69-34c22ddb7fab
+- company: Endicott Call Centers
+  board: recruiting.ultipro.com/ans1003afcc/6000f083-857a-4242-947e-27230e208453
+- company: Approved Freight Forwarders
+  board: recruiting.ultipro.com/app1009/ca517db5-89d4-4546-ae2f-cbbe6bad4e7d
+- company: Bettcher Industries
+  board: recruiting.ultipro.com/bet1004betin/8adef0ca-1e18-4acc-9274-130547589e57
+- company: CCC
+  board: recruiting.ultipro.com/cen1005/ebd4b8bf-6ccf-db23-e6da-f7f045a1f082
+- company: Center for Creative Leadership
+  board: recruiting.ultipro.com/cen1006creat/9ac7d5c8-232c-47ea-94cf-ab55ecf7fe02
+- company: CIBT
+  board: recruiting.ultipro.com/cib1001cbtho/651e26e3-d67c-4622-8ee3-62b19eab9aa9
+- company: UR Medicine Thompson Health
+  board: recruiting.ultipro.com/fft1000thm/a6bf8070-d222-4b6c-bd1f-330f8351d595
+- company: Flexco
+  board: recruiting.ultipro.com/fle1003flexc/9837c232-ff94-45f5-8a60-3affbd6b4188
+- company: 3form
+  board: recruiting.ultipro.com/for1014form/ee988aa9-dd8f-4537-ba47-6e668be45bca
+- company: Frontier Energy
+  board: recruiting.ultipro.com/gas1003/a652eb14-234e-2ca8-9351-cc65f383117a
+- company: Gen II
+  board: recruiting.ultipro.com/gen1035genfu/5731cfb1-dfc5-4fee-9796-9defe1582a54
+- company: Gray Television
+  board: recruiting.ultipro.com/gra1017gryt/ae441110-89bd-444d-8ad2-b76c7b9db7a9
+- company: Self Regional Healthcare
+  board: recruiting.ultipro.com/gre1050gnhp/2b67ecb4-00fb-4863-931a-7bf0ebcb493a
+- company: Gulfside Healthcare Services
+  board: recruiting.ultipro.com/gul1003gshc/42116aae-2a9b-421b-8c3f-f3c3e40ba037
+- company: Hollis Cobb Associates
+  board: recruiting.ultipro.com/hol1012hlcb/fff42a0c-0ef6-4123-a7c0-742b0c288290
+- company: Cognicion
+  board: recruiting.ultipro.com/hun1002hw/7f945dd0-7ef6-401f-aad1-d2db181a629e
+- company: Indelible Business Solutions
+  board: recruiting.ultipro.com/ind1018idbs/3a98c28a-7062-48c1-94d5-c02f29bf8eb0
+- company: IntraHealth International
+  board: recruiting.ultipro.com/int1028/e2116091-25aa-2eb8-64d2-db11ee75b469
+- company: Arrivia, Inc
+  board: recruiting.ultipro.com/int1043excur/ad5e5978-552f-4ef7-90c8-70ebb0a57994
+- company: IREX
+  board: recruiting.ultipro.com/int1065inre/86f30819-0126-446a-84bb-cf37a5e878c1
+- company: IAVI
+  board: recruiting.ultipro.com/int1086iavi/79d2b402-806e-448d-9abf-44b876cd43ee
+- company: ISCO Industries
+  board: recruiting.ultipro.com/isc1000isco/69fe5d40-cdc4-439c-8999-071e98297f88
+- company: LION
+  board: recruiting.ultipro.com/lio1001liog/d2d4e28b-6716-4955-9379-6890716c3ee7
+- company: MarshBerry
+  board: recruiting.ultipro.com/mar1036mbci/0127d5ea-e4e8-48ee-a74a-cc71dcd13133
+- company: NEPC, LLC
+  board: recruiting.ultipro.com/nep1001nepc/9b5186b6-746b-4df0-8522-90c2a5fcfa17
+- company: New Chapter
+  board: recruiting.ultipro.com/new1059nwch/2303fa88-cc71-464e-9bb7-929b7742757f
+- company: Visa Lighting
+  board: recruiting.ultipro.com/old1005ogin/ab89e154-d01d-482f-920e-be8693d2c335
+- company: OpSec Security
+  board: recruiting.ultipro.com/ops1000opsec/13a46332-5623-4cb6-8cc9-14dd28e1d2b6
+- company: ORNL Federal Credit Union
+  board: recruiting.ultipro.com/orn1000ornl/65362607-1ad7-45d8-a0c0-e176b1f92e4c
+- company: Partner ESI
+  board: recruiting.ultipro.com/par1017/fad04b97-00fa-bfd5-7029-ea0d0540ccf3
+- company: Cofense
+  board: recruiting.ultipro.com/phi1008pminc/2bfae9ff-dc34-4867-b871-a579eae69b54
+- company: Polen
+  board: recruiting.ultipro.com/pol1011polc/c5f932a4-d083-46c2-94a7-de31e39021c4
+- company: Questex
+  board: recruiting.ultipro.com/que1003qstx/5dcfdc99-74ef-40c7-803a-1e5bd5fefa87
+- company: New logo 2022
+  board: recruiting.ultipro.com/rad1005radiu/1e3a05c6-ec23-47fd-9831-8fcb9ed82568
+- company: Reagent
+  board: recruiting.ultipro.com/rea1015rcr/fb46ccb6-115e-477f-ad4f-f6efbec55fbb
+- company: Managed Health Care Associates, Inc.
+  board: recruiting.ultipro.com/rop1001roper/96d7c367-388f-4410-9b9a-b5b811a37825
+- company: Roper Pumps
+  board: recruiting.ultipro.com/rop1002ripic/4e0cc1ae-701f-49b2-91f8-a5fcfe1925e0
+- company: Safety National
+  board: recruiting.ultipro.com/saf1003sncc/eb5e6dcc-5a67-4833-b31e-f54b97ea0c3a
+- company: SaviLinx
+  board: recruiting.ultipro.com/sav1004svlnx/fe096e89-a9e3-4d3d-a9aa-cf4797884e3c
+- company: Charter Medical
+  board: recruiting.ultipro.com/sec1006tsgll/326e7e46-4c82-4d24-a854-16ccf4a8b2c6
+- company: SFM Mutual Insurance Company
+  board: recruiting.ultipro.com/sfm1001/ec93f271-092a-42be-b512-d3f64f8ab527
+- company: TechnoServe Inc.
+  board: recruiting.ultipro.com/tec1006teser/18180d88-ced0-4361-bd09-d5eef66dab24
+- company: Techmer PM
+  board: recruiting.ultipro.com/tec1011tpml/4e76433f-6af3-4f9a-8d94-ef4d96ad1501
+- company: InvestCloud
+  board: recruiting.ultipro.com/teg1001tegr/ad4204e8-c7f7-47f1-8177-c9f64730dccc
+- company: Titan Technologies
+  board: recruiting.ultipro.com/tel1010tefo/914e6c7a-35d4-4079-865a-b3a7e7758070
+- company: TNAA &amp; TotalMed
+  board: recruiting.ultipro.com/tra1015tnaa/2c7b9b40-f63f-4f66-9e04-20b2476fb5a4
+- company: Atlantic Union Bank
+  board: 'recruiting.ultipro.com/uni1046ufmb/d8f90aad-672e-4f0a-bbc1-a17aa8cf1111 '
+- company: Utica National Insurance Group
+  board: recruiting.ultipro.com/uti1000umic/0ae8178f-b389-4b3d-aaf4-e68b3756f2c7
+- company: Verdesian Life Sciences
+  board: recruiting.ultipro.com/ver1014vlsul/00042818-e26c-4f44-bef2-a2e36ee1e57a
+- company: True Rx Health Strategists
+  board: recruiting.ultipro.com/wil1019wbhcp/1f8973e1-9d49-4af6-bb26-5fdaa9f7d014
+- company: MarketLab
+  board: recruiting.ultipro.com/win1014windq/712ad02c-e865-4454-b2bd-4169a9068265
+- company: World Group
+  board: recruiting.ultipro.com/wor1017/258f2717-583b-e122-22b3-192fc0807b2d
+- company: World Education Services
+  board: recruiting.ultipro.com/wor1020wedu/e69cea0c-67ff-4625-8ec3-58d077d22d6b
+- company: Yaskawa Motoman
+  board: recruiting.ultipro.com/yas1000yaami/79c5e373-83ab-4894-be19-ed78fff999d4


### PR DESCRIPTION
## The bug

`atsboard` maps a job URL to `(source, board)`, and the board id it returns must be the one the
ingest adapter keys on. For two platforms it was not, so **every board discovered from a URL was
unusable** — recognized, recorded, then rejected by the crawl.

**UKG.** The adapter takes `<host>/<tenant>/<guid>` and refuses anything else
(`internal/sources/ukg.go`: `board %q must be <host>/<tenant>/<guid>`). The table used `path`
mode, which returns the first path segment — the tenant code alone, e.g. `ADV1023AVR`. It also
named a single host, `recruiting.ultipro.com`, where the catalogue actually holds:

| host family | boards |
|---|---:|
| `*.ultipro.com` | 2166 |
| `*.rec.pro.ukg.net` | 709 |
| `*.ultipro.ca` | 164 |

The other three were not recognized at all.

**CatsOne.** The adapter fetches `https://<board>/careers`, so the board is the whole host, which
is what `catsone.yml` stores (`authoritypartnersinc.catsone.com`). The table used `subdomain`
mode and returned the bare label.

## The fix

A `hosttenantboard` mode for UKG that reads `<host>/<tenant>/JobBoard/<guid>`. The literal
`JobBoard` segment is required: it is the only thing distinguishing a board URL from the rest of
a tenant's site, and without it there is no guid to take, so such a URL is declined rather than
turned into an id the crawl will reject.

The id is lower-cased. UKG answers either spelling — verified live against a real tenant, upper
and lower, both 200 — and every board in the catalogue is stored lower-case, so keeping a link's
own casing would file a board we already crawl as a new one. (This is the opposite of Workday
just above it, whose site segment is a human-chosen name the ingest stores verbatim — hence the
comment on each.)

CatsOne moves to `host` mode. Its custom-domain tenants (`jobs.evoplay.com.ua`) stay underivable
from a URL, like every other custom-domain ATS in this table.

## How it surfaced

The August 2026 website-walk harvest (#1963, #1982) proposed 87 UKG candidates and a handful of
CatsOne ones. Every one probed dead — not because the boards were dead, but because the ids were
never boards. Three platforms share the pattern and it is worth stating plainly: **a detector and
an adapter that disagree about the id shape fail silently**, as a harvest that finds nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job board recognition for UKG-hosted career sites across US, Canadian, and regional domains.
  * Added support for extracting UKG board identifiers from host and tenant paths, with consistent lowercase formatting.
  * Improved CatsOne board recognition using the complete host address.
  * Removed outdated recognition for unsupported UKG and CatsOne URL formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->