### PR TITLE
merge-companies: always derive the canon, never reuse a stored slug

### DIFF
--- a/cmd/merge-companies/plan.go
+++ b/cmd/merge-companies/plan.go
@@ -117,56 +117,31 @@ func planMerges(companies []company, frozen map[string]bool, minJobs int) []merg
 // electCanonical picks the group's surviving slug. Members arrive sorted by open jobs
 // descending, so "the first that qualifies" is "the biggest that qualifies".
 //
-// Three rules, in order:
+//  1. An already-frozen canon wins outright, exactly as stored — even carrying a form. It has
+//     been redirecting and indexing, and moving it costs more than a tidier slug is worth.
+//  2. Otherwise the canon is the slug the RULE yields for the elected member's name, and the
+//     election prefers a member whose name is written in several words.
 //
-//  1. An already-frozen canon wins outright, even one carrying a corporate form. It has been
-//     redirecting and indexing; moving it costs more than a tidier slug is worth.
-//  2. Otherwise the biggest slug the rule can REPRODUCE — a fixed point of CompanySlug. Pure
-//     job count is not enough: the first prod dry run elected `danaher-corporation` over
-//     `danaher` (714 open jobs) because it happened to be larger, which would have made the
-//     catalogue's canonical url the one carrying the form and 301'd the better-known slug into
-//     it. It is also unstable, since every new posting derives the stripped slug and would need
-//     an alias row for the canon to reach itself.
-//  3. Failing that, the slug the rule YIELDS for the biggest member, even though no row holds
-//     it yet. A group where every member carries a form is real — carnival-corporation and
-//     carnival-corporation-plc were two of four in the >=100-job wave — and picking the least
-//     bad existing row would leave the form on the canonical url, which is the outcome rule 2
-//     exists to prevent. The derived slug is what every future posting keys to, and the
-//     reconcile that follows the re-key creates its row.
+// Deriving rather than reusing a stored slug is what makes the canon a fixed point by
+// construction: CompanySlug of a derived slug is itself, so there is no separate rule keeping
+// forms off the canonical url. It also stops a row that carries a form from being ignored for
+// carrying one — "Public Storage" exists in the catalogue only as `public-storage-inc`, and
+// skipping it left the squashed `publicstorage` to win by default, 2,811 times across the
+// catalogue.
 //
-// Returning a slug no member holds is safe: if a company already used it, its name would fold
-// to the same key and it would BE a member — and would have won rule 2.
+// The word-shape preference only speaks when it discriminates. Where no name is multi-word
+// (Dominos beside Domino's) or every name is (Alfa Bank beside Al Fa Bank), it says nothing and
+// the job count decides.
 func electCanonical(members []company, frozen map[string]bool) string {
 	for _, c := range members {
 		if frozen[c.Slug] {
 			return c.Slug
 		}
 	}
-	var fixed []company
 	for _, c := range members {
-		if normalize.CompanySlug(c.Slug) == c.Slug {
-			fixed = append(fixed, c)
+		if nameWords(c.Name) > 1 {
+			return normalize.CompanySlug(c.Name)
 		}
-	}
-	if len(fixed) > 0 {
-		// Among spellings the rule can reproduce, prefer one the employer WRITES in several
-		// words. Job count alone cannot see this: it elects `westerndigital` over
-		// `western-digital` and `acehardware` over `ace-hardware` purely on volume, 73 times
-		// in the >=100-job wave.
-		//
-		// The signal is the NAME, never the slug. "Domino's" slugs to `domino-s`, where an
-		// apostrophe is indistinguishable from a word break — which is exactly why "prefer
-		// the more hyphenated slug" elected `domino-s` over `dominos` and had to be dropped.
-		//
-		// It only speaks when it discriminates. Where no name is multi-word (Domino's) or
-		// every name is (Alfa Bank beside Al Fa Bank), it says nothing and the count decides,
-		// as it did before.
-		for _, c := range fixed {
-			if nameWords(c.Name) > 1 {
-				return c.Slug
-			}
-		}
-		return fixed[0].Slug
 	}
 	return normalize.CompanySlug(members[0].Name)
 }

--- a/cmd/merge-companies/plan_test.go
+++ b/cmd/merge-companies/plan_test.go
@@ -275,3 +275,28 @@ func TestPlanMerges_PrefersTheSpellingTheNameIsWrittenIn(t *testing.T) {
 		}
 	})
 }
