### PR TITLE
Expand the filter hint tooltip with a concrete example and a link

### DIFF
--- a/web/src/lib/components/filters/FilterModal.svelte
+++ b/web/src/lib/components/filters/FilterModal.svelte
@@ -218,7 +218,17 @@
       <Info class="size-3.5" aria-hidden="true" />
     </button>
     {#snippet content()}
-      Click a filter once to include it, again to exclude it, again to clear it.
+      <span class="block">
+        Most filters are three-state: click once to require a value, again to rule it out — a
+        company you already applied to, a source you don't trust, a skill you're done with — and a
+        third time to clear it.
+      </span>
+      <a
+        href={resolve('/features/advanced-search')}
+        class="mt-1.5 block font-medium text-foreground underline-offset-2 hover:underline"
+      >
+        See how filters work →
+      </a>
     {/snippet}
   </Tooltip>
 {/snippet}


### PR DESCRIPTION
## Summary
Follow-up to #2087. The shipped tooltip only named the include/exclude/clear cycle in the abstract and had nowhere to send someone who wanted more. Adds a concrete example and a link to `/features/advanced-search`, which explains the same mechanic with a live interactive demo.

## Test plan
- [x] `svelte-check` clean (0 errors)
- [x] `eslint` clean
- [ ] Couldn't click through live on `/jobs` locally — this dev machine's Postgres/Meilisearch has no indexed jobs, so the page 500s independent of this change (same as noted on #2087). Will verify on freehire.me after merge+deploy.