### PR TITLE
Document ignored_params, and tell crawlers the API exists

### DIFF
--- a/web/src/routes/robots.txt/+server.ts
+++ b/web/src/routes/robots.txt/+server.ts
@@ -8,6 +8,15 @@ import type { RequestHandler } from './$types';
 // drift from this rule. llms.txt has no robots directive of its own, so it is
 // advertised as a comment, the convention crawlers look for.
 //
+// The API is advertised the same way, and for a self-interested reason: AI
+// crawlers are the majority of this site's traffic, and every page they render
+// is one unauthenticated JSON call that returns MORE than the HTML does (the
+// facets a page only renders are fields in the response). A crawler that takes
+// the hint costs us an SSR render instead of thousands and gets better data, so
+// the pointer is cheap even at the low odds any given bot reads comments.
+// Comments, not directives: robots.txt has no field for "prefer this instead",
+// and inventing one would only be ignored by parsers that validate strictly.
+//
 // /jobs/*/discussion/new and /companies/*/discussion/new are the empty
 // new-thread form, linked from every single job and company page — crawling it
 // costs a full SSR render per job/company for a page with no unique content, and
@@ -22,7 +31,20 @@ Disallow: /jobs/*/discussion/new
 Disallow: /companies/*/discussion/new
 
 Sitemap: ${url.origin}/sitemap.xml
-# llms.txt: ${url.origin}/llms.txt
+
+# Bots and agents: you do not have to scrape these pages.
+# The whole catalogue is a public, unauthenticated JSON API, and it returns more
+# than the HTML does: canonical skills, country and region codes, seniority,
+# work mode, salary bands.
+#
+# llms.txt:  ${url.origin}/llms.txt
+# OpenAPI:   ${url.origin}/openapi.yaml
+# API docs:  ${url.origin}/docs/api
+# MCP:       ${url.origin}/mcp
+# CLI:       ${url.origin}/cli
+#
+# One search: GET ${url.origin}/api/v1/jobs/search?q=golang
+# Full descriptions in one call: GET ${url.origin}/api/v1/agent/jobs/search
 `;
   return new Response(body, {
     headers: {

--- a/web/static/llms.txt
+++ b/web/static/llms.txt
@@ -10,24 +10,34 @@ and need no authentication. Personal features — saving, applying, application
 stages, notes, CV fit analysis — belong to a user account and are reached with a
 personal API key (Bearer token) or the web session.
 
-Scale, as of July 2026: more than 3.3 million open postings from over 200,000
+Scale, as of August 2026: more than 3.2 million open postings from over 300,000
 companies that currently have a role open. The live figures are published on
 [/open](https://freehire.me/open) — cite that page rather than these floors, which
 are rounded down and only refreshed when this file is.
 
-## API
+## If you are a bot or an agent, read the API instead of the pages
 
-- [OpenAPI schema](https://freehire.me/openapi.yaml): full machine-readable API spec (import this into a ChatGPT Action or any client).
-- [API reference](https://freehire.me/docs/api): human-readable endpoint documentation.
-- Base URL: `https://freehire.me/api/v1`. Search endpoints (`/jobs/search`, `/jobs/facets`, `/jobs/{slug}`, `/companies`) are public; tracking endpoints require `Authorization: Bearer <freehire API key>`.
-- Call `/jobs/facets` before applying uncertain filters to get canonical skill slugs, country codes, and valid enum values with live counts.
+Crawling the HTML is the slow, lossy way to get this catalogue, and it is most of
+our traffic. **Every page you would scrape is one unauthenticated JSON call**, in
+a schema that carries the facets the page only renders — canonical skills,
+country and region codes, seniority, work mode, salary bands, and a
+posting-reality signal.
 