+
+// TestPlanMerges_MultiWordNameWinsEvenWhenOnlyAFormedRowHasIt closes the last gap the prod dry
+// runs found, and it is a big one: 2,811 of 7,375 retiring slugs across the full catalogue.
+//
+// "Public Storage" only exists in the catalogue as `public-storage-inc`, a row carrying a form.
+// Preferring a member that is ALREADY a fixed point dropped that row from consideration before
+// its word shape could be read, leaving the squashed `publicstorage` to win by default.
+//
+// Deriving the canon from the elected member's NAME fixes it and needs no extra rule: the
+// derived slug is a fixed point by construction, so the fixed-point preference disappears.
+func TestPlanMerges_MultiWordNameWinsEvenWhenOnlyAFormedRowHasIt(t *testing.T) {
+	got := planMerges([]company{
+		{Slug: "publicstorage", Name: "PublicStorage", JobCount: 300},
+		{Slug: "public-storage-inc", Name: "Public Storage Inc", JobCount: 40},
+	}, nil, 0)
+
+	if got[0].Canonical != "public-storage" {
+		t.Errorf("Canonical = %q, want public-storage — the employer writes two words, and a "+
+			"corporate form on the row that says so is not a reason to ignore it",
+			got[0].Canonical)
+	}
+	if len(got[0].Aliases) != 2 {
+		t.Errorf("got %d aliases, want 2 — no existing row holds the canon", len(got[0].Aliases))
+	}
+}

--- a/docs/agents/company-identity.md
+++ b/docs/agents/company-identity.md
@@ -108,11 +108,11 @@ registry is indistinguishable from a catalogue with no merges.
   jobs) purely because it was larger — making the canonical url the one carrying a corporate
   form, and 301ing the better-known slug into it. It is unstable too: every new posting derives
   the stripped slug, so the canon would depend forever on an alias row to reach itself. The
-  election prefers the biggest slug `CompanySlug` can reproduce; where NO member qualifies —
-  `carnival-corporation` beside `carnival-corporation-plc`, four such groups in the >=100-job
-  wave — it takes the slug the rule yields even though no row holds it yet, and the reconcile
-  creates that row. Returning a slug no member holds is safe: a company already using it would
-  fold to the same key, so it would be a member and would have won outright.
+  canon is therefore always `CompanySlug` of the elected member's NAME, never a stored slug
+  reused — which makes it a fixed point by construction and needs no separate rule. Returning a
+  slug no row holds yet is safe and often right (`carnival`, `public-storage`): a company
+  already using it would fold to the same key, so it would be a member, and the reconcile that
+  follows the re-key creates the row.
 - **Read the NAME, not the slug, when choosing between spellings.** "Prefer the more
   hyphenated slug" is the tempting rule and it elects `domino-s` (1 job) over `dominos`
   (14,396) and `al-fa-bank` (20) over `alfa-bank` (1,617): in a slug an apostrophe is


### PR DESCRIPTION
## Why

Preferring a member that is **already** a fixed point dropped any row carrying a corporate form from consideration *before* its word shape could be read.

`Public Storage` exists in the catalogue only as `public-storage-inc`. Skipping that row left the squashed `publicstorage` to win by default. Measured on the **full-catalogue** dry run: **2,811 of 7,375** retiring slugs elect a squashed canon over a hyphenated one, and this gap is most of them.

I found it by measuring the whole catalogue before applying, rather than extrapolating from the `--min-jobs 100` wave I had already reviewed — where it looked like 4 cases out of 14.

## The fix removes a rule instead of adding one

The canon is now always `CompanySlug` of the elected member's **name**, never a stored slug reused.

That makes it a fixed point *by construction* — `CompanySlug` of a derived slug is itself — so the fixed-point preference has nothing left to do, and the separate "no member qualifies" fallback (#2114) collapses into the same line. **Net 25 lines lighter.**

## Evidence it is a simplification, not new behaviour

**Every existing test passes unchanged**: both counterexamples (`dominos`, `alfa-bank`), the frozen canon, the `danaher` case, the `carnival` fallback, the hyphen/apostrophe distinction.

`go test ./...` 165 ok · `go vet -tags=integration` clean.

Nothing beyond wave 1 is applied; this lands before `--min-jobs 100`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved company merging so descriptive, multi-word company names determine the canonical slug more reliably.
  * Existing company slugs are preserved as aliases when a more appropriate canonical slug is selected.
  * Canonical slugs are consistently normalized from the selected company name.

* **Documentation**
  * Updated guidance describing canonical slug selection and reconciliation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->