### PR TITLE
Let a key correct a banked entry, without moving its provenance

### DIFF
--- a/internal/handler/me_experience.go
+++ b/internal/handler/me_experience.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 
+	"github.com/strelov1/freehire/internal/auth"
 	"github.com/strelov1/freehire/internal/experience"
 )
 
@@ -59,19 +60,28 @@ func (h *experienceHandlers) withRequireContext(r experienceRequireContext) *exp
 
 func (h *experienceHandlers) register(api fiber.Router, mw middleware) {
 	// The read takes a key, like the profile read, so a programmatic consumer can ground
-	// itself in what the candidate has actually done. Correcting, merging or removing an
-	// EXISTING entry stays cookie-only: a key that leaks out of a script's environment
-	// must not edit or erase someone's career. Creating a new one takes a key too — it is
+	// itself in what the candidate has actually done. Creating takes a key too — it is
 	// additive-only, and a full-scope key already reaches everything more destructive than
-	// this (cv edit, apply) through the rest of the CLI's surface, so gating this narrower
-	// than that would protect a boundary the same key crosses everywhere else.
+	// this (cv edit, apply) through the rest of the CLI's surface.
+	//
+	// Correcting takes a key as well, but only because UpdateAtom below keeps a keyed
+	// caller's edit from moving the claim's provenance. Without that, a key reaching this
+	// route would be a laundering step rather than a correction — see provenanceForUpdate.
+	// A caller able to ADD an achievement from a script and unable to fix a typo in it has
+	// a bank it can only make worse: the duplicate check refuses the corrected retry.
+	//
+	// What DESTROYS stays cookie-only, and that is the enforcement rather than a
+	// preference. The bank has no undo. Deleting an employment cascades to every
+	// achievement under it (migration 0047), and a merge folds one atom's numbers into
+	// another across the provenance line. None of that belongs to a credential that lives
+	// in a script's environment.
 	api.Get("/me/experience", mw.key, h.ListExperience)
 	api.Post("/me/experience/employments", mw.key, h.AddEmployment)
-	api.Put("/me/experience/employments/:id", mw.cookie, h.UpdateEmployment)
+	api.Put("/me/experience/employments/:id", mw.key, h.UpdateEmployment)
 	api.Delete("/me/experience/employments/:id", mw.cookie, h.DeleteEmployment)
 	api.Post("/me/experience/atoms", mw.key, h.AddAtom)
 	api.Post("/me/experience/atoms/merge", mw.cookie, h.MergeAtoms)
-	api.Put("/me/experience/atoms/:id", mw.cookie, h.UpdateAtom)
+	api.Put("/me/experience/atoms/:id", mw.key, h.UpdateAtom)
 	api.Delete("/me/experience/atoms/:id", mw.cookie, h.DeleteAtom)
 }
 
@@ -321,7 +331,14 @@ func (h *experienceHandlers) UpdateAtom(c *fiber.Ctx) error {
 	if err := c.BodyParser(&in); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "invalid body")
 	}
