### PR TITLE
A rewrite keeps the stored label in one statement, with no read to race

### DIFF
--- a/internal/candidate/experience/repository.go
+++ b/internal/candidate/experience/repository.go
@@ -84,6 +84,13 @@ func (r queriesRepository) UpdateAtom(ctx context.Context, id uuid.UUID, userID 
 	})
 }
 
+func (r queriesRepository) UpdateAtomKeepingProvenance(ctx context.Context, id uuid.UUID, userID int64, a Atom, claimKey string) (db.ExperienceAtom, error) {
+	return r.q.UpdateExperienceAtomKeepingProvenance(ctx, db.UpdateExperienceAtomKeepingProvenanceParams{
+		ID: id, UserID: userID, EmploymentID: a.EmploymentID, Claim: a.Claim, ClaimKey: claimKey,
+		Context: a.Context, Metrics: a.Metrics, Skills: a.Skills,
+	})
+}
+
 func (r queriesRepository) DeleteAtom(ctx context.Context, id uuid.UUID, userID int64) (int64, error) {
 	return r.q.DeleteExperienceAtom(ctx, db.DeleteExperienceAtomParams{ID: id, UserID: userID})
 }

--- a/internal/candidate/experience/store.go
+++ b/internal/candidate/experience/store.go
@@ -42,6 +42,9 @@ type Repository interface {
 	GetAtom(ctx context.Context, id uuid.UUID, userID int64) (db.ExperienceAtom, error)
 	InsertAtomIfNew(ctx context.Context, userID int64, a Atom, claimKey string) (db.ExperienceAtom, error)
 	UpdateAtom(ctx context.Context, id uuid.UUID, userID int64, a Atom, claimKey string) (db.ExperienceAtom, error)
+	// UpdateAtomKeepingProvenance writes the same content but leaves the stored provenance
+	// untouched, in one statement. It exists so AuthorRewrite needs no read: see UpdateAtom.
+	UpdateAtomKeepingProvenance(ctx context.Context, id uuid.UUID, userID int64, a Atom, claimKey string) (db.ExperienceAtom, error)
 	DeleteAtom(ctx context.Context, id uuid.UUID, userID int64) (int64, error)
 	// MergeAtoms writes only when both rows' updated_at still match what the caller read —
 	// see Store.MergeAtoms and the query's own comment for why.
@@ -256,18 +259,16 @@ func (s *Store) insertAtom(ctx context.Context, userID int64, a Atom) (Atom, err
 // UpdateAtom replaces an owned atom's content. The claim key moves with the claim, so
 // the uniqueness guarantee holds after an edit as well as after an insert.
 func (s *Store) UpdateAtom(ctx context.Context, id uuid.UUID, userID int64, a Atom, author Author) (Atom, error) {
-	// AuthorRewrite keeps the standing the claim already had, so the stored label has to be
-	// read before the words are overwritten. Read here rather than trusted from the caller:
-	// a rule that depends on an argument the caller computes is a rule the caller can skip.
-	var existing Provenance
-	if author == AuthorRewrite {
-		stored, err := s.GetAtom(ctx, id, userID)
-		if err != nil {
-			return Atom{}, err
-		}
-		existing = stored.Provenance
+	// AuthorRewrite keeps the standing the claim already had, and it does so WITHOUT reading
+	// it: the statement simply omits the column. Reading the label and writing it back would
+	// leave a window in which a concurrent write lands and the rewrite then restores a label
+	// it never saw — the same laundering, taken at a different door. A corrupt stored label is
+	// safe to leave alone, because Provenance.Publishable fails closed on anything it does not
+	// recognise.
+	keepStoredLabel := author == AuthorRewrite
+	if !keepStoredLabel {
+		a.Provenance = ProvenanceFor(author, "")
 	}
-	a.Provenance = ProvenanceFor(author, existing)
 
 	a.Sanitize()
 	if err := a.Validate(); err != nil {
@@ -276,7 +277,12 @@ func (s *Store) UpdateAtom(ctx context.Context, id uuid.UUID, userID int64, a At
 	if err := s.ownsEmployment(ctx, userID, a.EmploymentID); err != nil {
 		return Atom{}, err
 	}
-	row, err := s.repo.UpdateAtom(ctx, id, userID, a, ClaimKey(a.Claim))
+
+	write := s.repo.UpdateAtom
+	if keepStoredLabel {
+		write = s.repo.UpdateAtomKeepingProvenance
+	}
+	row, err := write(ctx, id, userID, a, ClaimKey(a.Claim))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Atom{}, ErrNotFound
 	}

--- a/internal/candidate/experience/store_integration_test.go
+++ b/internal/candidate/experience/store_integration_test.go
@@ -176,3 +176,49 @@ func TestQueriesRepositoryMergeAtoms_RefusesAStaleUpdatedAt(t *testing.T) {
 		t.Errorf("GetAtom lose: %v, want the loser to survive an aborted merge", err)
 	}
 }
+
+// TestQueriesRepositoryUpdateAtomKeepingProvenance_RunsAgainstPostgres exercises the rewrite
+// statement for real. sqlc generates Go from SQL but does not run it, so a column omitted from
+// a SET list — which is the whole point of this query — is only proved correct here.
+//
+// It also pins the behaviour the statement exists for: the words change, the label does not,
+// and there is no read in between for a concurrent write to slip through.
+func TestQueriesRepositoryUpdateAtomKeepingProvenance_RunsAgainstPostgres(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	queries := db.New(pool)
+	userID := insertExperienceIntegrationUser(t, pool, "rewrite-keeps-provenance@example.test")
+
+	s := NewStore(NewQueriesRepository(queries))
+
+	// Banked as the model's own reading: the label a laundering rewrite would want replaced.
+	atom, err := s.AddAtom(ctx, userID, Atom{Claim: "Ran the payments migration"}, AuthorAgent)
+	if err != nil {
+		t.Fatalf("AddAtom: %v", err)
+	}
+	if atom.Provenance != ProvenanceAgentInferred {
+		t.Fatalf("seed provenance = %q, want agent_inferred", atom.Provenance)
+	}
+
+	atom.Claim = "Ran the payments migration across three regions"
+	atom.Provenance = ProvenanceManual // asked for, and must be ignored
+	got, err := s.UpdateAtom(ctx, atom.ID, userID, atom, AuthorRewrite)
+	if err != nil {
+		t.Fatalf("UpdateAtom(rewrite): %v", err)
+	}
+	if got.Claim != "Ran the payments migration across three regions" {
+		t.Errorf("Claim = %q, want the rewritten words", got.Claim)
+	}
+	if got.Provenance != ProvenanceAgentInferred {
+		t.Errorf("Provenance = %q, want agent_inferred left untouched by the statement", got.Provenance)
+	}
+
+	// And it is the STORED row that kept it, not just the returned value.
+	reread, err := s.GetAtom(ctx, atom.ID, userID)
+	if err != nil {
+		t.Fatalf("GetAtom: %v", err)
+	}
+	if reread.Provenance != ProvenanceAgentInferred || reread.Provenance.Publishable() {
+		t.Errorf("stored provenance = %q, want agent_inferred and unpublishable", reread.Provenance)
+	}
+}

--- a/internal/candidate/experience/store_test.go
+++ b/internal/candidate/experience/store_test.go
@@ -191,6 +191,20 @@ func (f *fakeRepo) UpdateAtom(_ context.Context, id uuid.UUID, userID int64, a A
 	return row, nil
 }
 
+// UpdateAtomKeepingProvenance mirrors the statement it stands for: it writes the content and
+// does not touch the label, so a test can tell a preserved label from a re-written one.
+func (f *fakeRepo) UpdateAtomKeepingProvenance(_ context.Context, id uuid.UUID, userID int64, a Atom, claimKey string) (db.ExperienceAtom, error) {
+	row, ok := f.atoms[id]
+	if !ok || row.UserID != userID {
+		return db.ExperienceAtom{}, pgx.ErrNoRows
+	}
+	row.EmploymentID, row.Claim, row.ClaimKey = a.EmploymentID, a.Claim, claimKey
+	row.Context, row.Metrics, row.Skills = a.Context, a.Metrics, a.Skills
+	row.UpdatedAt = f.stamp()
+	f.atoms[id] = row
+	return row, nil
+}
+
 func (f *fakeRepo) DeleteAtom(_ context.Context, id uuid.UUID, userID int64) (int64, error) {
 	if a, ok := f.atoms[id]; ok && a.UserID == userID {
 		delete(f.atoms, id)
@@ -745,5 +759,43 @@ func TestStoreMergeAtomsNotFoundAndCrossEmployment(t *testing.T) {
 	}
 	if _, err := s.MergeAtoms(ctx, owner, a.ID, a.ID); !errors.Is(err, ErrInvalidMerge) {
 		t.Errorf("same id = %v, want ErrInvalidMerge", err)
+	}
+}
+
+// TestRewriteKeepsTheStoredLabelWithoutReadingIt is the atomicity half of the anti-laundering
+// rule. AuthorRewrite must reach a statement that leaves provenance alone, not read it and
+// write it back: a read-then-write leaves a window in which a concurrent write lands and the
+// rewrite restores a label it never saw.
+//
+// The fake proves it structurally — UpdateAtomKeepingProvenance never touches the column, so
+// if the store took the reading path the assertion below would see the caller's value instead.
+func TestRewriteKeepsTheStoredLabelWithoutReadingIt(t *testing.T) {
+	s, _ := newStore()
+	ctx := context.Background()
+
+	// Banked by the agent: unpublishable, which is the label a laundering edit would want gone.
+	atom, err := s.AddAtom(ctx, owner, Atom{Claim: "Ran the migration"}, AuthorAgent)
+	if err != nil {
+		t.Fatalf("AddAtom: %v", err)
+	}
+	if atom.Provenance != ProvenanceAgentInferred {
+		t.Fatalf("seed provenance = %q, want agent_inferred", atom.Provenance)
+	}
+
+	// A keyed rewrite, asking loudly for a promotion it must not get.
+	atom.Claim = "Ran the migration across three regions"
+	atom.Provenance = ProvenanceManual
+	got, err := s.UpdateAtom(ctx, atom.ID, owner, atom, AuthorRewrite)
+	if err != nil {
+		t.Fatalf("UpdateAtom: %v", err)
+	}
+	if got.Claim != "Ran the migration across three regions" {
+		t.Errorf("Claim = %q, want the rewritten words — a rewrite still rewrites", got.Claim)
+	}
+	if got.Provenance != ProvenanceAgentInferred {
+		t.Errorf("Provenance = %q, want agent_inferred untouched", got.Provenance)
+	}
+	if got.Provenance.Publishable() {
+		t.Error("a rewrite promoted a model's reading to CV-publishable")
 	}
 }

--- a/internal/platform/db/experience.sql.go
+++ b/internal/platform/db/experience.sql.go
@@ -630,6 +630,61 @@ func (q *Queries) UpdateExperienceAtom(ctx context.Context, arg UpdateExperience
 	return i, err
 }
 
+const updateExperienceAtomKeepingProvenance = `-- name: UpdateExperienceAtomKeepingProvenance :one
+UPDATE experience_atoms
+SET employment_id = $3, claim = $4, claim_key = $5, context = $6, metrics = $7, skills = $8,
+    updated_at = now()
+WHERE id = $1 AND user_id = $2
+RETURNING id, user_id, employment_id, claim, claim_key, context, metrics, skills, provenance, source_ref, created_at, updated_at
+`
+
+type UpdateExperienceAtomKeepingProvenanceParams struct {
+	ID           uuid.UUID  `json:"id"`
+	UserID       int64      `json:"user_id"`
+	EmploymentID *uuid.UUID `json:"employment_id"`
+	Claim        string     `json:"claim"`
+	ClaimKey     string     `json:"claim_key"`
+	Context      string     `json:"context"`
+	Metrics      []string   `json:"metrics"`
+	Skills       []string   `json:"skills"`
+}
+
+// The rewrite path: changes the words and leaves the standing of the claim exactly where it is.
+//
+// provenance is deliberately ABSENT from the SET list rather than read and written back. A
+// read-then-write would leave a window in which a concurrent write lands, and the rewrite then
+// restores a label it never saw — which is the laundering route experience.Author exists to
+// close, taken at a different door. Omitting the column makes the preservation the statement's
+// own, so there is nothing to race.
+func (q *Queries) UpdateExperienceAtomKeepingProvenance(ctx context.Context, arg UpdateExperienceAtomKeepingProvenanceParams) (ExperienceAtom, error) {
+	row := q.db.QueryRow(ctx, updateExperienceAtomKeepingProvenance,
+		arg.ID,
+		arg.UserID,
+		arg.EmploymentID,
+		arg.Claim,
+		arg.ClaimKey,
+		arg.Context,
+		arg.Metrics,
+		arg.Skills,
+	)
+	var i ExperienceAtom
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.EmploymentID,
+		&i.Claim,
+		&i.ClaimKey,
+		&i.Context,
+		&i.Metrics,
+		&i.Skills,
+		&i.Provenance,
+		&i.SourceRef,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const updateExperienceEmployment = `-- name: UpdateExperienceEmployment :one
 UPDATE experience_employments
 SET kind = $3, company = $4, role = $5, location = $6, period_start = $7, period_end = $8,

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -3773,6 +3773,14 @@ type Querier interface {
 	// Owner-scoped edit. claim_key moves with the claim, so the uniqueness guarantee holds after
 	// an edit as well as after an insert.
 	UpdateExperienceAtom(ctx context.Context, arg UpdateExperienceAtomParams) (ExperienceAtom, error)
+	// The rewrite path: changes the words and leaves the standing of the claim exactly where it is.
+	//
+	// provenance is deliberately ABSENT from the SET list rather than read and written back. A
+	// read-then-write would leave a window in which a concurrent write lands, and the rewrite then
+	// restores a label it never saw — which is the laundering route experience.Author exists to
+	// close, taken at a different door. Omitting the column makes the preservation the statement's
+	// own, so there is nothing to race.
+	UpdateExperienceAtomKeepingProvenance(ctx context.Context, arg UpdateExperienceAtomKeepingProvenanceParams) (ExperienceAtom, error)
 	// A full owner-scoped replacement, used by the profile UI where the user is editing the
 	// fields directly and means what they typed — including blanking one.
 	UpdateExperienceEmployment(ctx context.Context, arg UpdateExperienceEmploymentParams) (ExperienceEmployment, error)

--- a/internal/platform/db/queries/experience.sql
+++ b/internal/platform/db/queries/experience.sql
@@ -113,6 +113,20 @@ SET employment_id = $3, claim = $4, claim_key = $5, context = $6, metrics = $7, 
 WHERE id = $1 AND user_id = $2
 RETURNING id, user_id, employment_id, claim, claim_key, context, metrics, skills, provenance, source_ref, created_at, updated_at;
 
+-- name: UpdateExperienceAtomKeepingProvenance :one
+-- The rewrite path: changes the words and leaves the standing of the claim exactly where it is.
+--
+-- provenance is deliberately ABSENT from the SET list rather than read and written back. A
+-- read-then-write would leave a window in which a concurrent write lands, and the rewrite then
+-- restores a label it never saw — which is the laundering route experience.Author exists to
+-- close, taken at a different door. Omitting the column makes the preservation the statement's
+-- own, so there is nothing to race.
+UPDATE experience_atoms
+SET employment_id = $3, claim = $4, claim_key = $5, context = $6, metrics = $7, skills = $8,
+    updated_at = now()
+WHERE id = $1 AND user_id = $2
+RETURNING id, user_id, employment_id, claim, claim_key, context, metrics, skills, provenance, source_ref, created_at, updated_at;
+
 -- name: DeleteExperienceAtom :execrows
 -- The only path that removes an atom, and it belongs to the user. Import never deletes.
 DELETE FROM experience_atoms


### PR DESCRIPTION
Follow-up to #2231, from its review. Correct — though it **predates** that PR, which narrowed
the window rather than opening it: on `main` the handler did the same read-then-write one layer
up (`GetAtom` → `provenanceForUpdate` → `UpdateAtom`).

## The window

`AuthorRewrite` read the stored provenance and wrote it back. A concurrent write landing
between the two makes the rewrite restore a label it never saw — the laundering route
`Author` exists to close, taken at a different door:

1. bank an inference as `agent_inferred` (the CV evidence gate refuses it)
2. race a keyed rewrite against a legitimate write
3. read back something publishable, cite it

## The fix

Smaller than a version column: `UpdateExperienceAtomKeepingProvenance` simply **omits
`provenance` from the SET list**. Preservation becomes the statement's own, so there is
nothing to race — and the read disappears with it.

```sql
UPDATE experience_atoms
SET employment_id = $3, claim = $4, claim_key = $5, context = $6, metrics = $7, skills = $8,
    updated_at = now()
WHERE id = $1 AND user_id = $2
```

The "absent or corrupt label falls to `agent_inferred`" half stays safe without the read,
because `Provenance.Publishable()` already fails closed on anything outside the known set.

## Proved twice, on purpose

**sqlc generates Go from SQL but never runs it**, and a column omitted from a SET list is
exactly the kind of thing that only fails at runtime:

- a **unit** test whose fake never touches the column, so if the store took the reading path
  the assertion would see the caller's value instead
- an **integration** test against a real Postgres that rewrites the words, re-reads the row,
  and finds `agent_inferred` still there and still unpublishable

Both mutation-checked: send the rewrite down the ordinary statement and each reports the
promotion (`Provenance = "manual", want agent_inferred untouched`).

## Verification

- `gofmt -l .` clean; `go vet ./...`; `go vet -tags=integration ./...`; `go test ./...` pass
- `go test -tags=integration ./internal/api/handler/ ./internal/candidate/... ./internal/platform/db/` — **exit 0**
- `golangci-lint run --new-from-rev=origin/main` → 0 issues
- `sqlc generate` run with the pinned v1.31.1; no hand-edited generated files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Rewriting an experience claim now preserves its existing provenance label.
  - Prevented rewrites from unintentionally changing claim status or making claims publishable.
  - Improved update consistency when changes occur concurrently.

- **Tests**
  - Added coverage confirming rewritten claims retain their original provenance in stored data and returned results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->