### PR TITLE
Correct the gulftalent record: the crawl does not fit, and the timer stays off

### DIFF
--- a/internal/ingest/sources/proxy.go
+++ b/internal/ingest/sources/proxy.go
@@ -177,6 +177,13 @@ func ApplyProxyEgress(registry map[string]Source) error {
 // spike-verified and re-verified from prod on 2026-09-01: via the same proxy, curl's JA3
 // 403s while the Chrome JA3 is served the sitemap index.
 //
+// That entry is necessary and not sufficient, and the difference has been mistaken for
+// success once. Wiring the right transport gets ONE request served; it does not get the
+// crawl through. gulftalent's sitemap is thousands of detail pages funnelled through this
+// single shared exit address, and a full run on 2026-09-01 was refused by the same edge
+// partway through — see sources/gulftalent.yml for the measurement and why its timer is off.
+// Validate a provider here by what a whole run yields, never by one 200.
+//
 // bayt is absent, but not because it is unpassable. That was the earlier reading and it is
 // wrong: measured 2026-09-01 with this same transport, bayt's UAE listing returns 200 and
 // 251 KB of real HTML from a residential IP, so no JS challenge is involved. It is 403 from

--- a/sources/gulftalent.yml
+++ b/sources/gulftalent.yml
@@ -6,10 +6,32 @@
 # in proxiedFingerprintProviders, and it needs both: measured from prod 2026-09-01, the Chrome
 # fingerprint on the direct datacenter IP is 403 and the same fingerprint through the proxy is 200.
 #
-# Re-verified 2026-09-01 after 19,828 postings sat unrefreshed since 2026-07-07. The crawl path was
-# never the problem — the systemd timer was disabled and nothing crawled this file at all, which is
-# invisible three ways over: no run means no board_health row, no board_health row means no
-# last_success_at, and no last_success_at means the freshness gauge publishes no sample. The
-# per-provider board-state gauge (cmd/queue-metrics) exists because of this file.
+# NOT CRAWLED, and the timer stays disabled until the crawl is made to fit. 19,828 postings have
+# sat unrefreshed since 2026-07-07 and last_success_at has never been set.
+#
+# A single request succeeding is NOT evidence this crawl works, and the two were confused once
+# already. Measured on prod 2026-09-01, in this order:
+#
+#   1. sitemap index through proxy + fingerprint: 200.
+#   2. a full run on that basis: 50 minutes at gulftalentDetailWorkers=4, SIGKILLed at the unit's
+#      TimeoutStartSec, 4m28s CPU against 267 MB peak — so it was waiting on the network, not
+#      working. It persisted NOTHING: the crawl has no partial credit, so a killed run leaves no
+#      rows, no board_health write, and no trace that it ran.
+#   3. the same request as (1), immediately after: 403, while djinni through the same proxy was
+#      still 200. The crawl burned the single shared exit IP on GulfTalent's edge by itself.
+#
+# So the shape of the failure is structural, not a broken endpoint: the whole sitemap is thousands
+# of detail fetches funnelled through ONE proxy address, which is both too slow for a 50-minute
+# oneshot and enough traffic for that address to be refused before it finishes. Re-enabling the
+# timer just repeats (2) and (3) every hour, which is how this ended up disabled in the first place.
+#
+# Two ways out, neither a board-file edit: a rotating residential pool (the same purchase echojobs,
+# bayt and wantedkr are waiting on), or a resumable crawl that takes a bounded slice per run and
+# persists what it got — the shape cmd/hydrate-adzuna-description already uses. The seam for the
+# second is gulftalentDetailWorkers' neighbourhood in internal/ingest/sources/gulftalent.go.
+#
+# Separately, this file is why the per-provider board-state gauge exists (cmd/queue-metrics). While
+# the timer was off the provider was invisible three ways over: no run means no board_health row,
+# no row means last_success_at stays NULL, and a NULL is published as an ABSENT sample.
 - company: GulfTalent
   provider: gulftalent


### PR DESCRIPTION
Correct the gulftalent record: the crawl does not fit, and the timer stays off

#2277 read gulftalent's disabled timer as the whole story and re-enabled it. That
was half the truth, and the half it left out is why the timer was disabled: the
crawl cannot finish, and trying gets the shared proxy address refused.

Measured on prod 2026-09-01, in this order. The sitemap index through proxy +
fingerprint returns 200. A full run on that basis then ran 50 minutes at
gulftalentDetailWorkers=4, was SIGKILLed at the unit's TimeoutStartSec, and spent
4m28s of CPU against a 267 MB peak — waiting on the network, not working. It
persisted nothing: this crawl has no partial credit, so a killed run leaves no
rows, no board_health write, and no trace it ran at all. Immediately afterwards
that same sitemap request returned 403 through the same proxy while djinni through
it was still 200 — the run had burned the single shared exit IP on GulfTalent's
edge by itself.

So the failure is structural rather than a broken endpoint, and re-enabling the
timer just repeats it hourly. It is disabled again on prod. The board file now
carries the measurement and the two ways out — a rotating residential pool, or a
resumable crawl that takes a bounded slice per run, the shape
cmd/hydrate-adzuna-description already uses — with the seam named.

proxy.go gains the general form of the same lesson beside the entry that invited
the mistake: membership there gets ONE request served and says nothing about
whether a whole run completes. Validate by yield, never by a single 200.

No behaviour change; comments and a board file only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the GulfTalent data source is currently disabled because full crawls may time out, save no partial results, or trigger proxy blocking.
  * Documented the distinction between sitemap access and successful full crawls, along with potential future remediation approaches.
  * Added guidance to validate proxied providers using complete crawl results rather than a single successful response.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->