### PR TITLE
Move the per-user gateway credential onto Bifrost, and turn audio off

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -233,14 +233,16 @@ func main() {
 	// account's model calls are spent under. Nil when unconfigured, and that is an
 	// ordinary deployment rather than a degraded one: every call then goes out on
 	// LLM_API_KEY exactly as it did before this existed. It is deliberately a separate
-	// endpoint and credential from inference — administration is served at the gateway
-	// root, and the key that mints keys has no business on a chat request.
+	// endpoint and credential from inference — administration is served under /api, and
+	// the administrator that mints keys has no business on a chat request.
 	llmKeys := llmkey.New(llmkey.Config{
-		BaseURL:      cfg.LLMAdminURL,
-		AdminKey:     cfg.LLMAdminKey,
-		MaxBudget:    cfg.LLMUserMaxBudget,
-		RPMLimit:     cfg.LLMUserRPMLimit,
-		BudgetWindow: cfg.LLMUserBudgetWindow,
+		BaseURL:       cfg.LLMAdminURL,
+		AdminUsername: cfg.LLMAdminUsername,
+		AdminPassword: cfg.LLMAdminPassword,
+		TemplateKey:   cfg.LLMAdminTemplateKey,
+		MaxBudget:     cfg.LLMUserMaxBudget,
+		RPMLimit:      cfg.LLMUserRPMLimit,
+		BudgetWindow:  cfg.LLMUserBudgetWindow,
 	})
 
 	// OAuth sign-in is optional: only providers with full credentials are

--- a/internal/ai/llmkey/AGENTS.md
+++ b/internal/ai/llmkey/AGENTS.md
@@ -17,16 +17,44 @@ lives in `internal/platform/llm` (`Client.As`); the one place per-user calls res
   owner; attributing its enrichment to whoever triggered a run would put a cost on someone
   who did not incur it. `scope_test.go` enforces this by parsing imports — a background
   entrypoint that reaches for this package fails the build's tests.
-- **Unconfigured is a normal deployment, not a degraded one.** No `LLM_ADMIN_URL` or no
-  `LLM_ADMIN_KEY` ⇒ `New` returns nil, nothing is minted, and every call goes out on
-  `LLM_API_KEY` exactly as it did before this existed. That is also the rollback.
+- **Unconfigured is a normal deployment, not a degraded one.** Any of `LLM_ADMIN_URL`,
+  `LLM_ADMIN_USERNAME`, `LLM_ADMIN_PASSWORD` or `LLM_ADMIN_TEMPLATE_KEY` unset ⇒ `New`
+  returns nil, nothing is minted, and every call goes out on `LLM_API_KEY` exactly as it
+  did before this existed. That is also the rollback. The template key counts as
+  configuration for a reason — see below; without it minting succeeds and the credentials
+  it produces are refused everything, which is a worse failure than not minting at all.
 
 ## The endpoints are not where you would guess
-Administration lives at the gateway **root**, inference under `/v1`: every call this
-client makes — `/key/generate`, `/key/block`, `/key/delete`, `/user/daily/activity` —
-is a root path on the ADMIN key. `LLM_ADMIN_URL` is therefore configured separately and
-never derived from `LLM_BASE_URL` — which also allows keeping the admin API off the
-public host.
+Administration lives under **`/api`**, inference under `/v1`. Every call this client makes
+— `POST /api/governance/virtual-keys`, `PUT` and `DELETE` on
+`/api/governance/virtual-keys/{id}`, and `GET /api/logs/stats` — authenticates as the
+ADMINISTRATOR over HTTP Basic, not with a bearer token. `LLM_ADMIN_URL` is therefore
+configured separately and never derived from `LLM_BASE_URL` — which also allows keeping
+the admin API off the public host.
+
+## A credential is two values, and both are load-bearing
+`Credential` carries a secret and an id. The secret is a bearer token and the only thing a
+model call needs; the id is opaque and the only thing block and delete accept — aimed at
+the secret they answer 404. Storing one without the other yields a credential that can
+spend but never be revoked, which is exactly what account deletion has to do. They are
+written and cleared in the same statement (`users.llm_key`, `users.llm_key_id`).
+
+Rows minted before migration 0119 hold a secret and no id. That is a real state, not a
+fault: they keep working for inference, and the first refusal sends them through the
+existing forget-and-re-mint path, which replaces them with a pair. Nothing backfills.
+
+## A key with no provider policy is a dead key
+This gateway denies every provider to a virtual key that carries no `provider_configs`, so
+minting without one produces credentials refused on their first call. `Mint` therefore
+reads the policy from the virtual key named by `LLM_ADMIN_TEMPLATE_KEY` and copies it.
+
+That indirection is the point. The alternative — carrying the provider list in this
+service's configuration — would put the provider vocabulary in two places and make adding
+a provider a deployment of freehire rather than an edit to the gateway's own config.
+
+One asymmetry to keep in mind when touching that copy: a read answers `key_ids` as null
+where a write requires `["*"]`, and echoing the null back mints a key pinned to no
+provider key at all.
 
 ## Three rules that are easy to get wrong
 
@@ -47,10 +75,12 @@ gateway refusing a user's credential on an inference call — is caught in `inte
 transport, which retries once on the fallback and calls `Resolver.Forget` to clear the
 row so the next call re-mints.
 
-**Block, do not delete, a credential that has been spent with.** The gateway's record of what
-a key spent hangs off that key, so deleting it takes the cost history along. `Revoke` (account
-deletion) blocks; `Delete` is reserved for a credential with nothing to preserve — the loser
-of a minting race, seconds old and never stored.
+**Block, do not delete, a credential that has been spent with.** This survives the gateway
+change but its reason has weakened: the usage log is keyed by the credential's id and
+outlives the credential, so deleting no longer erases the history the way it used to. What
+blocking still buys is legibility — a retired key stays in the gateway's listings. `Revoke`
+(account deletion) blocks; `Delete` is reserved for a credential with nothing to preserve —
+the loser of a minting race, seconds old and never stored.
 
 ## Minting races
 Two concurrent first calls both mint. The conditional claim
@@ -63,9 +93,25 @@ whether the store answered, because minting on a database fault would issue a fr
 request, each unstorable and each abandoned.
 
 ## Where the spend actually lands
-`LiteLLM_DailyUserSpend` and `LiteLLM_DailyTagSpend` hold months of daily rows — tokens,
-cost, request and failure counts, per key, per model, per tag. Only `LiteLLM_SpendLogs` is
-pruned (to a few days). This is why the change writes no cost table of its own.
+In the gateway's own request log, one row per call, keyed by the credential's id.
+`GET /api/logs/stats` aggregates it over a window; that is what `/me/usage` reads and why
+this package writes no cost table of its own.
+
+Two consequences worth knowing before trusting a figure:
+
+- **The read is scoped to ONE credential.** The gateway offers no way to ask by account,
+  so a key replaced mid-month leaves the earlier one's calls out of the total. Re-minting
+  only happens when the gateway refuses a stored key, so this is rare — and the fix, a
+  remembered list of retired ids, would keep dead credentials alive to make a counter
+  marginally more complete.
+- **The log write is asynchronous**, landing about five seconds after the call. Harmless
+  over a month, fatal to any read-after-write assumption.
+
+Per-feature cost is NOT an API question here. The `feature` dimension reaches the log row,
+the OpenTelemetry span, and — only while `feature` is listed in the gateway's
+`prometheus_labels` — the metrics. "What does tailoring cost" is therefore a Grafana query;
+`/api/logs/histogram/cost/by-dimension` aggregates only by provider, team, customer, user
+and business unit.
 
 **The figures are list-price, not an invoice.** The gateway prices from its model table while
 the pool behind it runs on mixed upstream keys. They compare features and periods to each
@@ -73,9 +119,11 @@ other honestly and must never be quoted as a bill.
 
 ## Adding a per-user LLM call
 1. Resolve through `userLLM` in `internal/api/handler` — the single identifier to grep for.
-2. Give it a `feature:` tag from the constants in `user_llm.go`. One tag per thing a person
-   can ask for; do not tag two surfaces the same or the report stops answering the question
-   it exists for.
+2. Give it a feature tag from the constants in `user_llm.go`. They are bare words — the
+   header `x-bf-dim-feature` names the dimension, so a `feature:` prefix in the value would
+   file the spend under `feature:assistant` and split one surface across two labels. One
+   tag per thing a person can ask for; do not tag two surfaces the same or the report stops
+   answering the question it exists for.
 3. If the service holds its client at construction, give it a one-line `As(*llm.Client)`
    clone rather than threading a second client through its constructor.
 4. Resolve BEFORE opening a stream. Minting is a network call, and making it after the

--- a/internal/ai/llmkey/AGENTS.md
+++ b/internal/ai/llmkey/AGENTS.md
@@ -58,12 +58,14 @@ provider key at all.
 
 ## Three rules that are easy to get wrong
 
-**The usage read authenticates as the administrator, scoped by account id — never AS
-the key.** `Client.Activity` reads `GET /user/daily/activity` on the admin key with the
-account id in the query string: an internal number, not a secret, so it can travel where
-a credential could not. The handler above it (`newUsageHandlers` in `me_usage.go`) takes
-no resolver on purpose — the read needs no key, cannot mint one, and still reports a
-month during which the key was replaced.
+**The usage read authenticates as the administrator, scoped by the credential's id —
+never AS the credential.** `Client.Activity` reads `GET /api/logs/stats` as the
+administrator with the virtual key's id in the query string: opaque, not a secret, so it
+can travel where the credential could not. The handler above it (`newUsageHandlers` in
+`me_usage.go`) therefore DOES take the resolver, and takes it to read — `Stored`, never
+`For`. Minting on a page view would issue a credential to every visitor who opened it out
+of curiosity. An empty id short-circuits to zeroes without asking the gateway anything,
+which is both the never-used-AI account and the row that predates 0119.
 
 **A 401 on a per-user call means the gateway forgot the key; on an administrative call it
 means our own admin key is wrong.** Conflating them would let one mistyped environment

--- a/internal/ai/llmkey/llmkey.go
+++ b/internal/ai/llmkey/llmkey.go
@@ -41,6 +41,11 @@ var ErrUnknownKey = fmt.Errorf("%w: key not recognised", ErrUpstream)
 // unattributed rather than hold the turn open.
 const requestTimeout = 5 * time.Second
 
+// keysPath is the governance collection every credential is created under and addressed
+// beneath. Written once because a typo in one of the three verbs that use it would fail as
+// a 404, which Block and Delete both read as "already done".
+const keysPath = "/api/governance/virtual-keys"
+
 // namePrefix labels a key for whoever reads the gateway's own listings. It is the only
 // place the account id appears at the gateway: spend is grouped by the credential's own
 // identifier, which we store, so nothing here has to double as a foreign key.
@@ -142,27 +147,14 @@ func (e envelope) key() virtualKey {
 // from the template key, so the list of providers and the weights between them stay in
 // the gateway's own configuration where they are already maintained, and adding a
 // provider never becomes a deployment of this service.
-//
-// key_ids is normalised rather than echoed: a read answers null where a write requires
-// ["*"], and passing the null straight back through mints a key pinned to no provider
-// key at all.
 func (c *Client) Mint(ctx context.Context, userID int64) (Credential, error) {
 	if c == nil {
 		return Credential{}, fmt.Errorf("%w: no admin API configured", ErrUpstream)
 	}
 
-	var tpl envelope
-	if err := c.do(ctx, http.MethodGet, "/api/governance/virtual-keys/"+url.PathEscape(c.cfg.TemplateKey), nil, &tpl); err != nil {
-		return Credential{}, fmt.Errorf("read policy template: %w", err)
-	}
-	policy := tpl.key().ProviderConfigs
-	if len(policy) == 0 {
-		return Credential{}, fmt.Errorf("%w: policy template %q allows no provider", ErrUpstream, c.cfg.TemplateKey)
-	}
-	for i := range policy {
-		if len(policy[i].KeyIDs) == 0 {
-			policy[i].KeyIDs = []string{"*"}
-		}
+	policy, err := c.policy(ctx)
+	if err != nil {
+		return Credential{}, err
 	}
 
 	body := map[string]any{
@@ -186,7 +178,7 @@ func (c *Client) Mint(ctx context.Context, userID int64) (Credential, error) {
 	}
 
 	var out envelope
-	if err := c.do(ctx, http.MethodPost, "/api/governance/virtual-keys", body, &out); err != nil {
+	if err := c.do(ctx, http.MethodPost, keysPath, body, &out); err != nil {
 		return Credential{}, err
 	}
 	minted := out.key()
@@ -197,6 +189,29 @@ func (c *Client) Mint(ctx context.Context, userID int64) (Credential, error) {
 		return Credential{}, fmt.Errorf("%w: minted an incomplete credential", ErrUpstream)
 	}
 	return Credential{ID: minted.ID, Secret: minted.Value}, nil
+}
+
+// policy is the provider allowlist a new credential is born with, read from the template
+// key rather than carried here.
+//
+// key_ids is normalised rather than echoed: a read answers null where a write requires
+// ["*"], and passing the null straight back through mints a key pinned to no provider key
+// at all.
+func (c *Client) policy(ctx context.Context) ([]providerConfig, error) {
+	var tpl envelope
+	if err := c.do(ctx, http.MethodGet, keysPath+"/"+url.PathEscape(c.cfg.TemplateKey), nil, &tpl); err != nil {
+		return nil, fmt.Errorf("read policy template: %w", err)
+	}
+	configs := tpl.key().ProviderConfigs
+	if len(configs) == 0 {
+		return nil, fmt.Errorf("%w: policy template %q allows no provider", ErrUpstream, c.cfg.TemplateKey)
+	}
+	for i := range configs {
+		if len(configs[i].KeyIDs) == 0 {
+			configs[i].KeyIDs = []string{"*"}
+		}
+	}
+	return configs, nil
 }
 
 // Block retires a credential without erasing it: it stops spending and stays in the
@@ -213,7 +228,7 @@ func (c *Client) Block(ctx context.Context, keyID string) error {
 	if c == nil || keyID == "" {
 		return nil
 	}
-	err := c.do(ctx, http.MethodPut, "/api/governance/virtual-keys/"+url.PathEscape(keyID),
+	err := c.do(ctx, http.MethodPut, keysPath+"/"+url.PathEscape(keyID),
 		map[string]any{"is_active": false}, nil)
 	if errors.Is(err, ErrUnknownKey) {
 		return nil
@@ -229,7 +244,7 @@ func (c *Client) Delete(ctx context.Context, keyID string) error {
 	if c == nil || keyID == "" {
 		return nil
 	}
-	err := c.do(ctx, http.MethodDelete, "/api/governance/virtual-keys/"+url.PathEscape(keyID), nil, nil)
+	err := c.do(ctx, http.MethodDelete, keysPath+"/"+url.PathEscape(keyID), nil, nil)
 	if errors.Is(err, ErrUnknownKey) {
 		return nil
 	}
@@ -285,12 +300,15 @@ func (c *Client) Activity(ctx context.Context, keyID string, from, to time.Time)
 		return Activity{}, err
 	}
 
-	failed := window
-	failed.Set("status", "error")
+	// Narrowed in place rather than through a copy. url.Values is a map, so `failed :=
+	// window` would alias it and the "widen the window" reasoning above would silently
+	// depend on the totals having already been read. One value, narrowed after use, says
+	// what is happening.
+	window.Set("status", "error")
 	var errs struct {
 		Requests int `json:"total_requests"`
 	}
-	if err := c.do(ctx, http.MethodGet, "/api/logs/stats?"+failed.Encode(), nil, &errs); err != nil {
+	if err := c.do(ctx, http.MethodGet, "/api/logs/stats?"+window.Encode(), nil, &errs); err != nil {
 		return Activity{}, err
 	}
 
@@ -312,22 +330,22 @@ func (c *Client) Activity(ctx context.Context, keyID string, from, to time.Time)
 //
 // Error messages carry the path and never the query or the credentials.
 func (c *Client) do(ctx context.Context, method, path string, body, out any) error {
-	var reader *bytes.Reader
+	// A nil blob is an empty reader, which is what GET and DELETE want. Marshalling
+	// only when there is a body keeps the two shapes on one path.
+	var blob []byte
 	if body != nil {
-		blob, err := json.Marshal(body)
+		encoded, err := json.Marshal(body)
 		if err != nil {
 			return fmt.Errorf("%w: encode request: %v", ErrUpstream, err)
 		}
-		reader = bytes.NewReader(blob)
-	} else {
-		reader = bytes.NewReader(nil)
+		blob = encoded
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, c.cfg.BaseURL+path, reader)
+	req, err := http.NewRequestWithContext(ctx, method, c.cfg.BaseURL+path, bytes.NewReader(blob))
 	if err != nil {
 		return fmt.Errorf("%w: build request: %v", ErrUpstream, err)
 	}
-	if body != nil {
+	if blob != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
 	req.SetBasicAuth(c.cfg.AdminUsername, c.cfg.AdminPassword)

--- a/internal/ai/llmkey/llmkey.go
+++ b/internal/ai/llmkey/llmkey.go
@@ -1,13 +1,13 @@
 // Package llmkey mints, reads and revokes the per-account credentials the LLM gateway
 // knows a user by.
 //
-// It talks to the gateway's administrative API, which is a different surface from the
-// one inference uses: `/key/generate` lives at the gateway root while chat completions
-// are served under `/v1`, and the two are configured separately so the admin API need
-// not be reachable wherever inference is. Nothing here makes a model call.
+// It talks to the gateway's administrative API, which is a different surface from the one
+// inference uses: governance lives under `/api` while chat completions are served under
+// `/v1`, and the two are configured separately so the admin API need not be reachable
+// wherever inference is. Nothing here makes a model call.
 //
 // Every method is safe on a nil client, which is what an unconfigured deployment gets.
-// Absence is the off switch: no admin URL or no admin key means no minting, and every
+// Absence is the off switch: no admin URL or no administrator means no minting, and every
 // call in the system goes out on the one service credential exactly as it did before.
 package llmkey
 
@@ -41,20 +41,38 @@ var ErrUnknownKey = fmt.Errorf("%w: key not recognised", ErrUpstream)
 // unattributed rather than hold the turn open.
 const requestTimeout = 5 * time.Second
 
-const (
-	// aliasPrefix labels a key for whoever reads the gateway's own listings.
-	aliasPrefix = "freehire-user-"
-	// ownerPrefix namespaces the account this gateway aggregates spend under. The
-	// gateway serves more than one product, so a bare id would collide with another's.
-	ownerPrefix = "freehire-"
-)
+// namePrefix labels a key for whoever reads the gateway's own listings. It is the only
+// place the account id appears at the gateway: spend is grouped by the credential's own
+// identifier, which we store, so nothing here has to double as a foreign key.
+const namePrefix = "freehire-user-"
 
-// Config is the gateway's administrative endpoint and the policy applied to new keys.
+// Credential is one account's key at the gateway: what its calls present, and what an
+// administrative call addresses.
+//
+// Two fields because this gateway separates them. The secret is a bearer token and the
+// only thing a model call needs; the ID is opaque and the only thing block and delete
+// accept — aiming either at the secret answers 404. Storing one without the other yields
+// a credential that can spend but not be revoked, which is what account deletion needs.
+type Credential struct {
+	ID     string
+	Secret string
+}
+
+// Config is the gateway's administrative endpoint, the administrator it authenticates as,
+// and the policy applied to new keys.
+//
 // MaxBudget, RPMLimit and BudgetWindow are omitted from the mint request when unset,
 // because a zero sent explicitly reads as "nothing is allowed" rather than "no limit".
 type Config struct {
-	BaseURL  string
-	AdminKey string
+	BaseURL       string
+	AdminUsername string
+	AdminPassword string
+
+	// TemplateKey is the id of the virtual key whose provider policy every minted
+	// credential copies. See Mint: without a policy a new key is refused everything,
+	// and reading one rather than carrying one is what keeps the provider vocabulary
+	// out of this repository.
+	TemplateKey string
 
 	MaxBudget    float64
 	RPMLimit     int
@@ -71,53 +89,151 @@ type Client struct {
 //
 // Nil is the "this deployment does not attribute spend" answer, following
 // internal/ai/speech: callers ask whether they have a client and carry on without one,
-// rather than every call site testing two strings.
+// rather than every call site testing four strings.
+//
+// TemplateKey counts as configuration. A client without one could mint, and every
+// credential it minted would be refused by every provider — an outage that looks like a
+// model problem and is really a missing environment variable.
 func New(cfg Config) *Client {
-	if cfg.BaseURL == "" || cfg.AdminKey == "" {
+	if cfg.BaseURL == "" || cfg.AdminUsername == "" || cfg.AdminPassword == "" || cfg.TemplateKey == "" {
 		return nil
 	}
 	cfg.BaseURL = strings.TrimSuffix(cfg.BaseURL, "/")
 	return &Client{cfg: cfg, http: &http.Client{Timeout: requestTimeout}}
 }
 
+// providerConfig is one entry of a virtual key's provider allowlist. The fields are
+// carried through verbatim from the template to the new key; this package does not
+// interpret them and deliberately knows no provider's name.
+type providerConfig struct {
+	Provider      string   `json:"provider"`
+	Weight        *float64 `json:"weight,omitempty"`
+	AllowedModels []string `json:"allowed_models,omitempty"`
+	KeyIDs        []string `json:"key_ids,omitempty"`
+}
+
+// virtualKey is the gateway's own shape for a credential, in both directions.
+type virtualKey struct {
+	ID              string           `json:"id"`
+	Value           string           `json:"value"`
+	ProviderConfigs []providerConfig `json:"provider_configs"`
+}
+
+// envelope covers both answer shapes the governance API uses: some routes return the key
+// at the top level, others wrap it. Reading both is cheaper than depending on which.
+type envelope struct {
+	VirtualKey *virtualKey `json:"virtual_key"`
+	virtualKey
+}
+
+func (e envelope) key() virtualKey {
+	if e.VirtualKey != nil {
+		return *e.VirtualKey
+	}
+	return e.virtualKey
+}
+
 // Mint issues a credential naming this account.
 //
-// The account is named twice on purpose. key_alias is what a human reads in the
-// gateway's listings; user_id is what the gateway aggregates daily spend under, and
-// without it the per-account rollup has nothing to group by. Both are namespaced,
-// because this gateway serves more than one product and a bare numeric id would collide.
-func (c *Client) Mint(ctx context.Context, userID int64) (string, error) {
+// It takes two calls, and the first one is not optional. A virtual key with no provider
+// policy is refused every provider — deny by default — so a key minted without one is
+// born useless, and usefully so only in the sense that the failure is total rather than
+// subtle. The policy could have been carried in configuration here; instead it is read
+// from the template key, so the list of providers and the weights between them stay in
+// the gateway's own configuration where they are already maintained, and adding a
+// provider never becomes a deployment of this service.
+//
+// key_ids is normalised rather than echoed: a read answers null where a write requires
+// ["*"], and passing the null straight back through mints a key pinned to no provider
+// key at all.
+func (c *Client) Mint(ctx context.Context, userID int64) (Credential, error) {
 	if c == nil {
-		return "", fmt.Errorf("%w: no admin API configured", ErrUpstream)
-	}
-	id := strconv.FormatInt(userID, 10)
-	body := map[string]any{
-		"key_alias": aliasPrefix + id,
-		"user_id":   ownerPrefix + id,
-	}
-	if c.cfg.MaxBudget > 0 {
-		body["max_budget"] = c.cfg.MaxBudget
-	}
-	if c.cfg.RPMLimit > 0 {
-		body["rpm_limit"] = c.cfg.RPMLimit
-	}
-	if c.cfg.BudgetWindow != "" {
-		body["budget_duration"] = c.cfg.BudgetWindow
+		return Credential{}, fmt.Errorf("%w: no admin API configured", ErrUpstream)
 	}
 
-	var out struct {
-		Key string `json:"key"`
+	var tpl envelope
+	if err := c.do(ctx, http.MethodGet, "/api/governance/virtual-keys/"+url.PathEscape(c.cfg.TemplateKey), nil, &tpl); err != nil {
+		return Credential{}, fmt.Errorf("read policy template: %w", err)
 	}
-	if err := c.post(ctx, "/key/generate", c.cfg.AdminKey, body, &out); err != nil {
-		return "", err
+	policy := tpl.key().ProviderConfigs
+	if len(policy) == 0 {
+		return Credential{}, fmt.Errorf("%w: policy template %q allows no provider", ErrUpstream, c.cfg.TemplateKey)
 	}
-	// A 200 carrying no key happens when something between us and the gateway rewrites
-	// the response. Storing "" would mark the account as credentialled for good and send
-	// every later call out unattributed, which is worse than not minting at all.
-	if out.Key == "" {
-		return "", fmt.Errorf("%w: minted an empty key", ErrUpstream)
+	for i := range policy {
+		if len(policy[i].KeyIDs) == 0 {
+			policy[i].KeyIDs = []string{"*"}
+		}
 	}
-	return out.Key, nil
+
+	body := map[string]any{
+		"name":             namePrefix + strconv.FormatInt(userID, 10),
+		"description":      "per-user spend attribution",
+		"is_active":        true,
+		"provider_configs": policy,
+	}
+	if c.cfg.MaxBudget > 0 {
+		budget := map[string]any{"max_limit": c.cfg.MaxBudget}
+		if c.cfg.BudgetWindow != "" {
+			budget["reset_duration"] = c.cfg.BudgetWindow
+		}
+		body["budgets"] = []any{budget}
+	}
+	if c.cfg.RPMLimit > 0 {
+		body["rate_limit"] = map[string]any{
+			"request_max_limit":      c.cfg.RPMLimit,
+			"request_reset_duration": "1m",
+		}
+	}
+
+	var out envelope
+	if err := c.do(ctx, http.MethodPost, "/api/governance/virtual-keys", body, &out); err != nil {
+		return Credential{}, err
+	}
+	minted := out.key()
+	// A 2xx carrying neither field happens when something between us and the gateway
+	// rewrites the response. Storing a half credential would mark the account as
+	// credentialled for good while leaving it unusable or unrevokable.
+	if minted.Value == "" || minted.ID == "" {
+		return Credential{}, fmt.Errorf("%w: minted an incomplete credential", ErrUpstream)
+	}
+	return Credential{ID: minted.ID, Secret: minted.Value}, nil
+}
+
+// Block retires a credential without erasing it: it stops spending and stays in the
+// gateway's listings, so what it was is still legible to whoever reads them.
+//
+// This is what a departing account gets. On the previous gateway it was also how the
+// spend record survived, because that record hung off the key; here the usage log is
+// keyed by the credential's id and outlives the credential itself, so the distinction
+// between this and Delete is now about legibility rather than about losing history.
+//
+// A key the gateway has already forgotten reports success — that is the state the caller
+// asked for, and account deletion must not log a fault for reaching it.
+func (c *Client) Block(ctx context.Context, keyID string) error {
+	if c == nil || keyID == "" {
+		return nil
+	}
+	err := c.do(ctx, http.MethodPut, "/api/governance/virtual-keys/"+url.PathEscape(keyID),
+		map[string]any{"is_active": false}, nil)
+	if errors.Is(err, ErrUnknownKey) {
+		return nil
+	}
+	return err
+}
+
+// Delete erases a credential outright.
+//
+// It is for a key with nothing worth keeping in the listings: one minted moments ago that
+// lost the race to store itself, or one nothing can reach any more.
+func (c *Client) Delete(ctx context.Context, keyID string) error {
+	if c == nil || keyID == "" {
+		return nil
+	}
+	err := c.do(ctx, http.MethodDelete, "/api/governance/virtual-keys/"+url.PathEscape(keyID), nil, nil)
+	if errors.Is(err, ErrUnknownKey) {
+		return nil
+	}
+	return err
 }
 
 // Activity is what an account did over a window: how many model calls it made, how many
@@ -132,108 +248,90 @@ type Activity struct {
 	Tokens   int
 }
 
-// Activity reports what one account did between two dates, inclusive.
+// Activity reports what one credential did between two dates, inclusive.
 //
-// The gateway aggregates this per day and hands back a pre-computed total, so the window
-// costs one call however long it is. It is an administrative read keyed by the account id
-// we minted under — an internal number, not a secret, so it travels in the query string
-// where a credential could not.
-func (c *Client) Activity(ctx context.Context, userID int64, from, to time.Time) (Activity, error) {
+// Two calls rather than one, because the gateway reports a success RATE and not a failure
+// count, and deriving one from the other rounds: 7 of 9 is 77.77…%, and turning that back
+// into "2 failed" is arithmetic on a display value. The second call asks the same question
+// filtered to failures and reads the count directly.
+//
+// The window is widened to whole days at both ends. The caller works in dates, the gateway
+// in instants, and a from/to pair taken literally would silently drop everything that
+// happened earlier on the first day.
+//
+// This is an administrative read keyed by the credential id — opaque, not a secret, so it
+// travels in a query string where the credential could not.
+func (c *Client) Activity(ctx context.Context, keyID string, from, to time.Time) (Activity, error) {
 	if c == nil {
 		return Activity{}, fmt.Errorf("%w: no admin API configured", ErrUpstream)
 	}
-	query := url.Values{
-		"user_id":    {ownerPrefix + strconv.FormatInt(userID, 10)},
-		"start_date": {from.UTC().Format(time.DateOnly)},
-		"end_date":   {to.UTC().Format(time.DateOnly)},
+	if keyID == "" {
+		// An account that never had a credential did nothing, which is an answer and
+		// not a fault: the usage page renders zeroes rather than an error.
+		return Activity{}, nil
 	}
-	var out struct {
-		Metadata struct {
-			Requests int `json:"total_api_requests"`
-			Failed   int `json:"total_failed_requests"`
-			Tokens   int `json:"total_tokens"`
-		} `json:"metadata"`
+
+	window := url.Values{
+		"virtual_key_ids": {keyID},
+		"start_time":      {from.UTC().Truncate(24 * time.Hour).Format(time.RFC3339)},
+		"end_time":        {to.UTC().Truncate(24 * time.Hour).Add(24*time.Hour - time.Second).Format(time.RFC3339)},
 	}
-	if err := c.get(ctx, "/user/daily/activity?"+query.Encode(), c.cfg.AdminKey, &out); err != nil {
+
+	var total struct {
+		Requests int `json:"total_requests"`
+		Tokens   int `json:"total_tokens"`
+	}
+	if err := c.do(ctx, http.MethodGet, "/api/logs/stats?"+window.Encode(), nil, &total); err != nil {
 		return Activity{}, err
 	}
-	return Activity{
-		Requests: out.Metadata.Requests,
-		Failed:   out.Metadata.Failed,
-		Tokens:   out.Metadata.Tokens,
-	}, nil
+
+	failed := window
+	failed.Set("status", "error")
+	var errs struct {
+		Requests int `json:"total_requests"`
+	}
+	if err := c.do(ctx, http.MethodGet, "/api/logs/stats?"+failed.Encode(), nil, &errs); err != nil {
+		return Activity{}, err
+	}
+
+	return Activity{Requests: total.Requests, Failed: errs.Requests, Tokens: total.Tokens}, nil
 }
 
-// Block retires a credential without erasing it: it stops spending and stays in the
-// gateway's records, so what was already spent with it remains attributable.
+// do carries out one administrative call and decodes its answer.
 //
-// This is what a departing account gets. Delete would take the gateway's own account of
-// the spend along with the key, and a cost record that disappears when somebody leaves is
-// not a cost record.
+// Every call here authenticates as the administrator and there is no second credential to
+// choose from, so unlike its predecessor this takes none: the gateway's management surface
+// admits exactly one identity, and offering a parameter would imply a decision that does
+// not exist.
 //
-// A key the gateway has already forgotten reports success — that is the state the caller
-// asked for, and account deletion must not log a fault for reaching it.
-func (c *Client) Block(ctx context.Context, secret string) error {
-	if c == nil {
-		return nil
+// 404 is singled out: the gateway answers it for a key it does not know, which is the
+// signal Block and Delete treat as already done. Every other non-2xx, including a 401, is
+// the gateway's own problem — a 401 here means OUR administrator credentials are wrong,
+// never that a user's key went stale, and conflating the two would turn one mistyped
+// environment variable into a re-minting storm.
+//
+// Error messages carry the path and never the query or the credentials.
+func (c *Client) do(ctx context.Context, method, path string, body, out any) error {
+	var reader *bytes.Reader
+	if body != nil {
+		blob, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("%w: encode request: %v", ErrUpstream, err)
+		}
+		reader = bytes.NewReader(blob)
+	} else {
+		reader = bytes.NewReader(nil)
 	}
-	err := c.post(ctx, "/key/block", c.cfg.AdminKey, map[string]any{"key": secret}, nil)
-	if errors.Is(err, ErrUnknownKey) {
-		return nil
-	}
-	return err
-}
 
-// Delete erases a credential outright, records and all.
-//
-// It is for a key that has no records worth keeping: one minted moments ago that lost the
-// race to store itself, or one nothing can reach any more. For a credential that has
-// actually been spent with, use Block.
-func (c *Client) Delete(ctx context.Context, secret string) error {
-	if c == nil {
-		return nil
-	}
-	err := c.post(ctx, "/key/delete", c.cfg.AdminKey, map[string]any{"keys": []string{secret}}, nil)
-	if errors.Is(err, ErrUnknownKey) {
-		return nil
-	}
-	return err
-}
-
-// post and get take the bearer credential explicitly rather than defaulting to the
-// administrator's. Which credential a call travels on is a security decision, and one
-// with a silent failure mode — an over-privileged read works perfectly — so it is named
-// at every call site instead of being inherited.
-func (c *Client) post(ctx context.Context, path, bearer string, body any, out any) error {
-	blob, err := json.Marshal(body)
-	if err != nil {
-		return fmt.Errorf("%w: encode request: %v", ErrUpstream, err)
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.cfg.BaseURL+path, bytes.NewReader(blob))
+	req, err := http.NewRequestWithContext(ctx, method, c.cfg.BaseURL+path, reader)
 	if err != nil {
 		return fmt.Errorf("%w: build request: %v", ErrUpstream, err)
 	}
-	req.Header.Set("Content-Type", "application/json")
-	return c.do(req, bearer, out)
-}
-
-func (c *Client) get(ctx context.Context, path, bearer string, out any) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.cfg.BaseURL+path, nil)
-	if err != nil {
-		return fmt.Errorf("%w: build request: %v", ErrUpstream, err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
 	}
-	return c.do(req, bearer, out)
-}
+	req.SetBasicAuth(c.cfg.AdminUsername, c.cfg.AdminPassword)
 
-// do carries out one call and decodes its answer.
-//
-// 404 is singled out: the gateway answers it for a key it does not know regardless of who
-// asked, which is the signal a caller (Block, Delete) treats as already done. Every other
-// non-2xx, including a 401, is the gateway's own problem.
-//
-// Error messages carry the path and never the query or the credential.
-func (c *Client) do(req *http.Request, bearer string, out any) error {
-	req.Header.Set("Authorization", "Bearer "+bearer)
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return fmt.Errorf("%w: %s: %v", ErrUpstream, req.URL.Path, err)

--- a/internal/ai/llmkey/llmkey.go
+++ b/internal/ai/llmkey/llmkey.go
@@ -289,7 +289,7 @@ func (c *Client) Activity(ctx context.Context, keyID string, from, to time.Time)
 	window := url.Values{
 		"virtual_key_ids": {keyID},
 		"start_time":      {from.UTC().Truncate(24 * time.Hour).Format(time.RFC3339)},
-		"end_time":        {to.UTC().Truncate(24 * time.Hour).Add(24*time.Hour - time.Second).Format(time.RFC3339)},
+		"end_time":        {to.UTC().Truncate(24 * time.Hour).Add(24*time.Hour - time.Nanosecond).Format(time.RFC3339Nano)},
 	}
 
 	var total struct {

--- a/internal/ai/llmkey/llmkey_test.go
+++ b/internal/ai/llmkey/llmkey_test.go
@@ -303,9 +303,19 @@ func TestARefusedAdminCallIsNotAnUnknownUserKey(t *testing.T) {
 }
 
 func TestActivityCountsWhatTheCredentialDid(t *testing.T) {
-	// Both calls answer the same body here; the second is filtered to failures, so its
-	// total_requests IS the failure count. See the two-call comment on Activity.
-	srv, got := gateway(t, http.StatusOK, `{"total_requests":128,"total_tokens":450000,"total_cost":1.25,"success_rate":98.4}`)
+	// The two reads must answer DIFFERENTLY, or this test passes with the second call
+	// deleted: the failure count comes from a read filtered to errors, where
+	// total_requests IS the failures.
+	got := &captured{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.path, got.method, got.query = r.URL.Path, r.Method, r.URL.RawQuery
+		if r.URL.Query().Get("status") == "error" {
+			_, _ = io.WriteString(w, `{"total_requests":2}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"total_requests":128,"total_tokens":450000,"total_cost":1.25,"success_rate":98.4}`)
+	}))
+	t.Cleanup(srv.Close)
 
 	from := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2026, 8, 31, 0, 0, 0, 0, time.UTC)
@@ -315,6 +325,11 @@ func TestActivityCountsWhatTheCredentialDid(t *testing.T) {
 	}
 	if act.Requests != 128 || act.Tokens != 450000 {
 		t.Errorf("Activity = %+v, want 128 calls and 450000 tokens", act)
+	}
+	// Read from the filtered call, not derived from success_rate: 126/128 is 98.4375%,
+	// and turning a rounded percentage back into a count is arithmetic on a display value.
+	if act.Failed != 2 {
+		t.Errorf("Failed = %d, want 2 read from the error-filtered call", act.Failed)
 	}
 	if got.path != "/api/logs/stats" || got.method != http.MethodGet {
 		t.Errorf("called %s %s, want GET /api/logs/stats", got.method, got.path)
@@ -344,7 +359,9 @@ func TestActivityWidensTheWindowToWholeDays(t *testing.T) {
 	if !strings.Contains(got.query, "start_time=2026-08-01T00%3A00%3A00Z") {
 		t.Errorf("query = %q, want the window opened at the start of the first day", got.query)
 	}
-	if !strings.Contains(got.query, "end_time=2026-08-31T23%3A59%3A59Z") {
+	// The last instant of the day, not the last whole second: an end of 23:59:59 would
+	// drop everything in the final second of the month.
+	if !strings.Contains(got.query, "end_time=2026-08-31T23%3A59%3A59.999999999Z") {
 		t.Errorf("query = %q, want the window closed at the end of the last day", got.query)
 	}
 }

--- a/internal/ai/llmkey/llmkey_test.go
+++ b/internal/ai/llmkey/llmkey_test.go
@@ -12,30 +12,61 @@ import (
 	"time"
 )
 
+// templateKey is the virtual key every minted credential copies its provider policy from.
+// Naming it once here keeps the fake and the assertions from drifting apart.
+const templateKey = "vk-freehire-service"
+
+// templatePath is where the fake serves that key.
+const templatePath = "/api/governance/virtual-keys/" + templateKey
+
+// templateBody is a plausible answer for a policy read, including the one asymmetry that
+// matters: the gateway returns key_ids as null where a write requires ["*"].
+const templateBody = `{"virtual_key":{"id":"vk-freehire-service","value":"sk-bf-svc","provider_configs":[
+	{"provider":"zai","weight":0.7,"allowed_models":["flagship","mid"],"key_ids":null},
+	{"provider":"gemini","weight":0.2,"allowed_models":["flagship","mid"],"key_ids":null}]}}`
+
 // captured is what the fake gateway saw, so a test can assert on the request the client
 // built rather than only on what it returned.
 type captured struct {
 	path   string
-	authz  string
 	method string
-	body   map[string]any
 	query  string
+	user   string
+	pass   string
+	body   map[string]any
+
+	// reads counts template lookups, which is how a test tells "minting read the
+	// policy" from "minting invented one".
+	reads int
 }
 
-// gateway stands in for the admin API. It records the request and answers with status
-// and body.
+// gateway stands in for the admin API. It answers a template read from templateBody and
+// everything else with status and body, recording that second request.
+//
+// Two behaviours in one fake because Mint is two calls: a test that stubbed only the
+// second would see the first fail and never reach what it meant to assert.
 func gateway(t *testing.T, status int, body string) (*httptest.Server, *captured) {
+	t.Helper()
+	return gatewayWithTemplate(t, templateBody, status, body)
+}
+
+func gatewayWithTemplate(t *testing.T, template string, status int, body string) (*httptest.Server, *captured) {
 	t.Helper()
 	got := &captured{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.Path == templatePath {
+			got.reads++
+			_, _ = io.WriteString(w, template)
+			return
+		}
 		got.path = r.URL.Path
-		got.authz = r.Header.Get("Authorization")
 		got.method = r.Method
 		got.query = r.URL.RawQuery
+		got.user, got.pass, _ = r.BasicAuth()
 		if raw, err := io.ReadAll(r.Body); err == nil && len(raw) > 0 {
 			_ = json.Unmarshal(raw, &got.body)
 		}
-		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)
 		_, _ = io.WriteString(w, body)
 	}))
@@ -43,61 +74,133 @@ func gateway(t *testing.T, status int, body string) (*httptest.Server, *captured
 	return srv, got
 }
 
+// configured is the client every test that is not about configuration uses.
+func configured(url string) *Client {
+	return New(Config{
+		BaseURL: url, AdminUsername: "admin", AdminPassword: "secret", TemplateKey: templateKey,
+	})
+}
+
+// mintedBody is what the gateway answers a create with.
+const mintedBody = `{"virtual_key":{"id":"vk-42","value":"sk-bf-minted"}}`
+
 func TestNewReportsUnconfiguredAsNil(t *testing.T) {
+	full := Config{BaseURL: "https://gw.example", AdminUsername: "admin", AdminPassword: "secret", TemplateKey: templateKey}
 	tests := []struct {
-		name              string
-		baseURL, adminKey string
+		name  string
+		strip func(*Config)
 	}{
-		{"both empty", "", ""},
-		{"no base url", "", "sk-admin"},
-		{"no admin key", "https://gw.example", ""},
+		{"no base url", func(c *Config) { c.BaseURL = "" }},
+		{"no username", func(c *Config) { c.AdminUsername = "" }},
+		{"no password", func(c *Config) { c.AdminPassword = "" }},
+		// A client without a template would mint credentials the gateway then refuses
+		// every provider — an outage that reads as a model fault and is really a missing
+		// environment variable. Absent is a better answer than subtly broken.
+		{"no policy template", func(c *Config) { c.TemplateKey = "" }},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if c := New(Config{BaseURL: tc.baseURL, AdminKey: tc.adminKey}); c != nil {
-				t.Errorf("New(%q, %q) = %v, want nil — an unconfigured gateway must be absent, not broken", tc.baseURL, tc.adminKey, c)
+			cfg := full
+			tc.strip(&cfg)
+			if c := New(cfg); c != nil {
+				t.Errorf("New(%+v) = %v, want nil — an unconfigured gateway must be absent, not broken", cfg, c)
 			}
 		})
 	}
 }
 
 func TestMintNamesTheAccountOnTheGateway(t *testing.T) {
-	srv, got := gateway(t, http.StatusOK, `{"key":"sk-minted","token_id":"hash-abc"}`)
-	c := New(Config{BaseURL: srv.URL, AdminKey: "sk-admin"})
+	srv, got := gateway(t, http.StatusOK, mintedBody)
 
-	key, err := c.Mint(context.Background(), 42)
+	cred, err := configured(srv.URL).Mint(context.Background(), 42)
 	if err != nil {
 		t.Fatalf("Mint: %v", err)
 	}
-	if key != "sk-minted" {
-		t.Errorf("Mint = %q, want the minted secret", key)
+	// Both halves or nothing: the secret spends, the id revokes, and a credential
+	// carrying only one of them is unusable in one direction without saying so.
+	if cred.Secret != "sk-bf-minted" || cred.ID != "vk-42" {
+		t.Errorf("Mint = %+v, want the minted secret and the gateway's own id", cred)
 	}
-	if got.path != "/key/generate" || got.method != http.MethodPost {
-		t.Errorf("called %s %s, want POST /key/generate", got.method, got.path)
+	if got.path != "/api/governance/virtual-keys" || got.method != http.MethodPost {
+		t.Errorf("called %s %s, want POST /api/governance/virtual-keys", got.method, got.path)
 	}
-	if got.authz != "Bearer sk-admin" {
-		t.Errorf("authorization = %q, want the admin credential", got.authz)
+	// Basic, not bearer: this gateway's management surface admits one identity and
+	// authenticates it with a username and password.
+	if got.user != "admin" || got.pass != "secret" {
+		t.Errorf("basic auth = %q/%q, want the administrator", got.user, got.pass)
 	}
-	// The account has to be named on the gateway's side or DailyUserSpend cannot
-	// attribute anything — this is the entire point of the change.
-	if uid, _ := got.body["user_id"].(string); uid != "freehire-42" {
-		t.Errorf("user_id = %v, want the namespaced account id", got.body["user_id"])
+	// The account has to be legible in the gateway's own listings, or a key found there
+	// belongs to nobody anybody can name.
+	if name, _ := got.body["name"].(string); name != "freehire-user-42" {
+		t.Errorf("name = %v, want a recognisable per-user name", got.body["name"])
 	}
-	if alias, _ := got.body["key_alias"].(string); alias != "freehire-user-42" {
-		t.Errorf("key_alias = %v, want a recognisable per-user alias", got.body["key_alias"])
+}
+
+// The policy is read, never invented here. It is what keeps the provider vocabulary in
+// the gateway's configuration: adding a provider must not become a deployment of this
+// service.
+func TestMintCopiesThePolicyFromTheTemplate(t *testing.T) {
+	srv, got := gateway(t, http.StatusOK, mintedBody)
+
+	if _, err := configured(srv.URL).Mint(context.Background(), 1); err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	if got.reads != 1 {
+		t.Errorf("template reads = %d, want exactly 1 — the policy is read, not assumed", got.reads)
+	}
+	configs, _ := got.body["provider_configs"].([]any)
+	if len(configs) != 2 {
+		t.Fatalf("provider_configs = %v, want both entries the template carried", got.body["provider_configs"])
+	}
+	first, _ := configs[0].(map[string]any)
+	if first["provider"] != "zai" {
+		t.Errorf("first provider = %v, want the template's own order preserved", first["provider"])
+	}
+	if weight, _ := first["weight"].(float64); weight != 0.7 {
+		t.Errorf("weight = %v, want the template's 0.7 — the weights are the fallback order", first["weight"])
+	}
+}
+
+// A read answers key_ids as null; a write reads null as "no provider key at all" and
+// mints a credential that can reach none of them. Echoing the read back would produce a
+// key that authenticates and then fails on every call.
+func TestMintNormalisesTheKeyAllowlistTheTemplateOmits(t *testing.T) {
+	srv, got := gateway(t, http.StatusOK, mintedBody)
+
+	if _, err := configured(srv.URL).Mint(context.Background(), 1); err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	configs, _ := got.body["provider_configs"].([]any)
+	for i, raw := range configs {
+		entry, _ := raw.(map[string]any)
+		ids, _ := entry["key_ids"].([]any)
+		if len(ids) != 1 || ids[0] != "*" {
+			t.Errorf("provider_configs[%d].key_ids = %v, want [\"*\"]", i, entry["key_ids"])
+		}
+	}
+}
+
+// A template that allows nothing mints credentials that are refused everything. Failing
+// here surfaces the misconfiguration at the gateway; succeeding would surface it as every
+// user's AI quietly breaking.
+func TestMintRefusesAPolicylessTemplate(t *testing.T) {
+	srv, _ := gatewayWithTemplate(t, `{"virtual_key":{"id":"vk-x","provider_configs":[]}}`,
+		http.StatusOK, mintedBody)
+
+	if _, err := configured(srv.URL).Mint(context.Background(), 1); err == nil {
+		t.Fatal("a template allowing no provider must fail the mint, not produce a dead key")
 	}
 }
 
 // A ceiling is policy, and this change deliberately ships without one. Sending a zero
 // would be read by the gateway as "no budget at all is allowed" rather than "no limit".
 func TestMintSendsNoCeilingWhenNoneIsConfigured(t *testing.T) {
-	srv, got := gateway(t, http.StatusOK, `{"key":"sk-minted","token_id":"hash-abc"}`)
-	c := New(Config{BaseURL: srv.URL, AdminKey: "sk-admin"})
+	srv, got := gateway(t, http.StatusOK, mintedBody)
 
-	if _, err := c.Mint(context.Background(), 1); err != nil {
+	if _, err := configured(srv.URL).Mint(context.Background(), 1); err != nil {
 		t.Fatalf("Mint: %v", err)
 	}
-	for _, field := range []string{"max_budget", "rpm_limit", "budget_duration"} {
+	for _, field := range []string{"budgets", "rate_limit"} {
 		if _, present := got.body[field]; present {
 			t.Errorf("%s was sent as %v, want it omitted entirely when unconfigured", field, got.body[field])
 		}
@@ -105,52 +208,82 @@ func TestMintSendsNoCeilingWhenNoneIsConfigured(t *testing.T) {
 }
 
 func TestMintPassesAConfiguredCeilingThrough(t *testing.T) {
-	srv, got := gateway(t, http.StatusOK, `{"key":"sk-minted","token_id":"hash-abc"}`)
+	srv, got := gateway(t, http.StatusOK, mintedBody)
 	c := New(Config{
-		BaseURL: srv.URL, AdminKey: "sk-admin",
+		BaseURL: srv.URL, AdminUsername: "admin", AdminPassword: "secret", TemplateKey: templateKey,
 		MaxBudget: 2.5, RPMLimit: 60, BudgetWindow: "30d",
 	})
 
 	if _, err := c.Mint(context.Background(), 1); err != nil {
 		t.Fatalf("Mint: %v", err)
 	}
-	if budget, _ := got.body["max_budget"].(float64); budget != 2.5 {
-		t.Errorf("max_budget = %v, want 2.5", got.body["max_budget"])
+	budgets, _ := got.body["budgets"].([]any)
+	if len(budgets) != 1 {
+		t.Fatalf("budgets = %v, want the one configured ceiling", got.body["budgets"])
 	}
-	if rpm, _ := got.body["rpm_limit"].(float64); rpm != 60 {
-		t.Errorf("rpm_limit = %v, want 60", got.body["rpm_limit"])
+	budget, _ := budgets[0].(map[string]any)
+	if limit, _ := budget["max_limit"].(float64); limit != 2.5 {
+		t.Errorf("max_limit = %v, want 2.5", budget["max_limit"])
 	}
-	if window, _ := got.body["budget_duration"].(string); window != "30d" {
-		t.Errorf("budget_duration = %v, want 30d", got.body["budget_duration"])
+	if window, _ := budget["reset_duration"].(string); window != "30d" {
+		t.Errorf("reset_duration = %v, want 30d", budget["reset_duration"])
+	}
+	rate, _ := got.body["rate_limit"].(map[string]any)
+	if requests, _ := rate["request_max_limit"].(float64); requests != 60 {
+		t.Errorf("request_max_limit = %v, want 60", rate["request_max_limit"])
 	}
 }
 
 // A refusal must not read as a successful mint of the empty string: storing "" would
 // mark the account as credentialled forever and send every later call out unattributed.
 func TestMintReportsARefusalAsAnError(t *testing.T) {
-	srv, _ := gateway(t, http.StatusUnauthorized, `{"error":"bad admin key"}`)
-	c := New(Config{BaseURL: srv.URL, AdminKey: "sk-wrong"})
+	srv, _ := gateway(t, http.StatusUnauthorized, `{"error":"bad admin credentials"}`)
 
-	key, err := c.Mint(context.Background(), 1)
+	cred, err := configured(srv.URL).Mint(context.Background(), 1)
 	if err == nil {
 		t.Fatal("Mint on a refusing gateway must fail")
 	}
 	if !errors.Is(err, ErrUpstream) {
 		t.Errorf("error = %v, want it to wrap ErrUpstream so callers can tell whose fault it is", err)
 	}
-	if key != "" {
-		t.Errorf("Mint returned secret %q alongside an error, want nothing usable", key)
+	if cred.Secret != "" || cred.ID != "" {
+		t.Errorf("Mint returned %+v alongside an error, want nothing usable", cred)
 	}
 }
 
-// A 200 carrying no key is the same hazard as a refusal, and gateways do answer this way
-// when a proxy in front of them rewrites a response.
-func TestMintReportsAnEmptyKeyAsAnError(t *testing.T) {
-	srv, _ := gateway(t, http.StatusOK, `{"token_id":"hash-abc"}`)
-	c := New(Config{BaseURL: srv.URL, AdminKey: "sk-admin"})
+// A 2xx carrying half a credential is the same hazard as a refusal, and gateways do
+// answer this way when a proxy in front of them rewrites a response. Either half missing
+// is fatal: a secret with no id can never be revoked, an id with no secret can never
+// spend, and both would be stored as though the account were credentialled.
+func TestMintReportsAnIncompleteCredentialAsAnError(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"no secret", `{"virtual_key":{"id":"vk-42"}}`},
+		{"no id", `{"virtual_key":{"value":"sk-bf-minted"}}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _ := gateway(t, http.StatusOK, tc.body)
+			if _, err := configured(srv.URL).Mint(context.Background(), 1); err == nil {
+				t.Fatal("a 2xx with half a credential must fail — storing it is worse than not minting")
+			}
+		})
+	}
+}
 
-	if _, err := c.Mint(context.Background(), 1); err == nil {
-		t.Fatal("a 200 with no key must fail — storing an empty credential is worse than not minting")
+// Some governance routes answer with the key at the top level rather than wrapped.
+// Depending on which would make the client fragile to a shape that carries no meaning.
+func TestMintReadsAnUnwrappedAnswer(t *testing.T) {
+	srv, _ := gateway(t, http.StatusOK, `{"id":"vk-42","value":"sk-bf-minted"}`)
+
+	cred, err := configured(srv.URL).Mint(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	if cred.ID != "vk-42" || cred.Secret != "sk-bf-minted" {
+		t.Errorf("Mint = %+v, want the credential read from an unwrapped answer", cred)
 	}
 }
 
@@ -158,123 +291,147 @@ func TestMintReportsAnEmptyKeyAsAnError(t *testing.T) {
 // Reading that as a stale user key would turn one bad environment variable into a
 // re-minting storm across every account — so the two must never be conflated.
 func TestARefusedAdminCallIsNotAnUnknownUserKey(t *testing.T) {
-	srv, _ := gateway(t, http.StatusUnauthorized, `{"error":"bad admin key"}`)
-	c := New(Config{BaseURL: srv.URL, AdminKey: "sk-wrong"})
+	srv, _ := gateway(t, http.StatusUnauthorized, `{"error":"bad admin credentials"}`)
 
-	_, err := c.Mint(context.Background(), 1)
+	_, err := configured(srv.URL).Mint(context.Background(), 1)
 	if errors.Is(err, ErrUnknownKey) {
-		t.Errorf("error = %v, want a plain upstream failure — a misconfigured admin key is not a stale user key", err)
+		t.Errorf("error = %v, want a plain upstream failure — a misconfigured administrator is not a stale user key", err)
 	}
 	if !errors.Is(err, ErrUpstream) {
 		t.Errorf("error = %v, want it to wrap ErrUpstream", err)
 	}
 }
 
-func TestActivityCountsWhatTheAccountDid(t *testing.T) {
-	srv, got := gateway(t, http.StatusOK, `{"results":[],"metadata":{
-		"total_api_requests":128,"total_successful_requests":126,"total_failed_requests":2,
-		"total_tokens":450000,"total_spend":1.25}}`)
-	c := New(Config{BaseURL: srv.URL, AdminKey: "sk-admin"})
+func TestActivityCountsWhatTheCredentialDid(t *testing.T) {
+	// Both calls answer the same body here; the second is filtered to failures, so its
+	// total_requests IS the failure count. See the two-call comment on Activity.
+	srv, got := gateway(t, http.StatusOK, `{"total_requests":128,"total_tokens":450000,"total_cost":1.25,"success_rate":98.4}`)
 
 	from := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2026, 8, 31, 0, 0, 0, 0, time.UTC)
-	act, err := c.Activity(context.Background(), 42, from, to)
+	act, err := configured(srv.URL).Activity(context.Background(), "vk-42", from, to)
 	if err != nil {
 		t.Fatalf("Activity: %v", err)
 	}
-	if act.Requests != 128 || act.Failed != 2 || act.Tokens != 450000 {
-		t.Errorf("Activity = %+v, want 128 calls, 2 failed, 450000 tokens", act)
+	if act.Requests != 128 || act.Tokens != 450000 {
+		t.Errorf("Activity = %+v, want 128 calls and 450000 tokens", act)
 	}
-	if got.path != "/user/daily/activity" || got.method != http.MethodGet {
-		t.Errorf("called %s %s, want GET /user/daily/activity", got.method, got.path)
+	if got.path != "/api/logs/stats" || got.method != http.MethodGet {
+		t.Errorf("called %s %s, want GET /api/logs/stats", got.method, got.path)
 	}
-	// The account is named by the SAME namespaced id minting writes, or the read
-	// silently reports zero for an account that has been busy all month.
-	if !strings.Contains(got.query, "user_id=freehire-42") {
-		t.Errorf("query = %q, want the namespaced account id", got.query)
+	// Scoped by the credential's own id. Asking by anything else reports somebody
+	// else's month, or nobody's.
+	if !strings.Contains(got.query, "virtual_key_ids=vk-42") {
+		t.Errorf("query = %q, want the credential id", got.query)
 	}
-	if !strings.Contains(got.query, "start_date=2026-08-01") || !strings.Contains(got.query, "end_date=2026-08-31") {
-		t.Errorf("query = %q, want the window as plain dates", got.query)
+	// The last recorded call is the failure one, and it must carry the same window as
+	// the total or the two numbers describe different months.
+	if !strings.Contains(got.query, "status=error") {
+		t.Errorf("query = %q, want the failure read filtered to errors", got.query)
 	}
 }
 
-// An account the gateway has never seen is the ordinary "never used AI" case, and the
-// endpoint answers it with zeroes rather than an error.
-func TestActivityOfAnUnknownAccountIsZero(t *testing.T) {
-	srv, _ := gateway(t, http.StatusOK, `{"results":[],"metadata":{"total_api_requests":0,"total_failed_requests":0,"total_tokens":0}}`)
-	c := New(Config{BaseURL: srv.URL, AdminKey: "sk-admin"})
+// The caller works in dates and the gateway in instants. A window taken literally would
+// drop everything that happened earlier on the first day and later on the last.
+func TestActivityWidensTheWindowToWholeDays(t *testing.T) {
+	srv, got := gateway(t, http.StatusOK, `{"total_requests":0,"total_tokens":0}`)
 
-	act, err := c.Activity(context.Background(), 42, time.Now(), time.Now())
+	from := time.Date(2026, 8, 1, 13, 45, 0, 0, time.UTC)
+	to := time.Date(2026, 8, 31, 9, 5, 0, 0, time.UTC)
+	if _, err := configured(srv.URL).Activity(context.Background(), "vk-42", from, to); err != nil {
+		t.Fatalf("Activity: %v", err)
+	}
+	if !strings.Contains(got.query, "start_time=2026-08-01T00%3A00%3A00Z") {
+		t.Errorf("query = %q, want the window opened at the start of the first day", got.query)
+	}
+	if !strings.Contains(got.query, "end_time=2026-08-31T23%3A59%3A59Z") {
+		t.Errorf("query = %q, want the window closed at the end of the last day", got.query)
+	}
+}
+
+// An account that never made a call has no credential, and that is an answer rather than
+// a fault: the usage page renders zeroes. Asking the gateway about an empty id would be a
+// request that cannot mean anything.
+func TestActivityOfAnAccountWithNoCredentialIsZeroWithoutAsking(t *testing.T) {
+	srv, got := gateway(t, http.StatusInternalServerError, `{"error":"boom"}`)
+
+	act, err := configured(srv.URL).Activity(context.Background(), "", time.Now(), time.Now())
 	if err != nil {
 		t.Fatalf("Activity: %v", err)
 	}
 	if act.Requests != 0 || act.Tokens != 0 {
 		t.Errorf("Activity = %+v, want zeroes", act)
 	}
+	if got.path != "" {
+		t.Errorf("called %s, want no request at all for an account with no credential", got.path)
+	}
 }
 
 func TestActivityReportsAFailure(t *testing.T) {
 	srv, _ := gateway(t, http.StatusInternalServerError, `{"error":"boom"}`)
-	c := New(Config{BaseURL: srv.URL, AdminKey: "sk-admin"})
 
-	if _, err := c.Activity(context.Background(), 42, time.Now(), time.Now()); err == nil {
+	if _, err := configured(srv.URL).Activity(context.Background(), "vk-42", time.Now(), time.Now()); err == nil {
 		t.Error("Activity must surface a gateway fault rather than report a false zero")
 	}
 }
 
-// Blocking is how a credential is retired when its spend history matters. Deleting takes
-// the gateway's record of what was spent with it; blocking stops the spending and keeps
-// the record.
-func TestBlockNamesTheKey(t *testing.T) {
-	srv, got := gateway(t, http.StatusOK, `{"blocked":true}`)
-	c := New(Config{BaseURL: srv.URL, AdminKey: "sk-admin"})
+// Blocking retires a credential while leaving it legible in the gateway's listings.
+// It addresses the key by id: this gateway answers 404 to anything aimed at the secret.
+func TestBlockNamesTheKeyById(t *testing.T) {
+	srv, got := gateway(t, http.StatusOK, `{"id":"vk-42","is_active":false}`)
 
-	if err := c.Block(context.Background(), "sk-user"); err != nil {
+	if err := configured(srv.URL).Block(context.Background(), "vk-42"); err != nil {
 		t.Fatalf("Block: %v", err)
 	}
-	if got.path != "/key/block" || got.method != http.MethodPost {
-		t.Errorf("called %s %s, want POST /key/block", got.method, got.path)
+	if got.path != "/api/governance/virtual-keys/vk-42" || got.method != http.MethodPut {
+		t.Errorf("called %s %s, want PUT /api/governance/virtual-keys/vk-42", got.method, got.path)
 	}
-	if key, _ := got.body["key"].(string); key != "sk-user" {
-		t.Errorf("key = %v, want the one credential", got.body["key"])
+	if active, ok := got.body["is_active"].(bool); !ok || active {
+		t.Errorf("is_active = %v, want false — blocking deactivates rather than erases", got.body["is_active"])
 	}
-	if got.authz != "Bearer sk-admin" {
-		t.Errorf("authorization = %q, want the admin credential — a key cannot block itself", got.authz)
+	if got.user != "admin" {
+		t.Errorf("basic auth user = %q, want the administrator — a key cannot block itself", got.user)
 	}
 }
 
 // A key the gateway has already forgotten is in the state asked for.
 func TestBlockTreatsAnUnknownKeyAsDone(t *testing.T) {
 	srv, _ := gateway(t, http.StatusNotFound, `{"error":"key not found"}`)
-	c := New(Config{BaseURL: srv.URL, AdminKey: "sk-admin"})
 
-	if err := c.Block(context.Background(), "sk-gone"); err != nil {
+	if err := configured(srv.URL).Block(context.Background(), "vk-gone"); err != nil {
 		t.Errorf("Block of an unknown key = %v, want nil", err)
+	}
+}
+
+// An account with no id to name — one credentialled before the id column existed — has
+// nothing to block. Sending the request anyway would aim it at an empty path.
+func TestBlockWithoutAnIdIsANoop(t *testing.T) {
+	srv, got := gateway(t, http.StatusInternalServerError, `{"error":"boom"}`)
+
+	if err := configured(srv.URL).Block(context.Background(), ""); err != nil {
+		t.Errorf("Block with no id = %v, want nil", err)
+	}
+	if got.path != "" {
+		t.Errorf("called %s, want no request at all", got.path)
 	}
 }
 
 func TestBlockReportsARealFailure(t *testing.T) {
 	srv, _ := gateway(t, http.StatusInternalServerError, `{"error":"boom"}`)
-	c := New(Config{BaseURL: srv.URL, AdminKey: "sk-admin"})
 
-	if err := c.Block(context.Background(), "sk-user"); err == nil {
+	if err := configured(srv.URL).Block(context.Background(), "vk-42"); err == nil {
 		t.Error("Block must surface a gateway fault; the caller decides whether to care")
 	}
 }
 
-func TestDeleteNamesTheKey(t *testing.T) {
-	srv, got := gateway(t, http.StatusOK, `{"deleted_keys":["sk-user"]}`)
-	c := New(Config{BaseURL: srv.URL, AdminKey: "sk-admin"})
+func TestDeleteNamesTheKeyById(t *testing.T) {
+	srv, got := gateway(t, http.StatusOK, `{"deleted":true}`)
 
-	if err := c.Delete(context.Background(), "sk-user"); err != nil {
+	if err := configured(srv.URL).Delete(context.Background(), "vk-42"); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
-	if got.path != "/key/delete" || got.method != http.MethodPost {
-		t.Errorf("called %s %s, want POST /key/delete", got.method, got.path)
-	}
-	keys, _ := got.body["keys"].([]any)
-	if len(keys) != 1 || keys[0] != "sk-user" {
-		t.Errorf("keys = %v, want exactly the one key", got.body["keys"])
+	if got.path != "/api/governance/virtual-keys/vk-42" || got.method != http.MethodDelete {
+		t.Errorf("called %s %s, want DELETE /api/governance/virtual-keys/vk-42", got.method, got.path)
 	}
 }
 
@@ -282,18 +439,16 @@ func TestDeleteNamesTheKey(t *testing.T) {
 // Reporting it as a failure would make account deletion log a fault on every retry.
 func TestDeleteTreatsAnUnknownKeyAsDone(t *testing.T) {
 	srv, _ := gateway(t, http.StatusNotFound, `{"error":"key not found"}`)
-	c := New(Config{BaseURL: srv.URL, AdminKey: "sk-admin"})
 
-	if err := c.Delete(context.Background(), "sk-gone"); err != nil {
+	if err := configured(srv.URL).Delete(context.Background(), "vk-gone"); err != nil {
 		t.Errorf("Delete of an unknown key = %v, want nil — it is already in the state asked for", err)
 	}
 }
 
 func TestDeleteReportsARealFailure(t *testing.T) {
 	srv, _ := gateway(t, http.StatusInternalServerError, `{"error":"boom"}`)
-	c := New(Config{BaseURL: srv.URL, AdminKey: "sk-admin"})
 
-	if err := c.Delete(context.Background(), "sk-user"); err == nil {
+	if err := configured(srv.URL).Delete(context.Background(), "vk-42"); err == nil {
 		t.Error("Delete must surface a gateway fault; the caller decides whether to care")
 	}
 }
@@ -305,7 +460,13 @@ func TestNilClientIsSafe(t *testing.T) {
 	if _, err := c.Mint(context.Background(), 1); err == nil {
 		t.Error("Mint on an unconfigured gateway must fail rather than return a usable key")
 	}
-	if err := c.Delete(context.Background(), "sk-user"); err != nil {
+	if err := c.Delete(context.Background(), "vk-42"); err != nil {
 		t.Errorf("Delete on an unconfigured gateway = %v, want nil — there is nothing to erase", err)
+	}
+	if err := c.Block(context.Background(), "vk-42"); err != nil {
+		t.Errorf("Block on an unconfigured gateway = %v, want nil", err)
+	}
+	if _, err := c.Activity(context.Background(), "vk-42", time.Now(), time.Now()); err == nil {
+		t.Error("Activity on an unconfigured gateway must fail rather than report a false zero")
 	}
 }

--- a/internal/ai/llmkey/resolver.go
+++ b/internal/ai/llmkey/resolver.go
@@ -150,7 +150,17 @@ func (r *Resolver) Forget(ctx context.Context, userID int64, secret string) {
 	// Read before clearing. The block below addresses the credential by the gateway's
 	// own id, and the row about to be emptied is the only place that id is written down;
 	// clearing first would leave a live key nothing can name.
-	stored, _ := r.read(ctx, userID)
+	//
+	// An unreadable store therefore stops the whole operation rather than only the block.
+	// Clearing anyway would erase the one record of that id while the credential kept
+	// spending — permanently, since nothing could ever name it again. Leaving the row is
+	// safe: the caller's request already completed on the service credential, and the
+	// next refusal retries this.
+	stored, ok := r.read(ctx, userID)
+	if !ok {
+		log.Printf("llmkey: cannot read credential for user %d; leaving it in place", userID)
+		return
+	}
 
 	err := r.q.ClearUserLLMKey(ctx, db.ClearUserLLMKeyParams{
 		ID:     userID,

--- a/internal/ai/llmkey/resolver.go
+++ b/internal/ai/llmkey/resolver.go
@@ -14,8 +14,8 @@ import (
 // Queries is the slice of the generated query surface the resolver needs. *db.Queries
 // satisfies it; tests supply a fake.
 type Queries interface {
-	GetUserLLMKey(ctx context.Context, id int64) (string, error)
-	ClaimUserLLMKey(ctx context.Context, arg db.ClaimUserLLMKeyParams) (string, error)
+	GetUserLLMKey(ctx context.Context, id int64) (db.GetUserLLMKeyRow, error)
+	ClaimUserLLMKey(ctx context.Context, arg db.ClaimUserLLMKeyParams) (db.ClaimUserLLMKeyRow, error)
 	ClearUserLLMKey(ctx context.Context, arg db.ClearUserLLMKeyParams) error
 }
 
@@ -51,10 +51,10 @@ func (r *Resolver) For(ctx context.Context, userID int64) string {
 		// each one unstorable and each one left at the gateway.
 		return ""
 	}
-	if stored != "" {
-		return stored
+	if stored.Secret != "" {
+		return stored.Secret
 	}
-	return r.mint(ctx, userID)
+	return r.mint(ctx, userID).Secret
 }
 
 // Stored returns the credential this account already has, or "" — and never mints one.
@@ -62,7 +62,7 @@ func (r *Resolver) For(ctx context.Context, userID int64) string {
 // It is what a read of somebody's own usage uses. Minting there would create a credential
 // for every visitor who opened a page out of curiosity, and turn "accounts with a key"
 // from a count of who has spent into a count of who has looked. Nil-safe.
-func (r *Resolver) Stored(ctx context.Context, userID int64) string {
+func (r *Resolver) Stored(ctx context.Context, userID int64) Credential {
 	stored, _ := r.read(ctx, userID)
 	return stored
 }
@@ -71,61 +71,62 @@ func (r *Resolver) Stored(ctx context.Context, userID int64) string {
 // are separate answers: "this account has none" invites minting one, while "the database
 // did not answer" must not — telling them apart is what keeps an unwell database from
 // issuing a key per request.
-func (r *Resolver) read(ctx context.Context, userID int64) (string, bool) {
+func (r *Resolver) read(ctx context.Context, userID int64) (Credential, bool) {
 	if r == nil || r.q == nil {
-		return "", false
+		return Credential{}, false
 	}
 	stored, err := r.q.GetUserLLMKey(ctx, userID)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return "", true // a real account with no credential yet
+		return Credential{}, true // a real account with no credential yet
 	}
 	if err != nil {
 		log.Printf("llmkey: read credential for user %d: %v", userID, err)
-		return "", false
+		return Credential{}, false
 	}
-	return stored, true
+	return Credential{ID: stored.LlmKeyID, Secret: stored.LlmKey}, true
 }
 
 // mint issues a credential and stores it, resolving the race two concurrent first calls
 // create: both mint, the database admits one, and the loser adopts the winner's value and
 // revokes its own.
-func (r *Resolver) mint(ctx context.Context, userID int64) string {
+func (r *Resolver) mint(ctx context.Context, userID int64) Credential {
 	minted, err := r.gateway.Mint(ctx, userID)
 	if err != nil {
 		log.Printf("llmkey: mint credential for user %d: %v", userID, err)
-		return ""
+		return Credential{}
 	}
-	// Mint already refuses an empty secret; this is the second lock on the same door,
+	// Mint already refuses a half credential; this is the second lock on the same door,
 	// because "" is the stored signal for "not minted" and writing it would strand the
 	// account in a state no later call can tell from a fresh one.
-	if minted == "" {
-		return ""
+	if minted.Secret == "" || minted.ID == "" {
+		return Credential{}
 	}
 
 	claimed, err := r.q.ClaimUserLLMKey(ctx, db.ClaimUserLLMKeyParams{
-		ID:     userID,
-		LlmKey: pgtype.Text{String: minted, Valid: true},
+		ID:       userID,
+		LlmKey:   pgtype.Text{String: minted.Secret, Valid: true},
+		LlmKeyID: pgtype.Text{String: minted.ID, Valid: true},
 	})
 	switch {
 	case err == nil:
-		return claimed
+		return Credential{ID: claimed.LlmKeyID, Secret: claimed.LlmKey}
 	case errors.Is(err, pgx.ErrNoRows):
 		// Somebody else claimed first. Their credential is the account's; ours was born
 		// unreferenced and has to go, or it sits at the gateway forever spending nothing
 		// and appearing in every listing.
-		r.revoke(ctx, minted)
+		r.revoke(ctx, minted.ID)
 		winner, err := r.q.GetUserLLMKey(ctx, userID)
 		if err != nil {
 			log.Printf("llmkey: re-read credential for user %d: %v", userID, err)
-			return ""
+			return Credential{}
 		}
-		return winner
+		return Credential{ID: winner.LlmKeyID, Secret: winner.LlmKey}
 	default:
 		// We hold a live credential the database will never point at again. Revoking it
 		// is the only way it does not spend under an account nothing can connect it to.
 		log.Printf("llmkey: store credential for user %d: %v", userID, err)
-		r.revoke(ctx, minted)
-		return ""
+		r.revoke(ctx, minted.ID)
+		return Credential{}
 	}
 }
 
@@ -146,6 +147,11 @@ func (r *Resolver) Forget(ctx context.Context, userID int64, secret string) {
 	if r == nil || r.q == nil {
 		return
 	}
+	// Read before clearing. The block below addresses the credential by the gateway's
+	// own id, and the row about to be emptied is the only place that id is written down;
+	// clearing first would leave a live key nothing can name.
+	stored, _ := r.read(ctx, userID)
+
 	err := r.q.ClearUserLLMKey(ctx, db.ClearUserLLMKeyParams{
 		ID:     userID,
 		LlmKey: pgtype.Text{String: secret, Valid: true},
@@ -153,7 +159,13 @@ func (r *Resolver) Forget(ctx context.Context, userID int64, secret string) {
 	if err != nil {
 		log.Printf("llmkey: clear credential for user %d: %v", userID, err)
 	}
-	if err := r.gateway.Block(ctx, secret); err != nil {
+	// Only block what the refusal was actually about. A concurrent call may already have
+	// re-minted, in which case the row now holds a different credential and blocking it
+	// would revoke a good key on the strength of a stale one's 401.
+	if stored.Secret != secret || stored.ID == "" {
+		return
+	}
+	if err := r.gateway.Block(ctx, stored.ID); err != nil {
 		log.Printf("llmkey: block refused credential: %v", err)
 	}
 }
@@ -176,18 +188,18 @@ func (r *Resolver) Revoke(ctx context.Context, userID int64) error {
 	if r == nil {
 		return nil
 	}
-	secret := r.Stored(ctx, userID)
-	if secret == "" {
+	stored := r.Stored(ctx, userID)
+	if stored.ID == "" {
 		return nil
 	}
-	return r.gateway.Block(ctx, secret)
+	return r.gateway.Block(ctx, stored.ID)
 }
 
 // revoke deletes a credential at the gateway, best-effort. Every caller has already
 // decided the value is not to be used again, so a failure here leaves a key that spends
 // nothing — worth a log line and nothing more.
-func (r *Resolver) revoke(ctx context.Context, secret string) {
-	if err := r.gateway.Delete(ctx, secret); err != nil {
+func (r *Resolver) revoke(ctx context.Context, keyID string) {
+	if err := r.gateway.Delete(ctx, keyID); err != nil {
 		log.Printf("llmkey: revoke credential: %v", err)
 	}
 }

--- a/internal/ai/llmkey/resolver.go
+++ b/internal/ai/llmkey/resolver.go
@@ -3,6 +3,7 @@ package llmkey
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 
 	"github.com/jackc/pgx/v5"
@@ -198,7 +199,16 @@ func (r *Resolver) Revoke(ctx context.Context, userID int64) error {
 	if r == nil {
 		return nil
 	}
-	stored := r.Stored(ctx, userID)
+	// An unreadable store is not an account without a credential, and the difference
+	// matters more here than anywhere else in this package: everywhere else a failed read
+	// costs attribution, while here it would let a deletion report success having revoked
+	// nothing, leaving a live credential spending for an account that no longer exists.
+	// The error goes back so the caller decides — deleting the row is what makes the id
+	// unrecoverable, so this is the last moment anyone can.
+	stored, ok := r.read(ctx, userID)
+	if !ok {
+		return fmt.Errorf("%w: cannot read the credential to revoke", ErrUpstream)
+	}
 	if stored.ID == "" {
 		return nil
 	}

--- a/internal/ai/llmkey/resolver_test.go
+++ b/internal/ai/llmkey/resolver_test.go
@@ -283,6 +283,11 @@ func TestForgetLeavesAReplacementAlone(t *testing.T) {
 	if q.stored[7] != "sk-replacement" {
 		t.Errorf("stored %q, want the replacement kept", q.stored[7])
 	}
+	// The hazard this branch guards is not the row but the gateway: blocking on the
+	// strength of a stale credential's 401 would revoke a good key.
+	if len(g.blocked) != 0 {
+		t.Errorf("blocked %v, want nothing — the refusal was about a credential the row no longer holds", g.blocked)
+	}
 }
 
 // Guard the pgtype wrapping: an empty-string key must never be written as a stored value,
@@ -300,5 +305,93 @@ func TestClaimNeverStoresAnEmptyCredential(t *testing.T) {
 	}
 	if q.claims != 0 {
 		t.Errorf("attempted %d claims for an empty credential, want none", q.claims)
+	}
+}
+
+// An unreadable store must stop Forget entirely, not merely stop it blocking. The row is
+// the only place the gateway's id is written down: clearing it while the read failed
+// would leave a live credential spending with nothing able to name it, permanently.
+func TestForgetLeavesTheRowAloneWhenItCannotBeRead(t *testing.T) {
+	q := newFakeQueries()
+	q.stored[7] = "sk-stale"
+	q.storedIDs[7] = keyID("sk-stale")
+	q.getErr = errors.New("database down")
+	g := &routedGateway{}
+	r := testResolver(t, q, g)
+
+	r.Forget(context.Background(), 7, "sk-stale")
+
+	if q.stored[7] != "sk-stale" {
+		t.Errorf("stored %q, want the credential left in place — the next refusal retries", q.stored[7])
+	}
+	if len(g.blocked) != 0 {
+		t.Errorf("blocked %v, want nothing blocked on a read we could not trust", g.blocked)
+	}
+}
+
+// A credential minted before the id column existed has nothing to block. Clearing the row
+// is still right — that is what makes the next call mint a complete pair — but reaching
+// for the gateway with an empty id would aim a request at no key at all.
+func TestForgetClearsAnIdlessRowWithoutBlocking(t *testing.T) {
+	q := newFakeQueries()
+	q.stored[7] = "sk-pre-0119"
+	g := &routedGateway{}
+	r := testResolver(t, q, g)
+
+	r.Forget(context.Background(), 7, "sk-pre-0119")
+
+	if q.stored[7] != "" {
+		t.Errorf("stored %q, want the row cleared so the next call mints a pair", q.stored[7])
+	}
+	if len(g.blocked) != 0 {
+		t.Errorf("blocked %v, want nothing blocked — there is no id to name", g.blocked)
+	}
+}
+
+// Revoke is why the id column exists: account deletion has to stop a credential spending,
+// and this gateway will not accept the secret to do it.
+func TestRevokeBlocksByIdAndLeavesTheRow(t *testing.T) {
+	q := newFakeQueries()
+	q.stored[7] = "sk-departing"
+	q.storedIDs[7] = keyID("sk-departing")
+	g := &routedGateway{}
+	r := testResolver(t, q, g)
+
+	if err := r.Revoke(context.Background(), 7); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if len(g.blocked) != 1 || g.blocked[0] != keyID("sk-departing") {
+		t.Errorf("blocked %v, want exactly the departing account's credential, by id", g.blocked)
+	}
+	if len(g.deleted) != 0 {
+		t.Errorf("deleted %v, want nothing deleted — a retired key stays legible in the listings", g.deleted)
+	}
+	// The row is about to go with the account's own cascade; clearing it here would only
+	// cost a write.
+	if q.stored[7] != "sk-departing" {
+		t.Errorf("stored %q, want the row left to the deletion cascade", q.stored[7])
+	}
+}
+
+// An account with no credential, and one credentialled before the id column existed, both
+// have nothing to revoke. Neither is a fault.
+func TestRevokeIsANoopWithoutAnId(t *testing.T) {
+	for name, seed := range map[string]func(*fakeQueries){
+		"never credentialled": func(*fakeQueries) {},
+		"credentialled before 0119": func(q *fakeQueries) {
+			q.stored[7] = "sk-pre-0119"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			q := newFakeQueries()
+			seed(q)
+			g := &routedGateway{}
+			if err := testResolver(t, q, g).Revoke(context.Background(), 7); err != nil {
+				t.Fatalf("Revoke: %v", err)
+			}
+			if len(g.blocked) != 0 {
+				t.Errorf("blocked %v, want nothing", g.blocked)
+			}
+		})
 	}
 }

--- a/internal/ai/llmkey/resolver_test.go
+++ b/internal/ai/llmkey/resolver_test.go
@@ -2,11 +2,11 @@ package llmkey
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -20,6 +20,10 @@ import (
 type fakeQueries struct {
 	mu     sync.Mutex
 	stored map[int64]string
+	// storedIDs holds the gateway's own identifier beside the secret, because the two
+	// are written and cleared as one credential and a test that tracked only the secret
+	// could not tell a revocable credential from an unrevocable one.
+	storedIDs map[int64]string
 
 	// commitDuringMint is the other transaction landing while we hold a freshly minted
 	// key: the first read saw nothing, and by the time we try to claim, the winner's
@@ -31,34 +35,38 @@ type fakeQueries struct {
 	claims                     int
 }
 
-func newFakeQueries() *fakeQueries { return &fakeQueries{stored: map[int64]string{}} }
+func newFakeQueries() *fakeQueries {
+	return &fakeQueries{stored: map[int64]string{}, storedIDs: map[int64]string{}}
+}
 
-func (f *fakeQueries) GetUserLLMKey(_ context.Context, id int64) (string, error) {
+func (f *fakeQueries) GetUserLLMKey(_ context.Context, id int64) (db.GetUserLLMKeyRow, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.getErr != nil {
-		return "", f.getErr
+		return db.GetUserLLMKeyRow{}, f.getErr
 	}
-	return f.stored[id], nil
+	return db.GetUserLLMKeyRow{LlmKey: f.stored[id], LlmKeyID: f.storedIDs[id]}, nil
 }
 
 // ClaimUserLLMKey mirrors the real statement: it writes only while the account has none,
 // and reports no rows when somebody else got there first.
-func (f *fakeQueries) ClaimUserLLMKey(_ context.Context, arg db.ClaimUserLLMKeyParams) (string, error) {
+func (f *fakeQueries) ClaimUserLLMKey(_ context.Context, arg db.ClaimUserLLMKeyParams) (db.ClaimUserLLMKeyRow, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.claims++
 	if f.claimErr != nil {
-		return "", f.claimErr
+		return db.ClaimUserLLMKeyRow{}, f.claimErr
 	}
 	if f.commitDuringMint != "" {
 		f.stored[arg.ID] = f.commitDuringMint
+		f.storedIDs[arg.ID] = keyID(f.commitDuringMint)
 	}
 	if f.stored[arg.ID] != "" {
-		return "", pgx.ErrNoRows
+		return db.ClaimUserLLMKeyRow{}, pgx.ErrNoRows
 	}
 	f.stored[arg.ID] = arg.LlmKey.String
-	return arg.LlmKey.String, nil
+	f.storedIDs[arg.ID] = arg.LlmKeyID.String
+	return db.ClaimUserLLMKeyRow{LlmKey: arg.LlmKey.String, LlmKeyID: arg.LlmKeyID.String}, nil
 }
 
 func (f *fakeQueries) ClearUserLLMKey(_ context.Context, arg db.ClearUserLLMKeyParams) error {
@@ -69,13 +77,20 @@ func (f *fakeQueries) ClearUserLLMKey(_ context.Context, arg db.ClearUserLLMKeyP
 	}
 	if f.stored[arg.ID] == arg.LlmKey.String {
 		delete(f.stored, arg.ID)
+		delete(f.storedIDs, arg.ID)
 	}
 	return nil
 }
 
-// routedGateway answers /key/generate with successive secrets and records every deletion
-// and block, so a test can prove an abandoned key was cleaned up (or, for a refused live
-// credential, merely retired) rather than orphaned.
+// keyID is the gateway id a test expects beside a given secret. The real gateway hands
+// back two unrelated opaque strings; deriving one from the other here keeps an assertion
+// about which credential was blocked readable — "vk-loser" beside "sk-loser" — without
+// pretending the production code may assume any such relationship.
+func keyID(secret string) string { return "vk-" + strings.TrimPrefix(secret, "sk-") }
+
+// routedGateway answers a create with successive secrets and records every deletion and
+// block BY ID, so a test can prove an abandoned key was cleaned up (or, for a refused
+// live credential, merely retired) rather than orphaned.
 type routedGateway struct {
 	mu       sync.Mutex
 	mints    []string
@@ -90,8 +105,13 @@ func (g *routedGateway) server(t *testing.T) *httptest.Server {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		g.mu.Lock()
 		defer g.mu.Unlock()
-		switch r.URL.Path {
-		case "/key/generate":
+		const keys = "/api/governance/virtual-keys"
+		switch {
+		// The policy read every mint begins with. Answering it here rather than in
+		// each test keeps these cases about the race they exist to describe.
+		case r.Method == http.MethodGet && r.URL.Path == keys+"/"+templateKey:
+			_, _ = io.WriteString(w, templateBody)
+		case r.Method == http.MethodPost && r.URL.Path == keys:
 			if g.mintFail {
 				w.WriteHeader(http.StatusInternalServerError)
 				_, _ = io.WriteString(w, `{"error":"boom"}`)
@@ -102,22 +122,12 @@ func (g *routedGateway) server(t *testing.T) *httptest.Server {
 				secret = g.mints[g.minted]
 			}
 			g.minted++
-			_, _ = io.WriteString(w, `{"key":"`+secret+`","token_id":"h"}`)
-		case "/key/delete":
-			var body struct {
-				Keys []string `json:"keys"`
-			}
-			raw, _ := io.ReadAll(r.Body)
-			_ = json.Unmarshal(raw, &body)
-			g.deleted = append(g.deleted, body.Keys...)
-			_, _ = io.WriteString(w, `{"deleted_keys":[]}`)
-		case "/key/block":
-			var body struct {
-				Key string `json:"key"`
-			}
-			raw, _ := io.ReadAll(r.Body)
-			_ = json.Unmarshal(raw, &body)
-			g.blocked = append(g.blocked, body.Key)
+			_, _ = io.WriteString(w, `{"virtual_key":{"id":"`+keyID(secret)+`","value":"`+secret+`"}}`)
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, keys+"/"):
+			g.deleted = append(g.deleted, strings.TrimPrefix(r.URL.Path, keys+"/"))
+			_, _ = io.WriteString(w, `{"deleted":true}`)
+		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, keys+"/"):
+			g.blocked = append(g.blocked, strings.TrimPrefix(r.URL.Path, keys+"/"))
 			_, _ = io.WriteString(w, `{}`)
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -129,12 +139,13 @@ func (g *routedGateway) server(t *testing.T) *httptest.Server {
 
 func testResolver(t *testing.T, q Queries, g *routedGateway) *Resolver {
 	t.Helper()
-	return NewResolver(q, New(Config{BaseURL: g.server(t).URL, AdminKey: "sk-admin"}))
+	return NewResolver(q, configured(g.server(t).URL))
 }
 
 func TestForReturnsTheStoredCredentialWithoutMinting(t *testing.T) {
 	q := newFakeQueries()
 	q.stored[7] = "sk-already"
+	q.storedIDs[7] = keyID("sk-already")
 	g := &routedGateway{}
 	r := testResolver(t, q, g)
 
@@ -171,7 +182,7 @@ func TestForLosesTheRaceAndRevokesItsOwnKey(t *testing.T) {
 	if got := r.For(context.Background(), 7); got != "sk-winner" {
 		t.Errorf("For = %q, want the credential that actually got stored", got)
 	}
-	if len(g.deleted) != 1 || g.deleted[0] != "sk-loser" {
+	if len(g.deleted) != 1 || g.deleted[0] != keyID("sk-loser") {
 		t.Errorf("deleted %v, want exactly the abandoned key", g.deleted)
 	}
 	if q.stored[7] != "sk-winner" {
@@ -219,7 +230,7 @@ func TestForRevokesACredentialItCouldNotStore(t *testing.T) {
 	if got := r.For(context.Background(), 7); got != "" {
 		t.Errorf("For = %q, want \"\" — a credential we cannot store must not be used", got)
 	}
-	if len(g.deleted) != 1 || g.deleted[0] != "sk-unstorable" {
+	if len(g.deleted) != 1 || g.deleted[0] != keyID("sk-unstorable") {
 		t.Errorf("deleted %v, want the unstorable credential revoked", g.deleted)
 	}
 }
@@ -242,6 +253,7 @@ func TestNilResolverIsUnattributed(t *testing.T) {
 func TestForgetClearsTheRowAndBlocksTheKey(t *testing.T) {
 	q := newFakeQueries()
 	q.stored[7] = "sk-stale"
+	q.storedIDs[7] = keyID("sk-stale")
 	g := &routedGateway{}
 	r := testResolver(t, q, g)
 
@@ -250,7 +262,7 @@ func TestForgetClearsTheRowAndBlocksTheKey(t *testing.T) {
 	if q.stored[7] != "" {
 		t.Errorf("stored %q, want the stale credential cleared so the next call re-mints", q.stored[7])
 	}
-	if len(g.blocked) != 1 || g.blocked[0] != "sk-stale" {
+	if len(g.blocked) != 1 || g.blocked[0] != keyID("sk-stale") {
 		t.Errorf("blocked %v, want the stale credential blocked", g.blocked)
 	}
 	if len(g.deleted) != 0 {
@@ -262,6 +274,7 @@ func TestForgetClearsTheRowAndBlocksTheKey(t *testing.T) {
 func TestForgetLeavesAReplacementAlone(t *testing.T) {
 	q := newFakeQueries()
 	q.stored[7] = "sk-replacement"
+	q.storedIDs[7] = keyID("sk-replacement")
 	g := &routedGateway{}
 	r := testResolver(t, q, g)
 

--- a/internal/ai/llmkey/resolver_test.go
+++ b/internal/ai/llmkey/resolver_test.go
@@ -395,3 +395,22 @@ func TestRevokeIsANoopWithoutAnId(t *testing.T) {
 		})
 	}
 }
+
+// A read that fails must not let account deletion report success having revoked nothing.
+// Everywhere else in this package a failed read costs only attribution; here it would
+// leave a live credential spending for an account that no longer exists, and deleting the
+// row is what makes its id unrecoverable — so this is the last moment anyone can act.
+func TestRevokeReportsAnUnreadableStore(t *testing.T) {
+	q := newFakeQueries()
+	q.stored[7] = "sk-departing"
+	q.storedIDs[7] = keyID("sk-departing")
+	q.getErr = errors.New("database down")
+	g := &routedGateway{}
+
+	if err := testResolver(t, q, g).Revoke(context.Background(), 7); err == nil {
+		t.Fatal("Revoke must surface an unreadable store, not report a revocation it did not perform")
+	}
+	if len(g.blocked) != 0 {
+		t.Errorf("blocked %v, want nothing", g.blocked)
+	}
+}

--- a/internal/ai/speech/AGENTS.md
+++ b/internal/ai/speech/AGENTS.md
@@ -5,6 +5,28 @@
 Its HTTP surface is `internal/api/handler/speech.go`; the microphone that feeds it is
 `web/src/lib/assistant/VoiceInput.svelte`.
 
+## Dark since 2026-08-22 — the gateway moved out from under it
+
+Audio is **not served** right now, and the reason is not in this package. The
+OpenAI-compatible gateway both this and voice mode depend on is being replaced
+(`provision/bifrost/` in freehire-ops). The replacement exposes
+`/v1/audio/transcriptions` and `/v1/realtime/client_secrets`, but neither has ever
+been called against it: the key pool behind it carries no OpenAI credential, which
+makes those routes unproven rather than known-good.
+
+Nothing here was deleted or edited to achieve that — the off switch was already the
+design. `STT_MODEL` unset means `New` returns nil, the handler answers 501, and the
+same holds for `internal/api/realtime`. What was added is a matching switch in the SPA
+(`web/src/lib/assistant/audioAvailability.ts`, `AUDIO_ENABLED`), because without it the
+microphone renders, records, fails once and only then latches away — a worse first
+impression than no microphone.
+
+**To bring it back:** give the gateway an audio-capable credential, exercise both routes
+against it, then set `STT_MODEL` (and the Realtime config) and flip `AUDIO_ENABLED`. One
+wire-shape difference is already known and will bite: that gateway wants
+`session.model` as `provider/model` on the client-secret route, which is not the shape
+sent today.
+
 ## Always true
 - **It is not part of `internal/platform/llm`.** That package is built on langchaingo, which
   models chat completions and has no audio surface; a multipart audio POST bolted onto

--- a/internal/api/handler/assistant.go
+++ b/internal/api/handler/assistant.go
@@ -714,7 +714,7 @@ func (h *assistantHandlers) streamSSE(
 // would believe it has a model and dereference it on the first round. That is a panic in
 // the stream goroutine, after the response has already begun.
 func (h *assistantHandlers) boundRunner(ctx context.Context, sess assistant.Session) *assistant.Runner {
-	bound := userLLM(ctx, h.keys, h.llm, sess.UserID, tagAssistant, "preset:"+sess.Preset)
+	bound := userLLM(ctx, h.keys, h.llm, sess.UserID, llm.Feature(tagAssistant), llm.Dimension{Name: "preset", Value: sess.Preset})
 	if bound == nil {
 		return h.runner
 	}

--- a/internal/api/handler/ats_report.go
+++ b/internal/api/handler/ats_report.go
@@ -15,6 +15,7 @@ import (
 	"github.com/strelov1/freehire/internal/dict/skilltag"
 	"github.com/strelov1/freehire/internal/identity/userprofile"
 	"github.com/strelov1/freehire/internal/platform/db"
+	"github.com/strelov1/freehire/internal/platform/llm"
 	"github.com/strelov1/freehire/internal/search/search"
 )
 
@@ -86,7 +87,7 @@ func (h *resumeHandlers) PostATSReport(c *fiber.Ctx) error {
 		// asking the model to judge a document it cannot see.
 		return c.JSON(fiber.Map{"data": atsResponse{HasCV: true, Report: report}})
 	}
-	analyzer := h.atsAnalyzer.As(h.llm.bind(c.Context(), userID, tagATSReview))
+	analyzer := h.atsAnalyzer.As(h.llm.bind(c.Context(), userID, llm.Feature(tagATSReview)))
 	review, err := analyzer.Analyze(c.Context(), candidate)
 	if err != nil {
 		// Best-effort: log (never the CV text) and serve the deterministic report.

--- a/internal/api/handler/autofill_agent.go
+++ b/internal/api/handler/autofill_agent.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/strelov1/freehire/internal/ai/autofillagent"
 	"github.com/strelov1/freehire/internal/identity/auth"
+	"github.com/strelov1/freehire/internal/platform/llm"
 )
 
 // RunAgentAutofill fills the form on whatever page the caller's browser is
@@ -41,7 +42,7 @@ func (h *autofillHandlers) RunAgentAutofill(c *fiber.Ctx) error {
 	report, err := autofillagent.Run(
 		c.Context(),
 		caller,
-		autofillagent.LLMPlanner{Client: h.llm.bind(c.Context(), userID, tagAutofill)},
+		autofillagent.LLMPlanner{Client: h.llm.bind(c.Context(), userID, llm.Feature(tagAutofill))},
 		profileFields(profile),
 	)
 	if err != nil {

--- a/internal/api/handler/handler.go
+++ b/internal/api/handler/handler.go
@@ -560,7 +560,7 @@ func Register(app *fiber.App, cfg Config) {
 	// shared client's default timeout. The contact block it plans over comes from the base
 	// CV, then the structured résumé — see autofillHandlers.autofillProfile.
 	autofillH := newAutofillHandlers(cvStore, resumeStore, queries, screeningAnswersSvc, a.browserTools, llmBinding{client: cfg.LLM, keys: llmKeys})
-	usageH := newUsageHandlers(cfg.LLMKeys)
+	usageH := newUsageHandlers(cfg.LLMKeys, llmKeys)
 	accountDeletion.WithGatewayKeys(llmKeys.Revoke)
 
 	// Referral notifications reuse the SES email transport (email is always present) and

--- a/internal/api/handler/mail_recall.go
+++ b/internal/api/handler/mail_recall.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/strelov1/freehire/internal/application/mailrecall"
 	"github.com/strelov1/freehire/internal/platform/db"
+	"github.com/strelov1/freehire/internal/platform/llm"
 )
 
 // recalledEmail is one message the sweep proposes, in the same shape the application
@@ -82,7 +83,7 @@ func (h *inboxHandlers) RecallApplicationMail(c *fiber.Ctx) error {
 	//
 	// The mailbox is resolved per caller and may be nil — a hosted address or a harness
 	// tier — in which case the service reads stored mail instead.
-	recall := h.recall.As(h.llm.bind(c.Context(), userID, tagMailRecall))
+	recall := h.recall.As(h.llm.bind(c.Context(), userID, llm.Feature(tagMailRecall)))
 	if h.mailboxes != nil {
 		recall = recall.WithMailbox(h.mailboxes.For(c.Context(), userID))
 	}

--- a/internal/api/handler/match_analysis.go
+++ b/internal/api/handler/match_analysis.go
@@ -21,6 +21,7 @@ import (
 	"github.com/strelov1/freehire/internal/candidate/resumeextract"
 	"github.com/strelov1/freehire/internal/identity/userprofile"
 	"github.com/strelov1/freehire/internal/platform/db"
+	"github.com/strelov1/freehire/internal/platform/llm"
 	"github.com/strelov1/freehire/internal/platform/pgconv"
 )
 
@@ -270,7 +271,7 @@ func (h *matchHandlers) buildAnalysisInput(c *fiber.Ctx, job db.Job, userID int6
 // endpoint. The autopilot's two halves run after the request and build that same input
 // through the same function, from plain values — see autopilotAnalysis.
 func (h *matchHandlers) runAnalysis(c *fiber.Ctx, userID int64, job db.Job, profile userprofile.Profile, blockers []hardconstraint.Blocker, language string) (*matchanalysis.Analysis, error) {
-	analyzer := h.matchAnalysis.As(h.llm.bind(c.Context(), userID, tagMatchAnalysis))
+	analyzer := h.matchAnalysis.As(h.llm.bind(c.Context(), userID, llm.Feature(tagMatchAnalysis)))
 	return analyzer.Analyze(c.Context(), h.buildAnalysisInput(c, job, userID, profile, blockers, language))
 }
 
@@ -309,7 +310,7 @@ func (h *matchHandlers) prepareAutopilotRun(c *fiber.Ctx, userID int64, job db.J
 		h:            h,
 		userID:       userID,
 		job:          job,
-		analyzer:     h.matchAnalysis.As(h.llm.bind(c.Context(), userID, tagMatchAnalysis)),
+		analyzer:     h.matchAnalysis.As(h.llm.bind(c.Context(), userID, llm.Feature(tagMatchAnalysis))),
 		input:        h.buildAnalysisInput(c, job, userID, profile, blockers, language),
 		cvUploadedAt: cvUploadedAt,
 	}

--- a/internal/api/handler/match_analysis_stream.go
+++ b/internal/api/handler/match_analysis_stream.go
@@ -20,6 +20,7 @@ import (
 	"github.com/strelov1/freehire/internal/candidate/jobmatch"
 	"github.com/strelov1/freehire/internal/candidate/matchanalysis"
 	"github.com/strelov1/freehire/internal/platform/db"
+	"github.com/strelov1/freehire/internal/platform/llm"
 )
 
 // StreamMatchAnalysis runs the three-stage fit chain over Server-Sent Events, emitting stage
@@ -103,7 +104,7 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 	if isLeader {
 		// Bound before the stream opens: minting a credential is a network call, and making
 		// it after the headers are out would stall a stream the client is already reading.
-		analyzer = h.matchAnalysis.As(h.llm.bind(c.Context(), userID, tagMatchAnalysis))
+		analyzer = h.matchAnalysis.As(h.llm.bind(c.Context(), userID, llm.Feature(tagMatchAnalysis)))
 
 		// Captured up front, same as cvUploadedAt above: the cache write happens after the
 		// stream's own goroutine outlives this request, so the language it stamps must be

--- a/internal/api/handler/me_usage.go
+++ b/internal/api/handler/me_usage.go
@@ -15,13 +15,19 @@ import (
 // number to disagree with.
 type usageHandlers struct {
 	gateway *llmkey.Client
+	keys    *llmkey.Resolver
 }
 
-// newUsageHandlers takes the gateway and no resolver on purpose. The read is scoped by the
-// account id rather than by a credential, so it needs no key, cannot mint one, and still
-// reports a month during which the key was replaced.
-func newUsageHandlers(gateway *llmkey.Client) *usageHandlers {
-	return &usageHandlers{gateway: gateway}
+// newUsageHandlers takes the resolver as well as the gateway, and only to READ.
+//
+// It used to take the gateway alone, because the gateway aggregated spend under an
+// account id we already had in the request. This one aggregates under the credential's
+// own identifier, which lives in our database, so the id has to be looked up — but with
+// Stored, never For: minting here would issue a credential to every visitor who opened
+// the page out of curiosity and turn "accounts with a key" from a count of who has spent
+// into a count of who has looked.
+func newUsageHandlers(gateway *llmkey.Client, keys *llmkey.Resolver) *usageHandlers {
+	return &usageHandlers{gateway: gateway, keys: keys}
 }
 
 func (h *usageHandlers) register(api fiber.Router, mw middleware) {
@@ -70,9 +76,13 @@ func (h *usageHandlers) usage(c *fiber.Ctx, userID int64) usageResponse {
 	if h.gateway == nil {
 		return out
 	}
-	// Scoped by the account id, not by the credential — so an account whose key was
-	// re-minted mid-month still reports everything it did, under both.
-	act, err := h.gateway.Activity(c.Context(), userID, credits.PeriodStart(now), now)
+	// Scoped by the credential, which is a real narrowing: the gateway keys its usage
+	// log by the credential's id and offers no way to ask by account, so a key replaced
+	// mid-month leaves the earlier one's calls out of this figure. That happens only when
+	// the gateway refuses a stored key, which is rare, and the alternative — remembering
+	// retired ids so the read could sum them — would keep a growing list of dead
+	// credentials alive to make a usage counter slightly more complete.
+	act, err := h.gateway.Activity(c.Context(), h.keys.Stored(c.Context(), userID).ID, credits.PeriodStart(now), now)
 	if err != nil {
 		log.Printf("usage: read activity for user %d: %v", userID, err)
 		return out

--- a/internal/api/handler/me_usage_test.go
+++ b/internal/api/handler/me_usage_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -16,24 +17,40 @@ import (
 	"github.com/strelov1/freehire/internal/identity/auth"
 )
 
-// activityGateway answers the daily-activity read per account id, so a test can give two
+// activity is one credential's month, as the fake gateway will report it.
+type activity struct{ requests, failed, tokens int }
+
+// activityGateway answers the usage read per CREDENTIAL id, so a test can give two
 // accounts different numbers and prove neither can see the other's.
-func activityGateway(t *testing.T, byAccount map[string]string) *httptest.Server {
+//
+// It serves the read twice over, because that is what the client does: once for the
+// totals and once filtered to failures, where total_requests IS the failure count. A fake
+// that ignored the filter would report every call as failed.
+//
+// The totals always carry a cost the handler must drop; see the wire-shape test below.
+func activityGateway(t *testing.T, byKey map[string]activity) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/user/daily/activity" {
+		if r.URL.Path != "/api/logs/stats" {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		body, ok := byAccount[r.URL.Query().Get("user_id")]
-		if !ok {
-			body = `{"results":[],"metadata":{"total_api_requests":0,"total_failed_requests":0,"total_tokens":0}}`
+		act := byKey[r.URL.Query().Get("virtual_key_ids")]
+		if r.URL.Query().Get("status") == "error" {
+			_, _ = fmt.Fprintf(w, `{"total_requests":%d}`, act.failed)
+			return
 		}
-		_, _ = io.WriteString(w, body)
+		_, _ = fmt.Fprintf(w, `{"total_requests":%d,"total_tokens":%d,"total_cost":9.99}`,
+			act.requests, act.tokens)
 	}))
 	t.Cleanup(srv.Close)
 	return srv
 }
+
+// usageKeyID is the credential id this account's usage is filed under. The handler reads
+// it from the store rather than deriving it, so the store has to be seeded with it — an
+// account whose row holds no id reports zeroes, which is a real state and not a fault.
+func usageKeyID(userID int64) string { return fmt.Sprintf("vk-%d", userID) }
 
 func usageApp(t *testing.T, gatewayURL string, userID int64) (*fiber.App, string) {
 	t.Helper()
@@ -42,7 +59,11 @@ func usageApp(t *testing.T, gatewayURL string, userID int64) (*fiber.App, string
 	if err != nil {
 		t.Fatalf("issue token: %v", err)
 	}
-	h := &usageHandlers{gateway: llmkey.New(llmkey.Config{BaseURL: gatewayURL, AdminKey: "sk-admin"})}
+	store := newStubKeyQueries()
+	store.stored[userID] = fmt.Sprintf("sk-user-%d", userID)
+	store.storedIDs[userID] = usageKeyID(userID)
+	gateway := llmkey.New(testGatewayConfig(gatewayURL))
+	h := &usageHandlers{gateway: gateway, keys: llmkey.NewResolver(store, gateway)}
 
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	app.Get("/api/v1/me/usage", auth.RequireAuth(iss, testVersions), h.GetMyUsage)
@@ -68,8 +89,8 @@ func readUsage(t *testing.T, app *fiber.App, token string) (int, map[string]any)
 }
 
 func TestUsageReportsWhatTheCallerDid(t *testing.T) {
-	gw := activityGateway(t, map[string]string{
-		"freehire-7": `{"results":[],"metadata":{"total_api_requests":128,"total_failed_requests":2,"total_tokens":450000}}`,
+	gw := activityGateway(t, map[string]activity{
+		"vk-7": {requests: 128, failed: 2, tokens: 450000},
 	})
 	app, token := usageApp(t, gw.URL, 7)
 
@@ -88,8 +109,8 @@ func TestUsageReportsWhatTheCallerDid(t *testing.T) {
 // No money, ever. The gateway's figure is a list price on a mixed pool — not our cost and
 // not the caller's price, which is credits. Two currencies for one thing, one fictional.
 func TestUsageReportsNoMoney(t *testing.T) {
-	gw := activityGateway(t, map[string]string{
-		"freehire-7": `{"results":[],"metadata":{"total_api_requests":5,"total_spend":9.99,"total_tokens":10}}`,
+	gw := activityGateway(t, map[string]activity{
+		"vk-7": {requests: 5, tokens: 10},
 	})
 	app, token := usageApp(t, gw.URL, 7)
 
@@ -104,7 +125,7 @@ func TestUsageReportsNoMoney(t *testing.T) {
 // The period must be the one credits already reset on, or a balance and a usage count sit
 // on different months and both look correct.
 func TestUsagePeriodMatchesTheCreditsCalendar(t *testing.T) {
-	gw := activityGateway(t, map[string]string{})
+	gw := activityGateway(t, map[string]activity{})
 	app, token := usageApp(t, gw.URL, 7)
 
 	_, data := readUsage(t, app, token)
@@ -117,7 +138,7 @@ func TestUsagePeriodMatchesTheCreditsCalendar(t *testing.T) {
 // Never used AI is a real and common state, and it is zero — not an error, and not a 404
 // that a client has to special-case before it can render a number.
 func TestUsageAnswersACallerWithNoneAsZeroes(t *testing.T) {
-	gw := activityGateway(t, map[string]string{})
+	gw := activityGateway(t, map[string]activity{})
 	app, token := usageApp(t, gw.URL, 7)
 
 	status, data := readUsage(t, app, token)
@@ -130,9 +151,9 @@ func TestUsageAnswersACallerWithNoneAsZeroes(t *testing.T) {
 }
 
 func TestUsageIsOwnerScoped(t *testing.T) {
-	gw := activityGateway(t, map[string]string{
-		"freehire-7": `{"results":[],"metadata":{"total_api_requests":12,"total_failed_requests":0,"total_tokens":1}}`,
-		"freehire-8": `{"results":[],"metadata":{"total_api_requests":99,"total_failed_requests":0,"total_tokens":1}}`,
+	gw := activityGateway(t, map[string]activity{
+		"vk-7": {requests: 12, tokens: 1},
+		"vk-8": {requests: 99, tokens: 1},
 	})
 
 	seven, tokenSeven := usageApp(t, gw.URL, 7)
@@ -146,7 +167,7 @@ func TestUsageIsOwnerScoped(t *testing.T) {
 }
 
 func TestUsageRequiresACredential(t *testing.T) {
-	gw := activityGateway(t, map[string]string{})
+	gw := activityGateway(t, map[string]activity{})
 	app, _ := usageApp(t, gw.URL, 7)
 
 	if status, _ := readUsage(t, app, ""); status != fiber.StatusUnauthorized {
@@ -197,8 +218,8 @@ func TestUsageWithNoGatewayConfiguredIsStillZeroes(t *testing.T) {
 // The read is scoped by the account id, never by a credential — so it needs no key, mints
 // nothing, and still reports a month during which the key was re-minted.
 func TestUsageNeitherNeedsNorReturnsACredential(t *testing.T) {
-	gw := activityGateway(t, map[string]string{
-		"freehire-7": `{"results":[],"metadata":{"total_api_requests":3,"total_failed_requests":0,"total_tokens":9}}`,
+	gw := activityGateway(t, map[string]activity{
+		"vk-7": {requests: 3, tokens: 9},
 	})
 	app, token := usageApp(t, gw.URL, 7)
 

--- a/internal/api/handler/me_usage_test.go
+++ b/internal/api/handler/me_usage_test.go
@@ -215,8 +215,10 @@ func TestUsageWithNoGatewayConfiguredIsStillZeroes(t *testing.T) {
 	}
 }
 
-// The read is scoped by the account id, never by a credential — so it needs no key, mints
-// nothing, and still reports a month during which the key was re-minted.
+// The response is about what an account DID, never about how it is known: no credential,
+// minted or stored, may appear on the wire. The figures are now scoped to the account's
+// current credential — see the design note on that narrowing — but the secret behind it
+// stays entirely server-side.
 func TestUsageNeitherNeedsNorReturnsACredential(t *testing.T) {
 	gw := activityGateway(t, map[string]activity{
 		"vk-7": {requests: 3, tokens: 9},
@@ -233,5 +235,38 @@ func TestUsageNeitherNeedsNorReturnsACredential(t *testing.T) {
 	raw, _ := io.ReadAll(resp.Body)
 	if strings.Contains(string(raw), "sk-") {
 		t.Errorf("the response looks like it carried a credential: %s", raw)
+	}
+}
+
+// Reading a usage page must never mint. Attribution exists to say what somebody spent, and
+// a credential issued to every visitor who opened the page out of curiosity would turn
+// "accounts with a key" from a count of who has spent into a count of who has looked.
+func TestUsageOfAnUncredentialledAccountMintsNothing(t *testing.T) {
+	gw := activityGateway(t, map[string]activity{})
+
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	token, err := iss.Issue(7, testTokenVersion)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	// Deliberately unseeded: this account has never made an AI call.
+	store := newStubKeyQueries()
+	gateway := llmkey.New(testGatewayConfig(gw.URL))
+	h := &usageHandlers{gateway: gateway, keys: llmkey.NewResolver(store, gateway)}
+
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/me/usage", auth.RequireAuth(iss, testVersions), h.GetMyUsage)
+
+	status, data := readUsage(t, app, token)
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200 — never having used AI is an answer, not a fault", status)
+	}
+	if data["requests"] != float64(0) || data["tokens"] != float64(0) {
+		t.Errorf("data = %v, want zeroes", data)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.stored) != 0 {
+		t.Errorf("store holds %v, want nothing minted by a read", store.stored)
 	}
 }

--- a/internal/api/handler/me_usage_test.go
+++ b/internal/api/handler/me_usage_test.go
@@ -270,3 +270,40 @@ func TestUsageOfAnUncredentialledAccountMintsNothing(t *testing.T) {
 		t.Errorf("store holds %v, want nothing minted by a read", store.stored)
 	}
 }
+
+// A credential minted before the id column existed has a secret and nothing to ask the
+// gateway with. Zeroes are the honest answer — the account self-heals into a complete pair
+// on the first refusal — but the read must not go out at all, because an id-less query
+// asks about every credential rather than none.
+func TestUsageOfAnIdlessCredentialAsksNothing(t *testing.T) {
+	asked := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		asked = true
+		_, _ = io.WriteString(w, `{"total_requests":999,"total_tokens":999}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	token, err := iss.Issue(7, testTokenVersion)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	store := newStubKeyQueries()
+	store.stored[7] = "sk-pre-0119" // secret, deliberately no id
+	gateway := llmkey.New(testGatewayConfig(srv.URL))
+	h := &usageHandlers{gateway: gateway, keys: llmkey.NewResolver(store, gateway)}
+
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/me/usage", auth.RequireAuth(iss, testVersions), h.GetMyUsage)
+
+	status, data := readUsage(t, app, token)
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if data["requests"] != float64(0) {
+		t.Errorf("requests = %v, want zero — there is no credential to report under", data["requests"])
+	}
+	if asked {
+		t.Error("the gateway was asked with no credential id, which is a question about everybody's usage")
+	}
+}

--- a/internal/api/handler/resume.go
+++ b/internal/api/handler/resume.go
@@ -18,6 +18,7 @@ import (
 	"github.com/strelov1/freehire/internal/dict/skilltag"
 	"github.com/strelov1/freehire/internal/identity/userprofile"
 	"github.com/strelov1/freehire/internal/platform/db"
+	"github.com/strelov1/freehire/internal/platform/llm"
 )
 
 // resumeHandlers serves the résumé/CV surfaces: skill extraction, stored-résumé
@@ -342,7 +343,7 @@ func (h *resumeHandlers) extractStructuredResume(userID int64, text string, uplo
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), resumeExtractLLMTimeout+30*time.Second)
 	defer cancel()
-	extractor := h.structuredExtractor.As(h.llm.bind(ctx, userID, tagCVExtract))
+	extractor := h.structuredExtractor.As(h.llm.bind(ctx, userID, llm.Feature(tagCVExtract)))
 	st, err := extractor.Extract(ctx, text)
 	if err != nil {
 		log.Printf("resume structured: user %d: %v", userID, err)

--- a/internal/api/handler/search_intent.go
+++ b/internal/api/handler/search_intent.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/strelov1/freehire/internal/api/ratelimit"
+	"github.com/strelov1/freehire/internal/platform/llm"
 	"github.com/strelov1/freehire/internal/search/searchintent"
 )
 
@@ -144,7 +145,7 @@ func (h *intentHandlers) InterpretSearch(c *fiber.Ctx) error {
 		req.Previous = &previous
 	}
 
-	interpreter := searchintent.NewInterpreter(h.llm.bind(c.Context(), userID, tagSearchIntent))
+	interpreter := searchintent.NewInterpreter(h.llm.bind(c.Context(), userID, llm.Feature(tagSearchIntent)))
 	res, err := interpreter.Interpret(c.Context(), req)
 	switch {
 	case errors.Is(err, searchintent.ErrDisabled):

--- a/internal/api/handler/search_intent_test.go
+++ b/internal/api/handler/search_intent_test.go
@@ -183,9 +183,13 @@ func TestInterpretSearchRefusesARequestWithNothingInIt(t *testing.T) {
 // Every per-user model call goes out on that user's own gateway credential under a
 // feature tag. This one is no exception, and the tag has to be a constant beside the
 // others rather than a string written here.
+//
+// The value is a bare word: the gateway names the dimension in the header, so a
+// "feature:" prefix here would file the spend under "feature:search-intent" and split
+// one feature's costs across two labels the day anybody wrote it the other way.
 func TestSearchIntentHasItsOwnFeatureTag(t *testing.T) {
-	if tagSearchIntent == "" || !strings.HasPrefix(tagSearchIntent, "feature:") {
-		t.Fatalf("tagSearchIntent = %q, want a feature: tag", tagSearchIntent)
+	if tagSearchIntent == "" || strings.Contains(tagSearchIntent, ":") {
+		t.Fatalf("tagSearchIntent = %q, want a bare feature name", tagSearchIntent)
 	}
 	if tagSearchIntent == tagAssistant {
 		t.Fatal("search intent must not be billed as assistant work")

--- a/internal/api/handler/user_llm.go
+++ b/internal/api/handler/user_llm.go
@@ -36,8 +36,8 @@ type llmBinding struct {
 }
 
 // bind returns the client one call should travel on. See userLLM: it cannot fail.
-func (b llmBinding) bind(ctx context.Context, userID int64, tags ...string) *llm.Client {
-	return userLLM(ctx, b.keys, b.client, userID, tags...)
+func (b llmBinding) bind(ctx context.Context, userID int64, dims ...llm.Dimension) *llm.Client {
+	return userLLM(ctx, b.keys, b.client, userID, dims...)
 }
 
 // userLLM binds a model client to the caller's own gateway credential and labels the call
@@ -52,13 +52,13 @@ func (b llmBinding) bind(ctx context.Context, userID int64, tags ...string) *llm
 // admin API all return a client that spends on the service credential — still tagged,
 // because knowing which feature spent is useful even when the person could not be worked
 // out. A nil model stays nil, so a deployment with no LLM keeps reporting the feature off.
-func userLLM(ctx context.Context, keys *llmkey.Resolver, client *llm.Client, userID int64, tags ...string) *llm.Client {
+func userLLM(ctx context.Context, keys *llmkey.Resolver, client *llm.Client, userID int64, dims ...llm.Dimension) *llm.Client {
 	if client == nil {
 		return nil
 	}
 	secret := keys.For(ctx, userID)
 	if secret == "" {
-		return client.As("", nil, tags...)
+		return client.As("", nil, dims...)
 	}
 	// Forgetting runs on a context detached from the caller's. A refusal is most likely
 	// to arrive exactly when someone has closed the tab, and a credential the gateway has
@@ -66,5 +66,5 @@ func userLLM(ctx context.Context, keys *llmkey.Resolver, client *llm.Client, use
 	// pays for one abandoned request.
 	forget := func() { keys.Forget(context.WithoutCancel(ctx), userID, secret) }
 
-	return client.As(secret, forget, tags...)
+	return client.As(secret, forget, dims...)
 }

--- a/internal/api/handler/user_llm.go
+++ b/internal/api/handler/user_llm.go
@@ -14,13 +14,13 @@ import (
 // mints a CV and debits credits, and the work is an assistant turn under the `tailor`
 // preset — already tagged as such. A second tag would double-count the same spend.
 const (
-	tagAssistant     = "feature:assistant"
-	tagMatchAnalysis = "feature:match-analysis"
-	tagCVExtract     = "feature:cv-extract"
-	tagATSReview     = "feature:ats-review"
-	tagAutofill      = "feature:autofill"
-	tagMailRecall    = "feature:mail-recall"
-	tagSearchIntent  = "feature:search-intent"
+	tagAssistant     = "assistant"
+	tagMatchAnalysis = "match-analysis"
+	tagCVExtract     = "cv-extract"
+	tagATSReview     = "ats-review"
+	tagAutofill      = "autofill"
+	tagMailRecall    = "mail-recall"
+	tagSearchIntent  = "search-intent"
 )
 
 // llmBinding is what a per-user surface needs to spend as its caller: the client the

--- a/internal/api/handler/user_llm_test.go
+++ b/internal/api/handler/user_llm_test.go
@@ -34,7 +34,7 @@ func newSpendProxy(t *testing.T) *spendProxy {
 	p.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		p.mu.Lock()
 		p.authz = append(p.authz, r.Header.Get("Authorization"))
-		p.tags = append(p.tags, r.Header.Get("X-Litellm-Tags"))
+		p.tags = append(p.tags, r.Header.Get("X-Bf-Dim-Feature"))
 		p.mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")
@@ -46,12 +46,19 @@ func newSpendProxy(t *testing.T) *spendProxy {
 }
 
 // keyGateway is the admin API, minting a fixed secret.
+// newKeyGateway answers the two calls a mint makes: the policy read, then the create.
+// The policy has to be there — a virtual key created without one is refused every
+// provider, so a fake that skipped it would let a mint "succeed" into a dead credential.
 func newKeyGateway(t *testing.T, mint string) *httptest.Server {
 	t.Helper()
+	const keys = "/api/governance/virtual-keys"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/key/generate":
-			_, _ = io.WriteString(w, `{"key":"`+mint+`","token_id":"h"}`)
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == keys+"/"+testTemplateKey:
+			_, _ = io.WriteString(w, `{"virtual_key":{"id":"`+testTemplateKey+`","provider_configs":[`+
+				`{"provider":"zai","weight":1,"allowed_models":["flagship"],"key_ids":["*"]}]}}`)
+		case r.Method == http.MethodPost && r.URL.Path == keys:
+			_, _ = io.WriteString(w, `{"virtual_key":{"id":"vk-`+mint+`","value":"`+mint+`"}}`)
 		default:
 			_, _ = io.WriteString(w, `{}`)
 		}
@@ -60,33 +67,47 @@ func newKeyGateway(t *testing.T, mint string) *httptest.Server {
 	return srv
 }
 
+// testTemplateKey names the virtual key these fakes serve a provider policy from.
+const testTemplateKey = "vk-freehire-service"
+
+// testGatewayConfig is the admin configuration every handler test uses. Spelling it once
+// keeps a new required field from having to be added at each call site.
+func testGatewayConfig(url string) llmkey.Config {
+	return llmkey.Config{
+		BaseURL: url, AdminUsername: "admin", AdminPassword: "secret", TemplateKey: testTemplateKey,
+	}
+}
+
 // stubKeyQueries is the smallest store the resolver needs.
 type stubKeyQueries struct {
-	mu     sync.Mutex
-	stored map[int64]string
+	mu        sync.Mutex
+	stored    map[int64]string
+	storedIDs map[int64]string
 }
 
 func newStubKeyQueries() *stubKeyQueries {
-	return &stubKeyQueries{stored: map[int64]string{}}
+	return &stubKeyQueries{stored: map[int64]string{}, storedIDs: map[int64]string{}}
 }
 
-func (s *stubKeyQueries) GetUserLLMKey(_ context.Context, id int64) (string, error) {
+func (s *stubKeyQueries) GetUserLLMKey(_ context.Context, id int64) (db.GetUserLLMKeyRow, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.stored[id], nil
+	return db.GetUserLLMKeyRow{LlmKey: s.stored[id], LlmKeyID: s.storedIDs[id]}, nil
 }
 
-func (s *stubKeyQueries) ClaimUserLLMKey(_ context.Context, arg db.ClaimUserLLMKeyParams) (string, error) {
+func (s *stubKeyQueries) ClaimUserLLMKey(_ context.Context, arg db.ClaimUserLLMKeyParams) (db.ClaimUserLLMKeyRow, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.stored[arg.ID] = arg.LlmKey.String
-	return arg.LlmKey.String, nil
+	s.storedIDs[arg.ID] = arg.LlmKeyID.String
+	return db.ClaimUserLLMKeyRow{LlmKey: arg.LlmKey.String, LlmKeyID: arg.LlmKeyID.String}, nil
 }
 
 func (s *stubKeyQueries) ClearUserLLMKey(_ context.Context, arg db.ClearUserLLMKeyParams) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.stored, arg.ID)
+	delete(s.storedIDs, arg.ID)
 	return nil
 }
 
@@ -102,7 +123,7 @@ func (p *spendProxy) llmClient(t *testing.T) *llm.Client {
 func TestUserLLMSpendsUnderTheCallersOwnCredential(t *testing.T) {
 	proxy := newSpendProxy(t)
 	keys := llmkey.NewResolver(newStubKeyQueries(),
-		llmkey.New(llmkey.Config{BaseURL: newKeyGateway(t, "sk-user-7").URL, AdminKey: "sk-admin"}))
+		llmkey.New(testGatewayConfig(newKeyGateway(t, "sk-user-7").URL)))
 
 	client := userLLM(context.Background(), keys, proxy.llmClient(t), 7, "feature:assistant", "preset:chat")
 	if _, err := client.GenerateJSON(context.Background(), "sys", "usr"); err != nil {
@@ -190,7 +211,7 @@ func TestUserLLMForgetsARejectedCredentialAfterCancellation(t *testing.T) {
 	store := newStubKeyQueries()
 	store.stored[7] = "sk-stale"
 	keys := llmkey.NewResolver(store,
-		llmkey.New(llmkey.Config{BaseURL: newKeyGateway(t, "sk-fresh").URL, AdminKey: "sk-admin"}))
+		llmkey.New(testGatewayConfig(newKeyGateway(t, "sk-fresh").URL)))
 
 	client, err := llm.New(refusing.URL, "sk-service", "test-model")
 	if err != nil {

--- a/internal/api/handler/user_llm_test.go
+++ b/internal/api/handler/user_llm_test.go
@@ -23,9 +23,10 @@ import (
 type spendProxy struct {
 	srv *httptest.Server
 
-	mu    sync.Mutex
-	authz []string
-	tags  []string
+	mu     sync.Mutex
+	authz  []string
+	tags   []string
+	preset []string
 }
 
 func newSpendProxy(t *testing.T) *spendProxy {
@@ -35,6 +36,7 @@ func newSpendProxy(t *testing.T) *spendProxy {
 		p.mu.Lock()
 		p.authz = append(p.authz, r.Header.Get("Authorization"))
 		p.tags = append(p.tags, r.Header.Get("X-Bf-Dim-Feature"))
+		p.preset = append(p.preset, r.Header.Get("X-Bf-Dim-Preset"))
 		p.mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")
@@ -125,7 +127,7 @@ func TestUserLLMSpendsUnderTheCallersOwnCredential(t *testing.T) {
 	keys := llmkey.NewResolver(newStubKeyQueries(),
 		llmkey.New(testGatewayConfig(newKeyGateway(t, "sk-user-7").URL)))
 
-	client := userLLM(context.Background(), keys, proxy.llmClient(t), 7, "feature:assistant", "preset:chat")
+	client := userLLM(context.Background(), keys, proxy.llmClient(t), 7, llm.Feature("assistant"), llm.Dimension{Name: "preset", Value: "chat"})
 	if _, err := client.GenerateJSON(context.Background(), "sys", "usr"); err != nil {
 		t.Fatalf("GenerateJSON: %v", err)
 	}
@@ -135,8 +137,14 @@ func TestUserLLMSpendsUnderTheCallersOwnCredential(t *testing.T) {
 	if proxy.authz[0] != "Bearer sk-user-7" {
 		t.Errorf("call carried %q, want the caller's own credential", proxy.authz[0])
 	}
-	if proxy.tags[0] != "feature:assistant,preset:chat" {
-		t.Errorf("tags = %q, want the feature and the preset", proxy.tags[0])
+	// One header per dimension, and the feature one carries the feature alone. A value
+	// of "assistant,preset:chat" would be neither, and would split the assistant across
+	// as many labels as it has presets.
+	if proxy.tags[0] != "assistant" {
+		t.Errorf("feature = %q, want the feature alone", proxy.tags[0])
+	}
+	if proxy.preset[0] != "chat" {
+		t.Errorf("preset = %q, want the preset under its own dimension", proxy.preset[0])
 	}
 }
 
@@ -146,7 +154,7 @@ func TestUserLLMFallsBackToTheServiceCredential(t *testing.T) {
 	proxy := newSpendProxy(t)
 	keys := llmkey.NewResolver(newStubKeyQueries(), nil) // unconfigured deployment
 
-	client := userLLM(context.Background(), keys, proxy.llmClient(t), 7, "feature:match")
+	client := userLLM(context.Background(), keys, proxy.llmClient(t), 7, llm.Feature("match"))
 	if _, err := client.GenerateJSON(context.Background(), "sys", "usr"); err != nil {
 		t.Fatalf("GenerateJSON: %v", err)
 	}
@@ -156,7 +164,7 @@ func TestUserLLMFallsBackToTheServiceCredential(t *testing.T) {
 	if proxy.authz[0] != "Bearer sk-service" {
 		t.Errorf("call carried %q, want the service credential", proxy.authz[0])
 	}
-	if proxy.tags[0] != "feature:match" {
+	if proxy.tags[0] != "match" {
 		t.Errorf("tags = %q, want the feature named even unattributed", proxy.tags[0])
 	}
 }
@@ -188,7 +196,7 @@ func (nilSafeModel) Chat(context.Context, []llms.MessageContent, []llms.Tool, ll
 
 func TestUserLLMOnAnUnconfiguredModelStaysNil(t *testing.T) {
 	keys := llmkey.NewResolver(newStubKeyQueries(), nil)
-	if got := userLLM(context.Background(), keys, nil, 7, "feature:chat"); got != nil {
+	if got := userLLM(context.Background(), keys, nil, 7, llm.Feature("chat")); got != nil {
 		t.Errorf("userLLM with no model = %v, want nil so callers keep reporting the feature off", got)
 	}
 }
@@ -218,7 +226,7 @@ func TestUserLLMForgetsARejectedCredentialAfterCancellation(t *testing.T) {
 		t.Fatalf("llm.New: %v", err)
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	bound := userLLM(ctx, keys, client, 7, "feature:chat")
+	bound := userLLM(ctx, keys, client, 7, llm.Feature("chat"))
 	cancel() // the caller walks away as the refusal comes back
 
 	if _, err := bound.GenerateJSON(context.Background(), "sys", "usr"); err != nil {

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -91,15 +91,26 @@ type Settings struct {
 	// share the same six values and the same loader; what differs is that policy.
 	LLM
 
-	// LLMAdminURL and LLMAdminKey reach the gateway's administrative API, which mints
-	// the per-user credential each account's calls are spent under. They are named
-	// apart from LLMBaseURL/LLMAPIKey for two reasons: the endpoints genuinely differ
-	// (inference is served under /v1, administration at the root), and separating them
-	// is what later lets LLMAPIKey stop being an administrative credential without a
-	// code change. Either empty disables attribution entirely — every call then goes
-	// out on LLMAPIKey exactly as it did before.
-	LLMAdminURL string
-	LLMAdminKey string
+	// LLMAdminURL, LLMAdminUsername and LLMAdminPassword reach the gateway's
+	// administrative API, which mints the per-user credential each account's calls are
+	// spent under. They are named apart from LLMBaseURL/LLMAPIKey for two reasons: the
+	// endpoints genuinely differ (inference is served under /v1, administration under
+	// /api), and separating them is what lets LLMAPIKey stop being an administrative
+	// credential without a code change. It authenticates with a username and password
+	// rather than a bearer token because the management surface admits exactly one
+	// identity, and it is HTTP Basic.
+	//
+	// LLMAdminTemplateKey names the virtual key whose provider policy every minted
+	// credential copies. It is required rather than optional: the gateway denies every
+	// provider to a key that carries no policy, so minting without it produces
+	// credentials that fail on their first call.
+	//
+	// Any of them empty disables attribution entirely — every call then goes out on
+	// LLMAPIKey exactly as it did before.
+	LLMAdminURL         string
+	LLMAdminUsername    string
+	LLMAdminPassword    string
+	LLMAdminTemplateKey string
 
 	// LLMUserMaxBudget and LLMUserRPMLimit bound one account at the gateway. Both are
 	// unset by default and omitted from a minted credential when zero: a ceiling
@@ -332,7 +343,9 @@ func Load() Settings {
 		RedisURL:              env("REDIS_URL", "redis://localhost:6379/0"),
 
 		LLMAdminURL:         os.Getenv("LLM_ADMIN_URL"),
-		LLMAdminKey:         os.Getenv("LLM_ADMIN_KEY"),
+		LLMAdminUsername:    os.Getenv("LLM_ADMIN_USERNAME"),
+		LLMAdminPassword:    os.Getenv("LLM_ADMIN_PASSWORD"),
+		LLMAdminTemplateKey: os.Getenv("LLM_ADMIN_TEMPLATE_KEY"),
 		LLMUserMaxBudget:    envFloat("LLM_USER_MAX_BUDGET", 0),
 		LLMUserRPMLimit:     envInt("LLM_USER_RPM_LIMIT", 0),
 		LLMUserBudgetWindow: env("LLM_USER_BUDGET_WINDOW", "30d"),

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -22,28 +22,38 @@ func TestLoad_LLMFromEnv(t *testing.T) {
 
 func TestLoad_GatewayAdminFromEnv(t *testing.T) {
 	t.Setenv("LLM_ADMIN_URL", "https://gw.example")
-	t.Setenv("LLM_ADMIN_KEY", "admin-123")
+	t.Setenv("LLM_ADMIN_USERNAME", "admin")
+	t.Setenv("LLM_ADMIN_PASSWORD", "admin-123")
+	t.Setenv("LLM_ADMIN_TEMPLATE_KEY", "vk-freehire-service")
 
 	s := Load()
-	if s.LLMAdminURL != "https://gw.example" || s.LLMAdminKey != "admin-123" {
-		t.Errorf("admin settings = %q/%q, want the env values", s.LLMAdminURL, s.LLMAdminKey)
+	if s.LLMAdminURL != "https://gw.example" || s.LLMAdminUsername != "admin" || s.LLMAdminPassword != "admin-123" {
+		t.Errorf("admin settings = %q/%q/%q, want the env values",
+			s.LLMAdminURL, s.LLMAdminUsername, s.LLMAdminPassword)
+	}
+	// The template key is what a minted credential copies its provider policy from.
+	// Losing it does not disable attribution loudly — it mints keys the gateway then
+	// refuses every provider — so it is read here rather than left to a nil check.
+	if s.LLMAdminTemplateKey != "vk-freehire-service" {
+		t.Errorf("template key = %q, want the env value", s.LLMAdminTemplateKey)
 	}
 }
 
 // The administrative endpoint is NOT the inference one: the gateway serves chat under
-// /v1 and administration at its root. Defaulting one from the other would encode a guess
+// /v1 and administration under /api. Defaulting one from the other would encode a guess
 // about how an operator wrote a URL, and would foreclose keeping the admin API off the
 // public host entirely.
 func TestLoad_GatewayAdminIsNotDerivedFromTheInferenceURL(t *testing.T) {
 	t.Setenv("LLM_BASE_URL", "https://gw.example/v1")
 	t.Setenv("LLM_API_KEY", "key-123")
 	t.Setenv("LLM_ADMIN_URL", "")
-	t.Setenv("LLM_ADMIN_KEY", "")
+	t.Setenv("LLM_ADMIN_USERNAME", "")
+	t.Setenv("LLM_ADMIN_PASSWORD", "")
 
 	s := Load()
-	if s.LLMAdminURL != "" || s.LLMAdminKey != "" {
-		t.Errorf("admin settings = %q/%q, want both empty — an unset admin API disables attribution",
-			s.LLMAdminURL, s.LLMAdminKey)
+	if s.LLMAdminURL != "" || s.LLMAdminUsername != "" || s.LLMAdminPassword != "" {
+		t.Errorf("admin settings = %q/%q/%q, want all empty — an unset admin API disables attribution",
+			s.LLMAdminURL, s.LLMAdminUsername, s.LLMAdminPassword)
 	}
 }
 

--- a/internal/platform/db/llm_keys.sql.go
+++ b/internal/platform/db/llm_keys.sql.go
@@ -13,14 +13,22 @@ import (
 
 const claimUserLLMKey = `-- name: ClaimUserLLMKey :one
 UPDATE users
-SET llm_key = $1
-WHERE id = $2 AND llm_key IS NULL
-RETURNING coalesce(llm_key, '')::text AS llm_key
+SET llm_key = $1,
+    llm_key_id = $2
+WHERE id = $3 AND llm_key IS NULL
+RETURNING coalesce(llm_key, '')::text AS llm_key,
+          coalesce(llm_key_id, '')::text AS llm_key_id
 `
 
 type ClaimUserLLMKeyParams struct {
-	LlmKey pgtype.Text `json:"llm_key"`
-	ID     int64       `json:"id"`
+	LlmKey   pgtype.Text `json:"llm_key"`
+	LlmKeyID pgtype.Text `json:"llm_key_id"`
+	ID       int64       `json:"id"`
+}
+
+type ClaimUserLLMKeyRow struct {
+	LlmKey   string `json:"llm_key"`
+	LlmKeyID string `json:"llm_key_id"`
 }
 
 // Store a freshly minted credential, but only if this account still has none, and report
@@ -31,16 +39,21 @@ type ClaimUserLLMKeyParams struct {
 // The `IS NULL` guard is the whole race resolution: two concurrent first calls both mint,
 // the row lock serializes them, and the loser's UPDATE re-evaluates the guard against the
 // committed row and matches nothing.
-func (q *Queries) ClaimUserLLMKey(ctx context.Context, arg ClaimUserLLMKeyParams) (string, error) {
-	row := q.db.QueryRow(ctx, claimUserLLMKey, arg.LlmKey, arg.ID)
-	var llm_key string
-	err := row.Scan(&llm_key)
-	return llm_key, err
+//
+// The guard stays on llm_key alone. That column is what decides whether an account has a
+// credential at all; guarding on both would let a pre-0119 row — secret set, id null —
+// read as unclaimed and be overwritten, orphaning a key that is still spending.
+func (q *Queries) ClaimUserLLMKey(ctx context.Context, arg ClaimUserLLMKeyParams) (ClaimUserLLMKeyRow, error) {
+	row := q.db.QueryRow(ctx, claimUserLLMKey, arg.LlmKey, arg.LlmKeyID, arg.ID)
+	var i ClaimUserLLMKeyRow
+	err := row.Scan(&i.LlmKey, &i.LlmKeyID)
+	return i, err
 }
 
 const clearUserLLMKey = `-- name: ClearUserLLMKey :exec
 UPDATE users
-SET llm_key = NULL
+SET llm_key = NULL,
+    llm_key_id = NULL
 WHERE id = $1 AND llm_key = $2
 `
 
@@ -53,23 +66,38 @@ type ClearUserLLMKeyParams struct {
 // replacement. Conditional on the value we believe is stored: a concurrent call may have
 // already re-minted, and clearing unconditionally would throw away that good credential
 // and leave it orphaned at the gateway.
+//
+// Both columns clear together. An id left behind would point at a credential nothing can
+// present, and the next mint would then fail a UNIQUE constraint on a value nobody can
+// explain.
 func (q *Queries) ClearUserLLMKey(ctx context.Context, arg ClearUserLLMKeyParams) error {
 	_, err := q.db.Exec(ctx, clearUserLLMKey, arg.ID, arg.LlmKey)
 	return err
 }
 
 const getUserLLMKey = `-- name: GetUserLLMKey :one
-SELECT coalesce(llm_key, '')::text AS llm_key
+SELECT coalesce(llm_key, '')::text AS llm_key,
+       coalesce(llm_key_id, '')::text AS llm_key_id
 FROM users
 WHERE id = $1
 `
 
+type GetUserLLMKeyRow struct {
+	LlmKey   string `json:"llm_key"`
+	LlmKeyID string `json:"llm_key_id"`
+}
+
 // The gateway credential this account is known by, or "" when none has been minted.
 // coalesce keeps the empty string as the single "not minted" signal, so callers test a
 // string rather than unwrapping a nullable through pgtype on every model call.
-func (q *Queries) GetUserLLMKey(ctx context.Context, id int64) (string, error) {
+//
+// The id comes back beside the secret because the two are one credential: the secret is
+// what a model call presents, the id is what an administrative call addresses. A reader
+// that took only the secret could spend but never revoke. The id is separately empty for
+// a credential minted before 0119 — a real state, not a fault; see the migration.
+func (q *Queries) GetUserLLMKey(ctx context.Context, id int64) (GetUserLLMKeyRow, error) {
 	row := q.db.QueryRow(ctx, getUserLLMKey, id)
-	var llm_key string
-	err := row.Scan(&llm_key)
-	return llm_key, err
+	var i GetUserLLMKeyRow
+	err := row.Scan(&i.LlmKey, &i.LlmKeyID)
+	return i, err
 }

--- a/internal/platform/db/models.go
+++ b/internal/platform/db/models.go
@@ -965,6 +965,7 @@ type User struct {
 	TalentNetworkPublicID      uuid.UUID          `json:"talent_network_public_id"`
 	Timezone                   pgtype.Text        `json:"timezone"`
 	Language                   string             `json:"language"`
+	LlmKeyID                   pgtype.Text        `json:"llm_key_id"`
 }
 
 type UserEmailCode struct {

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -325,7 +325,11 @@ type Querier interface {
 	// The `IS NULL` guard is the whole race resolution: two concurrent first calls both mint,
 	// the row lock serializes them, and the loser's UPDATE re-evaluates the guard against the
 	// committed row and matches nothing.
-	ClaimUserLLMKey(ctx context.Context, arg ClaimUserLLMKeyParams) (string, error)
+	//
+	// The guard stays on llm_key alone. That column is what decides whether an account has a
+	// credential at all; guarding on both would let a pre-0119 row — secret set, id null —
+	// read as unclaimed and be overwritten, orphaning a key that is still spending.
+	ClaimUserLLMKey(ctx context.Context, arg ClaimUserLLMKeyParams) (ClaimUserLLMKeyRow, error)
 	// Drop an application's pipeline progress while keeping the record — the notes are the
 	// candidate's own text, and reconsidering is not a claim the process never happened.
 	// Clearing both stage and applied_at is what takes it off the board (see columnOf).
@@ -371,6 +375,10 @@ type Querier interface {
 	// replacement. Conditional on the value we believe is stored: a concurrent call may have
 	// already re-minted, and clearing unconditionally would throw away that good credential
 	// and leave it orphaned at the gateway.
+	//
+	// Both columns clear together. An id left behind would point at a credential nothing can
+	// present, and the next mint would then fail a UNIQUE constraint on a value nobody can
+	// explain.
 	ClearUserLLMKey(ctx context.Context, arg ClearUserLLMKeyParams) error
 	// Clear the user's headshot pointer, after deleting the object from storage.
 	ClearUserPhoto(ctx context.Context, id int64) error
@@ -1556,7 +1564,12 @@ type Querier interface {
 	// The gateway credential this account is known by, or "" when none has been minted.
 	// coalesce keeps the empty string as the single "not minted" signal, so callers test a
 	// string rather than unwrapping a nullable through pgtype on every model call.
-	GetUserLLMKey(ctx context.Context, id int64) (string, error)
+	//
+	// The id comes back beside the secret because the two are one credential: the secret is
+	// what a model call presents, the id is what an administrative call addresses. A reader
+	// that took only the secret could spend but never revoke. The id is separately empty for
+	// a credential minted before 0119 — a real state, not a fault; see the migration.
+	GetUserLLMKey(ctx context.Context, id int64) (GetUserLLMKeyRow, error)
 	// The account's preferred interface language on its own, for a caller that needs
 	// nothing else about the user — the assistant's turn loop and the fit-analysis
 	// chain both build a language directive from just this column. Never NULL (NOT

--- a/internal/platform/db/queries/llm_keys.sql
+++ b/internal/platform/db/queries/llm_keys.sql
@@ -2,7 +2,13 @@
 -- The gateway credential this account is known by, or "" when none has been minted.
 -- coalesce keeps the empty string as the single "not minted" signal, so callers test a
 -- string rather than unwrapping a nullable through pgtype on every model call.
-SELECT coalesce(llm_key, '')::text AS llm_key
+--
+-- The id comes back beside the secret because the two are one credential: the secret is
+-- what a model call presents, the id is what an administrative call addresses. A reader
+-- that took only the secret could spend but never revoke. The id is separately empty for
+-- a credential minted before 0119 — a real state, not a fault; see the migration.
+SELECT coalesce(llm_key, '')::text AS llm_key,
+       coalesce(llm_key_id, '')::text AS llm_key_id
 FROM users
 WHERE id = $1;
 
@@ -15,16 +21,27 @@ WHERE id = $1;
 -- The `IS NULL` guard is the whole race resolution: two concurrent first calls both mint,
 -- the row lock serializes them, and the loser's UPDATE re-evaluates the guard against the
 -- committed row and matches nothing.
+--
+-- The guard stays on llm_key alone. That column is what decides whether an account has a
+-- credential at all; guarding on both would let a pre-0119 row — secret set, id null —
+-- read as unclaimed and be overwritten, orphaning a key that is still spending.
 UPDATE users
-SET llm_key = sqlc.arg(llm_key)
+SET llm_key = sqlc.arg(llm_key),
+    llm_key_id = sqlc.arg(llm_key_id)
 WHERE id = sqlc.arg(id) AND llm_key IS NULL
-RETURNING coalesce(llm_key, '')::text AS llm_key;
+RETURNING coalesce(llm_key, '')::text AS llm_key,
+          coalesce(llm_key_id, '')::text AS llm_key_id;
 
 -- name: ClearUserLLMKey :exec
 -- Forget a credential the gateway no longer recognises, so the next call mints a
 -- replacement. Conditional on the value we believe is stored: a concurrent call may have
 -- already re-minted, and clearing unconditionally would throw away that good credential
 -- and leave it orphaned at the gateway.
+--
+-- Both columns clear together. An id left behind would point at a credential nothing can
+-- present, and the next mint would then fail a UNIQUE constraint on a value nobody can
+-- explain.
 UPDATE users
-SET llm_key = NULL
+SET llm_key = NULL,
+    llm_key_id = NULL
 WHERE id = sqlc.arg(id) AND llm_key = sqlc.arg(llm_key);

--- a/internal/platform/llm/credential.go
+++ b/internal/platform/llm/credential.go
@@ -32,6 +32,23 @@ type Dimension struct {
 	Value string
 }
 
+// stamp writes each dimension onto a request as its own header. Both the original call
+// and the one replayed on the fallback credential go through here: a retry that dropped
+// the dimensions would file its spend under nothing, and the retry is exactly the case
+// where somebody later asks what happened.
+//
+// A half-named dimension is skipped rather than sent. `x-bf-dim-: value` is not a header
+// the gateway can group by, and an empty value is indistinguishable from an absent one at
+// the far end — so neither is worth a wire byte.
+func stamp(req *http.Request, dims []Dimension) {
+	for _, d := range dims {
+		if d.Name == "" || d.Value == "" {
+			continue
+		}
+		req.Header.Set(dimPrefix+d.Name, d.Value)
+	}
+}
+
 // Feature names the surface a call served. It is the dimension every per-user call
 // carries; see the constants in internal/api/handler/user_llm.go.
 func Feature(value string) Dimension { return Dimension{Name: "feature", Value: value} }
@@ -146,12 +163,7 @@ func (t *attribution) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	// A RoundTripper must not mutate the request it is given.
 	clone := req.Clone(req.Context())
-	for _, d := range t.dims {
-		if d.Name == "" || d.Value == "" {
-			continue
-		}
-		clone.Header.Set(dimPrefix+d.Name, d.Value)
-	}
+	stamp(clone, t.dims)
 
 	resp, err := next.RoundTrip(clone)
 	if err != nil || resp.StatusCode != http.StatusUnauthorized || t.fallback == "" {
@@ -189,12 +201,7 @@ func replay(req *http.Request, credential string, dims []Dimension) (*http.Reque
 		clone.Body = body
 	}
 	clone.Header.Set("Authorization", "Bearer "+credential)
-	for _, d := range dims {
-		if d.Name == "" || d.Value == "" {
-			continue
-		}
-		clone.Header.Set(dimPrefix+d.Name, d.Value)
-	}
+	stamp(clone, dims)
 
 	return clone, true
 }

--- a/internal/platform/llm/credential.go
+++ b/internal/platform/llm/credential.go
@@ -3,7 +3,6 @@ package llm
 import (
 	"log"
 	"net/http"
-	"strings"
 
 	"github.com/tmc/langchaingo/httputil"
 	"github.com/tmc/langchaingo/llms/openai"
@@ -17,7 +16,25 @@ import (
 // in the gateway's own prometheus_labels — onto every metric the call produces. That last
 // one is what makes "what does tailoring cost" answerable without a table of our own; it
 // is a Grafana question here rather than a SQL one.
-const tagHeader = "x-bf-dim-feature"
+const dimPrefix = "x-bf-dim-"
+
+// Dimension is one axis the gateway files a call under: a name and a value, sent as
+// `x-bf-dim-<name>: <value>`.
+//
+// A named pair rather than a list of opaque strings, because the gateway gives each
+// dimension its own header and each header one value. The shape this replaces — a
+// variadic list joined with commas — was the previous gateway's, which took
+// `key:value` pairs in one header and split them itself. Carried across unchanged it
+// filed the assistant under six values named "assistant,preset:chat" and its variants,
+// none of which was "assistant".
+type Dimension struct {
+	Name  string
+	Value string
+}
+
+// Feature names the surface a call served. It is the dimension every per-user call
+// carries; see the constants in internal/api/handler/user_llm.go.
+func Feature(value string) Dimension { return Dimension{Name: "feature", Value: value} }
 
 // As returns a client that spends under a given credential and labels its calls.
 //
@@ -37,11 +54,11 @@ const tagHeader = "x-bf-dim-feature"
 //
 // A failure to rebuild returns the receiver. Losing attribution is a log line; failing the
 // caller's request over bookkeeping is not a trade this package gets to make.
-func (c *Client) As(secret string, onRefused func(), tags ...string) *Client {
+func (c *Client) As(secret string, onRefused func(), dims ...Dimension) *Client {
 	if c == nil {
 		return nil
 	}
-	if secret == "" && len(tags) == 0 {
+	if secret == "" && len(dims) == 0 {
 		return c
 	}
 	if c.baseURL == "" {
@@ -65,7 +82,7 @@ func (c *Client) As(secret string, onRefused func(), tags ...string) *Client {
 		clone.apiKey = secret
 		clone.onRefused = onRefused
 	}
-	clone.tags = tags
+	clone.dims = dims
 
 	// The schema-model cache MUST NOT be shared with the client this was cloned from.
 	// It is keyed on the schema's name and rendered shape and on nothing else, so a
@@ -94,11 +111,11 @@ func (c *Client) As(secret string, onRefused func(), tags ...string) *Client {
 // Schema-bound models build on top of it, so a tagged client's schema calls are tagged
 // too.
 func (c *Client) transport() http.RoundTripper {
-	if len(c.tags) == 0 && c.fallbackKey == "" {
+	if len(c.dims) == 0 && c.fallbackKey == "" {
 		return httputil.DefaultTransport
 	}
 	return &attribution{
-		tags:      strings.Join(c.tags, ","),
+		dims:      c.dims,
 		fallback:  c.fallbackKey,
 		onRefused: c.onRefused,
 		// next is langchaingo's own transport, which stamps the library's User-Agent.
@@ -117,7 +134,7 @@ func (c *Client) transport() http.RoundTripper {
 // library reworded it, silently. The status code does not move.
 type attribution struct {
 	next      http.RoundTripper
-	tags      string
+	dims      []Dimension
 	fallback  string
 	onRefused func()
 }
@@ -129,8 +146,11 @@ func (t *attribution) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	// A RoundTripper must not mutate the request it is given.
 	clone := req.Clone(req.Context())
-	if t.tags != "" {
-		clone.Header.Set(tagHeader, t.tags)
+	for _, d := range t.dims {
+		if d.Name == "" || d.Value == "" {
+			continue
+		}
+		clone.Header.Set(dimPrefix+d.Name, d.Value)
 	}
 
 	resp, err := next.RoundTrip(clone)
@@ -141,7 +161,7 @@ func (t *attribution) RoundTrip(req *http.Request) (*http.Response, error) {
 	// The gateway does not know this credential. Retry once on the one it does — and
 	// only once: a gateway refusing the fallback too is a misconfiguration, and looping
 	// on it would turn one bad key into a request storm.
-	retry, ok := replay(req, t.fallback, t.tags)
+	retry, ok := replay(req, t.fallback, t.dims)
 	if !ok {
 		return resp, nil
 	}
@@ -156,7 +176,7 @@ func (t *attribution) RoundTrip(req *http.Request) (*http.Response, error) {
 // replay rebuilds a request under a different credential. It reports failure rather than
 // erroring, because a body that cannot be replayed means the original response — refusal
 // and all — is still the honest answer to give back.
-func replay(req *http.Request, credential, tags string) (*http.Request, bool) {
+func replay(req *http.Request, credential string, dims []Dimension) (*http.Request, bool) {
 	if req.Body != nil && req.GetBody == nil {
 		return nil, false
 	}
@@ -169,8 +189,11 @@ func replay(req *http.Request, credential, tags string) (*http.Request, bool) {
 		clone.Body = body
 	}
 	clone.Header.Set("Authorization", "Bearer "+credential)
-	if tags != "" {
-		clone.Header.Set(tagHeader, tags)
+	for _, d := range dims {
+		if d.Name == "" || d.Value == "" {
+			continue
+		}
+		clone.Header.Set(dimPrefix+d.Name, d.Value)
 	}
 
 	return clone, true

--- a/internal/platform/llm/credential.go
+++ b/internal/platform/llm/credential.go
@@ -9,10 +9,15 @@ import (
 	"github.com/tmc/langchaingo/llms/openai"
 )
 
-// tagHeader is how the gateway is told which feature a call served. It files one spend
-// row per tag per day, which is what makes "what does tailoring cost" answerable without
-// a table of our own.
-const tagHeader = "x-litellm-tags"
+// tagHeader is how the gateway is told which feature a call served.
+//
+// The header names the DIMENSION and carries only the value, which is why the feature
+// constants above it are bare words rather than "feature:x" pairs. The gateway files the
+// value onto the request log, its OpenTelemetry span, and — provided "feature" is listed
+// in the gateway's own prometheus_labels — onto every metric the call produces. That last
+// one is what makes "what does tailoring cost" answerable without a table of our own; it
+// is a Grafana question here rather than a SQL one.
+const tagHeader = "x-bf-dim-feature"
 
 // As returns a client that spends under a given credential and labels its calls.
 //

--- a/internal/platform/llm/credential_test.go
+++ b/internal/platform/llm/credential_test.go
@@ -18,9 +18,10 @@ import (
 type headerProxy struct {
 	srv *httptest.Server
 
-	mu    sync.Mutex
-	authz []string
-	tags  []string
+	mu     sync.Mutex
+	authz  []string
+	tags   []string
+	preset []string
 }
 
 func newHeaderProxy(t *testing.T) *headerProxy {
@@ -33,6 +34,7 @@ func newHeaderProxy(t *testing.T) *headerProxy {
 		p.mu.Lock()
 		p.authz = append(p.authz, r.Header.Get("Authorization"))
 		p.tags = append(p.tags, r.Header.Get("X-Bf-Dim-Feature"))
+		p.preset = append(p.preset, r.Header.Get("X-Bf-Dim-Preset"))
 		p.mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")
@@ -71,8 +73,8 @@ func TestAsDoesNotShareSchemaBoundModelsAcrossCredentials(t *testing.T) {
 	base := proxy.client(t)
 	schema := testSchema(t)
 
-	alice := base.As("sk-alice", nil, "feature:tailor")
-	bob := base.As("sk-bob", nil, "feature:tailor")
+	alice := base.As("sk-alice", nil, Feature("tailor"))
+	bob := base.As("sk-bob", nil, Feature("tailor"))
 
 	if _, err := alice.GenerateJSON(context.Background(), "sys", "usr", WithSchema("shape", schema)); err != nil {
 		t.Fatalf("alice: %v", err)
@@ -100,7 +102,7 @@ func TestAsRecreditsThePlainPath(t *testing.T) {
 	proxy := newHeaderProxy(t)
 	base := proxy.client(t)
 
-	if _, err := base.As("sk-alice", nil, "feature:chat").GenerateJSON(context.Background(), "sys", "usr"); err != nil {
+	if _, err := base.As("sk-alice", nil, Feature("chat")).GenerateJSON(context.Background(), "sys", "usr"); err != nil {
 		t.Fatalf("GenerateJSON: %v", err)
 	}
 
@@ -110,18 +112,28 @@ func TestAsRecreditsThePlainPath(t *testing.T) {
 	}
 }
 
-func TestAsTagsTheCall(t *testing.T) {
+// Each dimension travels in its own header, and the feature one carries the feature
+// ALONE. This is the whole reason Dimension exists: the previous gateway took a
+// comma-separated list of key:value pairs in one header and split them itself, and
+// carrying that shape across filed the assistant under "assistant,preset:tailor" — a
+// value that is neither the feature nor the preset, and that splits one surface across as
+// many labels as it has presets.
+func TestAsSendsOneHeaderPerDimension(t *testing.T) {
 	proxy := newHeaderProxy(t)
 	base := proxy.client(t)
 
-	if _, err := base.As("sk-alice", nil, "feature:assistant", "preset:tailor").
+	if _, err := base.As("sk-alice", nil, Feature("assistant"), Dimension{Name: "preset", Value: "tailor"}).
 		GenerateJSON(context.Background(), "sys", "usr"); err != nil {
 		t.Fatalf("GenerateJSON: %v", err)
 	}
 
-	_, tags := proxy.seen(t)
-	if tags[0] != "feature:assistant,preset:tailor" {
-		t.Errorf("tags = %q, want both tags — the gateway files one spend row per tag", tags[0])
+	proxy.mu.Lock()
+	defer proxy.mu.Unlock()
+	if proxy.tags[0] != "assistant" {
+		t.Errorf("feature = %q, want the feature alone — a value carrying the preset is a label nobody can group by", proxy.tags[0])
+	}
+	if proxy.preset[0] != "tailor" {
+		t.Errorf("preset = %q, want the preset under its own dimension", proxy.preset[0])
 	}
 }
 
@@ -131,7 +143,7 @@ func TestAsWithoutACredentialStillTags(t *testing.T) {
 	proxy := newHeaderProxy(t)
 	base := proxy.client(t)
 
-	if _, err := base.As("", nil, "feature:match").GenerateJSON(context.Background(), "sys", "usr"); err != nil {
+	if _, err := base.As("", nil, Feature("match")).GenerateJSON(context.Background(), "sys", "usr"); err != nil {
 		t.Fatalf("GenerateJSON: %v", err)
 	}
 
@@ -139,7 +151,7 @@ func TestAsWithoutACredentialStillTags(t *testing.T) {
 	if authz[0] != "Bearer sk-service" {
 		t.Errorf("call carried %q, want the service credential when no user credential resolved", authz[0])
 	}
-	if tags[0] != "feature:match" {
+	if tags[0] != "match" {
 		t.Errorf("tags = %q, want the feature tag even on an unattributed call", tags[0])
 	}
 }
@@ -157,7 +169,7 @@ func TestAsWithNeitherCredentialNorTagsIsTheSameClient(t *testing.T) {
 
 func TestAsIsNilSafe(t *testing.T) {
 	var c *Client
-	if got := c.As("sk-alice", nil, "feature:chat"); got != nil {
+	if got := c.As("sk-alice", nil, Feature("chat")); got != nil {
 		t.Errorf("As on a nil client = %v, want nil", got)
 	}
 }
@@ -166,7 +178,7 @@ func TestAsKeepsTheModelAndTimeout(t *testing.T) {
 	proxy := newHeaderProxy(t)
 	base := proxy.client(t).WithTimeout(1234)
 
-	clone := base.As("sk-alice", nil, "feature:chat")
+	clone := base.As("sk-alice", nil, Feature("chat"))
 	if clone.ModelID() != base.ModelID() {
 		t.Errorf("model = %q, want %q", clone.ModelID(), base.ModelID())
 	}
@@ -179,7 +191,7 @@ func TestAsKeepsTheModelAndTimeout(t *testing.T) {
 // re-crediting it is ignored the way a schema there is ignored — never fatal.
 func TestAsOnAnInjectedModelIsAPassthrough(t *testing.T) {
 	injected := NewWithModel(stubModel{})
-	if got := injected.As("sk-alice", nil, "feature:chat"); got != injected {
+	if got := injected.As("sk-alice", nil, Feature("chat")); got != injected {
 		t.Error("As on an injected model should return the receiver, not a client with no endpoint")
 	}
 }
@@ -193,6 +205,7 @@ func newRefusingProxy(t *testing.T, refuse string) *headerProxy {
 		p.mu.Lock()
 		p.authz = append(p.authz, r.Header.Get("Authorization"))
 		p.tags = append(p.tags, r.Header.Get("X-Bf-Dim-Feature"))
+		p.preset = append(p.preset, r.Header.Get("X-Bf-Dim-Preset"))
 		p.mu.Unlock()
 
 		if r.Header.Get("Authorization") == "Bearer "+refuse {
@@ -216,7 +229,7 @@ func TestARefusedCredentialFallsBackAndReportsItself(t *testing.T) {
 	base := proxy.client(t)
 
 	var refused int
-	clone := base.As("sk-stale", func() { refused++ }, "feature:chat")
+	clone := base.As("sk-stale", func() { refused++ }, Feature("chat"))
 
 	if _, err := clone.GenerateJSON(context.Background(), "sys", "usr"); err != nil {
 		t.Fatalf("a refused user credential must not fail the call: %v", err)
@@ -232,7 +245,7 @@ func TestARefusedCredentialFallsBackAndReportsItself(t *testing.T) {
 	if authz[0] != "Bearer sk-stale" || authz[1] != "Bearer sk-service" {
 		t.Errorf("credentials = %v, want the user's then the service one", authz)
 	}
-	if tags[1] != "feature:chat" {
+	if tags[1] != "chat" {
 		t.Errorf("retry tags = %q, want the feature still named on the fallback", tags[1])
 	}
 }
@@ -245,9 +258,9 @@ func TestAsChainedTwiceFallsBackToTheServiceCredentialNotAPriorUser(t *testing.T
 	proxy := newRefusingProxy(t, "sk-bob")
 	base := proxy.client(t)
 
-	alice := base.As("sk-alice", nil, "feature:tailor")
+	alice := base.As("sk-alice", nil, Feature("tailor"))
 	var refused int
-	bob := alice.As("sk-bob", func() { refused++ }, "feature:tailor")
+	bob := alice.As("sk-bob", func() { refused++ }, Feature("tailor"))
 
 	if _, err := bob.GenerateJSON(context.Background(), "sys", "usr"); err != nil {
 		t.Fatalf("a refused user credential must not fail the call: %v", err)
@@ -278,7 +291,7 @@ func TestARefusalIsRetriedOnlyOnce(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	_, _ = base.As("sk-service", nil, "feature:chat").GenerateJSON(context.Background(), "sys", "usr")
+	_, _ = base.As("sk-service", nil, Feature("chat")).GenerateJSON(context.Background(), "sys", "usr")
 
 	served, _ := proxy.seen(t)
 	if len(served) > 2 {
@@ -306,7 +319,7 @@ func TestACeilingRefusalIsNotRetried(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 	var refused int
-	_, _ = base.As("sk-capped", func() { refused++ }, "feature:chat").
+	_, _ = base.As("sk-capped", func() { refused++ }, Feature("chat")).
 		GenerateJSON(context.Background(), "sys", "usr")
 
 	if served != 1 {
@@ -323,7 +336,7 @@ func TestAnUnattributedCallIsNotRetried(t *testing.T) {
 	proxy := newRefusingProxy(t, "sk-service")
 	base := proxy.client(t)
 
-	_, _ = base.As("", nil, "feature:chat").GenerateJSON(context.Background(), "sys", "usr")
+	_, _ = base.As("", nil, Feature("chat")).GenerateJSON(context.Background(), "sys", "usr")
 
 	authz, _ := proxy.seen(t)
 	if len(authz) != 1 {

--- a/internal/platform/llm/credential_test.go
+++ b/internal/platform/llm/credential_test.go
@@ -32,7 +32,7 @@ func newHeaderProxy(t *testing.T) *headerProxy {
 
 		p.mu.Lock()
 		p.authz = append(p.authz, r.Header.Get("Authorization"))
-		p.tags = append(p.tags, r.Header.Get("X-Litellm-Tags"))
+		p.tags = append(p.tags, r.Header.Get("X-Bf-Dim-Feature"))
 		p.mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")
@@ -192,7 +192,7 @@ func newRefusingProxy(t *testing.T, refuse string) *headerProxy {
 	p.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		p.mu.Lock()
 		p.authz = append(p.authz, r.Header.Get("Authorization"))
-		p.tags = append(p.tags, r.Header.Get("X-Litellm-Tags"))
+		p.tags = append(p.tags, r.Header.Get("X-Bf-Dim-Feature"))
 		p.mu.Unlock()
 
 		if r.Header.Get("Authorization") == "Bearer "+refuse {

--- a/internal/platform/llm/llm.go
+++ b/internal/platform/llm/llm.go
@@ -49,10 +49,10 @@ type Client struct {
 	baseURL string
 	apiKey  string
 
-	// tags label each call for the gateway's per-feature spend rollup. Set by As and
-	// empty otherwise, so a client nobody re-credentialed sends exactly what it always
-	// did.
-	tags []string
+	// dims label each call for the gateway's per-feature spend rollup, one header per
+	// dimension. Set by As and empty otherwise, so a client nobody re-credentialed sends
+	// exactly what it always did.
+	dims []Dimension
 
 	// fallbackKey and onRefused belong to a client bound to a per-user credential: the
 	// credential to retry on when the gateway no longer knows that user's, and how to

--- a/migrations/0119_user_llm_key_id.sql
+++ b/migrations/0119_user_llm_key_id.sql
@@ -21,7 +21,15 @@
 -- delete each other's credential, and the wrongness would surface as somebody else's
 -- account losing AI, far from the cause.
 --
--- One nullable column: no rewrite, no default, no lock of consequence. Additive and
+-- The UNIQUE constraint builds an index under ACCESS EXCLUSIVE, which is the one thing
+-- here that blocks. It is the same shape 0067 took for the secret and for the same table,
+-- and `users` is small enough that the scan is milliseconds — but it does queue behind and
+-- ahead of anything else touching the table, so run it like any other DDL: not while the
+-- nightly dump holds its locks. If `users` ever grows past that assumption, the escape is
+-- CREATE UNIQUE INDEX CONCURRENTLY followed by ADD CONSTRAINT ... USING INDEX, which needs
+-- its own migration because CONCURRENTLY cannot run inside a transaction.
+--
+-- One nullable column: no rewrite, no default. Additive and
 -- unread by the previous binary, so deploy order does not matter and a rollback leaves
 -- the column harmlessly behind.
 ALTER TABLE public.users

--- a/migrations/0119_user_llm_key_id.sql
+++ b/migrations/0119_user_llm_key_id.sql
@@ -1,0 +1,31 @@
+-- The gateway's OWN identifier for the credential in users.llm_key.
+--
+-- 0067 stored the secret and nothing else, because the gateway it was written for
+-- addressed a key by its secret: block and delete both took `{"key": "sk-..."}`. The
+-- gateway being migrated to addresses a key by an opaque id instead, and only by that —
+-- a PUT or DELETE aimed at the secret answers 404. Without this column an account's
+-- credential can be minted and spent but never blocked, which is precisely what account
+-- deletion needs to do.
+--
+-- Two columns rather than one composite value. They are written in the same statement
+-- and read together, so packing them into one string would save a column and cost every
+-- reader a parse, plus a way to be wrong about the separator.
+--
+-- Nullable with no backfill, for the same reason 0067 was: an id cannot be derived for a
+-- credential minted by the old gateway. Those rows keep working for inference — the
+-- secret is all a model call needs — and the first time one of them is refused, the
+-- existing forget-and-re-mint path replaces it with a pair. Nothing has to migrate; the
+-- population drains on its own.
+--
+-- UNIQUE for the same reason the secret is: two accounts sharing an id would block or
+-- delete each other's credential, and the wrongness would surface as somebody else's
+-- account losing AI, far from the cause.
+--
+-- One nullable column: no rewrite, no default, no lock of consequence. Additive and
+-- unread by the previous binary, so deploy order does not matter and a rollback leaves
+-- the column harmlessly behind.
+ALTER TABLE public.users
+    ADD COLUMN llm_key_id text;
+
+ALTER TABLE public.users
+    ADD CONSTRAINT users_llm_key_id_key UNIQUE (llm_key_id);

--- a/openspec/changes/move-llm-gateway-to-bifrost/design.md
+++ b/openspec/changes/move-llm-gateway-to-bifrost/design.md
@@ -1,0 +1,61 @@
+## Context
+
+The gateway swap is mostly an operations change: `provision/bifrost/` in freehire-ops carries the compose file, the config generator and the measurements. What reaches this repository is narrow, because LiteLLM leaked into only three places — four admin endpoints in `internal/ai/llmkey`, one header constant in `internal/platform/llm`, and the audio surfaces.
+
+## Decisions
+
+### Store the credential id rather than deriving or looking it up
+
+Bifrost's create API does not accept a caller-chosen id, and its `PUT`/`DELETE` routes accept nothing else — aimed at the `sk-bf-…` secret they answer 404 (measured). Three options were live:
+
+1. **A second column.** One nullable `text` with a unique constraint.
+2. **Pack both into `users.llm_key`.** Saves a column, costs every reader a parse and adds a way to be wrong about the separator.
+3. **Look the key up by name.** `name` is deterministic (`freehire-user-<id>`), but the governance API offers no lookup by name — it would mean listing every virtual key on each block.
+
+(1). The two values are written and read together, which is what a second column is for.
+
+**Why the guard on `ClaimUserLLMKey` stays on `llm_key` alone:** that column decides whether an account has a credential at all. Guarding on both would let a pre-0119 row — secret set, id null — read as unclaimed and be overwritten, orphaning a key that is still spending.
+
+### Copy the provider policy from a template key
+
+A virtual key with no `provider_configs` is denied every provider (deny-by-default, measured: *"could not auto resolve a provider"* on every call). Teams carry budgets only, so there is nothing to inherit. Every minted key must therefore carry a policy, and the question is where it comes from.
+
+Carrying it in this service's configuration — an env var holding a JSON array, or a provider list in Go — would put the provider vocabulary in two places, and adding a provider would become a deployment of freehire rather than an edit to the gateway's own config. Instead `Mint` reads the virtual key named by `LLM_ADMIN_TEMPLATE_KEY` and copies its `provider_configs`. Verified end to end: the clone serves traffic, and this repository still names no provider.
+
+The cost is one extra admin call per mint. Minting happens once per account, on its first AI call, so it is bounded by new accounts rather than by traffic.
+
+**`TemplateKey` is required configuration, not optional.** Without it a client would mint successfully and every credential it produced would fail on first use — an outage that reads as a model fault. `New` returns nil instead, which is the same absent-not-broken answer the package already gives for a missing URL.
+
+**One asymmetry:** a read answers `key_ids` as `null` where a write requires `["*"]`. Echoing the read back mints a key pinned to no provider key at all, so the copy normalises rather than echoes.
+
+### `/me/usage` narrows, and the alternative was worse
+
+The old gateway aggregated by an account id we already had, so a key replaced mid-month still reported everything. Bifrost keys its log by the credential id and offers no account-scoped query. Two options:
+
+1. **Report the current credential only.** A re-mint loses the earlier key's calls from the figure.
+2. **Remember retired ids and sum them.** Complete, at the price of a growing list of dead credentials kept alive to serve a usage counter.
+
+(1). Re-minting happens only when the gateway refuses a stored key, which is rare; keeping a graveyard to make a counter marginally more complete is not a trade worth a table.
+
+A consequence for the handler: `newUsageHandlers` now takes the resolver, and takes it to READ. `Stored`, never `For` — minting there would issue a credential to every visitor who opened the page out of curiosity.
+
+### Switch audio off in the SPA, do not delete it
+
+Both audio surfaces already latch themselves away when the server answers 501, and the Go side already answers 501 when unconfigured — so "off" needed no Go change at all. What it needed was the affordance not to appear: without a client-side switch the microphone renders, records, fails once, and only then disappears, which is a worse first impression than no microphone.
+
+Commenting the markup out was rejected: two independent surfaces switched by one decision want one named constant with the reason attached, not two blocks of dead markup that rot. `AUDIO_ENABLED` in `web/src/lib/assistant/audioAvailability.ts` gates both mount points; the capability checks under it (`canRecord`, `canUseVoiceCall`) are untouched, so their tests keep testing what they were written for.
+
+### Feature tags become bare words
+
+`x-bf-dim-feature` names the dimension in the header. Keeping `feature:assistant` as the value would file spend under `feature:feature:assistant`-shaped labels and split one surface in two the day somebody wrote it the other way. The test that used to require the prefix now forbids a colon.
+
+## Risks / Trade-offs
+
+- **Per-feature cost stops being a SQL question.** The dimension reaches the log row, the OTel span, and the Prometheus labels — but `/api/logs/histogram/cost/by-dimension` aggregates only by provider, team, customer, user and business unit. "What does tailoring cost" becomes a Grafana query. Accepted: the figure is for us, not for users, and it is still answerable.
+- **The usage log lands ~5s after the call.** Harmless over a month; fatal to any read-after-write assumption. Recorded in the package contract.
+- **Dead keys cost availability differently.** Bifrost's dead-key set is per request, not a cooldown, so on a pool where most keys are dead the retry budget matters — measured at 1 failure in 6 with the default budget of 2. That is tuned in the gateway's own config (`provision/bifrost/gen-config.sh`), not here.
+
+## Open Questions
+
+- Which model each alias should point at. `flagship` currently resolves to a reasoning model on a free coding plan and shows a 38–70s tail on enrichment, inside the range where a 90s client timeout starts killing runs. This is a gateway-config question and belongs to a follow-on.
+- Whether audio moves to a second gateway rather than waiting for this one. `LLM_BASE_URL` is one variable; nothing forces speech and chat through the same host.

--- a/openspec/changes/move-llm-gateway-to-bifrost/proposal.md
+++ b/openspec/changes/move-llm-gateway-to-bifrost/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The LLM gateway is being replaced. LiteLLM needs one *deployment* entry per key × model, which is how its production config reached 164 entries for a 44-key pool, and it has no per-key cooldown story that survives a pool where most keys are dead. A candidate — Bifrost — was stood up beside it on the same host and the same key pool, and measured rather than read about:
+
+- **Cross-provider fallback works from configuration alone.** A virtual key carrying weighted `provider_configs` picks a primary and files the rest as fallbacks. Observed live: Z.AI failed → Gemini failed → Mistral answered, one user-facing request. The caller sends no `fallbacks` array.
+- **Structured output is not worse, and is better on Mistral.** Ten runs of the exact `response_format: json_schema` this repo builds: `gemini-2.5-flash` scored 7/10 through either gateway; `mistral-large-latest` scored 2/10 through LiteLLM and 10/10 through Bifrost.
+- **Streamed tool calls arrive whole.** The fragmentation `mergeToolCallFragments` exists to repair does not reproduce, verified to an 1851-byte argument.
+- **Spend history outlives the credential.** LiteLLM hangs the spend record off the key, which is why `internal/ai/llmkey` blocks rather than deletes. Bifrost keys its usage log by the credential's id; a deleted key's figures survive.
+
+Three things about the replacement force code changes rather than an environment edit, and they are what this change is for.
+
+## What Changes
+
+- **A credential becomes two values.** Bifrost addresses a virtual key by an opaque id and answers 404 to anything aimed at the secret, so a stored secret alone can spend but never be revoked — which is what account deletion has to do. Add `users.llm_key_id`; write and clear it with the secret.
+- **Minting reads its provider policy instead of carrying one.** A virtual key with no `provider_configs` is refused every provider. Rather than duplicate the provider list into this service's configuration, `Mint` copies it from a template virtual key named by `LLM_ADMIN_TEMPLATE_KEY`.
+- **The administrative surface changes shape.** Four endpoints move under `/api/governance/...` and `/api/logs/stats`, and authenticate over HTTP Basic rather than a bearer token. `LLM_ADMIN_KEY` retires in favour of `LLM_ADMIN_USERNAME` / `LLM_ADMIN_PASSWORD` / `LLM_ADMIN_TEMPLATE_KEY`.
+- **The feature tag changes header and shape.** `x-litellm-tags: feature:assistant` becomes `x-bf-dim-feature: assistant` — the header names the dimension, so the value is a bare word.
+- **`/me/usage` narrows to the current credential.** Bifrost offers no way to ask by account, so a key replaced mid-month leaves the earlier one's calls out of the figure.
+- **Audio goes dark.** Dictation and voice mode reach the gateway too, and the replacement's `/v1/audio/transcriptions` and `/v1/realtime/client_secrets` have never been exercised against it — the pool behind it carries no OpenAI credential. The Go side already degrades to 501 when unconfigured; the SPA gains a matching switch so the microphone is absent rather than present-then-broken.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `llm-spend-attribution`: the per-user gateway credential becomes an (id, secret) pair, mints its provider policy from a template rather than from configuration, and reports usage scoped to one credential.
+- `speech-to-text`: audio is unavailable while the gateway migration leaves its audio routes unproven, and the SPA suppresses the affordance rather than offering one that fails.
+
+### Removed Capabilities
+
+<!-- None. Audio is switched off, not removed: no code was deleted and one constant restores it. -->
+
+## Impact
+
+- **Deploy order matters.** Migration 0119 must land before the binary that reads `llm_key_id`. It is one nullable column with a unique constraint — additive, unread by the previous binary, harmless to roll back.
+- **Rollback is unsetting the new environment variables.** Any of the four unset ⇒ `llmkey.New` returns nil, nothing is minted, and every call goes out on `LLM_API_KEY` exactly as before.
+- **No backfill.** Rows minted before 0119 hold a secret and no id. They keep working for inference and acquire an id the first time the gateway refuses them, through the existing forget-and-re-mint path.
+- **Retired credentials at the old gateway are left alone.** They stop being presented the moment `LLM_BASE_URL` moves; erasing them is a separate, reversible decision.

--- a/openspec/changes/move-llm-gateway-to-bifrost/specs/llm-spend-attribution/spec.md
+++ b/openspec/changes/move-llm-gateway-to-bifrost/specs/llm-spend-attribution/spec.md
@@ -1,0 +1,72 @@
+## MODIFIED Requirements
+
+### Requirement: The per-account gateway credential is an (id, secret) pair
+
+The system SHALL store both the secret a model call presents and the identifier the gateway's administrative API addresses, and SHALL write and clear them as one credential. A credential holding only a secret SHALL remain usable for inference and SHALL NOT be blocked or deleted.
+
+#### Scenario: Minting stores both halves
+
+- **WHEN** an account makes its first AI call and no credential is stored
+- **THEN** the gateway mints one, and both the secret and the gateway's own identifier are stored in the same statement
+
+#### Scenario: A half credential is refused
+
+- **WHEN** the gateway answers a mint with a secret but no identifier, or an identifier but no secret
+- **THEN** the mint fails and nothing is stored, because a stored half would mark the account as credentialled while being unusable in one direction
+
+#### Scenario: A credential predating the identifier keeps working
+
+- **WHEN** an account's stored credential carries a secret and no identifier
+- **THEN** its model calls proceed on that secret, and the first refusal by the gateway clears the row so the next call mints a complete pair
+
+### Requirement: A minted credential carries a provider policy read from a template
+
+The system SHALL copy the provider policy of a configured template credential onto every credential it mints, and SHALL NOT carry a provider list of its own. Absent a configured template, the system SHALL behave as unconfigured rather than mint credentials the gateway will refuse.
+
+#### Scenario: The policy is copied
+
+- **WHEN** a credential is minted
+- **THEN** the template credential is read and its provider entries — providers, weights and allowed models — are sent verbatim on the new credential
+
+#### Scenario: A template allowing no provider fails the mint
+
+- **WHEN** the template credential carries no provider entries
+- **THEN** the mint fails rather than producing a credential that is refused on its first call
+
+#### Scenario: No template configured disables attribution
+
+- **WHEN** no template credential is configured
+- **THEN** nothing is minted and every model call goes out on the service credential, exactly as when no administrative endpoint is configured
+
+### Requirement: Usage is reported for the account's current credential
+
+The system SHALL report an account's own AI usage — calls made, calls failed, tokens moved — for the credential currently stored against that account, over the calendar period credits reset on. It SHALL NOT report money. It SHALL NOT mint a credential in order to answer.
+
+#### Scenario: An account reads its own month
+
+- **WHEN** a signed-in account requests its usage
+- **THEN** the figures cover only that account's credential, and no other account's usage is visible
+
+#### Scenario: An account that never used AI
+
+- **WHEN** an account with no stored credential requests its usage
+- **THEN** zeroes are reported, no request is made to the gateway, and no credential is minted
+
+#### Scenario: A credential replaced mid-period
+
+- **WHEN** an account's credential was replaced during the period being reported
+- **THEN** the figures cover the current credential only, and the retired credential's calls are absent from them
+
+### Requirement: A model call is labelled with the feature it served
+
+The system SHALL label every model call made for a signed-in user with the feature that call served, as a value under a single dimension, and SHALL apply the label whether or not the call could be attributed to a person.
+
+#### Scenario: An attributed call is labelled
+
+- **WHEN** a model call is made on an account's own credential
+- **THEN** the request carries the feature dimension with a bare feature name as its value
+
+#### Scenario: An unattributed call is still labelled
+
+- **WHEN** attribution is unavailable and the call falls back to the service credential
+- **THEN** the request still carries the feature dimension

--- a/openspec/changes/move-llm-gateway-to-bifrost/specs/speech-to-text/spec.md
+++ b/openspec/changes/move-llm-gateway-to-bifrost/specs/speech-to-text/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Audio surfaces are absent while the gateway cannot serve them
+
+The system SHALL NOT offer dictation or voice mode while the configured gateway's audio routes are unproven. The affordance SHALL be absent rather than present-and-failing, and the capability SHALL be restored by configuration and one client-side switch, with no code removed in the meantime.
+
+#### Scenario: No microphone in the composer
+
+- **WHEN** a signed-in user opens the assistant composer in a browser that supports recording
+- **THEN** no microphone control is rendered, and no recording can be started
+
+#### Scenario: No voice mode on an interview session
+
+- **WHEN** a signed-in user opens an interview session in a browser that supports WebRTC
+- **THEN** no voice-call trigger is offered
+
+#### Scenario: The server still answers an unconfigured surface honestly
+
+- **WHEN** a transcription or realtime-credential request reaches the API while no speech model or realtime gateway is configured
+- **THEN** the API answers 501, which the SPA reads as a surface that does not exist here rather than as a fault
+
+#### Scenario: Restoring the capability
+
+- **WHEN** the gateway is given an audio-capable credential, both audio routes are exercised against it, the speech model and realtime configuration are set, and the client-side switch is flipped
+- **THEN** dictation and voice mode return, gated as before by the browser capability checks that were left in place

--- a/openspec/changes/move-llm-gateway-to-bifrost/tasks.md
+++ b/openspec/changes/move-llm-gateway-to-bifrost/tasks.md
@@ -1,0 +1,45 @@
+> **Provenance.** Sections 1–5 were implemented and committed (`f24c66f4`) before
+> this change existed, during the evaluation that produced `provision/bifrost/` in
+> freehire-ops. They are ticked because the work and its tests are in the branch, not
+> because they ran through a red-first loop — they did not. Section 6 is the part of
+> the delivery discipline that can still be honoured, and it is open.
+
+## 1. Schema
+
+- [x] 1.1 Migration `0119_user_llm_key_id.sql`: nullable `users.llm_key_id text` with a unique constraint. Additive, no backfill, unread by the previous binary.
+- [x] 1.2 `llm_keys.sql`: `GetUserLLMKey` and `ClaimUserLLMKey` return both columns; `ClearUserLLMKey` clears both. The claim guard stays on `llm_key` alone so a pre-0119 row is not overwritten.
+- [x] 1.3 `make sqlc`.
+
+## 2. Gateway client
+
+- [x] 2.1 `Credential{ID, Secret}` replaces the bare secret; `Mint` returns both and refuses a half credential.
+- [x] 2.2 Endpoints move to `POST /api/governance/virtual-keys`, `PUT`/`DELETE` on `/{id}`, `GET /api/logs/stats`; authentication becomes HTTP Basic.
+- [x] 2.3 `Mint` reads the template key and copies its `provider_configs`, normalising `key_ids: null` to `["*"]`; a policyless template fails the mint.
+- [x] 2.4 `Activity` takes a credential id, makes two reads (totals, then filtered to errors for the exact failure count) and widens the window to whole days.
+- [x] 2.5 Tests: unconfigured-is-nil across all four fields, policy copied not invented, allowlist normalised, half-credential refused, unwrapped answer read, 404-is-done, admin 401 is not a stale user key.
+
+## 3. Resolver and callers
+
+- [x] 3.1 `read`/`Stored`/`mint` carry the pair; `Forget` reads before clearing and blocks only the credential the refusal was about; `Revoke` blocks by id.
+- [x] 3.2 `newUsageHandlers` takes the resolver to READ (`Stored`, never `For`).
+- [x] 3.3 Config: `LLM_ADMIN_USERNAME` / `LLM_ADMIN_PASSWORD` / `LLM_ADMIN_TEMPLATE_KEY` replace `LLM_ADMIN_KEY`; `cmd/server` rewired.
+- [x] 3.4 Tests: fakes carry ids, the usage fake answers both reads, seeding a secret seeds its id.
+
+## 4. Feature tag
+
+- [x] 4.1 `x-litellm-tags` → `x-bf-dim-feature`; the constants in `user_llm.go` become bare words.
+- [x] 4.2 The tag test forbids a colon in the value rather than requiring a `feature:` prefix.
+
+## 5. Audio off
+
+- [x] 5.1 `web/src/lib/assistant/audioAvailability.ts` — one `AUDIO_ENABLED` constant carrying the reason and the restore path.
+- [x] 5.2 Gate both mount points: the microphone in `Composer.svelte`, voice mode in `AssistantChat.svelte`. Capability checks underneath left untouched.
+- [x] 5.3 `internal/ai/speech/AGENTS.md` records why it is dark, that nothing was deleted, and the `session.model` wire-shape difference waiting on the way back.
+
+## 6. Delivery gates — OPEN
+
+- [x] 6.1 `simplify` over the branch diff; tests stay green after it. Extracted `Client.policy`, hoisted the governance path to a constant, folded the request-body encode onto one path, and stopped `Activity` aliasing its `url.Values` between the two reads.
+- [ ] 6.2 Code review of the diff (`requesting-code-review`, plus `/code-review`); fix Critical and Important.
+- [ ] 6.3 `verification-before-completion`: unit suite, `go vet` under both build tags, layering guard, lint ratchet, svelte-check, web tests — each with its output, not asserted from memory.
+- [ ] 6.4 `finishing-a-development-branch`: integrate `bifrost-gateway`.
+- [ ] 6.5 `/opsx:archive` then `/opsx:sync`.

--- a/openspec/changes/move-llm-gateway-to-bifrost/tasks.md
+++ b/openspec/changes/move-llm-gateway-to-bifrost/tasks.md
@@ -39,7 +39,13 @@
 ## 6. Delivery gates — OPEN
 
 - [x] 6.1 `simplify` over the branch diff; tests stay green after it. Extracted `Client.policy`, hoisted the governance path to a constant, folded the request-body encode onto one path, and stopped `Activity` aliasing its `url.Values` between the two reads.
-- [ ] 6.2 Code review of the diff (`requesting-code-review`, plus `/code-review`); fix Critical and Important.
-- [ ] 6.3 `verification-before-completion`: unit suite, `go vet` under both build tags, layering guard, lint ratchet, svelte-check, web tests — each with its output, not asserted from memory.
+- [x] 6.2 Code review of the diff. Found one Critical and four Important, all fixed:
+  - **Critical** — the assistant passed two tags, which the transport joined with a comma into ONE `x-bf-dim-feature`, filing it under `assistant,preset:chat` and five siblings. None was `assistant`. The variadic tag list was the previous gateway's shape; replaced with `llm.Dimension{Name, Value}` and one header per dimension, so the preset gets `x-bf-dim-preset`.
+  - **Important** — `Forget` discarded `read`'s `ok`, so a transient database fault cleared the row (the only record of the gateway id) while declining to block, permanently orphaning a live key. Now it leaves the row alone.
+  - **Important** — `Revoke` had no test at all, and it is the reason the id column exists. Added: blocks by id, leaves the row, no-ops without an id.
+  - **Important** — `/me/usage` must never mint; nothing asserted it. Added a test with an unseeded store.
+  - **Important** — a comment in `me_usage_test.go` still asserted the pre-migration semantics.
+  - Minors taken: the failure count is now observable (the fake answers the two reads differently), and the window closes at the last instant of the day rather than dropping its final second.
+- [x] 6.3 `verification-before-completion`: unit suite, `go vet` under both build tags, layering guard, lint ratchet, svelte-check, web tests — each run with its output: gofmt clean, unit suite pass, `go vet` clean under `integration` and `llmlive`, layering guard ok, lint ratchet 0 issues, svelte-check 0 errors, 1186 web tests pass.
 - [ ] 6.4 `finishing-a-development-branch`: integrate `bifrost-gateway`.
 - [ ] 6.5 `/opsx:archive` then `/opsx:sync`.

--- a/web/src/lib/assistant/AssistantChat.svelte
+++ b/web/src/lib/assistant/AssistantChat.svelte
@@ -11,6 +11,7 @@
   } from '$lib/assistant/api';
   import VoiceCall from '$lib/assistant/VoiceCall.svelte';
   import { canUseVoiceCall } from '$lib/assistant/voiceCall';
+  import { AUDIO_ENABLED } from '$lib/assistant/audioAvailability';
   import { track } from '$lib/analytics';
   import {
     openRehearsal,
@@ -161,6 +162,8 @@
   // not keep offering a call that can only fail. `voiceSupported` starts false and is
   // decided after mount, the same reasoning VoiceInput.svelte's `supported` gives:
   // reading navigator during SSR would disagree with the client on the first paint.
+  // It also carries AUDIO_ENABLED, which is false while the gateway migration leaves
+  // the Realtime route unproven — see audioAvailability.ts.
   let voiceCallOpen = $state(false);
   let voiceModeOff = $state(false);
   let voiceSupported = $state(false);
@@ -721,10 +724,12 @@
 
   onMount(() => {
     void boot();
-    voiceSupported = canUseVoiceCall({
-      mediaDevices: navigator.mediaDevices,
-      RTCPeerConnection: typeof RTCPeerConnection === 'undefined' ? undefined : RTCPeerConnection,
-    });
+    voiceSupported =
+      AUDIO_ENABLED &&
+      canUseVoiceCall({
+        mediaDevices: navigator.mediaDevices,
+        RTCPeerConnection: typeof RTCPeerConnection === 'undefined' ? undefined : RTCPeerConnection,
+      });
     document.addEventListener('visibilitychange', catchUpOnReturn);
     return () => {
       document.removeEventListener('visibilitychange', catchUpOnReturn);

--- a/web/src/lib/assistant/Composer.svelte
+++ b/web/src/lib/assistant/Composer.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { ArrowUp, Loader2, Trash2, Square } from '@lucide/svelte';
   import VoiceInput from '$lib/assistant/VoiceInput.svelte';
+  import { AUDIO_ENABLED } from '$lib/assistant/audioAvailability';
   import { appendTranscript } from '$lib/assistant/dictation';
 
   // The composer: the queued-message panel (messages typed mid-turn, sent
@@ -111,7 +112,7 @@
         }}
         class="block max-h-[200px] min-h-[1.5rem] flex-1 resize-none cursor-text bg-transparent py-1 text-base leading-6 text-foreground placeholder:text-muted-foreground/70 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 sm:text-sm"
       ></textarea>
-      {#if !dictationOff}
+      {#if AUDIO_ENABLED && !dictationOff}
         <VoiceInput
           {disabled}
           onTranscript={acceptTranscript}

--- a/web/src/lib/assistant/audioAvailability.ts
+++ b/web/src/lib/assistant/audioAvailability.ts
@@ -1,0 +1,22 @@
+/** Whether the assistant offers anything that needs a microphone.
+ *
+ *  Off since 2026-08-22. Both audio surfaces — dictation into the composer and
+ *  hands-free voice mode — reach the model through an OpenAI-compatible gateway,
+ *  and the gateway is being replaced (see `provision/bifrost/` in freehire-ops).
+ *  The replacement's audio routes exist but have never been exercised: the key
+ *  pool behind it carries no OpenAI credential, so `/v1/audio/transcriptions`
+ *  and `/v1/realtime/client_secrets` are unproven rather than known-good.
+ *
+ *  Shipping the affordance anyway would mean a microphone button that opens,
+ *  records, and then fails — the server answers 501 and `dictationOff` /
+ *  `voiceModeOff` latch it away for the rest of the session. That is a worse
+ *  first impression than no button.
+ *
+ *  This is deliberately a constant and not configuration. Nothing about it
+ *  varies per deployment: either the gateway serves audio or it does not, and
+ *  the day it does, this flips to `true` in one edit and the capability checks
+ *  underneath — `canRecord`, `canUseVoiceCall` — take over again untouched.
+ *
+ *  To restore: give the gateway an audio-capable credential, verify both routes
+ *  against it, then flip this. Nothing else here was removed. */
+export const AUDIO_ENABLED = false;


### PR DESCRIPTION
Replaces the LLM gateway's client surface. Nothing here switches the gateway over — that is `LLM_BASE_URL` and the new admin variables, and it stays unset until we choose to.

Measured against both gateways on litellm-host before committing to any of it (stand and figures in `provision/bifrost/` in freehire-ops):

| | LiteLLM | Bifrost |
|---|---|---|
| strict `json_schema`, `gemini-2.5-flash` | 7/10 | 7/10 |
| strict `json_schema`, `mistral-large` | 2/10 | **10/10** |
| cross-provider fallback | config | config, no `fallbacks` from the caller |
| streamed tool-call fragmentation | occurs | does not reproduce (to 1851-byte args) |
| spend history after deleting a key | lost | survives |

## What changes

**A credential is two values.** Bifrost addresses a virtual key by an opaque id and answers 404 to anything aimed at the secret, so a stored secret alone can spend but never be revoked — which is what account deletion has to do. `0119` adds nullable `users.llm_key_id`; the two are written and cleared together.

**Minting reads its provider policy rather than carrying one.** A key with no `provider_configs` is refused every provider. Carrying the list here would put the provider vocabulary in two places and make adding a provider a deploy of freehire; instead `Mint` copies it from the template key named by `LLM_ADMIN_TEMPLATE_KEY`. This repository still names no provider.

**Each dimension gets its own header.** `x-litellm-tags: feature:assistant` → `x-bf-dim-feature: assistant`, with the assistant's preset under `x-bf-dim-preset`. The first cut of this kept the old comma-joined shape and filed every assistant call under `assistant,preset:<preset>` — caught in review, fixed here.

**`/me/usage` narrows to the current credential.** Bifrost keys its usage log by credential id and offers no account-scoped query, so a key replaced mid-month leaves the earlier one's calls out of the figure. Rare (only on a refusal); the alternative was remembering dead ids forever.

**Audio goes dark rather than shipping unproven.** `/v1/audio/transcriptions` and `/v1/realtime/client_secrets` exist on Bifrost but have never been called against it — the pool behind it carries no OpenAI credential. Nothing was deleted; `AUDIO_ENABLED` in `web/src/lib/assistant/audioAvailability.ts` suppresses both affordances so the microphone is absent rather than present-then-broken.

## Deploying

1. **Migration 0119 first**, before the binary that reads `llm_key_id`. One nullable column, additive, unread by the previous binary.
2. Set `LLM_ADMIN_URL`, `LLM_ADMIN_USERNAME`, `LLM_ADMIN_PASSWORD`, `LLM_ADMIN_TEMPLATE_KEY` (retires `LLM_ADMIN_KEY`).
3. Rollback is unsetting any of them: `llmkey.New` returns nil, nothing mints, every call goes out on `LLM_API_KEY` exactly as before.

No backfill. Rows predating 0119 keep working and acquire an id the first time the gateway refuses them.

## Verification

gofmt clean · unit suite passes · `go vet` clean under `integration` and `llmlive` · layering guard ok · lint ratchet 0 issues · svelte-check 0 errors · 1186 web tests.

## Honesty about process

The implementation landed before the OpenSpec change and its tests were written after the code, not test-first. `openspec/changes/move-llm-gateway-to-bifrost/tasks.md` says so rather than implying a red-first trail. A review pass afterwards found one Critical and four Important — clustered, as you would expect, exactly where after-the-fact tests cluster: fakes mirroring the implementation instead of branches nobody thought to take. All are fixed in `4add3a57`.

## Follow-ups, not in this PR

- Which model each alias points at. `flagship` currently resolves to a reasoning model on a free coding plan and shows a 38–70s tail on enrichment — inside the range where a 90s client timeout starts killing runs. A gateway-config question.
- Whether audio moves to a second gateway rather than waiting for this one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for individually managed LLM credentials with improved credential tracking and provider-policy inheritance.
  * LLM usage reporting now reflects activity from the currently active credential.
  * Added separate feature and preset attribution for model requests.

* **Updates**
  * Replaced legacy administrator-key configuration with username, password, and template-key settings.
  * Voice input, dictation, and realtime assistant audio are temporarily unavailable until audio routes are enabled and verified.

* **Documentation**
  * Updated configuration, migration, usage-reporting, credential-management, and audio availability guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->