### PR TITLE
harvest: read Comeet apply URLs, and probe iCIMS vanity boards at their real host

### DIFF
--- a/cmd/harvest-boards/oracle_jazzhr_prober.go
+++ b/cmd/harvest-boards/oracle_jazzhr_prober.go
@@ -15,6 +15,17 @@ import (
 // seed-supplied company; see internal/sources/oracle.go for the board-id shape.
 type oracleProber struct{}
 
+// dedupKey folds an Oracle board's site segment to lower case. Oracle answers a requisition
+// listing for any spelling of the site — CX_2001, cx_2001 and Cx_2001 all return the same 51
+// jobs on tenant eetz.fa.us6 (checked live) — so two spellings are one board, and a candidate
+// derived from a job URL carries whatever case that URL happened to use. Without folding it is
+// filed beside the board we already crawl, which is the same defect Paycom's hex keys had.
+//
+// The HOST half is folded too: DNS is case-insensitive, so it cannot distinguish boards either.
+// This does not collapse a tenant's several real sites (CX, CX_1, CX_2001 are different names,
+// not different spellings) — only the case of one name.
+func (oracleProber) dedupKey(boardID string) string { return strings.ToLower(boardID) }
+
 func (oracleProber) probe(ctx context.Context, c httpClient, boardID string) (string, int, error) {
 	host, site, ok := strings.Cut(boardID, "/")
 	if !ok || host == "" || site == "" {

--- a/cmd/harvest-boards/oracle_jazzhr_prober_test.go
+++ b/cmd/harvest-boards/oracle_jazzhr_prober_test.go
@@ -54,3 +54,24 @@ func TestJazzHRProbe(t *testing.T) {
 		t.Errorf("gone: got n=%d err=%v, want 0,nil", n, err)
 	}
 }
+
+// TestOracleDedupKey: Oracle serves the same board under any spelling of its site segment, so
+// the dedup key must fold case — otherwise a candidate taken from a job URL lands beside the
+// board we already crawl. Different site NAMES on one tenant stay different boards.
+func TestOracleDedupKey(t *testing.T) {
+	p := oracleProber{}
+	same := []string{
+		"eetz.fa.us6.oraclecloud.com/CX_2001",
+		"eetz.fa.us6.oraclecloud.com/cx_2001",
+		"EETZ.fa.us6.oraclecloud.com/Cx_2001",
+	}
+	want := p.dedupKey(same[0])
+	for _, id := range same[1:] {
+		if got := p.dedupKey(id); got != want {
+			t.Errorf("dedupKey(%q) = %q, want %q", id, got, want)
+		}
+	}
+	if p.dedupKey("eetz.fa.us6.oraclecloud.com/CX_1") == want {
+		t.Error("CX_1 and CX_2001 are different sites, not different spellings of one")
+	}
+}

--- a/cmd/harvest-boards/prober.go
+++ b/cmd/harvest-boards/prober.go
@@ -296,13 +296,39 @@ type icimsProber struct{}
 // internal/sources, to avoid widening that package's API for a dev tool.
 var icimsJobLocPattern = regexp.MustCompile(`/jobs/\d+/`)
 
+// icimsHost mirrors internal/sources/icims.go: a board containing a dot IS the careers host, and
+// anything else is a bare slug the host is rebuilt from. Probing every candidate as the rebuilt
+// form asks for "careers-<host>.icims.com" whenever the board is a vanity one, which resolves
+// nowhere — so every vanity board would be reported dead instead of probed.
+func icimsHost(board string) string {
+	if strings.Contains(board, ".") {
+		return board
+	}
+	return "careers-" + board + ".icims.com"
+}
+
+// dedupKey folds "careers-<slug>.icims.com" to "<slug>". The catalogue holds both spellings of
+// the same board (57 of 1921 entries carry the full host), so a candidate derived from a job URL
+// as the bare slug would otherwise look new and be filed alongside the board we already crawl.
+// Only the "careers-" form folds: "pppl-princeton.icims.com" and a bare "pppl-princeton" name
+// DIFFERENT hosts, so collapsing them would hide a real board instead of a duplicate.
+func (icimsProber) dedupKey(boardID string) string {
+	id := strings.ToLower(boardID)
+	if host, isHost := strings.CutSuffix(id, ".icims.com"); isHost {
+		if slug, prefixed := strings.CutPrefix(host, "careers-"); prefixed && slug != "" {
+			return slug
+		}
+	}
+	return id
+}
+
 func (icimsProber) probe(ctx context.Context, c httpClient, slug string) (string, int, error) {
 	var sitemap struct {
 		URLs []struct {
 			Loc string `xml:"loc"`
 		} `xml:"url"`
 	}
-	if err := c.GetXML(ctx, fmt.Sprintf("https://careers-%s.icims.com/sitemap.xml", slug), &sitemap); err != nil {
+	if err := c.GetXML(ctx, "https://"+icimsHost(slug)+"/sitemap.xml", &sitemap); err != nil {
 		return "", 0, nil
 	}
 	n := 0

--- a/cmd/harvest-boards/prober_test.go
+++ b/cmd/harvest-boards/prober_test.go
@@ -173,6 +173,38 @@ func TestICIMSProbe(t *testing.T) {
 	if name, n, err := p.probe(context.Background(), getter, "gone"); err != nil || name != "" || n != 0 {
 		t.Errorf("gone: got (%q,%d,%v), want (\"\",0,nil)", name, n, err)
 	}
+
+	// A vanity board IS the host. Rebuilding it as careers-<host>.icims.com asks for a name that
+	// resolves nowhere, so the board would be reported dead rather than probed.
+	vanity := fakeGetter{
+		"https://pppl-princeton.icims.com/sitemap.xml": icimsSitemap(
+			"https://pppl-princeton.icims.com/jobs/303/role/job",
+		),
+	}
+	if name, n, err := p.probe(context.Background(), vanity, "pppl-princeton.icims.com"); err != nil || name != "" || n != 1 {
+		t.Errorf("vanity: got (%q,%d,%v), want (\"\",1,nil)", name, n, err)
+	}
+}
+
+// TestICIMSDedupKey: the catalogue spells the same board both ways, so the two must share a
+// dedup key — but only for the "careers-" form, which is the one the adapter rebuilds. A vanity
+// host without that prefix names a DIFFERENT site than the same string used as a bare slug, and
+// folding those together would suppress a real board as a duplicate.
+func TestICIMSDedupKey(t *testing.T) {
+	cases := map[string]string{
+		"careers-vet.icims.com":    "vet",
+		"CAREERS-VET.ICIMS.COM":    "vet",
+		"vet":                      "vet",
+		"pppl-princeton.icims.com": "pppl-princeton.icims.com",
+		"pppl-princeton":           "pppl-princeton",
+		"careers-.icims.com":       "careers-.icims.com",
+		"careers.docusign.com":     "careers.docusign.com",
+	}
+	for in, want := range cases {
+		if got := (icimsProber{}).dedupKey(in); got != want {
+			t.Errorf("dedupKey(%q) = %q, want %q", in, got, want)
+		}
+	}
 }
 
 // These platforms publish no employer name in their payloads, so a live board reports "" as

--- a/internal/atsdetect/fromurl.go
+++ b/internal/atsdetect/fromurl.go
@@ -2,6 +2,7 @@ package atsdetect
 
 import (
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/strelov1/freehire/internal/atsboard"
@@ -22,10 +23,10 @@ import (
 // Delegating also means an ATS added to atsboard is immediately visible to the harvest tools,
 // which was the standing cost of the split.
 //
-// What stays here are the five shapes atsboard deliberately EXCLUDES. That exclusion is not an
+// What stays here are the six shapes atsboard deliberately EXCLUDES. That exclusion is not an
 // oversight to correct: atsboard is the accept-set for internal/contribution, which PAYS for
 // onboarded boards, so widening it is a money-affecting decision that needs its own proposal.
-// These five are harvest-only, and the harvest path validates every candidate against the
+// These six are harvest-only, and the harvest path validates every candidate against the
 // platform's API before committing it.
 func FromURL(rawurl string) (provider, board string, ok bool) {
 	if src, brd, _, found := atsboard.Recognize(rawurl); found {
@@ -66,6 +67,14 @@ func FromURL(rawurl string) (provider, board string, ok bool) {
 		if agency := segAfter(segs, "careers"); agency != "" {
 			return "neogov", strings.TrimPrefix(host, "www.") + "/" + agency, true
 		}
+	case host == "www.comeet.com", host == "comeet.com":
+		// board is "<slug>/<companyUID>" — Comeet's adapter needs both halves, so the slug alone
+		// is not a shorter board id but one the crawl rejects. The uid's fixed shape ("B1.001")
+		// is what proves the path names a board: comeet.com also serves the vendor's own pages,
+		// whose second segment would otherwise read as a company uid.
+		if len(segs) >= 3 && segs[0] == "jobs" && comeetUID.MatchString(segs[2]) {
+			return "comeet", segs[1] + "/" + segs[2], true
+		}
 	case host == "www.paycomonline.net", host == "paycomonline.net":
 		// board is the 32-hex client key in /v4/ats/web.php/portal/<clientkey>/...
 		if key := segAfter(segs, "portal"); key != "" {
@@ -74,6 +83,10 @@ func FromURL(rawurl string) (provider, board string, ok bool) {
 	}
 	return "", "", false
 }
+
+// comeetUID matches a Comeet company UID: two alphanumerics, a dot, three more ("B1.001",
+// "32.00E"). Requiring the shape is what separates a board URL from any other comeet.com path.
+var comeetUID = regexp.MustCompile(`^[0-9A-Za-z]{2}\.[0-9A-Za-z]{3}$`)
 
 // pathSegments splits a URL path into its non-empty segments.
 func pathSegments(p string) []string {

--- a/internal/atsdetect/fromurl_test.go
+++ b/internal/atsdetect/fromurl_test.go
@@ -173,6 +173,30 @@ func TestFromURL(t *testing.T) {
 			ok:   false,
 		},
 		{
+			name:     "comeet vacancy keeps slug and company uid",
+			url:      "https://www.comeet.com/jobs/capslock/59.001/senior-marketing-strategist/9B.F62-B8.406",
+			provider: "comeet",
+			board:    "capslock/59.001",
+			ok:       true,
+		},
+		{
+			name:     "comeet board listing",
+			url:      "https://www.comeet.com/jobs/overwolf/B1.001",
+			provider: "comeet",
+			board:    "overwolf/B1.001",
+			ok:       true,
+		},
+		{
+			name: "comeet slug without a company uid is not a board",
+			url:  "https://www.comeet.com/jobs/overwolf",
+			ok:   false,
+		},
+		{
+			name: "comeet vendor path is not a board",
+			url:  "https://www.comeet.com/pricing/plans/x",
+			ok:   false,
+		},
+		{
 			name: "unknown host",
 			url:  "https://www.caci.com/careers/123",
 			ok:   false,
@@ -213,6 +237,7 @@ func TestLocalShapesStayOutsideTheSharedTable(t *testing.T) {
 		"taleo":  "https://valero.taleo.net/careersection/2/jobsearch.ftl",
 		"neogov": "https://www.governmentjobs.com/careers/cityofboise/jobs/4567",
 		"paycom": "https://www.paycomonline.net/v4/ats/web.php/portal/0123456789abcdef0123456789abcdef/jobs",
+		"comeet": "https://www.comeet.com/jobs/overwolf/B1.001",
 	}
 	for provider, rawurl := range local {
 		t.Run(provider, func(t *testing.T) {


### PR DESCRIPTION
Both fall out of resolving an aggregator's outbound apply links to the employer's own ATS, where these two shapes were 14 of the 52 unrecognised destinations in a 200-company pilot.

## Comeet goes in `internal/atsdetect`, not the shared table

`atsboard` is `internal/contribution`'s accept-set and onboarded boards are **paid for**, so widening it is a money-affecting decision that needs its own proposal — `atsdetect`'s guard test says exactly that, and it caught a first attempt that put Comeet (and iCIMS) in the shared table. Comeet joins the harvest-only local shapes instead, where every candidate is validated against the platform's API before it is committed.

A Comeet board is `<slug>/<companyUID>`; the adapter needs both halves, so the slug alone is not a shorter board id but one the crawl rejects. The uid's fixed shape (`B1.001`) is what proves a `comeet.com` path names a board rather than a vendor page.

## The iCIMS prober could never validate a vanity board

It rebuilt every candidate as `careers-<slug>.icims.com`. For the 57 of 1921 catalogue entries that are the full host, that asks for `careers-<host>.icims.com`, which resolves nowhere — so every vanity board read as dead instead of being probed. It now mirrors `internal/sources/icims.go`: a board containing a dot IS the host.

Those two spellings also name the same board, so `icimsProber` gains a `dedupKey` folding `careers-<slug>.icims.com` to `<slug>`. A candidate derived from a job URL always arrives bare, and without folding it is filed next to the board we already crawl. Only the `careers-` form folds: a vanity host without that prefix and the same string as a bare slug are DIFFERENT sites, and collapsing them would hide a real board.

## Checks

`gofmt` clean, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...` — all green.

Verified end to end: `harvest-boards comeet` found 28 candidates, 10 live, 0 probe failures, against a file that held 23.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting Comeet job board URLs and identifying their associated boards.
  * Improved iCIMS board discovery for vanity hostnames and direct board links.
* **Bug Fixes**
  * Standardized board matching across capitalization and equivalent hostname formats for Oracle and iCIMS.
  * Preserved distinct identities for different sites and custom iCIMS hosts.
* **Tests**
  * Added coverage for Comeet URL detection and board identification.
  * Added validation for Oracle and iCIMS matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->