### PR TITLE
Keep the filters when a page link is followed

### DIFF
--- a/web/src/lib/companyFilters.ts
+++ b/web/src/lib/companyFilters.ts
@@ -53,6 +53,11 @@ export class CompanyFilterStore implements FacetStore {
     return this.#url.applied;
   }
 
+  /** The filters as they stand in the address bar — build links off this, not `page.url`. */
+  get params(): URLSearchParams {
+    return this.#url.params;
+  }
+
   get active(): number {
     return activeCompanyFilterCount(this.#url.value);
   }

--- a/web/src/lib/components/CompaniesView.svelte
+++ b/web/src/lib/components/CompaniesView.svelte
@@ -221,7 +221,7 @@
         current={activePage}
         total={pageCount(companies.total)}
         pathname={page.url.pathname}
-        params={page.url.searchParams}
+        params={filters.params}
       />
     {/if}
   </div>

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -577,7 +577,7 @@
         current={activePage}
         total={pageCount(jobs.total)}
         pathname={page.url.pathname}
-        params={page.url.searchParams}
+        params={filters.params}
       />
     {/if}
   </div>

--- a/web/src/lib/components/Pagination.svelte
+++ b/web/src/lib/components/Pagination.svelte
@@ -19,6 +19,11 @@
   // of these IS a navigation to a new page of results, so landing at the top is
   // the right behaviour.
   //
+  // `params` is the caller's filter store's `params` — never `page.url.searchParams`,
+  // which the shallow URL writes leave behind (UrlSyncedState.params explains why).
+  // Read from `page.url`, a listing entered bare renders every link here as a
+  // filter-stripped `?page=N`, which is exactly the bug this note exists to prevent.
+  //
   // The hrefs below skip `resolve()` (and disable the lint that asks for it):
   // `pathname` is handed in from `page.url.pathname`, which SvelteKit has already
   // resolved — base path applied, route params substituted. There is no route id

--- a/web/src/lib/filters.ts
+++ b/web/src/lib/filters.ts
@@ -59,6 +59,11 @@ export class FilterStore {
     return this.#url.applied;
   }
 
+  /** The filters as they stand in the address bar — build links off this, not `page.url`. */
+  get params(): URLSearchParams {
+    return this.#url.params;
+  }
+
   get active(): number {
     return activeFilterCount(this.#url.value);
   }

--- a/web/src/lib/pagination.test.ts
+++ b/web/src/lib/pagination.test.ts
@@ -4,6 +4,7 @@ import {
   canFetchMore,
   pageCount,
   pageExists,
+  pageHref,
   pageOffset,
   pageWindow,
   parsePage,
@@ -133,5 +134,50 @@ describe('pageExists', () => {
   it('stops at the deepest page the search window reaches', () => {
     expect(pageExists(MAX_PAGE, 5_000_000)).toBe(true);
     expect(pageExists(MAX_PAGE + 1, 5_000_000)).toBe(false);
+  });
+});
+
+describe('pageHref', () => {
+  // The bug this guards: the page links were built from `page.url.searchParams`
+  // while the filters reach the URL through a shallow replaceState that SvelteKit
+  // never writes back into `page.url`. On the site's own front door — open `/`,
+  // pick a dozen facets, click "2" — that read returned nothing and the link was a
+  // bare `?page=2`, dropping every filter the visitor had set.
+  it('carries every filter param onto the next page', () => {
+    const params = new URLSearchParams({
+      regions: 'global,latam',
+      work_mode: 'hybrid,remote',
+      skills_exclude: 'java,ruby',
+      q: 'staff engineer',
+    });
+    expect(pageHref('/', params, 2)).toBe(
+      '/?regions=global,latam&work_mode=hybrid,remote&skills_exclude=java,ruby&q=staff+engineer&page=2',
+    );
+  });
+
+  // Page 1 is the canonical address of a filtered listing, so it carries the
+  // filters and NOT a redundant `page=1`.
+  it('drops the page param on the first page but keeps the filters', () => {
+    expect(pageHref('/companies', new URLSearchParams({ industries: 'fintech' }), 1)).toBe(
+      '/companies?industries=fintech',
+    );
+  });
+
+  it('replaces the page already in the params rather than appending one', () => {
+    const params = new URLSearchParams({ category: 'backend', page: '4' });
+    expect(pageHref('/', params, 5)).toBe('/?category=backend&page=5');
+  });
+
+  // Commas stay literal: the filter store writes `skills=go,react` to the address
+  // bar, so paging must not swap the visitor onto a percent-escaped twin of the
+  // URL they are already on.
+  it('keeps comma-joined facet values readable', () => {
+    expect(pageHref('/', new URLSearchParams({ skills: 'go,react' }), 3)).toBe(
+      '/?skills=go,react&page=3',
+    );
+  });
+
+  it('leaves an unfiltered listing with a plain path', () => {
+    expect(pageHref('/jobs', new URLSearchParams(), 1)).toBe('/jobs');
   });
 });

--- a/web/src/lib/pagination.ts
+++ b/web/src/lib/pagination.ts
@@ -6,7 +6,9 @@
 // back a plain <nav> of <a href="?page=N"> rendered alongside the feed, so the
 // catalogue is reachable by links and not by the sitemap alone.
 //
-// Pure and dependency-free so it unit-tests without a Svelte runtime.
+// Pure, and free of the Svelte runtime, so it unit-tests in plain Node.
+
+import { toSearchString } from './urlSearchString';
 
 /** Rows per page — the LIMIT every listing `load` searches with. */
 export const PAGE_SIZE = 20;
@@ -95,13 +97,17 @@ export function pageWindow(current: number, total: number): (number | null)[] {
   return out;
 }
 
-/** `?page=N` applied to the current query string, keeping every other param
- *  (filters, sort) intact. Page 1 drops the param entirely so the canonical
- *  first page has one address, not two. */
+/** `?page=N` applied to `params` — the query string as it stands in the ADDRESS BAR
+ *  (see Pagination.svelte's prop note) — keeping every other param intact. Page 1
+ *  drops the param entirely so the canonical first page has one address, not two.
+ *
+ *  Serialized with `toSearchString`, the same call the filter store's URL write
+ *  uses, so paging can't swap the visitor onto a percent-escaped twin of the
+ *  address they are already on. */
 export function pageHref(pathname: string, params: URLSearchParams, page: number): string {
   const next = new URLSearchParams(params);
   if (page <= 1) next.delete('page');
   else next.set('page', String(page));
-  const query = next.toString();
+  const query = toSearchString(next);
   return query ? `${pathname}?${query}` : pathname;
 }

--- a/web/src/lib/urlSynced.svelte.ts
+++ b/web/src/lib/urlSynced.svelte.ts
@@ -82,6 +82,20 @@ export class UrlSyncedState<T> {
     this.applied = seeded;
   }
 
+  /** The query params this state currently occupies in the address bar — the very
+   *  serialization `#write` last put there, so it is in lockstep with the URL by
+   *  construction (`value` is written synchronously).
+   *
+   *  Anything building a link to "this screen, with one thing changed" (the page
+   *  links, a share/return-to URL) must read THIS, never `page.url`. The writes are
+   *  shallow: `replaceState` updates the address bar and `page.state` and nothing
+   *  else, so `page.url` still holds whatever the last real navigation carried — on
+   *  a screen entered bare, no params at all. A link built from it silently drops
+   *  every filter applied since. */
+  get params(): URLSearchParams {
+    return this.#codec.serialize(this.value);
+  }
+
   /** Discrete change (facet pill, checkbox, clear): write the URL and apply at once.
    *  A click is never typed fast, so debouncing it would only add latency. */
   setNow(next: T) {


### PR DESCRIPTION
## What and why

Following a page link on a filtered listing dropped every filter. Open `/`, pick a
dozen facets, click "2" — the link reads a bare `?page=2`. Page one of a filtered
search was the only page of it a visitor could reach. Same on `/companies` and on a
company's own posting list.

The listings mirror their filters into the URL with a shallow `replaceState`, which
SvelteKit does **not** write back into `page.url` — it updates the address bar and
`page.state` and nothing else ([client.js#L2551](https://github.com/sveltejs/kit/blob/main/packages/kit/src/runtime/client/client.js)).
`Pagination.svelte` built its hrefs from `page.url.searchParams`, so they carried
whatever the last *real* navigation had. On the front door that is nothing at all.

The filter stores already hold the address bar's truth — they are what writes it —
so `UrlSyncedState` now exposes those params and the two listings build their page
links from that instead. `pageHref` serializes with `toSearchString`, the same call
the URL write uses, so paging no longer swaps the visitor onto a percent-escaped
twin (`skills=go%2Creact`) of the address they are already on.

### Verified against the production API

| case | before | after |
|---|---|---|
| `/?q=golang` | `/?page=2` | `/?q=golang&page=2` |
| `/?regions=global,latam&work_mode=hybrid,remote&category=backend,fullstack` | filters dropped | all carried, commas literal |
| `/companies?q=data` | filters dropped | `/companies?q=data&page=2` |
| `/companies/dollar-tree?q=manager` | filters dropped | `/companies/dollar-tree?q=manager&page=2` |

Following "Next" from a filtered page 1 lands on page 2 with the filters intact, and
"Previous" points back at the filtered page 1 with no redundant `page=1`.

Five `pageHref` unit tests cover the regression.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass. *(no Go in this change)*
- [x] `go test ./...` passes (and `go test -tags=integration ./...` if I touched DB/handlers). *(no Go in this change)*
- [x] I regenerated committed artifacts when their source changed. *(none changed)*
- [x] For `design-system/` changes: `pnpm run check` and `pnpm run build` pass. *(design-system untouched)*
- [x] For `web/` changes: `pnpm run check` and `pnpm run build` pass. *(svelte-check 0 errors, build clean, 1140 tests green, eslint clean)*
- [x] This stays within freehire's core/extension boundary — it does not bloat the core.