### PR TITLE
Hold entity pages at the edge for an hour, listings for five minutes

### DIFF
--- a/web/src/lib/httpCache.test.ts
+++ b/web/src/lib/httpCache.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { PRIVATE_CACHE, PUBLIC_CACHE, cachePolicy } from './httpCache';
+import { PRIVATE_CACHE, PUBLIC_CACHE, PUBLIC_DETAIL_CACHE, cachePolicy } from './httpCache';
 
 describe('cachePolicy', () => {
   it('lets a shared cache hold an anonymous public page', () => {
-    expect(cachePolicy({ pathname: '/companies/acme', authenticated: false })).toBe(PUBLIC_CACHE);
     expect(cachePolicy({ pathname: '/', authenticated: false })).toBe(PUBLIC_CACHE);
     expect(cachePolicy({ pathname: '/collections/python', authenticated: false })).toBe(PUBLIC_CACHE);
   });
@@ -49,6 +48,58 @@ describe('cachePolicy', () => {
   it('tells a shared cache to store nothing at all for a private response', () => {
     expect(PRIVATE_CACHE).toContain('no-store');
     expect(PRIVATE_CACHE).toContain('private');
+  });
+});
+
+// A page about ONE entity is not re-rendered by an ingest run the way a listing is,
+// and there are hundreds of thousands of them — the long tail is where a five-minute
+// lifetime costs the most, because each page is seen once or twice per data centre
+// per window and pays for a revalidation every time.
+describe('cachePolicy holds an entity page longer than a listing', () => {
+  it('gives a detail page the longer shared-cache lifetime', () => {
+    for (const pathname of [
+      '/jobs/senior-go-engineer-acme-1a2b',
+      '/companies/acme',
+      '/blog/why-we-built-this',
+    ]) {
+      expect(cachePolicy({ pathname, authenticated: false })).toBe(PUBLIC_DETAIL_CACHE);
+    }
+  });
+
+  // These move with every ingest run: counts, newest-first ordering, which jobs a
+  // filter now matches. They keep the short lifetime.
+  it('leaves listings and index pages on the short lifetime', () => {
+    for (const pathname of [
+      '/',
+      '/jobs',
+      '/companies',
+      '/collections/python',
+      '/insights/skills/backend',
+    ]) {
+      expect(cachePolicy({ pathname, authenticated: false })).toBe(PUBLIC_CACHE);
+    }
+  });
+
+  // A detail page's CHILDREN are a different thing: discussion carries
+  // user-submitted comments, which should not sit at the edge for an hour.
+  it('does not extend the lifetime to a detail page sub-route', () => {
+    for (const pathname of ['/jobs/some-slug/discussion', '/companies/acme/discussion']) {
+      expect(cachePolicy({ pathname, authenticated: false })).toBe(PUBLIC_CACHE);
+    }
+  });
+
+  // The lifetime split must never weaken the rule it sits next to.
+  it('still refuses to store a signed-in detail page', () => {
+    expect(cachePolicy({ pathname: '/jobs/some-slug', authenticated: true })).toBe(PRIVATE_CACHE);
+    expect(cachePolicy({ pathname: '/companies/acme', authenticated: true })).toBe(PRIVATE_CACHE);
+  });
+
+  it('differs from the listing policy only in the shared-cache lifetime', () => {
+    expect(PUBLIC_DETAIL_CACHE).toContain('s-maxage=3600');
+    // Same two guarantees as PUBLIC_CACHE: the browser keeps revalidating, and the
+    // edge may keep serving while it refreshes.
+    expect(PUBLIC_DETAIL_CACHE).toContain('max-age=0');
+    expect(PUBLIC_DETAIL_CACHE).toContain('stale-while-revalidate=86400');
   });
 });
 

--- a/web/src/lib/httpCache.ts
+++ b/web/src/lib/httpCache.ts
@@ -18,6 +18,24 @@
  *  `stale-while-revalidate` lets it keep serving during the refresh. */
 export const PUBLIC_CACHE = 'public, max-age=0, s-maxage=300, stale-while-revalidate=86400';
 
+/** A page about ONE entity, held twelve times longer. Same two guarantees as
+ *  `PUBLIC_CACHE` — the browser still revalidates, the edge may still serve while
+ *  it refreshes — and only the shared-cache lifetime differs.
+ *
+ *  The hour is not a guess about how fresh a job page can be; it is bounded by how
+ *  fresh the catalogue itself is. The fastest thing that takes a posting down is the
+ *  ingest sweep, which closes a job unseen for **48 hours**; the liveness probe runs
+ *  twice a day and needs two consecutive `expired` reads; the age rule waits 45 days
+ *  (docs/agents/job-lifecycle.md). Against a floor measured in days, an hour is
+ *  noise — and `stale-while-revalidate=86400` already accepted up to a day of it.
+ *
+ *  What the hour actually buys is the revalidation count. `stale-while-revalidate`
+ *  means the edge already answers instantly past expiry, so `s-maxage` was never
+ *  controlling latency — it controls how often a background refresh lands on the
+ *  origin. Entity pages are the overwhelming majority of URLs, so this is where
+ *  twelve-fold matters. */
+export const PUBLIC_DETAIL_CACHE = 'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400';
+
 /** Anything tied to a person. `no-store` is deliberate over `no-cache`: nothing
  *  should be written down at all, not even revalidated. */
 export const PRIVATE_CACHE = 'private, no-store';
@@ -25,6 +43,13 @@ export const PRIVATE_CACHE = 'private, no-store';
 /** Route trees that are never shared, whoever asks. An anonymous hit here is a
  *  sign-in screen or a redirect, which is not worth handing to the next visitor. */
 const PRIVATE_ROOTS = new Set(['my', 'auth', 'moderation', 'delete-account']);
+
+/** Route families whose SECOND segment names one entity. Only `/<root>/<slug>`
+ *  qualifies, never a deeper child: `/jobs/<slug>/discussion` carries comments
+ *  people expect to appear promptly, and the index above them (`/jobs`,
+ *  `/companies`) is reordered by every ingest run. Both stay on the short
+ *  lifetime. */
+const DETAIL_ROOTS = new Set(['jobs', 'companies', 'blog']);
 
 /** The Cache-Control an HTML response should carry. */
 export function cachePolicy({
@@ -36,7 +61,9 @@ export function cachePolicy({
 }): string {
   if (authenticated) return PRIVATE_CACHE;
   // Compare whole segments: /myths is not under /my.
-  const root = pathname.split('/').find(Boolean);
+  const segments = pathname.split('/').filter(Boolean);
+  const [root] = segments;
   if (root && PRIVATE_ROOTS.has(root)) return PRIVATE_CACHE;
+  if (segments.length === 2 && root && DETAIL_ROOTS.has(root)) return PUBLIC_DETAIL_CACHE;
   return PUBLIC_CACHE;
 }


### PR DESCRIPTION
`PUBLIC_CACHE` was one constant for every anonymous page. A probe of the live site
on 2026-08-16 showed `/collections/python` and `/companies` returning
`cf-cache-status: EXPIRED` — the edge held a copy and went back to the origin
anyway, every five minutes, per data centre, per page. On a catalogue of hundreds
of thousands of long-tail URLs served by one box that is also running the ingest,
that is where the cost is.

Splits it by what actually changes the page:

- **Entity pages** — `/jobs/<slug>`, `/companies/<slug>`, `/blog/<slug>` — describe
  one thing and are not rewritten between reposts. `s-maxage=3600`.
- **Listings and indexes** — `/jobs`, `/companies`, `/collections/*`, `/insights/*`
  — carry counts and newest-first ordering that every ingest run moves. Unchanged
  at `s-maxage=300`.

`max-age=0` and `stale-while-revalidate=86400` are untouched in both, so the
browser still revalidates and the edge still serves while it refreshes.

## Why an hour is conservative rather than bold

The number is bounded by the catalogue's own freshness, not by taste. Per
`docs/agents/job-lifecycle.md`: the ingest sweep closes a job unseen for **48
hours**; the liveness probe runs twice a day and needs **two consecutive**
`expired` reads; the age rule waits 45 days. Against a floor measured in days, an
hour of edge staleness is below the noise — and `stale-while-revalidate=86400`
already accepted up to a day of it.

## What it actually buys

Not latency. `stale-while-revalidate` means the edge already answers instantly past
expiry, so `s-maxage` was never controlling how fast a page returns — it controls
how often a **background revalidation** lands on the origin. Entity pages are the
overwhelming majority of URLs, which is why twelve-fold matters here specifically.

## Scope

Only `/<root>/<slug>` qualifies, never a deeper child: `/jobs/<slug>/discussion`
carries comments that should not sit at the edge for an hour. The negative rule is
unchanged and covered by a test — a signed-in request to a detail page is still
`private, no-store`.

Tests written first and confirmed failing, then green. Full web suite 1060/1060.

Companion: strelov1/freehire-ops#30 enables the edge settings this leans on,
including the release-time cache purge a longer TTL makes mandatory.