### PR TITLE
merge-companies: reconcile the catalogue after a wave

### DIFF
--- a/cmd/merge-companies/main.go
+++ b/cmd/merge-companies/main.go
@@ -61,8 +61,27 @@ func run() int {
 		log.Printf("merge-companies: %v", err)
 		return 1
 	}
-	log.Printf("merge-companies: done. The scheduled reindex will refresh the search facet; " +
-		"do NOT run one by hand.")
+
+	// The jobs now carry the canonical slug; re-key the derived catalogue and sweep the rows
+	// the re-key orphaned, exactly as cmd/backfill-company-names does after ITS re-key.
+	//
+	// This is not optional bookkeeping. Until the orphan row is gone, GET /companies/<retired>
+	// still FINDS a company — one with no jobs left — so it answers 200 instead of falling
+	// through to the alias lookup and the 301. The merge would look done and the redirect,
+	// which is the whole reason the alias row exists, would not be running.
+	if err := q.SyncCompaniesFromJobs(ctx); err != nil {
+		log.Printf("merge-companies: sync companies: %v", err)
+		return 1
+	}
+	orphans, err := q.DeleteOrphanCompanies(ctx)
+	if err != nil {
+		log.Printf("merge-companies: delete orphan companies: %v", err)
+		return 1
+	}
+	log.Printf("merge-companies: reconciled the catalogue, %d company rows retired", orphans)
+
+	log.Printf("merge-companies: done. Job counts stay stale until cmd/recount-companies runs, " +
+		"and the search facet until the scheduled reindex — do NOT run a reindex by hand.")
 	return 0
 }
 
@@ -103,7 +122,11 @@ func report(plan []merge) {
 			log.Printf("  %s <- %s (%s, %d jobs)", m.Canonical, a.Slug, a.Reason, a.JobCount)
 		}
 	}
-	log.Printf("merge-companies: %d groups, %d slugs retiring, %d job rows to move",
+	// OPEN jobs, because that is what companies.job_count holds and what elects a winner.
+	// The re-key moves closed rows too — it has to, or a closed posting would keep the
+	// retired slug and resurrect the duplicate the day it reopens — so the number of rows
+	// actually written is larger, on prod about 3x.
+	log.Printf("merge-companies: %d groups, %d slugs retiring, %d open jobs (closed rows move too)",
 		len(plan), aliases, jobs)
 }
 

--- a/docs/agents/company-identity.md
+++ b/docs/agents/company-identity.md
@@ -74,6 +74,16 @@ nothing, and an interrupted wave resumes. The alias row is written BEFORE its jo
 killed between the two then leaves a slug that redirects to a company whose count is short,
 where the other order leaves a slug with no jobs and no record of where they went.
 
+A wave ends by reconciling the derived catalogue — `SyncCompaniesFromJobs` then
+`DeleteOrphanCompanies`, the same pair `cmd/backfill-company-names` runs after its own re-key.
+Skipping it looks harmless and is not: until the orphan row is gone, `GET /companies/<retired>`
+still FINDS a company, one with no jobs left, so it answers 200 and never falls through to the
+alias lookup. The merge reads as done while the redirect it exists to serve is not running.
+
+The re-key moves CLOSED postings too, so the row count it writes is larger than the open-job
+figure the plan reports — about 3x on prod. That is deliberate: a closed posting left on the
+retired slug would resurrect the duplicate the day it reopens.
+
 **The worker does not touch the search index, deliberately.** A push to the facet index costs
 90-180s regardless of batch size, so feeding a wave through `search_outbox` would be tens of
 hours of pushes — the shape behind the 2026-08-05 outage. The scheduled `freehire-reindexw`


### PR DESCRIPTION
Caught by running the first wave on prod.

The merge moved **38,633 job rows across 42 groups — and not one retired slug redirected.**

The `companies` rows were still there, emptied of jobs but present, so `GET /companies/<retired>` *found* a company and answered 200 instead of falling through to the alias lookup. The merge read as done while the 301 it exists to serve was not running, and 63 company pages sat showing zero jobs.

`cmd/backfill-company-names` already runs `SyncCompaniesFromJobs` + `DeleteOrphanCompanies` after its own re-key, and explains why in a two-line comment. This worker should have followed the precedent.

## Also: the report understated its own work by 3x

It printed the count of **open** jobs — what `companies.job_count` holds, and what elects a winner — labelled as "job rows to move". The re-key moves closed postings too, and has to: one left on the retired slug would resurrect the duplicate the day it reopens. The plan said 11,712; 38,633 moved. An operator sizing a wave by that figure was being misled.

## State on prod

Wave 1 (`--min-jobs 1000`) is applied: 63 alias rows, jobs moved, redirects **not yet active** pending this fix. Re-running the same wave after deploy is a no-op for the jobs (the chunk statement selects rows still carrying the retired slug) and will run the reconcile.

`go test ./...` 165 ok · `go vet -tags=integration` clean.