### PR TITLE
Cut mobile LCP roughly in half, and stop emitting a job location Google cannot resolve

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -28,7 +28,21 @@ production; in dev the Vite proxy (`web/vite.config.ts`) forwards `/api` to the 
 - PostHog is gated on `PUBLIC_POSTHOG_KEY` (inert without it — no init, no events);
   ingestion goes through the same-origin `/ingest` reverse proxy (nginx → `eu.i.posthog.com`),
   overridable via `PUBLIC_POSTHOG_HOST`. Injected by `freehire-ops`, never committed, unset
-  in dev.
+  in dev. At boot the start is deferred to `requestIdleCallback` (3s timeout) so gtag.js and
+  the PostHog SDK stop competing with first paint; **calls made before the SDK resolves are
+  queued in `$lib/analytics` and replayed in order**, which is what keeps the initial
+  `afterNavigate` pageview and — load-bearing — the `/my/**` `stopSessionRecording()` from
+  being dropped. Accept-in-the-banner still starts them immediately.
+- **`hooks.server.ts` narrows the `Link` header** to the stylesheet and the two entry modules.
+  SvelteKit's default preloads a route's whole module graph, which here is ~85 sub-1.5KB
+  chunks — ~90 `modulepreload` fetches racing the render-blocking CSS. Removing them cut
+  mobile LCP from 8.5s to 4.4s on `/` and 7.8s to 4.7s on a job page (Lighthouse, Slow 4G,
+  same rig). Note `sequence()` semantics: the FIRST `preload` wins, later ones are ignored.
+- The header's GitHub star count comes from **our own `/github-stars`**, not `api.github.com`.
+  Called from the browser it spent the visitor's share of GitHub's 60/hour-per-IP cap and
+  returned 403 from any shared address; `$lib/server/github` holds one process-wide hourly
+  cache, shared with `/open`. `stars: null` is a valid answer — the badge drops the number,
+  never errors. Unauthenticated even server-side, so a busy IP still degrades to null.
 - The PWA service worker (`web/vite.config.ts`, `SvelteKitPWA`) precaches only the built app
   shell — no runtime-caching entry for `/api/*` or navigations, since every job listing,
   filter result and `/me/*` response is personalized or live. `workbox.navigateFallback` is
@@ -48,6 +62,11 @@ production; in dev the Vite proxy (`web/vite.config.ts`) forwards `/api` to the 
   `EventSource`), embedded in the workspace's `ArtifactPanel` and in `JobDrawer.svelte`.
   The pure SSE reducer `reduceMatchEvent` lives in `web/src/lib/matchAnalysis.ts`
   (unit-tested).
+- **`ReferralBlock` imports its modal on the click that opens it.** The block is small; the
+  `RequestReferralModal` behind it pulls in Dialog, FormField and the request flow, and it sat
+  in the module graph of every job and company page while only the few visitors who actually
+  ask for a referral open it. The block itself stays server-rendered — deferring it too would
+  push the description down after hydration and trade the CLS the page currently has at zero.
 - **Filters**: the companies FilterModal uses `COMPANY_FACETS` from `web/src/lib/facets.ts`,
   including a "Remote hiring" pill that reuses the shared `REGION` vocabulary for the
   `remote_regions` overlap facet.

--- a/web/src/app.html
+++ b/web/src/app.html
@@ -3,6 +3,19 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <!-- Warm the company-logo origin: every job row and company header renders an
+    <img> from it (CompanyLogo → $lib/logo), so a listing opens a connection to it
+    within the first paint, on every page that matters. Its handshake is otherwise
+    paid at the moment the first logo is needed.
+
+    Only this one origin gets a preconnect. googletagmanager.com is the other
+    candidate Lighthouse names, but it is loaded from $lib/analytics behind cookie
+    consent: outside a consent-required region it starts unprompted, inside one it
+    may never start at all, and a preconnect the visitor then never uses spends a
+    connection slot against the resources that do. dns-prefetch is the honest
+    weight for it — name resolution only, discarded cheaply if consent says no. -->
+    <link rel="preconnect" href="https://logo.freehire.me" crossorigin />
+    <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
     <link rel="icon" href="%sveltekit.assets%/favicon.svg" type="image/svg+xml" />
     <link rel="icon" href="%sveltekit.assets%/favicon.png" sizes="32x32" type="image/png" />
     <link rel="apple-touch-icon" href="%sveltekit.assets%/apple-touch-icon.png" />

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -76,8 +76,34 @@ const cacheControl: Handle = async ({ event, resolve }) => {
   return response;
 };
 
