### PR TITLE
feat(sources): onboard contributed boards

### DIFF
--- a/sources/jibe.yml
+++ b/sources/jibe.yml
@@ -75,3 +75,6 @@
   board: jobs.medallia.com
 - company: Rivian
   board: careers.rivian.com
+
+- company: Blain's Farm and Fleet
+  board: careers.farmandfleet.com

--- a/sources/radancy.yml
+++ b/sources/radancy.yml
@@ -51,3 +51,6 @@
   board: jobs.vinci.com
 - company: Walgreens
   board: jobs.walgreens.com
+
+- company: Cargill
+  board: careers.cargill.com

--- a/sources/workday.yml
+++ b/sources/workday.yml
@@ -13159,3 +13159,6 @@
   board: uasys.wd5.myworkdayjobs.com/uams_cw_career_site
 - company: University of Washington
   board: uw.wd5.myworkdayjobs.com/uwhires
+
+- company: Zühlke
+  board: zuehlke.wd3.myworkdayjobs.com/Zuhlke-Careers

--- a/sources/workday.yml
+++ b/sources/workday.yml
@@ -13159,6 +13159,3 @@
   board: uasys.wd5.myworkdayjobs.com/uams_cw_career_site
 - company: University of Washington
   board: uw.wd5.myworkdayjobs.com/uwhires
-
-- company: Zühlke
-  board: zuehlke.wd3.myworkdayjobs.com/Zuhlke-Careers


### PR DESCRIPTION
## Onboarded boards

| Source | Board | Company | Validation |
|--------|-------|---------|------------|
| workday | `zuehlke.wd3.myworkdayjobs.com/Zuhlke-Careers` | Zühlke | POST `/wday/cxs/zuehlke/Zuhlke-Careers/jobs` → 200, 38 postings |
| radancy | `careers.cargill.com` | Cargill | GET `/sitemap.xml` (→ 301 `/en/sitemap.xml` → 200), 1 413 job locs with `/job/…/<numeric-id>` |
| jibe | `careers.farmandfleet.com` | Blain's Farm and Fleet | GET `/api/jobs` → 200, non-empty job array; company name from page `<title>` |

## Rejected boards

| ID | Source | Board | Reason |
|----|--------|-------|--------|
| 300 | phenom | `ejta.fa.us6.oraclecloud.com` | POST `/widgets` → 404. The contributed URL resolves to Oracle HCM (`/hcmUI/CandidateExperience/…`), not a Phenom board. Platform mismatch; no live API endpoint. |
| 361 | greenhouse | `external_greenhouse_job_boards` | GET `https://job-boards.greenhouse.io/external_greenhouse_job_boards` → 404 (Greenhouse "Page not found"). Not a real company board — looks like a system/meta identifier leaked from link resolution. |

## queue_review.tsv — needs human

All 80 entries in queue_review.tsv are unrecognized links contributed as raw URLs. None maps cleanly to a known board without additional investigation. Notable patterns:

- **LinkedIn individual job views** (IDs 334–390 and others): `linkedin.com/jobs/view/<id>` — single postings, not boards; no action.
- **Known aggregator pages** — ID 330 (`in.indeed.com/jobs`), ID 366 (`wellfound.com/jobs`), ID 367 (`builtin.com`), ID 328 (`linkedin.com/jobs/search-results`) — generic listing pages, not boards.
- **Non-job URLs** — ID 297 (`github.com/strelov1/freehire/pulls`), ID 307 (Notion page), ID 311 (contact page), ID 319 (Onstrider profile) — reject outright.
- **Possibly recognizable boards needing a full probe**:
  - ID 292 `topazbrasil.gupy.io` — looks like a Gupy board (`topazbrasil`); needs live validation.
  - ID 299 `fortive.eightfold.ai` — looks like an Eightfold board (`fortive`); needs live validation.
  - ID 304/395 `jobs.dayforcehcm.com` — Dayforce HCM (Ceridian); source not yet in the repo.
  - ID 313 `careers.americanexpress.com` — Oracle HCM; needs probe.
  - ID 321 `careers.walmart.com` — large board, ATS unclear; needs probe.

## SQL for merge

```sql
-- Mark onboarded
UPDATE link_contributions SET status = 'onboarded' WHERE id IN (291, 394, 396);

-- Mark rejected
UPDATE link_contributions SET status = 'rejected' WHERE id IN (300, 361);
```

onboarded=3 rejected=2 skipped=0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added career-site listings for Blain’s Farm and Fleet, Cargill, and Zühlke.
  * Added support for their respective career boards, enabling job information to be sourced from these sites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->