### PR TITLE
SEO: a heading for the API reference, and collection links from every page

### DIFF
--- a/openspec/specs/web-ssr-seo/spec.md
+++ b/openspec/specs/web-ssr-seo/spec.md
@@ -247,7 +247,7 @@ collection landing page SHALL be enumerated in the sitemap.
 
 ### Requirement: Public list pages carry a primary heading
 
-The public list pages (`/jobs` and `/companies`) SHALL each render exactly one visible `<h1>` describing the page's content, so the primary heading is present for search engines and assistive technology.
+The public list pages (`/jobs` and `/companies`) SHALL each render exactly one visible `<h1>` describing the page's content, so the primary heading is present for search engines and assistive technology. Every API-reference endpoint page (`/docs/api/:group/:endpoint`) SHALL likewise carry one, taken from the endpoint's summary — the method and path are the identifier and already carry the `<title>`, while the summary is what the page is about.
 
 #### Scenario: The jobs list has a top-level heading
 
@@ -302,3 +302,26 @@ company.
 - **WHEN** `GET /companies/:slug` is requested for a company whose job search
   returns results
 - **THEN** the `<head>` contains no `robots` meta tag
+
+#### Scenario: An API endpoint page has a top-level heading
+
+- **WHEN** `GET /docs/api/:group/:endpoint` is requested for a documented endpoint
+- **THEN** the returned HTML body contains exactly one `<h1>`, holding that
+  endpoint's summary
+
+### Requirement: Collection landing pages are linked from every page
+
+The site footer SHALL render the popular collections as real `<a href>` anchors to
+their `/collections/:slug` landing pages, in the server-rendered HTML. Collection
+landings are the site's programmatic-SEO surface, and their only internal links came
+from the `/collections` hub and the job-detail "see also" block — the homepage, the
+strongest page on the domain, linked twenty jobs, four feature pages and no
+collection at all. Every slug SHALL resolve through the same resolver the landing
+route and the sitemap use, and an unresolvable slug SHALL be dropped rather than
+linked: a footer is the worst place to advertise a 404.
+
+#### Scenario: Any page links the popular collections
+
+- **WHEN** any public page is requested
+- **THEN** its HTML contains `<a href>` anchors to several distinct
+  `/collections/:slug` landing pages

--- a/web/src/lib/collections.test.ts
+++ b/web/src/lib/collections.test.ts
@@ -5,6 +5,7 @@ import {
   collectionBySlug,
   collectionSlugs,
   jobFacetsFromJob,
+  popularCollectionLinks,
   relatedCollectionLinks,
   relatedCollectionSlugs,
 } from './collections';
@@ -273,5 +274,34 @@ describe('jobFacetsFromJob', () => {
     expect(facets.category).toBeUndefined();
     expect(facets.seniority).toBeUndefined();
     expect(facets.workMode).toBeUndefined();
+  });
+});
+
+describe('popularCollectionLinks', () => {
+  // The gap this closes: the homepage — the site's strongest page — carried 20
+  // /jobs/* links, 4 /features/* and zero links to any individual collection, so
+  // the 101 collection landing pages got nothing from it. Footer links reach every
+  // page, not only the homepage.
+  it('resolves every popular slug to a title and its landing URL', () => {
+    const links = popularCollectionLinks();
+    expect(links.length).toBeGreaterThan(0);
+    for (const link of links) {
+      expect(link.title, `title for "${link.slug}"`).toBeTruthy();
+      expect(link.href).toBe(`/collections/${link.slug}`);
+    }
+  });
+
+  // A link to a page that 404s is worse than no link. collectionBySlug is the same
+  // resolver the landing route and the sitemap use, so this cannot drift from them.
+  it('never emits a slug that has no landing page', () => {
+    for (const link of popularCollectionLinks()) {
+      expect(collectionBySlug(link.slug), `slug "${link.slug}"`).toBeDefined();
+    }
+  });
+
+  it('keeps the curated order and holds no duplicates', () => {
+    const slugs = popularCollectionLinks().map((l) => l.slug);
+    expect(slugs).toEqual(POPULAR_COLLECTION_FALLBACK.filter((s) => collectionBySlug(s)));
+    expect(new Set(slugs).size).toBe(slugs.length);
   });
 });

