### PR TITLE
sources: add 2698 boards found by resolving one aggregator's apply links

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -8188,3 +8188,5 @@
   board: vandenboomassociates
 - company: Voyant Photonics
   board: voyant-photonics
+- company: Kantiv (formerly Joist AI)
+  board: kantiv

--- a/sources/bamboohr.yml
+++ b/sources/bamboohr.yml
@@ -19113,3 +19113,13 @@
   board: webdoctor
 - company: Wisconsin Women's Health Foundation
   board: wwhf
+- company: Attekmi
+  board: attekmi
+- company: Bluecore
+  board: bluecore
+- company: Environmental Law Alliance Worldwide
+  board: elaw
+- company: EonX
+  board: eonx
+- company: MacroAgility Systems, Inc.
+  board: macroagility

--- a/sources/breezy.yml
+++ b/sources/breezy.yml
@@ -3949,3 +3949,7 @@
   board: vectorvms
 - company: Viamo
   board: viamo-inc
+- company: Ignite HR Solutions and our Clients
+  board: ignite-hr-solutions
+- company: Kastech Software Solutions Group
+  board: kastech-canada-inc

--- a/sources/comeet.yml
+++ b/sources/comeet.yml
@@ -50,3 +50,57 @@
   board: dreamgroup/99.002
 - company: Cognyte
   board: cognyte/F2.009
+- company: Tenengroup Ltd.
+  board: Tenengroup/93.00C
+- company: AgencyBloc
+  board: agencybloc/08.008
+- company: Akeyless
+  board: akeyless/27.006
+- company: Alma Lasers
+  board: almalasers/67.006
+- company: BDR Solutions, LLC
+  board: bdrsolutionsllc/79.00B
+- company: Blockaid
+  board: blockaid/69.00B
+- company: Bright Data
+  board: brightdata/88.007
+- company: Caesarstone
+  board: caesarstone/25.000
+- company: CapsLock
+  board: capslock/59.001
+- company: Checkmarx
+  board: checkmarx/C0.008
+- company: Cycode
+  board: cycode/A8.00D
+- company: Driivz
+  board: driivz/C4.00B
+- company: Fluent Trade Technologies
+  board: fluenttech/E5.00E
+- company: Fullpath
+  board: fullpath/54.002
+- company: i4DM
+  board: i4DM/85.006
+- company: Ivix
+  board: ivix/09.002
+- company: Navina
+  board: navina/E6.00C
+- company: Onebeat
+  board: onebeat/0A.000
+- company: Orchid Security
+  board: orchid_security/4A.001
+- company: OuterBox
+  board: outerbox/49.00D
+- company: PolySwarm
+  board: polyswarm/95.008
+- company: Snapscale
+  board: snapscale/C9.006
+- company: VAST Data
+  board: vastdata/43.001
+- company: Vi
+  board: vi/B1.002
+- company: Visana Health
+  board: visanahealth/0B.008
+- company: Webbing
+  board: webbing/46.00E
+- company: Zenity
+  board: zenity/19.000

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14325,3 +14325,7 @@
   board: utilityprofit
 - company: ValidMind
   board: validmind
+- company: Airtame
+  board: airtamejobs
+- company: California Institute of Applied Technology
+  board: californiainstituteofartsandtechnology

--- a/sources/hibob.yml
+++ b/sources/hibob.yml
@@ -137,3 +137,13 @@
   board: wiredscore
 - company: Avvoka
   board: workatavvoka
+- company: Buckhill
+  board: buckhill
+- company: eCarsTrade
+  board: ecarstrade
+- company: KodeKloud
+  board: kodekloud
+- company: OverIT
+  board: overit
+- company: VALR
+  board: valr

--- a/sources/icims.yml
+++ b/sources/icims.yml
@@ -3851,3 +3851,5 @@
   board: quantumsky
 - company: Sopra Steria
   board: sbs
+- company: GR8 Global
+  board: gr8global

--- a/sources/jazzhr.yml
+++ b/sources/jazzhr.yml
@@ -8519,3 +8519,33 @@
   board: westcoastwound
 - company: ZigZag Careers
   board: zigzag
+- company: AIL
+  board: aoglobelifesholaadebayo
+- company: ASCENDING
+  board: ascendingdc
+- company: Dickerson Bakker
+  board: dickersonbakker
+- company: Galvanize USA
+  board: galvanize
+- company: Healthcare Information and Management Systems Society
+  board: himss
+- company: Healthcare Systems and Technologies, LLC
+  board: hstpathways
+- company: Ludi Inc
+  board: ludiinc
+- company: American Income Life Insurance Company
+  board: lunaagencies
+- company: MeVitae
+  board: mevitae94
+- company: Pitchup.com
+  board: pitchup
+- company: Pomelo
+  board: pomelohq
+- company: Spade Recruiting
+  board: spadepartners
+- company: System Six
+  board: systemsix
+- company: The VA Group, LLC
+  board: tvag
+- company: Veli Technologies Ltd.
+  board: velitech

--- a/sources/jobvite.yml
+++ b/sources/jobvite.yml
@@ -344,3 +344,5 @@
   board: windward
 - company: Xcelerate Solutions
   board: xceleratesolutions
+- company: CMG Financial
+  board: cmgfi

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4491,3 +4491,15 @@
   board: sentibio
 - company: Traild
   board: traildsoftware
+- company: Agerpoint
+  board: Agerpoint
+- company: Anovium
+  board: Anovium
+- company: Pretto
+  board: Pretto
+- company: SoundStack
+  board: SoundStack
+- company: Xpansiv
+  board: 'Xpansiv '
+- company: TrustedHousesitters
+  board: trustedhousesitters.com

--- a/sources/manatal.yml
+++ b/sources/manatal.yml
@@ -305,3 +305,287 @@
   board: wearefindigo
 - company: WGT EHR Pte Ltd
   board: wgt-ehr-pte-ltd