-	in.Provenance = experience.ProvenanceManual
+	// Read the standing of the claim before overwriting its words: a keyed caller may
+	// change what an achievement says and may not change who is held to have said it.
+	// The read also owner-scopes the write, so a foreign id is a 404 before any update.
+	existing, err := h.bank.GetAtom(c.Context(), id, userID)
+	if err != nil {
+		return experienceError(err)
+	}
+	in.Provenance = provenanceForUpdate(auth.ViaAPIKey(c), existing.Provenance)
 	updated, err := h.bank.UpdateAtom(c.Context(), id, userID, in)
 	if err != nil {
 		return experienceError(err)
@@ -360,6 +377,28 @@ func (h *experienceHandlers) checkContextRequired(ctx context.Context, userID in
 
 // ownedEntry resolves the caller and the addressed entry id together, since every route
 // here needs both and neither is useful alone.
+// provenanceForUpdate answers what an edit does to a claim's standing, and it is the reason
+// correcting an achievement can be reached with an API key at all.
+//
+// A candidate editing their own entry IS asserting it — that is what `manual` records, and
+// it is why the browser path stamps every correction with it regardless of where the row
+// came from. The tailoring agent holds a key, and the same stamp on its path would let it
+// promote its own reading: bank an inference as `agent_inferred` (which the CV evidence
+// gate refuses), PUT it, read back `manual`, and cite it. So a keyed edit rewrites the
+// words and leaves the label untouched.
+//
+// An unlabelled row falls to `agent_inferred` on the keyed path rather than to the strongest
+// claim, because a missing label is not evidence that anyone said anything.
+func provenanceForUpdate(viaKey bool, existing experience.Provenance) experience.Provenance {
+	if !viaKey {
+		return experience.ProvenanceManual
+	}
+	if !existing.Valid() {
+		return experience.ProvenanceAgentInferred
+	}
+	return existing
+}
+
 func ownedEntry(c *fiber.Ctx) (int64, uuid.UUID, error) {
 	userID, err := requireUserID(c)
 	if err != nil {

--- a/internal/handler/me_experience_routes_test.go
+++ b/internal/handler/me_experience_routes_test.go
@@ -1,0 +1,176 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/experience"
+)
+
+// TestProvenanceForUpdate is the whole of the rule that lets a key correct a banked
+// achievement at all.
+//
+// Correcting an atom stamps it `manual` — "the person asserted this" — and that stamp is
+// honest only because the candidate is the one pressing the button. A key is held by the
+// tailoring agent, so the same stamp coming from a key would be a laundering step: the
+// agent banks its own reading as `agent_inferred` (unpublishable), PUTs it, gets `manual`
+// back, and the CV evidence gate then admits a claim nobody ever made.
+//
+// So the label follows the credential. A keyed correction may fix the words and must leave
+// the standing of the claim exactly where it was.
+func TestProvenanceForUpdate(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		viaKey   bool
+		existing experience.Provenance
+		want     experience.Provenance
+	}{
+		{"candidate confirms their own inferred atom", false, experience.ProvenanceAgentInferred, experience.ProvenanceManual},
+		{"candidate corrects an imported one", false, experience.ProvenanceCVImport, experience.ProvenanceManual},
+		{"agent may not promote its own reading", true, experience.ProvenanceAgentInferred, experience.ProvenanceAgentInferred},
+		{"agent corrects what the candidate said", true, experience.ProvenanceStatedInChat, experience.ProvenanceStatedInChat},
+		{"agent corrects a manual atom", true, experience.ProvenanceManual, experience.ProvenanceManual},
+		// A row whose label is somehow unset must not become publishable by being edited
+		// with a key. Falling back to the strongest claim would be the same laundering.
+		{"agent editing an unlabelled row", true, "", experience.ProvenanceAgentInferred},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := provenanceForUpdate(tc.viaKey, tc.existing); got != tc.want {
+				t.Errorf("provenanceForUpdate(%v, %q) = %q, want %q", tc.viaKey, tc.existing, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExperienceRegister_Gates pins each route's gate against the real register().
+//
+// The two corrections take a key: a caller that can ADD an achievement from a script but
+// cannot fix a typo in it is left with a bank it can only make worse, since the duplicate
+// check refuses the corrected retry.
+//
+// Everything that DESTROYS stays cookie-only, and that is the enforcement rather than a
+// preference. The bank has no undo. Deleting an employment cascades to every achievement
+// under it (migration 0047), and a merge folds one atom's numbers into another across the
+// provenance line. None of that belongs to a credential living in a script's environment.
+func TestExperienceRegister_Gates(t *testing.T) {
+	const id = "/00000000-0000-0000-0000-000000000001"
+	for _, tc := range []struct {
+		method string
+		path   string
+		want   string
+	}{
+		{http.MethodGet, "/me/experience", "key"},
+		{http.MethodPost, "/me/experience/employments", "key"},
+		{http.MethodPost, "/me/experience/atoms", "key"},
+		{http.MethodPut, "/me/experience/employments" + id, "key"},
+		{http.MethodPut, "/me/experience/atoms" + id, "key"},
+		{http.MethodDelete, "/me/experience/employments" + id, "cookie"},
+		{http.MethodDelete, "/me/experience/atoms" + id, "cookie"},
+		{http.MethodPost, "/me/experience/atoms/merge", "cookie"},
+	} {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			app := fiber.New()
+			(&experienceHandlers{}).register(app.Group(""), middleware{
+				key:    namedGate("key"),
+				cookie: namedGate("cookie"),
+			})
+			resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), tc.method, tc.path, nil))
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if got := string(body); got != tc.want {
+				t.Errorf("%s %s is gated by %q, want %q", tc.method, tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// stubKeys resolves any presented key to one owner, so the REAL RequireAuthOrKey can run in
+// a unit test. Going through the real middleware is the point: it is what sets the
+// via-API-key marker the provenance rule reads, and a test that set that marker itself
+// would still pass if the middleware stopped setting it.
+type stubKeys struct{ userID int64 }
+
+func (s stubKeys) AuthenticateAPIKey(context.Context, string) (auth.APIKeyIdentity, error) {
+	return auth.APIKeyIdentity{UserID: s.userID, Scope: auth.ScopeFull}, nil
+}
+
+// TestUpdateAtomEndToEndProvenance is the rule above, through the real route and the real
+// auth middleware: the same correction, made with a key and with a cookie, must leave the
+// atom's standing in two different places.
+//
+// If the keyed subtest ever comes back `manual`, an agent can write its own invention onto
+// a real person's CV.
+func TestUpdateAtomEndToEndProvenance(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		viaKey bool
+		want   experience.Provenance
+	}{
+		{"keyed correction leaves the agent's own reading unpublishable", true, experience.ProvenanceAgentInferred},
+		{"the candidate's own correction is their assertion", false, experience.ProvenanceManual},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			iss := auth.NewIssuer("test-secret", time.Hour)
+			token, err := iss.Issue(1, testTokenVersion)
+			if err != nil {
+				t.Fatalf("issue token: %v", err)
+			}
+			bank := newStubBank()
+			atom := bank.add(1, experience.Atom{
+				Claim:      "Rewrote the billing pipeline",
+				Provenance: experience.ProvenanceAgentInferred,
+			})
+
+			guard := auth.RequireAuthOrKey(iss, testVersions, stubKeys{userID: 1})
+			app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+			newExperienceHandlers(bank).register(app.Group(""), middleware{cookie: guard, key: guard})
+
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPut,
+				"/me/experience/atoms/"+atom.ID.String(),
+				strings.NewReader(`{"claim":"Rewrote the billing pipeline end to end"}`))
+			req.Header.Set("Content-Type", fiber.MIMEApplicationJSON)
+			if tc.viaKey {
+				req.Header.Set("Authorization", "Bearer fhk_test")
+			} else {
+				req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+			}
+
+			resp, err := app.Test(req)
+			if err != nil {
+				t.Fatalf("put: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != fiber.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("put status = %d, body %s", resp.StatusCode, body)
+			}
+			var out struct {
+				Data experience.Atom `json:"data"`
+			}
+			if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if out.Data.Provenance != tc.want {
+				t.Errorf("provenance after update = %q, want %q", out.Data.Provenance, tc.want)
+			}
+			if tc.viaKey && out.Data.Provenance.Publishable() {
+				t.Error("a keyed correction made an agent-inferred claim publishable — the CV evidence gate would admit it")
+			}
+			if out.Data.Claim != "Rewrote the billing pipeline end to end" {
+				t.Errorf("the correction itself did not land: claim = %q", out.Data.Claim)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The gap

A caller could `POST /me/experience/atoms` with an API key and could not fix a typo in what it wrote: correcting was cookie-only, and the duplicate check refuses the corrected retry. The bank was writable from a script in one direction only, so it could only be made worse.

## The reason it was closed — which is not what the old comment said

`UpdateAtom` stamps every edit `manual`, ignoring the body. That is honest **because the candidate is the one pressing the button**: they touched the row, so they assert it.

The tailoring agent holds a key. The same stamp on a keyed path is a laundering step:

1. agent banks its own reading → `agent_inferred`
2. `bankGate.Publishable` refuses it for a CV — `Publishable()` is false only for `agent_inferred`
3. agent `PUT`s the row with its key → comes back `manual`
4. `cv edit --evidence <id>` now admits it

A model's invention reaches a real person's CV through the one check that exists to stop it. The old comment said "a leaked key must not edit someone's career", which is true but does not name the mechanism, so the route looked safe to widen.

## The change

The label follows the credential (`provenanceForUpdate`):

| caller | existing label | after the edit |
|---|---|---|
| cookie | anything | `manual` (unchanged behaviour) |
| key | `agent_inferred` | `agent_inferred` |
| key | `stated_in_chat` / `cv_import` / `manual` | unchanged |
| key | unset | `agent_inferred` |

An unlabelled row falls to `agent_inferred` rather than to the strongest claim: a missing label is not evidence that anyone said anything.

With that in place both `PUT`s take a key. `UpdateAtom` now reads the row before writing, which also owner-scopes the write.

## What stays cookie-only, and why

Every `DELETE`, and the atom merge. The `register` comment now states it in checkable terms rather than as a preference: the bank has no undo, deleting an employment **cascades** to every achievement under it (migration `0047`), and a merge folds one atom's numbers into another across the provenance line.

## Tests

- `TestProvenanceForUpdate` — the rule, table-driven, including the unlabelled row.
- `TestExperienceRegister_Gates` — all eight routes pinned against the real `register()`.
- `TestUpdateAtomEndToEndProvenance` — the same correction by key and by cookie, through the **real** `auth.RequireAuthOrKey` with a stubbed key authenticator. Deliberately not faking the via-key local: a test that set that marker itself would stay green if the middleware stopped setting it, which is exactly the failure that matters here.

`gofmt` / `go vet ./...` / `go test ./...` / `go vet -tags=integration ./...` clean.

Client side: strelov1/freehire-cli#37.