### PR TITLE
Add an advanced-search onboarding letter, push no_alert to day 6

### DIFF
--- a/cmd/onboarding/main.go
+++ b/cmd/onboarding/main.go
@@ -1,7 +1,8 @@
 // Command onboarding is the founder signup-sequence worker. One run does a single
-// pass over the three steps — greet, ask about the missing alert, talk about the
-// project — sending each eligible mail once and recording it. Run it on a schedule
-// (hourly is plenty; the first step is the only time-sensitive one) and it exits.
+// pass over the four steps — greet, introduce the filter panel, ask about the
+// missing alert, talk about the project — sending each eligible mail once and
+// recording it. Run it on a schedule (hourly is plenty; the first step is the only
+// time-sensitive one) and it exits.
 //
 // It exits non-zero when any send failed, so the timer's failure handling surfaces
 // a broken sender rather than the sequence quietly stopping.
@@ -36,7 +37,7 @@ import (
 //	./onboarding -to you@example.com -step open_source
 var (
 	sendTo   = flag.String("to", "", "send one mail to this address and exit (no database, no ledger)")
-	sendStep = flag.String("step", string(onboarding.StepWelcome), "which step -to sends: welcome | no_alert | open_source")
+	sendStep = flag.String("step", string(onboarding.StepWelcome), "which step -to sends: welcome | advanced_search | no_alert | open_source")
 )
 
 func main() {

--- a/design-system/static/email-previews/index.html
+++ b/design-system/static/email-previews/index.html
@@ -125,10 +125,35 @@ https://www.linkedin.com/in/istrelov/
 
   <div class="card">
     <div class="meta">
-      <div class="name">Onboarding / 2 · No alert yet</div>
+      <div class="name">Onboarding / 2 · Advanced search</div>
+      <div class="subject">The filters go deeper than you’d think</div>
+    </div>
+    <iframe data-mail="onboarding-advanced-search" src="onboarding-advanced-search.light.html" title="Onboarding / 2 · Advanced search" sandbox="allow-same-origin" loading="lazy"></iframe>
+    <div class="text">
+      <details><summary>Plain-text alternative</summary><pre>Most job boards give you a handful of dropdowns. freehire has twenty — role, seniority,
+stack, region, company type, salary currency, even whether a posting looks real.
+
+The one people miss: almost every filter can also mean &#34;not this.&#34; Click a value once to
+require it, again to rule it out — a company you already applied to, a stack you&#39;re done
+with, a source you don&#39;t trust.
+
+Save the search once, and freehire keeps running it for you — Telegram, email or push,
+your choice.
+
+See how the filters work: ./features/advanced-search
+
+— Ilya Strelov, building freehire
+https://www.linkedin.com/in/istrelov/
+</pre></details>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="meta">
+      <div class="name">Onboarding / 3 · No alert yet</div>
       <div class="subject">Want me to set up your search?</div>
     </div>
-    <iframe data-mail="onboarding-no-alert" src="onboarding-no-alert.light.html" title="Onboarding / 2 · No alert yet" sandbox="allow-same-origin" loading="lazy"></iframe>
+    <iframe data-mail="onboarding-no-alert" src="onboarding-no-alert.light.html" title="Onboarding / 3 · No alert yet" sandbox="allow-same-origin" loading="lazy"></iframe>
     <div class="text">
       <details><summary>Plain-text alternative</summary><pre>You signed up a few days ago but haven&#39;t set up a job alert yet. That is the part that does the
 work for you: describe the search once, and new matches come to you instead of you checking.
@@ -147,10 +172,10 @@ https://www.linkedin.com/in/istrelov/
 
   <div class="card">
     <div class="meta">
-      <div class="name">Onboarding / 3 · Open source</div>
+      <div class="name">Onboarding / 4 · Open source</div>
       <div class="subject">freehire is open source</div>
     </div>
-    <iframe data-mail="onboarding-open-source" src="onboarding-open-source.light.html" title="Onboarding / 3 · Open source" sandbox="allow-same-origin" loading="lazy"></iframe>
+    <iframe data-mail="onboarding-open-source" src="onboarding-open-source.light.html" title="Onboarding / 4 · Open source" sandbox="allow-same-origin" loading="lazy"></iframe>
     <div class="text">
       <details><summary>Plain-text alternative</summary><pre>Some background you might not know: freehire is fully open source. Every parser, every dedup
 rule, the ranking — all of it is public. Nothing is hidden about how a job gets in, or why it

--- a/design-system/static/email-previews/onboarding-advanced-search.dark.html
+++ b/design-system/static/email-previews/onboarding-advanced-search.dark.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="dark">
+<meta name="supported-color-schemes" content="dark">
+<title>The filters go deeper</title>
+<style>
+  .m-page   { background: #0d0e0b !important; }
+  .m-card   { background: #161616 !important; border-color: #2a2a2a !important; }
+  .m-ink    { color: #fafafa !important; }
+  .m-muted  { color: #a4a4a4 !important; }
+  .m-row    { border-top-color: #2a2a2a !important; }
+  .m-quote  { color: #a4a4a4 !important; border-left-color: #2a2a2a !important; }
+  .m-code   { background: #2e3318 !important; color: #b5c478 !important; }
+  .m-tile   { background: #2e3318 !important; color: #b5c478 !important; }
+  .m-btn    { background: #9cae69 !important; }
+  .m-btn-a  { color: #101309 !important; }
+  .m-logo   { filter: invert(1); }
+</style>
+</head>
+<body class="m-page" style="margin:0;padding:0;background:#f0f0f0;">
+<div style="display:none;max-height:0;overflow:hidden;opacity:0;">Exclude a value, not just include one — and save the search.</div>
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="m-page" style="background:#f0f0f0;">
+  <tr><td align="center" style="padding:32px 12px;">
+    <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;width:100%;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+
+      <tr><td style="padding:0 4px 16px 4px;">
+        <a href="." style="text-decoration:none;color:#070707;">
+          <img src="./email-logo.png" width="28" height="28" alt="" class="m-logo" style="vertical-align:middle;border:0;display:inline-block;">
+          <span class="m-ink" style="vertical-align:middle;padding-left:10px;font-size:17px;font-weight:700;letter-spacing:-0.01em;color:#070707;">freehire</span>
+        </a>
+      </td></tr>
+
+      <tr><td class="m-card" style="background:#ffffff;border:1px solid #e4e4e4;border-radius:12px;padding:28px;">
+        <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">The filters go deeper</h1>
+        
+<p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">Most job boards give you a handful of dropdowns. freehire has twenty — role, seniority, stack, region, company type, salary currency, even whether a posting looks real.</p>
+<p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">The one people miss: almost every filter can also mean “not this.” Click a value once to require it, again to rule it out — a company you already applied to, a stack you’re done with, a source you don’t trust.</p>
+<p class="m-ink" style="margin:0 0 14px 0;font-size:17px;line-height:1.5;font-weight:600;color:#070707;">Save the search once, and freehire keeps running it for you — Telegram, email or push, your choice.</p>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="./features/advanced-search?utm_source=email" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;">See how the filters work</a></td></tr></table>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin-top:22px;">
+  <tr>
+    <td width="52" valign="top" style="width:52px;padding-right:12px;">
+      <img src="./ilya.jpg" width="44" height="44" alt="Ilya" style="display:block;border:0;border-radius:22px;">
+    </td>
+    <td valign="middle">
+      <div class="m-ink" style="font-size:14px;font-weight:600;color:#070707;">Ilya Strelov</div>
+      <div class="m-muted" style="font-size:13px;color:#505050;padding-top:2px;">
+        building freehire ·
+        <a href="https://www.linkedin.com/in/istrelov/" class="m-muted" style="color:#505050;text-decoration:none;"><img src="./email-icon-linkedin.png" width="14" height="14" alt="" class="m-logo" style="vertical-align:-2px;border:0;padding-right:4px;">LinkedIn</a>
+      </div>
+    </td>
+  </tr>
+</table>
+      </td></tr>
+
+      
+      <tr><td class="m-muted" style="padding:20px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
+        You’re getting this because you signed up for freehire.
+      </td></tr>
+      
+
+      <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
+        <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
+        <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
+      </td></tr>
+
+    </table>
+  </td></tr>
+</table>
+</body>
+</html>

--- a/design-system/static/email-previews/onboarding-advanced-search.html
+++ b/design-system/static/email-previews/onboarding-advanced-search.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
+<title>The filters go deeper</title>
+<style>@media (prefers-color-scheme: dark) {
+  .m-page   { background: #0d0e0b !important; }
+  .m-card   { background: #161616 !important; border-color: #2a2a2a !important; }
+  .m-ink    { color: #fafafa !important; }
+  .m-muted  { color: #a4a4a4 !important; }
+  .m-row    { border-top-color: #2a2a2a !important; }
+  .m-quote  { color: #a4a4a4 !important; border-left-color: #2a2a2a !important; }
+  .m-code   { background: #2e3318 !important; color: #b5c478 !important; }
+  .m-tile   { background: #2e3318 !important; color: #b5c478 !important; }
+  .m-btn    { background: #9cae69 !important; }
+  .m-btn-a  { color: #101309 !important; }
+  .m-logo   { filter: invert(1); }
+}</style>
+</head>
+<body class="m-page" style="margin:0;padding:0;background:#f0f0f0;">
+<div style="display:none;max-height:0;overflow:hidden;opacity:0;">Exclude a value, not just include one — and save the search.</div>
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="m-page" style="background:#f0f0f0;">
+  <tr><td align="center" style="padding:32px 12px;">
+    <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;width:100%;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+
+      <tr><td style="padding:0 4px 16px 4px;">
+        <a href="." style="text-decoration:none;color:#070707;">
+          <img src="./email-logo.png" width="28" height="28" alt="" class="m-logo" style="vertical-align:middle;border:0;display:inline-block;">
+          <span class="m-ink" style="vertical-align:middle;padding-left:10px;font-size:17px;font-weight:700;letter-spacing:-0.01em;color:#070707;">freehire</span>
+        </a>
+      </td></tr>
+
+      <tr><td class="m-card" style="background:#ffffff;border:1px solid #e4e4e4;border-radius:12px;padding:28px;">
+        <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">The filters go deeper</h1>
+        
+<p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">Most job boards give you a handful of dropdowns. freehire has twenty — role, seniority, stack, region, company type, salary currency, even whether a posting looks real.</p>
+<p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">The one people miss: almost every filter can also mean “not this.” Click a value once to require it, again to rule it out — a company you already applied to, a stack you’re done with, a source you don’t trust.</p>
+<p class="m-ink" style="margin:0 0 14px 0;font-size:17px;line-height:1.5;font-weight:600;color:#070707;">Save the search once, and freehire keeps running it for you — Telegram, email or push, your choice.</p>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="./features/advanced-search?utm_source=email" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;">See how the filters work</a></td></tr></table>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin-top:22px;">
+  <tr>
+    <td width="52" valign="top" style="width:52px;padding-right:12px;">
+      <img src="./ilya.jpg" width="44" height="44" alt="Ilya" style="display:block;border:0;border-radius:22px;">
+    </td>
+    <td valign="middle">
+      <div class="m-ink" style="font-size:14px;font-weight:600;color:#070707;">Ilya Strelov</div>
+      <div class="m-muted" style="font-size:13px;color:#505050;padding-top:2px;">
+        building freehire ·
+        <a href="https://www.linkedin.com/in/istrelov/" class="m-muted" style="color:#505050;text-decoration:none;"><img src="./email-icon-linkedin.png" width="14" height="14" alt="" class="m-logo" style="vertical-align:-2px;border:0;padding-right:4px;">LinkedIn</a>
+      </div>
+    </td>
+  </tr>
+</table>
+      </td></tr>
+
+      
+      <tr><td class="m-muted" style="padding:20px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
+        You’re getting this because you signed up for freehire.
+      </td></tr>
+      
+
+      <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
+        <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
+        <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
+      </td></tr>
+
+    </table>
+  </td></tr>
+</table>
+</body>
+</html>

--- a/design-system/static/email-previews/onboarding-advanced-search.light.html
+++ b/design-system/static/email-previews/onboarding-advanced-search.light.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="light">
+<meta name="supported-color-schemes" content="light">
+<title>The filters go deeper</title>
+
+</head>
+<body class="m-page" style="margin:0;padding:0;background:#f0f0f0;">
+<div style="display:none;max-height:0;overflow:hidden;opacity:0;">Exclude a value, not just include one — and save the search.</div>
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="m-page" style="background:#f0f0f0;">
+  <tr><td align="center" style="padding:32px 12px;">
+    <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;width:100%;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+
+      <tr><td style="padding:0 4px 16px 4px;">
+        <a href="." style="text-decoration:none;color:#070707;">
+          <img src="./email-logo.png" width="28" height="28" alt="" class="m-logo" style="vertical-align:middle;border:0;display:inline-block;">
+          <span class="m-ink" style="vertical-align:middle;padding-left:10px;font-size:17px;font-weight:700;letter-spacing:-0.01em;color:#070707;">freehire</span>
+        </a>
+      </td></tr>
+
+      <tr><td class="m-card" style="background:#ffffff;border:1px solid #e4e4e4;border-radius:12px;padding:28px;">
+        <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">The filters go deeper</h1>
+        
+<p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">Most job boards give you a handful of dropdowns. freehire has twenty — role, seniority, stack, region, company type, salary currency, even whether a posting looks real.</p>
+<p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">The one people miss: almost every filter can also mean “not this.” Click a value once to require it, again to rule it out — a company you already applied to, a stack you’re done with, a source you don’t trust.</p>
+<p class="m-ink" style="margin:0 0 14px 0;font-size:17px;line-height:1.5;font-weight:600;color:#070707;">Save the search once, and freehire keeps running it for you — Telegram, email or push, your choice.</p>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="./features/advanced-search?utm_source=email" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;">See how the filters work</a></td></tr></table>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin-top:22px;">
+  <tr>
+    <td width="52" valign="top" style="width:52px;padding-right:12px;">
+      <img src="./ilya.jpg" width="44" height="44" alt="Ilya" style="display:block;border:0;border-radius:22px;">
+    </td>
+    <td valign="middle">
+      <div class="m-ink" style="font-size:14px;font-weight:600;color:#070707;">Ilya Strelov</div>
+      <div class="m-muted" style="font-size:13px;color:#505050;padding-top:2px;">
+        building freehire ·
+        <a href="https://www.linkedin.com/in/istrelov/" class="m-muted" style="color:#505050;text-decoration:none;"><img src="./email-icon-linkedin.png" width="14" height="14" alt="" class="m-logo" style="vertical-align:-2px;border:0;padding-right:4px;">LinkedIn</a>
+      </div>
+    </td>
+  </tr>
+</table>
+      </td></tr>
+
+      
+      <tr><td class="m-muted" style="padding:20px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
+        You’re getting this because you signed up for freehire.
+      </td></tr>
+      
+
+      <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
+        <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
+        <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
+      </td></tr>
+
+    </table>
+  </td></tr>
+</table>
+</body>
+</html>

--- a/internal/db/onboarding.sql.go
+++ b/internal/db/onboarding.sql.go
@@ -9,6 +9,58 @@ import (
 	"context"
 )
 
+const listAdvancedSearchCandidates = `-- name: ListAdvancedSearchCandidates :many
+SELECT u.id, u.email
+FROM users u
+JOIN onboarding_emails w ON w.user_id = u.id AND w.step = 'welcome'
+LEFT JOIN notification_settings ns ON ns.user_id = u.id
+WHERE u.email_verified
+  AND u.created_at > now() - make_interval(days => $1::int)
+  AND w.sent_at < now() - make_interval(days => $2::int)
+  AND COALESCE(ns.enabled, true)
+  AND NOT EXISTS (
+      SELECT 1 FROM onboarding_emails oe
+      WHERE oe.user_id = u.id AND oe.step = 'advanced_search'
+  )
+ORDER BY u.created_at
+LIMIT $3::int
+`
+
+type ListAdvancedSearchCandidatesParams struct {
+	WindowDays int32 `json:"window_days"`
+	AfterDays  int32 `json:"after_days"`
+	MaxRows    int32 `json:"max_rows"`
+}
+
+type ListAdvancedSearchCandidatesRow struct {
+	ID    int64  `json:"id"`
+	Email string `json:"email"`
+}
+
+// Greeted a while ago: an introduction to the filter panel (role, region, skills,
+// and how to exclude a value). Sent to everyone regardless of alert status, unlike
+// no_alert below — this is background on a feature, not a nudge toward one missing
+// action, so it asks nothing of the reader that would make it conditional.
+func (q *Queries) ListAdvancedSearchCandidates(ctx context.Context, arg ListAdvancedSearchCandidatesParams) ([]ListAdvancedSearchCandidatesRow, error) {
+	rows, err := q.db.Query(ctx, listAdvancedSearchCandidates, arg.WindowDays, arg.AfterDays, arg.MaxRows)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListAdvancedSearchCandidatesRow{}
+	for rows.Next() {
+		var i ListAdvancedSearchCandidatesRow
+		if err := rows.Scan(&i.ID, &i.Email); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listNoAlertCandidates = `-- name: ListNoAlertCandidates :many
 SELECT u.id, u.email
 FROM users u

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1605,6 +1605,11 @@ type Querier interface {
 	// worker groups these by canonical(query) so each distinct filter hits the search
 	// index once regardless of how many subscriptions share it.
 	ListActiveSubscriptions(ctx context.Context) ([]ListActiveSubscriptionsRow, error)
+	// Greeted a while ago: an introduction to the filter panel (role, region, skills,
+	// and how to exclude a value). Sent to everyone regardless of alert status, unlike
+	// no_alert below — this is background on a feature, not a nudge toward one missing
+	// action, so it asks nothing of the reader that would make it conditional.
+	ListAdvancedSearchCandidates(ctx context.Context, arg ListAdvancedSearchCandidatesParams) ([]ListAdvancedSearchCandidatesRow, error)
 	// Keyset page of one AGGREGATOR SOURCE's open postings.
 	//
 	// Scoped to a single source on purpose. The earlier `source = ANY(...)` form defeated its

--- a/internal/db/queries/onboarding.sql
+++ b/internal/db/queries/onboarding.sql
@@ -28,6 +28,26 @@ WHERE u.email_verified
 ORDER BY u.created_at
 LIMIT sqlc.arg(max_rows)::int;
 
+-- name: ListAdvancedSearchCandidates :many
+-- Greeted a while ago: an introduction to the filter panel (role, region, skills,
+-- and how to exclude a value). Sent to everyone regardless of alert status, unlike
+-- no_alert below — this is background on a feature, not a nudge toward one missing
+-- action, so it asks nothing of the reader that would make it conditional.
+SELECT u.id, u.email
+FROM users u
+JOIN onboarding_emails w ON w.user_id = u.id AND w.step = 'welcome'
+LEFT JOIN notification_settings ns ON ns.user_id = u.id
+WHERE u.email_verified
+  AND u.created_at > now() - make_interval(days => sqlc.arg(window_days)::int)
+  AND w.sent_at < now() - make_interval(days => sqlc.arg(after_days)::int)
+  AND COALESCE(ns.enabled, true)
+  AND NOT EXISTS (
+      SELECT 1 FROM onboarding_emails oe
+      WHERE oe.user_id = u.id AND oe.step = 'advanced_search'
+  )
+ORDER BY u.created_at
+LIMIT sqlc.arg(max_rows)::int;
+
 -- name: ListNoAlertCandidates :many
 -- Greeted a while ago, and still without an active alert — the one action the
 -- product is built around.

--- a/internal/mailpreview/mailpreview.go
+++ b/internal/mailpreview/mailpreview.go
@@ -83,6 +83,7 @@ var renderers = []func(string) (Sample, error){
 	phHeadsUpSample,
 	phLiveSample,
 	welcomeSample,
+	advancedSearchSample,
 	noAlertSample,
 	openSourceSample,
 	verificationSample,
@@ -170,12 +171,16 @@ func welcomeSample(baseURL string) (Sample, error) {
 	return onboardingSample("onboarding-welcome", "Onboarding / 1 · Welcome", onboarding.StepWelcome, baseURL)
 }
 
+func advancedSearchSample(baseURL string) (Sample, error) {
+	return onboardingSample("onboarding-advanced-search", "Onboarding / 2 · Advanced search", onboarding.StepAdvancedSearch, baseURL)
+}
+
 func noAlertSample(baseURL string) (Sample, error) {
-	return onboardingSample("onboarding-no-alert", "Onboarding / 2 · No alert yet", onboarding.StepNoAlert, baseURL)
+	return onboardingSample("onboarding-no-alert", "Onboarding / 3 · No alert yet", onboarding.StepNoAlert, baseURL)
 }
 
 func openSourceSample(baseURL string) (Sample, error) {
-	return onboardingSample("onboarding-open-source", "Onboarding / 3 · Open source", onboarding.StepOpenSource, baseURL)
+	return onboardingSample("onboarding-open-source", "Onboarding / 4 · Open source", onboarding.StepOpenSource, baseURL)
 }
 
 func verificationSample(baseURL string) (Sample, error) {

--- a/internal/onboarding/copy.go
+++ b/internal/onboarding/copy.go
@@ -74,6 +74,28 @@ var specs = map[Step]spec{
 		},
 	},
 
+	StepAdvancedSearch: {
+		subject:   "The filters go deeper than you’d think",
+		preheader: "Exclude a value, not just include one — and save the search.",
+		heading:   "The filters go deeper",
+		body: body("advanced_search", `
+{{template "p" "Most job boards give you a handful of dropdowns. freehire has twenty — role, seniority, stack, region, company type, salary currency, even whether a posting looks real."}}
+{{template "p" "The one people miss: almost every filter can also mean “not this.” Click a value once to require it, again to rule it out — a company you already applied to, a stack you’re done with, a source you don’t trust."}}
+{{template "lead" "Save the search once, and freehire keeps running it for you — Telegram, email or push, your choice."}}
+{{template "button" (mailLink .AdvancedSearchURL "See how the filters work")}}`),
+		text: func(base string) string {
+			return "Most job boards give you a handful of dropdowns. freehire has twenty — role, seniority,\n" +
+				"stack, region, company type, salary currency, even whether a posting looks real.\n\n" +
+				"The one people miss: almost every filter can also mean \"not this.\" Click a value once to\n" +
+				"require it, again to rule it out — a company you already applied to, a stack you're done\n" +
+				"with, a source you don't trust.\n\n" +
+				"Save the search once, and freehire keeps running it for you — Telegram, email or push,\n" +
+				"your choice.\n\n" +
+				"See how the filters work: " + base + "/features/advanced-search\n\n" +
+				"— Ilya Strelov, building freehire\n" + linkedInURL + "\n"
+		},
+	},
+
 	StepNoAlert: {
 		subject:   "Want me to set up your search?",
 		preheader: "Tell me the role — I’ll tell you honestly if we cover it.",

--- a/internal/onboarding/mailer.go
+++ b/internal/onboarding/mailer.go
@@ -1,4 +1,4 @@
-// Package onboarding sends the founder's signup sequence: three mails over a new
+// Package onboarding sends the founder's signup sequence: four mails over a new
 // account's first days, written in the first person and inviting a reply.
 //
 // It is deliberately unlike the other mail features in this codebase. A digest or a
@@ -8,11 +8,11 @@
 //
 //   - the mails carry a Reply-To pointing at a human inbox, not the send address;
 //   - the copy lives here as prose rather than being assembled from data, because
-//     there is no data — every recipient gets the same three letters.
+//     there is no data — every recipient gets the same four letters.
 //
-// The sequence is: welcome (immediately), no_alert (day 3, only if the account
-// never created an alert), open_source (day 10, everyone). Runner owns when; this
-// file owns what they say.
+// The sequence is: welcome (immediately), advanced_search (day 3, everyone),
+// no_alert (day 6, only if the account never created an alert), open_source
+// (day 10, everyone). Runner owns when; this file owns what they say.
 package onboarding
 
 import (
@@ -39,9 +39,10 @@ type Sender interface {
 type Step string
 
 const (
-	StepWelcome    Step = "welcome"
-	StepNoAlert    Step = "no_alert"
-	StepOpenSource Step = "open_source"
+	StepWelcome        Step = "welcome"
+	StepAdvancedSearch Step = "advanced_search"
+	StepNoAlert        Step = "no_alert"
+	StepOpenSource     Step = "open_source"
 )
 
 // Links the sequence points at. They are constants rather than configuration
@@ -99,14 +100,15 @@ type rendered struct {
 // content is what the body templates render from: the absolute URLs that cannot be
 // baked into the prose because they depend on the site origin.
 type content struct {
-	AlertsURL    string
-	GitHubIcon   string
-	DiscordIcon  string
-	LinkedInIcon string
-	PortraitURL  string
-	RepoURL      string
-	DiscordURL   string
-	LinkedInURL  string
+	AlertsURL         string
+	AdvancedSearchURL string
+	GitHubIcon        string
+	DiscordIcon       string
+	LinkedInIcon      string
+	PortraitURL       string
+	RepoURL           string
+	DiscordURL        string
+	LinkedInURL       string
 }
 
 func (m *Mailer) render(step Step) (rendered, error) {
@@ -131,13 +133,14 @@ func (m *Mailer) render(step Step) (rendered, error) {
 
 func (m *Mailer) content() content {
 	return content{
-		AlertsURL:    m.baseURL + "/my/notifications?utm_source=email",
-		GitHubIcon:   m.baseURL + "/email-icon-github.png",
-		DiscordIcon:  m.baseURL + "/email-icon-discord.png",
-		LinkedInIcon: m.baseURL + "/email-icon-linkedin.png",
-		PortraitURL:  m.baseURL + "/ilya.jpg",
-		RepoURL:      repoURL,
-		DiscordURL:   discordURL,
-		LinkedInURL:  linkedInURL,
+		AlertsURL:         m.baseURL + "/my/notifications?utm_source=email",
+		AdvancedSearchURL: m.baseURL + "/features/advanced-search?utm_source=email",
+		GitHubIcon:        m.baseURL + "/email-icon-github.png",
+		DiscordIcon:       m.baseURL + "/email-icon-discord.png",
+		LinkedInIcon:      m.baseURL + "/email-icon-linkedin.png",
+		PortraitURL:       m.baseURL + "/ilya.jpg",
+		RepoURL:           repoURL,
+		DiscordURL:        discordURL,
+		LinkedInURL:       linkedInURL,
 	}
 }

--- a/internal/onboarding/runner.go
+++ b/internal/onboarding/runner.go
@@ -12,6 +12,7 @@ import (
 // rather than taking *db.Queries so the runner can be tested without Postgres.
 type Store interface {
 	ListWelcomeCandidates(ctx context.Context, arg db.ListWelcomeCandidatesParams) ([]db.ListWelcomeCandidatesRow, error)
+	ListAdvancedSearchCandidates(ctx context.Context, arg db.ListAdvancedSearchCandidatesParams) ([]db.ListAdvancedSearchCandidatesRow, error)
 	ListNoAlertCandidates(ctx context.Context, arg db.ListNoAlertCandidatesParams) ([]db.ListNoAlertCandidatesRow, error)
 	ListOpenSourceCandidates(ctx context.Context, arg db.ListOpenSourceCandidatesParams) ([]db.ListOpenSourceCandidatesRow, error)
 	RecordOnboardingEmail(ctx context.Context, arg db.RecordOnboardingEmailParams) error
@@ -23,27 +24,32 @@ type Config struct {
 	// the whole feature: the sequence was added long after the user table filled up,
 	// and without a window the first run would greet every account ever created.
 	WindowDays int32
-	// NoAlertAfterDays and OpenSourceAfterDays are how long an account must have
-	// existed before those steps are eligible.
-	NoAlertAfterDays    int32
-	OpenSourceAfterDays int32
+	// AdvancedSearchAfterDays, NoAlertAfterDays and OpenSourceAfterDays are how long
+	// an account must have existed (since the welcome greeting) before those steps
+	// are eligible. They must strictly increase — Run iterates the steps in that
+	// order, and a later step racing ahead of an earlier one is what the pacing
+	// exists to prevent.
+	AdvancedSearchAfterDays int32
+	NoAlertAfterDays        int32
+	OpenSourceAfterDays     int32
 	// MaxPerStep caps one pass per step. A cap is what keeps a backlog — or a bug
 	// in the candidate query — from becoming one enormous send.
 	MaxPerStep int32
 }
 
-// DefaultConfig is the shipped schedule: greet immediately, ask about the missing
-// alert on day 3, talk about the project on day 10.
+// DefaultConfig is the shipped schedule: greet immediately, show the filter panel
+// on day 3, ask about the missing alert on day 6, talk about the project on day 10.
 func DefaultConfig() Config {
 	return Config{
-		WindowDays:          14,
-		NoAlertAfterDays:    3,
-		OpenSourceAfterDays: 10,
-		MaxPerStep:          200,
+		WindowDays:              14,
+		AdvancedSearchAfterDays: 3,
+		NoAlertAfterDays:        6,
+		OpenSourceAfterDays:     10,
+		MaxPerStep:              200,
 	}
 }
 
-// Runner performs one pass over all three steps.
+// Runner performs one pass over all four steps.
 type Runner struct {
 	store  Store
 	mailer *Mailer
@@ -61,7 +67,7 @@ type Stats struct {
 	Failed map[Step]int
 }
 
-// Run sends every eligible mail in all three steps.
+// Run sends every eligible mail in all four steps.
 //
 // A step whose candidate query fails aborts the pass — that is a broken query or a
 // broken database, and continuing would only produce more of the same error. A
@@ -70,7 +76,7 @@ type Stats struct {
 func (r *Runner) Run(ctx context.Context) (Stats, error) {
 	stats := Stats{Sent: map[Step]int{}, Failed: map[Step]int{}}
 
-	for _, step := range []Step{StepWelcome, StepNoAlert, StepOpenSource} {
+	for _, step := range []Step{StepWelcome, StepAdvancedSearch, StepNoAlert, StepOpenSource} {
 		recipients, err := r.candidates(ctx, step)
 		if err != nil {
 			return stats, fmt.Errorf("onboarding: listing %s candidates: %w", step, err)
@@ -97,6 +103,21 @@ func (r *Runner) candidates(ctx context.Context, step Step) ([]recipient, error)
 	case StepWelcome:
 		rows, err := r.store.ListWelcomeCandidates(ctx, db.ListWelcomeCandidatesParams{
 			WindowDays: r.cfg.WindowDays,
+			MaxRows:    r.cfg.MaxPerStep,
+		})
+		if err != nil {
+			return nil, err
+		}
+		out := make([]recipient, 0, len(rows))
+		for _, row := range rows {
+			out = append(out, recipient{userID: row.ID, email: row.Email})
+		}
+		return out, nil
+
+	case StepAdvancedSearch:
+		rows, err := r.store.ListAdvancedSearchCandidates(ctx, db.ListAdvancedSearchCandidatesParams{
+			WindowDays: r.cfg.WindowDays,
+			AfterDays:  r.cfg.AdvancedSearchAfterDays,
 			MaxRows:    r.cfg.MaxPerStep,
 		})
 		if err != nil {

--- a/internal/onboarding/runner_test.go
+++ b/internal/onboarding/runner_test.go
@@ -12,15 +12,16 @@ import (
 
 // fakeStore serves fixed candidate lists and records what was written back.
 type fakeStore struct {
-	welcome, noAlert, openSource []int64
-	recorded                     []db.RecordOnboardingEmailParams
-	listErr                      error
-	recordErr                    error
+	welcome, advancedSearch, noAlert, openSource []int64
+	recorded                                     []db.RecordOnboardingEmailParams
+	listErr                                      error
+	recordErr                                    error
 
 	// params captures what the runner asked for, so the tests can assert on the
 	// window and caps rather than trusting them.
-	welcomeParams db.ListWelcomeCandidatesParams
-	noAlertParams db.ListNoAlertCandidatesParams
+	welcomeParams        db.ListWelcomeCandidatesParams
+	advancedSearchParams db.ListAdvancedSearchCandidatesParams
+	noAlertParams        db.ListNoAlertCandidatesParams
 }
 
 func rows(ids []int64) []db.ListWelcomeCandidatesRow {
@@ -34,6 +35,15 @@ func rows(ids []int64) []db.ListWelcomeCandidatesRow {
 func (s *fakeStore) ListWelcomeCandidates(_ context.Context, arg db.ListWelcomeCandidatesParams) ([]db.ListWelcomeCandidatesRow, error) {
 	s.welcomeParams = arg
 	return rows(s.welcome), s.listErr
+}
+
+func (s *fakeStore) ListAdvancedSearchCandidates(_ context.Context, arg db.ListAdvancedSearchCandidatesParams) ([]db.ListAdvancedSearchCandidatesRow, error) {
+	s.advancedSearchParams = arg
+	out := make([]db.ListAdvancedSearchCandidatesRow, 0, len(s.advancedSearch))
+	for _, id := range s.advancedSearch {
+		out = append(out, db.ListAdvancedSearchCandidatesRow{ID: id, Email: "user@example.test"})
+	}
+	return out, nil
 }
 
 func (s *fakeStore) ListNoAlertCandidates(_ context.Context, arg db.ListNoAlertCandidatesParams) ([]db.ListNoAlertCandidatesRow, error) {
@@ -77,7 +87,7 @@ func newRunner(store *fakeStore, sender *fakeSender) *onboarding.Runner {
 }
 
 func TestRun_SendsOneMailPerCandidatePerStep(t *testing.T) {
-	store := &fakeStore{welcome: []int64{1, 2}, noAlert: []int64{3}, openSource: []int64{4}}
+	store := &fakeStore{welcome: []int64{1, 2}, advancedSearch: []int64{5}, noAlert: []int64{3}, openSource: []int64{4}}
 	sender := &fakeSender{}
 
 	stats, err := newRunner(store, sender).Run(context.Background())
@@ -85,13 +95,13 @@ func TestRun_SendsOneMailPerCandidatePerStep(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	if len(sender.sent) != 4 {
-		t.Fatalf("sent %d mails, want 4", len(sender.sent))
+	if len(sender.sent) != 5 {
+		t.Fatalf("sent %d mails, want 5", len(sender.sent))
 	}
-	if stats.Sent[onboarding.StepWelcome] != 2 || stats.Sent[onboarding.StepNoAlert] != 1 {
-		t.Errorf("stats = %+v, want 2 welcome and 1 no_alert", stats.Sent)
+	if stats.Sent[onboarding.StepWelcome] != 2 || stats.Sent[onboarding.StepAdvancedSearch] != 1 || stats.Sent[onboarding.StepNoAlert] != 1 {
+		t.Errorf("stats = %+v, want 2 welcome, 1 advanced_search and 1 no_alert", stats.Sent)
 	}
-	if len(store.recorded) != 4 {
+	if len(store.recorded) != 5 {
 		t.Errorf("recorded %d ledger rows, want one per send", len(store.recorded))
 	}
 }
@@ -156,6 +166,9 @@ func TestRun_BoundsCandidatesByTheSignupWindow(t *testing.T) {
 	if store.welcomeParams.MaxRows != cfg.MaxPerStep {
 		t.Errorf("welcome cap = %d, want %d", store.welcomeParams.MaxRows, cfg.MaxPerStep)
 	}
+	if store.advancedSearchParams.AfterDays != cfg.AdvancedSearchAfterDays {
+		t.Errorf("advanced_search delay = %d days, want %d", store.advancedSearchParams.AfterDays, cfg.AdvancedSearchAfterDays)
+	}
 	if store.noAlertParams.AfterDays != cfg.NoAlertAfterDays {
 		t.Errorf("no_alert delay = %d days, want %d", store.noAlertParams.AfterDays, cfg.NoAlertAfterDays)
 	}
@@ -176,7 +189,7 @@ func TestRun_MailsCarryTheReplyToAddress(t *testing.T) {
 }
 
 func TestRun_EachStepHasItsOwnSubjectAndBothBodies(t *testing.T) {
-	store := &fakeStore{welcome: []int64{1}, noAlert: []int64{2}, openSource: []int64{3}}
+	store := &fakeStore{welcome: []int64{1}, advancedSearch: []int64{4}, noAlert: []int64{2}, openSource: []int64{3}}
 	sender := &fakeSender{}
 
 	if _, err := newRunner(store, sender).Run(context.Background()); err != nil {
@@ -211,8 +224,15 @@ func TestRun_LaterStepsArePacedFromTheGreeting(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 	cfg := onboarding.DefaultConfig()
+	if store.advancedSearchParams.AfterDays != cfg.AdvancedSearchAfterDays {
+		t.Fatalf("advanced_search delay = %d, want %d", store.advancedSearchParams.AfterDays, cfg.AdvancedSearchAfterDays)
+	}
 	if store.noAlertParams.AfterDays != cfg.NoAlertAfterDays {
 		t.Fatalf("no_alert delay = %d, want %d", store.noAlertParams.AfterDays, cfg.NoAlertAfterDays)
+	}
+	if cfg.AdvancedSearchAfterDays >= cfg.NoAlertAfterDays {
+		t.Errorf("step delays must increase: advanced_search %d, no_alert %d",
+			cfg.AdvancedSearchAfterDays, cfg.NoAlertAfterDays)
 	}
 	if cfg.NoAlertAfterDays >= cfg.OpenSourceAfterDays {
 		t.Errorf("step delays must increase: no_alert %d, open_source %d",

--- a/migrations/0111_onboarding_advanced_search_step.sql
+++ b/migrations/0111_onboarding_advanced_search_step.sql
@@ -1,0 +1,9 @@
+-- Adds 'advanced_search' to the onboarding sequence's step vocabulary: a new
+-- letter introducing the filter panel (role, region, skills, include/exclude,
+-- saving a search) that now sits between the welcome greeting and the no-alert
+-- nudge, which moves later to make room for it.
+
+ALTER TABLE public.onboarding_emails
+    DROP CONSTRAINT onboarding_emails_step_check,
+    ADD CONSTRAINT onboarding_emails_step_check
+        CHECK (step IN ('welcome', 'advanced_search', 'no_alert', 'open_source'));


### PR DESCRIPTION
## Summary
- New onboarding step `advanced_search` (day 3): introduces the filter panel — twenty facets, the include/exclude click cycle, saving a search — linking to `/features/advanced-search`. Sent to everyone regardless of alert status (like `open_source`), since it's background on a feature rather than a nudge toward one missing action.
- `no_alert` moves from day 3 to day 6 to make room for it; `open_source` stays at day 10.
- Sequence is now: welcome (0) → advanced_search (3) → no_alert (6) → open_source (10).

## Details
- `migrations/0111_onboarding_advanced_search_step.sql` widens the `onboarding_emails` step CHECK constraint.
- `ListAdvancedSearchCandidates` mirrors `ListOpenSourceCandidates`'s shape (paced from the welcome send's `sent_at`, no subscription gate) rather than `ListNoAlertCandidates`'s (which additionally requires no active subscription).
- `cmd/mail-preview` regenerated — 15 samples now, onboarding steps renumbered in the contact sheet.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` all clean
- [x] `go test ./...` green, including updated `internal/onboarding` and `internal/mailpreview` suites
- [x] Applied migration 0111 against a local Postgres and confirmed the widened CHECK constraint
- [x] Regenerated and visually reviewed the new preview (`onboarding-advanced-search.html`)
- [ ] Not sent to a real inbox (no SES configured locally) — `./onboarding -to you@example.com -step advanced_search` is the way to do that before this ships