### PR TITLE
Give experience its own filter pane, with a years ceiling

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -136,6 +136,7 @@ Every facet below supports repeat-OR, `_mode=and`, and `_exclude` as described a
 | `salary_min` | Minimum salary | integer — jobs whose minimum salary is at least this (pair with salary_currency) |
 | `salary_max` | Maximum salary | integer — jobs whose maximum salary is at most this (pair with salary_currency) |
 | `experience_years_min` | Minimum experience | integer — jobs requiring at least this many years |
+| `experience_years_max` | Maximum experience | integer — jobs requiring at most this many years, the same figure experience_years_min bounds from below. Use 0 for jobs stating no prior experience is required. Either bound excludes jobs that state no requirement at all |
 | `posted_within_days` | Posted within | integer — jobs whose effective posting date falls in the last N days |
 
 ### Recipes

--- a/internal/jobfacts/jobfacts.go
+++ b/internal/jobfacts/jobfacts.go
@@ -135,13 +135,51 @@ var (
 	rePlainYears = regexp.MustCompile(`\b(\d{1,2})\s*\+?\s*(?:years?|yrs?)`)
 )
 
+// reNoExperience matches an explicit statement that the ROLE needs no prior
+// experience. The requirement word must follow the noun with at most a copula
+// between, because the same words scoped to an object say the opposite thing about
+// the job: "no prior experience WITH Kubernetes is required" makes the tool
+// optional while the role may still want a decade.
+var reNoExperience = regexp.MustCompile(`\bno\s+(?:prior\s+|previous\s+)?experience\s+(?:is\s+)?(?:required|necessary|needed)\b`)
+
+// reScopedToObject rejects a match whose object TRAILS the requirement word
+// instead of leading it — "no prior experience is required WITH our CRM" scopes
+// the statement exactly as "…with our CRM is required" does, and guarding only one
+// word order let the other through. Go's regexp is RE2 and has no lookahead, so
+// the tail is tested separately rather than folded into the pattern above.
+//
+// A trailing "for" is deliberately absent: "no experience necessary FOR this
+// position" is the ordinary entry-level phrasing, where the object is the role
+// itself rather than a tool.
+var reScopedToObject = regexp.MustCompile(`^\s*(?:with|in|using)\b`)
+
+// statesNoExperience reports whether the description carries an unscoped
+// no-experience statement. A description may carry both — a scoped mention and a
+// plain one — so every match is examined and one clean statement is enough.
+func statesNoExperience(s string) bool {
+	for _, loc := range reNoExperience.FindAllStringIndex(s, -1) {
+		if !reScopedToObject.MatchString(s[loc[1]:]) {
+			return true
+		}
+	}
+	return false
+}
+
 // ExperienceYearsMin extracts the minimum required years of experience from the
 // description, or nil when none is stated. It takes the smallest year figure
 // mentioned next to a year word (the conservative floor) and ignores age phrases
