### PR TITLE
Tailor-confirm modal: drop footnote, always show skills+bar

### DIFF
--- a/extension/entrypoints/sidepanel/MatchCard.svelte
+++ b/extension/entrypoints/sidepanel/MatchCard.svelte
@@ -249,18 +249,15 @@
     <div class="confirm-body">
       <div class="confirm-section">
         <div class="confirm-label">Skills coverage</div>
-        {#if match.missing.length > 0}
-          <div class="confirm-row">
-            <span class="confirm-count">{match.matched.length} of {match.total} required skills</span>
-            <span class="confirm-pct {tone}">{pct}%</span>
-          </div>
-          <div class="bar"><div class="fill {tone}" style="width:{pct}%"></div></div>
-          <div class="chips">
-            {#each match.missing as s (s)}<span class="chip miss">{s}</span>{/each}
-          </div>
-        {:else}
-          <p class="confirm-clear"><Check class="icon-sm" />You match all {match.total} required skills</p>
-        {/if}
+        <div class="confirm-row">
+          <span class="confirm-count">{match.matched.length} of {match.total} required skills</span>
+          <span class="confirm-pct {tone}">{pct}%</span>
+        </div>
+        <div class="bar"><div class="fill {tone}" style="width:{pct}%"></div></div>
+        <div class="chips">
+          {#each match.matched as s (s)}<span class="chip good">{s}</span>{/each}
+          {#each match.missing as s (s)}<span class="chip miss">{s}</span>{/each}
+        </div>
       </div>
 
       {#if blockers.unmet.length > 0 || blockers.met.length > 0}
@@ -276,10 +273,6 @@
           </ul>
         </div>
       {/if}
-
-      <p class="confirm-footnote">
-        Deterministic check against your CV and profile — no AI used, no credit spent yet.
-      </p>
     </div>
 </ConfirmDialog>
 
@@ -611,15 +604,6 @@
   .confirm-pct.bad {
     color: var(--destructive);
   }
-  .confirm-clear {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 13px;
-    font-weight: 600;
-    color: var(--brand-strong);
-    margin: 0;
-  }
   .confirm-checklist {
     list-style: none;
     margin: 0;
@@ -643,12 +627,5 @@
   }
   .confirm-check.good :global(.icon-sm) {
     color: var(--brand-strong);
-  }
-  .confirm-footnote {
-    font-size: 11px;
-    color: var(--muted-foreground);
-    margin: 0;
-    padding-top: 4px;
-    border-top: 1px solid var(--border);
   }
 </style>

--- a/extension/entrypoints/sidepanel/MatchCard.svelte
+++ b/extension/entrypoints/sidepanel/MatchCard.svelte
@@ -255,8 +255,8 @@
         </div>
         <div class="bar"><div class="fill {tone}" style="width:{pct}%"></div></div>
         <div class="chips">
-          {#each match.matched as s (s)}<span class="chip good">{s}</span>{/each}
-          {#each match.missing as s (s)}<span class="chip miss">{s}</span>{/each}
+          {#each match.matched as s (s)}<span class="chip good" aria-label="{s} — you have this skill">{s}</span>{/each}
+          {#each match.missing as s (s)}<span class="chip miss" aria-label="{s} — missing">{s}</span>{/each}
         </div>
       </div>
 

--- a/web/src/lib/components/ConfirmTailorDialog.svelte
+++ b/web/src/lib/components/ConfirmTailorDialog.svelte
@@ -8,13 +8,14 @@
   // something looks off, so the check is a habit rather than a surprise.
   import { Check, TriangleAlert } from '@lucide/svelte';
   import { confirmTailorDialog, settleConfirmTailorDialog } from '$lib/confirmTailorDialog.svelte';
-  import { partitionBlockers, toneText, missingChipClass } from '$lib/jobMatch';
+  import { partitionBlockers, toneText, haveChipClass, missingChipClass } from '$lib/jobMatch';
   import { ConfirmDialog } from '$lib/ui';
 
   const match = $derived(confirmTailorDialog.match);
   const blockers = $derived(partitionBlockers(match?.blockers));
   const missing = $derived(match?.missing ?? []);
-  const matchedCount = $derived(match?.matched.length ?? 0);
+  const matched = $derived(match?.matched ?? []);
+  const matchedCount = $derived(matched.length);
   const total = $derived(match?.total ?? 0);
   const pct = $derived(match?.coverage_percent ?? 0);
   const hasGaps = $derived(missing.length > 0 || blockers.unmet.length > 0);
@@ -44,22 +45,20 @@
     <div class="flex flex-col gap-4">
       <div class="flex flex-col gap-1.5">
         <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Skills coverage</p>
-        {#if missing.length > 0}
-          <div class="flex items-baseline justify-between gap-2">
-            <span class="text-xs text-muted-foreground">{matchedCount} of {total} required skills</span>
-            <span class="text-sm font-bold tabular-nums">{pct}%</span>
-          </div>
-          <div class="h-1.5 overflow-hidden rounded bg-secondary">
-            <div class="h-full rounded bg-warning" style="width: {pct}%"></div>
-          </div>
-          <div class="flex flex-wrap gap-1.5">
-            {#each missing as skill (skill)}<span class={missingChipClass}>{skill}</span>{/each}
-          </div>
-        {:else}
-          <p class="flex items-center gap-1.5 text-sm font-medium text-brand-strong">
-            <Check class="size-4 shrink-0" aria-hidden="true" />You match all {total} required skills
-          </p>
-        {/if}
+        <div class="flex items-baseline justify-between gap-2">
+          <span class="text-xs text-muted-foreground">{matchedCount} of {total} required skills</span>
+          <span class="text-sm font-bold tabular-nums">{pct}%</span>
+        </div>
+        <div class="h-1.5 overflow-hidden rounded bg-secondary">
+          <div
+            class="h-full rounded {missing.length > 0 ? 'bg-warning' : 'bg-brand'}"
+            style="width: {pct}%"
+          ></div>
+        </div>
+        <div class="flex flex-wrap gap-1.5">
+          {#each matched as skill (skill)}<span class={haveChipClass}>{skill}</span>{/each}
+          {#each missing as skill (skill)}<span class={missingChipClass}>{skill}</span>{/each}
+        </div>
       </div>
 
       {#if blockers.unmet.length || blockers.met.length}
@@ -81,10 +80,6 @@
           </ul>
         </div>
       {/if}
-
-      <p class="rounded-md bg-muted px-2.5 py-2 text-xs text-muted-foreground">
-        Deterministic check against your CV and profile — no AI used, no credit spent yet.
-      </p>
     </div>
   {:else}
     <p class="text-sm text-muted-foreground">

--- a/web/src/lib/components/ConfirmTailorDialog.svelte
+++ b/web/src/lib/components/ConfirmTailorDialog.svelte
@@ -56,8 +56,12 @@
           ></div>
         </div>
         <div class="flex flex-wrap gap-1.5">
-          {#each matched as skill (skill)}<span class={haveChipClass}>{skill}</span>{/each}
-          {#each missing as skill (skill)}<span class={missingChipClass}>{skill}</span>{/each}
+          {#each matched as skill (skill)}
+            <span class={haveChipClass} aria-label="{skill} — you have this skill">{skill}</span>
+          {/each}
+          {#each missing as skill (skill)}
+            <span class={missingChipClass} aria-label="{skill} — missing">{skill}</span>
+          {/each}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Removes the "Deterministic check against your CV and profile — no AI used, no credit spent yet." footnote from both the extension (`MatchCard.svelte`) and web (`ConfirmTailorDialog.svelte`) confirm dialogs, per user request.
- Stops collapsing the Skills coverage section to a bare checkmark line on a full match — the coverage bar and skill chips now always show, including the matched skills (not just missing ones), consistent with the card's own always-visible match summary.
- Follow-up to #1980.

## Test plan
- [x] `cd extension && npm run check && npm run build` — clean
- [x] `cd web && npm run check` — clean (0 errors)
- [x] `cd web && npx vitest run` — 1005/1005 green
- [x] `cd extension && npx vitest run` — 267/267 green
- [x] Playwright-drove the real `MatchCard.svelte` component for both gaps-found and all-clear states — footnote gone, bar always renders, chip counts correct, no console errors, screenshot confirmed visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Tailoring confirmation dialogs now consistently display skills coverage, progress, matched skills, and missing skills.
  - Progress indicators visually distinguish between complete matches and remaining skill gaps.
  - Removed the redundant “You match all…” success message and confirmation footnote for a clearer experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->