### PR TITLE
Let an API key list CVs and start tailoring

### DIFF
--- a/internal/handler/cv.go
+++ b/internal/handler/cv.go
@@ -25,11 +25,13 @@ import (
 )
 
 // CV-builder HTTP surface: per-user structured CVs (CRUD + seed) and on-demand PDF
-// rendering. Mutations are cookie-only (RequireAuth); the read + render endpoints also
-// accept an API key (RequireAuthOrKey) so the tailoring agent's CLI can fetch a CV and its
-// PDF. All routes are open to every signed-in user (the beta gate was lifted when tailoring
-// went public; AI credits meter the LLM spend). Every operation is owner-scoped — a foreign
-// id is a 404, never a leak.
+// rendering. Whole-document authoring (create, replace, delete) and the scoring/undo
+// surface are cookie-only (RequireAuth); everything the tailoring cycle itself needs —
+// list, read, render, field-level patch, context, and the bootstrap that creates the
+// vacancy-bound copy — also accepts an API key (RequireAuthOrKey), so a CLI can run the
+// whole cycle rather than half of it. All routes are open to every signed-in user (the
+// beta gate was lifted when tailoring went public; AI credits meter the LLM spend). Every
+// operation is owner-scoped — a foreign id is a 404, never a leak.
 
 // cvHandlers serves the CV builder + AI tailoring routes. The renderer is nil when no
 // typst binary is configured; the PDF endpoint then returns 501 while the rest of the
@@ -167,7 +169,10 @@ func (h *cvHandlers) register(api fiber.Router, mw middleware) {
 	// binary is configured; the rest still works.
 	api.Get("/cv-templates", mw.cookie, h.ListCVTemplates)
 	api.Get("/cv-fonts", mw.cookie, h.ListCVFonts)
-	api.Get("/me/cvs", mw.cookie, h.ListCVs)
+	// Listing takes a key: it is a read of the caller's own tailored copies, and it is where
+	// a CLI learns the CV id every other keyed route here is addressed by. Creating a blank
+	// CV stays cookie-only — authoring a whole document is the browser's.
+	api.Get("/me/cvs", mw.key, h.ListCVs)
 	api.Post("/me/cvs", mw.cookie, h.CreateCV)
 	// Read + render accept a key too (keyAuth), so the tailoring agent's CLI can fetch a CV
 	// and its PDF; mutations stay cookie-only (POST/PUT/DELETE — the browser owns authoring).
@@ -182,9 +187,11 @@ func (h *cvHandlers) register(api fiber.Router, mw middleware) {
 	api.Get("/me/cvs/:id/tracer-links", mw.cookie, h.ListCVTracerLinks)
 	api.Delete("/me/cvs/:id", mw.cookie, h.DeleteCV)
 	api.Get("/me/cvs/:id/pdf", mw.key, h.RenderCVPDF)
-	// Tailoring: the browser starts a session (cookie-only bootstrap); the agent's CLI drives
-	// the edit + context/get/render reads with its minted API key (keyAuth = cookie or Bearer).
-	api.Post("/me/cvs/tailor", mw.cookie, h.TailorCV)
+	// Tailoring: the bootstrap takes a key as well as a cookie, so a CLI can start the cycle
+	// it was already able to drive (edit + context/get/render all accept a key). It creates a
+	// copy of the caller's own CV and debits their own credits — both of which a full-scope
+	// key already does through the fit analysis and the assistant — and never calls the LLM.
+	api.Post("/me/cvs/tailor", mw.key, h.TailorCV)
 	api.Post("/me/cvs/:id/tailor-session", mw.cookie, h.StartTailorSession)
 	// Literal `/base/` before `:id` — otherwise Fiber treats "base" as a CV uuid.
 	api.Post("/me/cvs/base/reset-from-resume", mw.cookie, h.ResetBaseCVFromResume)

--- a/internal/handler/cv_tailor.go
+++ b/internal/handler/cv_tailor.go
@@ -44,8 +44,10 @@ type tailorCVResponse struct {
 // TailorCV bootstraps a tailoring session for a vacancy: it ensures the user has a base CV
 // (seeding one from their résumé, 409 when they have none), creates a vacancy-bound tailored
 // copy, mints the CLI credential, and returns the ids plus the cached analysis if one already
-// exists — no cached analysis is required to start. Cookie-only (the browser starts tailoring);
-// never calls the LLM.
+// exists — no cached analysis is required to start. Cookie or API key: the browser starts
+// tailoring, and so does a CLI holding the caller's own key, which is what lets an agent
+// enter the cycle instead of being handed a CV id copied out of a browser URL. Never calls
+// the LLM.
 func (h *cvHandlers) TailorCV(c *fiber.Ctx) error {
 	userID, err := requireUserID(c)
 	if err != nil {

--- a/internal/handler/cv_tailor_routes_test.go
+++ b/internal/handler/cv_tailor_routes_test.go
@@ -1,0 +1,77 @@
+package handler
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// TestCVRegister_TailoringEntryPointsTakeAKey pins the two routes a CLI needs to ENTER the
+// tailoring cycle against the real register().
+//
+// Every step of tailoring already accepted a key — read the CV, patch it, read the context,
+// render the PDF — but the two that hand out the CV id did not, so an agent holding the
+// user's own key could drive the cycle and not start it: the id had to be copied out of a
+// browser URL first. Listing is a read of the caller's own rows, and the bootstrap creates a
+// copy of their own CV and spends their own credits, which a full-scope key can already do
+// through the fit analysis and the assistant. Neither is a new capability class; the gap was
+// only that the entry points were missed.
+//
+// What must NOT follow this widening is the scoring and undo surface (ats-delta, job-match,
+// revisions). Those stay cookie-only on purpose — see TestCVRegister_ATSDeltaIsCookieOnly.
+func TestCVRegister_TailoringEntryPointsTakeAKey(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"list tailored CVs", http.MethodGet, "/api/v1/me/cvs"},
+		{"tailoring bootstrap", http.MethodPost, "/api/v1/me/cvs/tailor"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			app := fiber.New()
+			(&cvHandlers{}).register(app.Group("/api/v1"), middleware{
+				key:    namedGate("key"),
+				cvKey:  namedGate("cvKey"),
+				cookie: namedGate("cookie"),
+			})
+
+			resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), tc.method, tc.path, nil))
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if got := string(body); got != "key" {
+				t.Errorf("%s %s is gated by %q, want %q", tc.method, tc.path, got, "key")
+			}
+		})
+	}
+}
+
+// TestCVRegister_AuthoringStaysCookieOnly is the other half of the widening above: creating a
+// blank CV, replacing a whole document, and deleting one are the browser's, not a script's.
+// A key reaching these would let a leaked credential rewrite or destroy the candidate's CV
+// wholesale, which is a different thing from the field-level, evidence-gated PATCH it holds.
+func TestCVRegister_AuthoringStaysCookieOnly(t *testing.T) {
+	app := fiber.New()
+	(&cvHandlers{}).register(app.Group("/api/v1"), middleware{
+		key:    namedGate("key"),
+		cvKey:  namedGate("cvKey"),
+		cookie: namedGate("cookie"),
+	})
+
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/me/cvs", nil))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if got := string(body); got != "cookie" {
+		t.Errorf("POST /me/cvs is gated by %q, want %q", got, "cookie")
+	}
+}