+- company: Absolute Elder Care
+  board: absolute-elder-care
+- company: Acxelsus Co.
+  board: acxelsus
+- company: ADI Group
+  board: adi-recruitment
+- company: Adstify Search
+  board: adstifysearch
+- company: ALDIA
+  board: aldiagrp
+- company: Allen Insurance Insurance Recruitment Ltd
+  board: allen-insurance-insurance-recruitment-ltd
+- company: AMS Accelerate IT
+  board: ams-hr
+- company: Archie Labs
+  board: archielabs
+- company: Ascend HR
+  board: ascend-hr
+- company: AutoScale Ventures
+  board: autoscale-ventures
+- company: Avant Digital
+  board: avantdigital
+- company: Axiom Technologies
+  board: axiom-technologies-0
+- company: Axios HQ
+  board: axioshq
+- company: Ben Aris LLC
+  board: ben-aris-llc
+- company: Berkeley Square IT
+  board: berkeley-square-it
+- company: Blackfluo.ai
+  board: blackfluoai
+- company: BuildBear Labs
+  board: buildbear-labs
+- company: ByteCrew Technologies Pvt Ltd
+  board: bytecrew
+- company: CapX
+  board: capx
+- company: Focal Search Pte Ltd
+  board: career-focal
+- company: CareerPaths NW
+  board: careerpaths-nw
+- company: CEF Solutions Inc.
+  board: cef
+- company: Centrum-ai
+  board: centrum-ai
+- company: CK Funded
+  board: ck-funded
+- company: Concert8 Solutions Inc
+  board: concert8-solutions-inc
+- company: Convit Holding GmbH
+  board: convit-holding-gmbh
+- company: Cultivar Asia Pte Ltd (EA License 19C9782)
+  board: cultivar
+- company: Customertimes
+  board: customertimes
+- company: Darren Caddle
+  board: darren-caddle-3
+- company: Data Edge
+  board: data-edge
+- company: Datamatics Careers- Philippines
+  board: datamatics-2
+- company: DigiOrange Inc
+  board: digiorange-inc
+- company: Digital Data Foundation
+  board: digitaldatafoundation
+- company: Dorle Controls LLC
+  board: dorle-controls-llc
+- company: DotYeti Design
+  board: dotyeti-design
+- company: Duncan & Ross
+  board: duncan-ross-management-consultancies
+- company: EastWest BPO
+  board: eastwestbpo
+- company: Edward Jacobs
+  board: edward-jacobs
+- company: EESI Philippines
+  board: eesi-philippines
+- company: Emporia Group, Inc.
+  board: emporia-group-inc
+- company: Exquisite Software, Inc.
+  board: exquisite
+- company: FinTrust Connect
+  board: fintrustconnect
+- company: Fox Point Recruitment LLC
+  board: fox-point-recruitment-llc
+- company: ADV TECHMINDS
+  board: freelancer-career
+- company: Fromwhere
+  board: fromwhere
+- company: Gear Inc
+  board: gear-inc-2
+- company: Gigmos
+  board: gigmos
+- company: Gladys Synergies
+  board: gladys-synergies
+- company: Go Lean Health
+  board: go-lean-health
+- company: Gunia Consulting
+  board: guniaconsulting
+- company: Hong Kong Job Consulting
+  board: hkjobc
+- company: Housenumbers
+  board: housenumbers
+- company: HR Energy Recruitment Agency
+  board: hrenergy
+- company: HRTx, Inc.
+  board: hrtx-career
+- company: Hul Hub
+  board: hulhub
+- company: Identiscents
+  board: identiscents
+- company: iLabs
+  board: ilabs
+- company: Ingeniosi
+  board: ingeniosi
+- company: InTalent Asia
+  board: intalentasia
+- company: IntelliSense.io
+  board: intellisense
+- company: Invictus Direct
+  board: invictus-2
+- company: ITHR Technologies Consulting LLC
+  board: ithr-360-consulting-fze
+- company: ITproposal
+  board: itproposal
+- company: JBHired
+  board: jb-hired
+- company: Shore360
+  board: jobs360
+- company: Joven Health
+  board: jovenhealth
+- company: Kamayi
+  board: kamayi
+- company: KARRA Law PLLC
+  board: karralaw
+- company: King Deux Search & Consulting
+  board: kingdeux
+- company: Masters Career Consultancy Pte Ltd
+  board: masters-career-consultancy-pte-ltd
+- company: Meydenbauer Partners
+  board: meydenbauer-partners
+- company: MhyMatch
+  board: mhymatch
+- company: Agensi Pekerjaan Minde Group Sdn Bhd
+  board: mindegroup
+- company: MindPlus (Pvt) Ltd
+  board: mindplus-pvt-ltd
+- company: Mira Staffing
+  board: mirastaffing
+- company: Monocle Solutions
+  board: monocle-solutions
+- company: More Staffing LLC
+  board: morestaffing
+- company: Motravay.mu
+  board: motravay-jobs
+- company: Myanma Posts and Telecommunications
+  board: mptofficialpage
+- company: My Consulting Offer
+  board: my-consulting-offer-2
+- company: NANOSOFT CONSULTING TALENT PAGE
+  board: nanosoft-consulting
+- company: NearSource Technologies
+  board: nearsource
+- company: Nekia Nichelle, LLC.
+  board: nekia-nichelle-llc
+- company: Netsurit
+  board: netsurit
+- company: Newbridge
+  board: newbridge-
+- company: Norman Alex
+  board: normanalexjobs
+- company: Novare RH
+  board: novare-rh
+- company: Nubitz
+  board: nubitz
+- company: Ocean Virtual Assistant Solutions
+  board: ocean-virtual-assistant-solutions
+- company: Olive Recruit
+  board: olive-recruit-uk
+- company: Opulence Education Group
+  board: opulence-education-group
+- company: 'Our Lead Good Course LLC, DBA: HBAConnect'
+  board: our-lead-good-course-llc-dba-hbaconnect
+- company: OutsourcedIn
+  board: outsourcedin
+- company: Outsourcey
+  board: outsourcey
+- company: Palladium Transportation, LLC
+  board: palladium-transportation-llc
+- company: People Profilers
+  board: people-profilers
+- company: People Profilers Vietnam
+  board: people-profilers-vietnam
+- company: People's Growth HR Solutions
+  board: peoples-growth-hr-solutions
+- company: Perennial HR
+  board: perennial-hr
+- company: Permhunt
+  board: permhunt
+- company: PILLARS
+  board: pillars
+- company: Plutus21
+  board: plutus21
+- company: PM Consulting
+  board: pm-consulting-5
+- company: PPR Ventures
+  board: ppr-ventures
+- company: PradeepIT Consulting Services Pvt Ltd
+  board: pradeepit
+- company: PRIME PENSIONS INC
+  board: prime-pensions-inc-2
+- company: Purolabs
+  board: purolabs
+- company: Rosetta Languages Inc.
+  board: rosetta-languages-inc
+- company: Rural Staffing Services
+  board: ruralstaffingservices
+- company: RxCloud
+  board: rxcloud
+- company: Sasso Consulting (Pty) Ltd
+  board: sassoconsulting-co
+- company: SC Consulting
+  board: sc-consulting
+- company: Scale IR
+  board: scale-ir
+- company: Siegen HR Solutions, Inc.
+  board: siegensolutionsinc
+- company: SolveNow, Inc.
+  board: solvenow-inc
+- company: SiteHost
+  board: sourcein
+- company: Star Services LLC
+  board: star-services-llc-2
+- company: Success Matcher
+  board: success-matcher-recruitment
+- company: Supersourcing
+  board: supersourcing
+- company: Swell Recruit
+  board: swell-recruit
+- company: TalentWorldGroup
+  board: talentworldgroup
+- company: TalPods
+  board: talpods
+- company: Taraki
+  board: taraki-search
+- company: TechChain Talent
+  board: techchaintalent
+- company: TECHTRACE PARTNERS
+  board: techtrace-partners
+- company: Tekhqs
+  board: tekhqs-2
+- company: TransilvaniaHR
+  board: transilvaniahr
+- company: Triptastic Adventures
+  board: triptasticadventures
+- company: United Staff Source
+  board: united
+- company: Uplift People Consulting
+  board: uplift-people-consulting
+- company: Upgrade Resources
+  board: urrecruiting
+- company: Van Hyde International
+  board: van-hyde
+- company: Veracity Group
+  board: veracitygp
+- company: Virtual Sidekicks
+  board: virtual-sidekicks
+- company: Virtual Champs Global Inc.
+  board: virtualchamps-career
+- company: Vital Virtuals LLC
+  board: vital-virtuals-global-hr-solutions-llc
+- company: Vneuron
+  board: vneuron-group
+- company: Voypost GmbH
+  board: voypost
+- company: Wall of Wonders Travel
+  board: wall-of-wonders-travel
+- company: White Cloak Technologies
+  board: white-cloak-technologies
+- company: WIRE IT
+  board: wire-it
+- company: WizeTalent (a service/brand of Wize Mentoring)
+  board: wizetalent

