### PR TITLE
merge-companies: fall back to the slug the rule yields

### DIFF
--- a/cmd/merge-companies/plan.go
+++ b/cmd/merge-companies/plan.go
@@ -89,10 +89,10 @@ func planMerges(companies []company, frozen map[string]bool, minJobs int) []merg
 		})
 
 		winner := electCanonical(members, frozen)
-		m := merge{Canonical: winner.Slug, FoldedKey: key}
+		m := merge{Canonical: winner, FoldedKey: key}
 		for _, c := range members {
 			m.Jobs += c.JobCount
-			if c.Slug == winner.Slug {
+			if c.Slug == winner {
 				continue
 			}
 			m.Aliases = append(m.Aliases, alias{
@@ -125,28 +125,35 @@ func planMerges(companies []company, frozen map[string]bool, minJobs int) []merg
 //     catalogue's canonical url the one carrying the form and 301'd the better-known slug into
 //     it. It is also unstable, since every new posting derives the stripped slug and would need
 //     an alias row for the canon to reach itself.
-//  3. Failing that, the biggest. A group where nothing is a fixed point is odd but real, and
-//     merging it under an imperfect canon still beats leaving the employer split.
-func electCanonical(members []company, frozen map[string]bool) company {
+//  3. Failing that, the slug the rule YIELDS for the biggest member, even though no row holds
+//     it yet. A group where every member carries a form is real — carnival-corporation and
+//     carnival-corporation-plc were two of four in the >=100-job wave — and picking the least
+//     bad existing row would leave the form on the canonical url, which is the outcome rule 2
+//     exists to prevent. The derived slug is what every future posting keys to, and the
+//     reconcile that follows the re-key creates its row.
+//
+// Returning a slug no member holds is safe: if a company already used it, its name would fold
+// to the same key and it would BE a member — and would have won rule 2.
+func electCanonical(members []company, frozen map[string]bool) string {
 	for _, c := range members {
 		if frozen[c.Slug] {
-			return c
+			return c.Slug
 		}
 	}
 	for _, c := range members {
 		if normalize.CompanySlug(c.Slug) == c.Slug {
-			return c
+			return c.Slug
 		}
 	}
-	return members[0]
+	return normalize.CompanySlug(members[0].Name)
 }
 
 // reasonFor classifies why a slug is retiring. The test is whether the current pure rule,
 // applied to the alias's OWN name, already reaches the canonical slug: if it does, this
 // duplicate exists only because the catalogue was keyed before that rule did, and nothing but
 // the redirect needs the registry.
-func reasonFor(c, winner company) string {
-	if normalize.CompanySlug(c.Name) == winner.Slug {
+func reasonFor(c company, winner string) string {
+	if normalize.CompanySlug(c.Name) == winner {
 		return reasonLegalForm
 	}
 	return reasonSpelling

--- a/cmd/merge-companies/plan_test.go
+++ b/cmd/merge-companies/plan_test.go
@@ -159,3 +159,33 @@ func TestPlanMerges_FrozenCanonWinsEvenIfItCarriesAForm(t *testing.T) {
 		t.Errorf("Canonical = %q, want acme-inc (frozen)", got[0].Canonical)
 	}
 }
+
+// TestPlanMerges_FallsBackToTheDerivedSlug covers the group where NOTHING is a fixed point.
+//
+// The >=100-job wave surfaced four: carnival-corporation, dcs-corporation, quess-corp-limited,
+// avaron-pte-ltd. Every member carried a form, so "the biggest fixed point" found none and the
+// election fell back to the biggest member — leaving a canonical url with the form still on it,
+// which is the outcome the fixed-point rule exists to prevent.
+//
+// The right canon is the one the rule itself yields, whether or not a company row holds it yet:
+// that is the slug every future posting derives, and the reconcile creates the row.
+func TestPlanMerges_FallsBackToTheDerivedSlug(t *testing.T) {
+	got := planMerges([]company{
+		{Slug: "carnival-corporation", Name: "Carnival Corporation", JobCount: 300},
+		{Slug: "carnival-corporation-plc", Name: "Carnival Corporation plc", JobCount: 40},
+	}, nil, 0)
+
+	if len(got) != 1 {
+		t.Fatalf("planned %d merges, want 1", len(got))
+	}
+	if got[0].Canonical != "carnival" {
+		t.Errorf("Canonical = %q, want carnival — with no member the rule can reproduce, the "+
+			"canon is what the rule yields, not the least bad row that happens to exist",
+			got[0].Canonical)
+	}
+	// Both rows retire into it, including the one the election started from.
+	if len(got[0].Aliases) != 2 {
+		t.Errorf("got %d aliases, want 2 — every existing slug retires when none of them is "+
+			"the canon", len(got[0].Aliases))
+	}
+}

--- a/docs/agents/company-identity.md
+++ b/docs/agents/company-identity.md
@@ -100,7 +100,11 @@ crawl would put it back, and the display name comes from `companies.name` regard
   jobs) purely because it was larger — making the canonical url the one carrying a corporate
   form, and 301ing the better-known slug into it. It is unstable too: every new posting derives
   the stripped slug, so the canon would depend forever on an alias row to reach itself. The
-  election prefers the biggest slug `CompanySlug` can reproduce, and only then the biggest.
+  election prefers the biggest slug `CompanySlug` can reproduce; where NO member qualifies —
+  `carnival-corporation` beside `carnival-corporation-plc`, four such groups in the >=100-job
+  wave — it takes the slug the rule yields even though no row holds it yet, and the reconcile
+  creates that row. Returning a slug no member holds is safe: a company already using it would
+  fold to the same key, so it would be a member and would have won outright.
 - **Electing by anything but job count elects backwards.** "Prefer the more readable slug" is
   the tempting rule and it picks `domino-s` (1 job) over `dominos` (14,396) and `al-fa-bank`
   (20) over `alfa-bank` (1,617). Hyphens mark the corrupted spelling about as often as the


### PR DESCRIPTION
Third defect the prod dry runs have caught, and the last of this family.

#2101 made the election prefer a canonical slug `CompanySlug` can reproduce. It did not say what to do when **no member qualifies**. The `--min-jobs 100` wave has four such groups — `carnival-corporation` beside `carnival-corporation-plc`, plus `dcs-corporation`, `quess-corp-limited`, `avaron-pte-ltd` — where every member carries a form. The fallback took the biggest existing row, leaving the form on the canonical url: exactly what #2101 exists to prevent.

The right canon is the one the rule yields (`carnival`). That is the slug every future posting derives, so it is the only stable answer, and the reconcile that follows the re-key creates the row.

Returning a slug no member holds is safe: a company already using it would fold to the same key, so it would be a member — and would have won outright under rule 2.

Nothing beyond wave 1 has been applied; this lands before `--min-jobs 100`.

`go test ./...` 165 ok · `go vet -tags=integration` clean.