### PR TITLE
Rename the design system's Pagination to Pager, after what it is

### DIFF
--- a/design-system/docs/dsds/components.json
+++ b/design-system/docs/dsds/components.json
@@ -593,12 +593,12 @@
       ]
     },
     {
-      "id": "component.pagination",
+      "id": "component.pager",
       "type": "component",
-      "name": "Pagination",
-      "description": "Prev/next pagination with page count and ARIA nav label.",
+      "name": "Pager",
+      "description": "Prev/next stepper over a bound page, in local state only — no URL, no links. A crawlable listing wants the app's own Pagination component instead.",
       "source": {
-        "file": "../../src/pagination.svelte"
+        "file": "../../src/pager.svelte"
       },
       "props": [
         {
@@ -629,7 +629,7 @@
       ],
       "stories": [
         {
-          "file": "../../src/pagination.stories.ts"
+          "file": "../../src/pager.stories.ts"
         }
       ]
     },

--- a/design-system/scripts/adoption-baseline.json
+++ b/design-system/scripts/adoption-baseline.json
@@ -15,7 +15,7 @@
   "LoadMore": 6,
   "NoticeDialog": 0,
   "NumberedGrid": 5,
-  "Pagination": 0,
+  "Pager": 0,
   "ProviderIcon": 8,
   "SectionLabel": 8,
   "SettingRow": 3,

--- a/design-system/src/index.ts
+++ b/design-system/src/index.ts
@@ -21,7 +21,7 @@ export { default as Input } from './input.svelte';
 export { default as LoadMore } from './load-more.svelte';
 export { default as NoticeDialog } from './notice-dialog.svelte';
 export { default as NumberedGrid } from './numbered-grid.svelte';
-export { default as Pagination } from './pagination.svelte';
+export { default as Pager } from './pager.svelte';
 export { default as ProviderIcon } from './provider-icon.svelte';
 export { default as SectionLabel } from './section-label.svelte';
 export { default as SettingRow } from './setting-row.svelte';

--- a/design-system/src/pager.stories.ts
+++ b/design-system/src/pager.stories.ts
@@ -1,11 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
-import Pagination from './pagination.svelte';
+import Pager from './pager.svelte';
 
 const meta = {
-  title: 'Primitives/Pagination',
-  component: Pagination,
+  title: 'Primitives/Pager',
+  component: Pager,
   tags: ['autodocs'],
-} satisfies Meta<typeof Pagination>;
+} satisfies Meta<typeof Pager>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/design-system/src/pager.svelte
+++ b/design-system/src/pager.svelte
@@ -1,4 +1,14 @@
 <script lang="ts">
+  // Prev/Next stepper over a bound `page`, for a list paged in local state:
+  // nothing here touches the URL and there are no links, so the pages it steps
+  // through exist only for as long as the component is mounted.
+  //
+  // NOT the thing a public listing wants. `web/src/lib/components/Pagination.svelte`
+  // is the other shape — real `<a href="?page=N">` in the SSR markup, with window
+  // elision and rel=prev/next — and it exists because a crawler pages by following
+  // links, and a button it cannot press advertises nothing. The two were both called
+  // Pagination, which read as duplication and invited a merge that would have traded
+  // that away; this one is `Pager` now, after what it actually is.
   import type { Snippet } from 'svelte';
   import { cn } from './cn.js';
 

--- a/design-system/src/pager.svelte
+++ b/design-system/src/pager.svelte
@@ -9,6 +9,11 @@
   // links, and a button it cannot press advertises nothing. The two were both called
   // Pagination, which read as duplication and invited a merge that would have traded
   // that away; this one is `Pager` now, after what it actually is.
+  //
+  // Dormant, and unhardened because of it: nothing has ever rendered this, so `perPage`
+  // is taken on trust. A `0` makes `totalPages` Infinity and leaves Next enabled
+  // forever. Guard it — and test the clamp effect at runtime, not only at init —
+  // before the first consumer lands, rather than after it finds out.
   import type { Snippet } from 'svelte';
   import { cn } from './cn.js';
 

--- a/design-system/src/pager.test.ts
+++ b/design-system/src/pager.test.ts
@@ -1,10 +1,10 @@
 import { fireEvent, render } from '@testing-library/svelte';
 import { describe, expect, it } from 'vitest';
