### PR TITLE
Page the job and company lists, instead of growing them forever

### DIFF
--- a/design-system/scripts/adoption-baseline.json
+++ b/design-system/scripts/adoption-baseline.json
@@ -12,7 +12,7 @@
   "EntityLogo": 19,
   "FormField": 2,
   "Input": 15,
-  "LoadMore": 8,
+  "LoadMore": 6,
   "NoticeDialog": 0,
   "NumberedGrid": 5,
   "Pagination": 0,

--- a/web/src/lib/components/CompaniesView.svelte
+++ b/web/src/lib/components/CompaniesView.svelte
@@ -10,19 +10,22 @@
   import { CompanyFilterStore, companyFiltersToParams, type CompanySortField } from '$lib/companyFilters';
   import { setListSearchTarget } from '$lib/listSearch.svelte';
   import type { CompanyListItem } from '$lib/types';
-  import { Badge, CountryFlag, EntityLogo, LoadMore } from '$lib/ui';
+  import { Badge, CountryFlag, EntityLogo } from '$lib/ui';
   import { countryLabel } from '$lib/facets';
   import { companyLogoUrl } from '$lib/logo';
+  import { pageCount, pageOffset } from '$lib/pagination';
   import States from './States.svelte';
-  import InfiniteScroll from './InfiniteScroll.svelte';
+  import Pagination from './Pagination.svelte';
   import BackerBadge from './BackerBadge.svelte';
   import CompanyFilterSummary from './filters/CompanyFilterSummary.svelte';
   import CompanyFilterModal from './filters/CompanyFilterModal.svelte';
   import ListToolbar from './ListToolbar.svelte';
 
-  // The first page is server-rendered (route `load`) for the current filters, so
-  // the rows are in the initial HTML.
-  let { initial }: { initial: Slice<CompanyListItem> } = $props();
+  // The requested page is server-rendered (route `load`) for the current filters,
+  // so the rows are in the initial HTML. `currentPage` is the `?page=N` that load
+  // served: page links are the only way through the list, so it is required rather
+  // than optional — see JobsView, which holds the same contract.
+  let { initial, currentPage }: { initial: Slice<CompanyListItem>; currentPage: number } = $props();
 
   // The search query and sidebar facets live in the URL so a filtered view survives
   // reload, sharing, and back/forward. The store owns the state<->URL transport and
@@ -38,9 +41,18 @@
     );
 
   const seeded = makePaginator();
-  seeded.seed(untrack(() => initial));
+  seeded.seed(untrack(() => initial), pageOffset(untrack(() => currentPage)));
   let companies = $state.raw(seeded);
+
+  // The page being read. Starts at the route's `?page=N` and is reset only by a
+  // genuinely NEW query — see the effect below for why "the filters changed" is not
+  // the same question.
+  let activePage = $state(untrack(() => currentPage));
   let started = false;
+  // The applied filters as a string, so a re-seed to the same set can be told from a
+  // real change. Seeded with what the route searched with, not left empty: an empty
+  // one would make the first client run look like a new query and snap page 3 to 1.
+  let lastSearchKey = untrack(() => companyFiltersToParams(filters.applied).toString());
   let modalOpen = $state(false);
 
   // `initial` was fetched for page.url; if a shallow-routing back/forward left
@@ -68,14 +80,14 @@
     };
   });
 
