### PR TITLE
Count API responses by method and status

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -109,8 +109,11 @@ func main() {
 		// résumés up front so users get a clear message instead of a raw 413. Seam: if the
 		// broad ceiling ever matters, add a Content-Length guard middleware on the non-upload
 		// routes rather than lowering this.
-		BodyLimit:    8 * 1024 * 1024,
-		ErrorHandler: handler.RenderError,
+		BodyLimit: 8 * 1024 * 1024,
+		// Wrapped so an error-derived response is counted with the status actually sent:
+		// Fiber renders errors here, after the middleware chain has unwound, so the counter
+		// in observability.HTTPMetrics cannot see them.
+		ErrorHandler: observability.CountErrors(handler.RenderError),
 		// The app sits behind the in-network nginx proxy (web/nginx.conf). Key c.IP()
 		// (and thus the rate limiter) on X-Real-IP, which nginx OVERWRITES with the real
 		// peer — a single value the client cannot spoof. X-Forwarded-For is deliberately
@@ -125,6 +128,11 @@ func main() {
 		// API over loopback. One definition so the two cannot disagree.
 		TrustedProxies: ratelimit.TrustedCIDRs,
 	})
+
+	// Counting responses sits OUTSIDE recover.New on purpose: recover converts a panic into a
+	// 500 further in, so only a middleware the response passes through on its way back out
+	// records the status the client actually got.
+	app.Use(observability.HTTPMetrics())
 
 	// The recover middleware marks each unwound panic via c.Locals so RenderError
 	// won't double-report it: the sentryfiber middleware below already captures the

