### PR TITLE
Stop the method label from aliasing fasthttp's request buffer

### DIFF
--- a/internal/observability/AGENTS.md
+++ b/internal/observability/AGENTS.md
@@ -45,6 +45,14 @@ what status it sent rather than re-deriving it, because `RenderError` resolves t
 through `codedError` and `classify`, and a second copy of that mapping is the failure this
 codebase has already paid for once.
 
+**The method label is mapped, never passed through.** `c.Method()` is backed by fasthttp's
+request buffer, which is RECYCLED between requests, so a label value taken straight from it
+mutates after the counter has stored it. On prod 2026-08-20 that produced a label reading `GETT`
+and a `/metrics` endpoint answering 500 — the corrupted label sets collided with the intact ones,
+so the whole endpoint failed rather than degrading. `methodLabel` returns package-level constants
+that share nothing with the request. It also bounds the label: the method is CLIENT-SUPPLIED, so
+an unbounded passthrough would let any caller mint series at will.
+
 **No route label, deliberately.** The app registers ~700 routes; route x status x method is tens
 of thousands of series on a single-target Prometheus. "Which endpoint" is already answered by the
 per-request log line. If a future need justifies the cardinality, add a SEPARATE metric scoped to

--- a/internal/observability/httpmetrics.go
+++ b/internal/observability/httpmetrics.go
@@ -28,6 +28,40 @@ var httpRequests = promauto.NewCounterVec(prometheus.CounterOpts{
 	Help: "API responses by method and HTTP status code.",
 }, []string{"method", "status"})
 
+// methodLabel maps a request method onto one of a fixed set of package-level constants.
+//
+// It exists for two reasons, and the first one broke production. fasthttp backs c.Method() with
+// the request buffer and RECYCLES that buffer between requests, so the string a counter stores
+// as a label value mutates under it. On prod 2026-08-20 that surfaced as a label reading "GETT"
+// and a /metrics endpoint answering 500 — "collected metric ... was collected before with the
+// same name and label values" — because the corrupted label sets collided. Returning a constant
+// that shares nothing with the request is the fix; utils.CopyString would also work, but see the
+// second reason.
+//
+// The second: the method is CLIENT-SUPPLIED. Passing it through unbounded lets any caller mint
+// label values at will, which is the cardinality hole this metric refuses a route label to
+// avoid. Anything outside the set the API actually serves collapses to "other".
+func methodLabel(m string) string {
+	switch m {
+	case fiber.MethodGet:
+		return fiber.MethodGet
+	case fiber.MethodPost:
+		return fiber.MethodPost
+	case fiber.MethodPut:
+		return fiber.MethodPut
+	case fiber.MethodPatch:
+		return fiber.MethodPatch
+	case fiber.MethodDelete:
+		return fiber.MethodDelete
+	case fiber.MethodHead:
+		return fiber.MethodHead
+	case fiber.MethodOptions:
+		return fiber.MethodOptions
+	default:
+		return "other"
+	}
+}
+
 // HTTPMetrics counts responses that completed without an error. It is HALF the wiring: a
 // handler returning an error has no status yet when this unwinds, because Fiber renders it in
 // the ErrorHandler AFTER the middleware chain has fully unwound. Reading the status here would
@@ -47,7 +81,7 @@ func HTTPMetrics() fiber.Handler {
 			// CountErrors will record it once the ErrorHandler has chosen the status.
 			return err
 		}
-		httpRequests.WithLabelValues(c.Method(), strconv.Itoa(c.Response().StatusCode())).Inc()
+		httpRequests.WithLabelValues(methodLabel(c.Method()), strconv.Itoa(c.Response().StatusCode())).Inc()
 		return nil
 	}
 }
@@ -63,7 +97,7 @@ func HTTPMetrics() fiber.Handler {
 func CountErrors(next fiber.ErrorHandler) fiber.ErrorHandler {
 	return func(c *fiber.Ctx, err error) error {
 		rendered := next(c, err)
-		httpRequests.WithLabelValues(c.Method(), strconv.Itoa(c.Response().StatusCode())).Inc()
+		httpRequests.WithLabelValues(methodLabel(c.Method()), strconv.Itoa(c.Response().StatusCode())).Inc()
 		return rendered
 	}
 }

--- a/internal/observability/httpmetrics_test.go
+++ b/internal/observability/httpmetrics_test.go
@@ -144,3 +144,38 @@ func TestHTTPMetricsLabelsAreBounded(t *testing.T) {
 			"has crept in, and at ~700 routes that is tens of thousands of series", n)
 	}
 }