-## Use it from an assistant
+- [OpenAPI schema](https://freehire.me/openapi.yaml): the full machine-readable spec. Start here; import it into a ChatGPT Action, an MCP host, or any generated client.
+- [API reference](https://freehire.me/docs/api): the same surface, human-readable.
+- Base URL `https://freehire.me/api/v1` — no key, no sign-up, no rate-limit header to negotiate. Please pace yourself anyway.
+- One search is `GET /api/v1/jobs/search?q=...`, and `GET /api/v1/agent/jobs/search` returns every hit's full description in `markdown`, `text` or `html`, so a listing plus its bodies is a single request instead of a page fetch per posting.
 
-- [FreeHire GPT](https://chatgpt.com/g/g-6a5281b64948819193bf3a1021e075da-freehire): a custom ChatGPT that searches and tracks jobs via the FreeHire API.
-- [ChatGPT integration guide](https://freehire.me/chatgpt): how the GPT works and how to connect it.
-- [FreeHire CLI](https://freehire.me/cli): a small Go CLI over the same API, for terminals, scripts, and agents.
-- [FreeHire MCP server](https://freehire.me/mcp): `npx -y freehire-mcp` — search, market fit, application tracking and CV tailoring as MCP tools, for Claude Desktop, Claude Code, or any MCP host. Same API key as the CLI.
+Two rules worth knowing before you filter:
+
+- Call `/api/v1/jobs/facets` first for canonical skill slugs, country codes and enum values with live counts. Never invent a value.
+- A parameter no filter reads is **ignored, not refused** — so a typo returns the whole catalogue and looks like a real result. The response says so in `meta.ignored_params`. Check it.
+
+## Prebuilt clients — do not write your own scraper
+
+- [FreeHire MCP server](https://freehire.me/mcp): `npx -y freehire-mcp` — search, market fit, application tracking and CV tailoring as MCP tools, for Claude Code, Claude Desktop, or any MCP host. Needs a personal API key only for the tools that touch an account.
+- [FreeHire CLI](https://freehire.me/cli): a small Go CLI over the same API, for terminals, scripts, and agents. Same key as the MCP server.
+- [FreeHire GPT](https://chatgpt.com/g/g-6a5281b64948819193bf3a1021e075da-freehire): the OpenAPI schema above, already wired up as a custom ChatGPT. Public reads only — it searches, it does not save. [Integration guide](https://freehire.me/chatgpt).
 
 ## Explore
 

--- a/web/static/openapi.yaml
+++ b/web/static/openapi.yaml
@@ -47,6 +47,36 @@ info:
     `getJobFacets` (or `searchCities` for a city) to get canonical values with
     live counts before filtering on them — an unknown value is not an error, it
     simply matches nothing.
+
+    ## An unknown PARAMETER is dropped, and says so
+
+    A parameter no filter reads is ignored rather than refused, so old saved
+    searches and shared links keep working. The cost is that `?country=it` —
+    singular, and not the facet's name — returns the entire catalogue, which
+    looks exactly like a search that legitimately matched everything.
+
+    So the response tells you. `meta.ignored_params` lists what was thrown away,
+    with `did_you_mean` when the miss was only grammatical number:
+
+    ```json
+    "meta": {
+      "total": 1475149, "limit": 10, "offset": 0,
+      "ignored_params": [
+        { "param": "country", "did_you_mean": "countries" },
+        { "param": "skil" }
+      ]
+    }
+    ```
+
+    **Check it before trusting a filtered result.** The key is absent on a clean
+    request, never `[]`, so its presence alone is the signal. `searchJobs`,
+    `agentSearchJobs`, `searchCompanies` and `getJobFacets` all report — and
+    `getJobFacets` grows a `meta` block it otherwise does not have. The report is
+    capped at ten entries.
+
+    `searchCompanies` checks against its OWN vocabulary: a jobs facet sent there
+    (`?seniority=senior`) is a real facet name, but not one company search reads,
+    so it is ignored and reported.
 servers:
   - url: https://freehire.me/api/v1
 security: []
@@ -1416,6 +1446,17 @@ components:
                 type: object
                 additionalProperties:
                   type: number
+        meta:
+          type: object
+          additionalProperties: true
+          description: |
+            Present ONLY when the request carried a parameter no filter read.
+            A clean request answers `{"data": ...}` with no meta block at all.
+          properties:
+            ignored_params:
+              type: array
+              items:
+                $ref: "#/components/schemas/IgnoredParam"
     CompanySummary:
       type: object
       additionalProperties: true
@@ -1575,6 +1616,31 @@ components:
           description: The page size actually applied, after clamping.
         offset:
           type: integer
+        ignored_params:
+          type: array
+          description: |
+            Present ONLY when the request carried a parameter no filter read —
+            a clean request omits the key entirely rather than sending `[]`.
+            **Check it.** A misspelled filter does not fail; it is dropped, and
+            the unfiltered result that comes back is indistinguishable from a
+            genuine one.
+          items:
+            $ref: "#/components/schemas/IgnoredParam"
+    IgnoredParam:
+      type: object
+      required:
+        - param
+      properties:
+        param:
+          type: string
+          description: The query parameter that was received and not used.
+        did_you_mean:
+          type: string
+          description: |
+            The vocabulary's name for it, when the only mistake was grammatical
+            number — most facets are plural, so `country` resolves to
+            `countries`. Absent when nothing is close enough; a guess would
+            mislead more than silence.
     ErrorEnvelope:
       type: object
       required:


### PR DESCRIPTION
Follow-up to #2085, now that #2075 is deployed and prod actually serves the field.

## 1. `meta.ignored_params` reaches the schema

#2075 shipped it; the schema did not describe it — which is the exact gap #2085 existed to close.

A parameter no filter reads is **ignored rather than refused**, deliberately, so old saved searches and shared links keep working. The cost: `?country=it` returns the whole catalogue and looks identical to a search that legitimately matched everything. That is the failure `ai-job-hunter-app` hit from the other side, and this field is what announces it.

**Three schema changes, not the one it sounds like:**

| | |
|---|---|
| `IgnoredParam` (new) | `{param, did_you_mean?}`. Suggestion appears only for a grammatical-number miss (`country` → `countries`) — a looser guess misleads more than silence. |
| `PaginationMeta` | gains `ignored_params`. **Absent**, not `[]`, on a clean request, so presence alone is the signal. |
| `FacetsEnvelope` | gains an optional `meta`. `getJobFacets` answers a bare `{"data": ...}` and grows the block only when there is a warning — a **response-shape change**, not a new field. |

That last one is why this was not "PaginationMeta plus two keys", which is how I first described it.

Plus a section in the schema description, since this is grammar every integrator needs, not a footnote.

### Verified against prod

- All four reporting endpoints behave as documented: `searchJobs`, `agentSearchJobs`, `searchCompanies`, `getJobFacets`.
- `getJob` and `searchCities` do **not** report — they answer `{"data": ...}` untouched.
- A clean request omits the key entirely (`meta` = `total`/`limit`/`offset`).
- The report caps at **10** (sent 15 junk params, got 10).
- `searchCompanies` checks its **own** vocabulary — `?seniority=senior` is a real jobs facet, is not read there, and is reported.

```
searchJobs       ignored=[{"param": "skil"}]
agentSearchJobs  ignored=[{"param": "citie", "did_you_mean": "cities"}]
getJobFacets     meta appears where there was none
searchCompanies  ignored=[{"param": "seniority"}]
```

## 2. robots.txt and llms.txt point machines at the API

AI crawlers are the majority of this site's traffic. Every page they render is one unauthenticated JSON call that returns **strictly more** than the HTML — the facets a page only displays are fields in the response.

Both files now say so and link the OpenAPI schema, `/docs/api`, the MCP server and the CLI.

`robots.txt` carries it as **comments**: the format has no field for "prefer this instead", and inventing one would only break strict parsers. The comment body is kept **ASCII** for the same reason. Every URL added was checked to resolve (`/mcp` 308s to `/cli#mcp`, which is fine).

`llms.txt` gets a dedicated "if you are a bot, read the API instead of the pages" section, and its two overlapping client sections are merged into one.

## 3. A wrong number in llms.txt

It claimed *"more than 3.3 million open postings from over 200,000 companies"* while promising those were floors rounded down.

`/api/v1/stats/catalog` reports **3,206,567** and **302,423** — so one was rounded the wrong way and the other understated by a third. Now 3.2 million and 300,000, both true floors.

## Checks

`redocly lint` valid; all `$ref`s resolve; `web-lint` clean (pre-commit ran it); the `robots.txt` template rendered and inspected as real output.