### PR TITLE
Rebuild the invalid talent-network uniqueness index

### DIFF
--- a/migrations/0117_drop_invalid_talent_network_public_id_idx.sql
+++ b/migrations/0117_drop_invalid_talent_network_public_id_idx.sql
@@ -27,4 +27,7 @@
 --
 -- On an existing prod volume, run detached from the SSH session. Yes: the instruction
 -- that was ignored the first time is the one that has to be followed now.
+--
+-- IF EXISTS here, unlike 0118: a drop that already succeeded should be a no-op on
+-- retry, while a create that already "succeeded" into an invalid index must not be.
 DROP INDEX CONCURRENTLY IF EXISTS public.users_talent_network_public_id_key;

--- a/migrations/0117_drop_invalid_talent_network_public_id_idx.sql
+++ b/migrations/0117_drop_invalid_talent_network_public_id_idx.sql
@@ -1,0 +1,30 @@
+-- migrate: no-transaction
+--
+-- users_talent_network_public_id_key is INVALID on prod: a CREATE INDEX CONCURRENTLY
+-- that died before finishing, exactly the failure 0086 warns about in its own closing
+-- paragraph ("on an existing prod volume build it by hand, detached from the SSH
+-- session — a CONCURRENTLY build dies with its ssh session and leaves an INVALID index
+-- behind"). The warning was written into the file that creates this index, and then
+-- the build was run attached anyway.
+--
+-- An invalid index is not merely unused, it is two defects at once:
+--
+--   * The planner ignores it, so `WHERE u.talent_network_public_id = $1` — the lookup
+--     that resolves a public Talent Network profile URL — falls back to a sequential
+--     scan of users. Verified on prod: EXPLAIN returns `Seq Scan on users`.
+--   * 0086 chose a bare unique index over an inline UNIQUE as the ONLY enforcement of
+--     the public UUID's uniqueness. While the index is invalid there is no enforcement
+--     at all, so two accounts could in principle mint the same public profile address.
+--
+-- The second is the reason this is a repair and not a cleanup: nothing observes a
+-- missing guarantee until it is violated. Checked before writing this: 0 duplicate and
+-- 0 NULL values across the table, so the rebuild in 0118 has nothing to conflict with.
+--
+-- Dropped here and recreated in 0118 rather than REINDEXed, following the 0100/0101
+-- precedent for the same situation — one statement per no-transaction file, because a
+-- file's statements are sent as one multi-statement query and Postgres runs those in an
+-- implicit transaction that CONCURRENTLY refuses (see 0086's own note).
+--
+-- On an existing prod volume, run detached from the SSH session. Yes: the instruction
+-- that was ignored the first time is the one that has to be followed now.
+DROP INDEX CONCURRENTLY IF EXISTS public.users_talent_network_public_id_key;

--- a/migrations/0118_recreate_talent_network_public_id_idx.sql
+++ b/migrations/0118_recreate_talent_network_public_id_idx.sql
@@ -13,7 +13,15 @@
 -- CONCURRENTLY in its own no-transaction file, same reasoning as 0086/0101. On an
 -- existing prod volume, run it DETACHED from the SSH session (systemd-run or nohup):
 -- attached is how the original build died and left the invalid index this pair exists
--- to clean up. Re-running after an interrupted attempt needs the 0117 drop first,
--- because a half-built index is present-but-invalid and IF NOT EXISTS would skip it.
-CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS users_talent_network_public_id_key
+-- to clean up.
+--
+-- Deliberately NO `IF NOT EXISTS`, unlike 0086 and 0101. A failed CONCURRENTLY build
+-- leaves an invalid index UNDER THIS NAME, and a no-transaction file that errors is not
+-- recorded as applied — so the next migrate run retries this file. With IF NOT EXISTS
+-- that retry would see the name taken, skip silently, and record the migration as done,
+-- leaving prod with the invalid index and the ledger claiming it was rebuilt. That is
+-- precisely the failure this pair exists to repair, re-created automatically and this
+-- time invisibly. Without it the retry fails loudly and the operator runs 0117 first,
+-- which is the only order that actually works.
+CREATE UNIQUE INDEX CONCURRENTLY users_talent_network_public_id_key
     ON public.users (talent_network_public_id);

--- a/migrations/0118_recreate_talent_network_public_id_idx.sql
+++ b/migrations/0118_recreate_talent_network_public_id_idx.sql
@@ -1,0 +1,19 @@
+-- migrate: no-transaction
+--
+-- Recreates users_talent_network_public_id_key, which 0117 dropped because prod's copy
+-- was INVALID. Same definition as 0086 — this is a repair, not a redesign, so the shape
+-- must not drift: a bare unique index (no named UNIQUE table constraint), which is what
+-- 0086 chose and what credit_ledger_reward_ref_uniq (0041) established as the precedent
+-- for a concurrently-built uniqueness guard.
+--
+-- It restores both things the invalid index was failing to do: the uniqueness of the
+-- public profile UUID, and an index scan for `WHERE u.talent_network_public_id = $1`
+-- instead of the sequential scan on users that EXPLAIN showed on prod.
+--
+-- CONCURRENTLY in its own no-transaction file, same reasoning as 0086/0101. On an
+-- existing prod volume, run it DETACHED from the SSH session (systemd-run or nohup):
+-- attached is how the original build died and left the invalid index this pair exists
+-- to clean up. Re-running after an interrupted attempt needs the 0117 drop first,
+-- because a half-built index is present-but-invalid and IF NOT EXISTS would skip it.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS users_talent_network_public_id_key
+    ON public.users (talent_network_public_id);


### PR DESCRIPTION
`users_talent_network_public_id_key` is **INVALID** on prod — a `CREATE INDEX CONCURRENTLY` that died before finishing.

The irony: `0086`, the migration that creates this index, closes by warning to build it detached from the SSH session, because "a CONCURRENTLY build dies with its ssh session and leaves an INVALID index behind". It was run attached anyway.

## An invalid index is two defects, not one

**It is ignored by the planner.** `WHERE u.talent_network_public_id = $1` — the lookup that resolves a public Talent Network profile URL (`internal/db/queries/users.sql`) — falls back to a sequential scan. Verified on prod:

```
EXPLAIN SELECT id FROM users WHERE talent_network_public_id = '…'::uuid;

 Seq Scan on users
   Filter: (talent_network_public_id = '…'::uuid)
```

**It enforces nothing.** `0086` deliberately chose a bare unique index over an inline `UNIQUE` as the *only* enforcement of that public UUID's uniqueness. While invalid, there is no enforcement at all — two accounts could in principle mint the same public profile address.

That second half is why this is a repair and not a cleanup. `users` is 823 rows and 600 kB, so the sequential scan costs nothing today. The missing guarantee is the part that does not stay cheap, and nothing observes it until it is violated.

## Checked before writing it

| | |
|---|---|
| Duplicate `talent_network_public_id` values | **0** |
| NULL values | **0** |
| Column actually used? | yes — public profile URL resolution, plus `api.ts` / `types.ts` on the frontend |

So the rebuild has nothing to conflict with. Worth stating explicitly that this was checked: rebuilding a unique index over data that had been unguarded for an unknown period is exactly where a migration fails halfway through a deploy.

## Why drop-and-recreate rather than REINDEX

Follows the `0100`/`0101` precedent for the same situation. One statement per `no-transaction` file, because a file's statements go out as a single multi-statement query and Postgres runs those in an implicit transaction that `CONCURRENTLY` refuses — the reasoning `0086` already documents for itself.

`0118` restates `0086`'s definition unchanged. A repair must not quietly redesign the thing it repairs.

## Deploying

Both files are `CONCURRENTLY`, so **run detached from the SSH session**. `release.sh` runs under systemd and is already detached, which is what this PR relies on — attached is how the original build died and produced the invalid index this pair exists to clean up.

Order matters: `0117` drops before `0118` creates. A half-built index is present-but-invalid, and `IF NOT EXISTS` would skip it, so the drop cannot be omitted on a retry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the database uniqueness constraint for talent network public IDs.
  * Improved query planning and ensured duplicate public IDs are properly prevented.
  * Validated existing data before recreating the corrected unique index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->