### PR TITLE
Ask a control which form owns it, rather than the tree around it

### DIFF
--- a/extension/lib/form.ts
+++ b/extension/lib/form.ts
@@ -170,14 +170,24 @@ export function extractUploads(doc: Document): Upload[] {
 
 /**
  * The index of the form a control answers within, or -1 when it sits outside
- * one. Matched with `isSameNode` rather than `indexOf`, because that is the
- * identity check that holds however the two references were obtained — the
- * reference `closest` hands back need not be the very object the query list
- * holds.
+ * one.
+ *
+ * Asked of the control itself rather than of the tree around it. `.form` is the
+ * form owner HTML defines, and a control carrying `form="signup"` answers that
+ * form from wherever it is rendered — a distinction `closest('form')` cannot
+ * make. (happy-dom does not implement the attribute, so no test here covers
+ * that case; browsers do, which is where the extension runs.)
+ *
+ * It is also the only identity check happy-dom agrees with itself about across
+ * versions. Under 20.11.6 `closest` hands back a different object than the
+ * query list holds, so `===` fails and `isSameNode` is what matches; under
+ * 20.11.13 that reversed — `===` matches and `isSameNode` returns false for a
+ * node against itself. `.form` returns the very object `querySelectorAll`
+ * collected under both, so `indexOf` is enough.
  */
-function formIndex(el: Element, forms: HTMLFormElement[]): number {
-  const owner = el.closest('form');
-  return owner ? forms.findIndex((f) => f.isSameNode(owner)) : -1;
+function formIndex(el: Fillable, forms: HTMLFormElement[]): number {
+  const owner = el.form;
+  return owner ? forms.indexOf(owner) : -1;
 }
 
 function describeQuestion({ label, controls }: Question, index: number, forms: HTMLFormElement[]): FormField {


### PR DESCRIPTION
The extension files every field and every resume upload under a form index. That index came from `closest('form')` matched against the query list with `isSameNode` — and both halves rested on a happy-dom detail rather than on the DOM.

Under happy-dom 20.11.6, `closest` hands back a different object than `querySelectorAll` collected, so `===` fails and `isSameNode` is what matches. Under 20.11.13 that reversed: `===` matches and `isSameNode` returns false for a node compared against itself. Every field then silently moved outside its own form. That is the failure #2249 surfaced — two tests, both about which form owns what.

`.form` is the form owner HTML defines and the one answer both versions agree on. It is also the more correct question to ask: a control carrying `form="signup"` answers that form from wherever it is rendered, which `closest` cannot see. happy-dom does not implement the attribute, so no test here covers that case — browsers do, and that is where the extension runs.

All three callers already pass a form control, so the parameter narrows from `Element` to `Fillable` with no other change.

Verified locally: 274 extension tests pass on **both** happy-dom 20.11.6 and 20.11.13; `svelte-check` 0 errors, `lint` 0 errors. This unblocks #2249.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form control detection, including controls associated with a form through the `form` attribute.
  * Increased compatibility across supported browser-like environments when identifying a control’s owning form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->