+// Narrow what SvelteKit advertises in the response's `Link` header. The default
+// policy (`type === 'js' || type === 'css'`) walks the whole module graph of the
+// matched route, and this app's graph is wide: a route resolves to ~85 chunks,
+// most of them under 1.5KB. Every one of them became a `rel=modulepreload` the
+// browser started fetching before it had parsed a byte of HTML.
+//
+// On a fast connection that is free. On a throttled one it is the dominant cost:
+// ~85 highest-priority streams share the link with the single render-blocking
+// stylesheet, and Lighthouse (mobile, Slow 4G) measured LCP 6.2s on `/` and 7.0s
+// on a job page with 89-93% of it spent in render delay — not in TTFB (~0.5-0.7s),
+// and with no image or web font involved anywhere in the LCP.
+//
+// So: keep the stylesheet, keep the two entry modules (they are on the critical
+// path either way and are what the inline bootstrap immediately imports), and let
+// the rest be discovered through their own import statements. That trades a wide
+// burst for a slightly deeper waterfall, which is the right way round when the
+// burst is what delays first paint.
+//
+// Position in `sequence()` is not arbitrary: unlike `transformPageChunk`, whose
+// hooks are merged, the FIRST `preload` wins and later ones are ignored. Nothing
+// else sets one today — a second one added below this line would be dead code.
+const preloadPolicy: Handle = async ({ event, resolve }) =>
+  resolve(event, {
+    preload: ({ type, path }) => type === 'css' || path.includes('immutable/entry/'),
+  });
+
 // sentryHandle scopes each SSR request; it is a passthrough when init was skipped.
-export const handle = sequence(Sentry.sentryHandle(), locale, cacheControl);
+export const handle = sequence(Sentry.sentryHandle(), preloadPolicy, locale, cacheControl);
 
 // Reports uncaught SSR errors to Sentry; inert when init was skipped above.
 export const handleError = Sentry.handleErrorWithSentry();

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -33,11 +33,49 @@ declare global {
   }
 }
 
-// Null until the dynamic import resolves and init runs; every entry point below
-// guards on it, so calls before/without load are safe no-ops. `loading` coalesces
+// Null until the dynamic import resolves and init runs. `loading` coalesces
 // concurrent init calls.
 let ph: PostHog | null = null;
 let loading = false;
+
+// Calls made before the SDK resolves are held here and replayed, in order, once it
+// does. Without this they were silently dropped, and the very first pageview of
+// every visit is exactly such a call: `afterNavigate` fires on the initial load too
+// (see +layout.svelte), which is well before a dynamically imported ~40KB SDK can
+// have finished loading. That race was always lost more often than won; deferring
+// init to idle would have made losing it the rule.
+//
+// Replay makes the ordering load-bearing rather than merely nice: `syncReplayForRoute`
+// carries privacy state, not an event. Dropping its `stopSessionRecording()` for
+// /my/** and then starting the SDK would begin recording a CV page — the one thing
+// that call exists to prevent. Queued in order, the stop still lands first.
+//
+// Null once the queue has been handed over (or abandoned), which also makes
+// "already settled" and "still waiting" distinguishable at the push site.
+let pending: Array<(sdk: PostHog) => void> | null = [];
+
+// A visitor who never grants consent, or a deployment with no key, never drains the
+// queue — so it is bounded. Deep enough for a browsing session's worth of pageviews,
+// shallow enough that abandoning it costs nothing. Oldest entries are kept: the first
+// pageview and the initial replay decision are the ones worth having.
+const PENDING_LIMIT = 50;
+
+/** Run `fn` against the SDK now, or as soon as it has loaded. A no-op forever once
+ *  the queue has been abandoned (no key configured). */
+function withPostHog(fn: (sdk: PostHog) => void): void {
+  if (ph) {
+    fn(ph);
+    return;
+  }
+  if (pending && pending.length < PENDING_LIMIT) pending.push(fn);
+}
+
+/** Hand the queued calls to the freshly initialized SDK, in the order they were made. */
+function drainPending(sdk: PostHog): void {
+  const queued = pending;
+  pending = null;
+  queued?.forEach((fn) => fn(sdk));
+}
 
 // The runtime env read and browser guard live in the caller (hooks.client.ts,
 // which is client-only) so this module stays free of SvelteKit runtime imports
