### PR TITLE
Preload job data on tap, not on hover, so the pointer stops counting as a view

### DIFF
--- a/web/src/app.html
+++ b/web/src/app.html
@@ -67,7 +67,24 @@
     $lib/analytics (initTrackers), gated on cookie consent alongside PostHog. -->
     %sveltekit.head%
   </head>
-  <body data-sveltekit-preload-data="hover">
+  <!-- `tap`, not `hover`: preloading on hover made the pointer inflate job view
+  counts. internal/viewlog reads nginx's access log and counts GET
+  /jobs/<slug>/__data.json as a page open — which is right, because a real in-app
+  click produces that request and no other. But `hover` issues the same request
+  for every card the cursor passes, so scrolling a listing on a desktop "viewed"
+  every job scrolled past, and jobs.view_count is shown to visitors.
+
+  Sec-Purpose does not help here: SvelteKit preloads with a plain fetch() and the
+  browser only sets that header for its own prefetch/prerender, so these arrive
+  indistinguishable from a navigation (verified in production — the log line ends
+  in "-").
+
+  `tap` starts the same preload on pointerdown instead, which is a real intent to
+  open: the request now means what viewlog reads it as. The head start shrinks
+  from a hover's few hundred milliseconds to the ~100ms between pressing and
+  releasing, which is most of the perceived benefit — the load overlaps the click
+  either way. -->
+  <body data-sveltekit-preload-data="tap">
     <div style="display: contents">%sveltekit.body%</div>
   </body>
 </html>


### PR DESCRIPTION
`internal/viewlog` counts `GET /jobs/<slug>/__data.json` as a job view. That is correct as far as it goes — a real in-app click produces that request **and no other**, so it is how SPA navigations get counted at all.

But `data-sveltekit-preload-data="hover"` issued the same request for every card the cursor passed. Scrolling a listing on a desktop therefore "viewed" every job scrolled past, and `jobs.view_count` is a figure shown to visitors.

## Why not Sec-Purpose

I shipped parser support for `Sec-Purpose` first (#2118), on the assumption that the browser marks these fetches. **It does not.** SvelteKit preloads with a plain `fetch()` and no headers; the browser only sets `Sec-Purpose` for its own `prefetch`/`prerender`. Verified in production — the log line for a hover ends in `"-"`, identical to a real navigation.

That work is still worth having: a Speculation Rules prerender *does* carry the header, so it stays a prerequisite for adding prerendering later. It just does not fix this.

## The change

`tap` starts the same preload on `pointerdown` — a real intent to open. The request then means what viewlog reads it as.

The cost is small. Instead of a hover's few hundred milliseconds of head start, the preload gets the ~100 ms between press and release, and the load overlaps the click either way.

## Verified

Against a production build, in a browser:

| Action | Before | After |
|---|---|---|
| Hover a job card | `GET …/__data.json` → 200 | **no request** |
| Click a job card | (reuses preload) | exactly one `__data.json`, page opens |

- `pnpm test` — 1084 pass
- `pnpm lint` — clean; `pnpm check` — 0 errors

## Note on the counter's history

Worth flagging for whoever owns the metric: because a click after a hover made no second request, the *real* navigation left no log line while the hover did. Historical `view_count` therefore reflects hovers more than opens. This PR makes new counts mean what they say; it does not correct past ones.
