### PR TITLE
Add a Redis pause switch for the cron worker fleet

### DIFF
--- a/docs/superpowers/specs/2026-08-18-worker-pause-switch-design.md
+++ b/docs/superpowers/specs/2026-08-18-worker-pause-switch-design.md
@@ -1,0 +1,221 @@
+# Worker pause switch: a Redis kill switch for the cron fleet
+
+Date: 2026-08-18
+Status: approved, not implemented
+
+## Why
+
+host-2 is disk-bound, not CPU-bound. Measured on 2026-08-18 at 04:15 UTC while a full
+Meilisearch rebuild was running:
+
+```
+io  full avg60 = 28%
+cpu full avg60 =  0%
+```
+
+Read attribution over a 20-second window put the ingest backends at ~56 MB/s of ~212 MB/s
+total — roughly a quarter of all disk reads, and more than three times what the nightly
+`pg_dump` was taking. When a catalogue-wide backfill, a reindex, and the ingest fleet
+overlap, the only lever an operator has today is to stop ~140 systemd timers by hand and
+remember to start them again.
+
+That lever is bad in the specific way that matters: it is slow to pull under pressure, and
+it leaves state on the host that no one can see from the dashboard. A stopped timer looks
+exactly like a healthy timer that has not fired yet.
+
+This change adds one switch that sheds load from the whole cron fleet in a single command,
+carries its own expiry, and is visible in Prometheus while it is held.
+
+## What already exists
+
+Do not rebuild any of this.
+
+| Component | Location |
+|---|---|
+| Single worker entrypoint | `internal/worker/main.go` — `Main(run func() int)` wraps every one of the ~40 `cmd/` binaries |
+| Shared setup | `internal/worker/bootstrap.go` — `Bootstrap` does Sentry init, `config.Load()`, signal context, pgx pool |
+| Redis client and URL | `github.com/redis/go-redis/v9`; `config.Settings.RedisURL`, defaulting to `redis://localhost:6379/0` (`internal/config/config.go:325`) |
+| Per-run metrics | `internal/worker/metrics.go` — `writeRunMetrics` publishes `freehire_worker_last_run_{timestamp_seconds,duration_seconds,success}` into `PROM_TEXTFILE_DIR` |
+| Worker identity | `filepath.Base(os.Args[0])` for the job label; `runInstance(os.Args[1:])` for the per-board instance label |
+| Atomic textfile publish | `worker.WriteTextfile` — write-then-rename |
+| Ingest concurrency cap | `/opt/freehire/bin/ingest-slot.sh`, a counting `flock` semaphore, `INGEST_SLOTS=10` |
+
+The ingest semaphore already bounds how many boards crawl at once. It cannot express "stop",
+and it only governs ingest. This change is the orthogonal control: not *how many*, but
+*whether at all*, across every worker.
+
+## Scope
+
+In scope: refusing to *start* a worker run.
+
+Out of scope: stopping a run already in flight. A heavy ingest board runs up to ~50 minutes,
+so the switch does not reclaim the host instantly — it stops the bleeding and lets the
+current runs drain. Cancelling live work would mean trusting ~40 workers to unwind a
+mid-run context correctly, which is a much larger claim to make and to test. The seam is
+noted, not built: `Bootstrap` already derives a SIGINT/SIGTERM-cancellable context, so a
+future poll-and-cancel has an obvious place to attach.
+
+## Design
+
+### Where the check lives
+
+In `Main`, before `run()` is called — not in `Bootstrap`.
+
+```go
+func Main(run func() int) {
+    defer capturePanic()
+    if paused(workerJob()) {
+        writePausedMetrics()
+        os.Exit(0)
+    }
+    start := time.Now()
+    code := run()
+    writeRunMetrics(time.Since(start), code)
+    os.Exit(code)
+}
+```
+
+`Bootstrap` is the wrong place because it reports failure by returning an error, and every
+worker answers an error with `return 1`. A pause is not a failure; surfacing it as one would
+make every held switch page someone.
+
+Putting it in `Main` also means a paused run costs exactly one Redis `GET`. Sentry is never
+initialized and the pgx pool is never opened.
+
+### Keys
+
+Two keys are consulted, and either one holds the worker:
+
+```
+freehire:pause:all         # every worker
+freehire:pause:<job>       # one binary, e.g. freehire:pause:ingest
+```
+
+`<job>` is the binary name — the same string already used as the `job` metric label. The
+per-board `instance` label is deliberately *not* part of the key: pausing a single ingest
+board is a job for that board's timer, not for an incident switch.
+
+Presence is the signal; the value is ignored. Callers are expected to set a TTL:
+
+```bash
+# shed the whole fleet for three hours
+redis-cli SET freehire:pause:all 1 EX 10800
+
+# or just the loudest tenant
+redis-cli SET freehire:pause:ingest 1 EX 10800
+
+# lift early
+redis-cli DEL freehire:pause:all
+```
+
+The TTL is a convention, not an enforcement. `SET` without `EX` is accepted — refusing it
+would mean the switch could fail at the moment it is most needed. The forgotten-switch case
+is handled by making the pause visible (below) rather than by making it un-settable.
+
+### Manual override
+
+`FREEHIRE_IGNORE_PAUSE=1` in the environment skips the check entirely.
+
+systemd timer units do not carry it, so the override only admits what a human started by
+hand. This is the operating mode the switch exists for: hold the fleet, then run one thing
+under a quiet host.
+
+```bash
+redis-cli SET freehire:pause:all 1 EX 10800
+FREEHIRE_IGNORE_PAUSE=1 /opt/freehire/src/hire-current/backfill-derive
+```
+
+### Redis unreachable means run
+
+The check fails open. A Redis error, a timeout, or an unparseable URL logs one line and the
+worker proceeds with its normal run.
+
+The inverse would convert an optional convenience into a single point of failure for the
+entire catalogue: one Redis blip and all ~40 workers stop, silently, with the dashboard
+reporting clean exits. `cmd/server` may depend on Redis hard — there it backs rate limiting,
+without which the API must not serve — but nothing about shedding load justifies that
+coupling.
+
+The check takes a short timeout (250ms) so an unhealthy Redis delays a worker by a bounded
+amount rather than by its dial default.
+
+### Metric
+
+One file per worker, as today. `RunMetricsFilename()` is unchanged, so no second textfile is
+introduced and the "one worker, one filename" rule in `internal/worker/AGENTS.md` still
+holds.
+
+| Run | File contents |
+|---|---|
+| Normal | the `last_run_*` triple, plus `freehire_worker_paused{...} 0` |
+| Paused | `freehire_worker_paused{...} 1` alone |
+
+While a pause is held, `freehire_worker_last_run_timestamp_seconds` stops advancing and ages.
+Any age-based rule eventually fires — and that is the intended safety net for a switch
+someone forgot to lift. `freehire_worker_paused` sitting at 1 beside it is what tells the
+person paged that the silence was deliberate.
+
+This deliberately rejects the alternative of exiting 0 and stamping a successful run.
+`freehire-reindexw` already demonstrated that failure mode on this host: a skipped cycle
+recorded as a success kept the dashboard green while the index went stale for days.
+
+Both gauges carry the existing `job` and `instance` labels, and both are therefore subject
+to the documented `exported_job` rename by node_exporter's textfile collector. Any query
+must use `exported_job`, not `job`.
+
+### Out-of-repo work
+
+`freehire_worker_paused` becomes part of the metric-name contract with the Grafana dashboard
+and alert rules in `freehire-ops`, which cannot be compiled against this repository. Adding
+the gauge here does not make it visible there. The ops-side change is:
+
+1. Surface `freehire_worker_paused` on the worker panel.
+2. Add the paused state to the existing worker-staleness rule's annotation, so a page for a
+   stale worker says whether a switch is held.
+
+Treat this as part of shipping the feature, not as a follow-up.
+
+## Components
+
+| Unit | Responsibility | Depends on |
+|---|---|---|
+| `internal/worker/pause.go` | Decide whether this process may run: read the two keys, honour the override, fail open | `config.Settings.RedisURL`, `go-redis` |
+| `internal/worker/metrics.go` | Publish `freehire_worker_paused` alongside the existing triple | `WriteTextfile` |
+| `internal/worker/main.go` | Wire the decision in before `run()` | the two above |
+
+The pause decision is a pure function of (job name, override env, Redis contents), so it can
+be tested against `miniredis` — already a dependency — without a live Redis or a worker.
+
+## Testing
+
+Unit, against `miniredis`:
+
+- No keys set: the worker runs.
+- `freehire:pause:all` set: the worker is held.
+- `freehire:pause:ingest` set: `ingest` is held, `search-drain` runs.
+- `FREEHIRE_IGNORE_PAUSE=1` with `freehire:pause:all` set: the worker runs.
+- Redis unreachable: the worker runs, and the failure is logged.
+- Redis slow past the timeout: the worker runs.
+
+Metrics, against a temp directory:
+
+- A paused run writes `freehire_worker_paused 1` and no `last_run_*` series.
+- A normal run writes the `last_run_*` triple and `freehire_worker_paused 0`.
+- Both land in `RunMetricsFilename()`, with the exposition text pinned the way
+  `cmd/queue-metrics/render_test.go` pins its own — a rename must be a visible edit.
+
+## Risks
+
+**A held switch is invisible outside Prometheus.** Someone reading `systemctl list-timers`
+sees a healthy fleet that is doing nothing. Mitigated by the paused gauge; not eliminated.
+The `EX` convention is the practical defence.
+
+**Load is shed with a lag.** In-flight runs finish. On a host where the heaviest ingest
+boards run ~50 minutes, the switch is a way to stop the queue from refilling, not a way to
+free the disk in the next minute.
+
+## Related
+
+- `internal/worker/AGENTS.md` — the metrics filename rule and the `exported_job` trap
+- `docs/superpowers/specs/2026-08-15-ingest-observability-design.md` — the queue-depth
+  metrics this gauge sits beside

