### PR TITLE
Drop apostrophes from the company key, and make the elected name deterministic

### DIFF
--- a/docs/agents/company-identity.md
+++ b/docs/agents/company-identity.md
@@ -129,9 +129,10 @@ worked the more reliably the remainder hid.
   and `CompanySlug` DROPS apostrophes before slugging, so "Kohl's" keys at `kohls` rather than
   the `kohl-s` plain `Slug` would give. That artefact stopped being survivable once the canon
   became derived rather than chosen among stored slugs: it elected `kohl-s` over `kohls` across
-  2,939 postings. Beyond that,
-  and that is precisely the distinction a slug destroys, since it renders both as a hyphen — and that preference only speaks when it discriminates. Where no name is multi-word, or
-  every name is, the job count decides as before.
+  2,939 postings.
+
+  The preference only speaks when it discriminates. Where no name is multi-word, or every name
+  is, the job count decides as before.
 - **The word break is not whitespace.** It is every rune `Slug` drops EXCEPT `.` and `/`, which
   live inside the forms themselves (`B.V.`, `A/S`). Whitespace alone loses
   `Sun Technologies,Inc.`, and 13,730 catalogue companies are written that way.

--- a/docs/agents/company-identity.md
+++ b/docs/agents/company-identity.md
@@ -125,7 +125,11 @@ worked the more reliably the remainder hid.
   (14,396) and `al-fa-bank` (20) over `alfa-bank` (1,617): in a slug an apostrophe is
   indistinguishable from a word break. What actually decides is whether the employer WRITES
   its name in several words — `Western Digital`, `Ace Hardware` and `Kimberly-Clark` do, `AT&T`,
-  `Brink's` and `Dominos` do not. A hyphen in the NAME separates words; an apostrophe does not,
+  `Brink's` and `Dominos` do not. A hyphen in the NAME separates words; an apostrophe does not —
+  and `CompanySlug` DROPS apostrophes before slugging, so "Kohl's" keys at `kohls` rather than
+  the `kohl-s` plain `Slug` would give. That artefact stopped being survivable once the canon
+  became derived rather than chosen among stored slugs: it elected `kohl-s` over `kohls` across
+  2,939 postings. Beyond that,
   and that is precisely the distinction a slug destroys, since it renders both as a hyphen — and that preference only speaks when it discriminates. Where no name is multi-word, or
   every name is, the job count decides as before.
 - **The word break is not whitespace.** It is every rune `Slug` drops EXCEPT `.` and `/`, which

