### PR TITLE
Hold /companies to the same paging rules as every other listing

### DIFF
--- a/web/src/lib/pagedRoutes.test.ts
+++ b/web/src/lib/pagedRoutes.test.ts
@@ -1,0 +1,45 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// A listing route that reads `?page=N` must also refuse a page number that
+// addresses nothing.
+//
+// `parsePage` clamps anything malformed or oversized into range rather than
+// failing, which is right for a hand-edited or crawled URL — but it means the
+// pages between the last one holding rows and MAX_PAGE answer 200 with an empty
+// list and a canonical of their own, which Google reads as a soft 404. `pageExists`
+// is the check that turns those into a real 404.
+//
+// This is a source-text audit rather than a behavioural test because the thing it
+// guards is an OMISSION, and an omission has no call site to assert on. It is
+// written the way the bug arrived: `/companies` gained `?page=N` in one PR while
+// the soft-404 rule was being written in another, so the two were consistent on
+// their own and wrong together. Neither PR conflicted, and no test failed.
+const ROUTES = join(import.meta.dirname, '..', 'routes');
+
+function serverLoaders(): string[] {
+  return readdirSync(ROUTES, { recursive: true, encoding: 'utf8' }).filter((f) =>
+    f.endsWith('+page.server.ts')
+  );
+}
+
+describe('paged listing routes', () => {
+  const paged = serverLoaders().filter((f) =>
+    readFileSync(join(ROUTES, f), 'utf8').includes('parsePage(')
+  );
+
+  it('finds the listings that page', () => {
+    // Guards the audit itself: a rename that stops matching would otherwise leave
+    // this suite passing over an empty set, which is the failure mode of every test
+    // that greps.
+    expect(paged.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('refuses a page number past the last page with rows', () => {
+    const unguarded = paged.filter(
+      (f) => !readFileSync(join(ROUTES, f), 'utf8').includes('pageExists(')
+    );
+    expect(unguarded, 'routes reading ?page=N without checking the page exists').toEqual([]);
+  });
+});

--- a/web/src/routes/companies/+page.server.ts
+++ b/web/src/routes/companies/+page.server.ts
@@ -1,6 +1,7 @@
+import { error } from '@sveltejs/kit';
 import { serverApi } from '$lib/server/api';
 import { companyFiltersFromParams, companyFiltersToParams } from '$lib/companyFilters';
-import { PAGE_SIZE, pageOffset, parsePage } from '$lib/pagination';
+import { PAGE_SIZE, pageExists, pageOffset, parsePage } from '$lib/pagination';
 import type { PageServerLoad } from './$types';
 
 // Server-render the requested page of companies for the current filters (the ?q
@@ -16,5 +17,12 @@ export const load: PageServerLoad = async ({ url, fetch }) => {
   const facets = companyFiltersToParams(companyFiltersFromParams(url.searchParams));
   const pageNumber = parsePage(url.searchParams);
   const initial = await serverApi(fetch).listCompanies('', PAGE_SIZE, pageOffset(pageNumber), facets);
+  // Same rule the job feed and the collections hold: past the last page the matches
+  // fill there is no page, only an empty list under a canonical of its own — the
+  // shape Google reads as a soft 404. This listing gained `?page=N` after that rule
+  // was written, so it was the one route accepting a page number without checking
+  // that the number addressed anything. Page 1 always stands: a filter combination
+  // nothing matches renders the list's own empty state, not the site's 404.
+  if (!pageExists(pageNumber, initial.total)) error(404, 'Page not found');
   return { initial, pageNumber };
 };

--- a/web/src/routes/companies/+page.svelte
+++ b/web/src/routes/companies/+page.svelte
@@ -7,15 +7,32 @@
     collectionPageJsonLd,
     companyListItems,
     jsonLdScript,
+    listingRobots,
   } from '$lib/seo';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
 
   const origin = $derived(page.url.origin);
-  const canonical = $derived(`${origin}/companies`);
+  // Each paginated page is canonical to itself. Pointing them all at `/companies`
+  // told Google that pages 2..N were duplicates of page 1, which is the one thing
+  // that makes a paginator pointless: the links exist so the directory is reachable
+  // by crawling, and a canonical back to page 1 discards everything they reach.
+  const canonical = $derived(
+    data.pageNumber > 1 ? `${origin}/companies?page=${data.pageNumber}` : `${origin}/companies`
+  );
   const description =
     'Browse companies hiring in tech, with their current open roles — aggregated by freehire.';
+  // A filter combination nothing matches is a real page that should not be indexed;
+  // `pageExists` already 404s a page number past the end, so this only ever fires on
+  // page 1 of an empty result set.
+  const robots = $derived(listingRobots(data.initial.total));
+  // The page number belongs in the title too: twenty results in, every page carries
+  // the same one otherwise, and a search result reading "Companies · freehire" says
+  // nothing about which twenty. Mirrors the job feed.
+  const title = $derived(
+    data.pageNumber > 1 ? `Companies — page ${data.pageNumber} · freehire` : 'Companies · freehire'
+  );
   // Structured data for the directory: a CollectionPage wrapping the server-rendered
   // first page of companies as an ItemList, plus a breadcrumb (freehire → Companies),
   // mirroring the collection landings. The list follows the active filters, so a
@@ -36,7 +53,7 @@
   );
 </script>
 
-<Seo title="Companies · freehire" {description} {canonical} />
+<Seo title={title} {description} {canonical} {robots} />
 
 <svelte:head>
   <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->


### PR DESCRIPTION
## What happened

Two PRs landed an hour apart and left a gap between them:

- **#2034** gave `/companies` a `?page=N`.
- **#2035** wrote the rule that a page past the last one with rows must `404`, and applied it to the three listings that paged *at the time*.

They touched different files, so nothing conflicted and no test failed. `/companies` came out of the merge as the one route reading a page number without checking the number addressed anything:

| URL | before |
|---|---|
| `/?q=zzzqqqxyz&page=50` | `404` |
| `/collections/ai-companies?page=400` | `404` |
| `/companies/amazon?page=9999` | `404` |
| **`/companies?q=zzzqqqxyz&page=50`** | **`200`, empty list** |

## The canonical, which was worse

Every page of `/companies` declared `/companies` as its canonical:

| URL | canonical before |
|---|---|
| `/?page=3` | `/?page=3` |
| `/companies/amazon?page=3` | `/companies/amazon?page=3` |
| **`/companies?page=3`** | **`/companies`** |

That tells Google pages 2..N are duplicates of page 1 — which makes the paginator pointless. The links exist so the directory is reachable by crawling, and a canonical pointing back at page 1 discards everything they reach.

## Changes

- `pageExists` guard in `companies/+page.server.ts`, the same line the other three carry.
- Self-referencing canonical, and the page number in the `<title>`, mirroring the job feed.
- `noindex, follow` on an empty result set via the same `listingRobots` the company pages use. Page 1 always stands — a listing with nothing in it today is a real landing page that refills tomorrow.

## The test is the point

`pagedRoutes.test.ts` reads every `+page.server.ts`, takes the ones calling `parsePage(`, and fails if any omits `pageExists(`.

A source-text audit rather than a behavioural test, because what it guards is an **omission** — there is no call site to assert on. It is written in the shape the bug arrived in: two changes, each correct alone, inconsistent together, no merge conflict, nothing red. It also asserts it found at least four paged routes, so a rename can't leave it passing over an empty set.

Verified by deleting the guard and watching it fail by name:

```
× refuses a page number past the last page with rows
  routes reading ?page=N without checking the page exists:
  expected [ 'companies/+page.server.ts' ] to deeply equal []
```

## Verification

Against the production API (`VITE_API_URL=https://freehire.me`):

- `/companies?q=zzzqqqxyz&page=50` → `404` (was `200`), matching `/` for the identical URL shape
- `/companies?page=3` → `200`, canonical `/companies?page=3`, title `Companies — page 3 · freehire`
- `/companies?q=zzzqqqxyz` → `200` with `noindex, follow`
- `/companies` → `200`, canonical `/companies`, no robots directive

`pnpm test` 1063 passed · `pnpm run check` 0 errors · eslint clean.