### PR TITLE
Surface an upstream 429 as 429, not as a broken page

### DIFF
--- a/web/src/lib/server/upstream.ts
+++ b/web/src/lib/server/upstream.ts
@@ -1,0 +1,20 @@
+import { error } from '@sveltejs/kit';
+
+import { ApiError } from '$lib/api';
+
+/** Re-throw an API failure a `load` could not handle, mapping the statuses that mean
+ *  something to the CLIENT onto the response instead of letting them become a 500.
+ *
+ *  SvelteKit turns an unhandled throw in `load` into a 500, so before this every upstream
+ *  failure looked to a visitor — and to a crawler — like a broken page. The two differ in
+ *  what they invite: a 500 says the url is defective and is worth dropping, a 429 says come
+ *  back later and costs the page nothing. On a public catalogue that distinction is most of
+ *  the value of answering at all.
+ *
+ *  Anything else still becomes a 500. A genuine defect should look like one. */
+export function rethrowUpstream(e: unknown): never {
+  if (e instanceof ApiError && (e.status === 429 || e.status === 503)) {
+    error(e.status, e.status === 429 ? 'Too many requests' : 'Service unavailable');
+  }
+  throw e;
+}

--- a/web/src/routes/b/[slug]/+page.server.ts
+++ b/web/src/routes/b/[slug]/+page.server.ts
@@ -1,6 +1,7 @@
 import { error } from '@sveltejs/kit';
 import { ApiError } from '$lib/api';
 import { serverApi } from '$lib/server/api';
+import { rethrowUpstream } from '$lib/server/upstream';
 import type { PageServerLoad } from './$types';
 
 const LIMIT = 20;
@@ -17,7 +18,7 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
     board = await client.getBoard(params.slug);
   } catch (e) {
     if (e instanceof ApiError && e.status === 404) throw error(404, 'Board not found');
-    throw e;
+    rethrowUpstream(e);
   }
 
   const initial = await client.searchJobs(new URLSearchParams(board.query), LIMIT, 0);

--- a/web/src/routes/companies/[slug]/+page.server.ts
+++ b/web/src/routes/companies/[slug]/+page.server.ts
@@ -2,6 +2,7 @@ import { error, redirect } from '@sveltejs/kit';
 import { ApiError, MovedError } from '$lib/api';
 import { pageExists, pageOffset, parsePage } from '$lib/pagination';
 import { serverApi } from '$lib/server/api';
+import { rethrowUpstream } from '$lib/server/upstream';
 import type { PageServerLoad } from './$types';
 
 const LIMIT = 20;
@@ -55,7 +56,7 @@ export const load: PageServerLoad = async ({ params, url, fetch }) => {
     if (e instanceof ApiError && e.status === 404) {
       error(404, 'Company not found');
     }
-    throw e;
+    rethrowUpstream(e);
   }
 
   const initial = await search;

--- a/web/src/routes/jobs/[slug]/+page.server.ts
+++ b/web/src/routes/jobs/[slug]/+page.server.ts
@@ -9,6 +9,7 @@ import {
 } from '$lib/collections';
 import { resolveSeeAlsoMark } from '$lib/seeAlsoMark';
 import { serverApi } from '$lib/server/api';
+import { rethrowUpstream } from '$lib/server/upstream';
 import type { FacetCounts, Job } from '$lib/types';
 import type { PageServerLoad } from './$types';
 import { must } from '$lib/utils';
@@ -106,7 +107,7 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 
   const jobPromise = api.getJob(params.slug).catch((e) => {
     if (e instanceof ApiError && e.status === 404) error(404, 'Job not found');
-    throw e;
+    rethrowUpstream(e);
   });
   const seeAlsoPromise = jobPromise.then((job) => buildSeeAlso(job, api));
 

--- a/web/src/routes/jobs/[slug]/copies/+page.server.ts
+++ b/web/src/routes/jobs/[slug]/copies/+page.server.ts
@@ -1,6 +1,7 @@
 import { error } from '@sveltejs/kit';
 import { ApiError } from '$lib/api';
 import { serverApi } from '$lib/server/api';
+import { rethrowUpstream } from '$lib/server/upstream';
 import type { PageServerLoad } from './$types';
 
 // Rows per page of the full openings-by-location list. Kept within the endpoint's cap so
@@ -13,7 +14,7 @@ export const load: PageServerLoad = async ({ params, url, fetch }) => {
   const [job, result] = await Promise.all([
     api.getJob(params.slug).catch((e) => {
       if (e instanceof ApiError && e.status === 404) error(404, 'Job not found');
-      throw e;
+      rethrowUpstream(e);
     }),
     api.getJobCopies(params.slug, PAGE_SIZE, offset).catch(() => ({ copies: [], total: 0 })),
   ]);

--- a/web/src/routes/talent-network/[publicId]/+page.server.ts
+++ b/web/src/routes/talent-network/[publicId]/+page.server.ts
@@ -1,6 +1,7 @@
 import { error } from '@sveltejs/kit';
 import { ApiError } from '$lib/api';
 import { serverApi } from '$lib/server/api';
+import { rethrowUpstream } from '$lib/server/upstream';
 import type { PageServerLoad } from './$types';
 
 // The public, unauthenticated Talent Network profile page: load one candidate's profile
@@ -16,6 +17,6 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
     return { profile };
   } catch (e) {
     if (e instanceof ApiError && e.status === 404) error(404, 'Profile not found');
-    throw e;
+    rethrowUpstream(e);
   }
 };


### PR DESCRIPTION
## Why

`/companies/jp-morgan-chase` and `/companies/microsoft` are answering **500** on prod right now. The underlying cause is a **429** from the public read API's new rate limiter (#2096) — but the SSR load ended in a bare `throw e`, and SvelteKit turns an unhandled throw in `load` into a 500.

The two statuses say opposite things to the client that matters most for these pages:

- **500** — this url is defective. A crawler is invited to drop it.
- **429** — come back later. The page keeps its standing.

On a catalogue whose company and job pages exist to be found in search, that difference is most of the value of answering at all.

## What changes

Five loads shared the pattern — `companies/[slug]`, `jobs/[slug]`, `jobs/[slug]/copies`, `b/[slug]`, `talent-network/[publicId]` — so the mapping is one helper (`$lib/server/upstream`) rather than five copies. 429 and 503 propagate; **anything else still becomes a 500**, because a genuine defect should look like one.

## Not a fix for the rate limiting itself

This makes the symptom honest, it does not stop those pages being throttled. Worth a separate look at whether the SSR's own calls should count against a public per-IP budget at all — the server reaches its API over the public hostname, so it presents as an ordinary client.

`svelte-check` 0 errors · eslint clean.