### PR DESCRIPTION
## What

Widen two routes from `RequireAuth` to `RequireAuthOrKey`:

- `GET /me/cvs` — list the caller's tailored copies
- `POST /me/cvs/tailor` — the tailoring bootstrap

## Why

Every other step of the tailoring cycle already accepted a key — `GET /me/cvs/:id`, `PATCH /me/cvs/:id`, `/tailor-context`, `/pdf`. The two routes that hand out a CV id did not, so an agent holding the user's own key could *drive* the cycle but not *enter* it: the id had to be copied out of a browser URL first.

Neither widening is a new capability class. Listing is a read of the caller's own rows. The bootstrap creates a copy of their own CV and debits their own credits — both of which a full-scope key already does through `POST /jobs/:slug/fit` and the assistant — and it never calls the LLM.

## What deliberately does NOT follow

- **Whole-document authoring** (`POST /me/cvs`, `PUT /me/cvs/:id`, `DELETE`) stays cookie-only. The keyed `PATCH` is evidence-gated per operation; a `PUT` would hand that gate away for free.
- **Scoring and undo** (`ats-delta`, `job-match`, `revisions`) stays cookie-only. The tailoring agent authenticates with a CLI credential, and that gate is what keeps the measure of its work out of its own reach.

## Tests

`cv_tailor_routes_test.go` pins both halves against the real `register()`: the two widened routes must answer `key`, and `POST /me/cvs` must still answer `cookie`. Both were red before the change.

`gofmt` / `go vet ./...` / `go test ./...` / `go vet -tags=integration ./...` all clean.

Client side: strelov1/freehire-cli#cv-tailor-and-list adds `freehire cv tailor` and `freehire cv list`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI users can now use API keys to discover CVs and start CV tailoring sessions.
  * Browser users can continue using cookie-based authentication for CV tailoring.

* **Bug Fixes**
  * CV creation remains restricted to cookie-authenticated requests, preserving existing authoring access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->