### PR TITLE
docs: correct catalogue counts and refresh the stale parts of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ### Every IT job, straight from the source.
 
-**3.4M+ live postings pulled directly from company career pages — no recruiters, no reposts, no dead links. Fully open source.**
+**3.3M+ live postings pulled directly from company career pages — no recruiters, no reposts, no dead links. Fully open source.**
 
 [**Try it live →**](https://freehire.me) · [Features](docs/features.md) · [Architecture](docs/architecture.md) · [Sources](#sources) · [API](#api) · [Add a source](#adding-a-source) · [Contributing](CONTRIBUTING.md)
 
@@ -36,7 +36,7 @@
 
 <br>
 
-<img src="docs/assets/freehire.gif" alt="freehire — faceted search narrowing 3.4M+ live postings by region, work format, specialization and seniority, each linking straight to the company's own careers page" width="860">
+<img src="docs/assets/freehire.gif" alt="freehire — faceted search narrowing 3.3M+ live postings by region, work format, specialization and seniority, each linking straight to the company's own careers page" width="860">
 
 </div>
 
@@ -57,9 +57,9 @@
   workspace on top of the catalogue — see [Beyond the catalogue](#beyond-the-catalogue).
   Use the hosted site, run your own, or build on top.
 
-Aggregating **3.4M+ live postings** from **220,000+ companies** across **80+ ATS
-platforms** and a long tail of aggregators and direct feeds — see
-[Sources](#sources) for the full breakdown.
+Aggregating **3.3M+ live postings** from **294,000+ companies** across **92 ATS
+platforms** and a long tail of aggregators and direct feeds — **225 live sources**
+in all, see [Sources](#sources) for the full breakdown.
 
 > If freehire saves you time — or you just like the idea of jobs straight from the
 > source — a ⭐ helps other people find it.
@@ -85,16 +85,19 @@ which draw on AI credits.
 ## Stack
 
 - **Go** + [Fiber v2](https://gofiber.io/) — HTTP server
-- **PostgreSQL** — storage and filtering
+- **PostgreSQL** + [pgvector](https://github.com/pgvector/pgvector) — storage, filtering, semantic embeddings
 - **[sqlc](https://sqlc.dev/)** — type-safe DB access from SQL (no ORM)
 - **[Meilisearch](https://www.meilisearch.com/)** — full-text and faceted job search
 - **[langchaingo](https://github.com/tmc/langchaingo)** — LLM access over any OpenAI-compatible endpoint (no vendor baked in)
+- **[SvelteKit](https://kit.svelte.dev/) 2** (Svelte 5 runes) + **Tailwind 4** — the server-rendered frontend under `web/`
+- **Redis** — rate limiting and realtime fan-out · **S3-compatible object storage** — CVs, headshots, previews
 - **Docker Compose** — local development
 
 ## Quick start
 
 ```bash
-make up        # build + start app, postgres, and meilisearch in Docker
+make up        # build + start the whole stack in Docker:
+               # api, web, postgres, meilisearch, redis, minio
 curl localhost:8080/health
 curl localhost:8080/api/v1/jobs
 ```
@@ -135,17 +138,27 @@ make migrate   # apply migrations manually to an existing DB volume
 
 ## Workers
 
-The server only serves the API. Ingest and enrichment are standalone, run-once
-workers meant for cron — each crawls or drains its queue and exits.
+The server only serves the API. Everything else — crawling, enrichment, indexing,
+notifications — is a standalone, run-once worker meant for cron: it crawls or
+drains its queue and exits. `ls cmd/` for the full list; the ones you are most
+likely to run:
 
 ```bash
+go run ./cmd/migrate       # apply pending migrations (run before deploying code that reads new schema)
 go run ./cmd/ingest sources/greenhouse.yml  # crawl one board file and upsert jobs (path also via SOURCES_FILE)
 go run ./cmd/enrich        # drain the enrichment queue (LLM); needs LLM_* config
+go run ./cmd/embed         # drain the semantic queue into pgvector chunks
+go run ./cmd/search-drain  # push queued job writes into the live search index (run every 1-2 min)
+go run ./cmd/reindex       # rebuild the Meilisearch index from Postgres (full swap)
 go run ./cmd/tg-ingest     # crawl the Telegram channels in sources/telegram.yml
 go run ./cmd/tg-extract    # LLM-extract vacancies from crawled Telegram posts
-go run ./cmd/reindex       # rebuild the Meilisearch index from Postgres
-go run ./cmd/backfill-derive  # re-derive all six dictionary facets on existing jobs (follow with make reindex)
+go run ./cmd/capture-apply-form  # fetch queued postings' ATS application forms
+go run ./cmd/backfill-derive     # re-derive every deterministic column — facets, fingerprints,
+                                 # slugs — in one keyset pass (follow with make reindex)
 ```
+
+Every worker needs `DATABASE_URL` and exits non-zero on failure. `prune` is the
+only hard-delete path in the system, and it is dry-run by default.
 
 ## Layout
 
@@ -153,27 +166,35 @@ go run ./cmd/backfill-derive  # re-derive all six dictionary facets on existing 
 cmd/                 entry points: server + the standalone workers above
 sources/             board files, one per provider (e.g. greenhouse.yml = company + board id),
                      plus a mixed custom.yml and telegram.yml (Telegram channels to crawl)
-internal/
+migrations/          SQL schema (source for both sqlc and initdb)
+web/                 the SvelteKit frontend
+extension/           the Chrome side-panel extension
+design-system/       shared tokens and components, linked into web/ and extension/
+internal/            ~130 domain packages; the load-bearing ones:
   config/            env configuration
-  database/          pgxpool connection pool
-  db/                generated sqlc code + queries/*.sql
+  database/ db/      pgxpool pool; generated sqlc code + queries/*.sql
   handler/           HTTP handlers
   auth/              auth primitives (JWT cookie, API keys) + OAuth sign-in
-  sources/           ATS source adapters (greenhouse / lever / ashby) + registry
+  sources/           source adapters (greenhouse / lever / adzuna / …) + registry
+  pipeline/          ingest runner (fetch → normalize → dedup → upsert)
   linksource/        resolves outbound job links found in Telegram posts
   telegram/          Telegram-channel crawl + LLM vacancy extraction
-  pipeline/          ingest runner (fetch → normalize → dedup → upsert)
   enrich/            typed AI-enrichment contract + queue-draining runner
-  search/            Meilisearch indexing and query
-  location/          geography parsed from free-text ATS location strings
+  search/ searchdrain/  Meilisearch indexing and query; incremental drain of the write queue
+  embed/             semantic chunk embeddings into pgvector
+  location/ classify/ skilltag/  the curated facet dictionaries — never guess, emit nothing
+  ghost/             the posting-reality signal behind "is this job real?"
   jobview/           the single public wire shape of a job
-  normalize/         slug normalization
   cv/ cvedit/        structured CVs + PDF rendering; cvedit is their only writer
   experience/        durable employments + evidence atoms behind every CV claim
-  userjob/           per-user job tracking (view / apply / save / stages)
+  cvmatch/ matchanalysis/  deterministic CV↔vacancy score; the LLM fit analysis on top
+  applyform/         captured ATS application forms, in the platform's own vocabulary
+  userjob/ appevent/ per-user tracking (view / apply / save / stages) + the event ledger
   inbox/             recruiter mail → classify → link to an application
   assistant/         the in-process agent: turn loop, tools, transcripts
-migrations/          SQL schema (source for both sqlc and initdb)
+  browsertools/      relays tool frames between the agent and the browser extension
+  referral/ collections/  employee referrals; curated company tags
+  llm/ llmkey/       provider-agnostic LLM client + per-user spend attribution
 ```
 
 ## Architecture
@@ -197,22 +218,26 @@ search-filter vocabulary: [freehire.me/docs/api](https://freehire.me/docs/api).*
 
 ## Sources
 
-Live catalogue snapshot — **3,445,246 open postings** across **223,685 companies**.
-Counts are open postings unless noted; a company crawled from two sources is
-counted under each. Every source is one of three kinds:
+Live catalogue snapshot — **3,300,615 open postings** across **294,282 companies**,
+crawled from **225 live sources**. Counts are open postings unless noted; a
+company crawled from two sources is counted under each. Every source is one of
+three kinds:
 
 - **ATS platforms** — one adapter per multi-tenant applicant-tracking system,
   each serving many companies (Workday, Greenhouse, Lever, iCIMS…).
-  **84 platforms · 2,797,390 open postings.**
+  **92 platforms · 157,399 companies · 2,644,796 open postings.**
 - **Aggregators & job boards** — third-party feeds that republish many
-  companies' postings (mycareersfuture, himalayas, jobtech, Telegram…).
-  **47 sources · 612,690 open postings.**
+  companies' postings (Adzuna, trudvsem, himalayas, Telegram channels…).
+  **100 sources · 172,884 companies · 629,571 open postings.**
 - **Company career sites** — direct single-company feeds crawled from a
   company's own careers page (Amazon, Apple, Google, Yandex, Sber…).
-  **36 feeds · 35,160 open postings.**
+  **30 feeds · 59 companies · 26,222 open postings.**
 
-Full per-source breakdown — every one of the 167 sources with its own
-companies/open-jobs count — lives on its own page: [docs/sources.md](docs/sources.md).
+A source's kind is not configuration but a property of the adapter's own Go type,
+so `internal/sources` classifies every provider without a network call.
+
+Full per-source breakdown — every source with its own companies/open-jobs
+count — lives on its own page: [docs/sources.md](docs/sources.md).
 
 ## Adding a source
 
@@ -232,8 +257,11 @@ new provider before any code.
 
 ## Frontend
 
-A Svelte SPA lives under `web/` and consumes the API (same-origin; a dev Vite
-proxy forwards `/api` to the backend).
+A server-rendered SvelteKit 2 app (Svelte 5 runes, Tailwind 4, `adapter-node`)
+lives under `web/` and consumes the API same-origin; a dev Vite proxy forwards
+`/api` to the backend. Shared tokens and components come from the sibling
+`design-system/` package — install it before building `web/` or `extension/`,
+since it is symlinked, not copied. See [web/AGENTS.md](web/AGENTS.md).
 
 ## Browser extension
 

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -1,205 +1,263 @@
 # Sources
 
 The [README](../README.md) covers what freehire is; this is the full per-source
-breakdown behind the "3.4M+ postings" headline. Live catalogue snapshot —
-**3,445,246 open postings** across **223,685 companies**. Counts are open
-postings unless noted; a company crawled from two sources is counted under
-each, so the per-section company totals below sum to more than the distinct
-figure above. Every source is one of three kinds:
+breakdown behind the "3.3M+ postings" headline. Live catalogue snapshot —
+**3,300,615 open postings** across **294,282 companies** from
+**225** sources. Counts are open postings unless noted; a company crawled
+from two sources is counted under each, so the per-section company totals below
+sum to more than the distinct figure above. Every source is one of three kinds:
 
 - **ATS platforms** — one adapter per multi-tenant applicant-tracking system,
   each serving many companies (Workday, Greenhouse, Lever, iCIMS…).
 - **Aggregators & job boards** — third-party feeds that republish many
-  companies' postings (mycareersfuture, himalayas, jobtech, Telegram…).
+  companies' postings (Adzuna, trudvsem, himalayas, jobtech, Telegram…).
 - **Company career sites** — direct single-company feeds crawled from a
   company's own careers page (Amazon, Apple, Google, Yandex, Sber…).
 
+A source's kind is not configuration: it falls out of the adapter's own Go type
+in `internal/sources`, so the split below is derived, not maintained by hand.
+
 ## ATS platforms
 
-**84 platforms · 79,299 companies · 2,797,390 open postings.**
+**92 platforms · 157,399 companies · 2,644,796 open postings.**
 
 | Source | Companies | Open jobs |
 | --- | ---: | ---: |
-| workday | 4,124 | 790,007 |
-| oracle | 526 | 412,372 |
-| smartrecruiters | 2,557 | 264,647 |
-| greenhouse | 6,697 | 174,370 |
-| ukg | 1 | 157,286 |
-| icims | 2,985 | 100,990 |
-| paycom | 5,748 | 88,329 |
-| lever | 2,168 | 65,182 |
-| gupy | 1,428 | 62,465 |
-| ashby | 3,815 | 59,637 |
-| apploi | 2,957 | 53,388 |
-| bamboohr | 8,843 | 52,310 |
-| jazzhr | 3,802 | 43,162 |
-| phenom | 48 | 42,083 |
-| recruitee | 1,851 | 41,419 |
-| workable | 1,008 | 39,912 |
-| personio | 4,049 | 37,529 |
-| paylocity | 2,624 | 26,823 |
-| eightfold | 43 | 25,011 |
-| breezy | 1,685 | 24,637 |
-| teamtailor | 1,457 | 20,880 |
-| zohorecruit | 1,075 | 19,835 |
-| applicantpro | 1,761 | 19,720 |
-| jibe | 15 | 19,308 |
-| hireology | 2,252 | 16,379 |
-| careerplug | 4,286 | 14,764 |
-| pinpoint | 647 | 14,275 |
-| isolvedhire | 1,997 | 13,863 |
-| solides | 1,125 | 13,177 |
-| join | 3,997 | 9,760 |
-| jobylon | 886 | 8,320 |
-| inhire | 365 | 7,873 |
-| trakstar | 647 | 6,542 |
-| freshteam | 193 | 6,274 |
-| taleo | 13 | 6,133 |
-| successfactors | 12 | 4,521 |
-| factorial | 478 | 4,425 |
-| jobvite | 91 | 4,142 |
-| erecruiter | 30 | 2,553 |
-| gem | 225 | 2,367 |
-| traffit | 44 | 2,069 |
-| radancy | 7 | 1,934 |
-| senior | 83 | 1,725 |
-| cornerstone | 14 | 1,590 |
-| manatal | 17 | 1,373 |
-| rippling | 89 | 1,304 |
-| betterteam | 146 | 1,238 |
-| avature | 3 | 1,233 |
-| neogov | 11 | 1,072 |
-| pageup | 8 | 965 |
-| comeet | 21 | 892 |
-| softgarden | 18 | 815 |
-| loxo | 12 | 669 |
-| deel | 60 | 580 |
-| peopleforce | 63 | 556 |
-| clinch | 1 | 390 |
-| hibob | 17 | 387 |
-| wpyoast | 1 | 355 |
-| opencats | 9 | 238 |
-| compleo | 4 | 180 |
-| huntflow | 24 | 166 |
-| catsone | 4 | 153 |
-| ashbygraphql | 3 | 129 |
-| ismartrecruit | 2 | 104 |
-| cleverstaff | 35 | 84 |
-| jobscore | 6 | 82 |
-| bullhorn | 2 | 71 |
-| weblink | 32 | 51 |
-| hurma | 5 | 43 |
-| careerspage | 3 | 43 |
-| earcu | 1 | 41 |
+| workday | 4,202 | 748,235 |
+| trudvsem | 70,228 | 266,965 |
+| smartrecruiters | 2,810 | 218,150 |
+| oracle | 636 | 205,930 |
+| greenhouse | 6,863 | 155,528 |
+| ukg | 1,897 | 151,597 |
+| icims | 3,062 | 77,788 |
+| paycom | 5,804 | 69,672 |
+| ashby | 3,994 | 56,647 |
+| phenom | 92 | 53,137 |
+| gupy | 1,429 | 52,408 |
+| bamboohr | 9,120 | 50,674 |
+| lever | 2,205 | 50,293 |
+| workable | 1,480 | 40,563 |
+| recruitee | 2,037 | 39,521 |
+| teamtailor | 1,899 | 36,452 |
+| personio | 4,108 | 35,342 |
+| jazzhr | 3,940 | 34,285 |
+| paylocity | 2,635 | 23,303 |
+| breezy | 1,753 | 20,902 |
+| zohorecruit | 1,203 | 20,185 |
+| eightfold | 45 | 19,706 |
+| apploi | 2,957 | 17,742 |
+| applicantpro | 1,802 | 16,186 |
+| hireology | 2,293 | 15,364 |
+| pinpoint | 806 | 12,954 |
+| solides | 1,132 | 12,406 |
+| careerplug | 4,515 | 12,324 |
+| radancy | 575 | 12,313 |
+| isolvedhire | 2,043 | 12,149 |
+| jibe | 46 | 11,984 |
+| join | 4,260 | 9,393 |
+| manatal | 141 | 9,230 |
+| taleo | 27 | 7,818 |
+| inhire | 368 | 7,034 |
+| trakstar | 665 | 6,549 |
+| freshteam | 214 | 6,065 |
+| jobvite | 149 | 4,667 |
+| arbeitsagentur | 2,080 | 4,499 |
+| successfactors | 12 | 4,401 |
+| factorial | 482 | 4,270 |
+| rippling | 320 | 3,256 |
+| gem | 250 | 2,461 |
+| erecruiter | 30 | 2,434 |
+| traffit | 49 | 2,161 |
+| neogov | 16 | 1,842 |
+| senior | 83 | 1,591 |
+| likeit | 16 | 1,466 |
+| peopleforce | 77 | 1,458 |
+| cornerstone | 15 | 1,421 |
+| avature | 4 | 1,328 |
+| catsone | 21 | 1,086 |
+| betterteam | 150 | 1,007 |
+| pageup | 8 | 978 |
+| epam | 1 | 954 |
+| hibob | 67 | 911 |
+| softgarden | 20 | 867 |
+| luxoft | 1 | 747 |
+| loxo | 12 | 672 |
+| comeet | 23 | 625 |
+| deel | 65 | 580 |
+| wpyoast | 1 | 372 |
+| clinch | 1 | 363 |
+| compleo | 4 | 179 |
+| huntflow | 24 | 176 |
+| opencats | 9 | 164 |
+| workablemarketplace | 2 | 108 |
+| ismartrecruit | 2 | 102 |
+| ashbygraphql | 3 | 101 |
+| jobscore | 6 | 92 |
+| cleverstaff | 40 | 86 |
+| talentlyft | 8 | 73 |
+| bullhorn | 2 | 69 |
+| hurma | 7 | 51 |
+| earcu | 1 | 50 |
+| globalpayments | 1 | 45 |
+| quickin | 5 | 41 |
+| careerspage | 3 | 41 |
 | recruitingsolutions | 17 | 40 |
-| quickin | 3 | 32 |
-| talentlyft | 3 | 21 |
-| adp | 1 | 19 |
-| speedrun | 10 | 15 |
-| enlizt | 2 | 13 |
+| vention | 1 | 34 |
+| rapyd | 1 | 28 |
+| northstone | 3 | 21 |
+| adp | 1 | 17 |
+| speedrun | 10 | 16 |
 | odoo | 1 | 12 |
-| mindsight | 1 | 10 |
 | vouch | 1 | 10 |
-| spark | 1 | 8 |
-| talenthr | 1 | 4 |
+| mindsight | 1 | 8 |
+| spark | 1 | 7 |
+| enlizt | 2 | 6 |
+| talenthr | 2 | 4 |
 | talentadore | 1 | 2 |
 | briefhq | 1 | 2 |
 
 ## Aggregators & job boards
 
-**47 sources · 162,917 companies · 612,690 open postings.**
+**100 sources · 172,884 companies · 629,571 open postings.**
 
 | Source | Companies | Open jobs |
 | --- | ---: | ---: |
-| trudvsem | 56,770 | 231,054 |
-| mycareersfuture | 20,909 | 90,822 |
-| jobtech | 8,858 | 27,329 |
-| himalayas | 13,011 | 23,251 |
-| 4dayweek | 732 | 21,627 |
-| infojobs | 14,556 | 21,341 |
-| gulftalent | 776 | 19,828 |
-| nofluffjobs | 426 | 19,712 |
-| jobdanmark | 5,813 | 15,931 |
-| jobnet | 6,949 | 14,485 |
-| tyomarkkinatori | 3,567 | 11,752 |
-| justjoin | 1,234 | 11,161 |
-| reed | 1,536 | 10,651 |
-| whatjobs | 3,182 | 9,523 |
-| powertofly | 30 | 9,023 |
-| hh | 4,864 | 8,979 |
-| telegram | 2,978 | 8,537 |
-| usajobs | 372 | 7,648 |
-| jobstash | 930 | 7,535 |
-| djinni | 2,202 | 6,904 |
-| arbeitnow | 2,568 | 6,373 |
-| wantedkr | 2,440 | 5,840 |
-| workatastartup | 1,434 | 5,213 |
-| arbeitsagentur | 2,067 | 4,612 |
-| vagas | 468 | 1,641 |
-| likeit | 16 | 1,422 |
-| thehub | 322 | 1,278 |
-| instaffo | 607 | 1,221 |
-| getonbrd | 313 | 1,156 |
-| habr_career | 184 | 1,106 |
-| remoteok | 935 | 1,067 |
-| functionalworks | 333 | 884 |
-| getmatch | 147 | 816 |
-| jobicy | 453 | 606 |
-| wantapply | 102 | 528 |
-| getro | 122 | 436 |
-| weworkremotely | 326 | 420 |
-| workablemarketplace | 2 | 373 |
-| geekjob | 177 | 280 |
-| startupandvc | 74 | 100 |
-| tecla | 37 | 64 |
-| workingnomads | 21 | 49 |
-| remotive | 23 | 38 |
-| getmanfred | 32 | 37 |
-| jobspresso | 14 | 18 |
-| topco | 4 | 11 |
+| adzuna | 25,171 | 159,372 |
+| mycareersfuture | 23,094 | 70,203 |
+| echojobs | 5,922 | 49,590 |
+| jobtech | 11,344 | 31,103 |
+| infojobs | 16,667 | 22,690 |
+| jobnet | 8,912 | 16,326 |
+| gulftalent | 765 | 15,308 |
+| whatjobs-uk | 3,948 | 14,192 |
+| himalayas | 8,060 | 13,845 |
+| tyomarkkinatori | 4,401 | 12,613 |
+| 4dayweek | 672 | 10,518 |
+| whatjobs | 3,846 | 10,090 |
+| whatjobs-sg | 2,084 | 9,643 |
+| whatjobs-es | 1,674 | 9,542 |
+| hh | 6,195 | 9,375 |
+| justjoin | 1,295 | 9,036 |
+| reed | 1,664 | 8,921 |
+| telegram | 2,985 | 8,177 |
+| usajobs | 395 | 8,114 |
+| whatjobs-ca | 2,405 | 7,742 |
+| jobylon | 939 | 7,613 |
+| jobdanmark | 2,888 | 7,404 |
+| djinni | 2,417 | 6,719 |
+| whatjobs-pl | 1,732 | 6,572 |
+| jobstash | 925 | 6,571 |
+| wantedkr | 2,693 | 5,902 |
+| powertofly | 34 | 5,872 |
+| whatjobs-ph | 1,721 | 5,400 |
+| whatjobs-fr | 1,554 | 5,295 |
+| whatjobs-za | 869 | 5,277 |
+| whatjobs-it | 1,215 | 5,215 |
+| arbeitnow | 2,909 | 4,978 |
+| whatjobs-nl | 1,455 | 4,696 |
+| workatastartup | 1,374 | 4,254 |
+| nofluffjobs | 452 | 3,189 |
+| whatjobs-au | 1,168 | 3,120 |
+| whatjobs-mx | 837 | 2,510 |
+| whatjobs-co | 586 | 2,499 |
+| whatjobs-ae | 768 | 2,414 |
+| whatjobs-id | 880 | 2,304 |
+| whatjobs-my | 823 | 2,151 |
+| whatjobs-pk | 651 | 2,118 |
+| whatjobs-ie | 648 | 1,950 |
+| vagas | 527 | 1,753 |
+| whatjobs-ar | 414 | 1,547 |
+| whatjobs-hk | 407 | 1,497 |
+| whatjobs-vn | 698 | 1,433 |
+| whatjobs-br | 632 | 1,403 |
+| aijobs | 680 | 1,384 |
+| remoteok | 1,150 | 1,326 |
+| whatjobs-sa | 423 | 1,317 |
+| whatjobs-ch | 501 | 1,273 |
+| instaffo | 654 | 1,262 |
+| getonbrd | 355 | 1,180 |
+| whatjobs-de | 393 | 1,151 |
+| thehub | 348 | 949 |
+| whatjobs-cl | 291 | 923 |
+| whatjobs-dk | 382 | 878 |
+| getmatch | 156 | 855 |
+| whatjobs-qa | 194 | 840 |
+| functionalworks | 326 | 769 |
+| whatjobs-fi | 259 | 676 |
+| habr_career | 148 | 670 |
+| whatjobs-nz | 231 | 532 |
+| whatjobs-no | 259 | 528 |
+| whatjobs-pe | 169 | 489 |
+| whatjobs-tr | 230 | 482 |
+| jobicy | 313 | 407 |
+| whatjobs-in | 104 | 399 |
+| getro | 119 | 363 |
+| weworkremotely | 286 | 340 |
+| wantapply | 92 | 295 |
+| whatjobs-pt | 104 | 280 |
+| whatjobs-be | 108 | 262 |
+| geekjob | 142 | 227 |
+| whatjobs-se | 123 | 210 |
+| remotli | 25 | 158 |
+| whatjobs-kw | 52 | 141 |
+| whatjobs-om | 65 | 122 |
+| whatjobs-bh | 48 | 98 |
+| whatjobs-lu | 36 | 89 |
+| whatjobs-hu | 45 | 86 |
+| startupandvc | 71 | 80 |
+| whatjobs-at | 43 | 61 |
+| whatjobs-ve | 32 | 59 |
+| tecla | 39 | 57 |
+| workingnomads | 21 | 53 |
+| whatjobs-th | 14 | 45 |
+| getmanfred | 38 | 45 |
+| remotive | 23 | 36 |
+| landingjobs | 11 | 32 |
+| cryptocurrencyjobs | 29 | 32 |
+| jobspresso | 15 | 19 |
+| nodesk | 12 | 12 |
+| topco | 5 | 10 |
 | teamex | 1 | 8 |
+| whatjobs-gr | 1 | 2 |
+| whatjobs-ke | 1 | 1 |
+| whatjobs-py | 1 | 1 |
+| whatjobs-sv | 1 | 1 |
 
 ## Company career sites
 
-**36 feeds · 66 companies · 35,160 open postings.**
+**30 feeds · 59 companies · 26,222 open postings.**
 
 | Source | Companies | Open jobs |
 | --- | ---: | ---: |
-| amazon | 1 | 10,005 |
-| apple | 1 | 4,707 |
-| google | 7 | 3,582 |
-| sber | 10 | 3,220 |
-| alfabank | 1 | 2,385 |
-| tbank | 1 | 2,095 |
-| mts | 12 | 1,937 |
-| luxoft | 1 | 1,253 |
-| emagine | 1 | 1,033 |
-| epam | 1 | 896 |
-| yandex | 1 | 889 |
-| uber | 1 | 647 |
-| meta | 1 | 639 |
-| micro1 | 1 | 347 |
-| rwb | 1 | 326 |
-| vk | 1 | 259 |
-| bairesdev | 1 | 170 |
-| dataart | 1 | 139 |
-| avito | 1 | 133 |
+| amazon | 1 | 7,680 |
+| apple | 1 | 4,268 |
+| google | 7 | 3,452 |
+| alfabank | 1 | 2,208 |
+| sber | 11 | 1,649 |
+| mts | 12 | 1,188 |
+| emagine | 1 | 988 |
+| yandex | 1 | 846 |
+| meta | 1 | 790 |
+| uber | 1 | 606 |
+| bairesdev | 1 | 539 |
+| tbank | 1 | 465 |
+| micro1 | 1 | 351 |
+| vk | 1 | 262 |
+| onstrider | 1 | 241 |
+| avito | 1 | 162 |
+| dataart | 1 | 124 |
 | lamoda | 1 | 100 |
-| vention | 1 | 66 |
+| rwb | 1 | 92 |
 | alignerr | 1 | 55 |
-| globalpayments | 1 | 54 |
-| yandexcrowd | 1 | 34 |
-| domclick | 1 | 27 |
-| aviasales | 1 | 26 |
-| rapyd | 1 | 25 |
-| ozon | 1 | 22 |
-| northstone | 3 | 20 |
-| dodo | 3 | 19 |
-| 2gis | 1 | 19 |
-| lumenalta | 1 | 12 |
-| onstrider | 1 | 6 |
+| domclick | 1 | 32 |
+| yandexcrowd | 1 | 25 |
+| dodo | 3 | 21 |
+| ozon | 1 | 20 |
+| aviasales | 1 | 20 |
+| 2gis | 1 | 15 |
+| lumenalta | 1 | 11 |
 | mtslink | 1 | 6 |
 | telegramcareers | 1 | 5 |
-| kuper | 1 | 2 |
+| kuper | 1 | 1 |
 
-Plus **6** postings from manual bulk imports.
+Plus **26** postings from manually imported links and bulk imports.


### PR DESCRIPTION
## Why

The README and `docs/sources.md` headline figures were taken from `GET /api/v1/jobs`'s `meta.total`. That number is a planner estimate, and it is wrong two ways: it omits the `duplicate_of IS NULL AND NOT is_private` half of the predicate the listing actually applies, and it derives from `reltuples`, which table bloat has pushed well above the real row count.

Measured exactly on production instead:

| | Shown before | Actual |
| --- | ---: | ---: |
| Open postings | 3,445,246 | **3,300,658** |
| Companies | 223,685 | **294,282** |
| Live sources | 167 | **225** |

## What changed

- **Counts** — README and `docs/sources.md` headline figures, and the full per-source table in `docs/sources.md`, regenerated from one exact query.
- **Source split** — the ATS / aggregator / career-site breakdown is now derived from each adapter's own Go type in `internal/sources` (`aggregator` and `boardless` interface assertions) rather than maintained by hand. 92 ATS platforms · 100 aggregators & boards · 30 direct company feeds.
- **Workers** — added `migrate`, `embed`, `search-drain`, `capture-apply-form`; `backfill-derive` is described as re-deriving every deterministic column, not "all six dictionary facets".
- **Layout tree** — roughly half the `internal/` packages listed were missing; added `web/`, `extension/`, `design-system/` too.
- **Stack** — added pgvector, SvelteKit/Tailwind, Redis, S3-compatible storage.
- **Quick start** — `make up` starts api, web, postgres, meilisearch, redis and minio, not "app, postgres and meilisearch".
- **Frontend** — `web/` is a server-rendered SvelteKit 2 app (`adapter-node`), not a "Svelte SPA".

## Not in this PR

The estimate itself is a real defect — the live site currently advertises 5,226,661 open jobs on `/about` and `/open`. That is being fixed properly in the `consistent-catalog-counts` OpenSpec change (exact cached snapshot, one figure across every surface). This PR only stops the docs from repeating a wrong number.

## Verification

Counts came from `SELECT source, COUNT(DISTINCT company_slug), COUNT(*) FROM jobs WHERE closed_at IS NULL AND duplicate_of IS NULL AND NOT is_private GROUP BY source` on production. Every relative link in the README was checked to resolve. No code changes, so no test impact.