### PR TITLE
The experience bank derives provenance from who is asserting, not from the request

### DIFF
--- a/internal/api/handler/assistant_autopilot_integration_test.go
+++ b/internal/api/handler/assistant_autopilot_integration_test.go
@@ -542,7 +542,9 @@ func TestAnAutopilotRunSearchesEditsAndReports(t *testing.T) {
 		Claim:      "Ran the payments Kafka cluster through a 10x traffic year.",
 		Skills:     []string{"kafka"},
 		Provenance: experience.ProvenanceStatedInChat,
-	})
+	},
+		experience.AuthorQuoted,
+	)
 	if err != nil {
 		t.Fatalf("seed experience atom: %v", err)
 	}

--- a/internal/api/handler/assistant_cv_context_test.go
+++ b/internal/api/handler/assistant_cv_context_test.go
@@ -60,10 +60,15 @@ func (b *bankStub) ListAtoms(context.Context, int64) ([]experience.Atom, error) 
 func (b *bankStub) GetAtom(context.Context, uuid.UUID, int64) (experience.Atom, error) {
 	return experience.Atom{}, experience.ErrNotFound
 }
-func (b *bankStub) AddAtom(_ context.Context, _ int64, a experience.Atom) (experience.Atom, error) {
+
+// Both derive the label the way the real Store does, so a test that asserts on provenance is
+// asserting on the rule rather than on what it handed in.
+func (b *bankStub) AddAtom(_ context.Context, _ int64, a experience.Atom, author experience.Author) (experience.Atom, error) {
+	a.Provenance = experience.ProvenanceFor(author, "")
 	return a, nil
 }
-func (b *bankStub) UpdateAtom(_ context.Context, _ uuid.UUID, _ int64, a experience.Atom) (experience.Atom, error) {
+func (b *bankStub) UpdateAtom(_ context.Context, _ uuid.UUID, _ int64, a experience.Atom, author experience.Author) (experience.Atom, error) {
+	a.Provenance = experience.ProvenanceFor(author, a.Provenance)
 	return a, nil
 }
 func (b *bankStub) MergeAtoms(context.Context, int64, uuid.UUID, uuid.UUID) (experience.Atom, error) {

--- a/internal/api/handler/assistant_cv_evidence_fidelity_integration_test.go
+++ b/internal/api/handler/assistant_cv_evidence_fidelity_integration_test.go
@@ -42,7 +42,9 @@ func TestAutopilotRevisesAnOverstatedBulletAfterFidelityCheck(t *testing.T) {
 	atom, err := h.experience.AddAtom(ctx, userID, experience.Atom{
 		Claim:      "Listed AWS as a familiar technology",
 		Provenance: experience.ProvenanceStatedInChat,
-	})
+	},
+		experience.AuthorQuoted,
+	)
 	if err != nil {
 		t.Fatalf("seed experience atom: %v", err)
 	}

--- a/internal/api/handler/assistant_cv_gate_test.go
+++ b/internal/api/handler/assistant_cv_gate_test.go
@@ -50,21 +50,26 @@ func (b *stubBank) ListEmployments(context.Context, int64) ([]experience.Employm
 	return b.employments, nil
 }
 func (b *stubBank) ListAtoms(context.Context, int64) ([]experience.Atom, error) { return b.list, nil }
-func (b *stubBank) AddAtom(_ context.Context, userID int64, a experience.Atom) (experience.Atom, error) {
+func (b *stubBank) AddAtom(_ context.Context, userID int64, a experience.Atom, author experience.Author) (experience.Atom, error) {
 	if b.addErr != nil {
 		return experience.Atom{}, b.addErr
 	}
 	if strings.TrimSpace(a.Claim) == "" {
 		return experience.Atom{}, experience.ErrEmptyClaim
 	}
+	// Derive the label exactly as the real Store does — a fake that echoed the caller's
+	// value would let a handler test pass while the live path laundered.
+	a.Provenance = experience.ProvenanceFor(author, "")
 	stored := b.add(userID, a)
 	b.reindex()
 	return stored, nil
 }
-func (b *stubBank) UpdateAtom(_ context.Context, id uuid.UUID, userID int64, a experience.Atom) (experience.Atom, error) {
-	if _, ok := b.atoms[id]; !ok || b.owner[id] != userID {
+func (b *stubBank) UpdateAtom(_ context.Context, id uuid.UUID, userID int64, a experience.Atom, author experience.Author) (experience.Atom, error) {
+	prev, ok := b.atoms[id]
+	if !ok || b.owner[id] != userID {
 		return experience.Atom{}, experience.ErrNotFound
 	}
+	a.Provenance = experience.ProvenanceFor(author, prev.Provenance)
 	a.ID = id
 	b.atoms[id] = a
 	b.reindex()

--- a/internal/api/handler/assistant_experience_tools.go
+++ b/internal/api/handler/assistant_experience_tools.go
@@ -24,8 +24,8 @@ type experienceBankTools interface {
 	ListEmployments(ctx context.Context, userID int64) ([]experience.Employment, error)
 	ListAtoms(ctx context.Context, userID int64) ([]experience.Atom, error)
 	GetAtom(ctx context.Context, id uuid.UUID, userID int64) (experience.Atom, error)
-	AddAtom(ctx context.Context, userID int64, a experience.Atom) (experience.Atom, error)
-	UpdateAtom(ctx context.Context, id uuid.UUID, userID int64, a experience.Atom) (experience.Atom, error)
+	AddAtom(ctx context.Context, userID int64, a experience.Atom, author experience.Author) (experience.Atom, error)
+	UpdateAtom(ctx context.Context, id uuid.UUID, userID int64, a experience.Atom, author experience.Author) (experience.Atom, error)
 	MergeAtoms(ctx context.Context, userID int64, a, b uuid.UUID) (experience.Atom, error)
 }
 
@@ -317,9 +317,8 @@ func (h *assistantHandlers) experienceAddTool(sessionID uuid.UUID) assistant.Too
 				Context:      in.Context,
 				Metrics:      in.Metrics,
 				Skills:       in.Skills,
-				Provenance:   h.provenanceFor(ctx, sessionID, in.Said),
 			}
-			stored, err := h.experience.AddAtom(ctx, userID, atom)
+			stored, err := h.experience.AddAtom(ctx, userID, atom, h.authorFor(ctx, sessionID, in.Said))
 			if errors.Is(err, experience.ErrAlreadyBanked) {
 				// Not a failure: the candidate learns it is already recorded, and the
 				// model stops trying to record it again.
@@ -384,11 +383,13 @@ func (h *assistantHandlers) experienceUpdateTool(sessionID uuid.UUID) assistant.
 			if err != nil {
 				return nil, err
 			}
-			// Content the provenance is meant to vouch for is changing, so the provenance is
-			// re-derived rather than carried over from the fetch — otherwise a confirmed atom
-			// stays "confirmed" no matter how far the model edits it from what was said.
+			// Content the label is meant to vouch for is changing, so the authorship is
+			// re-derived rather than carried over — otherwise a confirmed atom stays
+			// "confirmed" no matter how far the model edits it from what was said. An edit
+			// that touches no content is a rewrite of nothing and keeps the standing it had.
+			author := experience.AuthorRewrite
 			if in.Claim != nil || in.Context != nil || in.Metrics != nil {
-				atom.Provenance = h.provenanceFor(ctx, sessionID, in.Said)
+				author = h.authorFor(ctx, sessionID, in.Said)
 			}
 			if in.Claim != nil {
 				atom.Claim = *in.Claim
@@ -410,7 +411,7 @@ func (h *assistantHandlers) experienceUpdateTool(sessionID uuid.UUID) assistant.
 				atom.EmploymentID = employmentID
 			}
 
-			stored, err := h.experience.UpdateAtom(ctx, id, userID, atom)
+			stored, err := h.experience.UpdateAtom(ctx, id, userID, atom, author)
 			if err != nil {
 				return nil, err
 			}
@@ -533,26 +534,29 @@ func (h *assistantHandlers) checkExperienceContextRequired(ctx context.Context, 
 // provenanceFor decides how an atom entered the bank, and it is the one place the honest
 // wall is actually enforced on the write side.
 //
-// The model supplies the candidate's words; the service checks them against what the
+// The model supplies the candidate's words; the entry point checks them against what the
 // candidate really said in this session. A quote that appears in their messages makes the
-// atom theirs. A quote that does not — a paraphrase, a summary, an invention — is the
-// model speaking, and is recorded as such rather than rejected: the agent needs its own
-// hypothesis on record in order to ask the candidate about it.
-func (h *assistantHandlers) provenanceFor(ctx context.Context, sessionID uuid.UUID, said string) experience.Provenance {
+// claim theirs. A quote that does not — a paraphrase, a summary, an invention — is the model
+// speaking, and is recorded as such rather than rejected: the agent needs its own hypothesis
+// on record in order to ask the candidate about it.
+//
+// This is the only place a claim's standing can go UP, and it can only because something
+// outside the model confirmed the words. The bank turns the answer into the stored label.
+func (h *assistantHandlers) authorFor(ctx context.Context, sessionID uuid.UUID, said string) experience.Author {
 	said = strings.TrimSpace(said)
 	if said == "" || h.store == nil {
-		return experience.ProvenanceAgentInferred
+		return experience.AuthorAgent
 	}
 	transcript, err := h.store.Transcript(ctx, sessionID)
 	if err != nil {
 		// Unverifiable is not verified. Failing closed costs the candidate a confirmation
 		// step; failing open would put an unchecked claim on their CV.
-		return experience.ProvenanceAgentInferred
+		return experience.AuthorAgent
 	}
 	if assistant.UserSaid(transcript, said) {
-		return experience.ProvenanceStatedInChat
+		return experience.AuthorQuoted
 	}
-	return experience.ProvenanceAgentInferred
+	return experience.AuthorAgent
 }
 
 // optionalUUID parses an id that may be absent, returning nil for an empty string.

--- a/internal/api/handler/cv_reset_integration_test.go
+++ b/internal/api/handler/cv_reset_integration_test.go
@@ -452,7 +452,9 @@ func TestResetCVFromResume_RefusesWhenTheBankSeedExceedsTheBulletCap(t *testing.
 			EmploymentID: &emp.ID,
 			Claim:        fmt.Sprintf("Banked achievement %d", i+1),
 			Provenance:   experience.ProvenanceStatedInChat,
-		}); err != nil {
+		},
+			experience.AuthorQuoted,
+		); err != nil {
 			t.Fatalf("AddAtom %d: %v", i, err)
 		}
 	}

--- a/internal/api/handler/cv_tailor_integration_test.go
+++ b/internal/api/handler/cv_tailor_integration_test.go
@@ -493,7 +493,9 @@ func TestPatchCVViaKey(t *testing.T) {
 	bank := experience.NewStore(experience.NewQueriesRepository(h.queries))
 	atom, err := bank.AddAtom(ctx, owner, experience.Atom{
 		Claim: "Cut latency", Provenance: experience.ProvenanceStatedInChat,
-	})
+	},
+		experience.AuthorQuoted,
+	)
 	if err != nil {
 		t.Fatalf("AddAtom: %v", err)
 	}

--- a/internal/api/handler/match_analysis_integration_test.go
+++ b/internal/api/handler/match_analysis_integration_test.go
@@ -92,7 +92,9 @@ func seedBankedCareer(t *testing.T, queries *db.Queries, userID int64) {
 	_, err = bank.AddAtom(ctx, userID, experience.Atom{
 		EmploymentID: &place.ID, Claim: "Built and ran the Go services behind Acme's API",
 		Skills: []string{"go"}, Provenance: experience.ProvenanceCVImport,
-	})
+	},
+		experience.AuthorCandidate,
+	)
 	if err != nil && !errors.Is(err, experience.ErrAlreadyBanked) {
 		t.Fatalf("seed atom: %v", err)
 	}

--- a/internal/api/handler/me_experience.go
+++ b/internal/api/handler/me_experience.go
@@ -38,8 +38,8 @@ type experienceBankOwner interface {
 	CreateEmployment(ctx context.Context, userID int64, e experience.Employment) (experience.Employment, error)
 	UpdateEmployment(ctx context.Context, id uuid.UUID, userID int64, e experience.Employment) (experience.Employment, error)
 	DeleteEmployment(ctx context.Context, id uuid.UUID, userID int64) error
-	AddAtom(ctx context.Context, userID int64, a experience.Atom) (experience.Atom, error)
-	UpdateAtom(ctx context.Context, id uuid.UUID, userID int64, a experience.Atom) (experience.Atom, error)
+	AddAtom(ctx context.Context, userID int64, a experience.Atom, author experience.Author) (experience.Atom, error)
+	UpdateAtom(ctx context.Context, id uuid.UUID, userID int64, a experience.Atom, author experience.Author) (experience.Atom, error)
 	DeleteAtom(ctx context.Context, id uuid.UUID, userID int64) error
 	MergeAtoms(ctx context.Context, userID int64, a, b uuid.UUID) (experience.Atom, error)
 }
@@ -251,11 +251,12 @@ func (h *experienceHandlers) AddAtom(c *fiber.Ctx) error {
 	if err := c.BodyParser(&in); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "invalid body")
 	}
-	in.Provenance = experience.ProvenanceManual
 	if err := h.checkContextRequired(c.Context(), userID, in.Context); err != nil {
 		return experienceError(err)
 	}
-	created, err := h.bank.AddAtom(c.Context(), userID, in)
+	// The door names who is asserting this; the bank derives the label. A provenance in the
+	// body is inert.
+	created, err := h.bank.AddAtom(c.Context(), userID, in, experience.AuthorCandidate)
 	if err != nil {
 		return experienceError(err)
 	}
@@ -390,15 +391,10 @@ func (h *experienceHandlers) UpdateAtom(c *fiber.Ctx) error {
 	if err := c.BodyParser(&in); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "invalid body")
 	}
-	// Read the standing of the claim before overwriting its words: a keyed caller may
-	// change what an achievement says and may not change who is held to have said it.
-	// The read also owner-scopes the write, so a foreign id is a 404 before any update.
-	existing, err := h.bank.GetAtom(c.Context(), id, userID)
-	if err != nil {
-		return experienceError(err)
-	}
-	in.Provenance = provenanceForUpdate(auth.ViaAPIKey(c), existing.Provenance)
-	updated, err := h.bank.UpdateAtom(c.Context(), id, userID, in)
+	// A keyed caller may change what an achievement says and may not change who is held to
+	// have said it — AuthorRewrite is that rule, and the bank reads the standing itself
+	// rather than trusting a label computed up here.
+	updated, err := h.bank.UpdateAtom(c.Context(), id, userID, in, updateAuthor(auth.ViaAPIKey(c)))
 	if err != nil {
 		return experienceError(err)
 	}
@@ -441,21 +437,16 @@ func (h *experienceHandlers) checkContextRequired(ctx context.Context, userID in
 //
 // A candidate editing their own entry IS asserting it — that is what `manual` records, and
 // it is why the browser path stamps every correction with it regardless of where the row
-// came from. The tailoring agent holds a key, and the same stamp on its path would let it
-// promote its own reading: bank an inference as `agent_inferred` (which the CV evidence
-// gate refuses), PUT it, read back `manual`, and cite it. So a keyed edit rewrites the
-// words and leaves the label untouched.
-//
-// An unlabelled row falls to `agent_inferred` on the keyed path rather than to the strongest
-// claim, because a missing label is not evidence that anyone said anything.
-func provenanceForUpdate(viaKey bool, existing experience.Provenance) experience.Provenance {
-	if !viaKey {
-		return experience.ProvenanceManual
+// came from. The tailoring agent holds a key, and stamping its path would let it promote its
+// own reading: bank an inference as `agent_inferred` (which the CV evidence gate refuses),
+// PUT it, read back `manual`, and cite it. So a keyed edit rewrites the words and leaves the
+// label untouched, which is what AuthorRewrite means; the cookie path is the person, so it is
+// AuthorCandidate.
+func updateAuthor(viaKey bool) experience.Author {
+	if viaKey {
+		return experience.AuthorRewrite
 	}
-	if !existing.Valid() {
-		return experience.ProvenanceAgentInferred
-	}
-	return existing
+	return experience.AuthorCandidate
 }
 
 func ownedEntry(c *fiber.Ctx) (int64, uuid.UUID, error) {

--- a/internal/api/handler/me_experience_routes_test.go
+++ b/internal/api/handler/me_experience_routes_test.go
@@ -27,29 +27,17 @@ import (
 //
 // So the label follows the credential. A keyed correction may fix the words and must leave
 // the standing of the claim exactly where it was.
-func TestProvenanceForUpdate(t *testing.T) {
-	for _, tc := range []struct {
-		name     string
-		viaKey   bool
-		existing experience.Provenance
-		want     experience.Provenance
-	}{
-		{"candidate confirms their own inferred atom", false, experience.ProvenanceAgentInferred, experience.ProvenanceManual},
-		{"candidate corrects an imported one", false, experience.ProvenanceCVImport, experience.ProvenanceManual},
-		{"agent may not promote its own reading", true, experience.ProvenanceAgentInferred, experience.ProvenanceAgentInferred},
-		{"agent corrects what the candidate said", true, experience.ProvenanceStatedInChat, experience.ProvenanceStatedInChat},
-		{"agent corrects a manual atom", true, experience.ProvenanceManual, experience.ProvenanceManual},
-		// A row whose label is somehow unset must not become publishable by being edited
-		// with a key. Falling back to the strongest claim would be the same laundering.
-		{"agent editing an unlabelled row", true, "", experience.ProvenanceAgentInferred},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := provenanceForUpdate(tc.viaKey, tc.existing); got != tc.want {
-				t.Errorf("provenanceForUpdate(%v, %q) = %q, want %q", tc.viaKey, tc.existing, got, tc.want)
-			}
-		})
+func TestUpdateAuthor(t *testing.T) {
+	if got := updateAuthor(false); got != experience.AuthorCandidate {
+		t.Errorf("cookie PUT author = %q, want AuthorCandidate — the person is editing their own bank", got)
+	}
+	if got := updateAuthor(true); got != experience.AuthorRewrite {
+		t.Errorf("keyed PUT author = %q, want AuthorRewrite — a keyed edit rewrites words and may not relabel", got)
 	}
 }
+
+// What each authorship then MEANS is experience.provenanceFor's, tested next to the rule in
+// TestProvenanceFor — including the laundering route this door exists to close.
 
 // TestExperienceRegister_Gates pins each route's gate against the real register().
 //

--- a/internal/candidate/experience/AGENTS.md
+++ b/internal/candidate/experience/AGENTS.md
@@ -10,6 +10,25 @@ is one piece of evidence at the grain of a CV bullet.
   replaced: `resume_structured` is regenerated on each upload, a tailored CV is thrown away
   with its vacancy. The bank accumulates, and **only its owner removes anything** — import
   never deletes, and there is no reconciler that prunes.
+- **The label is DERIVED from the Author, never taken from the caller's value.** `Store.AddAtom`
+  and `UpdateAtom` take an `Author` — who is asserting the claim, decided by the entry point
+  that received the request — and overwrite `Atom.Provenance` from it. A body-supplied
+  provenance is inert. Same rule and same reason as `cvedit.Actor`: a caller naming itself is
+  not evidence of who it is.
+
+  | Author | Label | Who passes it |
+  |---|---|---|
+  | `AuthorCandidate` | `manual` | the person, from their own session (cookie POST/PUT) |
+  | `AuthorQuoted` | `stated_in_chat` | the assistant, after checking the words against the session transcript — **the only authorship that can raise standing** |
+  | `AuthorAgent` | `agent_inferred` | a model's own reading, asserted now |
+  | `AuthorRewrite` | keeps the stored label | a keyed edit: rewriting words is not re-asserting them. An absent or corrupt label falls to `agent_inferred` |
+
+  Anything unrecognised — a new entry point that forgets to name itself — lands on
+  `agent_inferred`, which the CV evidence gate refuses. Failing closed is the point.
+
+  This closes the laundering route the cookie-only gate used to guard by routing alone: bank an
+  inference as `agent_inferred`, edit it, read back `manual`, cite it in a CV.
+
 - **Provenance decides publication, and the check is in the service.** `cv_import`,
   `stated_in_chat` and `manual` are the candidate speaking and may reach a CV;
   `agent_inferred` is the model speaking and may not, until the candidate confirms it and

--- a/internal/candidate/experience/author.go
+++ b/internal/candidate/experience/author.go
@@ -1,0 +1,68 @@
+package experience
+
+// Author is who is asserting a banked claim. It is decided by the ENTRY POINT that received
+// the request and is never read from the request body — a caller naming itself is not evidence
+// of who it is. Same rule, and the same reason, as cvedit.Actor.
+//
+// This is the wall the CV evidence gate stands on. Only a claim the CANDIDATE asserted may be
+// written into their CV (Provenance.Publishable); a model's own reading is banked, searchable,
+// and refused there. Until this type existed the rule lived in three functions in the HTTP
+// layer, so any new writer — a cmd worker, the CLI, a fourth assistant tool, a mobile endpoint
+// — could hand the store ProvenanceManual on model-authored text and have it come back
+// CV-publishable. The store now derives the label and ignores whatever is in the struct.
+type Author string
+
+const (
+	// AuthorCandidate is the person themselves, editing their own bank from an authenticated
+	// session with no chat behind it. The only honest reading of a typed-in achievement is
+	// that the owner typed it.
+	AuthorCandidate Author = "candidate"
+
+	// AuthorQuoted is the person's own words, verified by the entry point against what they
+	// actually said — the assistant checks the claim against the session transcript. This is
+	// the ONLY authorship that can raise a claim's standing, and it can do so only because
+	// something outside the model confirmed the words.
+	AuthorQuoted Author = "quoted"
+
+	// AuthorAgent is a model's own reading, asserted now: a paraphrase, a summary, an
+	// inference. Recorded rather than refused, because the agent needs its hypothesis on
+	// record in order to ask the candidate about it — and refused by the CV evidence gate.
+	AuthorAgent Author = "agent"
+
+	// AuthorRewrite is an edit that changes wording WITHOUT re-asserting it: a keyed caller
+	// rewriting an achievement with no transcript to check the new words against. It keeps
+	// whatever the claim was already labelled, because rewriting words is not the same act as
+	// claiming them, and a keyed caller must not be able to relabel.
+	//
+	// It is what stops the laundering route: bank an inference as agent_inferred, edit it,
+	// read back manual, cite it in a CV. An absent or unreadable label falls to
+	// agent_inferred — a missing label is not evidence that anyone said anything.
+	AuthorRewrite Author = "rewrite"
+)
+
+// ProvenanceFor derives the label a write records from who is asserting it. existing is the
+// label already stored, consulted only by AuthorRewrite; pass the zero value when there is
+// none (an insert).
+//
+// Exported so a test double can behave like the real store rather than echoing back whatever
+// it was handed — a fake that skipped this rule would let a handler test pass while the live
+// path laundered. It is a derivation, not a door: Store still ignores Atom.Provenance on
+// write, so knowing the rule buys a caller nothing.
+func ProvenanceFor(author Author, existing Provenance) Provenance {
+	switch author {
+	case AuthorCandidate:
+		return ProvenanceManual
+	case AuthorQuoted:
+		return ProvenanceStatedInChat
+	case AuthorRewrite:
+		if existing.Valid() {
+			return existing
+		}
+		return ProvenanceAgentInferred
+	default:
+		// Every unrecognised authorship reads as the model speaking. A new entry point that
+		// forgets to name itself must land on the label the evidence gate refuses, never on
+		// one it accepts.
+		return ProvenanceAgentInferred
+	}
+}

--- a/internal/candidate/experience/author_test.go
+++ b/internal/candidate/experience/author_test.go
@@ -1,0 +1,69 @@
+package experience
+
+import "testing"
+
+// TestProvenanceFor is the anti-laundering rule, and it is the reason Author exists.
+//
+// The CV evidence gate admits only a claim the CANDIDATE asserted. If an edit could raise a
+// claim's standing, the route is trivial: an agent banks its own reading as agent_inferred
+// (which the gate refuses), edits it, reads back manual, and cites it — a model's invention on
+// a real person's CV. So the label follows who is asserting, and only a verified quote can
+// raise it.
+func TestProvenanceFor(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		author   Author
+		existing Provenance
+		want     Provenance
+	}{
+		{"the person typed it", AuthorCandidate, "", ProvenanceManual},
+		{"the person confirms their own inferred claim", AuthorCandidate, ProvenanceAgentInferred, ProvenanceManual},
+		{"the person corrects an imported one", AuthorCandidate, ProvenanceCVImport, ProvenanceManual},
+
+		// The only way standing goes UP, and only because something outside the model — the
+		// session transcript — confirmed the words.
+		{"words verified against what they said", AuthorQuoted, "", ProvenanceStatedInChat},
+		{"a verified quote overrides a weaker label", AuthorQuoted, ProvenanceAgentInferred, ProvenanceStatedInChat},
+
+		{"a model's own reading", AuthorAgent, "", ProvenanceAgentInferred},
+		// An agent asserting afresh cannot keep a stronger label it did not earn: editing a
+		// confirmed claim into a paraphrase makes it the model's again.
+		{"a model re-asserting a confirmed claim downgrades it", AuthorAgent, ProvenanceStatedInChat, ProvenanceAgentInferred},
+
+		{"a keyed rewrite may not promote a model's reading", AuthorRewrite, ProvenanceAgentInferred, ProvenanceAgentInferred},
+		{"a keyed rewrite keeps what the candidate said", AuthorRewrite, ProvenanceStatedInChat, ProvenanceStatedInChat},
+		{"a keyed rewrite keeps a manual claim manual", AuthorRewrite, ProvenanceManual, ProvenanceManual},
+		// A row whose label is somehow unset must not become publishable by being edited.
+		// Falling back to the strongest claim would be the same laundering.
+		{"a keyed rewrite of an unlabelled row", AuthorRewrite, "", ProvenanceAgentInferred},
+		{"a keyed rewrite of a corrupt label", AuthorRewrite, Provenance("vibes"), ProvenanceAgentInferred},
+
+		// A new entry point that forgets to name itself must land where the gate refuses.
+		{"an unnamed authorship", Author("cli"), ProvenanceManual, ProvenanceAgentInferred},
+		{"the zero authorship", "", ProvenanceManual, ProvenanceAgentInferred},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ProvenanceFor(tc.author, tc.existing); got != tc.want {
+				t.Errorf("ProvenanceFor(%q, %q) = %q, want %q", tc.author, tc.existing, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestOnlyQuotedIsPublishableFromAnAgentPath states the invariant the table above serves, so a
+// future value added to Author cannot quietly become CV-publishable: of everything an AGENT
+// can produce, nothing the model authored itself may reach a CV.
+func TestOnlyVerifiedAgentWritesArePublishable(t *testing.T) {
+	if ProvenanceFor(AuthorAgent, "").Publishable() {
+		t.Error("a model's own reading became CV-publishable — this is the wall")
+	}
+	if ProvenanceFor(AuthorRewrite, "").Publishable() {
+		t.Error("an unlabelled row became publishable by being rewritten")
+	}
+	if !ProvenanceFor(AuthorQuoted, "").Publishable() {
+		t.Error("a verified quote must be publishable, or the candidate cannot use their own words")
+	}
+	if !ProvenanceFor(AuthorCandidate, "").Publishable() {
+		t.Error("what the person typed themselves must be publishable")
+	}
+}

--- a/internal/candidate/experience/experience.go
+++ b/internal/candidate/experience/experience.go
@@ -132,8 +132,11 @@ type Atom struct {
 	Context      string     `json:"context,omitempty"`
 	Metrics      []string   `json:"metrics,omitempty"`
 	Skills       []string   `json:"skills,omitempty"`
-	Provenance   Provenance `json:"provenance"`
-	SourceRef    string     `json:"source_ref,omitempty"`
+	// Provenance is READ-ONLY on a write. Store derives it from the Author the entry point
+	// names, and ignores whatever is here — see Author for the laundering route that closes.
+	// It is serialised because every reader needs to see the standing of a claim.
+	Provenance Provenance `json:"provenance"`
+	SourceRef  string     `json:"source_ref,omitempty"`
 }
 
 // Sanitize bounds every string and caps every array. Skills are canonicalized through

--- a/internal/candidate/experience/period_sort_test.go
+++ b/internal/candidate/experience/period_sort_test.go
@@ -144,7 +144,9 @@ func TestWorkHistory_PlacelessTrailsChronologicalRoles(t *testing.T) {
 	}
 	if _, err := s.AddAtom(ctx, owner, Atom{
 		Claim: "Certified cloud architect", Provenance: ProvenanceStatedInChat,
-	}); err != nil {
+	},
+		AuthorQuoted,
+	); err != nil {
 		t.Fatalf("AddAtom placeless: %v", err)
 	}
 	hist, err := s.WorkHistory(ctx, owner)

--- a/internal/candidate/experience/professional_test.go
+++ b/internal/candidate/experience/professional_test.go
@@ -49,11 +49,27 @@ func seedBank(t *testing.T, employments []Employment, atoms []Atom, placeOf []in
 		if place := placeOf[i]; place >= 0 {
 			a.EmploymentID = &ids[place]
 		}
-		if _, err := s.AddAtom(ctx, owner, a); err != nil {
+		// The seed states each atom's authorship, since the bank derives the label from it:
+		// a fixture that banked everything as the candidate could not express the
+		// unpublishable rows these tests exist to check.
+		if _, err := s.AddAtom(ctx, owner, a, authorOf(a.Provenance)); err != nil {
 			t.Fatalf("AddAtom: %v", err)
 		}
 	}
 	return s
+}
+
+// authorOf names the entry point that would have produced a given label, so a fixture can
+// still seed the full range of standings now that the bank derives them.
+func authorOf(p Provenance) Author {
+	switch p {
+	case ProvenanceStatedInChat:
+		return AuthorQuoted
+	case ProvenanceAgentInferred:
+		return AuthorAgent
+	default:
+		return AuthorCandidate
+	}
 }
 
 // professionalOf is the assertion subject of every test below: the live path the fit chain and
@@ -227,7 +243,9 @@ func TestStoreProfessional(t *testing.T) {
 	}
 	if _, err := s.AddAtom(ctx, owner, Atom{
 		EmploymentID: &role.ID, Claim: "Cut latency", Provenance: ProvenanceCVImport,
-	}); err != nil {
+	},
+		AuthorCandidate,
+	); err != nil {
 		t.Fatalf("AddAtom: %v", err)
 	}
 

--- a/internal/candidate/experience/retrieve_test.go
+++ b/internal/candidate/experience/retrieve_test.go
@@ -114,7 +114,7 @@ func TestRetrieveReturnsRankedMatchesWithinTheLimit(t *testing.T) {
 		{EmploymentID: &role.ID, Claim: "Cut message-posting latency 20s to 1s", Provenance: ProvenanceCVImport},
 		{Claim: "Wrote the onboarding handbook", Provenance: ProvenanceManual},
 	} {
-		if _, err := s.AddAtom(ctx, owner, a); err != nil {
+		if _, err := s.AddAtom(ctx, owner, a, AuthorCandidate); err != nil {
 			t.Fatalf("AddAtom: %v", err)
 		}
 	}
@@ -140,7 +140,7 @@ func TestRetrieveReturnsNothingWhenNothingMatches(t *testing.T) {
 	s, _ := newStore()
 	ctx := context.Background()
 
-	if _, err := s.AddAtom(ctx, owner, Atom{Claim: "Wrote the onboarding handbook", Provenance: ProvenanceManual}); err != nil {
+	if _, err := s.AddAtom(ctx, owner, Atom{Claim: "Wrote the onboarding handbook", Provenance: ProvenanceManual}, AuthorCandidate); err != nil {
 		t.Fatalf("AddAtom: %v", err)
 	}
 
@@ -157,7 +157,7 @@ func TestRetrieveIsOwnerScoped(t *testing.T) {
 	s, _ := newStore()
 	ctx := context.Background()
 
-	if _, err := s.AddAtom(ctx, owner, Atom{Claim: "Ran the cluster", Skills: []string{"kubernetes"}, Provenance: ProvenanceManual}); err != nil {
+	if _, err := s.AddAtom(ctx, owner, Atom{Claim: "Ran the cluster", Skills: []string{"kubernetes"}, Provenance: ProvenanceManual}, AuthorCandidate); err != nil {
 		t.Fatalf("AddAtom: %v", err)
 	}
 	matches, err := s.Retrieve(ctx, stranger, Query{Skills: []string{"kubernetes"}}, 5)

--- a/internal/candidate/experience/store.go
+++ b/internal/candidate/experience/store.go
@@ -221,7 +221,11 @@ func (s *Store) GetAtom(ctx context.Context, id uuid.UUID, userID int64) (Atom, 
 // recorded — under any spelling — comes back as ErrAlreadyBanked rather than a second
 // row: the unique index on (user_id, claim_key) swallows the insert, and the absent row
 // is the signal.
-func (s *Store) AddAtom(ctx context.Context, userID int64, a Atom) (Atom, error) {
+func (s *Store) AddAtom(ctx context.Context, userID int64, a Atom, author Author) (Atom, error) {
+	// The label is DERIVED from who is asserting the claim, never taken from the value the
+	// caller built. See Author: this is the wall the CV evidence gate stands on, and a
+	// struct field a caller can fill in is not a wall.
+	a.Provenance = ProvenanceFor(author, "")
 	a.Sanitize()
 	if err := a.Validate(); err != nil {
 		return Atom{}, err
@@ -251,7 +255,20 @@ func (s *Store) insertAtom(ctx context.Context, userID int64, a Atom) (Atom, err
 
 // UpdateAtom replaces an owned atom's content. The claim key moves with the claim, so
 // the uniqueness guarantee holds after an edit as well as after an insert.
-func (s *Store) UpdateAtom(ctx context.Context, id uuid.UUID, userID int64, a Atom) (Atom, error) {
+func (s *Store) UpdateAtom(ctx context.Context, id uuid.UUID, userID int64, a Atom, author Author) (Atom, error) {
+	// AuthorRewrite keeps the standing the claim already had, so the stored label has to be
+	// read before the words are overwritten. Read here rather than trusted from the caller:
+	// a rule that depends on an argument the caller computes is a rule the caller can skip.
+	var existing Provenance
+	if author == AuthorRewrite {
+		stored, err := s.GetAtom(ctx, id, userID)
+		if err != nil {
+			return Atom{}, err
+		}
+		existing = stored.Provenance
+	}
+	a.Provenance = ProvenanceFor(author, existing)
+
 	a.Sanitize()
 	if err := a.Validate(); err != nil {
 		return Atom{}, err

--- a/internal/candidate/experience/store_integration_test.go
+++ b/internal/candidate/experience/store_integration_test.go
@@ -72,7 +72,9 @@ func TestStoreAddAtom_SyncsSkillsIntoAnExistingProfile(t *testing.T) {
 		Claim:      "Migrated the cluster to Kubernetes",
 		Skills:     []string{"k8s"},
 		Provenance: ProvenanceManual,
-	}); err != nil {
+	},
+		AuthorCandidate,
+	); err != nil {
 		t.Fatalf("AddAtom: %v", err)
 	}
 
@@ -108,7 +110,9 @@ func TestStoreAddAtom_LeavesNoProfileBehindForAUserWithNone(t *testing.T) {
 		Claim:      "Migrated the cluster to Kubernetes",
 		Skills:     []string{"k8s"},
 		Provenance: ProvenanceManual,
-	}); err != nil {
+	},
+		AuthorCandidate,
+	); err != nil {
 		t.Fatalf("AddAtom: %v", err)
 	}
 

--- a/internal/candidate/experience/store_test.go
+++ b/internal/candidate/experience/store_test.go
@@ -250,7 +250,9 @@ func TestStoreAddAtomSyncsSkillsToProfile(t *testing.T) {
 
 	if _, err := s.AddAtom(context.Background(), owner, Atom{
 		Claim: "Cut latency", Skills: []string{"k8s"}, Provenance: ProvenanceManual,
-	}); err != nil {
+	},
+		AuthorCandidate,
+	); err != nil {
 		t.Fatalf("AddAtom: %v", err)
 	}
 	if len(profile.calls) != 1 {
@@ -266,7 +268,7 @@ func TestStoreAddAtomSyncsSkillsToProfile(t *testing.T) {
 
 func TestStoreUpdateAtomSyncsSkillsToProfile(t *testing.T) {
 	s, _ := newStore()
-	atom, err := s.AddAtom(context.Background(), owner, Atom{Claim: "Cut latency", Provenance: ProvenanceManual})
+	atom, err := s.AddAtom(context.Background(), owner, Atom{Claim: "Cut latency", Provenance: ProvenanceManual}, AuthorCandidate)
 	if err != nil {
 		t.Fatalf("AddAtom: %v", err)
 	}
@@ -275,7 +277,9 @@ func TestStoreUpdateAtomSyncsSkillsToProfile(t *testing.T) {
 	s.SetProfileSkills(profile)
 	if _, err := s.UpdateAtom(context.Background(), atom.ID, owner, Atom{
 		Claim: "Cut latency further", Skills: []string{"golang"}, Provenance: ProvenanceManual,
-	}); err != nil {
+	},
+		AuthorCandidate,
+	); err != nil {
 		t.Fatalf("UpdateAtom: %v", err)
 	}
 	if len(profile.calls) != 1 {
@@ -292,7 +296,9 @@ func TestStoreAddAtomToleratesProfileSyncFailure(t *testing.T) {
 
 	got, err := s.AddAtom(context.Background(), owner, Atom{
 		Claim: "Cut latency", Skills: []string{"k8s"}, Provenance: ProvenanceManual,
-	})
+	},
+		AuthorCandidate,
+	)
 	if err != nil {
 		t.Fatalf("AddAtom: %v, want the atom write to succeed despite the sync failure", err)
 	}
@@ -306,7 +312,9 @@ func TestStoreAddAtomWithoutProfileSkillsDependency(t *testing.T) {
 
 	if _, err := s.AddAtom(context.Background(), owner, Atom{
 		Claim: "Cut latency", Skills: []string{"k8s"}, Provenance: ProvenanceManual,
-	}); err != nil {
+	},
+		AuthorCandidate,
+	); err != nil {
 		t.Fatalf("AddAtom: %v, want it to work with no ProfileSkills dependency set", err)
 	}
 }
@@ -319,7 +327,9 @@ func TestStoreAddAtomSanitizesAndStamps(t *testing.T) {
 		Skills:     []string{"k8s", "blorptech"},
 		Metrics:    []string{"20s -> 1s", "  "},
 		Provenance: ProvenanceStatedInChat,
-	})
+	},
+		AuthorQuoted,
+	)
 	if err != nil {
 		t.Fatalf("AddAtom: %v", err)
 	}
@@ -340,11 +350,38 @@ func TestStoreAddAtomSanitizesAndStamps(t *testing.T) {
 func TestStoreAddAtomRejectsInvalid(t *testing.T) {
 	s, _ := newStore()
 
-	if _, err := s.AddAtom(context.Background(), owner, Atom{Claim: "   ", Provenance: ProvenanceManual}); !errors.Is(err, ErrEmptyClaim) {
+	if _, err := s.AddAtom(context.Background(), owner, Atom{Claim: "   ", Provenance: ProvenanceManual}, AuthorCandidate); !errors.Is(err, ErrEmptyClaim) {
 		t.Errorf("AddAtom(no claim) = %v, want ErrEmptyClaim", err)
 	}
-	if _, err := s.AddAtom(context.Background(), owner, Atom{Claim: "Did a thing", Provenance: "vibes"}); !errors.Is(err, ErrInvalidProvenance) {
-		t.Errorf("AddAtom(bad provenance) = %v, want ErrInvalidProvenance", err)
+}
+
+// TestAddAtomIgnoresABodySuppliedProvenance is the wall Author was introduced for. A caller
+// that fills the field in — a mis-wired handler, a cmd worker, the CLI, a future assistant
+// tool — must not be able to name a model's invention as something the candidate asserted, and
+// so make it CV-publishable through the evidence gate.
+func TestAddAtomIgnoresABodySuppliedProvenance(t *testing.T) {
+	s, _ := newStore()
+
+	got, err := s.AddAtom(context.Background(), owner,
+		Atom{Claim: "Rebuilt the billing pipeline", Provenance: ProvenanceManual}, AuthorAgent)
+	if err != nil {
+		t.Fatalf("AddAtom: %v", err)
+	}
+	if got.Provenance != ProvenanceAgentInferred {
+		t.Errorf("Provenance = %q, want agent_inferred — the author decides, not the struct", got.Provenance)
+	}
+	if got.Provenance.Publishable() {
+		t.Error("a model's own reading came back CV-publishable because the caller asked for it")
+	}
+
+	// The nonsense a caller could previously smuggle in is now simply inert.
+	got, err = s.AddAtom(context.Background(), owner,
+		Atom{Claim: "Ran the migration", Provenance: "vibes"}, AuthorCandidate)
+	if err != nil {
+		t.Fatalf("AddAtom with a junk provenance: %v", err)
+	}
+	if got.Provenance != ProvenanceManual {
+		t.Errorf("Provenance = %q, want manual", got.Provenance)
 	}
 }
 
@@ -355,10 +392,10 @@ func TestStoreAddAtomReportsAnAlreadyBankedClaim(t *testing.T) {
 	s, _ := newStore()
 	ctx := context.Background()
 
-	if _, err := s.AddAtom(ctx, owner, Atom{Claim: "Cut latency 20s to 1s", Provenance: ProvenanceCVImport}); err != nil {
+	if _, err := s.AddAtom(ctx, owner, Atom{Claim: "Cut latency 20s to 1s", Provenance: ProvenanceCVImport}, AuthorCandidate); err != nil {
 		t.Fatalf("first AddAtom: %v", err)
 	}
-	_, err := s.AddAtom(ctx, owner, Atom{Claim: "cut  latency 20s to 1s.", Provenance: ProvenanceStatedInChat})
+	_, err := s.AddAtom(ctx, owner, Atom{Claim: "cut  latency 20s to 1s.", Provenance: ProvenanceStatedInChat}, AuthorQuoted)
 	if !errors.Is(err, ErrAlreadyBanked) {
 		t.Errorf("second AddAtom = %v, want ErrAlreadyBanked", err)
 	}
@@ -369,10 +406,10 @@ func TestStoreAddAtomIsScopedPerOwner(t *testing.T) {
 	s, _ := newStore()
 	ctx := context.Background()
 
-	if _, err := s.AddAtom(ctx, owner, Atom{Claim: "Led the migration", Provenance: ProvenanceManual}); err != nil {
+	if _, err := s.AddAtom(ctx, owner, Atom{Claim: "Led the migration", Provenance: ProvenanceManual}, AuthorCandidate); err != nil {
 		t.Fatalf("owner AddAtom: %v", err)
 	}
-	if _, err := s.AddAtom(ctx, stranger, Atom{Claim: "Led the migration", Provenance: ProvenanceManual}); err != nil {
+	if _, err := s.AddAtom(ctx, stranger, Atom{Claim: "Led the migration", Provenance: ProvenanceManual}, AuthorCandidate); err != nil {
 		t.Errorf("stranger AddAtom = %v, want success — the claim key is owner-scoped", err)
 	}
 }
@@ -381,7 +418,7 @@ func TestStoreOwnershipIsAbsence(t *testing.T) {
 	s, _ := newStore()
 	ctx := context.Background()
 
-	atom, err := s.AddAtom(ctx, owner, Atom{Claim: "Cut latency", Provenance: ProvenanceManual})
+	atom, err := s.AddAtom(ctx, owner, Atom{Claim: "Cut latency", Provenance: ProvenanceManual}, AuthorCandidate)
 	if err != nil {
 		t.Fatalf("AddAtom: %v", err)
 	}
@@ -401,7 +438,7 @@ func TestStoreDeleteAtomIsTheOnlyRemoval(t *testing.T) {
 	s, _ := newStore()
 	ctx := context.Background()
 
-	atom, err := s.AddAtom(ctx, owner, Atom{Claim: "Cut latency", Provenance: ProvenanceManual})
+	atom, err := s.AddAtom(ctx, owner, Atom{Claim: "Cut latency", Provenance: ProvenanceManual}, AuthorCandidate)
 	if err != nil {
 		t.Fatalf("AddAtom: %v", err)
 	}
@@ -454,7 +491,9 @@ func TestStoreDeleteEmploymentTakesItsAtoms(t *testing.T) {
 	}
 	if _, err := s.AddAtom(ctx, owner, Atom{
 		EmploymentID: &job.ID, Claim: "Cut latency", Provenance: ProvenanceManual,
-	}); err != nil {
+	},
+		AuthorCandidate,
+	); err != nil {
 		t.Fatalf("AddAtom: %v", err)
 	}
 
@@ -487,17 +526,19 @@ func TestStoreAtomCannotAttachToAnotherOwnersEmployment(t *testing.T) {
 
 	_, err = s.AddAtom(ctx, owner, Atom{
 		EmploymentID: &theirs.ID, Claim: "Cut latency", Provenance: ProvenanceManual,
-	})
+	},
+		AuthorCandidate,
+	)
 	if !errors.Is(err, ErrNotFound) {
 		t.Errorf("AddAtom with a foreign employment = %v, want ErrNotFound", err)
 	}
 
-	mine, err := s.AddAtom(ctx, owner, Atom{Claim: "Cut latency", Provenance: ProvenanceManual})
+	mine, err := s.AddAtom(ctx, owner, Atom{Claim: "Cut latency", Provenance: ProvenanceManual}, AuthorCandidate)
 	if err != nil {
 		t.Fatalf("AddAtom: %v", err)
 	}
 	mine.EmploymentID = &theirs.ID
-	if _, err := s.UpdateAtom(ctx, mine.ID, owner, mine); !errors.Is(err, ErrNotFound) {
+	if _, err := s.UpdateAtom(ctx, mine.ID, owner, mine, AuthorCandidate); !errors.Is(err, ErrNotFound) {
 		t.Errorf("UpdateAtom onto a foreign employment = %v, want ErrNotFound", err)
 	}
 
@@ -505,7 +546,9 @@ func TestStoreAtomCannotAttachToAnotherOwnersEmployment(t *testing.T) {
 	ghost := uuid.New()
 	if _, err := s.AddAtom(ctx, owner, Atom{
 		EmploymentID: &ghost, Claim: "Ran the cluster", Provenance: ProvenanceManual,
-	}); !errors.Is(err, ErrNotFound) {
+	},
+		AuthorCandidate,
+	); !errors.Is(err, ErrNotFound) {
 		t.Errorf("AddAtom with an unknown employment = %v, want ErrNotFound", err)
 	}
 }
@@ -519,7 +562,9 @@ func TestStorePromoteUnplacedAtomToProject(t *testing.T) {
 	atom, err := s.AddAtom(ctx, owner, Atom{
 		Claim:      "Reverse-engineered game data for a Portuguese localization mod",
 		Provenance: ProvenanceStatedInChat,
-	})
+	},
+		AuthorQuoted,
+	)
 	if err != nil {
 		t.Fatalf("AddAtom: %v", err)
 	}
@@ -532,7 +577,7 @@ func TestStorePromoteUnplacedAtomToProject(t *testing.T) {
 	}
 
 	atom.EmploymentID = &project.ID
-	if _, err := s.UpdateAtom(ctx, atom.ID, owner, atom); err != nil {
+	if _, err := s.UpdateAtom(ctx, atom.ID, owner, atom, AuthorCandidate); err != nil {
 		t.Fatalf("UpdateAtom attach: %v", err)
 	}
 
@@ -563,7 +608,9 @@ func TestStoreMergeAtomsUnionsAndDeletesLoser(t *testing.T) {
 	a, err := s.AddAtom(ctx, owner, Atom{
 		Claim:  "Built a Chromium plugin with faster-whisper for live and batch",
 		Skills: []string{"python"}, Provenance: ProvenanceAgentInferred,
-	})
+	},
+		AuthorAgent,
+	)
 	if err != nil {
 		t.Fatalf("AddAtom a: %v", err)
 	}
@@ -571,7 +618,9 @@ func TestStoreMergeAtomsUnionsAndDeletesLoser(t *testing.T) {
 		Claim:   "Built a Chromium plugin with VAD filtering on faster-whisper",
 		Context: "small/medium/large-v3 model profiles", Metrics: []string{"VAD"},
 		Skills: []string{"nlp"}, Provenance: ProvenanceAgentInferred,
-	})
+	},
+		AuthorAgent,
+	)
 	if err != nil {
 		t.Fatalf("AddAtom b: %v", err)
 	}
@@ -627,11 +676,11 @@ func TestStoreMergeAtomsRejectsAConcurrentWriteInTheReadWriteGap(t *testing.T) {
 	s, repo := newStore()
 	ctx := context.Background()
 
-	a, err := s.AddAtom(ctx, owner, Atom{Claim: "Did the thing", Provenance: ProvenanceManual})
+	a, err := s.AddAtom(ctx, owner, Atom{Claim: "Did the thing", Provenance: ProvenanceManual}, AuthorCandidate)
 	if err != nil {
 		t.Fatalf("AddAtom a: %v", err)
 	}
-	b, err := s.AddAtom(ctx, owner, Atom{Claim: "Did the other thing", Provenance: ProvenanceManual})
+	b, err := s.AddAtom(ctx, owner, Atom{Claim: "Did the other thing", Provenance: ProvenanceManual}, AuthorCandidate)
 	if err != nil {
 		t.Fatalf("AddAtom b: %v", err)
 	}
@@ -670,13 +719,17 @@ func TestStoreMergeAtomsNotFoundAndCrossEmployment(t *testing.T) {
 	}
 	a, err := s.AddAtom(ctx, owner, Atom{
 		EmploymentID: &roleA.ID, Claim: "Did the thing at A", Provenance: ProvenanceManual,
-	})
+	},
+		AuthorCandidate,
+	)
 	if err != nil {
 		t.Fatalf("AddAtom a: %v", err)
 	}
 	b, err := s.AddAtom(ctx, owner, Atom{
 		EmploymentID: &roleB.ID, Claim: "Did the thing at B", Provenance: ProvenanceManual,
-	})
+	},
+		AuthorCandidate,
+	)
 	if err != nil {
 		t.Fatalf("AddAtom b: %v", err)
 	}


### PR DESCRIPTION
`CLAUDE.md` says the provenance check lives in the service path, not in a system prompt.
**It did not.**

## The hole

The rule lived in three functions in `internal/api/handler`:

- `POST /me/experience/atoms` forced `manual`
- `PUT …/:id` chose by credential (`provenanceForUpdate`)
- the assistant chose by transcript (`provenanceFor`)

…and `Store.AddAtom` took whatever `Provenance` the caller had put in the struct.

So any writer that is not one of those three could hand the bank `ProvenanceManual` on
model-authored text and get it back **CV-publishable through the evidence gate**: a `cmd`
worker, the CLI, a fourth assistant tool, a mobile endpoint. Nothing in `internal/candidate`
could catch it, and no test failed.

The cookie-only gate on bank mutations was guarding this **by routing alone**. That was a
deliberate wall, but a wall made of route registration.

## The fix

`experience.Author` is now the argument; the store derives the label from it and **ignores the
struct field**. Same shape and same reason as `cvedit.Actor`: it is decided by the entry point
that received the request, because a caller naming itself is not evidence of who it is.

| Author | Label | Who passes it |
|---|---|---|
| `AuthorCandidate` | `manual` | the person, from their own session |
| `AuthorQuoted` | `stated_in_chat` | the assistant, after checking the words against the session transcript — **the only authorship that can raise standing** |
| `AuthorAgent` | `agent_inferred` | a model's own reading, asserted now |
| `AuthorRewrite` | keeps the stored label | a keyed edit: rewriting words is not re-asserting them. Absent or corrupt falls to `agent_inferred` |

Anything unrecognised lands on `agent_inferred`, which the gate refuses — a new entry point
that forgets to name itself **fails closed**.

## No behaviour change

All four of today's rules map onto one of the four authorships, including the assistant's "an
edit that touches no content keeps the standing it had" (that is `AuthorRewrite`).

What changes is that the rule is one function with a table test beside it instead of three
functions a fourth writer would never meet. The handler's laundering test moved down with it.
Test doubles derive through the same exported `ProvenanceFor`, so a fake cannot pass while the
live path launders.

## Verification

- `gofmt -l .` clean; `go vet ./...`; `go vet -tags=integration ./...`; `go test ./...` pass
- `go test -tags=integration ./internal/api/handler/ ./internal/candidate/...` — **exit 0**
- `golangci-lint run --new-from-rev=origin/main` → 0 issues
- **Mutation-checked.** Let the store trust a body-supplied provenance again and
  `TestAddAtomIgnoresABodySuppliedProvenance` reports exactly the laundering:
  `Provenance = "manual", want agent_inferred` and `a model's own reading came back
  CV-publishable because the caller asked for it`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Experience claims now receive provenance based on their author, such as candidate-provided, quoted, agent-inferred, or rewritten.
  * Edited claims preserve their existing standing where appropriate.
* **Bug Fixes**
  * Prevented caller-supplied provenance from being used to misrepresent inferred claims as manually verified.
  * Improved CV evidence safeguards by ensuring only appropriately attributed claims are publishable.
* **Documentation**
  * Added guidance explaining provenance attribution and publishing rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->