### PR TITLE
Stop the header from rearranging itself after first paint

### DIFF
--- a/web/src/lib/components/GithubStars.svelte
+++ b/web/src/lib/components/GithubStars.svelte
@@ -38,10 +38,18 @@
   <ProviderIcon provider="github" />
   {#if variant === 'row'}
     <span>GitHub</span>
-    {#if count != null}
-      <span class="ml-auto tabular-nums text-xs">{formatStars(count)}</span>
-    {/if}
-  {:else if count != null}
-    <span class="tabular-nums">{formatStars(count)}</span>
+    <span class="ml-auto tabular-nums text-xs">{count != null ? formatStars(count) : ''}</span>
+  {:else}
+    <!-- The count's box is held from the first paint, empty until the number lands.
+         It cannot be there earlier: the store reads its localStorage cache in
+         `onMount`, and rendering a cached number the server did not render would be a
+         hydration mismatch. So the number always arrives a frame late, and without a
+         reserved box it widens this badge, pushes the header's right-hand group, and
+         drags the `flex-1` search box between them along with it — on every page load,
+         signed in or out.
+
+         `min-w-8` holds four tabular digits, which the repo will not outgrow soon; the
+         next shape after that is "10.9k", one character wider. -->
+    <span class="min-w-8 text-right tabular-nums">{count != null ? formatStars(count) : ''}</span>
   {/if}
 </a>

--- a/web/src/lib/components/GithubStars.svelte
+++ b/web/src/lib/components/GithubStars.svelte
@@ -19,6 +19,14 @@
   });
 
   const count = $derived(githubStars.count);
+
+  // Empty until the number lands, and rendered either way. The box has to be there
+  // from the first paint: the store reads its localStorage cache in `onMount`, so the
+  // count is always a frame late, and it cannot be earlier — rendering a cached number
+  // the server did not render is a hydration mismatch. Without a held box the badge
+  // widens on arrival, which pushes the header's right-hand group and drags the
+  // `flex-1` search box between them sideways, on every page load.
+  const label = $derived(count != null ? formatStars(count) : '');
 </script>
 
 <!-- eslint-disable svelte/no-navigation-without-resolve -- external GitHub URL, not an internal route -->
