### PR TITLE
Fix the four live errors Sentry was reporting

### DIFF
--- a/web/.oxlintrc.json
+++ b/web/.oxlintrc.json
@@ -11,7 +11,13 @@
     "perf": "warn"
   },
   "rules": {
-    "import/no-unassigned-import": "off"
+    "import/no-unassigned-import": "off",
+    // Pushes `.sort()` towards `.toSorted()`, which is the wrong direction for a
+    // browser bundle: Safari only grew the copying methods in 16.4, they are runtime
+    // methods no build target can transpile, and a throw during module init takes the
+    // page down rather than the one list. eslint.config.js bans them outright; leaving
+    // this on would have the two linters argue over every sort. Revisit together.
+    "unicorn/no-array-sort": "off"
   },
   "ignorePatterns": ["dist", "node_modules"]
 }

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -49,6 +49,29 @@ export default ts.config(
     },
   },
 
+  // The change-array-by-copy methods reach the browser untranspiled — they are
+  // runtime methods, so no build target polyfills them, and Safari only grew them
+  // in 16.4. One `.toSorted()` evaluated while `facets.ts` was initialising threw
+  // on iOS 15, which takes the module down and with it the whole page — not the
+  // one sorted list. Every call we had ran on an array a `.map`/`.filter`/spread
+  // had just produced, so `.sort()` in place is the same thing without the floor
+  // on who can open the site. Lift this once the analytics say iOS 15 is gone.
+  {
+    files: ['**/*.{ts,svelte,svelte.ts}'],
+    ignores: ['**/*.test.ts', 'scripts/**', 'src/lib/server/**'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "MemberExpression[property.name=/^(toSorted|toReversed|toSpliced)$/][computed=false]",
+          message:
+            'Not in Safari before 16.4, and a throw here kills the whole module. Use [...x].sort() — or .sort() when the array is already a fresh copy.',
+        },
+      ],
+    },
+  },
+
   // Must come last: disables every ESLint rule that oxlint already covers.
   ...oxlint.configs['flat/recommended'],
 );

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -65,7 +65,9 @@ describe('job path segment encoding', () => {
     const urls: string[] = [];
     const fetcher = ((url: string) => {
       urls.push(url);
-      return Promise.resolve(new Response('{"data":null}', { status: 200 }));
+      // A job-shaped body: getJob rejects anything else as "not a job" (see the
+      // reserved-word test below), and this case is about the path, not the payload.
+      return Promise.resolve(new Response('{"data":{"public_slug":"x"}}', { status: 200 }));
     }) as unknown as typeof fetch;
     const client = createApi(fetcher);
     const slug = 'a/b?c#d';
@@ -84,6 +86,21 @@ describe('job path segment encoding', () => {
       `/api/v1/jobs/${encoded}/vote`,
       `/api/v1/jobs/${encoded}/reports`,
     ]);
+  });
+
+  // `/api/v1/jobs/{search,find,facets,sitemap}` are static routes declared ahead of
+  // `/jobs/:slug`, so those four words answer 200 with their own body instead of the
+  // 404 a missing job gives. /jobs/search in a browser therefore handed the detail
+  // page a list of jobs where a posting belonged, and every one of the four rendered
+  // a 500. The shape is what getJob checks, so a fifth static sibling added later is
+  // covered without anyone remembering to add it here.
+  it('treats a non-job body as a missing job', async () => {
+    const listBody = '{"data":[{"public_slug":"a-job"}],"meta":{"total":1}}';
+    const fetcher = (() =>
+      Promise.resolve(new Response(listBody, { status: 200 }))) as unknown as typeof fetch;
+    const client = createApi(fetcher);
+
+    await expect(client.getJob('search')).rejects.toMatchObject({ status: 404 });
   });
 });
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -388,8 +388,18 @@ export function createApi(
     return toSlice(await request<Page<Job>>(`/api/v1/jobs${query(limit, offset)}`), offset);
   }
 
