### PR TITLE
Fix extension autofill: WS upgrade proxying and a cookie-leak 403

### DIFF
--- a/extension/lib/assistant/api.test.ts
+++ b/extension/lib/assistant/api.test.ts
@@ -21,6 +21,10 @@ afterEach(() => vi.unstubAllGlobals());
 describe('the assistant API', () => {
   // The whole divergence from the web's client: extension code cannot see hire's
   // httpOnly cookie across origins, so the credential rides a header instead.
+  // `credentials: 'omit'` is explicit, not incidental: host_permissions makes Chrome
+  // attach a signed-in website tab's session cookie to this call by default, which
+  // would make the request carry BOTH credentials and get misread server-side as
+  // the website rather than the extension.
   it('presents the session JWT as a Bearer credential, not as a cookie', async () => {
     const calls = stubFetch({ status: 200, body: { data: { id: 's1', preset: 'browse', label: '' } } });
 
@@ -28,7 +32,7 @@ describe('the assistant API', () => {
 
     expect(calls).toHaveLength(1);
     expect(must(calls[0]).init.headers).toMatchObject({ Authorization: 'Bearer tok-123' });
-    expect(must(calls[0]).init.credentials).toBeUndefined();
+    expect(must(calls[0]).init.credentials).toBe('omit');
   });
 
   // The panel's agent is the one with eyes; a chat session would have no page tool.

--- a/extension/lib/assistant/api.ts
+++ b/extension/lib/assistant/api.ts
@@ -32,6 +32,7 @@ export class SessionNotFound extends Error {
 async function request<T = void>(path: string, token: string, init?: RequestInit): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {
     ...init,
+    credentials: 'omit',
     headers: {
       'content-type': 'application/json',
       Authorization: `Bearer ${token}`,

--- a/extension/lib/assistant/client.test.ts
+++ b/extension/lib/assistant/client.test.ts
@@ -56,6 +56,10 @@ describe('sendTurn', () => {
 
     expect(must(calls[0]).init.headers).toMatchObject({ Authorization: 'Bearer tok-9' });
     expect(JSON.parse(must(calls[0]).init.body as string)).toEqual({ text: 'hello there' });
+    // `credentials: 'omit'`, not the default: host_permissions makes Chrome attach a
+    // signed-in website tab's session cookie to this call otherwise, and hire's auth
+    // middleware reads that cookie's mere presence as "not the extension" and 403s.
+    expect(must(calls[0]).init.credentials).toBe('omit');
   });
 
   // Stopping is something the user chose. It has to arrive as a terminal event, or

--- a/extension/lib/assistant/client.ts
+++ b/extension/lib/assistant/client.ts
@@ -44,6 +44,7 @@ export function sendTurn(
     try {
       res = await fetch(`${BASE}/sessions/${encodeURIComponent(sessionId)}/messages`, {
         method: 'POST',
+        credentials: 'omit',
         headers: {
           'content-type': 'application/json',
           Authorization: `Bearer ${token}`,

--- a/extension/lib/auth.ts
+++ b/extension/lib/auth.ts
@@ -73,6 +73,7 @@ export async function getToken(): Promise<string | null> {
  */
 export async function fetchMe(token: string): Promise<HireUser | null> {
   const res = await fetch(`${HIRE_ORIGIN}/api/v1/auth/me`, {
+    credentials: 'omit',
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!res.ok) return null;

--- a/extension/lib/freehire.ts
+++ b/extension/lib/freehire.ts
@@ -121,28 +121,36 @@ async function unwrap<T>(path: string, res: Response): Promise<T> {
   return (JSON.parse(body) as { data: T }).data;
 }
 
-async function getData<T>(path: string, token: string): Promise<T> {
-  const res = await fetch(`${HIRE_ORIGIN}${path}`, {
-    headers: { Authorization: `Bearer ${token}` },
+// `credentials: 'omit'` is explicit, not the default's redundant restatement: this
+// extension holds host_permissions for every origin, and Chrome attaches a target
+// site's cookies to a privileged extension-page fetch even without `include` — so a
+// signed-in website tab's session cookie rides along with the Bearer token unless
+// this forces it off. Endpoints that gate on "the extension's own Bearer connection"
+// (e.g. POST /me/autofill/run) read a cookie's mere presence as a *different* caller
+// and 403, regardless of the Bearer token also being valid.
+function authedFetch(path: string, token: string, init?: RequestInit): Promise<Response> {
+  return fetch(`${HIRE_ORIGIN}${path}`, {
+    ...init,
+    credentials: 'omit',
+    headers: { Authorization: `Bearer ${token}`, ...init?.headers },
   });
-  return unwrap<T>(path, res);
+}
+
+async function getData<T>(path: string, token: string): Promise<T> {
+  return unwrap<T>(path, await authedFetch(path, token));
 }
 
 async function postData<T>(path: string, body: unknown, token: string): Promise<T> {
-  const res = await fetch(`${HIRE_ORIGIN}${path}`, {
+  const res = await authedFetch(path, token, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
   return unwrap<T>(path, res);
 }
 
 async function deleteData<T>(path: string, token: string): Promise<T> {
-  const res = await fetch(`${HIRE_ORIGIN}${path}`, {
-    method: 'DELETE',
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  return unwrap<T>(path, res);
+  return unwrap<T>(path, await authedFetch(path, token, { method: 'DELETE' }));
 }
 
 export function getJob(slug: string, token: string): Promise<FreehireJob> {

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -2,6 +2,15 @@
 # keeps the SvelteKit SSR app and the Go API same-origin (required for the
 # SameSite=Lax auth cookie) by routing /api and /health to the backend and
 # everything else to the in-container Node SSR server.
+
+# Upgrades the connection when the client asks (WebSocket), keeps it open otherwise.
+# Needed for /api/v1/tools/ws below — a plain proxy_pass alone forwards HTTP/1.0 with
+# Connection: close, which never completes the 101 handshake.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 server {
     listen 80;
 
@@ -41,6 +50,25 @@ server {
     # Default is Docker's embedded DNS; docker-entrypoint.sh rewrites this to the
     # first nameserver in /etc/resolv.conf under Podman (aardvark-dns).
     resolver 127.0.0.11 valid=30s ipv6=off;
+
+    # The browsertools relay: a long-lived WebSocket, not a request/response call. Its own
+    # location (nginx picks the longest matching prefix over /api/, regardless of order)
+    # so the extended proxy_read_timeout below applies only here — everything else under
+    # /api/ keeps the stock 60s and fails fast on a genuinely hung backend.
+    location = /api/v1/tools/ws {
+        set $backend http://app:8080;
+        proxy_pass $backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        # The channel carries no application-level ping yet, so the stock 60s
+        # proxy_read_timeout would silently drop it between tool calls.
+        proxy_read_timeout 3600s;
+    }
 
     # Backend service name inside the compose network.
     location /api/ {


### PR DESCRIPTION
## Summary
- `web/nginx.conf`: the `/api/` location forwarded no `Upgrade`/`Connection` headers, so `wss://freehire.me/api/v1/tools/ws?role=extension` never completed its handshake — every side-panel connection failed and agent-driven autofill silently fell back to the basic filler. Split it into a dedicated `location = /api/v1/tools/ws` (upgrade headers + a 3600s read timeout, since the channel has no ping yet) so the rest of `/api/` keeps its stock 60s timeout.
- `extension/lib/{freehire,auth}.ts`, `extension/lib/assistant/{api,client}.ts`: today's `IsExtensionBearer` gate on `POST /me/autofill/run` (and the browse-preset assistant turn) reads a session cookie's mere presence as "not the extension" and 403s. The extension's `host_permissions: ["<all_urls>"]` make Chrome attach a signed-in website tab's `hire_token` cookie to these calls even without `credentials: 'include'`, so any user signed in on both surfaces hit a 403 on every autofill attempt. Made every extension→hire fetch call explicit `credentials: 'omit'`.
- Deduplicated the three repeated `credentials: 'omit'` fetch calls in `freehire.ts` into one `authedFetch` helper.
- Extended the existing credential tests (`api.test.ts`) and added the missing one (`client.test.ts`) to assert `credentials: 'omit'`, so a future refactor can't silently reintroduce the leak.

## Test plan
- [x] `go vet`/`gofmt` — n/a, no Go changed
- [x] `npx tsc --noEmit` (extension) — clean
- [x] `npx vitest run` (extension) — 267/267 passing
- [x] `npx eslint` on touched files — clean
- [x] `nginx -t` against the exact Alpine package layout `web/Dockerfile` installs (`apk add nginx nginx-mod-http-brotli`, config at `/etc/nginx/http.d/default.conf`) — syntax OK
- [ ] Manual: needs the web image rebuilt/redeployed and a new extension build to verify against production

🤖 Generated with [Claude Code](https://claude.com/claude-code)