### PR TITLE
Stop a slow round ending an unattended run

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -83,6 +83,21 @@ const (
 	// off the upload response path (background) so it can be generous, but still bounded so
 	// a stalled gateway cannot leak a goroutine indefinitely.
 	resumeExtractLLMTimeout = 120 * time.Second
+	// assistantLLMTimeout bounds ONE model call in an assistant turn. The shared default of
+	// 90s was measured, on 2026-08-21, to sit inside the working range rather than past it:
+	// over three days of tailoring turns the gateway's own spend log put p95 at 58s and the
+	// slowest SUCCESSFUL call at 83.1s, with the reasoning model taking up to 51.8s before
+	// its first token on a single call. A ceiling that close to the spread cuts work that
+	// was going to finish.
+	//
+	// And a cut call does not cost a step, it costs the run: Runner.Run surfaces a model
+	// error as a failed turn, so one slow round ends an unattended pass that had thirty. On
+	// 2026-08-21 that happened to three runs, each on its SECOND call — the first round of
+	// real work, where the model writes several thousand tokens off the fit analysis.
+	//
+	// 180s is twice the slowest observed success, and still well under the gateway's own
+	// limits (its nginx reads for 300s), so a genuinely hung call is still bounded here.
+	assistantLLMTimeout = 180 * time.Second
 )
 
 // API holds the cross-cutting dependencies every route shares: the DB pool, the
@@ -527,7 +542,10 @@ func Register(app *fiber.App, cfg Config) {
 	// hub, which a browsing session reads the caller's open page through.
 	assistantH := newAssistantHandlers(queries,
 		assistantModels{
-			Agent: cfg.AssistantLLM, Keys: llmKeys,
+			// Its own per-call timeout for the same reason the fit analysis has one, and
+			// nil-safe the same way: a turn's rounds are slower than a one-shot extraction,
+			// and here a call cut short takes the whole run with it.
+			Agent: cfg.AssistantLLM.WithTimeout(assistantLLMTimeout), Keys: llmKeys,
 			MaxSteps: cfg.AssistantMaxSteps, MaxPrompt: cfg.AssistantMaxPrompt,
 		},
 		assistantStore, searchH, resumeH, trackingH, cvH, profileH, a.browserTools, inboxH, bank, screeningAnswersSvc)


### PR DESCRIPTION
## What Sentry showed

One live backend issue over the last day: `llm: chat: error reading streaming response: context deadline exceeded`, three events. Their `url` tags name three assistant sessions — the same three that got a 504 from nginx the day before (#2186):

| session | nginx 504 | turn died |
|---|---|---|
| `51c2bd82` | 12:53:07 | 12:55:51 |
| `ccbfb5d5` | 21:05:55 | 21:13:35 |
| `b88a4db2` | 21:08:12 | 21:14:59 |

So the proxy fix was half the story. The runs kept going after the browser was cut off, and then failed on their own.

## Why

The gateway's spend log for `preset:tailor` calls, last three days:

| | |
|---|---|
| p50 | 15.3s |
| p95 | 58.1s |
| slowest success | 83.1s |
| slowest first-token | 51.8s |
| calls over 90s | 0 (they cannot be — that is where we cut) |

The ceiling was 90s. The distribution's tail is pressed right against it.

And the cost of hitting it is the whole run: `Runner.Run` returns the model error, which ends the turn. All three failures happened on the **second** call of the run — the first round of real work, where the model writes several thousand tokens off the fit analysis. Each run had 30 steps of budget and used one.

## The change

`assistantLLMTimeout = 180s`, applied to the agent client the way `matchAnalysisLLMTimeout` and `resumeExtractLLMTimeout` already are (`WithTimeout` is nil-safe). Twice the slowest observed success, still inside the gateway's own 300s nginx read.

## Deliberately not in this PR

Retrying a timed-out round inside the runner. It would double the wait on a genuinely hung gateway, and a round that streamed partial text before dying would replay that text to the client. The ceiling was the measured cause; if runs still die after this, retry is the next step with evidence behind it.

`go test ./...` and `go test -tags=integration ./internal/handler/` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a dedicated timeout for assistant responses, allowing up to 180 seconds for individual model calls.
  * Improved handling when timeout configuration is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->