### PR TITLE
fix(sources): resolve 63 more board-404 entries from issue #1529

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -1,6 +1,8 @@
 # ashby boards. Provider is the filename; each entry is company + board.
 # board = platform-specific id (see internal/sources/ashby.go).
 
+- company: ABC Labs
+  board: reserve
 - company: Adaptive Innovations
   board: adaptive-innovations
 - company: Allegheny Science & Technology
@@ -155,6 +157,10 @@
   board: inspiren
 - company: Investa
   board: investa
+- company: MacroHealth
+  board: macrohealth
+- company: Poetic
+  board: poetic
 - company: Ujwal Inc.
   board: level-ai
 - company: Luma
@@ -461,8 +467,6 @@
   board: dandy
 - company: Dash0
   board: dash0
-- company: Datacurve
-  board: datacurve
 - company: Dataleap
   board: dataleap
 - company: DatologyAI
@@ -595,8 +599,6 @@
   board: Flock
 - company: Fluidstack
   board: fluidstack
-- company: Forge
-  board: forge
 - company: Formance
   board: formance
 - company: Fortuna Health
@@ -2141,8 +2143,6 @@
   board: carwow
 - company: cas
   board: cas
-- company: casap
-  board: casap
 - company: casca
   board: casca
 - company: casdin-capital
@@ -2433,8 +2433,6 @@
   board: delphina
 - company: delphos-labs
   board: delphos-labs
-- company: deltia
-  board: deltia
 - company: demandbase
   board: demandbase
 - company: dentology
@@ -5839,8 +5837,6 @@
   board: b2spin
 - company: brodie rec league
   board: brodie%20rec%20league
-- company: cascade
-  board: cascade
 - company: codex
   board: codex
 - company: doctoralia-brasil

--- a/sources/factorial.yml
+++ b/sources/factorial.yml
@@ -37,6 +37,8 @@
   board: ahembo.factorial.es
 - company: Banca AideXa
   board: aidexa.factorial.it
+- company: Becloser Group
+  board: beclosergroup.factorial.it
 - company: Tecnofast
   board: airfix.factorialhr.com.br
 - company: Akibara Xpress
@@ -893,8 +895,6 @@
   board: unicredix.factorial.mx
 - company: Unimed Dourados
   board: unimeddourados.factorialhr.com.br
-- company: Uniting Group
-  board: uniting.factorial.it
 - company: Universiis
   board: universiis.factorial.it
 - company: Univet
@@ -903,8 +903,6 @@
   board: uniwareunilab.factorialhr.com.br
 - company: UNRWA España
   board: unrwa.factorial.es
-- company: Valeria
-  board: valeria-careers.factorial.es
 - company: Venuu
   board: venuu.factorialhr.com
 - company: Ve.Ra. Group Srl

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -123,8 +123,6 @@
   board: aircapture
 - company: Airtable
   board: airtable
-- company: Aisera
-  board: aiserajobs
 - company: AKQA
   board: akqa
 - company: Alamar Biosciences
@@ -223,8 +221,6 @@
   board: attentionarc
 - company: Attentive
   board: attentive
-- company: Attune
-  board: attune
 - company: Auctane
   board: auctane
 - company: Audax Group
@@ -555,8 +551,6 @@
   board: dataiku
 - company: David AI
   board: david
-- company: dbtlabsinc
-  board: dbtlabsinc
 - company: Decisions
   board: decisions
 - company: Deepmind
@@ -979,8 +973,6 @@
   board: hunterdouglas
 - company: NexGen Cloud
   board: nexgencloud
-- company: IBKR External
-  board: ibkrexternal
 - company: iCapital Network
   board: icapitalnetwork
 - company: ID.me
@@ -1255,8 +1247,6 @@
   board: medicalinformaticsengineering
 - company: MEMIC
   board: memic
-- company: Memphis Meats
-  board: memphismeats
 - company: MEMX
   board: memx
 - company: Mercer Advisors
