### PR TITLE
Name a hand list by what we wrote, not by how it is delivered

### DIFF
--- a/cmd/import-collections/main.go
+++ b/cmd/import-collections/main.go
@@ -156,9 +156,9 @@ func report(p planResult, companies int) {
 			continue
 		}
 		log.Printf("import-collections: %s matched=%d unmatched=%d", c.Slug, s.Matched, s.Unmatched)
-		// For a hand list the unmatched entries are actionable (a typo'd slug, or a
-		// marquee company we don't ingest yet), so list them. Datasets have thousands
-		// of unmatched names — only their count is logged, above.
+		// For a hand list the unmatched entries are actionable — an entry we wrote
+		// that matches nothing is a typo or a company that left the catalogue — so
+		// list them. A fetched dataset has thousands; only its count is logged, above.
 		if len(s.UnmatchedNames) > 0 {
 			log.Printf("import-collections: %s unmatched entries: %s", c.Slug, strings.Join(s.UnmatchedNames, ", "))
 		}
@@ -339,7 +339,7 @@ func plan(rows []db.ListCompanyCollectionsRow, resolved map[string][]collections
 	stats := make(map[string]collections.MatchStat, len(resolved))
 	for _, c := range collections.All {
 		matched, s := c.Members(resolved[c.Slug], companies)
-		if c.Slugs != nil { // hand list: keep the unmatched entries for diagnostics
+		if c.HandList() { // ours to fix: keep the unmatched entries for diagnostics
 			s.UnmatchedNames = s.UnmatchedNames[:min(len(s.UnmatchedNames), collections.MaxLoggedUnmatched)]
 		} else {
 			s.UnmatchedNames = nil

--- a/internal/job/collections/AGENTS.md
+++ b/internal/job/collections/AGENTS.md
@@ -8,15 +8,15 @@ are matched; `cmd/import-collections` writes `companies.collections`, and the se
 (`jobs.collections`) serves it.
 
 ## Always true
-- **The registry is code.** `All` (collections.go:157-269 — 15 slugs, in display order) is
+- **The registry is code.** `All` (collections.go:167-286 — 16 slugs, in display order) is
   the fixed set; adding a tag is one entry with exactly one membership source: a static
   `Slugs` hand list or a `Dataset`. `Kind` decides how the tag renders (editorial chip /
   credential with issuing body and snapshot date / backer brand mark) and its zero value is
-  deliberately invalid so a forgotten one fails the registry test (collections.go:99-115).
+  deliberately invalid so a forgotten one fails the registry test (collections.go:99-110).
 - **A partial dataset read reconciles the tag OFF every company it failed to reach.** A
   `Dataset.Records` source must read completely and error otherwise — a partial read is
-  indistinguishable from a shrunken source (collections.go:46-52). `Dataset.Valid` enforces
-  exactly one of URL / embedded Data / ResolveURL / Records (collections.go:64-79).
+  indistinguishable from a shrunken source (collections.go:34-59). `Dataset.Valid` enforces
+  exactly one of URL / embedded Data / ResolveURL / Records (collections.go:61-79).
 - **Both kinds match on `normalize.CompanySlug`** — `RegisterSlug` is now a thin caller of it
   (register.go). Editorial matching used `normalize.Slug` until the catalogue began stripping
   corporate forms; a dataset naming "Acme Robotics Limited" then asked for a slug ingest can no
@@ -28,38 +28,51 @@ are matched; `cmd/import-collections` writes `companies.collections`, and the se
   fixed point of `CompanySlug`; the test that pins this found three `eastern_roots.txt` entries
   already tagging the wrong company (`epam-systems-pte-ltd`, 19 open jobs, instead of
   `epam-systems`, 1,172). An entry the rule would never produce matches nothing, and a
-  collection that matches nothing reports no error.
-- **`RequireCountry`'s asymmetry is the point** (register.go:78-101): a multi-token name
+  collection that matches nothing reports no error. `TestHandListSlugsAreCompanySlugStable`
+  covers the static `Slugs` lists AND both embedded files — a new membership file must be
+  added to its map, or it is unguarded.
+- **A hand list is a list we wrote, whichever way it is delivered** (`Collection.HandList`,
+  collections.go:154-162). Both the static `Slugs` lists and the embedded `.txt` files are ours
+  to fix, so their unmatched entries are logged BY NAME; a fetched third-party dataset has
+  thousands and only its count is. The import worker drew this line as `Slugs != nil` until
+  2026-08-31, which silenced the two largest hand lists we have: a typo in `eastern_roots.txt`
+  or `indian_roots.txt` matched nothing and said nothing, which is the exact failure the
+  fixed-point test exists to catch on the other axis.
+- **`RequireCountry`'s asymmetry is the point** (register.go:54-77): a multi-token name
   ("Acme Robotics") needs only open jobs in the register's country; a single-token name
   ("Apple", "Spark") additionally requires HQ there, or a multinational with a local office
   inherits a licence from a same-named local business. Unknown HQ is not a match — absence
   of evidence is not evidence.
 - **`countryAliases` exists because a retired one-time importer left `hq_country` rows
-  its upstream's writer never normalized** (register.go:103-117): `cmd/import-yc`, the
+  its upstream's writer never normalized** (register.go:79-94): `cmd/import-yc`, the
   column's live writer, parses through `location.Parse`, but those legacy rows still carry
   the upstream's spelled-out value verbatim. The failure mode is silent — a company simply
   never earns a credential it qualifies for. Whole-value comparison only: "New Great
   Britain Holdings" is a company name, not a country.
 - **`DropAmbiguous` drops register rows whose name identifies more than one organisation**
-  (register.go:180-201), using `Dataset.IdentityKey` (UK town, NL kvk, US tin4). Rows
+  (register.go:143-174), using `Dataset.IdentityKey` (UK town, NL kvk, US tin4). Rows
   sharing a name AND an identity are one body listed once per route — they must survive for
   `RequireRoute`. With an empty IdentityKey the guard is permissive on purpose: firing it
   on a register that cannot disambiguate would delete its every duplicate, and the
   geography gates are the real defence there.
-- **A company is tagged when ANY of its records passes the gate** (collections.go:457-497):
+- **A company is tagged when ANY of its records passes the gate** (collections.go:469-496):
   a register lists an organisation once per route it holds, so a work-route row must win
   even when a temporary-route row sorts first.
 - **`Reconcile` is given live + retired slugs** so a removed or renamed tag is stripped
-  everywhere on the next run (collections.go:512-532; `RetiredSlugs` collections.go:421-426;
-  wired at cmd/import-collections/main.go:347). Tags the registry does not manage are
+  everywhere on the next run (collections.go:537-562; `RetiredSlugs` collections.go:447-452;
+  wired at cmd/import-collections/main.go:358). Tags the registry does not manage are
   preserved untouched.
 
 ## How it works
 `cmd/import-collections` resolves each collection's dataset, matches records to the
 catalogue (`Members`), and writes `companies.collections` via `SetCompanyCollections`
-(main.go:117). Dataset fetches egress through `SOURCES_PROXY_URL` when set — always falling
-back to direct (main.go:184-214) — and a per-collection `<SLUG>_DATASET_URL` override
-(e.g. `YC_DATASET_URL`) wins over the pinned URL (main.go:400-406). `cmd/harvest-ats`
+(main.go:128). Dataset fetches egress through `SOURCES_PROXY_URL` when set — always falling
+back to direct (main.go:196-228) — and a per-collection `<SLUG>_DATASET_URL` override
+(e.g. `YC_DATASET_URL`) wins over the pinned URL (main.go:410-425). `cmd/harvest-ats`
 re-reads the same datasets to mine new companies for board discovery
-(cmd/harvest-ats/main.go:107). Unmatched hand-list entries are logged, capped at
-`MaxLoggedUnmatched` (50) so a mis-edit cannot flood a run.
+(cmd/harvest-ats/main.go:107). Unmatched hand-list entries are logged by name, capped at
+`MaxLoggedUnmatched` (50) so a mis-edit cannot flood a run — which means a membership file
+should not carry entries it knows will not match. `indian_roots.txt` was written with a
+90-slug tail of marquee companies we do not ingest yet, on the theory that the tag would
+land the day their board arrived; a run then reports 90 intentional misses and a real typo
+sits somewhere among them. Add a company when its board lands, not before.

--- a/internal/job/collections/collections.go
+++ b/internal/job/collections/collections.go
@@ -151,6 +151,16 @@ func (c Collection) Admits(company Company, r Record) bool {
 	return c.Gate == nil || c.Gate(company, r)
 }
 
+// HandList reports whether this collection's membership is authored in this repo —
+// a static Slugs list or an embedded membership file — rather than fetched from a
+// third party. Only a hand list's unmatched entries are worth naming: they are ours
+// to fix, and there are few enough to read. The distinction lived in the import
+// worker and was drawn as "Slugs != nil", which silenced the embedded files (the
+// largest hand lists we have) and made a typo in one of them invisible.
+func (c Collection) HandList() bool {
+	return c.Slugs != nil || (c.Dataset != nil && len(c.Dataset.Data) > 0)
+}
+
 // All is the fixed registry, in display order. Adding a collection is one entry
 // here — a static Slugs list or a Dataset; the import worker resolves whichever is
 // set.
@@ -382,9 +392,9 @@ var BigTechSlugs = []string{
 // internationally (a hand-curated seed plus the larger eastern-roots company list).
 // "Eastern roots" is a fact about the company, so all of its roles belong here. It is
 // our own curated fact, not a third-party feed, so it is committed to the repo and
-// embedded rather than fetched. One canonical company slug (normalize.Slug) per line;
-// the list is matched against the catalogue at import time and unmatched slugs are
-// simply logged.
+// embedded rather than fetched. One canonical company slug (normalize.CompanySlug)
+// per line; the list is matched against the catalogue at import time and unmatched
+// slugs are logged by name.
 //
 //go:embed eastern_roots.txt
 var easternRootsData []byte
@@ -398,9 +408,9 @@ var easternRootsData []byte
 //go:embed indian_roots.txt
 var indianRootsData []byte
 
-// ParseSlugList parses a newline-delimited slug list (the embedded russian-roots
-// file): one entry per line, blank lines and #-comment lines skipped, surrounding
-// whitespace trimmed. Entries are returned verbatim (Match normalizes them).
+// ParseSlugList parses a newline-delimited slug list (the embedded eastern_roots.txt
+// and indian_roots.txt): one entry per line, blank lines and #-comment lines skipped,
+// surrounding whitespace trimmed. Entries are returned verbatim (Match normalizes them).
 func ParseSlugList(data []byte) ([]string, error) {
 	var out []string
 	for _, line := range strings.Split(string(data), "\n") {
@@ -668,15 +678,4 @@ func csvColumns(data []byte, delim rune, colNames ...string) ([][]string, error)
 		out = append(out, vals)
 	}
 	return out, nil
-}
-
-// embeddedSlugList parses an embedded membership file to its slugs, for the test that
-// guards every hand list against the catalogue's slug rule. It exists for the package's
-// tests only, because the file is embedded and there is no other way to read it back.
-func embeddedSlugList(data []byte) []string {
-	slugs, err := ParseSlugList(data)
-	if err != nil {
-		return nil
-	}
-	return slugs
 }

--- a/internal/job/collections/collections_test.go
+++ b/internal/job/collections/collections_test.go
@@ -529,16 +529,17 @@ var errBoom = errors.New("boom")
 // produce — one still carrying a corporate form — matches nothing, and nothing says so: the
 // collection just quietly holds fewer companies than it names.
 //
-// The test is that each entry is a fixed point of the rule. eastern_roots.txt is included
-// because it is the same kind of list, only larger and easier to add to carelessly.
+// The test is that each entry is a fixed point of the rule. The embedded membership files
+// are included because they are the same kind of list, only larger and easier to add to
+// carelessly.
 func TestHandListSlugsAreCompanySlugStable(t *testing.T) {
 	lists := map[string][]string{
 		"AICompanySlugs":   AICompanySlugs,
 		"Mag7Slugs":        Mag7Slugs,
 		"BigTechSlugs":     BigTechSlugs,
 		"AINativeSlugs":    AINativeSlugs,
-		"easternRootsData": embeddedSlugList(easternRootsData),
-		"indianRootsData":  embeddedSlugList(indianRootsData),
+		"easternRootsData": embeddedSlugList(t, easternRootsData),
+		"indianRootsData":  embeddedSlugList(t, indianRootsData),
 	}
 	var checked int
 	for name, slugs := range lists {
@@ -557,4 +558,46 @@ func TestHandListSlugsAreCompanySlugStable(t *testing.T) {
 		t.Errorf("checked only %d hand-list slugs, expected the curated lists to be far larger "+
 			"— has a list been renamed out from under this test?", checked)
 	}
+}
+
+// TestHandListCoversEmbeddedMembershipFiles pins which collections get their unmatched
+// entries named in the import log. The rule was "Slugs != nil" until 2026-08-31, which
+// read as "hand list" but excluded the embedded files — the two largest lists we author
+// — so a typo in one matched nothing and reported nothing. A fetched dataset must stay
+// out: it has thousands of unmatched names and would bury every hand list's few.
+func TestHandListCoversEmbeddedMembershipFiles(t *testing.T) {
+	want := map[string]bool{
+		"bigtech":        true, // static Slugs
+		"ai-native":      true, // static Slugs
+		"eastern-roots":  true, // embedded file
+		"indian-roots":   true, // embedded file
+		"yc":             false,
+		"unicorn":        false,
+		"us-h1b-sponsor": false,
+	}
+	for _, c := range All {
+		expected, ok := want[c.Slug]
+		if !ok {
+			continue
+		}
+		if got := c.HandList(); got != expected {
+			t.Errorf("%s: HandList() = %v, want %v", c.Slug, got, expected)
+		}
+		delete(want, c.Slug)
+	}
+	for slug := range want {
+		t.Errorf("%q is no longer in the registry — this test has stopped covering it", slug)
+	}
+}
+
+// embeddedSlugList parses an embedded membership file to its slugs. A parse failure is
+// fatal rather than an empty list: the population floor above is summed across every list,
+// so one file silently yielding nothing would still clear it on the others' entries.
+func embeddedSlugList(t *testing.T, data []byte) []string {
+	t.Helper()
+	slugs, err := ParseSlugList(data)
+	if err != nil {
+		t.Fatalf("parse embedded membership file: %v", err)
+	}
+	return slugs
 }

--- a/internal/job/collections/eastern_roots.txt
+++ b/internal/job/collections/eastern_roots.txt
@@ -1,8 +1,8 @@
 # eastern-roots collection membership (canonical company slugs, one per line).
 # Companies with Eastern European / Russian-speaking founding roots operating internationally.
 # Source: hand-curated seed + the eastern-roots company list (Airtable, 312 slugs).
-# Matched to our catalogue via normalize.Slug at import (cmd/import-collections);
-# unmatched slugs are simply logged. Lines starting with # are comments.
+# Matched to our catalogue via normalize.CompanySlug at import (cmd/import-collections);
+# unmatched slugs are logged by name. Lines starting with # are comments.
 10web
 1inch
 1password

--- a/internal/job/collections/indian_roots.txt
+++ b/internal/job/collections/indian_roots.txt
@@ -9,30 +9,37 @@
 # tracking the same Tracxn/Inc42 ecosystem count, ~130 unicorns as of Aug 2026),
 # Wikipedia's list of Indian IT companies, plus a hand seed for the diaspora strand.
 #
-# Everything above the second header was verified present in the catalogue at
-# curation time; the tail is well-known companies we do not carry yet, kept so the
-# tag lands the day their board is ingested. Matched via normalize.CompanySlug at
-# import (cmd/import-collections); unmatched slugs are simply logged. Lines starting
-# with # are comments.
+# Every entry was verified present in the catalogue at curation time. The list
+# deliberately does NOT carry marquee companies we do not ingest yet: an entry that
+# matches nothing is indistinguishable from a typo in the import's unmatched report,
+# and 71 speculative ones would bury a real one. Add a company when its board lands.
+#
+# Matched via normalize.CompanySlug at import (cmd/import-collections); unmatched
+# slugs are logged. Lines starting with # are comments.
 #
 # Ambiguous single-word slugs are deliberately absent: `porter`, `locus` and `slice`
 # in our catalogue are the US companies of those names, not the Indian ones.
 3i-infotech
+acko
 aerospike
 apna
 aryaka
 atlan
 birlasoft
 browserstack
+capillary-technologies
 cardekho
 cars24
 cashfree-payments
+chargebee
 coforge
 cohesity
+coindcx
 coinswitch
 cred
 cyient
 darwinbox
+dehaat
 dream-sports
 druva
 eclerx
@@ -58,6 +65,7 @@ innovaccer
 jar
 juspay
 kellton
+khatabook
 kpit
 kreditbee
 l-t-technology-services
@@ -74,6 +82,7 @@ navi
 netradyne
 newgen-software-technologies
 ninjacart
+nobroker
 nucleus-software-exports
 nutanix
 observe-ai
@@ -81,10 +90,16 @@ oyo
 paytm
 persistent-systems
 phonepe
+physicswallah
 postman
+purplle
 quest-global
+quikr
 razorpay
+rebel-foods
 rubrik
+sasken
+sharechat
 signoz
 snapdeal
 sonata-software
@@ -93,8 +108,13 @@ swiggy
 tata-consultancy-services
 tech-mahindra
 thoughtspot
+udaan
+unacademy
 uniphore
 upgrad
+upstox
+vedantu
+vymo
 whatfix
 wingify
 wipro
@@ -107,96 +127,5 @@ zensar
 zepto
 zeta
 zoho
-zscaler
-
-# --- Not in the catalogue yet (well-known; the tag lands when their board arrives) ---
-acko
-amagi
-ather-energy
-aye-finance
-bharatpe
-bigbasket
-blackbuck
-blusmart
-byjus
-capillary-technologies
-chargebee
-clevertap
-coindcx
-curefit
-dailyhunt
-dealshare
-dehaat
-delhivery
-dream11
-droom
-elasticrun
-entropik
-eruditus
-firstcry
-freshtohome
-games24x7
-globalbees
-gupshup
-hashedin
-hasura
-homelane
-incred
-infra-market
-instamojo
-interviewbit
-jumbotail
-jupiter-money
-khatabook
-kissflow
-knowlarity
-krutrim
-leadsquared
-licious
-livspace
-mamaearth
-mensa-brands
-microland
-mobikwik
-moglix
-mu-sigma
-nobroker
-nykaa
-ofbusiness
-ola-electric
-onecard
-oxyzo
-pepperfry
-perfios
-pharmeasy
-physicswallah
-pine-labs
-policybazaar
-practo
-purplle
-quikr
-ramco-systems
-rapido
-rebel-foods
-renew-power
-rivigo
-route-mobile
-sasken
-sharechat
-shiprocket
-tally-solutions
-tanla-platforms
-turtlemint
-udaan
-unacademy
-upstox
-urban-company
-vedantu
-vymo
-wakefit
-waycool
-xpressbees
-zerodha
-zetwerk
-zluri
 zomato
+zscaler


### PR DESCRIPTION
Fixes from the two-axis review of #2238 / #2241. One of the findings turned out to be a real hole older than either PR.

## The hole

`cmd/import-collections` decided whose unmatched entries are worth naming with `c.Slugs != nil`. That reads as "hand list", and it isn't one — both embedded membership files arrive as `Dataset{Data: ...}`, so `eastern_roots.txt` and `indian_roots.txt`, **the two largest lists we author**, had `UnmatchedNames` discarded before the report ran.

A typo in either matched nothing and reported nothing — the exact silence `TestHandListSlugsAreCompanySlugStable` exists to break on the other axis. The package's own AGENTS.md has claimed "unmatched hand-list entries are logged" throughout.

`Collection.HandList()` now owns the distinction, in the package that owns the registry, so the next caller can't redraw it wrong. A fetched dataset stays excluded — thousands of unmatched names would bury a hand list's few.

`TestHandListCoversEmbeddedMembershipFiles` pins both sides. Verified it fails against the old rule:

```
--- FAIL: TestHandListCoversEmbeddedMembershipFiles
    eastern-roots: HandList() = false, want true
    indian-roots:  HandList() = false, want true
```

## What that forces

`indian_roots.txt` carried a 90-slug tail of marquee companies we don't ingest, on the theory that the tag would land the day their board arrived. With reporting switched on, every run would name 90 intentional misses and a real typo would sit somewhere among them — `MaxLoggedUnmatched` is 50.

Checked all 90 against the live catalogue: **19 are in it after all** (`zomato`, `unacademy`, `chargebee`, `upstox`, `sharechat`, `udaan`, …) — my API name-matching missed them at curation time. This promotes those and drops the other 71. The file is now 110 entries, all of which match. Add a company when its board lands.

## The rest of the review

- Package `AGENTS.md` said the registry held **15** slugs; it holds 16. Most of its `file:line` citations had drifted, several from before this work. Every one is now verified against the source by script.
- `eastern_roots.txt` and the `easternRootsData` doc still named `normalize.Slug`, retired when the catalogue began stripping corporate forms — the rule the whole package is built around.
- `ParseSlugList`'s doc still named "the embedded russian-roots file", retired before that, and singular now that two files feed it.
- `embeddedSlugList` moves to the test file, where a parse failure is `t.Fatal` rather than an empty slice. The `checked < 100` population floor is summed across every list, so one file silently yielding nothing would still clear it on the others' entries.

Not addressed: the test map keys stay as `"easternRootsData"` — the reviewer called that a naming regression, but it is the uniform format the repo owner asked for in #2241.

## Checks

- `gofmt -l` clean, `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`
- `go test ./internal/job/collections/ ./cmd/import-collections/` — pass
- Every `file:line` citation in the touched AGENTS.md re-verified against the anchor it names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved collection importing to identify hand-maintained membership lists and provide more useful unmatched-entry diagnostics.
  - Expanded the Indian-roots company catalogue with verified entries.

- **Bug Fixes**
  - Corrected unmatched-entry handling for collections using embedded membership files.

- **Documentation**
  - Clarified collection matching behavior, diagnostic logging, catalogue coverage, and contribution guidance.
  - Updated collection metadata and comments to reflect current membership sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->