### PR TITLE
Make the slug backfill's chunk width configurable

### DIFF
--- a/cmd/backfill-slug-folded/chunk_test.go
+++ b/cmd/backfill-slug-folded/chunk_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+// The chunk width is an id RANGE, and on prod the ids are spread over 200x more space
+// than there are rows — so this knob is the difference between a pass that finishes
+// inside its unit timeout and one that does not. Everything unparseable falls back to
+// the default rather than to zero, which would make the loop never advance.
+func TestChunkSize(t *testing.T) {
+	tests := []struct {
+		env  string
+		want int64
+	}{
+		{"", defaultChunkSize},
+		{"2000000", 2_000_000},
+		{"1", 1},
+		// A zero would turn `from += step` into an infinite loop; a negative would walk
+		// backwards forever. Both must read as "not configured".
+		{"0", defaultChunkSize},
+		{"-50000", defaultChunkSize},
+		{"lots", defaultChunkSize},
+		{"1e6", defaultChunkSize},
+	}
+	for _, tt := range tests {
+		t.Run("BACKFILL_SLUG_CHUNK="+tt.env, func(t *testing.T) {
+			t.Setenv("BACKFILL_SLUG_CHUNK", tt.env)
+			if got := chunkSize(); got != tt.want {
+				t.Errorf("chunkSize() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/backfill-slug-folded/main.go
+++ b/cmd/backfill-slug-folded/main.go
@@ -16,19 +16,35 @@ package main
 import (
 	"context"
 	"log"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/worker"
 )
 
-// chunkSize is how many ids one UPDATE spans. Sized so a single statement stays a short
-// transaction on a 7.4M-row table: long transactions here would hold back autovacuum
-// exactly while the pass is generating the dead rows it needs to clean.
+// defaultChunkSize is how many ids one UPDATE spans, overridable with
+// BACKFILL_SLUG_CHUNK. It spans an ID RANGE, not a row count — and on prod that
+// distinction turned out to dominate the runtime: 7.4M rows are spread over 1.59
+// BILLION ids (the id sequence has run far ahead of the live row count through
+// pruning), so at 50k per chunk the pass is 31,900 statements, most of them over empty
+// stretches, and the pacing pause alone adds up to hours. Measured on the first run:
+// ~8h projected against a 6h unit timeout.
 //
-// It spans an ID RANGE, not a row count — ids are sparse (pruning hard-deletes), so a
-// chunk covers fewer rows than its width, never more.
-const chunkSize = 50_000
+// The ceiling on chunk width is how long ONE statement runs in the dense stretches —
+// a long transaction here holds back autovacuum exactly while the pass generates the
+// dead rows it needs to clean. Hence a knob rather than a bigger constant: the right
+// width depends on how the ids happen to be distributed, which is not knowable from
+// the code.
+const defaultChunkSize = 50_000
+
+func chunkSize() int64 {
+	if v, err := strconv.ParseInt(os.Getenv("BACKFILL_SLUG_CHUNK"), 10, 64); err == nil && v > 0 {
+		return v
+	}
+	return defaultChunkSize
+}
 
 // pauseBetweenChunks lets the host breathe between statements. The pass competes with
 // the ingest and with whatever reindex is running, and it is never urgent — the
@@ -56,19 +72,21 @@ func run() int {
 		log.Print("backfill-slug-folded: nothing to do")
 		return 0
 	}
-	log.Printf("backfill-slug-folded: %d rows to fill, ids %d..%d", bounds.Remaining, bounds.MinID, bounds.MaxID)
+	step := chunkSize()
+	log.Printf("backfill-slug-folded: %d rows to fill, ids %d..%d, chunk=%d (%d statements)",
+		bounds.Remaining, bounds.MinID, bounds.MaxID, step, (bounds.MaxID-bounds.MinID)/step+1)
 
 	var filled int64
 	lastLog := time.Now()
-	for from := bounds.MinID; from <= bounds.MaxID; from += chunkSize {
+	for from := bounds.MinID; from <= bounds.MaxID; from += step {
 		n, err := q.BackfillCompanySlugFoldedChunk(ctx, db.BackfillCompanySlugFoldedChunkParams{
 			FromID: from,
-			ToID:   from + chunkSize,
+			ToID:   from + step,
 		})
 		if err != nil {
 			// Report what was already committed: every chunk is its own transaction, so
 			// the work done so far survives and a re-run resumes from it.
-			log.Printf("backfill-slug-folded: chunk %d..%d after %d filled: %v", from, from+chunkSize, filled, err)
+			log.Printf("backfill-slug-folded: chunk %d..%d after %d filled: %v", from, from+step, filled, err)
 			return 1
 		}
 		filled += n


### PR DESCRIPTION
Caught on the first prod run of #2002's backfill, and fixed while it was running.

## The problem

The chunk is an **id range**, and `jobs` ids are spread over **1.59 billion values for 7.4M live rows** — the sequence has run far ahead of the row count through pruning. At the hardcoded 50k:

```
31,900 statements, most sweeping empty stretches
200ms pause × 31,900   = 1.8h in pacing alone
measured projection    ≈ 8h,  against the 6h unit timeout
```

## The fix

`BACKFILL_SLUG_CHUNK` sets the width; the default is unchanged. Re-run on prod at `2000000`:

```
798 statements,  ~3h  — comfortably inside the timeout
```

**A knob rather than a bigger constant**, because the two forces pull opposite ways and only one is knowable from the code: wider means fewer statements, but also a longer single transaction in the *dense* id stretches — and a long transaction holds back autovacuum exactly while this pass generates the dead rows it needs cleaned. How the ids are actually distributed is a property of the table.

Zero, negative and unparseable all fall back to the default: a zero makes `from += step` never advance, a negative walks backwards forever. Tested.

## Bonus: the resume path is confirmed working

Interrupting the first run to swap binaries exercised it end to end, unplanned:

```
cancelled after 654573 filled, resume by re-running
```

The restart then skipped every already-filled chunk for free — the `IS DISTINCT FROM` guard means a re-run over done work writes nothing and creates no dead rows. That is what makes this pass safe to stop whenever the host is busy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable chunk sizing for slug backfills through the `BACKFILL_SLUG_CHUNK` setting.
  * Positive integer values adjust processing size; invalid or non-positive values use the default.
  * Backfill progress now reports the selected chunk size and estimated statement count.

* **Tests**
  * Added coverage for valid, missing, invalid, zero, negative, and scientific-notation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->