### PR TITLE
Stop the onboarding nudge shoving the job feed down on a first visit

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -76,3 +76,14 @@
 .ph-dismissed [data-ph-banner] {
   display: none;
 }
+
+/* Onboarding nudge: same arrangement as the strip above, for the same reason. It
+   sits directly above the job feed, so rendering it only after hydration pushed
+   every row down by 74px on a first visit — CrUX measured CLS 0.28 on the mobile
+   home page, with 31% of visits in "poor", while lab Lighthouse saw only 0.066
+   because it never replays a returning visitor's localStorage. Server-rendered
+   now; this class hides it before first paint for anyone who already dismissed or
+   completed it, and JobsView drops the node on mount. See $lib/onboarding.ts. */
+.onboarding-seen [data-onboarding-banner] {
+  display: none;
+}

--- a/web/src/app.html
+++ b/web/src/app.html
@@ -50,6 +50,18 @@
             document.documentElement.classList.add('ph-dismissed');
         } catch (e) {}
       })();
+      // And once more for the onboarding nudge above the job feed, which is the
+      // costliest of the three: it sits in the flow directly above the rows, so
+      // appearing after hydration moved the whole feed down. Mirrors the lifecycle
+      // in $lib/onboarding.ts — 'seen' and 'done' both retire the banner, anything
+      // else (including no entry at all) leaves it visible for a first-time visitor.
+      (function () {
+        try {
+          var o = localStorage.getItem('hire.onboarding');
+          if (o === 'seen' || o === 'done')
+            document.documentElement.classList.add('onboarding-seen');
+        } catch (e) {}
+      })();
     </script>
     <!-- Google Analytics is no longer bootstrapped inline here: it now loads via
     $lib/analytics (initTrackers), gated on cookie consent alongside PostHog. -->

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -175,16 +175,27 @@
   // the sole entry — once dismissed or completed it retires; there is no persistent
   // re-open control.
   let wizardOpen = $state(false);
-  let onboardingState = $state<OnboardingLifecycle>(browser ? loadOnboardingState() : 'unseen');
+  // Starts 'unseen' on both sides so the hydrated markup matches the server's; the
+  // stored value arrives on mount, by which point app.css has already hidden the
+  // banner for anyone who dismissed or completed it. Reading localStorage here
+  // instead would make the client disagree with the SSR output on the very first
+  // frame. Same shape as ProductHuntBanner's `dismissed`.
+  let onboardingState = $state<OnboardingLifecycle>('unseen');
   // The ephemeral post-onboarding Telegram-alert offer (set after the wizard, or on
   // mount to resume a pending alert after sign-in). Dismissible; not persisted.
   let alertBanner = $state<{ query: string; autostart: boolean } | null>(null);
   // Show only to an un-nudged visitor with no active facet filters AND no text query,
   // so a shared search/filter link is never interrupted (activeFilterCount ignores the
-  // query, so check it explicitly). Gated on `browser`: never SSR the banner.
+  // query, so check it explicitly).
+  //
+  // Deliberately NOT gated on `browser`. It was, and that is what made this banner
+  // the site's largest source of layout shift: the feed rendered without it, then
+  // hydration inserted 74px directly above the rows. Lab Lighthouse missed it
+  // (0.066) because it never carries a returning visitor's localStorage; CrUX put
+  // the mobile home page at CLS 0.28. It is server-rendered now, and hidden before
+  // first paint by app.css for a visitor who has already seen it.
   const showBanner = $derived(
-    browser &&
-      standalone &&
+    standalone &&
       bannerVisible(onboardingState, filters.active > 0 || filters.value.q.trim() !== ''),
   );
 
