### PR TITLE
Stop the job breadcrumb from naming a route that redirects

### DIFF
--- a/web/src/routes/jobs/[slug]/+page.svelte
+++ b/web/src/routes/jobs/[slug]/+page.svelte
@@ -31,9 +31,15 @@
   const jsonLd = $derived(
     jsonLdScript([
       jobPostingJsonLd(data.job, origin),
+      // Two levels, not three: the feed a job sits in IS the homepage, so the
+      // parent here is `/`. There was a `Jobs` level pointing at `/jobs`, but
+      // that route is a 301 to `/` (jobs/+page.server.ts — the feed moved), and
+      // a trail step naming a redirect is a step Google resolves away. Adding
+      // it back with `/` as its target would be worse still: two positions, one
+      // URL. If the feed ever gets its own page again, this is where the level
+      // returns.
       breadcrumbJsonLd([
         { name: 'freehire', url: `${origin}/` },
-        { name: 'Jobs', url: `${origin}/jobs` },
         { name: data.job.title, url: canonical },
       ]),
     ])


### PR DESCRIPTION
## The defect

All 1.34M job pages emit a three-step `BreadcrumbList` whose middle step points at a redirect:

```
freehire [/] > Jobs [/jobs] > Principal Embedded Software Engineer [/jobs/…]
                     ^^^^^^ 301 → /
```

`/jobs` has been a permanent redirect since the feed moved to the homepage (`jobs/+page.server.ts`); the trail was never updated. Google resolves a step that names a redirect, so the markup has been describing a hierarchy the site does not have.

For contrast, this is what every other page type emits — all of them resolve:

```
freehire [/] > Companies [/companies] > 10Beauty [/companies/10beauty]
freehire [/] > Insights [/insights]   > Software Engineering Salaries [/insights/…]
freehire [/] > Collections [/collections] > 7,201 Go jobs [/collections/go]
```

## The fix

Two levels, not three — `freehire > <title>`.

Dropping the step rather than repointing it, because the feed a job sits in really *is* the homepage. Keeping `Jobs` and giving it `/` as its target would put two positions on one URL, which is worse than a missing level. `/jobs` itself is left alone: that redirect is deliberate and carries the query string through for saved filter links.

## Scope check

Extracted every fixed breadcrumb URL from all routes and probed them live. `/jobs` was the only one that did not answer 200, and it is the only one this PR touches:

| URL | status |
|---|---|
| `/` | 200 |
| `/companies` | 200 |
| `/collections` | 200 |
| `/insights` | 200 |
| ~~`/jobs`~~ | ~~301 → `/`~~ — removed here |

## Verification

```
vitest        100 files, 1091 tests — passed
svelte-check  10063 files, 0 errors (31 warnings — pre-existing baseline)
eslint        clean
vite build    ✔ done
```