-  function reload() {
+  function reload(offset = 0) {
     companies = makePaginator();
-    companies.start();
+    companies.start(offset);
   }
 
   // Reload whenever the debounced filters change (typing settled, a facet toggled,
   // or back/forward re-seeded them). Skip the first run: the SSR `initial` already
-  // rendered page one.
+  // rendered the page the URL asked for.
   $effect(() => {
     void filters.applied; // track the debounced filters
     untrack(() => {
@@ -83,7 +95,35 @@
         started = true;
         if (!initialStale) return;
       }
-      reload();
+      // "The filters object changed" is not "the visitor searched for something
+      // else": the store re-seeds on navigation and rewrites the URL, and both fire
+      // this effect with the same filters. Only a changed query means the result set
+      // is different and page 1 is where to be; anything else reloads the page being
+      // read, or `/companies?page=3` would render page 3 server-side and then snap
+      // itself back to page 1 the moment it hydrated. Mirrors JobsView.
+      const searchKey = companyFiltersToParams(filters.applied).toString();
+      const sameQuery = searchKey === lastSearchKey;
+      lastSearchKey = searchKey;
+      if (!sameQuery) activePage = 1;
+      reload(sameQuery ? pageOffset(activePage) : 0);
+    });
+  });
+
+  // Following a page link is a real navigation, but SvelteKit reuses this component
+  // across `?page=N` rather than remounting it — so `initial` and `currentPage` are
+  // re-supplied while the state seeded from them is not, and the address bar would
+  // move without the list moving. Re-seeds from the `initial` the route just loaded
+  // rather than fetching: the server already listed exactly this page. Mirrors
+  // JobsView.
+  $effect(() => {
+    const nextPage = currentPage;
+    const slice = initial;
+    untrack(() => {
+      if (nextPage === activePage) return;
+      activePage = nextPage;
+      const next = makePaginator();
+      next.seed(slice, pageOffset(nextPage));
+      companies = next;
     });
   });
 
@@ -174,19 +214,15 @@
         {/each}
       </div>
 
-      {#if companies.hasMore}
-        <!-- Scroll-to-bottom auto-load; the button below stays as the accessible
-             fallback (keyboard/screen-reader, and retry on a failed load). -->
-        <InfiniteScroll
-          onLoad={() => companies.loadMore()}
-          enabled={!companies.loadingMore && !companies.loadMoreError}
-        />
-        <LoadMore
-          loading={companies.loadingMore}
-          error={companies.loadMoreError}
-          onclick={() => companies.loadMore()}
-        />
-      {/if}
+      <!-- Page links, and the only way through the list. There was a scroll-to-bottom
+           auto-load here as well, which meant the page grew for as long as you
+           scrolled and the footer moved down every time you approached it. -->
+      <Pagination
+        current={activePage}
+        total={pageCount(companies.total)}
+        pathname={page.url.pathname}
+        params={page.url.searchParams}
+      />
     {/if}
   </div>
 </div>

--- a/web/src/lib/components/CompaniesView.svelte
+++ b/web/src/lib/components/CompaniesView.svelte
@@ -40,20 +40,22 @@
       api.listCompanies('', limit, offset, companyFiltersToParams(filters.applied)),
     );
 
+  // Seeded from the server-rendered page — an intentional one-time snapshot of the
+  // props, which the effects below re-take when the page or the query changes.
   const seeded = makePaginator();
-  seeded.seed(untrack(() => initial), pageOffset(untrack(() => currentPage)));
+  untrack(() => seeded.seed(initial, pageOffset(currentPage)));
   let companies = $state.raw(seeded);
 
   // The page being read. Starts at the route's `?page=N` and is reset only by a
   // genuinely NEW query — see the effect below for why "the filters changed" is not
   // the same question.
   let activePage = $state(untrack(() => currentPage));
+  let modalOpen = $state(false);
   let started = false;
   // The applied filters as a string, so a re-seed to the same set can be told from a
   // real change. Seeded with what the route searched with, not left empty: an empty
   // one would make the first client run look like a new query and snap page 3 to 1.
   let lastSearchKey = untrack(() => companyFiltersToParams(filters.applied).toString());
-  let modalOpen = $state(false);
 
   // `initial` was fetched for page.url; if a shallow-routing back/forward left
   // page.url lagging the address bar, it's stale — reload on the first run instead.
@@ -97,10 +99,10 @@
       }
       // "The filters object changed" is not "the visitor searched for something
       // else": the store re-seeds on navigation and rewrites the URL, and both fire
