### PR TITLE
Serve ads.txt so AdSense can verify the domain

### DIFF
--- a/web/static/ads.txt
+++ b/web/static/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-1462134396246733, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
`web/static/ads.txt` existed only in a local working tree, so `freehire.me/ads.txt` returns 404 and AdSense cannot authorise the publisher account.

One line, no code paths touched.

**Deploy note:** static files under `web/static/` are baked into the SvelteKit build, so the web service needs a restart after this lands for the file to be served.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an authorized Google Ads seller entry to improve advertising configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->