### PR TITLE
sources: add 573 Join boards resolved through the platform's job API

### DIFF
--- a/sources/join.yml
+++ b/sources/join.yml
@@ -8405,3 +8405,1149 @@
   board: "143084"
 - company: D4L data4life gGmbH # data4lifecare
   board: "842"
+- company: MOCHI VENTURES S.L.
+  board: "100372"
+- company: Jordan Caporaletti
+  board: "100797"
+- company: Sidekick Network GmbH & Co. KG
+  board: "10184"
+- company: Cloudiax AG
+  board: "101856"
+- company: Global Treats GmbH
+  board: "102375"
+- company: Bürokompetent GmbH
+  board: "102680"
+- company: RealStudio GmbH
+  board: "103973"
+- company: Metrikflow
+  board: "104736"
+- company: axcav
+  board: "104851"
+- company: SAJ Digital Energy Germany GmbH
+  board: "106931"
+- company: Event Yoga
+  board: "107316"
+- company: Atelier Métamorphoze
+  board: "107377"
+- company: DTAD GmbH
+  board: "108310"
+- company: Yoga Outside
+  board: "108416"
+- company: Menhal Hanna
+  board: "110012"
+- company: PinkStone Ventures GmbH
+  board: "111313"
+- company: wika AG Oldenburg
+  board: "11186"
+- company: Interkultura Verlag
+  board: "112025"
+- company: Advertical
+  board: "112788"
+- company: Eclarity.io
+  board: "114586"
+- company: CPU Consulting & Software GmbH
+  board: "1153"
+- company: Recruit 121 Group
+  board: "115958"
+- company: Uniplex AG
+  board: "116"
+- company: RocketAds
+  board: "117127"
+- company: INNOVA ADVANCED CONSULTING
+  board: "117776"
+- company: Enerdies Energieberatung
+  board: "118890"
+- company: SOFIPROS
+  board: "119403"
+- company: Mankind Media
+  board: "119638"
+- company: layer7 GmbH
+  board: "119930"
+- company: Brand your Voice
+  board: "120165"
+- company: Migelino
+  board: "12025"
+- company: Lambert Repetitorien
+  board: "120470"
+- company: Kryptos Technologies limited
+  board: "12061"
+- company: Yunicorn
+  board: "120875"
+- company: easybill GmbH
+  board: "121254"
+- company: Kanzlei Kick
+  board: "121488"
+- company: FIBERLIGHT S.L.
+  board: "121579"
+- company: it's prodigy
+  board: "12190"
+- company: BrainBook (Brain Media GmbH)
+  board: "122271"
+- company: Amicon Partners GmbH
+  board: "123483"
+- company: Steuerkanzlei Daniela Anders
+  board: "123709"
+- company: SHUTTLE99 OU
+  board: "12511"
+- company: EPL Group
+  board: "125289"
+- company: PlannerPal
+  board: "125879"
+- company: INNER CIRCLE AGENCY
+  board: "127855"
+- company: Genferberg Group
+  board: "128196"
+- company: buXperts GmbH
+  board: "12874"
+- company: P-CATION Consulting and Solutions GmbH
+  board: "12902"
+- company: Odepla
+  board: "129231"
+- company: Beutler Saghari & Partner GmbH
+  board: "12944"
+- company: LIFE Initiative e.V.
+  board: "129978"
+- company: AQUA SERVICES KG
+  board: "130062"
+- company: CYBERTEC PostgreSQL International GmbH
+  board: "130213"
+- company: Ganda Business Solutions Ltd.
+  board: "130699"
+- company: Adfinis AG
+  board: "13125"
+- company: Agemia
+  board: "131834"
+- company: ECS Engineering Consulting & Solutions GmbH
+  board: "132070"
+- company: P1 Security
+  board: "132165"
+- company: Notarbüro Dr. Julia Bochis
+  board: "132460"
+- company: SARIADNA
+  board: "132831"
+- company: VELZI.AI LIMITED
+  board: "132963"
+- company: VEGA FRANCE
+  board: "133515"
+- company: Personal Now
+  board: "133696"
+- company: Juicyway
+  board: "133769"
+- company: Marquardt Medien GmbH
+  board: "133921"
+- company: peter.at
+  board: "134300"
+- company: HYPERTEGRITY AG
+  board: "134913"
+- company: Gastrosterne
+  board: "135578"
+- company: apeirum
+  board: "136285"
+- company: GAIA AG
+  board: "13653"
+- company: snipKI
+  board: "136612"
+- company: Mightycare Solutions GmbH
+  board: "13673"
+- company: sync.blue® GmbH
+  board: "137280"
+- company: Dreamlight Labs GmbH
+  board: "137392"
+- company: DBA Digital Business Akademie
+  board: "137551"
+- company: Aufmaster GmbH
+  board: "137557"
+- company: Inspyr GmbH (drink&paint)
+  board: "137670"
+- company: HERA Digital GmbH
+  board: "137803"
+- company: Care Forward GmbH
+  board: "138335"
+- company: ORBITIS
+  board: "138986"
+- company: Corominas Consulting GmbH
+  board: "140633"
+- company: Particula
+  board: "140805"
+- company: BM-Homeoffice Service
+  board: "141040"
+- company: Raths Rechtsanwaltspartnerschaft
+  board: "14158"
+- company: CERTURIA
+  board: "141612"
+- company: Auralis Group
+  board: "141644"
+- company: Velo Solutions
+  board: "141874"
+- company: Brandcircle GmbH
+  board: "141927"
+- company: Premium Challenges by Robert Gülpen and friends
+  board: "142594"
+- company: Project 10
+  board: "142795"
+- company: MetaMedicsVR
+  board: "143423"
+- company: Psytastic
+  board: "144015"
+- company: Entrepreneurs
+  board: "144606"
+- company: Julia Goessler GmbH
+  board: "144825"
+- company: Benjamin Demarquilly
+  board: "145122"
+- company: Lane One
+  board: "145406"
+- company: Appatini
+  board: "145412"
+- company: SOCOMAB
+  board: "145700"
+- company: Ant-Tech
+  board: "146047"
+- company: SEO.CH
+  board: "146970"
+- company: Invest in start-up
+  board: "146976"
+- company: KoReXXio
+  board: "147207"
+- company: Credibur
+  board: "147240"
+- company: SHAVENT - ARA Sustainable Products
+  board: "147804"
+- company: Mojo Financial Technologies Ltd
+  board: "147920"
+- company: Ananda B.V.
+  board: "148900"
+- company: SearchneedsLOVE
+  board: "149550"
+- company: leadity GmbH
+  board: "149990"
+- company: KassenKompass GmbH
+  board: "150036"
+- company: Go For Climate e.V.
+  board: "150268"
+- company: Omtera
+  board: "150498"
+- company: SR Travel International S.L.
+  board: "150846"
+- company: li:on bikes
+  board: "151996"
+- company: pathway solutions gmbh
+  board: "152943"
+- company: brandleads marketing services FlexCo
+  board: "153335"
+- company: Farbraum Vision GmbH
+  board: "153452"
+- company: Förderfuchs Bildung
+  board: "153550"
+- company: C1NE
+  board: "153822"
+- company: Panda Marketing
+  board: "155282"
+- company: CHASR
+  board: "155311"
+- company: Privatinstitut für Klinikmanagement GmbH
+  board: "155358"
+- company: Wals Professional Services GmbH
+  board: "155546"
+- company: INSTITUT FÜR DATENSCHUTZ
+  board: "156211"
+- company: Aurora Group
+  board: "156400"
+- company: Cocons du bassin
+  board: "156834"
+- company: Nonstop Academy Gemeinnützig
+  board: "156925"
+- company: uNaice GmbH
+  board: "15696"
+- company: protectONE e.K.
+  board: "15703"
+- company: Muffin Finance SRL
+  board: "157536"
+- company: Opu's Holidays
+  board: "157638"
+- company: DATARELEVANT
+  board: "158616"
+- company: DataSmart Point GmbH
+  board: "158625"
+- company: Voda
+  board: "158944"
+- company: Kai Marxen Media
+  board: "159100"
+- company: DeDeNet GmbH
+  board: "159142"
+- company: Top 3 Pflege Franchise
+  board: "159162"
+- company: Subject Well Inc.
+  board: "159275"
+- company: FD Informatik
+  board: "159375"
+- company: Deutscher Hilfsbund e.V.
+  board: "159832"
+- company: ProviPanda GmbH
+  board: "159941"
+- company: Gall und Partner Versicherungsmakler
+  board: "159982"
+- company: NAIRON
+  board: "160041"
+- company: Retorna
+  board: "160130"
+- company: Staking Facilities GmbH
+  board: "160162"
+- company: Wedler Immobilien Consulting
+  board: "160356"
+- company: Sirket.io
+  board: "160380"
+- company: HealthWright Technologies
+  board: "160535"
+- company: Frühlingszwiebel
+  board: "160844"
+- company: Mammutmarsch UG
+  board: "161209"
+- company: We-Help-Solutions
+  board: "161560"
+- company: Affinity Labs
+  board: "161834"
+- company: Camformance
+  board: "161938"
+- company: JayBee AG
+  board: "16195"
+- company: Bellona Möbelhaus
+  board: "161990"
+- company: PowerBase Consulting
+  board: "162006"
+- company: comdaily GmbH
+  board: "162053"
+- company: MultiBase GmbH
+  board: "162080"
+- company: I Love Design GbR
+  board: "162261"
+- company: '@Backsta.Werbung'
+  board: "162443"
+- company: DSE-GROUP
+  board: "162473"
+- company: YAVO Yoga & Events
+  board: "162533"
+- company: Priesmeier & Bartsch GbR
+  board: "162833"
+- company: Animals Around The Globe GmbH
+  board: "162939"
+- company: MILEO SYSTEMS
+  board: "163132"
+- company: Female Power HUB
+  board: "163140"
+- company: RX-WATERTEC GmbH
+  board: "163448"
+- company: MerciMoonee
+  board: "163667"
+- company: QAVION SALES & RECRUITING GmbH
+  board: "163736"
+- company: TechMango
+  board: "164187"
+- company: Femlives
+  board: "164279"
+- company: Skinnify
+  board: "164510"
+- company: Institut für Zukunftsbildung
+  board: "164545"
+- company: Unseen Media GmbH
+  board: "164558"
+- company: CEF AI
+  board: "164568"
+- company: AImera Group GmbH
+  board: "164731"
+- company: TechPionier Next GmbH
+  board: "165043"
+- company: FivePD Czech Community, z. s.
+  board: "165063"
+- company: vermaye GmbH
+  board: "165161"
+- company: Bauvio
+  board: "165301"
+- company: Newcomer Performance GmbH
+  board: "165313"
+- company: Getbeauty.ai
+  board: "165510"
+- company: PrimeBoost
+  board: "165633"
+- company: Hadi Adworks
+  board: "165998"
+- company: YosysHQ
+  board: "166044"
+- company: BT Building Technology Sàrl
+  board: "166148"
+- company: ECSO CLOUD
+  board: "166152"
+- company: Wholix
+  board: "166161"
+- company: Nexun
+  board: "166252"
+- company: Calvergy UG
+  board: "166267"
+- company: Unleashed Potential
+  board: "166433"
+- company: cannarino
+  board: "166799"
+- company: Wildschytz UG
+  board: "166938"
+- company: Melanie Diwisch
+  board: "167207"
+- company: ivyclip
+  board: "167323"
+- company: OPTIMARIA
+  board: "167435"
+- company: Tangible
+  board: "167772"
+- company: Wertsicherung Schmidt
+  board: "168018"
+- company: Flatland Marketing
+  board: "168029"
+- company: IT Career Hub
+  board: "168209"
+- company: Lern-Fair e.V.
+  board: "168364"
+- company: H&H Ecommerce GmbH
+  board: "168398"
+- company: FORREST
+  board: "168468"
+- company: Boulevard des Experts
+  board: "168554"
+- company: YONA Systems GmbH
+  board: "168878"
+- company: Iber'ADS
+  board: "168937"
+- company: Avertis Group
+  board: "169005"
+- company: KU Europe GmbH
+  board: "169033"
+- company: GUDU STUDIO
+  board: "169058"
+- company: PortaPro Software
+  board: "169091"
+- company: IndieKidz GmbH
+  board: "169170"
+- company: Easify Int. Handels GmbH
+  board: "169400"
+- company: Vision Markets - Your global growth in Machine Vision
+  board: "16949"
+- company: ORIELLE
+  board: "169522"
+- company: Verisana
+  board: "169576"
+- company: Love Repair
+  board: "169693"
+- company: Curculia
+  board: "169719"
+- company: Vantivo UG
+  board: "169742"
+- company: von Schlapp Immobilien
+  board: "169759"
+- company: EquiMatch GmbH
+  board: "169816"
+- company: SportsXLab
+  board: "170004"
+- company: Like It Media GmbH
+  board: "170066"
+- company: safeXcon GmbH
+  board: "170084"
+- company: COLMENA GmbH & Co. KG
+  board: "170093"
+- company: Heartland Solutions GmbH
+  board: "170120"
+- company: Pont Connects e.K.
+  board: "170188"
+- company: docunest GmbH
+  board: "170239"
+- company: FlowBetrieb
+  board: "170548"
+- company: Chirayou
+  board: "170830"
+- company: GAM Medical
+  board: "170899"
+- company: TechPlanen
+  board: "171137"
+- company: Guarantee Standard Investment Company
+  board: "17133"
+- company: Saile App Inc.
+  board: "171386"
+- company: Sharkally
+  board: "171392"
+- company: VerLife
+  board: "171461"
+- company: DDMUR International Limited
+  board: "171781"
+- company: Ira Commerce
+  board: "171846"
+- company: Lean Improvements
+  board: "171913"
+- company: NOA Health
+  board: "171932"
+- company: Simon Gerwert - Sophie
+  board: "171962"
+- company: CodePipe GmbH
+  board: "172069"
+- company: ADOMIK
+  board: "172149"
+- company: Friedl & Kleinschmidt Buchhaltungsservice GmbH
+  board: "172240"
+- company: Dr. Paws
+  board: "172536"
+- company: VDB Digital GmbH
+  board: "172597"
+- company: Baufi Deutschland
+  board: "172716"
+- company: Capstone
+  board: "172756"
+- company: SageReport, Inc.
+  board: "172848"
+- company: Cuvo Health
+  board: "172876"
+- company: HOPn
+  board: "172937"
+- company: Deutsche Finanzhilfe e.V.
+  board: "172949"
+- company: Assurance Network
+  board: "173115"
+- company: Blacksd Global UG (haftungsbeschränkt)
+  board: "173207"
+- company: AImaxDOC GmbH
+  board: "173249"
+- company: MINTD
+  board: "173305"
+- company: Work and Travel Guide
+  board: "173333"
+- company: VisualHFT
+  board: "173592"
+- company: Global Inspector AI
+  board: "173834"
+- company: CryptoAviso
+  board: "174511"
+- company: BJ-Ecom B.V.
+  board: "174555"
+- company: LVA Vision
+  board: "174594"
+- company: Domy
+  board: "174620"
+- company: incupresa GmbH
+  board: "174751"
+- company: ConformIT Solutions
+  board: "174760"
+- company: beyondservice GmbH
+  board: "174791"
+- company: ZARTE-IT
+  board: "174899"
+- company: Online Marketing Berg GmbH
+  board: "174901"
+- company: The House Group AG
+  board: "174902"
+- company: CESAD
+  board: "174931"
+- company: Workforce AI
+  board: "175104"
+- company: ENSY AG
+  board: "175130"
+- company: Glory in LA
+  board: "175148"
+- company: medflex GmbH
+  board: "175173"
+- company: MPZ Medienagentur
+  board: "175231"
+- company: KLUUU
+  board: "175308"
+- company: LICALL
+  board: "175339"
+- company: AP Software Solutions
+  board: "175399"
+- company: Receiptor AI
+  board: "175487"
+- company: Soreli Paris
+  board: "175502"
+- company: EDITIONS LA GIROUETTE
+  board: "175512"
+- company: NAVIS HR
+  board: "175702"
+- company: Soldatenwissen
+  board: "175757"
+- company: Human Elevation GmbH
+  board: "175825"
+- company: Webinarhelden
+  board: "175835"
+- company: MaRe Head Spa System
+  board: "175910"
+- company: BYZA CONSULTING S.L.
+  board: "175916"
+- company: Tarp Communications
+  board: "175950"
+- company: Salvere Technology AI
+  board: "176020"
+- company: Travel With Lani
+  board: "176043"
+- company: Mobilezone Gmbh
+  board: "176050"
+- company: thankyu
+  board: "176173"
+- company: MOOCI GmbH
+  board: "176259"
+- company: App Innovators Solutions GmbH
+  board: "176289"
+- company: Onvery
+  board: "176317"
+- company: T. Eilers & Partner
+  board: "176398"
+- company: Immo Deutschland
+  board: "176427"
+- company: K3 Studio GmbH
+  board: "176461"
+- company: eternus technology gmbh
+  board: "176478"
+- company: Sippysoft
+  board: "176658"
+- company: PERY Media
+  board: "176685"
+- company: timedleads.de
+  board: "176697"
+- company: La Ressource Humaine
+  board: "176715"
+- company: Confidential Fintech
+  board: "176733"
+- company: Reputaweb
+  board: "176862"
+- company: Katrium Oü
+  board: "176939"
+- company: OpenSpot
+  board: "177005"
+- company: ZWW Deutschland GmbH
+  board: "177155"
+- company: energized& Company GmbH
+  board: "177323"
+- company: Dialekta GmbH
+  board: "177408"
+- company: easyCE GmbH
+  board: "177485"
+- company: METASKILLS.academy
+  board: "177560"
+- company: Wealth & Living Real Estate Group
+  board: "177588"
+- company: lunchlist GmbH
+  board: "177600"
+- company: Einfach Social Media GmbH
+  board: "177615"
+- company: Livara Service GmbH
+  board: "177686"
+- company: Christof Lutz
+  board: "177708"
+- company: LEWERENZ Medien+Druck GmbH
+  board: "177744"
+- company: Capstone Énergie
+  board: "177759"
+- company: AVENDIS GmbH
+  board: "177795"
+- company: WEBAN UG
+  board: "177863"
+- company: Bestandsfaktor
+  board: "177903"
+- company: ZB Unternehmensberatung GmbH
+  board: "177974"
+- company: Jäger Shot Productions
+  board: "177997"
+- company: Harmondu GmbH
+  board: "178119"
+- company: Layer2 GmbH
+  board: "178200"
+- company: 'Karl Reitter: External CMO'
+  board: "178423"
+- company: USUMA GmbH
+  board: "1786"
+- company: NXT Applied GmbH
+  board: "178610"
+- company: APT-ONE GmbH
+  board: "178643"
+- company: Prime Force Group
+  board: "1787"
+- company: LexDial
+  board: "178851"
+- company: Accessful GmbH
+  board: "178920"
+- company: nowmatters.health
+  board: "179206"
+- company: Hemmerich Consulting
+  board: "179232"
+- company: Hyposto Energy GmbH
+  board: "179298"
+- company: RANA Transporte GmbH
+  board: "179378"
+- company: Bullguard Deutschland
+  board: "179392"
+- company: MachsDirSelbst.Solar
+  board: "179415"
+- company: Andreas Thomas
+  board: "179440"
+- company: Fernstudium123
+  board: "179471"
+- company: JawBuddy
+  board: "180591"
+- company: Beglaubigt.de
+  board: "181152"
+- company: SAWOO GmbH
+  board: "18271"
+- company: Unternehmensberatung Michael Scholl
+  board: "18614"
+- company: Von Peach GmbH
+  board: "18637"
+- company: CareerTeam Group
+  board: "18760"
+- company: plehn media
+  board: "18827"
+- company: AMZ Advertise GmbH
+  board: "18975"
+- company: Advania Germany GmbH (smartvokat an Advania Brand)
+  board: "18985"
+- company: Alpha CRC Ltd.
+  board: "19174"
+- company: INVENTRY GmbH
+  board: "19237"
+- company: Lightly AG
+  board: "19460"
+- company: MaxPlus Advertising GmbH
+  board: "20246"
+- company: Auf- und Umbruch im Gesundheitswesen GmbH
+  board: "20789"
+- company: WizardTales
+  board: "21063"
+- company: WAITS Software- und Prozessberatungsgesellschaft mbH
+  board: "21319"
+- company: 100 Tasks GmbH
+  board: "21373"
+- company: TEACHY Education
+  board: "21653"
+- company: bits&birds GmbH
+  board: "21673"
+- company: Vicoland
+  board: "21836"
+- company: XAAS
+  board: "21874"
+- company: SAFA
+  board: "22387"
+- company: Insurgo GmbH
+  board: "22618"
+- company: Heeg Consulting GmbH
+  board: "22819"
+- company: vOffice Software
+  board: "22868"
+- company: Lumiform
+  board: "2288"
+- company: LWB Group
+  board: "23163"
+- company: Convact
+  board: "23235"
+- company: Global Changer
+  board: "23282"
+- company: smartkündigen OHG
+  board: "23661"
+- company: orderbird GmbH
+  board: "2378"
+- company: Softr
+  board: "23856"
+- company: MyGermanUniversity
+  board: "24235"
+- company: Hypercampus GmbH
+  board: "24312"
+- company: StraightAds Marketing GmbH
+  board: "24602"
+- company: PALTRON GmbH
+  board: "2541"
+- company: Una Health
+  board: "25465"
+- company: Learning Digital GmbH
+  board: "25646"
+- company: Gantner & Schmidt Wirtschaftskanzlei GmbH
+  board: "25782"
+- company: SKYVE
+  board: "26238"
+- company: Völzke Consulting
+  board: "26344"
+- company: hey contact heroes GmbH
+  board: "26562"
+- company: Strauß & Fliege
+  board: "27184"
+- company: steueragenten.de Steuerberatungsgesellschaft mbH
+  board: "27605"
+- company: big little things GmbH
+  board: "27960"
+- company: Cypher Consulting Europe
+  board: "28506"
+- company: Gromnitza Systemhaus GmbH
+  board: "28877"
+- company: OH MY! FANTASY
+  board: "29768"
+- company: Nutrition-Plus Germany e.K.
+  board: "29849"
+- company: qiibee
+  board: "299"
+- company: Schnell Global
+  board: "30216"
+- company: Lemontaps
+  board: "30420"
+- company: KeyNest
+  board: "30515"
+- company: Mala Management GmbH
+  board: "30644"
+- company: Harzspots GmbH
+  board: "30735"
+- company: Decentriq
+  board: "310"
+- company: Bots and People Product GmbH
+  board: "31202"
+- company: Sirius Music Communications GmbH
+  board: "31309"
+- company: Start To Finish Consulting GmbH
+  board: "31679"
+- company: Istikbal Bellona Möbelhaus
+  board: "31851"
+- company: telemedia-systems Unternehmergesellschaft
+  board: "33227"
+- company: clini.com GmbH
+  board: "34734"
+- company: Searchperts Deutschland GmbH
+  board: "35154"
+- company: paretos GmbH
+  board: "35456"
+- company: HomeOfficeClub.ch
+  board: "35673"
+- company: ACCELERATED
+  board: "36116"
+- company: Experius Co
+  board: "3772"
+- company: Gilytics AG
+  board: "37965"
+- company: StudyHelp GmbH
+  board: "38058"
+- company: clickworker GmbH
+  board: "38238"
+- company: Matchspace Music
+  board: "38506"
+- company: ehotel AG
+  board: "39012"
+- company: FastRocket GmbH
+  board: "40279"
+- company: Performancepixel GmbH
+  board: "40735"
+- company: zetcom group
+  board: "4110"
+- company: wealthAPI GmbH
+  board: "41214"
+- company: REPLUG
+  board: "41808"
+- company: Leadeffect GmbH
+  board: "42118"
+- company: THEFABERS
+  board: "43771"
+- company: yourXpert
+  board: "45172"
+- company: soonami.io GmbH
+  board: "45328"
+- company: Fimo Health
+  board: "45659"
+- company: mindmatters
+  board: "45702"
+- company: enclaive GmbH
+  board: "47781"
+- company: real PACE GmbH
+  board: "48065"
+- company: TecFox GmbH
+  board: "48586"
+- company: Trinovado GmbH / YOUCISION®
+  board: "50117"
+- company: AdRock Marketing
+  board: "51791"
+- company: BDF EXPERTS
+  board: "51906"
+- company: Flinker GmbH
+  board: "51961"
+- company: IUNA AI Systems GmbH
+  board: "52345"
+- company: Flummox
+  board: "53473"
+- company: relokate HR GmbH
+  board: "53635"
+- company: Qivalo GmbH
+  board: "54551"
+- company: AirTaxi Express AG
+  board: "55004"
+- company: NETSHAKE GmbH
+  board: "55830"
+- company: Consenzum Managementberatung UG (haftungsbeschränkt) & Co KG
+  board: "56576"
+- company: accantec group
+  board: "5663"
+- company: Die Eisenbahn Erlebnisreise
+  board: "56726"
+- company: Wegain GmbH
+  board: "56840"
+- company: FanQ
+  board: "5688"
+- company: IT & Beratung D. Meyer / Talentplatz.de
+  board: "57345"
+- company: STUR GmbH
+  board: "57614"
+- company: WORTHELDEN
+  board: "58258"
+- company: RIK JAMES Ventures GmbH
+  board: "59043"
+- company: Diingu
+  board: "59168"
+- company: Bundesgeschäftsstelle Sicher-Stark-Team
+  board: "59414"
+- company: Woospeak
+  board: "61207"
+- company: Spot Manufaktur GmbH
+  board: "61380"
+- company: Female Founder Space (WEFOUND gUG)
+  board: "6168"
+- company: Swiss Renewable Solutions AG
+  board: "61998"
+- company: HEY HOLY GmbH
+  board: "62205"
+- company: Windhoff Group
+  board: "626"
+- company: Infosim GmbH & Co. KG
+  board: "6287"
+- company: Skull Bliss
+  board: "62874"
+- company: MOVYNG MEDIA UG
+  board: "62976"
+- company: Masters of Digital
+  board: "64175"
+- company: FINN Design
+  board: "64706"
+- company: KORBEL GmbH
+  board: "65634"
+- company: Dropmaster.es
+  board: "65640"
+- company: totguia
+  board: "66538"
+- company: FindTutors
+  board: "66546"
+- company: Bundesverbraucherhilfe e.V.
+  board: "66600"
+- company: untersee Unternehmensberatung GmbH
+  board: "66872"
+- company: EDUopinions
+  board: "67042"
+- company: lasting brands GmbH
+  board: "67162"
+- company: Dawood Rechtsanwälte
+  board: "67192"
+- company: More Conversions GmbH
+  board: "67858"
+- company: BruBieBel Capital GmbH
+  board: "68388"
+- company: MOX Relations GmbH
+  board: "68995"
+- company: dynexo GmbH
+  board: "6905"
+- company: FFA GmbH
+  board: "69261"
+- company: dreamteam GmbH
+  board: "69271"
+- company: Mirtos Animal Project
+  board: "70833"
+- company: beatvest
+  board: "72278"
+- company: Piomic Medical
+  board: "72484"
+- company: DJOSSYE
+  board: "72489"
+- company: Pentest Factory GmbH
+  board: "72727"
+- company: FUTUREKIDS Computercenter
+  board: "72787"
+- company: everydays
+  board: "73031"
+- company: First Momentum Ventures
+  board: "7339"
+- company: Care Preventive AG
+  board: "73945"
+- company: Manuela Psychoéducatrice
+  board: "74536"
+- company: Ecoturn GmbH
+  board: "75918"
+- company: SnowHeap LLC
+  board: "75986"
+- company: App Akademie GmbH
+  board: "76692"
+- company: KTI Key Talent Indicator
+  board: "77332"
+- company: StudiBucht.de
+  board: "77602"
+- company: Winkler & Company
+  board: "77614"
+- company: Myosotis GmbH
+  board: "78770"
+- company: Artificient Mobility Intelligence
+  board: "79462"
+- company: No Bad Days Club (NBDC)
+  board: "79498"
+- company: SchoolRallye
+  board: "79753"
+- company: chocoBRAIN
+  board: "7987"
+- company: calmindon GmbH
+  board: "82594"
+- company: Slenderiser GmbH
+  board: "8290"
+- company: cleverlohn
+  board: "83543"
+- company: Agentur Nordblick
+  board: "83666"
+- company: JYMMiN Instant Music Feedback
+  board: "83699"
+- company: Deer Designer
+  board: "83711"
+- company: ofinto ag
+  board: "83910"
+- company: eFLY Marketplace Services GmbH
+  board: "8401"
+- company: HEMAV Technology
+  board: "84719"
+- company: ErsteNachhilfe
+  board: "85266"
+- company: Startup Wise Guys
+  board: "87381"
+- company: Andris Consulting GmbH
+  board: "8751"
+- company: nc newmedia
+  board: "87769"
+- company: Mens en Relatie
+  board: "87792"
+- company: NOELIE Deutschland Distribution GmbH & Co. KG
+  board: "88029"
+- company: LoveLane
+  board: "88232"
+- company: ZeroHassle - Interactivated Solutions Group
+  board: "88493"
+- company: Udo Prost GLOBAL-FINANZ
+  board: "8882"
+- company: anocus GmbH
+  board: "89230"
+- company: CUJU
+  board: "89986"
+- company: heygrün
+  board: "90034"
+- company: Renidere Verlag
+  board: "90070"
+- company: MyImmoLeads - FS Media
+  board: "90654"
+- company: Alirna
+  board: "90813"
+- company: Skalierung Mittelstand GmbH
+  board: "91598"
+- company: Jules & moi
+  board: "91708"
+- company: LDB Gruppe
+  board: "9223"
+- company: reemento
+  board: "92738"
+- company: Breathment
+  board: "93382"
+- company: leakshield GmbH
+  board: "93916"
+- company: ZEP GmbH
+  board: "93925"
+- company: Emma Grün GmbH
+  board: "94050"
+- company: L'Arbre à Thé
+  board: "94144"
+- company: Finesseo
+  board: "94208"
+- company: Fischer Media Consulting
+  board: "94732"
+- company: Paintgun
+  board: "9628"
+- company: Gostek Media
+  board: "97570"
+- company: Palantir Agency
+  board: "98458"
+- company: Clementine Media
+  board: "98716"
+- company: PR Profis®
+  board: "99159"
+- company: Heinsohn Business Technology
+  board: "99359"
+- company: Lemvos GmbH
+  board: "99412"
+- company: Mandarin Projects SA de CV
+  board: "99931"
+- company: Sardina Systems
+  board: "102607"
+- company: Elephant Webdesign & Marketing GmbH
+  board: "103515"
+- company: Broadgate Voice and Data Ltd
+  board: "108722"
+- company: Adhoq
+  board: "116137"
+- company: hurra.com
+  board: "118005"
+- company: promantis GmbH
+  board: "12291"
+- company: finanture
+  board: "125992"
+- company: Saddleback Solutions
+  board: "131437"
+- company: Aivy
+  board: "13286"
+- company: Passengers friend GmbH
+  board: "13897"
+- company: Blue Demonstration e.V.
+  board: "139857"
+- company: Scio Labs
+  board: "151066"
+- company: ND Autoteile GmbH
+  board: "153441"
+- company: parasus GmbH
+  board: "15759"
+- company: spectup
+  board: "161236"
+- company: Vorteilshero GmbH
+  board: "165179"
+- company: Szczerba Solutions
+  board: "168155"
+- company: LYON INCORPORATED LTD
+  board: "176626"
+- company: SyncVR Medical B.V. / GmbH / ApS / Ltd.
+  board: "20363"
+- company: TradeLink
+  board: "21803"
+- company: dexter health
+  board: "28474"
+- company: Depeur UG
+  board: "34838"
+- company: Roger
+  board: "38459"
+- company: PluginEnergy GmbH
+  board: "45457"
+- company: Luxregia GmbH
+  board: "47053"
+- company: AudioWerk Digital UG (haftungsbeschränkt)
+  board: "54707"
+- company: STUDIO EINS - Bürgerfunkinitiative e.V.
+  board: "64532"
+- company: Mothership Talents GmbH
+  board: "66311"
+- company: WOLF OF SEO FZ LLC
+  board: "66852"
+- company: audius SE
+  board: "68925"
+- company: D-I-S commerce engineering
+  board: "81315"
+- company: Pertemps ERP
+  board: "8165"
+- company: Smatched
+  board: "8833"
+- company: 12minutes GmbH
+  board: "92419"
+- company: verwoehnwochenende.de
+  board: "9482"
+- company: Voithru
+  board: "97307"
+- company: Adrián Alcalá
+  board: "99001"


