### PR TITLE
Let a deployment say its gateway does not honour strict schemas

### DIFF
--- a/internal/ai/enrich/live_measure_test.go
+++ b/internal/ai/enrich/live_measure_test.go
@@ -32,6 +32,13 @@ func liveClient(t *testing.T) *llm.Client {
 		APIKey:  os.Getenv("LLM_API_KEY"),
 		Model:   os.Getenv("LLM_MODEL"),
 	}
+	// LLM_STRICT_SCHEMA=false measures the gateway the way a deployment that set it
+	// would run: same prompt, plain JSON mode, no schema on the wire. Comparing the
+	// two is the only way to answer whether a model that ignores a strict schema can
+	// still be trusted with this contract.
+	if os.Getenv("LLM_STRICT_SCHEMA") == "false" {
+		s.SchemaMode = llm.SchemaModeJSONObject
+	}
 	if !s.Enabled() {
 		t.Skip("LLM_BASE_URL/LLM_API_KEY/LLM_MODEL not set")
 	}
@@ -91,10 +98,15 @@ func TestLive_EnrichmentFillsUnderTheSchema(t *testing.T) {
 		}
 	}
 
-	// Fields the prompt does not ask for must not come back at all.
-	if got.Seniority != "" || got.WorkMode != "" || len(got.Skills) > 0 {
-		t.Errorf("model returned dictionary-covered facets: seniority=%q work_mode=%q skills=%v",
-			got.Seniority, got.WorkMode, got.Skills)
+	// Fields the prompt does not ask for must not come back at all — the list is
+	// unaskedFields in schema.go, and skills is deliberately NOT on it: both the
+	// schema and the prompt request skills (see buildSystemPrompt's "Other keys"
+	// line). Asserting otherwise failed identically on gpt-4o-mini under a strict
+	// schema and on glm-4.7-flash under plain JSON mode, which is the shape of a
+	// test that outlived its contract rather than of a model that misbehaves.
+	if got.Seniority != "" || got.WorkMode != "" {
+		t.Errorf("model returned dictionary-covered facets: seniority=%q work_mode=%q",
+			got.Seniority, got.WorkMode)
 	}
 }
 

