### PR TITLE
Say what actually keeps the Snyk token from the dependency scan

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -15,6 +15,14 @@ name: snyk
 # failure nobody reads is how a real one gets waved through. The `credentials` job below
 # decides, and the scan skips rather than fails when there is nothing to authenticate with.
 #
+# WHICH IS ALMOST ALWAYS DEPENDABOT, NOT A MISSING SECRET. A run started from a Dependabot
+# pull request reads a SEPARATE store — repository secrets are not visible to it, only the
+# ones added under Settings › Secrets › Dependabot. `SNYK_TOKEN` is set as a repository
+# secret and the scan passes on an ordinary PR; it was empty on all thirteen open
+# Dependabot PRs at once, which is what made it look like the secret was missing. Adding
+# the same token to the Dependabot store is what restores coverage on exactly the PRs that
+# change a lockfile — the ones this scan exists for.
+#
 # That skip is deliberately LOUD: a warning annotation on the run and a note in the job
 # summary, both naming what went unscanned. A scanner that quietly opts out makes a commit
 # look examined, which is the same reason the gitleaks hook fails hard when its binary is
@@ -60,18 +68,20 @@ jobs:
             exit 0
           fi
           echo 'configured=false' >> "$GITHUB_OUTPUT"
-          echo '::warning title=Snyk did not run::No SNYK_TOKEN secret is set, so the JS lockfiles went unscanned.'
+          echo '::warning title=Snyk did not run::No SNYK_TOKEN was visible to this run, so the JS lockfiles went unscanned.'
           # Quoted heredoc: the body is Markdown for the summary, and nothing in it expands.
           cat >> "$GITHUB_STEP_SUMMARY" <<'SUMMARY'
           ## Snyk did not run
 
-          No `SNYK_TOKEN` secret is set on this repository, so the four JS lockfiles
-          (root, `design-system/`, `web/`, `extension/`) were **not scanned** for known
+          No `SNYK_TOKEN` was visible to this run, so the four JS lockfiles (root,
+          `design-system/`, `web/`, `extension/`) were **not scanned** for known
           vulnerabilities.
 
-          Go dependencies are unaffected: `govulncheck` covers those and needs no credential.
+          On a Dependabot pull request that usually does not mean the secret is missing:
+          such runs read their own store, so a repository secret is invisible to them.
+          Adding the token under **Settings › Secrets › Dependabot** restores the scan.
 
-          Set the secret to restore the scan.
+          Go dependencies are unaffected: `govulncheck` covers those and needs no credential.
           SUMMARY
 
   snyk:


### PR DESCRIPTION
The gate I just landed carries the wrong reason. It tells the reader no `SNYK_TOKEN` is set — and the secret has been set all along. The scan passes in full on an ordinary pull request; #2280's own run is the proof.

What is empty is the **Dependabot** side. A run started from a Dependabot PR reads a separate secret store, and repository secrets are not visible to it. So the token was missing on exactly the PRs that change a lockfile — which is every PR this scan exists for. Thirteen of them carried the red cross at once, which is what made "the secret is missing" the obvious-looking explanation.

The job summary now says that, and names the fix: add the same token under **Settings › Secrets › Dependabot**.

No behaviour changes — a run without a visible credential still skips loudly rather than failing. `actionlint` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified security scan diagnostics for automated dependency update runs.
  * Updated guidance for restoring scan coverage when the security token is unavailable.
  * Retained information about Go dependency coverage through `govulncheck`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->