### PR TITLE
Make a provider that never succeeded visible, and record why seven are dead

### DIFF
--- a/cmd/queue-metrics/collect.go
+++ b/cmd/queue-metrics/collect.go
@@ -21,7 +21,7 @@ type metricsQueries interface {
 	SemanticOutboxMetrics(context.Context) (db.SemanticOutboxMetricsRow, error)
 	BoardHealthMetrics(context.Context) (db.BoardHealthMetricsRow, error)
 	NewestOpenJobCreatedAt(context.Context) (pgtype.Timestamptz, error)
-	ProviderIngestFreshness(context.Context) ([]db.ProviderIngestFreshnessRow, error)
+	ProviderIngestHealth(context.Context) ([]db.ProviderIngestHealthRow, error)
 }
 
 // collect runs one measurement pass. Any query failure aborts the pass: a partial
@@ -51,16 +51,22 @@ func collect(ctx context.Context, q metricsQueries) (snapshot, error) {
 		return snapshot{}, err
 	}
 
-	freshness, err := q.ProviderIngestFreshness(ctx)
+	health, err := q.ProviderIngestHealth(ctx)
 	if err != nil {
-		return snapshot{}, fmt.Errorf("provider ingest freshness: %w", err)
+		return snapshot{}, fmt.Errorf("provider ingest health: %w", err)
 	}
