### PR TITLE
Say where a role change actually lands: the index, not a backfill

### DIFF
--- a/internal/roletag/roletag.go
+++ b/internal/roletag/roletag.go
@@ -17,6 +17,12 @@
 //
 // The package also owns the catalog (slug → human label), the source of truth
 // for the picker labels emitted into the web contracts.
+//
+// Roles are derived at INDEX time and stored nowhere else: outside code generation,
+// internal/search/document.go is this package's only caller, and `jobs` has no roles
+// column. So a change to the tables below reaches production with the next search
+// rebuild, which re-derives every document — never through cmd/backfill-derive, which
+// re-derives Postgres columns and would spend hours here changing nothing.
 package roletag
 
 import (
@@ -188,8 +194,12 @@ var namedRoleTable = []struct {
 	// The spelled-out forms are not just search synonyms: "User Experience Designer"
 	// derived the bare `design` category and no ux_designer at all, so the role
 	// under-counted every posting titled that way. 4,704 open postings carry one of
-	// these spellings. Existing rows pick the role up on the next backfill-derive; new
-	// ones get it at ingest.
+	// these spellings, and they need nothing to pick the role up: roles are derived at
+	// INDEX time (internal/search/document.go is this package's only non-codegen
+	// caller) and are not a jobs column, so the scheduled reindex re-derives every
+	// document against whatever this table says at the time. A dictionary change here
+	// therefore reaches production with the next rebuild and NOT via backfill-derive,
+	// which re-derives Postgres columns and would spend hours changing nothing.
 	{"ux_designer", "UX Designer", []string{
 		"ux designer", "ui designer", "ui/ux designer", "ux/ui designer",
 		"user experience designer", "user interface designer",

--- a/internal/roletag/roletag.go
+++ b/internal/roletag/roletag.go
@@ -18,11 +18,12 @@
 // The package also owns the catalog (slug → human label), the source of truth
 // for the picker labels emitted into the web contracts.
 //
-// Roles are derived at INDEX time and stored nowhere else: outside code generation,
-// internal/search/document.go is this package's only caller, and `jobs` has no roles
-// column. So a change to the tables below reaches production with the next search
-// rebuild, which re-derives every document — never through cmd/backfill-derive, which
-// re-derives Postgres columns and would spend hours here changing nothing.
+// Roles are derived at INDEX time and land only in the search document
+// (search.JobDocument.Roles) — `jobs` has no roles column. Outside code generation and
+// this package's own tests, internal/search/document.go is the only production caller.
+// So a change to the tables below reaches production with the next search rebuild,
+// which re-derives every document — never through cmd/backfill-derive, which re-derives
+// Postgres columns and would spend hours here changing nothing.
 package roletag
 
 import (
@@ -195,11 +196,11 @@ var namedRoleTable = []struct {
 	// derived the bare `design` category and no ux_designer at all, so the role
 	// under-counted every posting titled that way. 4,704 open postings carry one of
 	// these spellings, and they need nothing to pick the role up: roles are derived at
-	// INDEX time (internal/search/document.go is this package's only non-codegen
-	// caller) and are not a jobs column, so the scheduled reindex re-derives every
-	// document against whatever this table says at the time. A dictionary change here
-	// therefore reaches production with the next rebuild and NOT via backfill-derive,
-	// which re-derives Postgres columns and would spend hours changing nothing.
+	// INDEX time and are not a jobs column (see the package doc), so the scheduled
+	// reindex re-derives every document against whatever this table says at the time.
+	// A dictionary change here therefore reaches production with the next rebuild and
+	// NOT via backfill-derive, which re-derives Postgres columns and would spend hours
+	// changing nothing.
 	{"ux_designer", "UX Designer", []string{
 		"ux designer", "ui designer", "ui/ux designer", "ux/ui designer",
 		"user experience designer", "user interface designer",

--- a/internal/roletag/roletag_test.go
+++ b/internal/roletag/roletag_test.go
@@ -424,8 +424,9 @@ func TestDerive_CommercialMarketingCluster(t *testing.T) {
 // classify — which were redundant for tagging and needed only by search — these were a
 // real gap in the tagging itself: "User Experience Designer" derived the bare `design`
 // category and no ux_designer, so the role under-counted every posting titled that way.
-// Adding them therefore changes what is TAGGED, and existing rows only pick the role up
-// on the next backfill-derive.
+// Adding them therefore changes what is TAGGED — and every existing posting picks the
+// role up on the next scheduled reindex, because roles are derived at index time rather
+// than stored, so nothing has to be backfilled.
 func TestUXDesignerSpelledOutAliases(t *testing.T) {
 	for _, title := range []string{
 		"User Experience Designer",


### PR DESCRIPTION
Correction to #2162.

The comments I added with the `ux_designer` aliases claimed existing postings pick the role up "on the next `backfill-derive`". They do not — and a reader acting on that sentence would run a **fifteen-hour pass over the whole jobs table for no effect**.

Roles are derived at **index time**. Outside code generation, this package's only caller is `internal/search/document.go`, and `jobs` has no `roles` column:

```go
// Roles are the job's natural role slugs derived at index time by roletag from
// its seniority, category, and title.
Roles []string `json:"roles"`
```

So a change to the roletag tables reaches production with the next search rebuild, which re-derives every document. `cmd/backfill-derive` re-derives Postgres columns and never touches them.

In practice the 4,704 `ux_designer` postings from #2162 were picked up by the scheduled `freehire-reindexw` run with no manual step at all.

Recorded in the package doc as well as at the alias entry, because the fact is not visible from either place on its own.

`gofmt` clean · `go vet` · `go test ./internal/roletag/` · `golangci-lint` 0 issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that role tags are generated during search indexing.
  - Documented that updates to role-tag rules take effect when content is reindexed.
  - Updated guidance to explain that existing postings receive revised tags during the next scheduled reindex.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->