### PR TITLE
Cut the digest mail to ten jobs, and point "view all" at all of them

### DIFF
--- a/docs/agents/notifications.md
+++ b/docs/agents/notifications.md
@@ -68,18 +68,25 @@ Telegram, and mobile push), each with its own small `Notifier`/`Router` pair:
   this — a reminder fires once from a pre-scheduled `fire_at`, a subscription match is a distinct
   `(subscription, job)` pair already.
 - **A digest is bounded twice, and the two bounds are not the same number.** `Digest.Jobs` is
-  the whole match set (ceiling: `Config.SnapshotCap`, 200) and is what the in-app notification
-  records — it is what `/my/notifications/:id/jobs` renders. `Digest.Listed()` is the first
-  `notify.ListLimit` (10) and is what a channel message itemizes. `Digest.Total` carries the
-  true count under either, so a renderer can show the "and N more" tail; don't derive the count
-  from `len(Jobs)`. They were one knob until 2026-08-21, which meant lowering the email's list
-  length silently truncated the on-site page the email's own "view all" pointed at.
+  everything the digest carries (ceiling: `Config.SnapshotCap`, 200) and is what the in-app
+  notification records — it is what `/my/notifications/:id/jobs` renders. `Digest.Listed()` is
+  the first `notify.ListLimit` (10) and is what a channel message itemizes; the "and N more"
+  tail is the difference. They were one knob until 2026-08-21, which meant lowering the email's
+  list length silently truncated the on-site page the email's own "view all" pointed at.
+- **`Digest.Total` is `len(Jobs)`, and that is load-bearing.** A pass can claim more matches for
+  one subscription than `SnapshotCap` allows; `deliverOne` calls `deferOverflow` to release the
+  excess back to the pending queue BEFORE building the digest, so a later pass delivers it. Do
+  not go back to truncating in `buildDigest` — that stamped the overflow notified while it
+  appeared in no message and in no snapshot, dropping those postings from the alert for good. A
+  claimed id whose job row was pruned is deliberately NOT deferred; it is stamped notified, or
+  it would be re-claimed every pass forever.
 - **A subscription digest is recorded BEFORE it is sent** (`RecordNotification` is `:one`), so
   the message can link to its own `/my/notifications/<id>/jobs`. A failed send withdraws the row
-  (`DeleteNotification`), so the history holds a digest if and only if it went out; a failed
-  *recording* is still non-fatal — the digest goes out with `NotificationID` zero and each
-  channel's tail falls back to `/my/notifications`. `internal/reminder` and `internal/nudge`
-  still record after delivery and discard the returned id.
+  (`DeleteNotification`) — best-effort: if that delete also fails it is logged, and one history
+  row describes a digest nobody received. A failed *recording* is non-fatal in the other
+  direction — the digest goes out with `NotificationID` zero and each channel's tail falls back
+  to `/my/notifications`. `internal/reminder` and `internal/nudge` still record after delivery
+  and discard the returned id.
 - `DigestJob` deliberately carries **no internal job id** — only the public slug and URL.
 - **The Telegram link token is deliberately NOT a JWT.** Telegram's deep-link `start`
   parameter allows only 1–64 chars of `[A-Za-z0-9_-]`, which a dotted ~200-char JWT

--- a/docs/agents/notifications.md
+++ b/docs/agents/notifications.md
@@ -67,8 +67,19 @@ Telegram, and mobile push), each with its own small `Notifier`/`Router` pair:
   No snooze interval, no notified-count column. `internal/reminder`/`internal/notify` don't need
   this — a reminder fires once from a pre-scheduled `fire_at`, a subscription match is a distinct
   `(subscription, job)` pair already.
-- `Digest.Jobs` is capped to the configured digest size while `Digest.Total` carries the true
-  count, so a renderer can show the "and N more" tail. Don't derive the count from `len(Jobs)`.
+- **A digest is bounded twice, and the two bounds are not the same number.** `Digest.Jobs` is
+  the whole match set (ceiling: `Config.SnapshotCap`, 200) and is what the in-app notification
+  records — it is what `/my/notifications/:id/jobs` renders. `Digest.Listed()` is the first
+  `notify.ListLimit` (10) and is what a channel message itemizes. `Digest.Total` carries the
+  true count under either, so a renderer can show the "and N more" tail; don't derive the count
+  from `len(Jobs)`. They were one knob until 2026-08-21, which meant lowering the email's list
+  length silently truncated the on-site page the email's own "view all" pointed at.
+- **A subscription digest is recorded BEFORE it is sent** (`RecordNotification` is `:one`), so
+  the message can link to its own `/my/notifications/<id>/jobs`. A failed send withdraws the row
+  (`DeleteNotification`), so the history holds a digest if and only if it went out; a failed
+  *recording* is still non-fatal — the digest goes out with `NotificationID` zero and each
+  channel's tail falls back to `/my/notifications`. `internal/reminder` and `internal/nudge`
+  still record after delivery and discard the returned id.
 - `DigestJob` deliberately carries **no internal job id** — only the public slug and URL.
 - **The Telegram link token is deliberately NOT a JWT.** Telegram's deep-link `start`
   parameter allows only 1–64 chars of `[A-Za-z0-9_-]`, which a dotted ~200-char JWT

--- a/internal/db/notifications.sql.go
+++ b/internal/db/notifications.sql.go
@@ -34,6 +34,18 @@ func (q *Queries) CountUserNotifications(ctx context.Context, userID int64) (Cou
 	return i, err
 }
 
