### PR TITLE
Collapse the membership read-backs to one helper

### DIFF
--- a/internal/job/collections/collections.go
+++ b/internal/job/collections/collections.go
@@ -670,22 +670,13 @@ func csvColumns(data []byte, delim rune, colNames ...string) ([][]string, error)
 	return out, nil
 }
 
-// easternRootsSlugs is the eastern-roots membership file parsed to its slugs, for the test
-// that guards every hand list against the catalogue's slug rule. Exported to the package's
+// embeddedSlugList parses an embedded membership file to its slugs, for the test that
+// guards every hand list against the catalogue's slug rule. It exists for the package's
 // tests only, because the file is embedded and there is no other way to read it back.
-func easternRootsSlugs() []string {
-	return embeddedSlugList(easternRootsData)
-}
-
-// indianRootsSlugs is the same read-back for the indian-roots membership file.
-func indianRootsSlugs() []string {
-	return embeddedSlugList(indianRootsData)
-}
-
 func embeddedSlugList(data []byte) []string {
-	names, err := ParseSlugList(data)
+	slugs, err := ParseSlugList(data)
 	if err != nil {
 		return nil
 	}
-	return names
+	return slugs
 }

--- a/internal/job/collections/collections_test.go
+++ b/internal/job/collections/collections_test.go
@@ -533,12 +533,12 @@ var errBoom = errors.New("boom")
 // because it is the same kind of list, only larger and easier to add to carelessly.
 func TestHandListSlugsAreCompanySlugStable(t *testing.T) {
 	lists := map[string][]string{
-		"AICompanySlugs": AICompanySlugs,
-		"Mag7Slugs":      Mag7Slugs,
-		"BigTechSlugs":   BigTechSlugs,
-		"AINativeSlugs":  AINativeSlugs,
-		"eastern_roots":  embeddedSlugList(easternRootsData),
-		"indian_roots":   embeddedSlugList(indianRootsData),
+		"AICompanySlugs":   AICompanySlugs,
+		"Mag7Slugs":        Mag7Slugs,
+		"BigTechSlugs":     BigTechSlugs,
+		"AINativeSlugs":    AINativeSlugs,
+		"easternRootsData": embeddedSlugList(easternRootsData),
+		"indianRootsData":  embeddedSlugList(indianRootsData),
 	}
 	var checked int
 	for name, slugs := range lists {

--- a/internal/job/collections/collections_test.go
+++ b/internal/job/collections/collections_test.go
@@ -537,8 +537,8 @@ func TestHandListSlugsAreCompanySlugStable(t *testing.T) {
 		"Mag7Slugs":      Mag7Slugs,
 		"BigTechSlugs":   BigTechSlugs,
 		"AINativeSlugs":  AINativeSlugs,
-		"eastern_roots":  easternRootsSlugs(),
-		"indian_roots":   indianRootsSlugs(),
+		"eastern_roots":  embeddedSlugList(easternRootsData),
+		"indian_roots":   embeddedSlugList(indianRootsData),
 	}
 	var checked int
 	for name, slugs := range lists {

--- a/internal/job/collections/indian_roots.txt
+++ b/internal/job/collections/indian_roots.txt
@@ -8,9 +8,6 @@
 # Sources: the Indian unicorn lists published by Failory and FounderPin (both
 # tracking the same Tracxn/Inc42 ecosystem count, ~130 unicorns as of Aug 2026),
 # Wikipedia's list of Indian IT companies, plus a hand seed for the diaspora strand.
-# There is no maintained open dataset for this — every GitHub "Indian startups"
-# repository is a fork of one 2015-2017 Kaggle funding CSV — so this is an embedded
-# hand list, like eastern-roots, rather than a pinned Dataset URL.
 #
 # Everything above the second header was verified present in the catalogue at
 # curation time; the tail is well-known companies we do not carry yet, kept so the


### PR DESCRIPTION
Quality pass over the `indian-roots` change (#2238). No behaviour change — `go test ./internal/job/collections/` is green before and after, and the guarded hand lists are byte-identical.

**Three functions where the test needs one.** `indian-roots` arrived with a per-file wrapper beside `eastern-roots`', so `easternRootsSlugs` / `indianRootsSlugs` / `embeddedSlugList` all existed to do one thing. `TestHandListSlugsAreCompanySlugStable` is an internal test (`package collections`), so it can name the embedded bytes itself:

```go
"eastern_roots": embeddedSlugList(easternRootsData),
"indian_roots":  embeddedSlugList(indianRootsData),
```

That puts the file and the list it produces on the same line, instead of behind a wrapper whose only job was to pair them — and the next membership file added needs no third wrapper.

**One argument, stated once.** `indian_roots.txt`'s header re-argued the hand-list-over-`Dataset`-URL case a paragraph after the `//go:embed` comment already makes it. Kept the version next to the code it constrains.

`indianRootsData`'s doc comment stays at its current length deliberately: it mirrors `easternRootsData`'s, and trimming one of a matched pair reads as an oversight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal handling of embedded company slug lists with a shared parser.
  * Removed redundant list-specific helper functions.

* **Tests**
  * Updated slug stability checks to use the shared list-processing approach.

* **Documentation**
  * Removed outdated explanatory comments from an embedded company list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->