### PR TITLE
Pace the Teamtailor crawl to stop producing the 403s

### DIFF
--- a/internal/sources/pacer.go
+++ b/internal/sources/pacer.go
@@ -154,3 +154,23 @@ const (
 	hhRequestInterval = 250 * time.Millisecond // ~4 req/s
 	hhRequestBurst    = 4
 )
+
+// Teamtailor 403s the crawl in bulk, and the 403 is ours: a "failing" board answers 200 on
+// demand from the same IP, and 1207 of 1208 failures carried a timestamp inside the crawl hour.
+// The cause is the shape of the adapter — every posting's description is its own page fetch — so
+// a run is ~4k listing requests plus ~33k detail ones, and it fired them in 10 minutes: about
+// 62 req/s at one career-site vendor. Nearly half the fleet was turned away.
+//
+// Pacing is the lever that removes the burst rather than moving it: the refusal-retry proxy
+// (see refusalRetryProviders) recovered only a quarter of the failures, because a reputation
+// 403 follows the volume onto whatever address carries it.
+//
+// The interval is set by the run budget, not by a guess at Teamtailor's window: ~37k requests
+// must finish inside the ingest unit's TimeoutStartSec (3000s), so the floor is ~12 req/s and
+// this sits above it with room — a full run near 31 minutes. It is the first deliberate rate
+// this platform has had; tune from observed convergence, downward while boards are still
+// refused and upward only while they are not.
+const (
+	teamtailorRequestInterval = 50 * time.Millisecond // ~20 req/s
+	teamtailorRequestBurst    = 8
+)

