### PR TITLE
Add a SEEK (AU/NZ) source adapter

### DIFF
--- a/internal/sources/AGENTS.md
+++ b/internal/sources/AGENTS.md
@@ -48,6 +48,16 @@ Source ingest: board list, provider registry, board-file parsing/validation, per
 
 **Telegram ingest** is a two-stage queue (crawl then LLM-extract): `cmd/tg-ingest` crawls `sources/telegram.yml` channels into `telegram_posts`; `cmd/tg-extract` drains via the LLM. Both are run-once-and-exit cron workers.
 
+**SEEK traps** (all verified live on 2026-08-16, AU and NZ):
+
+- **The bot protection guards the pages, not the API.** A plain request to a SEEK search page or to a `/job/<id>` page answers **403** behind a Cloudflare interstitial ("Just a moment..."), and browser-shaped headers do not clear it. `GET /api/jobsearch/v5/search` — the site's own frontend endpoint — is not gated at all: it answers 200 JSON with no cookie, no credential and no browser-shaped User-Agent (confirmed with no UA, `curl/8.7.1`, `Go-http-client/2.0` and the project's own `freehire/0.1`). Descriptions come from `POST /graphql`, operation `jobDetails`, on the same terms. The consequence for the lifecycle: SEEK postings **cannot be liveness-probed**, because that path fetches the gated job page — which is why the adapter leans on `sweepGrace` instead.
+- **`totalCount` is a function of `pageSize`.** The same query answered **36** at `pageSize=1`, **688** at `pageSize=20`, 680 at 50 and 666 at 100. It can neither drive pagination nor detect truncation, so the adapter's response struct does not even declare the field and the walk stops on the repo's usual `added == 0`. This is the same class of bug as WhatJobs' `limit=1` below — a listing's self-reported total is not evidence.
+- **The result window ends near 550.** `pageSize=100` serves pages 1–5 and answers page 6 empty; `pageSize=50` serves through page 11 (offset 550) and page 12 empty. `pageSize` above 100 returns nothing. A slice larger than the window has a tail no crawl can reach — five of Australia's 22 ICT subclassifications, the largest at ~746 postings.
+- **`where` is load-bearing and omitting it does NOT mean "everywhere".** Dropping it collapsed a 688-posting slice to 36. It travels with the market's host and `siteKey` as one unit.
+- **`www.seek.com.au` now 308-redirects its HTML routes to `au.seek.com`**, and the older `chalice-search` API paths are gone. `api/jobsearch/v5/search` is the live one, and it answers on the `www.seek.com.au` host without a redirect.
+- **`companyName` is empty on roughly one posting in thirty**, where `advertiser.description` carries the name the employer typed — including SEEK's **`"Private Advertiser"`** placeholder, which is not a company. Such a posting is dropped rather than filed under a placeholder that would otherwise collect anonymous postings from both markets.
+- **`salaryLabel` is free text, and about a tenth of the postings that fill it use it for marketing copy** ("Strong remuneration", "Optional 9 day fortnight | Career Growth") rather than a salary. It is folded into the description verbatim; it never populates the structured salary fields.
+
 **WhatJobs FeedAPI traps** (its documentation is wrong in several places; all of the below was verified against the live API):
 
 - A `/` in the `user_agent` query value makes the edge redirect with the value corrupted (`Mozilla/5.0` → `Mozilla%215.0`), which is why every code sample in the vendor's docs fails. The adapter sends no `user_agent` at all.

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -277,6 +277,10 @@ func All(c HTTPClient) map[string]Source {
 		// SolidJobs: Polish job board, multi-company aggregator enumerated by division (board),
 		// same keyword-as-board shape as whatjobs.
 		NewSolidJobs(c),
+		// SEEK: the dominant AU/NZ job board, multi-company aggregator enumerated by ICT
+		// subclassification (board) with the market in region, reading its frontend search API and
+		// hydrating descriptions from its GraphQL endpoint. Keyless.
+		NewSeek(c),
 		// RU-domestic single-company adapters (boardless, except Yandex which selects
 		// host+language by board).
 		NewYandex(c),

--- a/internal/sources/seek.go
+++ b/internal/sources/seek.go
@@ -1,0 +1,347 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// seek adapts SEEK, the dominant job board in Australia and New Zealand. It aggregates postings
+// from many employers (employer read per posting), enumerated by ICT subclassification id carried
+// as the board file entry's board, with the market in the entry's Region — the same
+// board-is-a-slice, region-is-a-market split sources/adzuna.yml uses.
+//
+// SEEK's human-facing pages sit behind a Cloudflare interstitial (a plain request to
+// /software-engineer-jobs/... answers 403 "Just a moment..."), but its own frontend search API does
+// not: /api/jobsearch/v5/search serves JSON to any client — no cookie, no credential and no
+// browser-shaped User-Agent.
+type seek struct {
+	http seekHTTP
+}
+
+// seekHTTP is the transport role the adapter needs: a JSON GET for the search listing and a JSON
+// POST for the GraphQL detail.
+type seekHTTP interface {
+	JSONGetter
+	JSONPoster
+}
+
+// NewSeek builds the SEEK adapter over the shared HTTP client.
+func NewSeek(c seekHTTP) Source { return seek{http: c} }
+
+func (seek) Provider() string { return "seek" }
+
+// aggregator marks seek as a genuine multi-company aggregator: a vacancy an employer also posts on
+// its own ATS appears here too, so the cross-source dedup pass prefers the first-party copy. Unlike
+// the boardless aggregators seek still requires a board (the subclassification id) to bound the
+// crawl, so it is not boardless.
+func (seek) aggregator() {}
+
+// sweepGrace widens the unseen sweep because the crawl reaches only a SLICE of each subclassification:
+// SEEK stops serving results past roughly the 550th (see seekMaxPages), so the busiest slices — five
+// of Australia's 22 when this was written, the largest at ~746 postings — have a tail no crawl can
+// reach. Ordered newest-first the reachable window covers most of a SEEK advertisement's 30-day run,
+// but a posting drifting past it would, on the 48-hour default, be closed and reopened as it drifts
+// back, writing a phantom removal into job_daily_stats each cycle. The marker is sound here because
+// liveness CANNOT be probed instead: SEEK's own job pages sit behind the same Cloudflare interstitial
+// as its search pages.
+func (seek) sweepGrace() time.Duration { return 14 * 24 * time.Hour }
+
+const (
+	seekPageSize = 100
+	// seekMaxPages backstops the page loop at SEEK's result-window cap: at pageSize 100 the edge
+	// serves pages 1..5 and answers page 6 with an empty list, so six requests reach the whole
+	// window and confirm its end. The walk's real stop condition is a page adding no new posting;
+	// this only bounds an edge that keeps answering with fresh inventory.
+	seekMaxPages = 6
+)
+
+// seekMarket is one SEEK country site. The three request fields travel together because none works
+// alone: host serves the market's own domain, siteKey selects its catalogue, and where scopes the
+// search — omitting where does NOT mean "everywhere", it collapses the result set to a small
+// unrelated subset (36 of 688 on the slice this was measured against).
+type seekMarket struct {
+	host    string
+	siteKey string
+	where   string
+}
+
+// seekMarkets maps a board entry's Region to its market. A region outside this map is a config
+// error, reported per board rather than guessed.
+var seekMarkets = map[string]seekMarket{
+	"au": {host: "https://www.seek.com.au", siteKey: "AU-Main", where: "All Australia"},
+	"nz": {host: "https://www.seek.co.nz", siteKey: "NZ-Main", where: "All New Zealand"},
+}
+
+// seekSearchPage is the slice of a search response the adapter reads. totalCount is deliberately
+// absent: SEEK reports it as a function of pageSize (the same query answered 36 at pageSize=1, 688
+// at pageSize=20 and 666 at pageSize=100), so it can drive neither pagination nor a truncation check.
+type seekSearchPage struct {
+	Data []seekPosting `json:"data"`
+}
+
+// seekPosting is one search-result posting. It carries every field the adapter needs except the
+// description, which the listing gives only as a one-line teaser.
+type seekPosting struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	CompanyName string `json:"companyName"`
+	Advertiser  struct {
+		Description string `json:"description"`
+	} `json:"advertiser"`
+	Locations        []seekLocation       `json:"locations"`
+	ListingDate      string               `json:"listingDate"`
+	SalaryLabel      string               `json:"salaryLabel"`
+	WorkTypes        []string             `json:"workTypes"`
+	WorkArrangements seekWorkArrangements `json:"workArrangements"`
+}
+
+// seekWorkArrangements is SEEK's structured work-arrangement block. A posting may offer several.
+type seekWorkArrangements struct {
+	Data []seekWorkArrangement `json:"data"`
+}
+
+type seekWorkArrangement struct {
+	Label struct {
+		Text string `json:"text"`
+	} `json:"label"`
+}
+
+// seekLocation is one place a posting names. The label is the free-text form SEEK displays; the
+// country code is the structured signal, so it feeds Job.Countries directly.
+type seekLocation struct {
+	Label       string `json:"label"`
+	CountryCode string `json:"countryCode"`
+}
+
+// Fetch is the list-only crawl (no description).
+func (s seek) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	m, postings, err := s.crawl(ctx, e)
+	if err != nil {
+		return nil, err
+	}
+	jobs := make([]Job, 0, len(postings))
+	for _, p := range postings {
+		if job, ok := p.toJob(m); ok {
+			jobs = append(jobs, job)
+		}
+	}
+	return jobs, nil
+}
+
+// FetchNew hydrates a posting's description from SEEK's GraphQL endpoint only for a posting the
+// catalogue does not already have (seen); a seen posting yields the list-only job marked
+// SeenRefresh, so the pipeline refreshes liveness without spending a detail request or wiping the
+// body hydrated when it was new. A single detail failure is isolated (logged, list-only fallback) —
+// a posting is never dropped over a missing description.
+func (s seek) FetchNew(ctx context.Context, e CompanyEntry, seen func(externalID string) bool) ([]Job, error) {
+	m, postings, err := s.crawl(ctx, e)
+	if err != nil {
+		return nil, err
+	}
+	return fetchDetails(postings, defaultDetailWorkers, func(p seekPosting) (Job, bool) {
+		base, ok := p.toJob(m)
+		if !ok {
+			return Job{}, false // unusable posting — dropped, as in Fetch
+		}
+		if seen(base.ExternalID) {
+			base.SeenRefresh = true
+			base.Description = "" // liveness refresh only: never rewrite the stored body
+			return base, true
+		}
+		if body, ok := s.detail(ctx, m, p.ID); ok {
+			base.Description += body // base.Description is the salary paragraph (or "")
+		} else {
+			log.Printf("seek: detail %s/%s failed; ingesting list-only", e.Region, p.ID)
+		}
+		return base, true
+	}), nil
+}
+
+// crawl pages the search listing until a page yields no posting it has not already collected.
+func (s seek) crawl(ctx context.Context, e CompanyEntry) (seekMarket, []seekPosting, error) {
+	m, ok := seekMarkets[strings.ToLower(strings.TrimSpace(e.Region))]
+	if !ok {
+		return seekMarket{}, nil, fmt.Errorf("seek: company %q has an unknown market (Region) %q", e.Company, e.Region)
+	}
+	board := strings.TrimSpace(e.Board)
+	var out []seekPosting
+	seen := map[string]bool{}
+	for page := 1; page <= seekMaxPages; page++ {
+		var resp seekSearchPage
+		if err := s.http.GetJSON(ctx, s.searchURL(m, board, page), &resp); err != nil {
+			if page == 1 {
+				return seekMarket{}, nil, fmt.Errorf("seek: search %s subclass %q page %d: %w", e.Region, board, page, err)
+			}
+			break
+		}
+		added := 0
+		for _, p := range resp.Data {
+			if p.ID == "" || seen[p.ID] {
+				continue
+			}
+			seen[p.ID] = true
+			out = append(out, p)
+			added++
+		}
+		if added == 0 { // empty page, or SEEK's result window exhausted
+			break
+		}
+	}
+	return m, out, nil
+}
+
+// seekPrivateAdvertiser is the label SEEK shows for a posting whose employer stays anonymous. It is
+// a placeholder, not a company, so a posting offering nothing else is dropped rather than filed
+// under it — one bogus company would otherwise collect anonymous postings from both markets.
+const seekPrivateAdvertiser = "Private Advertiser"
+
+// employer resolves the posting's company. companyName is the employer SEEK holds a profile for and
+// is empty on roughly one posting in thirty, where advertiser.description carries the name the
+// employer typed instead. Empty means the posting is unusable.
+func (p seekPosting) employer() string {
+	name := strings.TrimSpace(firstNonEmpty(p.CompanyName, p.Advertiser.Description))
+	if strings.EqualFold(name, seekPrivateAdvertiser) {
+		return ""
+	}
+	return name
+}
+
+// seekDetailQuery is the description-fetching GraphQL operation. Its variables are declared exactly
+// as used: SEEK's endpoint rejects an unused variable with GRAPHQL_VALIDATION_FAILED rather than
+// ignoring it — which is the useful half of the bargain, since a drifted field fails loudly instead
+// of silently emptying every body.
+const seekDetailQuery = `query jobDetails($jobId: ID!) {
+  jobDetails(id: $jobId) {
+    job {
+      content(platform: WEB)
+    }
+  }
+}`
+
+// seekDetailResponse is the slice of the GraphQL reply the adapter reads.
+type seekDetailResponse struct {
+	Data struct {
+		JobDetails struct {
+			Job struct {
+				Content string `json:"content"`
+			} `json:"job"`
+		} `json:"jobDetails"`
+	} `json:"data"`
+}
+
+// detail fetches a posting's description through SEEK's GraphQL endpoint and returns it sanitized.
+// ok is false on a failed request or a reply carrying no content, so the caller falls back to the
+// list-only job rather than dropping the posting.
+func (s seek) detail(ctx context.Context, m seekMarket, id string) (string, bool) {
+	body := map[string]any{
+		"operationName": "jobDetails",
+		"query":         seekDetailQuery,
+		"variables":     map[string]any{"jobId": id},
+	}
+	var resp seekDetailResponse
+	if err := s.http.PostJSON(ctx, m.host+"/graphql", body, &resp); err != nil {
+		return "", false
+	}
+	content := resp.Data.JobDetails.Job.Content
+	if strings.TrimSpace(content) == "" {
+		return "", false
+	}
+	return sanitizeHTML(content), true
+}
+
+// workMode maps SEEK's structured work arrangements into our work-mode vocabulary, preferring the
+// most remote arrangement a posting offers. An unstated or unrecognized arrangement yields "", so
+// the pipeline's location heuristic decides instead of this guessing.
+func (p seekPosting) workMode() string {
+	set := map[string]bool{}
+	for _, a := range p.WorkArrangements.Data {
+		set[strings.ToLower(strings.TrimSpace(a.Label.Text))] = true
+	}
+	switch {
+	case set["remote"]:
+		return "remote"
+	case set["hybrid"]:
+		return "hybrid"
+	case set["on-site"]:
+		return "onsite"
+	default:
+		return ""
+	}
+}
+
+// seekEmploymentType maps SEEK's workTypes labels into vocab.EmploymentTypeValues, taking the first
+// that maps. An unmapped set (e.g. "Casual/Vacation", which has no counterpart in our vocabulary)
+// yields "" so the pipeline's dictionaries decide.
+func seekEmploymentType(workTypes []string) string {
+	for _, wt := range workTypes {
+		switch strings.ToLower(strings.TrimSpace(wt)) {
+		case "full time":
+			return "full_time"
+		case "part time":
+			return "part_time"
+		case "contract/temp":
+			return "contract"
+		}
+	}
+	return ""
+}
+
+// salaryParagraph renders the listing's salary label as a leading paragraph, folded into the
+// description because the label is free text rather than a structured amount — measured live it
+// ranges over "$75,000 – $85,000 per year", "160000", "$1,000/day + super" and "Rates Negotiable",
+// none of which Job's structured salary fields can take. Roughly a tenth of the postings that fill
+// it use it for marketing copy instead ("Strong remuneration", "Optional 9 day fortnight | Career
+// Growth"); it is quoted verbatim anyway, because SEEK labels the field as the salary and second-
+// guessing which values are "really" salaries would be exactly the heuristic the structured-facet
+// contract forbids. Empty when SEEK states nothing.
+func (p seekPosting) salaryParagraph() string {
+	label := strings.TrimSpace(p.SalaryLabel)
+	if label == "" {
+		return ""
+	}
+	return sanitizeHTML("<p>Salary: " + label + "</p>")
+}
+
+// searchURL builds one page of a subclassification search, newest-first.
+func (seek) searchURL(m seekMarket, subclassification string, page int) string {
+	q := url.Values{}
+	q.Set("siteKey", m.siteKey)
+	q.Set("where", m.where)
+	q.Set("subclassification", subclassification)
+	q.Set("page", strconv.Itoa(page))
+	q.Set("pageSize", strconv.Itoa(seekPageSize))
+	q.Set("sortmode", "ListedDate")
+	return m.host + "/api/jobsearch/v5/search?" + q.Encode()
+}
+
+// toJob maps a listing posting to a Job, returning ok=false for an unusable posting (no id to key
+// on, or no employer which would break the company slug).
+func (p seekPosting) toJob(m seekMarket) (Job, bool) {
+	company := p.employer()
+	if p.ID == "" || company == "" {
+		return Job{}, false
+	}
+	var location, countryCode string
+	if len(p.Locations) > 0 {
+		location, countryCode = strings.TrimSpace(p.Locations[0].Label), p.Locations[0].CountryCode
+	}
+	mode := p.workMode()
+	return Job{
+		ExternalID:     p.ID,
+		URL:            m.host + "/job/" + p.ID,
+		Title:          strings.TrimSpace(p.Title),
+		Company:        company,
+		Location:       location,
+		Countries:      countryFromCode(countryCode),
+		Description:    p.salaryParagraph(),
+		Remote:         mode == "remote",
+		WorkMode:       mode,
+		EmploymentType: seekEmploymentType(p.WorkTypes),
+		PostedAt:       parseRFC3339(p.ListingDate),
+	}, true
+}

