### PR TITLE
Forget a Telegram chat that has blocked us, instead of failing forever

### DIFF
--- a/docs/agents/notifications.md
+++ b/docs/agents/notifications.md
@@ -43,6 +43,18 @@ Telegram, and mobile push), each with its own small `Notifier`/`Router` pair:
 - **An unconfigured channel is a soft-skip, not a failure.** `Router.Send` returns
   `ErrChannelNotConfigured` (e.g. email while SES is unset) and the engine skips it. Don't
   promote that to a delivery error — it would fail every run in environments without SES.
+- **A blocked Telegram bot unlinks the chat; it does not fail the delivery.** Every 403 the
+  Bot API answers a send with means the chat is permanently closed (blocked, deactivated,
+  bot removed), and no retry reaches it. `telegramnotify.ErrChatUnreachable` carries that up;
+  each engine's Telegram notifier translates it into its own `ErrRecipientGone`, and the
+  runner deletes the user's `telegram_links` row and soft-skips. **Matched on the 403, not on
+  the description text** — that text is prose Telegram may reword, and a rule keyed to
+  "Forbidden: bot was blocked by the user" would stop firing silently. Unlinking rather than
+  disabling the subscription is the point: blocking the bot is a fact about the USER, so one
+  delete makes every telegram delivery for them — digest, reminder and nudge alike — read as
+  "not linked" and soft-skip, while their subscriptions survive for whenever they relink.
+  Before this, one blocked subscriber failed a digest per pass forever and kept
+  `freehire-notify.service` in `failed`.
 - **Matching is O(distinct queries), not O(subscribers).** `notify.Runner.Run` groups
   subscriptions sharing a saved-search query so the search index is hit once regardless of
   how many people subscribed to it. A per-subscription loop would multiply index load by

--- a/internal/notify/deliver.go
+++ b/internal/notify/deliver.go
@@ -113,6 +113,21 @@ func (r *Runner) deliverOne(ctx context.Context, subID int64, jobIDs []int64, st
 			stats.SoftSkips++
 			return
 		}
