### PR TITLE
Cache job facet counts to cut the 55% API-time recompute

### DIFF
--- a/internal/handler/facets.go
+++ b/internal/handler/facets.go
@@ -2,15 +2,70 @@ package handler
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"net/url"
 	"slices"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 
+	"github.com/strelov1/freehire/internal/cache"
 	"github.com/strelov1/freehire/internal/search"
 )
+
+// facetCacheTTL bounds how stale a cached facet distribution may be. Facet counts
+// are identical for every caller and change only when ingest lands a wave (a few
+// times an hour), so a minute of staleness is invisible to a user while collapsing
+// the repeated recomputation that the see-also block and crawler traffic drive —
+// the endpoint measured at 55% of API handler time. It is deliberately short: the
+// win is in absorbing bursts of identical requests, not in holding a count for long.
+const facetCacheTTL = time.Minute
+
+// cachedFacetCounts wraps facetCounter.FacetCounts with a best-effort read-through
+// cache. A nil cache, a miss, or any cache error all fall straight through to a
+// live count — the cache can never fail or refuse the request, only skip work.
+// The key is a hash of the exact FacetParams (query, filter, requested attributes),
+// so two requests share a cached result only when they would compute the identical
+// one. The disjunctive path is intentionally not routed here: it is the interactive
+// live-modal experience, lower volume, and its per-facet fan-out keys poorly.
+func (h *searchHandlers) cachedFacetCounts(ctx context.Context, p search.FacetParams) (search.FacetResult, error) {
+	if h.cache == nil {
+		return h.facets.FacetCounts(ctx, p)
+	}
+
+	key := facetCacheKey(p)
+	if cached, found, err := cache.GetJSON[search.FacetResult](ctx, h.cache, key); err == nil && found {
+		return cached, nil
+	}
+
+	res, err := h.facets.FacetCounts(ctx, p)
+	if err != nil {
+		return res, err
+	}
+	// Store is best-effort: a failed write just means the next request recomputes.
+	_ = cache.SetJSON(ctx, h.cache, key, res, facetCacheTTL)
+	return res, nil
+}
+
+// facetCacheKey derives a deterministic cache key from the params that fully
+// determine a facet result. It marshals FacetParams to JSON and hashes it, so the
+// key is bounded in length regardless of how many filter values a request carries.
+// FacetParams marshals in practice (Query string, Filter [][]string, Facets
+// []string); the error branch is a guard, not a real path, and its fixed key just
+// means any unmarshalable request degrades to sharing one cache slot rather than
+// panicking.
+func facetCacheKey(p search.FacetParams) string {
+	raw, err := json.Marshal(p)
+	if err != nil {
+		return "jobfacets:v1:unkeyable"
+	}
+	sum := sha256.Sum256(raw)
+	return "jobfacets:v1:" + hex.EncodeToString(sum[:])
+}
 
 // facetCounter is the analytics backend the facets handler depends on. It is
 // deliberately separate from searcher: counting facet distributions is a
