### PR TITLE
Teach the prompt three things one non-English sentence exposed

### DIFF
--- a/internal/searchintent/prompt.go
+++ b/internal/searchintent/prompt.go
@@ -20,6 +20,10 @@ Capture everything they asked for, and nothing they did not. Both halves matter 
 
 So: read their sentence, and fill exactly the fields it speaks to. "Remote" is work_mode. "Not in the UK" is an exclusion. "Posted this week" is posted_within_days=7. "At least 100k" is salary_min.
 
+Where a person IS is not where the job is: "a developer from Brazil, after remote work in the US" asks for the US. Their own country is context, never a filter and never an exclusion — the same goes for their citizenship and their current employer.
+
+Working remotely is not relocating and needs no visa. Leave relocation and visa_sponsorship alone unless they asked to move or asked for sponsorship.
+
 Say each thing once, at the level they said it. A continent is the "regions" field: "somewhere in Europe" is regions=eu, NOT the twenty countries that make up Europe. Name countries only when they named countries, or when they ruled one out.
 
 Prefer saying what they DO want. The exclude object is the last resort, for the cases a positive value cannot express:
@@ -44,7 +48,7 @@ Never write 0 to mean "I am not setting this". Leave the field out.
 
 That is about ZERO, not about the fields. When they DO name a time or a floor, write it: "posted this week" is posted_within_days=7, "in the last few days" is 3, "this month" is 30, "at least 100k" is salary_min=100000. Dropping a bound they asked for leaves them scrolling the same stale postings they came here to skip.
 
-summary is always required, even when little else is filled.
+summary is always required, even when little else is filled. Write it in the language they wrote in: it is shown to them and never matched against a posting.
 
 Values you are given a list to choose from must come from that list. For the rest:
 
@@ -54,6 +58,8 @@ Values you are given a list to choose from must come from that list. For the res
 - role: a specific role key of the form <seniority>_<role>, e.g. "senior_backend". Leave it empty unless the person named a precise role; the category and seniority fields already carry the general case.
 
 query is free text matched against the whole posting, and it is a last resort. Use it ONLY for something no other field can express — a niche the fields have no word for. Anything a field covers must go in that field: a term written in query as well narrows the results a second time, for no reason.
+
+query must be English whatever language they wrote in. It is matched word for word against postings written in English, so a term in another language matches nothing and empties their results. Translate it, or leave query empty.
 
 summary is one plain sentence describing the search you built, in the person's own terms. It is shown to them instead of the raw filters, so it must describe exactly the values you wrote — not what they asked for, if you could not express all of it.`
 


### PR DESCRIPTION
A description written in Russian resolved its facets correctly — software engineering, US, remote — and then added three things nobody asked for.

**It excluded the person's own country.** The sentence said they were from Brazil and wanted remote work in the US; Brazil came back as an exclusion, so their own address became a filter against them. Where someone IS is not where the job is. The profile mapping has always known this — it deliberately does not filter on a stored home address — but the prompt did not.

**It set relocation and visa sponsorship.** Working remotely is not relocating and needs no visa, and neither word appeared in the sentence.

**It copied a word of their language into the free-text query.** That query is an AND against the whole posting and the postings are in English, so one such word would have hidden every job the facets had just found — an empty list that reads as "we carry no such jobs" rather than "that could never have matched".

All three are prompt rules, and **no code**. The last one nearly was: a guard that dropped a query written in a script the catalogue does not use, added in the same breath as the prompt line. Measured afterwards, the prompt alone kept the foreign word out **five in five**, so the guard went. The standard this package already set for the region rule was to measure first and add code only where the prompt measurably does not hold — three in five there, which is why that one lives in code.

The mapping stays what it was meant to be: a written condition becomes a facet when one exists, and free text when none does. Code earns a place only where the failure is invisible to the person it happens to.

Verified against the live gateway: the reported sentence five times in five clean, and the three English regression cases unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved search intent interpretation to distinguish personal location, citizenship, employer, and other context from job-location requirements.
  * Clarified that remote work does not automatically indicate relocation or visa sponsorship needs.
  * Search summaries now use the person’s language, while free-text queries remain English or are omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->