### PR TITLE
Clearance filter: add the "only" state, and the changelog post

### DIFF
--- a/web/src/lib/clearanceFilter.test.ts
+++ b/web/src/lib/clearanceFilter.test.ts
@@ -1,43 +1,55 @@
 import { describe, it, expect } from 'vitest';
 import { emptyFilters, filtersToParams, filtersFromParams, activeFilterCount } from './facetModel';
 
-// The control is phrased as an exclusion — "hide jobs requiring security clearance" —
-// so the checked state serializes to requires_clearance=false. The inversion is
-// deliberate: the API param names the facet's value, while the control names what the
-// user wants done about it.
-describe('hideClearance filter', () => {
-  it('serializes the checked state as requires_clearance=false', () => {
+// The clearance control has three states, not two, because the facet answers two
+// different people: someone who cannot hold a clearance wants these postings gone, and
+// someone who holds one wants nothing else. A checkbox can only say one of those.
+//
+// The API param names the facet's VALUE (`requires_clearance=false` means "postings not
+// marked"), while the control names the user's INTENT ("hide them"). The two therefore
+// read inverted, which is why the mapping is asserted in both directions here.
+describe('clearance filter', () => {
+  it('defaults to any, writing no param', () => {
     const f = emptyFilters();
-    f.hideClearance = true;
+    expect(f.clearance).toBe('any');
+    expect(filtersToParams(f).has('requires_clearance')).toBe(false);
+  });
+
+  it('hide serializes to requires_clearance=false', () => {
+    const f = emptyFilters();
+    f.clearance = 'hide';
     expect(filtersToParams(f).get('requires_clearance')).toBe('false');
   });
 
-  it('writes no param when unchecked, so the default listing is unfiltered', () => {
-    expect(filtersToParams(emptyFilters()).has('requires_clearance')).toBe(false);
-  });
-
-  it('round-trips through the URL', () => {
+  it('only serializes to requires_clearance=true', () => {
     const f = emptyFilters();
-    f.hideClearance = true;
-    expect(filtersFromParams(filtersToParams(f)).hideClearance).toBe(true);
+    f.clearance = 'only';
+    expect(filtersToParams(f).get('requires_clearance')).toBe('true');
   });
 
-  it('reads an absent param as unchecked', () => {
-    expect(filtersFromParams(new URLSearchParams()).hideClearance).toBe(false);
-  });
-
-  // requires_clearance=true is a valid API request — a cleared candidate searching for
-  // the work they are uniquely eligible for — but it is not what this checkbox means,
-  // so it must not tick it.
-  it('does not read requires_clearance=true as hiding them', () => {
-    expect(filtersFromParams(new URLSearchParams('requires_clearance=true')).hideClearance).toBe(
-      false,
-    );
-  });
-
-  it('counts towards the mobile filter badge', () => {
+  it.each(['hide', 'only'] as const)('round-trips %s through the URL', (state) => {
     const f = emptyFilters();
-    f.hideClearance = true;
-    expect(activeFilterCount(f)).toBe(1);
+    f.clearance = state;
+    expect(filtersFromParams(filtersToParams(f)).clearance).toBe(state);
+  });
+
+  it('reads an absent param as any', () => {
+    expect(filtersFromParams(new URLSearchParams()).clearance).toBe('any');
+  });
+
+  // A hand-edited or truncated link must not land the control in a state it cannot
+  // render. Anything unrecognised reads as the neutral default.
+  it('reads a malformed value as any', () => {
+    expect(filtersFromParams(new URLSearchParams('requires_clearance=maybe')).clearance).toBe('any');
+  });
+
+  it.each([
+    ['hide', 1],
+    ['only', 1],
+    ['any', 0],
+  ] as const)('counts %s towards the filter badge as %i', (state, want) => {
+    const f = emptyFilters();
+    f.clearance = state;
+    expect(activeFilterCount(f)).toBe(want);
   });
 });

--- a/web/src/lib/components/filters/FilterModal.svelte
+++ b/web/src/lib/components/filters/FilterModal.svelte
@@ -8,7 +8,7 @@
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import { profileStore } from '$lib/profile.svelte';
   import { notifications } from '$lib/notifications.svelte';
-  import { emptyFilters, type FilterStore, type JobFilters } from '$lib/filters';
+  import { emptyFilters, type ClearanceFilter, type FilterStore, type JobFilters } from '$lib/filters';
   import { StagedFilters } from '$lib/stagedFilters.svelte';
   import { RAIL, RAIL_SECTIONS, type RailEntry, type RailSection } from '$lib/filterSections';
   import type { FacetCounts } from '$lib/types';
@@ -136,6 +136,15 @@
     ),
   ]);
 
+  // The clearance control's three states. It is not a FACETS entry (it filters on a
+  // single boolean attribute, not a value vocabulary), so its options live here rather
+  // than in the facet registry.
+  const CLEARANCE_OPTIONS: { value: ClearanceFilter; label: string }[] = [
+    { value: 'any', label: 'Any' },
+    { value: 'hide', label: 'Hide' },
+    { value: 'only', label: 'Only' },
+  ];
+
   const jobCollectionValues = JOB_COLLECTION.map((o) => o.value);
   const employerCredentialValues = EMPLOYER_CREDENTIALS.map((o) => o.value);
 
@@ -166,7 +175,7 @@
       return (
         selCount(f, 'relocation') +
         (f.visa ? 1 : 0) +
-        (f.hideClearance ? 1 : 0) +
+        (f.clearance !== 'any' ? 1 : 0) +
         selCount(f, 'collections', employerCredentialValues)
       );
     if (e.kind === 'posted') return f.postedWithinDays != null ? 1 : 0;
@@ -443,15 +452,24 @@
       <span>Offers visa sponsorship</span>
     </label>
     <h3 class="mb-2 mt-6 text-sm font-semibold tracking-tight">Security clearance</h3>
-    <label class="flex cursor-pointer items-center gap-2 text-sm">
-      <input
-        type="checkbox"
-        class="size-4 rounded border-border"
-        checked={staged.value.hideClearance}
-        onchange={(e) => staged.setHideClearance(e.currentTarget.checked)}
-      />
-      <span>Hide jobs requiring security clearance</span>
-    </label>
+    <div class="inline-flex overflow-hidden rounded-md border border-border" role="group">
+      {#each CLEARANCE_OPTIONS as opt (opt.value)}
+        <button
+          type="button"
+          class="px-3 py-1.5 text-sm transition-colors {staged.value.clearance === opt.value
+            ? 'bg-primary text-primary-foreground'
+            : 'bg-background hover:bg-muted'}"
+          aria-pressed={staged.value.clearance === opt.value}
+          onclick={() => staged.setClearance(opt.value)}
+        >
+          {opt.label}
+        </button>
+      {/each}
+    </div>
+    <p class="mt-2 text-xs text-muted-foreground">
+      Government vetting — UK SC/DV, US Secret/TS-SCI, AU NV1. Only is for candidates who
+      already hold one.
+    </p>
   {:else if entry.kind === 'posted'}
     <div class="mb-2 flex items-center justify-between">
       <h3 class="text-sm font-semibold tracking-tight">Posted within</h3>

--- a/web/src/lib/components/filters/FilterSummary.svelte
+++ b/web/src/lib/components/filters/FilterSummary.svelte
@@ -77,9 +77,13 @@
     push('Salary', salary);
 
     if (f.visa) push('Visa', [{ text: 'Sponsorship', exclude: false, remove: () => store.setVisa(false) }]);
-    if (f.hideClearance)
+    if (f.clearance !== 'any')
       push('Clearance', [
-        { text: 'Hidden', exclude: false, remove: () => store.setHideClearance(false) },
+        {
+          text: f.clearance === 'hide' ? 'Hidden' : 'Required only',
+          exclude: false,
+          remove: () => store.setClearance('any'),
+        },
       ]);
     if (f.postedWithinDays != null) push('Posted', [{ text: freshnessLabel(f.postedWithinDays), exclude: false, remove: () => store.setPostedWithinDays(null) }]);
     // `!= null`, not truthiness: a zero bound is the entry-level filter, and hiding

--- a/web/src/lib/docs/filters.ts
+++ b/web/src/lib/docs/filters.ts
@@ -119,4 +119,5 @@ export const RECIPES: Recipe[] = [
   { title: 'Exclude outstaff companies', query: 'company_type_exclude=outstaff' },
   { title: 'At least $100k, with visa sponsorship', query: 'salary_currency=USD&salary_min=100000&visa_sponsorship=true' },
   { title: 'Excluding jobs that need a security clearance', query: 'requires_clearance=false' },
+  { title: 'Only jobs that need a security clearance', query: 'requires_clearance=true' },
 ];

--- a/web/src/lib/facetModel.ts
+++ b/web/src/lib/facetModel.ts
@@ -21,18 +21,25 @@ export type Sign = 'off' | 'include' | 'exclude';
  *  shape `FacetSection` reads — one canonical type so the two can't drift. */
 export type FacetState = FacetSelection;
 
+/** The clearance control's three states. `any` writes no param at all, so the default
+ *  listing is untouched. */
+export type ClearanceFilter = 'any' | 'hide' | 'only';
+
 export interface JobFilters {
   q: string;
   /** Facet state keyed by the facet's query param (see FACETS). */
   facets: Record<string, FacetState>;
   visa: boolean;
-  /** Hide postings that state a government security-clearance requirement (UK SC/DV,
-   *  US Secret/TS-SCI, AU NV1). Serialized as `requires_clearance=false` — the param
-   *  names the facet's value, this flag names what the user wants done about it, so
-   *  the two are deliberately inverted. `requires_clearance=true` is a valid API
-   *  request (a cleared candidate seeking exactly that work) but not something this
-   *  control expresses, so it does not set the flag. */
-  hideClearance: boolean;
+  /** What to do about postings that state a government security-clearance requirement
+   *  (UK SC/DV, US Secret/TS-SCI, AU NV1). Three states rather than a boolean because
+   *  the facet answers two different people: someone who cannot hold a clearance wants
+   *  these gone, someone who holds one wants nothing else.
+   *
+   *  Serialized as `requires_clearance`, whose value names the FACET while this names
+   *  the INTENT — so `hide` writes `false` and `only` writes `true`. An unrecognised
+   *  value in a hand-edited link reads as `any` rather than leaving the control in a
+   *  state it cannot render. */
+  clearance: ClearanceFilter;
   salaryMin: number | null;
   /** Freshness: keep only jobs posted within the last N days (null = any age).
    *  Serialized as `posted_within_days`; the backend turns it into a posted_ts
@@ -80,7 +87,7 @@ export function emptyFilters(): JobFilters {
     q: '',
     facets: emptyFacets(),
     visa: false,
-    hideClearance: false,
+    clearance: 'any',
     salaryMin: null,
     postedWithinDays: null,
     experienceYearsMax: null,
@@ -103,7 +110,8 @@ export function filtersToParams(f: JobFilters): URLSearchParams {
     if (st.matchAll && st.include.length > 1) p.set(`${def.param}_mode`, 'and');
   }
   if (f.visa) p.set('visa_sponsorship', 'true');
-  if (f.hideClearance) p.set('requires_clearance', 'false');
+  if (f.clearance === 'hide') p.set('requires_clearance', 'false');
+  if (f.clearance === 'only') p.set('requires_clearance', 'true');
   if (f.salaryMin != null) p.set('salary_min', String(f.salaryMin));
   if (f.postedWithinDays != null) p.set('posted_within_days', String(f.postedWithinDays));
   if (f.experienceYearsMax != null) p.set('experience_years_max', String(f.experienceYearsMax));
@@ -148,7 +156,8 @@ export function filtersFromParams(p: URLSearchParams): JobFilters {
     f.facets[def.param] = { include, exclude, matchAll };
   }
   f.visa = p.get('visa_sponsorship') === 'true';
-  f.hideClearance = p.get('requires_clearance') === 'false';
+  const clearance = p.get('requires_clearance');
+  f.clearance = clearance === 'false' ? 'hide' : clearance === 'true' ? 'only' : 'any';
   const salary = Number(p.get('salary_min'));
   f.salaryMin = p.get('salary_min') && !Number.isNaN(salary) ? salary : null;
   // Freshness is a positive whole number of days; anything else (absent, zero,
@@ -179,7 +188,7 @@ export function activeFilterCount(f: JobFilters): number {
     if (st) n += st.include.length + st.exclude.length;
   }
   if (f.visa) n += 1;
-  if (f.hideClearance) n += 1;
+  if (f.clearance !== 'any') n += 1;
   if (f.salaryMin != null) n += 1;
   if (f.postedWithinDays != null) n += 1;
   if (f.experienceYearsMax != null) n += 1;

--- a/web/src/lib/filters.ts
+++ b/web/src/lib/filters.ts
@@ -6,6 +6,7 @@
 import { UrlSyncedState } from './urlSynced.svelte';
 import { saveJobFilters } from './filterStorage';
 import {
+  type ClearanceFilter,
   type FacetState,
   type JobFilters,
   type JobSort,
@@ -97,8 +98,8 @@ export class FilterStore {
     this.#url.setNow({ ...this.#url.value, visa: on });
   }
 
-  setHideClearance(on: boolean) {
-    this.#url.setNow({ ...this.#url.value, hideClearance: on });
+  setClearance(v: ClearanceFilter) {
+    this.#url.setNow({ ...this.#url.value, clearance: v });
   }
 
   /** Switch the feed ordering. setNow, not setSoon: this is a discrete choice from a

--- a/web/src/lib/stagedFilters.svelte.ts
+++ b/web/src/lib/stagedFilters.svelte.ts
@@ -9,6 +9,7 @@
 import type { FacetStore } from './facets';
 import type { UserProfile } from './types';
 import {
+  type ClearanceFilter,
   activeFilterCount,
   emptyFacet,
   emptyFilters,
@@ -84,8 +85,8 @@ export class StagedFilters implements FacetStore {
     this.#f = { ...this.#f, visa: on };
   }
 
-  setHideClearance(on: boolean): void {
-    this.#f = { ...this.#f, hideClearance: on };
+  setClearance(v: ClearanceFilter): void {
+    this.#f = { ...this.#f, clearance: v };
   }
 
   setPostedWithinDays(n: number | null): void {

--- a/web/src/posts/2026-08-31-hide-jobs-that-need-a-security-clearance.svx
+++ b/web/src/posts/2026-08-31-hide-jobs-that-need-a-security-clearance.svx
@@ -1,0 +1,64 @@
+---
+title: Hide jobs that need a security clearance
+date: 2026-08-31
+summary: 21 414 postings in the catalogue require a government security clearance — UK SC/DV, US Secret/TS-SCI, Australian NV1. One checkbox now takes them out of your results, or shows only them if you hold one.
+type: changelog
+tags:
+  - filters
+  - job-seekers
+draft: false
+---
+
+Someone asked us: *"Any way of filtering jobs to exclude the ones that need SC
+clearance?"*
+
+Now there is. Open **All filters → Relocation** and you will find **Security clearance**
+with three settings: **Any**, **Hide**, **Only**. It covers every scheme the catalogue
+actually carries — UK SC, DV, CTC and BPSS; US Secret, Top Secret, TS/SCI, public trust
+and polygraph; Australian Baseline, NV1 and NV2.
+
+**21 414 postings** are affected. That is a small share of the catalogue overall, and
+close to all of it if you are looking at UK government work or US defence contracting —
+which is exactly why it was worth doing. Being told about a job you are not allowed to
+hold is not a job listing, it is noise.
+
+**Only** exists because the filter has two audiences, not one. If you already hold a
+clearance, those 21 414 postings are not clutter — they are the shortlist almost nobody
+else can apply to, and now you can look at just them.
+
+Over the API it is one parameter: `requires_clearance=false` to drop them,
+`requires_clearance=true` to see nothing else.
+
+### The bit that nearly went wrong
+
+Our first estimate said 37 000 postings. It was wrong by more than double, and the
+reason is worth writing down.
+
+We sized the feature by asking the search index how many postings mention a clearance.
+Search engines treat a quoted phrase as a phrase — except this one, in this
+configuration, does not. Asking it for `"public trust"` and asking it for
+`"trust public"` returned the same 5 077 results, because it was matching documents
+containing both words *somewhere*, not the phrase. Half those documents said things
+like "our commitment to public trust", which is a press release, not a vetting tier.
+
+The same artefact inflated the opposite number. We believed 355 postings explicitly say
+no clearance is needed. The real figure, checked against the text itself, is close to
+zero: the word `no` is a stop word, so the engine had thrown it away and counted
+postings that said the reverse.
+
+Every rule in the filter was then checked against 2 084 real postings rather than
+reasoned about, and that caught things no amount of thinking would have:
+
+- **Job descriptions are HTML**, and one posting read
+  `<p><b>Security Clearance: </b></p>None/Not Required`. Read as markup, the label and
+  its answer are separated by tags — so the filter marked a job that explicitly needs
+  *no* clearance. It now reads what a person would see, not how the page is typeset.
+- **Employers state it as a form field**, not a sentence: `Clearance: Secret`,
+  `CLEARANCE REQUIRED FOR START: Yes`. That was about a fifth of all real matches and
+  no list of phrases could have caught it.
+- **Two-letter scheme names hide inside ordinary words** — `sc` in "describe", `ts` in
+  "contracts", `dv` in "advise". Each one would have flagged a job at random.
+
+The bias throughout is the same: when in doubt, leave the posting visible. Missing a
+clearance job costs you one line in a list. Wrongly hiding one costs you a job you
+could have had.


### PR DESCRIPTION
Follow-up to #2240.

## The `only` state

The checkbox could only say one of the two things this facet answers. Someone who cannot hold a clearance wants those 21,414 postings gone. Someone who **holds** one wants nothing else — for them it is not clutter, it is the shortlist almost nobody else can apply to.

So the control is now **Any / Hide / Only**, in All filters → Relocation. The API already accepted both values; this closes the gap in the UI. An unrecognised value in a hand-edited link reads as `Any` rather than leaving the control in a state it cannot render.

## Changelog post

Leads with the measured number and then with why the first measurement was wrong by more than double — the search index does not phrase-match quoted strings in this configuration, so `"public trust"` and `"trust public"` returned identical counts and half of them were press-release copy.

## Production state (from #2240)

- Migration applied, `requires_clearance` declared filterable on the live index (66s task), deployed.
- Backfill: 74,533 candidates read, **21,414 marked**, in 6 minutes. Re-run wrote **1** row — the guard holds, so the pass is genuinely resumable.
- `/api/v1/jobs/facets` stayed 200 throughout; the facet smoke in `release.sh` passed before the flip.
- The scheduled `freehire-reindexw` picks the values up on its next run — it starts after the backfill, so no manual rebuild was needed.

One thing worth recording: the migration file landed as `0119_`, and `0119_user_llm_key_id.sql` merged into main while this branch was open. The ledger keys on filename so there is no conflict, but the number is now used twice.

## Verification

1,211 web tests pass, `svelte-check` 0 errors, eslint clean on the changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a three-option security clearance filter: **Any**, **Hide**, and **Only**.
  * Filter results can now show only jobs requiring clearance or exclude them.
  * Added a clearance filter summary chip and active-filter counts.
  * Added documentation and a changelog entry describing supported clearance schemes and usage.

* **Bug Fixes**
  * Invalid or missing clearance filter values now safely default to **Any**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->