### PR TITLE
Rate limiter: trust the socket when the caller claims no address

### DIFF
--- a/internal/ratelimit/trust.go
+++ b/internal/ratelimit/trust.go
@@ -43,10 +43,32 @@ var trustedNets = func() []*net.IPNet {
 }()
 
 // trustedPeer reports whether the request comes from a peer we do not rate-limit.
-// An address that does not parse is treated as untrusted: an unrecognizable
-// caller is exactly the one to keep counting.
 func trustedPeer(c *fiber.Ctx) bool {
-	ip := net.ParseIP(c.IP())
+	return trusted(c.IP(), c.Context().RemoteIP())
+}
+
+// trusted decides on the address the request CLAIMS to come from, falling back to the socket
+// it actually came from when it claims nothing.
+//
+// The fallback is the whole point. Fiber resolves c.IP() to what a trusted proxy asserted, so
+// for nginx it is the visitor — correctly counted — but our own SSR asserts nothing at all,
+// and the empty string parsed to nil and read as untrusted. Every server-rendered page then
+// shared one key, `publicread:ip:`, and one budget; the busiest pages spent it and answered
+// 429 to the front end this exemption exists to protect.
+//
+// Reading the socket only when nothing was claimed keeps the fallback honest. The API listens
+// on 0.0.0.0, so a stranger can reach it directly and assert nothing — and a socket address
+// cannot be forged, which is why it, and not a header, decides that case.
+func trusted(claimed string, peer net.IP) bool {
+	if claimed != "" {
+		return isTrusted(net.ParseIP(claimed))
+	}
+	return isTrusted(peer)
+}
+
+// isTrusted reports whether an address is one of ours. An address that does not parse is
+// treated as untrusted: an unrecognizable caller is exactly the one to keep counting.
+func isTrusted(ip net.IP) bool {
 	if ip == nil {
 		return false
 	}

--- a/internal/ratelimit/trust_test.go
+++ b/internal/ratelimit/trust_test.go
@@ -1,0 +1,47 @@
+package ratelimit
+
+import (
+	"net"
+	"testing"
+)
+
+// TestTrusted_OurSSRAssertsNoAddress is the case production actually presents, and the case
+// the middleware test could not reach.
+//
+// Fiber resolves c.IP() to what a TRUSTED peer asserted, not to the socket it came from. Our
+// SSR asserts nothing, so c.IP() is the empty string — which parsed to nil and read as
+// "untrusted". Every server-rendered page in the site then shared one key, `publicread:ip:`,
+// and one 600/minute budget, so the busiest pages answered 429 while the limiter's whole
+// purpose was to exempt them.
+func TestTrusted_OurSSRAssertsNoAddress(t *testing.T) {
+	if !trusted("", net.ParseIP("127.0.0.1")) {
+		t.Error("a loopback peer asserting no client address is our own SSR, and must not be counted")
+	}
+	if !trusted("", net.ParseIP("10.1.2.3")) {
+		t.Error("a private-network peer asserting no client address must not be counted either")
+	}
+}
+
+// TestTrusted_AnUnclaimedRequestFromOutsideIsStillCounted: the API listens on 0.0.0.0, so a
+// stranger can reach it directly and assert nothing at all. The socket cannot be forged, which
+// is exactly why the fallback reads it rather than the header.
+func TestTrusted_AnUnclaimedRequestFromOutsideIsStillCounted(t *testing.T) {
+	if trusted("", net.ParseIP("203.0.113.7")) {
+		t.Error("a public peer asserting no client address is a stranger, not our SSR")
+	}
+	if trusted("", nil) {
+		t.Error("an unparseable peer is not trusted — an unrecognizable caller is the one to count")
+	}
+}
+
+// TestTrusted_AClaimedAddressStillDecides preserves what already worked: nginx asserts the
+// visitor's address, and the visitor is who gets counted — never the loopback socket nginx
+// happens to arrive on.
+func TestTrusted_AClaimedAddressStillDecides(t *testing.T) {
+	if trusted("203.0.113.7", net.ParseIP("127.0.0.1")) {
+		t.Error("a visitor proxied by nginx must be counted, not exempted for arriving on loopback")
+	}
+	if !trusted("127.0.0.1", net.ParseIP("127.0.0.1")) {
+		t.Error("a peer asserting loopback is still trusted")
+	}
+}


### PR DESCRIPTION
## Live incident

Every server-rendered page on the site was sharing **one** rate-limit key and **one** 600/minute budget. The busiest pages spent it and answered 429, which the SSR rendered as 500. `/companies/jp-morgan-chase` and `/companies/microsoft` are doing it right now.

The refusal log says it plainly:

```
ratelimit: refused key "publicread:ip:" on /api/v1/jobs/search (limit 600/1m0s, ua="node")
```

Empty IP. `ua=node`. That is our own front end.

## Cause

Fiber resolves `c.IP()` to the address a **trusted peer asserted**, not the socket the request arrived on. For nginx that is the visitor — correctly counted. Our SSR asserts nothing, so `c.IP()` was `""`, `ParseIP("")` was nil, and `trustedPeer` read it as untrusted.

This is exactly what the exemption exists to prevent, and its own comment says so: *"SSR reaches the API at http://127.0.0.1:8081, bypassing nginx and forwarding no client-address header … Counting those would put the whole site in one caller's budget."* The intent was right; the check asked the wrong question.

## Fix

`trusted()` decides on the claimed address when there is one, and on the real socket peer when there is not.

The fallback is safe: the API listens on `0.0.0.0`, so a stranger can reach it directly and assert nothing — and a socket address cannot be forged, which is why it, and not a header, decides that case. A visitor proxied by nginx is still counted as the visitor, never exempted for arriving on loopback.

## Why it shipped

The test drove the peer by **setting** `X-Forwarded-For: 127.0.0.1`. The SSR sends no such header, so a fixture that sends one can never exercise the request that sends none. The new tests call the decision directly, which makes the no-header case reachable at all.

`go test ./...` 165 ok · `go vet -tags=integration` clean.