--- a/sources/oracle.yml
+++ b/sources/oracle.yml
@@ -1598,3 +1598,41 @@
   board: ibywjb.fa.ocs.oraclecloud.com/CX_1
 - company: U.S. Silica
   board: icbajb.fa.ocs.oraclecloud.com/CX_1
+- company: Onity Group Inc.
+  board: ebhz.fa.us2.oraclecloud.com/cx
+- company: Ocwen Financial Corporation
+  board: ebhz.fa.us2.oraclecloud.com/jobsearch
+- company: Job Listings at Liquidity Services Inc.
+  board: ebwi.fa.us2.oraclecloud.com/careers-liquidityservices
+- company: Acosta
+  board: eczy.fa.us2.oraclecloud.com/cx_1
+- company: Alithya
+  board: effx.fa.ca2.oraclecloud.com/cx
+- company: Centra Health
+  board: ejid.fa.us6.oraclecloud.com/cx_1001
+- company: Universidad Europea
+  board: emer.fa.em3.oraclecloud.com/cx
+- company: Carrington
+  board: emvo.fa.us2.oraclecloud.com/jobsearch
+- company: Sensient Technologies
+  board: eour.fa.us2.oraclecloud.com/cx
+- company: The Church of Jesus Christ of Latter-day Saints
+  board: epej.fa.us2.oraclecloud.com/cx_1001
+- company: Avient
+  board: fa-eqzh-saasfaprod1.fa.ocs.oraclecloud.com/cx_1
+- company: EF Education First
+  board: fa-evad-saasfaprod1.fa.ocs.oraclecloud.com/cx_1
+- company: HealthTrust Workforce Solutions
+  board: fa-evzu-saasfaprod1.fa.ocs.oraclecloud.com/cx_1
+- company: Sana
+  board: fa-eycl-saasfaeuraprod1.fa.ocs.oraclecloud.com/cx_4025
+- company: Alta Genetics
+  board: hdjm.fa.ca2.oraclecloud.com/alta
+- company: Sinch
+  board: iaings.fa.ocs.oraclecloud.com/cx_1
+- company: Hoag Health System
+  board: iaucqy.fa.ocs.oraclecloud.com/cx
+- company: Anywhere Real Estate Inc.
+  board: ibmqjb.fa.ocs.oraclecloud.com/cx
+- company: Honeywell International Inc.
+  board: ibqbjb.fa.ocs.oraclecloud.com/cx

--- a/sources/peopleforce.yml
+++ b/sources/peopleforce.yml
@@ -160,3 +160,17 @@
   board: efuturemedia
 - company: MindK
   board: mindk