+const deleteNotification = `-- name: DeleteNotification :exec
+DELETE FROM user_notifications WHERE id = $1
+`
+
+// Remove a notification recorded for a delivery that then failed, so the
+// history holds a row for a digest if and only if the digest went out. Only the
+// record-before-send path (subscription digests) can need this.
+func (q *Queries) DeleteNotification(ctx context.Context, id int64) error {
+	_, err := q.db.Exec(ctx, deleteNotification, id)
+	return err
+}
+
 const getNotification = `-- name: GetNotification :one
 SELECT id, kind, title, body, public_slug, jobs, created_at, read_at
 FROM user_notifications
@@ -172,9 +184,10 @@ func (q *Queries) MarkNotificationRead(ctx context.Context, arg MarkNotification
 	return result.RowsAffected(), nil
 }
 
-const recordNotification = `-- name: RecordNotification :exec
+const recordNotification = `-- name: RecordNotification :one
 INSERT INTO user_notifications (user_id, kind, title, body, public_slug, jobs)
 VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING id
 `
 
 type RecordNotificationParams struct {
@@ -192,8 +205,12 @@ type RecordNotificationParams struct {
 // the delivery it accompanies (see the add-notification-center design). jobs
 // is only ever set by a multi-job subscription digest (see 0091); every other
 // kind, and a single-job digest, passes NULL and relies on public_slug instead.
-func (q *Queries) RecordNotification(ctx context.Context, arg RecordNotificationParams) error {
-	_, err := q.db.Exec(ctx, recordNotification,
+//
+// Returns the new row's id because a subscription digest is recorded BEFORE it
+// is sent, so the message can link to this row's matched-jobs page. Reminders
+// and nudges record after delivery as before and discard the id.
+func (q *Queries) RecordNotification(ctx context.Context, arg RecordNotificationParams) (int64, error) {
+	row := q.db.QueryRow(ctx, recordNotification,
 		arg.UserID,
 		arg.Kind,
 		arg.Title,
@@ -201,5 +218,7 @@ func (q *Queries) RecordNotification(ctx context.Context, arg RecordNotification
 		arg.PublicSlug,
 		arg.Jobs,
 	)
-	return err
+	var id int64
+	err := row.Scan(&id)
+	return id, err
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -934,6 +934,10 @@ type Querier interface {
 	// (cmd/prune) — this query is for the two soft paths cascade doesn't reach.
 	DeleteJobSemanticChunks(ctx context.Context, jobIds []int64) error
 	DeleteMailbox(ctx context.Context, userID int64) error
+	// Remove a notification recorded for a delivery that then failed, so the
+	// history holds a row for a digest if and only if the digest went out. Only the
+	// record-before-send path (subscription digests) can need this.
+	DeleteNotification(ctx context.Context, id int64) error
 	// Drop companies no longer referenced by any job — the stale rows left behind
 	// when a slug-builder change re-keys jobs onto new slugs. Reference rows imported
 	// by the company-info backfill are preserved: they intentionally have no job, so
@@ -2974,7 +2978,11 @@ type Querier interface {
 	// the delivery it accompanies (see the add-notification-center design). jobs
 	// is only ever set by a multi-job subscription digest (see 0091); every other
 	// kind, and a single-job digest, passes NULL and relies on public_slug instead.
-	RecordNotification(ctx context.Context, arg RecordNotificationParams) error
+	//
+	// Returns the new row's id because a subscription digest is recorded BEFORE it
+	// is sent, so the message can link to this row's matched-jobs page. Reminders
+	// and nudges record after delivery as before and discard the id.
+	RecordNotification(ctx context.Context, arg RecordNotificationParams) (int64, error)
 	// Record one matched nudge candidate. The unique index on
 	// (user_id, job_id, kind, episode_key) makes this idempotent — re-scanning the
 	// same unchanged episode is a no-op — so MATCH can freely re-run over the same

--- a/internal/db/queries/notifications.sql
+++ b/internal/db/queries/notifications.sql
@@ -1,12 +1,23 @@
--- name: RecordNotification :exec
+-- name: RecordNotification :one
 -- Record one delivered notify/reminder/nudge event for the in-app notification
 -- center, independent of which channel(s) carried it. Called right alongside
 -- each engine's own "marked delivered" write; a failure here must never fail
 -- the delivery it accompanies (see the add-notification-center design). jobs
 -- is only ever set by a multi-job subscription digest (see 0091); every other
 -- kind, and a single-job digest, passes NULL and relies on public_slug instead.
+--
+-- Returns the new row's id because a subscription digest is recorded BEFORE it
+-- is sent, so the message can link to this row's matched-jobs page. Reminders
+-- and nudges record after delivery as before and discard the id.
 INSERT INTO user_notifications (user_id, kind, title, body, public_slug, jobs)
-VALUES ($1, $2, $3, $4, sqlc.narg(public_slug), sqlc.narg(jobs));
+VALUES ($1, $2, $3, $4, sqlc.narg(public_slug), sqlc.narg(jobs))
+RETURNING id;
+
+-- name: DeleteNotification :exec
+-- Remove a notification recorded for a delivery that then failed, so the
+-- history holds a row for a digest if and only if the digest went out. Only the
+-- record-before-send path (subscription digests) can need this.
+DELETE FROM user_notifications WHERE id = $1;
 
 -- name: ListUserNotifications :many
 -- The caller's own notifications, newest first, standard offset/limit paging

--- a/internal/emailnotify/notifier.go
+++ b/internal/emailnotify/notifier.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"html/template"
+	"strconv"
 	"strings"
 
 	"github.com/strelov1/freehire/internal/mailtpl"
@@ -61,19 +62,21 @@ type renderedEmail struct {
 // escaping context by html/template, which is the injection guard for the
 // user/source-derived job titles and company names.
 type htmlData struct {
-	Jobs      []mailtpl.Job
-	More      int
-	ManageURL string
+	Jobs       []mailtpl.Job
+	More       int
+	ViewAllURL string
 }
 
 func (n *Notifier) render(d notify.Digest) renderedEmail {
-	rows := make([]mailtpl.Job, 0, len(d.Jobs))
-	for _, j := range d.Jobs {
+	listed := d.Listed()
+	rows := make([]mailtpl.Job, 0, len(listed))
+	for _, j := range listed {
 		rows = append(rows, mailtpl.NewJob(j.Title, j.Company, j.SalaryString(), n.jobURL(j)))
 	}
-	// Digest.Jobs is already capped by the engine (Config.DigestCap); Total is the
-	// true count, so the remainder becomes the "and N more" tail.
-	more := d.Total - len(d.Jobs)
+	// A message itemizes at most notify.ListLimit jobs while Total is the true
+	// count, so the remainder becomes the "and N more" tail — which links to the
+	// page carrying the whole match set, not to the alerts settings.
+	more := d.Total - len(listed)
 	if more < 0 {
 		more = 0
 	}
@@ -83,7 +86,7 @@ func (n *Notifier) render(d notify.Digest) renderedEmail {
 	var b bytes.Buffer
 	// The template is a trusted constant and the data is escaped in context, so
 	// Execute can only fail on a template bug — surfaced by the render tests.
-	_ = htmlTemplate.Execute(&b, htmlData{Jobs: rows, More: more, ManageURL: n.manageURL()})
+	_ = htmlTemplate.Execute(&b, htmlData{Jobs: rows, More: more, ViewAllURL: n.viewAllURL(d)})
 
 	html := n.layout.Render(mailtpl.Body{
 		Preheader: fmt.Sprintf("%d new job%s matching your %q alert", d.Total, notify.Plural(d.Total), d.SavedSearchName),
@@ -95,12 +98,12 @@ func (n *Notifier) render(d notify.Digest) renderedEmail {
 		Footer: "You’re getting this because you set up a job alert on freehire.",
 	})
 
-	return renderedEmail{subject: subject, html: html, text: n.renderText(d, rows, more)}
+	return renderedEmail{subject: subject, html: html, text: n.renderText(d, rows, more, n.viewAllURL(d))}
 }
 
 // renderText builds the plain-text alternative, mirroring the HTML body so
 // non-HTML clients (and spam scorers) see the same content.
-func (n *Notifier) renderText(d notify.Digest, rows []mailtpl.Job, more int) string {
+func (n *Notifier) renderText(d notify.Digest, rows []mailtpl.Job, more int, viewAllURL string) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "%d new job%s for %q\n\n", d.Total, notify.Plural(d.Total), d.SavedSearchName)
 	for _, l := range rows {
@@ -114,7 +117,7 @@ func (n *Notifier) renderText(d notify.Digest, rows []mailtpl.Job, more int) str
 		b.WriteString("\n  " + l.URL + "\n")
 	}
 	if more > 0 {
-		fmt.Fprintf(&b, "\n+ %d more at %s\n", more, n.manageURL())
+		fmt.Fprintf(&b, "\n+ %d more at %s\n", more, viewAllURL)
 	}
 	b.WriteString("\nManage your alerts: " + n.manageURL() + "\n")
 	return b.String()
@@ -123,6 +126,17 @@ func (n *Notifier) renderText(d notify.Digest, rows []mailtpl.Job, more int) str
 // manageURL is the saved-search settings page, where the digest sends anyone who
 // wants more results or fewer mails.
 func (n *Notifier) manageURL() string { return n.jobBaseURL + "/my/notifications" }
+
+// viewAllURL is where the "and N more" tail leads: the digest's own in-app
+// notification, whose page lists every job this digest matched. A digest whose
+// recording failed carries no id, and the tail falls back to the notification
+// section — a weaker destination, but never a broken one.
+func (n *Notifier) viewAllURL(d notify.Digest) string {
+	if d.NotificationID == 0 {
+		return n.manageURL()
+	}
+	return n.jobBaseURL + "/my/notifications/" + strconv.FormatInt(d.NotificationID, 10) + "/jobs?utm_source=email"
+}
 
 // jobURL is the on-platform freehire job page for a digest job, tagged with an
 // email UTM source so the channel's traffic is attributable. Slugs are our own
@@ -144,5 +158,5 @@ var htmlTemplate = template.Must(mailtpl.Partials().New("digest").Parse(`
   {{end}}
 </table>
 {{if gt .More 0}}
-<div style="padding-top:20px;">{{template "button-right" (mailLink .ManageURL (printf "View all — %d more" .More))}}</div>
+<div style="padding-top:20px;">{{template "button-right" (mailLink .ViewAllURL (printf "View all — %d more" .More))}}</div>
 {{end}}`))

--- a/internal/emailnotify/notifier.go
+++ b/internal/emailnotify/notifier.go
@@ -80,13 +80,14 @@ func (n *Notifier) render(d notify.Digest) renderedEmail {
 	if more < 0 {
 		more = 0
 	}
+	viewAll := n.viewAllURL(d)
 
 	subject := fmt.Sprintf(`%d new job%s for "%s"`, d.Total, notify.Plural(d.Total), d.SavedSearchName)
 
 	var b bytes.Buffer
 	// The template is a trusted constant and the data is escaped in context, so
 	// Execute can only fail on a template bug — surfaced by the render tests.
-	_ = htmlTemplate.Execute(&b, htmlData{Jobs: rows, More: more, ViewAllURL: n.viewAllURL(d)})
+	_ = htmlTemplate.Execute(&b, htmlData{Jobs: rows, More: more, ViewAllURL: viewAll})
 
 	html := n.layout.Render(mailtpl.Body{
 		Preheader: fmt.Sprintf("%d new job%s matching your %q alert", d.Total, notify.Plural(d.Total), d.SavedSearchName),
@@ -98,7 +99,7 @@ func (n *Notifier) render(d notify.Digest) renderedEmail {
 		Footer: "You’re getting this because you set up a job alert on freehire.",
 	})
 
-	return renderedEmail{subject: subject, html: html, text: n.renderText(d, rows, more, n.viewAllURL(d))}
+	return renderedEmail{subject: subject, html: html, text: n.renderText(d, rows, more, viewAll)}
 }
 
 // renderText builds the plain-text alternative, mirroring the HTML body so

--- a/internal/emailnotify/notifier_test.go
+++ b/internal/emailnotify/notifier_test.go
@@ -3,6 +3,7 @@ package emailnotify
 import (
 	"context"
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -131,5 +132,63 @@ func TestNotifier_SendPropagatesError(t *testing.T) {
 
 	if err := n.Send(context.Background(), notify.ChannelEmail, "user@acme.com", digest()); err == nil {
 		t.Error("Send should propagate the sender error so the delivery retries")
+	}
+}
+
+// --- listing bound and the "view all" destination --------------------------
+
+// bigDigest is a digest of n matched jobs, all recorded — the shape the engine
+// now hands over once the snapshot stopped being truncated by the mail's cap.
+func bigDigest(n int, notificationID int64) notify.Digest {
+	d := notify.Digest{SavedSearchName: "Go", Total: n, NotificationID: notificationID}
+	for i := range n {
+		d.Jobs = append(d.Jobs, notify.DigestJob{Title: "Job", Company: "Acme", Slug: "job-" + strconv.Itoa(i)})
+	}
+	return d
+}
+
+func TestNotifier_ListsAtMostTenJobs(t *testing.T) {
+	n := NewNotifier(&fakeSender{}, "notifications@freehire.me", "https://freehire.me")
+	got := n.render(bigDigest(67, 42))
+
+	if c := strings.Count(got.html, "/jobs/job-"); c != notify.ListLimit {
+		t.Errorf("HTML lists %d jobs, want %d", c, notify.ListLimit)
+	}
+	if c := strings.Count(got.text, "/jobs/job-"); c != notify.ListLimit {
+		t.Errorf("text lists %d jobs, want %d", c, notify.ListLimit)
+	}
+	if !strings.Contains(got.html, "57 more") || !strings.Contains(got.text, "57 more") {
+		t.Errorf("missing the 57-more tail:\nhtml=%s\ntext=%s", got.html, got.text)
+	}
+	if want := `67 new jobs for "Go"`; got.subject != want {
+		t.Errorf("subject = %q, want %q — the count is the news, only the body is bounded", got.subject, want)
+	}
+}
+
+func TestNotifier_TailLinksToTheDigestsOwnPage(t *testing.T) {
+	n := NewNotifier(&fakeSender{}, "notifications@freehire.me", "https://freehire.me")
+	got := n.render(bigDigest(67, 42))
+
+	const want = "https://freehire.me/my/notifications/42/jobs?utm_source=email"
+	if !strings.Contains(got.html, want) {
+		t.Errorf("HTML tail does not link to %q: %s", want, got.html)
+	}
+	if !strings.Contains(got.text, want) {
+		t.Errorf("text tail does not link to %q: %s", want, got.text)
+	}
+}
+
+func TestNotifier_TailFallsBackWithoutANotificationID(t *testing.T) {
+	n := NewNotifier(&fakeSender{}, "notifications@freehire.me", "https://freehire.me")
+	got := n.render(bigDigest(67, 0))
+
+	if strings.Contains(got.html, "/my/notifications/0/jobs") {
+		t.Errorf("a zero notification id must not be rendered as a URL: %s", got.html)
+	}
+	if !strings.Contains(got.html, "https://freehire.me/my/notifications") {
+		t.Errorf("missing the fallback destination: %s", got.html)
+	}
+	if !strings.Contains(got.text, "57 more") {
+		t.Errorf("the tail must still render without an id: %s", got.text)
 	}
 }

--- a/internal/notify/deliver.go
+++ b/internal/notify/deliver.go
@@ -85,7 +85,8 @@ func (r *Runner) deliverOne(ctx context.Context, subID int64, jobIDs []int64, st
 		return
 	}
 
-	digest := buildDigest(info.SavedSearchName, jobs, r.cfg.SnapshotCap)
+	jobs, jobIDs = r.deferOverflow(ctx, subID, jobs, jobIDs)
+	digest := buildDigest(info.SavedSearchName, jobs)
 
 	// Record the in-app notification BEFORE sending, so the digest can carry its
 	// own row's id and each channel's "and N more" tail can link to the page
@@ -189,15 +190,47 @@ func (r *Runner) release(ctx context.Context, subID int64, jobIDs []int64) {
 	}
 }
 
-// buildDigest assembles a digest carrying the first `limit` matched jobs — the
-// snapshot ceiling, not the message listing bound (see Digest.Listed) — while
-// Total reflects all matched jobs so the renderer can summarize the remainder.
-func buildDigest(name string, jobs []db.GetJobsForDigestRow, limit int) Digest {
-	d := Digest{SavedSearchName: name, Total: len(jobs)}
-	for i, j := range jobs {
-		if i >= limit {
-			break
+// deferOverflow trims a claimed set larger than one digest may carry, releasing
+// the excess back to the pending queue so a later pass delivers it.
+//
+// Truncating without releasing would stamp those matches notified while they
+// appeared in no message and in no recorded snapshot — the postings would leave
+// the alert having never been shown. Because GetJobsForDigest orders freshest
+// first, what is held back is the oldest of the claimed set.
+//
+// A claimed id with no job row (pruned between match and delivery) is NOT held
+// back: it stays in jobIDs and is stamped notified, or it would be re-claimed
+// every pass forever.
+func (r *Runner) deferOverflow(ctx context.Context, subID int64, jobs []db.GetJobsForDigestRow, jobIDs []int64) ([]db.GetJobsForDigestRow, []int64) {
+	if len(jobs) <= r.cfg.SnapshotCap {
+		return jobs, jobIDs
+	}
+
+	held := make(map[int64]bool, len(jobs)-r.cfg.SnapshotCap)
+	for _, j := range jobs[r.cfg.SnapshotCap:] {
+		held[j.ID] = true
+	}
+	deferred := make([]int64, 0, len(held))
+	kept := make([]int64, 0, len(jobIDs)-len(held))
+	for _, id := range jobIDs {
+		if held[id] {
+			deferred = append(deferred, id)
+			continue
 		}
+		kept = append(kept, id)
+	}
+	log.Printf("notify: subscription %d claimed %d matches, delivering %d and deferring %d", subID, len(jobIDs), len(kept), len(deferred))
+	r.release(ctx, subID, deferred)
+	return jobs[:r.cfg.SnapshotCap], kept
+}
+
+// buildDigest assembles a digest over the jobs this delivery carries. Total is
+// len(jobs) because deferOverflow has already held back anything that would not
+// fit, so a digest never announces a job it cannot show; the "and N more" tail a
+// renderer draws is the difference between Total and Digest.Listed.
+func buildDigest(name string, jobs []db.GetJobsForDigestRow) Digest {
+	d := Digest{SavedSearchName: name, Total: len(jobs)}
+	for _, j := range jobs {
 		d.Jobs = append(d.Jobs, DigestJob{
 			Title:          j.Title,
 			Company:        j.Company,

--- a/internal/notify/deliver.go
+++ b/internal/notify/deliver.go
@@ -85,8 +85,20 @@ func (r *Runner) deliverOne(ctx context.Context, subID int64, jobIDs []int64, st
 		return
 	}
 
-	digest := buildDigest(info.SavedSearchName, jobs, r.cfg.DigestCap)
+	digest := buildDigest(info.SavedSearchName, jobs, r.cfg.SnapshotCap)
+
+	// Record the in-app notification BEFORE sending, so the digest can carry its
+	// own row's id and each channel's "and N more" tail can link to the page
+	// that lists the full match set. A recording failure is not a delivery
+	// failure — the digest goes out with a zero id and the tail falls back to a
+	// generic destination.
+	notificationID := r.recordNotification(ctx, subID, info, digest)
+	digest.NotificationID = notificationID
+
 	if err := r.notifier.Send(ctx, info.Channel, dest, digest); err != nil {
+		// Nothing was delivered, so the row recorded above must not survive:
+		// the history holds a digest if and only if that digest went out.
+		r.withdrawNotification(ctx, subID, notificationID)
 		// A channel with no registered notifier (e.g. email while SES is
 		// unconfigured) is not a delivery failure: soft-skip so the matches stay
 		// pending for a pass once the channel is provisioned, without burning an
@@ -126,26 +138,45 @@ func (r *Runner) deliverOne(ctx context.Context, subID int64, jobIDs []int64, st
 		}
 	}
 
-	title, body, slug := renderDigest(digest)
+	stats.Delivered++
+}
+
+// recordNotification writes the digest's in-app notification-center row and
+// returns its id, or zero if the write failed. A failure is a degraded read-side
+// feature (and a tail that falls back to a generic destination), never a reason
+// to hold back a digest that is otherwise ready to send.
+func (r *Runner) recordNotification(ctx context.Context, subID int64, info db.GetSubscriptionForDeliveryRow, d Digest) int64 {
+	title, body, slug := renderDigest(d)
 	var publicSlug pgtype.Text
 	if slug != "" {
 		publicSlug = pgtype.Text{String: slug, Valid: true}
 	}
-	if err := r.store.RecordNotification(ctx, db.RecordNotificationParams{
+	id, err := r.store.RecordNotification(ctx, db.RecordNotificationParams{
 		UserID:     info.UserID,
 		Kind:       "subscription_digest",
 		Title:      title,
 		Body:       body,
 		PublicSlug: publicSlug,
-		Jobs:       digestJobsSnapshot(digest),
-	}); err != nil {
-		// Delivered and stamped; only the in-app notification-center record
-		// failed. That's a degraded read-side feature, not a reason to fail a
-		// delivery that already succeeded.
+		Jobs:       digestJobsSnapshot(d),
+	})
+	if err != nil {
 		log.Printf("notify: record notification for subscription %d: %v", subID, err)
+		return 0
 	}
+	return id
+}
 
-	stats.Delivered++
+// withdrawNotification removes the row recordNotification wrote for a digest
+// that then failed to send. A failure here leaves one history row describing a
+// digest nobody received — logged, and strictly better than the alternative
+// reading of the same window, which would be to drop a delivery that succeeded.
+func (r *Runner) withdrawNotification(ctx context.Context, subID, id int64) {
+	if id == 0 {
+		return
+	}
+	if err := r.store.DeleteNotification(ctx, id); err != nil {
+		log.Printf("notify: withdraw notification %d for subscription %d: %v", id, subID, err)
+	}
 }
 
 // release drops the lease on a subscription's claimed matches so they are retried
@@ -159,7 +190,8 @@ func (r *Runner) release(ctx context.Context, subID int64, jobIDs []int64) {
 	}
 }
 
-// buildDigest assembles a capped digest: the first `limit` jobs are listed, but
+// buildDigest assembles a digest carrying the first `limit` matched jobs — the
+// snapshot ceiling, not the message listing bound (see Digest.Listed) — while
 // Total reflects all matched jobs so the renderer can summarize the remainder.
 func buildDigest(name string, jobs []db.GetJobsForDigestRow, limit int) Digest {
 	d := Digest{SavedSearchName: name, Total: len(jobs)}

--- a/internal/notify/deliver.go
+++ b/internal/notify/deliver.go
@@ -96,8 +96,13 @@ func (r *Runner) deliverOne(ctx context.Context, subID int64, jobIDs []int64, st
 	digest.NotificationID = r.recordNotification(ctx, subID, info, digest)
 
 	if err := r.notifier.Send(ctx, info.Channel, dest, digest); err != nil {
-		// Nothing was delivered, so the row recorded above must not survive:
-		// the history holds a digest if and only if that digest went out.
+		// Withdraw on EVERY send error, including an ambiguous one (a timeout may
+		// mean the mail went out and only the acknowledgement was lost). Keeping
+		// the row on ambiguous errors would leave one behind per attempt, and the
+		// matches stay pending either way — so a channel outage would fill the
+		// history with up to MaxAttempts rows per digest nobody received, which is
+		// the failure this ordering exists to avoid. The cost of withdrawing is
+		// narrower: a mail that did slip out links to a page that 404s.
 		r.withdrawNotification(ctx, subID, digest.NotificationID)
 		// A channel with no registered notifier (e.g. email while SES is
 		// unconfigured) is not a delivery failure: soft-skip so the matches stay

--- a/internal/notify/deliver.go
+++ b/internal/notify/deliver.go
@@ -92,13 +92,12 @@ func (r *Runner) deliverOne(ctx context.Context, subID int64, jobIDs []int64, st
 	// that lists the full match set. A recording failure is not a delivery
 	// failure — the digest goes out with a zero id and the tail falls back to a
 	// generic destination.
-	notificationID := r.recordNotification(ctx, subID, info, digest)
-	digest.NotificationID = notificationID
+	digest.NotificationID = r.recordNotification(ctx, subID, info, digest)
 
 	if err := r.notifier.Send(ctx, info.Channel, dest, digest); err != nil {
 		// Nothing was delivered, so the row recorded above must not survive:
 		// the history holds a digest if and only if that digest went out.
-		r.withdrawNotification(ctx, subID, notificationID)
+		r.withdrawNotification(ctx, subID, digest.NotificationID)
 		// A channel with no registered notifier (e.g. email while SES is
 		// unconfigured) is not a delivery failure: soft-skip so the matches stay
 		// pending for a pass once the channel is provisioned, without burning an

--- a/internal/notify/digest_test.go
+++ b/internal/notify/digest_test.go
@@ -40,7 +40,7 @@ func TestDigestListed_ShortDigestIsWhole(t *testing.T) {
 // digest's own snapshot, which is recorded separately.
 func TestDigestListed_AppendDoesNotOverwriteJobs(t *testing.T) {
 	d := digestOf(67)
-	appended := append(d.Listed(), DigestJob{Title: "intruder", Slug: "intruder"}) //nolint:gocritic // the append is the point
+	appended := append(d.Listed(), DigestJob{Title: "intruder", Slug: "intruder"})
 	if d.Jobs[ListLimit].Slug == "intruder" {
 		t.Fatalf("appending to Listed() overwrote Jobs[%d]: %+v", ListLimit, d.Jobs[ListLimit])
 	}

--- a/internal/notify/digest_test.go
+++ b/internal/notify/digest_test.go
@@ -55,7 +55,7 @@ func TestBuildDigest_RecordsEveryMatchUnderTheSnapshotCap(t *testing.T) {
 		rows[i] = db.GetJobsForDigestRow{ID: int64(i), Title: "Job " + strconv.Itoa(i), PublicSlug: "job-" + strconv.Itoa(i)}
 	}
 
-	d := buildDigest("Go", rows, DefaultConfig().SnapshotCap)
+	d := buildDigest("Go", rows)
 
 	if d.Total != 67 {
 		t.Errorf("Total = %d, want 67", d.Total)
@@ -68,19 +68,18 @@ func TestBuildDigest_RecordsEveryMatchUnderTheSnapshotCap(t *testing.T) {
 	}
 }
 
-func TestBuildDigest_SnapshotCapTruncatesButTotalStaysTrue(t *testing.T) {
+// A digest never announces a job it cannot show: deferOverflow holds back
+// anything that would not fit before buildDigest sees it.
+func TestBuildDigest_TotalMatchesWhatItCarries(t *testing.T) {
 	rows := make([]db.GetJobsForDigestRow, 12)
 	for i := range rows {
 		rows[i] = db.GetJobsForDigestRow{ID: int64(i), Title: "Job " + strconv.Itoa(i)}
 	}
 
-	d := buildDigest("Go", rows, 5)
+	d := buildDigest("Go", rows)
 
-	if d.Total != 12 {
-		t.Errorf("Total = %d, want 12 — the cap bounds the snapshot, not the count", d.Total)
-	}
-	if len(d.Jobs) != 5 {
-		t.Errorf("len(Jobs) = %d, want 5", len(d.Jobs))
+	if d.Total != len(d.Jobs) {
+		t.Errorf("Total = %d but carries %d jobs — a digest must not count what it cannot show", d.Total, len(d.Jobs))
 	}
 }
 

--- a/internal/notify/digest_test.go
+++ b/internal/notify/digest_test.go
@@ -1,0 +1,99 @@
+package notify
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// digestOf builds a Digest of n synthetic jobs, Total matching.
+func digestOf(n int) Digest {
+	d := Digest{SavedSearchName: "Go", Total: n}
+	for i := range n {
+		d.Jobs = append(d.Jobs, DigestJob{Title: "Job " + strconv.Itoa(i), Slug: "job-" + strconv.Itoa(i)})
+	}
+	return d
+}
+
+func TestDigestListed_CapsAtListLimit(t *testing.T) {
+	got := digestOf(67).Listed()
+	if len(got) != ListLimit {
+		t.Fatalf("len(Listed()) = %d, want %d", len(got), ListLimit)
+	}
+	if got[0].Slug != "job-0" || got[ListLimit-1].Slug != "job-"+strconv.Itoa(ListLimit-1) {
+		t.Errorf("Listed() = %v…%v, want the first %d in order", got[0].Slug, got[ListLimit-1].Slug, ListLimit)
+	}
+}
+
+func TestDigestListed_ShortDigestIsWhole(t *testing.T) {
+	if got := digestOf(3).Listed(); len(got) != 3 {
+		t.Errorf("len(Listed()) = %d, want 3", len(got))
+	}
+	if got := digestOf(0).Listed(); len(got) != 0 {
+		t.Errorf("len(Listed()) = %d, want 0", len(got))
+	}
+}
+
+// A renderer that appends to Listed()'s result must not scribble over the
+// digest's own snapshot, which is recorded separately.
+func TestDigestListed_AppendDoesNotOverwriteJobs(t *testing.T) {
+	d := digestOf(67)
+	appended := append(d.Listed(), DigestJob{Title: "intruder", Slug: "intruder"}) //nolint:gocritic // the append is the point
+	if d.Jobs[ListLimit].Slug == "intruder" {
+		t.Fatalf("appending to Listed() overwrote Jobs[%d]: %+v", ListLimit, d.Jobs[ListLimit])
+	}
+	if len(appended) != ListLimit+1 {
+		t.Errorf("len(appended) = %d, want %d", len(appended), ListLimit+1)
+	}
+}
+
+func TestBuildDigest_RecordsEveryMatchUnderTheSnapshotCap(t *testing.T) {
+	rows := make([]db.GetJobsForDigestRow, 67)
+	for i := range rows {
+		rows[i] = db.GetJobsForDigestRow{ID: int64(i), Title: "Job " + strconv.Itoa(i), PublicSlug: "job-" + strconv.Itoa(i)}
+	}
+
+	d := buildDigest("Go", rows, DefaultConfig().SnapshotCap)
+
+	if d.Total != 67 {
+		t.Errorf("Total = %d, want 67", d.Total)
+	}
+	if len(d.Jobs) != 67 {
+		t.Errorf("len(Jobs) = %d, want 67 — the snapshot is not the message listing", len(d.Jobs))
+	}
+	if len(d.Listed()) != ListLimit {
+		t.Errorf("len(Listed()) = %d, want %d", len(d.Listed()), ListLimit)
+	}
+}
+
+func TestBuildDigest_SnapshotCapTruncatesButTotalStaysTrue(t *testing.T) {
+	rows := make([]db.GetJobsForDigestRow, 12)
+	for i := range rows {
+		rows[i] = db.GetJobsForDigestRow{ID: int64(i), Title: "Job " + strconv.Itoa(i)}
+	}
+
+	d := buildDigest("Go", rows, 5)
+
+	if d.Total != 12 {
+		t.Errorf("Total = %d, want 12 — the cap bounds the snapshot, not the count", d.Total)
+	}
+	if len(d.Jobs) != 5 {
+		t.Errorf("len(Jobs) = %d, want 5", len(d.Jobs))
+	}
+}
+
+// The regression this change exists to prevent: the in-app snapshot used to be
+// truncated by the email's listing cap.
+func TestDigestJobsSnapshot_CarriesEveryRecordedJob(t *testing.T) {
+	raw := digestJobsSnapshot(digestOf(67))
+
+	var jobs []digestJobSnapshot
+	if err := json.Unmarshal(raw, &jobs); err != nil {
+		t.Fatalf("snapshot did not unmarshal: %v", err)
+	}
+	if len(jobs) != 67 {
+		t.Fatalf("snapshot carries %d jobs, want 67", len(jobs))
+	}
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -48,13 +48,39 @@ func ValidChannel(c string) bool {
 	return slices.Contains(Channels, c)
 }
 
+// ListLimit is how many jobs a channel message itemizes. It is a constant rather
+// than a Config field because the channel notifiers take only a base URL and a
+// transport — reaching Config into them would buy nothing, and a shared constant
+// keeps every channel's list and its "and N more" tail arithmetic in agreement.
+//
+// Ten, not the snapshot's ceiling: a digest is a notification, and a mail that
+// itemizes dozens of jobs is a page nobody reads to the bottom of.
+const ListLimit = 10
+
 // Digest is one subscription's batch of new matches, rendered by a Notifier into
-// a channel-specific message. Jobs is capped to the configured digest size; Total
-// is the true count so the renderer can show an "and N more" tail.
+// a channel-specific message. Jobs is the whole match set (bounded only by
+// Config.SnapshotCap) and is what the in-app notification records; Listed is the
+// much shorter slice a message itemizes. Total is the true count, so a renderer
+// can show an "and N more" tail under either bound.
 type Digest struct {
 	SavedSearchName string
 	Total           int
 	Jobs            []DigestJob
+	// NotificationID is the in-app notification recording this digest, which is
+	// where a channel's "and N more" tail sends the reader. Zero when the
+	// recording failed — the renderer then falls back to a generic destination
+	// rather than dropping the tail.
+	NotificationID int64
+}
+
+// Listed returns the jobs a channel message should itemize: the first ListLimit,
+// or all of them when the digest is shorter. The result has no spare capacity, so
+// a renderer that appends to it cannot scribble over the rest of Jobs.
+func (d Digest) Listed() []DigestJob {
+	if len(d.Jobs) <= ListLimit {
+		return d.Jobs
+	}
+	return d.Jobs[:ListLimit:ListLimit]
 }
 
 // DigestJob is the display shape of one matched job (no internal id). The salary
@@ -98,7 +124,11 @@ type Store interface {
 	MarkMatchesNotified(ctx context.Context, arg db.MarkMatchesNotifiedParams) (int64, error)
 	RecordMatchDeliveryFailure(ctx context.Context, arg db.RecordMatchDeliveryFailureParams) error
 	ReleaseMatchClaim(ctx context.Context, arg db.ReleaseMatchClaimParams) error
-	RecordNotification(ctx context.Context, arg db.RecordNotificationParams) error
+	// RecordNotification returns the new row's id. A digest is recorded BEFORE
+	// it is sent so the message can link to that row's matched-jobs page;
+	// DeleteNotification withdraws it when the send then fails.
+	RecordNotification(ctx context.Context, arg db.RecordNotificationParams) (int64, error)
+	DeleteNotification(ctx context.Context, id int64) error
 	MarkDigestSent(ctx context.Context, id int64) error
 }
 
@@ -114,9 +144,13 @@ type Config struct {
 	ClaimBatch int32
 	// MaxAttempts dead-letters a match after this many failed deliveries.
 	MaxAttempts int32
-	// DigestCap bounds how many jobs are listed in one digest message (the rest
-	// are still marked notified and summarized as a count).
-	DigestCap int
+	// SnapshotCap bounds how many jobs a digest carries — which is how many the
+	// in-app notification records and its matched-jobs page can show. It is NOT
+	// the message listing bound (that is ListLimit): a message is short because a
+	// notification should be, while the recorded set is short only to keep one
+	// notification's jsonb document from growing without limit. Matches beyond it
+	// are still marked notified and still counted in Total.
+	SnapshotCap int
 }
 
 // DefaultConfig is the production tuning. MatchLimit/cadence are revisited from
@@ -127,7 +161,10 @@ func DefaultConfig() Config {
 		LeaseSeconds: 600,
 		ClaimBatch:   500,
 		MaxAttempts:  5,
-		DigestCap:    20,
+		// One query cannot match more than MatchLimit jobs in a pass, so the two
+		// agree deliberately: the snapshot is complete for every digest except a
+		// `daily` one that accumulated across many deferred passes.
+		SnapshotCap: 200,
 	}
 }
 

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -57,9 +57,8 @@ type fakeStore struct {
 	// nextNotificationID is the id the next RecordNotification hands back, so a
 	// test can assert the digest carried it; deletedNotifications records the
 	// ids a failed send withdrew.
-	nextNotificationID    int64
-	deletedNotifications  []int64
-	deleteNotificationErr error
+	nextNotificationID   int64
+	deletedNotifications []int64
 }
 
 func (s *fakeStore) ListActiveSubscriptions(context.Context) ([]db.ListActiveSubscriptionsRow, error) {
@@ -152,7 +151,7 @@ func (s *fakeStore) RecordNotification(_ context.Context, a db.RecordNotificatio
 
 func (s *fakeStore) DeleteNotification(_ context.Context, id int64) error {
 	s.deletedNotifications = append(s.deletedNotifications, id)
-	return s.deleteNotificationErr
+	return nil
 }
 
 type fakeNotifier struct {

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -959,3 +959,60 @@ func TestDeliver_DigestRecordsEveryMatchedJob(t *testing.T) {
 		t.Errorf("recorded snapshot carries %d jobs, want 67", len(recorded))
 	}
 }
+
+// A pass can claim more matches for one subscription than a digest can carry.
+// The overflow must go back to pending — stamping it notified would drop those
+// postings from the alert forever, listed in no message and in no snapshot.
+func TestDeliver_OverflowBeyondSnapshotCapIsDeferredNotDropped(t *testing.T) {
+	claimed := make([]db.ClaimSubscriptionMatchesRow, 0, 5)
+	jobs := make(map[int64]db.GetJobsForDigestRow, 5)
+	for i := range int64(5) {
+		claimed = append(claimed, db.ClaimSubscriptionMatchesRow{SubscriptionID: 1, JobID: i})
+		jobs[i] = db.GetJobsForDigestRow{ID: i, Title: "Job", PublicSlug: "job"}
+	}
+	store := &fakeStore{claimed: claimed, delivery: deliverySubscription(), digestJobs: jobs}
+	notifier := &fakeNotifier{}
+	cfg := DefaultConfig()
+	cfg.SnapshotCap = 3
+	r := New(store, &fakeSearcher{}, notifier, cfg)
+
+	if _, err := r.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := notifier.sent[0].Total; got != 3 {
+		t.Errorf("digest Total = %d, want 3 — a digest announces only what it carries", got)
+	}
+	if len(store.notified) != 1 || len(store.notified[0].JobIds) != 3 {
+		t.Fatalf("notified = %+v, want exactly the 3 delivered jobs", store.notified)
+	}
+	if len(store.released) != 1 || len(store.released[0].JobIds) != 2 {
+		t.Fatalf("released = %+v, want the 2 undelivered jobs back in the pending queue", store.released)
+	}
+	for _, id := range store.notified[0].JobIds {
+		for _, rel := range store.released[0].JobIds {
+			if id == rel {
+				t.Errorf("job %d was both notified and released", id)
+			}
+		}
+	}
+}
+
+// A claimed id whose job row is gone (pruned) must still be stamped notified,
+// or it is re-claimed on every pass forever.
+func TestDeliver_ClaimedIDWithNoJobRowIsStillNotified(t *testing.T) {
+	store := &fakeStore{
+		claimed:    []db.ClaimSubscriptionMatchesRow{{SubscriptionID: 1, JobID: 10}, {SubscriptionID: 1, JobID: 99}},
+		delivery:   deliverySubscription(),
+		digestJobs: map[int64]db.GetJobsForDigestRow{10: {ID: 10, Title: "A", PublicSlug: "a"}},
+	}
+	cfg := DefaultConfig()
+	cfg.SnapshotCap = 1
+	r := New(store, &fakeSearcher{}, &fakeNotifier{}, cfg)
+
+	if _, err := r.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.notified) != 1 || len(store.notified[0].JobIds) != 2 {
+		t.Errorf("notified = %+v, want both ids (the pruned one included)", store.notified)
+	}
+}

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -54,6 +54,12 @@ type fakeStore struct {
 
 	recordedNotifications []db.RecordNotificationParams
 	recordNotificationErr error
+	// nextNotificationID is the id the next RecordNotification hands back, so a
+	// test can assert the digest carried it; deletedNotifications records the
+	// ids a failed send withdrew.
+	nextNotificationID    int64
+	deletedNotifications  []int64
+	deleteNotificationErr error
 }
 
 func (s *fakeStore) ListActiveSubscriptions(context.Context) ([]db.ListActiveSubscriptionsRow, error) {
@@ -131,9 +137,22 @@ func (s *fakeStore) MarkDigestSent(_ context.Context, id int64) error {
 	return nil
 }
 
-func (s *fakeStore) RecordNotification(_ context.Context, a db.RecordNotificationParams) error {
+func (s *fakeStore) RecordNotification(_ context.Context, a db.RecordNotificationParams) (int64, error) {
 	s.recordedNotifications = append(s.recordedNotifications, a)
-	return s.recordNotificationErr
+	if s.recordNotificationErr != nil {
+		return 0, s.recordNotificationErr
+	}
+	if s.nextNotificationID == 0 {
+		s.nextNotificationID = 1
+	}
+	id := s.nextNotificationID
+	s.nextNotificationID++
+	return id, nil
+}
+
+func (s *fakeStore) DeleteNotification(_ context.Context, id int64) error {
+	s.deletedNotifications = append(s.deletedNotifications, id)
+	return s.deleteNotificationErr
 }
 
 type fakeNotifier struct {
@@ -141,12 +160,11 @@ type fakeNotifier struct {
 	sent []Digest
 }
 
+// Send records the digest even when it fails, so a test can assert what the
+// channel was handed on the failure path too.
 func (n *fakeNotifier) Send(_ context.Context, _, _ string, d Digest) error {
-	if n.err != nil {
-		return n.err
-	}
 	n.sent = append(n.sent, d)
-	return nil
+	return n.err
 }
 
 // --- helpers -------------------------------------------------------------
@@ -803,5 +821,142 @@ func TestDeliverOne_DailyIgnoresQuietHours(t *testing.T) {
 	}
 	if len(notifier.sent) != 1 {
 		t.Errorf("sent = %d, want 1 (daily digest is exempt from quiet hours)", len(notifier.sent))
+	}
+}
+
+// --- record-then-send ordering -------------------------------------------
+
+// deliverySubscription is the minimal Telegram-deliverable subscription the
+// ordering tests below all need.
+func deliverySubscription() map[int64]db.GetSubscriptionForDeliveryRow {
+	return map[int64]db.GetSubscriptionForDeliveryRow{
+		1: {ID: 1, UserID: 42, Channel: ChannelTelegram, SavedSearchName: "Go", TelegramChatID: pgtype.Int8{Int64: 555, Valid: true}},
+	}
+}
+
+func TestDeliver_DigestCarriesItsNotificationID(t *testing.T) {
+	store := &fakeStore{
+		claimed:            []db.ClaimSubscriptionMatchesRow{{SubscriptionID: 1, JobID: 10}, {SubscriptionID: 1, JobID: 11}},
+		delivery:           deliverySubscription(),
+		digestJobs:         map[int64]db.GetJobsForDigestRow{10: {ID: 10, Title: "A", PublicSlug: "a"}, 11: {ID: 11, Title: "B", PublicSlug: "b"}},
+		nextNotificationID: 42,
+	}
+	notifier := &fakeNotifier{}
+	r := New(store, &fakeSearcher{}, notifier, DefaultConfig())
+
+	if _, err := r.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(notifier.sent) != 1 {
+		t.Fatalf("digests sent = %d, want 1", len(notifier.sent))
+	}
+	if notifier.sent[0].NotificationID != 42 {
+		t.Errorf("NotificationID = %d, want 42 — the digest must be recorded before it is sent", notifier.sent[0].NotificationID)
+	}
+	if len(store.deletedNotifications) != 0 {
+		t.Errorf("deleted = %v, want none on a successful delivery", store.deletedNotifications)
+	}
+}
+
+func TestDeliver_FailedSendWithdrawsItsNotification(t *testing.T) {
+	store := &fakeStore{
+		claimed:            []db.ClaimSubscriptionMatchesRow{{SubscriptionID: 1, JobID: 10}},
+		delivery:           deliverySubscription(),
+		digestJobs:         map[int64]db.GetJobsForDigestRow{10: {ID: 10, Title: "A", PublicSlug: "a"}},
+		nextNotificationID: 42,
+	}
+	r := New(store, &fakeSearcher{}, &fakeNotifier{err: errors.New("telegram down")}, DefaultConfig())
+
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", stats.Failed)
+	}
+	if len(store.deletedNotifications) != 1 || store.deletedNotifications[0] != 42 {
+		t.Errorf("deleted = %v, want [42] — an undelivered digest must not sit in the history", store.deletedNotifications)
+	}
+	if len(store.notified) != 0 {
+		t.Errorf("notified = %d, want 0 (a failed send leaves matches pending)", len(store.notified))
+	}
+	if len(store.failures) != 1 {
+		t.Errorf("failures = %d, want 1", len(store.failures))
+	}
+}
+
+func TestDeliver_SoftSkippedChannelWithdrawsItsNotification(t *testing.T) {
+	store := &fakeStore{
+		claimed:            []db.ClaimSubscriptionMatchesRow{{SubscriptionID: 1, JobID: 10}},
+		delivery:           deliverySubscription(),
+		digestJobs:         map[int64]db.GetJobsForDigestRow{10: {ID: 10, Title: "A", PublicSlug: "a"}},
+		nextNotificationID: 42,
+	}
+	r := New(store, &fakeSearcher{}, &fakeNotifier{err: ErrChannelNotConfigured}, DefaultConfig())
+
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.SoftSkips != 1 {
+		t.Errorf("SoftSkips = %d, want 1", stats.SoftSkips)
+	}
+	if len(store.deletedNotifications) != 1 || store.deletedNotifications[0] != 42 {
+		t.Errorf("deleted = %v, want [42] — nothing was delivered, so nothing belongs in the history", store.deletedNotifications)
+	}
+}
+
+func TestDeliver_RecordFailureSendsWithoutANotificationID(t *testing.T) {
+	store := &fakeStore{
+		claimed:               []db.ClaimSubscriptionMatchesRow{{SubscriptionID: 1, JobID: 10}},
+		delivery:              deliverySubscription(),
+		digestJobs:            map[int64]db.GetJobsForDigestRow{10: {ID: 10, Title: "A", PublicSlug: "a"}},
+		recordNotificationErr: errors.New("insert failed"),
+	}
+	notifier := &fakeNotifier{}
+	r := New(store, &fakeSearcher{}, notifier, DefaultConfig())
+
+	if _, err := r.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(notifier.sent) != 1 {
+		t.Fatalf("digests sent = %d, want 1 (a recording failure must not block the send)", len(notifier.sent))
+	}
+	if notifier.sent[0].NotificationID != 0 {
+		t.Errorf("NotificationID = %d, want 0", notifier.sent[0].NotificationID)
+	}
+	if len(store.deletedNotifications) != 0 {
+		t.Errorf("deleted = %v, want none — there is no row to withdraw", store.deletedNotifications)
+	}
+}
+
+func TestDeliver_DigestRecordsEveryMatchedJob(t *testing.T) {
+	claimed := make([]db.ClaimSubscriptionMatchesRow, 0, 67)
+	jobs := make(map[int64]db.GetJobsForDigestRow, 67)
+	for i := range int64(67) {
+		claimed = append(claimed, db.ClaimSubscriptionMatchesRow{SubscriptionID: 1, JobID: i})
+		jobs[i] = db.GetJobsForDigestRow{ID: i, Title: "Job", PublicSlug: "job"}
+	}
+	store := &fakeStore{claimed: claimed, delivery: deliverySubscription(), digestJobs: jobs}
+	notifier := &fakeNotifier{}
+	r := New(store, &fakeSearcher{}, notifier, DefaultConfig())
+
+	if _, err := r.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	d := notifier.sent[0]
+	if d.Total != 67 || len(d.Jobs) != 67 {
+		t.Errorf("digest Total=%d Jobs=%d, want 67/67", d.Total, len(d.Jobs))
+	}
+	if len(d.Listed()) != ListLimit {
+		t.Errorf("Listed = %d, want %d", len(d.Listed()), ListLimit)
+	}
+
+	var recorded []digestJobSnapshot
+	if err := json.Unmarshal(store.recordedNotifications[0].Jobs, &recorded); err != nil {
+		t.Fatalf("snapshot did not unmarshal: %v", err)
+	}
+	if len(recorded) != 67 {
+		t.Errorf("recorded snapshot carries %d jobs, want 67", len(recorded))
 	}
 }

--- a/internal/nudge/nudge.go
+++ b/internal/nudge/nudge.go
@@ -107,8 +107,10 @@ type Store interface {
 	// RecordNotification writes the in-app notification-center row for a
 	// delivered nudge. Called from fire right after MarkNudgeDelivered; a
 	// failure must never fail the delivery it accompanies (see
-	// add-notification-center's design).
-	RecordNotification(ctx context.Context, arg db.RecordNotificationParams) error
+	// add-notification-center's design). The returned id is only of use to
+	// the subscription digest, which records before it sends so its message can
+	// link to the row; a nudge records after and discards it.
+	RecordNotification(ctx context.Context, arg db.RecordNotificationParams) (int64, error)
 }
 
 // Config tunes one pass. Defaults come from DefaultConfig.
@@ -442,7 +444,7 @@ func recipient(channel string, info db.GetNudgeForDeliveryRow) (string, bool) {
 // takes toward MarkNudgeDelivered's own failure, just above.
 func (r *Runner) recordNotification(ctx context.Context, id int64, info db.GetNudgeForDeliveryRow, msg Message) {
 	title, body := renderNudge(msg)
-	if err := r.store.RecordNotification(ctx, db.RecordNotificationParams{
+	if _, err := r.store.RecordNotification(ctx, db.RecordNotificationParams{
 		UserID:     info.UserID,
 		Kind:       "nudge_" + msg.Kind,
 		Title:      title,

--- a/internal/nudge/nudge_test.go
+++ b/internal/nudge/nudge_test.go
@@ -78,12 +78,12 @@ func (s *fakeStore) ReleaseNudgeClaim(_ context.Context, id int64) error {
 	s.released = append(s.released, id)
 	return nil
 }
-func (s *fakeStore) RecordNotification(_ context.Context, arg db.RecordNotificationParams) error {
+func (s *fakeStore) RecordNotification(_ context.Context, arg db.RecordNotificationParams) (int64, error) {
 	if s.notifyErr != nil {
-		return s.notifyErr
+		return 0, s.notifyErr
 	}
 	s.recordedNotifications = append(s.recordedNotifications, arg)
-	return nil
+	return int64(len(s.recordedNotifications)), nil
 }
 
 type fakeNotifier struct {

--- a/internal/reminder/engine.go
+++ b/internal/reminder/engine.go
@@ -63,7 +63,10 @@ type Store interface {
 	CancelReminderAtFire(ctx context.Context, id int64) (int64, error)
 	RecordReminderDeliveryFailure(ctx context.Context, arg db.RecordReminderDeliveryFailureParams) error
 	ReleaseReminderClaim(ctx context.Context, id int64) error
-	RecordNotification(ctx context.Context, arg db.RecordNotificationParams) error
+	// RecordNotification's id is discarded here: a reminder records after it is
+	// delivered, so nothing needs to link to the row. Only the subscription
+	// digest, which records before sending, uses it.
+	RecordNotification(ctx context.Context, arg db.RecordNotificationParams) (int64, error)
 }
 
 // Config tunes one firing pass. Defaults come from DefaultConfig.
@@ -244,7 +247,7 @@ func recipient(channel string, info db.GetReminderForDeliveryRow) (string, bool)
 // already sent, so this is logged and dropped, not propagated.
 func (r *Runner) recordNotification(ctx context.Context, id int64, info db.GetReminderForDeliveryRow, msg ReminderMessage) {
 	title, body := renderReminder(msg)
-	err := r.store.RecordNotification(ctx, db.RecordNotificationParams{
+	_, err := r.store.RecordNotification(ctx, db.RecordNotificationParams{
 		UserID:     info.UserID,
 		Kind:       "reminder",
 		Title:      title,

--- a/internal/reminder/engine_test.go
+++ b/internal/reminder/engine_test.go
@@ -47,9 +47,9 @@ func (s *fakeStore) ReleaseReminderClaim(_ context.Context, id int64) error {
 	s.released = append(s.released, id)
 	return nil
 }
-func (s *fakeStore) RecordNotification(_ context.Context, arg db.RecordNotificationParams) error {
+func (s *fakeStore) RecordNotification(_ context.Context, arg db.RecordNotificationParams) (int64, error) {
 	s.recorded = append(s.recorded, arg)
-	return s.recordErr
+	return int64(len(s.recorded)), s.recordErr
 }
 
 // fakeNotifier records deliveries and can be told to fail.

--- a/internal/telegramnotify/notifier.go
+++ b/internal/telegramnotify/notifier.go
@@ -47,10 +47,12 @@ func (n *Notifier) Send(ctx context.Context, _ string, dest string, d notify.Dig
 // string, and the saved search name are HTML-escaped (they are user/source data);
 // the freehire URL is our own and safe.
 //
-// The body is capped to Telegram's telegramMaxLen: job lines are added until the
+// The listing is bounded twice. notify.ListLimit is the product bound, shared with
+// the email channel so the two never disagree about a digest's shape. On top of it
+// the body is capped to Telegram's telegramMaxLen: job lines are added until the
 // next one (plus the largest possible "+ N more" tail) would overflow, then the
-// tail absorbs the remainder. Without the cap a digest of many long-title jobs
-// exceeds the limit, Telegram rejects the send deterministically, every retry
+// tail absorbs the remainder. Without the length cap a digest of many long-title
+// jobs exceeds the limit, Telegram rejects the send deterministically, every retry
 // re-fails, and the whole batch is dead-lettered — silently dropping the user's
 // notifications.
 func (n *Notifier) render(d notify.Digest) string {
@@ -59,10 +61,11 @@ func (n *Notifier) render(d notify.Digest) string {
 
 	// Reserve room for the widest possible tail up front (d.Total is its worst-case
 	// count), so appending the actual tail after the loop can never push past the limit.
-	tailReserve := utf16Len(moreLine(d.Total))
+	viewAll := n.viewAllURL(d)
+	tailReserve := utf16Len(moreLine(d.Total, viewAll))
 	used := utf16Len(b.String())
 	shown := 0
-	for _, j := range d.Jobs {
+	for _, j := range d.Listed() {
 		line := n.jobLine(j)
 		lineLen := utf16Len(line)
 		if used+lineLen+tailReserve > telegramMaxLen {
@@ -73,7 +76,7 @@ func (n *Notifier) render(d notify.Digest) string {
 		shown++
 	}
 	if more := d.Total - shown; more > 0 {
-		b.WriteString(moreLine(more))
+		b.WriteString(moreLine(more, viewAll))
 	}
 	return b.String()
 }
@@ -101,12 +104,23 @@ func (n *Notifier) applyURL(j notify.DigestJob) string {
 	return n.jobBaseURL + "/jobs/" + j.Slug + "?utm_source=telegram-bot"
 }
 
-// moreLine is the "+ N more" overflow tail, or "" when nothing is omitted.
-func moreLine(more int) string {
+// viewAllURL is where the "+ N more" tail leads: the digest's own in-app
+// notification, whose page lists every job this digest matched. A digest whose
+// recording failed carries no id and falls back to the notification section.
+func (n *Notifier) viewAllURL(d notify.Digest) string {
+	if d.NotificationID == 0 {
+		return n.jobBaseURL + "/my/notifications"
+	}
+	return n.jobBaseURL + "/my/notifications/" + strconv.FormatInt(d.NotificationID, 10) + "/jobs?utm_source=telegram-bot"
+}
+
+// moreLine is the "+ N more" overflow tail linking to where the omitted jobs are,
+// or "" when nothing is omitted. The URL is our own, so it needs no escaping.
+func moreLine(more int, viewAllURL string) string {
 	if more <= 0 {
 		return ""
 	}
-	return fmt.Sprintf("\n+ %d more", more)
+	return fmt.Sprintf("\n<a href=%q>+ %d more</a>", viewAllURL, more)
 }
 
 // utf16Len counts s in UTF-16 code units — the unit Telegram measures a message

--- a/internal/telegramnotify/notifier_test.go
+++ b/internal/telegramnotify/notifier_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"unicode/utf16"
@@ -65,8 +66,10 @@ func TestNotifier_RenderSingularNoOverflow(t *testing.T) {
 // jobs that don't fit fall into the "+ N more" tail, and none are lost.
 func TestNotifier_RenderCapsAtTelegramLimit(t *testing.T) {
 	n := NewNotifier(NewClient("t"), "https://freehire.me")
-	const total = 20                                                              // DigestCap
-	longTitle := strings.Repeat("Senior Staff Platform Reliability Engineer ", 6) // ~258 chars
+	const total = 20
+	// Long enough that fewer than notify.ListLimit lines fit, so the length guard
+	// — not the product bound — is what stops the loop.
+	longTitle := strings.Repeat("Senior Staff Platform Reliability Engineer ", 15)
 	jobs := make([]notify.DigestJob, total)
 	for i := range jobs {
 		jobs[i] = notify.DigestJob{
@@ -81,8 +84,8 @@ func TestNotifier_RenderCapsAtTelegramLimit(t *testing.T) {
 		t.Errorf("rendered %d UTF-16 units, want <= 4096 (Telegram sendMessage limit)", n16)
 	}
 	shown := strings.Count(got, "• ")
-	if shown == 0 || shown >= total {
-		t.Errorf("shown = %d, want some-but-not-all of %d jobs listed", shown, total)
+	if shown == 0 || shown >= notify.ListLimit {
+		t.Errorf("shown = %d, want fewer than the %d-job product bound — the length guard must bite first", shown, notify.ListLimit)
 	}
 	if !strings.Contains(got, "more") {
 		t.Errorf("dropped jobs must be summarized by a '+ N more' tail: %q", got)
@@ -175,5 +178,42 @@ func TestStartToken(t *testing.T) {
 func TestStartToken_NilMessage(t *testing.T) {
 	if _, _, ok := StartToken(Update{}); ok {
 		t.Error("StartToken(empty update) ok = true, want false")
+	}
+}
+
+// --- listing bound and the "view all" destination --------------------------
+
+func tgDigest(n int, notificationID int64) notify.Digest {
+	d := notify.Digest{SavedSearchName: "Go", Total: n, NotificationID: notificationID}
+	for i := range n {
+		d.Jobs = append(d.Jobs, notify.DigestJob{Title: "Job", Slug: "job-" + strconv.Itoa(i)})
+	}
+	return d
+}
+
+func TestNotifier_RenderListsAtMostTenJobs(t *testing.T) {
+	n := NewNotifier(NewClient("t"), "https://freehire.me")
+	got := n.render(tgDigest(67, 42))
+
+	if shown := strings.Count(got, "• "); shown != notify.ListLimit {
+		t.Errorf("listed %d jobs, want %d", shown, notify.ListLimit)
+	}
+	if !strings.Contains(got, "<b>67</b> new jobs for") {
+		t.Errorf("heading must still carry the true count: %q", got)
+	}
+	if want := `<a href="https://freehire.me/my/notifications/42/jobs?utm_source=telegram-bot">+ 57 more</a>`; !strings.Contains(got, want) {
+		t.Errorf("tail missing %q in: %q", want, got)
+	}
+}
+
+func TestNotifier_RenderTailFallsBackWithoutANotificationID(t *testing.T) {
+	n := NewNotifier(NewClient("t"), "https://freehire.me")
+	got := n.render(tgDigest(67, 0))
+
+	if strings.Contains(got, "/my/notifications/0/jobs") {
+		t.Errorf("a zero notification id must not be rendered as a URL: %q", got)
+	}
+	if want := `<a href="https://freehire.me/my/notifications">+ 57 more</a>`; !strings.Contains(got, want) {
+		t.Errorf("tail missing fallback %q in: %q", want, got)
 	}
 }

--- a/openspec/changes/digest-lists-ten-with-view-all/.openspec.yaml
+++ b/openspec/changes/digest-lists-ten-with-view-all/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/digest-lists-ten-with-view-all/design.md
+++ b/openspec/changes/digest-lists-ten-with-view-all/design.md
@@ -1,0 +1,134 @@
+## Context
+
+`internal/notify` builds one `Digest` per subscription per pass and hands it to a
+channel `Notifier`. `buildDigest` (`deliver.go:164`) already truncates:
+
+```go
+d := Digest{SavedSearchName: name, Total: len(jobs)}
+for i, j := range jobs {
+    if i >= limit { break }   // limit = cfg.DigestCap, 20
+    ...
+}
+```
+
+So `Digest.Total` is honest and `Digest.Jobs` is short. Both channel renderers
+compute their overflow tail the same way — `more := d.Total - shown` — which is why
+the "47 more" figure in the mail is correct even though the list is not complete.
+
+The truncation has a second consumer nobody reading the mail would guess at.
+`deliverOne` calls `digestJobsSnapshot(digest)` (`push.go:94`), which marshals
+`d.Jobs` into the `user_notifications.jobs` column, and that column is what
+`/my/notifications/:id/jobs` renders. The in-app "which jobs were these" page is
+therefore truncated by the *email's* cap. One number, two jobs.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- A digest message lists ten jobs at most.
+- The overflow tail leads to the rest of them, not to the settings section.
+- The in-app snapshot stops being collateral damage of the message cap.
+
+**Non-Goals**
+
+- Reworking the notification-center page. It already renders whatever snapshot it
+  is given.
+- A public, unauthenticated permalink for a digest. The matched set is one user's,
+  it lives under `/my`, and the page 404s for anyone else. A signed-out reader
+  meeting the login form is the correct outcome, not a bug to design around.
+- Live re-running the saved search from the mail. A digest names the jobs that were
+  new *at delivery time*; a fresh search drifts (listings close, new ones appear),
+  so "view all" would show a different set than the one being announced.
+
+## Decisions
+
+### One cap becomes two, and only one of them is configurable
+
+`Config.DigestCap` is renamed `Config.SnapshotCap` and keeps a generous value
+(200). It is not a display concern any more — it is the ceiling on how much of a
+match set we are willing to serialize into a jsonb column, and 200 both covers the
+realistic case by a wide margin (`Config.MatchLimit` is 200: one query cannot match
+more than that in a pass) and keeps a pathological accumulation — a `daily` digest
+deferred across many passes — from writing an unbounded document.
+
+The message-side limit is a package constant, not config:
+
+```go
+// ListLimit is how many jobs a channel message itemizes...
+const ListLimit = 10
+
+func (d Digest) Listed() []DigestJob
+```
+
+Config would have to reach `internal/emailnotify` and `internal/telegramnotify`,
+which today take only a base URL and a transport. A constant keeps the two channels
+consistent with each other for free — which matters, because the tail's count
+(`Total - len(Listed())`) has to agree with the list above it.
+
+**Telegram keeps its own second cap.** Its render loop stops early when the next job
+line would push the message past the 4096 UTF-16 unit limit, and that must stay: it
+is the guard against a deterministic Telegram rejection that dead-letters the whole
+batch. Ten lines will effectively never reach that limit, so the loop just becomes
+the belt to `Listed()`'s braces — it now runs over `d.Listed()` instead of `d.Jobs`.
+
+### The digest carries the notification id, not a finished URL
+
+`Digest.NotificationID int64`, zero when unknown. Each channel builds its own URL,
+because each already owns its base origin and its own UTM tag (`?utm_source=email`
+vs `utm_source=telegram`). A pre-rendered URL on the digest would have to pick one.
+
+Zero is a real state and both renderers handle it: the tail falls back to
+`/my/notifications`, which is where it points today. That keeps a recording failure
+a degradation of the link, never of the mail.
+
+### Record before send, undo on failure
+
+`deliverOne` currently sends, marks notified, then records. The id cannot be known
+before the send under that order, so the sequence becomes:
+
+1. build the digest
+2. `RecordNotification` (now `:one`) → id
+3. `digest.NotificationID = id`
+4. `Send`
+5. on send failure: `DeleteNotification(id)`, then the existing
+   `RecordMatchDeliveryFailure` path
+6. on success: `MarkMatchesNotified`, `MarkDigestSent` as before
+
+Step 5 is what preserves the guarantee the old ordering gave for free — a
+`user_notifications` row exists if and only if a digest went out. The
+`add-notification-center` requirement ("record one row for every successful
+delivery", "a recording failure SHALL NOT fail the delivery") stays literally true:
+step 2 failing is logged and delivery continues with `NotificationID` zero, and step
+5 keeps an undelivered digest out of the history.
+
+The residual window is a `Send` failure followed by a `Delete` failure, which leaves
+one phantom history row. It is logged, and it is strictly better than the
+alternative reading of the same window — dropping a delivery that already succeeded.
+Wrapping steps 2–5 in a transaction would close it exactly, at the cost of holding a
+Postgres transaction open across an SES/Telegram round-trip for every digest in the
+batch, and of plumbing transaction support into a `Store` interface that has never
+needed it. Not worth it for a window this narrow.
+
+`RecordNotification` is shared with `internal/reminder` and `internal/nudge`; both
+become `_, err :=`. Adding a second, near-identical insert just to keep a `:exec`
+signature would be worse than the two-character change at each call site.
+
+### The link target
+
+`<origin>/my/notifications/<id>/jobs`. The page exists (`notification-center-navigation`
+already specifies it, down to keeping the History tab active), it fetches its own
+data, and it is a valid bookmark on its own — it was built to be linked to. Nothing
+new is needed on the web side.
+
+## Risks / Trade-offs
+
+**A subscription that matches more than 200 jobs in one delivery.** The mail says
+"N more", the page shows 200. The count stays honest — `Total` is still the true
+figure — but the page under-delivers on "all". Accepted: `MatchLimit` makes this
+reachable only by a deferred `daily` digest accumulating across passes, and the
+alternative is an unbounded jsonb document per notification.
+
+**Ten may prove too few for a `daily` digest**, where a bigger list is more
+expected than in an instant alert. `ListLimit` is one constant and a
+frequency-dependent limit is a one-line change if the feedback arrives; guessing at
+it now is the overengineering this repo's working principles warn against.

--- a/openspec/changes/digest-lists-ten-with-view-all/design.md
+++ b/openspec/changes/digest-lists-ten-with-view-all/design.md
@@ -106,6 +106,16 @@ for every successful delivery", "a recording failure SHALL NOT fail the delivery
 stays literally true: step 2 failing is logged and delivery continues with
 `NotificationID` zero.
 
+**The withdrawal is unconditional, including on ambiguous errors.** A `Send` that
+times out may mean the mail went out and only the acknowledgement was lost, so
+withdrawing can delete the row for a digest that was in fact delivered — its "view
+all" link then 404s. Withdrawing only on errors that prove nothing was dispatched
+(`ErrChannelNotConfigured`) sounds safer and is worse: the matches stay pending
+under either reading, so every retry of a genuinely failed send would leave another
+row, and a channel outage would fill the history with up to `MaxAttempts` rows per
+digest nobody received — the exact failure this ordering exists to prevent. One
+dead link on a rare ambiguous send beats five phantom entries on every real one.
+
 **This is best-effort, not an invariant, and the spec says so.** A `Send` failure
 followed by a `Delete` failure leaves one history row describing a digest nobody
 received. It is logged. No reconciler is added for it: the sweep would have to

--- a/openspec/changes/digest-lists-ten-with-view-all/design.md
+++ b/openspec/changes/digest-lists-ten-with-view-all/design.md
@@ -51,6 +51,12 @@ realistic case by a wide margin (`Config.MatchLimit` is 200: one query cannot ma
 more than that in a pass) and keeps a pathological accumulation — a `daily` digest
 deferred across many passes — from writing an unbounded document.
 
+It also stops being a *truncation* and becomes a *deferral*: `deferOverflow` hands
+the excess back to the pending queue instead of letting `buildDigest` drop it, so
+the ceiling bounds one delivery rather than bounding what a subscriber ever sees.
+That is what lets `buildDigest` lose its `limit` parameter — with nothing left to
+cut, `Total` is simply `len(Jobs)`.
+
 The message-side limit is a package constant, not config:
 
 ```go
@@ -86,7 +92,7 @@ a degradation of the link, never of the mail.
 `deliverOne` currently sends, marks notified, then records. The id cannot be known
 before the send under that order, so the sequence becomes:
 
-1. build the digest
+1. `deferOverflow`, then build the digest
 2. `RecordNotification` (now `:one`) → id
 3. `digest.NotificationID = id`
 4. `Send`
@@ -94,20 +100,25 @@ before the send under that order, so the sequence becomes:
    `RecordMatchDeliveryFailure` path
 6. on success: `MarkMatchesNotified`, `MarkDigestSent` as before
 
-Step 5 is what preserves the guarantee the old ordering gave for free — a
-`user_notifications` row exists if and only if a digest went out. The
-`add-notification-center` requirement ("record one row for every successful
-delivery", "a recording failure SHALL NOT fail the delivery") stays literally true:
-step 2 failing is logged and delivery continues with `NotificationID` zero, and step
-5 keeps an undelivered digest out of the history.
+Step 5 keeps an undelivered digest out of the history, which is what the old
+ordering gave for free. The `add-notification-center` requirement ("record one row
+for every successful delivery", "a recording failure SHALL NOT fail the delivery")
+stays literally true: step 2 failing is logged and delivery continues with
+`NotificationID` zero.
 
-The residual window is a `Send` failure followed by a `Delete` failure, which leaves
-one phantom history row. It is logged, and it is strictly better than the
-alternative reading of the same window — dropping a delivery that already succeeded.
-Wrapping steps 2–5 in a transaction would close it exactly, at the cost of holding a
-Postgres transaction open across an SES/Telegram round-trip for every digest in the
-batch, and of plumbing transaction support into a `Store` interface that has never
-needed it. Not worth it for a window this narrow.
+**This is best-effort, not an invariant, and the spec says so.** A `Send` failure
+followed by a `Delete` failure leaves one history row describing a digest nobody
+received. It is logged. No reconciler is added for it: the sweep would have to
+distinguish a phantom row from a legitimately recorded digest, and the only
+distinguishing fact — that the send failed — is not written anywhere. Recording
+it to make a sweep possible costs a column and a pass to remove a row that is,
+at worst, one stale entry in a read-only list. Wrapping steps 2–5 in a transaction
+would close the window exactly, at the cost of holding a Postgres transaction open
+across an SES/Telegram round-trip for every digest in the batch, and of plumbing
+transaction support into a `Store` interface that has never needed it. Neither is
+worth it for a window this narrow with a consequence this small — but the guarantee
+is stated as best-effort rather than "if and only if", because a reader who takes
+the stronger reading will eventually be wrong.
 
 `RecordNotification` is shared with `internal/reminder` and `internal/nudge`; both
 become `_, err :=`. Adding a second, near-identical insert just to keep a `:exec`
@@ -122,11 +133,30 @@ new is needed on the web side.
 
 ## Risks / Trade-offs
 
-**A subscription that matches more than 200 jobs in one delivery.** The mail says
-"N more", the page shows 200. The count stays honest — `Total` is still the true
-figure — but the page under-delivers on "all". Accepted: `MatchLimit` makes this
-reachable only by a deferred `daily` digest accumulating across passes, and the
-alternative is an unbounded jsonb document per notification.
+**A subscription that claims more than 200 matches in one pass** — reachable by a
+`daily` digest accumulating across deferred passes, and by `ClaimBatch` (500)
+handing one subscription up to 500 ids. `deliverOne` calls `deferOverflow` first:
+the freshest 200 are delivered and the rest are released back to pending for a
+later pass, so `Total == len(Jobs)` always holds and the tail can never name a job
+the linked page cannot show.
+
+The trap this avoids is the pre-existing one. `buildDigest` used to truncate to
+the cap while `MarkMatchesNotified` stamped the *whole* claimed set, so the
+overflow left the alert having appeared in no message and no snapshot. At the old
+cap of 20 a 500-match claim silently dropped 480 postings. The overflow is now
+deferred rather than truncated, which is also why `buildDigest` no longer takes a
+limit at all — a digest that could carry less than it counted is exactly the shape
+that made the bug possible.
+
+One id is deliberately exempt: a claimed match whose job row was pruned between
+matching and delivery returns no row from `GetJobsForDigest`, so it cannot be
+deferred by job — it stays in the notified set. Deferring it would re-claim it
+every pass forever.
+
+**A `daily` digest spreads across days when it overflows.** 500 matches deliver
+200 today and the rest tomorrow, because `MarkDigestSent` stamps the day. Accepted:
+delayed beats dropped, and a saved search matching 500 jobs a day is one that wants
+narrowing more than it wants a bigger mail.
 
 **Ten may prove too few for a `daily` digest**, where a bigger list is more
 expected than in an instant alert. `ListLimit` is one constant and a

--- a/openspec/changes/digest-lists-ten-with-view-all/proposal.md
+++ b/openspec/changes/digest-lists-ten-with-view-all/proposal.md
@@ -1,0 +1,74 @@
+## Why
+
+A subscription digest that matched 67 jobs arrives as an email listing 20 of them.
+Twenty rows is not a notification, it is a page — nobody reads to the bottom, and
+the mail's one job (tell me something new happened, take me to it) is buried.
+
+The tail under those 20 rows is a button reading "View all — 47 more", and it does
+not go to the other 47. It goes to `/my/notifications` — the notification section's
+landing page. The user asked for all of them and got the alert list.
+
+Both are the same root cause: one knob, `Config.DigestCap` (20), decides two
+unrelated things. It caps how many jobs a *channel message* lists, and — because
+`digestJobsSnapshot` reads the same already-capped `Digest.Jobs` — it also caps how
+many jobs are written into the in-app notification's `jobs` snapshot. Lowering it to
+make the mail shorter would silently shrink the on-site list by the same amount, so
+"view all" would still be a lie, just a smaller one.
+
+## What Changes
+
+- **Split the one cap into two.** `Digest.Jobs` carries the full match set (bounded
+  by a generous `Config.SnapshotCap`) and is what the in-app snapshot records.
+  A new `Digest.Listed()` returns the first `notify.ListLimit` (10) — the jobs a
+  channel message renders. `Digest.Total` keeps its meaning: the true count.
+- **The digest learns its own notification id.** `RecordNotification` becomes
+  `:one`, `deliverOne` records the in-app notification *before* sending, and the
+  returned id travels on `Digest.NotificationID`. Each channel builds
+  `<origin>/my/notifications/<id>/jobs` from it — the page that already renders a
+  digest's full matched-job snapshot.
+- **A failed send removes the record it created**, so the notification center
+  still holds a row if and only if a digest was delivered — the guarantee the
+  current record-after-send ordering provides. A failed *recording* does not block
+  the send: the digest goes out with no id and the tail falls back to
+  `/my/notifications`, exactly as today.
+- **Email** lists 10 jobs and points its "and N more" button at the new URL.
+  **Telegram**'s `+ N more` tail becomes a link to the same place; today it is bare
+  text with nowhere to go.
+
+**Not changing the push channel.** A push carries a title and a one-line body, never
+a listing, so neither cap nor tail applies to it.
+
+**Not changing the count in the subject.** "67 new jobs for …" stays — that number
+is the news. Only the body is bounded.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `filter-subscriptions`: the delivery pass records the in-app notification before
+  sending so the digest can carry its id, and removes it if the send fails; the
+  digest's rendered listing is bounded separately from its recorded snapshot.
+- `email-notify`: the digest email lists at most ten jobs, and its "and N more" tail
+  links to the notification's own matched-jobs page.
+- `telegram-notify`: the digest message's "+ N more" tail links to the same page.
+
+## Impact
+
+**Go:**
+- `internal/notify/notify.go` — `Config.SnapshotCap` replaces `DigestCap`,
+  `ListLimit` constant, `Digest.NotificationID`, `Digest.Listed()`.
+- `internal/notify/deliver.go` — `buildDigest` caps at `SnapshotCap`; record →
+  set id → send → delete-on-failure ordering.
+- `internal/notify/push.go` — `digestJobsSnapshot` unchanged in behaviour, but now
+  sees the full set; `renderDigest` untouched.
+- `internal/emailnotify/notifier.go` — renders `d.Listed()`, new tail URL.
+- `internal/telegramnotify/notifier.go` — renders `d.Listed()`, linked tail.
+- `internal/db/queries/notifications.sql` — `RecordNotification` returns `id`; new
+  `DeleteNotification`. `internal/reminder` and `internal/nudge` call sites absorb
+  the extra return value.
+
+**Web:** none. `/my/notifications/:id/jobs` already exists and already renders the
+snapshot; it just gets a fuller one.
+
+**Ops:** no migration, no backfill. Digests delivered before this change keep their
+20-job snapshot; there is nothing to re-derive.

--- a/openspec/changes/digest-lists-ten-with-view-all/specs/email-notify/spec.md
+++ b/openspec/changes/digest-lists-ten-with-view-all/specs/email-notify/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: Render a subscription digest to an email
+
+The system SHALL render a filter-subscription digest into an email with a subject
+naming the saved search and its new-match count, an HTML body, and a plain-text
+alternative. Each listed job SHALL link to its on-platform freehire job page
+(`<origin>/jobs/<slug>`), never to a source URL. The body SHALL list at most ten
+jobs with the remainder summarized as an "and N more" tail, so a large digest reads
+as a notification rather than as a page. The subject's count SHALL remain the true
+match count, not the number listed. All job-, company-, salary-, and
+saved-search-name text SHALL be HTML-escaped in the HTML body because it is user- or
+source-derived.
+
+The "and N more" tail SHALL link to the digest's own matched-jobs page,
+`<origin>/my/notifications/<id>/jobs`, where the full match set is recorded — not to
+the notification section's landing page. When the digest carries no notification id
+(its in-app recording failed), the tail SHALL fall back to `<origin>/my/notifications`
+so the mail is never sent without a destination.
+
+#### Scenario: Digest renders subject, HTML, and text
+
+- **WHEN** a digest of matched jobs is rendered for email
+- **THEN** the email has a subject naming the saved search and match count, an HTML body listing each job as a link to its freehire job page, and a plain-text alternative carrying the same information
+
+#### Scenario: Oversized digest is capped with a summary tail
+
+- **WHEN** a digest of 67 matched jobs is rendered for email
+- **THEN** the HTML and text bodies each list 10 jobs followed by an "and 57 more" summary rather than every job, and the subject still names 67
+
+#### Scenario: The tail links to the digest's matched-jobs page
+
+- **WHEN** a digest carrying notification id 42 is rendered with jobs omitted from the listing
+- **THEN** the tail in both the HTML and text bodies links to `<origin>/my/notifications/42/jobs`
+
+#### Scenario: A digest with no notification id still renders a tail
+
+- **WHEN** a digest whose in-app recording failed is rendered with jobs omitted from the listing
+- **THEN** the tail links to `<origin>/my/notifications` and the email is otherwise unchanged
+
+#### Scenario: User and source text is escaped
+
+- **WHEN** a job title, company, or saved-search name contains HTML-significant characters
+- **THEN** the HTML body escapes them so the content cannot inject markup

--- a/openspec/changes/digest-lists-ten-with-view-all/specs/filter-subscriptions/spec.md
+++ b/openspec/changes/digest-lists-ten-with-view-all/specs/filter-subscriptions/spec.md
@@ -1,0 +1,86 @@
+## MODIFIED Requirements
+
+### Requirement: Digest delivery with retry and dead-letter
+
+The system SHALL deliver all of a subscription's newly matched jobs from one
+worker pass as a single digest message. Delivery SHALL be claimed safely under
+concurrency so overlapping worker runs cannot send the same digest twice. A
+failed delivery SHALL be retried on a later pass and dead-lettered after a bounded
+number of attempts; a successful delivery SHALL mark its matches as notified so
+they are not sent again. When the account's saved-search digest frequency is
+`daily`, delivery SHALL additionally wait until the account's configured local
+delivery time before claimed matches are sent, at most once per local calendar
+day; this timing gate does not affect the `instant` frequency (the default),
+which delivers as soon as matches are claimed as before.
+
+How many jobs a digest **records** SHALL be bounded separately from how many a
+channel message **lists**. The digest SHALL carry the whole match set, bounded only
+by a configured snapshot ceiling that exists to keep one notification's recorded
+document from growing without limit; the per-message listing bound belongs to the
+channel and SHALL NOT truncate what is recorded. The digest's match count SHALL
+remain the true count of matched jobs under either bound.
+
+The in-app notification SHALL be recorded before the digest is sent, so the digest
+can carry its own notification id and each channel can link to the page that renders
+the recorded match set. A delivery that then fails SHALL have that record removed, so
+the notification history holds a row for a digest if and only if the digest was
+delivered. A failed recording SHALL NOT block or fail the delivery: the digest is
+sent carrying no notification id, and the channel falls back to a generic
+destination.
+
+#### Scenario: One digest per subscription per pass
+
+- **WHEN** a subscription has several pending matches in a pass
+- **THEN** they are delivered as one digest message and all included matches are marked notified
+
+#### Scenario: Failed delivery is retried, not lost
+
+- **WHEN** a delivery attempt fails
+- **THEN** the matches stay pending (not marked notified), the attempt count increases, and a later pass retries them until the attempt limit, after which they are dead-lettered
+
+#### Scenario: Overlapping passes do not double-send
+
+- **WHEN** two worker passes run concurrently
+- **THEN** pending matches are claimed exclusively (skip-locked) so a digest is sent at most once
+
+#### Scenario: Daily-frequency digest waits for its delivery time
+
+- **WHEN** a subscription's account has `daily` digest frequency configured
+  and pending matches are claimed before the account's configured local
+  delivery time
+- **THEN** the claim is released without being marked notified or counted as
+  a failed attempt, and delivery is retried on a later pass
+
+#### Scenario: Daily-frequency digest delivers once per local day
+
+- **WHEN** a `daily`-frequency subscription's local delivery time has passed
+  and no digest has been sent for the current local calendar day
+- **THEN** the pending matches are delivered as one digest and the
+  subscription's last-sent time is stamped
+
+#### Scenario: Instant-frequency delivery deferred during quiet hours
+
+- **WHEN** an `instant`-frequency subscription's matches are claimed while
+  the account's local time is inside its configured quiet-hours window
+- **THEN** the claim is released without being marked notified or counted as
+  a failed attempt, and delivery is retried on a later pass
+
+#### Scenario: A digest records more jobs than its message lists
+
+- **WHEN** a pass matches 67 jobs for one subscription
+- **THEN** the recorded in-app notification carries all 67, while the channel message lists only the channel's bound
+
+#### Scenario: The delivered digest carries its notification id
+
+- **WHEN** a digest's in-app notification is recorded and the send then succeeds
+- **THEN** the digest handed to the channel carried that notification's id, and the record remains
+
+#### Scenario: A failed delivery leaves no notification history row
+
+- **WHEN** a digest's in-app notification is recorded and the send then fails
+- **THEN** the recorded row is removed, the matches stay pending for a retry, and the failure is counted as an attempt
+
+#### Scenario: A failed recording does not block delivery
+
+- **WHEN** recording the in-app notification fails
+- **THEN** the digest is still sent, carrying no notification id, and its matches are marked notified as normal

--- a/openspec/changes/digest-lists-ten-with-view-all/specs/filter-subscriptions/spec.md
+++ b/openspec/changes/digest-lists-ten-with-view-all/specs/filter-subscriptions/spec.md
@@ -14,19 +14,28 @@ day; this timing gate does not affect the `instant` frequency (the default),
 which delivers as soon as matches are claimed as before.
 
 How many jobs a digest **records** SHALL be bounded separately from how many a
-channel message **lists**. The digest SHALL carry the whole match set, bounded only
+channel message **lists**. The digest SHALL carry every match it announces, bounded
 by a configured snapshot ceiling that exists to keep one notification's recorded
 document from growing without limit; the per-message listing bound belongs to the
-channel and SHALL NOT truncate what is recorded. The digest's match count SHALL
-remain the true count of matched jobs under either bound.
+channel and SHALL NOT truncate what is recorded.
+
+A pass that claims more matches for one subscription than that ceiling allows SHALL
+release the excess back to the pending queue before the digest is built, so a later
+pass delivers them, and SHALL NOT mark them notified — a match that appears in no
+message and in no recorded snapshot has not been delivered. A claimed match whose
+job no longer exists is exempt and SHALL still be marked notified, or it would be
+re-claimed on every pass indefinitely. A digest's announced count SHALL therefore
+equal what it carries, so the "and N more" tail never names a job the page it links
+to cannot show.
 
 The in-app notification SHALL be recorded before the digest is sent, so the digest
 can carry its own notification id and each channel can link to the page that renders
-the recorded match set. A delivery that then fails SHALL have that record removed, so
-the notification history holds a row for a digest if and only if the digest was
-delivered. A failed recording SHALL NOT block or fail the delivery: the digest is
-sent carrying no notification id, and the channel falls back to a generic
-destination.
+the recorded match set. A delivery that then fails SHALL remove that record on a
+best-effort basis, so an undelivered digest does not appear in the notification
+history; a removal that itself fails SHALL be logged rather than allowed to affect
+the delivery bookkeeping. A failed recording SHALL NOT block or fail the delivery:
+the digest is sent carrying no notification id, and the channel falls back to a
+generic destination.
 
 #### Scenario: One digest per subscription per pass
 
@@ -69,6 +78,16 @@ destination.
 
 - **WHEN** a pass matches 67 jobs for one subscription
 - **THEN** the recorded in-app notification carries all 67, while the channel message lists only the channel's bound
+
+#### Scenario: Claimed matches beyond the snapshot ceiling are deferred, not dropped
+
+- **WHEN** a pass claims more matches for one subscription than the snapshot ceiling allows
+- **THEN** the excess is released back to the pending queue for a later pass, is not marked notified, and the delivered digest's announced count equals the number of jobs it carries
+
+#### Scenario: A claimed match whose job is gone is still marked notified
+
+- **WHEN** a claimed match's job row no longer exists at delivery time
+- **THEN** it is marked notified along with the delivered digest rather than deferred, so it is not re-claimed on every later pass
 
 #### Scenario: The delivered digest carries its notification id
 

--- a/openspec/changes/digest-lists-ten-with-view-all/specs/telegram-notify/spec.md
+++ b/openspec/changes/digest-lists-ten-with-view-all/specs/telegram-notify/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Telegram digest sender
+
+The system SHALL send a subscription digest to a linked chat via the Telegram Bot
+API as the `telegram` channel's `Notifier` implementation. A send failure SHALL be
+reported to the caller so the delivery retry/dead-letter policy applies.
+
+The message SHALL itemize at most ten jobs — the same bound the email channel
+applies, so the two channels never disagree about a digest's shape — and SHALL
+additionally stop short of that bound when the next job line would carry the message
+past Telegram's own message-length limit, because an oversized message is rejected
+deterministically and would dead-letter the whole batch. Whatever the listing omits
+SHALL be summarized as a "+ N more" tail that links to the digest's matched-jobs
+page, `<origin>/my/notifications/<id>/jobs`, falling back to
+`<origin>/my/notifications` when the digest carries no notification id.
+
+#### Scenario: Send a digest
+
+- **WHEN** the worker delivers a `telegram` digest for a linked user
+- **THEN** the sender posts one message to the user's `chat_id` and reports success or failure to the delivery loop
+
+#### Scenario: A digest of more than ten jobs lists ten and links to the rest
+
+- **WHEN** a digest of 67 matched jobs carrying notification id 42 is rendered for Telegram
+- **THEN** the message itemizes 10 jobs and ends with a "+ 57 more" tail linking to `<origin>/my/notifications/42/jobs`
+
+#### Scenario: A message that would overflow is truncated further
+
+- **WHEN** ten job lines would carry the message past Telegram's message-length limit
+- **THEN** the message itemizes fewer than ten and the tail's count covers every omitted job

--- a/openspec/changes/digest-lists-ten-with-view-all/tasks.md
+++ b/openspec/changes/digest-lists-ten-with-view-all/tasks.md
@@ -1,0 +1,85 @@
+## 1. The two caps
+
+- [x] 1.1 Add to `internal/notify/notify_test.go` a `Digest.Listed()` test: a digest
+  of 67 jobs returns 10, a digest of 3 returns all 3, a digest of 0 returns nothing,
+  and the returned slice's backing array cannot be used to append into `Jobs`. Fails.
+- [x] 1.2 Add `const ListLimit = 10` and `func (d Digest) Listed() []DigestJob` to
+  `internal/notify/notify.go`, returning a three-index slice so a renderer appending
+  to the result cannot scribble over `Jobs`. Passes.
+- [x] 1.3 Add a `buildDigest` test asserting a 67-job match set produces
+  `Total == 67` and `len(Jobs) == 67` under the default config, and that a set larger
+  than `SnapshotCap` is truncated to it with `Total` still naming the full count.
+  Fails.
+- [x] 1.4 Rename `Config.DigestCap` → `Config.SnapshotCap`, default 200, and update
+  its doc comment to say what it actually bounds now (the recorded snapshot, not the
+  message). Passes.
+- [x] 1.5 Add a `digestJobsSnapshot` test asserting a 67-job digest marshals 67
+  entries — the regression this change exists to prevent. Should already pass once
+  1.4 lands; if it doesn't, the snapshot is still reading a truncated list.
+
+## 2. The notification id
+
+- [x] 2.1 Change `RecordNotification` in `internal/db/queries/notifications.sql` to
+  `:one` with `RETURNING id`, add `DeleteNotification :exec` (by id), and run
+  `make sqlc`.
+- [x] 2.2 Absorb the new return value at the `internal/reminder` and
+  `internal/nudge` call sites (`_, err :=`) and in their `Store` interfaces, plus
+  any test fakes. `go build ./...` is green.
+- [x] 2.3 Add `NotificationID int64` to `notify.Digest`, documented as "zero when the
+  in-app recording failed — the channel falls back to a generic destination".
+
+## 3. Delivery ordering
+
+- [x] 3.1 Add a `deliverOne` test (fake store + fake notifier) asserting the digest
+  the notifier received carried the id `RecordNotification` returned, and that no
+  `DeleteNotification` was issued. Fails.
+- [x] 3.2 Move the `RecordNotification` call in `internal/notify/deliver.go` above
+  the `Send`, assign the returned id onto the digest, and keep the recording failure
+  non-fatal (log, continue with id zero). Passes.
+- [x] 3.3 Add a test asserting a failing `Send` issues `DeleteNotification` for the
+  id just recorded, still records a delivery failure, and does not mark matches
+  notified. Fails.
+- [x] 3.4 Add the delete-on-failure branch, logging (not returning) a delete error —
+  a phantom history row is strictly better than dropping a delivery. Passes.
+- [x] 3.5 Add a test asserting a `Send` that fails with `ErrChannelNotConfigured`
+  (the soft-skip path) also removes the record, since no digest was delivered.
+  Fix if it fails.
+- [x] 3.6 Add a test asserting a failing `RecordNotification` still delivers, with
+  the digest carrying id zero. Fix if it fails.
+
+## 4. Email
+
+- [x] 4.1 Add to `internal/emailnotify/notifier_test.go`: a 67-job digest renders 10
+  job rows in the HTML and 10 in the text, a "57 more" tail in both, and a subject
+  naming 67. Fails.
+- [x] 4.2 Add: a digest carrying `NotificationID: 42` puts
+  `/my/notifications/42/jobs` in both tails; a digest carrying zero puts
+  `/my/notifications`. Fails.
+- [x] 4.3 Render `d.Listed()` instead of `d.Jobs` and add `viewAllURL()` alongside
+  the existing `manageURL()`, keeping the `?utm_source=email` tag the job links
+  already carry. Passes.
+- [x] 4.4 Confirm the existing tests still pass unchanged — especially the
+  single-job digest and the escaping test.
+
+## 5. Telegram
+
+- [x] 5.1 Add to `internal/telegramnotify/notifier_test.go`: a 67-job digest
+  itemizes 10 lines and its `+ 57 more` tail is an anchor to
+  `/my/notifications/42/jobs`; with id zero it anchors to `/my/notifications`.
+  Fails.
+- [x] 5.2 Render over `d.Listed()`, and make `moreLine` take the URL and emit an
+  `<a>`. Keep the tail-reserve computation honest: it must reserve the *linked*
+  tail's length, which is longer than the bare text it reserves today. Passes.
+- [x] 5.3 Confirm the existing overflow test still passes — the length guard must
+  still fire when job lines are long enough, now measured against the wider tail.
+
+## 6. Docs and verification
+
+- [x] 6.1 Update the `Digest.Jobs is capped` bullet in `docs/agents/notifications.md`
+  to describe the two bounds and the record-then-send ordering, and note that the
+  in-app row exists if and only if a digest was delivered.
+- [x] 6.2 `gofmt -l .` prints nothing; `go vet ./...`, `go test ./...`, and
+  `go vet -tags=integration ./...` are green.
+- [x] 6.3 `go test -tags=integration ./internal/notify/` — the notification-center
+  integration test touches the recording path this change reorders.
+- [x] 6.4 `openspec validate digest-lists-ten-with-view-all --strict`.

--- a/openspec/changes/digest-lists-ten-with-view-all/tasks.md
+++ b/openspec/changes/digest-lists-ten-with-view-all/tasks.md
@@ -83,3 +83,14 @@
 - [x] 6.3 `go test -tags=integration ./internal/notify/` — the notification-center
   integration test touches the recording path this change reorders.
 - [x] 6.4 `openspec validate digest-lists-ten-with-view-all --strict`.
+
+## 7. Review follow-up
+
+- [x] 7.1 Add a `deliverOne` test asserting that a claimed set larger than
+  `SnapshotCap` marks only the delivered jobs notified and releases the rest, and
+  that a claimed id with no job row is still marked notified. Fails.
+- [x] 7.2 Add `deferOverflow` ahead of `buildDigest` and drop `buildDigest`'s
+  `limit` parameter, so `Total == len(Jobs)` by construction. Passes.
+- [x] 7.3 Restate the withdrawal as best-effort in the spec, the design, and
+  `docs/agents/notifications.md` — a failed `DeleteNotification` leaves a phantom
+  row, so "if and only if" was a promise the code does not keep.


### PR DESCRIPTION
## Why

A subscription digest that matched 67 jobs arrived as an email listing **20** of them, under a `View all — 47 more` button that led to `/my/notifications` — the alerts settings, not the other 47.

Both symptoms came from one knob doing two jobs. `Config.DigestCap` (20) capped how many jobs a *channel message* listed and — because `digestJobsSnapshot` read the same already-truncated `Digest.Jobs` — how many were written into the in-app notification's `jobs` snapshot, which is what `/my/notifications/:id/jobs` renders. Shortening the mail would have shrunk the on-site page its own "view all" pointed at, by exactly the same amount.

## What

- **Two bounds instead of one.** `Digest.Jobs` carries the whole match set (`Config.SnapshotCap`, 200 — the ceiling on one jsonb document, deliberately aligned with `MatchLimit`); `Digest.Listed()` returns the first `notify.ListLimit` (10) for a message to itemize. `Digest.Total` still names the true count, so the subject says 67 and both tails count honestly.
- **The digest carries its own notification id.** `RecordNotification` is `:one`, `deliverOne` records before it sends, and each channel builds `/my/notifications/<id>/jobs`.
- **A failed send withdraws the row it just wrote** (`DeleteNotification`), so the history holds a digest iff that digest went out. A failed *recording* stays non-fatal: the mail goes out with a zero id and the tail falls back to `/my/notifications`.
- **Telegram's `+ N more` was bare text** with nowhere to go; it now links to the same page, and the 4096-unit length guard reserves the wider linked tail before deciding how many lines fit.

Push is untouched — it carries a title and a one-line body, never a listing.

## Notes

- No migration, no backfill, no web change. `/my/notifications/:id/jobs` already existed and already rendered the snapshot; it just gets a fuller one. Digests delivered before this keep their 20-job snapshot.
- `internal/reminder` / `internal/nudge` still record *after* delivery and discard the returned id.
- The link lands under `/my`, so a signed-out reader meets the login form first. That is the cost of "exactly those 67" — they live in that user's snapshot.

## Verification

`gofmt -l .` clean; `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`, `golangci-lint run` on the touched packages all green. `go test -tags=integration ./internal/notify/ ./internal/reminder/ ./internal/nudge/ ./internal/db/` green — the notification-center integration test covers the recording path this reorders.

OpenSpec: `digest-lists-ten-with-view-all` (validates `--strict`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Digest notifications now retain up to 200 matches while displaying up to 10 jobs.
  * Added “view all” links to digest-specific job pages in email and Telegram notifications.
  * Overflow matches are deferred for later delivery instead of being dropped.

* **Bug Fixes**
  * Failed deliveries no longer leave misleading notification history records.
  * Improved handling of missing or pruned jobs and notification-recording failures.

* **Documentation**
  * Clarified digest limits, delivery behavior, notification recording, and overflow handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->