### PR TITLE
Retry a refused workable/teamtailor request through the proxy

### DIFF
--- a/internal/sources/http.go
+++ b/internal/sources/http.go
@@ -193,9 +193,15 @@ type Client struct {
 	// (JobStream) throttle to a trickle, so a full window read takes minutes — far past the
 	// 15s httpClient timeout. Same SSRF-guarded transport, just patient.
 	streamClient *http.Client
-	userAgent    string
-	maxRetries   int
-	retryDelay   time.Duration
+	// refusalClient is an optional second transport used ONLY after the direct one has been
+	// refused (429/403). It exists because a refusal is the one failure a different egress IP
+	// can actually fix, and because the proxy behind it is a single shared IP: routing a whole
+	// crawl through it would concentrate the same burst on a weaker address and starve the
+	// providers that are genuinely IP-blocked. Nil for every client but the opted-in few.
+	refusalClient *http.Client
+	userAgent     string
+	maxRetries    int
+	retryDelay    time.Duration
 	// maxBody overrides maxResponseBody; zero means the default. Only tests set it, so a
 	// cap-trip case need not stream tens of MiB through the loopback.
 	maxBody int64
@@ -218,6 +224,19 @@ func NewClient() *Client { return newClientWithProxy(nil) }
 // URL — including its host and credentials — comes entirely from configuration
 // (SOURCES_PROXY_URL); no proxy endpoint is hardcoded here.
 func NewProxyClient(proxy *url.URL) *Client { return newClientWithProxy(proxy) }
+
+// NewRefusalRetryClient builds a client that crawls on the DIRECT IP and falls back to proxy
+// only for a request the platform refused (429/403). It suits a platform that serves the prod
+// IP perfectly well until our own hourly fleet floods it — measured on teamtailor, where a
+// direct request returns 200 on demand and yet 1207 of 1208 board failures fell inside the
+// crawl hour. Routing such a platform entirely through the proxy (NewProxyClient) would move
+// that same flood onto one shared address; sending it only what was already refused spends the
+// proxy on requests that are otherwise pure loss.
+func NewRefusalRetryClient(proxy *url.URL) *Client {
+	c := NewClient()
+	c.refusalClient = safehttp.NewClientWithProxy(15*time.Second, proxy)
+	return c
+}
 
 // newClientWithProxy builds a Client with an optional egress proxy (nil = direct).
 func newClientWithProxy(proxy *url.URL) *Client {
@@ -509,6 +528,12 @@ type request struct {
 func (c *Client) do(ctx context.Context, r request) error {
 	var lastErr error
 	delay := c.retryDelay
+	// refusalTried records that the fallback egress has had its one turn. A refusal says the
+	// platform is there and is declining THIS IP, so a second IP is worth exactly one try;
+	// spending more of a shared proxy on a request the platform is refusing anyway would take
+	// the budget from the providers that have no direct path at all.
+	refusalTried := false
+	client := c.httpClient
 	for attempt := 0; attempt <= c.maxRetries; attempt++ {
 		if attempt > 0 && delay > 0 {
 			select {
@@ -544,7 +569,7 @@ func (c *Client) do(ctx context.Context, r request) error {
 			req.Header.Set("Content-Type", contentType)
 		}
 
-		resp, err := c.httpClient.Do(req)
+		resp, err := client.Do(req)
 		if err != nil {
 			lastErr = err
 			continue // network error — transient
@@ -577,6 +602,16 @@ func (c *Client) do(ctx context.Context, r request) error {
 			delay = retryAfter(resp, c.retryDelay) // honor the rate-limit hint
 			resp.Body.Close()
 			lastErr = &StatusError{Method: r.method, Code: resp.StatusCode, URL: r.url}
+			if c.refusalClient != nil {
+				// Both egresses refusing is not a transient failure of either — it is the
+				// platform declining the request, and further attempts only spend a shared
+				// proxy budget that the IP-blocked providers have no alternative to.
+				if refusalTried {
+					return lastErr
+				}
+				c.switchToRefusalEgress(&client, &refusalTried)
+				delay = 0 // a fresh IP has no penalty to wait out
+			}
 			continue // rate limited — transient
 		case resp.StatusCode >= 500:
 			resp.Body.Close()
@@ -584,10 +619,32 @@ func (c *Client) do(ctx context.Context, r request) error {
 			continue // server error — transient
 		default:
 			resp.Body.Close()
-			return &StatusError{Method: r.method, Code: resp.StatusCode, URL: r.url}
+			lastErr = &StatusError{Method: r.method, Code: resp.StatusCode, URL: r.url}
+			// A 403 is final on this IP but not necessarily on another: it is the shape an edge
+			// uses to turn away an address it has judged, which is the one 4xx a different
+			// egress can fix. So it retries once through the fallback when there is one, and
+			// otherwise returns immediately exactly as before.
+			if resp.StatusCode == http.StatusForbidden && c.switchToRefusalEgress(&client, &refusalTried) {
+				delay = 0
+				continue
+			}
+			return lastErr
 		}
 	}
 	return fmt.Errorf("sources: %s %s failed after %d attempts: %w", r.method, r.url, c.maxRetries+1, lastErr)
+}
+
+// switchToRefusalEgress points client at the fallback transport for the remaining attempts,
+// once. It reports whether the switch happened, so the caller can drop the backoff it was
+// about to serve: the wait exists to let the refusing IP cool down, and the fallback is a
+// different IP that owes nothing.
+func (c *Client) switchToRefusalEgress(client **http.Client, tried *bool) bool {
+	if c.refusalClient == nil || *tried {
+		return false
+	}
+	*tried = true
+	*client = c.refusalClient
+	return true
 }
 
 // retryAfter is how long to wait before retrying a 429, honoring the response's

--- a/internal/sources/proxy.go
+++ b/internal/sources/proxy.go
@@ -89,6 +89,26 @@ var proxiedProviders = map[string]func(HTTPClient) Source{
 	"wantedkr": func(c HTTPClient) Source { return NewWantedKR(c) },
 }
 
+// refusalRetryProviders is the second, weaker opt-in: providers that crawl on the DIRECT IP
+// and reach for the proxy only on a request the platform refused. proxiedProviders above is for
+// an IP that is blocked outright — there the direct path never works, so everything must egress
+// through the proxy. These two are the opposite case: the direct IP is served normally, and the
+// refusals are ours, produced by the hourly fleet's own burst.
+//
+// Measured on prod 2026-08-16: a direct request to a "failing" teamtailor board returned 200 on
+// demand, and 1207 of 1208 teamtailor board failures carried an error timestamp inside the
+// current crawl hour. Workable is the same shape one status code over (429 rather than 403),
+// and both grew by ~500 boards in the August harvest, so the burst is getting worse.
+//
+// Why not route them through the proxy wholesale: it is a single shared address (verified — six
+// calls, one exit IP), and it is what eightfold, djinni, 2gis and hh have INSTEAD of a direct
+// path. Moving ~3000 boards an hour onto it would concentrate the same burst on a weaker IP and
+// take the budget from the providers with nowhere else to go.
+var refusalRetryProviders = map[string]func(HTTPClient) Source{
+	"workable":   func(c HTTPClient) Source { return NewWorkable(c) },
+	"teamtailor": func(c HTTPClient) Source { return NewTeamtailor(c) },
+}
+
 // IsProxied reports whether provider is on the proxied-egress allowlist — the providers
 // ApplyProxyEgress routes through SOURCES_PROXY_URL. Callers outside the board crawl (the
 // single-URL resolve path in cmd/resolve-url) use it to route the same providers through
@@ -118,6 +138,14 @@ func ApplyProxyEgress(registry map[string]Source) error {
 	for name, build := range proxiedProviders {
 		if _, ok := registry[name]; ok {
 			registry[name] = build(proxied)
+		}
+	}
+	// The refusal-retry providers keep the direct IP and get the proxy only for what it turned
+	// away, so they are rewired over a different client than the wholly-proxied ones above.
+	refusalRetry := NewRefusalRetryClient(u)
+	for name, build := range refusalRetryProviders {
+		if _, ok := registry[name]; ok {
+			registry[name] = build(refusalRetry)
 		}
 	}
 	// Fingerprint-proxied providers need BOTH the Chrome fingerprint and the proxy IP, so they

--- a/internal/sources/proxyretry_test.go
+++ b/internal/sources/proxyretry_test.go
@@ -1,0 +1,148 @@
+package sources
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// rewriteTransport sends every request to base whatever URL was asked for, which is how these
+// tests stand in for "this transport egresses somewhere else" without running a real proxy.
+type rewriteTransport struct{ base *url.URL }
+
+func (t rewriteTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	r = r.Clone(r.Context())
+	r.URL.Scheme, r.URL.Host = t.base.Scheme, t.base.Host
+	return http.DefaultTransport.RoundTrip(r)
+}
+
+// twoWayClient builds a Client whose direct transport goes to direct and whose refusal
+// fallback goes to fallback, with no backoff so the tests stay fast.
+func twoWayClient(t *testing.T, direct, fallback *httptest.Server) *Client {
+	t.Helper()
+	du, err := url.Parse(direct.URL)
+	if err != nil {
+		t.Fatalf("parse direct: %v", err)
+	}
+	c := &Client{
+		httpClient: &http.Client{Transport: rewriteTransport{du}, Timeout: 5 * time.Second},
+		userAgent:  "test",
+		maxRetries: 2,
+		retryDelay: 0,
+	}
+	if fallback != nil {
+		fu, err := url.Parse(fallback.URL)
+		if err != nil {
+			t.Fatalf("parse fallback: %v", err)
+		}
+		c.refusalClient = &http.Client{Transport: rewriteTransport{fu}, Timeout: 5 * time.Second}
+	}
+	return c
+}
+
+func countingServer(t *testing.T, status int, body string, hits *atomic.Int64) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+// A 429 from the direct IP is the case this exists for: the platform is there and is declining
+// this IP's volume, so the retry goes out through the proxy instead of hammering the same IP.
+func TestRefusalRetryUsesFallbackOn429(t *testing.T) {
+	var directHits, fallbackHits atomic.Int64
+	direct := countingServer(t, http.StatusTooManyRequests, "", &directHits)
+	fallback := countingServer(t, http.StatusOK, `{"ok":true}`, &fallbackHits)
+
+	var out struct {
+		OK bool `json:"ok"`
+	}
+	if err := twoWayClient(t, direct, fallback).GetJSON(context.Background(), "https://board.example/x", &out); err != nil {
+		t.Fatalf("GetJSON: %v", err)
+	}
+	if !out.OK {
+		t.Error("decoded body did not come from the fallback")
+	}
+	if got := fallbackHits.Load(); got != 1 {
+		t.Errorf("fallback hits = %d, want 1", got)
+	}
+	if got := directHits.Load(); got != 1 {
+		t.Errorf("direct hits = %d, want 1 — the direct IP must not be retried once it is refusing", got)
+	}
+}
+
+// A 403 is normally final and returns at once. With a fallback it is worth exactly one more
+// try from a different IP, because that is precisely the shape of an IP-reputation refusal.
+func TestRefusalRetryUsesFallbackOn403(t *testing.T) {
+	var directHits, fallbackHits atomic.Int64
+	direct := countingServer(t, http.StatusForbidden, "", &directHits)
+	fallback := countingServer(t, http.StatusOK, `{"ok":true}`, &fallbackHits)
+
+	var out struct {
+		OK bool `json:"ok"`
+	}
+	if err := twoWayClient(t, direct, fallback).GetJSON(context.Background(), "https://board.example/x", &out); err != nil {
+		t.Fatalf("GetJSON: %v", err)
+	}
+	if got := fallbackHits.Load(); got != 1 {
+		t.Errorf("fallback hits = %d, want 1", got)
+	}
+}
+
+// Without a fallback a 403 must behave exactly as before — returned immediately, not retried.
+// This is what keeps the change inert for every provider that is not opted in.
+func TestNoFallbackLeaves403Final(t *testing.T) {
+	var directHits atomic.Int64
+	direct := countingServer(t, http.StatusForbidden, "", &directHits)
+
+	var out struct{}
+	err := twoWayClient(t, direct, nil).GetJSON(context.Background(), "https://board.example/x", &out)
+	if err == nil {
+		t.Fatal("GetJSON succeeded, want a 403 error")
+	}
+	if got := directHits.Load(); got != 1 {
+		t.Errorf("direct hits = %d, want 1 — a 403 is final without a fallback", got)
+	}
+}
+
+// The proxy is the expensive path (one shared IP), so it must stay untouched while the direct
+// IP is being served.
+func TestFallbackUnusedWhenDirectSucceeds(t *testing.T) {
+	var directHits, fallbackHits atomic.Int64
+	direct := countingServer(t, http.StatusOK, `{"ok":true}`, &directHits)
+	fallback := countingServer(t, http.StatusOK, `{"ok":false}`, &fallbackHits)
+
+	var out struct {
+		OK bool `json:"ok"`
+	}
+	if err := twoWayClient(t, direct, fallback).GetJSON(context.Background(), "https://board.example/x", &out); err != nil {
+		t.Fatalf("GetJSON: %v", err)
+	}
+	if got := fallbackHits.Load(); got != 0 {
+		t.Errorf("fallback hits = %d, want 0", got)
+	}
+}
+
+// A fallback that is refused too must not loop: the whole point of the budget is that the
+// proxy IP is a shared, limited resource.
+func TestFallbackTriedOnlyOnce(t *testing.T) {
+	var directHits, fallbackHits atomic.Int64
+	direct := countingServer(t, http.StatusTooManyRequests, "", &directHits)
+	fallback := countingServer(t, http.StatusTooManyRequests, "", &fallbackHits)
+
+	var out struct{}
+	if err := twoWayClient(t, direct, fallback).GetJSON(context.Background(), "https://board.example/x", &out); err == nil {
+		t.Fatal("GetJSON succeeded, want a rate-limit error")
+	}
+	if got := fallbackHits.Load(); got != 1 {
+		t.Errorf("fallback hits = %d, want 1 — the shared proxy IP gets one try, not every retry", got)
+	}
+}

--- a/internal/sources/proxyretry_wiring_test.go
+++ b/internal/sources/proxyretry_wiring_test.go
@@ -1,0 +1,61 @@
+package sources
+
+import (
+	"testing"
+)
+
+// The two allowlists must stay disjoint: a provider in both would be rewired twice, and the
+// wholly-proxied build would win by ordering rather than by decision — silently moving a whole
+// crawl onto the shared proxy IP, which is the thing the refusal-retry list exists to avoid.
+func TestRefusalRetryAndProxiedAllowlistsAreDisjoint(t *testing.T) {
+	for name := range refusalRetryProviders {
+		if _, both := proxiedProviders[name]; both {
+			t.Errorf("%q is in both proxiedProviders and refusalRetryProviders; pick one — "+
+				"wholly proxied (the direct IP is blocked) or refusal-retry (the direct IP works)", name)
+		}
+	}
+}
+
+// Every allowlisted name must be a real provider key, or the entry is inert and the platform
+// keeps failing while the file claims it is handled.
+func TestRefusalRetryProvidersAreRegistered(t *testing.T) {
+	registry := Taxonomy()
+	for name := range refusalRetryProviders {
+		if _, ok := registry[name]; !ok {
+			t.Errorf("refusalRetryProviders has %q, which is not a registered provider", name)
+		}
+	}
+}
+
+// ApplyProxyEgress must rewire the refusal-retry providers too. Without this the allowlist is
+// documentation: the adapters keep the plain client and never reach the proxy at all.
+func TestApplyProxyEgressRewiresRefusalRetryProviders(t *testing.T) {
+	t.Setenv("SOURCES_PROXY_URL", "http://user:pass@proxy.example:8080")
+	registry := All(NewClient())
+	before := registry["teamtailor"]
+
+	if err := ApplyProxyEgress(registry); err != nil {
+		t.Fatalf("ApplyProxyEgress: %v", err)
+	}
+	if registry["teamtailor"] == before {
+		t.Error("teamtailor was not rewired; it still crawls on the client it was built with")
+	}
+	if got := registry["teamtailor"].Provider(); got != "teamtailor" {
+		t.Errorf("rewired provider = %q, want teamtailor", got)
+	}
+}
+
+// With no proxy configured the wiring must be a no-op, so local and dev runs behave exactly as
+// they did — direct, with a 403 still final.
+func TestApplyProxyEgressWithoutProxyLeavesRefusalRetryProvidersAlone(t *testing.T) {
+	t.Setenv("SOURCES_PROXY_URL", "")
+	registry := All(NewClient())
+	before := registry["workable"]
+
+	if err := ApplyProxyEgress(registry); err != nil {
+		t.Fatalf("ApplyProxyEgress: %v", err)
+	}
+	if registry["workable"] != before {
+		t.Error("workable was rewired with no proxy configured")
+	}
+}


### PR DESCRIPTION
## What the failures actually are

Not a block. Measured on prod:

- a direct request to a "failing" teamtailor board returns **200 on demand**, right now;
- **1207 of 1208** teamtailor board failures carry an error timestamp inside the current crawl
  hour;
- workable is the same shape one status code over — 429 rather than 403.

So the platforms serve our IP fine and refuse it only while our own hourly fleet floods them.
Both files grew by ~500 boards in the August harvest (#1963, #1982), so the burst is getting
worse, not better.

## What this does

`Client` gains an optional second transport used **only after the direct one is refused**:

- a **429** switches to it immediately, dropping the backoff — that wait exists to let the
  refusing IP cool down, and the fallback is a different IP that owes nothing;
- a **403**, normally final, is worth exactly one try from another address, because that is the
  shape an edge uses to turn away an address it has judged;
- the fallback gets **one turn, not every retry**. If it is refused too the call returns, rather
  than spending more of a shared budget on a request the platform is declining anyway.

`workable` and `teamtailor` are opted in through a second allowlist next to `proxiedProviders`.

## Why not just proxy them

That was the first instinct and the evidence argues against it. `SOURCES_PROXY_URL` is a
**single shared address** — six calls, one exit IP — and it is what eightfold, djinni, 2gis and
hh have *instead of* a direct path. Routing ~3000 boards an hour through it would concentrate
the same burst on a weaker IP and take the budget from the providers with nowhere else to go.
Sending it only what was already refused spends the proxy on requests that are otherwise pure
loss.

The two allowlists mean different things and a test keeps them disjoint: `proxiedProviders` is
"the direct IP is blocked, everything must egress through the proxy"; `refusalRetryProviders` is
"the direct IP works, borrow another one when it is turned away".

## Safety

Inert without `SOURCES_PROXY_URL`: no fallback client is built, and a 403 stays final exactly as
before, so local and dev runs are unchanged. Covered by tests for each branch — 429 falls back,
403 falls back, 403 without a fallback stays final, a succeeding direct call never touches the
proxy, and the fallback is tried once.