### PR TITLE
Stop compliance acronyms from vouching for the words beside them

### DIFF
--- a/internal/dict/skilltag/dictionaries.go
+++ b/internal/dict/skilltag/dictionaries.go
@@ -694,37 +694,26 @@ var wordAliases = map[string]string{
 	"nagios":     "nagios",
 	"solarwinds": "solarwinds",
 	"citrix":     "citrix",
-	"kvm":        "kvm",
 	// networking
 	"vlans": "vlan",
 	"vxlan": "vxlan",
 	"sdn":   "sdn",
 	"sase":  "sase",
-	// security vendors, certifications and regulatory frameworks. A framework is the
-	// thing a security or compliance posting actually names, and each of these spellings
-	// is coined — unlike "soc" (system-on-chip / security operations centre / social)
-	// and "pci" (the bus), which are reachable only as phrases below.
+	// security vendors. The certifications and the regulatory frameworks that shipped
+	// here beside them have MOVED to the phrase lists and nonCorroboratingPhrases: each
+	// spelling is coined, so tagging was never the problem, but a strong match also
+	// vouches for every gated word in the same text — and "HIPAA training required"
+	// sits on most of a healthcare catalogue. See the compliance block below.
 	"crowdstrike": "crowdstrike",
 	"fortinet":    "fortinet",
 	"cyberark":    "cyberark",
 	"osint":       "osint",
-	"nist":        "nist",
-	"fedramp":     "fedramp",
-	"cmmc":        "cmmc",
-	"cissp":       "cissp",
-	"cism":        "cism",
-	"ccna":        "ccna",
-	"gdpr":        "gdpr",
-	"ccpa":        "ccpa",
-	"lgpd":        "lgpd",
-	"hipaa":       "hipaa",
-	"itar":        "itar",
-	"dfars":       "dfars",
-	// embedded, electronics and industrial automation
+	// embedded, electronics and industrial automation. "asic" (the Australian
+	// Securities and Investments Commission, on a large share of the AU finance
+	// postings SEEK brings in), "rtl" (right-to-left, in any i18n posting) and "cfd"
+	// (contract for difference) were strong here and are now phrase-routed.
 	"firmware": "firmware",
-	"asic":     "asic",
 	"cmos":     "cmos",
-	"rtl":      "rtl",
 	"uvm":      "uvm",
 	"hmi":      "hmi",
 	"modbus":   "modbus",
@@ -732,7 +721,6 @@ var wordAliases = map[string]string{
 	"simulink": "simulink",
 	// engineering analysis
 	"fea": "fea",
-	"cfd": "cfd",
 	// AEC / construction software
 	"bluebeam":     "bluebeam",
 	"microstation": "microstation",
@@ -746,6 +734,11 @@ var wordAliases = map[string]string{
 	// batch 4, gated half — declared here because ambiguousWords marks wordAliases
 	// keys, not canonicals. Each is a real product whose bare token is also ordinary
 	// English, so it tags only with a concrete technology beside it.
+	//
+	// "bedrock" and "ros" were here and are gone: each named a product the dictionary
+	// ALREADY carried under a different canonical ("aws bedrock" → aws-bedrock, "ros2"),
+	// so a posting matched both and the facet split its count between them. Gating does
+	// not help — a corroborated weak match still emits. The qualified forms cover them.
 	"bootstrap": "bootstrap",
 	"hibernate": "hibernate",
 	"unity":     "unity",
@@ -758,12 +751,10 @@ var wordAliases = map[string]string{
 	"bicep":     "bicep",
 	"athena":    "athena",
 	"aurora":    "aurora",
-	"bedrock":   "bedrock",
 	"parquet":   "parquet",
 	"loki":      "loki",
 	"prefect":   "prefect",
 	"flux":      "flux",
-	"ros":       "ros",
 }
 
 // ambiguousWords marks the wordAliases keys whose word-pass match is "weak": Parse
@@ -877,7 +868,7 @@ var ambiguousWords = map[string]bool{
 	// a solar "eclipse", "cut me some slack", "zoom in on the detail", "the notion
 	// that", the yoga "asana", a "puppet" show, the "bicep" a trainer works, Athena
 	// and Aurora and Loki as names, "parquet flooring" on a construction posting, a
-	// school "prefect", welding "flux core", and "ros" inside deaccented Spanish.
+	// school "prefect" and welding "flux core".
 	// Every one of them is unmistakable next to a named technology and noise without
 	// one, which is precisely what the corroboration gate decides.
 	"bootstrap": true,
@@ -892,12 +883,10 @@ var ambiguousWords = map[string]bool{
 	"bicep":     true,
 	"athena":    true,
 	"aurora":    true,
-	"bedrock":   true,
 	"parquet":   true,
 	"loki":      true,
 	"prefect":   true,
 	"flux":      true,
-	"ros":       true,
 }
 
 // phraseAlias is a punctuated or multi-word term matched against the normalized
@@ -1089,7 +1078,9 @@ var engineeringPhraseAliases = []phraseAlias{
 	{"azure data factory", "azure-data-factory"},
 	{"sales cloud", "sales-cloud"},
 	{"salesforce marketing cloud", "salesforce-marketing-cloud"},
-	{"sap s4hana", "sap-s4hana"}, {"s/4hana", "sap-s4hana"},
+	// No {"sap s4hana"}: the bare "s4hana" alias declared with the mined batch below
+	// matches inside it, so the two-word form is dead weight.
+	{"s/4hana", "sap-s4hana"},
 	{"sap mm", "sap-mm"},
 	{"siemens nx", "siemens-nx"},
 	{"premiere pro", "premiere-pro"},
@@ -1203,15 +1194,36 @@ var engineeringPhraseAliases = []phraseAlias{
 	// name is the only safe route.
 	{"palo alto networks", "palo-alto-networks"},
 	{"juniper networks", "juniper"}, {"junos", "juniper"},
-	// Compliance frameworks whose acronym alone is another thing entirely: "PCI" is the
-	// bus, "SOC" is a system-on-chip or a security operations centre, "ISO" is the
-	// organisation (and a camera setting). The versioned spelling is unambiguous.
+	// Compliance frameworks and security certifications. The acronyms are coined, so
+	// tagging them was never the risk — VOUCHING was. A strong match lifts the
+	// corroboration gate off every weak word in the same text, and these appear in the
+	// prose of postings that are not technical at all: "HIPAA training required" is on
+	// most of a healthcare catalogue, ISO 9001 on most of a manufacturing one. As word
+	// aliases they turned a nurse's "pick up the slack" into `slack`. They are phrases
+	// now, and every canonical below is listed in nonCorroboratingPhrases.
+	//
+	// The privacy and trade-control regimes sit in the PROFESSIONAL list further down
+	// instead: a posting whose only match is HIPAA or GDPR is a compliance role, and
+	// HasEngineering must not read it as an engineering one.
+	{"nist", "nist"}, {"fedramp", "fedramp"}, {"cmmc", "cmmc"},
+	{"cissp", "cissp"}, {"cism", "cism"}, {"ccna", "ccna"},
+	// "PCI" alone is the bus, "SOC" a system-on-chip or a security operations centre,
+	// "ISO" the organisation (and a camera setting) — the versioned spelling is what
+	// disambiguates each of these.
 	{"pci dss", "pci-dss"},
 	{"soc2", "soc-2"},
 	{"iso 9001", "iso-9001"}, {"iso9001", "iso-9001"},
 	{"iso 13485", "iso-13485"},
 	{"iso 26262", "iso-26262"},
 	{"as9100", "as9100"},
+	// Silicon and simulation terms whose bare acronym belongs to another industry
+	// this catalogue carries in bulk: ASIC is the Australian Securities and Investments
+	// Commission, RTL is right-to-left text (and React Testing Library), CFD is a
+	// contract for difference, and KVM is the switch in an IT-support closet.
+	{"asic design", "asic"}, {"asic verification", "asic"}, {"asic development", "asic"},
+	{"rtl design", "rtl"}, {"rtl verification", "rtl"}, {"rtl coding", "rtl"},
+	{"computational fluid dynamics", "cfd"}, {"cfd simulation", "cfd"}, {"cfd analysis", "cfd"},
+	{"kvm hypervisor", "kvm"}, {"kvm virtualization", "kvm"}, {"kvm virtualisation", "kvm"},
 	// Industrial automation. "PLC" is the British company suffix — "… PLC" closes a
 	// legal entity name in a third of UK postings — so the controller returns only
 	// through what an engineer actually writes beside it. "CAN" as a bare token is
@@ -1405,6 +1417,12 @@ var professionalPhraseAliases = []phraseAlias{
 	// Unambiguous single-token vendor names, same shape as quickbooks/bamboohr above.
 	{"zoominfo", "zoominfo"}, {"salesloft", "salesloft"},
 	{"veeva", "veeva"}, {"yardi", "yardi"},
+	// Privacy and trade-control regimes. They belong to this list rather than the
+	// engineering one for the reason the list exists: a posting whose only match is
+	// HIPAA is a healthcare compliance role, and HasEngineering reads an unrecognised
+	// vocabulary as engineering. All are non-corroborating — see below.
+	{"hipaa", "hipaa"}, {"gdpr", "gdpr"}, {"ccpa", "ccpa"}, {"lgpd", "lgpd"},
+	{"itar", "itar"}, {"dfars", "dfars"},
 }
 
 // nonCorroboratingPhrases are the phrase canonicals that tag on their own but do NOT
@@ -1447,6 +1465,29 @@ var nonCorroboratingPhrases = map[string]bool{
 	"cnc":          true,
 	"soldering":    true,
 	"oscilloscope": true,
+	// batch 4 — compliance frameworks and certifications. Naming a regime is evidence
+	// that the posting is SUBJECT to it, never that whoever fills it is technical: a
+	// nurse's posting carries HIPAA, an injection-moulding plant's carries ISO 9001,
+	// and a defence administrator's carries ITAR. As strong matches they lifted the
+	// gate off the words beside them and tagged `slack` on a nursing post.
+	"nist":      true,
+	"fedramp":   true,
+	"cmmc":      true,
+	"cissp":     true,
+	"cism":      true,
+	"ccna":      true,
+	"pci-dss":   true,
+	"soc-2":     true,
+	"iso-9001":  true,
+	"iso-13485": true,
+	"iso-26262": true,
+	"as9100":    true,
+	"hipaa":     true,
+	"gdpr":      true,
+	"ccpa":      true,
+	"lgpd":      true,
+	"itar":      true,
+	"dfars":     true,
 }
 
 // nonEngineeringBareCanonicals are non-engineering disciplines whose canonical also has a

--- a/internal/dict/skilltag/dictionaries_test.go
+++ b/internal/dict/skilltag/dictionaries_test.go
@@ -214,8 +214,14 @@ func TestParse_SalesAndSupportVocab(t *testing.T) {
 //
 // It is easy to do because the tiers are independent: a batch can add a phrase whose
 // canonical already exists as a word alias written the other way. That is exactly how
-// "hugging-face" landed beside "huggingface". Folding the separators out is enough to
-// catch it, and cheap enough to run on every canonical in the vocabulary.
+// "hugging-face" landed beside "huggingface". Folding the separators out catches that
+// shape across every tier that declares a canonical.
+//
+// It does NOT catch the other shape, where one canonical is a QUALIFIED form of
+// another ("bedrock" beside the pre-existing "aws-bedrock"), because a substring rule
+// cannot tell that apart from the many legitimate pairs the vocabulary already carries
+// — sap/sap-hana, azure/azure-synapse, aws/aws-glue. Those need a witness test on the
+// term itself, which is why the mined batches carry one per entry.
 func TestNoNearDuplicateCanonicals(t *testing.T) {
 	fold := strings.NewReplacer("-", "", "_", "", ".", "")
 	seen := map[string]string{}
@@ -232,5 +238,13 @@ func TestNoNearDuplicateCanonicals(t *testing.T) {
 	}
 	for _, p := range phraseAliases {
 		check("phraseAliases "+p.alias, p.canonical)
+	}
+	for tier, acr := range map[string]map[string]string{"sharedAcronyms": sharedAcronyms, "resumeAcronyms": resumeAcronyms} {
+		for surface, c := range acr {
+			check(tier+"["+surface+"]", c)
+		}
+	}
+	for surface, ca := range categoryScopedAcronyms {
+		check("categoryScopedAcronyms["+surface+"]", ca.canonical)
 	}
 }

--- a/internal/dict/skilltag/skilltag_test.go
+++ b/internal/dict/skilltag/skilltag_test.go
@@ -1269,7 +1269,7 @@ func TestParse_MinedBatch4(t *testing.T) {
 			[]string{"gdpr", "ccpa", "lgpd", "hipaa"}, nil},
 		{"industrial automation", "Controls engineer: Modbus and I2C links into the HMI.",
 			[]string{"modbus", "i2c", "hmi"}, nil},
-		{"silicon verification", "ASIC verification in UVM against the RTL, CMOS process.",
+		{"silicon verification", "ASIC verification in UVM, RTL design on a CMOS process.",
 			[]string{"asic", "uvm", "rtl", "cmos"}, nil},
 		{"aec software", "Estimator using Bluebeam, Navisworks and Procore.",
 			[]string{"bluebeam", "navisworks", "procore"}, nil},
@@ -1356,6 +1356,58 @@ func TestParse_MinedBatch4(t *testing.T) {
 		{"kms is kilometres", "Delivery driver covering 300 kms per shift.", nil, []string{"kms"}},
 		{"excel stays untagged", "Cashier: strong Excel and Microsoft Office skills.",
 			nil, []string{"excel", "microsoft-office"}},
+
+		// Witnesses the first cut of this batch shipped without. Each gated term needs
+		// both directions or the gate is untested in the one that matters.
+		{"eclipse the astronomy club", "Observatory guide: run the solar eclipse viewing evenings.",
+			nil, []string{"eclipse"}},
+		{"eclipse the ide", "Java developer working in Eclipse against a Maven build.",
+			[]string{"eclipse", "java"}, nil},
+		{"loki the given name", "Kennel assistant: Loki and Freya need walking twice daily.",
+			nil, []string{"loki"}},
+		{"loki the log store", "SRE stack: Grafana, Loki and Prometheus on Kubernetes.",
+			[]string{"loki", "grafana", "kubernetes"}, nil},
+		{"zoom the verb", "Photographer: zoom and focus by hand on a manual lens.", nil, []string{"zoom"}},
+		{"notion the noun", "Challenge the notion that retail cannot be premium.", nil, []string{"notion"}},
+		{"asana the tool", "Program manager tracking delivery in Asana beside our Python services.",
+			[]string{"asana", "python"}, nil},
+		{"prefect the orchestrator", "Data platform: Prefect flows loading into Snowflake.",
+			[]string{"prefect", "snowflake"}, nil},
+		{"flux the gitops tool", "Kubernetes platform with Flux for GitOps and Terraform for infra.",
+			[]string{"flux", "kubernetes", "terraform"}, nil},
+
+		// Compliance frameworks tag the posting they describe, and vouch for nobody.
+		// As strong word aliases they lifted the gate and tagged `slack` on a nurse.
+		{"hipaa does not corroborate", "Registered nurse. HIPAA training required. Pick up the slack on busy shifts.",
+			[]string{"hipaa"}, []string{"slack"}},
+		{"gdpr does not corroborate", "Care coordinator. GDPR duties, a flexible workday, and we value unity.",
+			[]string{"gdpr"}, []string{"unity", "workday"}},
+		{"iso 9001 does not corroborate", "Injection moulding supervisor under ISO 9001; sketch out the shift rota.",
+			[]string{"iso-9001"}, []string{"sketch"}},
+		{"security certifications still tag", "Security engineer: NIST 800-53, FedRAMP and CMMC; CISSP required.",
+			[]string{"nist", "fedramp", "cmmc", "cissp"}, nil},
+		{"hipaa alone is not engineering", "Medical records clerk handling HIPAA requests.",
+			[]string{"hipaa"}, nil},
+
+		// Acronyms that belong to another industry unless qualified.
+		{"asic the australian regulator", "Compliance officer: ASIC and AFSL reporting for our Sydney licence.",
+			nil, []string{"asic"}},
+		{"rtl the text direction", "Frontend i18n: RTL layouts for Arabic and Hebrew locales.",
+			nil, []string{"rtl"}},
+		{"cfd the trading product", "Trading desk: FX, CFD and equity derivatives for retail clients.",
+			nil, []string{"cfd"}},
+		{"cfd the simulation", "Thermal engineer running CFD simulation against MATLAB models.",
+			[]string{"cfd"}, nil},
+		{"kvm the closet switch", "IT support: rack the servers and use the KVM switch in the closet.",
+			nil, []string{"kvm"}},
+		{"kvm the hypervisor", "Linux virtualisation on the KVM hypervisor with Ansible.",
+			[]string{"kvm", "linux", "ansible"}, nil},
+
+		// Regressions for the two canonicals that were splitting a facet in two.
+		{"bedrock stays one canonical", "Deploy on AWS Bedrock behind Terraform.",
+			[]string{"aws-bedrock"}, []string{"bedrock"}},
+		{"ros stays one canonical", "Robotics engineer: ROS2 stack in C++.",
+			[]string{"ros2"}, []string{"ros"}},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/dict/skillvec/AGENTS.md
+++ b/internal/dict/skillvec/AGENTS.md
@@ -35,11 +35,18 @@ before that reuse would read the new skill's weight at the old skill's slot.
 quietly ranking as absent — it has no position until the registry is regenerated.
 
 ## Dimensions
-`Dimensions` (1024) is wider than the dictionary (749) so growth needs no
-re-declaration. It is NOT free: Meilisearch stores the declared width whether or not
-the tail is occupied, and at catalogue scale each 256 dimensions costs roughly 2.5 GB
-of index. Changing it forces a full rebuild, and until that rebuild finishes the
-index rejects every document carrying the new width.
+`Dimensions` (1024) is wider than the dictionary (866 after the 2026-08 mining batch,
+up from 749) so growth needs no re-declaration. It is NOT free: Meilisearch stores the
+declared width whether or not the tail is occupied, and at catalogue scale each 256
+dimensions costs roughly 2.5 GB of index. Changing it forces a full rebuild, and until
+that rebuild finishes the index rejects every document carrying the new width.
+
+**Headroom is now 158 positions, and the registry never gives one back** — a retired
+skill keeps its slot by design (see the rule above). One more batch the size of the
+last one crosses the cap, so a mining run that expects to add a hundred canonicals
+should check `RegistrySize()` against `Dimensions` BEFORE curating, not after: crossing
+it is not a bigger diff, it is a full reindex with a window where the live index
+rejects writes.
 
 ## Why there are no rarity weights
 An earlier version weighted each skill by how rare it is in the catalogue, so that


### PR DESCRIPTION
Stop compliance acronyms from vouching for the words beside them

A two-axis review of the mined batch (#2274, #2276) found the doctrine the file
already documents applied everywhere except where it mattered most.

A strong word alias does two things: it tags, and it lifts the corroboration gate
off every weak word in the same text. The batch reasoned that through for cnc and
soldering and then shipped the compliance vocabulary as strong word aliases, which
is the same mistake with a far bigger blast radius - HIPAA is on most of a
healthcare catalogue and ISO 9001 on most of a manufacturing one. Measured on the
tree before this change:

  "Registered nurse. HIPAA training required. Pick up the slack" -> hipaa, SLACK
  "Care coordinator. GDPR ... flexible workday; we value unity"  -> gdpr,  UNITY
  HasEngineering(["hipaa"])                                      -> TRUE

The third is its own defect: nonEngineeringCanonicals derives from
professionalPhraseAliases, so a compliance regime declared in the engineering half
made a medical-records clerk read as an engineering posting.

Every framework and certification is now a phrase listed in
nonCorroboratingPhrases - it tags the posting it describes and vouches for nobody.
The privacy and trade-control regimes (HIPAA, GDPR, CCPA, LGPD, ITAR, DFARS) sit in
the professional list; the security-practitioner ones (NIST, FedRAMP, CMMC, CISSP,
CISM, CCNA) stay engineering. Recall is unchanged; only the vouching is gone.

Four acronyms belonged to another industry outright and are phrase-routed:

- asic - the Australian Securities and Investments Commission, named across the AU
  finance postings SEEK brings in. Now "asic design"/"asic verification".
- rtl  - right-to-left in any i18n posting, and React Testing Library.
- cfd  - a contract for difference on a brokerage posting.
- kvm  - the switch in an IT-support closet, not the hypervisor.

Two canonicals were splitting a facet the way #2276 did, and the near-duplicate
guard could not see them because it only folds separators:

- bedrock, beside the pre-existing "aws bedrock" -> aws-bedrock
- ros, beside the pre-existing ros2

Both are removed; the qualified forms already covered them. That shape cannot be
caught by a substring rule without flagging sap/sap-hana and aws/aws-glue too, so
the test comment now says what the guard does and does not do, and the batch
carries a witness per entry instead. The guard itself now covers the three acronym
tiers it claimed to cover.

Also here: witnesses for the entries that shipped with none (eclipse, loki) or with
only one direction (zoom, notion, asana, prefect, flux); the {"sap s4hana"} phrase
this batch orphaned when it added the bare "s4hana" that matches inside it; and
skillvec/AGENTS.md, whose "wider than the dictionary (749)" was stale at 866 - 158
positions of headroom left, which is less than one more batch this size.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved skill recognition for compliance frameworks and security certifications, including HIPAA, GDPR, ISO 9001, and related standards.
  * Added more accurate handling of ambiguous technical acronyms and terms based on surrounding context.
  * Expanded skill dictionary coverage with additional canonical entries.

* **Bug Fixes**
  * Reduced false-positive tagging for ambiguous words and unrelated uses of technical acronyms.
  * Prevented duplicate or overlapping skill matches for several terms.

* **Documentation**
  * Updated dictionary capacity and maintenance guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->