### PR TITLE
Clear the unused-export backlog, and widen the knip gate to cover it

### DIFF
--- a/extension/lib/applyPlan.ts
+++ b/extension/lib/applyPlan.ts
@@ -37,7 +37,7 @@ export interface PlanItem {
 }
 
 /** How far along the questions that gate submission are. */
-export interface RequiredProgress {
+interface RequiredProgress {
   answered: number;
   total: number;
   /** Rounded to whole percent — the panel shows a figure, not a measurement. */

--- a/extension/lib/assistant/chat.ts
+++ b/extension/lib/assistant/chat.ts
@@ -11,7 +11,7 @@ import type { ToolCall } from './tool-formatters';
  *  call with its arguments and, once it comes back, its result) while
  *  `streaming`; `errored` is set when the turn ends with an error. User messages
  *  carry only `text`. */
-export interface ChatMessage {
+interface ChatMessage {
   role: 'user' | 'assistant';
   text: string;
   thinking: string;

--- a/extension/lib/assistant/deck.ts
+++ b/extension/lib/assistant/deck.ts
@@ -19,7 +19,7 @@ export interface DeckEntry {
   concerns: string[];
 }
 
-export interface JobDeck {
+interface JobDeck {
   heading?: string;
   entries: DeckEntry[];
 }

--- a/extension/lib/assistant/wire.ts
+++ b/extension/lib/assistant/wire.ts
@@ -7,7 +7,7 @@
 // read-only.
 
 /** Why a turn ended. Every turn ends with exactly one `result`. */
-export type StopReason = 'end_turn' | 'max_steps' | 'cancelled' | 'error' | (string & {});
+type StopReason = 'end_turn' | 'max_steps' | 'cancelled' | 'error' | (string & {});
 
 /** One streamed frame of a turn. */
 export type TurnEvent =

--- a/extension/lib/form.ts
+++ b/extension/lib/form.ts
@@ -18,7 +18,7 @@ type Fillable = HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
 const SKIP_TYPES = new Set(['hidden', 'submit', 'button', 'reset', 'image', 'file']);
 
 /** The ordered list of fillable controls on the page. */
-export function collectFillable(doc: Document): Fillable[] {
+function collectFillable(doc: Document): Fillable[] {
   const all = Array.from(doc.querySelectorAll<Fillable>('input, select, textarea'));
   return all.filter((el) => {
     if (el.disabled) return false;
@@ -224,7 +224,7 @@ function describeQuestion({ label, controls }: Question, index: number, forms: H
  * A react-select renders its listbox only once opened, so this is empty for one
  * that is closed — the agent reaches for `combobox.open` in that case.
  */
-export function comboOptions(el: Element): string[] {
+function comboOptions(el: Element): string[] {
   return comboOptionNodes(el).map(collapseText).filter(Boolean);
 }
 
@@ -659,7 +659,7 @@ function startsWithOption(value: string, option: string): boolean {
 }
 
 /** Writes one control, dispatching native events. Returns false if unfillable. */
-export function fillField(el: Fillable, value: string): boolean {
+function fillField(el: Fillable, value: string): boolean {
   if (el instanceof HTMLInputElement && (el.type === 'checkbox' || el.type === 'radio')) {
     el.checked = value === 'true' || value === '1' || normalizeLabel(value) === 'yes';
     dispatchNative(el);

--- a/extension/lib/freehire.ts
+++ b/extension/lib/freehire.ts
@@ -187,13 +187,13 @@ export function listSavedSlugs(token: string): Promise<string[]> {
 /** A cached AI fit analysis — only the fields the compact card reads. Never computes
  *  inline: this is a read of whatever the full-page analysis last cached, same
  *  contract as web's MatchSummary.svelte. */
-export interface MatchAnalysisSummary {
+interface MatchAnalysisSummary {
   overall_score: number;
   verdict: string;
   gaps: string[];
 }
 
-export interface MatchAnalysisCredits {
+interface MatchAnalysisCredits {
   remaining: number;
   resets_at: string;
 }

--- a/extension/lib/tools/client.ts
+++ b/extension/lib/tools/client.ts
@@ -17,7 +17,7 @@ import { parseToolCall } from './wire';
 export const WS_SUBPROTOCOL_MARKER = 'freehire-jwt';
 
 /** The relay endpoint, joined as the extension end of this user's channel. */
-export function toolsWsUrl(): string {
+function toolsWsUrl(): string {
   return `${HIRE_ORIGIN.replace(/^http/, 'ws')}/api/v1/tools/ws?role=extension`;
 }
 

--- a/knip.config.js
+++ b/knip.config.js
@@ -5,19 +5,26 @@
 // A .js config rather than knip.json: knip validates the JSON schema strictly and rejects
 // `//` keys, so the arguments below would have had to live somewhere nobody reads them.
 //
-// THE GATE COVERS FILES, DEPENDENCIES AND BINARIES, NOT EXPORTS. That line is drawn by
-// signal, and both sides of it were measured. The gated categories produced one finding on
-// adoption and it was real: web declared its own copy of tailwind-variants, which only
-// design-system imports and which design-system already declares — two copies of one
-// library, free to drift, in a package that never used it.
+// THE GATE COVERS EVERYTHING KNIP REPORTS, INCLUDING EXPORTS, and it took a cleanup to get
+// there. The first run found 81 unused exports, which is the number that usually turns into
+// "report them, do not gate them". Working through them left 13, and every one was
+// deliberate rather than forgotten — so the argument moved out of this file and next to the
+// code, as a JSDoc `@public` tag with the reason beside it. That is the better home for it:
+// a config-level exemption is invisible from the line it excuses.
 //
-// Exports are a different shape here, so `pnpm check:dead:exports` reports them and nothing
-// gates them. Eighty-one, and the two large groups are arguments against gating rather than
-// a backlog: design-system/src/index.ts is a package's PUBLIC API, where an export with no
-// consumer yet is the normal state of a design system — and how many primitives have one is
-// already measured, deliberately, by check:adoption. The rest are mostly constants exported
-// out of habit and read only inside their own module. Worth removing in reviewed passes;
-// not worth a gate that would be argued with on every unrelated change.
+// The two shapes that earned a tag:
+//
+//   web/src/lib/types.ts, cv.ts and collections.ts re-export the generated contract under
+//   the app's own names. A name is carried there whether or not a screen reads it yet —
+//   that is what the facade is for, and a missing one is the bug it prevents.
+//
+//   stages.ts exports a compile-time assertion. Declaring it IS the check; `export` is only
+//   what stops the linter deleting it as an unused local.
+//
+// Everything else was a real finding. 50 exports were read only inside their own module and
+// simply lost the keyword; that in turn let eslint see three genuinely dead declarations it
+// could not see through an export, which is worth knowing — knip and no-unused-vars answer
+// different halves of one question, and neither is complete alone.
 
 export default {
   // Scripts invoked from the CI workflow and from this package's own scripts, which knip
@@ -47,7 +54,7 @@ export default {
     // WXT builds the extension from entrypoints/, so those are the roots — nothing imports
     // them. The two config files are read by tooling rather than by code.
     extension: {
-      entry: ['entrypoints/**/*.{ts,svelte,html}', 'wxt.config.ts', 'vitest.config.ts'],
+      entry: ['entrypoints/**/*.{ts,svelte,html}'],
       project: ['entrypoints/**', 'lib/**'],
       ignoreDependencies: ['svelte-eslint-parser'],
     },

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "packageManager": "pnpm@11.7.0",
   "scripts": {
     "check:sql": "node scripts/check-migrations.mjs",
-    "check:dead": "pnpm --dir web exec svelte-kit sync && knip --include files,dependencies,unlisted,binaries,unresolved --no-config-hints",
-    "check:dead:exports": "pnpm --dir web exec svelte-kit sync && knip"
+    "check:dead": "pnpm --dir web exec svelte-kit sync && knip"
   },
   "devDependencies": {
     "knip": "^6.33.0",

--- a/web/src/lib/assistant/bulletCapAlert.ts
+++ b/web/src/lib/assistant/bulletCapAlert.ts
@@ -1,5 +1,5 @@
 /** Stable token the backend embeds in ErrListCap tool/HTTP errors. */
-export const BULLET_CAP_CODE = 'bullet_cap';
+const BULLET_CAP_CODE = 'bullet_cap';
 
 /**
  * Candidate-facing copy when a cv_edit was refused because a role is at the

--- a/web/src/lib/assistant/chat.ts
+++ b/web/src/lib/assistant/chat.ts
@@ -11,7 +11,7 @@ import type { ToolCall } from './tool-formatters';
  *  call with its arguments and, once it comes back, its result) while
  *  `streaming`; `errored` is set when the turn ends with an error. User messages
  *  carry only `text`. */
-export interface ChatMessage {
+interface ChatMessage {
   role: 'user' | 'assistant';
   text: string;
   thinking: string;

--- a/web/src/lib/assistant/client.ts
+++ b/web/src/lib/assistant/client.ts
@@ -39,7 +39,7 @@ export class StreamInterrupted extends Error {
 
 /** Ask the server to stop a session's running turn. Safe to call when nothing is
  *  running: the caller cannot know whether the turn it stopped watching has ended. */
-export async function cancelTurn(sessionId: string): Promise<void> {
+async function cancelTurn(sessionId: string): Promise<void> {
   try {
     await fetch(`${BASE}/sessions/${encodeURIComponent(sessionId)}/cancel`, {
       method: 'POST',

--- a/web/src/lib/assistant/deck.ts
+++ b/web/src/lib/assistant/deck.ts
@@ -19,7 +19,7 @@ export interface DeckEntry {
   concerns: string[];
 }
 
-export interface JobDeck {
+interface JobDeck {
   heading?: string;
   entries: DeckEntry[];
 }

--- a/web/src/lib/assistant/wire.ts
+++ b/web/src/lib/assistant/wire.ts
@@ -7,7 +7,7 @@
 // read-only.
 
 /** Why a turn ended. Every turn ends with exactly one `result`. */
-export type StopReason = 'end_turn' | 'max_steps' | 'cancelled' | 'error' | (string & {});
+type StopReason = 'end_turn' | 'max_steps' | 'cancelled' | 'error' | (string & {});
 
 /** One streamed frame of a turn. */
 export type TurnEvent =

--- a/web/src/lib/authCookie.ts
+++ b/web/src/lib/authCookie.ts
@@ -2,7 +2,7 @@
 // httpOnly, so nothing here can read its value — only whether it is present.
 
 /** Name of the session cookie the API sets. */
-export const SESSION_COOKIE = 'hire_token';
+const SESSION_COOKIE = 'hire_token';
 
 /** Whether a request's raw `Cookie` header carries a session.
  *

--- a/web/src/lib/calendarModel.ts
+++ b/web/src/lib/calendarModel.ts
@@ -56,7 +56,7 @@ function pad(n: number): string {
 /** The reader's own calendar date for an instant. Local accessors, deliberately: the
  *  UTC ones would file a late-evening event on the previous day for anyone east of
  *  Greenwich, and on the next one for anyone west of it. */
-export function dayKey(d: Date): string {
+function dayKey(d: Date): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 }
 

--- a/web/src/lib/collections.ts
+++ b/web/src/lib/collections.ts
@@ -589,6 +589,7 @@ export function toQuery(params: Record<string, string | string[]>): string {
 // mirror could get wrong silently, which is why this stopped being hand-kept.
 export { COLLECTIONS } from './generated/contracts';
 import { COLLECTIONS as COMPANY_COLLECTIONS } from './generated/contracts';
+/** @public */
 export type { Collection, CollectionKind } from './generated/contracts';
 
 // A resolved collection: the display copy plus the fixed job-search facet params

--- a/web/src/lib/companyFacetModel.ts
+++ b/web/src/lib/companyFacetModel.ts
@@ -18,7 +18,7 @@ import { COMPANY_FACETS } from './facets';
  *  the backend forces every rating-sorted request onto its Postgres path, since
  *  rating isn't a Meili-sortable attribute yet. */
 export type CompanySortField = 'job_count' | 'rating';
-export const DEFAULT_COMPANY_SORT: CompanySortField = 'job_count';
+const DEFAULT_COMPANY_SORT: CompanySortField = 'job_count';
 
 export interface CompanyFilters {
   q: string;

--- a/web/src/lib/companyFilters.ts
+++ b/web/src/lib/companyFilters.ts
@@ -1,7 +1,8 @@
 // Reactive company-catalog filters mirrored into the URL. The pure model (types,
 // serialization, mutators) lives in companyFacetModel.ts (unit-testable, $app-free);
-// this module owns only the reactive UrlSyncedState wrapper. Re-exports the model's
-// public surface so existing `$lib/companyFilters` importers are unchanged.
+// this module owns only the reactive UrlSyncedState wrapper. It re-exports the part of the
+// model that is still reached through this path; the rest of the model's callers import it
+// directly, so a name is re-exported here only while something actually asks for it here.
 
 import { type FacetSelection, type FacetStore } from './facets';
 import {
@@ -10,7 +11,6 @@ import {
   clearCompanyFacet,
   companyFiltersFromParams,
   companyFiltersToParams,
-  DEFAULT_COMPANY_SORT,
   emptyCompanyFilters,
   removeCompanyFacet,
   toggleCompanyFacet,
@@ -20,11 +20,8 @@ import {
 import { UrlSyncedState } from './urlSynced.svelte';
 
 export {
-  activeCompanyFilterCount,
   companyFiltersFromParams,
   companyFiltersToParams,
-  DEFAULT_COMPANY_SORT,
-  emptyCompanyFilters,
   type CompanyFilters,
   type CompanySortField,
 };

--- a/web/src/lib/cv.ts
+++ b/web/src/lib/cv.ts
@@ -103,12 +103,11 @@ export interface JdResolveInput {
   company?: string;
 }
 
-export const DEFAULT_TEMPLATE_ID = 'classic-ats';
-
 /** A CV template the user can pick in the gallery. `photo` marks the templates that print the
  *  profile headshot — the gallery prompts for an upload when there is none. Mirrors
  *  cv.TemplateInfo. */
 // The two-report comparison behind the tailoring ATS delta.
+/** @public */
 export type { Delta as AtsDelta, CategoryChange as AtsCategoryChange } from './generated/contracts';
 
 /** The tailoring ATS-delta response: what tailoring did to the CV's ATS readiness, measured on
@@ -154,8 +153,8 @@ export interface CvFont {
 /** A fresh, fully-populated (but empty) document so the form can bind every section
  *  without null-guards. The server still sanitizes on save, dropping the empties. */
 /** The half-inch-per-side page margins a fresh CV starts with (mirrors cv.DefaultMargins). */
-export const DEFAULT_MARGIN = 0.5;
-export function defaultMargins(): Margins {
+const DEFAULT_MARGIN = 0.5;
+function defaultMargins(): Margins {
   return { top: DEFAULT_MARGIN, right: DEFAULT_MARGIN, bottom: DEFAULT_MARGIN, left: DEFAULT_MARGIN };
 }
 
@@ -174,7 +173,7 @@ function toMargins(m?: Partial<Margins>): Margins {
  *  empty/zero, which is what tells the renderer to use the active template's own typography.
  *  Filling these in would send concrete values back on the next autosave and freeze whichever
  *  template happened to be selected into the document. */
-export function emptyStyle(): Style {
+function emptyStyle(): Style {
   return { font_family: '', font_size: 0, line_height: 0 };
 }
 

--- a/web/src/lib/docs/nav.ts
+++ b/web/src/lib/docs/nav.ts
@@ -16,7 +16,7 @@ export function slugify(s: string): string {
 }
 
 /** A group's URL segment. */
-export const groupSlug = (title: string) => slugify(title);
+const groupSlug = (title: string) => slugify(title);
 
 // An endpoint's URL segment within its group: the path (param names kept, so
 // `/jobs` and `/jobs/{slug}` don't collide) with any leading group-name segment
@@ -77,7 +77,3 @@ export function findEndpoint(gSlug: string, epSlug: string): { group: NavGroup; 
   const entry = group.endpoints.find((e) => e.slug === epSlug);
   return entry ? { group, entry } : null;
 }
-
-/** Every endpoint route, for prerender enumeration. */
-export const allEntries = () =>
-  NAV.flatMap((g) => g.endpoints.map((e) => ({ group: g.slug, endpoint: e.slug })));

--- a/web/src/lib/emailStatus.ts
+++ b/web/src/lib/emailStatus.ts
@@ -23,7 +23,7 @@ export const STATUS_LABELS: Record<EmailStatusSignal, string> = {
   other: '',
 };
 
-export const STATUS_CLASSES: Record<EmailStatusSignal, string> = {
+const STATUS_CLASSES: Record<EmailStatusSignal, string> = {
   acknowledgement: 'border-border text-muted-foreground',
   screening: 'border-blue-400/40 text-blue-600 dark:text-blue-400',
   interview_invitation: 'border-emerald-400/50 text-emerald-600 dark:text-emerald-400',

--- a/web/src/lib/enrichment.ts
+++ b/web/src/lib/enrichment.ts
@@ -17,7 +17,7 @@ import {
  *  job-search filter, the /jobs URL that applies it. `flag` carries an ISO 3166-1
  *  alpha-2 code for the country facet, so the renderer shows a flag icon (with
  *  `text` as its accessible name) instead of the bare code. */
-export interface FacetValue {
+interface FacetValue {
   text: string;
   href?: string;
   flag?: string;
@@ -112,7 +112,7 @@ export function seniorityLabel(e: Pick<Enrichment, 'seniority'>): string | null 
  * reach or an onsite role's area). Null when regions is unknown (empty is
  * unknown, not global).
  */
-export function regionLabel(job: Pick<Job, 'regions'>): string | null {
+function regionLabel(job: Pick<Job, 'regions'>): string | null {
   if (!job.regions?.length) return null;
   return job.regions.map((r) => label(REGION_LABELS, r)).join(', ');
 }

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -49,7 +49,7 @@ export interface FacetOption {
   icon?: string;
 }
 
-export type FacetControl = 'pills' | 'select' | 'tokens' | 'remote';
+type FacetControl = 'pills' | 'select' | 'tokens' | 'remote';
 
 /** One facet's live selection, as FacetSection reads it: the included and excluded
  *  values (a value is in at most one set), plus the include-set match mode. */
@@ -162,7 +162,7 @@ const languageNames = (() => {
   }
 })();
 
-export function languageLabel(code: string): string {
+function languageLabel(code: string): string {
   if (!code) return code;
   try {
     return languageNames?.of(code) ?? code.toUpperCase();
@@ -175,7 +175,7 @@ export function languageLabel(code: string): string {
 // no display name, so title-case the slug for a readable label. Imperfect for
 // acronyms (group-ib → "Group Ib") but consistent with the other facets — a real
 // slug→name lookup would need a per-company fetch, which this facet forgoes.
-export function companyLabel(slug: string): string {
+function companyLabel(slug: string): string {
   return titleCase(slug.replace(/-/g, '_'));
 }
 

--- a/web/src/lib/filterSections.ts
+++ b/web/src/lib/filterSections.ts
@@ -16,7 +16,7 @@ import { categoryLabel } from './labels';
 export type RailSection = 'SAVED' | 'ROLE' | 'PAY & BENEFITS' | 'REQUIREMENTS & ELIGIBILITY' | 'FILTERS';
 
 /** Display order of the specialization section headings. */
-export const CATEGORY_GROUP_ORDER = [
+const CATEGORY_GROUP_ORDER = [
   'Engineering',
   'Data & AI',
   'Quality & Security',
@@ -28,11 +28,11 @@ export const CATEGORY_GROUP_ORDER = [
   'Other',
 ] as const;
 
-export type CategoryGroup = (typeof CATEGORY_GROUP_ORDER)[number];
+type CategoryGroup = (typeof CATEGORY_GROUP_ORDER)[number];
 
 /** Each category → its section. Keyed by the full Category union: a missing key
  *  fails the type-check, keeping the grouping exhaustive as the vocabulary grows. */
-export const CATEGORY_GROUP: Record<Category, CategoryGroup> = {
+const CATEGORY_GROUP: Record<Category, CategoryGroup> = {
   software_engineering: 'Engineering',
   backend: 'Engineering',
   frontend: 'Engineering',
@@ -73,7 +73,7 @@ export const CATEGORY_GROUP: Record<Category, CategoryGroup> = {
   other: 'Other',
 };
 
-export interface CategorySectionOption {
+interface CategorySectionOption {
   value: Category;
   label: string;
 }
@@ -103,7 +103,7 @@ export const CATEGORY_GROUPS: CategorySection[] = CATEGORY_GROUP_ORDER.map((name
 
 export const RAIL_SECTIONS: RailSection[] = ['ROLE', 'PAY & BENEFITS', 'REQUIREMENTS & ELIGIBILITY'];
 
-export type RailKind =
+type RailKind =
   | 'facet'
   | 'category'
   | 'location'

--- a/web/src/lib/headerScope.ts
+++ b/web/src/lib/headerScope.ts
@@ -9,7 +9,7 @@ import { countryLabel } from './facets';
 import { WORK_MODE_VALUES, type WorkMode } from './generated/contracts';
 import { REGION_LABELS, WORK_MODE_LABELS } from './labels';
 
-export type ScopeIcon = 'globe' | WorkMode;
+type ScopeIcon = 'globe' | WorkMode;
 
 /** What the trigger draws: an overlapping icon cluster, then the head geography and
  *  its "+N" roll-up. `label` is the same summary in words — the icons carry meaning

--- a/web/src/lib/insights.ts
+++ b/web/src/lib/insights.ts
@@ -16,7 +16,7 @@ import { SENIORITY_LABELS, categoryLabel, titleCase } from './labels';
 export const MIN_CATEGORY_OPEN = 25;
 
 /** Seniority tokens in rank order. '' is the category-wide band. */
-export const SENIORITY_ORDER = [
+const SENIORITY_ORDER = [
   'intern',
   'junior',
   'middle',

--- a/web/src/lib/labels.ts
+++ b/web/src/lib/labels.ts
@@ -24,7 +24,7 @@ export function titleCase(value: string): string {
 
 // Region code → display names, one row per vocab.RegionValues entry. `short`
 // is the compact UI label (filter pills, facet rows).
-export const REGIONS: { code: string; short: string }[] = [
+const REGIONS: { code: string; short: string }[] = [
   { code: 'global', short: 'Worldwide' },
   { code: 'north_america', short: 'North America' },
   { code: 'latam', short: 'LATAM' },

--- a/web/src/lib/logo.ts
+++ b/web/src/lib/logo.ts
@@ -5,7 +5,7 @@
 // OG card). No third-party token or attribution ships in the browser — the proxy
 // owns everything server-side. Resolves by company name, since that is all most
 // call sites carry (job rows, search, referrals).
-export const COMPANY_LOGO_BASE = 'https://logo.freehire.me';
+const COMPANY_LOGO_BASE = 'https://logo.freehire.me';
 
 /** The proxy logo URL for a company name, or null when there is no name. */
 export function companyLogoUrl(name: string): string | null {

--- a/web/src/lib/matchAnalysis.ts
+++ b/web/src/lib/matchAnalysis.ts
@@ -41,9 +41,9 @@ export function requirementStatusMeta(status: string): { label: string; tone: To
 // The page consumes the match stream (server-sent events) and folds each event into this
 // state via reduceMatchEvent — pure and DOM-free so the accumulation is unit-tested.
 
-export type StageState = 'pending' | 'active' | 'done';
+type StageState = 'pending' | 'active' | 'done';
 
-export interface MatchStage {
+interface MatchStage {
   n: number;
   label: string;
   state: StageState;

--- a/web/src/lib/onboarding.ts
+++ b/web/src/lib/onboarding.ts
@@ -50,7 +50,7 @@ export function selectionsToQuery(sel: OnboardingSelection): string {
 // first. The role/specialization is deliberately absent — it's the visitor's
 // primary intent and is never auto-dropped. Operates on the live filter state so
 // the affordance works for any narrow feed, not only a wizard-built one.
-export const RELAX_FACET_ORDER = ['skills', 'regions', 'seniority'] as const;
+const RELAX_FACET_ORDER = ['skills', 'regions', 'seniority'] as const;
 
 /** The single narrowest relaxable facet currently constraining the feed, or null
  *  if none is set. The empty-state relax action clears exactly this one. */

--- a/web/src/lib/pagination.ts
+++ b/web/src/lib/pagination.ts
@@ -15,7 +15,7 @@ export const PAGE_SIZE = 20;
 
 /** How deep the search API will page: it refuses `offset + limit > SEARCH_WINDOW`
  *  with "pagination too deep" (internal/handler/search.go, maxSearchWindow). */
-export const SEARCH_WINDOW = 10000;
+const SEARCH_WINDOW = 10000;
 
 /** Last page the API will serve, and so the last one worth linking — a link past
  *  it walks a crawler (or a visitor) into a 400. */

--- a/web/src/lib/server/og/shared.ts
+++ b/web/src/lib/server/og/shared.ts
@@ -26,7 +26,7 @@ export function esc(s: string): string {
 }
 
 /** One or two uppercase initials from a name, for the logo fallback tile. */
-export function monogram(name: string): string {
+function monogram(name: string): string {
   const words = name.trim().split(/\s+/).filter(Boolean);
   const first = words[0];
   if (!first) return '?';

--- a/web/src/lib/skillDetailChart.ts
+++ b/web/src/lib/skillDetailChart.ts
@@ -7,7 +7,7 @@
 import type { SkillPulsePoint } from './api';
 import { must } from './utils';
 
-export interface DetailChartPoint {
+interface DetailChartPoint {
   x: number;
   y: number;
   weekStart: string;

--- a/web/src/lib/stages.ts
+++ b/web/src/lib/stages.ts
@@ -5,9 +5,9 @@
 // how the board, the funnel and this file came to disagree about what to call a
 // settled application.
 
-import { STAGE_GROUPS, STAGE_LABELS, STAGE_VALUES, type Stage } from './generated/contracts';
+import { STAGE_GROUPS, STAGE_LABELS, type Stage } from './generated/contracts';
 
-export interface StageOption {
+interface StageOption {
   value: string;
   label: string;
 }
@@ -23,9 +23,15 @@ export interface StageOptionGroup {
 // real. Both directions, at compile time: `false extends true` is an error, so a stage added
 // to the Go vocabulary without a group fails `pnpm run check` rather than reaching the board
 // as a card in no column.
+//
+// EXPORTED WITH NO CONSUMER, DELIBERATELY. The declaration is the whole check — evaluating
+// `Assert<Eq<…>>` is what fails — and `export` is what stops the linter deleting it as an
+// unused local. knip reports it as an unused export, correctly and unhelpfully; this is
+// the note that says so.
 type Assert<T extends true> = T;
 type Eq<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
 type GroupedStage = (typeof STAGE_GROUPS)[number]['stages'][number];
+/** @public */
 export type StagesAreFullyGrouped = Assert<Eq<Stage, GroupedStage>>;
 
 /** A human label for a stage value; the value itself (title-cased fallback) when
@@ -36,11 +42,6 @@ export function humanizeStage(stage: string): string {
     stage.charAt(0).toUpperCase() + stage.slice(1)
   );
 }
-
-export const STAGES: StageOption[] = STAGE_VALUES.map((value) => ({
-  value,
-  label: humanizeStage(value),
-}));
 
 /** The stages grouped as the selector shows them, in generated pipeline order, so
  *  `Closed` reads as a heading over its three outcomes rather than as a fifth state. */

--- a/web/src/lib/tailor/atsdelta.ts
+++ b/web/src/lib/tailor/atsdelta.ts
@@ -4,7 +4,7 @@
 import type { CvAtsDelta } from '$lib/cv';
 import type { LineItem } from '$lib/generated/contracts';
 
-export interface AtsDeltaRow {
+interface AtsDeltaRow {
   id: string;
   label: string;
   base: number;

--- a/web/src/lib/tailor/jobmatch.ts
+++ b/web/src/lib/tailor/jobmatch.ts
@@ -6,7 +6,7 @@
 import type { CvJobMatch } from '$lib/cv';
 import type { LineItem, RequirementCheck } from '$lib/generated/contracts';
 
-export interface JobMatchRow {
+interface JobMatchRow {
   id: string;
   label: string;
   earned: number;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -12,19 +12,24 @@ import type {
   Analysis as MatchAnalysisContract,
   Education as ResumeEducation,
 } from './generated/contracts';
+/** @public — the app's vocabulary for the generated contract; a name is carried here
+ *  whether or not a screen reads it yet. */
 export type { Job, Enrichment, Verdict, Gap, SkillRow } from './generated/contracts';
 // The list-row projection of a job: the same names and derivations as Job, minus the posting
 // text and everything else a row does not draw.
 export type { Card as JobCard } from './generated/contracts';
 // Per-job profile match (how well a job's skills are covered by the caller's profile).
+/** @public */
 export type { JobMatch, AdjacentSkill } from './generated/contracts';
 // Hard-constraint blockers (years, education, certs, work auth, location) surfaced
 // beside skill coverage. BlockerCategory/BlockerSeverity are the enum aliases.
+/** @public */
 export type { Blocker, BlockerCategory, BlockerSeverity } from './generated/contracts';
 // The profile-match endpoint returns skill coverage plus the advisory blockers.
 export type JobMatchResult = JobMatch & { blockers: Blocker[] };
 // atscheck's Report is aliased ATSReport (a local Report — job reports — already exists);
 // its category/line-item shapes come along for the report view.
+/** @public */
 export type {
   Report as ATSReport,
   ScoreCategory as ATSCategory,
@@ -40,6 +45,7 @@ export interface ATSResponse {
 
 // The on-demand LLM job-match analysis wire shapes (five scored dimensions + the
 // ATS-style requirement match), generated from internal/matchanalysis.
+/** @public */
 export type {
   Analysis as MatchAnalysis,
   Dimension as MatchDimension,
@@ -282,7 +288,7 @@ export interface User {
 /** A crowdsourced board contribution: a job link a user pasted for a company board we do
  *  not crawl yet. The unit is the board — `source` (ATS) + `board` (company slug) — not a
  *  single vacancy; the ingest side later scrapes all its vacancies. */
-export type ContributionStatus = 'pending' | 'onboarded' | 'rejected' | 'review';
+type ContributionStatus = 'pending' | 'onboarded' | 'rejected' | 'review';
 
 export interface Contribution {
   id: number;
@@ -304,7 +310,7 @@ export interface Contribution {
  *  - `imported` imported, and the board behind it is now queued for onboarding
  *  - `review`   imported, but its careers site names no board we can crawl, so it went to triage
  *  - `queued`   nothing could read the page, so the link went to manual triage */
-export type IntakeStatus = 'found' | 'tracked' | 'imported' | 'review' | 'queued';
+type IntakeStatus = 'found' | 'tracked' | 'imported' | 'review' | 'queued';
 
 export interface ResolvedLink {
   public_slug: string | null;
@@ -316,9 +322,9 @@ export interface ResolvedLink {
 }
 
 /** Employee referrals. An offer is a member's moderated "I can refer into company X". */
-export type ReferralOfferStatus = 'pending' | 'approved' | 'rejected';
+type ReferralOfferStatus = 'pending' | 'approved' | 'rejected';
 export type ReferralRequestStatus = 'sent' | 'contacted' | 'declined';
-export type ReferralCvKind = 'original' | 'built';
+type ReferralCvKind = 'original' | 'built';
 
 export interface ReferralOffer {
   id: string;
@@ -569,7 +575,7 @@ export type NotificationKind =
 /** One matched job as recorded into a multi-job subscription digest's `jobs`
  *  snapshot — the same {title, company, slug} shape as everywhere else in this
  *  app, no internal id. */
-export interface NotificationDigestJob {
+interface NotificationDigestJob {
   title: string;
   company: string;
   slug: string;
@@ -725,7 +731,7 @@ export interface MyJobCounts {
 /** The caller's application count at each stage of the vocabulary. Every stage is
  *  present, zero included, and the counts always sum to the application total —
  *  so a count of nothing is readable without being confused for a missing key. */
-export type PipelineStageCounts = Record<Stage, number>;
+type PipelineStageCounts = Record<Stage, number>;
 
 /** The application-pipeline snapshot for the Pipeline tab: the caller's total
  *  application count and the count at each stage. Grouping those stages into the
@@ -805,7 +811,7 @@ export type ProviderKind = 'ats' | 'aggregator' | 'company' | 'other';
 /** One provider's health on the public /status page: board counts, freshness, and
  *  the derived status. Sanitized — no error text or board identifiers are exposed.
  *  Timestamps are RFC3339 strings, or null when the provider has never run/succeeded. */
-export interface ProviderHealth {
+interface ProviderHealth {
   provider: string;
   kind: ProviderKind;
   status: HealthStatus;
@@ -844,7 +850,7 @@ export interface CreatedApiKey extends ApiKey {
   token: string;
 }
 
-export interface ConnectedIdentity {
+interface ConnectedIdentity {
   provider: string;
   linked_at: string;
   status: 'active' | 'revocation_pending';
@@ -890,20 +896,20 @@ export interface Board {
  *  per user (no id, no name); the foundation for finding relevant work. Timestamps are
  *  RFC3339 strings or null. */
 /** A geographic reach: controlled regions and/or ISO country codes. Empty = anywhere. */
-export interface LocationGeoSet {
+interface LocationGeoSet {
   regions?: string[];
   countries?: string[];
 }
 
 /** The user's current single base: an ISO country code and a free-text city. */
-export interface LocationBase {
+interface LocationBase {
   country?: string;
   city?: string;
 }
 
 /** Willingness to relocate: an open flag plus acceptable destinations (open + empty
  *  targets = anywhere). */
-export interface LocationRelocation {
+interface LocationRelocation {
   open: boolean;
   regions?: string[];
   countries?: string[];
@@ -1024,6 +1030,7 @@ export interface ResumeProfile {
 }
 
 /** The read-only structured résumé parsed from the uploaded CV by the LLM. */
+/** @public */
 export type {
   Structured as ResumeStructured,
   Experience as ResumeExperience,


### PR DESCRIPTION
#2237 gated files, dependencies and binaries and left 81 unused exports reported but not
gated, with a note saying they were worth a reviewed pass. This is that pass, and it ends
somewhere better than expected: **the backlog is gone and the gate now covers everything
knip reports.** No behaviour changed.

## What the 81 turned out to be

**Fifty were read only inside their own module** and simply lost the keyword. Nothing
moved, nothing was deleted — the symbols are the same, they just stopped claiming a
consumer they never had.

**Three were genuinely dead**, and eslint is what found them: `DEFAULT_TEMPLATE_ID`,
`STAGES`, and `allEntries` — the last carrying a comment saying it existed "for prerender
enumeration" by nothing. Removing `STAGES` orphaned an import, which is the tail of the
same thread.

That is worth stating plainly, because it is the reusable part: **knip and `no-unused-vars`
answer different halves of one question and neither is complete alone.** knip cannot see
past the `export`; eslint cannot see across the module. Dropping the keyword is what let
the second one speak.

**Three were a facade that had stopped facading.** `companyFilters.ts` re-exports
`companyFacetModel`'s public surface "so existing importers are unchanged" — and every one
of those importers now reaches the model directly. The single thing still taken through
that path is a type of the store itself. Three names dropped, and the comment corrected to
say what the file actually does.

**Thirteen are deliberate.** Their argument moved next to the code as a JSDoc `@public`
tag rather than into the config, because a config-level exemption is invisible from the
line it excuses. Two shapes earned one:

- `types.ts`, `cv.ts` and `collections.ts` re-export the generated contract under the app's
  own names. A name is carried there whether or not a screen reads it yet — that is what
  the facade is for, and a missing one is the bug it prevents.
- `stages.ts` exports a compile-time assertion. Declaring it **is** the check; `export` is
  only what stops the linter deleting it as an unused local.

With those tagged, the split invocation is gone: one `pnpm check:dead`, gating everything.

## Verification

All three packages, after the change:

| | web | extension |
|---|---|---|
| lint | 0 errors | 0 errors |
| typecheck | 0 errors over 10084 files | `tsc --noEmit` clean |
| tests | 1201 passed | 274 passed |
| build | production build succeeds | — |

`pnpm check:dead` exits 0 with no category excluded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the internal API surface by restricting unused helpers, constants, and types to their respective modules.
  - Removed obsolete public declarations while preserving existing functionality and behavior.
  - Simplified stage data exposure and eliminated an outdated flat stage list.

- **Documentation**
  - Clarified which contract types are part of the supported public API.
  - Improved static analysis guidance and configuration.

- **Chores**
  - Simplified dead-code checks and removed a redundant validation command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->