@@ -1717,8 +1707,6 @@
   board: scoutmotors
 - company: Scout Space
   board: scoutspace
-- company: Seamless.AI
-  board: seamlessai
 - company: Seamount
   board: seamount
 - company: SEO (Sponsors for Educational Opportunity)
@@ -1991,8 +1979,6 @@
   board: trace3
 - company: Trade Republic
   board: traderepublic
-- company: Transcarent
-  board: transcarent
 - company: TransMarket Group
   board: transmarketgroup
 - company: Treasury Prime
@@ -2205,8 +2191,6 @@
   board: yugabyte
 - company: Zenoti
   board: zenoti
-- company: ZENVIA
-  board: zenvia
 - company: Zeta Global
   board: zetaglobal
 - company: zetachain
@@ -2345,8 +2329,6 @@
   board: abarca
 - company: AbCellera
   board: abcellera
-- company: ABC Labs
-  board: abclabs
 - company: ABC Legal Services
   board: abclegalservices
 - company: AbilityPath
@@ -2657,8 +2639,6 @@
   board: ameelio
 - company: AMEND Consulting
   board: amendconsulting
-- company: Amenitiz
-  board: amenitiz
 - company: American Capital Group
   board: americancapitalgroup
 - company: American Flood Coalition
@@ -3029,8 +3009,6 @@
   board: babyzone
 - company: Backblaze External Website
   board: backblaze
-- company: Bain Capital Ventures
-  board: baincapitalventures
 - company: Banco PAN
   board: bancopan
 - company: Banyan Infrastructure Corporation
@@ -3503,8 +3481,6 @@
   board: cardata
 - company: CardFlight
   board: cardflight
-- company: Cardinal Point, Focus Partners Canada
-  board: cardinalpoint
 - company: Care Access
   board: careaccess
 - company: CareDx, Inc.
@@ -3745,8 +3721,6 @@
   board: clevr
 - company: Clickstop
   board: clickstop
-- company: ClimateAi
-  board: climateai
 - company: Climate Cabinet
   board: climatecabinet
 - company: Climate Lead
@@ -3919,8 +3893,6 @@
   board: coreone
 - company: CorePilot
   board: corepilot
-- company: Core Scientific
-  board: corescientific
 - company: CoreStory
   board: corestory
 - company: CoreTrust Purchasing Group
@@ -4959,8 +4931,6 @@
   board: gavindebeckerassociates
 - company: Gavin de Becker & Associates (Website)
   board: gavindebeckerassociatesindeed
-- company: Gelfand, Rennert & Feldman, Focus Partners Business Management
-  board: gelfandrennertfeldman
 - company: GE Mechanical
   board: gemechanicalasp
 - company: GeneDx
@@ -5385,8 +5355,6 @@
   board: hometap
 - company: Homeward
   board: homeward
-- company: Homeward
-  board: homewardhealth
 - company: Hone
   board: hone
 - company: Honeycomb.io
@@ -5747,8 +5715,6 @@
   board: julieproducts
 - company: Jumia
   board: jumia
-- company: JUMO
-  board: jumo
 - company: Jump Trading
   board: jumptrading
 - company: Juno
@@ -6343,8 +6309,6 @@
   board: mechanicallicensingcollective
 - company: Medallion
   board: medallionakafirstlayerai
-- company: Médecins Sans Frontières / Doctors Without Borders Canada
-  board: medecinssansfrontieres
 - company: Medeloop
   board: medeloop
 - company: MediaAlpha
@@ -6413,8 +6377,6 @@
   board: mgac
 - company: MG Properties
   board: mgproperties
-- company: MGT Insurance
-  board: mgtinsurance
 - company: Myers-Holum
   board: mhi
 - company: Microblink
@@ -6849,8 +6811,6 @@
   board: oasissecurity
 - company: On Board Experiential
   board: obexp
-- company: Objectstream
-  board: objectstream
 - company: Obligo
   board: obligo
 - company: O'Brien Veterinary Group
