### PR TITLE
Choose a spelling by how the employer writes its name, and stop backfill-derive undoing the merges

### DIFF
--- a/cmd/backfill-derive/derive_alias_test.go
+++ b/cmd/backfill-derive/derive_alias_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobhash"
+)
+
+// TestDeriveRow_ResolvesThroughTheAliasRegistry guards the merges against this worker.
+//
+// deriveRow re-derives every column from jobderive, which is a PURE function with no
+// knowledge of company_slug_aliases. Left alone it would rewrite every posting a merge moved
+// back to the spelling its source happened to use — silently undoing the whole spelling class,
+// and churning role_fingerprint with it, since the fingerprint is computed from the company
+// slug. A backfill is a routine ~15h run, so this is not a hypothetical.
+func TestDeriveRow_ResolvesThroughTheAliasRegistry(t *testing.T) {
+	canon := map[string]string{"dollartree": "dollar-tree"}
+	job := db.Job{
+		ID: 1, Title: "Backend Engineer", Company: "DollarTree",
+		Source: "adzuna", ExternalID: "1", CompanySlug: "dollar-tree",
+	}
+
+	params, changed, slugMoved := deriveRow(job, canon)
+
+	if params.CompanySlug != "dollar-tree" {
+		t.Errorf("CompanySlug = %q, want dollar-tree — the merge must survive a re-derive",
+			params.CompanySlug)
+	}
+	// The company slug is the point; the fixture leaves other derived columns empty, so
+	// `changed` says nothing here. What must hold is that the SLUG did not move: the stored
+	// value already is the canonical one.
+	_ = changed
+	if slugMoved && params.CompanySlug != job.CompanySlug {
+		t.Error("the company slug moved away from the canonical one it already held")
+	}
+}
+
+// TestDeriveRow_FingerprintFollowsTheCanonicalSlug: role_fingerprint is computed from the
+// company slug, so it has to be computed from the RESOLVED one or every merged posting's
+// repost identity churns on the next backfill.
+func TestDeriveRow_FingerprintFollowsTheCanonicalSlug(t *testing.T) {
+	canon := map[string]string{"dollartree": "dollar-tree"}
+	job := db.Job{
+		ID: 1, Title: "Backend Engineer", Company: "DollarTree",
+		Source: "adzuna", ExternalID: "1", CompanySlug: "dollartree",
+	}
+
+	params, _, _ := deriveRow(job, canon)
+
+	want := jobhash.RoleFingerprint(db.UpsertJobParams{
+		CompanySlug: "dollar-tree", Title: job.Title, Description: job.Description,
+	})
+	if params.RoleFingerprint.String != want {
+		t.Errorf("RoleFingerprint was computed from the unresolved slug")
+	}
+}
+
+// TestDeriveRow_WithNoRegistryIsUnchanged: an empty registry must leave the derivation exactly
+// as it was, so the guard cannot alter a catalogue that has never been merged.
+func TestDeriveRow_WithNoRegistryIsUnchanged(t *testing.T) {
+	job := db.Job{ID: 1, Title: "Backend Engineer", Company: "DollarTree", Source: "adzuna", ExternalID: "1"}
+	params, _, _ := deriveRow(job, nil)
+	if params.CompanySlug != "dollartree" {
+		t.Errorf("CompanySlug = %q, want dollartree", params.CompanySlug)
+	}
+}

--- a/cmd/backfill-derive/main.go
+++ b/cmd/backfill-derive/main.go
@@ -63,6 +63,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"slices"
@@ -76,6 +77,7 @@ import (
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/jobderive"
 	"github.com/strelov1/freehire/internal/jobhash"
+	"github.com/strelov1/freehire/internal/normalize"
 	"github.com/strelov1/freehire/internal/pgconv"
 	"github.com/strelov1/freehire/internal/worker"
 )