@@ -38,18 +46,10 @@
   <ProviderIcon provider="github" />
   {#if variant === 'row'}
     <span>GitHub</span>
-    <span class="ml-auto tabular-nums text-xs">{count != null ? formatStars(count) : ''}</span>
+    <span class="ml-auto tabular-nums text-xs">{label}</span>
   {:else}
-    <!-- The count's box is held from the first paint, empty until the number lands.
-         It cannot be there earlier: the store reads its localStorage cache in
-         `onMount`, and rendering a cached number the server did not render would be a
-         hydration mismatch. So the number always arrives a frame late, and without a
-         reserved box it widens this badge, pushes the header's right-hand group, and
-         drags the `flex-1` search box between them along with it — on every page load,
-         signed in or out.
-
-         `min-w-8` holds four tabular digits, which the repo will not outgrow soon; the
+    <!-- `min-w-8` holds four tabular digits, which the repo will not outgrow soon; the
          next shape after that is "10.9k", one character wider. -->
-    <span class="min-w-8 text-right tabular-nums">{count != null ? formatStars(count) : ''}</span>
+    <span class="min-w-8 text-right tabular-nums">{label}</span>
   {/if}
 </a>

--- a/web/src/lib/components/HeaderListSearch.svelte
+++ b/web/src/lib/components/HeaderListSearch.svelte
@@ -149,8 +149,19 @@
         counts={target.filterScope.counts()}
         inferred={target.filterScope.inferred?.() ?? false}
       />
-      <div class="h-5 w-px shrink-0 bg-border"></div>
+    {:else}
+      <!-- The same trigger in launcher mode, standing in until the list view registers
+           its filter scope. That registration happens in the view's `onMount`, ~300ms
+           after first paint, and rendering nothing until then made the trigger pop into
+           existence and shove this search box 114px to the right — on every load of
+           /jobs and /companies, which is most of the site's traffic.
+           Launcher is the honest stand-in rather than a dead placeholder box: it needs
+           no store, it renders the identical neutral label, and a pick during those few
+           hundred milliseconds navigates to the feed with that scope instead of doing
+           nothing. -->
+      <HeaderLocationFilter variant="launcher" />
     {/if}
+    <div class="h-5 w-px shrink-0 bg-border"></div>
     <Search class="size-4 shrink-0 text-muted-foreground" />
     <input
       bind:this={inputEl}

--- a/web/src/lib/components/HeaderListSearch.svelte
+++ b/web/src/lib/components/HeaderListSearch.svelte
@@ -142,25 +142,20 @@
     <!-- List pages expose a filter scope: surface the Location quick-filter as a
          scope-prefix, divided from the search icon. `variant` picks the popover body
          (jobs work-format+location vs the company region/remote-hiring pills). -->
-    {#if target?.filterScope}
-      <HeaderLocationFilter
-        variant={target.filterScope.variant}
-        store={target.filterScope.store}
-        counts={target.filterScope.counts()}
-        inferred={target.filterScope.inferred?.() ?? false}
-      />
-    {:else}
-      <!-- The same trigger in launcher mode, standing in until the list view registers
-           its filter scope. That registration happens in the view's `onMount`, ~300ms
-           after first paint, and rendering nothing until then made the trigger pop into
-           existence and shove this search box 114px to the right — on every load of
-           /jobs and /companies, which is most of the site's traffic.
-           Launcher is the honest stand-in rather than a dead placeholder box: it needs
-           no store, it renders the identical neutral label, and a pick during those few
-           hundred milliseconds navigates to the feed with that scope instead of doing
-           nothing. -->
-      <HeaderLocationFilter variant="launcher" />
-    {/if}
+    <!-- Always rendered, launcher-shaped until the list view registers its filter
+         scope. That registration happens in the view's `onMount`, ~300ms after first
+         paint, and rendering nothing until then made the trigger pop into existence and
+         shove this search box 114px to the right — on every load of /jobs and
+         /companies. Launcher is the honest stand-in rather than a dead placeholder box:
+         it needs no store, it renders the identical neutral label, and a pick during
+         those few hundred milliseconds navigates to the feed with that scope instead of
+         doing nothing. -->
+    <HeaderLocationFilter
+      variant={target?.filterScope?.variant ?? 'launcher'}
+      store={target?.filterScope?.store}
+      counts={target?.filterScope?.counts() ?? null}
+      inferred={target?.filterScope?.inferred?.() ?? false}
+    />
     <div class="h-5 w-px shrink-0 bg-border"></div>
     <Search class="size-4 shrink-0 text-muted-foreground" />
     <input


### PR DESCRIPTION
## What and why

Reported from the live site: the header visibly jumps on load — the region selector
appears and the GitHub number moves. Both are real, both predate the geo-scope feature
that led me here, and both hit **every** load of `/jobs` and `/companies`.

The header's search box is `flex-1`, so it absorbs whatever the sides leave it. Anything
that arrives late on either side drags it — and everything inside it — sideways.

### The location trigger was not in the first paint at all

It renders only once the list view registers its filter scope, and that registration is
in the view's `onMount`. Measured on the live catalogue:

| t | trigger | search input's left edge |
|---|---|---|
| 41ms | **absent** | 291px |
| 311ms | appears, 97px | **405px** |
| 324ms | label becomes the scope | 414px |

**114px of sideways shove, 300ms in.** It now renders from the start in launcher mode —
the honest stand-in rather than a dead placeholder box: no store needed, the identical
neutral "Location" label, and a pick during those few hundred milliseconds navigates to
the feed with that scope instead of doing nothing.

After: the trigger's box exists at t=41ms, and the input moves **9px** — the label itself
changing from "Location" to the chosen scope.

### The GitHub star count popped in

`{#if count != null}`, and the count arrives from the store's `onMount`. It cannot arrive
earlier even though the store caches to localStorage: rendering a cached number the
server did not render is a hydration mismatch. So the box is reserved from the first
paint and fills in when the number lands. Badge width measured constant at 70px through
load, where it previously grew.

## On the CLS number

**Not the evidence for this change, deliberately.** That number swings by an order of
magnitude between measurement sessions purely on which jobs the catalogue happens to be
serving — I have watched the same build read 0.026 and 0.246 an hour apart. This session
measured 0.0259 before and 0.0246 after, on a page that scored low either way.

The evidence is the DOM: a box that exists at 41ms instead of 311ms, and a width that
stops changing. Those are deterministic observations, repeated across runs.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [ ] Go checks — n/a, no Go changed.
- [ ] `go test ./...` — n/a.
- [x] Committed artifacts — n/a, no SQL or contract source changed.
- [ ] `design-system/` — n/a, none.
- [x] For `web/` changes: `pnpm run check` (0 errors), `pnpm run build`, `pnpm vitest run` (1169 passed), eslint, and the design-system token ratchet all pass.
- [x] This stays within freehire's core/extension boundary — two components, no new surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GitHub star count display with consistent labels and spacing while counts are unavailable or loading.
  - Ensured location filtering remains available in the list header even when a filter scope has not yet been selected.
  - Preserved existing scoped filtering behavior and divider placement.
  - Maintained the existing search and filter controls alongside these updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->