### PR TITLE
A rewrite ignores a junk provenance instead of refusing it

### DIFF
--- a/internal/candidate/experience/store.go
+++ b/internal/candidate/experience/store.go
@@ -266,7 +266,14 @@ func (s *Store) UpdateAtom(ctx context.Context, id uuid.UUID, userID int64, a At
 	// safe to leave alone, because Provenance.Publishable fails closed on anything it does not
 	// recognise.
 	keepStoredLabel := author == AuthorRewrite
-	if !keepStoredLabel {
+	if keepStoredLabel {
+		// Nothing writes this column on the rewrite path, so the caller's value must not be
+		// JUDGED either — "a body-supplied provenance is inert" has to mean inert, not
+		// "rejected on a technicality" by Validate below. It is normalised to what an
+		// unlabelled rewrite means; the statement omits the column, so this never reaches
+		// the row.
+		a.Provenance = ProvenanceFor(AuthorRewrite, "")
+	} else {
 		a.Provenance = ProvenanceFor(author, "")
 	}
 

--- a/internal/candidate/experience/store_test.go
+++ b/internal/candidate/experience/store_test.go
@@ -799,3 +799,30 @@ func TestRewriteKeepsTheStoredLabelWithoutReadingIt(t *testing.T) {
 		t.Error("a rewrite promoted a model's reading to CV-publishable")
 	}
 }
+
+// TestRewriteIgnoresAJunkProvenanceRatherThanRefusing closes the gap the atomic rewrite opened:
+// with the label no longer overwritten before Validate, a caller's nonsense survived long
+// enough to be rejected. "Inert" has to mean inert — the field is not written, so it is not
+// judged either, and the stored standing is untouched.
+func TestRewriteIgnoresAJunkProvenanceRatherThanRefusing(t *testing.T) {
+	s, _ := newStore()
+	ctx := context.Background()
+
+	atom, err := s.AddAtom(ctx, owner, Atom{Claim: "Ran the migration"}, AuthorAgent)
+	if err != nil {
+		t.Fatalf("AddAtom: %v", err)
+	}
+
+	atom.Claim = "Ran the migration across three regions"
+	atom.Provenance = "vibes"
+	got, err := s.UpdateAtom(ctx, atom.ID, owner, atom, AuthorRewrite)
+	if err != nil {
+		t.Fatalf("a junk provenance must be ignored, not refused: %v", err)
+	}
+	if got.Claim != "Ran the migration across three regions" {
+		t.Errorf("Claim = %q, want the rewritten words", got.Claim)
+	}
+	if got.Provenance != ProvenanceAgentInferred {
+		t.Errorf("Provenance = %q, want the stored agent_inferred", got.Provenance)
+	}
+}


### PR DESCRIPTION
Review catch on #2232 — and **that PR introduced it**, so this is a regression fix rather than
a pre-existing one.

Dropping the overwrite on the rewrite path meant the caller's value survived to
`Atom.Validate`, which rejects anything outside the four known labels. A keyed
`PUT /me/experience/atoms/:id` carrying `"provenance":"vibes"` therefore started answering
**400** where the field is supposed to be inert.

"Inert" has to mean inert, not "rejected on a technicality". The rewrite path now normalises
the field to what an unlabelled rewrite means, purely to satisfy `Validate`; the statement
still omits the column, so nothing reaches the row and the stored standing is untouched.

Mutation-checked: drop the normalisation and `TestRewriteIgnoresAJunkProvenanceRatherThanRefusing`
reports the refusal verbatim.

- `gofmt -l .` clean; `go vet ./...`; `go vet -tags=integration ./...`; `go test ./...` pass
- `go test -tags=integration ./internal/candidate/experience/ ./internal/api/handler/` — exit 0
- `golangci-lint run --new-from-rev=origin/main` → 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rewriting a claim now ignores invalid provenance supplied in the request instead of rejecting the update.
  * Existing provenance labels are preserved when a claim is rewritten.

* **Tests**
  * Added coverage confirming rewrites succeed with invalid provenance and retain the original stored label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->