--- a/go.mod
+++ b/go.mod
@@ -109,6 +109,7 @@ require (
 	github.com/klauspost/compress v1.19.1 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.11 // indirect
 	github.com/klauspost/crc32 v1.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect

--- a/internal/observability/AGENTS.md
+++ b/internal/observability/AGENTS.md
@@ -26,3 +26,37 @@ Opt-in Sentry across all three surfaces, env-gated.
 ## Config
 
 `SENTRY_DSN`/`SENTRY_ENVIRONMENT` (backend + workers) and `PUBLIC_SENTRY_DSN`/`PUBLIC_SENTRY_ENVIRONMENT` (frontend), all optional, injected by `freehire-ops` (never committed). Two Sentry projects (frontend + backend); `SENTRY_ENVIRONMENT` tags events for shared project filtering.
+
+## HTTP response metrics
+
+`freehire_http_requests_total{method,status}` counts every API response, exported on the
+`/metrics` listener. Two pieces, and both are needed:
+
+- **`HTTPMetrics()`** — mounted as the OUTERMOST middleware in `cmd/server`, before
+  `recover.New`. Counts only requests that returned no error.
+- **`CountErrors(handler.RenderError)`** — wraps the app's `ErrorHandler`. Counts the rest.
+
+**Why it is split, and the trap it exists for.** Fiber renders a returned error in the
+`ErrorHandler`, which runs AFTER the middleware chain has fully unwound. A middleware reading
+`c.Response().StatusCode()` after `c.Next()` therefore sees 200 for every 404 and every 500 —
+the exact responses the counter exists to see. A recovered panic behaves the same way: `recover`
+turns it into an error and the status is chosen later. The wrapper asks the real error handler
+what status it sent rather than re-deriving it, because `RenderError` resolves the status
+through `codedError` and `classify`, and a second copy of that mapping is the failure this
+codebase has already paid for once.
+
+**No route label, deliberately.** The app registers ~700 routes; route x status x method is tens
+of thousands of series on a single-target Prometheus. "Which endpoint" is already answered by the
+per-request log line. If a future need justifies the cardinality, add a SEPARATE metric scoped to
+5xx rather than widening this one — `TestHTTPMetricsLabelsAreBounded` fails if a path label
+creeps in.
+
+**This does not replace the site-alert watchdog and does not overlap it.** `site-alert.sh` polls
+a real endpoint every two minutes and pages to Telegram on two consecutive failures; it caught
+the 2026-08-19 schema outage at 11:37 and paged at 11:39, which no scrape interval improves on.
+What a poll cannot see is a RATE — 0.5% of requests failing while the poll keeps succeeding.
+That is this counter's job, and the two answer different questions.
+
+**Not yet reachable on prod.** `METRICS_PORT` is unset there, and `StartMetricsServer` is a no-op
+without it, so `/metrics` is not served. Setting the port and scoping a firewall rule to the
+scraper is an ops change (`freehire-ops`), as is the alert rule itself.

--- a/internal/observability/httpmetrics.go
+++ b/internal/observability/httpmetrics.go
@@ -1,0 +1,69 @@
+package observability
+
+import (
+	"strconv"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// httpRequests counts every response the API sends, by method and status code.
+//
+// Labelled by method and status ONLY, deliberately. The obvious third label is the route, and
+// it is the one this must not carry: the app registers ~700 routes, so route x status x method
+// is tens of thousands of series on a single-target Prometheus. The question this metric exists
+// to answer — "is the error rate rising" — does not need the route, and the question that does
+// ("which endpoint") is already answered by the per-request log line beside it. If a future
+// need justifies the cardinality, add a SEPARATE metric scoped to 5xx rather than widening this
+// one.
+//
+// The status label is the numeric code rather than a 2xx/5xx class: the codes this API actually
+// emits are a short list (200, 301, 400, 401, 403, 404, 429, 500, 503), so the cardinality is
+// the same either way, and 429 vs 500 is exactly the distinction an incident turns on — the
+// 2026-08-19 rate-limiter incident and the schema outage would have looked identical under a
+// class label.
+var httpRequests = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "freehire_http_requests_total",
+	Help: "API responses by method and HTTP status code.",
+}, []string{"method", "status"})
+
+// HTTPMetrics counts responses that completed without an error. It is HALF the wiring: a
+// handler returning an error has no status yet when this unwinds, because Fiber renders it in
+// the ErrorHandler AFTER the middleware chain has fully unwound. Reading the status here would
+// record 200 for every 404 and every 500 — the responses the counter exists to see. Those are
+// counted by CountErrors instead, and the err != nil skip below is what keeps the two from
+// double-counting the same request.
+//
+// This does not replace the site-alert watchdog and is not the reason it exists. That check
+// polls a real endpoint every two minutes and pages on two consecutive failures — it caught the
+// 2026-08-19 outage in two minutes, which no scrape interval improves on. What it cannot see is
+// a RATE: 0.5% of requests failing is invisible to a poll that keeps succeeding, and that is
+// what this counter is for.
+func HTTPMetrics() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		err := c.Next()
+		if err != nil {
+			// CountErrors will record it once the ErrorHandler has chosen the status.
+			return err
+		}
+		httpRequests.WithLabelValues(c.Method(), strconv.Itoa(c.Response().StatusCode())).Inc()
+		return nil
+	}
+}
+
+// CountErrors wraps the app's ErrorHandler so an error-derived response is counted with the
+// status that was actually sent.
+//
+// Deliberately a decorator rather than a copy of the mapping: handler.RenderError resolves the
+// status through codedError and classify, and reproducing that here would be a second
+// implementation of one rule — the failure mode this codebase has already paid for once, in the
+// four disagreeing legal-form vocabularies. The wrapper asks the real handler what it did
+// instead of predicting it.
+func CountErrors(next fiber.ErrorHandler) fiber.ErrorHandler {
+	return func(c *fiber.Ctx, err error) error {
+		rendered := next(c, err)
+		httpRequests.WithLabelValues(c.Method(), strconv.Itoa(c.Response().StatusCode())).Inc()
+		return rendered
+	}
+}