-import Pagination from './pagination.svelte';
+import Pager from './pager.svelte';
 import { must } from './test-utils';
 
 function setup(props: { page?: number; total: number; perPage?: number }) {
-  const { container, getByLabelText } = render(Pagination, props);
+  const { container, getByLabelText } = render(Pager, props);
   return {
     label: () => must(must(container.querySelector('span')).textContent).replace(/\s+/g, ' ').trim(),
     prev: getByLabelText('Previous page') as HTMLButtonElement,
@@ -12,7 +12,7 @@ function setup(props: { page?: number; total: number; perPage?: number }) {
   };
 }
 
-describe('Pagination', () => {
+describe('Pager', () => {
   it('counts the pages from the total and the page size', () => {
     expect(setup({ total: 50, perPage: 20 }).label()).toBe('Page 1 of 3');
   });

--- a/web/src/lib/components/Pagination.svelte
+++ b/web/src/lib/components/Pagination.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
   import { pageHref, pageWindow } from '$lib/pagination';
 
-  // Real <a href> page links rendered into the SSR markup, beside the feed's
-  // infinite scroll. The scroll is how a visitor pages; this is how a crawler
-  // does — link discovery happens when HTML is parsed, so without these the only
-  // rows any listing ever advertises are its first twenty.
+  // Real <a href> page links rendered into the SSR markup. This is how BOTH a
+  // visitor and a crawler page a listing: link discovery happens when HTML is
+  // parsed, so without these the only rows any listing ever advertises are its
+  // first twenty. (It used to sit beside a scroll-to-bottom auto-load that was the
+  // visitor's path; that grew the page endlessly and put the footer out of reach,
+  // so these links are now the only way through.)
+  //
+  // Deliberately NOT `Pager` from the design system, which steps a bound `page` in
+  // local state with buttons. Nothing there reaches the URL, so a shared link opens
+  // page one and a crawler sees twenty rows — which is the whole reason this file
+  // exists separately rather than reusing the primitive.
   //
   // Not hidden from visitors: a hidden link a crawler is meant to follow is the
   // shape of cloaking, and this doubles as the keyboard/no-JS way through the


### PR DESCRIPTION
## The finding

Two components were called `Pagination`. They are **not two versions of one thing**:

| | `design-system` | `web/src/lib/components` |
|---|---|---|
| How it pages | Prev/Next buttons over a `$bindable page` | real `<a href="?page=N">` |
| Where state lives | inside the component | in the URL |
| Visible to a crawler | no | yes, in the SSR markup |
| Renders | "Page 3 of 12" | `1 2 3 … 500`, `rel=prev/next`, `aria-current` |
| Consumers | **none**, in web or the extension | four listings |

The shared name read as duplication, and the obvious next move on duplication is to merge — which here means trading crawlable links for buttons a crawler cannot press, on the four routes that depend on them.

I put *"reconciling them is its own change"* in #2040's description. That was wrong. There is nothing to reconcile — only a name that misdescribes one of them.

## What changed

- The primitive is `Pager`: file, export, test, story, and its DSDS docs entry.
- **Both files now carry a comment naming the other and why they stayed apart**, so the next person to notice the resemblance doesn't repeat my conclusion.
- Adoption baseline records the rename (`"Pagination": 0` → `"Pager": 0`).

**No call site changed.** Nothing imported the old export — the baseline had it at 0 consumers — and the app's own `Pagination.svelte` is imported by relative path, never from `$lib/ui`.

`aria-label="Pagination"` inside it stays: that is what a screen reader announces, and "Pager" is our word for the shape, not the user's for the control.

## Kept, not deleted

Four other primitives (`Avatar`, `NoticeDialog`, `Tabs`, `Tooltip`) also sit at 0 consumers, and the baseline records that as a normal state. Removing one of the five would be a policy change wearing a cleanup's clothes.

## Verification

Design system: `pnpm test` 128 passed · `check` 0 errors · `check:tokens` clean · `check:adoption` clean · `build` + `check:dist` clean · **`validate-docs` clean**.

That last one earned its place — the pre-commit hook caught a `docs/dsds/components.json` manifest still pointing at `../../src/pagination.svelte`, which my grep over `src/`, `scripts/` and `*.md` had missed:

```
✗ components.json: entity "component.pagination" points at a missing file
✗ src/: story files no entity claims — pager.stories.ts
```

Web: `pnpm test` 1063 passed · `pnpm run check` 0 errors · full production `pnpm build` succeeds against the renamed package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Renamed the design-system component from **Pagination** to **Pager**.
  - Updated its public export, documentation, catalog, and Storybook presentation.
  - Clarified that the Pager provides local-state step navigation, while visitor-facing pagination uses server-rendered links.

- **Documentation**
  - Added guidance distinguishing Pager controls from public pagination and infinite scrolling.

- **Tests**
  - Updated component tests to use the new Pager name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->