### PR TITLE
Let the dependency scan skip when it has nothing to authenticate with

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -9,6 +9,22 @@ name: snyk
 # directories, and the paths filter below meant a change to the root lockfile did not even
 # start the job. Those are dev dependencies, but they run in CI and on every laptop, which
 # is the same trust boundary as anything else here.
+#
+# THE SCAN NEEDS A CREDENTIAL, AND SAYS SO WHEN IT HAS NONE. Without `SNYK_TOKEN` the CLI
+# exits 2 on its first call, which painted a red cross on every dependency PR — a standing
+# failure nobody reads is how a real one gets waved through. The `credentials` job below
+# decides, and the scan skips rather than fails when there is nothing to authenticate with.
+#
+# That skip is deliberately LOUD: a warning annotation on the run and a note in the job
+# summary, both naming what went unscanned. A scanner that quietly opts out makes a commit
+# look examined, which is the same reason the gitleaks hook fails hard when its binary is
+# missing.
+#
+# The gate is a separate job because `secrets` is NOT one of the contexts available to an
+# `if:` — not on a job, not on a step. Written there it evaluates to nothing, the condition
+# is false however the repository is configured, and the scan silently never runs again.
+# `needs` IS available, so the credential is read in a step's `env` and handed forward as
+# an output.
 on:
   schedule:
     - cron: '41 6 * * *'
@@ -27,7 +43,40 @@ permissions:
   contents: read
 
 jobs:
+  # Reads the secret in the one place an `if:` cannot: a step's `env`. Emits a plain
+  # string, not the credential, so the scan job can branch on it through `needs`.
+  credentials:
+    runs-on: ubuntu-latest
+    outputs:
+      configured: ${{ steps.probe.outputs.configured }}
+    steps:
+      - name: Probe for a Snyk credential
+        id: probe
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
+          if [ -n "$SNYK_TOKEN" ]; then
+            echo 'configured=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo 'configured=false' >> "$GITHUB_OUTPUT"
+          echo '::warning title=Snyk did not run::No SNYK_TOKEN secret is set, so the JS lockfiles went unscanned.'
+          # Quoted heredoc: the body is Markdown for the summary, and nothing in it expands.
+          cat >> "$GITHUB_STEP_SUMMARY" <<'SUMMARY'
+          ## Snyk did not run
+
+          No `SNYK_TOKEN` secret is set on this repository, so the four JS lockfiles
+          (root, `design-system/`, `web/`, `extension/`) were **not scanned** for known
+          vulnerabilities.
+
+          Go dependencies are unaffected: `govulncheck` covers those and needs no credential.
+
+          Set the secret to restore the scan.
+          SUMMARY
+
   snyk:
+    needs: credentials
+    if: needs.credentials.outputs.configured == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
There is no `SNYK_TOKEN` secret on this repository, so the CLI exits 2 on its first call and paints a red cross on every dependency PR. The check is not required, so nothing was blocked — which is the problem. A standing failure nobody reads is how a real finding gets waved through; thirteen open PRs carried it at once this week.

The scan now runs only when a credential exists, and **says plainly when it does not**: a warning annotation on the run, plus a job-summary note naming the four lockfiles that went unscanned and pointing out that `govulncheck` still covers Go. That loudness is the point — a scanner that quietly opts out makes a commit look examined, which is the same reason the gitleaks hook fails hard when its binary is missing.

### Why the gate is a separate job

`secrets` is **not** one of the contexts available to an `if:` — not on a job, not on a step. Written there, the condition is false however the repository is configured, and the scan silently never runs again: the exact failure this change exists to prevent. `needs` *is* available, so the credential is read in a step's `env` and handed forward as a plain `true`/`false` output.

### Verification

- `actionlint` (which runs shellcheck over every `run:` block) is green on this file.
- The probe script was extracted from the YAML and run both ways: empty token → `configured=false` + warning + summary; non-empty token → `configured=true`, no summary, exit 0.
- The summary body goes through a **quoted** heredoc, so its Markdown backticks read as text rather than command substitution.

Once `SNYK_TOKEN` is set, the scan resumes with no further change here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning to run only when the required scanning credentials are configured.
  * Added a clear warning and workflow summary when credentials are unavailable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->