### PR TITLE
Redraw architecture.md's diagrams as editorial SVGs

### DIFF
--- a/.diagram-design
+++ b/.diagram-design
@@ -1,0 +1,1 @@
+profile: freehire

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,77 +25,9 @@ freehire is a Go monolith with a satellite constellation of single-purpose worke
 
 That choice shapes everything downstream. Because workers do not share memory with the server or with each other, all coordination happens in Postgres — which is why the write paths are full of **transactional outboxes**: a table row queued in the same transaction as the write that caused it, drained later by whichever worker owns that queue.
 
-```mermaid
-flowchart LR
-    subgraph SOURCES["Sources · ~167 feeds"]
-        direction TB
-        ATS["ATS platforms<br/>Workday · Greenhouse<br/>Lever · Ashby · iCIMS"]
-        AGG["Aggregators<br/>himalayas · jobtech<br/>Adzuna · echojobs"]
-        CAREER["Company career sites"]
-        TGCH["Telegram channels"]
-    end
+<img src="diagrams/system-shape.svg" alt="How a job posting moves through freehire, from crawl to client: sources feed run-once ingest workers that write Postgres and, in the same transaction, an outbox; queue drains and a full reindex worker push into Meilisearch; the API server reads Postgres and Meilisearch to serve clients.">
 
-    subgraph INGEST["Ingest workers · cron, run-once"]
-        direction TB
-        ING["cmd/ingest<br/>one board file per run"]
-        TGI["cmd/tg-ingest → cmd/tg-extract"]
-        RUNNER["pipeline.Runner<br/>fetch → normalize → dedup → upsert"]
-    end
-
-    subgraph STORE["Storage"]
-        direction TB
-        PG[("PostgreSQL<br/>system of record")]
-        OUTBOX["Outbox tables<br/>enrichment · search<br/>semantic · apply_form"]
-    end
-
-    subgraph DRAIN["Queue drains · cron, run-once"]
-        direction TB
-        ENR["cmd/enrich<br/>LLM enrichment"]
-        SD["cmd/search-drain"]
-        EMB["cmd/embed"]
-        CAP["cmd/capture-apply-form"]
-    end
-
-    subgraph SEARCH["Meilisearch"]
-        direction TB
-        FACET["jobs<br/>keyword + facets"]
-    end
-
-    API["cmd/server · Fiber<br/>/api/v1/*"]
-
-    subgraph CLIENTS["Clients"]
-        direction TB
-        SPA["SvelteKit SPA · web/"]
-        EXT["Browser extension"]
-        BOTS["Telegram · Discord<br/>mobile push"]
-        THIRD["Public API · CLI<br/>ChatGPT Actions"]
-    end
-
-    ATS --> ING
-    AGG --> ING
-    CAREER --> ING
-    TGCH --> TGI
-    ING --> RUNNER
-    TGI --> RUNNER
-    RUNNER --> PG
-    RUNNER -.->|same transaction| OUTBOX
-    OUTBOX --> ENR
-    OUTBOX --> SD
-    OUTBOX --> EMB
-    OUTBOX --> CAP
-    ENR --> PG
-    CAP --> PG
-    SD --> FACET
-    EMB --> PG
-    RI["cmd/reindex<br/>full rebuild + atomic swap"] --> FACET
-    PG --> RI
-    PG --> API
-    FACET --> API
-    API --> SPA
-    API --> EXT
-    API --> BOTS
-    API --> THIRD
-```
+*Collapsed for readability: `Sources` folds the four crawl channels, `Queue drains` folds `cmd/enrich` · `cmd/search-drain` · `cmd/embed` · `cmd/capture-apply-form`, and `Clients` folds the SPA, extension, bots, and third-party API consumers. See each package's own `AGENTS.md` (linked below) for the full fan-out.*
 
 **Ingest.** `cmd/ingest` takes one board file per run — `sources/greenhouse.yml`, `sources/lever.yml`, and so on — so each provider crawls on its own schedule and a slow platform never blocks a fast one. It validates every entry against the adapter registry and fails before any request goes out, then hands off to `pipeline.Runner`, which fetches each board once, normalizes postings into a single schema, deduplicates, and upserts. The dedup key is `jobs.UNIQUE (source, external_id)`, so re-running a crawl is free. A board that keeps failing backs off on a recorded cooldown rather than being hammered every run. The large majority of postings are crawled straight from an employer's own ATS or career page; aggregators and Telegram are a smaller supplementary slice of the same pipeline — see [README's Sources breakdown](../README.md#sources) for the exact split.
 
@@ -113,42 +45,9 @@ Deeper: [`internal/pipeline`](../internal/pipeline/AGENTS.md) · [`internal/sour
 
 ## The repository
 
-```mermaid
-flowchart TB
-    subgraph GO["Go backend"]
-        direction LR
-        CMD["<b>cmd/</b><br/>~60 entry points<br/>server + mail-ingest are daemons<br/>everything else is cron, run-once"]
-        INT["<b>internal/</b><br/>domain packages — the substantial<br/>ones carry their own AGENTS.md"]
-        MIG["<b>migrations/</b><br/>SQL schema · source for BOTH<br/>sqlc codegen and Postgres initdb"]
-    end
+<img src="diagrams/repository.svg" alt="The freehire repository, module by module: Go backend packages (migrations, cmd, internal) generate types and read board data, feeding a frontend workspace (web, design-system, extension) that calls back over HTTP.">
 
-    subgraph DATA["Data, not code"]
-        direction LR
-        SRC["<b>sources/</b><br/>YAML board files, one per ATS provider<br/>+ custom.yml and telegram.yml<br/>retired/ holds withdrawn boards"]
-    end
-
-    subgraph JS["Frontend workspaces"]
-        direction LR
-        WEB["<b>web/</b><br/>SvelteKit SPA (pnpm)<br/>consumes /api/v1/*"]
-        DS["<b>design-system/</b><br/>separate pnpm package<br/>linked, not copied"]
-        EXTD["<b>extension/</b><br/>browser extension (WXT + Svelte)<br/>npm-managed, unlike the rest"]
-    end
-
-    subgraph DOCS["Docs and specs"]
-        direction LR
-        DOCD["<b>docs/</b><br/>this file · features.md<br/>agents/*.md cross-cutting notes"]
-        OS["<b>openspec/</b><br/>capability specs and change proposals"]
-    end
-
-    MIG -->|sqlc generates| INT
-    SRC -->|read at crawl time| CMD
-    CMD --> INT
-    INT -->|cmd/gen-contracts<br/>emits TS types| WEB
-    DS -->|linked dependency| WEB
-    DS -->|linked dependency| EXTD
-    WEB -->|HTTP| CMD
-    EXTD -->|HTTP| CMD
-```
+*`docs/` and `openspec/` are omitted from the diagram — they carry no code-level edges of their own.*
 
 **`cmd/`** holds roughly sixty entry points. Two are long-lived: `cmd/server` and `cmd/mail-ingest`. Everything else — crawlers, queue drains, backfills, rollups, notification passes — takes `DATABASE_URL`, does one pass, and exits non-zero on failure. What keeps a cron worker from stacking on itself is systemd's `Type=oneshot`, not a file lock.
 
@@ -166,44 +65,9 @@ Deeper: [`AGENTS.md`](../AGENTS.md) for the full module index · [`web/AGENTS.md
 
 freehire is fed by three quite different kinds of contribution, and the system's shape reflects which of them is cheap and which is expensive.
 
-```mermaid
-flowchart LR
-    subgraph PEOPLE["External contributors"]
-        ONELINE["Add a company<br/>one line in that provider's board file"]
-        ADAPTER["Add a platform<br/>new adapter in internal/sources<br/>+ one line in sources.All"]
-        DICT["Extend a dictionary<br/>skills · roles · locations · non-tech terms"]
-    end
+<img src="diagrams/ecosystem.svg" alt="Three contribution channels feeding freehire's catalogue and its derived signals: contributors, source platforms, and signed-in users all feed the catalogue; the catalogue's derived signals fan out into the ghost-job signal, the silence ladder, facets and analytics, and CV-tailoring evidence.">
 
-    subgraph PLATFORMS["Source platforms"]
-        PUBAPI["Public ATS JSON APIs<br/>read-only · keyless by default"]
-        FEEDS["Aggregator feeds<br/>some streaming, some paged"]
-    end
-
-    subgraph USERS["Signed-in users"]
-        APPS["Applications and stages"]
-        MAILBOX["Connected mailbox<br/>recruiter replies"]
-        REPORTS["Reports on a posting"]
-        BANK["Experience bank<br/>what they have actually done"]
-    end
-
-    CORE[("freehire<br/>catalogue + derived signals")]
-
-    ONELINE --> CORE
-    ADAPTER --> CORE
-    DICT --> CORE
-    PUBAPI --> CORE
-    FEEDS --> CORE
-    APPS --> CORE
-    MAILBOX --> CORE
-    REPORTS --> CORE
-    BANK --> CORE
-
-    CORE --> SIGNALS["Derived signals"]
-    SIGNALS --> GHOST["Ghost-job signal<br/>structural + outcome evidence"]
-    SIGNALS --> SILENCE["Application silence ladder"]
-    SIGNALS --> FACETS["Facets and market analytics"]
-    SIGNALS --> TAILOR["CV tailoring evidence"]
-```
+*Each contributor category, and `Signed-in users`, folds several distinct sources — see the prose above for the full breakdown.*
 
 **Contributors** mostly add coverage, and coverage is deliberately a one-line change. For a company on a platform freehire already crawls, adding it is one entry in that provider's board file — the single most useful contribution anyone can send. Only a company on an unsupported ATS needs a new adapter, and even then every adapter speaks the same `Source` interface, so the work is bounded. Dictionaries are the third path: skills, roles, locations and the non-technical-title terms are curated word lists, and they are **dict-only in production** — the system never guesses a facet, it emits nothing for an unknown.
 
@@ -217,27 +81,7 @@ Deeper: [`internal/sources`](../internal/sources/AGENTS.md) · [`internal/ghost`
 
 The search path is the most-travelled code in the system, and its defining property is that a result page is served **without touching Postgres for the payload**. The Meilisearch document *is* the public wire shape of a job, so the index answers the whole query.
 
-```mermaid
-sequenceDiagram
-    autonumber
-    participant U as Reader (SPA)
-    participant H as searchHandlers
-    participant F as search.FilterFromValues
-    participant M as Meilisearch
-    participant PG as PostgreSQL
-
-    U->>H: GET /api/v1/jobs/search?q=&facets…
-    Note over H: 503 if search unconfigured<br/>400 if offset+limit over 10000
-    H->>F: facet params → index filter
-    Note over F: the same pure translation the<br/>notification matcher applies to a<br/>saved search, so they cannot drift
-    F-->>H: filter expression
-    H->>M: Search(query, filter, sort, limit, offset)
-    M-->>H: hits — each already a full jobview.Job
-    H->>PG: ghost evidence + absence stamps for this page
-    Note over PG: best-effort — a failed lookup drops<br/>the signal, never the search
-    PG-->>H: per-job signal
-    H-->>U: data — job views · meta — total, limit, offset
-```
+<img src="diagrams/flow-finding-a-job.svg" alt="A search request served without touching Postgres for the payload: the reader's search request is translated to a Meilisearch filter and answered from the index; Postgres is queried only afterward, best-effort, for the ghost-job signal on that page.">
 
 A few things are load-bearing here.
 
@@ -257,35 +101,9 @@ Deeper: [`internal/search`](../internal/search/AGENTS.md) · [`internal/jobview`
 
 The CV workspace is built on a rule that shapes every part of it: **the agent may not write a claim the candidate has not made.** Enforcement is not a prompt instruction — it is an evidence gate in the write path, and the evidence comes from a durable store called the experience bank.
 
-```mermaid
-sequenceDiagram
-    autonumber
-    participant U as Candidate
-    participant API as API
-    participant RX as resumeextract
-    participant BANK as experience bank
-    participant ED as cvedit.Editor
-    participant TY as Typst
+<img src="diagrams/flow-tailoring-a-cv.svg" alt="A tailoring turn cites the experience bank for every edit it writes: the candidate's CV is imported additively into the experience bank; a tailoring turn loops per vacancy requirement, searching the bank for scored evidence and writing each CV edit through the evidence-gated editor, then renders the result with Typst.">
 
-    U->>API: upload CV file
-    API->>RX: extract structure (LLM)
-    RX-->>API: resume_structured, stamped to this upload
-    API->>BANK: Import — additive
-    Note over BANK: employments match on company plus role and only<br/>BLANK fields are filled. Atoms dedup on a<br/>normalized claim key. Import never deletes.
-    U->>API: POST /me/cvs/tailor (vacancy)
-    Note over API: refreshes a stale base CV, mints a tailored<br/>copy bound to the vacancy, opens an agent session
-    loop per vacancy requirement
-        API->>BANK: experience_search — scored, ranked, top-N
-        BANK-->>API: atoms with ids (no model call — a linear pass)
-        API->>ED: cv_edit with an evidence_id
-        Note over ED: policy + evidence gate run BEFORE the row lock<br/>one uncited operation refuses the whole batch
-        ED->>ED: apply ops, compute inverses, write<br/>document + revision in ONE transaction
-    end
-    U->>API: preview / download
-    API->>TY: render in a sandboxed temp root
-    Note over TY: system fonts disabled · bundled fonts staged in<br/>user data goes through data.json, never argv
-    TY-->>U: PDF (or SVG for previews)
-```
+*The upload-time `resumeextract` call is drawn as a self-message on `API` rather than its own lifeline.*
 
 **The bank is a store, not a cache.** Everything else about a candidate's experience is derived and replaced — the structured extract is regenerated on every upload, a tailored CV is discarded with its vacancy — but the bank accumulates, and only its owner removes anything. That is why import is additive: someone who uploads a trimmed one-page CV must not lose the history they built.
 
@@ -301,34 +119,9 @@ Deeper: [`internal/experience`](../internal/experience/AGENTS.md) · [`internal/
 
 The assistant runs **in this process**. There is no external agent runtime, no shell, and no credential minted for it: a tool receives the session owner's user id and calls the same Go service the HTTP handler calls. Anything the agent must not reach is simply a tool that does not exist.
 
-```mermaid
-sequenceDiagram
-    autonumber
-    participant U as User
-    participant H as assistant handler
-    participant R as Runner
-    participant L as LLM gateway
-    participant T as Tool registry
+<img src="diagrams/flow-asking-the-assistant.svg" alt="A bounded tool-calling loop that always ends in exactly one terminal event: the Runner calls the LLM gateway on the caller's own credential each round, then either calls a tool and streams the result back or streams a final answer; every path ends in exactly one terminal SSE event.">
 
-    U->>H: POST /assistant/sessions/:id/messages
-    Note over H: owner check — a foreign session is 404, never 403<br/>one turn per session — a second waits, a third is 409
-    H->>R: run one turn, SSE stream open
-    R->>R: persist prompt · history = system prompt<br/>+ last N transcript messages
-    loop ≤ MaxSteps (8 default · tailor 16 · autopilot 30)
-        R->>L: Chat(history, tools) on the CALLER's own credential
-        L-->>R: text deltas / reasoning deltas / tool calls
-        alt tool calls
-            R->>T: Call each, sequentially
-            Note over T: a failing tool returns an error object for the<br/>model to correct — it is not a turn failure
-            T-->>R: structured result
-            R-->>U: SSE tool_use, tool_result
-        else answer text
-            R-->>U: SSE result(end_turn)
-        end
-    end
-    Note over R: cap reached → one final Chat with NO tools → result(max_steps)
-    R-->>U: exactly one terminal result event, always
-```
+*The `≤ MaxSteps` iteration is drawn as an annotation rather than a wrapping `loop` frame, to keep the diagram to one combined fragment (the `alt` on tool-calls vs. answer text).*
 
 **A turn is bounded twice** — by tool-calling rounds and by the model client's per-call timeout — and both bounds are chosen server-side, because a ceiling a client can raise is not a ceiling. Zero or negative values fall back to defaults rather than meaning "unbounded"; an unbounded loop on a metered gateway is a runaway bill.
 

--- a/docs/diagrams/ecosystem.html
+++ b/docs/diagrams/ecosystem.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>The ecosystem</title>
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --color-paper:   #fdfefc;
+      --color-ink:     #141414;
+      --color-muted:   #505050;
+      --color-accent:  #5b6f00;
+      --font-sans:     'Geist', system-ui, sans-serif;
+      --font-serif:    'Instrument Serif', serif;
+      --font-mono:     'Geist Mono', ui-monospace, monospace;
+    }
+    body {
+      font-family: var(--font-sans);
+      background: var(--color-paper);
+      color: var(--color-ink);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 3rem 2rem;
+    }
+    .frame { max-width: 1280px; width: 100%; }
+    .eyebrow {
+      font-family: var(--font-mono);
+      font-size: 0.66rem;
+      font-weight: 500;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--color-muted);
+      margin-bottom: 0.5rem;
+    }
+    h1 {
+      font-family: var(--font-serif);
+      font-size: clamp(1.5rem, 2.4vw + 0.75rem, 1.75rem);
+      font-weight: 400;
+      letter-spacing: -0.02em;
+      line-height: 1.15;
+      color: var(--color-ink);
+      margin-bottom: 1.5rem;
+    }
+    svg { width: 100%; min-width: 900px; display: block; }
+  </style>
+</head>
+<body>
+  <div class="frame">
+    <p class="eyebrow">Architecture &middot; freehire</p>
+    <h1>The ecosystem</h1>
+
+    <svg viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="ecosystem-title ecosystem-desc">
+      <title id="ecosystem-title">Three contribution channels feeding freehire's catalogue and its derived signals</title>
+      <desc id="ecosystem-desc">Contributors, source platforms, and signed-in users all feed the catalogue; the catalogue's derived signals fan out into the ghost-job signal, the silence ladder, facets and analytics, and CV-tailoring evidence.</desc>
+      <defs>
+        <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#505050"/></marker>
+        <marker id="arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#5b6f00"/></marker>
+      </defs>
+
+      <rect width="100%" height="100%" fill="#fdfefc"/>
+
+      <!-- ===== Arrows (before boxes) ===== -->
+
+      <!-- Contributors -> CORE -->
+      <path d="M220,152 H302 Q310,152 310,160 V308 Q310,316 318,316 H400" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <!-- Platforms -> CORE -->
+      <path d="M220,336 H400" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <!-- Users -> CORE -->
+      <path d="M220,520 H302 Q310,520 310,512 V364 Q310,356 318,356 H400" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- CORE -> SIGNALS -->
+      <path d="M560,336 H680" fill="none" stroke="#5b6f00" stroke-width="1.2" marker-end="url(#arrow-accent)"/>
+
+      <!-- SIGNALS -> GHOST -->
+      <path d="M840,310 H876 Q884,310 884,302 V160 Q884,152 892,152 H960" fill="none" stroke="#5b6f00" stroke-width="1.2" marker-end="url(#arrow-accent)"/>
+      <!-- SIGNALS -> SILENCE -->
+      <path d="M840,326 H892 Q900,326 900,318 V290 Q900,282 908,282 H960" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <!-- SIGNALS -> FACETS -->
+      <path d="M840,342 H908 Q916,342 916,350 V404 Q916,412 924,412 H960" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <!-- SIGNALS -> TAILOR -->
+      <path d="M840,358 H924 Q932,358 932,366 V534 Q932,542 940,542 H960" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- ===== Nodes ===== -->
+
+      <!-- Contributors -->
+      <rect x="40" y="120" width="180" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="40" y="120" width="180" height="64" rx="6" fill="rgba(80,80,80,0.10)" stroke="#7a7a7a" stroke-width="1"/>
+      <rect x="48" y="126" width="32" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="64" y="135" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">PPL</text>
+      <text x="130" y="156" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Contributors</text>
+      <text x="130" y="172" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">company · platform · dict</text>
+
+      <!-- Source platforms -->
+      <rect x="40" y="304" width="180" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="40" y="304" width="180" height="64" rx="6" fill="rgba(80,80,80,0.10)" stroke="#7a7a7a" stroke-width="1"/>
+      <rect x="48" y="310" width="32" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="64" y="319" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">API</text>
+      <text x="130" y="340" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Source platforms</text>
+      <text x="130" y="356" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">ATS APIs · aggregators</text>
+
+      <!-- Signed-in users -->
+      <rect x="40" y="488" width="180" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="40" y="488" width="180" height="64" rx="6" fill="rgba(80,80,80,0.10)" stroke="#7a7a7a" stroke-width="1"/>
+      <rect x="48" y="494" width="32" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="64" y="503" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">USR</text>
+      <text x="130" y="524" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Signed-in users</text>
+      <text x="130" y="540" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">apps · mailbox · reports</text>
+
+      <!-- CORE: freehire (focal) -->
+      <rect x="400" y="304" width="160" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="400" y="304" width="160" height="64" rx="6" fill="rgba(91,111,0,0.08)" stroke="#5b6f00" stroke-width="1.2"/>
+      <rect x="408" y="310" width="28" height="12" rx="2" fill="transparent" stroke="rgba(91,111,0,0.5)" stroke-width="0.8"/>
+      <text x="422" y="319" fill="#5b6f00" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">DB</text>
+      <text x="480" y="340" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">freehire</text>
+      <text x="480" y="356" fill="#505050" font-size="9" font-family="'Geist Mono', monospace" text-anchor="middle">catalogue + signals</text>
+
+      <!-- SIGNALS: Derived signals -->
+      <rect x="680" y="304" width="160" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="680" y="304" width="160" height="64" rx="6" fill="rgba(20,20,20,0.05)" stroke="#505050" stroke-width="1"/>
+      <rect x="688" y="310" width="30" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="703" y="319" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">SIG</text>
+      <text x="760" y="340" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Derived signals</text>
+      <text x="760" y="356" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">computed, not crawled</text>
+
+      <!-- GHOST: Ghost-job signal (focal) -->
+      <rect x="960" y="120" width="180" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="960" y="120" width="180" height="64" rx="6" fill="rgba(91,111,0,0.08)" stroke="#5b6f00" stroke-width="1.2"/>
+      <rect x="968" y="126" width="30" height="12" rx="2" fill="transparent" stroke="rgba(91,111,0,0.5)" stroke-width="0.8"/>
+      <text x="983" y="135" fill="#5b6f00" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">SIG</text>
+      <text x="1050" y="156" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Ghost-job signal</text>
+      <text x="1050" y="172" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">structural + outcome</text>
+
+      <!-- SILENCE: Silence ladder -->
+      <rect x="960" y="250" width="180" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="960" y="250" width="180" height="64" rx="6" fill="rgba(20,20,20,0.05)" stroke="#505050" stroke-width="1"/>
+      <rect x="968" y="256" width="30" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="983" y="265" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">SIG</text>
+      <text x="1050" y="286" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Silence ladder</text>
+      <text x="1050" y="302" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">application follow-up</text>
+
+      <!-- FACETS: Facets & analytics -->
+      <rect x="960" y="380" width="180" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="960" y="380" width="180" height="64" rx="6" fill="rgba(20,20,20,0.05)" stroke="#505050" stroke-width="1"/>
+      <rect x="968" y="386" width="30" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="983" y="395" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">SIG</text>
+      <text x="1050" y="416" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Facets &amp; analytics</text>
+      <text x="1050" y="432" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">market signals</text>
+
+      <!-- TAILOR: CV tailoring -->
+      <rect x="960" y="510" width="180" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="960" y="510" width="180" height="64" rx="6" fill="rgba(20,20,20,0.05)" stroke="#505050" stroke-width="1"/>
+      <rect x="968" y="516" width="30" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="983" y="525" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">SIG</text>
+      <text x="1050" y="546" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">CV tailoring</text>
+      <text x="1050" y="562" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">evidence for edits</text>
+
+      <!-- ===== Legend ===== -->
+      <line x1="40" y1="640" x2="1240" y2="640" stroke="rgba(20,20,20,0.12)" stroke-width="0.8"/>
+      <text x="40" y="656" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.14em">LEGEND</text>
+
+      <rect x="140" y="648" width="14" height="14" rx="3" fill="rgba(80,80,80,0.10)" stroke="#7a7a7a" stroke-width="1"/>
+      <text x="162" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">contribution source</text>
+
+      <rect x="360" y="648" width="14" height="14" rx="3" fill="rgba(91,111,0,0.08)" stroke="#5b6f00" stroke-width="1.2"/>
+      <text x="382" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">catalogue / focal signal</text>
+
+      <rect x="600" y="648" width="14" height="14" rx="3" fill="rgba(20,20,20,0.05)" stroke="#505050" stroke-width="1"/>
+      <text x="622" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">derived signal</text>
+    </svg>
+  </div>
+</body>
+</html>

--- a/docs/diagrams/ecosystem.svg
+++ b/docs/diagrams/ecosystem.svg
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="ecosystem-title ecosystem-desc">
+      <title id="ecosystem-title">Three contribution channels feeding freehire's catalogue and its derived signals</title>
+      <desc id="ecosystem-desc">Contributors, source platforms, and signed-in users all feed the catalogue; the catalogue's derived signals fan out into the ghost-job signal, the silence ladder, facets and analytics, and CV-tailoring evidence.</desc>
+      <defs>
+        <style>@import url('https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&amp;family=Geist:wght@400;500;600&amp;family=Geist+Mono:wght@400;500;600&amp;display=swap');</style>
+        <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#505050"/></marker>
+        <marker id="arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#5b6f00"/></marker>
+      </defs>
+
+      <rect width="100%" height="100%" fill="#fdfefc"/>
+
+      <!-- ===== Arrows (before boxes) ===== -->
+
+      <!-- Contributors -> CORE -->
+      <path d="M220,152 H302 Q310,152 310,160 V308 Q310,316 318,316 H400" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <!-- Platforms -> CORE -->
+      <path d="M220,336 H400" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <!-- Users -> CORE -->
+      <path d="M220,520 H302 Q310,520 310,512 V364 Q310,356 318,356 H400" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- CORE -> SIGNALS -->
+      <path d="M560,336 H680" fill="none" stroke="#5b6f00" stroke-width="1.2" marker-end="url(#arrow-accent)"/>
+
+      <!-- SIGNALS -> GHOST -->
+      <path d="M840,310 H876 Q884,310 884,302 V160 Q884,152 892,152 H960" fill="none" stroke="#5b6f00" stroke-width="1.2" marker-end="url(#arrow-accent)"/>
+      <!-- SIGNALS -> SILENCE -->
+      <path d="M840,326 H892 Q900,326 900,318 V290 Q900,282 908,282 H960" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <!-- SIGNALS -> FACETS -->
+      <path d="M840,342 H908 Q916,342 916,350 V404 Q916,412 924,412 H960" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <!-- SIGNALS -> TAILOR -->
+      <path d="M840,358 H924 Q932,358 932,366 V534 Q932,542 940,542 H960" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- ===== Nodes ===== -->
+
+      <!-- Contributors -->
+      <rect x="40" y="120" width="180" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="40" y="120" width="180" height="64" rx="6" fill="rgba(80,80,80,0.10)" stroke="#7a7a7a" stroke-width="1"/>
+      <rect x="48" y="126" width="32" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="64" y="135" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">PPL</text>
+      <text x="130" y="156" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Contributors</text>
+      <text x="130" y="172" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">company · platform · dict</text>
+
+      <!-- Source platforms -->
+      <rect x="40" y="304" width="180" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="40" y="304" width="180" height="64" rx="6" fill="rgba(80,80,80,0.10)" stroke="#7a7a7a" stroke-width="1"/>
+      <rect x="48" y="310" width="32" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="64" y="319" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">API</text>
+      <text x="130" y="340" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Source platforms</text>
+      <text x="130" y="356" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">ATS APIs · aggregators</text>
+
+      <!-- Signed-in users -->
+      <rect x="40" y="488" width="180" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="40" y="488" width="180" height="64" rx="6" fill="rgba(80,80,80,0.10)" stroke="#7a7a7a" stroke-width="1"/>
+      <rect x="48" y="494" width="32" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="64" y="503" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">USR</text>
+      <text x="130" y="524" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Signed-in users</text>
+      <text x="130" y="540" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">apps · mailbox · reports</text>
+
+      <!-- CORE: freehire (focal) -->
+      <rect x="400" y="304" width="160" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="400" y="304" width="160" height="64" rx="6" fill="rgba(91,111,0,0.08)" stroke="#5b6f00" stroke-width="1.2"/>
+      <rect x="408" y="310" width="28" height="12" rx="2" fill="transparent" stroke="rgba(91,111,0,0.5)" stroke-width="0.8"/>
+      <text x="422" y="319" fill="#5b6f00" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">DB</text>
+      <text x="480" y="340" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">freehire</text>
+      <text x="480" y="356" fill="#505050" font-size="9" font-family="'Geist Mono', monospace" text-anchor="middle">catalogue + signals</text>
+
+      <!-- SIGNALS: Derived signals -->
+      <rect x="680" y="304" width="160" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="680" y="304" width="160" height="64" rx="6" fill="rgba(20,20,20,0.05)" stroke="#505050" stroke-width="1"/>
+      <rect x="688" y="310" width="30" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="703" y="319" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">SIG</text>
+      <text x="760" y="340" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Derived signals</text>
+      <text x="760" y="356" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">computed, not crawled</text>
+
+      <!-- GHOST: Ghost-job signal (focal) -->
+      <rect x="960" y="120" width="180" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="960" y="120" width="180" height="64" rx="6" fill="rgba(91,111,0,0.08)" stroke="#5b6f00" stroke-width="1.2"/>
+      <rect x="968" y="126" width="30" height="12" rx="2" fill="transparent" stroke="rgba(91,111,0,0.5)" stroke-width="0.8"/>
+      <text x="983" y="135" fill="#5b6f00" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">SIG</text>
+      <text x="1050" y="156" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Ghost-job signal</text>
+      <text x="1050" y="172" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">structural + outcome</text>
+
+      <!-- SILENCE: Silence ladder -->
+      <rect x="960" y="250" width="180" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="960" y="250" width="180" height="64" rx="6" fill="rgba(20,20,20,0.05)" stroke="#505050" stroke-width="1"/>
+      <rect x="968" y="256" width="30" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="983" y="265" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">SIG</text>
+      <text x="1050" y="286" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Silence ladder</text>
+      <text x="1050" y="302" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">application follow-up</text>
+
+      <!-- FACETS: Facets & analytics -->
+      <rect x="960" y="380" width="180" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="960" y="380" width="180" height="64" rx="6" fill="rgba(20,20,20,0.05)" stroke="#505050" stroke-width="1"/>
+      <rect x="968" y="386" width="30" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="983" y="395" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">SIG</text>
+      <text x="1050" y="416" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Facets &amp; analytics</text>
+      <text x="1050" y="432" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">market signals</text>
+
+      <!-- TAILOR: CV tailoring -->
+      <rect x="960" y="510" width="180" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="960" y="510" width="180" height="64" rx="6" fill="rgba(20,20,20,0.05)" stroke="#505050" stroke-width="1"/>
+      <rect x="968" y="516" width="30" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="983" y="525" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">SIG</text>
+      <text x="1050" y="546" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">CV tailoring</text>
+      <text x="1050" y="562" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">evidence for edits</text>
+
+      <!-- ===== Legend ===== -->
+      <line x1="40" y1="640" x2="1240" y2="640" stroke="rgba(20,20,20,0.12)" stroke-width="0.8"/>
+      <text x="40" y="656" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.14em">LEGEND</text>
+
+      <rect x="140" y="648" width="14" height="14" rx="3" fill="rgba(80,80,80,0.10)" stroke="#7a7a7a" stroke-width="1"/>
+      <text x="162" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">contribution source</text>
+
+      <rect x="360" y="648" width="14" height="14" rx="3" fill="rgba(91,111,0,0.08)" stroke="#5b6f00" stroke-width="1.2"/>
+      <text x="382" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">catalogue / focal signal</text>
+
+      <rect x="600" y="648" width="14" height="14" rx="3" fill="rgba(20,20,20,0.05)" stroke="#505050" stroke-width="1"/>
+      <text x="622" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">derived signal</text>
+    </svg>

--- a/docs/diagrams/flow-asking-the-assistant.html
+++ b/docs/diagrams/flow-asking-the-assistant.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flow: asking the assistant</title>
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --color-paper:   #fdfefc;
+      --color-ink:     #141414;
+      --color-muted:   #505050;
+      --color-accent:  #5b6f00;
+      --font-sans:     'Geist', system-ui, sans-serif;
+      --font-serif:    'Instrument Serif', serif;
+      --font-mono:     'Geist Mono', ui-monospace, monospace;
+    }
+    body {
+      font-family: var(--font-sans);
+      background: var(--color-paper);
+      color: var(--color-ink);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 3rem 2rem;
+    }
+    .frame { max-width: 1280px; width: 100%; }
+    .eyebrow {
+      font-family: var(--font-mono);
+      font-size: 0.66rem;
+      font-weight: 500;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--color-muted);
+      margin-bottom: 0.5rem;
+    }
+    h1 {
+      font-family: var(--font-serif);
+      font-size: clamp(1.5rem, 2.4vw + 0.75rem, 1.75rem);
+      font-weight: 400;
+      letter-spacing: -0.02em;
+      line-height: 1.15;
+      color: var(--color-ink);
+      margin-bottom: 1.5rem;
+    }
+    svg { width: 100%; min-width: 900px; display: block; }
+  </style>
+</head>
+<body>
+  <div class="frame">
+    <p class="eyebrow">Sequence &middot; freehire</p>
+    <h1>Flow: asking the assistant</h1>
+
+    <svg viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="flow-assistant-title flow-assistant-desc">
+      <title id="flow-assistant-title">A bounded tool-calling loop that always ends in exactly one terminal event</title>
+      <desc id="flow-assistant-desc">The Runner calls the LLM gateway on the caller's own credential each round, then either calls a tool and streams the result back or streams a final answer; every path ends in exactly one terminal SSE event.</desc>
+      <defs>
+        <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#505050"/></marker>
+        <marker id="arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#5b6f00"/></marker>
+        <marker id="arrow-open" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polyline points="0 0, 8 3, 0 6" fill="none" stroke="#505050" stroke-width="1.2"/></marker>
+      </defs>
+
+      <rect width="100%" height="100%" fill="#fdfefc"/>
+
+      <!-- ===== Lifelines ===== -->
+      <line x1="140" y1="100" x2="140" y2="620" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="380" y1="100" x2="380" y2="620" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="620" y1="100" x2="620" y2="620" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="860" y1="100" x2="860" y2="620" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="1100" y1="100" x2="1100" y2="620" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+
+      <!-- ===== Activation bar (Runner — active for the whole turn) ===== -->
+      <rect x="616" y="180" width="8" height="384" fill="rgba(91,111,0,0.10)" stroke="#5b6f00" stroke-width="0.8"/>
+
+      <!-- ===== ALT fragment: tool calls | answer text ===== -->
+      <rect x="90" y="324" width="1050" height="240" rx="4" fill="rgba(20,20,20,0.02)" stroke="rgba(20,20,20,0.22)" stroke-width="1"/>
+      <rect x="90" y="324" width="34" height="16" rx="2" fill="#fdfefc" stroke="rgba(20,20,20,0.22)" stroke-width="1"/>
+      <text x="107" y="336" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.12em">ALT</text>
+      <text x="132" y="336" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.02em">[tool calls]</text>
+      <line x1="98" y1="484" x2="1132" y2="484" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="4,3"/>
+      <text x="98" y="500" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.02em">[else — answer text]</text>
+
+      <!-- ===== Messages ===== -->
+
+      <!-- M1 User -> H -->
+      <path d="M140,136 H384" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="182" y="118" width="96" height="12" rx="2" fill="#fdfefc"/>
+      <text x="230" y="127" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">POST MESSAGE</text>
+
+      <!-- M2 H -> R -->
+      <path d="M380,180 H624" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="452" y="162" width="96" height="12" rx="2" fill="#fdfefc"/>
+      <text x="500" y="171" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">RUN TURN (SSE)</text>
+
+      <!-- R self-message: PERSIST PROMPT -->
+      <path d="M624,208 H672 Q680,208 680,216 Q680,224 672,224 H624" fill="none" stroke="#5b6f00" stroke-width="1" marker-end="url(#arrow-accent)"/>
+      <text x="688" y="220" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.04em">PERSIST PROMPT</text>
+
+      <!-- M3 R -> L -->
+      <path d="M624,256 H860" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="686" y="238" width="88" height="12" rx="2" fill="#fdfefc"/>
+      <text x="730" y="247" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">CHAT + TOOLS</text>
+
+      <!-- Note: iteration bound -->
+      <rect x="900" y="240" width="180" height="30" rx="3" fill="rgba(20,20,20,0.02)" stroke="rgba(20,20,20,0.18)" stroke-width="0.8" stroke-dasharray="3,2"/>
+      <text x="990" y="253" fill="#505050" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.02em">repeats ≤ MaxSteps rounds</text>
+      <text x="990" y="264" fill="#7a7a7a" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.02em">(8 default · tailor 16 · autopilot 30)</text>
+
+      <!-- M4 L --> R (return) -->
+      <path d="M860,300 H624" fill="none" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+      <rect x="686" y="282" width="88" height="12" rx="2" fill="#fdfefc"/>
+      <text x="730" y="291" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">MODEL REPLY</text>
+
+      <!-- M5 R -> T (region 1) -->
+      <path d="M624,368 H1096" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="816" y="350" width="88" height="12" rx="2" fill="#fdfefc"/>
+      <text x="860" y="359" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">CALL TOOLS</text>
+
+      <!-- M6 T --> R (return, region 1) -->
+      <path d="M1096,412 H624" fill="none" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+      <rect x="816" y="394" width="88" height="12" rx="2" fill="#fdfefc"/>
+      <text x="860" y="403" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">TOOL RESULT</text>
+
+      <!-- M7 R -->> User (async SSE notify, region 1, open arrowhead) -->
+      <path d="M624,456 H144" fill="none" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow-open)"/>
+      <rect x="316" y="438" width="96" height="12" rx="2" fill="#fdfefc"/>
+      <text x="364" y="447" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">SSE TOOL EVENT</text>
+
+      <!-- M8 R -->> User (headline success, region 2, solid accent) -->
+      <path d="M624,528 H144" fill="none" stroke="#5b6f00" stroke-width="1.4" marker-end="url(#arrow-accent)"/>
+      <rect x="316" y="510" width="96" height="12" rx="2" fill="#fdfefc"/>
+      <text x="364" y="519" fill="#5b6f00" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">SSE END_TURN</text>
+
+      <!-- Note: step-cap fallback -->
+      <rect x="400" y="576" width="320" height="30" rx="3" fill="rgba(20,20,20,0.02)" stroke="rgba(20,20,20,0.18)" stroke-width="0.8" stroke-dasharray="3,2"/>
+      <text x="560" y="589" fill="#505050" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.02em">cap reached → one final call, no tools</text>
+      <text x="560" y="600" fill="#7a7a7a" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.02em">still exactly one terminal event</text>
+
+      <!-- ===== Actor headers ===== -->
+      <rect x="70" y="60" width="140" height="40" rx="6" fill="rgba(80,80,80,0.10)" stroke="#7a7a7a" stroke-width="1"/>
+      <text x="140" y="84" fill="#141414" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">User</text>
+
+      <rect x="310" y="60" width="140" height="40" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <text x="380" y="79" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">assistant</text>
+      <text x="380" y="91" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">handler</text>
+
+      <rect x="550" y="60" width="140" height="40" rx="6" fill="rgba(91,111,0,0.08)" stroke="#5b6f00" stroke-width="1.2"/>
+      <text x="620" y="84" fill="#141414" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Runner</text>
+
+      <rect x="790" y="60" width="140" height="40" rx="6" fill="rgba(20,20,20,0.03)" stroke="rgba(20,20,20,0.30)" stroke-width="1"/>
+      <text x="860" y="79" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">LLM</text>
+      <text x="860" y="91" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">gateway</text>
+
+      <rect x="1030" y="60" width="140" height="40" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <text x="1100" y="79" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Tool</text>
+      <text x="1100" y="91" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">registry</text>
+
+      <!-- ===== Legend ===== -->
+      <line x1="40" y1="648" x2="1240" y2="648" stroke="rgba(20,20,20,0.12)" stroke-width="0.8"/>
+      <text x="40" y="664" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.14em">LEGEND</text>
+
+      <line x1="140" y1="663" x2="166" y2="663" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <text x="174" y="667" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">call / return</text>
+
+      <line x1="320" y1="663" x2="346" y2="663" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow-open)"/>
+      <text x="354" y="667" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">async SSE push</text>
+
+      <line x1="520" y1="663" x2="546" y2="663" stroke="#5b6f00" stroke-width="1.4" marker-end="url(#arrow-accent)"/>
+      <text x="554" y="667" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">terminal event</text>
+
+      <rect x="740" y="656" width="14" height="14" rx="3" fill="rgba(20,20,20,0.02)" stroke="rgba(20,20,20,0.18)" stroke-width="0.8" stroke-dasharray="3,2"/>
+      <text x="762" y="667" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">annotation</text>
+    </svg>
+  </div>
+</body>
+</html>

--- a/docs/diagrams/flow-asking-the-assistant.svg
+++ b/docs/diagrams/flow-asking-the-assistant.svg
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="flow-assistant-title flow-assistant-desc">
+      <title id="flow-assistant-title">A bounded tool-calling loop that always ends in exactly one terminal event</title>
+      <desc id="flow-assistant-desc">The Runner calls the LLM gateway on the caller's own credential each round, then either calls a tool and streams the result back or streams a final answer; every path ends in exactly one terminal SSE event.</desc>
+      <defs>
+        <style>@import url('https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&amp;family=Geist:wght@400;500;600&amp;family=Geist+Mono:wght@400;500;600&amp;display=swap');</style>
+        <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#505050"/></marker>
+        <marker id="arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#5b6f00"/></marker>
+        <marker id="arrow-open" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polyline points="0 0, 8 3, 0 6" fill="none" stroke="#505050" stroke-width="1.2"/></marker>
+      </defs>
+
+      <rect width="100%" height="100%" fill="#fdfefc"/>
+
+      <!-- ===== Lifelines ===== -->
+      <line x1="140" y1="100" x2="140" y2="620" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="380" y1="100" x2="380" y2="620" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="620" y1="100" x2="620" y2="620" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="860" y1="100" x2="860" y2="620" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="1100" y1="100" x2="1100" y2="620" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+
+      <!-- ===== Activation bar (Runner — active for the whole turn) ===== -->
+      <rect x="616" y="180" width="8" height="384" fill="rgba(91,111,0,0.10)" stroke="#5b6f00" stroke-width="0.8"/>
+
+      <!-- ===== ALT fragment: tool calls | answer text ===== -->
+      <rect x="90" y="324" width="1050" height="240" rx="4" fill="rgba(20,20,20,0.02)" stroke="rgba(20,20,20,0.22)" stroke-width="1"/>
+      <rect x="90" y="324" width="34" height="16" rx="2" fill="#fdfefc" stroke="rgba(20,20,20,0.22)" stroke-width="1"/>
+      <text x="107" y="336" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.12em">ALT</text>
+      <text x="132" y="336" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.02em">[tool calls]</text>
+      <line x1="98" y1="484" x2="1132" y2="484" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="4,3"/>
+      <text x="98" y="500" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.02em">[else — answer text]</text>
+
+      <!-- ===== Messages ===== -->
+
+      <!-- M1 User -> H -->
+      <path d="M140,136 H384" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="182" y="118" width="96" height="12" rx="2" fill="#fdfefc"/>
+      <text x="230" y="127" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">POST MESSAGE</text>
+
+      <!-- M2 H -> R -->
+      <path d="M380,180 H624" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="452" y="162" width="96" height="12" rx="2" fill="#fdfefc"/>
+      <text x="500" y="171" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">RUN TURN (SSE)</text>
+
+      <!-- R self-message: PERSIST PROMPT -->
+      <path d="M624,208 H672 Q680,208 680,216 Q680,224 672,224 H624" fill="none" stroke="#5b6f00" stroke-width="1" marker-end="url(#arrow-accent)"/>
+      <text x="688" y="220" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.04em">PERSIST PROMPT</text>
+
+      <!-- M3 R -> L -->
+      <path d="M624,256 H860" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="686" y="238" width="88" height="12" rx="2" fill="#fdfefc"/>
+      <text x="730" y="247" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">CHAT + TOOLS</text>
+
+      <!-- Note: iteration bound -->
+      <rect x="900" y="240" width="180" height="30" rx="3" fill="rgba(20,20,20,0.02)" stroke="rgba(20,20,20,0.18)" stroke-width="0.8" stroke-dasharray="3,2"/>
+      <text x="990" y="253" fill="#505050" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.02em">repeats ≤ MaxSteps rounds</text>
+      <text x="990" y="264" fill="#7a7a7a" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.02em">(8 default · tailor 16 · autopilot 30)</text>
+
+      <!-- M4 L --> R (return) -->
+      <path d="M860,300 H624" fill="none" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+      <rect x="686" y="282" width="88" height="12" rx="2" fill="#fdfefc"/>
+      <text x="730" y="291" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">MODEL REPLY</text>
+
+      <!-- M5 R -> T (region 1) -->
+      <path d="M624,368 H1096" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="816" y="350" width="88" height="12" rx="2" fill="#fdfefc"/>
+      <text x="860" y="359" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">CALL TOOLS</text>
+
+      <!-- M6 T --> R (return, region 1) -->
+      <path d="M1096,412 H624" fill="none" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+      <rect x="816" y="394" width="88" height="12" rx="2" fill="#fdfefc"/>
+      <text x="860" y="403" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">TOOL RESULT</text>
+
+      <!-- M7 R -->> User (async SSE notify, region 1, open arrowhead) -->
+      <path d="M624,456 H144" fill="none" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow-open)"/>
+      <rect x="316" y="438" width="96" height="12" rx="2" fill="#fdfefc"/>
+      <text x="364" y="447" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">SSE TOOL EVENT</text>
+
+      <!-- M8 R -->> User (headline success, region 2, solid accent) -->
+      <path d="M624,528 H144" fill="none" stroke="#5b6f00" stroke-width="1.4" marker-end="url(#arrow-accent)"/>
+      <rect x="316" y="510" width="96" height="12" rx="2" fill="#fdfefc"/>
+      <text x="364" y="519" fill="#5b6f00" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">SSE END_TURN</text>
+
+      <!-- Note: step-cap fallback -->
+      <rect x="400" y="576" width="320" height="30" rx="3" fill="rgba(20,20,20,0.02)" stroke="rgba(20,20,20,0.18)" stroke-width="0.8" stroke-dasharray="3,2"/>
+      <text x="560" y="589" fill="#505050" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.02em">cap reached → one final call, no tools</text>
+      <text x="560" y="600" fill="#7a7a7a" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.02em">still exactly one terminal event</text>
+
+      <!-- ===== Actor headers ===== -->
+      <rect x="70" y="60" width="140" height="40" rx="6" fill="rgba(80,80,80,0.10)" stroke="#7a7a7a" stroke-width="1"/>
+      <text x="140" y="84" fill="#141414" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">User</text>
+
+      <rect x="310" y="60" width="140" height="40" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <text x="380" y="79" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">assistant</text>
+      <text x="380" y="91" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">handler</text>
+
+      <rect x="550" y="60" width="140" height="40" rx="6" fill="rgba(91,111,0,0.08)" stroke="#5b6f00" stroke-width="1.2"/>
+      <text x="620" y="84" fill="#141414" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Runner</text>
+
+      <rect x="790" y="60" width="140" height="40" rx="6" fill="rgba(20,20,20,0.03)" stroke="rgba(20,20,20,0.30)" stroke-width="1"/>
+      <text x="860" y="79" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">LLM</text>
+      <text x="860" y="91" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">gateway</text>
+
+      <rect x="1030" y="60" width="140" height="40" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <text x="1100" y="79" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Tool</text>
+      <text x="1100" y="91" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">registry</text>
+
+      <!-- ===== Legend ===== -->
+      <line x1="40" y1="648" x2="1240" y2="648" stroke="rgba(20,20,20,0.12)" stroke-width="0.8"/>
+      <text x="40" y="664" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.14em">LEGEND</text>
+
+      <line x1="140" y1="663" x2="166" y2="663" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <text x="174" y="667" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">call / return</text>
+
+      <line x1="320" y1="663" x2="346" y2="663" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow-open)"/>
+      <text x="354" y="667" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">async SSE push</text>
+
+      <line x1="520" y1="663" x2="546" y2="663" stroke="#5b6f00" stroke-width="1.4" marker-end="url(#arrow-accent)"/>
+      <text x="554" y="667" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">terminal event</text>
+
+      <rect x="740" y="656" width="14" height="14" rx="3" fill="rgba(20,20,20,0.02)" stroke="rgba(20,20,20,0.18)" stroke-width="0.8" stroke-dasharray="3,2"/>
+      <text x="762" y="667" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">annotation</text>
+    </svg>

--- a/docs/diagrams/flow-finding-a-job.html
+++ b/docs/diagrams/flow-finding-a-job.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flow: finding a job</title>
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --color-paper:   #fdfefc;
+      --color-ink:     #141414;
+      --color-muted:   #505050;
+      --color-accent:  #5b6f00;
+      --font-sans:     'Geist', system-ui, sans-serif;
+      --font-serif:    'Instrument Serif', serif;
+      --font-mono:     'Geist Mono', ui-monospace, monospace;
+    }
+    body {
+      font-family: var(--font-sans);
+      background: var(--color-paper);
+      color: var(--color-ink);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 3rem 2rem;
+    }
+    .frame { max-width: 1280px; width: 100%; }
+    .eyebrow {
+      font-family: var(--font-mono);
+      font-size: 0.66rem;
+      font-weight: 500;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--color-muted);
+      margin-bottom: 0.5rem;
+    }
+    h1 {
+      font-family: var(--font-serif);
+      font-size: clamp(1.5rem, 2.4vw + 0.75rem, 1.75rem);
+      font-weight: 400;
+      letter-spacing: -0.02em;
+      line-height: 1.15;
+      color: var(--color-ink);
+      margin-bottom: 1.5rem;
+    }
+    svg { width: 100%; min-width: 900px; display: block; }
+  </style>
+</head>
+<body>
+  <div class="frame">
+    <p class="eyebrow">Sequence &middot; freehire</p>
+    <h1>Flow: finding a job</h1>
+
+    <svg viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="flow-job-title flow-job-desc">
+      <title id="flow-job-title">A search request served without touching Postgres for the payload</title>
+      <desc id="flow-job-desc">The reader's search request is translated to a Meilisearch filter and answered from the index; Postgres is queried only afterward, best-effort, for the ghost-job signal on that page.</desc>
+      <defs>
+        <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#505050"/></marker>
+        <marker id="arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#5b6f00"/></marker>
+      </defs>
+
+      <rect width="100%" height="100%" fill="#fdfefc"/>
+
+      <!-- ===== Lifelines ===== -->
+      <line x1="140" y1="100" x2="140" y2="600" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="380" y1="100" x2="380" y2="600" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="620" y1="100" x2="620" y2="600" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="860" y1="100" x2="860" y2="600" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="1100" y1="100" x2="1100" y2="600" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+
+      <!-- ===== Activation bars ===== -->
+      <rect x="376" y="140" width="8" height="392" fill="rgba(20,20,20,0.06)" stroke="#505050" stroke-width="0.8"/>
+      <rect x="616" y="196" width="8" height="56" fill="rgba(20,20,20,0.06)" stroke="#505050" stroke-width="0.8"/>
+      <rect x="856" y="308" width="8" height="56" fill="rgba(20,20,20,0.06)" stroke="#505050" stroke-width="0.8"/>
+      <rect x="1096" y="420" width="8" height="56" fill="rgba(20,20,20,0.06)" stroke="#505050" stroke-width="0.8"/>
+
+      <!-- ===== Messages ===== -->
+
+      <!-- 1. U -> H -->
+      <path d="M140,140 H384" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="200" y="122" width="84" height="12" rx="2" fill="#fdfefc"/>
+      <text x="242" y="131" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">GET SEARCH</text>
+
+      <!-- 2. H -> F -->
+      <path d="M384,196 H616" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="458" y="178" width="84" height="12" rx="2" fill="#fdfefc"/>
+      <text x="500" y="187" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">BUILD FILTER</text>
+
+      <!-- 3. F --> H (return, dashed) -->
+      <path d="M616,252 H384" fill="none" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+      <rect x="458" y="234" width="84" height="12" rx="2" fill="#fdfefc"/>
+      <text x="500" y="243" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">FILTER EXPR</text>
+
+      <!-- 4. H -> M -->
+      <path d="M384,308 H856" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="578" y="290" width="84" height="12" rx="2" fill="#fdfefc"/>
+      <text x="620" y="299" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">SEARCH QUERY</text>
+
+      <!-- 5. M --> H (return, dashed) -->
+      <path d="M856,364 H384" fill="none" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+      <rect x="588" y="346" width="44" height="12" rx="2" fill="#fdfefc"/>
+      <text x="610" y="355" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">HITS</text>
+
+      <!-- 6. H -> PG -->
+      <path d="M384,420 H1096" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="698" y="402" width="84" height="12" rx="2" fill="#fdfefc"/>
+      <text x="740" y="411" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">GHOST SIGNAL</text>
+
+      <!-- 7. PG --> H (return, dashed) -->
+      <path d="M1096,476 H384" fill="none" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+      <rect x="698" y="458" width="88" height="12" rx="2" fill="#fdfefc"/>
+      <text x="742" y="467" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">PER-JOB SIGNAL</text>
+
+      <!-- 8. H --> U (headline success, solid accent) -->
+      <path d="M384,532 H144" fill="none" stroke="#5b6f00" stroke-width="1.4" marker-end="url(#arrow-accent)"/>
+      <rect x="200" y="514" width="84" height="12" rx="2" fill="#fdfefc"/>
+      <text x="242" y="523" fill="#5b6f00" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">JOBS + META</text>
+
+      <!-- ===== Actor headers ===== -->
+      <rect x="70" y="60" width="140" height="40" rx="6" fill="rgba(80,80,80,0.10)" stroke="#7a7a7a" stroke-width="1"/>
+      <text x="140" y="84" fill="#141414" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Reader (SPA)</text>
+
+      <rect x="310" y="60" width="140" height="40" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <text x="380" y="84" fill="#141414" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">searchHandlers</text>
+
+      <rect x="550" y="60" width="140" height="40" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <text x="620" y="79" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">search.</text>
+      <text x="620" y="91" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">FilterFromValues</text>
+
+      <rect x="790" y="60" width="140" height="40" rx="6" fill="rgba(20,20,20,0.03)" stroke="rgba(20,20,20,0.30)" stroke-width="1"/>
+      <text x="860" y="84" fill="#141414" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Meilisearch</text>
+
+      <rect x="1030" y="60" width="140" height="40" rx="6" fill="rgba(91,111,0,0.08)" stroke="#5b6f00" stroke-width="1.2"/>
+      <text x="1100" y="84" fill="#141414" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">PostgreSQL</text>
+
+      <!-- ===== Legend ===== -->
+      <line x1="40" y1="640" x2="1240" y2="640" stroke="rgba(20,20,20,0.12)" stroke-width="0.8"/>
+      <text x="40" y="656" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.14em">LEGEND</text>
+
+      <line x1="140" y1="655" x2="166" y2="655" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <text x="174" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">call</text>
+
+      <line x1="300" y1="655" x2="326" y2="655" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+      <text x="334" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">return</text>
+
+      <line x1="460" y1="655" x2="486" y2="655" stroke="#5b6f00" stroke-width="1.4" marker-end="url(#arrow-accent)"/>
+      <text x="494" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">happy-path response</text>
+
+      <rect x="740" y="648" width="14" height="14" rx="3" fill="rgba(91,111,0,0.08)" stroke="#5b6f00" stroke-width="1.2"/>
+      <text x="762" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">system of record (best-effort)</text>
+    </svg>
+  </div>
+</body>
+</html>

--- a/docs/diagrams/flow-finding-a-job.svg
+++ b/docs/diagrams/flow-finding-a-job.svg
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="flow-job-title flow-job-desc">
+      <title id="flow-job-title">A search request served without touching Postgres for the payload</title>
+      <desc id="flow-job-desc">The reader's search request is translated to a Meilisearch filter and answered from the index; Postgres is queried only afterward, best-effort, for the ghost-job signal on that page.</desc>
+      <defs>
+        <style>@import url('https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&amp;family=Geist:wght@400;500;600&amp;family=Geist+Mono:wght@400;500;600&amp;display=swap');</style>
+        <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#505050"/></marker>
+        <marker id="arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#5b6f00"/></marker>
+      </defs>
+
+      <rect width="100%" height="100%" fill="#fdfefc"/>
+
+      <!-- ===== Lifelines ===== -->
+      <line x1="140" y1="100" x2="140" y2="600" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="380" y1="100" x2="380" y2="600" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="620" y1="100" x2="620" y2="600" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="860" y1="100" x2="860" y2="600" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="1100" y1="100" x2="1100" y2="600" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+
+      <!-- ===== Activation bars ===== -->
+      <rect x="376" y="140" width="8" height="392" fill="rgba(20,20,20,0.06)" stroke="#505050" stroke-width="0.8"/>
+      <rect x="616" y="196" width="8" height="56" fill="rgba(20,20,20,0.06)" stroke="#505050" stroke-width="0.8"/>
+      <rect x="856" y="308" width="8" height="56" fill="rgba(20,20,20,0.06)" stroke="#505050" stroke-width="0.8"/>
+      <rect x="1096" y="420" width="8" height="56" fill="rgba(20,20,20,0.06)" stroke="#505050" stroke-width="0.8"/>
+
+      <!-- ===== Messages ===== -->
+
+      <!-- 1. U -> H -->
+      <path d="M140,140 H384" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="200" y="122" width="84" height="12" rx="2" fill="#fdfefc"/>
+      <text x="242" y="131" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">GET SEARCH</text>
+
+      <!-- 2. H -> F -->
+      <path d="M384,196 H616" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="458" y="178" width="84" height="12" rx="2" fill="#fdfefc"/>
+      <text x="500" y="187" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">BUILD FILTER</text>
+
+      <!-- 3. F --> H (return, dashed) -->
+      <path d="M616,252 H384" fill="none" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+      <rect x="458" y="234" width="84" height="12" rx="2" fill="#fdfefc"/>
+      <text x="500" y="243" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">FILTER EXPR</text>
+
+      <!-- 4. H -> M -->
+      <path d="M384,308 H856" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="578" y="290" width="84" height="12" rx="2" fill="#fdfefc"/>
+      <text x="620" y="299" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">SEARCH QUERY</text>
+
+      <!-- 5. M --> H (return, dashed) -->
+      <path d="M856,364 H384" fill="none" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+      <rect x="588" y="346" width="44" height="12" rx="2" fill="#fdfefc"/>
+      <text x="610" y="355" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">HITS</text>
+
+      <!-- 6. H -> PG -->
+      <path d="M384,420 H1096" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="698" y="402" width="84" height="12" rx="2" fill="#fdfefc"/>
+      <text x="740" y="411" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">GHOST SIGNAL</text>
+
+      <!-- 7. PG --> H (return, dashed) -->
+      <path d="M1096,476 H384" fill="none" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+      <rect x="698" y="458" width="88" height="12" rx="2" fill="#fdfefc"/>
+      <text x="742" y="467" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">PER-JOB SIGNAL</text>
+
+      <!-- 8. H --> U (headline success, solid accent) -->
+      <path d="M384,532 H144" fill="none" stroke="#5b6f00" stroke-width="1.4" marker-end="url(#arrow-accent)"/>
+      <rect x="200" y="514" width="84" height="12" rx="2" fill="#fdfefc"/>
+      <text x="242" y="523" fill="#5b6f00" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">JOBS + META</text>
+
+      <!-- ===== Actor headers ===== -->
+      <rect x="70" y="60" width="140" height="40" rx="6" fill="rgba(80,80,80,0.10)" stroke="#7a7a7a" stroke-width="1"/>
+      <text x="140" y="84" fill="#141414" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Reader (SPA)</text>
+
+      <rect x="310" y="60" width="140" height="40" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <text x="380" y="84" fill="#141414" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">searchHandlers</text>
+
+      <rect x="550" y="60" width="140" height="40" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <text x="620" y="79" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">search.</text>
+      <text x="620" y="91" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">FilterFromValues</text>
+
+      <rect x="790" y="60" width="140" height="40" rx="6" fill="rgba(20,20,20,0.03)" stroke="rgba(20,20,20,0.30)" stroke-width="1"/>
+      <text x="860" y="84" fill="#141414" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Meilisearch</text>
+
+      <rect x="1030" y="60" width="140" height="40" rx="6" fill="rgba(91,111,0,0.08)" stroke="#5b6f00" stroke-width="1.2"/>
+      <text x="1100" y="84" fill="#141414" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">PostgreSQL</text>
+
+      <!-- ===== Legend ===== -->
+      <line x1="40" y1="640" x2="1240" y2="640" stroke="rgba(20,20,20,0.12)" stroke-width="0.8"/>
+      <text x="40" y="656" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.14em">LEGEND</text>
+
+      <line x1="140" y1="655" x2="166" y2="655" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <text x="174" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">call</text>
+
+      <line x1="300" y1="655" x2="326" y2="655" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+      <text x="334" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">return</text>
+
+      <line x1="460" y1="655" x2="486" y2="655" stroke="#5b6f00" stroke-width="1.4" marker-end="url(#arrow-accent)"/>
+      <text x="494" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">happy-path response</text>
+
+      <rect x="740" y="648" width="14" height="14" rx="3" fill="rgba(91,111,0,0.08)" stroke="#5b6f00" stroke-width="1.2"/>
+      <text x="762" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">system of record (best-effort)</text>
+    </svg>

--- a/docs/diagrams/flow-tailoring-a-cv.html
+++ b/docs/diagrams/flow-tailoring-a-cv.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flow: tailoring a CV</title>
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --color-paper:   #fdfefc;
+      --color-ink:     #141414;
+      --color-muted:   #505050;
+      --color-accent:  #5b6f00;
+      --font-sans:     'Geist', system-ui, sans-serif;
+      --font-serif:    'Instrument Serif', serif;
+      --font-mono:     'Geist Mono', ui-monospace, monospace;
+    }
+    body {
+      font-family: var(--font-sans);
+      background: var(--color-paper);
+      color: var(--color-ink);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 3rem 2rem;
+    }
+    .frame { max-width: 1280px; width: 100%; }
+    .eyebrow {
+      font-family: var(--font-mono);
+      font-size: 0.66rem;
+      font-weight: 500;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--color-muted);
+      margin-bottom: 0.5rem;
+    }
+    h1 {
+      font-family: var(--font-serif);
+      font-size: clamp(1.5rem, 2.4vw + 0.75rem, 1.75rem);
+      font-weight: 400;
+      letter-spacing: -0.02em;
+      line-height: 1.15;
+      color: var(--color-ink);
+      margin-bottom: 1.5rem;
+    }
+    svg { width: 100%; min-width: 900px; display: block; }
+  </style>
+</head>
+<body>
+  <div class="frame">
+    <p class="eyebrow">Sequence &middot; freehire</p>
+    <h1>Flow: tailoring a CV</h1>
+
+    <svg viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="flow-cv-title flow-cv-desc">
+      <title id="flow-cv-title">A tailoring turn cites the experience bank for every edit it writes</title>
+      <desc id="flow-cv-desc">The candidate's CV is imported additively into the experience bank; a tailoring turn loops per vacancy requirement, searching the bank for scored evidence and writing each CV edit through the evidence-gated editor, then renders the result with Typst.</desc>
+      <defs>
+        <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#505050"/></marker>
+        <marker id="arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#5b6f00"/></marker>
+      </defs>
+
+      <rect width="100%" height="100%" fill="#fdfefc"/>
+
+      <!-- ===== Lifelines ===== -->
+      <line x1="140" y1="100" x2="140" y2="612" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="380" y1="100" x2="380" y2="612" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="620" y1="100" x2="620" y2="612" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="860" y1="100" x2="860" y2="612" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="1100" y1="100" x2="1100" y2="612" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+
+      <!-- ===== Activation bar (API — active for the whole turn) ===== -->
+      <rect x="376" y="136" width="8" height="452" fill="rgba(20,20,20,0.06)" stroke="#505050" stroke-width="0.8"/>
+
+      <!-- ===== LOOP fragment: per vacancy requirement ===== -->
+      <rect x="340" y="276" width="580" height="192" rx="4" fill="rgba(20,20,20,0.02)" stroke="rgba(20,20,20,0.22)" stroke-width="1"/>
+      <rect x="340" y="276" width="44" height="16" rx="2" fill="#fdfefc" stroke="rgba(20,20,20,0.22)" stroke-width="1"/>
+      <text x="362" y="288" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.12em">LOOP</text>
+      <text x="396" y="288" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.02em">[per vacancy requirement]</text>
+
+      <!-- ===== Messages ===== -->
+
+      <!-- M1 Candidate -> API -->
+      <path d="M140,136 H384" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="196" y="118" width="72" height="12" rx="2" fill="#fdfefc"/>
+      <text x="232" y="127" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">UPLOAD CV</text>
+
+      <!-- API self-message: EXTRACT (LLM) -->
+      <path d="M384,172 H432 Q440,172 440,180 Q440,188 432,188 H384" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <text x="448" y="184" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.04em">EXTRACT (LLM)</text>
+
+      <!-- M2 API -> BANK -->
+      <path d="M384,216 H620" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="458" y="198" width="88" height="12" rx="2" fill="#fdfefc"/>
+      <text x="502" y="207" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">IMPORT (ADD)</text>
+
+      <!-- M3 Candidate -> API -->
+      <path d="M140,260 H384" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="188" y="242" width="88" height="12" rx="2" fill="#fdfefc"/>
+      <text x="232" y="251" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">TAILOR REQUEST</text>
+
+      <!-- M4 API -> BANK (in loop) -->
+      <path d="M384,316 H620" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="450" y="298" width="104" height="12" rx="2" fill="#fdfefc"/>
+      <text x="502" y="307" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">FIND EVIDENCE</text>
+
+      <!-- M5 BANK --> API (return, in loop) -->
+      <path d="M620,360 H384" fill="none" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+      <rect x="450" y="342" width="104" height="12" rx="2" fill="#fdfefc"/>
+      <text x="502" y="351" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">RANKED ATOMS</text>
+
+      <!-- M6 API -> ED (in loop) -->
+      <path d="M384,404 H860" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="578" y="386" width="88" height="12" rx="2" fill="#fdfefc"/>
+      <text x="622" y="395" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">CV_EDIT + EVID</text>
+
+      <!-- M7 ED self-message: APPLY + COMMIT (in loop) -->
+      <path d="M860,432 H900 Q908,432 908,440 Q908,448 900,448 H860" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <text x="668" y="444" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.04em">APPLY + COMMIT</text>
+
+      <!-- M8 Candidate -> API -->
+      <path d="M140,496 H384" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="196" y="478" width="68" height="12" rx="2" fill="#fdfefc"/>
+      <text x="230" y="487" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">PREVIEW/DL</text>
+
+      <!-- M9 API -> TY -->
+      <path d="M384,540 H1100" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="678" y="522" width="112" height="12" rx="2" fill="#fdfefc"/>
+      <text x="734" y="531" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">RENDER (SANDBOX)</text>
+
+      <!-- M10 TY --> Candidate (headline success, direct return, solid accent) -->
+      <path d="M1100,584 H144" fill="none" stroke="#5b6f00" stroke-width="1.4" marker-end="url(#arrow-accent)"/>
+      <rect x="600" y="566" width="40" height="12" rx="2" fill="#fdfefc"/>
+      <text x="620" y="575" fill="#5b6f00" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">PDF</text>
+
+      <!-- ===== Actor headers ===== -->
+      <rect x="70" y="60" width="140" height="40" rx="6" fill="rgba(80,80,80,0.10)" stroke="#7a7a7a" stroke-width="1"/>
+      <text x="140" y="84" fill="#141414" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Candidate</text>
+
+      <rect x="310" y="60" width="140" height="40" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <text x="380" y="84" fill="#141414" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">API</text>
+
+      <rect x="550" y="60" width="140" height="40" rx="6" fill="rgba(20,20,20,0.05)" stroke="#505050" stroke-width="1"/>
+      <text x="620" y="79" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">experience</text>
+      <text x="620" y="91" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">bank</text>
+
+      <rect x="790" y="60" width="140" height="40" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <text x="860" y="79" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">cvedit.</text>
+      <text x="860" y="91" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Editor</text>
+
+      <rect x="1030" y="60" width="140" height="40" rx="6" fill="rgba(20,20,20,0.03)" stroke="rgba(20,20,20,0.30)" stroke-width="1"/>
+      <text x="1100" y="84" fill="#141414" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Typst</text>
+
+      <!-- ===== Legend ===== -->
+      <line x1="40" y1="648" x2="1240" y2="648" stroke="rgba(20,20,20,0.12)" stroke-width="0.8"/>
+      <text x="40" y="664" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.14em">LEGEND</text>
+
+      <line x1="140" y1="663" x2="166" y2="663" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <text x="174" y="667" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">call</text>
+
+      <line x1="300" y1="663" x2="326" y2="663" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+      <text x="334" y="667" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">return</text>
+
+      <line x1="460" y1="663" x2="486" y2="663" stroke="#5b6f00" stroke-width="1.4" marker-end="url(#arrow-accent)"/>
+      <text x="494" y="667" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">happy-path response</text>
+
+      <rect x="740" y="656" width="14" height="14" rx="3" fill="rgba(20,20,20,0.02)" stroke="rgba(20,20,20,0.22)" stroke-width="1"/>
+      <text x="762" y="667" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">iterates per requirement</text>
+    </svg>
+  </div>
+</body>
+</html>

--- a/docs/diagrams/flow-tailoring-a-cv.svg
+++ b/docs/diagrams/flow-tailoring-a-cv.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="flow-cv-title flow-cv-desc">
+      <title id="flow-cv-title">A tailoring turn cites the experience bank for every edit it writes</title>
+      <desc id="flow-cv-desc">The candidate's CV is imported additively into the experience bank; a tailoring turn loops per vacancy requirement, searching the bank for scored evidence and writing each CV edit through the evidence-gated editor, then renders the result with Typst.</desc>
+      <defs>
+        <style>@import url('https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&amp;family=Geist:wght@400;500;600&amp;family=Geist+Mono:wght@400;500;600&amp;display=swap');</style>
+        <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#505050"/></marker>
+        <marker id="arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#5b6f00"/></marker>
+      </defs>
+
+      <rect width="100%" height="100%" fill="#fdfefc"/>
+
+      <!-- ===== Lifelines ===== -->
+      <line x1="140" y1="100" x2="140" y2="612" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="380" y1="100" x2="380" y2="612" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="620" y1="100" x2="620" y2="612" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="860" y1="100" x2="860" y2="612" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="1100" y1="100" x2="1100" y2="612" stroke="rgba(20,20,20,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+
+      <!-- ===== Activation bar (API — active for the whole turn) ===== -->
+      <rect x="376" y="136" width="8" height="452" fill="rgba(20,20,20,0.06)" stroke="#505050" stroke-width="0.8"/>
+
+      <!-- ===== LOOP fragment: per vacancy requirement ===== -->
+      <rect x="340" y="276" width="580" height="192" rx="4" fill="rgba(20,20,20,0.02)" stroke="rgba(20,20,20,0.22)" stroke-width="1"/>
+      <rect x="340" y="276" width="44" height="16" rx="2" fill="#fdfefc" stroke="rgba(20,20,20,0.22)" stroke-width="1"/>
+      <text x="362" y="288" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.12em">LOOP</text>
+      <text x="396" y="288" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.02em">[per vacancy requirement]</text>
+
+      <!-- ===== Messages ===== -->
+
+      <!-- M1 Candidate -> API -->
+      <path d="M140,136 H384" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="196" y="118" width="72" height="12" rx="2" fill="#fdfefc"/>
+      <text x="232" y="127" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">UPLOAD CV</text>
+
+      <!-- API self-message: EXTRACT (LLM) -->
+      <path d="M384,172 H432 Q440,172 440,180 Q440,188 432,188 H384" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <text x="448" y="184" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.04em">EXTRACT (LLM)</text>
+
+      <!-- M2 API -> BANK -->
+      <path d="M384,216 H620" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="458" y="198" width="88" height="12" rx="2" fill="#fdfefc"/>
+      <text x="502" y="207" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">IMPORT (ADD)</text>
+
+      <!-- M3 Candidate -> API -->
+      <path d="M140,260 H384" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="188" y="242" width="88" height="12" rx="2" fill="#fdfefc"/>
+      <text x="232" y="251" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">TAILOR REQUEST</text>
+
+      <!-- M4 API -> BANK (in loop) -->
+      <path d="M384,316 H620" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="450" y="298" width="104" height="12" rx="2" fill="#fdfefc"/>
+      <text x="502" y="307" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">FIND EVIDENCE</text>
+
+      <!-- M5 BANK --> API (return, in loop) -->
+      <path d="M620,360 H384" fill="none" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+      <rect x="450" y="342" width="104" height="12" rx="2" fill="#fdfefc"/>
+      <text x="502" y="351" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">RANKED ATOMS</text>
+
+      <!-- M6 API -> ED (in loop) -->
+      <path d="M384,404 H860" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="578" y="386" width="88" height="12" rx="2" fill="#fdfefc"/>
+      <text x="622" y="395" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">CV_EDIT + EVID</text>
+
+      <!-- M7 ED self-message: APPLY + COMMIT (in loop) -->
+      <path d="M860,432 H900 Q908,432 908,440 Q908,448 900,448 H860" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <text x="668" y="444" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.04em">APPLY + COMMIT</text>
+
+      <!-- M8 Candidate -> API -->
+      <path d="M140,496 H384" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="196" y="478" width="68" height="12" rx="2" fill="#fdfefc"/>
+      <text x="230" y="487" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">PREVIEW/DL</text>
+
+      <!-- M9 API -> TY -->
+      <path d="M384,540 H1100" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="678" y="522" width="112" height="12" rx="2" fill="#fdfefc"/>
+      <text x="734" y="531" fill="#141414" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">RENDER (SANDBOX)</text>
+
+      <!-- M10 TY --> Candidate (headline success, direct return, solid accent) -->
+      <path d="M1100,584 H144" fill="none" stroke="#5b6f00" stroke-width="1.4" marker-end="url(#arrow-accent)"/>
+      <rect x="600" y="566" width="40" height="12" rx="2" fill="#fdfefc"/>
+      <text x="620" y="575" fill="#5b6f00" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">PDF</text>
+
+      <!-- ===== Actor headers ===== -->
+      <rect x="70" y="60" width="140" height="40" rx="6" fill="rgba(80,80,80,0.10)" stroke="#7a7a7a" stroke-width="1"/>
+      <text x="140" y="84" fill="#141414" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Candidate</text>
+
+      <rect x="310" y="60" width="140" height="40" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <text x="380" y="84" fill="#141414" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">API</text>
+
+      <rect x="550" y="60" width="140" height="40" rx="6" fill="rgba(20,20,20,0.05)" stroke="#505050" stroke-width="1"/>
+      <text x="620" y="79" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">experience</text>
+      <text x="620" y="91" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">bank</text>
+
+      <rect x="790" y="60" width="140" height="40" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <text x="860" y="79" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">cvedit.</text>
+      <text x="860" y="91" fill="#141414" font-size="10" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Editor</text>
+
+      <rect x="1030" y="60" width="140" height="40" rx="6" fill="rgba(20,20,20,0.03)" stroke="rgba(20,20,20,0.30)" stroke-width="1"/>
+      <text x="1100" y="84" fill="#141414" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Typst</text>
+
+      <!-- ===== Legend ===== -->
+      <line x1="40" y1="648" x2="1240" y2="648" stroke="rgba(20,20,20,0.12)" stroke-width="0.8"/>
+      <text x="40" y="664" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.14em">LEGEND</text>
+
+      <line x1="140" y1="663" x2="166" y2="663" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <text x="174" y="667" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">call</text>
+
+      <line x1="300" y1="663" x2="326" y2="663" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+      <text x="334" y="667" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">return</text>
+
+      <line x1="460" y1="663" x2="486" y2="663" stroke="#5b6f00" stroke-width="1.4" marker-end="url(#arrow-accent)"/>
+      <text x="494" y="667" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">happy-path response</text>
+
+      <rect x="740" y="656" width="14" height="14" rx="3" fill="rgba(20,20,20,0.02)" stroke="rgba(20,20,20,0.22)" stroke-width="1"/>
+      <text x="762" y="667" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">iterates per requirement</text>
+    </svg>

--- a/docs/diagrams/repository.html
+++ b/docs/diagrams/repository.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>The repository</title>
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --color-paper:   #fdfefc;
+      --color-ink:     #141414;
+      --color-muted:   #505050;
+      --color-accent:  #5b6f00;
+      --font-sans:     'Geist', system-ui, sans-serif;
+      --font-serif:    'Instrument Serif', serif;
+      --font-mono:     'Geist Mono', ui-monospace, monospace;
+    }
+    body {
+      font-family: var(--font-sans);
+      background: var(--color-paper);
+      color: var(--color-ink);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 3rem 2rem;
+    }
+    .frame { max-width: 1280px; width: 100%; }
+    .eyebrow {
+      font-family: var(--font-mono);
+      font-size: 0.66rem;
+      font-weight: 500;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--color-muted);
+      margin-bottom: 0.5rem;
+    }
+    h1 {
+      font-family: var(--font-serif);
+      font-size: clamp(1.5rem, 2.4vw + 0.75rem, 1.75rem);
+      font-weight: 400;
+      letter-spacing: -0.02em;
+      line-height: 1.15;
+      color: var(--color-ink);
+      margin-bottom: 1.5rem;
+    }
+    svg { width: 100%; min-width: 900px; display: block; }
+  </style>
+</head>
+<body>
+  <div class="frame">
+    <p class="eyebrow">Architecture &middot; freehire</p>
+    <h1>The repository</h1>
+
+    <svg viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="repository-title repository-desc">
+      <title id="repository-title">The freehire repository, module by module</title>
+      <desc id="repository-desc">Go backend packages (migrations, cmd, internal) generate types and read board data, feeding a frontend workspace (web, design-system, extension) that calls back over HTTP.</desc>
+      <defs>
+        <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#505050"/></marker>
+        <marker id="arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#5b6f00"/></marker>
+        <marker id="arrow-link" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#2e5aa8"/></marker>
+      </defs>
+
+      <rect width="100%" height="100%" fill="#fdfefc"/>
+
+      <!-- ===== Zones (painted first, behind arrows/nodes) ===== -->
+      <rect x="240" y="120" width="384" height="232" rx="8" fill="rgba(20,20,20,0.02)" stroke="rgba(20,20,20,0.10)" stroke-width="0.8"/>
+      <rect x="252" y="124" width="112" height="12" rx="2" fill="#fdfefc"/>
+      <text x="308" y="133" fill="rgba(20,20,20,0.40)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.14em">GO BACKEND</text>
+
+      <rect x="712" y="120" width="384" height="232" rx="8" fill="rgba(20,20,20,0.02)" stroke="rgba(20,20,20,0.10)" stroke-width="0.8"/>
+      <rect x="724" y="124" width="168" height="12" rx="2" fill="#fdfefc"/>
+      <text x="808" y="133" fill="rgba(20,20,20,0.40)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.14em">FRONTEND WORKSPACES</text>
+
+      <!-- ===== Arrows (before boxes) ===== -->
+
+      <!-- E1 MIG -> INT : SQLC GENERATES -->
+      <path d="M336,224 V240 Q336,248 344,248 H384 Q392,248 392,256 V272" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="322" y="234" width="88" height="12" rx="2" fill="#fdfefc"/>
+      <text x="366" y="243" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">SQLC GENERATES</text>
+
+      <!-- E2 CMD -> INT -->
+      <path d="M528,224 V240 Q528,248 520,248 H480 Q472,248 472,256 V272" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- E3 SRC -> CMD : AT CRAWL TIME -->
+      <path d="M200,236 H316 Q324,236 324,228 V200 Q324,192 332,192 H448" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="222" y="216" width="84" height="12" rx="2" fill="#fdfefc"/>
+      <text x="264" y="225" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">AT CRAWL TIME</text>
+
+      <!-- E4 INT -> WEB : EMITS TS TYPES -->
+      <path d="M512,304 H728" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="576" y="286" width="88" height="12" rx="2" fill="#fdfefc"/>
+      <text x="620" y="295" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">EMITS TS TYPES</text>
+
+      <!-- E5 WEB -> CMD : HTTP (return path, over the top) -->
+      <path d="M808,272 V96 Q808,88 800,88 H568 Q560,88 560,96 V160" fill="none" stroke="#2e5aa8" stroke-width="1" marker-end="url(#arrow-link)"/>
+      <rect x="514" y="124" width="40" height="12" rx="2" fill="#fdfefc"/>
+      <text x="534" y="133" fill="#2e5aa8" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">HTTP</text>
+
+      <!-- E6 EXTD -> CMD : HTTP (return path, over the top, outer lane) -->
+      <path d="M1000,272 V72 Q1000,64 992,64 H488 Q480,64 480,72 V160" fill="none" stroke="#2e5aa8" stroke-width="1" marker-end="url(#arrow-link)"/>
+      <rect x="434" y="98" width="40" height="12" rx="2" fill="#fdfefc"/>
+      <text x="454" y="107" fill="#2e5aa8" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">HTTP</text>
+
+      <!-- E7 DS -> WEB : linked dependency -->
+      <path d="M864,224 V240 Q864,248 856,248 H816 Q808,248 808,256 V272" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- E8 DS -> EXTD : linked dependency -->
+      <path d="M944,224 V240 Q944,248 952,248 H992 Q1000,248 1000,256 V272" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="908" y="234" width="112" height="12" rx="2" fill="#fdfefc"/>
+      <text x="964" y="243" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">LINKED DEP</text>
+
+      <!-- ===== Nodes ===== -->
+
+      <!-- SRC: sources/ (store — data, not code) -->
+      <rect x="40" y="204" width="160" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="40" y="204" width="160" height="64" rx="6" fill="rgba(20,20,20,0.05)" stroke="#505050" stroke-width="1"/>
+      <rect x="48" y="210" width="36" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="66" y="219" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">DATA</text>
+      <text x="120" y="240" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">sources/</text>
+      <text x="120" y="256" fill="#505050" font-size="9" font-family="'Geist Mono', monospace" text-anchor="middle">yaml board files</text>
+
+      <!-- MIG: migrations/ -->
+      <rect x="256" y="160" width="160" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="256" y="160" width="160" height="64" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <rect x="264" y="166" width="34" height="12" rx="2" fill="transparent" stroke="rgba(20,20,20,0.4)" stroke-width="0.8"/>
+      <text x="281" y="175" fill="rgba(20,20,20,0.8)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">SQL</text>
+      <text x="336" y="196" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">migrations/</text>
+      <text x="336" y="212" fill="#505050" font-size="9" font-family="'Geist Mono', monospace" text-anchor="middle">sqlc + initdb source</text>
+
+      <!-- CMD: cmd/ -->
+      <rect x="448" y="160" width="160" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="448" y="160" width="160" height="64" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <rect x="456" y="166" width="34" height="12" rx="2" fill="transparent" stroke="rgba(20,20,20,0.4)" stroke-width="0.8"/>
+      <text x="473" y="175" fill="rgba(20,20,20,0.8)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">GO</text>
+      <text x="528" y="196" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">cmd/</text>
+      <text x="528" y="212" fill="#505050" font-size="9" font-family="'Geist Mono', monospace" text-anchor="middle">~60 entry points</text>
+
+      <!-- INT: internal/ (focal — the domain layer) -->
+      <rect x="352" y="272" width="160" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="352" y="272" width="160" height="64" rx="6" fill="rgba(91,111,0,0.08)" stroke="#5b6f00" stroke-width="1.2"/>
+      <rect x="360" y="278" width="34" height="12" rx="2" fill="transparent" stroke="rgba(91,111,0,0.5)" stroke-width="0.8"/>
+      <text x="377" y="287" fill="#5b6f00" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">GO</text>
+      <text x="432" y="308" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">internal/</text>
+      <text x="432" y="324" fill="#505050" font-size="9" font-family="'Geist Mono', monospace" text-anchor="middle">domain packages</text>
+
+      <!-- DS: design-system/ -->
+      <rect x="824" y="160" width="160" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="824" y="160" width="160" height="64" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <rect x="832" y="166" width="42" height="12" rx="2" fill="transparent" stroke="rgba(20,20,20,0.4)" stroke-width="0.8"/>
+      <text x="853" y="175" fill="rgba(20,20,20,0.8)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">PNPM</text>
+      <text x="904" y="196" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">design-system/</text>
+      <text x="904" y="212" fill="#505050" font-size="9" font-family="'Geist Mono', monospace" text-anchor="middle">linked, not copied</text>
+
+      <!-- WEB: web/ -->
+      <rect x="728" y="272" width="160" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="728" y="272" width="160" height="64" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <rect x="736" y="278" width="42" height="12" rx="2" fill="transparent" stroke="rgba(20,20,20,0.4)" stroke-width="0.8"/>
+      <text x="757" y="287" fill="rgba(20,20,20,0.8)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">PNPM</text>
+      <text x="808" y="308" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">web/</text>
+      <text x="808" y="324" fill="#505050" font-size="9" font-family="'Geist Mono', monospace" text-anchor="middle">sveltekit spa</text>
+
+      <!-- EXTD: extension/ -->
+      <rect x="920" y="272" width="160" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="920" y="272" width="160" height="64" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <rect x="928" y="278" width="38" height="12" rx="2" fill="transparent" stroke="rgba(20,20,20,0.4)" stroke-width="0.8"/>
+      <text x="947" y="287" fill="rgba(20,20,20,0.8)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">NPM</text>
+      <text x="1000" y="308" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">extension/</text>
+      <text x="1000" y="324" fill="#505050" font-size="9" font-family="'Geist Mono', monospace" text-anchor="middle">wxt + svelte</text>
+
+      <!-- ===== Legend ===== -->
+      <line x1="40" y1="640" x2="1240" y2="640" stroke="rgba(20,20,20,0.12)" stroke-width="0.8"/>
+      <text x="40" y="656" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.14em">LEGEND</text>
+
+      <rect x="140" y="648" width="14" height="14" rx="3" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <text x="162" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">package</text>
+
+      <rect x="320" y="648" width="14" height="14" rx="3" fill="rgba(91,111,0,0.08)" stroke="#5b6f00" stroke-width="1.2"/>
+      <text x="342" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">domain layer</text>
+
+      <rect x="500" y="648" width="14" height="14" rx="3" fill="rgba(20,20,20,0.05)" stroke="#505050" stroke-width="1"/>
+      <text x="522" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">data, not code</text>
+
+      <line x1="700" y1="655" x2="726" y2="655" stroke="#2e5aa8" stroke-width="1" marker-end="url(#arrow-link)"/>
+      <text x="734" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">http call</text>
+
+      <line x1="880" y1="655" x2="906" y2="655" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <text x="914" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">build-time link</text>
+    </svg>
+  </div>
+</body>
+</html>

--- a/docs/diagrams/repository.svg
+++ b/docs/diagrams/repository.svg
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="repository-title repository-desc">
+      <title id="repository-title">The freehire repository, module by module</title>
+      <desc id="repository-desc">Go backend packages (migrations, cmd, internal) generate types and read board data, feeding a frontend workspace (web, design-system, extension) that calls back over HTTP.</desc>
+      <defs>
+        <style>@import url('https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&amp;family=Geist:wght@400;500;600&amp;family=Geist+Mono:wght@400;500;600&amp;display=swap');</style>
+        <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#505050"/></marker>
+        <marker id="arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#5b6f00"/></marker>
+        <marker id="arrow-link" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#2e5aa8"/></marker>
+      </defs>
+
+      <rect width="100%" height="100%" fill="#fdfefc"/>
+
+      <!-- ===== Zones (painted first, behind arrows/nodes) ===== -->
+      <rect x="240" y="120" width="384" height="232" rx="8" fill="rgba(20,20,20,0.02)" stroke="rgba(20,20,20,0.10)" stroke-width="0.8"/>
+      <rect x="252" y="124" width="112" height="12" rx="2" fill="#fdfefc"/>
+      <text x="308" y="133" fill="rgba(20,20,20,0.40)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.14em">GO BACKEND</text>
+
+      <rect x="712" y="120" width="384" height="232" rx="8" fill="rgba(20,20,20,0.02)" stroke="rgba(20,20,20,0.10)" stroke-width="0.8"/>
+      <rect x="724" y="124" width="168" height="12" rx="2" fill="#fdfefc"/>
+      <text x="808" y="133" fill="rgba(20,20,20,0.40)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.14em">FRONTEND WORKSPACES</text>
+
+      <!-- ===== Arrows (before boxes) ===== -->
+
+      <!-- E1 MIG -> INT : SQLC GENERATES -->
+      <path d="M336,224 V240 Q336,248 344,248 H384 Q392,248 392,256 V272" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="322" y="234" width="88" height="12" rx="2" fill="#fdfefc"/>
+      <text x="366" y="243" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">SQLC GENERATES</text>
+
+      <!-- E2 CMD -> INT -->
+      <path d="M528,224 V240 Q528,248 520,248 H480 Q472,248 472,256 V272" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- E3 SRC -> CMD : AT CRAWL TIME -->
+      <path d="M200,236 H316 Q324,236 324,228 V200 Q324,192 332,192 H448" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="222" y="216" width="84" height="12" rx="2" fill="#fdfefc"/>
+      <text x="264" y="225" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">AT CRAWL TIME</text>
+
+      <!-- E4 INT -> WEB : EMITS TS TYPES -->
+      <path d="M512,304 H728" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="576" y="286" width="88" height="12" rx="2" fill="#fdfefc"/>
+      <text x="620" y="295" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">EMITS TS TYPES</text>
+
+      <!-- E5 WEB -> CMD : HTTP (return path, over the top) -->
+      <path d="M808,272 V96 Q808,88 800,88 H568 Q560,88 560,96 V160" fill="none" stroke="#2e5aa8" stroke-width="1" marker-end="url(#arrow-link)"/>
+      <rect x="514" y="124" width="40" height="12" rx="2" fill="#fdfefc"/>
+      <text x="534" y="133" fill="#2e5aa8" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">HTTP</text>
+
+      <!-- E6 EXTD -> CMD : HTTP (return path, over the top, outer lane) -->
+      <path d="M1000,272 V72 Q1000,64 992,64 H488 Q480,64 480,72 V160" fill="none" stroke="#2e5aa8" stroke-width="1" marker-end="url(#arrow-link)"/>
+      <rect x="434" y="98" width="40" height="12" rx="2" fill="#fdfefc"/>
+      <text x="454" y="107" fill="#2e5aa8" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">HTTP</text>
+
+      <!-- E7 DS -> WEB : linked dependency -->
+      <path d="M864,224 V240 Q864,248 856,248 H816 Q808,248 808,256 V272" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- E8 DS -> EXTD : linked dependency -->
+      <path d="M944,224 V240 Q944,248 952,248 H992 Q1000,248 1000,256 V272" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <rect x="908" y="234" width="112" height="12" rx="2" fill="#fdfefc"/>
+      <text x="964" y="243" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">LINKED DEP</text>
+
+      <!-- ===== Nodes ===== -->
+
+      <!-- SRC: sources/ (store — data, not code) -->
+      <rect x="40" y="204" width="160" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="40" y="204" width="160" height="64" rx="6" fill="rgba(20,20,20,0.05)" stroke="#505050" stroke-width="1"/>
+      <rect x="48" y="210" width="36" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="66" y="219" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">DATA</text>
+      <text x="120" y="240" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">sources/</text>
+      <text x="120" y="256" fill="#505050" font-size="9" font-family="'Geist Mono', monospace" text-anchor="middle">yaml board files</text>
+
+      <!-- MIG: migrations/ -->
+      <rect x="256" y="160" width="160" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="256" y="160" width="160" height="64" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <rect x="264" y="166" width="34" height="12" rx="2" fill="transparent" stroke="rgba(20,20,20,0.4)" stroke-width="0.8"/>
+      <text x="281" y="175" fill="rgba(20,20,20,0.8)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">SQL</text>
+      <text x="336" y="196" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">migrations/</text>
+      <text x="336" y="212" fill="#505050" font-size="9" font-family="'Geist Mono', monospace" text-anchor="middle">sqlc + initdb source</text>
+
+      <!-- CMD: cmd/ -->
+      <rect x="448" y="160" width="160" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="448" y="160" width="160" height="64" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <rect x="456" y="166" width="34" height="12" rx="2" fill="transparent" stroke="rgba(20,20,20,0.4)" stroke-width="0.8"/>
+      <text x="473" y="175" fill="rgba(20,20,20,0.8)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">GO</text>
+      <text x="528" y="196" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">cmd/</text>
+      <text x="528" y="212" fill="#505050" font-size="9" font-family="'Geist Mono', monospace" text-anchor="middle">~60 entry points</text>
+
+      <!-- INT: internal/ (focal — the domain layer) -->
+      <rect x="352" y="272" width="160" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="352" y="272" width="160" height="64" rx="6" fill="rgba(91,111,0,0.08)" stroke="#5b6f00" stroke-width="1.2"/>
+      <rect x="360" y="278" width="34" height="12" rx="2" fill="transparent" stroke="rgba(91,111,0,0.5)" stroke-width="0.8"/>
+      <text x="377" y="287" fill="#5b6f00" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">GO</text>
+      <text x="432" y="308" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">internal/</text>
+      <text x="432" y="324" fill="#505050" font-size="9" font-family="'Geist Mono', monospace" text-anchor="middle">domain packages</text>
+
+      <!-- DS: design-system/ -->
+      <rect x="824" y="160" width="160" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="824" y="160" width="160" height="64" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <rect x="832" y="166" width="42" height="12" rx="2" fill="transparent" stroke="rgba(20,20,20,0.4)" stroke-width="0.8"/>
+      <text x="853" y="175" fill="rgba(20,20,20,0.8)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">PNPM</text>
+      <text x="904" y="196" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">design-system/</text>
+      <text x="904" y="212" fill="#505050" font-size="9" font-family="'Geist Mono', monospace" text-anchor="middle">linked, not copied</text>
+
+      <!-- WEB: web/ -->
+      <rect x="728" y="272" width="160" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="728" y="272" width="160" height="64" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <rect x="736" y="278" width="42" height="12" rx="2" fill="transparent" stroke="rgba(20,20,20,0.4)" stroke-width="0.8"/>
+      <text x="757" y="287" fill="rgba(20,20,20,0.8)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">PNPM</text>
+      <text x="808" y="308" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">web/</text>
+      <text x="808" y="324" fill="#505050" font-size="9" font-family="'Geist Mono', monospace" text-anchor="middle">sveltekit spa</text>
+
+      <!-- EXTD: extension/ -->
+      <rect x="920" y="272" width="160" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="920" y="272" width="160" height="64" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <rect x="928" y="278" width="38" height="12" rx="2" fill="transparent" stroke="rgba(20,20,20,0.4)" stroke-width="0.8"/>
+      <text x="947" y="287" fill="rgba(20,20,20,0.8)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">NPM</text>
+      <text x="1000" y="308" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">extension/</text>
+      <text x="1000" y="324" fill="#505050" font-size="9" font-family="'Geist Mono', monospace" text-anchor="middle">wxt + svelte</text>
+
+      <!-- ===== Legend ===== -->
+      <line x1="40" y1="640" x2="1240" y2="640" stroke="rgba(20,20,20,0.12)" stroke-width="0.8"/>
+      <text x="40" y="656" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.14em">LEGEND</text>
+
+      <rect x="140" y="648" width="14" height="14" rx="3" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <text x="162" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">package</text>
+
+      <rect x="320" y="648" width="14" height="14" rx="3" fill="rgba(91,111,0,0.08)" stroke="#5b6f00" stroke-width="1.2"/>
+      <text x="342" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">domain layer</text>
+
+      <rect x="500" y="648" width="14" height="14" rx="3" fill="rgba(20,20,20,0.05)" stroke="#505050" stroke-width="1"/>
+      <text x="522" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">data, not code</text>
+
+      <line x1="700" y1="655" x2="726" y2="655" stroke="#2e5aa8" stroke-width="1" marker-end="url(#arrow-link)"/>
+      <text x="734" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">http call</text>
+
+      <line x1="880" y1="655" x2="906" y2="655" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+      <text x="914" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">build-time link</text>
+    </svg>

--- a/docs/diagrams/system-shape.html
+++ b/docs/diagrams/system-shape.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>The shape of the system</title>
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --color-paper:   #fdfefc;
+      --color-ink:     #141414;
+      --color-muted:   #505050;
+      --color-accent:  #5b6f00;
+      --font-sans:     'Geist', system-ui, sans-serif;
+      --font-serif:    'Instrument Serif', serif;
+      --font-mono:     'Geist Mono', ui-monospace, monospace;
+    }
+    body {
+      font-family: var(--font-sans);
+      background: var(--color-paper);
+      color: var(--color-ink);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 3rem 2rem;
+    }
+    .frame { max-width: 1280px; width: 100%; }
+    .eyebrow {
+      font-family: var(--font-mono);
+      font-size: 0.66rem;
+      font-weight: 500;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--color-muted);
+      margin-bottom: 0.5rem;
+    }
+    h1 {
+      font-family: var(--font-serif);
+      font-size: clamp(1.5rem, 2.4vw + 0.75rem, 1.75rem);
+      font-weight: 400;
+      letter-spacing: -0.02em;
+      line-height: 1.15;
+      color: var(--color-ink);
+      margin-bottom: 1.5rem;
+    }
+    svg { width: 100%; min-width: 900px; display: block; }
+  </style>
+</head>
+<body>
+  <div class="frame">
+    <p class="eyebrow">Architecture &middot; freehire</p>
+    <h1>The shape of the system</h1>
+
+    <svg viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="system-shape-title system-shape-desc">
+      <title id="system-shape-title">How a job posting moves through freehire, from crawl to client</title>
+      <desc id="system-shape-desc">Sources feed run-once ingest workers that write Postgres and, in the same transaction, an outbox; queue drains and a full reindex worker push into Meilisearch; the API server reads Postgres and Meilisearch to serve clients.</desc>
+      <defs>
+        <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#505050"/></marker>
+        <marker id="arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#5b6f00"/></marker>
+      </defs>
+
+      <rect width="100%" height="100%" fill="#fdfefc"/>
+
+      <!-- ===== Arrows (before boxes) ===== -->
+
+      <!-- E1 Sources -> Ingest -->
+      <path d="M160,320 H220" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- E2 Ingest -> PostgreSQL (bottom entry) -->
+      <path d="M340,312 H452 Q460,312 460,304 V244" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- E3 Ingest -.-> Outbox (dashed, same transaction) -->
+      <path d="M340,336 H452 Q460,336 460,344 V372" fill="none" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+      <rect x="424" y="346" width="64" height="12" rx="2" fill="#fdfefc"/>
+      <text x="456" y="355" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">SAME TXN</text>
+
+      <!-- E4 Outbox -> Queue drains (bottom entry, below-to-above) -->
+      <path d="M520,404 H632 Q640,404 640,396 V244" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- E5 Queue drains -> PostgreSQL (same row) -->
+      <path d="M580,212 H520" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- E6 Queue drains -> Meilisearch (top entry) -->
+      <path d="M700,212 H812 Q820,212 820,220 V288" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- E7 cmd/reindex -> Meilisearch (bottom entry) -->
+      <path d="M700,404 H812 Q820,404 820,396 V352" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- E8 PostgreSQL -> cmd/reindex -->
+      <path d="M420,244 V300 Q420,308 428,308 H592 Q600,308 600,316 V372" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- E9 PostgreSQL -> API (over the top) -->
+      <path d="M460,180 V148 Q460,140 468,140 H992 Q1000,140 1000,148 V288" fill="none" stroke="#5b6f00" stroke-width="1.2" marker-end="url(#arrow-accent)"/>
+
+      <!-- E10 Meilisearch -> API (same row) -->
+      <path d="M880,320 H940" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- E11 API -> Clients (same row) -->
+      <path d="M1060,320 H1120" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- ===== Nodes ===== -->
+
+      <!-- Sources (input/external) -->
+      <rect x="40" y="288" width="120" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="40" y="288" width="120" height="64" rx="6" fill="rgba(80,80,80,0.10)" stroke="#7a7a7a" stroke-width="1"/>
+      <rect x="48" y="294" width="30" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="63" y="303" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">EXT</text>
+      <text x="100" y="324" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Sources</text>
+      <text x="100" y="340" fill="#505050" font-size="9" font-family="'Geist Mono', monospace" text-anchor="middle">~167 feeds</text>
+
+      <!-- Ingest -> Runner (backend) -->
+      <rect x="220" y="288" width="120" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="220" y="288" width="120" height="64" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <rect x="228" y="294" width="36" height="12" rx="2" fill="transparent" stroke="rgba(20,20,20,0.4)" stroke-width="0.8"/>
+      <text x="246" y="303" fill="rgba(20,20,20,0.8)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">CRON</text>
+      <text x="280" y="322" fill="#141414" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Ingest → Runner</text>
+      <text x="280" y="338" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">fetch · dedup · upsert</text>
+
+      <!-- PostgreSQL (focal) -->
+      <rect x="400" y="180" width="120" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="400" y="180" width="120" height="64" rx="6" fill="rgba(91,111,0,0.08)" stroke="#5b6f00" stroke-width="1.2"/>
+      <rect x="408" y="186" width="26" height="12" rx="2" fill="transparent" stroke="rgba(91,111,0,0.5)" stroke-width="0.8"/>
+      <text x="421" y="195" fill="#5b6f00" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">DB</text>
+      <text x="460" y="216" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">PostgreSQL</text>
+      <text x="460" y="232" fill="#505050" font-size="9" font-family="'Geist Mono', monospace" text-anchor="middle">system of record</text>
+
+      <!-- Outbox tables (store) -->
+      <rect x="400" y="372" width="120" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="400" y="372" width="120" height="64" rx="6" fill="rgba(20,20,20,0.05)" stroke="#505050" stroke-width="1"/>
+      <rect x="408" y="378" width="32" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="424" y="387" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">TBL</text>
+      <text x="460" y="408" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Outbox tables</text>
+      <text x="460" y="424" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">4 outbox queues</text>
+
+      <!-- Queue drains (backend) -->
+      <rect x="580" y="180" width="120" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="580" y="180" width="120" height="64" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <rect x="588" y="186" width="36" height="12" rx="2" fill="transparent" stroke="rgba(20,20,20,0.4)" stroke-width="0.8"/>
+      <text x="606" y="195" fill="rgba(20,20,20,0.8)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">CRON</text>
+      <text x="640" y="216" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Queue drains</text>
+      <text x="640" y="232" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">4 cron workers</text>
+
+      <!-- cmd/reindex (backend) -->
+      <rect x="580" y="372" width="120" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="580" y="372" width="120" height="64" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <rect x="588" y="378" width="36" height="12" rx="2" fill="transparent" stroke="rgba(20,20,20,0.4)" stroke-width="0.8"/>
+      <text x="606" y="387" fill="rgba(20,20,20,0.8)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">CRON</text>
+      <text x="640" y="408" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">cmd/reindex</text>
+      <text x="640" y="424" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">rebuild + swap</text>
+
+      <!-- Meilisearch (external service) -->
+      <rect x="760" y="288" width="120" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="760" y="288" width="120" height="64" rx="6" fill="rgba(20,20,20,0.03)" stroke="rgba(20,20,20,0.30)" stroke-width="1"/>
+      <rect x="768" y="294" width="30" height="12" rx="2" fill="transparent" stroke="rgba(20,20,20,0.4)" stroke-width="0.8"/>
+      <text x="783" y="303" fill="rgba(20,20,20,0.7)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">SVC</text>
+      <text x="820" y="324" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Meilisearch</text>
+      <text x="820" y="340" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">keyword + facets</text>
+
+      <!-- cmd/server API (backend) -->
+      <rect x="940" y="288" width="120" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="940" y="288" width="120" height="64" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <rect x="948" y="294" width="32" height="12" rx="2" fill="transparent" stroke="rgba(20,20,20,0.4)" stroke-width="0.8"/>
+      <text x="964" y="303" fill="rgba(20,20,20,0.8)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">API</text>
+      <text x="1000" y="324" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">cmd/server</text>
+      <text x="1000" y="340" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">Fiber · /api/v1/*</text>
+
+      <!-- Clients (input/external) -->
+      <rect x="1120" y="288" width="120" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="1120" y="288" width="120" height="64" rx="6" fill="rgba(80,80,80,0.10)" stroke="#7a7a7a" stroke-width="1"/>
+      <rect x="1128" y="294" width="30" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="1143" y="303" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">EXT</text>
+      <text x="1180" y="324" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Clients</text>
+      <text x="1180" y="340" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">SPA · ext · bots</text>
+
+      <!-- ===== Legend ===== -->
+      <line x1="40" y1="640" x2="1240" y2="640" stroke="rgba(20,20,20,0.12)" stroke-width="0.8"/>
+      <text x="40" y="656" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.14em">LEGEND</text>
+
+      <rect x="140" y="648" width="14" height="14" rx="3" fill="rgba(91,111,0,0.08)" stroke="#5b6f00" stroke-width="1.2"/>
+      <text x="162" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">system of record</text>
+
+      <rect x="340" y="648" width="14" height="14" rx="3" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <text x="362" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">run-once worker</text>
+
+      <rect x="540" y="648" width="14" height="14" rx="3" fill="rgba(20,20,20,0.05)" stroke="#505050" stroke-width="1"/>
+      <text x="562" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">outbox table</text>
+
+      <rect x="720" y="648" width="14" height="14" rx="3" fill="rgba(20,20,20,0.03)" stroke="rgba(20,20,20,0.30)" stroke-width="1"/>
+      <text x="742" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">external service</text>
+
+      <line x1="920" y1="655" x2="946" y2="655" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+      <text x="954" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">same transaction</text>
+    </svg>
+  </div>
+</body>
+</html>

--- a/docs/diagrams/system-shape.svg
+++ b/docs/diagrams/system-shape.svg
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="system-shape-title system-shape-desc">
+      <title id="system-shape-title">How a job posting moves through freehire, from crawl to client</title>
+      <desc id="system-shape-desc">Sources feed run-once ingest workers that write Postgres and, in the same transaction, an outbox; queue drains and a full reindex worker push into Meilisearch; the API server reads Postgres and Meilisearch to serve clients.</desc>
+      <defs>
+        <style>@import url('https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&amp;family=Geist:wght@400;500;600&amp;family=Geist+Mono:wght@400;500;600&amp;display=swap');</style>
+        <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#505050"/></marker>
+        <marker id="arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#5b6f00"/></marker>
+      </defs>
+
+      <rect width="100%" height="100%" fill="#fdfefc"/>
+
+      <!-- ===== Arrows (before boxes) ===== -->
+
+      <!-- E1 Sources -> Ingest -->
+      <path d="M160,320 H220" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- E2 Ingest -> PostgreSQL (bottom entry) -->
+      <path d="M340,312 H452 Q460,312 460,304 V244" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- E3 Ingest -.-> Outbox (dashed, same transaction) -->
+      <path d="M340,336 H452 Q460,336 460,344 V372" fill="none" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+      <rect x="424" y="346" width="64" height="12" rx="2" fill="#fdfefc"/>
+      <text x="456" y="355" fill="#7a7a7a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">SAME TXN</text>
+
+      <!-- E4 Outbox -> Queue drains (bottom entry, below-to-above) -->
+      <path d="M520,404 H632 Q640,404 640,396 V244" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- E5 Queue drains -> PostgreSQL (same row) -->
+      <path d="M580,212 H520" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- E6 Queue drains -> Meilisearch (top entry) -->
+      <path d="M700,212 H812 Q820,212 820,220 V288" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- E7 cmd/reindex -> Meilisearch (bottom entry) -->
+      <path d="M700,404 H812 Q820,404 820,396 V352" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- E8 PostgreSQL -> cmd/reindex -->
+      <path d="M420,244 V300 Q420,308 428,308 H592 Q600,308 600,316 V372" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- E9 PostgreSQL -> API (over the top) -->
+      <path d="M460,180 V148 Q460,140 468,140 H992 Q1000,140 1000,148 V288" fill="none" stroke="#5b6f00" stroke-width="1.2" marker-end="url(#arrow-accent)"/>
+
+      <!-- E10 Meilisearch -> API (same row) -->
+      <path d="M880,320 H940" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- E11 API -> Clients (same row) -->
+      <path d="M1060,320 H1120" fill="none" stroke="#505050" stroke-width="1" marker-end="url(#arrow)"/>
+
+      <!-- ===== Nodes ===== -->
+
+      <!-- Sources (input/external) -->
+      <rect x="40" y="288" width="120" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="40" y="288" width="120" height="64" rx="6" fill="rgba(80,80,80,0.10)" stroke="#7a7a7a" stroke-width="1"/>
+      <rect x="48" y="294" width="30" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="63" y="303" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">EXT</text>
+      <text x="100" y="324" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Sources</text>
+      <text x="100" y="340" fill="#505050" font-size="9" font-family="'Geist Mono', monospace" text-anchor="middle">~167 feeds</text>
+
+      <!-- Ingest -> Runner (backend) -->
+      <rect x="220" y="288" width="120" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="220" y="288" width="120" height="64" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <rect x="228" y="294" width="36" height="12" rx="2" fill="transparent" stroke="rgba(20,20,20,0.4)" stroke-width="0.8"/>
+      <text x="246" y="303" fill="rgba(20,20,20,0.8)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">CRON</text>
+      <text x="280" y="322" fill="#141414" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Ingest → Runner</text>
+      <text x="280" y="338" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">fetch · dedup · upsert</text>
+
+      <!-- PostgreSQL (focal) -->
+      <rect x="400" y="180" width="120" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="400" y="180" width="120" height="64" rx="6" fill="rgba(91,111,0,0.08)" stroke="#5b6f00" stroke-width="1.2"/>
+      <rect x="408" y="186" width="26" height="12" rx="2" fill="transparent" stroke="rgba(91,111,0,0.5)" stroke-width="0.8"/>
+      <text x="421" y="195" fill="#5b6f00" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">DB</text>
+      <text x="460" y="216" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">PostgreSQL</text>
+      <text x="460" y="232" fill="#505050" font-size="9" font-family="'Geist Mono', monospace" text-anchor="middle">system of record</text>
+
+      <!-- Outbox tables (store) -->
+      <rect x="400" y="372" width="120" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="400" y="372" width="120" height="64" rx="6" fill="rgba(20,20,20,0.05)" stroke="#505050" stroke-width="1"/>
+      <rect x="408" y="378" width="32" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="424" y="387" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">TBL</text>
+      <text x="460" y="408" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Outbox tables</text>
+      <text x="460" y="424" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">4 outbox queues</text>
+
+      <!-- Queue drains (backend) -->
+      <rect x="580" y="180" width="120" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="580" y="180" width="120" height="64" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <rect x="588" y="186" width="36" height="12" rx="2" fill="transparent" stroke="rgba(20,20,20,0.4)" stroke-width="0.8"/>
+      <text x="606" y="195" fill="rgba(20,20,20,0.8)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">CRON</text>
+      <text x="640" y="216" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Queue drains</text>
+      <text x="640" y="232" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">4 cron workers</text>
+
+      <!-- cmd/reindex (backend) -->
+      <rect x="580" y="372" width="120" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="580" y="372" width="120" height="64" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <rect x="588" y="378" width="36" height="12" rx="2" fill="transparent" stroke="rgba(20,20,20,0.4)" stroke-width="0.8"/>
+      <text x="606" y="387" fill="rgba(20,20,20,0.8)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">CRON</text>
+      <text x="640" y="408" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">cmd/reindex</text>
+      <text x="640" y="424" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">rebuild + swap</text>
+
+      <!-- Meilisearch (external service) -->
+      <rect x="760" y="288" width="120" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="760" y="288" width="120" height="64" rx="6" fill="rgba(20,20,20,0.03)" stroke="rgba(20,20,20,0.30)" stroke-width="1"/>
+      <rect x="768" y="294" width="30" height="12" rx="2" fill="transparent" stroke="rgba(20,20,20,0.4)" stroke-width="0.8"/>
+      <text x="783" y="303" fill="rgba(20,20,20,0.7)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">SVC</text>
+      <text x="820" y="324" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Meilisearch</text>
+      <text x="820" y="340" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">keyword + facets</text>
+
+      <!-- cmd/server API (backend) -->
+      <rect x="940" y="288" width="120" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="940" y="288" width="120" height="64" rx="6" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <rect x="948" y="294" width="32" height="12" rx="2" fill="transparent" stroke="rgba(20,20,20,0.4)" stroke-width="0.8"/>
+      <text x="964" y="303" fill="rgba(20,20,20,0.8)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">API</text>
+      <text x="1000" y="324" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">cmd/server</text>
+      <text x="1000" y="340" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">Fiber · /api/v1/*</text>
+
+      <!-- Clients (input/external) -->
+      <rect x="1120" y="288" width="120" height="64" rx="6" fill="#fdfefc"/>
+      <rect x="1120" y="288" width="120" height="64" rx="6" fill="rgba(80,80,80,0.10)" stroke="#7a7a7a" stroke-width="1"/>
+      <rect x="1128" y="294" width="30" height="12" rx="2" fill="transparent" stroke="rgba(80,80,80,0.5)" stroke-width="0.8"/>
+      <text x="1143" y="303" fill="rgba(80,80,80,0.9)" font-size="7" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">EXT</text>
+      <text x="1180" y="324" fill="#141414" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Clients</text>
+      <text x="1180" y="340" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">SPA · ext · bots</text>
+
+      <!-- ===== Legend ===== -->
+      <line x1="40" y1="640" x2="1240" y2="640" stroke="rgba(20,20,20,0.12)" stroke-width="0.8"/>
+      <text x="40" y="656" fill="#505050" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.14em">LEGEND</text>
+
+      <rect x="140" y="648" width="14" height="14" rx="3" fill="rgba(91,111,0,0.08)" stroke="#5b6f00" stroke-width="1.2"/>
+      <text x="162" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">system of record</text>
+
+      <rect x="340" y="648" width="14" height="14" rx="3" fill="#ffffff" stroke="#141414" stroke-width="1"/>
+      <text x="362" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">run-once worker</text>
+
+      <rect x="540" y="648" width="14" height="14" rx="3" fill="rgba(20,20,20,0.05)" stroke="#505050" stroke-width="1"/>
+      <text x="562" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">outbox table</text>
+
+      <rect x="720" y="648" width="14" height="14" rx="3" fill="rgba(20,20,20,0.03)" stroke="rgba(20,20,20,0.30)" stroke-width="1"/>
+      <text x="742" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">external service</text>
+
+      <line x1="920" y1="655" x2="946" y2="655" stroke="#505050" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+      <text x="954" y="659" fill="#505050" font-size="9" font-family="'Geist Mono', monospace">same transaction</text>
+    </svg>


### PR DESCRIPTION
## Summary
- Replace the six Mermaid fences in `docs/architecture.md` with exported, editorial diagram-design SVGs (`docs/diagrams/*.svg`); the `.html` sources are kept alongside for future edits.
- Two of the three flowcharts (system shape, ecosystem) and the repository diagram were over the type's node/edge budget in the original Mermaid, so they're collapsed to fit — each image's alt text and a caption note in the doc call out what was folded (see the PR diff for specifics).
- Add a project-bound diagram-design profile (`.diagram-design` → `freehire` profile in `~/.diagram-design/profiles/`) carrying freehire's oats-green brand tokens, extracted from `design-system/tokens/color.tokens.json` / `color-dark.tokens.json`, so future diagrams in this repo inherit the same skin instead of the tool's default palette.

## Test plan
- [x] `python3 <diagram-design skill>/scripts/self_check.py` passes on all six `docs/diagrams/*.html` sources
- [x] Each exported `.svg` parses as well-formed XML
- [x] Diffed `docs/architecture.md` against `origin/main` before editing to confirm a clean, drift-free transplant
- [ ] Visual review of the six diagrams (rendered SVGs) by a human — recommended before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Replaced architecture diagrams with clearer, referenced SVG visuals and concise captions.
  - Added standalone diagrams covering system architecture, repository structure, ecosystem relationships, job search, CV tailoring, and assistant interactions.
  - Improved diagram accessibility with semantic metadata, legends, responsive layouts, and explanatory labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->