### PR TITLE
Surface a notice when the extension's WS relay can't connect

### DIFF
--- a/extension/entrypoints/sidepanel/App.svelte
+++ b/extension/entrypoints/sidepanel/App.svelte
@@ -66,7 +66,11 @@
   // The browser-tool wire: while the panel is open this holds the socket the
   // agent drives this browser through. It lives here rather than in the service
   // worker because only the panel stays alive.
-  const tools = new ToolChannel(activeTabPage);
+  const tools = new ToolChannel(activeTabPage, (status) => {
+    if (status === 'unreachable') {
+      notices.push('Could not connect the browsing tools — try signing out and back in.');
+    }
+  });
 
   type MatchStatus = 'idle' | 'loading' | 'ready' | 'error' | 'empty';
   let matchStatus = $state<MatchStatus>('idle');

--- a/extension/lib/tools/client.test.ts
+++ b/extension/lib/tools/client.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { respondTo } from './client';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { respondTo, ToolChannel, WS_SUBPROTOCOL_MARKER, type ChannelStatus } from './client';
 import type { PageBridge } from './executor';
 import { must } from '../test-utils';
 
@@ -26,5 +26,175 @@ describe('respondTo', () => {
   it('stays silent on a frame it cannot correlate to a call', async () => {
     expect(await respondTo('garbage', page)).toBeNull();
     expect(await respondTo('{"tool":"read_form"}', page)).toBeNull();
+  });
+});
+
+/** Stands in for the browser's WebSocket: the test drives its lifecycle events by hand. */
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  static readonly OPEN = 1;
+
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  readyState = 0;
+  sent: string[] = [];
+
+  constructor(
+    public url: string,
+    public protocols: string[],
+  ) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = 3;
+  }
+
+  triggerOpen() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  triggerClose() {
+    this.onclose?.();
+  }
+}
+
+function lastSocket(): FakeWebSocket {
+  const s = FakeWebSocket.instances.at(-1);
+  if (!s) throw new Error('no socket was opened');
+  return s;
+}
+
+// Never exercised: no ToolChannel test here sends the channel a tool call.
+const unusedPage: PageBridge = {
+  readPage: () => Promise.reject(new Error('unused')),
+  readForm: () => Promise.reject(new Error('unused')),
+  fillSimple: () => Promise.reject(new Error('unused')),
+  combobox: () => Promise.reject(new Error('unused')),
+};
+
+afterEach(() => {
+  FakeWebSocket.instances = [];
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('ToolChannel', () => {
+  it('opens the relay socket carrying the marker and the token as subprotocols', () => {
+    vi.stubGlobal('WebSocket', FakeWebSocket as unknown as typeof WebSocket);
+    new ToolChannel(unusedPage).start('tok-1');
+
+    expect(lastSocket().protocols).toEqual([WS_SUBPROTOCOL_MARKER, 'tok-1']);
+  });
+
+  it('reports connecting then open as the handshake completes', () => {
+    vi.stubGlobal('WebSocket', FakeWebSocket as unknown as typeof WebSocket);
+    const statuses: ChannelStatus[] = [];
+    new ToolChannel(unusedPage, (s) => statuses.push(s)).start('tok-1');
+    lastSocket().triggerOpen();
+
+    expect(statuses).toEqual(['connecting', 'open']);
+  });
+
+  it('retries a dropped connection with a widening backoff, capped at 30s', () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('WebSocket', FakeWebSocket as unknown as typeof WebSocket);
+    new ToolChannel(unusedPage).start('tok-1');
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    lastSocket().triggerClose();
+    vi.advanceTimersByTime(999);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    vi.advanceTimersByTime(1);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+
+    lastSocket().triggerClose();
+    vi.advanceTimersByTime(1999);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    vi.advanceTimersByTime(1);
+    expect(FakeWebSocket.instances).toHaveLength(3);
+  });
+
+  it('resets the backoff after a connection succeeds', () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('WebSocket', FakeWebSocket as unknown as typeof WebSocket);
+    new ToolChannel(unusedPage).start('tok-1');
+
+    lastSocket().triggerClose(); // 1st failure: next delay 1s
+    vi.advanceTimersByTime(1000);
+    lastSocket().triggerOpen(); // succeeds: backoff resets
+    lastSocket().triggerClose(); // 1st failure again: next delay should be 1s, not 2s
+
+    vi.advanceTimersByTime(999);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    vi.advanceTimersByTime(1);
+    expect(FakeWebSocket.instances).toHaveLength(3);
+  });
+
+  it('stops retrying once stop() is called', () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('WebSocket', FakeWebSocket as unknown as typeof WebSocket);
+    const channel = new ToolChannel(unusedPage);
+    channel.start('tok-1');
+    lastSocket().triggerClose();
+    channel.stop();
+
+    vi.advanceTimersByTime(60_000);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+
+  // The WebSocket API never exposes the HTTP status a rejected handshake got, so a
+  // permanently dead token (expired, revoked) looks identical to a momentary network
+  // blip from here — just an onclose with nothing to act on. Silence forever was the
+  // actual production bug this closes: the channel already retries indefinitely
+  // (right, for a restarting relay), but nothing ever told the user why autofill and
+  // the browse tool stayed broken the whole time.
+  it('reports unreachable after repeated failures, without breaking off the retry loop', () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('WebSocket', FakeWebSocket as unknown as typeof WebSocket);
+    const statuses: ChannelStatus[] = [];
+    new ToolChannel(unusedPage, (s) => statuses.push(s)).start('tok-1');
+
+    for (let i = 0; i < 5; i++) {
+      lastSocket().triggerClose();
+      vi.runOnlyPendingTimers();
+    }
+    expect(statuses.filter((s) => s === 'unreachable')).toHaveLength(1);
+    expect(FakeWebSocket.instances.length).toBeGreaterThan(5);
+
+    // Keeps retrying afterwards, and does not repeat the notice.
+    lastSocket().triggerClose();
+    vi.runOnlyPendingTimers();
+    expect(statuses.filter((s) => s === 'unreachable')).toHaveLength(1);
+  });
+
+  it('can report unreachable again after a fresh start', () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('WebSocket', FakeWebSocket as unknown as typeof WebSocket);
+    const statuses: ChannelStatus[] = [];
+    const channel = new ToolChannel(unusedPage, (s) => statuses.push(s));
+
+    channel.start('tok-1');
+    for (let i = 0; i < 5; i++) {
+      lastSocket().triggerClose();
+      vi.runOnlyPendingTimers();
+    }
+    expect(statuses.filter((s) => s === 'unreachable')).toHaveLength(1);
+
+    channel.stop();
+    statuses.length = 0;
+    channel.start('tok-2'); // e.g. the user signed out and back in with a fresh token
+    for (let i = 0; i < 5; i++) {
+      lastSocket().triggerClose();
+      vi.runOnlyPendingTimers();
+    }
+    expect(statuses.filter((s) => s === 'unreachable')).toHaveLength(1);
   });
 });