+- company: CMX Solutions
+  board: cmx-solutions
+- company: Fishing Planet
+  board: fishingplanet
+- company: Gehtsoft USA LLC
+  board: gehtsoft
+- company: Honeytech
+  board: honeytech
+- company: Hraymo
+  board: hraymo
+- company: Kraken Leads
+  board: kraken-leads
+- company: Sybilla Technologies
+  board: sybillatechnologies

--- a/sources/personio.yml
+++ b/sources/personio.yml
@@ -8255,3 +8255,9 @@
   board: wikando
 - company: XU Exponential University of Applied Science GmbH
   board: xu-de
+- company: Fishing-King
+  board: fishing-king-gmbh
+- company: OTL - Online Trainer GmbH
+  board: otl-akademie
+- company: SBIT AG
+  board: sbit-ag

--- a/sources/pinpoint.yml
+++ b/sources/pinpoint.yml
@@ -1539,3 +1539,5 @@
   board: missionedge
 - company: Xeneta
   board: xeneta
+- company: Algomarketing
+  board: algomarketing

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -4141,3 +4141,15 @@
   board: skycellag
 - company: SMART Recruiting GmbH
   board: smartrecruiting
+- company: ACCUFILE, INC.
+  board: accufilecareers
+- company: Óscala
+  board: oscalabv
+- company: Project Y
+  board: projecty
+- company: Self Bill Pro
+  board: selfbillpro
+- company: 'Codest Ltd. Company No. 12590542, VAT number: GB363431020'
+  board: thecodest
+- company: WeSoftYou
+  board: wesoftyou2

--- a/sources/rippling.yml
+++ b/sources/rippling.yml
@@ -655,3 +655,187 @@
   board: williamsburg-learning
 - company: Zumper
   board: zumper
+- company: Advisor360, LLC
+  board: advisor360-llc
+- company: Alias Intelligence
+  board: aliasintelligence
+- company: AllVoices
+  board: allvoices
+- company: Ampa Health
+  board: ampa
+- company: Anaconda
+  board: anaconda
+- company: Analyte Health
+  board: analyte-health-careers
+- company: apexanalytix
+  board: apexanalytix-careers
+- company: AspenView Technology Partners, Inc.
+  board: aspenview
+- company: BayRock Labs
+  board: bayrock-labs
+- company: BizzyCar, Inc.
+  board: bizzycar
+- company: Brainrider
+  board: brainrider
+- company: Brightside Health
+  board: brightside-health-jobs
+- company: BTC Inc
+  board: btc-inc
+- company: Carbon Health
+  board: carbon-health
+- company: Neuronetics
+  board: careers-neuronetics
+- company: InfoMC
+  board: careers_at_infomc
+- company: Cefaly US Inc.
+  board: cefaly-us-inc
+- company: Citrine Informatics
+  board: citrine-informatics
+- company: Citylogix
+  board: citylogix
+- company: Concept Plus
+  board: conceptplus
+- company: Cozey
+  board: cozey-fr
+- company: Curve Dental
+  board: curve-dental
+- company: Dialogue
+  board: dialogue-en
+- company: Divcon Controls
+  board: divcon-controls
+- company: Duku AI
+  board: duku-ai
+- company: Ecotrak
+  board: ecotrak-careers
+- company: EHS Support, LLC
+  board: ehs-support-llc
+- company: Eleanor Health
+  board: eleanor-health-careers
+- company: Enertiv
+  board: enertiv-jobs
+- company: Equality Florida
+  board: equality-florida
+- company: eSkillz Corp
+  board: eskillz
+- company: Eventeny
+  board: eventeny
+- company: Gridsight
+  board: gridsight
+- company: Hammerspace
+  board: hammerspace
+- company: Harbor IT
+  board: harbor-it
+- company: Harbor Compliance
+  board: harborcompliance
+- company: HealthSnap
+  board: healthsnapcareers
+- company: Hearth
+  board: hearth-careers
+- company: HTX Labs
+  board: htx-labs-careers
+- company: Hunter Strategy
+  board: hunterstrategy
+- company: Integrated Management Strategies
+  board: imstrat
+- company: InAir
+  board: inair
+- company: Incredible Health
+  board: incredible-health
+- company: Interplay Learning
+  board: interplaylearning
+- company: IOActive
+  board: ioactive-tc
+- company: Hipcamp
+  board: join-the-hipcamp-team
+- company: KlientBoost
+  board: klientboost-careers
+- company: Lavender
+  board: lavender-careers
+- company: Lemonaid Health
+  board: lemonaid-health
+- company: LinqCare
+  board: linqcare-careers
+- company: Loggerhead Insurance
+  board: loggerhead-risk-management-llc
+- company: Lyte AI
+  board: lyte
+- company: Malwarebytes
+  board: malwarebytes
+- company: Measurabl
+  board: measurabljobs
+- company: Mission Underwriting Managers
+  board: mission-underwriting-services
+- company: Nerdio
+  board: nerdio-careers
+- company: Net at Work
+  board: netatwork
+- company: NikoHealth
+  board: nikohealth
+- company: Nox Health
+  board: nox-health
+- company: Offprem Technology
+  board: offprem-technology
+- company: Onward Rides
+  board: onward
+- company: OrthoFi
+  board: orthofi-open-roles
+- company: Paradise Media
+  board: paradise-media-recruitment
+- company: PatientFi, Inc.
+  board: patientfi
+- company: PatientNow
+  board: patientnow
+- company: PAXAFE
+  board: paxafe
+- company: Peach Finance
+  board: peach-finance
+- company: Portside
+  board: portside
+- company: PreVeil
+  board: preveil
+- company: Priorities USA
+  board: priorities
+- company: Q4 Inc.
+  board: q4_careers
+- company: Qoria
+  board: qoria
+- company: ReUp Education
+  board: reup-education
+- company: RevOptimal
+  board: revoptimal
+- company: Rocket Clicks
+  board: rocket-clicks-careers
+- company: Recycle Track Systems
+  board: rts-careers
+- company: Sibros Technologies
+  board: sibros-technologies
+- company: Skillable
+  board: skillable-careers
+- company: Softengine
+  board: softengine
+- company: Soleno Therapeutics, Inc.
+  board: soleno
+- company: Solv
+  board: solv-health
+- company: Soteria
+  board: soteria
+- company: Sunco.com
+  board: sunco-lighting
+- company: Surfline\Wavetrak, Inc.
+  board: surfline
+- company: Swingtech
+  board: swingtech-careers
+- company: Texan Insurance
+  board: texan-insurance
+- company: ThreatDown
+  board: threatdown
+- company: TuneIn
+  board: tunein
+- company: Vaya Adventures
+  board: vaya-adventures
+- company: Vheda Health
+  board: vheda-health
+- company: Within Health
+  board: within-health-provider-services
+- company: Workstreet
+  board: workstreet

