### PR TITLE
Show country name next to a job's single-country flag

### DIFF
--- a/web/src/lib/components/CountryFlagStack.svelte
+++ b/web/src/lib/components/CountryFlagStack.svelte
@@ -9,6 +9,10 @@
   // browse card (display-only) and the job sidebar (`link` on), where a wide remote
   // role can list a dozen eligible countries.
   //
+  // A single country is common (most postings aren't remote-everywhere) and a bare
+  // flag alone leans on its title tooltip to say which one, so that case renders the
+  // country name next to the flag instead of collapsing into the stack.
+  //
   // The flags overlap by `--lap` (an em fraction of a flag's width) via a negative
   // left margin, and each carries a `ring-card` outline so neighbours stay legible
   // where they touch. Earlier flags sit on top (descending z-index) so the row reads
@@ -29,9 +33,27 @@
   const extra = $derived(codes.length - shown.length);
 </script>
 
-{#if codes.length}
+{#if codes.length === 1}
+  {@const code = codes[0] ?? ''}
+  {@const label = countryLabel(code)}
+  {#snippet chip()}
+    <CountryFlag {code} {label} />
+    <span class="truncate text-xs font-medium text-muted-foreground">{label}</span>
+  {/snippet}
+  <div class={['inline-flex items-center gap-1.5', className]}>
+    {#if link}
+      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal filter link from filterHref; query-only, no route to resolve -->
+      <a href={filterHref('countries', code)} class="inline-flex items-center gap-1.5 hover:text-foreground">
+        {@render chip()}
+      </a>
+    {:else}
+      {@render chip()}
+    {/if}
+  </div>
+{:else if codes.length > 1}
   <div class={['flex items-center', className]} style:--lap="0.4em">
     {#each shown as code, i (code)}
+      {@const label = countryLabel(code)}
       <span
         class={[
           'relative inline-flex rounded-full ring-2 ring-card transition hover:z-10 hover:-translate-y-px',
@@ -41,9 +63,9 @@
       >
         {#if link}
           <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal filter link from filterHref; query-only, no route to resolve -->
-          <a href={filterHref('countries', code)} class="inline-flex"><CountryFlag {code} label={countryLabel(code)} /></a>
+          <a href={filterHref('countries', code)} class="inline-flex"><CountryFlag {code} {label} /></a>
         {:else}
-          <CountryFlag {code} label={countryLabel(code)} />
+          <CountryFlag {code} {label} />
         {/if}
       </span>
     {/each}


### PR DESCRIPTION
## Summary
- `CountryFlagStack` collapsed to a bare round flag for the (common) single-country case, relying only on the title tooltip to say which country.
- Now renders the country name as visible text next to the flag, matching the flag+text pattern already used elsewhere (e.g. the company Headquarters fact).
- Multi-country jobs are unchanged — still the overlapping flag-stack avatar cluster.

Affects three call sites automatically: the job browse card, the job sidebar's "Country" row, and the company panel's "Offices" row.

## Test plan
- [x] `svelte-check` / `eslint` clean on the changed file
- [x] Verified visually with a local dev server + Playwright screenshot: single-country job now shows "🇷🇺 Russia" instead of a bare flag, on both the browse card and the job detail sidebar
- [x] Multi-country stack rendering unchanged (untouched code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)