### PR TITLE
Nail down that a contested city keeps its state code readable

### DIFF
--- a/internal/location/location_test.go
+++ b/internal/location/location_test.go
@@ -83,6 +83,17 @@ func TestParse(t *testing.T) {
 		// subdivision table is consulted BEFORE the bare two-letter country code, so the
 		// US-state readings of these tokens must be untouched by the new countries la/mn/mo.
 		{
+			// A CONTESTED city name must not cost the subdivision code its reading.
+			// "Taft" is claimed by Iran, the Philippines and the US, so the dictionary
+			// states no country for it — but "CA" here is still California, resolved from
+			// the preceding token rather than from the city's own country. Raised in
+			// review as a suspected regression; measured identical before and after the
+			// contested-alias change, and nailed down here so it stays that way.
+			name:     "contested city keeps the state code readable",
+			location: "Taft, CA",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}, Cities: []string{"Taft"}},
+		},
+		{
 			name:     "LA stays louisiana rather than laos",
 			location: "Baton Rouge, LA",
 			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}, Cities: []string{"Baton Rouge"}},


### PR DESCRIPTION
Follow-up to #2051, from a CodeRabbit finding on that branch.

## The concern

With "Taft" now contested across Iran, the Philippines and the US, the dictionary
states no country for it. The review asked whether `Taft, CA` would therefore lose
California and read `CA` as Canada.

## The measurement

Ran it on both sides of the change:

| input | before #2051 | after #2051 |
|---|---|---|
| `Taft, CA` | `us` | `us` |
| `Toronto, CA` | `ca us` | `ca us` |
| `Fresno, CA` | `us` | `us` |
| `Bakersfield, CA` | `us` | `us` |

Identical. The subdivision code resolves from the PRECEDING token (the same
mechanism that keeps `Baton Rouge, LA` in Louisiana and `Vientiane, LA` in Laos),
not from the city's own country — so a city that states nothing costs the code
nothing.

## What this PR does

Nothing but add the case to `TestParse`, next to the existing `LA`/`MN`/`MO`
subdivision guards. No fix was needed; the point is that the next change to the
contested-alias machinery finds out immediately if it breaks this.

`Toronto, CA` resolving to both countries is a real (pre-existing, unrelated)
imprecision — `CA` is genuinely both California and Canada, and the union keeps
both. Left alone here rather than folded into a test-only PR.