### PR TITLE
sources: pace the Join crawl, and say how many shards it needs

### DIFF
--- a/internal/sources/join_pace_test.go
+++ b/internal/sources/join_pace_test.go
@@ -1,0 +1,55 @@
+package sources
+
+import (
+	"testing"
+	"time"
+)
+
+// joinShards is how many staggered runs sources/join.yml is split across on prod
+// (freehire-ingest-join-shard@N.timer, --shard=N/4, one firing per hour so only one is ever
+// crawling and the pace below is the whole fleet's rate, not each shard's).
+const joinShards = 4
+
+// TestJoinPaceFitsTheRunBudget pins the arithmetic that picked both the pace and the shard
+// count. Too fast and the refusals come back; too slow and systemd kills the run mid-crawl,
+// which board_health cannot tell apart from the platform being down — the same trap the
+// Teamtailor pacing hit.
+func TestJoinPaceFitsTheRunBudget(t *testing.T) {
+	// Measured on prod 2026-08-18: 4749 boards needing 5234 listing pages at the API's
+	// hard pageSize cap of 5, and 10455 postings each costing one detail request.
+	const (
+		requestsPerRun = 5234 + 10455
+		unitTimeout    = 3000 * time.Second // freehire-ingest@.service TimeoutStartSec
+		// A run that uses its whole budget has no room for a slow page or a retry, and a
+		// killed run is indistinguishable from an outage in board_health.
+		headroom = 0.8
+	)
+
+	perSecond := float64(time.Second) / float64(joinRequestInterval)
+	perShard := float64(requestsPerRun) / joinShards
+	runtime := time.Duration(perShard / perSecond * float64(time.Second))
+
+	if budget := time.Duration(float64(unitTimeout) * headroom); runtime > budget {
+		t.Errorf("a shard takes %v at %.1f req/s (%.0f of %d requests), past the %v working "+
+			"budget — the tail would be killed mid-crawl; raise joinShards or the pace",
+			runtime.Round(time.Second), perSecond, perShard, requestsPerRun, budget)
+	}
+	// 3 req/s was refused 10% of the time against live boards; a "pace" at or above that
+	// would not be a pace at all.
+	if perSecond >= 3 {
+		t.Errorf("%.1f req/s is at or past the rate Join began refusing", perSecond)
+	}
+}
+
+// TestJoinIsPaced guards the wiring. Join has one wiring — it is not in proxiedProviders — but
+// the registry is where an adapter loses its pacer during an unrelated edit, and losing it is
+// silent: the crawl simply starts being refused again.
+func TestJoinIsPaced(t *testing.T) {
+	src, ok := All(NewClient())["join"].(join)
+	if !ok {
+		t.Fatal("join is not registered, or no longer the join type")
+	}
+	if _, paced := src.http.(rateLimitedJSONGetter); !paced {
+		t.Errorf("registry join is not paced: got %T", src.http)
+	}
+}

--- a/internal/sources/pacer.go
+++ b/internal/sources/pacer.go
@@ -77,6 +77,58 @@ const (
 	clinchRequestBurst    = 1
 )
 