-// and out-of-range numbers.
+// and out-of-range numbers. An explicit "no prior experience required" resolves
+// to 0 — the entry-level population states its requirement in prose rather than
+// as a figure, and reading digits alone left it indistinguishable from silence.
 func ExperienceYearsMin(description string) *int {
 	s := ageNoise.ReplaceAllString(strings.ToLower(description), " ")
 	best := -1
+	// Zero is the smallest value the walk below can reach, so seeding it also settles
+	// precedence: an explicit statement outranks any figure mentioned elsewhere, which
+	// is the conservative floor already in force between competing figures.
+	if statesNoExperience(s) {
+		best = 0
+	}
 	consider := func(re *regexp.Regexp) {
 		for _, m := range re.FindAllStringSubmatch(s, -1) {
 			n, err := strconv.Atoi(m[1])

--- a/internal/jobfacts/jobfacts_test.go
+++ b/internal/jobfacts/jobfacts_test.go
@@ -86,7 +86,33 @@ func TestExperienceYearsMin(t *testing.T) {
 		{"yrs abbrev", "10 yrs experience.", ptr(10)},
 		{"min across mentions", "5 years of Go and 2 years of Kubernetes.", ptr(2)},
 		{"age ignored", "Must be 18 years of age. 4+ years experience.", ptr(4)},
-		{"hyperbole capped out", "100 years of fun, no experience needed.", nil},
+		{"hyperbole capped out", "100 years of fun awaits you.", nil},
+
+		// An entry-level posting states the requirement in prose, not as a figure.
+		// Reading only digits left that population indistinguishable from a posting
+		// that says nothing at all, so the filter could not reach it.
+		{"no experience required", "No prior experience required — we will train you.", ptr(0)},
+		{"no experience necessary", "No experience necessary. Full training provided.", ptr(0)},
+		{"no previous experience needed", "No previous experience needed for this role.", ptr(0)},
+		{"copula between", "No prior experience is required for this position.", ptr(0)},
+		{"zero wins the floor", "No prior experience required. 3 years with Go is a plus.", ptr(0)},
+		{"hyperbole with explicit no-experience", "100 years of fun, no experience needed.", ptr(0)},
+
+		// The phrase is about a TOOL, not the job: "no prior experience with X is
+		// required" means X is optional. Requiring the statement to close without an
+		// object in between is what keeps this out.
+		{"tool-scoped is not entry level", "No prior experience with Kubernetes is required, but 5 years of backend is.", ptr(5)},
+		{"domain-scoped is not entry level", "No previous experience in fintech required; 4+ years engineering expected.", ptr(4)},
+
+		// The object can also TRAIL the requirement word, which reads the same way:
+		// the tool is optional, the role is not. Guarding only the leading order
+		// caught one word order and waved the other through.
+		{"trailing tool scope", "No prior experience is required with our proprietary CRM. The role needs 5+ years of enterprise sales.", ptr(5)},
+		{"trailing domain scope", "No experience required in Kubernetes, but 4 years of backend is expected.", ptr(4)},
+
+		// A trailing "for <the role>" is the ordinary entry-level phrasing, not a
+		// scoping object, so it must survive the guard above.
+		{"trailing role reference still entry level", "No experience necessary for this position.", ptr(0)},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/search/query_filter.go
+++ b/internal/search/query_filter.go
@@ -147,7 +147,10 @@ func filterFromValues(v url.Values, now time.Time) any {
 	if n, ok := atoiOK(v.Get("experience_years_min")); ok {
 		groups = append(groups, []string{Gte("enrichment.experience_years_min", n)})
 	}
-	if n, ok := atoiOK(v.Get("experience_years_max")); ok {
+	// n >= 0 because a negative ceiling can only match nothing — the attribute is
+	// never below zero — so it is a typo, and honouring it would render an empty
+	// page that looks like a legitimately narrow search rather than a bad param.
+	if n, ok := atoiOK(v.Get("experience_years_max")); ok && n >= 0 {
 		groups = append(groups, []string{Lte("enrichment.experience_years_min", n)})
 	}
 

--- a/internal/search/query_filter.go
+++ b/internal/search/query_filter.go
@@ -139,8 +139,16 @@ func filterFromValues(v url.Values, now time.Time) any {
 	if n, ok := atoiOK(v.Get("salary_max")); ok {
 		groups = append(groups, []string{Lte("enrichment.salary_max", n)})
 	}
+	// Both experience bounds read the SAME attribute: `enrichment.experience_years_min`
+	// is what the posting asks for, so these are a floor and a ceiling on that one ask,
+	// not a min/max pair over two fields. Meili compares only documents carrying the
+	// attribute, so either bound drops the postings that state no requirement — the
+	// honest reading of "asks for at most N years".
 	if n, ok := atoiOK(v.Get("experience_years_min")); ok {
 		groups = append(groups, []string{Gte("enrichment.experience_years_min", n)})
+	}
+	if n, ok := atoiOK(v.Get("experience_years_max")); ok {
+		groups = append(groups, []string{Lte("enrichment.experience_years_min", n)})
 	}
 
 	// Freshness: posted_within_days=N restricts to jobs posted in the last N days,

--- a/internal/search/query_filter_test.go
+++ b/internal/search/query_filter_test.go
@@ -167,6 +167,45 @@ func TestFilterFromValues_VisaBoolAndNumeric(t *testing.T) {
 	}
 }
 
+func TestFilterFromValues_ExperienceYearsMax(t *testing.T) {
+	got := normalizeGroups(t, FilterFromValues(vals("experience_years_max=3")))
+	want := [][]string{{`enrichment.experience_years_min <= 3`}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestFilterFromValues_ExperienceYearsClosedRange(t *testing.T) {
+	got := normalizeGroups(t, FilterFromValues(vals("experience_years_min=2&experience_years_max=5")))
+	want := [][]string{
+		{`enrichment.experience_years_min <= 5`},
+		{`enrichment.experience_years_min >= 2`},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// Zero is the entry-level selector, not an absent value: `experience_years_max=0`
+// asks for the postings that state no prior experience is required. A guard that
+// treats the bound as falsy would silently drop the one filter juniors need.
+func TestFilterFromValues_ExperienceYearsMaxZero(t *testing.T) {
+	got := normalizeGroups(t, FilterFromValues(vals("experience_years_max=0")))
+	want := [][]string{{`enrichment.experience_years_min <= 0`}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestFilterFromValues_ExperienceYearsMaxUnparseable(t *testing.T) {
+	for _, raw := range []string{"", "abc", "3.5"} {
+		got := normalizeGroups(t, FilterFromValues(vals("experience_years_max="+raw)))
+		if len(got) != 0 {
+			t.Errorf("experience_years_max=%q: got %v, want no filter group", raw, got)
+		}
+	}
+}
+
 func TestFilterFromValues_RegionUnspecifiedSentinel(t *testing.T) {
 	// The reserved `regions=none` value selects jobs with no resolved geography
 	// via Meili's IS EMPTY, not an equality against a literal "none" region.

--- a/internal/search/query_filter_test.go
+++ b/internal/search/query_filter_test.go
@@ -197,6 +197,19 @@ func TestFilterFromValues_ExperienceYearsMaxZero(t *testing.T) {
 	}
 }
 
+// A negative ceiling can only match nothing — `enrichment.experience_years_min` is
+// never below zero — so it is a typo, not a query. The contract declares the param
+// non-negative; honouring the sign would turn that typo into an empty result page
+// that looks like a legitimately narrow search.
+func TestFilterFromValues_ExperienceYearsMaxNegative(t *testing.T) {
+	for _, raw := range []string{"-1", "-10"} {
+		got := normalizeGroups(t, FilterFromValues(vals("experience_years_max="+raw)))
+		if len(got) != 0 {
+			t.Errorf("experience_years_max=%q: got %v, want no filter group", raw, got)
+		}
+	}
+}
+
 func TestFilterFromValues_ExperienceYearsMaxUnparseable(t *testing.T) {
 	for _, raw := range []string{"", "abc", "3.5"} {
 		got := normalizeGroups(t, FilterFromValues(vals("experience_years_max="+raw)))

--- a/internal/search/query_params.go
+++ b/internal/search/query_params.go
@@ -16,6 +16,7 @@ var scalarFilters = []string{
 	"salary_min",
 	"salary_max",
 	"experience_years_min",
+	"experience_years_max",
 	"posted_within_days",
 }
 

--- a/internal/search/query_params_test.go
+++ b/internal/search/query_params_test.go
@@ -35,6 +35,7 @@ func TestUnknownParams_AcceptsTheFilterVocabulary(t *testing.T) {
 		"salary_min":           {"1000"},
 		"salary_max":           {"9000"},
 		"experience_years_min": {"3"},
+		"experience_years_max": {"8"},
 		"posted_within_days":   {"7"},
 	}
 
@@ -75,6 +76,7 @@ func TestScalarFilters_EachOneStillNarrowsAQuery(t *testing.T) {
 		"salary_min":           "1000",
 		"salary_max":           "9000",
 		"experience_years_min": "3",
+		"experience_years_max": "8",
 		"posted_within_days":   "7",
 	}
 

--- a/openspec/changes/experience-filter-tab/.openspec.yaml
+++ b/openspec/changes/experience-filter-tab/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/experience-filter-tab/design.md
+++ b/openspec/changes/experience-filter-tab/design.md
@@ -1,0 +1,151 @@
+## Context
+
+The filter modal (`web/src/lib/components/filters/FilterModal.svelte`) renders a
+left rail of entries declared in `web/src/lib/filterSections.ts` as `RAIL`, each
+carrying a `RailKind` that selects which pane markup runs. Facet-shaped entries
+(`kind: 'facet'`) render a `FacetDef` from `web/src/lib/facets.ts`; the rest are
+bespoke panes with hand-written markup.
+
+Filter state is a `JobFilters` object (`web/src/lib/facetModel.ts`): a `q` string, a
+`Record<string, FacetState>` of the string-enum facets, and a handful of scalar
+fields — `visa`, `salaryMin`, `postedWithinDays` — each serialized to a URL param by
+`filtersToParams` and parsed back by `filtersFromParams`. Two stores wrap it: the
+live URL-synced `filters.ts` and the deferred `stagedFilters.svelte.ts` the modal
+edits.
+
+On the backend, `internal/search/query_params.go` allow-lists the query params the
+search accepts and `query_filter.go` turns them into Meilisearch filter groups.
+`enrichment.experience_years_min` is already a filterable attribute on the index and
+already has a floor filter; it has no ceiling.
+
+Production measurement on 1,349,667 searchable postings: 645,723 (48%) carry a stated
+experience requirement. Of those, 7,440 are `0`, 65,857 are `1`, 101,638 are `2`,
+165,177 are `3–4`, 201,055 are `5–7`, 36,358 are `8–9`, and 68,198 are `10+`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make experience a first-class pane in the filter rail, with seniority living there.
+- Let a candidate express "I have N years" and see what they can apply to.
+- Detect the prose form of "no prior experience required" so the entry-level
+  population is measurable instead of invisible.
+- Ship without a migration, a `cmd/backfill-derive` run, or a reindex.
+
+**Non-Goals:**
+- The `role_type` facet (Individual Contributor vs People Manager). Separate change.
+- A lower-bound years control in the UI. `experience_years_min` stays API-only; the
+  seniority pills already serve "not a junior posting" for the browsing case.
+- A dual-handle range slider. No such control exists in this codebase or in
+  `design-system/`, and nothing here needs one.
+- Adding a value to `vocab.SeniorityValues`. See the decision below.
+
+## Decisions
+
+### The years control is a preset-stop slider, not a raw-years slider
+
+The pane renders one `<input type="range">` whose `value` is an **index into a preset
+array**, exactly as the freshness control does (`FilterModal.svelte`, `kind: 'posted'`,
+driven by `FRESHNESS_PRESETS`). Stops: no-experience, 1, 2, 3, 5, 8, 10, Any.
+
+*Why:* the production distribution is heavily skewed — 5–7 years alone holds 201k
+postings while 8–9 holds 36k — so a linear 0–50 scale would spend most of its travel
+on a tail nobody filters into. Index-into-presets also makes the leftmost stop mean
+"no experience required" without a second control, and it reuses a native input, so
+there is no drag/touch/a11y work to write.
+
+*Alternatives considered.* A linear slider like `salaryMin`: simpler to read but
+mis-scaled against the data, and it cannot express "no experience" distinctly from
+"0 or more". A chip row of ranges: fits the surrounding UI but each chip would be a
+bespoke non-facet control fighting the include/exclude machinery `FacetDef` provides
+for string enums. A dual-handle range: matches the reference design, but means
+writing a slider component for a lower bound this change has no demand for.
+
+### "No prior experience" is a value of the existing column, not a new seniority value
+
+The detector writes `0` into the existing `jobs.experience_years_min`. It does **not**
+add a `no_experience` member to `vocab.SeniorityValues`.
+
+*Why:* `SeniorityValues` is the closed vocabulary shared by the enrichment contract,
+the LLM prompt schema, `internal/classify`'s title dictionary, and the facet config.
+Adding a member obliges all of them, plus a backfill and a reindex, to express
+something the numeric column already expresses exactly. `0` is not a workaround here —
+"requires zero years" is the literal fact.
+
+*Trade-off:* the entry-level filter therefore lives on the years control rather than
+next to the seniority pills, which is where the reference design puts it. The two sit
+in the same pane, so the grouping is preserved even though the control is not shared.
+
+### `experience_years_max` is additive; `experience_years_min` is untouched
+
+`experience_years_min=N` keeps meaning `enrichment.experience_years_min >= N`. The new
+`experience_years_max=N` means `enrichment.experience_years_min <= N`. Both bound the
+same attribute; together they express a closed range.
+
+*Why not rename.* `web/static/openapi.yaml` is the integration contract — the CLI, the
+MCP surface, and the ChatGPT action all read it. The existing name is live and its
+floor semantics are documented; a rename would break callers to buy nothing.
+
+*Acknowledged awkwardness:* `experience_years_max` upper-bounds a field named
+`..._min`. The name is right from the caller's side (it is the maximum they will
+accept) and wrong from the field's side. The parameter description in `openapi.yaml`
+must say plainly which attribute it bounds, or the pair reads as a min/max over two
+different fields.
+
+### Both bounds exclude postings with no stated requirement
+
+Meilisearch numeric comparisons match only documents where the attribute is present,
+so any bound drops the ~52% of postings with no stated requirement. This is correct —
+"asks for at most 3 years" is not something an unstated requirement satisfies — but it
+is invisible at the UI, where it looks like the result count collapsed for no reason.
+The pane therefore carries a permanent note, not a conditional one.
+
+### The phrase detector keeps the conservative floor
+
+`ExperienceYearsMin` already takes the **smallest** year figure in the description. An
+explicit no-experience statement resolves to `0`, which is the smallest possible
+value, so it naturally wins under the existing rule with no special-casing. A
+description saying "no prior experience required" and separately "3 years with Go is a
+plus" yields `0`, which is the honest reading.
+
+## Risks / Trade-offs
+
+**The 48% coverage makes any bound look broken.** → The permanent coverage note in the
+pane, plus keeping the default at **Any** so the control is never bounded unless the
+user acts.
+
+**The phrase list over-fires on negated or unrelated prose** ("no prior experience with
+Kubernetes is required" means the *tool* is optional, not the job). → Phrases are
+matched on word boundaries via the package's existing `wordmatch`, and the list is
+anchored to bare statements. A phrase followed by "with"/"in" naming a technology is
+the known false positive; the test suite covers it explicitly and the list stays
+precision-first — a missed entry-level posting is cheaper than a mislabelled senior one.
+
+**Moving seniority out of the `Role` pane splits it from the role picker,** whose slugs
+carry a grade prefix (`senior_backend`). A user can select "Senior Backend" in one pane
+and not see the Senior pill light up in another. → The two were already independent
+params with overlapping meaning; the rail's per-entry staged count makes the second
+selection visible without opening the pane. No behaviour changes, only adjacency.
+
+**Existing tests assert the rail's shape.** `filterSections` has a test requiring every
+facet param to be reachable in the UI, and the filter-modal tests assert pane contents.
+→ Both are updated as part of the tasks that change them; this is a signal the move is
+covered, not a hazard.
+
+## Migration Plan
+
+No schema change, no new index attribute, no backfill, no reindex. Deploy is the
+ordinary web + API release.
+
+The phrase detector reaches new ingests immediately and existing rows on the next
+scheduled `cmd/backfill-derive` run — until then the entry-level stop matches only the
+7,440 postings that already carry `0`. That is a smaller set than the feature will
+eventually serve, not a wrong one.
+
+Rollback is a revert: the new param is additive, so an older API paired with a newer
+web build simply ignores `experience_years_max` (`/jobs` drops unknown filters
+silently), and a newer API with an older web build is never asked for it.
+
+## Open Questions
+
+None. The control shape, the vocabulary question, and the parameter naming were
+settled above.

--- a/openspec/changes/experience-filter-tab/proposal.md
+++ b/openspec/changes/experience-filter-tab/proposal.md
@@ -1,0 +1,87 @@
+## Why
+
+Experience is the axis a candidate filters on first — "am I even eligible?" — and
+it is the one axis the filter modal does not offer. The catalogue already carries
+the data: `experience_years_min` is a `jobs` column, a Meilisearch filterable
+attribute, and a documented query param, and 645,723 of the 1,349,667 searchable
+postings (48%) have a value. None of it is reachable from the UI. The one control
+that does speak to experience — the seniority pills — is buried inside the `Role`
+pane next to the role picker and the specialization chips, where it reads as a
+qualifier on the role rather than a filter of its own.
+
+Two gaps make the data less useful than it looks. The API exposes only a **floor**
+(`experience_years_min=3` means "the posting asks for at least 3 years"), which
+serves a senior avoiding junior postings but not a candidate with 3 years looking
+for what they can actually apply to — that needs a ceiling, which does not exist.
+And the description parser reads only a digit adjacent to a year word, so
+"no prior experience required" — the phrasing entry-level postings actually use —
+parses as *nothing stated*, indistinguishable from silence. Only 7,440 postings
+(0.5%) currently carry `experience_years_min = 0`, which understates the
+entry-level population rather than measuring it.
+
+## What Changes
+
+- The filter modal's `ROLE` rail gains an **Experience** pane holding three
+  controls: the seniority pills, a "no prior experience required" toggle, and a
+  years-of-experience range.
+- The seniority pills **move** out of the `Role` pane into the new Experience
+  pane. They remain the same `seniority` URL param with the same values and
+  exclusion behaviour — only their home in the rail changes.
+- A new `experience_years_max` query param bounds
+  `enrichment.experience_years_min` from above, making the pair a range. The
+  existing `experience_years_min` keeps its current floor semantics unchanged;
+  this is additive, not a rename. **Not breaking.**
+- `jobfacts` gains a precision-first phrase list that resolves an explicit
+  "no prior experience" statement to `experience_years_min = 0`. Absent an
+  explicit statement it continues to emit nothing — the dict-only rule holds, and
+  a missing value is never inferred from silence.
+- The years range control states its own coverage: moving it away from "Any"
+  drops the ~52% of postings whose experience is unstated, and the pane says so
+  rather than letting the result count silently collapse.
+
+Explicitly **out of scope**: the `role_type` facet (Individual Contributor vs
+People Manager). It needs a new column, a new dictionary, a Meilisearch facet, and
+a `cmd/backfill-derive` + reindex pass, so it is a separate change. This change
+leaves room for it in the Experience pane and adds nothing on its behalf.
+
+## Capabilities
+
+### New Capabilities
+
+None. Every behaviour here extends an existing capability.
+
+### Modified Capabilities
+
+- `filter-modal`: the `ROLE` rail gains an `Experience` entry; the seniority pills
+  move there from the specialization pane, so the requirement that consolidates
+  "seniority within specialization" no longer holds.
+- `job-search`: the searchable index gains an `experience_years_max` query filter
+  that upper-bounds `enrichment.experience_years_min`.
+- `deterministic-facets`: `experience_years_min` additionally resolves to `0` from
+  an explicit "no prior experience required" statement in the description, while
+  still emitting nothing when the description is silent.
+- `api-documentation`: the documented numeric filter set gains
+  `experience_years_max`, and `web/static/openapi.yaml` — the integration
+  contract — declares the new parameter on every endpoint that accepts
+  `experience_years_min`.
+
+## Impact
+
+**Go (backend):**
+- `internal/search/query_params.go` — allow `experience_years_max`.
+- `internal/search/query_filter.go` — emit `enrichment.experience_years_min <= N`.
+- `internal/jobfacts/jobfacts.go` — the no-experience phrase list feeding
+  `ExperienceYearsMin`.
+
+**Web (SPA):**
+- `web/src/lib/filterSections.ts` — the new `experience` rail entry and its kind.
+- `web/src/lib/facets.ts` — the years-range and no-experience controls.
+- The filter modal pane component rendering `kind: 'experience'`.
+- `web/static/openapi.yaml`, `web/src/lib/docs/filters.ts`,
+  `web/src/lib/docs/api-spec.ts` — the new param in the public contract and docs.
+
+**Not affected:** no migration, no new `jobs` column, no new Meilisearch
+filterable attribute (`enrichment.experience_years_min` is already one), and
+therefore **no `cmd/backfill-derive` run and no reindex** are required to ship
+this. The phrase detector reaches existing rows on the next scheduled backfill
+and applies to new ingests immediately.

--- a/openspec/changes/experience-filter-tab/proposal.md
+++ b/openspec/changes/experience-filter-tab/proposal.md
@@ -21,9 +21,10 @@ entry-level population rather than measuring it.
 
 ## What Changes
 
-- The filter modal's `ROLE` rail gains an **Experience** pane holding three
-  controls: the seniority pills, a "no prior experience required" toggle, and a
-  years-of-experience range.
+- The filter modal's `ROLE` rail gains an **Experience** pane holding two controls:
+  the seniority pills and a years-of-experience ceiling. The entry-level case is the
+  ceiling's leftmost stop rather than a toggle of its own — see `design.md` for why
+  one control beats two here.
 - The seniority pills **move** out of the `Role` pane into the new Experience
   pane. They remain the same `seniority` URL param with the same values and
   exclusion behaviour — only their home in the rail changes.

--- a/openspec/changes/experience-filter-tab/specs/api-documentation/spec.md
+++ b/openspec/changes/experience-filter-tab/specs/api-documentation/spec.md
@@ -1,0 +1,38 @@
+## MODIFIED Requirements
+
+### Requirement: Documented API coverage
+
+The documentation SHALL cover the whole public API surface: the base URL, the
+response envelope and pagination conventions, the public job reads
+(`/jobs`, `/jobs/search`, `/jobs/facets`, `/jobs/:slug`, `/jobs/:slug/similar`),
+companies, authentication, API keys, per-user job interactions, submissions,
+reports, and saved searches/subscriptions. Each endpoint SHALL state its method,
+path, authentication requirement, parameters, and a copyable curl example.
+
+`web/static/openapi.yaml` is the integration contract, so every endpoint that
+declares `experience_years_min` SHALL also declare its companion
+`experience_years_max`. The two SHALL be documented as a pair whose meaning is a
+range over the posting's stated experience requirement, and the documentation SHALL
+state that either bound excludes postings that state no requirement.
+
+#### Scenario: Endpoint entry is complete
+
+- **WHEN** the documentation lists an endpoint
+- **THEN** it shows the HTTP method, the path, an authentication badge
+  (none / cookie-or-key / cookie / moderator), its parameters, and a curl example
+
+#### Scenario: Filter vocabulary is documented in depth
+
+- **WHEN** a reader looks up how to query jobs by filters
+- **THEN** the docs list every search facet param, the `<param>_mode=and` and
+  `<param>_exclude` modifiers, the numeric (`salary_min`/`salary_max`/
+  `experience_years_min`/`experience_years_max`) and boolean (`visa_sponsorship`)
+  filters, full-text `q`, `sort`/`order`, and `semantic_ratio`, with at least one
+  worked recipe
+
+#### Scenario: The OpenAPI contract declares both experience bounds
+
+- **WHEN** an endpoint in `web/static/openapi.yaml` declares the
+  `experience_years_min` parameter
+- **THEN** it also declares `experience_years_max`, described as the upper bound of
+  the same range

--- a/openspec/changes/experience-filter-tab/specs/deterministic-facets/spec.md
+++ b/openspec/changes/experience-filter-tab/specs/deterministic-facets/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: An explicit no-experience statement resolves to zero years
+
+`internal/jobfacts`'s `ExperienceYearsMin(description)` SHALL resolve to `0` when the
+description explicitly states that no prior experience is required
+("no prior experience required", "no experience necessary", "no previous experience
+needed", and like phrasings). Today such a posting yields nothing, because the
+extractor reads only a digit adjacent to a year word, and an entry-level posting
+states the requirement in prose rather than as a figure — leaving it
+indistinguishable from a posting that says nothing about experience at all.
+
+The phrase list SHALL be precision-first and matched on word boundaries, in keeping
+with every other dictionary in this package: a description that is merely silent
+about experience SHALL continue to yield nothing, and the extractor SHALL NOT infer
+`0` from the absence of a figure. Where a description carries both an explicit
+no-experience statement and a years figure, the smallest resolved value SHALL win,
+which preserves the extractor's existing conservative-floor behaviour.
+
+This requires no schema change: the value lands in the existing
+`jobs.experience_years_min` column and the existing
+`enrichment.experience_years_min` index attribute.
+
+#### Scenario: An explicit no-experience statement yields zero
+
+- **WHEN** a description says "No prior experience required — we will train you"
+- **THEN** `ExperienceYearsMin` returns `0`
+
+#### Scenario: Silence still yields nothing
+
+- **WHEN** a description mentions no experience requirement in any form
+- **THEN** `ExperienceYearsMin` returns nil, not `0`
+
+#### Scenario: A stated figure is unaffected
+
+- **WHEN** a description says "5+ years of experience"
+- **THEN** `ExperienceYearsMin` returns `5`, unchanged by this rule
+
+#### Scenario: The conservative floor still wins when both appear
+
+- **WHEN** a description says "No prior experience required" and elsewhere
+  "3 years of experience with Go is a plus"
+- **THEN** `ExperienceYearsMin` returns `0`

--- a/openspec/changes/experience-filter-tab/specs/filter-modal/spec.md
+++ b/openspec/changes/experience-filter-tab/specs/filter-modal/spec.md
@@ -1,0 +1,132 @@
+## MODIFIED Requirements
+
+### Requirement: The job filters are edited in a two-pane modal grouped into sections
+
+The web client SHALL provide a filter modal opened from an **All filters** control.
+The modal SHALL present two panes: a left rail listing every filter facet grouped
+under section headings (`ROLE`, `PAY & BENEFITS`, `REQUIREMENTS & ELIGIBILITY`), and
+a right pane rendering the controls of the facet selected in the rail. Each rail
+entry SHALL show a count of how many values are currently staged for that facet, and
+selecting a rail entry SHALL switch the right pane to that facet without closing the
+modal or applying anything. Related facets MAY be consolidated into one rail entry
+whose pane renders each as its own labelled chip group (e.g. work format + employment
+type; industry + company type + collection; salary currency + minimum; English level +
+job language; relocation + visa).
+
+The seniority pills SHALL NOT be consolidated into the specialization pane. They
+belong to the `Experience` rail entry (see "The rail carries an Experience pane"),
+because seniority states how much experience a posting wants, not which role it is.
+
+#### Scenario: Opening the modal shows the sectioned rail and the first facet
+
+- **WHEN** the user activates **All filters**
+- **THEN** the modal opens with the facets grouped under `ROLE` / `PAY & BENEFITS` /
+  `REQUIREMENTS & ELIGIBILITY` in the left rail and the first facet's controls in the
+  right pane
+
+#### Scenario: Selecting a rail entry switches the pane without applying
+
+- **WHEN** the user clicks a different facet in the rail
+- **THEN** the right pane renders that facet's controls and no change is applied to
+  the job list
+
+#### Scenario: The rail shows staged counts per facet
+
+- **WHEN** two values are staged for a facet (or a consolidated entry)
+- **THEN** that facet's rail entry shows the count `2`
+
+#### Scenario: The specialization pane no longer carries seniority
+
+- **WHEN** the user opens the specialization (`Role`) pane
+- **THEN** it renders the role picker, the specialization chips and the AI
+  specialization facet, and does NOT render the seniority pills
+
+## ADDED Requirements
+
+### Requirement: The rail carries an Experience pane
+
+The filter modal's `ROLE` section SHALL carry an `Experience` rail entry whose pane
+renders two labelled controls: the `seniority` pills, and a years-of-experience
+control bounding how much experience a posting asks for. The pane SHALL be reachable
+by the same rail interaction as every other entry, and its rail entry's staged count
+SHALL cover both controls together.
+
+Moving the seniority pills into this pane SHALL NOT change the `seniority` URL
+parameter, its allowed values, or its exclusion (`seniority_exclude`) behaviour — a
+URL that selects a seniority before this change SHALL select the same seniority
+after it.
+
+#### Scenario: The Experience pane renders both controls
+
+- **WHEN** the user selects the `Experience` rail entry
+- **THEN** the right pane renders the seniority pills and the years-of-experience
+  control
+
+#### Scenario: An existing seniority URL still applies
+
+- **WHEN** a filter URL carrying `seniority=senior` is loaded after the move
+- **THEN** the senior pill is selected in the `Experience` pane and the job list is
+  filtered to senior postings, exactly as before the move
+
+#### Scenario: The rail count sums the pane's controls
+
+- **WHEN** the user stages one seniority value and a years bound
+- **THEN** the `Experience` rail entry shows the count `2`
+
+### Requirement: Years of experience is a single upper-bound control over preset stops
+
+The years-of-experience control SHALL be a single-handle range input that moves over
+an ordered list of preset stops rather than over raw years, following the pattern the
+freshness ("Posted within") control already uses. The stops SHALL be, in order: no
+experience required, 1, 2, 3, 5, 8, 10 years, and an unbounded **Any**. The control
+SHALL default to **Any**.
+
+Each stop SHALL set `experienceYearsMax` to its year value, and **Any** SHALL clear
+it. The control SHALL NOT set a lower bound; `experience_years_min` remains an
+API-only parameter with its existing floor semantics. The leftmost stop SHALL be
+labelled as requiring no prior experience and SHALL send `experience_years_max=0`, so
+the entry-level case is a position on this control rather than a separate toggle.
+
+The stops are deliberately non-linear because the catalogue's stated requirements
+are: measured on production, postings asking 5–7 years outnumber those asking 8–9 by
+more than five to one, so an evenly spaced scale would spend most of its travel on a
+thin tail.
+
+#### Scenario: The default sends no parameter
+
+- **WHEN** the user opens the `Experience` pane and leaves the control at **Any**
+- **THEN** `experience_years_max` does not appear in the applied filter state or the
+  URL
+
+#### Scenario: A stop sets the upper bound
+
+- **WHEN** the user moves the control to the `3` stop and applies
+- **THEN** `experience_years_max=3` is present in the applied filter state and the
+  URL
+
+#### Scenario: The leftmost stop selects the no-experience postings
+
+- **WHEN** the user moves the control to its leftmost stop and applies
+- **THEN** `experience_years_max=0` is applied and only postings stating that no
+  prior experience is required are returned
+
+#### Scenario: Returning to Any clears the bound
+
+- **WHEN** the user moves the control back to **Any**
+- **THEN** `experience_years_max` is removed from the applied filter state and the URL
+
+### Requirement: The years control states its own coverage
+
+Roughly half the searchable catalogue states no experience requirement at all, and
+any bound excludes every posting with no stated value. The pane SHALL therefore
+display, alongside the years control, a note that the bound matches only postings
+whose experience requirement is stated. The note SHALL be present whenever the
+control is rendered, not only once a bound is set — a user who cannot see why the
+result count collapsed has already been misled.
+
+#### Scenario: The coverage note is always visible
+
+- **WHEN** the `Experience` pane is rendered, with the control at **Any** or at any
+  bounded stop
+- **THEN** the note stating that the bound matches only postings with a stated
+  experience requirement is visible

--- a/openspec/changes/experience-filter-tab/specs/job-search/spec.md
+++ b/openspec/changes/experience-filter-tab/specs/job-search/spec.md
@@ -6,7 +6,10 @@ The search endpoints SHALL accept an `experience_years_max` parameter that bound
 posting's stated experience requirement from above. When it is a non-negative
 integer `N`, the search SHALL be restricted to documents whose
 `enrichment.experience_years_min` is at most `N`. When the parameter is absent,
-empty, or not a valid integer, it SHALL impose no restriction.
+empty, negative, or not a valid integer, it SHALL impose no restriction. A negative
+ceiling is rejected rather than honoured: the attribute is never below zero, so such
+a filter can only match nothing, and serving an empty page would present a typo as a
+legitimately narrow search.
 
 The existing `experience_years_min` parameter keeps its current meaning unchanged —
 it lower-bounds the same attribute (`enrichment.experience_years_min >= N`). The two
@@ -35,7 +38,7 @@ requirement does not satisfy.
 #### Scenario: An invalid upper bound imposes no restriction
 
 - **WHEN** a client requests `GET /api/v1/jobs/search` with `experience_years_max`
-  absent, empty, or non-numeric
+  absent, empty, negative, or non-numeric
 - **THEN** the result is not restricted by experience years
 
 #### Scenario: Postings with no stated requirement fall outside a bounded range

--- a/openspec/changes/experience-filter-tab/specs/job-search/spec.md
+++ b/openspec/changes/experience-filter-tab/specs/job-search/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Experience years is filterable as a range
+
+The search endpoints SHALL accept an `experience_years_max` parameter that bounds a
+posting's stated experience requirement from above. When it is a non-negative
+integer `N`, the search SHALL be restricted to documents whose
+`enrichment.experience_years_min` is at most `N`. When the parameter is absent,
+empty, or not a valid integer, it SHALL impose no restriction.
+
+The existing `experience_years_min` parameter keeps its current meaning unchanged —
+it lower-bounds the same attribute (`enrichment.experience_years_min >= N`). The two
+parameters SHALL compose as an AND, so supplying both expresses a closed range. The
+addition is backward compatible: no existing parameter changes name or semantics.
+
+Because `enrichment.experience_years_min` is absent on a posting whose experience
+requirement was never stated, either bound SHALL exclude such postings. This
+follows from Meilisearch's numeric comparison semantics and is deliberate — the
+filter answers "the posting asks for at most N years", which an unstated
+requirement does not satisfy.
+
+#### Scenario: An upper bound restricts to postings asking for no more
+
+- **WHEN** a client requests `GET /api/v1/jobs/search?experience_years_max=3`
+- **THEN** only postings whose stated experience requirement is 3 years or fewer are
+  returned
+
+#### Scenario: Both bounds express a closed range
+
+- **WHEN** a client requests
+  `GET /api/v1/jobs/search?experience_years_min=2&experience_years_max=5`
+- **THEN** only postings whose stated experience requirement is between 2 and 5
+  years inclusive are returned
+
+#### Scenario: An invalid upper bound imposes no restriction
+
+- **WHEN** a client requests `GET /api/v1/jobs/search` with `experience_years_max`
+  absent, empty, or non-numeric
+- **THEN** the result is not restricted by experience years
+
+#### Scenario: Postings with no stated requirement fall outside a bounded range
+
+- **WHEN** a posting carries no `enrichment.experience_years_min` and a client
+  requests `experience_years_max=10`
+- **THEN** that posting is not returned
+
+#### Scenario: A zero upper bound selects the no-experience postings
+
+- **WHEN** a client requests `GET /api/v1/jobs/search?experience_years_max=0`
+- **THEN** only postings whose stated experience requirement is `0` are returned

--- a/openspec/changes/experience-filter-tab/tasks.md
+++ b/openspec/changes/experience-filter-tab/tasks.md
@@ -1,0 +1,73 @@
+## 1. Backend — the upper-bound filter
+
+- [x] 1.1 Add a `query_filter_test.go` case asserting `experience_years_max=3`
+  produces `enrichment.experience_years_min <= 3`, that it composes with
+  `experience_years_min` as a closed range, and that an absent/empty/non-numeric
+  value produces no group. Test fails.
+- [x] 1.2 Allow `experience_years_max` in `internal/search/query_params.go` and emit
+  the `Lte` group in `internal/search/query_filter.go`, next to the existing floor.
+  Test passes.
+- [x] 1.3 Add a `query_params_test.go` case covering the new param's pass-through,
+  matching how `experience_years_min` is already covered.
+
+## 2. Backend — the no-experience phrase detector
+
+- [x] 2.1 Add `jobfacts_test.go` cases: an explicit "no prior experience required"
+  yields `0`; "no experience necessary" and "no previous experience needed" yield `0`;
+  a description silent about experience still yields nil; "5+ years of experience"
+  still yields `5`; a description carrying both an explicit no-experience statement
+  and a "3 years ... is a plus" figure yields `0`. Tests fail.
+- [x] 2.2 Add the boundary-matched phrase list to `internal/jobfacts/jobfacts.go` and
+  wire it into `ExperienceYearsMin` so an explicit statement contributes `0` to the
+  existing smallest-value walk. Tests pass.
+- [x] 2.3 Add the known false-positive case as a test — "no prior experience with
+  Kubernetes is required" must NOT yield `0` — and tighten the phrases until it holds.
+- [x] 2.4 `gofmt -w` the touched Go files, then `go vet ./...` and `go test ./...`.
+
+## 3. Contract and docs
+
+- [x] 3.1 Declare the `ExperienceYearsMax` parameter in `web/static/openapi.yaml` and
+  reference it from every endpoint that already references `ExperienceYearsMin`. Its
+  description must state which attribute it bounds and that either bound excludes
+  postings with no stated requirement.
+- [x] 3.2 Add the param to `web/src/lib/docs/filters.ts` and the numeric-filter list
+  in `web/src/lib/docs/api-spec.ts`, then regenerate `docs/API.md` via `gen:api-docs`.
+
+## 4. SPA — filter state
+
+- [x] 4.1 Add a `facetModel` test asserting `experienceYearsMax` round-trips through
+  `filtersToParams`/`filtersFromParams` as `experience_years_max`, that `null` emits
+  no param, that `0` DOES emit `experience_years_max=0` (the falsy-zero trap), and
+  that a non-numeric URL value parses back to `null`. Test fails.
+- [x] 4.2 Add `experienceYearsMax` to `JobFilters`, `emptyFilters`, `filtersToParams`,
+  `filtersFromParams`, and `activeFilterCount` in `web/src/lib/facetModel.ts`. Test
+  passes.
+- [x] 4.3 Add the `setExperienceYearsMax` transition to both `web/src/lib/filters.ts`
+  (live) and `web/src/lib/stagedFilters.svelte.ts` (deferred), following `setSalaryMin`.
+
+## 5. SPA — the Experience pane
+
+- [x] 5.1 Add `'experience'` to `RailKind` and the `Experience` entry to `RAIL` in
+  `web/src/lib/filterSections.ts`, placed in the `ROLE` section after `category`.
+  Update the rail test that asserts every facet param is reachable.
+- [x] 5.2 Define the preset-stop array (no-experience, 1, 2, 3, 5, 8, 10, Any) with a
+  label per stop, alongside `FRESHNESS_PRESETS`. Add a unit test that the index→value
+  mapping is total and that the Any stop maps to `null`.
+- [x] 5.3 Render the `kind: 'experience'` pane in `FilterModal.svelte`: the seniority
+  `ChipFacet`, then the preset slider driven by index, then the permanent coverage
+  note. Model the slider on the `kind: 'posted'` branch.
+- [x] 5.4 Remove the seniority group from the `kind: 'category'` pane and update the
+  filter-modal tests that assert its contents.
+- [x] 5.5 Add the pane's staged count to the `selCount` switch in `FilterModal.svelte`
+  so the rail entry counts seniority values plus a set years bound.
+- [x] 5.6 Add the years bound to `FilterSummary.svelte` as a removable chip, following
+  the `salaryMin` chip.
+
+## 6. Verification
+
+- [x] 6.1 Run the web test suite and `eslint` on the touched files; both clean.
+- [x] 6.2 Run `go vet -tags=integration ./...` — the push-time guard.
+- [x] 6.3 Drive the app: open the filter modal, confirm the `Experience` pane renders
+  both controls, that moving the slider changes the result count and the URL, that the
+  leftmost stop applies `experience_years_max=0`, and that an old `?seniority=senior`
+  URL still selects the pill in its new home.

--- a/web/src/lib/components/filters/FilterModal.svelte
+++ b/web/src/lib/components/filters/FilterModal.svelte
@@ -12,7 +12,14 @@
   import { StagedFilters } from '$lib/stagedFilters.svelte';
   import { RAIL, RAIL_SECTIONS, type RailEntry, type RailSection } from '$lib/filterSections';
   import type { FacetCounts } from '$lib/types';
-  import { FRESHNESS_PRESETS, SALARY_MAX, SALARY_STEP, freshnessLabel } from '$lib/filterControls';
+  import {
+    EXPERIENCE_PRESETS,
+    FRESHNESS_PRESETS,
+    SALARY_MAX,
+    SALARY_STEP,
+    experienceLabel,
+    freshnessLabel,
+  } from '$lib/filterControls';
   import FacetSection from '../facets/FacetSection.svelte';
   import ChipFacet from './ChipFacet.svelte';
   import CategoryPane from './CategoryPane.svelte';
@@ -146,8 +153,8 @@
 
   function entryCount(e: RailEntry): number {
     const f = staged.value;
-    if (e.kind === 'category')
-      return selCount(f, 'role') + selCount(f, 'category') + selCount(f, 'seniority') + selCount(f, 'ai_archetype');
+    if (e.kind === 'category') return selCount(f, 'role') + selCount(f, 'category') + selCount(f, 'ai_archetype');
+    if (e.kind === 'experience') return selCount(f, 'seniority') + (f.experienceYearsMax != null ? 1 : 0);
     if (e.kind === 'location') return selCount(f, 'regions') + selCount(f, 'countries') + selCount(f, 'cities');
     if (e.kind === 'salary') return selCount(f, 'salary_currency') + (f.salaryMin != null ? 1 : 0);
     if (e.kind === 'work') return selCount(f, 'work_mode') + selCount(f, 'employment_type');
@@ -191,6 +198,16 @@
   const freshnessIndex = $derived.by(() => {
     const i = FRESHNESS_PRESETS.findIndex((p) => p.days === staged.value.postedWithinDays);
     return i < 0 ? FRESHNESS_PRESETS.length - 1 : i;
+  });
+
+  // Same snap-to-Any rule as freshness above: an off-preset bound (hand-edited or
+  // shared URL) has no exact stop, so the handle rests on the rightmost one. The
+  // LABEL still reports the real bound — see experienceLabel — so the two do not
+  // agree here on purpose: the handle says "no stop matches", the text says what
+  // is actually filtering.
+  const experienceIndex = $derived.by(() => {
+    const i = EXPERIENCE_PRESETS.findIndex((p) => p.years === staged.value.experienceYearsMax);
+    return i < 0 ? EXPERIENCE_PRESETS.length - 1 : i;
   });
 </script>
 
@@ -296,12 +313,7 @@
     {#if roleDef && !exclude.includes('role')}
       <div class="mb-6"><FacetSection def={roleDef} store={staged} counts={c} expand /></div>
     {/if}
-    {#if !exclude.includes('seniority')}
-      <ChipFacet store={staged} param="seniority" label="Seniority" counts={c} />
-      <div class="mt-6"><CategoryPane store={staged} {plain} counts={c} /></div>
-    {:else}
-      <CategoryPane store={staged} {plain} counts={c} />
-    {/if}
+    <CategoryPane store={staged} {plain} counts={c} />
     {#if !exclude.includes('ai_archetype')}
       {@const aiArchetypeDef = facetDefFor('ai_archetype')}
       {#if aiArchetypeDef}
@@ -349,6 +361,36 @@
       aria-label="Minimum salary"
       class="w-full accent-primary"
     />
+  {:else if entry.kind === 'experience'}
+    {@const showSeniority = !exclude.includes('seniority')}
+    {#if showSeniority}
+      <ChipFacet store={staged} param="seniority" label="Seniority" counts={c} />
+    {/if}
+    <div class:mt-6={showSeniority}>
+      <div class="mb-2 flex items-center justify-between">
+        <h3 class="text-sm font-semibold tracking-tight">Years of experience</h3>
+        <span class="text-xs font-medium text-muted-foreground"
+          >{experienceLabel(staged.value.experienceYearsMax)}</span
+        >
+      </div>
+      <input
+        type="range"
+        min="0"
+        max={EXPERIENCE_PRESETS.length - 1}
+        step="1"
+        value={experienceIndex}
+        oninput={(e) => staged.setExperienceYearsMax(EXPERIENCE_PRESETS[Number(e.currentTarget.value)]?.years ?? null)}
+        aria-label="Maximum years of experience"
+        class="w-full accent-primary"
+      />
+      <!-- Roughly half the catalogue states no experience requirement at all, and a
+           bound excludes every one of those postings. Said permanently rather than
+           on a bounded value: a result count that collapses without explanation is
+           read as a broken filter, and by then the user has already been misled. -->
+      <p class="mt-2 text-xs text-muted-foreground">
+        Matches only postings that state an experience requirement — about half of them.
+      </p>
+    </div>
   {:else if entry.kind === 'work'}
     <ChipFacet store={staged} param="work_mode" label="Work format" counts={c} />
     <div class="mt-6"><ChipFacet store={staged} param="employment_type" label="Employment type" counts={c} /></div>

--- a/web/src/lib/components/filters/FilterModal.svelte
+++ b/web/src/lib/components/filters/FilterModal.svelte
@@ -384,11 +384,13 @@
         class="w-full accent-primary"
       />
       <!-- Roughly half the catalogue states no experience requirement at all, and a
-           bound excludes every one of those postings. Said permanently rather than
-           on a bounded value: a result count that collapses without explanation is
-           read as a broken filter, and by then the user has already been misled. -->
+           bound excludes every one of those postings. Shown permanently rather than
+           only once bounded: a result count that collapses without explanation is
+           read as a broken filter, and by then the user has already been misled. The
+           sentence is therefore about what SETTING a bound does, so it stays true at
+           the unbounded "Any" stop instead of describing a filter that is not on. -->
       <p class="mt-2 text-xs text-muted-foreground">
-        Matches only postings that state an experience requirement — about half of them.
+        Setting a limit matches only postings that state an experience requirement — about half of them.
       </p>
     </div>
   {:else if entry.kind === 'work'}

--- a/web/src/lib/components/filters/FilterSummary.svelte
+++ b/web/src/lib/components/filters/FilterSummary.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { dynamicLabel, FACETS } from '$lib/facets';
   import { type FilterStore, savedSearchQuery } from '$lib/filters';
-  import { freshnessLabel } from '$lib/filterControls';
+  import { experienceLabel, freshnessLabel } from '$lib/filterControls';
   import FilterSummaryShell, { type SummaryChip, type SummaryGroup } from './FilterSummaryShell.svelte';
   import SaveSearchAlert from './SaveSearchAlert.svelte';
 
@@ -72,6 +72,9 @@
 
     if (f.visa) push('Visa', [{ text: 'Sponsorship', exclude: false, remove: () => store.setVisa(false) }]);
     if (f.postedWithinDays != null) push('Posted', [{ text: freshnessLabel(f.postedWithinDays), exclude: false, remove: () => store.setPostedWithinDays(null) }]);
+    // `!= null`, not truthiness: a zero bound is the entry-level filter, and hiding
+    // its chip would leave the narrowest experience filter with no way to remove it.
+    if (f.experienceYearsMax != null) push('Experience', [{ text: experienceLabel(f.experienceYearsMax), exclude: false, remove: () => store.setExperienceYearsMax(null) }]);
 
     return out;
   });

--- a/web/src/lib/docs/filters.ts
+++ b/web/src/lib/docs/filters.ts
@@ -66,6 +66,12 @@ export const FILTER_EXTRAS: FilterRow[] = [
     values: 'integer — jobs requiring at least this many years',
   },
   {
+    param: 'experience_years_max',
+    label: 'Maximum experience',
+    values:
+      'integer — jobs requiring at most this many years, the same figure experience_years_min bounds from below. Use 0 for jobs stating no prior experience is required. Either bound excludes jobs that state no requirement at all',
+  },
+  {
     param: 'posted_within_days',
     label: 'Posted within',
     values: 'integer — jobs whose effective posting date falls in the last N days',

--- a/web/src/lib/facetModel.test.ts
+++ b/web/src/lib/facetModel.test.ts
@@ -118,6 +118,44 @@ describe('filtersToParams / filtersFromParams round-trip', () => {
   });
 });
 
+describe('experienceYearsMax', () => {
+  it('is absent from the URL when unset', () => {
+    expect(filtersToParams(emptyFilters()).has('experience_years_max')).toBe(false);
+  });
+
+  it('serializes a bound and reads it back', () => {
+    const f = emptyFilters();
+    f.experienceYearsMax = 3;
+    const p = filtersToParams(f);
+    expect(p.get('experience_years_max')).toBe('3');
+    expect(filtersFromParams(p).experienceYearsMax).toBe(3);
+  });
+
+  // Zero is the entry-level selector, not "unset". A falsy guard here would drop the
+  // one bound juniors need, and the URL would silently widen back to the whole
+  // catalogue while the control still showed the leftmost stop.
+  it('serializes a zero bound rather than treating it as unset', () => {
+    const f = emptyFilters();
+    f.experienceYearsMax = 0;
+    const p = filtersToParams(f);
+    expect(p.get('experience_years_max')).toBe('0');
+    expect(filtersFromParams(p).experienceYearsMax).toBe(0);
+  });
+
+  it('reads a junk or negative URL value back as no bound', () => {
+    for (const raw of ['', 'abc', '-1', '2.5']) {
+      const back = filtersFromParams(new URLSearchParams(`experience_years_max=${raw}`));
+      expect(back.experienceYearsMax, `experience_years_max=${raw}`).toBeNull();
+    }
+  });
+
+  it('counts as one active filter, including at zero', () => {
+    const f = emptyFilters();
+    f.experienceYearsMax = 0;
+    expect(activeFilterCount(f)).toBe(1);
+  });
+});
+
 describe('role facet round-trips through the generic param path', () => {
   it('serializes include/exclude/mode and reads them back', () => {
     const f = emptyFilters();

--- a/web/src/lib/facetModel.test.ts
+++ b/web/src/lib/facetModel.test.ts
@@ -142,8 +142,11 @@ describe('experienceYearsMax', () => {
     expect(filtersFromParams(p).experienceYearsMax).toBe(0);
   });
 
-  it('reads a junk or negative URL value back as no bound', () => {
-    for (const raw of ['', 'abc', '-1', '2.5']) {
+  // `Number(' ')` is 0 and `' '` is truthy, so a whitespace-only value slips past a
+  // naive presence check and lands on the entry-level filter — a shared or
+  // hand-edited link would narrow to almost nothing without saying why.
+  it('reads a junk, blank or negative URL value back as no bound', () => {
+    for (const raw of ['', ' ', '%20', 'abc', '-1', '2.5']) {
       const back = filtersFromParams(new URLSearchParams(`experience_years_max=${raw}`));
       expect(back.experienceYearsMax, `experience_years_max=${raw}`).toBeNull();
     }

--- a/web/src/lib/facetModel.ts
+++ b/web/src/lib/facetModel.ts
@@ -31,6 +31,10 @@ export interface JobFilters {
    *  Serialized as `posted_within_days`; the backend turns it into a posted_ts
    *  range filter relative to request time. */
   postedWithinDays: number | null;
+  /** Keep only jobs asking for at most this many years of experience (null = any).
+   *  `0` is a real bound — the jobs stating no prior experience is required — so
+   *  every read of this field must test for null, never for falsiness. */
+  experienceYearsMax: number | null;
 }
 
 /** Splits every raw query value on comma and flattens the result, dropping
@@ -52,7 +56,14 @@ function emptyFacets(): Record<string, FacetState> {
 }
 
 export function emptyFilters(): JobFilters {
-  return { q: '', facets: emptyFacets(), visa: false, salaryMin: null, postedWithinDays: null };
+  return {
+    q: '',
+    facets: emptyFacets(),
+    visa: false,
+    salaryMin: null,
+    postedWithinDays: null,
+    experienceYearsMax: null,
+  };
 }
 
 // ---- URL serialization ----
@@ -72,6 +83,7 @@ export function filtersToParams(f: JobFilters): URLSearchParams {
   if (f.visa) p.set('visa_sponsorship', 'true');
   if (f.salaryMin != null) p.set('salary_min', String(f.salaryMin));
   if (f.postedWithinDays != null) p.set('posted_within_days', String(f.postedWithinDays));
+  if (f.experienceYearsMax != null) p.set('experience_years_max', String(f.experienceYearsMax));
   return p;
 }
 
@@ -99,6 +111,12 @@ export function filtersFromParams(p: URLSearchParams): JobFilters {
   // negative, non-numeric) reads as "any age", matching the backend's own guard.
   const days = Number(p.get('posted_within_days'));
   f.postedWithinDays = Number.isInteger(days) && days > 0 ? days : null;
+  // Zero IS a bound here — it selects the postings stating no prior experience is
+  // required — so the guard admits it and rejects only what cannot be a year count.
+  // `Number('')` is 0, hence the explicit presence check ahead of the range test.
+  const years = Number(p.get('experience_years_max'));
+  f.experienceYearsMax =
+    p.get('experience_years_max') && Number.isInteger(years) && years >= 0 ? years : null;
   return f;
 }
 
@@ -112,6 +130,7 @@ export function activeFilterCount(f: JobFilters): number {
   if (f.visa) n += 1;
   if (f.salaryMin != null) n += 1;
   if (f.postedWithinDays != null) n += 1;
+  if (f.experienceYearsMax != null) n += 1;
   return n;
 }
 

--- a/web/src/lib/facetModel.ts
+++ b/web/src/lib/facetModel.ts
@@ -113,10 +113,12 @@ export function filtersFromParams(p: URLSearchParams): JobFilters {
   f.postedWithinDays = Number.isInteger(days) && days > 0 ? days : null;
   // Zero IS a bound here — it selects the postings stating no prior experience is
   // required — so the guard admits it and rejects only what cannot be a year count.
-  // `Number('')` is 0, hence the explicit presence check ahead of the range test.
-  const years = Number(p.get('experience_years_max'));
-  f.experienceYearsMax =
-    p.get('experience_years_max') && Number.isInteger(years) && years >= 0 ? years : null;
+  // The presence test is on the TRIMMED string, not the raw one: `Number('')` and
+  // `Number(' ')` are both 0 while `' '` is truthy, so a naive check would turn
+  // `?experience_years_max=%20` in a shared link into the entry-level filter.
+  const rawYears = p.get('experience_years_max')?.trim() ?? '';
+  const years = Number(rawYears);
+  f.experienceYearsMax = rawYears !== '' && Number.isInteger(years) && years >= 0 ? years : null;
   return f;
 }
 

--- a/web/src/lib/filterControls.test.ts
+++ b/web/src/lib/filterControls.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { EXPERIENCE_PRESETS, experienceLabel } from './filterControls';
+
+describe('EXPERIENCE_PRESETS', () => {
+  it('runs least-to-most experience with Any as the rightmost stop', () => {
+    const years = EXPERIENCE_PRESETS.map((p) => p.years);
+    expect(years.at(-1)).toBeNull();
+
+    const bounded = years.slice(0, -1) as number[];
+    expect(bounded).toEqual([...bounded].sort((a, b) => a - b));
+    expect(bounded.every((y) => Number.isInteger(y) && y >= 0)).toBe(true);
+  });
+
+  // The leftmost stop is the entry-level selector. It must be a real 0, not null:
+  // `experience_years_max=0` is what selects the postings stating no prior
+  // experience is required, while null means "no bound at all".
+  it('starts at a zero bound, not at no bound', () => {
+    expect(EXPERIENCE_PRESETS[0]?.years).toBe(0);
+  });
+
+  it('labels every stop', () => {
+    expect(EXPERIENCE_PRESETS.every((p) => p.label.length > 0)).toBe(true);
+  });
+});
+
+describe('experienceLabel', () => {
+  it('names each preset stop', () => {
+    for (const p of EXPERIENCE_PRESETS) {
+      expect(experienceLabel(p.years)).toBe(p.label);
+    }
+  });
+
+  it('reads an unset bound as Any', () => {
+    expect(experienceLabel(null)).toBe('Any');
+  });
+
+  // A hand-edited URL can carry a year count that is no preset stop. The label must
+  // still describe the bound in force rather than claiming the filter is off.
+  it('describes an off-preset bound instead of calling it Any', () => {
+    expect(experienceLabel(6)).not.toBe('Any');
+    expect(experienceLabel(6)).toContain('6');
+  });
+});

--- a/web/src/lib/filterControls.ts
+++ b/web/src/lib/filterControls.ts
@@ -19,3 +19,34 @@ export const FRESHNESS_PRESETS: { days: number | null; label: string }[] = [
 export function freshnessLabel(days: number | null): string {
   return FRESHNESS_PRESETS.find((p) => p.days === days)?.label ?? 'Any';
 }
+
+/** Experience-ceiling presets, least→most with "Any" as the rightmost stop. Each
+ *  stop is an upper bound on the years a posting asks for, so the leftmost is a
+ *  real `0` — the postings stating no prior experience is required — and only the
+ *  rightmost is "no bound".
+ *
+ *  The spacing is deliberately non-linear because the catalogue is: measured on
+ *  production, postings asking 5–7 years outnumber those asking 8–9 by more than
+ *  five to one, so evenly spaced stops would spend most of the slider's travel on
+ *  a thin tail. */
+export const EXPERIENCE_PRESETS: { years: number | null; label: string }[] = [
+  { years: 0, label: 'No experience' },
+  { years: 1, label: 'Up to 1 year' },
+  { years: 2, label: 'Up to 2 years' },
+  { years: 3, label: 'Up to 3 years' },
+  { years: 5, label: 'Up to 5 years' },
+  { years: 8, label: 'Up to 8 years' },
+  { years: 10, label: 'Up to 10 years' },
+  { years: null, label: 'Any' },
+];
+
+/** Label for the current experience ceiling. Unlike freshnessLabel this does NOT
+ *  fall back to "Any" for an off-preset value: a hand-edited or shared URL can
+ *  carry any year count, and reporting a live bound as "Any" would tell the user
+ *  the filter is off while it is quietly narrowing their results. */
+export function experienceLabel(years: number | null): string {
+  const preset = EXPERIENCE_PRESETS.find((p) => p.years === years);
+  if (preset) return preset.label;
+  if (years == null) return 'Any';
+  return `Up to ${years} ${years === 1 ? 'year' : 'years'}`;
+}

--- a/web/src/lib/filterSections.test.ts
+++ b/web/src/lib/filterSections.test.ts
@@ -1,6 +1,23 @@
 import { describe, expect, it } from 'vitest';
 import { RAIL } from './filterSections';
 
+describe('the Experience pane', () => {
+  it('is a ROLE-section rail entry of its own', () => {
+    const entry = RAIL.find((e) => e.key === 'experience');
+    expect(entry).toBeDefined();
+    expect(entry?.kind).toBe('experience');
+    expect(entry?.section).toBe('ROLE');
+  });
+
+  // Seniority is a control of the Experience pane, not a facet entry of its own —
+  // FilterModal renders it there. A standalone entry would put the same pills in
+  // two places in the rail.
+  it('leaves seniority without a standalone rail entry', () => {
+    expect(RAIL.find((e) => e.key === 'seniority')).toBeUndefined();
+    expect(RAIL.find((e) => e.facetParam === 'seniority')).toBeUndefined();
+  });
+});
+
 describe('the ai_archetype facet', () => {
   it('has no standalone rail entry — FilterModal folds it into the Role pane instead', () => {
     expect(RAIL.find((e) => e.key === 'ai_archetype')).toBeUndefined();

--- a/web/src/lib/filterSections.ts
+++ b/web/src/lib/filterSections.ts
@@ -113,6 +113,7 @@ export type RailKind =
   | 'language'
   | 'relocation'
   | 'posted'
+  | 'experience'
   // The job modal's "My filters" (saved searches) tab — renders SavedSearches, not a facet control.
   | 'saved';
 
@@ -150,12 +151,17 @@ export const COMPANY_RAIL_GROUPS: CompanyRailGroup[] = [
 
 export const RAIL: RailEntry[] = [
   // One "Role" pane holds the whole "what role" concept: the role picker
-  // (natural/named/composite roles), the seniority pills, the specialization
-  // chips, and the AI Specialization facet — four controls, one tab. They overlap
-  // by design (role=senior is also reachable via the seniority pill); the picker is
-  // the natural-language entry, the pills/chips/AI-specialization the browse-by-axis
-  // entry.
+  // (natural/named/composite roles), the specialization chips, and the AI
+  // Specialization facet. The picker is the natural-language entry, the chips and
+  // AI-specialization the browse-by-axis entry.
+  //
+  // Seniority used to sit here too, because a role slug can carry a grade prefix
+  // (`senior_backend`) and the two read as one thought. It moved to Experience: a
+  // grade states how much experience a posting wants, which is the question that
+  // pane answers, and it sits there next to the years ceiling that qualifies it.
+  // The two params stay independent, as they already were.
   { key: 'category', label: 'Role', section: 'ROLE', kind: 'category' },
+  { key: 'experience', label: 'Experience', section: 'ROLE', kind: 'experience' },
   { key: 'location', label: 'Location', section: 'ROLE', kind: 'location' },
   { key: 'work', label: 'Work & employment', section: 'ROLE', kind: 'work' },
   { key: 'skills', label: 'Skills', section: 'ROLE', kind: 'facet', facetParam: 'skills' },

--- a/web/src/lib/filters.ts
+++ b/web/src/lib/filters.ts
@@ -81,6 +81,10 @@ export class FilterStore {
     this.#url.setSoon({ ...this.#url.value, postedWithinDays: n });
   }
 
+  setExperienceYearsMax(n: number | null) {
+    this.#url.setSoon({ ...this.#url.value, experienceYearsMax: n });
+  }
+
   // Discrete inputs (clicked/toggled): apply immediately via setNow.
   setVisa(on: boolean) {
     this.#url.setNow({ ...this.#url.value, visa: on });

--- a/web/src/lib/stagedFilters.svelte.ts
+++ b/web/src/lib/stagedFilters.svelte.ts
@@ -88,6 +88,10 @@ export class StagedFilters implements FacetStore {
     this.#f = { ...this.#f, postedWithinDays: n };
   }
 
+  setExperienceYearsMax(n: number | null): void {
+    this.#f = { ...this.#f, experienceYearsMax: n };
+  }
+
   /** Reset every staged filter. */
   clear(): void {
     this.#f = emptyFilters();

--- a/web/static/openapi.yaml
+++ b/web/static/openapi.yaml
@@ -186,6 +186,7 @@ paths:
         - $ref: "#/components/parameters/SalaryMin"
         - $ref: "#/components/parameters/SalaryMax"
         - $ref: "#/components/parameters/ExperienceYearsMin"
+        - $ref: "#/components/parameters/ExperienceYearsMax"
         - $ref: "#/components/parameters/PostedWithinDays"
         - $ref: "#/components/parameters/RegionsExclude"
         - $ref: "#/components/parameters/CountriesExclude"
@@ -253,6 +254,7 @@ paths:
         - $ref: "#/components/parameters/SalaryMin"
         - $ref: "#/components/parameters/SalaryMax"
         - $ref: "#/components/parameters/ExperienceYearsMin"
+        - $ref: "#/components/parameters/ExperienceYearsMax"
         - $ref: "#/components/parameters/PostedWithinDays"
         - $ref: "#/components/parameters/RegionsExclude"
         - $ref: "#/components/parameters/CountriesExclude"
@@ -333,6 +335,7 @@ paths:
         - $ref: "#/components/parameters/SalaryMin"
         - $ref: "#/components/parameters/SalaryMax"
         - $ref: "#/components/parameters/ExperienceYearsMin"
+        - $ref: "#/components/parameters/ExperienceYearsMax"
         - $ref: "#/components/parameters/PostedWithinDays"
       responses:
         "200":
@@ -1161,7 +1164,23 @@ components:
       in: query
       schema:
         type: integer
-      description: Lower bound on the years of experience the posting asks for.
+      description: >-
+        Lower bound on the years of experience the posting asks for. Pairs with
+        `experience_years_max` as a closed range over that one figure. A posting
+        that states no experience requirement carries no figure and is therefore
+        excluded by either bound.
+    ExperienceYearsMax:
+      name: experience_years_max
+      in: query
+      schema:
+        type: integer
+        minimum: 0
+      description: >-
+        Upper bound on the years of experience the posting asks for — the most you
+        are willing to be asked for. It bounds the same figure `experience_years_min`
+        bounds from below, not a second field. `experience_years_max=0` selects the
+        postings that state no prior experience is required. Like `experience_years_min`,
+        it excludes postings that state no requirement at all.
     PostedWithinDays:
       name: posted_within_days
       in: query


### PR DESCRIPTION
## Why

`experience_years_min` has been a `jobs` column since migration 0001, a Meilisearch filterable attribute, and a documented query param. **645,723 of 1,349,667 searchable postings (48%) carry a value.** None of it was reachable from the UI.

The one control that spoke to experience — the seniority pills — sat inside the `Role` pane next to the role picker, where it read as a qualifier on the role rather than a filter of its own.

## What changed

**A new `Experience` pane** in the filter modal's `ROLE` rail. The seniority pills move there; the `seniority` param, its values and its `_exclude` behaviour are untouched, so old links and saved searches keep working.

**A new `experience_years_max` query param.** It bounds the *same* attribute `experience_years_min` bounds from below — a floor and a ceiling on one figure, not a min/max over two fields. The existing param keeps its name and meaning: `web/static/openapi.yaml` is the integration contract the CLI, the MCP surface and the ChatGPT action all read.

**Prose detection for entry-level postings.** The parser read only a digit next to a year word, so "no prior experience required" parsed as *nothing stated* — indistinguishable from silence. Only 7,440 postings carried a `0`, which understated that population rather than measuring it.

## The years control

One preset-stop slider, following the existing freshness control rather than a raw-years scale. Production's stated requirements are skewed:

| Years asked | Postings |
|---|---|
| 0 | 7,440 |
| 1 | 65,857 |
| 2 | 101,638 |
| 3–4 | 165,177 |
| 5–7 | 201,055 |
| 8–9 | 36,358 |
| 10+ | 68,198 |

5–7 outnumbers 8–9 by more than five to one, so evenly spaced stops would spend most of the slider's travel on a thin tail. Folding "no experience" in as the leftmost stop also spares a second control.

## Three things worth a reviewer's attention

**Zero is a real bound, not "unset."** `experience_years_max=0` selects the entry-level postings. Every read tests `!= null`, never falsiness — a truthiness check anywhere would make the one filter juniors need silently vanish. Tested at each layer.

**The scoping guard runs in both directions.** "No prior experience **with Kubernetes** is required" and "…is required **with our CRM**" both scope the claim to a tool while the role may still want a decade. The first draft caught only the leading word order; review caught the trailing one. A trailing `for` is deliberately admitted — "no experience necessary **for this position**" is the ordinary entry-level phrasing, and there is a test pinning that.

**Any bound drops the ~52% of postings that state no requirement.** Meilisearch compares only documents carrying the attribute. That is the honest reading of "asks for at most N years", but at the UI it looks like the result count collapsed for no reason — so the pane carries a permanent note, not a conditional one.

## Ops

**No migration, no new column, no new index attribute — so no `backfill-derive` and no reindex are needed to ship this.** The phrase detector reaches new ingests immediately and existing rows on the next scheduled backfill; until then the entry-level stop matches the 7,440 postings that already carry a `0`. A smaller set than the feature will eventually serve, not a wrong one.

Rollback is a revert. The param is additive, so an older API with a newer web build ignores it (and says so via `meta.ignored_params`), and a newer API with an older web build is never asked for it.

## Verification

| | |
|---|---|
| `gofmt -l .` | empty |
| `go vet ./...` | exit 0 |
| `go test ./...` | exit 0, 166 packages |
| `go vet -tags=integration ./...` | exit 0 |
| `pnpm test` | 101 files / 1104 tests |
| `svelte-check` | 0 errors |
| `eslint` (touched files) | exit 0 |

Driven in a browser against the live API: the pane renders both controls, the slider reads `Any` → `Up to 3 years` → `No experience` across its stops, applying the leftmost stop puts `experience_years_max=0` in the URL, both chips appear in the sidebar and remove cleanly, and an existing `?seniority=senior` link still selects the pill in its new home.

**Not verified end-to-end against a live Meilisearch.** The dev server pointed at the production API, which does not know the new param yet and correctly reported it under `meta.ignored_params`. The filter string itself is covered by unit tests at the query-construction layer, and it is the same form as the `>=` filter that runs against that attribute in production today.

## Not in this change

`role_type` (Individual Contributor vs People Manager). It needs a new column, a new dictionary, a Meilisearch facet and a `backfill-derive` + reindex pass, so it is its own change. The pane leaves room for it.

Spec: `openspec/changes/experience-filter-tab/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Experience filter with maximum-years presets from no experience through 10 years, plus “Any.”
  * Added support for the `experience_years_max` search parameter, including combined minimum and maximum ranges.
  * Added detection for job postings explicitly requiring no prior experience.
  * Moved seniority controls into the Experience filter pane and added filter summaries.

* **Documentation**
  * Updated API, search-filter, and OpenAPI documentation for experience range filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->