### PR TITLE
fix(sources): repair the dead arbeitsagentur and uber adapters

### DIFF
--- a/internal/sources/arbeitsagentur.go
+++ b/internal/sources/arbeitsagentur.go
@@ -2,38 +2,41 @@ package sources
 
 import (
 	"context"
-	"encoding/json"
+	"encoding/base64"
 	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
-
-	"golang.org/x/net/html"
 )
 
 // arbeitsagentur adapts the Bundesagentur für Arbeit (Germany's federal employment agency) job
 // board. Its jobsuche-service search API is reachable keyless with the well-known public
 // X-API-Key "jobboerse-jobsuche"; postings are enumerated by professional field (berufsfeld),
-// carried as the board file entry's board. The search payload has no description and the detail
-// API is 403, so the description is scraped from the server-rendered public jobdetail page. Most
-// results carry an externeUrl (re-listed from other boards) and are dropped — only the agency's
-// own first-party postings are kept. Multi-company (company per posting), board-based.
+// carried as the board file entry's board. The search payload has no description, so it is
+// fetched from the same service's per-posting jobdetails endpoint (keyed by the base64 of the
+// posting's own referenznummer). Most results carry an externeURL (re-listed from other boards)
+// and are dropped — only the agency's own first-party postings are kept. Multi-company (company
+// per posting), board-based.
 type arbeitsagentur struct {
 	http arbeitsagenturHTTP
 }
 
