### PR TITLE
Trim the filter hint to just the link, fix modal overflow

### DIFF
--- a/web/src/lib/components/filters/FilterModal.svelte
+++ b/web/src/lib/components/filters/FilterModal.svelte
@@ -209,7 +209,11 @@
      header covers all of them rather than repeating the explanation on every
      excludable section. -->
 {#snippet titleHint()}
-  <Tooltip side="bottom">
+  <!-- side="right", not "bottom": the trigger sits at the modal's left edge, and a
+       centered tooltip (left-1/2 -translate-x-1/2) grows equally both ways —
+       overflowing the modal to the left no matter how short the content is.
+       Growing rightward only stays inside it. -->
+  <Tooltip side="right">
     <button
       type="button"
       aria-label="How filters work"
@@ -218,10 +222,9 @@
       <Info class="size-3.5" aria-hidden="true" />
     </button>
     {#snippet content()}
-      <span class="block">Click a filter once to include it, again to exclude it, again to clear it.</span>
       <a
         href={resolve('/features/advanced-search')}
-        class="mt-1.5 block font-medium text-foreground underline-offset-2 hover:underline"
+        class="block whitespace-nowrap font-medium text-foreground underline-offset-2 hover:underline"
       >
         See how filters work →
       </a>


### PR DESCRIPTION
## Summary
Follow-up to #2099. Two issues from feedback on the live tooltip:
1. The explanatory sentence was too much — cut it, keeping just the link.
2. The tooltip overflowed the modal's left edge on mobile. Root cause: it was centered under the trigger (`left-1/2 -translate-x-1/2`), and the trigger sits right at the modal's left edge — a centered box grows equally in both directions regardless of content length, so it always bled off the left side. `side="right"` grows from the trigger's right edge only, which stays inside the modal.

## Test plan
- [x] `svelte-check` / `eslint` clean
- [x] Reproduced the real header layout (icon-only trigger near a 420px container's left edge) in an isolated Playwright repro and confirmed `side="right"` keeps the tooltip fully inside the container, single line, no clipping