### PR TITLE
Make coverage decide the match order, not raw overlap

### DIFF
--- a/internal/api/handler/search.go
+++ b/internal/api/handler/search.go
@@ -163,7 +163,8 @@ func (h *searchHandlers) matchVector(c *fiber.Ctx) []float32 {
 	if err != nil {
 		return nil
 	}
-	return weights.Vector(profile.Skills)
+	// ProfileVector, never JobVector: the ballast belongs to the stored side only.
+	return weights.ProfileVector(profile.Skills)
 }
 
 // skillWeights reads the rarity snapshot through a best-effort cache. The snapshot is

--- a/internal/dict/skillvec/AGENTS.md
+++ b/internal/dict/skillvec/AGENTS.md
@@ -79,19 +79,41 @@ opt-out. It is not an omission: the index merges document fields, so omitting wo
 leave a stale vector ranking a job by skills it no longer has, AND a declared embedder
 makes the engine reject a document with no `_vectors` at all.
 
-## Why the cosine is the score
+## Why the cosine is the score, and why it needed a ballast
 Vectors are unit length, so
 
 ```text
 cos(A, B) = Σ idf(s)² over s ∈ A∩B  /  (‖A‖ · ‖B‖)
 ```
 
-The numerator is the weighted overlap; the denominator penalises both the one-tag
-vacancy (which would otherwise score 100% coverage) and the thirty-tag requirements
-dump (which would otherwise win on volume). `TestCosineOrdersOverlapAndCoverage`
-pins that worked example — **at equal rarity**, which is the qualifier that matters.
-A vacancy asking only for a scarce skill the candidate holds CAN outrank a broader
-match on ubiquitous ones, and should: that is what weighting by rarity means. Do not
+That alone is NOT enough, and the reason is worth understanding before touching this.
+When a vacancy sits almost entirely inside a large profile, the expression collapses to
+roughly `√(overlap) / ‖A‖` — it rewards the SIZE of the overlap, and the denominator
+only penalises the vacancy's skills the reader does NOT hold. So a posting listing 79
+skills of which the reader holds 63 beats one listing 5 they hold entirely.
+
+That is not theoretical. Against a real 162-skill profile the entire top ten was
+postings carrying 52-92 skills, out of a catalogue whose median is **7**. The feed
+served the 369 most cluttered postings in the catalogue and read as random.
+
+**The fix is `ballastPosition`:** one slot the profile never sets. It contributes
+nothing to the numerator and lengthens the job's vector, so a posting dilutes itself in
+proportion to how much it asks for — which is how coverage comes to matter more than
+raw overlap. Hence two constructors: `JobVector` (with ballast) and `ProfileVector`
+(without). Swapping them silently restores the defect, and
+`TestFromJobUsesTheJobSideConstructor` is what catches that.
+
+**The floor of six skills is load-bearing.** Ballast strong enough to lift genuinely
+full-coverage postings also lifts one-tag ones, because a single tag the reader holds
+is 100% covered: swept over real data, the top ten filled with single-skill nursing
+vacancies. The floor prices that out.
+
+Constants came from a sweep over a stratified production sample (k ∈ [2,12],
+floor ∈ [5,12]); results plateau from k=4, so the shipped setting is the gentlest one
+that reaches the plateau.
+
+Rarity still outranks breadth at the margin: a vacancy asking only for a scarce skill
+the candidate holds CAN outrank a broader match on ubiquitous ones, and should. Do not
 "fix" that by capping the weights.
 
 ## Not to be confused with