@@ -6929,8 +6889,6 @@
   board: omadahealth
 - company: Ombud
   board: ombud
-- company: Omnicom Media UK
-  board: omguk
 - company: Omicron Media, Inc.
   board: omicron
 - company: Omidyar Network
@@ -7183,8 +7141,6 @@
   board: paradigmtreatmentcenters
 - company: Paragon Insurance Holdings
   board: paragoncareers
-- company: Paragonix Technologies, Inc
-  board: paragonixtechnologies
 - company: Parallel
   board: parallellearning
 - company: Parasail
@@ -7237,8 +7193,6 @@
   board: paypaycard
 - company: PayPay Securities
   board: paypaysec
-- company: Paystack
-  board: paystack
 - company: Paystand
   board: paystand
 - company: Paytient
@@ -7357,8 +7311,6 @@
   board: pineadvisorsolutions
 - company: Pine Bluff Animal Hospital
   board: pinebluff
-- company: Pine Park Health
-  board: pineparkhealth
 - company: TiDB
   board: pingcap
 - company: Pinnacol Assurance
@@ -8085,8 +8037,6 @@
   board: scoutai
 - company: Scout Motors Talent Community
   board: scoutmotorstalentcommunity
-- company: SCS Financial
-  board: scsfinancial
 - company: Kimpton Seafire Resort & Spa | Hotel Indigo Grand Cayman
   board: seafireresortltd
 - company: Seaport Therapeutics
@@ -8121,16 +8071,12 @@
   board: selffinancial
 - company: Selini Capital
   board: selinicapital
-- company: Selkirk Sport
-  board: selkirksport
 - company: Semafor
   board: semafor
 - company: 'Sail Biomedicines '
   board: sendabiosciences
 - company: Sendbird
   board: sendbird
-- company: Senior Doc
-  board: seniordoc
 - company: Senra Systems
   board: senrasystems
 - company: Sensei Wellness Holdings Inc.,
@@ -8811,8 +8757,6 @@
   board: terremotobiosciencesinc
 - company: Territorial Dental Clinic
   board: territorialdentalclinic
-- company: identifeye HEALTH Inc.
-  board: tesseract
 - company: Tessera Therapeutics
   board: tesseratherapeutics
 - company: ACT Group
@@ -8925,8 +8869,6 @@
   board: thirdpoleinc
 - company: Third Wave Automation
   board: thirdwaveautomation
-- company: Remedy Meds
-  board: thirtymadison
 - company: 'The Humane League '
   board: thltestcareers
 - company: Thoropass
@@ -9165,8 +9107,6 @@
   board: unitedmedia
 - company: Unite Us
   board: uniteus
-- company: Unity Technologies
-  board: unity3d
 - company: Universal Audio
   board: universalaudio
 - company: Universal DX
@@ -9253,8 +9193,6 @@
   board: vecnyc
 - company: Vectra
   board: vectranetworks
-- company: VEED.IO
-  board: veedio
 - company: VEGA Americas
   board: vegaamericas
 - company: VEIR
@@ -9349,8 +9287,6 @@
   board: visia
 - company: Visiting Media
   board: visitingmedia
-- company: Vita Health
-  board: vitahealth
 - company: Vital Farms
   board: vitalfarms
 - company: Vital Farms - Current Crew Members
@@ -9760,8 +9696,6 @@
   board: bathworksmichigan
 - company: J-Bear Child Development Center
   board: jbearcdc
-- company: ReBath
-  board: rebathcorporate
 - company: Marketech International Corporation USA
   board: marketechinternationalcorporationusa
 - company: All Four Seasons Garage
@@ -10325,8 +10259,6 @@
   board: maxwell
 - company: Media Arts Lab
   board: mediaartslab
-- company: Mercury Z
-  board: mercuryz
 - company: Method Communications
   board: methodcommunications
 - company: Metro East JV
@@ -10337,8 +10269,6 @@
   board: missionhealthcare
 - company: MLB Network
   board: mlbnetwork
