### PR TITLE
Add last_job_added_at to the public ingest status endpoint

### DIFF
--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -1227,6 +1227,30 @@ func (q *Queries) InsertPrivateJob(ctx context.Context, arg InsertPrivateJobPara
 	return i, err
 }
 
+const latestOpenJobAddedAt = `-- name: LatestOpenJobAddedAt :one
+SELECT (
+    SELECT created_at
+    FROM jobs
+    WHERE closed_at IS NULL AND duplicate_of IS NULL AND NOT is_private
+    ORDER BY created_at DESC, id DESC
+    LIMIT 1
+) AS last_job_added_at
+`
+
+// created_at of the most recently added open, public job — the "is the pipeline
+// still writing rows" signal for the public /status endpoint. Same predicate and
+// ordering as ListJobs above, so it is served by the same jobs_open_created_idx
+// (an index scan for one row, not the full scan CountCatalogueScale needs) and
+// safe on a live request path. Wrapped in a scalar subquery so this always
+// returns exactly one row — NULL for an empty catalogue — rather than the
+// no-rows error a bare LIMIT 1 SELECT would give sqlc's :one on an empty table.
+func (q *Queries) LatestOpenJobAddedAt(ctx context.Context) (pgtype.Timestamptz, error) {
+	row := q.db.QueryRow(ctx, latestOpenJobAddedAt)
+	var last_job_added_at pgtype.Timestamptz
+	err := row.Scan(&last_job_added_at)
+	return last_job_added_at, err
+}
+
 const listJobIDsAfter = `-- name: ListJobIDsAfter :many
 SELECT id
 FROM jobs

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1601,6 +1601,14 @@ type Querier interface {
 	// Retracted rows are excluded, and the (user_id, job_id, kind) index is partial on exactly that
 	// predicate.
 	LastStageSetAt(ctx context.Context, arg LastStageSetAtParams) (pgtype.Timestamptz, error)
+	// created_at of the most recently added open, public job — the "is the pipeline
+	// still writing rows" signal for the public /status endpoint. Same predicate and
+	// ordering as ListJobs above, so it is served by the same jobs_open_created_idx
+	// (an index scan for one row, not the full scan CountCatalogueScale needs) and
+	// safe on a live request path. Wrapped in a scalar subquery so this always
+	// returns exactly one row — NULL for an empty catalogue — rather than the
+	// no-rows error a bare LIMIT 1 SELECT would give sqlc's :one on an empty table.
+	LatestOpenJobAddedAt(ctx context.Context) (pgtype.Timestamptz, error)
 	// Manually link (or relink) an email to a chosen application, overriding any
 	// auto-link or suggestion.
 	LinkEmailToJob(ctx context.Context, arg LinkEmailToJobParams) (int64, error)

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -162,6 +162,22 @@ SELECT similar_job_ids
 FROM jobs
 WHERE id = sqlc.arg(id)::bigint;
 
+-- name: LatestOpenJobAddedAt :one
+-- created_at of the most recently added open, public job — the "is the pipeline
+-- still writing rows" signal for the public /status endpoint. Same predicate and
+-- ordering as ListJobs above, so it is served by the same jobs_open_created_idx
+-- (an index scan for one row, not the full scan CountCatalogueScale needs) and
+-- safe on a live request path. Wrapped in a scalar subquery so this always
+-- returns exactly one row — NULL for an empty catalogue — rather than the
+-- no-rows error a bare LIMIT 1 SELECT would give sqlc's :one on an empty table.
+SELECT (
+    SELECT created_at
+    FROM jobs
+    WHERE closed_at IS NULL AND duplicate_of IS NULL AND NOT is_private
+    ORDER BY created_at DESC, id DESC
+    LIMIT 1
+) AS last_job_added_at;
+
 -- name: CountCatalogueScale :one
 -- Exact open-job and company totals for the published catalogue-scale snapshot
 -- (internal/catalogstats). Deliberately the opposite trade to EstimateOpenJobs below:

--- a/internal/handler/status.go
+++ b/internal/handler/status.go
@@ -107,12 +107,19 @@ type statusProvider struct {
 
 // IngestStatus serves the public, unauthenticated ingest-fleet status: a
 // per-provider health rollup over board_health with a derived operational/
-// degraded/down status per provider and an overall fleet status. Sanitized by
-// construction — the DTO carries no error text or board identifier — so no
-// internal detail can leak. An empty fleet yields overall "operational" with no
-// providers.
+// degraded/down status per provider and an overall fleet status, plus
+// last_job_added_at — the created_at of the most recently added open, public
+// job, a live signal that the pipeline is actually writing rows (independent
+// of per-provider crawl health). Sanitized by construction — the DTO carries
+// no error text or board identifier — so no internal detail can leak. An
+// empty fleet yields overall "operational" with no providers and a null
+// last_job_added_at.
 func (h *statsHandlers) IngestStatus(c *fiber.Ctx) error {
 	rows, err := h.queries.ProviderHealthRollup(c.Context())
+	if err != nil {
+		return err
+	}
+	lastJobAddedAt, err := h.queries.LatestOpenJobAddedAt(c.Context())
 	if err != nil {
 		return err
 	}
@@ -145,9 +152,10 @@ func (h *statsHandlers) IngestStatus(c *fiber.Ctx) error {
 
 	return c.JSON(fiber.Map{
 		"data": fiber.Map{
-			"overall":      fleetStatus(rolls, now),
-			"generated_at": now.Format(time.RFC3339),
-			"providers":    providers,
+			"overall":           fleetStatus(rolls, now),
+			"generated_at":      now.Format(time.RFC3339),
+			"last_job_added_at": isoOrNil(lastJobAddedAt),
+			"providers":         providers,
 		},
 	})
 }

--- a/internal/handler/status_integration_test.go
+++ b/internal/handler/status_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 
@@ -43,9 +44,10 @@ func TestIngestStatusEndpoint(t *testing.T) {
 		IngestedTotal int     `json:"ingested_total"`
 	}
 	type statusData struct {
-		Overall     string          `json:"overall"`
-		GeneratedAt string          `json:"generated_at"`
-		Providers   []providerEntry `json:"providers"`
+		Overall        string          `json:"overall"`
+		GeneratedAt    string          `json:"generated_at"`
+		LastJobAddedAt *string         `json:"last_job_added_at"`
+		Providers      []providerEntry `json:"providers"`
 	}
 	type envelope struct {
 		Data statusData `json:"data"`
@@ -72,9 +74,9 @@ func TestIngestStatusEndpoint(t *testing.T) {
 		return env, string(raw)
 	}
 
-	// --- Empty fleet: 200, operational, no providers ---------------------------
-	if env, _ := get(t); env.Data.Overall != "operational" || len(env.Data.Providers) != 0 {
-		t.Fatalf("empty fleet: overall=%q providers=%d, want operational/0", env.Data.Overall, len(env.Data.Providers))
+	// --- Empty fleet: 200, operational, no providers, no jobs yet --------------
+	if env, _ := get(t); env.Data.Overall != "operational" || len(env.Data.Providers) != 0 || env.Data.LastJobAddedAt != nil {
+		t.Fatalf("empty fleet: overall=%q providers=%d last_job_added_at=%v, want operational/0/nil", env.Data.Overall, len(env.Data.Providers), env.Data.LastJobAddedAt)
 	}
 
 	// --- Seed boards in controlled states --------------------------------------
@@ -134,7 +136,20 @@ func TestIngestStatusEndpoint(t *testing.T) {
 	// through from the sources registry into the DTO.
 	healthy("jobstash", "", 500)
 
+	// One open, public job with a known created_at, so last_job_added_at has
+	// something to report.
+	latestJobAddedAt := statusNow.Add(-5 * time.Minute)
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO jobs (source, external_id, url, title, public_slug, created_at)
+		VALUES ('test', 'status-latest', 'http://example.test', 'Job', 'status-latest-job', $1)`, latestJobAddedAt); err != nil {
+		t.Fatalf("seed latest job: %v", err)
+	}
+
 	env, raw := get(t)