+  /** A job by slug. Four words can never be one: `/jobs/{search,find,facets,sitemap}`
+   *  are static API routes declared ahead of `/jobs/:slug`, so they answer 200 with
+   *  their own shape instead of the 404 a missing job gives. Reaching /jobs/search in
+   *  a browser handed the page a list where it expected a posting, and the render died
+   *  on the first field it read — a 500 where the honest answer is "no such job". The
+   *  shape is the check, not a list of the four: any future static sibling is covered. */
   async function getJob(slug: string): Promise<Job> {
-    return requestData<Job>(`/api/v1/jobs/${encodeURIComponent(slug)}`);
+    const data = await requestData<Job>(`/api/v1/jobs/${encodeURIComponent(slug)}`);
+    if (!data || typeof data !== 'object' || Array.isArray(data) || !('public_slug' in data)) {
+      throw new ApiError(404, `not a job: /jobs/${slug}`);
+    }
+    return data;
   }
 
   /** Jobs semantically nearest to the one addressed by `slug` — the "Similar jobs"

--- a/web/src/lib/blog.ts
+++ b/web/src/lib/blog.ts
@@ -105,5 +105,5 @@ export function parseFrontmatter(raw: Record<string, unknown>, filePath: string)
 export function selectPosts(posts: PostMeta[], { includeDrafts }: { includeDrafts: boolean }): PostMeta[] {
   return posts
     .filter((post) => includeDrafts || !post.draft)
-    .toSorted((a, b) => b.date.localeCompare(a.date));
+    .sort((a, b) => b.date.localeCompare(a.date));
 }

--- a/web/src/lib/components/FacetBreakdown.svelte
+++ b/web/src/lib/components/FacetBreakdown.svelte
@@ -20,7 +20,7 @@
   const labels = $derived(new Map((def.options ?? []).map((o) => [o.value, o.label])));
 
   // Entries sorted by count descending; bar widths scale to the top count.
-  const entries = $derived(Object.entries(dist ?? {}).toSorted((a, b) => b[1] - a[1]));
+  const entries = $derived(Object.entries(dist ?? {}).sort((a, b) => b[1] - a[1]));
   const shown = $derived(entries.slice(0, TOP));
   const hidden = $derived(entries.length - shown.length);
   const max = $derived(shown[0]?.[1] ?? 0);

--- a/web/src/lib/components/facets/SearchSelect.svelte
+++ b/web/src/lib/components/facets/SearchSelect.svelte
@@ -72,7 +72,7 @@
   const matched = $derived(
     uniqueByValue(options)
       .filter((o) => optionMatches(o, filter, searchAliases))
-      .toSorted((a, b) => Number(isSelected(b.value)) - Number(isSelected(a.value))),
+      .sort((a, b) => Number(isSelected(b.value)) - Number(isSelected(a.value))),
   );
 
   // While unfiltered, cap the list to the top `cap` (already busiest-first) plus

--- a/web/src/lib/facets.test.ts
+++ b/web/src/lib/facets.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { COLLECTIONS, AI_ARCHETYPE_VALUES, ROLE_TYPE_VALUES } from './generated/contracts';
-import { cityOption, countryLabel, FACETS } from './facets';
+import { cityOption, collapseCities, countryLabel, FACETS } from './facets';
 
 const collectionOptions = () => FACETS.find((f) => f.param === 'collections')?.options ?? [];
 
@@ -97,5 +97,32 @@ describe('cityOption', () => {
     // just locks that cityOption doesn't hand-roll its own country formatting.
     const opt = cityOption({ value: 'Reykjavik', country: 'is' });
     expect(opt.label).toBe(`Reykjavik, ${countryLabel('is')}`);
+  });
+});
+
+describe('collapseCities', () => {
+  // A location preference stores the bare city name, so London/gb and London/ca are
+  // the same stored value — two rows offering one outcome. Worse, the picker keys its
+  // {#each} by value, and a duplicate key is a Svelte error that unmounts the entire
+  // list, so typing "london" emptied the dropdown instead of showing a wrong entry.
+  it('offers one option per city name, keeping the highest-population row', () => {
+    const options = collapseCities([
+      { value: 'London', country: 'gb' },
+      { value: 'London', country: 'ca' },
+      { value: 'Londonderry County Borough', country: 'gb' },
+    ]);
+
+    expect(options.map((o) => o.value)).toEqual(['London', 'Londonderry County Borough']);
+    // /geo/cities ranks by descending population, so the first London is the label kept.
+    expect(options[0]?.label).toBe(`London, ${countryLabel('gb')}`);
+  });
+
+  it('keeps distinct city names that merely share a prefix', () => {
+    const options = collapseCities([
+      { value: 'San Francisco', country: 'us' },
+      { value: 'San Diego', country: 'us' },
+    ]);
+
+    expect(options).toHaveLength(2);
   });
 });

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -191,8 +191,8 @@ async function companySearch(query: string): Promise<FacetOption[]> {
 
 // Composes one /geo/cities result into a FacetOption: the value stays the bare city
 // name (what a profile's location_preferences already stores), the label adds the
-// country via the same countryLabel() resolver COUNTRY_OPTIONS uses, so two
-// otherwise-identical city names (e.g. two "Springfield"s) read as distinct choices.
+// country via the same countryLabel() resolver COUNTRY_OPTIONS uses, so the country a
+// suggestion came from is at least readable.
 export function cityOption(row: { value: string; country: string }): FacetOption {
   return { value: row.value, label: `${row.value}, ${countryLabel(row.country)}` };
 }
@@ -202,9 +202,22 @@ export function cityOption(row: { value: string; country: string }): FacetOption
 // debounce means this fires at most once per ~250ms of typing, not per keystroke).
 // `country` narrows the base-city search to the already-chosen base country; the
 // relocation-cities search omits it, since that set may span multiple countries.
+//
 export async function searchCities(query: string, country?: string): Promise<FacetOption[]> {
-  const rows = await api.searchCities(query, country);
-  return rows.map(cityOption);
+  return collapseCities(await api.searchCities(query, country));
+}
+
+// One city name is one option. /geo/cities answers per (name, country), so a prefix
+// like "london" or "victoria" comes back several times over — and since a preference
+// stores the bare name, every one of those rows would save the identical value. Listing
+// them separately offered a choice that does not exist, and the repeated value collided
+// in the picker's keyed {#each}, which in Svelte takes down the whole list rather than
+// the duplicate row. The first row per name wins: /geo/cities returns them by
+// descending population, so that is the city a reader means by the name.
+export function collapseCities(rows: { value: string; country: string }[]): FacetOption[] {
+  const byName = new Map<string, FacetOption>();
+  for (const row of rows) if (!byName.has(row.value)) byName.set(row.value, cityOption(row));
+  return [...byName.values()];
 }
 
 // Role facet values are canonical slugs (senior_backend, founding_engineer); the
@@ -254,7 +267,7 @@ export function dynamicOptions(param: string, dist: Record<string, number>, sele
   const keys = new Set<string>([...Object.keys(dist), ...selected]);
   return [...keys]
     .map((value) => ({ value, label: dynamicLabel(param, value), count: dist[value] ?? 0 }))
-    .toSorted((a, b) => (b.count ?? 0) - (a.count ?? 0) || a.label.localeCompare(b.label));
+    .sort((a, b) => (b.count ?? 0) - (a.count ?? 0) || a.label.localeCompare(b.label));
 }
 
 // Role slugs carry an optional seniority grade prefix (senior_backend); the
@@ -494,7 +507,7 @@ const COUNTRY: FacetOption[] = ISO_COUNTRY_CODES.map((value) => ({
   value,
   label: countryLabel(value),
   flag: value,
-})).toSorted((a, b) => a.label.localeCompare(b.label));
+})).sort((a, b) => a.label.localeCompare(b.label));
 
 // The full ISO country select, exported for the profile's location editor (base +
 // remote/relocation countries) so it reuses the same list/labels as the company facet.

--- a/web/src/lib/jobMatch.ts
+++ b/web/src/lib/jobMatch.ts
@@ -134,7 +134,7 @@ export function matchTeaser(seed: string, jobSkills: string[]): MatchTeaser | nu
   const missing = new Set(
     jobSkills
       .map((name) => ({ name, key: rand() }))
-      .toSorted((a, b) => a.key - b.key)
+      .sort((a, b) => a.key - b.key)
       .slice(0, total - matched)
       .map((s) => s.name),
   );

--- a/web/src/lib/pagination.ts
+++ b/web/src/lib/pagination.ts
@@ -81,7 +81,7 @@ export function pageWindow(current: number, total: number): (number | null)[] {
     if (p >= 1 && p <= total) around.add(p);
   }
 
-  const pages = [...around].toSorted((a, b) => a - b);
+  const pages = [...around].sort((a, b) => a - b);
   const out: (number | null)[] = [];
   for (const [i, page] of pages.entries()) {
     const previous = pages[i - 1];

--- a/web/src/lib/roleSuggest.ts
+++ b/web/src/lib/roleSuggest.ts
@@ -143,7 +143,7 @@ export function suggestRoles(
       return { suggestion, tier: matchTier(o, q) };
     })
     .filter((r) => r.tier < fuzzyOnlyTier)
-    .toSorted(
+    .sort(
       (a, b) =>
         a.tier - b.tier ||
         gradePenalty(a.suggestion.slug) - gradePenalty(b.suggestion.slug) ||

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -203,7 +203,7 @@ function applicantRegions(
     : (regions ?? []).flatMap((r) => REGION_COUNTRIES[r] ?? []);
   const named = [
     ...new Set(iso.map(countryName).filter((n): n is string => Boolean(n))),
-  ].toSorted();
+  ].sort();
   if (named.length === 0) return undefined;
   const entries: CountryRef[] = named.map((name) => ({ '@type': 'Country', name }));
   // schema.org reads a lone object and a one-element array alike; emit the object

--- a/web/src/lib/sitemap.ts
+++ b/web/src/lib/sitemap.ts
@@ -69,7 +69,7 @@ export function collectionPaths(): string[] {
  *  its own schedule. The index carries the newest post's date, since that is
  *  exactly when its content last changed. */
 export function blogPaths(posts: { slug: string; date: string }[]): PathEntry[] {
-  const newest = posts.map((post) => post.date).toSorted().at(-1);
+  const newest = posts.map((post) => post.date).sort().at(-1);
   return [
     { path: '/blog', lastmod: newest },
     ...posts.map((post) => ({ path: `/blog/${post.slug}`, lastmod: post.date })),

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { navigating, page } from '$app/state';
-  import { afterNavigate } from '$app/navigation';
+  import { navigating, page, updated } from '$app/state';
+  import { afterNavigate, beforeNavigate } from '$app/navigation';
   import { onMount } from 'svelte';
   import { initTheme } from '$lib/theme.svelte';
   import { isAuthenticated } from '$lib/auth.svelte';
@@ -90,10 +90,25 @@
     if (!isAuthenticated()) resetUserStores();
   });
 
