### PR TITLE
Build the bridge to /roles that the last change forgot

### DIFF
--- a/design-system/scripts/web-token-baseline.json
+++ b/design-system/scripts/web-token-baseline.json
@@ -48,7 +48,6 @@
   "web/src/lib/components/HomeView.svelte": 16,
   "web/src/lib/components/InboxLandingView.svelte": 4,
   "web/src/lib/components/InboxView.svelte": 8,
-  "web/src/lib/components/InsightsPageShell.svelte": 2,
   "web/src/lib/components/JobDrawer.svelte": 7,
   "web/src/lib/components/JobMatch.svelte": 1,
   "web/src/lib/components/JobMatchBar.svelte": 1,

--- a/web/src/lib/collections.test.ts
+++ b/web/src/lib/collections.test.ts
@@ -3,6 +3,7 @@ import {
   FILTER_COLLECTIONS,
   POPULAR_COLLECTION_FALLBACK,
   collectionBySlug,
+  collectionForCategory,
   collectionSlugs,
   jobFacetsFromJob,
   popularCollectionLinks,
@@ -302,5 +303,29 @@ describe('popularCollectionLinks', () => {
     const slugs = popularCollectionLinks().map((l) => l.slug);
     expect(slugs).toEqual(POPULAR_COLLECTION_FALLBACK.filter((s) => collectionBySlug(s)));
     expect(new Set(slugs).size).toBe(slugs.length);
+  });
+});
+
+describe('collectionForCategory', () => {
+  it('finds the feed that pins exactly this category', () => {
+    expect(collectionForCategory('backend')).toMatchObject({ slug: 'backend' });
+    expect(collectionForCategory('devops')).toMatchObject({ slug: 'devops' });
+  });
+
+  it('returns nothing for a category no collection covers', () => {
+    // Only 15 of the 37 categories have a curated feed; the rest are not an error.
+    expect(collectionForCategory('legal')).toBeUndefined();
+    expect(collectionForCategory('')).toBeUndefined();
+  });
+
+  it('ignores a collection that pins the category ALONGSIDE something else', () => {
+    // Such a feed is not "all <category> jobs" — linking to it as if it were would
+    // send the reader somewhere narrower than the label promises.
+    const multi = FILTER_COLLECTIONS.filter(
+      (c) => c.params.category && Object.keys(c.params).length > 1
+    );
+    for (const c of multi) {
+      expect(collectionForCategory(c.params.category as string)?.slug).not.toBe(c.slug);
+    }
   });
 });

--- a/web/src/lib/collections.ts
+++ b/web/src/lib/collections.ts
@@ -657,6 +657,24 @@ export function collectionBySlug(slug: string): ResolvedCollection | undefined {
   return undefined;
 }
 
+// The curated feed for a category, where one exists — the counterpart link from the
+// /roles country table, which is a market map rather than a feed and so wants to hand
+// the reader the feed rather than reimplement it.
+//
+// Matches only a collection whose ONLY pin is the category. A feed pinning the
+// category alongside anything else is narrower than "all <category> jobs", and
+// offering it under that label would send the reader somewhere smaller than promised.
+// 15 of the 37 categories have one; the rest returning undefined is ordinary.
+export function collectionForCategory(
+  category: string
+): { slug: string; title: string } | undefined {
+  if (!category) return undefined;
+  const match = FILTER_COLLECTIONS.find(
+    (c) => c.params.category === category && Object.keys(c.params).length === 1
+  );
+  return match ? { slug: match.slug, title: match.title } : undefined;
+}
+
 // Every collection slug across both registries — the sitemap's source for the
 // collection landing URLs. Slugs are unique across the two sets.
 export function collectionSlugs(): string[] {

--- a/web/src/lib/components/Footer.svelte
+++ b/web/src/lib/components/Footer.svelte
@@ -14,6 +14,7 @@
         { label: 'Jobs', href: resolve('/') },
         { label: 'Companies', href: resolve('/companies') },
         { label: 'Collections', href: resolve('/collections') },
+        { label: 'Jobs by role', href: resolve('/roles') },
         { label: 'Recruiters', href: resolve('/recruiters') },
       ],
     },

--- a/web/src/lib/components/InsightsPageShell.svelte
+++ b/web/src/lib/components/InsightsPageShell.svelte
@@ -7,6 +7,7 @@
   import { resolve } from '$app/paths';
   import type { Snippet } from 'svelte';
   import type { CoveredCategory } from '$lib/insights';
+  import { categoryLandingLink } from '$lib/roleLandings';
 
   type Kind = 'salary' | 'skills' | 'roles';
 