--- a/internal/worker/AGENTS.md
+++ b/internal/worker/AGENTS.md
@@ -42,6 +42,41 @@ the exit-code convention, a progress heartbeat, and a corruption-tolerant keyset
   (openspec/changes/drop-hybrid-search-pgvector-similar) — re-add the pattern if a future
   worker genuinely needs a scoped scan, rather than resurrecting the old one blind.
 
+## The pause switch
+
+`Main` consults Redis before calling `run`, so a single command sheds load from the whole
+cron fleet. It refuses to START a run; a run already in flight is never interrupted, and the
+heaviest ingest boards take ~50 minutes to drain.
+
+```bash
+redis-cli SET freehire:pause:all 1 EX 10800     # hold everything for three hours
+redis-cli SET freehire:pause:ingest 1 EX 10800  # hold one binary
+redis-cli DEL freehire:pause:all                # lift early
+
+FREEHIRE_IGNORE_PAUSE=1 ./backfill-derive       # run one thing against the held fleet
+```
+
+- **Presence is the signal**; the value is ignored, so the key can carry a note to whoever
+  finds it. `<binary>` is `filepath.Base(os.Args[0])` — the same string as the `job` metric
+  label, so the key you type matches the label you read.
+- **The key names the binary, never the board.** One `freehire:pause:ingest` holds all ~140
+  ingest timers. Holding a single board is that board's timer's job.
+- **`EX` is a convention, not enforced.** A switch that could refuse to be set would fail at
+  the moment it is most needed; the forgotten-switch case is handled by visibility instead.
+- **`FREEHIRE_IGNORE_PAUSE` is parsed as a boolean**, unlike the keys — an operator who wrote
+  `=0` means the opposite of a bypass. systemd timer units do not carry it, so it admits only
+  a hand-started run.
+- **It fails open.** An unreachable Redis, a malformed URL, or a reply slower than 250ms logs
+  one line and the worker runs. A facility for shedding load must never become the reason the
+  catalogue stops updating.
+- **The budget is on the go-redis client, not only on the context.** go-redis applies its own
+  5s `DialTimeout` and retries three times with backoff, so a `context.WithTimeout` alone lets
+  a silent Redis stall every worker start for far longer than the deadline suggests.
+- **`EXISTS` is called with both keys at once, which is a multi-key command.** Correct against
+  the single Redis this runs on; on a cluster the two keys hash to different slots and the
+  reply is a CROSSSLOT error, which fails open — meaning the switch would silently never hold.
+  Split the lookup before moving Redis to a cluster.
+
 ## Prometheus metrics
 
 A run-once worker has no listener for Prometheus to scrape, so metrics go out as
@@ -69,6 +104,19 @@ its payload and then overwrite it, leaving the collector with only the run outco
 the setup still looks correct. `RunMetricsFilename()` exposes the name to compare
 against; `cmd/queue-metrics` publishes as `freehire-pipeline.prom` and asserts the two
 cannot converge.
+
+**`freehire_worker_paused` reports whether the switch held this run** — published by BOTH
+writers, so it is a live 0/1 signal rather than one that merely stops being written. A refused
+run publishes it as `1` and publishes NO `last_run_*` series, deliberately: the last-run
+timestamp then ages, an existing staleness rule eventually fires for a switch nobody lifted,
+and the paused gauge beside it identifies the silence as intentional. Do not "fix" this by
+stamping a refused run as a success — that is exactly how `freehire-reindexw`'s skipped cycles
+stayed invisible while the search index went stale for days.
+
+Both renderings are pinned verbatim by `metrics_test.go`, the way `cmd/queue-metrics` pins its
+own, because the names are a contract with dashboards and alert rules in `freehire-ops` that
+cannot be compiled against this repo. **Adding the gauge here does not surface it there** — the
+ops-side panel and the staleness rule's annotation are part of shipping a change to it.
 
 **The `exported_job` trap.** node_exporter's textfile collector does not set
 `honor_labels`, so Prometheus keeps its own `job="host2-node"` and renames a worker's

--- a/internal/worker/main.go
+++ b/internal/worker/main.go
@@ -1,10 +1,14 @@
 package worker
 
 import (
+	"context"
+	"log"
 	"os"
 	"time"
 
 	"github.com/getsentry/sentry-go"
+
+	"github.com/strelov1/freehire/internal/config"
 )
 
 // panicFlushTimeout bounds how long capturePanic waits to deliver a fatal panic
@@ -15,7 +19,10 @@ const panicFlushTimeout = 2 * time.Second
 // os.Exit(run()). On the normal path it times the run, writes it to
 // PROM_TEXTFILE_DIR (see writeRunMetrics — a no-op when unset), and exits with
 // run's status; Sentry was already flushed by Bootstrap's cleanup, which run
-// defers. If run panics, the deferred capturePanic reports the panic to Sentry,
+// defers. Before any of that it consults the pause switch (see runOrPause), so a
+// held fleet exits zero without run being called at all.
+//
+// If run panics, the deferred capturePanic reports the panic to Sentry,
 // flushes it, and re-panics so the process still crashes with the original stack
 // and a non-zero exit code — the metrics write is skipped on that path, since
 // Main never regains control to reach it.
@@ -25,10 +32,27 @@ const panicFlushTimeout = 2 * time.Second
 // as those paths already log and exit non-zero.
 func Main(run func() int) {
 	defer capturePanic()
+	os.Exit(runOrPause(run))
+}
+
+// runOrPause consults the pause switch and, unless it is held, times the run and
+// publishes its outcome. It returns the process's exit status.
+//
+// The gate sits here rather than in Bootstrap because Bootstrap reports failure
+// by returning an error and every worker answers an error with a non-zero exit —
+// a pause is an operator's decision, not a failure, and must not page anyone.
+// Refusing here also means a held run costs one Redis GET: Sentry is never
+// initialized and the database pool is never opened.
+func runOrPause(run func() int) int {
+	if Paused(context.Background(), config.Load().RedisURL, workerJob()) {
+		log.Printf("worker: %s is paused, skipping this run", workerJob())
+		writePausedMetrics()
+		return 0
+	}
 	start := time.Now()
 	code := run()
 	writeRunMetrics(time.Since(start), code)
-	os.Exit(code)
+	return code
 }
 
 // capturePanic, deferred by Main, reports an in-flight panic to Sentry, flushes,

