### PR TITLE
Open the autopilot's stream before it computes the analysis

### DIFF
--- a/internal/handler/assistant.go
+++ b/internal/handler/assistant.go
@@ -633,6 +633,15 @@ func (h *assistantHandlers) streamSSE(
 
 		defer cancel()
 
+		// One byte immediately, before anything this turn might wait on. Until something is
+		// written, fasthttp is holding the response line and the headers in its buffer, so
+		// "the stream is open" is true here and not yet true on the wire — and a proxy times
+		// out a request whose upstream has sent nothing, however busy that upstream is. The
+		// heartbeat below cannot cover this: its first comment is a whole interval away.
+		// A comment rather than an event because EventSource ignores it: this says nothing to
+		// the client, it only makes the connection real.
+		stream.comment("open")
+
 		// The heartbeat starts BEFORE the queue wait, not after it: a queued message can wait
 		// up to a minute, and an idle connection is exactly what a proxy in front of us
 		// collects. Waiting in silence would lose the connection at roughly the same moment
@@ -834,34 +843,50 @@ func (h *assistantHandlers) PostAssistantAutopilot(c *fiber.Ctx) error {
 	}
 	// One read of the vacancy for the whole pre-run: the fit analysis and the surface
 	// alignment both need it, and a run must not ask the database twice for the same row.
-	refreshAnalysis := func(context.Context) {}
+	// This read stays in the request — it is one row, and the pre-run has nothing to prepare
+	// without it.
+	var analysis *autopilotAnalysis
+	var jobDescription string
 	if job, err := h.queries.GetJob(c.Context(), *sess.JobID); err != nil {
 		log.Printf("assistant: loading job %d for the autopilot pre-run: %v", *sess.JobID, err)
 	} else {
-		refreshAnalysis = h.prepareAutopilotAnalysis(c, sess, job)
-		// Its own system revision — not the run's edit batch — so undoing the run leaves the
-		// vacancy's wording in place.
-		h.cv.logSurfaceAlign(c.Context(), sess.UserID, *sess.CVID, job.Description)
+		analysis, jobDescription = h.prepareAutopilotAnalysis(c, sess, job), job.Description
 	}
-	h.layDownRunPlan(c.Context(), sess)
 	return h.streamSSE(c, sess, func(ctx context.Context, runner *assistant.Runner, reg *assistant.Registry, system string, emit func(assistant.Event)) error {
+		// The pre-run happens HERE, inside the stream, and not in the handler above it. On a
+		// vacancy with no cached fit analysis it runs the three-stage chain — minutes, not
+		// seconds — and a handler that has not returned has written no byte, so a proxy in
+		// front of us times the request out and the candidate is told the run failed to
+		// start. From here the response is already open and its heartbeat already ticking,
+		// so the same wait costs nothing but the wait.
+		//
+		// Order is the order it had: the analysis first, because the run plan is written from
+		// it, and cv_context reads it on the run's first step.
+		analysis.ensure(ctx)
+		if jobDescription != "" {
+			// Its own system revision — not the run's edit batch — so undoing the run leaves
+			// the vacancy's wording in place.
+			h.cv.logSurfaceAlign(ctx, sess.UserID, *sess.CVID, jobDescription)
+		}
+		h.layDownRunPlan(ctx, sess)
+
 		err := runner.Run(ctx, sess, reg, system, autopilotBrief, assistant.TurnConfig{MaxSteps: autopilotMaxSteps}, emit)
 		// The refresh is unconditional — it must run even when the candidate cancelled the
 		// run partway through (CancelAssistantTurn cancels this very ctx) — so it runs on a
 		// detached copy, the same way boundRunner's credential-forget already does.
-		refreshAnalysis(context.WithoutCancel(ctx))
+		analysis.refresh(context.WithoutCancel(ctx))
 		return err
 	})
 }
 
