### PR TITLE
Recognize CatsOne's /apply URL when resolving a job

### DIFF
--- a/internal/sources/postingurl.go
+++ b/internal/sources/postingurl.go
@@ -96,6 +96,15 @@ var applyFormSuffix = map[string]string{
 	"jobs.workable.com":  "/apply",
 }
 
+// applyFormSuffixApex is applyFormSuffix's counterpart for a multi-tenant ATS whose
+// tenants each get their own host, so no single hostname names it — CatsOne serves
+// <tenant>.catsone.com per company, the same shape internal/atsboard's "catsone"
+// modeHost entry already recognises. Matched by domain label rather than a tenant
+// list, so a new CatsOne tenant needs no entry here either.
+var applyFormSuffixApex = map[string]string{
+	"catsone": "/apply",
+}
+
 // CanonicalPostingURL rewrites a posting's application-form URL to the posting
 // itself, and returns everything else unchanged.
 //
@@ -114,7 +123,11 @@ func CanonicalPostingURL(raw string) string {
 	if err != nil || u.Host == "" {
 		return raw
 	}
-	suffix, known := applyFormSuffix[strings.ToLower(u.Hostname())]
+	host := strings.ToLower(u.Hostname())
+	suffix, known := applyFormSuffix[host]
+	if !known {
+		suffix, known = applyFormSuffixByApex(host)
+	}
 	if !known {
 		return raw
 	}
@@ -133,4 +146,19 @@ func CanonicalPostingURL(raw string) string {
 	}
 	u.Path = stripped
 	return u.String()
+}
+
+// applyFormSuffixByApex matches host against applyFormSuffixApex's domain labels,
+// the same "apex sits somewhere in the middle" test internal/atsboard's matchHost
+// uses for its own modeHost entries: a HasSuffix(host, ".catsone") check would never
+// match "<tenant>.catsone.com" at all — the label is followed by a TLD, not the end
+// of the string — so this looks for the apex bracketed by dots instead, exactly like
+// atsboard's own "catsone" entry does when it recognises the same hosts for ingest.
+func applyFormSuffixByApex(host string) (string, bool) {
+	for apex, suffix := range applyFormSuffixApex {
+		if strings.Contains(host, "."+apex+".") {
+			return suffix, true
+		}
+	}
+	return "", false
 }

--- a/internal/sources/postingurl_test.go
+++ b/internal/sources/postingurl_test.go
@@ -116,6 +116,18 @@ func TestCanonicalPostingURL_DropsTheApplyForm(t *testing.T) {
 			want: "https://apply.workable.com/1kosmos/j/435C7BA5E4",
 		},
 		{
+			// CatsOne is multi-tenant per host (<tenant>.catsone.com), so this has to
+			// match by domain label rather than a fixed hostname.
+			name: "catsone apply, a tenant subdomain",
+			url:  "https://emergitel.catsone.com/careers/7701/jobs/16841332-full-stack-software-engineer-react-nodejs-typescript/apply",
+			want: "https://emergitel.catsone.com/careers/7701/jobs/16841332-full-stack-software-engineer-react-nodejs-typescript",
+		},
+		{
+			name: "catsone apply, a different tenant",
+			url:  "https://acme.catsone.com/careers/1/jobs/2-title/apply",
+			want: "https://acme.catsone.com/careers/1/jobs/2-title",
+		},
+		{
 			// The check that got us here is case-insensitive, so the cut must be too —
 			// otherwise the suffix matches, nothing is removed, and the URL comes back
 			// quietly altered instead of untouched.
@@ -148,6 +160,11 @@ func TestCanonicalPostingURL_LeavesEverythingElseAlone(t *testing.T) {
 		"https://careers.example.test/jobs/42/apply",
 		"https://boards.greenhouse.io/stripe/jobs/7826765",
 		"https://jobs.ashbyhq.com/truelogic",
+		"https://acme.catsone.com/careers/1/jobs/2-title",
+		// Ends in the apex's own label, not bracketed by it — must not match on a
+		// coincidental hostname.
+		"https://notcatsone.com/careers/1/jobs/2-title/apply",
+		"https://catsone.com/careers/1/jobs/2-title/apply",
 		"not a url",
 		"",
 	} {


### PR DESCRIPTION
## Summary
User report: the extension detects `https://emergitel.catsone.com/careers/7701/jobs/16841332-.../` as a known freehire job, but on the companion apply-form page (`.../apply`) it reports the posting as not in the catalog and offers to add it — even though it's already there.

Root cause: `internal/sources/postingurl.go`'s `CanonicalPostingURL` (used by `GET /api/v1/jobs/find`, the extension's `findJob`) strips a known apply-form suffix before the catalog URL lookup, but `applyFormSuffix` only covers single-host ATS (`jobs.ashbyhq.com`, `jobs.lever.co`, `jobs.eu.lever.co`, `apply.workable.com`, `jobs.workable.com`). CatsOne is multi-tenant per host (`<tenant>.catsone.com`, 19+ tenants in `sources/catsone.yml`), so no single hostname entry covers it — and adding one exact-hostname row would only fix this one company, not the platform.

Fix: match by domain label instead, mirroring exactly how `internal/atsboard`'s own `{"catsone", "catsone", modeHost}` entry already recognizes every CatsOne tenant for ingest (`strings.Contains(host, ".catsone.")`) — one row, generalizes to every tenant, no list to keep in sync with `catsone.yml`.

## Test plan
- [x] `gofmt -l` — clean
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — passing, incl. new cases for two different CatsOne tenants and negative cases (bare apex, a host that merely contains "catsone" as a substring without being bracketed by dots)
- [x] `go vet -tags=integration ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)