--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -6791,3 +6791,91 @@
   board: HarrierTalentSolutions
 - company: Hastee
   board: Hastee
+- company: Acadsoc
+  board: AcadsocLtd
+- company: Ansrsource
+  board: Ansrsource1
+- company: BelHard Academy
+  board: BELHARDAcademy
+- company: Cacheflow
+  board: Cacheflow
+- company: Christopher O'Keeffe CPA LLC
+  board: ChristopherOKeeffeCPALLC
+- company: Cystems Logic Inc
+  board: CystemsLogicInc1
+- company: DBServices Portugal
+  board: DBServicesPortugal
+- company: DDD Soluciones Estratégicas
+  board: DDDSolucionesEstratgicas
+- company: Duelit
+  board: Duelit
+- company: Excyl, Inc.
+  board: ExcylInc
+- company: Energi
+  board: Finance2ocom
+- company: Five to Nine
+  board: FiveToNine
+- company: Game On
+  board: GameOnStudio
+- company: Guest-tek
+  board: Guest-tekIndia
+- company: Harold Jean-Louis, Inc.
+  board: HaroldJean-LouisInc
+- company: Hedgehog
+  board: Hedgehog1
+- company: Italian Itinerary
+  board: IronicMusicBookingAgencyLLC
+- company: KGS Technology Group Inc
+  board: KGSTechnologyGroupInc
+- company: Koneo Mobile Inc.
+  board: KoneoMobileInc
+- company: Markeeters
+  board: Markeeterscom
+- company: MedSoft
+  board: MedSoft1
+- company: Mela Capital Group
+  board: MelaCapitalGroup
+- company: MyTime
+  board: MyTime
+- company: Now100
+  board: Now100
+- company: OnActuate
+  board: OnActuate
+- company: Otter Technologies
+  board: OtterLLC
+- company: Paragon One
+  board: ParagonOne
+- company: PayReview
+  board: PayReview
+- company: PhillyTech.Co
+  board: PhillyTechCo
+- company: Prieds
+  board: PriedsTechnology
+- company: proGroupX
+  board: ProGroupX
+- company: RedTeam - Construction Technology
+  board: RedteamDevelopers
+- company: Rocket Internet
+  board: RocketInternet
+- company: SEE Change Happen Ltd
+  board: SEEChangeHappenLtd
+- company: Sacré-Davey
+  board: Sacr-DaveyEngineeringInc
+- company: Shaping Cloud
+  board: ShapingCloud
+- company: Sky Solutions LLC.
+  board: SkySolutionsLLC
+- company: Tap
+  board: Tap1
+- company: The Coastal Star
+  board: TheCoastalStar
+- company: The League
+  board: TheLeague1
+- company: Verdant Services
+  board: Verdant1
+- company: Vied Technologies,Inc.
+  board: ViedTech
+- company: Vitt
+  board: Vitt1
+- company: ZILLION TECHNOLOGIES, INC
+  board: ZILLIONTECHNOLOGIESINC

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -4001,3 +4001,35 @@
   board: youth2030-1738049921.teamtailor.com
 - company: Zeekr EU
   board: zeekreu.teamtailor.com
+- company: Covenant House International
+  board: covenanthouseinternational.na.teamtailor.com
+- company: Fortray Global Service Limited
+  board: fortrayglobalservices.teamtailor.com
+- company: Full Fabric
+  board: fullfabricspoonsixlimited.teamtailor.com
+- company: Grapefruit Health
+  board: grapefruithealth.na.teamtailor.com
+- company: Harper James
+  board: harperjames.teamtailor.com
+- company: HelioCampus
+  board: heliocampus.teamtailor.com
+- company: iPostal1
+  board: ipostal.na.teamtailor.com
+- company: Keypath Education
+  board: keypatheducation.teamtailor.com
+- company: Lanterna Education
+  board: lanternaeducation.teamtailor.com
+- company: Let's Do This
+  board: letsdothis-1704821225.teamtailor.com
+- company: Opisto
+  board: opisto.teamtailor.com
+- company: Orbus Software
+  board: orbussoftware-1698312371.teamtailor.com
+- company: Spokeo
+  board: spokeo.na.teamtailor.com
+- company: SQDM
+  board: sqdm.na.teamtailor.com
+- company: Sydiera
+  board: sydiera.na.teamtailor.com
+- company: Upstart 13
+  board: upstart13.teamtailor.com

--- a/sources/trakstar.yml
+++ b/sources/trakstar.yml
@@ -1320,3 +1320,9 @@
   board: happyfox
 - company: Roccam Recruiting
   board: roccam
+- company: First American Insurance Underwriters
+  board: faiu
+- company: Fox Hill Entertainment LLC
+  board: foxhillllc
+- company: Independent Security Evaluators
+  board: securityevaluators

