### PR TITLE
Scan for secrets, lint new migrations, catch sqlc drift — and fix three checks that could not fire

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,44 @@ jobs:
           path: coverage/*.out
           if-no-files-found: ignore
 
+  # Lints only the migrations this pull request ADDS. The applied history carries 1322
+  # findings and is never going to be fixed — "never edit an applied migration" is the
+  # rule this repository runs on, and rewriting one is a worse hazard than any finding.
+  # A migration file genuinely never changes after it lands, which makes this a far
+  # cleaner ratchet than the line-based one the Go lint uses: no baseline file to drift.
+  #
+  # Read .squawk.toml for why the invocation is split in two passes.
+  migrations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          # The script asks git which migrations are new since the merge base, so the
+          # base commit has to be reachable. A shallow clone would make every migration
+          # look either new or absent, and neither is a useful answer — which is why the
+          # script fails on an unresolvable base rather than reporting an empty list.
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6.0.10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The step prints how many files it examined. On a branch with no migration that
+      # is zero, which is the honest answer — and visible, rather than a green tick over
+      # a check that found nothing to do.
+      - name: Lint new migrations
+        run: pnpm check:sql
+
   design-system:
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,37 @@ jobs:
           path: coverage/*.out
           if-no-files-found: ignore
 
+  # internal/platform/db is generated and committed. Nothing compared the two until now,
+  # so a query edited without `make sqlc` shipped the old Go and every job stayed green —
+  # the same class of gap the design-system `check:dist` step exists for.
+  #
+  # `make sqlc` rather than a pinned action, because the Makefile already holds the
+  # version (SQLC_VERSION) and it is the one developers run. Two pins would be two
+  # answers to the same question, and the drift between them would look exactly like
+  # stale generated code.
+  sqlc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Regenerate
+        run: make sqlc
+
+      # The bare `git status --porcelain` is correct HERE and would be wrong in the
+      # pre-commit hook: a fresh clone has an empty index, so "differs from HEAD" and
+      # "is unstaged" have the same answer. See lefthook.yml for the other half.
+      - name: Assert the generated code matches the queries
+        run: |
+          if [ -n "$(git status --porcelain -- internal/platform/db)" ]; then
+            git status --porcelain -- internal/platform/db
+            git --no-pager diff -- internal/platform/db
+            echo
+            echo 'internal/platform/db is stale. Run `make sqlc` and commit the result.'
+            exit 1
+          fi
+          echo 'Generated code matches internal/platform/db/queries.'
+
   # Lints only the migrations this pull request ADDS. The applied history carries 1322
   # findings and is never going to be fixed — "never edit an applied migration" is the
   # rule this repository runs on, and rewriting one is a worse hazard than any finding.

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,68 @@
+name: gitleaks
+
+# Secret scanning over the HISTORY, not the working tree: a credential removed in a
+# later commit is still leaked, and the tree looks clean. Suppressions and the rule
+# for adding one live in .gitleaks.toml.
+#
+# NO `paths:` FILTER, DELIBERATELY. The verdict comes from the history rather than
+# from the diff, so filtering on changed paths would be meaningless — and it is the
+# secret nobody expected, in the file nobody listed, that this exists for.
+#
+# The pre-commit hook in lefthook.yml is the half of this that PREVENTS rather than
+# reports; `--no-verify` walks past it, and whoever never ran `lefthook install`
+# never had it. Which is why both exist.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '17 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          # A shallow clone hides exactly the commit someone would want hidden.
+          # This is also what makes the assertion below meaningful.
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        env:
+          # Pinned so a finding here reproduces on a laptop with the same version
+          # instead of being argued about. Bumped deliberately, like any other tool.
+          GITLEAKS_VERSION: 8.30.1
+        run: |
+          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -o /tmp/gitleaks.tar.gz
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      # THE COMMIT COUNT IS ASSERTED, AND THAT IS NOT BELT-AND-BRACES. Given a
+      # repository it cannot read, gitleaks prints "0 commits scanned", says "no leaks
+      # found" and exits 0. A shallow clone, a missing fetch-depth or a detached
+      # checkout would each produce a green job that examined nothing — the same
+      # silent pass the scanner exists to prevent. Success is not evidence that the
+      # work happened; the count is.
+      - name: Scan history
+        run: |
+          set -o pipefail
+          gitleaks git --no-banner 2>&1 | tee /tmp/gitleaks.log
+          scanned=$(sed -n 's/.*[^0-9]\([0-9][0-9]*\) commits scanned.*/\1/p' /tmp/gitleaks.log | tail -1)
+          if [ -z "$scanned" ] || [ "$scanned" -lt 1 ]; then
+            echo "gitleaks reported no commits scanned — the scan was blind, not clean."
+            exit 1
+          fi
+          echo "Scanned $scanned commits."

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -38,17 +38,53 @@ jobs:
           # A shallow clone hides exactly the commit someone would want hidden.
           # This is also what makes the assertion below meaningful.
           fetch-depth: 0
+          # This job reads the history and writes nothing. Leaving the token in
+          # .git/config would hand it to anything the steps below run — and the steps
+          # below deliberately execute a downloaded binary over the repository.
+          persist-credentials: false
 
+      # The archive is executed, so its integrity is checked before it is unpacked
+      # rather than trusted because the URL looked right. The digest is the one in the
+      # release's own checksums file and moves with GITLEAKS_VERSION; a bump that
+      # forgets it fails loudly here instead of silently running something else.
       - name: Install gitleaks
         env:
           # Pinned so a finding here reproduces on a laptop with the same version
           # instead of being argued about. Bumped deliberately, like any other tool.
           GITLEAKS_VERSION: 8.30.1
