### PR TITLE
Make the curated Industry facet reachable, and retire the YC one

### DIFF
--- a/cmd/import-yc/main_test.go
+++ b/cmd/import-yc/main_test.go
@@ -27,6 +27,43 @@ func TestRecordToParamsCanonicalizesIndustries(t *testing.T) {
 	}
 }
 
+// The subindustry leaf reaches the curated column on the real path — ycdir.Map
+// unions it into Record.Industries, and this worker canonicalizes that union. The
+// web filter drops the separate `subindustries` facet on the strength of exactly
+// this: a company's YC leaf is already expressible as a curated industry, so the
+// leaf needs no filter of its own. Driven through Map, not a hand-built Record,
+// because the union is Map's job and this asserts the seam between them.
+func TestSubindustryLeafReachesIndustriesThroughMap(t *testing.T) {
+	rec, ok := ycdir.Map(ycdir.Entry{Name: "Acme", Subindustry: "B2B -> Fintech", Batch: "Winter 2024"})
+	if !ok {
+		t.Fatal("Map dropped the entry")
+	}
+
+	got := recordToParams(rec)
+	if want := []string{"fintech"}; !reflect.DeepEqual(got.Industries, want) {
+		t.Errorf("Industries = %q, want %q", got.Industries, want)
+	}
+	// The scalar column still holds the directory's own leaf verbatim: the facet is
+	// gone from the filter, the classification is not gone from the row.
+	if !got.Subindustry.Valid || got.Subindustry.String != "Fintech" {
+		t.Errorf("Subindustry = %+v, want a valid %q", got.Subindustry, "Fintech")
+	}
+}
+
+// A leaf the dictionary does not know reaches the curated column from no path —
+// the leaf's own vocabulary carries YC's bucket names ("B2B", "Engineering,
+// Product and Design"), which name no industry.
+func TestUnknownSubindustryLeafReachesIndustriesFromNoPath(t *testing.T) {
+	rec, ok := ycdir.Map(ycdir.Entry{Name: "Acme", Subindustry: "B2B -> Engineering, Product and Design", Batch: "Winter 2024"})
+	if !ok {
+		t.Fatal("Map dropped the entry")
+	}
+
+	if got := recordToParams(rec); len(got.Industries) != 0 {
+		t.Errorf("Industries = %q, want empty", got.Industries)
+	}
+}
+
 type fakeStore struct {
 	exists    map[string]bool
 	jobCounts map[string]int32

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -569,12 +569,6 @@ export function createApi(
     );
   }
 
