### PR TITLE
A hyphen in the name is a word break, an apostrophe is not

### DIFF
--- a/cmd/merge-companies/plan.go
+++ b/cmd/merge-companies/plan.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"slices"
 	"strings"
+	"unicode"
 
 	"github.com/strelov1/freehire/internal/normalize"
 )
@@ -170,10 +171,17 @@ func electCanonical(members []company, frozen map[string]bool) string {
 	return normalize.CompanySlug(members[0].Name)
 }
 
-// nameWords counts the whitespace words of a name that are the name proper, trailing legal
-// forms dropped: "Ace Hardware Corporation" is a two-word employer, not a three-word one.
+// nameWords counts the words of a name that are the name proper, trailing legal forms
+// dropped: "Ace Hardware Corporation" is a two-word employer, not a three-word one.
+//
+// A HYPHEN separates words as surely as a space — Kimberly-Clark and T-Mobile write themselves
+// that way — but an apostrophe does not: Brink's and Domino's are one word each. That is the
+// distinction a slug cannot preserve, since Slug renders every one of them as a hyphen, and it
+// is the whole reason this reads the name.
 func nameWords(name string) int {
-	fields := strings.Fields(name)
+	fields := strings.FieldsFunc(name, func(r rune) bool {
+		return unicode.IsSpace(r) || r == '-'
+	})
 	for len(fields) > 1 && normalize.IsLegalForm(fields[len(fields)-1]) {
 		fields = fields[:len(fields)-1]
 	}

--- a/cmd/merge-companies/plan_test.go
+++ b/cmd/merge-companies/plan_test.go
@@ -239,6 +239,30 @@ func TestPlanMerges_PrefersTheSpellingTheNameIsWrittenIn(t *testing.T) {
 		}
 	})
 
+	t.Run("a hyphen in the name is a word break too", func(t *testing.T) {
+		// Kimberly-Clark writes itself with a hyphen, which is as much a word break as a
+		// space. Counting only spaces made it a one-word name and elected `kimberlyclark`.
+		got := planMerges([]company{
+			{Slug: "kimberlyclark", Name: "KimberlyClark", JobCount: 300},
+			{Slug: "kimberly-clark", Name: "Kimberly-Clark", JobCount: 40},
+		}, nil, 0)
+		if got[0].Canonical != "kimberly-clark" {
+			t.Errorf("Canonical = %q, want kimberly-clark", got[0].Canonical)
+		}
+	})
+
+	t.Run("an apostrophe is NOT a word break", func(t *testing.T) {
+		// The distinction the slug cannot make: Brink's is one word, and `brinks` beats
+		// `brink-s` exactly as `dominos` beats `domino-s`.
+		got := planMerges([]company{
+			{Slug: "brinks", Name: "Brinks", JobCount: 200},
+			{Slug: "brink-s", Name: "Brink's", JobCount: 10},
+		}, nil, 0)
+		if got[0].Canonical != "brinks" {
+			t.Errorf("Canonical = %q, want brinks", got[0].Canonical)
+		}
+	})
+
 	t.Run("a legal form is not a word that makes a name multi-word", func(t *testing.T) {
 		// "Ace Hardware Corporation" is two words plus a form; it must not outrank a plain
 		// "Ace Hardware", and both must beat the squashed spelling.

--- a/docs/agents/company-identity.md
+++ b/docs/agents/company-identity.md
@@ -117,8 +117,9 @@ registry is indistinguishable from a catalogue with no merges.
   hyphenated slug" is the tempting rule and it elects `domino-s` (1 job) over `dominos`
   (14,396) and `al-fa-bank` (20) over `alfa-bank` (1,617): in a slug an apostrophe is
   indistinguishable from a word break. What actually decides is whether the employer WRITES
-  its name in several words — `Western Digital` and `Ace Hardware` do, `AT&T` and `Dominos` do
-  not — and that preference only speaks when it discriminates. Where no name is multi-word, or
+  its name in several words — `Western Digital`, `Ace Hardware` and `Kimberly-Clark` do, `AT&T`,
+  `Brink's` and `Dominos` do not. A hyphen in the NAME separates words; an apostrophe does not,
+  and that is precisely the distinction a slug destroys, since it renders both as a hyphen — and that preference only speaks when it discriminates. Where no name is multi-word, or
   every name is, the job count decides as before.
 - **The word break is not whitespace.** It is every rune `Slug` drops EXCEPT `.` and `/`, which
   live inside the forms themselves (`B.V.`, `A/S`). Whitespace alone loses


### PR DESCRIPTION
Completes #2116's rule rather than changing it.

The word-shape preference counted only **spaces**, so `Kimberly-Clark` read as a one-word name and the election kept the squashed `kimberlyclark` over `kimberly-clark`.

A hyphen separates words as surely as a space — Kimberly-Clark, T-Mobile — while an **apostrophe does not**: Brink's and Domino's are one word each.

That is exactly the distinction the *slug* destroys, since `Slug` renders space, hyphen and apostrophe all as a hyphen. It is the whole reason this rule reads the name instead, and it is why "prefer the more hyphenated slug" could never have worked.

## Effect on the pending wave

Squashed canonicals beating a hyphenated alias, `--min-jobs 100`: **73 → 16**, and the 16 that remain are correct — `att` (AT&T), `brinks` (Brink's), `autonation`, `elevenlabs`.

Both original counterexamples stay green: `dominos` beats `domino-s`, `alfa-bank` beats `al-fa-bank`.

`go test ./...` 165 ok · `go vet -tags=integration` clean.