### PR TITLE
Fix Tooltip collapsing to one word per line on a small trigger

### DIFF
--- a/design-system/.storybook/demos/TooltipDemo.svelte
+++ b/design-system/.storybook/demos/TooltipDemo.svelte
@@ -2,13 +2,23 @@
   // The tooltip wires aria-describedby onto the first focusable element inside
   // its trigger snippet, so the trigger has to be a real control for the story
   // to show the keyboard path (focus reveals it, Escape dismisses it).
+  import { Info } from '@lucide/svelte';
   import Button from '../../src/button.svelte';
   import Tooltip from '../../src/tooltip.svelte';
 
   let {
     label = 'Posted 4 months ago and still open',
     side = 'top',
-  }: { label?: string; side?: 'top' | 'right' | 'bottom' | 'left' } = $props();
+    // A small icon-only trigger, not the full Button — the shape that exposed
+    // the shrink-to-fit width bug (see tooltip.svelte's `w-max` comment): a
+    // narrow trigger is a narrow containing block, and content collapsed to
+    // one word per line no matter how generous max-w-xs was.
+    narrowTrigger = false,
+  }: {
+    label?: string;
+    side?: 'top' | 'right' | 'bottom' | 'left';
+    narrowTrigger?: boolean;
+  } = $props();
 </script>
 
 <!-- Room on every side so the story reads the same whichever `side` is picked. -->
@@ -17,6 +27,16 @@
     {#snippet content()}
       {label}
     {/snippet}
-    <Button variant="outline">Hover or focus me</Button>
+    {#if narrowTrigger}
+      <button
+        type="button"
+        aria-label="More info"
+        class="flex size-4 items-center justify-center rounded-full text-muted-foreground"
+      >
+        <Info class="size-3.5" aria-hidden="true" />
+      </button>
+    {:else}
+      <Button variant="outline">Hover or focus me</Button>
+    {/if}
   </Tooltip>
 </div>

--- a/design-system/src/tooltip.stories.ts
+++ b/design-system/src/tooltip.stories.ts
@@ -7,6 +7,7 @@ const meta = {
   tags: ['autodocs'],
   argTypes: {
     side: { control: 'select', options: ['top', 'right', 'bottom', 'left'] },
+    narrowTrigger: { control: 'boolean' },
   },
 } satisfies Meta<typeof TooltipDemo>;
 
@@ -23,5 +24,16 @@ export const LongContent: Story = {
     side: 'top',
     label:
       'Reposted three times in six months with no change to the description — the pattern the ghost-job signal looks for.',
+  },
+};
+// Regression guard for the `w-max` fix: a tiny icon-only trigger is a tiny
+// containing block, which used to collapse long content to one word per line
+// regardless of max-w-xs — see tooltip.svelte's positioning comment.
+export const NarrowTriggerLongContent: Story = {
+  args: {
+    side: 'bottom',
+    narrowTrigger: true,
+    label:
+      'Click a filter once to include it, again to exclude it, again to clear it. See how filters work.',
   },
 };

--- a/design-system/src/tooltip.svelte
+++ b/design-system/src/tooltip.svelte
@@ -97,12 +97,20 @@
   {@render children()}
   {#if visible}
     <!-- A <span>, not a <div>: the wrapper is a <span>, which only accepts
-         phrasing content. Absolute positioning blockifies it either way. -->
+         phrasing content. Absolute positioning blockifies it either way.
+
+         `w-max` (not just `max-w-xs`) is load-bearing on a small trigger. Left
+         at `width: auto`, a `left-1/2 -translate-x-1/2`-positioned box is sized
+         by CSS shrink-to-fit against the *containing block's* available width —
+         here, the trigger span itself. A tiny icon-button trigger makes that
+         available width tiny too, so long content collapsed to one word per
+         line no matter how generous max-w-xs was. `w-max` sizes to the
+         content's own max-content width instead, still capped by max-w-xs. -->
     <span
       id={tooltipId}
       role="tooltip"
       class={cn(
-        'absolute z-popover max-w-xs rounded-md border border-border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md',
+        'absolute z-popover w-max max-w-xs rounded-md border border-border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md',
         positions[side],
         className,
       )}

--- a/web/src/lib/components/filters/FilterModal.svelte
+++ b/web/src/lib/components/filters/FilterModal.svelte
@@ -218,11 +218,7 @@
       <Info class="size-3.5" aria-hidden="true" />
     </button>
     {#snippet content()}
-      <span class="block">
-        Most filters are three-state: click once to require a value, again to rule it out — a
-        company you already applied to, a source you don't trust, a skill you're done with — and a
-        third time to clear it.
-      </span>
+      <span class="block">Click a filter once to include it, again to exclude it, again to clear it.</span>
       <a
         href={resolve('/features/advanced-search')}
         class="mt-1.5 block font-medium text-foreground underline-offset-2 hover:underline"


### PR DESCRIPTION
## Summary
Follow-up to #2093. On production the filter hint tooltip rendered with almost one word per line — a real CSS bug in the shared `Tooltip` primitive, not a caching issue (verified the deployed bundle carried the right copy).

**Root cause**: a `left-1/2 -translate-x-1/2`-positioned tooltip with `width: auto` sizes by CSS shrink-to-fit against its *containing block's* available width — here, the trigger span itself. Every prior `Tooltip` consumer (including the existing `LongContent` story) used a full-width `Button` trigger, so nobody hit this. The filter-panel hint uses a small icon-only trigger; its containing block was narrow enough to collapse long content to near min-content width regardless of `max-w-xs`.

**Fix**: `w-max` sizes the box to its own max-content width instead, still capped by `max-w-xs`. This lives in `design-system/src/tooltip.svelte` since it's a primitive bug, not specific to this call site.

Also folded in the copy feedback from #2093 — cut the concrete-example sentence, kept the short version plus the link.

## Details
- Added a `NarrowTriggerLongContent` Storybook story (icon trigger + long content) as a regression guard — `tooltip.test.ts` is jsdom-based with no real layout engine, so it can't catch a shrink-to-fit sizing bug; only a rendered story can.
- `TooltipDemo.svelte` gained an opt-in `narrowTrigger` prop for that story, without touching the existing wide-trigger stories.

## Test plan
- [x] `pnpm test` (design-system, 128 tests), `pnpm build`, `pnpm check:dist`, `pnpm check:tokens`, `pnpm check:adoption`, `pnpm validate:docs`, `pnpm build-storybook` — all clean
- [x] `svelte-check` / `eslint` clean on the `web/` side
- [x] Visually verified both the new narrow-trigger story (wraps properly now) and the existing wide-trigger `LongContent` story (no regression) via Storybook + Playwright screenshots