--- a/sources/ukg.yml
+++ b/sources/ukg.yml
@@ -6198,3 +6198,21 @@
   board: recruiting.ultipro.com/wor1020wedu/e69cea0c-67ff-4625-8ec3-58d077d22d6b
 - company: Yaskawa Motoman
   board: recruiting.ultipro.com/yas1000yaami/79c5e373-83ab-4894-be19-ed78fff999d4
+- company: American Psychological Association
+  board: recruiting.ultipro.com/ame1075/09af7a49-6e44-7933-83ad-e62b675aa816
+- company: AppGate Cybersecurity, Inc.
+  board: recruiting.ultipro.com/app1016appg/b1835dc3-01c0-407b-8133-9f5271b45494
+- company: Chevron Federal Credit Union
+  board: recruiting.ultipro.com/che1007chev/604b85b9-c229-47a8-8319-5b9130e7bd81
+- company: DEKRA
+  board: recruiting.ultipro.com/dek1001dekra/279d4c12-9b32-4c76-b373-460f98949c0d
+- company: Nice North America
+  board: recruiting.ultipro.com/nor1040nscl/81bb5d78-faf6-4573-bbc6-103c08741b19
+- company: Applied High Voltage
+  board: recruiting.ultipro.com/sig1007sgen/e1600e84-a041-4ccd-9291-ca8e6e6d9d34
+- company: ConMet
+  board: recruiting2.ultipro.com/ams1003amsii/331f4ac6-5e4b-42db-aed0-5bf0b3f0acdb
+- company: StrongMind
+  board: recruiting2.ultipro.com/str1017sminc/a463cac3-d7a2-4601-bb54-c314f757142d
+- company: OneSupport
+  board: recruiting2.ultipro.com/tel1011telen/e93c61da-7e6d-48b6-8c39-f13572780311

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -3081,3 +3081,259 @@
   board: zaizi
 - company: ZILO
   board: zilo-1
+- company: 211 Broward
+  board: 211-broward-1
+- company: Adepto Technical Recruitment
+  board: adepto-technical-recruitment
+- company: AIRS Medical Inc
+  board: airs-medical-inc
+- company: Arpu Telecommunication Services
+  board: arpu-telecommunication-services
+- company: Associated Veterinary Partners
+  board: associated-veterinary-partners
+- company: AutoLeap
+  board: autoleap
+- company: Better Impact
+  board: better-impact
+- company: BigDataCorp
+  board: bigdatacorp
+- company: Blessinger Legal
+  board: blessinger-legal
+- company: Blue Raster
+  board: blue-raster
+- company: BP3 Global, Inc.
+  board: bp3
+- company: BusPlanner
+  board: busplanner
+- company: bwise Media AG
+  board: bwise-media-ag
+- company: C the Signs
+  board: c-the-signs
+- company: Cache Ventures
+  board: cache
+- company: CareHarmony
+  board: care-harmony
+- company: Centorrino Technologies
+  board: centorrino-technologies
+- company: Chase Design Group
+  board: chase-design-group
+- company: CircleLink Health
+  board: circlelink-health
+- company: ClassWallet
+  board: classwallet
+- company: ClearlyAgile
+  board: clearlyagile
+- company: Client Accelerators
+  board: client-accelerators
+- company: Clipt
+  board: clipt
+- company: Cloudtalk
+  board: cloudtalk
+- company: World Business Lenders, LLC
+  board: commercial-lending
+- company: Common App
+  board: commonapp
+- company: Coretek Services
+  board: coretek-services
+- company: COSMOTE GLOBAL SOLUTIONS NV
+  board: cosmote-global-solutions-nv
+- company: Crumdale Specialty
+  board: crumdale-specialty
+- company: CXG
+  board: cxg
+- company: CXM Direct LLC
+  board: cxmdirect
+- company: Cynet Corp
+  board: cynet-corp
+- company: Deep Science Ventures
+  board: deep-science-ventures
+- company: Destsetters
+  board: destsetters
+- company: DigitalGenius
+  board: digitalgenius
+- company: division50
+  board: division50
+- company: DomainTools
+  board: domain-tools
+- company: Dreamix Ltd.
+  board: dreamix-ltd
+- company: Elevate and Delegate
+  board: eandd
+- company: emerchantpay
+  board: emerchantpay
+- company: EMW, Inc.
+  board: emw
+- company: Encoded Therapeutics
+  board: encoded
+- company: EverService
+  board: everservice
+- company: Everyday Dose Inc.
+  board: everyday-dose-inc
+- company: EVOTEK, Inc.
+  board: evotek-1
+- company: Excelya
+  board: excelya
+- company: Facet
+  board: facetwealth
+- company: Focus Group
+  board: focus-group
+- company: Fuku
+  board: fuku
+- company: Fullstack Academy
+  board: fullstackacademy
+- company: Geeks on Site
+  board: geeks-on-site
+- company: Globaldev Group
+  board: globaldevgroup
+- company: Globl.Contact GmbH
+  board: globl-contact
+- company: Hadley Designs
+  board: hadley-designs
+- company: HeadQuarters
+  board: headquarters
+- company: HealthHero
+  board: healthhero
+- company: HeavenHR
+  board: heavenhr
+- company: Horizontal Digital
+  board: horizontal-digital
+- company: Huble
+  board: huble
+- company: IAPWE
+  board: iapwe
+- company: Infinum
+  board: infinum
+- company: InnovationTeam
+  board: innovationteam
+- company: Interlaced
+  board: interlaced
+- company: IPID
+  board: ipid
+- company: Isla
+  board: islacare
+- company: JMAC Lending
+  board: jmac-lending
+- company: Jump 450 Media
+  board: jump450
+- company: Kreyco
+  board: kreyco
+- company: KPI Solutions
+  board: kueckerpulseintegration
+- company: LanguageWire
+  board: languagewire
+- company: Livestock Information
+  board: livestock-information
+- company: Maker Lab
+  board: maker-lab
+- company: Michael & Associates, Attorneys at Law
+  board: michaelandassociates
+- company: Middle Seat
+  board: middle-seat
+- company: MMDSmart Ltd
+  board: mmdsmart-ltd
+- company: Move For Hunger
+  board: move-for-hunger
+- company: Mursion Inc
+  board: mursion-inc
+- company: Navarino
+  board: navarino
+- company: NeoWork
+  board: neowork
+- company: NobleAI
+  board: noble-ai
+- company: OJ Digital Solutions
+  board: ojdigitalsolutions
+- company: OneIMS Group
+  board: oneims
+- company: OOCA
+  board: oocahq
+- company: Orgvue
+  board: orgvue
+- company: Packback
+  board: packback
+- company: Packt
+  board: packtpublishing
+- company: PERSUIT
+  board: persuit-1
+- company: Petra Brands
+  board: petra-brands
+- company: PetroApp
+  board: petroapp
+- company: Pharmacy2U
+  board: pharmacy2u
+- company: Phillips Consulting
+  board: phillips-consulting
+- company: Platinumlist
+  board: platinum-list
+- company: PM2CM
+  board: pm2cm
+- company: Popmenu
+  board: popmenu
+- company: Power Factors
+  board: power-factors
+- company: Quant Master Servicer S.A.
+  board: qquant-master-servicer-sa
+- company: Re7 Capital
+  board: re7-capital
+- company: The Really Great Teacher Company
+  board: reallygreatteachers
+- company: REAPRA PTE. LTD.
+  board: reapra-pte-ltd
+- company: ResponsiveAds, Inc.
+  board: responsiveads-inc
+- company: Revive Media
+  board: revive-media
+- company: Right Hook Digital
+  board: righthookdigital
+- company: Ripjar
+  board: ripjar
+- company: Sago
+  board: sago-group
+- company: Shiftmove
+  board: shiftmove
+- company: Silvur
+  board: silvur
+- company: Skin + Me
+  board: skinandme
+- company: Slip Robotics
+  board: slip-robotics
+- company: Smeetz
+  board: smeetz
+- company: Sphynx
+  board: sphynx
+- company: stakefish
+  board: stakefish
+- company: SteadyMD
+  board: steadymd
+- company: Stethoscope SA
+  board: stethoscope-sa
+- company: Stitch Consulting Services, Inc.
+  board: stitch-consulting-services-inc
+- company: Talent Voyager
+  board: talent-voyager
+- company: TCP Software
+  board: tcp-software-1
+- company: Tech Firefly
+  board: techfirefly
+- company: TechOp Solutions International
+  board: techop-solutions-international
+- company: Toyota Tsusho Systems
+  board: toyota-tsusho-systems
+- company: TPAPT
+  board: tpapt
+- company: Triptease
+  board: triptease
+- company: Unblu Inc.
+  board: unblu
+- company: Vatica Health
+  board: vatica-health
+- company: Wifinity
+  board: wifinity-4
+- company: Wisevu
+  board: wisevu
+- company: WorldVia
+  board: worldviatravel
+- company: Xenon7
+  board: xenon7
+- company: zeroheight
+  board: zeroheight