+          GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
         run: |
           curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -o /tmp/gitleaks.tar.gz
+          echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tar.gz" | sha256sum --check --strict -
           tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
           sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
           gitleaks version
+
+      # A CANARY, because "no leaks found" is what a working scan and a disabled one
+      # both print. The commit-count assertion below catches a scanner that could not
+      # read the repository; this catches one that read it and was configured not to
+      # care — an allowlist widened until it matches everything, a `paths` entry, a
+      # rule set replaced rather than extended. It runs the SAME config the real scan
+      # uses, against a secret shaped like a credential no allowlist here mentions.
+      #
+      # `gitleaks dir` on a scratch path, not a file in the tree: nothing is committed,
+      # so the history the next step reads is unchanged.
+      #
+      # The token is assembled by printf rather than written whole, so this workflow file
+      # is not itself a finding when the next step scans the history — and the tail is
+      # exactly 36 characters, which is what the `github-pat` rule matches. A shorter one
+      # is not detected, and the canary would then fail on every run for the wrong reason.
+      - name: Assert the scanner still detects a planted secret
+        run: |
+          mkdir -p /tmp/canary
+          printf 'const t = "ghp_%s"\n' 'K3nQ7bZ2mR9xTvL4nWc8YpJ1dHsA6eG0uFiO' > /tmp/canary/planted.txt
+          if gitleaks dir /tmp/canary --config .gitleaks.toml --no-banner --redact >/dev/null 2>&1; then
+            echo 'gitleaks did not report a planted credential. The rule set or the'
+            echo 'allowlist in .gitleaks.toml has disabled detection — every green run'
+            echo 'since that change examined nothing.'
+            exit 1
+          fi
+          echo 'Canary detected. The scanner is looking.'
 
       # THE COMMIT COUNT IS ASSERTED, AND THAT IS NOT BELT-AND-BRACES. Given a
       # repository it cannot read, gitleaks prints "0 commits scanned", says "no leaks
@@ -56,10 +92,19 @@ jobs:
       # checkout would each produce a green job that examined nothing — the same
       # silent pass the scanner exists to prevent. Success is not evidence that the
       # work happened; the count is.
+      #
+      # `--redact` because this repository is public and so are its run logs. Without
+      # it a finding publishes the credential to a wider audience than the leak already
+      # had, which is the opposite of what this job is for. The finding's file, line
+      # and rule are still printed — everything needed to act on it.
+      #
+      # `--config` explicitly, though discovery would find the same file: a renamed or
+      # deleted .gitleaks.toml then fails the job instead of quietly falling back to the
+      # default rule set and reporting the ten allowlisted fixtures as fresh leaks.
       - name: Scan history
         run: |
           set -o pipefail
-          gitleaks git --no-banner 2>&1 | tee /tmp/gitleaks.log
+          gitleaks git --config .gitleaks.toml --no-banner --redact 2>&1 | tee /tmp/gitleaks.log
           scanned=$(sed -n 's/.*[^0-9]\([0-9][0-9]*\) commits scanned.*/\1/p' /tmp/gitleaks.log | tail -1)
           if [ -z "$scanned" ] || [ "$scanned" -lt 1 ]; then
             echo "gitleaks reported no commits scanned — the scan was blind, not clean."

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,55 @@
+# Suppressions for the secret scanner, and the rule for adding one.
+#
+# EVERY ENTRY ALLOWLISTS A LINE SHAPE, NEVER A PATH. gitleaks combines a `paths` key
+# with `regexes` using OR and prunes the file before reading it, so a path entry does
+# not narrow a rule — it switches the scanner off for that file entirely, including for
+# the real credential someone pastes into it next year. `_test.go` is exactly the file
+# that invites a path entry and exactly the file where a live token is most likely to be
+# used as a "realistic" fixture.
+#
+# The ten findings on adoption were all argued individually and are listed below. None
+# was a live credential; the one that was ever real is a publishable browser token that
+# the code no longer carries at all. A finding that survives this file is a leak: it is
+# already in the history, in every clone and in the runner's cache, and the response is
+# to REVOKE the credential. Rewriting history does not un-leak anything.
+#
+# Note what neither this file nor the scanner reaches: a key pasted into an issue, a
+# chat or an environment store never passes through git.
+
+[extend]
+# Without this the custom rules below REPLACE the built-in rule set rather than adding
+# to it, which is a green scan that looks for almost nothing.
+useDefault = true
+
+[[allowlists]]
+description = "Chrome extension manifest keys are RSA *public* keys (SPKI, DER, base64). The extension pins its development id with one, which is what the id is derived from — publishing it is the mechanism, not a slip. A private key carries a different prefix (MIIEv/MIIJ), so this shape cannot cover one."
+regexTarget = "secret"
+regexes = ['''^MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A''']
+
+[[allowlists]]
+description = "RFC 6455 §1.3 prints this exact Sec-WebSocket-Key on the page that defines the handshake. The WebSocket tests use it because a reader who knows the RFC recognises it."
+regexTarget = "secret"
+regexes = ['''^dGhlIHNhbXBsZSBub25jZQ==$''']
+
+[[allowlists]]
+description = "Source-adapter test fixtures: captured response bodies with the vendor's token field filled by an obvious placeholder. Listed one by one rather than by path — a fixture is where a real captured token would hide."
+regexTarget = "secret"
+regexes = [
+  # internal/ingest/sources — comeet, mts, solidjobs
+  '''^ABCDEF1234567890ABCDEF12$''',
+  '''^KEY-abc\.def-123_xyz$''',
+  '''^3aa5b098-aa6d-4f6c-950a-b92a81363cf8$''',
+]
+
+[[allowlists]]
+description = "Auth and mail test constants. Each is long enough to trip generic-api-key and says in its own text that it is not a credential."
+regexTarget = "secret"
+regexes = [
+  '''^test-secret-that-is-long-enough-0001$''',
+  '''^fh_live_abc123$''',
+]
+
+[[allowlists]]
+description = "logo.dev publishable key, history only. It was a `pk_` token — the kind designed to ship to a browser — and the code no longer carries it: company logos now go through our own logo.freehire.me proxy, which holds the credential server-side. Kept because the finding is in the history, where it stays."
+regexTarget = "secret"
+regexes = ['''^pk_fKgOEo0OT4KXvUshjPMGAQ$''']

