### PR TITLE
viewlog: stop counting a hover as a job view

### DIFF
--- a/internal/viewlog/AGENTS.md
+++ b/internal/viewlog/AGENTS.md
@@ -10,11 +10,26 @@ SSR→backend boundary) — lets us filter bots and cover anonymous + API unifor
 ## Shape
 
 - `ParseLine(line) (Record, ok)` — one nginx `combined`-format line → `Record`
-  (IP, timestamp, method, path, status, UA). Unparseable/bad-request lines → `ok=false`.
+  (IP, timestamp, method, path, status, UA, purpose). Unparseable/bad-request lines
+  → `ok=false`. The trailing `"$http_sec_purpose"` field is **optional** in the
+  pattern, so lines from before the nginx change parse unchanged; nginx's `-`
+  placeholder normalizes to empty.
 - `Classify(Record) (Signal, ok)` — a 2xx GET of `/jobs/<slug>` or its SvelteKit SPA
   data request `/jobs/<slug>/__data.json` (`KindPage`), or `/api/v1/jobs/<slug>`
   (`KindAPI`) → the slug; everything else ignored (a slug is one path segment, so
   lists and sub-resources like `/similar`, `/fit` don't count).
+- **A non-empty `Sec-Purpose` is never a view.** The app sets
+  `data-sveltekit-preload-data="hover"`, so moving the pointer across a listing
+  fetches `/jobs/<slug>/__data.json` for every card it passes — each of which
+  counted, inflating `view_count` for jobs nobody opened. Any non-empty value is
+  rejected rather than matching known ones: the header exists to say "not a real
+  navigation", and an unrecognized value still says it. This is also what makes
+  Speculation Rules safe to add later — a prerender carries the same header.
+
+**Deploy order matters:** the parser must ship BEFORE the nginx `log_format`
+change. It tolerates both formats, so parser-first is a no-op until nginx catches
+up; nginx-first would feed lines the old pattern cannot match, and a day that
+parses as nothing silently counts nothing.
 - `Aggregate(reader) map[day]map[slug]int` — dedups by the raw `(IP, UA, slug, day)`
   tuple (NUL-joined, no hashing), the day taken from each line's timestamp (UTC);
   page opens from known bots are dropped, API reads are not bot-filtered.

--- a/internal/viewlog/classify.go
+++ b/internal/viewlog/classify.go
@@ -26,6 +26,15 @@ func Classify(rec Record) (Signal, bool) {
 	if rec.Method != "GET" || rec.Status < 200 || rec.Status >= 300 {
 		return Signal{}, false
 	}
+	// A speculative fetch is not a view: nobody has seen the page, and may never.
+	// This is not a corner case — the app sets data-sveltekit-preload-data="hover",
+	// so moving the pointer across a listing fetched __data.json for every card it
+	// passed, and each one counted. Any non-empty Sec-Purpose is rejected rather
+	// than matching known values, because the header exists to say "not a real
+	// navigation" and a value we don't recognize still says it.
+	if rec.Purpose != "" {
+		return Signal{}, false
+	}
 	path := rec.Path
 	if i := strings.IndexByte(path, '?'); i >= 0 {
 		path = path[:i]

--- a/internal/viewlog/classify_test.go
+++ b/internal/viewlog/classify_test.go
@@ -101,3 +101,54 @@ func TestClassify(t *testing.T) {
 		})
 	}
 }
