### PR TITLE
Pin that the view parser ignores whatever nginx appends

### DIFF
--- a/internal/viewlog/parse.go
+++ b/internal/viewlog/parse.go
@@ -42,6 +42,16 @@ type Record struct {
 //
 // The request group requires METHOD PATH PROTO, so bad requests logged as "-"
 // (or otherwise malformed) fail to match and are skipped by the caller.
+//
+// NOT anchored at the end, and that is load-bearing rather than an oversight. The
+// live format also carries $request_time and $upstream_response_time after the
+// fields above, added so web-metrics.sh can export latency; this parser neither
+// reads them nor needs to know they are there, and the same pattern keeps reading
+// rotated files written before they existed. Anything appended in future is
+// likewise ignored. Do not "tidy" this by adding a $ — the guard for that is
+// TestParseLine/"ignores the timing fields appended for the latency metrics",
+// which fails on a slug credited to the wrong job rather than merely on a
+// rejected line.
 var combinedLine = regexp.MustCompile(`^(\S+) \S+ \S+ \[([^\]]*)\] "([A-Z]+) (\S+) [^"]*" (\d{3}) \S+ "[^"]*" "([^"]*)"(?: "([^"]*)")?`)
 
 // timeLocalLayout is nginx's $time_local, e.g. 21/Jul/2026:12:00:00 +0000.

--- a/internal/viewlog/parse_test.go
+++ b/internal/viewlog/parse_test.go
@@ -100,4 +100,57 @@ func TestParseLine(t *testing.T) {
 			t.Errorf("Purpose = %q, want empty", rec.Purpose)
 		}
 	})
+
+	// This one guards a decision made OUTSIDE this repository. web-metrics.sh on host2
+	// exports nginx response rates but no latency, and its comment gave the reason:
+	// latency needs $request_time in log_format, and "internal/viewlog parses this log
+	// — not worth breaking that for". The objection was reasonable and never checked.
+	// It does not hold: combinedLine is anchored at ^ and not at $, so anything nginx
+	// appends after the user-agent (and the optional Sec-Purpose) is simply not looked
+	// at.
+	//
+	// Every field is asserted rather than just ok, because the failure this exists to
+	// catch is not "the line was rejected" — it is a future edit anchoring the pattern
+	// or reordering a group, which would leave ParseLine returning true while the job
+	// slug came from the wrong capture and the view counts quietly moved.
+	t.Run("ignores the timing fields appended for the latency metrics", func(t *testing.T) {
+		const (
+			ip   = "203.0.113.5"
+			ua   = "Mozilla/5.0 (Macintosh)"
+			path = "/jobs/acme-engineer-123"
+		)
+		base := `203.0.113.5 - - [21/Jul/2026:12:00:00 +0000] "GET ` + path + ` HTTP/2.0" 200 1234 "https://ref" "` + ua + `"`
+
+		for name, line := range map[string]string{
+			"with purpose":    base + ` "prefetch" 0.412 0.398`,
+			"purpose as dash": base + ` "-" 0.412 0.398`,
+			// nginx writes "-" for upstream_response_time on a request it served itself
+			// (a 403 from the deny list, a file off disk), so the field is not always a
+			// number and the parser must not care either way.
+			"no upstream time": base + ` "-" 0.004 -`,
+		} {
+			rec, ok := ParseLine(line)
+			if !ok {
+				t.Fatalf("%s: ParseLine ok = false, want true", name)
+			}
+			if rec.IP != ip {
+				t.Errorf("%s: IP = %q, want %q", name, rec.IP, ip)
+			}
+			if want := time.Date(2026, time.July, 21, 12, 0, 0, 0, time.UTC); !rec.Time.Equal(want) {
+				t.Errorf("%s: Time = %v, want %v", name, rec.Time.UTC(), want)
+			}
+			if rec.Method != "GET" {
+				t.Errorf("%s: Method = %q, want GET", name, rec.Method)
+			}
+			if rec.Path != path {
+				t.Errorf("%s: Path = %q, want %q — a view would be credited to the wrong job", name, rec.Path, path)
+			}
+			if rec.Status != 200 {
+				t.Errorf("%s: Status = %d, want 200", name, rec.Status)
+			}
+			if rec.UserAgent != ua {
+				t.Errorf("%s: UserAgent = %q, want %q — bot filtering reads this", name, rec.UserAgent, ua)
+			}
+		}
+	})
 }


### PR DESCRIPTION
## Why

`web-metrics.sh` on host2 exported nginx response rates and no latency. Its header gave the reason: latency needs the timing fields in `log_format`, and *"internal/viewlog parses this log — not worth breaking that for"*.

Sensible, and never run. It does not hold: `combinedLine` is anchored at `^` and not at `$`, so nothing past the user-agent and the optional Sec-Purpose is looked at.

## Evidence

- **50 real production lines** in the new format through `ParseLine`: 50 parsed, 0 rejected, path/status/user-agent unchanged.
- The guard was checked by mutation: anchoring the pattern with `$` makes the new test fail; removing the anchor makes it pass.

## What is here

No behaviour change. A test and a doc comment.

The test asserts **every field**, not just `ok` — the failure worth catching is not a rejected line but a future edit anchoring the pattern or reordering a group, which would leave `ParseLine` returning true while the slug came from the wrong capture and per-job view counts moved silently.

Three shapes covered, including `upstream_response_time` written as `-`, which is what nginx logs when it answered without an upstream (a deny from the blocklist, a file off disk, a redirect).

## Paired with

`freehire-ops` — the `log_format` change and the percentiles computed from it. **Already live on prod**; the ordering is safe either way because the parser ignores the fields rather than requiring them.