### PR TITLE
Add a quiet include/exclude hint to the job filter modal

### DIFF
--- a/design-system/scripts/adoption-baseline.json
+++ b/design-system/scripts/adoption-baseline.json
@@ -23,5 +23,5 @@
   "Table": 6,
   "Tabs": 0,
   "TabStrip": 4,
-  "Tooltip": 0
+  "Tooltip": 1
 }

--- a/web/src/lib/components/filters/FilterModal.svelte
+++ b/web/src/lib/components/filters/FilterModal.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import { resolve } from '$app/paths';
-  import { Bell, UserRound } from '@lucide/svelte';
+  import { Bell, Info, UserRound } from '@lucide/svelte';
+  import { Tooltip } from '$lib/ui';
   import { FACETS } from '$lib/facets';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
@@ -199,9 +200,28 @@
   countsFetch={stagedCounts}
   {pane}
   headerAction={showProfileAction ? profileAction : undefined}
+  {titleHint}
   extra={extra ? extraStaged : undefined}
   {footerNote}
 />
+
+<!-- Most facets are three-state (off / include / exclude); one quiet hint in the
+     header covers all of them rather than repeating the explanation on every
+     excludable section. -->
+{#snippet titleHint()}
+  <Tooltip side="bottom">
+    <button
+      type="button"
+      aria-label="How filters work"
+      class="flex size-4 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground"
+    >
+      <Info class="size-3.5" aria-hidden="true" />
+    </button>
+    {#snippet content()}
+      Click a filter once to include it, again to exclude it, again to clear it.
+    {/snippet}
+  </Tooltip>
+{/snippet}
 
 {#snippet profileAction()}
   {#if !isAuthenticated() || profile}

--- a/web/src/lib/components/filters/FilterModalShell.svelte
+++ b/web/src/lib/components/filters/FilterModalShell.svelte
@@ -41,6 +41,7 @@
     initialKey,
     pane,
     headerAction,
+    titleHint,
     extra,
     footerNote,
   }: {
@@ -73,6 +74,10 @@
     /** Optional control rendered in the header row, between the title and Close (e.g. the
      *  job modal's "Apply my profile"). Absent for callers that don't need one. */
     headerAction?: Snippet;
+    /** Optional small hint rendered right after the title (e.g. the job modal's
+     *  include/exclude tooltip). Absent for callers with nothing to explain there —
+     *  the companies modal has no excludable facets, so it passes none. */
+    titleHint?: Snippet;
     /** Optional content above the pane (e.g. the profile editor's "import from CV"). */
     extra?: Snippet;
     /** Optional footer nudge above the action row, handed a `jumpTo` to switch panes and
@@ -183,7 +188,10 @@
     >
       <!-- header -->
       <div class="flex items-center gap-3 border-b border-border px-4 py-3">
-        <h2 class="flex-1 text-base font-semibold tracking-tight">{title}</h2>
+        <h2 class="flex flex-1 items-center gap-1.5 text-base font-semibold tracking-tight">
+          {title}
+          {#if titleHint}{@render titleHint()}{/if}
+        </h2>
         {#if headerAction}{@render headerAction()}{/if}
         <button
           type="button"


### PR DESCRIPTION
## Summary
- Most facets in the job filter panel are three-state (off / include / exclude) via a click cycle, but the panel never explained this — a user could easily miss that a second click excludes a value.
- Adds one small `Info` tooltip next to the modal title (not repeated per facet section, to stay unobtrusive) explaining the click cycle.
- `FilterModalShell` gains an optional `titleHint` snippet; only the jobs `FilterModal` passes one — the companies modal has no excludable facets, so it stays without.

## Test plan
- [x] `svelte-check` clean (0 errors)
- [x] `eslint` clean (fixed an initial `no-useless-children-snippet` + `a11y_no_noninteractive_tabindex` during review)
- [ ] Manual click-through on `/jobs` with a seeded local catalogue (this dev machine's local Postgres/Meilisearch has no indexed jobs, so the live page 500s independent of this change — see `internal/search/AGENTS.md` on why an unfilterable/empty index 500s rather than degrading)