--- a/internal/dict/skillvec/ballast_test.go
+++ b/internal/dict/skillvec/ballast_test.go
@@ -1,0 +1,116 @@
+package skillvec
+
+import (
+	"math"
+	"testing"
+)
+
+// The defect this fixes, stated as a test.
+//
+// A cosine over unit vectors rewards the SIZE of the overlap: when a vacancy sits
+// almost entirely inside a large profile, the score reduces to about
+// √(overlap) / ‖profile‖. So a posting listing 79 skills of which the candidate holds
+// 63 beat one listing 5 that they hold entirely — measured on production, the whole
+// top ten was postings with 52-92 skills, against a catalogue whose median is 7.
+//
+// The fix is a ballast: one vector position the PROFILE never sets, carrying a value
+// proportional to how much the vacancy asks for. It adds nothing to the numerator and
+// lengthens the vacancy's vector, so a posting dilutes itself in proportion to its
+// demands — which is what makes coverage matter.
+func TestFullCoverageOutranksALargerPartialOverlap(t *testing.T) {
+	// A broad profile, like a real one built from a CV.
+	profile := registry[:80]
+	counts := make(map[string]int64, 120)
+	for _, s := range registry[:120] {
+		counts[s] = 5_000
+	}
+	w := WeightsFromCounts(counts)
+
+	// Two postings: one asks for 9 skills the candidate holds every one of; the other
+	// asks for 40 and the candidate holds 30 — more overlap, worse coverage.
+	fullyCovered := w.JobVector(registry[:9])
+	sprawling := w.JobVector(append(append([]string{}, registry[:30]...), registry[90:100]...))
+	me := w.ProfileVector(profile)
+
+	full, partial := dot(fullyCovered, me), dot(sprawling, me)
+	if full <= partial {
+		t.Errorf("fully covered 9/9 scored %.4f, not above the 30/40 sprawl at %.4f", full, partial)
+	}
+}
+
+// The ballast must not hand the feed to one-tag postings — 100%% coverage of a single
+// skill is not a match. On production this was the failure mode of a ballast without a
+// floor: the top ten filled with single-tag nursing vacancies.
+func TestASingleTagPostingDoesNotOutrankARealMatch(t *testing.T) {
+	counts := make(map[string]int64, 120)
+	for _, s := range registry[:120] {
+		counts[s] = 5_000
+	}
+	w := WeightsFromCounts(counts)
+	me := w.ProfileVector(registry[:80])
+
+	oneTag := dot(w.JobVector(registry[:1]), me)
+	nineOfNine := dot(w.JobVector(registry[:9]), me)
+	if oneTag >= nineOfNine {
+		t.Errorf("a 1/1 posting scored %.4f, at or above a 9/9 posting's %.4f", oneTag, nineOfNine)
+	}
+}
+
+// The profile side must never carry ballast: it is what makes the position invisible
+// to the numerator. If both sides set it, it becomes a shared dimension that every
+// pair matches on, which would flatten the ranking instead of shaping it.
+func TestOnlyTheJobSideCarriesBallast(t *testing.T) {
+	counts := map[string]int64{registry[0]: 5_000, registry[1]: 5_000}
+	w := WeightsFromCounts(counts)
+
+	if v := w.ProfileVector(registry[:2]); v[ballastPosition] != 0 {
+		t.Errorf("profile vector set the ballast position to %f, want 0", v[ballastPosition])
+	}
+	if v := w.JobVector(registry[:2]); v[ballastPosition] == 0 {
+		t.Error("job vector left the ballast position empty")
+	}
+}
+
+// Both sides stay unit length: the cosine Meilisearch computes assumes it.
+func TestBothVectorsAreUnitLength(t *testing.T) {
+	counts := map[string]int64{}
+	for _, s := range registry[:20] {
+		counts[s] = 5_000
+	}
+	w := WeightsFromCounts(counts)
+
+	for name, v := range map[string][]float32{
+		"JobVector":     w.JobVector(registry[:5]),
+		"ProfileVector": w.ProfileVector(registry[:5]),
+	} {
+		var sum float64
+		for _, x := range v {
+			sum += float64(x) * float64(x)
+		}
+		if got := math.Sqrt(sum); math.Abs(got-1) > 1e-5 {
+			t.Errorf("%s length = %f, want 1", name, got)
+		}
+	}
+}
+
+// The ballast position must stay clear of the registry, or a skill and the ballast
+// would share a slot and the ranking would read one as the other.
+func TestBallastPositionIsOutsideTheRegistry(t *testing.T) {
+	if ballastPosition < len(registry) {
+		t.Fatalf("ballast sits at %d, inside the %d-entry registry", ballastPosition, len(registry))
+	}
+	if ballastPosition >= Dimensions {
+		t.Fatalf("ballast sits at %d, outside the declared %d dimensions", ballastPosition, Dimensions)
+	}
+}
+
+// A job with no recognised skills still has nothing to rank, ballast or not.
+func TestJobVectorOfUnrecognisedSkillsIsStillNil(t *testing.T) {
+	w := WeightsFromCounts(map[string]int64{registry[0]: 5_000})
+	if got := w.JobVector([]string{"definitely-not-a-skill"}); got != nil {
+		t.Errorf("JobVector() = %v, want nil", got)
+	}
+	if got := w.JobVector(nil); got != nil {
+		t.Errorf("JobVector(nil) = %v, want nil", got)
+	}
+}

