### PR TITLE
Move Employer credentials to Relocation, fold AI Specialization into Role

### DIFF
--- a/web/src/lib/components/filters/ChipFacet.svelte
+++ b/web/src/lib/components/filters/ChipFacet.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { FACETS, type FacetStore } from '$lib/facets';
+  import { FACETS, type FacetOption, type FacetStore } from '$lib/facets';
   import type { FacetCounts } from '$lib/types';
   import FacetHeader from './FacetHeader.svelte';
   import PillGroup from '../facets/PillGroup.svelte';
@@ -9,22 +9,38 @@
   // excludable flag come from the registry (by `param`), so a caller only names the
   // facet. Excludable facets cycle each pill off → include → exclude → off. When
   // `counts` is passed, each pill shows its live match count under the current scope.
-  let { store, param, label, counts = null }: { store: FacetStore; param: string; label: string; counts?: FacetCounts | null } = $props();
+  //
+  // `options`, when passed, overrides the registry's list — for a param rendered as
+  // more than one block (e.g. `collections` split between Industry & collection and
+  // Relocation). It scopes the header's count and Clear to just that subset too, so a
+  // block only reports and clears the values it actually shows, not the whole param.
+  let {
+    store,
+    param,
+    label,
+    counts = null,
+    options: optionsOverride,
+  }: { store: FacetStore; param: string; label: string; counts?: FacetCounts | null; options?: FacetOption[] } =
+    $props();
 
   const def = FACETS.find((d) => d.param === param);
   const excludable = def?.excludable ?? false;
   const st = $derived(store.facet(param));
+  const scoped = $derived(optionsOverride !== undefined);
+  const baseOptions = $derived(optionsOverride ?? def?.options ?? []);
+  const scopedValues = $derived(new Set(baseOptions.map((o) => o.value)));
+  const include = $derived(scoped ? st.include.filter((v) => scopedValues.has(v)) : st.include);
+  const exclude = $derived(scoped ? st.exclude.filter((v) => scopedValues.has(v)) : st.exclude);
   const onToggle = (v: string) => (excludable ? store.cycle(param, v) : store.pick(param, v));
 
   // Merge the live distribution counts into the static registry options.
   const options = $derived.by(() => {
     const dist = counts?.facets?.[param];
-    const base = def?.options ?? [];
-    return dist ? base.map((o) => ({ ...o, count: dist[o.value] ?? 0 })) : base;
+    return dist ? baseOptions.map((o) => ({ ...o, count: dist[o.value] ?? 0 })) : baseOptions;
   });
 </script>
 
 <div>
-  <FacetHeader {store} {param} {label} />
-  <PillGroup {options} include={st.include} exclude={st.exclude} {excludable} {onToggle} />
+  <FacetHeader {store} {param} {label} values={scoped ? [...scopedValues] : undefined} />
+  <PillGroup {options} {include} {exclude} {excludable} {onToggle} />
 </div>

--- a/web/src/lib/components/filters/FacetHeader.svelte
+++ b/web/src/lib/components/filters/FacetHeader.svelte
@@ -6,10 +6,28 @@
   // has a selection). Shared by the chip facets and the Specialization pane so the
   // per-facet header reads identically everywhere. Include/exclude is chosen per
   // value on the pills themselves, so there is no facet-wide exclude toggle here.
-  let { store, param, label }: { store: FacetStore; param: string; label: string } = $props();
+  //
+  // `values`, when passed, scopes the count and Clear to just that subset of the
+  // param's values — for a param rendered as more than one block (see ChipFacet's
+  // `options` override), so this header doesn't count or clear values shown in a
+  // different block that happens to share the same param.
+  let { store, param, label, values }: { store: FacetStore; param: string; label: string; values?: string[] } =
+    $props();
 
   const st = $derived(store.facet(param));
-  const total = $derived(st.include.length + st.exclude.length);
+  const total = $derived(
+    values
+      ? values.filter((v) => st.include.includes(v) || st.exclude.includes(v)).length
+      : st.include.length + st.exclude.length,
+  );
+
+  function clear() {
+    if (values) {
+      for (const v of values) store.remove(param, v);
+    } else {
+      store.clearFacet(param);
+    }
+  }
 </script>
 
 <div class="mb-2 flex min-h-6 items-center justify-between gap-2">
@@ -17,7 +35,7 @@
   {#if total > 0}
     <button
       type="button"
-      onclick={() => store.clearFacet(param)}
+      onclick={clear}
       title="Clear {label}"
       aria-label="Clear {label}"
       class="flex size-5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"

--- a/web/src/lib/components/filters/FilterModal.svelte
+++ b/web/src/lib/components/filters/FilterModal.svelte
@@ -3,7 +3,7 @@
   import { resolve } from '$app/paths';
   import { Bell, Info, UserRound } from '@lucide/svelte';
   import { Tooltip } from '$lib/ui';
-  import { FACETS } from '$lib/facets';
+  import { EMPLOYER_CREDENTIALS, FACETS, JOB_COLLECTION } from '$lib/facets';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import { profileStore } from '$lib/profile.svelte';
@@ -129,22 +129,33 @@
     ),
   ]);
 