@@ -249,6 +260,10 @@
   // sets stay empty). Cleanup: cancel any pending debounced reload so it can't fire
   // after this view is gone.
   onMount(() => {
+    // Catch up with the stored lifecycle now that localStorage is readable. For a
+    // returning visitor this drops the server-rendered banner — with no shift,
+    // because app.css already took it out of the flow before first paint.
+    onboardingState = loadOnboardingState();
     if (isAuthenticated()) {
       ensureViewedLoaded();
       ensureSavedLoaded();

--- a/web/src/lib/components/onboarding/OnboardingBanner.svelte
+++ b/web/src/lib/components/onboarding/OnboardingBanner.svelte
@@ -4,10 +4,20 @@
   // The unobtrusive nudge above the /jobs feed. Presentational only: it knows
   // whether it's shown and emits open/dismiss — JobsView owns visibility (unseen
   // AND no active filters) and lifecycle. Never blocks the feed below it.
+  //
+  // Server-rendered, and hidden before first paint for a visitor who already
+  // dismissed it — the same no-flash arrangement the Product Hunt strip uses, and
+  // for the same reason: this sits in the document flow above the feed, so
+  // mounting it after hydration shoves every job row down by 74px. It did exactly
+  // that, and CrUX put the resulting CLS at 0.28 on the mobile home page (31% of
+  // visits "poor"). `data-onboarding-banner` is what app.css keys the hide on.
   let { onOpen, onDismiss }: { onOpen: () => void; onDismiss: () => void } = $props();
 </script>
 
-<div class="mb-3 flex items-center gap-3 rounded-xl border border-border bg-card p-3 pl-4 sm:pl-4">
+<div
+  data-onboarding-banner
+  class="mb-3 flex items-center gap-3 rounded-xl border border-border bg-card p-3 pl-4 sm:pl-4"
+>
   <div class="flex size-9 shrink-0 items-center justify-center rounded-lg bg-brand/10 text-brand-strong">
     <Target class="size-4.5" />
   </div>

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -57,8 +57,9 @@ export default {
       directives: {
         'script-src': [
           'self',
-          // Anti-FOUC script in app.html — theme + Product Hunt strip (see WARNING above).
-          'sha256-MW6zpEdH1zWlGWKLAC6RP63TxcORvBoLwbJTeRL+HD0=',
+          // Anti-FOUC script in app.html — theme + Product Hunt strip + onboarding
+          // nudge (see WARNING above).
+          'sha256-u3FGDCCLNrppO+D5gI/BmV8qq0wTVlA/OoPesWqF1Ts=',
           // Google Analytics: the gtag.js host. GA now loads from the same-origin
           // bundle ($lib/analytics, consent-gated), so no inline-script hash is
           // needed — only the external host it injects.


### PR DESCRIPTION
The banner above the job feed was gated on `browser`, so the server rendered the page without it and hydration then inserted 74px directly above the rows. Every first-time visitor got the whole feed pushed down.

## Why this one matters

CrUX field data, 75th percentile:

| | Mobile | Desktop |
|---|---|---|
| INP | 171ms ✅ | 60ms ✅ |
| LCP | 2594ms ⚠️ | 1580ms ✅ |
| **CLS** | **0.190** ⚠️ | **0.160** ⚠️ |

The mobile home page on its own sits at **CLS 0.28 — "poor", with 31% of visits in that bucket**.

On desktop CLS is the *only* failing metric. LCP and INP are comfortably good, so this single number is what fails the Core Web Vitals assessment there.

## Why lab testing missed it

Lighthouse reported 0.066 — "good". It always arrives with empty storage and no notion of a returning visitor, and it stops measuring at load, while field CLS accumulates for the life of the page. Chasing the lab numbers is how the previous perf work ended up optimising LCP, which was already nearly passing, while leaving the one genuinely failing metric untouched.

## The fix

The arrangement this repo already uses one component over, for the same reason, with the reasoning written down in `app.css` and `ProductHuntBanner.svelte`: server-render the banner, and let the no-flash script in `app.html` hide it before first paint for whoever dismissed it.

`onboardingState` now starts `'unseen'` on both sides so the hydrated markup matches the server's, and catches up in `onMount` — by which point CSS has taken the banner out of the flow, so dropping the node shifts nothing.

The original gate was deliberate: it kept a returning visitor from seeing a banner they had already closed. That is still handled — just without charging every new visitor a layout shift for it.

## Measured

Local production build, mobile emulation, PerformanceObserver on `layout-shift`:

| Scenario | Before | After |
|---|---|---|
| First-time visitor | 0.064 | **0** |
| Returning visitor | — | **0** |
| After six screens of scrolling | — | **0** |

Also checked and cleared as sources: infinite scroll adds nothing, `CookieConsent` is `fixed`, `EmailVerificationBanner` comes from SSR.

## Review notes

- **The CSP hash in `svelte.config.js` is updated.** Getting that wrong fails silently — the browser blocks the whole inline block and the only symptom is a flash of the wrong theme. Verified in a browser that `<html>` still gets `class="dark"`.
- Field data moves on a 28-day window, so the CrUX assessment will not change immediately.
- `TTFB 1733ms` (threshold 800) remains the other failing input, eating two thirds of the LCP budget. Host load average was 23 on 16 cores with concurrent `ingest` workers — likely a scheduling problem, not a frontend one. Not addressed here.

## Verification

- `pnpm test` — 1081 pass
- `pnpm lint` — clean; `pnpm check` — 0 errors
- `go vet -tags=integration ./...` — clean
- Browser: banner shows for a new visitor, gone for a returning one, theme applies, console clean