--- a/.squawk.toml
+++ b/.squawk.toml
@@ -1,0 +1,42 @@
+# Migration linting. Two rules are excluded here and nothing else is; every other
+# finding is either a real hazard or gets a `-- squawk-ignore <rule>` line beside the
+# statement, where the argument sits next to the thing it argues about.
+#
+# WHAT RUNS THIS IS `scripts/check-migrations.mjs`, NOT A BARE `squawk migrations/*.sql`.
+# Two reasons, and both are facts about this repository rather than taste:
+#
+#   1. `assume_in_transaction` is not a property of the repository, it is a property of
+#      the FILE. The runner wraps each migration in a transaction unless the file's
+#      leading comment carries `migrate: no-transaction`
+#      (internal/platform/migrate/migrate.go), and 21 of 156 files do. Squawk has no
+#      per-file switch, so the invocation is split into two passes and the script decides
+#      which file goes in which. Setting the flag globally would be a lie in whichever
+#      direction it was set: `true` hides `prefer-robust-stmts` on exactly the files that
+#      can half-apply, and `false` demands `CREATE INDEX CONCURRENTLY` on files where it
+#      cannot run at all.
+#
+#   2. Ratchet. There are 1322 findings across the applied history and they are not going
+#      to be fixed — "never edit an applied migration" is the rule this repository runs
+#      on, and rewriting one is a worse hazard than any finding here. So the check reads
+#      only the files a change ADDS. That is unusually clean for a ratchet: unlike a line
+#      of Go, a migration file genuinely never changes after it lands, so there is no
+#      baseline file to drift and no blame-by-line to compute.
+
+# The runner sets `SET lock_timeout = '5s'` once per connection, session-level so it
+# covers the no-transaction files too, immediately after taking its advisory lock. The
+# rule wants the SET inside every migration; here that would be a second copy of a
+# setting that is already central — and a copy that can drift from it. See the comment on
+# `lockTimeout` in internal/platform/migrate/migrate.go, which records the 2026-07-30
+# incident it exists for: an ALTER queued behind the nightly pg_dump, with live reads
+# piling up behind the ALTER.
+#
+# The day the runner stops setting it, this exclusion is what let a migration through
+# without one.
+#
+# `require-statement-timeout` is excluded for the opposite reason — deliberately absent
+# rather than centrally present. lock_timeout bounds how long a migration WAITS for a
+# lock; a statement timeout would bound how long it may HOLD one, which would abort a
+# long index build partway. On a catalogue this size that is the common case, not the
+# edge, and an aborted CONCURRENTLY build leaves an INVALID index behind (migrations 0117
+# and 0118 are the repair pair for exactly that).
+excluded_rules = ["require-lock-timeout", "require-statement-timeout"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,16 @@ gofmt/vet/golangci-lint on staged Go files and eslint on staged files in web/, e
 design-system/ — the same ratchet policy as CI (only new issues fail the commit), so it
 won't block on the pre-existing backlog.
 
+**Secrets** are the one thing the hooks *prevent* rather than report: `gitleaks` (`brew
+install gitleaks`) scans the staged index on every commit and fails hard if the binary is
+missing, because a scanner that quietly skips makes a commit look examined. The
+`gitleaks` workflow scans the whole history on top, since `--no-verify` walks past the
+hook and a credential removed in a later commit is still leaked. A finding that survives
+`.gitleaks.toml` means **revoke the credential** — rewriting history does not un-leak
+anything. Suppressions in that file allowlist a *line shape*, never a path: gitleaks ORs
+`paths` with `regexes` and prunes the file before reading it, so a path entry switches
+the scanner off for that file entirely.
+
 **`go test ./...` compiles no `//go:build integration` file, and those files are not
 confined to `internal/platform/db`** — there are 187 of them across 20 packages, and `internal/api/handler`
 holds 78, which call unexported constructors like `newCVHandlers`. A changed signature

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ they are manual job intake rather than applications.
 
 Non-obvious:
 
-- `migrations/` — the source for **both** sqlc codegen and Postgres initdb. Never edit an applied migration; add a new file.
+- `migrations/` — the source for **both** sqlc codegen and Postgres initdb. Never edit an applied migration; add a new file. `pnpm check:sql` (squawk, via `scripts/check-migrations.mjs`) lints the ones a change ADDS — the applied history holds 1322 findings that stay, because rewriting an applied file is a worse hazard than any of them. Whether a file runs inside a transaction is a property of the FILE (the `migrate: no-transaction` marker), so the check runs two passes; `.squawk.toml` carries the argument. Suppress a rule with `-- squawk-ignore <rule-name>` on the line before the statement, with the reason beside it.
 - `sources/` — YAML board files, not Go. One file per ATS provider, plus `custom.yml` and `telegram.yml`.
 - `design-system/` — a separate pnpm package, sibling to `web/` and `extension/`, linked via
   pnpm's `link:../design-system` (`web/`) or npm's `file:../design-system` (`extension/`) — both

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Non-obvious:
   manager installs a linked/`file:` package's own dependencies for you.
 - `extension/` — the browser extension (WXT + Svelte side-panel agent client), npm-managed
   unlike the rest of the JS in this repo. See [extension/AGENTS.md](extension/AGENTS.md).
-- `internal/platform/db/` — **generated**; edit `internal/platform/db/queries/*.sql` and run `make sqlc`.
+- `internal/platform/db/` — **generated**; edit `internal/platform/db/queries/*.sql` and run `make sqlc`. The pre-commit hook and the `sqlc` CI job regenerate and diff, so a query edited without regenerating no longer ships the old Go with every check green. Both use `make sqlc`, which holds the only version pin — a second pin would be a second answer, and the drift between them would look exactly like stale code.
 - `services/pii-filter` — a standalone service, not a Go package.
 
 ## Commands

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -146,25 +146,43 @@ pre-commit:
         - "design-system/scripts/build-tokens.mjs"
         - "design-system/dist/**"
       run: pnpm run check:dist
+    # BOTH PATTERNS, AND THE PAIR IS THE POINT. `**/` requires a separator, so
+    # `design-system/src/**/*.svelte` matches src/email/email-preview.svelte and
+    # NOT src/alert.svelte — which is 25 of the 26 primitives, every one of them a
+    # direct child of src/. Measured with lefthook 1.13.6: `--file
+    # design-system/src/alert.svelte` reported "skip, no matching staged files"
+    # while the nested path ran.
     design-system-docs:
       root: "design-system/"
       glob:
         - "design-system/docs/**"
+        - "design-system/src/*.svelte"
         - "design-system/src/**/*.svelte"
         - "design-system/src/*.stories.ts"
       run: pnpm run validate:docs
-    # check:tokens and check:adoption also have a radius over ../web/src (a
-    # colour literal or an unreachable primitive can be introduced from either
-    # side), so both trigger on web/src changes too, not just design-system/.
+
+    # NO `root:` ON THESE TWO, AND THAT IS LOAD-BEARING. `root` does not merely set
+    # the working directory: lefthook first discards every staged file outside it,
+    # and only then applies the glob. So a command with `root: design-system/` can
+    # never be triggered by a change under web/, however its glob is written — and
+    # these two are the only commands here whose radius spans both sides. A colour
+    # literal or an unreachable primitive can be introduced from either, which is
+    # what the comment above them used to claim they caught. They did not: measured
+    # with lefthook 1.13.6, `--file web/src/lib/logo.ts` skipped both.
+    #
+    # `pnpm --dir` from the repository root instead, where every path means what it
+    # says. Not `--filter`: design-system and web are separate packages with their
+    # own lockfiles, not a pnpm workspace.
     design-system-tokens:
-      root: "design-system/"
       glob:
+        - "design-system/src/*.svelte"
         - "design-system/src/**/*.svelte"
+        - "design-system/scripts/check-token-coverage.mjs"
         - "web/src/**/*.{svelte,ts,js}"
-      run: pnpm run check:tokens
+      run: pnpm --dir design-system run check:tokens
     design-system-adoption:
-      root: "design-system/"
       glob:
         - "design-system/src/index.ts"
+        - "design-system/scripts/check-adoption.mjs"
         - "web/src/**/*.{svelte,ts,js}"
-      run: pnpm run check:adoption
+      run: pnpm --dir design-system run check:adoption

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -35,6 +35,39 @@ pre-commit:
           exit 0
         fi
         govulncheck ./... || echo "govulncheck reported findings above (non-blocking for now, see lefthook.yml)"
+    # internal/platform/db is generated and committed, so a query edited without
+    # regenerating ships the OLD Go with every check green — nothing else here reads
+    # both halves. Same shape of check as design-system's check:dist, except that an
+    # untracked file counts too: a *new* generated file that was never committed is
+    # untracked rather than modified, and a plain diff misses it.
+    #
+    # Globbed on the migrations as well as the queries. A renamed column is the other
+    # way to make the generated code wrong, and sqlc.yaml decides what is generated at
+    # all — a config that stops matching disables this check while it still reports
+    # success.
+    sqlc-drift:
+      glob: "{migrations/*.sql,internal/platform/db/queries/*.sql,sqlc.yaml}"
+      # An explicit `if` rather than `A && B || C`, which reads like "if A and B, else C"
+      # and is not: a *failing* `make sqlc` would fall into C and report the code as
+      # stale, a message pointing away from the real problem.
+      #
+      # The question here is "did regenerating leave anything UNSTAGED", which is not the
+      # question CI asks. `git status --porcelain` reports two columns — index against
+      # HEAD, and worktree against index — so the bare form would count the staged
+      # generated changes being committed as drift, and block the very commit that fixes
+      # it. CI keeps the bare form correctly: a fresh clone has an empty index, so there
+      # the two questions have the same answer.
+      run: |
+        set -e
+        make sqlc
+        unstaged="$(git diff --name-only -- internal/platform/db)"
+        untracked="$(git ls-files --others --exclude-standard -- internal/platform/db)"
+        if [ -n "$unstaged$untracked" ]; then
+          printf '%s\n' $unstaged $untracked
+          echo 'Generated code was stale — make sqlc has just fixed it; stage the result.'
+          exit 1
+        fi
+
     # Expand/contract for migrations, which was prose in AGENTS.md and read by nothing.
     # It is here rather than only in CI because the mistakes it catches — a UNIQUE
     # constraint that takes ACCESS EXCLUSIVE on a live table, a constraint added without

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -35,6 +35,18 @@ pre-commit:
           exit 0
         fi
         govulncheck ./... || echo "govulncheck reported findings above (non-blocking for now, see lefthook.yml)"
+    # Expand/contract for migrations, which was prose in AGENTS.md and read by nothing.
+    # It is here rather than only in CI because the mistakes it catches — a UNIQUE
+    # constraint that takes ACCESS EXCLUSIVE on a live table, a constraint added without
+    # NOT VALID — are cheap to fix while writing the migration and expensive once the
+    # file carries a version number someone else has applied.
+    #
+    # lefthook filters {staged_files} by the glob, so the script receives migrations and
+    # nothing else. Read .squawk.toml for why the invocation is split in two.
+    sql-migrations:
+      glob: "migrations/*.sql"
+      run: node scripts/check-migrations.mjs {staged_files}
+
     # THE ONLY HOOK HERE THAT PREVENTS SOMETHING RATHER THAN REPORTING IT.
     #
     # Everything else in this file is a convenience: it fails locally so CI does not

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -35,6 +35,35 @@ pre-commit:
           exit 0
         fi
         govulncheck ./... || echo "govulncheck reported findings above (non-blocking for now, see lefthook.yml)"
+    # THE ONLY HOOK HERE THAT PREVENTS SOMETHING RATHER THAN REPORTING IT.
+    #
+    # Everything else in this file is a convenience: it fails locally so CI does not
+    # have to, and skipping it costs a red run. This one is different. Once a
+    # credential reaches the remote it is leaked — it is in the history, in every
+    # clone and in the runner's cache — and the only real response is to revoke it.
+    # Rewriting history does not un-leak anything. This hook is the last moment at
+    # which that has not happened yet.
+    #
+    # .github/workflows/gitleaks.yml is NOT a redundant copy: it scans the whole
+    # history and cannot be bypassed, so it covers whoever never ran `lefthook
+    # install` or reached for --no-verify. But by the time it speaks the leak is
+    # real. Two controls, two moments, neither replaces the other.
+    #
+    # No glob — a secret is not a file type, and the one that matters will be in
+    # whatever nobody thought to list. `--staged` reads the index, so it sees
+    # exactly what is about to be committed rather than the working tree around it.
+    #
+    # Unlike govulncheck above, a missing binary FAILS. A scanner that quietly
+    # skips is worse than no scanner: it makes the commit look examined.
+    gitleaks:
+      run: |
+        if ! command -v gitleaks >/dev/null 2>&1; then
+          echo 'gitleaks is not installed (brew install gitleaks), and this hook will'
+          echo 'not pretend a commit was scanned when it was not. Install it, or use'
+          echo '--no-verify knowing CI scans the history anyway.'
+          exit 1
+        fi
+        gitleaks git --staged --no-banner
     web-lint:
       root: "web/"
       glob: "web/**/*.{js,ts,svelte}"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,13 @@
 {
   "name": "freehire",
   "private": true,
-  "packageManager": "pnpm@11.7.0"
+  "description": "Repository root. The Go module is the product; web/, design-system/ and extension/ are their own packages with their own manifests. Only repo-wide tooling lives here.",
+  "type": "module",
+  "packageManager": "pnpm@11.7.0",
+  "scripts": {
+    "check:sql": "node scripts/check-migrations.mjs"
+  },
+  "devDependencies": {
+    "squawk-cli": "^2.63.0"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,4 +6,64 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      squawk-cli:
+        specifier: ^2.63.0
+        version: 2.63.0
+
+packages:
+
+  '@squawk-cli/darwin-arm64@2.63.0':
+    resolution: {integrity: sha512-YaSfsQ8c0bb93thcBmJWLOte/1MExUFn6mVWfSqjgaFHip0UGHa3X4oZJiCdk75f/Tw2GrGmAiLV2/eQqnYfUA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@squawk-cli/darwin-x64@2.63.0':
+    resolution: {integrity: sha512-y23BkUAzD5VtxjCr2JGZz3j+gMVueyad6t4f8AfXV/cNp2CEY+5EmO7QAjXD9z8ro8Oye4F9aId9A5gCNsbh9A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@squawk-cli/linux-arm64@2.63.0':
+    resolution: {integrity: sha512-ino85Bg5vL3XIHCBLadoQdaTIZlTg+oh9LriyejIGur7s15fhavDkwhCjqnEUKznGnqsx7x92yW2uDUbJM3fYw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@squawk-cli/linux-x64@2.63.0':
+    resolution: {integrity: sha512-dh1IiQGs/7M9cQEHaC2JkV6lYrLoR5ytAyznRLxcBAfzExSfqEz/gPwc11dewzFZDq3G6TmKKVbMNhcWIhAsww==}
+    cpu: [x64]
+    os: [linux]
+
+  '@squawk-cli/win32-x64@2.63.0':
+    resolution: {integrity: sha512-7939Y/zW6ni0X/Zp19Mml8wS35eOsszgFT+RuZH5zYZwWvQxjEa00pc3baPugb9VIAIdWVMnJTjBcmFA31sKfg==}
+    cpu: [x64]
+    os: [win32]
+
+  squawk-cli@2.63.0:
+    resolution: {integrity: sha512-OR9UHzY3kSLoZCB4qk3iSHeEm9pwVccHSWnRggfvRKo/QAddkWJEyoXlIsz0gPAPpzsyk60WcaY4SkswZTXPVA==}
+    hasBin: true
+
+snapshots:
+
+  '@squawk-cli/darwin-arm64@2.63.0':
+    optional: true
+
+  '@squawk-cli/darwin-x64@2.63.0':
+    optional: true
+
+  '@squawk-cli/linux-arm64@2.63.0':
+    optional: true
+
+  '@squawk-cli/linux-x64@2.63.0':
+    optional: true
+
+  '@squawk-cli/win32-x64@2.63.0':
+    optional: true
+
+  squawk-cli@2.63.0:
+    optionalDependencies:
+      '@squawk-cli/darwin-arm64': 2.63.0
+      '@squawk-cli/darwin-x64': 2.63.0
+      '@squawk-cli/linux-arm64': 2.63.0
+      '@squawk-cli/linux-x64': 2.63.0
+      '@squawk-cli/win32-x64': 2.63.0

--- a/scripts/check-migrations.mjs
+++ b/scripts/check-migrations.mjs
@@ -15,8 +15,15 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const SQUAWK = ['squawk'];
+// Resolved relative to THIS FILE, not to the caller's PATH. The lefthook command runs
+// `node scripts/check-migrations.mjs` directly — no `pnpm run` wrapper — so
+// node_modules/.bin is not on PATH and a bare `squawk` fails for everyone with the hook
+// installed. Falls back to PATH for a global install.
+const LOCAL_SQUAWK = fileURLToPath(new URL('../node_modules/.bin/squawk', import.meta.url));
+const SQUAWK = existsSync(LOCAL_SQUAWK) ? LOCAL_SQUAWK : 'squawk';
+
 const MIGRATIONS_DIR = 'migrations';
 const RUNNER_SOURCE = 'internal/platform/migrate/migrate.go';
 
@@ -108,14 +115,14 @@ function squawk(files, { inTransaction }) {
   const args = [...files];
   if (inTransaction) args.push('--assume-in-transaction');
   try {
-    execFileSync(SQUAWK[0], [...SQUAWK.slice(1), ...args], { stdio: 'inherit' });
+    execFileSync(SQUAWK, args, { stdio: 'inherit' });
     return false;
   } catch (err) {
+    // A missing binary FAILS rather than passing quietly. A migration check that
+    // reports nothing because the linter was absent is worse than no check: it makes
+    // the commit look examined.
     if (err.code === 'ENOENT') {
-      console.error(
-        'squawk is not installed. Run `pnpm install` at the repository root, or use\n' +
-          '`pnpm exec node scripts/check-migrations.mjs` so the local binary is on PATH.',
-      );
+      console.error('squawk is not installed. Run `pnpm install` at the repository root.');
       process.exit(1);
     }
     return true;

--- a/scripts/check-migrations.mjs
+++ b/scripts/check-migrations.mjs
@@ -94,9 +94,15 @@ function mergeBase() {
 
 function changedMigrations() {
   const base = mergeBase();
+  // ADDED ONLY. A modified migration is a rule violation in its own right — "never edit
+  // an applied migration" — but linting its CONTENT is the wrong response to it: fixing
+  // a typo in the comment on 0012 would dump every historical finding in that file into
+  // a change that touched a comment, and the useful signal would be the one line nobody
+  // reads by then. What this check owes a new migration is a verdict on what it does to
+  // a live table; what an edited one needs is a reviewer.
   const out = execFileSync(
     'git',
-    ['diff', '--name-only', '--diff-filter=ACMR', base, 'HEAD', '--', `${MIGRATIONS_DIR}/*.sql`],
+    ['diff', '--name-only', '--diff-filter=A', base, 'HEAD', '--', `${MIGRATIONS_DIR}/*.sql`],
     { encoding: 'utf8' },
   );
   return out.split('\n').filter(Boolean);

--- a/scripts/check-migrations.mjs
+++ b/scripts/check-migrations.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// Lints the migrations a change ADDS, with squawk, in two passes.
+//
+// Read .squawk.toml first — it holds the argument for why this script exists at all
+// instead of a bare `squawk migrations/*.sql`. In short: whether a migration runs inside
+// a transaction is a property of the FILE, not of the repository, and squawk has one
+// global flag for it; and the applied history carries 1322 findings that are never going
+// to be fixed, because rewriting an applied migration is a worse hazard than any of them.
+//
+// Usage:
+//   node scripts/check-migrations.mjs                  # files added/changed vs origin/main
+//   node scripts/check-migrations.mjs migrations/*.sql # exactly these
+//   node scripts/check-migrations.mjs --all            # the whole history, for an audit
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SQUAWK = ['squawk'];
+const MIGRATIONS_DIR = 'migrations';
+const RUNNER_SOURCE = 'internal/platform/migrate/migrate.go';
+
+/**
+ * The marker is read out of the runner rather than copied, so the two cannot disagree
+ * about its spelling. The *rule* around it still lives in both places and is stated
+ * below; a rename of the constant's value stays in one.
+ */
+function noTxMarker() {
+  const src = readFileSync(RUNNER_SOURCE, 'utf8');
+  const m = src.match(/const\s+noTxMarker\s*=\s*"([^"]+)"/);
+  if (!m) {
+    throw new Error(
+      `Could not find noTxMarker in ${RUNNER_SOURCE}. The runner decides which migrations ` +
+        `run in a transaction; without the marker this check would lint every file under ` +
+        `the wrong assumption, and quietly.`,
+    );
+  }
+  return m[1];
+}
+
+/**
+ * Mirrors hasNoTxMarker in the runner: the marker counts only in the LEADING comment
+ * block — blank lines and `--` comments before the first statement. A marker further
+ * down is prose about the mechanism, which several migrations contain, and treating it
+ * as the opt-out would lint a transactional file as though it were not one.
+ */
+function isNoTx(file, marker) {
+  for (const raw of readFileSync(file, 'utf8').split('\n')) {
+    const line = raw.trim();
+    if (line === '') continue;
+    if (!line.startsWith('--')) return false;
+    if (line.includes(marker)) return true;
+  }
+  return false;
+}
+
+/**
+ * The merge base to compare against.
+ *
+ * A base that cannot be resolved is a BROKEN ASSUMPTION, not "nothing changed" — a
+ * shallow clone, a detached checkout or a missing remote would otherwise produce an
+ * empty file list and a green check that examined nothing, which is the exact failure
+ * mode a linter is supposed to remove. So this throws rather than returning [].
+ */
+function mergeBase() {
+  const candidates = ['origin/main'];
+  // GitHub sets this on a pull request. Not interpolated into a shell — execFileSync
+  // takes an argv array, and git treats an unknown ref as a failed lookup either way.
+  if (process.env.GITHUB_BASE_REF) candidates.push(`origin/${process.env.GITHUB_BASE_REF}`);
+  candidates.push('main');
+
+  for (const ref of candidates) {
+    try {
+      return execFileSync('git', ['merge-base', ref, 'HEAD'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+    } catch {
+      // Try the next one.
+    }
+  }
+  throw new Error(
+    `Could not resolve a merge base against any of ${candidates.join(', ')}. Fetch the ` +
+      `main branch (CI needs fetch-depth: 0), or pass the migration files explicitly.`,
+  );
+}
+
+function changedMigrations() {
+  const base = mergeBase();
+  const out = execFileSync(
+    'git',
+    ['diff', '--name-only', '--diff-filter=ACMR', base, 'HEAD', '--', `${MIGRATIONS_DIR}/*.sql`],
+    { encoding: 'utf8' },
+  );
+  return out.split('\n').filter(Boolean);
+}
+
+function allMigrations() {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.sql'))
+    .sort()
+    .map((f) => join(MIGRATIONS_DIR, f));
+}
+
+/** Runs one pass and reports whether it found anything. Output goes straight through. */
+function squawk(files, { inTransaction }) {
+  if (files.length === 0) return false;
+  const args = [...files];
+  if (inTransaction) args.push('--assume-in-transaction');
+  try {
+    execFileSync(SQUAWK[0], [...SQUAWK.slice(1), ...args], { stdio: 'inherit' });
+    return false;
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      console.error(
+        'squawk is not installed. Run `pnpm install` at the repository root, or use\n' +
+          '`pnpm exec node scripts/check-migrations.mjs` so the local binary is on PATH.',
+      );
+      process.exit(1);
+    }
+    return true;
+  }
+}
+
+const argv = process.argv.slice(2);
+const explicit = argv.filter((a) => !a.startsWith('--'));
+
+let files;
+if (argv.includes('--all')) {
+  files = allMigrations();
+} else if (explicit.length > 0) {
+  // The hook passes staged files, which include everything else in the commit.
+  files = explicit.filter((f) => f.startsWith(`${MIGRATIONS_DIR}/`) && f.endsWith('.sql'));
+} else {
+  files = changedMigrations();
+}
+
+// A path that no longer exists is a rename or a delete carried in by the hook's staged
+// file list, not something to lint — and reading it would end the run in a stack trace
+// rather than in a verdict.
+files = files.filter((f) => existsSync(f));
+
+if (files.length === 0) {
+  console.log('check-migrations: no migrations to check.');
+  process.exit(0);
+}
+
+const marker = noTxMarker();
+const noTx = files.filter((f) => isNoTx(f, marker));
+const inTx = files.filter((f) => !noTx.includes(f));
+
+console.log(
+  `check-migrations: ${inTx.length} transactional, ${noTx.length} outside a transaction ` +
+    `(marker: "${marker}").`,
+);
+
+// Both passes always run — an early exit on the first would hide the second's findings
+// behind a fix for the first's.
+const failedInTx = squawk(inTx, { inTransaction: true });
+const failedNoTx = squawk(noTx, { inTransaction: false });
+
+if (failedInTx || failedNoTx) {
+  console.error(
+    '\nA finding above is about the migration this change ADDS, not about the history.\n' +
+      'Fix the statement, or put `-- squawk-ignore <rule-name>` on the line before it with\n' +
+      'the argument in a comment beside it. Never edit an applied migration to satisfy this.',
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
Four checks the repository did not have, plus two glob traps that had silently
disabled three it thought it did. Each commit is one tool and the fixes it turned up,
and each was verified by planting the defect it exists to catch — not by counting
findings, since "the scanner is blind" and "the tree is clean" both print zero.

## Secrets — `gitleaks`

Nothing here looked for a credential in a commit. Formatting, vetting, linting and
`govulncheck` all pass over a key pasted into a config or a fixture.

Two moments, two controls. The **hook** reads the staged index and is the last point at
which a leak has not happened yet; it fails hard on a missing binary, because a scanner
that quietly skips makes a commit look examined. The **workflow** scans the whole history,
cannot be bypassed, and covers whoever never ran `lefthook install` — but by the time it
speaks the credential is on the remote, in every clone and in the runner's cache, and the
answer is to revoke it.

Ten findings on adoption, none a live credential: eight test fixtures, the extension's
Chrome manifest key (an RSA *public* key — publishing it is the mechanism, since the
extension id is derived from it), and a `logo.dev` publishable browser token the code no
longer carries. Each is allowlisted in `.gitleaks.toml` by its **line shape, never its
path**: gitleaks ORs `paths` with `regexes` and prunes the file before reading it, so a
path entry does not narrow a rule — it switches the scanner off for that file. `_test.go`
both invites such an entry and is where a live token would sit as a "realistic" fixture.

The workflow **asserts the commit count**. Given a repository it cannot read, gitleaks
prints `0 commits scanned`, says `no leaks found` and exits 0.

## Migrations — `squawk`

"Never edit an applied migration" was prose in AGENTS.md read by nothing, and nothing
looked at what a new migration does to a live table. That is the expensive class of
mistake: a `UNIQUE` constraint holds `ACCESS EXCLUSIVE` for the whole index build, a
constraint without `NOT VALID` scans the table and blocks writes, and Postgres queues lock
requests — so an `ALTER` waiting on a lock sits ahead of every reader arriving after it.
That is how a bounded migration took out signed-in profile reads on 2026-07-30.

Two facts about this repository shape it, and both are why a bare `squawk migrations/*.sql`
would be the wrong tool.

**Transactionality is a property of the FILE.** The runner wraps each migration unless its
leading comment carries `migrate: no-transaction`, and 18 of 156 do. Squawk has one global
flag, so `scripts/check-migrations.mjs` splits the invocation and reads the marker out of
the runner rather than copying it. Setting the flag globally is a lie either way: `true`
hides `prefer-robust-stmts` on exactly the files that can half-apply; `false` demands
`CREATE INDEX CONCURRENTLY` on files where it cannot run at all.

**The history stays.** Rewriting an applied migration is a worse hazard than any finding in
one, so the check reads only what a change ADDS. Unusually clean as ratchets go: unlike a
line of Go, a migration file genuinely never changes after it lands — no baseline file to
drift, no blame-by-line.

Two rules excluded, each on a fact rather than on taste — `require-lock-timeout` because
the runner sets it once per connection, session-level, and a copy inside every migration is
a copy that can drift; `require-statement-timeout` because it would abort a long index
build partway, and an aborted `CONCURRENTLY` build leaves an INVALID index behind (0117 and
0118 are the repair pair for exactly that). Those two corrections take the raw **1322
findings to 267** — four fifths of the noise was the tool being told the wrong thing about
how migrations run here.

Suppress a rule with `-- squawk-ignore <rule-name>` beside the statement, where the argument
sits next to the thing it argues about.

## Generated code — sqlc drift

`internal/platform/db` is generated and committed, and nothing compared the two halves. A
query edited without `make sqlc` ships the previous Go and every check stays green, because
each of them reads the committed file rather than the query it came from. The design-system
`check:dist` step exists for this shape of gap on the CSS side.

The two halves ask different questions. CI asks "does it differ from HEAD", and a bare
`git status --porcelain` answers that correctly on a fresh clone. The hook has to ask "did
regenerating leave anything UNSTAGED" — porcelain reports two columns, so the bare form
would count the staged generated files being committed as drift and block the very commit
that fixes it. Hence `git diff` plus `git ls-files --others`, and the second half is not
redundant: a NEW generated file is untracked, not modified.

Both invoke `make sqlc`, so `SQLC_VERSION` stays the only pin. A second pin would be a
second answer, and the drift between them would look exactly like stale code.

## Two glob traps that had disabled three existing checks

Both read as `skip, no matching staged files` — which looks like nothing to check, not like
a check that cannot fire. Measured with lefthook 1.13.6.

**`root:` discards before it globs.** It does not merely set the working directory: lefthook
first drops every staged file outside it, then applies the glob. `design-system-tokens` and
`design-system-adoption` both declare a radius over `web/src` — the comment above them said
so — while carrying `root: design-system/`, which made that half unreachable. `--file
web/src/lib/logo.ts` skipped both. They now run via `pnpm --dir` from the repository root;
not `--filter`, since these are separate packages with their own lockfiles rather than a
pnpm workspace.

**`**/` requires a separator.** `design-system/src/**/*.svelte` matches
`src/email/email-preview.svelte` and **not** `src/alert.svelte` — and every primitive is a
direct child of `src/`, so that pattern covered 1 of 26. It is the pattern `tokens` and
`docs` were globbed on.

Net effect: the token-coverage check — which exists to catch a hex literal or an arbitrary
Tailwind value the theme cannot move and the `.dark` selector cannot override — was
reachable from neither of the two places such a literal gets written.

## Verification

Each check was proved by planting its defect, and one probe failed usefully enough to keep:
gitleaks silently ignores `AKIAIOSFODNN7EXAMPLE` for its stop word, and a bare AWS access
key id is not a secret to begin with, so the first attempt looked exactly like a working
scan of a clean tree.

- **gitleaks** — history clean through the config; a planted secret reported in both `dir`
  and `git --staged` modes.
- **squawk** — a probe migration adding a plain `UNIQUE` to `public.users` is reported
  through the git-mode ratchet; the same two findings land on 0119, which added one. An
  unresolvable merge base fails rather than reporting an empty list.
- **sqlc** — an added query is reported; the tree is clean once reverted. No drift today.
- **globs** — all four combinations fire now (web file and direct-child primitive; tokens,
  adoption and docs), checked one at a time with `lefthook run pre-commit --file`.
- The `squawk` binary is resolved from `node_modules` rather than PATH: the hook runs the
  script directly with no `pnpm run` wrapper, so a bare `squawk` would have failed for
  everyone — on the one commit that actually carried a migration. Reproduced with a
  stripped PATH before the fix.

## Not in this PR

`knip` (dead JS code and unused dependencies) is the remaining gap. It is a different class
of check — hygiene rather than correctness or safety — and needs its own SvelteKit entry
configuration, so it belongs in its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Quality & Validation**
  * Added automated checks to keep generated database code synchronized.
  * Added linting for newly added SQL migrations.
  * Strengthened secret scanning for commits and complete repository history.
  * Added verification safeguards for security-scanning tools.
* **Developer Experience**
  * Added pre-commit checks for database code, migrations, and exposed secrets.
  * Documented migration, database-generation, and secret-scanning workflows.
  * Improved design-system check triggers and execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->