### PR TITLE
fix(sources): backfill blank company for ukg/teamtailor/workday

### DIFF
--- a/cmd/backfill-blank-company/main.go
+++ b/cmd/backfill-blank-company/main.go
@@ -1,0 +1,113 @@
+// Command backfill-blank-company fills jobs.company for postings whose provider sets Company
+// statically per board (sources/<provider>.yml), but landed empty because of a since-fixed
+// ingest bug — e.g. #1699, where ukg.go never set Job.Company at all. Unlike
+// cmd/backfill-company-names (which resolves a REAL name over the network for a squished-slug
+// company), this needs no network call: the correct name already sits in the board file the
+// affected job was ingested from, so this is a pure config-to-database backfill.
+//
+// A re-crawl of a still-live board would have self-healed via UpsertJob's ON CONFLICT, so what
+// survives here is postings that closed or dropped off their board's listing before the ingest
+// fix shipped and were never seen again.
+//
+//	backfill-blank-company [--dry-run]   # needs DATABASE_URL
+//
+// The provider list below is a hand-verified allowlist, not "every non-aggregator source": a
+// provider belongs here only if its adapter sets Job.Company = e.Company UNCONDITIONALLY for
+// every posting on a board (confirmed by reading the adapter). A "hub" adapter that reads the
+// company per posting from the platform itself (e.g. recruitingsolutions, huntflow) must never
+// be added — the board's configured company is not necessarily that posting's real employer,
+// so blindly applying it would introduce wrong data instead of fixing missing data.
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/normalize"
+	"github.com/strelov1/freehire/internal/sources"
+	"github.com/strelov1/freehire/internal/worker"
+)
+
+// staticCompanyProviders is the hand-verified allowlist described in the package doc.
+var staticCompanyProviders = []string{"ukg", "teamtailor", "workday"}
+
+func main() { worker.Main(run) }
+
+func run() int {
+	dryRun := flag.Bool("dry-run", false, "count rows that would be updated, without writing")
+	flag.Parse()
+
+	ctx, _, pool, cleanup, err := worker.Bootstrap(context.Background())
+	if err != nil {
+		log.Printf("database: %v", err)
+		return 1
+	}
+	defer cleanup()
+
+	queries := db.New(pool)
+
+	var boards, updated, enqueued, failed int
+	for _, provider := range staticCompanyProviders {
+		cfg, err := sources.LoadConfig("sources/" + provider + ".yml")
+		if err != nil {
+			log.Printf("load %s: %v", provider, err)
+			failed++
+			continue
+		}
+		for _, e := range cfg.Sources {
+			if e.Company == "" || e.Board == "" {
+				continue // Validate already guarantees this in production; defensive only
+			}
+			pattern := sources.BoardIDPattern(e.Board)
+			boards++
+
+			if *dryRun {
+				n, err := queries.CountBlankCompanyByBoard(ctx, db.CountBlankCompanyByBoardParams{
+					Source:       e.Provider,
+					BoardPattern: pattern,
+				})
+				if err != nil {
+					log.Printf("count %s/%s: %v", e.Provider, e.Board, err)
+					failed++
+					continue
+				}
+				updated += int(n)
+				continue
+			}
+
+			row, err := queries.BackfillBoardCompany(ctx, db.BackfillBoardCompanyParams{
+				Company:      e.Company,
+				CompanySlug:  normalize.Slug(e.Company),
+				Source:       e.Provider,
+				BoardPattern: pattern,
+			})
+			if err != nil {
+				log.Printf("backfill %s/%s: %v", e.Provider, e.Board, err)
+				failed++
+				continue
+			}
+			updated += int(row.UpdatedCount)
+			enqueued += int(row.EnqueuedCount)
+		}
+	}
+
+	if *dryRun {
+		log.Printf("backfill-blank-company dry-run: boards=%d would_update=%d failed=%d", boards, updated, failed)
+		return 0
+	}
+
+	// jobs now carry a real company/company_slug where they had none; the derived catalogue
+	// needs a matching companies row for /companies/<slug> to resolve.
+	if updated > 0 {
+		if err := queries.SyncCompaniesFromJobs(ctx); err != nil {
+			log.Printf("sync companies: %v", err)
+			return 1
+		}
+	}
+
+	log.Printf("backfill-blank-company done: boards=%d updated=%d enqueued_for_search=%d failed=%d",
+		boards, updated, enqueued, failed)
+	return worker.ExitCode(failed, 0)
+}

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -11,6 +11,58 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const backfillBoardCompany = `-- name: BackfillBoardCompany :one
+WITH updated AS (
+    UPDATE jobs
+    SET company             = $1,
+        company_slug        = $2,
+        company_slug_folded = replace($2, '-', ''),
+        updated_at          = now()
+    WHERE source = $3
+      AND company = ''
+      AND external_id LIKE $4
+    RETURNING id, closed_at, COALESCE(posted_at, created_at) AS eff_posted_at
+),
+enqueued AS (
+    INSERT INTO search_outbox (job_id, job_posted_at)
+    SELECT id, eff_posted_at FROM updated WHERE closed_at IS NULL
+    ON CONFLICT (job_id) DO NOTHING
+    RETURNING job_id
+)
+SELECT (SELECT count(*) FROM updated)::bigint AS updated_count,
+       (SELECT count(*) FROM enqueued)::bigint AS enqueued_count
+`
+
+type BackfillBoardCompanyParams struct {
+	Company      string `json:"company"`
+	CompanySlug  string `json:"company_slug"`
+	Source       string `json:"source"`
+	BoardPattern string `json:"board_pattern"`
+}
+
+type BackfillBoardCompanyRow struct {
+	UpdatedCount  int64 `json:"updated_count"`
+	EnqueuedCount int64 `json:"enqueued_count"`
+}
+
+// Fills company/company_slug/company_slug_folded for rows still blank under one board of a
+// provider whose adapter sets Company statically per board (see cmd/backfill-blank-company for
+// which providers qualify and why). board_pattern is sources.BoardIDPattern(board) — the
+// board's external_id namespace, so only this board's rows move. Also enqueues every touched
+// OPEN job into search_outbox, mirroring UpsertJob/EnqueueSearchOutbox's denormalized
+// job_posted_at, since this write bypasses the normal ingest path that would do it inline.
+func (q *Queries) BackfillBoardCompany(ctx context.Context, arg BackfillBoardCompanyParams) (BackfillBoardCompanyRow, error) {
+	row := q.db.QueryRow(ctx, backfillBoardCompany,
+		arg.Company,
+		arg.CompanySlug,
+		arg.Source,
+		arg.BoardPattern,
+	)
+	var i BackfillBoardCompanyRow
+	err := row.Scan(&i.UpdatedCount, &i.EnqueuedCount)
+	return i, err
+}
+
 const backfillCompanySlugFoldedChunk = `-- name: BackfillCompanySlugFoldedChunk :execrows
 UPDATE jobs
 SET company_slug_folded = replace(company_slug, '-', '')
@@ -416,6 +468,25 @@ func (q *Queries) CompanySlugFoldedBackfillBounds(ctx context.Context) (CompanyS
 	var i CompanySlugFoldedBackfillBoundsRow
 	err := row.Scan(&i.MinID, &i.MaxID, &i.Remaining)
 	return i, err
+}
+
+const countBlankCompanyByBoard = `-- name: CountBlankCompanyByBoard :one
+SELECT count(*)::bigint FROM jobs
+WHERE source = $1 AND company = '' AND external_id LIKE $2
+`
+
+type CountBlankCompanyByBoardParams struct {
+	Source       string `json:"source"`
+	BoardPattern string `json:"board_pattern"`
+}
+
+// Read-only companion to BackfillBoardCompany, for --dry-run: how many rows a board's backfill
+// would touch without writing anything.
+func (q *Queries) CountBlankCompanyByBoard(ctx context.Context, arg CountBlankCompanyByBoardParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countBlankCompanyByBoard, arg.Source, arg.BoardPattern)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
 }
 
 const countCatalogueScale = `-- name: CountCatalogueScale :one

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -63,6 +63,13 @@ type Querier interface {
 	// runs before any posting has been cleared out from under the events it is repairing, and
 	// a row whose job_id is already NULL is skipped rather than guessed at.
 	BackfillApplicationEventLinks(ctx context.Context, batchSize int32) (int64, error)
+	// Fills company/company_slug/company_slug_folded for rows still blank under one board of a
+	// provider whose adapter sets Company statically per board (see cmd/backfill-blank-company for
+	// which providers qualify and why). board_pattern is sources.BoardIDPattern(board) — the
+	// board's external_id namespace, so only this board's rows move. Also enqueues every touched
+	// OPEN job into search_outbox, mirroring UpsertJob/EnqueueSearchOutbox's denormalized
+	// job_posted_at, since this write bypasses the normal ingest path that would do it inline.
+	BackfillBoardCompany(ctx context.Context, arg BackfillBoardCompanyParams) (BackfillBoardCompanyRow, error)
 	// Fill jobs.company_slug_folded for one id range. The column is maintained by every
 	// write path (see migrations/0109), but the rows that predate it need this pass.
 	//
@@ -474,6 +481,9 @@ type Querier interface {
 	// Promote a suggested link to a confirmed one: the suggestion becomes job_id with
 	// link_source 'manual'. No-op (0 rows) when there is no pending suggestion.
 	ConfirmEmailLink(ctx context.Context, arg ConfirmEmailLinkParams) (int64, error)
+	// Read-only companion to BackfillBoardCompany, for --dry-run: how many rows a board's backfill
+	// would touch without writing anything.
+	CountBlankCompanyByBoard(ctx context.Context, arg CountBlankCompanyByBoardParams) (int64, error)
 	// How many people a campaign would reach right now. Read before sending: a campaign
 	// is irreversible and goes to everyone, so the number is worth seeing first.
 	CountBroadcastCandidates(ctx context.Context, campaign string) (int64, error)

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -315,6 +315,39 @@ RETURNING sqlc.embed(jobs),
     NOT COALESCE((SELECT existed FROM existing), false) AS inserted,
     ((SELECT old_hash FROM existing) IS DISTINCT FROM sqlc.arg(content_hash)) AS changed;
 
+-- name: BackfillBoardCompany :one
+-- Fills company/company_slug/company_slug_folded for rows still blank under one board of a
+-- provider whose adapter sets Company statically per board (see cmd/backfill-blank-company for
+-- which providers qualify and why). board_pattern is sources.BoardIDPattern(board) — the
+-- board's external_id namespace, so only this board's rows move. Also enqueues every touched
+-- OPEN job into search_outbox, mirroring UpsertJob/EnqueueSearchOutbox's denormalized
+-- job_posted_at, since this write bypasses the normal ingest path that would do it inline.
+WITH updated AS (
+    UPDATE jobs
+    SET company             = sqlc.arg(company),
+        company_slug        = sqlc.arg(company_slug),
+        company_slug_folded = replace(sqlc.arg(company_slug), '-', ''),
+        updated_at          = now()
+    WHERE source = sqlc.arg(source)
+      AND company = ''
+      AND external_id LIKE sqlc.arg(board_pattern)
+    RETURNING id, closed_at, COALESCE(posted_at, created_at) AS eff_posted_at
+),
+enqueued AS (
+    INSERT INTO search_outbox (job_id, job_posted_at)
+    SELECT id, eff_posted_at FROM updated WHERE closed_at IS NULL
+    ON CONFLICT (job_id) DO NOTHING
+    RETURNING job_id
+)
+SELECT (SELECT count(*) FROM updated)::bigint AS updated_count,
+       (SELECT count(*) FROM enqueued)::bigint AS enqueued_count;
+
+-- name: CountBlankCompanyByBoard :one
+-- Read-only companion to BackfillBoardCompany, for --dry-run: how many rows a board's backfill
+-- would touch without writing anything.
+SELECT count(*)::bigint FROM jobs
+WHERE source = sqlc.arg(source) AND company = '' AND external_id LIKE sqlc.arg(board_pattern);
+
 -- name: RefreshUnchangedJob :one
 -- The cheap half of the ingest write path, tried before UpsertJob: a crawl that re-sees a
 -- posting identical to the stored row refreshes its liveness and writes NOTHING else. Matching

--- a/sources/ukg.yml
+++ b/sources/ukg.yml
@@ -6182,8 +6182,6 @@
   board: recruiting.ultipro.com/tel1010tefo/914e6c7a-35d4-4079-865a-b3a7e7758070
 - company: TNAA &amp; TotalMed
   board: recruiting.ultipro.com/tra1015tnaa/2c7b9b40-f63f-4f66-9e04-20b2476fb5a4
-- company: Atlantic Union Bank
-  board: 'recruiting.ultipro.com/uni1046ufmb/d8f90aad-672e-4f0a-bbc1-a17aa8cf1111 '
 - company: Utica National Insurance Group
   board: recruiting.ultipro.com/uti1000umic/0ae8178f-b389-4b3d-aaf4-e68b3756f2c7
 - company: Verdesian Life Sciences


### PR DESCRIPTION
## Summary
- `ukg.go` never set `Job.Company` until #1699; every posting that closed or dropped off its board's listing before that fix shipped is frozen with `company=''` forever (a re-crawl would have self-healed it via `UpsertJob`'s `ON CONFLICT`). `teamtailor` and `workday` carried a couple of the same kind of frozen row.
- Adds `cmd/backfill-blank-company`, a one-off worker that fills these straight from the board file each job was ingested from — no network fetch needed, unlike `cmd/backfill-company-names`'s slug-resolution case. The provider list is a hand-verified allowlist (adapters confirmed to set `Company = e.Company` unconditionally); explicitly does *not* generalize to hub adapters like `recruitingsolutions`/`huntflow`, whose per-posting company can differ from the board's configured name.
- Drops `sources/ukg.yml`'s duplicate Atlantic Union Bank entry with a trailing space baked into the board id — invisible to `dedupeBoards` (which only collapses case, not whitespace) and the source of 148 of the leftover rows.

## Already run in prod
Ran the backfill live on 2026-08-17: 94,451 rows fixed automatically, plus 150 stragglers (the ukg.yml dup + a since-lowercased tenant path) fixed by hand with the identical update shape. `ukg`/`teamtailor`/`workday` are now at 0 blank-company rows (down from 94,601). `companies` re-synced, affected open jobs enqueued into `search_outbox`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...`
- [x] `go run ./cmd/validate-sources sources/` — OK
- [x] `--dry-run` against prod, then live run against prod (see above)
- [ ] `make reindex` (or let the incremental `search_outbox` drain catch it) so the corrected names show up in search facets

🤖 Generated with [Claude Code](https://claude.com/claude-code)