### PR TITLE
Stop double-crawling iCIMS, recognise two more ATS, and add 475 harvested boards

### DIFF
--- a/cmd/harvest-boards/adapter_prober_test.go
+++ b/cmd/harvest-boards/adapter_prober_test.go
@@ -45,7 +45,7 @@ func TestProberForPrefersTheBespokeProber(t *testing.T) {
 func TestProberForFallsBackToTheProvidersAdapter(t *testing.T) {
 	// Platforms with a board-keyed adapter and no bespoke prober. Before the fallback these
 	// were unharvestable: harvest-boards refused the provider outright.
-	for _, provider := range []string{"rippling", "zohorecruit", "ukg", "manatal", "phenom", "hibob"} {
+	for _, provider := range []string{"rippling", "zohorecruit", "ukg", "phenom", "hibob"} {
 		p, ok := proberFor(provider)
 		if !ok {
 			t.Errorf("proberFor(%q) not found; the provider has an adapter and is board-keyed", provider)

--- a/cmd/harvest-boards/manatal_prober.go
+++ b/cmd/harvest-boards/manatal_prober.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// manatalProber validates a Manatal board "<tenant>" by counting the postings linked from its
+// hosted career page ("careers-page.com/<tenant>") and reading the tenant's own name off that
+// page's title.
+//
+// The name matters more here than on most platforms. Manatal is heavily used by recruitment
+// AGENCIES, so a posting's hiring company is routinely NOT the board's owner — a seed built
+// from an aggregator's hiringOrganization labelled three different agency boards with the same
+// client, and the adapter stamps every posting with the entry's company. The career page names
+// the tenant that owns the board, which is the only correct label.
+//
+// Without this the provider fell through to adapterProber, which runs a whole crawl per
+// candidate and publishes no name at all.
+type manatalProber struct{}
+
+// manatalJobLink captures a posting's id from a Manatal career-page job link
+// (/<tenant>/job/<id>), so the title and apply links to one posting count once.
+var manatalJobLink = regexp.MustCompile(`/job/([A-Za-z0-9]+)`)
+
+// manatalTitleSuffix is what Manatal appends to every hosted career page's title. The tenant
+// name is whatever precedes it.
+const manatalTitleSuffix = "| Career Page"
+
+func (manatalProber) probe(ctx context.Context, c httpClient, board string) (string, int, error) {
+	root, err := c.GetHTML(ctx, fmt.Sprintf("https://careers-page.com/%s", board))
+	if err != nil {
+		return "", 0, nil
+	}
+	ids := map[string]bool{}
+	var title string
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode {
+			switch n.Data {
+			case "a":
+				for _, a := range n.Attr {
+					if a.Key == "href" {
+						if m := manatalJobLink.FindStringSubmatch(a.Val); m != nil {
+							ids[m[1]] = true
+						}
+					}
+				}
+			case "title":
+				if title == "" && n.FirstChild != nil {
+					title = n.FirstChild.Data
+				}
+			}
+		}
+		for ch := n.FirstChild; ch != nil; ch = ch.NextSibling {
+			walk(ch)
+		}
+	}
+	walk(root)
+	if len(ids) == 0 {
+		return "", 0, nil
+	}
+	return manatalTenantName(title), len(ids), nil
+}
+
+// manatalTenantName pulls the tenant out of a Manatal career-page title, which reads
+// " - <tenant> | Career Page". It cuts at the LAST suffix occurrence so a tenant whose own
+// name contains a pipe survives, and returns "" when the title carries no name — the caller
+// then falls back rather than storing a fragment of boilerplate as a company.
+func manatalTenantName(title string) string {
+	i := strings.LastIndex(title, manatalTitleSuffix)
+	if i < 0 {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(title[:i]), "-"))
+}

--- a/cmd/harvest-boards/manatal_prober_test.go
+++ b/cmd/harvest-boards/manatal_prober_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+func TestManatalProbe(t *testing.T) {
+	p := manatalProber{}
+	listing := `<html><head><title> - Aisling Group | Career Page</title></head><body>
+<a href="/aisling-group/job/38R3R8">Recruiter</a>
+<a href="/aisling-group/job/38R3R8">Apply</a>
+<a href="/aisling-group/job/534YR3">Analyst</a>
+<a href="/aisling-group">Home</a>
+</body></html>`
+	getter := fakeGetter{
+		"https://careers-page.com/aisling-group": listing,
+		"https://careers-page.com/empty": `<html><head><title> - Nobody Ltd | Career Page</title></head>
+<body><a href="/empty">Home</a></body></html>`,
+		"https://careers-page.com/untitled": `<html><body>
+<a href="/untitled/job/1">Role</a></body></html>`,
+	}
+	// The tenant name is the board owner and is what the entry must be labelled with: on an
+	// agency board it is the agency, never the client the posting is for.
+	if name, n, err := p.probe(context.Background(), getter, "aisling-group"); err != nil || name != "Aisling Group" || n != 2 {
+		t.Errorf("live: got (%q,%d,%v), want (\"Aisling Group\",2,nil)", name, n, err)
+	}
+	// A board with a name but no postings is not live, and must not be proposed.
+	if _, n, err := p.probe(context.Background(), getter, "empty"); err != nil || n != 0 {
+		t.Errorf("empty: got n=%d err=%v, want 0,nil", n, err)
+	}
+	// No parseable title: still live, but the name is left to the caller's fallback rather
+	// than invented.
+	if name, n, err := p.probe(context.Background(), getter, "untitled"); err != nil || name != "" || n != 1 {
+		t.Errorf("untitled: got (%q,%d,%v), want (\"\",1,nil)", name, n, err)
+	}
+	if _, n, err := p.probe(context.Background(), getter, "gone"); err != nil || n != 0 {
+		t.Errorf("gone: got n=%d err=%v, want 0,nil", n, err)
+	}
+}
+
+func TestManatalTenantName(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{" - Aisling Group | Career Page", "Aisling Group"},
+		{"Aisling Group | Career Page", "Aisling Group"},
+		{" - PT Yamaha Motor Indonesia | Career Page", "PT Yamaha Motor Indonesia"},
+		// A tenant whose own name carries a pipe must not be truncated at the first one.
+		{" - Saje | Retail | Career Page", "Saje | Retail"},
+		{"Career Page", ""},
+		{"", ""},
+	} {
+		if got := manatalTenantName(tc.in); got != tc.want {
+			t.Errorf("manatalTenantName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/cmd/harvest-boards/prober.go
+++ b/cmd/harvest-boards/prober.go
@@ -788,6 +788,7 @@ var probers = map[string]prober{
 	"paylocity":       paylocityProber{},
 	"hireology":       hireologyProber{},
 	"pageup":          pageupProber{},
+	"manatal":         manatalProber{},
 	"cornerstone":     adapterProber{provider: "cornerstone", newSource: func() sources.Source { return sources.NewCornerstone(sources.NewClient()) }},
 	"taleo":           adapterProber{provider: "taleo", newSource: func() sources.Source { return sources.NewTaleo(sources.NewCookieClient()) }},
 	"neogov":          adapterProber{provider: "neogov", newSource: func() sources.Source { return sources.NewNeogov(sources.NewClient()) }},

--- a/internal/atsboard/board.go
+++ b/internal/atsboard/board.go
@@ -122,6 +122,10 @@ var atsBoards = []struct{ host, source, mode string }{
 	{"portaldetalentos.senior.com.br", "senior", modeSubdomain},
 	{"vagas.solides.com.br", "solides", modeSubdomain},
 	{"softgarden.io", "softgarden", modeSubdomain},
+	// softgarden's regional career host. The tenant label is the same board the adapter fetches
+	// at <board>.softgarden.io, so this apex only changes where the label sits — keyed on
+	// softgarden.io alone, a .de tenant hid behind a second DNS label and was declined.
+	{"career.softgarden.de", "softgarden", modeSubdomain},
 	{"careers.hibob.com", "hibob", modeSubdomain}, // HiBob's careers module: <tenant>.careers.hibob.com
 
 	// --- subdomainchain: board = every label under the apex (tenant nested under a region) ---
@@ -137,6 +141,10 @@ var atsBoards = []struct{ host, source, mode string }{
 	// board no crawl can resolve. (Its custom-domain tenants, e.g. jobs.evoplay.com.ua, stay
 	// underivable from a URL, like every other custom-domain ATS here.)
 	{"catsone", "catsone", modeHost},
+	// Avature's board is the career-site host, the shape avature.yml stores
+	// (deloittecm.avature.net). Only tenants on the platform's own domain are derivable; a
+	// vanity host (jobs.ea.com) is not, like every other custom-domain ATS here.
+	{"avature", "avature", modeHost},
 
 	// --- hostpath: board = "<host>/<site>" (Workday tenant host + first-path-segment site) ---
 	{"myworkdayjobs.com", "workday", modeHostPath},

--- a/internal/atsboard/board_test.go
+++ b/internal/atsboard/board_test.go
@@ -72,6 +72,11 @@ func TestRecognize(t *testing.T) {
 		{"personio nested apex subdomain", "https://acme.jobs.personio.com/job/9", "personio", "acme", "https://acme.jobs.personio.com", true},
 		{"personio de host", "https://reflex-aerospace-gmbh.jobs.personio.de/job/2679152?display=en#apply", "personio", "reflex-aerospace-gmbh", "https://reflex-aerospace-gmbh.jobs.personio.de", true},
 		{"softgarden subdomain", "https://moll.softgarden.io/job/123/apply", "softgarden", "moll", "https://moll.softgarden.io", true},
+		// softgarden also serves tenants under a regional career host, <tenant>.career.softgarden.de.
+		// The tenant label is the same board the adapter fetches at <board>.softgarden.io (verified
+		// live: agilitaschweiz answers on both), so only the apex differs. Keyed on softgarden.io
+		// alone, the .de host left the label behind a second DNS label and was declined.
+		{"softgarden regional career host", "https://agilitaschweiz.career.softgarden.de/jobs/65679426/sap-consultant/", "softgarden", "agilitaschweiz", "https://agilitaschweiz.career.softgarden.de", true},
 		{"hibob careers subdomain", "https://qogita.careers.hibob.com/jobs/ceb6c947-c906-44d1-a56b-bb33ae5599fa", "hibob", "qogita", "https://qogita.careers.hibob.com", true},
 		{"hibob apply tail collapses to the same board", "https://unique.careers.hibob.com/jobs/f8d9a0bc/apply", "hibob", "unique", "https://unique.careers.hibob.com", true},
 
@@ -105,6 +110,12 @@ func TestRecognize(t *testing.T) {
 		// "authoritypartnersinc", which no crawl can resolve.
 		{"catsone vacancy", "https://authoritypartnersinc.catsone.com/careers/12345-senior-engineer", "catsone", "authoritypartnersinc.catsone.com", "https://authoritypartnersinc.catsone.com", true},
 		{"catsone board listing", "https://bfc.catsone.com/careers", "catsone", "bfc.catsone.com", "https://bfc.catsone.com", true},
+
+		// Avature's board is the career-site host, exactly as avature.yml stores it
+		// (deloittecm.avature.net). Its tenants on the platform's own domain are derivable;
+		// the vanity ones (jobs.ea.com) stay out, like every other custom-domain ATS here.
+		{"avature vacancy", "https://koch.avature.net/en_us/careers/jobdetail/sr-engineer/186706", "avature", "koch.avature.net", "https://koch.avature.net", true},
+		{"avature board listing", "https://deloittecm.avature.net/careers", "avature", "deloittecm.avature.net", "https://deloittecm.avature.net", true},
 
 		// host+tenant+board mode — UKG: the board is "<host>/<tenant>/<guid>", the three parts
 		// the adapter needs to reach LoadSearchResults. The old rule took the first path segment

--- a/internal/sources/config.go
+++ b/internal/sources/config.go
@@ -74,6 +74,12 @@ func ParseRawEntries(provider string, data []byte) ([]CompanyEntry, error) {
 		if entries[i].Provider == "" {
 			entries[i].Provider = provider
 		}
+		// A board id never legitimately carries surrounding whitespace, and one that does is
+		// a board that 404s: the adapters paste it into a URL and the pipeline namespaces
+		// external_id with the literal string. It also hides a duplicate from the collapse
+		// below — a harvested UKG board arrived with a trailing space and so did not collide
+		// with the same board already in the file.
+		entries[i].Board = strings.TrimSpace(entries[i].Board)
 	}
 	return entries, nil
 }

--- a/internal/sources/config.go
+++ b/internal/sources/config.go
@@ -78,10 +78,11 @@ func ParseRawEntries(provider string, data []byte) ([]CompanyEntry, error) {
 	return entries, nil
 }
 
-// dedupeBoards collapses entries that address the same case-insensitive board on the same
-// provider and region, keeping the first occurrence. ATS board ids are case-insensitive at
-// the platform (e.g. SmartRecruiters serves the same tenant for "SopraSteria1" and
-// "soprasteria1"), but the pipeline namespaces external_id with the literal board string
+// dedupeBoards collapses entries that address the same board on the same provider and
+// region, keeping the first occurrence. Two things make one board look like two: case (ATS
+// board ids are case-insensitive at the platform — SmartRecruiters serves the same tenant for
+// "SopraSteria1" and "soprasteria1") and, on some platforms, the FORM of the id (see
+// boardIdentity). Either way the pipeline namespaces external_id with the literal board string
 // (see NamespaceExternalID), so a case-variant duplicate crawls identical postings yet
 // stores them as a SECOND row-set under a different namespace but the SAME company_slug.
 // The post-run unseen sweep is scoped by company_slug (not board), so whenever a run
@@ -101,7 +102,7 @@ func dedupeBoards(entries []CompanyEntry) []CompanyEntry {
 			continue
 		}
 		if _, dup := seen[key]; dup {
-			log.Printf("sources: dropping duplicate board %q (provider %s, company %q) — case-variant of an earlier entry",
+			log.Printf("sources: dropping duplicate board %q (provider %s, company %q) — addresses the same site as an earlier entry",
 				e.Board, e.Provider, e.Company)
 			continue
 		}
@@ -111,14 +112,29 @@ func dedupeBoards(entries []CompanyEntry) []CompanyEntry {
 	return kept
 }
 
+// boardIdentity maps a provider to the function that folds every spelling of a board into
+// the one thing it addresses. Case folding is not enough where a platform accepts more than
+// one FORM of board id: iCIMS boards are stored both as a bare slug and as the full
+// "careers-<slug>.icims.com" host, and icimsHost resolves both to that host, so the two
+// spellings are one crawl target — 37 pairs were committed and crawled as if they were two.
+// A provider absent here folds on case alone.
+var boardIdentity = map[string]func(board string) string{
+	"icims": icimsHost,
+}
+
 // boardDedupeKey is the identity dedupeBoards and DuplicateBoards collapse on:
-// case-insensitive board, provider, and region. ok is false for a boardless entry, which
-// has no tenant id and so is never a duplicate of anything.
+// case-insensitive board (folded through boardIdentity), provider, and region. ok is false
+// for a boardless entry, which has no tenant id and so is never a duplicate of anything.
 func boardDedupeKey(e CompanyEntry) (key string, ok bool) {
 	if e.Board == "" {
 		return "", false
 	}
-	return strings.ToLower(e.Provider) + "\x00" + strings.ToLower(e.Board) + "\x00" + strings.ToLower(e.Region), true
+	provider := strings.ToLower(e.Provider)
+	board := e.Board
+	if fold := boardIdentity[provider]; fold != nil {
+		board = fold(board)
+	}
+	return provider + "\x00" + strings.ToLower(board) + "\x00" + strings.ToLower(e.Region), true
 }
 
 // DuplicateBoards reports every entry that collides with an earlier one under

--- a/internal/sources/config_test.go
+++ b/internal/sources/config_test.go
@@ -63,6 +63,56 @@ func TestParseConfigDropsCaseInsensitiveBoardDuplicates(t *testing.T) {
 	}
 }
 
+// Two spellings of one iCIMS board address the same site: the adapter builds
+// "careers-<slug>.icims.com" from a bare slug and takes a dotted board as the host verbatim,
+// so "vet" and "careers-vet.icims.com" are one crawl target under two names. Case folding
+// alone does not see that, and 37 such pairs sat in sources/icims.yml being crawled twice.
+func TestParseConfigDropsBoardSpellingsAddressingTheSameSite(t *testing.T) {
+	data := []byte(`
+- company: Vet Jobs
+  board: careers-vet.icims.com
+- company: Stripe
+  board: stripe
+- company: vet
+  board: vet
+`)
+	cfg, err := ParseConfig("icims", data)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	want := []CompanyEntry{
+		{Company: "Vet Jobs", Provider: "icims", Board: "careers-vet.icims.com"}, // first wins
+		{Company: "Stripe", Provider: "icims", Board: "stripe"},
+	}
+	if len(cfg.Sources) != len(want) {
+		t.Fatalf("len(Sources) = %d, want %d: %+v", len(cfg.Sources), len(want), cfg.Sources)
+	}
+	for i, w := range want {
+		if cfg.Sources[i] != w {
+			t.Errorf("Sources[%d] = %+v, want %+v", i, cfg.Sources[i], w)
+		}
+	}
+}
+
+// The fold is per-provider: a bare "vet" and a "careers-vet.icims.com" on a provider that
+// does NOT resolve both to one host are two different boards, and collapsing them would
+// silently drop a live crawl target.
+func TestParseConfigFoldsBoardSpellingsOnlyForTheOwningProvider(t *testing.T) {
+	data := []byte(`
+- company: Vet Jobs
+  board: careers-vet.icims.com
+- company: vet
+  board: vet
+`)
+	cfg, err := ParseConfig("greenhouse", data)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if len(cfg.Sources) != 2 {
+		t.Fatalf("len(Sources) = %d, want 2: %+v", len(cfg.Sources), cfg.Sources)
+	}
+}
+
 // A same-name board on two different regional hosts (distinct Region) is a genuinely
 // different crawl target, not a case duplicate, so both are kept.
 func TestParseConfigKeepsSameBoardOnDifferentRegions(t *testing.T) {

--- a/internal/sources/config_test.go
+++ b/internal/sources/config_test.go
@@ -94,6 +94,29 @@ func TestParseConfigDropsBoardSpellingsAddressingTheSameSite(t *testing.T) {
 	}
 }
 
+// A board id never legitimately carries surrounding whitespace, and one that does is a board
+// that 404s: the pipeline namespaces external_id with the literal string and the adapters
+// paste it into a URL. It also hides a duplicate — a harvested UKG board arrived with a
+// trailing space and so did not collide with the same board already in the file.
+func TestParseConfigTrimsBoardWhitespace(t *testing.T) {
+	data := []byte(`
+- company: Atlantic Union Bank
+  board: recruiting.ultipro.com/uni1046ufmb/d8f90aad
+- company: Atlantic Union Bank (harvested)
+  board: 'recruiting.ultipro.com/uni1046ufmb/d8f90aad '
+`)
+	cfg, err := ParseConfig("ukg", data)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if len(cfg.Sources) != 1 {
+		t.Fatalf("len(Sources) = %d, want 1: %+v", len(cfg.Sources), cfg.Sources)
+	}
+	if got := cfg.Sources[0].Board; got != "recruiting.ultipro.com/uni1046ufmb/d8f90aad" {
+		t.Errorf("Board = %q, want it trimmed", got)
+	}
+}
+
 // The fold is per-provider: a bare "vet" and a "careers-vet.icims.com" on a provider that
 // does NOT resolve both to one host are two different boards, and collapsing them would
 // silently drop a live crawl target.

--- a/sources/applicantpro.yml
+++ b/sources/applicantpro.yml
@@ -3980,3 +3980,13 @@
   board: ves
 - company: Wise Foods
   board: wisesnacks
+- company: Bastion Technologies, Inc.
+  board: bastiontechnologies
+- company: Resilient Structures
+  board: resilient-structures-ca
+- company: Vetco
+  board: vetcoclinics
+- company: Viking Pest Control
+  board: vikingpest
+- company: We Power America
+  board: wepoweramerica

--- a/sources/avature.yml
+++ b/sources/avature.yml
@@ -13,3 +13,17 @@
   board: deloittecm.avature.net
 - company: Qatar Airways
   board: careers.qatarairways.com
+- company: Bloomberg
+  board: bloomberg.avature.net
+- company: Bupa
+  board: bupaanz.avature.net
+- company: Jardine Restaurant Group
+  board: jrg.avature.net
+- company: Koch
+  board: koch.avature.net
+- company: MANTECH
+  board: mantech.avature.net
+- company: Murphy-Hoffman Company (MHC Kenworth)
+  board: mhcta.avature.net
+- company: Xerox
+  board: xerox.avature.net

--- a/sources/breezy.yml
+++ b/sources/breezy.yml
@@ -4167,3 +4167,5 @@
   board: wstudio
 - company: Zoomer
   board: zoomer
+- company: Next Generation Inc
+  board: next-generation-inc

--- a/sources/careerplug.yml
+++ b/sources/careerplug.yml
@@ -942,3 +942,71 @@
   board: full-package-media
 - company: Sir Grout
   board: sir-grout-careers
+- company: Amsterdam Cafe
+  board: amsterdam-cafe
+- company: Barrel House
+  board: barrel-house
+- company: Bear Flag Fish Company
+  board: bear-flag-fish-company
+- company: Blo Blow Dry Bar
+  board: blo-blow-dry-bar-careers
+- company: Bonton Farms
+  board: bonton
+- company: Boost Home Health
+  board: boost-home-health-careers
+- company: British Swim School - Hudson Waterfront
+  board: british-swim-school-glen-mills-media
+- company: The Brothers that just do Gutters
+  board: brothersgutters-north-houston
+- company: Buff City Soap
+  board: buff-city-soap
+- company: College H.U.N.K.S. Hauling Junk and Moving
+  board: chhj-careers
+- company: Chop Stop
+  board: chop-stop
+- company: ClinDCast
+  board: clindcast-llc
+- company: Conserva Irrigation
+  board: conserva-irrigation-careers
+- company: EITACIES Inc.
+  board: eitacies-inc
+- company: Experience Columbia SC
+  board: experiencecolumbiasc
+- company: Facilities Maintenance Management, LLC. (FMM)
+  board: fmmla
+- company: Grayson College
+  board: grayson-county-junior-college-district
+- company: Gyu-Kaku Japanese BBQ Restaurant
+  board: gyu-kaku
+- company: HealthSource® - America's Chiropractor
+  board: healthsource-chiropractic-careers
+- company: KidStrong
+  board: kidstrong-macleod-trail
+- company: Kimbrell’s Home Furnishings (Furniture Distributors, Inc.)
+  board: kimbrells-furniture
+- company: Live 2 B Healthy | Senior Fitness
+  board: live-2-b-healthy-careers
+- company: OnTheFly Hospitality
+  board: onthefly
+- company: Palm Beach Tan
+  board: palm-beach-tan-premiere-entertainment-llc
+- company: Palm Beach Tan
+  board: palm-beach-tan-west-coast-tanning-inc
+- company: Polly's Pies
+  board: polly-pies-careers
+- company: Right at Home
+  board: right-at-home-utah-county
+- company: Rosati's Pizza
+  board: rosatis-pizza-careers
+- company: THE SHACK WINGS & BREWS, INC.
+  board: shack-wings-brews
+- company: Texas Roadhouse
+  board: texas-roadhouse
+- company: Thrifty White Pharmacy
+  board: thrifty-white-pharmacy
+- company: Turning Point Restaurants
+  board: turning-point
+- company: Up Closets
+  board: up-closets-careers
+- company: Vitality Bowls
+  board: vitalitybowlscareers

--- a/sources/catsone.yml
+++ b/sources/catsone.yml
@@ -48,3 +48,15 @@
   board: cbsinfosys.catsone.com
 - company: PlacingIT
   board: placingit.catsone.com
+- company: Ricoh Hong Kong Limited
+  board: delken.catsone.com
+- company: hireVouch
+  board: hirevouch.catsone.com
+- company: Linked, LLC
+  board: linked.catsone.com
+- company: Med Career Solutions, LLC
+  board: medcareersolutions.catsone.com
+- company: Partnership with Children
+  board: partnershipwithchildren.catsone.com
+- company: Specialty Medical Staffing
+  board: specialtymedicalstaffing.catsone.com

--- a/sources/cornerstone.yml
+++ b/sources/cornerstone.yml
@@ -34,3 +34,13 @@
   board: sseacademy
 - company: SL Controls Ltd
   board: nnit
+- company: Banco Bradesco
+  board: bradesco
+- company: GALERIA
+  board: galeria
+- company: Henkel
+  board: henkel
+- company: Transdev
+  board: transdev
+- company: TravelCenters of America
+  board: travelcenters

--- a/sources/factorial.yml
+++ b/sources/factorial.yml
@@ -998,3 +998,11 @@
   board: mundi.factorialhr.com
 - company: Nextail
   board: nextaillabs.factorial.es
+- company: HiSERV GmbH
+  board: hiservjobs.factorialhr.com
+- company: Krank
+  board: krank.factorialhr.com
+- company: Remitee
+  board: remitee.factorialhr.com
+- company: SEIDOR
+  board: seidorarg.factorialhr.com

--- a/sources/freshteam.yml
+++ b/sources/freshteam.yml
@@ -450,3 +450,13 @@
   board: turnhq
 - company: Velocity
   board: velocity
+- company: Credit Saison India
+  board: creditsaisonin-talent
+- company: Crushvertise
+  board: crushvertise
+- company: Ninjacart
+  board: ninjacart
+- company: PSG & Sons' Charities
+  board: psgsonscharities
+- company: Tutoring Club
+  board: tutoringclub

--- a/sources/gem.yml
+++ b/sources/gem.yml
@@ -506,3 +506,9 @@
   board: rootly
 - company: Thrivory
   board: thrivory
+- company: 'Trayd: Construction Payroll, HR, & Compliance'
+  board: buildtrayd-com
+- company: Farmer's Business Network, Inc.
+  board: farmers-business-network
+- company: OpenReq
+  board: openreqstaffing

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14351,3 +14351,5 @@
   board: phagenesisltd
 - company: Weeks & Gowen Physical Therapy
   board: wgphysicaltherapyjobs
+- company: Copilot Careers
+  board: copilotcareers

--- a/sources/hireology.yml
+++ b/sources/hireology.yml
@@ -4940,3 +4940,5 @@
   board: abstraktmarketinggroup
 - company: Always Best Care - Charleston, SC
   board: alwaysbestcareseniorservices
+- company: EPOCH Senior Living
+  board: bridgesbyepochatwestford

--- a/sources/icims.yml
+++ b/sources/icims.yml
@@ -113,7 +113,7 @@
   board: aitworldwide
 - company: ajiusa
   board: ajiusa
-- company: akahillc
+- company: Akahi Associates, LLC
   board: akahillc
 - company: alaskausa
   board: alaskausa
@@ -161,7 +161,7 @@
   board: americafirst
 - company: americanaddictioncenters
   board: americanaddictioncenters
-- company: americancareercollege
+- company: American Career College
   board: americancareercollege
 - company: americanfoodsgroup
   board: americanfoodsgroup
@@ -359,7 +359,7 @@
   board: barrios
 - company: barstowhvac
   board: barstowhvac
-- company: barton-supply
+- company: Barton Supply
   board: barton-supply
 - company: bartwest
   board: bartwest
@@ -391,7 +391,7 @@
   board: bemcataubrey
 - company: benaroyaresearch
   board: benaroyaresearch
-- company: benefitcosmeticsuk
+- company: Benefit Cosmetics
   board: benefitcosmeticsuk
 - company: benjaminmoore
   board: benjaminmoore
@@ -573,7 +573,7 @@
   board: calspan
 - company: cambrianhomecare
   board: cambrianhomecare
-- company: campero
+- company: Pollo Campero
   board: campero
 - company: campusapts
   board: campusapts
@@ -789,7 +789,7 @@
   board: collinscomfort
 - company: colonialoaks
   board: colonialoaks
-- company: columbuszoo
+- company: Columbus Zoo and Aquarium
   board: columbuszoo
 - company: comcastspectacor
   board: comcastspectacor
@@ -853,7 +853,7 @@
   board: coolray
 - company: cooltoday
   board: cooltoday
-- company: cooperhealth
+- company: Cooper University Hospital
   board: cooperhealth
 - company: cooperparry
   board: cooperparry
@@ -1005,7 +1005,7 @@
   board: dillingheating
 - company: dippleservices
   board: dippleservices
-- company: directlumberanddoor
+- company: Direct Lumber and Door of Colorado
   board: directlumberanddoor
 - company: discountplumbingrooterinc
   board: discountplumbingrooterinc
@@ -1373,13 +1373,13 @@
   board: goprimegroup
 - company: gordontruckcenters
   board: gordontruckcenters
-- company: gotyto
+- company: Tyto Athene
   board: gotyto
 - company: gowithpeak
   board: gowithpeak
 - company: granerx
   board: granerx
-- company: granicus
+- company: Granicus
   board: granicus
 - company: gray
   board: gray
@@ -1439,7 +1439,7 @@
   board: harpercollins
 - company: harrison-ymca
   board: harrison-ymca
-- company: hawaiigas
+- company: Hawaiʻi Gas
   board: hawaiigas
 - company: haybrook
   board: haybrook
@@ -1831,7 +1831,7 @@
   board: kiscoseniorliving
 - company: kleinfelder
   board: kleinfelder
-- company: kloveair1
+- company: Educational Media Foundation
   board: kloveair1
 - company: kmco
   board: kmco
@@ -1911,7 +1911,7 @@
   board: lgamerica
 - company: lhbcorp
   board: lhbcorp
-- company: lhs
+- company: Legacy Health
   board: lhs
 - company: libertycompaniesllc
   board: libertycompaniesllc
@@ -1985,7 +1985,7 @@
   board: macalester
 - company: macny
   board: macny
-- company: madeiramadeira
+- company: Madeira Madeira
   board: madeiramadeira
 - company: mafint
   board: mafint
@@ -2147,7 +2147,7 @@
   board: mrcentral
 - company: mrn
   board: mrn
-- company: mrocorp
+- company: Q-Centrix (now part of MRO Corporation)
   board: mrocorp
 - company: mrplumberatlanta
   board: mrplumberatlanta
@@ -2309,7 +2309,7 @@
   board: oefederal
 - company: oldnational
   board: oldnational
-- company: omegatechserv
+- company: Omega Technical Services
   board: omegatechserv
 - company: omnisource
   board: omnisource
@@ -2339,7 +2339,7 @@
   board: osb
 - company: ostcm
   board: ostcm
-- company: osuphysicians
+- company: The Ohio State University Wexner Medical Center
   board: osuphysicians
 - company: otterproducts
   board: otterproducts
@@ -2481,13 +2481,13 @@
   board: premierdentistpartners
 - company: premierehcstaffing
   board: premierehcstaffing
-- company: preshomes
+- company: Presbyterian Homes & Services
   board: preshomes
 - company: prg
   board: prg
 - company: prginternational
   board: prginternational
-- company: prideindustries
+- company: PRIDE Industries
   board: prideindustries
 - company: pridemechanicalllc
   board: pridemechanicalllc
@@ -2649,7 +2649,7 @@
   board: robertsac
 - company: robertson
   board: robertson
-- company: rochebros
+- company: Roche Bros
   board: rochebros
 - company: rocketpharma
   board: rocketpharma
@@ -2677,7 +2677,7 @@
   board: rpmliving
 - company: rpoustinc
   board: rpoustinc
-- company: rrsc
+- company: Roto-Rooter
   board: rrsc
 - company: rsandh
   board: rsandh
@@ -2711,7 +2711,7 @@
   board: samedayelectric
 - company: sanctuaryhospice
   board: sanctuaryhospice
-- company: sanmiguel
+- company: San Miguel Foods
   board: sanmiguel
 - company: sares-regis
   board: sares-regis
@@ -2777,7 +2777,7 @@
   board: shaneco
 - company: shawmut
   board: shawmut
-- company: shepleywoodproducts
+- company: Shepley Wood Products
   board: shepleywoodproducts
 - company: shimmick
   board: shimmick
@@ -2871,11 +2871,11 @@
   board: southend-borough-council
 - company: southernairenow
   board: southernairenow
-- company: southernairms
+- company: Southern Pipe & Supply
   board: southernairms
 - company: southernmaine-ymca
   board: southernmaine-ymca
-- company: southland
+- company: Southland Development Authority
   board: southland
 - company: souto
   board: souto
@@ -2969,7 +2969,7 @@
   board: structurepoint
 - company: stuartmechanical
   board: stuartmechanical
-- company: studyville
+- company: Studyville
   board: studyville
 - company: suburbanpropane
   board: suburbanpropane
@@ -3233,13 +3233,13 @@
   board: udst
 - company: uewhealth
   board: uewhealth
-- company: uhnjcareers
+- company: University Hospital
   board: uhnjcareers
 - company: uk-merlinentertainments
   board: uk-merlinentertainments
 - company: uk-treliant
   board: uk-treliant
-- company: umms
+- company: ForHealth Consulting
   board: umms
 - company: undergroundconstruction
   board: undergroundconstruction
@@ -3293,11 +3293,11 @@
   board: usptm
 - company: usta
   board: usta
-- company: usu
+- company: Utah State University Extension
   board: usu
 - company: uti
   board: uti
-- company: uuhc
+- company: University of Utah Health
   board: uuhc
 - company: uwcu
   board: uwcu
@@ -3339,7 +3339,7 @@
   board: versiti
 - company: verticalscreen
   board: verticalscreen
-- company: vet
+- company: Vet Jobs
   board: vet
 - company: vetcor
   board: vetcor
@@ -3361,7 +3361,7 @@
   board: vintun
 - company: virginiahospitalcenter
   board: virginiahospitalcenter
-- company: virginiahousing
+- company: Virginia Housing
   board: virginiahousing
 - company: virginpulse
   board: virginpulse
@@ -3501,7 +3501,7 @@
   board: yelp
 - company: ymcagreenville
   board: ymcagreenville
-- company: ymcasd
+- company: YMCA of San Diego County
   board: ymcasd
 - company: yokohamatire
   board: yokohamatire
@@ -3513,17 +3513,17 @@
   board: yusa-ymca
 - company: yusen-logistics
   board: yusen-logistics
-- company: zemitek
+- company: ZemiTek
   board: zemitek
 - company: zolmanrestoration
   board: zolmanrestoration
-- company: grizzlies
+- company: Memphis Grizzlies
   board: grizzlies
 - company: growfinancial
   board: growfinancial
 - company: sigmaconnected
   board: sigmaconnected
-- company: wd40company
+- company: WD-40
   board: wd40company
 - company: wuglobal
   board: wuglobal
@@ -3659,7 +3659,7 @@
   board: primestorage
 - company: profire-cecoenviro
   board: profire-cecoenviro
-- company: quiddity
+- company: Quiddity
   board: quiddity
 - company: ramoscs
   board: ramoscs
@@ -3719,112 +3719,40 @@
   board: realalloy
 - company: The Stronghold Companies
   board: strongholdspecialtyltd
-- company: Vet Jobs
-  board: careers-vet.icims.com
-- company: ZemiTek
-  board: careers-zemitek.icims.com
 - company: Princeton Plasma Physics Laboratory
   board: pppl-princeton.icims.com
-- company: Shepley Wood Products
-  board: careers-shepleywoodproducts.icims.com
-- company: Southern Pipe & Supply
-  board: careers-southernairms.icims.com
 - company: PRI
   board: contractwork-eauditstaff.icims.com
-- company: Hawaiʻi Gas
-  board: careers-hawaiigas.icims.com
-- company: PRIDE Industries
-  board: careers-prideindustries.icims.com
-- company: Cooper University Hospital
-  board: careers-cooperhealth.icims.com
-- company: American Career College
-  board: careers-americancareercollege.icims.com
-- company: Akahi Associates, LLC
-  board: careers-akahillc.icims.com
 - company: Jhpiego
   board: jobs-jhpiego.icims.com
-- company: University Hospital
-  board: careers-uhnjcareers.icims.com
 - company: BC Public Service
   board: careersen-victoria.icims.com
-- company: The Ohio State University Wexner Medical Center
-  board: careers-osuphysicians.icims.com
-- company: University of Utah Health
-  board: careers-uuhc.icims.com
-- company: Virginia Housing
-  board: careers-virginiahousing.icims.com
 - company: Mountain West Partnership
-  board: careers-tradeupmountainwestregion.icims.com
-- company: Studyville
-  board: careers-studyville.icims.com
-- company: ForHealth Consulting
-  board: careers-umms.icims.com
-- company: Educational Media Foundation
-  board: careers-kloveair1.icims.com
+  board: tradeupmountainwestregion
 - company: Yelp
   board: uscareers-yelp.icims.com
 - company: Barnsco Texas
-  board: careers-barnsco.icims.com
-- company: Barton Supply
-  board: careers-barton-supply.icims.com
-- company: Benefit Cosmetics
-  board: careers-benefitcosmeticsuk.icims.com
+  board: barnsco
 - company: Drybar
   board: drybarshops-wellbizbrands.icims.com
-- company: Roche Bros
-  board: careers-rochebros.icims.com
 - company: Red Lobster
   board: management-redlobster.icims.com
-- company: WD-40
-  board: careers-wd40company.icims.com
 - company: PCC Community Markets
   board: external-pccsea.icims.com
-- company: Pollo Campero
-  board: careers-campero.icims.com
-- company: Roto-Rooter
-  board: careers-rrsc.icims.com
-- company: Omega Technical Services
-  board: careers-omegatechserv.icims.com
 - company: NYU SPS Center for Global Affairs
   board: global-nyu.icims.com
 - company: NANA Regional Corporation
   board: nrc-nana.icims.com
-- company: Legacy Health
-  board: careers-lhs.icims.com
 - company: OHSU Knight Cancer Institute
   board: nursingcareers-ohsu.icims.com
-- company: Direct Lumber and Door of Colorado
-  board: careers-directlumberanddoor.icims.com
-- company: Presbyterian Homes & Services
-  board: careers-preshomes.icims.com
-- company: Columbus Zoo and Aquarium
-  board: careers-columbuszoo.icims.com
-- company: San Miguel Foods
-  board: careers-sanmiguel.icims.com
-- company: Madeira Madeira
-  board: careers-madeiramadeira.icims.com
 - company: Jack's Family Restaurants
   board: teammemberjobs-eatatjacks.icims.com
-- company: Southland Development Authority
-  board: careers-southland.icims.com
-- company: Granicus
-  board: careers-granicus.icims.com
-- company: Tyto Athene
-  board: careers-gotyto.icims.com
 - company: Go-Ahead London
   board: external-goaheadlondon.icims.com
-- company: Quiddity
-  board: careers-quiddity.icims.com
 - company: Urban Outfitters
   board: homeoffice-eu-urbn.icims.com
-- company: Memphis Grizzlies
-  board: careers-grizzlies.icims.com
 - company: Eddie Bauer
-  board: careers-eddiebauerbrand.icims.com
-- company: Utah State University Extension
-  board: careers-usu.icims.com
-- company: YMCA of San Diego County
-  board: careers-ymcasd.icims.com
+  board: eddiebauerbrand
 - company: Beaumont Health
   board: general-beaumonthospital.icims.com
 - company: University of St. Thomas
@@ -3843,8 +3771,6 @@
 # icims board mined from remote.io (2026-08-09, live-validated; vanity host, careers-home product)
 - company: Avalara
   board: careers.avalara.com
-- company: Q-Centrix (now part of MRO Corporation)
-  board: careers-mrocorp.icims.com
 - company: GR8 Global
   board: gr8affinity
 - company: Quantum Sky

--- a/sources/isolvedhire.yml
+++ b/sources/isolvedhire.yml
@@ -4410,3 +4410,5 @@
   board: villagecapital
 - company: Aalis Management Consulting
   board: aalismc
+- company: Old Colony Elder Services (OCES)
+  board: ocesma

--- a/sources/jazzhr.yml
+++ b/sources/jazzhr.yml
@@ -8633,3 +8633,25 @@
   board: vseinc
 - company: Wheeler Accountants LLP
   board: wheeler
+- company: Centroid Systems, Inc.
+  board: centroid
+- company: Cerebrocare
+  board: cerebrocare
+- company: Cherry Tree Dental
+  board: cherrytreedental
+- company: Riser Fitness, LLC
+  board: clubpilatesmissionviejo
+- company: Eventscape Inc.
+  board: eventscapeinc
+- company: Grace Federal Solutions LLC
+  board: gracefederalsolutionsllc
+- company: Kilgore College
+  board: kilgorecollege
+- company: La Clinica de Familia Inc.
+  board: laclinicadefamiliainc
+- company: Prizmah
+  board: prizmah
+- company: Valiant-Management
+  board: valiantmgmt
+- company: Walpole, Inc.
+  board: walpoleinc

--- a/sources/jobvite.yml
+++ b/sources/jobvite.yml
@@ -354,3 +354,31 @@
   board: resgroup
 - company: WorldPantry.com
   board: worldpantry
+- company: Commercial Appliance Parts and Service, LLC.
+  board: comapp
+- company: ECC
+  board: ecc
+- company: Healing Partners
+  board: healing-partners
+- company: The Iowa Clinic
+  board: iowaclinic
+- company: LHH
+  board: lhhcareers-fr
+- company: Marelli
+  board: marelli
+- company: New Pig
+  board: newpig
+- company: Northwest Center
+  board: northwest-center
+- company: Optimas Solutions
+  board: optimas
+- company: Ornge
+  board: ornge
+- company: P1 Dental Partners
+  board: p1dental-careers
+- company: Palomar Health
+  board: palomarhealth
+- company: Seaboard Marine
+  board: seaboardmarine
+- company: ZoomCare
+  board: zoomcare

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4549,3 +4549,5 @@
   board: smithmicro
 - company: Shop Your Way
   board: syw.com
+- company: Equitas Academy Charter Schools
+  board: equitasacademy

--- a/sources/manatal.yml
+++ b/sources/manatal.yml
@@ -1177,3 +1177,255 @@
   board: zagreb-global-group-recruiting-consulting
 - company: Zenith Infotech(s) Pte Ltd
   board: zenith-infotechs-pte-ltd
+- company: Black Pen Recruitment
+  board: -black-pen-recruitment
+- company: Seven Seven
+  board: 77soft
+- company: ACIERTA HEADHUNTER
+  board: acierta-headhunter
+- company: Affinity International
+  board: affinityinternational
+- company: AGILOYA AFRIQUE
+  board: agiloya-afrique
+- company: AIDA Recruitment
+  board: aida-projektai-mb
+- company: Malayan Flour Mills Berhad
+  board: aisling-group
+- company: Antal International
+  board: antal-international-network-ime
+- company: confidential
+  board: aplus-consulting-2
+- company: Arbete Careers
+  board: arbete-careers
+- company: ARSAN International Consulting Group
+  board: arsan-international-consulting-group
+- company: Unison Group
+  board: auroraap
+- company: Balr Basketball
+  board: balr
+- company: Barker Staffing Solutions, LLC
+  board: barker-staffing-solutions
+- company: Bloom Education
+  board: bloomeducation
+- company: Boardroom Appointments - Global Human and Talent Capital
+  board: boardroom-appointments
+- company: Cadmus Resources
+  board: cadmusresources
+- company: Caliberly -  Recruitment Agency
+  board: caliberly
+- company: Campion Pickworth
+  board: campion-pickworth
+- company: Capcon
+  board: capcon-asia
+- company: Carrier Johnson + Culture
+  board: carrier-johnson-culture
+- company: Catalyst Labs
+  board: catalyst-labs
+- company: Central Square Foundation
+  board: central-square-foundation
+- company: Cityfix
+  board: cityfix
+- company: Clariter Group
+  board: claritergroup
+- company: Cobden & Carter International
+  board: cobdenandcarter
+- company: Comtech LLC
+  board: comtech-llc
+- company: Delfos HR
+  board: delfos
+- company: Destination Group
+  board: destination-group
+- company: Domo Ventures
+  board: domo-ventures-careers
+- company: Dribbler
+  board: dribbler-llc
+- company: East West Banking Corporation
+  board: eastwest-bank
+- company: Esha Parama Technology
+  board: eshaparamatechnology-careers
+- company: Externa Talent Excellence
+  board: externatalenthunters
+- company: Fairmedics
+  board: fairmedics-gmbh
+- company: fastn
+  board: fastn
+- company: Fellows Hawaii inc.
+  board: fellows-hawaii-inc
+- company: FFI Advisory GmbH
+  board: ffi-advisory
+- company: Ge-n.nl | Graduate engineer - network
+  board: ge-n
+- company: GETD - Global Exchange Tecnologías Digitales
+  board: getd-global-exchange-tecnologias-digitales
+- company: The GMP Group
+  board: gmp-group-2
+- company: Ground Zero
+  board: groundzero
+- company: Gulf Workforce
+  board: gulf-workforce
+- company: HCB  Group
+  board: hcb-outsourcing
+- company: Malayan Flour Mills Berhad
+  board: hirehub-management-sdn-bhd
+- company: Hovland Barnes
+  board: hovland-barnes
+- company: Hunters International
+  board: hunters-international
+- company: icreatives
+  board: icreatives-2
+- company: iFIVE Global
+  board: ifiveglobal
+- company: Ignite Digital Talent
+  board: ignite-digital
+- company: Inhousify Recruitment & HR
+  board: inhousify
+- company: Initiate International
+  board: initiate-2
+- company: Inspire Talent Consulting inc
+  board: inspiretci-careers
+- company: InstaSwim
+  board: instaswim-llc
+- company: IT Consultis
+  board: itc-2
+- company: JDJ Diagnostics
+  board: jdj-diagnostics
+- company: Jollibee Group
+  board: jollibee-foods-corporation
+- company: JUST VARGAS
+  board: justvargasjustsearch
+- company: KateWorthington
+  board: kate-worthington
+- company: Keystone Solutions
+  board: keystone-solutions
+- company: KreativeHR Services
+  board: kreativehr
+- company: LEADER CLINICS
+  board: leader-clinics
+- company: Little Rays ABA
+  board: little-rays-aba
+- company: PT Bank Danamon Indonesia Tbk
+  board: luminare-consulting
+- company: m2TALENTS
+  board: m2talents
+- company: Mavromatis Employment Bureau LTD
+  board: mavromatis-employment-bureau
+- company: MaxIT Consulting - Max Corporate Group
+  board: maxit-consulting-jobs
+- company: Meatplus Trading Corp.
+  board: meatplus-trading-corp
+- company: Medical Staffing Solutions, USA
+  board: medical-staffing-solutions-usa
+- company: Melioris Private Limited
+  board: melioris-recruitment-private-limited
+- company: Mentory Grupo Consultor
+  board: mentory-grupo-consultor
+- company: Meratus Group
+  board: meratus
+- company: MG Head Hunting
+  board: mgheadhunting
+- company: MR DIY Philippines
+  board: mr-diy-philippines
+- company: MyRobin.ID
+  board: myrobinid
+- company: NAXCON GROUP
+  board: naxcon-gmbh-2
+- company: NTT DATA
+  board: ntt-data-singapore
+- company: Osiris Recruitment
+  board: osiris-recruitment-ltd
+- company: People Working Corp
+  board: people-working-corp
+- company: Expansion People
+  board: peopleseleccion
+- company: Pinhome
+  board: pinhome-3
+- company: PointStar
+  board: point-star
+- company: Polyglot Group
+  board: polyglot-group-7
+- company: Premier NX
+  board: premiernx
+- company: PrimeSync
+  board: primesync-solutions
+- company: Pro Coffee Gear
+  board: pro-coffee-gear
+- company: PT Bank Danamon Indonesia Tbk
+  board: pt-yamaha-motor-indonesia
+- company: Q2 HR Solutions
+  board: q2hrsolutions
+- company: Raya CX
+  board: rayacx
+- company: SMBC Group
+  board: reachext-consulting
+- company: Recruitment Partnership UK & Ireland
+  board: recruitment-partnership-ireland
+- company: RippedBoxStation
+  board: rippedboxstation
+- company: Rising Star Talent, LLC
+  board: rising-star-talent
+- company: RMA Group Company Limited
+  board: rma-group-company-limited
+- company: Rubicon Path
+  board: rubiconpath-systems
+- company: confidential
+  board: savillsvn
+- company: SCC LLC
+  board: scc
+- company: Unison Group
+  board: seacare-manpower-services-pte-ltd
+- company: SEARCH4 Global - S4G Talent Solutions GmbH
+  board: searchfour
+- company: The Vet Office
+  board: secruits
+- company: Grupo Serlima
+  board: serlimapt
+- company: Siegen HR Solutions, Inc.
+  board: siegensolutions
+- company: Sigma Consulting Group
+  board: sigma-consulting-group
+- company: Sky rekruttering
+  board: sky-rekruttering-3
+- company: Snappymob
+  board: snappymob
+- company: Source Code
+  board: source-code
+- company: ÆON Thana Sinsap (Thailand) Public Company Limited (AEONTS)
+  board: sprout-solutions-phil-inc
+- company: Stantec
+  board: stantec
+- company: STXZ LLC
+  board: stxz-llc
+- company: Talent Bridge HR Consultancy | Jobs in Dubai | Recruitment Agency | Headhunters Dubai
+  board: talent-bridge-dubai
+- company: Talents Tide
+  board: talentstides
+- company: Tap Health
+  board: taphealthcare
+- company: Dexon Technology
+  board: to-be-advice
+- company: TradeBeyond
+  board: tradebeyond
+- company: TriVA Global
+  board: triva-global
+- company: UnitedYou Ventures
+  board: unitedyouventures
+- company: Uplive
+  board: uplive
+- company: Upright Talent
+  board: uprighttalent
+- company: confidential
+  board: upskillmnlinc
+- company: Unison Group
+  board: user-experience-researchers-pteltd
+- company: Venture Dynamics
+  board: venture-dynamics
+- company: KSI Auto Parts
+  board: virtually-helpful-llc
+- company: PT Bank Danamon Indonesia Tbk
+  board: wirehire
+- company: Wizpresso 濃說
+  board: wizpresso
+- company: Yeah! Global
+  board: yeah-global
+- company: Zoom Recruitment Services Ltd
+  board: zoom-recruitment

--- a/sources/manatal.yml
+++ b/sources/manatal.yml
@@ -13,7 +13,6 @@
 # Note: many Manatal tenants are recruitment agencies posting many clients' roles; the adapter
 # labels each job with the configured company (the agency), the same as bullhorn/careerspage —
 # the per-vacancy employer is not resolved (a hub seam for later).
-
 - company: Syfe
   board: syfe
 - company: IDR
@@ -34,23 +33,16 @@
   board: recruitment-apple-lovers
 - company: AGC Recruitment
   board: job-listings
-
-# Migrated from careerspage.yml: careers-page.com IS Manatal, and the JSON API is far more
-# complete than the old <slug>.careers-page.com HTML crawl (davidjoseph-co 182 vs 6, zarego 9 vs 0).
 - company: David Joseph & Company
   board: davidjoseph-co
 - company: Zarego
   board: zarego
 - company: Alcor
   board: alcor
-
-# --- contributed boards ---
 - company: Tidal
   board: hiretidal
 - company: Nearshore Business Solutions
   board: nearshore-business-solutions
-
-# --- boards behind an application history, live-validated 2026-08-02 ---
 - company: Initiumsoft
   board: initiumsoft
 - company: Keppri
@@ -625,7 +617,7 @@
   board: arise
 - company: Asa Healthcare Staffing
   board: asa-healthcare-staffing
-- company: AsiaLocalize
+- company: Asialocalize
   board: asialocalize
 - company: Asians Group LLC
   board: asian-group-llc
@@ -681,7 +673,7 @@
   board: citygrouprecruitment
 - company: CLICKnCRUISE
   board: clickncruise
-- company: CloudCure
+- company: Cloudcure
   board: cloudcure
 - company: Code Red Recruitment
   board: code-red-recruitment
@@ -835,7 +827,7 @@
   board: instage
 - company: Intellecruit
   board: intellecruit
-- company: Interaction24
+- company: Interaction24,LLC
   board: interaction24llc
 - company: Interdot Solutions
   board: interdot-solutions
@@ -863,7 +855,7 @@
   board: koality
 - company: Kosmos Corp
   board: kosmos-corp
-- company: Laguna Resorts & Hotels
+- company: Laguna Phuket
   board: lagunaphuket
 - company: Legacy Staffing
   board: legacystaffingsol
@@ -1189,33 +1181,33 @@
   board: agiloya-afrique
 - company: AIDA Recruitment
   board: aida-projektai-mb
-- company: Malayan Flour Mills Berhad
+- company: Aisling Group
   board: aisling-group
-- company: Antal International
+- company: Antal International Network - IME
   board: antal-international-network-ime
-- company: confidential
+- company: Aplus Careers
   board: aplus-consulting-2
 - company: Arbete Careers
   board: arbete-careers
 - company: ARSAN International Consulting Group
   board: arsan-international-consulting-group
-- company: Unison Group
+- company: Aurora
   board: auroraap
-- company: Balr Basketball
+- company: Balr
   board: balr
-- company: Barker Staffing Solutions, LLC
+- company: Barker Staffing Solutions LLC
   board: barker-staffing-solutions
 - company: Bloom Education
   board: bloomeducation
-- company: Boardroom Appointments - Global Human and Talent Capital
+- company: Boardroom Appointments
   board: boardroom-appointments
-- company: Cadmus Resources
+- company: CADMUS RESOURCES
   board: cadmusresources
-- company: Caliberly -  Recruitment Agency
+- company: Caliberly
   board: caliberly
 - company: Campion Pickworth
   board: campion-pickworth
-- company: Capcon
+- company: Capcon Asia
   board: capcon-asia
 - company: Carrier Johnson + Culture
   board: carrier-johnson-culture
@@ -1223,37 +1215,37 @@
   board: catalyst-labs
 - company: Central Square Foundation
   board: central-square-foundation
-- company: Cityfix
+- company: CitiFix
   board: cityfix
-- company: Clariter Group
+- company: Clariter
   board: claritergroup
 - company: Cobden & Carter International
   board: cobdenandcarter
 - company: Comtech LLC
   board: comtech-llc
-- company: Delfos HR
+- company: Delfos
   board: delfos
 - company: Destination Group
   board: destination-group
-- company: Domo Ventures
+- company: Domo Ventures W.L.L.
   board: domo-ventures-careers
-- company: Dribbler
+- company: Dribbler LLC
   board: dribbler-llc
-- company: East West Banking Corporation
+- company: EastWest Bank
   board: eastwest-bank
 - company: Esha Parama Technology
   board: eshaparamatechnology-careers
-- company: Externa Talent Excellence
+- company: Externa Talent Hunters
   board: externatalenthunters
-- company: Fairmedics
+- company: Fairmedics GmbH
   board: fairmedics-gmbh
-- company: fastn
+- company: Fastn
   board: fastn
 - company: Fellows Hawaii inc.
   board: fellows-hawaii-inc
-- company: FFI Advisory GmbH
+- company: FFI Advisory
   board: ffi-advisory
-- company: Ge-n.nl | Graduate engineer - network
+- company: Graduate engineer - network
   board: ge-n
 - company: GETD - Global Exchange Tecnologías Digitales
   board: getd-global-exchange-tecnologias-digitales
@@ -1263,121 +1255,121 @@
   board: groundzero
 - company: Gulf Workforce
   board: gulf-workforce
-- company: HCB  Group
+- company: HCB Outsourcing
   board: hcb-outsourcing
-- company: Malayan Flour Mills Berhad
+- company: Hirehub Management Sdn. Bhd.
   board: hirehub-management-sdn-bhd
 - company: Hovland Barnes
   board: hovland-barnes
-- company: Hunters International
+- company: Hunters International Sdn Bhd
   board: hunters-international
 - company: icreatives
   board: icreatives-2
-- company: iFIVE Global
+- company: iFive Global
   board: ifiveglobal
-- company: Ignite Digital Talent
+- company: Ignite Digital
   board: ignite-digital
-- company: Inhousify Recruitment & HR
+- company: Inhousify
   board: inhousify
 - company: Initiate International
   board: initiate-2
-- company: Inspire Talent Consulting inc
+- company: Inspiretci
   board: inspiretci-careers
-- company: InstaSwim
+- company: InstaSwim LLC
   board: instaswim-llc
-- company: IT Consultis
+- company: ITC
   board: itc-2
 - company: JDJ Diagnostics
   board: jdj-diagnostics
-- company: Jollibee Group
+- company: Career Opportunities
   board: jollibee-foods-corporation
-- company: JUST VARGAS
+- company: Just Vargas
   board: justvargasjustsearch
-- company: KateWorthington
+- company: Kate Worthington
   board: kate-worthington
 - company: Keystone Solutions
   board: keystone-solutions
-- company: KreativeHR Services
+- company: Creative Resurse Umane SRL
   board: kreativehr
-- company: LEADER CLINICS
+- company: Leader Clinics
   board: leader-clinics
 - company: Little Rays ABA
   board: little-rays-aba
-- company: PT Bank Danamon Indonesia Tbk
+- company: Luminare Consulting
   board: luminare-consulting
 - company: m2TALENTS
   board: m2talents
-- company: Mavromatis Employment Bureau LTD
+- company: Mavromatis Employment Bureau
   board: mavromatis-employment-bureau
 - company: MaxIT Consulting - Max Corporate Group
   board: maxit-consulting-jobs
-- company: Meatplus Trading Corp.
+- company: MEATPLUS TRADING CORP.
   board: meatplus-trading-corp
 - company: Medical Staffing Solutions, USA
   board: medical-staffing-solutions-usa
-- company: Melioris Private Limited
+- company: Melioris Recruitment Pte. Ltd.
   board: melioris-recruitment-private-limited
 - company: Mentory Grupo Consultor
   board: mentory-grupo-consultor
 - company: Meratus Group
   board: meratus
-- company: MG Head Hunting
+- company: MG head hunting
   board: mgheadhunting
 - company: MR DIY Philippines
   board: mr-diy-philippines
 - company: MyRobin.ID
   board: myrobinid
-- company: NAXCON GROUP
+- company: NAXCON GmbH
   board: naxcon-gmbh-2
-- company: NTT DATA
+- company: NTT Data Singapore
   board: ntt-data-singapore
-- company: Osiris Recruitment
+- company: Osiris Recruitment Ltd
   board: osiris-recruitment-ltd
 - company: People Working Corp
   board: people-working-corp
-- company: Expansion People
+- company: EXPANSION PEOPLE
   board: peopleseleccion
 - company: Pinhome
   board: pinhome-3
-- company: PointStar
+- company: Pointstar
   board: point-star
 - company: Polyglot Group
   board: polyglot-group-7
 - company: Premier NX
   board: premiernx
-- company: PrimeSync
+- company: PrimeSync Solutions
   board: primesync-solutions
 - company: Pro Coffee Gear
   board: pro-coffee-gear
-- company: PT Bank Danamon Indonesia Tbk
+- company: PT Yamaha Motor Indonesia
   board: pt-yamaha-motor-indonesia
-- company: Q2 HR Solutions
+- company: Q2 HR Solutions - Group of Companies
   board: q2hrsolutions
-- company: Raya CX
+- company: RayaCX
   board: rayacx
-- company: SMBC Group
+- company: ReachExt K.K.
   board: reachext-consulting
-- company: Recruitment Partnership UK & Ireland
+- company: Recruitment Partnership Ireland
   board: recruitment-partnership-ireland
-- company: RippedBoxStation
+- company: Rippedboxstation
   board: rippedboxstation
-- company: Rising Star Talent, LLC
+- company: Rising Star Talent LLC
   board: rising-star-talent
 - company: RMA Group Company Limited
   board: rma-group-company-limited
 - company: Rubicon Path
   board: rubiconpath-systems
-- company: confidential
+- company: Savills Vietnam
   board: savillsvn
 - company: SCC LLC
   board: scc
-- company: Unison Group
+- company: Seacare Manpower Services Pte Ltd
   board: seacare-manpower-services-pte-ltd
-- company: SEARCH4 Global - S4G Talent Solutions GmbH
+- company: SEARCH4 Global - POOL YOUR TALENT
   board: searchfour
-- company: The Vet Office
+- company: Secruits
   board: secruits
-- company: Grupo Serlima
+- company: Serlima
   board: serlimapt
 - company: Siegen HR Solutions, Inc.
   board: siegensolutions
@@ -1389,41 +1381,41 @@
   board: snappymob
 - company: Source Code
   board: source-code
-- company: ÆON Thana Sinsap (Thailand) Public Company Limited (AEONTS)
+- company: Sprout Solutions Phil. Inc.
   board: sprout-solutions-phil-inc
 - company: Stantec
   board: stantec
 - company: STXZ LLC
   board: stxz-llc
-- company: Talent Bridge HR Consultancy | Jobs in Dubai | Recruitment Agency | Headhunters Dubai
+- company: Talent Bridge HR Consultancy Dubai
   board: talent-bridge-dubai
 - company: Talents Tide
   board: talentstides
-- company: Tap Health
+- company: Taphealthcare
   board: taphealthcare
-- company: Dexon Technology
+- company: To be advice
   board: to-be-advice
 - company: TradeBeyond
   board: tradebeyond
 - company: TriVA Global
   board: triva-global
-- company: UnitedYou Ventures
+- company: UnitedYou
   board: unitedyouventures
 - company: Uplive
   board: uplive
 - company: Upright Talent
   board: uprighttalent
-- company: confidential
+- company: UpSkill MNL
   board: upskillmnlinc
-- company: Unison Group
+- company: User Experience Researchers Pte.Ltd
   board: user-experience-researchers-pteltd
 - company: Venture Dynamics
   board: venture-dynamics
-- company: KSI Auto Parts
+- company: Virtually Helpful LLC
   board: virtually-helpful-llc
-- company: PT Bank Danamon Indonesia Tbk
+- company: Wirehire
   board: wirehire
-- company: Wizpresso 濃說
+- company: Wizpresso
   board: wizpresso
 - company: Yeah! Global
   board: yeah-global

--- a/sources/neogov.yml
+++ b/sources/neogov.yml
@@ -41,3 +41,15 @@
   board: governmentjobs.com/mbtama
 - company: Southern Utah University
   board: schooljobs.com/suu
+- company: State of Alaska
+  board: governmentjobs.com/alaska
+- company: Charlotte County Board of County Commissioners
+  board: governmentjobs.com/charlottecountyfl
+- company: City of Detroit
+  board: governmentjobs.com/detroit
+- company: City of Laredo
+  board: governmentjobs.com/laredo
+- company: Prince George's County, Maryland
+  board: governmentjobs.com/pgc
+- company: Philadelphia Office of Human Resources
+  board: governmentjobs.com/phila

--- a/sources/oracle.yml
+++ b/sources/oracle.yml
@@ -1690,3 +1690,65 @@
   board: ibqajb.fa.ocs.oraclecloud.com/cx_1
 - company: Cherokee Federal
   board: ibtcjb.fa.ocs.oraclecloud.com/cx
+- company: Telenet group
+  board: ebza.fa.em2.oraclecloud.com/jobsearch
+- company: Hilton
+  board: efet.fa.us2.oraclecloud.com/jobsearch
+- company: London Borough of Lambeth
+  board: effe.fa.em3.oraclecloud.com/jobsearch
+- company: Hilton Grand Vacations
+  board: efuq.fa.us6.oraclecloud.com/jobsearch
+- company: AutoZone
+  board: egud.fa.us2.oraclecloud.com/jobsearch
+- company: Con Edison
+  board: ejcu.fa.us6.oraclecloud.com/jobsearch
+- company: Natixis in Portugal
+  board: ekez.fa.em2.oraclecloud.com/jobsearch
+- company: Budimex
+  board: ekjk.fa.em2.oraclecloud.com/jobsearch
+- company: Norwegian Refugee Council
+  board: ekum.fa.em2.oraclecloud.com/jobsearch
+- company: London Borough of Newham
+  board: elyq.fa.em3.oraclecloud.com/jobsearch
+- company: Skidmore College
+  board: eodq.fa.us6.oraclecloud.com/jobsearch
+- company: Nova Systems International
+  board: epdj.fa.ap1.oraclecloud.com/jobsearch
+- company: Commonwealth of Virginia
+  board: etgi.fa.us8.oraclecloud.com/jobsearch
+- company: Lakeview Center
+  board: etud.fa.us8.oraclecloud.com/jobsearch
+- company: Omega Healthcare Management Services
+  board: fa-equm-saasfaprod1.fa.ocs.oraclecloud.com/jobsearch
+- company: Hoya Vision Care
+  board: fa-esta-saasfaprod1.fa.ocs.oraclecloud.com/jobsearch
+- company: REDPATH MINING
+  board: fa-evvx-saasfaprod1.fa.ocs.oraclecloud.com/jobsearch
+- company: The Scottish Government
+  board: fa-evxn-saasfaukgovprod1.fa.ocs.oraclecloud.com/jobsearch
+- company: Baptist Memorial Health Care
+  board: fa-ewpe-saasfaprod1.fa.ocs.oraclecloud.com/jobsearch
+- company: The Duracell Company
+  board: fa-ewub-saasfaprod1.fa.ocs.oraclecloud.com/jobsearch
+- company: Good Samaritan
+  board: fa-exgl-saasfaprod1.fa.ocs.oraclecloud.com/jobsearch
+- company: Virtuos
+  board: fa-exhj-saasfaprod1.fa.ocs.oraclecloud.com/jobsearch
+- company: DENSO
+  board: hcwt.fa.us2.oraclecloud.com/jobsearch
+- company: INSEAD
+  board: iablgs.fa.ocs.oraclecloud.com/jobsearch
+- company: Legrand
+  board: iadugs.fa.ocs.oraclecloud.com/jobsearch
+- company: Ciklum
+  board: ialmme.fa.ocs.oraclecloud.com/jobsearch
+- company: UC San Francisco (UCSF)
+  board: iazuqy.fa.ocs.oraclecloud.com/jobsearch
+- company: Brookdale
+  board: ibmwjb.fa.ocs.oraclecloud.com/jobsearch
+- company: Lifepoint Health®
+  board: ibnjjb.fa.ocs.oraclecloud.com/jobsearch
+- company: Honeywell Technologies
+  board: ibqbjb.fa.ocs.oraclecloud.com/jobsearch
+- company: Encompass Health
+  board: ibwsjb.fa.ocs.oraclecloud.com/jobsearch

--- a/sources/pageup.yml
+++ b/sources/pageup.yml
@@ -45,3 +45,41 @@
   board: "865"
 - company: Virginia Tech
   board: "968"
+- company: ANSTO
+  board: "1035"
+- company: Town of Clarkdale
+  board: "1045"
+- company: Whiddon
+  board: "1072"
+- company: Hong Kong Housing Society
+  board: "1075"
+- company: The University of Toledo
+  board: "1086"
+- company: KCTCS
+  board: "1124"
+- company: Commonwealth of Virginia
+  board: "1125"
+- company: Tennessee Board of Regents (TBR)
+  board: "1126"
+- company: University of North Texas System
+  board: "1151"
+- company: Regent University
+  board: "1152"
+- company: University of Alabama
+  board: "669"
+- company: University of Oregon
+  board: "726"
+- company: ANSTO
+  board: "759"
+- company: Michigan State University
+  board: "782"
+- company: Swarthmore College
+  board: "819"
+- company: University of Massachusetts
+  board: "822"
+- company: Robert Morris University
+  board: "856"
+- company: Johnson & Wales University
+  board: "859"
+- company: The University of Hong Kong
+  board: "932"

--- a/sources/pageup.yml
+++ b/sources/pageup.yml
@@ -45,9 +45,9 @@
   board: "865"
 - company: Virginia Tech
   board: "968"
-- company: ANSTO
+- company: Department of Education Tasmania
   board: "1035"
-- company: Town of Clarkdale
+- company: Arizona Department of Administration
   board: "1045"
 - company: Whiddon
   board: "1072"
@@ -55,9 +55,9 @@
   board: "1075"
 - company: The University of Toledo
   board: "1086"
-- company: KCTCS
+- company: Kentucky Community and Technical College System
   board: "1124"
-- company: Commonwealth of Virginia
+- company: Virginia Information Technologies Agency
   board: "1125"
 - company: Tennessee Board of Regents (TBR)
   board: "1126"
@@ -69,7 +69,7 @@
   board: "669"
 - company: University of Oregon
   board: "726"
-- company: ANSTO
+- company: Tasmanian Government
   board: "759"
 - company: Michigan State University
   board: "782"

--- a/sources/paycom.yml
+++ b/sources/paycom.yml
@@ -12013,3 +12013,39 @@
   board: D27436F25A081BBB71DFB159DD849CA4
 - company: HARMLESS HARVEST INC
   board: FECAEFD5B20E5C789241B35264FA3E08
+- company: THE PHYSICAL THERAPY INSTITUTE INC
+  board: 0144c936906adb77ebcb1b0ec1dea087
+- company: PIONEER BANK
+  board: 0589b421df8a7e0fb5dce6d09aff4c7e
+- company: Cash-Wa Distributing
+  board: 0b611de3469f8de089e85087f07ceffa
+- company: Simon Pearce
+  board: 22fe6fad60a42ea7a89c18119765f4ba
+- company: VILLAGE CHRISTIAN SCHOOL
+  board: 2d73b1dcb8f67195cb944d41c61e8b19
+- company: Amerimed
+  board: 7c984c833967d41663af4fb55e364d36
+- company: Scientific Protein Laboratories
+  board: 7e72a1098e5cabf564c98d7b23ad1aff
+- company: Hydromax USA
+  board: 895c6780af2639d64abc970c920f52d7
+- company: NINE LINE APPAREL INC
+  board: 99bb331ef82973b844e4f17683adc19d
+- company: Greystone Programs
+  board: abd904ae072d91e72f61c32045ac4fb7
+- company: Prestonwood Baptist Church
+  board: be0e5a1c2f6db2a5ff610ddfdbb3f903
+- company: Renfro Brands
+  board: cbe09312db81b5b939a1e0217773560d
+- company: RED CAT HOLDINGS
+  board: df82f4fec533913ce59d380dc7829351
+- company: SIFCO Industries
+  board: e2198342ac745a41d276e0bda3e26874
+- company: ALLIED PLASTICS LLC
+  board: e5ab46c2c4d3b4ad944978bb853f75dd
+- company: Aviva Senior Living
+  board: eb0e5fac7046a5fdc839d696702c8c8f
+- company: APPLIED INTEGRATED TECHNOLOGIES INC
+  board: f4605ab01b8ed35d725d8958e025381d
+- company: Bryant Bank
+  board: fc5825dc82e1688ff0c80d4f01d3b6cc

--- a/sources/personio.yml
+++ b/sources/personio.yml
@@ -8329,3 +8329,5 @@
   board: workist-gmbh
 - company: XDi - Experience Design Institut
   board: xdi-experience-design-institut-gmbh
+- company: Tholl Gruppe
+  board: tholl-gmbh

--- a/sources/pinpoint.yml
+++ b/sources/pinpoint.yml
@@ -1547,3 +1547,5 @@
   board: qellus
 - company: UpdatePromise
   board: updatepromise
+- company: Knowles Precision Devices
+  board: knowles

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -4211,3 +4211,13 @@
   board: viepeople
 - company: WASABIT株式会社
   board: wasabit
+- company: AMI PARIS
+  board: amiparis
+- company: Clario
+  board: clario
+- company: Lamm HR GmbH
+  board: lammhr
+- company: Schlösser GmbH & Co. KG
+  board: schloesserdichtungen
+- company: Forp
+  board: werkenviaforp

--- a/sources/rippling.yml
+++ b/sources/rippling.yml
@@ -1393,3 +1393,63 @@
   board: xypncareers
 - company: Youtooz
   board: youtooz
+- company: Blackrock Neurotech
+  board: blackrockneurotech
+- company: Central Rock Gym
+  board: central-rock-gym
+- company: Chad Jones Law
+  board: chad-jones-law
+- company: Community Physicians
+  board: community-physicians
+- company: Contour Education
+  board: contour-education
+- company: Crafty
+  board: crafty
+- company: Custer, Inc.
+  board: custer-inc
+- company: Ethical Energy Solar
+  board: ethical-energy
+- company: Extrity Services
+  board: extrityservices
+- company: Forterra
+  board: forterra
+- company: ICANotes LLC
+  board: icanotes-llc
+- company: Kindthread
+  board: kindthread
+- company: Maven Roofing
+  board: maven-roofing
+- company: MBRYONICS
+  board: mbryonics
+- company: Orion180
+  board: orion180
+- company: Patriot Erectors, LLC Steel Fabricators
+  board: patriot-erectors-llc
+- company: Regent Surgical
+  board: regent-surgical-careers
+- company: RNWBL®
+  board: rnwbl
+- company: Sales-Hub
+  board: sales-hub-careers
+- company: SERVE Hospitality Group
+  board: serve-hospitality-group-careers_2
+- company: Sperry Rail Inc.
+  board: sperry-rail-inc
+- company: Strategic Analytix
+  board: strategic-analytix-careers
+- company: Sunshine Enterprise USA
+  board: sunshine-enterprise-usa-llc
+- company: Suvida Healthcare
+  board: suvida-careers
+- company: The Learning Lamp
+  board: tllignitejobs
+- company: Touchstone Climbing
+  board: touchstone-climbing
+- company: Tract
+  board: tract
+- company: VIP Hospitality, LLC
+  board: vip-hospitality-llc
+- company: Vortex Companies - Trenchless Infrastructure Rehabilitation Solutions
+  board: vortex-companies-llc
+- company: VulcanForms Inc.
+  board: vulcanforms

--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -7513,3 +7513,13 @@
   board: polishtvcompanycom
 - company: Lightspeed Human Capital Management Inc.
   board: wirelessxfactor
+- company: Alltype Engineering
+  board: alltypeengineeringptyltd
+- company: Dallas Healthcare Consultants
+  board: dallashealthcareconsultants
+- company: Iron Senergy
+  board: ironcumberlandllc
+- company: Verde Edge Consulting
+  board: verdeedgeconsultingltd
+- company: Trans Skills LLC
+  board: virtuaadvancedsolution

--- a/sources/softgarden.yml
+++ b/sources/softgarden.yml
@@ -41,3 +41,11 @@
   board: kinnovis
 - company: HTG Projektmanagement
   board: treysta
+- company: Alloheim Senioren-Residenzen SE
+  board: alloheim
+- company: Bäcker Bachmeier
+  board: bachmeier
+- company: Creditplus Bank AG
+  board: creditplus
+- company: emeis Deutschland
+  board: emeis

--- a/sources/talentlyft.yml
+++ b/sources/talentlyft.yml
@@ -18,3 +18,7 @@
   board: optimapharm-doo
 - company: Roko Labs
   board: roko-labs
+- company: Konzum
+  board: konzumhr
+- company: Pepco
+  board: pepco-italy

--- a/sources/taleo.yml
+++ b/sources/taleo.yml
@@ -76,8 +76,6 @@
   board: ugl.taleo.net/public
 - company: AAR
   board: aarcorp.taleo.net/2
-- company: AAR
-  board: aarcorp.taleo.net/aar_mobile
 - company: Asian Development Bank (ADB)
   board: adb.taleo.net/2
 - company: University of Colorado Anschutz Medical Campus

--- a/sources/taleo.yml
+++ b/sources/taleo.yml
@@ -74,3 +74,23 @@
   board: cinfin.taleo.net/ex
 - company: UGL Limited
   board: ugl.taleo.net/public
+- company: AAR
+  board: aarcorp.taleo.net/2
+- company: AAR
+  board: aarcorp.taleo.net/aar_mobile
+- company: Asian Development Bank (ADB)
+  board: adb.taleo.net/2
+- company: University of Colorado Anschutz Medical Campus
+  board: cu.taleo.net/mob
+- company: State of Ohio
+  board: dasstateoh.taleo.net/oh_ext
+- company: Hennepin Healthcare
+  board: hcmc.taleo.net/1
+- company: PruittHealth
+  board: pruitthealth.taleo.net/2
+- company: Scripps Health
+  board: scripps.taleo.net/2m
+- company: UT Southwestern Medical Center
+  board: utsw.taleo.net/2
+- company: Worley
+  board: worleyparsons.taleo.net/ext

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -4139,3 +4139,37 @@
   board: virtualteammate-1719208705.teamtailor.com
 - company: Visma Software International AS
   board: vismasoftwareinternationalas.teamtailor.com
+- company: AZQORE SA
+  board: azqoresa.teamtailor.com
+- company: Bashor Children's Home
+  board: bashor.teamtailor.com
+- company: Brooke Harrison Recruitment
+  board: brookeharrisonrecruitment.teamtailor.com
+- company: Pret A Manger
+  board: dallasholdings.teamtailor.com
+- company: EAG (Empresarios Agrupados - GHESA)
+  board: empre.teamtailor.com
+- company: ETUDE ET PROJET - Cabinet de recrutement
+  board: etudeetprojet-1712584726.teamtailor.com
+- company: GXO Logistics, Inc.
+  board: gxologisticsinc.teamtailor.com
+- company: Entropos
+  board: hanap.teamtailor.com
+- company: INEXCO GROUPE
+  board: inexcogroupe-1712242485.teamtailor.com
+- company: Lazeo
+  board: lazeo.teamtailor.com
+- company: Merlin Digital Partner
+  board: merlindigitalpartner-1613753675.teamtailor.com
+- company: Oxand
+  board: oxand.teamtailor.com
+- company: Praesidium
+  board: praesidium.teamtailor.com
+- company: Right at Home Ireland
+  board: rightathomegalway.teamtailor.com
+- company: Rtone
+  board: rtone.teamtailor.com
+- company: TCSCHOOLHOME
+  board: tcschoolhome.teamtailor.com
+- company: Y STRATEGIE
+  board: ystrategie.teamtailor.com

--- a/sources/trakstar.yml
+++ b/sources/trakstar.yml
@@ -1334,3 +1334,5 @@
   board: itemizecorp
 - company: Town Viera
   board: viera
+- company: Spartan SME Finance
+  board: spartan

--- a/sources/ukg.yml
+++ b/sources/ukg.yml
@@ -29,8 +29,6 @@
   board: alpla.rec.pro.ukg.net/alp1505apnc/4b4f22b7-1a92-48fc-86e5-8d2d15a4b89e
 - company: ALPLA
   board: alpla.rec.pro.ukg.net/alp1505apnc/9273be85-ad40-4638-932c-9bfc7a015338
-- company: Mahaska Health
-  board: mahaskaukg.rec.pro.ukg.net/MAH1000MAHC/JobBoard/0d34e7b0-f433-4e51-a750-b2785087496d
 - company: Opportunities, Inc.
   board: altstaffing.rec.pro.ukg.net/opp1501oijc/b27f106a-1ecc-43f2-a3f7-5efc6037d59f
 - company: American Textile Maintenance
@@ -6081,9 +6079,6 @@
   board: yoshinoya.rec.pro.ukg.net/yos1000yosh/bdb01443-3761-41d4-8820-dc825c271823
 - company: Zynex
   board: zynexmed.rec.pro.ukg.net/zyn1500zyxm/95f96ec9-5d7c-4c1f-b2d7-44b718da86ad
-# Plesk hires under its parent WebPros (Plesk/cPanel/WHMCS) on this shared UKG board. Validated
-# live (endpoint 200) but currently 0 open postings — the lone exception to the ">0" rule above;
-# ingests nothing until WebPros posts. Labelled Plesk so the eastern-roots `plesk` slug tags it.
 - company: Advarra
   board: recruiting.ultipro.com/adv1023avr/6051d363-03fe-4650-945e-f836306a8388
 - company: African Wildlife Foundation
@@ -6292,7 +6287,7 @@
   board: recruiting2.ultipro.com/cle1021cleda/1ecaf756-ba05-491f-9f88-5b1733c68f70
 - company: CSWI w/Subsidiaries
   board: recruiting2.ultipro.com/csw1002cswi/45220d28-f191-42b7-878c-f4d4a4987652
-- company: Didi Hirsch Brand
+- company: Didi Hirsch Mental Health Services
   board: recruiting2.ultipro.com/did1000didi/8d18ec3b-eca9-4792-8df1-814e2097ccc1
 - company: Braemac
   board: recruiting2.ultipro.com/exp1007extg/3147f1de-7168-4d42-a087-1c2109381410
@@ -6448,8 +6443,6 @@
   board: recruiting.ultipro.com/sgf1000sgfs/8daa09e3-0c07-4497-8d06-48273e07968f
 - company: Steel Technologies
   board: recruiting.ultipro.com/ste1020steel/214d1a03-87cf-444a-9dc0-d56d960c4864
-- company: Atlantic Union Bank
-  board: 'recruiting.ultipro.com/uni1046ufmb/d8f90aad-672e-4f0a-bbc1-a17aa8cf1111 '
 - company: Circana
   board: recruiting2.ultipro.com/inf1019irinc/17a8d008-9efe-4e51-8460-47ee205d5229
 - company: Mercy Corps

--- a/sources/ukg.yml
+++ b/sources/ukg.yml
@@ -6326,3 +6326,153 @@
   board: recruiting2.ultipro.com/tru1017trrh/c6989fd4-b2bf-441a-a6a5-8fa2b50f65dc
 - company: WebPT
   board: recruiting2.ultipro.com/web1004webin/1786dc47-531b-4fc7-a333-399de6a6684c
+- company: Acadian Medical Center
+  board: allegiance.rec.pro.ukg.net/all1049ahmi/bbf37c73-bf74-4b4d-b322-a95f13514044
+- company: Baptist Health System KY & IN
+  board: baptisthealth.rec.pro.ukg.net/bap1500bhdm/5a6b1470-b5c5-4d26-a171-11ad94efcba8
+- company: Colwen Hotels
+  board: colwen.rec.pro.ukg.net/col1049colho/40a44554-d507-4c8f-a351-5b8008f5826e
+- company: Dinosaur Bar-B-Que
+  board: dinobbq.rec.pro.ukg.net/din1001dinre/1425dd61-9bd8-4bc3-b66c-ce754ec1cd36
+- company: ESF Camps & Experiences
+  board: esfcamps.rec.pro.ukg.net/esf1000esfcc/1baae538-e6fe-4d03-abbc-59168cffab14
+- company: Ewing Automotive Group
+  board: ewingautogroup.rec.pro.ukg.net/ewi1500ewag/c9c1800b-caf3-4a9d-a0a4-82233eb5629f
+- company: MAC'S Hardware
+  board: hrdwr.rec.pro.ukg.net/org1002orll/6bce9f56-3905-4cd1-b2df-3cc8e3bfb7a2
+- company: Huggins Hospital
+  board: hugginshospital.rec.pro.ukg.net/hug1500hgsp/52664b36-fe16-4498-9f35-dae2a33f3e69
+- company: LifeScape
+  board: lifescape.rec.pro.ukg.net/lif1501lisc/57efc672-bd5a-4b6f-8356-1025d3d31cd9
+- company: Mahaska Health
+  board: mahaskaukg.rec.pro.ukg.net/mah1000mahc/0d34e7b0-f433-4e51-a750-b2785087496d
+- company: McClatchy Media
+  board: mcclatchy.rec.pro.ukg.net/mcc1008mcltc/ff11d963-22db-4278-a2b7-709f3b882262
+- company: Forest County Potawatomi Community
+  board: myfcp.rec.pro.ukg.net/for1500fcpc/0b37cec2-008f-4354-b589-cf601b476f78
+- company: Mountville
+  board: mymountville.rec.pro.ukg.net/mou1004mvlm/df7725bd-1c7b-4eca-b0da-396696cc01ea
+- company: Southern Ohio Medical Center
+  board: mysomc.rec.pro.ukg.net/sou1068somc/1735eb8a-40b2-43d2-89aa-99eea075dc4f
+- company: Terminal Security Solutions, Inc.
+  board: nautilus.rec.pro.ukg.net/nau1500naut/84738855-69d7-4b2c-b0f5-df20ad065089
+- company: New Waterloo
+  board: newwaterloo.rec.pro.ukg.net/new1510nwll/b439386e-fa77-4de6-81f7-860df45262a2
+- company: Rhodes Convenience Stores
+  board: pajco.rec.pro.ukg.net/paj1500pajc/49b876be-0c34-428f-b1a2-741b05ff745d
+- company: Perry County Memorial Hospital
+  board: perrycountymem.rec.pro.ukg.net/per1500pcmh/ad3e78fe-7ca1-44dd-9add-84fd268d95b4
+- company: Arbors of Ohio
+  board: prestige.rec.pro.ukg.net/pre1045prea/4b0e39e3-38f3-4b34-b976-ab267f42485a
+- company: Arbors of Ohio
+  board: prestige.rec.pro.ukg.net/pre1045prea/50de2cd1-1c88-42c3-9e6e-b966c3e39d7c
+- company: Rainbow Rehab & Healthcare
+  board: prestige.rec.pro.ukg.net/pre1045prea/5f82f9aa-3846-460d-a35c-71cc09c0aca7
+- company: MediLodge
+  board: prestige.rec.pro.ukg.net/pre1045prea/96fc16ef-1045-40d6-906f-bcf2540a8783
+- company: MediLodge
+  board: prestige.rec.pro.ukg.net/pre1045prea/97ccb50f-0172-47ea-9de4-a1a29b429e6a
+- company: Arbors of Ohio
+  board: prestige.rec.pro.ukg.net/pre1045prea/b59e94d3-a5ad-4a63-bb6f-abe238a5604b
+- company: MediLodge
+  board: prestige.rec.pro.ukg.net/pre1045prea/bab56c34-ed89-4c82-be2d-849a65d56f60
+- company: MediLodge
+  board: prestige.rec.pro.ukg.net/pre1045prea/cdf1bddc-70e1-4a68-a726-d782c2fe57fa
+- company: MediLodge
+  board: prestige.rec.pro.ukg.net/pre1045prea/dd11c633-632b-4829-bca1-733168db9d40
+- company: MediLodge
+  board: prestige.rec.pro.ukg.net/pre1045prea/ea660ec3-c0f1-4e7e-8bfa-4694b3432cfb
+- company: MediLodge
+  board: prestige.rec.pro.ukg.net/pre1045prea/fb42cd5b-d3b9-4cda-b821-79634ebd364e
+- company: ProAmpac
+  board: proampac.rec.pro.ukg.net/pro1065proam/27744923-fcd2-4f07-9507-b2da53f47388
+- company: PVS Chemicals
+  board: pvsdetroit.rec.pro.ukg.net/pvs1500pvsc/5e0b2431-65c4-4ea5-b1ad-59bd66f112cd
+- company: Altea
+  board: recruiting.ultipro.ca/alt5002alac/02359fd6-8671-4261-ae97-16dfab3fd29e
+- company: CBI Health
+  board: recruiting.ultipro.ca/cbi5000cbhig/5ed9b0b5-33c5-df47-591e-ac6551779695
+- company: Goodwill Industries of Alberta
+  board: recruiting.ultipro.ca/goo5000gwia/56a60297-5a63-43ac-9421-2fd463ab1524
+- company: Hotel X Toronto, A Destination by Hyatt Hotel
+  board: recruiting.ultipro.ca/hot5001hxt/34771b31-5cdb-427d-85c4-a13b11e282e2
+- company: MDA Space
+  board: recruiting.ultipro.ca/mac5000mcdw/664818ff-3594-4bec-9f30-3394e59e19f3
+- company: Modern Niagara
+  board: recruiting.ultipro.ca/mod5000mong/a0891200-a909-4c18-b8db-3bd0e1006828
+- company: Nature's Path Foods
+  board: recruiting.ultipro.ca/nat5000natur/dd2692af-6e2b-4330-abd8-ee8736002e07
+- company: Pharmascience
+  board: recruiting.ultipro.ca/pha5000/715b8649-d802-4e45-a4a0-e331ebb35d78
+- company: Pharmascience
+  board: recruiting.ultipro.ca/pha5000/edf34eee-d454-4904-b41c-3a54c065d2d0
+- company: Propak Systems Ltd.
+  board: recruiting.ultipro.ca/pro5002propa/db2f54bf-5114-45e8-b4b7-6f69f750ad6a
+- company: Stikeman Elliott LLP
+  board: recruiting.ultipro.ca/ses5000sellp/9cea37d8-40ac-4583-84aa-5469ad18b526
+- company: Sifton Properties Limited
+  board: recruiting.ultipro.ca/sif5000sift/1aef6bdd-bde3-402a-9fd6-410892be2cde
+- company: CIMCO Refrigeration Inc.
+  board: recruiting.ultipro.ca/tor5001til/e678a0f7-e0b2-4463-ac62-4724c8730cfc
+- company: Unilock
+  board: recruiting.ultipro.ca/uni5001unil/4b710784-c68d-45eb-bad7-f0f3f42602d1
+- company: Yukon Hospitals
+  board: recruiting.ultipro.ca/yuk5001yuhc/7ed94cc1-3925-495d-a225-c5d6b7c3ad3e
+- company: Wellabe
+  board: recruiting.ultipro.com/ame1065/cdfdf806-e3aa-dfb4-4c6e-c7c656217b40
+- company: ARA
+  board: recruiting.ultipro.com/app1010arai/07442cec-d18e-4589-ab15-8342edc29af7
+- company: BEL USA LLC
+  board: recruiting.ultipro.com/bel1007belu/45b3ae8a-ecb3-4c69-bfa0-d5489db2bf10
+- company: Cherry Hill Programs
+  board: recruiting.ultipro.com/che1023crry/f99546c8-1543-437d-b13b-ac58c6e27205
+- company: Chimes
+  board: recruiting.ultipro.com/chi1001chim/72cbb0b0-0593-4f9a-8317-11391b3533d8
+- company: Five Guys Enterprises
+  board: recruiting.ultipro.com/fiv1002fgllc/3281f7d3-3a9b-4482-905d-e4b2642b2db8
+- company: Lafayette 148 New York
+  board: recruiting.ultipro.com/laf1002lafa/1a07d948-3361-48d7-89f2-002c5a48346c
+- company: Los Angeles Dodgers
+  board: recruiting.ultipro.com/los1000ladod/5365ad6e-23ff-4703-bb77-1e9451fb855e
+- company: McAngus Goudelock & Courie
+  board: recruiting.ultipro.com/mca1000mcan/3e542129-b071-4bb3-b57f-c37ce25e4733
+- company: MIDWAY PRODUCTS GROUP, INC.
+  board: recruiting.ultipro.com/mid1003mpgmc/b543272c-6aa5-4c16-b238-3529df79927e
+- company: Paradies Lagardère
+  board: recruiting.ultipro.com/par1026pars/58872345-14a4-44df-bc73-e43b6c17c598
+- company: Pinnacle Home Care
+  board: recruiting.ultipro.com/pin1008phch/3eeb2abd-a875-439b-ae79-7bc46dd104e4
+- company: PAC
+  board: recruiting.ultipro.com/rop1002ripic/1de3540f-439f-4b30-aab1-c1b6e7ea446b
+- company: US Fertility
+  board: recruiting.ultipro.com/sgf1000sgfs/8daa09e3-0c07-4497-8d06-48273e07968f
+- company: Steel Technologies
+  board: recruiting.ultipro.com/ste1020steel/214d1a03-87cf-444a-9dc0-d56d960c4864
+- company: Atlantic Union Bank
+  board: 'recruiting.ultipro.com/uni1046ufmb/d8f90aad-672e-4f0a-bbc1-a17aa8cf1111 '
+- company: Circana
+  board: recruiting2.ultipro.com/inf1019irinc/17a8d008-9efe-4e51-8460-47ee205d5229
+- company: Mercy Corps
+  board: recruiting2.ultipro.com/mer1024mercy/444c1b88-2406-42f4-9273-a99cc3bb34e2
+- company: Metropolitan Nashville Airport Authority
+  board: recruiting2.ultipro.com/met1000mnaa/e5ff54da-0932-41b2-952c-f2ddf8d2283a
+- company: Shenandoah Medical Center
+  board: recruiting2.ultipro.com/she1012shem/bcd5738c-c38c-4642-a992-1887c69cb7aa
+- company: Robinson, Inc.
+  board: robinsoninc.rec.pro.ukg.net/rob1013robi/c967b48b-927e-406b-a9ad-385e05b3af06
+- company: Saginaw Chippewa Indian Tribe of Michigan
+  board: sagchip.rec.pro.ukg.net/sag1008scit/3125842b-c887-4ea3-97b4-d99a01a92a53
+- company: Sequoia Care
+  board: sequoiacare.rec.pro.ukg.net/apt1500aptr/24d8780f-f8eb-4b06-983b-2797a29a8adc
+- company: Cobblestone Auto Spa|Car Wash
+  board: spotless.rec.pro.ukg.net/spo1500spot/fa6ee69b-c4a9-43d2-83b5-8c0c2fa651fb
+- company: Tamarack Health
+  board: tamarackhealth.rec.pro.ukg.net/reg1500regi/9ad614d0-6df3-4942-bf76-c27dcf6898f9
+- company: TEAM, Inc.
+  board: teaminc.rec.pro.ukg.net/tea1500temi/a9bd01f6-f049-4ffa-851b-ec1d06dc206a
+- company: VT Industries
+  board: vtindustries.rec.pro.ukg.net/vti1500vtin/674339ab-9285-4ba2-80bd-aa3503cae1b2
+- company: Watchfire
+  board: watchfiresigns.rec.pro.ukg.net/wat1501wfsi/d3278620-b590-426f-899b-eb88c1096ad9
+- company: USNR
+  board: woodtech.rec.pro.ukg.net/vec1002midco/0e81673e-c740-4862-8d4c-d5c670fd46b9

--- a/sources/workday.yml
+++ b/sources/workday.yml
@@ -13143,3 +13143,19 @@
   board: talentmanagementsolution.wd3.myworkdayjobs.com/ConstellationPaymentProcessing-Career
 - company: Alltec Angewandte Laserlicht Technologie GmbH
   board: veralto.wd1.myworkdayjobs.com/AlltecFOBACareerSite
+- company: Ballester Hermanos
+  board: ballesterhermanos.wd12.myworkdayjobs.com/bhi-e
+- company: Bay Area Hospital
+  board: bayareahospital.wd1.myworkdayjobs.com/bay_area_hospital_external_career_site
+- company: BDO UK
+  board: bdouk.wd3.myworkdayjobs.com/bdo_careers
+- company: West Side DB, LLC
+  board: dutchbros.wd1.myworkdayjobs.com/referrals
+- company: Levi Strauss & Co.
+  board: levistraussandco.wd5.myworkdayjobs.com/elite
+- company: Richland County Government
+  board: richlandonline.wd5.myworkdayjobs.com/richlandcountygovcareers
+- company: University of Arkansas for Medical Sciences
+  board: uasys.wd5.myworkdayjobs.com/uams_cw_career_site
+- company: University of Washington
+  board: uw.wd5.myworkdayjobs.com/uwhires

--- a/sources/zohorecruit.yml
+++ b/sources/zohorecruit.yml
@@ -3312,3 +3312,35 @@
   board: trabajaonline.zohorecruit.eu
 - company: Upstaff
   board: upstaff.zohorecruit.ca
+- company: 8allocate
+  board: 8allocate.zohorecruit.com
+- company: Adelphi Staffing
+  board: adelphimedicalstaffing.zohorecruit.com
+- company: Alan&Grant
+  board: alanandgrant.zohorecruit.com
+- company: Black Pearl Consult
+  board: blackpearlconsult.zohorecruit.com
+- company: Groupe BMR
+  board: bmr.zohorecruit.com
+- company: cTrace Solutions
+  board: ctracesolutions.zohorecruit.com
+- company: Mexpress
+  board: empleate.zohorecruit.com
+- company: eRecruiter
+  board: erecnigeria.zohorecruit.com
+- company: EXPOZE Recrutement
+  board: expoze.zohorecruit.com
+- company: GEC _ Global Experts Consulting
+  board: gec-groupe.zohorecruit.com
+- company: iLink Digital
+  board: ilink-digital.zohorecruit.com
+- company: MadaJOB - RH
+  board: madajob.zohorecruit.com
+- company: Ontrack HR Services Private Limited
+  board: ontrackhrs.zohorecruit.com
+- company: PeoplePartners Inc.
+  board: peoplepartnersbpo.zohorecruit.com
+- company: Pharmavise Corporation
+  board: pharmavise.zohorecruit.com
+- company: Realynk Assistants (Formerly Trans Support)
+  board: realynk.zohorecruit.com


### PR DESCRIPTION
Rebased onto #2073, which landed 2105 boards from the same aggregator while this was open. The two harvests sampled different slices — only 47 of these boards were already there — so the union stands at **475 new boards** here.

## 1. 37 iCIMS boards were crawled twice

The icims adapter reaches a board either way: a bare slug becomes the host `careers-<slug>.icims.com`, and a dotted board IS that host. `sources/icims.yml` carried 37 boards under both spellings, so every run crawled those sites twice and stored one row-set per spelling.

`boardDedupeKey` now folds the two forms together through a per-provider board-identity hook, so the loader collapses them even if a future harvest reintroduces one. Case folding alone could not see this.

Worth noting on the data merge: the bare rows carried the slug in their `company` field and the dotted rows the real display name — `vet` vs `Vet Jobs`, `rochebros` vs `Roche Bros`. Deleting the dotted rows naively would have discarded 33 real company names, so the surviving row takes the name.

Board ids are also trimmed at parse now. Whitespace makes a board that 404s — adapters paste the string into a URL — and it hid a duplicate: a harvested UKG board arrived with a trailing space and so did not collide with the same board already in the file.

## 2. atsboard recognises Avature and softgarden's regional career host

- **Avature** — the board is the career-site host, the shape `avature.yml` already stores (`deloittecm.avature.net`). Vanity hosts (`jobs.ea.com`) stay out, like every other custom-domain ATS here.
- **softgarden** — tenants also appear under `<tenant>.career.softgarden.de`. The label is the same board the adapter fetches at `<board>.softgarden.io` (verified live: `agilitaschweiz` answers on both), so only the apex differs.

Both widen the accept-set `internal/contribution` pays out on. Deliberate and narrow: both platforms are already crawled, both board ids are exactly what their board file stores, and neither is one of the shapes `atsdetect.FromURL` documents as excluded on purpose.

## 3. A Manatal prober, because the seed's company name is not the board's owner

`chooseCompany` falls back to the seed's company when the platform publishes none, and the seed's company is the posting's *hiring organisation*. Manatal is heavily used by recruitment agencies, so that is the agency's client: one client name got stamped on three different agency boards and four more read `confidential`. Both manatal and pageup label every posting with the entry's company, so a wrong label poisons the whole board.

`manatalProber` reads the tenant off the hosted career page's title — the board's owner, not whoever a posting is for. It also replaces the `adapterProber` fallback, so a candidate costs one request instead of a whole crawl: the 157-board run went from 3m22s to 40s.

PageUp deliberately gets no such prober — its listing titles are `Job Search`, `Current Opportunities`, `CSU Careers | CSU`, and guessing a name out of those is what the dict-only rule forbids. Its 19 boards were checked against their own listing pages one by one instead; five disagreed with the seed and take the platform's name. Two boards labelled ANSTO are in fact the Tasmanian Department of Education and the Tasmanian whole-of-government board.

## 4. 475 boards

Same play as #2070/#2073, using the existing `cmd/harvest-role` and `cmd/harvest-boards`: 20000 job pages → 3867 distinct boards → every new candidate probed against its own platform API → only those that answered with jobs.

The yield is lopsided, and usefully so: manatal, ukg, rippling, careerplug and oracle carried it, while Workday contributed 8 out of 1007 boards seen and Greenhouse 1 out of 212. That is what saturation looks like — the boards were at the thin providers. Avature and softgarden appear only because of change 2.

Also dropped: `taleo/AAR aarcorp.taleo.net/aar_mobile`, the mobile mirror of its `/2` careersection — a second careersection is a second `external_id` namespace over the same requisitions. Checked and kept: the UKG tenants holding several boards (MediLodge, Arbors of Ohio, Pharmascience) return disjoint opportunity sets, so those are per-facility boards.

## Checks

`gofmt -l`, `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `go test ./...` — all clean. No harvest run was rate-limited or aborted, and no board file carries a duplicate board under the folded identity.