-      // this effect with the same filters. Only a changed query means the result set
-      // is different and page 1 is where to be; anything else reloads the page being
-      // read, or `/companies?page=3` would render page 3 server-side and then snap
-      // itself back to page 1 the moment it hydrated. Mirrors JobsView.
+      // this effect with the filters unchanged. Only a changed query means a
+      // different result set, and so page 1; anything else reloads the page being
+      // read. Without the distinction `/companies?page=3` rendered page 3 and snapped
+      // back to page 1 the moment it hydrated. Mirrors JobsView.
       const searchKey = companyFiltersToParams(filters.applied).toString();
       const sameQuery = searchKey === lastSearchKey;
       lastSearchKey = searchKey;
@@ -109,12 +111,10 @@
     });
   });
 
-  // Following a page link is a real navigation, but SvelteKit reuses this component
-  // across `?page=N` rather than remounting it — so `initial` and `currentPage` are
-  // re-supplied while the state seeded from them is not, and the address bar would
-  // move without the list moving. Re-seeds from the `initial` the route just loaded
-  // rather than fetching: the server already listed exactly this page. Mirrors
-  // JobsView.
+  // Re-seed when a page link is followed: SvelteKit reuses this component across
+  // `?page=N`, so the props arrive again and the state seeded from them does not.
+  // No fetch — the route already listed exactly this page. See JobsView, which
+  // carries the same effect and the longer explanation.
   $effect(() => {
     const nextPage = currentPage;
     const slice = initial;
@@ -214,9 +214,9 @@
         {/each}
       </div>
 
-      <!-- Page links, and the only way through the list. There was a scroll-to-bottom
-           auto-load here as well, which meant the page grew for as long as you
-           scrolled and the footer moved down every time you approached it. -->
+      <!-- Page links, and the only way through the list: a scroll-to-bottom auto-load
+           used to sit here, which grew the page every time the reader neared the end
+           of it and put the footer permanently out of reach. -->
       <Pagination
         current={activePage}
         total={pageCount(companies.total)}

--- a/web/src/lib/components/CompanyView.svelte
+++ b/web/src/lib/components/CompanyView.svelte
@@ -25,7 +25,9 @@
     company: Company;
     initial: Slice<Job> | null;
     slug: string;
-    currentPage?: number;
+    // Passed straight to JobsView, where page links are the only way through the
+    // results — so it is required here too rather than defaulting to page one.
+    currentPage: number;
     referralAvailable?: boolean;
   } = $props();
 </script>

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -491,10 +491,17 @@
       {/if}
     {:else}
       {#if visibleJobs.length === 0}
-        <!-- The server returned jobs but the user has hidden every one on this page.
-             The empty state replaces the feed; the paginator below still renders, so
-             this is somewhere to leave rather than a dead end. -->
-        <States state="empty" message="No matching jobs." />
+        <!-- The search DID match on this page — the client-side post-filters removed
+             every row. Saying "no matching jobs" here would blame the search for the
+             reader's own settings, and the two causes are worth telling apart because
+             one of them is a slider they can move. The paginator below still renders,
+             so this is somewhere to leave rather than a dead end. -->
+        <States
+          state="empty"
+          message={minMatch === null
+            ? 'Every job on this page is one you hid.'
+            : 'Every job on this page is hidden or below your match threshold.'}
+        />
       {:else}
         <div class="flex flex-col gap-3">
           {#each visibleJobs as job (job.public_slug)}

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -160,8 +160,14 @@
   let started = false;
   // Signature of the applied filters last reported as a search, so a re-run that
   // didn't change the filters (a back/forward re-seed) doesn't emit a spurious
-  // funnel event.
-  let lastSearchKey = '';
+  // funnel event — and, since it also decides `sameQuery`, doesn't reset the page.
+  //
+  // Seeded with what the route searched with rather than left empty. Empty only
+  // matches an unfiltered feed, so on `/?q=engineer&page=3` the first re-run read
+  // as a brand-new search and snapped the reader from page 3 back to page 1 — and
+  // logged a search they had not performed. It went unnoticed while scrolling was
+  // how anyone paged; the page links made it visible.
+  let lastSearchKey = untrack(() => filtersToParams(filters.applied).toString());
 
   // Onboarding: the one-time nudge banner + wizard, standalone-only. The lifecycle
   // lives in localStorage (client-only); seed it at init on the client so a returning

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -111,16 +111,16 @@
       keyOf: (job) => job.public_slug,
     });
 
-  // Seeded with the server-rendered page (an intentional one-time snapshot of the
-  // initial prop); filter changes fetch client-side.
   // The page being read. Starts at the route's `?page=N` and survives a reload that
   // didn't change the query; a changed query resets it to 1, because the visitor is
   // now looking at a different result set (and FilterStore has already dropped
   // `page` from the URL — it only ever writes facet params).
   let activePage = $state(untrack(() => currentPage));
 
+  // Seeded from the server-rendered page — an intentional one-time snapshot of the
+  // props, which the effects below re-take when the page or the query changes.
   const seeded = makePaginator();
-  seeded.seed(untrack(() => initial), pageOffset(untrack(() => currentPage)));
+  untrack(() => seeded.seed(initial, pageOffset(currentPage)));
   let jobs = $state.raw(seeded);
 
   // The live facet distribution (value → count per facet), feeding the dynamic
@@ -497,12 +497,11 @@
         </div>
       {/if}
 
-      <!-- Page links, and the only way through the results. There was a
-           scroll-to-bottom auto-load here as well, which meant the page grew for as
-           long as you scrolled and the footer moved down every time you approached
-           it — everything under the feed, /for-companies included, was unreachable
-           by scrolling. `pageCount` already caps at the deepest page the search API
-           will serve, so no link here walks into its "pagination too deep" 400. -->
+      <!-- Page links, and the only way through the results: a scroll-to-bottom
+           auto-load used to sit here, which grew the page every time the reader
+           neared the end of it and put the footer permanently out of reach.
+           `pageCount` caps at the deepest page the search API will serve, so no
+           link here walks into its "pagination too deep" 400. -->
       <Pagination
         current={activePage}
         total={pageCount(jobs.total)}

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -14,7 +14,7 @@
   import { ensureDismissedLoaded, isDismissed, markUndismissed } from '$lib/dismissedJobs.svelte';
   import { latestOnly } from '$lib/latestOnly';
   import { Paginator } from '$lib/paginated.svelte';
-  import { canFetchMore, pageCount, pageOffset } from '$lib/pagination';
+  import { pageCount, pageOffset } from '$lib/pagination';
   import Pagination from './Pagination.svelte';
   import { FilterStore, filtersToParams, activeFilterCount } from '$lib/filters';
   import { loadJobFilters } from '$lib/filterStorage';
@@ -39,8 +39,6 @@
   import ListToolbar from './ListToolbar.svelte';
   import States from './States.svelte';
   import JobRow from './JobRow.svelte';
-  import { LoadMore } from '$lib/ui';
-  import InfiniteScroll from './InfiniteScroll.svelte';
   import HiddenToast from './HiddenToast.svelte';
 
   // Filters live in the URL; the route `load` searches by them and returns the
@@ -63,11 +61,11 @@
   // URL, or the two would disagree and the mount effect would immediately
   // discard the SSR page and refetch.
   //
-  // `currentPage` is set by a route whose `load` honours `?page=N` — it both seeds
-  // the paginator at the right offset (so scrolling on continues the result set
-  // instead of replaying earlier pages) and turns on the <a href> page nav under
-  // the feed. Routes that always serve page one leave it unset and render no nav:
-  // links there would every one of them lead back to the same first page.
+  // `currentPage` is the `?page=N` the route's `load` served, and it is REQUIRED:
+  // page links are now the only way through the results, so a route that mounts
+  // this without honouring `?page=N` would render a nav whose every link leads
+  // back to the page already on screen. Required rather than optional so that
+  // mistake is a type error instead of a listing that silently stops at twenty.
   let {
     initial,
     scope = {},
@@ -81,7 +79,7 @@
     excludeFacets?: string[];
     sidebarTop?: Snippet;
     initialParams?: string;
-    currentPage?: number;
+    currentPage: number;
   } = $props();
 
   // Standalone /jobs (no fixed scope) hands its text search to the header; an
@@ -113,16 +111,16 @@
       keyOf: (job) => job.public_slug,
     });
 
