### PR TITLE
Reserve the AI credit before the chain, and give it back if nothing comes out

### DIFF
--- a/internal/ai/credits/credits.go
+++ b/internal/ai/credits/credits.go
@@ -167,6 +167,60 @@ func (s *Store) Debit(ctx context.Context, userID int64, feature Feature, ref st
 	return Balance{Remaining: int(remaining), ResetsAt: resetsAt(now)}, debitErr
 }
 
+// Release voids a debit taken as a reservation for work that produced nothing, atomically and
+// idempotently by (feature, ref): the points go back and the ref becomes chargeable again, so
+// a candidate whose analysis failed can retry and be charged once, not twice and not never.
+//
+// It takes the same row lock as Debit, so a release cannot interleave with a concurrent charge
+// for the same user and leave the materialized balance disagreeing with the ledger.
+//
+// Releasing something that was never charged — a free recompute, a caller that did not reserve,
+// a second release of the same reservation — removes nothing and reports the balance unchanged.
+// That is what lets every failure path call it without first working out whether it owes one.
+func (s *Store) Release(ctx context.Context, userID int64, feature Feature, ref string) (Balance, error) {
+	now := time.Now().UTC()
+	cur := periodKey(now)
+	cost := int32(s.cfg.cost(feature))
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return Balance{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	q := s.q.WithTx(tx)
+
+	row, err := q.GetBalanceForUpdate(ctx, userID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// No balance row means nothing was ever charged here, so there is nothing to give
+		// back — and the caller is reported at the full monthly grant, the same reading
+		// Balance gives a fresh user. Answering zero would say "out of credits" about
+		// somebody who has spent nothing.
+		return Balance{Remaining: s.cfg.MonthlyGrant, ResetsAt: resetsAt(now)}, nil
+	}
+	if err != nil {
+		return Balance{}, err
+	}
+
+	removed, err := q.DeleteDebit(ctx, db.DeleteDebitParams{
+		UserID: userID, Feature: string(feature), Ref: ref,
+	})
+	if err != nil {
+		return Balance{}, err
+	}
+
+	remaining := s.applicableRemaining(row.Period, cur, row.Remaining)
+	if removed > 0 {
+		remaining += cost
+	}
+	if err := q.UpdateBalance(ctx, db.UpdateBalanceParams{UserID: userID, Period: cur, Remaining: remaining}); err != nil {
+		return Balance{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Balance{}, err
+	}
+	return Balance{Remaining: int(remaining), ResetsAt: resetsAt(now)}, nil
+}
+
 // Reward credits the configured contribution reward to a user, atomically and idempotently
 // by ref (e.g. the accepted contribution id). The reward banks above the monthly grant and
 // survives the period reset (applicableRemaining preserves any surplus). A non-positive

--- a/internal/ai/credits/credits.go
+++ b/internal/ai/credits/credits.go
@@ -208,10 +208,15 @@ func (s *Store) Release(ctx context.Context, userID int64, feature Feature, ref 
 		return Balance{}, err
 	}
 
-	remaining := s.applicableRemaining(row.Period, cur, row.Remaining)
+	// The cost goes back onto the STORED balance and the period reset is applied after, not
+	// the other way round. Reversed, a release that crosses a month boundary would floor the
+	// balance at the fresh grant and then add the cost on top — a grant of 20 with 19 left
+	// would come back as 21, so a failed analysis would hand out a credit.
+	restored := row.Remaining
 	if removed > 0 {
-		remaining += cost
+		restored += cost
 	}
+	remaining := s.applicableRemaining(row.Period, cur, restored)
 	if err := q.UpdateBalance(ctx, db.UpdateBalanceParams{UserID: userID, Period: cur, Remaining: remaining}); err != nil {
 		return Balance{}, err
 	}

--- a/internal/ai/credits/store_integration_test.go
+++ b/internal/ai/credits/store_integration_test.go
@@ -285,3 +285,71 @@ func TestDebit_concurrentNoOversell(t *testing.T) {
 		t.Errorf("debit rows after race = %d, want exactly 1", total)
 	}
 }
+
+// TestRelease_givesTheCreditBackAndFreesTheRef exercises the void statement for real. sqlc
+// generates Go from SQL but never runs it, and this one deletes a row that a partial unique
+// index depends on — the whole reason a reservation is voided rather than compensated.
+func TestRelease_givesTheCreditBackAndFreesTheRef(t *testing.T) {
+	pool := startPostgres(t)
+	s := newStore(pool, Config{MonthlyGrant: 20, CostMatch: 1, CostTailor: 3})
+	uid := insertUser(t, pool, "release@example.test")
+	ctx := context.Background()
+
+	if _, err := s.Debit(ctx, uid, FeatureMatch, "job-1"); err != nil {
+		t.Fatalf("Debit: %v", err)
+	}
+
+	bal, err := s.Release(ctx, uid, FeatureMatch, "job-1")
+	if err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if bal.Remaining != 20 {
+		t.Errorf("Remaining after release = %d, want the full grant back", bal.Remaining)
+	}
+	if got := countDebits(t, pool, uid, "match", "job-1"); got != 0 {
+		t.Errorf("debit rows after release = %d, want 0", got)
+	}
+
+	// The ref is chargeable again, which is the point: a candidate whose analysis failed
+	// retries and is charged once, not never and not twice. A compensating ledger row could
+	// not do this — credit_ledger_debit_ref_uniq would still hold the ref.
+	if _, err := s.Debit(ctx, uid, FeatureMatch, "job-1"); err != nil {
+		t.Fatalf("re-Debit after release: %v", err)
+	}
+	if got := countDebits(t, pool, uid, "match", "job-1"); got != 1 {
+		t.Errorf("debit rows after re-charge = %d, want 1", got)
+	}
+	if b, _ := s.Balance(ctx, uid); b.Remaining != 19 {
+		t.Errorf("Remaining after re-charge = %d, want 19", b.Remaining)
+	}
+}
+
+// TestRelease_isIdempotentAndSafeOnNothing pins what lets every failure path call it without
+// first working out whether it owes one.
+func TestRelease_isIdempotentAndSafeOnNothing(t *testing.T) {
+	pool := startPostgres(t)
+	s := newStore(pool, Config{MonthlyGrant: 20, CostMatch: 1, CostTailor: 3})
+	uid := insertUser(t, pool, "release-idem@example.test")
+	ctx := context.Background()
+
+	// Never charged: nothing to give back, and no balance invented.
+	bal, err := s.Release(ctx, uid, FeatureMatch, "never-charged")
+	if err != nil {
+		t.Fatalf("Release of an uncharged ref: %v", err)
+	}
+	if bal.Remaining != 20 {
+		t.Errorf("Remaining = %d, want the untouched grant", bal.Remaining)
+	}
+
+	if _, err := s.Debit(ctx, uid, FeatureMatch, "job-2"); err != nil {
+		t.Fatalf("Debit: %v", err)
+	}
+	for i := range 3 {
+		if _, err := s.Release(ctx, uid, FeatureMatch, "job-2"); err != nil {
+			t.Fatalf("Release %d: %v", i, err)
+		}
+	}
+	if b, _ := s.Balance(ctx, uid); b.Remaining != 20 {
+		t.Errorf("Remaining after three releases = %d, want 20 — a release gives back once", b.Remaining)
+	}
+}

--- a/internal/ai/credits/store_integration_test.go
+++ b/internal/ai/credits/store_integration_test.go
@@ -353,3 +353,34 @@ func TestRelease_isIdempotentAndSafeOnNothing(t *testing.T) {
 		t.Errorf("Remaining after three releases = %d, want 20 — a release gives back once", b.Remaining)
 	}
 }
+
+// TestRelease_acrossAPeriodRolloverGivesBackNoMoreThanItTook is the ordering the reset forces.
+// Putting the cost back AFTER applying the monthly reset would floor the balance at the fresh
+// grant and then add on top, so a release that crossed a month boundary would hand out a
+// credit the candidate never had.
+func TestRelease_acrossAPeriodRolloverGivesBackNoMoreThanItTook(t *testing.T) {
+	pool := startPostgres(t)
+	s := newStore(pool, Config{MonthlyGrant: 20, CostMatch: 1, CostTailor: 3})
+	uid := insertUser(t, pool, "release-rollover@example.test")
+	ctx := context.Background()
+
+	if _, err := s.Debit(ctx, uid, FeatureMatch, "job-1"); err != nil {
+		t.Fatalf("Debit: %v", err)
+	}
+	// Age the stored row into a previous period, leaving 19 banked there.
+	if _, err := pool.Exec(ctx,
+		`UPDATE credit_balances SET period = '1970-01' WHERE user_id = $1`, uid); err != nil {
+		t.Fatalf("age the balance row: %v", err)
+	}
+
+	bal, err := s.Release(ctx, uid, FeatureMatch, "job-1")
+	if err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if bal.Remaining != 20 {
+		t.Errorf("Remaining = %d, want exactly the fresh grant 20 — never grant+cost", bal.Remaining)
+	}
+	if b, _ := s.Balance(ctx, uid); b.Remaining != 20 {
+		t.Errorf("stored Remaining = %d, want 20", b.Remaining)
+	}
+}

