### PR TITLE
Name the board-state vocabulary once, and let the parser check the new family

### DIFF
--- a/cmd/queue-metrics/render.go
+++ b/cmd/queue-metrics/render.go
@@ -62,15 +62,8 @@ func render(s snapshot) string {
 		func(q queueMetrics) string { return fmt.Sprintf("%.3f", q.oldestAgeSeconds) }, s.queues)
 
 	writeHeader(&b, "freehire_boards_total", "Ingest boards by health state.")
-	for _, state := range []struct {
-		name  string
-		count int64
-	}{
-		{"healthy", s.healthyBoards},
-		{"failing", s.failingBoards},
-		{"cooled", s.cooledBoards},
-	} {
-		fmt.Fprintf(&b, "freehire_boards_total{state=%q} %d\n", state.name, state.count)
+	for _, st := range boardStates(s.healthyBoards, s.failingBoards, s.cooledBoards) {
+		fmt.Fprintf(&b, "freehire_boards_total{state=%q} %d\n", st.name, st.count)
 	}
 
 	// A zero timestamp would be read as 1970, i.e. a catalogue infinitely overdue for
@@ -116,21 +109,40 @@ func render(s snapshot) string {
 	if len(s.providers) > 0 {
 		writeHeader(&b, "freehire_provider_boards", "Ingest boards by health state, per provider.")
 		for _, p := range s.providers {
-			for _, state := range []struct {
-				name  string
-				count int64
-			}{
-				{"healthy", p.healthy},
-				{"failing", p.failing},
-				{"cooled", p.cooled},
-			} {
+			for _, st := range boardStates(p.healthy, p.failing, p.cooled) {
 				fmt.Fprintf(&b, "freehire_provider_boards{provider=%q,state=%q} %d\n",
-					p.name, state.name, state.count)
+					p.name, st.name, st.count)
 			}
 		}
 	}
 
 	return b.String()
+}
+
+// boardState pairs one of the three mutually exclusive board health states with how many
+// boards are in it.
+type boardState struct {
+	name  string
+	count int64
+}
+
+// boardStates returns those three in the order both board families publish them.
+//
+// Two families carry these labels — freehire_boards_total fleet-wide and
+// freehire_provider_boards per provider — and a dashboard that stacks one against the
+// other only reads correctly while they agree on the names and the order. Spelled twice
+// they can drift apart without failing to compile, and the drift shows up as a graph that
+// quietly disagrees with itself, so the vocabulary lives here once.
+//
+// The precedence behind the counts (cooled over failing, so the three sum to the fleet
+// rather than double-counting) is BoardHealthMetrics' in queries/metrics.sql; this only
+// fixes how they are named and ordered.
+func boardStates(healthy, failing, cooled int64) [3]boardState {
+	return [3]boardState{
+		{"healthy", healthy},
+		{"failing", failing},
+		{"cooled", cooled},
+	}
 }
 
 // writeFamily emits one metric family: its HELP and TYPE lines, then one sample per

--- a/cmd/queue-metrics/render_test.go
+++ b/cmd/queue-metrics/render_test.go
@@ -251,16 +251,26 @@ func TestRenderProviderBoardsIsOneWellFormedFamily(t *testing.T) {
 		{name: "greenhouse", healthy: 4, failing: 1, cooled: 2},
 		{name: "gulftalent", failing: 1},
 	}
-	got := render(s)
-	if n := strings.Count(got, "# TYPE freehire_provider_boards gauge"); n != 1 {
-		t.Errorf("family has %d TYPE lines, want exactly 1", n)
+
+	// Parsed rather than counted, and with providers present, because fullSnapshot() has
+	// none — so TestRenderIsValidPrometheusTextFormat never sees these two families at all
+	// and the parser has never validated them. This family emits three samples per
+	// provider, which is the shape a loop nested the other way round would interleave:
+	// still correct sample-by-sample, and an invalid exposition that the textfile
+	// collector answers by silently skipping the file.
+	parser := expfmt.NewTextParser(model.UTF8Validation)
+	families, err := parser.TextToMetricFamilies(strings.NewReader(render(s)))
+	if err != nil {
+		t.Fatalf("rendered exposition does not parse: %v", err)
 	}
-	if n := strings.Count(got, "freehire_provider_boards{"); n != len(s.providers)*3 {
-		t.Errorf("family emitted %d samples, want %d (three states per provider)", n, len(s.providers)*3)
+	family, ok := families["freehire_provider_boards"]
+	if !ok {
+		t.Fatal("parsed exposition is missing family freehire_provider_boards")
 	}
-	header := strings.Index(got, "# HELP freehire_provider_boards ")
-	first := strings.Index(got, "freehire_provider_boards{")
-	if header < 0 || first < header {
-		t.Errorf("samples must follow the HELP line\ngot:\n%s", got)
+	if got, want := len(family.GetMetric()), len(s.providers)*3; got != want {
+		t.Errorf("family has %d samples, want %d (three states per provider)", got, want)
+	}
+	if family.GetType() != dto.MetricType_GAUGE {
+		t.Errorf("family parsed as %v, want GAUGE", family.GetType())
 	}
 }


### PR DESCRIPTION
Name the board-state vocabulary once, and let the parser check the new family

Quality pass over #2277, no behaviour change — the pinned exposition text and the
per-provider sample strings are byte-identical.

Two families publish the same three board health states under the same labels:
freehire_boards_total fleet-wide and freehire_provider_boards per provider. Each
spelled the triple as its own anonymous struct literal, so the names and the order
could drift apart without failing to compile, and the drift would surface as a
dashboard stacking one against the other and quietly disagreeing with itself.
boardStates() holds the vocabulary once; the per-provider loop also loses a level
of nesting, since the literal used to sit inside the loop over providers.

TestRenderProviderBoardsIsOneWellFormedFamily counted substrings and compared
string indices to assert the samples followed their HELP line. It now parses the
exposition with Prometheus's own parser instead, which is both shorter and
stronger — and it closes a real gap: fullSnapshot() carries no providers, so
TestRenderIsValidPrometheusTextFormat had never once seen either provider family,
and the parser had never validated them. A textfile collector answers an
unparseable file by skipping it, which reads downstream exactly like a worker
that never ran.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated board status handling to ensure consistent state names and ordering across metrics.
  * Preserved existing metric output.

* **Tests**
  * Strengthened validation of provider board metrics, including metric type, family presence, and samples for each board state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->