### PR TITLE
Move the application form into the job page's tab strip

### DIFF
--- a/web/src/lib/components/JobApplyForm.svelte
+++ b/web/src/lib/components/JobApplyForm.svelte
@@ -1,29 +1,39 @@
-<script lang="ts">
+<script module lang="ts">
   import type { Display } from '$lib/generated/contracts';
 
+  /** Whether a form has anything to show: questions, or a statement of what it wants
+   *  uploaded. Exported because the caller owning the tab has to ask the same question
+   *  this component answers — a tab offered over an empty panel is worse than no tab,
+   *  and two copies of the predicate would eventually disagree about which it is. */
+  export function applyFormWorthShowing(form: Display | null | undefined): boolean {
+    return !!form && ((form.questions?.length ?? 0) > 0 || (form.basics?.length ?? 0) > 0);
+  }
+</script>
+
+<script lang="ts">
   // What the application will ask, as the ATS published it. `form` is null for most
   // postings — only a few platforms publish a form we can read — and the block simply
   // does not render, which is the ordinary case rather than a degraded one.
+  //
+  // Renders bare, with no card or heading of its own: it sits inside the job page's
+  // tab panel, where the tab is the heading and a second one under it would say the
+  // same thing twice.
   let { form }: { form: Display | null } = $props();
-
-  // A form worth showing has either questions or a statement of what it wants uploaded.
-  // Neither is a reason to render a heading over nothing.
-  const worthShowing = $derived(
-    !!form && (form.questions?.length > 0 || form.basics?.length > 0)
-  );
 </script>
 