@@ -55,7 +93,13 @@ export function initTrackers(config: AnalyticsConfig): void {
  *  a failed dynamic import must never break the app, so the SDK download is fired
  *  and forgotten with errors swallowed. */
 function initPostHog(config: AnalyticsConfig): void {
-  if (ph || loading || !config.key) return;
+  if (ph || loading) return;
+  if (!config.key) {
+    // Inert deployment (no key): nothing will ever drain the queue, so stop
+    // holding closures for an SDK that is not coming.
+    pending = null;
+    return;
+  }
   loading = true;
   void import('posthog-js')
     .then(({ default: posthog }) => {
@@ -67,6 +111,7 @@ function initPostHog(config: AnalyticsConfig): void {
         session_recording: { maskAllInputs: true },
       });
       ph = posthog;
+      drainPending(posthog);
     })
     .catch(() => {
       loading = false; // let a later call retry the load
@@ -191,31 +236,35 @@ export function trackSignupIfNew(user: {
   track('signup', { method: user.has_password ? 'password' : 'oauth' });
 }
 
-/** Capture an explicit funnel event. No-op until the SDK has loaded. */
+/** Capture an explicit funnel event. Queued until the SDK has loaded. */
 export function track(event: string, props?: Record<string, unknown>): void {
-  ph?.capture(event, props);
+  withPostHog((sdk) => sdk.capture(event, props));
 }
 
 /** Bind analytics identity to a signed-in user by id only — never PII. */
 export function identifyUser(user: { id: number }): void {
-  ph?.identify(String(user.id));
+  withPostHog((sdk) => sdk.identify(String(user.id)));
 }
 
 /** Drop identity so subsequent events are anonymous (on sign-out). */
 export function resetIdentity(): void {
-  ph?.reset();
+  withPostHog((sdk) => sdk.reset());
 }
 
-/** Start or stop session recording based on route privacy. */
+/** Start or stop session recording based on route privacy. Queued like the rest,
+ *  so a /my/** stop decided before the SDK loaded is still applied — and applied
+ *  before anything queued after it. */
 export function syncReplayForRoute(path: string): void {
-  if (!ph) return;
-  if (isPrivateRoute(path)) ph.stopSessionRecording();
-  else ph.startSessionRecording();
+  const isPrivate = isPrivateRoute(path);
+  withPostHog((sdk) => {
+    if (isPrivate) sdk.stopSessionRecording();
+    else sdk.startSessionRecording();
+  });
 }
 
 /** Capture a pageview for the current SPA route. */
 export function capturePageview(): void {
-  ph?.capture('$pageview');
+  withPostHog((sdk) => sdk.capture('$pageview'));
 }
 
 /** Generic feature-flag reader: the flag's value when loaded, else the fallback.

--- a/web/src/lib/components/ReferralBlock.svelte
+++ b/web/src/lib/components/ReferralBlock.svelte
@@ -3,7 +3,6 @@
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import { Button } from '$lib/ui';
-  import RequestReferralModal from './RequestReferralModal.svelte';
 
   // Shown on a vacancy and on the company page when the company has an approved referrer.
   // jobId is the optional source-vacancy context passed through to the request.
@@ -17,12 +16,37 @@
     jobId?: number;
   } = $props();
 
+  // The request form is imported on the click that opens it, not with the page.
+  // This block itself is small, but the modal behind it pulls in Dialog, FormField
+  // and the whole request flow — and it was landing in the route's module graph for
+  // every job and company page, which is every visitor paying for a form that only
+  // the few who actually ask for a referral ever open. Same lazy posture as shiki
+  // and easymde elsewhere.
+  //
+  // `$state.raw`: this holds a component constructor, which must be stored as-is —
+  // a deep proxy around it is both pointless and a hazard.
+  type RequestReferralModal = typeof import('./RequestReferralModal.svelte').default;
+  let Modal = $state.raw<RequestReferralModal | null>(null);
+  let loading = $state(false);
   let open = $state(false);
 
-  function ask() {
+  async function ask() {
     if (!isAuthenticated()) {
       openAuthDialog();
       return;
+    }
+    if (!Modal) {
+      // The button is disabled for the duration: on a slow connection the chunk is
+      // a visible wait, and a click that looks ignored invites a second one.
+      loading = true;
+      try {
+        Modal = (await import('./RequestReferralModal.svelte')).default;
+      } catch {
+        // Offline or a failed deploy swap — leave the button live so a retry works.
+        return;
+      } finally {
+        loading = false;
+      }
     }
     open = true;
   }
@@ -39,14 +63,9 @@
       directly if interested.
     </p>
   </div>
-  <Button variant="primary" size="sm" onclick={ask}>Ask for a referral</Button>
+  <Button variant="primary" size="sm" onclick={ask} disabled={loading}>Ask for a referral</Button>
 </section>
 
-{#if open}
-  <RequestReferralModal
-    {companySlug}
-    {companyName}
-    {jobId}
-    onClose={() => (open = false)}
-  />
+{#if open && Modal}
+  <Modal {companySlug} {companyName} {jobId} onClose={() => (open = false)} />
 {/if}

--- a/web/src/lib/github.svelte.ts
+++ b/web/src/lib/github.svelte.ts
@@ -1,13 +1,21 @@
 import { browser } from '$app/environment';
 
 // Live GitHub star count for the repo, rendered as a header badge. Fetched once
-// per session on first mount and cached in localStorage for a few hours, so we
-// never hammer the unauthenticated API (60 req/h per IP) — a stale-but-instant
-// number beats a spinner, and on any failure the badge just drops the number
-// (the icon link still works). SSR-safe: every browser API is `browser`-guarded.
+// per session on first mount and cached in localStorage for a few hours — a
+// stale-but-instant number beats a spinner, and on any failure the badge just
+// drops the number (the icon link still works). SSR-safe: every browser API is
+// `browser`-guarded.
+//
+// The count comes from our own origin, not api.github.com. Called from the browser
+// it spent the visitor's share of GitHub's unauthenticated cap (60 requests/hour
+// per IP), which holds up from a home connection and fails from anything with a
+// shared address — a datacentre, a corporate proxy, carrier NAT — where the reply
+// is a 403: a console error, and a badge with no number. The server route answers
+// from one process-wide hourly cache (see $lib/server/github).
 
 const REPO = 'strelov1/freehire';
 export const GITHUB_URL = `https://github.com/${REPO}`;
+const STARS_ENDPOINT = '/github-stars';
 
 const CACHE_KEY = 'hire.gh_stars';
 const TTL_MS = 6 * 60 * 60 * 1000; // 6h
@@ -53,17 +61,17 @@ class GithubStarsStore {
     }
 
     try {
-      const res = await fetch(`https://api.github.com/repos/${REPO}`, {
-        headers: { Accept: 'application/vnd.github+json' },
-      });
+      const res = await fetch(STARS_ENDPOINT);
       if (!res.ok) return;
-      const data = (await res.json()) as { stargazers_count?: number };
-      if (typeof data.stargazers_count === 'number') {
-        this.count = data.stargazers_count;
-        writeCache({ count: data.stargazers_count, at: Date.now() });
+      // `stars: null` means the server could not reach GitHub. Keep whatever the
+      // cache held rather than overwriting a real number with an absence.
+      const data = (await res.json()) as { stars?: number | null };
+      if (typeof data.stars === 'number') {
+        this.count = data.stars;
+        writeCache({ count: data.stars, at: Date.now() });
       }
     } catch {
-      // offline / rate-limited — keep the cached value (or none)
+      // offline — keep the cached value (or none)
     }
   }
 }

--- a/web/src/lib/seo.test.ts
+++ b/web/src/lib/seo.test.ts
@@ -377,6 +377,45 @@ describe('jobPostingJsonLd', () => {
     );
     expect(ld).not.toHaveProperty('jobLocationType');
     expect(ld).not.toHaveProperty('applicantLocationRequirements');
+    // And it does not answer "where is this job" with the word that means "nowhere
+    // in particular": Google geocodes jobLocation against real places.
+    expect(ld).not.toHaveProperty('jobLocation');
+  });
+
+  // A worldwide posting's location text is a restatement of its work mode, not a
+  // place. Emitting it made 8 of the 10 postings sampled from the Remote Worldwide
+  // collection claim a city called "Remote", with no addressCountry to place it.
+  it.each([
+    'Remote',
+    'remote',
+    ' Worldwide ',
+    'Anywhere',
+    'Fully Remote',
+    'Remote - Worldwide',
+    'Work from home',
+  ])('never emits %j as a place', (location) => {
+    const ld = jobPostingJsonLd(postingJob({ work_mode: 'remote', regions: [], location }), ORIGIN);
+    expect(ld).not.toHaveProperty('jobLocation');
+  });
+
+  // The same text is just as meaningless on a posting whose work mode was never
+  // classified, and that is where most of them arrive.
+  it('never emits a placeholder location on a posting with no work mode', () => {
+    const ld = jobPostingJsonLd(postingJob({ location: 'Remote' }), ORIGIN);
+    expect(ld).not.toHaveProperty('jobLocation');
+  });
+
+  // The guard keys on the whole string, never a substring: a qualified phrase
+  // still names a real area, and dropping it would lose a genuine restriction.
+  it('keeps a location that only begins with a placeholder word', () => {
+    const ld = jobPostingJsonLd(
+      postingJob({ work_mode: 'remote', regions: [], location: 'Remote within the US' }),
+      ORIGIN
+    );
+    expect(ld.jobLocation).toEqual({
+      '@type': 'Place',
+      address: { '@type': 'PostalAddress', addressLocality: 'Remote within the US' },
+    });
   });
 
   it('falls back to a plain jobLocation when a remote posting has no resolved region but does have a location string', () => {

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -223,12 +223,47 @@ function baseSalary(e: Enrichment): Record<string, unknown> {
   };
 }
 
+// Location strings that restate the work mode instead of naming a place. Sources
+// put these in the location field constantly, and passing one through made the
+// posting claim a city that does not exist: 8 of the 10 postings sampled from the
+// Remote Worldwide collection told Google `addressLocality: "Remote"`, with no
+// addressCountry to place it. Google geocodes jobLocation against real places, so
+// that is not a harmless label — it is a location it cannot resolve.
+//
+// Matched on the whole (trimmed, lowercased) string, never as a substring:
+// "Remote within the Continental United States" does name a real area, and
+// dropping it would discard a genuine restriction.
+const PLACEHOLDER_LOCATIONS = new Set([
+  'remote',
+  'fully remote',
+  '100% remote',
+  'remote worldwide',
+  'remote - worldwide',
+  'remote (worldwide)',
+  'worldwide',
+  'anywhere',
+  'global',
+  'work from home',
+  'wfh',
+]);
+
+function isPlaceholderLocation(location: string): boolean {
+  return PLACEHOLDER_LOCATIONS.has(location.trim().toLowerCase());
+}
+
 // schema.org jobLocation from the raw location string: Google accepts a
 // PostalAddress with just locality; add the ISO country code when the geo
 // dictionary pinned one (job.countries is alpha-2), never a made-up street/postal
 // code — mismatched structured data is a ranking liability. Shared by a non-remote
 // posting and a remote one whose region never resolved (see jobPostingJsonLd).
-function jobLocationFromText(location: string, countries?: string[]): Record<string, unknown> {
+//
+// Returns undefined for a string that names no place, so the caller omits
+// jobLocation rather than emitting an unresolvable one.
+function jobLocationFromText(
+  location: string,
+  countries?: string[]
+): Record<string, unknown> | undefined {
+  if (isPlaceholderLocation(location)) return undefined;
   const address: Record<string, unknown> = {
     '@type': 'PostalAddress',
     addressLocality: location,
@@ -335,12 +370,18 @@ export function jobPostingJsonLd(job: Job, origin: string): Record<string, unkno
       // location string still reached the posting). Asserting TELECOMMUTE without
       // its required companion would be worse than not asserting it: fall back to
       // the same plain jobLocation a non-remote posting gets.
-      ld.jobLocation = jobLocationFromText(job.location, job.countries);
+      //
+      // Unless that string is a placeholder like "Remote", which is the work mode
+      // written into the location field. Then there is still nothing to state and
+      // this joins the omit-entirely case below.
+      const place = jobLocationFromText(job.location, job.countries);
+      if (place) ld.jobLocation = place;
     }
     // Neither a resolved region nor any location text at all: nothing honest to
     // state, so location is omitted rather than guessed.
   } else if (job.location) {
-    ld.jobLocation = jobLocationFromText(job.location, job.countries);
+    const place = jobLocationFromText(job.location, job.countries);
+    if (place) ld.jobLocation = place;
   }
 
   if (e.salary_min != null || e.salary_max != null) {

--- a/web/src/lib/server/github.ts
+++ b/web/src/lib/server/github.ts
@@ -1,0 +1,66 @@
+// Repo stats from the GitHub API, fetched server-side and memoized for the whole
+// process. Two surfaces read them — the /open transparency page (stars, forks,
+// contributors, licence) and the header's star badge (stars only) — and they share
+// this one cache deliberately: unauthenticated GitHub REST is capped at 60
+// requests/hour per IP, and two independent caches of the same resource would
+// spend that budget twice for no extra information.
+//
+// The badge used to call api.github.com straight from the browser. That put the
+// per-IP cap on the visitor rather than on us, which is fine from a home
+// connection and fails from anything shared — a datacentre, a corporate proxy, a
+// carrier NAT — where the reply is a 403 that surfaces as a console error and a
+// badge with no number. Serving it from here makes the count a property of the
+// deployment instead of a property of whoever is looking.
+
+export type GithubStats = {
+  stars: number;
+  forks: number;
+  contributors: number | null;
+  license: string | null;
+};
+
+const TTL_MS = 60 * 60 * 1000;
+const REPO = 'strelov1/freehire';
+
+// (Date.now() is fine here — this is a server module, not a resumable workflow.)
+let cache: { at: number; data: GithubStats | null } | null = null;
+
+/** Repo stats, from cache when fresh. Best-effort: any failure yields null, and
+ *  the null is cached too so a rate-limit spell doesn't retry on every request. */
+export async function githubStats(fetchImpl: typeof fetch): Promise<GithubStats | null> {
+  if (cache && Date.now() - cache.at < TTL_MS) return cache.data;
+
+  const headers = { Accept: 'application/vnd.github+json' };
+  let data: GithubStats | null; // assigned on both the success and catch paths below
+  try {
+    const res = await fetchImpl(`https://api.github.com/repos/${REPO}`, { headers });
+    if (!res.ok) throw new Error(`github repo ${res.status}`);
+    const repo = await res.json();
+
+    // Contributor count without pulling the whole list: page it one-per-page and
+    // read the last-page number out of the Link header.
+    let contributors: number | null = null;
+    try {
+      const c = await fetchImpl(
+        `https://api.github.com/repos/${REPO}/contributors?per_page=1&anon=true`,
+        { headers },
+      );
+      const last = c.headers.get('link')?.match(/[?&]page=(\d+)>;\s*rel="last"/);
+      contributors = last ? Number(last[1]) : c.ok ? 1 : null;
+    } catch {
+      contributors = null;
+    }
+
+    data = {
+      stars: repo.stargazers_count ?? 0,
+      forks: repo.forks_count ?? 0,
+      contributors,
+      license: repo.license?.spdx_id ?? null,
+    };
+  } catch {
+    data = null;
+  }
+
+  cache = { at: Date.now(), data };
+  return data;
+}

--- a/web/src/lib/trackers.ts
+++ b/web/src/lib/trackers.ts
@@ -20,8 +20,30 @@ export function startTrackers(): void {
   initTrackers(config());
 }
 
+// How long the boot start may wait for an idle moment before going anyway. The
+// trackers weigh roughly 300KB between them (gtag.js ~168KB, the PostHog SDK plus
+// its recorder and surveys chunks the rest), and at boot they competed for
+// bandwidth with the render-blocking stylesheet and the route's own modules —
+// measurable in LCP, which is 6-7s on mobile. Yielding until the browser is idle
+// takes them out of that contention.
+//
+// The timeout is what keeps this a deferral rather than a gamble: a page that
+// never goes idle still starts them, just late. Consent has already been checked
+// by the time we get here, so waiting cannot turn into consent-less tracking.
+const BOOT_IDLE_TIMEOUT_MS = 3000;
+
 /** Start trackers only when consent currently allows it: the visitor is not
- *  consent-required, or has already granted consent. */
+ *  consent-required, or has already granted consent.
+ *
+ *  Deferred to the first idle moment. Calls made in the meantime are not lost —
+ *  $lib/analytics queues them and replays them in order once the SDK is up. */
 export function startTrackersIfAllowed(): void {
-  if (trackersAllowed()) startTrackers();
+  if (!trackersAllowed()) return;
+  // requestIdleCallback is unsupported on older Safari; a plain timer is the
+  // same deferral without the idle heuristic.
+  if (typeof requestIdleCallback === 'function') {
+    requestIdleCallback(startTrackers, { timeout: BOOT_IDLE_TIMEOUT_MS });
+  } else {
+    setTimeout(startTrackers, BOOT_IDLE_TIMEOUT_MS);
+  }
 }

--- a/web/src/routes/github-stars/+server.ts
+++ b/web/src/routes/github-stars/+server.ts
@@ -1,0 +1,19 @@
+import { json } from '@sveltejs/kit';
+import { githubStats } from '$lib/server/github';
+import type { RequestHandler } from './$types';
+
+// The star count for the header badge, served from our own origin so the browser
+// never talks to api.github.com (see $lib/server/github for why that mattered).
+//
+// `stars: null` is a real answer, not an error: GitHub being unreachable or rate-
+// limited must leave the badge without a number, never break the header. A 5xx
+// here would put a failed request in the console — exactly what this replaced.
+export const GET: RequestHandler = async ({ fetch, setHeaders }) => {
+  const stats = await githubStats(fetch);
+  // An hour matches the server-side memo: past it the next caller repopulates the
+  // process cache anyway, so a longer browser TTL would only serve a staler number
+  // than we already hold. Shared caches may hold it too — it is identical for
+  // everyone and carries nothing about the visitor.
+  setHeaders({ 'cache-control': 'public, max-age=3600' });
+  return json({ stars: stats?.stars ?? null });
+};

--- a/web/src/routes/open/+page.server.ts
+++ b/web/src/routes/open/+page.server.ts
@@ -1,63 +1,16 @@
 import { serverApi } from '$lib/server/api';
+import { githubStats } from '$lib/server/github';
 import type { PageServerLoad } from './$types';
 
 // The /open transparency page pulls its numbers live at request time from our own
 // public API plus the GitHub API. Every leg is best-effort (`Promise.allSettled`):
 // a failing upstream yields null/[] and the page drops or falls back that one
 // section, never the whole page.
-
-export type GithubStats = {
-  stars: number;
-  forks: number;
-  contributors: number | null;
-  license: string | null;
-};
-
-// Unauthenticated GitHub REST is capped at 60 requests/hour per IP, so the repo
-// stats are memoized module-side and refreshed at most once per TTL, shared across
-// all page loads. (Date.now() is fine here — this is a server module, not a
-// resumable workflow script.)
-const GH_TTL_MS = 60 * 60 * 1000;
-const GH_REPO = 'strelov1/freehire';
-let ghCache: { at: number; data: GithubStats | null } | null = null;
-
-async function fetchGithub(fetchImpl: typeof fetch): Promise<GithubStats | null> {
-  if (ghCache && Date.now() - ghCache.at < GH_TTL_MS) return ghCache.data;
-
-  const headers = { Accept: 'application/vnd.github+json' };
-  let data: GithubStats | null; // assigned on both the success and catch paths below
-  try {
-    const res = await fetchImpl(`https://api.github.com/repos/${GH_REPO}`, { headers });
-    if (!res.ok) throw new Error(`github repo ${res.status}`);
-    const repo = await res.json();
-
-    // Contributor count without pulling the whole list: page it one-per-page and
-    // read the last-page number out of the Link header.
-    let contributors: number | null = null;
-    try {
-      const c = await fetchImpl(
-        `https://api.github.com/repos/${GH_REPO}/contributors?per_page=1&anon=true`,
-        { headers },
-      );
-      const last = c.headers.get('link')?.match(/[?&]page=(\d+)>;\s*rel="last"/);
-      contributors = last ? Number(last[1]) : c.ok ? 1 : null;
-    } catch {
-      contributors = null;
-    }
-
-    data = {
-      stars: repo.stargazers_count ?? 0,
-      forks: repo.forks_count ?? 0,
-      contributors,
-      license: repo.license?.spdx_id ?? null,
-    };
-  } catch {
-    data = null; // caching the null too, so a rate-limit spell doesn't retry every request
-  }
-
-  ghCache = { at: Date.now(), data };
-  return data;
-}
+//
+// The GitHub leg (memoized, rate-limit-aware) moved to $lib/server/github so the
+// header's star badge reads the same cache instead of spending the same 60/hour
+// budget a second time.
+export type { GithubStats } from '$lib/server/github';
 
 // Every figure on the page is a public read (no cookie, identical for all visitors)
 // and moves slowly, so the whole assembled payload is memoized module-side for a
@@ -80,7 +33,7 @@ async function buildPayload(fetchImpl: typeof fetch) {
     api.statsFacets(),
     api.userGrowth(),
     api.engagementStats(),
-    fetchGithub(fetchImpl),
+    githubStats(fetchImpl),
   ]);
 
   const value = <T>(r: PromiseSettledResult<T>): T | null =>


### PR DESCRIPTION
Four changes that came out of auditing Core Web Vitals on mobile. Three are about first paint; the fourth is a structured-data defect the audit turned up along the way.

## Measurements

Lighthouse 12, mobile, Slow 4G + 4x CPU. Both runs on one rig against the same production build, so the numbers are comparable to each other — not to a PageSpeed score.

| | Home `/` | Job page |
|---|---|---|
| **LCP** | 8.47s → **4.42s** | 7.83s → **4.73s** |
| **FCP** | 5.40s → **3.34s** | 5.12s → **3.46s** |
| Speed Index | 5.40s → 3.93s | 5.12s → 4.11s |
| Performance | 61 → **76** | 63 → **74** |
| CLS | 0.066 → 0.066 | 0 → 0 |
| Best Practices | 96 → **100** | — |

Render delay, which was 89-93% of LCP, went from 7.56s to 3.51s and from 6.79s to 3.58s.

## What changed

**1. The `Link` header no longer advertises the whole module graph.** SvelteKit's default preloads every module a route resolves to; this app's graph is ~85 chunks, most under 1.5KB, so ~90 `modulepreload` fetches started before any HTML was parsed and shared the connection with the render-blocking stylesheet. The header now carries the stylesheet and the two entry modules — 90 entries down to 3. This is the change the numbers above are mostly measuring.

**2. `ReferralBlock` imports its modal on click.** The block is small; the form behind it pulls in Dialog, FormField and the request flow, and sat in the graph of every job and company page for the few visitors who ask for a referral. The block itself stays server-rendered on purpose — deferring it would push the description down after hydration and spend the zero CLS the job page currently has. Verified in a browser: the modal's chunk arrives ~830ms after the rest, i.e. on the click.

**3. Trackers start at the first idle moment instead of at boot,** with a 3s timeout so a page that never idles still starts them. Accept-in-the-banner is unchanged and still immediate; consent is checked before the wait.

This one needed more than a `requestIdleCallback`. Calls made before the SDK resolves were being dropped, and the first pageview of every visit is such a call — `afterNavigate` fires on the initial load, long before a dynamically imported SDK is up. That race was already lost more often than won; deferring would have made losing it the rule. So calls are now queued and replayed in order.

Ordering is load-bearing rather than tidy: `syncReplayForRoute` carries privacy state, not an event. Dropping its `stopSessionRecording()` for `/my/**` and then starting the SDK would begin recording a CV page — the one thing that call exists to prevent. Queued, the stop still lands first. The queue is bounded and abandoned outright when no key is configured.

**4. A job no longer claims to be in a city called "Remote".** Sources put the work mode in the location field constantly, and `jobLocationFromText` passed it through, so the posting emitted `addressLocality: "Remote"` with no `addressCountry`. Google geocodes `jobLocation` against real places.

Not an edge case: of ten postings sampled from the Remote Worldwide collection, **eight** emitted exactly that, and only one carried `TELECOMMUTE`. `global` expands to no country, so `applicantRegions` returns nothing and the fallback runs. Placeholders are now recognized and the location omitted — the branch the function already had for a posting with no location text. Matching is on the whole string: `"Remote within the Continental United States"` names a real area and is kept.

## What this deliberately does not do

**It does not make those postings remote in Google's eyes.** `TELECOMMUTE` requires `applicantLocationRequirements`, and a worldwide posting names no country to put there. Google's docs require at least one country and define no "worldwide" value, so that half is left alone rather than guessed at — it wants a Rich Results Test against a real posting to settle. The fix removes a false claim; it does not add a true one.

## Also considered and rejected

Merging the ~85 micro-chunks, which is the obvious follow-up to change 1. Measured, and it made things worse:

- `experimentalMinChunkSize` did nothing at all, and cannot: it merges only when no entry point ends up loading more, and with 80+ routes almost any merge costs some route something.
- Grouping all of `node_modules` produced one 797KB chunk holding posthog, easymde, codemirror, dompurify and marked — the libraries this app imports dynamically on purpose. First-load JS doubled (709KB → 1362KB) and LCP went to 8.2s.
- Grouping only icons was within noise, slightly worse: LCP median 4829ms against 4589ms over three runs each.

Once the preload is fixed, request count is no longer the bottleneck — total JS weight and execution are, and grouping does not reduce either.

## Verification

- `pnpm test` — 1081 pass (9 added)
- `pnpm lint` — clean; `pnpm check` — 0 errors
- `go vet -tags=integration ./...` — clean
- Browser: console clean, `api.github.com` gone from browser requests, referral modal opens correctly, structured data confirmed on a local production build against the same ten postings

`web/AGENTS.md` updated in the same commits.

## Note for review

Change 3 has the widest blast radius — it touches every analytics call site. The queue is the part worth reading closely, particularly whether abandoning it when no key is configured is the right call for a deployment that adds a key later without a redeploy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved initial loading with optimized connection hints and reduced module preloading.
  * Deferred tracker startup to minimize impact on page responsiveness.

* **Bug Fixes**
  * Analytics events are now preserved while tracking services initialize.
  * GitHub statistics load more reliably, with graceful handling when unavailable.
  * Improved referral modal loading with retry support.

* **SEO**
  * Job listings no longer publish invalid locations for generic remote-work descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->