+// rateLimitedJSONGetter is the JSON-GET counterpart of rateLimitedHTMLGetter: it wraps a
+// JSONGetter with a shared limiter so its aggregate GetJSON rate stays under the endpoint's
+// budget, independent of the caller's worker concurrency. One instance carries one limiter, so
+// every request routed through it — across boards, listing pages and the detail fan-out —
+// shares the same token bucket.
+//
+// Distinct from concurrencyLimitedJSONGetter below: that one caps how many requests are in
+// FLIGHT, the right lever for an API that degrades under sustained concurrent load. This one
+// caps the request rate, the right lever for an API that meters requests per unit time and is
+// indifferent to how many arrive at once.
+type rateLimitedJSONGetter struct {
+	inner   JSONGetter
+	limiter waiter
+}
+
+// GetJSON blocks on the limiter before delegating, so a cancelled context surfaces as the Wait
+// error and the inner fetch is skipped.
+func (g rateLimitedJSONGetter) GetJSON(ctx context.Context, url string, v any) error {
+	if err := g.limiter.Wait(ctx); err != nil {
+		return err
+	}
+	return g.inner.GetJSON(ctx, url, v)
+}
+
+// join.com meters by RATE, and the two were easy to confuse: an unpaced crawl fans 8 board
+// workers out over its list endpoint and the refusals looked like a concurrency limit, but
+// holding the rate steady and varying only the worker count clears it — 4 workers at 2 req/s
+// were refused nothing, while 2 workers left to run flat out (5.7 req/s) lost 17%. Measured
+// against live boards 2026-08-18:
+//
+//	1.1 req/s, 700 requests  →   0% refused      3 req/s, 100 requests → 10% refused
+//	2   req/s, 240 requests  →   0% refused      5 req/s, 100 requests → 20% refused
+//
+// So the knee sits between 2 and 3, and the pace takes the clean side of it. Under-shooting
+// only lengthens a run; over-shooting re-enters the refusals that had 3436 of 4749 boards
+// failing before this existed.
+const (
+	joinRequestInterval = 500 * time.Millisecond // 2 req/s
+	joinRequestBurst    = 2
+)
+
+// pacedJoinGetter wraps a getter with a fresh limiter shared across one registry build, so every
+// board's listing pages and detail fan-out in a run compete for the same token bucket. Both paths
+// are wrapped because both hit the same metered host — unlike seek, whose listing was never
+// refused.
+func pacedJoinGetter(c JSONGetter) JSONGetter {
+	return rateLimitedJSONGetter{
+		inner:   c,
+		limiter: rate.NewLimiter(rate.Every(joinRequestInterval), joinRequestBurst),
+	}
+}
+
 // rateLimitedJSONPoster is the JSON-POST counterpart of rateLimitedHTMLGetter: it wraps a
 // JSONPoster with a shared limiter so its aggregate PostJSON rate stays under the endpoint's
 // budget, independent of the caller's worker concurrency. It exists because a detail endpoint is

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -160,7 +160,7 @@ func All(c HTTPClient) map[string]Source {
 		NewJazzHR(c),
 		NewWPYoast(c),
 		NewBreezy(c),
-		NewJoin(c),
+		NewJoin(pacedJoinGetter(c)),
 		NewGlobalPayments(c),
 		NewRapyd(c),
 		NewCareerPlug(c),


### PR DESCRIPTION
**3 436 of Join's 4 749 boards were failing on HTTP 429, 2 951 of them chronically** — roughly two thirds of that fleet had not been crawled successfully in a long time. A failing board in `board_health` looks identical whether the platform is down or we are the ones flooding it, which is why this sat unnoticed.

## Rate, not concurrency — and they were easy to confuse

An unpaced crawl fans 8 board workers over the list endpoint, so worker count and request rate move together; the first refusals read like a concurrency limit. Holding the rate fixed and varying only the workers separates them.

| setup | rate | refused |
|---|---:|---:|
| 1 worker, sequential (700 requests) | 1.1 req/s | **0%** |
| 4 workers, gated (80 requests) | 2 req/s | **0%** |
| 2 workers, flat out (80 requests) | 5.7 req/s | 17% |
| 8 workers, gated (100 requests) | 3 req/s | 10% |
| 8 workers, gated (100 requests) | 5 req/s | 20% |

Four workers at 2 req/s were refused nothing while two workers at 5.7 lost 17% — so it is the rate. The knee sits between 2 and 3, and the pace takes the clean side: **2 req/s, burst 2**. Under-shooting only lengthens a run; over-shooting re-enters the refusals this exists to stop.

Sequential runs are always clean for a reason worth stating: a request takes ~0.9s, so one in flight cannot exceed ~1.1 req/s no matter how hard it tries.

## A new limiter kind, deliberately

`pacer.go` had a rate limiter for HTML GET and JSON POST, plus a *concurrency* limiter for JSON GET (trudvsem). Join needs rate-limited JSON GET, which did not exist. The two are not interchangeable and the comment now says which lever fits which failure: cap in-flight requests for an API that degrades under sustained concurrent load, cap the rate for one that meters requests per unit time.

## Pacing alone is not enough, and the test says so

A full run is **5 234 listing pages** (the API caps `pageSize` at 5) plus **10 455 detail requests**. At 2 req/s that is 131 minutes against a 50-minute `TimeoutStartSec` — a run that gets killed mid-crawl, which is exactly the failure this is meant to end.

`TestJoinPaceFitsTheRunBudget` pins the arithmetic at **four shards with 20% headroom**; three would not fit (2 615s against a 2 400s working budget), so the test fails if anyone lowers it. Ops must therefore run `--shard=N/4` staggered one per hour, the way `freehire-ingest-eightfold-shard@N` already does. Only one shard crawls at a time, so the 2 req/s above is the whole fleet's rate rather than each shard's.

## Checks

`gofmt` clean, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...` — all green.

Follows #2081, which added 573 Join boards and surfaced this.