### PR TITLE
Say the header scope in glyphs, not in words it already drew

### DIFF
--- a/web/src/lib/components/HeaderLocationFilter.svelte
+++ b/web/src/lib/components/HeaderLocationFilter.svelte
@@ -33,10 +33,14 @@
   const summary = $derived(
     store
       ? summarizeScope(store, variant === 'companies' ? COMPANIES_SCOPE : JOBS_SCOPE)
-      : { icon: 'globe' as const, label: 'Location' },
+      : { icons: ['globe' as const], text: 'Location', extra: 0, label: 'Location' },
   );
   const ICONS = { globe: Globe, remote: House, hybrid: Blend, onsite: Building } as const;
-  const TriggerIcon = $derived(ICONS[summary.icon]);
+  // The head geography and its roll-up as one string; either half can be empty (a
+  // format with no geography draws its icon alone, worldwide draws the globe alone).
+  const trailing = $derived(
+    [summary.text, summary.extra > 0 ? `+${summary.extra}` : ''].filter(Boolean).join(' '),
+  );
 
   // Facets "Clear all" resets, per mode.
   const CLEAR_PARAMS = {
@@ -105,6 +109,7 @@
     aria-haspopup="menu"
     aria-expanded={open}
     aria-label={summary.label}
+    title={summary.label}
     onclick={(e) => {
       // Stop the toggle's own click from reaching the window outside-handler, which
       // would otherwise immediately re-close the just-opened popover.
@@ -113,8 +118,24 @@
     }}
     class="flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
   >
-    <TriggerIcon class="size-4 shrink-0" />
-    <span class="hidden max-w-40 truncate sm:inline">{summary.label}</span>
+    <!-- An avatar-stack of scope glyphs, same trick as CountryFlagStack: each icon laps
+         over the previous one by `--lap` and wears a ring in the box's own background,
+         so the pair reads as two marks rather than one tangle. Earlier icons sit on
+         top, so the cluster reads left-to-right: format first, then geography. -->
+    <span class="flex shrink-0 items-center" style:--lap="0.2em">
+      {#each summary.icons as name, i (name)}
+        {@const Icon = ICONS[name]}
+        <span
+          class={['relative inline-flex rounded-full bg-background ring-2 ring-background', i > 0 && '-ml-[var(--lap)]']}
+          style:z-index={summary.icons.length - i}
+        >
+          <Icon class="size-4" />
+        </span>
+      {/each}
+    </span>
+    {#if trailing}
+      <span class="hidden max-w-40 truncate sm:inline">{trailing}</span>
+    {/if}
     <ChevronDown class="size-3.5 shrink-0 opacity-60" />
   </button>
 

--- a/web/src/lib/components/HeaderLocationFilter.svelte
+++ b/web/src/lib/components/HeaderLocationFilter.svelte
@@ -119,14 +119,17 @@
     class="flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
   >
     <!-- An avatar-stack of scope glyphs, same trick as CountryFlagStack: each icon laps
-         over the previous one by `--lap` and wears a ring in the box's own background,
-         so the pair reads as two marks rather than one tangle. Earlier icons sit on
-         top, so the cluster reads left-to-right: format first, then geography. -->
-    <span class="flex shrink-0 items-center" style:--lap="0.2em">
+         over the previous one and wears a ring in the box's own background, so the pair
+         reads as two marks rather than one tangle. Earlier icons sit on top, so the
+         cluster reads left-to-right: format first, then geography. The lap is small —
+         2px of a 16px glyph, against the flags' 0.4em — because a line icon is mostly
+         the outline that names it, where a flag is a solid disc that survives being
+         half covered. -->
+    <span class="flex shrink-0 items-center">
       {#each summary.icons as name, i (name)}
         {@const Icon = ICONS[name]}
         <span
-          class={['relative inline-flex rounded-full bg-background ring-2 ring-background', i > 0 && '-ml-[var(--lap)]']}
+          class={['relative inline-flex rounded-full bg-background ring-2 ring-background', i > 0 && '-ml-0.5']}
           style:z-index={summary.icons.length - i}
         >
           <Icon class="size-4" />

--- a/web/src/lib/headerScope.test.ts
+++ b/web/src/lib/headerScope.test.ts
@@ -16,54 +16,110 @@ function fakeStore(sel: Record<string, Sel>): Pick<FacetStore, 'facet'> {
 
 describe('summarizeScope', () => {
   it('no selection → neutral Location', () => {
-    expect(summarizeScope(fakeStore({}))).toEqual({ icon: 'globe', label: 'Location' });
+    expect(summarizeScope(fakeStore({}))).toEqual({ icons: ['globe'], text: 'Location', extra: 0, label: 'Location' });
   });
 
-  it('work format only → format icon + label', () => {
+  // The glyph already says "remote", so the word survives only in the accessible
+  // name. With no geography picked the trigger keeps its neutral "Location" text —
+  // a lone glyph would not read as something you can open.
+  it('work format only → icon carries it, text stays the invitation', () => {
     expect(summarizeScope(fakeStore({ work_mode: { include: ['remote'] } }))).toEqual({
-      icon: 'remote',
+      icons: ['remote'],
+      text: 'Location',
+      extra: 0,
       label: 'Remote',
     });
   });
 
   it('single region → region label', () => {
     expect(summarizeScope(fakeStore({ regions: { include: ['eu'] } }))).toEqual({
-      icon: 'globe',
+      icons: ['globe'],
+      text: 'Europe',
+      extra: 0,
       label: 'Europe',
     });
   });
 
   it('multiple regions → first + N roll-up', () => {
     expect(summarizeScope(fakeStore({ regions: { include: ['eu', 'uk'] } }))).toEqual({
-      icon: 'globe',
+      icons: ['globe'],
+      text: 'Europe',
+      extra: 1,
       label: 'Europe +1',
     });
   });
 
   it('country with no region → country label', () => {
     expect(summarizeScope(fakeStore({ countries: { include: ['DE'] } }))).toEqual({
-      icon: 'globe',
+      icons: ['globe'],
+      text: 'Germany',
+      extra: 0,
       label: 'Germany',
     });
   });
 
-  it('work format + multiple regions → format · geo +N', () => {
+  it('work format + multiple regions → format icon, geo text +N', () => {
     expect(
       summarizeScope(fakeStore({ work_mode: { include: ['remote'] }, regions: { include: ['eu', 'uk'] } })),
-    ).toEqual({ icon: 'remote', label: 'Remote · Europe +1' });
+    ).toEqual({ icons: ['remote'], text: 'Europe', extra: 1, label: 'Remote · Europe +1' });
   });
 
   it('excluded geo counts toward the +N roll-up', () => {
     expect(summarizeScope(fakeStore({ regions: { include: ['eu'], exclude: ['uk'] } }))).toEqual({
-      icon: 'globe',
+      icons: ['globe'],
+      text: 'Europe',
+      extra: 1,
       label: 'Europe +1',
+    });
+  });
+
+  describe('worldwide', () => {
+    it('leads the geo roll-up → a globe lapping the format icon, no words', () => {
+      expect(
+        summarizeScope(
+          fakeStore({
+            work_mode: { include: ['remote'] },
+            regions: { include: ['global', 'eu', 'uk'] },
+            countries: { include: ['DE'] },
+          }),
+        ),
+      ).toEqual({ icons: ['remote', 'globe'], text: '', extra: 3, label: 'Remote · Worldwide +3' });
+    });
+
+    it('alone → the globe alone', () => {
+      expect(summarizeScope(fakeStore({ regions: { include: ['global'] } }))).toEqual({
+        icons: ['globe'],
+        text: '',
+        extra: 0,
+        label: 'Worldwide',
+      });
+    });
+
+    it('behind another region keeps that region as the text', () => {
+      expect(summarizeScope(fakeStore({ regions: { include: ['eu', 'global'] } }))).toEqual({
+        icons: ['globe'],
+        text: 'Europe',
+        extra: 1,
+        label: 'Europe +1',
+      });
+    });
+
+    it('a city named global is a place, not everywhere', () => {
+      expect(summarizeScope(fakeStore({ cities: { include: ['global'] } }))).toEqual({
+        icons: ['globe'],
+        text: 'global',
+        extra: 0,
+        label: 'global',
+      });
     });
   });
 
   describe('company spec', () => {
     it('summarizes remote_regions', () => {
       expect(summarizeScope(fakeStore({ remote_regions: { include: ['eu'] } }), COMPANIES_SCOPE)).toEqual({
-        icon: 'globe',
+        icons: ['globe'],
+        text: 'Europe',
+        extra: 0,
         label: 'Europe',
       });
     });
@@ -71,12 +127,14 @@ describe('summarizeScope', () => {
     it('rolls up regions then remote_regions', () => {
       expect(
         summarizeScope(fakeStore({ regions: { include: ['eu'] }, remote_regions: { include: ['uk'] } }), COMPANIES_SCOPE),
-      ).toEqual({ icon: 'globe', label: 'Europe +1' });
+      ).toEqual({ icons: ['globe'], text: 'Europe', extra: 1, label: 'Europe +1' });
     });
 
     it('ignores work_mode (companies have no work format)', () => {
       expect(summarizeScope(fakeStore({ work_mode: { include: ['remote'] } }), COMPANIES_SCOPE)).toEqual({
-        icon: 'globe',
+        icons: ['globe'],
+        text: 'Location',
+        extra: 0,
         label: 'Location',
       });
     });

--- a/web/src/lib/headerScope.ts
+++ b/web/src/lib/headerScope.ts
@@ -11,6 +11,19 @@ import { REGION_LABELS, WORK_MODE_LABELS } from './labels';
 
 export type ScopeIcon = 'globe' | WorkMode;
 
+/** What the trigger draws: an overlapping icon cluster, then the head geography and
+ *  its "+N" roll-up. `label` is the same summary in words — the icons carry meaning
+ *  no screen reader can read, so it stays as the accessible name and the tooltip. */
+export interface ScopeSummary {
+  icons: ScopeIcon[];
+  text: string;
+  extra: number;
+  label: string;
+}
+
+/** The region code that means "anywhere" — drawn as a globe rather than spelled out. */
+const WORLDWIDE = 'global';
+
 /** Which facets a mode summarizes: an optional work-format param (drives the icon)
  *  plus the ordered geography params rolled into "first +N". */
 export interface ScopeSpec {
@@ -36,24 +49,42 @@ function selected(store: Pick<FacetStore, 'facet'>, param: string): string[] {
   return [...f.include, ...f.exclude];
 }
 
-/** Derive the trigger's `{ icon, label }` from the scope facets named by `spec`. */
+/** Derive what the trigger draws from the scope facets named by `spec`.
+ *
+ *  Two selections collapse into icons rather than words: a work format is already
+ *  said by its glyph (a house is "remote"), and the worldwide region is a globe. So
+ *  "Remote · Worldwide +3" draws as a house lapped by a globe, then "+3" — the words
+ *  survive only in `label`, which the button wears as its accessible name and title.
+ */
 export function summarizeScope(
   store: Pick<FacetStore, 'facet'>,
   spec: ScopeSpec = JOBS_SCOPE,
-): { icon: ScopeIcon; label: string } {
+): ScopeSummary {
   const modes = spec.format ? selected(store, spec.format) : [];
   const firstMode = WORK_MODE_VALUES.find((m) => modes.includes(m));
-  const icon: ScopeIcon = firstMode ?? 'globe';
 
-  const geo = spec.geo.flatMap((param) => selected(store, param).map((v) => geoLabel(param, v)));
+  const geo = spec.geo.flatMap((param) => selected(store, param).map((v) => ({ param, value: v })));
+  const head = geo[0];
+  const extra = Math.max(geo.length - 1, 0);
+  // Only a region-shaped param carries the worldwide code; a city or a country
+  // literally named "global" would still be a place, not everywhere.
+  const headIsWorldwide =
+    head !== undefined && head.param !== 'countries' && head.param !== 'cities' && head.value === WORLDWIDE;
+
+  const icons: ScopeIcon[] = [];
+  if (firstMode) icons.push(firstMode);
+  if (headIsWorldwide) icons.push('globe');
+  // Nothing iconic selected — the neutral globe is the resting state of the trigger.
+  if (!icons.length) icons.push('globe');
+
+  const text = head === undefined ? 'Location' : headIsWorldwide ? '' : geoLabel(head.param, head.value);
 
   const parts: string[] = [];
   if (firstMode) parts.push(workModeLabel(firstMode));
-  const head = geo[0];
   if (head !== undefined) {
-    const extra = geo.length - 1;
-    parts.push(extra > 0 ? `${head} +${extra}` : head);
+    const label = geoLabel(head.param, head.value);
+    parts.push(extra > 0 ? `${label} +${extra}` : label);
   }
 
-  return { icon, label: parts.length ? parts.join(' · ') : 'Location' };
+  return { icons, text, extra, label: parts.length ? parts.join(' · ') : 'Location' };
 }


### PR DESCRIPTION
## What and why

The header's scope trigger read `🏠 Remote · Worldwide +3`. The house already says
"remote", and "Worldwide" is a long word for a fact a globe states in one glyph. Both
collapse into an icon cluster — work format, then a globe when the worldwide region
leads the geography — lapped over each other the way `CountryFlagStack` laps flags:
negative margin, a ring in the box's own background, earlier icon on top. What stays
in words is the part that needs them: the head country/region and its `+N`.

`summarizeScope` now returns what to draw (`icons`, `text`, `extra`) instead of a
pre-joined string. The worded summary survives as `label`, which the button wears as
its accessible name **and** its `title` — a glyph reads to no screen reader, and the
tooltip is now the only place the full scope is spelled out.

Two judgement calls worth a look:

- **`Location` stays** as the text whenever no geography is picked, including when a
  work format is (`🏠 Location`). A lone glyph with a chevron does not read as
  something you can open.
- **The globe stands in only for a region-shaped param** carrying `global`. A city
  literally named "global" is a place, not everywhere, and keeps its name. Covered by
  a test.

| Selected | Before | After |
|---|---|---|
| nothing | 🌐 Location | 🌐 Location |
| Remote | 🏠 Remote | 🏠 Location |
| Remote + Worldwide + 3 more | 🏠 Remote · Worldwide +3 | 🏠🌐 +3 (lapped) |
| Remote + Europe + 1 more | 🏠 Remote · Europe +1 | 🏠 Europe +1 |

Verified in a browser at all four states; the first lap value (`0.35em`) ate the
globe's left edge, `0.2em` keeps both glyphs legible.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [ ] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass. — n/a, no Go changed.
- [ ] `go test ./...` passes (and `go test -tags=integration ./...` if I touched DB/handlers). — n/a.
- [x] I regenerated committed artifacts when their source changed — n/a, no SQL or contract source changed.
- [ ] For `design-system/` changes: `pnpm run check` and `pnpm run build` pass. — n/a, none.
- [x] For `web/` changes: `pnpm run check` (0 errors) and `pnpm run build` pass; `pnpm vitest run` — 1144 tests green.
- [x] This stays within freehire's core/extension boundary — one component and its pure summarizer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Location filters now display multiple selected location icons in an overlapping stack.
  - Additional selected locations are summarized with a count.
  - Filter labels adapt responsively and remain accessible with descriptive text.
  - Worldwide selections are represented visually without cluttering the visible summary.

- **Bug Fixes**
  - Improved location summary handling for combinations of worldwide, country, and city selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->