### PR TITLE
Move the AI filter dialog to the body so the job cards stop painting over it

### DIFF
--- a/web/src/lib/actions/portal.test.ts
+++ b/web/src/lib/actions/portal.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { trapsOverlays } from './portal';
+
+// A fake element tree: each node knows its parent and its style. Enough to exercise the
+// rule without a DOM, the same split focusTrap uses.
+function tree(...styles: Partial<CSSStyleDeclaration>[]) {
+  const styleOf = new Map<Element, Partial<CSSStyleDeclaration>>();
+  let parent: Element | null = null;
+  let leaf: Element = null as unknown as Element;
+  // Outermost first, so the last style given is the leaf's own parent.
+  for (const style of styles) {
+    const el = { parentElement: parent } as unknown as Element;
+    styleOf.set(el, style);
+    parent = el;
+    leaf = el;
+  }
+  const node = { parentElement: leaf } as unknown as Element;
+  return { node, styleOf: (el: Element) => styleOf.get(el) ?? {} };
+}
+
+describe('trapsOverlays', () => {
+  // The one that actually shipped: the job list's filter sidebar is sticky, so a dialog
+  // rendered inside it painted under the job cards that come later in the document.
+  it('finds a sticky ancestor', () => {
+    const { node, styleOf } = tree({ position: 'static' }, { position: 'sticky' });
+    expect(trapsOverlays(styleOf, node)).toBe(true);
+  });
+
+  it('finds a transformed ancestor', () => {
+    const { node, styleOf } = tree({ transform: 'translateZ(0)' });
+    expect(trapsOverlays(styleOf, node)).toBe(true);
+  });
+
+  it('ignores an explicit none', () => {
+    const { node, styleOf } = tree({ transform: 'none', filter: 'none', perspective: 'none' });
+    expect(trapsOverlays(styleOf, node)).toBe(false);
+  });
+
+  it('is false when nothing between the node and the body opens a layer', () => {
+    const { node, styleOf } = tree({ position: 'static' }, { position: 'relative' });
+    expect(trapsOverlays(styleOf, node)).toBe(false);
+  });
+});

--- a/web/src/lib/actions/portal.ts
+++ b/web/src/lib/actions/portal.ts
@@ -1,0 +1,53 @@
+import type { Attachment } from 'svelte/attachments';
+
+/**
+ * Reports whether `node` has an ancestor that traps a fixed overlay — an element whose
+ * style makes it a stacking context, so a `z-50` child cannot paint above anything
+ * outside it however high the number goes.
+ *
+ * Pure so the rule is unit-testable in Node; the DOM glue lives in `portal` below.
+ *
+ * The properties listed are the ones that bite in this app's layouts. `position: sticky`
+ * is the one that actually did: the job list's filter sidebar is sticky, so a dialog
+ * rendered inside it painted *under* the job cards, which come later in the document.
+ * `transform`, `filter` and `perspective` are here because they do the same thing and
+ * are just as easy to add to a wrapper by accident.
+ */
+export function trapsOverlays(styleOf: (el: Element) => Partial<CSSStyleDeclaration>, node: Element): boolean {
+  for (let el = node.parentElement; el; el = el.parentElement) {
+    const style = styleOf(el);
+    if (style.position === 'sticky' || style.position === 'fixed') return true;
+    for (const value of [style.transform, style.filter, style.perspective]) {
+      if (value && value !== 'none') return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Moves the attached element to `document.body` for as long as it is mounted.
+ *
+ * A `fixed inset-0` overlay only covers the page when nothing between it and the body
+ * has opened a stacking context. `position: sticky` opens one unconditionally, so a
+ * dialog rendered inside a sticky sidebar is confined to the sidebar's layer and paints
+ * beneath every sibling that comes later in the document — which is what put the job
+ * cards on top of the AI filter dialog.
+ *
+ * The alternative is to mount every dialog at the view root and thread its open state
+ * down (what the All-filters modal does). This keeps a component that owns a dialog
+ * owning it, at the cost of one DOM move.
+ */
+export function portal(): Attachment<HTMLElement> {
+  return (node) => {
+    const parent = node.parentNode;
+    const anchor = node.nextSibling;
+    document.body.appendChild(node);
+
+    // Put it back where Svelte expects to find it. Svelte removes the node itself on
+    // destroy, and it can only do that from the parent it recorded.
+    return () => {
+      if (parent?.isConnected) parent.insertBefore(node, anchor);
+      else node.remove();
+    };
+  };
+}

--- a/web/src/lib/components/filters/AiFilterDialog.svelte
+++ b/web/src/lib/components/filters/AiFilterDialog.svelte
@@ -3,6 +3,7 @@
   import { Button } from '$lib/ui';
   import { errorMessage } from '$lib/utils';
   import { focusTrap } from '$lib/actions/focusTrap';
+  import { portal } from '$lib/actions/portal';
   import { dynamicLabel, FACETS } from '$lib/facets';
   import { experienceLabel, freshnessLabel } from '$lib/filterControls';
   import { filtersFromInterpretation } from '$lib/aiFilter';
@@ -96,7 +97,11 @@
 
 <svelte:window onkeydown={(e) => e.key === 'Escape' && onclose()} />
 
-<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+<!-- Moved to the body: this dialog is rendered from the filter sidebar, and that sidebar
+     is `sticky`, which opens a stacking context unconditionally. Inside one, `z-50` is
+     scoped to the sidebar's layer — so the overlay painted UNDER the job cards, which
+     come later in the document. No z-index can climb out of a stacking context. -->
+<div class="fixed inset-0 z-50 flex items-center justify-center p-4" {@attach portal()}>
   <button type="button" aria-label="Close dialog" class="absolute inset-0 bg-black/50" onclick={onclose}></button>
 
   <div


### PR DESCRIPTION
On production the dialog opened **under** the job list — overlay, backdrop and buttons all behind the cards.

`z-50` cannot cause that and cannot fix it. The dialog is rendered from the filter sidebar, and that sidebar is `position: sticky` (`JobsView.svelte`), which opens a stacking context unconditionally. Inside one, every z-index is scoped to the sidebar's own layer, so the overlay competes with the sidebar rather than with the page and anything later in the document wins. It is also why the All-filters modal never had this: it is mounted in `JobsView`, outside the sticky container.

`portal()` moves the overlay to the body while it is mounted and puts it back where Svelte expects it on destroy. The pure half — which ancestor styles trap an overlay — ships under test, so the next component that needs it gets the reason rather than a magic attachment to copy.

**Why it reached production:** I verified the dialog locally against an empty job list. An empty column has nothing to paint over an overlay, so the layout looked right for the one reason that could not hold on a page with results.

Verified: `svelte-check` 0 errors, 1182 web tests, eslint and the design-system token check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed filter dialogs appearing behind sidebar or other layered content.
  * Dialog overlays now render correctly above surrounding interface elements.

* **Tests**
  * Added coverage for overlay behavior involving sticky, transformed, filtered, positioned, and explicitly disabled styling contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->