### PR TITLE
Re-add six companies that had moved off their dead Greenhouse boards

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -135,6 +135,8 @@
   board: flinn
 - company: Forge Atomics Inc.
   board: forgeatomics
+- company: Form Bio
+  board: formbio
 - company: Fronza and Francis LLC
   board: FronzaFrancis
 - company: Galliant
@@ -159,8 +161,12 @@
   board: investa
 - company: MacroHealth
   board: macrohealth
+- company: Multivista
+  board: multivista
 - company: Poetic
   board: poetic
+- company: Simply
+  board: simply
 - company: Ujwal Inc.
   board: level-ai
 - company: Luma

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -955,6 +955,8 @@
   board: humansignal
 - company: HunterDouglas
   board: hunterdouglas
+- company: Lextech Global Services
+  board: lextechglobalservices
 - company: NexGen Cloud
   board: nexgencloud
 - company: iCapital Network
@@ -1825,6 +1827,8 @@
   board: systemstechnologyresearch
 - company: Strand Therapeutics
   board: strandtherapeutics
+- company: Strata Critical
+  board: stratacritical_logistics
 - company: Strata Decision Technology
   board: stratacareers
 - company: Striim

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -5,6 +5,8 @@
 
 - company: Arrive Logistics
   board: careers.arrive.com
+- company: Beauhurst
+  board: beauhurst.teamtailor.com
 - company: BRYTER
   board: bryter.teamtailor.com
 - company: Insense


### PR DESCRIPTION
Follow-up to #2197. Of the 63 dead boards whose company had **no live posting from any other source**, six turned out to be reachable again — the company had not stopped hiring, it had moved or been renamed.

## What was found

| company | was | now | jobs |
|---|---|---|---|
| Trinity Air Medical | `greenhouse/trinityairmedical` | `greenhouse/stratacritical_logistics` (renamed to Strata Critical) | 11 |
| Lex Tech | `greenhouse/lextech` | `greenhouse/lextechglobalservices` | 1 |
| Multivista | `greenhouse/multivista` | `ashby/multivista` | 6 |
| Simply | `greenhouse/simply` | `ashby/simply` | 4 |
| Beauhurst | `greenhouse/beauhurst` | `teamtailor/beauhurst.teamtailor.com` | 3 |
| Form Bio | `greenhouse/formbio` | `ashby/formbio` | 1 |

## How, and the dead end worth recording

The obvious approach — probe the old slug across other ATS platforms — **was worthless**. It returned a hit for all 63 boards, including `2. Pool Building` and `Pet Waste Removal Careers`, because:

- smartrecruiters answers `200` with `{"totalFound":0}` for *any* slug
- workable serves HTML from its JSON widget endpoint for an unknown account

What worked was fetching each company's own careers page and grepping for an ATS signature. That is also what surfaced the two renames, which no slug probe could have found.

Every candidate was then confirmed **by output, not by status code** — the same rule that already burned us on `niceplay-games`. A live ingest run on prod:

```
ingest done: providers=3 ingested=24 failed=0 skipped=0 rejected=2
  ashby cheap=0/11  greenhouse cheap=0/10  teamtailor cheap=0/3
```

(the 2 rejected are non-technical postings at Strata Critical — a courier and a staff accountant.)

The remaining 57 dead boards found no successor and stay removed.

## Test

`go test ./internal/ingest/sources/` — ok.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added job board listings from Form Bio, Multivista, Simply, Lextech Global Services, Strata Critical, and Beauhurst.
  * Expanded available listings across Ashby, Greenhouse, and Teamtailor sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->