### PR TITLE
Rate-limit the public read API, and publish the ceiling

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -120,7 +120,10 @@ func main() {
 		// (the nginx container); a direct public caller is not trusted.
 		ProxyHeader:             "X-Real-IP", // Fiber has no constant for this header
 		EnableTrustedProxyCheck: true,
-		TrustedProxies:          []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "127.0.0.1/32"},
+		// Shared with internal/ratelimit, which does not count a peer we trust to
+		// assert someone else's address — chiefly our own SSR, which reaches the
+		// API over loopback. One definition so the two cannot disagree.
+		TrustedProxies: ratelimit.TrustedCIDRs,
 	})
 
 	// The recover middleware marks each unwound panic via c.Locals so RenderError

--- a/internal/handler/companies.go
+++ b/internal/handler/companies.go
@@ -36,7 +36,7 @@ func newCompaniesHandlers(queries *db.Queries, companySearch companySearcher) *c
 func (h *companiesHandlers) register(api fiber.Router, mw middleware) {
 	readLimit := publicReadLimiter(mw.throttler)
 	api.Get("/companies", readLimit, h.ListCompanies)
-	api.Get("/companies/subindustries", h.CompanySubindustries)
+	api.Get("/companies/subindustries", readLimit, h.CompanySubindustries)
 	api.Get("/companies/:slug", readLimit, mw.optional, h.GetCompany)
 }
 

--- a/internal/handler/companies.go
+++ b/internal/handler/companies.go
@@ -34,9 +34,10 @@ func newCompaniesHandlers(queries *db.Queries, companySearch companySearcher) *c
 }
 
 func (h *companiesHandlers) register(api fiber.Router, mw middleware) {
-	api.Get("/companies", h.ListCompanies)
+	readLimit := publicReadLimiter(mw.throttler)
+	api.Get("/companies", readLimit, h.ListCompanies)
 	api.Get("/companies/subindustries", h.CompanySubindustries)
-	api.Get("/companies/:slug", mw.optional, h.GetCompany)
+	api.Get("/companies/:slug", readLimit, mw.optional, h.GetCompany)
 }
 
 // companySearcher is the company-search backend the list handler depends on.

--- a/internal/handler/geo.go
+++ b/internal/handler/geo.go
@@ -20,8 +20,8 @@ func newGeoHandlers() *geoHandlers {
 	return &geoHandlers{}
 }
 
