### PR TITLE
Center a dialog's content on the phone takeover

### DIFF
--- a/design-system/src/dialog.svelte
+++ b/design-system/src/dialog.svelte
@@ -136,7 +136,15 @@
     className,
   )}
 >
-  <div class="relative min-h-dvh p-6 sm:min-h-full">
+  <!--
+    Below sm the takeover is a full viewport, so flow layout leaves a short
+    dialog pinned to the top edge with the rest of the screen empty under it.
+    Centering is safe for tall content too: past min-h-dvh the box grows and
+    justify-center has nothing left to center, so it can never push content
+    above the scroll container's top. Back to flow at sm, where the card is
+    h-fit and there is no spare height to center against.
+  -->
+  <div class="relative flex min-h-dvh flex-col justify-center p-6 sm:block sm:min-h-full">
     {#if title}
       <h2 id={titleId} class="text-lg font-semibold">{title}</h2>
     {/if}


### PR DESCRIPTION
Below `sm` the shared `Dialog` becomes a full-viewport takeover, and normal flow left a short dialog — a confirm, the auth prompt, a notice — pinned to the very top edge with the rest of the screen empty under it.

The inner wrapper now centers its content there, and falls back to flow at `sm`, where the card is `h-fit` around its content and there is no spare height to center against.

Tall content is unaffected: past `min-h-dvh` the box grows and `justify-center` has nothing left to center, so it can never push content above the scroll container's top edge.

Scope is the design-system base only. `FollowUpDialog` and `GmailConnectDialog` already center their own shells; `FilterModalShell`, `JobDrawer`, `SwipeDeck` and `OnboardingWizard` are full-screen layouts with their own header and footer, so there is nothing to center in them.

## Verification

`pnpm test` / `pnpm lint` / `pnpm check` in `design-system/` — 131 tests, all green (run by the pre-commit hook).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dialog layout on smaller screens by vertically and horizontally centering its content.
  * Preserved the existing layout behavior on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->