### PR TITLE
Name the insights shell's prop `heading`, so the brand suffix leaves the <h1>

### DIFF
--- a/web/src/lib/components/InsightsPageShell.svelte
+++ b/web/src/lib/components/InsightsPageShell.svelte
@@ -17,11 +17,15 @@
     return resolve('/insights/roles/[category]', { category: cat });
   }
 
+  // `heading` is the page's <h1>, NOT its <title>. The distinction is the whole
+  // reason for the name: this prop was called `title`, every caller handed it the
+  // string it was already giving <Seo>, and the brand suffix that belongs in a tab
+  // label ("… · freehire") rendered inside the heading on every insights page.
   let {
     category,
     label,
     kind,
-    title,
+    heading,
     intro,
     updated,
     covered,
@@ -30,7 +34,7 @@
     category: string;
     label: string;
     kind: Kind;
-    title: string;
+    heading: string;
     intro: string;
     updated: string;
     covered: CoveredCategory[];
@@ -60,7 +64,7 @@
     <span class="text-foreground">{label} {KIND_LABEL[kind]}</span>
   </nav>
 
-  <h1 class="text-3xl font-bold tracking-tight text-foreground">{title}</h1>
+  <h1 class="text-3xl font-bold tracking-tight text-foreground">{heading}</h1>
   <p class="mt-3 text-lg text-muted-foreground">{intro}</p>
   <p class="mt-1 text-xs text-muted-foreground">Updated {updated}</p>
 

--- a/web/src/routes/insights/roles/[category]/+page.svelte
+++ b/web/src/routes/insights/roles/[category]/+page.svelte
@@ -11,7 +11,11 @@
 
   const origin = $derived(page.url.origin);
   const canonical = $derived(`${origin}/insights/roles/${data.category}`);
-  const title = $derived(`Most-Hiring ${data.label} Roles · freehire`);
+  // The heading is the page's own name; the title is that plus the brand suffix a
+  // browser tab and a SERP need. Kept apart deliberately — one variable serving both
+  // is how "· freehire" ended up inside the <h1>.
+  const heading = $derived(`Most-Hiring ${data.label} Roles`);
+  const title = $derived(`${heading} · freehire`);
   const updated = $derived(
     new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }),
   );
@@ -37,7 +41,7 @@
   category={data.category}
   label={data.label}
   kind="roles"
-  {title}
+  {heading}
   intro={data.intro}
   {updated}
   covered={data.covered}

--- a/web/src/routes/insights/salary/[category]/+page.svelte
+++ b/web/src/routes/insights/salary/[category]/+page.svelte
@@ -11,7 +11,11 @@
 
   const origin = $derived(page.url.origin);
   const canonical = $derived(`${origin}/insights/salary/${data.category}`);
-  const title = $derived(`${data.label} Salaries · freehire`);
+  // The heading is the page's own name; the title is that plus the brand suffix a
+  // browser tab and a SERP need. Kept apart deliberately — one variable serving both
+  // is how "· freehire" ended up inside the <h1>.
+  const heading = $derived(`${data.label} Salaries`);
+  const title = $derived(`${heading} · freehire`);
   const updated = $derived(
     new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }),
   );
@@ -37,7 +41,7 @@
   category={data.category}
   label={data.label}
   kind="salary"
-  {title}
+  {heading}
   intro={data.intro}
   {updated}
   covered={data.covered}

--- a/web/src/routes/insights/skills/[category]/+page.svelte
+++ b/web/src/routes/insights/skills/[category]/+page.svelte
@@ -10,7 +10,11 @@
 
   const origin = $derived(page.url.origin);
   const canonical = $derived(`${origin}/insights/skills/${data.category}`);
-  const title = $derived(`Most In-Demand ${data.label} Skills · freehire`);
+  // The heading is the page's own name; the title is that plus the brand suffix a
+  // browser tab and a SERP need. Kept apart deliberately — one variable serving both
+  // is how "· freehire" ended up inside the <h1>.
+  const heading = $derived(`Most In-Demand ${data.label} Skills`);
+  const title = $derived(`${heading} · freehire`);
   const updated = $derived(
     new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }),
   );
@@ -36,7 +40,7 @@
   category={data.category}
   label={data.label}
   kind="skills"
-  {title}
+  {heading}
   intro={data.intro}
   {updated}
   covered={data.covered}


### PR DESCRIPTION
## The defect

`InsightsPageShell` took a prop called `title` and rendered it as the page's `<h1>`. Every caller passed the same string it was already handing `<Seo>`, so a suffix that belongs in a browser tab and a SERP line was the last two words of the heading on all ~105 insights pages:

```html
<h1>Software Engineering Salaries · freehire</h1>
<h1>Most In-Demand Sales Skills · freehire</h1>
<h1>Most-Hiring Management Roles · freehire</h1>
```

The prop name is the whole cause: `title` invited exactly the string it got.

## The fix

The prop is now `heading` — what it always rendered — and each route derives the two separately. Naming them apart is what stops one being reused as the other again.

| | before | after |
|---|---|---|
| `<h1>` | `Software Engineering Salaries · freehire` | `Software Engineering Salaries` |
| `<title>` | `Software Engineering Salaries · freehire` | unchanged |

`/insights` and `/insights/companies` were already correct — they build their `<h1>` from a literal rather than going through the shell, which is why the bug stopped at the three `[category]` routes.

## Scope note

An earlier revision of this branch also reused `heading` for the breadcrumb's last item, to remove a third copy of the string. That silently rewrote the crumb on two of the three routes — `Sales Skills` → `Most In-Demand Sales Skills` — which is a worse breadcrumb (they are meant to be short) and was not part of the defect. Reverted; breadcrumb text is byte-identical to before this PR.

## Verification

Rendered all three routes against the production API (`VITE_API_URL=https://freehire.me`):

```
H1='Software Engineering Salaries'   title='… · freehire'  crumb=[freehire, Insights, Software Engineering Salaries]
H1='Most In-Demand Sales Skills'     title='… · freehire'  crumb=[freehire, Insights, Sales Skills]
H1='Most-Hiring Management Roles'    title='… · freehire'  crumb=[freehire, Insights, Management Roles]
```

```
vitest        100 files, 1091 tests — passed
svelte-check  10063 files, 0 errors (31 warnings — pre-existing baseline)
eslint        clean
vite build    ✔ done
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved Insights page presentation by separating visible headings from browser and search-result titles.
  * Insights pages now display clean, readable headings while retaining branded titles for SEO metadata.
  * Updated role, salary, and skills Insights pages consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->