### PR TITLE
Make Dialog fill the screen on mobile, like the filters modal

### DIFF
--- a/design-system/.storybook/demos/DialogDemo.svelte
+++ b/design-system/.storybook/demos/DialogDemo.svelte
@@ -9,7 +9,15 @@
     title = 'Withdraw application?',
     description,
     dismissible = true,
-  }: { title?: string; description?: string; dismissible?: boolean } = $props();
+    // 'long' stands in for a tall consumer (e.g. AuthDialog's form) to show the
+    // mobile takeover actually scrolling, with the close button pinned in place.
+    body = 'short',
+  }: {
+    title?: string;
+    description?: string;
+    dismissible?: boolean;
+    body?: 'short' | 'long';
+  } = $props();
 
   let open = $state(false);
 </script>
@@ -17,11 +25,26 @@
 <Button onclick={() => (open = true)}>Open dialog</Button>
 
 <Dialog bind:open {title} {description} {dismissible}>
-  <p class="text-sm text-muted-foreground">
-    Withdrawing moves the application to Closed. You can apply again while the job is open.
-  </p>
-  <div class="mt-6 flex justify-end gap-2">
-    <Button variant="ghost" onclick={() => (open = false)}>Cancel</Button>
-    <Button variant="destructive" onclick={() => (open = false)}>Withdraw</Button>
-  </div>
+  {#if body === 'long'}
+    <div class="space-y-4">
+      {#each Array(12) as _, i (i)}
+        <p class="text-sm text-muted-foreground">
+          Paragraph {i + 1}. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </p>
+      {/each}
+    </div>
+    <div class="mt-6 flex justify-end gap-2">
+      <Button variant="ghost" onclick={() => (open = false)}>Cancel</Button>
+      <Button onclick={() => (open = false)}>Submit</Button>
+    </div>
+  {:else}
+    <p class="text-sm text-muted-foreground">
+      Withdrawing moves the application to Closed. You can apply again while the job is open.
+    </p>
+    <div class="mt-6 flex justify-end gap-2">
+      <Button variant="ghost" onclick={() => (open = false)}>Cancel</Button>
+      <Button variant="destructive" onclick={() => (open = false)}>Withdraw</Button>
+    </div>
+  {/if}
 </Dialog>

--- a/design-system/src/dialog.stories.ts
+++ b/design-system/src/dialog.stories.ts
@@ -32,3 +32,9 @@ export const NotDismissible: Story = {
     dismissible: false,
   },
 };
+
+// Resize the canvas below the sm breakpoint (640px) to see the mobile takeover:
+// edge-to-edge, scrolling body, close button pinned to the viewport corner.
+export const LongContent: Story = {
+  args: { title: 'Update your profile', body: 'long' },
+};

--- a/design-system/src/dialog.svelte
+++ b/design-system/src/dialog.svelte
@@ -57,7 +57,15 @@
   // any of that by hand is strictly worse.
   $effect(() => {
     if (!el) return;
-    if (open && !el.open) el.showModal();
+    if (open && !el.open) {
+      el.showModal();
+      // showModal() focuses the first focusable descendant (often a button below
+      // the fold) and the platform scrolls it into view — invisible for a dialog
+      // that always fit the viewport, but on the mobile takeover it opens already
+      // scrolled past the title. The dialog is its own scroll container now, so
+      // reset it without touching the page scroll lockPageScroll owns.
+      el.scrollTop = 0;
+    }
     if (!open && el.open) el.close();
   });
 
@@ -103,11 +111,17 @@
   {oncancel}
   {onclick}
   class={cn(
-    'm-auto w-full max-w-lg rounded-lg border border-border bg-card p-0 text-card-foreground shadow-lg backdrop:bg-black/50 backdrop:backdrop-blur-sm',
+    // Below sm: fills the viewport edge-to-edge, same breakpoint FilterModalShell
+    // uses for its own mobile takeover. At sm and up: the original centered card.
+    'm-0 h-full w-full max-w-none overflow-y-auto rounded-none border-0 bg-card p-0 text-card-foreground shadow-lg backdrop:bg-black/50 backdrop:backdrop-blur-sm',
+    // h-fit, not h-auto: a top-layer <dialog> with inset:0 from the UA stylesheet
+    // stretches to fill when height is the keyword 'auto' — a well-known quirk of
+    // the CSS positioned-box sizing algorithm. fit-content bypasses it outright.
+    'sm:m-auto sm:h-fit sm:w-full sm:max-w-lg sm:rounded-lg sm:border sm:border-border',
     className,
   )}
 >
-  <div class="relative p-6">
+  <div class="relative min-h-full p-6">
     {#if title}
       <h2 id={titleId} class="text-lg font-semibold">{title}</h2>
     {/if}
@@ -120,7 +134,7 @@
     {#if dismissible}
       <button
         type="button"
-        class="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        class="fixed right-4 top-4 flex size-9 items-center justify-center rounded-lg border border-border bg-card text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:absolute"
         onclick={() => (open = false)}
         aria-label="Close"
       >


### PR DESCRIPTION
## Summary
- The shared `Dialog` primitive (and `ConfirmDialog`/`NoticeDialog` on top of it) was always a centered `max-w-lg` card, even on small screens — unlike `FilterModalShell`'s full-screen mobile takeover.
- Below the `sm` breakpoint (640px) it now fills the viewport edge-to-edge, scrolls internally, and has a more visible close button pinned to the corner. At `sm` and up it's unchanged: the original centered card.
- Fixes a bug this change exposed along the way: native `showModal()` focuses the first focusable descendant and the platform scrolls it into view — invisible on a dialog that always fit the viewport, but on the mobile takeover it opened already scrolled past the title. Reset via `el.scrollTop = 0` right after `showModal()`.
- Added a `LongContent` Storybook story (`Primitives/Dialog`) to show the scroll + pinned close button.

No call-site changes — this flows automatically to all ~30 consumers of `Dialog`/`ConfirmDialog`/`NoticeDialog`.

## Test plan
- [x] `vitest run` in `design-system/` — 130 tests pass
- [x] `svelte-check` — 0 errors
- [x] `npm run lint` — clean
- [x] Verified visually via headless Chromium against a live Storybook instance at mobile (375px) and desktop (1280px) widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)