### PR TITLE
Publish ingest freshness per provider

### DIFF
--- a/cmd/queue-metrics/collect.go
+++ b/cmd/queue-metrics/collect.go
@@ -21,6 +21,7 @@ type metricsQueries interface {
 	SemanticOutboxMetrics(context.Context) (db.SemanticOutboxMetricsRow, error)
 	BoardHealthMetrics(context.Context) (db.BoardHealthMetricsRow, error)
 	NewestOpenJobCreatedAt(context.Context) (pgtype.Timestamptz, error)
+	ProviderIngestFreshness(context.Context) ([]db.ProviderIngestFreshnessRow, error)
 }
 
 // collect runs one measurement pass. Any query failure aborts the pass: a partial
@@ -50,6 +51,22 @@ func collect(ctx context.Context, q metricsQueries) (snapshot, error) {
 		return snapshot{}, err
 	}
 
+	freshness, err := q.ProviderIngestFreshness(ctx)
+	if err != nil {
+		return snapshot{}, fmt.Errorf("provider ingest freshness: %w", err)
+	}
+	providers := make([]providerFreshness, len(freshness))
+	for i, r := range freshness {
+		// An invalid Timestamptz is max() over a provider whose every board has never
+		// succeeded. It stays the zero time here and is dropped by render, because the
+		// alternative — a Unix zero — reads downstream as a provider overdue since 1970.
+		p := providerFreshness{name: r.Provider}
+		if r.LastSuccessAt.Valid {
+			p.lastSuccess = r.LastSuccessAt.Time
+		}
+		providers[i] = p
+	}
+
 	return snapshot{
 		queues: []queueMetrics{
 			{name: "search_outbox", depth: search.Depth, deadLetters: search.DeadLetters, oldestAgeSeconds: search.OldestAgeSeconds},
@@ -60,6 +77,7 @@ func collect(ctx context.Context, q metricsQueries) (snapshot, error) {
 		failingBoards: boards.Failing,
 		cooledBoards:  boards.Cooled,
 		newestJob:     newestJob,
+		providers:     providers,
 	}, nil
 }
 

--- a/cmd/queue-metrics/collect_test.go
+++ b/cmd/queue-metrics/collect_test.go
@@ -20,6 +20,7 @@ type fakeQueries struct {
 	semantic  db.SemanticOutboxMetricsRow
 	boards    db.BoardHealthMetricsRow
 	newest    pgtype.Timestamptz
+	freshness []db.ProviderIngestFreshnessRow
 	newestErr error
 	searchErr error
 }
@@ -44,6 +45,10 @@ func (f fakeQueries) NewestOpenJobCreatedAt(context.Context) (pgtype.Timestamptz
 	return f.newest, f.newestErr
 }
 
+func (f fakeQueries) ProviderIngestFreshness(context.Context) ([]db.ProviderIngestFreshnessRow, error) {
+	return f.freshness, nil
+}
+
 func populatedQueries() fakeQueries {
 	return fakeQueries{
 		search:   db.SearchOutboxMetricsRow{Depth: 3, DeadLetters: 2, OldestAgeSeconds: 21600.5},
@@ -51,6 +56,30 @@ func populatedQueries() fakeQueries {
 		semantic: db.SemanticOutboxMetricsRow{Depth: 0, DeadLetters: 0, OldestAgeSeconds: 0},
 		boards:   db.BoardHealthMetricsRow{Healthy: 74894, Failing: 7002, Cooled: 1882},
 		newest:   pgtype.Timestamptz{Time: time.Unix(1786821346, 0), Valid: true},
+		freshness: []db.ProviderIngestFreshnessRow{
+			{Provider: "greenhouse", LastSuccessAt: pgtype.Timestamptz{Time: time.Unix(1786821000, 0), Valid: true}},
+			{Provider: "gulftalent", LastSuccessAt: pgtype.Timestamptz{}},
+		},
+	}
+}
+
+// A provider whose boards have never succeeded answers with a NULL max(), and that NULL
+// must survive collection as "no measurement" rather than collapsing to the zero instant
+// — render turns the two into an absent sample and a 1970 timestamp respectively, and
+// only one of those is honest.
+func TestCollectKeepsNeverSucceededProviderDistinctFromZero(t *testing.T) {
+	snap, err := collect(context.Background(), populatedQueries())
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if len(snap.providers) != 2 {
+		t.Fatalf("providers = %d, want 2", len(snap.providers))
+	}
+	if got := snap.providers[0]; got.name != "greenhouse" || !got.lastSuccess.Equal(time.Unix(1786821000, 0)) {
+		t.Errorf("first provider = %+v, want greenhouse at 1786821000", got)
+	}
+	if got := snap.providers[1]; got.name != "gulftalent" || !got.lastSuccess.IsZero() {
+		t.Errorf("second provider = %+v, want gulftalent with no measurement", got)
 	}
 }
 

--- a/cmd/queue-metrics/render.go
+++ b/cmd/queue-metrics/render.go
@@ -15,6 +15,14 @@ type queueMetrics struct {
 	oldestAgeSeconds float64
 }
 
+// providerFreshness is when one ingest provider's most recent board crawl succeeded.
+// lastSuccess is the zero time when no board of that provider has ever succeeded, which
+// render publishes as an absent sample rather than as a 1970 timestamp.
+type providerFreshness struct {
+	name        string
+	lastSuccess time.Time
+}
+
 // snapshot is everything one collection pass measured. newestJob is the zero time when
 // the catalogue holds no open job at all, which render treats as "publish nothing"
 // rather than as a 1970 timestamp.
@@ -24,6 +32,7 @@ type snapshot struct {
 	failingBoards int64
 	cooledBoards  int64
 	newestJob     time.Time
+	providers     []providerFreshness
 }
 
 // render turns a snapshot into the Prometheus text exposition format.
@@ -64,6 +73,26 @@ func render(s snapshot) string {
 	if !s.newestJob.IsZero() {
 		writeHeader(&b, "freehire_catalogue_newest_job_timestamp_seconds", "Unix time the newest open job was created.")
 		fmt.Fprintf(&b, "freehire_catalogue_newest_job_timestamp_seconds %d\n", s.newestJob.Unix())
+	}
+
+	// Per-provider freshness: the signal the catalogue-wide gauge above cannot give. That
+	// one stays young while any provider produces, so a provider that stopped is invisible
+	// in it — which is how a 13-day proxy outage went unnoticed until someone looked by
+	// hand. A provider with no measurement is omitted rather than zeroed, and the whole
+	// family is omitted when none has one, on the same reasoning as newestJob.
+	measured := make([]providerFreshness, 0, len(s.providers))
+	for _, p := range s.providers {
+		if !p.lastSuccess.IsZero() {
+			measured = append(measured, p)
+		}
+	}
+	if len(measured) > 0 {
+		writeHeader(&b, "freehire_provider_last_success_timestamp_seconds",
+			"Unix time an ingest provider's most recent board crawl succeeded.")
+		for _, p := range measured {
+			fmt.Fprintf(&b, "freehire_provider_last_success_timestamp_seconds{provider=%q} %d\n",
+				p.name, p.lastSuccess.Unix())
+		}
 	}
 
 	return b.String()

--- a/cmd/queue-metrics/render_test.go
+++ b/cmd/queue-metrics/render_test.go
@@ -162,3 +162,54 @@ func TestRenderGroupsEachFamilyUnderOneHelpAndType(t *testing.T) {
 		}
 	}
 }
+
+// The freehire-ops alert rule binds to this family by name and by the provider label, so
+// the exposition text is pinned the way the other families are: a rename must be a visible
+// edit here, not a silent break of an alert nobody notices until the next outage.
+func TestRenderProviderFreshness(t *testing.T) {
+	s := fullSnapshot()
+	s.providers = []providerFreshness{
+		{name: "greenhouse", lastSuccess: time.Unix(1786821000, 0)},
+		{name: "peopleforce", lastSuccess: time.Unix(1785700000, 0)},
+	}
+	got := render(s)
+	for _, want := range []string{
+		"# HELP freehire_provider_last_success_timestamp_seconds",
+		"# TYPE freehire_provider_last_success_timestamp_seconds gauge",
+		`freehire_provider_last_success_timestamp_seconds{provider="greenhouse"} 1786821000`,
+		`freehire_provider_last_success_timestamp_seconds{provider="peopleforce"} 1785700000`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("exposition missing %q\ngot:\n%s", want, got)
+		}
+	}
+}
+
+// A provider that has never succeeded must be ABSENT, not zero. An alert rule reads a
+// missing series as no-data and a 1970 timestamp as infinitely overdue; only the first is
+// what the measurement actually supports.
+func TestRenderOmitsProviderThatNeverSucceeded(t *testing.T) {
+	s := fullSnapshot()
+	s.providers = []providerFreshness{
+		{name: "greenhouse", lastSuccess: time.Unix(1786821000, 0)},
+		{name: "gulftalent"},
+	}
+	got := render(s)
+	if strings.Contains(got, `provider="gulftalent"`) {
+		t.Errorf("a provider with no successful crawl must publish no sample\ngot:\n%s", got)
+	}
+	if !strings.Contains(got, `provider="greenhouse"`) {
+		t.Error("the provider that did succeed must still publish")
+	}
+}
+
+// Every provider having never succeeded leaves the family with nothing to say; emitting a
+// bare HELP/TYPE pair with no samples would be a valid but pointless exposition, so the
+// family is omitted entirely — the same rule newestJob already follows.
+func TestRenderOmitsEmptyProviderFamily(t *testing.T) {
+	s := fullSnapshot()
+	s.providers = []providerFreshness{{name: "gulftalent"}, {name: "bayt"}}
+	if got := render(s); strings.Contains(got, "freehire_provider_last_success_timestamp_seconds") {
+		t.Errorf("family must be omitted when no provider has a measurement\ngot:\n%s", got)
+	}
+}