--- a/internal/sources/proxy.go
+++ b/internal/sources/proxy.go
@@ -105,8 +105,12 @@ var proxiedProviders = map[string]func(HTTPClient) Source{
 // path. Moving ~3000 boards an hour onto it would concentrate the same burst on a weaker IP and
 // take the budget from the providers with nowhere else to go.
 var refusalRetryProviders = map[string]func(HTTPClient) Source{
-	"workable":   func(c HTTPClient) Source { return NewWorkable(c) },
-	"teamtailor": func(c HTTPClient) Source { return NewTeamtailor(c) },
+	"workable": func(c HTTPClient) Source { return NewWorkable(c) },
+	// Paced as well as refusal-retried: the proxy recovers a refused request, the pacer stops
+	// producing them. Without the pacer this entry alone moved only a quarter of the failures.
+	"teamtailor": func(c HTTPClient) Source {
+		return NewTeamtailor(pacedHTMLGetter(c, teamtailorRequestInterval, teamtailorRequestBurst))
+	},
 }
 
 // IsProxied reports whether provider is on the proxied-egress allowlist — the providers

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -133,7 +133,9 @@ func All(c HTTPClient) map[string]Source {
 		NewHiBob(c),
 		NewGem(c),
 		NewSuccessFactors(c),
-		NewTeamtailor(c),
+		// Paced: its per-posting detail fan-out fired ~37k requests in 10 minutes and Teamtailor
+		// 403'd nearly half the fleet (see teamtailorRequestInterval).
+		NewTeamtailor(pacedHTMLGetter(c, teamtailorRequestInterval, teamtailorRequestBurst)),
 		NewHurma(c),
 		NewICIMS(c),
 		// careerspage is rate-paced (pacedHTMLGetter); the proxied path paces it too.

--- a/internal/sources/teamtailor_pace_test.go
+++ b/internal/sources/teamtailor_pace_test.go
@@ -1,0 +1,59 @@
+package sources
+
+import (
+	"testing"
+	"time"
+)
+
+// The rate exists to fit a measured run inside the ingest unit's budget. If either number moves
+// without the other being reconsidered, the crawl either keeps 403ing (too fast) or gets killed
+// at TimeoutStartSec with the tail uncrawled (too slow) — and a killed run looks exactly like a
+// platform outage in board_health.
+func TestTeamtailorPaceFitsTheRunBudget(t *testing.T) {
+	// Measured on prod 2026-08-16: 1987 boards, ~2 listing pages each, 33375 postings each
+	// costing one detail page.
+	const (
+		requestsPerRun = 1987*2 + 33375
+		unitTimeout    = 3000 * time.Second // freehire-ingest@.service TimeoutStartSec
+	)
+
+	perSecond := float64(time.Second) / float64(teamtailorRequestInterval)
+	runtime := time.Duration(float64(requestsPerRun) / perSecond * float64(time.Second))
+
+	if runtime > unitTimeout {
+		t.Errorf("a full run takes %v at %.1f req/s, past the unit's %v budget — the tail would be "+
+			"killed mid-crawl", runtime.Round(time.Second), perSecond, unitTimeout)
+	}
+	// The measured unpaced rate was ~62 req/s and it lost ~46%% of the fleet, so a "pace" that
+	// close to it would not be a pace at all.
+	if perSecond > 30 {
+		t.Errorf("%.1f req/s is not meaningfully below the unpaced ~62 req/s that Teamtailor refused", perSecond)
+	}
+}
+
+// Both call sites must pace: the registry one serves local/dev and any run without a proxy, the
+// proxy one serves prod. Pacing only one leaves prod or dev firing the burst that caused this.
+func TestTeamtailorPacedInBothWirings(t *testing.T) {
+	direct := All(NewClient())["teamtailor"]
+	if _, paced := unwrapTeamtailorGetter(direct).(rateLimitedHTMLGetter); !paced {
+		t.Error("registry teamtailor is not paced")
+	}
+
+	t.Setenv("SOURCES_PROXY_URL", "http://user:pass@proxy.example:8080")
+	registry := All(NewClient())
+	if err := ApplyProxyEgress(registry); err != nil {
+		t.Fatalf("ApplyProxyEgress: %v", err)
+	}
+	if _, paced := unwrapTeamtailorGetter(registry["teamtailor"]).(rateLimitedHTMLGetter); !paced {
+		t.Error("proxied teamtailor is not paced")
+	}
+}
+
+// unwrapTeamtailorGetter reaches the HTMLGetter the adapter was built over.
+func unwrapTeamtailorGetter(s Source) HTMLGetter {
+	tt, ok := s.(teamtailor)
+	if !ok {
+		return nil
+	}
+	return tt.http
+}


### PR DESCRIPTION
## The measurement

A Teamtailor run makes **~37,000 requests** — ~4k listing pages plus **one detail page for each
of 33,375 postings**, because that is where the description lives — and the last run made them
in **ten minutes**. That is roughly **62 req/s** aimed at a single career-site vendor.

Teamtailor turned away **1208 of 1987 boards**. The refusals are ours, not a block: a "failing"
board answers 200 on demand from the same IP, and 1207 of the 1208 failures carried a timestamp
inside the crawl hour.

## Why the proxy was not enough

#1989 sends a refused request out through the proxy, and that recovered **only a quarter** of
teamtailor's failures (1208 → 909) while doing most of the job for workable (1018 → 303).

The difference is what the two status codes mean. Workable's **429** is a per-IP counter and a
fresh address resets it. Teamtailor's **403** is its edge judging the address, so it follows the
volume onto whatever IP carries it — and our proxy is one shared address that ~900 refused
requests per run saturate on their own.

So the two changes compose rather than compete: **the pacer stops producing refusals, the proxy
recovers the ones still produced.**

## Choosing the rate

From the run budget, not from a guess at Teamtailor's window:

| | |
|---|---|
| requests per run | ~37,000 |
| unit budget (`TimeoutStartSec`) | 3000s |
| implied floor | ~12 req/s |
| **chosen** | **20 req/s**, burst 8 |
| resulting run | ~31 min (against 10 today) |

A test pins that arithmetic, so neither the interval nor the volume assumption can move alone.
Too fast keeps the 403s; too slow gets the run killed mid-crawl — and a killed run is
indistinguishable from a platform outage in `board_health`.

This is the first deliberate rate this platform has had, so it should be tuned from observed
convergence: downward while boards are still refused, upward only while they are not.

## Wiring

Paced at both call sites, the way careerspage already is — the registry one covers local, dev
and any run without a proxy, the proxied one covers prod. A test asserts both, since pacing only
one leaves either prod or dev still firing the burst.