--- a/sources/workday.yml
+++ b/sources/workday.yml
@@ -13081,3 +13081,11 @@
   board: webtravelgroup.wd103.myworkdayjobs.com/WebBeds_Jobs
 - company: Xeris Pharmaceuticals, Inc.
   board: xerispharma.wd503.myworkdayjobs.com/xerispharmaceuticalscareers
+- company: Elementis
+  board: elementis.wd502.myworkdayjobs.com/elementis_careers
+- company: evoila GmbH
+  board: evoila.wd3.myworkdayjobs.com/evoilajobs
+- company: Hyphen Solutions
+  board: hyphensolutions.wd5.myworkdayjobs.com/hyphen_solutions
+- company: Telstra
+  board: telstra.wd3.myworkdayjobs.com/tls-careers

--- a/sources/zohorecruit.yml
+++ b/sources/zohorecruit.yml
@@ -2478,3 +2478,111 @@
   board: wyrestorm.zohorecruit.com
 - company: Zuci Systems
   board: zucisystems.zohorecruit.com
+- company: 24 Hours Group
+  board: 24hours-group.zohorecruit.com
+- company: 8Twelve Mortgage
+  board: 8twelve.zohorecruit.com
+- company: Astra North Infoteck Inc.
+  board: astra-north.zohorecruit.ca
+- company: Autocorp.ai
+  board: autocorp.zohorecruit.com
+- company: Back At You
+  board: backatyou.zohorecruit.com
+- company: Berkeley Payment Solutions Inc.
+  board: berkeleypayment.zohorecruit.com
+- company: Career Directions Limited (CDL)
+  board: cdl.zohorecruit.com
+- company: CRT Construction
+  board: crtconstruction.zohorecruit.com
+- company: Deployed Philippines, Inc.
+  board: deployedstaff.zohorecruit.com
+- company: DocStar Medical Partners
+  board: docstarmedical.zohorecruit.com
+- company: DTC Canada
+  board: dtc-ctd.zohorecruit.com
+- company: Eastwood & Cleef, LLC
+  board: eastwoodcleef.zohorecruit.com
+- company: Effizient Immigration Inc.
+  board: effizient.zohorecruit.com
+- company: Elite Recruit LLC
+  board: elite-recruit.zohorecruit.eu
+- company: Everyday People Inc.
+  board: everydaypeopleinc.zohorecruit.com
+- company: Expertise Recruitment
+  board: expertiserecruitment.zohorecruit.com
+- company: Extratik
+  board: extratik.zohorecruit.com
+- company: FlexiSAF Edusoft
+  board: flexisaf.zohorecruit.com
+- company: Friedom Partners
+  board: friedompartners.zohorecruit.com
+- company: Sryde Digital Marketing
+  board: futureaccess.zohorecruit.com
+- company: Gbitcorp
+  board: gbitcorp.zohorecruit.com
+- company: Shapely
+  board: getshapely.zohorecruit.com
+- company: Helix Workforce
+  board: helixworkforce.zohorecruit.com
+- company: Heritage Health Network
+  board: heritagehealthnetwork.zohorecruit.com
+- company: Hespress
+  board: hespress.zohorecruit.com
+- company: Kasper
+  board: heykasper.zohorecruit.eu
+- company: Indigo Beam Consulting
+  board: indigobeam.zohorecruit.com
+- company: ITCareerHub
+  board: itcareerhub.zohorecruit.com
+- company: Look4IT
+  board: look4it.zohorecruit.com
+- company: Mach7 Technologies
+  board: mach7t.zohorecruit.com
+- company: Marktine Technology Solutions Pvt Ltd
+  board: marktine.zohorecruit.com
+- company: MNF Global Jobs
+  board: mnfglobal.zohorecruit.com
+- company: My Zoom Technologies Inc.
+  board: myzoomride.zohorecruit.com
+- company: NENO
+  board: neno.zohorecruit.com
+- company: Onemind Services LLC
+  board: onemindservices.zohorecruit.com
+- company: People and Partners Group Company Limited
+  board: peopleandpartnersgroup.zohorecruit.com
+- company: Planned Growth
+  board: plannedgrowth.zohorecruit.com
+- company: Paradise Travel Group
+  board: playadelcarmen.zohorecruit.com
+- company: Roundglass Wellbeing Pvt Ltd
+  board: roundglass.zohorecruit.com
+- company: SUNSHINE ENTERPRISE USA LLC
+  board: seu-usa.zohorecruit.com
+- company: Singapore Math Classes & Camps
+  board: singaporemathclasses.zohorecruit.com
+- company: SkillHat
+  board: skillhat.zohorecruit.com
+- company: Softensity Inc.,
+  board: softensity.zohorecruit.com
+- company: Softgic
+  board: softwareestrategico.zohorecruit.com
+- company: Spektra Systems
+  board: spektrasystems.zohorecruit.com
+- company: Talencore
+  board: talencore.zohorecruit.com
+- company: torchinsky
+  board: torchinsky.zohorecruit.com
+- company: Tyfone, Inc.
+  board: tyfone.zohorecruit.com
+- company: Virtual Talent Latam
+  board: virtualtalentlatam.zohorecruit.com
+- company: Visvero, Inc.
+  board: visvero.zohorecruit.com
+- company: Wanderlog
+  board: wanderlog.zohorecruit.com
+- company: White Tiger Connections
+  board: whitetigerconnections.zohorecruit.com
+- company: WOW Remote Teams
+  board: wowremoteteams.zohorecruit.com
+- company: X-Series USA
+  board: xseriesusa.zohorecruit.com