+
+// The app sets data-sveltekit-preload-data="hover", so merely moving the pointer
+// over a job card fetches /jobs/<slug>/__data.json — which counted as a view.
+// Someone scrolling a listing on a desktop therefore "viewed" every job they
+// passed the cursor over. The browser marks those fetches with Sec-Purpose, which
+// is now the whole basis for telling them apart from an opened page.
+func TestClassifyIgnoresSpeculativeFetches(t *testing.T) {
+	base := Record{Method: "GET", Status: 200, Path: "/jobs/acme-engineer-123"}
+
+	t.Run("a hover preload is not a view", func(t *testing.T) {
+		rec := base
+		rec.Path = "/jobs/acme-engineer-123/__data.json"
+		rec.Purpose = "prefetch"
+		if _, ok := Classify(rec); ok {
+			t.Errorf("Classify ok = true for a prefetch, want false")
+		}
+	})
+
+	t.Run("a prerender is not a view", func(t *testing.T) {
+		rec := base
+		rec.Purpose = "prefetch;prerender"
+		if _, ok := Classify(rec); ok {
+			t.Errorf("Classify ok = true for a prerender, want false")
+		}
+	})
+
+	// The same shape without the header is a real navigation and must still count,
+	// including the SPA data request that a genuine in-app click produces.
+	t.Run("a real SPA navigation still counts", func(t *testing.T) {
+		rec := base
+		rec.Path = "/jobs/acme-engineer-123/__data.json"
+		sig, ok := Classify(rec)
+		if !ok {
+			t.Fatalf("Classify ok = false for a real navigation, want true")
+		}
+		if sig.Slug != "acme-engineer-123" || sig.Kind != KindPage {
+			t.Errorf("got %+v, want acme-engineer-123/KindPage", sig)
+		}
+	})
+
+	// The API is read by scripts that may send anything; the header is a browser
+	// signal, and honouring it uniformly keeps one rule rather than two.
+	t.Run("a speculative API read is not a view either", func(t *testing.T) {
+		rec := base
+		rec.Path = "/api/v1/jobs/acme-engineer-123"
+		rec.Purpose = "prefetch"
+		if _, ok := Classify(rec); ok {
+			t.Errorf("Classify ok = true for a speculative API read, want false")
+		}
+	})
+}

--- a/internal/viewlog/parse.go
+++ b/internal/viewlog/parse.go
@@ -4,7 +4,8 @@
 // tuple (NUL-joined, no hashing) so a visitor counts at most once per job per
 // day. Two request shapes are counted — the SSR detail page GET /jobs/<slug>
 // (bot-filtered) and the API read GET /api/v1/jobs/<slug> (not bot-filtered) —
-// every other line is ignored.
+// every other line is ignored, including any request the browser marked
+// speculative with Sec-Purpose (see Classify).
 package viewlog
 
 import (
@@ -20,16 +21,28 @@ type Record struct {
 	UserAgent string
 	Method    string
 	Path      string
-	Status    int
+	// Purpose is the request's Sec-Purpose header: non-empty when the browser
+	// fetched this speculatively (`prefetch`, or `prefetch;prerender`) rather than
+	// because someone opened the page. Empty for a real navigation, for a client
+	// that does not send the header, and for every line written before the log
+	// format carried it.
+	Purpose string
+	Status  int
 }
 
 // combinedLine matches the nginx `combined` log format:
 //
 //	$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$referer" "$user_agent"
 //
+// plus one OPTIONAL trailing quoted field, "$http_sec_purpose", which the freehire
+// site config appends (see freehire-ops, provision/host2/nginx). The group is
+// optional on purpose: rotated files written before that change are still fed to
+// the aggregator, and the parser has to ship before the nginx change rather than
+// with it — a day whose lines it could not read would silently count nothing.
+//
 // The request group requires METHOD PATH PROTO, so bad requests logged as "-"
 // (or otherwise malformed) fail to match and are skipped by the caller.
-var combinedLine = regexp.MustCompile(`^(\S+) \S+ \S+ \[([^\]]*)\] "([A-Z]+) (\S+) [^"]*" (\d{3}) \S+ "[^"]*" "([^"]*)"`)
+var combinedLine = regexp.MustCompile(`^(\S+) \S+ \S+ \[([^\]]*)\] "([A-Z]+) (\S+) [^"]*" (\d{3}) \S+ "[^"]*" "([^"]*)"(?: "([^"]*)")?`)
 
 // timeLocalLayout is nginx's $time_local, e.g. 21/Jul/2026:12:00:00 +0000.
 const timeLocalLayout = "02/Jan/2006:15:04:05 -0700"
@@ -50,11 +63,19 @@ func ParseLine(line string) (Record, bool) {
 	if err != nil {
 		return Record{}, false
 	}
+	// nginx writes "-" for a header the request did not carry, which means the same
+	// thing as the field being absent — normalize both to empty so Classify has one
+	// case to test rather than two.
+	purpose := m[7]
+	if purpose == "-" {
+		purpose = ""
+	}
 	return Record{
 		IP:        m[1],
 		Time:      ts,
 		Method:    m[3],
 		Path:      m[4],
+		Purpose:   purpose,
 		Status:    status,
 		UserAgent: m[6],
 	}, true

--- a/internal/viewlog/parse_test.go
+++ b/internal/viewlog/parse_test.go
@@ -58,4 +58,46 @@ func TestParseLine(t *testing.T) {
 			t.Errorf("ParseLine ok = true for dash request, want false")
 		}
 	})
