### PR TITLE
Send duplicate-status changes through the outbox queues

### DIFF
--- a/internal/db/duplicate_marker_outbox_integration_test.go
+++ b/internal/db/duplicate_marker_outbox_integration_test.go
@@ -1,0 +1,253 @@
+//go:build integration
+
+// Integration tests for routing duplicate-status changes onto the two facet-index queues: a
+// posting that becomes a duplicate is queued for removal, one that becomes canonical again is
+// queued for indexing, and a duplicate that merely changes canon is queued nowhere.
+//
+// The case worth reading first is TestMarkerOutbox_OnePassReleasesWhileAnotherHolds. An
+// implementation that branches on the pass's OWN column passes every other test here and gets
+// that one wrong, by putting a posting that is still a duplicate back into search.
+// Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// queued reads the job ids sitting on one of the two queues.
+func queued(t *testing.T, pool *pgxpool.Pool, table string) map[int64]bool {
+	t.Helper()
+	out := map[int64]bool{}
+	// table is a test-supplied literal, never user input.
+	rows, err := pool.Query(context.Background(), "SELECT job_id FROM "+table)
+	if err != nil {
+		t.Fatalf("read %s: %v", table, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan %s: %v", table, err)
+		}
+		out[id] = true
+	}
+	return out
+}
+
+// clearQueues empties both queues so a test can assert on what ONE pass produced rather than
+// on everything the fixture happened to enqueue.
+func clearQueues(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		`TRUNCATE search_outbox, search_delete_outbox`); err != nil {
+		t.Fatalf("clear queues: %v", err)
+	}
+}
+
+// TestMarkerOutbox_BecomingADuplicateQueuesRemoval covers the transition that costs a user
+// something: until this existed, a repost stayed searchable as its own vacancy until the next
+// rebuild, up to six hours.
+func TestMarkerOutbox_BecomingADuplicateQueuesRemoval(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	mustUpsert(t, q, withRoleFP(atsJob("acme:canon", "Staff Engineer", []string{"US"}), "fp-role"))
+	mustUpsert(t, q, withRoleFP(atsJob("acme:repost", "Staff Engineer", []string{"US"}), "fp-role"))
+	canonID, _ := dupOf(t, pool, "acme:canon")
+	repostID, _ := dupOf(t, pool, "acme:repost")
+	clearQueues(t, pool)
+
+	recomputeDuplicates(t, q)
+
+	if _, dup := dupOf(t, pool, "acme:repost"); dup != canonID {
+		t.Fatalf("fixture: repost duplicate_of = %d, want canon %d", dup, canonID)
+	}
+	if !queued(t, pool, "search_delete_outbox")[repostID] {
+		t.Error("the new duplicate was not queued for removal; its document would sit in the index until the next rebuild")
+	}
+	if queued(t, pool, "search_outbox")[repostID] {
+		t.Error("the new duplicate was queued for indexing; the claim would skip it anyway, but queueing it is wrong")
+	}
+	if queued(t, pool, "search_delete_outbox")[canonID] {
+		t.Error("the canon was queued for removal")
+	}
+}
+
+// TestMarkerOutbox_BecomingCanonicalQueuesIndexing is the same transition backwards: a canon
+// closes, its repost is promoted, and the promoted row has to come back into search.
+func TestMarkerOutbox_BecomingCanonicalQueuesIndexing(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	mustUpsert(t, q, withRoleFP(atsJob("acme:canon", "Staff Engineer", []string{"US"}), "fp-role"))
+	mustUpsert(t, q, withRoleFP(atsJob("acme:repost", "Staff Engineer", []string{"US"}), "fp-role"))
+	canonID, _ := dupOf(t, pool, "acme:canon")
+	repostID, _ := dupOf(t, pool, "acme:repost")
+
+	recomputeDuplicates(t, q)
+	if _, dup := dupOf(t, pool, "acme:repost"); dup != canonID {
+		t.Fatalf("fixture: repost is not a duplicate")
+	}
+
+	// The canon closes; the repost is the only open row of its role and becomes canonical.
+	if _, err := pool.Exec(ctx, `UPDATE jobs SET closed_at = now() WHERE id = $1`, canonID); err != nil {
+		t.Fatalf("close canon: %v", err)
+	}
+	clearQueues(t, pool)
+
+	recomputeDuplicates(t, q)
+
+	if _, dup := dupOf(t, pool, "acme:repost"); dup != -1 {
+		t.Fatalf("fixture: repost duplicate_of = %d, want NULL after its canon closed", dup)
+	}
+	if !queued(t, pool, "search_outbox")[repostID] {
+		t.Error("the promoted posting was not queued for indexing; it would stay out of search until the next rebuild")
+	}
+	if queued(t, pool, "search_delete_outbox")[repostID] {
+		t.Error("the promoted posting was queued for removal")
+	}
+
+	// The queue orders by job_posted_at, so the enqueue must carry it rather than leave NULL.
+	var postedAt *string
+	if err := pool.QueryRow(ctx,
+		`SELECT job_posted_at::text FROM search_outbox WHERE job_id = $1`, repostID).Scan(&postedAt); err != nil {
+		t.Fatalf("read job_posted_at: %v", err)
+	}
+	if postedAt == nil {
+		t.Error("job_posted_at is NULL; the claim orders by it, so a NULL sorts the posting to the back of the queue")
+	}
+}
+
+// TestMarkerOutbox_RepointingADuplicateQueuesNothing keeps the volume proportional to status
+// changes rather than to marker writes. The document is already absent; removing it again is a
+// no-op in Meilisearch and pure cost at ~200 documents a push.
+func TestMarkerOutbox_RepointingADuplicateQueuesNothing(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	mustUpsert(t, q, withRoleFP(atsJob("acme:first", "Staff Engineer", []string{"US"}), "fp-role"))
+	mustUpsert(t, q, withRoleFP(atsJob("acme:second", "Staff Engineer", []string{"US"}), "fp-role"))
+	mustUpsert(t, q, withRoleFP(atsJob("acme:third", "Staff Engineer", []string{"US"}), "fp-role"))
+	firstID, _ := dupOf(t, pool, "acme:first")
+	thirdID, _ := dupOf(t, pool, "acme:third")
+
+	recomputeDuplicates(t, q)
+	if _, dup := dupOf(t, pool, "acme:third"); dup != firstID {
+		t.Fatalf("fixture: third points at %d, want the min-id canon %d", dup, firstID)
+	}
+
+	// Close the canon: third stays a duplicate but now points at second.
+	if _, err := pool.Exec(ctx, `UPDATE jobs SET closed_at = now() WHERE id = $1`, firstID); err != nil {
+		t.Fatalf("close canon: %v", err)
+	}
+	clearQueues(t, pool)
+
+	recomputeDuplicates(t, q)
+
+	if _, dup := dupOf(t, pool, "acme:third"); dup == -1 || dup == firstID {
+		t.Fatalf("fixture: third duplicate_of = %d, want a new canon", dup)
+	}
+	if queued(t, pool, "search_delete_outbox")[thirdID] || queued(t, pool, "search_outbox")[thirdID] {
+		t.Error("a duplicate that only changed canon was queued; it was a duplicate before and after, so its document never moved")
+	}
+}
+
+// TestMarkerOutbox_OnePassReleasesWhileAnotherHolds is why the decision reads the DERIVED
+// marker. The aggregator pass releases its suppression while the role pass still marks the
+// posting a repost: the aggregator's OWN column goes non-NULL to NULL, which looks exactly like
+// "became canonical" — but the posting is still a duplicate, and queueing it for indexing would
+// put a repost back into search.
+func TestMarkerOutbox_OnePassReleasesWhileAnotherHolds(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	// Getting a row to carry BOTH markers takes care, and the constraint is instructive: the
+	// aggregator pass skips a row the role pass pointed at another AGGREGATOR, so the role
+	// canon has to be a non-aggregator — and a DIFFERENT one from the ATS twin the aggregator
+	// pass matches by title, or closing the twin would release both markers at once.
+	//
+	//   acme:role-canon  ATS, "Backend Engineer",  fp-shared  <- role canon, stays open
+	//   acme:agg         aggregator, "Platform Engineer", fp-shared  <- carries both markers
+	//   acme:ats-twin    ATS, "Platform Engineer", fp-twin    <- the aggregator twin, closes
+	mustUpsert(t, q, withRoleFP(atsJob("acme:role-canon", "Backend Engineer", []string{"US"}), "fp-shared"))
+	mustUpsert(t, q, withRoleFP(aggJob("acme:agg", "Platform Engineer", []string{"US"}), "fp-shared"))
+	mustUpsert(t, q, withRoleFP(atsJob("acme:ats-twin", "Platform Engineer", []string{"US"}), "fp-twin"))
+	roleCanonID, _ := dupOf(t, pool, "acme:role-canon")
+	atsID, _ := dupOf(t, pool, "acme:ats-twin")
+	agg2ID, _ := dupOf(t, pool, "acme:agg")
+
+	recomputeDuplicates(t, q)
+	suppressAggregators(t, q)
+
+	agg, role, _, derived := ownedMarkers(t, pool, "acme:agg")
+	if agg != atsID || role != roleCanonID {
+		t.Fatalf("fixture: agg must carry BOTH markers, got aggregator=%d (want %d) role=%d (want %d)",
+			agg, atsID, role, roleCanonID)
+	}
+	if derived != atsID {
+		t.Fatalf("fixture: derived = %d, want the aggregator verdict %d (it outranks role)", derived, atsID)
+	}
+
+	// The ATS twin closes, so the aggregator pass releases its suppression. The role pass
+	// still marks the aggregator row a repost of acme:role-canon.
+	if _, err := pool.Exec(ctx, `UPDATE jobs SET closed_at = now() WHERE id = $1`, atsID); err != nil {
+		t.Fatalf("close ATS twin: %v", err)
+	}
+	clearQueues(t, pool)
+
+	suppressAggregators(t, q)
+
+	agg, role, _, derived = ownedMarkers(t, pool, "acme:agg")
+	if agg != -1 {
+		t.Fatalf("fixture: the suppression was not released, aggregator column = %d", agg)
+	}
+	if role != roleCanonID || derived != roleCanonID {
+		t.Fatalf("fixture: the row should still be a duplicate by role, got role=%d derived=%d, want %d",
+			role, derived, roleCanonID)
+	}
+	if queued(t, pool, "search_outbox")[agg2ID] {
+		t.Error("a posting that is STILL a duplicate was queued for indexing — the decision read the " +
+			"pass's own column instead of the derived one, and this repost would return to search")
+	}
+	if queued(t, pool, "search_delete_outbox")[agg2ID] {
+		t.Error("a posting whose duplicate status did not change was queued for removal")
+	}
+}
+
+// TestMarkerOutbox_UnchangedRefreshQueuesNothing pairs with the ownership change's idempotence
+// test: a refresh that writes no markers must also queue nothing.
+func TestMarkerOutbox_UnchangedRefreshQueuesNothing(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	mustUpsert(t, q, withRoleFP(atsJob("acme:canon", "Staff Engineer", []string{"US"}), "fp-role"))
+	mustUpsert(t, q, withRoleFP(atsJob("acme:repost", "Staff Engineer", []string{"US"}), "fp-role"))
+	mustUpsert(t, q, withRoleFP(atsJob("acme:ats", "Platform Engineer", []string{"US"}), "fp-ats"))
+	mustUpsert(t, q, withRoleFP(aggJob("acme:agg", "Platform Engineer", []string{"US"}), "fp-agg"))
+
+	recomputeDuplicates(t, q)
+	suppressAggregators(t, q)
+	clearQueues(t, pool)
+
+	// Second refresh over an unchanged catalogue.
+	recomputeDuplicates(t, q)
+	suppressAggregators(t, q)
+
+	if n := len(queued(t, pool, "search_delete_outbox")); n != 0 {
+		t.Errorf("an unchanged refresh queued %d removals, want 0", n)
+	}
+	if n := len(queued(t, pool, "search_outbox")); n != 0 {
+		t.Errorf("an unchanged refresh queued %d index pushes, want 0", n)
+	}
+}

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -2136,12 +2136,22 @@ updated AS (
     SET duplicate_of_role = $2,
         updated_at        = now()
     WHERE j.id = $1
-    RETURNING j.id, j.duplicate_of AS now_duplicate_of
+    RETURNING j.id,
+              j.duplicate_of AS now_duplicate_of,
+              COALESCE(j.posted_at, j.created_at) AS eff_posted_at
+),
+flipped AS (
+    SELECT u.id, b.was_duplicate_of, u.now_duplicate_of, u.eff_posted_at
+    FROM updated u JOIN before b ON b.id = u.id
 ),
 dequeued AS (
     INSERT INTO search_delete_outbox (job_id)
-    SELECT u.id FROM updated u JOIN before b ON b.id = u.id
-    WHERE b.was_duplicate_of IS NULL AND u.now_duplicate_of IS NOT NULL
+    SELECT id FROM flipped WHERE was_duplicate_of IS NULL AND now_duplicate_of IS NOT NULL
+    ON CONFLICT (job_id) DO NOTHING
+),
+requeued AS (
+    INSERT INTO search_outbox (job_id, job_posted_at)
+    SELECT id, eff_posted_at FROM flipped WHERE was_duplicate_of IS NOT NULL AND now_duplicate_of IS NULL
     ON CONFLICT (job_id) DO NOTHING
 )
 SELECT count(*)::bigint FROM updated
