### PR TITLE
Make the MCP server reachable from the site and the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ same repository, under the same licence.
 | **Apply** | CV builder with ATS-safe PDF templates, deterministic CV↔vacancy scoring, AI fit analysis, CV tailoring that invents nothing, tracer links, referrals |
 | **Track** | An application board with stages, a mail inbox that links recruiter replies to the application they answer, an append-only event ledger, reminders |
 | **Ask** | An in-process agent with five presets — chat, browse, profile, CV tailoring, interview rehearsal — with no shell and no minted credential |
-| **Build on** | A keyless public API, a CLI, a form-filling browser extension, ChatGPT Actions |
+| **Build on** | A keyless public API, a [CLI](https://github.com/strelov1/freehire-cli), an [MCP server](https://github.com/strelov1/freehire-mcp) for Claude Desktop and Claude Code, a form-filling browser extension, ChatGPT Actions |
 
 **[Full feature reference → `docs/features.md`](docs/features.md)** — what each one
 does, where it lives in the tree, which need an LLM endpoint configured, and

--- a/web/src/routes/mcp/+page.ts
+++ b/web/src/routes/mcp/+page.ts
@@ -1,0 +1,10 @@
+import { redirect } from '@sveltejs/kit';
+
+// The MCP server lives in the CLI page's `#mcp` section rather than on a page of its own —
+// one API key drives both surfaces, so splitting them would duplicate the setup story.
+// This route exists because directory listings (the MCP registry, mcp.so, PulseMCP) are
+// filled in by hand and several of them strip the fragment, leaving a bare /mcp that used
+// to 404. Permanent, so the anchor is what gets indexed.
+export const load = () => {
+  redirect(308, '/cli#mcp');
+};

--- a/web/static/llms.txt
+++ b/web/static/llms.txt
@@ -27,6 +27,7 @@ are rounded down and only refreshed when this file is.
 - [FreeHire GPT](https://chatgpt.com/g/g-6a5281b64948819193bf3a1021e075da-freehire): a custom ChatGPT that searches and tracks jobs via the FreeHire API.
 - [ChatGPT integration guide](https://freehire.me/chatgpt): how the GPT works and how to connect it.
 - [FreeHire CLI](https://freehire.me/cli): a small Go CLI over the same API, for terminals, scripts, and agents.
+- [FreeHire MCP server](https://freehire.me/mcp): `npx -y freehire-mcp` — search, market fit, application tracking and CV tailoring as MCP tools, for Claude Desktop, Claude Code, or any MCP host. Same API key as the CLI.
 
 ## Explore
 


### PR DESCRIPTION
Three small edits, all of them things a listing already promises but the site did not deliver.

## /mcp returned 404

The MCP server lives in the CLI page's `#mcp` section — one API key drives both surfaces, so a page of its own would duplicate the setup story. But directory listings are filled in by hand and several strip the fragment, storing a bare `/mcp`. That path 404'd. Now a 308 to `/cli#mcp`.

## llms.txt did not mention MCP at all

"Use it from an assistant" listed the GPT, the ChatGPT guide and the CLI. An agent reading llms.txt had no way to learn the MCP server exists. Added, with the npx one-liner and the note that it shares the CLI's API key.

## The README's build-on row

It named a CLI without linking it, and did not mention the MCP server. This repo has 378 stars — it is the highest-traffic surface either tool has, and it pointed at neither. Both are now linked.

Context: freehire-mcp is now listed in the official MCP registry as `me.freehire/freehire` with `websiteUrl: https://freehire.me/cli`, and on Smithery. Copy for every directory is kept in `docs/LISTINGS.md` in freehire-cli.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an MCP server link to the assistant integrations list, including available tools and setup information.
  - Added a direct redirect from the MCP page to the CLI’s MCP section.

- **Documentation**
  - Updated the “Build on” links to include the CLI and MCP server repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->