--- a/internal/platform/config/llm.go
+++ b/internal/platform/config/llm.go
@@ -25,6 +25,22 @@ type LLM struct {
 	APIKey  string
 	Model   string
 
+	// StrictSchema says whether the model behind this gateway honours
+	// `response_format: json_schema`. Default true, because that is the stronger
+	// request and every model this ran against until now understood it.
+	//
+	// It is a deployment fact, not a vendor name: the same reason no model is
+	// hard-coded here. Measured on 2026-08-31 against z.ai's glm-4.7-flash, which
+	// answers a strict schema with a fenced array of invented objects and answers
+	// `json_object` — the same prompt, one weaker request — with the exact shape
+	// asked for, three times out of three. Asking for less got more.
+	//
+	// Turning it off does not remove the contract: every caller here already
+	// spells its shape out in the prompt, and every caller validates what comes
+	// back. See internal/ai/enrich/langchain.go's buildSystemPrompt, which lists
+	// every field and every allowed enum value before any schema is attached.
+	StrictSchema bool
+
 	// Langfuse tracing is optional observability. All three empty simply means tracing is off
 	// and the caller runs unchanged; a partial configuration is treated as off, mirroring how a
 	// missing MEILI_MASTER_KEY disables search.
@@ -39,6 +55,7 @@ func LoadLLM() LLM {
 		BaseURL:           os.Getenv("LLM_BASE_URL"),
 		APIKey:            os.Getenv("LLM_API_KEY"),
 		Model:             os.Getenv("LLM_MODEL"),
+		StrictSchema:      envBool("LLM_STRICT_SCHEMA", true),
 		LangfuseBaseURL:   os.Getenv("LANGFUSE_BASE_URL"),
 		LangfusePublicKey: os.Getenv("LANGFUSE_PUBLIC_KEY"),
 		LangfuseSecretKey: os.Getenv("LANGFUSE_SECRET_KEY"),
@@ -77,8 +94,21 @@ func (l LLM) Settings(model string) llm.Settings {
 		BaseURL:           l.BaseURL,
 		APIKey:            l.APIKey,
 		Model:             model,
+		SchemaMode:        schemaMode(l.StrictSchema),
 		LangfuseBaseURL:   l.LangfuseBaseURL,
 		LangfusePublicKey: l.LangfusePublicKey,
 		LangfuseSecretKey: l.LangfuseSecretKey,
 	}
+}
+
+// schemaMode turns the env's yes/no into the library's vocabulary. The two are
+// deliberately different words: the deployment answers "does this gateway honour a
+// strict schema", while the library takes "how should a schema be asked for" — and
+// the second has room for an answer the first does not anticipate.
+func schemaMode(strict bool) llm.SchemaMode {
+	if strict {
+		return llm.SchemaModeStrict
+	}
+
+	return llm.SchemaModeJSONObject
 }

--- a/internal/platform/llm/llm.go
+++ b/internal/platform/llm/llm.go
@@ -49,6 +49,13 @@ type Client struct {
 	baseURL string
 	apiKey  string
 
+	// schemaMode is how this gateway wants a schema asked for. Empty is strict mode,
+	// so a client built without an opinion behaves as every client did before this
+	// existed. Carried on the Client rather than passed per call because it
+	// describes the endpoint, and because it is part of the schema-bound model's
+	// cache key by way of the rendered format.
+	schemaMode SchemaMode
+
 	// dims label each call for the gateway's per-feature spend rollup, one header per
 	// dimension. Set by As and empty otherwise, so a client nobody re-credentialed sends
 	// exactly what it always did.
@@ -91,6 +98,15 @@ func (c *Client) WithTimeout(d time.Duration) *Client {
 // changing the constructors' required parameters, so existing call sites compile
 // unchanged.
 type Option func(*Client)
+
+// WithSchemaMode sets how WithSchema asks for its shape on this endpoint. The zero
+// value (strict mode) is what every caller got before this option existed, so a
+// client built without it is unchanged.
+func WithSchemaMode(mode SchemaMode) Option {
+	return func(c *Client) {
+		c.schemaMode = mode
+	}
+}
 
 // WithTracer attaches a tracer and the source label recorded on each observation.
 // A nil tracer is fine — the client simply performs no tracing.
@@ -136,6 +152,11 @@ type Settings struct {
 	APIKey  string
 	Model   string
 
+	// SchemaMode is how WithSchema asks for its shape. The zero value is strict
+	// mode, so a caller that says nothing keeps sending exactly what it sent
+	// before — the same rule GenOption follows.
+	SchemaMode SchemaMode
+
 	// Langfuse tracing is optional: all three set ⇒ every call is traced under the
 	// caller's source label; otherwise the client runs untraced.
 	LangfuseBaseURL   string
@@ -160,7 +181,7 @@ func NewClient(s Settings, source string) (*Client, func(), error) {
 	if !s.Enabled() {
 		return nil, noop, nil
 	}
-	var opts []Option
+	opts := []Option{WithSchemaMode(s.SchemaMode)}
 	flush := noop
 	if tracer := NewTracer(s.LangfuseBaseURL, s.LangfusePublicKey, s.LangfuseSecretKey); tracer != nil {
 		opts = append(opts, WithTracer(tracer, source))

--- a/internal/platform/llm/schema.go
+++ b/internal/platform/llm/schema.go
@@ -15,6 +15,31 @@ import (
 	"github.com/strelov1/freehire/internal/platform/llmschema"
 )
 
+// SchemaMode selects how a schema is asked for on the wire. It is a property of the
+// GATEWAY, not of any call, which is why it lives on Settings rather than on a
+// GenOption: one deployment's model either honours strict mode or it does not, and a
+// per-call answer would just be the same answer repeated at every call site.
+type SchemaMode string
+
+const (
+	// SchemaModeStrict sends the schema itself, as `response_format: json_schema`
+	// with strict: true. The zero value, and the right request wherever it is
+	// understood.
+	SchemaModeStrict SchemaMode = ""
+
+	// SchemaModeJSONObject sends `response_format: json_object` and no schema, for
+	// a gateway whose model answers a strict schema worse than it answers no
+	// schema at all. Measured on z.ai's glm-4.7-flash: a strict two-field object
+	// came back as a fenced array of invented job postings, while json_object with
+	// the same prompt returned the exact shape three times out of three.
+	//
+	// The shape is still asked for — every caller in this repository spells its
+	// fields out in the system prompt — and still checked, by the caller's own
+	// validator. What is lost is the provider-side guarantee, which the package
+	// documentation already declines to treat as one.
+	SchemaModeJSONObject SchemaMode = "json_object"
+)
+
 // GenOption configures a single JSON generation. Options are variadic so a call site
 // that asks for nothing keeps sending exactly what it sent before.
 type GenOption func(*genConfig)
@@ -114,7 +139,7 @@ func (c *Client) modelFor(cfg genConfig) (llms.Model, error) {
 		return c.model, nil
 	}
 
-	format, err := responseFormat(cfg)
+	format, err := responseFormat(cfg, c.schemaMode)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +170,7 @@ func (c *Client) modelFor(cfg genConfig) (llms.Model, error) {
 }
 
 // responseFormat renders the strict json_schema response format for cfg.
-func responseFormat(cfg genConfig) (json.RawMessage, error) {
+func responseFormat(cfg genConfig, mode SchemaMode) (json.RawMessage, error) {
 	format := map[string]any{
 		"type": "json_schema",
 		"json_schema": map[string]any{
@@ -153,6 +178,9 @@ func responseFormat(cfg genConfig) (json.RawMessage, error) {
 			"strict": true,
 			"schema": cfg.schema,
 		},
+	}
+	if mode == SchemaModeJSONObject {
+		format = map[string]any{"type": "json_object"}
 	}
 
 	raw, err := json.Marshal(format)

--- a/internal/platform/llm/schema_test.go
+++ b/internal/platform/llm/schema_test.go
@@ -152,6 +152,50 @@ func TestGenerateJSON_WithSchemaSendsItStrict(t *testing.T) {
 	}
 }
 
+// The gateway, not the call, decides how a schema is asked for — and on a gateway
+// that answers a strict schema worse than none, WithSchema must degrade to plain JSON
+// mode rather than to nothing. Losing the schema silently would be the same bug this
+// package's fence-stripping exists to catch, one layer earlier.
+func TestGenerateJSON_JSONObjectModeSendsNoSchema(t *testing.T) {
+	proxy := newRecordingProxy(t)
+
+	c, err := New(proxy.srv.URL, "test-key", "test-model", WithSchemaMode(SchemaModeJSONObject))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, err := c.GenerateJSON(context.Background(), "sys", "user",
+		WithSchema("verdict", testSchema(t))); err != nil {
+		t.Fatalf("GenerateJSON: %v", err)
+	}
+
+	format, ok := proxy.lastRequest(t)["response_format"].(map[string]any)
+	if !ok {
+		t.Fatal("request carried no response_format at all")
+	}
+	if format["type"] != "json_object" {
+		t.Errorf("response_format.type = %v, want json_object", format["type"])
+	}
+	if _, ok := format["json_schema"]; ok {
+		t.Error("json_object mode still sent a json_schema")
+	}
+}
+
+// A client built without an opinion is the one every existing caller has.
+func TestGenerateJSON_DefaultModeIsStrict(t *testing.T) {
+	proxy := newRecordingProxy(t)
+
+	if _, err := proxy.client(t).GenerateJSON(context.Background(), "sys", "user",
+		WithSchema("verdict", testSchema(t))); err != nil {
+		t.Fatalf("GenerateJSON: %v", err)
+	}
+
+	format, _ := proxy.lastRequest(t)["response_format"].(map[string]any)
+	if format["type"] != "json_schema" {
+		t.Errorf("response_format.type = %v, want json_schema", format["type"])
+	}
+}
+
 func TestGenerateJSONStream_WithSchemaSendsItToo(t *testing.T) {
 	proxy := newRecordingProxy(t)
 


### PR DESCRIPTION
Every JSON call in this repository asks for `response_format: json_schema` with `strict: true`. That is the right request wherever it is understood — and on z.ai's `glm-4.7-flash` it is not: the same prompt that returns the exact shape under `json_object` returns a fenced array of invented objects under a strict schema. Asking for less gets more, and there was no way to ask for less.

`LLM_STRICT_SCHEMA=false` is that way.

## Why this is needed now

Production's `mid` tier — enrichment, search-intent, the CV features — runs on Gemini, whose free tier meters `GenerateRequestsPerDayPerProjectPerModel` at **20. Per day.** Nineteen keys is 380 requests a day for everything. Enrichment alone exhausted it on 2026-08-31 and dead-lettered 154 postings before it was stopped.

z.ai's free Flash tier allows roughly 1000 requests per day per key — 13 keys, so ~13 000 — but only answers structurally when asked without a strict schema.

## What it does not change

- The zero value on both sides is the old behaviour. `Settings.SchemaMode` defaults to strict, so a caller that says nothing sends exactly what it sent before (`TestGenerateJSON_DefaultModeIsStrict`).
- The contract does not weaken. Every caller spells its fields out in the prompt — `buildSystemPrompt` lists each field and every allowed enum value — and every caller validates what comes back. `internal/platform/llm/AGENTS.md` already says a schema is "a first line, never a proof".
- No provider is named in the library. The deployment answers "does this gateway honour a strict schema"; the library takes "how should a schema be asked for".

## Measured

Same posting, same prompt, the enrichment contract's live test (`-tags=llmlive`):

| model | mode | result |
|---|---|---|
| `glm-4.7-flash` (free) | `json_object` | pass, 53s |
| `gpt-4o-mini` (paid) | strict schema | pass, 2.8s |

The free tier is nineteen times slower and fills the same fields.

## One correction to that test

It asserted that `skills` never comes back — but `skills` is not in `unaskedFields`, and the prompt asks for it outright in the "Other keys" line. So it failed identically on `gpt-4o-mini` under a strict schema. That is an assertion that outlived its contract, not a model misbehaving, and it is now scoped to the two facets the prompt really withholds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable response formatting for AI-powered enrichment.
  * Supports strict schema responses by default, with an optional plain JSON mode for greater compatibility.
* **Bug Fixes**
  * Preserved existing strict-schema behavior when no configuration is provided.
  * Improved enrichment validation across both supported response formats.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->