### PR TITLE
feat(sources): onboard contributed boards

### DIFF
--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14151,3 +14151,5 @@
   board: wgphysicaltherapyjobs
 - company: Copilot Careers
   board: copilotcareers
+- company: Emergence AI
+  board: emergenceai

--- a/sources/inhire.yml
+++ b/sources/inhire.yml
@@ -754,3 +754,5 @@
   board: marisacare
 - company: "Solo Recruiter"
   board: solorecruiter
+- company: Akad Seguros
+  board: akadseguros

--- a/sources/jazzhr.yml
+++ b/sources/jazzhr.yml
@@ -8655,3 +8655,5 @@
   board: valiantmgmt
 - company: Walpole, Inc.
   board: walpoleinc
+- company: Rhapsody VP
+  board: rhapsodyvp

--- a/sources/jibe.yml
+++ b/sources/jibe.yml
@@ -71,3 +71,7 @@
   board: jobs.essilorluxottica.com
 - company: poppi
   board: pepsicojobs.com
+- company: Medallia
+  board: jobs.medallia.com
+- company: Rivian
+  board: careers.rivian.com

--- a/sources/phenom.yml
+++ b/sources/phenom.yml
@@ -199,3 +199,5 @@
   board: jobs.thecignagroup.com
 - company: Veralto
   board: jobs.veralto.com
+- company: CarGurus
+  board: careers.cargurus.com

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -4177,3 +4177,5 @@
   board: ystrategie.teamtailor.com
 - company: Bonapolia
   board: jobs.bonapolia.com
+- company: Fadir
+  board: careers.fadir.com

--- a/sources/trakstar.yml
+++ b/sources/trakstar.yml
@@ -1336,3 +1336,5 @@
   board: viera
 - company: Spartan SME Finance
   board: spartan
+- company: LogiNext
+  board: loginext


### PR DESCRIPTION
## Crowdsourced board contributions — 2026-08-24

Drains `queue_pending.tsv` (11 rows). Each board was checked against the live source file,
validated via the adapter's public listing endpoint, and the company display name resolved
from `og:site_name` / API metadata before being appended.

---

### Onboarded (8)

| Source | Board | Company | Validation |
|--------|-------|---------|------------|
| greenhouse | `emergenceai` | Emergence AI | `GET https://job-boards.greenhouse.io/emergenceai` → 200; `og:site_name: "Emergence AI"`; `boards-api.greenhouse.io` reports 2 open jobs |
| jazzhr | `rhapsodyvp` | Rhapsody VP | `GET https://rhapsodyvp.applytojob.com` → 200; `<title>Rhapsody VP - Career Page` |
| jibe | `jobs.medallia.com` | Medallia | `GET https://jobs.medallia.com/api/jobs?page=1&limit=1` → 200 with jobs; `hiring_organization: "Medallia"` |
| jibe | `careers.rivian.com` | Rivian | `GET https://careers.rivian.com/api/jobs?page=1&limit=1` → 200 with jobs; `hiring_organization: "Rivian"` |
| inhire | `akadseguros` | Akad Seguros | `GET https://api.inhire.app/job-posts/public/pages` with `X-Tenant: akadseguros` → 200; `tenantName: "Akad Seguros"` |
| phenom | `careers.cargurus.com` | CarGurus | `POST https://careers.cargurus.com/widgets` → 200; `totalHits: 52`; `og:site_name: "CarGurus"` |
| trakstar | `loginext` | LogiNext | `GET https://loginext.hire.trakstar.com/jobfeeds/loginext` → 200 RSS with jobs; channel title "Jobs at LogiNext" |
| teamtailor | `careers.fadir.com` | Fadir | `GET https://careers.fadir.com/jobs` → 200 with Teamtailor signals; `og:site_name: "Fadir"` |

---

### Turned down (2)

| ID | Source | Board | Reason |
|----|--------|-------|--------|
| 300 | phenom | `ejta.fa.us6.oraclecloud.com` | Not a Phenom board — domain is `oraclecloud.com` (Oracle HCM Cloud). `POST /widgets` → 404. The contributed URL (`/hcmUI/CandidateExperience/…`) is a per-posting Oracle HCM URL; the recognizer misclassified it. |
| 361 | greenhouse | `external_greenhouse_job_boards` | 404 on `https://job-boards.greenhouse.io/external_greenhouse_job_boards`. The contributed URL was a Greenhouse short-link (`grnh.se/9zt3l182teu`) for a single job posting; `external_greenhouse_job_boards` is Greenhouse's own internal meta-board name, not a company board. |

