### PR TITLE
The canonical company slug must be one the rule can reproduce

### DIFF
--- a/cmd/merge-companies/plan.go
+++ b/cmd/merge-companies/plan.go
@@ -112,11 +112,29 @@ func planMerges(companies []company, frozen map[string]bool, minJobs int) []merg
 	return out
 }
 
-// electCanonical picks the group's surviving slug: an already-frozen canon if the group holds
-// one, otherwise the member with the most open jobs (members arrive pre-sorted).
+// electCanonical picks the group's surviving slug. Members arrive sorted by open jobs
+// descending, so "the first that qualifies" is "the biggest that qualifies".
+//
+// Three rules, in order:
+//
+//  1. An already-frozen canon wins outright, even one carrying a corporate form. It has been
+//     redirecting and indexing; moving it costs more than a tidier slug is worth.
+//  2. Otherwise the biggest slug the rule can REPRODUCE — a fixed point of CompanySlug. Pure
+//     job count is not enough: the first prod dry run elected `danaher-corporation` over
+//     `danaher` (714 open jobs) because it happened to be larger, which would have made the
+//     catalogue's canonical url the one carrying the form and 301'd the better-known slug into
+//     it. It is also unstable, since every new posting derives the stripped slug and would need
+//     an alias row for the canon to reach itself.
+//  3. Failing that, the biggest. A group where nothing is a fixed point is odd but real, and
+//     merging it under an imperfect canon still beats leaving the employer split.
 func electCanonical(members []company, frozen map[string]bool) company {
 	for _, c := range members {
 		if frozen[c.Slug] {
+			return c
+		}
+	}
+	for _, c := range members {
+		if normalize.CompanySlug(c.Slug) == c.Slug {
 			return c
 		}
 	}

--- a/cmd/merge-companies/plan_test.go
+++ b/cmd/merge-companies/plan_test.go
@@ -100,3 +100,62 @@ func TestPlanMerges_IsDeterministic(t *testing.T) {
 		}
 	}
 }
+
+// TestPlanMerges_CanonicalIsAFixedPointOfTheSlugRule guards against electing a canonical slug
+// the rule itself would never produce.
+//
+// Found in the first prod dry run: `danaher-corporation` outweighed `danaher` (714 open jobs),
+// so pure job count elected it — and the catalogue's canonical url for the employer became the
+// one carrying a corporate form, with the better-known slug 301ing INTO it. That inverts the
+// change: the whole point is that the key does not carry the form.
+//
+// A slug still keying an employer under a form is also unstable. Every new posting derives the
+// stripped slug, so the canon would depend forever on an alias row to reach itself.
+func TestPlanMerges_CanonicalIsAFixedPointOfTheSlugRule(t *testing.T) {
+	got := planMerges([]company{
+		{Slug: "danaher-corporation", Name: "Danaher Corporation", JobCount: 900},
+		{Slug: "danaher", Name: "Danaher", JobCount: 714},
+	}, nil, 0)
+
+	if len(got) != 1 {
+		t.Fatalf("planned %d merges, want 1", len(got))
+	}
+	if got[0].Canonical != "danaher" {
+		t.Errorf("Canonical = %q, want danaher — a slug carrying a corporate form is not a "+
+			"canonical the rule can reproduce, whatever its job count", got[0].Canonical)
+	}
+}
+
+// TestPlanMerges_JobCountStillDecidesBetweenFixedPoints: the fixed-point preference is a
+// tie-break BEFORE job count, not a replacement for it. Both spellings here are ones the rule
+// produces, so the bigger one still wins — including when it is the uglier of the two.
+func TestPlanMerges_JobCountStillDecidesBetweenFixedPoints(t *testing.T) {
+	got := planMerges([]company{
+		{Slug: "dollartree", Name: "DollarTree", JobCount: 283},
+		{Slug: "dollar-tree", Name: "Dollar Tree", JobCount: 22683},
+	}, nil, 0)
+	if got[0].Canonical != "dollar-tree" {
+		t.Errorf("Canonical = %q, want dollar-tree", got[0].Canonical)
+	}
+
+	got = planMerges([]company{
+		{Slug: "turner-townsend", Name: "Turner Townsend", JobCount: 16},
+		{Slug: "turnertownsend", Name: "TurnerTownsend", JobCount: 400},
+	}, nil, 0)
+	if got[0].Canonical != "turnertownsend" {
+		t.Errorf("Canonical = %q, want turnertownsend — both are fixed points, so the count "+
+			"decides even though the hyphenated one reads better", got[0].Canonical)
+	}
+}
+
+// TestPlanMerges_FrozenCanonWinsEvenIfItCarriesAForm: a canon already elected has been
+// redirecting and indexing. Moving it would cost more than the tidier slug is worth.
+func TestPlanMerges_FrozenCanonWinsEvenIfItCarriesAForm(t *testing.T) {
+	got := planMerges([]company{
+		{Slug: "acme-inc", Name: "Acme Inc", JobCount: 5},
+		{Slug: "acme", Name: "Acme", JobCount: 900},
+	}, map[string]bool{"acme-inc": true}, 0)
+	if got[0].Canonical != "acme-inc" {
+		t.Errorf("Canonical = %q, want acme-inc (frozen)", got[0].Canonical)
+	}
+}

--- a/docs/agents/company-identity.md
+++ b/docs/agents/company-identity.md
@@ -85,6 +85,12 @@ crawl would put it back, and the display name comes from `companies.name` regard
 
 ## Gotchas
 
+- **The canonical slug must be a fixed point of the rule, and job count alone does not give
+  you one.** The first prod dry run elected `danaher-corporation` over `danaher` (714 open
+  jobs) purely because it was larger — making the canonical url the one carrying a corporate
+  form, and 301ing the better-known slug into it. It is unstable too: every new posting derives
+  the stripped slug, so the canon would depend forever on an alias row to reach itself. The
+  election prefers the biggest slug `CompanySlug` can reproduce, and only then the biggest.
 - **Electing by anything but job count elects backwards.** "Prefer the more readable slug" is
   the tempting rule and it picks `domino-s` (1 job) over `dominos` (14,396) and `al-fa-bank`
   (20) over `alfa-bank` (1,617). Hyphens mark the corrupted spelling about as often as the


### PR DESCRIPTION
Found by the first prod dry run of `merge-companies`, which is what dry runs are for.

`danaher-corporation` outweighed `danaher` (714 open jobs), so electing purely by job count picked it. That would have made the catalogue's canonical url for the employer **the one carrying a corporate form**, with the better-known slug 301ing into it — inverting the whole point of #2095, which is that the key does not carry the form.

It is also unstable: every new posting for that employer derives the stripped slug, so the canon would depend forever on an alias row to reach itself.

## The rule now

1. A **frozen** canon wins outright, even carrying a form — it has been redirecting and indexing, and moving it costs more than a tidier slug is worth.
2. Otherwise the biggest slug `CompanySlug` can **reproduce** (a fixed point).
3. Failing that, the biggest. A group where nothing is a fixed point is odd but real, and merging under an imperfect canon still beats leaving the employer split.

The fixed-point preference is a tie-break *before* job count, not a replacement: `dollar-tree`(22,683) still beats `dollartree`(283), and `turnertownsend` still beats `turner-townsend` even though the hyphenated one reads better — both are fixed points, so the count decides.

## Scope

One group in the `--min-jobs 1000` wave. The long tail of small waves will hold many more, which is why this lands **before any `--apply`**. Nothing has been merged on prod yet; `company_slug_aliases` holds 0 rows.

`go test ./...` 165 ok · `go vet -tags=integration` clean · gofmt/golangci-lint clean.