### PR TITLE
Move the fit-analysis reads off the CV handler, so the agent's tools stop reaching through it

### DIFF
--- a/internal/api/handler/assistant.go
+++ b/internal/api/handler/assistant.go
@@ -21,6 +21,7 @@ import (
 	"github.com/strelov1/freehire/internal/ai/browsertools"
 	"github.com/strelov1/freehire/internal/ai/llmkey"
 	"github.com/strelov1/freehire/internal/candidate/cv"
+	"github.com/strelov1/freehire/internal/candidate/fitanalysis"
 	"github.com/strelov1/freehire/internal/identity/auth"
 	"github.com/strelov1/freehire/internal/ingest/screeninganswers"
 	"github.com/strelov1/freehire/internal/platform/db"
@@ -50,7 +51,14 @@ type assistantHandlers struct {
 	// at a time. Its zero value works; see assistant_turns.go.
 	turns turnRegistry
 
-	queries  *db.Queries
+	queries *db.Queries
+	// fit reads the cached fit analysis the tailoring and interview tools ground on. Held
+	// directly rather than reached for through the CV handlers: these are use cases, and a
+	// tool must not depend on which HTTP surface happens to assemble them.
+	fit *fitanalysis.Service
+	// jobs serves the vacancy a tool is about — one row by id, the same narrow read the CV
+	// surface takes.
+	jobs     jobReader
 	search   *searchHandlers
 	resume   *resumeHandlers
 	tracking *trackingHandlers
@@ -111,6 +119,7 @@ func newAssistantHandlers(queries *db.Queries, models assistantModels, store *as
 		screeningAnswers: screeningAnswers,
 		store:            store,
 		queries:          queries,
+		jobs:             queries,
 		search:           search,
 		resume:           resumeH,
 		tracking:         tracking,
@@ -119,6 +128,12 @@ func newAssistantHandlers(queries *db.Queries, models assistantModels, store *as
 		browserTools:     browserTools,
 		mail:             mail,
 		stages:           queries,
+	}
+	// The fit reads come from the service, not from whichever handler happens to hold it:
+	// a tool that grounds on the cached analysis must not break because the CV surface was
+	// reshaped.
+	if cvH != nil {
+		h.fit = cvH.fit
 	}
 	// The rehearsal reads the invitation through the mail service, not through the store:
 	// the guarantee that this read leaves read_at alone is inbox's, and reaching past it
@@ -897,10 +912,10 @@ func (h *assistantHandlers) prepareAutopilotAnalysis(c *fiber.Ctx, sess assistan
 // Best-effort: a missing or unreadable analysis leaves the report as it was. The run itself
 // is worth starting either way, and the agent replaces the whole report when it reports.
 func (h *assistantHandlers) layDownRunPlan(ctx context.Context, sess assistant.Session) {
-	if h.cv.matchAnalysisCache == nil {
+	if h.fit == nil {
 		return
 	}
-	analysis, err := h.cv.cachedAnalysisCtx(ctx, sess.UserID, *sess.JobID)
+	analysis, err := h.fit.Required(ctx, sess.UserID, *sess.JobID)
 	if err != nil || analysis == nil {
 		return
 	}

--- a/internal/api/handler/assistant_autopilot_integration_test.go
+++ b/internal/api/handler/assistant_autopilot_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/strelov1/freehire/internal/candidate/cv"
 	"github.com/strelov1/freehire/internal/candidate/cvedit"
 	"github.com/strelov1/freehire/internal/candidate/experience"
+	"github.com/strelov1/freehire/internal/candidate/fitanalysis"
 	"github.com/strelov1/freehire/internal/candidate/matchanalysis"
 	"github.com/strelov1/freehire/internal/candidate/resume"
 	"github.com/strelov1/freehire/internal/identity/auth"
@@ -48,12 +49,16 @@ func newAutopilotHarness(t *testing.T, pool *pgxpool.Pool, iss *auth.Issuer, tur
 		maxPrompt:  defaultAssistantMaxPrompt,
 		stages:     queries,
 		experience: bank,
+		// The run plan reads the cached analysis through the service, and the tools read the
+		// vacancy through jobs — both held by the assistant itself now.
+		fit:  fitanalysis.New(queries, nil, matchanalysis.NewAnalyzer(nil)),
+		jobs: queries,
 		cv: &cvHandlers{
-			cvStore:            cv.NewStore(cv.NewQueriesRepository(queries)),
-			editor:             cvedit.NewEditor(cvedit.NewRepository(pool, queries), bankGate{bank: bank}),
-			queries:            queries,
-			jobReader:          queries,
-			matchAnalysisCache: queries,
+			cvStore:   cv.NewStore(cv.NewQueriesRepository(queries)),
+			editor:    cvedit.NewEditor(cvedit.NewRepository(pool, queries), bankGate{bank: bank}),
+			queries:   queries,
+			jobReader: queries,
+			fit:       fitanalysis.New(queries, nil, matchanalysis.NewAnalyzer(nil)),
 			match: fitAPI(pool, queries, iss, resume.New(nil, resume.NewQueriesRepository(queries)),
 				matchanalysis.NewAnalyzer(llm.NewWithModel(fitM))),
 		},

--- a/internal/api/handler/assistant_cv_context_test.go
+++ b/internal/api/handler/assistant_cv_context_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/strelov1/freehire/internal/candidate/experience"
+	"github.com/strelov1/freehire/internal/candidate/fitanalysis"
+	"github.com/strelov1/freehire/internal/candidate/matchanalysis"
 	"github.com/strelov1/freehire/internal/platform/db"
 )
 
@@ -80,11 +82,11 @@ const twoRequirementAnalysis = `{
 func contextToolAPI(t *testing.T, description string, atoms []experience.Atom) (*assistantHandlers, *bankStub) {
 	t.Helper()
 	bank := &bankStub{atoms: atoms}
+	// No cvHandlers in sight: cv_context reads the fit service and one job row, and now says
+	// so — the point of moving these reads off the CV surface.
 	h := &assistantHandlers{
-		cv: &cvHandlers{
-			matchAnalysisCache: analysisCache{analysis: twoRequirementAnalysis},
-			jobReader:          jobStub{job: db.Job{Title: "Senior Backend Engineer", Company: "Acme", PublicSlug: "senior-backend-acme", Description: description}},
-		},
+		fit:        fitanalysis.New(analysisCache{analysis: twoRequirementAnalysis}, nil, matchanalysis.NewAnalyzer(nil)),
+		jobs:       jobStub{job: db.Job{Title: "Senior Backend Engineer", Company: "Acme", PublicSlug: "senior-backend-acme", Description: description}},
 		experience: bank,
 	}
 	return h, bank
@@ -225,5 +227,19 @@ func TestCVContextLeavesTheNarrativeToThePanel(t *testing.T) {
 		if !strings.Contains(payload, wanted) {
 			t.Errorf("the agent's context lost %s:\n%s", wanted, payload)
 		}
+	}
+}
+
+// TestCVContextReportsAnUnwiredDeployment mirrors the interview tool's guard. The tool runs
+// inside the SSE writer's goroutine, where Registry.Call's error path cannot reach a panic and
+// Fiber's recover is not listening — so a collaborator nobody wired must be a sentence the
+// model can act on, not a segfault that takes the process down.
+func TestCVContextReportsAnUnwiredDeployment(t *testing.T) {
+	bare := &assistantHandlers{}
+
+	_, err := toolByName(t, bare.assistantCVTools(testCVID, 9, uuid.New()), "cv_context").
+		Run(context.Background(), 3, json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("cv_context answered from a handler wired to nothing")
 	}
 }

--- a/internal/api/handler/assistant_cv_job_match_test.go
+++ b/internal/api/handler/assistant_cv_job_match_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/strelov1/freehire/internal/candidate/cv"
+	"github.com/strelov1/freehire/internal/candidate/fitanalysis"
+	"github.com/strelov1/freehire/internal/candidate/matchanalysis"
 	"github.com/strelov1/freehire/internal/platform/db"
 )
 
@@ -18,13 +20,13 @@ func jobMatchToolAPI(t *testing.T, doc string, job db.Job, analysis string) (*as
 	t.Helper()
 	repo := &cvRepo{id: testCVID, userID: 3, jobID: 9, data: []byte(doc)}
 	h := &cvHandlers{
-		cvStore:            cv.NewStore(repo),
-		cvRenderer:         &fakeCVRenderer{pdf: []byte(scorableCV)},
-		extractPDFText:     textFromPDF,
-		jobReader:          jobStub{job: job},
-		matchAnalysisCache: analysisCache{analysis: analysis},
+		cvStore:        cv.NewStore(repo),
+		cvRenderer:     &fakeCVRenderer{pdf: []byte(scorableCV)},
+		extractPDFText: textFromPDF,
+		jobReader:      jobStub{job: job},
+		fit:            fitanalysis.New(analysisCache{analysis: analysis}, nil, matchanalysis.NewAnalyzer(nil)),
 	}
-	return &assistantHandlers{cv: h}, repo
+	return &assistantHandlers{cv: h, fit: h.fit, jobs: jobStub{job: job}}, repo
 }
 
 func TestJobMatchToolScoresTheCurrentCV(t *testing.T) {

--- a/internal/api/handler/assistant_cv_job_match_test.go
+++ b/internal/api/handler/assistant_cv_job_match_test.go
@@ -92,3 +92,17 @@ func TestJobMatchToolReflectsAnEditedDocument(t *testing.T) {
 		t.Errorf("score did not change after the rendered text changed: %s", beforePayload)
 	}
 }
+
+// TestJobMatchReportsAnUnwiredDeployment is the companion to cv_context's own guard: a tool
+// that dereferences a collaborator nobody wired must report it, because the call runs inside
+// the SSE writer's goroutine where Registry.Call's error path cannot reach a panic and Fiber's
+// recover is not listening — so it takes the process down, not one request.
+func TestJobMatchReportsAnUnwiredDeployment(t *testing.T) {
+	bare := &assistantHandlers{}
+
+	_, err := toolByName(t, bare.assistantCVTools(testCVID, 9, uuid.New()), "job_match").
+		Run(context.Background(), 3, json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("job_match answered from a handler wired to nothing")
+	}
+}

--- a/internal/api/handler/assistant_cv_tools.go
+++ b/internal/api/handler/assistant_cv_tools.go
@@ -16,6 +16,7 @@ import (
 	"github.com/strelov1/freehire/internal/candidate/cvedit"
 	"github.com/strelov1/freehire/internal/candidate/cvmatch"
 	"github.com/strelov1/freehire/internal/candidate/experience"
+	"github.com/strelov1/freehire/internal/candidate/fitanalysis"
 	"github.com/strelov1/freehire/internal/candidate/matchanalysis"
 )
 
@@ -193,7 +194,18 @@ func (h *assistantHandlers) cvContextTool(jobID int64) assistant.Tool {
 			if err := assistant.DecodeArgs(raw, &in); err != nil {
 				return nil, err
 			}
-			base, err := h.cv.tailoringContext(ctx, userID, jobID)
+			// A tool error is a sentence the model can act on; a nil dereference here is a
+			// panic inside the SSE writer's goroutine, where Registry.Call's error path
+			// cannot reach it and Fiber's recover is not listening. Production always wires
+			// this, so the guard is for the next partially-wired harness.
+			if h.jobs == nil {
+				return nil, errors.New("the tailoring context is unavailable in this deployment")
+			}
+			job, err := h.jobs.GetJob(ctx, jobID)
+			if err != nil {
+				return nil, err
+			}
+			base, err := h.fit.TailoringContext(ctx, userID, job)
 			if err != nil {
 				return nil, err
 			}
@@ -229,11 +241,11 @@ func (h *assistantHandlers) cvJobMatchTool(cvID uuid.UUID, jobID int64) assistan
 			if err != nil {
 				return nil, cvToolError(err)
 			}
-			job, err := h.cv.jobReader.GetJob(ctx, jobID)
+			job, err := h.jobs.GetJob(ctx, jobID)
 			if err != nil {
 				return nil, err
 			}
-			analysis, hasAnalysis := h.cv.cachedAnalysisOrNone(ctx, userID, jobID)
+			analysis, hasAnalysis := h.fit.Optional(ctx, userID, jobID)
 			score, err := h.cv.cvJobMatchScore(ctx, rec.Document, tmpl, cvmatch.Input{
 				JobTitle:     job.Title,
 				JobSkills:    job.Skills,
@@ -365,11 +377,11 @@ type requirementEvidence struct {
 // So the agent gets what it works from: the vacancy, the score in one line for tone, and the
 // requirements with the bank's answer attached.
 type agentTailorContext struct {
-	Job          tailorJob              `json:"job"`
-	Verdict      string                 `json:"verdict"`
-	OverallScore int                    `json:"overall_score"`
-	MissingHave  []evidencedRequirement `json:"missing_have"`
-	MissingGap   []evidencedRequirement `json:"missing_gap"`
+	Job          fitanalysis.TailoringJob `json:"job"`
+	Verdict      string                   `json:"verdict"`
+	OverallScore int                      `json:"overall_score"`
+	MissingHave  []evidencedRequirement   `json:"missing_have"`
+	MissingGap   []evidencedRequirement   `json:"missing_gap"`
 }
 
 // evidencePerRequirement bounds what one requirement may carry. Three is enough to write a
@@ -385,7 +397,7 @@ const evidencePerRequirement = 3
 //
 // A bank that cannot be read degrades to no evidence rather than to an error: the requirements
 // are worth reading either way, and an empty list already means "nothing found".
-func (h *assistantHandlers) withBankEvidence(ctx context.Context, userID int64, base tailorContextResponse) agentTailorContext {
+func (h *assistantHandlers) withBankEvidence(ctx context.Context, userID int64, base fitanalysis.TailoringContext) agentTailorContext {
 	return agentTailorContext{
 		Job:          base.Job,
 		Verdict:      base.Verdict,

--- a/internal/api/handler/assistant_cv_tools.go
+++ b/internal/api/handler/assistant_cv_tools.go
@@ -233,6 +233,12 @@ func (h *assistantHandlers) cvJobMatchTool(cvID uuid.UUID, jobID int64) assistan
 			if err := assistant.DecodeArgs(raw, &in); err != nil {
 				return nil, err
 			}
+			// Same reason cv_context guards: a nil dereference here is a panic on the SSE
+			// writer's goroutine, which takes the process down rather than one request.
+			// This tool needs both the CV surface and the vacancy read.
+			if h.cv == nil || h.jobs == nil {
+				return nil, errors.New("the job-match score is unavailable in this deployment")
+			}
 			rec, err := h.cv.cvStore.GetForModel(ctx, cvID, userID)
 			if err != nil {
 				return nil, cvToolError(err)

--- a/internal/api/handler/assistant_integration_test.go
+++ b/internal/api/handler/assistant_integration_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/strelov1/freehire/internal/candidate/cv"
 	"github.com/strelov1/freehire/internal/candidate/cvedit"
 	"github.com/strelov1/freehire/internal/candidate/experience"
+	"github.com/strelov1/freehire/internal/candidate/fitanalysis"
+	"github.com/strelov1/freehire/internal/candidate/matchanalysis"
 	"github.com/strelov1/freehire/internal/identity/auth"
 	"github.com/strelov1/freehire/internal/platform/db"
 	"github.com/strelov1/freehire/internal/platform/llm"
@@ -70,14 +72,17 @@ func newAssistantApp(pool *pgxpool.Pool, iss *auth.Issuer, model assistant.Model
 		// reason — which is why the editor below is CONSTRUCTED with it, exactly as the
 		// production assembly does, rather than having it attached afterwards.
 		experience: bank,
+		// The run's plan, the tailoring context and the rehearsal all read the cached fit
+		// analysis and the vacancy. They take both directly, exactly as the production
+		// wiring hands them over — not through whichever HTTP surface happens to hold one.
+		fit:  fitanalysis.New(queries, nil, matchanalysis.NewAnalyzer(nil)),
+		jobs: queries,
 		// The tailoring tools and the autopilot run reach the CV store, so the assistant
 		// under test carries the same CV service the HTTP surface uses.
 		cv: &cvHandlers{
 			cvStore: cv.NewStore(cv.NewQueriesRepository(queries)),
 			editor:  cvedit.NewEditor(cvedit.NewRepository(pool, queries), bankGate{bank: bank}), queries: queries, jobReader: queries,
-			// The run reads the cached fit analysis to lay down its plan, so the CV handlers
-			// under test carry the same cache the production wiring gives them.
-			matchAnalysisCache: queries,
+			fit: fitanalysis.New(queries, nil, matchanalysis.NewAnalyzer(nil)),
 		},
 	}
 	if model != nil {

--- a/internal/api/handler/assistant_interview_tools.go
+++ b/internal/api/handler/assistant_interview_tools.go
@@ -113,7 +113,7 @@ func (h *assistantHandlers) rehearsalContext(ctx context.Context, userID, jobID 
 	// inside the SSE writer's goroutine, where Registry.Call's error path cannot reach it
 	// and Fiber's recover is not listening. Production always wires both, so this guards
 	// the next partially-wired harness rather than a live caller.
-	if h.stages == nil || h.cv == nil {
+	if h.stages == nil || h.jobs == nil {
 		return interviewContext{}, errors.New("the rehearsal context is unavailable in this deployment")
 	}
 	stage, err := h.stages.GetUserJobStage(ctx, db.GetUserJobStageParams{UserID: userID, JobID: jobID})
@@ -121,7 +121,7 @@ func (h *assistantHandlers) rehearsalContext(ctx context.Context, userID, jobID 
 		return interviewContext{}, err
 	}
 
-	job, err := h.cv.jobReader.GetJob(ctx, jobID)
+	job, err := h.jobs.GetJob(ctx, jobID)
 	if err != nil {
 		return interviewContext{}, err
 	}
@@ -143,7 +143,7 @@ func (h *assistantHandlers) rehearsalContext(ctx context.Context, userID, jobID 
 	// A missing analysis is not a refused rehearsal. The vacancy and the bank carry most
 	// of the value, and the candidate opening this the night before an interview is
 	// exactly who should not be told to go and run something else first.
-	if analysis, err := h.cv.cachedAnalysisCtx(ctx, userID, jobID); err == nil && analysis != nil {
+	if analysis, err := h.fit.Required(ctx, userID, jobID); err == nil && analysis != nil {
 		out.Verdict = analysis.Verdict
 		out.OverallScore = analysis.OverallScore
 		out.Requirements = h.evidenceFor(ctx, userID, capRequirements(analysis.RequirementMatch))

--- a/internal/api/handler/assistant_interview_tools_test.go
+++ b/internal/api/handler/assistant_interview_tools_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/strelov1/freehire/internal/ai/assistant"
 	"github.com/strelov1/freehire/internal/application/inbox"
 	"github.com/strelov1/freehire/internal/candidate/experience"
+	"github.com/strelov1/freehire/internal/candidate/fitanalysis"
 	"github.com/strelov1/freehire/internal/candidate/matchanalysis"
 	"github.com/strelov1/freehire/internal/platform/db"
 )
@@ -105,13 +106,11 @@ func (s invitationStub) InterviewInvitation(context.Context, int64, int64) (inbo
 func rehearsalAPI(t *testing.T, analysis string, atoms []experience.Atom, stage stageStub, invite invitationStub) *assistantHandlers {
 	t.Helper()
 	return &assistantHandlers{
-		cv: &cvHandlers{
-			matchAnalysisCache: analysisCache{analysis: analysis},
-			jobReader: jobStub{job: db.Job{
-				Title: "Senior Backend Engineer", Company: "Acme",
-				PublicSlug: "senior-backend-acme", Description: "We need Kafka in production.",
-			}},
-		},
+		fit: fitanalysis.New(analysisCache{analysis: analysis}, nil, matchanalysis.NewAnalyzer(nil)),
+		jobs: jobStub{job: db.Job{
+			Title: "Senior Backend Engineer", Company: "Acme",
+			PublicSlug: "senior-backend-acme", Description: "We need Kafka in production.",
+		}},
 		experience: &bankStub{atoms: atoms},
 		stages:     stage,
 		invitation: invite,

--- a/internal/api/handler/cv.go
+++ b/internal/api/handler/cv.go
@@ -55,10 +55,10 @@ type cvHandlers struct {
 	photos  *headshot.Store
 	queries *db.Queries
 	credits *credits.Store
-	// matchAnalysisCache reads the cached fit analysis the tailoring context grounds on.
-	// The read only, deliberately: fitanalysis.Service owns every write, the staleness rule
-	// and the metering, and this surface needs none of them.
-	matchAnalysisCache fitanalysis.Store
+	// fit reads the cached fit analysis the tailoring context and the CV-vs-job score
+	// ground on. Reads only, from this surface: the writes, the staleness rule and the
+	// metering are the same service's and belong to the match surface.
+	fit *fitanalysis.Service
 	// jobReader serves the vacancy a tailoring context is about. Narrow on purpose: the
 	// tailoring path reads one row by id and nothing else.
 	jobReader jobReader
@@ -139,17 +139,17 @@ func newCVHandlers(pool *pgxpool.Pool, queries *db.Queries, cvStore *cv.Store, a
 		// something attached afterwards: PATCH /me/cvs/:id edits as the agent for any
 		// API-key caller, so the wall cannot depend on which other features the assembly
 		// built.
-		editor:             cvedit.NewEditor(cvedit.NewRepository(pool, queries), gate).SetRefuseListCap(refuseListCap),
-		jobReader:          queries,
-		resume:             resumeStore,
-		photos:             photoStore,
-		seeder:             bankedSeeder{resume: resumeStore, bank: newWorkHistoryReader(queries)},
-		queries:            queries,
-		credits:            creditsStore,
-		matchAnalysisCache: queries,
-		match:              match,
-		jobs:               jobs,
-		extractPDFText:     resume.ExtractPDFText,
+		editor:         cvedit.NewEditor(cvedit.NewRepository(pool, queries), gate).SetRefuseListCap(refuseListCap),
+		jobReader:      queries,
+		resume:         resumeStore,
+		photos:         photoStore,
+		seeder:         bankedSeeder{resume: resumeStore, bank: newWorkHistoryReader(queries)},
+		queries:        queries,
+		credits:        creditsStore,
+		fit:            match.fit,
+		match:          match,
+		jobs:           jobs,
+		extractPDFText: resume.ExtractPDFText,
 	}
 	return h
 }

--- a/internal/api/handler/cv_job_match.go
+++ b/internal/api/handler/cv_job_match.go
@@ -68,7 +68,7 @@ func (h *cvHandlers) GetCVJobMatch(c *fiber.Ctx) error {
 	// A missing analysis degrades Requirements Coverage; it does not fail the read. The
 	// workspace opens before any analysis is guaranteed current, and a score of the other
 	// three categories is worth more than a refusal.
-	analysis, hasAnalysis := h.cachedAnalysisOrNone(c.Context(), userID, tailored.JobID)
+	analysis, hasAnalysis := h.fit.Optional(c.Context(), userID, tailored.JobID)
 
 	score, err := h.cvJobMatchScore(c.Context(), tailored.Document, tmpl, cvmatch.Input{
 		JobTitle:     job.Title,
@@ -103,26 +103,6 @@ func (h *cvHandlers) cvJobMatchScore(ctx context.Context, doc cv.Document, tmpl 
 	in.CVText = text
 	in.CVSkills = skilltag.Parse(text, skilltag.WithResumeAcronyms())
 	return cvmatch.Compute(in), nil
-}
-
-// cachedAnalysisOrNone reads the cached fit analysis, reporting its absence rather than
-// refusing the request the way the tailoring endpoints do. Those endpoints cannot proceed
-// without it; this one can, and says so in the score.
-//
-// "No analysis cached" arrives as a 409 and is an ordinary state here. Anything else is a
-// failed read, which degrades the same way — the other three categories are worth more than
-// a refusal — but is logged: a broken database must not look to us like a candidate who
-// never ran their fit analysis.
-func (h *cvHandlers) cachedAnalysisOrNone(ctx context.Context, userID, jobID int64) (*matchanalysis.Analysis, bool) {
-	analysis, err := h.cachedAnalysisCtx(ctx, userID, jobID)
-	if err != nil {
-		var fe *fiber.Error
-		if !errors.As(err, &fe) || fe.Code != fiber.StatusConflict {
-			log.Printf("cv job-match: cached analysis for user %d job %d: %v", userID, jobID, err)
-		}
-		return nil, false
-	}
-	return analysis, true
 }
 
 // cvJobMatchRequirements projects the cached ledger onto the scorer's input, carrying a

--- a/internal/api/handler/cv_job_match_integration_test.go
+++ b/internal/api/handler/cv_job_match_integration_test.go
@@ -18,6 +18,8 @@ import (
 
 	"github.com/strelov1/freehire/internal/candidate/cv"
 	"github.com/strelov1/freehire/internal/candidate/cvmatch"
+	"github.com/strelov1/freehire/internal/candidate/fitanalysis"
+	"github.com/strelov1/freehire/internal/candidate/matchanalysis"
 	"github.com/strelov1/freehire/internal/candidate/resume"
 	"github.com/strelov1/freehire/internal/identity/auth"
 	"github.com/strelov1/freehire/internal/platform/db"
@@ -50,10 +52,10 @@ func newJobMatchFixture(t *testing.T, pool *pgxpool.Pool) jobMatchFixture {
 	renderer := &fakeCVRenderer{pdf: []byte(jobMatchCVText)}
 	h := &cvHandlers{
 		queries: queries, jobReader: queries, cvStore: store,
-		matchAnalysisCache: queries,
-		resume:             resume.New(nil, resume.NewQueriesRepository(queries)),
-		cvRenderer:         renderer,
-		extractPDFText:     textFromPDF,
+		fit:            fitanalysis.New(queries, nil, matchanalysis.NewAnalyzer(nil)),
+		resume:         resume.New(nil, resume.NewQueriesRepository(queries)),
+		cvRenderer:     renderer,
+		extractPDFText: textFromPDF,
 	}
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	h.register(app.Group("/api/v1"), middleware{

--- a/internal/api/handler/cv_tailor.go
+++ b/internal/api/handler/cv_tailor.go
@@ -11,17 +11,14 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 
 	"github.com/strelov1/freehire/internal/ai/assistant"
 	"github.com/strelov1/freehire/internal/ai/credits"
 	"github.com/strelov1/freehire/internal/candidate/cv"
 	"github.com/strelov1/freehire/internal/candidate/cvedit"
-	"github.com/strelov1/freehire/internal/candidate/fitanalysis"
 	"github.com/strelov1/freehire/internal/candidate/matchanalysis"
 	"github.com/strelov1/freehire/internal/dict/skilltag"
 	"github.com/strelov1/freehire/internal/identity/auth"
-	"github.com/strelov1/freehire/internal/platform/db"
 )
 
 type tailorCVRequest struct {
@@ -320,21 +317,6 @@ func clipRunes(s string, max int) string {
 	return strings.TrimSpace(string(r[:max])) + "…"
 }
 
-// tailorContextResponse is the reasoning context the agent reads (freehire cv context): the
-// vacancy, the verdict and recommendation, per-dimension comments, and the requirement split
-// the honest wall turns on — missing_have (reframe existing evidence) vs missing_gap (ask first).
-type tailorContextResponse struct {
-	Job            tailorJob                   `json:"job"`
-	Verdict        string                      `json:"verdict"`
-	OverallScore   int                         `json:"overall_score"`
-	Recommendation string                      `json:"recommendation"`
-	Dimensions     []matchanalysis.Dimension   `json:"dimensions"`
-	MissingHave    []matchanalysis.Requirement `json:"missing_have"`
-	MissingGap     []matchanalysis.Requirement `json:"missing_gap"`
-	Strengths      []string                    `json:"strengths"`
-	Gaps           []string                    `json:"gaps"`
-}
-
 // TailorContext serves the cached fit analysis for a tailored CV, projected to the tailoring
 // reasoning context. Cookie or API key. 409 when the CV is not a tailored copy (no bound
 // vacancy) or has no cached analysis; never calls the LLM.
@@ -354,7 +336,13 @@ func (h *cvHandlers) TailorContext(c *fiber.Ctx) error {
 	if rec.JobID == 0 {
 		return fiber.NewError(fiber.StatusConflict, "not a tailored CV")
 	}
-	ctx, err := h.tailoringContext(c.Context(), userID, rec.JobID)
+	job, err := h.jobReader.GetJob(c.Context(), rec.JobID)
+	if err != nil {
+		return err
+	}
+	// fitanalysis.ErrNoAnalysis renders as the 409 this endpoint documents; classify maps it
+	// once, at the port boundary, for every route that can meet it.
+	ctx, err := h.fit.TailoringContext(c.Context(), userID, job)
 	if err != nil {
 		return err
 	}
@@ -362,77 +350,11 @@ func (h *cvHandlers) TailorContext(c *fiber.Ctx) error {
 }
 
 // optionalAnalysis loads the cached fit analysis for (user, job) if one exists, returning nil
-// without error when none is cached yet (or the cached blob is empty/corrupt) rather than a
-// 409 — the tailoring bootstrap no longer requires one to exist before starting.
+// when none is cached yet (or the cached blob is unreadable) rather than refusing — the
+// tailoring bootstrap no longer requires one to exist before starting.
 func (h *cvHandlers) optionalAnalysis(ctx context.Context, userID, jobID int64) *matchanalysis.Analysis {
-	analysis, _ := h.cachedAnalysisCtx(ctx, userID, jobID)
+	analysis, _ := h.fit.Optional(ctx, userID, jobID)
 	return analysis
-}
-
-// cachedAnalysisCtx is cachedAnalysis over a plain context, so the assistant's CV
-// tools — which have no fiber request — read the analysis through the same path
-// the HTTP endpoints do.
-func (h *cvHandlers) cachedAnalysisCtx(ctx context.Context, userID, jobID int64) (*matchanalysis.Analysis, error) {
-	row, err := h.matchAnalysisCache.GetUserJobAnalysis(ctx, db.GetUserJobAnalysisParams{UserID: userID, JobID: jobID})
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, fiber.NewError(fiber.StatusConflict, "run the fit analysis first")
-	}
-	if err != nil {
-		return nil, err
-	}
-	analysis := fitanalysis.DecodeAnalysis(row.Analysis)
-	if analysis == nil {
-		return nil, fiber.NewError(fiber.StatusConflict, "run the fit analysis first")
-	}
-	return analysis, nil
-}
-
-// tailorContext projects an analysis + its vacancy to the agent's reasoning context, splitting
-// requirements into the reframe-able (missing-have) and the genuine gaps (missing-gap).
-func tailorContext(a *matchanalysis.Analysis, job db.Job) tailorContextResponse {
-	var have, gap []matchanalysis.Requirement
-	for _, r := range a.RequirementMatch {
-		switch r.Status {
-		case matchanalysis.StatusMissingHave:
-			have = append(have, r)
-		case matchanalysis.StatusMissingGap:
-			gap = append(gap, r)
-		}
-	}
-	return tailorContextResponse{
-		Job: tailorJob{
-			Title:   job.Title,
-			Company: job.Company,
-			Slug:    job.PublicSlug,
-			// The posting is the largest thing in the turn and the least trusted: it reaches
-			// the model as words, bounded, the same way get_job already serves it. Sending
-			// markup spends the context window on tags and widens what there is to misread.
-			Description: clipRunes(formatDescription(job.Description, "markdown"), tailorDescriptionLimit),
-		},
-		Verdict:        a.Verdict,
-		OverallScore:   a.OverallScore,
-		Recommendation: a.Recommendation,
-		Dimensions:     a.Dimensions,
-		MissingHave:    have,
-		MissingGap:     gap,
-		Strengths:      a.Strengths,
-		Gaps:           a.Gaps,
-	}
-}
-
-// tailoringContext assembles what a tailoring reader needs: the cached analysis, projected
-// over the vacancy it is about. Both the HTTP endpoint and the agent's tool go through here,
-// so neither can drift into reading a different analysis or a different vacancy.
-func (h *cvHandlers) tailoringContext(ctx context.Context, userID, jobID int64) (tailorContextResponse, error) {
-	analysis, err := h.cachedAnalysisCtx(ctx, userID, jobID)
-	if err != nil {
-		return tailorContextResponse{}, err
-	}
-	job, err := h.jobReader.GetJob(ctx, jobID)
-	if err != nil {
-		return tailorContextResponse{}, err
-	}
-	return tailorContext(analysis, job), nil
 }
 
 // tailoredCVTitle names a tailored copy from the vacancy title (bounded/defaulted like any CV

--- a/internal/api/handler/cv_tailor_integration_test.go
+++ b/internal/api/handler/cv_tailor_integration_test.go
@@ -56,11 +56,11 @@ func newTailorAPI(t *testing.T) (*cvHandlers, *auth.Issuer, *pgxpool.Pool) {
 		// refused. A fixture asserting otherwise tests nothing that ships.
 		editor: cvedit.NewEditor(cvedit.NewRepository(pool, queries),
 			bankGate{bank: bank}),
-		resume:             resumeStore,
-		seeder:             bankedSeeder{resume: resumeStore, bank: bank},
-		matchAnalysisCache: queries,
-		credits:            creditsStore,
-		match:              &matchHandlers{fit: fitanalysis.New(queries, creditsStore, matchanalysis.NewAnalyzer(nil))},
+		resume:  resumeStore,
+		seeder:  bankedSeeder{resume: resumeStore, bank: bank},
+		fit:     fitanalysis.New(queries, nil, matchanalysis.NewAnalyzer(nil)),
+		credits: creditsStore,
+		match:   &matchHandlers{fit: fitanalysis.New(queries, creditsStore, matchanalysis.NewAnalyzer(nil))},
 		// Same adapter Register wires: bootstrap must place the vacancy on the board.
 		jobs: trackingBoarder{repo: jobtracking.NewQueriesRepository(queries, pool)},
 		// The tailoring bootstrap mints its conversation through the assistant's store,
@@ -590,7 +590,7 @@ func TestTailorContextSplit(t *testing.T) {
 		t.Fatalf("context = %d, want 200", resp.StatusCode)
 	}
 	var got struct {
-		Data tailorContextResponse `json:"data"`
+		Data fitanalysis.TailoringContext `json:"data"`
 	}
 	json.NewDecoder(resp.Body).Decode(&got)
 	resp.Body.Close()

--- a/internal/api/handler/errors.go
+++ b/internal/api/handler/errors.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/strelov1/freehire/internal/application/inbox"
+	"github.com/strelov1/freehire/internal/candidate/fitanalysis"
 	"github.com/strelov1/freehire/internal/platform/pgerr"
 	"github.com/strelov1/freehire/internal/search/search"
 )
@@ -106,6 +107,11 @@ func classify(err error) (status int, msg string, report bool) {
 		return fiber.StatusBadRequest, err.Error(), false
 	case errors.Is(err, inbox.ErrPendingSuggestion):
 		return fiber.StatusConflict, err.Error(), false
+	// The candidate has not run their fit analysis for this job, so the tailoring surfaces
+	// have nothing to ground on. A state, not a fault — and one both readers of the fit
+	// service meet, so the status is decided here rather than at each call site.
+	case errors.Is(err, fitanalysis.ErrNoAnalysis):
+		return fiber.StatusConflict, "run the fit analysis first", false
 	// The client cancelled the request (navigated away, closed the tab). The
 	// cancellation propagates through downstream calls (DB, Meilisearch) as
 	// context.Canceled — not a server fault, and there is no one left to answer.

--- a/internal/candidate/fitanalysis/AGENTS.md
+++ b/internal/candidate/fitanalysis/AGENTS.md
@@ -18,6 +18,9 @@ The chain has four entry points and only one of them speaks HTTP:
 | `POST /jobs/:slug/match-analysis` | `Authorize` → `Run` | first analysis of that job only |
 | `GET …/match-analysis/stream` | `Authorize` → `Claim` → `Run` or `Follow` | same rule, per caller |
 | the autopilot's cold-start fill and post-run refresh | `Ensure` / `Refresh` | **never** |
+| `GET /me/cvs/:id/tailor-context` + the agent's `cv_context` tool | `TailoringContext` | never (read only) |
+| `GET /me/cvs/:id/job-match` + the agent's `job_match` tool | `Optional` | never (read only) |
+| the agent's `interview_context` tool, the autopilot's run plan | `Required` | never (read only) |
 
 The last two execute **after** the request, from a detached SSE-writer goroutine, with no fiber
 ctx at all. A rule written where one caller happens to reach it is a rule the other three never
@@ -50,6 +53,29 @@ reachable only through a `*fiber.Ctx`.
   analysis is already computed by then. `Balance` answers nil on any failure; the atomic `Debit`
   is the real ceiling, not the pre-check.
 
+## Reading a cached analysis
+
+Three readers, three shapes, one rule about what "no analysis" means:
+
+- **`Required`** — `ErrNoAnalysis` when there is none. For readers that cannot proceed.
+- **`Optional`** — `(nil, false)`. For readers that carry on and say so in the result. A failed
+  read degrades the same way but is **logged**: a broken database must not look like a candidate
+  who never ran their analysis.
+- **`Cached`** — the analysis plus the stamps it was written under, for the surface that reports
+  staleness.
+
+An unreadable stored blob reads exactly like an absent one. Both mean "there is nothing to ground
+on, offer them a run", and a decode failure must not become a 500 on a surface whose honest answer
+is "run the fit analysis first".
+
+**`ErrNoAnalysis` never becomes a status here.** `internal/api/handler`'s `classify` maps it to 409
+once, at the port boundary, so no call site invents its own code.
+
+**A nil `*Service`, or one with no store, degrades rather than panicking** — `Required` answers
+`ErrNoAnalysis`, `Optional` answers `false`, `Balance` answers `nil`. Agent tools run inside an SSE
+writer's goroutine where a panic reaches no recover and takes the process down, so a partially
+wired harness has to fail soft. The tools guard their other collaborators for the same reason.
+
 ## Ports
 
 - `Store` — the analysis cache. `*db.Queries` satisfies it. It trades generated row types
@@ -77,6 +103,11 @@ an analysis that does not exist would put a query on the commonest read there is
 
 ## Gotchas
 
+- `ProjectTailoring` strips the posting's markup and clips it. The posting is the largest thing
+  in a turn and the least trusted; sending markup spends the context window on tags and widens
+  what there is to misread.
+- `TailoringContext` takes the job rather than reading it, so this package needs no job port —
+  every caller has already loaded and authorized that row.
 - `Refresh` claims nothing, on purpose: by the time it runs the turn is over, so there is no
   concurrent caller for that pair to coalesce with.
 - `Run` with a nil `emit` runs the sync chain; non-nil streams it. That is the only difference

--- a/internal/candidate/fitanalysis/fitanalysis_test.go
+++ b/internal/candidate/fitanalysis/fitanalysis_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -339,5 +340,103 @@ func TestEnsureReleasesItsClaimWhenTheCacheReadFails(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("the follower was never released by a leader that failed its cache read")
+	}
+}
+
+// TestRequiredAndOptional pin the two readers of one cached analysis: the tailoring surfaces
+// that cannot proceed without it, and the CV-vs-job score that can.
+func TestRequiredAndOptional(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no analysis is ErrNoAnalysis for Required, plain absence for Optional", func(t *testing.T) {
+		svc := newService(&fakeStore{}, nil)
+		if _, err := svc.Required(ctx, userID, jobID); !errors.Is(err, fitanalysis.ErrNoAnalysis) {
+			t.Errorf("Required err = %v, want ErrNoAnalysis", err)
+		}
+		if a, ok := svc.Optional(ctx, userID, jobID); ok || a != nil {
+			t.Errorf("Optional = %v/%v, want nil/false", a, ok)
+		}
+	})
+
+	t.Run("an unreadable blob reads the same as none", func(t *testing.T) {
+		// Both mean "there is nothing to ground on" — a decode failure must not become a
+		// 500 on a surface whose honest answer is "run the analysis first".
+		store := &fakeStore{row: &db.GetUserJobAnalysisRow{Analysis: []byte("{not json")}}
+		svc := newService(store, nil)
+		if _, err := svc.Required(ctx, userID, jobID); !errors.Is(err, fitanalysis.ErrNoAnalysis) {
+			t.Errorf("Required err = %v, want ErrNoAnalysis", err)
+		}
+	})
+
+	t.Run("a store failure surfaces on Required and degrades on Optional", func(t *testing.T) {
+		svc := newService(&fakeStore{readErr: errors.New("db down")}, nil)
+		if _, err := svc.Required(ctx, userID, jobID); err == nil || errors.Is(err, fitanalysis.ErrNoAnalysis) {
+			t.Errorf("Required err = %v, want the read failure itself, not ErrNoAnalysis", err)
+		}
+		if _, ok := svc.Optional(ctx, userID, jobID); ok {
+			t.Error("Optional must report no analysis when the read failed")
+		}
+	})
+
+	t.Run("a service wired to nothing degrades rather than panicking", func(t *testing.T) {
+		// Tools run inside an SSE writer's goroutine, where a panic reaches no recover.
+		var svc *fitanalysis.Service
+		if _, err := svc.Required(ctx, userID, jobID); !errors.Is(err, fitanalysis.ErrNoAnalysis) {
+			t.Errorf("Required on a nil service = %v, want ErrNoAnalysis", err)
+		}
+		if _, ok := svc.Optional(ctx, userID, jobID); ok {
+			t.Error("Optional on a nil service must report no analysis")
+		}
+	})
+
+	t.Run("a cached analysis comes back to both", func(t *testing.T) {
+		svc := newService(&fakeStore{row: cachedRow(t, 80)}, nil)
+		got, err := svc.Required(ctx, userID, jobID)
+		if err != nil || got == nil || got.OverallScore != 80 {
+			t.Fatalf("Required = %+v, %v; want the cached analysis", got, err)
+		}
+		if a, ok := svc.Optional(ctx, userID, jobID); !ok || a.OverallScore != 80 {
+			t.Errorf("Optional = %+v/%v, want the same analysis/true", a, ok)
+		}
+	})
+}
+
+// TestProjectTailoring pins the requirement split the honest wall turns on: the agent may
+// reframe a missing_have from evidence the candidate already owns, and must ASK about a
+// missing_gap. Putting one in the other's list is what would let it write an unbacked claim.
+func TestProjectTailoring(t *testing.T) {
+	a := &matchanalysis.Analysis{
+		Verdict:      "Good Fit",
+		OverallScore: 71,
+		RequirementMatch: []matchanalysis.Requirement{
+			{Text: "Kafka in production", Status: matchanalysis.StatusMissingHave},
+			{Text: "Kubernetes operator authoring", Status: matchanalysis.StatusMissingGap},
+			{Text: "Go", Status: matchanalysis.StatusCovered},
+			{Text: "Terraform", Status: matchanalysis.StatusMissingHave},
+		},
+	}
+	job := db.Job{Title: "Senior Backend", Company: "Acme", PublicSlug: "senior-backend-acme",
+		Description: "<p>We need <strong>Kafka</strong> in production.</p>"}
+
+	got := fitanalysis.ProjectTailoring(a, job)
+
+	if len(got.MissingHave) != 2 || got.MissingHave[0].Text != "Kafka in production" {
+		t.Errorf("MissingHave = %+v, want the two reframe-able requirements", got.MissingHave)
+	}
+	if len(got.MissingGap) != 1 || got.MissingGap[0].Text != "Kubernetes operator authoring" {
+		t.Errorf("MissingGap = %+v, want only the genuine gap", got.MissingGap)
+	}
+	// A covered requirement belongs in neither list: there is nothing to reframe and nothing
+	// to ask about.
+	for _, r := range append(got.MissingHave, got.MissingGap...) {
+		if r.Status == matchanalysis.StatusCovered {
+			t.Errorf("a covered requirement (%q) leaked into the split", r.Text)
+		}
+	}
+	if strings.Contains(got.Job.Description, "<p>") || strings.Contains(got.Job.Description, "<strong>") {
+		t.Errorf("the posting reaches the model as markup: %q", got.Job.Description)
+	}
+	if got.Job.Slug != "senior-backend-acme" || got.Verdict != "Good Fit" || got.OverallScore != 71 {
+		t.Errorf("projection = %+v, want the vacancy and verdict carried through", got)
 	}
 }

--- a/internal/candidate/fitanalysis/tailoring.go
+++ b/internal/candidate/fitanalysis/tailoring.go
@@ -1,0 +1,143 @@
+package fitanalysis
+
+import (
+	"context"
+	"errors"
+	"log"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/candidate/matchanalysis"
+	"github.com/strelov1/freehire/internal/platform/db"
+	"github.com/strelov1/freehire/internal/platform/htmltext"
+)
+
+// ErrNoAnalysis reports that the candidate has not run the fit analysis for this job yet, or
+// that what was stored is unreadable — which reads the same to every caller, since both mean
+// "there is nothing to ground on, offer them a run".
+//
+// It is a state, not a failure, and the two readers treat it differently on purpose: the
+// tailoring surfaces cannot proceed without an analysis and refuse (the port renders 409),
+// while the CV-vs-job score carries on and says so in the result. That is why the decision is
+// a sentinel here rather than a status invented at either call site.
+var ErrNoAnalysis = errors.New("fitanalysis: no analysis has been run for this job")
+
+// Required returns the cached analysis, or ErrNoAnalysis when the candidate has not run one.
+// For the readers that cannot do their job without it.
+//
+// A service with no store — a partially wired harness — reads as "no analysis" rather than
+// panicking, the same way Balance answers nil. A tool runs inside an SSE writer's goroutine
+// where a panic reaches no recover, so a missing collaborator has to degrade, not explode.
+func (s *Service) Required(ctx context.Context, userID, jobID int64) (*matchanalysis.Analysis, error) {
+	if s == nil || s.store == nil {
+		return nil, ErrNoAnalysis
+	}
+	analysis, _, err := s.Cached(ctx, userID, jobID)
+	if err != nil {
+		return nil, err
+	}
+	if analysis == nil {
+		return nil, ErrNoAnalysis
+	}
+	return analysis, nil
+}
+
+// Optional returns the cached analysis and whether there is one, for the readers that can
+// carry on without it.
+//
+// A failed read degrades to "none" the same way an absent one does — the caller's other
+// signals are worth more than a refusal — but is logged, because a broken database must not
+// look to us like a candidate who never ran their analysis.
+func (s *Service) Optional(ctx context.Context, userID, jobID int64) (*matchanalysis.Analysis, bool) {
+	if s == nil || s.store == nil {
+		return nil, false
+	}
+	analysis, _, err := s.Cached(ctx, userID, jobID)
+	if err != nil {
+		log.Printf("fitanalysis: cached analysis for user %d job %d: %v", userID, jobID, err)
+		return nil, false
+	}
+	return analysis, analysis != nil
+}
+
+// TailoringContext is the reasoning context a tailoring reader gets: the vacancy, the verdict
+// and recommendation, per-dimension comments, and the requirement split the honest wall turns
+// on — MissingHave (reframe existing evidence) vs MissingGap (ask the candidate first).
+//
+// One projection serves both readers — the HTTP endpoint and the agent's tool — so neither
+// can drift into showing a different shape of the same analysis.
+type TailoringContext struct {
+	Job            TailoringJob                `json:"job"`
+	Verdict        string                      `json:"verdict"`
+	OverallScore   int                         `json:"overall_score"`
+	Recommendation string                      `json:"recommendation"`
+	Dimensions     []matchanalysis.Dimension   `json:"dimensions"`
+	MissingHave    []matchanalysis.Requirement `json:"missing_have"`
+	MissingGap     []matchanalysis.Requirement `json:"missing_gap"`
+	Strengths      []string                    `json:"strengths"`
+	Gaps           []string                    `json:"gaps"`
+}
+
+// TailoringJob is the vacancy as a tailoring reader sees it.
+type TailoringJob struct {
+	Title       string `json:"title"`
+	Company     string `json:"company"`
+	Slug        string `json:"slug"`
+	Description string `json:"description"`
+}
+
+// descriptionLimit bounds the posting in a tailoring context. The posting is the largest thing
+// in the turn and the least trusted, so it is clipped as well as stripped of markup.
+const descriptionLimit = 6000
+
+// TailoringContext assembles what a tailoring reader needs: the cached analysis, projected over
+// the vacancy it is about. The job is supplied rather than read here — every caller has already
+// loaded and authorized it — so this package needs no job port of its own.
+func (s *Service) TailoringContext(ctx context.Context, userID int64, job db.Job) (TailoringContext, error) {
+	analysis, err := s.Required(ctx, userID, job.ID)
+	if err != nil {
+		return TailoringContext{}, err
+	}
+	return ProjectTailoring(analysis, job), nil
+}
+
+// ProjectTailoring splits an analysis's requirements into the reframe-able and the genuine
+// gaps and pairs them with the vacancy. Pure, so the split is unit-testable without a store.
+func ProjectTailoring(a *matchanalysis.Analysis, job db.Job) TailoringContext {
+	var have, gap []matchanalysis.Requirement
+	for _, r := range a.RequirementMatch {
+		switch r.Status {
+		case matchanalysis.StatusMissingHave:
+			have = append(have, r)
+		case matchanalysis.StatusMissingGap:
+			gap = append(gap, r)
+		}
+	}
+	return TailoringContext{
+		Job: TailoringJob{
+			Title:   job.Title,
+			Company: job.Company,
+			Slug:    job.PublicSlug,
+			// The posting reaches the model as words, bounded, the same way get_job already
+			// serves it. Sending markup spends the context window on tags and widens what
+			// there is to misread.
+			Description: clipRunes(htmltext.ToMarkdown(job.Description), descriptionLimit),
+		},
+		Verdict:        a.Verdict,
+		OverallScore:   a.OverallScore,
+		Recommendation: a.Recommendation,
+		Dimensions:     a.Dimensions,
+		MissingHave:    have,
+		MissingGap:     gap,
+		Strengths:      a.Strengths,
+		Gaps:           a.Gaps,
+	}
+}
+
+// clipRunes truncates on a rune boundary so a clip never splits a multi-byte character.
+func clipRunes(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return strings.TrimSpace(string(r[:max])) + "…"
+}


### PR DESCRIPTION
**First slice** of finding #2 from the `golang-ddd-architecture` pass. #2227 shipped the four
small fixes; #2228 gave the fit analysis its app service.

## The coupling

`assistantHandlers` holds six sibling handler structs and the tools reach through them —
sometimes for a service underneath (fine), sometimes for a method the *handler itself* owns
(not fine). The second kind means every use case the agent needs must first exist as a Fiber
handler, and a handler refactor can silently change agent behaviour with no compiler signal
that a second consumer existed.

Three of those reaches are the same thing: reading the cached fit analysis.

| Was | Now |
|---|---|
| `h.cv.tailoringContext(ctx, userID, jobID)` | `h.fit.TailoringContext(ctx, userID, job)` |
| `h.cv.cachedAnalysisOrNone(...)` | `h.fit.Optional(...)` |
| `h.cv.cachedAnalysisCtx(...)` | `h.fit.Required(...)` |
| `h.cv.jobReader.GetJob(...)` | `h.jobs.GetJob(...)` |

## What moved into `internal/candidate/fitanalysis`

- **`Required`** — `ErrNoAnalysis` when the candidate has not run one, for readers that cannot
  proceed (tailoring context, interview context, the autopilot's run plan).
- **`Optional`** — `(nil, false)`, for the CV-vs-job score, which carries on and says so in the
  result. A failed read degrades the same way but is logged: a broken database must not look
  like a candidate who never ran their analysis.
- **`TailoringContext` + `ProjectTailoring`** — the requirement split the honest wall turns on
  (`missing_have` = reframe existing evidence, `missing_gap` = ask first), so the HTTP endpoint
  and the agent's `cv_context` tool cannot drift into different shapes of one analysis.

`cachedAnalysisCtx` used to return a **`*fiber.Error` from a path with no request in it**. The
sentinel replaces it and `classify` maps it to 409 once, at the port boundary — the rule this
repo already states about translating transport codes.

## A real hazard this surfaced

`cv_context` had **no guard on its collaborators** where `interview_context` does. A partially
wired harness panicked inside the SSE writer's goroutine — where `Registry.Call`'s error path
cannot reach it and Fiber's recover is not listening, so it takes the **process** down rather
than one request. It now returns a sentence the model can act on, and the fit reads degrade on
a nil service for the same reason.

Both are mutation-checked: removing the guard makes the new test panic; restoring it passes.

## Visible in the fixtures

`cv_context` and `interview_context` tests no longer construct a `cvHandlers` at all — they hold
the service and one job reader, which is what those tools actually need.

`h.cv` survives for the CV store and editor pass-throughs. Those are later slices; this PR does
not claim to have emptied the field.

## Verification

- `gofmt -l .` clean; `go vet ./...`; `go vet -tags=integration ./...`; `go test ./...` pass
- `go test -tags=integration ./internal/api/handler/ ./internal/candidate/...` — **exit 0**
- `golangci-lint run --new-from-rev=origin/main` → 0 issues
- Two fixtures needed the collaborators moved up to match the production wiring. The failures
  they produced first (a 500 on voice-token, a missing autopilot run plan) are exactly the class
  of breakage this change is meant to make impossible to miss.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent fit-analysis support for CV tailoring, job matching, interview context, and assistant planning.
  * Improved tailoring context with categorized requirements, strengths, gaps, recommendations, and sanitized job descriptions.
  * Added clear handling when fit analysis has not been completed.

* **Bug Fixes**
  * Prevented assistant tools from failing when required services or cached analysis are unavailable.

* **Documentation**
  * Documented fit-analysis reading behavior and supported integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->