### PR TITLE
Reap enrichment-queue entries the claim can never take

### DIFF
--- a/cmd/enrich/main.go
+++ b/cmd/enrich/main.go
@@ -61,7 +61,7 @@ func run() int {
 		return 1
 	}
 
-	log.Printf("enrichment done: enriched=%d failed=%d dead_lettered=%d",
-		stats.Enriched, stats.Failed, stats.DeadLettered)
+	log.Printf("enrichment done: enriched=%d failed=%d dead_lettered=%d reaped=%d",
+		stats.Enriched, stats.Failed, stats.DeadLettered, stats.Reaped)
 	return worker.ExitCode(stats.Failed, stats.DeadLettered)
 }

--- a/cmd/enrich/store.go
+++ b/cmd/enrich/store.go
@@ -48,6 +48,10 @@ func (s *dbStore) Claim(ctx context.Context, batch, leaseSeconds int) ([]enrich.
 	return out, nil
 }
 
+func (s *dbStore) Reap(ctx context.Context, maxRows int) (int64, error) {
+	return s.q.DeleteIneligibleEnrichmentOutbox(ctx, int32(maxRows))
+}
+
 func (s *dbStore) Job(ctx context.Context, id int64) (enrich.JobInput, error) {
 	j, err := s.q.GetJob(ctx, id)
 	if err != nil {

--- a/internal/db/enrichment.sql.go
+++ b/internal/db/enrichment.sql.go
@@ -116,6 +116,21 @@ WHERE id IN (
 //
 // Bounded by max_rows so one enrich run cannot turn into an unbounded delete on the first
 // pass over a long-accumulated backlog; the next run takes the next slice.
+//
+// There is a race here, and it is left unserialized deliberately. A job can become eligible
+// again (reopened, or released from duplicate_of) while this statement runs: the enqueue that
+// follows that lifecycle write hits ON CONFLICT DO NOTHING because this row still exists, and
+// then this deletes it, leaving an eligible job with no entry. Three things bound it. The
+// window is one statement, not a transaction — once the row is gone the next
+// EnqueueJobEnrichment inserts normally. Runner.Run reaps BEFORE it enqueues, so its own
+// EnqueuePendingJobs re-adds anything that became eligible up to that point. And
+// EnqueuePendingJobs re-evaluates the whole catalogue at the start of every run, so the worst
+// case is one cron period of delay for one job, not a lost posting.
+//
+// Serializing it would mean locking jobs rows from a housekeeping statement — contending with
+// ingest on the hottest table in the schema to prevent an hour's delay on a job that is not
+// yet enriched anyway. DeleteIneligibleSearchOutbox carries the identical race for the identical
+// reason.
 func (q *Queries) DeleteIneligibleEnrichmentOutbox(ctx context.Context, maxRows int32) (int64, error) {
 	result, err := q.db.Exec(ctx, deleteIneligibleEnrichmentOutbox, maxRows)
 	if err != nil {

--- a/internal/db/enrichment.sql.go
+++ b/internal/db/enrichment.sql.go
@@ -83,6 +83,47 @@ func (q *Queries) DeleteEnrichmentEntry(ctx context.Context, id int64) error {
 	return err
 }
 
+const deleteIneligibleEnrichmentOutbox = `-- name: DeleteIneligibleEnrichmentOutbox :execrows
+DELETE FROM enrichment_outbox
+WHERE id IN (
+    SELECT o.id
+    FROM enrichment_outbox o
+    LEFT JOIN jobs j ON j.id = o.job_id
+    WHERE o.failed_at IS NULL
+      AND (j.id IS NULL OR j.closed_at IS NOT NULL OR j.duplicate_of IS NOT NULL)
+    LIMIT $1
+)
+`
+
+// Reap live entries ClaimEnrichmentBatch can never take: their job has closed, become a
+// non-canonical repost, or gone. That query's inner join plus its closed/duplicate filter
+// correctly skips them — a dead or hidden posting should not spend LLM budget — but until
+// this existed nothing deleted them either, and they accumulated. The same gap
+// DeleteIneligibleSearchOutbox closed for search_outbox, on the queue beside it.
+//
+// Measured on prod 2026-08-19, before the first run: of 1,118,601 entries, 486,178 sat
+// behind a closed job, 216,283 behind a duplicate, and 19 behind no job at all. Only
+// 484,651 were claimable — 57% of the queue was unreachable, and the depth gauge read it
+// as work.
+//
+// Deleting is not lossy: EnqueuePendingJobs re-enqueues every open, non-duplicate,
+// unenriched, tech job with a description, so an entry reaped here comes back on its own
+// if the job becomes eligible again.
+//
+// Dead-lettered rows (failed_at set) are deliberately left alone, exactly as in the search
+// reaper: they are a record of repeated failure, surfaced as freehire_queue_dead_letters,
+// so reaping them would erase the evidence rather than the garbage.
+//
+// Bounded by max_rows so one enrich run cannot turn into an unbounded delete on the first
+// pass over a long-accumulated backlog; the next run takes the next slice.
+func (q *Queries) DeleteIneligibleEnrichmentOutbox(ctx context.Context, maxRows int32) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteIneligibleEnrichmentOutbox, maxRows)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const enqueuePendingJobs = `-- name: EnqueuePendingJobs :execrows
 INSERT INTO enrichment_outbox (job_id, target_version)
 SELECT id, $1::int

--- a/internal/db/enrichment_reaper_integration_test.go
+++ b/internal/db/enrichment_reaper_integration_test.go
@@ -1,0 +1,127 @@
+//go:build integration
+
+// Integration tests for the enrichment-queue reaper: deleting entries
+// ClaimEnrichmentBatch can never take. The claim's inner join and its closed/duplicate
+// filter correctly skip them; until this existed nothing deleted them either, and on prod
+// they had grown into 57% of the queue.
+// Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+// TestDeleteIneligibleEnrichmentOutboxReapsWhatClaimCanNeverTake pins the reaper's
+// boundary: it deletes exactly what the claim skips forever, and nothing the claim would
+// still take.
+func TestDeleteIneligibleEnrichmentOutboxReapsWhatClaimCanNeverTake(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	live := insertJob(t, pool, "live")
+	canon := insertJob(t, pool, "canon")
+	closedJob := insertJob(t, pool, "closed")
+	repost := insertJob(t, pool, "repost")
+	deadLettered := insertJob(t, pool, "dead")
+
+	if _, err := q.EnqueuePendingJobs(ctx, targetVersion); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, `UPDATE jobs SET closed_at = now() WHERE id = $1`, closedJob); err != nil {
+		t.Fatalf("close job: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE jobs SET duplicate_of_role = $1 WHERE id = $2`, canon, repost); err != nil {
+		t.Fatalf("mark repost: %v", err)
+	}
+	// A dead-lettered entry whose job ALSO closed: ineligible on both counts, and it must
+	// still survive. failed_at is the record of repeated failure that
+	// freehire_queue_dead_letters reports, so reaping it would erase the evidence rather
+	// than the garbage — the same rule the search reaper follows.
+	if _, err := pool.Exec(ctx, `UPDATE jobs SET closed_at = now() WHERE id = $1`, deadLettered); err != nil {
+		t.Fatalf("close dead-lettered job: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE enrichment_outbox SET failed_at = now() WHERE job_id = $1`, deadLettered); err != nil {
+		t.Fatalf("dead-letter entry: %v", err)
+	}
+
+	reaped, err := q.DeleteIneligibleEnrichmentOutbox(ctx, 100)
+	if err != nil {
+		t.Fatalf("DeleteIneligibleEnrichmentOutbox: %v", err)
+	}
+	if reaped != 2 {
+		t.Errorf("reaped %d entries, want 2 (the closed job's and the repost's)", reaped)
+	}
+
+	remaining := map[int64]bool{}
+	rows, err := pool.Query(ctx, `SELECT job_id FROM enrichment_outbox`)
+	if err != nil {
+		t.Fatalf("read queue: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		remaining[id] = true
+	}
+	if !remaining[live] {
+		t.Error("the live job's entry was reaped; the claim would still take it")
+	}
+	if !remaining[canon] {
+		t.Error("the canonical job's entry was reaped; the claim would still take it")
+	}
+	if !remaining[deadLettered] {
+		t.Error("the dead-lettered entry was reaped; failed_at is evidence, not garbage")
+	}
+	if remaining[closedJob] || remaining[repost] {
+		t.Error("an ineligible entry survived; the claim skips it forever, so nothing else would remove it")
+	}
+}
+
+// TestDeleteIneligibleEnrichmentOutboxRespectsItsBound guards the reason the query takes a
+// limit at all: the backlog it first meets is measured in hundreds of thousands, and an
+// unbounded delete would hold row locks the claim then waits on.
+func TestDeleteIneligibleEnrichmentOutboxRespectsItsBound(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	for _, name := range []string{"a", "b", "c"} {
+		id := insertJob(t, pool, name)
+		if _, err := q.EnqueuePendingJobs(ctx, targetVersion); err != nil {
+			t.Fatalf("enqueue %s: %v", name, err)
+		}
+		if _, err := pool.Exec(ctx, `UPDATE jobs SET closed_at = now() WHERE id = $1`, id); err != nil {
+			t.Fatalf("close %s: %v", name, err)
+		}
+	}
+
+	first, err := q.DeleteIneligibleEnrichmentOutbox(ctx, 2)
+	if err != nil {
+		t.Fatalf("first reap: %v", err)
+	}
+	if first != 2 {
+		t.Fatalf("first reap removed %d, want exactly the bound of 2", first)
+	}
+	second, err := q.DeleteIneligibleEnrichmentOutbox(ctx, 2)
+	if err != nil {
+		t.Fatalf("second reap: %v", err)
+	}
+	if second != 1 {
+		t.Errorf("second reap removed %d, want the remaining 1", second)
+	}
+	third, err := q.DeleteIneligibleEnrichmentOutbox(ctx, 2)
+	if err != nil {
+		t.Fatalf("third reap: %v", err)
+	}
+	if third != 0 {
+		t.Errorf("third reap removed %d, want 0 — the backlog is drained", third)
+	}
+}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -848,6 +848,28 @@ type Querier interface {
 	// aged out.
 	DeleteExpiredTracerClicks(ctx context.Context, maxAge pgtype.Interval) (int64, error)
 	DeleteGmailConnection(ctx context.Context, userID int64) error
+	// Reap live entries ClaimEnrichmentBatch can never take: their job has closed, become a
+	// non-canonical repost, or gone. That query's inner join plus its closed/duplicate filter
+	// correctly skips them — a dead or hidden posting should not spend LLM budget — but until
+	// this existed nothing deleted them either, and they accumulated. The same gap
+	// DeleteIneligibleSearchOutbox closed for search_outbox, on the queue beside it.
+	//
+	// Measured on prod 2026-08-19, before the first run: of 1,118,601 entries, 486,178 sat
+	// behind a closed job, 216,283 behind a duplicate, and 19 behind no job at all. Only
+	// 484,651 were claimable — 57% of the queue was unreachable, and the depth gauge read it
+	// as work.
+	//
+	// Deleting is not lossy: EnqueuePendingJobs re-enqueues every open, non-duplicate,
+	// unenriched, tech job with a description, so an entry reaped here comes back on its own
+	// if the job becomes eligible again.
+	//
+	// Dead-lettered rows (failed_at set) are deliberately left alone, exactly as in the search
+	// reaper: they are a record of repeated failure, surfaced as freehire_queue_dead_letters,
+	// so reaping them would erase the evidence rather than the garbage.
+	//
+	// Bounded by max_rows so one enrich run cannot turn into an unbounded delete on the first
+	// pass over a long-accumulated backlog; the next run takes the next slice.
+	DeleteIneligibleEnrichmentOutbox(ctx context.Context, maxRows int32) (int64, error)
 	// Reap live entries ClaimSearchOutboxBatch can never take: their job has closed, become
 	// a non-canonical repost, or gone. That query's EXISTS requires open AND canonical, so
 	// these rows are correctly skipped — there is nothing left to index — but until this

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -869,6 +869,21 @@ type Querier interface {
 	//
 	// Bounded by max_rows so one enrich run cannot turn into an unbounded delete on the first
 	// pass over a long-accumulated backlog; the next run takes the next slice.
+	//
+	// There is a race here, and it is left unserialized deliberately. A job can become eligible
+	// again (reopened, or released from duplicate_of) while this statement runs: the enqueue that
+	// follows that lifecycle write hits ON CONFLICT DO NOTHING because this row still exists, and
+	// then this deletes it, leaving an eligible job with no entry. Three things bound it. The
+	// window is one statement, not a transaction — once the row is gone the next
+	// EnqueueJobEnrichment inserts normally. Runner.Run reaps BEFORE it enqueues, so its own
+	// EnqueuePendingJobs re-adds anything that became eligible up to that point. And
+	// EnqueuePendingJobs re-evaluates the whole catalogue at the start of every run, so the worst
+	// case is one cron period of delay for one job, not a lost posting.
+	//
+	// Serializing it would mean locking jobs rows from a housekeeping statement — contending with
+	// ingest on the hottest table in the schema to prevent an hour's delay on a job that is not
+	// yet enriched anyway. DeleteIneligibleSearchOutbox carries the identical race for the identical
+	// reason.
 	DeleteIneligibleEnrichmentOutbox(ctx context.Context, maxRows int32) (int64, error)
 	// Reap live entries ClaimSearchOutboxBatch can never take: their job has closed, become
 	// a non-canonical repost, or gone. That query's EXISTS requires open AND canonical, so

--- a/internal/db/queries/enrichment.sql
+++ b/internal/db/queries/enrichment.sql
@@ -49,6 +49,38 @@ FROM claimable c
 WHERE o.id = c.id
 RETURNING o.id, o.job_id, o.target_version;
 
+-- name: DeleteIneligibleEnrichmentOutbox :execrows
+-- Reap live entries ClaimEnrichmentBatch can never take: their job has closed, become a
+-- non-canonical repost, or gone. That query's inner join plus its closed/duplicate filter
+-- correctly skips them — a dead or hidden posting should not spend LLM budget — but until
+-- this existed nothing deleted them either, and they accumulated. The same gap
+-- DeleteIneligibleSearchOutbox closed for search_outbox, on the queue beside it.
+--
+-- Measured on prod 2026-08-19, before the first run: of 1,118,601 entries, 486,178 sat
+-- behind a closed job, 216,283 behind a duplicate, and 19 behind no job at all. Only
+-- 484,651 were claimable — 57% of the queue was unreachable, and the depth gauge read it
+-- as work.
+--
+-- Deleting is not lossy: EnqueuePendingJobs re-enqueues every open, non-duplicate,
+-- unenriched, tech job with a description, so an entry reaped here comes back on its own
+-- if the job becomes eligible again.
+--
+-- Dead-lettered rows (failed_at set) are deliberately left alone, exactly as in the search
+-- reaper: they are a record of repeated failure, surfaced as freehire_queue_dead_letters,
+-- so reaping them would erase the evidence rather than the garbage.
+--
+-- Bounded by max_rows so one enrich run cannot turn into an unbounded delete on the first
+-- pass over a long-accumulated backlog; the next run takes the next slice.
+DELETE FROM enrichment_outbox
+WHERE id IN (
+    SELECT o.id
+    FROM enrichment_outbox o
+    LEFT JOIN jobs j ON j.id = o.job_id
+    WHERE o.failed_at IS NULL
+      AND (j.id IS NULL OR j.closed_at IS NOT NULL OR j.duplicate_of IS NOT NULL)
+    LIMIT sqlc.arg(max_rows)
+);
+
 -- name: DeleteEnrichmentEntry :exec
 DELETE FROM enrichment_outbox
 WHERE id = $1;

--- a/internal/db/queries/enrichment.sql
+++ b/internal/db/queries/enrichment.sql
@@ -71,6 +71,21 @@ RETURNING o.id, o.job_id, o.target_version;
 --
 -- Bounded by max_rows so one enrich run cannot turn into an unbounded delete on the first
 -- pass over a long-accumulated backlog; the next run takes the next slice.
+--
+-- There is a race here, and it is left unserialized deliberately. A job can become eligible
+-- again (reopened, or released from duplicate_of) while this statement runs: the enqueue that
+-- follows that lifecycle write hits ON CONFLICT DO NOTHING because this row still exists, and
+-- then this deletes it, leaving an eligible job with no entry. Three things bound it. The
+-- window is one statement, not a transaction — once the row is gone the next
+-- EnqueueJobEnrichment inserts normally. Runner.Run reaps BEFORE it enqueues, so its own
+-- EnqueuePendingJobs re-adds anything that became eligible up to that point. And
+-- EnqueuePendingJobs re-evaluates the whole catalogue at the start of every run, so the worst
+-- case is one cron period of delay for one job, not a lost posting.
+--
+-- Serializing it would mean locking jobs rows from a housekeeping statement — contending with
+-- ingest on the hottest table in the schema to prevent an hour's delay on a job that is not
+-- yet enriched anyway. DeleteIneligibleSearchOutbox carries the identical race for the identical
+-- reason.
 DELETE FROM enrichment_outbox
 WHERE id IN (
     SELECT o.id

--- a/internal/enrich/AGENTS.md
+++ b/internal/enrich/AGENTS.md
@@ -20,6 +20,7 @@ The typed enrichment contract, the LLM provider abstraction, and the queue-drain
 - `SetJobEnrichment` is deliberately separate from `UpsertJob` so ingest and enrichment stay decoupled.
 - Never hard-code a vendor or model — the LLM is configured by `LLM_BASE_URL`/`LLM_API_KEY`/`LLM_MODEL` (any OpenAI-compatible endpoint).
 - The lease expiry is the built-in reaper — no separate process.
+- **Entries whose job stops being claimable are reaped at the START of each run** (`Store.Reap` → `DeleteIneligibleEnrichmentOutbox`, bounded by `reapLimit`). The claim's join plus its `closed_at IS NULL AND duplicate_of IS NULL` filter correctly skips a job that closed or became a repost — but nothing deleted those entries, so they accumulated. Measured on prod 2026-08-19: of **1,118,601** entries, 486,178 sat behind a closed job and 216,283 behind a duplicate; only **484,651 were claimable**, so 57% of the queue was unreachable and the depth gauge read it as work. Reaping is best-effort and never aborts the run, and it is not lossy — `EnqueuePendingJobs` re-adds anything that becomes eligible again. Dead-lettered entries (`failed_at`) are left alone: they are the evidence `freehire_queue_dead_letters` reports.
 - Overlapping cron runs can't double-enrich: the wave is sized to the concurrency so an entry's lease window stays ≈ one LLM call.
 
 ## How it works

--- a/internal/enrich/runner.go
+++ b/internal/enrich/runner.go
@@ -36,6 +36,9 @@ type Store interface {
 	// Fail records a failed attempt under the given policy; it returns whether the
 	// entry was dead-lettered.
 	Fail(ctx context.Context, outboxID int64, errMsg string, policy FailurePolicy) (deadLettered bool, err error)
+	// Reap deletes up to maxRows live entries Claim can never take (their job closed,
+	// became a non-canonical repost, or is gone), returning how many it removed.
+	Reap(ctx context.Context, maxRows int) (int64, error)
 }
 
 // FailurePolicy is how one failure should be bounded. Which of the two bounds applies
@@ -67,7 +70,18 @@ type Stats struct {
 	Enriched     int
 	Failed       int
 	DeadLettered int
+	// Reaped counts entries deleted because Claim could never take them — housekeeping,
+	// not enrichment work.
+	Reaped int
 }
+
+// reapLimit bounds how many ineligible entries one run deletes. Sized against the backlog
+// this accumulated into before anything reaped it: 633,532 of 1,118,601 entries on prod
+// 2026-08-19, 57% of the queue. An unbounded first pass over that is a long delete holding
+// row locks the claim then waits on, so the run takes a slice and the next one takes the
+// next. Larger than search-drain's 2,000 because enrich runs on a far slower cadence and
+// its backlog is two orders of magnitude bigger.
+const reapLimit = 20_000
 
 // Runner drives the enrichment process: enqueue pending jobs, then drain claimed
 // batches, enriching and writing back each entry.
@@ -79,9 +93,20 @@ type Runner struct {
 // Run enqueues pending jobs and drains the queue until no claimable entries remain.
 // A failure on a single entry is recorded and never aborts the run.
 func (r Runner) Run(ctx context.Context, opt RunOptions) (Stats, error) {
+	// Reap before enqueueing, so the depth this run reports is work and not residue.
+	// Claim skips an entry whose job has closed or become a repost, but nothing deleted
+	// those entries, and they accumulated into most of the queue. Best-effort:
+	// housekeeping must never be the reason enrichment stops.
+	reaped, err := r.Store.Reap(ctx, reapLimit)
+	if err != nil {
+		log.Printf("enrich: reap ineligible entries (continuing): %v", err)
+	} else if reaped > 0 {
+		log.Printf("enrich: reaped %d entries whose job closed or became a repost", reaped)
+	}
+
 	enqueued, err := r.Store.Enqueue(ctx, opt.TargetVersion)
 	if err != nil {
-		return Stats{}, fmt.Errorf("enqueue: %w", err)
+		return Stats{Reaped: int(reaped)}, fmt.Errorf("enqueue: %w", err)
 	}
 	log.Printf("enrich: enqueued %d pending, draining (concurrency=%d)", enqueued, opt.Concurrency)
 
@@ -98,7 +123,7 @@ func (r Runner) Run(ctx context.Context, opt RunOptions) (Stats, error) {
 			log.Printf("enrich: progress enriched=%d failed=%d dead=%d", cum.Succeeded, cum.Failed, cum.DeadLettered)
 		},
 	}, rn.process)
-	stats := Stats{Enriched: s.Succeeded, Failed: s.Failed, DeadLettered: s.DeadLettered}
+	stats := Stats{Enriched: s.Succeeded, Failed: s.Failed, DeadLettered: s.DeadLettered, Reaped: int(reaped)}
 	if err != nil {
 		return stats, fmt.Errorf("claim: %w", err)
 	}

--- a/internal/enrich/runner_fault_test.go
+++ b/internal/enrich/runner_fault_test.go
@@ -13,6 +13,9 @@ type recordingStore struct {
 	policies []FailurePolicy
 }
 
+// Reap is a no-op here: these tests are about failure bounding, not housekeeping.
+func (s *recordingStore) Reap(context.Context, int) (int64, error) { return 0, nil }
+
 func (s *recordingStore) Fail(ctx context.Context, outboxID int64, msg string, policy FailurePolicy) (bool, error) {
 	s.policies = append(s.policies, policy)
 	return s.fakeStore.Fail(ctx, outboxID, msg, policy)

--- a/internal/enrich/runner_test.go
+++ b/internal/enrich/runner_test.go
@@ -45,6 +45,7 @@ type fakeStore struct {
 	deadFor  map[int64]bool
 
 	mu        sync.Mutex
+	reapCalls int
 	enqueued  bool
 	completed []int64
 	failed    []int64
@@ -74,6 +75,13 @@ func (s *fakeStore) Complete(_ context.Context, entry Claimed, _ json.RawMessage
 	s.completed = append(s.completed, entry.OutboxID)
 	s.mu.Unlock()
 	return nil
+}
+
+// Reap records the call so a test can assert the runner reaps before it enqueues; the
+// fake has nothing ineligible to delete.
+func (s *fakeStore) Reap(context.Context, int) (int64, error) {
+	s.reapCalls++
+	return 0, nil
 }
 
 func (s *fakeStore) Fail(_ context.Context, outboxID int64, _ string, policy FailurePolicy) (bool, error) {


### PR DESCRIPTION
## The gap

`ClaimEnrichmentBatch` joins `jobs` and filters `closed_at IS NULL AND duplicate_of IS NULL`, so an entry whose job closed or became a non-canonical repost is correctly skipped — a dead or hidden posting should not spend LLM budget. Nothing deleted those entries, and they accumulated.

Measured on prod 2026-08-19, before anything reaped:

| | Entries |
|---|---|
| Behind a closed job | 486,178 |
| Behind a duplicate | 216,283 |
| Behind no job at all | 19 |
| Dead-lettered | 418 |
| **Actually claimable** | **484,651** |
| **Total** | **1,118,601** |

57% of the queue was unreachable, and `freehire_queue_depth` reported all of it as work.

## The fix

The same gap `DeleteIneligibleSearchOutbox` closed for `search_outbox`, on the queue beside it, fixed the same way: each run reaps first, bounded, best-effort, and never the reason enrichment stops.

- **Not lossy.** `EnqueuePendingJobs` re-enqueues every open, non-duplicate, unenriched, tech job with a description, so an entry reaped here comes back on its own if the job becomes eligible again.
- **Dead-lettered entries survive**, as in the search reaper: `failed_at` is the record of repeated failure that `freehire_queue_dead_letters` reports, so reaping them would erase the evidence rather than the garbage.
- **Bound is 20,000**, not search-drain's 2,000 — enrich runs on a far slower cadence and its backlog was two orders of magnitude bigger. An unbounded first pass over 633k rows is a long delete holding row locks the claim then waits on.

## Scope

Deliberately strict: the reaper deletes exactly what the claim can never take. The measurement also found 55,518 entries whose job is no longer `is_tech`, 2,620 already enriched at or above their target version, and 482 with a blank description — the claim *will* take those, so they are a different question (a claim-predicate gap, not a reaping gap) and are not touched here.

## Verification

Two integration tests: one pins the boundary (reaps the closed and duplicate entries, leaves the live, the canonical, and the dead-lettered), one pins that the limit is respected across successive runs and drains to zero.

A one-off cleanup of the accumulated backlog has already run on prod — the queue went from 1,118,601 to ~479,000. This change is what stops it coming back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of stale enrichment queue entries before each run.
  * Cleanup is limited per run, preserves failed entries, and reports the number of removed entries.
  * Enrichment continues even if cleanup encounters an error.

* **Bug Fixes**
  * Prevented closed, missing, and duplicate-job entries from remaining stuck in the enrichment queue.
  * Eligible jobs can be re-enqueued after stale entries are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->