+  const jobCollectionValues = JOB_COLLECTION.map((o) => o.value);
+  const employerCredentialValues = EMPLOYER_CREDENTIALS.map((o) => o.value);
+
   // Values selected for one facet — included plus excluded — so the rail count reflects
-  // any staged selection regardless of sign.
-  function selCount(f: JobFilters, param: string): number {
+  // any staged selection regardless of sign. `values`, when passed, scopes the count to
+  // just that subset — for a param split across two panes (see ChipFacet's `options`
+  // override), so a badge doesn't count values shown under a different tab.
+  function selCount(f: JobFilters, param: string, values?: string[]): number {
     const st = f.facets[param];
-    return st ? st.include.length + st.exclude.length : 0;
+    if (!st) return 0;
+    if (!values) return st.include.length + st.exclude.length;
+    const allowed = new Set(values);
+    return st.include.filter((v) => allowed.has(v)).length + st.exclude.filter((v) => allowed.has(v)).length;
   }
 
   function entryCount(e: RailEntry): number {
     const f = staged.value;
-    if (e.kind === 'category') return selCount(f, 'role') + selCount(f, 'category') + selCount(f, 'seniority');
+    if (e.kind === 'category')
+      return selCount(f, 'role') + selCount(f, 'category') + selCount(f, 'seniority') + selCount(f, 'ai_archetype');
     if (e.kind === 'location') return selCount(f, 'regions') + selCount(f, 'countries') + selCount(f, 'cities');
     if (e.kind === 'salary') return selCount(f, 'salary_currency') + (f.salaryMin != null ? 1 : 0);
     if (e.kind === 'work') return selCount(f, 'work_mode') + selCount(f, 'employment_type');
-    if (e.kind === 'industry') return selCount(f, 'domains') + selCount(f, 'company_type') + selCount(f, 'collections');
+    if (e.kind === 'industry')
+      return selCount(f, 'domains') + selCount(f, 'company_type') + selCount(f, 'collections', jobCollectionValues);
     if (e.kind === 'language') return selCount(f, 'english_level') + selCount(f, 'posting_language');
-    if (e.kind === 'relocation') return selCount(f, 'relocation') + (f.visa ? 1 : 0);
+    if (e.kind === 'relocation')
+      return selCount(f, 'relocation') + (f.visa ? 1 : 0) + selCount(f, 'collections', employerCredentialValues);
     if (e.kind === 'posted') return f.postedWithinDays != null ? 1 : 0;
     // The Minimum skill match threshold lives at the top of the Skills pane, so it
     // counts toward that tab's badge alongside the skills facet selections.
@@ -291,6 +302,12 @@
     {:else}
       <CategoryPane store={staged} {plain} counts={c} />
     {/if}
+    {#if !exclude.includes('ai_archetype')}
+      {@const aiArchetypeDef = facetDefFor('ai_archetype')}
+      {#if aiArchetypeDef}
+        <div class="mt-6"><FacetSection def={aiArchetypeDef} store={staged} counts={c} expand /></div>
+      {/if}
+    {/if}
   {:else if entry.kind === 'location'}
     <LocationPane store={staged} counts={c} />
   {:else if entry.kind === 'facet'}
@@ -338,12 +355,23 @@
   {:else if entry.kind === 'industry'}
     <ChipFacet store={staged} param="domains" label="Industry" counts={c} />
     <div class="mt-6"><ChipFacet store={staged} param="company_type" label="Company type" counts={c} /></div>
-    <div class="mt-6"><ChipFacet store={staged} param="collections" label="Collection" counts={c} /></div>
+    <div class="mt-6">
+      <ChipFacet store={staged} param="collections" label="Collection" counts={c} options={JOB_COLLECTION} />
+    </div>
   {:else if entry.kind === 'language'}
     {#if englishDef}<FacetSection def={englishDef} store={staged} counts={c} expand />{/if}
     <div class="mt-4">{#if postingDef}<FacetSection def={postingDef} store={staged} counts={c} expand />{/if}</div>
   {:else if entry.kind === 'relocation'}
     <ChipFacet store={staged} param="relocation" label="Relocation" counts={c} />
+    <div class="mt-6">
+      <ChipFacet
+        store={staged}
+        param="collections"
+        label="Employer credentials"
+        counts={c}
+        options={EMPLOYER_CREDENTIALS}
+      />
+    </div>
     <h3 class="mb-2 mt-6 text-sm font-semibold tracking-tight">Visa</h3>
     <label class="flex cursor-pointer items-center gap-2 text-sm">
       <input

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -433,6 +433,24 @@ const COLLECTION: FacetOption[] = [
   })),
 ];
 
+// The job filter modal splits COLLECTION across two panes instead of one grouped
+// list: the curated picks stay on Industry & collection, the credentials move to
+// their own block on the Relocation pane (they're evidence of visa/sponsorship
+// eligibility, which is what that pane is about). Both stay ChipFacet `options`
+// overrides on the same `collections` param rather than becoming separate FACETS
+// entries — a second entry sharing the param would double its value in the query
+// string. The company modal has no Relocation pane to split into, so it keeps using
+// COLLECTION (and its "Employer credentials" sub-heading) unchanged.
+export const JOB_COLLECTION: FacetOption[] = COLLECTION.filter((o) => o.group !== 'Employer credentials');
+
+// Stripped of `group`: this renders as its own ChipFacet block with its own "Employer
+// credentials" header, so the in-list sub-heading PillGroup would otherwise add above
+// the first pill (COLLECTION's grouping cue for the combined company-modal list) would
+// just repeat that header.
+export const EMPLOYER_CREDENTIALS: FacetOption[] = COLLECTION.filter((o) => o.group === 'Employer credentials').map(
+  ({ group: _group, ...o }) => o,
+);
+
 // Company-size buckets — the vocab.CompanySizeValues vocabulary. Not exported as
 // a generated values array (it's a scalar enrichment field, not a search facet on
 // jobs), so the closed set is spelled out here like CURRENCY; the values are

--- a/web/src/lib/filterSections.test.ts
+++ b/web/src/lib/filterSections.test.ts
@@ -1,17 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { RAIL } from './filterSections';
 
-describe('the ai_archetype rail entry', () => {
-  it('is registered right after category, so the facet is reachable in the modal', () => {
-    const categoryIndex = RAIL.findIndex((e) => e.key === 'category');
-    const archetypeIndex = RAIL.findIndex((e) => e.key === 'ai_archetype');
-    expect(archetypeIndex).toBeGreaterThan(-1);
-    expect(archetypeIndex).toBe(categoryIndex + 1);
-  });
-
-  it('renders through the generic facet path with the ai_archetype param', () => {
-    const entry = RAIL.find((e) => e.key === 'ai_archetype');
-    expect(entry?.kind).toBe('facet');
-    expect(entry?.facetParam).toBe('ai_archetype');
+describe('the ai_archetype facet', () => {
+  it('has no standalone rail entry — FilterModal folds it into the Role pane instead', () => {
+    expect(RAIL.find((e) => e.key === 'ai_archetype')).toBeUndefined();
+    expect(RAIL.find((e) => e.facetParam === 'ai_archetype')).toBeUndefined();
   });
 });

--- a/web/src/lib/filterSections.ts
+++ b/web/src/lib/filterSections.ts
@@ -150,12 +150,12 @@ export const COMPANY_RAIL_GROUPS: CompanyRailGroup[] = [
 
 export const RAIL: RailEntry[] = [
   // One "Role" pane holds the whole "what role" concept: the role picker
-  // (natural/named/composite roles), the seniority pills, and the specialization
-  // chips — three controls, one tab. They overlap by design (role=senior is also
-  // reachable via the seniority pill); the picker is the natural-language entry,
-  // the pills/chips the browse-by-axis entry.
+  // (natural/named/composite roles), the seniority pills, the specialization
+  // chips, and the AI Specialization facet — four controls, one tab. They overlap
+  // by design (role=senior is also reachable via the seniority pill); the picker is
+  // the natural-language entry, the pills/chips/AI-specialization the browse-by-axis
+  // entry.
   { key: 'category', label: 'Role', section: 'ROLE', kind: 'category' },
-  { key: 'ai_archetype', label: 'AI Specialization', section: 'ROLE', kind: 'facet', facetParam: 'ai_archetype' },
   { key: 'location', label: 'Location', section: 'ROLE', kind: 'location' },
   { key: 'work', label: 'Work & employment', section: 'ROLE', kind: 'work' },
   { key: 'skills', label: 'Skills', section: 'ROLE', kind: 'facet', facetParam: 'skills' },


### PR DESCRIPTION
## Summary
- Employer credentials pills (Licensed UK/NL sponsor, H-1B sponsor history) move from the Industry & collection tab to the Relocation tab, right after the Relocation chips and before the Visa checkbox — they're evidence of visa/sponsorship eligibility, so that's where they belong.
- AI Specialization stops being its own rail tab and instead renders at the end of the Role tab, alongside the role picker, Seniority, and Specialization chips.
- `ChipFacet`/`FacetHeader` gain an optional `options` override that scopes a block's header count and Clear button to just the values it renders, since `collections` is now rendered as two separate blocks sharing one facet param (avoids double-counting/cross-clearing between the two).

## Test plan
- [x] `go vet`/`gofmt` not applicable (frontend-only change)
- [x] `npx svelte-check` — 0 errors
- [x] `npx vitest run` — 1071 passed (full web suite), including updated `filterSections.test.ts`
- [x] `npx eslint` on touched files — clean
- [x] Live-verified in a browser against a local dev stack: Role tab shows AI Specialization at the bottom, Relocation tab shows Employer credentials between Relocation chips and Visa, Industry & collection no longer shows Employer credentials
- [x] Verified selecting a credential pill on Relocation doesn't affect Industry & collection's Collection header count/Clear, and vice versa

🤖 Generated with [Claude Code](https://claude.com/claude-code)