### PR TITLE
Add Integrations tab; how-it-works page with a live sources animation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -16,23 +16,33 @@ Base URL: `https://freehire.me/api/v1`
 - [Jobs](#jobs)
 - [AI analysis](#ai-analysis)
 - [Companies](#companies)
+- [Geography](#geography)
+- [Company feedback](#company-feedback)
 - [Authentication](#authentication)
 - [API keys](#api-keys)
 - [Job interactions](#job-interactions)
+- [In-app assistant](#in-app-assistant)
 - [Job submissions](#job-submissions)
 - [Job reports](#job-reports)
+- [Ghost job reports](#ghost-job-reports)
 - [Moderator jobs](#moderator-jobs)
 - [Profile & résumé](#profile-r-sum)
+- [Screening answers](#screening-answers)
 - [Activity & shared boards](#activity-shared-boards)
 - [Saved searches & subscriptions](#saved-searches-subscriptions)
+- [Push notifications & alerts](#push-notifications-alerts)
 - [Account, credits & extension](#account-credits-extension)
 - [Link intake & discovery](#link-intake-discovery)
 - [Votes, notifications & discussions](#votes-notifications-discussions)
 - [Market insights & stats](#market-insights-stats)
+- [Market pulse](#market-pulse)
 - [Employee referrals](#employee-referrals)
+- [Talent Network](#talent-network)
 - [CV builder & tailoring](#cv-builder-tailoring)
+- [Photo](#photo)
 - [Experience bank](#experience-bank)
 - [Application mail](#application-mail)
+- [Speech](#speech)
 
 ## Base URL
 
@@ -70,7 +80,7 @@ Endpoints marked “Session or API key” accept either; endpoints marked “Ses
 
 ## What is not here
 
-This reference covers every endpoint you can call. A handful are deliberately left out because calling them directly is meaningless: the Gmail consent redirect (`/me/gmail/connect` and its callback), which only a browser can complete; the Telegram bot webhook; the browser-tool websocket relay; and the sitemap-cursor helpers behind `/sitemap.xml`.
+This reference covers every endpoint you can call. A handful are deliberately left out because calling them directly is meaningless: the Gmail and calendar consent redirects (`/me/gmail/connect`, `/me/calendar/connect`, and their callbacks), which only a browser can complete; the Telegram bot webhook and the Discord interaction webhook; the browser-tool websocket relay; the sitemap-cursor helpers behind `/sitemap.xml`; and the `/og/*.png` social-preview cards, which render an image rather than answer with JSON.
 
 The `/jobs/{slug}/fit` endpoints are pre-rename aliases of `/jobs/{slug}/match-analysis` and hit the same handlers. They still work, so existing clients do not break — use the match-analysis paths in new code.
 
@@ -83,8 +93,10 @@ These parameters apply to `GET /jobs/search` and `GET /jobs/facets`. Combine any
 - Pass multiple values as a comma-separated list to OR them: `skills=go,rust` matches either. Repeating the param (`skills=go&skills=rust`) also works.
 - Add `<param>_mode=and` to require all selected values: `skills=go,rust&skills_mode=and` matches both.
 - Add `<param>_exclude=<value>` to exclude matches: `company_type_exclude=outstaff` drops outstaff jobs.
-- Different facets are ANDed together; numeric and boolean filters are ANDed too.
+- Different facets are ANDed together; numeric and boolean filters are ANDed too. The geography facets are the one exception — see below.
+- Geography is a single OR group: `regions`, `countries` and `cities` widen each other instead of narrowing. `regions=eu&countries=IT` means "in Europe **or** in Italy", so it returns everything `regions=eu` alone would. To search one country, drop the region: `countries=IT`. The three name a single concept — *where* — so picking two places reads as "either", which is what makes `regions=eu&countries=BR` ("Europe or Brazil") useful. There is no AND to switch on: `_mode=and` does not apply to geography.
 - Use `regions=none` to match jobs with no resolved geography (an empty region set); it ORs with real region values and supports `_exclude` like any region.
+- A param no filter reads is ignored rather than refused — so old links and saved searches keep working — and comes back in `meta.ignored_params`, with `did_you_mean` when it is only the singular of a real facet. Check it: a dropped filter otherwise looks like a genuinely broad result. At most 10 are listed per response. The same report rides on `/jobs/facets`, `/market/coverage` and `/companies`, which answer `{"data": ...}` and grow a `meta` block only when there is something to warn about. `/companies` filters on its own vocabulary, so a jobs facet sent there is reported as ignored.
 
 ### Facets
 
@@ -130,6 +142,7 @@ Every facet below supports repeat-OR, `_mode=and`, and `_exclude` as described a
 
 - **Senior Go, remote, in the CIS region** — `q=go&seniority=senior&work_mode=remote&regions=cis`
 - **Backend roles, freshest first, in Germany** — `category=backend&countries=DE&sort=posted_at&order=desc`
+- **One country only — no region param, or it widens back out** — `countries=IT&employment_type=contract`
 - **Must use both Go and Rust** — `skills=go,rust&skills_mode=and`
 - **Exclude outstaff companies** — `company_type_exclude=outstaff`
 - **At least $100k, with visa sponsorship** — `salary_currency=USD&salary_min=100000&visa_sponsorship=true`
@@ -222,7 +235,7 @@ curl "https://freehire.me/api/v1/jobs?limit=20&offset=0"
 
 Full-text + faceted search over open jobs.
 
-Combine free-text `q` with any of the filter params below. Repeated facet params are ORed; add `<param>_mode=and` to require all, or `<param>_exclude=<value>` to exclude. Without `q`, results default to newest first; with `q`, to relevance.
+Combine free-text `q` with any of the filter params below. Repeated facet params are ORed; add `<param>_mode=and` to require all, or `<param>_exclude=<value>` to exclude. Without `q`, results default to newest first; with `q`, to relevance. A param no filter reads is ignored rather than refused, and listed in `meta.ignored_params` — check it, since a dropped filter otherwise looks like a broad result.
 
 **Query parameters**
 
@@ -397,6 +410,34 @@ curl "https://freehire.me/api/v1/jobs/senior-go-engineer-acme-1a2b/copies"
     }
   ],
   "meta": { "total": 4 }
+}
+```
+
+### `GET /jobs/{slug}/apply-form`
+
+**Auth:** Public
+
+The captured ATS application form for the posting.
+
+The questions a candidate will have to answer, shaped for reading. Only captured for a minority of postings (roughly a sixth of technical ATS platforms are readable at all) — no captured form is a `404`, distinguishable from an unknown slug (also `404`, but at the job lookup rather than the form lookup).
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `slug` | string | yes | The job `public_slug`. (e.g. `senior-go-engineer-acme-1a2b`) |
+
+```bash
+curl "https://freehire.me/api/v1/jobs/senior-go-engineer-acme-1a2b/apply-form"
+```
+
+```json
+{
+  "data": {
+    "provider": "greenhouse",
+    "basics": ["resume", "phone", "linkedin"],
+    "questions": [ { "text": "Why do you want to work here?", "required": true } ]
+  }
 }
 ```
 
@@ -711,6 +752,249 @@ curl "https://freehire.me/api/v1/companies/subindustries"
 { "data": [ { "value": "payments", "count": 42 }, { "value": "developer-tools", "count": 31 } ] }
 ```
 
+## Geography
+
+Public reference data backing search and profile city autocompletes.
+
+### `GET /geo/cities`
+
+**Auth:** Public
+
+Prefix-search city names for autocomplete.
+
+Population-ranked prefix search over the embedded city dictionary, optionally narrowed to one country. A blank `q` returns an empty list.
+
+**Query parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `q` | string | no | Prefix to match. (e.g. `berl`) |
+| `country` | string | no | ISO 3166-1 alpha-2 code to narrow to. (e.g. `DE`) |
+
+```bash
+curl "https://freehire.me/api/v1/geo/cities?q=berl&country=DE"
+```
+
+```json
+{ "data": [ { "value": "Berlin", "country": "DE" } ] }
+```
+
+## Company feedback
+
+Signed-in users leave a 1–5 star rating plus category and text about a company, shown under their site-wide pseudonymous persona (never a user id). Reads are public; writes are cookie-only. A reader can report a specific review, and a moderator can hide it.
+
+### `GET /companies/{slug}/feedback`
+
+**Auth:** Public
+
+List a company's feedback, newest first.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `slug` | string | yes | The company slug. (e.g. `acme`) |
+
+**Query parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `limit` | integer | no | Page size, 1–100. (e.g. `20`) |
+| `offset` | integer | no | Rows to skip. (e.g. `0`) |
+
+```bash
+curl "https://freehire.me/api/v1/companies/acme/feedback"
+```
+
+```json
+{
+  "data": [
+    {
+      "id": 5,
+      "author": "quiet-falcon-42",
+      "rating": 4,
+      "feedback_type": "interview",
+      "body": "Fast process, clear communication.",
+      "created_at": "2026-06-18T09:12:00Z",
+      "updated_at": "2026-06-18T09:12:00Z"
+    }
+  ],
+  "meta": { "total": 12, "limit": 20, "offset": 0 }
+}
+```
+
+### `GET /companies/{slug}/feedback/mine`
+
+**Auth:** Session only
+
+Your own feedback on this company, across every category (empty if none).
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `slug` | string | yes | The company slug. (e.g. `acme`) |
+
+```bash
+curl "https://freehire.me/api/v1/companies/acme/feedback/mine" -b cookies.txt
+```
+
+```json
+{ "data": [ { "id": 5, "author": "quiet-falcon-42", "rating": 4, "feedback_type": "interview", "body": "...", "created_at": "...", "updated_at": "..." } ] }
+```
+
+### `POST /companies/{slug}/feedback`
+
+**Auth:** Session only
+
+Create or overwrite your feedback in one category on a company.
+
+One entry per (user, category): posting again in the same `feedback_type` overwrites your existing review rather than adding a second one. The response's nested `company` field is the freshly recomputed rating count/average, so you can update your own view of the company without a second fetch. `422` on an empty body, `429` past the daily review cap.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `slug` | string | yes | The company slug. (e.g. `acme`) |
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `rating` | integer | yes | 1–5 stars. (e.g. `4`) |
+| `feedback_type` | string | yes | Review category, e.g. `interview`, `culture`, `compensation`. (e.g. `interview`) |
+| `body` | string | yes | Free-text review. (e.g. `Fast process, clear communication.`) |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/companies/acme/feedback" \
+  -b cookies.txt -H 'Content-Type: application/json' \
+  -d '{"rating":4,"feedback_type":"interview","body":"Fast process, clear communication."}'
+```
+
+```json
+{
+  "data": {
+    "id": 5,
+    "author": "quiet-falcon-42",
+    "rating": 4,
+    "feedback_type": "interview",
+    "body": "Fast process, clear communication.",
+    "created_at": "2026-06-18T09:12:00Z",
+    "updated_at": "2026-06-18T09:12:00Z",
+    "company": { "feedback_count": 12, "feedback_rating_avg": 4.1 }
+  }
+}
+```
+
+### `DELETE /companies/{slug}/feedback`
+
+**Auth:** Session only
+
+Delete your feedback in one category (no-op if absent).
+
+Returns the company's freshly recomputed counters, the same cast/clear shape as the vote endpoints.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `slug` | string | yes | The company slug. (e.g. `acme`) |
+
+**Query parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `feedback_type` | string | yes | Which category to delete. (e.g. `interview`) |
+
+```bash
+curl -X DELETE "https://freehire.me/api/v1/companies/acme/feedback?feedback_type=interview" -b cookies.txt
+```
+
+```json
+{ "data": { "feedback_count": 11, "feedback_rating_avg": 4.0 } }
+```
+
+### `POST /company-feedback/{id}/report`
+
+**Auth:** Session only
+
+Report a specific review.
+
+A second report of the same review by you is a silent no-op.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | integer | yes | The feedback entry id. (e.g. `5`) |
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `reason` | string | yes | Report reason code. (e.g. `spam`) |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/company-feedback/5/report" \
+  -b cookies.txt -H 'Content-Type: application/json' \
+  -d '{"reason":"spam"}'
+```
+
+```json
+(204 No Content)
+```
+
+### `GET /company-feedback/reported`
+
+**Auth:** Moderator
+
+Every review with at least one report, most-reported first.
+
+```bash
+curl "https://freehire.me/api/v1/company-feedback/reported" -H "Authorization: Bearer $MODERATOR_API_KEY"
+```
+
+```json
+{
+  "data": [
+    {
+      "id": 5,
+      "author": "quiet-falcon-42",
+      "rating": 1,
+      "feedback_type": "culture",
+      "body": "...",
+      "created_at": "...",
+      "updated_at": "...",
+      "company_slug": "acme",
+      "report_count": 3,
+      "report_reasons": ["spam", "off-topic"]
+    }
+  ]
+}
+```
+
+### `POST /company-feedback/{id}/hide`
+
+**Auth:** Moderator
+
+Hide a review, dropping it from the company's public list and average.
+
+Idempotent. 404 for an unknown id.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | integer | yes | The feedback entry id. (e.g. `5`) |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/company-feedback/5/hide" -H "Authorization: Bearer $MODERATOR_API_KEY"
+```
+
+```json
+(204 No Content)
+```
+
 ## Authentication
 
 Register/login set the session cookie and return the user. Logout clears it. `me` resolves the caller (cookie or API key). OAuth sign-in is a redirect flow. Credential endpoints are rate-limited.
@@ -822,6 +1106,162 @@ Browser-only: redirects to the provider, then back to `/auth/oauth/{provider}/ca
 ```bash
 # open in a browser:
 https://freehire.me/api/v1/auth/oauth/google/start
+```
+
+### `POST /auth/verify/request`
+
+**Auth:** Session only
+
+Send (or resend) a six-digit email verification code.
+
+Mails a fresh code to the caller’s own address, never a body field. Returns `202 Accepted`. `409` if the address is already confirmed.
+
+```bash
+curl -X POST "https://freehire.me/api/v1/auth/verify/request" -b cookies.txt
+```
+
+### `POST /auth/verify/confirm`
+
+**Auth:** Session only
+
+Confirm the address with the mailed code.
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `code` | string | yes | The six-digit code mailed to your address. (e.g. `123456`) |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/auth/verify/confirm" \
+  -H 'Content-Type: application/json' -b cookies.txt \
+  -d '{"code":"123456"}'
+```
+
+```json
+{ "data": { "id": 1, "email": "me@example.com", "role": "user", "...": "..." } }
+```
+
+### `POST /auth/password/forgot`
+
+**Auth:** Public
+
+Request a password-reset code by email.
+
+Always answers `202`, whether or not the address has an account — this is deliberately not an email-enumeration oracle.
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `email` | string | yes | Account email. (e.g. `me@example.com`) |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/auth/password/forgot" \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"me@example.com"}'
+```
+
+### `POST /auth/password/reset`
+
+**Auth:** Public
+
+Set a new password against a mailed code.
+
+Public — the code is the credential. Success revokes every existing session, so sign in fresh with the new password afterward.
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `email` | string | yes | Account email. (e.g. `me@example.com`) |
+| `code` | string | yes | The mailed reset code. (e.g. `123456`) |
+| `password` | string | yes | New password. |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/auth/password/reset" \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"me@example.com","code":"123456","password":"hunter2hunter2"}'
+```
+
+```json
+{ "data": { "reset": true } }
+```
+
+### `POST /auth/logout-all`
+
+**Auth:** Session only
+
+Sign out every session on the account, including this one.
+
+Bumps the account’s session generation (stranding every issued token and API-key session state) then clears the caller’s cookie. Cookie-only — an API key must not be able to sign a human out of their browser. Returns `204 No Content`.
+
+```bash
+curl -X POST "https://freehire.me/api/v1/auth/logout-all" -b cookies.txt
+```
+
+### `POST /auth/oauth/exchange`
+
+**Auth:** Public
+
+Redeem a mobile OAuth callback code for a session.
+
+Mobile-only: the app’s custom-scheme OAuth callback carries a single-use code (not the session directly); this exchanges it for the session cookie, landing in the app’s own cookie jar. Public — the code is the credential, and a missing/expired/reused one is a `401`.
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `code` | string | yes | The one-time code from the mobile callback redirect. |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/auth/oauth/exchange" \
+  -H 'Content-Type: application/json' -c cookies.txt \
+  -d '{"code":"..."}'
+```
+
+```json
+{ "data": { "id": 1, "email": "me@example.com", "role": "user" } }
+```
+
+### `GET /auth/extension/connect`
+
+**Auth:** Browser extension only
+
+Consent screen for "Sign in with freehire" from the browser extension.
+
+Opened by the extension via `chrome.identity.launchWebAuthFlow`, not called directly — renders an HTML consent page, not JSON. `redirect_uri` must be an allowlisted `https://<extension-id>.chromiumapp.org` origin, or this is a `400`. A signed-out visitor is bounced through sign-in first, then back to this same consent step.
+
+**Query parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `redirect_uri` | string | yes | The allowlisted chromiumapp.org redirect the extension is listening on. |
+| `state` | string | no | Opaque value echoed back on completion. |
+
+```bash
+# opened by the extension, not called directly:
+https://freehire.me/api/v1/auth/extension/connect?redirect_uri=https://<extension-id>.chromiumapp.org/&state=...
+```
+
+### `POST /auth/extension/connect`
+
+**Auth:** Browser extension only
+
+Submit the consent decision and mint the extension’s session token.
+
+Submitted by the consent screen’s own form, not called directly. On `decision=allow`, 302-redirects to `redirect_uri` with a session token in the URL fragment (never the query, so it is never logged or sent to a server); on anything else, redirects with `error=access_denied`. Not a JSON endpoint.
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `redirect_uri` | string | yes | Must match the allowlisted redirect validated on the GET step. |
+| `state` | string | no | Opaque value echoed back. |
+| `decision` | string | yes | `allow` or `cancel`. (e.g. `allow`) |
+
+```bash
+# submitted by the consent page's own form, not called directly
 ```
 
 ## API keys
@@ -1050,6 +1490,78 @@ curl -X DELETE "https://freehire.me/api/v1/jobs/<slug>/track" -H "Authorization:
 
 ```json
 { "data": { "ok": true } }
+```
+
+### `PATCH /me/applications/{id}`
+
+**Auth:** Session or API key
+
+Set the application stage and/or notes, addressed by row id.
+
+Same as `PATCH /jobs/{slug}/track`, but addressed by the tracking-board row id instead of the job slug — needed when a tracked application’s posting was later pruned and has no slug left to address it by. Same `stage` vocabulary and body shape.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | integer | yes | The tracking row id (from `/me/tracking`). (e.g. `42`) |
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `stage` | string | no | Application stage. (e.g. `interview`) |
+| `notes` | string | no | Free-text notes. |
+
+```bash
+curl -X PATCH "https://freehire.me/api/v1/me/applications/42" \
+  -H "Authorization: Bearer $FREEHIRE_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"stage":"interview"}'
+```
+
+```json
+{ "data": { "job_id": 42, "stage": "interview", "notes": null } }
+```
+
+### `DELETE /me/applications/{id}`
+
+**Auth:** Session or API key
+
+Remove the interaction record entirely, addressed by row id.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | integer | yes | The tracking row id. (e.g. `42`) |
+
+```bash
+curl -X DELETE "https://freehire.me/api/v1/me/applications/42" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+```
+
+```json
+{ "data": { "ok": true } }
+```
+
+### `DELETE /me/applications/{id}/stage`
+
+**Auth:** Session or API key
+
+Clear the application stage, addressed by row id.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | integer | yes | The tracking row id. (e.g. `42`) |
+
+```bash
+curl -X DELETE "https://freehire.me/api/v1/me/applications/42/stage" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+```
+
+```json
+{ "data": { "job_id": 42, "stage": null } }
 ```
 
 ### `POST /jobs/{slug}/dismiss`
@@ -1321,6 +1833,297 @@ curl "https://freehire.me/api/v1/me/timeline?from=2026-08-01T00:00:00Z&to=2026-0
 }
 ```
 
+### `GET /me/interviews`
+
+**Auth:** Session or API key
+
+Arranged meetings whose start falls in the date range.
+
+The calendar’s second layer beside `/me/timeline`: a meeting is arranged and can move or be cancelled, unlike a ledger event which happened and cannot change. `status` is `suggested`, `confirmed`, or `cancelled` — a cancelled meeting is still served, not withheld. Both bounds are required, RFC3339.
+
+**Query parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `from` | string (RFC3339) | yes | Lower bound, inclusive. (e.g. `2026-08-01T00:00:00Z`) |
+| `to` | string (RFC3339) | yes | Upper bound, inclusive. (e.g. `2026-08-31T23:59:59Z`) |
+
+```bash
+curl "https://freehire.me/api/v1/me/interviews?from=2026-08-01T00:00:00Z&to=2026-08-31T23:59:59Z" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+```
+
+```json
+{
+  "data": [
+    {
+      "id": 3,
+      "application_id": 31,
+      "starts_at": "2026-08-20T13:00:00Z",
+      "ends_at": "2026-08-20T13:30:00Z",
+      "title": "Interview with Acme",
+      "join_url": "https://meet.example.com/abc",
+      "status": "confirmed",
+      "company_slug": "acme",
+      "role_title": "Senior Go Engineer",
+      "job_slug": "senior-go-engineer-acme-1a2b"
+    }
+  ],
+  "meta": { "from": "2026-08-01T00:00:00Z", "to": "2026-08-31T23:59:59Z", "count": 1 }
+}
+```
+
+## In-app assistant
+
+The same agent the web app and browser extension chat with, over HTTP: create a conversation, then post messages to it. All routes accept the session cookie or an API key (`autopilot` is cookie-only — see below) and act on a session you own; someone else’s session id answers `404`, same as one that never existed. Turns run one at a time per session — a message sent while one is already running queues rather than running alongside it. `preset` selects which conversation this is: `chat` (default), `profile` (the experience interviewer), `browse` (a browsing session held from the extension’s side panel), `interview` (a mock-interview rehearsal) or `debrief` (after a real one) — the last two must name the vacancy via `?job=<slug>`, an application you already hold. A `tailor` session cannot be created here; it is minted by the CV tailoring bootstrap, which knows the CV and vacancy to bind it to.
+
+### `POST /assistant/sessions`
+
+**Auth:** Session or API key
+
+Start a new conversation.
+
+**Query parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `preset` | string | no | One of `chat` (default), `profile`, `browse`, `interview`, `debrief`. (e.g. `chat`) |
+| `job` | string | no | Public slug of an application you hold. Required for `interview`/`debrief`, ignored otherwise. (e.g. `senior-go-engineer-acme-1a2b`) |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/assistant/sessions?preset=chat" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+```
+
+```json
+{ "data": { "id": "b2f1c2b0-6e2a-4c9e-9c2e-0a1b2c3d4e5f", "preset": "chat", "label": "" } }
+```
+
+### `GET /assistant/sessions`
+
+**Auth:** Session or API key
+
+List your chat conversations, newest activity first.
+
+Tailoring conversations are not chats — each belongs to a CV — so they never appear here.
+
+```bash
+curl "https://freehire.me/api/v1/assistant/sessions" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+```
+
+```json
+{
+  "data": [
+    { "id": "b2f1c2b0-6e2a-4c9e-9c2e-0a1b2c3d4e5f", "preset": "chat", "label": "Relocating to Berlin?" }
+  ],
+  "meta": { "total": 1 }
+}
+```
+
+### `GET /assistant/sessions/{id}`
+
+**Auth:** Session or API key
+
+One owned conversation with its full transcript.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string (UUID) | yes | The session id. (e.g. `b2f1c2b0-6e2a-4c9e-9c2e-0a1b2c3d4e5f`) |
+
+```bash
+curl "https://freehire.me/api/v1/assistant/sessions/<id>" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+```
+
+```json
+{
+  "data": {
+    "session": { "id": "b2f1c2b0-6e2a-4c9e-9c2e-0a1b2c3d4e5f", "preset": "chat", "label": "Relocating to Berlin?" },
+    "messages": [
+      { "seq": 1, "role": "user", "content": { "text": "Should I relocate for this role?" } },
+      { "seq": 2, "role": "assistant", "content": { "text": "...", "...": "..." } }
+    ]
+  }
+}
+```
+
+### `DELETE /assistant/sessions/{id}`
+
+**Auth:** Session or API key
+
+Delete an owned conversation and its transcript.
+
+Returns `204 No Content`.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string (UUID) | yes | The session id. |
+
+```bash
+curl -X DELETE "https://freehire.me/api/v1/assistant/sessions/<id>" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+```
+
+### `POST /assistant/sessions/{id}/messages`
+
+**Auth:** Session or API key
+
+Send a message and stream the turn as Server-Sent Events.
+
+Body is `{"text": "..."}` (max ~8000 characters, deployment-configured). The response is `text/event-stream`, not JSON: each frame is `event: <kind>` plus a `data:` line carrying the JSON event (whose own `type` field repeats the kind). Kinds: `queued` (this turn waited for one already running), `user_prompt`, `assistant_text` / `assistant_thought` (streamed deltas), `tool_use` / `tool_result`, `usage`, and exactly one terminal `result` carrying `stop_reason` (`completed`, `cancelled`, or `error`). The turn keeps running even if you stop reading — stopping it is a separate call to `.../cancel`.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string (UUID) | yes | The session id. |
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `text` | string | yes | Your message. (e.g. `Should I relocate for this role?`) |
+
+```bash
+curl -N -X POST "https://freehire.me/api/v1/assistant/sessions/<id>/messages" \
+  -H "Authorization: Bearer $FREEHIRE_API_KEY" -H 'Content-Type: application/json' \
+  -d '{"text":"Should I relocate for this role?"}'
+```
+
+```json
+event: user_prompt
+data: {"type":"user_prompt","text":"Should I relocate for this role?"}
+
+event: assistant_text
+data: {"type":"assistant_text","text":"Based on the salary range..."}
+
+event: result
+data: {"type":"result","stop_reason":"completed"}
+
+
+```
+
+### `POST /assistant/sessions/{id}/cancel`
+
+**Auth:** Session or API key
+
+Stop the session’s running turn.
+
+A no-op (still `204`) when nothing is running — you cannot see whether a turn is live before asking.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string (UUID) | yes | The session id. |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/assistant/sessions/<id>/cancel" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+```
+
+### `POST /assistant/sessions/{id}/opening`
+
+**Auth:** Session or API key
+
+Have the assistant speak first, on an `interview`/`debrief` session.
+
+Streams one turn under a server-side brief (no body), the same SSE shape as `.../messages`. `409` if the session’s preset does not open by itself, or if it already has an assistant message (an opening cannot be re-run).
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string (UUID) | yes | The session id. |
+
+```bash
+curl -N -X POST "https://freehire.me/api/v1/assistant/sessions/<id>/opening" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+```
+
+### `POST /assistant/sessions/{id}/retry`
+
+**Auth:** Session or API key
+
+Resume after a failed turn, without adding another user message.
+
+Re-runs the loop over the existing history (no body) — the same SSE shape as `.../messages`. `409 "nothing to retry"` when the session has no prior user message.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string (UUID) | yes | The session id. |
+
+```bash
+curl -N -X POST "https://freehire.me/api/v1/assistant/sessions/<id>/retry" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+```
+
+### `POST /assistant/sessions/{id}/voice-token`
+
+**Auth:** Session or API key
+
+Mint a short-lived credential for a hands-free voice call.
+
+Only on an `interview` session; `409` otherwise. Rate-limited to 20 calls started per hour per caller. The audio itself never reaches this server: take the returned `value` to `calls_url` (this deployment’s own realtime gateway, not api.openai.com directly) to negotiate the WebRTC call. `501` when voice mode is not configured.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string (UUID) | yes | The session id. |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/assistant/sessions/<id>/voice-token" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+```
+
+```json
+{ "data": { "value": "ek_...", "model": "gpt-realtime", "calls_url": "https://freehire.me/api/v1/realtime/calls" } }
+```
+
+### `POST /assistant/sessions/{id}/voice-turns`
+
+**Auth:** Session or API key
+
+Append one completed spoken exchange to the transcript.
+
+Only on an `interview` session. Lets a call continued by typing carry the spoken turns forward in context. Returns `204 No Content`.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string (UUID) | yes | The session id. |
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `role` | string | yes | `user` or `assistant`. (e.g. `user`) |
+| `content` | string | yes | The transcribed/spoken text. |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/assistant/sessions/<id>/voice-turns" \
+  -H "Authorization: Bearer $FREEHIRE_API_KEY" -H 'Content-Type: application/json' \
+  -d '{"role":"user","content":"I led the migration to Kubernetes."}'
+```
+
+### `POST /assistant/sessions/{id}/autopilot`
+
+**Auth:** Session only
+
+Run an unattended CV-tailoring pass as one long streamed turn.
+
+Session-only, not API-key — an unattended run edits a CV, and the browser is the only place you can watch it happen and undo it. Requires a `tailor` session bound to both a CV and a vacancy (`409` otherwise). Same SSE shape as `.../messages`, no body; every edit lands in one revision batch, so undoing the run is reverting that batch.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string (UUID) | yes | The session id. |
+
+```bash
+curl -N -X POST "https://freehire.me/api/v1/assistant/sessions/<id>/autopilot" -b cookies.txt
+```
+
 ## Job submissions
 
 Any signed-in user can submit a vacancy for moderation and read their own queue. The review actions are moderator-only; approval mints a live job.
@@ -1353,6 +2156,30 @@ curl -X POST "https://freehire.me/api/v1/submissions" \
 
 ```json
 { "data": { "id": 9, "status": "pending", "title": "Senior Go Engineer", "company": "Acme", "url": "https://acme.com/careers/123" } }
+```
+
+### `POST /submissions/prefill`
+
+**Auth:** Session or API key
+
+Parse a job URL into a draft submission for review before posting.
+
+Uses the same ATS-recognition registry as `/jobs/resolve`, but writes nothing — no job, no submission, no credit. An unrecognized URL returns an empty object rather than an error. Rate-limited (shares the outbound-fetch budget).
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `url` | string | yes | The job posting URL to parse. |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/submissions/prefill" \
+  -H "Authorization: Bearer $FREEHIRE_API_KEY" -H 'Content-Type: application/json' \
+  -d '{"url":"https://boards.greenhouse.io/acme/jobs/123"}'
+```
+
+```json
+{ "data": { "title": "Senior Go Engineer", "company": "Acme", "location": "Remote — EU", "description": "...", "work_mode": "remote", "employment_type": "full_time", "seniority": "senior", "skills": ["go"], "source": "greenhouse" } }
 ```
 
 ### `GET /me/submissions`
@@ -1540,6 +2367,62 @@ curl -X POST "https://freehire.me/api/v1/reports/3/dismiss" \
 
 ```json
 { "data": { "id": 3, "status": "dismissed", "review_reason": "not an issue" } }
+```
+
+## Ghost job reports
+
+One person states they applied to a posting and were never answered, feeding the ghost-signal evidence used elsewhere in the API (see the `reality` field on a job). Distinct from Job reports above: nothing here reaches a moderator and nothing here closes the job directly.
+
+### `POST /jobs/{slug}/ghost-report`
+
+**Auth:** Session or API key
+
+File a claim that you applied and got no response.
+
+An unproven (unverified) address is a `403`; a closed job or a claim you already have on this job is a `409`; past the daily cap is a `429`.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `slug` | string | yes | The job `public_slug`. |
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `applied_on` | string | yes | The day you applied (`YYYY-MM-DD`). (e.g. `2026-07-29`) |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/jobs/<slug>/ghost-report" \
+  -H "Authorization: Bearer $FREEHIRE_API_KEY" -H 'Content-Type: application/json' \
+  -d '{"applied_on":"2026-07-29"}'
+```
+
+```json
+{ "data": { "job_id": 42, "applied_on": "2026-07-29", "created_at": "2026-07-29T10:00:00Z" } }
+```
+
+### `DELETE /jobs/{slug}/ghost-report`
+
+**Auth:** Session or API key
+
+Withdraw your claim about this job.
+
+A claim that is absent or already withdrawn is a `404`.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `slug` | string | yes | The job `public_slug`. |
+
+```bash
+curl -X DELETE "https://freehire.me/api/v1/jobs/<slug>/ghost-report" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+```
+
+```json
+(204 No Content)
 ```
 
 ## Moderator jobs
@@ -1819,6 +2702,125 @@ Returns `204 No Content`. `501` when object storage is unconfigured.
 
 ```bash
 curl -X DELETE "https://freehire.me/api/v1/me/resume" -b cookies.txt
+```
+
+### `PUT /me/resume/contacts`
+
+**Auth:** Session only
+
+Override one or more contact-block fields on your profile.
+
+Each body field is owned per field: a value you set here takes over that field from whatever the structured résumé extract would otherwise contribute. Omit a field to leave it as-is; to clear rather than override, use `POST /me/resume/contacts/replace-from-cv`.
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `full_name` | string | no | Overrides the extracted name. |
+| `email` | string | no | Overrides the extracted email. |
+| `phone` | string | no | Overrides the extracted phone. |
+| `location` | string | no | Overrides the extracted location. |
+| `links` | string[] | no | Overrides the extracted links. |
+| `headline` | string | no | A one-line positioning statement. |
+| `summary` | string | no | A short profile summary. |
+| `languages` | string[] | no | Spoken/written languages. |
+| `certifications` | string[] | no | Certifications to show. |
+| `education` | object[] | no | Education entries to show. |
+
+```bash
+curl -X PUT "https://freehire.me/api/v1/me/resume/contacts" -b cookies.txt \
+  -H 'Content-Type: application/json' -d '{"email":"me@work.com","phone":"+1 555 0100"}'
+```
+
+```json
+{ "data": { "full_name": "Jane Doe", "email": "me@work.com", "phone": "+1 555 0100", "location": "Berlin, Germany" } }
+```
+
+### `POST /me/resume/contacts/replace-from-cv`
+
+**Auth:** Session only
+
+Reset every contact override from your current structured résumé.
+
+A full reset, not just identity fields — every owned field is replaced from the current structured extract. `409` when you have no structured résumé to copy from.
+
+```bash
+curl -X POST "https://freehire.me/api/v1/me/resume/contacts/replace-from-cv" -b cookies.txt
+```
+
+```json
+{ "data": { "full_name": "Jane Doe", "email": "jane@example.com", "location": "Berlin, Germany" } }
+```
+
+## Screening answers
+
+The six candidate-stated facts that repeat across ATS application forms and no CV can supply. A singleton per user — no id in the path. `PUT` is a partial update: a field the body omits keeps its stored value.
+
+### `GET /me/screening-answers`
+
+**Auth:** Session or API key
+
+Your stored screening answers, or `null` if you have stated none.
+
+```bash
+curl "https://freehire.me/api/v1/me/screening-answers" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+```
+
+```json
+{
+  "data": {
+    "authorized_countries": ["DE", "NL"],
+    "visa_sponsorship_needed": false,
+    "desired_salary_amount": 90000,
+    "desired_salary_currency": "EUR",
+    "desired_salary_period": "year",
+    "notice_period_days": 30,
+    "willing_to_relocate": true,
+    "age_18_or_older": true
+  }
+}
+```
+
+### `PUT /me/screening-answers`
+
+**Auth:** Session only
+
+Update one or more screening answers.
+
+A field the body omits is left unchanged. An unrecognized country code, a currency that is not a three-letter ISO 4217 code, a period outside the vocabulary, a non-positive salary, or a negative notice period is a `400` naming the invalid value.
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `authorized_countries` | string[] | no | ISO alpha-2 country codes you are authorized to work in. (e.g. `["DE","NL"]`) |
+| `visa_sponsorship_needed` | boolean | no | Whether you need visa sponsorship. |
+| `desired_salary_amount` | integer | no | Desired salary figure. (e.g. `90000`) |
+| `desired_salary_currency` | string | no | Three-letter ISO 4217 currency code. (e.g. `EUR`) |
+| `desired_salary_period` | string | no | Salary period, e.g. `year`, `month`. (e.g. `year`) |
+| `notice_period_days` | integer | no | Notice period in days. (e.g. `30`) |
+| `willing_to_relocate` | boolean | no | Whether you are willing to relocate. |
+| `age_18_or_older` | boolean | no | Whether you are 18 or older. |
+
+```bash
+curl -X PUT "https://freehire.me/api/v1/me/screening-answers" \
+  -b cookies.txt -H 'Content-Type: application/json' \
+  -d '{"willing_to_relocate":true,"notice_period_days":30}'
+```
+
+```json
+{
+  "data": {
+    "authorized_countries": ["DE", "NL"],
+    "visa_sponsorship_needed": false,
+    "desired_salary_amount": 90000,
+    "desired_salary_currency": "EUR",
+    "desired_salary_period": "year",
+    "notice_period_days": 30,
+    "willing_to_relocate": true,
+    "age_18_or_older": true
+  }
+}
 ```
 
 ## Activity & shared boards
@@ -2139,7 +3141,205 @@ curl -X DELETE "https://freehire.me/api/v1/me/telegram" -b cookies.txt
 ```
 
 ```json
-{ "data": { "ok": true } }
+(204 No Content)
+```
+
+### `GET /me/discord`
+
+**Auth:** Session only
+
+Your Discord link status (for the `/contribute` bot command).
+
+```bash
+curl "https://freehire.me/api/v1/me/discord" -b cookies.txt
+```
+
+```json
+{ "data": { "enabled": true, "linked": true, "discord_id": 123456789 } }
+```
+
+### `POST /me/discord/link`
+
+**Auth:** Session only
+
+Mint a one-time token to link your Discord account.
+
+Discord has no deep-link URL equivalent to Telegram’s — paste the returned token into the bot’s `/link` slash command.
+
+```bash
+curl -X POST "https://freehire.me/api/v1/me/discord/link" -b cookies.txt
+```
+
+```json
+{ "data": { "token": "abc123...", "instructions": "In the freehire Discord server, run /link token:abc123..." } }
+```
+
+### `DELETE /me/discord`
+
+**Auth:** Session only
+
+Unlink your Discord account. Idempotent.
+
+```bash
+curl -X DELETE "https://freehire.me/api/v1/me/discord" -b cookies.txt
+```
+
+```json
+(204 No Content)
+```
+
+## Push notifications & alerts
+
+The mobile app’s device push tokens, and the in-app notification center — a durable, channel-independent record of every delivered digest, reminder and nudge. All cookie-only.
+
+### `POST /me/push-tokens`
+
+**Auth:** Session only
+
+Register (or reassign) a mobile device’s Expo push token.
+
+Upserted by token value, not by user: if a different account signs in on the same device, this reassigns the token to the new caller. Returns `204 No Content`.
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `token` | string | yes | The Expo push token minted by the device. (e.g. `ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]`) |
+| `platform` | string | yes | `ios` or `android`. (e.g. `ios`) |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/me/push-tokens" \
+  -H 'Content-Type: application/json' -b cookies.txt \
+  -d '{"token":"ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]","platform":"ios"}'
+```
+
+### `GET /me/push-tokens`
+
+**Auth:** Session only
+
+List your own registered devices.
+
+```bash
+curl "https://freehire.me/api/v1/me/push-tokens" -b cookies.txt
+```
+
+```json
+{
+  "data": [ { "token": "ExponentPushToken[...]", "platform": "ios", "created_at": "2026-06-19T10:00:00Z", "last_seen_at": "2026-06-19T10:00:00Z" } ],
+  "meta": { "total": 1 }
+}
+```
+
+### `DELETE /me/push-tokens`
+
+**Auth:** Session only
+
+Unregister one of your own device tokens.
+
+Returns `204 No Content`. `404` if the token is not yours (or unknown).
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `token` | string | yes | The token to remove. |
+
+```bash
+curl -X DELETE "https://freehire.me/api/v1/me/push-tokens" \
+  -H 'Content-Type: application/json' -b cookies.txt \
+  -d '{"token":"ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]"}'
+```
+
+### `POST /me/push-tokens/test`
+
+**Auth:** Session only
+
+Send a test push to all of your own registered devices.
+
+Never targets another user or a caller-supplied destination — only your own registered tokens. Rate-limited to 20/hour, since each call fans out one outbound send per device.
+
+```bash
+curl -X POST "https://freehire.me/api/v1/me/push-tokens/test" -b cookies.txt
+```
+
+```json
+{ "data": { "devices": 2, "sent": 1, "pruned": 1, "failed": 0 } }
+```
+
+### `GET /me/notifications`
+
+**Auth:** Session only
+
+List your notification-center entries, newest first.
+
+**Query parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `limit` | integer | no | Page size, 1–100. (e.g. `20`) |
+| `offset` | integer | no | Rows to skip. (e.g. `0`) |
+
+```bash
+curl "https://freehire.me/api/v1/me/notifications?limit=20" -b cookies.txt
+```
+
+```json
+{
+  "data": [ { "id": 5, "kind": "subscription_digest", "title": "3 new jobs match Senior Go remote", "body": "...", "public_slug": null, "jobs": [ "...": "..." ], "created_at": "2026-06-19T10:00:00Z", "read_at": null } ],
+  "meta": { "total": 12, "unread_count": 3, "limit": 20, "offset": 0 }
+}
+```
+
+### `GET /me/notifications/{id}`
+
+**Auth:** Session only
+
+One of your notifications, including its jobs snapshot.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | integer | yes | The notification id. (e.g. `5`) |
+
+```bash
+curl "https://freehire.me/api/v1/me/notifications/5" -b cookies.txt
+```
+
+```json
+{ "data": { "id": 5, "kind": "reminder", "title": "...", "body": "...", "public_slug": "senior-go-engineer-acme-1a2b", "created_at": "2026-06-19T10:00:00Z", "read_at": null } }
+```
+
+### `POST /me/notifications/{id}/read`
+
+**Auth:** Session only
+
+Mark one notification read (idempotent).
+
+Returns `204 No Content`.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | integer | yes | The notification id. (e.g. `5`) |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/me/notifications/5/read" -b cookies.txt
+```
+
+### `POST /me/notifications/read-all`
+
+**Auth:** Session only
+
+Mark every unread notification read.
+
+```bash
+curl -X POST "https://freehire.me/api/v1/me/notifications/read-all" -b cookies.txt
+```
+
+```json
+{ "data": { "marked": 3 } }
 ```
 
 ## Account, credits & extension
@@ -2201,6 +3401,22 @@ curl "https://freehire.me/api/v1/me/credits/history" -H "Authorization: Bearer f
 
 ```json
 { "data": [ { "delta": -1, "reason": "match_analysis", "label": "Senior Backend Engineer at Acme", "created_at": "2026-07-28T09:00:00Z" } ] }
+```
+
+### `GET /me/usage`
+
+**Auth:** Session or API key
+
+Your AI request activity this billing period.
+
+Counts and token usage, not cost — the gateway’s dollar figure is a list price against a mixed upstream pool, not what you pay; your price is credits, reported by `/me/credits`. Never fails for a reason you could act on: no usage yet, or an unreachable gateway, both answer 200 with zeroes.
+
+```bash
+curl "https://freehire.me/api/v1/me/usage" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+```
+
+```json
+{ "data": { "requests": 42, "failed": 1, "tokens": 118000, "period": "2026-08", "resets_at": "2026-09-01T00:00:00Z" } }
 ```
 
 ### `GET /me/tracking/{slug}`
@@ -2307,6 +3523,50 @@ curl -X POST "https://freehire.me/api/v1/me/autofill/run" -H "Authorization: Bea
 { "data": { "filled": 11, "skipped": 2 } }
 ```
 
+### `PATCH /me/timezone`
+
+**Auth:** Session only
+
+Set your account’s IANA timezone.
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `timezone` | string | yes | IANA timezone name. (e.g. `Europe/Berlin`) |
+
+```bash
+curl -X PATCH "https://freehire.me/api/v1/me/timezone" \
+  -H 'Content-Type: application/json' -b cookies.txt \
+  -d '{"timezone":"Europe/Berlin"}'
+```
+
+```json
+{ "data": { "id": 1, "email": "me@example.com", "role": "user", "timezone": "Europe/Berlin", "...": "..." } }
+```
+
+### `PATCH /me/language`
+
+**Auth:** Session only
+
+Set your preferred interface language.
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `language` | string | yes | Supported language code. (e.g. `en`) |
+
+```bash
+curl -X PATCH "https://freehire.me/api/v1/me/language" \
+  -H 'Content-Type: application/json' -b cookies.txt \
+  -d '{"language":"en"}'
+```
+
+```json
+{ "data": { "id": 1, "email": "me@example.com", "role": "user", "language": "en", "...": "..." } }
+```
+
 ## Link intake & discovery
 
 Turning a URL in the wild into something freehire knows about. One intake sequence serves every surface — the website, the bot, the extension and the CLI — deliberately, so a pasted link gets the same answer everywhere.
@@ -2372,26 +3632,32 @@ curl "https://freehire.me/api/v1/me/contributions" -H "Authorization: Bearer fhk
 { "data": [ { "url": "https://boards.greenhouse.io/acme", "source": "greenhouse", "board": "acme", "state": "onboarded", "created_at": "2026-07-20T12:00:00Z" } ] }
 ```
 
-### `POST /me/contributions`
+### `POST /me/jd/resolve`
 
-**Auth:** Session or API key
+**Auth:** Session only
 
-Contribute a board by link.
+Turn a URL, pasted text, or an existing job into one usable by CV tailoring.
+
+Exactly one of `job_slug`, `url`, or `text` is required. A recognized URL resolves through the same ATS-aware registry `/jobs/resolve` uses (a network fetch — only the `url` form is rate-limited); an unrecognized URL falls back to a generic scrape; pasted text is stored as a private, unlisted job. Returns the slug the tailor workspace should open — an existing job, or a freshly created private one. `404` for an unknown `job_slug`, `422` for a URL nothing could read.
 
 **Body**
 
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
-| `url` | string | yes | A vacancy or a company's careers page. |
+| `job_slug` | string | no | An existing job’s slug. |
+| `url` | string | no | A job posting URL. |
+| `text` | string | no | Pasted job description text. |
+| `title` | string | no | Optional hint, used only alongside `text`. |
+| `company` | string | no | Optional hint, used only alongside `text`. |
 
 ```bash
-curl -X POST "https://freehire.me/api/v1/me/contributions" \
-  -H "Authorization: Bearer fhk_…" -H 'Content-Type: application/json' \
-  -d '{"url":"https://boards.greenhouse.io/acme"}'
+curl -X POST "https://freehire.me/api/v1/me/jd/resolve" \
+  -H 'Content-Type: application/json' -b cookies.txt \
+  -d '{"url":"https://boards.greenhouse.io/acme/jobs/123"}'
 ```
 
 ```json
-{ "data": { "source": "greenhouse", "board": "acme", "state": "pending" } }
+{ "data": { "job_slug": "senior-go-engineer-acme-1a2b" } }
 ```
 
 ## Votes, notifications & discussions
@@ -2656,6 +3922,32 @@ curl -X POST "https://freehire.me/api/v1/threads/31/close" -b cookies.txt
 
 Aggregate market intelligence, all public and all unauthenticated. Every figure is served from a precomputed rollup rather than counted live, and nothing here exposes a record-level field or a user identifier — these are counts over the catalogue, not a way to read it.
 
+### `GET /stats/catalog`
+
+**Auth:** Public
+
+The headline catalogue-scale figures (open jobs, companies, sources, …).
+
+The canonical numbers behind every "how big is this" figure on the site (the jobs list total, the /about and /open pages). Backed by one snapshot `cmd/rollup-stats` republishes periodically, not a live count. `exact: false` means the cache was cold and the figures fell back to a planner estimate — treat them as approximate when it is false.
+
+```bash
+curl "https://freehire.me/api/v1/stats/catalog"
+```
+
+```json
+{
+  "data": {
+    "open_jobs": 42130,
+    "companies": 6210,
+    "sources": 48,
+    "ats_platforms": 22,
+    "telegram_channels": 340,
+    "computed_at": "2026-06-18T06:00:00Z",
+    "exact": true
+  }
+}
+```
+
 ### `GET /insights/roles`
 
 **Auth:** Public
@@ -2833,6 +4125,39 @@ curl "https://freehire.me/api/v1/status"
 
 ```json
 { "data": { "providers": [ { "source": "greenhouse", "boards": 812, "failing": 14, "last_run_at": "2026-07-28T18:00:00Z" } ] } }
+```
+
+## Market pulse
+
+Your own profile skills’ demand trend, joined against the weekly market snapshot. Cookie-only, unlike the aggregate insights above — this reads your saved profile.
+
+### `GET /me/market-pulse`
+
+**Auth:** Session only
+
+Weekly demand trend for your profile skills.
+
+One entry per profile skill seen in at least one open job; a skill never seen is omitted rather than reported with a zero. `change_pct` is `null` with fewer than two snapshots, or when the earliest snapshot’s count was zero. A profile with no skills yet answers an empty `data` array, not an error.
+
+```bash
+curl "https://freehire.me/api/v1/me/market-pulse" -b cookies.txt
+```
+
+```json
+{
+  "data": [
+    {
+      "skill": "go",
+      "open_count": 640,
+      "change_pct": 12.5,
+      "series": [
+        { "week_start": "2026-07-06", "open_count": 570 },
+        { "week_start": "2026-08-10", "open_count": 640 }
+      ]
+    }
+  ],
+  "meta": { "week_start": "2026-08-10" }
+}
 ```
 
 ## Employee referrals
@@ -3052,6 +4377,77 @@ curl -X POST "https://freehire.me/api/v1/referrals/offers/b71e…/decide" \
 
 ```json
 { "data": { "id": "b71e…", "status": "approved", "decided_at": "2026-07-28T21:00:00Z" } }
+```
+
+## Talent Network
+
+A candidate-controlled public profile page, shareable by URL. The visibility setting lives on `users`, distinct from `user_profiles`.
+
+### `GET /me/talent-network`
+
+**Auth:** Session or API key
+
+Your current Talent Network visibility and shareable id.
+
+A caller who has never touched the setting reads `"off"` — the column default, not a sentinel. `talent_network_public_id` rides along even when visibility is off, so the client can render the shareable URL a candidate would get before they turn it on.
+
+```bash
+curl "https://freehire.me/api/v1/me/talent-network" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+```
+
+```json
+{ "data": { "talent_network_visibility": "public", "talent_network_public_id": "5b1e2b7a-9c3d-4e21-8f0a-1234567890ab" } }
+```
+
+### `PUT /me/talent-network`
+
+**Auth:** Session only
+
+Set your Talent Network visibility.
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `visibility` | string | yes | One of `off`, `public`, `anonymous`. (e.g. `public`) |
+
+```bash
+curl -X PUT "https://freehire.me/api/v1/me/talent-network" \
+  -H 'Content-Type: application/json' -b cookies.txt \
+  -d '{"visibility":"public"}'
+```
+
+```json
+{ "data": { "talent_network_visibility": "public", "talent_network_public_id": "5b1e2b7a-9c3d-4e21-8f0a-1234567890ab" } }
+```
+
+### `GET /talent-network/{publicID}`
+
+**Auth:** Public
+
+The public, shareable Talent Network profile page.
+
+A hidden (`off`) profile and a nonexistent id answer an identical 404 — the route never lets a caller distinguish the two. `full_name` is present only in `public` mode; `anonymous` omits it entirely.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `publicID` | string (uuid) | yes | The candidate’s `talent_network_public_id`. (e.g. `5b1e2b7a-9c3d-4e21-8f0a-1234567890ab`) |
+
+```bash
+curl "https://freehire.me/api/v1/talent-network/5b1e2b7a-9c3d-4e21-8f0a-1234567890ab"
+```
+
+```json
+{
+  "data": {
+    "full_name": "Jane Doe",
+    "specializations": ["backend"],
+    "skills": ["go", "postgresql"],
+    "cv": { "...": "..." }
+  }
+}
 ```
 
 ## CV builder & tailoring
@@ -3415,6 +4811,285 @@ curl -X PUT "https://freehire.me/api/v1/me/cvs/7d1a…/session" -H "Authorizatio
 { "data": { "id": "7d1a…", "agent_session_id": "s_9f…" } }
 ```
 
+### `PUT /me/cvs/{id}/tracer-links`
+
+**Auth:** Session only
+
+Turn link tracing on or off for this CV's PDF.
+
+Off is the default for every CV. Turning it on is refused with a `409` on a deployment with no visitor salt configured — there would be no honest way to count distinct visitors. Turning it off is never refused.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string (uuid) | yes | The CV id. |
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `enabled` | boolean | yes | Turn tracing on or off. |
+
+```bash
+curl -X PUT "https://freehire.me/api/v1/me/cvs/0f2c…/tracer-links" -b cookies.txt \
+  -H 'Content-Type: application/json' -d '{"enabled":true}'
+```
+
+```json
+{ "data": { "tracer_links_enabled": true } }
+```
+
+### `GET /me/cvs/{id}/tracer-links`
+
+**Auth:** Session only
+
+What is known about this CV's traced links.
+
+One entry per link the PDF carries (header links, project links). Clicks you made on your own CV are excluded from the counts; `bot_clicks` is tallied separately rather than folded in. `distinct_visitors` is omitted — not zero — on a deployment with no visitor salt, since there is no honest count to report.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string (uuid) | yes | The CV id. |
+
+```bash
+curl "https://freehire.me/api/v1/me/cvs/0f2c…/tracer-links" -b cookies.txt
+```
+
+```json
+{
+  "data": [
+    {
+      "source_path": "header.links[0]",
+      "destination_url": "https://github.com/you",
+      "traced_url": "https://freehire.me/cv/acme-x7abc",
+      "clicks": 12,
+      "bot_clicks": 3,
+      "distinct_visitors": 9,
+      "last_click_at": "2026-07-20T10:00:00Z"
+    }
+  ]
+}
+```
+
+### `GET /me/cvs/{id}/revisions`
+
+**Auth:** Session only
+
+The edit history of this CV, newest first.
+
+Each entry names what changed and where (`paths`), not the edit itself — the operations carry your own prior text and stay server-side. `undoable` is false for an entry with nothing to reverse (e.g. the CV’s own creation); `reverted` marks an entry already undone rather than removing it from the feed.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string (uuid) | yes | The CV id. |
+
+```bash
+curl "https://freehire.me/api/v1/me/cvs/0f2c…/revisions" -b cookies.txt
+```
+
+```json
+{
+  "data": [
+    {
+      "id": "b1a2…",
+      "actor": "agent",
+      "origin": "tailoring",
+      "batch_id": "f3c1…",
+      "title": "Reframed 2 bullets toward Kafka",
+      "note": "Emphasized event-bus scale to match the requirement",
+      "paths": ["experience[0].bullets[1]"],
+      "reverted": false,
+      "undoable": true,
+      "created_at": "2026-07-28T20:10:00Z"
+    }
+  ]
+}
+```
+
+### `POST /me/cvs/{id}/revisions/{rid}/undo`
+
+**Auth:** Session only
+
+Reverse one revision, leaving later edits in place.
+
+The undo is itself recorded as a new revision. A `409` when the entry has nothing to reverse or the part of the document it changed is already gone.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string (uuid) | yes | The CV id. |
+| `rid` | string (uuid) | yes | The revision id, from the history feed. |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/me/cvs/0f2c…/revisions/b1a2…/undo" -b cookies.txt
+```
+
+```json
+{
+  "data": {
+    "cv": { "id": "0f2c…", "title": "Backend engineer", "template_id": "classic", "created_at": "2026-07-01T10:00:00Z", "updated_at": "2026-07-28T20:15:00Z" },
+    "revision": { "id": "c4d5…", "actor": "user", "origin": "editor", "title": "Undid \"Reframed 2 bullets toward Kafka\"", "reverts_id": "b1a2…", "reverted": false, "undoable": false, "paths": ["experience[0].bullets[1]"], "created_at": "2026-07-28T20:15:00Z" }
+  }
+}
+```
+
+### `POST /me/cvs/{id}/revisions/batch/{bid}/undo`
+
+**Auth:** Session only
+
+Reverse every standing edit of one agent turn, newest first.
+
+`bid` is a revision’s `batch_id` from the history feed, not a separate id — undoing one entry of a batch and then the batch itself is well-defined, since an already-reverted entry is simply skipped.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string (uuid) | yes | The CV id. |
+| `bid` | string (uuid) | yes | The batch id shared by the revisions to undo. |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/me/cvs/0f2c…/revisions/batch/f3c1…/undo" -b cookies.txt
+```
+
+```json
+{ "data": { "id": "0f2c…", "title": "Backend engineer", "template_id": "classic", "created_at": "2026-07-01T10:00:00Z", "updated_at": "2026-07-28T20:16:00Z" } }
+```
+
+### `GET /me/cvs/{id}/ats-delta`
+
+**Auth:** Session only
+
+How tailoring changed this CV's ATS-readiness score.
+
+The tailored copy scored against the base CV it came from, with template, page margins and typography held identical so the difference reflects content alone — the base is a copy rendered with the tailored copy’s formatting, never the stored base itself. Recomputed per request, never stored. `available: false` (with `reason`, no `delta`) when rendering is unavailable rather than an error. `409` when the CV is not a tailored copy, has no base CV to compare against, or its vacancy no longer exists.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string (uuid) | yes | The tailored CV id. |
+
+```bash
+curl "https://freehire.me/api/v1/me/cvs/7d1a…/ats-delta" -b cookies.txt
+```
+
+```json
+{
+  "data": {
+    "available": true,
+    "base_cv_id": "0f2c…",
+    "delta": {
+      "base": 62,
+      "tailored": 78,
+      "change": 16,
+      "categories": [ { "id": "keyword_coverage", "label": "Keyword coverage", "...": "..." } ],
+      "regressed": false
+    }
+  }
+}
+```
+
+### `GET /me/cvs/{id}/job-match`
+
+**Auth:** Session only
+
+How well a tailored CV matches the vacancy it was written for.
+
+Deterministic and free — no model call, unlike the AI match analysis. Scored off the CV’s rendered PDF text layer against the vacancy alone (no base-CV comparison, unlike the ATS delta), so it is cheap enough to refresh after every saved edit. `available: false` when nothing about the vacancy could be matched automatically, or rendering failed. `409` when the CV is not a tailored copy or its vacancy no longer exists.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string (uuid) | yes | The tailored CV id. |
+
+```bash
+curl "https://freehire.me/api/v1/me/cvs/7d1a…/job-match" -b cookies.txt
+```
+
+```json
+{
+  "data": {
+    "available": true,
+    "score": {
+      "overall": 74,
+      "categories": [ { "...": "..." } ],
+      "contributing": ["skills", "requirements"],
+      "matched_skills": ["go", "postgresql"],
+      "missing_skills": ["kubernetes"],
+      "requirements": [ { "text": "5+ years Go", "priority": "required", "cached_status": "covered" } ]
+    }
+  }
+}
+```
+
+## Photo
+
+The one image the CV templates that print a portrait compose in. Cookie-only throughout — the image is PII, so there is no key-authenticated or public path.
+
+### `PUT /me/photo`
+
+**Auth:** Session only
+
+Upload (or replace) your headshot.
+
+Multipart upload of the `file` part — JPEG, PNG, or WebP, capped at 8 MB and rate-limited to 12 uploads/hour. Replaces any existing headshot. `501` when object storage is not configured, `400` for an undecodable, unsupported, or oversized image.
+
+```bash
+curl -X PUT "https://freehire.me/api/v1/me/photo" -b cookies.txt -F "file=@headshot.jpg"
+```
+
+```json
+{ "data": { "enabled": true, "present": true, "uploaded_at": "2026-08-18T10:00:00Z" } }
+```
+
+### `GET /me/photo`
+
+**Auth:** Session only
+
+Whether you have a stored headshot, and when it was uploaded.
+
+`enabled` is false when object storage is not configured — the client should then offer no upload control at all rather than one that answers `501`. `uploaded_at` doubles as a cache-busting value for the image URL.
+
+```bash
+curl "https://freehire.me/api/v1/me/photo" -b cookies.txt
+```
+
+```json
+{ "data": { "enabled": true, "present": false, "uploaded_at": null } }
+```
+
+### `GET /me/photo/image`
+
+**Auth:** Session only
+
+The stored headshot itself, as image bytes.
+
+Not a JSON endpoint — the response is `image/jpeg` with a short private cache lifetime (60s), meant to be busted with `?v=<uploaded_at>`. `404` when no headshot is stored.
+
+```bash
+curl "https://freehire.me/api/v1/me/photo/image" -b cookies.txt -o headshot.jpg
+```
+
+### `DELETE /me/photo`
+
+**Auth:** Session only
+
+Remove your stored headshot.
+
+Returns `204 No Content`.
+
+```bash
+curl -X DELETE "https://freehire.me/api/v1/me/photo" -b cookies.txt
+```
+
 ## Experience bank
 
 The durable record a CV is built from: employments, and the evidence atoms under them. Every atom carries who asserted it — you, or a model that inferred it — and only your own assertions may be written into a CV. Reading accepts an API key; editing is session-only.
@@ -3443,15 +5118,15 @@ Edit one employment.
 
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | integer | yes | The employment id. |
+| `id` | string (uuid) | yes | The employment id. |
 
 ```bash
-curl -X PUT "https://freehire.me/api/v1/me/experience/employments/12" -b cookies.txt \
-  -H 'Content-Type: application/json' -d '{"company":"Acme","title":"Staff Engineer"}'
+curl -X PUT "https://freehire.me/api/v1/me/experience/employments/3fa8…" -b cookies.txt \
+  -H 'Content-Type: application/json' -d '{"company":"Acme","role":"Staff Engineer"}'
 ```
 
 ```json
-{ "data": { "id": 12, "company": "Acme", "title": "Staff Engineer" } }
+{ "data": { "id": "3fa8…", "kind": "job", "company": "Acme", "role": "Staff Engineer" } }
 ```
 
 ### `DELETE /me/experience/employments/{id}`
@@ -3464,10 +5139,10 @@ Remove an employment and its atoms.
 
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | integer | yes | The employment id. |
+| `id` | string (uuid) | yes | The employment id. |
 
 ```bash
-curl -X DELETE "https://freehire.me/api/v1/me/experience/employments/12" -b cookies.txt
+curl -X DELETE "https://freehire.me/api/v1/me/experience/employments/3fa8…" -b cookies.txt
 ```
 
 ### `PUT /me/experience/atoms/{id}`
@@ -3480,15 +5155,15 @@ Edit one evidence atom.
 
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | integer | yes | The atom id. |
+| `id` | string (uuid) | yes | The atom id. |
 
 ```bash
-curl -X PUT "https://freehire.me/api/v1/me/experience/atoms/88" -b cookies.txt \
-  -H 'Content-Type: application/json' -d '{"text":"Cut p99 checkout latency 40% (12k rps)"}'
+curl -X PUT "https://freehire.me/api/v1/me/experience/atoms/88b1…" -b cookies.txt \
+  -H 'Content-Type: application/json' -d '{"claim":"Cut p99 checkout latency 40% (12k rps)"}'
 ```
 
 ```json
-{ "data": { "id": 88, "text": "Cut p99 checkout latency 40% (12k rps)", "source": "manual" } }
+{ "data": { "id": "88b1…", "claim": "Cut p99 checkout latency 40% (12k rps)", "provenance": "manual" } }
 ```
 
 ### `DELETE /me/experience/atoms/{id}`
@@ -3501,15 +5176,200 @@ Remove an evidence atom.
 
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | integer | yes | The atom id. |
+| `id` | string (uuid) | yes | The atom id. |
 
 ```bash
-curl -X DELETE "https://freehire.me/api/v1/me/experience/atoms/88" -b cookies.txt
+curl -X DELETE "https://freehire.me/api/v1/me/experience/atoms/88b1…" -b cookies.txt
+```
+
+### `POST /me/experience/employments`
+
+**Auth:** Session or API key
+
+Record a new place — a job or a project.
+
+An employment carries no claim of its own (only the atoms attached to it do), so nothing about provenance applies here. `kind` is `job` or `project`; a project’s name arrives as `name` on the wire (legacy `company` accepted as a fallback), a job’s as `company`.
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `kind` | string | yes | `job` or `project`. (e.g. `job`) |
+| `company` | string | no | The employer (jobs) — or the project name via `name` (see description). (e.g. `Acme`) |
+| `role` | string | no | Your title. (e.g. `Senior Backend Engineer`) |
+| `location` | string | no | Where you worked. |
+| `start` | string | no | Start date. (e.g. `2023-02`) |
+| `end` | string | no | End date; omit with `current`. |
+| `current` | boolean | no | Still ongoing. |
+| `summary` | string | no | A short description of the role. |
+| `link` | string | no | Outbound URL, for a project. |
+| `stack` | string[] | no | Technologies used, printed on the CV’s per-role stack line. |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/me/experience/employments" \
+  -H "Authorization: Bearer $FREEHIRE_API_KEY" -H 'Content-Type: application/json' \
+  -d '{"kind":"job","company":"Acme","role":"Senior Backend Engineer","start":"2023-02","current":true}'
+```
+
+```json
+{ "data": { "id": "3fa8…", "kind": "job", "company": "Acme", "role": "Senior Backend Engineer", "start": "2023-02", "current": true } }
+```
+
+### `POST /me/experience/atoms`
+
+**Auth:** Session or API key
+
+Record a new achievement.
+
+The only route besides the assistant’s own tool that can add evidence outside a chat session, which is why `provenance` is forced to `manual` regardless of what the body sends — an authenticated POST with no chat transcript behind it can only honestly be the owner’s own words. When the account has opted into requiring it, an empty `context` is a 400.
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `claim` | string | yes | The sentence a CV bullet would carry. (e.g. `Cut p99 checkout latency 40%`) |
+| `employment_id` | string (uuid) | no | The place this achievement belongs under; omit to leave it unplaced. |
+| `context` | string | no | How it was done — raw material for reframing toward a vacancy. |
+| `metrics` | string[] | no | Numbers backing the claim. (e.g. `["12k rps", "40%"]`) |
+| `skills` | string[] | no | Skills this achievement demonstrates. |
+| `source_ref` | string | no | Where this came from, for your own reference. |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/me/experience/atoms" \
+  -H "Authorization: Bearer $FREEHIRE_API_KEY" -H 'Content-Type: application/json' \
+  -d '{"claim":"Cut p99 checkout latency 40%","employment_id":"3fa8…","metrics":["40%","12k rps"]}'
+```
+
+```json
+{ "data": { "id": "88b1…", "employment_id": "3fa8…", "claim": "Cut p99 checkout latency 40%", "metrics": ["40%", "12k rps"], "provenance": "manual" } }
+```
+
+### `POST /me/experience/atoms/merge`
+
+**Auth:** Session only
+
+Fold two of your atoms into one richer keep.
+
+Session-only, unlike its sibling create/edit/delete routes — the merge folds the discarded atom’s metrics and skills into the kept one while the kept one’s own provenance stands, letting a `manual` atom absorb numbers a model had inferred, so it cannot be widened to a key the way the others were.
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `ids` | string[] (2 uuids) | yes | Exactly two atom ids; the first is kept. (e.g. `["88b1…","91c2…"]`) |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/me/experience/atoms/merge" -b cookies.txt \
+  -H 'Content-Type: application/json' -d '{"ids":["88b1…","91c2…"]}'
+```
+
+```json
+{ "data": { "id": "88b1…", "claim": "Cut p99 checkout latency 40% (12k rps)", "metrics": ["40%", "12k rps"], "provenance": "manual" } }
 ```
 
 ## Application mail
 
 Your job mail, and the link between a message and the application it belongs to. Mail arrives three ways: a connected Gmail account, the hosted freehire address, or a batch your own client pushed. Only the first two are classified by freehire — pushed mail is yours to triage, which is what makes that tier free. Everything here takes a full-scope API key, so a harness can drive the whole surface; the Gmail consent redirect is the one exception and stays browser-only.
+
+### `GET /me/tracking/{slug}/followup`
+
+**Auth:** Session or API key
+
+Draft a chase for a silent application.
+
+Offered only when the application is in the silent state the tracking board’s own badge uses — a `409` otherwise. `recipient`/`recipient_name` are omitted when nobody at the company ever replied, which is the common case: the draft is handed to you, nothing is sent.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `slug` | string | yes | The job `public_slug`. |
+
+```bash
+curl "https://freehire.me/api/v1/me/tracking/<slug>/followup" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+```
+
+```json
+{ "data": { "subject": "Following up: Senior Go Engineer application", "body": "Hi …", "recipient": "recruiting@acme.com", "recipient_name": "Acme Recruiting", "days_silent": 12 } }
+```
+
+### `POST /me/tracking/{slug}/followup`
+
+**Auth:** Session or API key
+
+Record that you sent a chase.
+
+Does not itself affect the silence calculation — that reads when the other side last moved, and a chase is not a reply. Idempotent within the hour: a double click overwrites the timestamp rather than logging a second event. Returns `204 No Content`.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `slug` | string | yes | The job `public_slug`. |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/me/tracking/<slug>/followup" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+```
+
+### `POST /me/tracking/{slug}/mail-recall`
+
+**Auth:** Session or API key
+
+Sweep your connected mailbox for mail belonging to this application.
+
+For an application whose mail arrived before you connected an inbox, or that a sync missed. Runs an LLM pass over your mailbox and returns matches as suggestions — it never links or writes the ledger itself; confirm a pick with `POST /me/tracking/{slug}/mail-recall/link`. Rate-limited. A `503` when no mail gateway is configured, a `502` when the model call fails.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `slug` | string | yes | The job `public_slug`. |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/me/tracking/<slug>/mail-recall" -H "Authorization: Bearer $FREEHIRE_API_KEY"
+```
+
+```json
+{
+  "data": {
+    "scanned": 340,
+    "suggested": [
+      { "id": 0, "provider_id": "18f2a…", "from_addr": "recruiting@acme.com", "from_name": "Acme Recruiting", "subject": "Interview invitation", "received_at": "2026-07-15T09:00:00Z", "invitation": true }
+    ],
+    "invitations": 1
+  }
+}
+```
+
+### `POST /me/tracking/{slug}/mail-recall/link`
+
+**Auth:** Session or API key
+
+Import and link one message a mail-recall sweep proposed.
+
+Imports the message from your mailbox by `provider_id` (from a mail-recall response) and links it to the application in one step — the same import-then-link path a Gmail sync uses, so the response is the full message body, the same shape `POST /me/emails/{id}/link` returns.
+
+**Path parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `slug` | string | yes | The job `public_slug`. |
+
+**Body**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `provider_id` | string | yes | The message’s `provider_id`, from a mail-recall response. |
+
+```bash
+curl -X POST "https://freehire.me/api/v1/me/tracking/<slug>/mail-recall/link" \
+  -H "Authorization: Bearer $FREEHIRE_API_KEY" -H 'Content-Type: application/json' \
+  -d '{"provider_id":"18f2a…"}'
+```
+
+```json
+{ "data": { "id": 4822, "subject": "Interview invitation", "linked_slug": "senior-go-engineer-acme-1a2b", "link_source": "manual", "...": "..." } }
+```
 
 ### `GET /me/inbox`
 
@@ -3915,4 +5775,26 @@ curl -X DELETE "https://freehire.me/api/v1/me/gmail" -H "Authorization: Bearer f
 
 ```json
 { "data": { "connected": false } }
+```
+
+## Speech
+
+Turns one recording into text for the assistant composer’s dictation control. Nothing is stored — the audio is read, forwarded to the transcription gateway, and dropped.
+
+### `POST /speech/transcriptions`
+
+**Auth:** Session or API key
+
+Transcribe one short audio recording to text.
+
+Multipart upload of the `file` part — webm, mp4, m4a, ogg, wav, or mp3, capped at ~8 minutes of audio (2 MB) and rate-limited to 60 recordings/hour per caller. `501` when no speech gateway is configured, `502` if the gateway call itself fails, `400` for an empty recording.
+
+```bash
+curl -X POST "https://freehire.me/api/v1/speech/transcriptions" \
+  -H "Authorization: Bearer $FREEHIRE_API_KEY" \
+  -F "file=@dictation.webm"
+```
+
+```json
+{ "data": { "text": "remote go engineer roles in Berlin" } }
 ```

--- a/internal/handler/gmail.go
+++ b/internal/handler/gmail.go
@@ -203,13 +203,14 @@ func (h *inboxHandlers) GmailConnect(c *fiber.Ctx) error {
 
 // GmailCallback finishes the flow: it verifies state, exchanges the code for a
 // refresh token + the connected address, stores the token encrypted, and
-// redirects back to the inbox. Failures redirect with ?gmail_error (never JSON);
-// the underlying cause is logged server-side first (like oauthFail), since the
-// generic redirect marker tells the user nothing.
+// redirects back to the Integrations tab — the surface the connect was started
+// from. Failures redirect with ?gmail_error (never JSON); the underlying cause
+// is logged server-side first (like oauthFail), since the generic redirect
+// marker tells the user nothing.
 func (h *inboxHandlers) GmailCallback(c *fiber.Ctx) error {
 	redirect := func(qs string, err error) error {
 		log.Printf("gmail connect: %s: %v", qs, err)
-		return c.Redirect(h.frontendOrigin+"/my/inbox?"+qs, fiber.StatusFound)
+		return c.Redirect(h.frontendOrigin+"/my/integrations?"+qs, fiber.StatusFound)
 	}
 	userID, ok := auth.UserID(c)
 	if !ok {
@@ -242,7 +243,7 @@ func (h *inboxHandlers) GmailCallback(c *fiber.Ctx) error {
 			return redirect("gmail_error=exchange", err)
 		}
 	}
-	return c.Redirect(h.frontendOrigin+"/my/inbox?gmail=connected", fiber.StatusFound)
+	return c.Redirect(h.frontendOrigin+"/my/integrations?gmail=connected", fiber.StatusFound)
 }
 
 // CalendarConnect starts the calendar consent. Its own state cookie: two flows in flight
@@ -260,12 +261,12 @@ func (h *inboxHandlers) CalendarConnect(c *fiber.Ctx) error {
 // that it now covers the calendar. Failures redirect with ?calendar_error and are logged
 // server-side first, exactly as the mail flow does — the marker tells the user nothing.
 //
-// It lands back on the tracking calendar rather than the inbox: that is the surface the
-// grant was given for.
+// It lands back on Integrations rather than the tracking calendar: that is the surface
+// the connect was started from, same as the mail flow.
 func (h *inboxHandlers) CalendarCallback(c *fiber.Ctx) error {
 	redirect := func(qs string, err error) error {
 		log.Printf("calendar connect: %s: %v", qs, err)
-		return c.Redirect(h.frontendOrigin+"/my/tracking/calendar?"+qs, fiber.StatusFound)
+		return c.Redirect(h.frontendOrigin+"/my/integrations?"+qs, fiber.StatusFound)
 	}
 	userID, ok := auth.UserID(c)
 	if !ok {
@@ -294,7 +295,7 @@ func (h *inboxHandlers) CalendarCallback(c *fiber.Ctx) error {
 			return redirect("calendar_error=exchange", err)
 		}
 	}
-	return c.Redirect(h.frontendOrigin+"/my/tracking/calendar?calendar=connected", fiber.StatusFound)
+	return c.Redirect(h.frontendOrigin+"/my/integrations?calendar=connected", fiber.StatusFound)
 }
 
 // GmailStatus reports whether the caller has connected Gmail.

--- a/internal/handler/gmail.go
+++ b/internal/handler/gmail.go
@@ -189,6 +189,11 @@ const gmailStateCookieName = "hire_gmail_state"
 // one so two consents in flight cannot complete each other.
 const calendarStateCookieName = "hire_calendar_state"
 
+// integrationsPath is where both the mail and calendar OAuth callbacks land, success or
+// failure — the Integrations tab is the one surface that owns connect/disconnect for
+// every third-party account.
+const integrationsPath = "/my/integrations"
+
 // GmailConnect starts the "Connect Gmail" incremental-OAuth flow for the
 // signed-in user: it sets a CSRF state cookie and redirects to Google's consent
 // screen for gmail.readonly.
@@ -210,7 +215,7 @@ func (h *inboxHandlers) GmailConnect(c *fiber.Ctx) error {
 func (h *inboxHandlers) GmailCallback(c *fiber.Ctx) error {
 	redirect := func(qs string, err error) error {
 		log.Printf("gmail connect: %s: %v", qs, err)
-		return c.Redirect(h.frontendOrigin+"/my/integrations?"+qs, fiber.StatusFound)
+		return c.Redirect(h.frontendOrigin+integrationsPath+"?"+qs, fiber.StatusFound)
 	}
 	userID, ok := auth.UserID(c)
 	if !ok {
@@ -243,7 +248,7 @@ func (h *inboxHandlers) GmailCallback(c *fiber.Ctx) error {
 			return redirect("gmail_error=exchange", err)
 		}
 	}
-	return c.Redirect(h.frontendOrigin+"/my/integrations?gmail=connected", fiber.StatusFound)
+	return c.Redirect(h.frontendOrigin+integrationsPath+"?gmail=connected", fiber.StatusFound)
 }
 
 // CalendarConnect starts the calendar consent. Its own state cookie: two flows in flight
@@ -266,7 +271,7 @@ func (h *inboxHandlers) CalendarConnect(c *fiber.Ctx) error {
 func (h *inboxHandlers) CalendarCallback(c *fiber.Ctx) error {
 	redirect := func(qs string, err error) error {
 		log.Printf("calendar connect: %s: %v", qs, err)
-		return c.Redirect(h.frontendOrigin+"/my/integrations?"+qs, fiber.StatusFound)
+		return c.Redirect(h.frontendOrigin+integrationsPath+"?"+qs, fiber.StatusFound)
 	}
 	userID, ok := auth.UserID(c)
 	if !ok {
@@ -295,7 +300,7 @@ func (h *inboxHandlers) CalendarCallback(c *fiber.Ctx) error {
 			return redirect("calendar_error=exchange", err)
 		}
 	}
-	return c.Redirect(h.frontendOrigin+"/my/integrations?calendar=connected", fiber.StatusFound)
+	return c.Redirect(h.frontendOrigin+integrationsPath+"?calendar=connected", fiber.StatusFound)
 }
 
 // GmailStatus reports whether the caller has connected Gmail.
@@ -316,7 +321,12 @@ func (h *inboxHandlers) GmailStatus(c *fiber.Ctx) error {
 		return err
 	}
 	return c.JSON(fiber.Map{"data": fiber.Map{
-		"connected": true, "email": conn.Email, "status": conn.Status, "available": h.gmailReady(),
+		// The row's existence alone does not mean mail is connected: UpsertCalendarGrant
+		// inserts this same row with an empty address for a calendar-only consent (see its
+		// comment, and ListConnectedGmailUsers' matching `email <> ''` guard). Reporting
+		// `connected: true` for that row would show the SPA's Mail card as connected with
+		// no address behind it.
+		"connected": conn.Email != "", "email": conn.Email, "status": conn.Status, "available": h.gmailReady(),
 		// Whether this grant also covers the calendar. Read from the recorded scopes and
 		// not from the row's existence: the two consents are separate, so a connected
 		// mailbox says nothing about the calendar and a calendar grant may have no

--- a/internal/handler/gmail_callback_test.go
+++ b/internal/handler/gmail_callback_test.go
@@ -16,7 +16,7 @@ import (
 
 // The Gmail callback is a top-level browser navigation returning from Google, not
 // an XHR: a caller whose session cookie did not survive the round-trip must land
-// back on the inbox with an error marker, never on a JSON 401 with no way forward.
+// back on Integrations with an error marker, never on a JSON 401 with no way forward.
 // This is the shape the handler was written for — RequireAuth on the route made its
 // own unauthenticated branch unreachable and rendered `{"error":"not authenticated"}`
 // into the browser instead.
@@ -33,7 +33,7 @@ func TestGmailCallbackWithoutSessionRedirectsInsteadOfJSON(t *testing.T) {
 	if resp.StatusCode != fiber.StatusFound {
 		t.Fatalf("status = %d, want %d (a redirect, not a JSON error)", resp.StatusCode, fiber.StatusFound)
 	}
-	if got, want := resp.Header.Get("Location"), frontend+"/my/inbox?gmail_error=auth"; got != want {
+	if got, want := resp.Header.Get("Location"), frontend+"/my/integrations?gmail_error=auth"; got != want {
 		t.Errorf("Location = %q, want %q", got, want)
 	}
 }
@@ -59,7 +59,7 @@ func TestGmailCallbackStateMismatchRedirects(t *testing.T) {
 	if resp.StatusCode != fiber.StatusFound {
 		t.Fatalf("status = %d, want %d", resp.StatusCode, fiber.StatusFound)
 	}
-	if got, want := resp.Header.Get("Location"), frontend+"/my/inbox?gmail_error=state"; got != want {
+	if got, want := resp.Header.Get("Location"), frontend+"/my/integrations?gmail_error=state"; got != want {
 		t.Errorf("Location = %q, want %q", got, want)
 	}
 }

--- a/internal/handler/gmail_integration_test.go
+++ b/internal/handler/gmail_integration_test.go
@@ -112,4 +112,18 @@ func TestGmailInboxEndToEnd(t *testing.T) {
 	if _, body := do("GET", "/api/v1/me/inbox"); func() bool { g, _ := body["data"].([]any); return len(g) != 0 }() {
 		t.Error("inbox not purged after disconnect")
 	}
+
+	// A calendar-only consent (UpsertCalendarGrant) writes the same gmail_connections row
+	// with an empty address — GmailStatus must not report that as Mail connected, or the
+	// SPA's Mail card shows "Connected" with no address behind it.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO gmail_connections (user_id, email, refresh_token_enc, status) VALUES ($1, '', 'enc', 'connected')`, uid); err != nil {
+		t.Fatalf("seed calendar-only connection: %v", err)
+	}
+	if _, body := do("GET", "/api/v1/me/gmail"); func() bool {
+		d, _ := body["data"].(map[string]any)
+		return d["connected"] == true
+	}() {
+		t.Error("calendar-only grant (empty email) reported as Mail connected")
+	}
 }

--- a/web/package.json
+++ b/web/package.json
@@ -30,6 +30,7 @@
     "@tailwindcss/vite": "^4.3.3",
     "@tsconfig/svelte": "^5.0.4",
     "@types/node": "^26.2.0",
+    "@types/three": "^0.185.4",
     "@vite-pwa/sveltekit": "^1.1.0",
     "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^10.8.0",
@@ -65,6 +66,7 @@
     "shiki": "^4.4.3",
     "simple-icons": "^16.28.0",
     "svelte-dnd-action": "^0.9.78",
+    "three": "^0.185.1",
     "workbox-window": "^7.4.1"
   }
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       svelte-dnd-action:
         specifier: ^0.9.78
         version: 0.9.78(svelte@5.56.7(@typescript-eslint/types@8.65.0))
+      three:
+        specifier: ^0.185.1
+        version: 0.185.1
       workbox-window:
         specifier: ^7.4.1
         version: 7.4.1
@@ -84,6 +87,9 @@ importers:
       '@types/node':
         specifier: ^26.2.0
         version: 26.2.0
+      '@types/three':
+        specifier: ^0.185.4
+        version: 0.185.4
       '@vite-pwa/sveltekit':
         specifier: ^1.1.0
         version: 1.1.0(@sveltejs/kit@2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.7(@typescript-eslint/types@8.65.0))(vite@8.1.5(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)))(svelte@5.56.7(@typescript-eslint/types@8.65.0))(typescript@6.0.3)(vite@8.1.5(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)))(vite@8.1.5(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
@@ -716,6 +722,9 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -1889,6 +1898,9 @@ packages:
   '@tsconfig/svelte@5.0.8':
     resolution: {integrity: sha512-UkNnw1/oFEfecR8ypyHIQuWYdkPvHiwcQ78sh+ymIiYoF+uc5H1UBetbjyqT+vgGJ3qQN6nhucJviX6HesWtKQ==}
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -1928,8 +1940,14 @@ packages:
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
   '@types/tern@0.23.9':
     resolution: {integrity: sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==}
+
+  '@types/three@0.185.4':
+    resolution: {integrity: sha512-gAsBIC07NIFrxjbf7tH2t71c38uulFfk/RFoC7FNBSjMRAQ8J1x/RBvusX0N5PJouaYFJawXQqfCQ0RKUx/1nA==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -1939,6 +1957,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@typescript-eslint/eslint-plugin@8.65.0':
     resolution: {integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==}
@@ -2538,6 +2559,9 @@ packages:
 
   fflate@0.7.5:
     resolution: {integrity: sha512-QieYf//cis6ywHNi5qW1+PXPQ4bC+XVJAtS4AXIML8P76GroEiOxm/oQtn1f02UkJY1+KsXMJcC+R2v/Eg4G3g==}
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -3161,6 +3185,9 @@ packages:
     resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
     engines: {node: '>=18.0.0'}
 
+  meshoptimizer@1.1.1:
+    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
+
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
 
@@ -3711,6 +3738,9 @@ packages:
     resolution: {integrity: sha512-CN9BVxWhgS/hRxtUMjtC2uRWSTcSfQFHMDWma6sKKfIivCD91sM+FOPfvwoaRMqCSrUpe1nv3jDamd9eEQ4y+w==}
     engines: {node: '>=10'}
     hasBin: true
+
+  three@0.185.1:
+    resolution: {integrity: sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==}
 
   tiny-glob@0.2.9:
     resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
@@ -4884,6 +4914,8 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
+  '@dimforge/rapier3d-compat@0.12.0': {}
+
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
@@ -5822,6 +5854,8 @@ snapshots:
 
   '@tsconfig/svelte@5.0.8': {}
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -5862,15 +5896,28 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
+  '@types/stats.js@0.17.4': {}
+
   '@types/tern@0.23.9':
     dependencies:
       '@types/estree': 1.0.9
+
+  '@types/three@0.185.4':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      fflate: 0.8.3
+      meshoptimizer: 1.1.1
 
   '@types/trusted-types@2.0.7': {}
 
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/webxr@0.5.24': {}
 
   '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
@@ -6579,6 +6626,8 @@ snapshots:
 
   fflate@0.7.5: {}
 
+  fflate@0.8.3: {}
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -7179,6 +7228,8 @@ snapshots:
       vfile-message: 2.0.4
 
   meriyah@6.1.4: {}
+
+  meshoptimizer@1.1.1: {}
 
   micromark-util-character@2.1.1:
     dependencies:
@@ -7860,6 +7911,8 @@ snapshots:
       acorn: 8.18.0
       commander: 2.20.3
       source-map-support: 0.5.21
+
+  three@0.185.1: {}
 
   tiny-glob@0.2.9:
     dependencies:

--- a/web/src/lib/accountNav.test.ts
+++ b/web/src/lib/accountNav.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { accountNav, isSectionActive, visibleAccountNav } from './accountNav';
 
 describe('accountNav config', () => {
-  it('lists the fourteen account sections', () => {
-    expect(accountNav).toHaveLength(14);
+  it('lists the fifteen account sections', () => {
+    expect(accountNav).toHaveLength(15);
   });
 
   it('offers a security section for password and session management', () => {

--- a/web/src/lib/accountNav.ts
+++ b/web/src/lib/accountNav.ts
@@ -34,6 +34,11 @@ export const accountNav = [
   // The notification center: delivery history, saved-search alerts, and the
   // account-level reminder/nudge settings, as three tabs of one section.
   { href: '/my/notifications', label: 'Notifications' },
+  // Connect/disconnect surface for third-party accounts: Google (Gmail + Calendar),
+  // Telegram (the alert bot, decoupled from any one saved search) and Discord (the
+  // /contribute reward link). Each connection's own domain page keeps a short status
+  // line pointing here instead of duplicating the connect/disconnect UI.
+  { href: '/my/integrations', label: 'Integrations' },
   { href: '/my/api-keys', label: 'API keys' },
   { href: '/my/submissions', label: 'My submissions' },
   // Paste a job link we don't have yet; a supported, novel link earns AI credits.

--- a/web/src/lib/accountNavIcons.ts
+++ b/web/src/lib/accountNavIcons.ts
@@ -20,6 +20,7 @@ import {
   Coins,
   ShieldCheck,
   TrendingUp,
+  Plug,
 } from '@lucide/svelte';
 import type { LucideIcon } from '@lucide/svelte';
 import type { AccountNavItem } from './accountNav';
@@ -34,6 +35,7 @@ export const accountNavIcons: Record<AccountNavItem['href'], LucideIcon> = {
   '/my/inbox': Inbox,
   '/my/market-pulse': TrendingUp,
   '/my/notifications': BellRing,
+  '/my/integrations': Plug,
   '/my/api-keys': Key,
   '/my/submissions': FileText,
   '/my/contributions': Link2,

--- a/web/src/lib/components/Footer.svelte
+++ b/web/src/lib/components/Footer.svelte
@@ -31,6 +31,7 @@
     {
       title: 'Resources',
       links: [
+        { label: 'How it works', href: resolve('/how-it-works') },
         { label: 'Blog', href: resolve('/blog') },
         { label: 'Insights', href: resolve('/insights') },
         { label: 'Hiring signal', href: resolve('/insights/companies') },

--- a/web/src/lib/components/HowItWorksLandingView.svelte
+++ b/web/src/lib/components/HowItWorksLandingView.svelte
@@ -12,17 +12,14 @@
   // narrowing anything. All three are answered by walking one posting through the same
   // five stages the backend runs it through — see docs/architecture.md and the root
   // AGENTS.md, which this page's copy is written from.
-  let {
-    scale,
-  }: { scale: { sources: number | null; atsPlatforms: number | null; companies: number | null } } =
-    $props();
+  let { scale }: { scale: { sources: number | null; companies: number | null } } = $props();
 </script>
 
 <article class="flex flex-col gap-14">
   <header class="flex flex-col items-start gap-5">
     <SectionLabel text="how it works" />
     <h1 class="max-w-2xl text-3xl font-semibold tracking-tight sm:text-4xl">
-      One posting, five steps, before you ever see it.
+      Five steps before a posting reaches you.
     </h1>
     <p class="max-w-xl text-base leading-relaxed text-muted-foreground">
       Crawled, tagged, checked for duplicates, and rebuilt into the index you search —
@@ -35,7 +32,7 @@
   </header>
 
   <!-- The opening thesis, made visual: not one board, a field of them. -->
-  <SourcesField sources={scale.sources} atsPlatforms={scale.atsPlatforms} />
+  <SourcesField sources={scale.sources} companies={scale.companies} />
 
   <!-- The signature: one example posting, followed through all five stages. Its title and
        facts stay the same specific example end to end (StageIllustration's five cards)

--- a/web/src/lib/components/HowItWorksLandingView.svelte
+++ b/web/src/lib/components/HowItWorksLandingView.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
-  import { ArrowRight } from '@lucide/svelte';
   import { Button, SectionLabel } from '$lib/ui';
   import Disclosure from '$lib/components/ghost/Disclosure.svelte';
+  import SourcesField from '$lib/components/pipeline/SourcesField.svelte';
   import StageIllustration from '$lib/components/pipeline/StageIllustration.svelte';
   import { PIPELINE_STAGES } from '$lib/pipelineStages';
   import { PIPELINE_FAQ } from '$lib/pipelineFaq';
@@ -12,25 +12,30 @@
   // narrowing anything. All three are answered by walking one posting through the same
   // five stages the backend runs it through — see docs/architecture.md and the root
   // AGENTS.md, which this page's copy is written from.
+  let {
+    scale,
+  }: { scale: { sources: number | null; atsPlatforms: number | null; companies: number | null } } =
+    $props();
 </script>
 
-<article class="flex flex-col gap-16">
-  <header class="flex flex-col items-start gap-6">
+<article class="flex flex-col gap-14">
+  <header class="flex flex-col items-start gap-5">
     <SectionLabel text="how it works" />
     <h1 class="max-w-2xl text-3xl font-semibold tracking-tight sm:text-4xl">
       One posting, five steps, before you ever see it.
     </h1>
-    <p class="max-w-2xl text-base leading-relaxed text-muted-foreground">
-      Every job in the catalogue is crawled straight from where a company actually posted
-      it, tagged against a fixed dictionary, checked for duplicates against every other
-      board, and rebuilt into the index you search — automatically, continuously, with no
-      person touching an individual listing.
+    <p class="max-w-xl text-base leading-relaxed text-muted-foreground">
+      Crawled, tagged, checked for duplicates, and rebuilt into the index you search —
+      automatically, with no person touching an individual listing.
     </p>
     <div class="flex flex-wrap gap-3">
       <Button href={resolve('/jobs')} variant="primary" size="lg">Browse jobs</Button>
       <Button href={resolve('/open')} variant="ghost" size="lg">See the live catalogue</Button>
     </div>
   </header>
+
+  <!-- The opening thesis, made visual: not one board, a field of them. -->
+  <SourcesField sources={scale.sources} atsPlatforms={scale.atsPlatforms} />
 
   <!-- The signature: one example posting, followed through all five stages. Its title and
        facts stay the same specific example end to end (StageIllustration's five cards)
@@ -41,24 +46,24 @@
       Follow one posting below — the picture at each step is that same job, at that stage.
     </p>
 
-    <div class="flex flex-col items-stretch gap-2 lg:flex-row lg:items-stretch lg:gap-0">
-      {#each PIPELINE_STAGES as stage, i (stage.key)}
-        <div class="flex flex-1 flex-col gap-3 rounded-lg border border-border p-4">
-          <div class="flex items-baseline gap-2">
-            <span class="font-mono text-xs text-muted-foreground">{stage.n}</span>
-            <h3 class="text-sm font-semibold tracking-tight">{stage.title}</h3>
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-5">
+      {#each PIPELINE_STAGES as stage (stage.key)}
+        <div class="relative flex flex-col gap-3 overflow-hidden rounded-lg border border-border p-4">
+          <div
+            class="pointer-events-none absolute -right-2 -top-3 font-mono text-6xl font-bold text-border select-none"
+            aria-hidden="true"
+          >
+            {stage.n}
           </div>
-          <StageIllustration stage={stage.key} />
-          <p class="text-sm leading-relaxed text-muted-foreground">{stage.blurb}</p>
-          <Disclosure summary="More detail" srSuffix={stage.title}>
+          <h3 class="relative text-sm font-semibold tracking-tight">{stage.title}</h3>
+          <div class="relative rounded-md bg-secondary/40 p-3">
+            <StageIllustration stage={stage.key} />
+          </div>
+          <p class="relative text-sm font-medium leading-snug">{stage.blurb}</p>
+          <Disclosure summary="More detail" srSuffix={stage.title} class="relative">
             <p class="mt-2 text-sm leading-relaxed text-muted-foreground">{stage.detail}</p>
           </Disclosure>
         </div>
-        {#if i < PIPELINE_STAGES.length - 1}
-          <div class="flex items-center justify-center py-1 lg:px-1 lg:py-0" aria-hidden="true">
-            <ArrowRight class="size-4 shrink-0 rotate-90 text-muted-foreground/40 lg:rotate-0" />
-          </div>
-        {/if}
       {/each}
     </div>
   </section>
@@ -81,8 +86,7 @@
   <section class="flex flex-col items-start gap-4 rounded-lg border border-border p-6">
     <h2 class="text-lg font-semibold tracking-tight">See it running on the real catalogue</h2>
     <p class="max-w-2xl text-sm leading-relaxed text-muted-foreground">
-      The pipeline runs on every job you'll find here. The open startup page shows the
-      current figures — jobs, companies and sources — straight from the same API.
+      This pipeline runs on every job you'll find here.
     </p>
     <div class="flex flex-wrap gap-3">
       <Button href={resolve('/jobs')} variant="primary">Browse jobs</Button>

--- a/web/src/lib/components/HowItWorksLandingView.svelte
+++ b/web/src/lib/components/HowItWorksLandingView.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import { ArrowRight } from '@lucide/svelte';
+  import { Button, SectionLabel } from '$lib/ui';
+  import Disclosure from '$lib/components/ghost/Disclosure.svelte';
+  import StageIllustration from '$lib/components/pipeline/StageIllustration.svelte';
+  import { PIPELINE_STAGES } from '$lib/pipelineStages';
+  import { PIPELINE_FAQ } from '$lib/pipelineFaq';
+
+  // The page a reader reaches wanting to know why they can trust the catalogue: is it
+  // current, is it the same ten jobs copied across ten boards, is a filter actually
+  // narrowing anything. All three are answered by walking one posting through the same
+  // five stages the backend runs it through — see docs/architecture.md and the root
+  // AGENTS.md, which this page's copy is written from.
+</script>
+
+<article class="flex flex-col gap-16">
+  <header class="flex flex-col items-start gap-6">
+    <SectionLabel text="how it works" />
+    <h1 class="max-w-2xl text-3xl font-semibold tracking-tight sm:text-4xl">
+      One posting, five steps, before you ever see it.
+    </h1>
+    <p class="max-w-2xl text-base leading-relaxed text-muted-foreground">
+      Every job in the catalogue is crawled straight from where a company actually posted
+      it, tagged against a fixed dictionary, checked for duplicates against every other
+      board, and rebuilt into the index you search — automatically, continuously, with no
+      person touching an individual listing.
+    </p>
+    <div class="flex flex-wrap gap-3">
+      <Button href={resolve('/jobs')} variant="primary" size="lg">Browse jobs</Button>
+      <Button href={resolve('/open')} variant="ghost" size="lg">See the live catalogue</Button>
+    </div>
+  </header>
+
+  <!-- The signature: one example posting, followed through all five stages. Its title and
+       facts stay the same specific example end to end (StageIllustration's five cards)
+       so the sequence reads as one job's actual journey, not five unrelated icons. -->
+  <section class="flex flex-col gap-6">
+    <SectionLabel text="the pipeline" />
+    <p class="max-w-2xl text-sm leading-relaxed text-muted-foreground">
+      Follow one posting below — the picture at each step is that same job, at that stage.
+    </p>
+
+    <div class="flex flex-col items-stretch gap-2 lg:flex-row lg:items-stretch lg:gap-0">
+      {#each PIPELINE_STAGES as stage, i (stage.key)}
+        <div class="flex flex-1 flex-col gap-3 rounded-lg border border-border p-4">
+          <div class="flex items-baseline gap-2">
+            <span class="font-mono text-xs text-muted-foreground">{stage.n}</span>
+            <h3 class="text-sm font-semibold tracking-tight">{stage.title}</h3>
+          </div>
+          <StageIllustration stage={stage.key} />
+          <p class="text-sm leading-relaxed text-muted-foreground">{stage.blurb}</p>
+          <Disclosure summary="More detail" srSuffix={stage.title}>
+            <p class="mt-2 text-sm leading-relaxed text-muted-foreground">{stage.detail}</p>
+          </Disclosure>
+        </div>
+        {#if i < PIPELINE_STAGES.length - 1}
+          <div class="flex items-center justify-center py-1 lg:px-1 lg:py-0" aria-hidden="true">
+            <ArrowRight class="size-4 shrink-0 rotate-90 text-muted-foreground/40 lg:rotate-0" />
+          </div>
+        {/if}
+      {/each}
+    </div>
+  </section>
+
+  <!-- FAQ; shares PIPELINE_FAQ with the page's JSON-LD. Collapsed with <details>, so every
+       answer is still in the served HTML and the structured data cannot disagree with it. -->
+  <section class="flex flex-col gap-4">
+    <SectionLabel text="questions" />
+    <div class="flex flex-col divide-y divide-border border-y border-border">
+      {#each PIPELINE_FAQ as item (item.question)}
+        <Disclosure summary={item.question} class="py-3">
+          <p class="mt-2 max-w-3xl text-sm leading-relaxed text-muted-foreground">
+            {item.answer}
+          </p>
+        </Disclosure>
+      {/each}
+    </div>
+  </section>
+
+  <section class="flex flex-col items-start gap-4 rounded-lg border border-border p-6">
+    <h2 class="text-lg font-semibold tracking-tight">See it running on the real catalogue</h2>
+    <p class="max-w-2xl text-sm leading-relaxed text-muted-foreground">
+      The pipeline runs on every job you'll find here. The open startup page shows the
+      current figures — jobs, companies and sources — straight from the same API.
+    </p>
+    <div class="flex flex-wrap gap-3">
+      <Button href={resolve('/jobs')} variant="primary">Browse jobs</Button>
+      <Button href={resolve('/open')} variant="ghost">See the live catalogue</Button>
+    </div>
+  </section>
+</article>

--- a/web/src/lib/components/InboxSettings.svelte
+++ b/web/src/lib/components/InboxSettings.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  // The inbox's Settings pane: the two ways to get mail in. It owns its own
-  // mutations (claim, release, disconnect) and the flags that go with them, and
-  // reports the outcome upward — the mail list, its filters and its pager live in
-  // InboxView and stay there.
+  // The inbox's Settings pane: the freehire mailbox, the one source it still owns
+  // (claim/release). It reports the outcome upward — the mail list, its filters and
+  // its pager live in InboxView and stay there.
   //
-  // `sync` is deliberately NOT owned here even though its button is. Syncing polls
-  // the listing repeatedly while Gmail catches up, and that loop belongs beside the
-  // pager it polls; this component only renders the button and its pending state.
+  // Gmail connect/disconnect/sync lives on the Integrations tab (/my/integrations),
+  // not here — this pane only shows a short status line pointing there, so a caller
+  // wondering "where did the Gmail card go" finds it in one click.
+  import { resolve } from '$app/paths';
   import { api } from '$lib/api';
   import type { GmailStatus, MailboxStatus, InboxSource } from '$lib/api';
   import { Badge, Button, ConfirmDialog } from '$lib/ui';
@@ -16,14 +16,6 @@
   interface Props {
     gmail: GmailStatus | null;
     mailbox: MailboxStatus | null;
-    /** True while the parent's sync poll is running. */
-    syncing: boolean;
-    /** Run the Gmail sync + the listing poll that follows it. */
-    onSync: () => void;
-    /** Open the first-time connect explainer. */
-    onConnect: () => void;
-    /** Send the browser to Google's consent screen (re-consent path). */
-    onReconnect: () => void;
     /**
      * A source was added or removed. `removed` names the account that went away, so
      * the parent can drop a filter pointing at it before reloading.
@@ -32,33 +24,12 @@
     onError: (message: string) => void;
   }
 
-  let {
-    gmail = $bindable(),
-    mailbox = $bindable(),
-    syncing,
-    onSync,
-    onConnect,
-    onReconnect,
-    onSourceChanged,
-    onError,
-  }: Props = $props();
+  let { gmail, mailbox = $bindable(), onSourceChanged, onError }: Props = $props();
 
   let claiming = $state(false);
-  let confirmDisconnectGmailOpen = $state(false);
   let confirmReleaseMailboxOpen = $state(false);
 
-  const hasGmail = $derived(!!gmail?.connected);
   const hasMailbox = $derived(!!mailbox?.address);
-
-  async function disconnectGmail() {
-    try {
-      await api.disconnectGmail();
-      gmail = { connected: false, available: gmail?.available };
-      onSourceChanged('gmail');
-    } catch (e) {
-      onError(errorMessage(e, 'Failed to disconnect.'));
-    }
-  }
 
   async function claimMailbox() {
     if (claiming) return;
@@ -87,37 +58,27 @@
   }
 </script>
 
-<!-- Sources: the two ways to get mail in — connect Gmail and/or claim a mailbox. -->
+<!-- Sources: the two ways to get mail in — Gmail (a status line, connected on
+     Integrations) and the freehire mailbox (owned here). -->
 <div class="grid gap-3 sm:grid-cols-2">
-  <!-- Gmail -->
+  <!-- Gmail: status only — the connect/disconnect/sync UI lives on Integrations. -->
   <div class="rounded-xl border border-border bg-card p-4">
     <div class="flex items-center gap-2 text-sm font-medium">
       <Mail class="h-4 w-4 text-muted-foreground" /> Gmail
-    </div>
-    {#if hasGmail}
-      <p class="mt-1 truncate text-xs text-muted-foreground">{gmail?.email}</p>
-      {#if gmail?.status === 'needs_reconsent'}
-        <Badge variant="outline" class="mt-2 border-destructive/40 text-destructive">Reconnect needed</Badge>
+      {#if gmail?.connected}
+        <Badge variant="outline" class="border-brand-ring/40 text-brand-strong">Connected</Badge>
       {/if}
-      <div class="mt-3 flex flex-wrap gap-2">
-        {#if gmail?.status === 'needs_reconsent'}
-          <Button variant="secondary" size="sm" onclick={onReconnect}>Reconnect</Button>
-        {/if}
-        <Button variant="secondary" size="sm" disabled={syncing} onclick={onSync}>
-          {syncing ? 'Syncing…' : 'Sync'}
-        </Button>
-        <Button variant="outline" size="sm" onclick={() => (confirmDisconnectGmailOpen = true)}>
-          Disconnect
-        </Button>
-      </div>
+    </div>
+    {#if gmail?.connected}
+      <p class="mt-1 truncate text-xs text-muted-foreground">{gmail?.email}</p>
     {:else if gmail?.available}
       <p class="mt-1 text-xs text-muted-foreground">Pull replies from your own Gmail (needs Google sign-in).</p>
-      <Button variant="primary" size="sm" class="mt-3" onclick={onConnect}>
-        Connect Gmail <Mail class="h-4 w-4" />
-      </Button>
     {:else}
       <p class="mt-1 text-xs text-muted-foreground">Not available yet.</p>
     {/if}
+    <Button variant="secondary" size="sm" class="mt-3" href={resolve('/my/integrations')}>
+      {gmail?.connected ? 'Manage in Integrations' : 'Connect in Integrations'}
+    </Button>
   </div>
 
   <!-- Hosted mailbox -->
@@ -146,14 +107,6 @@
     {/if}
   </div>
 </div>
-
-<ConfirmDialog
-  bind:open={confirmDisconnectGmailOpen}
-  title="Disconnect Gmail?"
-  description="Its synced mail is removed."
-  confirmLabel="Disconnect"
-  onConfirm={disconnectGmail}
-/>
 
 <ConfirmDialog
   bind:open={confirmReleaseMailboxOpen}

--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount } from 'svelte';
   import { page } from '$app/state';
   import { replaceState } from '$app/navigation';
   import { resolve } from '$app/paths';
@@ -16,7 +16,6 @@
   import StatusChip from '$lib/components/StatusChip.svelte';
   import { inboxLinkState, type LastUnlinked } from '$lib/inboxLink';
   import { Paginator } from '$lib/paginated.svelte';
-  import GmailConnectDialog from './GmailConnectDialog.svelte';
   import InboxSettings from './InboxSettings.svelte';
   import ApplicationLinkPicker from './ApplicationLinkPicker.svelte';
   import InfiniteScroll from './InfiniteScroll.svelte';
@@ -71,7 +70,6 @@
     { limit: PAGE_SIZE },
   );
 
-  let syncing = $state(false);
   let refreshing = $state(false);
   let markingAll = $state(false);
 
@@ -111,38 +109,6 @@
   );
   const sourceOptions = $derived([{ value: '' as InboxSource, label: 'All' }, ...presentSources]);
 
-  // The Gmail connect flow ends as a top-level browser navigation back to this page
-  // carrying its verdict in the URL: ?gmail=connected, or ?gmail_error=<reason> when
-  // the backend gave up. It is a banner and not the fatal `error` screen — the inbox
-  // itself is fine, only the connect attempt is not. The URL is cleaned afterwards so
-  // a reload does not replay a stale verdict. onMount (not afterNavigate, as in
-  // TopBar) is enough: this page is only ever reached from the callback by a cold
-  // load, never by an in-app navigation.
-  const GMAIL_CONNECT_ERRORS: Record<string, string> = {
-    auth: 'Your session ended before Gmail finished connecting. Sign in, then try again.',
-    state: 'That connect link expired or was opened out of order. Start the connection again.',
-    exchange: 'Google did not finish handing over access. Try connecting again.',
-  };
-  let connectNotice = $state<{ ok: boolean; text: string } | null>(null);
-
-  function readConnectVerdict() {
-    const params = page.url.searchParams;
-    const failed = params.get('gmail_error');
-    if (failed) {
-      connectNotice = {
-        ok: false,
-        text: GMAIL_CONNECT_ERRORS[failed] ?? 'Connecting Gmail failed. Try again.',
-      };
-    } else if (params.get('gmail') === 'connected') {
-      connectNotice = { ok: true, text: 'Gmail connected — your ATS mail will show up here shortly.' };
-    } else {
-      return;
-    }
-    // eslint-disable-next-line svelte/no-navigation-without-resolve -- shallow same-page URL clean-up to the current pathname; nothing to resolve
-    replaceState(page.url.pathname, {});
-  }
-
-  let destroyed = false;
   // A message addressed from outside the inbox — the tracking calendar links each
   // mail-derived event to the message behind it. Opening it here marks it read, which is
   // correct: read_at means a human saw the message, and this arrival is a person clicking
@@ -158,14 +124,10 @@
   }
 
   onMount(() => {
-    readConnectVerdict();
     // After load(), not before: fetchFirstPage replaces pager.items wholesale, and
     // openMessage patches the opened row to read INSIDE that list. Racing the two leaves
     // the message the reader just opened still showing as unread.
     void load().then(openAddressedMessage);
-  });
-  onDestroy(() => {
-    destroyed = true;
   });
 
   async function load() {
@@ -432,42 +394,9 @@
 
   // --- Gmail source ---
 
-  // First-time connect opens an explainer dialog (what's read + how the LLM pipeline
-  // sorts it, with source links); connectGmail is the actual OAuth redirect it triggers.
-  let showConnectDialog = $state(false);
-
-  function connectGmail() {
-    window.location.href = '/api/v1/me/gmail/connect';
-  }
-
-  async function sync() {
-    if (syncing) return;
-    syncing = true;
-    error = null;
-    try {
-      await api.syncGmail();
-      for (let i = 0; i < 8; i++) {
-        await new Promise((r) => setTimeout(r, 2500));
-        // Stop polling once the page is gone — no requests for a dead view.
-        if (destroyed) return;
-        await fetchFirstPage('Sync failed.');
-      }
-    } catch (e) {
-      error = errorMessage(e, 'Sync failed.');
-    } finally {
-      syncing = false;
-    }
-  }
-
-
   // Deep link to a Gmail message in Gmail's web UI (the Gmail API id is the URL id).
   const gmailUrl = (externalId: string) =>
     `https://mail.google.com/mail/?authuser=${encodeURIComponent(gmail?.email ?? '')}#all/${externalId}`;
-
-  // --- Hosted mailbox source ---
-
-
-
 
   // A source was added or removed in the Settings pane. A filter pointing at an
   // account that no longer exists would render an empty list that looks like "no
@@ -495,15 +424,6 @@
   <p class="text-sm text-destructive">{error}</p>
 {:else}
   <div class="flex flex-col gap-4">
-    {#if connectNotice}
-      <p
-        class="rounded-md border px-3 py-2 text-sm {connectNotice.ok
-          ? 'border-brand/30 bg-brand/10 text-foreground'
-          : 'border-destructive/30 bg-destructive/10 text-destructive'}"
-      >
-        {connectNotice.text}
-      </p>
-    {/if}
     <!-- Tabs: keep the mail list and the account setup on separate panes. -->
     <div class="flex gap-4 border-b border-border text-sm">
       {#each [{ id: 'inbox', label: 'Inbox' }, { id: 'settings', label: 'Settings' }] as t (t.id)}
@@ -520,16 +440,7 @@
     </div>
 
     {#if tab === 'settings'}
-      <InboxSettings
-        bind:gmail
-        bind:mailbox
-        {syncing}
-        onSync={sync}
-        onConnect={() => (showConnectDialog = true)}
-        onReconnect={connectGmail}
-        onSourceChanged={onSourceChanged}
-        onError={(m) => (error = m)}
-      />
+      <InboxSettings {gmail} bind:mailbox onSourceChanged={onSourceChanged} onError={(m) => (error = m)} />
     {:else if !hasAnySource}
       <p class="py-8 text-center text-sm text-muted-foreground">
         No mail source yet —
@@ -841,10 +752,6 @@
       {/if}
     {/if}
   </div>
-{/if}
-
-{#if showConnectDialog}
-  <GmailConnectDialog onClose={() => (showConnectDialog = false)} onConnect={connectGmail} />
 {/if}
 
 <style>

--- a/web/src/lib/components/IntegrationsView.svelte
+++ b/web/src/lib/components/IntegrationsView.svelte
@@ -73,17 +73,15 @@
 
   // Both the mail and calendar connect flows end as a top-level browser navigation
   // back here, carrying their verdict in the URL — the same convention the inbox
-  // used to read for the mail flow alone.
-  const GMAIL_CONNECT_ERRORS: Record<string, string> = {
-    auth: 'Your session ended before Gmail finished connecting. Sign in, then try again.',
+  // used to read for the mail flow alone. Only the `auth` message names the product;
+  // `state` and `exchange` are the same regardless of which consent failed.
+  const connectErrors = (product: string): Record<string, string> => ({
+    auth: `Your session ended before ${product} finished connecting. Sign in, then try again.`,
     state: 'That connect link expired or was opened out of order. Start the connection again.',
     exchange: 'Google did not finish handing over access. Try connecting again.',
-  };
-  const CALENDAR_CONNECT_ERRORS: Record<string, string> = {
-    auth: 'Your session ended before Calendar finished connecting. Sign in, then try again.',
-    state: 'That connect link expired or was opened out of order. Start the connection again.',
-    exchange: 'Google did not finish handing over access. Try connecting again.',
-  };
+  });
+  const GMAIL_CONNECT_ERRORS = connectErrors('Gmail');
+  const CALENDAR_CONNECT_ERRORS = connectErrors('Calendar');
   let googleNotice = $state<{ ok: boolean; text: string } | null>(null);
 
   function readGoogleVerdict() {
@@ -240,6 +238,9 @@
     void notifications.ensureLoaded();
     void loadDiscord();
   });
+
+  // Shared by every "already connected" badge below (Mail, Calendar, Telegram, Discord).
+  const CONNECTED_BADGE_CLASS = 'border-brand-ring/40 text-brand-strong';
 </script>
 
 <div class="flex flex-col gap-4">
@@ -274,7 +275,7 @@
             <div class="flex items-center gap-1.5 text-sm">
               <Mail class="h-3.5 w-3.5 text-muted-foreground" /> Mail
               {#if hasGmail}
-                <Badge variant="outline" class="border-brand-ring/40 text-brand-strong">Connected</Badge>
+                <Badge variant="outline" class={CONNECTED_BADGE_CLASS}>Connected</Badge>
                 {#if gmail?.status === 'needs_reconsent'}
                   <Badge variant="outline" class="border-destructive/40 text-destructive">Reconnect needed</Badge>
                 {/if}
@@ -314,7 +315,7 @@
             <div class="flex items-center gap-1.5 text-sm">
               <CalendarDays class="h-3.5 w-3.5 text-muted-foreground" /> Calendar
               {#if hasCalendar}
-                <Badge variant="outline" class="border-brand-ring/40 text-brand-strong">Connected</Badge>
+                <Badge variant="outline" class={CONNECTED_BADGE_CLASS}>Connected</Badge>
               {/if}
             </div>
             <p class="text-xs text-muted-foreground">
@@ -349,7 +350,7 @@
           <div class="flex items-center gap-2 text-sm font-medium">
             <ProviderIcon provider="telegram" class="h-4 w-4" /> Telegram
             {#if tg.linked}
-              <Badge variant="outline" class="border-brand-ring/40 text-brand-strong">Connected</Badge>
+              <Badge variant="outline" class={CONNECTED_BADGE_CLASS}>Connected</Badge>
             {/if}
           </div>
           <p class="mt-1 text-xs text-muted-foreground">
@@ -398,7 +399,7 @@
           <div class="flex items-center gap-2 text-sm font-medium">
             <ProviderIcon provider="discord" class="h-4 w-4" /> Discord
             {#if discord.linked}
-              <Badge variant="outline" class="border-brand-ring/40 text-brand-strong">Linked</Badge>
+              <Badge variant="outline" class={CONNECTED_BADGE_CLASS}>Linked</Badge>
             {/if}
           </div>
           <p class="mt-1 text-xs text-muted-foreground">

--- a/web/src/lib/components/IntegrationsView.svelte
+++ b/web/src/lib/components/IntegrationsView.svelte
@@ -1,0 +1,475 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { page } from '$app/state';
+  import { replaceState } from '$app/navigation';
+  import { resolve } from '$app/paths';
+  import { env } from '$env/dynamic/public';
+  import { api, ApiError } from '$lib/api';
+  import type { GmailStatus } from '$lib/api';
+  import type { DiscordLinkResult, DiscordStatus } from '$lib/types';
+  import { notifications } from '$lib/notifications.svelte';
+  import { Badge, Button, ConfirmDialog, ProviderIcon } from '$lib/ui';
+  import { Mail, CalendarDays } from '@lucide/svelte';
+  import { errorMessage } from '$lib/utils';
+  import GmailConnectDialog from './GmailConnectDialog.svelte';
+
+  // The account-level home for every third-party connection: Google (Gmail +
+  // Calendar, two separate consents on the same grant), Telegram (the alert bot,
+  // connected here independently of any one saved search) and Discord (the
+  // /contribute reward link). Each connection's own page (Inbox, Tracking →
+  // Calendar, Contributions) keeps only a short status line pointing back here —
+  // this is the one place that owns connect/disconnect.
+
+  // --- Google: Mail ---
+  let gmail = $state<GmailStatus | null>(null);
+  let gmailLoading = $state(true);
+  let gmailError = $state<string | null>(null);
+  let syncing = $state(false);
+  let syncStarted = $state(false);
+  let showConnectDialog = $state(false);
+  let confirmDisconnectOpen = $state(false);
+
+  const hasGmail = $derived(!!gmail?.connected);
+  const hasCalendar = $derived(gmail?.calendar_connected === true);
+
+  async function loadGmail() {
+    gmailLoading = true;
+    try {
+      gmail = await api.gmailStatus();
+    } catch (e) {
+      gmailError = errorMessage(e, 'Failed to load Gmail status.');
+    } finally {
+      gmailLoading = false;
+    }
+  }
+
+  function connectGmail() {
+    window.location.href = '/api/v1/me/gmail/connect';
+  }
+
+  async function sync() {
+    if (syncing) return;
+    syncing = true;
+    syncStarted = false;
+    gmailError = null;
+    try {
+      await api.syncGmail();
+      syncStarted = true;
+    } catch (e) {
+      gmailError = errorMessage(e, 'Sync failed.');
+    } finally {
+      syncing = false;
+    }
+  }
+
+  async function disconnectGmail() {
+    try {
+      await api.disconnectGmail();
+      gmail = { connected: false, available: gmail?.available, calendar_connected: false };
+    } catch (e) {
+      gmailError = errorMessage(e, 'Failed to disconnect.');
+    }
+  }
+
+  // Both the mail and calendar connect flows end as a top-level browser navigation
+  // back here, carrying their verdict in the URL — the same convention the inbox
+  // used to read for the mail flow alone.
+  const GMAIL_CONNECT_ERRORS: Record<string, string> = {
+    auth: 'Your session ended before Gmail finished connecting. Sign in, then try again.',
+    state: 'That connect link expired or was opened out of order. Start the connection again.',
+    exchange: 'Google did not finish handing over access. Try connecting again.',
+  };
+  const CALENDAR_CONNECT_ERRORS: Record<string, string> = {
+    auth: 'Your session ended before Calendar finished connecting. Sign in, then try again.',
+    state: 'That connect link expired or was opened out of order. Start the connection again.',
+    exchange: 'Google did not finish handing over access. Try connecting again.',
+  };
+  let googleNotice = $state<{ ok: boolean; text: string } | null>(null);
+
+  function readGoogleVerdict() {
+    const params = page.url.searchParams;
+    const gmailFailed = params.get('gmail_error');
+    const calendarFailed = params.get('calendar_error');
+    if (gmailFailed) {
+      googleNotice = { ok: false, text: GMAIL_CONNECT_ERRORS[gmailFailed] ?? 'Connecting Gmail failed. Try again.' };
+    } else if (calendarFailed) {
+      googleNotice = {
+        ok: false,
+        text: CALENDAR_CONNECT_ERRORS[calendarFailed] ?? 'Connecting Calendar failed. Try again.',
+      };
+    } else if (params.get('gmail') === 'connected') {
+      googleNotice = { ok: true, text: 'Gmail connected — your ATS mail will show up in the Inbox shortly.' };
+    } else if (params.get('calendar') === 'connected') {
+      googleNotice = { ok: true, text: 'Calendar connected — accepted interviews will show up on the Tracking calendar.' };
+    } else {
+      return;
+    }
+    // eslint-disable-next-line svelte/no-navigation-without-resolve -- shallow same-page URL clean-up to the current pathname; nothing to resolve
+    replaceState(page.url.pathname, {});
+  }
+
+  // --- Telegram ---
+  const tg = $derived(notifications.telegram);
+  let tgBusy = $state(false);
+  let tgConnecting = $state(false);
+  let tgError = $state<string | null>(null);
+
+  async function connectTelegram() {
+    if (tgBusy) return;
+    tgBusy = true;
+    tgError = null;
+    try {
+      const url = await notifications.link();
+      window.open(url, '_blank', 'noopener');
+      tgConnecting = true;
+    } catch (e) {
+      tgError = e instanceof ApiError ? e.message : 'Could not start the Telegram connection. Please try again.';
+    } finally {
+      tgBusy = false;
+    }
+  }
+
+  async function recheckTelegram() {
+    if (tgBusy) return;
+    tgBusy = true;
+    tgError = null;
+    try {
+      await notifications.refreshTelegram();
+      if (notifications.telegram.linked) tgConnecting = false;
+      else tgError = 'Not connected yet — tap “Start” in Telegram, then retry.';
+    } catch {
+      tgError = 'Could not check the connection. Please try again.';
+    } finally {
+      tgBusy = false;
+    }
+  }
+
+  async function disconnectTelegram() {
+    if (tgBusy) return;
+    tgBusy = true;
+    tgError = null;
+    try {
+      await notifications.unlink();
+    } catch (e) {
+      tgError = e instanceof ApiError ? e.message : 'Could not disconnect Telegram. Please try again.';
+    } finally {
+      tgBusy = false;
+    }
+  }
+
+  // --- Discord ---
+  let discord = $state<DiscordStatus | null>(null);
+  let discordBusy = $state(false);
+  let discordError = $state<string | null>(null);
+  // Shown only right after a successful link mint — the token is short-TTL and a
+  // status refetch never returns it again, so this is never restored from anywhere.
+  let discordLinkResult = $state.raw<DiscordLinkResult | null>(null);
+  let discordCopied = $state(false);
+
+  const discordCommand = $derived(discordLinkResult ? `/link token:${discordLinkResult.token}` : '');
+  // The operator's own Discord server URL, set once at deploy time (optional — the
+  // card still works without it, just without the shortcut link).
+  const discordChannelUrl = env.PUBLIC_DISCORD_CHANNEL_URL;
+
+  async function loadDiscord() {
+    try {
+      discord = await api.discordStatus();
+    } catch {
+      // Left null — the card stays hidden; Contributions' own load surfaces the
+      // same failure if the user goes looking there.
+    }
+  }
+
+  async function copyDiscordCommand() {
+    if (!discordCommand) return;
+    try {
+      await navigator.clipboard.writeText(discordCommand);
+      discordCopied = true;
+    } catch {
+      discordCopied = false;
+    }
+  }
+
+  async function linkDiscord() {
+    discordCopied = false;
+    if (discordBusy) return;
+    discordBusy = true;
+    discordError = null;
+    try {
+      discordLinkResult = await api.discordLink();
+    } catch (e) {
+      discordError = e instanceof ApiError ? e.message : 'Could not start Discord linking. Please try again.';
+    } finally {
+      discordBusy = false;
+    }
+  }
+
+  async function recheckDiscord() {
+    if (discordBusy) return;
+    discordBusy = true;
+    discordError = null;
+    try {
+      discord = await api.discordStatus();
+      if (discord.linked) discordLinkResult = null;
+      else discordError = 'Not linked yet — run the command above, then retry.';
+    } catch (e) {
+      discordError = e instanceof ApiError ? e.message : 'Could not check the link. Please try again.';
+    } finally {
+      discordBusy = false;
+    }
+  }
+
+  async function unlinkDiscord() {
+    if (discordBusy) return;
+    discordBusy = true;
+    discordError = null;
+    try {
+      await api.discordUnlink();
+      discord = discord ? { ...discord, linked: false, discord_id: undefined } : null;
+      discordLinkResult = null;
+    } catch (e) {
+      discordError = e instanceof ApiError ? e.message : 'Could not unlink Discord. Please try again.';
+    } finally {
+      discordBusy = false;
+    }
+  }
+
+  onMount(() => {
+    readGoogleVerdict();
+    void loadGmail();
+    void notifications.ensureLoaded();
+    void loadDiscord();
+  });
+</script>
+
+<div class="flex flex-col gap-4">
+  <div class="flex flex-col gap-1">
+    <h1 class="text-2xl font-semibold tracking-tight">Integrations</h1>
+    <p class="text-sm text-muted-foreground">Connect the third-party accounts freehire can use on your behalf.</p>
+  </div>
+
+  {#if googleNotice}
+    <p
+      class="rounded-md border px-3 py-2 text-sm {googleNotice.ok
+        ? 'border-brand/30 bg-brand/10 text-foreground'
+        : 'border-destructive/30 bg-destructive/10 text-destructive'}"
+    >
+      {googleNotice.text}
+    </p>
+  {/if}
+
+  <!-- Google -->
+  <div class="rounded-xl border border-border bg-card p-4">
+    <div class="flex items-center gap-2 text-sm font-medium">
+      <ProviderIcon provider="google" class="h-4 w-4" /> Google
+    </div>
+
+    {#if gmailLoading}
+      <p class="mt-3 text-xs text-muted-foreground">Loading…</p>
+    {:else}
+      <div class="mt-3 flex flex-col gap-3">
+        <!-- Mail -->
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <div class="min-w-0">
+            <div class="flex items-center gap-1.5 text-sm">
+              <Mail class="h-3.5 w-3.5 text-muted-foreground" /> Mail
+              {#if hasGmail}
+                <Badge variant="outline" class="border-brand-ring/40 text-brand-strong">Connected</Badge>
+                {#if gmail?.status === 'needs_reconsent'}
+                  <Badge variant="outline" class="border-destructive/40 text-destructive">Reconnect needed</Badge>
+                {/if}
+              {/if}
+            </div>
+            {#if hasGmail}
+              <p class="truncate text-xs text-muted-foreground">{gmail?.email}</p>
+            {:else if gmail?.available}
+              <p class="text-xs text-muted-foreground">Pull replies from your own Gmail into the Inbox.</p>
+            {:else}
+              <p class="text-xs text-muted-foreground">Not available yet.</p>
+            {/if}
+          </div>
+          <div class="flex shrink-0 flex-wrap gap-2">
+            {#if hasGmail}
+              {#if gmail?.status === 'needs_reconsent'}
+                <Button variant="secondary" size="sm" onclick={connectGmail}>Reconnect</Button>
+              {/if}
+              <Button variant="secondary" size="sm" disabled={syncing} onclick={sync}>
+                {syncing ? 'Syncing…' : 'Sync'}
+              </Button>
+              <Button variant="outline" size="sm" onclick={() => (confirmDisconnectOpen = true)}>Disconnect</Button>
+            {:else if gmail?.available}
+              <Button variant="primary" size="sm" onclick={() => (showConnectDialog = true)}>
+                Connect <Mail class="h-4 w-4" />
+              </Button>
+            {/if}
+          </div>
+        </div>
+        {#if syncStarted}
+          <p class="text-xs text-muted-foreground">Sync started — new mail will show up in the Inbox shortly.</p>
+        {/if}
+
+        <!-- Calendar: a separate consent, so it needs its own status and its own connect. -->
+        <div class="flex flex-wrap items-center justify-between gap-3 border-t border-border pt-3">
+          <div class="min-w-0">
+            <div class="flex items-center gap-1.5 text-sm">
+              <CalendarDays class="h-3.5 w-3.5 text-muted-foreground" /> Calendar
+              {#if hasCalendar}
+                <Badge variant="outline" class="border-brand-ring/40 text-brand-strong">Connected</Badge>
+              {/if}
+            </div>
+            <p class="text-xs text-muted-foreground">
+              {hasCalendar
+                ? 'Accepted interviews appear on the Tracking calendar.'
+                : 'Connecting Mail does not grant this — it asks separately.'}
+            </p>
+          </div>
+          {#if !hasCalendar && gmail?.available}
+            <!-- eslint-disable svelte/no-navigation-without-resolve -- an API route the browser must navigate to so Google can redirect it back, not a SvelteKit page to resolve -->
+            <a
+              href="/api/v1/me/calendar/connect"
+              class="shrink-0 rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground"
+              >Connect</a
+            >
+            <!-- eslint-enable svelte/no-navigation-without-resolve -->
+          {/if}
+        </div>
+      </div>
+    {/if}
+
+    {#if gmailError}
+      <p class="mt-2 text-xs text-destructive">{gmailError}</p>
+    {/if}
+  </div>
+
+  <!-- Telegram -->
+  {#if tg.enabled}
+    <div class="rounded-xl border border-border bg-card p-4">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <div class="min-w-0">
+          <div class="flex items-center gap-2 text-sm font-medium">
+            <ProviderIcon provider="telegram" class="h-4 w-4" /> Telegram
+            {#if tg.linked}
+              <Badge variant="outline" class="border-brand-ring/40 text-brand-strong">Connected</Badge>
+            {/if}
+          </div>
+          <p class="mt-1 text-xs text-muted-foreground">
+            {tg.linked
+              ? 'Turn on alerts for individual saved searches from the search itself.'
+              : 'Connect the bot once, then turn on alerts from any saved search.'}
+          </p>
+        </div>
+        <div class="shrink-0">
+          {#if tg.linked}
+            <Button variant="outline" size="sm" disabled={tgBusy} onclick={disconnectTelegram}>
+              {tgBusy ? 'Disconnecting…' : 'Disconnect'}
+            </Button>
+          {:else}
+            <Button variant="primary" size="sm" disabled={tgBusy} onclick={connectTelegram}>
+              {tgBusy ? 'Starting…' : 'Connect'}
+            </Button>
+          {/if}
+        </div>
+      </div>
+
+      {#if tgConnecting}
+        <p class="mt-2 text-xs text-muted-foreground">
+          Opened Telegram — tap “Start”, then
+          <button
+            type="button"
+            onclick={recheckTelegram}
+            disabled={tgBusy}
+            class="font-medium text-foreground underline underline-offset-2 hover:opacity-80"
+          >
+            I’ve connected
+          </button>.
+        </p>
+      {/if}
+      {#if tgError}
+        <p class="mt-2 text-xs text-destructive">{tgError}</p>
+      {/if}
+    </div>
+  {/if}
+
+  <!-- Discord -->
+  {#if discord?.enabled}
+    <div class="rounded-xl border border-border bg-card p-4">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <div class="min-w-0">
+          <div class="flex items-center gap-2 text-sm font-medium">
+            <ProviderIcon provider="discord" class="h-4 w-4" /> Discord
+            {#if discord.linked}
+              <Badge variant="outline" class="border-brand-ring/40 text-brand-strong">Linked</Badge>
+            {/if}
+          </div>
+          <p class="mt-1 text-xs text-muted-foreground">
+            Link your account to run <code class="rounded bg-secondary px-1 py-0.5 font-mono text-[11px]">/contribute</code>
+            in the freehire Discord server — the same reward as pasting a link on
+            <a href={resolve('/my/contributions')} class="font-medium underline underline-offset-2 hover:opacity-80">
+              Contributions
+            </a>.
+            {#if discordChannelUrl}
+              <!-- eslint-disable svelte/no-navigation-without-resolve -- external Discord channel URL, not an internal route -->
+              <a
+                href={discordChannelUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="font-medium underline underline-offset-2 hover:opacity-80"
+              >
+                Open the channel
+              </a>
+              <!-- eslint-enable svelte/no-navigation-without-resolve -->
+            {/if}
+          </p>
+        </div>
+        <div class="shrink-0">
+          {#if discord.linked}
+            <Button variant="outline" size="sm" onclick={unlinkDiscord} disabled={discordBusy}>
+              {discordBusy ? 'Unlinking…' : 'Unlink'}
+            </Button>
+          {:else}
+            <Button variant="outline" size="sm" onclick={linkDiscord} disabled={discordBusy}>
+              {discordBusy ? 'Starting…' : 'Link'}
+            </Button>
+          {/if}
+        </div>
+      </div>
+
+      {#if discordLinkResult}
+        <div class="mt-3 rounded-md bg-secondary/40 p-3 text-xs">
+          <p>Paste this command in the freehire Discord server:</p>
+          <div class="mt-1 flex items-center gap-2">
+            <code class="flex-1 overflow-x-auto rounded bg-background px-2 py-1.5 font-mono text-[11px]"
+              >{discordCommand}</code
+            >
+            <Button variant="secondary" size="sm" onclick={copyDiscordCommand}>
+              {discordCopied ? 'Copied' : 'Copy'}
+            </Button>
+          </div>
+          <button
+            type="button"
+            onclick={recheckDiscord}
+            disabled={discordBusy}
+            class="mt-2 font-medium text-foreground underline underline-offset-2 hover:opacity-80"
+          >
+            I've linked it
+          </button>
+        </div>
+      {/if}
+      {#if discordError}
+        <p class="mt-2 text-xs text-destructive">{discordError}</p>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+{#if showConnectDialog}
+  <GmailConnectDialog onClose={() => (showConnectDialog = false)} onConnect={connectGmail} />
+{/if}
+
+<ConfirmDialog
+  bind:open={confirmDisconnectOpen}
+  title="Disconnect Gmail?"
+  description="Its synced mail is removed."
+  confirmLabel="Disconnect"
+  onConfirm={disconnectGmail}
+/>

--- a/web/src/lib/components/IntegrationsView.svelte
+++ b/web/src/lib/components/IntegrationsView.svelte
@@ -403,7 +403,7 @@
             {/if}
           </div>
           <p class="mt-1 text-xs text-muted-foreground">
-            Link your account to run <code class="rounded bg-secondary px-1 py-0.5 font-mono text-[11px]">/contribute</code>
+            Link your account to run <code class="rounded bg-secondary px-1 py-0.5 font-mono text-xs">/contribute</code>
             in the freehire Discord server — the same reward as pasting a link on
             <a href={resolve('/my/contributions')} class="font-medium underline underline-offset-2 hover:opacity-80">
               Contributions
@@ -439,7 +439,7 @@
         <div class="mt-3 rounded-md bg-secondary/40 p-3 text-xs">
           <p>Paste this command in the freehire Discord server:</p>
           <div class="mt-1 flex items-center gap-2">
-            <code class="flex-1 overflow-x-auto rounded bg-background px-2 py-1.5 font-mono text-[11px]"
+            <code class="flex-1 overflow-x-auto rounded bg-background px-2 py-1.5 font-mono text-xs"
               >{discordCommand}</code
             >
             <Button variant="secondary" size="sm" onclick={copyDiscordCommand}>

--- a/web/src/lib/components/TrackingCalendar.svelte
+++ b/web/src/lib/components/TrackingCalendar.svelte
@@ -349,7 +349,9 @@
     {#if calendarConnected === false && connectAvailable}
       <!-- Said plainly rather than discovered at Google's consent screen. The OAuth app
            is not verified yet, so an account outside the test roster is simply refused
-           there — and a refusal with no explanation reads as a fault in freehire. -->
+           there — and a refusal with no explanation reads as a fault in freehire. The
+           connect action itself lives on Integrations, alongside Mail and every other
+           third-party connection, not inline here. -->
       <div class="rounded-lg border bg-card p-4">
         <p class="text-sm">
           Connect your calendar and the interviews you accept will appear here, on the day they
@@ -360,15 +362,9 @@
           calendar is read and discarded. While our Google app is awaiting verification the
           connection works for approved test accounts only.
         </p>
-        <!-- eslint-disable svelte/no-navigation-without-resolve -- an API route the browser must
-             navigate to so Google can redirect it back, not a SvelteKit page to resolve. The
-             block form because prettier puts href on its own line, past a next-line disable. -->
-        <a
-          href="/api/v1/me/calendar/connect"
-          class="mt-3 inline-block rounded-md border px-3 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground"
-          >Connect Google Calendar</a
-        >
-        <!-- eslint-enable svelte/no-navigation-without-resolve -->
+        <Button variant="outline" size="sm" class="mt-3" href={resolve('/my/integrations')}>
+          Connect in Integrations
+        </Button>
       </div>
     {/if}
 

--- a/web/src/lib/components/filters/ChipFacet.svelte
+++ b/web/src/lib/components/filters/ChipFacet.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { FACETS, type FacetStore } from '$lib/facets';
+  import { FACETS, type FacetOption, type FacetStore } from '$lib/facets';
   import type { FacetCounts } from '$lib/types';
   import FacetHeader from './FacetHeader.svelte';
   import PillGroup from '../facets/PillGroup.svelte';
@@ -9,22 +9,38 @@
   // excludable flag come from the registry (by `param`), so a caller only names the
   // facet. Excludable facets cycle each pill off → include → exclude → off. When
   // `counts` is passed, each pill shows its live match count under the current scope.
-  let { store, param, label, counts = null }: { store: FacetStore; param: string; label: string; counts?: FacetCounts | null } = $props();
+  //
+  // `options`, when passed, overrides the registry's list — for a param rendered as
+  // more than one block (e.g. `collections` split between Industry & collection and
+  // Relocation). It scopes the header's count and Clear to just that subset too, so a
+  // block only reports and clears the values it actually shows, not the whole param.
+  let {
+    store,
+    param,
+    label,
+    counts = null,
+    options: optionsOverride,
+  }: { store: FacetStore; param: string; label: string; counts?: FacetCounts | null; options?: FacetOption[] } =
+    $props();
 
   const def = FACETS.find((d) => d.param === param);
   const excludable = def?.excludable ?? false;
   const st = $derived(store.facet(param));
+  const scoped = $derived(optionsOverride !== undefined);
+  const baseOptions = $derived(optionsOverride ?? def?.options ?? []);
+  const scopedValues = $derived(new Set(baseOptions.map((o) => o.value)));
+  const include = $derived(scoped ? st.include.filter((v) => scopedValues.has(v)) : st.include);
+  const exclude = $derived(scoped ? st.exclude.filter((v) => scopedValues.has(v)) : st.exclude);
   const onToggle = (v: string) => (excludable ? store.cycle(param, v) : store.pick(param, v));
 
   // Merge the live distribution counts into the static registry options.
   const options = $derived.by(() => {
     const dist = counts?.facets?.[param];
-    const base = def?.options ?? [];
-    return dist ? base.map((o) => ({ ...o, count: dist[o.value] ?? 0 })) : base;
+    return dist ? baseOptions.map((o) => ({ ...o, count: dist[o.value] ?? 0 })) : baseOptions;
   });
 </script>
 
 <div>
-  <FacetHeader {store} {param} {label} />
-  <PillGroup {options} include={st.include} exclude={st.exclude} {excludable} {onToggle} />
+  <FacetHeader {store} {param} {label} values={scoped ? [...scopedValues] : undefined} />
+  <PillGroup {options} {include} {exclude} {excludable} {onToggle} />
 </div>

--- a/web/src/lib/components/filters/FacetHeader.svelte
+++ b/web/src/lib/components/filters/FacetHeader.svelte
@@ -6,10 +6,28 @@
   // has a selection). Shared by the chip facets and the Specialization pane so the
   // per-facet header reads identically everywhere. Include/exclude is chosen per
   // value on the pills themselves, so there is no facet-wide exclude toggle here.
-  let { store, param, label }: { store: FacetStore; param: string; label: string } = $props();
+  //
+  // `values`, when passed, scopes the count and Clear to just that subset of the
+  // param's values — for a param rendered as more than one block (see ChipFacet's
+  // `options` override), so this header doesn't count or clear values shown in a
+  // different block that happens to share the same param.
+  let { store, param, label, values }: { store: FacetStore; param: string; label: string; values?: string[] } =
+    $props();
 
   const st = $derived(store.facet(param));
-  const total = $derived(st.include.length + st.exclude.length);
+  const total = $derived(
+    values
+      ? values.filter((v) => st.include.includes(v) || st.exclude.includes(v)).length
+      : st.include.length + st.exclude.length,
+  );
+
+  function clear() {
+    if (values) {
+      for (const v of values) store.remove(param, v);
+    } else {
+      store.clearFacet(param);
+    }
+  }
 </script>
 
 <div class="mb-2 flex min-h-6 items-center justify-between gap-2">
@@ -17,7 +35,7 @@
   {#if total > 0}
     <button
       type="button"
-      onclick={() => store.clearFacet(param)}
+      onclick={clear}
       title="Clear {label}"
       aria-label="Clear {label}"
       class="flex size-5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"

--- a/web/src/lib/components/filters/FilterModal.svelte
+++ b/web/src/lib/components/filters/FilterModal.svelte
@@ -3,7 +3,7 @@
   import { resolve } from '$app/paths';
   import { Bell, Info, UserRound } from '@lucide/svelte';
   import { Tooltip } from '$lib/ui';
-  import { FACETS } from '$lib/facets';
+  import { EMPLOYER_CREDENTIALS, FACETS, JOB_COLLECTION } from '$lib/facets';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import { profileStore } from '$lib/profile.svelte';
@@ -129,22 +129,33 @@
     ),
   ]);
 
+  const jobCollectionValues = JOB_COLLECTION.map((o) => o.value);
+  const employerCredentialValues = EMPLOYER_CREDENTIALS.map((o) => o.value);
+
   // Values selected for one facet — included plus excluded — so the rail count reflects
-  // any staged selection regardless of sign.
-  function selCount(f: JobFilters, param: string): number {
+  // any staged selection regardless of sign. `values`, when passed, scopes the count to
+  // just that subset — for a param split across two panes (see ChipFacet's `options`
+  // override), so a badge doesn't count values shown under a different tab.
+  function selCount(f: JobFilters, param: string, values?: string[]): number {
     const st = f.facets[param];
-    return st ? st.include.length + st.exclude.length : 0;
+    if (!st) return 0;
+    if (!values) return st.include.length + st.exclude.length;
+    const allowed = new Set(values);
+    return st.include.filter((v) => allowed.has(v)).length + st.exclude.filter((v) => allowed.has(v)).length;
   }
 
   function entryCount(e: RailEntry): number {
     const f = staged.value;
-    if (e.kind === 'category') return selCount(f, 'role') + selCount(f, 'category') + selCount(f, 'seniority');
+    if (e.kind === 'category')
+      return selCount(f, 'role') + selCount(f, 'category') + selCount(f, 'seniority') + selCount(f, 'ai_archetype');
     if (e.kind === 'location') return selCount(f, 'regions') + selCount(f, 'countries') + selCount(f, 'cities');
     if (e.kind === 'salary') return selCount(f, 'salary_currency') + (f.salaryMin != null ? 1 : 0);
     if (e.kind === 'work') return selCount(f, 'work_mode') + selCount(f, 'employment_type');
-    if (e.kind === 'industry') return selCount(f, 'domains') + selCount(f, 'company_type') + selCount(f, 'collections');
+    if (e.kind === 'industry')
+      return selCount(f, 'domains') + selCount(f, 'company_type') + selCount(f, 'collections', jobCollectionValues);
     if (e.kind === 'language') return selCount(f, 'english_level') + selCount(f, 'posting_language');
-    if (e.kind === 'relocation') return selCount(f, 'relocation') + (f.visa ? 1 : 0);
+    if (e.kind === 'relocation')
+      return selCount(f, 'relocation') + (f.visa ? 1 : 0) + selCount(f, 'collections', employerCredentialValues);
     if (e.kind === 'posted') return f.postedWithinDays != null ? 1 : 0;
     // The Minimum skill match threshold lives at the top of the Skills pane, so it
     // counts toward that tab's badge alongside the skills facet selections.
@@ -291,6 +302,12 @@
     {:else}
       <CategoryPane store={staged} {plain} counts={c} />
     {/if}
+    {#if !exclude.includes('ai_archetype')}
+      {@const aiArchetypeDef = facetDefFor('ai_archetype')}
+      {#if aiArchetypeDef}
+        <div class="mt-6"><FacetSection def={aiArchetypeDef} store={staged} counts={c} expand /></div>
+      {/if}
+    {/if}
   {:else if entry.kind === 'location'}
     <LocationPane store={staged} counts={c} />
   {:else if entry.kind === 'facet'}
@@ -338,12 +355,23 @@
   {:else if entry.kind === 'industry'}
     <ChipFacet store={staged} param="domains" label="Industry" counts={c} />
     <div class="mt-6"><ChipFacet store={staged} param="company_type" label="Company type" counts={c} /></div>
-    <div class="mt-6"><ChipFacet store={staged} param="collections" label="Collection" counts={c} /></div>
+    <div class="mt-6">
+      <ChipFacet store={staged} param="collections" label="Collection" counts={c} options={JOB_COLLECTION} />
+    </div>
   {:else if entry.kind === 'language'}
     {#if englishDef}<FacetSection def={englishDef} store={staged} counts={c} expand />{/if}
     <div class="mt-4">{#if postingDef}<FacetSection def={postingDef} store={staged} counts={c} expand />{/if}</div>
   {:else if entry.kind === 'relocation'}
     <ChipFacet store={staged} param="relocation" label="Relocation" counts={c} />
+    <div class="mt-6">
+      <ChipFacet
+        store={staged}
+        param="collections"
+        label="Employer credentials"
+        counts={c}
+        options={EMPLOYER_CREDENTIALS}
+      />
+    </div>
     <h3 class="mb-2 mt-6 text-sm font-semibold tracking-tight">Visa</h3>
     <label class="flex cursor-pointer items-center gap-2 text-sm">
       <input

--- a/web/src/lib/components/pipeline/DedupCard.svelte
+++ b/web/src/lib/components/pipeline/DedupCard.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  // The same posting again, now shown converging: two faint copies from other boards
+  // sit behind it, offset less than IngestCard's messy original was — they are
+  // collapsing into the one card in front, not fanning out like a repost pattern would.
+</script>
+
+<div class="flex h-28 items-center gap-4" aria-hidden="true">
+  <div class="relative h-16 w-32 shrink-0">
+    <div class="absolute inset-0 translate-x-2 translate-y-2 rounded-md border border-border bg-muted/50"
+    ></div>
+    <div class="absolute inset-0 translate-x-1 translate-y-1 rounded-md border border-border bg-muted/70"
+    ></div>
+    <div class="absolute inset-0 rounded-md border border-brand/40 bg-card px-2.5 py-2">
+      <p class="truncate text-[11px] font-medium">Senior Software Engineer</p>
+      <p class="truncate text-[10px] text-muted-foreground">Berlin, DE</p>
+    </div>
+  </div>
+
+  <div class="font-mono text-[11px] text-muted-foreground">
+    <div class="text-brand-strong">3 boards</div>
+    <div>→ 1 listing</div>
+  </div>
+</div>

--- a/web/src/lib/components/pipeline/DedupCard.svelte
+++ b/web/src/lib/components/pipeline/DedupCard.svelte
@@ -2,22 +2,25 @@
   // The same posting again, now shown converging: two faint copies from other boards
   // sit behind it, offset less than IngestCard's messy original was — they are
   // collapsing into the one card in front, not fanning out like a repost pattern would.
+  // Stacked vertically, like every other stage's illustration, so it fits the narrowest
+  // grid column the same way they do rather than needing its own width budget.
 </script>
 
-<div class="flex h-28 items-center gap-4" aria-hidden="true">
-  <div class="relative h-16 w-32 shrink-0">
-    <div class="absolute inset-0 translate-x-2 translate-y-2 rounded-md border border-border bg-muted/50"
+<div class="flex h-28 flex-col items-center justify-center gap-2" aria-hidden="true">
+  <div class="relative h-14 w-28 shrink-0">
+    <div
+      class="absolute inset-0 translate-x-2 translate-y-2 rounded-md border border-border bg-muted/50"
     ></div>
-    <div class="absolute inset-0 translate-x-1 translate-y-1 rounded-md border border-border bg-muted/70"
+    <div
+      class="absolute inset-0 translate-x-1 translate-y-1 rounded-md border border-border bg-muted/70"
     ></div>
-    <div class="absolute inset-0 rounded-md border border-brand/40 bg-card px-2.5 py-2">
-      <p class="truncate text-[11px] font-medium">Senior Software Engineer</p>
-      <p class="truncate text-[10px] text-muted-foreground">Berlin, DE</p>
+    <div class="absolute inset-0 rounded-md border border-brand/40 bg-card px-2 py-1.5">
+      <p class="truncate text-[10px] font-medium">Senior Software Engineer</p>
+      <p class="truncate text-[9px] text-muted-foreground">Berlin, DE</p>
     </div>
   </div>
 
   <div class="font-mono text-[11px] text-muted-foreground">
-    <div class="text-brand-strong">3 boards</div>
-    <div>→ 1 listing</div>
+    <span class="text-brand-strong">3 boards</span> → 1 listing
   </div>
 </div>

--- a/web/src/lib/components/pipeline/DeriveCard.svelte
+++ b/web/src/lib/components/pipeline/DeriveCard.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { Chip } from '$lib/ui';
+  // Same raw title as IngestCard, now legible, with the facets a dictionary lookup
+  // actually found underneath it — nothing here is a guess, so there are exactly four
+  // chips because exactly four terms in this title matched something.
+</script>
+
+<div class="flex h-28 flex-col justify-center gap-2" aria-hidden="true">
+  <div class="rounded-md border border-border bg-card px-3 py-2">
+    <p class="truncate text-xs font-medium">Senior Software Engineer — Berlin, DE</p>
+  </div>
+  <div class="flex flex-wrap gap-1 pl-1">
+    <Chip variant="brand">Senior</Chip>
+    <Chip variant="brand">Software Engineer</Chip>
+    <Chip variant="brand">Berlin, DE</Chip>
+    <Chip variant="brand">Remote-friendly</Chip>
+  </div>
+</div>

--- a/web/src/lib/components/pipeline/EnrichCard.svelte
+++ b/web/src/lib/components/pipeline/EnrichCard.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import { Sparkles } from '@lucide/svelte';
+  // The same posting, with the two facts nothing in this title could have told a
+  // dictionary — pulled from the body text an LLM actually read, and marked as such
+  // rather than blended in beside the derived facets.
+</script>
+
+<div class="flex h-28 flex-col justify-center gap-2" aria-hidden="true">
+  <div class="rounded-md border border-border bg-card px-3 py-2">
+    <p class="truncate text-xs font-medium">Senior Software Engineer — Berlin, DE</p>
+  </div>
+  <div class="flex flex-col gap-1 pl-1 text-[11px] text-muted-foreground">
+    <div class="flex items-center gap-1.5">
+      <Sparkles class="size-3 shrink-0 text-brand" />
+      Team size: ~12 engineers
+    </div>
+    <div class="flex items-center gap-1.5">
+      <Sparkles class="size-3 shrink-0 text-brand" />
+      Visa sponsorship: not mentioned
+    </div>
+  </div>
+</div>

--- a/web/src/lib/components/pipeline/IngestCard.svelte
+++ b/web/src/lib/components/pipeline/IngestCard.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  // The same posting followed through every stage (see StageIllustration.svelte) starts
+  // here exactly as a source wrote it — title casing, marketing bracket and all. Nothing
+  // downstream is legible unless this first frame is honestly messy.
+</script>
+
+<div class="flex h-28 flex-col justify-center gap-2" aria-hidden="true">
+  <div class="rounded-md border border-border bg-card px-3 py-2">
+    <p class="truncate text-xs text-muted-foreground">Sr. SWE (m/f/d) — Berlin, DE 🇩🇪</p>
+  </div>
+  <div class="flex items-center gap-1.5 pl-1 font-mono text-[11px] text-muted-foreground">
+    <span class="size-1.5 rounded-full bg-muted-foreground/50"></span>
+    from workday · checked 4×/day
+  </div>
+</div>

--- a/web/src/lib/components/pipeline/ReindexCard.svelte
+++ b/web/src/lib/components/pipeline/ReindexCard.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { Check } from '@lucide/svelte';
+  // The same posting once more, now inside a mocked search-result row rather than a
+  // bare card — this is the shape it actually reaches you in, and the checkmark is the
+  // one new fact this stage adds: it's live and searchable, not just correct.
+</script>
+
+<div class="flex h-28 flex-col justify-center gap-2" aria-hidden="true">
+  <div class="flex items-center gap-3 rounded-md border border-border bg-card px-3 py-2.5">
+    <div class="size-7 shrink-0 rounded bg-secondary"></div>
+    <div class="min-w-0 flex-1">
+      <p class="truncate text-xs font-medium">Senior Software Engineer</p>
+      <p class="truncate text-[11px] text-muted-foreground">Berlin, DE · Remote-friendly</p>
+    </div>
+    <Check class="size-3.5 shrink-0 text-brand" />
+  </div>
+  <div class="pl-1 font-mono text-[11px] text-muted-foreground">indexed, searchable</div>
+</div>

--- a/web/src/lib/components/pipeline/SourcesField.svelte
+++ b/web/src/lib/components/pipeline/SourcesField.svelte
@@ -22,8 +22,8 @@
   const compactNf = new Intl.NumberFormat('en', { notation: 'compact', maximumFractionDigits: 1 });
   const companiesLabel = $derived(companies != null ? compactNf.format(companies) : null);
 
-  let container: HTMLDivElement;
-  let canvas: HTMLCanvasElement;
+  let container = $state<HTMLDivElement | undefined>(undefined);
+  let canvas = $state<HTMLCanvasElement | undefined>(undefined);
   let cleanup: (() => void) | undefined;
 
   onMount(() => {
@@ -294,16 +294,21 @@
       core.position.copy(fieldOffset);
       halo.position.copy(fieldOffset);
 
+      // This whole block runs from onMount, after bind:this has set container — but it's
+      // `let`, so TS won't carry that narrowing into the closures below without a `const`
+      // alias to hold onto.
+      const el = container;
+      if (!el) return;
       const resize = () => {
-        const w = container.clientWidth;
-        const h = container.clientHeight;
+        const w = el.clientWidth;
+        const h = el.clientHeight;
         renderer.setSize(w, h, false);
         camera.aspect = w / Math.max(1, h);
         camera.updateProjectionMatrix();
       };
       resize();
       const ro = new ResizeObserver(resize);
-      ro.observe(container);
+      ro.observe(el);
 
       const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
       let raf = 0;

--- a/web/src/lib/components/pipeline/SourcesField.svelte
+++ b/web/src/lib/components/pipeline/SourcesField.svelte
@@ -3,10 +3,12 @@
   import { SectionLabel } from '$lib/ui';
 
   // The opening thesis of the page: before any of the five stages run, this is what
-  // stage one actually faces — not one board, a field of them. `sources` and
-  // `ats_platforms` come from the same live catalogue-scale snapshot /open reads (see
-  // +page.server.ts), so the number here is never invented and never drifts from what
-  // the rest of the site claims.
+  // stage one actually faces — not one board, a field of them. `sources` drives how
+  // many points fly (the field's actual density); `companies` is what the headline
+  // number says, since "how many employers" is the more legible scale claim than
+  // "how many crawler adapters". Both come from the same live catalogue-scale
+  // snapshot /open reads (see +page.server.ts), so neither is ever invented or
+  // drifts from what the rest of the site claims.
   //
   // Three.js is dynamically imported inside onMount — never in the initial bundle —
   // and the real numbers render as plain HTML underneath the canvas regardless of
@@ -14,11 +16,11 @@
   // enhancement layered on top; losing it loses nothing true about the page.
   let {
     sources,
-    atsPlatforms,
-  }: { sources: number | null; atsPlatforms: number | null } = $props();
+    companies,
+  }: { sources: number | null; companies: number | null } = $props();
 
-  const nf = new Intl.NumberFormat('en');
-  const sourcesLabel = $derived(sources != null ? nf.format(sources) : '200+');
+  const compactNf = new Intl.NumberFormat('en', { notation: 'compact', maximumFractionDigits: 1 });
+  const companiesLabel = $derived(companies != null ? compactNf.format(companies) : null);
 
   let container: HTMLDivElement;
   let canvas: HTMLCanvasElement;
@@ -311,7 +313,6 @@
       if (reduceMotion) {
         renderer.render(scene, camera);
       } else {
-        let pulse = 0;
         let last = performance.now();
         const animate = (now: number) => {
           // Clamped so a backgrounded tab regaining focus doesn't fast-forward the
@@ -320,13 +321,18 @@
           last = now;
 
           step(dt);
-          const fired = stepRays(dt);
-          if (fired) pulse = 1;
-          pulse *= 0.9;
-          const flare = 1 + pulse * 0.5;
-          core.scale.setScalar(flare);
-          halo.scale.setScalar(flare);
-          (halo.material as InstanceType<typeof THREE.MeshBasicMaterial>).opacity = 0.12 + pulse * 0.35;
+          stepRays(dt);
+
+          // A slow, smooth breath — deliberately NOT tied to the rays firing. Five
+          // rays cycling every ~0.4s each fire roughly every 80ms; snapping the
+          // core's scale on every one of those (the previous version) sawtoothed
+          // visibly at that rate instead of reading as a pulse. This is a single
+          // gentle sine, low amplitude, its own slow period.
+          const breathe = 1 + Math.sin(now / 1600) * 0.05;
+          core.scale.setScalar(breathe);
+          halo.scale.setScalar(breathe);
+          (halo.material as InstanceType<typeof THREE.MeshBasicMaterial>).opacity =
+            0.12 + Math.sin(now / 1600) * 0.04;
 
           group.rotation.y += 0.0006 * dt;
           renderer.render(scene, camera);
@@ -374,12 +380,12 @@
   <div class="relative z-10 flex h-full flex-col justify-start gap-2 p-6 sm:p-8">
     <SectionLabel text="where it starts" />
     <p class="font-mono text-4xl font-bold tracking-tight sm:text-5xl">
-      {sourcesLabel}<span class="text-muted-foreground"> sources</span>
+      {companiesLabel ?? 'thousands of'}
+      <span class="text-muted-foreground">companies</span>
     </p>
     <p class="max-w-sm text-sm leading-relaxed text-muted-foreground">
-      Career pages, ATS platforms and boards
-      {atsPlatforms != null ? `— ${nf.format(atsPlatforms)} platforms among them` : ''} — each crawled
-      on its own schedule. Every one is where stage one starts.
+      Every open role traces back to one of them — crawled straight from where they
+      actually posted it, not a copy of a copy.
     </p>
   </div>
 </div>

--- a/web/src/lib/components/pipeline/SourcesField.svelte
+++ b/web/src/lib/components/pipeline/SourcesField.svelte
@@ -141,38 +141,54 @@
       scene.add(halo);
       scene.add(core);
 
-      // The core scanning: a curved ray that snaps out to one flying point at a time
-      // — quick to appear, brief hold, quick to fade — then swings to the next. A
-      // child of `group` so it shares the points' own local coordinate frame — it
-      // always starts at (0,0,0), the core's local position, and its far end tracks
-      // that point's live position each frame. The curve is a quadratic bezier
-      // through a control point offset perpendicular to the straight line, sampled
-      // into a fixed-length polyline every frame it's live — an actual arc, not a
-      // straight spoke.
+      // The core scanning: several curved rays, each independently snapping out to
+      // one flying point at a time — quick to appear, brief hold, quick to fade —
+      // then swinging to the next. Every ray is its own Line (its own geometry and
+      // material), all children of `group` so they share the points' own local
+      // coordinate frame: each always starts at (0,0,0), the core's local position,
+      // and its far end tracks its target's live position every frame. The curve is
+      // a quadratic bezier through a control point offset perpendicular to the
+      // straight line, sampled into a fixed-length polyline every live frame — an
+      // actual arc, not a straight spoke.
+      const RAY_COUNT = 5;
       const RAY_SEGMENTS = 14;
-      const rayPositions = new Float32Array((RAY_SEGMENTS + 1) * 3);
-      const rayGeometry = new THREE.BufferGeometry();
-      rayGeometry.setAttribute('position', new THREE.BufferAttribute(rayPositions, 3));
-      const rayMaterial = new THREE.LineBasicMaterial({
-        color: brand,
-        transparent: true,
-        opacity: 0,
-      });
-      const ray = new THREE.Line(rayGeometry, rayMaterial);
-      group.add(ray);
-      const rayPositionAttr = rayGeometry.getAttribute('position') as InstanceType<
-        typeof THREE.BufferAttribute
-      >;
-      let rayTarget = 0;
-      let rayBow = 1;
-      let rayPhase = 0;
       const RAY_CYCLE = 0.045; // phase units per animation tick (~60fps): ~0.4s/target — a scan, not a hold
-      const RAY_PEAK = 0.95;
+      const RAY_PEAK = 0.9;
 
-      const updateRayCurve = () => {
-        const ex = at(positions, rayTarget * 3);
-        const ey = at(positions, rayTarget * 3 + 1);
-        const ez = at(positions, rayTarget * 3 + 2);
+      type RayState = {
+        geometry: InstanceType<typeof THREE.BufferGeometry>;
+        positions: Float32Array;
+        positionAttr: InstanceType<typeof THREE.BufferAttribute>;
+        material: InstanceType<typeof THREE.LineBasicMaterial>;
+        target: number;
+        bow: number;
+        phase: number;
+      };
+
+      const makeRay = (phase: number): RayState => {
+        const rayPositions = new Float32Array((RAY_SEGMENTS + 1) * 3);
+        const rayGeometry = new THREE.BufferGeometry();
+        rayGeometry.setAttribute('position', new THREE.BufferAttribute(rayPositions, 3));
+        const rayMaterial = new THREE.LineBasicMaterial({ color: brand, transparent: true, opacity: 0 });
+        group.add(new THREE.Line(rayGeometry, rayMaterial));
+        return {
+          geometry: rayGeometry,
+          positions: rayPositions,
+          positionAttr: rayGeometry.getAttribute('position') as InstanceType<typeof THREE.BufferAttribute>,
+          material: rayMaterial,
+          target: Math.floor(Math.random() * pointCount),
+          bow: Math.random() < 0.5 ? -1 : 1,
+          phase,
+        };
+      };
+      // Staggered start phases so the rays don't all snap to a new target in the
+      // same frame — a scan, not a synchronized blink.
+      const rays: RayState[] = Array.from({ length: RAY_COUNT }, (_, i) => makeRay(i / RAY_COUNT));
+
+      const updateRayCurve = (ray: RayState) => {
+        const ex = at(positions, ray.target * 3);
+        const ey = at(positions, ray.target * 3 + 1);
+        const ez = at(positions, ray.target * 3 + 2);
         const len = Math.hypot(ex, ey, ez) || 1;
         const dirx = ex / len;
         const diry = ey / len;
@@ -188,41 +204,44 @@
         cpx /= plen;
         cpy /= plen;
         cpz /= plen;
-        const bow = len * 0.35 * rayBow;
+        const bow = len * 0.35 * ray.bow;
         const ctrlX = ex / 2 + cpx * bow;
         const ctrlY = ey / 2 + cpy * bow;
         const ctrlZ = ez / 2 + cpz * bow;
+        const rp = ray.positions;
         for (let s = 0; s <= RAY_SEGMENTS; s++) {
           const t = s / RAY_SEGMENTS;
           const it = 1 - t;
           const w1 = 2 * it * t;
           const w2 = t * t;
-          rayPositions[s * 3] = w1 * ctrlX + w2 * ex;
-          rayPositions[s * 3 + 1] = w1 * ctrlY + w2 * ey;
-          rayPositions[s * 3 + 2] = w1 * ctrlZ + w2 * ez;
+          rp[s * 3] = w1 * ctrlX + w2 * ex;
+          rp[s * 3 + 1] = w1 * ctrlY + w2 * ey;
+          rp[s * 3 + 2] = w1 * ctrlZ + w2 * ez;
         }
-        rayPositionAttr.needsUpdate = true;
+        ray.positionAttr.needsUpdate = true;
       };
 
-      // Fades the ray in fast, holds it briefly at full opacity on rayTarget's live
-      // position, fades it out fast, then snaps to a newly-picked target — a scan
-      // beat, not a lingering beam. Returns whether this tick fired a new target, so
-      // the core can flare in step with it.
-      const stepRay = (dt: number): boolean => {
-        rayPhase += RAY_CYCLE * dt;
+      // Fades each ray in fast, holds it briefly at full opacity on its target's
+      // live position, fades it out fast, then snaps to a newly-picked target — a
+      // scan beat, not a lingering beam. Returns whether ANY ray fired a new target
+      // this tick, so the core can flare in step with the scan.
+      const stepRays = (dt: number): boolean => {
         let fired = false;
-        if (rayPhase >= 1) {
-          rayPhase = 0;
-          let next = Math.floor(Math.random() * pointCount);
-          if (pointCount > 1 && next === rayTarget) next = (next + 1) % pointCount;
-          rayTarget = next;
-          rayBow = Math.random() < 0.5 ? -1 : 1;
-          fired = true;
+        for (const ray of rays) {
+          ray.phase += RAY_CYCLE * dt;
+          if (ray.phase >= 1) {
+            ray.phase = 0;
+            let next = Math.floor(Math.random() * pointCount);
+            if (pointCount > 1 && next === ray.target) next = (next + 1) % pointCount;
+            ray.target = next;
+            ray.bow = Math.random() < 0.5 ? -1 : 1;
+            fired = true;
+          }
+          const p = Math.min(1, ray.phase);
+          const envelope = p < 0.25 ? p / 0.25 : p > 0.7 ? (1 - p) / 0.3 : 1;
+          ray.material.opacity = envelope * RAY_PEAK;
+          updateRayCurve(ray);
         }
-        const p = Math.min(1, rayPhase);
-        const envelope = p < 0.25 ? p / 0.25 : p > 0.7 ? (1 - p) / 0.3 : 1;
-        rayMaterial.opacity = envelope * RAY_PEAK;
-        updateRayCurve();
         return fired;
       };
 
@@ -301,7 +320,7 @@
           last = now;
 
           step(dt);
-          const fired = stepRay(dt);
+          const fired = stepRays(dt);
           if (fired) pulse = 1;
           pulse *= 0.9;
           const flare = 1 + pulse * 0.5;
@@ -323,8 +342,10 @@
         material.dispose();
         core.geometry.dispose();
         (core.material as InstanceType<typeof THREE.Material>).dispose();
-        rayGeometry.dispose();
-        rayMaterial.dispose();
+        for (const ray of rays) {
+          ray.geometry.dispose();
+          ray.material.dispose();
+        }
         halo.geometry.dispose();
         (halo.material as InstanceType<typeof THREE.Material>).dispose();
         renderer.dispose();

--- a/web/src/lib/components/pipeline/SourcesField.svelte
+++ b/web/src/lib/components/pipeline/SourcesField.svelte
@@ -80,6 +80,10 @@
       // (i*3(+0..2) never exceeds pointCount*3), so this is purely a type escape
       // hatch, not a real fallback.
       const at = (arr: Float32Array, i: number) => arr[i] ?? 0;
+      // BufferGeometry.getAttribute() is typed to return possibly-undefined too, for
+      // an attribute name that was in fact just set two lines above every call site.
+      const attrOf = (g: InstanceType<typeof THREE.BufferGeometry>, name: string) =>
+        g.getAttribute(name) as InstanceType<typeof THREE.BufferAttribute>;
 
       // Uniform-random point on a unit sphere (rejection-free: this parametrization
       // does not clump at the poles the way naive lat/long sampling would).
@@ -129,17 +133,15 @@
       scene.add(group);
 
       // The one node nothing ever flies into: a dim, larger halo behind the solid
-      // core reads as a glow without a postprocessing bloom pass, and both briefly
-      // flare each time the scan ray fires (see `pulse` in the animation loop below).
+      // core reads as a glow without a postprocessing bloom pass, and both breathe
+      // gently on their own slow cycle (see the animation loop below). Named
+      // materials, not `.material` casts at the point of use — Mesh's own typing
+      // widens that to `Material | Material[]`.
       const coreColor = readCssColor('--foreground');
-      const halo = new THREE.Mesh(
-        new THREE.SphereGeometry(0.13, 24, 24),
-        new THREE.MeshBasicMaterial({ color: coreColor, transparent: true, opacity: 0.12 })
-      );
-      const core = new THREE.Mesh(
-        new THREE.SphereGeometry(0.06, 24, 24),
-        new THREE.MeshBasicMaterial({ color: coreColor })
-      );
+      const haloMaterial = new THREE.MeshBasicMaterial({ color: coreColor, transparent: true, opacity: 0.12 });
+      const coreMaterial = new THREE.MeshBasicMaterial({ color: coreColor });
+      const halo = new THREE.Mesh(new THREE.SphereGeometry(0.13, 24, 24), haloMaterial);
+      const core = new THREE.Mesh(new THREE.SphereGeometry(0.06, 24, 24), coreMaterial);
       scene.add(halo);
       scene.add(core);
 
@@ -176,7 +178,7 @@
         return {
           geometry: rayGeometry,
           positions: rayPositions,
-          positionAttr: rayGeometry.getAttribute('position') as InstanceType<typeof THREE.BufferAttribute>,
+          positionAttr: attrOf(rayGeometry, 'position'),
           material: rayMaterial,
           target: Math.floor(Math.random() * pointCount),
           bow: Math.random() < 0.5 ? -1 : 1,
@@ -196,11 +198,12 @@
         const diry = ey / len;
         const dirz = ez / len;
         // A reference axis unlikely to be parallel to the line, so the cross product
-        // below never degenerates to zero.
+        // below never degenerates to zero. Its z-component is always 0, so the cross
+        // product's own z-dropping terms are omitted rather than written out as `* 0`.
         const upx = Math.abs(diry) > 0.9 ? 1 : 0;
         const upy = Math.abs(diry) > 0.9 ? 0 : 1;
-        let cpx = diry * 0 - dirz * upy;
-        let cpy = dirz * upx - dirx * 0;
+        let cpx = -dirz * upy;
+        let cpy = dirz * upx;
         let cpz = dirx * upy - diry * upx;
         const plen = Math.hypot(cpx, cpy, cpz) || 1;
         cpx /= plen;
@@ -225,10 +228,8 @@
 
       // Fades each ray in fast, holds it briefly at full opacity on its target's
       // live position, fades it out fast, then snaps to a newly-picked target — a
-      // scan beat, not a lingering beam. Returns whether ANY ray fired a new target
-      // this tick, so the core can flare in step with the scan.
-      const stepRays = (dt: number): boolean => {
-        let fired = false;
+      // scan beat, not a lingering beam.
+      const stepRays = (dt: number) => {
         for (const ray of rays) {
           ray.phase += RAY_CYCLE * dt;
           if (ray.phase >= 1) {
@@ -237,14 +238,12 @@
             if (pointCount > 1 && next === ray.target) next = (next + 1) % pointCount;
             ray.target = next;
             ray.bow = Math.random() < 0.5 ? -1 : 1;
-            fired = true;
           }
           const p = Math.min(1, ray.phase);
           const envelope = p < 0.25 ? p / 0.25 : p > 0.7 ? (1 - p) / 0.3 : 1;
           ray.material.opacity = envelope * RAY_PEAK;
           updateRayCurve(ray);
         }
-        return fired;
       };
 
       // Advances one point by one tick — a dead straight line, nothing bends it.
@@ -267,10 +266,8 @@
         for (let k = 0; k < warmup; k++) advance(i, 1);
       }
 
-      const positionAttr = geometry.getAttribute('position') as InstanceType<
-        typeof THREE.BufferAttribute
-      >;
-      const colorAttr = geometry.getAttribute('color') as InstanceType<typeof THREE.BufferAttribute>;
+      const positionAttr = attrOf(geometry, 'position');
+      const colorAttr = attrOf(geometry, 'color');
       const step = (dt: number) => {
         for (let i = 0; i < pointCount; i++) {
           advance(i, dt);
@@ -331,8 +328,7 @@
           const breathe = 1 + Math.sin(now / 1600) * 0.05;
           core.scale.setScalar(breathe);
           halo.scale.setScalar(breathe);
-          (halo.material as InstanceType<typeof THREE.MeshBasicMaterial>).opacity =
-            0.12 + Math.sin(now / 1600) * 0.04;
+          haloMaterial.opacity = 0.12 + Math.sin(now / 1600) * 0.04;
 
           group.rotation.y += 0.0006 * dt;
           renderer.render(scene, camera);
@@ -347,13 +343,13 @@
         geometry.dispose();
         material.dispose();
         core.geometry.dispose();
-        (core.material as InstanceType<typeof THREE.Material>).dispose();
+        coreMaterial.dispose();
         for (const ray of rays) {
           ray.geometry.dispose();
           ray.material.dispose();
         }
         halo.geometry.dispose();
-        (halo.material as InstanceType<typeof THREE.Material>).dispose();
+        haloMaterial.dispose();
         renderer.dispose();
       };
     })();

--- a/web/src/lib/components/pipeline/SourcesField.svelte
+++ b/web/src/lib/components/pipeline/SourcesField.svelte
@@ -61,22 +61,13 @@
       }
       renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
 
-      // A field of independent flight paths, not a funnel: each point launches on a
-      // straight chord between two random points on the outer shell — uncorrelated
-      // with the core, same as the original static field, except now in motion. Most
-      // chords pass nowhere near the middle and just cross the field and exit; the
-      // rare one that happens to come close gets bent in by gravity and caught.
+      // A field of independent flight paths, nothing more: each point launches on a
+      // straight chord between two random points on the outer shell and flies it in
+      // a dead straight line — uncorrelated with the core, same distribution as the
+      // original static field, just moving. Nothing is ever pulled toward the
+      // center; the core's only involvement is the scanning ray below.
       const group = new THREE.Group();
       const FIELD_R = 3.3;
-      const CAPTURE_R = 0.1;
-      // Gravity only exists inside this radius — a chord that never enters it is a
-      // straight line for its entire flight, guaranteed. Without this cutoff, the
-      // pull (however weak) acts on every point for its whole time in the field, and
-      // a long enough flight eventually spirals almost everything inward regardless
-      // of how far off-center it started — which was the actual bug, not the aim.
-      const INFLUENCE_R = 0.9;
-      const GRAVITY = 0.16;
-      const MAX_ACCEL = 0.01;
       const positions = new Float32Array(pointCount * 3);
       const velocities = new Float32Array(pointCount * 3);
       const colors = new Float32Array(pointCount * 3);
@@ -135,9 +126,9 @@
       group.add(points);
       scene.add(group);
 
-      // The one node that never falls: what all of it feeds into. A dim, larger halo
-      // behind the solid core reads as a glow without a postprocessing bloom pass, and
-      // both briefly flare on every catch (see `pulse` in the animation loop below).
+      // The one node nothing ever flies into: a dim, larger halo behind the solid
+      // core reads as a glow without a postprocessing bloom pass, and both briefly
+      // flare each time the scan ray fires (see `pulse` in the animation loop below).
       const coreColor = readCssColor('--foreground');
       const halo = new THREE.Mesh(
         new THREE.SphereGeometry(0.13, 24, 24),
@@ -150,13 +141,16 @@
       scene.add(halo);
       scene.add(core);
 
-      // The core reaching out: a single ray that swings from itself to one flying
-      // point at a time, fading in, tracking that point while it holds, then fading
-      // out before picking the next target. A child of `group` so it shares the
-      // points' own local coordinate frame — its start is always (0,0,0), the core's
-      // local position, and its end is read straight from that point's live position
-      // each frame, so it never drifts off a point that is itself still moving.
-      const rayPositions = new Float32Array(6);
+      // The core scanning: a curved ray that snaps out to one flying point at a time
+      // — quick to appear, brief hold, quick to fade — then swings to the next. A
+      // child of `group` so it shares the points' own local coordinate frame — it
+      // always starts at (0,0,0), the core's local position, and its far end tracks
+      // that point's live position each frame. The curve is a quadratic bezier
+      // through a control point offset perpendicular to the straight line, sampled
+      // into a fixed-length polyline every frame it's live — an actual arc, not a
+      // straight spoke.
+      const RAY_SEGMENTS = 14;
+      const rayPositions = new Float32Array((RAY_SEGMENTS + 1) * 3);
       const rayGeometry = new THREE.BufferGeometry();
       rayGeometry.setAttribute('position', new THREE.BufferAttribute(rayPositions, 3));
       const rayMaterial = new THREE.LineBasicMaterial({
@@ -170,68 +164,78 @@
         typeof THREE.BufferAttribute
       >;
       let rayTarget = 0;
+      let rayBow = 1;
       let rayPhase = 0;
-      const RAY_CYCLE = 0.0045; // phase units per animation tick (~60fps): ~3.7s/target
+      const RAY_CYCLE = 0.045; // phase units per animation tick (~60fps): ~0.4s/target — a scan, not a hold
       const RAY_PEAK = 0.95;
 
-      // Fades the ray in, holds it at full opacity on rayTarget's live position for
-      // the middle of the cycle (not just a fleeting sine peak — long enough to
-      // actually register), fades it out, then swings to a newly-picked target.
-      const stepRay = (dt: number) => {
+      const updateRayCurve = () => {
+        const ex = at(positions, rayTarget * 3);
+        const ey = at(positions, rayTarget * 3 + 1);
+        const ez = at(positions, rayTarget * 3 + 2);
+        const len = Math.hypot(ex, ey, ez) || 1;
+        const dirx = ex / len;
+        const diry = ey / len;
+        const dirz = ez / len;
+        // A reference axis unlikely to be parallel to the line, so the cross product
+        // below never degenerates to zero.
+        const upx = Math.abs(diry) > 0.9 ? 1 : 0;
+        const upy = Math.abs(diry) > 0.9 ? 0 : 1;
+        let cpx = diry * 0 - dirz * upy;
+        let cpy = dirz * upx - dirx * 0;
+        let cpz = dirx * upy - diry * upx;
+        const plen = Math.hypot(cpx, cpy, cpz) || 1;
+        cpx /= plen;
+        cpy /= plen;
+        cpz /= plen;
+        const bow = len * 0.35 * rayBow;
+        const ctrlX = ex / 2 + cpx * bow;
+        const ctrlY = ey / 2 + cpy * bow;
+        const ctrlZ = ez / 2 + cpz * bow;
+        for (let s = 0; s <= RAY_SEGMENTS; s++) {
+          const t = s / RAY_SEGMENTS;
+          const it = 1 - t;
+          const w1 = 2 * it * t;
+          const w2 = t * t;
+          rayPositions[s * 3] = w1 * ctrlX + w2 * ex;
+          rayPositions[s * 3 + 1] = w1 * ctrlY + w2 * ey;
+          rayPositions[s * 3 + 2] = w1 * ctrlZ + w2 * ez;
+        }
+        rayPositionAttr.needsUpdate = true;
+      };
+
+      // Fades the ray in fast, holds it briefly at full opacity on rayTarget's live
+      // position, fades it out fast, then snaps to a newly-picked target — a scan
+      // beat, not a lingering beam. Returns whether this tick fired a new target, so
+      // the core can flare in step with it.
+      const stepRay = (dt: number): boolean => {
         rayPhase += RAY_CYCLE * dt;
+        let fired = false;
         if (rayPhase >= 1) {
           rayPhase = 0;
           let next = Math.floor(Math.random() * pointCount);
           if (pointCount > 1 && next === rayTarget) next = (next + 1) % pointCount;
           rayTarget = next;
+          rayBow = Math.random() < 0.5 ? -1 : 1;
+          fired = true;
         }
         const p = Math.min(1, rayPhase);
-        const envelope = p < 0.2 ? p / 0.2 : p > 0.75 ? (1 - p) / 0.25 : 1;
+        const envelope = p < 0.25 ? p / 0.25 : p > 0.7 ? (1 - p) / 0.3 : 1;
         rayMaterial.opacity = envelope * RAY_PEAK;
-        rayPositions[3] = at(positions, rayTarget * 3);
-        rayPositions[4] = at(positions, rayTarget * 3 + 1);
-        rayPositions[5] = at(positions, rayTarget * 3 + 2);
-        rayPositionAttr.needsUpdate = true;
+        updateRayCurve();
+        return fired;
       };
 
-      // Advances one point by one tick: gravity bends its velocity toward the core,
-      // then it moves. Returns whether this tick caught it (came within CAPTURE_R,
-      // in which case it's relaunched from the edge) or lost it (drifted past
-      // FIELD_R outbound with too wide a miss to ever come back — also relaunched,
-      // but that is NOT a catch, so the core's flare only fires on a real capture).
-      const advance = (i: number, dt: number): 'caught' | 'lost' | null => {
-        const px = at(positions, i * 3);
-        const py = at(positions, i * 3 + 1);
-        const pz = at(positions, i * 3 + 2);
-        const distSq = px * px + py * py + pz * pz;
-        const dist = Math.sqrt(distSq);
-
-        if (dist < CAPTURE_R) {
-          spawn(i);
-          return 'caught';
-        }
-
-        let vx = at(velocities, i * 3);
-        let vy = at(velocities, i * 3 + 1);
-        let vz = at(velocities, i * 3 + 2);
-        if (dist < INFLUENCE_R) {
-          const accel = Math.min(MAX_ACCEL, GRAVITY / Math.max(distSq, 0.05)) * dt;
-          vx -= (px / dist) * accel;
-          vy -= (py / dist) * accel;
-          vz -= (pz / dist) * accel;
-          velocities[i * 3] = vx;
-          velocities[i * 3 + 1] = vy;
-          velocities[i * 3 + 2] = vz;
-        }
-        positions[i * 3] = px + vx * dt;
-        positions[i * 3 + 1] = py + vy * dt;
-        positions[i * 3 + 2] = pz + vz * dt;
-
-        if (dist > FIELD_R * 1.15) {
-          spawn(i);
-          return 'lost';
-        }
-        return null;
+      // Advances one point by one tick — a dead straight line, nothing bends it.
+      // Once it drifts past FIELD_R outbound it's relaunched on a fresh chord.
+      const advance = (i: number, dt: number) => {
+        const px = at(positions, i * 3) + at(velocities, i * 3) * dt;
+        const py = at(positions, i * 3 + 1) + at(velocities, i * 3 + 1) * dt;
+        const pz = at(positions, i * 3 + 2) + at(velocities, i * 3 + 2) * dt;
+        positions[i * 3] = px;
+        positions[i * 3 + 1] = py;
+        positions[i * 3 + 2] = pz;
+        if (Math.hypot(px, py, pz) > FIELD_R * 1.15) spawn(i);
       };
 
       // A fresh spawn() puts every point on the outer shell, which would render as a
@@ -247,12 +251,11 @@
       >;
       const colorAttr = geometry.getAttribute('color') as InstanceType<typeof THREE.BufferAttribute>;
       const step = (dt: number) => {
-        let caught = 0;
         for (let i = 0; i < pointCount; i++) {
-          if (advance(i, dt) === 'caught') caught++;
+          advance(i, dt);
           const dist = Math.hypot(at(positions, i * 3), at(positions, i * 3 + 1), at(positions, i * 3 + 2));
-          // Brighter as it nears the core — a point reads as flying toward the light,
-          // not just sliding along a static gradient.
+          // A depth cue only — brighter the closer it happens to pass to the core on
+          // its own straight line, nothing pulls it there.
           const proximity = 1 - Math.min(1, dist / FIELD_R);
           const bright = 0.55 + proximity * 0.85;
           colors[i * 3] = brand.r * bright;
@@ -261,7 +264,6 @@
         }
         positionAttr.needsUpdate = true;
         colorAttr.needsUpdate = true;
-        return caught;
       };
       step(0);
 
@@ -294,13 +296,13 @@
         let last = performance.now();
         const animate = (now: number) => {
           // Clamped so a backgrounded tab regaining focus doesn't fast-forward the
-          // fall by several seconds in one jump.
+          // flight by several seconds in one jump.
           const dt = Math.min(3, (now - last) / (1000 / 60));
           last = now;
 
-          const caught = step(dt);
-          stepRay(dt);
-          if (caught > 0) pulse = 1;
+          step(dt);
+          const fired = stepRay(dt);
+          if (fired) pulse = 1;
           pulse *= 0.9;
           const flare = 1 + pulse * 0.5;
           core.scale.setScalar(flare);

--- a/web/src/lib/components/pipeline/SourcesField.svelte
+++ b/web/src/lib/components/pipeline/SourcesField.svelte
@@ -68,9 +68,15 @@
       // rare one that happens to come close gets bent in by gravity and caught.
       const group = new THREE.Group();
       const FIELD_R = 3.3;
-      const CAPTURE_R = 0.16;
-      const GRAVITY = 0.3;
-      const MAX_ACCEL = 0.012;
+      const CAPTURE_R = 0.1;
+      // Gravity only exists inside this radius — a chord that never enters it is a
+      // straight line for its entire flight, guaranteed. Without this cutoff, the
+      // pull (however weak) acts on every point for its whole time in the field, and
+      // a long enough flight eventually spirals almost everything inward regardless
+      // of how far off-center it started — which was the actual bug, not the aim.
+      const INFLUENCE_R = 0.9;
+      const GRAVITY = 0.16;
+      const MAX_ACCEL = 0.01;
       const positions = new Float32Array(pointCount * 3);
       const velocities = new Float32Array(pointCount * 3);
       const colors = new Float32Array(pointCount * 3);
@@ -108,7 +114,7 @@
         const dy = ey * FIELD_R - py;
         const dz = ez * FIELD_R - pz;
         const len = Math.hypot(dx, dy, dz) || 1;
-        const speed = 0.006 + Math.random() * 0.007;
+        const speed = 0.0028 + Math.random() * 0.0032;
         velocities[i * 3] = (dx / len) * speed;
         velocities[i * 3 + 1] = (dy / len) * speed;
         velocities[i * 3 + 2] = (dz / len) * speed;
@@ -134,11 +140,11 @@
       // both briefly flare on every catch (see `pulse` in the animation loop below).
       const coreColor = readCssColor('--foreground');
       const halo = new THREE.Mesh(
-        new THREE.SphereGeometry(0.2, 24, 24),
+        new THREE.SphereGeometry(0.13, 24, 24),
         new THREE.MeshBasicMaterial({ color: coreColor, transparent: true, opacity: 0.12 })
       );
       const core = new THREE.Mesh(
-        new THREE.SphereGeometry(0.11, 24, 24),
+        new THREE.SphereGeometry(0.06, 24, 24),
         new THREE.MeshBasicMaterial({ color: coreColor })
       );
       scene.add(halo);
@@ -154,7 +160,7 @@
       const rayGeometry = new THREE.BufferGeometry();
       rayGeometry.setAttribute('position', new THREE.BufferAttribute(rayPositions, 3));
       const rayMaterial = new THREE.LineBasicMaterial({
-        color: coreColor,
+        color: brand,
         transparent: true,
         opacity: 0,
       });
@@ -165,10 +171,12 @@
       >;
       let rayTarget = 0;
       let rayPhase = 0;
-      const RAY_CYCLE = 0.014; // phase units per animation tick (~60fps): about 1.2s/target
+      const RAY_CYCLE = 0.0045; // phase units per animation tick (~60fps): ~3.7s/target
+      const RAY_PEAK = 0.95;
 
-      // Fades the ray in, holds it on rayTarget's live position, fades it out, then
-      // swings it to a newly-picked target for the next cycle.
+      // Fades the ray in, holds it at full opacity on rayTarget's live position for
+      // the middle of the cycle (not just a fleeting sine peak — long enough to
+      // actually register), fades it out, then swings to a newly-picked target.
       const stepRay = (dt: number) => {
         rayPhase += RAY_CYCLE * dt;
         if (rayPhase >= 1) {
@@ -177,7 +185,9 @@
           if (pointCount > 1 && next === rayTarget) next = (next + 1) % pointCount;
           rayTarget = next;
         }
-        rayMaterial.opacity = Math.sin(Math.min(1, rayPhase) * Math.PI) * 0.55;
+        const p = Math.min(1, rayPhase);
+        const envelope = p < 0.2 ? p / 0.2 : p > 0.75 ? (1 - p) / 0.25 : 1;
+        rayMaterial.opacity = envelope * RAY_PEAK;
         rayPositions[3] = at(positions, rayTarget * 3);
         rayPositions[4] = at(positions, rayTarget * 3 + 1);
         rayPositions[5] = at(positions, rayTarget * 3 + 2);
@@ -201,13 +211,18 @@
           return 'caught';
         }
 
-        const accel = Math.min(MAX_ACCEL, GRAVITY / Math.max(distSq, 0.05)) * dt;
-        const vx = at(velocities, i * 3) - (px / dist) * accel;
-        const vy = at(velocities, i * 3 + 1) - (py / dist) * accel;
-        const vz = at(velocities, i * 3 + 2) - (pz / dist) * accel;
-        velocities[i * 3] = vx;
-        velocities[i * 3 + 1] = vy;
-        velocities[i * 3 + 2] = vz;
+        let vx = at(velocities, i * 3);
+        let vy = at(velocities, i * 3 + 1);
+        let vz = at(velocities, i * 3 + 2);
+        if (dist < INFLUENCE_R) {
+          const accel = Math.min(MAX_ACCEL, GRAVITY / Math.max(distSq, 0.05)) * dt;
+          vx -= (px / dist) * accel;
+          vy -= (py / dist) * accel;
+          vz -= (pz / dist) * accel;
+          velocities[i * 3] = vx;
+          velocities[i * 3 + 1] = vy;
+          velocities[i * 3 + 2] = vz;
+        }
         positions[i * 3] = px + vx * dt;
         positions[i * 3 + 1] = py + vy * dt;
         positions[i * 3 + 2] = pz + vz * dt;

--- a/web/src/lib/components/pipeline/SourcesField.svelte
+++ b/web/src/lib/components/pipeline/SourcesField.svelte
@@ -61,29 +61,61 @@
       }
       renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
 
-      // A Fibonacci sphere: even coverage with no clumping, and deterministic — a
-      // reader who reloads the page sees the same shape, not a different random field.
+      // A real gravity well, not a funnel: each point launches on a straight line
+      // aimed near — not necessarily through — the core, with a random miss distance.
+      // A wide miss just arcs past and exits the field to respawn on the far side; a
+      // close miss gets bent in by the pull and is caught. Most points fly by; only
+      // the ones that come close enough are the ones the core keeps.
       const group = new THREE.Group();
+      const FIELD_R = 3.3;
+      const CAPTURE_R = 0.3;
+      const GRAVITY = 0.55;
+      const MAX_ACCEL = 0.02;
       const positions = new Float32Array(pointCount * 3);
+      const velocities = new Float32Array(pointCount * 3);
       const colors = new Float32Array(pointCount * 3);
       const brand = readCssColor('--brand');
-      const golden = Math.PI * (3 - Math.sqrt(5));
-      for (let i = 0; i < pointCount; i++) {
-        const y = 1 - (i / Math.max(1, pointCount - 1)) * 2;
-        const radiusAtY = Math.sqrt(1 - y * y);
-        const theta = golden * i;
-        const r = 3.3;
-        positions[i * 3] = Math.cos(theta) * radiusAtY * r;
-        positions[i * 3 + 1] = y * r;
-        positions[i * 3 + 2] = Math.sin(theta) * radiusAtY * r;
-        // Per-point brightness jitter so the field has texture instead of reading as
-        // one flat color — an even field of identical dots is what makes a point
-        // cloud look like a placeholder rather than real, varied sources.
-        const jitter = 0.6 + Math.random() * 0.5;
-        colors[i * 3] = brand.r * jitter;
-        colors[i * 3 + 1] = brand.g * jitter;
-        colors[i * 3 + 2] = brand.b * jitter;
-      }
+
+      // A plain numeric-index read on a typed array is `number | undefined` under
+      // this project's tsconfig; every read here is bounds-safe by construction
+      // (i*3(+0..2) never exceeds pointCount*3), so this is purely a type escape
+      // hatch, not a real fallback.
+      const at = (arr: Float32Array, i: number) => arr[i] ?? 0;
+
+      // Uniform-random point on a unit sphere (rejection-free: this parametrization
+      // does not clump at the poles the way naive lat/long sampling would).
+      const randomOnSphere = (): [number, number, number] => {
+        const cosPhi = Math.random() * 2 - 1;
+        const sinPhi = Math.sqrt(1 - cosPhi * cosPhi);
+        const theta = Math.random() * Math.PI * 2;
+        return [Math.cos(theta) * sinPhi, cosPhi, Math.sin(theta) * sinPhi];
+      };
+
+      // (Re)launches point i from the field's outer edge, aimed at a point offset
+      // from the core by a random "miss distance" — the thing that makes most
+      // trajectories a near-pass rather than a bullseye.
+      const spawn = (i: number) => {
+        const [sx, sy, sz] = randomOnSphere();
+        const px = sx * FIELD_R;
+        const py = sy * FIELD_R;
+        const pz = sz * FIELD_R;
+        positions[i * 3] = px;
+        positions[i * 3 + 1] = py;
+        positions[i * 3 + 2] = pz;
+
+        const missDistance = Math.random() * Math.random() * 1.8; // biased toward small misses
+        const [mx, my, mz] = randomOnSphere();
+        const dx = mx * missDistance - px;
+        const dy = my * missDistance - py;
+        const dz = mz * missDistance - pz;
+        const len = Math.hypot(dx, dy, dz) || 1;
+        const speed = 0.018 + Math.random() * 0.02;
+        velocities[i * 3] = (dx / len) * speed;
+        velocities[i * 3 + 1] = (dy / len) * speed;
+        velocities[i * 3 + 2] = (dz / len) * speed;
+      };
+      for (let i = 0; i < pointCount; i++) spawn(i);
+
       const geometry = new THREE.BufferGeometry();
       geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
       geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
@@ -98,8 +130,9 @@
       group.add(points);
       scene.add(group);
 
-      // The one node that never orbits: what all of it feeds into. A dim, larger halo
-      // behind the solid core reads as a glow without a postprocessing bloom pass.
+      // The one node that never falls: what all of it feeds into. A dim, larger halo
+      // behind the solid core reads as a glow without a postprocessing bloom pass, and
+      // both briefly flare on every catch (see `pulse` in the animation loop below).
       const coreColor = readCssColor('--foreground');
       const halo = new THREE.Mesh(
         new THREE.SphereGeometry(0.34, 24, 24),
@@ -111,6 +144,72 @@
       );
       scene.add(halo);
       scene.add(core);
+
+      // Advances one point by one tick: gravity bends its velocity toward the core,
+      // then it moves. Returns whether this tick caught it (came within CAPTURE_R,
+      // in which case it's relaunched from the edge) or lost it (drifted past
+      // FIELD_R outbound with too wide a miss to ever come back — also relaunched,
+      // but that is NOT a catch, so the core's flare only fires on a real capture).
+      const advance = (i: number, dt: number): 'caught' | 'lost' | null => {
+        const px = at(positions, i * 3);
+        const py = at(positions, i * 3 + 1);
+        const pz = at(positions, i * 3 + 2);
+        const distSq = px * px + py * py + pz * pz;
+        const dist = Math.sqrt(distSq);
+
+        if (dist < CAPTURE_R) {
+          spawn(i);
+          return 'caught';
+        }
+
+        const accel = Math.min(MAX_ACCEL, GRAVITY / Math.max(distSq, 0.05)) * dt;
+        const vx = at(velocities, i * 3) - (px / dist) * accel;
+        const vy = at(velocities, i * 3 + 1) - (py / dist) * accel;
+        const vz = at(velocities, i * 3 + 2) - (pz / dist) * accel;
+        velocities[i * 3] = vx;
+        velocities[i * 3 + 1] = vy;
+        velocities[i * 3 + 2] = vz;
+        positions[i * 3] = px + vx * dt;
+        positions[i * 3 + 1] = py + vy * dt;
+        positions[i * 3 + 2] = pz + vz * dt;
+
+        if (dist > FIELD_R * 1.15) {
+          spawn(i);
+          return 'lost';
+        }
+        return null;
+      };
+
+      // A fresh spawn() puts every point on the outer shell, which would render as a
+      // hollow ring on the very first frame — so each point gets independently
+      // fast-forwarded a random distance into its own flight before the first paint.
+      for (let i = 0; i < pointCount; i++) {
+        const warmup = Math.floor(Math.random() * 220);
+        for (let k = 0; k < warmup; k++) advance(i, 1);
+      }
+
+      const positionAttr = geometry.getAttribute('position') as InstanceType<
+        typeof THREE.BufferAttribute
+      >;
+      const colorAttr = geometry.getAttribute('color') as InstanceType<typeof THREE.BufferAttribute>;
+      const step = (dt: number) => {
+        let caught = 0;
+        for (let i = 0; i < pointCount; i++) {
+          if (advance(i, dt) === 'caught') caught++;
+          const dist = Math.hypot(at(positions, i * 3), at(positions, i * 3 + 1), at(positions, i * 3 + 2));
+          // Brighter as it nears the core — a point reads as flying toward the light,
+          // not just sliding along a static gradient.
+          const proximity = 1 - Math.min(1, dist / FIELD_R);
+          const bright = 0.55 + proximity * 0.85;
+          colors[i * 3] = brand.r * bright;
+          colors[i * 3 + 1] = brand.g * bright;
+          colors[i * 3 + 2] = brand.b * bright;
+        }
+        positionAttr.needsUpdate = true;
+        colorAttr.needsUpdate = true;
+        return caught;
+      };
+      step(0);
 
       // The text sits top-left (the canvas mask fades that corner out); push the whole
       // field toward the bottom-right so the core node — the brightest, largest thing
@@ -137,13 +236,27 @@
       if (reduceMotion) {
         renderer.render(scene, camera);
       } else {
-        const animate = () => {
-          group.rotation.y += 0.0015;
-          group.rotation.x = Math.sin(Date.now() / 8000) * 0.08;
+        let pulse = 0;
+        let last = performance.now();
+        const animate = (now: number) => {
+          // Clamped so a backgrounded tab regaining focus doesn't fast-forward the
+          // fall by several seconds in one jump.
+          const dt = Math.min(3, (now - last) / (1000 / 60));
+          last = now;
+
+          const caught = step(dt);
+          if (caught > 0) pulse = 1;
+          pulse *= 0.9;
+          const flare = 1 + pulse * 0.5;
+          core.scale.setScalar(flare);
+          halo.scale.setScalar(flare);
+          (halo.material as InstanceType<typeof THREE.MeshBasicMaterial>).opacity = 0.12 + pulse * 0.35;
+
+          group.rotation.y += 0.0006 * dt;
           renderer.render(scene, camera);
           raf = requestAnimationFrame(animate);
         };
-        animate();
+        raf = requestAnimationFrame(animate);
       }
 
       cleanup = () => {
@@ -170,7 +283,7 @@
 
 <div
   bind:this={container}
-  class="relative h-80 overflow-hidden rounded-xl border border-border bg-secondary/20 sm:h-[26rem]"
+  class="relative h-96 overflow-hidden sm:h-[32rem] lg:h-[38rem]"
 >
   <canvas
     bind:this={canvas}

--- a/web/src/lib/components/pipeline/SourcesField.svelte
+++ b/web/src/lib/components/pipeline/SourcesField.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy, onMount } from 'svelte';
+  import { onMount } from 'svelte';
   import { SectionLabel } from '$lib/ui';
 
   // The opening thesis of the page: before any of the five stages run, this is what
@@ -359,8 +359,6 @@
       cleanup?.();
     };
   });
-
-  onDestroy(() => cleanup?.());
 </script>
 
 <div

--- a/web/src/lib/components/pipeline/SourcesField.svelte
+++ b/web/src/lib/components/pipeline/SourcesField.svelte
@@ -289,7 +289,7 @@
       // field toward the bottom-right so the core node — the brightest, largest thing
       // here — never sits behind a word regardless of how the box's aspect ratio
       // reflows the text block across breakpoints.
-      const fieldOffset = new THREE.Vector3(1.2, -0.75, 0);
+      const fieldOffset = new THREE.Vector3(1.2, -0.15, 0);
       group.position.copy(fieldOffset);
       core.position.copy(fieldOffset);
       halo.position.copy(fieldOffset);
@@ -363,7 +363,7 @@
 
 <div
   bind:this={container}
-  class="relative h-96 overflow-hidden sm:h-[32rem] lg:h-[38rem]"
+  class="relative h-72 overflow-hidden sm:h-80 lg:h-96"
 >
   <canvas
     bind:this={canvas}

--- a/web/src/lib/components/pipeline/SourcesField.svelte
+++ b/web/src/lib/components/pipeline/SourcesField.svelte
@@ -61,16 +61,16 @@
       }
       renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
 
-      // A real gravity well, not a funnel: each point launches on a straight line
-      // aimed near — not necessarily through — the core, with a random miss distance.
-      // A wide miss just arcs past and exits the field to respawn on the far side; a
-      // close miss gets bent in by the pull and is caught. Most points fly by; only
-      // the ones that come close enough are the ones the core keeps.
+      // A field of independent flight paths, not a funnel: each point launches on a
+      // straight chord between two random points on the outer shell — uncorrelated
+      // with the core, same as the original static field, except now in motion. Most
+      // chords pass nowhere near the middle and just cross the field and exit; the
+      // rare one that happens to come close gets bent in by gravity and caught.
       const group = new THREE.Group();
       const FIELD_R = 3.3;
-      const CAPTURE_R = 0.3;
-      const GRAVITY = 0.55;
-      const MAX_ACCEL = 0.02;
+      const CAPTURE_R = 0.16;
+      const GRAVITY = 0.3;
+      const MAX_ACCEL = 0.012;
       const positions = new Float32Array(pointCount * 3);
       const velocities = new Float32Array(pointCount * 3);
       const colors = new Float32Array(pointCount * 3);
@@ -91,9 +91,9 @@
         return [Math.cos(theta) * sinPhi, cosPhi, Math.sin(theta) * sinPhi];
       };
 
-      // (Re)launches point i from the field's outer edge, aimed at a point offset
-      // from the core by a random "miss distance" — the thing that makes most
-      // trajectories a near-pass rather than a bullseye.
+      // (Re)launches point i on a chord from one random point on the outer shell to
+      // another — a trajectory that has nothing to do with where the core sits, so
+      // whether it happens to pass close is geometry, not aim.
       const spawn = (i: number) => {
         const [sx, sy, sz] = randomOnSphere();
         const px = sx * FIELD_R;
@@ -103,13 +103,12 @@
         positions[i * 3 + 1] = py;
         positions[i * 3 + 2] = pz;
 
-        const missDistance = Math.random() * Math.random() * 1.8; // biased toward small misses
-        const [mx, my, mz] = randomOnSphere();
-        const dx = mx * missDistance - px;
-        const dy = my * missDistance - py;
-        const dz = mz * missDistance - pz;
+        const [ex, ey, ez] = randomOnSphere();
+        const dx = ex * FIELD_R - px;
+        const dy = ey * FIELD_R - py;
+        const dz = ez * FIELD_R - pz;
         const len = Math.hypot(dx, dy, dz) || 1;
-        const speed = 0.018 + Math.random() * 0.02;
+        const speed = 0.006 + Math.random() * 0.007;
         velocities[i * 3] = (dx / len) * speed;
         velocities[i * 3 + 1] = (dy / len) * speed;
         velocities[i * 3 + 2] = (dz / len) * speed;
@@ -135,15 +134,55 @@
       // both briefly flare on every catch (see `pulse` in the animation loop below).
       const coreColor = readCssColor('--foreground');
       const halo = new THREE.Mesh(
-        new THREE.SphereGeometry(0.34, 24, 24),
+        new THREE.SphereGeometry(0.2, 24, 24),
         new THREE.MeshBasicMaterial({ color: coreColor, transparent: true, opacity: 0.12 })
       );
       const core = new THREE.Mesh(
-        new THREE.SphereGeometry(0.2, 24, 24),
+        new THREE.SphereGeometry(0.11, 24, 24),
         new THREE.MeshBasicMaterial({ color: coreColor })
       );
       scene.add(halo);
       scene.add(core);
+
+      // The core reaching out: a single ray that swings from itself to one flying
+      // point at a time, fading in, tracking that point while it holds, then fading
+      // out before picking the next target. A child of `group` so it shares the
+      // points' own local coordinate frame — its start is always (0,0,0), the core's
+      // local position, and its end is read straight from that point's live position
+      // each frame, so it never drifts off a point that is itself still moving.
+      const rayPositions = new Float32Array(6);
+      const rayGeometry = new THREE.BufferGeometry();
+      rayGeometry.setAttribute('position', new THREE.BufferAttribute(rayPositions, 3));
+      const rayMaterial = new THREE.LineBasicMaterial({
+        color: coreColor,
+        transparent: true,
+        opacity: 0,
+      });
+      const ray = new THREE.Line(rayGeometry, rayMaterial);
+      group.add(ray);
+      const rayPositionAttr = rayGeometry.getAttribute('position') as InstanceType<
+        typeof THREE.BufferAttribute
+      >;
+      let rayTarget = 0;
+      let rayPhase = 0;
+      const RAY_CYCLE = 0.014; // phase units per animation tick (~60fps): about 1.2s/target
+
+      // Fades the ray in, holds it on rayTarget's live position, fades it out, then
+      // swings it to a newly-picked target for the next cycle.
+      const stepRay = (dt: number) => {
+        rayPhase += RAY_CYCLE * dt;
+        if (rayPhase >= 1) {
+          rayPhase = 0;
+          let next = Math.floor(Math.random() * pointCount);
+          if (pointCount > 1 && next === rayTarget) next = (next + 1) % pointCount;
+          rayTarget = next;
+        }
+        rayMaterial.opacity = Math.sin(Math.min(1, rayPhase) * Math.PI) * 0.55;
+        rayPositions[3] = at(positions, rayTarget * 3);
+        rayPositions[4] = at(positions, rayTarget * 3 + 1);
+        rayPositions[5] = at(positions, rayTarget * 3 + 2);
+        rayPositionAttr.needsUpdate = true;
+      };
 
       // Advances one point by one tick: gravity bends its velocity toward the core,
       // then it moves. Returns whether this tick caught it (came within CAPTURE_R,
@@ -245,6 +284,7 @@
           last = now;
 
           const caught = step(dt);
+          stepRay(dt);
           if (caught > 0) pulse = 1;
           pulse *= 0.9;
           const flare = 1 + pulse * 0.5;
@@ -266,6 +306,8 @@
         material.dispose();
         core.geometry.dispose();
         (core.material as InstanceType<typeof THREE.Material>).dispose();
+        rayGeometry.dispose();
+        rayMaterial.dispose();
         halo.geometry.dispose();
         (halo.material as InstanceType<typeof THREE.Material>).dispose();
         renderer.dispose();

--- a/web/src/lib/components/pipeline/SourcesField.svelte
+++ b/web/src/lib/components/pipeline/SourcesField.svelte
@@ -1,0 +1,192 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { SectionLabel } from '$lib/ui';
+
+  // The opening thesis of the page: before any of the five stages run, this is what
+  // stage one actually faces — not one board, a field of them. `sources` and
+  // `ats_platforms` come from the same live catalogue-scale snapshot /open reads (see
+  // +page.server.ts), so the number here is never invented and never drifts from what
+  // the rest of the site claims.
+  //
+  // Three.js is dynamically imported inside onMount — never in the initial bundle —
+  // and the real numbers render as plain HTML underneath the canvas regardless of
+  // whether WebGL, motion, or JavaScript itself is available. The canvas is a pure
+  // enhancement layered on top; losing it loses nothing true about the page.
+  let {
+    sources,
+    atsPlatforms,
+  }: { sources: number | null; atsPlatforms: number | null } = $props();
+
+  const nf = new Intl.NumberFormat('en');
+  const sourcesLabel = $derived(sources != null ? nf.format(sources) : '200+');
+
+  let container: HTMLDivElement;
+  let canvas: HTMLCanvasElement;
+  let cleanup: (() => void) | undefined;
+
+  onMount(() => {
+    let cancelled = false;
+
+    (async () => {
+      const pointCount = sources ?? 200;
+      const THREE = await import('three');
+      if (cancelled) return;
+
+      // The token's raw value can be any CSS Color 4 syntax (this codebase's dark
+      // tokens are oklch()), and a modern canvas fillStyle GETTER can hand the same
+      // syntax straight back rather than normalizing it — which THREE.Color cannot
+      // parse and silently leaves at its white default. Rasterizing one pixel and
+      // reading it back is what actually forces concrete 8-bit sRGB, regardless of
+      // the input color space or the browser's serialization quirks.
+      const ctx = document.createElement('canvas').getContext('2d');
+      const readCssColor = (name: string) => {
+        const raw = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+        if (!ctx || !raw) return new THREE.Color(0x5b6f00);
+        ctx.fillStyle = raw;
+        ctx.fillRect(0, 0, 1, 1);
+        const pixel = ctx.getImageData(0, 0, 1, 1).data;
+        return new THREE.Color((pixel[0] ?? 91) / 255, (pixel[1] ?? 111) / 255, (pixel[2] ?? 0) / 255);
+      };
+
+      const scene = new THREE.Scene();
+      const camera = new THREE.PerspectiveCamera(50, 1, 0.1, 100);
+      camera.position.set(0, 0.3, 5.2);
+      camera.lookAt(0, 0, 0);
+
+      let renderer: InstanceType<typeof THREE.WebGLRenderer>;
+      try {
+        renderer = new THREE.WebGLRenderer({ canvas, alpha: true, antialias: true });
+      } catch {
+        return; // No WebGL — the HTML figures underneath already say everything true.
+      }
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+
+      // A Fibonacci sphere: even coverage with no clumping, and deterministic — a
+      // reader who reloads the page sees the same shape, not a different random field.
+      const group = new THREE.Group();
+      const positions = new Float32Array(pointCount * 3);
+      const colors = new Float32Array(pointCount * 3);
+      const brand = readCssColor('--brand');
+      const golden = Math.PI * (3 - Math.sqrt(5));
+      for (let i = 0; i < pointCount; i++) {
+        const y = 1 - (i / Math.max(1, pointCount - 1)) * 2;
+        const radiusAtY = Math.sqrt(1 - y * y);
+        const theta = golden * i;
+        const r = 3.3;
+        positions[i * 3] = Math.cos(theta) * radiusAtY * r;
+        positions[i * 3 + 1] = y * r;
+        positions[i * 3 + 2] = Math.sin(theta) * radiusAtY * r;
+        // Per-point brightness jitter so the field has texture instead of reading as
+        // one flat color — an even field of identical dots is what makes a point
+        // cloud look like a placeholder rather than real, varied sources.
+        const jitter = 0.6 + Math.random() * 0.5;
+        colors[i * 3] = brand.r * jitter;
+        colors[i * 3 + 1] = brand.g * jitter;
+        colors[i * 3 + 2] = brand.b * jitter;
+      }
+      const geometry = new THREE.BufferGeometry();
+      geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+      geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+      const material = new THREE.PointsMaterial({
+        size: 0.075,
+        vertexColors: true,
+        transparent: true,
+        opacity: 0.95,
+        sizeAttenuation: true,
+      });
+      const points = new THREE.Points(geometry, material);
+      group.add(points);
+      scene.add(group);
+
+      // The one node that never orbits: what all of it feeds into. A dim, larger halo
+      // behind the solid core reads as a glow without a postprocessing bloom pass.
+      const coreColor = readCssColor('--foreground');
+      const halo = new THREE.Mesh(
+        new THREE.SphereGeometry(0.34, 24, 24),
+        new THREE.MeshBasicMaterial({ color: coreColor, transparent: true, opacity: 0.12 })
+      );
+      const core = new THREE.Mesh(
+        new THREE.SphereGeometry(0.2, 24, 24),
+        new THREE.MeshBasicMaterial({ color: coreColor })
+      );
+      scene.add(halo);
+      scene.add(core);
+
+      // The text sits top-left (the canvas mask fades that corner out); push the whole
+      // field toward the bottom-right so the core node — the brightest, largest thing
+      // here — never sits behind a word regardless of how the box's aspect ratio
+      // reflows the text block across breakpoints.
+      const fieldOffset = new THREE.Vector3(1.2, -0.75, 0);
+      group.position.copy(fieldOffset);
+      core.position.copy(fieldOffset);
+      halo.position.copy(fieldOffset);
+
+      const resize = () => {
+        const w = container.clientWidth;
+        const h = container.clientHeight;
+        renderer.setSize(w, h, false);
+        camera.aspect = w / Math.max(1, h);
+        camera.updateProjectionMatrix();
+      };
+      resize();
+      const ro = new ResizeObserver(resize);
+      ro.observe(container);
+
+      const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      let raf = 0;
+      if (reduceMotion) {
+        renderer.render(scene, camera);
+      } else {
+        const animate = () => {
+          group.rotation.y += 0.0015;
+          group.rotation.x = Math.sin(Date.now() / 8000) * 0.08;
+          renderer.render(scene, camera);
+          raf = requestAnimationFrame(animate);
+        };
+        animate();
+      }
+
+      cleanup = () => {
+        cancelAnimationFrame(raf);
+        ro.disconnect();
+        geometry.dispose();
+        material.dispose();
+        core.geometry.dispose();
+        (core.material as InstanceType<typeof THREE.Material>).dispose();
+        halo.geometry.dispose();
+        (halo.material as InstanceType<typeof THREE.Material>).dispose();
+        renderer.dispose();
+      };
+    })();
+
+    return () => {
+      cancelled = true;
+      cleanup?.();
+    };
+  });
+
+  onDestroy(() => cleanup?.());
+</script>
+
+<div
+  bind:this={container}
+  class="relative h-80 overflow-hidden rounded-xl border border-border bg-secondary/20 sm:h-[26rem]"
+>
+  <canvas
+    bind:this={canvas}
+    class="absolute inset-0 h-full w-full"
+    style="mask-image: radial-gradient(140% 140% at 0% 0%, transparent, transparent 25%, black 62%); -webkit-mask-image: radial-gradient(140% 140% at 0% 0%, transparent, transparent 25%, black 62%);"
+    aria-hidden="true"
+  ></canvas>
+  <div class="relative z-10 flex h-full flex-col justify-start gap-2 p-6 sm:p-8">
+    <SectionLabel text="where it starts" />
+    <p class="font-mono text-4xl font-bold tracking-tight sm:text-5xl">
+      {sourcesLabel}<span class="text-muted-foreground"> sources</span>
+    </p>
+    <p class="max-w-sm text-sm leading-relaxed text-muted-foreground">
+      Career pages, ATS platforms and boards
+      {atsPlatforms != null ? `— ${nf.format(atsPlatforms)} platforms among them` : ''} — each crawled
+      on its own schedule. Every one is where stage one starts.
+    </p>
+  </div>
+</div>

--- a/web/src/lib/components/pipeline/StageIllustration.svelte
+++ b/web/src/lib/components/pipeline/StageIllustration.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import type { Component } from 'svelte';
+  import type { StageKey } from '$lib/pipelineStages';
+  import DedupCard from './DedupCard.svelte';
+  import DeriveCard from './DeriveCard.svelte';
+  import EnrichCard from './EnrichCard.svelte';
+  import IngestCard from './IngestCard.svelte';
+  import ReindexCard from './ReindexCard.svelte';
+
+  // Exhaustive at compile time, same as ghost/SignalDiagram.svelte's registry — a stage
+  // added to pipelineStages.ts without a matching entry here fails the build rather than
+  // rendering nothing.
+  const REGISTRY: Record<StageKey, Component> = {
+    ingest: IngestCard,
+    derive: DeriveCard,
+    enrich: EnrichCard,
+    deduplicate: DedupCard,
+    reindex: ReindexCard,
+  };
+
+  let { stage }: { stage: StageKey } = $props();
+  const Illustration = $derived(REGISTRY[stage]);
+</script>
+
+<Illustration />

--- a/web/src/lib/docs/api-spec.ts
+++ b/web/src/lib/docs/api-spec.ts
@@ -126,9 +126,12 @@ export const OVERVIEW: Overview[] = [
     paragraphs: [
       'This reference covers every endpoint you can call. A handful are ' +
         'deliberately left out because calling them directly is meaningless: the ' +
-        'Gmail consent redirect (`/me/gmail/connect` and its callback), which only ' +
-        'a browser can complete; the Telegram bot webhook; the browser-tool ' +
-        'websocket relay; and the sitemap-cursor helpers behind `/sitemap.xml`.',
+        'Gmail and calendar consent redirects (`/me/gmail/connect`, ' +
+        '`/me/calendar/connect`, and their callbacks), which only a browser can ' +
+        'complete; the Telegram bot webhook and the Discord interaction webhook; the ' +
+        'browser-tool websocket relay; the sitemap-cursor helpers behind ' +
+        '`/sitemap.xml`; and the `/og/*.png` social-preview cards, which render an ' +
+        'image rather than answer with JSON.',
       'The `/jobs/{slug}/fit` endpoints are pre-rename aliases of ' +
         '`/jobs/{slug}/match-analysis` and hit the same handlers. They still work, ' +
         'so existing clients do not break — use the match-analysis paths in new code.',
@@ -343,6 +346,27 @@ export const GROUPS: Group[] = [
     }
   ],
   "meta": { "total": 4 }
+}`,
+      },
+      {
+        method: 'GET',
+        path: '/jobs/{slug}/apply-form',
+        auth: 'none',
+        summary: 'The captured ATS application form for the posting.',
+        description:
+          'The questions a candidate will have to answer, shaped for reading. ' +
+          'Only captured for a minority of postings (roughly a sixth of ' +
+          'technical ATS platforms are readable at all) — no captured form is ' +
+          'a `404`, distinguishable from an unknown slug (also `404`, but at ' +
+          'the job lookup rather than the form lookup).',
+        pathParams: [{ name: 'slug', type: 'string', required: true, description: 'The job `public_slug`.', example: 'senior-go-engineer-acme-1a2b' }],
+        curl: `curl "${BASE_URL}/jobs/senior-go-engineer-acme-1a2b/apply-form"`,
+        responseExample: `{
+  "data": {
+    "provider": "greenhouse",
+    "basics": ["resume", "phone", "linkedin"],
+    "questions": [ { "text": "Why do you want to work here?", "required": true } ]
+  }
 }`,
       },
     ],
@@ -603,6 +627,165 @@ data: {"kind":"final","analysis":{"overall_score":82,"verdict":"Strong Fit","...
     ],
   },
   {
+    title: 'Geography',
+    intro: 'Public reference data backing search and profile city autocompletes.',
+    endpoints: [
+      {
+        method: 'GET',
+        path: '/geo/cities',
+        auth: 'none',
+        summary: 'Prefix-search city names for autocomplete.',
+        description:
+          'Population-ranked prefix search over the embedded city dictionary, ' +
+          'optionally narrowed to one country. A blank `q` returns an empty list.',
+        query: [
+          { name: 'q', type: 'string', description: 'Prefix to match.', example: 'berl' },
+          { name: 'country', type: 'string', description: 'ISO 3166-1 alpha-2 code to narrow to.', example: 'DE' },
+        ],
+        curl: `curl "${BASE_URL}/geo/cities?q=berl&country=DE"`,
+        responseExample: `{ "data": [ { "value": "Berlin", "country": "DE" } ] }`,
+      },
+    ],
+  },
+  {
+    title: 'Company feedback',
+    intro:
+      'Signed-in users leave a 1–5 star rating plus category and text about a ' +
+      'company, shown under their site-wide pseudonymous persona (never a user ' +
+      'id). Reads are public; writes are cookie-only. A reader can report a ' +
+      'specific review, and a moderator can hide it.',
+    endpoints: [
+      {
+        method: 'GET',
+        path: '/companies/{slug}/feedback',
+        auth: 'none',
+        summary: "List a company's feedback, newest first.",
+        pathParams: [{ name: 'slug', type: 'string', required: true, description: 'The company slug.', example: 'acme' }],
+        query: [
+          { name: 'limit', type: 'integer', description: 'Page size, 1–100.', example: '20' },
+          { name: 'offset', type: 'integer', description: 'Rows to skip.', example: '0' },
+        ],
+        curl: `curl "${BASE_URL}/companies/acme/feedback"`,
+        responseExample: `{
+  "data": [
+    {
+      "id": 5,
+      "author": "quiet-falcon-42",
+      "rating": 4,
+      "feedback_type": "interview",
+      "body": "Fast process, clear communication.",
+      "created_at": "2026-06-18T09:12:00Z",
+      "updated_at": "2026-06-18T09:12:00Z"
+    }
+  ],
+  "meta": { "total": 12, "limit": 20, "offset": 0 }
+}`,
+      },
+      {
+        method: 'GET',
+        path: '/companies/{slug}/feedback/mine',
+        auth: 'cookie',
+        summary: 'Your own feedback on this company, across every category (empty if none).',
+        pathParams: [{ name: 'slug', type: 'string', required: true, description: 'The company slug.', example: 'acme' }],
+        curl: `curl "${BASE_URL}/companies/acme/feedback/mine" -b cookies.txt`,
+        responseExample: `{ "data": [ { "id": 5, "author": "quiet-falcon-42", "rating": 4, "feedback_type": "interview", "body": "...", "created_at": "...", "updated_at": "..." } ] }`,
+      },
+      {
+        method: 'POST',
+        path: '/companies/{slug}/feedback',
+        auth: 'cookie',
+        summary: 'Create or overwrite your feedback in one category on a company.',
+        description:
+          'One entry per (user, category): posting again in the same ' +
+          '`feedback_type` overwrites your existing review rather than adding a ' +
+          "second one. The response's nested `company` field is the freshly " +
+          'recomputed rating count/average, so you can update your own view of ' +
+          'the company without a second fetch. `422` on an empty body, `429` past ' +
+          'the daily review cap.',
+        pathParams: [{ name: 'slug', type: 'string', required: true, description: 'The company slug.', example: 'acme' }],
+        body: [
+          { name: 'rating', type: 'integer', required: true, description: '1–5 stars.', example: '4' },
+          { name: 'feedback_type', type: 'string', required: true, description: 'Review category, e.g. `interview`, `culture`, `compensation`.', example: 'interview' },
+          { name: 'body', type: 'string', required: true, description: 'Free-text review.', example: 'Fast process, clear communication.' },
+        ],
+        curl: `curl -X POST "${BASE_URL}/companies/acme/feedback" \\
+  -b cookies.txt -H 'Content-Type: application/json' \\
+  -d '{"rating":4,"feedback_type":"interview","body":"Fast process, clear communication."}'`,
+        responseExample: `{
+  "data": {
+    "id": 5,
+    "author": "quiet-falcon-42",
+    "rating": 4,
+    "feedback_type": "interview",
+    "body": "Fast process, clear communication.",
+    "created_at": "2026-06-18T09:12:00Z",
+    "updated_at": "2026-06-18T09:12:00Z",
+    "company": { "feedback_count": 12, "feedback_rating_avg": 4.1 }
+  }
+}`,
+      },
+      {
+        method: 'DELETE',
+        path: '/companies/{slug}/feedback',
+        auth: 'cookie',
+        summary: 'Delete your feedback in one category (no-op if absent).',
+        description:
+          "Returns the company's freshly recomputed counters, the same " +
+          'cast/clear shape as the vote endpoints.',
+        pathParams: [{ name: 'slug', type: 'string', required: true, description: 'The company slug.', example: 'acme' }],
+        query: [{ name: 'feedback_type', type: 'string', required: true, description: 'Which category to delete.', example: 'interview' }],
+        curl: `curl -X DELETE "${BASE_URL}/companies/acme/feedback?feedback_type=interview" -b cookies.txt`,
+        responseExample: `{ "data": { "feedback_count": 11, "feedback_rating_avg": 4.0 } }`,
+      },
+      {
+        method: 'POST',
+        path: '/company-feedback/{id}/report',
+        auth: 'cookie',
+        summary: 'Report a specific review.',
+        description: 'A second report of the same review by you is a silent no-op.',
+        pathParams: [{ name: 'id', type: 'integer', required: true, description: 'The feedback entry id.', example: '5' }],
+        body: [{ name: 'reason', type: 'string', required: true, description: 'Report reason code.', example: 'spam' }],
+        curl: `curl -X POST "${BASE_URL}/company-feedback/5/report" \\
+  -b cookies.txt -H 'Content-Type: application/json' \\
+  -d '{"reason":"spam"}'`,
+        responseExample: `(204 No Content)`,
+      },
+      {
+        method: 'GET',
+        path: '/company-feedback/reported',
+        auth: 'moderator',
+        summary: 'Every review with at least one report, most-reported first.',
+        curl: `curl "${BASE_URL}/company-feedback/reported" -H "Authorization: Bearer $MODERATOR_API_KEY"`,
+        responseExample: `{
+  "data": [
+    {
+      "id": 5,
+      "author": "quiet-falcon-42",
+      "rating": 1,
+      "feedback_type": "culture",
+      "body": "...",
+      "created_at": "...",
+      "updated_at": "...",
+      "company_slug": "acme",
+      "report_count": 3,
+      "report_reasons": ["spam", "off-topic"]
+    }
+  ]
+}`,
+      },
+      {
+        method: 'POST',
+        path: '/company-feedback/{id}/hide',
+        auth: 'moderator',
+        summary: "Hide a review, dropping it from the company's public list and average.",
+        description: 'Idempotent. 404 for an unknown id.',
+        pathParams: [{ name: 'id', type: 'integer', required: true, description: 'The feedback entry id.', example: '5' }],
+        curl: `curl -X POST "${BASE_URL}/company-feedback/5/hide" -H "Authorization: Bearer $MODERATOR_API_KEY"`,
+        responseExample: `(204 No Content)`,
+      },
+    ],
+  },
+  {
     title: 'Authentication',
     intro:
       'Register/login set the session cookie and return the user. Logout clears ' +
@@ -675,6 +858,112 @@ data: {"kind":"final","analysis":{"overall_score":82,"verdict":"Strong Fit","...
         pathParams: [{ name: 'provider', type: 'string', required: true, description: 'One of the enabled providers.', example: 'google' }],
         curl: `# open in a browser:
 ${BASE_URL}/auth/oauth/google/start`,
+      },
+      {
+        method: 'POST',
+        path: '/auth/verify/request',
+        auth: 'cookie',
+        summary: 'Send (or resend) a six-digit email verification code.',
+        description: 'Mails a fresh code to the caller’s own address, never a body field. Returns `202 Accepted`. `409` if the address is already confirmed.',
+        curl: `curl -X POST "${BASE_URL}/auth/verify/request" -b cookies.txt`,
+      },
+      {
+        method: 'POST',
+        path: '/auth/verify/confirm',
+        auth: 'cookie',
+        summary: 'Confirm the address with the mailed code.',
+        body: [{ name: 'code', type: 'string', required: true, description: 'The six-digit code mailed to your address.', example: '123456' }],
+        curl: `curl -X POST "${BASE_URL}/auth/verify/confirm" \\
+  -H 'Content-Type: application/json' -b cookies.txt \\
+  -d '{"code":"123456"}'`,
+        responseExample: `{ "data": { "id": 1, "email": "me@example.com", "role": "user", "...": "..." } }`,
+      },
+      {
+        method: 'POST',
+        path: '/auth/password/forgot',
+        auth: 'none',
+        summary: 'Request a password-reset code by email.',
+        description: 'Always answers `202`, whether or not the address has an account — this is deliberately not an email-enumeration oracle.',
+        body: [{ name: 'email', type: 'string', required: true, description: 'Account email.', example: 'me@example.com' }],
+        curl: `curl -X POST "${BASE_URL}/auth/password/forgot" \\
+  -H 'Content-Type: application/json' \\
+  -d '{"email":"me@example.com"}'`,
+      },
+      {
+        method: 'POST',
+        path: '/auth/password/reset',
+        auth: 'none',
+        summary: 'Set a new password against a mailed code.',
+        description: 'Public — the code is the credential. Success revokes every existing session, so sign in fresh with the new password afterward.',
+        body: [
+          { name: 'email', type: 'string', required: true, description: 'Account email.', example: 'me@example.com' },
+          { name: 'code', type: 'string', required: true, description: 'The mailed reset code.', example: '123456' },
+          { name: 'password', type: 'string', required: true, description: 'New password.' },
+        ],
+        curl: `curl -X POST "${BASE_URL}/auth/password/reset" \\
+  -H 'Content-Type: application/json' \\
+  -d '{"email":"me@example.com","code":"123456","password":"hunter2hunter2"}'`,
+        responseExample: `{ "data": { "reset": true } }`,
+      },
+      {
+        method: 'POST',
+        path: '/auth/logout-all',
+        auth: 'cookie',
+        summary: 'Sign out every session on the account, including this one.',
+        description: 'Bumps the account’s session generation (stranding every issued token and API-key session state) then clears the caller’s cookie. Cookie-only — an API key must not be able to sign a human out of their browser. Returns `204 No Content`.',
+        curl: `curl -X POST "${BASE_URL}/auth/logout-all" -b cookies.txt`,
+      },
+      {
+        method: 'POST',
+        path: '/auth/oauth/exchange',
+        auth: 'none',
+        summary: 'Redeem a mobile OAuth callback code for a session.',
+        description:
+          'Mobile-only: the app’s custom-scheme OAuth callback carries a ' +
+          'single-use code (not the session directly); this exchanges it for ' +
+          'the session cookie, landing in the app’s own cookie jar. Public — the ' +
+          'code is the credential, and a missing/expired/reused one is a `401`.',
+        body: [{ name: 'code', type: 'string', required: true, description: 'The one-time code from the mobile callback redirect.' }],
+        curl: `curl -X POST "${BASE_URL}/auth/oauth/exchange" \\
+  -H 'Content-Type: application/json' -c cookies.txt \\
+  -d '{"code":"..."}'`,
+        responseExample: `{ "data": { "id": 1, "email": "me@example.com", "role": "user" } }`,
+      },
+      {
+        method: 'GET',
+        path: '/auth/extension/connect',
+        auth: 'extension',
+        summary: 'Consent screen for "Sign in with freehire" from the browser extension.',
+        description:
+          'Opened by the extension via `chrome.identity.launchWebAuthFlow`, not ' +
+          'called directly — renders an HTML consent page, not JSON. ' +
+          '`redirect_uri` must be an allowlisted `https://<extension-id>.chromiumapp.org` ' +
+          'origin, or this is a `400`. A signed-out visitor is bounced through ' +
+          'sign-in first, then back to this same consent step.',
+        query: [
+          { name: 'redirect_uri', type: 'string', required: true, description: 'The allowlisted chromiumapp.org redirect the extension is listening on.' },
+          { name: 'state', type: 'string', description: 'Opaque value echoed back on completion.' },
+        ],
+        curl: `# opened by the extension, not called directly:
+${BASE_URL}/auth/extension/connect?redirect_uri=https://<extension-id>.chromiumapp.org/&state=...`,
+      },
+      {
+        method: 'POST',
+        path: '/auth/extension/connect',
+        auth: 'extension',
+        summary: 'Submit the consent decision and mint the extension’s session token.',
+        description:
+          'Submitted by the consent screen’s own form, not called directly. On ' +
+          '`decision=allow`, 302-redirects to `redirect_uri` with a session ' +
+          'token in the URL fragment (never the query, so it is never logged or ' +
+          'sent to a server); on anything else, redirects with `error=access_denied`. ' +
+          'Not a JSON endpoint.',
+        body: [
+          { name: 'redirect_uri', type: 'string', required: true, description: 'Must match the allowlisted redirect validated on the GET step.' },
+          { name: 'state', type: 'string', description: 'Opaque value echoed back.' },
+          { name: 'decision', type: 'string', required: true, description: '`allow` or `cancel`.', example: 'allow' },
+        ],
+        curl: `# submitted by the consent page's own form, not called directly`,
       },
     ],
   },
@@ -817,6 +1106,45 @@ ${BASE_URL}/auth/oauth/google/start`,
         pathParams: [{ name: 'slug', type: 'string', required: true, description: 'The job `public_slug`.' }],
         curl: `curl -X DELETE "${BASE_URL}/jobs/<slug>/track" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
         responseExample: `{ "data": { "ok": true } }`,
+      },
+      {
+        method: 'PATCH',
+        path: '/me/applications/{id}',
+        auth: 'cookie-or-key',
+        summary: 'Set the application stage and/or notes, addressed by row id.',
+        description:
+          'Same as `PATCH /jobs/{slug}/track`, but addressed by the ' +
+          'tracking-board row id instead of the job slug — needed when a ' +
+          'tracked application’s posting was later pruned and has no slug left ' +
+          'to address it by. Same `stage` vocabulary and body shape.',
+        pathParams: [{ name: 'id', type: 'integer', required: true, description: 'The tracking row id (from `/me/tracking`).', example: '42' }],
+        body: [
+          { name: 'stage', type: 'string', description: 'Application stage.', example: 'interview' },
+          { name: 'notes', type: 'string', description: 'Free-text notes.' },
+        ],
+        curl: `curl -X PATCH "${BASE_URL}/me/applications/42" \\
+  -H "Authorization: Bearer $FREEHIRE_API_KEY" \\
+  -H 'Content-Type: application/json' \\
+  -d '{"stage":"interview"}'`,
+        responseExample: `{ "data": { "job_id": 42, "stage": "interview", "notes": null } }`,
+      },
+      {
+        method: 'DELETE',
+        path: '/me/applications/{id}',
+        auth: 'cookie-or-key',
+        summary: 'Remove the interaction record entirely, addressed by row id.',
+        pathParams: [{ name: 'id', type: 'integer', required: true, description: 'The tracking row id.', example: '42' }],
+        curl: `curl -X DELETE "${BASE_URL}/me/applications/42" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
+        responseExample: `{ "data": { "ok": true } }`,
+      },
+      {
+        method: 'DELETE',
+        path: '/me/applications/{id}/stage',
+        auth: 'cookie-or-key',
+        summary: 'Clear the application stage, addressed by row id.',
+        pathParams: [{ name: 'id', type: 'integer', required: true, description: 'The tracking row id.', example: '42' }],
+        curl: `curl -X DELETE "${BASE_URL}/me/applications/42/stage" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
+        responseExample: `{ "data": { "job_id": 42, "stage": null } }`,
       },
       {
         method: 'POST',
@@ -1030,6 +1358,217 @@ ${BASE_URL}/auth/oauth/google/start`,
   "meta": { "from": "2026-08-01T00:00:00Z", "to": "2026-08-31T23:59:59Z", "count": 2 }
 }`,
       },
+      {
+        method: 'GET',
+        path: '/me/interviews',
+        auth: 'cookie-or-key',
+        summary: 'Arranged meetings whose start falls in the date range.',
+        description:
+          'The calendar’s second layer beside `/me/timeline`: a meeting is ' +
+          'arranged and can move or be cancelled, unlike a ledger event which ' +
+          'happened and cannot change. `status` is `suggested`, `confirmed`, or ' +
+          '`cancelled` — a cancelled meeting is still served, not withheld. Both ' +
+          'bounds are required, RFC3339.',
+        query: [
+          { name: 'from', type: 'string (RFC3339)', required: true, description: 'Lower bound, inclusive.', example: '2026-08-01T00:00:00Z' },
+          { name: 'to', type: 'string (RFC3339)', required: true, description: 'Upper bound, inclusive.', example: '2026-08-31T23:59:59Z' },
+        ],
+        curl: `curl "${BASE_URL}/me/interviews?from=2026-08-01T00:00:00Z&to=2026-08-31T23:59:59Z" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
+        responseExample: `{
+  "data": [
+    {
+      "id": 3,
+      "application_id": 31,
+      "starts_at": "2026-08-20T13:00:00Z",
+      "ends_at": "2026-08-20T13:30:00Z",
+      "title": "Interview with Acme",
+      "join_url": "https://meet.example.com/abc",
+      "status": "confirmed",
+      "company_slug": "acme",
+      "role_title": "Senior Go Engineer",
+      "job_slug": "senior-go-engineer-acme-1a2b"
+    }
+  ],
+  "meta": { "from": "2026-08-01T00:00:00Z", "to": "2026-08-31T23:59:59Z", "count": 1 }
+}`,
+      },
+    ],
+  },
+  {
+    title: 'In-app assistant',
+    intro:
+      'The same agent the web app and browser extension chat with, over HTTP: create a ' +
+      'conversation, then post messages to it. All routes accept the session cookie or an ' +
+      'API key (`autopilot` is cookie-only — see below) and act on a session you own; ' +
+      'someone else’s session id answers `404`, same as one that never existed. Turns run ' +
+      'one at a time per session — a message sent while one is already running queues ' +
+      'rather than running alongside it. `preset` selects which conversation this is: ' +
+      '`chat` (default), `profile` (the experience interviewer), `browse` (a browsing ' +
+      'session held from the extension’s side panel), `interview` (a mock-interview ' +
+      'rehearsal) or `debrief` (after a real one) — the last two must name the vacancy via ' +
+      '`?job=<slug>`, an application you already hold. A `tailor` session cannot be created ' +
+      'here; it is minted by the CV tailoring bootstrap, which knows the CV and vacancy to ' +
+      'bind it to.',
+    endpoints: [
+      {
+        method: 'POST',
+        path: '/assistant/sessions',
+        auth: 'cookie-or-key',
+        summary: 'Start a new conversation.',
+        query: [
+          { name: 'preset', type: 'string', description: 'One of `chat` (default), `profile`, `browse`, `interview`, `debrief`.', example: 'chat' },
+          { name: 'job', type: 'string', description: 'Public slug of an application you hold. Required for `interview`/`debrief`, ignored otherwise.', example: 'senior-go-engineer-acme-1a2b' },
+        ],
+        curl: `curl -X POST "${BASE_URL}/assistant/sessions?preset=chat" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
+        responseExample: `{ "data": { "id": "b2f1c2b0-6e2a-4c9e-9c2e-0a1b2c3d4e5f", "preset": "chat", "label": "" } }`,
+      },
+      {
+        method: 'GET',
+        path: '/assistant/sessions',
+        auth: 'cookie-or-key',
+        summary: 'List your chat conversations, newest activity first.',
+        description: 'Tailoring conversations are not chats — each belongs to a CV — so they never appear here.',
+        curl: `curl "${BASE_URL}/assistant/sessions" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
+        responseExample: `{
+  "data": [
+    { "id": "b2f1c2b0-6e2a-4c9e-9c2e-0a1b2c3d4e5f", "preset": "chat", "label": "Relocating to Berlin?" }
+  ],
+  "meta": { "total": 1 }
+}`,
+      },
+      {
+        method: 'GET',
+        path: '/assistant/sessions/{id}',
+        auth: 'cookie-or-key',
+        summary: 'One owned conversation with its full transcript.',
+        pathParams: [{ name: 'id', type: 'string (UUID)', required: true, description: 'The session id.', example: 'b2f1c2b0-6e2a-4c9e-9c2e-0a1b2c3d4e5f' }],
+        curl: `curl "${BASE_URL}/assistant/sessions/<id>" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
+        responseExample: `{
+  "data": {
+    "session": { "id": "b2f1c2b0-6e2a-4c9e-9c2e-0a1b2c3d4e5f", "preset": "chat", "label": "Relocating to Berlin?" },
+    "messages": [
+      { "seq": 1, "role": "user", "content": { "text": "Should I relocate for this role?" } },
+      { "seq": 2, "role": "assistant", "content": { "text": "...", "...": "..." } }
+    ]
+  }
+}`,
+      },
+      {
+        method: 'DELETE',
+        path: '/assistant/sessions/{id}',
+        auth: 'cookie-or-key',
+        summary: 'Delete an owned conversation and its transcript.',
+        description: 'Returns `204 No Content`.',
+        pathParams: [{ name: 'id', type: 'string (UUID)', required: true, description: 'The session id.' }],
+        curl: `curl -X DELETE "${BASE_URL}/assistant/sessions/<id>" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
+      },
+      {
+        method: 'POST',
+        path: '/assistant/sessions/{id}/messages',
+        auth: 'cookie-or-key',
+        summary: 'Send a message and stream the turn as Server-Sent Events.',
+        description:
+          'Body is `{"text": "..."}` (max ~8000 characters, deployment-configured). The ' +
+          'response is `text/event-stream`, not JSON: each frame is `event: <kind>` plus a ' +
+          '`data:` line carrying the JSON event (whose own `type` field repeats the kind). ' +
+          'Kinds: `queued` (this turn waited for one already running), `user_prompt`, ' +
+          '`assistant_text` / `assistant_thought` (streamed deltas), `tool_use` / ' +
+          '`tool_result`, `usage`, and exactly one terminal `result` carrying `stop_reason` ' +
+          '(`completed`, `cancelled`, or `error`). The turn keeps running even if you stop ' +
+          'reading — stopping it is a separate call to `.../cancel`.',
+        pathParams: [{ name: 'id', type: 'string (UUID)', required: true, description: 'The session id.' }],
+        body: [{ name: 'text', type: 'string', required: true, description: 'Your message.', example: 'Should I relocate for this role?' }],
+        curl: `curl -N -X POST "${BASE_URL}/assistant/sessions/<id>/messages" \\
+  -H "Authorization: Bearer $FREEHIRE_API_KEY" -H 'Content-Type: application/json' \\
+  -d '{"text":"Should I relocate for this role?"}'`,
+        responseExample: `event: user_prompt
+data: {"type":"user_prompt","text":"Should I relocate for this role?"}
+
+event: assistant_text
+data: {"type":"assistant_text","text":"Based on the salary range..."}
+
+event: result
+data: {"type":"result","stop_reason":"completed"}
+
+`,
+      },
+      {
+        method: 'POST',
+        path: '/assistant/sessions/{id}/cancel',
+        auth: 'cookie-or-key',
+        summary: 'Stop the session’s running turn.',
+        description: 'A no-op (still `204`) when nothing is running — you cannot see whether a turn is live before asking.',
+        pathParams: [{ name: 'id', type: 'string (UUID)', required: true, description: 'The session id.' }],
+        curl: `curl -X POST "${BASE_URL}/assistant/sessions/<id>/cancel" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
+      },
+      {
+        method: 'POST',
+        path: '/assistant/sessions/{id}/opening',
+        auth: 'cookie-or-key',
+        summary: 'Have the assistant speak first, on an `interview`/`debrief` session.',
+        description:
+          'Streams one turn under a server-side brief (no body), the same SSE shape as ' +
+          '`.../messages`. `409` if the session’s preset does not open by itself, or if it ' +
+          'already has an assistant message (an opening cannot be re-run).',
+        pathParams: [{ name: 'id', type: 'string (UUID)', required: true, description: 'The session id.' }],
+        curl: `curl -N -X POST "${BASE_URL}/assistant/sessions/<id>/opening" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
+      },
+      {
+        method: 'POST',
+        path: '/assistant/sessions/{id}/retry',
+        auth: 'cookie-or-key',
+        summary: 'Resume after a failed turn, without adding another user message.',
+        description:
+          'Re-runs the loop over the existing history (no body) — the same SSE shape as ' +
+          '`.../messages`. `409 "nothing to retry"` when the session has no prior user message.',
+        pathParams: [{ name: 'id', type: 'string (UUID)', required: true, description: 'The session id.' }],
+        curl: `curl -N -X POST "${BASE_URL}/assistant/sessions/<id>/retry" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
+      },
+      {
+        method: 'POST',
+        path: '/assistant/sessions/{id}/voice-token',
+        auth: 'cookie-or-key',
+        summary: 'Mint a short-lived credential for a hands-free voice call.',
+        description:
+          'Only on an `interview` session; `409` otherwise. Rate-limited to 20 calls started ' +
+          'per hour per caller. The audio itself never reaches this server: take the returned ' +
+          '`value` to `calls_url` (this deployment’s own realtime gateway, not api.openai.com ' +
+          'directly) to negotiate the WebRTC call. `501` when voice mode is not configured.',
+        pathParams: [{ name: 'id', type: 'string (UUID)', required: true, description: 'The session id.' }],
+        curl: `curl -X POST "${BASE_URL}/assistant/sessions/<id>/voice-token" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
+        responseExample: `{ "data": { "value": "ek_...", "model": "gpt-realtime", "calls_url": "https://freehire.me/api/v1/realtime/calls" } }`,
+      },
+      {
+        method: 'POST',
+        path: '/assistant/sessions/{id}/voice-turns',
+        auth: 'cookie-or-key',
+        summary: 'Append one completed spoken exchange to the transcript.',
+        description:
+          'Only on an `interview` session. Lets a call continued by typing carry the spoken ' +
+          'turns forward in context. Returns `204 No Content`.',
+        pathParams: [{ name: 'id', type: 'string (UUID)', required: true, description: 'The session id.' }],
+        body: [
+          { name: 'role', type: 'string', required: true, description: '`user` or `assistant`.', example: 'user' },
+          { name: 'content', type: 'string', required: true, description: 'The transcribed/spoken text.' },
+        ],
+        curl: `curl -X POST "${BASE_URL}/assistant/sessions/<id>/voice-turns" \\
+  -H "Authorization: Bearer $FREEHIRE_API_KEY" -H 'Content-Type: application/json' \\
+  -d '{"role":"user","content":"I led the migration to Kubernetes."}'`,
+      },
+      {
+        method: 'POST',
+        path: '/assistant/sessions/{id}/autopilot',
+        auth: 'cookie',
+        summary: 'Run an unattended CV-tailoring pass as one long streamed turn.',
+        description:
+          'Session-only, not API-key — an unattended run edits a CV, and the browser is the ' +
+          'only place you can watch it happen and undo it. Requires a `tailor` session bound ' +
+          'to both a CV and a vacancy (`409` otherwise). Same SSE shape as `.../messages`, no ' +
+          'body; every edit lands in one revision batch, so undoing the run is reverting that ' +
+          'batch.',
+        pathParams: [{ name: 'id', type: 'string (UUID)', required: true, description: 'The session id.' }],
+        curl: `curl -N -X POST "${BASE_URL}/assistant/sessions/<id>/autopilot" -b cookies.txt`,
+      },
     ],
   },
   {
@@ -1058,6 +1597,22 @@ ${BASE_URL}/auth/oauth/google/start`,
   -H 'Content-Type: application/json' \\
   -d '{"url":"https://acme.com/careers/123","title":"Senior Go Engineer","company":"Acme","remote":true}'`,
         responseExample: `{ "data": { "id": 9, "status": "pending", "title": "Senior Go Engineer", "company": "Acme", "url": "https://acme.com/careers/123" } }`,
+      },
+      {
+        method: 'POST',
+        path: '/submissions/prefill',
+        auth: 'cookie-or-key',
+        summary: 'Parse a job URL into a draft submission for review before posting.',
+        description:
+          'Uses the same ATS-recognition registry as `/jobs/resolve`, but ' +
+          'writes nothing — no job, no submission, no credit. An unrecognized ' +
+          'URL returns an empty object rather than an error. Rate-limited ' +
+          '(shares the outbound-fetch budget).',
+        body: [{ name: 'url', type: 'string', required: true, description: 'The job posting URL to parse.' }],
+        curl: `curl -X POST "${BASE_URL}/submissions/prefill" \\
+  -H "Authorization: Bearer $FREEHIRE_API_KEY" -H 'Content-Type: application/json' \\
+  -d '{"url":"https://boards.greenhouse.io/acme/jobs/123"}'`,
+        responseExample: `{ "data": { "title": "Senior Go Engineer", "company": "Acme", "location": "Remote — EU", "description": "...", "work_mode": "remote", "employment_type": "full_time", "seniority": "senior", "skills": ["go"], "source": "greenhouse" } }`,
       },
       {
         method: 'GET',
@@ -1182,6 +1737,43 @@ ${BASE_URL}/auth/oauth/google/start`,
   -H 'Content-Type: application/json' \\
   -d '{"reason":"not an issue"}'`,
         responseExample: `{ "data": { "id": 3, "status": "dismissed", "review_reason": "not an issue" } }`,
+      },
+    ],
+  },
+  {
+    title: 'Ghost job reports',
+    intro:
+      'One person states they applied to a posting and were never answered, ' +
+      'feeding the ghost-signal evidence used elsewhere in the API (see the ' +
+      '`reality` field on a job). Distinct from Job reports above: nothing here ' +
+      'reaches a moderator and nothing here closes the job directly.',
+    endpoints: [
+      {
+        method: 'POST',
+        path: '/jobs/{slug}/ghost-report',
+        auth: 'cookie-or-key',
+        summary: 'File a claim that you applied and got no response.',
+        description:
+          'An unproven (unverified) address is a `403`; a closed job or a claim ' +
+          'you already have on this job is a `409`; past the daily cap is a `429`.',
+        pathParams: [{ name: 'slug', type: 'string', required: true, description: 'The job `public_slug`.' }],
+        body: [
+          { name: 'applied_on', type: 'string', required: true, description: 'The day you applied (`YYYY-MM-DD`).', example: '2026-07-29' },
+        ],
+        curl: `curl -X POST "${BASE_URL}/jobs/<slug>/ghost-report" \\
+  -H "Authorization: Bearer $FREEHIRE_API_KEY" -H 'Content-Type: application/json' \\
+  -d '{"applied_on":"2026-07-29"}'`,
+        responseExample: `{ "data": { "job_id": 42, "applied_on": "2026-07-29", "created_at": "2026-07-29T10:00:00Z" } }`,
+      },
+      {
+        method: 'DELETE',
+        path: '/jobs/{slug}/ghost-report',
+        auth: 'cookie-or-key',
+        summary: 'Withdraw your claim about this job.',
+        description: 'A claim that is absent or already withdrawn is a `404`.',
+        pathParams: [{ name: 'slug', type: 'string', required: true, description: 'The job `public_slug`.' }],
+        curl: `curl -X DELETE "${BASE_URL}/jobs/<slug>/ghost-report" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
+        responseExample: `(204 No Content)`,
       },
     ],
   },
@@ -1396,6 +1988,108 @@ ${BASE_URL}/auth/oauth/google/start`,
         description: 'Returns `204 No Content`. `501` when object storage is unconfigured.',
         curl: `curl -X DELETE "${BASE_URL}/me/resume" -b cookies.txt`,
       },
+      {
+        method: 'PUT',
+        path: '/me/resume/contacts',
+        auth: 'cookie',
+        summary: 'Override one or more contact-block fields on your profile.',
+        description:
+          'Each body field is owned per field: a value you set here takes over ' +
+          'that field from whatever the structured résumé extract would otherwise ' +
+          'contribute. Omit a field to leave it as-is; to clear rather than ' +
+          'override, use `POST /me/resume/contacts/replace-from-cv`.',
+        body: [
+          { name: 'full_name', type: 'string', description: 'Overrides the extracted name.' },
+          { name: 'email', type: 'string', description: 'Overrides the extracted email.' },
+          { name: 'phone', type: 'string', description: 'Overrides the extracted phone.' },
+          { name: 'location', type: 'string', description: 'Overrides the extracted location.' },
+          { name: 'links', type: 'string[]', description: 'Overrides the extracted links.' },
+          { name: 'headline', type: 'string', description: 'A one-line positioning statement.' },
+          { name: 'summary', type: 'string', description: 'A short profile summary.' },
+          { name: 'languages', type: 'string[]', description: 'Spoken/written languages.' },
+          { name: 'certifications', type: 'string[]', description: 'Certifications to show.' },
+          { name: 'education', type: 'object[]', description: 'Education entries to show.' },
+        ],
+        curl: `curl -X PUT "${BASE_URL}/me/resume/contacts" -b cookies.txt \\
+  -H 'Content-Type: application/json' -d '{"email":"me@work.com","phone":"+1 555 0100"}'`,
+        responseExample: `{ "data": { "full_name": "Jane Doe", "email": "me@work.com", "phone": "+1 555 0100", "location": "Berlin, Germany" } }`,
+      },
+      {
+        method: 'POST',
+        path: '/me/resume/contacts/replace-from-cv',
+        auth: 'cookie',
+        summary: 'Reset every contact override from your current structured résumé.',
+        description:
+          'A full reset, not just identity fields — every owned field is replaced ' +
+          'from the current structured extract. `409` when you have no structured ' +
+          'résumé to copy from.',
+        curl: `curl -X POST "${BASE_URL}/me/resume/contacts/replace-from-cv" -b cookies.txt`,
+        responseExample: `{ "data": { "full_name": "Jane Doe", "email": "jane@example.com", "location": "Berlin, Germany" } }`,
+      },
+    ],
+  },
+  {
+    title: 'Screening answers',
+    intro:
+      'The six candidate-stated facts that repeat across ATS application forms ' +
+      'and no CV can supply. A singleton per user — no id in the path. `PUT` is ' +
+      'a partial update: a field the body omits keeps its stored value.',
+    endpoints: [
+      {
+        method: 'GET',
+        path: '/me/screening-answers',
+        auth: 'cookie-or-key',
+        summary: 'Your stored screening answers, or `null` if you have stated none.',
+        curl: `curl "${BASE_URL}/me/screening-answers" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
+        responseExample: `{
+  "data": {
+    "authorized_countries": ["DE", "NL"],
+    "visa_sponsorship_needed": false,
+    "desired_salary_amount": 90000,
+    "desired_salary_currency": "EUR",
+    "desired_salary_period": "year",
+    "notice_period_days": 30,
+    "willing_to_relocate": true,
+    "age_18_or_older": true
+  }
+}`,
+      },
+      {
+        method: 'PUT',
+        path: '/me/screening-answers',
+        auth: 'cookie',
+        summary: 'Update one or more screening answers.',
+        description:
+          'A field the body omits is left unchanged. An unrecognized country ' +
+          'code, a currency that is not a three-letter ISO 4217 code, a period ' +
+          'outside the vocabulary, a non-positive salary, or a negative notice ' +
+          'period is a `400` naming the invalid value.',
+        body: [
+          { name: 'authorized_countries', type: 'string[]', description: 'ISO alpha-2 country codes you are authorized to work in.', example: '["DE","NL"]' },
+          { name: 'visa_sponsorship_needed', type: 'boolean', description: 'Whether you need visa sponsorship.' },
+          { name: 'desired_salary_amount', type: 'integer', description: 'Desired salary figure.', example: '90000' },
+          { name: 'desired_salary_currency', type: 'string', description: 'Three-letter ISO 4217 currency code.', example: 'EUR' },
+          { name: 'desired_salary_period', type: 'string', description: 'Salary period, e.g. `year`, `month`.', example: 'year' },
+          { name: 'notice_period_days', type: 'integer', description: 'Notice period in days.', example: '30' },
+          { name: 'willing_to_relocate', type: 'boolean', description: 'Whether you are willing to relocate.' },
+          { name: 'age_18_or_older', type: 'boolean', description: 'Whether you are 18 or older.' },
+        ],
+        curl: `curl -X PUT "${BASE_URL}/me/screening-answers" \\
+  -b cookies.txt -H 'Content-Type: application/json' \\
+  -d '{"willing_to_relocate":true,"notice_period_days":30}'`,
+        responseExample: `{
+  "data": {
+    "authorized_countries": ["DE", "NL"],
+    "visa_sponsorship_needed": false,
+    "desired_salary_amount": 90000,
+    "desired_salary_currency": "EUR",
+    "desired_salary_period": "year",
+    "notice_period_days": 30,
+    "willing_to_relocate": true,
+    "age_18_or_older": true
+  }
+}`,
+      },
     ],
   },
   {
@@ -1590,7 +2284,132 @@ ${BASE_URL}/auth/oauth/google/start`,
         auth: 'cookie',
         summary: 'Unlink your Telegram account.',
         curl: `curl -X DELETE "${BASE_URL}/me/telegram" -b cookies.txt`,
-        responseExample: `{ "data": { "ok": true } }`,
+        responseExample: `(204 No Content)`,
+      },
+      {
+        method: 'GET',
+        path: '/me/discord',
+        auth: 'cookie',
+        summary: 'Your Discord link status (for the `/contribute` bot command).',
+        curl: `curl "${BASE_URL}/me/discord" -b cookies.txt`,
+        responseExample: `{ "data": { "enabled": true, "linked": true, "discord_id": 123456789 } }`,
+      },
+      {
+        method: 'POST',
+        path: '/me/discord/link',
+        auth: 'cookie',
+        summary: 'Mint a one-time token to link your Discord account.',
+        description:
+          'Discord has no deep-link URL equivalent to Telegram’s — paste the ' +
+          'returned token into the bot’s `/link` slash command.',
+        curl: `curl -X POST "${BASE_URL}/me/discord/link" -b cookies.txt`,
+        responseExample: `{ "data": { "token": "abc123...", "instructions": "In the freehire Discord server, run /link token:abc123..." } }`,
+      },
+      {
+        method: 'DELETE',
+        path: '/me/discord',
+        auth: 'cookie',
+        summary: 'Unlink your Discord account. Idempotent.',
+        curl: `curl -X DELETE "${BASE_URL}/me/discord" -b cookies.txt`,
+        responseExample: `(204 No Content)`,
+      },
+    ],
+  },
+  {
+    title: 'Push notifications & alerts',
+    intro:
+      'The mobile app’s device push tokens, and the in-app notification center ' +
+      '— a durable, channel-independent record of every delivered digest, ' +
+      'reminder and nudge. All cookie-only.',
+    endpoints: [
+      {
+        method: 'POST',
+        path: '/me/push-tokens',
+        auth: 'cookie',
+        summary: 'Register (or reassign) a mobile device’s Expo push token.',
+        description:
+          'Upserted by token value, not by user: if a different account signs ' +
+          'in on the same device, this reassigns the token to the new caller. ' +
+          'Returns `204 No Content`.',
+        body: [
+          { name: 'token', type: 'string', required: true, description: 'The Expo push token minted by the device.', example: 'ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]' },
+          { name: 'platform', type: 'string', required: true, description: '`ios` or `android`.', example: 'ios' },
+        ],
+        curl: `curl -X POST "${BASE_URL}/me/push-tokens" \\
+  -H 'Content-Type: application/json' -b cookies.txt \\
+  -d '{"token":"ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]","platform":"ios"}'`,
+      },
+      {
+        method: 'GET',
+        path: '/me/push-tokens',
+        auth: 'cookie',
+        summary: 'List your own registered devices.',
+        curl: `curl "${BASE_URL}/me/push-tokens" -b cookies.txt`,
+        responseExample: `{
+  "data": [ { "token": "ExponentPushToken[...]", "platform": "ios", "created_at": "2026-06-19T10:00:00Z", "last_seen_at": "2026-06-19T10:00:00Z" } ],
+  "meta": { "total": 1 }
+}`,
+      },
+      {
+        method: 'DELETE',
+        path: '/me/push-tokens',
+        auth: 'cookie',
+        summary: 'Unregister one of your own device tokens.',
+        description: 'Returns `204 No Content`. `404` if the token is not yours (or unknown).',
+        body: [{ name: 'token', type: 'string', required: true, description: 'The token to remove.' }],
+        curl: `curl -X DELETE "${BASE_URL}/me/push-tokens" \\
+  -H 'Content-Type: application/json' -b cookies.txt \\
+  -d '{"token":"ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]"}'`,
+      },
+      {
+        method: 'POST',
+        path: '/me/push-tokens/test',
+        auth: 'cookie',
+        summary: 'Send a test push to all of your own registered devices.',
+        description: 'Never targets another user or a caller-supplied destination — only your own registered tokens. Rate-limited to 20/hour, since each call fans out one outbound send per device.',
+        curl: `curl -X POST "${BASE_URL}/me/push-tokens/test" -b cookies.txt`,
+        responseExample: `{ "data": { "devices": 2, "sent": 1, "pruned": 1, "failed": 0 } }`,
+      },
+      {
+        method: 'GET',
+        path: '/me/notifications',
+        auth: 'cookie',
+        summary: 'List your notification-center entries, newest first.',
+        query: [
+          { name: 'limit', type: 'integer', description: 'Page size, 1–100.', example: '20' },
+          { name: 'offset', type: 'integer', description: 'Rows to skip.', example: '0' },
+        ],
+        curl: `curl "${BASE_URL}/me/notifications?limit=20" -b cookies.txt`,
+        responseExample: `{
+  "data": [ { "id": 5, "kind": "subscription_digest", "title": "3 new jobs match Senior Go remote", "body": "...", "public_slug": null, "jobs": [ "...": "..." ], "created_at": "2026-06-19T10:00:00Z", "read_at": null } ],
+  "meta": { "total": 12, "unread_count": 3, "limit": 20, "offset": 0 }
+}`,
+      },
+      {
+        method: 'GET',
+        path: '/me/notifications/{id}',
+        auth: 'cookie',
+        summary: 'One of your notifications, including its jobs snapshot.',
+        pathParams: [{ name: 'id', type: 'integer', required: true, description: 'The notification id.', example: '5' }],
+        curl: `curl "${BASE_URL}/me/notifications/5" -b cookies.txt`,
+        responseExample: `{ "data": { "id": 5, "kind": "reminder", "title": "...", "body": "...", "public_slug": "senior-go-engineer-acme-1a2b", "created_at": "2026-06-19T10:00:00Z", "read_at": null } }`,
+      },
+      {
+        method: 'POST',
+        path: '/me/notifications/{id}/read',
+        auth: 'cookie',
+        summary: 'Mark one notification read (idempotent).',
+        description: 'Returns `204 No Content`.',
+        pathParams: [{ name: 'id', type: 'integer', required: true, description: 'The notification id.', example: '5' }],
+        curl: `curl -X POST "${BASE_URL}/me/notifications/5/read" -b cookies.txt`,
+      },
+      {
+        method: 'POST',
+        path: '/me/notifications/read-all',
+        auth: 'cookie',
+        summary: 'Mark every unread notification read.',
+        curl: `curl -X POST "${BASE_URL}/me/notifications/read-all" -b cookies.txt`,
+        responseExample: `{ "data": { "marked": 3 } }`,
       },
     ],
   },
@@ -1637,6 +2456,20 @@ ${BASE_URL}/auth/oauth/google/start`,
         ],
         curl: `curl "${BASE_URL}/me/credits/history" -H "Authorization: Bearer fhk_…"`,
         responseExample: `{ "data": [ { "delta": -1, "reason": "match_analysis", "label": "Senior Backend Engineer at Acme", "created_at": "2026-07-28T09:00:00Z" } ] }`,
+      },
+      {
+        method: 'GET',
+        path: '/me/usage',
+        auth: 'cookie-or-key',
+        summary: 'Your AI request activity this billing period.',
+        description:
+          'Counts and token usage, not cost — the gateway’s dollar figure is a ' +
+          'list price against a mixed upstream pool, not what you pay; your ' +
+          'price is credits, reported by `/me/credits`. Never fails for a reason ' +
+          'you could act on: no usage yet, or an unreachable gateway, both ' +
+          'answer 200 with zeroes.',
+        curl: `curl "${BASE_URL}/me/usage" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
+        responseExample: `{ "data": { "requests": 42, "failed": 1, "tokens": 118000, "period": "2026-08", "resets_at": "2026-09-01T00:00:00Z" } }`,
       },
       {
         method: 'GET',
@@ -1714,6 +2547,28 @@ ${BASE_URL}/auth/oauth/google/start`,
         curl: `curl -X POST "${BASE_URL}/me/autofill/run" -H "Authorization: Bearer <extension session token>"`,
         responseExample: `{ "data": { "filled": 11, "skipped": 2 } }`,
       },
+      {
+        method: 'PATCH',
+        path: '/me/timezone',
+        auth: 'cookie',
+        summary: 'Set your account’s IANA timezone.',
+        body: [{ name: 'timezone', type: 'string', required: true, description: 'IANA timezone name.', example: 'Europe/Berlin' }],
+        curl: `curl -X PATCH "${BASE_URL}/me/timezone" \\
+  -H 'Content-Type: application/json' -b cookies.txt \\
+  -d '{"timezone":"Europe/Berlin"}'`,
+        responseExample: `{ "data": { "id": 1, "email": "me@example.com", "role": "user", "timezone": "Europe/Berlin", "...": "..." } }`,
+      },
+      {
+        method: 'PATCH',
+        path: '/me/language',
+        auth: 'cookie',
+        summary: 'Set your preferred interface language.',
+        body: [{ name: 'language', type: 'string', required: true, description: 'Supported language code.', example: 'en' }],
+        curl: `curl -X PATCH "${BASE_URL}/me/language" \\
+  -H 'Content-Type: application/json' -b cookies.txt \\
+  -d '{"language":"en"}'`,
+        responseExample: `{ "data": { "id": 1, "email": "me@example.com", "role": "user", "language": "en", "...": "..." } }`,
+      },
     ],
   },
   {
@@ -1774,14 +2629,29 @@ ${BASE_URL}/auth/oauth/google/start`,
       },
       {
         method: 'POST',
-        path: '/me/contributions',
-        auth: 'cookie-or-key',
-        summary: 'Contribute a board by link.',
-        body: [{ name: 'url', type: 'string', required: true, description: "A vacancy or a company's careers page." }],
-        curl: `curl -X POST "${BASE_URL}/me/contributions" \\
-  -H "Authorization: Bearer fhk_…" -H 'Content-Type: application/json' \\
-  -d '{"url":"https://boards.greenhouse.io/acme"}'`,
-        responseExample: `{ "data": { "source": "greenhouse", "board": "acme", "state": "pending" } }`,
+        path: '/me/jd/resolve',
+        auth: 'cookie',
+        summary: 'Turn a URL, pasted text, or an existing job into one usable by CV tailoring.',
+        description:
+          'Exactly one of `job_slug`, `url`, or `text` is required. A recognized ' +
+          'URL resolves through the same ATS-aware registry `/jobs/resolve` uses ' +
+          '(a network fetch — only the `url` form is rate-limited); an ' +
+          'unrecognized URL falls back to a generic scrape; pasted text is ' +
+          'stored as a private, unlisted job. Returns the slug the tailor ' +
+          'workspace should open — an existing job, or a freshly created ' +
+          'private one. `404` for an unknown `job_slug`, `422` for a URL ' +
+          'nothing could read.',
+        body: [
+          { name: 'job_slug', type: 'string', description: 'An existing job’s slug.' },
+          { name: 'url', type: 'string', description: 'A job posting URL.' },
+          { name: 'text', type: 'string', description: 'Pasted job description text.' },
+          { name: 'title', type: 'string', description: 'Optional hint, used only alongside `text`.' },
+          { name: 'company', type: 'string', description: 'Optional hint, used only alongside `text`.' },
+        ],
+        curl: `curl -X POST "${BASE_URL}/me/jd/resolve" \\
+  -H 'Content-Type: application/json' -b cookies.txt \\
+  -d '{"url":"https://boards.greenhouse.io/acme/jobs/123"}'`,
+        responseExample: `{ "data": { "job_slug": "senior-go-engineer-acme-1a2b" } }`,
       },
     ],
   },
@@ -1928,6 +2798,31 @@ ${BASE_URL}/auth/oauth/google/start`,
     endpoints: [
       {
         method: 'GET',
+        path: '/stats/catalog',
+        auth: 'none',
+        summary: 'The headline catalogue-scale figures (open jobs, companies, sources, …).',
+        description:
+          'The canonical numbers behind every "how big is this" figure on the ' +
+          'site (the jobs list total, the /about and /open pages). Backed by one ' +
+          'snapshot `cmd/rollup-stats` republishes periodically, not a live ' +
+          'count. `exact: false` means the cache was cold and the figures fell ' +
+          'back to a planner estimate — treat them as approximate when it is ' +
+          'false.',
+        curl: `curl "${BASE_URL}/stats/catalog"`,
+        responseExample: `{
+  "data": {
+    "open_jobs": 42130,
+    "companies": 6210,
+    "sources": 48,
+    "ats_platforms": 22,
+    "telegram_channels": 340,
+    "computed_at": "2026-06-18T06:00:00Z",
+    "exact": true
+  }
+}`,
+      },
+      {
+        method: 'GET',
         path: '/insights/roles',
         auth: 'none',
         summary: 'Roles (category × seniority) ranked by openings or growth.',
@@ -2031,6 +2926,42 @@ ${BASE_URL}/auth/oauth/google/start`,
         description: 'Sanitized: which boards are healthy, cooled or failing, without error text or internal identifiers.',
         curl: `curl "${BASE_URL}/status"`,
         responseExample: `{ "data": { "providers": [ { "source": "greenhouse", "boards": 812, "failing": 14, "last_run_at": "2026-07-28T18:00:00Z" } ] } }`,
+      },
+    ],
+  },
+  {
+    title: 'Market pulse',
+    intro:
+      'Your own profile skills’ demand trend, joined against the weekly market ' +
+      'snapshot. Cookie-only, unlike the aggregate insights above — this reads ' +
+      'your saved profile.',
+    endpoints: [
+      {
+        method: 'GET',
+        path: '/me/market-pulse',
+        auth: 'cookie',
+        summary: 'Weekly demand trend for your profile skills.',
+        description:
+          'One entry per profile skill seen in at least one open job; a skill ' +
+          'never seen is omitted rather than reported with a zero. `change_pct` ' +
+          'is `null` with fewer than two snapshots, or when the earliest ' +
+          'snapshot’s count was zero. A profile with no skills yet answers an ' +
+          'empty `data` array, not an error.',
+        curl: `curl "${BASE_URL}/me/market-pulse" -b cookies.txt`,
+        responseExample: `{
+  "data": [
+    {
+      "skill": "go",
+      "open_count": 640,
+      "change_pct": 12.5,
+      "series": [
+        { "week_start": "2026-07-06", "open_count": 570 },
+        { "week_start": "2026-08-10", "open_count": 640 }
+      ]
+    }
+  ],
+  "meta": { "week_start": "2026-08-10" }
+}`,
       },
     ],
   },
@@ -2162,6 +3093,60 @@ ${BASE_URL}/auth/oauth/google/start`,
         curl: `curl -X POST "${BASE_URL}/referrals/offers/b71e…/decide" \\
   -H "Authorization: Bearer fhk_…" -H 'Content-Type: application/json' -d '{"approve":true}'`,
         responseExample: `{ "data": { "id": "b71e…", "status": "approved", "decided_at": "2026-07-28T21:00:00Z" } }`,
+      },
+    ],
+  },
+  {
+    title: 'Talent Network',
+    intro:
+      'A candidate-controlled public profile page, shareable by URL. The ' +
+      'visibility setting lives on `users`, distinct from `user_profiles`.',
+    endpoints: [
+      {
+        method: 'GET',
+        path: '/me/talent-network',
+        auth: 'cookie-or-key',
+        summary: 'Your current Talent Network visibility and shareable id.',
+        description:
+          'A caller who has never touched the setting reads `"off"` — the column ' +
+          'default, not a sentinel. `talent_network_public_id` rides along even ' +
+          'when visibility is off, so the client can render the shareable URL a ' +
+          'candidate would get before they turn it on.',
+        curl: `curl "${BASE_URL}/me/talent-network" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
+        responseExample: `{ "data": { "talent_network_visibility": "public", "talent_network_public_id": "5b1e2b7a-9c3d-4e21-8f0a-1234567890ab" } }`,
+      },
+      {
+        method: 'PUT',
+        path: '/me/talent-network',
+        auth: 'cookie',
+        summary: 'Set your Talent Network visibility.',
+        body: [
+          { name: 'visibility', type: 'string', required: true, description: 'One of `off`, `public`, `anonymous`.', example: 'public' },
+        ],
+        curl: `curl -X PUT "${BASE_URL}/me/talent-network" \\
+  -H 'Content-Type: application/json' -b cookies.txt \\
+  -d '{"visibility":"public"}'`,
+        responseExample: `{ "data": { "talent_network_visibility": "public", "talent_network_public_id": "5b1e2b7a-9c3d-4e21-8f0a-1234567890ab" } }`,
+      },
+      {
+        method: 'GET',
+        path: '/talent-network/{publicID}',
+        auth: 'none',
+        summary: 'The public, shareable Talent Network profile page.',
+        description:
+          'A hidden (`off`) profile and a nonexistent id answer an identical 404 ' +
+          '— the route never lets a caller distinguish the two. `full_name` is ' +
+          'present only in `public` mode; `anonymous` omits it entirely.',
+        pathParams: [{ name: 'publicID', type: 'string (uuid)', required: true, description: 'The candidate’s `talent_network_public_id`.', example: '5b1e2b7a-9c3d-4e21-8f0a-1234567890ab' }],
+        curl: `curl "${BASE_URL}/talent-network/5b1e2b7a-9c3d-4e21-8f0a-1234567890ab"`,
+        responseExample: `{
+  "data": {
+    "full_name": "Jane Doe",
+    "specializations": ["backend"],
+    "skills": ["go", "postgresql"],
+    "cv": { "...": "..." }
+  }
+}`,
       },
     ],
   },
@@ -2386,6 +3371,227 @@ ${BASE_URL}/auth/oauth/google/start`,
   -H 'Content-Type: application/json' -d '{"session_id":"s_9f…"}'`,
         responseExample: `{ "data": { "id": "7d1a…", "agent_session_id": "s_9f…" } }`,
       },
+      {
+        method: 'PUT',
+        path: '/me/cvs/{id}/tracer-links',
+        auth: 'cookie',
+        summary: "Turn link tracing on or off for this CV's PDF.",
+        description:
+          'Off is the default for every CV. Turning it on is refused with a `409` ' +
+          'on a deployment with no visitor salt configured — there would be no ' +
+          'honest way to count distinct visitors. Turning it off is never refused.',
+        pathParams: [{ name: 'id', type: 'string (uuid)', required: true, description: 'The CV id.' }],
+        body: [{ name: 'enabled', type: 'boolean', required: true, description: 'Turn tracing on or off.' }],
+        curl: `curl -X PUT "${BASE_URL}/me/cvs/0f2c…/tracer-links" -b cookies.txt \\
+  -H 'Content-Type: application/json' -d '{"enabled":true}'`,
+        responseExample: `{ "data": { "tracer_links_enabled": true } }`,
+      },
+      {
+        method: 'GET',
+        path: '/me/cvs/{id}/tracer-links',
+        auth: 'cookie',
+        summary: "What is known about this CV's traced links.",
+        description:
+          'One entry per link the PDF carries (header links, project links). ' +
+          'Clicks you made on your own CV are excluded from the counts; ' +
+          '`bot_clicks` is tallied separately rather than folded in. ' +
+          '`distinct_visitors` is omitted — not zero — on a deployment with no ' +
+          'visitor salt, since there is no honest count to report.',
+        pathParams: [{ name: 'id', type: 'string (uuid)', required: true, description: 'The CV id.' }],
+        curl: `curl "${BASE_URL}/me/cvs/0f2c…/tracer-links" -b cookies.txt`,
+        responseExample: `{
+  "data": [
+    {
+      "source_path": "header.links[0]",
+      "destination_url": "https://github.com/you",
+      "traced_url": "https://freehire.me/cv/acme-x7abc",
+      "clicks": 12,
+      "bot_clicks": 3,
+      "distinct_visitors": 9,
+      "last_click_at": "2026-07-20T10:00:00Z"
+    }
+  ]
+}`,
+      },
+      {
+        method: 'GET',
+        path: '/me/cvs/{id}/revisions',
+        auth: 'cookie',
+        summary: 'The edit history of this CV, newest first.',
+        description:
+          'Each entry names what changed and where (`paths`), not the edit ' +
+          'itself — the operations carry your own prior text and stay ' +
+          'server-side. `undoable` is false for an entry with nothing to reverse ' +
+          '(e.g. the CV’s own creation); `reverted` marks an entry already undone ' +
+          'rather than removing it from the feed.',
+        pathParams: [{ name: 'id', type: 'string (uuid)', required: true, description: 'The CV id.' }],
+        curl: `curl "${BASE_URL}/me/cvs/0f2c…/revisions" -b cookies.txt`,
+        responseExample: `{
+  "data": [
+    {
+      "id": "b1a2…",
+      "actor": "agent",
+      "origin": "tailoring",
+      "batch_id": "f3c1…",
+      "title": "Reframed 2 bullets toward Kafka",
+      "note": "Emphasized event-bus scale to match the requirement",
+      "paths": ["experience[0].bullets[1]"],
+      "reverted": false,
+      "undoable": true,
+      "created_at": "2026-07-28T20:10:00Z"
+    }
+  ]
+}`,
+      },
+      {
+        method: 'POST',
+        path: '/me/cvs/{id}/revisions/{rid}/undo',
+        auth: 'cookie',
+        summary: 'Reverse one revision, leaving later edits in place.',
+        description:
+          'The undo is itself recorded as a new revision. A `409` when the entry ' +
+          'has nothing to reverse or the part of the document it changed is ' +
+          'already gone.',
+        pathParams: [
+          { name: 'id', type: 'string (uuid)', required: true, description: 'The CV id.' },
+          { name: 'rid', type: 'string (uuid)', required: true, description: 'The revision id, from the history feed.' },
+        ],
+        curl: `curl -X POST "${BASE_URL}/me/cvs/0f2c…/revisions/b1a2…/undo" -b cookies.txt`,
+        responseExample: `{
+  "data": {
+    "cv": { "id": "0f2c…", "title": "Backend engineer", "template_id": "classic", "created_at": "2026-07-01T10:00:00Z", "updated_at": "2026-07-28T20:15:00Z" },
+    "revision": { "id": "c4d5…", "actor": "user", "origin": "editor", "title": "Undid \\"Reframed 2 bullets toward Kafka\\"", "reverts_id": "b1a2…", "reverted": false, "undoable": false, "paths": ["experience[0].bullets[1]"], "created_at": "2026-07-28T20:15:00Z" }
+  }
+}`,
+      },
+      {
+        method: 'POST',
+        path: '/me/cvs/{id}/revisions/batch/{bid}/undo',
+        auth: 'cookie',
+        summary: 'Reverse every standing edit of one agent turn, newest first.',
+        description:
+          '`bid` is a revision’s `batch_id` from the history feed, not a separate ' +
+          'id — undoing one entry of a batch and then the batch itself is ' +
+          'well-defined, since an already-reverted entry is simply skipped.',
+        pathParams: [
+          { name: 'id', type: 'string (uuid)', required: true, description: 'The CV id.' },
+          { name: 'bid', type: 'string (uuid)', required: true, description: 'The batch id shared by the revisions to undo.' },
+        ],
+        curl: `curl -X POST "${BASE_URL}/me/cvs/0f2c…/revisions/batch/f3c1…/undo" -b cookies.txt`,
+        responseExample: `{ "data": { "id": "0f2c…", "title": "Backend engineer", "template_id": "classic", "created_at": "2026-07-01T10:00:00Z", "updated_at": "2026-07-28T20:16:00Z" } }`,
+      },
+      {
+        method: 'GET',
+        path: '/me/cvs/{id}/ats-delta',
+        auth: 'cookie',
+        summary: "How tailoring changed this CV's ATS-readiness score.",
+        description:
+          'The tailored copy scored against the base CV it came from, with ' +
+          'template, page margins and typography held identical so the ' +
+          'difference reflects content alone — the base is a copy rendered with ' +
+          'the tailored copy’s formatting, never the stored base itself. ' +
+          'Recomputed per request, never stored. `available: false` (with ' +
+          '`reason`, no `delta`) when rendering is unavailable rather than an ' +
+          'error. `409` when the CV is not a tailored copy, has no base CV to ' +
+          'compare against, or its vacancy no longer exists.',
+        pathParams: [{ name: 'id', type: 'string (uuid)', required: true, description: 'The tailored CV id.' }],
+        curl: `curl "${BASE_URL}/me/cvs/7d1a…/ats-delta" -b cookies.txt`,
+        responseExample: `{
+  "data": {
+    "available": true,
+    "base_cv_id": "0f2c…",
+    "delta": {
+      "base": 62,
+      "tailored": 78,
+      "change": 16,
+      "categories": [ { "id": "keyword_coverage", "label": "Keyword coverage", "...": "..." } ],
+      "regressed": false
+    }
+  }
+}`,
+      },
+      {
+        method: 'GET',
+        path: '/me/cvs/{id}/job-match',
+        auth: 'cookie',
+        summary: 'How well a tailored CV matches the vacancy it was written for.',
+        description:
+          'Deterministic and free — no model call, unlike the AI match analysis. ' +
+          'Scored off the CV’s rendered PDF text layer against the vacancy alone ' +
+          '(no base-CV comparison, unlike the ATS delta), so it is cheap enough ' +
+          'to refresh after every saved edit. `available: false` when nothing ' +
+          'about the vacancy could be matched automatically, or rendering ' +
+          'failed. `409` when the CV is not a tailored copy or its vacancy no ' +
+          'longer exists.',
+        pathParams: [{ name: 'id', type: 'string (uuid)', required: true, description: 'The tailored CV id.' }],
+        curl: `curl "${BASE_URL}/me/cvs/7d1a…/job-match" -b cookies.txt`,
+        responseExample: `{
+  "data": {
+    "available": true,
+    "score": {
+      "overall": 74,
+      "categories": [ { "...": "..." } ],
+      "contributing": ["skills", "requirements"],
+      "matched_skills": ["go", "postgresql"],
+      "missing_skills": ["kubernetes"],
+      "requirements": [ { "text": "5+ years Go", "priority": "required", "cached_status": "covered" } ]
+    }
+  }
+}`,
+      },
+    ],
+  },
+  {
+    title: 'Photo',
+    intro:
+      'The one image the CV templates that print a portrait compose in. ' +
+      'Cookie-only throughout — the image is PII, so there is no key-authenticated ' +
+      'or public path.',
+    endpoints: [
+      {
+        method: 'PUT',
+        path: '/me/photo',
+        auth: 'cookie',
+        summary: 'Upload (or replace) your headshot.',
+        description:
+          'Multipart upload of the `file` part — JPEG, PNG, or WebP, capped at 8 MB ' +
+          'and rate-limited to 12 uploads/hour. Replaces any existing headshot. ' +
+          '`501` when object storage is not configured, `400` for an undecodable, ' +
+          'unsupported, or oversized image.',
+        curl: `curl -X PUT "${BASE_URL}/me/photo" -b cookies.txt -F "file=@headshot.jpg"`,
+        responseExample: `{ "data": { "enabled": true, "present": true, "uploaded_at": "2026-08-18T10:00:00Z" } }`,
+      },
+      {
+        method: 'GET',
+        path: '/me/photo',
+        auth: 'cookie',
+        summary: 'Whether you have a stored headshot, and when it was uploaded.',
+        description:
+          '`enabled` is false when object storage is not configured — the client ' +
+          'should then offer no upload control at all rather than one that answers ' +
+          '`501`. `uploaded_at` doubles as a cache-busting value for the image URL.',
+        curl: `curl "${BASE_URL}/me/photo" -b cookies.txt`,
+        responseExample: `{ "data": { "enabled": true, "present": false, "uploaded_at": null } }`,
+      },
+      {
+        method: 'GET',
+        path: '/me/photo/image',
+        auth: 'cookie',
+        summary: 'The stored headshot itself, as image bytes.',
+        description:
+          'Not a JSON endpoint — the response is `image/jpeg` with a short private ' +
+          'cache lifetime (60s), meant to be busted with `?v=<uploaded_at>`. `404` ' +
+          'when no headshot is stored.',
+        curl: `curl "${BASE_URL}/me/photo/image" -b cookies.txt -o headshot.jpg`,
+      },
+      {
+        method: 'DELETE',
+        path: '/me/photo',
+        auth: 'cookie',
+        summary: 'Remove your stored headshot.',
+        description: 'Returns `204 No Content`.',
+        curl: `curl -X DELETE "${BASE_URL}/me/photo" -b cookies.txt`,
+      },
     ],
   },
   {
@@ -2409,36 +3615,103 @@ ${BASE_URL}/auth/oauth/google/start`,
         path: '/me/experience/employments/{id}',
         auth: 'cookie',
         summary: 'Edit one employment.',
-        pathParams: [{ name: 'id', type: 'integer', required: true, description: 'The employment id.' }],
-        curl: `curl -X PUT "${BASE_URL}/me/experience/employments/12" -b cookies.txt \\
-  -H 'Content-Type: application/json' -d '{"company":"Acme","title":"Staff Engineer"}'`,
-        responseExample: `{ "data": { "id": 12, "company": "Acme", "title": "Staff Engineer" } }`,
+        pathParams: [{ name: 'id', type: 'string (uuid)', required: true, description: 'The employment id.' }],
+        curl: `curl -X PUT "${BASE_URL}/me/experience/employments/3fa8…" -b cookies.txt \\
+  -H 'Content-Type: application/json' -d '{"company":"Acme","role":"Staff Engineer"}'`,
+        responseExample: `{ "data": { "id": "3fa8…", "kind": "job", "company": "Acme", "role": "Staff Engineer" } }`,
       },
       {
         method: 'DELETE',
         path: '/me/experience/employments/{id}',
         auth: 'cookie',
         summary: 'Remove an employment and its atoms.',
-        pathParams: [{ name: 'id', type: 'integer', required: true, description: 'The employment id.' }],
-        curl: `curl -X DELETE "${BASE_URL}/me/experience/employments/12" -b cookies.txt`,
+        pathParams: [{ name: 'id', type: 'string (uuid)', required: true, description: 'The employment id.' }],
+        curl: `curl -X DELETE "${BASE_URL}/me/experience/employments/3fa8…" -b cookies.txt`,
       },
       {
         method: 'PUT',
         path: '/me/experience/atoms/{id}',
         auth: 'cookie',
         summary: 'Edit one evidence atom.',
-        pathParams: [{ name: 'id', type: 'integer', required: true, description: 'The atom id.' }],
-        curl: `curl -X PUT "${BASE_URL}/me/experience/atoms/88" -b cookies.txt \\
-  -H 'Content-Type: application/json' -d '{"text":"Cut p99 checkout latency 40% (12k rps)"}'`,
-        responseExample: `{ "data": { "id": 88, "text": "Cut p99 checkout latency 40% (12k rps)", "source": "manual" } }`,
+        pathParams: [{ name: 'id', type: 'string (uuid)', required: true, description: 'The atom id.' }],
+        curl: `curl -X PUT "${BASE_URL}/me/experience/atoms/88b1…" -b cookies.txt \\
+  -H 'Content-Type: application/json' -d '{"claim":"Cut p99 checkout latency 40% (12k rps)"}'`,
+        responseExample: `{ "data": { "id": "88b1…", "claim": "Cut p99 checkout latency 40% (12k rps)", "provenance": "manual" } }`,
       },
       {
         method: 'DELETE',
         path: '/me/experience/atoms/{id}',
         auth: 'cookie',
         summary: 'Remove an evidence atom.',
-        pathParams: [{ name: 'id', type: 'integer', required: true, description: 'The atom id.' }],
-        curl: `curl -X DELETE "${BASE_URL}/me/experience/atoms/88" -b cookies.txt`,
+        pathParams: [{ name: 'id', type: 'string (uuid)', required: true, description: 'The atom id.' }],
+        curl: `curl -X DELETE "${BASE_URL}/me/experience/atoms/88b1…" -b cookies.txt`,
+      },
+      {
+        method: 'POST',
+        path: '/me/experience/employments',
+        auth: 'cookie-or-key',
+        summary: 'Record a new place — a job or a project.',
+        description:
+          'An employment carries no claim of its own (only the atoms attached to it ' +
+          'do), so nothing about provenance applies here. `kind` is `job` or ' +
+          '`project`; a project’s name arrives as `name` on the wire (legacy ' +
+          '`company` accepted as a fallback), a job’s as `company`.',
+        body: [
+          { name: 'kind', type: 'string', required: true, description: '`job` or `project`.', example: 'job' },
+          { name: 'company', type: 'string', description: 'The employer (jobs) — or the project name via `name` (see description).', example: 'Acme' },
+          { name: 'role', type: 'string', description: 'Your title.', example: 'Senior Backend Engineer' },
+          { name: 'location', type: 'string', description: 'Where you worked.' },
+          { name: 'start', type: 'string', description: 'Start date.', example: '2023-02' },
+          { name: 'end', type: 'string', description: 'End date; omit with `current`.' },
+          { name: 'current', type: 'boolean', description: 'Still ongoing.' },
+          { name: 'summary', type: 'string', description: 'A short description of the role.' },
+          { name: 'link', type: 'string', description: 'Outbound URL, for a project.' },
+          { name: 'stack', type: 'string[]', description: 'Technologies used, printed on the CV’s per-role stack line.' },
+        ],
+        curl: `curl -X POST "${BASE_URL}/me/experience/employments" \\
+  -H "Authorization: Bearer $FREEHIRE_API_KEY" -H 'Content-Type: application/json' \\
+  -d '{"kind":"job","company":"Acme","role":"Senior Backend Engineer","start":"2023-02","current":true}'`,
+        responseExample: `{ "data": { "id": "3fa8…", "kind": "job", "company": "Acme", "role": "Senior Backend Engineer", "start": "2023-02", "current": true } }`,
+      },
+      {
+        method: 'POST',
+        path: '/me/experience/atoms',
+        auth: 'cookie-or-key',
+        summary: 'Record a new achievement.',
+        description:
+          'The only route besides the assistant’s own tool that can add evidence ' +
+          'outside a chat session, which is why `provenance` is forced to `manual` ' +
+          'regardless of what the body sends — an authenticated POST with no chat ' +
+          'transcript behind it can only honestly be the owner’s own words. When ' +
+          'the account has opted into requiring it, an empty `context` is a 400.',
+        body: [
+          { name: 'claim', type: 'string', required: true, description: 'The sentence a CV bullet would carry.', example: 'Cut p99 checkout latency 40%' },
+          { name: 'employment_id', type: 'string (uuid)', description: 'The place this achievement belongs under; omit to leave it unplaced.' },
+          { name: 'context', type: 'string', description: 'How it was done — raw material for reframing toward a vacancy.' },
+          { name: 'metrics', type: 'string[]', description: 'Numbers backing the claim.', example: '["12k rps", "40%"]' },
+          { name: 'skills', type: 'string[]', description: 'Skills this achievement demonstrates.' },
+          { name: 'source_ref', type: 'string', description: 'Where this came from, for your own reference.' },
+        ],
+        curl: `curl -X POST "${BASE_URL}/me/experience/atoms" \\
+  -H "Authorization: Bearer $FREEHIRE_API_KEY" -H 'Content-Type: application/json' \\
+  -d '{"claim":"Cut p99 checkout latency 40%","employment_id":"3fa8…","metrics":["40%","12k rps"]}'`,
+        responseExample: `{ "data": { "id": "88b1…", "employment_id": "3fa8…", "claim": "Cut p99 checkout latency 40%", "metrics": ["40%", "12k rps"], "provenance": "manual" } }`,
+      },
+      {
+        method: 'POST',
+        path: '/me/experience/atoms/merge',
+        auth: 'cookie',
+        summary: 'Fold two of your atoms into one richer keep.',
+        description:
+          'Session-only, unlike its sibling create/edit/delete routes — the merge ' +
+          'folds the discarded atom’s metrics and skills into the kept one while ' +
+          'the kept one’s own provenance stands, letting a `manual` atom absorb ' +
+          'numbers a model had inferred, so it cannot be widened to a key the way ' +
+          'the others were.',
+        body: [{ name: 'ids', type: 'string[] (2 uuids)', required: true, description: 'Exactly two atom ids; the first is kept.', example: '["88b1…","91c2…"]' }],
+        curl: `curl -X POST "${BASE_URL}/me/experience/atoms/merge" -b cookies.txt \\
+  -H 'Content-Type: application/json' -d '{"ids":["88b1…","91c2…"]}'`,
+        responseExample: `{ "data": { "id": "88b1…", "claim": "Cut p99 checkout latency 40% (12k rps)", "metrics": ["40%", "12k rps"], "provenance": "manual" } }`,
       },
     ],
   },
@@ -2453,6 +3726,74 @@ ${BASE_URL}/auth/oauth/google/start`,
       'drive the whole surface; the Gmail consent redirect is the one exception and ' +
       'stays browser-only.',
     endpoints: [
+      {
+        method: 'GET',
+        path: '/me/tracking/{slug}/followup',
+        auth: 'cookie-or-key',
+        summary: 'Draft a chase for a silent application.',
+        description:
+          'Offered only when the application is in the silent state the tracking ' +
+          'board’s own badge uses — a `409` otherwise. `recipient`/`recipient_name` ' +
+          'are omitted when nobody at the company ever replied, which is the common ' +
+          'case: the draft is handed to you, nothing is sent.',
+        pathParams: [{ name: 'slug', type: 'string', required: true, description: 'The job `public_slug`.' }],
+        curl: `curl "${BASE_URL}/me/tracking/<slug>/followup" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
+        responseExample: `{ "data": { "subject": "Following up: Senior Go Engineer application", "body": "Hi …", "recipient": "recruiting@acme.com", "recipient_name": "Acme Recruiting", "days_silent": 12 } }`,
+      },
+      {
+        method: 'POST',
+        path: '/me/tracking/{slug}/followup',
+        auth: 'cookie-or-key',
+        summary: 'Record that you sent a chase.',
+        description:
+          'Does not itself affect the silence calculation — that reads when the ' +
+          'other side last moved, and a chase is not a reply. Idempotent within the ' +
+          'hour: a double click overwrites the timestamp rather than logging a ' +
+          'second event. Returns `204 No Content`.',
+        pathParams: [{ name: 'slug', type: 'string', required: true, description: 'The job `public_slug`.' }],
+        curl: `curl -X POST "${BASE_URL}/me/tracking/<slug>/followup" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
+      },
+      {
+        method: 'POST',
+        path: '/me/tracking/{slug}/mail-recall',
+        auth: 'cookie-or-key',
+        summary: 'Sweep your connected mailbox for mail belonging to this application.',
+        description:
+          'For an application whose mail arrived before you connected an inbox, or ' +
+          'that a sync missed. Runs an LLM pass over your mailbox and returns ' +
+          'matches as suggestions — it never links or writes the ledger itself; ' +
+          'confirm a pick with `POST /me/tracking/{slug}/mail-recall/link`. ' +
+          'Rate-limited. A `503` when no mail gateway is configured, a `502` when ' +
+          'the model call fails.',
+        pathParams: [{ name: 'slug', type: 'string', required: true, description: 'The job `public_slug`.' }],
+        curl: `curl -X POST "${BASE_URL}/me/tracking/<slug>/mail-recall" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
+        responseExample: `{
+  "data": {
+    "scanned": 340,
+    "suggested": [
+      { "id": 0, "provider_id": "18f2a…", "from_addr": "recruiting@acme.com", "from_name": "Acme Recruiting", "subject": "Interview invitation", "received_at": "2026-07-15T09:00:00Z", "invitation": true }
+    ],
+    "invitations": 1
+  }
+}`,
+      },
+      {
+        method: 'POST',
+        path: '/me/tracking/{slug}/mail-recall/link',
+        auth: 'cookie-or-key',
+        summary: 'Import and link one message a mail-recall sweep proposed.',
+        description:
+          'Imports the message from your mailbox by `provider_id` (from a ' +
+          'mail-recall response) and links it to the application in one step — the ' +
+          'same import-then-link path a Gmail sync uses, so the response is the ' +
+          'full message body, the same shape `POST /me/emails/{id}/link` returns.',
+        pathParams: [{ name: 'slug', type: 'string', required: true, description: 'The job `public_slug`.' }],
+        body: [{ name: 'provider_id', type: 'string', required: true, description: 'The message’s `provider_id`, from a mail-recall response.' }],
+        curl: `curl -X POST "${BASE_URL}/me/tracking/<slug>/mail-recall/link" \\
+  -H "Authorization: Bearer $FREEHIRE_API_KEY" -H 'Content-Type: application/json' \\
+  -d '{"provider_id":"18f2a…"}'`,
+        responseExample: `{ "data": { "id": 4822, "subject": "Interview invitation", "linked_slug": "senior-go-engineer-acme-1a2b", "link_source": "manual", "...": "..." } }`,
+      },
       {
         method: 'GET',
         path: '/me/inbox',
@@ -2713,6 +4054,30 @@ ${BASE_URL}/auth/oauth/google/start`,
           'removes the Gmail-sourced mail. Mail from the hosted address stays.',
         curl: `curl -X DELETE "${BASE_URL}/me/gmail" -H "Authorization: Bearer fhk_…"`,
         responseExample: `{ "data": { "connected": false } }`,
+      },
+    ],
+  },
+  {
+    title: 'Speech',
+    intro:
+      'Turns one recording into text for the assistant composer’s dictation ' +
+      'control. Nothing is stored — the audio is read, forwarded to the ' +
+      'transcription gateway, and dropped.',
+    endpoints: [
+      {
+        method: 'POST',
+        path: '/speech/transcriptions',
+        auth: 'cookie-or-key',
+        summary: 'Transcribe one short audio recording to text.',
+        description:
+          'Multipart upload of the `file` part — webm, mp4, m4a, ogg, wav, or mp3, ' +
+          'capped at ~8 minutes of audio (2 MB) and rate-limited to 60 ' +
+          'recordings/hour per caller. `501` when no speech gateway is configured, ' +
+          '`502` if the gateway call itself fails, `400` for an empty recording.',
+        curl: `curl -X POST "${BASE_URL}/speech/transcriptions" \\
+  -H "Authorization: Bearer $FREEHIRE_API_KEY" \\
+  -F "file=@dictation.webm"`,
+        responseExample: `{ "data": { "text": "remote go engineer roles in Berlin" } }`,
       },
     ],
   },

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -433,6 +433,24 @@ const COLLECTION: FacetOption[] = [
   })),
 ];
 
+// The job filter modal splits COLLECTION across two panes instead of one grouped
+// list: the curated picks stay on Industry & collection, the credentials move to
+// their own block on the Relocation pane (they're evidence of visa/sponsorship
+// eligibility, which is what that pane is about). Both stay ChipFacet `options`
+// overrides on the same `collections` param rather than becoming separate FACETS
+// entries — a second entry sharing the param would double its value in the query
+// string. The company modal has no Relocation pane to split into, so it keeps using
+// COLLECTION (and its "Employer credentials" sub-heading) unchanged.
+export const JOB_COLLECTION: FacetOption[] = COLLECTION.filter((o) => o.group !== 'Employer credentials');
+
+// Stripped of `group`: this renders as its own ChipFacet block with its own "Employer
+// credentials" header, so the in-list sub-heading PillGroup would otherwise add above
+// the first pill (COLLECTION's grouping cue for the combined company-modal list) would
+// just repeat that header.
+export const EMPLOYER_CREDENTIALS: FacetOption[] = COLLECTION.filter((o) => o.group === 'Employer credentials').map(
+  ({ group: _group, ...o }) => o,
+);
+
 // Company-size buckets — the vocab.CompanySizeValues vocabulary. Not exported as
 // a generated values array (it's a scalar enrichment field, not a search facet on
 // jobs), so the closed set is spelled out here like CURRENCY; the values are

--- a/web/src/lib/filterSections.test.ts
+++ b/web/src/lib/filterSections.test.ts
@@ -1,17 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { RAIL } from './filterSections';
 
-describe('the ai_archetype rail entry', () => {
-  it('is registered right after category, so the facet is reachable in the modal', () => {
-    const categoryIndex = RAIL.findIndex((e) => e.key === 'category');
-    const archetypeIndex = RAIL.findIndex((e) => e.key === 'ai_archetype');
-    expect(archetypeIndex).toBeGreaterThan(-1);
-    expect(archetypeIndex).toBe(categoryIndex + 1);
-  });
-
-  it('renders through the generic facet path with the ai_archetype param', () => {
-    const entry = RAIL.find((e) => e.key === 'ai_archetype');
-    expect(entry?.kind).toBe('facet');
-    expect(entry?.facetParam).toBe('ai_archetype');
+describe('the ai_archetype facet', () => {
+  it('has no standalone rail entry — FilterModal folds it into the Role pane instead', () => {
+    expect(RAIL.find((e) => e.key === 'ai_archetype')).toBeUndefined();
+    expect(RAIL.find((e) => e.facetParam === 'ai_archetype')).toBeUndefined();
   });
 });

--- a/web/src/lib/filterSections.ts
+++ b/web/src/lib/filterSections.ts
@@ -150,12 +150,12 @@ export const COMPANY_RAIL_GROUPS: CompanyRailGroup[] = [
 
 export const RAIL: RailEntry[] = [
   // One "Role" pane holds the whole "what role" concept: the role picker
-  // (natural/named/composite roles), the seniority pills, and the specialization
-  // chips — three controls, one tab. They overlap by design (role=senior is also
-  // reachable via the seniority pill); the picker is the natural-language entry,
-  // the pills/chips the browse-by-axis entry.
+  // (natural/named/composite roles), the seniority pills, the specialization
+  // chips, and the AI Specialization facet — four controls, one tab. They overlap
+  // by design (role=senior is also reachable via the seniority pill); the picker is
+  // the natural-language entry, the pills/chips/AI-specialization the browse-by-axis
+  // entry.
   { key: 'category', label: 'Role', section: 'ROLE', kind: 'category' },
-  { key: 'ai_archetype', label: 'AI Specialization', section: 'ROLE', kind: 'facet', facetParam: 'ai_archetype' },
   { key: 'location', label: 'Location', section: 'ROLE', kind: 'location' },
   { key: 'work', label: 'Work & employment', section: 'ROLE', kind: 'work' },
   { key: 'skills', label: 'Skills', section: 'ROLE', kind: 'facet', facetParam: 'skills' },

--- a/web/src/lib/pipelineFaq.ts
+++ b/web/src/lib/pipelineFaq.ts
@@ -1,0 +1,32 @@
+// How-it-works landing FAQ — the single source for both the visible section
+// (HowItWorksLandingView.svelte) and the FAQPage JSON-LD (routes/how-it-works). Answers
+// are written from docs/architecture.md and the root AGENTS.md.
+import type { FaqItem } from './seo';
+
+export const PIPELINE_FAQ: FaqItem[] = [
+  {
+    question: 'How fresh is a posting when I see it?',
+    answer:
+      'Each source is crawled on its own schedule, several times a day for most boards. A posting typically clears ingest, tagging and dedup within the same day it goes up on the source.',
+  },
+  {
+    question: 'Why do some postings have more detail than others?',
+    answer:
+      "Enrichment runs from a queue and reads the full posting text, so the depth of detail depends on how much the source itself wrote. A one-line listing stays a one-line listing — nothing here is invented to fill a gap.",
+  },
+  {
+    question: "If a job is on three boards, which one do I see?",
+    answer:
+      "One listing, picked by preferring an employer's own ATS or careers page over an aggregator's copy of the same role. The listing still tells you where it's actually hosted.",
+  },
+  {
+    question: 'Does deduplication ever merge two different jobs by mistake?',
+    answer:
+      'It clusters on role and company together, not on title text alone, so two different openings with the same title at the same company stay separate. The clustering is re-run periodically as new postings arrive, which is also how a wrongly split pair gets caught and merged later.',
+  },
+  {
+    question: 'Can search show a job that was already deleted?',
+    answer:
+      "No — the index is rebuilt from the current catalogue and swapped in as a whole, never patched in place, so a search can only return what was true at that rebuild.",
+  },
+];

--- a/web/src/lib/pipelineStages.ts
+++ b/web/src/lib/pipelineStages.ts
@@ -1,0 +1,62 @@
+// The five stages a posting passes through before it's searchable, in order — this is a
+// real pipeline, not a curated list, so the numbering is load-bearing rather than
+// decorative. Written from docs/architecture.md and the root AGENTS.md; kept in one file
+// so the page's copy and its illustration registry (pipeline/StageIllustration.svelte)
+// cannot name a stage that has no picture, or draw one nothing describes.
+export type StageKey = 'ingest' | 'derive' | 'enrich' | 'deduplicate' | 'reindex';
+
+export type Stage = {
+  key: StageKey;
+  n: string;
+  title: string;
+  blurb: string;
+  detail: string;
+};
+
+export const PIPELINE_STAGES: Stage[] = [
+  {
+    key: 'ingest',
+    n: '01',
+    title: 'Ingest',
+    blurb:
+      'We crawl company career pages, ATS platforms and boards directly, several times a day — so you see a posting the day it goes up, not weeks later from a stale aggregator.',
+    detail:
+      "Most of the catalogue comes straight from an employer's own ATS or careers page, not from a copy of a copy. Each source runs on its own schedule so one slow platform never holds up the rest, and a board that keeps failing backs off instead of being hammered every run.",
+  },
+  {
+    key: 'derive',
+    n: '02',
+    title: 'Derive',
+    blurb:
+      'Seniority, skills, location and remote/onsite are pulled out by a fixed dictionary, not guessed — so filtering by "Senior · Go · Remote" actually narrows to that.',
+    detail:
+      'This step never invents a value: it looks a term up in a closed dictionary and tags the posting if it finds a match, and emits nothing for anything it doesn\'t recognize. That is deliberate — a facet built on a guess degrades quietly, and quietly is the one way a filter is allowed to fail here.',
+  },
+  {
+    key: 'enrich',
+    n: '03',
+    title: 'Enrich',
+    blurb:
+      "An LLM reads the full posting for the things a dictionary can't catch — what the role actually involves, benefits, visa mentions — checked before it's shown.",
+    detail:
+      'This runs from a queue, not inline with the crawl, so a slow model call never holds up ingest. Every result is validated against a fixed schema before it reaches you; one that fails validation is dropped rather than shown half-formed.',
+  },
+  {
+    key: 'deduplicate',
+    n: '04',
+    title: 'Deduplicate',
+    blurb:
+      "The same opening often sits on three or four boards at once. We collapse those into one listing, so your search results aren't full of repeats.",
+    detail:
+      "Postings cluster by role and company, and near-duplicate copies collapse into one — including the aggregator's copy of a job we already have straight from the source. You see one listing; where it's actually posted is still there for you to check.",
+  },
+  {
+    key: 'reindex',
+    n: '05',
+    title: 'Reindex',
+    blurb:
+      "The deduped catalogue rebuilds into the search index you actually query, then swaps in at once — search is never down for a rebuild.",
+    detail:
+      'The index is rebuilt from scratch and swapped in atomically, so a search you run mid-rebuild reads the old, complete index or the new one — never a half-written one in between.',
+  },
+];

--- a/web/src/lib/pipelineStages.ts
+++ b/web/src/lib/pipelineStages.ts
@@ -18,8 +18,7 @@ export const PIPELINE_STAGES: Stage[] = [
     key: 'ingest',
     n: '01',
     title: 'Ingest',
-    blurb:
-      'We crawl company career pages, ATS platforms and boards directly, several times a day — so you see a posting the day it goes up, not weeks later from a stale aggregator.',
+    blurb: 'Crawled straight from the source, several times a day.',
     detail:
       "Most of the catalogue comes straight from an employer's own ATS or careers page, not from a copy of a copy. Each source runs on its own schedule so one slow platform never holds up the rest, and a board that keeps failing backs off instead of being hammered every run.",
   },
@@ -27,8 +26,7 @@ export const PIPELINE_STAGES: Stage[] = [
     key: 'derive',
     n: '02',
     title: 'Derive',
-    blurb:
-      'Seniority, skills, location and remote/onsite are pulled out by a fixed dictionary, not guessed — so filtering by "Senior · Go · Remote" actually narrows to that.',
+    blurb: 'Tagged by a fixed dictionary — never guessed.',
     detail:
       'This step never invents a value: it looks a term up in a closed dictionary and tags the posting if it finds a match, and emits nothing for anything it doesn\'t recognize. That is deliberate — a facet built on a guess degrades quietly, and quietly is the one way a filter is allowed to fail here.',
   },
@@ -36,8 +34,7 @@ export const PIPELINE_STAGES: Stage[] = [
     key: 'enrich',
     n: '03',
     title: 'Enrich',
-    blurb:
-      "An LLM reads the full posting for the things a dictionary can't catch — what the role actually involves, benefits, visa mentions — checked before it's shown.",
+    blurb: "An LLM reads what a dictionary can't tag.",
     detail:
       'This runs from a queue, not inline with the crawl, so a slow model call never holds up ingest. Every result is validated against a fixed schema before it reaches you; one that fails validation is dropped rather than shown half-formed.',
   },
@@ -45,8 +42,7 @@ export const PIPELINE_STAGES: Stage[] = [
     key: 'deduplicate',
     n: '04',
     title: 'Deduplicate',
-    blurb:
-      "The same opening often sits on three or four boards at once. We collapse those into one listing, so your search results aren't full of repeats.",
+    blurb: 'Three boards, one listing.',
     detail:
       "Postings cluster by role and company, and near-duplicate copies collapse into one — including the aggregator's copy of a job we already have straight from the source. You see one listing; where it's actually posted is still there for you to check.",
   },
@@ -54,8 +50,7 @@ export const PIPELINE_STAGES: Stage[] = [
     key: 'reindex',
     n: '05',
     title: 'Reindex',
-    blurb:
-      "The deduped catalogue rebuilds into the search index you actually query, then swaps in at once — search is never down for a rebuild.",
+    blurb: 'Rebuilt and swapped in — search never goes down.',
     detail:
       'The index is rebuilt from scratch and swapped in atomically, so a search you run mid-rebuild reads the old, complete index or the new one — never a half-written one in between.',
   },

--- a/web/src/lib/sitemap.ts
+++ b/web/src/lib/sitemap.ts
@@ -34,6 +34,7 @@ export const STATIC_PATHS = [
   '/features/tailor',
   '/features/ghost-jobs',
   '/features/advanced-search',
+  '/how-it-works',
   // The data and API surfaces. Indexable pages that carry the site's most citable
   // material — live catalogue figures (/open), market rollups (/trends), the API
   // reference — so they belong in the sitemap even though nothing links to some of

--- a/web/src/routes/how-it-works/+page.server.ts
+++ b/web/src/routes/how-it-works/+page.server.ts
@@ -13,7 +13,6 @@ export const load: PageServerLoad = async ({ fetch, setHeaders }) => {
   return {
     scale: {
       sources: catalog?.sources ?? null,
-      atsPlatforms: catalog?.ats_platforms ?? null,
       // A degraded snapshot (`exact: false`) has no real company count — it reads
       // zero, and zero is not "we measured zero companies", so drop it like /open does.
       companies: catalog?.exact ? (catalog?.companies ?? null) : null,

--- a/web/src/routes/how-it-works/+page.server.ts
+++ b/web/src/routes/how-it-works/+page.server.ts
@@ -1,0 +1,22 @@
+import { serverApi } from '$lib/server/api';
+import type { PageServerLoad } from './$types';
+
+// The one number this page cannot get away with inventing: how many sources actually
+// feed the pipeline. Reads the same published snapshot /open and /about read (never a
+// live count on the request path — see the "Catalogue scale" convention in
+// AGENTS.md), so this page's figure and /open's figure cannot disagree.
+export const load: PageServerLoad = async ({ fetch, setHeaders }) => {
+  setHeaders({ 'cache-control': 'public, max-age=300' });
+
+  const catalog = await serverApi(fetch).catalogScale().catch(() => null);
+
+  return {
+    scale: {
+      sources: catalog?.sources ?? null,
+      atsPlatforms: catalog?.ats_platforms ?? null,
+      // A degraded snapshot (`exact: false`) has no real company count — it reads
+      // zero, and zero is not "we measured zero companies", so drop it like /open does.
+      companies: catalog?.exact ? (catalog?.companies ?? null) : null,
+    },
+  };
+};

--- a/web/src/routes/how-it-works/+page.svelte
+++ b/web/src/routes/how-it-works/+page.svelte
@@ -4,6 +4,9 @@
   import HowItWorksLandingView from '$lib/components/HowItWorksLandingView.svelte';
   import { breadcrumbJsonLd, faqPageJsonLd, jsonLdScript } from '$lib/seo';
   import { PIPELINE_FAQ } from '$lib/pipelineFaq';
+  import type { PageData } from './$types';
+
+  const { data }: { data: PageData } = $props();
 
   const origin = $derived(page.url.origin);
   const canonical = $derived(`${origin}/how-it-works`);
@@ -30,5 +33,5 @@
 </svelte:head>
 
 <div class="mx-auto w-full max-w-6xl px-4 py-6">
-  <HowItWorksLandingView />
+  <HowItWorksLandingView scale={data.scale} />
 </div>

--- a/web/src/routes/how-it-works/+page.svelte
+++ b/web/src/routes/how-it-works/+page.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import Seo from '$lib/components/Seo.svelte';
+  import HowItWorksLandingView from '$lib/components/HowItWorksLandingView.svelte';
+  import { breadcrumbJsonLd, faqPageJsonLd, jsonLdScript } from '$lib/seo';
+  import { PIPELINE_FAQ } from '$lib/pipelineFaq';
+
+  const origin = $derived(page.url.origin);
+  const canonical = $derived(`${origin}/how-it-works`);
+  const jsonLd = $derived(
+    jsonLdScript([
+      faqPageJsonLd(PIPELINE_FAQ),
+      breadcrumbJsonLd([
+        { name: 'freehire', url: `${origin}/` },
+        { name: 'How it works', url: canonical },
+      ]),
+    ])
+  );
+</script>
+
+<Seo
+  title="How freehire works — from a job board to your search results | freehire"
+  description="How a posting becomes searchable on freehire: crawled straight from the source, tagged, checked for duplicates across every board, and rebuilt into the live search index — five steps, no person touching a listing."
+  {canonical}
+/>
+
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->
+  {@html jsonLd}
+</svelte:head>
+
+<div class="mx-auto w-full max-w-6xl px-4 py-6">
+  <HowItWorksLandingView />
+</div>

--- a/web/src/routes/my/integrations/+page.svelte
+++ b/web/src/routes/my/integrations/+page.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import IntegrationsView from '$lib/components/IntegrationsView.svelte';
+</script>
+
+<svelte:head>
+  <title>Integrations — freehire</title>
+</svelte:head>
+
+<!-- The account shell (my/+layout) owns the container, auth gate, and noindex;
+     an inner max-width keeps the connection cards readable within the content column. -->
+<div class="max-w-2xl">
+  <IntegrationsView />
+</div>


### PR DESCRIPTION
## What and why

Two independent pieces of work landed on this branch in parallel:

**Integrations tab** (`internal/handler/gmail.go`, `web/src/lib/components/IntegrationsView.svelte`, `web/src/routes/my/integrations/`)
Gmail, Telegram and Discord each had their own scattered connect/disconnect UI (Inbox Settings, a per-saved-search Telegram toggle, Contributions) with no single place to see what's linked. Adds one home at `/my/integrations` for Google (Mail + Calendar, two independent consents), Telegram (decoupled from any one saved search) and Discord (the `/contribute` reward link); the old surfaces now point there instead of duplicating the connect/disconnect UI. The Gmail/Calendar OAuth callback redirects were moved from `/my/inbox` and `/my/tracking/calendar` to `/my/integrations` accordingly.

Also fixes a bug this surfaced during review: `GmailStatus` reported `connected: true` off the mere existence of a `gmail_connections` row, but a calendar-only consent (`UpsertCalendarGrant`) writes that same row with an empty address — so the new Mail card would have shown "Connected" with no address and live Sync/Reconnect/Disconnect buttons for a mail account that was never actually connected. `GmailStatus` now checks the address, matching the guard `ListConnectedGmailUsers` already had for the same reason.

**How-it-works page** (`web/src/routes/how-it-works/`, `web/src/lib/components/pipeline/`)
A new `/how-it-works` page walking a posting through the ingest pipeline, with a live animated sources visual (`SourcesField.svelte`).

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes (and `go test -tags=integration ./...` if I touched DB/handlers).
- [ ] I regenerated committed artifacts when their source changed (`make sqlc` for SQL/migrations, `make gen-contracts` for contract types).
- [ ] For `design-system/` changes: `pnpm run check` and `pnpm run build` pass.
- [x] For `web/` changes: `pnpm run check` and `pnpm run build` pass.
- [x] This stays within freehire's core/extension boundary (see CONTRIBUTING.md) — it does not bloat the core.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Integrations page for managing Google Mail, Calendar, Telegram, and Discord connections.
  * Added a “How It Works” page explaining the five-stage job pipeline, with illustrations, FAQs, metrics, and navigation links.
  * Added improved filtering for AI specialization, job collections, and employer credentials.
* **Improvements**
  * Gmail and Calendar connection results now return to Integrations.
  * Inbox and calendar prompts now link to the Integrations page.
  * Expanded API documentation with numerous endpoint details.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->