### PR TITLE
Never let a server error be stored in the shared cache

### DIFF
--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -62,11 +62,15 @@ const cacheControl: Handle = async ({ event, resolve }) => {
   if (response.headers.has('cache-control')) return response;
   if (!response.headers.get('content-type')?.includes('text/html')) return response;
 
+  // The status is passed because an error page is HTML like any other and was
+  // otherwise handed the same shared-cache lifetime as the page it replaced — see
+  // NO_CACHE in $lib/httpCache for what that cost in production.
   response.headers.set(
     'cache-control',
     cachePolicy({
       pathname: event.url.pathname,
       authenticated: hasSessionCookie(event.request.headers.get('cookie')),
+      status: response.status,
     }),
   );
   // The response body differs by session, so a shared cache must key on it. Without

--- a/web/src/lib/httpCache.test.ts
+++ b/web/src/lib/httpCache.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { PRIVATE_CACHE, PUBLIC_CACHE, PUBLIC_DETAIL_CACHE, cachePolicy } from './httpCache';
+import { NO_CACHE, PRIVATE_CACHE, PUBLIC_CACHE, PUBLIC_DETAIL_CACHE, cachePolicy } from './httpCache';
 
 describe('cachePolicy', () => {
   it('lets a shared cache hold an anonymous public page', () => {
@@ -110,5 +110,43 @@ describe('cachePolicy holds an entity page longer than a listing', () => {
 describe('cachePolicy is method-agnostic', () => {
   it('gives a HEAD probe the same answer as a GET', () => {
     expect(cachePolicy({ pathname: '/collections/python', authenticated: false })).toBe(PUBLIC_CACHE);
+  });
+});
+
+// Regression, observed in production: an error page is HTML like any other, so it
+// was handed the same `s-maxage=3600, stale-while-revalidate=86400` as the page it
+// replaced. Cloudflare stored a 500 and served it as a HIT for the next hour — a
+// transient failure during a blue/green flip turned into a page that stayed broken
+// long after the origin had recovered.
+describe('cachePolicy never lets a server error be stored', () => {
+  it('refuses to cache a 5xx, whatever the route would otherwise get', () => {
+    expect(cachePolicy({ pathname: '/', authenticated: false, status: 500 })).toBe(NO_CACHE);
+    expect(cachePolicy({ pathname: '/companies/acme', authenticated: false, status: 502 })).toBe(
+      NO_CACHE,
+    );
+    expect(cachePolicy({ pathname: '/collections/python', authenticated: false, status: 503 })).toBe(
+      NO_CACHE,
+    );
+  });
+
+  // A 404 is a fact about the URL, not a symptom: closed postings are a routine,
+  // permanent outcome here and there are a great many of them, so letting the edge
+  // absorb those repeats is the point. Only 5xx is withheld.
+  it('still caches a 404, which is a stable answer rather than a failure', () => {
+    expect(cachePolicy({ pathname: '/jobs/gone', authenticated: false, status: 404 })).toBe(
+      PUBLIC_DETAIL_CACHE,
+    );
+    expect(cachePolicy({ pathname: '/nope', authenticated: false, status: 404 })).toBe(PUBLIC_CACHE);
+  });
+
+  // The signed-in guard is the one rule that must not be weakened by any of this.
+  it('keeps a signed-in error response private, not merely uncached', () => {
+    expect(cachePolicy({ pathname: '/', authenticated: true, status: 500 })).toBe(PRIVATE_CACHE);
+  });
+
+  // Omitting the status keeps the old signature working and means "nothing wrong".
+  it('treats an absent status as a success', () => {
+    expect(cachePolicy({ pathname: '/', authenticated: false })).toBe(PUBLIC_CACHE);
+    expect(cachePolicy({ pathname: '/', authenticated: false, status: 200 })).toBe(PUBLIC_CACHE);
   });
 });

--- a/web/src/lib/httpCache.ts
+++ b/web/src/lib/httpCache.ts
@@ -40,6 +40,18 @@ export const PUBLIC_DETAIL_CACHE = 'public, max-age=0, s-maxage=3600, stale-whil
  *  should be written down at all, not even revalidated. */
 export const PRIVATE_CACHE = 'private, no-store';
 
+/** A response that failed. Not `private` — there is nothing personal about a 500,
+ *  and saying so would be misleading; it simply must not be written down, because
+ *  what it describes is a moment rather than a page.
+ *
+ *  This exists because the opposite was tried by omission. An error page is HTML,
+ *  so it collected the same policy as the page it replaced, and Cloudflare stored a
+ *  500 under the URL and served it as a HIT for the next hour — `s-maxage=3600` on
+ *  an entity page, with `stale-while-revalidate=86400` extending it up to a day.
+ *  A blue/green flip that 500s for a few seconds therefore outlives itself by
+ *  hours, on pages the origin is already serving correctly again. */
+export const NO_CACHE = 'no-store';
+
 /** Route trees that are never shared, whoever asks. An anonymous hit here is a
  *  sign-in screen or a redirect, which is not worth handing to the next visitor. */
 const PRIVATE_ROOTS = new Set(['my', 'auth', 'moderation', 'delete-account']);
@@ -55,11 +67,23 @@ const DETAIL_ROOTS = new Set(['jobs', 'companies', 'blog']);
 export function cachePolicy({
   pathname,
   authenticated,
+  status = 200,
 }: {
   pathname: string;
   authenticated: boolean;
+  /** The response's status. Absent means "nothing went wrong" — the parameter was
+   *  added after the fact, and a caller that doesn't pass one is describing a page,
+   *  not a failure. */
+  status?: number;
 }): string {
+  // The signed-in guard outranks everything, including the error rule: a 500
+  // rendered for a signed-in visitor still carries their header state, so it is
+  // private first and uncacheable second. NO_CACHE would be the weaker claim.
   if (authenticated) return PRIVATE_CACHE;
+  // Only 5xx. A 404 is a stable fact about the URL — closed postings are a routine
+  // and permanent outcome here, in large numbers, and letting the edge absorb those
+  // repeats is exactly what this cache is for. A 5xx describes a moment.
+  if (status >= 500) return NO_CACHE;
   // Compare whole segments: /myths is not under /my.
   const segments = pathname.split('/').filter(Boolean);
   const [root] = segments;


### PR DESCRIPTION
The cache hook keyed on method and content-type and never looked at the status. An error page is HTML like any other, so a 500 collected the same policy as the page it replaced — `s-maxage=3600, stale-while-revalidate=86400` on an entity page. Cloudflare stored it and served it as a HIT.

## Seen in production today

A blue/green flip 500ed for a few seconds while the old colour was still answering. The edge cached that, and `/companies/stripe` kept returning 500 with `cf-cache-status: HIT` and `age: 84` long after both colours were serving it correctly — directly against the node servers it was 200 the whole time.

A transient failure had outlived itself by an hour, and `stale-while-revalidate=86400` could have stretched that to a day.

The wider case is worse than one page. If the API is briefly unreachable during a deploy, every SSR load 500s — and the edge would hold a broken copy of much of the catalogue at once, visibly long after recovery, with nothing in the origin to explain it.

## The rule

5xx now gets `no-store`.

**Only 5xx.** A 404 is a stable fact about the URL rather than a symptom: closed postings are a routine, permanent outcome here and there are a great many of them, so letting the edge absorb those repeats is exactly what this cache is for. A 5xx describes a moment.

**The signed-in guard still outranks both.** A 500 rendered for a signed-in visitor carries their header state, so it stays `private, no-store` — `no-store` alone would be the weaker claim.

The status is threaded through `cachePolicy` rather than checked in the hook, so the rule lives with the others and is unit-testable. `status` defaults to 200, so callers that don't pass one are unchanged.

## Verified

Against a production build pointed at no API, so the 500s are real rather than mocked:

| Path | Status | Cache-Control |
|---|---|---|
| `/` (no API) | 500 | `no-store` |
| `/companies/stripe` (no API) | 500 | `no-store` |
| `/` | 200 | `s-maxage=300, stale-while-revalidate=86400` |
| `/companies/stripe` | 200 | `s-maxage=3600, …` |
| `/jobs/does-not-exist` | 404 | `s-maxage=3600, …` |
| `/nonexistent-page` | 404 | `s-maxage=300, …` |

- `pnpm test` — 1085 pass (4 added)
- `pnpm lint` — clean; `pnpm check` — 0 errors
- `go vet -tags=integration ./...` — clean