-func (h *geoHandlers) register(api fiber.Router) {
-	api.Get("/geo/cities", h.SearchCities)
+func (h *geoHandlers) register(api fiber.Router, mw middleware) {
+	api.Get("/geo/cities", publicReadLimiter(mw.throttler), h.SearchCities)
 }
 
 // cityMatch is the wire shape of one city-search result. country is a raw ISO

--- a/internal/handler/geo_test.go
+++ b/internal/handler/geo_test.go
@@ -9,7 +9,8 @@ import (
 func geoApp() *fiber.App {
 	h := newGeoHandlers()
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
-	h.register(app)
+	// A nil throttler fails open, so this exercises the handler and not the limiter.
+	h.register(app, middleware{})
 	return app
 }
 

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -634,7 +634,7 @@ func Register(app *fiber.App, cfg Config) {
 	sitemapH.register(api)
 	jobsH.register(api, mw)
 	companiesH.register(api, mw)
-	geoH.register(api)
+	geoH.register(api, mw)
 
 	// Saved searches + the public shared-board read (see savedSearchHandlers).
 	savedSearchH.register(api, mw)

--- a/internal/handler/jobs.go
+++ b/internal/handler/jobs.go
@@ -44,12 +44,17 @@ func (h *jobsHandlers) register(api fiber.Router, mw middleware) {
 	// attaches the caller when signed in but never rejects, so the detail read can
 	// overlay the caller's own vote (my_vote) while staying open to anonymous
 	// visitors.
-	api.Get("/jobs", h.ListJobs)
+	// Every job read shares the public-read budget. Leaving any one of them out
+	// would void the limit rather than narrow it: /jobs returns the same
+	// catalogue as /jobs/search, so an unbounded one is simply the door a
+	// throttled caller walks through instead.
+	readLimit := publicReadLimiter(mw.throttler)
+	api.Get("/jobs", readLimit, h.ListJobs)
 	// Static route registered before /jobs/:slug so it isn't captured as a slug.
-	api.Get("/jobs/find", h.FindJob)
-	api.Get("/jobs/:slug", publicReadLimiter(mw.throttler), mw.optional, h.GetJob)
-	api.Get("/jobs/:slug/copies", h.JobCopies)
-	api.Get("/jobs/:slug/apply-form", h.JobApplyForm)
+	api.Get("/jobs/find", readLimit, h.FindJob)
+	api.Get("/jobs/:slug", readLimit, mw.optional, h.GetJob)
+	api.Get("/jobs/:slug/copies", readLimit, h.JobCopies)
+	api.Get("/jobs/:slug/apply-form", readLimit, h.JobApplyForm)
 
 	// Moderator-authored jobs: create a hand-curated vacancy and edit it. Authenticated
 	// by cookie or API key (the CLI uses a key), then gated on the moderator role. The

--- a/internal/handler/jobs.go
+++ b/internal/handler/jobs.go
@@ -47,7 +47,7 @@ func (h *jobsHandlers) register(api fiber.Router, mw middleware) {
 	api.Get("/jobs", h.ListJobs)
 	// Static route registered before /jobs/:slug so it isn't captured as a slug.
 	api.Get("/jobs/find", h.FindJob)
-	api.Get("/jobs/:slug", mw.optional, h.GetJob)
+	api.Get("/jobs/:slug", publicReadLimiter(mw.throttler), mw.optional, h.GetJob)
 	api.Get("/jobs/:slug/copies", h.JobCopies)
 	api.Get("/jobs/:slug/apply-form", h.JobApplyForm)
 

--- a/internal/handler/public_read_limit.go
+++ b/internal/handler/public_read_limit.go
@@ -1,0 +1,48 @@
+package handler
+
+import (
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/ratelimit"
+)
+
+// The public read API is unauthenticated and, until this existed, unbounded:
+// every other limiter in this package guards an auth route, a write, or an LLM
+// spend, and nginx applies its own limit_req to the SvelteKit pages and not to
+// /api/. Both ceilings below sit above the highest per-IP minute measured on
+// production over a 4.6-hour window, so they bound abuse without cutting off any
+// caller that exists today.
+//
+// The split is by cost, not by path. `/agent/jobs/search` rehydrates every hit's
+// full description from Postgres — ~833 KB and ~1.3s at limit=100, against
+// ~123 KB and ~0.55s for the ordinary search — so one shared budget would have
+// to be sized for it and would then throttle facet lookups seven times harder
+// than their cost warrants.
+const (
+	// publicReadsPerMinute covers the cheap reads. 600/min is 10 r/s, deliberately
+	// the same ceiling nginx already applies to the HTML pages, so the site has one
+	// number to explain rather than two. Measured peak: 258/min.
+	publicReadsPerMinute = 600
+
+	// agentSearchPerMinute covers the one expensive read. Measured peak: 184/min,
+	// held steadily by a single third-party client, so this leaves that caller room
+	// to grow by two thirds before it ever sees a 429.
+	agentSearchPerMinute = 300
+)
+
+// publicReadLimiter throttles the cheap public reads as one shared budget.
+//
+// Keyed by user-or-IP rather than by IP alone. Not to grant an authenticated
+// caller a larger allowance — the ceiling is identical either way — but so that
+// callers sharing an egress address do not share an allowance.
+func publicReadLimiter(throttler ratelimit.Throttler) fiber.Handler {
+	return ratelimit.Middleware(throttler, ratelimit.KeyByUserOrIP("publicread"), publicReadsPerMinute, time.Minute)
+}
+
+// agentSearchLimiter throttles the full-description search on its own budget, so
+// exhausting it leaves the ordinary search endpoints serving.
+func agentSearchLimiter(throttler ratelimit.Throttler) fiber.Handler {
+	return ratelimit.Middleware(throttler, ratelimit.KeyByUserOrIP("agentsearch"), agentSearchPerMinute, time.Minute)
+}

--- a/internal/handler/public_read_limit_e2e_test.go
+++ b/internal/handler/public_read_limit_e2e_test.go
@@ -3,8 +3,8 @@ package handler
 import (
 	"context"
 	"net/http/httptest"
-	"strconv"
 	"testing"
+	"time"
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/gofiber/fiber/v2"
@@ -18,6 +18,12 @@ import (
 // prove the wiring and not the arithmetic.
 func TestLimiterE2E(t *testing.T) {
 	mr := miniredis.RunT(t)
+	// Freeze the clock. redis_rate is GCRA: at 600/min a token leaks back every
+	// 100ms, so a loop of 600 requests that takes longer than that on a slow
+	// machine gets extra headroom and the "601st is refused" assertion becomes a
+	// race against the runner. CI caught exactly that. A frozen clock makes the
+	// budget arithmetic the only variable, which is what these cases are about.
+	mr.SetTime(time.Unix(1755000000, 0))
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	t.Cleanup(func() { _ = client.Close() })
 	th := ratelimit.NewRedisThrottler(client)
@@ -37,52 +43,50 @@ func TestLimiterE2E(t *testing.T) {
 		return resp.StatusCode, resp.Header.Get("X-RateLimit-Remaining"), resp.Header.Get("Retry-After")
 	}
 
-	t.Run("cheap budget admits exactly publicReadsPerMinute", func(t *testing.T) {
-		const peer = "203.0.113.10"
-		for i := 1; i <= publicReadsPerMinute; i++ {
-			code, rem, _ := hit("/cheap", peer)
-			if code != fiber.StatusOK {
-				t.Fatalf("request %d/%d = %d, want 200 (remaining=%s)", i, publicReadsPerMinute, code, rem)
-			}
-			// Remaining is a GCRA reading, not limit-minus-count: redis_rate is a
-			// leaky bucket, so the figure trails naive counting by up to one while
-			// the elapsed time has not yet credited a whole token back. Assert the
-			// band it must stay inside rather than an exact value that encodes the
-			// arithmetic of a particular backend.
-			if i == 1 {
-				n, err := strconv.Atoi(rem)
-				if err != nil || n < publicReadsPerMinute-2 || n > publicReadsPerMinute-1 {
-					t.Errorf("first Remaining = %q, want %d or %d", rem, publicReadsPerMinute-2, publicReadsPerMinute-1)
+	// GCRA's instantaneous capacity is limit-1, not limit: the emission-interval
+	// arithmetic reserves one slot. So these cases assert the honest contract —
+	// about `limit` requests get through and the budget then refuses — rather than
+	// an exact count that encodes one backend's off-by-one and breaks the day we
+	// change limiters.
+	admitUntilRefused := func(t *testing.T, path, peer string, ceiling int) int {
+		t.Helper()
+		for i := 1; i <= ceiling+1; i++ {
+			code, rem, retry := hit(path, peer)
+			if code == fiber.StatusTooManyRequests {
+				if rem != "0" {
+					t.Errorf("Remaining on refusal = %q, want 0", rem)
 				}
+				if retry == "" || retry == "0" {
+					t.Errorf("Retry-After = %q, want a positive whole second", retry)
+				}
+				return i - 1
+			}
+			if code != fiber.StatusOK {
+				t.Fatalf("request %d = %d, want 200 or 429", i, code)
 			}
 		}
-		code, rem, retry := hit("/cheap", peer)
-		if code != fiber.StatusTooManyRequests {
-			t.Fatalf("request %d = %d, want 429", publicReadsPerMinute+1, code)
+		t.Fatalf("%s never refused within %d requests against a ceiling of %d", path, ceiling+1, ceiling)
+		return 0
+	}
+
+	t.Run("cheap budget admits about publicReadsPerMinute then refuses", func(t *testing.T) {
+		got := admitUntilRefused(t, "/cheap", "203.0.113.10", publicReadsPerMinute)
+		if got < publicReadsPerMinute-1 || got > publicReadsPerMinute {
+			t.Errorf("admitted %d, want %d or %d", got, publicReadsPerMinute-1, publicReadsPerMinute)
 		}
-		if rem != "0" {
-			t.Errorf("Remaining on refusal = %q, want 0", rem)
-		}
-		if retry == "" || retry == "0" {
-			t.Errorf("Retry-After = %q, want a positive whole second", retry)
-		}
-		t.Logf("admitted %d, refused the next with Retry-After=%ss", publicReadsPerMinute, retry)
+		t.Logf("admitted %d of a %d ceiling, then refused", got, publicReadsPerMinute)
 	})
 
 	t.Run("agent budget is separate and smaller", func(t *testing.T) {
 		const peer = "203.0.113.11"
-		for i := 1; i <= agentSearchPerMinute; i++ {
-			if code, rem, _ := hit("/agent", peer); code != fiber.StatusOK {
-				t.Fatalf("agent request %d = %d (remaining=%s)", i, code, rem)
-			}
-		}
-		if code, _, _ := hit("/agent", peer); code != fiber.StatusTooManyRequests {
-			t.Fatalf("agent request %d = %d, want 429", agentSearchPerMinute+1, code)
+		got := admitUntilRefused(t, "/agent", peer, agentSearchPerMinute)
+		if got < agentSearchPerMinute-1 || got > agentSearchPerMinute {
+			t.Errorf("agent admitted %d, want %d or %d", got, agentSearchPerMinute-1, agentSearchPerMinute)
 		}
 		if code, _, _ := hit("/cheap", peer); code != fiber.StatusOK {
 			t.Errorf("/cheap after exhausting /agent = %d, want 200", code)
 		}
-		t.Logf("agent admitted %d then refused; cheap budget untouched", agentSearchPerMinute)
+		t.Logf("agent admitted %d then refused; cheap budget untouched", got)
 	})
 
 	t.Run("the live peak of 184 rpm never trips the agent budget", func(t *testing.T) {

--- a/internal/handler/public_read_limit_e2e_test.go
+++ b/internal/handler/public_read_limit_e2e_test.go
@@ -1,0 +1,106 @@
+package handler
+
+import (
+	"context"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/gofiber/fiber/v2"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/strelov1/freehire/internal/ratelimit"
+)
+
+// TestLimiterE2E drives the real constants through the real Redis-backed
+// throttler, which the unit tests deliberately do not: they use fakes, so they
+// prove the wiring and not the arithmetic.
+func TestLimiterE2E(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	th := ratelimit.NewRedisThrottler(client)
+
+	app := fiber.New(fiber.Config{ProxyHeader: fiber.HeaderXForwardedFor})
+	app.Get("/cheap", publicReadLimiter(th), func(c *fiber.Ctx) error { return c.SendStatus(fiber.StatusOK) })
+	app.Get("/agent", agentSearchLimiter(th), func(c *fiber.Ctx) error { return c.SendStatus(fiber.StatusOK) })
+
+	hit := func(path, peer string) (int, string, string) {
+		req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, path, nil)
+		req.Header.Set(fiber.HeaderXForwardedFor, peer)
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("%s: %v", path, err)
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode, resp.Header.Get("X-RateLimit-Remaining"), resp.Header.Get("Retry-After")
+	}
+
+	t.Run("cheap budget admits exactly publicReadsPerMinute", func(t *testing.T) {
+		const peer = "203.0.113.10"
+		for i := 1; i <= publicReadsPerMinute; i++ {
+			code, rem, _ := hit("/cheap", peer)
+			if code != fiber.StatusOK {
+				t.Fatalf("request %d/%d = %d, want 200 (remaining=%s)", i, publicReadsPerMinute, code, rem)
+			}
+			// Remaining is a GCRA reading, not limit-minus-count: redis_rate is a
+			// leaky bucket, so the figure trails naive counting by up to one while
+			// the elapsed time has not yet credited a whole token back. Assert the
+			// band it must stay inside rather than an exact value that encodes the
+			// arithmetic of a particular backend.
+			if i == 1 {
+				n, err := strconv.Atoi(rem)
+				if err != nil || n < publicReadsPerMinute-2 || n > publicReadsPerMinute-1 {
+					t.Errorf("first Remaining = %q, want %d or %d", rem, publicReadsPerMinute-2, publicReadsPerMinute-1)
+				}
+			}
+		}
+		code, rem, retry := hit("/cheap", peer)
+		if code != fiber.StatusTooManyRequests {
+			t.Fatalf("request %d = %d, want 429", publicReadsPerMinute+1, code)
+		}
+		if rem != "0" {
+			t.Errorf("Remaining on refusal = %q, want 0", rem)
+		}
+		if retry == "" || retry == "0" {
+			t.Errorf("Retry-After = %q, want a positive whole second", retry)
+		}
+		t.Logf("admitted %d, refused the next with Retry-After=%ss", publicReadsPerMinute, retry)
+	})
+
+	t.Run("agent budget is separate and smaller", func(t *testing.T) {
+		const peer = "203.0.113.11"
+		for i := 1; i <= agentSearchPerMinute; i++ {
+			if code, rem, _ := hit("/agent", peer); code != fiber.StatusOK {
+				t.Fatalf("agent request %d = %d (remaining=%s)", i, code, rem)
+			}
+		}
+		if code, _, _ := hit("/agent", peer); code != fiber.StatusTooManyRequests {
+			t.Fatalf("agent request %d = %d, want 429", agentSearchPerMinute+1, code)
+		}
+		if code, _, _ := hit("/cheap", peer); code != fiber.StatusOK {
+			t.Errorf("/cheap after exhausting /agent = %d, want 200", code)
+		}
+		t.Logf("agent admitted %d then refused; cheap budget untouched", agentSearchPerMinute)
+	})
+
+	t.Run("the live peak of 184 rpm never trips the agent budget", func(t *testing.T) {
+		const peer = "203.0.113.12"
+		for i := 1; i <= 184; i++ {
+			if code, _, _ := hit("/agent", peer); code != fiber.StatusOK {
+				t.Fatalf("ManyApplyAssist's measured peak was refused at request %d", i)
+			}
+		}
+		t.Log("184 rpm — today's heaviest live client — passes untouched")
+	})
+
+	t.Run("loopback is exempt at ten times the ceiling", func(t *testing.T) {
+		for i := 1; i <= agentSearchPerMinute*10; i++ {
+			if code, _, _ := hit("/agent", "127.0.0.1"); code != fiber.StatusOK {
+				t.Fatalf("loopback refused at request %d — SSR would be throttled", i)
+			}
+		}
+		t.Logf("%d loopback requests, none refused", agentSearchPerMinute*10)
+	})
+}

--- a/internal/handler/public_read_limit_test.go
+++ b/internal/handler/public_read_limit_test.go
@@ -1,0 +1,87 @@
+package handler
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/ratelimit"
+)
+
+// TestPublicReadBudgets_ClearTheMeasuredLivePeaks guards the numbers themselves.
+// A ceiling below what production already carries would not bound abuse; it would
+// cut off a caller this change was designed to tolerate, and do it silently,
+// since nothing else in the suite knows what live traffic looks like. The peaks
+// are per-IP per-minute over a 4.6-hour window — see the change's design.md.
+func TestPublicReadBudgets_ClearTheMeasuredLivePeaks(t *testing.T) {
+	const (
+		measuredAgentPeak = 184 // one third-party client, held steadily
+		measuredReadPeak  = 258
+	)
+	if agentSearchPerMinute <= measuredAgentPeak {
+		t.Errorf("agentSearchPerMinute = %d, must exceed the measured live peak of %d",
+			agentSearchPerMinute, measuredAgentPeak)
+	}
+	if publicReadsPerMinute <= measuredReadPeak {
+		t.Errorf("publicReadsPerMinute = %d, must exceed the measured live peak of %d",
+			publicReadsPerMinute, measuredReadPeak)
+	}
+}
+
+// oneShotThrottler admits the first request per key and refuses the rest, so a
+// test can exhaust one budget in two calls without depending on the real ceiling.
+type oneShotThrottler struct {
+	mu   sync.Mutex
+	seen map[string]bool
+}
+
+func newOneShotThrottler() *oneShotThrottler {
+	return &oneShotThrottler{seen: make(map[string]bool)}
+}
+
+func (o *oneShotThrottler) Allow(_ context.Context, key string, limit int, window time.Duration) (ratelimit.Decision, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.seen[key] {
+		return ratelimit.Decision{Limit: limit, ResetAfter: window, RetryAfter: window}, nil
+	}
+	o.seen[key] = true
+	return ratelimit.Decision{Allowed: true, Limit: limit, Remaining: limit - 1, ResetAfter: window}, nil
+}
+
+// TestPublicReadLimiters_DoNotShareABudget pins that the two classes are keyed
+// apart. They exist as two budgets because they cost differently; one shared key
+// would quietly undo the split and put facet lookups under the expensive
+// endpoint's ceiling.
+func TestPublicReadLimiters_DoNotShareABudget(t *testing.T) {
+	th := newOneShotThrottler()
+
+	app := fiber.New(fiber.Config{ProxyHeader: fiber.HeaderXForwardedFor})
+	app.Get("/cheap", publicReadLimiter(th), func(c *fiber.Ctx) error { return c.SendStatus(fiber.StatusOK) })
+	app.Get("/agent", agentSearchLimiter(th), func(c *fiber.Ctx) error { return c.SendStatus(fiber.StatusOK) })
+
+	get := func(path string) int {
+		req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, path, nil)
+		req.Header.Set(fiber.HeaderXForwardedFor, "203.0.113.9")
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	if got := get("/agent"); got != fiber.StatusOK {
+		t.Fatalf("first /agent = %d, want 200", got)
+	}
+	if got := get("/agent"); got != fiber.StatusTooManyRequests {
+		t.Fatalf("second /agent = %d, want 429 (its own budget is spent)", got)
+	}
+	if got := get("/cheap"); got != fiber.StatusOK {
+		t.Errorf("/cheap = %d, want 200 — exhausting the agent budget must not spend the read budget", got)
+	}
+}

--- a/internal/handler/search.go
+++ b/internal/handler/search.go
@@ -35,12 +35,13 @@ func newSearchHandlers(search searcher, facets facetCounter, queries *db.Queries
 func (h *searchHandlers) register(api fiber.Router, mw middleware) {
 	// Literal routes are registered before the /jobs/:slug param route (see
 	// Register) so they are not read as slugs.
-	api.Get("/jobs/search", h.SearchJobs)
+	readLimit := publicReadLimiter(mw.throttler)
+	api.Get("/jobs/search", readLimit, h.SearchJobs)
 	// Agent search: same query as /jobs/search, but always full descriptions in a
 	// selectable format for programmatic consumers. Public, like the other reads.
-	api.Get("/agent/jobs/search", h.AgentSearchJobs)
-	api.Get("/jobs/facets", h.JobFacets)
-	api.Get("/jobs/:slug/similar", h.SimilarJobs)
+	api.Get("/agent/jobs/search", agentSearchLimiter(mw.throttler), h.AgentSearchJobs)
+	api.Get("/jobs/facets", readLimit, h.JobFacets)
+	api.Get("/jobs/:slug/similar", readLimit, h.SimilarJobs)
 }
 
 // searcher is the search backend the handler depends on. *search.Client

--- a/internal/ratelimit/middleware_test.go
+++ b/internal/ratelimit/middleware_test.go
@@ -23,30 +23,35 @@ func newMemoryThrottler() *memoryThrottler {
 	return &memoryThrottler{counts: make(map[string]int)}
 }
 
-func (m *memoryThrottler) Allow(_ context.Context, key string, limit int, window time.Duration) (bool, time.Duration, error) {
+func (m *memoryThrottler) Allow(_ context.Context, key string, limit int, window time.Duration) (Decision, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.counts[key] >= limit {
-		return false, window, nil
+		return Decision{Limit: limit, Remaining: 0, ResetAfter: window, RetryAfter: window}, nil
 	}
 	m.counts[key]++
-	return true, 0, nil
+	return Decision{
+		Allowed:    true,
+		Limit:      limit,
+		Remaining:  limit - m.counts[key],
+		ResetAfter: window,
+	}, nil
 }
 
 // erroringThrottler always returns an error, simulating a backend failure.
 type erroringThrottler struct{}
 
-func (erroringThrottler) Allow(context.Context, string, int, time.Duration) (bool, time.Duration, error) {
-	return false, 0, errors.New("backend unreachable")
+func (erroringThrottler) Allow(context.Context, string, int, time.Duration) (Decision, error) {
+	return Decision{}, errors.New("backend unreachable")
 }
 
 // hangingThrottler blocks until the context passed to Allow is done, then
 // reports the context error — simulating a backend that never responds in time.
 type hangingThrottler struct{}
 
-func (hangingThrottler) Allow(ctx context.Context, _ string, _ int, _ time.Duration) (bool, time.Duration, error) {
+func (hangingThrottler) Allow(ctx context.Context, _ string, _ int, _ time.Duration) (Decision, error) {
 	<-ctx.Done()
-	return false, 0, ctx.Err()
+	return Decision{}, ctx.Err()
 }
 
 func TestMiddleware_AllowsUnderLimit(t *testing.T) {
@@ -174,10 +179,35 @@ func TestMiddleware_FloorsRetryAfterToAtLeastOneSecond(t *testing.T) {
 	}
 }
 
+// fractionalRetryThrottler reports a retryAfter with a fraction, to pin that the
+// header rounds UP. Truncating 1.7s to "1" tells a compliant client to retry a
+// full second before its budget exists, straight into the denial it just got.
+type fractionalRetryThrottler struct{}
+
+func (fractionalRetryThrottler) Allow(_ context.Context, _ string, limit int, window time.Duration) (Decision, error) {
+	return Decision{Limit: limit, ResetAfter: window, RetryAfter: 1700 * time.Millisecond}, nil
+}
+
+func TestMiddleware_RoundsRetryAfterUp(t *testing.T) {
+	app := fiber.New()
+	app.Get("/probe", Middleware(fractionalRetryThrottler{}, KeyByIP("test"), 1, time.Minute), func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/probe", nil))
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	defer resp.Body.Close()
+	if got := resp.Header.Get("Retry-After"); got != "2" {
+		t.Errorf("Retry-After for 1.7s = %q, want %q", got, "2")
+	}
+}
+
 type subSecondRetryThrottler struct{}
 
-func (subSecondRetryThrottler) Allow(context.Context, string, int, time.Duration) (bool, time.Duration, error) {
-	return false, 200 * time.Millisecond, nil
+func (subSecondRetryThrottler) Allow(_ context.Context, _ string, limit int, window time.Duration) (Decision, error) {
+	return Decision{Limit: limit, ResetAfter: window, RetryAfter: 200 * time.Millisecond}, nil
 }
 
 // TestMiddleware_WithRedisThrottler_FailsOpenWhenRedisUnreachable exercises the
@@ -204,5 +234,113 @@ func TestMiddleware_WithRedisThrottler_FailsOpenWhenRedisUnreachable(t *testing.
 	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusOK {
 		t.Errorf("status = %d, want 200 (fail open through the real RedisThrottler + Middleware pair)", resp.StatusCode)
+	}
+}
+
+func TestMiddleware_SetsBudgetHeadersOnAllowedRequest(t *testing.T) {
+	// The headers exist so a ceiling can be respected rather than merely
+	// discovered: a client reading Remaining can slow down before it is refused,
+	// whereas one that only ever sees Retry-After has already failed a request.
+	th := newMemoryThrottler()
+	app := fiber.New()
+	app.Get("/probe", Middleware(th, KeyByIP("test"), 3, time.Minute), func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/probe", nil))
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := resp.Header.Get("X-RateLimit-Limit"); got != "3" {
+		t.Errorf("X-RateLimit-Limit = %q, want %q", got, "3")
+	}
+	if got := resp.Header.Get("X-RateLimit-Remaining"); got != "2" {
+		t.Errorf("X-RateLimit-Remaining = %q, want %q", got, "2")
+	}
+	if resp.Header.Get("X-RateLimit-Reset") == "" {
+		t.Error("expected X-RateLimit-Reset on an allowed response")
+	}
+}
+
+func TestMiddleware_RemainingDecreasesAcrossRequests(t *testing.T) {
+	th := newMemoryThrottler()
+	app := fiber.New()
+	app.Get("/probe", Middleware(th, KeyByIP("test"), 5, time.Minute), func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	remaining := func() string {
+		resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/probe", nil))
+		if err != nil {
+			t.Fatalf("Test: %v", err)
+		}
+		defer resp.Body.Close()
+		return resp.Header.Get("X-RateLimit-Remaining")
+	}
+
+	if first, second := remaining(), remaining(); first != "4" || second != "3" {
+		t.Errorf("Remaining across two requests = %q, %q; want %q, %q", first, second, "4", "3")
+	}
+}
+
+func TestMiddleware_SetsBudgetHeadersOnRejection(t *testing.T) {
+	th := newMemoryThrottler()
+	app := fiber.New()
+	app.Get("/probe", Middleware(th, KeyByIP("test"), 1, time.Minute), func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	first, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/probe", nil))
+	if err != nil {
+		t.Fatalf("first request: %v", err)
+	}
+	first.Body.Close()
+
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/probe", nil))
+	if err != nil {
+		t.Fatalf("second request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Retry-After"); got == "" {
+		t.Error("Retry-After must survive alongside the new headers")
+	}
+	if got := resp.Header.Get("X-RateLimit-Limit"); got != "1" {
+		t.Errorf("X-RateLimit-Limit = %q, want %q", got, "1")
+	}
+	if got := resp.Header.Get("X-RateLimit-Remaining"); got != "0" {
+		t.Errorf("X-RateLimit-Remaining = %q, want %q", got, "0")
+	}
+	if resp.Header.Get("X-RateLimit-Reset") == "" {
+		t.Error("expected X-RateLimit-Reset on a 429 response")
+	}
+}
+
+func TestMiddleware_FailOpenReportsNoBudget(t *testing.T) {
+	// No check happened, so there is no budget to report. Inventing one would be
+	// worse than silence: a client would pace itself against a fabricated number.
+	app := fiber.New()
+	app.Get("/probe", Middleware(erroringThrottler{}, KeyByIP("test"), 1, time.Minute), func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/probe", nil))
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200 (fail open)", resp.StatusCode)
+	}
+	for _, h := range []string{"X-RateLimit-Limit", "X-RateLimit-Remaining", "X-RateLimit-Reset"} {
+		if got := resp.Header.Get(h); got != "" {
+			t.Errorf("%s = %q on a fail-open response, want it absent", h, got)
+		}
 	}
 }

--- a/internal/ratelimit/middleware_test.go
+++ b/internal/ratelimit/middleware_test.go
@@ -3,6 +3,7 @@ package ratelimit
 import (
 	"context"
 	"errors"
+	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"
@@ -199,6 +200,9 @@ func TestMiddleware_RoundsRetryAfterUp(t *testing.T) {
 		t.Fatalf("Test: %v", err)
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", resp.StatusCode)
+	}
 	if got := resp.Header.Get("Retry-After"); got != "2" {
 		t.Errorf("Retry-After for 1.7s = %q, want %q", got, "2")
 	}
@@ -342,5 +346,82 @@ func TestMiddleware_FailOpenReportsNoBudget(t *testing.T) {
 		if got := resp.Header.Get(h); got != "" {
 			t.Errorf("%s = %q on a fail-open response, want it absent", h, got)
 		}
+	}
+}
+
+// peerApp builds a test app whose c.IP() reads X-Real-IP, which is exactly how
+// c.IP() resolves in production: cmd/server sets ProxyHeader to X-Real-IP and
+// nginx populates it. Fiber's app.Test always reports a 0.0.0.0 remote address
+// and ignores httptest's RemoteAddr, so this is the only way to drive the peer
+// a middleware sees.
+func peerApp(th Throttler, limit int) *fiber.App {
+	app := fiber.New(fiber.Config{ProxyHeader: fiber.HeaderXForwardedFor})
+	app.Get("/probe", Middleware(th, KeyByIP("test"), limit, time.Minute), func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+	return app
+}
+
+func getAsPeer(t *testing.T, app *fiber.App, peer string) *http.Response {
+	t.Helper()
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/probe", nil)
+	req.Header.Set(fiber.HeaderXForwardedFor, peer)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("request as %s: %v", peer, err)
+	}
+	return resp
+}
+
+func TestMiddleware_TrustedPeerIsNeverLimited(t *testing.T) {
+	// SSR reaches the API over loopback without a client-address header, so every
+	// server-rendered page presents the same peer. Counting those would put the
+	// whole site in one caller's budget and throttle it as a single abusive
+	// client — the limiter exists to bound external abuse, and our own front end
+	// flooding the API is a different bug that a 429 makes worse, not better.
+	app := peerApp(newMemoryThrottler(), 1)
+
+	for i := range 5 {
+		resp := getAsPeer(t, app, "127.0.0.1")
+		if resp.StatusCode != fiber.StatusOK {
+			t.Fatalf("request %d status = %d, want 200 (loopback is never limited, limit is 1)", i, resp.StatusCode)
+		}
+		if got := resp.Header.Get("X-RateLimit-Limit"); got != "" {
+			t.Errorf("request %d: X-RateLimit-Limit = %q, want it absent — no check happened", i, got)
+		}
+		resp.Body.Close()
+	}
+}
+
+func TestMiddleware_PrivateNetworkPeerIsNeverLimited(t *testing.T) {
+	app := peerApp(newMemoryThrottler(), 1)
+
+	// Three requests each against a limit of 1: one apiece would pass even
+	// unexempted, since every peer is its own key.
+	for _, peer := range []string{"10.1.2.3", "172.16.9.9", "192.168.1.10"} {
+		for i := range 3 {
+			resp := getAsPeer(t, app, peer)
+			if resp.StatusCode != fiber.StatusOK {
+				t.Errorf("peer %s request %d status = %d, want 200 (private peer is never limited)", peer, i, resp.StatusCode)
+			}
+			resp.Body.Close()
+		}
+	}
+}
+
+func TestMiddleware_ExternalPeerIsStillLimited(t *testing.T) {
+	// The companion to the exemption: it must not become a blanket bypass.
+	app := peerApp(newMemoryThrottler(), 1)
+
+	first := getAsPeer(t, app, "203.0.113.7")
+	first.Body.Close()
+	if first.StatusCode != fiber.StatusOK {
+		t.Fatalf("first request status = %d, want 200", first.StatusCode)
+	}
+
+	second := getAsPeer(t, app, "203.0.113.7")
+	defer second.Body.Close()
+	if second.StatusCode != fiber.StatusTooManyRequests {
+		t.Errorf("second request status = %d, want 429 — an external caller is still limited", second.StatusCode)
 	}
 }

--- a/internal/ratelimit/redis.go
+++ b/internal/ratelimit/redis.go
@@ -22,17 +22,31 @@ func NewRedisThrottler(client *redis.Client) *RedisThrottler {
 }
 
 // Allow implements Throttler.
-func (t *RedisThrottler) Allow(ctx context.Context, key string, limit int, window time.Duration) (bool, time.Duration, error) {
+//
+// Every field of the Decision comes from the one round trip redis_rate already
+// makes: Remaining and ResetAfter are computed by the same Lua script that
+// decides Allowed, so the budget a caller is told about cannot disagree with the
+// verdict it accompanies.
+func (t *RedisThrottler) Allow(ctx context.Context, key string, limit int, window time.Duration) (Decision, error) {
 	res, err := t.limiter.Allow(ctx, key, redisrate.Limit{Rate: limit, Burst: limit, Period: window})
 	if err != nil {
-		return false, 0, err
+		return Decision{}, err
 	}
-	if res.Allowed > 0 {
-		return true, 0, nil
+
+	decision := Decision{
+		Allowed:    res.Allowed > 0,
+		Limit:      limit,
+		Remaining:  res.Remaining,
+		ResetAfter: res.ResetAfter,
 	}
-	retryAfter := res.RetryAfter
-	if retryAfter < 0 {
-		retryAfter = window
+	if decision.Allowed {
+		return decision, nil
 	}
-	return false, retryAfter, nil
+	// A negative RetryAfter means redis_rate could not say when the next request
+	// fits; the whole window is the safe over-estimate.
+	decision.RetryAfter = res.RetryAfter
+	if decision.RetryAfter < 0 {
+		decision.RetryAfter = window
+	}
+	return decision, nil
 }

--- a/internal/ratelimit/redis_test.go
+++ b/internal/ratelimit/redis_test.go
@@ -27,11 +27,11 @@ func TestRedisThrottler_AllowsWithinLimit(t *testing.T) {
 	th := newTestRedisThrottler(t)
 
 	for i := 0; i < 3; i++ {
-		allowed, _, err := th.Allow(context.Background(), "key1", 3, time.Minute)
+		decision, err := th.Allow(context.Background(), "key1", 3, time.Minute)
 		if err != nil {
 			t.Fatalf("Allow %d: %v", i, err)
 		}
-		if !allowed {
+		if !decision.Allowed {
 			t.Fatalf("request %d should be allowed (within limit 3)", i)
 		}
 	}
@@ -41,39 +41,39 @@ func TestRedisThrottler_RejectsOverLimit(t *testing.T) {
 	th := newTestRedisThrottler(t)
 
 	for i := 0; i < 2; i++ {
-		if _, _, err := th.Allow(context.Background(), "key2", 2, time.Minute); err != nil {
+		if _, err := th.Allow(context.Background(), "key2", 2, time.Minute); err != nil {
 			t.Fatalf("Allow %d: %v", i, err)
 		}
 	}
 
-	allowed, retryAfter, err := th.Allow(context.Background(), "key2", 2, time.Minute)
+	decision, err := th.Allow(context.Background(), "key2", 2, time.Minute)
 	if err != nil {
 		t.Fatalf("Allow: %v", err)
 	}
-	if allowed {
+	if decision.Allowed {
 		t.Fatal("3rd request should be rejected (limit 2)")
 	}
-	if retryAfter <= 0 {
-		t.Errorf("retryAfter = %v, want > 0", retryAfter)
+	if decision.RetryAfter <= 0 {
+		t.Errorf("RetryAfter = %v, want > 0", decision.RetryAfter)
 	}
 }
 
 func TestRedisThrottler_SeparateKeysAreIndependent(t *testing.T) {
 	th := newTestRedisThrottler(t)
 
-	if _, _, err := th.Allow(context.Background(), "a", 1, time.Minute); err != nil {
+	if _, err := th.Allow(context.Background(), "a", 1, time.Minute); err != nil {
 		t.Fatalf("Allow a: %v", err)
 	}
-	allowedA, _, _ := th.Allow(context.Background(), "a", 1, time.Minute)
-	if allowedA {
+	a2, _ := th.Allow(context.Background(), "a", 1, time.Minute)
+	if a2.Allowed {
 		t.Fatal("key a should be exhausted after 1 request (limit 1)")
 	}
 
-	allowedB, _, err := th.Allow(context.Background(), "b", 1, time.Minute)
+	b1, err := th.Allow(context.Background(), "b", 1, time.Minute)
 	if err != nil {
 		t.Fatalf("Allow b: %v", err)
 	}
-	if !allowedB {
+	if !b1.Allowed {
 		t.Fatal("key b should be independent of key a")
 	}
 }
@@ -94,8 +94,42 @@ func TestRedisThrottler_ReturnsErrorWhenRedisUnreachable(t *testing.T) {
 
 	th := NewRedisThrottler(client)
 
-	_, _, err := th.Allow(context.Background(), "any-key", 1, time.Minute)
+	_, err := th.Allow(context.Background(), "any-key", 1, time.Minute)
 	if err == nil {
 		t.Fatal("Allow: want a non-nil error when Redis is unreachable")
+	}
+}
+
+func TestRedisThrottler_ReportsBudgetFromTheBackend(t *testing.T) {
+	// The middleware tests prove the headers are written; this proves the numbers
+	// in them are the backend's own. Remaining and ResetAfter come out of the same
+	// Lua script that decides Allowed, so a caller's reported budget cannot drift
+	// from the verdict it accompanies — which is the whole reason Allow returns a
+	// Decision rather than a bare bool.
+	th := newTestRedisThrottler(t)
+
+	first, err := th.Allow(context.Background(), "budget", 3, time.Minute)
+	if err != nil {
+		t.Fatalf("first Allow: %v", err)
+	}
+	if !first.Allowed {
+		t.Fatal("first request should be allowed")
+	}
+	if first.Limit != 3 {
+		t.Errorf("Limit = %d, want 3", first.Limit)
+	}
+	if first.Remaining != 2 {
+		t.Errorf("Remaining after 1 of 3 = %d, want 2", first.Remaining)
+	}
+	if first.ResetAfter <= 0 {
+		t.Errorf("ResetAfter = %v, want > 0 once the bucket is partly drained", first.ResetAfter)
+	}
+
+	second, err := th.Allow(context.Background(), "budget", 3, time.Minute)
+	if err != nil {
+		t.Fatalf("second Allow: %v", err)
+	}
+	if second.Remaining >= first.Remaining {
+		t.Errorf("Remaining did not decrease: %d then %d", first.Remaining, second.Remaining)
 	}
 }

--- a/internal/ratelimit/throttler.go
+++ b/internal/ratelimit/throttler.go
@@ -53,9 +53,13 @@ type Throttler interface {
 // throttler (no backend configured) also fails open, with no warning logged. A
 // fail-open response carries no budget headers: no check happened, so there is
 // no budget to report, and an invented one is worse than silence.
+//
+// A request from a trusted peer (see TrustedCIDRs) skips the check entirely and
+// carries no headers, because our own server-rendered front end reaches the API
+// over loopback and would otherwise spend one shared budget for the whole site.
 func Middleware(throttler Throttler, keyFunc func(c *fiber.Ctx) string, limit int, window time.Duration) fiber.Handler {
 	return func(c *fiber.Ctx) error {
-		if throttler == nil {
+		if throttler == nil || trustedPeer(c) {
 			return c.Next()
 		}
 

--- a/internal/ratelimit/throttler.go
+++ b/internal/ratelimit/throttler.go
@@ -4,8 +4,9 @@ package ratelimit
 
 import (
 	"context"
-	"fmt"
 	"log"
+	"math"
+	"strconv"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -17,16 +18,41 @@ import (
 // warning and passes through" instead of stalling requests.
 const allowTimeout = 100 * time.Millisecond
 
+// Decision is one rate-limit verdict, carrying everything the caller needs to
+// answer the request AND to tell the client where it stands.
+//
+// It is a struct rather than a longer return list because the backend already
+// computes all of it in the same round trip, and reporting a budget the decision
+// did not produce is how a client ends up pacing itself against a number that
+// was never true.
+type Decision struct {
+	Allowed bool
+	// Limit is the ceiling in force for this check, echoed back so a client
+	// never has to infer it from observed rejections.
+	Limit int
+	// Remaining is how many further requests the window still permits.
+	Remaining int
+	// ResetAfter is how long until the caller's budget is full again.
+	ResetAfter time.Duration
+	// RetryAfter is how long until the next request would be permitted. It is
+	// meaningful only when Allowed is false.
+	RetryAfter time.Duration
+}
+
 // Throttler checks whether a request rate limit has been exceeded for a key.
 type Throttler interface {
-	Allow(ctx context.Context, key string, limit int, window time.Duration) (allowed bool, retryAfter time.Duration, err error)
+	Allow(ctx context.Context, key string, limit int, window time.Duration) (Decision, error)
 }
 
 // Middleware creates a Fiber middleware that enforces rate limiting via a
-// Throttler. It fails open — logging a warning and allowing the request — on
-// any error from Allow, including exceeding the bounded per-call timeout it
-// imposes. A nil throttler (no backend configured) also fails open, with no
-// warning logged.
+// Throttler, and reports the caller's remaining budget on every response it
+// checks.
+//
+// It fails open — logging a warning and allowing the request — on any error from
+// Allow, including exceeding the bounded per-call timeout it imposes. A nil
+// throttler (no backend configured) also fails open, with no warning logged. A
+// fail-open response carries no budget headers: no check happened, so there is
+// no budget to report, and an invented one is worse than silence.
 func Middleware(throttler Throttler, keyFunc func(c *fiber.Ctx) string, limit int, window time.Duration) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		if throttler == nil {
@@ -37,21 +63,48 @@ func Middleware(throttler Throttler, keyFunc func(c *fiber.Ctx) string, limit in
 		defer cancel()
 
 		key := keyFunc(c)
-		allowed, retryAfter, err := throttler.Allow(ctx, key, limit, window)
+		decision, err := throttler.Allow(ctx, key, limit, window)
 		if err != nil {
 			log.Printf("ratelimit: Allow error for key %q: %v (failing open)", key, err)
 			return c.Next()
 		}
-		if allowed {
+
+		setBudgetHeaders(c, decision)
+		if decision.Allowed {
 			return c.Next()
 		}
-		// The header is whole seconds (RFC 9110 delta-seconds); floor it so a
-		// sub-second retryAfter doesn't round down to "0" and tell a compliant
-		// client to retry immediately into another denial.
-		if retryAfter < time.Second {
-			retryAfter = time.Second
-		}
-		c.Set("Retry-After", fmt.Sprintf("%.0f", retryAfter.Seconds()))
+
+		// Retry-After is whole seconds (RFC 9110 delta-seconds), rounded UP and
+		// floored at one: every way of losing the fraction tells a compliant
+		// client to retry early, into a denial it was just given. 1.7s must read
+		// as "2", and 200ms as "1", never "0".
+		c.Set("Retry-After", wholeSecondsAtLeastOne(decision.RetryAfter))
+		log.Printf("ratelimit: refused key %q on %s (limit %d/%v, ua=%q)",
+			key, c.Path(), limit, window, c.Get(fiber.HeaderUserAgent))
 		return fiber.NewError(fiber.StatusTooManyRequests, "too many requests, please try again later")
 	}
+}
+
+// setBudgetHeaders writes the caller-facing view of a Decision. Reset is rounded
+// UP for the same reason as Retry-After: a bucket that refills in 400ms must not
+// report "0", which reads as "you are already clear" to a client that then
+// retries into the same denial.
+func setBudgetHeaders(c *fiber.Ctx, d Decision) {
+	c.Set("X-RateLimit-Limit", strconv.Itoa(d.Limit))
+	c.Set("X-RateLimit-Remaining", strconv.Itoa(max(d.Remaining, 0)))
+	c.Set("X-RateLimit-Reset", strconv.Itoa(ceilSeconds(d.ResetAfter)))
+}
+
+// ceilSeconds renders a duration as whole seconds, rounding any fraction up.
+func ceilSeconds(d time.Duration) int {
+	if d <= 0 {
+		return 0
+	}
+	return int(math.Ceil(d.Seconds()))
+}
+
+// wholeSecondsAtLeastOne is ceilSeconds with a floor of one, for the headers
+// that name a wait: "0" would invite an immediate retry.
+func wholeSecondsAtLeastOne(d time.Duration) string {
+	return strconv.Itoa(max(ceilSeconds(d), 1))
 }

--- a/internal/ratelimit/trust.go
+++ b/internal/ratelimit/trust.go
@@ -1,0 +1,62 @@
+package ratelimit
+
+import (
+	"net"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// TrustedCIDRs is the set of peers allowed to speak on another caller's behalf,
+// and therefore the set this package does not defend against.
+//
+// It is the single definition: cmd/server hands it to Fiber as TrustedProxies so
+// an X-Real-IP from one of these is believed, and Middleware reads it to decide
+// whom not to count. Defining it twice would let the two drift, and a peer we
+// trust to assert someone else's address while also rate-limiting as if it were
+// a stranger is incoherent in both directions.
+//
+// The concrete need is the front end: SSR reaches the API at
+// http://127.0.0.1:8081, bypassing nginx and forwarding no client-address
+// header, so every server-rendered page presents the same peer. Counting those
+// would put the whole site in one caller's budget.
+var TrustedCIDRs = []string{
+	"10.0.0.0/8",
+	"172.16.0.0/12",
+	"192.168.0.0/16",
+	"127.0.0.1/32",
+}
+
+// trustedNets is TrustedCIDRs parsed once at init. A malformed entry is a
+// programming error in a package-level literal, so it panics here rather than
+// silently narrowing the trusted set at runtime — a CIDR that fails to parse
+// would otherwise turn our own SSR into a rate-limited stranger.
+var trustedNets = func() []*net.IPNet {
+	nets := make([]*net.IPNet, 0, len(TrustedCIDRs))
+	for _, cidr := range TrustedCIDRs {
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic("ratelimit: malformed trusted CIDR " + cidr + ": " + err.Error())
+		}
+		nets = append(nets, network)
+	}
+	return nets
+}()
+
+// trustedPeer reports whether the request comes from a peer we do not rate-limit.
+// An address that does not parse is treated as untrusted: an unrecognizable
+// caller is exactly the one to keep counting.
+func trustedPeer(c *fiber.Ctx) bool {
+	ip := net.ParseIP(c.IP())
+	if ip == nil {
+		return false
+	}
+	if ip.IsLoopback() {
+		return true
+	}
+	for _, network := range trustedNets {
+		if network.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/openspec/changes/rate-limit-public-reads/design.md
+++ b/openspec/changes/rate-limit-public-reads/design.md
@@ -1,0 +1,119 @@
+## Context
+
+`internal/ratelimit` is already the single rate-limit facility: a `Throttler`
+interface, one Redis-backed GCRA implementation via `redis_rate`, a Fiber
+`Middleware`, and two key builders (`KeyByIP`, `KeyByUserOrIP`). Eighteen routes
+use it. None of them is a public read.
+
+Everything this change needs is nearly there. The one structural obstacle is
+that `Allow` throws away most of what the backend returns.
+
+## Decision 1: widen `Throttler.Allow` rather than add a second method
+
+```go
+Allow(ctx, key string, limit int, window time.Duration) (bool, time.Duration, error)
+```
+
+`redis_rate.Result` already carries `Remaining` and `ResetAfter` alongside
+`RetryAfter`; our signature discards both. Headers cannot be built from what the
+interface returns, so the interface changes:
+
+```go
+type Decision struct {
+    Allowed    bool
+    Limit      int           // the ceiling in force, echoed for X-RateLimit-Limit
+    Remaining  int           // requests left in the window
+    ResetAfter time.Duration // until the bucket is full again
+    RetryAfter time.Duration // meaningful only when !Allowed
+}
+
+Allow(ctx, key string, limit int, window time.Duration) (Decision, error)
+```
+
+A struct rather than a fourth and fifth return value: five positional results at
+a call site is where argument-order bugs live, and the set will grow again if a
+tier ever needs a name attached.
+
+The alternative — keep `Allow` and add `AllowDetailed` — was rejected. Two
+methods with one implementation means every fake implements both or embeds a
+default, and the header path silently regresses the moment someone calls the
+older one. There are five implementations in the tree (one real, four test
+fakes) and all five are inside `internal/ratelimit`, so the widening does not
+leave the package.
+
+## Decision 2: two budgets, split by measured cost
+
+| class | endpoints | measured peak/IP | ceiling |
+|---|---|---|---|
+| cheap | `/jobs/search`, `/jobs/facets`, `/jobs/{slug}`, `/jobs/{slug}/similar`, `/companies`, `/companies/{slug}`, `/geo/cities` | 258/min | 600/min |
+| expensive | `/agent/jobs/search` | 184/min | 300/min |
+
+Peaks are per-IP per-minute over a 4.6-hour production window (419,957 log
+lines). The split is not aesthetic: `agent/jobs/search` rehydrates every hit's
+full description from Postgres, which measures ~7x the ordinary search in bytes
+and ~2.4x in latency. A single budget would have to be set for the expensive
+endpoint and would then throttle facet lookups seven times harder than their
+cost warrants.
+
+600/min is 10 r/s — deliberately the same number nginx already enforces on the
+HTML pages, so the site has one ceiling to explain rather than two.
+
+Keys use `KeyByUserOrIP`, not `KeyByIP`. Not for tiering — the budget is
+identical either way — but for correctness: a signed-in user behind a corporate
+NAT should not share a bucket with strangers who happen to share their egress
+address.
+
+## Decision 3: exempt trusted peers, and do it in the middleware
+
+SSR calls the API at `http://127.0.0.1:8081` (`API_INTERNAL_URL`), bypassing
+nginx. `web/src/lib/server/api.ts` forwards the session cookie and nothing else,
+so no `X-Real-IP` reaches Fiber. With `ProxyHeader: "X-Real-IP"` and a trusted
+peer, Fiber's `extractIPFromHeader` finds no header and falls back to the socket
+address: **every server-rendered page keys to `127.0.0.1`**. A per-IP budget
+would put the entire website in one bucket and throttle it within seconds of a
+traffic spike.
+
+Two ways out; the second is rejected:
+
+1. **Skip the limiter when the peer is loopback or private.** The limiter exists
+   to bound external abuse. If our own SSR ever floods the API that is a bug in
+   the SSR, and a 429 to our own page renderer is a worse symptom than the flood.
+2. Have SSR forward `getClientAddress()` as `X-Real-IP`. Conceptually tidier —
+   each visitor spends their own budget — but it makes a human clicking through
+   the site draw from the same allowance as a scraper, which is exactly the
+   false positive the ceiling was chosen to avoid. It also spreads the change
+   across two languages for no gain the origin can feel.
+
+The exemption reuses the CIDR list already in `cmd/server/main.go:123`
+(`10/8`, `172.16/12`, `192.168/16`, `127.0.0.1/32`), lifted into the ratelimit
+package so the two cannot drift: a peer Fiber trusts to set `X-Real-IP` is
+exactly a peer we are not defending against.
+
+## Decision 4: headers on every limited response, not only on rejection
+
+`X-RateLimit-*` goes on the 200s too. A ceiling disclosed only at the moment of
+rejection is not a contract, it is a surprise — the integrator report that
+prompted this change specifically noted the *absence* of headers, not the
+presence of throttling. A client that reads `Remaining` can slow down before it
+is refused; one that only sees `Retry-After` has already failed a request.
+
+`Retry-After` stays exactly as it is on 429, including the existing floor to one
+second so a sub-second value never rounds to `0` and invites an immediate retry
+into a second denial.
+
+## Risks
+
+**A ceiling too low breaks a real integrator silently.** Mitigated by deriving
+both numbers from measured peaks with headroom (2.3x and 1.6x), and by logging
+every 429 with its user agent and path so "who did this catch" is answerable a
+week later without new instrumentation.
+
+**Redis outage becomes a site outage.** It does not: `Middleware` already fails
+open on any `Allow` error and on its own 100 ms timeout, and that path is
+untouched. A fail-open response carries no `X-RateLimit-*` headers — absent is
+honest, invented numbers are not.
+
+**The exemption is a bypass if the trust boundary is wrong.** It is the same
+boundary Fiber already uses to decide whether to believe `X-Real-IP`; if that
+list were wrong, IP-based limiting would already be spoofable and the auth
+limiters already broken. This change does not widen it.

--- a/openspec/changes/rate-limit-public-reads/proposal.md
+++ b/openspec/changes/rate-limit-public-reads/proposal.md
@@ -1,0 +1,82 @@
+## Why
+
+**The public read API has no rate limit at all.** Not a generous one — none.
+Every one of the eighteen limiters built on `internal/ratelimit` guards an auth
+route, a write, or an LLM spend. `nginx` applies `limit_req` to `location /`
+(the SvelteKit pages, 10 r/s per IP) and **not** to `location /api/`, and the
+`freehire-limit-req` fail2ban jail reads the `limit_req` rejections that only
+that location produces. Measured on production: 134 IPs are currently banned
+across the nginx jails, and **zero** of their requests ever touched
+`/api/v1/`. An API client cannot be banned, because nothing observes it.
+
+One consumer already lives in that gap. `ManyApplyAssist/6.0` holds a steady
+~180 requests per minute — 59% of all API traffic in a 4.6-hour window — and
+**100% of it lands on `/api/v1/agent/jobs/search`**, the most expensive endpoint
+we serve (833 KB and ~1.3 s at `limit=100`, against 123 KB and ~0.55 s for the
+ordinary search). It is not misbehaving; it simply has no ceiling to respect and
+no way to learn one, because we publish neither a limit nor a header.
+
+That was already worth fixing. #2085 and #2092 made it urgent: `robots.txt` and
+`llms.txt` now actively tell crawlers to stop scraping the HTML and call the API
+instead — steering traffic off the rate-limited path onto the unlimited one.
+That advice is right (one JSON call is cheaper than an SSR render and returns
+more) and it must not ship without the ceiling it assumes.
+
+## What Changes
+
+- **Public read endpoints get two budgets**, split by measured cost rather than
+  by path: the cheap reads (`/jobs/search`, `/jobs/facets`, `/jobs/{slug}`,
+  `/jobs/{slug}/similar`, `/companies`, `/companies/{slug}`, `/geo/cities`) at
+  600/min, and `/agent/jobs/search` alone at 300/min. Both sit above today's
+  measured per-IP peaks (258/min and 184/min), so no current caller is cut off
+  on the day this ships.
+- **Every rate-limited response carries `X-RateLimit-Limit`,
+  `X-RateLimit-Remaining` and `X-RateLimit-Reset`.** This is the half that makes
+  a limit legible instead of merely punitive, and it applies to all eighteen
+  existing limiters too — today a caller who exhausts the login limiter gets a
+  bare 429 with no `Retry-After` guidance until the very moment of rejection.
+- **Loopback and private-network callers skip the limiter entirely.** Without
+  this the change is not merely wrong, it is an outage: SSR reaches the API at
+  `http://127.0.0.1:8081`, bypassing nginx and sending no `X-Real-IP`, so
+  `c.IP()` returns `127.0.0.1` for every server-rendered page and the whole site
+  would share one bucket.
+- **`openapi.yaml` documents the limits and the headers**, closing the gap a
+  third-party integrator named in writing: *"There is no SLA and no rate-limit
+  header of any kind (verified: no `X-RateLimit-*`, no `Retry-After`)."*
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `api-rate-limiting`: gains client-visible budget headers, a public-read
+  ceiling, and a trusted-caller exemption. The shared-backend, key-namespacing
+  and fail-open contracts are unchanged.
+- `api-documentation`: the published schema states the limits and the headers.
+
+## Impact
+
+- `internal/ratelimit/throttler.go` — `Throttler.Allow` returns a `Decision`
+  carrying `Remaining`/`Limit`/`ResetAfter` instead of discarding what
+  `redis_rate` already computes; `Middleware` sets the headers and skips
+  trusted peers.
+- `internal/ratelimit/redis.go` — populate the new fields.
+- `internal/ratelimit/{keys,middleware,redis}_test.go` — four test fakes
+  implement the widened interface.
+- `internal/handler/{search,jobs,companies,geo}.go` — attach the two limiters.
+- `web/static/openapi.yaml` — document limits and headers.
+- No schema change, no migration, no reindex, no new dependency.
+
+**Deliberately not done here.** No tiering: an API key does not buy a higher
+ceiling. That is a monetization decision, and building the mechanism before the
+decision would be infrastructure ahead of need. The seam is free when it is
+wanted — the limiter already keys by user when a caller is authenticated, so a
+per-tier budget is a lookup where a constant is today.
+
+**Deliberately not done here.** No fail2ban jail for the API. A ban must come
+*after* a published ceiling and a header telling callers what it is, never
+before: the first client a 24-hour ban would catch is the conscientious
+integrator who simply never had a number to respect.

--- a/openspec/changes/rate-limit-public-reads/specs/api-rate-limiting/spec.md
+++ b/openspec/changes/rate-limit-public-reads/specs/api-rate-limiting/spec.md
@@ -1,0 +1,136 @@
+## ADDED Requirements
+
+### Requirement: Rate-limit budget headers on every limited response
+
+Every response from a rate-limited route SHALL carry `X-RateLimit-Limit`,
+`X-RateLimit-Remaining` and `X-RateLimit-Reset`, on success as well as on
+rejection.
+
+The headers exist so a ceiling can be respected rather than merely discovered.
+A limit disclosed only in the 429 that enforces it tells a client what it did
+wrong after the request has already failed; a client that can read its remaining
+budget can slow down before that point. `X-RateLimit-Reset` SHALL be whole
+seconds until the caller's budget is full again, and `X-RateLimit-Remaining` the
+count of further requests permitted in the current window.
+
+The backend already computes all three values on every check. They SHALL be
+carried through the `Throttler` contract rather than recomputed or estimated in
+the middleware, so a caller's remaining budget can never disagree with the
+decision that produced it.
+
+A request allowed because the backend failed (see *Fail-open on backend error*)
+SHALL carry no rate-limit headers. No check happened, so there is no budget to
+report, and reporting a fabricated one would be worse than silence.
+
+#### Scenario: Headers accompany an allowed request
+
+- **WHEN** a caller makes a request to a rate-limited route while within its budget
+- **THEN** the response is the route's normal success response and additionally
+  carries `X-RateLimit-Limit`, `X-RateLimit-Remaining` and `X-RateLimit-Reset`
+
+#### Scenario: Remaining decreases across successive requests
+
+- **WHEN** a caller makes two successive requests to the same rate-limited route
+  inside one window
+- **THEN** the `X-RateLimit-Remaining` on the second response is lower than on the
+  first
+
+#### Scenario: Headers accompany a rejection
+
+- **WHEN** a caller exceeds a route's limit
+- **THEN** the `429` response carries `Retry-After` as before, and additionally
+  `X-RateLimit-Limit`, `X-RateLimit-Remaining` and `X-RateLimit-Reset`
+
+#### Scenario: A fail-open response reports no budget
+
+- **WHEN** the rate-limit backend errors or times out and the request is allowed
+  through
+- **THEN** the response carries none of the `X-RateLimit-*` headers
+
+### Requirement: Public read endpoints are rate-limited by cost class
+
+The public, unauthenticated read endpoints SHALL enforce a request budget, split
+into two classes by the cost of serving them.
+
+The ordinary reads — job search, job facets, a single job, similar jobs, company
+search, a single company, and city lookup — SHALL share one budget. The
+agent-oriented job search SHALL have its own, smaller budget, because it
+rehydrates every result's full description from the database and so costs
+several times more per request in both bytes and latency than any other read. A
+single shared budget would have to be sized for the expensive endpoint, and
+would then throttle the cheap ones far harder than their cost justifies.
+
+Each budget SHALL be namespaced separately, so exhausting one leaves the other
+untouched, and SHALL identify an authenticated caller by user rather than by
+address — not to grant a larger allowance, which this change does not do, but so
+that callers sharing an egress address do not share an allowance.
+
+#### Scenario: Exhausting the agent search budget leaves ordinary search available
+
+- **WHEN** a caller exhausts the budget for the agent job-search endpoint
+- **THEN** their next request to the ordinary job-search endpoint is still served
+
+#### Scenario: A caller over the public read budget is refused
+
+- **WHEN** an external caller exceeds a public read budget within its window
+- **THEN** the response is `429 Too Many Requests` with `Retry-After` and the
+  rate-limit headers
+
+#### Scenario: Two callers do not share an allowance
+
+- **WHEN** two distinct callers each make requests to the same public read endpoint
+- **THEN** neither caller's requests count against the other's budget
+
+### Requirement: Trusted internal callers are not rate-limited
+
+A request arriving from a loopback or private-network peer SHALL bypass
+rate-limit enforcement entirely, and SHALL carry no rate-limit headers.
+
+The server-rendered front end reaches the API directly over loopback rather than
+through the reverse proxy, and forwards no client-address header, so every
+server-rendered page presents the same peer address. Counting those requests
+would place the whole site in one caller's budget and throttle it as a single
+abusive client.
+
+The trusted set SHALL be exactly the proxy-trust list the server already uses to
+decide whether an address may assert a client address on another's behalf.
+Defining it twice invites the two to drift, and a peer trusted to speak for
+other callers is by construction not one this limit defends against.
+
+#### Scenario: A loopback caller is never refused
+
+- **WHEN** a request reaches a rate-limited route from a loopback address, in
+  volume far exceeding the route's configured limit
+- **THEN** every request is served, and none carries rate-limit headers
+
+#### Scenario: An external caller is still limited
+
+- **WHEN** a request reaches the same route from a public address that exceeds the
+  configured limit
+- **THEN** it is refused with `429`
+
+## MODIFIED Requirements
+
+### Requirement: Existing per-route limits preserved
+
+Migrating a route onto the shared backend SHALL NOT change its configured limit,
+window, or rejection status code, and SHALL NOT remove any header the route
+already sent.
+
+Adding the budget headers is additive: a route that answered `429` with
+`Retry-After` still answers `429` with `Retry-After`, and gains
+`X-RateLimit-*` alongside. No caller relying on the previous behaviour observes
+a regression; a caller ignoring the new headers is unaffected.
+
+#### Scenario: Request over the limit is rejected the same way
+
+- **WHEN** a caller exceeds a route's configured limit within its configured window
+- **THEN** the response is `429 Too Many Requests` with a `Retry-After` header, as it
+  was before migrating that route onto the shared backend
+
+#### Scenario: An existing limiter's configured budget is unchanged
+
+- **WHEN** a route that was rate-limited before this change is exercised up to and
+  past its limit
+- **THEN** it admits exactly the same number of requests in the same window as it
+  did before

--- a/openspec/changes/rate-limit-public-reads/specs/api-rate-limiting/spec.md
+++ b/openspec/changes/rate-limit-public-reads/specs/api-rate-limiting/spec.md
@@ -52,8 +52,13 @@ report, and reporting a fabricated one would be worse than silence.
 The public, unauthenticated read endpoints SHALL enforce a request budget, split
 into two classes by the cost of serving them.
 
-The ordinary reads — job search, job facets, a single job, similar jobs, company
-search, a single company, and city lookup — SHALL share one budget. The
+**Every** public job and company read SHALL share one budget — the job list, job
+search, job facets, a single job and its copies and apply form, similar jobs,
+company search and its vocabulary, a single company, and city lookup. The set is
+exhaustive by intent rather than by enumeration: leaving one read out would void
+the limit rather than narrow it, since the job list returns the same catalogue as
+job search, so an unbounded sibling is simply the door a throttled caller walks
+through instead. The
 agent-oriented job search SHALL have its own, smaller budget, because it
 rehydrates every result's full description from the database and so costs
 several times more per request in both bytes and latency than any other read. A

--- a/openspec/changes/rate-limit-public-reads/tasks.md
+++ b/openspec/changes/rate-limit-public-reads/tasks.md
@@ -26,9 +26,13 @@
 - [x] 3.1 Add the budget constants and their two key prefixes in one place, sized
       from the measured peaks recorded in design.md (cheap 600/min, agent 300/min),
       each carrying a comment naming the peak it was derived from
-- [x] 3.2 Attach the cheap limiter to `/jobs/search`, `/jobs/facets`,
-      `/jobs/{slug}`, `/jobs/{slug}/similar`, `/companies`, `/companies/{slug}`
-      and `/geo/cities`, keyed by `KeyByUserOrIP`
+- [x] 3.2 Attach the cheap limiter to EVERY public job and company read —
+      `/jobs`, `/jobs/find`, `/jobs/search`, `/jobs/facets`, `/jobs/{slug}` and
+      its `/copies` and `/apply-form`, `/jobs/{slug}/similar`, `/companies`,
+      `/companies/subindustries`, `/companies/{slug}` and `/geo/cities` — keyed
+      by `KeyByUserOrIP`. The sitemaps stay unlimited on purpose: they are the
+      polite bulk path, nginx-cached, and throttling them pushes crawlers back
+      onto the endpoints this change is protecting
 - [x] 3.3 Attach the expensive limiter to `/agent/jobs/search` alone, with its own
       prefix; test that exhausting it leaves the ordinary search endpoint serving
 - [x] 3.4 Log every refusal with the request path and user agent, so "who did this

--- a/openspec/changes/rate-limit-public-reads/tasks.md
+++ b/openspec/changes/rate-limit-public-reads/tasks.md
@@ -1,53 +1,53 @@
 ## 1. Carry the backend's numbers through the Throttler contract
 
-- [ ] 1.1 Introduce `ratelimit.Decision{Allowed, Limit, Remaining, ResetAfter,
+- [x] 1.1 Introduce `ratelimit.Decision{Allowed, Limit, Remaining, ResetAfter,
       RetryAfter}` and change `Throttler.Allow` to return `(Decision, error)`;
       update `RedisThrottler.Allow` to populate every field from
       `redis_rate.Result` rather than discarding `Remaining`/`ResetAfter`
-- [ ] 1.2 Update the four test fakes in `internal/ratelimit` to the widened
+- [x] 1.2 Update the four test fakes in `internal/ratelimit` to the widened
       interface, keeping each one's existing behaviour (in-memory counter,
       always-error, hang-past-timeout, sub-second retry)
-- [ ] 1.3 `Middleware` sets `X-RateLimit-Limit`/`Remaining`/`Reset` on both the
+- [x] 1.3 `Middleware` sets `X-RateLimit-Limit`/`Remaining`/`Reset` on both the
       allowed and the refused path, keeps `Retry-After` and its one-second floor
       on refusal, and sets no headers when it fails open — with a test per branch,
       including that `Remaining` decreases across two calls
 
 ## 2. Do not limit our own front end
 
-- [ ] 2.1 Lift the proxy-trust CIDR list out of `cmd/server/main.go` into
+- [x] 2.1 Lift the proxy-trust CIDR list out of `cmd/server/main.go` into
       `internal/ratelimit` as the single definition, and have `cmd/server` read it
       from there so the two cannot drift
-- [ ] 2.2 `Middleware` returns `c.Next()` without consulting the throttler when the
+- [x] 2.2 `Middleware` returns `c.Next()` without consulting the throttler when the
       peer is loopback or private, setting no headers; test that a loopback caller
       far over the limit is never refused while an external one still is
 
 ## 3. Attach the two public-read budgets
 
-- [ ] 3.1 Add the budget constants and their two key prefixes in one place, sized
+- [x] 3.1 Add the budget constants and their two key prefixes in one place, sized
       from the measured peaks recorded in design.md (cheap 600/min, agent 300/min),
       each carrying a comment naming the peak it was derived from
-- [ ] 3.2 Attach the cheap limiter to `/jobs/search`, `/jobs/facets`,
+- [x] 3.2 Attach the cheap limiter to `/jobs/search`, `/jobs/facets`,
       `/jobs/{slug}`, `/jobs/{slug}/similar`, `/companies`, `/companies/{slug}`
       and `/geo/cities`, keyed by `KeyByUserOrIP`
-- [ ] 3.3 Attach the expensive limiter to `/agent/jobs/search` alone, with its own
+- [x] 3.3 Attach the expensive limiter to `/agent/jobs/search` alone, with its own
       prefix; test that exhausting it leaves the ordinary search endpoint serving
-- [ ] 3.4 Log every refusal with the request path and user agent, so "who did this
+- [x] 3.4 Log every refusal with the request path and user agent, so "who did this
       catch" is answerable later without adding instrumentation after the fact
 
 ## 4. Publish the ceiling
 
-- [ ] 4.1 Document the two budgets, the three headers and `Retry-After` in
+- [x] 4.1 Document the two budgets, the three headers and `Retry-After` in
       `web/static/openapi.yaml`, in the same filter-grammar section that already
       warns about ignored parameters — a limit nobody can read about is the defect
       this change exists to fix
-- [ ] 4.2 State in the schema that a loopback/internal caller is exempt only to the
+- [x] 4.2 State in the schema that a loopback/internal caller is exempt only to the
       extent of saying the limits apply to public callers, without publishing the
       trust list itself
 
 ## 5. Verify against the case that prompted this
 
-- [ ] 5.1 A test asserting the agent-search budget admits more than the 184
+- [x] 5.1 A test asserting the agent-search budget admits more than the 184
       requests/minute the heaviest live consumer currently sends, so the change
       cannot silently cut off a caller it was designed to tolerate
-- [ ] 5.2 `go vet -tags=integration ./...` before pushing, and the full tagged
+- [x] 5.2 `go vet -tags=integration ./...` before pushing, and the full tagged
       suite for `internal/handler` and `internal/ratelimit` since behaviour changed

--- a/openspec/changes/rate-limit-public-reads/tasks.md
+++ b/openspec/changes/rate-limit-public-reads/tasks.md
@@ -1,0 +1,53 @@
+## 1. Carry the backend's numbers through the Throttler contract
+
+- [ ] 1.1 Introduce `ratelimit.Decision{Allowed, Limit, Remaining, ResetAfter,
+      RetryAfter}` and change `Throttler.Allow` to return `(Decision, error)`;
+      update `RedisThrottler.Allow` to populate every field from
+      `redis_rate.Result` rather than discarding `Remaining`/`ResetAfter`
+- [ ] 1.2 Update the four test fakes in `internal/ratelimit` to the widened
+      interface, keeping each one's existing behaviour (in-memory counter,
+      always-error, hang-past-timeout, sub-second retry)
+- [ ] 1.3 `Middleware` sets `X-RateLimit-Limit`/`Remaining`/`Reset` on both the
+      allowed and the refused path, keeps `Retry-After` and its one-second floor
+      on refusal, and sets no headers when it fails open — with a test per branch,
+      including that `Remaining` decreases across two calls
+
+## 2. Do not limit our own front end
+
+- [ ] 2.1 Lift the proxy-trust CIDR list out of `cmd/server/main.go` into
+      `internal/ratelimit` as the single definition, and have `cmd/server` read it
+      from there so the two cannot drift
+- [ ] 2.2 `Middleware` returns `c.Next()` without consulting the throttler when the
+      peer is loopback or private, setting no headers; test that a loopback caller
+      far over the limit is never refused while an external one still is
+
+## 3. Attach the two public-read budgets
+
+- [ ] 3.1 Add the budget constants and their two key prefixes in one place, sized
+      from the measured peaks recorded in design.md (cheap 600/min, agent 300/min),
+      each carrying a comment naming the peak it was derived from
+- [ ] 3.2 Attach the cheap limiter to `/jobs/search`, `/jobs/facets`,
+      `/jobs/{slug}`, `/jobs/{slug}/similar`, `/companies`, `/companies/{slug}`
+      and `/geo/cities`, keyed by `KeyByUserOrIP`
+- [ ] 3.3 Attach the expensive limiter to `/agent/jobs/search` alone, with its own
+      prefix; test that exhausting it leaves the ordinary search endpoint serving
+- [ ] 3.4 Log every refusal with the request path and user agent, so "who did this
+      catch" is answerable later without adding instrumentation after the fact
+
+## 4. Publish the ceiling
+
+- [ ] 4.1 Document the two budgets, the three headers and `Retry-After` in
+      `web/static/openapi.yaml`, in the same filter-grammar section that already
+      warns about ignored parameters — a limit nobody can read about is the defect
+      this change exists to fix
+- [ ] 4.2 State in the schema that a loopback/internal caller is exempt only to the
+      extent of saying the limits apply to public callers, without publishing the
+      trust list itself
+
+## 5. Verify against the case that prompted this
+
+- [ ] 5.1 A test asserting the agent-search budget admits more than the 184
+      requests/minute the heaviest live consumer currently sends, so the change
+      cannot silently cut off a caller it was designed to tolerate
+- [ ] 5.2 `go vet -tags=integration ./...` before pushing, and the full tagged
+      suite for `internal/handler` and `internal/ratelimit` since behaviour changed

--- a/web/static/openapi.yaml
+++ b/web/static/openapi.yaml
@@ -64,7 +64,9 @@ info:
     ceiling by hitting it:
 
     * `X-RateLimit-Limit` — the ceiling in force.
-    * `X-RateLimit-Remaining` — requests left in the current window.
+    * `X-RateLimit-Remaining` — requests left in the current window. The limiter
+      is a leaky bucket, not a counter, so this can trail your own request count
+      by one; treat it as a reading to pace against, not an exact ledger.
     * `X-RateLimit-Reset` — whole seconds until your budget is full again.
 
     Over the limit is `429` with `Retry-After` in whole seconds, alongside the

--- a/web/static/openapi.yaml
+++ b/web/static/openapi.yaml
@@ -48,6 +48,33 @@ info:
     live counts before filtering on them — an unknown value is not an error, it
     simply matches nothing.
 
+    ## Rate limits
+
+    These endpoints need no key, which is not the same as being free. Two
+    per-caller budgets apply, split by what a request costs to serve:
+
+    * **600 requests per minute** across the ordinary reads — `searchJobs`,
+      `getJobFacets`, `getJob`, `getSimilarJobs`, `searchCompanies`,
+      `getCompany` and `searchCities`, sharing one budget between them.
+    * **300 requests per minute** for `agentSearchJobs` alone, on its own
+      budget, because it rehydrates every result's full description. Exhausting
+      it does not touch the budget above.
+
+    Every response carries where you stand, so you never have to discover the
+    ceiling by hitting it:
+
+    * `X-RateLimit-Limit` — the ceiling in force.
+    * `X-RateLimit-Remaining` — requests left in the current window.
+    * `X-RateLimit-Reset` — whole seconds until your budget is full again.
+
+    Over the limit is `429` with `Retry-After` in whole seconds, alongside the
+    same three headers. **Read `X-RateLimit-Remaining` and slow down before you
+    are refused** — that is the whole reason it is sent on success too.
+
+    Rarely, a response carries no `X-RateLimit-*` at all. That means the limiter
+    could not run and let the request through rather than failing it; treat it as
+    "unknown", not as "unlimited".
+
     ## An unknown PARAMETER is dropped, and says so
 
     A parameter no filter reads is ignored rather than refused, so old saved


### PR DESCRIPTION
OpenSpec change: `rate-limit-public-reads`.

## Why

**The public read API had no rate limit at all.** All eighteen limiters in `internal/ratelimit` guard an auth route, a write, or an LLM spend. nginx applies `limit_req` to `location /` (the pages) and **not** to `location /api/`, and the `freehire-limit-req` fail2ban jail reads only the rejections that location produces.

Measured on production: **134 IPs currently banned** across the nginx jails, and **zero** of their requests ever touched `/api/v1/`. An API client could not be banned, because nothing observed it.

One consumer already lived in that gap — `ManyApplyAssist/6.0` at a steady **~180 req/min**, 59% of all API traffic in a 4.6-hour window, **100% of it on `/agent/jobs/search`**, the most expensive endpoint we serve. It is not misbehaving; it simply had no ceiling to respect and no way to learn one.

#2085 and #2092 made it urgent: `robots.txt` and `llms.txt` now tell crawlers to prefer the API over the HTML — steering traffic off the limited path onto the unlimited one. Correct advice that must not ship without the ceiling it assumes.

## What

**Two budgets, split by measured cost:**

| class | ceiling | measured peak/IP |
|---|---|---|
| every public job & company read | 600/min (= the 10 r/s nginx already gives the pages) | 258/min |
| `agentSearchJobs` alone | 300/min | 184/min |

`agent/jobs/search` rehydrates every hit's full description — ~833 KB / ~1.3 s at `limit=100` against ~123 KB / ~0.55 s for the ordinary search. One shared budget would be sized for it and would throttle facet lookups 7× harder than their cost warrants.

**`X-RateLimit-Limit` / `-Remaining` / `-Reset` on every limited response**, success included — that is what makes a ceiling respectable rather than merely punitive. This required widening `Throttler.Allow` to return a `Decision`: `redis_rate` already computed `Remaining` and `ResetAfter` in the same round trip and we discarded both. **All eighteen existing limiters get the headers too.**

**Trusted peers skip the limiter.** Without this the change is an outage, not a feature: SSR reaches the API at `http://127.0.0.1:8081`, bypassing nginx with no `X-Real-IP`, so `c.IP()` is `127.0.0.1` for every server-rendered page and the whole site would share one bucket. The CIDR list moves into `internal/ratelimit` as the single definition; `cmd/server` reads it from there, because a peer trusted to assert another's address is by construction not one this limit defends against.

**`openapi.yaml` documents both budgets, all three headers and the 429 contract** — closing the gap an integrator named in writing: *"no SLA and no rate-limit header of any kind."* It also says what an *absent* header means: the limiter could not run and let the request through — "unknown", not "unlimited".

## Deliberately not done

- **No tiering.** An API key does not buy a higher ceiling; that is a monetization decision and the mechanism is free when it is wanted (the limiter already keys by user when authenticated).
- **No fail2ban jail for the API.** A ban must come *after* a published ceiling, never before — the first client a 24-hour ban would catch is the conscientious integrator who never had a number to respect.
- **Sitemaps stay unlimited.** They are the polite bulk path, nginx-cached; a crawler refused there returns to the endpoints this protects.

## Two defects caught in review

- **Truncation vs rounding.** Swapping `fmt.Sprintf("%.0f")` for `strconv.Itoa(int(...))` turned rounding into truncation, so a 1.7 s wait would have gone out as `"1"` and invited a retry a second early into the denial just issued. Both wait-naming headers now round up through one helper, with a test at 1.7 s.
- **`/api/v1/jobs` was left unlimited** — and it returns the same catalogue as `/jobs/search`, paginated. A caller throttled on search would simply have used the list. Every public job and company read now shares the budget, and the spec states it as a rule rather than a list, since an enumerated set is what invited the gap.

## Testing

RED→GREEN per task. New tests: headers on allow / on 429 / absent on fail-open, `Remaining` decreasing, `Retry-After` rounding up, the real (miniredis) backend actually populating the fields, loopback and private peers never limited while external ones still are, the two budgets not sharing a key, and the ceilings clearing the measured live peaks so this cannot silently cut off the caller it was designed to tolerate.

A first draft of the peer tests passed for the wrong reason — Fiber's `app.Test` ignores `httptest`'s `RemoteAddr` and always reports `0.0.0.0`, so loopback and external were indistinguishable. They now drive `c.IP()` through a proxy header, which is how it resolves in production.

`gofmt`, `go vet`, `go test ./...`, `go vet -tags=integration ./...`, `golangci-lint` (0 issues), `govulncheck` all clean. `redocly lint` valid.

**Review note:** CodeRabbit hit its own rate limit on the final pass (44-minute wait), so the last review is mine rather than the tool's — the `/api/v1/jobs` gap above is what it turned up. Worth a second pass before merge.