-// arbeitsagenturHTTP is the two-stage transport: a keyed JSON search and an SSR detail page fetch.
+// arbeitsagenturHTTP is the transport arbeitsagentur needs: a keyed JSON GET, used for both the
+// paginated search and the per-posting detail fetch.
 type arbeitsagenturHTTP interface {
 	GetJSONWithHeaders(ctx context.Context, url string, headers map[string]string, v any) error
-	GetHTML(ctx context.Context, url string) (*html.Node, error)
 }
 
 const (
-	arbeitsagenturSearchURL = "https://rest.arbeitsagentur.de/jobboerse/jobsuche-service/pc/v4/jobs"
-	arbeitsagenturDetailURL = "https://www.arbeitsagentur.de/jobsuche/jobdetail/"
-	arbeitsagenturAPIKey    = "jobboerse-jobsuche"
-	arbeitsagenturPageSize  = 100
+	arbeitsagenturSearchURL = "https://rest.arbeitsagentur.de/jobboerse/jobsuche-service/pc/v6/jobs"
+	// arbeitsagenturDetailAPIURL is the JSON detail endpoint, keyed by base64(referenznummer).
+	arbeitsagenturDetailAPIURL = "https://rest.arbeitsagentur.de/jobboerse/jobsuche-service/pc/v4/jobdetails/"
+	// arbeitsagenturDetailPageURL is the public SSR page a posting's own URL points at — distinct
+	// from arbeitsagenturDetailAPIURL, which this adapter reads instead of scraping that page.
+	arbeitsagenturDetailPageURL = "https://www.arbeitsagentur.de/jobsuche/jobdetail/"
+	arbeitsagenturAPIKey        = "jobboerse-jobsuche"
+	arbeitsagenturPageSize      = 100
 	// arbeitsagenturWithinDays bounds each crawl to a fresh window, keeping the result set well
 	// inside the API's page*size ≈ 10 000 pagination depth cap.
 	arbeitsagenturWithinDays = 7
@@ -41,48 +44,51 @@ const (
 	arbeitsagenturMaxPages = 10000 / arbeitsagenturPageSize
 )
 
-// NewArbeitsagentur builds the Arbeitsagentur adapter over the given two-stage client.
+// NewArbeitsagentur builds the Arbeitsagentur adapter over the given client.
 func NewArbeitsagentur(c arbeitsagenturHTTP) Source { return arbeitsagentur{http: c} }
 
 func (arbeitsagentur) Provider() string { return "arbeitsagentur" }
 
 // arbeitsagenturSearch is one search-API page.
 type arbeitsagenturSearch struct {
-	Stellenangebote []arbeitsagenturPosting `json:"stellenangebote"`
-	MaxErgebnisse   int                     `json:"maxErgebnisse"`
+	Ergebnisliste []arbeitsagenturPosting `json:"ergebnisliste"`
+	MaxErgebnisse int                     `json:"maxErgebnisse"`
 }
 
-// arbeitsagenturPosting is one search result. externeUrl is present when the posting is re-listed
-// from another board; such postings are dropped.
+// arbeitsagenturPosting is one search result. ExterneURL is present when the posting is
+// re-listed from another board; such postings are dropped. Homeofficemoeglich is carried
+// directly on the search result — unlike the description, it needs no detail fetch.
 type arbeitsagenturPosting struct {
-	Refnr       string            `json:"refnr"`
-	Titel       string            `json:"titel"`
-	Arbeitgeber string            `json:"arbeitgeber"`
-	Arbeitsort  arbeitsagenturOrt `json:"arbeitsort"`
-	Datum       string            `json:"aktuelleVeroeffentlichungsdatum"`
-	ExterneURL  string            `json:"externeUrl"`
+	Referenznummer              string                   `json:"referenznummer"`
+	StellenangebotsTitel        string                   `json:"stellenangebotsTitel"`
+	Firma                       string                   `json:"firma"`
+	Stellenlokationen           []arbeitsagenturLokation `json:"stellenlokationen"`
+	DatumErsteVeroeffentlichung string                   `json:"datumErsteVeroeffentlichung"`
+	ExterneURL                  string                   `json:"externeURL"`
+	Homeofficemoeglich          bool                     `json:"homeofficemoeglich"`
 }
 
-type arbeitsagenturOrt struct {
+// arbeitsagenturLokation is one entry of a posting's (possibly multi-site) location list.
+type arbeitsagenturLokation struct {
+	Adresse arbeitsagenturAdresse `json:"adresse"`
+}
+
+type arbeitsagenturAdresse struct {
 	Ort    string `json:"ort"`
 	Region string `json:"region"`
 	Land   string `json:"land"`
 }
 
-// arbeitsagenturDetail decodes the fields the adapter needs out of the jobdetail page's ng-state
-// JSON blob: the description and the per-job home-office flag.
+// arbeitsagenturDetail is the jobdetails endpoint's response — only the field this adapter needs.
 type arbeitsagenturDetail struct {
-	Jobdetail struct {
-		Beschreibung       string `json:"stellenangebotsBeschreibung"`
-		Homeofficemoeglich bool   `json:"homeofficemoeglich"`
-	} `json:"jobdetail"`
+	StellenangebotsBeschreibung string `json:"stellenangebotsBeschreibung"`
 }
 
 // description is the sanitized posting body. The Stellenbeschreibung is plain text (newline
 // paragraphs, no markup), so it goes through plainTextToHTML — as djinni/lumenalta do — to rebuild
 // paragraph structure rather than collapsing into one block when rendered.
 func (d arbeitsagenturDetail) description() string {
-	return sanitizeHTML(plainTextToHTML(d.Jobdetail.Beschreibung))
+	return sanitizeHTML(plainTextToHTML(d.StellenangebotsBeschreibung))
 }
 
 func (a arbeitsagentur) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
@@ -93,12 +99,12 @@ func (a arbeitsagentur) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error
 		if err := a.http.GetJSONWithHeaders(ctx, a.searchURL(e.Board, page), headers, &resp); err != nil {
 			return nil, fmt.Errorf("arbeitsagentur: search board %q page %d: %w", e.Board, page, err)
 		}
-		for _, p := range resp.Stellenangebote {
-			if strings.TrimSpace(p.ExterneURL) == "" && p.Refnr != "" {
+		for _, p := range resp.Ergebnisliste {
+			if strings.TrimSpace(p.ExterneURL) == "" && p.Referenznummer != "" {
 				kept = append(kept, p) // first-party only
 			}
 		}
-		if len(resp.Stellenangebote) < arbeitsagenturPageSize || page*arbeitsagenturPageSize >= resp.MaxErgebnisse {
+		if len(resp.Ergebnisliste) < arbeitsagenturPageSize || page*arbeitsagenturPageSize >= resp.MaxErgebnisse {
 			break
 		}
 	}
@@ -119,43 +125,41 @@ func (arbeitsagentur) searchURL(berufsfeld string, page int) string {
 }
 
 func (a arbeitsagentur) toJob(ctx context.Context, p arbeitsagenturPosting) Job {
-	detailURL := arbeitsagenturDetailURL + p.Refnr
-	d := a.detail(ctx, detailURL)
+	d := a.detail(ctx, p.Referenznummer)
 	return Job{
-		ExternalID:  p.Refnr,
-		URL:         detailURL,
-		Title:       strings.TrimSpace(p.Titel),
-		Company:     strings.TrimSpace(p.Arbeitgeber),
-		Location:    arbeitsagenturLocation(p.Arbeitsort),
+		ExternalID:  p.Referenznummer,
+		URL:         arbeitsagenturDetailPageURL + p.Referenznummer,
+		Title:       strings.TrimSpace(p.StellenangebotsTitel),
+		Company:     strings.TrimSpace(p.Firma),
+		Location:    arbeitsagenturLocation(p.Stellenlokationen),
 		Description: d.description(),
-		Remote:      d.Jobdetail.Homeofficemoeglich,
-		WorkMode:    workModeFromRemote(d.Jobdetail.Homeofficemoeglich),
-		PostedAt:    arbeitsagenturDate(p.Datum),
+		Remote:      p.Homeofficemoeglich,
+		WorkMode:    workModeFromRemote(p.Homeofficemoeglich),
+		PostedAt:    arbeitsagenturDate(p.DatumErsteVeroeffentlichung),
 	}
 }
 
-// detail scrapes and decodes the SSR jobdetail page's ng-state JSON. Any failure (fetch error, no
-// ng-state block, bad JSON) yields the zero detail rather than an error — the posting is still worth
-// emitting, just without a description or the home-office flag.
-func (a arbeitsagentur) detail(ctx context.Context, detailURL string) arbeitsagenturDetail {
-	root, err := a.http.GetHTML(ctx, detailURL)
-	if err != nil {
-		return arbeitsagenturDetail{}
-	}
-	blob := scriptTextByID(root, "ng-state")
-	if blob == "" {
-		return arbeitsagenturDetail{}
-	}
+// detail fetches the posting's description from the jobdetails JSON endpoint, keyed by the
+// base64 of its own referenznummer. Any failure (fetch error, bad JSON) yields the zero detail
+// rather than an error — the posting is still worth emitting, just without a description.
+func (a arbeitsagentur) detail(ctx context.Context, refnr string) arbeitsagenturDetail {
+	headers := map[string]string{"X-API-Key": arbeitsagenturAPIKey}
+	url := arbeitsagenturDetailAPIURL + base64.StdEncoding.EncodeToString([]byte(refnr))
 	var d arbeitsagenturDetail
-	if err := json.Unmarshal([]byte(blob), &d); err != nil {
+	if err := a.http.GetJSONWithHeaders(ctx, url, headers, &d); err != nil {
 		return arbeitsagenturDetail{}
 	}
 	return d
 }
 
-// arbeitsagenturLocation joins the non-empty parts of an arbeitsort, dropping the literal "null"
-// the API emits for absent fields.
-func arbeitsagenturLocation(o arbeitsagenturOrt) string {
+// arbeitsagenturLocation joins the non-empty parts of a posting's first location entry,
+// dropping the literal "null" the API emits for absent fields. A posting may list several
+// sites; only the first is surfaced, matching what the old single-location API exposed.
+func arbeitsagenturLocation(locs []arbeitsagenturLokation) string {
+	if len(locs) == 0 {
+		return ""
+	}
+	o := locs[0].Adresse
 	parts := make([]string, 0, 3)
 	for _, s := range []string{o.Ort, o.Region, o.Land} {
 		if s = strings.TrimSpace(s); s != "" && s != "null" {
@@ -172,31 +176,4 @@ func arbeitsagenturDate(s string) *time.Time {
 		return nil
 	}
 	return &t
-}
-
-// scriptTextByID returns the text of the first <script> element with the given id, or "".
-func scriptTextByID(root *html.Node, id string) string {
-	var found *html.Node
-	var walk func(*html.Node)
-	walk = func(n *html.Node) {
-		if found != nil {
-			return
-		}
-		if n.Type == html.ElementNode && n.Data == "script" {
-			for _, a := range n.Attr {
-				if a.Key == "id" && a.Val == id {
-					found = n
-					return
-				}
-			}
-		}
-		for c := n.FirstChild; c != nil; c = c.NextSibling {
-			walk(c)
-		}
-	}
-	walk(root)
-	if found == nil {
-		return ""
-	}
-	return textContent(found)
 }

--- a/internal/sources/arbeitsagentur.go
+++ b/internal/sources/arbeitsagentur.go
@@ -92,11 +92,10 @@ func (d arbeitsagenturDetail) description() string {
 }
 
 func (a arbeitsagentur) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
-	headers := map[string]string{"X-API-Key": arbeitsagenturAPIKey}
 	var kept []arbeitsagenturPosting
 	for page := 1; page <= arbeitsagenturMaxPages; page++ {
 		var resp arbeitsagenturSearch
-		if err := a.http.GetJSONWithHeaders(ctx, a.searchURL(e.Board, page), headers, &resp); err != nil {
+		if err := a.http.GetJSONWithHeaders(ctx, a.searchURL(e.Board, page), arbeitsagenturHeaders(), &resp); err != nil {
 			return nil, fmt.Errorf("arbeitsagentur: search board %q page %d: %w", e.Board, page, err)
 		}
 		for _, p := range resp.Ergebnisliste {
@@ -143,13 +142,17 @@ func (a arbeitsagentur) toJob(ctx context.Context, p arbeitsagenturPosting) Job 
 // base64 of its own referenznummer. Any failure (fetch error, bad JSON) yields the zero detail
 // rather than an error — the posting is still worth emitting, just without a description.
 func (a arbeitsagentur) detail(ctx context.Context, refnr string) arbeitsagenturDetail {
-	headers := map[string]string{"X-API-Key": arbeitsagenturAPIKey}
 	url := arbeitsagenturDetailAPIURL + base64.StdEncoding.EncodeToString([]byte(refnr))
 	var d arbeitsagenturDetail
-	if err := a.http.GetJSONWithHeaders(ctx, url, headers, &d); err != nil {
+	if err := a.http.GetJSONWithHeaders(ctx, url, arbeitsagenturHeaders(), &d); err != nil {
 		return arbeitsagenturDetail{}
 	}
 	return d
+}
+
+// arbeitsagenturHeaders is the X-API-Key header both the search and detail requests carry.
+func arbeitsagenturHeaders() map[string]string {
+	return map[string]string{"X-API-Key": arbeitsagenturAPIKey}
 }
 
 // arbeitsagenturLocation joins the non-empty parts of a posting's first location entry,

--- a/internal/sources/arbeitsagentur_test.go
+++ b/internal/sources/arbeitsagentur_test.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,22 +11,37 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/html"
 )
 
-// arbeitsagenturFake routes search calls by their page param and detail calls by the refnr in
-// the URL, so a single fake drives both stages (paginated JSON search + per-posting SSR detail).
+// arbeitsagenturFake routes search calls by their page param and detail calls by the base64
+// referenznummer suffix of the URL, so a single fake drives both stages (paginated JSON search +
+// per-posting JSON detail).
 type arbeitsagenturFake struct {
 	searchByPage map[int]string    // page -> search JSON body ("" => empty page)
-	detailByRef  map[string]string // refnr -> detail HTML ("" => no ng-state)
-	detailErr    map[string]bool   // refnr -> GetHTML returns an error
+	detailByRef  map[string]string // refnr -> detail JSON body ("" => empty detail)
+	detailErr    map[string]bool   // refnr -> detail fetch returns an error
 	gotHeaders   map[string]string
 	searchPages  []int // pages requested, in order
 }
 
 func (f *arbeitsagenturFake) GetJSONWithHeaders(_ context.Context, u string, headers map[string]string, v any) error {
 	f.gotHeaders = headers
+	if strings.Contains(u, arbeitsagenturDetailAPIURL) {
+		enc := u[strings.LastIndex(u, "/")+1:]
+		raw, err := base64.StdEncoding.DecodeString(enc)
+		if err != nil {
+			return err
+		}
+		ref := string(raw)
+		if f.detailErr[ref] {
+			return errors.New("detail boom")
+		}
+		body := f.detailByRef[ref]
+		if body == "" {
+			body = `{}`
+		}
+		return json.Unmarshal([]byte(body), v)
+	}
 	page := 1
 	if pu, err := url.Parse(u); err == nil {
 		if p, err := strconv.Atoi(pu.Query().Get("page")); err == nil {
@@ -35,37 +51,28 @@ func (f *arbeitsagenturFake) GetJSONWithHeaders(_ context.Context, u string, hea
 	f.searchPages = append(f.searchPages, page)
 	body := f.searchByPage[page]
 	if body == "" {
-		body = `{"stellenangebote":[],"maxErgebnisse":0}`
+		body = `{"ergebnisliste":[],"maxErgebnisse":0}`
 	}
 	return json.Unmarshal([]byte(body), v)
 }
 
-func (f *arbeitsagenturFake) GetHTML(_ context.Context, u string) (*html.Node, error) {
-	ref := u[strings.LastIndex(u, "/")+1:]
-	if f.detailErr[ref] {
-		return nil, errors.New("detail boom")
-	}
-	return html.Parse(strings.NewReader(f.detailByRef[ref]))
-}
-
-// detailHTML wraps an ng-state script carrying the given description and home-office flag,
-// mirroring the real SSR page.
-func detailHTML(desc string, homeOffice bool) string {
-	return `<html><body><script id="ng-state" type="application/json">{"jobdetail":{"stellenangebotsBeschreibung":` +
-		strconv.Quote(desc) + `,"homeofficemoeglich":` + strconv.FormatBool(homeOffice) + `}}</script></body></html>`
+// arbeitsagenturDetailJSON builds a jobdetails response carrying only the description this adapter reads.
+func arbeitsagenturDetailJSON(desc string) string {
+	b, _ := json.Marshal(map[string]string{"stellenangebotsBeschreibung": desc})
+	return string(b)
 }
 
 func TestArbeitsagenturFetchMapsFirstPartyAndDropsExterne(t *testing.T) {
-	const page1 = `{"maxErgebnisse":2,"stellenangebote":[
-	  {"refnr":"20177-44320844-717-S","titel":"Fachinformatiker*in","arbeitgeber":"Boehringer Ingelheim Pharma GmbH & Co. KG","arbeitsort":{"ort":"Biberach an der Riß","region":"Baden-Württemberg","land":"Deutschland","strasse":"null"},"aktuelleVeroeffentlichungsdatum":"2026-07-18"},
-	  {"refnr":"EXT-1","titel":"Re-listed","arbeitgeber":"Other","arbeitsort":{"ort":"Berlin"},"aktuelleVeroeffentlichungsdatum":"2026-07-10","externeUrl":"https://aubi-plus.de/x"},
-	  {"refnr":"AC-2","titel":"DevOps Engineer","arbeitgeber":"Acme GmbH","arbeitsort":{"ort":"München","region":"Bayern","land":"Deutschland"},"aktuelleVeroeffentlichungsdatum":"2026-07-15"}
+	const page1 = `{"maxErgebnisse":2,"ergebnisliste":[
+	  {"referenznummer":"20177-44320844-717-S","stellenangebotsTitel":"Fachinformatiker*in","firma":"Boehringer Ingelheim Pharma GmbH & Co. KG","stellenlokationen":[{"adresse":{"ort":"Biberach an der Riß","region":"Baden-Württemberg","land":"Deutschland"}}],"datumErsteVeroeffentlichung":"2026-07-18","homeofficemoeglich":true},
+	  {"referenznummer":"EXT-1","stellenangebotsTitel":"Re-listed","firma":"Other","stellenlokationen":[{"adresse":{"ort":"Berlin"}}],"datumErsteVeroeffentlichung":"2026-07-10","externeURL":"https://aubi-plus.de/x"},
+	  {"referenznummer":"AC-2","stellenangebotsTitel":"DevOps Engineer","firma":"Acme GmbH","stellenlokationen":[{"adresse":{"ort":"München","region":"Bayern","land":"Deutschland"}}],"datumErsteVeroeffentlichung":"2026-07-15","homeofficemoeglich":false}
 	]}`
 	fake := &arbeitsagenturFake{
 		searchByPage: map[int]string{1: page1},
 		detailByRef: map[string]string{
-			"20177-44320844-717-S": detailHTML("Bei Boehringer Ingelheim entwickeln wir <b>bahnbrechende</b> Therapien.", true),
-			"AC-2":                 detailHTML("Wir suchen einen DevOps Engineer.", false),
+			"20177-44320844-717-S": arbeitsagenturDetailJSON("Bei Boehringer Ingelheim entwickeln wir bahnbrechende Therapien."),
+			"AC-2":                 arbeitsagenturDetailJSON("Wir suchen einen DevOps Engineer."),
 		},
 	}
 	jobs, err := NewArbeitsagentur(fake).Fetch(context.Background(), CompanyEntry{
@@ -74,12 +81,12 @@ func TestArbeitsagenturFetchMapsFirstPartyAndDropsExterne(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
-	// The externeUrl re-list is dropped; two first-party postings map.
+	// The externeURL re-list is dropped; two first-party postings map.
 	if len(jobs) != 2 {
-		t.Fatalf("len(jobs) = %d, want 2 (externeUrl dropped)", len(jobs))
+		t.Fatalf("len(jobs) = %d, want 2 (externeURL dropped)", len(jobs))
 	}
 	// Header carried the static public key.
-	if fake.gotHeaders["X-API-Key"] != "jobboerse-jobsuche" {
+	if fake.gotHeaders["X-API-Key"] != arbeitsagenturAPIKey {
 		t.Errorf("X-API-Key header = %q", fake.gotHeaders["X-API-Key"])
 	}
 	byID := map[string]Job{}
@@ -102,7 +109,7 @@ func TestArbeitsagenturFetchMapsFirstPartyAndDropsExterne(t *testing.T) {
 	if j.PostedAt == nil || j.PostedAt.Format("2006-01-02") != "2026-07-18" {
 		t.Errorf("PostedAt = %v, want 2026-07-18", j.PostedAt)
 	}
-	// homeofficemoeglich:true → remote; the non-home-office posting stays unset.
+	// homeofficemoeglich:true (carried directly on the search result) → remote.
 	if !j.Remote || j.WorkMode != "remote" {
 		t.Errorf("home-office job: Remote=%v WorkMode=%q, want true/remote", j.Remote, j.WorkMode)
 	}
@@ -112,17 +119,17 @@ func TestArbeitsagenturFetchMapsFirstPartyAndDropsExterne(t *testing.T) {
 }
 
 func TestArbeitsagenturScrapesDescription(t *testing.T) {
-	const page1 = `{"maxErgebnisse":2,"stellenangebote":[
-	  {"refnr":"OK-1","titel":"A","arbeitgeber":"Co","arbeitsort":{"ort":"Berlin"},"aktuelleVeroeffentlichungsdatum":"2026-07-18"},
-	  {"refnr":"NODESC-2","titel":"B","arbeitgeber":"Co","arbeitsort":{"ort":"Berlin"},"aktuelleVeroeffentlichungsdatum":"2026-07-18"},
-	  {"refnr":"ERR-3","titel":"C","arbeitgeber":"Co","arbeitsort":{"ort":"Berlin"},"aktuelleVeroeffentlichungsdatum":"2026-07-18"}
+	const page1 = `{"maxErgebnisse":3,"ergebnisliste":[
+	  {"referenznummer":"OK-1","stellenangebotsTitel":"A","firma":"Co","stellenlokationen":[{"adresse":{"ort":"Berlin"}}],"datumErsteVeroeffentlichung":"2026-07-18"},
+	  {"referenznummer":"NODESC-2","stellenangebotsTitel":"B","firma":"Co","stellenlokationen":[{"adresse":{"ort":"Berlin"}}],"datumErsteVeroeffentlichung":"2026-07-18"},
+	  {"referenznummer":"ERR-3","stellenangebotsTitel":"C","firma":"Co","stellenlokationen":[{"adresse":{"ort":"Berlin"}}],"datumErsteVeroeffentlichung":"2026-07-18"}
 	]}`
 	fake := &arbeitsagenturFake{
 		searchByPage: map[int]string{1: page1},
 		detailByRef: map[string]string{
 			// The real Stellenbeschreibung is plain text with newline paragraphs, no markup.
-			"OK-1":     detailHTML("Bei uns arbeitest du remote.\n\nZweiter Absatz mit Details.", false),
-			"NODESC-2": `<html><body><p>no ng-state here</p></body></html>`,
+			"OK-1": arbeitsagenturDetailJSON("Bei uns arbeitest du remote.\n\nZweiter Absatz mit Details."),
+			// NODESC-2 has no entry, so the fake serves "{}" — an empty description.
 		},
 		detailErr: map[string]bool{"ERR-3": true},
 	}
@@ -130,7 +137,7 @@ func TestArbeitsagenturScrapesDescription(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
-	// A detail error or a page without a description must not drop the posting.
+	// A detail error or an empty description must not drop the posting.
 	if len(jobs) != 3 {
 		t.Fatalf("len(jobs) = %d, want 3 (missing/failed descriptions still emit)", len(jobs))
 	}
@@ -143,14 +150,10 @@ func TestArbeitsagenturScrapesDescription(t *testing.T) {
 		t.Errorf("OK-1 description = %q, want both paragraphs with rebuilt <p> structure", d)
 	}
 	if d := byID["NODESC-2"].Description; d != "" {
-		t.Errorf("NODESC-2 description = %q, want empty (no ng-state block)", d)
+		t.Errorf("NODESC-2 description = %q, want empty (no description in detail response)", d)
 	}
 	if d := byID["ERR-3"].Description; d != "" {
 		t.Errorf("ERR-3 description = %q, want empty (detail fetch failed)", d)
-	}
-	// A failed/blockless detail leaves the remote flag unset.
-	if byID["ERR-3"].Remote || byID["NODESC-2"].Remote {
-		t.Error("postings with no usable detail should not be marked remote")
 	}
 }
 
@@ -177,9 +180,9 @@ func TestArbeitsagenturPaginates(t *testing.T) {
 func arbeitsagenturPage(n, base int) string {
 	items := make([]string, n)
 	for i := range items {
-		items[i] = fmt.Sprintf(`{"refnr":"R-%d","titel":"T","arbeitgeber":"Co","arbeitsort":{"ort":"Berlin"},"aktuelleVeroeffentlichungsdatum":"2026-07-18"}`, base+i)
+		items[i] = fmt.Sprintf(`{"referenznummer":"R-%d","stellenangebotsTitel":"T","firma":"Co","stellenlokationen":[{"adresse":{"ort":"Berlin"}}],"datumErsteVeroeffentlichung":"2026-07-18"}`, base+i)
 	}
-	return `{"maxErgebnisse":100000,"stellenangebote":[` + strings.Join(items, ",") + `]}`
+	return `{"maxErgebnisse":100000,"ergebnisliste":[` + strings.Join(items, ",") + `]}`
 }
 
 func TestArbeitsagenturProviderRegistered(t *testing.T) {

--- a/internal/sources/html.go
+++ b/internal/sources/html.go
@@ -50,24 +50,16 @@ func textContent(n *html.Node) string {
 // scriptTextByID returns the text of the first <script> element with the given id, or "".
 func scriptTextByID(root *html.Node, id string) string {
 	var found *html.Node
-	var walk func(*html.Node)
-	walk = func(n *html.Node) {
+	walk(root, func(n *html.Node) bool {
 		if found != nil {
-			return
+			return false
 		}
-		if n.Type == html.ElementNode && n.Data == "script" {
-			for _, a := range n.Attr {
-				if a.Key == "id" && a.Val == id {
-					found = n
-					return
-				}
-			}
+		if n.Type == html.ElementNode && n.Data == "script" && attr(n, "id") == id {
+			found = n
+			return false
 		}
-		for c := n.FirstChild; c != nil; c = c.NextSibling {
-			walk(c)
-		}
-	}
-	walk(root)
+		return true
+	})
 	if found == nil {
 		return ""
 	}

--- a/internal/sources/html.go
+++ b/internal/sources/html.go
@@ -47,6 +47,33 @@ func textContent(n *html.Node) string {
 	return strings.TrimSpace(b.String())
 }
 
+// scriptTextByID returns the text of the first <script> element with the given id, or "".
+func scriptTextByID(root *html.Node, id string) string {
+	var found *html.Node
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if found != nil {
+			return
+		}
+		if n.Type == html.ElementNode && n.Data == "script" {
+			for _, a := range n.Attr {
+				if a.Key == "id" && a.Val == id {
+					found = n
+					return
+				}
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(root)
+	if found == nil {
+		return ""
+	}
+	return textContent(found)
+}
+
 // innerHTML renders n's children back to HTML markup.
 func innerHTML(n *html.Node) string {
 	var b strings.Builder

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -257,7 +257,6 @@ func All(c HTTPClient) map[string]Source {
 		NewArbeitsagentur(c),
 		// International single-company adapters (boardless).
 		NewTelegramCareers(c),
-		NewUber(c),
 		NewAmazon(c),
 		NewGoogle(c),
 		NewApple(c),
@@ -354,22 +353,25 @@ func All(c HTTPClient) map[string]Source {
 	registry["aijobs"] = cookieSessionSource[aijobsHTTP](c, func(h aijobsHTTP) Source {
 		return NewAijobs(h, aijobsMaxNewPerRun)
 	})
-	// meta is NOT served by the shared client: Meta's edge 400s the default Go TLS+HTTP/2
-	// fingerprint, so it needs the shared Chrome-fingerprint transport (fingerprintHTTP, also used
-	// by the bayt/gulftalent aggregators). Build it only when there is a real client to serve (the
-	// c == nil marker/listing path — e.g. FilterableProviders — must stay transport-free, so meta
-	// registers with a nil client there; Provider()/boardless() never touch it). If the
-	// deterministic transport build ever fails, meta is left unregistered so config validation
-	// fails fast on the "meta" entry, rather than registering a client guaranteed to be rejected by
-	// Meta's edge.
+	// meta/uber are NOT served by the shared client: Meta's edge 400s the default Go TLS+HTTP/2
+	// fingerprint and Uber's Cloudflare edge challenges it, so both need the shared
+	// Chrome-fingerprint transport (fingerprintHTTP, also used by the bayt/gulftalent
+	// aggregators). Build it only when there is a real client to serve (the c == nil
+	// marker/listing path — e.g. FilterableProviders — must stay transport-free, so these
+	// register with a nil client there; Provider()/boardless() never touch it). If the
+	// deterministic transport build ever fails, all four are left unregistered so config
+	// validation fails fast on their board entries, rather than registering a client guaranteed
+	// to be rejected by the edge.
 	if c == nil {
 		registry["meta"] = NewMetaCareers(nil)
 		registry["bayt"] = NewBayt(nil)
 		registry["gulftalent"] = NewGulfTalent(nil)
+		registry["uber"] = NewUber(nil)
 	} else if fp, err := newFingerprintHTTP(); err == nil {
 		registry["meta"] = NewMetaCareers(fp)
 		registry["bayt"] = NewBayt(fp)
 		registry["gulftalent"] = NewGulfTalent(fp)
+		registry["uber"] = NewUber(fp)
 	}
 	return registry
 }

--- a/internal/sources/uber.go
+++ b/internal/sources/uber.go
@@ -76,7 +76,7 @@ func (u uber) detail(ctx context.Context, e CompanyEntry, entry sitemapLoc) (Job
 	if len(p.JobLocation) > 0 {
 		location = p.JobLocation[0].Address.Location()
 	}
-	posted := parseDate(p.DatePosted)
+	posted := parseRFC3339OrDate(p.DatePosted)
 	if posted == nil {
 		posted = parseRFC3339(entry.LastMod)
 	}

--- a/internal/sources/uber.go
+++ b/internal/sources/uber.go
@@ -3,105 +3,96 @@ package sources
 import (
 	"context"
 	"fmt"
-	"strconv"
 )
 
-// uber adapts Uber's public careers search API (www.uber.com/api/loadSearchJobsResults),
-// a single-company source with no per-tenant board id (boardless). The search endpoint is
-// a POST that returns the full posting — including the Markdown description — inline, so
-// unlike Ozon/Gem there is no per-job detail request: one paged list call assembles every
-// Job. The HTML career pages sit behind bot protection, but this JSON API is open.
+// uber adapts Uber's public careers site (jobs.uber.com), a Next.js/RSC app whose HTML routes
+// sit behind a Cloudflare bot-challenge a plain HTTP client cannot pass — so it is wired with
+// the shared Chrome-fingerprint transport (fingerprintHTTP, see fingerprinthttp.go) rather than
+// the shared client, like meta/bayt/gulftalent. The site's own sitemap enumerates every live
+// posting (the XML endpoint is not behind the challenge); each job page server-renders a full
+// schema.org JobPosting ld+json block, including the HTML description, so one sitemap fetch plus
+// a per-job detail fetch assembles every Job — no search API needed. Single-company, boardless
+// (no per-tenant board id).
 type uber struct {
-	http HeaderJSONPoster
+	http uberHTTP
 }
 
-const (
-	uberSearchURL  = "https://www.uber.com/api/loadSearchJobsResults?localeCode=en"
-	uberVacancyURL = "https://www.uber.com/global/en/careers/list/%d/"
-	// uberPageLimit is how many postings to request per page.
-	uberPageLimit = 100
-	// uberCSRFToken is a non-secret header Uber's search API requires: any value is
-	// accepted, but without it the endpoint 403s (it gates casual scraping, not auth).
-	uberCSRFToken = "x"
-)
+// uberHTTP is the transport uber needs: an XML sitemap plus HTML detail pages.
+type uberHTTP interface {
+	XMLGetter
+	HTMLGetter
+}
 
-// NewUber builds the Uber adapter over the given HTTP client.
-func NewUber(c HeaderJSONPoster) Source { return uber{http: c} }
+// NewUber builds the Uber adapter over the given HTTP client (the shared Chrome-fingerprint
+// fingerprintHTTP in production — see registry.go).
+func NewUber(c uberHTTP) Source { return uber{http: c} }
 
 func (uber) Provider() string { return "uber" }
 
 // uber is single-company, so its config entries carry no board.
 func (uber) boardless() {}
 
-// uberRequest is the search POST body. An empty Params returns the whole catalogue;
-// pagination is driven by Page (0-based) at a fixed Limit.
-type uberRequest struct {
-	Params map[string]any `json:"params"`
-	Page   int            `json:"page"`
-	Limit  int            `json:"limit"`
-}
-
-// uberResponse is the search response. Status is "success" on a healthy read; Results is
-// null past the last page. TotalResults.Low is the catalogue size (the API splits a 64-bit
-// count into low/high words; the job count never overflows Low).
-type uberResponse struct {
-	Status string `json:"status"`
-	Data   struct {
-		Results      []uberResult `json:"results"`
-		TotalResults struct {
-			Low int `json:"low"`
-		} `json:"totalResults"`
-	} `json:"data"`
-}
-
-// uberResult is one posting from the search response. The description is Markdown.
-type uberResult struct {
-	ID          int64  `json:"id"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	Location    struct {
-		City        string `json:"city"`
-		Region      string `json:"region"`
-		CountryName string `json:"countryName"`
-	} `json:"location"`
-	CreationDate string `json:"creationDate"`
-}
+// uberSitemapURL is jobs.uber.com's flat job sitemap: a <urlset> of /en/jobs/<id>/ detail URLs.
+const uberSitemapURL = "https://jobs.uber.com/en/jobs/sitemap.xml"
 
 func (u uber) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
-	var jobs []Job
-	for page := 0; ; page++ {
-		var resp uberResponse
-		req := uberRequest{Params: map[string]any{}, Page: page, Limit: uberPageLimit}
-		headers := map[string]string{"x-csrf-token": uberCSRFToken}
-		if err := u.http.PostJSONWithHeaders(ctx, uberSearchURL, headers, req, &resp); err != nil {
-			return nil, fmt.Errorf("uber: list page %d: %w", page, err)
-		}
-		if resp.Status != "success" {
-			return nil, fmt.Errorf("uber: list page %d: status %q", page, resp.Status)
-		}
-		if len(resp.Data.Results) == 0 {
-			break
-		}
-		for _, r := range resp.Data.Results {
-			jobs = append(jobs, u.toJob(e, r))
-		}
-		if len(jobs) >= resp.Data.TotalResults.Low {
-			break
-		}
+	sitemap, err := getSitemap(ctx, u.http, uberSitemapURL)
+	if err != nil {
+		return nil, fmt.Errorf("uber: sitemap: %w", err)
 	}
-	return jobs, nil
+
+	// The sitemap's lastmod is carried into detail as a posted_at fallback.
+	return fetchDetails(sitemap.URLs, defaultDetailWorkers, func(entry sitemapLoc) (Job, bool) {
+		return u.detail(ctx, e, entry)
+	}), nil
 }
 
-// toJob maps a search result to a Job. The Markdown description is rendered to HTML and
-// sanitized; the location collapses blank city/region fields.
-func (uber) toJob(e CompanyEntry, r uberResult) Job {
-	return Job{
-		ExternalID:  strconv.FormatInt(r.ID, 10),
-		URL:         fmt.Sprintf(uberVacancyURL, r.ID),
-		Title:       r.Title,
-		Company:     e.Company,
-		Location:    joinNonEmpty(r.Location.City, r.Location.Region, r.Location.CountryName),
-		Description: sanitizeHTML(markdownToHTML(r.Description)),
-		PostedAt:    parseRFC3339(r.CreationDate),
+// uberPosting is the schema.org JobPosting slice this adapter reads off a job detail page.
+type uberPosting struct {
+	Title          string `json:"title"`
+	Description    string `json:"description"`
+	DatePosted     string `json:"datePosted"`
+	EmploymentType string `json:"employmentType"`
+	Identifier     struct {
+		Value string `json:"value"`
+	} `json:"identifier"`
+	JobLocation schemaPlaces `json:"jobLocation"`
+}
+
+// detail fetches one job page and maps its ld+json JobPosting to a Job, returning ok=false when
+// the page fetch fails, carries no JobPosting, or has no identifier (which would collide on the
+// dedup key) — so the caller skips just that posting.
+func (u uber) detail(ctx context.Context, e CompanyEntry, entry sitemapLoc) (Job, bool) {
+	root, err := u.http.GetHTML(ctx, entry.Loc)
+	if err != nil {
+		return Job{}, false
 	}
+	var p uberPosting
+	if !ldJobPosting(root, &p) || p.Identifier.Value == "" {
+		return Job{}, false
+	}
+
+	var location string
+	if len(p.JobLocation) > 0 {
+		location = p.JobLocation[0].Address.Location()
+	}
+	posted := parseDate(p.DatePosted)
+	if posted == nil {
+		posted = parseRFC3339(entry.LastMod)
+	}
+
+	return Job{
+		ExternalID:  p.Identifier.Value,
+		URL:         entry.Loc,
+		Title:       p.Title,
+		Company:     e.Company,
+		Location:    location,
+		Description: sanitizeHTML(p.Description),
+		// No structured jobLocationType is present in Uber's ld+json, so remote is the same
+		// location-text heuristic meta's adapter falls back to — never WorkMode, which is
+		// reserved for a platform's own structured signal.
+		Remote:         isRemote(location),
+		EmploymentType: schemaEmploymentType(p.EmploymentType),
+		PostedAt:       posted,
+	}, true
 }

--- a/internal/sources/uber_test.go
+++ b/internal/sources/uber_test.go
@@ -157,3 +157,12 @@ func TestUberEmptySitemapYieldsNoJobsNoError(t *testing.T) {
 		t.Fatalf("got %d jobs, want 0", len(jobs))
 	}
 }
+
+func TestUberSitemapFetchErrorFailsBoard(t *testing.T) {
+	// No route for the sitemap URL at all: the sitemap fetch itself fails, and Fetch must
+	// return that error rather than reading it as an empty catalogue.
+	fake := &routedHTTP{}
+	if _, err := NewUber(fake).Fetch(context.Background(), CompanyEntry{Company: "Uber"}); err == nil {
+		t.Fatal("Fetch: want error on sitemap fetch failure, got nil")
+	}
+}

--- a/internal/sources/uber_test.go
+++ b/internal/sources/uber_test.go
@@ -2,159 +2,44 @@ package sources
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"strings"
 	"testing"
 	"time"
 )
 
-// uberHTTP is a body-aware test JSONPoster: Uber pages its search results by the page
-// number in the POST body (the URL is constant), so this fake routes a canned response
-// on req.Page. An unknown page returns an empty, successful result set — the natural
-// "past the end" response that ends pagination.
-type uberHTTP struct {
-	pages      map[int]string
-	fail       bool
-	gotURL     string
-	gotPages   []int
-	gotHeaders map[string]string
+// uberDetailHTML renders a job page the way jobs.uber.com does: a single
+// application/ld+json JobPosting whose identifier is a PropertyValue{value: "<id>"}.
+func uberDetailHTML(title, datePosted, employmentType string, locations ...[3]string) string {
+	var locs strings.Builder
+	for _, l := range locations {
+		locs.WriteString(`{"@type":"Place","name":"` + l[0] + `","address":{"@type":"PostalAddress","addressLocality":"` +
+			l[0] + `","addressRegion":"` + l[1] + `","addressCountry":"` + l[2] + `"}},`)
+	}
+	loc := strings.TrimSuffix(locs.String(), ",")
+	return `<html><head><script type="application/ld+json">
+{"@context":"https://schema.org","@type":"JobPosting",
+"title":"` + title + `",
+"description":"<p>Build the future of movement.<\/p><script>alert(1)<\/script>",
+"identifier":{"@type":"PropertyValue","name":"Uber","value":"149574"},
+"datePosted":"` + datePosted + `",
+"employmentType":"` + employmentType + `",
+"jobLocation":[` + loc + `]}
+</script></head><body>page</body></html>`
 }
 
-func (f *uberHTTP) PostJSONWithHeaders(_ context.Context, url string, headers map[string]string, body, v any) error {
-	f.gotURL = url
-	f.gotHeaders = headers
-	req, ok := body.(uberRequest)
-	if !ok {
-		return errors.New("uberHTTP: body is not a uberRequest")
+func uberSitemapXML(entries ...[2]string) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0"?><urlset>`)
+	for _, e := range entries {
+		b.WriteString(`<url><loc>` + e[0] + `</loc><lastmod>` + e[1] + `</lastmod></url>`)
 	}
-	f.gotPages = append(f.gotPages, req.Page)
-	if f.fail {
-		return errors.New("uberHTTP: boom")
-	}
-	raw, ok := f.pages[req.Page]
-	if !ok {
-		raw = `{"status":"success","data":{"results":[],"totalResults":{"low":0}}}`
-	}
-	return json.Unmarshal([]byte(raw), v)
+	b.WriteString(`</urlset>`)
+	return b.String()
 }
 
 func TestUberProvider(t *testing.T) {
 	if got := NewUber(nil).Provider(); got != "uber" {
 		t.Errorf("Provider() = %q, want %q", got, "uber")
-	}
-}
-
-func TestUberFetchPaginatesAndMaps(t *testing.T) {
-	fake := &uberHTTP{pages: map[int]string{
-		0: `{"status":"success","data":{"totalResults":{"low":3},"results":[
-			{"id":153366,"title":"Engineering Manager","description":"**Hybrid** role\n\n<script>alert(1)</script>","location":{"city":"Seattle","region":"Washington","countryName":"United States"},"creationDate":"2026-01-08T22:29:00.000Z"},
-			{"id":159903,"title":"Solutions Architect","description":"About the role","location":{"city":"Sao Paulo","region":"Sao Paulo","countryName":"Brazil"},"creationDate":"2026-06-12T17:50:00.000Z"}
-		]}}`,
-		1: `{"status":"success","data":{"totalResults":{"low":3},"results":[
-			{"id":160000,"title":"Data Scientist","description":"Numbers","location":{"city":"","region":"","countryName":"India"},"creationDate":""}
-		]}}`,
-	}}
-
-	jobs, err := NewUber(fake).Fetch(context.Background(), CompanyEntry{Company: "Uber", Provider: "uber"})
-	if err != nil {
-		t.Fatalf("Fetch: %v", err)
-	}
-	if len(jobs) != 3 {
-		t.Fatalf("got %d jobs, want 3 (two pages)", len(jobs))
-	}
-
-	byID := map[string]Job{}
-	for _, j := range jobs {
-		byID[j.ExternalID] = j
-	}
-
-	j := byID["153366"]
-	if j.Title != "Engineering Manager" {
-		t.Errorf("Title = %q", j.Title)
-	}
-	if j.Company != "Uber" {
-		t.Errorf("Company = %q, want Uber", j.Company)
-	}
-	if want := "https://www.uber.com/global/en/careers/list/153366/"; j.URL != want {
-		t.Errorf("URL = %q, want %q", j.URL, want)
-	}
-	if want := "Seattle, Washington, United States"; j.Location != want {
-		t.Errorf("Location = %q, want %q", j.Location, want)
-	}
-	if !strings.Contains(j.Description, "<strong>Hybrid</strong>") {
-		t.Errorf("Description not rendered from Markdown: %q", j.Description)
-	}
-	if strings.Contains(j.Description, "<script>") {
-		t.Errorf("Description not sanitized: %q", j.Description)
-	}
-	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 1, 8, 22, 29, 0, 0, time.UTC)) {
-		t.Errorf("PostedAt = %v, want 2026-01-08T22:29:00Z", j.PostedAt)
-	}
-
-	// Empty city/region collapse to just the country; empty creationDate -> nil PostedAt.
-	jd := byID["160000"]
-	if jd.Location != "India" {
-		t.Errorf("Location = %q, want India (blank city/region skipped)", jd.Location)
-	}
-	if jd.PostedAt != nil {
-		t.Errorf("PostedAt = %v, want nil (blank creationDate)", jd.PostedAt)
-	}
-}
-
-func TestUberStopsAtEmptyPage(t *testing.T) {
-	// totalResults says 5 but the source only returns 1 then an empty page: the adapter
-	// must stop on the empty page rather than loop forever chasing the count.
-	fake := &uberHTTP{pages: map[int]string{
-		0: `{"status":"success","data":{"totalResults":{"low":5},"results":[
-			{"id":1,"title":"Only One","description":"x","location":{"countryName":"US"},"creationDate":""}
-		]}}`,
-	}}
-	jobs, err := NewUber(fake).Fetch(context.Background(), CompanyEntry{Company: "Uber"})
-	if err != nil {
-		t.Fatalf("Fetch: %v", err)
-	}
-	if len(jobs) != 1 {
-		t.Fatalf("got %d jobs, want 1 (stop at empty page)", len(jobs))
-	}
-}
-
-func TestUberPostsToSearchURL(t *testing.T) {
-	fake := &uberHTTP{pages: map[int]string{}}
-	if _, err := NewUber(fake).Fetch(context.Background(), CompanyEntry{Company: "Uber"}); err != nil {
-		t.Fatalf("Fetch: %v", err)
-	}
-	if !strings.HasPrefix(fake.gotURL, "https://www.uber.com/api/loadSearchJobsResults") {
-		t.Errorf("posted to %q, want the loadSearchJobsResults endpoint", fake.gotURL)
-	}
-}
-
-func TestUberSendsCSRFHeader(t *testing.T) {
-	// Uber's search API 403s without an x-csrf-token header (any value is accepted); the
-	// adapter must send it or every board fails.
-	fake := &uberHTTP{pages: map[int]string{}}
-	if _, err := NewUber(fake).Fetch(context.Background(), CompanyEntry{Company: "Uber"}); err != nil {
-		t.Fatalf("Fetch: %v", err)
-	}
-	if fake.gotHeaders["x-csrf-token"] == "" {
-		t.Errorf("missing x-csrf-token header; sent %v", fake.gotHeaders)
-	}
-}
-
-func TestUberNonSuccessFailsBoard(t *testing.T) {
-	// A 200 whose status is not "success" must fail the board, not read as empty.
-	fake := &uberHTTP{pages: map[int]string{
-		0: `{"status":"error","data":{"results":null,"totalResults":{"low":0}}}`,
-	}}
-	if _, err := NewUber(fake).Fetch(context.Background(), CompanyEntry{Company: "Uber"}); err == nil {
-		t.Fatal("Fetch: want error on non-success status, got nil")
-	}
-}
-
-func TestUberTransportErrorFailsBoard(t *testing.T) {
-	fake := &uberHTTP{fail: true}
-	if _, err := NewUber(fake).Fetch(context.Background(), CompanyEntry{Company: "Uber"}); err == nil {
-		t.Fatal("Fetch: want transport error, got nil")
 	}
 }
 
@@ -165,5 +50,110 @@ func TestUberRegisteredInAllAndBoardless(t *testing.T) {
 	}
 	if _, isBoardless := s.(boardless); !isBoardless {
 		t.Error("uber should be boardless (single company, no board id)")
+	}
+}
+
+func TestUberFetchSitemapThenDetailAndMaps(t *testing.T) {
+	loc := "https://jobs.uber.com/en/jobs/149574/"
+	fake := (&routedHTTP{}).
+		route("/en/jobs/sitemap.xml", uberSitemapXML([2]string{loc, "2026-06-06T19:38:59Z"})).
+		route("/en/jobs/149574", uberDetailHTML("Sr Staff Engineer", "2026-06-19", "FULL_TIME",
+			[3]string{"Sao Paulo", "SP", "Brazil"}))
+
+	jobs, err := NewUber(fake).Fetch(context.Background(), CompanyEntry{Company: "Uber", Provider: "uber"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "149574" {
+		t.Errorf("ExternalID = %q, want 149574", j.ExternalID)
+	}
+	if j.URL != loc {
+		t.Errorf("URL = %q, want %q", j.URL, loc)
+	}
+	if j.Title != "Sr Staff Engineer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Uber" {
+		t.Errorf("Company = %q, want Uber", j.Company)
+	}
+	if want := "Sao Paulo, SP, Brazil"; j.Location != want {
+		t.Errorf("Location = %q, want %q", j.Location, want)
+	}
+	if strings.Contains(j.Description, "<script>") || !strings.Contains(j.Description, "Build the future") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if j.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time", j.EmploymentType)
+	}
+	// datePosted ("2026-06-19", date-only) wins over the sitemap <lastmod>.
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 6, 19, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-06-19", j.PostedAt)
+	}
+	if j.WorkMode != "" {
+		t.Errorf("WorkMode = %q, want empty (no structured signal, only the Remote heuristic)", j.WorkMode)
+	}
+}
+
+func TestUberPostedAtFallsBackToLastmod(t *testing.T) {
+	loc := "https://jobs.uber.com/en/jobs/999/"
+	fake := (&routedHTTP{}).
+		route("/en/jobs/sitemap.xml", uberSitemapXML([2]string{loc, "2026-05-05T12:00:00Z"})).
+		route("/en/jobs/999", uberDetailHTML("Eng", "", "FULL_TIME", [3]string{"Remote", "", "US"}))
+	jobs, err := NewUber(fake).Fetch(context.Background(), CompanyEntry{Company: "Uber"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	if jobs[0].PostedAt == nil || !jobs[0].PostedAt.Equal(time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want lastmod fallback 2026-05-05T12:00:00Z", jobs[0].PostedAt)
+	}
+}
+
+func TestUberEmptyLocationWhenNoJobLocation(t *testing.T) {
+	loc := "https://jobs.uber.com/en/jobs/888/"
+	fake := (&routedHTTP{}).
+		route("/en/jobs/sitemap.xml", uberSitemapXML([2]string{loc, "2026-06-06T00:00:00Z"})).
+		route("/en/jobs/888", uberDetailHTML("Eng", "2026-04-14", "FULL_TIME"))
+	jobs, err := NewUber(fake).Fetch(context.Background(), CompanyEntry{Company: "Uber"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].Location != "" {
+		t.Fatalf("want empty location, got %v", jobs)
+	}
+}
+
+func TestUberFailedDetailDropsOnlyThatPosting(t *testing.T) {
+	ok := "https://jobs.uber.com/en/jobs/111/"
+	bad := "https://jobs.uber.com/en/jobs/222/"
+	// No route for /en/jobs/222 → GetHTML errors → that posting drops.
+	fake := (&routedHTTP{}).
+		route("/en/jobs/sitemap.xml", uberSitemapXML(
+			[2]string{ok, "2026-06-06T00:00:00Z"}, [2]string{bad, "2026-06-06T00:00:00Z"})).
+		route("/en/jobs/111", uberDetailHTML("Kept", "2026-04-14", "FULL_TIME", [3]string{"Remote", "", "US"}))
+
+	jobs, err := NewUber(fake).Fetch(context.Background(), CompanyEntry{Company: "Uber"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].Title != "Kept" {
+		t.Fatalf("got %v, want only the kept posting", jobs)
+	}
+}
+
+func TestUberEmptySitemapYieldsNoJobsNoError(t *testing.T) {
+	fake := (&routedHTTP{}).route("/en/jobs/sitemap.xml", uberSitemapXML())
+	jobs, err := NewUber(fake).Fetch(context.Background(), CompanyEntry{Company: "Uber"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("got %d jobs, want 0", len(jobs))
 	}
 }


### PR DESCRIPTION
## Summary

Part of the investigation into #2017 (open jobs stop being re-crawled but are never closed). Both providers had 100% of their live jobs stuck unswept for days because their upstream APIs moved out from under the adapters — since the whole board fails every run, the unseen-sweep's zero-ingest guard correctly refuses to close anything, but that also means nothing ever gets fixed until the crawl itself works again.

- **arbeitsagentur** (`consecutive_failures=17`, no success since 2026-08-03): the search API's `/pc/v4/jobs` route is gone (403 even with the correct `X-API-Key`). Moved to `/pc/v6/jobs`, whose response schema also changed (`stellenangebote`→`ergebnisliste`, `titel`→`stellenangebotsTitel`, `arbeitsort`→`stellenlokationen`, etc.). `homeofficemoeglich` now ships directly on the search result, so it no longer needs a detail fetch just for that. The detail step itself moves off HTML-scraping the SSR jobdetail page (a fallback from when the JSON detail API used to 403) onto that same service's own JSON `jobdetails` endpoint, keyed by `base64(referenznummer)`.

- **uber** (`consecutive_failures=12`, no success since 2026-08-08): the search API (`www.uber.com/api/loadSearchJobsResults`) is gone (404) — Uber's careers site moved to `jobs.uber.com`, a Cloudflare-challenged Next.js app a plain HTTP client can't reach. Rewritten as sitemap-driven: the site's own `sitemap.xml` (not behind the challenge) enumerates every live posting, and each detail page — server-rendered, reached via the shared Chrome-fingerprint transport (`fingerprintHTTP`, same as meta/bayt/gulftalent) — carries a full schema.org `JobPosting` ld+json block, so no search API is needed at all. Reuses the existing `jsonld.go`/`schema.go` helpers rather than reimplementing them.

`scriptTextByID` moved from `arbeitsagentur.go` to `html.go` (still needed by `epam.go`/`getro.go` after arbeitsagentur's own HTML-scrape path was removed).

## Test plan

- [x] `gofmt -l .` clean
- [x] `go build ./...` / `go vet ./...` / `go vet -tags=integration ./...` clean
- [x] `go test ./...` green
- [x] Verified live against the real APIs: arbeitsagentur returns 1204 jobs for the `Informatik` board; uber returns 684 jobs (vs. ~606 stale rows currently in the DB from the dead adapter) via the full registry (fingerprint transport included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Arbeitsagentur listings now include improved location details, remote-work information, descriptions, and direct public posting links.
  * Uber job listings now provide mapped locations, employment types, remote status, descriptions, and posting dates.
* **Bug Fixes**
  * Improved handling of unavailable or incomplete job details, preserving valid listings where possible.
  * Excluded invalid Uber postings while continuing to process other available jobs.
  * Improved support for listings with multiple locations and missing location data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->