### PR TITLE
Confine the browse preset and agent-driven autofill to the extension's own connection

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -105,7 +105,7 @@ Every facet below supports repeat-OR, `_mode=and`, and `_exclude` as described a
 | `countries` | Countries | Open vocabulary — call /jobs/facets for live values |
 | `cities` | City | Open vocabulary — call /jobs/facets for live values |
 | `relocation` | Relocation | not_supported, supported, required |
-| `employment_type` | Employment | full_time, part_time, contract, internship |
+| `employment_type` | Employment | full_time, part_time, contract, internship, fellowship |
 | `english_level` | English | none, a1, a2, b1, b2, c1, c2, native |
 | `posting_language` | Job language | Open vocabulary — call /jobs/facets for live values |
 | `reality` | Posting reality | fresh, stale, likely-evergreen |
@@ -1229,7 +1229,6 @@ curl "https://freehire.me/api/v1/me/tracking/pipeline" -H "Authorization: Bearer
   "data": {
     "applications": 12,
     "stages": {
-      "preparing": 0,
       "applied": 4,
       "screening": 2,
       "responded": 1,
@@ -1237,8 +1236,7 @@ curl "https://freehire.me/api/v1/me/tracking/pipeline" -H "Authorization: Bearer
       "offer": 1,
       "accepted": 1,
       "rejected": 1,
-      "withdrawn": 0,
-      "expired": 0
+      "withdrawn": 0
     }
   }
 }
@@ -2294,14 +2292,14 @@ curl "https://freehire.me/api/v1/me/autofill-profile" -H "Authorization: Bearer 
 
 ### `POST /me/autofill/run`
 
-**Auth:** Session or API key
+**Auth:** Browser extension only
 
 Drive your own browser to fill an application form.
 
-Runs the autofill agent over the browser-tool wire — your extension on one end, the agent on the other, routed strictly within your own channel. Requires the extension to be connected.
+Runs the autofill agent over the browser-tool wire — your extension on one end, the agent on the other, routed strictly within your own channel. Requires the extension to be connected, and authenticates only as the extension itself — a session cookie or an API key gets a 403, since this call writes into whatever form your browser has open, not just reads it.
 
 ```bash
-curl -X POST "https://freehire.me/api/v1/me/autofill/run" -H "Authorization: Bearer fhk_…"
+curl -X POST "https://freehire.me/api/v1/me/autofill/run" -H "Authorization: Bearer <extension session token>"
 ```
 
 ```json

--- a/internal/assistant/AGENTS.md
+++ b/internal/assistant/AGENTS.md
@@ -249,14 +249,22 @@ to `other`. The worker sanitizes because it persists raw model output derived fr
 attacker's body; the tool carries a judgement the candidate asked for, and silently
 rewriting it would record a verdict nobody chose.
 
-A `browse` session is one held from the browser extension. It is the only preset whose
-agent can see something outside this process: `read_current_page` attaches to the
-caller's browser-tool channel (`internal/browsertools`) as an in-process harness for the
-length of one call, the same way `/me/autofill/run` does. That tool is deliberately
-absent from every other preset — nothing is attached to their channel, and a tool that
-can only fail teaches the model to stop calling tools. Reaching no browser is a tool
-error naming the remedy, never a failed turn; the call carries its own deadline, because
-it is the only tool whose completion depends on a client we do not control.
+A `browse` session is meant to be held from the browser extension, but the preset
+recorded on the session does not by itself prove that: `internal/browsertools.Hub` is
+keyed by user id, not session id, so a browse session reached any other way would still
+find a browser attached the moment the caller's extension is open elsewhere. The
+`preset` a turn's request carries is therefore not the last word — `effectivePreset`
+(`internal/handler/assistant.go`) demotes a browse session to plain chat, for BOTH the
+prompt and the tool set, unless the turn itself authenticated as the extension's own
+Bearer session JWT (`auth.ViaCookie`/`auth.ViaAPIKey` both false). Only a session that
+clears that gate is the one preset whose agent can see something outside this process:
+`read_current_page` attaches to the caller's browser-tool channel (`internal/browsertools`)
+as an in-process harness for the length of one call, the same way `/me/autofill/run`
+does. That tool is deliberately absent from every other preset, and from a browse turn
+that fails the carrier check — nothing is attached to their channel, and a tool that can
+only fail teaches the model to stop calling tools. Reaching no browser is a tool error
+naming the remedy, never a failed turn; the call carries its own deadline, because it is
+the only tool whose completion depends on a client we do not control.
 
 **History trimming.** `trim` keeps the most recent N messages and then drops any
 leading tool results whose originating call was trimmed away — providers reject a

--- a/internal/assistant/store.go
+++ b/internal/assistant/store.go
@@ -23,8 +23,12 @@ const (
 	// PresetProfile is the experience interviewer: the same tools as a chat session, and a
 	// prompt that goes looking for what the bank does not yet know.
 	PresetProfile = "profile"
-	// PresetBrowse is a conversation held from the browser extension's side panel.
-	// It is the only preset whose agent can see the page the candidate is on.
+	// PresetBrowse is a conversation meant to be held from the browser extension's
+	// side panel. It is the only preset whose agent can EVER see the page the
+	// candidate is on — but only when the turn itself authenticated as the
+	// extension's own Bearer session JWT; reached any other way (a stale rail entry,
+	// an API key) it runs as a plain chat instead. See internal/handler's
+	// effectivePreset and internal/assistant/AGENTS.md.
 	PresetBrowse = "browse"
 	// PresetInterview is the mock interview held against one application. Like a
 	// tailoring session it is bound to a vacancy, but to no CV: it reads the CV and

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -25,6 +25,13 @@ const localsViaAPIKey = "auth.viaAPIKey"
 // are unscoped by construction — a browser session is the owner themselves.
 const localsKeyScope = "auth.keyScope"
 
+// localsViaCookie is set true whenever the request authenticated with the website's own
+// session cookie, as opposed to a Bearer credential (a session JWT — the browser
+// extension's carrier — or an API key). Handlers read it via ViaCookie to confine a
+// capability to the extension's own connection, the same way localsViaAPIKey narrows one
+// to a programmatic caller.
+const localsViaCookie = "auth.viaCookie"
+
 // Scopes an API key can carry. ScopeFull is everything a key may do and is what a
 // user-created key gets; ScopeCV is the CV surface a tailoring agent needs and nothing
 // else, so a credential handed to an external agent cannot reach the rest of the account.
@@ -46,6 +53,30 @@ func ViaAPIKey(c *fiber.Ctx) bool {
 func KeyScope(c *fiber.Ctx) string {
 	scope, _ := c.Locals(localsKeyScope).(string)
 	return scope
+}
+
+// ViaCookie reports whether the request authenticated via the website's session cookie,
+// as opposed to a Bearer credential. False for a Bearer session JWT, false for an API
+// key, and false for a request that did not pass through RequireAuth or
+// RequireAuthOrScopedKey.
+func ViaCookie(c *fiber.Ctx) bool {
+	via, _ := c.Locals(localsViaCookie).(bool)
+	return via
+}
+
+// IsExtensionBearer reports whether the request authenticated as a Bearer session
+// JWT — neither the website's cookie nor an API key. That carrier is the browser
+// extension's own: it holds the session JWT the connect flow minted and presents it
+// as a Bearer header because a browser cannot send a cross-origin cookie.
+//
+// This is the single definition every caller that must confine a capability to the
+// extension's own connection shares (the assistant's browse-preset page tool,
+// agent-driven autofill — both reach a browser-tool channel keyed by user id, not by
+// how the request that reached it authenticated). Re-deriving "not cookie, not API
+// key" inline at each call site is exactly the kind of duplication that drifts the
+// moment one of them is edited and the other is not.
+func IsExtensionBearer(c *fiber.Ctx) bool {
+	return !ViaCookie(c) && !ViaAPIKey(c)
 }
 
 type sessionResult int
@@ -81,6 +112,7 @@ func RequireAuth(iss *Issuer, versions TokenVersionLoader) fiber.Handler {
 			return fiber.NewError(fiber.StatusUnauthorized, "invalid or expired session")
 		}
 		c.Locals(LocalsUserID, id)
+		c.Locals(localsViaCookie, true)
 		return c.Next()
 	}
 }
@@ -174,6 +206,7 @@ func RequireAuthOrScopedKey(iss *Issuer, versions TokenVersionLoader, keys APIKe
 			id, res, _ := resolveSession(c, iss, versions, token)
 			if res == sessionOK {
 				c.Locals(LocalsUserID, id)
+				c.Locals(localsViaCookie, true)
 				return c.Next()
 			}
 			if res == sessionInfraError {

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -22,7 +22,7 @@ func protectedApp(iss *Issuer) *fiber.App {
 		if !ok {
 			return fiber.NewError(fiber.StatusInternalServerError, "user id missing from context")
 		}
-		return c.JSON(fiber.Map{"id": id})
+		return c.JSON(fiber.Map{"id": id, "via_cookie": ViaCookie(c)})
 	})
 	return app
 }
@@ -54,6 +54,32 @@ func TestRequireAuth_ValidTokenGrantsAccessAndPropagatesID(t *testing.T) {
 	}
 	if body.ID != 7 {
 		t.Errorf("handler saw user id %d, want 7", body.ID)
+	}
+}
+
+// The extension gates read_current_page on this flag (see the
+// confine-browse-preset-to-extension change): ViaCookie must be true for the
+// website's own carrier so the tool stays confined to the extension's Bearer JWT.
+func TestRequireAuth_FlagsCookieAuth(t *testing.T) {
+	iss := NewIssuer("secret", time.Hour)
+	token, _ := iss.Issue(7, 1)
+
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me", nil)
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: token})
+
+	resp, err := protectedApp(iss).Test(req)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	defer resp.Body.Close()
+	var body struct {
+		ViaCookie bool `json:"via_cookie"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.ViaCookie {
+		t.Error("ViaCookie should be true for RequireAuth's cookie path")
 	}
 }
 

--- a/internal/auth/requireauthorkey_test.go
+++ b/internal/auth/requireauthorkey_test.go
@@ -47,7 +47,7 @@ func dualAuthApp(iss *Issuer, keys APIKeyAuthenticator) *fiber.App {
 		if !ok {
 			return fiber.NewError(fiber.StatusInternalServerError, "user id missing from context")
 		}
-		return c.JSON(fiber.Map{"id": id, "via_key": ViaAPIKey(c)})
+		return c.JSON(fiber.Map{"id": id, "via_key": ViaAPIKey(c), "via_cookie": ViaCookie(c), "is_extension": IsExtensionBearer(c)})
 	})
 	return app
 }
