### PR TITLE
Add Tracking and Notifications feature landing pages

### DIFF
--- a/web/src/lib/components/Footer.svelte
+++ b/web/src/lib/components/Footer.svelte
@@ -24,6 +24,8 @@
         { label: 'Browser extension', href: resolve('/features/extension') },
         { label: 'Inbox', href: resolve('/features/inbox') },
         { label: 'CV tailoring', href: resolve('/features/tailor') },
+        { label: 'Application tracking', href: resolve('/features/tracking') },
+        { label: 'Notifications', href: resolve('/features/notifications') },
         { label: 'Referrals', href: resolve('/features/referrals') },
         { label: 'Ghost jobs', href: resolve('/features/ghost-jobs') },
       ],

--- a/web/src/lib/components/HomeView.svelte
+++ b/web/src/lib/components/HomeView.svelte
@@ -77,16 +77,6 @@
   // shows a gap; the -50% loop stays seamless because the copies are identical.
   const sourcesMarquee = [...sources, ...sources, ...sources, ...sources];
 
-  // Illustrative "My jobs" board — decorative, not live data. Mirrors the real
-  // kanban (board.ts BOARD_COLUMNS) so the preview never promises a flow the
-  // product doesn't have: drag a saved job along its stages to the offer.
-  const board = [
-    { label: 'Saved', cards: [{ title: 'Data Engineer', company: 'Datadog' }] },
-    { label: 'Applied', cards: [{ title: 'Staff Frontend Engineer', company: 'Stripe' }] },
-    { label: 'Interview', cards: [{ title: 'Senior Backend Engineer', company: 'Linear' }] },
-    { label: 'Offer', cards: [{ title: 'Platform Engineer', company: 'Grafana' }] },
-  ];
-
   // Illustrative application-pipeline snapshot for the funnel below — decorative,
   // not live data. Counts sum to `applications`, and the keys are the product's own
   // pipeline groups, so the preview never promises a flow the product doesn't have.
@@ -126,6 +116,18 @@
       title: 'CV tailoring',
       body: 'Reframe your CV toward one vacancy — pulling forward the experience you already have but buried, and asking about anything your history does not support.',
       cta: 'How tailoring works',