-	providers := make([]providerFreshness, len(freshness))
-	for i, r := range freshness {
+	providers := make([]providerHealth, len(health))
+	for i, r := range health {
 		// An invalid Timestamptz is max() over a provider whose every board has never
 		// succeeded. It stays the zero time here and is dropped by render, because the
 		// alternative — a Unix zero — reads downstream as a provider overdue since 1970.
-		p := providerFreshness{name: r.Provider}
+		// The board counts below carry that provider instead: they are always present.
+		p := providerHealth{
+			name:    r.Provider,
+			cooled:  r.Cooled,
+			failing: r.Failing,
+			healthy: r.Healthy,
+		}
 		if r.LastSuccessAt.Valid {
 			p.lastSuccess = r.LastSuccessAt.Time
 		}

--- a/cmd/queue-metrics/collect_test.go
+++ b/cmd/queue-metrics/collect_test.go
@@ -20,7 +20,7 @@ type fakeQueries struct {
 	semantic  db.SemanticOutboxMetricsRow
 	boards    db.BoardHealthMetricsRow
 	newest    pgtype.Timestamptz
-	freshness []db.ProviderIngestFreshnessRow
+	health    []db.ProviderIngestHealthRow
 	newestErr error
 	searchErr error
 }
@@ -45,8 +45,8 @@ func (f fakeQueries) NewestOpenJobCreatedAt(context.Context) (pgtype.Timestamptz
 	return f.newest, f.newestErr
 }
 
-func (f fakeQueries) ProviderIngestFreshness(context.Context) ([]db.ProviderIngestFreshnessRow, error) {
-	return f.freshness, nil
+func (f fakeQueries) ProviderIngestHealth(context.Context) ([]db.ProviderIngestHealthRow, error) {
+	return f.health, nil
 }
 
 func populatedQueries() fakeQueries {
@@ -56,9 +56,15 @@ func populatedQueries() fakeQueries {
 		semantic: db.SemanticOutboxMetricsRow{Depth: 0, DeadLetters: 0, OldestAgeSeconds: 0},
 		boards:   db.BoardHealthMetricsRow{Healthy: 74894, Failing: 7002, Cooled: 1882},
 		newest:   pgtype.Timestamptz{Time: time.Unix(1786821346, 0), Valid: true},
-		freshness: []db.ProviderIngestFreshnessRow{
-			{Provider: "greenhouse", LastSuccessAt: pgtype.Timestamptz{Time: time.Unix(1786821000, 0), Valid: true}},
-			{Provider: "gulftalent", LastSuccessAt: pgtype.Timestamptz{}},
+		health: []db.ProviderIngestHealthRow{
+			{
+				Provider:      "greenhouse",
+				LastSuccessAt: pgtype.Timestamptz{Time: time.Unix(1786821000, 0), Valid: true},
+				Healthy:       9312, Failing: 604, Cooled: 71,
+			},
+			// The shape that started this: no success ever, so no timestamp — and one
+			// failing board, which is the only thing left that can name it.
+			{Provider: "gulftalent", LastSuccessAt: pgtype.Timestamptz{}, Failing: 1},
 		},
 	}
 }
@@ -80,6 +86,15 @@ func TestCollectKeepsNeverSucceededProviderDistinctFromZero(t *testing.T) {
 	}
 	if got := snap.providers[1]; got.name != "gulftalent" || !got.lastSuccess.IsZero() {
 		t.Errorf("second provider = %+v, want gulftalent with no measurement", got)
+	}
+	// The board counts are what that provider is left with once the timestamp drops out,
+	// so they must arrive alongside the NULL rather than be lost with it.
+	if got := snap.providers[1]; got.failing != 1 || got.healthy != 0 || got.cooled != 0 {
+		t.Errorf("gulftalent boards = %d healthy/%d failing/%d cooled, want 0/1/0",
+			got.healthy, got.failing, got.cooled)
+	}
+	if got := snap.providers[0]; got.healthy != 9312 || got.failing != 604 || got.cooled != 71 {
+		t.Errorf("greenhouse boards = %d/%d/%d, want 9312/604/71", got.healthy, got.failing, got.cooled)
 	}
 }
 

--- a/cmd/queue-metrics/render.go
+++ b/cmd/queue-metrics/render.go
@@ -15,12 +15,19 @@ type queueMetrics struct {
 	oldestAgeSeconds float64
 }
 
-// providerFreshness is when one ingest provider's most recent board crawl succeeded.
+// providerHealth is one ingest provider's state: when its most recent board crawl
+// succeeded, and how its boards currently split across the three health states.
+//
 // lastSuccess is the zero time when no board of that provider has ever succeeded, which
-// render publishes as an absent sample rather than as a 1970 timestamp.
-type providerFreshness struct {
+// render publishes as an absent sample rather than as a 1970 timestamp. The board counts
+// carry the signal that absence throws away — they exist for every provider, so a provider
+// that has never succeeded is still measurable as one with no healthy boards.
+type providerHealth struct {
 	name        string
 	lastSuccess time.Time
+	cooled      int64
+	failing     int64
+	healthy     int64
 }
 
 // snapshot is everything one collection pass measured. newestJob is the zero time when
@@ -32,7 +39,7 @@ type snapshot struct {
 	failingBoards int64
 	cooledBoards  int64
 	newestJob     time.Time
-	providers     []providerFreshness
+	providers     []providerHealth
 }
 
 // render turns a snapshot into the Prometheus text exposition format.
@@ -80,7 +87,7 @@ func render(s snapshot) string {
 	// in it — which is how a 13-day proxy outage went unnoticed until someone looked by
 	// hand. A provider with no measurement is omitted rather than zeroed, and the whole
 	// family is omitted when none has one, on the same reasoning as newestJob.
-	measured := make([]providerFreshness, 0, len(s.providers))
+	measured := make([]providerHealth, 0, len(s.providers))
 	for _, p := range s.providers {
 		if !p.lastSuccess.IsZero() {
 			measured = append(measured, p)
@@ -92,6 +99,34 @@ func render(s snapshot) string {
 		for _, p := range measured {
 			fmt.Fprintf(&b, "freehire_provider_last_success_timestamp_seconds{provider=%q} %d\n",
 				p.name, p.lastSuccess.Unix())
+		}
+	}
+
+	// Per-provider board states: the companion the timestamp above needs, because omitting
+	// the never-succeeded case is exactly what hid gulftalent. It sat at 19,828 postings
+	// unrefreshed since 2026-07-07 with its systemd timer disabled — no crawl, so no
+	// success, so no timestamp sample, so nothing for an alert to be late about. These
+	// counts exist for every provider board_health knows, so `healthy == 0` names it.
+	//
+	// Published as raw counts under one state label rather than as a baked-in "is this
+	// provider down" boolean: the fleet runs a few percent failing boards as background, so
+	// what separates a broken provider from a normal one is the RATIO, and which ratio
+	// deserves a page belongs in the alert rule, not here. Same three mutually exclusive
+	// states as freehire_boards_total, so summing these by state reproduces it.
+	if len(s.providers) > 0 {
+		writeHeader(&b, "freehire_provider_boards", "Ingest boards by health state, per provider.")
+		for _, p := range s.providers {
+			for _, state := range []struct {
+				name  string
+				count int64
+			}{
+				{"healthy", p.healthy},
+				{"failing", p.failing},
+				{"cooled", p.cooled},
+			} {
+				fmt.Fprintf(&b, "freehire_provider_boards{provider=%q,state=%q} %d\n",
+					p.name, state.name, state.count)
+			}
 		}
 	}
 

--- a/cmd/queue-metrics/render_test.go
+++ b/cmd/queue-metrics/render_test.go
@@ -168,9 +168,9 @@ func TestRenderGroupsEachFamilyUnderOneHelpAndType(t *testing.T) {
 // edit here, not a silent break of an alert nobody notices until the next outage.
 func TestRenderProviderFreshness(t *testing.T) {
 	s := fullSnapshot()
-	s.providers = []providerFreshness{
-		{name: "greenhouse", lastSuccess: time.Unix(1786821000, 0)},
-		{name: "peopleforce", lastSuccess: time.Unix(1785700000, 0)},
+	s.providers = []providerHealth{
+		{name: "greenhouse", lastSuccess: time.Unix(1786821000, 0), healthy: 4},
+		{name: "peopleforce", lastSuccess: time.Unix(1785700000, 0), healthy: 2},
 	}
 	got := render(s)
 	for _, want := range []string{
@@ -185,31 +185,82 @@ func TestRenderProviderFreshness(t *testing.T) {
 	}
 }
 
-// A provider that has never succeeded must be ABSENT, not zero. An alert rule reads a
-// missing series as no-data and a 1970 timestamp as infinitely overdue; only the first is
-// what the measurement actually supports.
-func TestRenderOmitsProviderThatNeverSucceeded(t *testing.T) {
+// A provider that has never succeeded must be ABSENT from the TIMESTAMP family, not zero.
+// An alert rule reads a missing series as no-data and a 1970 timestamp as infinitely
+// overdue; only the first is what the measurement actually supports.
+func TestRenderOmitsProviderThatNeverSucceededFromTimestamp(t *testing.T) {
 	s := fullSnapshot()
-	s.providers = []providerFreshness{
-		{name: "greenhouse", lastSuccess: time.Unix(1786821000, 0)},
-		{name: "gulftalent"},
+	s.providers = []providerHealth{
+		{name: "greenhouse", lastSuccess: time.Unix(1786821000, 0), healthy: 4},
+		{name: "gulftalent", failing: 1},
 	}
 	got := render(s)
-	if strings.Contains(got, `provider="gulftalent"`) {
-		t.Errorf("a provider with no successful crawl must publish no sample\ngot:\n%s", got)
+	if strings.Contains(got, `freehire_provider_last_success_timestamp_seconds{provider="gulftalent"}`) {
+		t.Errorf("a provider with no successful crawl must publish no timestamp sample\ngot:\n%s", got)
 	}
-	if !strings.Contains(got, `provider="greenhouse"`) {
-		t.Error("the provider that did succeed must still publish")
+	if !strings.Contains(got, `freehire_provider_last_success_timestamp_seconds{provider="greenhouse"}`) {
+		t.Error("the provider that did succeed must still publish a timestamp")
 	}
 }
 
-// Every provider having never succeeded leaves the family with nothing to say; emitting a
-// bare HELP/TYPE pair with no samples would be a valid but pointless exposition, so the
-// family is omitted entirely — the same rule newestJob already follows.
-func TestRenderOmitsEmptyProviderFamily(t *testing.T) {
+// Every provider having never succeeded leaves the TIMESTAMP family with nothing to say;
+// emitting a bare HELP/TYPE pair with no samples would be a valid but pointless exposition,
+// so that family is omitted entirely — the same rule newestJob already follows.
+func TestRenderOmitsEmptyProviderTimestampFamily(t *testing.T) {
 	s := fullSnapshot()
-	s.providers = []providerFreshness{{name: "gulftalent"}, {name: "bayt"}}
+	s.providers = []providerHealth{{name: "gulftalent", failing: 1}, {name: "bayt", cooled: 8}}
 	if got := render(s); strings.Contains(got, "freehire_provider_last_success_timestamp_seconds") {
 		t.Errorf("family must be omitted when no provider has a measurement\ngot:\n%s", got)
+	}
+}
+
+// The board-state family is the reason a never-succeeded provider is no longer invisible,
+// so the case the timestamp family drops is the case this one MUST keep. gulftalent held
+// 19,828 postings unrefreshed since 2026-07-07 with its timer disabled: no crawl, no
+// success, no timestamp — and nothing else named it.
+//
+// Like the timestamp family, the name and both labels are a freehire-ops contract.
+func TestRenderProviderBoardsCoversNeverSucceeded(t *testing.T) {
+	s := fullSnapshot()
+	s.providers = []providerHealth{
+		{name: "greenhouse", lastSuccess: time.Unix(1786821000, 0), healthy: 4, failing: 1},
+		{name: "gulftalent", failing: 1},
+	}
+	got := render(s)
+	for _, want := range []string{
+		"# HELP freehire_provider_boards",
+		"# TYPE freehire_provider_boards gauge",
+		`freehire_provider_boards{provider="greenhouse",state="healthy"} 4`,
+		`freehire_provider_boards{provider="greenhouse",state="failing"} 1`,
+		`freehire_provider_boards{provider="greenhouse",state="cooled"} 0`,
+		`freehire_provider_boards{provider="gulftalent",state="healthy"} 0`,
+		`freehire_provider_boards{provider="gulftalent",state="failing"} 1`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("exposition missing %q\ngot:\n%s", want, got)
+		}
+	}
+}
+
+// Every sample of a family must follow ONE HELP/TYPE pair, and this family emits three
+// samples per provider — so a loop nested the other way round would interleave the states
+// across providers and still look right sample-by-sample while being an invalid exposition.
+func TestRenderProviderBoardsIsOneWellFormedFamily(t *testing.T) {
+	s := fullSnapshot()
+	s.providers = []providerHealth{
+		{name: "greenhouse", healthy: 4, failing: 1, cooled: 2},
+		{name: "gulftalent", failing: 1},
+	}
+	got := render(s)
+	if n := strings.Count(got, "# TYPE freehire_provider_boards gauge"); n != 1 {
+		t.Errorf("family has %d TYPE lines, want exactly 1", n)
+	}
+	if n := strings.Count(got, "freehire_provider_boards{"); n != len(s.providers)*3 {
+		t.Errorf("family emitted %d samples, want %d (three states per provider)", n, len(s.providers)*3)
+	}
+	header := strings.Index(got, "# HELP freehire_provider_boards ")
+	first := strings.Index(got, "freehire_provider_boards{")
+	if header < 0 || first < header {
+		t.Errorf("samples must follow the HELP line\ngot:\n%s", got)
 	}
 }

--- a/internal/dict/normalize/legal_form_rule_test.go
+++ b/internal/dict/normalize/legal_form_rule_test.go
@@ -51,8 +51,17 @@ func TestOnlyOneLegalFormListExists(t *testing.T) {
 			return err
 		}
 		if d.IsDir() {
+			name := d.Name()
+			// A dot- or underscore-prefixed directory is not part of this module: the go
+			// toolchain never descends into one, so `./...` cannot compile what lives there.
+			// This walk is a filesystem walk, not a package walk, and without the same rule it
+			// reads every git worktree checked out INSIDE the repo (.worktrees, .claude/worktrees)
+			// as a second copy of company.go — one violation per worktree, none of them real.
+			if path != root && (strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_")) {
+				return fs.SkipDir
+			}
 			// Vendored and generated trees are not ours to police.
-			if name := d.Name(); name == ".git" || name == "node_modules" || name == "web" {
+			if name == "node_modules" || name == "web" {
 				return fs.SkipDir
 			}
 			return nil

--- a/internal/ingest/sources/proxy.go
+++ b/internal/ingest/sources/proxy.go
@@ -174,9 +174,16 @@ func ApplyProxyEgress(registry map[string]Source) error {
 // direct datacenter IP even with a correct Chrome TLS fingerprint, but serves that same
 // fingerprint through the residential proxy — so they need both, unlike proxiedProviders
 // (proxy only) and the direct fingerprint providers (fingerprint only). gulftalent is
-// spike-verified: via the same proxy, curl's JA3 403s while the Chrome JA3 is 200. bayt is
-// deliberately absent — it sits behind a Cloudflare JS challenge that no fingerprint or IP
-// passes.
+// spike-verified and re-verified from prod on 2026-09-01: via the same proxy, curl's JA3
+// 403s while the Chrome JA3 is served the sitemap index.
+//
+// bayt is absent, but not because it is unpassable. That was the earlier reading and it is
+// wrong: measured 2026-09-01 with this same transport, bayt's UAE listing returns 200 and
+// 251 KB of real HTML from a residential IP, so no JS challenge is involved. It is 403 from
+// the prod datacenter IP AND 403 through SOURCES_PROXY_URL, whose exit that edge classifies
+// as datacenter too — adding bayt here today would route it through an IP it already
+// refuses. It belongs here the day a genuinely residential pool exists, alongside echojobs
+// (Vercel's bot firewall, same measurement, same answer) and wantedkr.
 var proxiedFingerprintProviders = map[string]func(*fingerprintHTTP) Source{
 	"gulftalent": func(c *fingerprintHTTP) Source { return NewGulfTalent(c) },
 }

--- a/internal/platform/db/metrics.sql.go
+++ b/internal/platform/db/metrics.sql.go
@@ -101,20 +101,55 @@ func (q *Queries) NewestOpenJobCreatedAt(ctx context.Context) (pgtype.Timestampt
 	return created_at, err
 }
 
-const providerIngestFreshness = `-- name: ProviderIngestFreshness :many
-SELECT provider, max(last_success_at)::timestamptz AS last_success_at
+const providerIngestHealth = `-- name: ProviderIngestHealth :many
+SELECT
+    provider,
+    max(last_success_at)::timestamptz AS last_success_at,
+    count(*) FILTER (
+        WHERE cooldown_until > now()
+    ) AS cooled,
+    count(*) FILTER (
+        WHERE (cooldown_until IS NULL OR cooldown_until <= now())
+          AND consecutive_failures > 0
+    ) AS failing,
+    count(*) FILTER (
+        WHERE (cooldown_until IS NULL OR cooldown_until <= now())
+          AND consecutive_failures = 0
+    ) AS healthy
 FROM board_health
 GROUP BY provider
 ORDER BY provider
 `
 
-type ProviderIngestFreshnessRow struct {
+type ProviderIngestHealthRow struct {
 	Provider      string             `json:"provider"`
 	LastSuccessAt pgtype.Timestamptz `json:"last_success_at"`
+	Cooled        int64              `json:"cooled"`
+	Failing       int64              `json:"failing"`
+	Healthy       int64              `json:"healthy"`
 }
 
-// The most recent successful crawl per ingest provider, for the gauge that makes a
-// provider which has stopped producing data visible as itself.
+// Per-provider ingest health: when the provider's most recent board crawl succeeded, and
+// how its boards split across the same three states BoardHealthMetrics publishes fleet-wide.
+//
+// The two halves answer different questions and neither substitutes for the other.
+//
+// The timestamp says when data last ARRIVED. max() over a nullable column yields NULL for a
+// provider whose every board has never succeeded, and that NULL is rendered as an ABSENT
+// sample rather than a zero, because a Unix zero reads downstream as overdue since 1970.
+// So on the timestamp alone a provider is invisible in precisely the case where it is most
+// broken — gulftalent held 19,828 postings unrefreshed since 2026-07-07 with its systemd
+// timer disabled, and published no sample at all.
+//
+// The state counts say whether anything is TRYING. Every provider board_health knows has a
+// row, so these always have a value, and "no healthy boards" is a predicate that fires for
+// the never-succeeded case as well as the stopped-succeeding one. It is also selective:
+// measured on prod 2026-09-01 it named 20 providers out of ~180, while a fleet whose
+// background is ~5% failing boards leaves a mostly-healthy provider like personio out.
+//
+// The three states are mutually exclusive and carry BoardHealthMetrics' precedence rule
+// (cooled over failing), so they sum to the provider's board count and the fleet-wide
+// family stays the sum of these.
 //
 // Reads board_health rather than the jobs table on purpose. The catalogue-side form of
 // the same question — max(last_seen_at) grouped by source over open jobs — measured 41s
@@ -122,20 +157,22 @@ type ProviderIngestFreshnessRow struct {
 // file's header commits every query in it to never being why ingest waits, and the host
 // is disk-bound, so a once-a-minute scan of that size is exactly the thing it forbids.
 // The same measurement here reads 97k rows in 54ms.
-//
-// max() over a nullable column yields NULL for a provider whose every board has never
-// succeeded; that NULL is carried through and rendered as an ABSENT sample, never as a
-// zero — see cmd/queue-metrics/render.go.
-func (q *Queries) ProviderIngestFreshness(ctx context.Context) ([]ProviderIngestFreshnessRow, error) {
-	rows, err := q.db.Query(ctx, providerIngestFreshness)
+func (q *Queries) ProviderIngestHealth(ctx context.Context) ([]ProviderIngestHealthRow, error) {
+	rows, err := q.db.Query(ctx, providerIngestHealth)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []ProviderIngestFreshnessRow{}
+	items := []ProviderIngestHealthRow{}
 	for rows.Next() {
-		var i ProviderIngestFreshnessRow
-		if err := rows.Scan(&i.Provider, &i.LastSuccessAt); err != nil {
+		var i ProviderIngestHealthRow
+		if err := rows.Scan(
+			&i.Provider,
+			&i.LastSuccessAt,
+			&i.Cooled,
+			&i.Failing,
+			&i.Healthy,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -2821,8 +2821,27 @@ type Querier interface {
 	// coalesced/cast to bigint so it reads as a plain int64 (an all-failing provider
 	// yields 0, not NULL).
 	ProviderHealthRollup(ctx context.Context) ([]ProviderHealthRollupRow, error)
-	// The most recent successful crawl per ingest provider, for the gauge that makes a
-	// provider which has stopped producing data visible as itself.
+	// Per-provider ingest health: when the provider's most recent board crawl succeeded, and
+	// how its boards split across the same three states BoardHealthMetrics publishes fleet-wide.
+	//
+	// The two halves answer different questions and neither substitutes for the other.
+	//
+	// The timestamp says when data last ARRIVED. max() over a nullable column yields NULL for a
+	// provider whose every board has never succeeded, and that NULL is rendered as an ABSENT
+	// sample rather than a zero, because a Unix zero reads downstream as overdue since 1970.
+	// So on the timestamp alone a provider is invisible in precisely the case where it is most
+	// broken — gulftalent held 19,828 postings unrefreshed since 2026-07-07 with its systemd
+	// timer disabled, and published no sample at all.
+	//
+	// The state counts say whether anything is TRYING. Every provider board_health knows has a
+	// row, so these always have a value, and "no healthy boards" is a predicate that fires for
+	// the never-succeeded case as well as the stopped-succeeding one. It is also selective:
+	// measured on prod 2026-09-01 it named 20 providers out of ~180, while a fleet whose
+	// background is ~5% failing boards leaves a mostly-healthy provider like personio out.
+	//
+	// The three states are mutually exclusive and carry BoardHealthMetrics' precedence rule
+	// (cooled over failing), so they sum to the provider's board count and the fleet-wide
+	// family stays the sum of these.
 	//
 	// Reads board_health rather than the jobs table on purpose. The catalogue-side form of
 	// the same question — max(last_seen_at) grouped by source over open jobs — measured 41s
@@ -2830,11 +2849,7 @@ type Querier interface {
 	// file's header commits every query in it to never being why ingest waits, and the host
 	// is disk-bound, so a once-a-minute scan of that size is exactly the thing it forbids.
 	// The same measurement here reads 97k rows in 54ms.
-	//
-	// max() over a nullable column yields NULL for a provider whose every board has never
-	// succeeded; that NULL is carried through and rendered as an ABSENT sample, never as a
-	// zero — see cmd/queue-metrics/render.go.
-	ProviderIngestFreshness(ctx context.Context) ([]ProviderIngestFreshnessRow, error)
+	ProviderIngestHealth(ctx context.Context) ([]ProviderIngestHealthRow, error)
 	// One keyset page of rows the prune rule evaluates, ordered by id.
 	//
 	// Closed rows are included deliberately. Once ingest rejects a board's non-technical

--- a/internal/platform/db/queries/metrics.sql
+++ b/internal/platform/db/queries/metrics.sql
@@ -86,9 +86,28 @@ WHERE closed_at IS NULL
 ORDER BY created_at DESC, id DESC
 LIMIT 1;
 
--- name: ProviderIngestFreshness :many
--- The most recent successful crawl per ingest provider, for the gauge that makes a
--- provider which has stopped producing data visible as itself.
+-- name: ProviderIngestHealth :many
+-- Per-provider ingest health: when the provider's most recent board crawl succeeded, and
+-- how its boards split across the same three states BoardHealthMetrics publishes fleet-wide.
+--
+-- The two halves answer different questions and neither substitutes for the other.
+--
+-- The timestamp says when data last ARRIVED. max() over a nullable column yields NULL for a
+-- provider whose every board has never succeeded, and that NULL is rendered as an ABSENT
+-- sample rather than a zero, because a Unix zero reads downstream as overdue since 1970.
+-- So on the timestamp alone a provider is invisible in precisely the case where it is most
+-- broken — gulftalent held 19,828 postings unrefreshed since 2026-07-07 with its systemd
+-- timer disabled, and published no sample at all.
+--
+-- The state counts say whether anything is TRYING. Every provider board_health knows has a
+-- row, so these always have a value, and "no healthy boards" is a predicate that fires for
+-- the never-succeeded case as well as the stopped-succeeding one. It is also selective:
+-- measured on prod 2026-09-01 it named 20 providers out of ~180, while a fleet whose
+-- background is ~5% failing boards leaves a mostly-healthy provider like personio out.
+--
+-- The three states are mutually exclusive and carry BoardHealthMetrics' precedence rule
+-- (cooled over failing), so they sum to the provider's board count and the fleet-wide
+-- family stays the sum of these.
 --
 -- Reads board_health rather than the jobs table on purpose. The catalogue-side form of
 -- the same question — max(last_seen_at) grouped by source over open jobs — measured 41s
@@ -96,11 +115,20 @@ LIMIT 1;
 -- file's header commits every query in it to never being why ingest waits, and the host
 -- is disk-bound, so a once-a-minute scan of that size is exactly the thing it forbids.
 -- The same measurement here reads 97k rows in 54ms.
---
--- max() over a nullable column yields NULL for a provider whose every board has never
--- succeeded; that NULL is carried through and rendered as an ABSENT sample, never as a
--- zero — see cmd/queue-metrics/render.go.
-SELECT provider, max(last_success_at)::timestamptz AS last_success_at
+SELECT
+    provider,
+    max(last_success_at)::timestamptz AS last_success_at,
+    count(*) FILTER (
+        WHERE cooldown_until > now()
+    ) AS cooled,
+    count(*) FILTER (
+        WHERE (cooldown_until IS NULL OR cooldown_until <= now())
+          AND consecutive_failures > 0
+    ) AS failing,
+    count(*) FILTER (
+        WHERE (cooldown_until IS NULL OR cooldown_until <= now())
+          AND consecutive_failures = 0
+    ) AS healthy
 FROM board_health
 GROUP BY provider
 ORDER BY provider;

--- a/internal/platform/pgerr/pgerr_test.go
+++ b/internal/platform/pgerr/pgerr_test.go
@@ -105,8 +105,18 @@ func TestOnlyThisPackageUnwrapsAPgError(t *testing.T) {
 			return err
 		}
 		if d.IsDir() {
+			name := d.Name()
+			// A dot- or underscore-prefixed directory is not part of this module: the go
+			// toolchain never descends into one, so `./...` cannot compile what lives there.
+			// This is a filesystem walk, not a package walk, and without the same rule it
+			// reads every git worktree checked out INSIDE the repo (.worktrees,
+			// .claude/worktrees) as another copy of this package — one offender per
+			// worktree, none of them real, and the count below then fails on a clean tree.
+			if path != root && (strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_")) {
+				return filepath.SkipDir
+			}
 			// Vendored and generated trees are nobody's taxonomy to keep.
-			if name := d.Name(); name == "node_modules" || name == ".git" || name == "archive" {
+			if name == "node_modules" || name == "archive" {
 				return filepath.SkipDir
 			}
 			return nil

--- a/sources/bayt.yml
+++ b/sources/bayt.yml
@@ -4,6 +4,17 @@
 # comes from the posting, so `company` here is only a per-scope label. Country slugs are
 # live-validated (each returns a populated listing). Bayt is behind an Akamai/Cloudflare edge, so
 # the adapter crawls it over the shared Chrome-fingerprint transport.
+#
+# NOT CRAWLED, and the reason is the egress IP, not this file. Measured 2026-09-01 with the
+# repository's own fingerprint transport: from a residential IP the UAE listing returns 200 and
+# 251 KB of real HTML; from the prod datacenter IP it is 403, and 403 again through
+# SOURCES_PROXY_URL, whose exit (45.61.127.48) that edge classifies as datacenter too. Every
+# board here therefore carries consecutive_failures with last_success_at NULL — bayt has never
+# once succeeded — and its systemd timer is disabled.
+#
+# So the entries and the adapter are both fine and stay as they are; what is missing is a
+# genuinely residential egress pool. echojobs and wantedkr are blocked on the same purchase.
+# Until it exists, leave the timer off rather than burning an hourly run on eight certain 403s.
 - company: Bayt Saudi Arabia
   provider: bayt
   board: saudi-arabia

--- a/sources/echojobs.yml
+++ b/sources/echojobs.yml
@@ -1,5 +1,20 @@
 # echojobs.io multi-employer tech-jobs aggregator. Boardless: one global keyless feed
 # (echojobs.io/api/jobs), so the entry carries no board, and each job's company and URL (the
 # upstream ATS link) come from the posting, not this placeholder.
+#
+# BLOCKED since 2026-08-19, with 84,606 open postings going stale behind it — the largest single
+# loss in the fleet. echojobs now sits behind Vercel's bot firewall: the plain client is answered
+# with a 429 carrying a "Vercel Security Checkpoint" page rather than a rate-limit, so the status
+# code names the wrong problem.
+#
+# Measured 2026-09-01 with the repository's own Chrome-fingerprint transport: from a residential IP
+# the sitemap index returns 200 and parses; from the prod datacenter IP it is 403, and 429 through
+# SOURCES_PROXY_URL. So this needs BOTH the fingerprint transport (which the adapter does not use
+# today — it is on the standard client) and a genuinely residential egress. Wiring the first
+# without the second changes a 403 into a 429 and nothing else, so both land together or neither
+# does. bayt and wantedkr are blocked on the same purchase.
+#
+# /api/jobs itself is gone (404 even from a residential IP) — the adapter already walks the sitemap
+# instead; this header's first paragraph predates that and is kept for the provider description.
 - company: echojobs
   provider: echojobs

--- a/sources/functionalworks.yml
+++ b/sources/functionalworks.yml
@@ -1,5 +1,15 @@
 # Functional Works (functional.works-hub.com) niche engineering board. Boardless: one public
 # GraphQL endpoint (functional.works-hub.com/api/graphql), so the entry carries no board; each
 # job's company comes from the posting, not this placeholder.
+#
+# BLOCKED since 2026-08-12, 888 open postings going stale. Not a moved endpoint, though it looks
+# like one from the outside: functional.works-hub.com 302s to works-hub.com, so a redirect-following
+# GET reports success while the adapter's POST loses its body to the redirect and fails. Measured
+# 2026-09-01, the destination is a rebuilt site — /api/graphql and /graphql on the new host both
+# answer with the app's HTML shell, and the `functional` vertical no longer exists as a subdomain.
+#
+# So the GraphQL feed this adapter is written against is gone, and there is no one-line host swap
+# that recovers it. The new site server-renders its listing (~260 job links on /jobs, plus a live
+# sitemap), which is a different adapter shape and wants its own spike.
 - company: Functional Works
   provider: functionalworks

--- a/sources/globalpayments.yml
+++ b/sources/globalpayments.yml
@@ -1,5 +1,14 @@
 # globalpayments boards. Provider is the filename; each entry is company + board.
-# board = the careers-site host (see internal/sources/globalpayments.go).
+# board = the careers-site host (see internal/ingest/sources/globalpayments.go).
+#
+# BLOCKED since 2026-08-20, 54 open postings going stale — the smallest loss in the fleet, listed
+# here so the next revision does not re-derive it. The host is unchanged and still 200s; what moved
+# is the path. jobs.globalpayments.com/en/jobs/?page=N now 301s to /?page=N, the site has been
+# rebuilt on Next.js, and its listing lives at /jobs with the job data no longer in the server-
+# rendered anchors the adapter scrapes (gpJobLinks finds none). gpJobIDPattern also keys the
+# posting id off an /en/jobs/<id>/<slug> path that no longer exists.
+#
+# So this is a re-spike of the listing and detail shape, not a prefix swap.
 
 - company: Global Payments
   board: jobs.globalpayments.com

--- a/sources/gulftalent.yml
+++ b/sources/gulftalent.yml
@@ -2,6 +2,14 @@
 # enumerates the sitemap index, follows the job-posting shards (sitemap_jx0NN.xml), and reads each
 # posting's self-contained schema.org JobPosting. The employer comes from the posting, so `company`
 # here is only a placeholder label. GulfTalent is behind an Akamai edge, so the adapter crawls it
-# over the shared Chrome-fingerprint transport.
+# over the shared Chrome-fingerprint transport AND through SOURCES_PROXY_URL — it is the one entry
+# in proxiedFingerprintProviders, and it needs both: measured from prod 2026-09-01, the Chrome
+# fingerprint on the direct datacenter IP is 403 and the same fingerprint through the proxy is 200.
+#
+# Re-verified 2026-09-01 after 19,828 postings sat unrefreshed since 2026-07-07. The crawl path was
+# never the problem — the systemd timer was disabled and nothing crawled this file at all, which is
+# invisible three ways over: no run means no board_health row, no board_health row means no
+# last_success_at, and no last_success_at means the freshness gauge publishes no sample. The
+# per-provider board-state gauge (cmd/queue-metrics) exists because of this file.
 - company: GulfTalent
   provider: gulftalent

--- a/sources/justjoin.yml
+++ b/sources/justjoin.yml
@@ -1,5 +1,15 @@
 # JustJoin.it Polish/CEE IT marketplace. Boardless: one public API
 # (api.justjoin.it/v2/user-panel/offers/by-cursor), so the entry carries no board; each job's
 # company comes from the posting, not this placeholder.
+#
+# BLOCKED since 2026-08-21, 10,984 open postings going stale. Unlike echojobs/bayt/wantedkr this is
+# NOT an IP or fingerprint problem: the endpoint answers 503 from a residential IP, from the prod
+# datacenter IP, through SOURCES_PROXY_URL, and with the Chrome-fingerprint transport alike, while
+# justjoin.it itself serves 200. An nginx 503 on one path with the site up reads as a retired
+# route, not an outage — and it has read that way for eleven days.
+#
+# The adapter needs a re-spike against whatever justjoin.it serves its listing from now; the
+# v2/user-panel path is not coming back on its own. Left in place meanwhile so board_health keeps
+# saying so out loud.
 - company: JustJoin
   provider: justjoin

--- a/sources/wantedkr.yml
+++ b/sources/wantedkr.yml
@@ -1,4 +1,16 @@
 # Wanted (wanted.co.kr) South-Korean tech job board. Boardless: one public API, so the
 # entry carries no board; each job's company comes from the API. Postings are Korean.
+#
+# PARKED since 2026-09-01, 6,175 open postings going stale. wantedkr is on proxiedProviders because
+# its API 403s the prod datacenter IP, and that entry is no longer enough: measured 2026-09-01, the
+# API returns 200 from a residential IP and 403 through SOURCES_PROXY_URL, whose exit
+# (45.61.127.48) wanted.co.kr classifies as datacenter as well. The proxy itself is healthy — djinni,
+# enlizt and vagas are all served 200 through the same credential on the same day — so this is that
+# edge's IP classification, not a broken proxy.
+#
+# Its timer is disabled rather than left to fail hourly, because a run that reaches the API and is
+# refused looks like a run: `ingested=0 failed=0`, exit 0. Re-enable it the day a genuinely
+# residential pool exists; echojobs and bayt are waiting on the same purchase, and echojobs alone
+# is 84,606 postings, so the three are one decision rather than three.
 - company: Wanted Korea
   provider: wantedkr


### PR DESCRIPTION
Make a provider that never succeeded visible, and record why seven are dead

gulftalent has held 19,828 postings unrefreshed since 2026-07-07 and nothing
said so. Its crawl path was never broken: measured from prod today, the Chrome
fingerprint through SOURCES_PROXY_URL returns the sitemap index normally. Its
systemd timer was disabled, and that is invisible three times over — no run
means no board_health write, no write means last_success_at stays NULL, and a
NULL is rendered as an ABSENT sample by design, so the freshness gauge #2272
added publishes nothing for exactly the provider that is most broken.

ProviderIngestFreshness becomes ProviderIngestHealth and returns the provider's
board split across the same three mutually exclusive states BoardHealthMetrics
already publishes fleet-wide. Those counts exist for every provider board_health
knows, so "no healthy boards" is a predicate that fires where the timestamp has
nothing to say. It is selective rather than noisy: on prod today it names 20
providers out of ~180, and leaves personio — 12 dead boards inside a healthy
fleet — out. Published as raw counts under a state label, not as a baked-in
"is this provider down" boolean, because the fleet runs a few percent failing
boards as background and which ratio deserves a page belongs in the alert rule.

The timestamp family is unchanged and still omits the never-succeeded case.

Alongside it, the revision of the seven board files whose providers are not
producing, each with a measurement rather than a guess:

- gulftalent — path verified working; the timer is the fix, now re-enabled.
- echojobs (84,606 postings, the largest loss) — Vercel's bot firewall answers
  429 with a "Security Checkpoint" page, so the status code names the wrong
  problem. The fingerprint transport is served 200 from a residential IP, 403
  from prod, 429 through the proxy. Needs the fingerprint client AND a
  residential egress; either alone changes nothing.
- bayt — the comment claiming a Cloudflare JS challenge no fingerprint or IP
  passes is wrong, and corrected here: the same transport gets 251 KB of real
  listing HTML from a residential IP. It is the egress class, like echojobs.
- wantedkr — same again; its timer is parked rather than left to fail hourly,
  because a refused run reports ingested=0 failed=0 and exits 0.
- justjoin — not an IP problem at all: 503 from every IP and transport while
  justjoin.it serves 200, which reads as a retired route. Needs a re-spike.
- functionalworks — not a moved endpoint despite the 302. The destination is a
  rebuilt site with no GraphQL API; the vertical subdomain is gone.
- globalpayments — the host is fine, the path moved and the site is now Next.js
  with no server-rendered anchors for gpJobLinks to find.

Two module-walking guards also stopped failing on a clean checkout. Both walk
the filesystem from the module root and skip .git by name, so a git worktree
checked out inside the repo (.worktrees, .claude/worktrees) reads as another
copy of the file each polices — 24 violations from twelve worktrees, none real,
and go test ./... red for everyone. Both now skip dot- and underscore-prefixed
directories, which is the rule the go toolchain itself applies: `./...` cannot
compile what lives there, so it is not theirs to police either.
