### PR TITLE
Let a key delete a banked entry, but never cascade

### DIFF
--- a/internal/handler/me_experience.go
+++ b/internal/handler/me_experience.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/gofiber/fiber/v2"
@@ -70,19 +71,24 @@ func (h *experienceHandlers) register(api fiber.Router, mw middleware) {
 	// A caller able to ADD an achievement from a script and unable to fix a typo in it has
 	// a bank it can only make worse: the duplicate check refuses the corrected retry.
 	//
-	// What DESTROYS stays cookie-only, and that is the enforcement rather than a
-	// preference. The bank has no undo. Deleting an employment cascades to every
-	// achievement under it (migration 0047), and a merge folds one atom's numbers into
-	// another across the provenance line. None of that belongs to a credential that lives
-	// in a script's environment.
+	// Deleting takes a key, but the CASCADE does not come with it. Removing an achievement
+	// removes the row named and nothing else. Removing a place takes every achievement
+	// under it (experience_atoms.employment_id is ON DELETE CASCADE, migration 0047), and
+	// the bank has no undo — so DeleteEmployment refuses a keyed caller while the place is
+	// still occupied. Move the achievements first, then remove the shell.
+	//
+	// The merge stays cookie-only, and unlike the deletes it cannot simply be widened:
+	// unionForMerge folds the discarded atom's metrics and skills into the kept one while
+	// the kept one's provenance stands, so a `manual` atom can absorb numbers an agent
+	// invented. That has to be settled before the gate moves.
 	api.Get("/me/experience", mw.key, h.ListExperience)
 	api.Post("/me/experience/employments", mw.key, h.AddEmployment)
 	api.Put("/me/experience/employments/:id", mw.key, h.UpdateEmployment)
-	api.Delete("/me/experience/employments/:id", mw.cookie, h.DeleteEmployment)
+	api.Delete("/me/experience/employments/:id", mw.key, h.DeleteEmployment)
 	api.Post("/me/experience/atoms", mw.key, h.AddAtom)
 	api.Post("/me/experience/atoms/merge", mw.cookie, h.MergeAtoms)
 	api.Put("/me/experience/atoms/:id", mw.key, h.UpdateAtom)
-	api.Delete("/me/experience/atoms/:id", mw.cookie, h.DeleteAtom)
+	api.Delete("/me/experience/atoms/:id", mw.key, h.DeleteAtom)
 }
 
 // experienceResponse is the bank as its owner sees it: the places, and the achievements
