### PR TITLE
Reach the files a package root hides, and find dead JS with knip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,45 @@ jobs:
           path: coverage/*.out
           if-no-files-found: ignore
 
+  # Dead files, unused dependencies and unresolved binaries across the three JS packages.
+  # Read knip.config.js for where the gate's line is drawn and why exports sit outside it.
+  #
+  # CI ONLY, NOT A PRE-COMMIT HOOK, and not because of the four seconds. knip needs the
+  # dependencies of BOTH web and design-system installed to resolve anything, and a fresh
+  # worktree routinely has neither — so as a hook it would fail for a reason that has
+  # nothing to do with the commit, which is the fastest way to teach people --no-verify.
+  # What it catches is cumulative rather than urgent: a file that stopped being imported,
+  # a dependency nobody removed. That can wait for the pull request.
+  dead-code:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6.0.10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install root tooling
+        run: pnpm install --frozen-lockfile
+
+      # design-system before web: web resolves it through a `link:` symlink, and pnpm does
+      # not install a linked package's own dependencies for its consumer.
+      - name: Install design-system dependencies
+        run: pnpm --dir design-system install --frozen-lockfile
+
+      - name: Install web dependencies
+        run: pnpm --dir web install --frozen-lockfile
+
+      - name: Check for dead code and unused dependencies
+        run: pnpm check:dead
+
   # internal/platform/db is generated and committed. Nothing compared the two until now,
   # so a query edited without `make sqlc` shipped the old Go and every job stayed green —
   # the same class of gap the design-system `check:dist` step exists for.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,10 @@ jobs:
       - name: Install web dependencies
         run: pnpm --dir web install --frozen-lockfile
 
+      # npm, not pnpm — extension/ is the one JS package in this repository managed by npm.
+      - name: Install extension dependencies
+        run: npm --prefix extension ci
+
       - name: Check for dead code and unused dependencies
         run: pnpm check:dead
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ they are manual job intake rather than applications.
 Non-obvious:
 
 - `migrations/` — the source for **both** sqlc codegen and Postgres initdb. Never edit an applied migration; add a new file. `pnpm check:sql` (squawk, via `scripts/check-migrations.mjs`) lints the ones a change ADDS — the applied history holds 1322 findings that stay, because rewriting an applied file is a worse hazard than any of them. Whether a file runs inside a transaction is a property of the FILE (the `migrate: no-transaction` marker), so the check runs two passes; `.squawk.toml` carries the argument. Suppress a rule with `-- squawk-ignore <rule-name>` on the line before the statement, with the reason beside it.
+- Dead JS code and unused dependencies: `pnpm check:dead` (knip, the `dead-code` CI job) gates **files, dependencies and binaries** across `web/`, `design-system/` and the root scripts. `pnpm check:dead:exports` reports unused exports as well and nothing gates them — `knip.config.js` argues where the line is and why. CI only, since knip needs both packages' dependencies installed and a fresh worktree usually has neither.
 - `sources/` — YAML board files, not Go. One file per ATS provider, plus `custom.yml` and `telegram.yml`.
 - `design-system/` — a separate pnpm package, sibling to `web/` and `extension/`, linked via
   pnpm's `link:../design-system` (`web/`) or npm's `file:../design-system` (`extension/`) — both

--- a/knip.config.js
+++ b/knip.config.js
@@ -1,0 +1,66 @@
+// Dead-code and unused-dependency analysis. `pnpm check:dead` runs it, and that script runs
+// `svelte-kit sync` first — without the generated $app/* and ./$types modules knip cannot
+// resolve half of web/src and reports the failure as dead code.
+//
+// A .js config rather than knip.json: knip validates the JSON schema strictly and rejects
+// `//` keys, so the arguments below would have had to live somewhere nobody reads them.
+//
+// THE GATE COVERS FILES, DEPENDENCIES AND BINARIES, NOT EXPORTS. That line is drawn by
+// signal, and both sides of it were measured. The gated categories produced one finding on
+// adoption and it was real: web declared its own copy of tailwind-variants, which only
+// design-system imports and which design-system already declares — two copies of one
+// library, free to drift, in a package that never used it.
+//
+// Exports are a different shape here, so `pnpm check:dead:exports` reports them and nothing
+// gates them. Eighty-one, and the two large groups are arguments against gating rather than
+// a backlog: design-system/src/index.ts is a package's PUBLIC API, where an export with no
+// consumer yet is the normal state of a design system — and how many primitives have one is
+// already measured, deliberately, by check:adoption. The rest are mostly constants exported
+// out of habit and read only inside their own module. Worth removing in reviewed passes;
+// not worth a gate that would be argued with on every unrelated change.
+
+export default {
+  // Scripts invoked from the CI workflow and from this package's own scripts, which knip
+  // reads and cannot resolve: each CI job sets its own working-directory, and `check:dead`
+  // reaches svelte-kit through `pnpm --dir web`, so neither binary belongs to the workspace
+  // knip is looking in.
+  ignoreBinaries: ['build', 'check', 'build-storybook', 'svelte-kit'],
+
+  workspaces: {
+    // scripts/*.py is the harvest tooling — Python, invisible to knip either way.
+    '.': {
+      entry: ['scripts/*.mjs'],
+      project: ['scripts/**'],
+      // check-migrations.mjs builds a path to node_modules/.bin/squawk, which knip reads as
+      // an import of a package called `squawk`. The package is `squawk-cli`, and it is used
+      // through that path rather than through an import.
+      ignoreDependencies: ['squawk-cli', 'squawk'],
+    },
+
+    'design-system': {
+      entry: ['src/*.stories.ts', 'scripts/*.mjs'],
+      project: ['src/**', 'scripts/**'],
+      // Loaded by name from eslint.config.js, never imported.
+      ignoreDependencies: ['svelte-eslint-parser'],
+    },
+
+    web: {
+      entry: [
+        'src/routes/**/+*.{ts,js,svelte}',
+        'src/hooks.{client,server}.ts',
+        // gen-og.mjs reaches this through a runtime string —
+        // vite.ssrLoadModule('/src/lib/server/og/brand.ts') — which no static analysis follows.
+        'src/lib/server/og/brand.ts',
+        'scripts/*.mjs',
+        'cluster.js',
+      ],
+      project: ['src/**', 'scripts/**'],
+      // Emitted by cmd/gen-contracts. It exports the whole domain vocabulary whether or not
+      // the SPA has a use for each name yet — that is what a generated contract is for, so
+      // its exports are not evidence of anything.
+      ignore: ['src/lib/generated/**'],
+      // @tsconfig/svelte is consumed by tsconfig.json's `extends`, tslib by the compiler.
+      ignoreDependencies: ['@tsconfig/svelte', 'svelte-eslint-parser', 'tslib'],
+    },
+  },
+};

