### PR TITLE
fix(sources): restore the line breaks a double-escaping feed shows as text

### DIFF
--- a/cmd/backfill-descriptions/main.go
+++ b/cmd/backfill-descriptions/main.go
@@ -79,6 +79,11 @@ const (
 	percentEncodedMarker = "%3C"
 	entityEncodedMarker  = "&lt;"
 	anchorMarker         = "<a"
+	// literalNewlineMarker is the fourth signature: a backslash followed by an "n", left by an
+	// aggregator that escaped its JSON twice (whatjobs markets and adzuna, which resell through
+	// the same upstream network). Unlike the encodings this needs no decoder of its own — the
+	// sanitizer repairs it — so the marker only has to select the row.
+	literalNewlineMarker = `\n`
 )
 
 // himalayasSource is the one provider whose stored bodies carry the aggregator's own branding
@@ -198,6 +203,12 @@ func backfillPause() time.Duration {
 // outweighing live markup (see sources.UnescapeEncodedHTML), which is what leaves a posting that
 // merely writes "&lt;" as a less-than sign alone.
 //
+// A stored literal "\n" sends the body through the sanitizer for the same reason as an anchor:
+// the repair lives there (see internal/sources.repairLiteralNewlines), not in a decoder here,
+// because deciding what an escape meant needs the markup around it. The marker is narrow enough
+// to select almost nothing — 15 rows in a 20k-row sample of the live catalogue — so it does not
+// widen the universal sweep in any meaningful way.
+//
 // A stored anchor also sends the body through the sanitizer, whatever its source: descriptions
 // carry no links any more (see internal/sources.sanitizeHTML), and the rows stored before that
 // rule can only be brought in line by re-running it. Unlike the decodes this path does lean on
@@ -218,7 +229,7 @@ func repairDescription(source, stored string) string {
 		decoded = sources.UnescapeEncodedHTML(decoded)
 	}
 	repaired := stored
-	if decoded != stored || strings.Contains(decoded, anchorMarker) {
+	if decoded != stored || strings.Contains(decoded, anchorMarker) || strings.Contains(decoded, literalNewlineMarker) {
 		repaired = sources.SanitizeHTML(decoded)
 	}
 	if source == himalayasSource {

--- a/internal/sources/sanitize.go
+++ b/internal/sources/sanitize.go
@@ -56,15 +56,61 @@ func newDescriptionPolicy() *bluemonday.Policy {
 //
 // Self-labelled anchors are dropped BEFORE the policy runs, because that is the only point
 // at which an anchor's text can still be compared against its own destination — the policy
-// unwraps the tag and the two become indistinguishable from prose.
+// unwraps the tag and the two become indistinguishable from prose. The literal-newline repair
+// runs first for the same reason: it reads the markup around each escape to decide what the
+// escape meant, and it may emit a <br> the policy must then vet like any other tag.
 func sanitizeHTML(s string) string {
-	stripped, dropped := dropSelfLabelledAnchors(s)
+	stripped, dropped := dropSelfLabelledAnchors(repairLiteralNewlines(s))
 	out := noBreakSpaces.Replace(descriptionPolicy.Sanitize(stripped))
 	if dropped {
 		// Only a drop can empty a block, so a body with nothing stripped is never rewritten.
 		out = dropEmptyBlocks(out)
 	}
 	return wrapOrphanListItems(out)
+}
+
+// literalNewlineMarker is the two-character sequence a double-escaping feed leaves behind:
+// its JSON holds "\\n", so the decoded value carries a backslash followed by an "n" instead
+// of the line break the source HTML had.
+const literalNewlineMarker = `\n`
+
+var (
+	// tagAdjacentLiteralNewline matches a literal newline escape that sits against a tag on
+	// either side, whitespace allowed in between. That is the source file's own indentation,
+	// which HTML collapses — so the escape stands in for whitespace and nothing more. The two
+	// sides are one alternation rather than two passes so that an escape between two tags
+	// ("</p>\n<p>") is rewritten once instead of matching twice.
+	tagAdjacentLiteralNewline = regexp.MustCompile(`(>\s*)\\n|\\n(\s*<)`)
+	// looseLiteralNewline matches whatever escapes the tag-adjacent pass left: an escape with
+	// prose on both sides, where it is the posting's ONLY line break.
+	looseLiteralNewline = regexp.MustCompile(`\\n`)
+)
+
+// repairLiteralNewlines restores the line breaks a double-escaping feed turned into visible
+// text. Some aggregators (seen live on whatjobs markets and adzuna, which resell through the
+// same upstream network) escape their JSON twice, so a description reaches the catalogue with
+// literal "\n" sequences the reader sees mid-sentence.
+//
+// What an escape MEANT depends on where it sits, so the repair is not one replacement:
+//
+//   - Against a tag it is indentation between blocks ("</p>\n<p>", "<ul>\n <li>"). It becomes a
+//     real newline, which HTML collapses exactly as the original did. Emitting a <br> here would
+//     add a blank line between every paragraph, and inside a list it would be markup a browser
+//     hoists out of the <ul> altogether.
+//   - Between two sentences it is the only break the posting has ("~ Kita-Zuschuss \n~ Weihnachtsgeld").
+//     A real newline would collapse and glue the lines together, so it becomes a <br>.
+//
+// Measured over a 20k-row sample of the live catalogue, 578 of 605 escapes were the first kind.
+//
+// A posting that deliberately shows "\n" as a code escape would be rewritten too. Nothing in the
+// sample did, and such a sample would live inside <code>/<pre> — the seam to exempt those is the
+// tree walk wrapOrphanListItems already does, if a real case ever turns up.
+func repairLiteralNewlines(s string) string {
+	if !strings.Contains(s, literalNewlineMarker) {
+		return s
+	}
+	s = tagAdjacentLiteralNewline.ReplaceAllString(s, "${1}\n${2}")
+	return looseLiteralNewline.ReplaceAllString(s, "<br>")
 }
 
 // wrapOrphanListItems wraps each maximal run of <li> siblings that lacks a <ul>/<ol>

--- a/internal/sources/sanitize_test.go
+++ b/internal/sources/sanitize_test.go
@@ -174,6 +174,54 @@ func TestSanitizeHTMLWrapsOrphanListItemsIsIdempotent(t *testing.T) {
 	}
 }
 
+// Some aggregator feeds double-escape the newlines in their JSON, so the decoded description
+// carries the two characters "\" and "n" where the source HTML had a line break — visible to
+// the reader as literal "\n" in the middle of the prose (seen live on whatjobs and adzuna
+// postings resold through the same upstream network). What the escape MEANT depends on where
+// it sits, which is why the repair is not a single replacement: next to a tag it is the source
+// file's indentation and collapses like any other whitespace, while between two sentences it
+// is the only line break the posting has and must survive as a <br>.
+func TestSanitizeHTMLRepairsLiteralNewlines(t *testing.T) {
+	cases := map[string]struct{ in, want string }{
+		"indentation between blocks collapses": {
+			`<p>Company Description</p>\n<p>We are hiring.</p>`,
+			"<p>Company Description</p>\n<p>We are hiring.</p>",
+		},
+		"indentation before a list item collapses": {
+			`<ul>\n <li>Go</li>\n <li>SQL</li>\n</ul>`,
+			"<ul>\n <li>Go</li>\n <li>SQL</li>\n</ul>",
+		},
+		"escape between bare text and a tag collapses": {
+			`<p>Was du bewegst\n<p>Deine Aufgaben</p>`,
+			"<p>Was du bewegst\n<p>Deine Aufgaben</p>",
+		},
+		"escape between two sentences becomes a break": {
+			`<p>~ Kita-Zuschuss \n~ Weihnachtsgeld</p>`,
+			`<p>~ Kita-Zuschuss <br>~ Weihnachtsgeld</p>`,
+		},
+		"body with no escape is untouched": {
+			`<p>Ship features</p>`,
+			`<p>Ship features</p>`,
+		},
+	}
+	for name, c := range cases {
+		if got := sanitizeHTML(c.in); got != c.want {
+			t.Errorf("%s: sanitizeHTML(%q) = %q, want %q", name, c.in, got, c.want)
+		}
+	}
+}
+
+// The backfill re-runs this pipeline over already-repaired rows, so a body that carries no
+// escape any more must come back byte-for-byte — otherwise every run would rewrite the same
+// rows and each rewrite is a TOAST write.
+func TestSanitizeHTMLRepairsLiteralNewlinesIsIdempotent(t *testing.T) {
+	in := `<p>~ Kita-Zuschuss \n~ Weihnachtsgeld</p>\n<p>Bewirb dich.</p>`
+	once := sanitizeHTML(in)
+	if twice := sanitizeHTML(once); twice != once {
+		t.Errorf("sanitizeHTML is not idempotent:\nonce:  %q\ntwice: %q", once, twice)
+	}
+}
+
 func TestLenientPercentUnescape(t *testing.T) {
 	cases := map[string]struct{ in, want string }{
 		"plain":              {"hello world", "hello world"},


### PR DESCRIPTION
Some aggregator feeds escape their JSON twice, so a decoded description carries the two characters `\` and `n` where the source HTML had a line break. Nothing in the pipeline created or removed them, so they reached the reader as a literal `\n` in the middle of the prose — [seen live](https://freehire.me/jobs/business-systems-software-developer-bet365-mwb6xlts) on whatjobs markets and adzuna, which resell through the same upstream network.

## The repair is not one replacement

What an escape meant depends on where it sits:

| Where it sits | Becomes | Why |
|---|---|---|
| against a tag (`</p>\n<p>`, `<ul>\n <li>`) | a real newline | it is the source file's indentation, which HTML collapses exactly as the original did. A `<br>` here adds a blank line between every paragraph, and inside a list it is markup a browser hoists out of the `<ul>` altogether |
| between two sentences (`~ Kita-Zuschuss \n~ Weihnachtsgeld`) | `<br>` | it is the only break the posting has; a real newline would collapse and glue the lines together |

Measured over a 20k-row sample of the live catalogue, **578 of 605** escapes were the first kind, and `\n` was the only escape shape present at all (no `\r`, `\t`, or `\\`).

## Where it lives

In `sanitizeHTML`, not in one adapter: the cause is upstream of any single provider, and both affected sources are aggregators reselling the same bodies. It runs before the policy, since it reads the markup around each escape to decide what the escape meant and may emit a `<br>` the policy must then vet.

`backfill-descriptions` gains the escape as a fourth marker, so rows already stored can be brought in line without a re-ingest. It needs no decoder of its own — the decision needs surrounding markup, which only exists inside the sanitizer. The marker selects almost nothing (15 rows in the 20k sample), so it does not meaningfully widen the universal sweep.

## Verification

- New table-driven tests cover both branches plus idempotency (the backfill re-runs this pipeline, and each rewrite is a TOAST write).
- Both branches checked against real prod bodies: the bet365 posting's escapes became newlines; a `whatjobs-de` posting's benefits list produced 10 `<br>`, 0 escapes left.
- `gofmt`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...` all clean. (`internal/normalize` fails identically on a clean tree — its module walk picks up stale worktree directories on disk; unrelated.)

## Rollout

Fix only. No prod backfill: the universal sweep would rewrite millions of TOAST rows for ~15 affected ones. If it ever matters, scope it per market (`backfill-descriptions whatjobs-de`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected descriptions containing literal `\n` characters so they render with proper line breaks.
  * Improved formatting around HTML tags and list content by preserving appropriate spacing and indentation.
  * Ensured prose line breaks display consistently as readable breaks.
  * Prevented repeated processing from altering already-corrected descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->