@@ -53,6 +54,8 @@
   );
   // A few sibling categories to cross-link (excluding the current one).
   const siblings = $derived(covered.filter((c) => c.category !== category).slice(0, 8));
+  // The /roles country table for this category, when it publishes one.
+  const marketLink = $derived(categoryLandingLink(category));
 </script>
 
 <article class="mx-auto w-full max-w-4xl px-4 py-8">
@@ -77,10 +80,21 @@
       <span class="font-medium text-foreground">More on {label}:</span>
       {#each otherKinds as k (k)}
         <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- href is resolve()d inside kindHref; the linter can't trace it through the helper -->
-        <a href={kindHref(k, category)} class="text-blue-600 hover:underline">{KIND_LABEL[k]}</a>
+        <a href={kindHref(k, category)} class="text-brand-strong hover:underline">{KIND_LABEL[k]}</a>
       {/each}
+      <!-- These pages are global; the country breakdown is the geographic cut of the
+           same data, so it belongs in this row rather than being reachable only from
+           the footer. -->
+      {#if marketLink}
+        <a
+          href={resolve('/roles/[category]', { category: marketLink.slug })}
+          class="text-brand-strong hover:underline"
+        >
+          By country
+        </a>
+      {/if}
       <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal /jobs filter link; resolve()d base plus a query string, no dynamic route to resolve -->
-      <a href={`${resolve('/jobs')}?category=${encodeURIComponent(category)}`} class="text-blue-600 hover:underline">
+      <a href={`${resolve('/jobs')}?category=${encodeURIComponent(category)}`} class="text-brand-strong hover:underline">
         Browse {label} jobs →
       </a>
     </div>

--- a/web/src/lib/roleLandings.test.ts
+++ b/web/src/lib/roleLandings.test.ts
@@ -7,6 +7,7 @@ import {
   englishBreakdown,
   freshCount,
   landingCategories,
+  categoryLandingLink,
   landingIntro,
   MIN_PAIR_OPEN,
   MIN_SALARY_SAMPLE,
@@ -206,5 +207,29 @@ describe('internal linking', () => {
     );
     expect(Object.keys(many).length).toBeGreaterThan(8);
     expect(neighbourCountries(many, 'de').length).toBeLessThanOrEqual(8);
+  });
+});
+
+describe('the link a job page offers', () => {
+  it('points at the category table, which is published whenever any country is', () => {
+    expect(categoryLandingLink('backend')).toMatchObject({
+      category: 'backend',
+      slug: 'backend',
+      label: 'Backend',
+    });
+  });
+
+  it('offers nothing for the catch-all category', () => {
+    expect(categoryLandingLink('other')).toBeNull();
+  });
+
+  it('offers nothing when the posting carries no category', () => {
+    expect(categoryLandingLink(null)).toBeNull();
+    expect(categoryLandingLink(undefined)).toBeNull();
+    expect(categoryLandingLink('')).toBeNull();
+  });
+
+  it('offers nothing for a value outside the vocabulary', () => {
+    expect(categoryLandingLink('astrology')).toBeNull();
   });
 });

--- a/web/src/lib/roleLandings.ts
+++ b/web/src/lib/roleLandings.ts
@@ -59,6 +59,25 @@ export interface LandingCategory {
   label: string;
 }
 