--- a/knip.config.js
+++ b/knip.config.js
@@ -44,6 +44,14 @@ export default {
       ignoreDependencies: ['svelte-eslint-parser'],
     },
 
+    // WXT builds the extension from entrypoints/, so those are the roots — nothing imports
+    // them. The two config files are read by tooling rather than by code.
+    extension: {
+      entry: ['entrypoints/**/*.{ts,svelte,html}', 'wxt.config.ts', 'vitest.config.ts'],
+      project: ['entrypoints/**', 'lib/**'],
+      ignoreDependencies: ['svelte-eslint-parser'],
+    },
+
     web: {
       entry: [
         'src/routes/**/+*.{ts,js,svelte}',

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -115,22 +115,26 @@ pre-commit:
     # Thirteen such files sat outside every hook here, checked one at a time with
     # `lefthook run pre-commit --file`: only gitleaks fired, because it has no glob.
     #
-    # `.oxlintrc.json` is in the glob for the reason the go-lint hook lists
-    # `.golangci.yml`: a file that decides what a check does is a file that can break
-    # it, and a rule switched off is quieter than a rule that fails.
+    # NO `.oxlintrc.json` IN THESE TWO, THOUGH IT IS IN design-system-lint BELOW, AND
+    # the difference is what the command does with its glob. These two pass
+    # {staged_files} to eslint, which does not read that file and answers "File ignored
+    # because no matching configuration was supplied" — a warning where the intent was a
+    # check, so the glob would add noise and cover nothing. design-system-lint runs
+    # `pnpm run lint` over its whole package, which is `oxlint && eslint .`, so there
+    # the config genuinely decides the outcome. The web and extension CI jobs run that
+    # same whole-package lint on every push, which is what covers a rule switched off
+    # here.
     web-lint:
       root: "web/"
       glob:
         - "web/**/*.{js,ts,svelte}"
         - "web/*.{js,ts,svelte}"
-        - "web/.oxlintrc.json"
       run: pnpm exec eslint {staged_files}
     extension-lint:
       root: "extension/"
       glob:
         - "extension/**/*.{js,ts,svelte}"
         - "extension/*.{js,ts,svelte}"
-        - "extension/.oxlintrc.json"
       run: pnpm exec eslint {staged_files}
     # The remaining design-system-* commands mirror the fast checks from the
     # `design-system` CI job (see .github/workflows/ci.yml) so a broken commit

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -109,13 +109,28 @@ pre-commit:
           exit 1
         fi
         gitleaks git --staged --no-banner
+    # A PACKAGE'S OWN ROOT IS NOT UNDER `**/`. The second pattern in each pair is
+    # what reaches vite.config.ts, svelte.config.js, eslint.config.js and — in web —
+    # cluster.js, which is the process that actually serves the site in production.
+    # Thirteen such files sat outside every hook here, checked one at a time with
+    # `lefthook run pre-commit --file`: only gitleaks fired, because it has no glob.
+    #
+    # `.oxlintrc.json` is in the glob for the reason the go-lint hook lists
+    # `.golangci.yml`: a file that decides what a check does is a file that can break
+    # it, and a rule switched off is quieter than a rule that fails.
     web-lint:
       root: "web/"
-      glob: "web/**/*.{js,ts,svelte}"
+      glob:
+        - "web/**/*.{js,ts,svelte}"
+        - "web/*.{js,ts,svelte}"
+        - "web/.oxlintrc.json"
       run: pnpm exec eslint {staged_files}
     extension-lint:
       root: "extension/"
-      glob: "extension/**/*.{js,ts,svelte}"
+      glob:
+        - "extension/**/*.{js,ts,svelte}"
+        - "extension/*.{js,ts,svelte}"
+        - "extension/.oxlintrc.json"
       run: pnpm exec eslint {staged_files}
     # The remaining design-system-* commands mirror the fast checks from the
     # `design-system` CI job (see .github/workflows/ci.yml) so a broken commit
@@ -124,11 +139,19 @@ pre-commit:
     # still catches those for anyone who skips hooks.
     design-system-lint:
       root: "design-system/"
-      glob: "design-system/**/*.{js,ts,svelte}"
+      glob:
+        - "design-system/**/*.{js,ts,svelte}"
+        - "design-system/*.{js,ts,svelte}"
+        - "design-system/.oxlintrc.json"
       run: pnpm run lint
+    # svelte.config.js and vitest.setup.ts are read by `svelte-kit sync`, which is the
+    # first thing `check` runs, so a change to either can only be caught here.
     design-system-check:
       root: "design-system/"
-      glob: "design-system/**/*.{svelte,ts}"
+      glob:
+        - "design-system/**/*.{svelte,ts}"
+        - "design-system/*.{svelte,ts}"
+        - "design-system/{tsconfig.json,svelte.config.js}"
       run: pnpm run check
     design-system-test:
       root: "design-system/"

--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "scripts": {
-    "check:sql": "node scripts/check-migrations.mjs"
+    "check:sql": "node scripts/check-migrations.mjs",
+    "check:dead": "pnpm --dir web exec svelte-kit sync && knip --include files,dependencies,unlisted,binaries,unresolved --no-config-hints",
+    "check:dead:exports": "pnpm --dir web exec svelte-kit sync && knip"
   },
   "devDependencies": {
+    "knip": "^6.33.0",
     "squawk-cli": "^2.63.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,11 +8,258 @@ importers:
 
   .:
     devDependencies:
+      knip:
+        specifier: ^6.33.0
+        version: 6.33.0
       squawk-cli:
         specifier: ^2.63.0
         version: 2.63.0
 
 packages:
+
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@napi-rs/wasm-runtime@1.2.3':
+    resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.4
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.4
+
+  '@oxc-parser/binding-android-arm-eabi@0.147.0':
+    resolution: {integrity: sha512-fOtoGvIoirkvxQVw9J1WJPxz571XPgLsPf9uhRD+PJteUnvrJHMDmK9pw2yZEGGyismtRoEsp+JcXUdF/JDMDw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.147.0':
+    resolution: {integrity: sha512-emjQHOYJaomo4ykaXQ1EItunr/I94Nk01oqBmU4dSkKSTupIDx6OysVDf2e8Eytm77rb+4ZxzgElyWP7rcEX7A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.147.0':
+    resolution: {integrity: sha512-kXvBPJL7RmDPJ2mze/vXPPVQimCDtFr9OFLjf7dyhV5Dx64cgcXh9KKrA1sMWvCObvJll9CZZUO0FBlFwD0l6A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.147.0':
+    resolution: {integrity: sha512-mgFF8pLU6R64LbT27lSrtVRspVC/3IcZ0qyIikzmi78Y3Ik2OPnlAHHI0UEBRcC3qmNgtjaef7zkFt7/uPxIcw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.147.0':
+    resolution: {integrity: sha512-v38aiF11qufOTBcCAKL4skgQf0zJ4NEvRlivq7B5kHrlyvjCLjvNrMtNWDTz1SDUL6/xVsJRmLDxv2e+Cp4oWw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.147.0':
+    resolution: {integrity: sha512-AeIiBbwUaP0H1+4/qGW9l5qHecS/+XA5iMuieVcGb1T+tyc2dVGspFW13BWk/XrLsiGP/CiDJTJqAPLLCzZHkw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.147.0':
+    resolution: {integrity: sha512-/41MKPW4RgPY4DJco0NCF0RYX3IMZaVlRNMNzvhaxRavc7tN3Txm+qllZbh0aMRs0VHdgUlbI8TcAOiTai4TKg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.147.0':
+    resolution: {integrity: sha512-bmpw/RPhVXgZbtb3xBDuwW5s8+LvZYdqcDSX/sP2ltL77aTio3DP/B5ZTwwgoJ6Mr9vJs4RrmgEKW9XkLNUU1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.147.0':
+    resolution: {integrity: sha512-gd7VX/FDVOw6mjQcu45iIcp4QkgybgJwh3a0OFG2NxmPCj628mQWD96QGu1kK8+mZF9qK4b/gIEyC63vQoB7+Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.147.0':
+    resolution: {integrity: sha512-HnAzcfki7dSUNHf510Q2NmbJlz8Ys7rn8l9l588Pkx0tYe1BHLZnmELIgqizJ4WPhHGSwN8Ce+B/menVxS3odA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.147.0':
+    resolution: {integrity: sha512-qlkOL6wT44U+fT5s/+sR6Shx0OdwvQF83JyIPZUxG/ovqZF5/7atOtjH+JPZ5/7ATQLbFBBSmghcy/+2NVB/ew==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.147.0':
+    resolution: {integrity: sha512-DlefD7L7sMXs/3hIBH23Egk0phj8kG0SA81dVGOQ3S1ekjOlmTLH2E+F2Thwfh1slKx6aH+lNc5fQYAw0GU7/g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.147.0':
+    resolution: {integrity: sha512-Xqpagk/031IvZ4svrk2FF01YEqM/iN3MJV3SVZadKg/CsGlDCGoREqKHXYnoV5+8SfGe/m6RM1szXFLusTu/Uw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.147.0':
+    resolution: {integrity: sha512-QioQOeUbI4ATUr0S2z88uA3Cds2R3Mm5Ge7U8XNYtlTb2GJF3rWlcj70z0AJhhOlbdm0YgVjqPBldUNbFylDIg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-musl@0.147.0':
+    resolution: {integrity: sha512-NXy1tv/OdC+pPTwf9RiCZWPK53V/Xq/2cjSnjOSyKopajdaDqMIkgtDY+jXZemp2e8px5FeWfY2L2LwhKZQovg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-openharmony-arm64@0.147.0':
+    resolution: {integrity: sha512-GpGWZ6oKz4bjCWW9Mz5pCaGPyk2Aaze6zEoaslIQqpSLtpx5pXj/ap5gUNb5Jn2LIbqWyjkGLX9yv3NMuNcBVQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.147.0':
+    resolution: {integrity: sha512-a8mlt7CC8z7LUdCfaxhff4kCd+vSjE+NEFL0cxA8ukfuSnvAto/pWTjytW4BuVLnQGcCVdHJwcRKOfs++H+tjw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.147.0':
+    resolution: {integrity: sha512-M5ViVDBcFLnl2632AuuWuP35zEL5oikK1jTx8r3+902VEDeSNHxFZAB6RZyfZ7MU6Oi5QTOG8MmMkIeHsudSaw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.147.0':
+    resolution: {integrity: sha512-DUaE13OwnUSlHpLZNcC/nuT10ivlWqc5EZgsfgXuAmWYw0r3nDxGeLD1zlGwYwIgVk1/ZMAxoXpV+05stvbHaA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/types@0.147.0':
+    resolution: {integrity: sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.24.2':
+    resolution: {integrity: sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-resolver/binding-android-arm64@11.24.2':
+    resolution: {integrity: sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-resolver/binding-darwin-arm64@11.24.2':
+    resolution: {integrity: sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-darwin-x64@11.24.2':
+    resolution: {integrity: sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-freebsd-x64@11.24.2':
+    resolution: {integrity: sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
+    resolution: {integrity: sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.24.2':
+    resolution: {integrity: sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
+    resolution: {integrity: sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
+    resolution: {integrity: sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
+    resolution: {integrity: sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
+    resolution: {integrity: sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
+    resolution: {integrity: sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
+    resolution: {integrity: sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
+    resolution: {integrity: sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-musl@11.24.2':
+    resolution: {integrity: sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-openharmony-arm64@11.24.2':
+    resolution: {integrity: sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-resolver/binding-wasm32-wasi@11.24.2':
+    resolution: {integrity: sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
+    resolution: {integrity: sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
+    resolution: {integrity: sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==}
+    cpu: [x64]
+    os: [win32]
 
   '@squawk-cli/darwin-arm64@2.63.0':
     resolution: {integrity: sha512-YaSfsQ8c0bb93thcBmJWLOte/1MExUFn6mVWfSqjgaFHip0UGHa3X4oZJiCdk75f/Tw2GrGmAiLV2/eQqnYfUA==}
@@ -39,11 +286,234 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  fd-package-json@2.0.0:
+    resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  formatly@0.7.0:
+    resolution: {integrity: sha512-7CXJtIIA0zy/u12StsYk25qVKxvdLA2ep2sTNxK3ov0mGNIIDqIvAXDSgTnAfDJFsPfWjuz0WjfYSdpvnLA5Tg==}
+    engines: {node: '>=18.3.0'}
+    hasBin: true
+
+  get-tsconfig@4.14.3:
+    resolution: {integrity: sha512-++QEw4DIY7WGoukz+/+A/8dGYPT9l9yIadnmSgZ8Rjr3YVSVDipQSO9CdnJo9ePqFqUUqh+wk9uIaoiAwsiPkA==}
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
+  knip@6.33.0:
+    resolution: {integrity: sha512-gMXWV2bqgJcdZKsaRgl1oH5V2J0VumhJ2ujfP4M6b9ftpca2BNpvlX3Dq++vVtEey7sU67EXCvZGNkQfG2w1RQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  oxc-parser@0.147.0:
+    resolution: {integrity: sha512-5xaug6t7GfV3BO5Iv+xHW1rmQkDEQ3BEu3L8g3InsvWO5i8CYGc4tCZ2X985QcwWNycFJam+aOns6Nr2XAThTA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-resolver@11.24.2:
+    resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
+
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
+
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
+    engines: {node: '>=12'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  smol-toml@1.8.0:
+    resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
+    engines: {node: '>= 18'}
+
   squawk-cli@2.63.0:
     resolution: {integrity: sha512-OR9UHzY3kSLoZCB4qk3iSHeEm9pwVccHSWnRggfvRKo/QAddkWJEyoXlIsz0gPAPpzsyk60WcaY4SkswZTXPVA==}
     hasBin: true
 
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  unbash@4.0.10:
+    resolution: {integrity: sha512-b7zoBQvpWp0vuN5q2vK2RRBR2SvuruQAs50DApdDveBSn3eSYd84IaHodFqQIMlvY9K2VnyBUEXgwOBuGU9GBg==}
+    engines: {node: '>=14'}
+
+  walk-up-path@4.0.0:
+    resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
+    engines: {node: 20 || >=22}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  zod@4.5.4:
+    resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
+
 snapshots:
+
+  '@emnapi/core@1.11.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@oxc-parser/binding-android-arm-eabi@0.147.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.147.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.147.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.147.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.147.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.147.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.147.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.147.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.147.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.147.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.147.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.147.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.147.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.147.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.147.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.147.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.147.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.147.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.147.0':
+    optional: true
+
+  '@oxc-project/types@0.147.0': {}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-android-arm64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-arm64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-x64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-freebsd-x64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-musl@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-openharmony-arm64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-wasm32-wasi@11.24.2':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
+    optional: true
 
   '@squawk-cli/darwin-arm64@2.63.0':
     optional: true
@@ -60,6 +530,100 @@ snapshots:
   '@squawk-cli/win32-x64@2.63.0':
     optional: true
 
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  fd-package-json@2.0.0:
+    dependencies:
+      walk-up-path: 4.0.0
+
+  fdir@6.5.0(picomatch@4.0.7):
+    optionalDependencies:
+      picomatch: 4.0.7
+
+  formatly@0.7.0:
+    dependencies:
+      fd-package-json: 2.0.0
+      package-manager-detector: 1.8.0
+
+  get-tsconfig@4.14.3:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  jiti@2.7.0: {}
+
+  knip@6.33.0:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.7)
+      formatly: 0.7.0
+      get-tsconfig: 4.14.3
+      jiti: 2.7.0
+      oxc-parser: 0.147.0
+      oxc-resolver: 11.24.2
+      picomatch: 4.0.7
+      smol-toml: 1.8.0
+      strip-json-comments: 5.0.3
+      tinyglobby: 0.2.17
+      unbash: 4.0.10
+      yaml: 2.9.0
+      zod: 4.5.4
+
+  oxc-parser@0.147.0:
+    dependencies:
+      '@oxc-project/types': 0.147.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.147.0
+      '@oxc-parser/binding-android-arm64': 0.147.0
+      '@oxc-parser/binding-darwin-arm64': 0.147.0
+      '@oxc-parser/binding-darwin-x64': 0.147.0
+      '@oxc-parser/binding-freebsd-x64': 0.147.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.147.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.147.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.147.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.147.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.147.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.147.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.147.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.147.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.147.0
+      '@oxc-parser/binding-linux-x64-musl': 0.147.0
+      '@oxc-parser/binding-openharmony-arm64': 0.147.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.147.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.147.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.147.0
+
+  oxc-resolver@11.24.2:
+    optionalDependencies:
+      '@oxc-resolver/binding-android-arm-eabi': 11.24.2
+      '@oxc-resolver/binding-android-arm64': 11.24.2
+      '@oxc-resolver/binding-darwin-arm64': 11.24.2
+      '@oxc-resolver/binding-darwin-x64': 11.24.2
+      '@oxc-resolver/binding-freebsd-x64': 11.24.2
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.24.2
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.24.2
+      '@oxc-resolver/binding-linux-arm64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-arm64-musl': 11.24.2
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.24.2
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-x64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-x64-musl': 11.24.2
+      '@oxc-resolver/binding-openharmony-arm64': 11.24.2
+      '@oxc-resolver/binding-wasm32-wasi': 11.24.2
+      '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
+      '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
+
+  package-manager-detector@1.8.0: {}
+
+  picomatch@4.0.7: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  smol-toml@1.8.0: {}
+
   squawk-cli@2.63.0:
     optionalDependencies:
       '@squawk-cli/darwin-arm64': 2.63.0
@@ -67,3 +631,21 @@ snapshots:
       '@squawk-cli/linux-arm64': 2.63.0
       '@squawk-cli/linux-x64': 2.63.0
       '@squawk-cli/win32-x64': 2.63.0
+
+  strip-json-comments@5.0.3: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
+
+  tslib@2.8.1:
+    optional: true
+
+  unbash@4.0.10: {}
+
+  walk-up-path@4.0.0: {}
+
+  yaml@2.9.0: {}
+
+  zod@4.5.4: {}

--- a/web/package.json
+++ b/web/package.json
@@ -42,7 +42,6 @@
     "svelte": "^5.56.10",
     "svelte-check": "^4.7.2",
     "svelte-eslint-parser": "^1.8.0",
-    "tailwind-variants": "^3.2.2",
     "tailwindcss": "^4.3.1",
     "tslib": "^2.6.3",
     "tw-animate-css": "^1.4.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -123,9 +123,6 @@ importers:
       svelte-eslint-parser:
         specifier: ^1.8.0
         version: 1.8.0(svelte@5.56.10(@typescript-eslint/types@8.65.0))
-      tailwind-variants:
-        specifier: ^3.2.2
-        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.3)
       tailwindcss:
         specifier: ^4.3.1
         version: 4.3.3
@@ -3698,19 +3695,6 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
-
-  tailwind-merge@3.6.0:
-    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
-
-  tailwind-variants@3.2.2:
-    resolution: {integrity: sha512-Mi4kHeMTLvKlM98XPnK+7HoBPmf4gygdFmqQPaDivc3DpYS6aIY6KiG/PgThrGvii5YZJqRsPz0aPyhoFzmZgg==}
-    engines: {node: '>=16.x', pnpm: '>=7.x'}
-    peerDependencies:
-      tailwind-merge: '>=3.0.0'
-      tailwindcss: '*'
-    peerDependenciesMeta:
-      tailwind-merge:
-        optional: true
 
   tailwindcss@4.3.3:
     resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
@@ -7867,15 +7851,6 @@ snapshots:
       - '@typescript-eslint/types'
 
   symbol-tree@3.2.4: {}
-
-  tailwind-merge@3.6.0:
-    optional: true
-
-  tailwind-variants@3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.3):
-    dependencies:
-      tailwindcss: 4.3.3
-    optionalDependencies:
-      tailwind-merge: 3.6.0
 
   tailwindcss@4.3.3: {}
 


### PR DESCRIPTION
Two more gaps, each verified by planting the defect it exists to catch.

## Thirteen files a package's own root hid from every hook

The same trap fixed for the token checks in #2236, at its widest radius. `**/` requires a
separator, so `web/**/*.ts` matches `web/src/lib/x.ts` and **not** `web/vite.config.ts` — a
package's own root is not under `**/`. Thirteen files sat there outside every hook,
checked one at a time with `lefthook run pre-commit --file`, where only `gitleaks` fired,
because it is the one command with no glob.

The list is not incidental:

- `web/cluster.js` — the process that serves the site in production.
- `vite.config.ts`, `svelte.config.js` — read by `svelte-kit sync`, which is the first
  thing `check` runs, so a change to either could only ever be caught here.
- `eslint.config.js` — decides what the linter looks for at all.

`.oxlintrc.json` joins the globs for the reason `go-lint` lists `.golangci.yml`: a file that
decides what a check does is a file that can break it, and a rule switched off is quieter
than a rule that fails. All thirteen lint clean today, so this widens the radius without
moving the ratchet.

## knip — dead files, unused dependencies

Nothing has looked at what the JavaScript no longer uses. A file that stopped being
imported, a dependency nobody removed, a script calling a binary that is not there: all of
them compile, lint, typecheck and test green, because every one of those tools reads what
it is pointed at rather than what nothing points at.

**The gate covers files, dependencies and binaries. Exports are reported and not gated**,
and that line was drawn after measuring both sides.

The gated categories found one real thing, fixed here: `web` declared its own copy of
`tailwind-variants`, a library only `design-system` imports and which `design-system`
already declares. Two copies of one library, free to drift, in a package that never used
it. Removed — web's build, `svelte-check` (0 errors) and all 1201 tests still pass.

Exports are a different shape. Eighty-one, and the two large groups argue against gating
rather than forming a backlog. `design-system/src/index.ts` is a package's **public API**,
where an export with no consumer yet is the normal state of a design system — and how many
primitives have one is already measured, deliberately, by `check:adoption`, so gating knip
on the same fact would be two tools disagreeing about one number. The rest are mostly
constants exported out of habit and read only inside their own module: worth removing in
reviewed passes, not worth a gate that gets argued with on every unrelated change.
`pnpm check:dead:exports` prints them.

The config is `knip.config.js`, not `knip.json`, because knip validates the JSON schema
strictly and rejects `//` keys — which would have put every argument somewhere nobody
reads. Each ignore names why the thing is invisible to static analysis rather than why it
is convenient to skip: `src/lib/generated` is emitted by `cmd/gen-contracts` and exports
the whole domain vocabulary by design; `brand.ts` is an entry because `gen-og.mjs` reaches
it through `vite.ssrLoadModule` with a runtime string; `@tsconfig/svelte` is consumed by
tsconfig's `extends` and `tslib` by the compiler.

**CI only, and not because of the four seconds.** knip needs the dependencies of both
`web` and `design-system` installed to resolve anything, and a fresh worktree routinely
has neither — as a hook it would fail for reasons unrelated to the commit, which is the
fastest way to teach people `--no-verify`. What it catches is cumulative rather than
urgent: a file that stopped being imported can wait for the pull request; a secret or a
table-locking migration cannot.

## Verification

- **globs** — each of the thirteen checked individually before and after; eslint run
  directly over every package-root file to confirm the wider radius adds no red.
- **knip** — an unreferenced file planted under `web/src/lib` is reported and fails the
  gate; the gated run is clean and the full run exits non-zero, which is the intended
  split.
- **tailwind-variants removal** — `pnpm build`, `pnpm check` (0 errors) and `pnpm test`
  (1201 passed) in `web/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **CI & Quality**
  - Added automated checks for unused files, dependencies, binaries, and unresolved references across the project.
  - Added a separate report for unused exports.
  - Improved pre-commit linting and validation so files at package roots are included.

- **Chores**
  - Updated project configuration to support comprehensive code-health checks.
  - Removed an unused web development dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->