-- company: Mid-Ohio Air Conditioning
-  board: moa
 - company: Model Corp
   board: modelcorp
 - company: Money Mart
@@ -10359,8 +10289,6 @@
   board: myfavoritetherapists
 - company: Team Konovo
   board: naukri
-- company: 'NorthCoast Asset Management '
-  board: nc
 - company: Netcraft
   board: netcraft
 - company: 'capSpire - Netherlands '
@@ -10469,8 +10397,6 @@
   board: purplestrategies
 - company: Quality Trusted Commercial
   board: qt
-- company: Qualogy
-  board: qualogy
 - company: Quantium
   board: quantium
 - company: Quidient
@@ -10683,8 +10609,6 @@
   board: nuitee
 - company: Yondr Group
   board: yondrgroup
-- company: Bolt
-  board: boltv2
 - company: EXANTE
   board: xntltd
 - company: Wargaming
@@ -10813,10 +10737,6 @@
   board: monsterenergylatam
 - company: Nexaminds
   board: nexaminds
-- company: Neysa Networks - Careers Page
-  board: neysanetwork
-- company: Neysa Networks Private Limited - Linkedin
-  board: neysanetworksprivatelimited
 - company: Nicola Wealth
   board: nicolawealth
 - company: N-iX
@@ -11085,8 +11005,6 @@
   board: c4ads
 - company: cabi, LLC
   board: cabiclothing
-- company: Cabot Properties Job Board
-  board: cabotproperties
 - company: Camus Energy
   board: camusenergy
 - company: Cancos Tile & Stone
@@ -11595,8 +11513,6 @@
   board: missionhospicenandhomecare
 - company: 'Mission Road Animal Clinic '
   board: missionroad
-- company: MN Custom Homes
-  board: mncustomhomes
 - company: AAC Midwest
   board: mobileanesthesiologists
 - company: Mochi Medical
@@ -11665,14 +11581,6 @@
   board: oconnellelectric
 - company: Old Second National Bank
   board: oldsecondnationalbank
-- company: Omnicom Media US
-  board: omgus
-- company: Omnicom Media US H&S
-  board: omgushs
-- company: Omnicom Media US OMD
-  board: omgusomd
-- company: Omnicom Media US PHD
-  board: omgusphd
 - company: OMP
   board: ompexternaljobboards
 - company: One Acre Fund- NCE
@@ -12081,8 +11989,6 @@
   board: sgfieldinternal
 - company: SunWorks Landscape Partners
   board: sunworks
-- company: Teleios Collaborative Network
-  board: teleios
 - company: THG Ingenuity
   board: thgingenuity
 - company: USA Mechanical & Energy Services
@@ -13011,8 +12917,6 @@
   board: ludorobotics
 - company: M2X Energy Inc
   board: m2xenergyinc
-- company: MacroHealth
-  board: macrohealth
 - company: Magnitude Capital
   board: magnitudecapital
 - company: Mail & Media (German)
@@ -13887,8 +13791,6 @@
   board: willowbrookvet
 - company: WindWright
   board: windwright
-- company: Win Holding
-  board: winholding
 - company: Wireless Logic
   board: wirelesslogic
 - company: Wisemotion Robotics

--- a/sources/icims.yml
+++ b/sources/icims.yml
@@ -157,8 +157,6 @@
   board: aluminumdynamics
 - company: alumus
   board: alumus
-- company: amanet
-  board: amanet
 - company: americafirst
   board: americafirst
 - company: americanaddictioncenters
@@ -1405,8 +1403,6 @@
   board: group1auto
 - company: groupsrecovertogether
   board: groupsrecovertogether
-- company: gsi
-  board: gsi
 - company: gtsx
   board: gtsx
 - company: guard
@@ -1997,8 +1993,6 @@
   board: magaero
 - company: magnera
   board: magnera
-- company: mahaskahealth
-  board: mahaskahealth
 - company: makingspace
   board: makingspace
 - company: malanai