@@ -312,10 +318,63 @@ func (h *experienceHandlers) DeleteEmployment(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
+	if auth.ViaAPIKey(c) {
+		if err := h.refuseKeyedCascade(c.Context(), userID, id); err != nil {
+			return err
+		}
+	}
 	if err := h.bank.DeleteEmployment(c.Context(), id, userID); err != nil {
 		return experienceError(err)
 	}
 	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// refuseKeyedCascade is the one thing a keyed caller may not do to the bank: take a place
+// down and every achievement recorded under it with it.
+//
+// The cascade lives in the schema (migration 0047), so nothing downstream will stop it and
+// nothing can put the rows back. A candidate doing this in the browser has been told what
+// they are about to lose; a credential in a script's environment has not, and one wrong id
+// there erases years of someone's record in a single request.
+//
+// Confining the keyed form to an already-empty place keeps the route useful — move the
+// achievements with PUT, then remove the shell — while the destructive form stays where its
+// consequence is visible. Unknown or foreign ids resolve to 404 here, before the count, so
+// the refusal never doubles as a way to probe which ids exist.
+func (h *experienceHandlers) refuseKeyedCascade(ctx context.Context, userID int64, id uuid.UUID) error {
+	employments, err := h.bank.ListEmployments(ctx, userID)
+	if err != nil {
+		return err
+	}
+	found := false
+	for _, e := range employments {
+		if e.ID == id {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fiber.NewError(fiber.StatusNotFound, "not found")
+	}
+	atoms, err := h.bank.ListAtoms(ctx, userID)
+	if err != nil {
+		return err
+	}
+	n := 0
+	for _, a := range atoms {
+		if a.EmploymentID != nil && *a.EmploymentID == id {
+			n++
+		}
+	}
+	if n == 0 {
+		return nil
+	}
+	// The message names the way out, because the caller reading it is usually an agent and
+	// this is its only route to correcting itself inside the turn.
+	return fiber.NewError(fiber.StatusConflict, fmt.Sprintf(
+		"this place still holds %d achievement(s), and deleting it would delete them too. "+
+			"Move them first (PUT /me/experience/atoms/:id with another employment_id, or "+
+			"delete them one by one), or remove the place from the experience page on the site.", n))
 }
 
 // UpdateAtom rewrites one achievement. Editing it makes it the owner's own statement —

--- a/internal/handler/me_experience_delete_test.go
+++ b/internal/handler/me_experience_delete_test.go
@@ -1,0 +1,144 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/experience"
+)
+
+// deleteApp wires the bank surface behind the real RequireAuthOrKey, and returns a cookie
+// token so one fixture can exercise both credentials.
+func deleteApp(t *testing.T, bank *stubBank) (*fiber.App, string) {
+	t.Helper()
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	token, err := iss.Issue(1, testTokenVersion)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	guard := auth.RequireAuthOrKey(iss, testVersions, stubKeys{userID: 1})
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	newExperienceHandlers(bank).register(app.Group(""), middleware{cookie: guard, key: guard})
+	return app, token
+}
+
+// deleteReq issues a DELETE as either credential.
+func deleteReq(t *testing.T, app *fiber.App, path, token string, viaKey bool) *http.Response {
+	t.Helper()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, path, nil)
+	if viaKey {
+		req.Header.Set("Authorization", "Bearer fhk_test")
+	} else {
+		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+	}
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("delete %s: %v", path, err)
+	}
+	return resp
+}
+
+// TestKeyedEmploymentDeleteRefusesToCascade is what makes deleting reachable by key at all.
+//
+// experience_atoms.employment_id is ON DELETE CASCADE (migration 0047), so removing a place
+// removes every achievement recorded under it, and the bank has no undo. That is a coherent
+// thing for a person to do in a browser, where the confirm dialog says how many go with it.
+// It is not a coherent thing to reach through a credential sitting in a script's environment,
+// where the same call is one wrong id away from erasing years of someone's record.
+//
+// So a keyed delete is confined to a place that is already empty. The route stays useful —
+// move the achievements first, then remove the shell — and the destructive form stays where
+// its consequence is visible. The rule lives here rather than in a CLI confirmation prompt,
+// because a prompt is no obstacle at all to the agent it would be protecting against.
+func TestKeyedEmploymentDeleteRefusesToCascade(t *testing.T) {
+	bank := newStubBank()
+	place := bank.addEmployment(1, experience.Employment{Kind: experience.KindJob, Company: "Informa"})
+	bank.add(1, experience.Atom{
+		Claim: "Led the migration to serverless", EmploymentID: &place.ID,
+		Provenance: experience.ProvenanceManual,
+	})
+	bank.reindex()
+	app, _ := deleteApp(t, bank)
+
+	resp := deleteReq(t, app, "/me/experience/employments/"+place.ID.String(), "", true)
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusConflict {
+		t.Fatalf("keyed delete of a non-empty employment = %d, want 409", resp.StatusCode)
+	}
+	if _, err := bank.GetAtom(context.Background(), bank.list[0].ID, 1); err != nil {
+		t.Errorf("the achievement was destroyed by a refused delete: %v", err)
+	}
+}
+
+// The candidate's own delete keeps the cascade. They are looking at the confirmation the
+// browser showed them; taking the capability away here would be removing the only way to
+// delete a place at all.
+func TestCookieEmploymentDeleteStillCascades(t *testing.T) {
+	bank := newStubBank()
+	place := bank.addEmployment(1, experience.Employment{Kind: experience.KindJob, Company: "Informa"})
+	bank.add(1, experience.Atom{
+		Claim: "Led the migration to serverless", EmploymentID: &place.ID,
+		Provenance: experience.ProvenanceManual,
+	})
+	bank.reindex()
+	app, token := deleteApp(t, bank)
+
+	resp := deleteReq(t, app, "/me/experience/employments/"+place.ID.String(), token, false)
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusNoContent {
+		t.Fatalf("cookie delete of a non-empty employment = %d, want 204", resp.StatusCode)
+	}
+	if len(bank.employments) != 0 {
+		t.Errorf("the employment survived a cookie delete: %v", bank.employments)
+	}
+}
+
+// An emptied place is the whole point of the rule above: move the achievements, then remove
+// the shell. If this were refused too, the keyed delete would be decorative.
+func TestKeyedEmploymentDeleteAllowsAnEmptyPlace(t *testing.T) {
+	bank := newStubBank()
+	place := bank.addEmployment(1, experience.Employment{Kind: experience.KindJob, Company: "TEST — delete me"})
+	app, _ := deleteApp(t, bank)
+
+	resp := deleteReq(t, app, "/me/experience/employments/"+place.ID.String(), "", true)
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusNoContent {
+		t.Fatalf("keyed delete of an empty employment = %d, want 204", resp.StatusCode)
+	}
+}
+
+// Deleting one achievement takes nothing with it, so it needs no equivalent of the rule
+// above — the row named is the only row removed.
+func TestKeyedAtomDelete(t *testing.T) {
+	bank := newStubBank()
+	atom := bank.add(1, experience.Atom{Claim: "Duplicate of another entry", Provenance: experience.ProvenanceCVImport})
+	bank.reindex()
+	app, _ := deleteApp(t, bank)
+
+	resp := deleteReq(t, app, "/me/experience/atoms/"+atom.ID.String(), "", true)
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusNoContent {
+		t.Fatalf("keyed atom delete = %d, want 204", resp.StatusCode)
+	}
+	if _, err := bank.GetAtom(context.Background(), atom.ID, 1); err == nil {
+		t.Error("the atom survived its own delete")
+	}
+}
+
+// A foreign or absent id is a 404 before the emptiness check runs, so the refusal above
+// never doubles as a way to probe whether an id exists.
+func TestKeyedEmploymentDeleteUnknownID(t *testing.T) {
+	app, _ := deleteApp(t, newStubBank())
+	resp := deleteReq(t, app, "/me/experience/employments/"+uuid.NewString(), "", true)
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusNotFound {
+		t.Fatalf("keyed delete of an unknown employment = %d, want 404", resp.StatusCode)
+	}
+}

