### PR TITLE
Say the autopilot's new name everywhere the old one was written

### DIFF
--- a/internal/handler/assistant.go
+++ b/internal/handler/assistant.go
@@ -634,12 +634,12 @@ func (h *assistantHandlers) streamSSE(
 		defer cancel()
 
 		// One byte immediately, before anything this turn might wait on. Until something is
-		// written, fasthttp is holding the response line and the headers in its buffer, so
-		// "the stream is open" is true here and not yet true on the wire — and a proxy times
-		// out a request whose upstream has sent nothing, however busy that upstream is. The
-		// heartbeat below cannot cover this: its first comment is a whole interval away.
-		// A comment rather than an event because EventSource ignores it: this says nothing to
-		// the client, it only makes the connection real.
+		// written, fasthttp holds the response line and the headers in its buffer, so "the
+		// stream is open" is true here and not yet true on the wire — and a proxy times out
+		// an upstream that has sent nothing, however busy it is. The heartbeat below cannot
+		// cover this: its first comment is a whole interval away. A comment rather than an
+		// event because EventSource ignores it — this says nothing to the client, it only
+		// makes the connection real.
 		stream.comment("open")
 
 		// The heartbeat starts BEFORE the queue wait, not after it: a queued message can wait
@@ -843,8 +843,9 @@ func (h *assistantHandlers) PostAssistantAutopilot(c *fiber.Ctx) error {
 	}
 	// One read of the vacancy for the whole pre-run: the fit analysis and the surface
 	// alignment both need it, and a run must not ask the database twice for the same row.
-	// This read stays in the request — it is one row, and the pre-run has nothing to prepare
-	// without it.
+	// It stays in the request because the pre-run has nothing to prepare without it; an
+	// unreadable vacancy leaves a nil analysis and an empty description, both of which the
+	// steps below already treat as nothing to do.
 	var analysis *autopilotAnalysis
 	var jobDescription string
 	if job, err := h.queries.GetJob(c.Context(), *sess.JobID); err != nil {
@@ -853,21 +854,14 @@ func (h *assistantHandlers) PostAssistantAutopilot(c *fiber.Ctx) error {
 		analysis, jobDescription = h.prepareAutopilotAnalysis(c, sess, job), job.Description
 	}
 	return h.streamSSE(c, sess, func(ctx context.Context, runner *assistant.Runner, reg *assistant.Registry, system string, emit func(assistant.Event)) error {
-		// The pre-run happens HERE, inside the stream, and not in the handler above it. On a
-		// vacancy with no cached fit analysis it runs the three-stage chain — minutes, not
-		// seconds — and a handler that has not returned has written no byte, so a proxy in
-		// front of us times the request out and the candidate is told the run failed to
-		// start. From here the response is already open and its heartbeat already ticking,
-		// so the same wait costs nothing but the wait.
-		//
-		// Order is the order it had: the analysis first, because the run plan is written from
-		// it, and cv_context reads it on the run's first step.
+		// The pre-run happens HERE rather than in the handler above, because a handler that
+		// has not returned has written no byte and a cold-start chain takes minutes — see
+		// autopilotAnalysis for what that cost. Order is the order it had: the analysis
+		// first, because the run plan is written from it and cv_context reads it on the run's
+		// first step. Surface alignment gets its own system revision — not the run's edit
+		// batch — so undoing the run leaves the vacancy's wording in place.
 		analysis.ensure(ctx)
-		if jobDescription != "" {
-			// Its own system revision — not the run's edit batch — so undoing the run leaves
-			// the vacancy's wording in place.
-			h.cv.logSurfaceAlign(ctx, sess.UserID, *sess.CVID, jobDescription)
-		}
+		h.cv.logSurfaceAlign(ctx, sess.UserID, *sess.CVID, jobDescription)
 		h.layDownRunPlan(ctx, sess)
 
 		err := runner.Run(ctx, sess, reg, system, autopilotBrief, assistant.TurnConfig{MaxSteps: autopilotMaxSteps}, emit)

--- a/internal/handler/assistant_autopilot_integration_test.go
+++ b/internal/handler/assistant_autopilot_integration_test.go
@@ -35,6 +35,54 @@ import (
 	"github.com/strelov1/freehire/internal/resume"
 )
 
+// newAutopilotHarness wires the handlers, the app and the routes an autopilot test needs.
+// Every test here wants the same assembly — the CV tools, the editor, the experience bank and
+// a match surface — and differs only in the two models: the one that answers the turn and the
+// one that answers the fit chain.
+func newAutopilotHarness(t *testing.T, pool *pgxpool.Pool, iss *auth.Issuer, turnM assistant.Model, fitM llms.Model) (*assistantHandlers, *fiber.App) {
+	t.Helper()
+	queries := db.New(pool)
+	bank := experience.NewStore(experience.NewQueriesRepository(queries))
+	h := &assistantHandlers{
+		store: assistant.NewStore(queries), queries: queries,
+		maxPrompt:  defaultAssistantMaxPrompt,
+		stages:     queries,
+		experience: bank,
+		cv: &cvHandlers{
+			cvStore:            cv.NewStore(cv.NewQueriesRepository(queries)),
+			editor:             cvedit.NewEditor(cvedit.NewRepository(pool, queries), bankGate{bank: bank}),
+			queries:            queries,
+			jobReader:          queries,
+			matchAnalysisCache: queries,
+			match: fitAPI(pool, queries, iss, resume.New(nil, resume.NewQueriesRepository(queries)),
+				matchanalysis.NewAnalyzer(llm.NewWithModel(fitM))),
+		},
+	}
+	h.runner = assistant.NewRunner(turnM, h.store, assistant.RunnerConfig{MaxSteps: 3})
+
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	api := app.Group("/api/v1")
+	mw := middleware{
+		cookie: auth.RequireAuth(iss, testVersions),
+		key:    auth.RequireAuthOrKey(iss, testVersions, apiKeys{queries}),
+	}
+	h.register(api, mw)
+	h.cv.register(api, mw)
+	return h, app
+}
+
+// walkedTheRequirements is the turn model an autopilot test uses when the run itself is not
+// what it is checking: one answer, no tool calls.
+func walkedTheRequirements() *turnModel {
+	return &turnModel{replies: []*llms.ContentChoice{{Content: "Walked the requirements."}}}
+}
+
+// fullFitChain is a fit model that answers all three stages, cycling so one model can serve
+// more than one analysis.
+func fullFitChain() *fitModel {
+	return &fitModel{resp: []string{fitStage1, fitStage2, fitStage3}}
+}
+
 // seedTailoringSession creates a CV bound to a vacancy plus the tailoring session that
 // addresses it, and returns the session id and the CV id.
 func seedTailoringSession(t *testing.T, pool *pgxpool.Pool, h *assistantHandlers, userID int64) (string, uuid.UUID) {
@@ -141,34 +189,8 @@ func TestAutopilotComputesAnalysisWhenMissing(t *testing.T) {
 	pool := startPostgres(t)
 	queries := db.New(pool)
 	iss := auth.NewIssuer("test-secret", time.Hour)
-	turnM := &turnModel{replies: []*llms.ContentChoice{{Content: "Walked the requirements."}}}
-	fitM := &fitModel{resp: []string{fitStage1, fitStage2, fitStage3}}
-	an := matchanalysis.NewAnalyzer(llm.NewWithModel(fitM))
-
-	bank := experience.NewStore(experience.NewQueriesRepository(queries))
-	h := &assistantHandlers{
-		store: assistant.NewStore(queries), queries: queries,
-		maxPrompt:  defaultAssistantMaxPrompt,
-		stages:     queries,
-		experience: bank,
-		cv: &cvHandlers{
-			cvStore:            cv.NewStore(cv.NewQueriesRepository(queries)),
-			editor:             cvedit.NewEditor(cvedit.NewRepository(pool, queries), bankGate{bank: bank}),
-			queries:            queries,
-			jobReader:          queries,
-			matchAnalysisCache: queries,
-			match:              fitAPI(pool, queries, iss, resume.New(nil, resume.NewQueriesRepository(queries)), an),
-		},
-	}
-	h.runner = assistant.NewRunner(turnM, h.store, assistant.RunnerConfig{MaxSteps: 3})
-	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
-	api := app.Group("/api/v1")
-	mw := middleware{
-		cookie: auth.RequireAuth(iss, testVersions),
-		key:    auth.RequireAuthOrKey(iss, testVersions, apiKeys{queries}),
-	}
-	h.register(api, mw)
-	h.cv.register(api, mw)
+	fitM := fullFitChain()
+	h, app := newAutopilotHarness(t, pool, iss, walkedTheRequirements(), fitM)
 
 	userID, cookie := assistantUser(t, pool, iss, "autopilot-analysis@example.test", true)
 	// The fit chain refuses to analyze a candidate with an empty bank (there is nothing to
@@ -248,34 +270,8 @@ func TestAutopilotAnswersBeforeTheColdStartAnalysis(t *testing.T) {
 	pool := startPostgres(t)
 	queries := db.New(pool)
 	iss := auth.NewIssuer("test-secret", time.Hour)
-	turnM := &turnModel{replies: []*llms.ContentChoice{{Content: "Walked the requirements."}}}
 	fitM := newGatedFitModel(t)
-	an := matchanalysis.NewAnalyzer(llm.NewWithModel(fitM))
-
-	bank := experience.NewStore(experience.NewQueriesRepository(queries))
-	h := &assistantHandlers{
-		store: assistant.NewStore(queries), queries: queries,
-		maxPrompt:  defaultAssistantMaxPrompt,
-		stages:     queries,
-		experience: bank,
-		cv: &cvHandlers{
-			cvStore:            cv.NewStore(cv.NewQueriesRepository(queries)),
-			editor:             cvedit.NewEditor(cvedit.NewRepository(pool, queries), bankGate{bank: bank}),
-			queries:            queries,
-			jobReader:          queries,
-			matchAnalysisCache: queries,
-			match:              fitAPI(pool, queries, iss, resume.New(nil, resume.NewQueriesRepository(queries)), an),
-		},
-	}
-	h.runner = assistant.NewRunner(turnM, h.store, assistant.RunnerConfig{MaxSteps: 3})
-	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
-	api := app.Group("/api/v1")
-	mw := middleware{
-		cookie: auth.RequireAuth(iss, testVersions),
-		key:    auth.RequireAuthOrKey(iss, testVersions, apiKeys{queries}),
-	}
-	h.register(api, mw)
-	h.cv.register(api, mw)
+	h, app := newAutopilotHarness(t, pool, iss, walkedTheRequirements(), fitM)
 
 	userID, cookie := assistantUser(t, pool, iss, "autopilot-ttfb@example.test", true)
 	seedBankedCareer(t, queries, userID)
@@ -313,34 +309,8 @@ func TestAutopilotRefreshesAnalysisAfterEveryRun(t *testing.T) {
 	pool := startPostgres(t)
 	queries := db.New(pool)
 	iss := auth.NewIssuer("test-secret", time.Hour)
-	turnM := &turnModel{replies: []*llms.ContentChoice{{Content: "Walked the requirements."}}}
-	fitM := &fitModel{resp: []string{fitStage1, fitStage2, fitStage3}}
-	an := matchanalysis.NewAnalyzer(llm.NewWithModel(fitM))
-
-	bank := experience.NewStore(experience.NewQueriesRepository(queries))
-	h := &assistantHandlers{
-		store: assistant.NewStore(queries), queries: queries,
-		maxPrompt:  defaultAssistantMaxPrompt,
-		stages:     queries,
-		experience: bank,
-		cv: &cvHandlers{
-			cvStore:            cv.NewStore(cv.NewQueriesRepository(queries)),
-			editor:             cvedit.NewEditor(cvedit.NewRepository(pool, queries), bankGate{bank: bank}),
-			queries:            queries,
-			jobReader:          queries,
-			matchAnalysisCache: queries,
-			match:              fitAPI(pool, queries, iss, resume.New(nil, resume.NewQueriesRepository(queries)), an),
-		},
-	}
-	h.runner = assistant.NewRunner(turnM, h.store, assistant.RunnerConfig{MaxSteps: 3})
-	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
-	api := app.Group("/api/v1")
-	mw := middleware{
-		cookie: auth.RequireAuth(iss, testVersions),
-		key:    auth.RequireAuthOrKey(iss, testVersions, apiKeys{queries}),
-	}
-	h.register(api, mw)
-	h.cv.register(api, mw)
+	fitM := fullFitChain()
+	h, app := newAutopilotHarness(t, pool, iss, walkedTheRequirements(), fitM)
 
 	userID, cookie := assistantUser(t, pool, iss, "autopilot-refresh@example.test", true)
 	seedBankedCareer(t, queries, userID)
@@ -421,33 +391,8 @@ func TestAutopilotRefreshSurvivesACancelledRun(t *testing.T) {
 	queries := db.New(pool)
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	turnM := newDisconnectModel(t)
-	fitM := &fitModel{resp: []string{fitStage1, fitStage2, fitStage3}}
-	an := matchanalysis.NewAnalyzer(llm.NewWithModel(fitM))
-
-	bank := experience.NewStore(experience.NewQueriesRepository(queries))
-	h := &assistantHandlers{
-		store: assistant.NewStore(queries), queries: queries,
-		maxPrompt:  defaultAssistantMaxPrompt,
-		stages:     queries,
-		experience: bank,
-		cv: &cvHandlers{
-			cvStore:            cv.NewStore(cv.NewQueriesRepository(queries)),
-			editor:             cvedit.NewEditor(cvedit.NewRepository(pool, queries), bankGate{bank: bank}),
-			queries:            queries,
-			jobReader:          queries,
-			matchAnalysisCache: queries,
-			match:              fitAPI(pool, queries, iss, resume.New(nil, resume.NewQueriesRepository(queries)), an),
-		},
-	}
-	h.runner = assistant.NewRunner(turnM, h.store, assistant.RunnerConfig{MaxSteps: 3})
-	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
-	api := app.Group("/api/v1")
-	mw := middleware{
-		cookie: auth.RequireAuth(iss, testVersions),
-		key:    auth.RequireAuthOrKey(iss, testVersions, apiKeys{queries}),
-	}
-	h.register(api, mw)
-	h.cv.register(api, mw)
+	fitM := fullFitChain()
+	h, app := newAutopilotHarness(t, pool, iss, turnM, fitM)
 
 	userID, cookie := assistantUser(t, pool, iss, "autopilot-cancel-refresh@example.test", true)
 	seedBankedCareer(t, queries, userID)

--- a/internal/handler/match_analysis.go
+++ b/internal/handler/match_analysis.go
@@ -53,7 +53,7 @@ type matchHandlers struct {
 	bank candidateProfiler
 	// coalesce ensures at most one fit-analysis compute runs at a time for a given (user, job)
 	// — see matchAnalysisCoordinator for why the cold-start autopilot's invisible pre-run and
-	// the workspace's visible stream can both reach ensureCachedAnalysis/StreamMatchAnalysis
+	// the workspace's visible stream can both reach autopilotAnalysis.ensure/StreamMatchAnalysis
 	// for the identical pair. Billing is decided per caller, not by who leads — see
 	// StreamMatchAnalysis's own comment.
 	coalesce matchAnalysisCoordinator
@@ -266,10 +266,9 @@ func (h *matchHandlers) buildAnalysisInput(c *fiber.Ctx, job db.Job, userID int6
 }
 
 // runAnalysis runs the three-stage fit chain under the caller's own attribution, over an
-// input built by buildAnalysisInput. Shared by the on-demand endpoint and the cold-start
-// autopilot's inline precondition (ensureCachedAnalysis) — both assemble the exact same
-// input the exact same way; only what happens to the RESULT (credits, response shape,
-// whether the caller even asked for one) differs between them.
+// input built by buildAnalysisInput, for a caller that has a live fiber ctx: the on-demand
+// endpoint. The autopilot's two halves run after the request and build that same input
+// through the same function, from plain values — see autopilotAnalysis.
 func (h *matchHandlers) runAnalysis(c *fiber.Ctx, userID int64, job db.Job, profile userprofile.Profile, blockers []hardconstraint.Blocker, language string) (*matchanalysis.Analysis, error) {
 	analyzer := h.matchAnalysis.As(h.llm.bind(c.Context(), userID, tagMatchAnalysis))
 	return analyzer.Analyze(c.Context(), h.buildAnalysisInput(c, job, userID, profile, blockers, language))
@@ -296,7 +295,6 @@ type autopilotAnalysis struct {
 	analyzer     *matchanalysis.Analyzer
 	input        matchanalysis.Input
 	cvUploadedAt *time.Time
-	language     string
 }
 
 // prepareAutopilotRun assembles the run's analysis while the fiber ctx is still valid. It
@@ -314,7 +312,6 @@ func (h *matchHandlers) prepareAutopilotRun(c *fiber.Ctx, userID int64, job db.J
 		analyzer:     h.matchAnalysis.As(h.llm.bind(c.Context(), userID, tagMatchAnalysis)),
 		input:        h.buildAnalysisInput(c, job, userID, profile, blockers, language),
 		cvUploadedAt: cvUploadedAt,
-		language:     language,
 	}
 }
 
@@ -381,7 +378,7 @@ func (a *autopilotAnalysis) compute(ctx context.Context, stage string) bool {
 	if analysis == nil {
 		return false // LLM unconfigured — nothing to cache
 	}
-	a.h.cacheAnalysis(ctx, a.userID, a.job, a.cvUploadedAt, a.language, analysis)
+	a.h.cacheAnalysis(ctx, a.userID, a.job, a.cvUploadedAt, a.input.Language, analysis)
 	return true
 }
 

--- a/internal/handler/match_analysis_coordinator.go
+++ b/internal/handler/match_analysis_coordinator.go
@@ -4,7 +4,7 @@ import "sync"
 
 // matchAnalysisCoordinator coalesces concurrent fit-analysis computes for the same (user, job)
 // pair across the two entry points that can each decide to run the three-stage LLM chain:
-// ensureCachedAnalysis (the cold-start autopilot's invisible pre-run, so cv_context has
+// autopilotAnalysis.ensure (the cold-start autopilot's invisible pre-run, so cv_context has
 // something to read) and StreamMatchAnalysis (the tailoring workspace's visible stepper,
 // started at the same cold start). Both can reach here for the identical pair within
 // milliseconds of each other; without coalescing that is two three-stage chains spent on one
@@ -22,7 +22,7 @@ import "sync"
 //
 // Billing is NOT decided here. Each caller that cares about AI credits (StreamMatchAnalysis)
 // gates and debits for itself, whether it ends up leading or following — see its own comment
-// on why that is safe to do independently without double-charging. ensureCachedAnalysis never
+// on why that is safe to do independently without double-charging. autopilotAnalysis.ensure never
 // touches credits at all, leader or follower, which is what keeps the cold-start pre-run free.
 //
 // Zero value is ready to use — the map is created lazily under the lock — so every existing
@@ -62,10 +62,10 @@ type analysisRun struct {
 // A concurrent caller for the same pair is a FOLLOWER (isLeader=false, done=nil): it gets back
 // the same *analysisRun the leader is working on, to wait on directly (<-run.done) and then
 // consult (run.succeeded). lead itself never blocks — a follower decides for itself where to
-// wait (StreamMatchAnalysis waits inside its own SSE body-writer, on the background context its
-// leader compute already runs under, rather than blocking the request that is about to open the
-// stream; ensureCachedAnalysis waits inline, exactly as it already blocked for a whole chain's
-// duration running its OWN compute before this existed).
+// wait, and both of today's callers wait from inside their own SSE body-writer rather than from
+// the request: StreamMatchAnalysis so the request that is about to open the stream is not
+// blocked, autopilotAnalysis.ensure because a wait of a whole chain's duration in the handler is
+// silence a proxy severs (see autopilotAnalysis).
 //
 // run.done carries no cancellation and lead takes no ctx: nothing that calls this today needs
 // the wait to be interruptible — see the two call sites' own comments.

--- a/internal/handler/match_analysis_coordinator_integration_test.go
+++ b/internal/handler/match_analysis_coordinator_integration_test.go
@@ -2,7 +2,7 @@
 
 // Integration tests for the real coalescing between the two entry points that can each decide
 // to run the three-stage fit chain for the same (user, job): the cold-start autopilot's
-// invisible ensureCachedAnalysis and the tailoring workspace's visible StreamMatchAnalysis.
+// invisible autopilotAnalysis.ensure and the tailoring workspace's visible StreamMatchAnalysis.
 // See match_analysis_coordinator.go and the tailor cold-start animation design.
 // Run with: go test -tags=integration ./internal/handler/
 package handler
@@ -114,7 +114,7 @@ func coordinatorJobSlug(prefix string, i int) string {
 
 // newCoordinatorHandlers builds the matchHandlers a coordinator test drives requests against —
 // model bound to a fresh Analyzer, everything else the fixed fixture StreamMatchAnalysis and
-// ensureCachedAnalysis both need.
+// autopilotAnalysis.ensure both need.
 func newCoordinatorHandlers(pool *pgxpool.Pool, queries *db.Queries, store *resume.Store, model llms.Model) *matchHandlers {
 	return &matchHandlers{
 		queries:            queries,
@@ -229,7 +229,7 @@ func TestMatchAnalysisCoordinatorEnsureCachedAnalysisLeadsStreamFollows(t *testi
 	select {
 	case <-model.started:
 	case <-time.After(2 * time.Second):
-		t.Fatal("ensureCachedAnalysis never started its compute")
+		t.Fatal("autopilotAnalysis.ensure never started its compute")
 	}
 
 	stream := startStream(t, app, "/api/v1/jobs/"+coordinatorJobSlug("a", 0)+"/fit/stream", token)
@@ -237,7 +237,7 @@ func TestMatchAnalysisCoordinatorEnsureCachedAnalysisLeadsStreamFollows(t *testi
 
 	close(model.release)
 
-	waitDone(t, ensure, 2*time.Second, "ensureCachedAnalysis never finished")
+	waitDone(t, ensure, 2*time.Second, "autopilotAnalysis.ensure never finished")
 	waitDone(t, stream, 2*time.Second, "the follower stream never finished")
 
 	if model.n != 3 {
@@ -275,7 +275,7 @@ func TestMatchAnalysisCoordinatorEnsureCachedAnalysisLeadsStreamFollows(t *testi
 		t.Errorf("cache rows = %d, want 1", rows)
 	}
 
-	// ensureCachedAnalysis (the leader here) never touches credits — but the stream (the
+	// autopilotAnalysis.ensure (the leader here) never touches credits — but the stream (the
 	// follower) is a genuinely paying request for a never-analysed job, and must still cost
 	// its own credit even though it didn't run the chain itself: h.debitMatch is idempotent
 	// per (user, feature, job), so this is one row, not zero (a free ride for a paying
@@ -285,13 +285,13 @@ func TestMatchAnalysisCoordinatorEnsureCachedAnalysisLeadsStreamFollows(t *testi
 		t.Fatalf("count match debits: %v", err)
 	}
 	if debits != 1 {
-		t.Errorf("match debits = %d, want 1 — the follower is a genuinely new paying request and must still be charged once, not given a free ride because ensureCachedAnalysis led", debits)
+		t.Errorf("match debits = %d, want 1 — the follower is a genuinely new paying request and must still be charged once, not given a free ride because autopilotAnalysis.ensure led", debits)
 	}
 }
 
 // TestMatchAnalysisCoordinatorStreamLeadsEnsureCachedAnalysisFollowsAndLeaderStillBills is the
 // mirror of the test above with roles reversed: the paying stream leads, the free
-// ensureCachedAnalysis pre-run follows. The leader must bill exactly as it would with no
+// autopilotAnalysis.ensure pre-run follows. The leader must bill exactly as it would with no
 // follower at all — an unmetered follower joining must never suppress a real charge (that
 // was the actual bug: a leader used to skip billing whenever ANY follower joined, which let a
 // second browser tab or a reload silently dodge the credit a new job's analysis costs).
@@ -326,12 +326,12 @@ func TestMatchAnalysisCoordinatorStreamLeadsEnsureCachedAnalysisFollowsAndLeader
 	}
 
 	ensure := startEnsure(t, app)
-	waitStillRunning(t, ensure, 200*time.Millisecond, "ensureCachedAnalysis (the follower) returned before the leader was released")
+	waitStillRunning(t, ensure, 200*time.Millisecond, "autopilotAnalysis.ensure (the follower) returned before the leader was released")
 
 	close(model.release)
 
 	waitDone(t, stream, 2*time.Second, "the leader stream never finished")
-	waitDone(t, ensure, 2*time.Second, "ensureCachedAnalysis never finished")
+	waitDone(t, ensure, 2*time.Second, "autopilotAnalysis.ensure never finished")
 
 	if model.n != 3 {
 		t.Errorf("fit model called %d times, want 3 (one chain, not two — no double spend)", model.n)
@@ -369,7 +369,7 @@ func TestMatchAnalysisCoordinatorStreamLeadsEnsureCachedAnalysisFollowsAndLeader
 // (followMatchAnalysis) — so a follower that won that race read an empty cache and degraded
 // straight to "analysis unavailable", even though the leader was about to succeed.
 //
-// ensureCachedAnalysis's own follower branch can't catch this (it never reads the cache — see
+// autopilotAnalysis.ensure's own follower branch can't catch this (it never reads the cache — see
 // the two tests above), so this drives TWO concurrent StreamMatchAnalysis calls instead: the
 // second becomes a follower via followMatchAnalysis, which does read the cache and is exactly
 // where the live bug surfaced. Repeated: the race window was narrow (a channel close vs. a

--- a/internal/handler/match_analysis_stream.go
+++ b/internal/handler/match_analysis_stream.go
@@ -31,7 +31,7 @@ import (
 //
 // Coalesced through h.coalesce: this is also what the tailoring workspace's cold start now
 // opens to animate the fit analysis, at the same moment the autopilot's own invisible
-// ensureCachedAnalysis may be racing for the identical (user, job). Whichever claims
+// autopilotAnalysis.ensure may be racing for the identical (user, job). Whichever claims
 // leadership runs the chain for real; the other becomes a follower and replays the result via
 // followMatchAnalysis instead of paying for a second chain.
 func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
@@ -53,7 +53,7 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 	// compute below — not just the leader. A follower still spends a real credit on a
 	// genuinely new job (two tabs open on the same never-analysed job is not a discount),
 	// and an out-of-credits caller must still 402 even when someone else is already
-	// computing the same analysis for free reasons (ensureCachedAnalysis never reaches this
+	// computing the same analysis for free reasons (autopilotAnalysis.ensure never reaches this
 	// gate at all — see prepareAutopilotRun). Debiting twice for one job is safe: h.debitMatch
 	// is idempotent per (user, feature, job) — see credits.Store.Debit's DebitExists check —
 	// so a leader and a follower that both decide "I owe one credit here" collapse into a
@@ -74,7 +74,7 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 	// Leadership for (user, job) is claimed after the gate above, not before: nothing here
 	// can fail, so there is no path where a caller becomes leader and then has to immediately
 	// hand leadership back. A follower (almost always the cold-start autopilot's own invisible
-	// ensureCachedAnalysis, racing for the same pair) runs neither the LLM nor the reads below
+	// autopilotAnalysis.ensure, racing for the same pair) runs neither the LLM nor the reads below
 	// — see matchAnalysisCoordinator and followMatchAnalysis.
 	var done func(bool)
 	var run *analysisRun
@@ -163,7 +163,7 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 
 		if !isLeader {
 			// Someone else — almost always the cold-start autopilot's own invisible
-			// ensureCachedAnalysis — already claimed this pair. Wait for it and replay its
+			// autopilotAnalysis.ensure — already claimed this pair. Wait for it and replay its
 			// result rather than running a second chain.
 			h.followMatchAnalysis(ctx, stream, run, userID, job, blockers, isNew)
 			return
@@ -213,7 +213,7 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 
 // followMatchAnalysis is the graceful degrade for the rare race a visible stream loses: some
 // concurrent caller for the same (user, job) — almost always the cold-start autopilot's own
-// invisible ensureCachedAnalysis — claimed the compute first. It waits on run.done, then
+// invisible autopilotAnalysis.ensure — claimed the compute first. It waits on run.done, then
 // replays whatever landed in the cache as one synthesized burst — stage_done for all three
 // stages (there is nothing to show progressing through) followed by final — so this reader's
 // stepper still resolves instead of hanging on "pending" forever.
@@ -228,7 +228,7 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 // client that leaves during the wait costs nothing extra. Never emits
 // stage_start/thinking/requirements/dimensions: those describe progress this caller never
 // watched. isNew is THIS caller's own credits gate result (see StreamMatchAnalysis) — debiting
-// here when the leader was the free ensureCachedAnalysis pre-run is exactly the case that must
+// here when the leader was the free autopilotAnalysis.ensure pre-run is exactly the case that must
 // still charge a genuinely new analysis; h.debitMatch's idempotency (by user, feature, job) is
 // what keeps two callers that both decide to debit from charging twice.
 func (h *matchHandlers) followMatchAnalysis(ctx context.Context, stream *sseStream, run *analysisRun, userID int64, job db.Job, blockers []hardconstraint.Blocker, isNew bool) {


### PR DESCRIPTION
A quality pass over #2186 — no behaviour moved, both suites green.

**The orphaned name.** That PR renamed `ensureCachedAnalysis` to `autopilotAnalysis.ensure` and left twenty comments and test messages naming the old one. Two of them had gone from stale to actively wrong:
- `matchAnalysisCoordinator.lead` still said the pre-run "waits inline" — it now waits from the SSE writer, which is the whole point of the change.
- `runAnalysis`'s doc still claimed the cold-start autopilot shares it. It doesn't; the autopilot builds its Input through `buildAnalysisInput` and runs the analyzer itself.

**Three simplifications.**
- `if jobDescription != ""` around `logSurfaceAlign` deleted: `commitSurfaceAlign` returns before any read when the vacancy names no recognised skills, and an empty description names none. The branch restated the callee.
- `autopilotAnalysis.language` deleted — it was a second copy of `input.Language`.
- `newAutopilotHarness` replaces four identical 28-line fixtures in the autopilot tests, which differed only in the turn model and the fit model. −132/+71 in that file.

Comment edits elsewhere are wording only.