+    },
+    {
+      href: resolve('/features/tracking'),
+      title: 'Application tracking',
+      body: 'One board for every application — Preparing, Applied, Interview, Offer — with a day-counter when an employer goes quiet and every reply attached automatically.',
+      cta: 'How tracking works',
+    },
+    {
+      href: resolve('/features/notifications'),
+      title: 'Notifications',
+      body: 'Save a search and get told about a new match instantly or as a daily digest, over email, Telegram or push — the same channels that carry your tracking nudges.',
+      cta: 'How notifications work',
     },
     {
       href: resolve('/features/referrals'),
@@ -270,8 +272,8 @@
     <NumberedGrid items={steps} class="mt-10 sm:grid-cols-3" />
   </section>
 
-  <!-- Track your search — the per-user My jobs board. A polished, hero-style
-       preview of the real kanban; the board data is illustrative, not live. -->
+  <!-- Track your search — trimmed to a pointer at the dedicated feature page,
+       which carries the full board preview and explains how tracking works. -->
   <section class="border-t border-border py-16 sm:py-20">
     <SectionLabel text="track your search" />
     <div class="mt-6 max-w-2xl">
@@ -279,66 +281,17 @@
         Track every application on your board.
       </h2>
       <p class="mt-5 leading-relaxed text-muted-foreground">
-        Save the openings worth a second look, mark the ones you applied to, and drag each card through
-        its stages — Saved → Applied → Interview → Offer. Your
-        <code class="font-mono text-foreground">My jobs</code> board keeps the whole search in one place.
-        Prefer the terminal? The <a href={resolve('/cli')} class="font-medium text-foreground underline-offset-4 hover:underline">freehire CLI</a>
-        does the same — <code class="font-mono text-foreground">apply</code>,
-        <code class="font-mono text-foreground">save</code>,
-        <code class="font-mono text-foreground">stage</code> and
-        <code class="font-mono text-foreground">note</code> any job from a script or an agent.
-      </p>
-      <p class="mt-4 leading-relaxed text-muted-foreground">
-        You don't have to move the cards by hand either: connect your mail and the
-        <a href={resolve('/features/inbox')} class="font-medium text-foreground underline-offset-4 hover:underline">freehire inbox</a>
-        tags each recruiter reply, attaches it to the application it belongs to, and walks the card
-        forward for you.
+        Save the openings worth a second look, mark the ones you applied to, and drag each card
+        through its stages — Preparing → Applied → Interview → Offer — on your
+        <code class="font-mono text-foreground">My jobs</code> board. See the board and how it works on the
+        <a href={resolve('/features/tracking')} class="font-medium text-foreground underline-offset-4 hover:underline">Tracking</a>
+        page.
       </p>
       <div class="mt-8 flex flex-wrap gap-3">
-        <Button href={resolve('/my/tracking')} variant="primary" size="lg">Open Tracking</Button>
-        <Button href={resolve('/cli')} variant="ghost" size="lg">Track from the CLI</Button>
+        <Button href={resolve('/features/tracking')} variant="primary" size="lg">See how tracking works</Button>
+        <Button href={resolve('/my/tracking')} variant="ghost" size="lg">Open Tracking</Button>
       </div>
     </div>
-
-    <!-- Board preview: the real kanban columns, hairline-separated (gap-px on a
-         bg-border grid) like the "how it works" tiles. Stacks on mobile. -->
-    <figure
-      class="mt-10 overflow-hidden rounded-xl border border-border bg-card shadow-sm"
-    >
-      <figcaption
-        class="flex items-center gap-2 border-b border-border px-4 py-2.5 text-xs text-muted-foreground"
-      >
-        <span class="size-2.5 rounded-full bg-muted-foreground/30"></span>
-        My jobs · Board
-      </figcaption>
-      <div class="grid gap-px bg-border sm:grid-cols-4">
-        {#each board as col (col.label)}
-          <div class="bg-background p-4">
-            <div class="flex items-center justify-between">
-              <span class="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                {col.label}
-              </span>
-              <span class="font-mono text-[11px] text-muted-foreground">{col.cards.length}</span>
-            </div>
-            <div class="mt-3 flex flex-col gap-2">
-              {#each col.cards as card (card.title)}
-                <article class="flex items-center gap-3 rounded-lg border border-border bg-card px-3 py-2.5">
-                  <div
-                    class="grid size-8 shrink-0 place-items-center rounded-lg border border-border font-mono text-xs font-medium"
-                  >
-                    {card.company.charAt(0)}
-                  </div>
-                  <div class="min-w-0 flex-1">
-                    <p class="truncate text-sm font-medium">{card.title}</p>
-                    <p class="truncate text-xs text-muted-foreground">{card.company}</p>
-                  </div>
-                </article>
-              {/each}
-            </div>
-          </div>
-        {/each}
-      </div>
-    </figure>
   </section>
 
   <!-- Your pipeline — the analytical view of the same My jobs board: a static
@@ -404,7 +357,9 @@
         added, freehire sends it to you on Telegram as a tidy digest. No inbox clutter, no checking back:
         connect once from
         <a href={resolve('/my/notifications/searches')} class="font-medium text-foreground underline-offset-4 hover:underline">Saved searches &amp; alerts</a>
-        and the openings come to you.
+        and the openings come to you. Email and push work the same way — see how on the
+        <a href={resolve('/features/notifications')} class="font-medium text-foreground underline-offset-4 hover:underline">Notifications</a>
+        page.
       </p>
       <div class="mt-8 flex flex-wrap gap-3">
         <Button href={resolve('/')} variant="primary" size="lg">Find &amp; save a filter</Button>

--- a/web/src/lib/components/NotificationsLandingView.svelte
+++ b/web/src/lib/components/NotificationsLandingView.svelte
@@ -1,0 +1,279 @@
+<script lang="ts">
+  import { Bell, Check, ChevronRight, Mail, SlidersHorizontal, Smartphone } from '@lucide/svelte';
+  import { resolve } from '$app/paths';
+  import { Button, EntityLogo, ProviderIcon, SectionLabel } from '$lib/ui';
+  import BrandMark from '$lib/components/BrandMark.svelte';
+  import { NOTIFICATIONS_FAQ } from '$lib/notificationsFaq';
+
+  // Illustrative jobs for the digest mockup — decorative, not live data, all
+  // named for a "Remote Go Backend" saved search so the subject line and the
+  // rows agree with each other.
+  const digestJobs = [
+    { company: 'Grafana', title: 'Platform Engineer' },
+    { company: 'Datadog', title: 'Senior Backend Engineer' },
+    { company: 'Cloudflare', title: 'Staff Backend Engineer' },
+  ];
+
+  const triggers = [
+    { key: 'match', text: 'A new match: instantly, or once a day at a time you pick.' },
+    { key: 'saved', text: "A saved job you haven't applied to, 3 days after saving it." },
+    {
+      key: 'silent',
+      text: 'An application gone quiet, at 21, 18, 15, 12 and 5 days of silence — sooner the closer the stage is to a decision.',
+    },
+    { key: 'interview', text: 'An interview, the moment it is scheduled.' },
+  ];
+</script>
+
+{#snippet mailHeader()}
+  <div class="flex items-center gap-2">
+    <BrandMark class="size-5 text-foreground" />
+    <span class="text-sm font-bold">freehire</span>
+  </div>
+{/snippet}
+
+{#snippet mailFooter(note: string)}
+  <p class="mt-6 border-t border-border pt-4 text-xs text-muted-foreground">
+    {note}
+    <a href={resolve('/my/notifications/settings')} class="underline-offset-4 hover:underline">Manage notifications</a>.
+  </p>
+{/snippet}
+
+<div class="flex flex-col">
+  <!-- Hero. Headline and pitch, then the real "save a search, get alerted"
+       controls in miniature — the same ones on the job feed's filter sidebar. -->
+  <section class="dot-grid -mx-4 grid items-center gap-12 px-4 pb-16 pt-8 lg:grid-cols-[1.05fr_0.95fr]">
+    <div>
+      <SectionLabel text="notifications" />
+      <h1 class="mt-6 max-w-2xl text-balance text-4xl font-semibold leading-[1.0] tracking-tighter sm:text-6xl">
+        You don't refresh the feed. It comes to you.
+      </h1>
+      <p class="mt-7 max-w-xl text-lg leading-relaxed text-muted-foreground">
+        Save a search once and freehire watches it for you — instantly, or as a daily digest. The
+        same settings also carry your tracking nudges, so a new match and a stalled application
+        both reach you the same way: email, Telegram, or push.
+      </p>
+      <div class="mt-9 flex flex-wrap items-center gap-3">
+        <Button href={resolve('/')} variant="primary" size="lg">Browse jobs</Button>
+        <Button href={resolve('/my/notifications/settings')} variant="outline" size="lg">Notification settings</Button>
+      </div>
+    </div>
+
+    <!-- The real filter-sidebar controls, in miniature: FilterSummaryShell's
+         "All filters" + SaveSearchAlert's "Get new-job alerts", then the
+         AlertChannels toggle it leads to. Static — no click handlers. -->
+    <figure class="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
+      <figcaption class="flex items-center gap-2 border-b border-border px-4 py-2.5 text-xs text-muted-foreground">
+        <span class="size-2.5 rounded-full bg-muted-foreground/30"></span>
+        Jobs · Filters
+      </figcaption>
+      <div class="flex flex-col gap-3 p-4 sm:p-5">
+        <span
+          class="flex h-11 w-full items-center justify-center gap-2 rounded-xl border border-border bg-background text-sm font-medium"
+        >
+          <SlidersHorizontal class="size-4" aria-hidden="true" />
+          All filters
+          <span
+            class="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-brand px-1.5 text-[11px] font-semibold text-brand-foreground"
+          >3</span>
+        </span>
+        <span
+          class="flex h-11 w-full items-center justify-center gap-2 rounded-xl bg-secondary text-sm font-semibold"
+        >
+          <Bell class="size-4" aria-hidden="true" />
+          Get new-job alerts
+          <ChevronRight class="size-4 text-muted-foreground" aria-hidden="true" />
+        </span>
+        <div class="mt-2 flex flex-col gap-2 border-t border-border pt-4">
+          <span class="flex items-center gap-1.5 text-sm text-muted-foreground">
+            <Bell class="size-3.5 shrink-0" aria-hidden="true" />
+            Notify me when a new job matches these filters
+          </span>
+          <div class="flex flex-wrap gap-2">
+            <span
+              class="inline-flex items-center gap-1.5 rounded-full border border-transparent bg-brand-muted px-3 py-1.5 text-xs font-semibold text-brand-strong"
+            >
+              <Check class="size-3.5" aria-hidden="true" />
+              Email
+            </span>
+            <span
+              class="inline-flex items-center gap-1.5 rounded-full border border-border bg-background px-3 py-1.5 text-xs font-semibold text-muted-foreground"
+            >
+              <Smartphone class="size-3.5" aria-hidden="true" />
+              Push
+            </span>
+          </div>
+        </div>
+      </div>
+    </figure>
+  </section>
+
+  <!-- The two triggers. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="two things worth knowing about" />
+    <div class="mt-6 max-w-2xl">
+      <h2 class="text-3xl font-semibold tracking-tight sm:text-4xl">A new match, or your own board gone quiet.</h2>
+    </div>
+    <div class="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2">
+      <div class="bg-background p-6 sm:p-7">
+        <h3 class="text-lg font-semibold tracking-tight">A job that just appeared</h3>
+        <p class="mt-2 text-sm leading-relaxed text-muted-foreground">
+          Save a search — stack, seniority, region, salary — and freehire matches new postings
+          against it as they're added. Get told instantly, or once a day at a time you pick.
+        </p>
+        <a
+          href={resolve('/my/notifications/searches')}
+          class="mt-4 inline-block text-sm font-medium text-foreground underline-offset-4 hover:underline"
+        >
+          Manage your saved searches →
+        </a>
+      </div>
+      <div class="bg-background p-6 sm:p-7">
+        <h3 class="text-lg font-semibold tracking-tight">Your own board, going quiet</h3>
+        <p class="mt-2 text-sm leading-relaxed text-muted-foreground">
+          The same channels also carry your tracking nudges — a saved job you haven't applied to,
+          an application gone silent, an interview coming up.
+        </p>
+        <a
+          href={resolve('/features/tracking')}
+          class="mt-4 inline-block text-sm font-medium text-foreground underline-offset-4 hover:underline"
+        >
+          How tracking works →
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- What the two emails actually look like. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="what it looks like" />
+    <div class="mt-6 max-w-2xl">
+      <h2 class="text-3xl font-semibold tracking-tight sm:text-4xl">Two kinds of email, one settings page.</h2>
+      <p class="mt-5 leading-relaxed text-muted-foreground">
+        Both mirror the real template — the same card, the same brand button, the same opt-out
+        line at the bottom.
+      </p>
+    </div>
+    <div class="mt-10 grid gap-6 lg:grid-cols-2">
+      <!-- Job-alert digest. -->
+      <figure class="overflow-hidden rounded-xl border border-border bg-secondary/40 shadow-sm">
+        <figcaption class="border-b border-border px-4 py-2.5 text-xs text-muted-foreground">
+          3 new jobs for "Remote Go Backend"
+        </figcaption>
+        <div class="p-4 sm:p-5">
+          <div class="rounded-xl border border-border bg-card p-5 shadow-sm">
+            {@render mailHeader()}
+            <h3 class="mt-4 text-base font-semibold tracking-tight">3 new jobs for &ldquo;Remote Go Backend&rdquo;</h3>
+            <div class="mt-4 flex flex-col gap-2">
+              {#each digestJobs as job (job.title)}
+                <div class="flex items-center gap-3 rounded-lg border border-border p-2.5">
+                  <EntityLogo name={job.company} shape="square" size="xs" />
+                  <div class="min-w-0">
+                    <p class="truncate text-sm font-medium">{job.title}</p>
+                    <p class="truncate text-xs text-muted-foreground">{job.company}</p>
+                  </div>
+                </div>
+              {/each}
+            </div>
+            <span class="mt-5 inline-block rounded-md bg-brand px-4 py-2 text-sm font-medium text-brand-foreground">
+              View all — 12 more
+            </span>
+            {@render mailFooter("You're getting this because you set up a job alert on freehire.")}
+          </div>
+        </div>
+      </figure>
+
+      <!-- Tracking follow-up nudge. -->
+      <figure class="overflow-hidden rounded-xl border border-border bg-secondary/40 shadow-sm">
+        <figcaption class="border-b border-border px-4 py-2.5 text-xs text-muted-foreground">
+          Time to follow up: Senior Backend Engineer at Linear
+        </figcaption>
+        <div class="p-4 sm:p-5">
+          <div class="rounded-xl border border-border bg-card p-5 shadow-sm">
+            {@render mailHeader()}
+            <h3 class="mt-4 text-base font-semibold tracking-tight">Worth a follow-up?</h3>
+            <div class="mt-4 flex items-center gap-3 rounded-lg border border-border p-2.5">
+              <EntityLogo name="Linear" shape="square" size="xs" />
+              <div class="min-w-0">
+                <p class="truncate text-sm font-medium">Senior Backend Engineer</p>
+                <p class="truncate text-xs text-muted-foreground">Linear</p>
+              </div>
+            </div>
+            <p class="mt-4 text-sm leading-relaxed text-muted-foreground">Nothing has moved here in 12 days.</p>
+            <span class="mt-5 inline-block rounded-md bg-brand px-4 py-2 text-sm font-medium text-brand-foreground">
+              Open your tracking board
+            </span>
+            {@render mailFooter("You're getting this because you're tracking this application on freehire.")}
+          </div>
+        </div>
+      </figure>
+    </div>
+  </section>
+
+  <!-- Every trigger, on your channel. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="every trigger, on your channel" />
+    <div class="mt-6 grid gap-10 lg:grid-cols-2 lg:items-start">
+      <div>
+        <h2 class="max-w-md text-3xl font-semibold tracking-tight sm:text-4xl">Four things trigger a notification.</h2>
+        <ul class="mt-6 flex flex-col gap-2.5 text-sm leading-relaxed text-muted-foreground">
+          {#each triggers as t (t.key)}
+            <li class="flex gap-2.5">
+              <span class="mt-2 size-1.5 shrink-0 rounded-full bg-muted-foreground/50"></span>
+              {t.text}
+            </li>
+          {/each}
+        </ul>
+      </div>
+      <div>
+        <p class="max-w-md leading-relaxed text-muted-foreground">
+          Pick the channel — any combination sends, and one you never connect is simply skipped —
+          and set quiet hours; nothing arrives while they're on. A daily digest is exempt, since
+          it already fires once at a time you chose.
+        </p>
+        <div class="mt-6 flex flex-wrap items-center gap-4 text-muted-foreground">
+          <span class="flex items-center gap-1.5 text-sm"><Mail class="size-4" aria-hidden="true" /> Email</span>
+          <span class="flex items-center gap-1.5 text-sm"><ProviderIcon provider="telegram" class="size-4" /> Telegram</span>
+          <span class="flex items-center gap-1.5 text-sm"><Smartphone class="size-4" aria-hidden="true" /> Push</span>
+        </div>
+        <div class="mt-8">
+          <Button href={resolve('/my/notifications/settings')} variant="primary" size="lg">Notification settings</Button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- FAQ. Visible answers and the FAQPage JSON-LD share NOTIFICATIONS_FAQ. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="faq" />
+    <h2 class="mt-6 max-w-md text-3xl font-semibold tracking-tight sm:text-4xl">Frequently asked questions.</h2>
+    <!-- An odd number of items would leave the last row half empty (see the
+         features doorway grid in HomeView.svelte) — the last card fills the
+         row instead when the count is odd. -->
+    <dl
+      class="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2 sm:[&>*:last-child:nth-child(odd)]:col-span-2"
+    >
+      {#each NOTIFICATIONS_FAQ as item (item.question)}
+        <div class="bg-background p-6 sm:p-7">
+          <dt class="text-lg font-semibold tracking-tight">{item.question}</dt>
+          <dd class="mt-2 text-sm leading-relaxed text-muted-foreground">{item.answer}</dd>
+        </div>
+      {/each}
+    </dl>
+  </section>
+
+  <!-- Closing CTA. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <div class="flex flex-col items-start gap-4 rounded-xl border border-border bg-secondary/40 p-6 sm:p-8">
+      <h2 class="text-2xl font-semibold tracking-tight">Stop checking back to find out.</h2>
+      <p class="max-w-xl leading-relaxed text-muted-foreground">
+        Save the next search worth watching and freehire tells you the moment — or the day — it
+        matters.
+      </p>
+      <div class="flex flex-wrap gap-3">
+        <Button href={resolve('/')} variant="primary" size="lg">Browse jobs</Button>
+        <Button href={resolve('/my/notifications/settings')} variant="outline" size="lg">Notification settings</Button>
+      </div>
+    </div>
+  </section>
+</div>

--- a/web/src/lib/components/TrackingLandingView.svelte
+++ b/web/src/lib/components/TrackingLandingView.svelte
@@ -1,0 +1,336 @@
+<script lang="ts">
+  import { Clock, Mail } from '@lucide/svelte';
+  import { resolve } from '$app/paths';
+  import { Badge, Button, EntityLogo, SectionLabel } from '$lib/ui';
+  import HomeFunnel from '$lib/components/HomeFunnel.svelte';
+  import { TRACKING_FAQ } from '$lib/trackingFaq';
+
+  interface PreviewCard {
+    company: string;
+    title: string;
+    badge?: string;
+    silenceDays?: number;
+    mailCount?: number;
+    hasNotes?: boolean;
+  }
+
+  interface PreviewColumn {
+    id: string;
+    label: string;
+    count: number;
+    cards: PreviewCard[];
+  }
+
+  // Illustrative "My jobs" board for the hero figure — decorative, not live data,
+  // and deliberately not anyone's real search: mirrors the product's own stage
+  // vocabulary (STAGE_GROUPS) and BoardCard's signal set (stage badge, silence
+  // day-counter, linked-mail count, notes marker) so the preview never shows a
+  // signal the real board doesn't have. Column `count` can exceed its visible
+  // cards, same as the real board once a column scrolls.
+  const board: PreviewColumn[] = [
+    {
+      id: 'preparing',
+      label: 'Preparing',
+      count: 6,
+      cards: [
+        { company: 'Grafana', title: 'Platform Engineer' },
+        { company: 'Vercel', title: 'Staff Frontend Engineer', hasNotes: true },
+      ],
+    },
+    {
+      id: 'applied',
+      label: 'Applied',
+      count: 18,
+      cards: [
+        { company: 'Stripe', title: 'Senior Backend Engineer', badge: 'Applied', mailCount: 1 },
+        { company: 'Datadog', title: 'Data Engineer', badge: 'Screening', hasNotes: true },
+        { company: 'Hugging Face', title: 'ML Engineer', badge: 'Applied' },
+      ],
+    },
+    {
+      id: 'interview',
+      label: 'Interview',
+      count: 2,
+      cards: [
+        { company: 'Linear', title: 'Senior Backend Engineer', silenceDays: 12, mailCount: 3 },
+        { company: 'Figma', title: 'Product Designer', hasNotes: true },
+      ],
+    },
+    {
+      id: 'offer',
+      label: 'Offer',
+      count: 1,
+      cards: [{ company: 'Notion', title: 'Staff Frontend Engineer', mailCount: 2 }],
+    },
+  ];
+
+  // Illustrative pipeline snapshot for the funnel below — the counts match the
+  // hero board above (same 64 applications, split the same way) so the two
+  // figures read as one search rather than two disconnected mockups.
+  const funnel = {
+    applications: 64,
+    buckets: { preparing: 6, applied: 18, interview: 2, offer: 1, closed: 37 },
+  };
+
+  const signals = [
+    {
+      key: 'silence',
+      title: 'A day-counter when it goes quiet',
+      body: 'Once an application has gone unanswered past the point worth noticing, its card carries a day-counter — days since the last contact — so a stalled thread stays visible instead of aging quietly at the bottom of a column.',
+    },
+    {
+      key: 'inbox',
+      title: 'Replies attach themselves',
+      body: 'Connect your mail and a recruiter reply is tagged with what it says, attached to the application it belongs to, and walks the card forward for you.',
+      href: resolve('/features/inbox'),
+      cta: 'How the inbox works',
+    },
+    {
+      key: 'notes',
+      title: 'A note only you see',
+      body: "A contact's name, a red flag, the reason you applied — attach a private note to any card and it travels with it wherever it moves.",
+    },
+    {
+      key: 'search',
+      title: 'Search the board itself',
+      body: 'Once it is long, filter by company or role right on the board — the same search that narrows the list and calendar views.',
+    },
+  ];
+
+  const views = [
+    { key: 'board', title: 'Board', body: 'Drag a card through its stages by hand.' },
+    { key: 'list', title: 'List', body: 'Every application, one row each, sorted and filtered.' },
+    { key: 'pipeline', title: 'Pipeline', body: 'The funnel below — the shape of the whole search.' },
+    { key: 'calendar', title: 'Calendar', body: 'Anything with a date, an interview included.' },
+  ];
+</script>
+
+<div class="flex flex-col">
+  <!-- Hero. Headline and pitch, then the board itself, full width — a kanban
+       needs the room a side-column hero figure doesn't have. -->
+  <section class="dot-grid -mx-4 px-4 pb-16 pt-8">
+    <SectionLabel text="job tracking" />
+    <h1 class="mt-6 max-w-2xl text-balance text-4xl font-semibold leading-[1.0] tracking-tighter sm:text-6xl">
+      Every application, one board. Nothing falls through.
+    </h1>
+    <p class="mt-7 max-w-xl text-lg leading-relaxed text-muted-foreground">
+      Save what's worth a second look and freehire keeps it visible until it's resolved — through
+      four stages, from Preparing to Offer, with a day-counter when an employer goes quiet and a
+      place for the notes only you need.
+    </p>
+    <div class="mt-9 flex flex-wrap items-center gap-3">
+      <Button href={resolve('/my/tracking')} variant="primary" size="lg">Open Tracking</Button>
+      <Button href={resolve('/cli')} variant="outline" size="lg">Track from the CLI</Button>
+    </div>
+
+    <!-- Board preview: the real kanban columns, hairline-separated. -->
+    <figure class="mt-12 overflow-hidden rounded-xl border border-border bg-card shadow-sm">
+      <figcaption class="flex items-center gap-2 border-b border-border px-4 py-2.5 text-xs text-muted-foreground">
+        <span class="size-2.5 rounded-full bg-muted-foreground/30"></span>
+        My jobs · Board
+      </figcaption>
+      <div class="grid gap-px bg-border sm:grid-cols-4">
+        {#each board as col (col.id)}
+          <div class="bg-background p-4">
+            <div class="flex items-center justify-between">
+              <span class="text-xs font-medium uppercase tracking-wide text-muted-foreground">{col.label}</span>
+              <span class="font-mono text-[11px] text-muted-foreground">{col.count}</span>
+            </div>
+            <div class="mt-3 flex flex-col gap-2">
+              {#each col.cards as card (card.title)}
+                <article class="flex flex-col gap-1.5 rounded-lg border border-border bg-card p-3 shadow-sm">
+                  <span class="flex items-center gap-1.5 text-sm font-semibold">
+                    <EntityLogo name={card.company} shape="square" size="xs" />
+                    <span class="min-w-0 truncate">{card.company}</span>
+                  </span>
+                  <span class="line-clamp-2 text-sm">{card.title}</span>
+                  <span class="flex flex-wrap items-center gap-x-1.5 gap-y-1">
+                    {#if card.badge}
+                      <Badge variant="secondary">{card.badge}</Badge>
+                    {/if}
+                    {#if card.silenceDays}
+                      <span class="flex items-center gap-0.5 text-xs tabular-nums text-warning-strong">
+                        <Clock class="size-3 shrink-0" aria-hidden="true" />
+                        {card.silenceDays}d
+                      </span>
+                    {/if}
+                    {#if card.mailCount}
+                      <span class="flex items-center gap-0.5 text-xs tabular-nums text-muted-foreground">
+                        <Mail class="size-3 shrink-0" aria-hidden="true" />
+                        {card.mailCount}
+                      </span>
+                    {/if}
+                    {#if card.hasNotes}
+                      <svg
+                        class="size-3 shrink-0 text-muted-foreground"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        aria-hidden="true"
+                      >
+                        <path d="M8 7h8M8 12h8M8 17h5" />
+                      </svg>
+                    {/if}
+                  </span>
+                </article>
+              {/each}
+            </div>
+          </div>
+        {/each}
+      </div>
+    </figure>
+  </section>
+
+  <!-- What a card carries. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="every card, at a glance" />
+    <div class="mt-6 max-w-2xl">
+      <h2 class="text-3xl font-semibold tracking-tight sm:text-4xl">The card tells you where things stand.</h2>
+      <p class="mt-5 leading-relaxed text-muted-foreground">
+        Nothing here is a control you have to open a panel to find. It's read straight off the card.
+      </p>
+    </div>
+    <div class="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2">
+      {#each signals as s (s.key)}
+        <div class="bg-background p-6 sm:p-7">
+          <h3 class="text-lg font-semibold tracking-tight">{s.title}</h3>
+          <p class="mt-2 text-sm leading-relaxed text-muted-foreground">{s.body}</p>
+          {#if s.href}
+            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal route already passed through resolve() when building `signals`; the linter can't trace it via the variable -->
+            <a href={s.href} class="mt-4 inline-block text-sm font-medium text-foreground underline-offset-4 hover:underline">
+              {s.cta} →
+            </a>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  </section>
+
+  <!-- Nudges — trimmed to a pointer at the dedicated Notifications page, which
+       covers this alongside job alerts and shows what the emails look like. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="nudges" />
+    <div class="mt-6 max-w-2xl">
+      <h2 class="text-3xl font-semibold tracking-tight sm:text-4xl">
+        It follows up before you have to remember to.
+      </h2>
+      <p class="mt-5 leading-relaxed text-muted-foreground">
+        The same silence a card's day-counter shows also goes out as a nudge — over email,
+        Telegram or push — so a stalled application doesn't just sit there. See what that looks
+        like on the <a href={resolve('/features/notifications')} class="font-medium text-foreground underline-offset-4 hover:underline">Notifications</a> page.
+      </p>
+      <div class="mt-8 flex flex-wrap gap-3">
+        <Button href={resolve('/features/notifications')} variant="primary" size="lg">See how notifications work</Button>
+        <Button href={resolve('/my/notifications/settings')} variant="ghost" size="lg">Notification settings</Button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Your pipeline — the funnel view of the same board. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="your pipeline" />
+    <div class="mt-6 max-w-2xl">
+      <h2 class="text-3xl font-semibold tracking-tight sm:text-4xl">See where every application lands.</h2>
+      <p class="mt-5 leading-relaxed text-muted-foreground">
+        As cards move through the board, freehire rolls them into one funnel — how many are still in
+        Preparing, sitting in Applied, in an active Interview loop, or turned into an Offer. Whatever
+        settled moves to Closed: out of the active board, never erased.
+      </p>
+    </div>
+    <figure class="mt-10 overflow-hidden rounded-xl border border-border bg-card shadow-sm">
+      <figcaption class="flex items-center gap-2 border-b border-border px-4 py-2.5 text-xs text-muted-foreground">
+        <span class="size-2.5 rounded-full bg-muted-foreground/30"></span>
+        My jobs · Pipeline
+      </figcaption>
+      <div class="p-5 sm:p-8">
+        <HomeFunnel applications={funnel.applications} buckets={funnel.buckets} />
+      </div>
+    </figure>
+  </section>
+
+  <!-- Four views over the same data. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="four ways to look at it" />
+    <div class="mt-6 max-w-2xl">
+      <h2 class="text-3xl font-semibold tracking-tight sm:text-4xl">Board, List, Pipeline, Calendar.</h2>
+      <p class="mt-5 leading-relaxed text-muted-foreground">
+        Same applications, four tabs. Switch when the board isn't the shape you need right now.
+      </p>
+    </div>
+    <div class="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2 lg:grid-cols-4">
+      {#each views as v (v.key)}
+        <div class="bg-background p-6">
+          <h3 class="text-sm font-semibold tracking-tight">{v.title}</h3>
+          <p class="mt-2 text-sm leading-relaxed text-muted-foreground">{v.body}</p>
+        </div>
+      {/each}
+    </div>
+  </section>
+
+  <!-- Terminal / agents. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="from the terminal" />
+    <div class="mt-6 grid gap-10 lg:grid-cols-2 lg:items-center">
+      <div>
+        <h2 class="max-w-md text-3xl font-semibold tracking-tight sm:text-4xl">
+          Or let a script keep the board current.
+        </h2>
+        <p class="mt-5 max-w-md leading-relaxed text-muted-foreground">
+          The freehire CLI drives the same board with one API key — save, apply, move a stage, leave a
+          note — so your own agent can keep it current without a browser.
+        </p>
+        <div class="mt-8 flex flex-wrap gap-3">
+          <Button href={resolve('/cli')} variant="primary" size="lg">Explore the CLI</Button>
+          <Button href={resolve('/docs/api')} variant="ghost" size="lg">API reference</Button>
+        </div>
+      </div>
+      <figure class="overflow-hidden rounded-xl border border-border bg-secondary/60 font-mono text-sm shadow-sm">
+        <figcaption class="flex items-center gap-2 border-b border-border px-4 py-2.5 text-xs text-muted-foreground">
+          <span class="size-2.5 rounded-full bg-muted-foreground/30"></span>
+          terminal
+        </figcaption>
+        <pre class="overflow-x-auto p-4 leading-relaxed"><span class="text-muted-foreground"># save or apply — either starts tracking it</span>
+freehire <span class="text-foreground">apply &lt;slug&gt;</span>
+freehire <span class="text-foreground">save &lt;slug&gt;</span>
+
+<span class="text-muted-foreground"># move it yourself, or let the inbox do it</span>
+freehire <span class="text-foreground">stage &lt;slug&gt; --to interview</span>
+
+<span class="text-muted-foreground"># a private note, attached to the card</span>
+freehire <span class="text-foreground">note &lt;slug&gt; "referred by a former teammate"</span></pre>
+      </figure>
+    </div>
+  </section>
+
+  <!-- FAQ. Visible answers and the FAQPage JSON-LD share TRACKING_FAQ. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <SectionLabel text="faq" />
+    <h2 class="mt-6 max-w-md text-3xl font-semibold tracking-tight sm:text-4xl">Frequently asked questions.</h2>
+    <dl class="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2">
+      {#each TRACKING_FAQ as item (item.question)}
+        <div class="bg-background p-6 sm:p-7">
+          <dt class="text-lg font-semibold tracking-tight">{item.question}</dt>
+          <dd class="mt-2 text-sm leading-relaxed text-muted-foreground">{item.answer}</dd>
+        </div>
+      {/each}
+    </dl>
+  </section>
+
+  <!-- Closing CTA. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <div class="flex flex-col items-start gap-4 rounded-xl border border-border bg-secondary/40 p-6 sm:p-8">
+      <h2 class="text-2xl font-semibold tracking-tight">Stop losing track of where you applied.</h2>
+      <p class="max-w-xl leading-relaxed text-muted-foreground">
+        Save the next job worth a second look and it's on the board — Preparing, Applied, Interview,
+        Offer, tracked from there on.
+      </p>
+      <div class="flex flex-wrap gap-3">
+        <Button href={resolve('/')} variant="primary" size="lg">Browse jobs</Button>
+        <Button href={resolve('/my/tracking')} variant="outline" size="lg">Open Tracking</Button>
+      </div>
+    </div>
+  </section>
+</div>

--- a/web/src/lib/notificationsFaq.ts
+++ b/web/src/lib/notificationsFaq.ts
@@ -1,0 +1,32 @@
+// Notifications landing FAQ — the single source for both the visible section
+// (NotificationsLandingView.svelte) and the FAQPage JSON-LD (routes/features/notifications).
+// Google requires the schema's answers to match the on-page text, so they share this.
+
+import type { FaqItem } from './seo';
+
+export const NOTIFICATIONS_FAQ: FaqItem[] = [
+  {
+    question: 'How fast does a job alert arrive?',
+    answer:
+      'Choose Instant and it goes out as soon as the next match run finds a job against your saved search, or a daily digest at a time you set — either way, over email, Telegram or push, whichever you connect.',
+  },
+  {
+    question: 'What besides new jobs sends a notification?',
+    answer:
+      "Your own tracking board. A saved job nudges you after 3 days if you haven't applied, a stalled application follows up at 21, 18, 15, 12 and 5 days of silence depending on the stage, and an interview nudges you the moment it's scheduled.",
+  },
+  {
+    question: 'Can I go quiet for part of the day?',
+    answer:
+      'Yes — set quiet hours and every reminder, nudge and instant alert waits until the window ends. A daily digest is exempt, since it already fires once at a time you chose.',
+  },
+  {
+    question: 'Which channels are supported?',
+    answer: 'Email, Telegram, and push to the freehire mobile app — pick any combination; a channel you never connect is simply skipped, not an error.',
+  },
+  {
+    question: 'Where do I change any of this?',
+    answer:
+      'One settings page covers every notification the account sends: which channels, how often search alerts fire, and your quiet hours.',
+  },
+];

--- a/web/src/lib/sitemap.ts
+++ b/web/src/lib/sitemap.ts
@@ -32,6 +32,8 @@ export const STATIC_PATHS = [
   '/features/inbox',
   '/features/referrals',
   '/features/tailor',
+  '/features/tracking',
+  '/features/notifications',
   '/features/ghost-jobs',
   '/features/advanced-search',
   // The data and API surfaces. Indexable pages that carry the site's most citable

--- a/web/src/lib/trackingFaq.ts
+++ b/web/src/lib/trackingFaq.ts
@@ -1,0 +1,38 @@
+// Application-tracking landing FAQ — the single source for both the visible section
+// (TrackingLandingView.svelte) and the FAQPage JSON-LD (routes/features/tracking).
+// Google requires the schema's answers to match the on-page text, so they share this.
+
+import type { FaqItem } from './seo';
+
+export const TRACKING_FAQ: FaqItem[] = [
+  {
+    question: 'How does a job end up on my board?',
+    answer:
+      'Save it or apply to it from anywhere on freehire — the job page, search, or the browser extension — and it lands on your board as a tracked application. Nothing is added without you doing one of those two things first.',
+  },
+  {
+    question: 'What are the stages?',
+    answer:
+      'Preparing, Applied, Interview and Offer, in that order — the four columns on the board. A settled application, whether it ended in an offer you accepted or one that did not work out, moves into Closed, which is out of the active board so it stops competing for your attention.',
+  },
+  {
+    question: 'Does it notice when an employer goes quiet?',
+    answer:
+      "Yes. Once an application has gone unanswered past a point worth noticing, its card carries a day-counter — days since the last contact — so a stalled application stays visible instead of quietly aging at the bottom of a column.",
+  },
+  {
+    question: 'Can a reply move the card for me?',
+    answer:
+      'Connect your mail through the freehire inbox and a recruiter reply is tagged with what it says, attached to the application it belongs to, and walks the card to its next stage automatically — you only intervene when it guesses wrong.',
+  },
+  {
+    question: 'Is the board the only view?',
+    answer:
+      'No — the same applications also render as a List for scanning, a Pipeline funnel for the shape of your search, and a Calendar for anything with a date attached, like an interview.',
+  },
+  {
+    question: 'Can I track from the terminal?',
+    answer:
+      'Yes. The freehire CLI drives the same board with one API key: `save` and `apply` add a job, `stage` moves it, and `note` attaches a private note — so a script or your own agent can keep the board current without a browser.',
+  },
+];

--- a/web/src/routes/features/notifications/+page.svelte
+++ b/web/src/routes/features/notifications/+page.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import Seo from '$lib/components/Seo.svelte';
+  import NotificationsLandingView from '$lib/components/NotificationsLandingView.svelte';
+  import { faqPageJsonLd, jsonLdScript } from '$lib/seo';
+  import { NOTIFICATIONS_FAQ } from '$lib/notificationsFaq';
+
+  const canonical = $derived(`${page.url.origin}/features/notifications`);
+  // The FAQ block and this payload render from the same NOTIFICATIONS_FAQ array, so the
+  // structured data can never disagree with what the page shows.
+  const jsonLd = $derived(jsonLdScript([faqPageJsonLd(NOTIFICATIONS_FAQ)]));
+</script>
+
+<Seo
+  title="Notifications — job alerts and tracking nudges, on your channel | freehire"
+  description="Save a search and get told about a new match instantly or as a daily digest, over email, Telegram or push. The same settings carry your tracking nudges — a saved job you haven't applied to, an application gone quiet, an interview coming up — with quiet hours to keep it out of your evening."
+  {canonical}
+/>
+
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->
+  {@html jsonLd}
+</svelte:head>
+
+<div class="mx-auto w-full max-w-6xl px-4 py-6">
+  <NotificationsLandingView />
+</div>

--- a/web/src/routes/features/tracking/+page.svelte
+++ b/web/src/routes/features/tracking/+page.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import Seo from '$lib/components/Seo.svelte';
+  import TrackingLandingView from '$lib/components/TrackingLandingView.svelte';
+  import { faqPageJsonLd, jsonLdScript } from '$lib/seo';
+  import { TRACKING_FAQ } from '$lib/trackingFaq';
+
+  const canonical = $derived(`${page.url.origin}/features/tracking`);
+  // The FAQ block and this payload render from the same TRACKING_FAQ array, so the
+  // structured data can never disagree with what the page shows.
+  const jsonLd = $derived(jsonLdScript([faqPageJsonLd(TRACKING_FAQ)]));
+</script>
+
+<Seo
+  title="Job application tracking — one board, from Preparing to Offer | freehire"
+  description="Track every application on one board — Preparing, Applied, Interview, Offer — with a day-counter when an employer goes quiet, notes on every card, and recruiter replies that attach and advance it themselves. Also a List, a Pipeline funnel, and a Calendar. Drive it from the browser or the CLI."
+  {canonical}
+/>
+
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->
+  {@html jsonLd}
+</svelte:head>
+
+<div class="mx-auto w-full max-w-6xl px-4 py-6">
+  <TrackingLandingView />
+</div>


### PR DESCRIPTION
## Summary
- New `/features/tracking` page: mirrors the real "My jobs" board (Preparing/Applied/Interview/Offer, day-counter, mail count, notes, stage badges) and reuses `HomeFunnel` for the pipeline view — no invented data shapes or colors.
- New `/features/notifications` page: covers saved-search job alerts and tracking nudges together, mirroring the real filters-sidebar "Get new-job alerts" / Email-Push toggle UI and the actual `internal/mailtpl`/`internal/emailnotify`/`internal/nudge` email subject lines and copy.
- `/about`'s tracker section trimmed to a short pointer at the new Tracking page (also fixes a stale "Saved" stage label to the real "Preparing"); its Telegram-alerts section now cross-links to Notifications.
- Both pages registered in the sitemap, footer, and homepage feature doorway grid, each with its own FAQ + FAQPage JSON-LD.

## Test plan
- [x] `svelte-check` — 0 errors (pre-existing unrelated warnings only)
- [x] `eslint` on all new/changed files — clean
- [x] `vitest run src/lib/sitemap.test.ts` — 10/10 passing
- [x] Manually rendered both pages in a browser (light + dark), confirmed no console errors
- [ ] Manual review of copy/design in the deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated landing pages for application tracking and notifications.
  * Added tracking details, workflow previews, notification examples, supported channels, and FAQs.
  * Added footer and home-page links to the new features.
  * Added searchable feature pages to the site sitemap with improved SEO metadata and structured FAQ information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->