@@ -146,6 +146,128 @@ func TestRequireAuthOrKey_ValidCookieAuthenticates(t *testing.T) {
 	}
 	if id := decodeID(t, resp); id != 7 {
 		t.Errorf("handler saw user id %d, want 7", id)
+	}
+}
+
+func decodeViaCookie(t *testing.T, resp *http.Response) bool {
+	t.Helper()
+	var body struct {
+		ViaCookie bool `json:"via_cookie"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return body.ViaCookie
+}
+
+// ViaCookie is the signal `read_current_page`'s registration gates on (see the
+// confine-browse-preset-to-extension change): the website authenticates by cookie,
+// so a browse session reached from there must not read as the extension's own
+// Bearer-JWT carrier.
+func TestRequireAuthOrKey_FlagsCookieAuth(t *testing.T) {
+	iss := NewIssuer("secret", time.Hour)
+	token, _ := iss.Issue(7, 1)
+
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me", nil)
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: token})
+
+	resp, err := dualAuthApp(iss, fakeKeyAuth{}).Test(req)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	defer resp.Body.Close()
+	if !decodeViaCookie(t, resp) {
+		t.Error("ViaCookie should be true for cookie auth")
+	}
+}
+
+func TestRequireAuthOrKey_JWTBearerIsNotViaCookie(t *testing.T) {
+	iss := NewIssuer("secret", time.Hour)
+	token, _ := iss.Issue(42, 1) // a session JWT presented as a Bearer header, as the extension does
+	keys := fakeKeyAuth{}        // no valid API key — the JWT must carry the identity
+
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := dualAuthApp(iss, keys).Test(req)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	defer resp.Body.Close()
+	if decodeViaCookie(t, resp) {
+		t.Error("ViaCookie should be false for a Bearer session JWT — the extension's own carrier")
+	}
+}
+
+func TestRequireAuthOrKey_APIKeyIsNotViaCookie(t *testing.T) {
+	iss := NewIssuer("secret", time.Hour)
+	const token = "fhk_test-key"
+	keys := fakeKeyAuth{validHash: HashAPIKey(token), userID: 9}
+
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := dualAuthApp(iss, keys).Test(req)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	defer resp.Body.Close()
+	if decodeViaCookie(t, resp) {
+		t.Error("ViaCookie should be false for an API key")
+	}
+}
+
+func decodeIsExtension(t *testing.T, resp *http.Response) bool {
+	t.Helper()
+	var body struct {
+		IsExtension bool `json:"is_extension"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return body.IsExtension
+}
+
+// IsExtensionBearer is the single primitive every caller that must confine a
+// capability to the extension's own connection shares (the assistant's browse
+// preset, agent-driven autofill) — rather than each re-deriving "not cookie, not
+// API key" inline, which is easy to phrase differently at each call site and drift.
+// See the confine-browse-preset-to-extension change.
+func TestIsExtensionBearer_TrueOnlyForTheSessionJWT(t *testing.T) {
+	iss := NewIssuer("secret", time.Hour)
+	const apiKey = "fhk_test-key"
+	keys := fakeKeyAuth{validHash: HashAPIKey(apiKey), userID: 9}
+	cookieToken, _ := iss.Issue(7, 1)
+	jwtBearerToken, _ := iss.Issue(42, 1)
+
+	cases := []struct {
+		name   string
+		cookie string // "" = no cookie
+		bearer string // "" = no Authorization header
+		want   bool
+	}{
+		{"cookie", cookieToken, "", false},
+		{"API key", "", apiKey, false},
+		{"Bearer session JWT — the extension's own carrier", "", jwtBearerToken, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me", nil)
+			if tc.cookie != "" {
+				req.AddCookie(&http.Cookie{Name: CookieName, Value: tc.cookie})
+			}
+			if tc.bearer != "" {
+				req.Header.Set("Authorization", "Bearer "+tc.bearer)
+			}
+			resp, err := dualAuthApp(iss, keys).Test(req)
+			if err != nil {
+				t.Fatalf("Test: %v", err)
+			}
+			defer resp.Body.Close()
+			if got := decodeIsExtension(t, resp); got != tc.want {
+				t.Errorf("IsExtensionBearer = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/db/assistant.sql.go
+++ b/internal/db/assistant.sql.go
@@ -157,7 +157,7 @@ func (q *Queries) GetAssistantSession(ctx context.Context, arg GetAssistantSessi
 const listAssistantChatSessions = `-- name: ListAssistantChatSessions :many
 SELECT id, user_id, preset, label, cv_id, job_id, created_at, updated_at
 FROM assistant_sessions
-WHERE user_id = $1 AND preset IN ('chat', 'profile', 'browse', 'interview', 'debrief')
+WHERE user_id = $1 AND preset IN ('chat', 'profile', 'interview', 'debrief')
 ORDER BY updated_at DESC, id DESC
 `
 
@@ -175,18 +175,23 @@ type ListAssistantChatSessionsRow struct {
 // The caller's session rail: their unbound conversations, most recently active first.
 // Owner-scoped by construction — another user's sessions can never appear.
 //
-// The rail carries every conversation that can be continued on its own: chat, profile,
-// browse, interview and debrief alike. An experience interview is resumable and would
-// otherwise be lost the moment its author navigated away; a browsing conversation begun in
-// the extension's side panel is one the candidate can pick up at their desk, where it
-// simply cannot see a page any more; a rehearsal is opened days before the interview and
-// closed again, and a debrief is written in one sitting and reread before the next round.
+// The rail carries every conversation that works when reopened here: chat, profile,
+// interview and debrief alike. An experience interview is resumable and would otherwise
+// be lost the moment its author navigated away; a rehearsal is opened days before the
+// interview and closed again, and a debrief is written in one sitting and reread before
+// the next round.
 //
 // A rehearsal and a debrief are bound to a vacancy, so the test is not "binds to nothing"
 // — it is whether the conversation still works when reopened from here. It does: their
-// context tool closes over the vacancy id the session already carries. Tailoring
-// conversations are excluded for exactly that reason inverted — they belong to the CV that
-// owns them, are reached through the tailoring workspace, and cannot be continued without it.
+// context tool closes over the vacancy id the session already carries.
+//
+// Tailoring conversations are excluded because they belong to the CV that owns them and
+// are reached through the tailoring workspace, not this rail. Browsing conversations are
+// excluded for a sharper reason: read_current_page — the one tool that makes a browsing
+// session worth having — only works over the extension's own connection, so listing one
+// here would offer a chat that silently loses its distinguishing capability the moment it
+// is opened. It stays reachable from the extension, which holds its id directly rather
+// than listing it. See the confine-browse-preset-to-extension change.
 func (q *Queries) ListAssistantChatSessions(ctx context.Context, userID int64) ([]ListAssistantChatSessionsRow, error) {
 	rows, err := q.db.Query(ctx, listAssistantChatSessions, userID)
 	if err != nil {

--- a/internal/db/assistant_preset_integration_test.go
+++ b/internal/db/assistant_preset_integration_test.go
@@ -75,3 +75,55 @@ func TestAssistantSessionsStillRejectAnUnknownPreset(t *testing.T) {
 		t.Fatalf("error = %v, want a 23514 check violation", err)
 	}
 }
+
+// The rail is the website's session list — a browsing conversation only works over the
+// extension's own connection, so listing it there would offer a chat that silently loses
+// its one distinguishing tool the moment it is opened. See the confine-browse-preset-to-
+// extension change.
+func TestListAssistantChatSessionsExcludesTailorAndBrowse(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	user := seedAssistantUser(t, pool, "rail-scope@example.test")
+	jobID := insertJob(t, pool, "rail-scope-vacancy")
+	cv, err := q.CreateCV(ctx, CreateCVParams{
+		UserID: user, Title: "Rail scope", TemplateID: "classic-ats", Data: []byte(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("create cv: %v", err)
+	}
+
+	for _, preset := range []string{"chat", "profile", "browse", "interview", "debrief", "tailor"} {
+		params := CreateAssistantSessionParams{UserID: user, Preset: preset}
+		switch preset {
+		case "interview", "debrief":
+			params.JobID = &jobID
+		case "tailor":
+			params.CvID = &cv.ID
+			params.JobID = &jobID
+		}
+		if _, err := q.CreateAssistantSession(ctx, params); err != nil {
+			t.Fatalf("create %s session: %v", preset, err)
+		}
+	}
+
+	rows, err := q.ListAssistantChatSessions(ctx, user)
+	if err != nil {
+		t.Fatalf("ListAssistantChatSessions: %v", err)
+	}
+	got := make(map[string]bool, len(rows))
+	for _, r := range rows {
+		got[r.Preset] = true
+	}
+	for _, want := range []string{"chat", "profile", "interview", "debrief"} {
+		if !got[want] {
+			t.Errorf("rail is missing the %q session; got %v", want, got)
+		}
+	}
+	for _, excluded := range []string{"tailor", "browse"} {
+		if got[excluded] {
+			t.Errorf("rail lists a %q session, want it excluded", excluded)
+		}
+	}
+}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1642,18 +1642,23 @@ type Querier interface {
 	// The caller's session rail: their unbound conversations, most recently active first.
 	// Owner-scoped by construction — another user's sessions can never appear.
 	//
-	// The rail carries every conversation that can be continued on its own: chat, profile,
-	// browse, interview and debrief alike. An experience interview is resumable and would
-	// otherwise be lost the moment its author navigated away; a browsing conversation begun in
-	// the extension's side panel is one the candidate can pick up at their desk, where it
-	// simply cannot see a page any more; a rehearsal is opened days before the interview and
-	// closed again, and a debrief is written in one sitting and reread before the next round.
+	// The rail carries every conversation that works when reopened here: chat, profile,
+	// interview and debrief alike. An experience interview is resumable and would otherwise
+	// be lost the moment its author navigated away; a rehearsal is opened days before the
+	// interview and closed again, and a debrief is written in one sitting and reread before
+	// the next round.
 	//
 	// A rehearsal and a debrief are bound to a vacancy, so the test is not "binds to nothing"
 	// — it is whether the conversation still works when reopened from here. It does: their
-	// context tool closes over the vacancy id the session already carries. Tailoring
-	// conversations are excluded for exactly that reason inverted — they belong to the CV that
-	// owns them, are reached through the tailoring workspace, and cannot be continued without it.
+	// context tool closes over the vacancy id the session already carries.
+	//
+	// Tailoring conversations are excluded because they belong to the CV that owns them and
+	// are reached through the tailoring workspace, not this rail. Browsing conversations are
+	// excluded for a sharper reason: read_current_page — the one tool that makes a browsing
+	// session worth having — only works over the extension's own connection, so listing one
+	// here would offer a chat that silently loses its distinguishing capability the moment it
+	// is opened. It stays reachable from the extension, which holds its id directly rather
+	// than listing it. See the confine-browse-preset-to-extension change.
 	ListAssistantChatSessions(ctx context.Context, userID int64) ([]ListAssistantChatSessionsRow, error)
 	// A session's whole transcript in order, for the client to replay. Tool calls and tool
 	// results are included. Unbounded by design: the client's own message list must show

--- a/internal/db/queries/assistant.sql
+++ b/internal/db/queries/assistant.sql
@@ -10,21 +10,26 @@ RETURNING id, user_id, preset, label, cv_id, job_id, created_at, updated_at;
 -- The caller's session rail: their unbound conversations, most recently active first.
 -- Owner-scoped by construction — another user's sessions can never appear.
 --
--- The rail carries every conversation that can be continued on its own: chat, profile,
--- browse, interview and debrief alike. An experience interview is resumable and would
--- otherwise be lost the moment its author navigated away; a browsing conversation begun in
--- the extension's side panel is one the candidate can pick up at their desk, where it
--- simply cannot see a page any more; a rehearsal is opened days before the interview and
--- closed again, and a debrief is written in one sitting and reread before the next round.
+-- The rail carries every conversation that works when reopened here: chat, profile,
+-- interview and debrief alike. An experience interview is resumable and would otherwise
+-- be lost the moment its author navigated away; a rehearsal is opened days before the
+-- interview and closed again, and a debrief is written in one sitting and reread before
+-- the next round.
 --
 -- A rehearsal and a debrief are bound to a vacancy, so the test is not "binds to nothing"
 -- — it is whether the conversation still works when reopened from here. It does: their
--- context tool closes over the vacancy id the session already carries. Tailoring
--- conversations are excluded for exactly that reason inverted — they belong to the CV that
--- owns them, are reached through the tailoring workspace, and cannot be continued without it.
+-- context tool closes over the vacancy id the session already carries.
+--
+-- Tailoring conversations are excluded because they belong to the CV that owns them and
+-- are reached through the tailoring workspace, not this rail. Browsing conversations are
+-- excluded for a sharper reason: read_current_page — the one tool that makes a browsing
+-- session worth having — only works over the extension's own connection, so listing one
+-- here would offer a chat that silently loses its distinguishing capability the moment it
+-- is opened. It stays reachable from the extension, which holds its id directly rather
+-- than listing it. See the confine-browse-preset-to-extension change.
 SELECT id, user_id, preset, label, cv_id, job_id, created_at, updated_at
 FROM assistant_sessions
-WHERE user_id = $1 AND preset IN ('chat', 'profile', 'browse', 'interview', 'debrief')
+WHERE user_id = $1 AND preset IN ('chat', 'profile', 'interview', 'debrief')
 ORDER BY updated_at DESC, id DESC;
 
 -- name: GetAssistantSession :one

--- a/internal/handler/assistant.go
+++ b/internal/handler/assistant.go
@@ -18,6 +18,7 @@ import (
 	"github.com/valyala/fasthttp"
 
 	"github.com/strelov1/freehire/internal/assistant"
+	"github.com/strelov1/freehire/internal/auth"
 	"github.com/strelov1/freehire/internal/browsertools"
 	"github.com/strelov1/freehire/internal/cv"
 	"github.com/strelov1/freehire/internal/db"
@@ -549,6 +550,25 @@ func (h *assistantHandlers) userLanguage(ctx context.Context, userID int64) stri
 	return lang
 }
 
+// effectivePreset resolves the preset a turn actually runs under. A browse session's
+// one distinguishing tool, read_current_page, only works over the extension's own
+// connection (internal/browsertools.Hub is keyed by user id, not session id, so ANY
+// turn of the caller's could otherwise reach a browser they never opened on this
+// surface) — reached any other way, the session must run as an ordinary chat.
+//
+// This is called ONCE, before either the prompt or the registry is built, and both
+// are built from its answer rather than from sess.Preset directly. Deciding the same
+// question twice — once for the prompt, once for the tools — is exactly what
+// assistant.NormalizePreset's own doc comment warns against: the two could disagree,
+// and a model told to always open by calling a tool it was never given just reports
+// "unknown tool" instead of running the plain chat it degraded to.
+func effectivePreset(preset string, asExtension bool) string {
+	if assistant.NormalizePreset(preset) == assistant.PresetBrowse && !asExtension {
+		return assistant.PresetChat
+	}
+	return preset
+}
+
 // streamSSE owns the SSE headers, turn claim/queue, keepalive and writer. start is the
 // one difference between a fresh message and a retry.
 func (h *assistantHandlers) streamSSE(
@@ -556,13 +576,22 @@ func (h *assistantHandlers) streamSSE(
 	sess assistant.Session,
 	start func(context.Context, *assistant.Runner, *assistant.Registry, string, func(assistant.Event)) error,
 ) error {
+	asExtension := auth.IsExtensionBearer(c)
+	turnSess := sess
+	turnSess.Preset = effectivePreset(sess.Preset, asExtension)
+
 	// One batch per turn. Every CV edit the agent makes in this turn is filed under it, so
 	// the history can group them and "undo the run" is undoing a batch — which is what
 	// retires the single pre-run snapshot and the edge two concurrent runs used to create.
-	registry := h.registry(sess, uuid.New())
-	system := assistant.SystemPrompt(sess.Preset, h.userLanguage(c.Context(), sess.UserID))
+	registry := h.registry(turnSess, uuid.New())
+	system := assistant.SystemPrompt(turnSess.Preset, h.userLanguage(c.Context(), sess.UserID))
 
-	turnRunner := h.boundRunner(c.Context(), sess)
+	// Tagged from turnSess, not sess: a demoted browse turn spends like a chat turn — no
+	// page tool, the chat prompt — so it must be billed as one. Tagging it "browse" would
+	// pollute that preset's cost bucket with turns that never touched its one distinguishing
+	// tool, defeating the reason the tag exists (AGENTS.md: "the preset is what makes them
+	// comparable").
+	turnRunner := h.boundRunner(c.Context(), turnSess)
 
 	sseHeaders(c)
 

--- a/internal/handler/assistant_integration_test.go
+++ b/internal/handler/assistant_integration_test.go
@@ -322,20 +322,23 @@ func TestCreateAssistantSessionTakesThePresetTheClientAsksFor(t *testing.T) {
 
 // A conversation begun on a vacancy in the side panel is one the candidate can
 // pick up at their desk, so it belongs in the same rail as their chats.
-func TestSessionListSpansBrowsingConversations(t *testing.T) {
+func TestSessionListSpansRehearsalsButExcludesBrowsing(t *testing.T) {
 	pool := startPostgres(t)
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	app, h := newAssistantApp(pool, iss, nil)
 	userID, cookie := assistantUser(t, pool, iss, "rail@example.test", true)
 
+	// A browsing conversation's one distinguishing tool, read_current_page, only works
+	// over the extension's own connection — see the confine-browse-preset-to-extension
+	// change — so it stays out of the rail this endpoint serves, the same as tailoring.
 	browsing, err := h.store.CreateSession(context.Background(), userID, assistant.PresetBrowse, nil, nil)
 	if err != nil {
 		t.Fatalf("create browsing session: %v", err)
 	}
-	// The other half of the same predicate: widening it must not have swept tailoring
-	// conversations in. Only a real query can prove that — the store's own unit tests
-	// run against a fake that never sees the WHERE clause. The binding is left unset
-	// because what is on trial here is the preset filter, not the CV it points at.
+	// The other half of the same predicate: excluding browse and tailor must not have
+	// swept a rehearsal out too. Only a real query can prove that — the store's own unit
+	// tests run against a fake that never sees the WHERE clause. The binding is left
+	// unset because what is on trial here is the preset filter, not the CV it points at.
 	tailoring, err := h.store.CreateSession(context.Background(), userID, assistant.PresetTailor, nil, nil)
 	if err != nil {
 		t.Fatalf("create tailoring session: %v", err)
@@ -359,20 +362,17 @@ func TestSessionListSpansBrowsingConversations(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	var sawBrowsing, sawRehearsal bool
+	var sawRehearsal bool
 	for _, s := range list.Data {
-		if s.ID == browsing.ID.String() {
-			sawBrowsing = true
-		}
 		if s.ID == rehearsal.ID.String() {
 			sawRehearsal = true
 		}
 		if s.ID == tailoring.ID.String() {
 			t.Errorf("the rail contains the tailoring session %s; it is reached through its CV, not here", tailoring.ID)
 		}
-	}
-	if !sawBrowsing {
-		t.Errorf("the rail = %+v, want it to contain the browsing session %s", list.Data, browsing.ID)
+		if s.ID == browsing.ID.String() {
+			t.Errorf("the rail contains the browsing session %s; read_current_page only works from the extension", browsing.ID)
+		}
 	}
 	if !sawRehearsal {
 		t.Errorf("the rail = %+v, want it to contain the rehearsal %s", list.Data, rehearsal.ID)

--- a/internal/handler/assistant_preset_test.go
+++ b/internal/handler/assistant_preset_test.go
@@ -73,6 +73,54 @@ func TestOnlyTheBrowsePresetOffersThePageTool(t *testing.T) {
 	}
 }
 
+// effectivePreset is the one place that decides whether a browse session is running
+// over the extension's own connection. Both the prompt and the tool set are built
+// from its answer — never from sess.Preset directly — or the two could disagree
+// about what preset actually governs the turn.
+func TestEffectivePresetDemotesBrowseWithoutTheExtension(t *testing.T) {
+	if got := effectivePreset(assistant.PresetBrowse, false); got != assistant.PresetChat {
+		t.Errorf("effectivePreset(browse, asExtension=false) = %q, want chat", got)
+	}
+	if got := effectivePreset(assistant.PresetBrowse, true); got != assistant.PresetBrowse {
+		t.Errorf("effectivePreset(browse, asExtension=true) = %q, want browse", got)
+	}
+}
+
+func TestEffectivePresetLeavesOtherPresetsAlone(t *testing.T) {
+	for _, preset := range []string{assistant.PresetChat, assistant.PresetTailor, assistant.PresetProfile, assistant.PresetInterview, assistant.PresetDebrief} {
+		for _, asExtension := range []bool{true, false} {
+			if got := effectivePreset(preset, asExtension); got != preset {
+				t.Errorf("effectivePreset(%q, asExtension=%v) = %q, want it unchanged", preset, asExtension, got)
+			}
+		}
+	}
+}
+
+// The website authenticates by cookie; the extension by Bearer session JWT (never an
+// API key — a key is never the extension's own credential either). Preset alone is
+// not enough — a browse session reached any other way (a stale rail entry, a direct
+// URL, an API key) must degrade to an ordinary chat, PROMPT AND TOOLS BOTH, rather
+// than expose the one tool that only works over the extension's connection while
+// still being told to call it first. See the confine-browse-preset-to-extension
+// change.
+func TestBrowsePresetOverCookieRunsAsAnOrdinaryChat(t *testing.T) {
+	resolved := effectivePreset(assistant.PresetBrowse, false)
+
+	reg := presetAPI().registry(assistant.Session{UserID: 3, Preset: resolved}, uuid.New())
+	if slices.Contains(reg.Names(), "read_current_page") {
+		t.Error("a demoted browse session still offers read_current_page")
+	}
+	// It still degrades to an ordinary, working chat rather than losing everything.
+	if !slices.Contains(reg.Names(), "search_jobs") {
+		t.Errorf("a demoted browse session lost the discovery tools too; registered: %v", reg.Names())
+	}
+
+	if assistant.SystemPrompt(resolved, "en") != assistant.SystemPrompt(assistant.PresetChat, "en") {
+		t.Error("a demoted browse session must run under the chat prompt, not one that opens by " +
+			"insisting on a tool it was never given")
+	}
+}
+
 func TestChatPresetHasNoCVTools(t *testing.T) {
 	reg := presetAPI().registry(assistant.Session{UserID: 3, Preset: assistant.PresetChat}, uuid.New())
 

--- a/internal/handler/assistant_tools.go
+++ b/internal/handler/assistant_tools.go
@@ -347,6 +347,15 @@ const assistantResultCap = 60_000
 // whenever they happen to, and a version of this that only listens in one surface
 // would miss most of what they say. The page tool is the opposite case: it is scoped,
 // because only a browsing session has a browser on the other end of the relay.
+//
+// sess.Preset is trusted as-is here — it is the caller's job (streamSSE, via
+// effectivePreset) to have already demoted a browse session that is not running over
+// the extension's own connection to plain chat, BEFORE calling this. Deciding that
+// here too, from a second signal this function would have to take on its own, is
+// exactly the split answer assistant.NormalizePreset's doc comment warns against: the
+// prompt and the tool set must resolve from the SAME preset value or the model is
+// told to always call a tool it was never given. See the
+// confine-browse-preset-to-extension change.
 func (h *assistantHandlers) registry(sess assistant.Session, batchID uuid.UUID) *assistant.Registry {
 	// One normaliser answers the preset for BOTH the prompt and the tools. Comparing
 	// against the constants directly would let an unrecognised preset fall back to the

--- a/internal/handler/autofill_agent.go
+++ b/internal/handler/autofill_agent.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/gofiber/fiber/v2"
 
+	"github.com/strelov1/freehire/internal/auth"
 	"github.com/strelov1/freehire/internal/autofillagent"
 )
 
@@ -12,10 +13,21 @@ import (
 //
 // The extension triggers this and then watches its own socket do the work — the
 // agent never touches the DOM itself, it only drives the primitives.
+//
+// internal/browsertools.Hub is keyed by user id, not session id, so this call reaches
+// whatever browser the caller's extension currently has attached — regardless of
+// which surface issued THIS request. Unlike read_current_page (see the
+// confine-browse-preset-to-extension change), there is no degraded mode to fall back
+// to: autofill WRITES into the live form on that page, so a request that did not
+// authenticate as the extension's own Bearer session JWT is refused outright rather
+// than run against a browser the caller on this surface never opened.
 func (h *autofillHandlers) RunAgentAutofill(c *fiber.Ctx) error {
 	userID, err := requireUserID(c)
 	if err != nil {
 		return err
+	}
+	if !auth.IsExtensionBearer(c) {
+		return fiber.NewError(fiber.StatusForbidden, "autofill runs only from the browser extension's own connection")
 	}
 
 	profile, err := h.autofillProfile(c.Context(), userID)

--- a/internal/handler/autofill_agent_test.go
+++ b/internal/handler/autofill_agent_test.go
@@ -1,6 +1,31 @@
 package handler
 
-import "testing"
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/strelov1/freehire/internal/auth"
+)
+
+// stubValidKey authenticates exactly one full-scope key; any other hash is unknown,
+// mirroring the real db layer's ErrNoRows. Mirrors internal/auth's own fakeKeyAuth.
+type stubValidKey struct {
+	hash   string
+	userID int64
+}
+
+func (s stubValidKey) AuthenticateAPIKey(_ context.Context, hash string) (auth.APIKeyIdentity, error) {
+	if hash == s.hash {
+		return auth.APIKeyIdentity{UserID: s.userID, Scope: auth.ScopeFull}, nil
+	}
+	return auth.APIKeyIdentity{}, pgx.ErrNoRows
+}
 
 func TestProfileFields_IncludesScreeningAnswers(t *testing.T) {
 	p := autofillProfile{
@@ -19,5 +44,59 @@ func TestProfileFields_IncludesScreeningAnswers(t *testing.T) {
 	// The existing identity fields must not regress.
 	if got["full_name"] != "Ilya Strelov" {
 		t.Errorf(`profileFields["full_name"] = %q, want "Ilya Strelov"`, got["full_name"])
+	}
+}
+
+// autofillRunApp mounts /me/autofill/run behind the same RequireAuthOrKey mw.key uses in
+// production, on a handler with no DB. The refusal cases below reject before any query
+// runs, so the nil autofillHandlers fields are never dereferenced.
+func autofillRunApp(iss *auth.Issuer, keys auth.APIKeyAuthenticator) *fiber.App {
+	app := fiber.New()
+	h := &autofillHandlers{}
+	app.Post("/api/v1/me/autofill/run", auth.RequireAuthOrKey(iss, testVersions, keys), h.RunAgentAutofill)
+	return app
+}
+
+// RunAgentAutofill attaches to the caller's browsertools.Hub channel unconditionally —
+// the same channel read_current_page reaches, but this one WRITES into whatever form the
+// caller's extension currently has open. Hub is keyed by user id, not session id, so
+// without this guard a website user (cookie) or a full-scope API key could trigger it
+// against a page they never opened on this surface. See the
+// confine-browse-preset-to-extension change.
+func TestRunAgentAutofillRefusesNonExtensionAuth(t *testing.T) {
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	token, err := iss.Issue(7, testTokenVersion)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	const apiKey = "fhk_test-key"
+	keys := stubValidKey{hash: auth.HashAPIKey(apiKey), userID: 7}
+
+	cases := []struct {
+		name   string
+		cookie bool
+		bearer string // "" = no Authorization header
+	}{
+		{"website cookie", true, ""},
+		{"API key", false, apiKey},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), fiber.MethodPost, "/api/v1/me/autofill/run", nil)
+			if tc.cookie {
+				req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+			}
+			if tc.bearer != "" {
+				req.Header.Set("Authorization", "Bearer "+tc.bearer)
+			}
+			resp, err := autofillRunApp(iss, keys).Test(req)
+			if err != nil {
+				t.Fatalf("Test: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != fiber.StatusForbidden {
+				t.Errorf("status = %d, want 403 (autofill must run only from the extension's own connection)", resp.StatusCode)
+			}
+		})
 	}
 }

--- a/internal/handler/autofill_profile.go
+++ b/internal/handler/autofill_profile.go
@@ -95,7 +95,9 @@ func (h *autofillHandlers) register(api fiber.Router, mw middleware) {
 	// extension to write into application forms. keyAuth (Bearer).
 	api.Get("/me/autofill-profile", mw.key, h.AutofillProfile)
 	// Agent-driven autofill: the caller's own browser is driven over the browser-tool
-	// wire. keyAuth (Bearer) so the extension can trigger it.
+	// wire. keyAuth admits the cookie too, same as every other mw.key route — the
+	// handler itself refuses anything but the extension's own Bearer session JWT,
+	// because unlike a read this one writes into a live form.
 	api.Post("/me/autofill/run", mw.key, h.RunAgentAutofill)
 }
 

--- a/openspec/changes/confine-browse-preset-to-extension/.openspec.yaml
+++ b/openspec/changes/confine-browse-preset-to-extension/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/openspec/changes/confine-browse-preset-to-extension/design.md
+++ b/openspec/changes/confine-browse-preset-to-extension/design.md
@@ -1,0 +1,174 @@
+## Context
+
+See `proposal.md` - Why for the motivation. Two facts shape the approach:
+
+- The rail-inclusion of `browse` sessions was deliberate, and the reasoning is recorded
+  right at the source of the leak — `internal/db/queries/assistant.sql`,
+  `ListAssistantChatSessions`: *"a browsing conversation begun in the extension's side
+  panel is one the candidate can pick up at their desk, where it **simply cannot see a
+  page any more**."* That assumption holds only if the extension is disconnected while
+  the website is used. It is not: `internal/browsertools.Hub` keys a channel by user id,
+  not by session id, so a user with the side panel open in one tab and `/my/assistant`
+  open in another still has a live channel, and `read_current_page` succeeds.
+- `read_current_page`'s registration (`internal/handler/assistant_tools.go`, `registry`)
+  is gated purely on `session.Preset`. The request that carries a turn already
+  distinguishes cookie vs. Bearer auth in `internal/auth` (`ViaAPIKey` exists for
+  key-vs-cookie, but nothing today separates a Bearer *session JWT* — the extension's own
+  carrier — from the cookie).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Close the leak at both the layer that causes it (backend tool registration) and the
+  layer that surfaces it (the website's session rail), per the confirmed direction.
+- Keep the fix mechanically small: no new tables, no new capability, reuse the
+  degrade-rather-than-fail pattern the codebase already uses for an unbound tailoring
+  session.
+
+**Non-Goals:**
+- Preserving cross-surface continuity for browsing conversations. The proposal marks
+  this **BREAKING** on purpose — restoring it safely (e.g., only when the extension is
+  provably NOT the caller's) is future scope, not this change.
+- The broader `assistant_*_tools.go` structural refactor (data-driven `registry()`,
+  file-naming consistency) surfaced while investigating this. Real, but separate —
+  left for a follow-up.
+
+## Decisions
+
+**1. Exclude `browse` at the SQL query, not just in the Go handler or the client.**
+`ListAssistantChatSessions`'s `WHERE preset IN (...)` already excludes `tailor` this
+way. Adding `browse` to the exclusion (`'chat', 'profile', 'interview', 'debrief'`)
+makes the backend list endpoint itself the single source of truth — the website rail
+needs no special-casing beyond what it already does for `tailor`, and any other current
+or future client of `GET /assistant/sessions` inherits the same behavior for free.
+Alternative considered: filter in `ListAssistantSessions` (Go) instead of SQL — rejected,
+since `tailor` is already excluded at the SQL layer and splitting the two exclusions
+across layers would be its own inconsistency.
+
+**2. Also make the website treat a browse session opened by direct URL as a dead link,
+matching `tailor`.** `opensInRail(preset)` (`web/src/lib/assistant/presets.ts`) currently
+returns `true` for `browse`; change it to return `false`, i.e. `preset !== 'tailor' &&
+preset !== 'browse'`. Without this, a bookmarked or guessed `/my/assistant/<browse-id>`
+URL would still load and run — silently missing the page tool because of Decision 3, an
+inconsistent-feeling degrade rather than the clear "chat unavailable" the tailoring case
+already shows. Confining `browse` to the extension should mean the website never
+presents it as a conversation to continue, not that it presents it with one fewer tool.
+
+**3. Gate `read_current_page`'s registration on the request's auth carrier, in addition
+to preset — defense in depth, not the primary fix. Resolve it ONCE, before either the
+prompt or the tool set is built, not separately in each.** Add `auth.ViaCookie(c) bool`,
+mirroring the existing `auth.ViaAPIKey(c)`: a new `localsViaCookie` local set `true` in
+`RequireAuth`'s cookie path and in `RequireAuthOrScopedKey`'s cookie branch, left unset
+on the Bearer branch (both the JWT and API-key cases). Neither carrier flag alone answers
+"is this the extension" — an API key is never the extension's own credential either, even
+though it also leaves `ViaCookie` false — so `streamSSE` combines both:
+`asExtension := !auth.ViaCookie(c) && !auth.ViaAPIKey(c)`.
+
+That combined bool feeds a new pure function, `effectivePreset(preset string, asExtension
+bool) string` (`internal/handler/assistant.go`, beside `streamSSE`, its only caller):
+demotes `browse` to `chat` when `!asExtension`, passes every other preset through
+unchanged. `streamSSE` calls it once into a local `turnSess` (a copy of `sess` with only
+`.Preset` overridden) and builds BOTH the prompt and the registry from `turnSess.Preset` —
+`registry()` itself is untouched, still taking only `(sess, batchID)` and trusting
+whatever preset it is handed, exactly as before this change.
+
+This shape is not incidental. `assistant.NormalizePreset`'s own doc comment already
+warns against deciding a session's effective preset twice — once for
+`assistant.SystemPrompt`, once for `registry()` — because the two can disagree, and a
+model told to always open by calling a tool it does not have just reports "unknown tool."
+An earlier version of this change added the carrier check as a second `viaCookie bool`
+parameter on `registry()` alone, leaving `SystemPrompt(sess.Preset, ...)` to read the
+UNDEMOTED preset — so a cookie-authenticated `browse` turn got the chat tool set under
+the browse prompt, which opens by insisting the model call `read_current_page` first. A
+carrier-aware demotion is exactly the kind of second preset-deciding switch
+`NormalizePreset` forbids, so it has to happen before the fork, not inside one branch of
+it. A `browse` session that reaches a turn any way other than the extension's own Bearer
+JWT (a stale rail entry, a future client bug, an API key) now runs, prompt and tools
+alike, as an ordinary chat — the same degrade-rather-than-fail shape
+`TestTailorPresetWithoutABindingHasNoCVTools` already establishes for a CV-less tailoring
+session.
+
+**4. Do not attempt to distinguish "the extension" from "any other Bearer session-JWT
+client."** `asExtension` excludes the two carriers this codebase can already name —
+cookie and API key — but does not prove the caller is specifically the extension: a
+future first-party client authenticating with a Bearer session JWT the same way (a
+mobile app, say) would also pass. That is acceptable: the leak this change closes is
+specifically "a credential that is provably NOT the extension's own silently gained
+page-read access" — narrowing further would need a dedicated client credential this
+codebase does not have today, and the AGENTS.md invariant this restores ("meant to be
+held from the browser extension") is already stated in terms of carrier, not a stronger
+identity check.
+
+**5. Close the identical leak in `POST /me/autofill/run` — found by review of this
+change, not the original proposal.** `RunAgentAutofill`
+(`internal/handler/autofill_agent.go`) attaches to the SAME `internal/browsertools.Hub`
+channel `read_current_page` does, mounted behind the SAME `mw.key` (cookie or
+full-scope API key), with no carrier check at all before this fix. The exact reasoning
+that motivates the rest of this change — a user-id-keyed channel is reachable from any
+of that user's authenticated requests, not only the one that opened the extension —
+applies unchanged. It is worse here: autofill WRITES into the live form on whatever
+page is attached, so a caller reaching it without the extension does not just read a
+page, it submits data into one. Unlike `read_current_page` / the browse preset, there
+is no "run as an ordinary chat" degraded mode for a form-filling endpoint — the whole
+route is the browser-tool call — so the fix is a flat refusal: `RunAgentAutofill`
+returns `403` unless `auth.ViaCookie(c)` and `auth.ViaAPIKey(c)` are both false. This
+reuses the exact primitives Decision 3 already added; no new auth surface.
+
+## Risks / Trade-offs
+
+- **[Risk]** A user who relied on resuming a browsing conversation from their desktop
+  loses that ability with no migration path — their old `browse` sessions still exist in
+  the database but become permanently unreachable from any client (the website excludes
+  them by query; the extension addresses sessions by an id in its own `storage.local`, not
+  by browsing a list, so it never surfaces an old one either).
+  → Mitigation: none needed functionally (no data is deleted, and nothing else read
+  those rows) — call it out plainly as the proposal's BREAKING note so it isn't a
+  surprise in review.
+- **[Risk]** A carrier-aware demotion applied to only one of {prompt, tools} silently
+  reintroduces the exact split-brain `NormalizePreset` exists to prevent.
+  → Mitigation: `effectivePreset` is the only place that decides it, called once, before
+  either the prompt or the registry is built; `registry()` itself stays carrier-blind, so
+  there is no second switch left to disagree. `TestBrowsePresetOverCookieRunsAsAnOrdinaryChat`
+  pins both halves together in one assertion.
+- **[Trade-off]** `ViaCookie` is a second boolean beside `ViaAPIKey` rather than one
+  three-state carrier enum (`cookie` / `session-bearer` / `api-key`). Chosen because
+  today only one call site needs to ask "was this cookie or not," and `ViaAPIKey` already
+  answers the API-key question independently; introducing an enum type would touch more
+  of `internal/auth`'s public surface than this change needs. If a third caller needs the
+  distinction, consolidate then.
+
+- **[Risk, accepted]** The fix is applied at each caller's own site (`streamSSE` for
+  `read_current_page`, `RunAgentAutofill` for autofill — Decision 5), not inside
+  `internal/browsertools.Hub` itself. Both of today's harnesses now carry the check,
+  but nothing in `Hub` forces a THIRD one to. Building a shared enforcement point now
+  would be infrastructure for a caller that does not exist yet; the seam is `Hub`, and
+  Decision 5 turning out to be needed at all is itself the signal that the seam is
+  worth revisiting once a third caller arrives.
+- **[Risk, accepted]** `RunAgentAutofill`'s refusal (Decision 5) is covered only for
+  the cookie and API-key cases; the success path — a genuine extension Bearer JWT
+  reaching past the guard into the DB-backed profile assembly — is not exercised by a
+  new test, because doing so would need mocking `h.cvs`/`h.resumes`/`h.accounts` this
+  file's existing tests do not set up, for a path this change does not otherwise touch.
+  The guard's own boolean logic is a plain `||` of two independently-tested primitives
+  (`auth.ViaCookie`, `auth.ViaAPIKey`), so the residual risk is narrow.
+
+## Migration Plan
+
+1. `internal/db/queries/assistant.sql` + `make sqlc` (regenerates `internal/db/*.go`).
+2. `internal/auth/middleware.go`: add `localsViaCookie` / `ViaCookie`.
+3. `internal/handler/assistant.go`: add `effectivePreset` and wire `asExtension` /
+   `turnSess` into `streamSSE`, so both the prompt and `registry()` resolve from the
+   same demoted preset.
+4. `web/src/lib/assistant/presets.ts`: `opensInRail` excludes `browse`.
+5. Add the new scenarios from the spec deltas: `effectivePreset`'s own cases, and one
+   pinning that the prompt and the tool set agree after a demotion.
+6. `internal/handler/autofill_agent.go`: refuse `RunAgentAutofill` for cookie/API-key
+   auth (Decision 5).
+
+No data migration, no feature flag: this is a behavior change deployed atomically with
+the next release, matching how `tailor`'s exclusion from the rail was never flagged
+either. Rollback is a plain revert — no stored data changes shape.
+
+## Open Questions
+
+(none — see Non-Goals for what was deliberately deferred rather than left open)

--- a/openspec/changes/confine-browse-preset-to-extension/proposal.md
+++ b/openspec/changes/confine-browse-preset-to-extension/proposal.md
@@ -1,0 +1,74 @@
+## Why
+
+A `browse`-preset session (created by the extension's side panel) is currently listed
+in the ordinary website's `/my/assistant` rail and can be continued there — that
+inclusion was a deliberate choice (`assistant-sessions`'s "session list spans every
+conversation" requirement), meant to let a candidate pick up a browsing conversation
+at their desk. But the backend still grants that continued session the
+`read_current_page` tool purely because `session.preset == "browse"`
+(`internal/handler/assistant_tools.go`), with no check on how the turn's request
+authenticated. The browser-tool relay (`internal/browsertools.Hub`) is keyed by user
+id, not by session id, so if the user's browser extension is connected, the "ordinary"
+website assistant will silently read whatever page is open in that extension while the
+user believes they are talking to a chat with no page access. This contradicts the
+documented invariant in `internal/assistant/AGENTS.md` ("A browse session is one held
+from the browser extension") and is a real capability leak, not a hypothetical one.
+
+## What Changes
+
+- Drop `browse` from the session list the website's `/my/assistant` surface can see:
+  `GET /assistant/sessions` no longer returns `browse` sessions (alongside the
+  existing `tailor` exclusion), so a browsing conversation is no longer listed,
+  selectable, or continuable from the ordinary site. **BREAKING**: a candidate can no
+  longer resume a side-panel conversation from the desktop website; each surface's
+  history stays on that surface.
+- Add a defense-in-depth check at the tool-registry layer: `read_current_page` is
+  registered only when the turn's request itself authenticated via a Bearer session
+  JWT (the extension's carrier), never via the website's cookie — even for a
+  `browse`-preset session reached some other way (a stale rail entry, a direct URL, a
+  future client bug). A `browse` session continued over cookie auth degrades to a
+  plain chat with no page tool, the same graceful-degradation pattern already used for
+  an unbound tailoring session.
+- `internal/auth` gains a way for a handler to tell whether the current request
+  authenticated via the cookie or via a Bearer session JWT (today it only exposes
+  API-key-vs-not).
+- Close the same class of leak in `POST /me/autofill/run` (`RunAgentAutofill`), found
+  during review of this change: it attaches to the identical
+  `internal/browsertools.Hub` channel unconditionally for any `mw.key`-authenticated
+  caller (cookie or API key), and unlike `read_current_page` it WRITES into the
+  attached browser's form. It now refuses outright unless the request authenticated as
+  the extension's own Bearer session JWT — there is no degraded mode for a write.
+
+## Capabilities
+
+### New Capabilities
+(none)
+
+### Modified Capabilities
+- `assistant-sessions`: the session list SHALL no longer include `browse` sessions —
+  only `chat`, `profile`, `interview` and `debrief` remain listed; `browse` joins
+  `tailor` as excluded.
+- `assistant-page-awareness`: `read_current_page` SHALL be registered only when the
+  request authenticated via a Bearer session JWT, in addition to the existing
+  preset check — a `browse` session reached over cookie auth SHALL NOT be offered the
+  tool.
+- `extension-autofill`: the agent-driven fill (`POST /me/autofill/run`) SHALL refuse a
+  request that authenticated by cookie or API key, admitting only the extension's own
+  Bearer session JWT — the read endpoint (`GET /me/autofill-profile`) is unchanged.
+
+## Impact
+
+- Backend: `internal/handler/assistant.go` (`ListAssistantSessions`, `streamSSE`,
+  `effectivePreset`), `internal/handler/assistant_tools.go` (`registry`, unchanged in
+  signature — see design.md Decision 3), `internal/handler/autofill_agent.go`
+  (`RunAgentAutofill`), `internal/auth/middleware.go` (new carrier signal).
+- Frontend (web): `web/src/lib/assistant/presets.ts` (`opensInRail` becomes
+  unnecessary as a rail filter once the backend stops returning `browse`, but the
+  "dead link" UX it exists for — arriving with no id when the newest session was
+  filtered out — must still resolve to a fresh chat rather than an error).
+- Frontend (extension): none — it never calls `GET /assistant/sessions` and always
+  authenticates via Bearer, so its own `browse` conversation is unaffected.
+- Out of scope: the broader stylistic inconsistencies across
+  `internal/handler/assistant_*_tools.go` (naming, single-tool registration idiom)
+  found while investigating this — real, but a separate readability concern from this
+  security-relevant fix, left for a follow-up change.

--- a/openspec/changes/confine-browse-preset-to-extension/specs/assistant-page-awareness/spec.md
+++ b/openspec/changes/confine-browse-preset-to-extension/specs/assistant-page-awareness/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: The page tool is confined to the browsing preset
+
+`read_current_page` SHALL NOT be registered for the `chat` or `tailor` presets. A
+conversation held outside a browser extension has no page to read, and a tool
+that can only fail spends the model's context without ever returning an answer.
+
+Preset alone is not sufficient: `read_current_page` SHALL additionally be withheld
+from a `browse`-preset turn unless the request that carries it authenticated with a
+Bearer session JWT — the extension's own carrier — rather than the website's session
+cookie. A `browse` session reached some other way (a stale link, a future client
+that lists it anyway) SHALL still run as a conversation; it SHALL simply run without
+the page tool, the same degrade-rather-than-fail pattern a tailoring session without
+a CV binding already follows.
+
+#### Scenario: A chat session is not offered the page tool
+
+- **WHEN** a session running the `chat` preset builds its tool registry
+- **THEN** `read_current_page` is absent from it
+
+#### Scenario: A browsing session reached over the website's cookie has no page tool
+
+- **WHEN** a turn for a `browse`-preset session is submitted authenticated by the website's session cookie rather than a Bearer session JWT
+- **THEN** the registry built for that turn does not contain `read_current_page`, and the turn otherwise runs as an ordinary chat
+
+#### Scenario: A browsing session reached from the extension keeps the page tool
+
+- **WHEN** a turn for a `browse`-preset session is submitted authenticated by a Bearer session JWT
+- **THEN** the registry built for that turn contains `read_current_page`

--- a/openspec/changes/confine-browse-preset-to-extension/specs/assistant-sessions/spec.md
+++ b/openspec/changes/confine-browse-preset-to-extension/specs/assistant-sessions/spec.md
@@ -1,0 +1,54 @@
+## MODIFIED Requirements
+
+### Requirement: The session list spans every conversation the user can return to
+
+The session list SHALL contain every conversation of the caller's except a tailoring
+or a browsing one, most recently active first — general chats, experience
+interviews, rehearsals and debriefs alike. Tailoring sessions stay out because each
+is reached through the CV that owns it; browsing sessions stay out because their
+only useful reading — `read_current_page` — works solely over the extension's own
+Bearer-JWT connection, so surfacing them on the website would list a conversation
+that degrades to an ordinary chat the moment it is opened there.
+
+A rehearsal and a debrief bind to a vacancy rather than to nothing, and are still
+listed: what keeps a conversation out of the rail is having its own way in (the
+extension, for browsing; the CV, for tailoring), not having a binding.
+
+#### Scenario: A browsing session appears in the rail
+
+- **WHEN** the caller has held a conversation from the extension's side panel and requests the session list
+- **THEN** that conversation is absent from the response; it remains reachable from the extension, which holds its id directly rather than listing it
+
+#### Scenario: A debrief appears in the rail
+
+- **WHEN** the caller has debriefed an interview and requests the session list
+- **THEN** that debrief is in the response, named after the vacancy it was held against
+
+#### Scenario: A tailoring conversation is still absent
+
+- **WHEN** the caller has a CV-tailoring conversation and requests the session list
+- **THEN** it is absent from the response
+
+### Requirement: A conversation has its own address
+
+Each chat SHALL be addressable by a URL carrying its id, so it can be
+bookmarked, reopened later, and reached with the browser's Back button.
+Selecting a chat SHALL navigate to that chat's address, adding a history entry;
+entering the assistant without an id SHALL open the newest chat (or start one)
+and replace the address with that chat's own, so landing there is not itself a
+step in the user's history.
+
+#### Scenario: Switching chats changes the address
+
+- **WHEN** the user selects a different chat in the sidebar
+- **THEN** the address becomes that chat's URL, and pressing Back returns to the chat they came from
+
+#### Scenario: A saved link reopens its chat
+
+- **WHEN** the user opens a previously saved chat URL
+- **THEN** that chat is opened and its transcript is repainted
+
+#### Scenario: A dead link explains itself
+
+- **WHEN** the URL names a conversation the caller cannot open on this surface — deleted, another user's, a tailoring conversation that belongs to a CV, or a browsing conversation held from the extension
+- **THEN** the page says the chat is unavailable and offers a way back to the chat list, rather than silently opening a different conversation or opening it here with reduced capability

--- a/openspec/changes/confine-browse-preset-to-extension/specs/extension-autofill/spec.md
+++ b/openspec/changes/confine-browse-preset-to-extension/specs/extension-autofill/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: Both autofill entry points share one assembly
+
+The system SHALL assemble the contact block once and serve it to both the extension's
+deterministic read (`GET /api/v1/me/autofill-profile`) and the agent-driven fill
+(`POST /api/v1/me/autofill/run`), so the values a person sees in a form and the values the
+agent grounds its plan in cannot diverge. The read endpoint remains authenticated by
+either the website's cookie or a full-scope API key, same as any other `mw.key` route.
+The agent-driven fill does not: see "The agent-driven fill is confined to the
+extension's own connection" below for what authenticates it.
+
+#### Scenario: The agent fills from the same block the endpoint serves
+
+- **WHEN** the agent-driven autofill runs for a user
+- **THEN** it grounds its plan in the same contact block the read endpoint would serve that
+  user
+
+## ADDED Requirements
+
+### Requirement: The agent-driven fill is confined to the extension's own connection
+
+`POST /api/v1/me/autofill/run` SHALL refuse a request that authenticated by the
+website's session cookie or by an API key, even though both otherwise pass this
+route's ordinary auth gate. It attaches to the caller's browser-tool channel
+(`internal/browsertools.Hub`, keyed by user id, not session id) and WRITES into
+whatever form the browser currently attached to that channel is showing — unlike a
+read, there is no safe degraded behavior, so a request that did not authenticate with
+the extension's own Bearer session JWT is refused outright rather than run against a
+browser the caller on this surface never opened.
+
+#### Scenario: A cookie-authenticated request is refused
+
+- **WHEN** `POST /api/v1/me/autofill/run` is called authenticated by the website's session cookie
+- **THEN** the request is refused and no browser-tool call is made
+
+#### Scenario: An API-key-authenticated request is refused
+
+- **WHEN** `POST /api/v1/me/autofill/run` is called authenticated by a full-scope API key
+- **THEN** the request is refused and no browser-tool call is made
+
+#### Scenario: The extension's own Bearer session JWT is admitted
+
+- **WHEN** `POST /api/v1/me/autofill/run` is called authenticated by a Bearer session JWT
+- **THEN** the request proceeds to read the caller's browser-tool channel

--- a/openspec/changes/confine-browse-preset-to-extension/tasks.md
+++ b/openspec/changes/confine-browse-preset-to-extension/tasks.md
@@ -1,0 +1,175 @@
+## 0. Review fixes (found by `/code-review` after tasks 1-5 first went green)
+
+- [x] 0.1 **Confirmed bug**: `registry()`'s `viaCookie` gate left an API key able to
+      register `read_current_page` for a browse session (`!viaCookie` is also true for
+      a Bearer API key, not only the extension's Bearer session JWT) — contradicted
+      design.md's own stated rationale. Fixed by combining `!auth.ViaCookie(c) &&
+      !auth.ViaAPIKey(c)` into one `asExtension` bool at the single call site.
+- [x] 0.2 **Confirmed bug**: the system prompt was still chosen from raw `sess.Preset`
+      (always the browse prompt, which opens by insisting the model call
+      `read_current_page` first) while only the tool registry was demoted for a
+      cookie-authenticated browse turn — the model's first call then failed with
+      "unknown tool". This is exactly the split-brain `assistant.NormalizePreset`'s doc
+      comment warns against. Fixed by extracting `effectivePreset(preset, asExtension)`
+      (`internal/handler/assistant.go`) as the ONE place that resolves a browse turn's
+      real preset, called once in `streamSSE` before either the prompt or the registry
+      is built; `registry()`'s signature reverted to its original two args and no
+      longer knows about the carrier at all. See design.md Decision 3.
+- [x] 0.3 Updated the stale invariant in `internal/assistant/AGENTS.md` ("a browse
+      session is one held from the browser extension") to state the carrier gate.
+- [x] 0.4 Noted, deliberately NOT acted on: `internal/browsertools.Hub` has no shared
+      enforcement point of its own, so a future second tool on the same channel would
+      need this same carrier check re-applied by hand. Recorded as an accepted risk in
+      design.md rather than building an enforcement abstraction for one caller.
+- [x] 0.5 Updated the pre-existing (not-new-to-this-change)
+      `TestSessionListSpansBrowsingConversations` in
+      `internal/handler/assistant_integration_test.go`, which asserted the OLD
+      behaviour (browse sessions listed) and only surfaces when the full
+      `-tags=integration` suite runs — renamed to
+      `TestSessionListSpansRehearsalsButExcludesBrowsing` and inverted its browsing
+      assertion.
+- [x] 0.6 New regression tests: `TestEffectivePresetDemotesBrowseWithoutTheExtension`,
+      `TestEffectivePresetLeavesOtherPresetsAlone`,
+      `TestBrowsePresetOverCookieRunsAsAnOrdinaryChat` (asserts prompt AND tools agree)
+      in `assistant_preset_test.go`. Full `go test ./...`,
+      `go test -tags=integration ./internal/db/` and `./internal/handler/`, and
+      `npx vitest run` (web, full suite) all clean beyond the one pre-existing
+      unrelated `TestExtractResumeProfile_PDF` failure.
+- [x] 0.7 **Confirmed nit, second `/code-review` pass**: `streamSSE` still passed the
+      original `sess` (untouched `Preset`) to `boundRunner`, so a demoted browse turn's
+      LLM spend was tagged `"preset:browse"` even though it ran the chat prompt with no
+      page tool — polluting that cost bucket with turns that never touched the tool the
+      tag exists to price. Fixed: `boundRunner` now takes `turnSess`. `UserID` is the
+      only other field it reads, unchanged between the two, so no other behavior moves.
+      Not independently unit-tested — asserting the exact gateway tag string would need
+      mocking `llmkey`/`llm.Client` binding beyond what any existing test does for
+      marginal return; covered instead by `go vet`/`go build` plus the same
+      `turnSess`-derivation path `TestBrowsePresetOverCookieRunsAsAnOrdinaryChat` already
+      pins.
+- [x] 0.8 **Confirmed bug, second `/code-review` pass, user directed it into this
+      PR**: `POST /me/autofill/run` (`RunAgentAutofill`) attaches to the same
+      `internal/browsertools.Hub` channel unconditionally for any `mw.key`-authenticated
+      caller (cookie or API key) — the identical leak this whole change closes for
+      `read_current_page`, except this one WRITES into the attached browser's form.
+      Fixed: refuses with 403 unless `auth.IsExtensionBearer(c)` (see 0.9). Also
+      corrected the route's own stale comment
+      (`internal/handler/autofill_profile.go`) and the `extension-autofill` spec's
+      "accept an API key" line, both of which were already wrong about this endpoint's
+      real caller (the extension's Bearer session JWT, per `extension/lib/freehire.ts`
+      / `extension/lib/auth.ts` — traced to confirm before writing the fix). New test:
+      `TestRunAgentAutofillRefusesNonExtensionAuth`
+      (`internal/handler/autofill_agent_test.go`), RED (panic on nil DB fields,
+      confirming no guard existed) before the fix, GREEN after. See design.md
+      Decision 5 and its accepted-risk note on what this test does NOT cover.
+- [x] 0.9 **Third `/code-review` pass, three findings, all fixed**:
+  - Public API docs (`web/src/lib/docs/api-spec.ts`) still said `/me/autofill/run` was
+    `cookie-or-key` with a `fhk_…` (API-key-shaped) curl example — now a new `'extension'`
+    Auth variant, labeled "Browser extension only", with a curl example using a
+    placeholder session token instead of the API-key prefix. Regenerated
+    `docs/API.md` (`npm run gen:api-docs`); `gen:api-docs:smoke` still passes.
+  - `!auth.ViaCookie(c) && !auth.ViaAPIKey(c)` was duplicated (as its De Morgan
+    negation) between `streamSSE` and `RunAgentAutofill` — exactly the drift
+    design.md's own accepted-risk note anticipated, except it had already happened
+    with only two callers, not three. Extracted `auth.IsExtensionBearer(c) bool`
+    (`internal/auth/middleware.go`) as the one definition both now call; RED
+    (`TestIsExtensionBearer_TrueOnlyForTheSessionJWT`, compile failure) confirmed
+    before adding it.
+  - `internal/assistant/store.go`'s `PresetBrowse` constant doc comment still stated
+    the pre-fix, unconditional guarantee ("the only preset whose agent can see the
+    page") — updated to name the carrier gate and point at `effectivePreset`.
+  - `gofmt`/`go vet`/`go vet -tags=integration` clean; `go test ./...` clean beyond
+    the same pre-existing `TestExtractResumeProfile_PDF`; web `npm run check`
+    (svelte-check): 0 errors (pre-existing warnings elsewhere, none in touched
+    files); `npx vitest run`: 1006/1006.
+
+## 1. Backend: exclude `browse` from the session rail
+
+- [x] 1.1 `internal/db/queries/assistant.sql`: in `ListAssistantChatSessions`, drop
+      `'browse'` from the `preset IN (...)` list and update the comment above the
+      query to state the browse exclusion and why (mirroring the existing tailoring
+      rationale), per `design.md` Decision 1.
+- [x] 1.2 Run `make sqlc` to regenerate `internal/db/*.go`; confirm
+      `ListAssistantChatSessionsRow`/the generated method compile unchanged in shape
+      (only the WHERE clause changes).
+- [x] 1.3 Update or add a test asserting `ListAssistantChatSessions` (or its handler,
+      `ListAssistantSessions`) omits a `browse` session for its owner, alongside the
+      existing tailoring-exclusion coverage. Covers the `assistant-sessions` spec's
+      "A browsing session is absent from the rail" scenario.
+      Done: `TestListAssistantChatSessionsExcludesTailorAndBrowse` in
+      `internal/db/assistant_preset_integration_test.go` — RED against the old
+      query, GREEN after the fix.
+
+## 2. Backend: auth-carrier signal
+
+- [x] 2.1 `internal/auth/middleware.go`: add `localsViaCookie` const and `ViaCookie(c
+      *fiber.Ctx) bool`, mirroring `localsViaAPIKey`/`ViaAPIKey`.
+- [x] 2.2 Set it `true` in `RequireAuth`'s success path and in
+      `RequireAuthOrScopedKey`'s cookie branch; leave it unset on the Bearer branch
+      (both JWT and API-key).
+- [x] 2.3 Add a test in `internal/auth` covering: cookie auth → `ViaCookie` true;
+      Bearer session JWT → `ViaCookie` false; Bearer API key → `ViaCookie` false.
+      Done: `TestRequireAuth_FlagsCookieAuth` (middleware_test.go),
+      `TestRequireAuthOrKey_FlagsCookieAuth`,
+      `TestRequireAuthOrKey_JWTBearerIsNotViaCookie`,
+      `TestRequireAuthOrKey_APIKeyIsNotViaCookie` (requireauthorkey_test.go).
+
+## 3. Backend: gate `read_current_page` on the carrier
+
+**Superseded by task group 0** after review found this original approach let the prompt
+and the tool set disagree (0.2). Left here for history; the final shape is: `registry()`
+keeps its ORIGINAL two-arg signature and stays carrier-blind, `effectivePreset` resolves
+the carrier-aware demotion once in `streamSSE`, and both the prompt and `registry()` are
+built from that single resolved preset. See design.md Decision 3 and tasks 0.1-0.2, 0.6.
+
+- [x] 3.1 (superseded) ~~add a `viaCookie bool` parameter to `registry()`~~ — reverted;
+      `registry()` is unchanged from before this whole change.
+- [x] 3.2 (superseded) ~~pass `auth.ViaCookie(c)` into `h.registry(...)`~~ — `streamSSE`
+      instead computes `asExtension` and passes a preset-overridden `turnSess` to both
+      `registry()` and `assistant.SystemPrompt`.
+- [x] 3.3 Update every other `registry(...)` call site — reverted to the original
+      two-arg call in `assistant_preset_test.go`, `assistant_inbox_preset_test.go`,
+      `assistant_interview_tools_test.go`, since `registry()`'s signature no longer
+      changed.
+- [x] 3.4 (superseded) `TestBrowsePresetOverCookieHasNoPageTool` replaced by
+      `TestBrowsePresetOverCookieRunsAsAnOrdinaryChat` (task 0.6), which additionally
+      pins the prompt.
+- [x] 3.5 Confirm the existing `TestBrowsePresetOffersThePageTool` is unaffected — it
+      still calls `registry()` with two args, unchanged from before this change.
+      Group done: full `internal/handler`, `internal/auth`, `internal/assistant`,
+      `internal/db` (incl. `-tags=integration`), and web suites pass (one pre-existing
+      unrelated failure, `TestExtractResumeProfile_PDF`, confirmed present on
+      unmodified origin/main too).
+
+## 4. Frontend: stop treating `browse` as rail-openable
+
+- [x] 4.1 `web/src/lib/assistant/presets.ts`: change `opensInRail` to `preset !==
+      'tailor' && preset !== 'browse'`; update its doc comment (the "whitelist goes
+      stale" rationale no longer applies to `browse`, which is now excluded on
+      purpose, matching `tailor`).
+- [x] 4.2 `web/src/lib/assistant/presets.test.ts`: update the `browse` expectation
+      from `true` to `false`; add/keep a case pinning `tailor` and `browse` as the
+      only two presets `opensInRail` refuses.
+- [x] 4.3 Confirm `AssistantChat.svelte`'s existing dead-link handling
+      (`showSessionRail && !opensInRail(meta.preset)`) needs no further change — it
+      already renders the same "chat unavailable" state `tailor` produces.
+      Verified by reading; no edit needed. `npx vitest run presets`: 22/22 pass.
+
+## 5. Verify
+
+- [x] 5.1 `gofmt -w` the touched Go files; `go vet ./...`; `go test ./...`.
+      Clean; only pre-existing failure `TestExtractResumeProfile_PDF`
+      (confirmed present on unmodified origin/main, unrelated to this change).
+- [x] 5.2 `go vet -tags=integration ./...`; if any integration test in
+      `internal/handler` touches `ListAssistantSessions` or session creation for
+      `browse`, run the tagged suite for that package.
+      Full `go test -tags=integration ./internal/db/` (35s) and
+      `./internal/handler/` (38s) both clean beyond the same pre-existing PDF failure.
+- [x] 5.3 `cd web && npm test -- presets` (or the project's usual vitest invocation)
+      for the frontend changes.
+      `npx vitest run presets`: 22/22 pass.
+- [ ] 5.4 Manually confirm in a dev environment: create a `browse` session from the
+      extension, confirm it no longer appears in `/my/assistant`'s rail, and confirm
+      a direct link to its id on the website shows the dead-link state rather than a
+      working chat.
+      NOT DONE — needs `make up` + a built/loaded extension + a signed-in browser
+      session; left for the user or a follow-up live-verification pass.

--- a/web/src/lib/assistant/presets.test.ts
+++ b/web/src/lib/assistant/presets.test.ts
@@ -105,19 +105,24 @@ describe('profileKickoff', () => {
 
 describe('opensInRail', () => {
   it('opens every conversation the rail lists', () => {
-    // These are the presets ListAssistantSessions returns. A browsing conversation
-    // started in the extension's side panel is meant to be picked up here — refusing it
-    // stranded anyone whose newest chat came from the extension, because boot() opens
-    // the newest and the dead-link panel replaces the rail that would let them escape.
+    // These are the presets ListAssistantSessions returns.
     expect(opensInRail('chat')).toBe(true);
     expect(opensInRail('profile')).toBe(true);
-    expect(opensInRail('browse')).toBe(true);
   });
 
   it('refuses a conversation bound to an artifact', () => {
     // A tailoring chat belongs to the CV that owns it and is reached through the
     // tailoring workspace; opening one here shows a conversation the rail cannot list.
     expect(opensInRail('tailor')).toBe(false);
+  });
+
+  it('refuses a browsing conversation', () => {
+    // read_current_page — the one thing that makes a browsing session worth having —
+    // only works over the extension's own connection. The backend already excludes
+    // `browse` from ListAssistantSessions; this refuses it here too, so a bookmarked or
+    // guessed link to one shows the same "chat unavailable" state a tailoring link does,
+    // rather than silently opening a chat with no page tool.
+    expect(opensInRail('browse')).toBe(false);
   });
 
   it('admits a preset it has not heard of', () => {

--- a/web/src/lib/assistant/presets.ts
+++ b/web/src/lib/assistant/presets.ts
@@ -83,18 +83,19 @@ export function entryFromQuery(params: URLSearchParams): AssistantEntry {
  * Whether this surface may open a conversation running under `preset`.
  *
  * Stated as a refusal, not a whitelist, and that is the point: `ListAssistantSessions`
- * decides what the rail carries (chat, profile and browse today), and a client that
- * whitelists presets goes stale the moment the backend gains one. It did — `browse`
- * arrived with the extension's side panel and this check did not follow, so anyone whose
- * newest conversation came from the extension landed on the dead-link panel, which
- * replaces the rail they would have escaped through.
+ * decides what the rail carries (chat, profile, interview and debrief today), and a
+ * client that whitelists presets goes stale the moment the backend gains one.
  *
- * Only a conversation BOUND to another artifact is refused: a tailoring chat belongs to
- * the CV that owns it, is reached through the tailoring workspace, and its tools close
- * over ids this surface knows nothing about.
+ * Two presets are refused, for two different reasons. A tailoring chat belongs to the
+ * CV that owns it, is reached through the tailoring workspace, and its tools close over
+ * ids this surface knows nothing about. A browsing chat's one distinguishing tool,
+ * `read_current_page`, only works over the extension's own connection — the backend
+ * already excludes it from `ListAssistantSessions`, and this refuses it here too, so a
+ * bookmarked or guessed link to one shows the same "chat unavailable" state rather than
+ * silently opening a chat that lost its reason to exist.
  */
 export function opensInRail(preset: string): boolean {
-  return preset !== 'tailor';
+  return preset !== 'tailor' && preset !== 'browse';
 }
 
 /**

--- a/web/src/lib/docs/api-spec.ts
+++ b/web/src/lib/docs/api-spec.ts
@@ -8,7 +8,7 @@
 export const BASE_URL = 'https://freehire.me/api/v1';
 
 /** Authentication requirement for an endpoint, rendered as a badge. */
-export type Auth = 'none' | 'cookie-or-key' | 'cookie' | 'moderator';
+export type Auth = 'none' | 'cookie-or-key' | 'cookie' | 'moderator' | 'extension';
 
 /** Human-readable label for an auth level. */
 export const AUTH_LABELS: Record<Auth, string> = {
@@ -16,6 +16,7 @@ export const AUTH_LABELS: Record<Auth, string> = {
   'cookie-or-key': 'Session or API key',
   cookie: 'Session only',
   moderator: 'Moderator',
+  extension: 'Browser extension only',
 };
 
 /** A single request parameter (path, query, or body field). */
@@ -1699,13 +1700,15 @@ ${BASE_URL}/auth/oauth/google/start`,
       {
         method: 'POST',
         path: '/me/autofill/run',
-        auth: 'cookie-or-key',
+        auth: 'extension',
         summary: 'Drive your own browser to fill an application form.',
         description:
           'Runs the autofill agent over the browser-tool wire — your extension on ' +
           'one end, the agent on the other, routed strictly within your own channel. ' +
-          'Requires the extension to be connected.',
-        curl: `curl -X POST "${BASE_URL}/me/autofill/run" -H "Authorization: Bearer fhk_…"`,
+          "Requires the extension to be connected, and authenticates only as the " +
+          'extension itself — a session cookie or an API key gets a 403, since this ' +
+          'call writes into whatever form your browser has open, not just reads it.',
+        curl: `curl -X POST "${BASE_URL}/me/autofill/run" -H "Authorization: Bearer <extension session token>"`,
         responseExample: `{ "data": { "filled": 11, "skipped": 2 } }`,
       },
     ],


### PR DESCRIPTION
## Summary
- A `browse`-preset assistant session was listed and continuable from the ordinary website (`/my/assistant`), and `read_current_page` was granted purely by `session.preset`, with no check on how the turn's request authenticated. `internal/browsertools.Hub` is keyed by user id, not session id, so a user with the extension connected elsewhere could get the "ordinary" website chat to silently read whatever page their extension had open.
- `GET /assistant/sessions` no longer lists `browse` sessions (SQL layer, alongside the existing `tailor` exclusion); the website treats a `browse` session reached by direct URL as unavailable, same as `tailor`. **BREAKING**: a browsing conversation can no longer be resumed from the desktop website — each surface's history stays on that surface.
- `read_current_page`'s registration and the turn's system prompt both now resolve from one carrier-aware `effectivePreset`, computed once in `streamSSE`, so a `browse` turn that isn't authenticated as the extension degrades to an ordinary chat — not a chat tool set running under a prompt that opens by insisting on a tool it doesn't have.
- `POST /me/autofill/run` had the identical gap (found during review), and it *writes* into the live form on whatever page is attached rather than reading it — refused outright (403) now unless the caller is the extension's own Bearer session JWT.
- `internal/auth` gains `ViaCookie` and `IsExtensionBearer`, mirroring the existing `ViaAPIKey`, as the one shared definition of "this is the extension's own connection."

Full OpenSpec proposal/design/tasks: `openspec/changes/confine-browse-preset-to-extension/`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` — clean
- [x] `go test ./...` — clean (one pre-existing, unrelated failure: `TestExtractResumeProfile_PDF`, confirmed present on unmodified `origin/main` too)
- [x] `go test -tags=integration ./internal/db/` and `./internal/handler/` — clean beyond the same pre-existing failure
- [x] `npx vitest run` (web) — 1006/1006
- [x] `npm run check` (svelte-check) — 0 errors
- [x] `npm run gen:api-docs:smoke` — 16/16
- [x] Three rounds of `/code-review`, each round's findings fixed and re-verified
- [ ] Manual: create a `browse` session from the extension, confirm it no longer appears in `/my/assistant`'s rail, and confirm a direct link to its id on the website shows the dead-link state — not done, needs `make up` + a built/loaded extension + a signed-in browser session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser browsing sessions are now available only through the browser extension.
  * Website session lists exclude browsing and tailoring conversations while retaining chats, interviews, rehearsals, and debriefs.
  * Non-extension browsing requests use standard chat behavior without page-reading capabilities.

* **Security**
  * Agent-driven autofill now requires browser extension authentication; cookie- and API-key-authenticated requests receive a 403 response.

* **Documentation**
  * Updated API authentication requirements and employment filter documentation, including the new `fellowship` value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->