@@ -2647,8 +2641,6 @@
   board: riyadhair
 - company: rmrgroup
   board: rmrgroup
-- company: roadguard-gsi
-  board: roadguard-gsi
 - company: roadrunnersports
   board: roadrunnersports
 - company: robertgraham

--- a/sources/jobvite.yml
+++ b/sources/jobvite.yml
@@ -12,6 +12,8 @@
   board: actionet-review
 - company: ainsworth
   board: ainsworth
+- company: MN Custom Homes
+  board: mncustom
 - company: nutanix
   board: nutanix
 - company: actionet

--- a/sources/paylocity.yml
+++ b/sources/paylocity.yml
@@ -1,6 +1,8 @@
 # paylocity boards. Provider is the filename; each entry is company + board.
 # board = the company GUID in recruiting.paylocity.com/Recruiting/Jobs/All/<board>
 # (see internal/sources/paylocity.go).
+- company: "Cabot Properties, Inc."
+  board: 7186761b-1318-47f2-b709-d7e7995cd3f3
 - company: Paquin & Carroll Insurance
   board: 0074dae6-e7c6-4b3e-80b7-5006355028a4
 - company: Allan Aircraft Supply

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -17,8 +17,6 @@
   board: crazygames
 - company: Curv Group
   board: curvgroup
-- company: Edelman
-  board: edelman
 - company: Focus Entertainment
   board: focusentertainment
 - company: Focus Home Interactive

--- a/sources/rippling.yml
+++ b/sources/rippling.yml
@@ -19,6 +19,8 @@
   board: kevel-careers
 - company: Klir
   board: klir
+- company: Pine Park Health
+  board: pineparkhealth
 - company: Positron AI
   board: positron
 - company: GoTu
@@ -43,6 +45,10 @@
   board: gaiias-open-positions
 - company: Mytra
   board: mytra
+- company: Seamless.AI
+  board: seamless
+- company: Selkirk Sport
+  board: selkirk-sport
 - company: Thrive Global
   board: thriveglobal
 - company: OneOrigin
@@ -85,6 +91,8 @@
   board: bad-birdie
 - company: The Digital Shelf Institute
   board: the-shelf-careers
+- company: UPSIDE Foods
+  board: upside-group
 - company: Wine Enthusiast
   board: wineenthusiast
 - company: Booster Juice

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -23,6 +23,8 @@
   board: naranjax.na.teamtailor.com
 - company: Opinov8
   board: jobs.opinov8.com
+- company: Paystack
+  board: paystack
 - company: Periferia IT Group
   board: jobs.periferiaitgroup.com
 - company: Product Hackers
@@ -90,6 +92,8 @@
   board: careers.tightlinesoftware.com
 - company: Tried and True Media
   board: triedandtruemedia.na.teamtailor.com
+- company: Valeria HR
+  board: careers.valeriahr.com
 - company: Venoeer
   board: veoneerin.teamtailor.com
 - company: Whitestack

--- a/sources/ukg.yml
+++ b/sources/ukg.yml
@@ -29,6 +29,8 @@
   board: alpla.rec.pro.ukg.net/alp1505apnc/4b4f22b7-1a92-48fc-86e5-8d2d15a4b89e
 - company: ALPLA
   board: alpla.rec.pro.ukg.net/alp1505apnc/9273be85-ad40-4638-932c-9bfc7a015338
+- company: Mahaska Health
+  board: mahaskaukg.rec.pro.ukg.net/MAH1000MAHC/JobBoard/0d34e7b0-f433-4e51-a750-b2785087496d
 - company: Opportunities, Inc.
   board: altstaffing.rec.pro.ukg.net/opp1501oijc/b27f106a-1ecc-43f2-a3f7-5efc6037d59f
 - company: American Textile Maintenance

--- a/sources/workday.yml
+++ b/sources/workday.yml
@@ -5,6 +5,8 @@
 
 - company: Carbon Health
   board: carbonhealth.wd1.myworkdayjobs.com/Careers