@@ -2161,6 +2171,10 @@ type MarkJobDuplicateOfRoleParams struct {
 // jobdedup.CanonicalForRole, so this is the role verdict arriving early — the same clustering
 // the batch pass would reach hours later. A write to duplicate_of itself would not survive:
 // the derivation in migration 0115 recomputes it from the owned columns.
+// Both callers pass a canon, so today this branch never fires: the import path only ever SETS
+// the role marker. It is here because the argument is nullable and the other three writers are
+// symmetric — a future caller clearing the marker through this query would otherwise leave a
+// now-canonical posting out of search until the next rebuild, silently.
 func (q *Queries) MarkJobDuplicateOfRole(ctx context.Context, arg MarkJobDuplicateOfRoleParams) (int64, error) {
 	row := q.db.QueryRow(ctx, markJobDuplicateOfRole, arg.ID, arg.DuplicateOfRole)
 	var column_1 int64

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -2067,24 +2067,52 @@ func (q *Queries) ListRoleClusterCopies(ctx context.Context, arg ListRoleCluster
 	return items, nil
 }
 
-const markFuzzyDuplicatesForCompany = `-- name: MarkFuzzyDuplicatesForCompany :execrows
-UPDATE jobs j
-SET duplicate_of_fuzzy = m.canon_id,
-    updated_at         = now()
-FROM (
-    SELECT unnest($2::bigint[]) AS id,
-           unnest($3::bigint[]) AS canon_id
-) m
-WHERE j.id = m.id
-  AND j.company_slug = $1
-  AND j.closed_at IS NULL
-  AND j.duplicate_of_fuzzy IS DISTINCT FROM m.canon_id
+const markFuzzyDuplicatesForCompany = `-- name: MarkFuzzyDuplicatesForCompany :one
+WITH assign AS (
+    SELECT unnest($1::bigint[]) AS id,
+           unnest($2::bigint[]) AS canon_id
+),
+before AS (
+    -- Every CTE of one statement reads the same snapshot, so this is the derived marker as it
+    -- stood BEFORE the update below — which is what makes the status transition readable
+    -- without a second statement and the race between them.
+    SELECT j.id, j.duplicate_of AS was_duplicate_of
+    FROM jobs j JOIN assign a ON a.id = j.id
+),
+updated AS (
+    UPDATE jobs j
+    SET duplicate_of_fuzzy = m.canon_id,
+        updated_at         = now()
+    FROM assign m
+    WHERE j.id = m.id
+      AND j.company_slug = $3
+      AND j.closed_at IS NULL
+      AND j.duplicate_of_fuzzy IS DISTINCT FROM m.canon_id
+    RETURNING j.id,
+              j.duplicate_of AS now_duplicate_of,
+              COALESCE(j.posted_at, j.created_at) AS eff_posted_at
+),
+flipped AS (
+    SELECT u.id, b.was_duplicate_of, u.now_duplicate_of, u.eff_posted_at
+    FROM updated u JOIN before b ON b.id = u.id
+),
+dequeued AS (
+    INSERT INTO search_delete_outbox (job_id)
+    SELECT id FROM flipped WHERE was_duplicate_of IS NULL AND now_duplicate_of IS NOT NULL
+    ON CONFLICT (job_id) DO NOTHING
+),
+requeued AS (
+    INSERT INTO search_outbox (job_id, job_posted_at)
+    SELECT id, eff_posted_at FROM flipped WHERE was_duplicate_of IS NOT NULL AND now_duplicate_of IS NULL
+    ON CONFLICT (job_id) DO NOTHING
+)
+SELECT count(*)::bigint FROM flipped
 `
 
 type MarkFuzzyDuplicatesForCompanyParams struct {
-	Company string  `json:"company"`
 	Ids     []int64 `json:"ids"`
 	Canons  []int64 `json:"canons"`
+	Company string  `json:"company"`
 }
 
 // Point each fuzzy-clustered posting at its canon. Takes two parallel arrays (ids, canons) so
@@ -2093,23 +2121,35 @@ type MarkFuzzyDuplicatesForCompanyParams struct {
 // meantime is left alone. The IS DISTINCT FROM guard makes a re-run free, and the standard
 // recompute reverses everything here by recomputing duplicate_of from scratch.
 func (q *Queries) MarkFuzzyDuplicatesForCompany(ctx context.Context, arg MarkFuzzyDuplicatesForCompanyParams) (int64, error) {
-	result, err := q.db.Exec(ctx, markFuzzyDuplicatesForCompany, arg.Company, arg.Ids, arg.Canons)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
+	row := q.db.QueryRow(ctx, markFuzzyDuplicatesForCompany, arg.Ids, arg.Canons, arg.Company)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
 }
 
-const markJobDuplicateOfRole = `-- name: MarkJobDuplicateOfRole :execrows
-UPDATE jobs
-SET duplicate_of_role = $1,
-    updated_at        = now()
-WHERE id = $2
+const markJobDuplicateOfRole = `-- name: MarkJobDuplicateOfRole :one
+WITH before AS (
+    SELECT b.id, b.duplicate_of AS was_duplicate_of FROM jobs b WHERE b.id = $1
+),
+updated AS (
+    UPDATE jobs j
+    SET duplicate_of_role = $2,
+        updated_at        = now()
+    WHERE j.id = $1
+    RETURNING j.id, j.duplicate_of AS now_duplicate_of
+),
+dequeued AS (
+    INSERT INTO search_delete_outbox (job_id)
+    SELECT u.id FROM updated u JOIN before b ON b.id = u.id
+    WHERE b.was_duplicate_of IS NULL AND u.now_duplicate_of IS NOT NULL
+    ON CONFLICT (job_id) DO NOTHING
+)
+SELECT count(*)::bigint FROM updated
 `
 
 type MarkJobDuplicateOfRoleParams struct {
-	DuplicateOfRole pgtype.Int8 `json:"duplicate_of_role"`
 	ID              int64       `json:"id"`
+	DuplicateOfRole pgtype.Int8 `json:"duplicate_of_role"`
 }
 
 // Point one row at its ROLE canon. The import path only: the batch passes recompute whole
@@ -2122,11 +2162,10 @@ type MarkJobDuplicateOfRoleParams struct {
 // the batch pass would reach hours later. A write to duplicate_of itself would not survive:
 // the derivation in migration 0115 recomputes it from the owned columns.
 func (q *Queries) MarkJobDuplicateOfRole(ctx context.Context, arg MarkJobDuplicateOfRoleParams) (int64, error) {
-	result, err := q.db.Exec(ctx, markJobDuplicateOfRole, arg.DuplicateOfRole, arg.ID)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
+	row := q.db.QueryRow(ctx, markJobDuplicateOfRole, arg.ID, arg.DuplicateOfRole)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
 }
 
 const markLivenessExpired = `-- name: MarkLivenessExpired :one
@@ -2252,7 +2291,7 @@ func (q *Queries) PropagateCollectionsToJobs(ctx context.Context) (int64, error)
 	return result.RowsAffected(), nil
 }
 
-const recomputeRoleDuplicatesForCompanies = `-- name: RecomputeRoleDuplicatesForCompanies :execrows
+const recomputeRoleDuplicatesForCompanies = `-- name: RecomputeRoleDuplicatesForCompanies :one
 WITH canon AS (
     SELECT jobs.role_fingerprint, MIN(jobs.id) AS canon_id, COUNT(*) AS n
     FROM jobs
@@ -2262,17 +2301,35 @@ WITH canon AS (
 ),
 target AS (
     SELECT j.id,
-        CASE WHEN c.n > 1 AND j.id <> c.canon_id THEN c.canon_id END AS new_dup
+        CASE WHEN c.n > 1 AND j.id <> c.canon_id THEN c.canon_id END AS new_dup,
+        j.duplicate_of AS was_duplicate_of
     FROM jobs j
     JOIN canon c ON j.role_fingerprint = c.role_fingerprint
     WHERE j.company_slug = ANY($1::text[]) AND j.closed_at IS NULL
+),
+updated AS (
+    UPDATE jobs j
+    SET duplicate_of_role = t.new_dup,
+        updated_at        = now()
+    FROM target t
+    WHERE j.id = t.id
+      AND j.duplicate_of_role IS DISTINCT FROM t.new_dup
+    RETURNING j.id,
+              t.was_duplicate_of,
+              j.duplicate_of AS now_duplicate_of,
+              COALESCE(j.posted_at, j.created_at) AS eff_posted_at
+),
+dequeued AS (
+    INSERT INTO search_delete_outbox (job_id)
+    SELECT id FROM updated WHERE was_duplicate_of IS NULL AND now_duplicate_of IS NOT NULL
+    ON CONFLICT (job_id) DO NOTHING
+),
+requeued AS (
+    INSERT INTO search_outbox (job_id, job_posted_at)
+    SELECT id, eff_posted_at FROM updated WHERE was_duplicate_of IS NOT NULL AND now_duplicate_of IS NULL
+    ON CONFLICT (job_id) DO NOTHING
 )
-UPDATE jobs j
-SET duplicate_of_role = t.new_dup,
-    updated_at        = now()
-FROM target t
-WHERE j.id = t.id
-  AND j.duplicate_of_role IS DISTINCT FROM t.new_dup
+SELECT count(*)::bigint FROM updated
 `
 
 // The batched slice of the role-duplicate recompute, driven over a CHUNK of companies
@@ -2292,11 +2349,10 @@ WHERE j.id = t.id
 // The IS DISTINCT FROM guard makes re-runs cheap and idempotent, and a closed canon
 // fails over to the next min(id) on the next run.
 func (q *Queries) RecomputeRoleDuplicatesForCompanies(ctx context.Context, companies []string) (int64, error) {
-	result, err := q.db.Exec(ctx, recomputeRoleDuplicatesForCompanies, companies)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
+	row := q.db.QueryRow(ctx, recomputeRoleDuplicatesForCompanies, companies)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
 }
 
 const refreshUnchangedJob = `-- name: RefreshUnchangedJob :one
@@ -2913,7 +2969,7 @@ func (q *Queries) SetJobEnrichment(ctx context.Context, arg SetJobEnrichmentPara
 	return err
 }
 
-const suppressAggregatorDuplicatesForCompanies = `-- name: SuppressAggregatorDuplicatesForCompanies :execrows
+const suppressAggregatorDuplicatesForCompanies = `-- name: SuppressAggregatorDuplicatesForCompanies :one
 WITH ats AS (
     SELECT jobs.id,
            jobs.company_slug_folded AS fcompany,
@@ -3010,17 +3066,36 @@ target AS (
     -- Every candidate aggregator row, with its MIN matching ATS id or NULL. LEFT JOIN so an
     -- unmatched row (including one whose ATS twin just closed) resolves to NULL and is
     -- released back into search/embedding/enrichment. min(id) picks a stable target.
-    SELECT a.id, MIN(m.ats_id) AS new_dup
+    SELECT a.id, MIN(m.ats_id) AS new_dup,
+           MIN(j.duplicate_of) AS was_duplicate_of
     FROM agg a
     LEFT JOIN matches m ON m.agg_id = a.id
+    JOIN jobs j ON j.id = a.id
     GROUP BY a.id
+),
+updated AS (
+    UPDATE jobs j
+    SET duplicate_of_aggregator = t.new_dup,
+        updated_at              = now()
+    FROM target t
+    WHERE j.id = t.id
+      AND j.duplicate_of_aggregator IS DISTINCT FROM t.new_dup
+    RETURNING j.id,
+              t.was_duplicate_of,
+              j.duplicate_of AS now_duplicate_of,
+              COALESCE(j.posted_at, j.created_at) AS eff_posted_at
+),
+dequeued AS (
+    INSERT INTO search_delete_outbox (job_id)
+    SELECT id FROM updated WHERE was_duplicate_of IS NULL AND now_duplicate_of IS NOT NULL
+    ON CONFLICT (job_id) DO NOTHING
+),
+requeued AS (
+    INSERT INTO search_outbox (job_id, job_posted_at)
+    SELECT id, eff_posted_at FROM updated WHERE was_duplicate_of IS NOT NULL AND now_duplicate_of IS NULL
+    ON CONFLICT (job_id) DO NOTHING
 )
-UPDATE jobs j
-SET duplicate_of_aggregator = t.new_dup,
-    updated_at              = now()
-FROM target t
-WHERE j.id = t.id
-  AND j.duplicate_of_aggregator IS DISTINCT FROM t.new_dup
+SELECT count(*)::bigint FROM updated
 `
 
 type SuppressAggregatorDuplicatesForCompaniesParams struct {
@@ -3074,11 +3149,10 @@ type SuppressAggregatorDuplicatesForCompaniesParams struct {
 // DISTINCT FROM guard makes re-runs cheap and idempotent. Run AFTER
 // RecomputeRoleDuplicatesForCompanies so ATS reposts have already collapsed to their canon.
 func (q *Queries) SuppressAggregatorDuplicatesForCompanies(ctx context.Context, arg SuppressAggregatorDuplicatesForCompaniesParams) (int64, error) {
-	result, err := q.db.Exec(ctx, suppressAggregatorDuplicatesForCompanies, arg.FoldedCompanies, arg.Aggregators)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
+	row := q.db.QueryRow(ctx, suppressAggregatorDuplicatesForCompanies, arg.FoldedCompanies, arg.Aggregators)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
 }
 
 const touchJob = `-- name: TouchJob :one

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -2545,6 +2545,10 @@ type Querier interface {
 	// jobdedup.CanonicalForRole, so this is the role verdict arriving early — the same clustering
 	// the batch pass would reach hours later. A write to duplicate_of itself would not survive:
 	// the derivation in migration 0115 recomputes it from the owned columns.
+	// Both callers pass a canon, so today this branch never fires: the import path only ever SETS
+	// the role marker. It is here because the argument is nullable and the other three writers are
+	// symmetric — a future caller clearing the marker through this query would otherwise leave a
+	// now-canonical posting out of search until the next rebuild, silently.
 	MarkJobDuplicateOfRole(ctx context.Context, arg MarkJobDuplicateOfRoleParams) (int64, error)
 	// Record one expired probe: increment the strike counter and, in the same write,
 	// close the job (closed_at) once it reaches the threshold the caller owns — the

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -530,12 +530,26 @@ updated AS (
     SET duplicate_of_role = sqlc.arg(duplicate_of_role),
         updated_at        = now()
     WHERE j.id = sqlc.arg(id)
-    RETURNING j.id, j.duplicate_of AS now_duplicate_of
+    RETURNING j.id,
+              j.duplicate_of AS now_duplicate_of,
+              COALESCE(j.posted_at, j.created_at) AS eff_posted_at
+),
+flipped AS (
+    SELECT u.id, b.was_duplicate_of, u.now_duplicate_of, u.eff_posted_at
+    FROM updated u JOIN before b ON b.id = u.id
 ),
 dequeued AS (
     INSERT INTO search_delete_outbox (job_id)
-    SELECT u.id FROM updated u JOIN before b ON b.id = u.id
-    WHERE b.was_duplicate_of IS NULL AND u.now_duplicate_of IS NOT NULL
+    SELECT id FROM flipped WHERE was_duplicate_of IS NULL AND now_duplicate_of IS NOT NULL
+    ON CONFLICT (job_id) DO NOTHING
+),
+-- Both callers pass a canon, so today this branch never fires: the import path only ever SETS
+-- the role marker. It is here because the argument is nullable and the other three writers are
+-- symmetric — a future caller clearing the marker through this query would otherwise leave a
+-- now-canonical posting out of search until the next rebuild, silently.
+requeued AS (
+    INSERT INTO search_outbox (job_id, job_posted_at)
+    SELECT id, eff_posted_at FROM flipped WHERE was_duplicate_of IS NOT NULL AND now_duplicate_of IS NULL
     ON CONFLICT (job_id) DO NOTHING
 )
 SELECT count(*)::bigint FROM updated;

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -512,7 +512,7 @@ WHERE company_slug = sqlc.arg(company_slug)
 ORDER BY id
 LIMIT 1;
 
--- name: MarkJobDuplicateOfRole :execrows
+-- name: MarkJobDuplicateOfRole :one
 -- Point one row at its ROLE canon. The import path only: the batch passes recompute whole
 -- companies (RecomputeRoleDuplicatesForCompanies, SuppressAggregatorDuplicatesForCompanies) and
 -- must keep doing so — this marks the single row an import just wrote.
@@ -522,10 +522,23 @@ LIMIT 1;
 -- jobdedup.CanonicalForRole, so this is the role verdict arriving early — the same clustering
 -- the batch pass would reach hours later. A write to duplicate_of itself would not survive:
 -- the derivation in migration 0115 recomputes it from the owned columns.
-UPDATE jobs
-SET duplicate_of_role = sqlc.arg(duplicate_of_role),
-    updated_at        = now()
-WHERE id = sqlc.arg(id);
+WITH before AS (
+    SELECT b.id, b.duplicate_of AS was_duplicate_of FROM jobs b WHERE b.id = sqlc.arg(id)
+),
+updated AS (
+    UPDATE jobs j
+    SET duplicate_of_role = sqlc.arg(duplicate_of_role),
+        updated_at        = now()
+    WHERE j.id = sqlc.arg(id)
+    RETURNING j.id, j.duplicate_of AS now_duplicate_of
+),
+dequeued AS (
+    INSERT INTO search_delete_outbox (job_id)
+    SELECT u.id FROM updated u JOIN before b ON b.id = u.id
+    WHERE b.was_duplicate_of IS NULL AND u.now_duplicate_of IS NOT NULL
+    ON CONFLICT (job_id) DO NOTHING
+)
+SELECT count(*)::bigint FROM updated;
 
 -- name: ListRoleClusterCopies :many
 -- The open postings sharing a role cluster (company_slug + role_fingerprint) with the
@@ -609,7 +622,7 @@ UNION
 SELECT DISTINCT company_slug FROM jobs
 WHERE closed_at IS NULL AND company_slug <> '' AND duplicate_of IS NOT NULL;
 
--- name: RecomputeRoleDuplicatesForCompanies :execrows
+-- name: RecomputeRoleDuplicatesForCompanies :one
 -- The batched slice of the role-duplicate recompute, driven over a CHUNK of companies
 -- (cmd/reindex's forCompanyBatches) rather than one call per company — see that
 -- function's doc comment for why: at catalogue scale (2026-08-06 prod measurement:
@@ -635,17 +648,35 @@ WITH canon AS (
 ),
 target AS (
     SELECT j.id,
-        CASE WHEN c.n > 1 AND j.id <> c.canon_id THEN c.canon_id END AS new_dup
+        CASE WHEN c.n > 1 AND j.id <> c.canon_id THEN c.canon_id END AS new_dup,
+        j.duplicate_of AS was_duplicate_of
     FROM jobs j
     JOIN canon c ON j.role_fingerprint = c.role_fingerprint
     WHERE j.company_slug = ANY(sqlc.arg(companies)::text[]) AND j.closed_at IS NULL
+),
+updated AS (
+    UPDATE jobs j
+    SET duplicate_of_role = t.new_dup,
+        updated_at        = now()
+    FROM target t
+    WHERE j.id = t.id
+      AND j.duplicate_of_role IS DISTINCT FROM t.new_dup
+    RETURNING j.id,
+              t.was_duplicate_of,
+              j.duplicate_of AS now_duplicate_of,
+              COALESCE(j.posted_at, j.created_at) AS eff_posted_at
+),
+dequeued AS (
+    INSERT INTO search_delete_outbox (job_id)
+    SELECT id FROM updated WHERE was_duplicate_of IS NULL AND now_duplicate_of IS NOT NULL
+    ON CONFLICT (job_id) DO NOTHING
+),
+requeued AS (
+    INSERT INTO search_outbox (job_id, job_posted_at)
+    SELECT id, eff_posted_at FROM updated WHERE was_duplicate_of IS NOT NULL AND now_duplicate_of IS NULL
+    ON CONFLICT (job_id) DO NOTHING
 )
-UPDATE jobs j
-SET duplicate_of_role = t.new_dup,
-    updated_at        = now()
-FROM target t
-WHERE j.id = t.id
-  AND j.duplicate_of_role IS DISTINCT FROM t.new_dup;
+SELECT count(*)::bigint FROM updated;
 
 -- name: CompaniesWithAggregatorPostings :many
 -- Company slugs with at least one OPEN aggregator posting — the drive list for the
@@ -657,7 +688,7 @@ SELECT DISTINCT company_slug FROM jobs
 WHERE closed_at IS NULL AND company_slug <> ''
   AND source = ANY(sqlc.arg(aggregators)::text[]);
 
--- name: SuppressAggregatorDuplicatesForCompanies :execrows
+-- name: SuppressAggregatorDuplicatesForCompanies :one
 -- The batched slice of the cross-source aggregator suppression, driven over a CHUNK of
 -- companies (cmd/reindex's forCompanyBatches) rather than one call per company — see
 -- RecomputeRoleDuplicatesForCompanies' doc comment for the prod measurement that
@@ -799,17 +830,36 @@ target AS (
     -- Every candidate aggregator row, with its MIN matching ATS id or NULL. LEFT JOIN so an
     -- unmatched row (including one whose ATS twin just closed) resolves to NULL and is
     -- released back into search/embedding/enrichment. min(id) picks a stable target.
-    SELECT a.id, MIN(m.ats_id) AS new_dup
+    SELECT a.id, MIN(m.ats_id) AS new_dup,
+           MIN(j.duplicate_of) AS was_duplicate_of
     FROM agg a
     LEFT JOIN matches m ON m.agg_id = a.id
+    JOIN jobs j ON j.id = a.id
     GROUP BY a.id
+),
+updated AS (
+    UPDATE jobs j
+    SET duplicate_of_aggregator = t.new_dup,
+        updated_at              = now()
+    FROM target t
+    WHERE j.id = t.id
+      AND j.duplicate_of_aggregator IS DISTINCT FROM t.new_dup
+    RETURNING j.id,
+              t.was_duplicate_of,
+              j.duplicate_of AS now_duplicate_of,
+              COALESCE(j.posted_at, j.created_at) AS eff_posted_at
+),
+dequeued AS (
+    INSERT INTO search_delete_outbox (job_id)
+    SELECT id FROM updated WHERE was_duplicate_of IS NULL AND now_duplicate_of IS NOT NULL
+    ON CONFLICT (job_id) DO NOTHING
+),
+requeued AS (
+    INSERT INTO search_outbox (job_id, job_posted_at)
+    SELECT id, eff_posted_at FROM updated WHERE was_duplicate_of IS NOT NULL AND now_duplicate_of IS NULL
+    ON CONFLICT (job_id) DO NOTHING
 )
-UPDATE jobs j
-SET duplicate_of_aggregator = t.new_dup,
-    updated_at              = now()
-FROM target t
-WHERE j.id = t.id
-  AND j.duplicate_of_aggregator IS DISTINCT FROM t.new_dup;
+SELECT count(*)::bigint FROM updated;
 
 -- name: PropagateCollectionsToJobs :execrows
 -- Denormalize each company's curated-collection set onto its jobs, so the search
@@ -1554,23 +1604,51 @@ FROM jobs
 WHERE company_slug = sqlc.arg(company) AND closed_at IS NULL AND duplicate_of IS NULL
 ORDER BY id;
 
--- name: MarkFuzzyDuplicatesForCompany :execrows
+-- name: MarkFuzzyDuplicatesForCompany :one
 -- Point each fuzzy-clustered posting at its canon. Takes two parallel arrays (ids, canons) so
 -- one company's whole assignment lands in a single statement rather than a round trip per row.
 -- Scoped to the company and to still-canonical open rows, so a row the exact pass claimed in the
 -- meantime is left alone. The IS DISTINCT FROM guard makes a re-run free, and the standard
 -- recompute reverses everything here by recomputing duplicate_of from scratch.
-UPDATE jobs j
-SET duplicate_of_fuzzy = m.canon_id,
-    updated_at         = now()
-FROM (
+WITH assign AS (
     SELECT unnest(sqlc.arg(ids)::bigint[]) AS id,
            unnest(sqlc.arg(canons)::bigint[]) AS canon_id
-) m
-WHERE j.id = m.id
-  AND j.company_slug = sqlc.arg(company)
-  AND j.closed_at IS NULL
-  AND j.duplicate_of_fuzzy IS DISTINCT FROM m.canon_id;
+),
+before AS (
+    -- Every CTE of one statement reads the same snapshot, so this is the derived marker as it
+    -- stood BEFORE the update below — which is what makes the status transition readable
+    -- without a second statement and the race between them.
+    SELECT j.id, j.duplicate_of AS was_duplicate_of
+    FROM jobs j JOIN assign a ON a.id = j.id
+),
+updated AS (
+    UPDATE jobs j
+    SET duplicate_of_fuzzy = m.canon_id,
+        updated_at         = now()
+    FROM assign m
+    WHERE j.id = m.id
+      AND j.company_slug = sqlc.arg(company)
+      AND j.closed_at IS NULL
+      AND j.duplicate_of_fuzzy IS DISTINCT FROM m.canon_id
+    RETURNING j.id,
+              j.duplicate_of AS now_duplicate_of,
+              COALESCE(j.posted_at, j.created_at) AS eff_posted_at
+),
+flipped AS (
+    SELECT u.id, b.was_duplicate_of, u.now_duplicate_of, u.eff_posted_at
+    FROM updated u JOIN before b ON b.id = u.id
+),
+dequeued AS (
+    INSERT INTO search_delete_outbox (job_id)
+    SELECT id FROM flipped WHERE was_duplicate_of IS NULL AND now_duplicate_of IS NOT NULL
+    ON CONFLICT (job_id) DO NOTHING
+),
+requeued AS (
+    INSERT INTO search_outbox (job_id, job_posted_at)
+    SELECT id, eff_posted_at FROM flipped WHERE was_duplicate_of IS NOT NULL AND now_duplicate_of IS NULL
+    ON CONFLICT (job_id) DO NOTHING
+)
+SELECT count(*)::bigint FROM flipped;
 
 -- name: OrphanAggregatorCompanies :many
 -- Companies the catalogue holds ONLY through aggregators — the worklist cmd/harvest-orphans

--- a/openspec/changes/duplicate-marker-outbox/.openspec.yaml
+++ b/openspec/changes/duplicate-marker-outbox/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/duplicate-marker-outbox/design.md
+++ b/openspec/changes/duplicate-marker-outbox/design.md
@@ -1,0 +1,127 @@
+## Context
+
+Three passes write duplicate markers, each into its own column since
+`duplicate-marker-ownership`; `jobs.duplicate_of` is derived from them by a BEFORE trigger
+(migration 0115) and is what every reader consumes. `ClaimSearchOutboxBatch` requires a job to
+be open AND canonical, so a posting that becomes a duplicate is simply never re-indexed — its
+existing document persists until a rebuild swaps the whole index.
+`ClaimSearchDeleteOutboxBatch` needs only a primary key and is already drained beside it.
+
+So the mechanism to remove a document incrementally exists and works; nothing produces the
+removals for duplicates. Producing them is the whole change.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A posting that becomes a duplicate leaves search in minutes, not up to six hours.
+- A posting that becomes canonical returns just as fast.
+- The decision is made in the same statement that writes the marker, so an interrupted run
+  cannot leave a status change unqueued.
+- No new queue, no new worker, no schema change.
+
+**Non-Goals:**
+
+- Changing the rebuild's schedule. That is a separate decision that this change makes
+  *possible* to consider, and deliberately does not take.
+- Backfilling the duplicates already in the index. They have no transition to observe and the
+  rebuild still collapses them.
+- Touching the drain, the claim predicates, or the queue tables.
+
+## Decisions
+
+### Decision 1: Read the transition with Postgres 18's `RETURNING old./new.`
+
+Each pass's UPDATE returns `old.duplicate_of` and `new.duplicate_of`, and two CTEs over that
+result insert into the two queues.
+
+*Alternative — read the current markers, then write:* two statements with a window between
+them in which another pass can change the same row, so the recorded "before" may not be the
+value the write actually replaced. The failure is silent and directional: a missed removal
+leaves a duplicate in search.
+
+*Alternative — a trigger that enqueues:* moves the logic away from the statement that owns it
+and fires on every marker write including the backfill's, which would have queued two million
+rows. Rejected.
+
+Postgres 18 makes the first option available at all; prod is 18.4. Verified on
+`pgvector/pgvector:pg18`, including the part that matters most — `new.duplicate_of` reflects
+the BEFORE trigger's `COALESCE`, not the value the statement assigned to an owned column.
+
+### Decision 2: Branch on the DERIVED marker, never on the owning column
+
+`old.duplicate_of IS NULL AND new.duplicate_of IS NOT NULL` → queue a removal.
+`old.duplicate_of IS NOT NULL AND new.duplicate_of IS NULL` → queue an index.
+Both non-NULL, or both NULL → queue nothing.
+
+Branching on the pass's own column would be wrong in exactly the case ownership created: the
+aggregator pass releasing a suppression on a posting the role pass still marks. Its own column
+goes non-NULL → NULL, which reads as "became canonical", while the derived value never moved.
+The posting would be queued back into search while still a duplicate. The derived value is the
+only one that answers the question the index asks.
+
+### Decision 3: Both-non-NULL queues nothing, deliberately
+
+A duplicate re-pointed at a different canon is still a duplicate, and its document is already
+absent from the index. Queueing a removal would be a Meilisearch no-op — harmless, and pure
+cost at ~200 documents per push. Silence here is what keeps the volume proportional to status
+changes rather than to marker writes.
+
+### Decision 4: `search_outbox` needs `job_posted_at`; take it from the returned row
+
+`EnqueueSearchOutbox` denormalizes `COALESCE(posted_at, created_at)` so the claim can order
+without joining. The passes' UPDATEs already have the row, so the CTE returns
+`COALESCE(posted_at, created_at)` alongside the two markers rather than re-reading `jobs`.
+
+### Decision 5: `:execrows` becomes `:one`
+
+A CTE takes the affected-row count out of the command tag, so each pass's query ends in
+`SELECT count(*) FROM updated` and its sqlc annotation changes from `:execrows` to `:one`.
+Exactly what PR #2133 did to the five closing statements; callers keep taking `int64` and do
+not change.
+
+### Decision 6: No backfill
+
+A posting already marked and already indexed has no transition. Backfilling would mean
+enqueuing every current duplicate — on the order of a million rows — to remove documents the
+next rebuild removes anyway, at a cost measured in hours of drain. The rebuild stays on its
+schedule (that is Goal-adjacent, not a Non-Goal by accident), so the stock is handled and only
+the flow needs this change.
+
+## Risks / Trade-offs
+
+- **A missed removal leaves a duplicate visible** → The transition is computed in the same
+  statement as the write, so there is no window to miss one. The test that matters is the
+  one-releases-while-another-holds case, which is where a plausible-looking implementation
+  goes wrong.
+- **Queue volume grows with dedup churn** → Bounded by status changes, not marker writes:
+  ~13,385 rows a cycle across all three passes today, and only the flips among those queue.
+  If a future change makes markers churn again, this queue is where it will show — which is
+  better than the churn being invisible, as it was until 2026-08-19.
+- **`RETURNING old./new.` ties the schema layer to Postgres 18** → Prod is 18.4 and the test
+  container is `pgvector/pgvector:pg18`. The alternative costs a race; the version floor is
+  already established by the running database, not raised by this change.
+- **A queued removal for a job that is also closing** → Both paths queue the same job on
+  `search_delete_outbox`; the queue's `ON CONFLICT` keeps one entry, and deleting an absent
+  document is a Meilisearch no-op. No interaction to manage.
+
+## Migration Plan
+
+None. No schema change, no backfill, no worker. The change is live for every status change
+after deploy, and the rebuild covers everything before it — so there is no window where the
+index is worse off than it is today, and no ordering constraint between migration and code.
+
+**Rollback** is a code revert: the queues return to being fed by ingest and the closing
+statements alone, and duplicates go back to waiting for the rebuild.
+
+**Acceptance:** after deploy, a posting marked duplicate by a refresh should disappear from
+`/api/v1/jobs/search` within a drain cycle rather than at the next rebuild. The drain's own
+log line reports how many removals it took, so the count appearing at all is the first signal
+the producer is wired.
+
+## Open Questions
+
+- Does the drain's removal batch size want tuning once duplicates share the queue with
+  closures? Closures alone measured ~19,827 a day; this adds status flips on top. The batch
+  is 200 and a removal push measured ~7.7s, so a cycle's worth is minutes — but the number is
+  worth a look after a week rather than guessed at now.

--- a/openspec/changes/duplicate-marker-outbox/design.md
+++ b/openspec/changes/duplicate-marker-outbox/design.md
@@ -30,23 +30,33 @@ removals for duplicates. Producing them is the whole change.
 
 ## Decisions
 
-### Decision 1: Read the transition with Postgres 18's `RETURNING old./new.`
+### Decision 1: Read the transition from one statement's own snapshot
 
-Each pass's UPDATE returns `old.duplicate_of` and `new.duplicate_of`, and two CTEs over that
-result insert into the two queues.
+Every CTE of a single statement reads the same snapshot, so a CTE that selects `duplicate_of`
+alongside the pass's own work holds the value as it stood BEFORE the update, while the
+UPDATE's `RETURNING` holds it after. Both in one statement, no window between them.
 
-*Alternative — read the current markers, then write:* two statements with a window between
-them in which another pass can change the same row, so the recorded "before" may not be the
-value the write actually replaced. The failure is silent and directional: a missed removal
-leaves a duplicate in search.
+The role and aggregator passes already read `jobs` in their `target` CTE to compute the new
+marker, so the old value comes free — one more column. The fuzzy pass and
+`MarkJobDuplicateOfRole` drive off an argument rather than a scan, so they gain a small
+`before` CTE that reads only the rows they are about to touch.
+
+*This started as `RETURNING old.duplicate_of, new.duplicate_of`* — Postgres 18 syntax, and
+prod is 18.4. It was verified working against `pgvector/pgvector:pg18`, including the part
+that mattered: `new.` reflects the BEFORE trigger's `COALESCE` rather than the value assigned
+to an owned column. Then sqlc 1.31.1 rejected it — its analyzer predates PG18 — and the
+snapshot form turned out to be both portable and no more code. The verification was not
+wasted: it established that the transition is readable atomically at all, which is the
+property the design needs; the syntax was only the first way found to get it.
+
+*Alternative — read the current markers in one statement, then write in another:* a window in
+which another pass can change the same row, so the recorded "before" may not be the value the
+write replaced. The failure is silent and directional: a missed removal leaves a duplicate in
+search.
 
 *Alternative — a trigger that enqueues:* moves the logic away from the statement that owns it
 and fires on every marker write including the backfill's, which would have queued two million
 rows. Rejected.
-
-Postgres 18 makes the first option available at all; prod is 18.4. Verified on
-`pgvector/pgvector:pg18`, including the part that matters most — `new.duplicate_of` reflects
-the BEFORE trigger's `COALESCE`, not the value the statement assigned to an owned column.
 
 ### Decision 2: Branch on the DERIVED marker, never on the owning column
 

--- a/openspec/changes/duplicate-marker-outbox/proposal.md
+++ b/openspec/changes/duplicate-marker-outbox/proposal.md
@@ -1,0 +1,70 @@
+## Why
+
+A posting stops being a duplicate — or becomes one — the moment a dedup pass writes its
+marker. It leaves or re-enters the facet index only at the next full rebuild, up to six hours
+later. For those six hours search shows a repost as its own vacancy, or hides a posting that
+is canonical again.
+
+Every other change already travels incrementally. New and edited postings go through
+`search_outbox`; closed ones through `search_delete_outbox`, shipped 2026-08-18. Duplicate
+markers are the last thing the rebuild is the only path for.
+
+They were left out for a reason that no longer holds. Until 2026-08-19 a marker refresh
+changed ~950,000 rows per cycle, six cycles a day, because the three passes overwrote each
+other's verdicts. At the drain's measured 200 documents per ~7.7s that is over ten hours of
+queue per cycle — the queue would have grown faster than it drained. Ownership
+(`duplicate-marker-ownership`) took a cycle to **13,385** changed rows, about 67 batches, a
+few minutes. The blocker is gone.
+
+## What Changes
+
+- Each of the three marker passes enqueues the rows whose duplicate status actually flipped,
+  in the same statement that flips it:
+  - canonical → duplicate: the document must go, so the row is queued on
+    `search_delete_outbox`.
+  - duplicate → canonical: the document must come back, so the row is queued on
+    `search_outbox`.
+  - a duplicate that merely changes which canon it points at: nothing. Its document is
+    already absent, and re-queueing it would be work with no effect.
+- The transition is read from the DERIVED `jobs.duplicate_of`, not from the pass's own
+  column. A pass clearing its own marker does not make the row canonical if another pass
+  still holds one — reading its own column would put a still-duplicate posting back into
+  search.
+- `MarkJobDuplicateOfRole`, the ingest-time role verdict, gets the same treatment for the
+  same reason.
+- **Nothing is backfilled.** Duplicates already sitting in the index have no transition to
+  detect; the scheduled rebuild continues to collapse them, exactly as today. This change
+  bounds how long a NEW duplicate lingers, and deliberately does not try to be the rebuild.
+
+## Capabilities
+
+### New Capabilities
+
+- `duplicate-marker-indexing`: how a change in duplicate status reaches the facet index —
+  which transition queues which way, which value the decision reads, and what is deliberately
+  left to the rebuild.
+
+### Modified Capabilities
+
+None. The queues' own contracts (`ClaimSearchOutboxBatch` requires open and canonical;
+`ClaimSearchDeleteOutboxBatch` needs only a primary key) are unchanged — this change only
+gives them a new producer.
+
+## Impact
+
+- **Queries:** `internal/db/queries/jobs.sql` — `RecomputeRoleDuplicatesForCompanies`,
+  `SuppressAggregatorDuplicatesForCompanies`, `MarkFuzzyDuplicatesForCompany`,
+  `MarkJobDuplicateOfRole`. Each gains a CTE over `RETURNING` in the shape the closing
+  statements already use for `search_delete_outbox`.
+- **Postgres 18 is required** and prod is on 18.4. `RETURNING old.duplicate_of,
+  new.duplicate_of` is an 18 feature, and it is what makes the transition readable atomically
+  instead of through a read-then-write with a race in the middle. Verified against
+  `pgvector/pgvector:pg18`, including that `new` reflects the BEFORE trigger's derivation
+  rather than the value the statement assigned.
+- **Return types:** the three batch passes are `:execrows`; a CTE moves the row count out of
+  the command tag, so they become `:one` ending in `SELECT count(*)`, as PR #2133 did for the
+  five closing statements. Callers keep taking `int64`.
+- **Not affected:** the drain, the queue schemas, the claim predicates, the rebuild, and
+  every reader of `duplicate_of`.
+- **Volume:** ~13,385 rows a cycle across all three passes today, of which only the flips
+  queue — the rest change canon without changing status.

--- a/openspec/changes/duplicate-marker-outbox/proposal.md
+++ b/openspec/changes/duplicate-marker-outbox/proposal.md
@@ -56,11 +56,11 @@ gives them a new producer.
   `SuppressAggregatorDuplicatesForCompanies`, `MarkFuzzyDuplicatesForCompany`,
   `MarkJobDuplicateOfRole`. Each gains a CTE over `RETURNING` in the shape the closing
   statements already use for `search_delete_outbox`.
-- **Postgres 18 is required** and prod is on 18.4. `RETURNING old.duplicate_of,
-  new.duplicate_of` is an 18 feature, and it is what makes the transition readable atomically
-  instead of through a read-then-write with a race in the middle. Verified against
-  `pgvector/pgvector:pg18`, including that `new` reflects the BEFORE trigger's derivation
-  rather than the value the statement assigned.
+- **No version floor and no new dependency.** The transition is read from the statement's own
+  snapshot: a CTE selecting `duplicate_of` holds the value before the update, `RETURNING`
+  holds it after, and every CTE of one statement sees the same snapshot. This began as
+  Postgres 18's `RETURNING old./new.` — verified working, prod is 18.4 — until sqlc 1.31.1
+  rejected the syntax; the snapshot form is portable and no larger.
 - **Return types:** the three batch passes are `:execrows`; a CTE moves the row count out of
   the command tag, so they become `:one` ending in `SELECT count(*)`, as PR #2133 did for the
   five closing statements. Callers keep taking `int64`.

--- a/openspec/changes/duplicate-marker-outbox/specs/duplicate-marker-indexing/spec.md
+++ b/openspec/changes/duplicate-marker-outbox/specs/duplicate-marker-indexing/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: A change in duplicate status reaches the index without a rebuild
+
+The system SHALL queue a posting for the facet index the moment its duplicate status changes,
+rather than waiting for the next full rebuild. A posting that becomes a non-canonical
+duplicate SHALL be queued for removal; a posting that becomes canonical again SHALL be queued
+for indexing. Queueing SHALL happen in the same statement that writes the marker, so a run
+that fails partway cannot leave a status change unqueued.
+
+#### Scenario: A posting that becomes a duplicate leaves search
+
+- **WHEN** a dedup pass marks an open, canonical posting as a duplicate
+- **THEN** that posting is queued for removal from the facet index, and the drain removes its
+  document on its next run rather than the next rebuild
+
+#### Scenario: A posting that becomes canonical returns to search
+
+- **WHEN** a dedup pass clears the last marker on a posting — for example its canon closed
+  and it is now the canon itself
+- **THEN** that posting is queued for indexing, and the drain restores its document
+
+#### Scenario: Re-pointing a duplicate queues nothing
+
+- **WHEN** a pass changes which canon a posting points at, and the posting is a duplicate both
+  before and after
+- **THEN** nothing is queued: the document is already absent from the index, so removing it
+  again is work with no effect
+
+#### Scenario: An unchanged pass run queues nothing
+
+- **WHEN** a marker refresh runs over a catalogue whose duplicate statuses have not changed
+- **THEN** no rows are queued on either queue
+
+### Requirement: The queueing decision reads the derived marker
+
+The queueing decision SHALL be made from the derived `jobs.duplicate_of` before and after the
+write, not from the owning column the pass itself writes. A pass clearing its own column does
+not make a posting canonical while another pass still holds a marker on it, and treating that
+as a return to canonical would put a posting that is still a duplicate back into search.
+
+#### Scenario: One pass releases while another still holds
+
+- **WHEN** the aggregator pass releases a posting it had suppressed, but the role pass still
+  marks that posting as a repost
+- **THEN** the posting is NOT queued for indexing, because it is still a duplicate
+
+#### Scenario: The last marker released returns the posting
+
+- **WHEN** the aggregator pass releases a posting and no other pass holds a marker on it
+- **THEN** the posting is queued for indexing
+
+### Requirement: Duplicates already in the index remain the rebuild's job
+
+This change SHALL NOT backfill postings whose duplicate status predates it. A posting already
+marked and already indexed has no transition to observe, and the scheduled full rebuild
+continues to collapse it exactly as before.
+
+#### Scenario: A pre-existing duplicate is not queued
+
+- **WHEN** a marker refresh runs over a posting that was already a duplicate before this
+  change shipped, and its status does not change
+- **THEN** nothing is queued for it, and its document is removed by the next scheduled
+  rebuild as it would have been anyway

--- a/openspec/changes/duplicate-marker-outbox/tasks.md
+++ b/openspec/changes/duplicate-marker-outbox/tasks.md
@@ -1,0 +1,45 @@
+## 1. Prove the transition is readable before building on it
+
+- [x] 1.1 Verify `RETURNING old.col, new.col` works on the Postgres the tests and prod run,
+      and that `new.` reflects a BEFORE trigger's rewrite rather than the assigned value.
+      **Done before writing the design** — checked against `pgvector/pgvector:pg18`: a row
+      whose owned column was cleared returned `was=7, now=NULL`, a row whose owned column was
+      set returned `was=NULL, now=5`. Prod is 18.4.
+
+## 2. The three batch passes
+
+- [ ] 2.1 `RecomputeRoleDuplicatesForCompanies`: return `old.duplicate_of`,
+      `new.duplicate_of` and `COALESCE(posted_at, created_at)`, then two CTEs — removals into
+      `search_delete_outbox`, re-indexes into `search_outbox`. `:execrows` → `:one` ending in
+      `SELECT count(*)`.
+- [ ] 2.2 Same for `SuppressAggregatorDuplicatesForCompanies`.
+- [ ] 2.3 Same for `MarkFuzzyDuplicatesForCompany`.
+- [ ] 2.4 `MarkJobDuplicateOfRole` (the ingest-time role verdict) — same treatment; it already
+      runs inside the ingest transaction, so the queue write lands atomically with the marker.
+- [ ] 2.5 `make sqlc`, fix the call sites the `:one` change touches.
+
+## 3. Tests
+
+- [ ] 3.1 Integration: a canonical posting marked duplicate lands on `search_delete_outbox`
+      and NOT on `search_outbox`.
+- [ ] 3.2 Integration: a duplicate whose last marker is cleared lands on `search_outbox` with
+      the right `job_posted_at`, and not on the removal queue.
+- [ ] 3.3 Integration: a duplicate re-pointed at a different canon lands on neither queue.
+- [ ] 3.4 **Integration: one pass releases while another still holds — the posting lands on
+      NEITHER queue.** This is the case Decision 2 exists for and the one an implementation
+      that reads its own column gets wrong.
+- [ ] 3.5 Integration: a refresh over an unchanged catalogue queues nothing on either queue.
+- [ ] 3.6 Extend the ownership tests' fixture where it overlaps rather than duplicating it —
+      the passes' matching behaviour is already covered and must not be re-asserted here.
+
+## 4. Ship
+
+- [ ] 4.1 `gofmt -w`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`, then
+      the tagged suites for `internal/db`, `cmd/reindex`, `cmd/ingest`, `internal/linkimport`.
+- [ ] 4.2 Deploy. No migration, no backfill, no ordering constraint — the change is live for
+      every status change after it lands.
+- [ ] 4.3 Confirm on prod that the drain reports removals after the next marker refresh, and
+      that a posting marked duplicate leaves `/api/v1/jobs/search` within a drain cycle
+      instead of at the next rebuild.
+- [ ] 4.4 Note the queue depth a week later against the open question in `design.md` — whether
+      the removal batch size wants tuning now that duplicates share the queue with closures.

--- a/openspec/changes/duplicate-marker-outbox/tasks.md
+++ b/openspec/changes/duplicate-marker-outbox/tasks.md
@@ -1,40 +1,46 @@
 ## 1. Prove the transition is readable before building on it
 
-- [x] 1.1 Verify `RETURNING old.col, new.col` works on the Postgres the tests and prod run,
-      and that `new.` reflects a BEFORE trigger's rewrite rather than the assigned value.
-      **Done before writing the design** — checked against `pgvector/pgvector:pg18`: a row
-      whose owned column was cleared returned `was=7, now=NULL`, a row whose owned column was
-      set returned `was=NULL, now=5`. Prod is 18.4.
+- [x] 1.1 Verify the transition is readable atomically. **Done before writing the design**,
+      first with Postgres 18's `RETURNING old.col, new.col` against `pgvector/pgvector:pg18`:
+      a row whose owned column was cleared returned `was=7, now=NULL`, one whose column was
+      set returned `was=NULL, now=5`, and `new.` reflected the BEFORE trigger rather than the
+      assigned value. **sqlc 1.31.1 then rejected that syntax** — its analyzer predates PG18 —
+      so the implementation reads the old value from the statement's own snapshot instead
+      (Decision 1). Portable, no larger, and the verification still earned its keep: it
+      established the property before anything was built on it.
 
 ## 2. The three batch passes
 
-- [ ] 2.1 `RecomputeRoleDuplicatesForCompanies`: return `old.duplicate_of`,
-      `new.duplicate_of` and `COALESCE(posted_at, created_at)`, then two CTEs — removals into
-      `search_delete_outbox`, re-indexes into `search_outbox`. `:execrows` → `:one` ending in
-      `SELECT count(*)`.
-- [ ] 2.2 Same for `SuppressAggregatorDuplicatesForCompanies`.
-- [ ] 2.3 Same for `MarkFuzzyDuplicatesForCompany`.
-- [ ] 2.4 `MarkJobDuplicateOfRole` (the ingest-time role verdict) — same treatment; it already
+- [x] 2.1 `RecomputeRoleDuplicatesForCompanies`: carry the pre-update `duplicate_of` through
+      the existing `target` CTE, return it with the post-update value and
+      `COALESCE(posted_at, created_at)`, then two CTEs — removals into `search_delete_outbox`,
+      re-indexes into `search_outbox`. `:execrows` → `:one` ending in `SELECT count(*)`.
+- [x] 2.2 Same for `SuppressAggregatorDuplicatesForCompanies` — its `target` CTE gains a join
+      back to `jobs` for the pre-update value, since it aggregates over match candidates.
+- [x] 2.3 `MarkFuzzyDuplicatesForCompany` drives off an `unnest` rather than a scan, so it
+      gains a small `before` CTE reading only the rows it is about to touch.
+- [x] 2.4 `MarkJobDuplicateOfRole` (the ingest-time role verdict) — same treatment; it already
       runs inside the ingest transaction, so the queue write lands atomically with the marker.
-- [ ] 2.5 `make sqlc`, fix the call sites the `:one` change touches.
+- [x] 2.5 `make sqlc`, fix the call sites the `:one` change touches. None needed changing —
+      the callers already took `int64`.
 
 ## 3. Tests
 
-- [ ] 3.1 Integration: a canonical posting marked duplicate lands on `search_delete_outbox`
+- [x] 3.1 Integration: a canonical posting marked duplicate lands on `search_delete_outbox`
       and NOT on `search_outbox`.
-- [ ] 3.2 Integration: a duplicate whose last marker is cleared lands on `search_outbox` with
+- [x] 3.2 Integration: a duplicate whose last marker is cleared lands on `search_outbox` with
       the right `job_posted_at`, and not on the removal queue.
-- [ ] 3.3 Integration: a duplicate re-pointed at a different canon lands on neither queue.
-- [ ] 3.4 **Integration: one pass releases while another still holds — the posting lands on
+- [x] 3.3 Integration: a duplicate re-pointed at a different canon lands on neither queue.
+- [x] 3.4 **Integration: one pass releases while another still holds — the posting lands on
       NEITHER queue.** This is the case Decision 2 exists for and the one an implementation
       that reads its own column gets wrong.
-- [ ] 3.5 Integration: a refresh over an unchanged catalogue queues nothing on either queue.
-- [ ] 3.6 Extend the ownership tests' fixture where it overlaps rather than duplicating it —
+- [x] 3.5 Integration: a refresh over an unchanged catalogue queues nothing on either queue.
+- [x] 3.6 Extend the ownership tests' fixture where it overlaps rather than duplicating it —
       the passes' matching behaviour is already covered and must not be re-asserted here.
 
 ## 4. Ship
 
-- [ ] 4.1 `gofmt -w`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`, then
+- [x] 4.1 `gofmt -w`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`, then
       the tagged suites for `internal/db`, `cmd/reindex`, `cmd/ingest`, `internal/linkimport`.
 - [ ] 4.2 Deploy. No migration, no backfill, no ordering constraint — the change is live for
       every status change after it lands.

--- a/openspec/changes/duplicate-marker-outbox/tasks.md
+++ b/openspec/changes/duplicate-marker-outbox/tasks.md
@@ -21,6 +21,10 @@
       gains a small `before` CTE reading only the rows it is about to touch.
 - [x] 2.4 `MarkJobDuplicateOfRole` (the ingest-time role verdict) — same treatment; it already
       runs inside the ingest transaction, so the queue write lands atomically with the marker.
+      Carries BOTH branches even though its two callers only ever set a canon and the clearing
+      branch is therefore unreachable today: the argument is nullable, the other three writers
+      are symmetric, and a future caller clearing the marker here would otherwise leave a
+      now-canonical posting out of search until the next rebuild, silently.
 - [x] 2.5 `make sqlc`, fix the call sites the `:one` change touches. None needed changing —
       the callers already took `int64`.
 
@@ -40,8 +44,9 @@
 
 ## 4. Ship
 
-- [x] 4.1 `gofmt -w`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`, then
-      the tagged suites for `internal/db`, `cmd/reindex`, `cmd/ingest`, `internal/linkimport`.
+- [x] 4.1 `gofmt -l .` clean, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`,
+      then the tagged suites for `internal/db`, `cmd/reindex`, `cmd/ingest` and
+      `internal/linkimport` — all pass.
 - [ ] 4.2 Deploy. No migration, no backfill, no ordering constraint — the change is live for
       every status change after it lands.
 - [ ] 4.3 Confirm on prod that the drain reports removals after the next marker refresh, and


### PR DESCRIPTION
Closes the last gap where a full rebuild was the only path to the facet index.

## What it does

A posting that becomes a duplicate is queued for removal; one that becomes canonical again is queued for indexing. Both in the same statement that writes the marker, so an interrupted run cannot leave a status change unqueued.

Until now a repost stayed searchable as its own vacancy until the next rebuild — up to six hours.

| Transition | Queue |
|---|---|
| canonical → duplicate | `search_delete_outbox` |
| duplicate → canonical | `search_outbox` |
| duplicate → duplicate (new canon) | neither |

## Why now

This was blocked, not forgotten. Until #2140 a marker refresh changed ~950,000 rows a cycle, six cycles a day, because the three passes overwrote each other's verdicts. At the drain's measured 200 documents per ~7.7s that is over ten hours of queue per cycle — it would have grown faster than it drained. Ownership took a cycle to **13,385** changed rows, of which only the status flips queue.

## The case that matters

The decision branches on the **derived** `duplicate_of`, never on the pass's own column.

The aggregator pass releasing a suppression on a posting the role pass still marks sees its own column go non-NULL → NULL. That reads exactly like "became canonical" — while the posting is still a duplicate. Queueing it would put a repost back into search.

`TestMarkerOutbox_OnePassReleasesWhileAnotherHolds` is that case. An implementation that reads its own column passes every other test in the file.

Building its fixture was itself instructive: the aggregator pass skips a row the role pass pointed at another *aggregator*, so a row carries both markers only when its role canon is a non-aggregator — and a different one from the ATS twin, or closing the twin releases both at once.

## Implementation note

This started as Postgres 18's `RETURNING old.duplicate_of, new.duplicate_of`, verified working against `pgvector/pgvector:pg18` (prod is 18.4), including that `new.` reflects the BEFORE trigger's `COALESCE` rather than the assigned value. **sqlc 1.31.1 rejects that syntax** — its analyzer predates PG18.

The shipped form reads the old value from the statement's own snapshot instead: every CTE of one statement sees the same snapshot, so a CTE selecting `duplicate_of` holds the before-value while `RETURNING` holds the after. Portable, no larger, no version floor. The verification still earned its keep — it established the transition is readable atomically before anything was built on it.

## Scope

No migration, no backfill, no worker, no schema change. Duplicates already in the index have no transition to observe; the rebuild stays on its schedule and collapses them exactly as today. So there is no window where the index is worse off than it is now, and no ordering constraint on deploy.

Relaxing the rebuild cadence is deliberately **not** part of this — it becomes possible to consider, which is a separate decision with its own evidence to gather.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search index updates now occur automatically when a job’s duplicate status changes.
  * Jobs becoming duplicates are removed from search results.
  * Jobs released from duplicate status are re-indexed with their posting date.

* **Bug Fixes**
  * Unchanged duplicate markers and duplicate-to-duplicate reassignment no longer trigger unnecessary search activity.
  * Canonical jobs correctly regain search eligibility when duplicate status is cleared.

* **Tests**
  * Added coverage for duplicate transitions, reassignment, suppression, and idempotent refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->