### PR TITLE
Rescue geography from eligibility statements beyond the US

### DIFF
--- a/internal/jobderive/jobderive.go
+++ b/internal/jobderive/jobderive.go
@@ -106,16 +106,19 @@ type Derived struct {
 // and skills (structured ∪ dictionary).
 func Derive(in Input) Derived {
 	geo := location.Parse(in.Location)
-	// Geography precedence: the location dictionary → a US-only description signal.
-	// When the location left the geography unpinned (no country, and either no region
-	// or only the bare-"Remote" global bucket) but the description states a hard
-	// US-only eligibility requirement, the job is US-restricted, not open-anywhere —
-	// pin it to the US so it leaves Global/Worldwide. Like the work-mode fallback
-	// below, prose is the lowest-priority source and only fills what the location
-	// dictionary left blank; a resolved place is never overridden.
+	// Geography precedence: the location dictionary → an eligibility signal in the
+	// description. When the location left the geography unpinned (no country, and
+	// either no region or only the bare-"Remote" global bucket) but the description
+	// states a hard eligibility requirement — US citizenship, EU work rights, a UK
+	// right to work — the job is restricted to that place, not open-anywhere, so pin
+	// it there and let it leave Global/Worldwide. Like the work-mode fallback below,
+	// prose is the lowest-priority source and only fills what the location dictionary
+	// left blank; a resolved place is never overridden.
 	countries, regions := geo.Countries, geo.Regions
-	if usOnly(countries, regions, in.Description) {
-		countries, regions = []string{"us"}, []string{"north_america"}
+	if geoUnpinned(countries, regions) {
+		if c, r := location.EligibilityFromDescription(in.Description); len(r) > 0 {
+			countries, regions = c, r
+		}
 	}
 	// An explicit country signal is authoritative: it fully replaces the derived/US-override
 	// countries, the same way a stated work mode replaces the hint — and pulls its region
@@ -257,20 +260,16 @@ func regionsForCountries(countries []string) []string {
 	return stringset.Sorted(set)
 }
 
-// usOnly reports whether a job's geography is unpinned by the location dictionary —
-// no country resolved, and either no region or only the bare-"Remote" global bucket —
-// while its description carries a hard US-only eligibility signal. It is the gate for
-// the US geography override in Derive: a resolved country or a specific region (e.g.
-// "eu" from "Europe") is left untouched, so the override only rescues the exact case a
-// bare-"Remote" posting with a US-citizenship/clearance requirement falls into.
-func usOnly(countries, regions []string, desc string) bool {
+// geoUnpinned reports whether the location dictionary left a job's geography unpinned —
+// no country resolved, and either no region or only the bare-"Remote" global bucket. It
+// is the gate for the eligibility override in Derive: a resolved country or a specific
+// region (e.g. "eu" from "Europe") is left untouched, so the override only rescues the
+// exact case a bare-"Remote" posting with a stated eligibility requirement falls into.
+func geoUnpinned(countries, regions []string) bool {
 	if len(countries) != 0 {
 		return false
 	}
-	if len(regions) > 1 || (len(regions) == 1 && regions[0] != "global") {
-		return false
-	}
-	return location.USOnlyFromDescription(desc)
+	return len(regions) == 0 || (len(regions) == 1 && regions[0] == "global")
 }
 
 // unionSkills merges the structured source skills with the dictionary skills into a

--- a/internal/location/eligibility.go
+++ b/internal/location/eligibility.go
@@ -1,6 +1,11 @@
 package location
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/stringset"
+)
 
 // usOnlyPhrases are anchored, US-specific eligibility statements that mark a role
 // as restricted to the United States. Like descriptionWorkModePhrases, they are
@@ -11,26 +16,130 @@ import "strings"
 // clearance", "TS/SCI") that other countries' vetting schemes do not use (the UK
 // says "SC"/"DV", not "Secret clearance"), so generic "security clearance" is
 // deliberately excluded to avoid mislabeling a UK/AU role as US.
+// The work-authorization phrasings were the largest gap: "authorized to work in
+// the United States" alone matches ~950 postings catalogue-wide, and in a sampled
+// 53 of them 15 carried no resolved geography at all — exactly the bucket this
+// rescue exists for. They read as requirements, not as the protected-characteristic
+// lists in equal-opportunity boilerplate, which say "citizenship status" without
+// naming a nationality and so cannot match these.
 var usOnlyPhrases = []string{
 	"u.s. citizen", "us citizen", "united states citizen", "citizen of the united states",
 	"u.s. citizenship", "us citizenship",
+	"authorized to work in the united states", "authorised to work in the united states",
+	"authorization to work in the united states",
 	"secret clearance", "ts/sci",
 }
 
-// USOnlyFromDescription reports whether a job description carries a hard US-only
-// eligibility signal (US citizenship or a US security clearance). It reads prose,
-// so it is a lowest-priority geography hint used only to rescue a job the location
-// dictionary could not pin to a country (see jobderive): a bare-"Remote" posting
-// that resolved to the global bucket but requires US citizenship is US-restricted,
-// not open-anywhere. It never guesses — an absent phrase yields false.
+// euOnlyPhrases mark a role as restricted to the European Union. They pin a region
+// and no country, because the restriction genuinely is region-level: a posting open
+// to anyone holding EU work rights is not a posting in one member state, and
+// enumerating 27 countries into the `countries` facet would claim a precision the
+// text does not carry.
+//
+// This list is deliberately short because the catalogue barely uses these phrasings:
+// a full-text sweep put "right to work in the EU" at 45 hits, of which exactly ONE
+// carried the phrase verbatim. EU-restricted postings overwhelmingly state a member
+// state instead, which the location dictionary already pins. Note that "no visa
+// sponsorship" does NOT belong here — it says the employer will not file paperwork,
+// not that only EU nationals may apply, and it has its own `visa_sponsorship` facet.
+var euOnlyPhrases = []string{
+	"right to work in the eu", "right to work in the european union",
+	"eu work authorisation", "eu work authorization",
+	"valid eu work permit",
+}
+
+// ukOnlyPhrases mark a role as restricted to the United Kingdom. This pins a country
+// as well as a region, because the UK is one.
+//
+// "right to work in the UK" is the dominant form (~435 catalogue-wide). A sample of 35
+// verbatim matches named no second area — no "UK or EU" phrasings — so pinning the UK
+// alone does not quietly narrow a posting that was open wider.
+//
+// The UK's own clearance vocabulary ("SC", "DV", "BPSS") is deliberately absent: those
+// are short tokens that collide with ordinary words and unrelated initialisms, and no
+// longer anchoring form of them appeared often enough to earn a place.
+var ukOnlyPhrases = []string{
+	"right to work in the uk", "right to work in the united kingdom",
+	"eligible to work in the uk", "authorised to work in the uk",
+	"british citizen",
+}
+
+// auOnlyPhrases mark a role as restricted to Australia. "Australian citizen" subsumes
+// "Australian citizenship" by substring, so only the shorter form is listed. Australian
+// government and defence contracts drive this: a sample of 44 verbatim matches had 16
+// with no resolved geography, the highest unpinned share of any area measured.
+var auOnlyPhrases = []string{
+	"australian citizen",
+}
+
+// caOnlyPhrases mark a role as restricted to Canada. Both forms are clean in the
+// catalogue — 38 of 38 sampled "eligible to work in Canada" matches carried the phrase
+// verbatim — though few of them are geographically unpinned, so this rule rescues less
+// than the others. It is here because the phrasings are unambiguous, not because the
+// volume is large.
+var caOnlyPhrases = []string{
+	"canadian citizen", "eligible to work in canada",
+}
+
+// eligibilityRule pairs a set of anchored eligibility phrases with the geography an
+// asserted phrase pins a posting to. Countries may be empty where the restriction is
+// genuinely region-level (the EU); regions never are, because every rescue exists to
+// move a posting OUT of the global bucket and a region-less result would not.
+type eligibilityRule struct {
+	countries []string
+	regions   []string
+	phrases   []string
+}
+
+// eligibilityRules is the full set, consulted in order. Order carries no priority —
+// EligibilityFromDescription unions every rule that matches — but a stable list keeps
+// its test table readable.
+var eligibilityRules = []eligibilityRule{
+	{countries: []string{"us"}, regions: []string{"north_america"}, phrases: usOnlyPhrases},
+	{regions: []string{"eu"}, phrases: euOnlyPhrases},
+	{countries: []string{"gb"}, regions: []string{"uk"}, phrases: ukOnlyPhrases},
+	{countries: []string{"au"}, regions: []string{"apac"}, phrases: auOnlyPhrases},
+	{countries: []string{"ca"}, regions: []string{"north_america"}, phrases: caOnlyPhrases},
+}
+
+// EligibilityFromDescription reports the geography a job description's eligibility
+// statements restrict a posting to. It reads prose, so it is a lowest-priority
+// geography hint used only to rescue a job the location dictionary could not pin
+// (see jobderive): a bare-"Remote" posting that resolved to the global bucket but
+// requires US citizenship is US-restricted, not open-anywhere. It never guesses — no
+// asserted phrase yields two empty slices.
+//
+// Matching rules are UNIONED rather than resolved by priority. A posting saying "you
+// must be authorized to work in the US or Canada" is genuinely open to both, and
+// picking one would be a coin flip. Unioning is safe precisely because these are
+// anchored eligibility statements and not place names: prose that merely lists offices
+// in three countries asserts eligibility in none of them.
 //
 // A phrase found in a sentence that also denies it ("does not require US citizenship",
 // "no US citizenship required") is not a match: an unanchored Contains would read the
 // denial as the assertion, which is the opposite mistake this function exists to avoid —
-// the same precision-over-recall rule the phrase list itself follows.
-func USOnlyFromDescription(desc string) bool {
+// the same precision-over-recall rule the phrase lists themselves follow.
+func EligibilityFromDescription(desc string) (countries, regions []string) {
 	lower := strings.ToLower(desc)
-	for _, p := range usOnlyPhrases {
+	countrySet := make(map[string]struct{})
+	regionSet := make(map[string]struct{})
+	for _, rule := range eligibilityRules {
+		if !ruleAsserted(lower, rule) {
+			continue
+		}
+		for _, c := range rule.countries {
+			countrySet[c] = struct{}{}
+		}
+		for _, r := range rule.regions {
+			regionSet[r] = struct{}{}
+		}
+	}
+	return stringset.Sorted(countrySet), stringset.Sorted(regionSet)
+}
+
+// ruleAsserted reports whether any one of a rule's phrases is asserted in lower.
+func ruleAsserted(lower string, rule eligibilityRule) bool {
+	for _, p := range rule.phrases {
 		if phraseAsserted(lower, p) {
 			return true
 		}
@@ -42,6 +151,16 @@ func USOnlyFromDescription(desc string) bool {
 // phrase match, so one long unpunctuated block of text cannot pull an unrelated paragraph's
 // wording into the check.
 const negationWindow = 80
+
+// sponsorshipTail matches "without sponsorship" and its common expansions. "without" is
+// a negation word everywhere else, but in this construction it STRENGTHENS the
+// eligibility requirement rather than denying it — "authorized to work in the US without
+// sponsorship" is more restrictive, not less. The tail is stripped before the negation
+// scan because the dominant US work-authorization phrasing in the catalogue carries it
+// verbatim ("...without the need for current or future sponsorship"), so leaving it in
+// would silently suppress the single highest-volume signal this file has.
+var sponsorshipTail = regexp.MustCompile(
+	`without\s+(?:the\s+need\s+for\s+|any\s+|requiring\s+)?(?:current\s+or\s+future\s+)?(?:visa\s+|employment\s+|immigration\s+)?sponsor\w*`)
 
 // negationWords cancel the eligibility signal a phrase would otherwise assert. Checked as
 // whole words (or, for "n't"/"non-", as a suffix/prefix of one) against the sentence the
@@ -98,9 +217,10 @@ func sentenceAround(lower string, start, end int) string {
 // The check is sentence-wide, not clause-scoped to the phrase: a sentence that negates
 // something else entirely ("Applicants must not have unresolved conflicts and must be a US
 // Citizen") suppresses the match too. That is the safe side of the same precision-over-recall
-// trade this file already makes elsewhere — missing a real US-only signal costs less than
-// mislabeling a globally-open role as US-restricted.
+// trade this file already makes elsewhere — missing a real eligibility signal costs less than
+// mislabeling a globally-open role as restricted.
 func negatedSentence(sentence string) bool {
+	sentence = sponsorshipTail.ReplaceAllString(sentence, " ")
 	for _, word := range strings.Fields(sentence) {
 		word = strings.Trim(word, ".,;:!?()\"'")
 		if negationWords[word] || strings.HasSuffix(word, "n't") || strings.HasPrefix(word, "non-") {

--- a/internal/location/eligibility.go
+++ b/internal/location/eligibility.go
@@ -24,7 +24,7 @@ import (
 // naming a nationality and so cannot match these.
 var usOnlyPhrases = []string{
 	"u.s. citizen", "us citizen", "united states citizen", "citizen of the united states",
-	"u.s. citizenship", "us citizenship",
+	"u.s. citizenship", "us citizenship", "united states citizenship",
 	"authorized to work in the united states", "authorised to work in the united states",
 	"authorization to work in the united states",
 	"secret clearance", "ts/sci",

--- a/internal/location/eligibility.go
+++ b/internal/location/eligibility.go
@@ -61,15 +61,18 @@ var euOnlyPhrases = []string{
 var ukOnlyPhrases = []string{
 	"right to work in the uk", "right to work in the united kingdom",
 	"eligible to work in the uk", "authorised to work in the uk",
-	"british citizen",
+	"british citizen", "british citizenship",
 }
 
-// auOnlyPhrases mark a role as restricted to Australia. "Australian citizen" subsumes
-// "Australian citizenship" by substring, so only the shorter form is listed. Australian
-// government and defence contracts drive this: a sample of 44 verbatim matches had 16
-// with no resolved geography, the highest unpinned share of any area measured.
+// auOnlyPhrases mark a role as restricted to Australia. Australian government and
+// defence contracts drive this: a sample of 44 verbatim matches had 16 with no resolved
+// geography, the highest unpinned share of any area measured.
+//
+// Both noun forms are listed. Matching is whole-word (with a plural "s" allowed), so the
+// shorter entry does NOT reach inside the longer one — that is what stops "uk" matching
+// "Ukraine", and it costs an explicit variant here.
 var auOnlyPhrases = []string{
-	"australian citizen",
+	"australian citizen", "australian citizenship",
 }
 
 // caOnlyPhrases mark a role as restricted to Canada. Both forms are clean in the
@@ -78,7 +81,7 @@ var auOnlyPhrases = []string{
 // than the others. It is here because the phrasings are unambiguous, not because the
 // volume is large.
 var caOnlyPhrases = []string{
-	"canadian citizen", "eligible to work in canada",
+	"canadian citizen", "canadian citizenship", "eligible to work in canada",
 }
 
 // eligibilityRule pairs a set of anchored eligibility phrases with the geography an
@@ -182,11 +185,35 @@ func phraseAsserted(lower, p string) bool {
 		}
 		start := offset + i
 		end := start + len(p)
-		if !negatedSentence(sentenceAround(lower, start, end)) {
+		if wholeWordMatch(lower, start, end) && !negatedSentence(sentenceAround(lower, start, end)) {
 			return true
 		}
 		offset = end
 	}
+}
+
+// wholeWordMatch reports whether lower[start:end] sits on word boundaries, so a phrase
+// cannot match inside a longer word. Without it "right to work in the uk" matches "right
+// to work in the Ukraine" and files a Ukrainian posting under the United Kingdom.
+//
+// A single trailing "s" is allowed, because the plural is how these statements are
+// usually written ("United States citizens", "Australian citizens") and the phrase lists
+// carry the singular. Nothing longer is: "us citizen" must NOT swallow "US citizenship",
+// which is a separate list entry that matches itself exactly.
+func wholeWordMatch(lower string, start, end int) bool {
+	if start > 0 && isWordByte(lower[start-1]) {
+		return false
+	}
+	if end < len(lower) && lower[end] == 's' {
+		end++
+	}
+	return end == len(lower) || !isWordByte(lower[end])
+}
+
+// isWordByte reports whether b continues a word. ASCII-only is enough: every eligibility
+// phrase is ASCII, so only an ASCII neighbour can extend one into a longer word.
+func isWordByte(b byte) bool {
+	return b >= 'a' && b <= 'z' || b >= 'A' && b <= 'Z' || b >= '0' && b <= '9'
 }
 
 // sentenceAround returns the text around lower[start:end], trimmed to the nearest sentence

--- a/internal/location/eligibility_test.go
+++ b/internal/location/eligibility_test.go
@@ -1,47 +1,128 @@
 package location
 
-import "testing"
+import (
+	"slices"
+	"testing"
 
-func TestUSOnlyFromDescription(t *testing.T) {
+	"github.com/strelov1/freehire/internal/vocab"
+)
+
+func TestEligibilityFromDescription(t *testing.T) {
 	tests := []struct {
-		name string
-		desc string
-		want bool
+		name          string
+		desc          string
+		wantCountries []string
+		wantRegions   []string
 	}{
 		// Positives — hard, US-specific eligibility statements.
-		{"citizen and clearance", "Must be a U.S. Citizen and eligible for a U.S. SECRET clearance.", true},
-		{"us citizen", "This role requires a US Citizen.", true},
-		{"united states citizen", "Applicants must be United States citizens.", true},
-		{"us citizenship", "US citizenship is required for this position.", true},
-		{"us citizenship dotted", "U.S. citizenship required.", true},
-		{"secret clearance", "Candidates must hold an active Secret clearance.", true},
-		{"top secret via substring", "An active Top Secret clearance is mandatory.", true},
-		{"ts sci", "Requires a current TS/SCI with polygraph.", true},
+		{"citizen and clearance", "Must be a U.S. Citizen and eligible for a U.S. SECRET clearance.", []string{"us"}, []string{"north_america"}},
+		{"us citizen", "This role requires a US Citizen.", []string{"us"}, []string{"north_america"}},
+		{"united states citizen", "Applicants must be United States citizens.", []string{"us"}, []string{"north_america"}},
+		{"us citizenship", "US citizenship is required for this position.", []string{"us"}, []string{"north_america"}},
+		{"us citizenship dotted", "U.S. citizenship required.", []string{"us"}, []string{"north_america"}},
+		{"secret clearance", "Candidates must hold an active Secret clearance.", []string{"us"}, []string{"north_america"}},
+		{"top secret via substring", "An active Top Secret clearance is mandatory.", []string{"us"}, []string{"north_america"}},
+		{"ts sci", "Requires a current TS/SCI with polygraph.", []string{"us"}, []string{"north_america"}},
 
 		// Trap negatives — incidental tokens that must NOT trigger a match.
-		{"join us", "Join us! We are hiring engineers worldwide.", false},
-		{"corporate citizen", "We strive to be a good corporate citizen.", false},
-		{"global citizen", "We welcome every global citizen to apply.", false},
-		{"trade secret", "You will help protect our trade secrets.", false},
-		{"security engineer", "We are hiring an Application Security Engineer.", false},
-		{"generic security clearance", "A UK SC security clearance is a plus.", false},
-		{"worldwide", "Open to candidates anywhere in the world.", false},
-		{"empty", "", false},
+		{"join us", "Join us! We are hiring engineers worldwide.", nil, nil},
+		{"corporate citizen", "We strive to be a good corporate citizen.", nil, nil},
+		{"global citizen", "We welcome every global citizen to apply.", nil, nil},
+		{"trade secret", "You will help protect our trade secrets.", nil, nil},
+		{"security engineer", "We are hiring an Application Security Engineer.", nil, nil},
+		{"generic security clearance", "A UK SC security clearance is a plus.", nil, nil},
+		{"worldwide", "Open to candidates anywhere in the world.", nil, nil},
+		{"empty", "", nil, nil},
 
 		// Negated mentions — the phrase is present, but the sentence denies it.
-		{"does not require citizenship", "This role does not require US citizenship; applicants worldwide are welcome.", false},
-		{"no clearance required", "No Secret clearance is required for this position.", false},
-		{"non-us citizens welcome", "We welcome non-US citizens to apply for this fully remote role.", false},
-		{"cannot sponsor but no citizenship needed", "We cannot sponsor visas, and US citizenship is not required.", false},
+		{"does not require citizenship", "This role does not require US citizenship; applicants worldwide are welcome.", nil, nil},
+		{"no clearance required", "No Secret clearance is required for this position.", nil, nil},
+		{"non-us citizens welcome", "We welcome non-US citizens to apply for this fully remote role.", nil, nil},
+		{"cannot sponsor but no citizenship needed", "We cannot sponsor visas, and US citizenship is not required.", nil, nil},
 
 		// A denial elsewhere must not hide a genuine assertion in a later sentence.
-		{"negation in an earlier unrelated sentence", "This is not a contractor role. US citizenship is required.", true},
+		{"negation in an earlier unrelated sentence", "This is not a contractor role. US citizenship is required.", []string{"us"}, []string{"north_america"}},
+
+		// Visa sponsorship is not a geography statement — it says the employer will not
+		// file paperwork, not that only locals may apply. It belongs to the
+		// `visa_sponsorship` facet and must never pin a region here.
+		{"no sponsorship is not a restriction", "We are unable to offer visa sponsorship for this role.", nil, nil},
+
+		// Work-authorization phrasings, the largest gap the catalogue sweep found.
+		{"authorized to work in the us", "Candidates must be authorized to work in the United States without sponsorship.", []string{"us"}, []string{"north_america"}},
+		{"legally authorized variant", "Applicants must be legally authorized to work in the United States.", []string{"us"}, []string{"north_america"}},
+		{"authorization noun form", "This role requires authorization to work in the United States.", []string{"us"}, []string{"north_america"}},
+
+		// UK.
+		{"right to work uk", "You must have the right to work in the UK.", []string{"gb"}, []string{"uk"}},
+		{"right to work united kingdom", "Applicants need the right to work in the United Kingdom.", []string{"gb"}, []string{"uk"}},
+		{"british citizen", "This post is open to British citizens only.", []string{"gb"}, []string{"uk"}},
+
+		// EU — region only, deliberately no country.
+		{"right to work eu", "You must have the right to work in the EU.", nil, []string{"eu"}},
+		{"eu work permit", "A valid EU work permit is required.", nil, []string{"eu"}},
+
+		// Australia — "citizen" subsumes "citizenship" by substring.
+		{"australian citizen", "Australian citizens only; NV1 clearance required.", []string{"au"}, []string{"apac"}},
+		{"australian citizenship", "Eligibility: Australian citizenship and a security clearance.", []string{"au"}, []string{"apac"}},
+
+		// Canada.
+		{"eligible to work in canada", "You must be eligible to work in Canada.", []string{"ca"}, []string{"north_america"}},
+
+		// Two areas named together are unioned, not resolved by priority.
+		{"us or canada", "You must be authorized to work in the United States. Canadian citizens are also welcome.", []string{"ca", "us"}, []string{"north_america"}},
+
+		// Equal-opportunity boilerplate names "citizenship" among protected traits but
+		// never a nationality, so it must not pin anything. This exact shape appears
+		// verbatim in production descriptions.
+		{"eeo boilerplate", "We do not discriminate on the basis of religion, sex, national origin, age, citizenship, marital status, or disability.", nil, nil},
+		{"regardless of citizenship", "We welcome applicants regardless of citizenship or background.", nil, nil},
+
+		// "without sponsorship" strengthens the requirement; "without" must not read as a
+		// denial there. The long form is quoted from a real production description.
+		{"without the need for sponsorship", "Candidates must be authorized to work in the United States without the need for current or future sponsorship.", []string{"us"}, []string{"north_america"}},
+		{"without visa sponsorship", "Must be authorized to work in the United States without visa sponsorship.", []string{"us"}, []string{"north_america"}},
+
+		// ...but "without" still denies when it genuinely negates the requirement.
+		{"without still negates elsewhere", "You may join this team without US citizenship.", nil, nil},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := USOnlyFromDescription(tt.desc); got != tt.want {
-				t.Errorf("USOnlyFromDescription(%q) = %v, want %v", tt.desc, got, tt.want)
+			gotCountries, gotRegions := EligibilityFromDescription(tt.desc)
+			if !slices.Equal(gotCountries, tt.wantCountries) {
+				t.Errorf("countries = %v, want %v", gotCountries, tt.wantCountries)
+			}
+			if !slices.Equal(gotRegions, tt.wantRegions) {
+				t.Errorf("regions = %v, want %v", gotRegions, tt.wantRegions)
 			}
 		})
+	}
+}
+
+// TestEligibilityRulesPinARegion guards the one invariant every rule must hold: a rule
+// exists to move a posting OUT of the global bucket, so a rule with phrases but no
+// region would match and change nothing. Countries stay optional — the EU rule is
+// deliberately region-only.
+func TestEligibilityRulesPinARegion(t *testing.T) {
+	for _, rule := range eligibilityRules {
+		if len(rule.phrases) == 0 {
+			continue
+		}
+		if len(rule.regions) == 0 {
+			t.Errorf("rule with phrases %v pins no region", rule.phrases)
+		}
+	}
+}
+
+// TestEligibilityRegionsAreVocabulary keeps the rules honest against the shared region
+// vocabulary: a typo'd region here would produce a facet value nothing can filter on,
+// and the failure would be silent in production.
+func TestEligibilityRegionsAreVocabulary(t *testing.T) {
+	for _, rule := range eligibilityRules {
+		for _, r := range rule.regions {
+			if !slices.Contains(vocab.RegionValues, r) {
+				t.Errorf("rule region %q is not in vocab.RegionValues", r)
+			}
+		}
 	}
 }

--- a/internal/location/eligibility_test.go
+++ b/internal/location/eligibility_test.go
@@ -85,6 +85,16 @@ func TestEligibilityFromDescription(t *testing.T) {
 
 		// ...but "without" still denies when it genuinely negates the requirement.
 		{"without still negates elsewhere", "You may join this team without US citizenship.", nil, nil},
+
+		// Word boundaries. "right to work in the uk" is a prefix of "...in the Ukraine",
+		// and matching inside that word would file a Ukrainian posting under the UK.
+		{"uk does not match ukraine", "You must have the right to work in the Ukraine.", nil, nil},
+		{"uk still matches its own sentence", "You must have the right to work in the UK.", []string{"gb"}, []string{"uk"}},
+
+		// A trailing plural "s" is part of the word and still matches; anything longer
+		// is a different word and does not.
+		{"plural citizens matches", "Open to Australian citizens only.", []string{"au"}, []string{"apac"}},
+		{"citizenship matches its own entry, not the citizen prefix", "US citizenship is required.", []string{"us"}, []string{"north_america"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/location/eligibility_test.go
+++ b/internal/location/eligibility_test.go
@@ -2,6 +2,7 @@ package location
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/strelov1/freehire/internal/vocab"
@@ -62,7 +63,8 @@ func TestEligibilityFromDescription(t *testing.T) {
 		{"right to work eu", "You must have the right to work in the EU.", nil, []string{"eu"}},
 		{"eu work permit", "A valid EU work permit is required.", nil, []string{"eu"}},
 
-		// Australia — "citizen" subsumes "citizenship" by substring.
+		// Australia — both noun forms, since whole-word matching stopped one covering
+		// the other (see TestCitizenPhrasesCarryTheirCitizenshipForm).
 		{"australian citizen", "Australian citizens only; NV1 clearance required.", []string{"au"}, []string{"apac"}},
 		{"australian citizenship", "Eligibility: Australian citizenship and a security clearance.", []string{"au"}, []string{"apac"}},
 
@@ -95,6 +97,7 @@ func TestEligibilityFromDescription(t *testing.T) {
 		// is a different word and does not.
 		{"plural citizens matches", "Open to Australian citizens only.", []string{"au"}, []string{"apac"}},
 		{"citizenship matches its own entry, not the citizen prefix", "US citizenship is required.", []string{"us"}, []string{"north_america"}},
+		{"spelled-out citizenship has its own entry too", "United States citizenship is required.", []string{"us"}, []string{"north_america"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -106,6 +109,25 @@ func TestEligibilityFromDescription(t *testing.T) {
 				t.Errorf("regions = %v, want %v", gotRegions, tt.wantRegions)
 			}
 		})
+	}
+}
+
+// TestCitizenPhrasesCarryTheirCitizenshipForm guards the trap that whole-word matching
+// introduced: "australian citizen" used to cover "Australian citizenship" by substring,
+// and once matching became whole-word every such pair had to be spelled out. The pairs
+// were then added one review finding at a time — "united states citizenship" was missed
+// twice — so the invariant is asserted instead of remembered.
+func TestCitizenPhrasesCarryTheirCitizenshipForm(t *testing.T) {
+	for _, rule := range eligibilityRules {
+		for _, p := range rule.phrases {
+			if !strings.HasSuffix(p, " citizen") {
+				continue
+			}
+			want := p + "ship"
+			if !slices.Contains(rule.phrases, want) {
+				t.Errorf("phrase %q has no %q alongside it; whole-word matching will miss the noun form", p, want)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## What

The description-based geography rescue in `jobderive` only knew US citizenship and
US security clearances. A posting whose location string parsed to nothing but
"Remote", and whose description said "you must have the right to work in the UK",
stayed in the `global` bucket and was served to everyone — the exact mislabelling
the rescue exists to prevent, just under a different flag.

This generalizes the single US predicate into a rule table: each rule pairs anchored
eligibility phrases with the geography they pin. Matching rules are **unioned**
rather than resolved by priority, because a posting open to two areas is genuinely
open to both. The gate is unchanged in spirit — it still only fires where the
location dictionary pinned nothing.

## Phrases came from the live catalogue, not from guesswork

A full-text sweep over production, verifying each hit actually contained the phrase
verbatim and counting how many carried no resolved geography:

| Area | Catalogue hits | Verbatim | Geo-unpinned |
|---|---|---|---|
| `authorized to work in the United States` | ~950 | 53/60 | **15** |
| `australian citizen` | 98 | 44/50 | **16** |
| `right to work in the UK` | 435 | 35/60 | 3 |
| `eligible to work in Canada` | 79 | 38/50 | 1 |
| `right to work in the EU` | 45 | **1**/45 | 0 |

Two findings shaped the result:

- **`authorized to work in the United States` was absent from the US list entirely**,
  despite being the single highest-volume eligibility phrase in the catalogue.
- **The EU list is deliberately thin.** EU-restricted postings overwhelmingly name a
  member state, which the location dictionary already pins.

Brazil, Germany, Singapore, Ireland, India, Mexico, NZ and Japan were measured and
deliberately left out: they have verbatim matches but **zero** geo-unpinned ones, so
a rule for them would only ever fire where the geography is already correct.

## A real bug fixed on the way

`without sponsorship` was suppressing its own signal. `without` is a negation word,
so `"authorized to work in the United States without the need for current or future
sponsorship"` — a phrasing quoted verbatim from production — read as a denial. That
tail *strengthens* an eligibility requirement, so it is now stripped before the
negation scan.

## Verification

- `go test ./...` — pass
- `go vet -tags=integration ./...` — pass
- `gofmt`, `go vet`, `govulncheck`, `golangci-lint` — clean
- Replayed against 437 unpinned production descriptions: 3 rescued (2x AU, 1x US)

## Deploy note

Dictionary changes do not reach stored rows on their own. This needs
`cmd/backfill-derive` followed by `cmd/reindex` after merge. The backfill runs
~15h on production — do not start it on a Friday.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded work-authorization detection to recognize eligibility requirements for the US, EU, UK, Australia, and Canada.
  * Improved handling of combined locations and region-specific eligibility.
* **Bug Fixes**
  * Correctly interprets sponsorship wording and avoids treating valid eligibility statements as negations.
  * Improved detection for unpinned locations without applying an automatic US or North America designation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->