+- company: Core Scientific
+  board: corescientific.wd108.myworkdayjobs.com/corescientificcareers
 - company: Equifax
   board: equifax.wd5.myworkdayjobs.com/External
 - company: Fugro
@@ -7541,8 +7543,6 @@
   board: oxy.wd5.myworkdayjobs.com/corporate
 - company: pacbio
   board: pacbio.wd12.myworkdayjobs.com/pacbio-
-- company: pace
-  board: pace.wd1.myworkdayjobs.com/pace
 - company: pacelabs
   board: pacelabs.wd108.myworkdayjobs.com/careers
 - company: pacificlife
@@ -8395,8 +8395,6 @@
   board: scj.wd5.myworkdayjobs.com/external_career_site_lifestyle_brands
 - company: scj
   board: scj.wd5.myworkdayjobs.com/external_career_site_professional
-- company: scm
-  board: scm.wd3.myworkdayjobs.com/scm
 - company: scottsmiraclegro
   board: scottsmiraclegro.wd5.myworkdayjobs.com/smgexternal
 - company: scripps


### PR DESCRIPTION
## What and why

Second live-recheck pass over #1529, continuing from #1946 (which fixed 99 entries the same way). This closes #1529 — remaining unresolved entries move to a new tracking issue.

Live-rechecked every board slug still open in the issue across all providers. For each one still 404ing, looked for the company's verified current home and either moved the entry or deleted it — never guessed. 14 parallel research passes, one per provider chunk, each required a live positive re-fetch of both the old (still-broken) and new (working) board before recording a move.

- **14 moved** to their verified current home (e.g. `memphismeats` → rippling/upside-group under its rebrand UPSIDE Foods, `forge` → ashby/poetic under its rebrand, `paystack` → teamtailor, `mahaskahealth` → UKG).
- **49 deleted**:
  - 25 were stale duplicates of a board this repo already tracks live under a different provider/slug (e.g. all 5 `omg*` Interpublic entries collapse into the existing `Interpublic Group` Workday board; `zenvia` already lives in gupy.yml; `unity3d` already lives in workday.yml).
  - 24 confirmed acquired/shut down, or moved to an ATS this codebase has no adapter for (Dayforce, Darwinbox, ApplicantStack, Consider, Kula.ai, Revolut People, Scalis).

**Not touched, tracked separately:**
- **59 entries** are genuinely unresolved — still 404, no verified live replacement, no solid defunct evidence. Moved to a new tracking issue rather than guessed.
- **35 `ashby` entries** are left as-is: the check endpoint (`api.ashbyhq.com/posting-api/job-board/<slug>`) 404s a plain server-side fetch, but the same slugs have verifiable live postings at `jobs.ashbyhq.com/<slug>` found via search — this looks like anti-bot gating on the check endpoint, not a dead board. Worth a follow-up with a browser-driven checker or an Ashby partner key rather than more YAML changes.
- **2 `personio` entries** (`ibec`, `engelvoelkerspeople`) turned out to be a false alarm with an adapter-level cause: Personio migrated these boards to a newer frontend that no longer serves the legacy `/xml` feed this repo's check (and adapter) reads, but real job data still renders in the board's root HTML. Other personio boards could be silently affected the same way — worth a separate look at the adapter, not a YAML fix.
- Incidentally found a stray dead `Poetic`/`poetic` entry already in `greenhouse.yml`, unrelated to this issue (a different, defunct Greenhouse board for the same company name) — flagging, not fixing here, out of scope.

`go run ./cmd/validate-sources` passes clean on the result.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass — no Go changed, YAML-only.
- [x] `go test ./...` passes (and `go test -tags=integration ./...` if I touched DB/handlers) — N/A, no Go changed.
- [x] I regenerated committed artifacts when their source changed — N/A.
- [ ] For `design-system/` changes — N/A.
- [ ] For `web/` changes — N/A.
- [x] This stays within freehire's core/extension boundary — YAML data only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)