--- a/extension/lib/tools/client.ts
+++ b/extension/lib/tools/client.ts
@@ -31,7 +31,19 @@ export async function respondTo(data: unknown, page: PageBridge): Promise<string
   return JSON.stringify(await executeTool(call, page));
 }
 
-export type ChannelStatus = 'idle' | 'connecting' | 'open' | 'closed';
+export type ChannelStatus = 'idle' | 'connecting' | 'open' | 'closed' | 'unreachable';
+
+// A rejected handshake (expired/revoked token, relay down, ...) reaches the client
+// as the same opaque close event a network blip would — the WebSocket API never
+// exposes the HTTP status a failed upgrade got, so there is no way to tell "stop
+// retrying this token" apart from "try again in a moment" from here. Retrying
+// forever is still right (this is what makes a restarting relay self-heal), but
+// retrying SILENTLY forever is not: a stale token would otherwise fail every 30s
+// with nothing on screen to explain why autofill and the browse tool never work.
+// After this many consecutive failures, 'unreachable' fires once so the panel can
+// tell the user, without breaking off the retry loop that recovers a transient
+// outage on its own.
+const GIVE_UP_NOTICE_AFTER_ATTEMPTS = 5;
 
 /**
  * Keeps the extension attached to the relay, answering tool calls for as long as
@@ -43,6 +55,7 @@ export class ToolChannel {
   private timer: ReturnType<typeof setTimeout> | null = null;
   private attempt = 0;
   private stopped = true;
+  private notifiedUnreachable = false;
 
   constructor(
     private readonly page: PageBridge,
@@ -52,6 +65,8 @@ export class ToolChannel {
   /** Attaches, and keeps re-attaching, until `stop()`. */
   start(token: string): void {
     this.stopped = false;
+    this.attempt = 0;
+    this.notifiedUnreachable = false;
     this.open(token);
   }
 
@@ -71,6 +86,7 @@ export class ToolChannel {
 
     ws.onopen = () => {
       this.attempt = 0;
+      this.notifiedUnreachable = false;
       this.onStatus('open');
     };
     ws.onmessage = async (ev) => {
@@ -88,7 +104,12 @@ export class ToolChannel {
 
   private retry(token: string): void {
     if (this.stopped) return;
-    const delay = Math.min(30_000, 1_000 * 2 ** this.attempt++);
+    this.attempt++;
+    if (this.attempt >= GIVE_UP_NOTICE_AFTER_ATTEMPTS && !this.notifiedUnreachable) {
+      this.notifiedUnreachable = true;
+      this.onStatus('unreachable');
+    }
+    const delay = Math.min(30_000, 1_000 * 2 ** (this.attempt - 1));
     this.timer = setTimeout(() => this.open(token), delay);
   }
 }


### PR DESCRIPTION
## Summary
Follow-up to #2028. Checked production (host2) logs while diagnosing that fix and found the WS handshake to `/api/v1/tools/ws` is not the problem there — nginx already upgrades it fine (`101` responses in the access log). The actual production symptom is repeated `401 | not authenticated` on that route from the same session that was hitting the autofill 403, most likely a stale extension token (`token_version` no longer current — e.g. after a password change or sign-out-everywhere).

The browser's WebSocket API never exposes the HTTP status a rejected handshake got, so `ToolChannel` cannot distinguish "this token is permanently dead" from "the relay hiccuped for a moment" — it already retries forever with backoff, which is the right call for the latter, but it did so in total silence. A user in this state gets autofill falling back to the basic filler and the browse tool silently missing, forever, with nothing on screen explaining why.

- `extension/lib/tools/client.ts`: `ToolChannel` now emits a one-time `'unreachable'` status after 5 consecutive failed attempts, without breaking off the retry loop (so a relay that comes back on its own still self-heals silently). Resets on a successful open or a fresh `start()`.
- `extension/entrypoints/sidepanel/App.svelte`: wires that into the existing `notices` mechanism with the fix that works today — sign out, sign back in, which mints a fresh token.
- `extension/lib/tools/client.test.ts`: added the test suite `ToolChannel` never had (it previously only covered the sibling `respondTo` helper in the same file).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 274/274 passing
- [x] `npx eslint` on touched files — clean
- [ ] Manual: needs a new extension build/release to verify against the affected production session

🤖 Generated with [Claude Code](https://claude.com/claude-code)