--- a/internal/platform/db/metrics.sql.go
+++ b/internal/platform/db/metrics.sql.go
@@ -101,6 +101,51 @@ func (q *Queries) NewestOpenJobCreatedAt(ctx context.Context) (pgtype.Timestampt
 	return created_at, err
 }
 
+const providerIngestFreshness = `-- name: ProviderIngestFreshness :many
+SELECT provider, max(last_success_at)::timestamptz AS last_success_at
+FROM board_health
+GROUP BY provider
+ORDER BY provider
+`
+
+type ProviderIngestFreshnessRow struct {
+	Provider      string             `json:"provider"`
+	LastSuccessAt pgtype.Timestamptz `json:"last_success_at"`
+}
+
+// The most recent successful crawl per ingest provider, for the gauge that makes a
+// provider which has stopped producing data visible as itself.
+//
+// Reads board_health rather than the jobs table on purpose. The catalogue-side form of
+// the same question — max(last_seen_at) grouped by source over open jobs — measured 41s
+// and 2.1M buffer reads on prod (2026-09-01), a parallel sequential scan of 8M rows. This
+// file's header commits every query in it to never being why ingest waits, and the host
+// is disk-bound, so a once-a-minute scan of that size is exactly the thing it forbids.
+// The same measurement here reads 97k rows in 54ms.
+//
+// max() over a nullable column yields NULL for a provider whose every board has never
+// succeeded; that NULL is carried through and rendered as an ABSENT sample, never as a
+// zero — see cmd/queue-metrics/render.go.
+func (q *Queries) ProviderIngestFreshness(ctx context.Context) ([]ProviderIngestFreshnessRow, error) {
+	rows, err := q.db.Query(ctx, providerIngestFreshness)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ProviderIngestFreshnessRow{}
+	for rows.Next() {
+		var i ProviderIngestFreshnessRow
+		if err := rows.Scan(&i.Provider, &i.LastSuccessAt); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const searchOutboxMetrics = `-- name: SearchOutboxMetrics :one
 
 SELECT

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -2743,6 +2743,20 @@ type Querier interface {
 	// coalesced/cast to bigint so it reads as a plain int64 (an all-failing provider
 	// yields 0, not NULL).
 	ProviderHealthRollup(ctx context.Context) ([]ProviderHealthRollupRow, error)
+	// The most recent successful crawl per ingest provider, for the gauge that makes a
+	// provider which has stopped producing data visible as itself.
+	//
+	// Reads board_health rather than the jobs table on purpose. The catalogue-side form of
+	// the same question — max(last_seen_at) grouped by source over open jobs — measured 41s
+	// and 2.1M buffer reads on prod (2026-09-01), a parallel sequential scan of 8M rows. This
+	// file's header commits every query in it to never being why ingest waits, and the host
+	// is disk-bound, so a once-a-minute scan of that size is exactly the thing it forbids.
+	// The same measurement here reads 97k rows in 54ms.
+	//
+	// max() over a nullable column yields NULL for a provider whose every board has never
+	// succeeded; that NULL is carried through and rendered as an ABSENT sample, never as a
+	// zero — see cmd/queue-metrics/render.go.
+	ProviderIngestFreshness(ctx context.Context) ([]ProviderIngestFreshnessRow, error)
 	// One keyset page of rows the prune rule evaluates, ordered by id.
 	//
 	// Closed rows are included deliberately. Once ingest rejects a board's non-technical

--- a/internal/platform/db/queries/metrics.sql
+++ b/internal/platform/db/queries/metrics.sql
@@ -85,3 +85,22 @@ FROM jobs
 WHERE closed_at IS NULL
 ORDER BY created_at DESC, id DESC
 LIMIT 1;
+
+-- name: ProviderIngestFreshness :many
+-- The most recent successful crawl per ingest provider, for the gauge that makes a
+-- provider which has stopped producing data visible as itself.
+--
+-- Reads board_health rather than the jobs table on purpose. The catalogue-side form of
+-- the same question — max(last_seen_at) grouped by source over open jobs — measured 41s
+-- and 2.1M buffer reads on prod (2026-09-01), a parallel sequential scan of 8M rows. This
+-- file's header commits every query in it to never being why ingest waits, and the host
+-- is disk-bound, so a once-a-minute scan of that size is exactly the thing it forbids.
+-- The same measurement here reads 97k rows in 54ms.
+--
+-- max() over a nullable column yields NULL for a provider whose every board has never
+-- succeeded; that NULL is carried through and rendered as an ABSENT sample, never as a
+-- zero — see cmd/queue-metrics/render.go.
+SELECT provider, max(last_success_at)::timestamptz AS last_success_at
+FROM board_health
+GROUP BY provider
+ORDER BY provider;

--- a/openspec/changes/per-provider-freshness-metric/proposal.md
+++ b/openspec/changes/per-provider-freshness-metric/proposal.md
@@ -1,0 +1,79 @@
+# Publish per-provider ingest freshness
+
+## Why
+
+The residential proxy's credentials stopped working on 2026-08-18. Every provider
+behind it — eightfold, hh, djinni, wantedkr, vagas, peopleforce, wantapply,
+cleverstaff, geekjob, 2gis — returned `407 Proxy Authentication Required` on every
+request from that moment. It was found by hand on 2026-08-31, **thirteen days later**,
+while looking at something else. ~54,000 open postings had gone unverified the whole
+time.
+
+Nothing alerted, and the reason is structural: none of the three signals the fleet
+publishes measures data arriving per provider.
+
+| Published today | Why it stayed quiet |
+|---|---|
+| `freehire_catalogue_newest_job_timestamp_seconds` | Catalogue-wide. Greenhouse and Workday kept adding postings every minute, so the gauge never aged. |
+| `freehire_boards_total{state=...}` | Fleet-wide. A provider going 0% → 100% failing moves 92 boards out of 97,221 — inside the normal 4.9% failing background. |
+| `freehire_worker_last_run_*` | Measures the *process*, not the *data*. The peopleforce run on 2026-08-31 skipped all 92 boards as cooled, reported `failed=0`, and exited 0 — indistinguishable from a run that ingested everything. |
+
+Querying `board_health` for the missing signal takes one line and exposes more than the
+proxy outage:
+
+| Provider | Last successful crawl | Silent for |
+|---|---|---:|
+| `gulftalent`, `bayt` | never | — |
+| `recruitingsolutions` | 2026-07-14 | **49 days** |
+| `careerspage` | 2026-07-18 | **44 days** |
+| `alfabank` | 2026-07-29 | **34 days** |
+| `functionalworks` | 2026-08-12 | 19 days |
+| the proxied cluster | 2026-08-18 | 13 days |
+
+Six providers beyond the proxy outage have been dead for weeks, two have never
+succeeded at all, and none of it was visible.
+
+## What Changes
+
+- `cmd/queue-metrics` publishes one new family:
+  `freehire_provider_last_success_timestamp_seconds{provider="<name>"}` — the most recent
+  successful crawl across all of that provider's boards.
+- A provider whose every board has never succeeded publishes **no sample** rather than a
+  zero, matching how `freehire_catalogue_newest_job_timestamp_seconds` already treats an
+  empty catalogue: an absent series is what the consuming alert rule reads as "no data",
+  and 1970 would read as "infinitely overdue" — the same claim made much more loudly than
+  the evidence supports.
+- The alert rule itself lives in `freehire-ops` and is out of this repository's reach;
+  the proposal names it so shipping the gauge is not mistaken for shipping the alert.
+
+## Impact
+
+- Affected specs: `ingest-board-health` (a new requirement beside "Unhealthy boards are
+  visible without grepping logs")
+- Affected code: `internal/platform/db/queries/metrics.sql` (one query, then `make sqlc`),
+  `cmd/queue-metrics/collect.go`, `cmd/queue-metrics/render.go`
+- No migration. `board_health.last_success_at` already exists and is already written on
+  every successful crawl.
+
+## The query this deliberately does NOT use
+
+The obvious source is the jobs table — `SELECT source, max(last_seen_at) FROM jobs WHERE
+closed_at IS NULL GROUP BY source`. Measured on prod it is a **41-second** parallel
+sequential scan reading 2.1M buffers, and `metrics.sql`'s own header states that every
+query in it "runs once a minute alongside ingest, search-drain, and reindex, and must
+never be the reason one of them waits". On a host already documented as disk-bound, that
+query once a minute would evict the buffer cache the rest of the pipeline depends on.
+
+The same measurement over `board_health` — 97,221 rows against the jobs table's 8M —
+runs in **54ms**, and is the better signal anyway: it reports whether the crawl
+succeeded, not whether a posting happened to change.
+
+## Out of scope
+
+- The alert rule and dashboard panel (`freehire-ops`).
+- Fixing any of the providers this reveals. `gulftalent` and `bayt` have never succeeded;
+  `recruitingsolutions`, `careerspage`, `alfabank` and `functionalworks` have been dead
+  for weeks. Each is its own investigation — this change makes them visible.
+- Reporting ingest failures to Sentry. A board failing is ordinary (boards close every
+  day), so per-failure reporting would be noise; the signal that matters is duration,
+  which is a gauge and an alert rule, not an exception.

--- a/openspec/changes/per-provider-freshness-metric/specs/ingest-board-health/spec.md
+++ b/openspec/changes/per-provider-freshness-metric/specs/ingest-board-health/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Ingest freshness is published per provider
+
+The metrics worker SHALL publish, for each ingest provider, the time that provider's most
+recent **successful** board crawl completed, labelled by provider — so a provider that has
+stopped producing data is visible as itself rather than averaged into the fleet.
+
+The measurement SHALL be taken from the board-health state, not from the catalogue: the
+question is whether the crawl succeeded, not whether a posting happened to change, and the
+catalogue-side query is a full scan of a table two orders of magnitude larger which the
+metrics worker must not run on its once-a-minute schedule.
+
+A provider whose boards have **never** succeeded SHALL publish no sample for that
+provider rather than a zero timestamp. An absent series is what a consuming alert rule
+reads as no-data; a zero would be read as a provider infinitely overdue, which states far
+more than the evidence supports.
+
+The samples SHALL be emitted in a stable order, so a scrape does not differ from the last
+one purely by ordering.
+
+This requirement covers publishing the measurement. The alert rule that consumes it lives
+outside this repository and is not satisfied by this requirement alone.
+
+#### Scenario: A healthy provider publishes its last success
+
+- **WHEN** a provider has at least one board whose last crawl succeeded
+- **THEN** the exposition carries one sample for that provider, labelled with its name,
+  holding the most recent success time across all of its boards
+
+#### Scenario: A provider dead for weeks is visible as itself
+
+- **WHEN** every board of one provider has been failing for weeks while the rest of the
+  fleet is healthy
+- **THEN** that provider's sample carries its weeks-old timestamp, unaffected by the other
+  providers' freshness
+
+#### Scenario: A provider that never succeeded publishes nothing
+
+- **WHEN** no board of a provider has ever recorded a successful crawl
+- **THEN** the exposition carries no sample for that provider, and no zero timestamp
+
+#### Scenario: The exposition order is stable
+
+- **WHEN** two collection passes measure the same providers
+- **THEN** the samples appear in the same order in both expositions

--- a/openspec/changes/per-provider-freshness-metric/tasks.md
+++ b/openspec/changes/per-provider-freshness-metric/tasks.md
@@ -1,0 +1,37 @@
+## 1. The query
+
+- [ ] 1.1 Add `ProviderIngestFreshness :many` to
+  `internal/platform/db/queries/metrics.sql` — `provider, max(last_success_at)` grouped by
+  provider — with a comment stating why it reads `board_health` and not `jobs` (41s vs
+  54ms, measured on prod 2026-09-01).
+- [ ] 1.2 Run `make sqlc` and commit the regenerated `internal/platform/db`.
+
+## 2. Collection
+
+- [ ] 2.1 Write the failing test in `cmd/queue-metrics/collect_test.go`: the fake returns
+  two providers, one with a timestamp and one with NULL, and `collect` carries both into
+  the snapshot with the NULL distinguishable from a zero instant.
+- [ ] 2.2 Add the method to the `metricsQueries` interface, the field to `snapshot`, and
+  the call to `collect` — failing the whole pass on error, as every other query there does.
+
+## 3. Rendering
+
+- [ ] 3.1 Write the failing test in `cmd/queue-metrics/render_test.go` pinning the exact
+  exposition text for the new family, including the `provider` label — the existing tests
+  pin text because the metric names are a cross-repo contract with `freehire-ops`.
+- [ ] 3.2 Write the failing test that a provider with no successful crawl emits **no
+  sample**, not a zero.
+- [ ] 3.3 Write the failing test that providers are emitted in a stable order, so the
+  exposition does not churn between scrapes.
+- [ ] 3.4 Implement the family in `render`.
+
+## 4. Verify
+
+- [ ] 4.1 `gofmt -l .` prints nothing; `go vet ./...`; `go test ./...`;
+  `go vet -tags=integration ./...`.
+- [ ] 4.2 `make sqlc` leaves no diff (the CI job and pre-commit hook both check this).
+- [ ] 4.3 Run `cmd/queue-metrics` against prod read-only with `PROM_TEXTFILE_DIR` set to a
+  temp directory and confirm the emitted family lists the providers and that the known-dead
+  ones (`recruitingsolutions`, `careerspage`, `alfabank`) carry timestamps weeks old.
+- [ ] 4.4 State in the PR that the alert rule is a `freehire-ops` change and is not
+  included, so the gauge is not mistaken for the alert.


### PR DESCRIPTION
Adds `freehire_provider_last_success_timestamp_seconds{provider="…"}`.

## Why

The residential proxy's credentials stopped working on **2026-08-18**. Every provider
behind it returned `407` on every request. It was found by hand **thirteen days later**,
while looking at something else, with ~54,000 postings unverified the whole time.

Nothing alerted, and the reason is structural — none of the three published signals
measures data arriving *per provider*:

| Published today | Why it stayed quiet |
|---|---|
| `freehire_catalogue_newest_job_timestamp_seconds` | Catalogue-wide. Greenhouse and Workday kept it young every minute. |
| `freehire_boards_total{state=…}` | Fleet-wide. 92 boards going dead hid inside a 4.9% failing background. |
| `freehire_worker_last_run_*` | Measures the process. The peopleforce run skipped all 92 boards as cooled, reported `failed=0`, exited 0. |

## What it already shows

Run read-only against prod, the new family reports more than the proxy outage:

| Provider | Silent for |
|---|---:|
| `recruitingsolutions` | **48.7 days** |
| `careerspage` | **44.2 days** |
| `alfabank` | **33.6 days** |
| `functionalworks` | 19.4 days |
| `gulftalent`, `bayt` | no success on record — **absent**, not zero |

On `gulftalent` the absence needs reading carefully, and it is the metric's one subtlety:
`board_health.last_success_at` was added by migration `0006` on 2026-07-09, and
gulftalent's postings were last seen 2026-07-07 — two days earlier. So the NULL means
"no success since the column existed", not "never worked". It has 19,828 open postings
frozen since 2026-07-07. For a 24h alert the distinction does not matter; for reading the
gauge by hand it does.

## Why `board_health` and not `jobs`

The obvious source is `SELECT source, max(last_seen_at) FROM jobs WHERE closed_at IS NULL
GROUP BY source`. Measured on prod: **41 seconds**, a parallel sequential scan reading
2.1M buffers over 8M rows. `metrics.sql`'s own header commits every query in it to never
being why ingest waits, and the host is documented as disk-bound.

The same measurement over `board_health` reads 97k rows in **54ms** — and is the better
signal anyway: it reports whether the crawl succeeded, not whether a posting happened to
change.

## Absent, not zero

A provider with no success on record publishes **no sample**. An absent series is what an
alert rule reads as no-data; a Unix zero reads as a provider infinitely overdue. Same rule
`freehire_catalogue_newest_job_timestamp_seconds` already follows for an empty catalogue.
Pinned by `TestRenderOmitsProviderThatNeverSucceeded`.

## Verification

- TDD throughout; the exposition text is pinned because the metric name and label are a
  cross-repo contract with `freehire-ops`.
- `go test ./...`, `go vet`, `gofmt` clean; `make sqlc` leaves no drift.
- Ran end-to-end against prod read-only: 228 provider samples, dead providers carrying
  weeks-old timestamps, `gulftalent` and `bayt` correctly absent.

## Not included

**The alert rule.** It lives in `freehire-ops` and cannot be compiled against this repo.
Shipping this gauge is not shipping the alert — the ops-side rule
(`time() - freehire_provider_last_success_timestamp_seconds > 86400`) is the other half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)