### PR TITLE
design-system: document BrandMark in the DSDS component registry

### DIFF
--- a/design-system/docs/dsds/components.json
+++ b/design-system/docs/dsds/components.json
@@ -937,6 +937,45 @@
           "file": "../../src/country-flag.stories.ts"
         }
       ]
+    },
+    {
+      "id": "component.brand-mark",
+      "type": "component",
+      "name": "BrandMark",
+      "description": "A brand's logo glyph, drawn from its own SVG path + hex color — always renders in that brand color, flat on the page (not on a colored badge, unlike ProviderIcon's fixed OAuth switch). The caller supplies the path/hex/title (e.g. the app's own techmarks.ts, sourced from simple-icons); this primitive takes no icon-set dependency itself.",
+      "source": {
+        "file": "../../src/brand-mark.svelte"
+      },
+      "props": [
+        {
+          "name": "path",
+          "type": "string",
+          "required": true,
+          "description": "SVG path data, drawn in a 0 0 24 24 viewBox."
+        },
+        {
+          "name": "hex",
+          "type": "string",
+          "required": true,
+          "description": "Brand color, without the leading #."
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "required": true,
+          "description": "Accessible name, set as the svg's aria-label."
+        },
+        {
+          "name": "class",
+          "type": "string",
+          "default": "size-4"
+        }
+      ],
+      "stories": [
+        {
+          "file": "../../src/brand-mark.stories.ts"
+        }
+      ]
     }
   ]
 }

--- a/design-system/scripts/adoption-baseline.json
+++ b/design-system/scripts/adoption-baseline.json
@@ -2,6 +2,7 @@
   "Alert": 1,
   "Avatar": 0,
   "Badge": 15,
+  "BrandMark": 1,
   "Button": 63,
   "Card": 1,
   "Chip": 3,


### PR DESCRIPTION
## Summary
- #2115 (merged) added `brand-mark.svelte` + `brand-mark.stories.ts` without a matching `docs/dsds/components.json` entity, which `pnpm validate:docs` requires (every story file needs an entity claiming it) — this broke the `design-system` CI job on `main`.
- Adds the `component.brand-mark` entity, matching the format of the other icon primitives (`ProviderIcon`, `CountryFlag`).

## Test plan
- [x] `node scripts/validate-docs.mjs` passes locally (26 entities, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Brand Mark component to the design system catalog.
  * Documented its required SVG properties and optional styling class.
  * Linked the component to its usage story for easier reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->