### PR TITLE
sources: slow Join to 1.5 req/s and add a fifth shard

### DIFF
--- a/internal/sources/join_pace_test.go
+++ b/internal/sources/join_pace_test.go
@@ -6,9 +6,11 @@ import (
 )
 
 // joinShards is how many staggered runs sources/join.yml is split across on prod
-// (freehire-ingest-join-shard@N.timer, --shard=N/4, one firing per hour so only one is ever
-// crawling and the pace below is the whole fleet's rate, not each shard's).
-const joinShards = 4
+// (freehire-ingest-join-shard@N.timer, --shard=N/5, one firing per hour so only one is ever
+// crawling and the pace below is the whole fleet's rate, not each shard's). Raised from 4 to
+// 5 alongside the pace drop to 1.5 req/s (issue #2094) — at 4 shards that pace misses the run
+// budget below.
+const joinShards = 5
 
 // TestJoinPaceFitsTheRunBudget pins the arithmetic that picked both the pace and the shard
 // count. Too fast and the refusals come back; too slow and systemd kills the run mid-crawl,

--- a/internal/sources/pacer.go
+++ b/internal/sources/pacer.go
@@ -113,8 +113,15 @@ func (g rateLimitedJSONGetter) GetJSON(ctx context.Context, url string, v any) e
 // So the knee sits between 2 and 3, and the pace takes the clean side of it. Under-shooting
 // only lengthens a run; over-shooting re-enters the refusals that had 3436 of 4749 boards
 // failing before this existed.
+//
+// 2 req/s still left a residue in production: refusals were not random but accelerated
+// through a run (8 failures at 368 boards, 44 at 1115, 70 at 1187 — see issue #2090), which
+// looks like a cumulative budget layered on top of the per-second one and would not show up
+// in the short isolated samples above. 1.5 req/s buys back headroom against that budget; see
+// issue #2094 for why that pace needed joinShards raised from 4 to 5 rather than just slowing
+// the existing 4 down (TestJoinPaceFitsTheRunBudget pins the arithmetic).
 const (
-	joinRequestInterval = 500 * time.Millisecond // 2 req/s
+	joinRequestInterval = time.Second * 2 / 3 // 1.5 req/s
 	joinRequestBurst    = 2
 )
 


### PR DESCRIPTION
## Summary
- Fixes #2094 (item 2 of the leftovers list): join.com's refusal residue (down to 5.9% after #2090) was shown to accelerate through a long run at 2 req/s rather than staying flat, which reads as a cumulative budget layered on top of the per-second one.
- Drops `joinRequestInterval` to 1.5 req/s and raises `joinShards` from 4 to 5 — `TestJoinPaceFitsTheRunBudget` pins the arithmetic showing 1.5 req/s only fits the run timeout split five ways, not four.

## Ops
The matching `freehire-ops` change (bringing the 4 hand-deployed prod shard timers into `gen-ingest-timers.sh` and raising them to 5) is committed to that repo's `main` but **not yet pushed or deployed to host2** — deploy there is a separate manual step once this PR lands.

## Test plan
- [x] `gofmt -l` clean
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test ./internal/sources/... -run TestJoin -v`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reduced request pacing for Join.com to help avoid cumulative request refusals.
  * Updated shard configuration and pacing guidance to reflect the revised request rate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->