### PR TITLE
Remove a 26 MB worker binary from the repo, and guard against the next one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,27 +16,57 @@ hire
 # ignored every new file under internal/migrate/, and `enrich`/`embed`/`ingest` did the same
 # to theirs. 26 package directories were shadowed this way; a new source file in one of them
 # would simply never be committed.
+/apple-revoke
+/auth-cleanup
+/backfill-application-events
+/backfill-applications
+/backfill-blank-company
 /backfill-company-info
 /backfill-company-names
 /backfill-derive
 /backfill-descriptions
+/backfill-duplicate-marker-owner
+/backfill-echojobs
 /backfill-experience
+/backfill-resume-geo
 /backfill-resume-structured
+/backfill-slug-folded
+/broadcast
+/cal-sync
+/capture-apply-form
 /classify-mail
+/cv-previews
 /embed
 /enrich
+/ghost-crosscheck
 /gmail-sync
+/harvest-linkedin
+/harvest-orphans
 /hire-api
+/hydrate-adzuna-description
+/import-company-industries
 /ingest
 /liveness
 /mail-ingest
+/mail-preview
 /migrate
 /mine-titles
 /notify
+/nudge
+/onboarding
 /prune
+/push-receipts
+/queue-metrics
 /recount-companies
 /reindex
 /remind
+/resolve-url
+/rollup-company
+/rollup-views
+/search-drain
+/seed-adzuna-description-queue
+/similar-backfill
+/validate-sources
 # Root-level build output of `go build ./cmd/<name>/` — never commit these artifacts.
 /backfill-company-info
 /backfill-derive

--- a/internal/platform/arch/gitignore_test.go
+++ b/internal/platform/arch/gitignore_test.go
@@ -1,0 +1,59 @@
+package arch
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/platform/modroot"
+)
+
+// TestEveryCmdBinaryIsGitignored keeps .gitignore in step with cmd/.
+//
+// release.sh builds every cmd/ target into the checkout ROOT, so each one lands there
+// as an untracked file. A target missing from .gitignore is one `git add -A` away from
+// being committed as a ~26 MB blob — and once committed, it blocks `git pull` on every
+// deploy host that already has its own build sitting there, which fails the release
+// outright.
+//
+// That has now happened twice: `prune` in #1212, and `search-drain` in #2220, which
+// found 30 further targets the hand-maintained list had never caught up with. The list
+// is deliberately explicit rather than a glob (see .gitignore's own comment: a bare
+// name matches at any depth and would shadow the package directory of the same name),
+// so it needs something to keep it honest. This is that something.
+func TestEveryCmdBinaryIsGitignored(t *testing.T) {
+	root, err := modroot.Find()
+	if err != nil {
+		t.Fatalf("locate module root: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(root, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	ignored := make(map[string]bool)
+	for _, line := range strings.Split(string(raw), "\n") {
+		ignored[strings.TrimSpace(line)] = true
+	}
+
+	entries, err := os.ReadDir(filepath.Join(root, "cmd"))
+	if err != nil {
+		t.Fatalf("read cmd/: %v", err)
+	}
+	var missing []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		// Anchored: an unanchored name would also ignore internal/<name>/ and silently
+		// swallow new source files there.
+		if !ignored["/"+e.Name()] {
+			missing = append(missing, "/"+e.Name())
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("cmd/ targets with no anchored .gitignore entry — a build in the checkout root can be committed as a multi-MB blob and break every deploy:\n\t%s",
+			strings.Join(missing, "\n\t"))
+	}
+}

--- a/internal/platform/arch/layering/blocks.go
+++ b/internal/platform/arch/layering/blocks.go
@@ -39,7 +39,7 @@ var blocks = map[string][]string{
 	// config-to-Settings conversion across eight cmd/ entrypoints or to add a package
 	// holding one function. The classification was wrong, not the code.
 	"platform": {
-		"arch/layering", "backfillpage", "blobstore", "cache", "config", "database", "db",
+		"arch", "arch/layering", "backfillpage", "blobstore", "cache", "config", "database", "db",
 		"externalid", "flexjson", "htmltext", "isoweek", "linktoken", "llm", "llmschema", "migrate",
 		"modroot", "observability", "outbox", "pgconv", "pgerr", "safehttp", "stringset", "testdb",
 		"tokencrypt", "tracerlink", "worker",


### PR DESCRIPTION
**This is why the releases for #2220 and #2221 failed.**

I committed `cmd/search-drain`'s build output in #2220. `release.sh` builds every `cmd/`
target into the checkout **root**, `go build ./cmd/search-drain/` does the same thing
locally, and `git add -A` took the 26 MB result.

A committed worker binary then blocks `git pull` on every deploy host that already has
its own build sitting there:

```
error: The following untracked working tree files would be overwritten by merge:
        search-drain
```

`.gitignore`'s own comment records this happening before — `prune`, 25 MB, in #1212.

## Why the fix is bigger than one line

The ignore list is maintained by hand and had fallen **30 targets behind**. Removing
only `search-drain` would leave thirty more loaded guns, so all thirty are added.

More usefully, a test now requires every `cmd/` directory to have an anchored
`.gitignore` entry, so the list cannot drift again. Verified it fails when it should:
removing `/search-drain` from `.gitignore` makes it red and name the missing entry.

It stays an explicit list rather than becoming a glob, for the reason `.gitignore`
already documents: an unanchored bare name matches at any depth and would shadow the
package directory of the same name — which once silently ignored every new file under
`internal/migrate/` and 25 other packages.

## Not done here

The 26 MB blob stays in git history; removing it means a force-push over `main`, which
is not worth it for a 238 MB repo. Only the checked-out file is gone, which is what
unblocks the deploys.

The deeper fix is `release.sh` building into `bin/` (already ignored) instead of the
checkout root, but that lives in the ops repo and every systemd unit references
`/opt/freehire/src/hire-current/<name>`, so it is a separate, coordinated change.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` (175 packages), `gofmt` clean,
`golangci-lint` clean on changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated repository ignore rules so worker binaries are excluded only from the intended locations.
  - Added safeguards to verify all command-line binaries are properly ignored.

- **Refactor**
  - Updated platform package organization so architecture-related packages are included in platform package mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->