### PR TITLE
feat(sources): onboard contributed boards

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -8196,3 +8196,7 @@
   board: marble.ai
 - company: Prolego
   board: prolego
+- company: Crucibl
+  board: crucibl
+- company: Outpost
+  board: outpost-red


### PR DESCRIPTION
# Board contributions drain — 2026-08-20

## Onboarded boards

| Source | Board | Company | Validation |
|---|---|---|---|
| ashby | `crucibl` | Crucibl | GET `/posting-api/job-board/crucibl?includeCompensation=true` → 200 with jobs; company name from page title |
| ashby | `outpost-red` | Outpost | GET `/posting-api/job-board/outpost-red?includeCompensation=true` → 200 with jobs; company name from job description ("About Outpost") |

## Turned down

| ID | Source | Board | Reason |
|---|---|---|---|
| 300 | phenom | `ejta.fa.us6.oraclecloud.com` | URL is Oracle Fusion HCM (`fa.us6.oraclecloud.com` host), not a Phenom People site. POST to `/widgets` returned 404. The oracle board `ejta.fa.us6.oraclecloud.com/CX_2001` may be valid but requires a fresh contribution under the correct source. |
| 291 | workday | `zuehlke.wd3.myworkdayjobs.com/Zuhlke-Careers` | Exact board already present as `zuehlke.wd3.myworkdayjobs.com/zuhlke-careers` (lowercase path). Workday site case is significant for the `external_id` dedup key — adding the uppercase variant would create a second dedup namespace and silently double-crawl the same board. Skipped; the board is already being ingested. |

## queue_review.tsv — needs human

These links arrived unrecognized; they need a human to confirm the source, extract the board ID, and re-submit via the contribution flow.

| ID | URL | Notes |
|---|---|---|
| 288 | https://www.anticipy.ai/grow | Startup hiring page — ATS behind it unidentified |
| 290 | https://sunbit.com/careers | Corporate careers page — ATS behind it unidentified |
| 292 | https://topazbrasil.gupy.io/job/eyJqb2JJZCI6MTExNTMyNjEsInNvdXJjZSI6ImxpbmtlZGluIn0= | Gupy board. We crawl Gupy; board ID is a numeric `companyId` from the page's `__NEXT_DATA__`, not the subdomain. A human can extract it and re-contribute as `gupy / <companyId>`. |
| 293 | https://jobsearch.createyourowncareer.com/Riverty/... | CreateYourOwnCareer platform — not a recognised source |
| 296 | https://it.corporate.trustpilot.com/careers | Corporate careers page — ATS behind it unidentified |
| 297 | https://github.com/strelov1/freehire/pulls | GitHub PR page — not a job board; noise |
| 298 | https://himalayas.app/companies/fortive/jobs/software-engineering | Himalayas.app aggregator listing — not a direct ATS board |
| 299 | https://fortive.eightfold.ai/careers | Eightfold ATS — we crawl Eightfold but Fortive is not yet in `eightfold.yml`. Board format: `fortive.eightfold.ai/<domain>`. Needs live validation and domain confirmation before adding. |
| 302 | https://www.weareroku.com/jobs/senior-machine-learning-engineer-content-platform-bengaluru-karnataka-india | Roku careers page — ATS behind it unidentified |
| 304 | https://jobs.dayforcehcm.com/en-US/bav/CANDIDATEPORTAL/jobs/11122 | Dayforce HCM — no Dayforce source in the registry |
| 305 | https://dressup.selfrecruit.ge/a7cdcc00-1c9c-464c-8960-945af0c0e0a4 | selfrecruit.ge (Georgian ATS) — not a recognised source |
| 306 | https://en-sa.whatjobs.com/jobs/machine-learning-engineer | WhatJobs Saudi Arabia — already crawled by `whatjobs-sa` source; no action needed |
| 307 | https://uncovered-cell-d0c.notion.site/fd447255316e82648b1701d63190deed | Notion page — not a job board; noise |
| 308 | https://jobs.polymer.co/voiceops/40085 | Polymer.co jobs platform — not a recognised source |
| 309 | https://app.onstrider.com/r/nicolebarra | Strider user profile — `onstrider` is a boardless source already in the registry; this individual posting is already in scope |
| 310 | https://www.onstrider.com/jobs/product-engineer-8f02097f | Strider job listing — same as above, already covered by the boardless `onstrider` source |
| 311 | https://infusionbillingservices.com/contact | Contact page — not a job board; noise |
| 312 | https://moniepoint.com/careers | Corporate careers page — ATS behind it unidentified |
| 313 | https://careers.americanexpress.com/en/sites/CX_1/job/26012235 | American Express — already crawled via oracle source (`egug.fa.us2.oraclecloud.com/CX_1`); no action needed |

## SQL

```sql
-- Boards onboarded (added to sources/ or confirmed already present and being crawled)
UPDATE link_contributions SET status = 'onboarded' WHERE id IN (289, 291, 314);

-- Boards rejected (invalid source classification or dead endpoint)
UPDATE link_contributions SET status = 'rejected' WHERE id IN (300);
```

---

onboarded=2 rejected=1 skipped=1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Crucibl and its job board to the Ashby source list.
  * Added an additional Outpost job board entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->