### PR DESCRIPTION
Closes the single biggest unresolved group left by the apply-link harvest (#2070, #2073): 607 of the 1 748 destinations that reached a supported platform but carried no usable board id.

## Why the URL was not enough — and why that stays true

A Join job URL names the company by **domain** (`join.com/companies/<domain>/<jobid>-<title>`), while `internal/sources/join.go` addresses a board by the **numeric company id**. That is exactly why `internal/atsdetect` declines this shape rather than guessing, and nothing here changes that: the id is genuinely not derivable from the URL.

It is, however, one keyless request away. The job id is already in the path, and `/api/public/jobs/<id>` answers with `companyId` and the company's real name. So the board still comes from the platform's own answer — no page scraping, no id guessing, no slug resemblance.

## Yield

| | |
|---|---|
| apply URLs | 607 |
| resolved to a company id | **607 (100%)** |
| new to the catalogue | 578 |
| **answered a live listing** | **573** |

Probe failures: 0. Name mismatches: 0 — unsurprising, since the seed's company name comes from the same API the gate checks against.

`sources/join.yml`: 4 171 → 4 744.

## Pacing, for the next Join run

Join rate-limits a burst. The default 16 workers had **533 of 578** probes refused, and `harvest-boards` correctly wrote nothing and exited non-zero rather than reporting live boards as dead. `-pace 2 -workers 2` takes ten minutes and refuses 75; a follow-up `-pace 1 -workers 1` sweep picked up the remainder.

Duplicate audit on the file: 0 introduced. `go test ./internal/sources/` green.