### PR TITLE
Tidy the /companies paging change

### DIFF
--- a/web/src/lib/pagedRoutes.test.ts
+++ b/web/src/lib/pagedRoutes.test.ts
@@ -18,16 +18,11 @@ import { describe, expect, it } from 'vitest';
 // their own and wrong together. Neither PR conflicted, and no test failed.
 const ROUTES = join(import.meta.dirname, '..', 'routes');
 
-function serverLoaders(): string[] {
-  return readdirSync(ROUTES, { recursive: true, encoding: 'utf8' }).filter((f) =>
-    f.endsWith('+page.server.ts')
-  );
-}
-
 describe('paged listing routes', () => {
-  const paged = serverLoaders().filter((f) =>
-    readFileSync(join(ROUTES, f), 'utf8').includes('parsePage(')
-  );
+  const paged = readdirSync(ROUTES, { recursive: true, encoding: 'utf8' })
+    .filter((file) => file.endsWith('+page.server.ts'))
+    .map((file) => ({ file, source: readFileSync(join(ROUTES, file), 'utf8') }))
+    .filter(({ source }) => source.includes('parsePage('));
 
   it('finds the listings that page', () => {
     // Guards the audit itself: a rename that stops matching would otherwise leave
@@ -37,9 +32,9 @@ describe('paged listing routes', () => {
   });
 
   it('refuses a page number past the last page with rows', () => {
-    const unguarded = paged.filter(
-      (f) => !readFileSync(join(ROUTES, f), 'utf8').includes('pageExists(')
-    );
+    const unguarded = paged
+      .filter(({ source }) => !source.includes('pageExists('))
+      .map(({ file }) => file);
     expect(unguarded, 'routes reading ?page=N without checking the page exists').toEqual([]);
   });
 });

--- a/web/src/routes/companies/+page.svelte
+++ b/web/src/routes/companies/+page.svelte
@@ -27,9 +27,8 @@
   // `pageExists` already 404s a page number past the end, so this only ever fires on
   // page 1 of an empty result set.
   const robots = $derived(listingRobots(data.initial.total));
-  // The page number belongs in the title too: twenty results in, every page carries
-  // the same one otherwise, and a search result reading "Companies · freehire" says
-  // nothing about which twenty. Mirrors the job feed.
+  // The number belongs in the title too, or every page advertises itself as the same
+  // one. Mirrors the job feed.
   const title = $derived(
     data.pageNumber > 1 ? `Companies — page ${data.pageNumber} · freehire` : 'Companies · freehire'
   );
@@ -53,7 +52,7 @@
   );
 </script>
 
-<Seo title={title} {description} {canonical} {robots} />
+<Seo {title} {description} {canonical} {robots} />
 
 <svelte:head>
   <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->


### PR DESCRIPTION
Quality pass over #2040. **No behaviour change**, and nothing here reaches a bundle — a Svelte prop shorthand, a comment, and a test-only file. **No deploy needed.**

## Changes

**1. Prop shorthand.** `<Seo title={title} {description} {canonical} {robots} />` — `title` was the one prop on that line not using the shorthand the other three use.

**2. The audit test read every candidate file twice**, once per assertion, repeating the `join`/`readFileSync` expression to do it, behind a helper used exactly once:

```js
// before
function serverLoaders(): string[] { ... }
const paged = serverLoaders().filter((f) => readFileSync(join(ROUTES, f), 'utf8').includes('parsePage('));
// ...and again in the second test
const unguarded = paged.filter((f) => !readFileSync(join(ROUTES, f), 'utf8').includes('pageExists('));

// after — one pass, carrying what it read
const paged = readdirSync(ROUTES, { recursive: true, encoding: 'utf8' })
  .filter((file) => file.endsWith('+page.server.ts'))
  .map((file) => ({ file, source: readFileSync(join(ROUTES, file), 'utf8') }))
  .filter(({ source }) => source.includes('parsePage('));
```

**3. A comment that argued a point nobody disputes** — three lines on why a page number belongs in a `<title>`. The reason it exists fits on one.

## Considered and deliberately not done

- **Extracting `data.pageNumber > 1`** shared by the canonical and title derivations. The job feed's route spells the same two ternaries out; matching the sibling is worth more than saving a line.
- **Reordering the SEO derivations** so `description` doesn't sit between them. Pure diff noise.

## Verification

`pnpm test` 1063 passed · `pnpm run check` 0 errors · eslint clean.

The audit test was re-verified the way it was written — delete the guard from `companies/+page.server.ts` and watch it fail by name:

```
× refuses a page number past the last page with rows
  expected [ 'companies/+page.server.ts' ] to deeply equal []
```

then restored, green again.