+		// The recipient is gone for good — the Telegram bot was blocked or removed,
+		// and no retry reaches that chat again. Forget the link and soft-skip: the
+		// subscription survives (relinking the bot resumes it) while every other
+		// telegram delivery for this user, in this worker and in remind/nudge alike,
+		// now reads as "not linked" and soft-skips too.
+		//
+		// Without this one blocked user failed a digest per pass forever, and the
+		// exit code that failure produces turned the whole run red — which is how a
+		// stranger's choice to mute a bot became a worker in a failed state.
+		if errors.Is(err, ErrRecipientGone) {
+			r.unlinkTelegram(ctx, subID, info.UserID, err)
+			r.release(ctx, subID, jobIDs)
+			stats.SoftSkips++
+			return
+		}
 		log.Printf("notify: deliver subscription %d: %v", subID, err)
 		if ferr := r.store.RecordMatchDeliveryFailure(ctx, db.RecordMatchDeliveryFailureParams{
 			SubscriptionID: subID,
@@ -182,6 +197,26 @@ func (r *Runner) withdrawNotification(ctx context.Context, subID, id int64) {
 	if err := r.store.DeleteNotification(ctx, id); err != nil {
 		log.Printf("notify: withdraw notification %d for subscription %d: %v", id, subID, err)
 	}
+}
+
+// unlinkTelegram forgets the user's Telegram chat after a send reported it
+// permanently closed, and says so in the log — this is a visible change to the
+// user's settings made without them asking, so it should not happen silently.
+//
+// A failure to unlink is logged and nothing more: the digest is soft-skipped
+// either way, and the next pass will meet the same 403 and try again.
+func (r *Runner) unlinkTelegram(ctx context.Context, subID, userID int64, cause error) {
+	rows, err := r.store.DeleteTelegramLink(ctx, userID)
+	if err != nil {
+		log.Printf("notify: unlink telegram for user %d (subscription %d): %v", userID, subID, err)
+		return
+	}
+	if rows == 0 {
+		// Already unlinked by an earlier subscription in this same pass — every
+		// telegram subscription this user has meets the same 403.
+		return
+	}
+	log.Printf("notify: unlinked telegram for user %d after subscription %d: %v", userID, subID, cause)
 }
 
 // release drops the lease on a subscription's claimed matches so they are retried

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -130,6 +130,10 @@ type Store interface {
 	RecordNotification(ctx context.Context, arg db.RecordNotificationParams) (int64, error)
 	DeleteNotification(ctx context.Context, id int64) error
 	MarkDigestSent(ctx context.Context, id int64) error
+	// DeleteTelegramLink forgets a user's Telegram chat. Called when a send
+	// reports the chat is permanently closed (ErrRecipientGone) — the same
+	// unlink the settings page performs, reached from the delivery side.
+	DeleteTelegramLink(ctx context.Context, userID int64) (int64, error)
 }
 
 // Config tunes one pass. Defaults come from DefaultConfig.

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -36,6 +36,11 @@ func (f *fakeSearcher) Search(_ context.Context, p search.SearchParams) (search.
 type recordedMatch struct{ sub, job int64 }
 
 type fakeStore struct {
+	// unlinkedTelegram records the user ids a delivery forgot the Telegram chat
+	// for, so a test can assert the 403 path unlinks exactly once per user.
+	unlinkedTelegram  []int64
+	unlinkTelegramErr error
+
 	active      []db.ListActiveSubscriptionsRow
 	recorded    []recordedMatch
 	recordCalls int // how many times RecordSubscriptionMatches was called, not how many pairs
@@ -152,6 +157,14 @@ func (s *fakeStore) RecordNotification(_ context.Context, a db.RecordNotificatio
 func (s *fakeStore) DeleteNotification(_ context.Context, id int64) error {
 	s.deletedNotifications = append(s.deletedNotifications, id)
 	return nil
+}
+
+func (s *fakeStore) DeleteTelegramLink(_ context.Context, userID int64) (int64, error) {
+	s.unlinkedTelegram = append(s.unlinkedTelegram, userID)
+	if s.unlinkTelegramErr != nil {
+		return 0, s.unlinkTelegramErr
+	}
+	return 1, nil
 }
 
 type fakeNotifier struct {
@@ -1014,5 +1027,66 @@ func TestDeliver_ClaimedIDWithNoJobRowIsStillNotified(t *testing.T) {
 	}
 	if len(store.notified) != 1 || len(store.notified[0].JobIds) != 2 {
 		t.Errorf("notified = %+v, want both ids (the pruned one included)", store.notified)
+	}
+}
+
+// The bug these guard: a subscriber who blocked the Telegram bot answered every
+// send with 403. The digest counted a delivery failure, the run exited non-zero,
+// and freehire-notify.service sat in `failed` — one stranger muting a bot turning
+// a worker red every five minutes, forever, because nothing ever concluded that
+// the chat was not coming back.
+func TestDeliver_RecipientGoneUnlinksTelegramAndSoftSkips(t *testing.T) {
+	store := &fakeStore{
+		claimed:            []db.ClaimSubscriptionMatchesRow{{SubscriptionID: 1, JobID: 10}},
+		delivery:           deliverySubscription(),
+		digestJobs:         map[int64]db.GetJobsForDigestRow{10: {ID: 10, Title: "A", PublicSlug: "a"}},
+		nextNotificationID: 42,
+	}
+	r := New(store, &fakeSearcher{}, &fakeNotifier{err: ErrRecipientGone}, DefaultConfig())
+
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.SoftSkips != 1 || stats.Failed != 0 {
+		t.Errorf("SoftSkips = %d, Failed = %d, want 1 and 0 — a chat that will never accept us is not a delivery failure to retry", stats.SoftSkips, stats.Failed)
+	}
+	if len(store.unlinkedTelegram) != 1 || store.unlinkedTelegram[0] != 42 {
+		t.Errorf("unlinkedTelegram = %v, want [42] — the link is what has to go, so every later send soft-skips instead of re-failing", store.unlinkedTelegram)
+	}
+	if len(store.failures) != 0 {
+		t.Errorf("failures = %v, want none — burning attempts toward the dead-letter limit cannot help here", store.failures)
+	}
+	// The matches go back to pending rather than being stamped notified: nobody
+	// received them, and they are owed over whatever channel comes next.
+	if len(store.released) != 1 {
+		t.Errorf("released = %v, want the claim released", store.released)
+	}
+	if len(store.notified) != 0 {
+		t.Errorf("notified = %v, want none — the digest was never delivered", store.notified)
+	}
+	if len(store.deletedNotifications) != 1 || store.deletedNotifications[0] != 42 {
+		t.Errorf("deleted = %v, want [42] — nothing was delivered, so nothing belongs in the history", store.deletedNotifications)
+	}
+}
+
+// The unlink is best-effort: it changes what the NEXT pass does, and this pass
+// soft-skips either way. A store that refuses must not turn the skip back into a
+// failure, or the red-worker loop returns by another door.
+func TestDeliver_RecipientGoneSoftSkipsEvenIfUnlinkFails(t *testing.T) {
+	store := &fakeStore{
+		claimed:           []db.ClaimSubscriptionMatchesRow{{SubscriptionID: 1, JobID: 10}},
+		delivery:          deliverySubscription(),
+		digestJobs:        map[int64]db.GetJobsForDigestRow{10: {ID: 10, Title: "A", PublicSlug: "a"}},
+		unlinkTelegramErr: errors.New("boom"),
+	}
+	r := New(store, &fakeSearcher{}, &fakeNotifier{err: ErrRecipientGone}, DefaultConfig())
+
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.SoftSkips != 1 || stats.Failed != 0 {
+		t.Errorf("SoftSkips = %d, Failed = %d, want 1 and 0", stats.SoftSkips, stats.Failed)
 	}
 }

--- a/internal/notify/router.go
+++ b/internal/notify/router.go
@@ -16,6 +16,21 @@ const ChannelEmail = "email"
 // failed attempt is counted — rather than a delivery failure to dead-letter.
 var ErrChannelNotConfigured = errors.New("notify: channel not configured")
 
+// ErrRecipientGone is returned by a Notifier whose channel has learned, from the
+// send itself, that this recipient will not accept messages again — the Telegram
+// bot was blocked or removed, and the chat is permanently closed to us.
+//
+// Distinct from ErrChannelNotConfigured, which is about the channel being absent
+// for everyone, though the delivery loop treats both as a soft-skip. What it adds
+// is a side effect: the engine forgets the link before skipping, so the recipient
+// stops being deliverable at all rather than failing once per digest forever.
+//
+// A channel-level sentinel rather than the transport's own: internal/telegramnotify
+// imports this package for Digest, so it cannot be imported back. Each engine
+// declares its own and its Telegram notifier translates, exactly as they already do
+// for ErrChannelNotConfigured.
+var ErrRecipientGone = errors.New("notify: recipient will not accept messages")
+
 // Router is a Notifier that dispatches a digest to the per-channel notifier
 // registered for the subscription's channel, so the matching engine stays
 // channel-agnostic (it depends only on Notifier). A channel with no registered

--- a/internal/nudge/nudge.go
+++ b/internal/nudge/nudge.go
@@ -68,6 +68,14 @@ type Notifier interface {
 // registered notifier. The engine treats it as a soft-skip, not a delivery failure.
 var ErrChannelNotConfigured = errors.New("nudge: channel not configured")
 
+// ErrRecipientGone is returned by a Notifier whose channel learned from the send
+// that this recipient is permanently closed to us — the Telegram bot was blocked
+// or removed. Like ErrChannelNotConfigured it is a soft-skip, and additionally the
+// runner forgets the link, so no later nudge, digest or reminder tries that chat
+// again. Mirrors notify.ErrRecipientGone; see the note there on why each engine
+// declares its own rather than sharing the transport's.
+var ErrRecipientGone = errors.New("nudge: recipient will not accept messages")
+
 // Router dispatches a nudge to the notifier registered for its channel, so the
 // engine stays channel-agnostic.
 type Router map[string]Notifier
@@ -104,6 +112,9 @@ type Store interface {
 	CancelNudgeAtFire(ctx context.Context, id int64) (int64, error)
 	RecordNudgeDeliveryFailure(ctx context.Context, arg db.RecordNudgeDeliveryFailureParams) error
 	ReleaseNudgeClaim(ctx context.Context, id int64) error
+	// DeleteTelegramLink forgets a user's Telegram chat, called when a send
+	// reports it permanently closed (ErrRecipientGone).
+	DeleteTelegramLink(ctx context.Context, userID int64) (int64, error)
 	// RecordNotification writes the in-app notification-center row for a
 	// delivered nudge. Called from fire right after MarkNudgeDelivered; a
 	// failure must never fail the delivery it accompanies (see
@@ -401,6 +412,13 @@ func (r *Runner) deliverChannels(ctx context.Context, info db.GetNudgeForDeliver
 		if errors.Is(err, ErrChannelNotConfigured) {
 			continue
 		}
+		// The chat is closed to us for good. Forget it and skip this channel
+		// without recording a failure: retrying cannot reach it, and a nudge whose
+		// OTHER channel worked is still delivered.
+		if errors.Is(err, ErrRecipientGone) {
+			r.unlinkTelegram(ctx, info.UserID, err)
+			continue
+		}
 		if err != nil {
 			failedErr = err
 			continue
@@ -408,6 +426,21 @@ func (r *Runner) deliverChannels(ctx context.Context, info db.GetNudgeForDeliver
 		delivered = true
 	}
 	return delivered, failedErr
+}
+
+// unlinkTelegram forgets a user's Telegram chat after a send reported it
+// permanently closed, logging it because this changes the user's settings without
+// them asking. A failure here is logged and no more: the send is skipped either
+// way, and the next nudge meets the same 403 and tries again.
+func (r *Runner) unlinkTelegram(ctx context.Context, userID int64, cause error) {
+	rows, err := r.store.DeleteTelegramLink(ctx, userID)
+	if err != nil {
+		log.Printf("nudge: unlink telegram for user %d: %v", userID, err)
+		return
+	}
+	if rows > 0 {
+		log.Printf("nudge: unlinked telegram for user %d: %v", userID, cause)
+	}
 }
 
 // recipient resolves the destination for a channel, and whether the nudge is

--- a/internal/nudge/nudge_test.go
+++ b/internal/nudge/nudge_test.go
@@ -16,6 +16,9 @@ import (
 // fakeStore is a DB-free Store. It serves canned candidate rows and delivery
 // context, and records every write the engine makes.
 type fakeStore struct {
+	// unlinkedTelegram records the user ids a delivery forgot the Telegram chat for.
+	unlinkedTelegram []int64
+
 	followUp      []db.ListFollowUpCandidatesRow
 	interviewPrep []db.ListInterviewPrepCandidatesRow
 	jobClosed     []db.ListJobClosedCandidatesRow
@@ -78,6 +81,10 @@ func (s *fakeStore) ReleaseNudgeClaim(_ context.Context, id int64) error {
 	s.released = append(s.released, id)
 	return nil
 }
+func (s *fakeStore) DeleteTelegramLink(_ context.Context, userID int64) (int64, error) {
+	s.unlinkedTelegram = append(s.unlinkedTelegram, userID)
+	return 1, nil
+}
 func (s *fakeStore) RecordNotification(_ context.Context, arg db.RecordNotificationParams) (int64, error) {
 	if s.notifyErr != nil {
 		return 0, s.notifyErr
@@ -89,9 +96,15 @@ func (s *fakeStore) RecordNotification(_ context.Context, arg db.RecordNotificat
 type fakeNotifier struct {
 	sent []string // "channel:dest"
 	err  error
+	// errByChannel fails only the named channels, so a test can model one channel
+	// dying while another lands — which a blanket err cannot express.
+	errByChannel map[string]error
 }
 
 func (n *fakeNotifier) Send(_ context.Context, channel, dest string, _ Message) error {
+	if err, ok := n.errByChannel[channel]; ok {
+		return err
+	}
 	if n.err != nil {
 		return n.err
 	}
@@ -679,5 +692,55 @@ func TestDeliver_DeliversOutsideQuietHours(t *testing.T) {
 	}
 	if stats.Delivered != 1 {
 		t.Errorf("stats.Delivered = %d, want 1", stats.Delivered)
+	}
+}
+
+// Same failure as the digest and reminder workers': a user who blocked the bot
+// answered every telegram send with 403, and each nudge counted that as a delivery
+// failure to retry. Retrying cannot reach a closed chat, so the link goes instead.
+func TestDeliver_RecipientGoneUnlinksTelegramInsteadOfFailing(t *testing.T) {
+	chat := int64(555)
+	row := deliveryRow(KindFollowUp, "applied", 25, true, true, []string{"telegram"}, &chat, "")
+	row.UserID = 42
+	store := &fakeStore{due: []int64{1}, row: row}
+	r := newRunner(store, &fakeNotifier{err: ErrRecipientGone})
+
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(store.unlinkedTelegram) != 1 || store.unlinkedTelegram[0] != 42 {
+		t.Errorf("unlinkedTelegram = %v, want [42]", store.unlinkedTelegram)
+	}
+	if stats.Failed != 0 {
+		t.Errorf("stats.Failed = %d, want 0 — a chat that will never accept us is not a failure to retry", stats.Failed)
+	}
+	if len(store.failed) != 0 {
+		t.Errorf("failed = %v, want none", store.failed)
+	}
+}
+
+// A nudge is delivered if ANY of its channels lands. A dead Telegram chat must not
+// cancel the email that did arrive.
+func TestDeliver_RecipientGoneOnOneChannelStillDeliversTheOther(t *testing.T) {
+	chat := int64(555)
+	row := deliveryRow(KindFollowUp, "applied", 25, true, true, []string{"telegram", "email"}, &chat, "a@b.c")
+	row.UserID = 42
+	store := &fakeStore{due: []int64{1}, row: row}
+	notifier := &fakeNotifier{errByChannel: map[string]error{"telegram": ErrRecipientGone}}
+	r := newRunner(store, notifier)
+
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(store.delivered) != 1 {
+		t.Errorf("delivered = %v, want the nudge delivered over email", store.delivered)
+	}
+	if stats.Failed != 0 {
+		t.Errorf("stats.Failed = %d, want 0", stats.Failed)
+	}
+	if len(store.unlinkedTelegram) != 1 {
+		t.Errorf("unlinkedTelegram = %v, want the dead chat forgotten anyway", store.unlinkedTelegram)
 	}
 }

--- a/internal/nudge/transports.go
+++ b/internal/nudge/transports.go
@@ -3,6 +3,7 @@ package nudge
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"html"
 	"html/template"
@@ -43,12 +44,19 @@ func NewTelegramNotifier(client *telegramnotify.Client, origin string) *Telegram
 
 // Send renders the nudge and posts it to the chat encoded in dest. The channel
 // argument is ignored — this notifier only serves the telegram channel.
+// A 403 is translated to ErrRecipientGone, this engine's vocabulary for a chat
+// permanently closed to us, so the runner unlinks it instead of retrying a send
+// that cannot land. Same translation the digest and reminder notifiers do.
 func (n *TelegramNotifier) Send(ctx context.Context, _ string, dest string, m Message) error {
 	chatID, err := strconv.ParseInt(dest, 10, 64)
 	if err != nil {
 		return fmt.Errorf("nudge: invalid telegram chat id %q: %w", dest, err)
 	}
-	return n.client.SendMessage(ctx, chatID, n.render(m))
+	err = n.client.SendMessage(ctx, chatID, n.render(m))
+	if errors.Is(err, telegramnotify.ErrChatUnreachable) {
+		return fmt.Errorf("%w: %w", ErrRecipientGone, err)
+	}
+	return err
 }
 
 func (n *TelegramNotifier) render(m Message) string {

--- a/internal/reminder/engine.go
+++ b/internal/reminder/engine.go
@@ -36,6 +36,14 @@ type Notifier interface {
 // as a soft-skip, not a delivery failure.
 var ErrChannelNotConfigured = errors.New("reminder: channel not configured")
 
+// ErrRecipientGone is returned by a Notifier whose channel learned from the send
+// that this recipient is permanently closed to us — the Telegram bot was blocked
+// or removed. Like ErrChannelNotConfigured it is a soft-skip, and additionally the
+// runner forgets the link, so no later reminder, digest or nudge tries that chat
+// again. Mirrors notify.ErrRecipientGone; see the note there on why each engine
+// declares its own rather than sharing the transport's.
+var ErrRecipientGone = errors.New("reminder: recipient will not accept messages")
+
 // Router dispatches a reminder to the notifier registered for its channel, so the
 // engine stays channel-agnostic.
 type Router map[string]Notifier
@@ -67,6 +75,9 @@ type Store interface {
 	// delivered, so nothing needs to link to the row. Only the subscription
 	// digest, which records before sending, uses it.
 	RecordNotification(ctx context.Context, arg db.RecordNotificationParams) (int64, error)
+	// DeleteTelegramLink forgets a user's Telegram chat, called when a send
+	// reports it permanently closed (ErrRecipientGone).
+	DeleteTelegramLink(ctx context.Context, userID int64) (int64, error)
 }
 
 // Config tunes one firing pass. Defaults come from DefaultConfig.
@@ -207,6 +218,13 @@ func (r *Runner) deliverChannels(ctx context.Context, info db.GetReminderForDeli
 		if errors.Is(err, ErrChannelNotConfigured) {
 			continue
 		}
+		// The chat is closed to us for good. Forget it and skip this channel
+		// without recording a failure: retrying cannot reach it, and a reminder
+		// whose OTHER channel worked is still delivered.
+		if errors.Is(err, ErrRecipientGone) {
+			r.unlinkTelegram(ctx, info.UserID, err)
+			continue
+		}
 		if err != nil {
 			failedErr = err
 			continue
@@ -214,6 +232,21 @@ func (r *Runner) deliverChannels(ctx context.Context, info db.GetReminderForDeli
 		delivered = true
 	}
 	return delivered, failedErr
+}
+
+// unlinkTelegram forgets a user's Telegram chat after a send reported it
+// permanently closed, logging it because this changes the user's settings without
+// them asking. A failure here is logged and no more: the send is skipped either
+// way, and the next reminder meets the same 403 and tries again.
+func (r *Runner) unlinkTelegram(ctx context.Context, userID int64, cause error) {
+	rows, err := r.store.DeleteTelegramLink(ctx, userID)
+	if err != nil {
+		log.Printf("reminder: unlink telegram for user %d: %v", userID, err)
+		return
+	}
+	if rows > 0 {
+		log.Printf("reminder: unlinked telegram for user %d: %v", userID, cause)
+	}
 }
 
 // recipient resolves the destination for a channel, and whether the reminder is

--- a/internal/reminder/engine_test.go
+++ b/internal/reminder/engine_test.go
@@ -12,6 +12,9 @@ import (
 // fakeStore is a DB-free reminder.Store. It serves canned delivery rows keyed by
 // id and records which finalizers the engine invoked.
 type fakeStore struct {
+	// unlinkedTelegram records the user ids a delivery forgot the Telegram chat for.
+	unlinkedTelegram []int64
+
 	due      []int64
 	rows     map[int64]db.GetReminderForDeliveryRow
 	claimErr error
@@ -47,6 +50,10 @@ func (s *fakeStore) ReleaseReminderClaim(_ context.Context, id int64) error {
 	s.released = append(s.released, id)
 	return nil
 }
+func (s *fakeStore) DeleteTelegramLink(_ context.Context, userID int64) (int64, error) {
+	s.unlinkedTelegram = append(s.unlinkedTelegram, userID)
+	return 1, nil
+}
 func (s *fakeStore) RecordNotification(_ context.Context, arg db.RecordNotificationParams) (int64, error) {
 	s.recorded = append(s.recorded, arg)
 	return int64(len(s.recorded)), s.recordErr
@@ -56,9 +63,16 @@ func (s *fakeStore) RecordNotification(_ context.Context, arg db.RecordNotificat
 type fakeNotifier struct {
 	sent []string // "channel:dest"
 	err  error
+	// errByChannel fails only the named channels, so a test can model one channel
+	// dying while another lands — which is the whole point of a multi-channel
+	// reminder and the case a blanket err cannot express.
+	errByChannel map[string]error
 }
 
 func (n *fakeNotifier) Send(_ context.Context, channel, dest string, _ ReminderMessage) error {
+	if err, ok := n.errByChannel[channel]; ok {
+		return err
+	}
 	if n.err != nil {
 		return n.err
 	}
@@ -332,5 +346,51 @@ func TestRun_QuietHoursOffDoesNotDefer(t *testing.T) {
 
 	if stats.Delivered != 1 || stats.Deferred != 0 {
 		t.Errorf("stats = %+v, want Delivered=1 Deferred=0 when quiet hours are unset", stats)
+	}
+}
+
+// Same failure as the digest worker's: a user who blocked the bot answered every
+// telegram send with 403, and each reminder counted that as a delivery failure to
+// retry. Retrying cannot reach a closed chat, so the link goes instead — which
+// also stops the digest and nudge workers meeting the same wall.
+func TestRun_RecipientGoneUnlinksTelegramInsteadOfFailing(t *testing.T) {
+	chat := int64(555)
+	store := &fakeStore{
+		due:  []int64{1},
+		rows: map[int64]db.GetReminderForDeliveryRow{1: actionableRow(1, []string{"telegram"}, &chat, "a@b.c")},
+	}
+	stats := run(t, store, &fakeNotifier{err: ErrRecipientGone})
+
+	if len(store.unlinkedTelegram) != 1 || store.unlinkedTelegram[0] != 42 {
+		t.Errorf("unlinkedTelegram = %v, want [42]", store.unlinkedTelegram)
+	}
+	if len(store.failed) != 0 {
+		t.Errorf("failed = %v, want none — a chat that will never accept us is not a failure to retry", store.failed)
+	}
+	if stats.Failed != 0 {
+		t.Errorf("stats.Failed = %d, want 0", stats.Failed)
+	}
+}
+
+// A reminder is delivered if ANY of its channels lands. A dead Telegram chat must
+// not cancel the email that did arrive, nor mark the reminder undelivered.
+func TestRun_RecipientGoneOnOneChannelStillDeliversTheOther(t *testing.T) {
+	chat := int64(555)
+	store := &fakeStore{
+		due:  []int64{1},
+		rows: map[int64]db.GetReminderForDeliveryRow{1: actionableRow(1, []string{"telegram", "email"}, &chat, "a@b.c")},
+	}
+	// Telegram is gone; email works.
+	notifier := &fakeNotifier{errByChannel: map[string]error{"telegram": ErrRecipientGone}}
+	stats := run(t, store, notifier)
+
+	if len(store.delivered) != 1 {
+		t.Errorf("delivered = %v, want the reminder delivered over email", store.delivered)
+	}
+	if stats.Failed != 0 {
+		t.Errorf("stats.Failed = %d, want 0", stats.Failed)
+	}
+	if len(store.unlinkedTelegram) != 1 {
+		t.Errorf("unlinkedTelegram = %v, want the dead chat forgotten anyway", store.unlinkedTelegram)
 	}
 }

--- a/internal/reminder/transports.go
+++ b/internal/reminder/transports.go
@@ -3,6 +3,7 @@ package reminder
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"html"
 	"html/template"
@@ -40,12 +41,20 @@ func NewTelegramNotifier(client *telegramnotify.Client, jobBaseURL string) *Tele
 
 // Send renders the reminder and posts it to the chat encoded in dest. The channel
 // argument is ignored — this notifier only serves the telegram channel.
+//
+// A 403 is translated to ErrRecipientGone, this engine's vocabulary for a chat
+// permanently closed to us, so the runner unlinks it instead of retrying a send
+// that cannot land. Same translation the digest and nudge notifiers do.
 func (n *TelegramNotifier) Send(ctx context.Context, _ string, dest string, m ReminderMessage) error {
 	chatID, err := strconv.ParseInt(dest, 10, 64)
 	if err != nil {
 		return fmt.Errorf("reminder: invalid telegram chat id %q: %w", dest, err)
 	}
-	return n.client.SendMessage(ctx, chatID, n.render(m))
+	err = n.client.SendMessage(ctx, chatID, n.render(m))
+	if errors.Is(err, telegramnotify.ErrChatUnreachable) {
+		return fmt.Errorf("%w: %w", ErrRecipientGone, err)
+	}
+	return err
 }
 
 // render builds the HTML body. Title and company are user/source data and are

--- a/internal/telegramnotify/client.go
+++ b/internal/telegramnotify/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -13,6 +14,16 @@ import (
 // defaultAPIBase is the Telegram Bot API host. A fixed, trusted host — no SSRF
 // surface — so a plain http.Client is used.
 const defaultAPIBase = "https://api.telegram.org"
+
+// ErrChatUnreachable wraps every 403 the Bot API answers a send with: the bot was
+// blocked, the account was deactivated, the bot was removed from the group, or it
+// was never allowed to open the conversation. All four say the same thing — this
+// chat will not accept messages again — and none of them is fixed by retrying.
+//
+// Matched on the status code rather than the description text, which is prose
+// Telegram is free to reword: a rule keyed to "Forbidden: bot was blocked by the
+// user" stops firing the day that sentence changes, and stops silently.
+var ErrChatUnreachable = errors.New("telegramnotify: chat unreachable")
 
 // Client is a thin Telegram Bot API client over net/http for the handful of
 // methods this feature needs (sendMessage, setWebhook). It deliberately avoids a
@@ -83,6 +94,9 @@ func (c *Client) call(ctx context.Context, method string, payload map[string]any
 		return fmt.Errorf("telegram %s: decode response: %w", method, err)
 	}
 	if !r.OK {
+		if resp.StatusCode == http.StatusForbidden {
+			return fmt.Errorf("telegram %s failed (%d): %s: %w", method, resp.StatusCode, r.Description, ErrChatUnreachable)
+		}
 		return fmt.Errorf("telegram %s failed (%d): %s", method, resp.StatusCode, r.Description)
 	}
 	return nil

--- a/internal/telegramnotify/notifier.go
+++ b/internal/telegramnotify/notifier.go
@@ -2,6 +2,7 @@ package telegramnotify
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"html"
 	"strconv"
@@ -35,12 +36,19 @@ func NewNotifier(client *Client, jobBaseURL string) *Notifier {
 // Send renders the digest and posts it to the chat encoded in dest. The channel
 // argument is ignored — this Notifier only serves the telegram channel, which the
 // worker routes to it.
+// A 403 is translated to notify.ErrRecipientGone, the engine-side vocabulary for
+// "this recipient is permanently closed to us" — the engine unlinks the chat and
+// soft-skips instead of counting a delivery failure it would retry to no purpose.
 func (n *Notifier) Send(ctx context.Context, _ string, dest string, d notify.Digest) error {
 	chatID, err := strconv.ParseInt(dest, 10, 64)
 	if err != nil {
 		return fmt.Errorf("telegramnotify: invalid chat id %q: %w", dest, err)
 	}
-	return n.client.SendMessage(ctx, chatID, n.render(d))
+	err = n.client.SendMessage(ctx, chatID, n.render(d))
+	if errors.Is(err, ErrChatUnreachable) {
+		return fmt.Errorf("%w: %w", notify.ErrRecipientGone, err)
+	}
+	return err
 }
 
 // render builds the HTML message body. Job titles, company names, the salary

--- a/internal/telegramnotify/notifier_test.go
+++ b/internal/telegramnotify/notifier_test.go
@@ -3,6 +3,7 @@ package telegramnotify
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -215,5 +216,93 @@ func TestNotifier_RenderTailFallsBackWithoutANotificationID(t *testing.T) {
 	}
 	if want := `<a href="https://freehire.me/my/notifications">+ 57 more</a>`; !strings.Contains(got, want) {
 		t.Errorf("tail missing fallback %q in: %q", want, got)
+	}
+}
+
+// Every 403 the Bot API answers a send with means the same thing — this chat will
+// not take messages again — and the engines act on it by forgetting the link. The
+// status code is the signal, deliberately not the description: that text is prose
+// Telegram may reword, and a rule keyed to one sentence would stop firing silently.
+func TestClient_ForbiddenIsChatUnreachable(t *testing.T) {
+	for _, desc := range []string{
+		"Forbidden: bot was blocked by the user",
+		"Forbidden: user is deactivated",
+		"Forbidden: bot was kicked from the group chat",
+		"Forbidden: bot can't initiate conversation with a user",
+		"Forbidden: something Telegram has not thought of yet",
+	} {
+		t.Run(desc, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"ok":false,"description":"` + desc + `"}`))
+			}))
+			defer srv.Close()
+
+			c := NewClient("t")
+			c.base = srv.URL
+			err := c.SendMessage(context.Background(), 1, "hi")
+			if !errors.Is(err, ErrChatUnreachable) {
+				t.Errorf("SendMessage err = %v, want it to wrap ErrChatUnreachable", err)
+			}
+			if !strings.Contains(err.Error(), desc) {
+				t.Errorf("SendMessage err = %v, want it to keep the API description for the log", err)
+			}
+		})
+	}
+}
+
+// A rejection that is not a 403 stays an ordinary failure: "message is too long"
+// and "chat not found" are the engine's to retry or dead-letter, and unlinking a
+// user's chat over either would be destroying settings on a guess.
+func TestClient_NonForbiddenRejectionIsNotChatUnreachable(t *testing.T) {
+	for _, tc := range []struct {
+		status int
+		desc   string
+	}{
+		{http.StatusBadRequest, "message is too long"},
+		{http.StatusBadRequest, "chat not found"},
+		{http.StatusTooManyRequests, "Too Many Requests: retry after 30"},
+		{http.StatusInternalServerError, "Internal Server Error"},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(`{"ok":false,"description":"` + tc.desc + `"}`))
+			}))
+			defer srv.Close()
+
+			c := NewClient("t")
+			c.base = srv.URL
+			err := c.SendMessage(context.Background(), 1, "hi")
+			if err == nil {
+				t.Fatal("SendMessage succeeded, want an error")
+			}
+			if errors.Is(err, ErrChatUnreachable) {
+				t.Errorf("SendMessage err = %v, want it NOT to read as a permanently closed chat", err)
+			}
+		})
+	}
+}
+
+// The engines cannot import this package (it imports notify for Digest), so the
+// notifier is where the transport's 403 becomes the engine's vocabulary. If this
+// translation is dropped the 403 reaches the runner as a plain error and the
+// blocked-user loop comes back.
+func TestNotifier_ForbiddenSurfacesAsRecipientGone(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"ok":false,"description":"Forbidden: bot was blocked by the user"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient("t")
+	c.base = srv.URL
+	n := NewNotifier(c, "https://freehire.me")
+	err := n.Send(context.Background(), notify.ChannelTelegram, "555", notify.Digest{SavedSearchName: "Go", Total: 1})
+	if !errors.Is(err, notify.ErrRecipientGone) {
+		t.Errorf("Send err = %v, want it to wrap notify.ErrRecipientGone", err)
+	}
+	if !errors.Is(err, ErrChatUnreachable) {
+		t.Errorf("Send err = %v, want the transport cause kept for the log", err)
 	}
 }


### PR DESCRIPTION
## What was happening

A subscriber blocked the bot. Every send to them answered 403:

```
notify: deliver subscription 26: telegram sendMessage failed (403): Forbidden: bot was blocked by the user
notify: queries=29 matched=802 delivered=2 soft_skips=0 deferred=3 failed=1
freehire-notify.service: Failed with result 'exit-code'.
```

The digest counted a delivery failure, `cmd/notify` exited non-zero, and
`freehire-notify.service` sat in `failed` — **one stranger muting a bot turning a worker red
every five minutes, indefinitely**, because nothing in the path ever concluded that the chat
was not coming back.

Retrying is the wrong response to a 403, and the dead-letter limit is no help either: it
burns five attempts on a closed chat and then abandons the matches, so the user's
notifications are *lost* rather than paused. Meanwhile the same user's other telegram
subscriptions, and their reminders and nudges, each hit the same wall independently.

## The fix, at the level the fact lives at

Blocking the bot is a fact about the **user**, not about one subscription. Deleting their
`telegram_links` row makes every telegram delivery for them read as "not linked" and
soft-skip through the path that already exists for someone who never linked at all — in all
three engines at once, without touching their subscriptions, which resume the day they
relink.

```
403 → telegramnotify.ErrChatUnreachable
    → notify/reminder/nudge.ErrRecipientGone
    → DELETE FROM telegram_links WHERE user_id = $1
    → soft-skip (not a failure, no attempt burned)
```

**Matched on the 403 status, deliberately not on the description.** Telegram answers
*bot was blocked by the user*, *user is deactivated*, *bot was kicked from the group chat*
and *bot can't initiate conversation* with the same code, all four permanent — and those
sentences are prose it is free to reword. A rule keyed to one of them would stop firing
without anyone noticing.

A **400 or 429 is untouched**: "message is too long" and "chat not found" are still the
engine's to retry or dead-letter, and unlinking someone's chat over either would be
destroying their settings on a guess.

## Shape notes

The sentinel is two-level because `internal/telegramnotify` imports `internal/notify` for
`Digest` and cannot be imported back. The transport declares `ErrChatUnreachable`; each
engine declares its own `ErrRecipientGone` that its Telegram notifier translates into —
exactly the shape `ErrChannelNotConfigured` already has in all three.

The unlink is **best-effort and logged**: it changes what the *next* pass does, this one
soft-skips either way, and it is a visible change to a user's settings made without them
asking, so it should not happen silently.

**No migration, no `make sqlc`.** `DeleteTelegramLink` already existed for the settings
page's manual unlink; this reaches it from the delivery side.

## Tests

| | |
|---|---|
| every 403 description (incl. one Telegram has not invented yet) | reads as unreachable |
| 400 / 429 / 500 | do **not** — still ordinary failures |
| notifier translation | 403 surfaces as `notify.ErrRecipientGone`, transport cause kept for the log |
| digest | unlinks, soft-skips, no failure recorded, claim released, notification withdrawn |
| digest, unlink itself fails | still soft-skips — the red-worker loop must not return by another door |
| reminder + nudge | unlink instead of failing |
| reminder + nudge, telegram dead but email fine | **still delivered**, chat forgotten anyway |

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes; `go vet -tags=integration ./...` clean.
- [x] I regenerated committed artifacts when their source changed. *(none changed — the query existed)*
- [x] For `design-system/` changes: n/a.
- [x] For `web/` changes: n/a.
- [x] This stays within freehire's core/extension boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Telegram delivery now recognizes permanently unreachable chats and automatically removes the invalid Telegram connection.
  * Failed Telegram deliveries are skipped without marking notifications, nudges, or reminders as failed.
  * Other configured delivery channels continue normally when Telegram is unreachable.
  * Repeated digest failures caused by blocked Telegram chats are eliminated.

* **Documentation**
  * Documented Telegram handling for blocked or unreachable chats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->