--- a/internal/worker/main_test.go
+++ b/internal/worker/main_test.go
@@ -2,6 +2,9 @@ package worker
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +20,65 @@ func (t *recordingTransport) SendEvent(e *sentry.Event)             { t.events =
 func (t *recordingTransport) Flush(time.Duration) bool              { return true }
 func (t *recordingTransport) FlushWithContext(context.Context) bool { return true }
 func (t *recordingTransport) Close()                                {}
+
+// A held switch must stop the work itself, not merely tidy up after it: the run
+// function is the thing that opens pools and crawls boards, so "paused" is only
+// true if it is never called.
+func TestRunOrPauseSkipsTheRunWhenHeld(t *testing.T) {
+	mr, url := newPauseRedis(t)
+	hold(t, mr, "freehire:pause:all")
+	t.Setenv("REDIS_URL", url)
+	dir := t.TempDir()
+	t.Setenv(PromTextfileDirEnv, dir)
+
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"/opt/freehire/src/hire-current/ingest", "sources/eightfold.yml"}
+
+	called := false
+	code := runOrPause(func() int {
+		called = true
+		return 3
+	})
+
+	if called {
+		t.Error("the run function was called while the switch was held")
+	}
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0 — a pause is an operator's decision, not a failure", code)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "ingest_eightfold.prom"))
+	if err != nil {
+		t.Fatalf("read metrics file: %v", err)
+	}
+	if !strings.Contains(string(data), `freehire_worker_paused{job="ingest",instance="eightfold"} 1`) {
+		t.Errorf("a refused run did not publish the paused gauge; got:\n%s", string(data))
+	}
+}
+
+func TestRunOrPauseRunsAndReportsWhenClear(t *testing.T) {
+	_, url := newPauseRedis(t)
+	t.Setenv("REDIS_URL", url)
+	dir := t.TempDir()
+	t.Setenv(PromTextfileDirEnv, dir)
+
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"/opt/freehire/src/hire-current/embed"}
+
+	code := runOrPause(func() int { return 3 })
+
+	if code != 3 {
+		t.Errorf("exit code = %d, want 3 — the run's own status must survive", code)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "embed.prom"))
+	if err != nil {
+		t.Fatalf("read metrics file: %v", err)
+	}
+	if !strings.Contains(string(data), `freehire_worker_last_run_success{job="embed"} 0`) {
+		t.Errorf("a completed run did not publish its outcome; got:\n%s", string(data))
+	}
+}
 
 // A panic flowing through the worker guard must be reported to Sentry AND
 // re-raised, so the process still crashes with the original stack and non-zero exit.

--- a/internal/worker/metrics.go
+++ b/internal/worker/metrics.go
@@ -32,13 +32,7 @@ func writeRunMetrics(runDuration time.Duration, exitCode int) {
 	if dir == "" {
 		return
 	}
-	job := filepath.Base(os.Args[0])
-	instance := runInstance(os.Args[1:])
-
-	labels := fmt.Sprintf(`job=%q`, job)
-	if instance != "" {
-		labels = fmt.Sprintf(`job=%q,instance=%q`, job, instance)
-	}
+	labels := metricLabels()
 
 	success := 0
 	if exitCode == 0 {
@@ -54,11 +48,50 @@ freehire_worker_last_run_duration_seconds{%[1]s} %[3]f
 # HELP freehire_worker_last_run_success Whether the worker's last run exited zero (1) or not (0).
 # TYPE freehire_worker_last_run_success gauge
 freehire_worker_last_run_success{%[1]s} %[4]d
-`, labels, time.Now().Unix(), runDuration.Seconds(), success)
+`, labels, time.Now().Unix(), runDuration.Seconds(), success) + pausedGauge(labels, 0)
 
+	publishRunFile(dir, content)
+}
+
+// writePausedMetrics records that the pause switch refused this run, if
+// PROM_TEXTFILE_DIR is set. It publishes the paused gauge ALONE: the last-run
+// series are deliberately left to age, so an existing staleness rule still fires
+// for a switch nobody lifted, while this gauge beside it identifies the silence
+// as deliberate rather than broken.
+func writePausedMetrics() {
+	dir := os.Getenv(PromTextfileDirEnv)
+	if dir == "" {
+		return
+	}
+	publishRunFile(dir, pausedGauge(metricLabels(), 1))
+}
+
+// metricLabels renders the label set both writers share: the running binary's
+// name, plus the board instance when the invocation carries one.
+func metricLabels() string {
+	job := filepath.Base(os.Args[0])
+	if instance := runInstance(os.Args[1:]); instance != "" {
+		return fmt.Sprintf(`job=%q,instance=%q`, job, instance)
+	}
+	return fmt.Sprintf(`job=%q`, job)
+}
+
+// publishRunFile writes this process's metrics file. Errors are logged, not
+// fatal — a metrics file failing to write must not fail the worker's actual job.
+func publishRunFile(dir, content string) {
 	if err := WriteTextfile(dir, RunMetricsFilename(), content); err != nil {
 		log.Printf("worker: %v", err)
 	}
+}
+
+// pausedGauge renders the freehire_worker_paused series, which reports whether
+// the pause switch held this run back. It is published by both writers so the
+// gauge is a live 0/1 signal rather than one that merely stops being written.
+func pausedGauge(labels string, held int) string {
+	return fmt.Sprintf(`# HELP freehire_worker_paused Whether the pause switch held this worker's run back (1) or not (0).
+# TYPE freehire_worker_paused gauge
+freehire_worker_paused{%s} %d
+`, labels, held)
 }
 
 // RunMetricsFilename reports the textfile-collector file this process's run

--- a/internal/worker/metrics_test.go
+++ b/internal/worker/metrics_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -137,6 +138,126 @@ func TestWriteRunMetricsWritesExpectedSeries(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dir, "ingest_eightfold.prom.tmp")); !os.IsNotExist(err) {
 		t.Errorf("expected the .tmp file to be gone after rename, stat err: %v", err)
 	}