---

### Already present (1)

| ID | Source | Board | Note |
|----|--------|-------|------|
| 291 | workday | `zuehlke.wd3.myworkdayjobs.com/Zuhlke-Careers` | Company board already crawled as `zuehlke.wd3.myworkdayjobs.com/zuhlke-careers` (all-lowercase, line 10076–10077 of `sources/workday.yml`). Both case variants return 200 from the Workday CXS endpoint. Adding the mixed-case version would risk duplicating every job via a second `external_id` namespace; marked onboarded against the existing entry. |

---

### Needs human review — queue_review.tsv (unrecognized links)

The system could not classify these to a known ATS. Obvious noise (raw LinkedIn `/jobs/view/` links, example.com, a PR link, Notion, Airtable, aggregators like Indeed/Wellfound/Himalayas) is listed at the end. Items that look like they could be real ATS boards are flagged first.

| ID | URL | Why it needs a human |
|----|-----|----------------------|
| 292 | `https://topazbrasil.gupy.io/job/…` | Looks like a Gupy board (`topazbrasil`); `sources/gupy.yml` exists but does not contain this tenant. Worth validating and adding. |
| 299 | `https://fortive.eightfold.ai/careers` | Looks like an Eightfold board; `sources/eightfold.yml` exists. Needs validation against the Eightfold API. |
| 302 | `https://www.weareroku.com/jobs/…` | Roku careers page — ATS platform not identifiable from the URL alone. |
| 304 | `https://jobs.dayforcehcm.com/en-US/bav/CANDIDATEPORTAL/jobs/11122` | Dayforce HCM — not a currently supported source. |
| 313 | `https://careers.americanexpress.com/en/sites/CX_1/job/…` | Oracle HCM Cloud (`/hcmUI/CandidateExperience/` pattern) — same platform as the rejected row 300; no Oracle source in the file yet. |
| 321 | `https://careers.walmart.com/us/en/jobs/R-…` | Likely a Workday board; Walmart's careers site resolves via Workday but the board identifier needs to be confirmed. |
| 288 | `https://www.anticipy.ai/grow` | Small company careers page — ATS unknown. |
| 290 | `https://sunbit.com/careers` | Company careers page — ATS unknown. |
| 293 | `https://jobsearch.createyourowncareer.com/Riverty/…` | Unknown ATS platform (`createyourowncareer.com`). |
| 305 | `https://dressup.selfrecruit.ge/…` | `selfrecruit.ge` — unknown/regional platform. |
| 308 | `https://jobs.polymer.co/voiceops/40085` | Polymer Jobs platform — not a currently supported source. |
| 312 | `https://moniepoint.com/careers` | Company careers page — ATS unknown. |
| 323 | `https://www.useparallel.com/app/candidate/job/…` | Parallel platform — not a currently supported source. |
| 325 | `https://meetfrank.com/jobs/legora/…` | MeetFrank aggregator — already listed under `sources/` if applicable, otherwise an aggregator. |

**Pure noise (no action needed):**
IDs 296, 297, 298, 306, 307, 309, 310, 311, 318, 319, 320, 322, 328, 330, 334–390 — LinkedIn job view links, `example.com`, a PR link to this repo, Notion, Airtable, `hh.ru` (already indexed), Indeed, LinkedIn search results, `builtin.com`, `wellfound.com`, `workstory.io`, `meetfrank.com` (aggregator), `sundayy.com`.

---

### SQL

```sql
-- Mark successfully onboarded contributions
UPDATE link_contributions SET status = 'onboarded' WHERE id IN (291, 317, 324, 326, 327, 332, 333, 387, 392);

-- Mark rejected contributions
UPDATE link_contributions SET status = 'rejected' WHERE id IN (300, 361);
```

*(ID 291 — Zuehlke — is marked onboarded because the company board is already live in the crawler; the contribution is satisfied even though no new YAML line was added.)*

---

onboarded=8 rejected=2 skipped=1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added job board coverage for Emergence AI, Akad Seguros, Rhapsody VP, and LogiNext.
  - Added career-site coverage for Medallia, Rivian, CarGurus, and Fadir.
  - Job listings from these companies can now be discovered through the platform’s supported sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->