### PR TITLE
Fetch a Teamtailor description only for a posting we do not have

### DIFF
--- a/internal/sources/pacer.go
+++ b/internal/sources/pacer.go
@@ -165,6 +165,11 @@ const (
 // (see refusalRetryProviders) recovered only a quarter of the failures, because a reputation
 // 403 follows the volume onto whatever address carries it.
 //
+// Since FetchNew, a normal run costs a request per NEW posting rather than per posting, so the
+// rate matters far less than it did — but the pace stays, sized for the worst case it still has
+// to survive: the Fetch fallback, used whenever the pipeline cannot supply a seen set, which
+// hydrates everything exactly as before.
+//
 // The interval is set by the run budget, not by a guess at Teamtailor's window: ~37k requests
 // must finish inside the ingest unit's TimeoutStartSec (3000s), so the floor is ~12 req/s and
 // this sits above it with room — a full run near 31 minutes. It is the first deliberate rate

--- a/internal/sources/teamtailor.go
+++ b/internal/sources/teamtailor.go
@@ -31,6 +31,54 @@ const (
 )
 
 func (t teamtailor) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	urls, err := t.jobURLs(ctx, e)
+	if err != nil {
+		return nil, err
+	}
+
+	// Each job's posting comes from its own page fetch, fanned out under a bounded pool.
+	return fetchDetails(urls, defaultDetailWorkers, func(u string) (Job, bool) {
+		return t.detail(ctx, e, u)
+	}), nil
+}
+
+// FetchNew is the hydrating crawl: it enumerates the whole board, but fetches a posting's detail
+// page only for an id the catalogue does not already have. A seen posting is emitted as a
+// liveness refresh (identity only, no detail request, no content rewrite); an unseen one is
+// hydrated as before.
+//
+// This is the difference between a run that costs a request per POSTING and one that costs a
+// request per NEW posting, and on this platform the two are worlds apart: measured on prod
+// 2026-08-16, the board file holds ~40k live postings and about one an hour is genuinely new, so
+// the old crawl spent ~36.7k detail fetches to discover ~100. That volume is what Teamtailor's
+// edge turned away — nearly half the fleet 403'd — and what pacing could only spread out.
+func (t teamtailor) FetchNew(ctx context.Context, e CompanyEntry, seen func(externalID string) bool) ([]Job, error) {
+	urls, err := t.jobURLs(ctx, e)
+	if err != nil {
+		return nil, err
+	}
+
+	return fetchDetails(urls, defaultDetailWorkers, func(u string) (Job, bool) {
+		id := ttJobID(u)
+		if id == "" {
+			return Job{}, false // no native id → would collide on the dedup key; skip it
+		}
+		// Already ingested: refresh liveness by identity only. Re-upserting it content-less
+		// would wipe the description and the facets derived from it, so the pipeline routes a
+		// SeenRefresh to a liveness touch instead of a write.
+		if seen(id) {
+			// Identity only: the pipeline resolves the row by (provider, board-namespaced id),
+			// and it judges an empty-titled refresh on the STORED evidence rather than on this
+			// content-less listing — so no title is the honest thing to send, not a defect.
+			return Job{ExternalID: id, URL: u, Company: e.Company, SeenRefresh: true}, true
+		}
+		return t.detail(ctx, e, u)
+	}), nil
+}
+
+// jobURLs enumerates every posting URL on a board — the listing walk shared by Fetch and
+// FetchNew, which differ only in what they do with the result.
+func (t teamtailor) jobURLs(ctx context.Context, e CompanyEntry) ([]string, error) {
 	// base carries the scheme+host; relative job hrefs resolve against it (an absolute
 	// href resolves to itself), so it is parsed once rather than per listing page.
 	base, err := url.Parse(fmt.Sprintf("https://%s/", e.Board))
@@ -76,11 +124,7 @@ func (t teamtailor) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 			break
 		}
 	}
-
-	// Each job's posting comes from its own page fetch, fanned out under a bounded pool.
-	return fetchDetails(urls, defaultDetailWorkers, func(u string) (Job, bool) {
-		return t.detail(ctx, e, u)
-	}), nil
+	return urls, nil
 }
 
 // detail fetches one job page and maps its JobPosting ld+json to a Job, returning ok=false