-  /** The subindustry facet vocabulary (each clean YC leaf + its company count),
-   *  count-ordered, backing the company "Industry" filter's searchable options. */
-  async function listCompanySubindustries(): Promise<{ value: string; count: number }[]> {
-    return requestData<{ value: string; count: number }[]>('/api/v1/companies/subindustries');
-  }
-
   /** Population-ranked city-name search over the embedded GeoNames dictionary,
    *  backing the profile's base-city and relocation-cities autocomplete. `country`
    *  narrows to one ISO 3166-1 alpha-2 code; each result carries its own raw code
@@ -2034,7 +2028,6 @@ export function createApi(
     ingestStatus,
     listCompanies,
     getCompany,
-    listCompanySubindustries,
     searchCities,
     insightsRoles,
     insightsSkills,

--- a/web/src/lib/companyRailGroups.test.ts
+++ b/web/src/lib/companyRailGroups.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { COMPANY_FACETS } from './facets';
+import { COMPANY_RAIL_GROUPS } from './filterSections';
+
+describe('company filter rail groups', () => {
+  // The rail is the ONLY way into a company facet: a param the groups forget is
+  // still parsed from the URL and still sent to the API, but nothing in the modal
+  // can select it. That is how the curated Industry facet and Company stage sat
+  // unreachable — declared, wired, and invisible. Assert the cover so the next
+  // facet cannot repeat it.
+  it('renders every company facet in exactly one pane', () => {
+    const grouped = COMPANY_RAIL_GROUPS.flatMap((g) => g.params);
+
+    expect(new Set(grouped).size).toBe(grouped.length);
+    expect(new Set(grouped)).toEqual(new Set(COMPANY_FACETS.map((f) => f.param)));
+  });
+
+  it('names each pane with a distinct key', () => {
+    const keys = COMPANY_RAIL_GROUPS.map((g) => g.key);
+
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});

--- a/web/src/lib/components/filters/CompanyFilterModal.svelte
+++ b/web/src/lib/components/filters/CompanyFilterModal.svelte
@@ -2,7 +2,7 @@
   import { COMPANY_FACETS } from '$lib/facets';
   import type { CompanyFilterStore } from '$lib/companyFilters';
   import { StagedCompanyFilters } from '$lib/stagedCompanyFilters.svelte';
-  import type { RailEntry, RailSection } from '$lib/filterSections';
+  import { COMPANY_RAIL_GROUPS, type RailEntry, type RailSection } from '$lib/filterSections';
   import type { FacetCounts } from '$lib/types';
   import FacetSection from '../facets/FacetSection.svelte';
   import FilterModalShell from './FilterModalShell.svelte';
@@ -21,20 +21,10 @@
 
   const staged = new StagedCompanyFilters();
 
-  // Rail groups: each pane renders the FacetSections for its `params`, in order. A
-  // single-facet group is just its own pane (Collection/Country/Industry). Every
-  // COMPANY_FACETS param appears in exactly one group.
-  const GROUPS: { key: string; label: string; params: string[] }[] = [
-    { key: 'collections', label: 'Collection', params: ['collections'] },
-    { key: 'region', label: 'Region', params: ['regions', 'remote_regions'] },
-    { key: 'countries', label: 'Country', params: ['countries'] },
-    { key: 'subindustries', label: 'Industry', params: ['subindustries'] },
-    { key: 'domains', label: 'Domain', params: ['domains'] },
-    { key: 'company', label: 'Company', params: ['company_type', 'company_size'] },
-    { key: 'yc', label: 'Y Combinator', params: ['yc_status', 'yc_stage', 'yc_flags', 'yc_batch'] },
-  ];
-
-  const rail: RailEntry[] = GROUPS.map((g) => ({
+  // Rail groups live in filterSections.ts beside the job modal's RAIL, where a test
+  // can assert they cover every COMPANY_FACETS param — an ungrouped facet is not
+  // merely misplaced, it is unreachable.
+  const rail: RailEntry[] = COMPANY_RAIL_GROUPS.map((g) => ({
     key: g.key,
     label: g.label,
     section: 'FILTERS',
@@ -42,7 +32,7 @@
   }));
   const sections: RailSection[] = ['FILTERS'];
 
-  const paramsOf = (key: string) => GROUPS.find((g) => g.key === key)?.params ?? [];
+  const paramsOf = (key: string) => COMPANY_RAIL_GROUPS.find((g) => g.key === key)?.params ?? [];
 
   // Company facets are include-only, so the badge is the total selected across the
   // group's params.

--- a/web/src/lib/facets.industries.test.ts
+++ b/web/src/lib/facets.industries.test.ts
@@ -14,19 +14,18 @@ describe('company industry facets', () => {
     expect(facet?.options?.length).toBe(INDUSTRY_VALUES.length);
   });
 
-  it('labels the YC-only subindustry facet as such', () => {
-    // subindustry is written by the YC importer alone, so calling it plain
-    // "Industry" promised catalogue-wide coverage it never had — and it held the
-    // label the curated vocabulary now earns.
-    const facet = COMPANY_FACETS.find((f) => f.param === 'subindustries');
-
-    expect(facet?.label).toBe('YC industry');
+  it('offers no second industry vocabulary beside it', () => {
+    // The YC subindustry leaf named the same thing in the directory's own words and
+    // for the ~1% of companies it covers. cmd/import-yc now folds that leaf into the
+    // curated column, so offering it as its own facet would be two filters for one
+    // idea — the column stays, the filter does not.
+    expect(COMPANY_FACETS.find((f) => f.param === 'subindustries')).toBeUndefined();
   });
 
   it('keeps the coarse domain facet distinct from the fine one', () => {
-    const labels = COMPANY_FACETS.filter((f) =>
-      ['industries', 'domains', 'subindustries'].includes(f.param),
-    ).map((f) => f.label);
+    const labels = COMPANY_FACETS.filter((f) => ['industries', 'domains'].includes(f.param)).map(
+      (f) => f.label,
+    );
 
     expect(new Set(labels).size).toBe(labels.length);
   });

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -181,30 +181,6 @@ async function companySearch(query: string): Promise<FacetOption[]> {
   return items.map((c) => ({ value: c.slug, label: c.name, count: c.job_count }));
 }
 
-// Option source for the company "Industry" facet: the full YC subindustry
-// vocabulary with company counts, fetched ONCE and searched client-side. Unlike
-// the company entity facet (thousands of rows, queried server-side per keystroke),
-// this is a bounded ~100-value list, so the whole vocabulary is loaded up front and
-// cached at module scope — the filter modal reuses it instead of re-fetching per
-// open. The subindustry leaf is already human-readable, so value == label.
-let subindustryOptions: Promise<FacetOption[]> | null = null;
-function loadSubindustries(): Promise<FacetOption[]> {
-  return (subindustryOptions ??= api
-    .listCompanySubindustries()
-    .then((rows) => rows.map((r) => ({ value: r.value, label: r.value, count: r.count })))
-    .catch((e) => {
-      // Don't cache a failed fetch — clear it so a later open retries instead of
-      // leaving the facet permanently empty until a page reload.
-      subindustryOptions = null;
-      throw e;
-    }));
-}
-async function subindustrySearch(query: string): Promise<FacetOption[]> {
-  const all = await loadSubindustries();
-  const q = query.trim().toLowerCase();
-  return q ? all.filter((o) => o.label.toLowerCase().includes(q)) : all;
-}
-
 // Composes one /geo/cities result into a FacetOption: the value stays the bare city
 // name (what a profile's location_preferences already stores), the label adds the
 // country via the same countryLabel() resolver COUNTRY_OPTIONS uses, so two
@@ -533,9 +509,6 @@ export const COMPANY_FACETS: FacetDef[] = [
   { param: 'remote_regions', label: 'Remote hiring', control: 'pills', options: REGION, excludable: false },
   { param: 'countries', label: 'Country', control: 'select', options: COUNTRY, excludable: false, placeholder: 'Search countries' },
   { param: 'industries', label: 'Industry', control: 'select', options: INDUSTRIES, excludable: false, placeholder: 'Search industries' },
-  // Written by the YC importer alone, so it never covered the catalogue. Named for
-  // what it is rather than holding the label the curated vocabulary earns.
-  { param: 'subindustries', label: 'YC industry', control: 'remote', excludable: false, placeholder: 'Search YC industries', remote: subindustrySearch },
   { param: 'domains', label: 'Domain', control: 'select', options: DOMAINS, excludable: false, placeholder: 'Search domains' },
   { param: 'company_type', label: 'Company type', control: 'pills', options: COMPANY_TYPE, excludable: false },
   { param: 'company_size', label: 'Company size', control: 'pills', options: COMPANY_SIZE, excludable: false },

--- a/web/src/lib/filterSections.ts
+++ b/web/src/lib/filterSections.ts
@@ -126,6 +126,29 @@ export interface RailEntry {
   facetParam?: string;
 }
 
+/** One pane of the company modal's rail: the FacetSections it stacks, in order. */
+export interface CompanyRailGroup {
+  key: string;
+  label: string;
+  params: string[];
+}
+
+// The company modal's rail. Unlike RAIL every pane is plain facet controls, so a
+// group is just its params — related facets fold into one pane so the geography,
+// company-shape and YC-directory facets read as three panes instead of nine rows.
+//
+// A COMPANY_FACETS param missing here is unreachable in the UI, not merely
+// ungrouped, so companyRailGroups.test.ts asserts the two sets match.
+export const COMPANY_RAIL_GROUPS: CompanyRailGroup[] = [
+  { key: 'collections', label: 'Collection', params: ['collections'] },
+  { key: 'region', label: 'Region', params: ['regions', 'remote_regions'] },
+  { key: 'countries', label: 'Country', params: ['countries'] },
+  { key: 'industries', label: 'Industry', params: ['industries'] },
+  { key: 'domains', label: 'Domain', params: ['domains'] },
+  { key: 'company', label: 'Company', params: ['company_type', 'company_size', 'maturity'] },
+  { key: 'yc', label: 'Y Combinator', params: ['yc_status', 'yc_stage', 'yc_flags', 'yc_batch'] },
+];
+
 export const RAIL: RailEntry[] = [
   // One "Role" pane holds the whole "what role" concept: the role picker
   // (natural/named/composite roles), the seniority pills, and the specialization


### PR DESCRIPTION
## What

The companies filter modal declared seven rail panes over a fourteen-param facet list. Two params — `industries` and `maturity` — were parsed from the URL, sent to the API, and selectable from nowhere. The pane labelled **Industry** rendered `subindustries` instead: the YC subindustry leaf, covering ~1% of the catalogue, which `facets.ts` already called `'YC industry'` to its face.

So the curated 74-value industry vocabulary (`internal/industrytag`, ~105k companies) shipped in July and has never been clickable.

## Changes

- Point the **Industry** pane at `industries`; give **Company stage** (`maturity`) a home in the Company pane.
- Drop the `subindustries` facet from `COMPANY_FACETS`, with its now-orphaned module-scope option cache and `api.listCompanySubindustries` wrapper.
- Move the rail groups out of the component into `filterSections.ts`, beside the job modal's `RAIL`, so a test can assert they cover every `COMPANY_FACETS` param.

## Why dropping the YC facet loses nothing

`ycdir.Map` already unions the subindustry leaf into `Record.Industries`, so `cmd/import-yc` has always canonicalized it into the very column the curated facet filters. A YC company's leaf is already expressible there — minus the leaf's own bucket names (`B2B`, `Engineering, Product and Design`), which name no industry and which the dictionary is right to refuse.

`companies.subindustry`, the `subindustries` query param and `GET /api/v1/companies/subindustries` all stay. This removes a duplicate filter, not a classification.

## Tests

- `companyRailGroups.test.ts` — every company facet lands in exactly one pane. Verified it fails when `industries` is removed from the groups; the comment asserting this cover was already in the component, only the test was missing, which is how two facets sat unreachable.
- `main_test.go` — the leaf reaches `industries` through `ycdir.Map` → `recordToParams`, and an unknown leaf reaches it from no path. Driven through `Map` rather than a hand-built `Record`, since the union is `Map`'s job.
- `facets.industries.test.ts` updated: no second industry vocabulary beside the curated one.

`go test ./...`, `go vet -tags=integration ./...`, `gofmt`, `golangci-lint`, `svelte-check` (0 errors) and all 1071 web unit tests pass.

## Ops

None. No migration, no reindex, no worker re-run — the data this facet reads is already in the column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organized filter sections for company searches, including collection, geography, industry, domain, company, and accelerator-related filters.
  * Standardized filter navigation across company filter views.

* **Bug Fixes**
  * Improved industry mapping so recognized subindustry values appear under their canonical industries while preserving subindustry details.
  * Prevented unknown subindustry values from being incorrectly classified.

* **Changes**
  * Removed subindustry as a standalone company filter and from the public filtering API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->