+/** The landing a posting can be linked to from its own page, or null when it carries
+ *  no category we publish.
+ *
+ *  Deliberately the CATEGORY table and not the (category, country) pair the posting
+ *  actually belongs to. The pair would be the more relevant link, and checking whether
+ *  it clears the gate costs a facet call — on the single hottest page on the site,
+ *  which declared crawlers already fetch tens of thousands of times an hour. Linking
+ *  it unchecked is worse than not linking: only 1,471 of the ~8,800 possible pairs are
+ *  published, so most postings would point at a 404 from an indexed page.
+ *
+ *  The category table needs no check: it is published whenever ANY of its countries
+ *  is, so a category with a page for the posting's country necessarily has one here —
+ *  and the posting's country is a row in the table it lands on, one click away. */
+export function categoryLandingLink(category: string | null | undefined): LandingCategory | null {
+  if (!category) return null;
+  const slug = categorySlug(category);
+  return CATEGORY_BY_SLUG.has(slug) ? { category, slug, label: categoryLabel(category) } : null;
+}
+
 /** Every category that gets pages, in vocabulary order. */
 export function landingCategories(): LandingCategory[] {
   return [...CATEGORY_BY_SLUG.entries()].map(([slug, category]) => ({

--- a/web/src/routes/collections/[slug]/+page.server.ts
+++ b/web/src/routes/collections/[slug]/+page.server.ts
@@ -2,6 +2,7 @@ import { error } from '@sveltejs/kit';
 import { serverApi } from '$lib/server/api';
 import { collectionBySlug } from '$lib/collections';
 import { pageExists, pageOffset, parsePage } from '$lib/pagination';
+import { categoryLandingLink } from '$lib/roleLandings';
 import type { PageServerLoad } from './$types';
 
 const LIMIT = 20;
@@ -37,5 +38,11 @@ export const load: PageServerLoad = async ({ params, url, fetch }) => {
   // a self-referencing canonical. parsePage clamps to MAX_PAGE rather than failing,
   // which is right for the number and wrong for what we then serve.
   if (!pageExists(pageNumber, initial.total)) error(404, 'Page not found');
-  return { slug: params.slug, collection, initial, pageNumber };
+  // The country map for this feed's category, where the feed pins exactly one. The
+  // reverse of the link /roles/[category] carries: this page answers "show me the
+  // jobs", that one answers "where are they, and what do they pay".
+  const marketLink = categoryLandingLink(
+    Object.keys(collection.params).length === 1 ? (collection.params.category ?? null) : null
+  );
+  return { slug: params.slug, collection, initial, pageNumber, marketLink };
 };

--- a/web/src/routes/collections/[slug]/+page.svelte
+++ b/web/src/routes/collections/[slug]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import JobsView from '$lib/components/JobsView.svelte';
   import Seo from '$lib/components/Seo.svelte';
@@ -81,6 +82,16 @@
     <p class="mt-2 max-w-2xl text-sm leading-relaxed text-muted-foreground">
       {data.collection.description}
     </p>
+    {#if data.marketLink}
+      <p class="mt-3 text-sm">
+        <a
+          href={resolve('/roles/[category]', { category: data.marketLink.slug })}
+          class="text-brand-strong hover:underline"
+        >
+          {data.marketLink.label} jobs by country — openings, pay and top skills →
+        </a>
+      </p>
+    {/if}
   </header>
 
   <!-- Remount on slug change so the seeded paginator/filters start fresh per

--- a/web/src/routes/jobs/[slug]/+page.svelte
+++ b/web/src/routes/jobs/[slug]/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
+  import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import JobRelated from '$lib/components/JobRelated.svelte';
   import JobSeeAlso from '$lib/components/JobSeeAlso.svelte';
   import JobView from '$lib/components/JobView.svelte';
   import Seo from '$lib/components/Seo.svelte';
+  import { categoryLandingLink } from '$lib/roleLandings';
   import {
     breadcrumbJsonLd,
     jobPageTitle,
@@ -15,6 +17,7 @@
 
   let { data }: { data: PageData } = $props();
 
+  const marketLink = $derived(categoryLandingLink(data.job.enrichment.category));
   const origin = $derived(page.url.origin);
   const canonical = $derived(`${origin}/jobs/${data.job.public_slug}`);
   // The per-job OG preview lives beside the canonical URL; og:image must be absolute.
@@ -67,4 +70,20 @@
   />
 
   <JobSeeAlso cards={data.seeAlso} />
+
+  <!-- The bridge from a posting to the market pages. Costs nothing to render: the
+       category is already on the job, and the category table needs no gate check
+       (see categoryLandingLink). Without this the /roles tree is reachable only from
+       the footer and the sitemap, which is how a page ends up crawled but not
+       weighted. -->
+  {#if marketLink}
+    <p class="mt-8 text-sm">
+      <a
+        href={resolve('/roles/[category]', { category: marketLink.slug })}
+        class="text-brand-strong hover:underline"
+      >
+        {marketLink.label} jobs by country — openings, pay and top skills →
+      </a>
+    </p>
+  {/if}
 </div>

--- a/web/src/routes/roles/[category]/+page.server.ts
+++ b/web/src/routes/roles/[category]/+page.server.ts
@@ -1,4 +1,5 @@
 import { error, redirect } from '@sveltejs/kit';
+import { collectionForCategory } from '$lib/collections';
 import {
   categoryFromSlug,
   categorySlug,
@@ -44,6 +45,10 @@ export const load: PageServerLoad = async ({ params, fetch, setHeaders }) => {
     category,
     categorySlug: canonicalSlug,
     label: categoryLabel(category),
+    // The curated feed for this category, where one exists. This page is the map; the
+    // feed is /collections. Linking it is what keeps the two from reading as rivals
+    // for one query — see the cannibalisation note in the spec.
+    feed: collectionForCategory(category) ?? null,
     total: counts.total,
     countries,
     siblings: landingCategories().filter((c) => c.category !== category),

--- a/web/src/routes/roles/[category]/+page.svelte
+++ b/web/src/routes/roles/[category]/+page.svelte
@@ -53,8 +53,19 @@
     <!-- The feed lives at /collections; this page is the map. Linking it keeps the
          two from reading as rivals for the same query. -->
     <p class="mt-3 text-sm">
-      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal /jobs filter link; resolve()d base plus a query string, no dynamic route to resolve -->
-      <a href={jobsHref} class="text-primary hover:underline">Browse all {data.label} jobs →</a>
+      {#if data.feed}
+        <!-- The curated feed owns this query; prefer it over a raw /jobs filter, which
+             the list canonicalises back to bare /jobs and so cannot rank. -->
+        <a
+          href={resolve('/collections/[slug]', { slug: data.feed.slug })}
+          class="text-brand-strong hover:underline"
+        >
+          Browse all {data.label} jobs →
+        </a>
+      {:else}
+        <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal /jobs filter link; resolve()d base plus a query string, no dynamic route to resolve -->
+        <a href={jobsHref} class="text-brand-strong hover:underline">Browse all {data.label} jobs →</a>
+      {/if}
     </p>
   </header>
 
@@ -73,7 +84,7 @@
               category: data.categorySlug,
               country: c.slug,
             })}
-            class="flex items-center gap-2 text-primary hover:underline"
+            class="flex items-center gap-2 text-brand-strong hover:underline"
           >
             <CountryFlag code={c.code} label={c.label} />
             {c.label}


### PR DESCRIPTION
## What

The `/roles` tree shipped in #2264 with internal linking **between** its own pages and **none into it**. Nothing on freehire.me linked `/roles` — the only route in was the sitemap.

A sitemap says a page exists. A link says it matters. Google weighs them differently, so 1,508 pages were sitting on the far side of a missing bridge.

## Four ways in

| From | To | Why there |
|---|---|---|
| Footer | `/roles` | the hub needs one durable, site-wide entry |
| `/collections/<category>` | `/roles/<category>` | the feed's readers are the ones asking "where?" |
| `/insights/*/<category>` rail | `/roles/<category>` | those pages are global; this is the geographic cut of the same data |
| **every job page** | `/roles/<category>` | the catalogue is millions of pages — this is the one that carries weight |

## Why the job page links the category, not the pair

The pair (`/roles/backend/germany`) is the more relevant link, and the posting knows both axes already. It is not used, for two reasons that point the same way:

- Checking whether the pair clears the publication gate costs a facet call — on the single hottest page on the site, which declared crawlers already fetch tens of thousands of times an hour.
- Linking it **unchecked** is worse: only 1,471 of the ~8,800 possible pairs are published, so most postings would point at a 404 **from an indexed page**.

The category table needs no check at all — it is published whenever any of its countries is — and the posting's own country is a row on the table it lands on, one click away.

## Two things I got wrong last time

**Wrong target.** `/roles/[category]` linked `/jobs?category=X`, which the jobs list canonicalises back to bare `/jobs` and therefore cannot rank. The spec said link the curated feed; I built the other thing. Now it links `/collections/<category>` where one exists (15 of 37 do), falling back to the filter otherwise.

**Invisible links.** The token check rejected `text-blue-600`, and I reached for `text-primary` — which is `oklch(0.13 0 0)`, the near-black neutral. Every link on the new pages was rendering as plain text. The token for a link is `text-brand-strong` ("darker brand tone for readable text/links"), which 40 other files already use. Fixed on the new pages, and on the insights rail whose two pre-existing `text-blue-600` links sit in the row I was editing — token debt 512 → 510.

## Testing

1,253 unit tests (7 new, covering both link helpers and their refusals: the `other` catch-all, a missing category, a value outside the vocabulary, and a collection that pins the category *alongside* something else — that feed is narrower than "all X jobs" and must not be offered under that label).

All four links verified rendering against the production API on a built server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Jobs by role” navigation to the footer.
  * Added links connecting job listings, role pages, collections, and country-based job insights.
  * Role pages now direct visitors to curated job collections when available.
  * Collection pages now link to related jobs by country, including openings, pay, and top skills.
  * Added contextual “By country” links to insights pages.
* **Style**
  * Updated internal-link styling for improved visual consistency.
* **Tests**
  * Added coverage for category-based links and curated collection matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->