### PR TITLE
Fix every Dialog consumer breaking the mobile full-screen takeover

### DIFF
--- a/design-system/src/dialog.svelte
+++ b/design-system/src/dialog.svelte
@@ -42,6 +42,13 @@
      * held and is not.
      */
     dismissible?: boolean;
+    /**
+     * Size the card at `sm` and up with an `sm:max-w-*` utility, never a bare
+     * `max-w-*` — the base classes carry an unprefixed `max-w-none` for the
+     * mobile takeover, and `cn()`'s twMerge keeps only the last unprefixed
+     * value in the group, so a bare override wins at every width and cancels
+     * the takeover below `sm` too.
+     */
     class?: string;
     children: Snippet;
   } = $props();

--- a/design-system/src/dialog.test.ts
+++ b/design-system/src/dialog.test.ts
@@ -79,6 +79,18 @@ describe('Dialog', () => {
     expect(getByRole('dialog', { hidden: true }).getAttribute('aria-labelledby')).toBeNull();
   });
 
+  // A bare `max-w-*` override used to share twMerge's conflict group with the
+  // base's unprefixed `max-w-none`, so the caller's class won at every width
+  // and cancelled the mobile takeover below `sm`. An `sm:`-prefixed override
+  // lives in its own group and must leave `max-w-none` in place.
+  it('keeps the mobile takeover when the caller sizes the card at sm and up', () => {
+    const { getByRole } = render(Dialog, { ...open(true), class: 'sm:max-w-md' });
+    const el = getByRole('dialog', { hidden: true });
+
+    expect(el.className).toContain('max-w-none');
+    expect(el.className).toContain('sm:max-w-md');
+  });
+
   // A dialog holding the outcome of a request that cannot be repeated has to be
   // able to refuse to go away — otherwise Escape hides whether the irreversible
   // thing succeeded. The platform gives us the refusal for free through

--- a/web/src/lib/components/AuthDialog.svelte
+++ b/web/src/lib/components/AuthDialog.svelte
@@ -152,7 +152,7 @@
   }
 </script>
 
-<Dialog bind:open {title} class="max-w-sm">
+<Dialog bind:open {title} class="sm:max-w-sm">
 
     {#if providers.length > 0 && !isRecovery}
       <div class="mb-4 flex flex-col gap-2">

--- a/web/src/lib/components/CompanyFeedbackDialog.svelte
+++ b/web/src/lib/components/CompanyFeedbackDialog.svelte
@@ -93,7 +93,7 @@
   }
 </script>
 
-<Dialog bind:open title={isEdit ? 'Edit your feedback' : 'Leave feedback'} class="max-w-md">
+<Dialog bind:open title={isEdit ? 'Edit your feedback' : 'Leave feedback'} class="sm:max-w-md">
   {#if !loaded}
     <p class="text-sm text-muted-foreground">Loading…</p>
   {:else}

--- a/web/src/lib/components/CompanyFeedbackListDialog.svelte
+++ b/web/src/lib/components/CompanyFeedbackListDialog.svelte
@@ -69,7 +69,7 @@
   }
 </script>
 
-<Dialog bind:open title={companyName ? `Feedback on ${companyName}` : 'Feedback'} class="max-w-lg">
+<Dialog bind:open title={companyName ? `Feedback on ${companyName}` : 'Feedback'} class="sm:max-w-lg">
   {#if page.status !== 'loading'}
     <div class="mb-4 flex justify-end">
       <Button variant="outline" size="sm" onclick={onWriteFeedback}>Write feedback</Button>

--- a/web/src/lib/components/DeleteAccountButton.svelte
+++ b/web/src/lib/components/DeleteAccountButton.svelte
@@ -65,7 +65,7 @@
   {s.trigger}
 </Button>
 
-<Dialog bind:open title={s.dialogTitle} dismissible={!busy} class="max-w-md border-destructive/30">
+<Dialog bind:open title={s.dialogTitle} dismissible={!busy} class="sm:max-w-md border-destructive/30">
   <p class="text-sm text-muted-foreground">{s.warning}</p>
 
   <ul class="mt-4 flex list-disc flex-col gap-1 pl-5 text-sm text-muted-foreground">

--- a/web/src/lib/components/ReportDialog.svelte
+++ b/web/src/lib/components/ReportDialog.svelte
@@ -107,7 +107,7 @@
   }
 </script>
 