-  // Analytics is inert unless PostHog was initialized (see hooks.client.ts), so
-  // every call below is a no-op when the key is absent. afterNavigate also fires
-  // on the initial load, so the pageview and the replay privacy toggle cover a
-  // hard-loaded route too — replay is stopped on /my/* before it can leak.
+  // A tab open across a deploy still holds the old build's route manifest, naming
+  // _app/immutable chunks the release has deleted. Its next client-side navigation
+  // import()s one, gets a 404, and SvelteKit draws the 500 page over an HTTP 200 —
+  // 265 of those reached Sentry in a day. `updated.current` flips once the version
+  // poll (see svelte.config.js) sees a new build; leaving through a full page load
+  // instead of a client-side one fetches the new manifest and the chunk resolves.
+  //
+  // Not a second copy of the service worker's onNeedReload prompt above: that one
+  // asks a tab sitting still whether to reload NOW, and takes a confirmation because
+  // saying yes drops whatever is half-typed. This one waits until the reader is
+  // already leaving, where nothing they were looking at survives the navigation
+  // either way — so it needs no prompt, and costs only the round trip. It also
+  // covers the tab whose service worker never registered, which is how these 404s
+  // outlived the `paths.relative` fix. `willUnload` means the browser is handling
+  // the navigation itself (external link, reload) and there is nothing to intercept.
+  beforeNavigate(({ willUnload, to }) => {
+    if (updated.current && !willUnload && to?.url) location.href = to.url.href;
+  });
+
   afterNavigate(() => {
     capturePageview();
     syncReplayForRoute(page.url.pathname);

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -15,6 +15,15 @@ export default {
     // and API same-origin for the SameSite=Lax auth cookie.
     adapter: adapter(),
 
+    // Poll _app/version.json so `updated` can tell an open tab that the build it
+    // was served has been replaced. Without this Kit never checks, `updated.current`
+    // stays false forever, and the first the tab hears of a deploy is a dynamic
+    // import 404ing for a chunk the release deleted — which reaches the reader as
+    // the 500 page. The service-worker fix below removed one route to that failure;
+    // this closes the other, for a tab that simply sat open across a release.
+    // Five minutes: a deploy runs every few hours, and the file is a few bytes.
+    version: { pollInterval: 300_000 },
+
     // Absolute asset paths. Kit defaults `relative` to true, which sets Vite's
     // `base` to './' — and @vite-pwa/sveltekit reads that base directly
     // (`base = viteOptions.base ?? "/"`) to build the service-worker registration.


### PR DESCRIPTION
Worked back from a day of `freehire-web` reports to the line behind each. No shared cause — four independent fixes, each with the reproduction that found it.

### `/jobs/{search,find,facets,sitemap}` → 500 on prod right now
Those four words are static API routes declared *ahead* of `/jobs/:slug`, so the backend answers 200 with its own body. `/jobs/search` handed the detail page a job **list** where a posting belonged, and SSR died on `job.enrichment.category`. `getJob` now rejects a body that is not job-shaped, so all four give the honest 404 — and a fifth static sibling added later is covered without anyone updating a list of names.

### The city picker emptied itself
`/geo/cities?q=london` returns `London/gb` **and** `London/ca`; `victoria` returns eight. A location preference stores the bare city name, so every one of those rows saves the identical value — the second option was never a real choice. It was also a duplicate key in the picker's `{#each}`, which in Svelte unmounts the entire list rather than the offending row, so typing "london" on `/my/profile` made the dropdown vanish. One name is now one option, keeping the highest-population row (`/geo/cities` ranks by population).

### `.toSorted` took the whole page down on iOS 15
Safari only grew the copying array methods in 16.4, and they are runtime methods — no build target transpiles them. The call in `facets.ts` runs during module init, so the throw killed the page, not one sorted list. Sentry has real iPhones behind it, not bots. Every call site sat on an array a `.map`/`.filter`/spread had just produced, so `.sort()` is the identical result. Lint now bans the three copying methods in shipped code (tests and `src/lib/server` excepted), and oxlint's `unicorn/no-array-sort`, which pushes the other way, is off with a note — otherwise the two linters argue over every sort.

### A tab open across a deploy drew the 500 page — 265 in a day
It still holds the old route manifest and `import()`s a chunk the release deleted. `svelte.config.js` already documents this failure and fixed one route to it (`paths.relative`); this closes the other. Kit now polls `_app/version.json`, and a stale tab leaves through the server on its next navigation — at which point nothing it was showing survives anyway, so no prompt is needed. Deliberately distinct from the service worker's `onNeedReload` prompt above it, which asks a *sitting* tab and takes a confirmation because saying yes drops unsaved work.

---
`pnpm check` 0 errors · `pnpm test` 1190 passed · `pnpm build` ok. New tests cover the non-job body and the city collapse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * City search results now consolidate duplicate city names while preserving the most relevant country information.
  * Open tabs detect new deployments and automatically refresh before loading outdated application resources.

* **Bug Fixes**
  * Invalid job routes that return unrelated data are now correctly reported as missing jobs.
  * Improved compatibility across browsers and runtimes by replacing unsupported modern sorting methods.
  * Added safeguards and test coverage for city filtering and job lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->