### PR TITLE
feat(sources): onboard contributed boards

### DIFF
--- a/sources/manatal.yml
+++ b/sources/manatal.yml
@@ -1421,3 +1421,5 @@
   board: yeah-global
 - company: Zoom Recruitment Services Ltd
   board: zoom-recruitment
+- company: Toplent
+  board: toplent

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -4173,3 +4173,5 @@
   board: tcschoolhome.teamtailor.com
 - company: Y STRATEGIE
   board: ystrategie.teamtailor.com
+- company: Bonapolia
+  board: jobs.bonapolia.com


### PR DESCRIPTION
# Board contributions — 2026-08-20

## Onboarded

| Source | Board | Company | Validation |
|---|---|---|---|
| teamtailor | `jobs.bonapolia.com` | Bonapolia | GET https://jobs.bonapolia.com/jobs → HTTP 200; JSON feed at `/jobs.json` returns 18 active jobs; `og:site_name = "Bonapolia"` |
| manatal | `toplent` | Toplent | GET https://open.api.manatal.com/open/v3/career-page/toplent/jobs/ → HTTP 200; `count=50` active postings |

## Rejected

| ID | Source | Board | Reason |
|---|---|---|---|
| 289 | ashby | `crucibl` | POST https://api.ashbyhq.com/posting-api/job-board/crucibl → HTTP 401 "Unauthorized". Board is private or gated — not a public job board. |
| 291 | workday | `zuehlke.wd3.myworkdayjobs.com/Zuhlke-Careers` | Board is already onboarded as `zuehlke.wd3.myworkdayjobs.com/zuhlke-careers` (line 10076–10077 of `sources/workday.yml`). Both case variants return identical results (39 jobs). Adding the contributed variant would double-crawl the same board under two IDs. |
| 300 | phenom | `ejta.fa.us6.oraclecloud.com` | POST https://ejta.fa.us6.oraclecloud.com/widgets → HTTP 404. URL is an Oracle HCM Cloud application-form deep-link, not a Phenom People career site. |
| 314 | ashby | `outpost-red` | POST https://api.ashbyhq.com/posting-api/job-board/outpost-red → HTTP 401 "Unauthorized". Board is private or gated — not a public job board. |

## Unresolved links (queue_review — need a human)

These contributed URLs were not recognized as a known ATS board by the pipeline and could not be automatically matched to a source adapter. Each needs manual inspection to determine whether there is an existing adapter that covers it, a new adapter to write, or whether to reject it entirely.

| ID | URL | Notes |
|---|---|---|
| 288 | https://www.anticipy.ai/grow | Company careers page — no recognized ATS. Possibly custom or unsupported platform. |
| 290 | https://sunbit.com/careers | Company careers page — no recognized ATS detected. |
| 292 | https://topazbrasil.gupy.io/job/eyJqb2JJZCI6MTExNTMyNjEsInNvdXJjZSI6ImxpbmtlZGluIn0= | Gupy (Brazilian ATS) single-job link with Base64 job ID; `topazbrasil` may be an existing or new Gupy board — needs Gupy adapter check. |
| 293 | https://jobsearch.createyourowncareer.com/Riverty/job/... | `createyourowncareer.com` — not a recognized source. May be a white-label ATS. |
| 296 | https://it.corporate.trustpilot.com/careers | Custom Trustpilot careers page — no recognized ATS path. |
| 297 | https://github.com/strelov1/freehire/pulls | GitHub pull request URL — not a job board. Spam/mistake. |
| 298 | https://himalayas.app/companies/fortive/jobs/software-engineering | Himalayas aggregator — already covered by the `himalayas` source if Fortive is listed there; otherwise a company-specific check is needed. |
| 299 | https://fortive.eightfold.ai/careers | Eightfold AI board for Fortive — check if `fortive` is in `sources/eightfold.yml`. |
| 302 | https://www.weareroku.com/jobs/... | Roku careers page — no recognized ATS subdomain pattern; may be Greenhouse or Workday behind the custom domain. |
| 304 | https://jobs.dayforcehcm.com/en-US/bav/CANDIDATEPORTAL/jobs/11122 | Dayforce HCM (Ceridian) — no source adapter currently exists for this platform. |
| 305 | https://dressup.selfrecruit.ge/a7cdcc00-... | `selfrecruit.ge` — Georgian ATS, no adapter. Single-job link. |
| 306 | https://en-sa.whatjobs.com/jobs/machine-learning-engineer | whatjobs Saudi Arabia — check `sources/whatjobs-sa.yml`; this is an aggregator listing, not a direct board contribution. |
| 307 | https://uncovered-cell-d0c.notion.site/fd447255... | Notion page — not a job board. Spam/mistake. |
| 308 | https://jobs.polymer.co/voiceops/40085 | Polymer (jobs.polymer.co) — not a recognized source adapter. Single-job URL. |
| 309 | https://app.onstrider.com/r/nicolebarra | Onstrider recruiter profile — not a company job board. |
| 310 | https://www.onstrider.com/jobs/product-engineer-8f02097f | Onstrider job listing — `onstrider` source exists (`sources/onstrider.yml`); single-job URL but the board slug is not visible here. |
| 311 | https://infusionbillingservices.com/contact | Contact page — not a job board. Spam/mistake. |
| 312 | https://moniepoint.com/careers | Moniepoint careers — no recognized ATS subdomain; may be Greenhouse or Workday. |
| 313 | https://careers.americanexpress.com/en/sites/CX_1/job/26012235 | American Express — Oracle HCM Cloud (`fa.us*.oraclecloud.com` pattern behind custom domain). Needs oracle source check. |

## SQL to sync the queue

```sql
-- Boards successfully onboarded into sources/
UPDATE link_contributions SET status = 'onboarded' WHERE id IN (303, 315);

-- Boards rejected (dead, private, duplicate, or wrong platform)
UPDATE link_contributions SET status = 'rejected' WHERE id IN (289, 291, 300, 314);
```

---

onboarded=2 rejected=4 skipped=0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Toplent career board to the available job sources.
  * Added Bonapolia’s career board at jobs.bonapolia.com.
  * Job listings from both boards are now available through the platform’s search and browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->