--- a/internal/db/company_slug_aliases.sql.go
+++ b/internal/db/company_slug_aliases.sql.go
@@ -81,7 +81,10 @@ func (q *Queries) ListCanonicalCompanySlugs(ctx context.Context) ([]string, erro
 
 const listCompaniesForMerge = `-- name: ListCompaniesForMerge :many
 SELECT company_slug AS slug,
-       ((array_agg(company ORDER BY created_at DESC))[1])::text AS name,
+       -- id breaks the tie: two rows sharing a created_at would otherwise pick a name
+       -- arbitrarily, and the name decides the CANONICAL SLUG — so a dry run a human read
+       -- could differ from what --apply then does.
+       ((array_agg(company ORDER BY created_at DESC, id DESC))[1])::text AS name,
        count(*) FILTER (WHERE closed_at IS NULL)::int AS job_count
 FROM jobs
 WHERE company_slug <> ''

--- a/internal/db/queries/company_slug_aliases.sql
+++ b/internal/db/queries/company_slug_aliases.sql
@@ -54,7 +54,10 @@ SELECT DISTINCT canonical_slug FROM company_slug_aliases;
 -- is normalize.CompanyKey — a repeating legal-form strip no SQL expression should reproduce,
 -- since a second implementation of that rule is the bug this whole change removes.
 SELECT company_slug AS slug,
-       ((array_agg(company ORDER BY created_at DESC))[1])::text AS name,
+       -- id breaks the tie: two rows sharing a created_at would otherwise pick a name
+       -- arbitrarily, and the name decides the CANONICAL SLUG — so a dry run a human read
+       -- could differ from what --apply then does.
+       ((array_agg(company ORDER BY created_at DESC, id DESC))[1])::text AS name,
        count(*) FILTER (WHERE closed_at IS NULL)::int AS job_count
 FROM jobs
 WHERE company_slug <> ''

--- a/internal/normalize/company.go
+++ b/internal/normalize/company.go
@@ -57,7 +57,7 @@ var legalSuffixes = map[string]struct{}{
 // A single-word name is never stripped: "Limited" stays "limited", because an empty slug
 // silently matches nothing while a visibly odd company row can be found and fixed.
 func CompanySlug(name string) string {
-	words := strings.FieldsFunc(name, isWordBreak)
+	words := strings.FieldsFunc(dropApostrophes(name), isWordBreak)
 	for len(words) > 1 {
 		if _, isForm := legalSuffixes[letters(words[len(words)-1])]; !isForm {
 			break
@@ -65,6 +65,18 @@ func CompanySlug(name string) string {
 		words = words[:len(words)-1]
 	}
 	return Slug(strings.Join(words, " "))
+}
+
+// dropApostrophes removes the possessive/elision marks a name carries so they cannot become
+// word breaks in the key. "Kohl's" is one word and belongs at `kohls`, which is also what a
+// person types; [Slug] alone renders it `kohl-s`.
+//
+// It matters more than it looks. Once the canonical slug is DERIVED from a name rather than
+// chosen among stored slugs, that artefact can no longer lose to the clean sibling spelling —
+// it elected `kohl-s` over `kohls` across 2,939 postings. Both the ASCII and the typographic
+// mark are covered, since sources use either.
+func dropApostrophes(name string) string {
+	return strings.NewReplacer("'", "", "\u2019", "", "\u02bc", "").Replace(name)
 }
 
 // isWordBreak reports whether a rune separates two words of a company name. Everything [Slug]

--- a/internal/normalize/company_slug_test.go
+++ b/internal/normalize/company_slug_test.go
@@ -28,6 +28,14 @@ func TestCompanySlug(t *testing.T) {
 		{"form word inside a name is kept", "Limited Brands", "limited-brands"},
 		{"a name that is only a form is not erased", "Limited", "limited"},
 		{"no form to strip", "Yandex", "yandex"},
+		// An apostrophe is not a word break, so it must not become one in the key. Slug turns
+		// "Kohl's" into kohl-s, and once the canon is DERIVED from the name that artefact
+		// could no longer lose to the clean sibling spelling — it elected kohl-s over kohls
+		// across 2,939 postings.
+		{"possessive apostrophe", "Kohl's", "kohls"},
+		{"possessive apostrophe, US style", "Domino's", "dominos"},
+		{"apostrophe inside a name", "Brink's Incorporated", "brinks"},
+		{"typographic apostrophe", "Macy\u2019s", "macys"},
 		{"a symbol word is not part of the key", "Acme ™", "acme"},
 		{"a non-latin word is kept and transliterated", "Яндекс ООО", "iandeks-ooo"},
 		{"empty stays empty", "", ""},


### PR DESCRIPTION
## Why now

`Slug` renders `Kohl's` as `kohl-s`, turning a possessive mark into a word break.

That was **survivable** while the canonical slug was *chosen* among stored slugs — the clean sibling `kohls` could win on volume. It stopped being survivable when #2122 made the canon **derived** from the name: the artefact is now what deriving produces, so it can no longer lose.

On the full-catalogue plan it elects **`kohl-s` over `kohls` across 2,939 postings** — and `dominos` would have gone the same way, which is the very counterexample that ruled out "prefer the more hyphenated slug" at the start of this work.

Caught in the dry run, before applying.

## The fix

`CompanySlug` drops the mark before slugging, so `Kohl's` keys at `kohls` — which is also what a person types. Both the ASCII `'` and the typographic `’` are covered, since sources use either.

`Slug` itself is untouched: job `public_slug`s and every other URL keep their current shape.

`go test ./...` 166 ok · `go vet -tags=integration` clean.