--- a/internal/dict/skillvec/ballast_test.go
+++ b/internal/dict/skillvec/ballast_test.go
@@ -114,3 +114,28 @@ func TestJobVectorOfUnrecognisedSkillsIsStillNil(t *testing.T) {
 		t.Errorf("JobVector(nil) = %v, want nil", got)
 	}
 }
+
+// Ballast must be priced on what actually reached the vector, not on the raw slice.
+// A posting listing ["go","go","retired-slug"] contributes ONE component but would be
+// charged for three, so a job whose tags are half unrecognised — or simply repeated —
+// would be pushed down for asking more than it does.
+func TestBallastCountsOnlyWhatEnteredTheVector(t *testing.T) {
+	counts := make(map[string]int64, 8)
+	for _, s := range registry[:8] {
+		counts[s] = 5_000
+	}
+	w := WeightsFromCounts(counts)
+
+	// Eight real skills, so both sides clear the six-skill floor and the ballast is
+	// actually doing something.
+	clean := w.JobVector(registry[:8])
+	noisy := w.JobVector(append(append([]string{}, registry[:8]...),
+		registry[0], registry[1], "retired-slug", "another-unknown"))
+
+	for i := range clean {
+		if clean[i] != noisy[i] {
+			t.Fatalf("duplicates and unknown slugs changed the vector at position %d (%f vs %f): ballast is priced on the raw slice",
+				i, clean[i], noisy[i])
+		}
+	}
+}