--- a/internal/handler/me_experience_routes_test.go
+++ b/internal/handler/me_experience_routes_test.go
@@ -57,10 +57,9 @@ func TestProvenanceForUpdate(t *testing.T) {
 // cannot fix a typo in it is left with a bank it can only make worse, since the duplicate
 // check refuses the corrected retry.
 //
-// Everything that DESTROYS stays cookie-only, and that is the enforcement rather than a
-// preference. The bank has no undo. Deleting an employment cascades to every achievement
-// under it (migration 0047), and a merge folds one atom's numbers into another across the
-// provenance line. None of that belongs to a credential living in a script's environment.
+// The deletes take a key too, but the cascade does not come with them: DeleteEmployment
+// refuses a keyed caller while achievements still hang off the row (migration 0047 deletes
+// them with it). See TestKeyedEmploymentDeleteRefusesToCascade.
 func TestExperienceRegister_Gates(t *testing.T) {
 	const id = "/00000000-0000-0000-0000-000000000001"
 	for _, tc := range []struct {
@@ -73,8 +72,12 @@ func TestExperienceRegister_Gates(t *testing.T) {
 		{http.MethodPost, "/me/experience/atoms", "key"},
 		{http.MethodPut, "/me/experience/employments" + id, "key"},
 		{http.MethodPut, "/me/experience/atoms" + id, "key"},
-		{http.MethodDelete, "/me/experience/employments" + id, "cookie"},
-		{http.MethodDelete, "/me/experience/atoms" + id, "cookie"},
+		{http.MethodDelete, "/me/experience/employments" + id, "key"},
+		{http.MethodDelete, "/me/experience/atoms" + id, "key"},
+		// The merge stays cookie-only, and unlike the deletes it cannot simply be widened:
+		// unionForMerge folds the discarded atom's metrics and skills into the kept one
+		// while the kept one's provenance stands, so a `manual` atom can absorb numbers an
+		// agent invented. Opening it needs that settled first, not a gate change.
 		{http.MethodPost, "/me/experience/atoms/merge", "cookie"},
 	} {
 		t.Run(tc.method+" "+tc.path, func(t *testing.T) {


### PR DESCRIPTION
## The gap

Removing was cookie-only, so a caller that could add and correct from a script could not take anything back out. The obvious cleanup was impossible: a duplicate achievement, a place recorded twice, a row left behind by an old smoke test.

## The reason it was closed is the cascade, not deletion

`experience_atoms.employment_id` is `ON DELETE CASCADE` (migration `0047`). Removing a place removes every achievement under it, and the bank has no undo.

In a browser that is coherent — the confirmation says how many go with it. Through a credential sitting in a script's environment it is one wrong id away from erasing years of someone's record.

## The change

| route | key | note |
|---|---|---|
| `DELETE /me/experience/atoms/:id` | ✅ | the row named is the only row removed |
| `DELETE /me/experience/employments/:id` | ✅ | **409 while it still holds achievements** |
| `DELETE /me/experience/employments/:id` (cookie) | — | still cascades, unchanged |

`refuseKeyedCascade` runs after an existence check, so a foreign or absent id is still a 404 and the 409 never doubles as a way to probe which ids exist. The 409 message names the way out, because the caller reading it is usually an agent and that is its only route to correcting itself inside the turn.

The workflow this leaves is: move the achievements (`PUT`, shipped in #2025), then remove the empty shell.

## What does NOT follow

The merge, and it is not merely a gate away. `unionForMerge` folds the discarded atom's metrics and skills into the kept one while the kept one's provenance stands — so a `manual` atom can absorb numbers an agent invented. That is the same laundering shape as the provenance stamp fixed in #2025, one level down in the data. It needs settling on its own terms before the gate moves. The route-gate test says so at the assertion.

## On where the rule lives

Deliberately not a CLI confirmation prompt. A prompt is no obstacle to the automated caller it would be protecting against; only the service path is.

## Tests

`TestKeyedEmploymentDeleteRefusesToCascade` (409, and the achievement survives), `TestCookieEmploymentDeleteStillCascades` (204, the browser keeps the capability), `TestKeyedEmploymentDeleteAllowsAnEmptyPlace`, `TestKeyedAtomDelete`, `TestKeyedEmploymentDeleteUnknownID` (404 before the count). All through the real `auth.RequireAuthOrKey`.

`gofmt` / `go vet ./...` / `go test ./...` / `go vet -tags=integration ./...` clean.

Client side: strelov1/freehire-cli#38.