--- a/internal/sources/seek_test.go
+++ b/internal/sources/seek_test.go
@@ -1,0 +1,530 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// errSeekTest is the failure the fake returns for a page the test marked as failing.
+var errSeekTest = errors.New("seek: boom")
+
+// seekPost builds a minimal usable listing posting (id, title, employer).
+func seekPost(id, title, company string) seekPosting {
+	return seekPosting{ID: id, Title: title, CompanyName: company}
+}
+
+// seekArrangements builds the nested work-arrangement shape SEEK's listing carries.
+func seekArrangements(labels ...string) seekWorkArrangements {
+	var wa seekWorkArrangements
+	for _, l := range labels {
+		var one seekWorkArrangement
+		one.Label.Text = l
+		wa.Data = append(wa.Data, one)
+	}
+	return wa
+}
+
+// seekFake serves search pages keyed by their page param and GraphQL details keyed by job id, so
+// one fake drives both stages of the crawl.
+type seekFake struct {
+	searchByPage map[int][]seekPosting // page -> postings that page yields
+	searchErr    map[int]bool          // page -> GetJSON returns an error
+	searchURLs   []string              // search URLs requested, in order
+	detailByID   map[string]string     // job id -> the GraphQL content it answers
+	detailErr    map[string]bool       // job id -> PostJSON returns an error
+	// The adapter fans its detail fetches out across a worker pool, so these recorders are written
+	// from several goroutines at once. Assertions read them after FetchNew has joined the pool.
+	mu         sync.Mutex
+	detailHits []string // job ids whose detail was requested
+	detailURL  string   // the endpoint the detail call went to
+}
+
+func (f *seekFake) GetJSON(_ context.Context, u string, v any) error {
+	f.searchURLs = append(f.searchURLs, u)
+	pu, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	page := 0
+	if p := pu.Query().Get("page"); p != "" {
+		if n, err := strconv.Atoi(p); err == nil {
+			page = n
+		}
+	}
+	if f.searchErr[page] {
+		return errSeekTest
+	}
+	out, ok := v.(*seekSearchPage)
+	if !ok {
+		return errSeekTest
+	}
+	out.Data = f.searchByPage[page]
+	return nil
+}
+
+// PostJSON serves the GraphQL detail. It records the job id every detail call asked for, so a test
+// can assert that a posting the catalogue already holds costs no request at all.
+func (f *seekFake) PostJSON(_ context.Context, u string, body, v any) error {
+	id := seekTestJobID(body)
+	f.mu.Lock()
+	f.detailHits = append(f.detailHits, id)
+	f.detailURL = u
+	f.mu.Unlock()
+	if f.detailErr[id] {
+		return errSeekTest
+	}
+	out, ok := v.(*seekDetailResponse)
+	if !ok {
+		return errSeekTest
+	}
+	out.Data.JobDetails.Job.Content = f.detailByID[id]
+	return nil
+}
+
+// seekTestJobID digs the jobId out of the GraphQL request body the adapter built.
+func seekTestJobID(body any) string {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return ""
+	}
+	var req struct {
+		Variables struct {
+			JobID string `json:"jobId"`
+		} `json:"variables"`
+	}
+	if err := json.Unmarshal(b, &req); err != nil {
+		return ""
+	}
+	return req.Variables.JobID
+}
+
+func TestSeekUnknownMarketFailsTheBoard(t *testing.T) {
+	fake := &seekFake{}
+	_, err := NewSeek(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "SEEK Nowhere", Region: "xx", Board: "6287",
+	})
+	if err == nil {
+		t.Fatal("Fetch with an unknown market: want an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "xx") {
+		t.Errorf("error should name the unknown market, got %q", err)
+	}
+	if len(fake.searchURLs) != 0 {
+		t.Errorf("an unknown market must not issue a request, got %v", fake.searchURLs)
+	}
+}
+
+func TestSeekSearchURLCarriesMarketAndSlice(t *testing.T) {
+	fake := &seekFake{searchByPage: map[int][]seekPosting{1: {seekPost("1", "Dev", "Co")}}}
+	if _, err := NewSeek(fake).Fetch(context.Background(), CompanyEntry{Region: "au", Board: "6287"}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(fake.searchURLs) == 0 {
+		t.Fatal("no search request issued")
+	}
+	pu, err := url.Parse(fake.searchURLs[0])
+	if err != nil {
+		t.Fatalf("parse search URL: %v", err)
+	}
+	if pu.Host != "www.seek.com.au" {
+		t.Errorf("host = %q, want www.seek.com.au", pu.Host)
+	}
+	q := pu.Query()
+	for param, want := range map[string]string{
+		"siteKey":           "AU-Main",
+		"where":             "All Australia",
+		"subclassification": "6287",
+		"page":              "1",
+		"sortmode":          "ListedDate",
+	} {
+		if got := q.Get(param); got != want {
+			t.Errorf("%s = %q, want %q", param, got, want)
+		}
+	}
+	// The result window is reached in as few requests as possible, so the walk asks for full pages.
+	if q.Get("pageSize") != "100" {
+		t.Errorf("pageSize = %q, want 100", q.Get("pageSize"))
+	}
+}
+
+func TestSeekWalksPagesUntilOneAddsNothingNew(t *testing.T) {
+	fake := &seekFake{searchByPage: map[int][]seekPosting{
+		1: {seekPost("1", "A", "Co"), seekPost("2", "B", "Co")},
+		2: {seekPost("3", "C", "Co")},
+		// Page 3 repeats page 2's posting: SEEK clamping past its last page, not new inventory.
+		3: {seekPost("3", "C", "Co")},
+		4: {seekPost("4", "Never reached", "Co")},
+	}}
+	jobs, err := NewSeek(fake).Fetch(context.Background(), CompanyEntry{Region: "au", Board: "6287"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("len(jobs) = %d, want 3 (pages 1-2, page 3 adds nothing)", len(jobs))
+	}
+	if len(fake.searchURLs) != 3 {
+		t.Errorf("requested %d pages, want 3 (the walk stops on the page that adds nothing)", len(fake.searchURLs))
+	}
+}
+
+// SEEK serves at most ~550 results per query, so a well-behaved edge ends the walk on its own. This
+// pins the backstop for one that does not: an edge answering every page with fresh postings must
+// not loop the crawl forever.
+func TestSeekWalkIsBackstoppedByAPageCeiling(t *testing.T) {
+	fake := &seekFake{searchByPage: map[int][]seekPosting{}}
+	for page := 1; page <= 50; page++ {
+		fake.searchByPage[page] = []seekPosting{seekPost(strconv.Itoa(page), "Endless", "Co")}
+	}
+	if _, err := NewSeek(fake).Fetch(context.Background(), CompanyEntry{Region: "au", Board: "6287"}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(fake.searchURLs) >= 50 {
+		t.Fatalf("walk requested %d pages: it is not backstopped", len(fake.searchURLs))
+	}
+	// The ceiling must still clear SEEK's own window (~550 results at 100 per page).
+	if want := 550 / seekPageSize; len(fake.searchURLs) < want {
+		t.Errorf("walk stopped after %d pages, too few to reach SEEK's ~550-result window", len(fake.searchURLs))
+	}
+}
+
+// The repository-wide rule for a paginated listing walk: the FIRST page failing is a board-level
+// error, a LATER page failing ends the walk with what it gathered. seek is not a fullCatalog source,
+// so a partial crawl is safe and only a wholly unreachable board should be reported.
+func TestSeekFirstPageFailureFailsTheBoard(t *testing.T) {
+	fake := &seekFake{
+		searchByPage: map[int][]seekPosting{1: {seekPost("1", "A", "Co")}},
+		searchErr:    map[int]bool{1: true},
+	}
+	jobs, err := NewSeek(fake).Fetch(context.Background(), CompanyEntry{Region: "au", Board: "6287"})
+	if err == nil {
+		t.Fatalf("first page failing: want a board-level error, got %d jobs", len(jobs))
+	}
+}
+
+func TestSeekLaterPageFailureKeepsWhatItGathered(t *testing.T) {
+	fake := &seekFake{
+		searchByPage: map[int][]seekPosting{1: {seekPost("1", "A", "Co"), seekPost("2", "B", "Co")}},
+		searchErr:    map[int]bool{2: true},
+	}
+	jobs, err := NewSeek(fake).Fetch(context.Background(), CompanyEntry{Region: "au", Board: "6287"})
+	if err != nil {
+		t.Fatalf("later page failing must not fail the board: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Errorf("len(jobs) = %d, want 2 (page 1 survives page 2's failure)", len(jobs))
+	}
+}
+
+func TestSeekMapsListingFieldsToAJob(t *testing.T) {
+	p := seekPost("93497500", "Senior Go Engineer", "Atlassian")
+	p.ListingDate = "2026-07-22T11:47:32Z"
+	p.Locations = []seekLocation{{Label: "Smithfield, Sydney NSW", CountryCode: "AU"}}
+
+	fake := &seekFake{searchByPage: map[int][]seekPosting{1: {p}}}
+	jobs, err := NewSeek(fake).Fetch(context.Background(), CompanyEntry{Region: "au", Board: "6290"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "93497500" || j.Title != "Senior Go Engineer" || j.Company != "Atlassian" {
+		t.Errorf("id/title/company wrong: %q / %q / %q", j.ExternalID, j.Title, j.Company)
+	}
+	// The /job/<id> page is Cloudflare-gated for our crawler but is the URL a human needs.
+	if j.URL != "https://www.seek.com.au/job/93497500" {
+		t.Errorf("URL = %q, want the market host's /job/<id>", j.URL)
+	}
+	if j.Location != "Smithfield, Sydney NSW" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	if len(j.Countries) != 1 || j.Countries[0] != "au" {
+		t.Errorf("Countries = %v, want [au] from the posting's structured country code", j.Countries)
+	}
+	if j.PostedAt == nil || j.PostedAt.Format("2006-01-02") != "2026-07-22" {
+		t.Errorf("PostedAt = %v, want 2026-07-22", j.PostedAt)
+	}
+}
+
+// Roughly one posting in thirty has no profiled employer; advertiser.description carries the name
+// the employer typed instead — and sometimes SEEK's "Private Advertiser" placeholder, which must
+// never become a company.
+func TestSeekResolvesEmployerPerPosting(t *testing.T) {
+	profiled := seekPost("1", "Profiled", "Atlassian")
+	profiled.Advertiser.Description = "Atlassian Pty Ltd"
+
+	advertiserOnly := seekPost("2", "Advertiser only", "")
+	advertiserOnly.Advertiser.Description = "Proxmox Server Solutions GmbH"
+
+	placeholder := seekPost("3", "Private", "")
+	placeholder.Advertiser.Description = "Private Advertiser"
+
+	nameless := seekPost("4", "Nameless", "")
+	noID := seekPost("", "No id", "Co")
+
+	fake := &seekFake{searchByPage: map[int][]seekPosting{
+		1: {profiled, advertiserOnly, placeholder, nameless, noID},
+	}}
+	jobs, err := NewSeek(fake).Fetch(context.Background(), CompanyEntry{Region: "au", Board: "6290"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	got := map[string]string{}
+	for _, j := range jobs {
+		got[j.ExternalID] = j.Company
+	}
+	if len(got) != 2 {
+		t.Fatalf("kept %d postings (%v), want 2 — placeholder, nameless and id-less are dropped", len(got), got)
+	}
+	if got["1"] != "Atlassian" {
+		t.Errorf("profiled employer = %q, want Atlassian (the profile wins over the advertiser)", got["1"])
+	}
+	if got["2"] != "Proxmox Server Solutions GmbH" {
+		t.Errorf("advertiser fallback = %q", got["2"])
+	}
+}
+
+func TestSeekWorkModePrefersTheMostRemoteArrangement(t *testing.T) {
+	cases := []struct {
+		arrangements []string
+		want         string
+	}{
+		{[]string{"Remote"}, "remote"},
+		{[]string{"Hybrid"}, "hybrid"},
+		{[]string{"On-site"}, "onsite"},
+		{[]string{"On-site", "Hybrid"}, "hybrid"},
+		{[]string{"On-site", "Remote"}, "remote"},
+		// Unstated must stay empty so the pipeline's location heuristic decides instead.
+		{nil, ""},
+		{[]string{"Something SEEK invented"}, ""},
+	}
+	for _, c := range cases {
+		p := seekPost("1", "T", "Co")
+		p.WorkArrangements = seekArrangements(c.arrangements...)
+		if got := p.workMode(); got != c.want {
+			t.Errorf("workMode(%v) = %q, want %q", c.arrangements, got, c.want)
+		}
+	}
+}
+
+func TestSeekRemoteFlagTracksWorkMode(t *testing.T) {
+	remote := seekPost("1", "Remote role", "Co")
+	remote.WorkArrangements = seekArrangements("Remote")
+	onsite := seekPost("2", "Onsite role", "Co")
+	onsite.WorkArrangements = seekArrangements("On-site")
+
+	fake := &seekFake{searchByPage: map[int][]seekPosting{1: {remote, onsite}}}
+	jobs, err := NewSeek(fake).Fetch(context.Background(), CompanyEntry{Region: "au", Board: "6290"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !jobs[0].Remote || jobs[0].WorkMode != "remote" {
+		t.Errorf("remote posting: Remote=%v WorkMode=%q", jobs[0].Remote, jobs[0].WorkMode)
+	}
+	if jobs[1].Remote {
+		t.Errorf("on-site posting must not be marked Remote")
+	}
+}
+
+func TestSeekEmploymentTypeMapping(t *testing.T) {
+	for _, c := range []struct {
+		workTypes []string
+		want      string
+	}{
+		{[]string{"Full time"}, "full_time"},
+		{[]string{"Part time"}, "part_time"},
+		{[]string{"Contract/Temp"}, "contract"},
+		{[]string{"Casual/Vacation"}, ""},
+		{nil, ""},
+	} {
+		if got := seekEmploymentType(c.workTypes); got != c.want {
+			t.Errorf("seekEmploymentType(%v) = %q, want %q", c.workTypes, got, c.want)
+		}
+	}
+}
+
+// SEEK's salaryLabel is free text — anything from "$75,000 – $85,000 per year" to "160000" to
+// "Rates Negotiable" — so it belongs in the description, not in Job's structured salary fields.
+func TestSeekSalaryLabelIsFoldedIntoTheDescription(t *testing.T) {
+	paid := seekPost("1", "Paid", "Co")
+	paid.SalaryLabel = "$75,000 – $85,000 per year"
+	silent := seekPost("2", "Silent", "Co")
+
+	fake := &seekFake{searchByPage: map[int][]seekPosting{1: {paid, silent}}}
+	jobs, err := NewSeek(fake).Fetch(context.Background(), CompanyEntry{Region: "au", Board: "6290"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !strings.Contains(jobs[0].Description, "$75,000 – $85,000 per year") {
+		t.Errorf("salary label missing from description: %q", jobs[0].Description)
+	}
+	if jobs[0].SalaryMin != nil || jobs[0].SalaryMax != nil || jobs[0].SalaryCurrency != "" {
+		t.Error("a free-text label must not populate the structured salary fields")
+	}
+	if jobs[1].Description != "" {
+		t.Errorf("no salary label must yield no paragraph, got %q", jobs[1].Description)
+	}
+}
+
+// The listing carries only a one-line teaser, so bodies cost a GraphQL call each. Spending one on a
+// posting the catalogue already holds would make every crawl cost the whole catalogue.
+func TestSeekFetchNewHydratesOnlyPostingsTheCatalogueLacks(t *testing.T) {
+	fresh := seekPost("101", "New role", "Co")
+	known := seekPost("202", "Known role", "Co")
+	fake := &seekFake{
+		searchByPage: map[int][]seekPosting{1: {fresh, known}},
+		detailByID:   map[string]string{"101": "<p>Full body</p>", "202": "<p>Should never be asked for</p>"},
+	}
+	src, ok := NewSeek(fake).(HydratingSource)
+	if !ok {
+		t.Fatal("seek must implement HydratingSource")
+	}
+	jobs, err := src.FetchNew(context.Background(), CompanyEntry{Region: "au", Board: "6290"},
+		func(id string) bool { return id == "202" })
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if !slices.Equal(fake.detailHits, []string{"101"}) {
+		t.Errorf("detail requested for %v, want only [101]", fake.detailHits)
+	}
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+	if !strings.Contains(byID["101"].Description, "Full body") {
+		t.Errorf("new posting was not hydrated: %q", byID["101"].Description)
+	}
+	if byID["101"].SeenRefresh {
+		t.Error("a newly hydrated posting must not be marked SeenRefresh")
+	}
+	if !byID["202"].SeenRefresh {
+		t.Error("a posting the catalogue holds must be marked SeenRefresh so the pipeline only refreshes liveness")
+	}
+	if byID["202"].Description != "" {
+		t.Errorf("a SeenRefresh posting must carry no body, got %q", byID["202"].Description)
+	}
+}
+
+func TestSeekDetailIsAppendedAfterTheSalaryParagraph(t *testing.T) {
+	p := seekPost("101", "Paid role", "Co")
+	p.SalaryLabel = "$120,000 per year"
+	fake := &seekFake{
+		searchByPage: map[int][]seekPosting{1: {p}},
+		detailByID:   map[string]string{"101": "<p>What you will do</p>"},
+	}
+	jobs, err := NewSeek(fake).(HydratingSource).FetchNew(context.Background(),
+		CompanyEntry{Region: "au", Board: "6290"}, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if fake.detailURL != "https://www.seek.com.au/graphql" {
+		t.Errorf("detail endpoint = %q, want the market host's /graphql", fake.detailURL)
+	}
+	salary, body := strings.Index(jobs[0].Description, "$120,000"), strings.Index(jobs[0].Description, "What you will do")
+	if salary < 0 || body < 0 || salary > body {
+		t.Errorf("want the salary paragraph then the body, got %q", jobs[0].Description)
+	}
+}
+
+// A missing body is not a reason to lose a posting: the title, employer and facets are still worth
+// having, and the next crawl can hydrate it.
+func TestSeekFailedDetailKeepsTheListOnlyPosting(t *testing.T) {
+	fake := &seekFake{
+		searchByPage: map[int][]seekPosting{1: {seekPost("1", "Transport fails", "Co"), seekPost("2", "Empty body", "Co")}},
+		detailErr:    map[string]bool{"1": true},
+		detailByID:   map[string]string{"2": "   "},
+	}
+	jobs, err := NewSeek(fake).(HydratingSource).FetchNew(context.Background(),
+		CompanyEntry{Region: "au", Board: "6290"}, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2 — a failed detail never drops a posting", len(jobs))
+	}
+	for _, j := range jobs {
+		if j.Description != "" {
+			t.Errorf("posting %s: want an empty body, got %q", j.ExternalID, j.Description)
+		}
+	}
+}
+
+// seek re-lists vacancies employers also post on their own ATS, so the cross-source dedup pass must
+// be able to prefer the first-party copy. It still needs a board to bound the crawl, so unlike the
+// boardless aggregators it must NOT carry that marker.
+func TestSeekIsAnAggregatorButNotBoardless(t *testing.T) {
+	src := NewSeek(&seekFake{})
+	if _, ok := src.(aggregator); !ok {
+		t.Error("seek must be an aggregator so its copies lose to first-party ATS postings")
+	}
+	if _, ok := src.(boardless); ok {
+		t.Error("seek must not be boardless: the board selects the slice to crawl")
+	}
+	if !slices.Contains(AggregatorProviders(Taxonomy()), "seek") {
+		t.Error("seek missing from AggregatorProviders")
+	}
+}
+
+// SEEK stops serving results past ~550, so the busiest slices have a tail no crawl reaches. On the
+// default window that tail would be closed and reopened as it drifts, writing a phantom removal
+// each cycle — and SEEK's job pages are interstitial-gated, so liveness cannot settle it instead.
+func TestSeekDeclaresAWiderSweepGrace(t *testing.T) {
+	got, ok := SweepGraceWindows(Taxonomy())["seek"]
+	if !ok {
+		t.Fatal("seek must declare a sweep-grace window")
+	}
+	if got <= DefaultSweepGrace {
+		t.Errorf("sweep grace = %v, want wider than the %v default", got, DefaultSweepGrace)
+	}
+	if want := 14 * 24 * time.Hour; got != want {
+		t.Errorf("sweep grace = %v, want %v", got, want)
+	}
+}
+
+func TestSeekIsRegisteredAndItsBoardsValidate(t *testing.T) {
+	src, ok := All(nil)["seek"]
+	if !ok {
+		t.Fatal(`All(nil)["seek"] missing`)
+	}
+	if src.Provider() != "seek" {
+		t.Errorf("Provider() = %q, want seek", src.Provider())
+	}
+	cfg := Config{Sources: []CompanyEntry{
+		{Company: "SEEK Australia — Engineering - Software", Provider: "seek", Region: "au", Board: "6290"},
+		{Company: "SEEK New Zealand — Engineering - Software", Provider: "seek", Region: "nz", Board: "6290"},
+	}}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("board entries must validate against the registry: %v", err)
+	}
+	// Region is part of the board dedupe key, so the same slice in two markets is two crawl targets.
+	if dups := DuplicateBoards(cfg.Sources); len(dups) != 0 {
+		t.Errorf("same board id across markets must not collide: %v", dups)
+	}
+}
+
+func TestSeekNewZealandMarketUsesItsOwnHostAndScope(t *testing.T) {
+	fake := &seekFake{searchByPage: map[int][]seekPosting{1: {seekPost("1", "Dev", "Co")}}}
+	if _, err := NewSeek(fake).Fetch(context.Background(), CompanyEntry{Region: "nz", Board: "6287"}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	pu, _ := url.Parse(fake.searchURLs[0])
+	if pu.Host != "www.seek.co.nz" {
+		t.Errorf("host = %q, want www.seek.co.nz", pu.Host)
+	}
+	if got := pu.Query().Get("siteKey"); got != "NZ-Main" {
+		t.Errorf("siteKey = %q, want NZ-Main", got)
+	}
+	// where is load-bearing: omitting it does not mean "everywhere", it collapses the result set.
+	if got := pu.Query().Get("where"); got != "All New Zealand" {
+		t.Errorf("where = %q, want All New Zealand", got)
+	}
+}

--- a/openspec/changes/add-seek-source-adapter/.openspec.yaml
+++ b/openspec/changes/add-seek-source-adapter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/openspec/changes/add-seek-source-adapter/design.md
+++ b/openspec/changes/add-seek-source-adapter/design.md
@@ -108,6 +108,17 @@ board-swept, not liveness-probed.
   remedies.
 - **`"Private Advertiser"` postings are dropped** → a real, if small, coverage loss, taken because a
   placeholder company would pollute the company dimension for every such posting across both markets.
+- **A posting whose detail failed is ingested body-less and never retried** → accepted, and NOT
+  fixable in this adapter. `seen` is `func(externalID string) bool` over
+  `ExistingExternalIDs`, which reports row existence (and `is_tech`), never whether the stored row
+  carries a description — so an adapter cannot tell a hydrated row from a body-less one, and every
+  `HydratingSource` in the repository shares the behaviour. The alternative available at adapter
+  level is to drop the posting on a detail failure so the next crawl sees it as new, which trades a
+  permanent body-less row for a temporarily absent one and contradicts the documented rule that a
+  posting is never lost over a missing detail. Closing the hole properly means a seen-set that
+  excludes description-less rows — a change to the hydration contract and its SQL, shared by every
+  hydrating adapter, not something to fork inside SEEK. Rare in practice: 31 of 31 details succeeded
+  on the live verification run.
 
 ## Migration Plan
 

--- a/openspec/changes/add-seek-source-adapter/design.md
+++ b/openspec/changes/add-seek-source-adapter/design.md
@@ -1,0 +1,121 @@
+## Context
+
+Issue #1634 proposed SEEK as the highest-value, highest-risk target of its source batch: AU is a
+market no per-employer ATS covers at scale, but a plain fetch of a SEEK search page answered 403
+with a tiny body, which reads as active bot protection. The issue explicitly deferred the work
+pending a feasibility spike.
+
+The spike ran on 2026-08-16 and produced these live-verified facts, which the whole design rests on:
+
+- The 403 is a **Cloudflare interstitial** ("Just a moment...") and it covers the human-facing HTML
+  pages, including a job's own `/job/<id>` page. Browser-shaped headers do not clear it.
+- SEEK's frontend **search API does not sit behind it**: `GET
+  https://www.seek.com.au/api/jobsearch/v5/search` answers 200 JSON with no cookie, no credential
+  and no browser-shaped User-Agent — verified with no UA at all, with `curl/8.7.1`, with
+  `Go-http-client/2.0`, and with the project's own `freehire/0.1` agent. All four succeeded.
+- `www.seek.com.au` now 308-redirects its HTML routes to `au.seek.com`, and the older
+  `chalice-search` API paths are gone. `api/jobsearch/v5/search` is the live one on both hosts.
+- The listing carries every field the adapter needs **except the description** (only a one-line
+  teaser). The body comes from `POST /graphql`, operation `jobDetails`, which validates its own
+  query — an unused variable is rejected with `GRAPHQL_VALIDATION_FAILED`, so a drifted field fails
+  loudly rather than silently returning nothing.
+- SEEK serves at most ~550 results per query (page size 100 serves pages 1–5 and answers page 6
+  empty; page size 50 serves through page 11, offset 550). Page size above 100 returns nothing.
+- **`totalCount` is a function of `pageSize`.** The same query answered 36 at `pageSize=1`, 688 at
+  `pageSize=20`, 680 at 50 and 666 at 100. It cannot drive pagination or detect truncation.
+- Omitting the `where` parameter does not mean "everywhere": it collapsed a 688-posting slice to 36.
+- Roughly one posting in thirty has no profiled employer; `advertiser.description` carries the typed
+  name instead, and sometimes SEEK's `"Private Advertiser"` placeholder.
+
+Measured live at spike time: AU ICT ≈ 6,471 postings across 22 subclassifications, NZ ≈ 1,323 across
+21.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Cover SEEK's ICT catalogue in both AU and NZ, with descriptions, at a request cost that does not
+  grow with catalogue size once steady-state.
+- Fit the existing `Source` / `HydratingSource` contracts and the repository's board-is-a-slice
+  aggregator shape — no new pipeline concepts.
+- Encode every verified platform trap where it will be read: at the code that would otherwise trip
+  on it.
+
+**Non-Goals:**
+
+- Non-ICT classifications. SEEK's taxonomy spans every industry; the catalogue is an IT job board.
+- Defeating the Cloudflare interstitial. Nothing the adapter needs is behind it.
+- Structured salary. SEEK states a free-text label, not an amount.
+- Liveness probing SEEK postings. Their job pages are interstitial-gated.
+
+## Decisions
+
+**Board = ICT subclassification, region = market.** SEEK's whole ICT classification is ~6.5k
+postings in AU against a ~550 result window, so it is unreachable as one query; its subclassifications
+(319–746 postings) are mostly reachable as slices. Region carries the market, mirroring
+`sources/adzuna.yml`, where region is the country and board the category. Region is already part of
+the board dedupe key and of the `board_health` primary key, so the same subclassification id in `au`
+and `nz` is two independent, independently-healthy crawl targets for free.
+
+*Alternative considered:* slicing further by state, giving full coverage of the five slices that
+exceed the window. Rejected: it quadruples the request count and the board-file size to chase a tail
+that ages out anyway (below), and the user chose the simpler shape explicitly.
+
+**Five slices exceed the window; wait rather than slice.** AU's Engineering - Software (~746),
+Help Desk (~689), Business/Systems Analysts (~688), Developers/Programmers (~638) and Programme &
+Project Management (~584) hold more postings than the ~550 the crawl can reach. Ordered newest-first,
+the reachable window covers roughly the first 24 days of a SEEK advertisement's 30-day run, so a
+steadily-running crawl sees every posting while it is new and only loses sight of it near expiry.
+The cost is a tail that reads as unseen, which is exactly what `sweepGrace` exists for.
+
+**14-day sweep grace.** Same reasoning `whatjobs` uses: a posting drifting past crawl depth would be
+closed and reopened on the 48-hour default, writing a phantom removal into `job_daily_stats` each
+cycle. 14 days is wider than the drift and still narrower than the ~30-day ad life. The marker is
+sound here specifically because liveness CANNOT be probed — SEEK's job pages are interstitial-gated —
+which is the condition the marker's own documentation sets.
+
+**`HydratingSource`, not a plain `Source`.** A detail request per posting per run would be ~7.8k
+GraphQL calls every crawl. Hydrating only what the catalogue lacks reduces steady state to the day's
+new postings, and `SeenRefresh` keeps the pipeline from re-deriving facets from an empty body.
+
+**Never trust `totalCount`.** The walk's stop condition is "this page added no new id", the
+repository's existing `added == 0` convention. A page ceiling of 6 backstops it. The field is
+deliberately absent from the response struct so no future edit can reach for it.
+
+**Fold the salary label into the description.** `Job`'s structured salary fields take a structured
+amount; SEEK's label ranges from `"$75,000 – $85,000 per year"` to `"160000"` to `"Rates
+Negotiable"`. `hh` sets the precedent for folding a list-carried salary into the body and letting
+enrichment parse it.
+
+**Store the interstitial-gated `/job/<id>` URL anyway.** It is the URL a human needs, and it works
+in a browser. Our crawler cannot fetch it, but nothing in the ingest path needs to: SEEK is
+board-swept, not liveness-probed.
+
+## Risks / Trade-offs
+
+- **Both endpoints are frontend internals, not a documented API** → a first-page failure is a
+  board-level error, so board health cools the board and surfaces it rather than letting the
+  catalogue drift. The GraphQL operation validates its own query, so a renamed field errors instead
+  of silently emptying descriptions.
+- **The five over-window slices lose their oldest postings** → accepted, mitigated by newest-first
+  ordering plus the 14-day grace. Re-slicing by state remains available without a schema change if
+  the loss proves material.
+- **SEEK could extend the interstitial to `/api/`** → the crawl fails loudly per board. There is no
+  silent-degradation path, because the walk never trusts a reported count.
+- **Cloudflare may rate-limit at crawl volume** → the pipeline's per-board concurrency plus the
+  adapter's bounded detail pool keep the burst modest; if it proves too much, the repository already
+  has the pacer (`internal/sources/pacer.go`) and the proxy-egress allowlist as the two established
+  remedies.
+- **`"Private Advertiser"` postings are dropped** → a real, if small, coverage loss, taken because a
+  placeholder company would pollute the company dimension for every such posting across both markets.
+
+## Migration Plan
+
+Additive: a new adapter, a new board file, one registration line. Deploy needs one ingest cron entry
+for `sources/seek.yml`. Rollback is removing that entry — the crawled jobs then age out through the
+normal unseen sweep.
+
+## Open Questions
+
+None blocking. Whether the five over-window slices need a state split is a question the first weeks
+of production data answer, not a design-time one.

--- a/openspec/changes/add-seek-source-adapter/proposal.md
+++ b/openspec/changes/add-seek-source-adapter/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Australia and New Zealand are absent from the catalogue at any meaningful scale: no per-employer
+ATS board covers them, and the region's hiring runs through SEEK, the dominant job board in both
+markets (~6.5k live ICT postings in AU, ~1.3k in NZ). Issue #1634 flagged SEEK as the highest-value
+target of its batch but could not confirm it was reachable — a plain fetch of a SEEK search page
+answers 403. A feasibility spike settled that question: the 403 is a Cloudflare interstitial on the
+HUMAN-facing pages only. SEEK's own frontend search API answers 200 JSON to an unauthenticated,
+un-spoofed request, and its GraphQL endpoint serves the full posting body. The blocker the issue
+raised does not exist on the path we would actually crawl.
+
+## What Changes
+
+- New `seek` source adapter (`internal/sources/seek.go`) crawling SEEK's `/api/jobsearch/v5/search`
+  listing and hydrating descriptions from its `/graphql` `jobDetails` operation.
+- New board file `sources/seek.yml`: one entry per ICT **subclassification** id (the `board`) per
+  **market** (the `region`, `au` or `nz`) — 22 Australian and 21 New Zealand slices.
+- The adapter registers as an `aggregator` (many employers, employer read per posting) that is NOT
+  boardless, joining `hh` and `whatjobs` in the board-is-a-slice shape.
+- It implements `HydratingSource`: a detail request is spent only on a posting the catalogue does
+  not already hold, so a steady-state crawl costs listing requests plus one GraphQL call per genuinely
+  new posting.
+- It declares a 14-day `sweepGrace`, because SEEK stops serving results past roughly the 550th and
+  the busiest slices have a tail no crawl can reach.
+- No credential, no proxy egress, and no browser-shaped headers: the endpoints are keyless and
+  indifferent to User-Agent.
+
+## Capabilities
+
+### New Capabilities
+- `seek-source`: crawling SEEK's AU and NZ catalogues — market and slice selection, the listing
+  walk and its result-window cap, description hydration, employer resolution, and the sweep-grace
+  contract that keeps the unreachable tail from churning.
+
+### Modified Capabilities
+<!-- None: this adds a provider behind the existing Source/HydratingSource contracts and changes no
+     existing requirement. -->
+
+## Impact
+
+- **New:** `internal/sources/seek.go`, `internal/sources/seek_test.go`, `sources/seek.yml`.
+- **Modified:** `internal/sources/registry.go` (one registration line),
+  `internal/sources/AGENTS.md` (the platform's verified traps).
+- **Ops:** one new ingest cron entry for `sources/seek.yml`, as every board file has.
+- **Dependencies:** none — the adapter uses the existing shared HTTP client's `JSONGetter` and
+  `JSONPoster` roles.
+- **Risk:** both endpoints are frontend internals rather than a documented API, so a SEEK frontend
+  change can move either. Board health surfaces that as a failing board rather than silent drift.

--- a/openspec/changes/add-seek-source-adapter/specs/seek-source/spec.md
+++ b/openspec/changes/add-seek-source-adapter/specs/seek-source/spec.md
@@ -1,0 +1,162 @@
+## ADDED Requirements
+
+### Requirement: SEEK per-market, per-subclassification listing crawl
+
+The system SHALL provide a `seek` source adapter that crawls SEEK's Australian and New Zealand
+ICT catalogues into the catalogue. The adapter is a **board-based multi-company aggregator**: each
+configured entry names a MARKET in its region field (`au` or `nz`) and an ICT **subclassification
+id** in its board field, not a per-company board. The crawl is keyless — SEEK's search API requires
+no credential, no cookie, and no browser-shaped User-Agent.
+
+#### Scenario: Slice yields its listed postings
+
+- **WHEN** the adapter crawls a configured (market, subclassification) entry
+- **THEN** it returns one `Job` per posting the search listing yields for that slice, each populated
+  with the posting's id, title, employer, free-text location, structured country, work mode,
+  employment type and listing date
+
+#### Scenario: Market selects host, site key and search scope together
+
+- **WHEN** an entry names market `au`
+- **THEN** the adapter requests SEEK's Australian host with that market's site key AND its
+  whole-country search scope, because omitting the scope does not mean "everywhere" — it collapses
+  the result set to a small unrelated subset
+
+#### Scenario: Unknown market fails the board
+
+- **WHEN** an entry names a market the adapter does not know
+- **THEN** the crawl returns a board-level error naming the entry, rather than guessing a market
+
+### Requirement: Listing walk bounded by observation, not by reported total
+
+The adapter MUST advance through listing pages until a page yields no posting it has not already
+collected. It MUST NOT use the listing's own `totalCount` to drive or bound pagination: SEEK reports
+that field as a function of the requested page size (the same query answers a small nonsense number
+at page size 1 and the real figure at page size 20), so it can neither schedule the walk nor detect
+truncation.
+
+#### Scenario: Walk stops when a page adds nothing new
+
+- **WHEN** a listing page yields only postings already collected, or no postings at all
+- **THEN** the walk ends and the adapter returns what it gathered
+
+#### Scenario: Result window is backstopped
+
+- **WHEN** SEEK keeps serving pages past its result window
+- **THEN** the walk still stops at a fixed page ceiling, so a misbehaving edge cannot loop the crawl
+
+### Requirement: Which page failed decides whether the board failed
+
+The adapter SHALL treat a FIRST-page failure as a board-level error and a LATER-page failure as the
+end of the walk, returning the postings gathered so far — the repository-wide rule for a paginated
+listing walk. The adapter is not a `fullCatalog` source, so a partial crawl is safe.
+
+#### Scenario: First page fails
+
+- **WHEN** the first listing page of a slice cannot be fetched or decoded
+- **THEN** the crawl returns an error, so board health records the failure and the sweep does not
+  read the slice as emptied
+
+#### Scenario: Later page fails
+
+- **WHEN** a listing page after the first fails
+- **THEN** the walk ends and the adapter returns the postings collected from the earlier pages
+
+### Requirement: Descriptions hydrated only for postings the catalogue lacks
+
+The listing carries no description, only a one-line teaser, so the adapter SHALL implement
+`HydratingSource` and fetch a posting's body from SEEK's GraphQL `jobDetails` operation ONLY when
+the pipeline reports that posting as not yet ingested. A posting the catalogue already holds MUST be
+returned marked `SeenRefresh`, so the pipeline refreshes its liveness without re-fetching or
+overwriting the body hydrated when it was new.
+
+#### Scenario: New posting is hydrated
+
+- **WHEN** the crawl yields a posting the catalogue does not hold
+- **THEN** the adapter fetches its description and returns the job with that body
+
+#### Scenario: Known posting costs no detail request
+
+- **WHEN** the crawl yields a posting the catalogue already holds
+- **THEN** the adapter returns it marked `SeenRefresh` and issues no detail request for it
+
+#### Scenario: Failed detail never drops a posting
+
+- **WHEN** a posting's detail request fails or returns no content
+- **THEN** the adapter logs it and returns the list-only job, rather than omitting the posting
+
+### Requirement: Employer resolved per posting, placeholder rejected
+
+The adapter MUST read each posting's employer from the posting itself, preferring the profiled
+employer name and falling back to the advertiser name SEEK shows when no profile exists. SEEK's
+"Private Advertiser" placeholder is NOT an employer; a posting carrying it, or carrying no name at
+all, MUST be dropped rather than persisted under a placeholder company.
+
+#### Scenario: Profiled employer wins
+
+- **WHEN** a posting names a profiled employer
+- **THEN** that name is the job's company
+
+#### Scenario: Advertiser name is the fallback
+
+- **WHEN** a posting has no profiled employer but names an advertiser
+- **THEN** the advertiser name is the job's company
+
+#### Scenario: Placeholder advertiser is dropped
+
+- **WHEN** a posting's only employer name is SEEK's "Private Advertiser" placeholder
+- **THEN** the adapter omits that posting
+
+### Requirement: Structured facets carried only where SEEK states them
+
+The adapter SHALL map SEEK's structured fields into freehire's controlled vocabularies — work
+arrangement to work mode, work type to employment type, the posting's country code to a canonical
+country — and leave a field empty when SEEK states no value, so the pipeline's dictionaries decide.
+SEEK's salary is a free-text label rather than a structured amount, so it MUST be folded into the
+description instead of the structured salary fields.
+
+#### Scenario: Work arrangement maps to work mode
+
+- **WHEN** a posting states a work arrangement
+- **THEN** the job carries the corresponding work mode, preferring the most remote arrangement the
+  posting offers
+
+#### Scenario: Unstated arrangement leaves work mode empty
+
+- **WHEN** a posting states no work arrangement
+- **THEN** the job's work mode is empty, so the pipeline's location heuristic decides
+
+#### Scenario: Salary label is not a structured amount
+
+- **WHEN** a posting carries a salary label
+- **THEN** it is folded into the description and the job's structured salary fields stay unset
+
+### Requirement: Sweep grace covers the unreachable tail
+
+The adapter SHALL declare a post-run sweep grace window wider than the default, because SEEK stops
+serving results past roughly the 550th and the busiest slices hold more postings than that. Ordered
+newest-first, the reachable window covers most of a SEEK advertisement's run, but a posting that
+drifts past it would otherwise be closed and reopened as it drifts back, writing a phantom removal
+each cycle. SEEK's own job pages sit behind the same interstitial as its search pages, so liveness
+cannot be probed instead.
+
+#### Scenario: Grace window is declared
+
+- **WHEN** the ingest worker computes the unseen-job cutoff for `seek`
+- **THEN** it reads the adapter's declared window rather than the default
+
+### Requirement: Aggregator identity in the source taxonomy
+
+The adapter MUST register as an `aggregator` so the cross-source dedup pass prefers a first-party
+ATS copy of a posting over SEEK's re-listing. It MUST NOT register as `boardless`: the board selects
+the slice to crawl and is required.
+
+#### Scenario: SEEK copy loses to the first-party posting
+
+- **WHEN** the same vacancy exists both on an employer's own ATS board and on SEEK
+- **THEN** the dedup pass keeps the ATS copy and suppresses the SEEK one
+
+#### Scenario: Entry without a board fails validation
+
+- **WHEN** a `seek` entry omits its board
+- **THEN** board-file validation rejects it before any request goes out

--- a/openspec/changes/add-seek-source-adapter/tasks.md
+++ b/openspec/changes/add-seek-source-adapter/tasks.md
@@ -1,0 +1,54 @@
+## 1. Listing crawl
+
+- [ ] 1.1 Adapter skeleton: `seek` type over a `JSONGetter`+`JSONPoster` transport role, `Provider()`
+      returning `"seek"`, `NewSeek` constructor, and the market table mapping region `au`/`nz` to its
+      host, site key, search scope and locale. Test: an entry with an unknown region fails the board
+      with an error naming it; a known region builds a search URL carrying host, site key, scope,
+      subclassification, page, page size and newest-first sort.
+- [ ] 1.2 Listing walk: page until a page adds no new posting id, backstopped by a page ceiling.
+      Test: a second page with fresh ids is walked; a page repeating the first page's ids ends the
+      walk; the response struct carries no `totalCount` field to reach for.
+- [ ] 1.3 First-page-vs-later-page failure rule. Test: a failing first page returns a board-level
+      error; a failing second page returns the first page's postings with no error.
+- [ ] 1.4 `Fetch` maps a listing posting to a `Job`: id, title, `/job/<id>` URL on the market host,
+      free-text location, structured country from the posting's country code, and listing date.
+
+## 2. Posting mapping
+
+- [ ] 2.1 Employer resolution: profiled employer name, falling back to the advertiser name; a
+      posting whose only name is the `"Private Advertiser"` placeholder, or which has no name at
+      all, is dropped. Test: all three cases plus a posting with no id.
+- [ ] 2.2 Work-mode mapping from SEEK's work arrangements, preferring the most remote arrangement;
+      unstated leaves it empty and `Remote` false. Test: remote / hybrid / on-site / unstated, and
+      a posting offering several.
+- [ ] 2.3 Employment-type mapping from SEEK's work types into `vocab.EmploymentTypeValues`; an
+      unmapped type leaves it empty. Test: full time, part time, contract/temp, unmapped.
+- [ ] 2.4 Salary label folded into the description as a leading paragraph, structured salary fields
+      left unset; no label yields no paragraph. Test: both cases.
+
+## 3. Description hydration
+
+- [ ] 3.1 `FetchNew` implementing `HydratingSource`: hydrate only postings the `seen` predicate
+      reports as new, mark the rest `SeenRefresh`. Test: exactly the new posting's id reaches the
+      detail transport; the seen posting carries `SeenRefresh` and no body.
+- [ ] 3.2 GraphQL `jobDetails` detail call, response sanitized through `sanitizeHTML`; a failed
+      request or an empty body falls back to the list-only job rather than dropping the posting.
+      Test: success appends the body after the salary paragraph; transport error and empty content
+      both keep the posting.
+
+## 4. Registration and configuration
+
+- [ ] 4.1 Markers: `aggregator` (not `boardless`) and `sweepGrace` of 14 days. Test: the adapter
+      appears in `AggregatorProviders`, is absent from the boardless-driven exclusions, and reports
+      its window through `SweepGraceWindows`.
+- [ ] 4.2 Register `NewSeek(c)` in `sources.All`, keyless.
+- [ ] 4.3 Write `sources/seek.yml` — 22 AU and 21 NZ entries with live-verified counts — and confirm
+      `go run ./cmd/validate-sources` passes.
+
+## 5. Verification and documentation
+
+- [ ] 5.1 Live smoke run against both markets: `go run ./cmd/ingest sources/seek.yml` reaches SEEK,
+      yields postings with employers and hydrated descriptions, and reports no board failures.
+- [ ] 5.2 Record the platform's verified traps in `internal/sources/AGENTS.md`: the interstitial
+      covers pages but not the API, `totalCount` varies with `pageSize`, the ~550 result window,
+      `where` is load-bearing, and the `"Private Advertiser"` placeholder.

--- a/openspec/changes/add-seek-source-adapter/tasks.md
+++ b/openspec/changes/add-seek-source-adapter/tasks.md
@@ -1,54 +1,54 @@
 ## 1. Listing crawl
 
-- [ ] 1.1 Adapter skeleton: `seek` type over a `JSONGetter`+`JSONPoster` transport role, `Provider()`
+- [x] 1.1 Adapter skeleton: `seek` type over a `JSONGetter`+`JSONPoster` transport role, `Provider()`
       returning `"seek"`, `NewSeek` constructor, and the market table mapping region `au`/`nz` to its
       host, site key, search scope and locale. Test: an entry with an unknown region fails the board
       with an error naming it; a known region builds a search URL carrying host, site key, scope,
       subclassification, page, page size and newest-first sort.
-- [ ] 1.2 Listing walk: page until a page adds no new posting id, backstopped by a page ceiling.
+- [x] 1.2 Listing walk: page until a page adds no new posting id, backstopped by a page ceiling.
       Test: a second page with fresh ids is walked; a page repeating the first page's ids ends the
       walk; the response struct carries no `totalCount` field to reach for.
-- [ ] 1.3 First-page-vs-later-page failure rule. Test: a failing first page returns a board-level
+- [x] 1.3 First-page-vs-later-page failure rule. Test: a failing first page returns a board-level
       error; a failing second page returns the first page's postings with no error.
-- [ ] 1.4 `Fetch` maps a listing posting to a `Job`: id, title, `/job/<id>` URL on the market host,
+- [x] 1.4 `Fetch` maps a listing posting to a `Job`: id, title, `/job/<id>` URL on the market host,
       free-text location, structured country from the posting's country code, and listing date.
 
 ## 2. Posting mapping
 
-- [ ] 2.1 Employer resolution: profiled employer name, falling back to the advertiser name; a
+- [x] 2.1 Employer resolution: profiled employer name, falling back to the advertiser name; a
       posting whose only name is the `"Private Advertiser"` placeholder, or which has no name at
       all, is dropped. Test: all three cases plus a posting with no id.
-- [ ] 2.2 Work-mode mapping from SEEK's work arrangements, preferring the most remote arrangement;
+- [x] 2.2 Work-mode mapping from SEEK's work arrangements, preferring the most remote arrangement;
       unstated leaves it empty and `Remote` false. Test: remote / hybrid / on-site / unstated, and
       a posting offering several.
-- [ ] 2.3 Employment-type mapping from SEEK's work types into `vocab.EmploymentTypeValues`; an
+- [x] 2.3 Employment-type mapping from SEEK's work types into `vocab.EmploymentTypeValues`; an
       unmapped type leaves it empty. Test: full time, part time, contract/temp, unmapped.
-- [ ] 2.4 Salary label folded into the description as a leading paragraph, structured salary fields
+- [x] 2.4 Salary label folded into the description as a leading paragraph, structured salary fields
       left unset; no label yields no paragraph. Test: both cases.
 
 ## 3. Description hydration
 
-- [ ] 3.1 `FetchNew` implementing `HydratingSource`: hydrate only postings the `seen` predicate
+- [x] 3.1 `FetchNew` implementing `HydratingSource`: hydrate only postings the `seen` predicate
       reports as new, mark the rest `SeenRefresh`. Test: exactly the new posting's id reaches the
       detail transport; the seen posting carries `SeenRefresh` and no body.
-- [ ] 3.2 GraphQL `jobDetails` detail call, response sanitized through `sanitizeHTML`; a failed
+- [x] 3.2 GraphQL `jobDetails` detail call, response sanitized through `sanitizeHTML`; a failed
       request or an empty body falls back to the list-only job rather than dropping the posting.
       Test: success appends the body after the salary paragraph; transport error and empty content
       both keep the posting.
 
 ## 4. Registration and configuration
 
-- [ ] 4.1 Markers: `aggregator` (not `boardless`) and `sweepGrace` of 14 days. Test: the adapter
+- [x] 4.1 Markers: `aggregator` (not `boardless`) and `sweepGrace` of 14 days. Test: the adapter
       appears in `AggregatorProviders`, is absent from the boardless-driven exclusions, and reports
       its window through `SweepGraceWindows`.
-- [ ] 4.2 Register `NewSeek(c)` in `sources.All`, keyless.
-- [ ] 4.3 Write `sources/seek.yml` — 22 AU and 21 NZ entries with live-verified counts — and confirm
+- [x] 4.2 Register `NewSeek(c)` in `sources.All`, keyless.
+- [x] 4.3 Write `sources/seek.yml` — 22 AU and 21 NZ entries with live-verified counts — and confirm
       `go run ./cmd/validate-sources` passes.
 
 ## 5. Verification and documentation
 
-- [ ] 5.1 Live smoke run against both markets: `go run ./cmd/ingest sources/seek.yml` reaches SEEK,
+- [x] 5.1 Live smoke run against both markets: `go run ./cmd/ingest sources/seek.yml` reaches SEEK,
       yields postings with employers and hydrated descriptions, and reports no board failures.
-- [ ] 5.2 Record the platform's verified traps in `internal/sources/AGENTS.md`: the interstitial
+- [x] 5.2 Record the platform's verified traps in `internal/sources/AGENTS.md`: the interstitial
       covers pages but not the API, `totalCount` varies with `pageSize`, the ~550 result window,
       `where` is load-bearing, and the `"Private Advertiser"` placeholder.

--- a/sources/seek.yml
+++ b/sources/seek.yml
@@ -1,0 +1,153 @@
+# SEEK — the dominant job board in Australia and New Zealand, a multi-company aggregator
+# (employer read per posting; company below is a display label only).
+#
+# Each entry's board is an ICT SUBCLASSIFICATION id under SEEK's "Information & Communication
+# Technology" classification (6281), and region is the market whose site to crawl — the same
+# board-is-a-slice, region-is-a-market split sources/adzuna.yml uses. The subclassification is
+# what makes the slice small enough to walk: SEEK stops serving results past roughly the 550th,
+# so the whole classification (~6.5k in AU) is unreachable in one query while its parts are not.
+# See internal/sources/seek.go for the window and why totalCount cannot be used to detect it.
+#
+# Counts below are live-verified totals (2026-08-16), read at pageSize=20 — SEEK's totalCount
+# varies with pageSize (the same query answered 36 at pageSize=1 and 688 at pageSize=20), so they
+# are indicative, not exact. A slice marked "over window" has a tail no crawl reaches; ordered
+# newest-first the ~550 the crawl does reach covers roughly the first 24 days of a SEEK ad's
+# 30-day run, so steady-state coverage stays near-complete and the adapter declares a 14-day
+# sweep grace to keep the unreachable tail from churning open/closed.
+#
+# Keyless: SEEK's search API and GraphQL detail endpoint both serve unauthenticated requests.
+
+# Australia — ~6,471 postings across the 22 slices below.
+- company: SEEK Australia — Architects
+  region: au
+  board: "6282" # ~319
+- company: SEEK Australia — Business/Systems Analysts
+  region: au
+  board: "6283" # ~688, over window
+- company: SEEK Australia — Computer Operators
+  region: au
+  board: "6284" # ~1, a near-dead category kept because it is live; the NZ counterpart is empty
+- company: SEEK Australia — Consultants
+  region: au
+  board: "6285" # ~448
+- company: SEEK Australia — Database Development & Administration
+  region: au
+  board: "6286" # ~178
+- company: SEEK Australia — Developers/Programmers
+  region: au
+  board: "6287" # ~638, over window
+- company: SEEK Australia — Engineering - Hardware
+  region: au
+  board: "6288" # ~35
+- company: SEEK Australia — Engineering - Network
+  region: au
+  board: "6289" # ~192
+- company: SEEK Australia — Engineering - Software
+  region: au
+  board: "6290" # ~746, over window
+- company: SEEK Australia — Help Desk & IT Support
+  region: au
+  board: "6291" # ~689, over window
+- company: SEEK Australia — Management
+  region: au
+  board: "6292" # ~290
+- company: SEEK Australia — Networks & Systems Administration
+  region: au
+  board: "6293" # ~407
+- company: SEEK Australia — Product Management & Development
+  region: au
+  board: "6294" # ~177
+- company: SEEK Australia — Programme & Project Management
+  region: au
+  board: "6295" # ~584, over window
+- company: SEEK Australia — Sales - Pre & Post
+  region: au
+  board: "6296" # ~114
+- company: SEEK Australia — Security
+  region: au
+  board: "6297" # ~392
+- company: SEEK Australia — Team Leaders
+  region: au
+  board: "6298" # ~52
+- company: SEEK Australia — Technical Writing
+  region: au
+  board: "6299" # ~24
+- company: SEEK Australia — Telecommunications
+  region: au
+  board: "6300" # ~128
+- company: SEEK Australia — Testing & Quality Assurance
+  region: au
+  board: "6301" # ~145
+- company: SEEK Australia — Web Development & Production
+  region: au
+  board: "6302" # ~43
+- company: SEEK Australia — Other IT
+  region: au
+  board: "6303" # ~181
+
+# New Zealand — ~1,323 postings. Subclassification 6284 (Computer Operators) is omitted: zero live
+# postings when measured, and the bar for a board is at least one real posting, not a code that
+# exists.
+- company: SEEK New Zealand — Architects
+  region: nz
+  board: "6282" # ~58
+- company: SEEK New Zealand — Business/Systems Analysts
+  region: nz
+  board: "6283" # ~143
+- company: SEEK New Zealand — Consultants
+  region: nz
+  board: "6285" # ~90
+- company: SEEK New Zealand — Database Development & Administration
+  region: nz
+  board: "6286" # ~55
+- company: SEEK New Zealand — Developers/Programmers
+  region: nz
+  board: "6287" # ~126
+- company: SEEK New Zealand — Engineering - Hardware
+  region: nz
+  board: "6288" # ~9
+- company: SEEK New Zealand — Engineering - Network
+  region: nz
+  board: "6289" # ~25
+- company: SEEK New Zealand — Engineering - Software
+  region: nz
+  board: "6290" # ~207
+- company: SEEK New Zealand — Help Desk & IT Support
+  region: nz
+  board: "6291" # ~126
+- company: SEEK New Zealand — Management
+  region: nz
+  board: "6292" # ~65
+- company: SEEK New Zealand — Networks & Systems Administration
+  region: nz
+  board: "6293" # ~68
+- company: SEEK New Zealand — Product Management & Development
+  region: nz
+  board: "6294" # ~57
+- company: SEEK New Zealand — Programme & Project Management
+  region: nz
+  board: "6295" # ~115
+- company: SEEK New Zealand — Sales - Pre & Post
+  region: nz
+  board: "6296" # ~14
+- company: SEEK New Zealand — Security
+  region: nz
+  board: "6297" # ~55
+- company: SEEK New Zealand — Team Leaders
+  region: nz
+  board: "6298" # ~24
+- company: SEEK New Zealand — Technical Writing
+  region: nz
+  board: "6299" # ~3
+- company: SEEK New Zealand — Telecommunications
+  region: nz
+  board: "6300" # ~10
+- company: SEEK New Zealand — Testing & Quality Assurance
+  region: nz
+  board: "6301" # ~45
+- company: SEEK New Zealand — Web Development & Production
+  region: nz
+  board: "6302" # ~6
+- company: SEEK New Zealand — Other IT
+  region: nz
+  board: "6303" # ~22


### PR DESCRIPTION
## What and why

SEEK is the dominant job board in Australia and New Zealand — two markets no per-employer ATS board covers at scale. Issue #1634 flagged it as the highest-value target of its batch but explicitly deferred it pending a spike: a plain fetch of a SEEK search page answers **403**, which reads as bot protection.

**The spike settled it: the 403 is a Cloudflare interstitial on the human-facing pages only.** SEEK's own frontend search API is not gated — `GET /api/jobsearch/v5/search` answers 200 JSON with no cookie, no credential and no browser-shaped User-Agent (confirmed with no UA at all, `curl/8.7.1`, `Go-http-client/2.0`, and the project's own `freehire/0.1`). Descriptions come from `POST /graphql`, operation `jobDetails`, on the same terms. The blocker the issue raised does not exist on the path we crawl.

Closes #1634

### Shape

`board` is an ICT **subclassification** id, `region` is the **market** (`au`/`nz`) — the same board-is-a-slice, region-is-a-market split `sources/adzuna.yml` uses, and region is already part of both the board dedupe key and the `board_health` key, so the same slice id in two markets is two independently-healthy crawl targets for free. The adapter is an `aggregator` (not `boardless`) and a `HydratingSource`, so a detail request is spent only on a posting the catalogue lacks.

43 boards: 22 Australian slices (~6,471 postings) and 21 New Zealand (~1,323).

### Two platform traps drive the design

Both verified live and recorded at the code and in `internal/sources/AGENTS.md`:

1. **`totalCount` is a function of `pageSize`.** The same query answered **36** at `pageSize=1`, **688** at `pageSize=20`, 680 at 50 and 666 at 100. It can drive neither pagination nor a truncation check, so the response struct does not even declare the field and the walk stops only on the repo's usual "this page added nothing new".
2. **The result window ends near 550.** `pageSize=100` serves pages 1–5 and answers page 6 empty. Five of Australia's 22 slices hold more than that, so they have a tail no crawl reaches. Ordered newest-first, the reachable window covers roughly the first 24 days of a SEEK ad's 30-day run; the declared **14-day `sweepGrace`** absorbs the drift that would otherwise close-and-reopen those postings each cycle. The marker is sound here specifically because liveness *cannot* be probed instead — SEEK's own job pages sit behind the same interstitial.

Also handled: `where` is load-bearing (omitting it collapsed a 688-posting slice to 36); `companyName` is empty on ~1 posting in 30, where `advertiser.description` carries the typed name — including the `"Private Advertiser"` placeholder, which is dropped rather than filed as a company.

### Verification

Live run against both markets: 31 postings, **every one** with an employer, a structured country, a work mode, a listing date and a hydrated description.

`go run ./cmd/validate-sources` → OK, 205 files. 19 unit tests for the adapter.

**Known limitation, deliberately not fixed here:** a posting whose detail request fails is ingested body-less and never retried, because the next crawl reports it as seen. `seen` is a bare membership predicate over `ExistingExternalIDs`, which reports row existence and `is_tech` — never whether the row carries a description — so no adapter can tell the two apart. Every `HydratingSource` in the repo shares this. Closing it properly means changing the hydration contract and its SQL for all of them, not forking the behaviour inside SEEK. Rare in practice: 31/31 details succeeded on the verification run. Written up in the change's `design.md`.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes (and `go vet -tags=integration ./...` — no DB/handler code touched).
- [x] I regenerated committed artifacts when their source changed (none: no SQL, migrations or contracts touched).
- [x] For `design-system/` changes: n/a.
- [x] For `web/` changes: n/a.
- [x] This stays within freehire's core/extension boundary — one more source adapter behind the existing `Source`/`HydratingSource` contracts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SEEK job listings for ICT roles across Australia and New Zealand.
  * Supports market-specific searches, pagination, duplicate removal, and job detail retrieval.
  * Includes employer, location, work arrangement, employment type, salary, posting date, and description details.
  * Continues providing list results when individual detail requests fail.
  * Added SEEK source configuration and registration for scheduled ingestion.

* **Documentation**
  * Documented SEEK search behavior, coverage limitations, and API constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->