### PR TITLE
Fix the mobile Dialog takeover falling short of the screen edge

### DIFF
--- a/design-system/src/dialog.svelte
+++ b/design-system/src/dialog.svelte
@@ -113,15 +113,23 @@
   class={cn(
     // Below sm: fills the viewport edge-to-edge, same breakpoint FilterModalShell
     // uses for its own mobile takeover. At sm and up: the original centered card.
-    'm-0 h-full w-full max-w-none overflow-y-auto rounded-none border-0 bg-card p-0 text-card-foreground shadow-lg backdrop:bg-black/50 backdrop:backdrop-blur-sm',
+    // max-h-none is load-bearing: the UA stylesheet gives dialog:modal its own
+    // max-height reserve (leaving a gap around the edges by default), which
+    // silently clamps h-dvh short of the actual viewport unless overridden.
+    // dvh, not h-full (%): a mobile browser's toolbar grows and shrinks the
+    // visual viewport without firing a resize, and a percentage height resolves
+    // against the larger, toolbar-collapsed one, reopening the same gap.
+    'm-0 h-dvh max-h-none w-full max-w-none overflow-y-auto rounded-none border-0 bg-card p-0 text-card-foreground shadow-lg backdrop:bg-black/50 backdrop:backdrop-blur-sm',
     // h-fit, not h-auto: a top-layer <dialog> with inset:0 from the UA stylesheet
     // stretches to fill when height is the keyword 'auto' — a well-known quirk of
     // the CSS positioned-box sizing algorithm. fit-content bypasses it outright.
-    'sm:m-auto sm:h-fit sm:w-full sm:max-w-lg sm:rounded-lg sm:border sm:border-border',
+    // max-h is explicit (matching FilterModalShell's own cap) rather than left to
+    // the UA default reserve, which isn't a documented, cross-browser-stable value.
+    'sm:m-auto sm:h-fit sm:max-h-[calc(100vh-3rem)] sm:w-full sm:max-w-lg sm:rounded-lg sm:border sm:border-border',
     className,
   )}
 >
-  <div class="relative min-h-full p-6">
+  <div class="relative min-h-dvh p-6 sm:min-h-full">
     {#if title}
       <h2 id={titleId} class="text-lg font-semibold">{title}</h2>
     {/if}


### PR DESCRIPTION
## Summary
Follow-up to #2129. On a real phone the mobile full-screen Dialog left a visible gap at the bottom instead of reaching the edge.

Root cause: Chrome's UA stylesheet gives `dialog:modal` its own `max-height` reserve by default, which silently clamped `h-dvh` (and `h-full`, before it) short of the actual viewport — that's the gap. `max-h-none` defeats it on the mobile takeover. The desktop card now gets an explicit cap (`calc(100vh-3rem)`, matching `FilterModalShell`'s own) instead of relying on the UA's unstated, browser-dependent default — this is also what was actually behind the earlier "stretched card" bug fixed in #2129, not (only) the `height:auto` positioning quirk I originally diagnosed it as.

Also swaps `h-full` for `h-dvh`: a mobile browser's toolbar grows/shrinks the visual viewport without firing a resize, and a percentage height resolves against the larger, toolbar-collapsed one — reopening the same gap the max-height fix alone wouldn't close.

## Test plan
- [x] `vitest run` in `design-system/` — 130 tests pass
- [x] `svelte-check` — 0 errors
- [x] `npm run lint` — clean
- [x] Measured via headless Chromium: mobile dialog's `getBoundingClientRect()` now reaches `bottom: 700` at a 700px viewport (previously clamped ~38px short); desktop long-content still caps and scrolls correctly at a short viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)