-// prepareAutopilotAnalysis delegates to matchHandlers.prepareAutopilotRun, which both fills
-// the fit-analysis cache when empty (so cv_context — the run's first tool call — has
-// something to read instead of erroring) and returns the closure that unconditionally
-// refreshes that cache once the run ends. A missing match surface degrades to a no-op
-// refresh — the same best-effort posture the pre-run ensure step already had.
-func (h *assistantHandlers) prepareAutopilotAnalysis(c *fiber.Ctx, sess assistant.Session, job db.Job) func(context.Context) {
+// prepareAutopilotAnalysis delegates to matchHandlers.prepareAutopilotRun, which assembles
+// both halves of the run's fit analysis — the fill that gives cv_context something to read,
+// and the refresh that follows the run — out of reads taken while c is still valid. A
+// missing match surface degrades to a nil, whose ensure and refresh are no-ops: the same
+// best-effort posture this step always had.
+func (h *assistantHandlers) prepareAutopilotAnalysis(c *fiber.Ctx, sess assistant.Session, job db.Job) *autopilotAnalysis {
 	if h.cv == nil || h.cv.match == nil {
-		return func(context.Context) {}
+		return nil
 	}
 	return h.cv.match.prepareAutopilotRun(c, sess.UserID, job)
 }

--- a/internal/handler/assistant_autopilot_integration_test.go
+++ b/internal/handler/assistant_autopilot_integration_test.go
@@ -7,12 +7,14 @@
 package handler
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -199,6 +201,108 @@ func TestAutopilotComputesAnalysisWhenMissing(t *testing.T) {
 	if fitM.n != 6 {
 		t.Errorf("fit model called %d times, want 6 (one full chain run before the run, one after) — the post-run refresh must fire even when the pre-run step just computed one", fitM.n)
 	}
+}
+
+// gatedFitModel is a fitModel that holds its FIRST call until released, so a test can inspect
+// the world while the cold-start chain is provably mid-flight.
+type gatedFitModel struct {
+	fitModel
+	started     chan struct{}
+	release     chan struct{}
+	holdOnce    sync.Once
+	releaseOnce sync.Once
+}
+
+func newGatedFitModel(t *testing.T) *gatedFitModel {
+	m := &gatedFitModel{
+		fitModel: fitModel{resp: []string{fitStage1, fitStage2, fitStage3}},
+		started:  make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+	t.Cleanup(m.letGo)
+	return m
+}
+
+// letGo releases the model however many times it is called, so a test may release it
+// explicitly and still be cleaned up after.
+func (m *gatedFitModel) letGo() { m.releaseOnce.Do(func() { close(m.release) }) }
+
+func (m *gatedFitModel) GenerateContent(ctx context.Context, msgs []llms.MessageContent, opts ...llms.CallOption) (*llms.ContentResponse, error) {
+	m.holdOnce.Do(func() {
+		close(m.started)
+		<-m.release
+	})
+	return m.fitModel.GenerateContent(ctx, msgs, opts...)
+}
+
+// TestAutopilotAnswersBeforeTheColdStartAnalysis: the response must open BEFORE the cold-start
+// fit analysis runs, not after it.
+//
+// The pre-run used to happen in the handler, ahead of streamSSE, so on a vacancy with nothing
+// cached the response stayed silent for as long as the three-stage chain took — measured at
+// 2m6s on prod, 2026-08-21, against nginx's 60s default. The proxy cut five runs that day and
+// the browser reported "could not start the run" for runs that were running fine and went on
+// to finish. Nothing downstream can tell those two apart, so the fix has to be here: open the
+// stream first, wait inside it, where the heartbeat is already ticking.
+func TestAutopilotAnswersBeforeTheColdStartAnalysis(t *testing.T) {
+	pool := startPostgres(t)
+	queries := db.New(pool)
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	turnM := &turnModel{replies: []*llms.ContentChoice{{Content: "Walked the requirements."}}}
+	fitM := newGatedFitModel(t)
+	an := matchanalysis.NewAnalyzer(llm.NewWithModel(fitM))
+
+	bank := experience.NewStore(experience.NewQueriesRepository(queries))
+	h := &assistantHandlers{
+		store: assistant.NewStore(queries), queries: queries,
+		maxPrompt:  defaultAssistantMaxPrompt,
+		stages:     queries,
+		experience: bank,
+		cv: &cvHandlers{
+			cvStore:            cv.NewStore(cv.NewQueriesRepository(queries)),
+			editor:             cvedit.NewEditor(cvedit.NewRepository(pool, queries), bankGate{bank: bank}),
+			queries:            queries,
+			jobReader:          queries,
+			matchAnalysisCache: queries,
+			match:              fitAPI(pool, queries, iss, resume.New(nil, resume.NewQueriesRepository(queries)), an),
+		},
+	}
+	h.runner = assistant.NewRunner(turnM, h.store, assistant.RunnerConfig{MaxSteps: 3})
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	api := app.Group("/api/v1")
+	mw := middleware{
+		cookie: auth.RequireAuth(iss, testVersions),
+		key:    auth.RequireAuthOrKey(iss, testVersions, apiKeys{queries}),
+	}
+	h.register(api, mw)
+	h.cv.register(api, mw)
+
+	userID, cookie := assistantUser(t, pool, iss, "autopilot-ttfb@example.test", true)
+	seedBankedCareer(t, queries, userID)
+	sessionID, _ := seedTailoringSession(t, pool, h, userID)
+
+	addr := serveOnSocket(t, app)
+	conn := dialAutopilotTurn(t, addr, sessionID, cookie)
+	defer func() { _ = conn.Close() }()
+
+	select {
+	case <-fitM.started:
+	case <-time.After(15 * time.Second):
+		t.Fatal("the cold-start analysis never started")
+	}
+
+	// The chain is held mid-flight. The response line must already be on the wire: what a
+	// proxy counts is silence from the upstream, and this is the silence that cost the runs.
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	status, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		t.Fatalf("nothing answered while the cold-start analysis is still running (%v) — the "+
+			"stream opens only after the chain, which is exactly what a proxy times out", err)
+	}
+	if !strings.HasPrefix(status, "HTTP/1.1 200") {
+		t.Fatalf("response line %q, want HTTP/1.1 200", strings.TrimSpace(status))
+	}
+	fitM.letGo()
 }
 
 // TestAutopilotRefreshesAnalysisAfterEveryRun: the fit analysis is no longer a frozen

--- a/internal/handler/match_analysis.go
+++ b/internal/handler/match_analysis.go
@@ -275,21 +275,67 @@ func (h *matchHandlers) runAnalysis(c *fiber.Ctx, userID int64, job db.Job, prof
 	return analyzer.Analyze(c.Context(), h.buildAnalysisInput(c, job, userID, profile, blockers, language))
 }
 
-// ensureCachedAnalysis computes and caches the fit analysis for (user, job) when none is cached
-// yet, reusing the exact compute path PostMatchAnalysis uses. It exists for the cold-start
-// autopilot run, whose first tool call (cv_context) reads the cache and errors without one — this
-// is what lets that run start without requiring the candidate to have produced an analysis first.
+// autopilotAnalysis is one autopilot run's fit analysis: the cold-start fill the run's first
+// tool call (cv_context) depends on, and the refresh that must follow the run. Both run the
+// same three-stage chain over the same Input, so both are assembled once, here, rather than
+// each reading the candidate's profile, blockers and bank for itself.
 //
-// Best-effort and silent: a lookup or compute failure (no LLM configured, an analyzer error) is
-// logged and left uncached, exactly as PostMatchAnalysis already degrades. No credits debit — this
-// path is unmetered, tracked only by the same LLM spend attribution every call already carries
-// (see the tailor-coldstart-autopilot design's "no new metering" decision).
+// Everything it holds is a plain value because NEITHER half runs in the request. The refresh
+// never could — it fires after the turn, from the SSE writer's detached goroutine. The fill
+// now joins it there: run in the handler ahead of the stream, it left the response silent for
+// the whole chain, which on 2026-08-21 was 2m6s against nginx's 60s default. The proxy cut
+// five runs that way, and each one told the candidate their run had failed to start while it
+// was in fact running.
 //
-// Coalesced through h.coalesce: the tailoring workspace's visible match-analysis stream now
+// A nil *autopilotAnalysis is a working no-op — the caller has no match surface wired — so
+// PostAssistantAutopilot needs no branch of its own.
+type autopilotAnalysis struct {
+	h            *matchHandlers
+	userID       int64
+	job          db.Job
+	analyzer     *matchanalysis.Analyzer
+	input        matchanalysis.Input
+	cvUploadedAt *time.Time
+	language     string
+}
+
+// prepareAutopilotRun assembles the run's analysis while the fiber ctx is still valid. It
+// reads — profile, blockers, language, the credential binding, the Input, the CV's upload
+// stamp — and computes nothing; both halves are the caller's to run from the stream.
+func (h *matchHandlers) prepareAutopilotRun(c *fiber.Ctx, userID int64, job db.Job) *autopilotAnalysis {
+	profile, _ := h.userProfile.Get(c.Context(), userID)
+	blockers := h.jobBlockers(c.Context(), userID, job, profile)
+	language := h.callerLanguage(c.Context(), userID)
+	cvUploadedAt, _ := h.cvUploadedAt(c, userID)
+	return &autopilotAnalysis{
+		h:            h,
+		userID:       userID,
+		job:          job,
+		analyzer:     h.matchAnalysis.As(h.llm.bind(c.Context(), userID, tagMatchAnalysis)),
+		input:        h.buildAnalysisInput(c, job, userID, profile, blockers, language),
+		cvUploadedAt: cvUploadedAt,
+		language:     language,
+	}
+}
+
+// ensure computes and caches the analysis when none is cached yet. It exists for the
+// cold-start autopilot run, whose first tool call reads the cache and errors without one —
+// this is what lets that run start without requiring the candidate to have produced an
+// analysis first.
+//
+// Best-effort and silent: a lookup or compute failure (no LLM configured, an analyzer error)
+// is logged and left uncached, exactly as PostMatchAnalysis already degrades. No credits
+// debit — this path is unmetered, tracked only by the same LLM spend attribution every call
+// already carries (see the tailor-coldstart-autopilot design's "no new metering" decision).
+//
+// Coalesced through h.coalesce: the tailoring workspace's visible match-analysis stream
 // starts at the same cold start this runs at, so both routinely race for the identical
 // (user, job) — see matchAnalysisCoordinator for why only one of them ever actually computes.
-func (h *matchHandlers) ensureCachedAnalysis(c *fiber.Ctx, userID int64, job db.Job) {
-	done, run, isLeader := h.coalesce.lead(userID, job.ID)
+func (a *autopilotAnalysis) ensure(ctx context.Context) {
+	if a == nil {
+		return
+	}
+	done, run, isLeader := a.h.coalesce.lead(a.userID, a.job.ID)
 	if !isLeader {
 		// The visible stream (or another concurrent call for this pair) already claimed the
 		// compute — wait for it rather than spending a second three-stage chain on the same
@@ -301,66 +347,42 @@ func (h *matchHandlers) ensureCachedAnalysis(c *fiber.Ctx, userID int64, job db.
 	succeeded := false
 	defer func() { done(succeeded) }()
 
-	if _, err := h.matchAnalysisCache.GetUserJobAnalysis(c.Context(),
-		db.GetUserJobAnalysisParams{UserID: userID, JobID: job.ID}); err == nil {
+	if _, err := a.h.matchAnalysisCache.GetUserJobAnalysis(ctx,
+		db.GetUserJobAnalysisParams{UserID: a.userID, JobID: a.job.ID}); err == nil {
 		succeeded = true // already cached — nothing to compute, and it's a good row for a follower to read
 		return
 	} else if !errors.Is(err, pgx.ErrNoRows) {
-		log.Printf("matchanalysis: checking cache before an autopilot run, user %d job %d: %v", userID, job.ID, err)
+		log.Printf("matchanalysis: checking cache before an autopilot run, user %d job %d: %v",
+			a.userID, a.job.ID, err)
 		return
 	}
-	profile, _ := h.userProfile.Get(c.Context(), userID)
-	blockers := h.jobBlockers(c.Context(), userID, job, profile)
-	language := h.callerLanguage(c.Context(), userID)
-	analysis, err := h.runAnalysis(c, userID, job, profile, blockers, language)
-	if err != nil {
-		log.Printf("matchanalysis: inline compute before an autopilot run, user %d job %d: %v", userID, job.ID, err)
-		return
-	}
-	if analysis == nil {
-		return // LLM unconfigured — nothing to cache
-	}
-	cvUploadedAt, _ := h.cvUploadedAt(c, userID)
-	h.cacheAnalysis(c.Context(), userID, job, cvUploadedAt, language, analysis)
-	succeeded = true
+	succeeded = a.compute(ctx, "inline compute before an autopilot run")
 }
 
-// prepareAutopilotRun ensures the fit analysis is cached before an autopilot run starts —
-// exactly ensureCachedAnalysis's fill-if-empty, so cv_context has something to read — and
-// returns the closure PostAssistantAutopilot calls once the run ends, which UNCONDITIONALLY
-// recomputes the chain and overwrites the (user, job) cache, even when nothing was cached
-// or an analysis was already there. This is what repeals the fit-analysis-post-autopilot-verify
-// design's predecessor rule that the fit analysis is a frozen snapshot of the base profile.
-//
-// The Input/Analyzer for the guaranteed refresh is assembled here, before returning, so it
-// closes over plain values rather than c — the closure runs later from the SSE writer's
-// detached goroutine, which only has a plain context.Context (see cacheAnalysis's own
-// comment on the same constraint). ensureCachedAnalysis assembles its own Input on a cache
-// miss; the two are not shared, so a cold cache costs the profile/blockers/bank reads
-// twice in one autopilot invocation — an accepted cost of keeping this function simple,
-// since a cache miss on the run's own vacancy is the rarer path. Never debits credits —
-// this path, like ensureCachedAnalysis, is unmetered.
-func (h *matchHandlers) prepareAutopilotRun(c *fiber.Ctx, userID int64, job db.Job) func(context.Context) {
-	h.ensureCachedAnalysis(c, userID, job)
-
-	profile, _ := h.userProfile.Get(c.Context(), userID)
-	blockers := h.jobBlockers(c.Context(), userID, job, profile)
-	language := h.callerLanguage(c.Context(), userID)
-	analyzer := h.matchAnalysis.As(h.llm.bind(c.Context(), userID, tagMatchAnalysis))
-	input := h.buildAnalysisInput(c, job, userID, profile, blockers, language)
-	cvUploadedAt, _ := h.cvUploadedAt(c, userID)
-
-	return func(ctx context.Context) {
-		analysis, err := analyzer.Analyze(ctx, input)
-		if err != nil {
-			log.Printf("matchanalysis: post-autopilot refresh, user %d job %d: %v", userID, job.ID, err)
-			return
-		}
-		if analysis == nil {
-			return // LLM unconfigured — nothing to cache
-		}
-		h.cacheAnalysis(ctx, userID, job, cvUploadedAt, language, analysis)
+// refresh UNCONDITIONALLY recomputes the chain and overwrites the (user, job) cache, even
+// when nothing was cached or an analysis was already there. This is what repeals the
+// fit-analysis-post-autopilot-verify design's predecessor rule that the fit analysis is a
+// frozen snapshot of the base profile.
+func (a *autopilotAnalysis) refresh(ctx context.Context) {
+	if a == nil {
+		return
 	}
+	a.compute(ctx, "post-autopilot refresh")
+}
+
+// compute runs the chain and caches what it produced, reporting whether the cache is left
+// holding this call's own result — which is what a coalescing follower waits to learn.
+func (a *autopilotAnalysis) compute(ctx context.Context, stage string) bool {
+	analysis, err := a.analyzer.Analyze(ctx, a.input)
+	if err != nil {
+		log.Printf("matchanalysis: %s, user %d job %d: %v", stage, a.userID, a.job.ID, err)
+		return false
+	}
+	if analysis == nil {
+		return false // LLM unconfigured — nothing to cache
+	}
+	a.h.cacheAnalysis(ctx, a.userID, a.job, a.cvUploadedAt, a.language, analysis)
+	return true
 }
 
 // creditsBalance reports the caller's current points, or nil on a DB error (logged).

--- a/internal/handler/match_analysis_coordinator_integration_test.go
+++ b/internal/handler/match_analysis_coordinator_integration_test.go
@@ -127,11 +127,13 @@ func newCoordinatorHandlers(pool *pgxpool.Pool, queries *db.Queries, store *resu
 }
 
 // registerEnsureRoute mounts a test-only route standing in for the cold-start autopilot's
-// invisible pre-run: it calls the exact same unexported method PostAssistantAutopilot calls,
-// against the same matchHandlers and (user, job) a stream request in the same test races.
+// invisible pre-run: it prepares and fills exactly as PostAssistantAutopilot does, against the
+// same matchHandlers and (user, job) a stream request in the same test races. The real caller
+// runs the fill from its SSE writer on a plain context; a request context stands in for that
+// here, since what these tests exercise is the coalescing, not where the fill is called from.
 func registerEnsureRoute(app *fiber.App, h *matchHandlers, userID int64, job db.Job) {
 	app.Post("/test/ensure", func(c *fiber.Ctx) error {
-		h.ensureCachedAnalysis(c, userID, job)
+		h.prepareAutopilotRun(c, userID, job).ensure(c.Context())
 		return c.SendStatus(fiber.StatusOK)
 	})
 }


### PR DESCRIPTION
## What broke

`POST /api/v1/assistant/sessions/:id/autopilot` returned 504 to the browser — "could not start the run" — on vacancies with no cached fit analysis. Five occurrences on 2026-08-21, every one of them at exactly 60.000s in the nginx log, while the Go handler went on to finish the same request in 2m6s and answer 200.

The pre-run (`ensureCachedAnalysis` → the three-stage fit chain) ran in the handler, ahead of `streamSSE`. Until `SetBodyStreamWriter` starts, nothing is on the wire, and nginx counts silence, not work.

```
22:11:50  POST .../autopilot            <- request in
22:13:20  llm: stream dur=1m29.893s
22:13:53  llm: stream dur=33.251s
22:13:57  llm: stream dur=4.25s
22:13:57  matchanalysis DONE dur=2m7.46s
22:13:57  200 | 2m6.658s | POST .../autopilot
          ^ nginx had already answered 504 at 22:12:51
```

## The fix

- The fill, the surface alignment and the run plan move **inside** the stream, in the order they had (analysis first — the run plan is written from it, and `cv_context` reads it on the run's first step).
- Both halves of the analysis become one `autopilotAnalysis`, assembled while the fiber ctx is valid, since neither half runs in the request any more. This also retires the duplicate profile/blockers/bank reads a cold cache used to cost — the old comment called that an accepted cost of keeping two paths separate; there is now one path.
- Every assistant turn writes one SSE comment as it opens. Opening the stream alone was not enough: the first heartbeat is 15s away, and the test proved the socket stayed empty until then.

## Tests

`TestAutopilotAnswersBeforeTheColdStartAnalysis` holds the fit model mid-chain and reads the raw socket: the response line must be readable while the analysis is provably still running. Verified red against the old ordering (times out with an empty socket), green with the fix.

`go test -tags=integration ./internal/handler/` green (68s).

## Ops half

freehire-ops#58 gives the turn endpoints the `proxy_read_timeout 300s` + `proxy_buffering off` treatment `/api/v1/jobs/*/fit/stream` already has — already applied on host2. Either fix alone leaves the other's failure reachable: without the app fix a slow chain still outlasts any timeout; without the nginx fix a turn that goes quiet longer than 60s still gets cut.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Autopilot streams now open immediately, before background analysis completes.
  * Analysis preparation and run planning continue while the stream remains active.
  * Match analysis is refreshed after an autopilot run for more current results.
* **Bug Fixes**
  * Improved handling of cold-start analysis and concurrent requests.
  * Prevented empty vacancy descriptions from appearing in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->