### PR TITLE
Bump extension to 0.1.6

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freehire-extension",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freehire-extension",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "hasInstallScript": true,
       "dependencies": {
         "@lucide/svelte": "^1.25.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "freehire-extension",
   "description": "Browser extension: a job-application agent side panel, on any page.",
   "private": true,
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "scripts": {
     "dev": "wxt",


### PR DESCRIPTION
## Summary
Version bump only — ships the extension fixes already on `main` to real users: the cookie-leak 403 fix (#2028) and the WS-unreachable notice (#2029). Neither takes effect until a new version is actually released.

Merging this triggers `.github/workflows/extension.yml`'s push-to-main path: build, GitHub Release tagged `extension-v0.1.6`, and — since the Chrome Web Store API credentials are configured as repo secrets — an automatic upload + submission to the Chrome Web Store, which then goes through Google's review before reaching users.

## Test plan
- [x] `npx vitest run` — 274/274 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npm install --package-lock-only` — package-lock.json version synced, no dependency changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Incremented the extension version to 0.1.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->