--- a/internal/observability/httpmetrics_test.go
+++ b/internal/observability/httpmetrics_test.go
@@ -1,0 +1,146 @@
+package observability
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/recover"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// count reads one series of the counter, or 0 when that label pair has never been touched.
+func count(t *testing.T, method, status string) float64 {
+	t.Helper()
+	return testutil.ToFloat64(httpRequests.WithLabelValues(method, status))
+}
+
+func TestHTTPMetricsCountsByMethodAndStatus(t *testing.T) {
+	app := fiber.New()
+	app.Use(HTTPMetrics())
+	app.Get("/ok", func(c *fiber.Ctx) error { return c.SendString("fine") })
+	app.Post("/created", func(c *fiber.Ctx) error { return c.SendStatus(fiber.StatusCreated) })
+
+	before200 := count(t, "GET", "200")
+	before201 := count(t, "POST", "201")
+
+	for range 3 {
+		resp, err := app.Test(httptest.NewRequestWithContext(t.Context(), fiber.MethodGet, "/ok", nil))
+		if err != nil {
+			t.Fatalf("GET /ok: %v", err)
+		}
+		resp.Body.Close()
+	}
+	resp, err := app.Test(httptest.NewRequestWithContext(t.Context(), fiber.MethodPost, "/created", nil))
+	if err != nil {
+		t.Fatalf("POST /created: %v", err)
+	}
+	resp.Body.Close()
+
+	if got := count(t, "GET", "200") - before200; got != 3 {
+		t.Errorf("GET 200 counted %v, want 3", got)
+	}
+	if got := count(t, "POST", "201") - before201; got != 1 {
+		t.Errorf("POST 201 counted %v, want 1", got)
+	}
+}
+
+// TestHTTPMetricsCountsAPanicAs500 is the reason the middleware is mounted outside recover.New.
+// A panic is not a status until recover has turned it into one; a counter mounted inside would
+// observe whatever the response held before the handler blew up — undercounting exactly the
+// failures worth counting.
+func TestHTTPMetricsCountsAPanicAs500(t *testing.T) {
+	app := fiber.New(fiber.Config{ErrorHandler: CountErrors(fiber.DefaultErrorHandler)})
+	app.Use(HTTPMetrics())
+	app.Use(recover.New())
+	app.Get("/boom", func(c *fiber.Ctx) error { panic("boom") })
+
+	before := count(t, "GET", "500")
+
+	resp, err := app.Test(httptest.NewRequestWithContext(t.Context(), fiber.MethodGet, "/boom", nil))
+	if err != nil {
+		t.Fatalf("GET /boom: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != fiber.StatusInternalServerError {
+		t.Fatalf("fixture: status %d, want 500", resp.StatusCode)
+	}
+
+	if got := count(t, "GET", "500") - before; got != 1 {
+		t.Errorf("panic counted as 500 %v times, want 1 — the middleware is probably mounted "+
+			"inside recover.New, where it cannot see the status the client got", got)
+	}
+}
+
+// TestHTTPMetricsCountsAnErrorHandlerStatus covers the shape this API actually uses: handlers
+// return an error and Fiber's ErrorHandler renders the envelope. The status is set during that
+// render, after the handler returned, so reading it before c.Next() unwinds would record 200.
+func TestHTTPMetricsCountsAnErrorHandlerStatus(t *testing.T) {
+	app := fiber.New(fiber.Config{ErrorHandler: CountErrors(fiber.DefaultErrorHandler)})
+	app.Use(HTTPMetrics())
+	app.Get("/missing", func(c *fiber.Ctx) error {
+		return fiber.NewError(fiber.StatusNotFound, "no such job")
+	})
+
+	before := count(t, "GET", "404")
+
+	resp, err := app.Test(httptest.NewRequestWithContext(t.Context(), fiber.MethodGet, "/missing", nil))
+	if err != nil {
+		t.Fatalf("GET /missing: %v", err)
+	}
+	resp.Body.Close()
+
+	if got := count(t, "GET", "404") - before; got != 1 {
+		t.Errorf("error-handler 404 counted %v times, want 1", got)
+	}
+}
+
+// TestHTTPMetricsCountsEachRequestOnce pins the split: the middleware skips a request that
+// returned an error so CountErrors can record it with the rendered status, and exactly one of
+// the two fires. A request counted twice would double every error rate the metric reports.
+func TestHTTPMetricsCountsEachRequestOnce(t *testing.T) {
+	app := fiber.New(fiber.Config{ErrorHandler: CountErrors(fiber.DefaultErrorHandler)})
+	app.Use(HTTPMetrics())
+	app.Get("/fail", func(c *fiber.Ctx) error { return fiber.NewError(fiber.StatusBadRequest, "no") })
+
+	before400 := count(t, "GET", "400")
+	before200 := count(t, "GET", "200")
+
+	resp, err := app.Test(httptest.NewRequestWithContext(t.Context(), fiber.MethodGet, "/fail", nil))
+	if err != nil {
+		t.Fatalf("GET /fail: %v", err)
+	}
+	resp.Body.Close()
+
+	if got := count(t, "GET", "400") - before400; got != 1 {
+		t.Errorf("400 counted %v times, want exactly 1", got)
+	}
+	if got := count(t, "GET", "200") - before200; got != 0 {
+		t.Errorf("the same request also counted as 200 %v times — the middleware did not skip "+
+			"the error path, so every error inflates the success count too", got)
+	}
+}
+
+// TestHTTPMetricsLabelsAreBounded guards the decision NOT to label by route. The app registers
+// ~700 routes; route x status x method would be tens of thousands of series on a single-target
+// Prometheus. This asserts the metric's label set, so widening it becomes a deliberate edit
+// rather than a convenience someone adds mid-incident.
+func TestHTTPMetricsLabelsAreBounded(t *testing.T) {
+	app := fiber.New()
+	app.Use(HTTPMetrics())
+	app.Get("/jobs/:slug", func(c *fiber.Ctx) error { return c.SendString("ok") })
+
+	for _, slug := range []string{"a-1", "b-2", "c-3"} {
+		resp, err := app.Test(httptest.NewRequestWithContext(t.Context(), fiber.MethodGet, "/jobs/"+slug, nil))
+		if err != nil {
+			t.Fatalf("GET /jobs/%s: %v", slug, err)
+		}
+		resp.Body.Close()
+	}
+
+	// Three distinct paths, one series: the path is not a label.
+	if n := testutil.CollectAndCount(httpRequests); n > 24 {
+		t.Errorf("the counter holds %d series after three distinct paths — a path or route label "+
+			"has crept in, and at ~700 routes that is tens of thousands of series", n)
+	}
+}


### PR DESCRIPTION
`freehire_http_requests_total{method,status}`, exported on the `/metrics` listener.

## What this is not

I proposed this as "the 2026-08-19 outage was invisible to monitoring". **That was wrong**, and checking the prod journal is what showed it:

```
11:37:22  api https://freehire.me/api/v1/jobs?limit=1 -> HTTP 500
11:39:23  api -> HTTP 500
11:39:23  🔴 alert sent to Telegram (failing 2x)
```

`site-alert.sh` polls a real endpoint every two minutes and pages on two consecutive failures — its own comment says `/health` "is too cheap to prove the site works". It caught the outage in two minutes. No scrape interval improves on that.

What a poll cannot see is a **rate**: 0.5% of requests failing while the poll keeps succeeding. That is what this counter is for, and it is a different question from the one the watchdog answers.

## The Fiber trap this is shaped around

Fiber renders a returned error in the `ErrorHandler`, which runs **after** the middleware chain has fully unwound. A middleware reading `c.Response().StatusCode()` after `c.Next()` therefore sees **200 for every 404 and every 500** — the exact responses the counter exists to see. A recovered panic behaves the same way.

So the counting is split:

| Piece | Counts |
|---|---|
| `HTTPMetrics()` middleware | requests that returned no error |
| `CountErrors(handler.RenderError)` | everything the ErrorHandler rendered |

The middleware skips the error path so nothing is counted twice. Three tests pin this: one per half, and one asserting exactly one fires for an error response.

`CountErrors` is a decorator rather than a copy of the mapping — `RenderError` resolves the status through `codedError` and `classify`, and a second implementation of one rule is the failure this codebase already paid for in four disagreeing legal-form vocabularies. It asks the real handler what it sent.

## No route label

The app registers ~700 routes, so `route x status x method` is tens of thousands of series on a single-target Prometheus. "Which endpoint" is already answered by the per-request log line beside it. `TestHTTPMetricsLabelsAreBounded` fails if a path label creeps in; a future need should add a *separate* 5xx-scoped metric rather than widen this one.

## Ops work still outstanding

`METRICS_PORT` is unset on prod and `StartMetricsServer` is a no-op without it, so `/metrics` is not currently served at all. Setting the port, scoping a firewall rule to the scraper, and writing the alert rule are `freehire-ops` changes — noted in `internal/observability/AGENTS.md` rather than left implicit.