### PR TITLE
Hold a DSDS entity's props to the ones the component takes

### DIFF
--- a/design-system/docs/dsds/components.json
+++ b/design-system/docs/dsds/components.json
@@ -41,6 +41,18 @@
           "description": "If set, renders an <a> instead of a <button>."
         },
         {
+          "name": "target",
+          "type": "string",
+          "default": "undefined",
+          "description": "Anchor target; only meaningful alongside href."
+        },
+        {
+          "name": "rel",
+          "type": "string",
+          "default": "undefined",
+          "description": "Left unset, target=\"_blank\" still gets rel=\"noopener noreferrer\" — the component fills the reverse-tabnabbing default in so no call site has to. Passing rel yourself replaces it, including that default."
+        },
+        {
           "name": "class",
           "type": "string",
           "default": "undefined"
@@ -49,6 +61,11 @@
           "name": "children",
           "type": "Snippet",
           "required": true
+        },
+        {
+          "name": "...rest",
+          "type": "HTMLButtonAttributes & HTMLAnchorAttributes",
+          "description": "Forwarded to the rendered <button> or <a> — disabled, type, onclick, aria-*."
         }
       ],
       "stories": [

--- a/design-system/docs/verification.md
+++ b/design-system/docs/verification.md
@@ -25,6 +25,25 @@ The two in bold cross the package boundary. They are **repo checks that live her
 not package checks: they read a directory the package itself knows nothing about,
 and if `design-system/` is ever extracted they stay with the repo.
 
+## What an entity has to keep true
+
+An entity in `docs/dsds/` is a hand-written copy of something in `src/`, so every
+field of it is free to drift. `scripts/validate-docs.mjs` compares three of them
+back against the package: the files an entity points at exist, its `tokens` list
+matches the token file's keys, and its `props` list matches what the component
+destructures out of `$props()`. Each comparison runs **both ways** — a copy that
+omits half the original is as wrong as one that invents a field, and only the first
+kind is the sort of drift a reader would never notice.
+
+Props are named the way a **call site** writes them, not the way the component
+destructures them: `class: className` is documented as `class`, and the rest spread
+is documented as `...rest` so the passthrough has somewhere to be described. This is
+the check with a reader in mind — an agent decides what it may pass from the `props`
+list alone. `Button` grew `target` and `rel` in #1920 and the entity never learned
+about them, so the fact that the component fills in `rel="noopener noreferrer"` for a
+`_blank` target lived only in a source comment. Nothing was red for the week it took
+this check to notice.
+
 ## Token coverage — two radii
 
 `scripts/check-token-coverage.mjs` looks for three things, all the same defect: a

--- a/design-system/scripts/validate-docs.mjs
+++ b/design-system/scripts/validate-docs.mjs
@@ -5,6 +5,8 @@
 // this script notices when the original moves.
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { stripComments } from './source.mjs';
 
 const root = join(import.meta.dirname, '..');
 const docsDir = join(root, 'docs', 'dsds');
@@ -16,76 +18,188 @@ function fail(message) {
   errors++;
 }
 
+// Index of the brace/bracket/paren closing the one at `open`, skipping over string
+// and template literals so a delimiter inside a default value cannot unbalance the
+// count. -1 if the source never closes it.
+function matchClose(source, open) {
+  const pairs = { '{': '}', '[': ']', '(': ')' };
+  const stack = [pairs[source[open]]];
+  for (let i = open + 1; i < source.length; i++) {
+    const char = source[i];
+    if (char === '\\') i++;
+    else if (char === '"' || char === "'" || char === '`') {
+      i = skipString(source, i);
+      if (i < 0) return -1;
+    } else if (pairs[char]) stack.push(pairs[char]);
+    else if (char === stack.at(-1)) {
+      stack.pop();
+      if (stack.length === 0) return i;
+    }
+  }
+  return -1;
+}
+
+// Index of the quote closing the one at `open`. -1 if unterminated.
+function skipString(source, open) {
+  const quote = source[open];
+  for (let i = open + 1; i < source.length; i++) {
+    if (source[i] === '\\') i++;
+    else if (source[i] === quote) return i;
+  }
+  return -1;
+}
+
+// Whether the destructure ending at `from` is the one $props() fills. What sits
+// between the two is an optional type annotation, which may be a whole brace block
+// of its own — so skip balanced groups rather than scanning for the next '=', which
+// an arrow type (`() => void`) would hand us far too early.
+function isPropsDestructure(source, from) {
+  let i = from;
+  while (/\s/.test(source[i] ?? '')) i++;
+  if (source[i] === ':') {
+    for (i++; i < source.length; i++) {
+      if (source[i] === '"' || source[i] === "'" || source[i] === '`') i = skipString(source, i);
+      else if ('{[('.includes(source[i])) i = matchClose(source, i);
+      else if (source[i] === '=' && source[i + 1] !== '>' && source[i + 1] !== '=') break;
+      if (i < 0) return false;
+    }
+  }
+  if (source[i] !== '=') return false;
+  for (i++; /\s/.test(source[i] ?? ''); i++);
+  return source.startsWith('$props(', i);
+}
+
+// The members of a destructure, split on the commas that separate them rather than
+// on every comma — a default value is free to contain its own.
+function splitMembers(body) {
+  const members = [];
+  let start = 0;
+  for (let i = 0; i < body.length; i++) {
+    if (body[i] === '"' || body[i] === "'" || body[i] === '`') i = skipString(body, i);
+    else if ('{[('.includes(body[i])) i = matchClose(body, i);
+    else if (body[i] === ',') {
+      members.push(body.slice(start, i));
+      start = i + 1;
+      continue;
+    }
+    if (i < 0) break;
+  }
+  members.push(body.slice(start));
+  return members;
+}
+
+// The prop names a component accepts, spelled the way a call site writes them:
+// `class: className` is passed as class, and the rest spread keeps its `...` so the
+// docs can name the passthrough. Exported for the test, and because a docs site
+// would want the same list.
+export function propsFrom(source) {
+  const src = stripComments(source);
+  for (const match of src.matchAll(/\blet\s*\{/g)) {
+    const open = match.index + match[0].length - 1;
+    const close = matchClose(src, open);
+    if (close < 0 || !isPropsDestructure(src, close + 1)) continue;
+    return splitMembers(src.slice(open + 1, close))
+      .map((member) => member.trim().match(/^(\.\.\.)?([A-Za-z_$][\w$]*)/))
+      .filter(Boolean)
+      .map(([, spread, name]) => (spread ?? '') + name);
+  }
+  return [];
+}
+
 // Every story file some entity claims, so the sweep at the end can name the ones
 // nobody claims.
 const claimedStories = new Set();
 
-const files = readdirSync(docsDir).filter((file) => file.endsWith('.json'));
-if (files.length === 0) fail('docs/dsds/: no JSON files — the docs are gone, not valid');
+function checkEntity(file, path, entity) {
+  if (!entity.id) fail(`${file}: entity missing "id"`);
+  if (!entity.type) fail(`${file}: entity "${entity.id}" missing "type"`);
+  if (!entity.name) fail(`${file}: entity "${entity.id}" missing "name"`);
 
-for (const file of files) {
-  const path = join(docsDir, file);
-  let data;
-  try {
-    data = JSON.parse(readFileSync(path, 'utf-8'));
-  } catch (e) {
-    fail(`${file}: invalid JSON — ${e.message}`);
-    continue;
+  // File references are relative to the JSON that holds them.
+  const stories = entity.stories ?? [];
+  for (const ref of [entity.source, ...stories]) {
+    if (!ref?.file) continue;
+    const target = resolve(dirname(path), ref.file);
+    if (existsSync(target)) continue;
+    fail(`${file}: entity "${entity.id}" points at a missing file — ${ref.file}`);
   }
-  if (!Array.isArray(data.entities)) {
-    fail(`${file}: missing "entities" array`);
-    continue;
+  for (const story of stories) {
+    if (story.file) claimedStories.add(resolve(dirname(path), story.file));
   }
 
-  for (const entity of data.entities) {
-    if (!entity.id) fail(`${file}: entity missing "id"`);
-    if (!entity.type) fail(`${file}: entity "${entity.id}" missing "type"`);
-    if (!entity.name) fail(`${file}: entity "${entity.id}" missing "name"`);
+  const target = entity.source?.file && resolve(dirname(path), entity.source.file);
+  if (!target || !existsSync(target)) return;
 
-    // File references are relative to the JSON that holds them.
-    const stories = entity.stories ?? [];
-    for (const ref of [entity.source, ...stories]) {
-      if (!ref?.file) continue;
-      const target = resolve(dirname(path), ref.file);
-      if (existsSync(target)) continue;
-      fail(`${file}: entity "${entity.id}" points at a missing file — ${ref.file}`);
+  // A token list is a copy of the token file's keys. Drift either way means the
+  // docs describe a palette the package no longer ships.
+  if (entity.tokens) {
+    const authored = Object.keys(JSON.parse(readFileSync(target, 'utf-8')));
+    const shipped = authored.filter((name) => !name.startsWith('$'));
+    const documented = new Set(entity.tokens);
+    const undocumented = shipped.filter((name) => !documented.has(name));
+    const gone = entity.tokens.filter((name) => !shipped.includes(name));
+    if (undocumented.length) {
+      fail(`${file}: entity "${entity.id}" does not document ${undocumented.join(', ')}`);
     }
-    for (const story of stories) {
-      if (story.file) claimedStories.add(resolve(dirname(path), story.file));
-    }
-
-    // A token list is a copy of the token file's keys. Drift either way means the
-    // docs describe a palette the package no longer ships.
-    if (entity.tokens && entity.source?.file) {
-      const target = resolve(dirname(path), entity.source.file);
-      if (existsSync(target)) {
-        const authored = Object.keys(JSON.parse(readFileSync(target, 'utf-8')));
-        const shipped = authored.filter((name) => !name.startsWith('$'));
-        const documented = new Set(entity.tokens);
-        const undocumented = shipped.filter((name) => !documented.has(name));
-        const gone = entity.tokens.filter((name) => !shipped.includes(name));
-        if (undocumented.length) {
-          fail(`${file}: entity "${entity.id}" does not document ${undocumented.join(', ')}`);
-        }
-        if (gone.length) {
-          fail(`${file}: entity "${entity.id}" documents tokens that no longer exist — ${gone.join(', ')}`);
-        }
-      }
+    if (gone.length) {
+      fail(`${file}: entity "${entity.id}" documents tokens that no longer exist — ${gone.join(', ')}`);
     }
   }
 
-  console.log(`✓ ${file}: ${data.entities.length} entities`);
+  // Same rule one level down, for the props of a component. The prop list is the
+  // half of an entity an agent reads to decide what it may pass, so a prop missing
+  // from it is a capability nothing can discover — Button grew target/rel and the
+  // entity did not, taking with it the reverse-tabnabbing default the component
+  // sets so no call site has to.
+  if (entity.props && target.endsWith('.svelte')) {
+    const shipped = propsFrom(readFileSync(target, 'utf-8'));
+    const documented = entity.props.map((prop) => prop.name);
+    const undocumented = shipped.filter((name) => !documented.includes(name));
+    const gone = documented.filter((name) => !shipped.includes(name));
+    if (undocumented.length) {
+      fail(`${file}: entity "${entity.id}" does not document prop(s) ${undocumented.join(', ')}`);
+    }
+    if (gone.length) {
+      fail(`${file}: entity "${entity.id}" documents prop(s) the component no longer takes — ${gone.join(', ')}`);
+    }
+  }
 }
 
-// The other direction: a story file added to the package and never documented.
-const unclaimed = readdirSync(srcDir)
-  .filter((file) => file.endsWith('.stories.ts'))
-  .filter((file) => !claimedStories.has(join(srcDir, file)));
-if (unclaimed.length) fail(`src/: story files no entity claims — ${unclaimed.join(', ')}`);
+function main() {
+  const files = readdirSync(docsDir).filter((file) => file.endsWith('.json'));
+  if (files.length === 0) fail('docs/dsds/: no JSON files — the docs are gone, not valid');
 
-if (errors > 0) {
-  console.error(`\n${errors} error(s) found.`);
-  process.exit(1);
-} else {
-  console.log('\nAll DSDS docs valid.');
+  for (const file of files) {
+    const path = join(docsDir, file);
+    let data;
+    try {
+      data = JSON.parse(readFileSync(path, 'utf-8'));
+    } catch (e) {
+      fail(`${file}: invalid JSON — ${e.message}`);
+      continue;
+    }
+    if (!Array.isArray(data.entities)) {
+      fail(`${file}: missing "entities" array`);
+      continue;
+    }
+
+    for (const entity of data.entities) checkEntity(file, path, entity);
+
+    console.log(`✓ ${file}: ${data.entities.length} entities`);
+  }
+
+  // The other direction: a story file added to the package and never documented.
+  const unclaimed = readdirSync(srcDir)
+    .filter((file) => file.endsWith('.stories.ts'))
+    .filter((file) => !claimedStories.has(join(srcDir, file)));
+  if (unclaimed.length) fail(`src/: story files no entity claims — ${unclaimed.join(', ')}`);
+
+  if (errors > 0) {
+    console.error(`\n${errors} error(s) found.`);
+    process.exit(1);
+  } else {
+    console.log('\nAll DSDS docs valid.');
+  }
 }
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) main();

--- a/design-system/scripts/validate-docs.test.mjs
+++ b/design-system/scripts/validate-docs.test.mjs
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { propsFrom } from './validate-docs.mjs';
+
+// The names the docs have to use. A prop is what the *call site* writes, which is
+// not always what the component destructures into — `class: className` is written
+// `class`, and the rest spread is written by naming it.
+describe('propsFrom', () => {
+  it('reads a multi-line destructure with defaults', () => {
+    expect(
+      propsFrom(`let {
+        variant = 'secondary',
+        size = 'md',
+        children,
+      }: Props = $props();`),
+    ).toEqual(['variant', 'size', 'children']);
+  });
+
+  it('reads a single-line destructure', () => {
+    expect(propsFrom(`let { code, label }: { code: string; label: string } = $props();`)).toEqual([
+      'code',
+      'label',
+    ]);
+  });
+
+  // The call site writes class=, never className=, so className is the wrong name
+  // to hold the docs to.
+  it('names a renamed prop by the name callers write', () => {
+    expect(propsFrom(`let { class: className = 'size-4' } = $props();`)).toEqual(['class']);
+  });
+
+  // Input documents its passthrough as a prop called '...rest'. Keep that spelling:
+  // it is the one entry that tells a reader the component forwards anything else.
+  it('names the rest spread the way the docs already do', () => {
+    expect(propsFrom(`let { value = $bindable(), ...rest } = $props();`)).toEqual([
+      'value',
+      '...rest',
+    ]);
+  });
+
+  // The inline type annotation is a second brace block between the destructure and
+  // = $props(). Its members are types, not props, and counting them would demand
+  // docs for entries no caller can pass.
+  it('stops at the destructure, not at the inline type that follows it', () => {
+    expect(
+      propsFrom(`let {
+        open = $bindable(false),
+        onConfirm,
+      }: {
+        open?: boolean;
+        onConfirm: () => void | Promise<void>;
+      } = $props();`),
+    ).toEqual(['open', 'onConfirm']);
+  });
+
+  it('ignores a commented-out prop', () => {
+    expect(
+      propsFrom(`let {
+        title,
+        // description, — dropped, nothing rendered it
+      } = $props();`),
+    ).toEqual(['title']);
+  });
+
+  // A snippet or a plain module has no props to document, and that is not a failure.
+  it('returns nothing when the source declares no props', () => {
+    expect(propsFrom(`const cc = $derived(code.trim());`)).toEqual([]);
+  });
+});


### PR DESCRIPTION
`validate-docs` already compares two fields of a DSDS entity back against the package — the files it points at, and its token list, both ways. The prop list was the third copy and nothing reconciled it.

`Button` grew `target` and `rel` in #1920 and the entity did not, so the reverse-tabnabbing default the component fills in for a `_blank` target was written down only in a source comment. That prop list is the half of an entity an agent reads to decide what it may pass, so a prop missing from it is a capability nothing can discover.

**What's here**

- `propsFrom(source)` — reads the destructure `$props()` fills, naming each prop the way a call site writes it: `class`, not `className`, and `...rest` kept whole so the passthrough has somewhere to be described. Balanced-brace walk rather than a regex — the inline type annotation between the destructure and `$props()` is a second brace block whose members are types, and an arrow type inside it puts an `=` where scanning for one would stop too early.
- The comparison, both ways, next to the token one.
- 7 tests in `scripts/validate-docs.test.mjs`, matching the sibling scripts' export-a-pure-function shape. `validate-docs.mjs` grew the `import.meta.url` main guard the siblings have, so importing it no longer runs the validation.
- Button's entity documents `target`, `rel` and `...rest`.
- `docs/verification.md` records what the check holds and how prop names are spelled.

**Evidence**

The check found exactly one drifted entity out of 26 before the docs fix:

```
✗ components.json: entity "component.button" does not document prop(s) target, rel, ...rest
```

After: `pnpm validate:docs` clean, `pnpm test` 19 files / 138 tests green, `pnpm lint` adds no new warnings.