-  // Seeded with the server-rendered first page (an intentional one-time snapshot
-  // of the initial prop); "load more" and filter changes fetch client-side.
+  // Seeded with the server-rendered page (an intentional one-time snapshot of the
+  // initial prop); filter changes fetch client-side.
   // The page being read. Starts at the route's `?page=N` and survives a reload that
   // didn't change the query; a changed query resets it to 1, because the visitor is
   // now looking at a different result set (and FilterStore has already dropped
   // `page` from the URL — it only ever writes facet params).
-  let activePage = $state(untrack(() => currentPage) ?? 1);
+  let activePage = $state(untrack(() => currentPage));
 
   const seeded = makePaginator();
-  seeded.seed(untrack(() => initial), pageOffset(untrack(() => currentPage) ?? 1));
+  seeded.seed(untrack(() => initial), pageOffset(untrack(() => currentPage)));
   let jobs = $state.raw(seeded);
 
   // The live facet distribution (value → count per facet), feeding the dynamic
@@ -287,11 +285,6 @@
   // a hidden or filtered-out card drops (and an undone one returns) instantly. A job
   // with no skills has no percent to test (see computeClientMatch) and stays, matching
   // the card's own `no-skills` state, which shows no match at all rather than a false 0%.
-  // The search API only serves the first SEARCH_WINDOW rows, however many matches it
-  // reports. Past that, asking for another page returns 400 and the feed would show
-  // "Couldn't load more" — an error for what is just the end of what's reachable.
-  const moreReachable = $derived(canFetchMore(pageOffset(activePage), jobs.items.length));
-
   const visibleJobs = $derived(
     jobs.items.filter((j) => {
       if (isDismissed(j.public_slug)) return false;
@@ -373,6 +366,24 @@
       lastSearchKey = searchKey;
       if (!sameQuery) activePage = 1;
       reloadList(sameQuery ? pageOffset(activePage) : 0);
+    });
+  });
+
+  // Following a page link is a real navigation, but SvelteKit reuses this component
+  // across `?page=N` rather than remounting it — so `initial` and `currentPage` are
+  // re-supplied while the state seeded from them is not. Without this the address bar
+  // said page 4 and the feed still showed page 3, which is the whole nav being
+  // decorative. It re-seeds from the `initial` the route just loaded rather than
+  // fetching: the server already searched for exactly this page.
+  $effect(() => {
+    const nextPage = currentPage;
+    const slice = initial;
+    untrack(() => {
+      if (nextPage === activePage) return;
+      activePage = nextPage;
+      const next = makePaginator();
+      next.seed(slice, pageOffset(nextPage));
+      jobs = next;
     });
   });
 
