### PR TITLE
Say which gateway these calls actually go to

### DIFF
--- a/internal/ai/assistant/AGENTS.md
+++ b/internal/ai/assistant/AGENTS.md
@@ -187,14 +187,15 @@ the ordinary tool-calling turn loop, not inside it:
   `STTModel` in `internal/platform/config` — unset means the feature is absent, not billed for
   by accident).
 - **`REALTIME_MODEL` must carry the provider prefix** (`openai/gpt-realtime-2.1`, not
-  the bare `gpt-realtime-2.1`), unlike every other model name in this file. The
-  litellm proxy's realtime WebRTC feature is lazy-loaded and does not resolve a
-  `model_name` alias the way the rest of the proxy does — `can_key_call_resolved_model`
-  accepts the alias, but the actual upstream call then fails with `litellm.BadRequestError:
-  LLM Provider NOT provided`. Confirmed live against the production proxy
-  (`root@204.168.137.149:/opt/litellm`) on 2026-08-10: a `model_name: gpt-realtime-2.1`
-  entry in `config.yaml` is harmless but unnecessary — what actually works is the
-  client passing the provider-prefixed string directly.
+  the bare `gpt-realtime-2.1`), unlike every other model name in this file. It has
+  outlived the gateway it was discovered on, which is the reason to keep both halves
+  written down. On the litellm proxy the realtime WebRTC feature was lazy-loaded and did
+  not resolve a `model_name` alias the way the rest of the proxy did —
+  `can_key_call_resolved_model` accepted the alias and the upstream call then failed with
+  `litellm.BadRequestError: LLM Provider NOT provided` (confirmed 2026-08-10). Production
+  moved to Bifrost on 2026-08-31, where the same prefixed string answers 200 and mints an
+  ephemeral key, and where nothing named `realtime` is a tier alias at all — audio is
+  entitled by model name. Either way the client passes the provider-prefixed string.
 
 **Interview debrief** is the rehearsal's mirror: the review of an interview that has
 already happened, minted from `POST /assistant/sessions?preset=debrief&job=<slug>`. It

--- a/internal/platform/llm/AGENTS.md
+++ b/internal/platform/llm/AGENTS.md
@@ -4,7 +4,7 @@
 A thin provider-agnostic wrapper over langchaingo for OpenAI-compatible endpoints: JSON
 generation with fence-stripping and optional schema constraints, streaming, tool-calling
 chat, Langfuse tracing, and per-user spend attribution via gateway credentials and
-`x-litellm-tags` (credential.go:15). Callers keep their own prompts and typed-contract
+`x-bf-dim-<dimension>` headers (credential.go:19). Callers keep their own prompts and typed-contract
 parsing. Consumers: `cmd/server`, `cmd/enrich`, `cmd/tg-extract`, `cmd/classify-mail`, the
 backfills, and `internal/ai/enrich`, `matchanalysis`, `resumeextract`, `atscheck`,
 `mailclassify`, `mailrecall`, `telegram`, `autofillagent`, `assistant`, `cv`.


### PR DESCRIPTION
Production moved off the LiteLLM proxy onto **Bifrost** on 2026-08-31 — the API, the assistant, dictation, voice mode and every worker. This PR is documentation only: the code needed no change, because it had been ready for a while (`internal/ai/llmkey` speaks the virtual-key admin API, `credential.go` stamps `x-bf-dim-<dimension>`, migration 0119 stores the id the gateway returns). What had drifted were two AGENTS.md files.

- `internal/platform/llm/AGENTS.md` named `x-litellm-tags` as the attribution header. Nothing sends it; `credential.go:19` has stamped `x-bf-dim-<dimension>` since the header shape changed.
- `internal/ai/assistant/AGENTS.md` explained the `REALTIME_MODEL` prefix rule entirely through a litellm bug. The rule outlived its explanation — on Bifrost the prefixed string answers 200 and audio is entitled by model name rather than by tier — so a reader who knew only the old reason could reasonably have dropped the prefix.

Operational detail lives in `freehire-ops` (provision/bifrost), including the gateway address, the tier→model table, and the two traps worth knowing: a per-user credential belongs to exactly one gateway (290 stored LiteLLM keys had to be dumped and cleared, or every one of those accounts would have got a 401), and Bifrost's `config.json` only seeds its SQLite state on first start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated realtime model guidance to reflect the current production gateway and audio entitlement behavior.
  - Clarified why the provider-prefixed realtime model string remains required.
  - Updated LLM client conventions to reference the current dimension header format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->