+}
+
+// A completed run clears the paused gauge rather than omitting it, so the series
+// is a live signal an alert can read as "not held" instead of one that merely
+// stops being written.
+func TestWriteRunMetricsClearsThePausedGauge(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(PromTextfileDirEnv, dir)
+
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"/opt/freehire/src/hire-current/ingest", "sources/eightfold.yml"}
+
+	writeRunMetrics(time.Second, 0)
+
+	data, err := os.ReadFile(filepath.Join(dir, "ingest_eightfold.prom"))
+	if err != nil {
+		t.Fatalf("read metrics file: %v", err)
+	}
+	if want := `freehire_worker_paused{job="ingest",instance="eightfold"} 0`; !strings.Contains(string(data), want) {
+		t.Errorf("metrics file missing %q; got:\n%s", want, string(data))
+	}
+}
+
+// A refused run must not refresh the last-run series. Leaving them to age is what
+// keeps an existing staleness alert firing for a switch nobody lifted; stamping a
+// refused run as a success is the failure mode that kept reindexw's skipped cycles
+// invisible for days.
+func TestWritePausedMetricsPublishesOnlyThePausedGauge(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(PromTextfileDirEnv, dir)
+
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"/opt/freehire/src/hire-current/ingest", "sources/eightfold.yml"}
+
+	writePausedMetrics()
+
+	data, err := os.ReadFile(filepath.Join(dir, "ingest_eightfold.prom"))
+	if err != nil {
+		t.Fatalf("read metrics file: %v", err)
+	}
+	got := string(data)
+
+	if want := `freehire_worker_paused{job="ingest",instance="eightfold"} 1`; !strings.Contains(got, want) {
+		t.Errorf("metrics file missing %q; got:\n%s", want, got)
+	}
+	if strings.Contains(got, "freehire_worker_last_run") {
+		t.Errorf("a refused run refreshed the last-run series; got:\n%s", got)
+	}
+}
+
+func TestWritePausedMetricsDisabledWithoutEnv(t *testing.T) {
+	t.Setenv(PromTextfileDirEnv, "")
+	writePausedMetrics()
+}
+
+// The exact text below is the contract the freehire-ops dashboard and alert rules
+// bind to. Renaming a metric or a label here silently breaks queries in another
+// repository that cannot be compiled against this one, so both outputs are pinned
+// in full rather than spot-checked. The run timestamp is the one value that cannot
+// be pinned, so it is normalised before comparison.
+const (
+	wantCompletedRunRender = `# HELP freehire_worker_last_run_timestamp_seconds Unix time the worker last finished a run.
+# TYPE freehire_worker_last_run_timestamp_seconds gauge
+freehire_worker_last_run_timestamp_seconds{job="ingest",instance="eightfold"} STAMP
+# HELP freehire_worker_last_run_duration_seconds How long the worker's last run took, in seconds.
+# TYPE freehire_worker_last_run_duration_seconds gauge
+freehire_worker_last_run_duration_seconds{job="ingest",instance="eightfold"} 2.500000
+# HELP freehire_worker_last_run_success Whether the worker's last run exited zero (1) or not (0).
+# TYPE freehire_worker_last_run_success gauge
+freehire_worker_last_run_success{job="ingest",instance="eightfold"} 1
+# HELP freehire_worker_paused Whether the pause switch held this worker's run back (1) or not (0).
+# TYPE freehire_worker_paused gauge
+freehire_worker_paused{job="ingest",instance="eightfold"} 0
+`
+
+	wantPausedRunRender = `# HELP freehire_worker_paused Whether the pause switch held this worker's run back (1) or not (0).
+# TYPE freehire_worker_paused gauge
+freehire_worker_paused{job="ingest",instance="eightfold"} 1
+`
+)
+
+var runStamp = regexp.MustCompile(`(freehire_worker_last_run_timestamp_seconds\{[^}]*\} )\d+`)
+
+func readRunFile(t *testing.T, dir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, "ingest_eightfold.prom"))
+	if err != nil {
+		t.Fatalf("read metrics file: %v", err)
+	}
+	return runStamp.ReplaceAllString(string(data), "${1}STAMP")
+}
+
+func TestMetricsRenderMatchesThePublishedContract(t *testing.T) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"/opt/freehire/src/hire-current/ingest", "sources/eightfold.yml"}
+
+	t.Run("completed run", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv(PromTextfileDirEnv, dir)
+
+		writeRunMetrics(2500*time.Millisecond, 0)
+
+		if got := readRunFile(t, dir); got != wantCompletedRunRender {
+			t.Errorf("completed-run render mismatch:\ngot:\n%s\nwant:\n%s", got, wantCompletedRunRender)
+		}
+	})
+
+	t.Run("refused run", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv(PromTextfileDirEnv, dir)
+
+		writePausedMetrics()
+
+		if got := readRunFile(t, dir); got != wantPausedRunRender {
+			t.Errorf("refused-run render mismatch:\ngot:\n%s\nwant:\n%s", got, wantPausedRunRender)
+		}
+	})
 }
 
 func TestWriteRunMetricsWithoutInstance(t *testing.T) {

--- a/internal/worker/pause.go
+++ b/internal/worker/pause.go
@@ -1,0 +1,91 @@
+package worker
+
+import (
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// pauseAllKey holds the entire cron fleet, and pauseKeyPrefix + a binary name
+// holds one worker. Presence is the signal; the stored value is ignored, so an
+// operator can leave themselves a note in it.
+const (
+	pauseKeyPrefix = "freehire:pause:"
+	pauseAllKey    = pauseKeyPrefix + "all"
+)
+
+// pauseTimeout bounds the switch lookup. An unhealthy-but-reachable Redis must
+// delay a worker's start by a known amount rather than by go-redis's dial
+// default — the switch is a convenience, and a convenience may not decide how
+// long the catalogue waits.
+const pauseTimeout = 250 * time.Millisecond
+
+// IgnorePauseEnv names the environment variable that bypasses the pause switch.
+// systemd timer units do not carry it, so it admits only a run an operator
+// started by hand — which is the point: hold the fleet, then run one thing
+// against a quiet host.
+//
+// Parsed as a boolean rather than treated as present-or-absent, unlike the keys
+// themselves: an operator who wrote =0 means the opposite of a bypass, and
+// reading that as one would run the very fleet they just held.
+const IgnorePauseEnv = "FREEHIRE_IGNORE_PAUSE"
+
+// Paused reports whether an external switch is holding this worker back, where
+// job is the worker binary's name. It answers only "may this run start"; a run
+// already in flight is never interrupted.
+func Paused(ctx context.Context, redisURL, job string) bool {
+	if ignore, err := strconv.ParseBool(os.Getenv(IgnorePauseEnv)); err == nil && ignore {
+		return false
+	}
+
+	held, err := switchHeld(ctx, redisURL, job)
+	if err != nil {
+		// Fail open, and say so. A facility for shedding load must never become
+		// the reason the catalogue stops updating, but a silent degrade would be
+		// indistinguishable from a switch that was genuinely clear.
+		log.Printf("worker: pause switch unreadable, running anyway: %v", err)
+		return false
+	}
+	return held
+}
+
+// switchHeld reports whether either pause key exists, or why it could not tell.
+func switchHeld(ctx context.Context, redisURL, job string) (bool, error) {
+	opts, err := redis.ParseURL(redisURL)
+	if err != nil {
+		return false, err
+	}
+	// The budget goes on the client, not only on the context: go-redis applies
+	// its own DialTimeout (5s) and retries a failed command three times with
+	// backoff, so a context deadline alone lets a silent Redis hold up every
+	// worker start for far longer than the deadline suggests.
+	opts.DialTimeout = pauseTimeout
+	opts.ReadTimeout = pauseTimeout
+	opts.WriteTimeout = pauseTimeout
+	opts.MaxRetries = -1
+
+	client := redis.NewClient(opts)
+	defer func() { _ = client.Close() }()
+
+	ctx, cancel := context.WithTimeout(ctx, pauseTimeout)
+	defer cancel()
+
+	held, err := client.Exists(ctx, pauseAllKey, pauseKeyPrefix+job).Result()
+	return held > 0, err
+}
+
+// workerJob names the running binary, which is both the per-worker pause key's
+// suffix and the `job` label on its metrics — so the key an operator types is
+// the label they read on the dashboard.
+//
+// It deliberately ignores os.Args[1:]. cmd/ingest takes a board file and gets a
+// distinct metrics `instance` from it, but the pause key stays the binary's, so
+// one key holds all ~140 board timers instead of needing one key each.
+func workerJob() string {
+	return filepath.Base(os.Args[0])
+}

--- a/internal/worker/pause_test.go
+++ b/internal/worker/pause_test.go
@@ -1,0 +1,185 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+)
+
+// newPauseRedis starts an in-process Redis and returns its URL in the form
+// config.Settings.RedisURL carries, so the tests exercise the same parsing path
+// a worker takes.
+func newPauseRedis(t *testing.T) (*miniredis.Miniredis, string) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis.Run: %v", err)
+	}
+	t.Cleanup(mr.Close)
+	return mr, "redis://" + mr.Addr() + "/0"
+}
+
+// hold sets a pause key the way an operator would.
+func hold(t *testing.T, mr *miniredis.Miniredis, key string) {
+	t.Helper()
+	if err := mr.Set(key, "1"); err != nil {
+		t.Fatalf("miniredis.Set %s: %v", key, err)
+	}
+}
+
+func TestPausedRunsWhenNoKeyIsSet(t *testing.T) {
+	_, url := newPauseRedis(t)
+
+	if Paused(context.Background(), url, "ingest") {
+		t.Error("Paused = true with no key set, want false")
+	}
+}
+
+func TestPausedHoldsOnTheFleetKey(t *testing.T) {
+	mr, url := newPauseRedis(t)
+	hold(t, mr, "freehire:pause:all")
+
+	if !Paused(context.Background(), url, "ingest") {
+		t.Error("Paused = false while freehire:pause:all is set, want true")
+	}
+}
+
+func TestPausedPerBinaryKeyHoldsOnlyThatBinary(t *testing.T) {
+	mr, url := newPauseRedis(t)
+	hold(t, mr, "freehire:pause:ingest")
+
+	if !Paused(context.Background(), url, "ingest") {
+		t.Error("ingest: Paused = false while its own key is set, want true")
+	}
+	if Paused(context.Background(), url, "search-drain") {
+		t.Error("search-drain: Paused = true while only ingest is held, want false")
+	}
+}
+
+func TestPausedOverrideAdmitsAHandStartedRun(t *testing.T) {
+	mr, url := newPauseRedis(t)
+	hold(t, mr, "freehire:pause:all")
+	t.Setenv(IgnorePauseEnv, "1")
+
+	if Paused(context.Background(), url, "backfill-derive") {
+		t.Errorf("Paused = true with %s set, want false", IgnorePauseEnv)
+	}
+}
+
+// A falsy value must not read as "bypass". Under pressure an operator who typed
+// FREEHIRE_IGNORE_PAUSE=0 means the opposite of a bypass, and presence-alone
+// semantics here would silently run the fleet they just held.
+func TestPausedOverrideRejectsAFalsyValue(t *testing.T) {
+	mr, url := newPauseRedis(t)
+	hold(t, mr, "freehire:pause:all")
+	t.Setenv(IgnorePauseEnv, "0")
+
+	if !Paused(context.Background(), url, "backfill-derive") {
+		t.Errorf("Paused = false with %s=0, want true", IgnorePauseEnv)
+	}
+}
+
+// captureLog redirects the standard logger for one test and returns what was
+// written, so the fail-open paths can be checked to announce themselves rather
+// than degrading in silence.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	flags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(os.Stderr)
+		log.SetFlags(flags)
+	})
+	return &buf
+}
+
+func TestPausedRunsWhenRedisIsUnreachable(t *testing.T) {
+	mr, url := newPauseRedis(t)
+	mr.Close() // the address is now refused
+	logs := captureLog(t)
+
+	if Paused(context.Background(), url, "ingest") {
+		t.Error("Paused = true against an unreachable Redis, want false (fail open)")
+	}
+	if logs.Len() == 0 {
+		t.Error("an unreachable switch was not logged; a silent degrade is indistinguishable from a healthy read")
+	}
+}
+
+func TestPausedRunsOnAMalformedURL(t *testing.T) {
+	logs := captureLog(t)
+
+	if Paused(context.Background(), "not-a-redis-url", "ingest") {
+		t.Error("Paused = true on a malformed URL, want false (fail open)")
+	}
+	if logs.Len() == 0 {
+		t.Error("a malformed switch URL was not logged")
+	}
+}
+
+// A reachable-but-silent Redis is the case a plain fail-open misses: without a
+// bound the worker waits out go-redis's dial/read default on every start.
+func TestPausedGivesUpOnASilentRedis(t *testing.T) {
+	var lc net.ListenConfig
+	listener, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	accepted := make(chan struct{})
+	go func() {
+		defer close(accepted)
+		var conns []net.Conn
+		defer func() {
+			for _, conn := range conns {
+				_ = conn.Close()
+			}
+		}()
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			conns = append(conns, conn) // accept, and never answer
+		}
+	}()
+	t.Cleanup(func() {
+		_ = listener.Close()
+		<-accepted
+	})
+	captureLog(t)
+
+	start := time.Now()
+	paused := Paused(context.Background(), "redis://"+listener.Addr().String()+"/0", "ingest")
+	elapsed := time.Since(start)
+
+	if paused {
+		t.Error("Paused = true against a silent Redis, want false (fail open)")
+	}
+	// Well under go-redis's 5s dial default (the bound this guards), and well
+	// over the 250ms budget, so the assertion is meaningful without being timing-
+	// flaky on a loaded machine.
+	if elapsed > 2*time.Second {
+		t.Errorf("Paused took %s against a silent Redis; the lookup is not bounded", elapsed)
+	}
+}
+
+// The per-binary key names the binary and nothing else, so one key holds the
+// whole same-binary fleet — the ~140 ingest boards are released together rather
+// than needing a key each.
+func TestWorkerJobIgnoresInvocationArguments(t *testing.T) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"/opt/freehire/src/hire-current/ingest", "sources/greenhouse.yml"}
+
+	if got := workerJob(); got != "ingest" {
+		t.Errorf("workerJob() = %q, want %q", got, "ingest")
+	}
+}