@@ -103,6 +105,7 @@ type deriveStore interface {
 	// from its readable neighbours.
 	worker.FullScanQueries
 	UpdateJobDerived(ctx context.Context, arg db.UpdateJobDerivedParams) error
+	ListCompanySlugAliases(ctx context.Context) ([]db.ListCompanySlugAliasesRow, error)
 }
 
 func main() {
@@ -162,7 +165,7 @@ func backfillConcurrency() int {
 // re-keying). The fingerprint is computed from the freshly derived company_slug, so
 // the result matches what cmd/ingest/store.go writes for the same raw fields. Pure —
 // safe to call concurrently.
-func deriveRow(j db.Job) (params db.UpdateJobDerivedParams, changed, slugMoved bool) {
+func deriveRow(j db.Job, canon map[string]string) (params db.UpdateJobDerivedParams, changed, slugMoved bool) {
 	d := jobderive.Derive(jobderive.Input{
 		Title:       j.Title,
 		Company:     j.Company,
@@ -172,6 +175,12 @@ func deriveRow(j db.Job) (params db.UpdateJobDerivedParams, changed, slugMoved b
 		Description: j.Description,
 		WorkMode:    j.WorkMode, // preserves a set work_mode (jobderive precedence)
 	})
+	// jobderive is pure, so it re-derives the spelling the SOURCE used. Resolving through the
+	// alias registry here is what stops a backfill silently undoing every merge — and it must
+	// happen before the fingerprint, which is computed from the company slug.
+	if canonical, ok := canon[normalize.FoldSlug(d.CompanySlug)]; ok {
+		d.CompanySlug = canonical
+	}
 	fingerprint := jobhash.RoleFingerprint(db.UpsertJobParams{
 		CompanySlug: d.CompanySlug,
 		Title:       j.Title,
@@ -235,10 +244,39 @@ func backfillAll(ctx context.Context, store deriveStore, concurrency int) (scann
 // report fires ON each multiple of every, from whichever worker happens to cross it —
 // the counter is atomic, so exactly one goroutine observes each multiple whatever the
 // concurrency. It runs on the worker's goroutine, so it must stay cheap.
+// loadAliasRegistry reads company_slug_aliases into a folded-key lookup.
+//
+// A backfill that could not read it must FAIL rather than proceed: an empty registry looks
+// exactly like a catalogue with no merges, and proceeding would rewrite every merged posting
+// back to its source spelling — the one failure mode this guard exists for.
+func loadAliasRegistry(ctx context.Context, store deriveStore) (map[string]string, error) {
+	rows, err := store.ListCompanySlugAliases(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load company slug aliases: %w", err)
+	}
+	canon := make(map[string]string, len(rows))
+	for _, r := range rows {
+		if _, seen := canon[r.FoldedKey]; !seen {
+			canon[r.FoldedKey] = r.CanonicalSlug
+		}
+	}
+	log.Printf("backfill-derive: company alias registry loaded (%d folded keys)", len(canon))
+	return canon, nil
+}
+
 func backfillProgress(ctx context.Context, store deriveStore, concurrency int, every int64, report func(scanned, updated, slugsMoved int64)) (scanned, updated, slugsMoved int, err error) {
 	if concurrency < 1 {
 		concurrency = 1
 	}
+
+	// Loaded ONCE for the whole run rather than per row: the registry is small (one entry per
+	// retired slug) and the pool re-derives millions of rows. Read before any worker starts,
+	// so every row in a run resolves against the same registry.
+	canon, err := loadAliasRegistry(ctx, store)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -309,7 +347,7 @@ func backfillProgress(ctx context.Context, store deriveStore, concurrency int, e
 				if every > 0 && n%every == 0 && report != nil {
 					report(n, atomic.LoadInt64(&updatedN), atomic.LoadInt64(&slugsN))
 				}
-				params, changed, slugMoved := deriveRow(j)
+				params, changed, slugMoved := deriveRow(j, canon)
 				if !changed {
 					continue
 				}

--- a/cmd/backfill-derive/main_test.go
+++ b/cmd/backfill-derive/main_test.go
@@ -80,6 +80,12 @@ func (f *fakeStore) GetJob(_ context.Context, id int64) (db.Job, error) {
 	return db.Job{}, pgx.ErrNoRows
 }
 
+// ListCompanySlugAliases: this fake catalogue holds no merges, so the registry is empty and
+// the derivation is unchanged by it. A test that wants a merged row hands deriveRow its own.
+func (f *fakeStore) ListCompanySlugAliases(context.Context) ([]db.ListCompanySlugAliasesRow, error) {
+	return nil, nil
+}
+
 func (f *fakeStore) UpdateJobDerived(_ context.Context, arg db.UpdateJobDerivedParams) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/cmd/merge-companies/plan.go
+++ b/cmd/merge-companies/plan.go
@@ -3,6 +3,7 @@ package main
 import (
 	"cmp"
 	"slices"
+	"strings"
 
 	"github.com/strelov1/freehire/internal/normalize"
 )
@@ -140,12 +141,43 @@ func electCanonical(members []company, frozen map[string]bool) string {
 			return c.Slug
 		}
 	}
+	var fixed []company
 	for _, c := range members {
 		if normalize.CompanySlug(c.Slug) == c.Slug {
-			return c.Slug
+			fixed = append(fixed, c)
 		}
 	}
+	if len(fixed) > 0 {
+		// Among spellings the rule can reproduce, prefer one the employer WRITES in several
+		// words. Job count alone cannot see this: it elects `westerndigital` over
+		// `western-digital` and `acehardware` over `ace-hardware` purely on volume, 73 times
+		// in the >=100-job wave.
+		//
+		// The signal is the NAME, never the slug. "Domino's" slugs to `domino-s`, where an
+		// apostrophe is indistinguishable from a word break — which is exactly why "prefer
+		// the more hyphenated slug" elected `domino-s` over `dominos` and had to be dropped.
+		//
+		// It only speaks when it discriminates. Where no name is multi-word (Domino's) or
+		// every name is (Alfa Bank beside Al Fa Bank), it says nothing and the count decides,
+		// as it did before.
+		for _, c := range fixed {
+			if nameWords(c.Name) > 1 {
+				return c.Slug
+			}
+		}
+		return fixed[0].Slug
+	}
 	return normalize.CompanySlug(members[0].Name)
+}
+
+// nameWords counts the whitespace words of a name that are the name proper, trailing legal
+// forms dropped: "Ace Hardware Corporation" is a two-word employer, not a three-word one.
+func nameWords(name string) int {
+	fields := strings.Fields(name)
+	for len(fields) > 1 && normalize.IsLegalForm(fields[len(fields)-1]) {
+		fields = fields[:len(fields)-1]
+	}
+	return len(fields)
 }
 
 // reasonFor classifies why a slug is retiring. The test is whether the current pure rule,

--- a/cmd/merge-companies/plan_test.go
+++ b/cmd/merge-companies/plan_test.go
@@ -126,9 +126,12 @@ func TestPlanMerges_CanonicalIsAFixedPointOfTheSlugRule(t *testing.T) {
 	}
 }
 
-// TestPlanMerges_JobCountStillDecidesBetweenFixedPoints: the fixed-point preference is a
-// tie-break BEFORE job count, not a replacement for it. Both spellings here are ones the rule
-// produces, so the bigger one still wins — including when it is the uglier of the two.
+// TestPlanMerges_JobCountStillDecidesBetweenFixedPoints: the preferences are tie-breaks BEFORE
+// job count, not replacements for it. Where neither the fixed-point rule nor the word shape of
+// the name discriminates, the bigger spelling still wins.
+//
+// This once asserted that turnertownsend beats turner-townsend on volume. The employer writes
+// two words, so the word-shape rule now takes it the other way — and that is the better url.
 func TestPlanMerges_JobCountStillDecidesBetweenFixedPoints(t *testing.T) {
 	got := planMerges([]company{
 		{Slug: "dollartree", Name: "DollarTree", JobCount: 283},
@@ -138,13 +141,13 @@ func TestPlanMerges_JobCountStillDecidesBetweenFixedPoints(t *testing.T) {
 		t.Errorf("Canonical = %q, want dollar-tree", got[0].Canonical)
 	}
 
+	// Both spellings of one WORD: the count decides and nothing else has an opinion.
 	got = planMerges([]company{
-		{Slug: "turner-townsend", Name: "Turner Townsend", JobCount: 16},
-		{Slug: "turnertownsend", Name: "TurnerTownsend", JobCount: 400},
+		{Slug: "dominos", Name: "Dominos", JobCount: 14396},
+		{Slug: "domino-s", Name: "Domino's", JobCount: 1},
 	}, nil, 0)
-	if got[0].Canonical != "turnertownsend" {
-		t.Errorf("Canonical = %q, want turnertownsend — both are fixed points, so the count "+
-			"decides even though the hyphenated one reads better", got[0].Canonical)
+	if got[0].Canonical != "dominos" {
+		t.Errorf("Canonical = %q, want dominos", got[0].Canonical)
 	}
 }
 
@@ -188,4 +191,63 @@ func TestPlanMerges_FallsBackToTheDerivedSlug(t *testing.T) {
 		t.Errorf("got %d aliases, want 2 — every existing slug retires when none of them is "+
 			"the canon", len(got[0].Aliases))
 	}
+}
+
+// TestPlanMerges_PrefersTheSpellingTheNameIsWrittenIn decides the spelling class by the shape
+// of the NAME, which is the signal job count alone cannot see.
+//
+// The >=100-job wave elects a squashed canonical over a hyphenated one 73 times out of 162
+// spelling merges. Some are right — AT&T really is one word, so `att` beats `at-t` — and some
+// are plainly wrong: `accenturefederalservices`, `acehardware`, `westerndigital`. What tells
+// them apart is not the slug but whether the employer writes its name with spaces.
+//
+// This is also why "prefer the more hyphenated slug" failed and this does not: that rule read
+// the slug, where a stray apostrophe looks exactly like a word break.
+func TestPlanMerges_PrefersTheSpellingTheNameIsWrittenIn(t *testing.T) {
+	t.Run("a multi-word name keeps its word breaks", func(t *testing.T) {
+		got := planMerges([]company{
+			{Slug: "westerndigital", Name: "WesternDigital", JobCount: 400},
+			{Slug: "western-digital", Name: "Western Digital", JobCount: 126},
+		}, nil, 0)
+		if got[0].Canonical != "western-digital" {
+			t.Errorf("Canonical = %q, want western-digital — the employer writes two words",
+				got[0].Canonical)
+		}
+	})
+
+	t.Run("no member is multi-word, so the count decides", func(t *testing.T) {
+		// The counterexample that killed "prefer hyphens": the break in `domino-s` comes from
+		// an apostrophe, not a space, and neither name has a space at all.
+		got := planMerges([]company{
+			{Slug: "dominos", Name: "Dominos", JobCount: 14396},
+			{Slug: "domino-s", Name: "Domino's", JobCount: 1},
+		}, nil, 0)
+		if got[0].Canonical != "dominos" {
+			t.Errorf("Canonical = %q, want dominos", got[0].Canonical)
+		}
+	})
+
+	t.Run("every member is multi-word, so the count decides", func(t *testing.T) {
+		// The other counterexample: both names carry spaces, so the shape says nothing and
+		// the count correctly picks the un-corrupted spelling.
+		got := planMerges([]company{
+			{Slug: "alfa-bank", Name: "Alfa Bank", JobCount: 1617},
+			{Slug: "al-fa-bank", Name: "Al Fa Bank", JobCount: 20},
+		}, nil, 0)
+		if got[0].Canonical != "alfa-bank" {
+			t.Errorf("Canonical = %q, want alfa-bank", got[0].Canonical)
+		}
+	})
+
+	t.Run("a legal form is not a word that makes a name multi-word", func(t *testing.T) {
+		// "Ace Hardware Corporation" is two words plus a form; it must not outrank a plain
+		// "Ace Hardware", and both must beat the squashed spelling.
+		got := planMerges([]company{
+			{Slug: "acehardware", Name: "AceHardware", JobCount: 500},
+			{Slug: "ace-hardware", Name: "Ace Hardware", JobCount: 90},
+		}, nil, 0)
+		if got[0].Canonical != "ace-hardware" {
+			t.Errorf("Canonical = %q, want ace-hardware", got[0].Canonical)
+		}
+	})
 }

--- a/docs/agents/company-identity.md
+++ b/docs/agents/company-identity.md
@@ -105,10 +105,13 @@ crawl would put it back, and the display name comes from `companies.name` regard
   wave — it takes the slug the rule yields even though no row holds it yet, and the reconcile
   creates that row. Returning a slug no member holds is safe: a company already using it would
   fold to the same key, so it would be a member and would have won outright.
-- **Electing by anything but job count elects backwards.** "Prefer the more readable slug" is
-  the tempting rule and it picks `domino-s` (1 job) over `dominos` (14,396) and `al-fa-bank`
-  (20) over `alfa-bank` (1,617). Hyphens mark the corrupted spelling about as often as the
-  correct one.
+- **Read the NAME, not the slug, when choosing between spellings.** "Prefer the more
+  hyphenated slug" is the tempting rule and it elects `domino-s` (1 job) over `dominos`
+  (14,396) and `al-fa-bank` (20) over `alfa-bank` (1,617): in a slug an apostrophe is
+  indistinguishable from a word break. What actually decides is whether the employer WRITES
+  its name in several words — `Western Digital` and `Ace Hardware` do, `AT&T` and `Dominos` do
+  not — and that preference only speaks when it discriminates. Where no name is multi-word, or
+  every name is, the job count decides as before.
 - **The word break is not whitespace.** It is every rune `Slug` drops EXCEPT `.` and `/`, which
   live inside the forms themselves (`B.V.`, `A/S`). Whitespace alone loses
   `Sun Technologies,Inc.`, and 13,730 catalogue companies are written that way.

--- a/docs/agents/company-identity.md
+++ b/docs/agents/company-identity.md
@@ -93,6 +93,14 @@ nothing 404s. Do not run a manual reindex, and do not set `REINDEX_DEDUP`.
 `jobs.company` is left alone by a merge. The source keeps sending "DollarTree", so the next
 crawl would put it back, and the display name comes from `companies.name` regardless.
 
+**Any worker that re-derives `company_slug` must resolve through the registry.** `jobderive` is
+pure, so a re-derive yields the spelling the SOURCE used — which for a merged posting is the
+retired one. `cmd/backfill-derive` loads the registry once per run and resolves before it
+computes `role_fingerprint` (itself derived from the company slug); without that, a routine
+~15h backfill would silently undo every spelling merge and churn the repost identities on the
+way out. A worker that cannot READ the registry must fail rather than proceed: an empty
+registry is indistinguishable from a catalogue with no merges.
+
 ## Gotchas
 
 - **The canonical slug must be a fixed point of the rule, and job count alone does not give

--- a/internal/db/company_slug_aliases.sql.go
+++ b/internal/db/company_slug_aliases.sql.go
@@ -115,6 +115,45 @@ func (q *Queries) ListCompaniesForMerge(ctx context.Context) ([]ListCompaniesFor
 	return items, nil
 }
 
+const listCompanySlugAliases = `-- name: ListCompanySlugAliases :many
+SELECT DISTINCT folded_key, canonical_slug
+FROM company_slug_aliases
+ORDER BY folded_key, canonical_slug
+`
+
+type ListCompanySlugAliasesRow struct {
+	FoldedKey     string `json:"folded_key"`
+	CanonicalSlug string `json:"canonical_slug"`
+}
+
+// The whole registry, folded key to canonical slug. cmd/backfill-derive loads it once per run
+// and resolves in memory: it re-derives every job in the table, and jobderive is pure, so
+// without this a backfill would silently move every merged posting back to the spelling its
+// source happened to use — undoing the merges and taking role_fingerprint, which is computed
+// from the company slug, with it.
+//
+// Ordered for the same reason ResolveCompanySlugAliases is: one canonical slug per folded key
+// is the writer's invariant, and a violation should resolve identically every run.
+func (q *Queries) ListCompanySlugAliases(ctx context.Context) ([]ListCompanySlugAliasesRow, error) {
+	rows, err := q.db.Query(ctx, listCompanySlugAliases)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListCompanySlugAliasesRow{}
+	for rows.Next() {
+		var i ListCompanySlugAliasesRow
+		if err := rows.Scan(&i.FoldedKey, &i.CanonicalSlug); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const rekeyCompanySlugChunk = `-- name: RekeyCompanySlugChunk :execrows
 UPDATE jobs
 SET company_slug = $1,

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1817,6 +1817,15 @@ type Querier interface {
 	// rows that already hold industries, but the merge pass must also reach companies
 	// with none, and one query serving both keeps the two walks identical.
 	ListCompanyIndustriesPage(ctx context.Context, arg ListCompanyIndustriesPageParams) ([]ListCompanyIndustriesPageRow, error)
+	// The whole registry, folded key to canonical slug. cmd/backfill-derive loads it once per run
+	// and resolves in memory: it re-derives every job in the table, and jobderive is pure, so
+	// without this a backfill would silently move every merged posting back to the spelling its
+	// source happened to use — undoing the merges and taking role_fingerprint, which is computed
+	// from the company slug, with it.
+	//
+	// Ordered for the same reason ResolveCompanySlugAliases is: one canonical slug per folded key
+	// is the writer's invariant, and a violation should resolve identically every run.
+	ListCompanySlugAliases(ctx context.Context) ([]ListCompanySlugAliasesRow, error)
 	// Every company slug, unfiltered. cmd/import-yc loads this once into an
 	// in-memory set to resolve each yc-oss directory entry's current-name and
 	// former-name slug candidates, instead of one CompanyExists round trip per

--- a/internal/db/queries/company_slug_aliases.sql
+++ b/internal/db/queries/company_slug_aliases.sql
@@ -67,3 +67,16 @@ WHERE jobs.id IN (
     ORDER BY j.id
     LIMIT @chunk_size
 );
+
+-- name: ListCompanySlugAliases :many
+-- The whole registry, folded key to canonical slug. cmd/backfill-derive loads it once per run
+-- and resolves in memory: it re-derives every job in the table, and jobderive is pure, so
+-- without this a backfill would silently move every merged posting back to the spelling its
+-- source happened to use — undoing the merges and taking role_fingerprint, which is computed
+-- from the company slug, with it.
+--
+-- Ordered for the same reason ResolveCompanySlugAliases is: one canonical slug per folded key
+-- is the writer's invariant, and a violation should resolve identically every run.
+SELECT DISTINCT folded_key, canonical_slug
+FROM company_slug_aliases
+ORDER BY folded_key, canonical_slug;


### PR DESCRIPTION
Fourth and last of the election fixes the prod dry runs have surfaced.

## Why

In the `--min-jobs 100` wave, job count elects a **squashed** canonical over a hyphenated one **73 times out of 162** spelling merges.

Some are right — AT&T really is one word, so `att` beats `at-t`; so do `autonation`, `aspentech`, `agileengine`. Others are plainly wrong: `accenturefederalservices`, `acehardware`, `westerndigital`, `allegisglobalsolutions`.

## The signal is the name, not the slug

An employer that writes its name in several words should key as several words.

This is also why the obvious version of the rule failed before. "Prefer the more hyphenated slug" reads the slug — and in a slug an apostrophe is indistinguishable from a space, so it elects `domino-s`(1 job) over `dominos`(14,396) and `al-fa-bank`(20) over `alfa-bank`(1,617).

Reading the name fixes both, because the preference **only speaks when it discriminates**:

| Group | Names | Multi-word? | Outcome |
|---|---|---|---|
| Domino's | "Dominos", "Domino's" | neither | count → `dominos` ✓ |
| Alfa Bank | "Alfa Bank", "Al Fa Bank" | both | count → `alfa-bank` ✓ |
| Western Digital | "WesternDigital", "Western Digital" | one | → `western-digital` ✓ |
| AT&T | "AT&T" | neither | count → `att` ✓ |

Trailing legal forms do not count as words: "Ace Hardware Corporation" is a two-word employer.

## Note

Wave 1 is already applied and its canons are **frozen**, so `turnertownsend` and `nexthire` keep theirs — freezing beats tidiness once a url has been redirecting. Both were minted about an hour ago and could be reversed cheaply if you'd rather; say so and I will.

`go test ./...` 165 ok · `go vet -tags=integration` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved company merge planning to prefer candidate names that preserve distinct multi-word naming.
  - Maintained job-count ordering when names provide no clear distinction.
  - Improved fallback handling when a reproducible company identifier is unavailable.
- **Documentation**
  - Updated company identity guidance to clarify name-based selection and tie-breaking behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->