### PR TITLE
Animate the match analysis on Tailor cold start

### DIFF
--- a/internal/handler/match_analysis.go
+++ b/internal/handler/match_analysis.go
@@ -51,6 +51,12 @@ type matchHandlers struct {
 	// bank supplies the candidate's work history. Nil when there are no queries to build
 	// it over, which reads as an empty bank — and an empty bank means no analysis.
 	bank candidateProfiler
+	// coalesce ensures at most one fit-analysis compute runs at a time for a given (user, job)
+	// — see matchAnalysisCoordinator for why the cold-start autopilot's invisible pre-run and
+	// the workspace's visible stream can both reach ensureCachedAnalysis/StreamMatchAnalysis
+	// for the identical pair. Billing is decided per caller, not by who leads — see
+	// StreamMatchAnalysis's own comment.
+	coalesce matchAnalysisCoordinator
 }
 
 func newMatchHandlers(queries *db.Queries, userProfile *userprofile.Service, resumeStore *resume.Store, analyzer *matchanalysis.Analyzer, creditsStore *credits.Store) *matchHandlers {
@@ -278,10 +284,27 @@ func (h *matchHandlers) runAnalysis(c *fiber.Ctx, userID int64, job db.Job, prof
 // logged and left uncached, exactly as PostMatchAnalysis already degrades. No credits debit — this
 // path is unmetered, tracked only by the same LLM spend attribution every call already carries
 // (see the tailor-coldstart-autopilot design's "no new metering" decision).
+//
+// Coalesced through h.coalesce: the tailoring workspace's visible match-analysis stream now
+// starts at the same cold start this runs at, so both routinely race for the identical
+// (user, job) — see matchAnalysisCoordinator for why only one of them ever actually computes.
 func (h *matchHandlers) ensureCachedAnalysis(c *fiber.Ctx, userID int64, job db.Job) {
+	done, run, isLeader := h.coalesce.lead(userID, job.ID)
+	if !isLeader {
+		// The visible stream (or another concurrent call for this pair) already claimed the
+		// compute — wait for it rather than spending a second three-stage chain on the same
+		// input. Best-effort either way, exactly as before this coalescing existed: whether
+		// the leader actually cached anything is not this function's concern.
+		<-run.done
+		return
+	}
+	succeeded := false
+	defer func() { done(succeeded) }()
+
 	if _, err := h.matchAnalysisCache.GetUserJobAnalysis(c.Context(),
 		db.GetUserJobAnalysisParams{UserID: userID, JobID: job.ID}); err == nil {
-		return // already cached
+		succeeded = true // already cached — nothing to compute, and it's a good row for a follower to read
+		return
 	} else if !errors.Is(err, pgx.ErrNoRows) {
 		log.Printf("matchanalysis: checking cache before an autopilot run, user %d job %d: %v", userID, job.ID, err)
 		return
@@ -299,6 +322,7 @@ func (h *matchHandlers) ensureCachedAnalysis(c *fiber.Ctx, userID int64, job db.
 	}
 	cvUploadedAt, _ := h.cvUploadedAt(c, userID)
 	h.cacheAnalysis(c.Context(), userID, job, cvUploadedAt, language, analysis)
+	succeeded = true
 }
 
 // prepareAutopilotRun ensures the fit analysis is cached before an autopilot run starts —

--- a/internal/handler/match_analysis_coordinator.go
+++ b/internal/handler/match_analysis_coordinator.go
@@ -1,0 +1,101 @@
+package handler
+
+import "sync"
+
+// matchAnalysisCoordinator coalesces concurrent fit-analysis computes for the same (user, job)
+// pair across the two entry points that can each decide to run the three-stage LLM chain:
+// ensureCachedAnalysis (the cold-start autopilot's invisible pre-run, so cv_context has
+// something to read) and StreamMatchAnalysis (the tailoring workspace's visible stepper,
+// started at the same cold start). Both can reach here for the identical pair within
+// milliseconds of each other; without coalescing that is two three-stage chains spent on one
+// input — real wasted spend, since the cache exists specifically to avoid recomputing — racing
+// to upsert the same row.
+//
+// Hand-rolled rather than golang.org/x/sync/singleflight: a follower must never touch the LLM —
+// it waits, then reads whatever the leader left in the cache, over a completely different code
+// path from the leader's own AnalyzeStream-and-emit loop. singleflight.Do blocks every caller
+// (leader and followers alike) inside the call for the compute's whole duration, with no way
+// for a follower to run its OWN concurrent work meanwhile — StreamMatchAnalysis's follower
+// needs exactly that, to keep its own SSE connection's heartbeat ticking while it waits (see
+// followMatchAnalysis). lead here returns immediately with an explicit role and a wait handle,
+// so a follower can select on it alongside its own ticker instead of blocking inside Do.
+//
+// Billing is NOT decided here. Each caller that cares about AI credits (StreamMatchAnalysis)
+// gates and debits for itself, whether it ends up leading or following — see its own comment
+// on why that is safe to do independently without double-charging. ensureCachedAnalysis never
+// touches credits at all, leader or follower, which is what keeps the cold-start pre-run free.
+//
+// Zero value is ready to use — the map is created lazily under the lock — so every existing
+// matchHandlers{...} literal (test fixtures included) keeps compiling with nothing to wire.
+type matchAnalysisCoordinator struct {
+	mu       sync.Mutex
+	inflight map[analysisKey]*analysisRun
+}
+
+// analysisKey is the pair a compute is coalesced on. Scoped to one user: two candidates
+// analysing the same vacancy at once are not the same input (different résumé, different
+// blockers) and must never coalesce.
+type analysisKey struct {
+	userID, jobID int64
+}
+
+// analysisRun is what a follower waits on: done closes once the leader's compute ends, and
+// succeeded — safe to read only after that, never before — reports whether the cache is left
+// in a trustworthy state (a fresh compute, or one found already cached) versus a failed
+// attempt that left nothing new behind. A follower that skips this check and reads the cache
+// unconditionally can serve a stale row as if it were this run's result — see
+// followMatchAnalysis's own comment for the failure this caused live.
+type analysisRun struct {
+	done      chan struct{}
+	succeeded bool
+}
+
+// lead claims (userID, jobID) for the calling goroutine. The first caller becomes the LEADER
+// (isLeader=true) and owns running the chain; it MUST call done exactly once when its compute
+// ends — success, failure, or "LLM unconfigured" all count, with succeeded reporting which —
+// or every follower blocks forever. done is safe to call more than once (only the first call
+// has any effect): a future edit that adds one more early return before an existing done() call
+// must not turn into a double-close panic, which — running from the async SSE body-writer
+// goroutine fasthttp does not recover panics in — would take the whole process down, not just
+// the one request.
+//
+// A concurrent caller for the same pair is a FOLLOWER (isLeader=false, done=nil): it gets back
+// the same *analysisRun the leader is working on, to wait on directly (<-run.done) and then
+// consult (run.succeeded). lead itself never blocks — a follower decides for itself where to
+// wait (StreamMatchAnalysis waits inside its own SSE body-writer, on the background context its
+// leader compute already runs under, rather than blocking the request that is about to open the
+// stream; ensureCachedAnalysis waits inline, exactly as it already blocked for a whole chain's
+// duration running its OWN compute before this existed).
+//
+// run.done carries no cancellation and lead takes no ctx: nothing that calls this today needs
+// the wait to be interruptible — see the two call sites' own comments.
+func (co *matchAnalysisCoordinator) lead(userID, jobID int64) (done func(succeeded bool), run *analysisRun, isLeader bool) {
+	key := analysisKey{userID, jobID}
+	co.mu.Lock()
+	if existing, running := co.inflight[key]; running {
+		co.mu.Unlock()
+		return nil, existing, false
+	}
+	run = &analysisRun{done: make(chan struct{})}
+	if co.inflight == nil {
+		co.inflight = make(map[analysisKey]*analysisRun)
+	}
+	co.inflight[key] = run
+	co.mu.Unlock()
+
+	var once sync.Once
+	done = func(succeeded bool) {
+		once.Do(func() {
+			co.mu.Lock()
+			delete(co.inflight, key)
+			co.mu.Unlock()
+			// Written before the close, which is what makes it safe for a follower to read
+			// right after <-run.done unblocks: a channel close happens-before a receive that
+			// observes it, per the Go memory model, so this write is visible by then with no
+			// extra lock needed on the follower's side.
+			run.succeeded = succeeded
+			close(run.done)
+		})
+	}
+	return done, run, true
+}

--- a/internal/handler/match_analysis_coordinator_integration_test.go
+++ b/internal/handler/match_analysis_coordinator_integration_test.go
@@ -1,0 +1,542 @@
+//go:build integration
+
+// Integration tests for the real coalescing between the two entry points that can each decide
+// to run the three-stage fit chain for the same (user, job): the cold-start autopilot's
+// invisible ensureCachedAnalysis and the tailoring workspace's visible StreamMatchAnalysis.
+// See match_analysis_coordinator.go and the tailor cold-start animation design.
+// Run with: go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/tmc/langchaingo/llms"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/credits"
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/llm"
+	"github.com/strelov1/freehire/internal/matchanalysis"
+	"github.com/strelov1/freehire/internal/resume"
+	"github.com/strelov1/freehire/internal/resumeextract"
+	"github.com/strelov1/freehire/internal/userprofile"
+)
+
+// blockingFitModel blocks the FIRST GenerateContent call (Stage 1) until release is closed, so
+// a test can deterministically observe "a chain is under way" (started) and hold it there while
+// a concurrent caller for the same (user, job) races in. Every call after the first proceeds
+// immediately, cycling the canned stage responses exactly as fitModel does.
+type blockingFitModel struct {
+	resp    []string
+	n       int
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func newBlockingFitModel() *blockingFitModel {
+	return &blockingFitModel{
+		resp:    []string{fitStage1, fitStage2, fitStage3},
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (m *blockingFitModel) GenerateContent(context.Context, []llms.MessageContent, ...llms.CallOption) (*llms.ContentResponse, error) {
+	m.once.Do(func() {
+		close(m.started)
+		<-m.release
+	})
+	r := m.resp[m.n%len(m.resp)]
+	m.n++
+	return &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: r}}}, nil
+}
+func (*blockingFitModel) Call(context.Context, string, ...llms.CallOption) (string, error) {
+	return "", nil
+}
+
+// seedCoordinatorUser creates a user with a stored, structured CV and a banked career — what
+// the fit chain requires to produce an analysis — with an email distinguished by suffix so a
+// test seeding more than one user doesn't collide.
+func seedCoordinatorUser(t *testing.T, pool *pgxpool.Pool, queries *db.Queries, suffix string) (int64, *resume.Store) {
+	t.Helper()
+	ctx := context.Background()
+	var userID int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (email) VALUES ($1) RETURNING id`, "coalesce-"+suffix+"@example.test").Scan(&userID); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	store := resume.New(newFakeResumeBlobs(), &fakeResumeRepo{})
+	if _, err := store.Put(ctx, userID, "text/plain", []byte("5y Go at Acme.")); err != nil {
+		t.Fatalf("seed CV: %v", err)
+	}
+	if err := store.SetStructured(ctx, userID, resumeextract.Structured{Summary: "5y Go at Acme.", Skills: []string{"Go"}}, "test-model", resumeUploadedAt); err != nil {
+		t.Fatalf("seed structured: %v", err)
+	}
+	seedBankedCareer(t, queries, userID)
+	return userID, store
+}
+
+// seedCoordinatorJob seeds one job, slugged and hashed from prefix+i. Callers that only need
+// one job pass i=0; TestMatchAnalysisCoordinatorSecondStreamNeverSeesAnalysisUnavailable seeds
+// a fresh one per loop iteration — reusing a single (user, job) across iterations would let a
+// later iteration's GetUserJobAnalysis hit an earlier iteration's row before the coordinator
+// ever ran, hiding the very race that test exists to catch.
+func seedCoordinatorJob(t *testing.T, pool *pgxpool.Pool, prefix string, i int) int64 {
+	t.Helper()
+	var jobID int64
+	ext := fmt.Sprintf("%s-%d", prefix, i)
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO jobs (source, external_id, url, title, description, company_slug, public_slug, skills, content_hash)
+		 VALUES ('test', $1, 'http://e.test', 'Senior Go Engineer', 'Build backends.', 'acme', $2, ARRAY['go'], $1)
+		 RETURNING id`, ext, coordinatorJobSlug(prefix, i)).Scan(&jobID); err != nil {
+		t.Fatalf("seed job %d: %v", i, err)
+	}
+	return jobID
+}
+
+func coordinatorJobSlug(prefix string, i int) string {
+	return fmt.Sprintf("%s-race-job-%d", prefix, i)
+}
+
+// newCoordinatorHandlers builds the matchHandlers a coordinator test drives requests against —
+// model bound to a fresh Analyzer, everything else the fixed fixture StreamMatchAnalysis and
+// ensureCachedAnalysis both need.
+func newCoordinatorHandlers(pool *pgxpool.Pool, queries *db.Queries, store *resume.Store, model llms.Model) *matchHandlers {
+	return &matchHandlers{
+		queries:            queries,
+		userProfile:        userprofile.New(ownedProfile()),
+		resume:             store,
+		matchAnalysis:      matchanalysis.NewAnalyzer(llm.NewWithModel(model)),
+		matchAnalysisCache: queries,
+		credits:            credits.NewStore(queries, pool, credits.Config{MonthlyGrant: 20, CostMatch: 1, CostTailor: 3}),
+	}
+}
+
+// registerEnsureRoute mounts a test-only route standing in for the cold-start autopilot's
+// invisible pre-run: it calls the exact same unexported method PostAssistantAutopilot calls,
+// against the same matchHandlers and (user, job) a stream request in the same test races.
+func registerEnsureRoute(app *fiber.App, h *matchHandlers, userID int64, job db.Job) {
+	app.Post("/test/ensure", func(c *fiber.Ctx) error {
+		h.ensureCachedAnalysis(c, userID, job)
+		return c.SendStatus(fiber.StatusOK)
+	})
+}
+
+// asyncCall is one in-flight test request: done closes when it completes, and body (only
+// meaningful for a stream request — startEnsure leaves it empty) holds its SSE response body.
+type asyncCall struct {
+	done chan struct{}
+	body string
+}
+
+// startStream issues a GET to path with the caller's auth cookie in a goroutine, returning
+// immediately so the test can interleave a second concurrent call before this one completes.
+func startStream(t *testing.T, app *fiber.App, path, token string) *asyncCall {
+	t.Helper()
+	call := &asyncCall{done: make(chan struct{})}
+	go func() {
+		defer close(call.done)
+		req := httptest.NewRequest(fiber.MethodGet, path, nil)
+		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+		resp, err := app.Test(req, 5000)
+		if err != nil {
+			t.Errorf("stream request %s: %v", path, err)
+			return
+		}
+		defer resp.Body.Close()
+		call.body = readSSEBody(t, resp.Body)
+	}()
+	return call
+}
+
+// startEnsure issues the test-only POST /test/ensure route in a goroutine — the coordinator
+// side of a cold-start autopilot run, with no body worth capturing.
+func startEnsure(t *testing.T, app *fiber.App) *asyncCall {
+	t.Helper()
+	call := &asyncCall{done: make(chan struct{})}
+	go func() {
+		defer close(call.done)
+		resp, err := app.Test(httptest.NewRequest(fiber.MethodPost, "/test/ensure", nil), 5000)
+		if err != nil {
+			t.Errorf("ensure request: %v", err)
+			return
+		}
+		resp.Body.Close()
+	}()
+	return call
+}
+
+// waitDone blocks until call finishes or timeout elapses, failing the test in the latter case.
+func waitDone(t *testing.T, call *asyncCall, timeout time.Duration, msg string) {
+	t.Helper()
+	select {
+	case <-call.done:
+	case <-time.After(timeout):
+		t.Fatal(msg)
+	}
+}
+
+// waitStillRunning is waitDone's inverse: fails if call finishes before timeout elapses — used
+// to assert a follower is genuinely blocked on the leader rather than having raced ahead.
+func waitStillRunning(t *testing.T, call *asyncCall, timeout time.Duration, msg string) {
+	t.Helper()
+	select {
+	case <-call.done:
+		t.Fatal(msg)
+	case <-time.After(timeout):
+	}
+}
+
+func TestMatchAnalysisCoordinatorEnsureCachedAnalysisLeadsStreamFollows(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	queries := db.New(pool)
+
+	userID, store := seedCoordinatorUser(t, pool, queries, "a")
+	jobID := seedCoordinatorJob(t, pool, "a", 0)
+	job, err := queries.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("read job: %v", err)
+	}
+
+	model := newBlockingFitModel()
+	h := newCoordinatorHandlers(pool, queries, store, model)
+
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	token, _ := iss.Issue(userID, testTokenVersion)
+
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	registerEnsureRoute(app, h, userID, job)
+	app.Get("/api/v1/jobs/:slug/fit/stream", auth.RequireAuth(iss, testVersions), h.StreamMatchAnalysis)
+
+	ensure := startEnsure(t, app)
+	select {
+	case <-model.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ensureCachedAnalysis never started its compute")
+	}
+
+	stream := startStream(t, app, "/api/v1/jobs/"+coordinatorJobSlug("a", 0)+"/fit/stream", token)
+	waitStillRunning(t, stream, 200*time.Millisecond, "the follower stream returned before the leader was released")
+
+	close(model.release)
+
+	waitDone(t, ensure, 2*time.Second, "ensureCachedAnalysis never finished")
+	waitDone(t, stream, 2*time.Second, "the follower stream never finished")
+
+	if model.n != 3 {
+		t.Errorf("fit model called %d times, want 3 (one chain, not two — no double spend)", model.n)
+	}
+
+	names := sseEvents(t, stream.body)
+	if len(names) == 0 || names[0] != "meta" {
+		t.Fatalf("follower's first event = %v, want meta; all=%v", names, names)
+	}
+	if names[len(names)-1] != "final" {
+		t.Errorf("follower's last event = %q, want final; all=%v", names[len(names)-1], names)
+	}
+	var stageDone, stageStart int
+	for _, n := range names {
+		if n == "stage_done" {
+			stageDone++
+		}
+		if n == "stage_start" {
+			stageStart++
+		}
+	}
+	if stageDone != 3 {
+		t.Errorf("follower stage_done count = %d, want 3; all=%v", stageDone, names)
+	}
+	if stageStart != 0 {
+		t.Errorf("follower must never see stage_start (it never watched progress); all=%v", names)
+	}
+
+	var rows int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM user_job_analysis WHERE user_id=$1 AND job_id=$2`, userID, jobID).Scan(&rows); err != nil {
+		t.Fatalf("count cache rows: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("cache rows = %d, want 1", rows)
+	}
+
+	// ensureCachedAnalysis (the leader here) never touches credits — but the stream (the
+	// follower) is a genuinely paying request for a never-analysed job, and must still cost
+	// its own credit even though it didn't run the chain itself: h.debitMatch is idempotent
+	// per (user, feature, job), so this is one row, not zero (a free ride for a paying
+	// caller) or two (double-billed).
+	var debits int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM credit_ledger WHERE user_id=$1 AND kind='debit' AND feature='match'`, userID).Scan(&debits); err != nil {
+		t.Fatalf("count match debits: %v", err)
+	}
+	if debits != 1 {
+		t.Errorf("match debits = %d, want 1 — the follower is a genuinely new paying request and must still be charged once, not given a free ride because ensureCachedAnalysis led", debits)
+	}
+}
+
+// TestMatchAnalysisCoordinatorStreamLeadsEnsureCachedAnalysisFollowsAndLeaderStillBills is the
+// mirror of the test above with roles reversed: the paying stream leads, the free
+// ensureCachedAnalysis pre-run follows. The leader must bill exactly as it would with no
+// follower at all — an unmetered follower joining must never suppress a real charge (that
+// was the actual bug: a leader used to skip billing whenever ANY follower joined, which let a
+// second browser tab or a reload silently dodge the credit a new job's analysis costs).
+func TestMatchAnalysisCoordinatorStreamLeadsEnsureCachedAnalysisFollowsAndLeaderStillBills(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	queries := db.New(pool)
+
+	userID, store := seedCoordinatorUser(t, pool, queries, "b")
+	jobID := seedCoordinatorJob(t, pool, "b", 0)
+	job, err := queries.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("read job: %v", err)
+	}
+
+	model := newBlockingFitModel()
+	h := newCoordinatorHandlers(pool, queries, store, model)
+
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	token, _ := iss.Issue(userID, testTokenVersion)
+
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	registerEnsureRoute(app, h, userID, job)
+	app.Get("/api/v1/jobs/:slug/fit/stream", auth.RequireAuth(iss, testVersions), h.StreamMatchAnalysis)
+
+	stream := startStream(t, app, "/api/v1/jobs/"+coordinatorJobSlug("b", 0)+"/fit/stream", token)
+
+	select {
+	case <-model.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the visible stream never started its compute")
+	}
+
+	ensure := startEnsure(t, app)
+	waitStillRunning(t, ensure, 200*time.Millisecond, "ensureCachedAnalysis (the follower) returned before the leader was released")
+
+	close(model.release)
+
+	waitDone(t, stream, 2*time.Second, "the leader stream never finished")
+	waitDone(t, ensure, 2*time.Second, "ensureCachedAnalysis never finished")
+
+	if model.n != 3 {
+		t.Errorf("fit model called %d times, want 3 (one chain, not two — no double spend)", model.n)
+	}
+
+	names := sseEvents(t, stream.body)
+	joined := strings.Join(names, ",")
+	for _, want := range []string{"stage_start", "requirements", "dimensions", "final"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("leader stream missing %q event — it must show real progress, not a synthesized burst; got %v", want, names)
+		}
+	}
+
+	var rows int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM user_job_analysis WHERE user_id=$1 AND job_id=$2`, userID, jobID).Scan(&rows); err != nil {
+		t.Fatalf("count cache rows: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("cache rows = %d, want 1", rows)
+	}
+
+	var debits int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM credit_ledger WHERE user_id=$1 AND kind='debit' AND feature='match'`, userID).Scan(&debits); err != nil {
+		t.Fatalf("count match debits: %v", err)
+	}
+	if debits != 1 {
+		t.Errorf("match debits = %d, want 1 — the leader is a genuinely new paying request and an unmetered follower joining must not suppress its charge", debits)
+	}
+}
+
+// TestMatchAnalysisCoordinatorSecondStreamNeverSeesAnalysisUnavailable is a regression test
+// for a real race caught live: a leader used to call done() (releasing any follower)
+// immediately after AnalyzeStream returned, BEFORE its own h.cacheAnalysis write landed. A
+// follower unblocks the instant done() runs and reads the cache right away
+// (followMatchAnalysis) — so a follower that won that race read an empty cache and degraded
+// straight to "analysis unavailable", even though the leader was about to succeed.
+//
+// ensureCachedAnalysis's own follower branch can't catch this (it never reads the cache — see
+// the two tests above), so this drives TWO concurrent StreamMatchAnalysis calls instead: the
+// second becomes a follower via followMatchAnalysis, which does read the cache and is exactly
+// where the live bug surfaced. Repeated: the race window was narrow (a channel close vs. a
+// local DB round trip), so a single pass is not guaranteed to reproduce it.
+func TestMatchAnalysisCoordinatorSecondStreamNeverSeesAnalysisUnavailable(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	queries := db.New(pool)
+
+	userID, store := seedCoordinatorUser(t, pool, queries, "c")
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	token, _ := iss.Issue(userID, testTokenVersion)
+
+	const iterations = 15
+	for i := 0; i < iterations; i++ {
+		jobID := seedCoordinatorJob(t, pool, "cc", i)
+		path := "/api/v1/jobs/" + coordinatorJobSlug("cc", i) + "/fit/stream"
+
+		model := newBlockingFitModel()
+		h := newCoordinatorHandlers(pool, queries, store, model)
+		app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+		app.Get("/api/v1/jobs/:slug/fit/stream", auth.RequireAuth(iss, testVersions), h.StreamMatchAnalysis)
+
+		leader := startStream(t, app, path, token)
+		select {
+		case <-model.started:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("iteration %d: leader never started its compute", i)
+		}
+
+		follower := startStream(t, app, path, token)
+		// Give the follower a moment to actually reach the coordinator and register before
+		// releasing — otherwise it might not join as a follower at all on a slow scheduler.
+		time.Sleep(30 * time.Millisecond)
+		close(model.release)
+
+		waitDone(t, leader, 2*time.Second, fmt.Sprintf("iteration %d: leader stream never finished", i))
+		waitDone(t, follower, 2*time.Second, fmt.Sprintf("iteration %d: follower stream never finished", i))
+
+		followerNames := sseEvents(t, follower.body)
+		if len(followerNames) == 0 || followerNames[len(followerNames)-1] != "final" {
+			t.Fatalf("iteration %d: follower's stream = %v (leader's = %v) — must end in final, never \"analysis unavailable\"",
+				i, followerNames, sseEvents(t, leader.body))
+		}
+		if strings.Contains(follower.body, "analysis unavailable") {
+			t.Fatalf("iteration %d: follower saw \"analysis unavailable\" — done() raced ahead of the cache write; body=%q", i, follower.body)
+		}
+
+		var rows int
+		if err := pool.QueryRow(ctx, `SELECT count(*) FROM user_job_analysis WHERE user_id=$1 AND job_id=$2`, userID, jobID).Scan(&rows); err != nil {
+			t.Fatalf("iteration %d: count cache rows: %v", i, err)
+		}
+		if rows != 1 {
+			t.Errorf("iteration %d: cache rows = %d, want 1", i, rows)
+		}
+	}
+}
+
+// blockingFailingFitModel blocks the first call until release, then always fails — used to
+// deterministically make a leader's RECOMPUTE attempt fail while a follower is already
+// waiting on it.
+type blockingFailingFitModel struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func newBlockingFailingFitModel() *blockingFailingFitModel {
+	return &blockingFailingFitModel{started: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (m *blockingFailingFitModel) GenerateContent(context.Context, []llms.MessageContent, ...llms.CallOption) (*llms.ContentResponse, error) {
+	m.once.Do(func() {
+		close(m.started)
+		<-m.release
+	})
+	return nil, errors.New("upstream llm exploded")
+}
+func (*blockingFailingFitModel) Call(context.Context, string, ...llms.CallOption) (string, error) {
+	return "", nil
+}
+
+// TestMatchAnalysisCoordinatorFollowerNeverServesStaleAnalysisAfterFailedRecompute is a
+// regression test for a real gap: followMatchAnalysis used to trust whatever was in the cache
+// unconditionally, with no way to tell "the leader just computed this successfully" apart from
+// "the leader's recompute failed and this is what a PREVIOUS successful run left behind". A
+// follower joining a failed recompute would replay that stale row as a normal `final` event —
+// masking a failed recompute as a successful fresh one. run.succeeded is what closes this: a
+// follower must see stream_error whenever the leader's attempt failed, never the old analysis.
+func TestMatchAnalysisCoordinatorFollowerNeverServesStaleAnalysisAfterFailedRecompute(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	queries := db.New(pool)
+
+	userID, store := seedCoordinatorUser(t, pool, queries, "d")
+	jobID := seedCoordinatorJob(t, pool, "d", 0)
+
+	// Seed a stale cached row directly, as if a prior successful analysis already ran — a
+	// distinctive sentinel score so the test can tell "stale row leaked through" apart from
+	// "a real (if canned) analysis was served".
+	staleAnalysis := matchanalysis.Analysis{OverallScore: 999, Verdict: "Stale Sentinel"}
+	blob, err := json.Marshal(staleAnalysis)
+	if err != nil {
+		t.Fatalf("marshal stale analysis: %v", err)
+	}
+	if err := queries.UpsertUserJobAnalysis(ctx, db.UpsertUserJobAnalysisParams{
+		UserID: userID, JobID: jobID, Analysis: blob, Model: "stale-model", Language: "en",
+	}); err != nil {
+		t.Fatalf("seed stale analysis: %v", err)
+	}
+
+	model := newBlockingFailingFitModel()
+	h := newCoordinatorHandlers(pool, queries, store, model)
+
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	token, _ := iss.Issue(userID, testTokenVersion)
+
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/jobs/:slug/fit/stream", auth.RequireAuth(iss, testVersions), h.StreamMatchAnalysis)
+	path := "/api/v1/jobs/" + coordinatorJobSlug("d", 0) + "/fit/stream"
+
+	leader := startStream(t, app, path, token)
+	select {
+	case <-model.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the leader's recompute never started")
+	}
+
+	follower := startStream(t, app, path, token)
+	waitStillRunning(t, follower, 200*time.Millisecond, "the follower returned before the leader's failed recompute was released")
+
+	close(model.release)
+
+	waitDone(t, leader, 2*time.Second, "the leader stream never finished")
+	waitDone(t, follower, 2*time.Second, "the follower stream never finished")
+
+	leaderNames := sseEvents(t, leader.body)
+	if leaderNames[len(leaderNames)-1] != "stream_error" {
+		t.Errorf("leader's last event = %q, want stream_error (the recompute failed); all=%v", leaderNames[len(leaderNames)-1], leaderNames)
+	}
+
+	followerNames := sseEvents(t, follower.body)
+	if followerNames[len(followerNames)-1] != "stream_error" {
+		t.Errorf("follower's last event = %q, want stream_error — it must report the leader's failure, not replay the stale cached row; all=%v", followerNames[len(followerNames)-1], followerNames)
+	}
+	if strings.Contains(follower.body, "999") || strings.Contains(follower.body, "Stale Sentinel") {
+		t.Errorf("follower's body contains the stale sentinel analysis — a failed recompute was masked as success; body=%q", follower.body)
+	}
+
+	// The stale row must survive untouched — a failed recompute must not overwrite good data
+	// with nothing, and must not have been silently replaced either.
+	row, err := queries.GetUserJobAnalysis(ctx, db.GetUserJobAnalysisParams{UserID: userID, JobID: jobID})
+	if err != nil {
+		t.Fatalf("re-read cache row: %v", err)
+	}
+	if !strings.Contains(string(row.Analysis), "999") {
+		t.Errorf("cache row changed after a failed recompute; got %s", row.Analysis)
+	}
+}
+
+// readSSEBody reads a full (bounded) SSE response body as a string.
+func readSSEBody(t *testing.T, r io.Reader) string {
+	t.Helper()
+	var b strings.Builder
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 1<<20), 1<<20)
+	for sc.Scan() {
+		b.WriteString(sc.Text())
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/internal/handler/match_analysis_coordinator_test.go
+++ b/internal/handler/match_analysis_coordinator_test.go
@@ -1,0 +1,179 @@
+package handler
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestMatchAnalysisCoordinatorSecondCallerFollows(t *testing.T) {
+	var co matchAnalysisCoordinator
+
+	done, _, isLeader := co.lead(1, 100)
+	if !isLeader {
+		t.Fatal("first caller for a fresh key must lead")
+	}
+
+	followerReturned := make(chan struct{})
+	go func() {
+		_, run, isLeader := co.lead(1, 100)
+		if isLeader {
+			t.Error("second caller for the same key must follow, not lead")
+		}
+		<-run.done
+		close(followerReturned)
+	}()
+
+	select {
+	case <-followerReturned:
+		t.Fatal("follower returned before the leader called done")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	done(true)
+
+	select {
+	case <-followerReturned:
+	case <-time.After(time.Second):
+		t.Fatal("follower never unblocked after done()")
+	}
+}
+
+// TestMatchAnalysisCoordinatorSucceededVisibleToFollower is the coordinator-level building
+// block for followMatchAnalysis's "don't trust the cache after a failed run" fix: whatever
+// succeeded value the leader passes to done() must be exactly what a follower observes on
+// run.succeeded once <-run.done unblocks it, for both outcomes.
+func TestMatchAnalysisCoordinatorSucceededVisibleToFollower(t *testing.T) {
+	for _, succeeded := range []bool{true, false} {
+		var co matchAnalysisCoordinator
+		done, _, isLeader := co.lead(1, 100)
+		if !isLeader {
+			t.Fatal("first caller for a fresh key must lead")
+		}
+		_, run, isLeader := co.lead(1, 100)
+		if isLeader {
+			t.Fatal("second caller for the same key must follow, not lead")
+		}
+
+		done(succeeded)
+
+		select {
+		case <-run.done:
+		case <-time.After(time.Second):
+			t.Fatal("follower's run.done never closed")
+		}
+		if run.succeeded != succeeded {
+			t.Errorf("run.succeeded = %v, want %v", run.succeeded, succeeded)
+		}
+	}
+}
+
+// TestMatchAnalysisCoordinatorDoneIsIdempotent guards the fix for a real hazard: done() used
+// to be called ad hoc at several return points in StreamMatchAnalysis rather than deferred
+// once, so a future edit adding one more early return before an existing done() call would
+// double-close run.done and panic. done() must tolerate being called more than once.
+func TestMatchAnalysisCoordinatorDoneIsIdempotent(t *testing.T) {
+	var co matchAnalysisCoordinator
+	done, run, isLeader := co.lead(1, 100)
+	if !isLeader {
+		t.Fatal("first caller for a fresh key must lead")
+	}
+
+	done(true)
+	if !run.succeeded {
+		t.Fatal("run.succeeded = false after done(true)")
+	}
+
+	// A second call — with a different argument, to make a silent no-op obvious — must not
+	// panic (double close) and must not overwrite the first call's result.
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("second done() call panicked: %v", r)
+			}
+		}()
+		done(false)
+	}()
+	if !run.succeeded {
+		t.Error("a second done() call overwrote the first call's succeeded value")
+	}
+}
+
+func TestMatchAnalysisCoordinatorDifferentKeysDoNotBlock(t *testing.T) {
+	var co matchAnalysisCoordinator
+	_, _, leaderA := co.lead(1, 100)
+	_, _, leaderB := co.lead(1, 200)
+	if !leaderA || !leaderB {
+		t.Fatal("distinct (user, job) pairs must each lead independently")
+	}
+}
+
+func TestMatchAnalysisCoordinatorRunsAgainAfterDone(t *testing.T) {
+	var co matchAnalysisCoordinator
+	done, _, isLeader := co.lead(1, 100)
+	if !isLeader {
+		t.Fatal("first caller for a fresh key must lead")
+	}
+	done(true)
+
+	_, _, isLeader = co.lead(1, 100)
+	if !isLeader {
+		t.Fatal("a later call for the same key, after the prior run finished, must lead again")
+	}
+}
+
+func TestMatchAnalysisCoordinatorZeroValueUsable(t *testing.T) {
+	var co matchAnalysisCoordinator
+	done, _, isLeader := co.lead(1, 100)
+	if !isLeader {
+		t.Fatal("zero-value coordinator must work with no constructor")
+	}
+	done(true)
+}
+
+// TestMatchAnalysisCoordinatorRace exercises lead() under -race with many goroutines racing
+// on one key: exactly one must lead, none may deadlock, and the leader's done() must
+// eventually release every follower.
+func TestMatchAnalysisCoordinatorRace(t *testing.T) {
+	var co matchAnalysisCoordinator
+	const n = 50
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var leaders int
+	var doneFn func(bool)
+	followers := make([]*analysisRun, 0, n)
+
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			done, run, isLeader := co.lead(1, 100)
+			mu.Lock()
+			defer mu.Unlock()
+			if isLeader {
+				leaders++
+				doneFn = done
+			} else {
+				followers = append(followers, run)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if leaders != 1 {
+		t.Fatalf("expected exactly one leader, got %d", leaders)
+	}
+	if doneFn == nil {
+		t.Fatal("leader's done() was never captured")
+	}
+	doneFn(true)
+
+	for _, run := range followers {
+		select {
+		case <-run.done:
+		case <-time.After(time.Second):
+			t.Fatal("a follower never unblocked after the leader's done()")
+		}
+	}
+}

--- a/internal/handler/match_analysis_stream.go
+++ b/internal/handler/match_analysis_stream.go
@@ -16,6 +16,7 @@ import (
 	"github.com/valyala/fasthttp"
 
 	"github.com/strelov1/freehire/internal/credits"
+	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/hardconstraint"
 	"github.com/strelov1/freehire/internal/jobmatch"
 	"github.com/strelov1/freehire/internal/matchanalysis"
@@ -27,6 +28,12 @@ import (
 // The stream always opens with a `meta` event (has_cv); when no CV is stored it closes
 // after that. Everything the stream needs is captured before the body writer starts,
 // because the fiber ctx is released once this handler returns.
+//
+// Coalesced through h.coalesce: this is also what the tailoring workspace's cold start now
+// opens to animate the fit analysis, at the same moment the autopilot's own invisible
+// ensureCachedAnalysis may be racing for the identical (user, job). Whichever claims
+// leadership runs the chain for real; the other becomes a follower and replays the result via
+// followMatchAnalysis instead of paying for a second chain.
 func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 	userID, err := requireUserID(c)
 	if err != nil {
@@ -41,6 +48,16 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 	// out-of-credits new job returns a real 402 instead of an SSE error). Only a CV-backed
 	// request would run the LLM; without one the stream just reports has_cv. A recompute is
 	// free — only a new analysis is charged, and only after it persists (in the writer).
+	//
+	// Every caller runs this gate for ITSELF, whether it ends up leading or following the
+	// compute below — not just the leader. A follower still spends a real credit on a
+	// genuinely new job (two tabs open on the same never-analysed job is not a discount),
+	// and an out-of-credits caller must still 402 even when someone else is already
+	// computing the same analysis for free reasons (ensureCachedAnalysis never reaches this
+	// gate at all — see prepareAutopilotRun). Debiting twice for one job is safe: h.debitMatch
+	// is idempotent per (user, feature, job) — see credits.Store.Debit's DebitExists check —
+	// so a leader and a follower that both decide "I owe one credit here" collapse into a
+	// single ledger row, whichever of them reaches it first.
 	isNew := false
 	if hasCV {
 		var err error
@@ -53,6 +70,18 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 			}
 		}
 	}
+
+	// Leadership for (user, job) is claimed after the gate above, not before: nothing here
+	// can fail, so there is no path where a caller becomes leader and then has to immediately
+	// hand leadership back. A follower (almost always the cold-start autopilot's own invisible
+	// ensureCachedAnalysis, racing for the same pair) runs neither the LLM nor the reads below
+	// — see matchAnalysisCoordinator and followMatchAnalysis.
+	var done func(bool)
+	var run *analysisRun
+	isLeader := true
+	if hasCV {
+		done, run, isLeader = h.coalesce.lead(userID, job.ID)
+	}
 	profile, _ := h.userProfile.Get(c.Context(), userID)
 
 	// Compute the hard-constraint blockers exactly as the POST path does: the unmet
@@ -61,32 +90,41 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 	// the served response — so the ceiling has to be applied here, not skipped on the
 	// assumption a later GET will do it. The cache still holds the uncapped analysis,
 	// exactly as the POST path leaves it, so a dictionary change still takes effect
-	// on a later GET with no cache invalidation.
+	// on a later GET with no cache invalidation. Needed by both roles: a follower caps
+	// the same way before replaying the leader's cached analysis.
 	blockers := h.jobBlockers(c.Context(), userID, job, profile)
 
-	// Bound before the stream opens: minting a credential is a network call, and making
-	// it after the headers are out would stall a stream the client is already reading.
-	analyzer := h.matchAnalysis.As(h.llm.bind(c.Context(), userID, tagMatchAnalysis))
+	// Everything below is the leader's own compute setup — a follower runs neither the LLM
+	// nor these reads, and reaches its own path (followMatchAnalysis) once the body-writer
+	// opens.
+	var analyzer *matchanalysis.Analyzer
+	var language string
+	var input matchanalysis.Input
+	if isLeader {
+		// Bound before the stream opens: minting a credential is a network call, and making
+		// it after the headers are out would stall a stream the client is already reading.
+		analyzer = h.matchAnalysis.As(h.llm.bind(c.Context(), userID, tagMatchAnalysis))
 
-	// Captured up front, same as cvUploadedAt above: the cache write happens after the
-	// stream's own goroutine outlives this request, so the language it stamps must be
-	// the one the chain actually ran under, not whatever a profile edit changes it to
-	// mid-stream.
-	language := h.callerLanguage(c.Context(), userID)
-	input := matchanalysis.Input{
-		JobTitle:            job.Title,
-		JobDescription:      job.Description,
-		CompanyInfo:         h.companyInfo(c, job.CompanySlug),
-		StructuredResume:    h.candidateProfile(c, userID),
-		Match:               jobmatch.Compute(job.Skills, profile.Skills),
-		JobWorkMode:         job.WorkMode,
-		JobRemote:           job.Remote,
-		JobLocation:         job.Location,
-		JobRegions:          job.Regions,
-		JobCountries:        job.Countries,
-		LocationPreferences: string(profile.LocationPreferences),
-		Blockers:            blockers,
-		Language:            language,
+		// Captured up front, same as cvUploadedAt above: the cache write happens after the
+		// stream's own goroutine outlives this request, so the language it stamps must be
+		// the one the chain actually ran under, not whatever a profile edit changes it to
+		// mid-stream.
+		language = h.callerLanguage(c.Context(), userID)
+		input = matchanalysis.Input{
+			JobTitle:            job.Title,
+			JobDescription:      job.Description,
+			CompanyInfo:         h.companyInfo(c, job.CompanySlug),
+			StructuredResume:    h.candidateProfile(c, userID),
+			Match:               jobmatch.Compute(job.Skills, profile.Skills),
+			JobWorkMode:         job.WorkMode,
+			JobRemote:           job.Remote,
+			JobLocation:         job.Location,
+			JobRegions:          job.Regions,
+			JobCountries:        job.Countries,
+			LocationPreferences: string(profile.LocationPreferences),
+			Blockers:            blockers,
+			Language:            language,
+		}
 	}
 
 	sseHeaders(c)
@@ -107,7 +145,7 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 	c.Context().SetBodyStreamWriter(fasthttp.StreamWriter(func(w *bufio.Writer) {
 		stream := newSSEStream(w, conn, sseWriteTimeout)
 		start := time.Now()
-		log.Printf("matchanalysis: stream start user=%d job=%d has_cv=%v", userID, job.ID, hasCV)
+		log.Printf("matchanalysis: stream start user=%d job=%d has_cv=%v leader=%v", userID, job.ID, hasCV, isLeader)
 		stream.event("meta", map[string]bool{"has_cv": hasCV})
 		if !hasCV {
 			return
@@ -122,8 +160,25 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 		// the routes that reach here (matchAnalysisLimiter), not the lifetime of a TCP
 		// connection — a limit a reload could reset would bound nothing at all.
 		ctx := context.Background()
-		events := 0
 
+		if !isLeader {
+			// Someone else — almost always the cold-start autopilot's own invisible
+			// ensureCachedAnalysis — already claimed this pair. Wait for it and replay its
+			// result rather than running a second chain.
+			h.followMatchAnalysis(ctx, stream, run, userID, job, blockers, isNew)
+			return
+		}
+
+		// succeeded reports to any follower whether the cache is left in a trustworthy state
+		// by the time done runs. Deferred (not called ad hoc at each return below) so a panic
+		// between here and the end — anywhere in AnalyzeStream, the cache write, or the debit
+		// — still releases a waiting follower instead of stranding that (user, job) pair
+		// behind a leader that never finishes; see matchAnalysisCoordinator's own comment on
+		// why a bare, non-deferred done() was a real hazard here.
+		succeeded := false
+		defer func() { done(succeeded) }()
+
+		events := 0
 		// A long stage (a silent LLM call with no thinking tokens) would let the
 		// connection go quiet long enough for nginx's proxy_read_timeout to sever it
 		// mid-analysis — the client sees a bare "Connection lost". A periodic SSE comment
@@ -147,12 +202,61 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 			return
 		}
 		h.cacheAnalysis(ctx, userID, job, cvUploadedAt, language, analysis)
+		succeeded = true
 		if isNew {
 			h.debitMatch(ctx, userID, job.ID)
 		}
 		log.Printf("matchanalysis: stream DONE user=%d job=%d dur=%s events=%d overall=%d", userID, job.ID, time.Since(start).Round(time.Millisecond), events, analysis.OverallScore)
 	}))
 	return nil
+}
+
+// followMatchAnalysis is the graceful degrade for the rare race a visible stream loses: some
+// concurrent caller for the same (user, job) — almost always the cold-start autopilot's own
+// invisible ensureCachedAnalysis — claimed the compute first. It waits on run.done, then
+// replays whatever landed in the cache as one synthesized burst — stage_done for all three
+// stages (there is nothing to show progressing through) followed by final — so this reader's
+// stepper still resolves instead of hanging on "pending" forever.
+//
+// run.succeeded is checked before trusting the cache at all: a leader whose attempt failed
+// leaves an OLDER (or absent) row behind, not a fresh one, and reading it unconditionally would
+// serve a stale analysis dressed up as this run's live result — a follower must report the
+// same failure the leader saw, not paper over it.
+//
+// The wait runs on ctx (StreamMatchAnalysis's background context, taken after the fiber ctx is
+// gone): the same disconnect-proof posture the leader's own compute already runs under, so a
+// client that leaves during the wait costs nothing extra. Never emits
+// stage_start/thinking/requirements/dimensions: those describe progress this caller never
+// watched. isNew is THIS caller's own credits gate result (see StreamMatchAnalysis) — debiting
+// here when the leader was the free ensureCachedAnalysis pre-run is exactly the case that must
+// still charge a genuinely new analysis; h.debitMatch's idempotency (by user, feature, job) is
+// what keeps two callers that both decide to debit from charging twice.
+func (h *matchHandlers) followMatchAnalysis(ctx context.Context, stream *sseStream, run *analysisRun, userID int64, job db.Job, blockers []hardconstraint.Blocker, isNew bool) {
+	stopHeartbeat := stream.keepalive(sseKeepalive) // the wait can run as long as a full chain
+	<-run.done
+	stopHeartbeat()
+
+	if !run.succeeded {
+		stream.event("stream_error", map[string]string{"message": "analysis unavailable"})
+		return
+	}
+	row, err := h.matchAnalysisCache.GetUserJobAnalysis(ctx, db.GetUserJobAnalysisParams{UserID: userID, JobID: job.ID})
+	analysis := decodeAnalysis(row.Analysis)
+	if err != nil || analysis == nil {
+		stream.event("stream_error", map[string]string{"message": "analysis unavailable"})
+		return
+	}
+	served := *analysis
+	applyBlockers(&served, blockers)
+	for n := 1; n <= 3; n++ {
+		stream.event(string(matchanalysis.EventStageDone), matchanalysis.Event{
+			Kind: matchanalysis.EventStageDone, Stage: n, Label: matchanalysis.StageLabel(n),
+		})
+	}
+	stream.event(string(matchanalysis.EventFinal), matchanalysis.Event{Kind: matchanalysis.EventFinal, Analysis: &served})
+	if isNew {
+		h.debitMatch(ctx, userID, job.ID)
+	}
 }
 
 // capFinalEvent applies the caller's hard-constraint blockers to the audited `final`

--- a/internal/matchanalysis/analyzer.go
+++ b/internal/matchanalysis/analyzer.go
@@ -134,6 +134,11 @@ type Event struct {
 
 var stageLabels = map[int]string{1: "Extract & Match", 2: "Recruiter verdict", 3: "Adversarial audit"}
 
+// StageLabel names one of the three chain stages (1-3) for a caller that describes a stage
+// without running the chain (e.g. synthesizing a stage_done burst for a reader who joined
+// after the chain already finished elsewhere). Empty for an unknown stage.
+func StageLabel(stage int) string { return stageLabels[stage] }
+
 // Analyze runs the three-stage chain and returns the final analysis, discarding the
 // stream. Returns (nil, nil) when the LLM is unconfigured. It is a thin collector over
 // AnalyzeStream — one chain implementation, no duplication.

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -32,7 +32,7 @@ describe('createApi request timeout', () => {
   });
 
   // The browser client is built without a timeout: it drives the LLM-backed calls
-  // (fit analysis, tailoring), which legitimately run for minutes.
+  // (match analysis, tailoring), which legitimately run for minutes.
   it('leaves the call unbounded when no timeout is configured', async () => {
     const seen: { init?: RequestInit } = {};
     await createApi(okFetch(seen), '', {}).ingestStatus();

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -409,21 +409,21 @@ export function createApi(
     return requestData<JobMatchResult>(`/api/v1/jobs/${slug}/match`);
   }
 
-  /** The cached LLM fit analysis for a job (never runs the model). `has_cv` is false
+  /** The cached LLM match analysis for a job (never runs the model). `has_cv` is false
    *  when no CV is stored; `analysis` is null when none is cached yet; `stale` marks a
    *  cached analysis whose CV or job changed since. Safe to call on expand. */
   async function getMatchAnalysis(slug: string): Promise<MatchAnalysisResponse> {
     return requestData<MatchAnalysisResponse>(`/api/v1/jobs/${slug}/match-analysis`);
   }
 
-  /** Run the three-stage fit prompt-chain over the caller's CV and this job, cache it
+  /** Run the three-stage match prompt-chain over the caller's CV and this job, cache it
    *  per (user, job), and return it fresh. Bound to the explicit compute/recompute
    *  action. With no LLM configured this returns `has_cv` with a null analysis. */
   async function runMatchAnalysis(slug: string): Promise<MatchAnalysisResponse> {
     return requestData<MatchAnalysisResponse>(`/api/v1/jobs/${slug}/match-analysis`, { method: 'POST' });
   }
 
-  /** The same-origin URL for the fit SSE stream — the fit page opens an EventSource on
+  /** The same-origin URL for the match SSE stream — the tailoring workspace opens an EventSource on
    *  it (EventSource takes a URL, not our fetch wrapper; the session cookie rides along). */
   function matchAnalysisStreamUrl(slug: string): string {
     return `${baseUrl}/api/v1/jobs/${slug}/match-analysis/stream`;
@@ -927,8 +927,8 @@ export function createApi(
     );
   }
 
-  /** The jobs the current user has run the AI fit analysis on (newest first), plus their
-   *  AI-credits balance — powers the Tracking → AI fit tab. Never triggers the LLM. */
+  /** The jobs the current user has run the AI match analysis on (newest first), plus their
+   *  AI-credits balance — powers the Activity → Matches tab. Never triggers the LLM. */
   async function myAnalyses(): Promise<{ items: MyAnalysisItem[]; credits: AiCredits | null }> {
     const res = await request<{ data: MyAnalysisItem[]; meta: { credits: AiCredits | null } }>(
       '/api/v1/me/tracking/analyses',
@@ -1877,7 +1877,7 @@ export function createApi(
   /**
    * Bootstrap a tailoring session for a vacancy: seeds/creates the base CV, makes a
    * vacancy-bound tailored copy, and returns its id plus the cached analysis. Requires a
-   * cached fit analysis and a stored résumé (409 otherwise); beta-gated.
+   * cached match analysis and a stored résumé (409 otherwise); beta-gated.
    */
   async function tailorCv(jobSlug: string): Promise<TailorResult> {
     return requestData<TailorResult>('/api/v1/me/cvs/tailor', jsonBody('POST', { job_slug: jobSlug }));

--- a/web/src/lib/assistant/tool-formatters.ts
+++ b/web/src/lib/assistant/tool-formatters.ts
@@ -34,7 +34,7 @@ const LABELS: Record<string, string> = {
   apply_job: 'Marking as applied',
   track_job: 'Updating your board',
   my_jobs: 'Reading your tracked jobs',
-  cv_context: 'Reading the fit analysis',
+  cv_context: 'Reading the match analysis',
   cv_get: 'Reading your CV',
   cv_edit: 'Updating your CV',
 };

--- a/web/src/lib/components/AnalysesView.svelte
+++ b/web/src/lib/components/AnalysesView.svelte
@@ -9,7 +9,7 @@
   import { EntityLogo } from '$lib/ui';
   import States from './States.svelte';
 
-  // The Tracking → AI fit tab: the jobs the caller has run the AI fit analysis on. Read-only —
+  // The Activity → Matches tab: the jobs the caller has run the AI match analysis on. Read-only —
   // never triggers the LLM (each row links to the Tailor workspace, which owns compute/recompute).
   // The AI-credits balance lives on its own page (/my/credits), not inline here.
   let status = $state<'loading' | 'error' | 'ready'>('loading');
@@ -46,7 +46,7 @@
 {:else if status === 'error'}
   <States state="error" message="Couldn't load your analyses." />
 {:else if items.length === 0}
-  <States state="empty" message="No AI fit analyses yet. Open a job and run “Analyse fit with AI”." />
+  <States state="empty" message="No AI match analyses yet. Open a job and run “Analyse match with AI”." />
 {:else}
   <ul class="flex flex-col gap-3">
     {#each items as it (it.slug)}

--- a/web/src/lib/components/CliView.svelte
+++ b/web/src/lib/components/CliView.svelte
@@ -244,14 +244,14 @@ freehire search <span class="text-foreground">"golang"</span> --remote --region 
     <div class="mt-8 max-w-2xl rounded-lg border border-border bg-secondary/40 p-4">
       <h3 class="text-sm font-semibold">Tailor a CV to a vacancy</h3>
       <p class="mt-2 text-sm leading-relaxed text-muted-foreground">
-        After a fit analysis, <a href={resolve('/features/tailor')} class="font-medium text-foreground underline-offset-4 hover:underline">reframe your CV</a> toward one job — grounded in what you actually did, never
+        After a match analysis, <a href={resolve('/features/tailor')} class="font-medium text-foreground underline-offset-4 hover:underline">reframe your CV</a> toward one job — grounded in what you actually did, never
         fabricated — then export an ATS-ready PDF. <code class="font-mono text-foreground">cv context</code>
         is the honest part: it splits the job's requirements into the ones your history already covers but
         buries (reframe those) and the ones it doesn't (ask, don't invent), so an agent editing your CV
         knows which is which.
       </p>
       <pre
-        class="mt-3 overflow-x-auto rounded-md border border-border bg-background/60 p-3 font-mono text-sm leading-relaxed"><span class="text-muted-foreground">freehire</span> cv context &lt;id&gt;        <span class="text-muted-foreground"># the fit analysis to reframe toward</span>
+        class="mt-3 overflow-x-auto rounded-md border border-border bg-background/60 p-3 font-mono text-sm leading-relaxed"><span class="text-muted-foreground">freehire</span> cv context &lt;id&gt;        <span class="text-muted-foreground"># the match analysis to reframe toward</span>
 <span class="text-muted-foreground">freehire</span> cv get &lt;id&gt;            <span class="text-muted-foreground"># the CV document as JSON</span>
 <span class="text-muted-foreground">freehire</span> cv edit &lt;id&gt; --set …   <span class="text-muted-foreground"># one edit by path (--ops for a batch)</span>
 <span class="text-muted-foreground">freehire</span> cv render &lt;id&gt; --out cv.pdf</pre>

--- a/web/src/lib/components/MatchAnalysisFull.svelte
+++ b/web/src/lib/components/MatchAnalysisFull.svelte
@@ -17,14 +17,19 @@
   import { renderMarkdown } from '$lib/markdown';
   import { Button } from '$lib/ui';
 
-  // The full AI fit report + live SSE stream. Caller: `ArtifactPanel`'s Job Match tab (seeded,
-  // read-only, `autoRun=false`) — the tailoring workspace's own cold start computes the analysis
-  // inline as part of its autopilot run rather than through this component's stream.
-  // `initial` seeds from an SSR-cached fit for an instant paint when the caller has one; when
-  // absent, the cached fit is fetched on mount. `autoRun` starts the stream on a cold start —
-  // the "never silently recompute a cached analysis" gate. `stacked` forces every multi-column
-  // section into a single column regardless of viewport width — for callers narrower than the
-  // viewport-based `lg:`/`sm:` breakpoints assume (the tailoring artifact panel).
+  // The full AI match report + live SSE stream. Caller: `ArtifactPanel`'s Job Match tab, with
+  // `autoRun` wired to the tailoring workspace's own `coldStartRunning` — a cold start opens
+  // this component's stream immediately, in parallel with the autopilot's CV-edit run, so the
+  // stage stepper actually animates instead of the compute happening invisibly elsewhere. A
+  // concurrent invisible compute (autopilot's pre-run) can still win the race on occasion; see
+  // internal/handler/match_analysis_coordinator.go for how that's kept from double-running the
+  // chain, and its `followMatchAnalysis` for what this component renders when it does.
+  // `initial` seeds from an SSR-cached analysis for an instant paint when the caller has one;
+  // when absent, the cached analysis is fetched on mount. `autoRun` starts the stream on a
+  // cold start — the "never silently recompute a cached analysis" gate. `stacked` forces
+  // every multi-column section into a single column regardless of viewport width — for
+  // callers narrower than the viewport-based `lg:`/`sm:` breakpoints assume (the tailoring
+  // artifact panel).
   let {
     job,
     initial = null,
@@ -167,7 +172,7 @@
 
   const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-  // Poll the cached fit after a dropped stream: the server's background compute lands the
+  // Poll the cached analysis after a dropped stream: the server's background compute lands the
   // analysis in the cache even with no client attached, so a re-read recovers it without a
   // fresh (charged) recompute. Attempts are spent only while the tab is visible, so a long
   // background freeze on mobile doesn't exhaust the budget before the user returns; stop()
@@ -198,14 +203,14 @@
   }
 
   onMount(async () => {
-    // The card has no SSR fit — fetch the cache, then seed from it (the stream was
+    // The card has no SSR analysis — fetch the cache, then seed from it (the stream was
     // seeded from a null `initial`, so there is nothing to preserve).
     if (!fit && isAuthenticated()) {
       try {
         fit = await api.getMatchAnalysis(job.public_slug);
         stream = seedFrom(fit);
       } catch {
-        /* best-effort: an unconfigured/failing fit endpoint leaves the empty state */
+        /* best-effort: an unconfigured/failing match-analysis endpoint leaves the empty state */
       }
     }
     // Read the cache fields directly rather than via $derived: onMount is not a reactive
@@ -278,12 +283,12 @@
 <div class="flex flex-col gap-8">
   {#if !isAuthenticated()}
     <p class="rounded-xl border border-border bg-card p-8 text-center text-sm text-muted-foreground">
-      Sign in to analyse your fit for this role.
+      Sign in to analyse your match for this role.
     </p>
   {:else if !stream.hasCV}
     <div class="flex flex-col items-center gap-4 rounded-xl border border-dashed border-border bg-card p-10 text-center">
       <FileText class="size-8 text-muted-foreground" />
-      <p class="text-sm text-muted-foreground">Upload a CV to analyse your fit for this role.</p>
+      <p class="text-sm text-muted-foreground">Upload a CV to analyse your match for this role.</p>
       <Button variant="primary" size="sm" href={resolve('/my/profile')}>Upload CV</Button>
     </div>
   {:else}
@@ -370,9 +375,10 @@
       </div>
     {/if}
 
-    <!-- Streaming: stage stepper + thinking. Idle cold starts used to render the same
-         pending stepper with nothing driving it (tailor sets autoRun=false), which looked
-         like Extract & Match / Recruiter verdict were hung. Show an explicit Run when idle. -->
+    <!-- Streaming: stage stepper + thinking. An idle cold start (autoRun=false — a resumed
+         CV, the standalone page) used to render the same pending stepper with nothing driving
+         it, which looked like Extract & Match / Recruiter verdict were hung. Show an explicit
+         Run when idle. -->
     {#if !blockedNew && (streaming || recovering)}
       <section class="rounded-2xl border border-border bg-card p-6 sm:px-8">
         <!-- Stage stepper: evenly-spaced nodes over a single connecting rail. -->
@@ -417,7 +423,7 @@
     {:else if !blockedNew && !analysis && !stream.error}
       <div class="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border bg-card p-8 text-center">
         <p class="text-sm text-muted-foreground">
-          Run the three-stage fit analysis — Extract &amp; Match, Recruiter verdict, then Adversarial audit.
+          Run the three-stage match analysis — Extract &amp; Match, Recruiter verdict, then Adversarial audit.
         </p>
         <Button variant="primary" size="sm" onclick={start} disabled={streaming || recovering}>
           <RefreshCw class="size-3.5" /> Run analysis

--- a/web/src/lib/components/MatchSummary.svelte
+++ b/web/src/lib/components/MatchSummary.svelte
@@ -10,7 +10,7 @@
   import type { MatchAnalysisResponse } from '$lib/types';
   import { Button } from '$lib/ui';
 
-  // A compact fit summary in the Profile-match sidebar: the overall %, verdict, and the
+  // A compact match summary in the Profile-match sidebar: the overall %, verdict, and the
   // single biggest gap when an analysis is cached, with a link to the full-page analysis
   // (which runs the live streaming compute). It never computes inline.
   //

--- a/web/src/lib/components/TailorLandingView.svelte
+++ b/web/src/lib/components/TailorLandingView.svelte
@@ -39,8 +39,8 @@
   const steps = [
     {
       n: '01',
-      title: 'Analyse the fit',
-      body: 'Run the AI fit analysis on the vacancy. It scores the match dimension by dimension and names what is missing — the reasoning the tailored CV will work from.',
+      title: 'Analyse the match',
+      body: 'Run the AI match analysis on the vacancy. It scores the match dimension by dimension and names what is missing — the reasoning the tailored CV will work from.',
     },
     {
       n: '02',
@@ -138,7 +138,7 @@
         It knows the difference between burying something and not having it.
       </h2>
       <p class="mt-5 leading-relaxed text-muted-foreground">
-        Before the agent writes a word, it reads the fit analysis for this vacancy and sorts the
+        Before the agent writes a word, it reads the match analysis for this vacancy and sorts the
         job's requirements into two piles. That split is the whole feature: one pile is editing,
         the other is a question.
       </p>
@@ -283,7 +283,7 @@ freehire <span class="text-foreground">cv render &lt;cv-id&gt; --out cv.pdf</spa
     <div class="flex flex-col items-start gap-4 rounded-xl border border-border bg-secondary/40 p-6 sm:p-8">
       <h2 class="text-2xl font-semibold tracking-tight">Stop sending the same CV everywhere.</h2>
       <p class="max-w-xl leading-relaxed text-muted-foreground">
-        Find a job worth the effort, run the fit analysis, and tailor from it. Ten minutes per
+        Find a job worth the effort, run the match analysis, and tailor from it. Ten minutes per
         application, and nothing on the page that you did not do.
       </p>
       <div class="flex flex-wrap gap-3">

--- a/web/src/lib/cv.ts
+++ b/web/src/lib/cv.ts
@@ -71,7 +71,7 @@ export interface CvTailoredItem extends CvMeta {
 
 /**
  * Result of bootstrapping a tailoring session: the ids of the new vacancy-bound CV and the
- * base it was copied from, the cached fit analysis, and the id of the tailoring conversation
+ * base it was copied from, the cached match analysis, and the id of the tailoring conversation
  * the backend minted and bound to that CV. There is no credential — the agent runs inside the
  * backend as the caller.
  */

--- a/web/src/lib/docs/api-spec.ts
+++ b/web/src/lib/docs/api-spec.ts
@@ -350,7 +350,7 @@ export const GROUPS: Group[] = [
     intro:
       'Personalized signals computed against the caller’s profile or stored CV. ' +
       'All accept the session cookie or an API key. The skill-match endpoint is ' +
-      'deterministic (no LLM); the fit endpoints run the LLM chain and cost AI ' +
+      'deterministic (no LLM); the match-analysis endpoints run the LLM chain and cost AI ' +
       'credits. All take the same facet filter params as search where they narrow a ' +
       'market or candidate set.',
     endpoints: [
@@ -381,7 +381,7 @@ export const GROUPS: Group[] = [
         method: 'GET',
         path: '/jobs/{slug}/match-analysis',
         auth: 'cookie-or-key',
-        summary: 'The cached AI fit analysis for the job (never runs the LLM).',
+        summary: 'The cached AI match analysis for the job (never runs the LLM).',
         description:
           'Returns the cached analysis, flagged `stale` when your CV or the job ' +
           'changed since it was computed, or a null analysis when none is cached. ' +
@@ -410,9 +410,9 @@ export const GROUPS: Group[] = [
         method: 'POST',
         path: '/jobs/{slug}/match-analysis',
         auth: 'cookie-or-key',
-        summary: 'Run the three-stage AI fit analysis and cache it.',
+        summary: 'Run the three-stage AI match analysis and cache it.',
         description:
-          'Runs the fit prompt-chain over your stored CV and the job, caches the ' +
+          'Runs the match prompt-chain over your stored CV and the job, caches the ' +
           'result, and returns it fresh (no `credits` on this response). Analysing a new ' +
           'job costs one AI credit; if you have none left it is a `402`, and recomputing ' +
           'an already-analyzed job is free. `has_cv` is false when no CV is stored; a ' +
@@ -431,13 +431,13 @@ export const GROUPS: Group[] = [
         method: 'GET',
         path: '/jobs/{slug}/match-analysis/stream',
         auth: 'cookie-or-key',
-        summary: 'Run the fit analysis over Server-Sent Events.',
+        summary: 'Run the match analysis over Server-Sent Events.',
         description:
           'The same three-stage chain as `POST /jobs/{slug}/match-analysis`, streamed as SSE ' +
           '(`text/event-stream`) rather than a single JSON body. Each event’s `kind` ' +
           'is one of `stage_start`, `stage_done`, `thinking`, `requirements`, ' +
           '`dimensions`, `final`; the `final` event carries the completed `analysis` ' +
-          '(the same shape as the fit endpoints). Not a JSON endpoint.',
+          '(the same shape as the match-analysis endpoints). Not a JSON endpoint.',
         pathParams: [{ name: 'slug', type: 'string', required: true, description: 'The job `public_slug`.' }],
         curl: `curl -N "${BASE_URL}/jobs/<slug>/match-analysis/stream" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
         responseExample: `data: {"kind":"stage_start","stage":1,"label":"Extracting requirements"}
@@ -885,7 +885,7 @@ ${BASE_URL}/auth/oauth/google/start`,
         method: 'GET',
         path: '/me/tracking/analyses',
         auth: 'cookie-or-key',
-        summary: 'Jobs you have run the AI fit analysis on.',
+        summary: 'Jobs you have run the AI match analysis on.',
         description:
           'Newest first, closed jobs included (with `closed: true`). Each item carries the ' +
           'overall score and verdict; `stale` marks an analysis whose CV, job, or model has ' +
@@ -914,7 +914,7 @@ ${BASE_URL}/auth/oauth/google/start`,
         summary: 'Your current AI-credits balance.',
         description:
           'The points left this month (`remaining`) and when the monthly grant renews ' +
-          '(`resets_at`). AI credits are spent on the fit analysis (1) and CV tailoring (3), ' +
+          '(`resets_at`). AI credits are spent on the match analysis (1) and CV tailoring (3), ' +
           'topped up by the monthly grant and by accepted board contributions. Never runs the LLM.',
         curl: `curl "${BASE_URL}/me/credits" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
         responseExample: `{
@@ -1627,7 +1627,7 @@ ${BASE_URL}/auth/oauth/google/start`,
         path: '/me/credits/history',
         auth: 'cookie-or-key',
         summary: 'Your AI-credit ledger, newest first.',
-        description: 'Each debit is labelled with what it bought — the job a fit analysis was run on, the vacancy a CV was tailored for — rather than an opaque reference.',
+        description: 'Each debit is labelled with what it bought — the job a match analysis was run on, the vacancy a CV was tailored for — rather than an opaque reference.',
         query: [
           { name: 'limit', type: 'integer', description: 'Page size.' },
           { name: 'offset', type: 'integer', description: 'Page offset.' },
@@ -2299,7 +2299,7 @@ ${BASE_URL}/auth/oauth/google/start`,
         summary: 'Start tailoring a CV toward one vacancy.',
         description:
           'Copies your base CV into a vacancy-bound tailored one and mints the ' +
-          'short-lived credential its agent session runs on. Requires a cached fit ' +
+          'short-lived credential its agent session runs on. Requires a cached match ' +
           'analysis for the job (409 otherwise) and a base CV — one is seeded from ' +
           'your stored history when you have none, and it is a 409 when there is ' +
           'nothing to seed from. Calls no LLM itself.',
@@ -2350,7 +2350,7 @@ ${BASE_URL}/auth/oauth/google/start`,
         method: 'GET',
         path: '/me/cvs/{id}/tailor-context',
         auth: 'cookie-or-key',
-        summary: 'The fit analysis a tailored CV should reframe toward.',
+        summary: 'The match analysis a tailored CV should reframe toward.',
         description:
           'The split that keeps tailoring honest: `missing_have` are requirements ' +
           'your history already covers but the CV buries — reframe those — and ' +

--- a/web/src/lib/matchAnalysis.test.ts
+++ b/web/src/lib/matchAnalysis.test.ts
@@ -51,6 +51,22 @@ describe('reduceMatchEvent', () => {
     expect(s.stages.every((x) => x.state === 'done')).toBe(true);
   });
 
+  it('folds a synthesized "already computed" burst: meta → stage_done×3 (no stage_start) → final', () => {
+    // The shape internal/handler's followMatchAnalysis sends when this reader lost the race
+    // to lead the compute (some concurrent caller — almost always the cold-start autopilot's
+    // own pre-run — got there first): no stage_start/thinking/requirements/dimensions, just
+    // the three stages marked done and the cached result.
+    let s = initMatchStream();
+    s = reduceMatchEvent(s, 'meta', { has_cv: true });
+    s = reduceMatchEvent(s, 'stage_done', { stage: 1 });
+    s = reduceMatchEvent(s, 'stage_done', { stage: 2 });
+    s = reduceMatchEvent(s, 'stage_done', { stage: 3 });
+    expect(s.stages.every((x) => x.state === 'done')).toBe(true);
+    s = reduceMatchEvent(s, 'final', { analysis: { overall_score: 71, verdict: 'Good Fit', dimensions: [], requirement_match: [], strengths: [], gaps: [], recommendation: 'Apply.' } });
+    expect(s.done).toBe(true);
+    expect(s.analysis?.overall_score).toBe(71);
+  });
+
   it('records has_cv=false from meta', () => {
     const s = reduceMatchEvent(initMatchStream(), 'meta', { has_cv: false });
     expect(s.hasCV).toBe(false);

--- a/web/src/lib/matchAnalysis.ts
+++ b/web/src/lib/matchAnalysis.ts
@@ -1,4 +1,4 @@
-// Pure presentation logic for the AI fit-analysis block and page. Kept out of the
+// Pure presentation logic for the AI match-analysis block and page. Kept out of the
 // components so it is unit-testable (vitest) without a DOM: the verdict/score → colour
 // tone, the ATS requirement-status → label + tone, and the SSE stream reducer. The wire
 // shapes come from the Go contract.
@@ -38,7 +38,7 @@ export function requirementStatusMeta(status: string): { label: string; tone: To
 }
 
 // ── SSE stream state ────────────────────────────────────────────────────────────
-// The page consumes the fit stream (server-sent events) and folds each event into this
+// The page consumes the match stream (server-sent events) and folds each event into this
 // state via reduceMatchEvent — pure and DOM-free so the accumulation is unit-tested.
 
 export type StageState = 'pending' | 'active' | 'done';

--- a/web/src/lib/tailor/ArtifactPanel.svelte
+++ b/web/src/lib/tailor/ArtifactPanel.svelte
@@ -3,7 +3,7 @@
   // each one MEASURES, so no tab mixes numbers taken against different baselines.
   //
   //  - Job Match — the live, deterministic score of the document being edited against this
-  //    vacancy, with the cached LLM fit analysis beneath it — refreshed by every autopilot
+  //    vacancy, with the cached LLM match analysis beneath it — refreshed by every autopilot
   //    run, not a frozen snapshot.
   //  - Score — what tailoring did to the CV's ATS readability against the base CV, and the
   //    last autopilot run's log.
@@ -12,8 +12,8 @@
   // Every tab here MEASURES the document or is the thing it is measured against; what CHANGES
   // the document — its text, its template, its typography — lives in the left panel.
   //
-  // JD and the fit analysis reuse the SAME components the job page / fit page use, so they
-  // read identically. Splitter width is clamped by the vitest-covered clampWidth.
+  // JD and the match analysis reuse the SAME components the job page / match page use, so
+  // they read identically. Splitter width is clamped by the vitest-covered clampWidth.
   import { resolve } from '$app/paths';
   import { ExternalLink, PanelRightClose, PanelRightOpen } from '@lucide/svelte';
   import { clampWidth } from './geometry';
@@ -41,6 +41,7 @@
     mobileVisible = false,
     autopilotReport = undefined,
     autopilotBusy = false,
+    autoRunAnalysis = false,
     atsDelta = null,
     jobMatch = null,
     onRerunAutopilot,
@@ -56,10 +57,16 @@
     analysis: Analysis | null;
     tab?: Tab;
     mobileVisible?: boolean;
-    /** The last unattended run's log, shown in the Score tab. The fit analysis (Job Match
+    /** The last unattended run's log, shown in the Score tab. The match analysis (Job Match
      *  tab) is refreshed by every run — see prepareAutopilotRun on the server. */
     autopilotReport?: AutopilotEntry[];
     autopilotBusy?: boolean;
+    /** True only for the tailoring workspace's own cold start — see `+page.svelte`'s
+     *  `coldStartRunning`. Opens the match analysis's own visible SSE stream (the stage
+     *  stepper) at the same moment the autopilot's CV-edit run starts, instead of leaving
+     *  it to autopilot's invisible pre-run compute (see match_analysis_coordinator.go for
+     *  how the two are kept from both running the chain). */
+    autoRunAnalysis?: boolean;
     /** What tailoring did to the CV's ATS readiness. Null renders nothing — an unavailable
      *  delta is an absence, not an error state. */
     atsDelta?: CvAtsDelta | null;
@@ -250,10 +257,10 @@
     {:else}
       <div class="p-4">
         <JobMatch data={jobMatch} />
-        <!-- The fit analysis used to be a frozen base-profile snapshot; it is now refreshed
+        <!-- The match analysis used to be a frozen base-profile snapshot; it is now refreshed
              by every autopilot run, so it says that instead of implying it never moves. -->
         <div class="mb-3 rounded-lg border border-border bg-muted/30 px-2.5 py-2">
-          <h3 class="text-sm font-semibold text-foreground">Fit analysis</h3>
+          <h3 class="text-sm font-semibold text-foreground">Match analysis</h3>
           <p class="mt-0.5 text-xs leading-snug text-muted-foreground">
             Refreshed automatically after every autopilot run. You can also run or recompute it
             here any time.
@@ -261,11 +268,12 @@
         </div>
         <!-- Keyed on whether an analysis is present: MatchAnalysisFull seeds its internal state
              from `initial` once, on mount, and does not re-read it if the prop changes later —
-             so when a cold-start run's inline analysis step lands after the tab first rendered
-             empty, this forces a clean remount to pick it up rather than staying stuck showing
-             the pending stepper forever. -->
+             so once the visible stream (or, on the rare race it loses, autopilot's invisible
+             pre-run) lands an analysis after the tab first rendered empty, this forces a clean
+             remount to pick it up rather than staying stuck showing the pending stepper
+             forever. -->
         {#key !!analysis}
-          <MatchAnalysisFull {job} initial={fit} autoRun={false} stacked />
+          <MatchAnalysisFull {job} initial={fit} autoRun={autoRunAnalysis} stacked />
         {/key}
       </div>
     {/if}

--- a/web/src/lib/tailor/AutopilotReport.svelte
+++ b/web/src/lib/tailor/AutopilotReport.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  // What an unattended run did, shown above the fit analysis: one row per requirement with
+  // What an unattended run did, shown above the match analysis: one row per requirement with
   // how it was closed, plus the two things to do next — run again, or undo the whole run.
   //
   // The block renders whether or not a run has happened. Hiding it behind "has a report"
@@ -7,7 +7,7 @@
   // (which clears the report by design), and after a run that stopped before reporting.
   //
   // This is the run's own account of itself, not a re-scored verdict: nothing here recomputes
-  // the fit analysis underneath, which still measures the BASE CV against the vacancy.
+  // the match analysis underneath, which still measures the BASE CV against the vacancy.
   import { RotateCcw } from '@lucide/svelte';
   import { summarizeRun, statusMeta } from './autopilot';
   import type { AutopilotEntry } from '$lib/generated/contracts';

--- a/web/src/lib/tailor/JobMatch.svelte
+++ b/web/src/lib/tailor/JobMatch.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   // How well the CV being edited matches this vacancy — measured on the rendered PDF's text
-  // layer, against the vacancy and nothing else. Unlike the fit analysis below it in the same
-  // tab, this number moves as the candidate types: it is deterministic, costs no AI credits,
+  // layer, against the vacancy and nothing else. Unlike the match analysis below it in the
+  // same tab, this number moves as the candidate types: it is deterministic, costs no AI credits,
   // and is recomputed after every saved edit.
   //
   // An unavailable score renders nothing at all. A panel that says "score unavailable"
@@ -111,7 +111,7 @@
               <span>
                 {req.text}
                 {#if req.cached_status}
-                  <span class="text-muted-foreground/70">— the earlier fit analysis read this as {req.cached_status}</span>
+                  <span class="text-muted-foreground/70">— the earlier match analysis read this as {req.cached_status}</span>
                 {/if}
               </span>
             </li>

--- a/web/src/lib/tailor/autopilot.ts
+++ b/web/src/lib/tailor/autopilot.ts
@@ -26,7 +26,7 @@ export function openingActions(): OpeningAction[] {
     {
       label: 'Walk me through it',
       kind: 'message',
-      text: "Let's tailor my CV for this role — review the fit analysis and walk me through the gaps.",
+      text: "Let's tailor my CV for this role — review the match analysis and walk me through the gaps.",
     },
   ];
 }

--- a/web/src/lib/tailor/jobmatch.test.ts
+++ b/web/src/lib/tailor/jobmatch.test.ts
@@ -127,7 +127,7 @@ describe('impactOf', () => {
 });
 
 describe('scoreTone', () => {
-  it('grades a score the way the fit verdict does', () => {
+  it('grades a score the way the match verdict does', () => {
     expect(scoreTone(85)).toBe('strong');
     expect(scoreTone(60)).toBe('moderate');
     expect(scoreTone(20)).toBe('poor');

--- a/web/src/lib/tailor/jobmatch.ts
+++ b/web/src/lib/tailor/jobmatch.ts
@@ -92,7 +92,7 @@ export function impactOf(weight: number): string {
 
 export type JobMatchTone = 'strong' | 'moderate' | 'poor';
 
-/** scoreTone grades an overall on the same bands the fit verdict uses, so two scores in one
+/** scoreTone grades an overall on the same bands the match verdict uses, so two scores in one
  *  workspace never colour the same number differently. */
 export function scoreTone(overall: number): JobMatchTone {
   if (overall >= 75) return 'strong';

--- a/web/src/lib/tailorFaq.ts
+++ b/web/src/lib/tailorFaq.ts
@@ -15,7 +15,7 @@ export const TAILOR_FAQ: FaqItem[] = [
   {
     question: 'How do I start tailoring?',
     answer:
-      'From a job. Run the AI fit analysis on a vacancy, then tailor from its result — the analysis is what the tailored CV reframes toward, so the flow needs one first. freehire copies your base CV into a new one bound to that vacancy; your original is never edited.',
+      'From a job. Run the AI match analysis on a vacancy, then tailor from its result — the analysis is what the tailored CV reframes toward, so the flow needs one first. freehire copies your base CV into a new one bound to that vacancy; your original is never edited.',
   },
   {
     question: 'What does it actually change?',
@@ -35,6 +35,6 @@ export const TAILOR_FAQ: FaqItem[] = [
   {
     question: 'What does it cost?',
     answer:
-      'AI credits, the same currency the fit analysis uses. Every account gets a monthly grant, and contributing a company board we do not track yet earns more. Your balance and what each action spent are on your credits page.',
+      'AI credits, the same currency the match analysis uses. Every account gets a monthly grant, and contributing a company board we do not track yet earns more. Your balance and what each action spent are on your credits page.',
   },
 ];

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -37,7 +37,7 @@ export interface ATSResponse {
   report: ATSReportContract | null;
 }
 
-// The on-demand LLM job-fit analysis wire shapes (five scored dimensions + the
+// The on-demand LLM job-match analysis wire shapes (five scored dimensions + the
 // ATS-style requirement match), generated from internal/matchanalysis.
 export type {
   Analysis as MatchAnalysis,
@@ -79,7 +79,7 @@ export interface CreditHistoryEntry {
   created_at: string;
 }
 
-/** The job-fit analysis response: `has_cv` is false when the caller has no stored CV
+/** The job-match analysis response: `has_cv` is false when the caller has no stored CV
  *  (the block prompts an upload); `analysis` is null when none is cached yet or the LLM
  *  is unconfigured; `stale` marks a cached analysis whose CV or job changed since (the
  *  block then offers a recompute); `credits` reports the points balance on reads (omitted
@@ -91,7 +91,7 @@ export interface MatchAnalysisResponse {
   credits?: AiCredits;
 }
 
-/** One row of the Tracking → AI fit tab: a compact projection of a cached fit analysis
+/** One row of the Activity → Matches tab: a compact projection of a cached match analysis
  *  (not the full analysis). `closed` marks a job that has since closed; `stale` marks an
  *  analysis whose CV/job/model changed since it ran. `analysed_at` is an ISO timestamp. */
 export interface MyAnalysisItem {

--- a/web/src/routes/features/tailor/+page.svelte
+++ b/web/src/routes/features/tailor/+page.svelte
@@ -13,7 +13,7 @@
 
 <Seo
   title="CV tailoring — rewrite your CV for one job, inventing nothing | freehire"
-  description="freehire reframes your CV toward a single vacancy: it reads the fit analysis, pulls forward the experience you already have but buried, asks about anything your history doesn't support, and exports an ATS-readable PDF. Drive it in the browser or from the CLI."
+  description="freehire reframes your CV toward a single vacancy: it reads the match analysis, pulls forward the experience you already have but buried, asks about anything your history doesn't support, and exports an ATS-readable PDF. Drive it in the browser or from the CLI."
   {canonical}
 />
 

--- a/web/src/routes/jobs/[slug]/fit/+page.ts
+++ b/web/src/routes/jobs/[slug]/fit/+page.ts
@@ -1,7 +1,7 @@
 import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
-// The fit analysis moved into the Tailor workspace; keep old links working with a permanent redirect.
+// The match analysis moved into the Tailor workspace; keep old links working with a permanent redirect.
 export const load: PageLoad = ({ params }) => {
   redirect(308, `/tailor/${params.slug}`);
 };

--- a/web/src/routes/match/[slug]/+page.server.ts
+++ b/web/src/routes/match/[slug]/+page.server.ts
@@ -1,9 +1,10 @@
 import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
-// The standalone fit-analysis page was removed; the Tailor workspace is now the sole
+// The standalone match-analysis page was removed; the Tailor workspace is now the sole
 // surface for viewing and triggering the analysis (see job-fit-analysis's "Fit analysis
-// surfaces in the tailoring workspace" requirement). Old links keep working via redirect.
+// surfaces in the tailoring workspace" requirement — the design doc's own name). Old
+// links keep working via redirect.
 export const load: PageServerLoad = ({ params }) => {
   redirect(308, `/tailor/${params.slug}`);
 };

--- a/web/src/routes/privacy/+page.svelte
+++ b/web/src/routes/privacy/+page.svelte
@@ -56,8 +56,8 @@
         </li>
         <li>
           <span class="font-medium text-foreground">CV / résumé.</span> If you upload a CV for skill
-          matching or AI fit analysis, we store the file and the text we extract from it. Running an
-          AI fit analysis sends the relevant parts of your CV, together with the job posting, to our
+          matching or AI match analysis, we store the file and the text we extract from it. Running an
+          AI match analysis sends the relevant parts of your CV, together with the job posting, to our
           language-model provider (see “Third-party services”).
         </li>
         <li>
@@ -116,7 +116,7 @@
       <ul class="flex flex-col gap-2 text-sm leading-relaxed text-muted-foreground">
         <li>
           <span class="font-medium text-foreground">A language-model provider</span> — processes CV
-          and job text to produce AI fit analysis, only when you request it.
+          and job text to produce AI match analysis, only when you request it.
         </li>
         <li>
           <span class="font-medium text-foreground">Product analytics (Google Analytics, PostHog)</span>

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -142,7 +142,10 @@
     ['history', 'History'],
     ['jd', 'Job'],
   ];
-  let mobileView = $state<MobileView>('chat');
+  // Defaults to the same tab the desktop right panel opens on (artifactTab above), so a
+  // cold start's match-analysis animation is the first thing a mobile visitor sees too,
+  // not hidden behind Chat.
+  let mobileView = $state<MobileView>('jobmatch');
 
   // Below lg the account icon rail collapses into a drawer opened by the burger in the mobile tab
   // bar; AccountNavRail owns the drawer and binds this open flag.
@@ -479,9 +482,10 @@
       void loadRevisions(true);
       void refreshAtsDelta();
       void refreshJobMatch();
-      // A cold-start run computes the fit analysis inline as its own first step (see
-      // internal/handler.PostAssistantAutopilot); the bootstrap response predates that, so the
-      // Job Match tab is still showing its empty/pending state until this picks it up.
+      // A cold start's own visible match-analysis stream (in ArtifactPanel) normally lands the
+      // analysis well before this fires — this is only a fallback for the rare case that
+      // stream lost the lead race and is showing a synthesized burst read straight from the
+      // cache; that cache is exactly what this re-fetches.
       if (!analysis) {
         analysis = (await api.getMatchAnalysis(slug).catch(() => null))?.analysis ?? null;
       }
@@ -696,6 +700,13 @@
               </section>
             </div>
           </div>
+          <!-- Mounts before ArtifactPanel's MatchAnalysisFull (below, in the right panel) —
+               deliberately: on a cold start MatchAnalysisFull opens its match-analysis SSE
+               stream synchronously from its own onMount, while this chat's autopilot kickoff
+               needs a network round trip (listSessions) before it fires, so the visible stream
+               reliably wins the race to lead the match-analysis compute (see
+               match_analysis_coordinator.go). Correctness never depends on this order — the
+               backend coordinator does — this only keeps the common case looking right. -->
           <div class="flex min-h-0 h-full" class:hidden={leftTab !== 'chat'}>
             <AssistantChat
               bind:this={chatRef}
@@ -766,6 +777,7 @@
       <ArtifactPanel
         job={must(job, 'job')}
         {analysis}
+        autoRunAnalysis={coldStartRunning}
         {autopilotReport}
         autopilotBusy={turnActive || runActive}
         {atsDelta}

--- a/web/src/routes/terms/+page.svelte
+++ b/web/src/routes/terms/+page.svelte
@@ -42,7 +42,7 @@
       <p class="text-sm leading-relaxed text-muted-foreground">
         We aggregate job postings from public company career boards and other public sources,
         normalise and deduplicate them, and let you search, filter, save, and track them. We also
-        offer optional AI features — CV matching and fit analysis — that you choose to run.
+        offer optional AI features — CV matching and match analysis — that you choose to run.
       </p>
     </section>
 
@@ -79,7 +79,7 @@
     <section class="flex flex-col gap-3">
       <h2 class="text-xl font-semibold tracking-tight">AI features</h2>
       <p class="text-sm leading-relaxed text-muted-foreground">
-        Features like fit analysis and CV matching use a language model and can be wrong. They're
+        Features like match analysis and CV matching use a language model and can be wrong. They're
         a research aid, not career or legal advice — use your own judgment before acting on them.
       </p>
     </section>


### PR DESCRIPTION
## Summary
- Cold-start CV tailoring now opens the fit/match-analysis SSE stream immediately, in parallel with the autopilot's CV-edit run, so the stage stepper actually animates instead of the compute happening invisibly (a prior attempt showed the same stepper on cold start and pulled it because it looked stuck — the compute was happening elsewhere at the time).
- A new per-(user, job) coordinator (`match_analysis_coordinator.go`) keeps the autopilot's own invisible pre-run and this newly-visible stream from both running the three-stage LLM chain when they race for the same pair: one leads and computes for real, the other waits and replays the result.
- Each caller (leader or follower) gates and debits AI credits for itself independently, relying on `credits.Store.Debit`'s existing idempotency — closes a real bypass where a second tab/reload could dodge a charge, and the leftover coordinator-billing question from a first pass that skipped debiting whenever *any* follower joined.
- `done()` is deferred and idempotent (fixes a panic-safety/double-close hazard), and a follower now checks the leader's actual success before trusting the cache (fixes a stale-analysis-served-as-fresh case after a failed recompute).
- Mobile now opens the tailoring workspace on the Job Match tab (matching desktop's existing default), so the new animation is the first thing a mobile visitor sees too.
- Renamed every user-facing "Fit analysis" → "Match analysis" (heading, chat tool-activity label, FAQ, CLI docs, public API reference, legal pages), matching the rename the backend routes/package already had. Deprecated `/fit` route aliases and backend verdict strings ("Strong Fit" etc., real persisted LLM output) are untouched.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` — clean
- [x] `go test ./...` — all green
- [x] `go test -tags=integration ./internal/handler/` (coordinator + autopilot + match-analysis suites, incl. new regression tests for the credit-bypass, panic-safety, and stale-analysis bugs a review pass caught) — all green
- [x] `pnpm vitest run` (1043 tests) and `eslint` on changed files — clean
- [x] Manually verified end-to-end against a real LLM (prod credentials, isolated throwaway DB): the stage stepper genuinely animates through Extract & Match → Recruiter verdict → Adversarial audit, credit ledger shows exactly one `tailor` debit and zero/one `match` debits as expected per scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)