-{#if form && worthShowing}
-  <section class="mt-6 rounded-lg border border-border bg-card p-4">
-    <div class="mb-3 flex items-baseline justify-between gap-3">
-      <h2 class="text-sm font-semibold tracking-tight">What this application asks</h2>
-      <span class="text-xs text-muted-foreground capitalize">{form.provider}</span>
-    </div>
+{#if applyFormWorthShowing(form) && form}
+  <section class="flex flex-col gap-3">
+    <!-- The provider is the whole caption here. It was a chip beside a heading before
+         this block moved into a tab; the tab now says what it is, so what is left worth
+         saying is whose form it is, verbatim from the ATS. -->
+    <p class="text-xs text-muted-foreground">
+      As published by <span class="capitalize">{form.provider}</span>
+    </p>
 
     {#if form.basics?.length}
       <!-- The controls every application demands, said once. Listed rather than dropped:
            a form that does NOT want a CV is worth knowing too. -->
-      <p class="mb-2 max-w-3xl text-sm text-muted-foreground">
+      <p class="max-w-3xl text-sm text-muted-foreground">
         {form.basics.join(', ')}
       </p>
     {/if}

--- a/web/src/lib/components/JobApplyForm.svelte
+++ b/web/src/lib/components/JobApplyForm.svelte
@@ -4,8 +4,11 @@
   /** Whether a form has anything to show: questions, or a statement of what it wants
    *  uploaded. Exported because the caller owning the tab has to ask the same question
    *  this component answers — a tab offered over an empty panel is worse than no tab,
-   *  and two copies of the predicate would eventually disagree about which it is. */
-  export function applyFormWorthShowing(form: Display | null | undefined): boolean {
+   *  and two copies of the predicate would eventually disagree about which it is.
+   *
+   *  Narrows rather than returning a bare boolean, so a caller that passes the guard
+   *  does not then have to re-prove to the compiler that the form is there. */
+  export function applyFormWorthShowing(form: Display | null | undefined): form is Display {
     return !!form && ((form.questions?.length ?? 0) > 0 || (form.basics?.length ?? 0) > 0);
   }
 </script>
@@ -21,7 +24,7 @@
   let { form }: { form: Display | null } = $props();
 </script>
 
-{#if applyFormWorthShowing(form) && form}
+{#if applyFormWorthShowing(form)}
   <section class="flex flex-col gap-3">
     <!-- The provider is the whole caption here. It was a chip beside a heading before
          this block moved into a tab; the tab now says what it is, so what is left worth

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -9,12 +9,14 @@
   import { markSaved, markUnsaved } from '$lib/savedJobs.svelte';
   import { track } from '$lib/analytics';
   import { foreignContentLang } from '$lib/seo';
+  import type { Display } from '$lib/generated/contracts';
   import type { Job, UserJob } from '$lib/types';
   import { companyLogoUrl } from '$lib/logo';
   import { Badge, Button, Chip, EntityLogo, TabStrip, tabStripId } from '$lib/ui';
   import { formatDate } from '$lib/utils';
   import BackerBadge from './BackerBadge.svelte';
   import CountryFlagStack from './CountryFlagStack.svelte';
+  import JobApplyForm, { applyFormWorthShowing } from './JobApplyForm.svelte';
   import JobCompanyPanel from './JobCompanyPanel.svelte';
   import JobDescription from './JobDescription.svelte';
   import JobMatch from './JobMatch.svelte';
@@ -29,7 +31,11 @@
   // The job is server-rendered: it arrives as a prop from the route's `load`, so
   // the article's content is in the initial HTML. Only the per-user interactions
   // below hydrate client-side.
-  let { job }: { job: Job } = $props();
+  // `applyForm` is the employer's own screening form when its ATS publishes one —
+  // null for most postings, which is the ordinary case and simply means one fewer tab.
+  let { job, applyForm = null }: { job: Job; applyForm?: Display | null } = $props();
+
+  type ContentTab = 'description' | 'company' | 'application';
 
   // Set on the two subtrees below that carry the posting's own words; undefined
   // (so unset) when it is English. See foreignContentLang for why the document
@@ -73,17 +79,22 @@
   const views = $derived(job.view_count ?? 0);
   const applies = $derived(job.applied_count ?? 0);
 
-  // The content column is tabbed whenever we know the employer, so "who are these
-  // people?" is answerable without leaving the posting. Page state, not a route: the
+  // The content column is tabbed so "who are these people?" and "what will they ask
+  // me?" are answerable without leaving the posting. Page state, not a route: the
   // company copy already has a canonical home at /companies/<slug>, and a second URL
   // serving it would be a thin duplicate we'd then have to keep out of the index.
-  const CONTENT_TABS = [
-    { id: 'description', label: 'Description' },
-    { id: 'company', label: 'Company' },
-  ] as const;
-  type ContentTab = (typeof CONTENT_TABS)[number]['id'];
-
+  //
+  // Built per job rather than fixed, because neither of the two extra tabs is always
+  // there: a posting can arrive without a company slug, and only a few ATS platforms
+  // publish a form we can read. A tab is offered only when its panel has something in
+  // it — `applyFormWorthShowing` is the same predicate the panel itself renders on, so
+  // the two cannot disagree about whether there is anything to show.
   const companySlug = $derived(job.company_slug ?? '');
+  const contentTabs = $derived([
+    { id: 'description', label: 'Description' } as const,
+    ...(companySlug ? [{ id: 'company', label: 'Company' } as const] : []),
+    ...(applyFormWorthShowing(applyForm) ? [{ id: 'application', label: 'Application' } as const] : []),
+  ]);
   let contentTab = $state<ContentTab>('description');
   // Per-instance so a second JobView on one page can't claim the same panel, which
   // would leave both strips' aria-controls pointing at the first one's panel.
@@ -505,29 +516,36 @@
       </div>
     {/if}
 
-    {#if companySlug}
+    {#if contentTabs.length > 1}
       <TabStrip
-        tabs={CONTENT_TABS}
+        tabs={contentTabs}
         active={contentTab}
         onSelect={(id) => (contentTab = id)}
         label="Job details"
         {panelId}
       />
-      <!-- One panel for both tabs, its contents toggled by class rather than {#if}.
+      <!-- One panel for every tab, its contents toggled by class rather than {#if}.
            Unmounting the inactive one would throw away the company the visitor already
-           waited for, and re-render the description on every switch back. -->
+           waited for, and re-render the description on every switch back. It also keeps
+           all three in the server-rendered HTML, so a crawler reads what a visitor would
+           have to click for. -->
       <div id={panelId} role="tabpanel" aria-labelledby={tabStripId(panelId, contentTab)}>
         <div class={contentTab === 'description' ? 'flex flex-col gap-6' : 'hidden'}>
           {@render descriptionContent()}
         </div>
-        <div class={contentTab === 'company' ? 'block' : 'hidden'}>
-          {#key companySlug}
-            <JobCompanyPanel
-              slug={companySlug}
-              name={job.company || 'this company'}
-              active={contentTab === 'company'}
-            />
-          {/key}
+        {#if companySlug}
+          <div class={contentTab === 'company' ? 'block' : 'hidden'}>
+            {#key companySlug}
+              <JobCompanyPanel
+                slug={companySlug}
+                name={job.company || 'this company'}
+                active={contentTab === 'company'}
+              />
+            {/key}
+          </div>
+        {/if}
+        <div class={contentTab === 'application' ? 'block' : 'hidden'}>
+          <JobApplyForm form={applyForm} />
         </div>
       </div>
     {:else}

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -35,8 +35,6 @@
   // null for most postings, which is the ordinary case and simply means one fewer tab.
   let { job, applyForm = null }: { job: Job; applyForm?: Display | null } = $props();
 
-  type ContentTab = 'description' | 'company' | 'application';
-
   // Set on the two subtrees below that carry the posting's own words; undefined
   // (so unset) when it is English. See foreignContentLang for why the document
   // stays `en` regardless.
@@ -89,11 +87,15 @@
   // publish a form we can read. A tab is offered only when its panel has something in
   // it — `applyFormWorthShowing` is the same predicate the panel itself renders on, so
   // the two cannot disagree about whether there is anything to show.
+  type ContentTab = 'description' | 'company' | 'application';
+
   const companySlug = $derived(job.company_slug ?? '');
-  const contentTabs = $derived([
-    { id: 'description', label: 'Description' } as const,
-    ...(companySlug ? [{ id: 'company', label: 'Company' } as const] : []),
-    ...(applyFormWorthShowing(applyForm) ? [{ id: 'application', label: 'Application' } as const] : []),
+  const contentTabs: { id: ContentTab; label: string }[] = $derived([
+    { id: 'description', label: 'Description' },
+    ...(companySlug ? [{ id: 'company' as const, label: 'Company' }] : []),
+    ...(applyFormWorthShowing(applyForm)
+      ? [{ id: 'application' as const, label: 'Application' }]
+      : []),
   ]);
   let contentTab = $state<ContentTab>('description');
   // Per-instance so a second JobView on one page can't claim the same panel, which
@@ -527,8 +529,8 @@
       <!-- One panel for every tab, its contents toggled by class rather than {#if}.
            Unmounting the inactive one would throw away the company the visitor already
            waited for, and re-render the description on every switch back. It also keeps
-           all three in the server-rendered HTML, so a crawler reads what a visitor would
-           have to click for. -->
+           every panel in the server-rendered HTML, so a crawler reads what a visitor
+           would have to click for. -->
       <div id={panelId} role="tabpanel" aria-labelledby={tabStripId(panelId, contentTab)}>
         <div class={contentTab === 'description' ? 'flex flex-col gap-6' : 'hidden'}>
           {@render descriptionContent()}

--- a/web/src/routes/jobs/[slug]/+page.svelte
+++ b/web/src/routes/jobs/[slug]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { page } from '$app/state';
-  import JobApplyForm from '$lib/components/JobApplyForm.svelte';
   import JobRelated from '$lib/components/JobRelated.svelte';
   import JobSeeAlso from '$lib/components/JobSeeAlso.svelte';
   import JobView from '$lib/components/JobView.svelte';
@@ -58,9 +57,7 @@
      raw text with no card wrapper, so 16px reads tight against the edge; sm+ falls
      back to the shared px-4 rhythm. -->
 <div class="mx-auto w-full max-w-6xl px-5 py-6 sm:px-4">
-  <JobView job={data.job} />
-
-  <JobApplyForm form={data.applyForm} />
+  <JobView job={data.job} applyForm={data.applyForm} />
 
   <JobRelated
     similar={data.similar}


### PR DESCRIPTION
## What changed

"What this application asks" was a card *below* the tabbed content column. A posting with a screening form split its three answers — what is this job, who are these people, what will they ask me — across two different layouts. It is now the third tab.

```
before                          after
┌──────────────────────────┐    ┌───────────────────────────────────────┐
│ [Description] [Company]  │    │ [Description] [Company] [Application] │
│ описание…                │    │                                       │
└──────────────────────────┘    │ As published by Greenhouse            │
┌──────────────────────────┐    │ First Name, Last Name, Email, …       │
│ What this application    │    │ Preferred First Name        optional  │
│ asks          Greenhouse │    │ Are you legally authorized…  choose   │
└──────────────────────────┘    └───────────────────────────────────────┘
```

## The tab is conditional

Neither extra tab is unconditional: a posting can arrive without a company slug, and only a few ATS platforms publish a form we can read — measured at **44 of 100** sampled Greenhouse postings. So the strip is built per job and falls back to a bare description when it would hold a single tab.

The predicate is `applyFormWorthShowing`, exported from `<script module>` in the component that renders the panel. One definition, so a tab cannot be offered over a panel that then declines to draw itself — the failure mode a second copy of the check would eventually produce.

`JobApplyForm` loses its card wrapper and its `<h2>`: the tab is the heading now, and the provider it used to caption with is what is left worth saying.

## SEO note

Panels stay mounted and are toggled by class, exactly as the existing two already were, so all three are in the server-rendered HTML. Confirmed on the dev render — the form's questions are present in the initial HTML without any click.

## Verification

Ran the frontend against the production API (`VITE_API_URL=https://freehire.me`) and checked both branches in a real browser:

| case | tabs rendered | form markup |
|---|---|---|
| Ripple, Greenhouse form (7 questions) | `Description, Company, Application` | present |
| City of Detroit, no form | `Description, Company` | absent |

```
vitest        100 files, 1091 tests — passed
svelte-check  10063 files, 0 errors (31 warnings — pre-existing baseline)
eslint        clean
vite build    ✔ done
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an application tab to job listings when application questions or uploads are available.
  * Application forms now appear within the job’s tabbed content layout.
  * Improved application form presentation with provider information in a streamlined, borderless section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->