--- a/web/src/lib/collections.test.ts
+++ b/web/src/lib/collections.test.ts
@@ -282,12 +282,11 @@ describe('popularCollectionLinks', () => {
   // /jobs/* links, 4 /features/* and zero links to any individual collection, so
   // the 101 collection landing pages got nothing from it. Footer links reach every
   // page, not only the homepage.
-  it('resolves every popular slug to a title and its landing URL', () => {
+  it('resolves every popular slug to a title', () => {
     const links = popularCollectionLinks();
     expect(links.length).toBeGreaterThan(0);
     for (const link of links) {
       expect(link.title, `title for "${link.slug}"`).toBeTruthy();
-      expect(link.href).toBe(`/collections/${link.slug}`);
     }
   });
 

--- a/web/src/lib/collections.ts
+++ b/web/src/lib/collections.ts
@@ -715,6 +715,26 @@ export const POPULAR_COLLECTION_FALLBACK = [
   'aws',
 ];
 
+/** The popular collections as footer links, in curated order.
+ *
+ *  Collection landing pages are the site's programmatic-SEO surface, and until this
+ *  existed the only internal links they had came from the /collections hub and the
+ *  job-detail "see also" block. The homepage — the strongest page on the domain —
+ *  linked 20 jobs, 4 feature pages and not one collection. A footer strip fixes that
+ *  for every page at once.
+ *
+ *  Resolved through collectionBySlug, the same resolver the landing route and the
+ *  sitemap use, and unknown slugs are dropped rather than linked: a footer on every
+ *  page is the worst place to advertise a 404. A test also asserts the pool resolves,
+ *  so dropping here is belt-and-braces, not the expected path. */
+export function popularCollectionLinks(): { slug: string; title: string; href: string }[] {
+  return POPULAR_COLLECTION_FALLBACK.flatMap((slug) => {
+    const collection = collectionBySlug(slug);
+    if (!collection) return [];
+    return [{ slug, title: collection.title, href: `/collections/${slug}` }];
+  });
+}
+
 // Whether a single FILTER_COLLECTIONS param entry is satisfied by the job's
 // facets. `role` (and any other key the job carries no data for) never
 // matches — see JobFacets' doc comment.

--- a/web/src/lib/collections.ts
+++ b/web/src/lib/collections.ts
@@ -723,15 +723,19 @@ export const POPULAR_COLLECTION_FALLBACK = [
  *  linked 20 jobs, 4 feature pages and not one collection. A footer strip fixes that
  *  for every page at once.
  *
+ *  Returns the slug and title only, not an href: the caller builds the URL with
+ *  `resolve('/collections/[slug]', …)` like every other dynamic route in the app, so
+ *  the link stays correct under a non-empty `paths.base` and needs no lint exemption.
+ *
  *  Resolved through collectionBySlug, the same resolver the landing route and the
  *  sitemap use, and unknown slugs are dropped rather than linked: a footer on every
  *  page is the worst place to advertise a 404. A test also asserts the pool resolves,
  *  so dropping here is belt-and-braces, not the expected path. */
-export function popularCollectionLinks(): { slug: string; title: string; href: string }[] {
+export function popularCollectionLinks(): { slug: string; title: string }[] {
   return POPULAR_COLLECTION_FALLBACK.flatMap((slug) => {
     const collection = collectionBySlug(slug);
     if (!collection) return [];
-    return [{ slug, title: collection.title, href: `/collections/${slug}` }];
+    return [{ slug, title: collection.title }];
   });
 }
 

--- a/web/src/lib/components/DocsEndpoint.svelte
+++ b/web/src/lib/components/DocsEndpoint.svelte
@@ -68,7 +68,13 @@
     <Badge variant={authVariant(ep.auth)}>{AUTH_LABELS[ep.auth]}</Badge>
   </div>
 
-  <p class="mt-5 text-lg leading-relaxed text-foreground">{ep.summary}</p>
+  <!-- The endpoint's summary IS this page's heading, and it was a <p>: all 140
+       /docs/api/:group/:endpoint pages shipped without an h1, which a crawl flagged
+       and which leaves the page outline headless for assistive technology too. The
+       summary is the right text for it — the method and path are the identifier and
+       already carry the <title>, while "Search open jobs" is what the page is about.
+       Styling is unchanged; only the element is. -->
+  <h1 class="mt-5 text-lg font-normal leading-relaxed text-foreground">{ep.summary}</h1>
   {#if ep.description}
     <!-- eslint-disable-next-line svelte/no-at-html-tags -- inlineCode escapes &<> then wraps static api-spec constants; no user data -->
     <p class="mt-3 leading-relaxed text-muted-foreground">{@html inlineCode(ep.description)}</p>

--- a/web/src/lib/components/Footer.svelte
+++ b/web/src/lib/components/Footer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
+  import { popularCollectionLinks } from '$lib/collections';
   import { reopen } from '$lib/consent.svelte';
   import { ProviderIcon } from '$lib/ui';
 
@@ -61,6 +62,12 @@
     { provider: 'discord', label: 'Discord', href: 'https://discord.gg/aAXS2rghW' },
   ];
 
+  // A strip below the four groups rather than a fifth column: the grid is
+  // sm:grid-cols-4, and ten links would not fit one anyway. Kept out of `groups`
+  // because these are collection landing pages, not site navigation — and because
+  // it is the one place every page links them from (see popularCollectionLinks).
+  const popular = popularCollectionLinks();
+
   const year = new Date().getFullYear();
 
   // Product Hunt "featured" badge. Two embed URLs — one per theme — swapped by the
@@ -102,6 +109,25 @@
         </nav>
       {/each}
     </div>
+
+    <!-- Popular collections. Real <a href> in the server-rendered HTML: crawlers
+         discover links by parsing markup, and these landing pages had none from the
+         homepage at all. -->
+    <nav class="mt-8 border-t border-border pt-6" aria-label="Popular collections">
+      <p class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Popular</p>
+      <ul class="mt-3 flex flex-wrap gap-x-4 gap-y-2">
+        {#each popular as collection (collection.slug)}
+          <li>
+            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- collection landing path built from a slug collectionBySlug already resolved; the linter can't trace it through the array -->
+            <a href={collection.href}
+              class="text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+              {collection.title}
+            </a>
+          </li>
+        {/each}
+      </ul>
+    </nav>
 
     <div class="mt-8">
       <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external Product Hunt page opened in a new tab; not an internal route -->

--- a/web/src/lib/components/Footer.svelte
+++ b/web/src/lib/components/Footer.svelte
@@ -118,8 +118,7 @@
       <ul class="mt-3 flex flex-wrap gap-x-4 gap-y-2">
         {#each popular as collection (collection.slug)}
           <li>
-            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- collection landing path built from a slug collectionBySlug already resolved; the linter can't trace it through the array -->
-            <a href={collection.href}
+            <a href={resolve('/collections/[slug]', { slug: collection.slug })}
               class="text-sm text-muted-foreground transition-colors hover:text-foreground"
             >
               {collection.title}

--- a/web/src/lib/seo.test.ts
+++ b/web/src/lib/seo.test.ts
@@ -593,15 +593,16 @@ describe('listingRobots', () => {
 describe('companiesPageTitle', () => {
   // "Companies · freehire" was 20 characters naming no subject — two thirds of the
   // SERP title width spent on the brand, and nothing a query could match.
+  //
+  // The comma grouping is asserted exactly because the helper pins 'en-US': this is
+  // crawler-visible metadata, so SSR and the client recompute must format the number
+  // identically whatever the visitor's locale. Worth knowing what this does and does
+  // not catch: on a runner whose own locale groups differently it fails the moment the
+  // pin is dropped, but on an en-US runner a bare toLocaleString() reads the same, so
+  // it would pass. Asserting the output rather than spying on the formatter is still
+  // the right trade — the alternative tests the call, not the metadata.
   it('leads with the live count and the subject', () => {
     expect(companiesPageTitle(294_021)).toBe('294,021 companies hiring in tech · freehire');
-  });
-
-  // Pinned locale, like companyPageTitle and collectionHeading: this is
-  // crawler-visible metadata, so SSR and the client recompute must group digits
-  // identically whatever the visitor's browser locale.
-  it('groups digits the same way regardless of locale', () => {
-    expect(companiesPageTitle(1234)).toContain('1,234');
   });
 
   it('singularizes one company', () => {

--- a/web/src/lib/seo.test.ts
+++ b/web/src/lib/seo.test.ts
@@ -6,6 +6,7 @@ import {
   companyListItems,
   companyMetaDescription,
   companyPageTitle,
+  companiesPageTitle,
   datasetJsonLd,
   jobListItems,
   jobPostingJsonLd,
@@ -586,5 +587,31 @@ describe('listingRobots', () => {
   // dropping them would strand whatever they reach.
   it('keeps the page a link source', () => {
     expect(listingRobots(0)).toContain('follow');
+  });
+});
+
+describe('companiesPageTitle', () => {
+  // "Companies · freehire" was 20 characters naming no subject — two thirds of the
+  // SERP title width spent on the brand, and nothing a query could match.
+  it('leads with the live count and the subject', () => {
+    expect(companiesPageTitle(294_021)).toBe('294,021 companies hiring in tech · freehire');
+  });
+
+  // Pinned locale, like companyPageTitle and collectionHeading: this is
+  // crawler-visible metadata, so SSR and the client recompute must group digits
+  // identically whatever the visitor's browser locale.
+  it('groups digits the same way regardless of locale', () => {
+    expect(companiesPageTitle(1234)).toContain('1,234');
+  });
+
+  it('singularizes one company', () => {
+    expect(companiesPageTitle(1)).toBe('1 company hiring in tech · freehire');
+  });
+
+  // A failed or empty search must not advertise "0 companies hiring in tech" — the
+  // directory is still a real page, and the count is the decorative part.
+  it('falls back to the plain subject with no usable count', () => {
+    expect(companiesPageTitle(undefined)).toBe('Companies hiring in tech · freehire');
+    expect(companiesPageTitle(0)).toBe('Companies hiring in tech · freehire');
   });
 });

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -90,6 +90,25 @@ export function companyPageTitle(name: string, total: number | undefined): strin
   return `${name} — ${roles} · ${SITE}`;
 }
 
+/** "<n> companies hiring in tech · freehire" for the /companies directory title.
+ *
+ *  The bare "Companies · freehire" it replaces was 20 characters that named no
+ *  subject: nothing in it could match a query, and most of the SERP title width went
+ *  to the brand. The count is the fact a searcher weighs, and it is the same total
+ *  the page's own heading and its ItemList describe.
+ *
+ *  No count (search failed) or a zero one falls back to the subject alone — the
+ *  directory is a real page when a filter matches nothing, and "0 companies hiring"
+ *  is an argument against clicking. */
+export function companiesPageTitle(total: number | undefined): string {
+  if (!total) return `Companies hiring in tech · ${SITE}`;
+  // Pinned locale, like companyPageTitle: crawler-visible metadata, so SSR and the
+  // client recompute must group digits identically.
+  const count = total.toLocaleString('en-US');
+  const subject = total === 1 ? 'company hiring in tech' : 'companies hiring in tech';
+  return `${count} ${subject} · ${SITE}`;
+}
+
 /** The `<meta name="robots">` a listing page should carry, given how many results
  *  it actually rendered — `undefined` for the normal case of leaving it off.
  *

--- a/web/src/routes/about/+page.svelte
+++ b/web/src/routes/about/+page.svelte
@@ -18,9 +18,11 @@
   );
 </script>
 
+<!-- The description was 215 characters and got cut mid-sentence in the SERP snippet,
+     and where Google cuts is not where we would. Trimmed to ~155, the width it shows. -->
 <Seo
   title="About freehire — the open-source search engine for tech jobs"
-  description="Freehire is an open-source search engine for tech jobs: it indexes millions of openings straight from company career boards, deduplicates them, and tags each with stack, seniority and location. Free and open source."
+  description="An open-source search engine for tech jobs: millions of openings indexed straight from company career boards, deduplicated and tagged by stack and location."
   {canonical}
 />
 

--- a/web/src/routes/companies/+page.svelte
+++ b/web/src/routes/companies/+page.svelte
@@ -5,6 +5,7 @@
   import {
     breadcrumbJsonLd,
     collectionPageJsonLd,
+    companiesPageTitle,
     companyListItems,
     jsonLdScript,
     listingRobots,
@@ -28,9 +29,12 @@
   // page 1 of an empty result set.
   const robots = $derived(listingRobots(data.initial.total));
   // The number belongs in the title too, or every page advertises itself as the same
-  // one. Mirrors the job feed.
+  // one. Mirrors the job feed. Page 1 leads with the live count and the subject —
+  // see companiesPageTitle for why the bare "Companies · freehire" was a waste.
   const title = $derived(
-    data.pageNumber > 1 ? `Companies — page ${data.pageNumber} · freehire` : 'Companies · freehire'
+    data.pageNumber > 1
+      ? `Companies — page ${data.pageNumber} · freehire`
+      : companiesPageTitle(data.initial.total)
   );
   // Structured data for the directory: a CollectionPage wrapping the server-rendered
   // first page of companies as an ItemList, plus a breadcrumb (freehire → Companies),

--- a/web/src/routes/trends/+page.svelte
+++ b/web/src/routes/trends/+page.svelte
@@ -72,7 +72,9 @@
   }
 </script>
 
-<Seo title="Trends · freehire" {description} {canonical} />
+<!-- "Trends · freehire" was 17 characters: it named no subject, so nothing in it
+     could match a query, and it left two thirds of the SERP title width unused. -->
+<Seo title="Tech hiring trends — jobs added and removed daily · freehire" {description} {canonical} />
 
 <svelte:head>
   <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->


### PR DESCRIPTION
The remaining on-page items from the freehire.me audit. Follows #2035.

## The API reference had no heading

All 140 `/docs/api/:group/:endpoint` pages shipped without an `<h1>` — the endpoint's summary was a `<p>`. That summary is the right text for the heading: the method and path are the identifier and already carry the `<title>`, while "Full-text + faceted search over open jobs." is what the page is *about*. Only the element changes; the class list keeps the size it had.

`/docs/api` is the site's fourth-largest landing page by real organic traffic, so this is not a hypothetical.

## Collection landings had no links from the homepage

Collection landings are the programmatic-SEO surface, and their only internal links came from the `/collections` hub and the job-detail see-also block. Parsing every `href` on the homepage:

| Target | Links |
|---|---|
| `/jobs/*` | 20 |
| `/features/*` | 4 |
| `/insights/*` | 1 |
| **`/collections/*`** | **0** |

`popularCollectionLinks()` resolves the existing curated pool through `collectionBySlug` — the same resolver the landing route and the sitemap use — and the footer renders it, which reaches every page rather than only the homepage. Unresolvable slugs are dropped: a footer is the worst place to advertise a 404.

## Titles and descriptions that wasted their width

- `Trends · freehire` — 17 characters naming no subject, so nothing in it could match a query → `Tech hiring trends — jobs added and removed daily · freehire`
- `Companies · freehire` — 20 characters → `companiesPageTitle` leads with the live count, like `companyPageTitle` does for one employer, and falls back to the bare subject on a zero or absent count ("0 companies hiring in tech" is an argument against clicking)
- `/about`'s description was 215 characters and got cut mid-sentence, where Google chose rather than where we would → trimmed to ~155

## A correction to the audit

`/collections` links **all 101** collections, not "101 of 198" as first reported. 198 was the total URL count of `sitemap-pages.xml`, which also holds `/about`, `/companies`, the 79 blog posts and the rest. The hub was never missing any, and there is nothing to fix there.

## Verification

Against the production API with the dev server: one `<h1>` per endpoint page holding its summary; 10 collection anchors on `/`, `/companies` and `/docs/api`; `/companies` titled "148,973 companies hiring in tech · freehire"; `/about`'s description at 156 characters.

\#2035's guards still hold — `remote-latam` is 200 through page 474 and 404 at 475 (9,465 matches, the boundary having moved with the catalogue), `ooo-marta` still `noindex`, `stripe` still not.

Green: `npm test` (1070), `npm run check` (0 errors), oxlint + eslint (0 errors).

## Not in this PR

Core Web Vitals are now measured (local Lighthouse, mobile) and **LCP fails**: 5.3 s on the homepage, 7.8 s on a job page, against a 2.5 s threshold. CLS (0.066 / 0) and TBT (60 / 120 ms) both pass, and the SEO category is 100.

It is not a byte problem and not a blocking-resource problem. Render delay is 91–94% of LCP while every critical resource completes within 805 ms unthrottled, and the mechanism is visible in the HTML: the nonce'd bootstrap does exactly **two** dynamic imports (`start.js`, `app.js`), there are **zero** `<link rel="modulepreload">` or `preload` hints, and 91 JS requests — 71 of them under 3 KiB — are discovered only by recursively parsing those two. On a 150 ms RTT link that serializes into seconds.

I did not determine why SvelteKit emits no `modulepreload` here: there is no `preload` filter in `hooks.server.ts` and no `kit.output` config, so the default should apply. Separately, `logo.freehire.me` serves 512×512 PNGs (one is 200 KB for a thumbnail slot) and ignores every size parameter — that proxy is not in this repo.

Both deserve their own change. And the field impact is unconfirmed: these are *simulated* lab numbers, and settling what real users see needs CrUX or Search Console, neither of which is connected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-rendered “Popular collections” links to the footer, showing only valid collection pages.
  * API reference pages now display endpoint summaries as visible page headings.

* **SEO Improvements**
  * Improved companies page titles with formatted job counts and singular/plural wording.
  * Updated About and Trends page titles and descriptions for clearer search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->