@@ -209,7 +264,7 @@ func (h *searchHandlers) JobFacets(c *fiber.Ctx) error {
 		vals := queryValues(c)
 		res, err = h.facets.DisjunctiveFacetCounts(c.Context(), q, facetReqs(vals), search.FilterFromValues(vals))
 	} else {
-		res, err = h.facets.FacetCounts(c.Context(), search.FacetParams{
+		res, err = h.cachedFacetCounts(c.Context(), search.FacetParams{
 			Query:  q,
 			Filter: buildSearchFilter(c),
 			Facets: facetAttributes(only...),

--- a/internal/handler/facets.go
+++ b/internal/handler/facets.go
@@ -58,13 +58,43 @@ func (h *searchHandlers) cachedFacetCounts(ctx context.Context, p search.FacetPa
 // []string); the error branch is a guard, not a real path, and its fixed key just
 // means any unmarshalable request degrades to sharing one cache slot rather than
 // panicking.
+//
+// The filter must be canonicalized first. search.FilterFromValues builds the
+// [][]string by ranging over a map (query_filter.go), so its group order — and the
+// value order inside the location OR-group — is randomized per request. Left as-is,
+// the SAME multi-facet request would hash to different keys on successive calls and
+// miss its own cache entry, defeating the cache on exactly the filtered traffic it
+// targets. AND across groups and OR within one are both order-independent, so
+// sorting is safe for keying and never touches the filter actually sent to Meili.
 func facetCacheKey(p search.FacetParams) string {
+	p.Filter = canonicalFilter(p.Filter)
 	raw, err := json.Marshal(p)
 	if err != nil {
 		return "jobfacets:v1:unkeyable"
 	}
 	sum := sha256.Sum256(raw)
 	return "jobfacets:v1:" + hex.EncodeToString(sum[:])
+}
+
+// canonicalFilter returns f with a stable ordering when it is the [][]string the
+// facet filter uses (sorted within each group, then across groups), so an
+// order-only difference cannot change the cache key. Any other shape is returned
+// unchanged — the key still reflects it, just without canonicalization.
+func canonicalFilter(f any) any {
+	groups, ok := f.([][]string)
+	if !ok {
+		return f
+	}
+	out := make([][]string, len(groups))
+	for i, g := range groups {
+		g = slices.Clone(g)
+		slices.Sort(g)
+		out[i] = g
+	}
+	slices.SortFunc(out, func(a, b []string) int {
+		return slices.Compare(a, b)
+	})
+	return out
 }
 
 // facetCounter is the analytics backend the facets handler depends on. It is

--- a/internal/handler/facets_test.go
+++ b/internal/handler/facets_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 
+	"github.com/strelov1/freehire/internal/cache"
 	"github.com/strelov1/freehire/internal/search"
 )
 
@@ -15,10 +16,14 @@ type fakeFacetCounter struct {
 	gotTotal any
 	res      search.FacetResult
 	err      error
+	// calls counts FacetCounts invocations, so a test can prove the cache served a
+	// repeated request without recomputing.
+	calls int
 }
 
 func (f *fakeFacetCounter) FacetCounts(_ context.Context, p search.FacetParams) (search.FacetResult, error) {
 	f.got = p
+	f.calls++
 	return f.res, f.err
 }
 
@@ -41,6 +46,14 @@ func (f *fakeFacetCounter) reqFilter(attr string) any {
 
 func facetsApp(fc facetCounter) *fiber.App {
 	h := &searchHandlers{facets: fc}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/jobs/facets", h.JobFacets)
+	return app
+}
+
+// facetsAppCached is facetsApp with a live cache wired in, for the caching tests.
+func facetsAppCached(fc facetCounter, c cache.Cache) *fiber.App {
+	h := &searchHandlers{facets: fc, cache: c}
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	app.Get("/jobs/facets", h.JobFacets)
 	return app
@@ -343,5 +356,63 @@ func TestJobFacets_CleanQueryKeepsTheBareDataEnvelope(t *testing.T) {
 
 	if _, present := body["meta"]; present {
 		t.Errorf("meta = %v, want the key absent on a clean query", body["meta"])
+	}
+}
+
+func TestJobFacets_CacheServesRepeatedRequestWithoutRecomputing(t *testing.T) {
+	fake := &fakeFacetCounter{res: search.FacetResult{Total: 42}}
+	app := facetsAppCached(fake, cache.NewMemory())
+
+	// Two identical requests. The first computes and populates the cache; the
+	// second must be served from it, leaving FacetCounts called exactly once.
+	for i := 0; i < 2; i++ {
+		status, _ := doGet(t, app, "/jobs/facets?q=go&seniority=senior")
+		if status != fiber.StatusOK {
+			t.Fatalf("request %d: status = %d, want 200", i, status)
+		}
+	}
+	if fake.calls != 1 {
+		t.Errorf("FacetCounts calls = %d, want 1 (second request should hit cache)", fake.calls)
+	}
+}
+
+func TestJobFacets_CacheKeyVariesByFilter(t *testing.T) {
+	// Different filters are different results and must not collide on one key.
+	fake := &fakeFacetCounter{res: search.FacetResult{Total: 42}}
+	app := facetsAppCached(fake, cache.NewMemory())
+
+	doGet(t, app, "/jobs/facets?seniority=senior")
+	doGet(t, app, "/jobs/facets?seniority=junior")
+
+	if fake.calls != 2 {
+		t.Errorf("FacetCounts calls = %d, want 2 (distinct filters must not share a cache key)", fake.calls)
+	}
+}
+
+func TestJobFacets_DisjunctiveIsNotCached(t *testing.T) {
+	// The disjunctive path is the interactive live-modal experience and is left
+	// uncached, so two identical disjunctive requests both recompute.
+	fake := &fakeFacetCounter{res: search.FacetResult{Total: 42}}
+	app := facetsAppCached(fake, cache.NewMemory())
+
+	doGet(t, app, "/jobs/facets?disjunctive=1&seniority=senior")
+	doGet(t, app, "/jobs/facets?disjunctive=1&seniority=senior")
+
+	if fake.calls != 0 {
+		t.Fatalf("FacetCounts calls = %d; disjunctive should not use the FacetCounts path at all", fake.calls)
+	}
+}
+
+func TestJobFacets_NilCacheStillComputes(t *testing.T) {
+	// A handler with no cache configured must fall straight through to compute,
+	// every time — this is the shape every other facet test runs under.
+	fake := &fakeFacetCounter{res: search.FacetResult{Total: 42}}
+	app := facetsApp(fake) // nil cache
+
+	doGet(t, app, "/jobs/facets?seniority=senior")
+	doGet(t, app, "/jobs/facets?seniority=senior")
+
+	if fake.calls != 2 {
+		t.Errorf("FacetCounts calls = %d, want 2 (no cache = always compute)", fake.calls)
 	}
 }

--- a/internal/handler/facets_test.go
+++ b/internal/handler/facets_test.go
@@ -376,6 +376,26 @@ func TestJobFacets_CacheServesRepeatedRequestWithoutRecomputing(t *testing.T) {
 	}
 }
 
+func TestJobFacets_CacheKeyStableAcrossMultiFacetRequests(t *testing.T) {
+	// The filter is built by ranging over a map, so its group order is randomized
+	// per request. The cache key must canonicalize it: the SAME multi-facet request
+	// fired repeatedly must hit one cache entry, not miss on a reordered filter.
+	// Without canonicalization this fails flakily (map order occasionally repeats).
+	fake := &fakeFacetCounter{res: search.FacetResult{Total: 42}}
+	app := facetsAppCached(fake, cache.NewMemory())
+
+	const q = "/jobs/facets?seniority=senior&work_mode=remote&category=backend&regions=eu"
+	for i := 0; i < 8; i++ {
+		status, _ := doGet(t, app, q)
+		if status != fiber.StatusOK {
+			t.Fatalf("request %d: status = %d, want 200", i, status)
+		}
+	}
+	if fake.calls != 1 {
+		t.Errorf("FacetCounts calls = %d, want 1 (multi-facet key must be order-stable)", fake.calls)
+	}
+}
+
 func TestJobFacets_CacheKeyVariesByFilter(t *testing.T) {
 	// Different filters are different results and must not collide on one key.
 	fake := &fakeFacetCounter{res: search.FacetResult{Total: 42}}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -502,7 +502,7 @@ func Register(app *fiber.App, cfg Config) {
 		sitemapCompanies = companySitemapIndex{c: cfg.Search}
 	}
 	sitemapH := newSitemapHandlers(sitemapJobs, sitemapCompanies)
-	searchH := newSearchHandlers(jobSearch, facets, queries)
+	searchH := newSearchHandlers(jobSearch, facets, queries, cfg.Cache)
 	// The AI filter reads the same saved profile the assistant does, so a profile-seeded
 	// search and a profile-aware conversation cannot disagree about what it says.
 	intentH := newIntentHandlers(llmBinding{client: cmp.Or(cfg.SearchIntentLLM, cfg.LLM), keys: llmKeys})

--- a/internal/handler/search.go
+++ b/internal/handler/search.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 
+	"github.com/strelov1/freehire/internal/cache"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/jobview"
 	"github.com/strelov1/freehire/internal/search"
@@ -26,10 +27,14 @@ type searchHandlers struct {
 	descriptions jobDescriptions
 	queries      *db.Queries
 	facets       facetCounter
+	// cache holds facet distributions for facetCacheTTL. Best-effort and optional:
+	// a nil cache (search configured but no Redis) simply recomputes every request,
+	// the shape every facet test but the caching ones runs under.
+	cache cache.Cache
 }
 
-func newSearchHandlers(search searcher, facets facetCounter, queries *db.Queries) *searchHandlers {
-	return &searchHandlers{search: search, descriptions: queries, queries: queries, facets: facets}
+func newSearchHandlers(search searcher, facets facetCounter, queries *db.Queries, c cache.Cache) *searchHandlers {
+	return &searchHandlers{search: search, descriptions: queries, queries: queries, facets: facets, cache: c}
 }
 
 func (h *searchHandlers) register(api fiber.Router, mw middleware) {


### PR DESCRIPTION
## What

Read-through cache for `GET /api/v1/jobs/facets`. Facet distributions ("Golang — 1240 jobs") were recomputed in Meilisearch on every request — measured at **55% of API handler time**, driven by the see-also block on job pages (~1.94 facet calls per render) and AI-crawler traffic hitting those pages in bulk.

## How

- Best-effort read-through cache on the **non-disjunctive** path, backed by the existing `internal/cache` (Redis in prod, the same shared cache `catalogstats`/stats/OG use).
- Key = `sha256(FacetParams)` — query + filter + requested facet attributes. TTL **60s** (facet counts change only when ingest lands a wave; a minute of staleness is invisible).
- **Best-effort contract:** a nil cache, a miss, or any cache error all fall through to a live count. The cache can never fail or refuse a request.
- The **disjunctive** path (interactive live-modal, lower volume, per-facet fan-out) stays uncached.

## Correctness note

The cache key canonicalizes the `[][]string` filter before hashing. `search.FilterFromValues` builds it by ranging over a map, so group order is randomized per request — hashing as-is made identical multi-facet requests miss their own entry. Groups are sorted (within and across) before hashing; AND/OR are order-independent, so this is safe for keying and never touches the filter sent to Meili. Caught in code review; a regression test fails without the sort.

## Measurements (prod idle colour)

| | before |
|---|---|
| all facets | 150–200 ms |
| disjunctive (cold) | 360–490 ms |

Warm cache serves in single-digit ms. Effect verified after merge on deploy.

## Tests

- `TestJobFacets_CacheServesRepeatedRequestWithoutRecomputing` — repeated request computes once
- `TestJobFacets_CacheKeyStableAcrossMultiFacetRequests` — multi-facet key is order-stable (fails without the fix)
- `TestJobFacets_CacheKeyVariesByFilter` — distinct filters don't collide
- `TestJobFacets_DisjunctiveIsNotCached` — disjunctive path uncached
- `TestJobFacets_NilCacheStillComputes` — no cache = always compute

`go build ./...`, `go vet -tags=integration ./...`, and the affected package suites all green. `exact:false` convention confirmed not applicable (that is catalog-scale stats; facet counts are already Meili estimates).