+
+	// The log format gained a trailing "$http_sec_purpose" so a speculative fetch
+	// can be told apart from a real visit. Both formats have to parse: rotated
+	// files written before the nginx change are still fed to the aggregator, and a
+	// deploy where the parser lands first must not drop the day's counts.
+	t.Run("reads sec-purpose from the extended format", func(t *testing.T) {
+		line := `203.0.113.5 - - [21/Jul/2026:12:00:00 +0000] "GET /jobs/acme-engineer-123/__data.json HTTP/2.0" 200 1234 "-" "Mozilla/5.0" "prefetch"`
+		rec, ok := ParseLine(line)
+		if !ok {
+			t.Fatalf("ParseLine ok = false, want true")
+		}
+		if rec.Purpose != "prefetch" {
+			t.Errorf("Purpose = %q, want prefetch", rec.Purpose)
+		}
+		if rec.UserAgent != "Mozilla/5.0" {
+			t.Errorf("UserAgent = %q, want Mozilla/5.0", rec.UserAgent)
+		}
+	})
+
+	t.Run("a line in the old format still parses, with no purpose", func(t *testing.T) {
+		line := `203.0.113.5 - - [21/Jul/2026:12:00:00 +0000] "GET /jobs/acme-engineer-123 HTTP/2.0" 200 1234 "-" "Mozilla/5.0"`
+		rec, ok := ParseLine(line)
+		if !ok {
+			t.Fatalf("ParseLine ok = false, want true")
+		}
+		if rec.Purpose != "" {
+			t.Errorf("Purpose = %q, want empty", rec.Purpose)
+		}
+	})
+
+	// nginx writes "-" for a header the request did not carry, which means the
+	// same thing as absent and must not read as a purpose.
+	t.Run("treats nginx's dash placeholder as no purpose", func(t *testing.T) {
+		line := `203.0.113.5 - - [21/Jul/2026:12:00:00 +0000] "GET /jobs/acme-engineer-123 HTTP/2.0" 200 1234 "-" "Mozilla/5.0" "-"`
+		rec, ok := ParseLine(line)
+		if !ok {
+			t.Fatalf("ParseLine ok = false, want true")
+		}
+		if rec.Purpose != "" {
+			t.Errorf("Purpose = %q, want empty", rec.Purpose)
+		}
+	})
 }


### PR DESCRIPTION
The app sets `data-sveltekit-preload-data="hover"`, so moving the pointer over a job card fetches `/jobs/<slug>/__data.json` — and `Classify` counts that path as a page view. Someone scrolling a listing on a desktop therefore "viewed" every job the cursor passed over. `jobs.view_count` is a figure we show to visitors.

Confirmed against production — hovering one card in the feed issues:

```
GET /jobs/project-finance-analyst-mobolutions-i66i6mwd/__data.json?x-sveltekit-invalidated=01 → 200
```

which is exactly the shape `Classify` counts.

## Why not just drop `__data.json`

A real in-app click produces that request **and no other** — the HTML is never re-fetched. Dropping it would stop counting genuine SPA navigations instead, trading one wrong number for another.

The browser already distinguishes the two: a speculative fetch carries `Sec-Purpose` (`prefetch`, or `prefetch;prerender`), a real navigation carries nothing. `Record` now holds it and `Classify` rejects any non-empty value — **rejected rather than matched against known values**, because the header exists to say "not a real navigation", and one we don't recognize still says it.

## Deploy order

**This ships first.** The trailing `"$http_sec_purpose"` field is *optional* in the parse pattern, so:

- Rotated files written under the old format still parse — no gap in yesterday's counts.
- Parser-first is a no-op until the nginx change lands.
- The reverse order feeds the old pattern lines it cannot match, and a day that parses as nothing silently counts nothing.

The nginx side is a separate PR in `freehire-ops` (`ops/log-sec-purpose`), already verified with `nginx -t` on host-2 and then removed again — it stays unapplied until this is live.

## Side benefit

This also clears the way for **Speculation Rules**, which is what I was originally asked to add. A prerender carries the same header, so prerendering job pages will not inflate the counter either. Adding prerender before this fix would have made the miscount substantially worse — a full page load per hover instead of one JSON fetch.

## Verification

- `go test ./internal/viewlog/` — pass (4 tests added: extended format, old format, `-` placeholder, and four `Classify` cases)
- `gofmt -l` clean, `go vet ./...` clean, `go vet -tags=integration ./...` clean
- `golangci-lint` 0 issues, `govulncheck` 0 vulnerabilities

`internal/viewlog/AGENTS.md` updated in the same commit, including the deploy-order note.