+
+	if env.Data.LastJobAddedAt == nil || *env.Data.LastJobAddedAt != latestJobAddedAt.Format(time.RFC3339) {
+		t.Errorf("last_job_added_at = %v, want %s", env.Data.LastJobAddedAt, latestJobAddedAt.Format(time.RFC3339))
+	}
 
 	// Overall folds every provider into one fleet rollup: 21 boards, 11 cooled → 10/21
 	// served (~0.48) with a fresh success present → degraded. Note it is NOT down even


### PR DESCRIPTION
## Summary
- Adds `last_job_added_at` to `GET /api/v1/status`: the `created_at` of the most recently added open, public job, so an external caller can confirm the ingest pipeline is actually writing rows — independent of per-provider crawl health, which only reflects crawl success.
- New sqlc query `LatestOpenJobAddedAt`, served by the same partial index (`jobs_open_created_idx`) `ListJobs` already uses, so it's a cheap index scan safe on a live request path (unlike `CountCatalogueScale`, which is a full scan reserved for the scheduled rollup worker).

## Test plan
- [x] Extended `TestIngestStatusEndpoint` (integration, testcontainers): empty catalogue → `last_job_added_at: null`; seeded job → field renders the correct RFC3339 timestamp.
- [x] `go build ./...`, `go vet ./...`, `go test ./internal/handler/... ./internal/db/...`, `go vet -tags=integration ./...`, `gofmt -l` — all clean on latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)