### PR TITLE
Stop the feed asking twice for a role facet it was already handed

### DIFF
--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -16,7 +16,12 @@
   import { Paginator } from '$lib/paginated.svelte';
   import { pageCount, pageOffset } from '$lib/pagination';
   import Pagination from './Pagination.svelte';
-  import { FilterStore, filtersToParams, activeFilterCount } from '$lib/filters';
+  import {
+    FilterStore,
+    filtersToParams,
+    activeFilterCount,
+    generalCountsCoverRole,
+  } from '$lib/filters';
   import { geoScopeOffered, loadJobFilters, markGeoScopeOffered } from '$lib/filterStorage';
   import { geoScopeQuery, shouldOfferGeoScope, WORLDWIDE_REGION } from '$lib/geoScope';
   import {
@@ -130,23 +135,42 @@
   // counts — the selects degrade to plain (countless) options, never break.
   // latestOnly stops a slow earlier response overwriting a newer one.
   let counts = $state.raw<FacetCounts | null>(null);
-  const refreshCounts = latestOnly(
-    () => api.facetCounts(scopedParams()),
-    (c) => (counts = c),
-  );
 
-  // The role distribution the header's suggestions are ranked and filtered by. Its own
-  // fetch, deliberately: `counts` above is scoped by the text query, and a suggestion
-  // list keyed off that would rank by "jobs matching what you have typed so far", lag
-  // it by one debounce, and drop roles in and out mid-word. One facet, no `q` — the
-  // rest of the filter scope stays, so the figure still answers what a click would
-  // give. Refreshed only when a non-text filter changes; typing does not touch it.
+  // The role distribution the header's suggestions are ranked and filtered by. A scope
+  // of its own, deliberately: `counts` above is scoped by the text query, and a
+  // suggestion list keyed off that would rank by "jobs matching what you have typed so
+  // far", lag it by one debounce, and drop roles in and out mid-word. Same filters, no
+  // `q` — so the figure still answers what a click would give.
   const roleScopeParams = () => {
     const p = scopedParams();
     p.delete('q');
     return p;
   };
   let roleCounts = $state.raw<FacetCounts | null>(null);
+
+  const refreshCounts = latestOnly(
+    () => {
+      // Whether THIS request's scope covers the role distribution is captured with the
+      // request, not read when it lands: the filters can move while it is in flight,
+      // and the answer belongs to the scope that was actually asked for.
+      const scope = scopedParams();
+      const coversRole = generalCountsCoverRole(scope);
+      return api.facetCounts(scope).then((c) => ({ counts: c, coversRole }));
+    },
+    ({ counts: c, coversRole }) => {
+      counts = c;
+      // One scope, one measurement: with no text query separating them, this response
+      // already IS the role distribution, `role` included and identical (see
+      // generalCountsCoverRole). Publishing it here is what lets the dedicated request
+      // below be skipped on the load every visitor pays for — and it leaves the
+      // suggestions populated, so the first keystroke has them in hand instead of
+      // waiting on a fetch.
+      if (coversRole) roleCounts = c;
+    },
+  );
+
+  // The dedicated measurement, for the one case the general response cannot answer: a
+  // scope that moved while a query was narrowing `counts`. One facet, no `q`.
   const refreshRoleCounts = latestOnly(
     () => api.facetCounts(roleScopeParams(), { facets: ['role'] }),
     (c) => (roleCounts = c),
@@ -429,11 +453,14 @@
       refreshCounts();
       // The role distribution ignores the text query, so refetch it only when the rest
       // of the scope moves — otherwise every settled keystroke would spend a request
-      // re-measuring something that did not change.
+      // re-measuring something that did not change. And when the scope carries no
+      // query, `refreshCounts` above is already measuring exactly this, so the request
+      // is skipped outright: that is the whole cold-load case, where the two calls
+      // returned the same `role` map twice.
       const roleScopeKey = roleScopeParams().toString();
       if (roleScopeKey !== lastRoleScopeKey) {
         lastRoleScopeKey = roleScopeKey;
-        refreshRoleCounts();
+        if (!generalCountsCoverRole(scopedParams())) refreshRoleCounts();
       }
       const firstRun = !started;
       if (firstRun) {

--- a/web/src/lib/facetModel.test.ts
+++ b/web/src/lib/facetModel.test.ts
@@ -6,6 +6,7 @@ import {
   filtersFromParams,
   activeFilterCount,
   canonicalQuery,
+  generalCountsCoverRole,
   savedSearchQuery,
   signOf,
   facetSetSign,
@@ -304,5 +305,25 @@ describe('filtersWithRole', () => {
     filtersWithRole(before, 'data_analytics');
     expect(before.q).toBe('data an');
     expect(must(before.facets.role).include).toEqual([]);
+  });
+});
+
+describe('generalCountsCoverRole', () => {
+  it('covers role when the scope carries no text query', () => {
+    expect(generalCountsCoverRole(new URLSearchParams('regions=latam,global'))).toBe(true);
+  });
+
+  it('covers role for the bare, unfiltered scope', () => {
+    expect(generalCountsCoverRole(new URLSearchParams())).toBe(true);
+  });
+
+  it('does not cover role once a text query narrows the scope', () => {
+    expect(generalCountsCoverRole(new URLSearchParams('regions=latam,global&q=python'))).toBe(
+      false,
+    );
+  });
+
+  it('treats an empty q the way filtersToParams does — as no query at all', () => {
+    expect(generalCountsCoverRole(new URLSearchParams('q='))).toBe(true);
   });
 });

--- a/web/src/lib/facetModel.ts
+++ b/web/src/lib/facetModel.ts
@@ -87,6 +87,25 @@ export function filtersToParams(f: JobFilters): URLSearchParams {
   return p;
 }
 
+/** Whether a general facet response measured under `scope` also answers for the role
+ *  distribution, which is measured under the same scope minus the text query.
+ *
+ *  The two coincide exactly when there is no text query to separate them — and then
+ *  they are not merely equivalent but identical, because `/jobs/facets` with no
+ *  `facets=` counts every facet, `role` among them. Measured against prod on
+ *  2026-08-21: `?regions=latam,global` and `?regions=latam,global&facets=role`
+ *  returned byte-identical `role` maps (867 values), while adding `q=python` cut the
+ *  general response's `role` to 209 — which is exactly why the role distribution has
+ *  its own scope in the first place.
+ *
+ *  So this is the test for "the dedicated role request would be a second copy of a
+ *  response we already have". An empty `q` counts as no query: `filtersToParams` only
+ *  writes the param when the string is non-empty, and a hand-built `?q=` means the
+ *  same thing to the API. */
+export function generalCountsCoverRole(scope: URLSearchParams): boolean {
+  return !scope.get('q');
+}
+
 /** Parse filters back from URL query params. Include and exclude are independent
  *  sets; if a value appears in both (a malformed or legacy link), exclude wins and
  *  it is dropped from include so a value carries exactly one sign. */


### PR DESCRIPTION
## What

The jobs feed measured the role distribution (the header's suggestion list) with its own request, always. When there is no text query that request is a second copy of one already in flight.

`/jobs/facets` with no `facets=` counts every facet, `role` among them. Measured on prod: `?regions=latam,global` and `?regions=latam,global&facets=role` return **byte-identical** `role` maps (867 values, 24,346 bytes each). Adding `q=python` cuts the general response's `role` to 209 — which is why the separate scope exists, and why it stays for that case.

The general refresh now publishes the role distribution itself when its own scope carried no query; the dedicated request is left for the one case it is needed — a scope that moves while a query is narrowing the general response.

## Why now

Measured a first visit to `/` with a real browser from Brazil. Six API calls, in two waves, content settling at 4.07s:

| Request | Duration | |
|---|---|---|
| `/api/v1/jobs/facets?` | 701 ms | discarded |
| `/api/v1/jobs/facets?facets=role` | 534 ms | discarded |
| `/geo/region` | 264 ms | |
| `/api/v1/jobs/facets?regions=latam,global` | 950 ms | |
| `...&facets=role` | 425 ms | **duplicate of the row above** |
| `/api/v1/jobs/search?regions=latam,global` | 314 ms | |

This removes the duplicate from both waves. The wasted first wave is the geo scope's own cost and is left alone — the design deliberately keeps geography off the server so the edge-cached HTML does not vary by country.

Keeping the general response as the source also leaves the suggestions populated from first paint, so the first keystroke has them in hand rather than waiting on a fetch; the mount-time request used to cover that.

## Verification

Against prod through the dev proxy, with a real browser:

- Cold feed, no query → **one** facet call, not two.
- Typing `data eng` → no extra request, and the suggestions still show the query-free counts (`Data Engineer 39,031`, not the `38,923` a query-scoped count gives).
- Cold load of `?q=data+eng` → both calls, unchanged.
- Cold load of `?q=data+eng&regions=europe` → dedicated call correctly scoped `?regions=europe&facets=role` — carries the region, drops the query.
- Applying a role suggestion (which clears the query) → one call.

`vitest run`: 1182 passed. `svelte-check`: 0 errors. `eslint`: clean. Four new tests state the rule in `facetModel.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved job filtering so role counts load more efficiently when available from general search results.
  * Avoided redundant role-count requests for searches without a text query.
  * Continued fetching dedicated role counts when text searches require more specific results.

* **Bug Fixes**
  * Improved accuracy and consistency of role facet counts across different search scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->