+
+// TestMethodLabelDoesNotAliasTheRequestBuffer is the regression test for a live prod failure.
+//
+// fasthttp backs c.Method() with the request buffer and recycles it, so a label value taken
+// straight from it mutates after the counter has stored it. On 2026-08-20 that produced a label
+// reading "GETT" and a /metrics endpoint answering 500, because the corrupted label sets
+// collided with the intact ones. The check is that the returned string shares no backing array
+// with the input: mutating the caller's bytes must not change the label.
+func TestMethodLabelDoesNotAliasTheRequestBuffer(t *testing.T) {
+	buf := []byte("GET")
+	label := methodLabel(string(buf))
+	buf[2] = 'X' // fasthttp reusing the buffer for the next request
+
+	if label != fiber.MethodGet {
+		t.Errorf("label became %q after the caller's buffer changed — it aliases the request "+
+			"buffer, which is what broke /metrics on prod", label)
+	}
+}
+
+// TestMethodLabelBoundsClientSuppliedValues closes the cardinality hole the method label opens:
+// the method comes from the client, so an unbounded passthrough lets any caller mint label
+// values — exactly what refusing a route label was meant to prevent.
+func TestMethodLabelBoundsClientSuppliedValues(t *testing.T) {
+	for _, m := range []string{fiber.MethodGet, fiber.MethodPost, fiber.MethodDelete} {
+		if got := methodLabel(m); got != m {
+			t.Errorf("methodLabel(%q) = %q, want it preserved", m, got)
+		}
+	}
+	for _, m := range []string{"BREW", "", "get", "GETT", "PROPFIND"} {
+		if got := methodLabel(m); got != "other" {
+			t.Errorf("methodLabel(%q) = %q, want \"other\" — an unknown method must not become "+
+				"its own series", m, got)
+		}
+	}
+}


### PR DESCRIPTION
Fixes a live failure introduced by #2149, found by curling the endpoint on prod right after deploy.

## The failure

`/metrics` answered **500**, three errors over:

```
collected metric "freehire_http_requests_total"
  label:{name:"method" value:"GETT"}
  was collected before with the same name and label values
```

`GETT` is not a method. fasthttp backs `c.Method()` with the request buffer and **recycles that buffer between requests**, so the string the counter stored as a label value mutated under it — a fragment of a later request bleeding into an earlier label.

The consequence is worse than a wrong label: corrupted label sets collide with intact ones, so the whole endpoint fails. Not one bad series — **no metrics at all**, and a failing scrape.

## The fix

`methodLabel` maps onto package-level constants that share nothing with the request.

`utils.CopyString` would fix the aliasing too. Mapping is chosen because it also closes a hole I missed while designing #2149: **the method is client-supplied.** Passing it through unbounded lets any caller mint label values at will — the exact cardinality problem that refusing a route label was meant to avoid. Anything outside the set the API serves collapses to `other`.

## Tests

- One mutates the caller's bytes after the call and asserts the label did not follow — the regression itself.
- One asserts unknown methods (`BREW`, `get`, `GETT`, `PROPFIND`, empty) collapse to `other` rather than becoming their own series.

## Note on how this was found

`METRICS_PORT` turned out to be **already set** on prod, in the per-colour env (`api-blue.env` / `api-green.env`), along with firewall rules for 9091/9092 and a `hire-api` scrape job on the litellm-host Prometheus. I had reported it as unset after grepping only the shared `.env`. The infrastructure was ready; curling the endpoint is what surfaced this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP metrics reliability by ensuring method labels remain accurate after requests are processed.
  * Limited unsupported or invalid HTTP methods to a stable “other” category, preventing excessive metric label variation.
  * Preserved recognized methods such as GET, POST, and DELETE in monitoring data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->