--- a/internal/sources/teamtailor_hydrate_test.go
+++ b/internal/sources/teamtailor_hydrate_test.go
@@ -1,0 +1,135 @@
+package sources
+
+import (
+	"context"
+	"testing"
+)
+
+// The whole point: a posting the catalogue already holds costs no detail request. Teamtailor
+// re-fetched every description every hour — 36771 detail pages for the ~100 postings that were
+// actually new — which is what made the crawl a ~37k-request burst its edge turned away.
+func TestTeamtailorFetchNewSkipsDetailForSeenPostings(t *testing.T) {
+	seenURL := "https://jobs.tibber.com/jobs/1111111-known-role"
+	newURL := "https://jobs.tibber.com/jobs/2222222-fresh-role"
+	fake := (&routedHTTP{}).
+		route("page=1", ttListingHTML(seenURL, newURL)).
+		route("page=2", ttListingHTML()).
+		route("/jobs/2222222", ttDetailHTML("Fresh Role", "&lt;p&gt;New&lt;/p&gt;",
+			"2026-08-01T00:00:00+02:00", "Stockholm", "SE", ""))
+	// Deliberately no route for /jobs/1111111: if the adapter fetches the seen posting's
+	// detail the fake errors, and the posting is dropped instead of refreshed.
+
+	jobs, err := NewTeamtailor(fake).(HydratingSource).FetchNew(context.Background(),
+		CompanyEntry{Company: "Tibber", Provider: "teamtailor", Board: "jobs.tibber.com"},
+		func(id string) bool { return id == "1111111" })
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 (one refresh, one hydrated)", len(jobs))
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	refresh, ok := byID["1111111"]
+	if !ok {
+		t.Fatal("the seen posting was dropped; it must still be re-listed as a liveness refresh")
+	}
+	if !refresh.SeenRefresh {
+		t.Error("seen posting not marked SeenRefresh — the pipeline would re-upsert it content-less " +
+			"and wipe the description and facets hydrated when it was new")
+	}
+	if refresh.Description != "" {
+		t.Error("a refresh must carry no content")
+	}
+	if refresh.URL != seenURL {
+		t.Errorf("refresh URL = %q, want %q — the identity still has to resolve", refresh.URL, seenURL)
+	}
+
+	hydrated, ok := byID["2222222"]
+	if !ok {
+		t.Fatal("the unseen posting was not hydrated")
+	}
+	if hydrated.SeenRefresh {
+		t.Error("a newly hydrated posting must not be marked SeenRefresh")
+	}
+	if hydrated.Description == "" || hydrated.Title != "Fresh Role" {
+		t.Errorf("unseen posting not hydrated: title=%q descLen=%d", hydrated.Title, len(hydrated.Description))
+	}
+}
+
+// The request count is the deliverable, so assert it directly: two listing pages and exactly one
+// detail fetch for the one unseen posting, out of three postings listed.
+func TestTeamtailorFetchNewIssuesOneDetailRequestPerUnseenPosting(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("page=1", ttListingHTML(
+			"https://jobs.tibber.com/jobs/1-a",
+			"https://jobs.tibber.com/jobs/2-b",
+			"https://jobs.tibber.com/jobs/3-c")).
+		route("page=2", ttListingHTML()).
+		route("/jobs/3", ttDetailHTML("C", "&lt;p&gt;c&lt;/p&gt;", "", "", "", ""))
+
+	if _, err := NewTeamtailor(fake).(HydratingSource).FetchNew(context.Background(),
+		CompanyEntry{Company: "Tibber", Provider: "teamtailor", Board: "jobs.tibber.com"},
+		func(id string) bool { return id == "1" || id == "2" }); err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	// 2 listing pages + 1 detail. Unpaced, the old crawl would have made 5.
+	if fake.calls != 3 {
+		t.Errorf("made %d requests, want 3 (2 listing + 1 detail for the single unseen posting)", fake.calls)
+	}
+}
+
+// Every posting already known means a run that touches no detail page at all — the steady state
+// this change exists to reach, since only ~1 posting an hour is genuinely new.
+func TestTeamtailorFetchNewFetchesNoDetailWhenAllSeen(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("page=1", ttListingHTML("https://jobs.tibber.com/jobs/1-a", "https://jobs.tibber.com/jobs/2-b")).
+		route("page=2", ttListingHTML())
+
+	jobs, err := NewTeamtailor(fake).(HydratingSource).FetchNew(context.Background(),
+		CompanyEntry{Company: "Tibber", Provider: "teamtailor", Board: "jobs.tibber.com"},
+		func(string) bool { return true })
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 refreshes", len(jobs))
+	}
+	if fake.calls != 2 {
+		t.Errorf("made %d requests, want 2 (listing only)", fake.calls)
+	}
+}
+
+// A board whose listing fails must fail the board, not report it empty — an empty result would
+// let the unseen sweep close every posting the board still has.
+func TestTeamtailorFetchNewPropagatesListingFailure(t *testing.T) {
+	fake := &routedHTTP{} // no routes: the first listing GET errors
+
+	if _, err := NewTeamtailor(fake).(HydratingSource).FetchNew(context.Background(),
+		CompanyEntry{Company: "Tibber", Provider: "teamtailor", Board: "jobs.tibber.com"},
+		func(string) bool { return false }); err == nil {
+		t.Fatal("FetchNew returned nil error for a board whose listing failed")
+	}
+}
+
+// Fetch stays the list-and-hydrate-everything fallback the pipeline uses when it cannot supply a
+// seen set, so it must keep hydrating regardless.
+func TestTeamtailorFetchStillHydratesEverything(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("page=1", ttListingHTML("https://jobs.tibber.com/jobs/1-a")).
+		route("page=2", ttListingHTML()).
+		route("/jobs/1", ttDetailHTML("A", "&lt;p&gt;a&lt;/p&gt;", "", "", "", ""))
+
+	jobs, err := NewTeamtailor(fake).Fetch(context.Background(),
+		CompanyEntry{Company: "Tibber", Provider: "teamtailor", Board: "jobs.tibber.com"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].Description == "" || jobs[0].SeenRefresh {
+		t.Errorf("Fetch no longer hydrates: %+v", jobs)
+	}
+}


### PR DESCRIPTION
## The waste

The Teamtailor crawl fetched **every posting's detail page every hour**, because that is where
the description lives. Measured on prod 2026-08-16:

| | |
|---|---:|
| live postings | ~40,000 |
| genuinely new in the last hour | **1** |
| new in the last 3 hours | 341 |
| detail requests per run | **36,771** |

So a run spent ~36.7k requests to discover ~100 postings, and fired them in ten minutes — about
62 req/s at one career-site vendor. That volume is what Teamtailor's edge turned away (1208 of
1987 boards 403'd), and what #1989 and #1992 could only recover or spread out rather than remove.

## The fix already had a seam

`HydratingSource` exists for exactly this and **thirteen adapters already implement it** —
`workday` among them, a per-tenant ATS like this one. The pipeline supplies a `seen(externalID)`
predicate; the adapter hydrates only what the catalogue lacks.

`FetchNew` enumerates the board exactly as before and then:

- **unseen** posting → hydrated from its detail page, as today;
- **seen** posting → emitted as a liveness refresh carrying identity alone, no request.

That second branch is load-bearing rather than an optimisation detail: the pipeline routes a
`SeenRefresh` to a liveness touch instead of a write, because a content-less re-upsert would
re-derive the facets from an empty description and **wipe them**.

`Fetch` is untouched and still hydrates everything — it is the fallback used when the pipeline
cannot supply a seen set, and the worst case the pacer's interval is still sized for.

## Expected effect

A steady-state run should cost **~4k requests instead of ~41k**, nearly all of them the listing
pages that enumerate the board. That also unwinds the trend this exposed: run duration had crept
31 → 42 minutes against the unit's 50-minute `TimeoutStartSec`, and it was creeping *because the
earlier fixes worked* — more boards answering means more postings found means more detail
fetches.

## Tests

The request count is the deliverable, so it is asserted directly: three postings listed with two
already seen makes exactly three requests (two listing pages, one detail). Plus: a seen posting
is marked `SeenRefresh` and carries no content, an unseen one is hydrated, an all-seen board
touches no detail page at all, a failed listing still fails the board (an empty result would let
the unseen sweep close everything the board still has), and `Fetch` still hydrates everything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved incremental job updates by avoiding unnecessary detail requests for postings that have already been seen.
  * Maintained full detail loading during standard job board refreshes.
  * Added bounded concurrent loading for posting details.

* **Reliability**
  * Preserved listing-only behavior when all postings are already known.
  * Improved handling and propagation of listing failures.

* **Tests**
  * Added coverage for incremental updates, unseen postings, fully known boards, failures, and complete refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->