### PR TITLE
Pull four use-case rules out of the layer that happened to call them

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,9 +91,10 @@ TYPST_BIN=typst
 # Ops kill switch; restart required.
 # CV_EDIT_ALLOW_BULLET_TRUNCATION=false
 
-# Fit-analysis sanitize caps (internal/matchanalysis). Applied to untrusted LLM
-# output before it is cached or served. Unset → package defaults below. Values
-# below 1 fall back to the matching default. Restart required after change.
+# Fit-analysis sanitize caps (internal/candidate/matchanalysis). Applied to untrusted
+# LLM output before it is cached or served. Unset → that package's Default* constants,
+# which are the only place these numbers live; the values shown here are a copy for
+# reading. Values below 1 fall back the same way. Restart required after change.
 #
 # MATCH_ANALYSIS_MAX_COMMENT_RUNES=240          # per-dimension Comment
 # MATCH_ANALYSIS_MAX_LIST_ITEM_RUNES=200        # each Strengths / Gaps bullet

--- a/internal/api/handler/assistant_inbox_tools_test.go
+++ b/internal/api/handler/assistant_inbox_tools_test.go
@@ -46,8 +46,8 @@ func (m *mailStore) GetEmail(context.Context, db.GetEmailParams) (db.GetEmailRow
 func (m *mailStore) GetInterviewInvitation(context.Context, db.GetInterviewInvitationParams) (db.GetInterviewInvitationRow, error) {
 	return db.GetInterviewInvitationRow{}, pgx.ErrNoRows
 }
-func (m *mailStore) GetJobBySlug(context.Context, string) (db.Job, error) {
-	return db.Job{ID: 42}, nil
+func (m *mailStore) GetJobIDBySlug(context.Context, string) (int64, error) {
+	return 42, nil
 }
 func (m *mailStore) AgentTriageEmail(context.Context, db.AgentTriageEmailParams) (int64, error) {
 	m.triaged++

--- a/internal/api/handler/me_reminders_test.go
+++ b/internal/api/handler/me_reminders_test.go
@@ -48,9 +48,13 @@ func (r *stubReminderRepo) CancelReminder(context.Context, int64, int64) error {
 func remindersApp(settings reminder.Settings) (*fiber.App, *auth.Issuer, *stubReminderRepo) {
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	repo := &stubReminderRepo{settings: settings}
+	rem := reminder.New(repo)
 	h := &trackingHandlers{
-		tracking: jobtracking.New(stubTrackingRepo{}),
-		reminder: reminder.New(repo),
+		// Wired the way newTrackingHandlers wires production: the reminder service is
+		// tracking's Reminders port, so the scheduling these tests assert on happens in
+		// the service every caller shares, not in the Fiber handler.
+		tracking: jobtracking.New(stubTrackingRepo{}, jobtracking.WithReminders(rem)),
+		reminder: rem,
 	}
 	app := fiber.New()
 	gate := auth.RequireAuth(iss, testVersions)

--- a/internal/api/handler/user_jobs.go
+++ b/internal/api/handler/user_jobs.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"errors"
-	"log"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -18,8 +17,9 @@ import (
 // trackingHandlers serves the per-user job interactions (view/apply/save/dismiss/
 // track), the user-scoped tracking reads (the Kanban listing, slug sets, pipeline,
 // swipe deck), and the saved-job reminder controls. The interaction use cases live
-// in jobtracking.Service, the reminder scheduling in reminder.Service — the save/
-// apply/unsave handlers orchestrate both; the cmd/remind worker fires the scheduled
+// in jobtracking.Service, which also owns the reminder side effect of save/unsave/
+// apply — reminder.Service is handed to it as a port, and is held here only for the
+// notification-settings endpoints. The cmd/remind worker fires the scheduled
 // reminders.
 type trackingHandlers struct {
 	tracking *jobtracking.Service
@@ -28,9 +28,14 @@ type trackingHandlers struct {
 }
 
 func newTrackingHandlers(queries *db.Queries, pool *pgxpool.Pool, search searcher) *trackingHandlers {
+	// One reminder service, handed to tracking as its Reminders port and kept here
+	// for the notification-settings endpoints. Save/unsave/apply schedule and cancel
+	// inside the tracking service, so every caller of it — this handler, the in-app
+	// assistant, the mail reconstruction — gets the same side effect.
+	rem := reminder.New(reminder.NewQueriesRepository(queries))
 	return &trackingHandlers{
-		tracking: jobtracking.New(jobtracking.NewQueriesRepository(queries, pool)),
-		reminder: reminder.New(reminder.NewQueriesRepository(queries)),
+		tracking: jobtracking.New(jobtracking.NewQueriesRepository(queries, pool), jobtracking.WithReminders(rem)),
+		reminder: rem,
 		search:   search,
 	}
 }
@@ -184,8 +189,6 @@ func (h *trackingHandlers) MarkApplied(c *fiber.Ctx) error {
 	if err != nil {
 		return trackingError(err)
 	}
-	// Applying ends the "come back and apply" intent, so drop any pending reminder.
-	h.cancelReminderBestEffort(c, userID, interaction.JobID)
 	return c.JSON(fiber.Map{"data": toResponse(interaction)})
 }
 
@@ -234,33 +237,7 @@ func (h *trackingHandlers) SaveJob(c *fiber.Ctx) error {
 	if err != nil {
 		return trackingError(err)
 	}
-	h.scheduleReminderOnSave(c, userID, interaction.JobID)
 	return c.JSON(fiber.Map{"data": toResponse(interaction)})
-}
-
-// scheduleReminderOnSave applies the reminder decision for a just-saved job. It is
-// a best-effort side effect of the save: a failure is logged, never surfaced — the
-// save already succeeded and is the primary action, and the worker's fire-time
-// re-check backstops correctness.
-func (h *trackingHandlers) scheduleReminderOnSave(c *fiber.Ctx, userID, jobID int64) {
-	if h.reminder == nil {
-		return
-	}
-	if err := h.reminder.ScheduleOnSave(c.Context(), userID, jobID); err != nil {
-		log.Printf("reminder: schedule on save user=%d job=%d: %v", userID, jobID, err)
-	}
-}
-
-// cancelReminderBestEffort cancels a job's pending reminder after the user applied
-// or unsaved it. Best-effort: a failure is logged, not surfaced — the worker's
-// fire-time re-check cancels a missed one anyway.
-func (h *trackingHandlers) cancelReminderBestEffort(c *fiber.Ctx, userID, jobID int64) {
-	if h.reminder == nil {
-		return
-	}
-	if err := h.reminder.Cancel(c.Context(), userID, jobID); err != nil {
-		log.Printf("reminder: cancel user=%d job=%d: %v", userID, jobID, err)
-	}
 }
 
 // UnsaveJob clears a job's saved mark for the authenticated user. The interaction
@@ -276,8 +253,6 @@ func (h *trackingHandlers) UnsaveJob(c *fiber.Ctx) error {
 	if err != nil {
 		return trackingError(err)
 	}
-	// Unsaving withdraws the intent the reminder was nudging toward, so cancel it.
-	h.cancelReminderBestEffort(c, userID, interaction.JobID)
 	return c.JSON(fiber.Map{"data": toResponse(interaction)})
 }
 

--- a/internal/application/inbox/fake_test.go
+++ b/internal/application/inbox/fake_test.go
@@ -20,7 +20,7 @@ type fakeQueries struct {
 	total      int64
 	state      []db.CountEmailsByStateRow
 	email      db.GetEmailRow
-	job        db.Job
+	jobID      int64
 	invitation db.GetInterviewInvitationRow
 
 	// failures to inject
@@ -91,8 +91,8 @@ func (f *fakeQueries) GetInterviewInvitation(context.Context, db.GetInterviewInv
 	return f.invitation, f.invitationErr
 }
 
-func (f *fakeQueries) GetJobBySlug(context.Context, string) (db.Job, error) {
-	return f.job, f.jobErr
+func (f *fakeQueries) GetJobIDBySlug(context.Context, string) (int64, error) {
+	return f.jobID, f.jobErr
 }
 
 func (f *fakeQueries) AgentTriageEmail(_ context.Context, arg db.AgentTriageEmailParams) (int64, error) {

--- a/internal/application/inbox/inbox.go
+++ b/internal/application/inbox/inbox.go
@@ -41,7 +41,10 @@ type Queries interface {
 	CountEmailsByState(ctx context.Context, userID int64) ([]db.CountEmailsByStateRow, error)
 	GetEmail(ctx context.Context, arg db.GetEmailParams) (db.GetEmailRow, error)
 	GetInterviewInvitation(ctx context.Context, arg db.GetInterviewInvitationParams) (db.GetInterviewInvitationRow, error)
-	GetJobBySlug(ctx context.Context, publicSlug string) (db.Job, error)
+	// Every slug this package resolves is resolved to an id and nothing else, so it
+	// takes the slim lookup: the wide row would TOAST a description and an
+	// enrichment blob on every triage, link and application recorded from mail.
+	GetJobIDBySlug(ctx context.Context, publicSlug string) (int64, error)
 	AgentTriageEmail(ctx context.Context, arg db.AgentTriageEmailParams) (int64, error)
 	LinkEmailToJob(ctx context.Context, arg db.LinkEmailToJobParams) (int64, error)
 	UnlinkEmail(ctx context.Context, arg db.UnlinkEmailParams) (int64, error)

--- a/internal/application/inbox/mutate.go
+++ b/internal/application/inbox/mutate.go
@@ -46,11 +46,11 @@ func (s *Service) Triage(ctx context.Context, userID, id int64, v Verdict) (Mess
 	// Resolve the slug before writing: an unknown one changes nothing.
 	var jobID pgtype.Int8
 	if v.Slug != "" {
-		job, err := s.q.GetJobBySlug(ctx, v.Slug)
+		resolved, err := s.q.GetJobIDBySlug(ctx, v.Slug)
 		if err != nil {
 			return Message{}, err
 		}
-		jobID = pgtype.Int8{Int64: job.ID, Valid: true}
+		jobID = pgtype.Int8{Int64: resolved, Valid: true}
 	}
 
 	var confidence pgtype.Float4
@@ -87,13 +87,13 @@ func (s *Service) Link(ctx context.Context, userID, id int64, slug string) (Mess
 	if slug == "" {
 		return Message{}, ErrSlugRequired
 	}
-	job, err := s.q.GetJobBySlug(ctx, slug)
+	jobID, err := s.q.GetJobIDBySlug(ctx, slug)
 	if err != nil {
 		return Message{}, err
 	}
 	return s.mutate(ctx, userID, id, func() (int64, error) {
 		return s.q.LinkEmailToJob(ctx, db.LinkEmailToJobParams{
-			ID: id, UserID: userID, JobID: pgtype.Int8{Int64: job.ID, Valid: true},
+			ID: id, UserID: userID, JobID: pgtype.Int8{Int64: jobID, Valid: true},
 		})
 	})
 }
@@ -146,7 +146,7 @@ func (s *Service) RecordApplication(ctx context.Context, userID, id int64, slug 
 	if email.SuggestedJobID.Valid && !email.JobID.Valid {
 		return Message{}, ErrPendingSuggestion
 	}
-	job, err := s.q.GetJobBySlug(ctx, slug)
+	jobID, err := s.q.GetJobIDBySlug(ctx, slug)
 	if err != nil {
 		return Message{}, err
 	}
@@ -159,7 +159,7 @@ func (s *Service) RecordApplication(ctx context.Context, userID, id int64, slug 
 	}
 	return s.mutate(ctx, userID, id, func() (int64, error) {
 		return s.q.LinkEmailToJob(ctx, db.LinkEmailToJobParams{
-			ID: id, UserID: userID, JobID: pgtype.Int8{Int64: job.ID, Valid: true},
+			ID: id, UserID: userID, JobID: pgtype.Int8{Int64: jobID, Valid: true},
 		})
 	})
 }

--- a/internal/application/inbox/mutate_test.go
+++ b/internal/application/inbox/mutate_test.go
@@ -68,7 +68,7 @@ func TestTriageWithAnUnknownSlugWritesNothing(t *testing.T) {
 
 // A linked verdict that implies progress moves the application forward.
 func TestTriageAdvancesTheStageOfALinkedApplication(t *testing.T) {
-	q := &fakeQueries{job: db.Job{ID: 42}, stage: "applied"}
+	q := &fakeQueries{jobID: 42, stage: "applied"}
 
 	if _, err := New(q, nil).Triage(context.Background(), 7, 812, Verdict{Signal: "interview_invitation", Slug: "go-dev-acme"}); err != nil {
 		t.Fatalf("Triage: %v", err)
@@ -84,7 +84,7 @@ func TestTriageAdvancesTheStageOfALinkedApplication(t *testing.T) {
 // The verdict is already durable by the time the stage is considered, so a failed
 // advance must not fail the triage the caller successfully recorded.
 func TestTriageSurvivesAFailedStageAdvance(t *testing.T) {
-	q := &fakeQueries{job: db.Job{ID: 42}, stage: "applied", advanceErr: errors.New("deadlock")}
+	q := &fakeQueries{jobID: 42, stage: "applied", advanceErr: errors.New("deadlock")}
 
 	if _, err := New(q, nil).Triage(context.Background(), 7, 812, Verdict{Signal: "offer", Slug: "go-dev-acme"}); err != nil {
 		t.Fatalf("Triage failed because the stage advance did: %v", err)
@@ -94,7 +94,7 @@ func TestTriageSurvivesAFailedStageAdvance(t *testing.T) {
 // Mail linked to a job the caller does not track has no stage to advance — that is
 // not an error, it is simply nothing to do.
 func TestTriageIgnoresAnUntrackedJob(t *testing.T) {
-	q := &fakeQueries{job: db.Job{ID: 42}, stageErr: errNoRows}
+	q := &fakeQueries{jobID: 42, stageErr: errNoRows}
 
 	if _, err := New(q, nil).Triage(context.Background(), 7, 812, Verdict{Signal: "offer", Slug: "go-dev-acme"}); err != nil {
 		t.Fatalf("Triage: %v", err)
@@ -145,7 +145,7 @@ func TestRecordApplicationIsDatedByTheMail(t *testing.T) {
 	wrote := time.Date(2026, 3, 4, 9, 0, 0, 0, time.UTC)
 	q := &fakeQueries{
 		email: db.GetEmailRow{ID: 812, Source: "hosted", ReceivedAt: pgtype.Timestamptz{Time: wrote, Valid: true}},
-		job:   db.Job{ID: 42},
+		jobID: 42,
 	}
 	apps := &fakeApps{}
 
@@ -167,7 +167,7 @@ func TestRecordApplicationIsDatedByTheMail(t *testing.T) {
 func TestRecordApplicationRefusesAnUnknownMailStore(t *testing.T) {
 	q := &fakeQueries{
 		email: db.GetEmailRow{ID: 812, Source: "imap", ReceivedAt: pgtype.Timestamptz{Time: time.Now(), Valid: true}},
-		job:   db.Job{ID: 42},
+		jobID: 42,
 	}
 	apps := &fakeApps{}
 
@@ -266,7 +266,7 @@ func TestEveryLinkMutationReconcilesTheLedger(t *testing.T) {
 	} {
 		q := &fakeQueries{
 			email: db.GetEmailRow{ID: 812, Source: "gmail"},
-			job:   db.Job{ID: 42},
+			jobID: 42,
 		}
 		if err := call(New(q, nil)); err != nil {
 			t.Fatalf("%s: %v", name, err)

--- a/internal/application/jobtracking/jobtracking.go
+++ b/internal/application/jobtracking/jobtracking.go
@@ -7,6 +7,7 @@ package jobtracking
 import (
 	"context"
 	"errors"
+	"log"
 	"time"
 
 	"github.com/strelov1/freehire/internal/application/userjob"
@@ -254,14 +255,66 @@ type Repository interface {
 // occasionally re-see a long-ago-seen job, which is acceptable.
 const excludedJobsCap int32 = 1000
 
+// Reminders is the come-back-and-apply reminder, as this package needs it.
+//
+// It is declared here rather than imported because internal/engage sits ABOVE
+// internal/application in the block order: reminder.Service satisfies it
+// structurally and the composition root supplies it, so the dependency points the
+// way the layering allows.
+//
+// It lives on the service and not on a caller because saving is what creates the
+// intent a reminder nudges, and applying or unsaving is what ends it. Every caller
+// of these use cases means the same thing by them — the HTTP handler, the in-app
+// assistant, the mail reconstruction — so the side effect belongs where the use
+// case is, not repeated at each door.
+type Reminders interface {
+	ScheduleOnSave(ctx context.Context, userID, jobID int64) error
+	Cancel(ctx context.Context, userID, jobID int64) error
+}
+
+// Option configures a Service at construction.
+type Option func(*Service)
+
+// WithReminders attaches the reminder side effects to save, unsave and apply.
+// Without it those calls schedule and cancel nothing, which is what a caller with
+// no reminder store wants.
+func WithReminders(r Reminders) Option { return func(s *Service) { s.reminders = r } }
+
 // Service implements the per-user job-tracking use cases.
 type Service struct {
-	repo Repository
+	repo      Repository
+	reminders Reminders
 }
 
 // New creates a Service backed by the given Repository.
-func New(repo Repository) *Service {
-	return &Service{repo: repo}
+func New(repo Repository, opts ...Option) *Service {
+	s := &Service{repo: repo}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// scheduleReminder and cancelReminder are best-effort. The tracking write has
+// already succeeded and is the primary action, and the reminder worker re-checks
+// the intent (still open, still saved-but-unapplied) immediately before sending —
+// so a lost schedule or cancel degrades the nudge rather than corrupting anything.
+func (s *Service) scheduleReminder(ctx context.Context, userID, jobID int64) {
+	if s.reminders == nil {
+		return
+	}
+	if err := s.reminders.ScheduleOnSave(ctx, userID, jobID); err != nil {
+		log.Printf("jobtracking: schedule reminder user=%d job=%d: %v", userID, jobID, err)
+	}
+}
+
+func (s *Service) cancelReminder(ctx context.Context, userID, jobID int64) {
+	if s.reminders == nil {
+		return
+	}
+	if err := s.reminders.Cancel(ctx, userID, jobID); err != nil {
+		log.Printf("jobtracking: cancel reminder user=%d job=%d: %v", userID, jobID, err)
+	}
 }
 
 // ListTracked validates the filter (the vocabulary and its default live in
@@ -334,7 +387,13 @@ func (s *Service) MarkApplied(ctx context.Context, userID int64, slug, source st
 	if err != nil {
 		return Interaction{}, err
 	}
-	return s.repo.MarkApplied(ctx, userID, jobID, source)
+	row, err := s.repo.MarkApplied(ctx, userID, jobID, source)
+	if err != nil {
+		return row, err
+	}
+	// Applying ends the "come back and apply" intent.
+	s.cancelReminder(ctx, userID, jobID)
+	return row, nil
 }
 
 // MarkAppliedAt resolves slug → jobID then records an application dated by `at`
@@ -344,7 +403,15 @@ func (s *Service) MarkAppliedAt(ctx context.Context, userID int64, slug string, 
 	if err != nil {
 		return Interaction{}, err
 	}
-	return s.repo.MarkAppliedAt(ctx, userID, jobID, at, source)
+	row, err := s.repo.MarkAppliedAt(ctx, userID, jobID, at, source)
+	if err != nil {
+		return row, err
+	}
+	// An application reconstructed from mail ends the intent exactly as a clicked
+	// one does. Only the HTTP door used to cancel, so this path never did — the
+	// same omission this side effect moved down here to stop repeating.
+	s.cancelReminder(ctx, userID, jobID)
+	return row, nil
 }
 
 // MarkAppliedOn records an application on the day the candidate states, overwriting a date
@@ -366,7 +433,12 @@ func (s *Service) MarkAppliedOn(ctx context.Context, userID int64, slug string, 
 	if err != nil {
 		return Interaction{}, err
 	}
-	return s.repo.MarkAppliedOn(ctx, userID, jobID, applydate.Instant(day), source)
+	row, err := s.repo.MarkAppliedOn(ctx, userID, jobID, applydate.Instant(day), source)
+	if err != nil {
+		return row, err
+	}
+	s.cancelReminder(ctx, userID, jobID)
+	return row, nil
 }
 
 // SaveJob resolves slug → jobID then delegates to the repository.
@@ -375,7 +447,13 @@ func (s *Service) SaveJob(ctx context.Context, userID int64, slug string) (Inter
 	if err != nil {
 		return Interaction{}, err
 	}
-	return s.repo.SaveJob(ctx, userID, jobID)
+	row, err := s.repo.SaveJob(ctx, userID, jobID)
+	if err != nil {
+		return row, err
+	}
+	// Saving is what creates the intent the reminder nudges toward.
+	s.scheduleReminder(ctx, userID, jobID)
+	return row, nil
 }
 
 // Unsave resolves slug → jobID then clears the saved mark. If the repository
@@ -388,9 +466,14 @@ func (s *Service) Unsave(ctx context.Context, userID int64, slug string) (Intera
 	}
 	row, err := s.repo.UnsaveJob(ctx, userID, jobID)
 	if errors.Is(err, ErrNoInteraction) {
-		return Interaction{JobID: jobID}, nil
+		row, err = Interaction{JobID: jobID}, nil
 	}
-	return row, err
+	if err != nil {
+		return row, err
+	}
+	// Unsaving withdraws the intent the reminder was nudging toward.
+	s.cancelReminder(ctx, userID, jobID)
+	return row, nil
 }
 
 // Dismiss resolves slug → jobID then delegates to the repository, marking the

--- a/internal/application/jobtracking/jobtracking_test.go
+++ b/internal/application/jobtracking/jobtracking_test.go
@@ -871,3 +871,155 @@ func TestMarkAppliedOn_StoresTheDayAtNoon(t *testing.T) {
 		t.Errorf("repository received %v, want %v", repo.redatedAt, want)
 	}
 }
+
+// fakeReminders records the reminder side effects the service asks for. It is a
+// two-method port, so a handwritten fake stays this small — which is the point of
+// declaring the interface here rather than reaching for engage's own service.
+type fakeReminders struct {
+	scheduled []int64
+	cancelled []int64
+	err       error
+}
+
+func (f *fakeReminders) ScheduleOnSave(_ context.Context, _, jobID int64) error {
+	f.scheduled = append(f.scheduled, jobID)
+	return f.err
+}
+
+func (f *fakeReminders) Cancel(_ context.Context, _, jobID int64) error {
+	f.cancelled = append(f.cancelled, jobID)
+	return f.err
+}
+
+// TestSaveJob_SchedulesTheReminder is the regression this side effect was moved
+// down for: it used to live in the Fiber handler, so a job saved through the in-app
+// assistant — which calls this service directly and issues no HTTP request — never
+// got a reminder row. The test drives the service, exactly as that caller does.
+func TestSaveJob_SchedulesTheReminder(t *testing.T) {
+	repo := newRepo()
+	repo.saveResult = jobtracking.Interaction{JobID: jobID, SavedAt: tPtr(time.Now())}
+	rem := &fakeReminders{}
+	svc := jobtracking.New(repo, jobtracking.WithReminders(rem))
+
+	if _, err := svc.SaveJob(ctx(), userID, slug); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rem.scheduled) != 1 || rem.scheduled[0] != jobID {
+		t.Errorf("scheduled = %v, want exactly [%d]", rem.scheduled, jobID)
+	}
+	if len(rem.cancelled) != 0 {
+		t.Errorf("cancelled = %v, want none", rem.cancelled)
+	}
+}
+
+// TestEndingTheIntentCancelsTheReminder covers every way an application stops being
+// pending. MarkAppliedAt is the mail-reconstruction path, which never cancelled at
+// all while the rule lived at the HTTP door.
+func TestEndingTheIntentCancelsTheReminder(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		act  func(*jobtracking.Service) error
+	}{
+		{"apply", func(s *jobtracking.Service) error {
+			_, err := s.MarkApplied(ctx(), userID, slug, appevent.SourceAssistant)
+			return err
+		}},
+		{"apply from mail", func(s *jobtracking.Service) error {
+			_, err := s.MarkAppliedAt(ctx(), userID, slug, time.Now().Add(-time.Hour), appevent.SourceMailGmail)
+			return err
+		}},
+		{"apply on a stated day", func(s *jobtracking.Service) error {
+			day := time.Date(2026, 7, 27, 0, 0, 0, 0, time.UTC)
+			now := time.Date(2026, 8, 2, 9, 0, 0, 0, time.UTC)
+			_, err := s.MarkAppliedOn(ctx(), userID, slug, day, now, appevent.SourceUser)
+			return err
+		}},
+		{"unsave", func(s *jobtracking.Service) error {
+			_, err := s.Unsave(ctx(), userID, slug)
+			return err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newRepo()
+			rem := &fakeReminders{}
+			svc := jobtracking.New(repo, jobtracking.WithReminders(rem))
+
+			if err := tc.act(svc); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(rem.cancelled) != 1 || rem.cancelled[0] != jobID {
+				t.Errorf("cancelled = %v, want exactly [%d]", rem.cancelled, jobID)
+			}
+			if len(rem.scheduled) != 0 {
+				t.Errorf("scheduled = %v, want none", rem.scheduled)
+			}
+		})
+	}
+}
+
+// TestUnsave_CancelsEvenWithNothingToClear pins the idempotent case: unsaving a job
+// that carries no interaction row still withdraws the intent, because the caller
+// asked for it and the reminder may exist regardless.
+func TestUnsave_CancelsEvenWithNothingToClear(t *testing.T) {
+	repo := newRepo()
+	repo.unsaveErr = jobtracking.ErrNoInteraction
+	rem := &fakeReminders{}
+	svc := jobtracking.New(repo, jobtracking.WithReminders(rem))
+
+	got, err := svc.Unsave(ctx(), userID, slug)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.JobID != jobID {
+		t.Errorf("JobID = %d, want %d", got.JobID, jobID)
+	}
+	if len(rem.cancelled) != 1 {
+		t.Errorf("cancelled = %v, want exactly one", rem.cancelled)
+	}
+}
+
+// TestReminderIsBestEffort pins both halves of "best effort": a failing reminder
+// never fails the tracking write, and a service built without the port does the
+// write and nothing else.
+func TestReminderIsBestEffort(t *testing.T) {
+	t.Run("a reminder failure does not fail the save", func(t *testing.T) {
+		repo := newRepo()
+		repo.saveResult = jobtracking.Interaction{JobID: jobID, SavedAt: tPtr(time.Now())}
+		rem := &fakeReminders{err: errors.New("reminder store is down")}
+		svc := jobtracking.New(repo, jobtracking.WithReminders(rem))
+
+		got, err := svc.SaveJob(ctx(), userID, slug)
+		if err != nil {
+			t.Fatalf("save should succeed despite the reminder: %v", err)
+		}
+		if got.SavedAt == nil {
+			t.Error("SavedAt should be set")
+		}
+	})
+
+	t.Run("no port configured is silent", func(t *testing.T) {
+		repo := newRepo()
+		repo.saveResult = jobtracking.Interaction{JobID: jobID, SavedAt: tPtr(time.Now())}
+		svc := jobtracking.New(repo)
+
+		if _, err := svc.SaveJob(ctx(), userID, slug); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+// TestFailedWriteSchedulesNothing keeps the side effect downstream of the write it
+// belongs to: a save that did not happen must not leave a reminder behind.
+func TestFailedWriteSchedulesNothing(t *testing.T) {
+	repo := newRepo()
+	repo.saveErr = errors.New("write failed")
+	rem := &fakeReminders{}
+	svc := jobtracking.New(repo, jobtracking.WithReminders(rem))
+
+	if _, err := svc.SaveJob(ctx(), userID, slug); err == nil {
+		t.Fatal("expected the save to fail")
+	}
+	if len(rem.scheduled) != 0 {
+		t.Errorf("scheduled = %v, want none", rem.scheduled)
+	}
+}

--- a/internal/candidate/matchanalysis/matchanalysis_test.go
+++ b/internal/candidate/matchanalysis/matchanalysis_test.go
@@ -235,6 +235,21 @@ func TestProductionSanitizeBoundsLocked(t *testing.T) {
 	}
 }
 
+// TestSetBounds_ZeroRestoresDefaults pins the boot contract with the config layer.
+// config.Load leaves every MATCH_ANALYSIS_* field at zero when the environment says
+// nothing, precisely so the defaults live here and nowhere else; cmd/server then
+// hands that zero Bounds straight to SetBounds. If this stopped restoring the
+// defaults, an unconfigured server would run with erased ceilings.
+func TestSetBounds_ZeroRestoresDefaults(t *testing.T) {
+	prev := CurrentBounds()
+	t.Cleanup(func() { SetBounds(prev) })
+
+	SetBounds(Bounds{})
+	if got := CurrentBounds(); got != DefaultBounds() {
+		t.Fatalf("CurrentBounds() = %+v after SetBounds(Bounds{}), want DefaultBounds() %+v", got, DefaultBounds())
+	}
+}
+
 func TestSetBoundsRejectsNonPositive(t *testing.T) {
 	prev := CurrentBounds()
 	t.Cleanup(func() { SetBounds(prev) })

--- a/internal/identity/auth/mobileauth/identities.go
+++ b/internal/identity/auth/mobileauth/identities.go
@@ -2,14 +2,13 @@ package mobileauth
 
 import (
 	"context"
-	"crypto/sha256"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/strelov1/freehire/internal/identity/auth/apple"
+	"github.com/strelov1/freehire/internal/identity/auth/recentauth"
 	"github.com/strelov1/freehire/internal/platform/pgerr"
 )
 
@@ -198,8 +197,6 @@ func (s *Store) ActivateAppleCompensation(ctx context.Context, jobID uuid.UUID) 
 	return err
 }
 
-func proofDigest(raw string) []byte { sum := sha256.Sum256([]byte(raw)); return sum[:] }
-
 // ReleaseAppleGrantsForDeletion queues Apple revocation for every grant the
 // account holds and clears the apple_grants rows, freeing the FK
 // (ON DELETE RESTRICT) that would otherwise block deleting the user. The
@@ -282,15 +279,13 @@ func (s *Store) unlinkIdentityOnce(ctx context.Context, userID int64, tokenVersi
 	if err = tx.QueryRow(ctx, `SELECT password_hash IS NOT NULL FROM users WHERE id=$1 FOR UPDATE`, userID).Scan(&hasPassword); err != nil {
 		return false, err
 	}
-	if len(sessionHash) != sha256.Size {
-		return false, ErrSession
-	}
-	tag, err := tx.Exec(ctx, `UPDATE recent_auth_proofs SET consumed_at=now() WHERE proof_hash=$1 AND user_id=$2 AND token_version=$3 AND session_hash=$4 AND consumed_at IS NULL AND expires_at>now()`, proofDigest(recentProof), userID, tokenVersion, sessionHash)
-	if err != nil {
+	// The proof is spent inside this transaction, after the account lock, so a
+	// concurrent unlink cannot reuse it. recentauth owns the predicate.
+	if err = recentauth.ConsumeTx(ctx, tx, recentProof, userID, tokenVersion, sessionHash); err != nil {
+		if errors.Is(err, recentauth.ErrRequired) {
+			return false, ErrSession
+		}
 		return false, err
-	}
-	if tag.RowsAffected() != 1 {
-		return false, fmt.Errorf("%w", ErrSession)
 	}
 	rows, err := tx.Query(ctx, `SELECT provider,provider_user_id,status FROM user_identities WHERE user_id=$1 ORDER BY provider,provider_user_id FOR UPDATE`, userID)
 	if err != nil {

--- a/internal/identity/auth/recentauth/recentauth.go
+++ b/internal/identity/auth/recentauth/recentauth.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -78,11 +79,17 @@ func (s *Store) Validate(ctx context.Context, raw string, userID int64, tokenVer
 	return nil
 }
 
-func (s *Store) Consume(ctx context.Context, raw string, userID int64, tokenVersion int32, sessionHash []byte) error {
+// execer is satisfied by both *pgxpool.Pool and pgx.Tx, so Consume and ConsumeTx
+// spend a proof through one statement instead of two copies of the predicate.
+type execer interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+}
+
+func consume(ctx context.Context, q execer, raw string, userID int64, tokenVersion int32, sessionHash []byte) error {
 	if raw == "" || len(sessionHash) != sha256.Size {
 		return ErrRequired
 	}
-	tag, err := s.pool.Exec(ctx, `
+	tag, err := q.Exec(ctx, `
 		UPDATE recent_auth_proofs SET consumed_at=now()
 		WHERE proof_hash=$1 AND user_id=$2 AND token_version=$3 AND session_hash=$4
 		  AND consumed_at IS NULL AND expires_at > now()`, hash(raw), userID, tokenVersion, sessionHash)
@@ -93,6 +100,19 @@ func (s *Store) Consume(ctx context.Context, raw string, userID int64, tokenVers
 		return ErrRequired
 	}
 	return nil
+}
+
+func (s *Store) Consume(ctx context.Context, raw string, userID int64, tokenVersion int32, sessionHash []byte) error {
+	return consume(ctx, s.pool, raw, userID, tokenVersion, sessionHash)
+}
+
+// ConsumeTx spends the proof inside a caller's transaction, for the callers that
+// must serialize the spend with the write it authorises — unlinking a sign-in
+// method locks the account first, so it cannot reach the pool-backed Consume.
+// It takes no Store because a proof is identified entirely by its arguments;
+// tightening the predicate here reaches every caller.
+func ConsumeTx(ctx context.Context, tx pgx.Tx, raw string, userID int64, tokenVersion int32, sessionHash []byte) error {
+	return consume(ctx, tx, raw, userID, tokenVersion, sessionHash)
 }
 
 func (s *Store) Revoke(ctx context.Context, raw string) error {

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -279,31 +279,37 @@ type OAuthCredentials struct {
 	PrivateKey   string
 }
 
-// MatchAnalysisSettings holds the sanitize ceilings for fit-analysis model output.
-// Defaults match internal/candidate/matchanalysis.DefaultBounds(); cmd/server applies them via
+// MatchAnalysisSettings carries the MATCH_ANALYSIS_* overrides for the sanitize
+// ceilings on fit-analysis model output; cmd/server applies them via
 // matchanalysis.SetBounds at boot. Restart required after any change.
+//
+// A field left at zero means "not overridden": SetBounds substitutes that field's
+// own Default* from internal/candidate/matchanalysis, which is where every default
+// number lives. This layer deliberately holds none of them — it is not supposed to
+// know what a fit analysis is, and a second copy here would be the one the server
+// actually reads, silently retiring the domain's own defaults.
 type MatchAnalysisSettings struct {
-	// MaxCommentRunes caps each dimension's Comment (default 240).
+	// MaxCommentRunes caps each dimension's Comment.
 	MaxCommentRunes int
-	// MaxListItemRunes caps each Strengths / Gaps bullet (default 200).
+	// MaxListItemRunes caps each Strengths / Gaps bullet.
 	MaxListItemRunes int
-	// MaxRecommendRunes caps the free-text Recommendation (default 1200).
+	// MaxRecommendRunes caps the free-text Recommendation.
 	MaxRecommendRunes int
-	// MaxReqTextRunes caps Requirement.Text (default 200).
+	// MaxReqTextRunes caps Requirement.Text.
 	MaxReqTextRunes int
-	// MaxReqEvidenceRunes caps Requirement.Evidence (default 240).
+	// MaxReqEvidenceRunes caps Requirement.Evidence.
 	MaxReqEvidenceRunes int
-	// MaxStrengths caps the Strengths list length (default 6).
+	// MaxStrengths caps the Strengths list length.
 	MaxStrengths int
-	// MaxGaps caps the Gaps list length (default 6).
+	// MaxGaps caps the Gaps list length.
 	MaxGaps int
-	// MaxRequirements caps the RequirementMatch list length (default 30).
+	// MaxRequirements caps the RequirementMatch list length.
 	MaxRequirements int
-	// MaxSignals caps the HiddenSignals list length (default 5).
+	// MaxSignals caps the HiddenSignals list length.
 	MaxSignals int
-	// MaxSignalQuoteRunes caps Signal.Quote (default 200).
+	// MaxSignalQuoteRunes caps Signal.Quote.
 	MaxSignalQuoteRunes int
-	// MaxSignalInsightRunes caps Signal.Insight (default 200).
+	// MaxSignalInsightRunes caps Signal.Insight.
 	MaxSignalInsightRunes int
 }
 
@@ -370,18 +376,19 @@ func Load() Settings {
 		CVEditAllowBulletTruncation: envBool("CV_EDIT_ALLOW_BULLET_TRUNCATION", false),
 		CVMaxBullets:                envInt("CV_MAX_BULLETS", 20),
 
+		// Zero is the "unset" fallback on purpose — see MatchAnalysisSettings.
 		MatchAnalysis: MatchAnalysisSettings{
-			MaxCommentRunes:       envInt("MATCH_ANALYSIS_MAX_COMMENT_RUNES", 240),
-			MaxListItemRunes:      envInt("MATCH_ANALYSIS_MAX_LIST_ITEM_RUNES", 200),
-			MaxRecommendRunes:     envInt("MATCH_ANALYSIS_MAX_RECOMMEND_RUNES", 1200),
-			MaxReqTextRunes:       envInt("MATCH_ANALYSIS_MAX_REQ_TEXT_RUNES", 200),
-			MaxReqEvidenceRunes:   envInt("MATCH_ANALYSIS_MAX_REQ_EVIDENCE_RUNES", 240),
-			MaxStrengths:          envInt("MATCH_ANALYSIS_MAX_STRENGTHS", 6),
-			MaxGaps:               envInt("MATCH_ANALYSIS_MAX_GAPS", 6),
-			MaxRequirements:       envInt("MATCH_ANALYSIS_MAX_REQUIREMENTS", 30),
-			MaxSignals:            envInt("MATCH_ANALYSIS_MAX_SIGNALS", 5),
-			MaxSignalQuoteRunes:   envInt("MATCH_ANALYSIS_MAX_SIGNAL_QUOTE_RUNES", 200),
-			MaxSignalInsightRunes: envInt("MATCH_ANALYSIS_MAX_SIGNAL_INSIGHT_RUNES", 200),
+			MaxCommentRunes:       envInt("MATCH_ANALYSIS_MAX_COMMENT_RUNES", 0),
+			MaxListItemRunes:      envInt("MATCH_ANALYSIS_MAX_LIST_ITEM_RUNES", 0),
+			MaxRecommendRunes:     envInt("MATCH_ANALYSIS_MAX_RECOMMEND_RUNES", 0),
+			MaxReqTextRunes:       envInt("MATCH_ANALYSIS_MAX_REQ_TEXT_RUNES", 0),
+			MaxReqEvidenceRunes:   envInt("MATCH_ANALYSIS_MAX_REQ_EVIDENCE_RUNES", 0),
+			MaxStrengths:          envInt("MATCH_ANALYSIS_MAX_STRENGTHS", 0),
+			MaxGaps:               envInt("MATCH_ANALYSIS_MAX_GAPS", 0),
+			MaxRequirements:       envInt("MATCH_ANALYSIS_MAX_REQUIREMENTS", 0),
+			MaxSignals:            envInt("MATCH_ANALYSIS_MAX_SIGNALS", 0),
+			MaxSignalQuoteRunes:   envInt("MATCH_ANALYSIS_MAX_SIGNAL_QUOTE_RUNES", 0),
+			MaxSignalInsightRunes: envInt("MATCH_ANALYSIS_MAX_SIGNAL_INSIGHT_RUNES", 0),
 		},
 
 		SentryDSN:         os.Getenv("SENTRY_DSN"),

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -145,7 +145,11 @@ func TestLoad_MaxBulletsFromEnv(t *testing.T) {
 	}
 }
 
-func TestLoad_MatchAnalysisDefaults(t *testing.T) {
+// TestLoad_MatchAnalysisUnsetLeavesZero pins the half of the contract this layer
+// owns: with nothing in the environment, every field stays zero. The numbers a
+// zero turns into belong to internal/candidate/matchanalysis, which this block may
+// not import — TestSetBounds_ZeroRestoresDefaults over there pins the other half.
+func TestLoad_MatchAnalysisUnsetLeavesZero(t *testing.T) {
 	for _, key := range []string{
 		"MATCH_ANALYSIS_MAX_COMMENT_RUNES",
 		"MATCH_ANALYSIS_MAX_LIST_ITEM_RUNES",
@@ -161,15 +165,8 @@ func TestLoad_MatchAnalysisDefaults(t *testing.T) {
 	} {
 		t.Setenv(key, "")
 	}
-	s := Load()
-	want := MatchAnalysisSettings{
-		MaxCommentRunes: 240, MaxListItemRunes: 200, MaxRecommendRunes: 1200,
-		MaxReqTextRunes: 200, MaxReqEvidenceRunes: 240,
-		MaxStrengths: 6, MaxGaps: 6, MaxRequirements: 30,
-		MaxSignals: 5, MaxSignalQuoteRunes: 200, MaxSignalInsightRunes: 200,
-	}
-	if s.MatchAnalysis != want {
-		t.Fatalf("MatchAnalysis = %+v, want %+v", s.MatchAnalysis, want)
+	if s := Load(); s.MatchAnalysis != (MatchAnalysisSettings{}) {
+		t.Fatalf("MatchAnalysis = %+v, want the zero value", s.MatchAnalysis)
 	}
 }
 
@@ -183,8 +180,8 @@ func TestLoad_MatchAnalysisFromEnv(t *testing.T) {
 	if s.MatchAnalysis.MaxSignals != 9 {
 		t.Fatalf("MaxSignals = %d, want 9", s.MatchAnalysis.MaxSignals)
 	}
-	if s.MatchAnalysis.MaxCommentRunes != 240 {
-		t.Fatalf("MaxCommentRunes = %d, want untouched default 240", s.MatchAnalysis.MaxCommentRunes)
+	if s.MatchAnalysis.MaxCommentRunes != 0 {
+		t.Fatalf("MaxCommentRunes = %d, want 0 — an override of one key must not stamp the others", s.MatchAnalysis.MaxCommentRunes)
 	}
 }
 


### PR DESCRIPTION
An architecture pass over `internal/` (ports/app/domain/adapters, run against the
existing block layering rather than instead of it) found the same shape four
times: a rule that every caller of a use case means, written where one caller
happens to reach it. Each is small and independently checkable, so they are here
together rather than as four PRs.

## 1. Saved-job reminders belong to the use case, not to Fiber — and this one was live

`SaveJob` in `internal/api/handler/user_jobs.go` called `scheduleReminderOnSave`;
`assistant_tracking_tools.go` calls `jobtracking.Service.SaveJob` directly and
issues no HTTP request. **A job saved by asking the in-app assistant never got a
reminder row.** `MarkAppliedAt` — the mail-reconstruction path — never cancelled
one either, for the same reason.

The schedule/cancel now sits in `jobtracking.Service`, behind a two-method
`Reminders` port. `internal/engage` sits *above* `internal/application`, so the
interface is declared in the consumer and `reminder.Service` satisfies it
structurally; the composition root supplies it. No block-layering change.

Best-effort as before: a reminder failure is logged, never surfaced, and the
worker still re-checks intent immediately before sending.

## 2. `recentauth.ConsumeTx` — one predicate instead of two

The proof-consumption predicate existed twice: `recentauth.Store.Consume` and an
inline copy in `mobileauth.unlinkIdentityOnce`, which cannot reach the
pool-backed `Consume` because it must serialize with the account lock.

Both copies were correct. The risk was drift on a security control: tighten the
proof in `recentauth` — the obvious place — and `UnlinkIdentity`, the endpoint
that *deletes a sign-in method*, would keep accepting proofs under the old rule.
`Consume` and `ConsumeTx` now run one statement through a small `execer` that
both `*pgxpool.Pool` and `pgx.Tx` satisfy.

## 3. `inbox` asked for a whole job row to read one id

All three call sites used only `job.ID`, and `jobs.sql` already carries
`GetJobIDBySlug` with a comment saying it exists so the wide description and
enrichment columns stay off the wire. Every mailbox triage, link and
mail-reconstructed application was detoasting a description to get an int64.

## 4. `config` no longer restates `matchanalysis.Bounds`

It held all eleven default numbers as `envInt` fallbacks. Because `envInt` never
returns 0 for those keys and `boundOrDefault` only falls back below 1, the
domain's own `Default*` constants **were never consulted in `cmd/server`** — so
`TestProductionSanitizeBoundsLocked` was locking values the server did not read.

The fallbacks are 0 now, which `SetBounds` already turns into the domain default.
`TestSetBounds_ZeroRestoresDefaults` pins that boot contract from the
`matchanalysis` side; `config`'s own test pins the half it owns (unset → zero),
since `platform` may not import `candidate`.

## Verification

- `gofmt -l .` clean, `go vet ./...`, `go test ./...` all pass
- `go vet -tags=integration ./...` passes
- `golangci-lint run --new-from-rev=origin/main` → 0 issues
- The three new reminder tests were mutation-checked: disabling the side effect
  makes them fail, restoring it makes them pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job tracking now automatically schedules reminders when jobs are saved and cancels them when application intent ends.
  * Reminder failures no longer interrupt job updates.

* **Bug Fixes**
  * Recent-auth proof consumption is handled consistently during identity unlinking.
  * Match-analysis defaults are reliably restored when no configuration overrides are provided.

* **Tests**
  * Added coverage for reminder behavior, authentication proof handling, and match-analysis default settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->