### PR TITLE
fix(similar-jobs): rewrite NearestJobsToJob as per-chunk LATERAL ANN probes

### DIFF
--- a/cmd/similar-backfill/store.go
+++ b/cmd/similar-backfill/store.go
@@ -37,12 +37,21 @@ func (s *dbStore) JobGeneration(ctx context.Context, jobID int64) (string, error
 	return hash.String, nil
 }
 
+// overFetchMultiplier bounds how many nearest chunks NearestJobsToJob's per-source-chunk
+// LATERAL probe asks pgvector for, past the final limit — headroom to absorb whatever
+// the closed-job/same-company filters discard, without falling back to the whole-table
+// scan the pre-rewrite query needed (see that query's comment). 10x is a starting
+// heuristic, not a measured value; widen it if a source job in a company-dense cluster
+// starts coming back under-filled.
+const overFetchMultiplier = 10
+
 // NearestJobs wraps db.NearestJobsToJob, which already returns rows ordered nearest
 // (lowest distance) first — this just projects out the job ids in that same order.
 func (s *dbStore) NearestJobs(ctx context.Context, jobID int64, limit int) ([]int64, error) {
 	rows, err := s.q.NearestJobsToJob(ctx, db.NearestJobsToJobParams{
 		JobID:      jobID,
 		LimitCount: int32(limit),
+		OverFetch:  int32(limit * overFetchMultiplier),
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/similar-backfill/store.go
+++ b/cmd/similar-backfill/store.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -9,16 +10,17 @@ import (
 	"github.com/strelov1/freehire/internal/db"
 )
 
-// dbStore adapts the generated queries to similarjobs.Store. Unlike cmd/embed's
-// dbStore, no transaction is needed here: each operation is a single independent
-// statement (a SELECT, a job-to-job join query, or a one-row UPDATE), not a
-// multi-table commit that must land atomically.
+// dbStore adapts the generated queries to similarjobs.Store. Every operation but
+// NearestJobs is a single independent statement (a SELECT, a job-to-job join query, or
+// a one-row UPDATE) — no transaction needed. NearestJobs is the one exception: it needs
+// a transaction-scoped SET LOCAL, so it keeps its own connection via pool.
 type dbStore struct {
-	q *db.Queries
+	pool *pgxpool.Pool
+	q    *db.Queries
 }
 
 func newDBStore(pool *pgxpool.Pool) *dbStore {
-	return &dbStore{q: db.New(pool)}
+	return &dbStore{pool: pool, q: db.New(pool)}
 }
 
 func (s *dbStore) PendingJobIDs(ctx context.Context, limit int) ([]int64, error) {
@@ -47,15 +49,36 @@ const overFetchMultiplier = 10
 
 // NearestJobs wraps db.NearestJobsToJob, which already returns rows ordered nearest
 // (lowest distance) first — this just projects out the job ids in that same order.
+//
+// hnsw.ef_search (pgvector's HNSW candidate-list size, default 40) bounds how many
+// candidates the index scan itself can return — below overFetch, each LATERAL probe's
+// `LIMIT over_fetch` silently gets fewer rows than requested, no error, just a
+// short-filled (and less accurate) result. Raised via SET LOCAL inside a transaction so
+// it never leaks onto a pooled connection's next, unrelated query.
 func (s *dbStore) NearestJobs(ctx context.Context, jobID int64, limit int) ([]int64, error) {
-	rows, err := s.q.NearestJobsToJob(ctx, db.NearestJobsToJobParams{
+	overFetch := limit * overFetchMultiplier
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL hnsw.ef_search = %d", overFetch)); err != nil {
+		return nil, fmt.Errorf("set hnsw.ef_search: %w", err)
+	}
+	rows, err := s.q.WithTx(tx).NearestJobsToJob(ctx, db.NearestJobsToJobParams{
 		JobID:      jobID,
 		LimitCount: int32(limit),
-		OverFetch:  int32(limit * overFetchMultiplier),
+		OverFetch:  int32(overFetch),
 	})
 	if err != nil {
 		return nil, err
 	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit: %w", err)
+	}
+
 	ids := make([]int64, len(rows))
 	for i, r := range rows {
 		ids[i] = r.JobID

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -2437,16 +2437,26 @@ type Querier interface {
 	// one perfectly-matching paragraph outranks a job that is merely "somewhat close"
 	// everywhere; this mirrors the chunking branch's own Meili-side scoring rule ("nearest
 	// of a multi-vector document's vectors"), kept intentionally the same across the
-	// storage-engine change. j1 (the source job) is joined once, not re-looked-up per c1
-	// row via a correlated subquery, to read its company_slug for the exclusion below —
-	// functionally identical to design.md's draft (which used
-	// `company_slug IS DISTINCT FROM (SELECT company_slug FROM jobs WHERE id = c1.job_id)`)
-	// but avoids re-executing a subquery per source-chunk row. Excludes: the source job
-	// itself (c2.job_id <> c1.job_id), closed candidates, and — unless the source job has
-	// no resolved company (company_slug = '', this repo's "unknown company" sentinel, see
-	// jobs.company_slug NOT NULL DEFAULT '') — any candidate sharing the source's exact
-	// company_slug, so two different companies that both merely lack a resolved slug don't
-	// spuriously exclude each other.
+	// storage-engine change.
+	//
+	// Rewritten from a plain GROUP BY over the full (source chunk × every other chunk)
+	// cross join to a LATERAL join, one ANN probe per source chunk — measured live on prod
+	// at 730k total chunk rows (a fraction of the eventual target): the cross-join form
+	// took 152.7s for a SINGLE job (confirmed via EXPLAIN ANALYZE), because pgvector's
+	// HNSW index only accelerates `ORDER BY embedding <=> const LIMIT k`, a shape the
+	// cross-join's `MIN(...) ... GROUP BY` never produces — Postgres has no choice but to
+	// compute every pairwise distance before it can take a minimum. Each source chunk's
+	// LATERAL subquery is exactly that index-servable shape (see migration 0110's HNSW
+	// index): it asks for the `over_fetch` nearest chunks to ONE source chunk, over-fetching
+	// past `limit_count` to absorb whatever the closed/same-company filters below discard.
+	// over_fetch too small under-fills the final top-N; too large gives back the cross-join
+	// query's own cost — cmd/similar-backfill picks it as a multiple of limit_count.
+	//
+	// The company/closed exclusion moves to the outer SELECT (against jobs, not repeated per
+	// LATERAL probe) — unless the source job has no resolved company (company_slug = '',
+	// this repo's "unknown company" sentinel, see jobs.company_slug NOT NULL DEFAULT ''),
+	// any candidate sharing the source's exact company_slug is excluded, so two different
+	// companies that both merely lack a resolved slug don't spuriously exclude each other.
 	NearestJobsToJob(ctx context.Context, arg NearestJobsToJobParams) ([]NearestJobsToJobRow, error)
 	// The revision a follow-on edit might be folded into. Only the newest is a candidate:
 	// coalescing into anything older would reorder the log.

--- a/internal/db/queries/semantic.sql
+++ b/internal/db/queries/semantic.sql
@@ -218,23 +218,50 @@ WHERE id = ANY(sqlc.arg(ids)::bigint[]);
 -- one perfectly-matching paragraph outranks a job that is merely "somewhat close"
 -- everywhere; this mirrors the chunking branch's own Meili-side scoring rule ("nearest
 -- of a multi-vector document's vectors"), kept intentionally the same across the
--- storage-engine change. j1 (the source job) is joined once, not re-looked-up per c1
--- row via a correlated subquery, to read its company_slug for the exclusion below —
--- functionally identical to design.md's draft (which used
--- `company_slug IS DISTINCT FROM (SELECT company_slug FROM jobs WHERE id = c1.job_id)`)
--- but avoids re-executing a subquery per source-chunk row. Excludes: the source job
--- itself (c2.job_id <> c1.job_id), closed candidates, and — unless the source job has
--- no resolved company (company_slug = '', this repo's "unknown company" sentinel, see
--- jobs.company_slug NOT NULL DEFAULT '') — any candidate sharing the source's exact
--- company_slug, so two different companies that both merely lack a resolved slug don't
--- spuriously exclude each other.
-SELECT j2.id AS job_id, MIN(c2.embedding <=> c1.embedding)::float8 AS distance
-FROM job_semantic_chunks c1
-JOIN jobs j1 ON j1.id = c1.job_id
-JOIN job_semantic_chunks c2 ON c2.job_id <> c1.job_id
-JOIN jobs j2 ON j2.id = c2.job_id AND j2.closed_at IS NULL
-WHERE c1.job_id = sqlc.arg(job_id)::bigint
-  AND (j1.company_slug = '' OR j2.company_slug IS DISTINCT FROM j1.company_slug)
+-- storage-engine change.
+--
+-- Rewritten from a plain GROUP BY over the full (source chunk × every other chunk)
+-- cross join to a LATERAL join, one ANN probe per source chunk — measured live on prod
+-- at 730k total chunk rows (a fraction of the eventual target): the cross-join form
+-- took 152.7s for a SINGLE job (confirmed via EXPLAIN ANALYZE), because pgvector's
+-- HNSW index only accelerates `ORDER BY embedding <=> const LIMIT k`, a shape the
+-- cross-join's `MIN(...) ... GROUP BY` never produces — Postgres has no choice but to
+-- compute every pairwise distance before it can take a minimum. Each source chunk's
+-- LATERAL subquery is exactly that index-servable shape (see migration 0110's HNSW
+-- index): it asks for the `over_fetch` nearest chunks to ONE source chunk, over-fetching
+-- past `limit_count` to absorb whatever the closed/same-company filters below discard.
+-- over_fetch too small under-fills the final top-N; too large gives back the cross-join
+-- query's own cost — cmd/similar-backfill picks it as a multiple of limit_count.
+--
+-- The company/closed exclusion moves to the outer SELECT (against jobs, not repeated per
+-- LATERAL probe) — unless the source job has no resolved company (company_slug = '',
+-- this repo's "unknown company" sentinel, see jobs.company_slug NOT NULL DEFAULT ''),
+-- any candidate sharing the source's exact company_slug is excluded, so two different
+-- companies that both merely lack a resolved slug don't spuriously exclude each other.
+WITH source_chunks AS (
+    SELECT embedding
+    FROM job_semantic_chunks
+    WHERE job_id = sqlc.arg(job_id)::bigint
+),
+source_job AS (
+    SELECT company_slug FROM jobs WHERE id = sqlc.arg(job_id)::bigint
+),
+nearest AS (
+    SELECT n.job_id, n.distance
+    FROM source_chunks sc
+    CROSS JOIN LATERAL (
+        SELECT c2.job_id, (c2.embedding <=> sc.embedding)::float8 AS distance
+        FROM job_semantic_chunks c2
+        WHERE c2.job_id <> sqlc.arg(job_id)::bigint
+        ORDER BY c2.embedding <=> sc.embedding
+        LIMIT sqlc.arg(over_fetch)::int
+    ) n
+)
+SELECT j2.id AS job_id, MIN(nearest.distance)::float8 AS distance
+FROM nearest
+JOIN jobs j2 ON j2.id = nearest.job_id AND j2.closed_at IS NULL
+CROSS JOIN source_job sj
+WHERE (sj.company_slug = '' OR j2.company_slug IS DISTINCT FROM sj.company_slug)
 GROUP BY j2.id
 ORDER BY distance
 LIMIT sqlc.arg(limit_count)::int;

--- a/internal/db/semantic.sql.go
+++ b/internal/db/semantic.sql.go
@@ -374,21 +374,39 @@ func (q *Queries) InsertJobSemanticChunks(ctx context.Context, arg InsertJobSema
 }
 
 const nearestJobsToJob = `-- name: NearestJobsToJob :many
-SELECT j2.id AS job_id, MIN(c2.embedding <=> c1.embedding)::float8 AS distance
-FROM job_semantic_chunks c1
-JOIN jobs j1 ON j1.id = c1.job_id
-JOIN job_semantic_chunks c2 ON c2.job_id <> c1.job_id
-JOIN jobs j2 ON j2.id = c2.job_id AND j2.closed_at IS NULL
-WHERE c1.job_id = $1::bigint
-  AND (j1.company_slug = '' OR j2.company_slug IS DISTINCT FROM j1.company_slug)
+WITH source_chunks AS (
+    SELECT embedding
+    FROM job_semantic_chunks
+    WHERE job_id = $2::bigint
+),
+source_job AS (
+    SELECT company_slug FROM jobs WHERE id = $2::bigint
+),
+nearest AS (
+    SELECT n.job_id, n.distance
+    FROM source_chunks sc
+    CROSS JOIN LATERAL (
+        SELECT c2.job_id, (c2.embedding <=> sc.embedding)::float8 AS distance
+        FROM job_semantic_chunks c2
+        WHERE c2.job_id <> $2::bigint
+        ORDER BY c2.embedding <=> sc.embedding
+        LIMIT $3::int
+    ) n
+)
+SELECT j2.id AS job_id, MIN(nearest.distance)::float8 AS distance
+FROM nearest
+JOIN jobs j2 ON j2.id = nearest.job_id AND j2.closed_at IS NULL
+CROSS JOIN source_job sj
+WHERE (sj.company_slug = '' OR j2.company_slug IS DISTINCT FROM sj.company_slug)
 GROUP BY j2.id
 ORDER BY distance
-LIMIT $2::int
+LIMIT $1::int
 `
 
 type NearestJobsToJobParams struct {
-	JobID      int64 `json:"job_id"`
 	LimitCount int32 `json:"limit_count"`
+	JobID      int64 `json:"job_id"`
+	OverFetch  int32 `json:"over_fetch"`
 }
 
 type NearestJobsToJobRow struct {
@@ -403,18 +421,28 @@ type NearestJobsToJobRow struct {
 // one perfectly-matching paragraph outranks a job that is merely "somewhat close"
 // everywhere; this mirrors the chunking branch's own Meili-side scoring rule ("nearest
 // of a multi-vector document's vectors"), kept intentionally the same across the
-// storage-engine change. j1 (the source job) is joined once, not re-looked-up per c1
-// row via a correlated subquery, to read its company_slug for the exclusion below —
-// functionally identical to design.md's draft (which used
-// `company_slug IS DISTINCT FROM (SELECT company_slug FROM jobs WHERE id = c1.job_id)`)
-// but avoids re-executing a subquery per source-chunk row. Excludes: the source job
-// itself (c2.job_id <> c1.job_id), closed candidates, and — unless the source job has
-// no resolved company (company_slug = ”, this repo's "unknown company" sentinel, see
-// jobs.company_slug NOT NULL DEFAULT ”) — any candidate sharing the source's exact
-// company_slug, so two different companies that both merely lack a resolved slug don't
-// spuriously exclude each other.
+// storage-engine change.
+//
+// Rewritten from a plain GROUP BY over the full (source chunk × every other chunk)
+// cross join to a LATERAL join, one ANN probe per source chunk — measured live on prod
+// at 730k total chunk rows (a fraction of the eventual target): the cross-join form
+// took 152.7s for a SINGLE job (confirmed via EXPLAIN ANALYZE), because pgvector's
+// HNSW index only accelerates `ORDER BY embedding <=> const LIMIT k`, a shape the
+// cross-join's `MIN(...) ... GROUP BY` never produces — Postgres has no choice but to
+// compute every pairwise distance before it can take a minimum. Each source chunk's
+// LATERAL subquery is exactly that index-servable shape (see migration 0110's HNSW
+// index): it asks for the `over_fetch` nearest chunks to ONE source chunk, over-fetching
+// past `limit_count` to absorb whatever the closed/same-company filters below discard.
+// over_fetch too small under-fills the final top-N; too large gives back the cross-join
+// query's own cost — cmd/similar-backfill picks it as a multiple of limit_count.
+//
+// The company/closed exclusion moves to the outer SELECT (against jobs, not repeated per
+// LATERAL probe) — unless the source job has no resolved company (company_slug = ”,
+// this repo's "unknown company" sentinel, see jobs.company_slug NOT NULL DEFAULT ”),
+// any candidate sharing the source's exact company_slug is excluded, so two different
+// companies that both merely lack a resolved slug don't spuriously exclude each other.
 func (q *Queries) NearestJobsToJob(ctx context.Context, arg NearestJobsToJobParams) ([]NearestJobsToJobRow, error) {
-	rows, err := q.db.Query(ctx, nearestJobsToJob, arg.JobID, arg.LimitCount)
+	rows, err := q.db.Query(ctx, nearestJobsToJob, arg.LimitCount, arg.JobID, arg.OverFetch)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/semantic_chunks_integration_test.go
+++ b/internal/db/semantic_chunks_integration_test.go
@@ -249,7 +249,7 @@ func TestNearestJobsToJob(t *testing.T) {
 	farAway := insertChunkTestJob(t, pool, "far-away", "delta-co")
 	insertChunks(t, farAway, []int16{0}, []int{6})
 
-	rows, err := q.NearestJobsToJob(ctx, NearestJobsToJobParams{JobID: source, LimitCount: 10})
+	rows, err := q.NearestJobsToJob(ctx, NearestJobsToJobParams{JobID: source, LimitCount: 10, OverFetch: 100})
 	if err != nil {
 		t.Fatalf("NearestJobsToJob: %v", err)
 	}

--- a/migrations/0110_job_semantic_chunks_hnsw_idx.sql
+++ b/migrations/0110_job_semantic_chunks_hnsw_idx.sql
@@ -1,0 +1,20 @@
+-- migrate: no-transaction
+--
+-- HNSW index on job_semantic_chunks.embedding (design.md Decision 2 / tasks.md 3.1),
+-- what makes NearestJobsToJob's LATERAL rewrite (see that query's comment) actually
+-- index-servable: pgvector's HNSW accelerates exactly the `ORDER BY embedding <=>
+-- const LIMIT k` shape each source chunk's LATERAL probe now uses.
+--
+-- CONCURRENTLY needs its own no-transaction file, same reasoning as every other
+-- CONCURRENTLY migration in this repo (0078/0081/0097/0107 etc): Postgres forbids it
+-- inside a transaction block, and a multi-statement migration file runs as one implicit
+-- transaction regardless of the no-transaction marker.
+--
+-- Applied to a fresh volume by initdb after 0092 (job_semantic_chunks' own migration);
+-- on an existing prod volume, build it by hand, detached from the SSH session
+-- (systemd-run or nohup) — a CONCURRENTLY build dies with its ssh session and leaves an
+-- INVALID index behind. Raise maintenance_work_mem for the session running this: the
+-- default (64MB) spills the build graph to disk past roughly half a million tuples
+-- (this session's own earlier local spike, see design.md Risks).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS job_semantic_chunks_embedding_hnsw_idx
+    ON public.job_semantic_chunks USING hnsw (embedding vector_cosine_ops);

--- a/migrations/0110_job_semantic_chunks_hnsw_idx.sql
+++ b/migrations/0110_job_semantic_chunks_hnsw_idx.sql
@@ -15,6 +15,10 @@
 -- (systemd-run or nohup) — a CONCURRENTLY build dies with its ssh session and leaves an
 -- INVALID index behind. Raise maintenance_work_mem for the session running this: the
 -- default (64MB) spills the build graph to disk past roughly half a million tuples
--- (this session's own earlier local spike, see design.md Risks).
+-- (this session's own earlier local spike, see design.md Risks). Recovering an INVALID
+-- index (confirmed live on prod for the semantic_outbox/search_outbox claim indexes,
+-- same failure mode): `DROP INDEX CONCURRENTLY job_semantic_chunks_embedding_hnsw_idx;`
+-- then re-run this file's CREATE INDEX CONCURRENTLY — `IF NOT EXISTS` alone will not
+-- retry a build once an invalid index already holds the name.
 CREATE INDEX CONCURRENTLY IF NOT EXISTS job_semantic_chunks_embedding_hnsw_idx
     ON public.job_semantic_chunks USING hnsw (embedding vector_cosine_ops);


### PR DESCRIPTION
## Summary
- `NearestJobsToJob` computed `MIN(...) GROUP BY` over a full cross join of every (source chunk, candidate chunk) pair — a shape pgvector's HNSW index cannot accelerate (ANN indexes only serve `ORDER BY embedding <=> const LIMIT k`). Confirmed live on prod: **152.7s for a single job** via EXPLAIN ANALYZE, at only 730k total chunk rows (a fraction of the eventual full-catalogue target).
- Rewritten to one LATERAL ANN probe per source chunk, over-fetching past the final limit to absorb the closed/same-company filters (moved to the outer SELECT, applied once instead of per pairwise row), then rolled up to the minimum distance per candidate job.
- Adds the HNSW index on `job_semantic_chunks.embedding` (migration 0110, `CREATE INDEX CONCURRENTLY` in its own no-transaction file per this repo's convention) — required for the LATERAL probes to actually be index-servable.

## Context
This was flagged as an unmeasured architectural risk during PR #1905's CodeRabbit review and deliberately deferred pending real data. It's now confirmed as a hard blocker: `cmd/similar-backfill` cannot run at any real scale without this fix.

## Test plan
- [x] `go test -tags=integration ./internal/db/... ./cmd/similar-backfill/... ./internal/migrate/...` clean
- [x] `go build/vet ./...`, `gofmt -l .` clean
- [ ] Deploy, build the HNSW index on prod, re-measure the same query with EXPLAIN ANALYZE to confirm the real speedup