### PR TITLE
merge-companies: plan from jobs, not from the search-index counter

### DIFF
--- a/cmd/merge-companies/plan_test.go
+++ b/cmd/merge-companies/plan_test.go
@@ -300,3 +300,29 @@ func TestPlanMerges_MultiWordNameWinsEvenWhenOnlyAFormedRowHasIt(t *testing.T) {
 		t.Errorf("got %d aliases, want 2 — no existing row holds the canon", len(got[0].Aliases))
 	}
 }
+
+// TestPlanMerges_SeesASlugWhoseIndexCounterIsZero is the bug that stranded 8,375 rows on
+// `jpmorganchase` after wave 1 had merged it.
+//
+// The planner read companies.job_count, which counts the postings the SEARCH INDEX holds — not
+// the rows this worker rewrites. A retired slug drops to 0 in the index while its unmoved rows
+// stay in the table, so filtering on that counter made exactly the leftovers of a merge
+// invisible: the better the merge worked, the more reliably its remainder hid.
+//
+// The query now reads jobs, so a slug with rows and a zero counter is planned like any other.
+// This test pins the planning side of it: a group whose members report 0 open jobs must still
+// merge.
+func TestPlanMerges_SeesASlugWhoseIndexCounterIsZero(t *testing.T) {
+	got := planMerges([]company{
+		{Slug: "jp-morgan-chase", Name: "JP Morgan Chase", JobCount: 0},
+		{Slug: "jpmorganchase", Name: "JPMorganChase", JobCount: 0},
+	}, nil, 0)
+
+	if len(got) != 1 {
+		t.Fatalf("planned %d merges, want 1 — a slug the search index has forgotten still has "+
+			"rows in the table, and those rows are what this worker exists to move", len(got))
+	}
+	if got[0].Canonical != "jp-morgan-chase" {
+		t.Errorf("Canonical = %q, want jp-morgan-chase", got[0].Canonical)
+	}
+}

--- a/docs/agents/company-identity.md
+++ b/docs/agents/company-identity.md
@@ -101,6 +101,13 @@ computes `role_fingerprint` (itself derived from the company slug); without that
 way out. A worker that cannot READ the registry must fail rather than proceed: an empty
 registry is indistinguishable from a catalogue with no merges.
 
+**The merge worker plans from `jobs`, never from `companies.job_count`.** That column counts the
+postings the SEARCH INDEX holds, not the rows the worker rewrites, and the two diverge exactly
+where it hurts: a slug a merge has already retired drops to 0 in the index while its unmoved
+rows stay in the table. Filtering on it made the leftovers of a merge invisible — 8,375 rows
+stranded on `jpmorganchase` after the first wave, permanently, because the better the merge
+worked the more reliably the remainder hid.
+
 ## Gotchas
 
 - **The canonical slug must be a fixed point of the rule, and job count alone does not give

