### PR TITLE
Mark a posting's own language on the subtree that holds it

### DIFF
--- a/web/src/lib/components/JobDescription.svelte
+++ b/web/src/lib/components/JobDescription.svelte
@@ -2,13 +2,17 @@
   // A job's server-sanitized description HTML with consistent typographic styles. Reused by the
   // job page (JobView), the tracker/drawer, and the tailor artifact panel — one home for the CSS
   // so the description reads the same everywhere.
-  let { html }: { html: string } = $props();
+  //
+  // `lang` marks the body as a foreign-language subtree of an English page (see
+  // foreignContentLang in $lib/seo). Optional: callers that don't know the posting's
+  // language omit it and the body simply inherits the document's.
+  let { html, lang }: { html: string; lang?: string } = $props();
 </script>
 
 {#if html}
   <!-- Description is server-sanitized HTML (see internal/sources), safe to render. -->
   <!-- eslint-disable-next-line svelte/no-at-html-tags -- server-sanitized; the rule flags every {@html} regardless -->
-  <div class="job-description text-sm leading-relaxed">{@html html}</div>
+  <div class="job-description text-sm leading-relaxed" {lang}>{@html html}</div>
 {/if}
 
 <style>

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -11,7 +11,7 @@
   import { cardTags, cardTagsFromCard, formatSalary } from '$lib/enrichment';
   import { computeClientMatch, matchTeaser, resolveMatchState } from '$lib/jobMatch';
   import { profileStore } from '$lib/profile.svelte';
-  import { metaDescription } from '$lib/seo';
+  import { foreignContentLang, metaDescription } from '$lib/seo';
   import type { Job, JobCard } from '$lib/types';
   import { Badge, EntityLogo } from '$lib/ui';
   import { supersedesReality } from '$lib/ghost';
@@ -255,8 +255,12 @@
   </div>
 
   <!-- The title is the card's hero — a size up from the body with tight leading, so
-       the eye lands on the role first. -->
+       the eye lands on the role first.
+
+       `lang` sits on the card rather than anywhere above it because one listing
+       can hold a Russian, a German and an English title in a row. -->
   <h3
+    lang={foreignContentLang(job)}
     class={[
       'font-semibold leading-snug tracking-tight',
       compact ? 'mt-2 line-clamp-1 text-base' : 'mt-2.5 line-clamp-2 text-lg sm:text-[1.35rem]',

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -8,6 +8,7 @@
   import { markViewed } from '$lib/viewedJobs.svelte';
   import { markSaved, markUnsaved } from '$lib/savedJobs.svelte';
   import { track } from '$lib/analytics';
+  import { foreignContentLang } from '$lib/seo';
   import type { Job, UserJob } from '$lib/types';
   import { companyLogoUrl } from '$lib/logo';
   import { Badge, Button, Chip, EntityLogo, TabStrip, tabStripId } from '$lib/ui';
@@ -29,6 +30,11 @@
   // the article's content is in the initial HTML. Only the per-user interactions
   // below hydrate client-side.
   let { job }: { job: Job } = $props();
+
+  // Set on the two subtrees below that carry the posting's own words; undefined
+  // (so unset) when it is English. See foreignContentLang for why the document
+  // stays `en` regardless.
+  const contentLang = $derived(foreignContentLang(job));
 
   // The signed-in user's interaction with this job (null when signed out or not
   // yet loaded). `showApplyPrompt` is the post-click "Did you apply?" question.
@@ -244,7 +250,10 @@
     </section>
   {/if}
 
-  <JobDescription html={job.description} />
+  <!-- The Summary above is an LLM synopsis the enrichment prompt pins to English
+       (internal/enrich), so the body is the only part of this snippet that takes
+       the posting's language. -->
+  <JobDescription html={job.description} lang={contentLang} />
 {/snippet}
 
 <!-- Wide layout mirroring /jobs. The company line spans the very top; below it a
@@ -294,7 +303,7 @@
   <header class="flex flex-col gap-3 lg:col-start-2 lg:row-start-2">
     <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
       <div class="flex flex-wrap items-center gap-2.5">
-        <h1 class="text-2xl font-semibold tracking-tight">{job.title}</h1>
+        <h1 class="text-2xl font-semibold tracking-tight" lang={contentLang}>{job.title}</h1>
         {#if applied}
           <Chip variant="brand" class="gap-1.5 border-brand/30 font-semibold">
             <CheckCircle2 class="size-3.5" aria-hidden="true" /> Applied

--- a/web/src/lib/seo.test.ts
+++ b/web/src/lib/seo.test.ts
@@ -8,6 +8,7 @@ import {
   companyPageTitle,
   companiesPageTitle,
   datasetJsonLd,
+  foreignContentLang,
   jobListItems,
   jobPostingJsonLd,
   listingRobots,
@@ -16,7 +17,7 @@ import {
 } from './seo';
 import { companyLogoUrl } from './logo';
 import type { PostMeta } from './blog';
-import type { Company, Job } from './types';
+import type { Company, Job, JobCard } from './types';
 
 // collectionPageJsonLd reads only title + public_slug off each job.
 function job(title: string, slug: string): Job {
@@ -236,7 +237,68 @@ describe('organizationJsonLd', () => {
   });
 });
 
+describe('foreignContentLang', () => {
+  it('names the posting language when it is not the page language', () => {
+    expect(foreignContentLang(postingJob({ enrichment: { posting_language: 'ru' } }))).toBe('ru');
+    expect(foreignContentLang(postingJob({ enrichment: { posting_language: 'DE' } }))).toBe('de');
+  });
+
+  it('stays silent for English, so the document language is never restated', () => {
+    expect(foreignContentLang(postingJob({ enrichment: { posting_language: 'en' } }))).toBeUndefined();
+  });
+
+  it('accepts any ISO 639-1 code, down to the catalogue rarities', () => {
+    // Guards the shape check against ever becoming a whitelist. All real
+    // production values — one Javanese posting, three Malagasy — and a language
+    // new to the catalogue must work without touching seo.ts.
+    for (const code of ['jv', 'ha', 'mg', 'eo', 'zu', 'zh']) {
+      expect(foreignContentLang(postingJob({ enrichment: { posting_language: code } }))).toBe(code);
+    }
+  });
+
+  it('stays silent when no language was resolved', () => {
+    expect(foreignContentLang(postingJob())).toBeUndefined();
+    expect(foreignContentLang(postingJob({ enrichment: {} }))).toBeUndefined();
+    expect(foreignContentLang(postingJob({ enrichment: { posting_language: '' } }))).toBeUndefined();
+  });
+
+  it('degrades rather than emitting a tag no consumer can resolve', () => {
+    // Prose where a code belongs — the failure mode of an unenforced LLM field.
+    expect(
+      foreignContentLang(postingJob({ enrichment: { posting_language: 'russian' } }))
+    ).toBeUndefined();
+    expect(foreignContentLang(postingJob({ enrichment: { posting_language: 'r u' } }))).toBeUndefined();
+    // Real languages, wrong standard: ISO 639-3 and a regional subtag are not in
+    // the contract today, so they degrade instead of corrupting. Widening the
+    // pattern is what should flip these, not an accident.
+    expect(foreignContentLang(postingJob({ enrichment: { posting_language: 'fil' } }))).toBeUndefined();
+    expect(
+      foreignContentLang(postingJob({ enrichment: { posting_language: 'pt-BR' } }))
+    ).toBeUndefined();
+  });
+
+  it('degrades to silence on a Card, the projection that carries no enrichment', () => {
+    const card: JobCard = { public_slug: 'engineer-abc', title: 'Engineer', company: 'Acme' };
+    expect(foreignContentLang(card)).toBeUndefined();
+  });
+});
+
 describe('jobPostingJsonLd', () => {
+  it('states inLanguage whenever the posting language is known, English included', () => {
+    const ru = jobPostingJsonLd(postingJob({ enrichment: { posting_language: 'ru' } }), ORIGIN);
+    expect(ru.inLanguage).toBe('ru');
+
+    // Unlike the lang attribute, the JSON-LD has no surrounding document to
+    // inherit from — 'en' is a fact worth stating, not a restatement.
+    const en = jobPostingJsonLd(postingJob({ enrichment: { posting_language: 'en' } }), ORIGIN);
+    expect(en.inLanguage).toBe('en');
+
+    expect(jobPostingJsonLd(postingJob(), ORIGIN)).not.toHaveProperty('inLanguage');
+    expect(
+      jobPostingJsonLd(postingJob({ enrichment: { posting_language: 'russian' } }), ORIGIN)
+    ).not.toHaveProperty('inLanguage');
+  });
+
   it('adds logo, skills, and experience/education requirements when present', () => {
     const ld = jobPostingJsonLd(
       postingJob({

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -6,7 +6,7 @@ import type { PostMeta } from './blog';
 import { countryLabel } from './facets';
 import { COUNTRY_REGION_MAP } from './generated/contracts';
 import { companyLogoUrl } from './logo';
-import type { Company, Enrichment, Job } from './types';
+import type { Company, Enrichment, Job, JobCard } from './types';
 
 const SITE = 'freehire';
 // Site-level facts reused across the homepage WebSite/Organization schema.
@@ -303,6 +303,41 @@ function estimatedValidThrough(job: Job): string | undefined {
   return d.toISOString();
 }
 
+// A shape check, deliberately NOT a vocabulary: every ISO 639-1 code passes, so
+// a language new to the catalogue needs no change here.
+//
+// It rejects what is not a language code at all. The enrichment contract
+// promises ISO 639-1 (internal/enrich/enrichment.go) but nothing enforces it —
+// the value arrives as a bare string, written by an LLM — and a tag no consumer
+// can resolve is worse than none, having announced a switch it cannot make.
+// Should a source ever report ISO 639-3 (`fil`) or a regional tag (`pt-BR`),
+// widen the pattern; until one does, both degrade to undefined rather than
+// reaching markup wrong.
+function isoLanguage(raw: string | undefined): string | undefined {
+  const code = raw?.trim().toLowerCase();
+  return code && /^[a-z]{2}$/.test(code) ? code : undefined;
+}
+
+/** The posting's own language, for a `lang` attribute on the subtree that holds
+ *  it — the title and the description body, the only places a posting speaks
+ *  for itself.
+ *
+ *  Deliberately a subtree and not the document. Public pages render English
+ *  chrome by contract (hooks.server.ts pins `<html lang="en">` off `/my/**`)
+ *  and that is accurate — the nav, the metadata rail and every control really
+ *  are English. Only the posting is foreign, so only the posting is relabelled.
+ *
+ *  Undefined for English, for an unknown language, and for a `Card` (which
+ *  carries no enrichment to read) — all three mean "emit no attribute", so a
+ *  caller can hand the result straight to `lang` and let Svelte drop it. An
+ *  empty string would be worse than silence: it asserts "language unknown" and
+ *  overrides what the subtree would otherwise inherit. */
+export function foreignContentLang(job: Job | JobCard): string | undefined {
+  const enrichment = 'enrichment' in job ? job.enrichment : undefined;
+  const code = isoLanguage(enrichment?.posting_language);
+  return code === 'en' ? undefined : code;
+}
+
 /** schema.org JobPosting for a job-detail page, eligible for Google Jobs. A
  *  closed posting sets `validThrough` to its close time so it reads as expired,
  *  not open; an open one gets a rolling estimate (see estimatedValidThrough) so
@@ -390,6 +425,12 @@ export function jobPostingJsonLd(job: Job, origin: string): Record<string, unkno
 
   // skills is the dictionary facet (canonical names), served as Google Text.
   if (job.skills?.length) ld.skills = job.skills.join(', ');
+
+  // Every known language, English included: a JSON-LD node inherits nothing, so
+  // unlike the `lang` attribute there is no default here worth staying silent
+  // about (see foreignContentLang).
+  const inLanguage = isoLanguage(e.posting_language);
+  if (inLanguage) ld.inLanguage = inLanguage;
 
   // A zero minimum (explicit entry-level) carries no SEO signal, so omit it.
   if (e.experience_years_min != null && e.experience_years_min > 0) {


### PR DESCRIPTION
## The defect

~195k of the 1.34M postings are not written in English, and every one was served under a bare `<html lang="en">` with nothing in the markup or the JSON-LD saying otherwise. A screen reader read Russian prose in an English voice.

The catalogue holds **54 languages** (`GET /api/v1/jobs/facets?facets=posting_language`):

| | | | | |
|---|---|---|---|---|
| ru 31,708 | de 23,797 | fr 20,674 | es 16,521 | pt 12,731 |
| nl 7,578 | it 5,511 | pl 3,510 | ko 2,814 | uk 2,105 |

…down to a single Javanese posting and three Malagasy ones.

## Why a subtree and not the document

The obvious fix — pass the posting language through to `%lang%` — would have been wrong. `hooks.server.ts` pins `lang="en"` on public routes deliberately, and it is *accurate*: the nav, the metadata rail and every control really are English. So is the Summary block, which `internal/enrich/langchain.go` pins to a `plain-English synopsis` no matter what language the posting is in.

Only the title and the description body speak the posting's language. Relabelling the document would have fixed those two and mislabelled everything around them.

## What changed

- **`foreignContentLang(job)`** in `seo.ts` — reads `jobs.posting_language`, already carried in the job projection beside the description. Nothing new is fetched, nothing is detected.
- **`lang` on the `<h1>` and the body** in `JobView.svelte`.
- **`lang` on the listing card title** in `JobRow.svelte` — one listing can hold a Russian, a German and an English title in a row, so the tag belongs per card.
- **`inLanguage` on `JobPosting`** — English included here, unlike the attribute: a JSON-LD node inherits nothing, so there is no default worth staying silent about.

### The check is a shape, not a vocabulary

`/^[a-z]{2}$/` — every ISO 639-1 code passes, so a language new to the catalogue needs no change here. There is no list to feed. What it rejects is a value that is not a language code: the field is written by an LLM and nothing enforces the contract, so `"russian"` degrades to no attribute rather than an unresolvable tag. ISO 639-3 (`fil`) and regional subtags (`pt-BR`) degrade the same way until someone deliberately widens the pattern — a test pins that so it cannot flip by accident.

## Verification

```
vitest        100 files, 1091 tests — passed
svelte-check  10063 files, 0 errors (31 warnings — pre-existing baseline)
eslint        clean
vite build    ✔ done
```

Attribute mechanics checked by compiling the component to SSR and rendering, not by reasoning:

```
ru posting → <div class="job-description …" lang="ru"><p>Привет</p></div>
en posting → <div class="job-description …"><p>Hello</p></div>
```

`undefined` (not `""`) matters: an empty `lang` asserts "language unknown" and would override what the subtree inherits.

## Not in scope

`JobDrawer.svelte:673` renders a description on the signed-in tracker — same defect, private surface, left alone. Tracking rows use the `Card` projection, which carries no `posting_language`; they degrade to no attribute rather than having the field added to the API for a non-indexed screen.