### PR DESCRIPTION
Targets a gap the site-crawl harvests could not reach: companies whose postings we hold ONLY through an aggregator, with no direct-ATS row anywhere in the catalogue.

## How the boards were found

The aggregator's public API only ever exposes its own internal apply page. Its mobile API's per-posting detail carries a short redirect code, and that redirect — ungated — lands on the employer's own ATS. So each board comes from a **real URL the employer published**, never from a guessed or searched slug. That distinction is why this works at all: the earlier name-guessing harvest returned 12 boards from 14 385 candidates.

The redirect is metered per IP, and an over-budget request answers **302 to the aggregator's own /jobs page** — a success status carrying a useless destination. Results are therefore checked against the destination host, not the status code; an early interleaved run silently lost 46% of its yield to exactly this before the check was added.

The run was then split so each hop pays only its own cost: collect every code under the hourly device token, then drain the redirects at a self-tuning rate that halves on a trip and creeps back while clean. **One rate-limit trip in 7 200 redirects.**

## Coverage and yield

| | |
|---|---|
| companies with no ATS coverage | 7 328 (of 15 845 matched by folded name) |
| apply codes collected | 7 200 (98%) |
| redirects resolved | 7 200 (100%) |
| destinations resolving to a known board | 5 546 (77%) |
| **landed after live probe** | **2 698** |

The second wave covered the 4 109 companies the aggregator reported as having NO live postings. That flag describes the aggregator's index, not the employer — 98.6% still answered, and the "empty" half landed 3.5x what the live half did.

## Which platforms this reaches

The catalogue effect is lopsided, and that is the finding:

| provider | before | after |
|---|---:|---:|
| manatal | 142 | **578** |
| comeet | 23 | **114** |
| rippling | 326 | **695** |
| zohorecruit | 1 238 | 1 655 |
| smartrecruiters | 3 394 | 3 755 |
| greenhouse | 7 153 | 7 166 |
| ashby | 4 087 | 4 091 |

A `careers-page.com` or `comeet.com` tenant is normally linked only from a posting's Apply button, never from the company's own site — so site-walking harvests could not reach them however many companies they visited. Where the platform IS reachable from a homepage, the yield is a rounding error.

## Quality

- **Probe failures: 0.** Every board answered its platform's API before landing.
- **The name gate refused 159** whose board reports a slightly different employer name (`Leverify` vs `Leverify Group`). Left out rather than argued with — a wrong board costs more than a missing one.
- **Duplicate audit over all 95 994 entries in every board file: 0 introduced.** The first wave did produce four Oracle case-variant duplicates, removed by hand; #2068 carries the dedup-key fix, which was applied while harvesting the second wave and held.
- ~6% of the new boards carry a staffing-agency name, so this is mostly ordinary employers rather than agency repost inventory.

`go test ./internal/sources/` green (it parses and validates every board file).

Independent of #2068, which only prevents the Oracle and iCIMS identity defects from recurring.