### PR TITLE
Stop deleting the skill embedder right after declaring it

### DIFF
--- a/cmd/reindex/skillvector_test.go
+++ b/cmd/reindex/skillvector_test.go
@@ -32,8 +32,10 @@ func TestSplitJobs_CarriesTheSkillVector(t *testing.T) {
 }
 
 // A rebuild started before the rarity rollup ever ran must still rebuild. Losing the
-// match sort for a cycle is far better than not rebuilding the index at all.
-func TestSplitJobs_WithoutWeightsStillBuildsDocuments(t *testing.T) {
+// match sort for a cycle is far better than not rebuilding the index at all — and the
+// documents must stay ACCEPTABLE to the engine, which rejects any that omits the
+// vector field once the embedder is declared.
+func TestSplitJobs_WithoutWeightsStillBuildsIndexableDocuments(t *testing.T) {
 	job := db.Job{
 		ID: 1, Title: "Go Engineer", PublicSlug: "go-x", Category: "backend",
 		Description: "<p>Build things.</p>", Skills: []string{"go"},
@@ -46,7 +48,11 @@ func TestSplitJobs_WithoutWeightsStillBuildsDocuments(t *testing.T) {
 	if len(docs) != 1 {
 		t.Fatalf("docs = %d, want 1", len(docs))
 	}
-	if docs[0].Vectors != nil {
-		t.Errorf("Vectors = %v, want nil without weights", docs[0].Vectors)
+	v, ok := docs[0].Vectors[search.SkillEmbedder]
+	if !ok {
+		t.Fatalf("no %q key; the engine would reject every document of this rebuild", search.SkillEmbedder)
+	}
+	if v != nil {
+		t.Errorf("vector = %v, want nil without weights", v)
 	}
 }

--- a/internal/dict/skillvec/AGENTS.md
+++ b/internal/dict/skillvec/AGENTS.md
@@ -63,19 +63,21 @@ Two more deliberate choices:
 - the result is floored at 1, so a skill every posting names still contributes
   something rather than vanishing from the vector entirely.
 
-`Ready()` separates "no snapshot loaded" from "this job has no skills". Callers must
-not conflate them: the first is an absence of knowledge and leaves a stored vector
-alone; the second is knowledge of an absence and clears it.
+An unloaded snapshot and a job with no skills look the same downstream, and that is
+forced rather than chosen: with the embedder declared, Meilisearch rejects a document
+that omits `_vectors`, so there is no "leave it alone" option to express. Both write
+the null opt-out. The cost is that documents written while the rollup is unavailable
+lose their vectors until the next rebuild — the indexers log loudly for that reason.
 
 ## Why `Vector` returns nil rather than a zero vector
 A zero vector is not "no opinion" — it is a document Meilisearch rejects, and a query
 that ranks against nothing. So `Vector` reports an absence: no weights loaded, no
 skills given, or no slug recognised all yield nil.
 
-What the caller does with that nil depends on WHY (see `Ready()`): with weights loaded
-it writes an explicit clear, because the index merges document fields and an omission
-would leave a stale vector ranking a job by skills it no longer has; with no weights it
-omits the field and leaves whatever is stored alone.
+The caller turns that nil into `"_vectors":{"skills":null}` — Meilisearch's documented
+opt-out. It is not an omission: the index merges document fields, so omitting would
+leave a stale vector ranking a job by skills it no longer has, AND a declared embedder
+makes the engine reject a document with no `_vectors` at all.
 
 ## Why the cosine is the score
 Vectors are unit length, so

--- a/internal/dict/skillvec/vector.go
+++ b/internal/dict/skillvec/vector.go
@@ -55,12 +55,6 @@ func WeightsFromCounts(counts map[string]int64) Weights {
 	return Weights{byPosition: byPosition}
 }
 
-// Ready reports whether these weights can build vectors at all. It distinguishes two
-// states a caller must NOT conflate: "the rarity snapshot is loaded and this job simply
-// has no recognisable skills" from "no snapshot is loaded, so nothing can be said".
-// The first is knowledge worth writing down; the second is an absence to leave alone.
-func (w Weights) Ready() bool { return len(w.byPosition) > 0 }
-
 // MarshalJSON serialises the weights as a plain array, so they can be cached between
 // requests. Without this the unexported field would encode as `{}` and decode as the
 // zero value — a cache that answers "no weights" on every hit, disabling the match

--- a/internal/dict/skillvec/vector_test.go
+++ b/internal/dict/skillvec/vector_test.go
@@ -125,8 +125,8 @@ func TestASkillListedTwiceCountsOnce(t *testing.T) {
 }
 
 func TestWeightsFromCountsRejectsAnEmptySnapshot(t *testing.T) {
-	if WeightsFromCounts(nil).Ready() {
-		t.Error("an empty snapshot produced usable weights")
+	if got := WeightsFromCounts(nil).Vector([]string{registry[0]}); got != nil {
+		t.Errorf("a nil snapshot produced %v, want no vector", got)
 	}
 	if got := WeightsFromCounts(map[string]int64{}).Vector([]string{registry[0]}); got != nil {
 		t.Errorf("an empty snapshot produced %v, want no vector", got)

--- a/internal/search/search/AGENTS.md
+++ b/internal/search/search/AGENTS.md
@@ -139,6 +139,18 @@ restart web.
 rebuild**, and until that rebuild finishes the index rejects every document carrying
 the new width.
 
+**The embedder reset runs BEFORE the settings update, never after.** Meilisearch merges
+settings, and it merges `embedders` BY KEY — an update naming one embedder leaves any
+other in place — so the reset still has to happen or an index a prior version gave a
+model-backed embedder would keep embedding forever. But doing it afterwards deletes the
+embedder the settings just declared. That shipped once: `EnsureIndex` and
+`Rebuild.Prepare` each declared the skill embedder and immediately reset it, so a
+rebuild would have produced an index with no embedder while every unit test passed and
+nothing logged. The order now lives in `ensure()` alone, and
+`embedder_integration_test.go` asserts the embedder survives both paths against a real
+engine — which is the only place that claim can be tested, since a unit test of
+`facetSettings()` cannot see what the index ends up with.
+
 A rebuild with vectors is materially slower and larger than one without — the cost is
 HNSW graph construction, so it lands on full rebuilds, not on incremental
 `search_outbox` pushes. Schedule it deliberately; `freehire-reindexw` has outgrown its

--- a/internal/search/search/client.go
+++ b/internal/search/search/client.go
@@ -316,12 +316,17 @@ func (c *Client) ensure(ctx context.Context, idx meilisearch.IndexManager, uid, 
 	if err != nil {
 		return fmt.Errorf("search: reset embedders on %s: %w", uid, err)
 	}
-	if err := c.awaitTask(ctx, idx, reset.TaskUID); err != nil {
-		return err
-	}
+	// Queue the settings WITHOUT awaiting the reset. Meilisearch runs one serial task
+	// queue per index, so submission order IS execution order — the reset still lands
+	// first. Awaiting it here instead would leave a live index embedder-less for the
+	// round trip between the two, and a match-sort query arriving in that window gets a
+	// 400. Both task ids are awaited below, in the order they were queued.
 	st, err := idx.UpdateSettingsWithContext(ctx, settings)
 	if err != nil {
 		return fmt.Errorf("search: update settings: %w", err)
+	}
+	if err := c.awaitTask(ctx, idx, reset.TaskUID); err != nil {
+		return err
 	}
 	return c.awaitTask(ctx, idx, st.TaskUID)
 }

--- a/internal/search/search/client.go
+++ b/internal/search/search/client.go
@@ -169,23 +169,14 @@ func NewClient(url, key string, opts ...Option) *Client {
 	return c
 }
 
-// EnsureIndex creates the facet/keyword jobs index (no embedder) and applies its
-// settings. It is idempotent — safe to call on every reindex. This is the fast
+// EnsureIndex creates the facet/keyword jobs index and applies its settings,
+// including the userProvided skill embedder behind the match sort. It is idempotent — safe to call on every reindex. This is the fast
 // production index that all default (keyword) traffic and faceting hit.
 func (c *Client) EnsureIndex(ctx context.Context) error {
-	if err := c.ensure(ctx, c.facet, facetIndexUID, primaryKey, facetSettings()); err != nil {
-		return err
-	}
-	// Meilisearch settings updates MERGE: facetSettings omits the embedder, but an
-	// omitted (nil or empty) embedders map LEAVES any embedder a prior version put
-	// on this index in place — so a `jobs` index that once carried the embedder
-	// would keep embedding on every facet reindex, defeating the split. Reset it
-	// explicitly. On an index that never had one this is a harmless no-op.
-	task, err := c.facet.ResetEmbeddersWithContext(ctx)
-	if err != nil {
-		return fmt.Errorf("search: reset facet embedders: %w", err)
-	}
-	return c.awaitTask(ctx, c.facet, task.TaskUID)
+	// ensure() clears inherited embedders before applying these settings, so the live
+	// set ends up as exactly the one facetSettings declares — the skill embedder and
+	// nothing else. See ensure() for why the order is load-bearing.
+	return c.ensure(ctx, c.facet, facetIndexUID, primaryKey, facetSettings())
 }
 
 // Rebuild is a fresh-index build session for a full reindex. Documents are streamed
@@ -223,16 +214,10 @@ func (r *Rebuild) Prepare(ctx context.Context) error {
 		return err
 	}
 	r.rebuild = r.c.manager.Index(r.rebuildUID)
-	if err := r.c.ensure(ctx, r.rebuild, r.rebuildUID, primaryKey, r.settings); err != nil {
-		return err
-	}
-	// The facet index carries no embedder; reset it in case a prior version left one
-	// (mirrors EnsureIndex).
-	task, err := r.rebuild.ResetEmbeddersWithContext(ctx)
-	if err != nil {
-		return fmt.Errorf("search: reset rebuild embedders: %w", err)
-	}
-	return r.c.awaitTask(ctx, r.rebuild, task.TaskUID)
+	// ensure() clears inherited embedders first, so the rebuild index carries exactly
+	// the embedders these settings declare — which is how the skill embedder reaches
+	// production at all.
+	return r.c.ensure(ctx, r.rebuild, r.rebuildUID, primaryKey, r.settings)
 }
 
 // Push enqueues a batch into the rebuild index WITHOUT waiting for it to finish —
@@ -313,6 +298,25 @@ func (c *Client) swapIndexes(ctx context.Context, a, b string) error {
 // index (slug-keyed, see company.go) differ only in uid, primary key, and settings.
 func (c *Client) ensure(ctx context.Context, idx meilisearch.IndexManager, uid, pk string, settings *meilisearch.Settings) error {
 	if err := c.createIndex(ctx, idx, uid, pk); err != nil {
+		return err
+	}
+	// Reset embedders BEFORE applying the settings, never after.
+	//
+	// Meilisearch merges settings updates, and it merges `embedders` BY KEY: an update
+	// naming one embedder leaves any other in place. So the reset is still needed — an
+	// index that a prior version gave a model-backed embedder would otherwise keep
+	// embedding every document forever — but doing it afterwards deletes the embedder
+	// the settings just declared. That is exactly what used to happen here, and it made
+	// a rebuild ship an index with no skill embedder while every unit test still passed.
+	//
+	// Ordering it first means the live embedder set ends up as EXACTLY what `settings`
+	// declares: nothing inherited, nothing dropped. An index with no embedder is
+	// unaffected either way.
+	reset, err := idx.ResetEmbeddersWithContext(ctx)
+	if err != nil {
+		return fmt.Errorf("search: reset embedders on %s: %w", uid, err)
+	}
+	if err := c.awaitTask(ctx, idx, reset.TaskUID); err != nil {
 		return err
 	}
 	st, err := idx.UpdateSettingsWithContext(ctx, settings)

--- a/internal/search/search/document.go
+++ b/internal/search/search/document.go
@@ -84,22 +84,24 @@ type JobDocument struct {
 	// internal/dict/skillvec). Like Roles and RoleType it lives on the document rather
 	// than jobview.Job, so it never enters the public wire shape.
 	//
-	// It has THREE meaningful states, because the indexers push with PUT — Meilisearch's
-	// add-or-update, which MERGES fields rather than replacing the document:
+	// The key is ALWAYS present, and carries one of two values:
 	//
 	//   {skills: vec}   the job's vector.
-	//   {skills: nil}   serialises as `"skills":null` and CLEARS a stored vector. This is
-	//                   what a job that LOST its skills needs: omitting the key would
-	//                   merge, leaving the old vector in place and the posting ranking by
-	//                   skills it no longer has. Verified against a live engine.
-	//   nil             the key is absent, so whatever is stored is left untouched. Used
-	//                   ONLY when the rarity weights could not be loaded — an absence of
-	//                   knowledge, not knowledge of an absence. Clearing every vector a
-	//                   rebuild wrote because one drain wave could not read a snapshot
-	//                   would take the sort down by itself.
+	//   {skills: nil}   serialises as `"skills":null`, which is Meilisearch's documented
+	//                   opt-out. It both declines to provide a vector AND clears any
+	//                   previously stored one — the latter matters because the indexers
+	//                   push with PUT (add-or-update), which merges fields, so a job
+	//                   that lost its skills would otherwise keep ranking by them.
 	//
-	// `omitempty` is what distinguishes that third state from the first two.
-	Vectors map[string][]float32 `json:"_vectors,omitempty"`
+	// Omitting the key is NOT a third state: with the embedder declared, Meilisearch
+	// rejects the whole document ("no vectors provided for document"), which would drop
+	// the posting out of the index rather than merely out of the match ordering. That
+	// costs a searchable job; a lost vector costs an ordering the next rebuild restores.
+	//
+	// The consequence is worth naming: while the rarity weights are unavailable, every
+	// document written carries a null and loses its vector. The indexers log loudly for
+	// exactly this reason, and the next rebuild with weights repairs it.
+	Vectors map[string][]float32 `json:"_vectors"`
 }
 
 // SkillEmbedder is the name of the Meilisearch embedder carrying skill vectors. It
@@ -146,11 +148,10 @@ func FromJob(j db.Job, w skillvec.Weights) (JobDocument, error) {
 	if eff := jobview.EffectivePostedAt(j.PostedAt, j.CreatedAt, time.Now()); eff.Valid {
 		doc.PostedTS = eff.Time.Unix()
 	}
-	// Set the vector — or an explicit null that CLEARS a stored one — but only when the
-	// weights are loaded. See JobDocument.Vectors for why the three states differ.
-	if w.Ready() {
-		doc.Vectors = map[string][]float32{SkillEmbedder: w.Vector(j.Skills)}
-	}
+	// ALWAYS set the key. With the embedder declared, Meilisearch REJECTS any document
+	// that omits it — "no vectors provided for document" — so an omission is not a
+	// no-op, it drops the posting out of the index entirely.
+	doc.Vectors = map[string][]float32{SkillEmbedder: w.Vector(j.Skills)}
 	return doc, nil
 }
 

--- a/internal/search/search/document_vector_test.go
+++ b/internal/search/search/document_vector_test.go
@@ -64,25 +64,29 @@ func TestFromJobWithNoSkillsClearsTheVector(t *testing.T) {
 	}
 }
 
-// Weights being unavailable is NOT the same as a job having no skills, and the
-// difference matters: "no weights" means the rarity rollup has not run or failed, and
-// wiping every vector a rebuild wrote because a drain wave could not read a snapshot
-// would be a self-inflicted outage of the whole sort. So an unweighted document omits
-// the key entirely and leaves whatever is stored alone.
-func TestFromJobWithoutWeightsLeavesTheStoredVectorAlone(t *testing.T) {
+// The key is present even with no weights loaded, and this is NOT a nicety: with the
+// embedder declared, Meilisearch rejects a document that omits it outright ("no vectors
+// provided for document"). Omitting would drop the posting out of the index entirely,
+// which costs a searchable job — far worse than the lost ordering a null costs, which
+// the next rebuild repairs.
+func TestFromJobWithoutWeightsStillCarriesTheKey(t *testing.T) {
 	doc, err := FromJob(db.Job{ID: 1, PublicSlug: "s", Title: "Engineer", Skills: []string{"go"}}, skillvec.Weights{})
 	if err != nil {
 		t.Fatalf("FromJob: %v", err)
 	}
-	if doc.Vectors != nil {
-		t.Errorf("Vectors = %v; with no weights loaded the key must be absent, not a null clear", doc.Vectors)
+	v, ok := doc.Vectors[SkillEmbedder]
+	if !ok {
+		t.Fatalf("no %q key with unloaded weights; the engine would reject the document", SkillEmbedder)
+	}
+	if v != nil {
+		t.Errorf("vector = %v, want nil", v)
 	}
 	b, err := json.Marshal(doc)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if bytes.Contains(b, []byte(`"_vectors"`)) {
-		t.Errorf("serialised as %s, want no _vectors key at all", b)
+	if !bytes.Contains(b, []byte(`"_vectors":{"skills":null}`)) {
+		t.Errorf("serialised as %s, want the documented null opt-out", b)
 	}
 }
 

--- a/internal/search/search/embedder_integration_test.go
+++ b/internal/search/search/embedder_integration_test.go
@@ -13,6 +13,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/meilisearch/meilisearch-go"
+
 	"github.com/strelov1/freehire/internal/dict/skillvec"
 	"github.com/strelov1/freehire/internal/platform/db"
 )
@@ -142,19 +144,24 @@ func TestIntegration_LosingSkillsClearsTheStoredVector(t *testing.T) {
 		t.Fatalf("IndexJobs (cleared): %v", err)
 	}
 
-	// The claim itself: the job no longer ranks by the vector it used to carry.
-	res, err := c.Search(ctx, SearchParams{Vector: w.Vector([]string{"go"}), Limit: 10})
-	if err != nil {
-		t.Fatalf("vector Search after clearing: %v", err)
+	// Read the STORED document rather than inferring from a search. A vector search
+	// over a one-document index returns that document whether or not it has a vector,
+	// so "is it still in the results" cannot answer this; "what does the index hold"
+	// can.
+	var stored struct {
+		Vectors map[string]struct {
+			Embeddings [][]float32 `json:"embeddings"`
+		} `json:"_vectors"`
 	}
-	for _, h := range res.Hits {
-		if h.ID == 1 {
-			t.Error("the job still ranks by a vector it no longer has — the clear merged instead of replacing")
-		}
+	if err := c.facet.GetDocumentWithContext(ctx, "1", &meilisearch.DocumentQuery{RetrieveVectors: true}, &stored); err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if n := len(stored.Vectors[SkillEmbedder].Embeddings); n != 0 {
+		t.Errorf("the index still holds %d embedding(s) for a job with no skills — the clear merged instead of replacing", n)
 	}
 
-	// And it is still there: clearing a vector is not a deletion.
-	res, err = c.Search(ctx, SearchParams{Query: "Go Engineer", Limit: 10})
+	// And the job is still there: clearing a vector is not a deletion.
+	res, err := c.Search(ctx, SearchParams{Query: "Go Engineer", Limit: 10})
 	if err != nil {
 		t.Fatalf("keyword Search: %v", err)
 	}

--- a/internal/search/search/embedder_integration_test.go
+++ b/internal/search/search/embedder_integration_test.go
@@ -1,0 +1,154 @@
+//go:build integration
+
+// Integration tests for the skill embedder's LIFECYCLE against a real engine: that it
+// survives the very calls that apply index settings.
+//
+// The unit tests assert facetSettings() declares the embedder. That is not the same
+// claim: settings are applied and then adjusted, so an embedder can be declared and
+// still be absent from the live index a moment later. This file tests the index, not
+// the struct.
+package search
+
+import (
+	"context"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/dict/skillvec"
+	"github.com/strelov1/freehire/internal/platform/db"
+)
+
+// TestIntegration_EnsureIndexLeavesTheSkillEmbedderInPlace is the regression that
+// matters: EnsureIndex applies the settings and then used to reset every embedder,
+// which would have declared the skill embedder and deleted it in the same call. The
+// match sort would have returned a 400 with nothing in the code looking wrong.
+func TestIntegration_EnsureIndexLeavesTheSkillEmbedderInPlace(t *testing.T) {
+	ctx := context.Background()
+	c := startMeili(t)
+
+	if err := c.EnsureIndex(ctx); err != nil {
+		t.Fatalf("EnsureIndex: %v", err)
+	}
+
+	got, err := c.facet.GetEmbeddersWithContext(ctx)
+	if err != nil {
+		t.Fatalf("GetEmbedders: %v", err)
+	}
+	e, ok := got[SkillEmbedder]
+	if !ok {
+		t.Fatalf("the live index carries no %q embedder after EnsureIndex; it has %v", SkillEmbedder, got)
+	}
+	if e.Dimensions != skillvec.Dimensions {
+		t.Errorf("live embedder dimensions = %d, want %d", e.Dimensions, skillvec.Dimensions)
+	}
+}
+
+// A rebuild is how the embedder reaches production at all, so the same claim has to
+// hold for the index a rebuild prepares — and it is the path that was broken.
+func TestIntegration_RebuildPreparesTheSkillEmbedder(t *testing.T) {
+	ctx := context.Background()
+	c := startMeili(t)
+
+	r := c.NewFacetRebuild()
+	if err := r.Prepare(ctx); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	got, err := r.rebuild.GetEmbeddersWithContext(ctx)
+	if err != nil {
+		t.Fatalf("GetEmbedders: %v", err)
+	}
+	if _, ok := got[SkillEmbedder]; !ok {
+		t.Fatalf("the rebuild index carries no %q embedder; a rebuild would ship without the match sort", SkillEmbedder)
+	}
+}
+
+// End to end against the engine: a document carrying a vector is accepted, and a
+// vector search over it ranks. This is what a 400 from a missing embedder would break.
+func TestIntegration_VectorSearchRanksByTheSkillVector(t *testing.T) {
+	ctx := context.Background()
+	c := startMeili(t)
+
+	if err := c.EnsureIndex(ctx); err != nil {
+		t.Fatalf("EnsureIndex: %v", err)
+	}
+
+	w := skillvec.WeightsFromCounts(map[string]int64{"go": 5000, "docker": 4000, "erlang": 12})
+	jobs := []db.Job{
+		{ID: 1, Title: "Go Engineer", Company: "Acme", Location: "Berlin", PublicSlug: "go-acme-a",
+			Category: "backend", Description: "Build things.", Skills: []string{"go", "docker"}},
+		{ID: 2, Title: "Erlang Engineer", Company: "Beta", Location: "Berlin", PublicSlug: "erlang-beta-b",
+			Category: "backend", Description: "Build other things.", Skills: []string{"erlang"}},
+	}
+	docs := make([]JobDocument, 0, len(jobs))
+	for _, j := range jobs {
+		d, err := FromJob(j, w)
+		if err != nil {
+			t.Fatalf("FromJob: %v", err)
+		}
+		docs = append(docs, d)
+	}
+	if err := c.IndexJobs(ctx, docs); err != nil {
+		t.Fatalf("IndexJobs: %v", err)
+	}
+
+	// A candidate who knows Go and Docker: the Go posting must come first.
+	res, err := c.Search(ctx, SearchParams{Vector: w.Vector([]string{"go", "docker"}), Limit: 10})
+	if err != nil {
+		t.Fatalf("vector Search: %v", err)
+	}
+	if len(res.Hits) == 0 {
+		t.Fatal("vector search returned nothing")
+	}
+	if res.Hits[0].ID != 1 {
+		t.Errorf("top hit id = %d, want 1 (the Go posting) — ranking is not following the vector", res.Hits[0].ID)
+	}
+}
+
+// The clearing semantics, against the engine that motivated them: pushing a job that
+// has lost its skills must remove the stored vector, not merge around it.
+func TestIntegration_LosingSkillsClearsTheStoredVector(t *testing.T) {
+	ctx := context.Background()
+	c := startMeili(t)
+
+	if err := c.EnsureIndex(ctx); err != nil {
+		t.Fatalf("EnsureIndex: %v", err)
+	}
+
+	w := skillvec.WeightsFromCounts(map[string]int64{"go": 5000, "docker": 4000})
+	job := db.Job{ID: 1, Title: "Go Engineer", Company: "Acme", Location: "Berlin",
+		PublicSlug: "go-acme-a", Category: "backend", Description: "Build things.",
+		Skills: []string{"go", "docker"}}
+
+	withSkills, err := FromJob(job, w)
+	if err != nil {
+		t.Fatalf("FromJob: %v", err)
+	}
+	if err := c.IndexJobs(ctx, []JobDocument{withSkills}); err != nil {
+		t.Fatalf("IndexJobs: %v", err)
+	}
+	if res, err := c.Search(ctx, SearchParams{Vector: w.Vector([]string{"go"}), Limit: 10}); err != nil {
+		t.Fatalf("vector Search: %v", err)
+	} else if len(res.Hits) == 0 {
+		t.Fatal("the job is not rankable by vector before losing its skills")
+	}
+
+	// The same job, re-indexed with its skills gone.
+	job.Skills = nil
+	cleared, err := FromJob(job, w)
+	if err != nil {
+		t.Fatalf("FromJob: %v", err)
+	}
+	if err := c.IndexJobs(ctx, []JobDocument{cleared}); err != nil {
+		t.Fatalf("IndexJobs (cleared): %v", err)
+	}
+
+	// The job must still be there and findable by text — clearing a vector is not a
+	// deletion.
+	res, err := c.Search(ctx, SearchParams{Query: "Go Engineer", Limit: 10})
+	if err != nil {
+		t.Fatalf("keyword Search: %v", err)
+	}
+	if len(res.Hits) == 0 {
+		t.Error("clearing the vector removed the job from keyword search")
+	}
+}

--- a/internal/search/search/embedder_integration_test.go
+++ b/internal/search/search/embedder_integration_test.go
@@ -142,9 +142,19 @@ func TestIntegration_LosingSkillsClearsTheStoredVector(t *testing.T) {
 		t.Fatalf("IndexJobs (cleared): %v", err)
 	}
 
-	// The job must still be there and findable by text — clearing a vector is not a
-	// deletion.
-	res, err := c.Search(ctx, SearchParams{Query: "Go Engineer", Limit: 10})
+	// The claim itself: the job no longer ranks by the vector it used to carry.
+	res, err := c.Search(ctx, SearchParams{Vector: w.Vector([]string{"go"}), Limit: 10})
+	if err != nil {
+		t.Fatalf("vector Search after clearing: %v", err)
+	}
+	for _, h := range res.Hits {
+		if h.ID == 1 {
+			t.Error("the job still ranks by a vector it no longer has — the clear merged instead of replacing")
+		}
+	}
+
+	// And it is still there: clearing a vector is not a deletion.
+	res, err = c.Search(ctx, SearchParams{Query: "Go Engineer", Limit: 10})
 	if err != nil {
 		t.Fatalf("keyword Search: %v", err)
 	}

--- a/internal/search/search/search_integration_test.go
+++ b/internal/search/search/search_integration_test.go
@@ -208,15 +208,20 @@ func TestIntegration_EnsureIndexResetsExistingEmbedder(t *testing.T) {
 	if _, err := c.facet.WaitForTaskWithContext(ctx, task.TaskUID, 50*time.Millisecond); err != nil {
 		t.Fatalf("await embedder set: %v", err)
 	}
-	if emb, err := c.facet.GetEmbeddersWithContext(ctx); err != nil || len(emb) == 0 {
-		t.Fatalf("precondition: embedder should be set (emb=%v err=%v)", emb, err)
+	emb, err := c.facet.GetEmbeddersWithContext(ctx)
+	if err != nil {
+		t.Fatalf("precondition: GetEmbedders: %v", err)
+	}
+	if _, ok := emb["manual"]; !ok {
+		t.Fatalf("precondition: the inherited embedder should be set, got %v", emb)
 	}
 
-	// EnsureIndex must strip it, leaving the facet index embedder-free.
+	// EnsureIndex must strip the inherited one and leave the skill embedder standing —
+	// not leave the index embedder-free, which is what it used to do.
 	if err := c.EnsureIndex(ctx); err != nil {
 		t.Fatalf("EnsureIndex (reset): %v", err)
 	}
-	emb, err := c.facet.GetEmbeddersWithContext(ctx)
+	emb, err = c.facet.GetEmbeddersWithContext(ctx)
 	if err != nil {
 		t.Fatalf("GetEmbedders: %v", err)
 	}

--- a/internal/search/search/search_integration_test.go
+++ b/internal/search/search/search_integration_test.go
@@ -184,10 +184,13 @@ func TestIntegration_EnsureIndexIndexAndSearch(t *testing.T) {
 	})
 }
 
-// TestIntegration_EnsureIndexResetsExistingEmbedder guards the merge-semantics
-// trap: facetSettings omits the embedder, but a Meilisearch settings update only
-// MERGES, so an embedder a prior version put on the `jobs` index would survive and
-// keep embedding on every facet reindex. EnsureIndex must reset it explicitly.
+// TestIntegration_EnsureIndexResetsExistingEmbedder guards the merge-semantics trap:
+// a Meilisearch settings update only MERGES, and merges embedders BY KEY, so one a
+// prior version put on the `jobs` index would survive every update that does not name
+// it — and keep embedding on every facet reindex. EnsureIndex must strip it.
+//
+// It must strip it WITHOUT taking the skill embedder with it, which is the whole
+// reason the reset runs before the settings rather than after (see ensure()).
 func TestIntegration_EnsureIndexResetsExistingEmbedder(t *testing.T) {
 	ctx := context.Background()
 	c := startMeili(t)
@@ -217,8 +220,11 @@ func TestIntegration_EnsureIndexResetsExistingEmbedder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetEmbedders: %v", err)
 	}
-	if len(emb) != 0 {
-		t.Errorf("EnsureIndex left embedders on the facet index: %v", emb)
+	if _, inherited := emb["manual"]; inherited {
+		t.Errorf("EnsureIndex left the inherited embedder on the facet index: %v", emb)
+	}
+	if _, ours := emb[SkillEmbedder]; !ours {
+		t.Errorf("EnsureIndex stripped the skill embedder along with the inherited one: %v", emb)
 	}
 }
 

--- a/openspec/changes/skill-match-sort/specs/skill-match-sort/spec.md
+++ b/openspec/changes/skill-match-sort/specs/skill-match-sort/spec.md
@@ -72,12 +72,12 @@ stored vector.
 - **THEN** weight loading succeeds and produces weights that build no vectors,
   rather than failing indexing or producing an unweighted ranking
 
-#### Scenario: Unloadable weights leave stored vectors alone
+#### Scenario: Unloadable weights still produce an indexable document
 
 - **WHEN** a document is built while no weights could be loaded
-- **THEN** it omits the vector field entirely rather than clearing it, so an index
-  already carrying vectors keeps them — an absence of knowledge is not knowledge of
-  an absence
+- **THEN** it carries the clearing value rather than omitting the field, so the engine
+  accepts it and the posting stays searchable — losing its match ordering until a
+  rebuild with weights restores it
 
 ### Requirement: Vector ordering rewards overlap and coverage together
 
@@ -143,10 +143,18 @@ Every code path that builds an index document SHALL supply the weights. The
 weights SHALL be a parameter of document construction rather than a field a caller
 may attach afterwards, so that a path which omits them fails to compile.
 
-A document whose weights are loaded but whose skills yield no vector SHALL carry an
-explicit CLEARING value, not an omission: the index merges document fields rather than
-replacing them, so an omitted field leaves a previously stored vector in place. Only a
-document built without loaded weights SHALL omit the field.
+Every document SHALL carry the vector field, with either a vector or an explicit
+clearing value. It SHALL NEVER be omitted, for two independent reasons: the index
+merges document fields rather than replacing them, so an omission leaves a previously
+stored vector in place; and an index with a declared embedder REJECTS a document that
+omits the field, which would drop the posting out of the index entirely rather than
+merely out of the match ordering.
+
+The second reason overrides a distinction that would otherwise be worth drawing. A
+document built while the rarity weights are unavailable therefore also carries the
+clearing value and loses its vector, even though nothing is known about its skills.
+That is a deliberate trade: a lost vector costs an ordering the next rebuild restores,
+while a rejected document costs a searchable job.
 
 #### Scenario: An indexed job carries its vector
 

--- a/openspec/changes/skill-match-sort/specs/skill-match-sort/spec.md
+++ b/openspec/changes/skill-match-sort/specs/skill-match-sort/spec.md
@@ -95,14 +95,15 @@ scarce skill the candidate happens to hold CAN outrank a broader match on common
 ones, and SHOULD: that is what weighting by rarity means. The system SHALL NOT cap
 or flatten the weights to force a count-based order.
 
-A vector SHALL be absent — not zero-valued — when it would be meaningless: no
-weights available, no skills given, or no skill recognised. An absent vector is an
-omission the caller propagates, never a vector that ranks against everything.
+Vector CONSTRUCTION SHALL report no vector — not a zero-valued one — when the result
+would be meaningless: no weights available, no skills given, or no skill recognised. A
+zero vector is not "no opinion"; it ranks against everything.
 
-The two absences SHALL be distinguished where they reach the index. A job whose
-skills are gone SHALL have any stored vector CLEARED, since the index merges rather
-than replaces documents and an omission would leave it ranking by skills it no longer
-has. A job built without loaded weights SHALL leave the stored vector untouched.
+Document SERIALISATION is a separate question and answers it uniformly: the document
+always carries the vector field, with the clearing value standing in for every one of
+those cases. The two layers deliberately differ — construction distinguishes why there
+is no vector, the wire shape cannot, because a declared embedder rejects a document
+that omits the field.
 
 #### Scenario: A well-targeted vacancy outranks both extremes
 


### PR DESCRIPTION
Follow-up to #2220, found while verifying the deployment path rather than by a test.

## The bug

`EnsureIndex` and `Rebuild.Prepare` each applied the index settings and then called
`ResetEmbedders`. Now that the settings declare the skill embedder, that deleted it in
the same call.

A full rebuild — the only way the embedder reaches production — would have produced an
index with **no** embedder. Every `sort=match` query would then 400, which this
package's error mapping turns into a 500. Meanwhile `facetSettings()` still declared
the embedder and every unit test still passed. Nothing would have logged.

## The fix

The reset is still necessary. Meilisearch merges settings, and merges `embedders` **by
key**: an update naming one embedder leaves any other in place, so an index that a
prior version gave a model-backed embedder would keep it — and keep embedding every
document — through any update that does not mention it.

What was wrong is the order. The reset moves into `ensure()`, **before** the settings
update, so the live embedder set ends up as exactly what the settings declare: nothing
inherited, nothing dropped. Both call sites lose their trailing reset.

## Tests

The gap was structural: a unit test over `facetSettings()` asserts what we *ask for*,
and only a live engine shows what the index *ends up with*. That is precisely where the
two diverged, so the new coverage is integration-tagged:

- the embedder survives `EnsureIndex`, at the declared width
- the embedder survives `Rebuild.Prepare` — the path that was broken
- a vector search ranks end to end against a real engine
- a job that loses its skills has its stored vector cleared, and stays findable by text

## Verification

`gofmt` clean, `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`,
`go test ./...`, `golangci-lint` clean on changed files. Integration tests run in CI —
Docker would not start locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed skill-based search setup so the configured skill embedder remains available after index creation and rebuilds.
  * Improved vector search ranking for skill matches.
  * Ensured stored skill vectors are cleared when a job’s skills are removed or matching data is unavailable, while keeping jobs searchable by keyword.
  * Preserved indexable documents when skill-matching weights cannot be loaded.

* **Tests**
  * Added coverage for embedder availability, vector ranking, skill removal, and unavailable matching data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->