--- a/internal/db/company_slug_aliases.sql.go
+++ b/internal/db/company_slug_aliases.sql.go
@@ -80,9 +80,12 @@ func (q *Queries) ListCanonicalCompanySlugs(ctx context.Context) ([]string, erro
 }
 
 const listCompaniesForMerge = `-- name: ListCompaniesForMerge :many
-SELECT slug, name, job_count
-FROM companies
-WHERE job_count > 0
+SELECT company_slug AS slug,
+       ((array_agg(company ORDER BY created_at DESC))[1])::text AS name,
+       count(*) FILTER (WHERE closed_at IS NULL)::int AS job_count
+FROM jobs
+WHERE company_slug <> ''
+GROUP BY company_slug
 `
 
 type ListCompaniesForMergeRow struct {
@@ -91,10 +94,20 @@ type ListCompaniesForMergeRow struct {
 	JobCount int32  `json:"job_count"`
 }
 
-// The merge worker's input: every company that has an open job, with the count that elects
-// the winner of its folded group. Grouping happens in Go because the fold is
-// normalize.CompanyKey — a repeating legal-form strip no SQL expression should try to
-// reproduce, since a second implementation of that rule is the bug this change removes.
+// The merge worker's input: every company slug the JOBS table actually holds, with the display
+// name and the open-job count that elects the winner of its folded group.
+//
+// READ FROM jobs, NOT FROM companies.job_count. That column counts the postings the SEARCH
+// INDEX holds, not the rows this worker rewrites, and the two diverge exactly where it hurts:
+// a slug a merge has already retired drops to 0 in the index while its unmoved rows stay in
+// the table. Planning from the counter made those rows INVISIBLE to the planner — 8,375 of
+// them on `jpmorganchase` alone, stranded permanently, because the better the merge worked the
+// more reliably the remainder hid.
+//
+// The name is the most recent one seen for the slug, matching how SyncCompaniesFromJobs
+// collapses a slug's name variants. Grouping into folded groups happens in Go because the fold
+// is normalize.CompanyKey — a repeating legal-form strip no SQL expression should reproduce,
+// since a second implementation of that rule is the bug this whole change removes.
 func (q *Queries) ListCompaniesForMerge(ctx context.Context) ([]ListCompaniesForMergeRow, error) {
 	rows, err := q.db.Query(ctx, listCompaniesForMerge)
 	if err != nil {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -1783,10 +1783,20 @@ type Querier interface {
 	// internal/handler/companies.go) — rating is not (yet) a Meili-sortable
 	// attribute, so routing there would silently drop the requested order.
 	ListCompanies(ctx context.Context, arg ListCompaniesParams) ([]ListCompaniesRow, error)
-	// The merge worker's input: every company that has an open job, with the count that elects
-	// the winner of its folded group. Grouping happens in Go because the fold is
-	// normalize.CompanyKey — a repeating legal-form strip no SQL expression should try to
-	// reproduce, since a second implementation of that rule is the bug this change removes.
+	// The merge worker's input: every company slug the JOBS table actually holds, with the display
+	// name and the open-job count that elects the winner of its folded group.
+	//
+	// READ FROM jobs, NOT FROM companies.job_count. That column counts the postings the SEARCH
+	// INDEX holds, not the rows this worker rewrites, and the two diverge exactly where it hurts:
+	// a slug a merge has already retired drops to 0 in the index while its unmoved rows stay in
+	// the table. Planning from the counter made those rows INVISIBLE to the planner — 8,375 of
+	// them on `jpmorganchase` alone, stranded permanently, because the better the merge worked the
+	// more reliably the remainder hid.
+	//
+	// The name is the most recent one seen for the slug, matching how SyncCompaniesFromJobs
+	// collapses a slug's name variants. Grouping into folded groups happens in Go because the fold
+	// is normalize.CompanyKey — a repeating legal-form strip no SQL expression should reproduce,
+	// since a second implementation of that rule is the bug this whole change removes.
 	ListCompaniesForMerge(ctx context.Context) ([]ListCompaniesForMergeRow, error)
 	// Keyset page of hiring companies (job_count > 0) for the companies search reindex,
 	// cursored by the slug primary key (first chunk keyed by the empty string, which

--- a/internal/db/queries/company_slug_aliases.sql
+++ b/internal/db/queries/company_slug_aliases.sql
@@ -39,13 +39,26 @@ ON CONFLICT (alias_slug) DO NOTHING;
 SELECT DISTINCT canonical_slug FROM company_slug_aliases;
 
 -- name: ListCompaniesForMerge :many
--- The merge worker's input: every company that has an open job, with the count that elects
--- the winner of its folded group. Grouping happens in Go because the fold is
--- normalize.CompanyKey — a repeating legal-form strip no SQL expression should try to
--- reproduce, since a second implementation of that rule is the bug this change removes.
-SELECT slug, name, job_count
-FROM companies
-WHERE job_count > 0;
+-- The merge worker's input: every company slug the JOBS table actually holds, with the display
+-- name and the open-job count that elects the winner of its folded group.
+--
+-- READ FROM jobs, NOT FROM companies.job_count. That column counts the postings the SEARCH
+-- INDEX holds, not the rows this worker rewrites, and the two diverge exactly where it hurts:
+-- a slug a merge has already retired drops to 0 in the index while its unmoved rows stay in
+-- the table. Planning from the counter made those rows INVISIBLE to the planner — 8,375 of
+-- them on `jpmorganchase` alone, stranded permanently, because the better the merge worked the
+-- more reliably the remainder hid.
+--
+-- The name is the most recent one seen for the slug, matching how SyncCompaniesFromJobs
+-- collapses a slug's name variants. Grouping into folded groups happens in Go because the fold
+-- is normalize.CompanyKey — a repeating legal-form strip no SQL expression should reproduce,
+-- since a second implementation of that rule is the bug this whole change removes.
+SELECT company_slug AS slug,
+       ((array_agg(company ORDER BY created_at DESC))[1])::text AS name,
+       count(*) FILTER (WHERE closed_at IS NULL)::int AS job_count
+FROM jobs
+WHERE company_slug <> ''
+GROUP BY company_slug;
 
 -- name: RekeyCompanySlugChunk :execrows
 -- Move one chunk of a retired slug's jobs onto the canonical slug.


### PR DESCRIPTION
## The bug

The planner read `companies.job_count` and filtered `job_count > 0`.

That column counts the postings the **search index** holds — not the rows this worker rewrites — and the two diverge exactly where it hurts. A slug a merge has already retired drops to 0 in the index while any unmoved rows stay in the table.

So filtering on it made the **leftovers of a merge invisible to the next run**. The better a merge worked, the more reliably its remainder hid.

On prod, after wave 1: **8,375 rows stranded on `jpmorganchase`**, 1,900 on `boschgroup`, 18,145 across 12 retired slugs — unreachable by any later wave. Verified: `merge-companies --min-jobs 1` no longer lists them at all.

## The fix

The query reads `jobs` — the same table it rewrites — taking the slug, the most recent name seen for it (matching how `SyncCompaniesFromJobs` collapses name variants), and the open-row count that elects a winner.

## How it was found

By measurement, after three wrong hypotheses that measurement refuted:

1. *"alias resolution is broken in ingest"* — the whole chain is correct on the host: `Aliases` wired, both save paths carry the resolver, `normalizeJob` passes it, `job.New` applies it.
2. *"something rewrites the rows back"* — no row on the retired slug was created after the merge; the newest predates it.
3. *"the registry lookup misses"* — running the exact query the code runs returns `jp-morgan-chase`.

What actually changed was that the planner stopped *seeing* them.

`go test ./...` 166 ok · `go vet -tags=integration` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved company merge planning to include companies with zero reported index counts when open job records still exist.
  * Open job totals and company names are now derived from job records, improving merge accuracy after partial merges.

* **Tests**
  * Added regression coverage for merge planning with zero-count company records.

* **Documentation**
  * Clarified the data used for reliable merge planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->