--- a/internal/dict/skillvec/vector.go
+++ b/internal/dict/skillvec/vector.go
@@ -109,19 +109,18 @@ const (
 // and lengthens this vector alone. The effect is that a posting is discounted in
 // proportion to how much it asks for, which is what makes coverage — not raw overlap —
 // decide the order.
-func (w Weights) JobVector(skills []string) []float32 {
-	v := w.vector(skills, ballast(len(skills)))
-	return v
-}
+func (w Weights) JobVector(skills []string) []float32 { return w.vector(skills, true) }
 
 // ProfileVector builds the vector for the READER. No ballast: the position must stay
 // zero on this side, since that is what keeps it out of the numerator. If both sides
 // set it, every pair would match on it and the ranking would flatten.
-func (w Weights) ProfileVector(skills []string) []float32 {
-	return w.vector(skills, 0)
-}
+func (w Weights) ProfileVector(skills []string) []float32 { return w.vector(skills, false) }
 
-// ballast is how much a posting listing n skills dilutes itself by.
+// ballast is how much a posting asking for n skills dilutes itself by.
+//
+// n counts what actually REACHED the vector, not the raw slice: unknown slugs and
+// repeats contribute no component, so charging for them would push a posting down for
+// asking more than it does. ["go","go","retired-slug"] asks for one skill.
 func ballast(n int) float64 {
 	if n < ballastFloorSkills {
 		n = ballastFloorSkills
@@ -139,17 +138,18 @@ func ballast(n int) float64 {
 // Returns nil — never a zero vector — when the result would be meaningless: no
 // weights loaded, no skills given, or no skill recognised. A nil vector is an absence
 // the caller omits, not a document that ranks against everything.
-func (w Weights) Vector(skills []string) []float32 { return w.vector(skills, 0) }
+func (w Weights) Vector(skills []string) []float32 { return w.vector(skills, false) }
 
-// vector is the shared construction. extra is a value placed at ballastPosition before
-// normalisation, so it counts toward the length without ever meeting a profile's
-// non-zero component.
-func (w Weights) vector(skills []string, extra float64) []float32 {
+// vector is the shared construction. withBallast places a value at ballastPosition
+// before normalisation, so it counts toward the length without ever meeting a
+// profile's non-zero component.
+func (w Weights) vector(skills []string, withBallast bool) []float32 {
 	if len(w.byPosition) == 0 || len(skills) == 0 {
 		return nil
 	}
 	v := make([]float32, Dimensions)
 	var sumSq float64
+	var placed int
 	for _, s := range skills {
 		pos, ok := Position(s)
 		if !ok || v[pos] != 0 {
@@ -160,14 +160,17 @@ func (w Weights) vector(skills []string, extra float64) []float32 {
 		x := w.byPosition[pos]
 		v[pos] = x
 		sumSq += float64(x) * float64(x)
+		placed++
 	}
 	if sumSq == 0 {
 		// Nothing recognised: the ballast alone would be a vector about nothing.
 		return nil
 	}
-	if extra != 0 {
-		v[ballastPosition] = float32(extra)
-		sumSq += extra * extra
+	if withBallast {
+		// Priced on `placed`, not len(skills) — see ballast.
+		b := ballast(placed)
+		v[ballastPosition] = float32(b)
+		sumSq += b * b
 	}
 	norm := float32(math.Sqrt(sumSq))
 	for i, x := range v {

--- a/internal/dict/skillvec/vector.go
+++ b/internal/dict/skillvec/vector.go
@@ -77,6 +77,58 @@ func (w *Weights) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// ballastPosition is the vector slot the JOB side fills and the profile never does.
+// It sits past the registry, in the headroom Dimensions leaves — so it can never
+// collide with a skill, and adding skills to the registry can never reach it.
+const ballastPosition = Dimensions - 1
+
+// ballastPerSkill and ballastFloorSkills shape how hard a posting dilutes itself.
+//
+// Without ballast, the cosine rewards the SIZE of the overlap: a vacancy sitting
+// almost entirely inside a large profile scores about √(overlap) / ‖profile‖, so one
+// listing 79 skills of which the reader holds 63 beats one listing 5 they hold
+// entirely. Measured on production against a 162-skill profile, the whole top ten was
+// postings with 52-92 skills — from a catalogue whose median is 7.
+//
+// The floor is not a detail. Swept over real data, ballast strong enough to lift
+// genuinely full-coverage postings ALSO lifts one-tag ones, because a single tag the
+// reader holds is 100% covered: the top ten filled with single-skill nursing vacancies.
+// Flooring the ballast at six skills prices that out while leaving real postings alone.
+//
+// Values chosen by sweeping k ∈ [2,12] and floor ∈ [5,12] over a stratified sample of
+// production postings; results plateau from k=4 upward, so this is the gentlest setting
+// that gets there — full coverage leads the ranking, the median result carries nine
+// skills, and no 1-3 tag posting reaches the top ten.
+const (
+	ballastPerSkill    = 4.0
+	ballastFloorSkills = 6
+)
+
+// JobVector builds the vector stored on a JOB document. It is Vector plus the ballast:
+// a component the profile side never sets, so it adds nothing to the cosine's numerator
+// and lengthens this vector alone. The effect is that a posting is discounted in
+// proportion to how much it asks for, which is what makes coverage — not raw overlap —
+// decide the order.
+func (w Weights) JobVector(skills []string) []float32 {
+	v := w.vector(skills, ballast(len(skills)))
+	return v
+}
+
+// ProfileVector builds the vector for the READER. No ballast: the position must stay
+// zero on this side, since that is what keeps it out of the numerator. If both sides
+// set it, every pair would match on it and the ranking would flatten.
+func (w Weights) ProfileVector(skills []string) []float32 {
+	return w.vector(skills, 0)
+}
+
+// ballast is how much a posting listing n skills dilutes itself by.
+func ballast(n int) float64 {
+	if n < ballastFloorSkills {
+		n = ballastFloorSkills
+	}
+	return ballastPerSkill * float64(n)
+}
+
 // Vector builds the L2-normalised vector for a set of canonical skill slugs.
 //
 // Normalising is what makes the cosine of two such vectors read as "how many of my
@@ -87,7 +139,12 @@ func (w *Weights) UnmarshalJSON(b []byte) error {
 // Returns nil — never a zero vector — when the result would be meaningless: no
 // weights loaded, no skills given, or no skill recognised. A nil vector is an absence
 // the caller omits, not a document that ranks against everything.
-func (w Weights) Vector(skills []string) []float32 {
+func (w Weights) Vector(skills []string) []float32 { return w.vector(skills, 0) }
+
+// vector is the shared construction. extra is a value placed at ballastPosition before
+// normalisation, so it counts toward the length without ever meeting a profile's
+// non-zero component.
+func (w Weights) vector(skills []string, extra float64) []float32 {
 	if len(w.byPosition) == 0 || len(skills) == 0 {
 		return nil
 	}
@@ -105,7 +162,12 @@ func (w Weights) Vector(skills []string) []float32 {
 		sumSq += float64(x) * float64(x)
 	}
 	if sumSq == 0 {
+		// Nothing recognised: the ballast alone would be a vector about nothing.
 		return nil
+	}
+	if extra != 0 {
+		v[ballastPosition] = float32(extra)
+		sumSq += extra * extra
 	}
 	norm := float32(math.Sqrt(sumSq))
 	for i, x := range v {

--- a/internal/search/search/document.go
+++ b/internal/search/search/document.go
@@ -151,7 +151,7 @@ func FromJob(j db.Job, w skillvec.Weights) (JobDocument, error) {
 	// ALWAYS set the key. With the embedder declared, Meilisearch REJECTS any document
 	// that omits it — "no vectors provided for document" — so an omission is not a
 	// no-op, it drops the posting out of the index entirely.
-	doc.Vectors = map[string][]float32{SkillEmbedder: w.Vector(j.Skills)}
+	doc.Vectors = map[string][]float32{SkillEmbedder: w.JobVector(j.Skills)}
 	return doc, nil
 }
 

--- a/internal/search/search/document_vector_test.go
+++ b/internal/search/search/document_vector_test.go
@@ -111,3 +111,24 @@ func TestFromJobVectorSerialisesUnderTheReservedKey(t *testing.T) {
 		t.Errorf("_vectors[%q] has %d values, want %d", SkillEmbedder, len(out.Vectors[SkillEmbedder]), skillvec.Dimensions)
 	}
 }
+
+// The two sides must not be swapped. A document built with the PROFILE constructor
+// would carry no ballast, so it would rank as if it asked for nothing — the exact
+// defect the ballast exists to fix, reintroduced silently. Assert the stored vector
+// carries it.
+func TestFromJobUsesTheJobSideConstructor(t *testing.T) {
+	doc, err := FromJob(db.Job{ID: 1, PublicSlug: "s", Title: "Engineer", Skills: []string{"go", "docker"}}, docWeights())
+	if err != nil {
+		t.Fatalf("FromJob: %v", err)
+	}
+	stored := doc.Vectors[SkillEmbedder]
+	want := docWeights().JobVector([]string{"go", "docker"})
+	if len(stored) != len(want) {
+		t.Fatalf("vector width = %d, want %d", len(stored), len(want))
+	}
+	for i := range want {
+		if stored[i] != want[i] {
+			t.Fatalf("document vector differs from JobVector at position %d — is it built with ProfileVector?", i)
+		}
+	}
+}

--- a/internal/search/search/embedder_integration_test.go
+++ b/internal/search/search/embedder_integration_test.go
@@ -94,7 +94,7 @@ func TestIntegration_VectorSearchRanksByTheSkillVector(t *testing.T) {
 	}
 
 	// A candidate who knows Go and Docker: the Go posting must come first.
-	res, err := c.Search(ctx, SearchParams{Vector: w.Vector([]string{"go", "docker"}), Limit: 10})
+	res, err := c.Search(ctx, SearchParams{Vector: w.ProfileVector([]string{"go", "docker"}), Limit: 10})
 	if err != nil {
 		t.Fatalf("vector Search: %v", err)
 	}
@@ -128,7 +128,7 @@ func TestIntegration_LosingSkillsClearsTheStoredVector(t *testing.T) {
 	if err := c.IndexJobs(ctx, []JobDocument{withSkills}); err != nil {
 		t.Fatalf("IndexJobs: %v", err)
 	}
-	if res, err := c.Search(ctx, SearchParams{Vector: w.Vector([]string{"go"}), Limit: 10}); err != nil {
+	if res, err := c.Search(ctx, SearchParams{Vector: w.ProfileVector([]string{"go"}), Limit: 10}); err != nil {
 		t.Fatalf("vector Search: %v", err)
 	} else if len(res.Hits) == 0 {
 		t.Fatal("the job is not rankable by vector before losing its skills")


### PR DESCRIPTION
Reported from production after #2220 shipped: the match feed **looks random**.

It was not random. It was serving the 369 most cluttered postings in the catalogue.

## The defect

A cosine over unit vectors rewards the **size** of the overlap. When a vacancy sits
almost entirely inside a large profile, the score collapses to roughly
`√(overlap) / ‖profile‖` — and the denominator only penalises the vacancy's skills the
reader does *not* hold. So a posting listing 79 skills of which the reader holds 63
beats one listing 5 they hold entirely.

Measured against the reporter's real 162-skill profile:

```
score  skills  mine   posting
0.753     79     63   DESENVOLVEDOR FULL STACK PLENO
0.752     61     55   Accolite Digital-Senior Full Stack
0.746     61     50   Senior Engineering Manager
0.737     92     67   Technical Architect
```

The catalogue's median posting carries **7** skills. Only 369 open postings out of
4.7M carry more than 60 — and they took the whole top ten.

`TestCosineOrdersOverlapAndCoverage` passed throughout, because its profile is five
skills and its "sprawl" is twelve. At those sizes the formula behaves; at 162 against
79 it inverts. The test was not wrong, it was too small.

## The fix

A **ballast**: one vector position the profile never sets, carrying a value
proportional to how much the posting asks for. It contributes nothing to the cosine's
numerator and lengthens the job's vector alone, so a posting dilutes itself in
proportion to its demands.

Two constructors now name the sides — `JobVector` (with ballast) and `ProfileVector`
(without) — and a test catches a swap, since swapping them silently restores the
defect.

**The six-skill floor is not a tuning detail.** Ballast strong enough to lift genuinely
full-coverage postings also lifts one-tag ones, because a single tag the reader holds
is 100% covered. Swept over real data, the top ten filled with single-skill nursing
vacancies. The floor prices that out.

Constants come from sweeping `k ∈ [2,12]` and `floor ∈ [5,12]` over a stratified
production sample (1600 postings across the size distribution, plus 600 one-to-three
tag postings for the edge case). Results plateau from `k=4`, so the shipped setting is
the gentlest one that reaches the plateau.

## Result on that sample

```
before   49/59   57/74   44/51   54/66   45/49
after     9/9     8/9     8/8     5/6   16/16
```

Full coverage leads, the median result carries nine skills, no 1-3 tag posting reaches
the top ten.

## Deploying this needs a rebuild

The ballast lives in the stored vector, so the ~2h full reindex has to run again for it
to take effect. The button can stay on meanwhile — the ordering is wrong either way
until the rebuild lands.

## Verification

`gofmt` clean, `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`,
`go test ./...` (175 packages), `golangci-lint` clean on changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved skill-based search ranking by balancing overlap and coverage.
  * Full matches for smaller skill sets now rank above larger, partial overlaps.
  * Profiles and job postings use optimized matching vectors for more accurate results.

* **Tests**
  * Added coverage for ranking behavior, vector construction, and edge cases involving unrecognized or missing skills.

* **Documentation**
  * Updated guidance explaining skill-match scoring and the improved ranking approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->