--- a/openspec/changes/worker-pause-switch/.openspec.yaml
+++ b/openspec/changes/worker-pause-switch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/worker-pause-switch/design.md
+++ b/openspec/changes/worker-pause-switch/design.md
@@ -1,0 +1,168 @@
+## Context
+
+host-2 runs the API, Meilisearch, Postgres, and a cron fleet of ~40 run-once worker binaries
+(~140 timer units once per-board ingest is counted) on one bare-metal box. The host is
+disk-bound: measured 2026-08-18 during a full reindex, `io full avg60 = 28%` against
+`cpu full = 0%`, with per-process read attribution putting the ingest backends at ~56 MB/s of
+~212 MB/s total.
+
+Two load-shedding mechanisms already exist and neither fits:
+
+- `/opt/freehire/bin/ingest-slot.sh` is a counting `flock` semaphore (`INGEST_SLOTS=10`). It
+  bounds *how many* boards crawl at once and governs ingest only. It cannot express "none".
+- `systemctl stop <unit>.timer` works, but there are ~140 of them, it must be undone by hand,
+  and a stopped timer is indistinguishable from one that simply has not fired.
+
+The seam that makes a single switch cheap already exists: `worker.Main(run func() int)` in
+`internal/worker/main.go` wraps every worker. `internal/worker/AGENTS.md` records it as the
+one entry wrapper, and a spec requirement already enforces mechanically that no `cmd/` binary
+opening a pool bypasses the shared bootstrap.
+
+Redis is already a hard dependency of `cmd/server` (rate limiting, response cache) and
+`config.Settings.RedisURL` is loaded for every binary, defaulting to
+`redis://localhost:6379/0`. `go-redis/v9` and `miniredis/v2` are both already in `go.mod`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Shed load from the entire cron fleet, or from one binary, with a single command.
+- Let an operator run one worker by hand while the fleet is held — the workflow that prompted
+  this: hold everything, then run `backfill-derive` against a quiet host.
+- Make a held switch visible in the monitoring that already exists, and make a forgotten
+  switch eventually page someone.
+- Cost nothing on the normal path: one Redis `GET` before any pool is opened.
+
+**Non-Goals:**
+
+- Cancelling a run already in flight. The heaviest ingest boards run ~50 minutes, so the
+  switch stops the queue refilling rather than freeing the disk immediately.
+- Per-board granularity. Holding one ingest board is a job for that board's timer.
+- Replacing `ingest-slot.sh`. That answers "how many"; this answers "whether at all". They are
+  orthogonal and both stay.
+- Any enforcement that a pause carries an expiry.
+
+## Decisions
+
+### The gate lives in `Main`, not `Bootstrap`
+
+`Bootstrap` reports failure by returning an error, and every worker answers an error with
+`return 1`. Routing a pause through it would make each held switch look like a failed run and
+page someone. `Main` can exit on its own terms.
+
+Placing it in `Main` also means a paused run never initializes Sentry and never opens the pgx
+pool — the cost of a held switch is one `GET`.
+
+*Alternative considered:* a sentinel error from `Bootstrap` that workers recognize. Rejected —
+it needs an edit in all ~40 workers and one missed worker fails open in the wrong direction,
+silently running while the fleet is held.
+
+### Two keys, presence-as-signal
+
+```
+freehire:pause:all       # the whole fleet
+freehire:pause:<binary>  # one binary, e.g. freehire:pause:ingest
+```
+
+Either key present holds the worker. `<binary>` is `filepath.Base(os.Args[0])` — the same
+string already used as the `job` metric label, so the key an operator types matches the label
+they read on the dashboard.
+
+The per-invocation `instance` label (cmd/ingest's board file) is deliberately excluded from
+the key. Holding one board is a timer's job; an incident switch that needs 140 keys to quiet
+ingest is not a switch.
+
+The stored value is ignored, so `SET ... 1` and `SET ... "reindex running"` behave the same
+and an operator can leave themselves a note.
+
+*Alternative considered:* a Redis set of paused worker names. Rejected — a set cannot carry a
+per-entry TTL, which is exactly the property that makes a forgotten switch self-healing.
+
+### TTL is a convention, not an enforcement
+
+`SET freehire:pause:all 1 EX 10800` is the documented form, but a key without `EX` is honoured.
+Refusing it would mean the switch can fail at the moment it is most needed. The forgotten-switch
+case is handled by visibility (below), not by making the switch harder to set.
+
+### Override by environment variable
+
+`FREEHIRE_IGNORE_PAUSE=1` skips the check. systemd timer units do not carry it, so the bypass
+admits only a hand-started run.
+
+*Alternative considered:* a Redis exception key (`freehire:pause:except`). Rejected — it puts
+two keys with independent TTLs into a state that must be kept consistent, and the exception
+outliving the pause is a silent, confusing failure. An environment variable holds no state
+between invocations, so there is nothing to forget to clean up.
+
+### Fail open
+
+A Redis error, a malformed URL, or a response slower than a 250ms timeout logs one line and
+the worker runs.
+
+The inverse would turn an optional convenience into a single point of failure for the whole
+catalogue: one Redis blip stops all ~40 workers, silently, with the dashboard reporting clean
+exits. `cmd/server` depends on Redis hard because rate limiting is load-bearing for serving;
+nothing about shedding background load justifies the same coupling.
+
+The bounded timeout matters as much as the fallback: an unhealthy-but-reachable Redis would
+otherwise delay every worker start by the dial default.
+
+### Metrics: one file, a paused gauge, and a deliberately stale timestamp
+
+`RunMetricsFilename()` is unchanged — the "one worker, one filename" rule in
+`internal/worker/AGENTS.md` exists because `Main` writes that file *last*, so a second
+publisher would be silently overwritten. Only the contents differ:
+
+| Run | Contents |
+|---|---|
+| Completed | the `freehire_worker_last_run_*` triple, plus `freehire_worker_paused 0` |
+| Refused | `freehire_worker_paused 1` alone |
+
+While a pause is held the last-run timestamp ages, so any age-based staleness rule eventually
+fires — the safety net for a switch nobody lifted — and `freehire_worker_paused 1` beside it
+tells whoever is paged that the silence was deliberate.
+
+*Alternative considered:* exit zero and stamp a successful run. Rejected on evidence from this
+host: `freehire-reindexw` recorded skipped cycles as successes, which kept the dashboard green
+while the search index went stale for days.
+
+Both gauges carry the existing `job` and `instance` labels and are therefore subject to
+node_exporter's documented `exported_job` rename. Queries must use `exported_job`.
+
+### Testability
+
+The decision is a pure function of (binary name, override env, Redis contents), so it lives in
+its own file and is tested against `miniredis` — no live Redis, no worker process.
+
+## Risks / Trade-offs
+
+- **A held switch is invisible outside Prometheus** → `systemctl list-timers` shows a healthy
+  fleet doing nothing. Mitigated by the paused gauge and by the documented `EX` convention;
+  not eliminated.
+- **Load sheds with a lag** → in-flight runs finish, up to ~50 minutes for the heaviest ingest
+  boards. Accepted; cancelling live work is a much larger claim to make across 40 workers and
+  is explicitly out of scope.
+- **A new metric name is a cross-repo contract** → `freehire_worker_paused` must be surfaced in
+  the Grafana dashboard and alert annotations in `freehire-ops`, which cannot be compiled
+  against this repo, so nothing here catches the omission. Treated as part of shipping, and
+  the exposition text is pinned by test so a rename is a visible edit.
+- **Redis becomes a dependency of every worker start** → mitigated by the fail-open rule and
+  the 250ms bound, which together cap the worst case at a quarter-second of added start
+  latency and no behavioural change.
+
+## Migration Plan
+
+No schema change, no data migration, no API change. Deploy is the ordinary `release.sh` path.
+
+Before deploy the feature is inert: no keys exist, so every worker takes the fail-open or
+no-key path and runs exactly as today. Rollback is a redeploy of the previous binary; any key
+left in Redis becomes meaningless rather than harmful, and expires on its own if it was set
+with `EX`.
+
+The `freehire-ops` dashboard and alert change ships alongside, not after.
+
+## Open Questions
+
+None. The four decisions that were genuinely open — how deep the pause cuts, its granularity,
+how a single worker is excepted, and how a pause appears in monitoring — were settled with the
+user during brainstorming and are recorded above with their rejected alternatives.

--- a/openspec/changes/worker-pause-switch/proposal.md
+++ b/openspec/changes/worker-pause-switch/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+host-2 is disk-bound, and the only way to shed load from the cron fleet today is to stop
+~140 systemd timers by hand and remember to start them again. That is slow to do under
+pressure and invisible afterwards: a stopped timer looks exactly like a healthy timer that
+has not fired yet. Measured on 2026-08-18 during a full reindex, `io full avg60` sat at 28%
+while `cpu full` sat at 0%, with the ingest backends taking ~56 MB/s of ~212 MB/s of reads —
+so shedding ingest is the lever that matters, and there is no fast way to pull it.
+
+## What Changes
+
+- A worker consults a Redis pause switch before it runs, and exits without doing work when
+  the switch is held. The check happens in the shared `worker.Main` wrapper, so it covers
+  every one of the ~40 run-once binaries at once.
+- Two key shapes: `freehire:pause:all` holds the whole fleet, `freehire:pause:<binary>` holds
+  one worker. Either being present is enough.
+- `FREEHIRE_IGNORE_PAUSE=1` in the environment bypasses the switch. systemd timer units do
+  not carry it, so the bypass admits only what an operator started by hand.
+- The check fails open: an unreachable or slow Redis logs one line and the worker runs.
+- A held pause publishes `freehire_worker_paused` and stops refreshing the worker's
+  `freehire_worker_last_run_*` series, so an age-based alert still fires on a switch nobody
+  lifted.
+- Not in scope: cancelling a run already in flight. In-flight work drains; only new starts
+  are refused.
+
+## Capabilities
+
+### New Capabilities
+
+None. This adds behaviour to an existing capability rather than introducing one.
+
+### Modified Capabilities
+
+- `worker-lifecycle`: two new requirements — a worker MAY be refused a run by an external
+  pause switch (with a manual override and fail-open semantics), and a refused run MUST be
+  distinguishable from a successful one in the published metrics.
+
+## Impact
+
+- `internal/worker/main.go` — the pause gate runs before `run()`.
+- `internal/worker/pause.go` — new; owns the decision.
+- `internal/worker/metrics.go` — publishes `freehire_worker_paused` alongside the existing
+  `last_run_*` triple.
+- `internal/worker/AGENTS.md` — documents the switch and its keys.
+- No migration, no schema change, no API change.
+- Dependencies: `github.com/redis/go-redis/v9` and `github.com/alicebob/miniredis/v2` are
+  already in `go.mod`; nothing new is added.
+- Out of this repository: `freehire_worker_paused` becomes part of the metric-name contract
+  with the Grafana dashboard and alert rules in `freehire-ops`, which cannot be compiled
+  against this repo. Surfacing the gauge there is part of shipping this, not a follow-up.

--- a/openspec/changes/worker-pause-switch/specs/worker-lifecycle/spec.md
+++ b/openspec/changes/worker-pause-switch/specs/worker-lifecycle/spec.md
@@ -1,0 +1,97 @@
+## ADDED Requirements
+
+### Requirement: External pause switch refuses a worker run
+
+A run-once worker SHALL consult an external pause switch before performing any work, and
+SHALL exit successfully without working while that switch is held. The check SHALL occur in
+the shared entry wrapper, before the worker's run function is called, so that no worker can
+opt out of it and a refused run costs neither a database pool nor an error-reporting
+handshake.
+
+The switch SHALL be expressed as the presence of either of two Redis keys: one naming the
+whole fleet, and one naming a single worker binary. Presence alone is the signal; the stored
+value carries no meaning. A key naming a single worker SHALL match on the binary's name only,
+not on any per-invocation argument, so that a fleet of same-binary runs (the ~140 ingest
+boards) is held or released as one.
+
+A refused run SHALL exit zero. A pause is an operator's decision, not a failure, and must not
+be reported as one.
+
+An environment variable SHALL bypass the switch entirely, so that an operator can run one
+worker by hand against an otherwise-held fleet. Because systemd timer units do not carry that
+variable, the bypass admits only what a human started deliberately.
+
+The check SHALL fail open. If the switch cannot be read — an unreachable server, a malformed
+URL, or a response slower than a short fixed timeout — the worker SHALL log the failure and
+proceed with its normal run. A facility for shedding load must never itself become the reason
+the catalogue stops updating.
+
+#### Scenario: No switch is held
+
+- **WHEN** neither the fleet-wide key nor the worker's own key is present
+- **THEN** the worker runs normally
+
+#### Scenario: The fleet-wide switch holds every worker
+
+- **WHEN** the fleet-wide key is present
+- **THEN** the worker exits zero without calling its run function
+
+#### Scenario: A per-worker switch holds only that binary
+
+- **WHEN** a key naming the `ingest` binary is present
+- **THEN** an `ingest` run is refused, and a `search-drain` run proceeds
+
+#### Scenario: A per-worker switch ignores invocation arguments
+
+- **WHEN** a key naming the `ingest` binary is present
+- **THEN** every `ingest` invocation is refused regardless of which board file it was given
+
+#### Scenario: The override admits a hand-started run
+
+- **WHEN** the fleet-wide key is present and the bypass variable is set in the environment
+- **THEN** the worker runs normally
+
+#### Scenario: An unreachable switch does not stop the fleet
+
+- **WHEN** the Redis server cannot be reached
+- **THEN** the worker logs the failure and runs normally
+
+#### Scenario: A slow switch does not stall the fleet
+
+- **WHEN** reading the switch takes longer than the fixed timeout
+- **THEN** the worker stops waiting, logs the failure, and runs normally
+
+### Requirement: A refused run is distinguishable from a completed one
+
+The metrics a worker publishes SHALL distinguish a run refused by the pause switch from a run
+that executed and succeeded. A refused run SHALL publish a dedicated paused gauge and SHALL
+NOT refresh the worker's last-run timestamp, duration, or success series.
+
+This is deliberate: leaving the last-run series to age means an existing staleness alert still
+fires for a switch nobody lifted, while the paused gauge beside it identifies the silence as
+intentional. Stamping a refused run as a success would make a held switch indistinguishable
+from a healthy fleet — the failure mode already observed on this host, where skipped reindex
+cycles recorded as successes kept a dashboard green while the search index went stale.
+
+A completed run SHALL publish the paused gauge as zero alongside its last-run series, so the
+gauge is a live signal rather than one that merely stops being written.
+
+Both the paused gauge and the existing last-run series SHALL be published to the worker's
+single existing metrics file, so that no worker owns two textfile names and the last writer
+cannot silently overwrite the other's payload.
+
+#### Scenario: A refused run publishes the paused gauge alone
+
+- **WHEN** a worker's run is refused by the pause switch
+- **THEN** its metrics file contains the paused gauge set to one, and contains no last-run
+  timestamp, duration, or success series
+
+#### Scenario: A completed run clears the paused gauge
+
+- **WHEN** a worker completes a run normally
+- **THEN** its metrics file contains the last-run series and the paused gauge set to zero
+
+#### Scenario: Both states share one metrics file
+
+- **WHEN** a worker publishes either a refused or a completed run
+- **THEN** the output is written to the same single filename that worker already owns

--- a/openspec/changes/worker-pause-switch/tasks.md
+++ b/openspec/changes/worker-pause-switch/tasks.md
@@ -14,12 +14,12 @@
 
 ## 2. Metrics
 
-- [ ] 2.1 Extend `internal/worker/metrics.go` so a completed run publishes
+- [x] 2.1 Extend `internal/worker/metrics.go` so a completed run publishes
       `freehire_worker_paused 0` alongside the existing `freehire_worker_last_run_*` triple,
       carrying the same `job`/`instance` labels.
-- [ ] 2.2 Add a refused-run publisher that writes `freehire_worker_paused 1` and no last-run
+- [x] 2.2 Add a refused-run publisher that writes `freehire_worker_paused 1` and no last-run
       series, to the same `RunMetricsFilename()` the worker already owns.
-- [ ] 2.3 Pin the exact exposition text of both outputs by test, the way
+- [x] 2.3 Pin the exact exposition text of both outputs by test, the way
       `cmd/queue-metrics/render_test.go` pins its own, so a metric rename is a visible edit
       rather than a silent break of the `freehire-ops` contract.
 

--- a/openspec/changes/worker-pause-switch/tasks.md
+++ b/openspec/changes/worker-pause-switch/tasks.md
@@ -1,14 +1,14 @@
 ## 1. The pause decision
 
-- [ ] 1.1 Add `internal/worker/pause.go` with a decision function that reports whether this
+- [x] 1.1 Add `internal/worker/pause.go` with a decision function that reports whether this
       process may run, given a binary name and a Redis URL. Cover the no-key case (runs) and
       the `freehire:pause:all` case (refused) against `miniredis`.
-- [ ] 1.2 Honour the per-binary key `freehire:pause:<binary>`: `ingest` is refused while
+- [x] 1.2 Honour the per-binary key `freehire:pause:<binary>`: `ingest` is refused while
       `search-drain` runs, and every `ingest` invocation is refused regardless of the board
       file argument (the key matches the binary name only).
-- [ ] 1.3 Honour `FREEHIRE_IGNORE_PAUSE=1`: with the fleet-wide key present and the variable
+- [x] 1.3 Honour `FREEHIRE_IGNORE_PAUSE=1`: with the fleet-wide key present and the variable
       set, the decision is "run".
-- [ ] 1.4 Fail open on an unreachable Redis, on a malformed URL, and on a response slower than
+- [x] 1.4 Fail open on an unreachable Redis, on a malformed URL, and on a response slower than
       the 250ms timeout — each logs and returns "run". Assert the slow case completes within a
       bound so a regression to the dial default is caught.
 

--- a/openspec/changes/worker-pause-switch/tasks.md
+++ b/openspec/changes/worker-pause-switch/tasks.md
@@ -31,14 +31,14 @@
 
 ## 4. Documentation
 
-- [ ] 4.1 Document the switch in `internal/worker/AGENTS.md`: both key shapes, the
+- [x] 4.1 Document the switch in `internal/worker/AGENTS.md`: both key shapes, the
       presence-as-signal rule, the `EX` convention, the override variable, the fail-open rule,
       and the paused-gauge/stale-timestamp pairing.
-- [ ] 4.2 Record the out-of-repo contract: `freehire_worker_paused` must be surfaced on the
+- [x] 4.2 Record the out-of-repo contract: `freehire_worker_paused` must be surfaced on the
       worker panel and in the staleness alert's annotation in `freehire-ops`, which cannot be
       compiled against this repo.
 
 ## 5. Verification
 
-- [ ] 5.1 Run `gofmt -l .` (must print nothing), `go vet ./...`, `go test ./...`, and
+- [x] 5.1 Run `gofmt -l .` (must print nothing), `go vet ./...`, `go test ./...`, and
       `go vet -tags=integration ./...` before pushing.

--- a/openspec/changes/worker-pause-switch/tasks.md
+++ b/openspec/changes/worker-pause-switch/tasks.md
@@ -1,0 +1,44 @@
+## 1. The pause decision
+
+- [ ] 1.1 Add `internal/worker/pause.go` with a decision function that reports whether this
+      process may run, given a binary name and a Redis URL. Cover the no-key case (runs) and
+      the `freehire:pause:all` case (refused) against `miniredis`.
+- [ ] 1.2 Honour the per-binary key `freehire:pause:<binary>`: `ingest` is refused while
+      `search-drain` runs, and every `ingest` invocation is refused regardless of the board
+      file argument (the key matches the binary name only).
+- [ ] 1.3 Honour `FREEHIRE_IGNORE_PAUSE=1`: with the fleet-wide key present and the variable
+      set, the decision is "run".
+- [ ] 1.4 Fail open on an unreachable Redis, on a malformed URL, and on a response slower than
+      the 250ms timeout — each logs and returns "run". Assert the slow case completes within a
+      bound so a regression to the dial default is caught.
+
+## 2. Metrics
+
+- [ ] 2.1 Extend `internal/worker/metrics.go` so a completed run publishes
+      `freehire_worker_paused 0` alongside the existing `freehire_worker_last_run_*` triple,
+      carrying the same `job`/`instance` labels.
+- [ ] 2.2 Add a refused-run publisher that writes `freehire_worker_paused 1` and no last-run
+      series, to the same `RunMetricsFilename()` the worker already owns.
+- [ ] 2.3 Pin the exact exposition text of both outputs by test, the way
+      `cmd/queue-metrics/render_test.go` pins its own, so a metric rename is a visible edit
+      rather than a silent break of the `freehire-ops` contract.
+
+## 3. Wiring
+
+- [ ] 3.1 Gate `worker.Main` on the decision before `run()` is called: a refused run publishes
+      the paused metrics and exits zero, without initializing Sentry or opening the pgx pool.
+      Assert `run` is never invoked when refused.
+
+## 4. Documentation
+
+- [ ] 4.1 Document the switch in `internal/worker/AGENTS.md`: both key shapes, the
+      presence-as-signal rule, the `EX` convention, the override variable, the fail-open rule,
+      and the paused-gauge/stale-timestamp pairing.
+- [ ] 4.2 Record the out-of-repo contract: `freehire_worker_paused` must be surfaced on the
+      worker panel and in the staleness alert's annotation in `freehire-ops`, which cannot be
+      compiled against this repo.
+
+## 5. Verification
+
+- [ ] 5.1 Run `gofmt -l .` (must print nothing), `go vet ./...`, `go test ./...`, and
+      `go vet -tags=integration ./...` before pushing.

--- a/openspec/changes/worker-pause-switch/tasks.md
+++ b/openspec/changes/worker-pause-switch/tasks.md
@@ -25,7 +25,7 @@
 
 ## 3. Wiring
 
-- [ ] 3.1 Gate `worker.Main` on the decision before `run()` is called: a refused run publishes
+- [x] 3.1 Gate `worker.Main` on the decision before `run()` is called: a refused run publishes
       the paused metrics and exits zero, without initializing Sentry or opening the pgx pool.
       Assert `run` is never invoked when refused.
 


### PR DESCRIPTION
## Why

host-2 is disk-bound, and the only way to shed load from the cron fleet today is to stop ~140 systemd timers by hand and remember to start them again. That is slow under pressure and invisible afterwards — a stopped timer looks exactly like one that has not fired yet.

Measured 2026-08-18 at 04:15 UTC during a full reindex: `io full avg60 = 28%` against `cpu full = 0%`, with the ingest backends taking ~56 MB/s of ~212 MB/s of reads.

## What this adds

`worker.Main` consults Redis before calling `run`, so one command holds the whole fleet — or one binary:

```bash
redis-cli SET freehire:pause:all 1 EX 10800     # hold everything for three hours
redis-cli SET freehire:pause:ingest 1 EX 10800  # hold one binary
redis-cli DEL freehire:pause:all                # lift early

FREEHIRE_IGNORE_PAUSE=1 ./backfill-derive       # run one thing against the held fleet
```

- Refuses to **start** a run; in-flight work drains untouched.
- The key names the binary, never the board — one key holds all ~140 ingest timers.
- `FREEHIRE_IGNORE_PAUSE` is parsed as a boolean (an operator who wrote `=0` meant the opposite of a bypass) and systemd timer units do not carry it, so it admits only a hand-started run.
- **Fails open**: an unreachable Redis, a bad URL, or a reply slower than 250ms logs one line and the worker runs. A load-shedding convenience must never become the reason the catalogue stops updating.
- Gated in `Main` rather than `Bootstrap`: Bootstrap reports failure by returning an error and every worker answers that with a non-zero exit, which would page someone for an operator's decision. A held run therefore costs one Redis `GET` — no Sentry init, no pgx pool.

## Metrics

`freehire_worker_paused` is published by both writers, so it is a live 0/1 signal. A refused run publishes it as `1` and publishes **no** `last_run_*` series — the last-run timestamp then ages and an existing staleness rule eventually fires for a switch nobody lifted, while the paused gauge identifies the silence as deliberate.

This deliberately rejects "exit 0 and stamp a success": that is how `freehire-reindexw`'s skipped cycles stayed invisible while the search index went stale for days.

Both renderings are pinned verbatim by test, the way `cmd/queue-metrics` pins its own.

## Out of this repository

`freehire_worker_paused` is a contract with dashboards and alert rules in `freehire-ops`, which cannot be compiled against this repo. **Adding the gauge here does not surface it there** — the ops-side panel and the staleness rule's annotation still need doing.

## Known seam

`EXISTS` is called with both keys at once. Correct against the single Redis this runs on; on a cluster the keys hash to different slots and the reply is a CROSSSLOT error, which fails open — the switch would silently never hold. Documented in `internal/worker/AGENTS.md`; split the lookup before moving Redis to a cluster.

## Not in scope

Cancelling a run already in flight. The heaviest ingest boards run ~50 minutes, so this stops the queue refilling rather than freeing the disk immediately. `Bootstrap` already derives a SIGTERM-cancellable context if that is wanted later.

## Verification

`gofmt -l .` clean, `go vet ./...` clean, `go test ./...` green across the module, `go vet -tags=integration ./...` clean, `golangci-lint` clean on the new files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Redis-backed pause switch for workers, supporting fleet-wide and worker-specific controls.
  * Paused workers exit successfully without starting work or external service initialization.
  * Added an environment override for authorized manual runs.
  * Added paused-state metrics while preserving existing run metrics.
* **Documentation**
  * Added operational guidance, monitoring requirements, configuration details, and testing expectations.
* **Tests**
  * Added coverage for pause behavior, overrides, failures, timeouts, worker-specific controls, and metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->