### PR TITLE
Measure the feed's facets once, for the scope the visitor actually gets

### DIFF
--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -129,6 +129,33 @@
   untrack(() => seeded.seed(initial, pageOffset(currentPage)));
   let jobs = $state.raw(seeded);
 
+  // Whether an opening scope is still to be guessed from the visitor's IP country, and
+  // so whether the facet measurement below is worth making yet. Asked here, at setup,
+  // because the answer is knowable without the network: `offerGeoScope` runs these same
+  // three guards before it fetches anything, and only a first-time visitor landing on a
+  // bare URL gets past them. Everybody else — a repeat visitor, a link carrying filters,
+  // a restored set — is false here and waits for nothing.
+  //
+  // What the wait buys: measured from Brazil on 2026-08-21, a cold feed spent 778ms on
+  // a facet count of the unscoped catalogue that `/geo/region` (330ms) then replaced
+  // wholesale, and the two overlapped, so the discarded one was also competing for the
+  // connection the useful one needed. One scope, measured once.
+  //
+  // Never true on the server (no `location`, and `geoScopeOffered` reads an absent
+  // localStorage as "already offered"), so SSR is untouched.
+  let geoGuessPending = $state(
+    untrack(
+      () =>
+        browser &&
+        standalone &&
+        shouldOfferGeoScope({
+          search: location.search,
+          storedFilters: loadJobFilters(),
+          offered: geoScopeOffered(),
+        }),
+    ),
+  );
+
   // The live facet distribution (value → count per facet), feeding the dynamic
   // selects (skills, countries) so the user sees which values exist and how many
   // jobs each has under the current filters. A failed fetch leaves the prior
@@ -443,12 +470,19 @@
     goto(resolve('/jobs/swipe') + (qs ? `?${qs}` : ''));
   }
 
-  // Reload list + counts whenever the debounced filters change — a settled
-  // keystroke, an immediate facet toggle, or a back/forward re-seed. Skip the
-  // first run for the list (the SSR `initial` already seeded page one); still
-  // fetch counts on mount since they aren't server-rendered into this view.
+  // Measure the facets for the scope now in force — on mount too, since they are not
+  // server-rendered into this view.
+  //
+  // Its own effect, apart from the list reload below, because the two answer to
+  // different triggers: releasing the geography hold must re-measure the facets and must
+  // NOT reload the list. In one effect that did both, the visitor whose guess resolved
+  // to no region got a second, identical search — the release re-ran the whole body
+  // while the filters had not moved.
   $effect(() => {
     void filters.applied; // track the debounced snapshot
+    // Read outside untrack: clearing the hold is what re-runs this, and it is the only
+    // thing that ever will for a visitor whose guess came back empty.
+    if (geoGuessPending) return;
     untrack(() => {
       refreshCounts();
       // The role distribution ignores the text query, so refetch it only when the rest
@@ -462,6 +496,15 @@
         lastRoleScopeKey = roleScopeKey;
         if (!generalCountsCoverRole(scopedParams())) refreshRoleCounts();
       }
+    });
+  });
+
+  // Reload the list whenever the debounced filters change — a settled keystroke, an
+  // immediate facet toggle, or a back/forward re-seed. The first run is a no-op: the
+  // SSR `initial` already seeded page one.
+  $effect(() => {
+    void filters.applied; // track the debounced snapshot
+    untrack(() => {
       const firstRun = !started;
       if (firstRun) {
         started = true;
@@ -625,12 +668,21 @@
   if (untrack(() => standalone)) {
     afterNavigate((nav) => {
       const stored = nav.type !== 'enter' && location.search === '' ? loadJobFilters() : '';
-      if (stored) filters.apply(stored);
-      else {
+      if (stored) {
+        filters.apply(stored);
+        // A restored set outranks the guess, so nothing is going to be asked for and
+        // the facet measurement must not keep waiting on an answer that is not coming.
+        geoGuessPending = false;
+      } else {
         filters.syncFromUrl();
         // Last in the precedence chain, and the only branch that runs on a cold
         // load: URL params were just applied, or there was nothing to restore.
-        void offerGeoScope();
+        //
+        // Released on EVERY outcome — scope applied, no region, guard failed on the
+        // re-read, storage refused the marker — because the facet measurement is held
+        // behind this and a path that forgot to release would leave the filter panel
+        // permanently countless.
+        void offerGeoScope().finally(() => (geoGuessPending = false));
       }
     });
   } else {


### PR DESCRIPTION
Follow-up to #2183. Same page, the other half of the waste.

## What

A first-time visitor on a bare URL opens on their own region plus worldwide, guessed from the edge's country header. That guess arrives over the network, so the feed measured its facets **twice** — once for the unscoped catalogue on mount, then again for the scope that landed a few hundred milliseconds later.

The wait this replaces is knowable without asking anyone. `offerGeoScope` already runs three synchronous guards — address bar, stored filters, the already-offered marker — before it fetches anything. So the hold is decided at setup from those same guards, and **only the visitor who is actually going to be asked waits**. Everyone else reads `false` and waits for nothing.

## Before / after, first visit from Brazil

| | Before | After |
|---|---|---|
| `/api/v1/jobs/facets?` (unscoped) | 778 ms, discarded | **gone** |
| `/geo/region` | 330 ms | 330 ms |
| `/api/v1/jobs/facets?regions=…` | ✓ | ✓ |
| `/api/v1/jobs/search?regions=…` | ✓ | ✓ |

The discarded measurement overlapped the useful one, so it was also competing for the connection.

## The part that made it correct rather than merely shorter

Splitting the facet measurement out of the list-reload effect. Held in the single effect that did both, releasing the hold re-ran the whole body — and for the visitor whose guess came back with **no region** the filters had not moved, so they collected a second, identical search request. I caught this in the browser before it went anywhere.

The two effects now answer to their own triggers: releasing the hold re-measures the facets and leaves the list alone. The list effect is otherwise unchanged, including the first-run and re-seed behaviour the geography path relies on to load the scoped page.

The release is attached with `finally` on every outcome — scope applied, no region, a guard that failed on the re-read, storage that refused the marker. The facet counts hang off it, and a path that forgot to release would leave the filter panel permanently countless.

## Verification

Against prod through the dev proxy, with a real browser, all four visitor classes:

- **First visit, region resolved** (spoofed `CF-IPCountry: BR`) → `/geo/region`, then the scoped search and **one** scoped facet call. The unscoped one is gone.
- **First visit, no region** → `/geo/region`, then one unscoped facet call and **no** search — matching what the SSR page already showed.
- **Repeat visit** (marker set) → no `/geo/region`, facets immediately, one call.
- **Link carrying `?seniority=senior`** → no `/geo/region`, facets immediately, scoped.
- **Typing** → one query-scoped call, suggestions still query-free.

`vitest run`: 1182 passed. `svelte-check`: 0 errors. `eslint`: clean.

Note on measuring this locally: `performance.getEntriesByType('resource')` is useless against the dev server — its default 250-entry buffer fills with dev module requests before any API call happens, and the API fetches are silently dropped. The browser's own request log is the reliable source.