-<Dialog bind:open title="Report this job" class="max-w-md">
+<Dialog bind:open title="Report this job" class="sm:max-w-md">
 
     {#if step === 'reason'}
       <ul class="flex flex-col gap-2">

--- a/web/src/lib/components/RequestReferralModal.svelte
+++ b/web/src/lib/components/RequestReferralModal.svelte
@@ -106,7 +106,7 @@
   }
 </script>
 
-<Dialog bind:open title={`Ask for a referral · ${companyName}`} class="max-w-md">
+<Dialog bind:open title={`Ask for a referral · ${companyName}`} class="sm:max-w-md">
 
     {#if done}
       <div class="flex flex-col items-center gap-3 py-4 text-center">

--- a/web/src/lib/components/cv/CliEditDialog.svelte
+++ b/web/src/lib/components/cv/CliEditDialog.svelte
@@ -31,7 +31,7 @@
   }
 </script>
 
-<Dialog bind:open title="Edit this CV from the CLI" class="max-w-lg">
+<Dialog bind:open title="Edit this CV from the CLI" class="sm:max-w-lg">
   <p class="text-sm leading-relaxed text-muted-foreground">
     Give this to your own coding agent — with the freehire CLI installed and signed in, it reads
     and writes this exact CV the same way the in-app assistant does.

--- a/web/src/lib/components/cv/JdIntakeDialog.svelte
+++ b/web/src/lib/components/cv/JdIntakeDialog.svelte
@@ -105,7 +105,7 @@
     'rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
 </script>
 
-<Dialog bind:open title="Tailor a CV for a job" class="max-w-lg">
+<Dialog bind:open title="Tailor a CV for a job" class="sm:max-w-lg">
   <div class="flex gap-4 border-b border-border text-sm">
     {#each [{ id: 'existing', label: 'Our vacancy' }, { id: 'url', label: 'Link' }, { id: 'text', label: 'Paste text' }] as t (t.id)}
       <button


### PR DESCRIPTION
## Summary
- `Dialog`'s base classes carry an unprefixed `max-w-none` for the mobile takeover, plus `sm:max-w-lg` as the default desktop cap.
- Every real caller sizes its card with a bare `max-w-*` override (e.g. `class="max-w-md"`). `cn()`'s `twMerge` treats that as the same conflict group as the base's unprefixed `max-w-none`, drops the base, and the caller's fixed width then applies at *every* breakpoint — including below `sm`, where the dialog is supposed to fill the viewport edge-to-edge. Confirmed live on main: none of the 8 current Dialog consumers actually get the mobile takeover today.
- Switched every caller (`AuthDialog`, `ReportDialog`, `CompanyFeedbackDialog`, `CompanyFeedbackListDialog`, `DeleteAccountButton`, `RequestReferralModal`, `JdIntakeDialog`, `CliEditDialog`) to an `sm:`-prefixed override, which only conflicts with the base's own `sm:max-w-lg` and leaves `max-w-none` alone.
- Documented the contract on `Dialog`'s `class` prop and added a regression test asserting an `sm:max-w-*` override keeps `max-w-none` in the rendered class list.

## Test plan
- [x] New `dialog.test.ts` case passes, full design-system suite green (lint, svelte-check, 131 vitest tests, check:tokens, check:adoption)
- [x] `eslint` + `svelte-check` clean on all 8 edited web/ files
- [x] Verified visually: mobile viewport (390px) screenshot of `AuthDialog` now fills the screen edge-to-edge instead of a narrow centered card

🤖 Generated with [Claude Code](https://claude.com/claude-code)