@@ -472,33 +483,32 @@
           </button>
         </div>
       {/if}
-    {:else if visibleJobs.length === 0 && !jobs.hasMore}
-      <!-- The server returned jobs but the user has hidden every one on this final
-           page: show the empty state rather than a blank feed. (With more pages,
-           the {:else} below keeps InfiniteScroll loading instead.) -->
-      <States state="empty" message="No matching jobs." />
     {:else}
-      <div class="flex flex-col gap-3">
-        {#each visibleJobs as job (job.public_slug)}
-          <JobRow {job} {onHide} />
-        {/each}
-      </div>
-
-      {#if jobs.hasMore && moreReachable}
-        <!-- Scroll-to-bottom auto-load; the button stays as the accessible
-             fallback (keyboard/screen-reader, and retry on a failed load). -->
-        <InfiniteScroll onLoad={() => jobs.loadMore()} enabled={!jobs.loadingMore && !jobs.loadMoreError} />
-        <LoadMore loading={jobs.loadingMore} error={jobs.loadMoreError} onclick={() => jobs.loadMore()} />
+      {#if visibleJobs.length === 0}
+        <!-- The server returned jobs but the user has hidden every one on this page.
+             The empty state replaces the feed; the paginator below still renders, so
+             this is somewhere to leave rather than a dead end. -->
+        <States state="empty" message="No matching jobs." />
+      {:else}
+        <div class="flex flex-col gap-3">
+          {#each visibleJobs as job (job.public_slug)}
+            <JobRow {job} {onHide} />
+          {/each}
+        </div>
       {/if}
 
-      {#if currentPage !== undefined}
-        <Pagination
-          current={activePage}
-          total={pageCount(jobs.total)}
-          pathname={page.url.pathname}
-          params={page.url.searchParams}
-        />
-      {/if}
+      <!-- Page links, and the only way through the results. There was a
+           scroll-to-bottom auto-load here as well, which meant the page grew for as
+           long as you scrolled and the footer moved down every time you approached
+           it — everything under the feed, /for-companies included, was unreachable
+           by scrolling. `pageCount` already caps at the deepest page the search API
+           will serve, so no link here walks into its "pagination too deep" 400. -->
+      <Pagination
+        current={activePage}
+        total={pageCount(jobs.total)}
+        pathname={page.url.pathname}
+        params={page.url.searchParams}
+      />
     {/if}
   </div>
 </div>

--- a/web/src/routes/companies/+page.server.ts
+++ b/web/src/routes/companies/+page.server.ts
@@ -1,15 +1,20 @@
 import { serverApi } from '$lib/server/api';
 import { companyFiltersFromParams, companyFiltersToParams } from '$lib/companyFilters';
+import { PAGE_SIZE, pageOffset, parsePage } from '$lib/pagination';
 import type { PageServerLoad } from './$types';
 
-const LIMIT = 20;
-
-// Server-render the first page of companies for the current filters (the ?q search
-// plus the sidebar facets), so a shared/deep-linked filtered URL renders filtered
-// in the initial HTML. Round-tripping through companyFilters whitelists the params
-// to the known facets. The debounced search and "load more" then run client-side.
+// Server-render the requested page of companies for the current filters (the ?q
+// search plus the sidebar facets), so a shared/deep-linked filtered URL renders
+// filtered in the initial HTML. Round-tripping through companyFilters whitelists
+// the params to the known facets; the debounced search then runs client-side.
+//
+// `?page=N` addresses the list rather than filtering it, so it is read here and
+// never forwarded as a facet. `parsePage` folds every malformed or out-of-range
+// value to 1 — this URL is hand-edited and crawled, and a bad one has to mean the
+// first page rather than a negative offset. Mirrors the job feed's own `load`.
 export const load: PageServerLoad = async ({ url, fetch }) => {
   const facets = companyFiltersToParams(companyFiltersFromParams(url.searchParams));
-  const initial = await serverApi(fetch).listCompanies('', LIMIT, 0, facets);
-  return { initial };
+  const pageNumber = parsePage(url.searchParams);
+  const initial = await serverApi(fetch).listCompanies('', PAGE_SIZE, pageOffset(pageNumber), facets);
+  return { initial, pageNumber };
 };

--- a/web/src/routes/companies/+page.server.ts
+++ b/web/src/routes/companies/+page.server.ts
@@ -9,9 +9,9 @@ import type { PageServerLoad } from './$types';
 // the params to the known facets; the debounced search then runs client-side.
 //
 // `?page=N` addresses the list rather than filtering it, so it is read here and
-// never forwarded as a facet. `parsePage` folds every malformed or out-of-range
-// value to 1 — this URL is hand-edited and crawled, and a bad one has to mean the
-// first page rather than a negative offset. Mirrors the job feed's own `load`.
+// never reaches the facets. `parsePage` folds every malformed or out-of-range value
+// to 1: this URL is hand-edited and crawled, and a bad one has to mean the first
+// page rather than a negative offset. Mirrors the job feed's own `load`.
 export const load: PageServerLoad = async ({ url, fetch }) => {
   const facets = companyFiltersToParams(companyFiltersFromParams(url.searchParams));
   const pageNumber = parsePage(url.searchParams);

--- a/web/src/routes/companies/+page.svelte
+++ b/web/src/routes/companies/+page.svelte
@@ -48,5 +48,5 @@
        hidden: the list and filters make the page's purpose clear, so the on-screen
        title was redundant. sr-only takes no layout space. Mirrors /jobs. -->
   <h1 class="sr-only">Companies hiring in tech</h1>
-  <CompaniesView initial={data.initial} />
+  <CompaniesView initial={data.initial} currentPage={data.pageNumber} />
 </div>


### PR DESCRIPTION
## The report

> когда список вакансий прогружается футер все время уезжает вниз и его не посмотреть… а посмотреть футер хочется, потому что там видимо инфа как пользоваться сервисом, например, если я работодатель

Exactly right. Both listings auto-loaded the next page on reaching the bottom, so the page grew every time you approached the end of it and the footer moved down with it. Everything under the feed was unreachable by scrolling — including `/for-companies`, which is where someone who is hiring goes to find out what this is.

## What I found

The page links were already under the feed. They were built for crawlers — `Pagination.svelte` says so in its own comment — and it turns out they did not work for a visitor:

1. **Following one changed the URL and not the list.** SvelteKit reuses the component across `?page=N` rather than remounting it, so `initial` and `currentPage` arrived again while the state seeded from them did not. `?page=4` in the address bar, page 3 on screen.
2. **`/companies` ignored `?page=N` entirely** — no paginator, no page in its `load`. Removing auto-load there without building one would have capped the company list at twenty rows.
3. **`/companies?page=3` snapped back to page 1 on hydration.** CompaniesView lacked the guard JobsView already had: "the filters object changed" is not "the visitor searched for something else" — the store re-seeds on navigation and rewrites the URL, and both fire the reload effect with unchanged filters.

## What changed

- Auto-load removed from the job feed and the company list; page links are the way through.
- `/companies` got a real paginator: `?page=N` in its `load`, `<Pagination>` under the list.
- Both views re-seed from the `initial` the route just loaded when `currentPage` changes — no fetch, the server already searched for that page.
- `currentPage` is now **required** on `JobsView`/`CompaniesView`. A route that mounts a listing without honouring `?page=N` would render a nav whose every link returns to the current page; required makes that a type error. It caught `CompanyView` immediately.
- **The inbox keeps its auto-load** — a work queue for signed-in users, not a page anyone scrolls down to read the footer of.

## Verification

Run against the production API (`VITE_API_URL=https://freehire.me`), not fixtures:

| check | `/` | `/companies` | `/companies/amazon` |
|---|---|---|---|
| paginator in SSR HTML | ✅ | ✅ | ✅ |
| `?page=N` serves different rows | ✅ | ✅ | ✅ |
| click a page link → URL + highlight + rows all move | ✅ | ✅ | ✅ |
| browser Back | ✅ | ✅ | — |
| filter change resets to page 1 | ✅ | ✅ | — |

And the original complaint, measured: scrolling to the bottom five times leaves `document.body.scrollHeight` unchanged (6066 → 6066 on `/`, 2915 → 2915 on `/companies`) and the `<footer>` on screen. Before, it grew on every pass.

`pnpm test` 1052 passed · `pnpm run check` 0 errors · eslint clean · design-system ratchets updated (`LoadMore` lost two consumers).

## Noted, not done

The design system has its own unused `Pagination` primitive, separate from `web/src/lib/components/Pagination.svelte` used here. The local one carries the SEO behaviour (`rel=prev/next`, window elision, real `<a href>` in SSR) and is on three routes; reconciling them is its own change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added page-based navigation for companies and jobs listings.
  - Added support for loading and displaying the selected page directly.
  - Filtering now preserves the current page when applicable and resets to page one for new searches.
  - Replaced infinite scrolling and load-more controls with pagination links.

- **Bug Fixes**
  - Improved empty-state handling when a selected page contains no visible jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->