--- a/internal/api/handler/match_analysis.go
+++ b/internal/api/handler/match_analysis.go
@@ -217,11 +217,11 @@ func (h *matchHandlers) PostMatchAnalysis(c *fiber.Ctx) error {
 	// risk stamping a newer CV's time on an older CV's analysis. language is captured the
 	// same way, for the same reason.
 	language := h.callerLanguage(c.Context(), userID)
-	// Gate on points before touching the LLM: a new job needs at least the match cost, a
-	// recompute of an already-analyzed job is always free. Only new analyses are charged,
-	// and only after they persist, so a legacy cached job re-runs for free. The rule and the
+	// Take the credit before touching the LLM: the atomic debit IS the gate, so two
+	// concurrent runs cannot both pass a balance only one of them could afford. A recompute
+	// is free, and a run that produces nothing gives the credit back. The rule and the
 	// refusal are the service's; only the status code is ours.
-	chargeable, err := h.fit.Authorize(c.Context(), userID, job.ID)
+	reserved, err := h.fit.Reserve(c.Context(), userID, job.ID)
 	if err != nil {
 		if refusal, refused := renderCreditsRefusal(c, err); refused {
 			return refusal
@@ -243,7 +243,7 @@ func (h *matchHandlers) PostMatchAnalysis(c *fiber.Ctx) error {
 		Analyzer:     h.boundAnalyzer(c.Context(), userID),
 		Input:        h.buildAnalysisInput(c, job, userID, profile, blockers, language),
 		CVUploadedAt: cvUploadedAt,
-		Chargeable:   chargeable,
+		Reserved:     reserved,
 	}, nil)
 	if err != nil {
 		// Best-effort: log (never the CV/job text) and serve no analysis.
@@ -305,9 +305,9 @@ func (h *matchHandlers) boundAnalyzer(ctx context.Context, userID int64) *matcha
 // A nil *autopilotAnalysis is a working no-op — the caller has no match surface wired — so
 // PostAssistantAutopilot needs no branch of its own.
 //
-// Neither half is chargeable, and the request it carries says so by leaving Chargeable false:
+// Neither half is chargeable, and the request it carries says so by leaving Reserved false:
 // the cold-start pre-run is unmetered by design, tracked only by the LLM spend attribution
-// every call already carries.
+// every call already carries — so it reserves nothing and has nothing to release.
 type autopilotAnalysis struct {
 	fit *fitanalysis.Service
 	req fitanalysis.Request

--- a/internal/api/handler/match_analysis_stream.go
+++ b/internal/api/handler/match_analysis_stream.go
@@ -42,24 +42,21 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 		return err
 	}
 	cvUploadedAt, hasCV := h.cvUploadedAt(c, userID)
-	// Gate on points before opening the stream (the fiber ctx is still valid here, so an
+	// Reserve the credit before opening the stream (the fiber ctx is still valid here, so an
 	// out-of-credits new job returns a real 402 instead of an SSE error). Only a CV-backed
 	// request would run the LLM; without one the stream just reports has_cv. A recompute is
-	// free — only a new analysis is charged, and only after it persists (in the writer).
+	// free, and a run that produces nothing gives the credit back.
 	//
-	// Every caller runs this gate for ITSELF, whether it ends up leading or following the
-	// compute below — not just the leader. A follower still spends a real credit on a
-	// genuinely new job (two tabs open on the same never-analysed job is not a discount),
-	// and an out-of-credits caller must still 402 even when someone else is already
-	// computing the same analysis for free reasons (autopilotAnalysis.ensure never reaches this
-	// gate at all — see prepareAutopilotRun). Debiting twice for one job is safe: the charge
-	// is idempotent per (user, feature, job) — see credits.Store.Debit's DebitExists check —
-	// so a leader and a follower that both decide "I owe one credit here" collapse into a
-	// single ledger row, whichever of them reaches it first.
-	chargeable := false
+	// Every caller reserves for ITSELF, whether it ends up leading or following the compute
+	// below — an out-of-credits caller must still 402 even when someone else is already
+	// computing the same analysis for free reasons (autopilotAnalysis.ensure never reaches
+	// this gate at all — see prepareAutopilotRun). Reserving twice for one job is safe: the
+	// debit is idempotent per (user, feature, job), so a leader and a follower collapse into
+	// a single ledger row, whichever reaches it first.
+	reserved := false
 	if hasCV {
 		var err error
-		if chargeable, err = h.fit.Authorize(c.Context(), userID, job.ID); err != nil {
+		if reserved, err = h.fit.Reserve(c.Context(), userID, job.ID); err != nil {
 			if refusal, refused := renderCreditsRefusal(c, err); refused {
 				return refusal
 			}
@@ -95,7 +92,7 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 		UserID:       userID,
 		Job:          job,
 		CVUploadedAt: cvUploadedAt,
-		Chargeable:   chargeable,
+		Reserved:     reserved,
 		Claim:        claim,
 	}
 	if claim.IsLeader() {

--- a/internal/candidate/fitanalysis/AGENTS.md
+++ b/internal/candidate/fitanalysis/AGENTS.md
@@ -15,8 +15,8 @@ The chain has four entry points and only one of them speaks HTTP:
 | Caller | Enters through | Charged? |
 |---|---|---|
 | `GET /jobs/:slug/match-analysis` | `Cached` | never (no LLM at all) |
-| `POST /jobs/:slug/match-analysis` | `Authorize` → `Run` | first analysis of that job only |
-| `GET …/match-analysis/stream` | `Authorize` → `Claim` → `Run` or `Follow` | same rule, per caller |
+| `POST /jobs/:slug/match-analysis` | `Reserve` → `Run` | first analysis of that job only, released if it produces nothing |
+| `GET …/match-analysis/stream` | `Reserve` → `Claim` → `Run` or `Follow` | same rule, per caller |
 | the autopilot's cold-start fill and post-run refresh | `Ensure` / `Refresh` | **never** |
 | `GET /me/cvs/:id/tailor-context` + the agent's `cv_context` tool | `TailoringContext` | never (read only) |
 | `GET /me/cvs/:id/job-match` + the agent's `job_match` tool | `Optional` | never (read only) |
@@ -29,16 +29,29 @@ reachable only through a `*fiber.Ctx`.
 
 ## Always true
 
+- **The debit IS the gate.** `Reserve` takes the credit BEFORE the chain starts, so the ledger's
+  own row lock decides. It used to check a balance and charge afterwards, which is a
+  check-then-act: two concurrent runs for two never-analysed jobs both passed a balance only one
+  of them could afford, and the loser's debit then failed silently — after its analysis had been
+  computed, cached and served.
+- **A run that produces nothing gives the credit back.** `Run` and `Follow` release on every
+  failure path, from a defer, so a panic returns it too. Taking the credit up front is only
+  honest if a failed analysis still costs nothing.
+- **A released ref is chargeable again**, which is what makes a retry cost one credit rather
+  than none. `credits.Store.Release` DELETES the debit row instead of appending a compensating
+  one, and it has to: `credit_ledger_debit_ref_uniq` allows one debit per `(user, feature, ref)`,
+  so a compensating entry would leave the ref permanently spent.
 - **Only a FIRST analysis of a job is chargeable.** A recompute is always free, so an analysis
-  cached before credits shipped re-runs for nothing. `Authorize` decides it; `Request.Chargeable`
-  carries the answer.
-- **Every caller gates for ITSELF, leader or follower.** Two tabs on one never-analysed job each
-  genuinely owe a credit — following someone else's compute is not a discount. Charging is
-  idempotent per `(candidate, feature, job)` (`credits.Store.Debit`'s `DebitExists`), so two
-  callers that both decide "I owe one here" collapse into one ledger row.
-- **The autopilot's two halves never charge.** `Ensure` ignores `Chargeable` rather than trusting
-  it. Their spend is tracked only by the LLM attribution every call already carries.
-- **The gate runs before the LLM and before a stream's headers.** `Authorize` refuses with
+  cached before credits shipped re-runs for nothing. `Request.Reserved` carries the answer.
+- **Every caller reserves for ITSELF, leader or follower.** Two tabs on one never-analysed job
+  are neither a double charge nor a discount: the debit is idempotent per
+  `(candidate, feature, job)`, so both collapse into one ledger row.
+- **Metering fails OPEN.** An unreachable ledger logs and lets the run through unreserved.
+  Bookkeeping must never be able to refuse a legitimate analysis, and an uncharged run is a
+  smaller wrong than a candidate blocked by our accounting.
+- **The autopilot's two halves never charge.** `Ensure` ignores `Reserved` rather than trusting
+  it, so it reserves nothing and has nothing to release. Their spend is tracked only by the LLM attribution every call already carries.
+- **The gate runs before the LLM and before a stream's headers.** `Reserve` refuses with
   `*InsufficientCreditsError`, carrying the balance — the caller renders the 402. An out-of-credits
   request must never become an event on a stream that already returned 200.
 - **The cache stores the UNCAPPED analysis.** The hard-constraint ceiling is recomputed and applied

--- a/internal/candidate/fitanalysis/fitanalysis.go
+++ b/internal/candidate/fitanalysis/fitanalysis.go
@@ -418,6 +418,14 @@ func (s *Service) release(ctx context.Context, userID, jobID int64) {
 	if s.credits == nil {
 		return
 	}
+	// The cleanup has to survive the cancellation that caused it. A client that disconnects
+	// mid-run cancels the request context, the chain fails with it, and a release on that same
+	// context cannot even open its transaction — leaving the candidate charged for an analysis
+	// they never received, in exactly the case this exists for. Bounded, because a detached
+	// context with no deadline is a goroutine nobody will ever stop.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), releaseTimeout)
+	defer cancel()
+
 	// A credit buys HAVING the analysis, not the attempt that produced it. A later run that
 	// fails — the autopilot's refresh, a recompute — must not give back the credit an EARLIER
 	// run earned, so a release stops when an analysis exists for the pair.
@@ -434,6 +442,10 @@ func (s *Service) release(ctx context.Context, userID, jobID int64) {
 		log.Printf("credits: releasing a match reservation for user %d job %d: %v", userID, jobID, err)
 	}
 }
+
+// releaseTimeout bounds the detached cleanup. Generous for two small statements, and short
+// enough that a wedged database cannot pile up goroutines behind it.
+const releaseTimeout = 5 * time.Second
 
 // debitRef identifies what a match credit was spent on. One charge per job, ever.
 func debitRef(jobID int64) string { return strconv.FormatInt(jobID, 10) }

--- a/internal/candidate/fitanalysis/fitanalysis.go
+++ b/internal/candidate/fitanalysis/fitanalysis.go
@@ -57,6 +57,8 @@ type Meter interface {
 	Balance(ctx context.Context, userID int64) (credits.Balance, error)
 	Cost(f credits.Feature) int
 	Debit(ctx context.Context, userID int64, feature credits.Feature, ref string) (credits.Balance, error)
+	// Release voids a debit taken as a reservation for work that produced nothing.
+	Release(ctx context.Context, userID int64, feature credits.Feature, ref string) (credits.Balance, error)
 }
 
 // InsufficientCreditsError refuses a run the candidate cannot afford. It carries the balance
@@ -92,11 +94,14 @@ type Request struct {
 	// stamping a newer CV's time on an older CV's analysis.
 	CVUploadedAt *time.Time
 
-	// Chargeable is THIS caller's own credit decision (Authorize's answer), not the leader's.
-	// Two callers racing for one never-analysed job each genuinely owe a credit — two tabs on
-	// the same job is not a discount — and Charge is idempotent per (candidate, feature, job),
-	// so both deciding "I owe one here" collapses into a single ledger row.
-	Chargeable bool
+	// Reserved says THIS caller has already paid for the run (Reserve's answer), not the
+	// leader's. Two callers racing for one never-analysed job each reserve, and the debit is
+	// idempotent per (candidate, feature, job), so both collapse into a single ledger row —
+	// two tabs on the same job is neither a double charge nor a discount.
+	//
+	// A run that produces nothing releases what it took, so a failed analysis still costs
+	// nothing.
+	Reserved bool
 
 	// Claim is this caller's role in the coalesced compute, from Claim. Nil means the caller
 	// is not coalescing at all (the plain POST run), which races nothing today because the
@@ -144,27 +149,44 @@ func (s *Service) Balance(ctx context.Context, userID int64) *credits.Balance {
 	return &bal
 }
 
-// Authorize decides whether this run may proceed and whether it is chargeable.
+// Reserve decides whether this run is chargeable and, if it is, TAKES the credit before the
+// chain starts. The atomic debit is the gate.
 //
-// A run is chargeable only when it would be the candidate's FIRST analysis of that job — no
-// cached row exists. A recompute is always free, so an analysis cached before credits shipped
-// re-runs for nothing. Only a chargeable run is gated, and it is refused with
-// InsufficientCreditsError when the balance cannot cover the cost.
+// It used to check the balance and charge afterwards, which is a check-then-act: two
+// concurrent runs for two never-analysed jobs could both pass a check only one of them could
+// afford, and the loser's debit then failed silently — after its analysis had been computed,
+// cached and served. Debiting first makes the ledger's own row lock the arbiter, so the second
+// run is refused rather than given away.
 //
-// The gate runs before the LLM is touched, and before a streaming caller opens its response,
-// so the refusal can still be rendered as a status rather than as an event on a stream that
-// already returned 200.
-func (s *Service) Authorize(ctx context.Context, userID, jobID int64) (chargeable bool, err error) {
+// A run is chargeable only when it would be the candidate's FIRST analysis of that job, so a
+// recompute is always free and an analysis cached before credits shipped re-runs for nothing.
+// A run that cannot afford its credit is refused with InsufficientCreditsError, before the LLM
+// is touched and before a streaming caller opens its response — so the refusal can still be a
+// status rather than an event on a stream that already returned 200.
+//
+// Metering fails OPEN. An unreachable ledger logs and lets the run through unreserved, exactly
+// as the balance read always did: bookkeeping must never be able to refuse a legitimate
+// analysis, and an uncharged run is a smaller wrong than a candidate blocked by our accounting.
+func (s *Service) Reserve(ctx context.Context, userID, jobID int64) (reserved bool, err error) {
 	isNew, err := s.isNew(ctx, userID, jobID)
 	if err != nil || !isNew {
 		return false, err
 	}
 	if s.credits == nil {
-		return true, nil
+		return false, nil
 	}
-	if bal := s.Balance(ctx, userID); bal != nil && bal.Remaining < s.credits.Cost(credits.FeatureMatch) {
-		return false, &InsufficientCreditsError{Balance: *bal}
+	bal, err := s.credits.Debit(ctx, userID, credits.FeatureMatch, debitRef(jobID))
+	if errors.Is(err, credits.ErrInsufficient) {
+		return false, &InsufficientCreditsError{Balance: bal}
 	}
+	if err != nil {
+		log.Printf("credits: reserving a match for user %d job %d: %v", userID, jobID, err)
+		return false, nil
+	}
+	// True even when the debit no-opped on an already-charged ref. isNew said there is no
+	// analysis for this job, so a charge standing against it has bought the candidate nothing
+	// — and releasing it if this run also fails is the right answer, not a refund of somebody
+	// else's work.
 	return true, nil
 }
 
@@ -231,6 +253,14 @@ func (s *Service) Run(ctx context.Context, r Request, emit func(matchanalysis.Ev
 	if r.Claim.IsLeader() {
 		defer func() { r.Claim.Release(succeeded) }()
 	}
+	// Nothing produced means nothing owed. Deferred so a panic anywhere below — in the chain,
+	// the emit callback or the cache write — gives the credit back too, rather than leaving a
+	// candidate charged for an analysis that does not exist.
+	defer func() {
+		if !succeeded && r.Reserved {
+			s.release(ctx, r.UserID, r.Job.ID)
+		}
+	}()
 
 	var analysis *matchanalysis.Analysis
 	var err error
@@ -247,9 +277,6 @@ func (s *Service) Run(ctx context.Context, r Request, emit func(matchanalysis.Ev
 	}
 	s.Cache(ctx, r.UserID, r.Job, r.CVUploadedAt, r.Input.Language, analysis)
 	succeeded = true
-	if r.Chargeable {
-		s.charge(ctx, r.UserID, r.Job.ID)
-	}
 	return analysis, nil
 }
 
@@ -271,15 +298,20 @@ var ErrUnavailable = errors.New("fitanalysis: analysis unavailable")
 // autopilot pre-run is exactly the case that must still charge a genuinely new analysis.
 func (s *Service) Follow(ctx context.Context, r Request) (*matchanalysis.Analysis, error) {
 	if !r.Claim.wait() {
+		// The leader produced nothing, so this caller owes nothing either. Its own reservation
+		// is separate from the leader's when the leader was the free autopilot pre-run.
+		if r.Reserved {
+			s.release(ctx, r.UserID, r.Job.ID)
+		}
 		return nil, ErrUnavailable
 	}
 	row, err := s.store.GetUserJobAnalysis(ctx, db.GetUserJobAnalysisParams{UserID: r.UserID, JobID: r.Job.ID})
 	analysis := DecodeAnalysis(row.Analysis)
 	if err != nil || analysis == nil {
+		if r.Reserved {
+			s.release(ctx, r.UserID, r.Job.ID)
+		}
 		return nil, ErrUnavailable
-	}
-	if r.Chargeable {
-		s.charge(ctx, r.UserID, r.Job.ID)
 	}
 	return analysis, nil
 }
@@ -369,15 +401,18 @@ func (s *Service) Cache(ctx context.Context, userID int64, job db.Job, cvUploade
 	}
 }
 
-// charge debits one match against the candidate's points after a fresh analysis has
-// persisted, idempotent by job id. Best-effort: the analysis is already computed and cached,
-// so a debit error (including a rare insufficient-balance race the pre-check let through) is
-// logged, not surfaced.
-func (s *Service) charge(ctx context.Context, userID, jobID int64) {
+// release gives back a credit reserved for a run that produced nothing, and is best-effort:
+// the candidate is already being told the analysis is unavailable, and a failure to return
+// their point is not something to fail them a second time over. It is idempotent, so every
+// failure path may call it without first working out whether it owes one.
+func (s *Service) release(ctx context.Context, userID, jobID int64) {
 	if s.credits == nil {
 		return
 	}
-	if _, err := s.credits.Debit(ctx, userID, credits.FeatureMatch, strconv.FormatInt(jobID, 10)); err != nil {
-		log.Printf("credits: match debit user=%d job=%d: %v", userID, jobID, err)
+	if _, err := s.credits.Release(ctx, userID, credits.FeatureMatch, debitRef(jobID)); err != nil {
+		log.Printf("credits: releasing a match reservation for user %d job %d: %v", userID, jobID, err)
 	}
 }
+
+// debitRef identifies what a match credit was spent on. One charge per job, ever.
+func debitRef(jobID int64) string { return strconv.FormatInt(jobID, 10) }

--- a/internal/candidate/fitanalysis/fitanalysis.go
+++ b/internal/candidate/fitanalysis/fitanalysis.go
@@ -253,11 +253,16 @@ func (s *Service) Run(ctx context.Context, r Request, emit func(matchanalysis.Ev
 	if r.Claim.IsLeader() {
 		defer func() { r.Claim.Release(succeeded) }()
 	}
-	// Nothing produced means nothing owed. Deferred so a panic anywhere below — in the chain,
-	// the emit callback or the cache write — gives the credit back too, rather than leaving a
-	// candidate charged for an analysis that does not exist.
+	// Nothing produced means nothing owed — and whoever RAN THE CHAIN says so for everyone.
+	// Only a leader or a caller that is not coalescing at all reaches Run (a follower goes to
+	// Follow), so this is exactly the caller that knows the outcome. It releases the ref
+	// rather than just its own reservation: when the leader is the free autopilot pre-run, the
+	// charge standing against that ref belongs to a follower about to be told there is nothing.
+	//
+	// Deferred so a panic anywhere below — in the chain, the emit callback or the cache write
+	// — gives the credit back too.
 	defer func() {
-		if !succeeded && r.Reserved {
+		if !succeeded {
 			s.release(ctx, r.UserID, r.Job.ID)
 		}
 	}()
@@ -298,19 +303,15 @@ var ErrUnavailable = errors.New("fitanalysis: analysis unavailable")
 // autopilot pre-run is exactly the case that must still charge a genuinely new analysis.
 func (s *Service) Follow(ctx context.Context, r Request) (*matchanalysis.Analysis, error) {
 	if !r.Claim.wait() {
-		// The leader produced nothing, so this caller owes nothing either. Its own reservation
-		// is separate from the leader's when the leader was the free autopilot pre-run.
-		if r.Reserved {
-			s.release(ctx, r.UserID, r.Job.ID)
-		}
+		// No release here, deliberately. The debit is per (candidate, job) and this caller
+		// shares it with the leader, so giving it back could void a charge the leader's own
+		// result earned — a leader whose CACHE WRITE failed still returned its analysis to
+		// whoever paid for it. The leader releases on failure for everyone; see Run.
 		return nil, ErrUnavailable
 	}
 	row, err := s.store.GetUserJobAnalysis(ctx, db.GetUserJobAnalysisParams{UserID: r.UserID, JobID: r.Job.ID})
 	analysis := DecodeAnalysis(row.Analysis)
 	if err != nil || analysis == nil {
-		if r.Reserved {
-			s.release(ctx, r.UserID, r.Job.ID)
-		}
 		return nil, ErrUnavailable
 	}
 	return analysis, nil
@@ -337,7 +338,15 @@ func (s *Service) Ensure(ctx context.Context, r Request) {
 		return
 	}
 	succeeded := false
-	defer func() { r.Claim.Release(succeeded) }()
+	defer func() {
+		r.Claim.Release(succeeded)
+		// This half never charges, but it can LEAD a paying caller. When it produces nothing,
+		// the follower waiting on it gets nothing either, and the charge standing against this
+		// ref is that follower's — so the leader gives it back on their behalf.
+		if !succeeded {
+			s.release(ctx, r.UserID, r.Job.ID)
+		}
+	}()
 
 	if _, err := s.store.GetUserJobAnalysis(ctx,
 		db.GetUserJobAnalysisParams{UserID: r.UserID, JobID: r.Job.ID}); err == nil {
@@ -409,16 +418,17 @@ func (s *Service) release(ctx context.Context, userID, jobID int64) {
 	if s.credits == nil {
 		return
 	}
-	// A credit buys HAVING the analysis, not the attempt that produced it, and two concurrent
-	// callers for one pair share a single ledger row. So a caller that got nothing must not
-	// void a charge somebody else's result earned: if an analysis exists for this pair, the
-	// charge stands whoever produced it.
+	// A credit buys HAVING the analysis, not the attempt that produced it. A later run that
+	// fails — the autopilot's refresh, a recompute — must not give back the credit an EARLIER
+	// run earned, so a release stops when an analysis exists for the pair.
 	//
-	// The case is real rather than theoretical. A leader whose cache write fails still returns
-	// its analysis to the caller that paid for it; a follower then finds no readable row, and
-	// without this check would release the shared debit and make that served analysis free.
-	if analysis, _, err := s.Cached(ctx, userID, jobID); err == nil && analysis != nil {
-		return
+	// A service with no store cannot answer that question and simply releases: it is the
+	// nil-degrades-rather-than-panics rule the reads already follow, and a tool runs inside an
+	// SSE writer's goroutine where a panic reaches no recover.
+	if s.store != nil {
+		if analysis, _, err := s.Cached(ctx, userID, jobID); err == nil && analysis != nil {
+			return
+		}
 	}
 	if _, err := s.credits.Release(ctx, userID, credits.FeatureMatch, debitRef(jobID)); err != nil {
 		log.Printf("credits: releasing a match reservation for user %d job %d: %v", userID, jobID, err)

--- a/internal/candidate/fitanalysis/fitanalysis.go
+++ b/internal/candidate/fitanalysis/fitanalysis.go
@@ -409,6 +409,17 @@ func (s *Service) release(ctx context.Context, userID, jobID int64) {
 	if s.credits == nil {
 		return
 	}
+	// A credit buys HAVING the analysis, not the attempt that produced it, and two concurrent
+	// callers for one pair share a single ledger row. So a caller that got nothing must not
+	// void a charge somebody else's result earned: if an analysis exists for this pair, the
+	// charge stands whoever produced it.
+	//
+	// The case is real rather than theoretical. A leader whose cache write fails still returns
+	// its analysis to the caller that paid for it; a follower then finds no readable row, and
+	// without this check would release the shared debit and make that served analysis free.
+	if analysis, _, err := s.Cached(ctx, userID, jobID); err == nil && analysis != nil {
+		return
+	}
 	if _, err := s.credits.Release(ctx, userID, credits.FeatureMatch, debitRef(jobID)); err != nil {
 		log.Printf("credits: releasing a match reservation for user %d job %d: %v", userID, jobID, err)
 	}

--- a/internal/candidate/fitanalysis/fitanalysis.go
+++ b/internal/candidate/fitanalysis/fitanalysis.go
@@ -421,24 +421,31 @@ func (s *Service) release(ctx context.Context, userID, jobID int64) {
 	// The cleanup has to survive the cancellation that caused it. A client that disconnects
 	// mid-run cancels the request context, the chain fails with it, and a release on that same
 	// context cannot even open its transaction — leaving the candidate charged for an analysis
-	// they never received, in exactly the case this exists for. Bounded, because a detached
-	// context with no deadline is a goroutine nobody will ever stop.
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), releaseTimeout)
-	defer cancel()
+	// they never received, in exactly the case this exists for.
+	detached := context.WithoutCancel(ctx)
 
 	// A credit buys HAVING the analysis, not the attempt that produced it. A later run that
-	// fails — the autopilot's refresh, a recompute — must not give back the credit an EARLIER
+	// fails — a recompute, the autopilot's refresh — must not give back the credit an EARLIER
 	// run earned, so a release stops when an analysis exists for the pair.
 	//
 	// A service with no store cannot answer that question and simply releases: it is the
 	// nil-degrades-rather-than-panics rule the reads already follow, and a tool runs inside an
-	// SSE writer's goroutine where a panic reaches no recover.
+	// SSE writer's goroutine where a panic reaches no recover. A read that FAILS releases too —
+	// an unanswered question is not a yes, and leaving a candidate charged is the worse error.
 	if s.store != nil {
-		if analysis, _, err := s.Cached(ctx, userID, jobID); err == nil && analysis != nil {
+		read, cancelRead := context.WithTimeout(detached, releaseTimeout)
+		analysis, _, err := s.Cached(read, userID, jobID)
+		cancelRead()
+		if err == nil && analysis != nil {
 			return
 		}
 	}
-	if _, err := s.credits.Release(ctx, userID, credits.FeatureMatch, debitRef(jobID)); err != nil {
+
+	// Its own budget, not the read's leftovers: a slow cache read must not spend the deadline
+	// the refund needs and leave the reservation standing.
+	write, cancel := context.WithTimeout(detached, releaseTimeout)
+	defer cancel()
+	if _, err := s.credits.Release(write, userID, credits.FeatureMatch, debitRef(jobID)); err != nil {
 		log.Printf("credits: releasing a match reservation for user %d job %d: %v", userID, jobID, err)
 	}
 }

--- a/internal/candidate/fitanalysis/fitanalysis_test.go
+++ b/internal/candidate/fitanalysis/fitanalysis_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -50,13 +51,23 @@ func (f *fakeStore) ListUserJobAnalyses(context.Context, int64) ([]db.ListUserJo
 	return f.list, nil
 }
 
-// fakeMeter records what the service asked the ledger for, so a test can assert on the charge
-// that was NOT made — which is most of what matters here.
+// fakeMeter is a ledger that actually holds a balance, because the rule under test is that the
+// DEBIT is the gate: a fake that only recorded calls could not show a second reservation being
+// refused by the first one having landed.
 type fakeMeter struct {
 	remaining int
 	cost      int
 	balErr    error
+	debitErr  error
 	debits    []string
+	releases  []string
+	// charged is the ledger's idempotency by (feature, ref): a second debit for a ref already
+	// charged takes nothing more.
+	charged map[string]bool
+}
+
+func newMeter(remaining, cost int) *fakeMeter {
+	return &fakeMeter{remaining: remaining, cost: cost, charged: map[string]bool{}}
 }
 
 func (m *fakeMeter) Balance(context.Context, int64) (credits.Balance, error) {
@@ -69,8 +80,28 @@ func (m *fakeMeter) Balance(context.Context, int64) (credits.Balance, error) {
 func (m *fakeMeter) Cost(credits.Feature) int { return m.cost }
 
 func (m *fakeMeter) Debit(_ context.Context, _ int64, f credits.Feature, ref string) (credits.Balance, error) {
+	if m.debitErr != nil {
+		return credits.Balance{Remaining: m.remaining}, m.debitErr
+	}
+	if m.charged[ref] {
+		return credits.Balance{Remaining: m.remaining}, nil // idempotent: already spent on this ref
+	}
+	if m.remaining < m.cost {
+		return credits.Balance{Remaining: m.remaining}, credits.ErrInsufficient
+	}
+	m.remaining -= m.cost
+	m.charged[ref] = true
 	m.debits = append(m.debits, string(f)+":"+ref)
-	return credits.Balance{Remaining: m.remaining - m.cost}, nil
+	return credits.Balance{Remaining: m.remaining}, nil
+}
+
+func (m *fakeMeter) Release(_ context.Context, _ int64, f credits.Feature, ref string) (credits.Balance, error) {
+	if m.charged[ref] {
+		delete(m.charged, ref)
+		m.remaining += m.cost
+		m.releases = append(m.releases, string(f)+":"+ref)
+	}
+	return credits.Balance{Remaining: m.remaining}, nil
 }
 
 func cachedRow(t *testing.T, score int) *db.GetUserJobAnalysisRow {
@@ -87,75 +118,119 @@ func newService(store fitanalysis.Store, meter fitanalysis.Meter) *fitanalysis.S
 	return fitanalysis.New(store, meter, matchanalysis.NewAnalyzer(nil))
 }
 
-// TestAuthorize is the credit rule, which used to be reachable only through a *fiber.Ctx.
-func TestAuthorize(t *testing.T) {
-	t.Run("a first analysis of a job is chargeable", func(t *testing.T) {
-		svc := newService(&fakeStore{}, &fakeMeter{remaining: 10, cost: 1})
-		chargeable, err := svc.Authorize(context.Background(), userID, jobID)
+// TestReserve is the credit rule, and it is now the GATE: the atomic debit decides, so a check
+// that two concurrent runs could both pass no longer exists.
+func TestReserve(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("a first analysis of a job takes the credit up front", func(t *testing.T) {
+		meter := newMeter(10, 1)
+		svc := newService(&fakeStore{}, meter)
+
+		reserved, err := svc.Reserve(ctx, userID, jobID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if !chargeable {
-			t.Error("a never-analysed job must be chargeable")
+		if !reserved {
+			t.Error("a never-analysed job must reserve")
+		}
+		if len(meter.debits) != 1 || meter.debits[0] != "match:7" {
+			t.Errorf("debits = %v, want the charge taken BEFORE the chain", meter.debits)
+		}
+		if meter.remaining != 9 {
+			t.Errorf("remaining = %d, want 9 — the credit is held, not merely checked", meter.remaining)
 		}
 	})
 
-	t.Run("a recompute is free and never gated", func(t *testing.T) {
-		// No points at all: a recompute must still be allowed, which is what keeps an
-		// analysis cached before credits shipped re-runnable.
-		svc := newService(&fakeStore{row: cachedRow(t, 80)}, &fakeMeter{remaining: 0, cost: 1})
-		chargeable, err := svc.Authorize(context.Background(), userID, jobID)
+	t.Run("a recompute is free and takes nothing", func(t *testing.T) {
+		meter := newMeter(0, 1) // no points at all
+		svc := newService(&fakeStore{row: cachedRow(t, 80)}, meter)
+
+		reserved, err := svc.Reserve(ctx, userID, jobID)
 		if err != nil {
 			t.Fatalf("a recompute must not be refused: %v", err)
 		}
-		if chargeable {
-			t.Error("a recompute must not be chargeable")
+		if reserved || len(meter.debits) != 0 {
+			t.Errorf("reserved=%v debits=%v, want a free recompute", reserved, meter.debits)
 		}
 	})
 
-	t.Run("a first analysis with too few points is refused, with the balance", func(t *testing.T) {
-		svc := newService(&fakeStore{}, &fakeMeter{remaining: 0, cost: 1})
-		_, err := svc.Authorize(context.Background(), userID, jobID)
+	t.Run("too few points is refused, with the balance", func(t *testing.T) {
+		meter := newMeter(0, 1)
+		svc := newService(&fakeStore{}, meter)
+
+		_, err := svc.Reserve(ctx, userID, jobID)
 		var refused *fitanalysis.InsufficientCreditsError
 		if !errors.As(err, &refused) {
 			t.Fatalf("err = %v, want *InsufficientCreditsError", err)
 		}
 		if refused.Balance.Remaining != 0 {
-			t.Errorf("refusal carries remaining = %d, want 0 — the caller renders it", refused.Balance.Remaining)
+			t.Errorf("refusal carries remaining = %d, want 0", refused.Balance.Remaining)
 		}
 	})
 
-	t.Run("exactly enough points is allowed", func(t *testing.T) {
-		svc := newService(&fakeStore{}, &fakeMeter{remaining: 1, cost: 1})
-		if _, err := svc.Authorize(context.Background(), userID, jobID); err != nil {
-			t.Fatalf("a balance equal to the cost must be affordable: %v", err)
+	// THE RACE. Two never-analysed jobs, one credit. Before the ledger became the gate both
+	// passed a balance check, both ran the chain, and the loser's debit failed silently after
+	// its analysis had been computed, cached and served.
+	t.Run("one credit cannot fund two different jobs", func(t *testing.T) {
+		meter := newMeter(1, 1)
+		svc := newService(&fakeStore{}, meter)
+
+		if _, err := svc.Reserve(ctx, userID, 100); err != nil {
+			t.Fatalf("the first run must be affordable: %v", err)
+		}
+		_, err := svc.Reserve(ctx, userID, 200)
+		var refused *fitanalysis.InsufficientCreditsError
+		if !errors.As(err, &refused) {
+			t.Fatalf("second job err = %v, want *InsufficientCreditsError — one credit funds one job", err)
+		}
+		if len(meter.debits) != 1 {
+			t.Errorf("debits = %v, want exactly one — the second run never got its credit", meter.debits)
 		}
 	})
 
-	t.Run("an unreadable balance never refuses", func(t *testing.T) {
-		// Best-effort: the atomic Debit is the real ceiling, so a transient read failure
-		// must not 402 a caller who can in fact afford the run.
-		svc := newService(&fakeStore{}, &fakeMeter{balErr: errors.New("db down"), cost: 1})
-		chargeable, err := svc.Authorize(context.Background(), userID, jobID)
+	t.Run("two callers for the SAME job collapse into one charge", func(t *testing.T) {
+		// Two tabs on one never-analysed job is neither a double charge nor a discount.
+		meter := newMeter(10, 1)
+		svc := newService(&fakeStore{}, meter)
+
+		for i := range 2 {
+			if _, err := svc.Reserve(ctx, userID, jobID); err != nil {
+				t.Fatalf("caller %d: %v", i, err)
+			}
+		}
+		if meter.remaining != 9 || len(meter.debits) != 1 {
+			t.Errorf("remaining=%d debits=%v, want one charge for one job", meter.remaining, meter.debits)
+		}
+	})
+
+	t.Run("metering fails open", func(t *testing.T) {
+		// Bookkeeping must never be able to refuse a legitimate analysis. An uncharged run is
+		// a smaller wrong than a candidate blocked by our accounting.
+		meter := newMeter(10, 1)
+		meter.debitErr = errors.New("ledger unreachable")
+		svc := newService(&fakeStore{}, meter)
+
+		reserved, err := svc.Reserve(ctx, userID, jobID)
 		if err != nil {
-			t.Fatalf("a balance read failure must not refuse: %v", err)
+			t.Fatalf("an unreachable ledger must not refuse: %v", err)
 		}
-		if !chargeable {
-			t.Error("the run is still a first analysis, so still chargeable")
+		if reserved {
+			t.Error("nothing was reserved, so nothing may be released later")
 		}
 	})
 
-	t.Run("no meter wired means no gate", func(t *testing.T) {
+	t.Run("no meter wired reserves nothing and refuses nothing", func(t *testing.T) {
 		svc := newService(&fakeStore{}, nil)
-		chargeable, err := svc.Authorize(context.Background(), userID, jobID)
-		if err != nil || !chargeable {
-			t.Fatalf("chargeable=%v err=%v, want true/nil with no ledger", chargeable, err)
+		reserved, err := svc.Reserve(ctx, userID, jobID)
+		if err != nil || reserved {
+			t.Fatalf("reserved=%v err=%v, want false/nil with no ledger", reserved, err)
 		}
 	})
 
 	t.Run("a store failure is an error, not a free pass", func(t *testing.T) {
-		svc := newService(&fakeStore{readErr: errors.New("db down")}, &fakeMeter{remaining: 10, cost: 1})
-		if _, err := svc.Authorize(context.Background(), userID, jobID); err == nil {
+		svc := newService(&fakeStore{readErr: errors.New("db down")}, newMeter(10, 1))
+		if _, err := svc.Reserve(ctx, userID, jobID); err == nil {
 			t.Error("a cache read failure must surface, not be read as 'never analysed'")
 		}
 	})
@@ -203,6 +278,14 @@ func TestCached(t *testing.T) {
 	})
 }
 
+// reserve stands in for the caller having paid before it reached the code under test.
+func reserve(t *testing.T, m *fakeMeter, jobID int64) {
+	t.Helper()
+	if _, err := m.Debit(context.Background(), userID, credits.FeatureMatch, strconv.FormatInt(jobID, 10)); err != nil {
+		t.Fatalf("seed reservation: %v", err)
+	}
+}
+
 func TestFollow(t *testing.T) {
 	ctx := context.Background()
 
@@ -219,18 +302,21 @@ func TestFollow(t *testing.T) {
 		// The row is present and readable: only run.succeeded says the leader failed, and
 		// serving this row would dress a stale analysis up as the live result.
 		store := &fakeStore{row: cachedRow(t, 80)}
-		meter := &fakeMeter{remaining: 10, cost: 1}
+		meter := newMeter(10, 1)
 		svc := newService(store, meter)
+		// This caller reserved before it started waiting, exactly as the streaming path does.
+		reserve(t, meter, jobID)
 
 		_, err := svc.Follow(ctx, fitanalysis.Request{
-			UserID: userID, Job: db.Job{ID: jobID}, Chargeable: true,
+			UserID: userID, Job: db.Job{ID: jobID}, Reserved: true,
 			Claim: followerOf(svc, false),
 		})
 		if !errors.Is(err, fitanalysis.ErrUnavailable) {
 			t.Fatalf("err = %v, want ErrUnavailable", err)
 		}
-		if len(meter.debits) != 0 {
-			t.Errorf("debits = %v, want none — nothing was served", meter.debits)
+		// The caller had already paid before waiting; nothing was served, so it gets it back.
+		if len(meter.releases) != 1 {
+			t.Errorf("releases = %v, want the reservation given back", meter.releases)
 		}
 	})
 
@@ -238,11 +324,12 @@ func TestFollow(t *testing.T) {
 		// The leader here stands in for the autopilot's free pre-run: it never charges, so
 		// the follower's own genuinely-new analysis must still be billed once.
 		store := &fakeStore{row: cachedRow(t, 80)}
-		meter := &fakeMeter{remaining: 10, cost: 1}
+		meter := newMeter(10, 1)
 		svc := newService(store, meter)
+		reserve(t, meter, jobID)
 
 		analysis, err := svc.Follow(ctx, fitanalysis.Request{
-			UserID: userID, Job: db.Job{ID: jobID}, Chargeable: true,
+			UserID: userID, Job: db.Job{ID: jobID}, Reserved: true,
 			Claim: followerOf(svc, true),
 		})
 		if err != nil {
@@ -251,28 +338,29 @@ func TestFollow(t *testing.T) {
 		if analysis == nil || analysis.OverallScore != 80 {
 			t.Fatalf("analysis = %+v, want the leader's cached one", analysis)
 		}
-		if len(meter.debits) != 1 || meter.debits[0] != "match:7" {
-			t.Errorf("debits = %v, want exactly [match:7]", meter.debits)
+		// The caller reserved before waiting and the result is real, so the charge stands.
+		if len(meter.releases) != 0 {
+			t.Errorf("releases = %v, want none — a served analysis is paid for", meter.releases)
 		}
 	})
 
 	t.Run("a recompute follower pays nothing", func(t *testing.T) {
-		meter := &fakeMeter{remaining: 10, cost: 1}
+		meter := newMeter(10, 1)
 		svc := newService(&fakeStore{row: cachedRow(t, 80)}, meter)
 
 		if _, err := svc.Follow(ctx, fitanalysis.Request{
-			UserID: userID, Job: db.Job{ID: jobID}, Chargeable: false,
+			UserID: userID, Job: db.Job{ID: jobID}, Reserved: false,
 			Claim: followerOf(svc, true),
 		}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if len(meter.debits) != 0 {
-			t.Errorf("debits = %v, want none — this caller owed nothing", meter.debits)
+		if len(meter.releases) != 0 {
+			t.Errorf("releases = %v, want none — this caller reserved nothing", meter.releases)
 		}
 	})
 
 	t.Run("a leader that succeeded but left nothing readable is unavailable", func(t *testing.T) {
-		svc := newService(&fakeStore{}, &fakeMeter{remaining: 10, cost: 1})
+		svc := newService(&fakeStore{}, newMeter(10, 1))
 		if _, err := svc.Follow(ctx, fitanalysis.Request{
 			UserID: userID, Job: db.Job{ID: jobID},
 			Claim: followerOf(svc, true),
@@ -287,23 +375,24 @@ func TestFollow(t *testing.T) {
 // told the cache is good.
 func TestEnsureShortCircuitsOnACachedAnalysis(t *testing.T) {
 	store := &fakeStore{row: cachedRow(t, 80)}
-	meter := &fakeMeter{remaining: 10, cost: 1}
+	meter := newMeter(10, 1)
 	svc := newService(store, meter)
 
 	leader := svc.Claim(userID, jobID)
 	follower := svc.Claim(userID, jobID)
 
-	// Chargeable is deliberately true: Ensure must ignore it, never charge, and never be
-	// made metered by a caller that filled the field in.
+	// Reserved is deliberately true: Ensure must ignore it, never charge and never release,
+	// and never be made metered by a caller that filled the field in.
 	svc.Ensure(context.Background(), fitanalysis.Request{
-		UserID: userID, Job: db.Job{ID: jobID}, Chargeable: true, Claim: leader,
+		UserID: userID, Job: db.Job{ID: jobID}, Reserved: true, Claim: leader,
 	})
 
 	if len(store.upserted) != 0 {
 		t.Errorf("upserts = %d, want 0 — an already-cached analysis is not recomputed", len(store.upserted))
 	}
-	if len(meter.debits) != 0 {
-		t.Errorf("debits = %v, want none — the cold-start pre-run is unmetered by design", meter.debits)
+	if len(meter.debits) != 0 || len(meter.releases) != 0 {
+		t.Errorf("debits=%v releases=%v, want none — the cold-start pre-run is unmetered by design",
+			meter.debits, meter.releases)
 	}
 
 	// The follower must be released, and told the cache is trustworthy.
@@ -438,5 +527,68 @@ func TestProjectTailoring(t *testing.T) {
 	}
 	if got.Job.Slug != "senior-backend-acme" || got.Verdict != "Good Fit" || got.OverallScore != 71 {
 		t.Errorf("projection = %+v, want the vacancy and verdict carried through", got)
+	}
+}
+
+// TestRunReleasesTheReservationWhenNothingIsProduced is the other half of making the debit the
+// gate: taking the credit up front is only honest if a run that produces nothing gives it back.
+// Otherwise closing the race would have cost candidates money on every failed analysis.
+func TestRunReleasesTheReservationWhenNothingIsProduced(t *testing.T) {
+	ctx := context.Background()
+	store := &fakeStore{}
+	meter := newMeter(10, 1)
+	svc := newService(store, meter)
+
+	reserved, err := svc.Reserve(ctx, userID, jobID)
+	if err != nil || !reserved {
+		t.Fatalf("Reserve = %v, %v; want a reservation", reserved, err)
+	}
+	if meter.remaining != 9 {
+		t.Fatalf("remaining = %d, want the credit held", meter.remaining)
+	}
+
+	// A nil client makes Analyze answer (nil, nil): the LLM is unconfigured, so nothing is
+	// computed and nothing cached.
+	analysis, err := svc.Run(ctx, fitanalysis.Request{
+		UserID: userID, Job: db.Job{ID: jobID}, Reserved: reserved,
+		Analyzer: matchanalysis.NewAnalyzer(nil),
+	}, nil)
+	if err != nil || analysis != nil {
+		t.Fatalf("Run = %v, %v; want nil/nil for an unconfigured LLM", analysis, err)
+	}
+
+	if meter.remaining != 10 {
+		t.Errorf("remaining = %d, want 10 — a failed analysis costs nothing", meter.remaining)
+	}
+	if len(meter.releases) != 1 {
+		t.Errorf("releases = %v, want the reservation given back", meter.releases)
+	}
+	if len(store.upserted) != 0 {
+		t.Errorf("upserts = %d, want 0 — nothing was produced to cache", len(store.upserted))
+	}
+
+	// And the ref is chargeable again, so the candidate's retry is charged once, not never.
+	again, err := svc.Reserve(ctx, userID, jobID)
+	if err != nil || !again {
+		t.Fatalf("retry Reserve = %v, %v; a released ref must be chargeable again", again, err)
+	}
+}
+
+// TestRunKeepsTheReservationWhenItProducesAnAnalysis is the companion: a run that delivers is
+// paid for, and the release path must not fire on success.
+func TestRunKeepsTheReservationWhenItProducesAnAnalysis(t *testing.T) {
+	// Run's success branch needs a real analyzer, which needs a model; the streamed and
+	// on-demand success paths are covered end to end by the tagged handler tests. What is
+	// checked here is the accounting either side of it: Reserve holds, and nothing releases
+	// unless the run says it produced nothing.
+	ctx := context.Background()
+	meter := newMeter(10, 1)
+	svc := newService(&fakeStore{}, meter)
+
+	if _, err := svc.Reserve(ctx, userID, jobID); err != nil {
+		t.Fatalf("Reserve: %v", err)
+	}
+	if meter.remaining != 9 || len(meter.releases) != 0 {
+		t.Fatalf("remaining=%d releases=%v after reserving", meter.remaining, meter.releases)
 	}
 }

--- a/internal/candidate/fitanalysis/fitanalysis_test.go
+++ b/internal/candidate/fitanalysis/fitanalysis_test.go
@@ -723,3 +723,31 @@ func TestACancelledRunStillGivesTheCreditBack(t *testing.T) {
 		t.Errorf("releases = %v, want the reservation given back despite the cancellation", meter.releases)
 	}
 }
+
+// TestAFailedEarnedCheckStillGivesTheCreditBack pins the direction the cleanup errs in. The
+// check that stops a release — "does an analysis already exist for this pair?" — is a database
+// read, and it can fail or time out. An unanswered question is not a yes: leaving a candidate
+// charged for a run that produced nothing is the worse of the two errors.
+func TestAFailedEarnedCheckStillGivesTheCreditBack(t *testing.T) {
+	ctx := context.Background()
+	meter := newMeter(10, 1)
+	store := &fakeStore{}
+	svc := newService(store, meter)
+
+	if _, err := svc.Reserve(ctx, userID, jobID); err != nil {
+		t.Fatalf("Reserve: %v", err)
+	}
+	// From here the cache is unreadable, so the release cannot learn whether anything exists.
+	store.readErr = errors.New("db down")
+
+	if _, err := svc.Run(ctx, fitanalysis.Request{
+		UserID: userID, Job: db.Job{ID: jobID}, Reserved: true,
+		Analyzer: matchanalysis.NewAnalyzer(nil),
+	}, nil); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if meter.remaining != 10 {
+		t.Errorf("remaining = %d, want 10 — an unanswerable check must not keep the charge", meter.remaining)
+	}
+}

--- a/internal/candidate/fitanalysis/fitanalysis_test.go
+++ b/internal/candidate/fitanalysis/fitanalysis_test.go
@@ -95,7 +95,13 @@ func (m *fakeMeter) Debit(_ context.Context, _ int64, f credits.Feature, ref str
 	return credits.Balance{Remaining: m.remaining}, nil
 }
 
-func (m *fakeMeter) Release(_ context.Context, _ int64, f credits.Feature, ref string) (credits.Balance, error) {
+func (m *fakeMeter) Release(ctx context.Context, _ int64, f credits.Feature, ref string) (credits.Balance, error) {
+	// A real ledger opens a transaction, so a cancelled context means the release never
+	// happens. Modelling that is the only way a test can show the cleanup outliving the
+	// cancellation that triggered it.
+	if err := ctx.Err(); err != nil {
+		return credits.Balance{Remaining: m.remaining}, err
+	}
 	if m.charged[ref] {
 		delete(m.charged, ref)
 		m.remaining += m.cost
@@ -681,5 +687,39 @@ func TestAFollowerNeverReleasesOnItsOwn(t *testing.T) {
 	}
 	if meter.remaining != 9 {
 		t.Errorf("remaining = %d, want 9 — the served analysis stays paid for", meter.remaining)
+	}
+}
+
+// TestACancelledRunStillGivesTheCreditBack is the disconnect case. The on-demand endpoint runs
+// on the request's own context, so a client that walks away mid-analysis cancels it — the chain
+// fails with the cancellation, and a release on that same context could not even open its
+// transaction. The candidate would stay charged for an analysis they never received, in exactly
+// the situation the release exists for.
+func TestACancelledRunStillGivesTheCreditBack(t *testing.T) {
+	meter := newMeter(10, 1)
+	svc := newService(&fakeStore{}, meter)
+
+	if _, err := svc.Reserve(context.Background(), userID, jobID); err != nil {
+		t.Fatalf("Reserve: %v", err)
+	}
+	if meter.remaining != 9 {
+		t.Fatalf("remaining = %d, want the credit held", meter.remaining)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the reader is gone before the run even starts
+
+	if _, err := svc.Run(ctx, fitanalysis.Request{
+		UserID: userID, Job: db.Job{ID: jobID}, Reserved: true,
+		Analyzer: matchanalysis.NewAnalyzer(nil),
+	}, nil); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if meter.remaining != 10 {
+		t.Errorf("remaining = %d, want 10 — a run nobody waited for still costs nothing", meter.remaining)
+	}
+	if len(meter.releases) != 1 {
+		t.Errorf("releases = %v, want the reservation given back despite the cancellation", meter.releases)
 	}
 }

--- a/internal/candidate/fitanalysis/fitanalysis_test.go
+++ b/internal/candidate/fitanalysis/fitanalysis_test.go
@@ -286,25 +286,43 @@ func reserve(t *testing.T, m *fakeMeter, jobID int64) {
 	}
 }
 
+// followerOf claims for the leader, then again for a follower, and releases the leader with the
+// given outcome — the shape a streaming caller is in when it loses the race.
+func followerOf(svc *fitanalysis.Service, leaderSucceeded bool) *fitanalysis.Claim {
+	leader := svc.Claim(userID, jobID)
+	follower := svc.Claim(userID, jobID)
+	leader.Release(leaderSucceeded)
+	return follower
+}
+
 func TestFollow(t *testing.T) {
 	ctx := context.Background()
 
-	// followerOf claims for the leader, then again for a follower, and releases the leader
-	// with the given outcome — the shape the streaming caller is in when it loses the race.
-	followerOf := func(svc *fitanalysis.Service, leaderSucceeded bool) *fitanalysis.Claim {
-		leader := svc.Claim(userID, jobID)
-		follower := svc.Claim(userID, jobID)
-		leader.Release(leaderSucceeded)
-		return follower
-	}
-
 	t.Run("a failed leader is reported, never papered over with the older row", func(t *testing.T) {
 		// The row is present and readable: only run.succeeded says the leader failed, and
-		// serving this row would dress a stale analysis up as the live result.
+		// serving this row would dress a stale analysis up as the live result. Reserved is
+		// false because a cached analysis is exactly what makes a run free.
 		store := &fakeStore{row: cachedRow(t, 80)}
 		meter := newMeter(10, 1)
 		svc := newService(store, meter)
-		// This caller reserved before it started waiting, exactly as the streaming path does.
+
+		_, err := svc.Follow(ctx, fitanalysis.Request{
+			UserID: userID, Job: db.Job{ID: jobID}, Reserved: false,
+			Claim: followerOf(svc, false),
+		})
+		if !errors.Is(err, fitanalysis.ErrUnavailable) {
+			t.Fatalf("err = %v, want ErrUnavailable", err)
+		}
+		if len(meter.releases) != 0 {
+			t.Errorf("releases = %v, want none — this caller reserved nothing", meter.releases)
+		}
+	})
+
+	t.Run("a failed leader gives this caller's reservation back", func(t *testing.T) {
+		// Nothing cached, so this caller genuinely reserved; the leader — typically the free
+		// autopilot pre-run — produced nothing, so there is nothing to pay for.
+		meter := newMeter(10, 1)
+		svc := newService(&fakeStore{}, meter)
 		reserve(t, meter, jobID)
 
 		_, err := svc.Follow(ctx, fitanalysis.Request{
@@ -314,9 +332,11 @@ func TestFollow(t *testing.T) {
 		if !errors.Is(err, fitanalysis.ErrUnavailable) {
 			t.Fatalf("err = %v, want ErrUnavailable", err)
 		}
-		// The caller had already paid before waiting; nothing was served, so it gets it back.
 		if len(meter.releases) != 1 {
 			t.Errorf("releases = %v, want the reservation given back", meter.releases)
+		}
+		if meter.remaining != 10 {
+			t.Errorf("remaining = %d, want 10 — a run that produced nothing costs nothing", meter.remaining)
 		}
 	})
 
@@ -590,5 +610,38 @@ func TestRunKeepsTheReservationWhenItProducesAnAnalysis(t *testing.T) {
 	}
 	if meter.remaining != 9 || len(meter.releases) != 0 {
 		t.Fatalf("remaining=%d releases=%v after reserving", meter.remaining, meter.releases)
+	}
+}
+
+// TestReleaseNeverVoidsACreditAnExistingAnalysisEarned is the shared-ledger-row rule. A credit
+// buys HAVING the analysis, and two concurrent callers for one (candidate, job) share a single
+// debit — so a caller that got nothing must not void a charge somebody else's result earned.
+//
+// The live case: a leader whose CACHE WRITE fails still returns its analysis to the caller that
+// paid for it. A follower then finds no readable row and, without this rule, would release the
+// shared debit and make that served analysis free.
+func TestReleaseNeverVoidsACreditAnExistingAnalysisEarned(t *testing.T) {
+	ctx := context.Background()
+	meter := newMeter(10, 1)
+	// An analysis exists for the pair — whoever produced it, the charge is earned.
+	svc := newService(&fakeStore{row: cachedRow(t, 80)}, meter)
+	reserve(t, meter, jobID)
+	if meter.remaining != 9 {
+		t.Fatalf("remaining = %d, want the credit held", meter.remaining)
+	}
+
+	// A caller that believes it owes nothing tries to give the credit back.
+	if _, err := svc.Follow(ctx, fitanalysis.Request{
+		UserID: userID, Job: db.Job{ID: jobID}, Reserved: true,
+		Claim: followerOf(svc, false),
+	}); !errors.Is(err, fitanalysis.ErrUnavailable) {
+		t.Fatalf("err = %v, want ErrUnavailable", err)
+	}
+
+	if len(meter.releases) != 0 {
+		t.Errorf("releases = %v, want none — an analysis exists, so the charge stands", meter.releases)
+	}
+	if meter.remaining != 9 {
+		t.Errorf("remaining = %d, want 9 — the served analysis stays paid for", meter.remaining)
 	}
 }

--- a/internal/candidate/fitanalysis/fitanalysis_test.go
+++ b/internal/candidate/fitanalysis/fitanalysis_test.go
@@ -318,28 +318,6 @@ func TestFollow(t *testing.T) {
 		}
 	})
 
-	t.Run("a failed leader gives this caller's reservation back", func(t *testing.T) {
-		// Nothing cached, so this caller genuinely reserved; the leader — typically the free
-		// autopilot pre-run — produced nothing, so there is nothing to pay for.
-		meter := newMeter(10, 1)
-		svc := newService(&fakeStore{}, meter)
-		reserve(t, meter, jobID)
-
-		_, err := svc.Follow(ctx, fitanalysis.Request{
-			UserID: userID, Job: db.Job{ID: jobID}, Reserved: true,
-			Claim: followerOf(svc, false),
-		})
-		if !errors.Is(err, fitanalysis.ErrUnavailable) {
-			t.Fatalf("err = %v, want ErrUnavailable", err)
-		}
-		if len(meter.releases) != 1 {
-			t.Errorf("releases = %v, want the reservation given back", meter.releases)
-		}
-		if meter.remaining != 10 {
-			t.Errorf("remaining = %d, want 10 — a run that produced nothing costs nothing", meter.remaining)
-		}
-	})
-
 	t.Run("a successful leader's result is replayed and this caller still pays", func(t *testing.T) {
 		// The leader here stands in for the autopilot's free pre-run: it never charges, so
 		// the follower's own genuinely-new analysis must still be billed once.
@@ -613,33 +591,93 @@ func TestRunKeepsTheReservationWhenItProducesAnAnalysis(t *testing.T) {
 	}
 }
 
-// TestReleaseNeverVoidsACreditAnExistingAnalysisEarned is the shared-ledger-row rule. A credit
-// buys HAVING the analysis, and two concurrent callers for one (candidate, job) share a single
-// debit — so a caller that got nothing must not void a charge somebody else's result earned.
-//
-// The live case: a leader whose CACHE WRITE fails still returns its analysis to the caller that
-// paid for it. A follower then finds no readable row and, without this rule, would release the
-// shared debit and make that served analysis free.
-func TestReleaseNeverVoidsACreditAnExistingAnalysisEarned(t *testing.T) {
+// TestReleaseNeverVoidsACreditAnEarlierRunEarned pins the other half of the rule: a LATER run
+// that fails — the autopilot's refresh, a recompute — must not give back the credit an earlier
+// run already earned. A credit buys HAVING the analysis, not the attempt that produced it.
+func TestReleaseNeverVoidsACreditAnEarlierRunEarned(t *testing.T) {
 	ctx := context.Background()
 	meter := newMeter(10, 1)
-	// An analysis exists for the pair — whoever produced it, the charge is earned.
+	// An analysis exists for the pair, and it was paid for.
 	svc := newService(&fakeStore{row: cachedRow(t, 80)}, meter)
+	reserve(t, meter, jobID)
+
+	// A recompute runs later and produces nothing. It reaches the release (it ran the chain),
+	// and the guard is what stops it giving back the earlier run's credit.
+	if _, err := svc.Run(ctx, fitanalysis.Request{
+		UserID: userID, Job: db.Job{ID: jobID},
+		Analyzer: matchanalysis.NewAnalyzer(nil),
+	}, nil); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(meter.releases) != 0 {
+		t.Errorf("releases = %v, want none — the analysis it was paid for still exists", meter.releases)
+	}
+	if meter.remaining != 9 {
+		t.Errorf("remaining = %d, want 9", meter.remaining)
+	}
+}
+
+// TestAFreeLeaderReleasesThePayingFollowersCredit is why the release belongs to whoever ran the
+// chain rather than to whoever paid. The autopilot's cold-start pre-run leads for free; a
+// streaming caller reserved and is following it. When the pre-run produces nothing, the
+// follower is told the analysis is unavailable — and the charge standing against that pair is
+// theirs, so the leader gives it back on their behalf.
+func TestAFreeLeaderReleasesThePayingFollowersCredit(t *testing.T) {
+	ctx := context.Background()
+	meter := newMeter(10, 1)
+	svc := newService(&fakeStore{}, meter)
+
+	// The streaming caller reserved before it started following.
 	reserve(t, meter, jobID)
 	if meter.remaining != 9 {
 		t.Fatalf("remaining = %d, want the credit held", meter.remaining)
 	}
 
-	// A caller that believes it owes nothing tries to give the credit back.
+	leader := svc.Claim(userID, jobID)
+	follower := svc.Claim(userID, jobID)
+
+	// The pre-run: nothing cached, a nil client, so it computes nothing. Reserved is false —
+	// this half never charges.
+	svc.Ensure(ctx, fitanalysis.Request{
+		UserID: userID, Job: db.Job{ID: jobID}, Claim: leader,
+		Analyzer: matchanalysis.NewAnalyzer(nil),
+	})
+
+	if _, err := svc.Follow(ctx, fitanalysis.Request{
+		UserID: userID, Job: db.Job{ID: jobID}, Reserved: true, Claim: follower,
+	}); !errors.Is(err, fitanalysis.ErrUnavailable) {
+		t.Fatalf("follower err = %v, want ErrUnavailable", err)
+	}
+
+	if meter.remaining != 10 {
+		t.Errorf("remaining = %d, want 10 — nobody got an analysis, so nobody pays", meter.remaining)
+	}
+	if len(meter.releases) != 1 {
+		t.Errorf("releases = %v, want exactly one, from the leader", meter.releases)
+	}
+}
+
+// TestAFollowerNeverReleasesOnItsOwn is the other side: the debit is per (candidate, job) and
+// shared, so a follower giving it back could void a charge the leader's result earned. The
+// route that matters is a leader whose CACHE WRITE fails — it still returned its analysis to
+// whoever paid for it, and leaves no row for the follower to read.
+func TestAFollowerNeverReleasesOnItsOwn(t *testing.T) {
+	ctx := context.Background()
+	meter := newMeter(10, 1)
+	// No row: the leader "succeeded" but its cache write did not land.
+	svc := newService(&fakeStore{}, meter)
+	reserve(t, meter, jobID)
+
 	if _, err := svc.Follow(ctx, fitanalysis.Request{
 		UserID: userID, Job: db.Job{ID: jobID}, Reserved: true,
-		Claim: followerOf(svc, false),
+		Claim: followerOf(svc, true), // leader reports success
 	}); !errors.Is(err, fitanalysis.ErrUnavailable) {
 		t.Fatalf("err = %v, want ErrUnavailable", err)
 	}
 
 	if len(meter.releases) != 0 {
-		t.Errorf("releases = %v, want none — an analysis exists, so the charge stands", meter.releases)
+		t.Errorf("releases = %v, want none — the leader was served and earned the charge", meter.releases)
 	}
 	if meter.remaining != 9 {
 		t.Errorf("remaining = %d, want 9 — the served analysis stays paid for", meter.remaining)

--- a/internal/platform/db/credits.sql.go
+++ b/internal/platform/db/credits.sql.go
@@ -37,6 +37,43 @@ func (q *Queries) DebitExists(ctx context.Context, arg DebitExistsParams) (bool,
 	return exists, err
 }
 
+const deleteDebit = `-- name: DeleteDebit :execrows
+DELETE FROM credit_ledger
+WHERE user_id = $1
+  AND kind = 'debit'
+  AND feature = $2::text
+  AND ref = $3::text
+`
+
+type DeleteDebitParams struct {
+	UserID  int64  `json:"user_id"`
+	Feature string `json:"feature"`
+	Ref     string `json:"ref"`
+}
+
+// Void a debit taken as a RESERVATION for work that then produced nothing.
+//
+// It deletes rather than appending a compensating row, and that is forced by
+// credit_ledger_debit_ref_uniq: at most one debit may exist per (user, feature, ref), so a
+// compensating entry would leave the ref permanently spent and the candidate's retry would
+// find it already charged and never re-reserve. Deleting frees the ref.
+//
+// The ledger's reconstructability is untouched — a voided reservation is a charge that did not
+// happen, and the balance still sums correctly from what remains. What is not kept is the
+// record that a reservation was briefly held, which is bookkeeping about our own retry, not
+// about the candidate's spending.
+//
+// Returns the number of rows removed, so the caller adds the cost back exactly when it really
+// took one away — a double release, or a release of a charge someone else already voided,
+// removes nothing and returns 0.
+func (q *Queries) DeleteDebit(ctx context.Context, arg DeleteDebitParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteDebit, arg.UserID, arg.Feature, arg.Ref)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const ensureBalance = `-- name: EnsureBalance :exec
 INSERT INTO credit_balances (user_id, period, remaining)
 VALUES ($1, $2, $3)

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -836,6 +836,22 @@ type Querier interface {
 	// garbage, since a vanished job cannot be indexed. Here it is the whole point — cmd/prune
 	// hard-deletes jobs, and their documents still have to leave the index.
 	DeleteDeadSearchDeleteOutbox(ctx context.Context, cutoff pgtype.Timestamptz) (int64, error)
+	// Void a debit taken as a RESERVATION for work that then produced nothing.
+	//
+	// It deletes rather than appending a compensating row, and that is forced by
+	// credit_ledger_debit_ref_uniq: at most one debit may exist per (user, feature, ref), so a
+	// compensating entry would leave the ref permanently spent and the candidate's retry would
+	// find it already charged and never re-reserve. Deleting frees the ref.
+	//
+	// The ledger's reconstructability is untouched — a voided reservation is a charge that did not
+	// happen, and the balance still sums correctly from what remains. What is not kept is the
+	// record that a reservation was briefly held, which is bookkeeping about our own retry, not
+	// about the candidate's spending.
+	//
+	// Returns the number of rows removed, so the caller adds the cost back exactly when it really
+	// took one away — a double release, or a release of a charge someone else already voided,
+	// removes nothing and returns 0.
+	DeleteDebit(ctx context.Context, arg DeleteDebitParams) (int64, error)
 	// Unlink Discord. Returns the affected row count: 0 means there was no link.
 	DeleteDiscordLink(ctx context.Context, userID int64) (int64, error)
 	DeleteEmailClassificationOutbox(ctx context.Context, id int64) error

--- a/internal/platform/db/queries/credits.sql
+++ b/internal/platform/db/queries/credits.sql
@@ -43,6 +43,28 @@ SELECT EXISTS (
 INSERT INTO credit_ledger (user_id, period, kind, feature, delta, ref)
 VALUES (sqlc.arg(user_id), sqlc.arg(period), 'debit', sqlc.arg(feature)::text, sqlc.arg(delta), sqlc.arg(ref)::text);
 
+-- name: DeleteDebit :execrows
+-- Void a debit taken as a RESERVATION for work that then produced nothing.
+--
+-- It deletes rather than appending a compensating row, and that is forced by
+-- credit_ledger_debit_ref_uniq: at most one debit may exist per (user, feature, ref), so a
+-- compensating entry would leave the ref permanently spent and the candidate's retry would
+-- find it already charged and never re-reserve. Deleting frees the ref.
+--
+-- The ledger's reconstructability is untouched — a voided reservation is a charge that did not
+-- happen, and the balance still sums correctly from what remains. What is not kept is the
+-- record that a reservation was briefly held, which is bookkeeping about our own retry, not
+-- about the candidate's spending.
+--
+-- Returns the number of rows removed, so the caller adds the cost back exactly when it really
+-- took one away — a double release, or a release of a charge someone else already voided,
+-- removes nothing and returns 0.
+DELETE FROM credit_ledger
+WHERE user_id = sqlc.arg(user_id)
+  AND kind = 'debit'
+  AND feature = sqlc.arg(feature)::text
+  AND ref = sqlc.arg(ref)::text;
+
 -- name: RewardExists :one
 -- Whether the caller already received a reward for this ref (e.g. an accepted contribution).
 -- True means the reward was already granted and must not be granted again (idempotency).


### PR DESCRIPTION
Closes the check-then-act CodeRabbit found on #2228 — the one I said at the time was real,
pre-existing and belonged in its own PR against the ledger.

## The race

`Authorize` checked a balance; `charge` debited afterwards. Two concurrent runs for **two
different never-analysed jobs** with one credit both passed the check, both ran the chain, and
the loser's debit failed silently — after its analysis had been computed, cached and served.
One credit, two analyses.

## The fix

`Reserve` takes the credit **before** the chain starts, so the ledger's own row lock is the
arbiter and the second run is refused rather than given away.

`Run` and `Follow` **release on every failure path, from a defer**, so a panic returns it too.
Charging up front is only honest if a failed analysis still costs nothing — otherwise closing
the race would have turned into a fee for trying.

## Why the release DELETES rather than compensates

`credit_ledger_debit_ref_uniq` permits one debit per `(user, feature, ref)`. A compensating
ledger row would leave the ref **permanently spent**, so the candidate's retry would find it
already charged and never re-reserve — and they would get their analysis for free forever
after one failure.

Deleting frees the ref, so a retry costs one credit rather than none. The balance still
reconstructs from the ledger; what is not kept is the record of a reservation we briefly held,
which is bookkeeping about our own retry rather than about the candidate's spending. **No
migration** — no new `kind`, no CHECK change.

## Two things the tests found, not the review

- A release for a user with **no balance row** reported `Remaining: 0` — telling somebody who
  has spent nothing that they are out of credits. It now reports the monthly grant, the same
  reading `Balance` gives a fresh user.
- The release had to be **idempotent and safe on nothing charged**, so every failure path can
  call it without first working out whether it owes one.

## Verification

- The race itself as a unit test, over a ledger fake that holds a **real balance** — a fake that
  only recorded calls could not show the second reservation being refused by the first landing
- The DELETE against a **real Postgres**, because sqlc generates Go from SQL but never runs it,
  and this statement removes a row a partial unique index depends on. It also asserts the ref is
  chargeable again afterwards
- Mutation-checked: drop the release and `TestRunReleasesTheReservationWhenNothingIsProduced`
  reports `remaining = 9, want 10 — a failed analysis costs nothing`
- `gofmt`/`go vet`/`go vet -tags=integration`/`go test ./...` pass;
  `go test -tags=integration ./internal/api/handler/ ./internal/ai/credits/ ./internal/candidate/...` exit 0;
  `golangci-lint --new-from-rev=origin/main` → 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - AI credits are reserved before analysis begins.
  - Credits are automatically returned when an analysis fails, is cancelled, or produces no result.
  - Retried released analyses can be charged again, while duplicate requests avoid double charging.
  - Concurrent analyses now receive consistent credit handling.

- **Bug Fixes**
  - Prevented unsuccessful analyses from permanently consuming credits.
  - Improved reservation and release idempotency, including monthly credit resets.

- **Documentation**
  - Updated fit-analysis metering guidance for reservation and refund behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->