### PR TITLE
Record why the API key hash is a bare SHA-256, where the scanner will look

### DIFF
--- a/internal/identity/auth/apikey.go
+++ b/internal/identity/auth/apikey.go
@@ -32,6 +32,13 @@ func GenerateAPIKey() (token, hash, prefix string, err error) {
 // high-entropy random, so a single SHA-256 is sufficient and keeps the lookup an
 // indexed, constant-work probe — unlike a salted password hash, which a low-entropy
 // password needs but which would forbid an indexed lookup.
+//
+// CodeQL reads this as password hashing (go/weak-sensitive-data-hashing, high) and
+// the finding is dismissed, not silenced: nothing but a 32-byte crypto/rand token
+// reaches here — GenerateAPIKey above, or the Bearer header in middleware.go — and
+// passwords take an entirely separate path through bcrypt in password.go. Re-check
+// that the two paths are still separate before dismissing it again; the rule is
+// right about what it looks for, only wrong about what this argument is.
 func HashAPIKey(token string) string {
 	sum := sha256.Sum256([]byte(token))
 	return hex.EncodeToString(sum[:])


### PR DESCRIPTION
CodeQL reports `go/weak-sensitive-data-hashing` on `HashAPIKey` at **high** severity, reading the argument as a password ([alert #11](https://github.com/strelov1/freehire/security/code-scanning/11)).

It is not a password. Nothing but a 32-byte `crypto/rand` token reaches that function — from `GenerateAPIKey` directly, or from the Bearer header in `middleware.go` — and passwords take an entirely separate path through bcrypt in `password.go`. For a 256-bit random secret a single SHA-256 is the right hash: there is nothing to brute-force, and a slow salted hash would forbid the indexed constant-work lookup every authenticated request depends on. That reasoning was already in the comment; what was missing is that a scanner disagrees.

The alert is now dismissed as a false positive on the repository — which is invisible from the source. The next person to open a high-severity finding on this line would redo the whole trace to reach the same answer, so the answer goes where they will be reading, along with what to re-check before dismissing it again: that the token path and the password path are still separate.

Comment only, no behaviour change. `gofmt`, `go vet`, `go build` and `go test ./internal/identity/auth/` all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification about API-key hashing security review requirements.
  * Documented the distinction between API-key hashing and password hashing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->