### PR TITLE
Record the host's units in git, and name the env split that hid a mail channel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,10 @@ Non-obvious:
   unlike the rest of the JS in this repo. See [extension/AGENTS.md](extension/AGENTS.md).
 - `internal/platform/db/` — **generated**; edit `internal/platform/db/queries/*.sql` and run `make sqlc`. The pre-commit hook and the `sqlc` CI job regenerate and diff, so a query edited without regenerating no longer ships the old Go with every check green. Both use `make sqlc`, which holds the only version pin — a second pin would be a second answer, and the drift between them would look exactly like stale code.
 - `services/pii-filter` — a standalone service, not a Go package.
+- `deploy/` — the production host's systemd units and operator scripts, recorded because the
+  machine was the only copy of them. **Nothing there deploys itself**: `release.sh` flips the
+  app and never touches a unit, so an edit is only half done until it is copied to the host.
+  `./deploy/check-drift.sh` reports what has moved apart. See [deploy/AGENTS.md](deploy/AGENTS.md).
 
 ## Commands
 
@@ -146,6 +150,7 @@ Each is self-contained and can be read independently.
 | **`internal/platform`** — the block itself: what it is, what it may import | [internal/platform/AGENTS.md](internal/platform/AGENTS.md) |
 | **SQL layer** (sqlc, queries, migrations) | [internal/platform/db/AGENTS.md](internal/platform/db/AGENTS.md) |
 | **Cron worker plumbing** (Main/Bootstrap, exit codes, heartbeat, corruption-tolerant scans) | [internal/platform/worker/AGENTS.md](internal/platform/worker/AGENTS.md) |
+| **Host configuration** (systemd units and timers, operator scripts, the two-file env split) | [deploy/AGENTS.md](deploy/AGENTS.md) |
 | **LLM client** (provider-agnostic wrapper, schema cache, streaming, attribution tags) | [internal/platform/llm/AGENTS.md](internal/platform/llm/AGENTS.md) |
 | **Sentry error tracking** (backend, workers, frontend — env-gated) | [internal/platform/observability/AGENTS.md](internal/platform/observability/AGENTS.md) |
 | **`internal/dict`** — the block itself: what it is, what it may import | [internal/dict/AGENTS.md](internal/dict/AGENTS.md) |

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -1,0 +1,55 @@
+# deploy
+
+The production host's systemd units and operator scripts, as they run on host-2. Not Go,
+not built, not imported by anything — this directory is a **record**, and the only reason
+it exists is that the machine was the sole copy.
+
+Snapshot taken 2026-09-01 from `/etc/systemd/system/freehire-*` and `/opt/freehire/bin/*.sh`.
+
+## What is here
+
+```
+systemd/   334 files — 46 .service, 283 .timer, 5 drop-in directories
+bin/        13 operator scripts (release, backups, alerting, ingest slotting)
+```
+
+`systemd/freehire-ingest@.service` is one template; the 255 `freehire-ingest@<board>.timer`
+files beside it are per-source schedules, which is why the timer count dwarfs everything
+else. Nothing generates them — a new board means a new timer file, by hand.
+
+## Always true
+
+- **Nothing here deploys itself.** `release.sh` builds and flips the app; it does not touch
+  units or the scripts in this directory. Changing a file here is half the job — the other
+  half is copying it to the host and running `systemctl daemon-reload`. Treat git as the
+  truth and the host as the copy, not the other way round, or this snapshot rots into
+  fiction within a month.
+- **The environment is split across two files, and the split is a trap.** Every unit reads
+  `/opt/freehire/.env`; the mail credentials (`NOTIFY_EMAIL_FROM` plus the SES keys) live
+  ONLY in `/opt/freehire/.env.notify`. A worker that sends mail and reads just the first
+  loses its email channel — and does not fail, because "channel not configured" is a
+  deliberate soft-skip. **The five workers that send mail are `notify`, `nudge`, `remind`,
+  `broadcast` and `onboarding`**, and each must read both files. `remind` and `nudge` did
+  not, from the day they shipped until 2026-09-01: 244 email reminders piled up unsent
+  across 43 people while every run exited 0 with `failed=0`. Neither env file is in git and
+  neither should be.
+- **A `.d/` drop-in beside a unit is how the host adds to it**, and both spellings are in
+  use here: `mail.conf` adds the env file above, `10-timeout.conf` and
+  `10-skip-if-reindexing.conf` adjust one setting. A drop-in's directives apply after the
+  unit's own, which is what makes `EnvironmentFile=` ordering come out right — the later
+  file wins on a key both define (`AWS_REGION` is in both).
+- **The `.bak` files on the host are not here on purpose.** There are a dozen dated copies
+  of `release.sh` alone. They are what a directory without version control grows instead of
+  history; this directory is the replacement, so they were dropped rather than imported.
+- **The binaries in `/opt/freehire/bin` are not here either** — `hire-api`, `logo-proxy`,
+  `meilisearch`, `rollup-views`, `seed-from-nginx` are compiled artifacts, and a committed
+  binary breaks `git pull` on the host.
+- **The scripts are shellcheck-clean and CI enforces it.** The `artifacts` job runs
+  shellcheck over every tracked `*.sh`, so these 13 are covered the moment they are
+  committed. The findings that came with them were all style-level and are suppressed
+  inline with the reason beside them — none was a defect.
+
+## Checking for drift
+
+`./deploy/check-drift.sh` diffs the host against this directory and prints what has moved
+apart. It reads; it never writes to either side.

--- a/deploy/bin/after-semantic-reindex.sh
+++ b/deploy/bin/after-semantic-reindex.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# One-shot: wait for the running semantic reindex (PID 2684382) to finish, then run the
+# facet reindex to completion (populates react_native/flutter/team_lead across the
+# whole catalogue), then restore the normal 3-hourly facet timer. Installed
+# 2026-07-07 after a green deploy aborted the in-flight facet reindex; user chose
+# semantic-first to avoid the Meili facet/semantic stacking deadlock.
+set -uo pipefail
+while kill -0 2684382 2>/dev/null; do sleep 60; done
+sleep 120  # let Meili finalize the semantic rebuild swap
+logger -t after-semantic-reindex "semantic PID 2684382 gone; starting facet reindex"
+systemctl start freehire-reindexw.service
+systemctl start freehire-reindexw.timer
+logger -t after-semantic-reindex "facet reindex kicked; timer restored"

--- a/deploy/bin/disk-alert.sh
+++ b/deploy/bin/disk-alert.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Disk-space alert for freehire (host-2).
+#
+# Checks the root filesystem and, at or above THRESHOLD_PCT used, sends a Telegram
+# message so a filling disk is caught BEFORE it takes down Postgres/Meili — a recurring
+# outage (see the disk-full incident notes: an orphan `jobs_rebuild` Meili index has
+# filled the disk to 100% several times). Read-only and best-effort: it never fails the
+# way a broken backup would, so it can run every 15 min without noise.
+#
+# Installed at /opt/freehire/bin/disk-alert.sh, driven by freehire-disk-alert.timer.
+# Telegram delivery reuses the freehire bot: TELEGRAM_BOT_TOKEN + DISK_ALERT_CHAT_ID from
+# /opt/freehire/.env. Alerting is OPT-IN via DISK_ALERT_CHAT_ID — if it is unset the check
+# still logs the usage but sends nothing, so installing the timer is harmless before the
+# channel is configured.
+set -uo pipefail
+
+MOUNT=/
+THRESHOLD_PCT=85
+ENV_FILE=/opt/freehire/.env
+
+log() { printf '%s %s\n' "$(date -u +%FT%TZ)" "$*"; }
+
+used=$(df --output=pcent "$MOUNT" | tail -1 | tr -dc '0-9')
+avail=$(df -h --output=avail "$MOUNT" | tail -1 | tr -d ' ')
+log "disk $MOUNT ${used}% used, ${avail} free (threshold ${THRESHOLD_PCT}%)"
+
+if [ "${used:-0}" -lt "$THRESHOLD_PCT" ]; then
+	exit 0
+fi
+
+# Above threshold — try to alert. Read only the two keys we need (never source the whole
+# env, which would execute arbitrary content).
+token=$(grep -E '^TELEGRAM_BOT_TOKEN=' "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2-)
+chat=$(grep -E '^DISK_ALERT_CHAT_ID=' "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2-)
+if [ -z "$token" ] || [ -z "$chat" ]; then
+	log "ALERT: disk ${used}% used but Telegram alert not configured (set DISK_ALERT_CHAT_ID in $ENV_FILE)"
+	exit 0
+fi
+
+text="⚠️ freehire $(hostname): disk ${MOUNT} at ${used}% used, ${avail} free. Free space before Postgres/Meili fail — check for an orphan jobs_rebuild Meili index."
+if curl -sS -m 10 -o /dev/null \
+	--data-urlencode "chat_id=${chat}" \
+	--data-urlencode "text=${text}" \
+	"https://api.telegram.org/bot${token}/sendMessage"; then
+	log "alert sent to Telegram chat ${chat}"
+else
+	log "alert send FAILED"
+fi
+exit 0

--- a/deploy/bin/ingest-slot.sh
+++ b/deploy/bin/ingest-slot.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Cap how many ingest runs may execute at once. Installed at /opt/freehire/bin/,
+# wrapped around every ingest ExecStart.
+#
+# Why: systemd fires ~137 independent per-file ingest timers staggered across the
+# hour, but nothing bounds how many run together. Once a board's crawl outlasts its
+# interval the runs stack up — measured 16 concurrent on a 16-vCPU box, driving
+# `/proc/pressure/io` full to 19% and making every API query slow. CPUWeight/IOWeight
+# on the unit only arbitrate against OTHER cgroups; they do not limit the fleet
+# against itself.
+#
+# How: a counting semaphore built from INGEST_SLOTS flock'd files. Each run grabs a
+# free slot and holds it for its lifetime (flock holds the lock for the child it
+# execs). A run that cannot get a slot within INGEST_SLOT_WAIT skips this cycle
+# rather than queueing into its own TimeoutStartSec and being killed mid-crawl —
+# ingest is idempotent and hourly, so the next tick picks the board up. Skips are
+# logged, never silent: a fleet that quietly stops crawling looks identical to a
+# healthy one.
+set -uo pipefail
+
+# 10, calibrated against the fleet rather than guessed. 8 was the first cut and ran
+# short: ~4 slots sit occupied by 30-50 min crawls, leaving only 4 for the ~124 boards
+# that finish in under a minute, so throughput settled near 104 runs/h against ~139/h of
+# demand and the tail kept skipping. Note the heavy boards now run to completion where
+# they used to be killed at TimeoutStartSec, so each costs more than the pre-change
+# measurement suggested. Seam if the tail still skips: give heavy boards their own small
+# pool so they cannot squat the shared one.
+SLOTS=${INGEST_SLOTS:-10}
+WAIT=${INGEST_SLOT_WAIT:-600}
+DIR=${INGEST_SLOT_DIR:-/run/freehire/ingest-slots}
+POLL=15
+BUSY=75 # flock --conflict-exit-code: distinguishes "slot taken" from a real failure
+
+[ $# -gt 0 ] || { echo "usage: ${0##*/} <command> [args...]" >&2; exit 64; }
+mkdir -p "$DIR" 2>/dev/null || true
+
+deadline=$((SECONDS + WAIT))
+while :; do
+	for ((i = 1; i <= SLOTS; i++)); do
+		flock -n -E "$BUSY" "$DIR/$i" "$@"
+		rc=$?
+		# Anything but BUSY means we held the slot and ran: propagate the real status.
+		[ "$rc" -ne "$BUSY" ] && exit "$rc"
+	done
+	if ((SECONDS >= deadline)); then
+		echo "ingest-slot: all $SLOTS slots busy for ${WAIT}s, skipping this cycle: $*" >&2
+		exit 0
+	fi
+	sleep "$POLL"
+done

--- a/deploy/bin/logo-cache-backup.sh
+++ b/deploy/bin/logo-cache-backup.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Nightly mirror of the logo cache to Hetzner Object Storage (host-2).
+#
+# `sync`, not a tar: cache entries are immutable, so a steady-state night uploads only
+# the logos resolved that day and moves almost nothing.
+#
+# This protects the logo.dev ALLOWANCE, not the data. The logos are re-derivable, just not
+# affordably all at once: a lost cache disk means ~294,000 upstream fetches, which is a
+# monthly cap spent in one restore.
+#
+# Installed at /opt/freehire/bin/logo-cache-backup.sh, driven by
+# freehire-logo-cache-backup.timer. Fails loudly (set -e) so a broken run shows up in
+# `systemctl --failed`.
+set -euo pipefail
+
+CACHE_DIR=${CACHE_DIR:-/var/cache/freehire-logo}
+S3_REMOTE=hz
+BACKUP_BUCKET=freehire-backups
+S3_PREFIX=logos
+
+# S3 credentials and the rclone remote, exactly as pg-backup.sh does it: read from the
+# 0600 env file and exported as RCLONE_CONFIG_HZ_* so no rclone.conf exists on disk.
+#
+# The exports are not optional decoration. Without them `hz` is an unknown remote and
+# EVERY run fails — which is loud, thanks to set -e, but leaves the cache this script
+# exists to protect unbacked-up.
+set -a
+# The env file is deployment state, not a checked-in script: shellcheck can neither
+# find it here nor learn anything from it there.
+# shellcheck disable=SC1090,SC1091
+. /opt/freehire/.env
+set +a
+: "${S3_ENDPOINT:?S3_ENDPOINT missing from /opt/freehire/.env}"
+: "${S3_ACCESS_KEY:?S3_ACCESS_KEY missing from /opt/freehire/.env}"
+: "${S3_SECRET_KEY:?S3_SECRET_KEY missing from /opt/freehire/.env}"
+# Region is the first endpoint label (hel1.your-objectstorage.com -> hel1); Hetzner
+# rejects writes if the location constraint disagrees.
+S3_REGION=$(printf '%s' "$S3_ENDPOINT" | sed -E 's#^https?://([^.]+)\..*#\1#')
+export RCLONE_CONFIG_HZ_TYPE=s3
+export RCLONE_CONFIG_HZ_PROVIDER=Other
+export RCLONE_CONFIG_HZ_ENDPOINT="$S3_ENDPOINT"
+export RCLONE_CONFIG_HZ_REGION="$S3_REGION"
+export RCLONE_CONFIG_HZ_LOCATION_CONSTRAINT="$S3_REGION"
+export RCLONE_CONFIG_HZ_ACCESS_KEY_ID="$S3_ACCESS_KEY"
+export RCLONE_CONFIG_HZ_SECRET_ACCESS_KEY="$S3_SECRET_KEY"
+
+if [ ! -d "$CACHE_DIR" ]; then
+  echo "logo-cache-backup: $CACHE_DIR does not exist" >&2
+  exit 1
+fi
+
+before=$(find "$CACHE_DIR" -type f | wc -l)
+rclone sync "$CACHE_DIR" "${S3_REMOTE}:${BACKUP_BUCKET}/${S3_PREFIX}" \
+  --transfers 16 --checkers 32 --stats-one-line
+echo "logo-cache-backup: mirrored $before entries to ${BACKUP_BUCKET}/${S3_PREFIX}"

--- a/deploy/bin/onboard-contributions.sh
+++ b/deploy/bin/onboard-contributions.sh
@@ -1,0 +1,293 @@
+#!/bin/bash
+# Daily contribution onboarding: drain link_contributions into a pull request.
+# Runs as a systemd oneshot off freehire-onboard-contributions.timer, like every
+# other freehire worker.
+#
+# The "contribute a board" flow records a pending row per contributed board and
+# never crawls anything — migration 0025 calls the status "the seam for the
+# deferred ingest worker". This script is that worker: it validates each
+# contributed board live, adds the ones that answer to sources/<source>.yml, and
+# opens a pull request. A human merges it.
+#
+# Environment (systemd supplies both files; a hand run reads them itself):
+#   /opt/freehire/.env                        DATABASE_URL, TELEGRAM_BOT_TOKEN
+#   /opt/freehire/env/onboard-contributions.env
+#       GH_TOKEN                  required, opens the pull request
+#       ANTHROPIC_API_KEY         required unless CLAUDE_CODE_OAUTH_TOKEN is set
+#       ANTHROPIC_BASE_URL        optional, when Claude Code runs through a proxy
+#       TELEGRAM_CHAT_ID          optional, reports the run
+#       REPO                      default strelov1/freehire
+#       WORK_DIR                  default /var/tmp/onboard-contributions
+set -uo pipefail
+
+for env_file in "${FREEHIRE_ENV:-/opt/freehire/.env}" \
+                "${ENV_FILE:-/opt/freehire/env/onboard-contributions.env}"; do
+  if [ -f "$env_file" ]; then
+    # shellcheck disable=SC1090
+    set -a && . "$env_file" && set +a
+  fi
+done
+
+REPO="${REPO:-strelov1/freehire}"
+WORK_DIR="${WORK_DIR:-/var/tmp/onboard-contributions}"
+# Pinned on purpose: Claude Code's own default is not among the models the proxy
+# in ANTHROPIC_BASE_URL serves, and it fails the run at the first prompt.
+CLAUDE_MODEL="${CLAUDE_MODEL:-claude-sonnet-4-6}"
+REPO_DIR="$WORK_DIR/repo"
+# Minute-resolution: a failed run leaves its branch pushed, and the next run must
+# not collide with it. The open-PR guard, not the branch name, prevents pile-up.
+STAMP="$(date -u +%Y%m%d-%H%M)"
+LABEL="onboard-contributions"
+
+log() { echo "$(date -u '+%Y-%m-%d %H:%M:%S') $*"; }
+
+# Reports to Telegram when configured, and is a no-op otherwise, so the script
+# is runnable by hand without a bot.
+notify() {
+  [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ] || return 0
+  curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+    --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+    --data-urlencode "text=$1" >/dev/null || log "WARN: Telegram notification failed"
+}
+
+die() {
+  log "ERROR: $1"
+  notify "Contribution onboarding FAILED: $1"
+  exit 1
+}
+
+# Same connection every other freehire worker uses.
+psql_hire() { psql "$DATABASE_URL" -tAF'|' -c "$1"; }
+
+# --- preflight ---------------------------------------------------------------
+
+for bin in claude git gh go curl psql; do
+  command -v "$bin" >/dev/null 2>&1 || die "$bin not found on PATH"
+done
+[ -n "${DATABASE_URL:-}" ] || die "DATABASE_URL is not set"
+[ -n "${GH_TOKEN:-}" ] || die "GH_TOKEN is not set"
+[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}${ANTHROPIC_API_KEY:-}" ] || die "no Claude credential is set"
+export GH_TOKEN
+
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR" || die "cannot create $WORK_DIR"
+cd "$WORK_DIR" || die "cannot enter $WORK_DIR"
+
+log "Cloning $REPO"
+git clone --depth 50 "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" repo >/dev/null 2>&1 \
+  || die "clone failed"
+
+# The service account has no git identity of its own, and commits are signed off,
+# so set one on the clone rather than globally on the host.
+git -C repo config user.name "${GIT_USER_NAME:-freehire-agent}"
+git -C repo config user.email "${GIT_USER_EMAIL:-strelov1@gmail.com}"
+
+# --- reconcile ---------------------------------------------------------------
+# A board counts as onboarded once it is in main, not when its PR opens. This is
+# the only write this script makes, and it only confirms what the repository
+# already says.
+
+psql_hire "SELECT id, source, board FROM link_contributions WHERE status='pending' AND source IS NOT NULL;" \
+  > "$WORK_DIR/pending.tsv" || die "cannot read the queue"
+
+: > "$WORK_DIR/merged_ids.txt"
+while IFS='|' read -r id source board; do
+  [ -n "${board:-}" ] || continue
+  [ -f "$REPO_DIR/sources/${source}.yml" ] || continue
+  if grep -qF "$board" "$REPO_DIR/sources/${source}.yml"; then
+    echo "$id" >> "$WORK_DIR/merged_ids.txt"
+  fi
+done < "$WORK_DIR/pending.tsv"
+
+if [ -s "$WORK_DIR/merged_ids.txt" ]; then
+  ids=$(paste -sd, "$WORK_DIR/merged_ids.txt")
+  psql_hire "UPDATE link_contributions SET status='onboarded' WHERE id IN (${ids});" >/dev/null \
+    || die "reconcile update failed"
+  log "Reconciled to onboarded: $ids"
+else
+  log "Nothing to reconcile"
+fi
+
+# --- guards ------------------------------------------------------------------
+
+gh label create "$LABEL" --repo "$REPO" --color 0e8a16 \
+  --description "Boards onboarded from the contribution queue" >/dev/null 2>&1 || true
+
+open_pr=$(gh pr list --repo "$REPO" --state open --label "$LABEL" --json url --jq '.[0].url // ""' 2>/dev/null)
+if [ -n "$open_pr" ]; then
+  # Without this guard a week of runs leaves seven branches editing one file.
+  log "An earlier pull request is still open: $open_pr"
+  notify "Contribution onboarding skipped: $open_pr is still open"
+  exit 0
+fi
+
+psql_hire "SELECT min(id), source, board, min(url), count(*) FROM link_contributions WHERE status='pending' AND source IS NOT NULL GROUP BY source, board ORDER BY min(created_at);" \
+  > "$WORK_DIR/queue_pending.tsv" || die "cannot read pending rows"
+psql_hire "SELECT id, url FROM link_contributions WHERE status='review' ORDER BY created_at;" \
+  > "$WORK_DIR/queue_review.tsv" || die "cannot read review rows"
+
+# The rejected pile is a lead list, not a graveyard, but it only changes when the
+# recognizer changes — re-triaging it daily buys nothing. Look at it only when
+# there is no fresh work, 20 rows at a time.
+: > "$WORK_DIR/queue_rejected.tsv"
+if [ ! -s "$WORK_DIR/queue_pending.tsv" ] && [ ! -s "$WORK_DIR/queue_review.tsv" ]; then
+  psql_hire "SELECT id, source, board, url FROM link_contributions WHERE status='rejected' ORDER BY created_at LIMIT 20;" \
+    > "$WORK_DIR/queue_rejected.tsv"
+  total=$(psql_hire "SELECT count(*) FROM link_contributions WHERE status='rejected';")
+  log "Re-triaging 20 of ${total} rejected rows"
+fi
+
+if [ ! -s "$WORK_DIR/queue_pending.tsv" ] && [ ! -s "$WORK_DIR/queue_review.tsv" ] && [ ! -s "$WORK_DIR/queue_rejected.tsv" ]; then
+  log "Queue is empty"
+  notify "Contribution onboarding: queue is empty, nothing to do"
+  exit 0
+fi
+
+log "Queue: $(wc -l < "$WORK_DIR/queue_pending.tsv") pending, $(wc -l < "$WORK_DIR/queue_review.tsv") review"
+
+# --- onboard the boards ------------------------------------------------------
+
+cd "$REPO_DIR" || die "cannot enter $REPO_DIR"
+git checkout -b "feat/onboard-contributed-boards-$STAMP" >/dev/null 2>&1 || die "cannot create the board branch"
+
+# Claude has no web tools here, only Bash/Read/Edit/Write, so every board is
+# validated with curl.
+claude -p --model "$CLAUDE_MODEL" --permission-mode acceptEdits --allowedTools Bash,Read,Edit,Write -- "$(cat <<PROMPT
+You are draining the crowdsourced board contribution queue. The repository is checked out in
+your current working directory, on a fresh branch off main.
+
+Input files, pipe-separated:
+- $WORK_DIR/queue_pending.tsv — recognized boards: id|source|board|url|count
+- $WORK_DIR/queue_review.tsv — unrecognized links: id|url
+- $WORK_DIR/queue_rejected.tsv — earlier rejections worth a second look: id|source|board|url
+
+For every row of queue_pending.tsv:
+
+1. Already onboarded? \`grep -F "<board>" sources/<source>.yml\`. If it is there, skip the
+   edit and record it as already present.
+2. Validate the board live with curl. Recipes by source:
+   - greenhouse: GET https://job-boards.greenhouse.io/<board> → 200 with jobs
+   - lever: GET https://api.lever.co/v0/postings/<board>?mode=json → non-empty array
+   - ashby: POST https://api.ashbyhq.com/posting-api/job-board/<board> → jobs
+   - recruitee and other subdomain ATS: GET https://<board> → 200 careers page
+   - zohorecruit: GET https://<board>/jobs/Careers → 200
+   - inhire: GET https://api.inhire.app/job-posts/public/pages with header X-Tenant: <board>
+   - workday (<host>/<site>): GET https://<host>/wday/cxs/<tenant>/<site>/jobs → 200
+   - anything else: read internal/sources/<source>.go, find the public listing URL and
+     required headers, and probe that.
+   0 jobs, 404 or a hard block means the board is dead: record it as rejected and do not add
+   it. When you cannot tell whether a board is live, reject it — a phantom board burns crawl
+   budget every cycle, and a real board can be contributed again.
+3. Resolve the company display name, cheapest signal first: og:site_name, then <title>, then
+   a name field in the adapter's JSON, then a humanized slug.
+4. Append it to sources/<source>.yml, following that file's own ordering and quoting. Most
+   files are flat append-only lists; zohorecruit.yml is sorted alphabetically by board, so
+   insert in position rather than at the end.
+
+       - company: <Display Name>
+         board: <board copied byte for byte from the queue>
+
+Copy \`board\` verbatim — never re-derive, re-case or trim it. Ingest dedups with
+\`external_id LIKE '<board>:%'\`, so any change silently doubles the board, and Workday site
+case is significant.
+
+Rules:
+- One bad board must not stop the run: note it and move to the next row.
+- Do not reformat unrelated entries and do not touch anything outside sources/.
+- Never commit or push. The script does that.
+
+Then write $WORK_DIR/pr_body.md — the pull request description:
+- a table of onboarded boards: source, board, company, how you validated it
+- the boards you turned down, with the reason
+- rows from queue_review.tsv you could not resolve, marked as needing a human
+- the SQL for whoever merges, so the queue matches the repository:
+  UPDATE link_contributions SET status='onboarded' WHERE id IN (...);
+  UPDATE link_contributions SET status='rejected' WHERE id IN (...);
+
+Finish with one line: onboarded=<n> rejected=<n> skipped=<n>
+PROMPT
+)" || die "the onboarding agent failed"
+
+if git diff --quiet -- sources; then
+  log "No board passed validation"
+  notify "Contribution onboarding: no contributed board passed validation, no pull request opened"
+  exit 0
+fi
+
+go build ./... || die "go build failed after the board edits"
+git add sources
+git commit -s -m "feat(sources): onboard contributed boards" >/dev/null || die "commit failed"
+branch=$(git rev-parse --abbrev-ref HEAD)
+git push origin HEAD >/dev/null 2>&1 || die "push failed"
+
+# --head is explicit because the shallow single-branch clone has no tracking ref
+# for a new branch, and gh refuses to guess one.
+pr_url=$(gh pr create --repo "$REPO" --head "$branch" \
+  --title "feat(sources): onboard contributed boards" \
+  --body-file "$WORK_DIR/pr_body.md" \
+  --label "$LABEL")
+# The run's deliverable is a pull request. Editing sources and failing to open
+# one must fail loudly, not report success.
+[ -n "$pr_url" ] || die "gh pr create returned no URL"
+log "Opened $pr_url"
+
+# --- at most one new adapter -------------------------------------------------
+# Boards and adapters go to separate pull requests: a two-line YAML list is
+# reviewed in a minute, a new Go adapter is code with tests, and one diff holding
+# both blocks the cheap half behind the expensive one.
+
+adapter_pr_url=""
+if [ -s "$WORK_DIR/queue_review.tsv" ]; then
+  git checkout -- . >/dev/null 2>&1
+  git checkout main >/dev/null 2>&1 || die "cannot switch back to main"
+  git checkout -b "feat/onboard-new-adapter-$STAMP" >/dev/null 2>&1 || die "cannot create the adapter branch"
+
+  claude -p --continue --model "$CLAUDE_MODEL" --permission-mode acceptEdits --allowedTools Bash,Read,Edit,Write -- "$(cat <<PROMPT
+The review queue holds links the recognizer could not map to a supported ATS. Most of them are
+a company's own careers page fronting an ATS we already crawl.
+
+1. Before fetching anything, settle them with one catalogue query. Guess company slugs from the
+   URLs in $WORK_DIR/queue_review.tsv and ask the database:
+
+       psql "\$DATABASE_URL" -c "SELECT company_slug, source, count(*) FROM jobs WHERE company_slug IN ('acme','globex') GROUP BY 1,2 ORDER BY 1;"
+
+   Anything already crawled needs no adapter. Note it in $WORK_DIR/adapter_notes.md.
+2. From what is left, pick at most ONE row that is a real, ingestable ATS with a public listing
+   endpoint, and write its adapter in internal/sources, following the closest existing adapter
+   in that package. Add its board file under sources/ and a test alongside the neighbouring
+   adapters' tests. Single-tenant pages, dead sites, login walls and aggregators are not
+   ingestable — leave them for a human.
+3. If nothing qualifies, write nothing and reply NO-ADAPTER.
+
+When you do write an adapter, also write:
+- $WORK_DIR/adapter_pr_title.txt — one line, e.g. feat(sources): add <ats> adapter
+- $WORK_DIR/adapter_pr_body.md — what the ATS is, the endpoint you measured, which contribution
+  row (id and URL) led here, and how you validated it
+
+Do not commit or push; the script does.
+PROMPT
+)" || log "WARN: the adapter agent failed, continuing"
+
+  if [ -f "$WORK_DIR/adapter_pr_title.txt" ]; then
+    title=$(cat "$WORK_DIR/adapter_pr_title.txt")
+    if go build ./... && go test ./internal/sources/...; then
+      git add -A
+      git commit -s -m "$title" >/dev/null
+      adapter_branch=$(git rev-parse --abbrev-ref HEAD)
+      git push origin HEAD >/dev/null 2>&1
+      adapter_pr_url=$(gh pr create --repo "$REPO" --head "$adapter_branch" --title "$title" \
+        --body-file "$WORK_DIR/adapter_pr_body.md")
+      log "Opened $adapter_pr_url"
+    else
+      log "WARN: the new adapter does not build or test clean, no pull request opened"
+    fi
+  fi
+fi
+
+# --- report ------------------------------------------------------------------
+
+summary="Contribution onboarding: $pr_url"
+[ -n "$adapter_pr_url" ] && summary="$summary
+adapter: $adapter_pr_url"
+notify "$summary"
+log "Done"

--- a/deploy/bin/pg-backup.sh
+++ b/deploy/bin/pg-backup.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Nightly PostgreSQL backup for freehire (host-2).
+#
+# Dumps every database in DATABASES with pg_dump custom format (-Fc), verifies
+# each archive is readable, uploads it to Hetzner Object Storage, then prunes
+# old copies (local: keep the newest LOCAL_KEEP per db; S3: drop objects older
+# than S3_MAX_AGE).
+#
+# Runs as root:
+#   - pg_dump connects as the postgres OS user (peer auth, no password),
+#   - S3 credentials come from /opt/freehire/.env (already 0600),
+#   - rclone is configured entirely from env vars (no persistent rclone.conf).
+#
+# Installed at /opt/freehire/bin/pg-backup.sh, driven by
+# freehire-pg-backup.timer at 03:00 UTC. Fails loudly (set -e) so a broken run
+# surfaces in `systemctl --failed`.
+set -euo pipefail
+
+# `mail` was the retired apply app's DB (dropped 2026-07-15); only `hire` remains.
+DATABASES=(hire)
+BACKUP_DIR=/var/backups/freehire
+S3_REMOTE=hz
+BACKUP_BUCKET=freehire-backups
+S3_PREFIX=pg
+# Keep only the newest local dump — S3 (below) is the authoritative backup with
+# S3_MAX_AGE history. On host-2's 301G disk, Meili (~128G) + PG (~70G) + a facet
+# reindex's ~2x transient index leave no room for a stack of ~19G dumps; three of
+# them once filled the disk mid-reindex (2026-07-20), aborting it on `unexpected
+# EOF`. One local copy is the fast-restore convenience; older history lives in S3.
+LOCAL_KEEP=1
+S3_MAX_AGE=30d
+ENV_FILE=/opt/freehire/.env
+
+log() { printf '%s %s\n' "$(date -u +%FT%TZ)" "$*"; }
+
+# --- S3 credentials + rclone env-config (no rclone.conf on disk) ------------
+# NOTE: .env defines its own S3_BUCKET (freehire-resumes) — that is why our
+# target is BACKUP_BUCKET, a distinct name sourcing cannot clobber.
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+set +a
+: "${S3_ENDPOINT:?S3_ENDPOINT missing from $ENV_FILE}"
+: "${S3_ACCESS_KEY:?S3_ACCESS_KEY missing from $ENV_FILE}"
+: "${S3_SECRET_KEY:?S3_SECRET_KEY missing from $ENV_FILE}"
+# Region is the first endpoint label (hel1.your-objectstorage.com -> hel1);
+# Hetzner rejects CreateBucket/writes if the location constraint disagrees.
+S3_REGION=$(printf '%s' "$S3_ENDPOINT" | sed -E 's#^https?://([^.]+)\..*#\1#')
+export RCLONE_CONFIG_HZ_TYPE=s3
+export RCLONE_CONFIG_HZ_PROVIDER=Other
+export RCLONE_CONFIG_HZ_ENDPOINT="$S3_ENDPOINT"
+export RCLONE_CONFIG_HZ_REGION="$S3_REGION"
+export RCLONE_CONFIG_HZ_LOCATION_CONSTRAINT="$S3_REGION"
+export RCLONE_CONFIG_HZ_ACCESS_KEY_ID="$S3_ACCESS_KEY"
+export RCLONE_CONFIG_HZ_SECRET_ACCESS_KEY="$S3_SECRET_KEY"
+
+install -d -m 0700 "$BACKUP_DIR"
+ts=$(date -u +%Y%m%dT%H%M%SZ)
+
+for db in "${DATABASES[@]}"; do
+  file="$BACKUP_DIR/${db}_${ts}.dump"
+  log "dumping $db -> $file"
+  # pg_dump runs as postgres (peer auth); root's shell owns the output file.
+  #
+  # UNTHROTTLED since 2026-08-20, deliberately reversing the previous nice -n 19 /
+  # ionice -c 3 (idle class). Idle-class I/O measured 5.4 MB/s and stretched the run
+  # to ~75 minutes; the throttle did not prevent the 2026-08-20 outage, it LENGTHENED
+  # the window in which the dump competed with autovacuum on a 96 GB jobs table. A
+  # short sharp run beats a long quiet one when the thing it collides with is another
+  # whole-table reader. The unit pauses the ingest fleet for the duration, which is
+  # what buys the headroom this used to buy by going slowly.
+  #
+  # What is still NOT throttled either way: the server-side sequential read runs in
+  # the postgres backend, not here, so client priority never governed it. The real
+  # fix remains a physical backup (pgBackRest/WAL), deferred.
+  #
+  # If this run's own dump/verify fails, remove its partial file immediately —
+  # unconditional, independent of the upload step below. Previously `set -e`
+  # exited before the retention step ever ran, so a failing dump (e.g. the
+  # 2026-08-11 TOAST corruption incident) left an ever-growing pile of large
+  # partial .dump files across multiple failed nights instead of just one.
+  trap 'rm -f -- "$file"' ERR
+  # zstd, not the -Fc default of gzip, and this is the change that actually made the
+  # run fast. Measured 2026-08-20 on this host: gzip pinned pg_dump at 98.5% of ONE
+  # core while I/O pressure sat at 3% — the dump was compression-bound, not
+  # disk-bound, the whole time. Removing the nice/ionice throttle the same night
+  # bought 5.4 -> 7.3 MB/s, because it was rationing a resource that was never
+  # scarce. zstd alone then took it to 24 MB/s, a 4.4x win over the throttled gzip.
+  #
+  # NO workers= here. pg_dump answers `compression option "workers" is not currently
+  # supported by pg_dump` and ignores it — the option exists in the shared compression
+  # parser, not in this tool. An earlier revision passed workers=4 and the warning was
+  # missed because the exit code was 0: the same mistake as trusting `pg_restore -l` on
+  # a truncated archive, reading the wrong signal for success. The speed was always
+  # single-threaded zstd.
+  #
+  # Requires PostgreSQL 16+ on BOTH sides: a zstd archive cannot be read by an older
+  # pg_restore. This host runs 18 and the S3 copy is restored by the same major, so
+  # the constraint is recorded rather than defended against.
+  # --- API watchdog -------------------------------------------------------------
+  #
+  # Suspend the dump whenever the live API stops answering; resume when it recovers.
+  # Better no backup tonight than a site that is down: a dump can be re-run at any
+  # hour, an outage cannot be un-served.
+  #
+  # WHY THE PROBE IS THE API AND NOT CPU/IO. On 2026-08-20 the site 500ed while CPU
+  # pressure read 0.00% full, I/O 0.87% full and load average 3.17 on 16 cores — the
+  # hardware was idle. The bottleneck was the API's connection pool: pgx defaults to
+  # roughly one connection per core, so once the dump made some queries slow, all ~16
+  # were held and EVERY request queued behind them into a 60s timeout. Resource gauges
+  # cannot see that. Whether the API answers is the only signal that can.
+  #
+  # WHY SIGSTOP AND NOT KILL. Killing pg_dump discards the whole run AND releases its
+  # transaction snapshot, which lets autovacuum immediately attack the backlog it was
+  # holding back; that burst is itself an outage on a 96 GB table (observed twice the
+  # same night). STOP/CONT leaves both the work and the snapshot exactly where they are.
+  #
+  # WHY A PAUSE BUDGET. A stopped pg_dump still holds its snapshot, so autovacuum
+  # cannot clean while it sits there — pausing forever trades a short outage for a
+  # slow-growing one. Past the budget the run gives up, removes its partial file via
+  # the ERR trap, and exits non-zero so the missing backup is visible rather than
+  # silently absent.
+  api_port=$(grep -oE 'freehire_api \{ server 127\.0\.0\.1:[0-9]+' /etc/nginx/snippets/freehire-upstream-active.conf | grep -oE '[0-9]+$')
+  probe_url="http://127.0.0.1:${api_port}/api/v1/jobs?limit=1"
+  PAUSE_BUDGET=900
+  watch_api() {
+    local dump_pid=$1 fails=0 paused=0 paused_total=0
+    while kill -0 "$dump_pid" 2>/dev/null; do
+      sleep 10
+      if curl -fsS --max-time 8 -o /dev/null "$probe_url" 2>/dev/null; then
+        fails=0
+        if [ "$paused" = 1 ]; then
+          kill -CONT "$dump_pid" 2>/dev/null && log "api recovered, resuming dump"
+          paused=0
+        fi
+      else
+        fails=$((fails + 1))
+        # Two consecutive misses, not one: a single slow probe is noise, and
+        # site-alert.sh uses the same two-strike rule for the same reason.
+        if [ "$fails" -ge 2 ] && [ "$paused" = 0 ]; then
+          kill -STOP "$dump_pid" 2>/dev/null && log "api not answering, dump SUSPENDED"
+          paused=1
+        fi
+        if [ "$paused" = 1 ]; then
+          paused_total=$((paused_total + 10))
+          if [ "$paused_total" -ge "$PAUSE_BUDGET" ]; then
+            log "api still down after ${paused_total}s suspended, abandoning this run"
+            kill -CONT "$dump_pid" 2>/dev/null
+            kill -TERM "$dump_pid" 2>/dev/null
+            return 1
+          fi
+        fi
+      fi
+    done
+  }
+  runuser -u postgres -- pg_dump -Fc --compress=zstd:3 "$db" > "$file" &
+  dump_pid=$!
+  watch_api "$dump_pid" &
+  watcher_pid=$!
+  wait "$dump_pid"; dump_rc=$?
+  kill "$watcher_pid" 2>/dev/null || true
+  if [ "$dump_rc" -ne 0 ]; then log "dump failed rc=$dump_rc"; rm -f -- "$file"; exit 1; fi
+
+  # Fail the run if the archive's table of contents is not readable.
+  pg_restore -l "$file" > /dev/null
+  log "verified $db dump ($(du -h "$file" | cut -f1))"
+  trap - ERR
+
+  # Local retention: keep the newest LOCAL_KEEP *verified* dumps for this db.
+  # Runs right after verification, before the S3 upload — an upload outage no
+  # longer stops local disk usage from being bounded.
+  # ls -t, not find: the retention rule is "the newest N", so the sort by mtime IS
+  # the operation. The names are this script's own timestamped dumps.
+  # shellcheck disable=SC2012
+  ls -1t "$BACKUP_DIR/${db}_"*.dump 2>/dev/null | tail -n +$((LOCAL_KEEP + 1)) \
+    | xargs -r rm -f --
+
+  dest="${S3_REMOTE}:${BACKUP_BUCKET}/${S3_PREFIX}/${db}/${db}_${ts}.dump"
+  log "uploading -> $dest"
+  rclone copyto "$file" "$dest"
+
+  # S3 retention: drop objects older than S3_MAX_AGE.
+  rclone delete --min-age "$S3_MAX_AGE" \
+    "${S3_REMOTE}:${BACKUP_BUCKET}/${S3_PREFIX}/${db}/"
+done
+
+log "backup complete"

--- a/deploy/bin/reindex-restore-wait.sh
+++ b/deploy/bin/reindex-restore-wait.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Waits for the detached from-pg semantic rebuild to finish, then restores the writers
+# that were paused for a clean fill (ingest timers + shards, enrich, embed supervisor).
+# Best-effort; runs regardless of the reindex exit status so services are never left
+# paused. Launched via systemd-run so it survives an ssh disconnect.
+LOG=/opt/freehire/reindex-restore.log
+log(){ printf '%s %s\n' "$(date -u +%FT%TZ)" "$*" >>"$LOG"; }
+log "waiter up; watching freehire-reindex-frompg"
+while systemctl is-active --quiet freehire-reindex-frompg 2>/dev/null; do sleep 60; done
+sleep 5
+log "reindex-frompg finished; restoring writers"
+# The enabled set is what timers.target.wants holds, and the names are systemd unit
+# names — no whitespace to mishandle. The unquoted expansion below is the point: the
+# list is passed to systemctl as separate arguments.
+# shellcheck disable=SC2010
+TIMERS=$(ls /etc/systemd/system/timers.target.wants/ 2>/dev/null | grep -E 'freehire-ingest.*\.timer')
+# Each start is logged on its own so a partial restore names which unit failed;
+# grouping the three into one redirect would lose that.
+# shellcheck disable=SC2086,SC2129
+systemctl start $TIMERS 2>>"$LOG"
+systemctl start freehire-enrich.timer 2>>"$LOG"
+systemctl start freehire-embed-supervisor.service 2>>"$LOG"
+active=$(systemctl list-units 'freehire-ingest@*.timer' --no-legend 2>/dev/null | grep -c ' active ')
+log "restored: ingest_timers_active=$active enrich=$(systemctl is-active freehire-enrich.timer) embed=$(systemctl is-active freehire-embed-supervisor.service)"

--- a/deploy/bin/release.sh
+++ b/deploy/bin/release.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# Blue/green release for freehire. Usage: release.sh [freehire]
+# Builds the INACTIVE color from its own checkout, health-checks, flips nginx,
+# rebuilds the worker binaries, and repoints the `hire-current` symlink (workers
+# follow the active release). Old color stays warm for rollback.
+set -euo pipefail
+app="${1:-freehire}"
+case "$app" in
+  freehire) snip=freehire-upstream; apisvc=freehire-api; websvc=freehire-web; dir=hire; bin=hire-api; b_api=8081; b_web=8083; g_api=8082; g_web=8084 ;;
+  *) echo "usage: release.sh [freehire]" >&2; exit 1 ;;
+esac
+S=/etc/nginx/snippets
+active=$(readlink -f "$S/${snip}-active.conf")
+case "$active" in
+  *-blue.conf)  new=green; aport=$g_api; wport=$g_web ;;
+  *-green.conf) new=blue;  aport=$b_api; wport=$b_web ;;
+  *) echo "release: cannot determine active color from $active" >&2; exit 1 ;;
+esac
+echo "[release:$app] target inactive color: $new (api:$aport web:$wport)"
+# The flip at the end of this script is a symlink swap, and nginx serves whatever
+# upstream the file behind that symlink defines. So a color whose conf names the OTHER
+# color's ports turns the whole release into a no-op: it builds, health-checks, flips,
+# prints Done, and keeps serving the old code.
+#
+# Not hypothetical. freehire-upstream-green.conf was overwritten with blue's ports
+# (8081/8083) on 2026-08-20 and stayed that way, so every release that targeted green
+# was silently discarded — and since this script always targets the INACTIVE color,
+# that was every OTHER release. Nothing downstream catches it: the health check curls
+# 127.0.0.1:$aport directly, which passes fine on a color nginx will never route to.
+#
+# Assert it here rather than after the build: five minutes of compiling for a flip that
+# cannot take traffic is the expensive way to find out. The canonical files live in
+# freehire-ops (provision/host2/nginx/${snip}-{blue,green}.conf) — the server had drifted
+# from them, which is the only reason this check has anything to say.
+newconf="$S/${snip}-${new}.conf"
+if ! grep -q "127\.0\.0\.1:${aport};" "$newconf" || ! grep -q "127\.0\.0\.1:${wport};" "$newconf"; then
+  echo "release: $newconf does not point at $new's own ports (api:$aport web:$wport)." >&2
+  echo "release: flipping to it would keep serving the other color. Refusing to build." >&2
+  echo "release: expected contents are in freehire-ops provision/host2/nginx/${snip}-${new}.conf" >&2
+  sed 's/^/release:   /' "$newconf" >&2
+  exit 1
+fi
+cd "/opt/freehire/src/${dir}-${new}"
+sudo -u freehire git pull --ff-only
+echo "[release:$app] building api + web ..."
+sudo -u freehire /usr/local/bin/go build -buildvcs=false -o "$bin" ./cmd/server
+# The design system is a `link:` dependency (freehire#1335) — a bare symlink into
+# ../design-system, so there is no copy to go stale. It was `file:` until 2026-07-31, which
+# COPIES the package into web's virtual store keyed by name+version, and its version is a
+# permanent 0.0.0: `pnpm install --frozen-lockfile` reused the copy from the previous release
+# however much the package changed. That failed loudly once (freehire#1300, a build error for
+# a theme.css the copy did not have) and silently once — the app shipped markup referencing
+# `bg-warning` against a design system defining no such token, so every caution badge on the
+# site rendered colourless, with a green release and a 200 from /health.
+#
+# The cost of a symlink is that pnpm does NOT install the linked package's dependencies with
+# web's. tailwind-variants, clsx, tailwind-merge and @lucide/svelte resolve out of
+# design-system's OWN node_modules, so it has to be installed first or the web build dies with
+# MODULE_NOT_FOUND. Loud, which is the whole trade.
+( cd design-system && sudo -u freehire corepack pnpm install --frozen-lockfile )
+# Source-map upload credentials for the Sentry vite plugin, if provisioned. Without them the
+# plugin skips the upload and the build still succeeds — Sentry then shows minified frames
+# (`t.$$render` at line 1) instead of real ones, which is the only thing this buys. The maps
+# stay published either way: freehire is open source, so there is nothing to withhold.
+#
+# The file is 0600 root and read here, not exported into the unit, so the token never reaches
+# the running app. `--preserve-env` rather than `env VAR=...` keeps it out of ps(1) too.
+SENTRY_BUILD_ENV=/opt/freehire/env/sentry-build.env
+if [ -r "$SENTRY_BUILD_ENV" ]; then
+	set -a
+	# shellcheck source=/dev/null
+	. "$SENTRY_BUILD_ENV"
+	set +a
+	echo "[release:$app] source maps will be uploaded to Sentry (${SENTRY_ORG:-?}/${SENTRY_PROJECT:-?})"
+fi
+# web migrated from npm to pnpm (DS Phase 2, freehire#1088): install/build via corepack,
+# which provisions the pnpm version pinned in web/package.json's packageManager field.
+( cd web && sudo -u freehire corepack pnpm install --frozen-lockfile &&
+	sudo -u freehire --preserve-env=SENTRY_ORG,SENTRY_PROJECT,SENTRY_AUTH_TOKEN corepack pnpm run build )
+# The web build can succeed-with-exit-0 and still leave no client bundle: on 2026-07-27 vite's
+# closeBundle rimraf of build/client/_app raced the precompress step, deleting all 2409 assets
+# and leaving only version.json.{gz,br}. Nothing below catches that — SSR renders fine without
+# client assets, so the node server starts and the health-check passes, and the broken color
+# took traffic. Gate on the bundle actually being there. The floor is deliberately far below a
+# real build (~2400 files) so it fires only on this kind of wipe, not on bundle-size drift.
+assets=$(find web/build/client/_app -type f 2>/dev/null | wc -l)
+if [ "$assets" -lt 100 ]; then
+  echo "release: web client build is empty ($assets files under web/build/client/_app) — refusing to release $new" >&2
+  echo "release: rm -rf web/build in that checkout and re-run; the live color is untouched" >&2
+  exit 1
+fi
+echo "[release:$app] web client bundle ok ($assets files)"
+# The second guard on the same build, for CONTENT rather than count. The one above catches a
+# bundle that is not there; this catches one built against a different copy of the design
+# system than the checkout holds — the failure the rm above prevents, asserted rather than
+# trusted, because the rm is a prevention and preventions rot. Every custom property the
+# checkout's token build defines has to appear in the CSS this build emitted; the token names
+# are read from the file rather than listed here, so it covers whatever ships next without
+# being touched. On 2026-07-31 exactly four were missing (--warning and its three siblings)
+# out of seventy-nine.
+if [ -z "$(find web/build/client/_app -name '*.css' -type f 2>/dev/null | head -1)" ]; then
+  echo "release: no stylesheet in the web bundle — refusing to release $new" >&2
+  exit 1
+fi
+# `grep -r --include` rather than a list of filenames in a variable: an unquoted list only
+# splits into arguments because this runs under bash, and it would stop working the day a
+# path has a space in it. One directory, no splitting.
+missing=$(grep -oE '^  --[a-z0-9-]+:' design-system/dist/tokens-light.css | tr -d ' :' |
+  while read -r t; do
+    grep -rqF --include='*.css' -- "$t:" web/build/client/_app || echo "$t"
+  done)
+if [ -n "$missing" ]; then
+  echo "release: the web bundle is missing design tokens this checkout defines:" >&2
+  # sed, not ${var//}: the substitution indents EVERY line of a multi-line list,
+  # which bash's parameter expansion cannot express (^ is not per-line there).
+  # shellcheck disable=SC2001
+  echo "$missing" | sed 's/^/  /' >&2
+  echo "release: the build did not see this checkout's design-system." >&2
+  echo "release: check that design-system/node_modules exists and dist/ is built; the live color is untouched" >&2
+  exit 1
+fi
+echo "[release:$app] web bundle carries the checkout's design tokens"
+if [ "$app" = freehire ]; then
+  echo "[release:$app] building worker binaries ..."
+  # Reference point for the completeness check below: anything the loop builds lands after it.
+  marker=$(mktemp) && trap 'rm -f "$marker"' EXIT
+  # Every binary a freehire-*.service ExecStarts from hire-current must be listed here, or
+  # its timer keeps firing the copy built by whichever release last happened to include it.
+  # reindex-companies was missing and ran 6-day-old code off its daily timer (2026-07-27).
+  # The backfill-* one-offs have no unit; they are listed so a manual repair run does not
+  # need a hand build on the box. harvest-orphans is the same class: it reads the catalogue
+  # for companies held only through aggregators and writes a candidate-board seed, so it has
+  # to run where DATABASE_URL is (freehire#1413). import-collections is the same class too —
+  # missing from this list until the us-h1b-sponsor rollout (2026-08-05) needed a hand build
+  # on the box mid-incident, exactly the failure mode this comment already warns about. Built
+  # here rather than by hand, because a hand-built binary silently disappears on the next
+  # release. import-yc and import-company-industries joined for the same reason: both write
+  # companies.industries through the curated dictionary, and a stale copy of either would
+  # write a vocabulary the current code no longer agrees with.
+  # onboarding, broadcast and backfill-slug-folded were found MISSING from this list on
+  # 2026-08-16, while the copy actually installed at /opt/freehire/bin/release.sh carried all
+  # three — the list on the box had been edited in place and the edit never came back to git.
+  # That is the same failure this comment block keeps warning about, arriving from the other
+  # direction: not a worker missing from prod, but a worker missing from the repo, so the next
+  # person to deploy this file from git would silently stop rebuilding three binaries.
+  # queue-metrics joined 2026-08-15 with the pipeline alerts. It matters more than most
+  # entries here: its own staleness IS an alert (pipeline-exporter-stopped), so a missing
+  # binary does not fail quietly — it pages, every ten minutes, forever.
+  # nudge, apple-revoke, auth-cleanup and capture-apply-form joined 2026-08-21, found by the
+  # check below on its first run. All four had enabled timers firing binaries this list had
+  # never built: nudge, apple-revoke and auth-cleanup were six days old, capture-apply-form
+  # sixteen. Their units were hand-installed on the box and never reached git either (#56) —
+  # the same half-provisioned move, arriving here as a stale binary instead of a missing file.
+  for w in migrate onboarding broadcast ingest enrich embed similar-backfill search-drain reindex reindex-companies import-collections import-yc import-company-industries queue-metrics tg-ingest tg-extract liveness notify remind nudge apple-revoke auth-cleanup capture-apply-form backfill-derive backfill-company-names backfill-descriptions backfill-application-events backfill-slug-folded backfill-duplicate-marker-owner merge-companies harvest-orphans recount-companies rollup-stats rollup-facets rollup-company rollup-views classify-mail resolve-url gmail-sync cal-sync mail-ingest hydrate-adzuna-description seed-adzuna-description-queue; do
+    sudo -u freehire /usr/local/bin/go build -buildvcs=false -o "$w" "./cmd/$w"
+  done
+  # Every binary a freehire-*.service starts from hire-current has to have just been built,
+  # or its timer keeps firing whatever the last release that happened to include it left
+  # behind. The list above is hand-kept, and the comment on it has been asking people to
+  # keep it in step since 2026-07-27 — asking is what failed. Derive the requirement from
+  # the units instead and say so out loud.
+  #
+  # `-nt` against a marker stamped at the top of this loop, not an mtime read: a binary the
+  # loop rebuilt is newer than the marker even when the source did not change, because `go
+  # build -o` rewrites the file. Reported and not fatal — a release that stops on this would
+  # be refusing to ship the API over a stale cron worker, which is the wrong trade — but
+  # loud, because the whole failure mode is that nothing said anything.
+  stale=$(grep -h "^ExecStart=" /etc/systemd/system/freehire-*.service 2>/dev/null |
+    grep -oE "/opt/freehire/src/hire-current/[a-z0-9-]+( |$)" | tr -d " " | sed "s|.*/||" |
+    sort -u |
+    while read -r b; do
+      [ -d "./$b" ] && continue   # a path, not a binary (ingest@ points at sources/)
+      if [ ! -x "./$b" ] || [ ! "./$b" -nt "$marker" ]; then echo "$b"; fi
+    done)
+  if [ -n "$stale" ]; then
+    echo "[release:$app] WARNING: a unit starts these from hire-current, but this release did not build them:" >&2
+    # Same per-line indent as above; see the note there.
+    # shellcheck disable=SC2001
+    echo "$stale" | sed "s/^/[release:$app]   /" >&2
+    echo "[release:$app]   their timers are firing whatever an older release left. Add them to the list in $0." >&2
+  fi
+  # mail-ingest is a long-lived daemon (not a timer): restart it so it picks up the
+  # freshly built binary from the repointed hire-current. Enabled once via provision.
+  systemctl try-restart freehire-mail-ingest.service 2>/dev/null || true
+fi
+# Schema BEFORE the code that reads it. This exists because on 2026-07-29 a release carried
+# a merged migration nobody had applied: sqlc reads every column of a table, so one missing
+# `jobs.ats_absent_at` returned 42703 on EVERY job read — the catalogue, the job pages, the
+# search — not just the feature that added it. Nothing in the pipeline noticed, because
+# /health does not touch jobs and the migration was somebody else's.
+#
+# The runner is idempotent (one transaction per file, recorded in schema_migrations under an
+# advisory lock), so running it on every release is a no-op when there is nothing new. It runs
+# BEFORE the new color starts, so that color never serves a request against an older schema.
+#
+# A migration failure aborts the release with the live color untouched: a half-migrated
+# database serving new code is the state this whole block exists to prevent.
+if [ "$app" = freehire ]; then
+  echo "[release:$app] applying migrations ..."
+  sudo -u freehire /usr/local/bin/go build -buildvcs=false -o migrate ./cmd/migrate
+  # The env file is deployment state, not a checked-in script — see logo-cache-backup.sh.
+  # shellcheck disable=SC1091
+  ( set -a; . /opt/freehire/.env; set +a; sudo -u freehire -E ./migrate ) || {
+    echo "[release:$app] migrations FAILED — not touching $new or the live color" >&2
+    exit 1
+  }
+fi
+systemctl restart "${apisvc}@${new}" "${websvc}@${new}"
+echo "[release:$app] health-checking $new ..."
+ok=
+for _ in $(seq 1 30); do
+  if curl -fsS "http://127.0.0.1:$aport/health" >/dev/null 2>&1 && curl -fsS -o /dev/null "http://127.0.0.1:$wport/" 2>/dev/null; then ok=1; break; fi
+  sleep 1
+done
+[ -n "$ok" ] || { echo "[release:$app] health-check FAILED on $new — NOT flipping"; exit 1; }
+# Facet smoke: a new filterable/facet attribute 500s until the Meili index is
+# reindexed to register it (e.g. #663's is_tech). /health can't see this — it needs
+# a real facet query. Probe the bare distribution plus the disjunctive+filtered path
+# the SPA hits, so shipping a facet without its reindex aborts here, not in prod.
+if [ "$app" = freehire ]; then
+  echo "[release:$app] facet smoke on $new ..."
+  fok=
+  for _ in $(seq 1 15); do
+    if curl -fsS -o /dev/null "http://127.0.0.1:$aport/api/v1/jobs/facets" 2>/dev/null \
+       && curl -fsS -o /dev/null "http://127.0.0.1:$aport/api/v1/jobs/facets?work_mode=remote&disjunctive=1" 2>/dev/null; then fok=1; break; fi
+    sleep 1
+  done
+  [ -n "$fok" ] || { echo "[release:$app] facet smoke FAILED on $new — a facet attr likely needs a reindex; NOT flipping"; exit 1; }
+fi
+ln -sf "$S/${snip}-${new}.conf" "$S/${snip}-active.conf"
+nginx -t && nginx -s reload
+if [ "$app" = freehire ]; then
+  ln -sfn "/opt/freehire/src/hire-${new}" /opt/freehire/src/hire-current
+  echo "[release:$app] workers now follow hire-${new} (hire-current repointed)"
+fi
+echo "[release:$app] flipped to $new; previous color warm for rollback"
+
+# Cloudflare holds anonymous HTML at the edge (infra/cloudflare/), so a flip that
+# changes what a page renders leaves the superseded copy being served until its TTL
+# runs out. Purge AFTER the flip, never before — a purge issued while the old colour
+# is still active only refills the cache from the old build.
+#
+# This must never fail the release. By this line the flip has already happened;
+# aborting here would report failure for a release that succeeded, and the worst
+# case of a missed purge is one TTL of stale HTML. Hence the explicit `set +e` — the
+# script runs under `set -euo pipefail`, where an unguarded non-zero curl would exit.
+#
+# `purge_everything` also evicts the hashed `/_app/immutable/*` chunks, which is not
+# the waste it looks like: the flip changed their hashes, so those entries are for
+# URLs the new colour will never serve, and nginx refills them off disk
+# (`location ^~ /_app/immutable/`), not through the Node SSR process.
+#
+# Only the token needs provisioning — the zone is not a secret and is the same one
+# `infra/cloudflare/` describes. Missing token is a SKIP, not a failure, so a host
+# that has not been given one still deploys.
+CF_ZONE_DEFAULT=41b0d0bd7b22a66a6d3211079c6fe2fe
+cf_env=/opt/freehire/.env
+cf_token=$(grep -E '^CLOUDFLARE_PURGE_TOKEN=' "$cf_env" 2>/dev/null | head -1 | cut -d= -f2- || true)
+cf_zone=$(grep -E '^CLOUDFLARE_ZONE_ID=' "$cf_env" 2>/dev/null | head -1 | cut -d= -f2- || true)
+cf_zone=${cf_zone:-$CF_ZONE_DEFAULT}
+if [ -z "${cf_token:-}" ]; then
+  echo "[release:$app] cloudflare purge SKIPPED (no CLOUDFLARE_PURGE_TOKEN in $cf_env)"
+else
+  set +e
+  cf_out=$(curl -sS --max-time 20 -X POST \
+    "https://api.cloudflare.com/client/v4/zones/${cf_zone}/purge_cache" \
+    -H "Authorization: Bearer ${cf_token}" \
+    -H 'Content-Type: application/json' \
+    --data '{"purge_everything":true}' 2>&1)
+  cf_rc=$?
+  set -e
+  if [ "$cf_rc" -eq 0 ] && printf '%s' "$cf_out" | grep -q '"success":true'; then
+    echo "[release:$app] cloudflare edge cache purged"
+  else
+    echo "[release:$app] cloudflare purge FAILED (rc=$cf_rc); release STANDS, edge may serve stale HTML for one TTL: $cf_out"
+  fi
+fi

--- a/deploy/bin/rollback.sh
+++ b/deploy/bin/rollback.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Instantly flip nginx back to the other (warm) color. Usage: rollback.sh [freehire|apply]
+#
+# The `apply` branch is provisioned ahead of the app itself: as of 2026-08-17
+# host-2 has no freehire-apply-api@/freehire-apply-web@ units and no
+# apply-upstream-*.conf snippets, so that argument fails at the first
+# systemctl. Harmless — the default is freehire, whose behaviour is unchanged —
+# but do not read the case arm as evidence that a second app is deployed.
+set -euo pipefail
+app="${1:-freehire}"
+case "$app" in
+  freehire) snip=freehire-upstream; apisvc=freehire-api;       websvc=freehire-web;       b_api=8081; g_api=8082 ;;
+  apply)    snip=apply-upstream;    apisvc=freehire-apply-api; websvc=freehire-apply-web; b_api=8085; g_api=8086 ;;
+  *) echo "usage: rollback.sh [freehire|apply]" >&2; exit 1 ;;
+esac
+S=/etc/nginx/snippets
+active=$(readlink -f "$S/${snip}-active.conf")
+case "$active" in
+  *-blue.conf)  target=green; aport=$g_api ;;
+  *-green.conf) target=blue;  aport=$b_api ;;
+  *) echo "rollback: cannot determine active color" >&2; exit 1 ;;
+esac
+systemctl is-active "${apisvc}@${target}" >/dev/null 2>&1 || systemctl start "${apisvc}@${target}" "${websvc}@${target}"
+curl -fsS "http://127.0.0.1:$aport/health" >/dev/null || { echo "rollback: target $target not healthy, aborting" >&2; exit 1; }
+ln -sf "$S/${snip}-${target}.conf" "$S/${snip}-active.conf"
+nginx -t && nginx -s reload
+echo "rolled back $app to $target"

--- a/deploy/bin/site-alert.sh
+++ b/deploy/bin/site-alert.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Site + memory + load alert for freehire (host-2).
+#
+# Every run checks four things and, on any failing, sends a Telegram message:
+#   1. https://freehire.me/health returns HTTP 200 (site up, DB reachable — see
+#      internal/handler/health.go, which itself pings Postgres).
+#   2. A real API endpoint answers 200 within API_TIMEOUT seconds — the check
+#      /health is too cheap to be (see the api check below).
+#   3. Available RAM is at or above MIN_FREE_PCT of total (catches an OOM
+#      before the kernel starts killing processes).
+#   4. 1-minute load average is under MAX_LOAD_PER_CORE x nproc (catches CPU
+#      starvation, which /health does not see — see the load check below).
+#
+# Installed at /opt/freehire/bin/site-alert.sh, driven by freehire-site-alert.timer
+# (every 2 min — faster than the 15-min disk-alert because a site outage is
+# user-visible immediately). Telegram delivery reuses the freehire bot:
+# TELEGRAM_BOT_TOKEN + SITE_ALERT_CHAT_ID from /opt/freehire/.env. Alerting is
+# OPT-IN via SITE_ALERT_CHAT_ID — if unset the check still logs, so installing
+# the timer is harmless before the channel is configured.
+#
+# State-debounced: at a 2-min cadence, alerting on every run while a problem
+# persists would be noise. A state file remembers the last status per check
+# and only sends on a transition (bad→worse, or back to ok) plus one reminder
+# every REMINDER_EVERY runs while still bad.
+set -uo pipefail
+
+URL=https://freehire.me/health
+# The endpoint the site is useless without, requested the way a visitor's browser
+# requests it: through Cloudflare, so an edge failure counts as an outage here.
+# limit=1 keeps it cheap enough to run every 2 minutes.
+API_URL='https://freehire.me/api/v1/jobs?limit=1'
+API_TIMEOUT=10
+MIN_FREE_PCT=10
+# Tenths of a core, per core: 20 means "alert once load1 reaches 2x nproc".
+# The 2026-08-16 outage sat at 28-30 on 16 cores, so 1.5x (24) looked like the
+# obvious threshold — until measurement: a normal night of ingest fan-out plus
+# a running embed backfill already carries 23-24. At 1.5x this alert would page
+# for healthy work, and an alert that cries wolf is worse than none.
+#
+# Raising it costs less coverage than it looks. Load is the coarse signal here;
+# the api check above is the precise one, because it measures the damage rather
+# than a cause — during that outage it would have tripped on the very first run
+# (61s against a 10s deadline) while load was still climbing.
+MAX_LOAD_PER_CORE_X10=20
+ENV_FILE=/opt/freehire/.env
+STATE_FILE=/run/freehire-site-alert.state
+REMINDER_EVERY=10 # ~20 min at a 2-min cadence
+
+log() { printf '%s %s\n' "$(date -u +%FT%TZ)" "$*"; }
+
+token=$(grep -E '^TELEGRAM_BOT_TOKEN=' "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2-)
+chat=$(grep -E '^SITE_ALERT_CHAT_ID=' "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2-)
+
+send() {
+	local text=$1
+	if [ -z "$token" ] || [ -z "$chat" ]; then
+		log "ALERT (not sent, SITE_ALERT_CHAT_ID unset): $text"
+		return
+	fi
+	if curl -sS -m 10 -o /dev/null \
+		--data-urlencode "chat_id=${chat}" \
+		--data-urlencode "text=${text}" \
+		"https://api.telegram.org/bot${token}/sendMessage"; then
+		log "alert sent to Telegram chat ${chat}: $text"
+	else
+		log "alert send FAILED: $text"
+	fi
+}
+
+# key=count, one per check, e.g. "site=3 api=0 mem=0 load=0". A key absent from
+# an older state file starts at 0 via check()'s default, so adding a check needs
+# no migration and no wiping of /run.
+read -r -a prev_state < <(cat "$STATE_FILE" 2>/dev/null || echo "site=0 api=0 mem=0 load=0")
+declare -A count
+for kv in "${prev_state[@]}"; do count[${kv%%=*}]=${kv##*=}; done
+
+# min_n delays the first alert until the check has failed that many runs in a
+# row. Defaults to 1 (alert immediately); the load check raises it, because a
+# reindex or an ingest fan-out spikes load for a minute and recovers on its own.
+# The recovery notice is gated on the same threshold, so a transient blip that
+# never alerted never announces itself as fixed either.
+check() {
+	local name=$1 bad=$2 bad_text=$3 ok_text=$4 min_n=${5:-1}
+	local n=${count[$name]:-0}
+	if [ "$bad" = "1" ]; then
+		n=$((n + 1))
+		if [ "$n" -eq "$min_n" ] || { [ "$n" -gt "$min_n" ] && [ $((n % REMINDER_EVERY)) -eq 0 ]; }; then
+			send "🔴 freehire $(hostname): ${bad_text} (failing ${n}x)"
+		fi
+	else
+		[ "$n" -ge "$min_n" ] && send "✅ freehire $(hostname): ${ok_text}"
+		n=0
+	fi
+	count[$name]=$n
+}
+
+# --- site check ---
+http_code=$(curl -sS -m 10 -o /dev/null -w '%{http_code}' "$URL" 2>/dev/null || echo "000")
+log "site $URL -> HTTP $http_code"
+site_bad=0
+[ "$http_code" != "200" ] && site_bad=1
+check site "$site_bad" "site down: ${URL} returned HTTP ${http_code}" "site back up: ${URL} returned HTTP 200"
+
+# --- real-endpoint check ---
+# Why /health is not enough: it is a trivial handler, so it answers 200 in
+# milliseconds under conditions where the site is unusable. On 2026-08-16 it
+# stayed green for hours while /api/v1/jobs took 61s and Cloudflare turned that
+# into 520s for every visitor. This check requests what the site actually needs
+# and treats slow as down — curl's -m turns a timeout into code 000, so the
+# deadline needs no separate comparison.
+#
+# It goes through Cloudflare deliberately. That covers one more failure mode than
+# a loopback probe (an edge or DNS fault the box itself cannot see) at the cost
+# of one: an outage of Cloudflare alone will page us. That trade is right for a
+# site whose visitors all arrive through the edge.
+api_read=$(curl -sS -m "$API_TIMEOUT" -o /dev/null -w '%{http_code} %{time_total}' "$API_URL" 2>/dev/null || echo "000 ${API_TIMEOUT}")
+api_code=${api_read%% *}
+api_time=${api_read##* }
+log "api ${API_URL} -> HTTP ${api_code} in ${api_time}s (timeout ${API_TIMEOUT}s)"
+api_bad=0
+[ "$api_code" != "200" ] && api_bad=1
+check api "$api_bad" \
+	"API failing: ${API_URL} returned HTTP ${api_code} after ${api_time}s (000 = no answer within ${API_TIMEOUT}s). /health may still be green — it is too cheap to prove the site works" \
+	"API back: ${API_URL} returned HTTP 200 in ${api_time}s" \
+	2
+
+# --- memory check ---
+mem_total=$(awk '/^MemTotal:/{print $2}' /proc/meminfo)
+mem_avail=$(awk '/^MemAvailable:/{print $2}' /proc/meminfo)
+free_pct=$((mem_avail * 100 / mem_total))
+log "memory ${free_pct}% available (threshold ${MIN_FREE_PCT}%)"
+mem_bad=0
+[ "$free_pct" -lt "$MIN_FREE_PCT" ] && mem_bad=1
+check mem "$mem_bad" "low memory: only ${free_pct}% RAM available" "memory back to normal: ${free_pct}% RAM available"
+
+# --- load check ---
+# The blind spot this closes: /health is a trivial handler, so it answers 200
+# long after the box has run out of CPU to serve real traffic. On 2026-08-16 a
+# forgotten embed backfill held a locally-run TEI container at ~7 of 16 cores
+# for two days; /health stayed green while /api/v1/jobs took 61s and Cloudflare
+# returned 520. Load average is the signal that saw it — coarsely; see
+# MAX_LOAD_PER_CORE_X10 for why it is set where it is.
+#
+# Compared in hundredths because /proc/loadavg is fractional and bash has no
+# floats. Alerts only after 2 consecutive runs (~4 min) — see check()'s min_n.
+cores=$(nproc)
+load1_x100=$(awk '{printf "%d", $1 * 100}' /proc/loadavg)
+load_limit_x100=$((cores * MAX_LOAD_PER_CORE_X10 * 10))
+load1=$(awk '{print $1}' /proc/loadavg)
+log "load ${load1} over ${cores} cores (threshold $(awk -v c="$cores" -v m="$MAX_LOAD_PER_CORE_X10" 'BEGIN{printf "%.1f", c * m / 10}'))"
+load_bad=0
+[ "$load1_x100" -ge "$load_limit_x100" ] && load_bad=1
+check load "$load_bad" \
+	"CPU starvation: load ${load1} on ${cores} cores — the site can still answer /health while real requests time out; check for a stray backfill (systemd-run units, docker ps)" \
+	"load back to normal: ${load1} on ${cores} cores" \
+	2
+
+{
+	for k in "${!count[@]}"; do printf '%s=%s ' "$k" "${count[$k]}"; done
+	printf '\n'
+} >"$STATE_FILE"
+
+exit 0

--- a/deploy/bin/skip-if-reindexing.sh
+++ b/deploy/bin/skip-if-reindexing.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# ExecCondition for freehire-reindex-companies.service.
+#
+# Meilisearch runs ONE serial task queue, so a companies rebuild started while the jobs facet
+# rebuild (freehire-reindexw) is mid-flight just queues behind it — it reads as a hang, and the
+# two swaps transiently hold ~2x the index on disk. Exiting non-zero here marks this cycle
+# SKIPPED (not failed), so the next daily firing is unaffected and nobody has to remember to
+# re-enable a timer they stopped by hand.
+#
+# Test ActiveState, NOT "systemctl is-active": reindexw is Type=oneshot, and a oneshot reports
+# "activating" for the WHOLE of its run and never reaches "active", so is-active returns
+# non-zero throughout and this guard would never fire.
+case "$(systemctl show -p ActiveState --value freehire-reindexw.service)" in
+	active|activating|reloading|deactivating) exit 1 ;;
+esac
+exit 0

--- a/deploy/bin/web-metrics.sh
+++ b/deploy/bin/web-metrics.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Web-tier Prometheus metrics for freehire (host-2), via the node_exporter
+# textfile collector.
+#
+# Prometheus scrapes node_exporter, Postgres, the Go API and Meilisearch. The SSR
+# web tier — the only component that has actually fallen over — had nothing, so
+# every incident was first noticed from the watchdog's Telegram message after it
+# had already restarted the process.
+#
+# Two exports, both the evidence those incidents were reconstructed from:
+#
+#   1. Accept-queue depth per colour. On a LISTEN socket, ss(8) reports the queue
+#      depth as Recv-Q and the configured backlog as Send-Q — not byte counts.
+#      Depth reaching the backlog is the exact condition web-watchdog.sh restarts
+#      on, and it lived only in that script's log. Both colours, because a
+#      capacity experiment against the idle one is invisible otherwise.
+#
+#   2. Response rates by status class, from nginx's access log. 504 is broken out
+#      of 5xx: here it means "timed out while CONNECTING to upstream", i.e. a full
+#      accept queue, which says something else entirely than an application 500.
+#
+# Latency is absent on purpose. It needs $upstream_response_time in log_format,
+# and internal/viewlog parses this log's combined format to count job views — not
+# worth breaking that for. Latency comes from perf/k6.
+#
+# Rates are gauges over the interval since the last run, not counters: a textfile
+# counter must stay monotonic across reboots, log rotations and this script's own
+# restarts, and a recomputed rate carries the same signal without that state.
+#
+# Installed at /opt/freehire/bin/web-metrics.sh, driven by
+# freehire-web-metrics.timer (every 15s, matching the watchdog it explains).
+set -uo pipefail
+
+S=/etc/nginx/snippets
+LOG=/var/log/nginx/access.log
+TEXTFILE_DIR=/var/lib/prometheus/node-exporter
+STATE_FILE=/run/freehire-web-metrics.state
+OUT="$TEXTFILE_DIR/web.prom"
+
+log() { printf '%s %s\n' "$(date -u +%FT%TZ)" "$*"; }
+
+[ -d "$TEXTFILE_DIR" ] || {
+	log "textfile dir $TEXTFILE_DIR missing — is node_exporter installed?"
+	exit 0
+}
+
+active=$(readlink -f "$S/freehire-upstream-active.conf" 2>/dev/null || true)
+case "$active" in
+	*-blue.conf) active_color=blue ;;
+	*-green.conf) active_color=green ;;
+	*) active_color=unknown ;;
+esac
+
+now=$(date +%s)
+
+# --- accept queues, both colours -------------------------------------------
+queue_lines=""
+for pair in "blue 8083" "green 8084"; do
+	# Splitting the pair into two positional arguments is the point here.
+	# shellcheck disable=SC2086
+	set -- $pair
+	color=$1 port=$2
+	line=$(ss -ltn "sport = :${port}" 2>/dev/null | awk 'NR==2')
+	# A colour with no LISTEN socket is not "queue 0" — it is not running, and a 0
+	# would read as healthy. Emit nothing and let the series go stale.
+	[ -z "$line" ] && continue
+	recvq=$(echo "$line" | awk '{print $2}')
+	sendq=$(echo "$line" | awk '{print $3}')
+	is_active=0
+	[ "$color" = "$active_color" ] && is_active=1
+	queue_lines="${queue_lines}freehire_web_accept_queue{color=\"${color}\"} ${recvq:-0}
+freehire_web_accept_queue_limit{color=\"${color}\"} ${sendq:-0}
+freehire_web_active{color=\"${color}\"} ${is_active}
+"
+done
+
+# --- response rates from the access log -------------------------------------
+# Only the bytes appended since the last run: the log grows by millions of lines
+# a day, so re-reading it would cost more than everything else here combined.
+prev=$(cat "$STATE_FILE" 2>/dev/null || echo "offset=0 ts=0")
+offset=$(echo "$prev" | grep -oE 'offset=[0-9]+' | cut -d= -f2)
+prev_ts=$(echo "$prev" | grep -oE 'ts=[0-9]+' | cut -d= -f2)
+offset=${offset:-0}
+prev_ts=${prev_ts:-0}
+
+size=$(stat -c %s "$LOG" 2>/dev/null || echo 0)
+# Shrunk since last run ⇒ logrotate moved the file underneath us. Start from the
+# new file's beginning; losing the rotated tail beats double-counting it.
+[ "$size" -lt "$offset" ] && offset=0
+
+elapsed=$((now - prev_ts))
+counts=""
+latency=""
+if [ "$prev_ts" -gt 0 ] && [ "$elapsed" -gt 0 ] && [ "$size" -gt "$offset" ]; then
+	# The slice is read TWICE — once for rates, once for latency — so it is spooled
+	# to a file rather than piped. It is one interval's worth of lines, a few hundred
+	# KB at this site's rate, and re-running tail|head over the log would be the more
+	# expensive of the two.
+	slice=$(mktemp) || slice=""
+	if [ -n "$slice" ]; then
+		trap 'rm -f "$slice"' EXIT
+		tail -c "+$((offset + 1))" "$LOG" 2>/dev/null | head -c "$((size - offset))" >"$slice"
+
+		counts=$(awk -v elapsed="$elapsed" '
+			# $9 is the status code in the combined log format. Requests still
+			# in flight and malformed lines do not match, and are skipped.
+			$9 ~ /^[0-9]{3}$/ {
+				total++
+				if ($9 == 504) { c["504"]++ }
+				else if ($9 >= 500) { c["5xx"]++ }
+				else if ($9 == 429) { c["429"]++ }
+				else if ($9 >= 400) { c["4xx"]++ }
+				else if ($9 >= 300) { c["3xx"]++ }
+				else { c["2xx"]++ }
+			}
+			END {
+				split("2xx 3xx 4xx 429 5xx 504", classes, " ")
+				for (i in classes) {
+					printf "freehire_nginx_responses_per_second{class=\"%s\"} %.3f\n", classes[i], c[classes[i]] / elapsed
+				}
+				printf "freehire_nginx_requests_per_second %.3f\n", total / elapsed
+			}' "$slice")
+
+		# --- latency ---------------------------------------------------------
+		# This is the thing the file's own header used to say was not worth having:
+		# "latency needs $upstream_response_time in log_format, and internal/viewlog
+		# parses this log". The objection turned out to be untrue — viewlog's pattern
+		# is anchored at ^ and not at $ — and is pinned by a test in that package.
+		#
+		# $request_time is read off the END of the line, not by field number. The
+		# referer and user-agent are quoted but contain spaces, so counting forward
+		# stops working after $body_bytes_sent, and $upstream_response_time before it
+		# can be a comma-separated list, so counting backward past it does not work
+		# either. The last field is the only one that can be addressed safely, which
+		# is why log_format puts $request_time there.
+		#
+		# A line that does not end in a number is simply skipped, which is what makes
+		# the deploy orderless: lines written before the format change carry no timing
+		# and contribute nothing rather than a zero.
+		#
+		# Split api/page because they answer different questions and have different
+		# costs. A page is an SSR render on ONE Node process and is what a visitor
+		# means by "the site is slow"; /api/ is the Go service. /_app/ is dropped
+		# entirely — hashed assets come off disk and would drag every percentile down
+		# with numbers no human waits for.
+		#
+		# Percentiles over the interval, as gauges, for the same reason the rates
+		# above are gauges: a textfile counter has to stay monotonic across reboots,
+		# rotations and this script's own restarts, and there is no histogram here to
+		# aggregate properly. These are honest for "how slow was the last 15 seconds"
+		# and must not be averaged across a longer window as if they were quantiles
+		# of a distribution.
+		latency=$(awk '
+			match($0, /[0-9]+\.[0-9]+$/) {
+				path = $7
+				if (path ~ /^\/_app\//) next
+				print ((path ~ /^\/api\//) ? "api" : "page"), substr($0, RSTART, RLENGTH)
+			}' "$slice" |
+			sort -k1,1 -k2,2n |
+			awk '
+				{ n[$1]++; v[$1, n[$1]] = $2 }
+				END {
+					split("0.5 0.9 0.99", qs, " ")
+					for (kind in n) {
+						for (i in qs) {
+							idx = int(n[kind] * (qs[i] + 0))
+							if (idx < 1) idx = 1
+							printf "freehire_nginx_request_seconds{kind=\"%s\",quantile=\"%s\"} %.3f\n", kind, qs[i], v[kind, idx]
+						}
+						printf "freehire_nginx_request_seconds{kind=\"%s\",quantile=\"1.0\"} %.3f\n", kind, v[kind, n[kind]]
+						printf "freehire_nginx_request_samples{kind=\"%s\"} %d\n", kind, n[kind]
+					}
+				}')
+	fi
+fi
+
+echo "offset=${size} ts=${now}" >"$STATE_FILE"
+
+# --- emit --------------------------------------------------------------------
+# Write-then-rename: the collector polls on its own schedule and would otherwise
+# be able to read a half-written file — same reason internal/worker/metrics.go does.
+tmp="${OUT}.tmp"
+{
+	echo "# HELP freehire_web_accept_queue Pending connections in the SSR listener's accept queue (ss Recv-Q on a LISTEN socket)."
+	echo "# TYPE freehire_web_accept_queue gauge"
+	echo "# HELP freehire_web_accept_queue_limit Configured backlog for that listener (ss Send-Q on a LISTEN socket)."
+	echo "# TYPE freehire_web_accept_queue_limit gauge"
+	echo "# HELP freehire_web_active Whether this colour is the one nginx currently proxies to."
+	echo "# TYPE freehire_web_active gauge"
+	printf '%s' "$queue_lines"
+	if [ -n "$counts" ]; then
+		echo "# HELP freehire_nginx_responses_per_second Responses per second by status class since the last scrape."
+		echo "# TYPE freehire_nginx_responses_per_second gauge"
+		echo "# HELP freehire_nginx_requests_per_second Total requests per second since the last scrape."
+		echo "# TYPE freehire_nginx_requests_per_second gauge"
+		printf '%s\n' "$counts"
+	fi
+	if [ -n "$latency" ]; then
+		echo "# HELP freehire_nginx_request_seconds Request duration over the last interval, as seen by nginx. kind=page is an SSR render, kind=api is the Go service; hashed assets are excluded. Quantiles are over the interval only and must not be averaged across a longer window."
+		echo "# TYPE freehire_nginx_request_seconds gauge"
+		echo "# HELP freehire_nginx_request_samples How many requests the quantiles beside it were computed from, so a percentile off three samples can be told from one off three thousand."
+		echo "# TYPE freehire_nginx_request_samples gauge"
+		printf '%s\n' "$latency"
+	fi
+} >"$tmp" && mv "$tmp" "$OUT"
+
+exit 0

--- a/deploy/bin/web-watchdog.sh
+++ b/deploy/bin/web-watchdog.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Web accept-queue watchdog for freehire (host-2).
+#
+# The SSR web process (Node/SvelteKit) has repeatedly wedged under concurrent
+# ingest+meilisearch+postgres load: its LISTEN socket's accept queue fills up,
+# the kernel silently drops new SYNs, and nginx reports "upstream timed out
+# while connecting" for every real page — while /health (a lightweight
+# endpoint served straight from the API) keeps answering 200, so a health-only
+# check never sees it. Recurred three times (2026-07-31 full outage,
+# 2026-08-05 partial, 2026-08-08 during a release) with the same signature.
+# A wedged process clears in ~2s once restarted, but only once a human
+# notices and runs it by hand — this replaces that hand with a timer.
+#
+# Checks the CURRENTLY ACTIVE color's web LISTEN socket: Recv-Q (the accept
+# queue depth, not bytes — see ss(8)) against its own configured backlog
+# (Send-Q, on a LISTEN socket). Recv-Q >= Send-Q means the queue is at
+# capacity right now. Requires CONSECUTIVE_BAD consecutive bad checks before
+# acting (one sample could be a benign burst) and a COOLDOWN between restarts
+# (a genuinely overloaded box restarting every 15s would never finish warming
+# up, and would turn a capacity problem into a crash-loop) — so this heals a
+# wedge without masking a real capacity problem into invisibility.
+#
+# Installed at /opt/freehire/bin/web-watchdog.sh, driven by
+# freehire-web-watchdog.timer (every 15s — the failure fills the queue within
+# about a minute, so the check has to be tighter than site-alert's 2 min).
+# Telegram delivery reuses the freehire bot: TELEGRAM_BOT_TOKEN +
+# SITE_ALERT_CHAT_ID from /opt/freehire/.env (same channel as site-alert.sh —
+# both are "something needed intervention" ops noise). Alerting is OPT-IN —
+# if unset, the watchdog still restarts and logs, it just doesn't notify.
+set -uo pipefail
+
+S=/etc/nginx/snippets
+ENV_FILE=/opt/freehire/.env
+STATE_FILE=/run/freehire-web-watchdog.state
+CONSECUTIVE_BAD=2 # ~30s of a full queue before acting
+COOLDOWN_SECS=300 # don't restart more than once per 5 min
+
+log() { printf '%s %s\n' "$(date -u +%FT%TZ)" "$*"; }
+
+active=$(readlink -f "$S/freehire-upstream-active.conf" 2>/dev/null || true)
+case "$active" in
+	*-blue.conf) color=blue port=8083 ;;
+	*-green.conf) color=green port=8084 ;;
+	*)
+		log "cannot determine active color from '$active' — skipping"
+		exit 0
+		;;
+esac
+
+line=$(ss -ltn "sport = :${port}" 2>/dev/null | awk 'NR==2')
+if [ -z "$line" ]; then
+	log "no LISTEN socket on :${port} (color=${color}) — skipping"
+	exit 0
+fi
+recvq=$(echo "$line" | awk '{print $2}')
+sendq=$(echo "$line" | awk '{print $3}')
+log "web@${color} :${port} Recv-Q=${recvq} Send-Q=${sendq}"
+
+# count=<consecutive bad checks> last=<unix ts of last restart, 0 = never>
+prev=$(cat "$STATE_FILE" 2>/dev/null || echo "count=0 last=0")
+count=$(echo "$prev" | grep -oE 'count=[0-9]+' | cut -d= -f2)
+last=$(echo "$prev" | grep -oE 'last=[0-9]+' | cut -d= -f2)
+count=${count:-0}
+last=${last:-0}
+now=$(date +%s)
+
+bad=0
+if [ "${sendq:-0}" -gt 0 ] && [ "${recvq:-0}" -ge "${sendq:-0}" ]; then
+	bad=1
+fi
+
+if [ "$bad" -eq 0 ]; then
+	echo "count=0 last=${last}" >"$STATE_FILE"
+	exit 0
+fi
+
+count=$((count + 1))
+echo "count=${count} last=${last}" >"$STATE_FILE"
+
+if [ "$count" -lt "$CONSECUTIVE_BAD" ]; then
+	log "web@${color} accept queue full (${count}/${CONSECUTIVE_BAD} consecutive) — waiting for confirmation"
+	exit 0
+fi
+
+if [ "$last" -gt 0 ] && [ $((now - last)) -lt "$COOLDOWN_SECS" ]; then
+	log "web@${color} accept queue still full but restarted $((now - last))s ago (< ${COOLDOWN_SECS}s cooldown) — skipping"
+	exit 0
+fi
+
+log "web@${color} accept queue full for ${count} consecutive checks — restarting freehire-web@${color}"
+systemctl restart "freehire-web@${color}"
+echo "count=0 last=${now}" >"$STATE_FILE"
+
+token=$(grep -E '^TELEGRAM_BOT_TOKEN=' "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2-)
+chat=$(grep -E '^SITE_ALERT_CHAT_ID=' "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2-)
+text="🛠️ freehire $(hostname): web@${color} accept queue was full (Recv-Q=${recvq}/Send-Q=${sendq}) — auto-restarted freehire-web@${color}. Site may have been briefly unreachable before this ran; check load (ingest/meilisearch/postgres) if this repeats."
+if [ -n "$token" ] && [ -n "$chat" ]; then
+	if curl -sS -m 10 -o /dev/null \
+		--data-urlencode "chat_id=${chat}" \
+		--data-urlencode "text=${text}" \
+		"https://api.telegram.org/bot${token}/sendMessage"; then
+		log "alert sent to Telegram chat ${chat}"
+	else
+		log "alert send FAILED"
+	fi
+else
+	log "ALERT (not sent, SITE_ALERT_CHAT_ID unset): ${text}"
+fi
+
+exit 0

--- a/deploy/check-drift.sh
+++ b/deploy/check-drift.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Reports where the production host and deploy/ have drifted apart.
+#
+# Nothing in deploy/ deploys itself, so an edit that never reached the host — or a
+# hotfix applied on the host and never committed — is invisible until something
+# breaks. This makes it one command:
+#
+#   ./deploy/check-drift.sh              # against the default host
+#   DEPLOY_HOST=root@1.2.3.4 ./deploy/check-drift.sh
+#
+# Read-only on both sides. Exits 1 when anything differs, so it can gate a check.
+set -euo pipefail
+
+HOST=${DEPLOY_HOST:-root@89.167.94.146}
+here=$(cd "$(dirname "$0")" && pwd)
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# The same two sets deploy/ holds: units without the host's .bak clutter, and the
+# shell scripts without the compiled binaries beside them.
+ssh -o ConnectTimeout=15 "$HOST" '
+  cd /etc/systemd/system && tar cz $(ls -d freehire-* | grep -v "\.bak") 2>/dev/null
+' > "$work/units.tgz"
+ssh -o ConnectTimeout=15 "$HOST" '
+  cd /opt/freehire/bin && tar cz $(ls *.sh | grep -v "\.bak")
+' > "$work/bin.tgz"
+
+mkdir -p "$work/systemd" "$work/bin"
+tar xzf "$work/units.tgz" -C "$work/systemd"
+tar xzf "$work/bin.tgz" -C "$work/bin"
+
+status=0
+for set in systemd bin; do
+  if diff -ru "$here/$set" "$work/$set" > "$work/$set.diff" 2>&1; then
+    echo "$set: in sync"
+  else
+    echo "$set: DRIFTED"
+    sed 's/^/  /' "$work/$set.diff"
+    status=1
+  fi
+done
+
+if [ "$status" -ne 0 ]; then
+  echo
+  echo "A '-' line is in git and not on the host; a '+' line is on the host and not in git."
+fi
+exit "$status"

--- a/deploy/systemd/freehire-api@.service
+++ b/deploy/systemd/freehire-api@.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=freehire API (%i)
+After=network.target postgresql.service meilisearch.service
+[Service]
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-%i
+EnvironmentFile=/opt/freehire/.env
+EnvironmentFile=/opt/freehire/env/hire-api.env
+EnvironmentFile=/opt/freehire/env/api-%i.env
+ExecStart=/opt/freehire/src/hire-%i/hire-api
+# Interactive traffic must outweigh the batch worker pool: cgroup weights sum across
+# siblings, so ten ingest units at CPUWeight=40 add up to 400 and starve a
+# default-weight service. 2026-07-31: the SSR accept queue filled and nginx timed
+# out connecting while node itself was healthy.
+CPUWeight=500
+IOWeight=500
+Restart=on-failure
+RestartSec=2
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/freehire-api@.service.d/mail.conf
+++ b/deploy/systemd/freehire-api@.service.d/mail.conf
@@ -1,0 +1,10 @@
+# Account mail (email verification, password reset) and referral pings.
+#
+# The shared /opt/freehire/.env carries apply mail-worker AWS keys scoped to S3+SQS in
+# eu-west-1, where SES is sandboxed and its production-access request was denied. This
+# drop-in loads the notify credentials AFTER it, so the API alone sends through
+# us-east-1 (production access, mail.freehire.me verified) while the other units keep
+# their region. Safe because the API build has exactly one AWS client: SES. Its S3 use
+# is MinIO-style static credentials, untouched by AWS_*.
+[Service]
+EnvironmentFile=/opt/freehire/.env.notify

--- a/deploy/systemd/freehire-apple-revoke.service
+++ b/deploy/systemd/freehire-apple-revoke.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=freehire worker: drain durable native Sign in with Apple token revocations
+After=network.target postgresql.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=10
+IOWeight=10
+ExecStart=/opt/freehire/src/hire-current/apple-revoke

--- a/deploy/systemd/freehire-apple-revoke.timer
+++ b/deploy/systemd/freehire-apple-revoke.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer: freehire-apple-revoke every minute
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=1min
+Persistent=true
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-auth-cleanup.service
+++ b/deploy/systemd/freehire-auth-cleanup.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=freehire worker: delete expired v2 auth attempts, exchange codes, and recent-auth proofs
+After=network.target postgresql.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=10
+IOWeight=10
+ExecStart=/opt/freehire/src/hire-current/auth-cleanup

--- a/deploy/systemd/freehire-auth-cleanup.timer
+++ b/deploy/systemd/freehire-auth-cleanup.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer: freehire-auth-cleanup every 5 min
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+Persistent=true
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-broadcast-ph-heads-up.service
+++ b/deploy/systemd/freehire-broadcast-ph-heads-up.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=freehire one-off campaign: Product Hunt heads-up (26 August launch)
+After=network.target postgresql.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+EnvironmentFile=/opt/freehire/.env.notify
+CPUWeight=10
+IOWeight=10
+# -max above the audience size so the whole list goes in one pass; the ledger makes
+# a repeat harmless, but a second pass would need a second schedule to exist.
+ExecStart=/opt/freehire/src/hire-current/broadcast -campaign ph-heads-up -max 900

--- a/deploy/systemd/freehire-broadcast-ph-heads-up.timer
+++ b/deploy/systemd/freehire-broadcast-ph-heads-up.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer: Product Hunt heads-up campaign, once, Monday 17 August 14:00 UTC
+[Timer]
+OnCalendar=2026-08-17 14:00:00 UTC
+Persistent=true
+AccuracySec=1min
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-cal-sync.service
+++ b/deploy/systemd/freehire-cal-sync.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=freehire worker: interview schedule sync from Google Calendar
+After=network.target postgresql.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+ExecStart=/opt/freehire/src/hire-current/cal-sync

--- a/deploy/systemd/freehire-cal-sync.timer
+++ b/deploy/systemd/freehire-cal-sync.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=timer: freehire-cal-sync
+[Timer]
+# Hourly. A calendar changes far less often than a mailbox fills, and the window is
+# +/-90 days on every run, so a missed hour costs nothing — the next run sees the same
+# meetings. Offset from the top of the hour so it does not start alongside gmail-sync.
+OnCalendar=*:20:00
+Persistent=true
+RandomizedDelaySec=120
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-capture-apply-form.service
+++ b/deploy/systemd/freehire-capture-apply-form.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=freehire worker: capture ATS application forms
+After=network.target postgresql.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+# Measured on prod 2026-08-02, first timer-driven run: 2490 captures in 361s at
+# concurrency 4 = 6.9/s, with 10 transient failures and none abandoned. (An earlier
+# 1.54/s reading was contaminated — it raced a manual drain for the same queue rows.)
+#
+# Concurrency came down from 4 to 2 after that run returned 136 rate-limit 429s from
+# Ashby; the drain is not in a hurry and a blocked crawl would cost far more.
+# 8000 per run is therefore ~20 minutes, leaving two thirds of an hourly window spare, so
+# a slow platform cannot make a run overrun its own schedule. The initial ~224k backlog
+# drains in a bit over a day; after that a run finishes in seconds, because only newly
+# ingested postings are ever queued.
+Environment=APPLY_FORM_MAX_PER_RUN=8000
+Environment=APPLY_FORM_CONCURRENCY=2
+Environment=APPLY_FORM_BATCH_SIZE=100
+CPUWeight=40
+IOWeight=40
+ExecStart=/opt/freehire/src/hire-current/capture-apply-form

--- a/deploy/systemd/freehire-capture-apply-form.timer
+++ b/deploy/systemd/freehire-capture-apply-form.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer: freehire-capture-apply-form
+[Timer]
+OnCalendar=*-*-* *:35:00
+Persistent=true
+RandomizedDelaySec=300
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-classify-mail.service
+++ b/deploy/systemd/freehire-classify-mail.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=freehire worker: email → application classification
+After=network.target postgresql.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+ExecStart=/opt/freehire/src/hire-current/classify-mail

--- a/deploy/systemd/freehire-classify-mail.timer
+++ b/deploy/systemd/freehire-classify-mail.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=timer: freehire-classify-mail
+[Timer]
+# Every 5 minutes: an idle run is nearly free (an empty-queue enqueue + claim, then
+# exit — an LLM call only fires when there are unclassified emails), so a tight cadence
+# keeps newly-synced mail sorted within minutes.
+OnCalendar=*:0/5:00
+Persistent=true
+RandomizedDelaySec=30
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-disk-alert.service
+++ b/deploy/systemd/freehire-disk-alert.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=freehire: disk-space alert (root fs, Telegram at >=85%)
+After=network-online.target
+Wants=network-online.target
+[Service]
+Type=oneshot
+# Runs as root: reads TELEGRAM_BOT_TOKEN + DISK_ALERT_CHAT_ID from /opt/freehire/.env (0600).
+ExecStart=/opt/freehire/bin/disk-alert.sh
+Nice=15
+IOSchedulingClass=idle

--- a/deploy/systemd/freehire-disk-alert.timer
+++ b/deploy/systemd/freehire-disk-alert.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer: freehire disk-space alert every 15 min
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=15min
+Persistent=true
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-embed-supervisor.service
+++ b/deploy/systemd/freehire-embed-supervisor.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=freehire semantic embed supervisor (keeps embed worker draining, cleans up at end)
+[Service]
+Type=simple
+ExecStart=/usr/bin/bash /opt/freehire/embed-supervisor.sh
+Restart=on-failure
+RestartSec=15
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/freehire-enrich.service
+++ b/deploy/systemd/freehire-enrich.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=freehire worker: LLM enrichment
+After=network.target postgresql.service meilisearch.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+ExecStart=/opt/freehire/src/hire-current/enrich

--- a/deploy/systemd/freehire-enrich.timer
+++ b/deploy/systemd/freehire-enrich.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer: freehire-enrich
+[Timer]
+OnCalendar=*:30:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-gmail-sync.service
+++ b/deploy/systemd/freehire-gmail-sync.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=freehire worker: Gmail ATS-inbox sync
+After=network.target postgresql.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+ExecStart=/opt/freehire/src/hire-current/gmail-sync

--- a/deploy/systemd/freehire-gmail-sync.timer
+++ b/deploy/systemd/freehire-gmail-sync.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=timer: freehire-gmail-sync
+[Timer]
+# Every 15 minutes: pull new recruiting mail; cmd/classify-mail (*/5) then sorts it.
+OnCalendar=*:0/15:00
+Persistent=true
+RandomizedDelaySec=60
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-hydrate-adzuna-description.service
+++ b/deploy/systemd/freehire-hydrate-adzuna-description.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=freehire worker: Adzuna full-description capture (adzuna_description_outbox)
+After=network.target postgresql.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+# Low and cautious on purpose: this is the one worker in the fleet that issues requests
+# to a third party's own website rather than a documented API, and the feasibility spike
+# never exercised sustained traffic from this host — see internal/sources/AGENTS.md
+# (adzunadesc). ADZUNA_DESCRIPTION_MAX_PER_RUN bounds how much of a run gets spent
+# finding out the hard way if that's wrong.
+CPUWeight=10
+IOWeight=10
+ExecStart=/opt/freehire/src/hire-current/hydrate-adzuna-description

--- a/deploy/systemd/freehire-hydrate-adzuna-description.timer
+++ b/deploy/systemd/freehire-hydrate-adzuna-description.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=timer: freehire-hydrate-adzuna-description every 30 min
+[Timer]
+# Queue-driven, so an empty queue costs nothing (fast exit) — this is the cadence, not a
+# rate limit. The real throttle is ADZUNA_DESCRIPTION_MAX_PER_RUN/CONCURRENCY (env), kept
+# conservative until a live run shows Adzuna tolerating the pace (see the .service file).
+OnBootSec=5min
+OnUnitActiveSec=30min
+Persistent=true
+RandomizedDelaySec=120
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-eightfold-shard@.service
+++ b/deploy/systemd/freehire-ingest-eightfold-shard@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=freehire ingest eightfold shard %i/4
+After=network.target postgresql.service meilisearch.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+TimeoutStartSec=3000
+ExecStart=/opt/freehire/bin/ingest-slot.sh /opt/freehire/src/hire-current/ingest /opt/freehire/src/hire-current/sources/eightfold.yml --shard=%i/4

--- a/deploy/systemd/freehire-ingest-eightfold-shard@1.timer
+++ b/deploy/systemd/freehire-ingest-eightfold-shard@1.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest eightfold shard 1/4
+[Timer]
+OnCalendar=*-*-* 00/4:50:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-eightfold-shard@2.timer
+++ b/deploy/systemd/freehire-ingest-eightfold-shard@2.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest eightfold shard 2/4
+[Timer]
+OnCalendar=*-*-* 01/4:50:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-eightfold-shard@3.timer
+++ b/deploy/systemd/freehire-ingest-eightfold-shard@3.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest eightfold shard 3/4
+[Timer]
+OnCalendar=*-*-* 02/4:50:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-eightfold-shard@4.timer
+++ b/deploy/systemd/freehire-ingest-eightfold-shard@4.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest eightfold shard 4/4
+[Timer]
+OnCalendar=*-*-* 03/4:50:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-join-shard@.service
+++ b/deploy/systemd/freehire-ingest-join-shard@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=freehire ingest join shard %i/5
+After=network.target postgresql.service meilisearch.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+TimeoutStartSec=3000
+ExecStart=/opt/freehire/bin/ingest-slot.sh /opt/freehire/src/hire-current/ingest /opt/freehire/src/hire-current/sources/join.yml --shard=%i/5

--- a/deploy/systemd/freehire-ingest-join-shard@1.timer
+++ b/deploy/systemd/freehire-ingest-join-shard@1.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest join shard 1/5
+[Timer]
+OnCalendar=*-*-* 00/5:20:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-join-shard@2.timer
+++ b/deploy/systemd/freehire-ingest-join-shard@2.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest join shard 2/5
+[Timer]
+OnCalendar=*-*-* 01/5:20:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-join-shard@3.timer
+++ b/deploy/systemd/freehire-ingest-join-shard@3.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest join shard 3/5
+[Timer]
+OnCalendar=*-*-* 02/5:20:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-join-shard@4.timer
+++ b/deploy/systemd/freehire-ingest-join-shard@4.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest join shard 4/5
+[Timer]
+OnCalendar=*-*-* 03/5:20:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-join-shard@5.timer
+++ b/deploy/systemd/freehire-ingest-join-shard@5.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest join shard 5/5
+[Timer]
+OnCalendar=*-*-* 04/5:20:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-oracle-shard@.service
+++ b/deploy/systemd/freehire-ingest-oracle-shard@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=freehire ingest oracle shard %i/4
+After=network.target postgresql.service meilisearch.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+TimeoutStartSec=3000
+ExecStart=/opt/freehire/bin/ingest-slot.sh /opt/freehire/src/hire-current/ingest /opt/freehire/src/hire-current/sources/oracle.yml --shard=%i/4

--- a/deploy/systemd/freehire-ingest-oracle-shard@1.timer
+++ b/deploy/systemd/freehire-ingest-oracle-shard@1.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest oracle shard 1/4
+[Timer]
+OnCalendar=*-*-* 00/4:15:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-oracle-shard@2.timer
+++ b/deploy/systemd/freehire-ingest-oracle-shard@2.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest oracle shard 2/4
+[Timer]
+OnCalendar=*-*-* 01/4:15:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-oracle-shard@3.timer
+++ b/deploy/systemd/freehire-ingest-oracle-shard@3.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest oracle shard 3/4
+[Timer]
+OnCalendar=*-*-* 02/4:15:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-oracle-shard@4.timer
+++ b/deploy/systemd/freehire-ingest-oracle-shard@4.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest oracle shard 4/4
+[Timer]
+OnCalendar=*-*-* 03/4:15:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@.service
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=freehire ingest paylocity shard %i/24
+After=network.target postgresql.service meilisearch.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+TimeoutStartSec=4500
+ExecStart=/opt/freehire/bin/ingest-slot.sh /opt/freehire/src/hire-current/ingest /opt/freehire/src/hire-current/sources/paylocity.yml --shard=%i/24

--- a/deploy/systemd/freehire-ingest-paylocity-shard@1.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@1.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 1/24
+[Timer]
+OnCalendar=*-*-* 00:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@10.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@10.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 10/24
+[Timer]
+OnCalendar=*-*-* 09:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@11.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@11.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 11/24
+[Timer]
+OnCalendar=*-*-* 10:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@12.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@12.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 12/24
+[Timer]
+OnCalendar=*-*-* 11:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@13.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@13.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 13/24
+[Timer]
+OnCalendar=*-*-* 12:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@14.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@14.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 14/24
+[Timer]
+OnCalendar=*-*-* 13:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@15.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@15.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 15/24
+[Timer]
+OnCalendar=*-*-* 14:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@16.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@16.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 16/24
+[Timer]
+OnCalendar=*-*-* 15:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@17.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@17.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 17/24
+[Timer]
+OnCalendar=*-*-* 16:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@18.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@18.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 18/24
+[Timer]
+OnCalendar=*-*-* 17:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@19.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@19.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 19/24
+[Timer]
+OnCalendar=*-*-* 18:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@2.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@2.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 2/24
+[Timer]
+OnCalendar=*-*-* 01:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@20.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@20.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 20/24
+[Timer]
+OnCalendar=*-*-* 19:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@21.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@21.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 21/24
+[Timer]
+OnCalendar=*-*-* 20:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@22.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@22.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 22/24
+[Timer]
+OnCalendar=*-*-* 21:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@23.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@23.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 23/24
+[Timer]
+OnCalendar=*-*-* 22:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@24.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@24.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 24/24
+[Timer]
+OnCalendar=*-*-* 23:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@3.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@3.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 3/24
+[Timer]
+OnCalendar=*-*-* 02:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@4.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@4.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 4/24
+[Timer]
+OnCalendar=*-*-* 03:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@5.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@5.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 5/24
+[Timer]
+OnCalendar=*-*-* 04:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@6.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@6.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 6/24
+[Timer]
+OnCalendar=*-*-* 05:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@7.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@7.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 7/24
+[Timer]
+OnCalendar=*-*-* 06:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@8.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@8.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 8/24
+[Timer]
+OnCalendar=*-*-* 07:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-paylocity-shard@9.timer
+++ b/deploy/systemd/freehire-ingest-paylocity-shard@9.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity shard 9/24
+[Timer]
+OnCalendar=*-*-* 08:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-workday-shard@.service
+++ b/deploy/systemd/freehire-ingest-workday-shard@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=freehire ingest workday shard %i/6
+After=network.target postgresql.service meilisearch.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+TimeoutStartSec=3000
+ExecStart=/opt/freehire/bin/ingest-slot.sh /opt/freehire/src/hire-current/ingest /opt/freehire/src/hire-current/sources/workday.yml --shard=%i/6

--- a/deploy/systemd/freehire-ingest-workday-shard@1.timer
+++ b/deploy/systemd/freehire-ingest-workday-shard@1.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest workday shard 1/6
+[Timer]
+OnCalendar=*-*-* 00/6:40:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-workday-shard@2.timer
+++ b/deploy/systemd/freehire-ingest-workday-shard@2.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest workday shard 2/6
+[Timer]
+OnCalendar=*-*-* 01/6:40:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-workday-shard@3.timer
+++ b/deploy/systemd/freehire-ingest-workday-shard@3.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest workday shard 3/6
+[Timer]
+OnCalendar=*-*-* 02/6:40:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-workday-shard@4.timer
+++ b/deploy/systemd/freehire-ingest-workday-shard@4.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest workday shard 4/6
+[Timer]
+OnCalendar=*-*-* 03/6:40:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-workday-shard@5.timer
+++ b/deploy/systemd/freehire-ingest-workday-shard@5.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest workday shard 5/6
+[Timer]
+OnCalendar=*-*-* 04/6:40:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest-workday-shard@6.timer
+++ b/deploy/systemd/freehire-ingest-workday-shard@6.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest workday shard 6/6
+[Timer]
+OnCalendar=*-*-* 05/6:40:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@.service
+++ b/deploy/systemd/freehire-ingest@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=freehire ingest %i
+After=network.target postgresql.service meilisearch.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+# 2400s of crawl budget plus the semaphore's 600s worst-case wait for a free slot,
+# so capping concurrency can't quietly shorten a board's time to finish.
+TimeoutStartSec=3000
+ExecStart=/opt/freehire/bin/ingest-slot.sh /opt/freehire/src/hire-current/ingest /opt/freehire/src/hire-current/sources/%i.yml

--- a/deploy/systemd/freehire-ingest@4dayweek.timer
+++ b/deploy/systemd/freehire-ingest@4dayweek.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest 4dayweek
+[Timer]
+OnCalendar=*:00:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@adp.timer
+++ b/deploy/systemd/freehire-ingest@adp.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest adp
+[Timer]
+OnCalendar=*:41:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@adzuna.timer
+++ b/deploy/systemd/freehire-ingest@adzuna.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest adzuna
+[Timer]
+OnCalendar=*:22:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@aijobs.timer
+++ b/deploy/systemd/freehire-ingest@aijobs.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest aijobs
+[Timer]
+OnCalendar=*:03:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@alignerr.timer
+++ b/deploy/systemd/freehire-ingest@alignerr.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest alignerr
+[Timer]
+OnCalendar=*:44:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@apple.timer
+++ b/deploy/systemd/freehire-ingest@apple.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest apple
+[Timer]
+OnCalendar=*-*-* 00/3:00:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@applicantpro.timer
+++ b/deploy/systemd/freehire-ingest@applicantpro.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest applicantpro
+[Timer]
+OnCalendar=*:06:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@apploi.timer
+++ b/deploy/systemd/freehire-ingest@apploi.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest apploi
+[Timer]
+OnCalendar=*:47:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@arbeitnow.timer
+++ b/deploy/systemd/freehire-ingest@arbeitnow.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest arbeitnow
+[Timer]
+OnCalendar=*:28:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@arbeitsagentur.timer
+++ b/deploy/systemd/freehire-ingest@arbeitsagentur.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest arbeitsagentur
+[Timer]
+OnCalendar=*:09:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@ashby.timer
+++ b/deploy/systemd/freehire-ingest@ashby.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest ashby
+[Timer]
+OnCalendar=*:50:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@avature.timer
+++ b/deploy/systemd/freehire-ingest@avature.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest avature
+[Timer]
+OnCalendar=*:31:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@bairesdev.timer
+++ b/deploy/systemd/freehire-ingest@bairesdev.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest bairesdev
+[Timer]
+OnCalendar=*:12:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@bamboohr.timer
+++ b/deploy/systemd/freehire-ingest@bamboohr.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest bamboohr
+[Timer]
+OnCalendar=*-*-* 01/3:17:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@bayt.timer
+++ b/deploy/systemd/freehire-ingest@bayt.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest bayt
+[Timer]
+OnCalendar=*:28:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@betterteam.timer
+++ b/deploy/systemd/freehire-ingest@betterteam.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest betterteam
+[Timer]
+OnCalendar=*:34:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@breezy.timer
+++ b/deploy/systemd/freehire-ingest@breezy.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest breezy
+[Timer]
+OnCalendar=*:15:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@briefhq.timer
+++ b/deploy/systemd/freehire-ingest@briefhq.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest briefhq
+[Timer]
+OnCalendar=*:56:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@bullhorn.timer
+++ b/deploy/systemd/freehire-ingest@bullhorn.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest bullhorn
+[Timer]
+OnCalendar=*:37:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@careerplug.timer
+++ b/deploy/systemd/freehire-ingest@careerplug.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest careerplug
+[Timer]
+OnCalendar=*-*-* 02/3:34:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@careerspage.timer
+++ b/deploy/systemd/freehire-ingest@careerspage.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest careerspage
+[Timer]
+OnCalendar=*:59:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@catsone.timer
+++ b/deploy/systemd/freehire-ingest@catsone.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest catsone
+[Timer]
+OnCalendar=*:40:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@cleverstaff.timer
+++ b/deploy/systemd/freehire-ingest@cleverstaff.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest cleverstaff
+[Timer]
+OnCalendar=*:21:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@clinch.timer
+++ b/deploy/systemd/freehire-ingest@clinch.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest clinch
+[Timer]
+OnCalendar=*:02:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@comeet.timer
+++ b/deploy/systemd/freehire-ingest@comeet.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest comeet
+[Timer]
+OnCalendar=*:43:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@compleo.timer
+++ b/deploy/systemd/freehire-ingest@compleo.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest compleo
+[Timer]
+OnCalendar=*:24:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@cornerstone.timer
+++ b/deploy/systemd/freehire-ingest@cornerstone.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest cornerstone
+[Timer]
+OnCalendar=*:05:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@crelate.timer
+++ b/deploy/systemd/freehire-ingest@crelate.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest crelate
+[Timer]
+OnCalendar=*:46:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@cryptocurrencyjobs.timer
+++ b/deploy/systemd/freehire-ingest@cryptocurrencyjobs.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest cryptocurrencyjobs
+[Timer]
+OnCalendar=*:27:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@custom.timer
+++ b/deploy/systemd/freehire-ingest@custom.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest custom
+[Timer]
+OnCalendar=*-*-* 00/3:51:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@dataart.timer
+++ b/deploy/systemd/freehire-ingest@dataart.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest dataart
+[Timer]
+OnCalendar=*:49:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@deel.timer
+++ b/deploy/systemd/freehire-ingest@deel.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest deel
+[Timer]
+OnCalendar=*:30:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@djinni.timer
+++ b/deploy/systemd/freehire-ingest@djinni.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest djinni
+[Timer]
+OnCalendar=*:11:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@earcu.timer
+++ b/deploy/systemd/freehire-ingest@earcu.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest earcu
+[Timer]
+OnCalendar=*:52:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@echojobs.timer
+++ b/deploy/systemd/freehire-ingest@echojobs.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest echojobs
+[Timer]
+OnCalendar=*:33:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@eightfold.timer
+++ b/deploy/systemd/freehire-ingest@eightfold.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest eightfold
+[Timer]
+OnCalendar=*:37:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@emagine.timer
+++ b/deploy/systemd/freehire-ingest@emagine.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest emagine
+[Timer]
+OnCalendar=*:14:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@enlizt.timer
+++ b/deploy/systemd/freehire-ingest@enlizt.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest enlizt
+[Timer]
+OnCalendar=*:55:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@epam.timer
+++ b/deploy/systemd/freehire-ingest@epam.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest epam
+[Timer]
+OnCalendar=*:36:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@erecruiter.timer
+++ b/deploy/systemd/freehire-ingest@erecruiter.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest erecruiter
+[Timer]
+OnCalendar=*:17:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@factorial.timer
+++ b/deploy/systemd/freehire-ingest@factorial.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest factorial
+[Timer]
+OnCalendar=*:58:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@freshteam.timer
+++ b/deploy/systemd/freehire-ingest@freshteam.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest freshteam
+[Timer]
+OnCalendar=*:39:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@functionalworks.timer
+++ b/deploy/systemd/freehire-ingest@functionalworks.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest functionalworks
+[Timer]
+OnCalendar=*:20:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@geekjob.timer
+++ b/deploy/systemd/freehire-ingest@geekjob.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest geekjob
+[Timer]
+OnCalendar=*:01:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@gem.timer
+++ b/deploy/systemd/freehire-ingest@gem.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest gem
+[Timer]
+OnCalendar=*:42:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@getmanfred.timer
+++ b/deploy/systemd/freehire-ingest@getmanfred.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest getmanfred
+[Timer]
+OnCalendar=*:23:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@getmatch.timer
+++ b/deploy/systemd/freehire-ingest@getmatch.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest getmatch
+[Timer]
+OnCalendar=*:04:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@getonbrd.timer
+++ b/deploy/systemd/freehire-ingest@getonbrd.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest getonbrd
+[Timer]
+OnCalendar=*:45:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@getro.timer
+++ b/deploy/systemd/freehire-ingest@getro.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest getro
+[Timer]
+OnCalendar=*:26:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@globalpayments.timer
+++ b/deploy/systemd/freehire-ingest@globalpayments.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest globalpayments
+[Timer]
+OnCalendar=*:07:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@greenhouse.timer
+++ b/deploy/systemd/freehire-ingest@greenhouse.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest greenhouse
+[Timer]
+OnCalendar=*:48:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@gulftalent.timer
+++ b/deploy/systemd/freehire-ingest@gulftalent.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest gulftalent
+[Timer]
+OnCalendar=*:27:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@gupy.timer
+++ b/deploy/systemd/freehire-ingest@gupy.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest gupy
+[Timer]
+OnCalendar=*-*-* 01/3:08:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@habrcareer.timer
+++ b/deploy/systemd/freehire-ingest@habrcareer.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest habrcareer
+[Timer]
+OnCalendar=*:10:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@hh.timer
+++ b/deploy/systemd/freehire-ingest@hh.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest hh
+[Timer]
+OnCalendar=*:51:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@hibob.timer
+++ b/deploy/systemd/freehire-ingest@hibob.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest hibob
+[Timer]
+OnCalendar=*:32:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@himalayas.timer
+++ b/deploy/systemd/freehire-ingest@himalayas.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest himalayas
+[Timer]
+OnCalendar=*:13:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@hireology.timer
+++ b/deploy/systemd/freehire-ingest@hireology.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest hireology
+[Timer]
+OnCalendar=*:54:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@huntflow.timer
+++ b/deploy/systemd/freehire-ingest@huntflow.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest huntflow
+[Timer]
+OnCalendar=*:35:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@hurma.timer
+++ b/deploy/systemd/freehire-ingest@hurma.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest hurma
+[Timer]
+OnCalendar=*:16:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@icims.timer
+++ b/deploy/systemd/freehire-ingest@icims.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest icims
+[Timer]
+OnCalendar=*-*-* 02/3:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@infojobs.timer
+++ b/deploy/systemd/freehire-ingest@infojobs.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest infojobs
+[Timer]
+OnCalendar=*:38:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@inhire.timer
+++ b/deploy/systemd/freehire-ingest@inhire.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest inhire
+[Timer]
+OnCalendar=*:19:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@instaffo.timer
+++ b/deploy/systemd/freehire-ingest@instaffo.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest instaffo
+[Timer]
+OnCalendar=*:00:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@ismartrecruit.timer
+++ b/deploy/systemd/freehire-ingest@ismartrecruit.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest ismartrecruit
+[Timer]
+OnCalendar=*:41:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@isolvedhire.timer
+++ b/deploy/systemd/freehire-ingest@isolvedhire.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest isolvedhire
+[Timer]
+OnCalendar=*:22:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@itechart.timer
+++ b/deploy/systemd/freehire-ingest@itechart.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest itechart
+[Timer]
+OnCalendar=*:45:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@jazzhr.timer
+++ b/deploy/systemd/freehire-ingest@jazzhr.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest jazzhr
+[Timer]
+OnCalendar=*-*-* 00/3:42:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@jibe.timer
+++ b/deploy/systemd/freehire-ingest@jibe.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest jibe
+[Timer]
+OnCalendar=*-*-* 01/3:59:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@jobdanmark.timer
+++ b/deploy/systemd/freehire-ingest@jobdanmark.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest jobdanmark
+[Timer]
+OnCalendar=*:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@jobicy.timer
+++ b/deploy/systemd/freehire-ingest@jobicy.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest jobicy
+[Timer]
+OnCalendar=*:06:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@jobnet.timer
+++ b/deploy/systemd/freehire-ingest@jobnet.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest jobnet
+[Timer]
+OnCalendar=*:47:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@jobscore.timer
+++ b/deploy/systemd/freehire-ingest@jobscore.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest jobscore
+[Timer]
+OnCalendar=*:28:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@jobspresso.timer
+++ b/deploy/systemd/freehire-ingest@jobspresso.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest jobspresso
+[Timer]
+OnCalendar=*:09:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@jobstash.timer
+++ b/deploy/systemd/freehire-ingest@jobstash.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest jobstash
+[Timer]
+OnCalendar=*:50:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@jobtech.timer
+++ b/deploy/systemd/freehire-ingest@jobtech.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest jobtech
+[Timer]
+OnCalendar=*:31:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@jobvite.timer
+++ b/deploy/systemd/freehire-ingest@jobvite.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest jobvite
+[Timer]
+OnCalendar=*:12:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@jobylon.timer
+++ b/deploy/systemd/freehire-ingest@jobylon.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest jobylon
+[Timer]
+OnCalendar=*:53:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@join.timer
+++ b/deploy/systemd/freehire-ingest@join.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest join
+[Timer]
+OnCalendar=*:34:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@justjoin.timer
+++ b/deploy/systemd/freehire-ingest@justjoin.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest justjoin
+[Timer]
+OnCalendar=*:15:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@landingjobs.timer
+++ b/deploy/systemd/freehire-ingest@landingjobs.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest landingjobs
+[Timer]
+OnCalendar=*:56:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@lever.timer
+++ b/deploy/systemd/freehire-ingest@lever.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest lever
+[Timer]
+OnCalendar=*:37:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@likeit.timer
+++ b/deploy/systemd/freehire-ingest@likeit.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest likeit
+[Timer]
+OnCalendar=*:18:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@loxo.timer
+++ b/deploy/systemd/freehire-ingest@loxo.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest loxo
+[Timer]
+OnCalendar=*:59:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@luxoft.timer
+++ b/deploy/systemd/freehire-ingest@luxoft.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest luxoft
+[Timer]
+OnCalendar=*:40:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@manatal.timer
+++ b/deploy/systemd/freehire-ingest@manatal.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest manatal
+[Timer]
+OnCalendar=*:21:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@micro1.timer
+++ b/deploy/systemd/freehire-ingest@micro1.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest micro1
+[Timer]
+OnCalendar=*:02:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@mindsight.timer
+++ b/deploy/systemd/freehire-ingest@mindsight.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest mindsight
+[Timer]
+OnCalendar=*:43:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@mycareersfuture.timer
+++ b/deploy/systemd/freehire-ingest@mycareersfuture.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest mycareersfuture
+[Timer]
+OnCalendar=*-*-* 02/3:16:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@neogov.timer
+++ b/deploy/systemd/freehire-ingest@neogov.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest neogov
+[Timer]
+OnCalendar=*:05:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@nodesk.timer
+++ b/deploy/systemd/freehire-ingest@nodesk.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest nodesk
+[Timer]
+OnCalendar=*:46:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@nofluffjobs.timer
+++ b/deploy/systemd/freehire-ingest@nofluffjobs.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest nofluffjobs
+[Timer]
+OnCalendar=*:27:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@northstone.timer
+++ b/deploy/systemd/freehire-ingest@northstone.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest northstone
+[Timer]
+OnCalendar=*:08:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@odoo.timer
+++ b/deploy/systemd/freehire-ingest@odoo.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest odoo
+[Timer]
+OnCalendar=*:49:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@onstrider.timer
+++ b/deploy/systemd/freehire-ingest@onstrider.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest onstrider
+[Timer]
+OnCalendar=*:30:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@opencats.timer
+++ b/deploy/systemd/freehire-ingest@opencats.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest opencats
+[Timer]
+OnCalendar=*:11:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@oracle.timer
+++ b/deploy/systemd/freehire-ingest@oracle.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest oracle
+[Timer]
+OnCalendar=*-*-* 00/3:33:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@pageup.timer
+++ b/deploy/systemd/freehire-ingest@pageup.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest pageup
+[Timer]
+OnCalendar=*:52:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@paycom.timer
+++ b/deploy/systemd/freehire-ingest@paycom.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paycom
+[Timer]
+OnCalendar=*-*-* 00/3:33:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@paylocity.timer
+++ b/deploy/systemd/freehire-ingest@paylocity.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest paylocity
+[Timer]
+OnCalendar=*-*-* 01/3:50:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@peopleforce.timer
+++ b/deploy/systemd/freehire-ingest@peopleforce.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest peopleforce
+[Timer]
+OnCalendar=*:14:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@personio.timer
+++ b/deploy/systemd/freehire-ingest@personio.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest personio
+[Timer]
+OnCalendar=*:55:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@phenom.timer
+++ b/deploy/systemd/freehire-ingest@phenom.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest phenom
+[Timer]
+OnCalendar=*:36:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@pinpoint.timer
+++ b/deploy/systemd/freehire-ingest@pinpoint.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest pinpoint
+[Timer]
+OnCalendar=*:17:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@powertofly.timer
+++ b/deploy/systemd/freehire-ingest@powertofly.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest powertofly
+[Timer]
+OnCalendar=*:58:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@quickin.timer
+++ b/deploy/systemd/freehire-ingest@quickin.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest quickin
+[Timer]
+OnCalendar=*:39:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@radancy.timer
+++ b/deploy/systemd/freehire-ingest@radancy.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest radancy
+[Timer]
+OnCalendar=*:20:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@rapyd.timer
+++ b/deploy/systemd/freehire-ingest@rapyd.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest rapyd
+[Timer]
+OnCalendar=*:01:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@recruitee.timer
+++ b/deploy/systemd/freehire-ingest@recruitee.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest recruitee
+[Timer]
+OnCalendar=*:42:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@recruitingsolutions.timer
+++ b/deploy/systemd/freehire-ingest@recruitingsolutions.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest recruitingsolutions
+[Timer]
+OnCalendar=*:23:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@reed.timer
+++ b/deploy/systemd/freehire-ingest@reed.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest reed
+[Timer]
+OnCalendar=*-*-* 00/6:04:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@remotedotcom.timer
+++ b/deploy/systemd/freehire-ingest@remotedotcom.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest remotedotcom
+[Timer]
+OnCalendar=*:45:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@remoteok.timer
+++ b/deploy/systemd/freehire-ingest@remoteok.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest remoteok
+[Timer]
+OnCalendar=*:26:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@remotive.timer
+++ b/deploy/systemd/freehire-ingest@remotive.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest remotive
+[Timer]
+OnCalendar=*:07:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@remotli.timer
+++ b/deploy/systemd/freehire-ingest@remotli.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest remotli
+[Timer]
+OnCalendar=*:48:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@rippling.timer
+++ b/deploy/systemd/freehire-ingest@rippling.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest rippling
+[Timer]
+OnCalendar=*:29:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@seek.timer
+++ b/deploy/systemd/freehire-ingest@seek.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest seek
+[Timer]
+OnCalendar=*:10:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@senior.timer
+++ b/deploy/systemd/freehire-ingest@senior.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest senior
+[Timer]
+OnCalendar=*:51:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@smartrecruiters.timer
+++ b/deploy/systemd/freehire-ingest@smartrecruiters.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest smartrecruiters
+[Timer]
+OnCalendar=*:32:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@softgarden.timer
+++ b/deploy/systemd/freehire-ingest@softgarden.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest softgarden
+[Timer]
+OnCalendar=*:13:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@solides.timer
+++ b/deploy/systemd/freehire-ingest@solides.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest solides
+[Timer]
+OnCalendar=*:54:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@solidjobs.timer
+++ b/deploy/systemd/freehire-ingest@solidjobs.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest solidjobs
+[Timer]
+OnCalendar=*:35:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@spark.timer
+++ b/deploy/systemd/freehire-ingest@spark.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest spark
+[Timer]
+OnCalendar=*:16:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@speedrun.timer
+++ b/deploy/systemd/freehire-ingest@speedrun.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest speedrun
+[Timer]
+OnCalendar=*:57:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@startupandvc.timer
+++ b/deploy/systemd/freehire-ingest@startupandvc.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest startupandvc
+[Timer]
+OnCalendar=*:38:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@successfactors.timer
+++ b/deploy/systemd/freehire-ingest@successfactors.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest successfactors
+[Timer]
+OnCalendar=*:19:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@talentadore.timer
+++ b/deploy/systemd/freehire-ingest@talentadore.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest talentadore
+[Timer]
+OnCalendar=*:00:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@talenthr.timer
+++ b/deploy/systemd/freehire-ingest@talenthr.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest talenthr
+[Timer]
+OnCalendar=*:41:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@talentlyft.timer
+++ b/deploy/systemd/freehire-ingest@talentlyft.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest talentlyft
+[Timer]
+OnCalendar=*:22:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@taleo.timer
+++ b/deploy/systemd/freehire-ingest@taleo.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest taleo
+[Timer]
+OnCalendar=*-*-* 01/3:50:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@teamex.timer
+++ b/deploy/systemd/freehire-ingest@teamex.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest teamex
+[Timer]
+OnCalendar=*:44:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@teamtailor.timer
+++ b/deploy/systemd/freehire-ingest@teamtailor.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest teamtailor
+[Timer]
+OnCalendar=*:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@tecla.timer
+++ b/deploy/systemd/freehire-ingest@tecla.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest tecla
+[Timer]
+OnCalendar=*:06:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@thehub.timer
+++ b/deploy/systemd/freehire-ingest@thehub.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest thehub
+[Timer]
+OnCalendar=*:47:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@themuse.timer
+++ b/deploy/systemd/freehire-ingest@themuse.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest themuse
+[Timer]
+OnCalendar=*:28:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@topco.timer
+++ b/deploy/systemd/freehire-ingest@topco.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest topco
+[Timer]
+OnCalendar=*:09:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@traffit.timer
+++ b/deploy/systemd/freehire-ingest@traffit.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest traffit
+[Timer]
+OnCalendar=*:50:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@trakstar.timer
+++ b/deploy/systemd/freehire-ingest@trakstar.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest trakstar
+[Timer]
+OnCalendar=*:31:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@trudvsem.timer
+++ b/deploy/systemd/freehire-ingest@trudvsem.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest trudvsem
+[Timer]
+OnCalendar=*:12:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@tyomarkkinatori.timer
+++ b/deploy/systemd/freehire-ingest@tyomarkkinatori.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest tyomarkkinatori
+[Timer]
+OnCalendar=*:53:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@ukg.timer
+++ b/deploy/systemd/freehire-ingest@ukg.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest ukg
+[Timer]
+OnCalendar=*-*-* 02/3:07:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@usajobs.timer
+++ b/deploy/systemd/freehire-ingest@usajobs.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest usajobs
+[Timer]
+OnCalendar=*:15:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@vagas.timer
+++ b/deploy/systemd/freehire-ingest@vagas.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest vagas
+[Timer]
+OnCalendar=*-*-* 00/3:24:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@vention.timer
+++ b/deploy/systemd/freehire-ingest@vention.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest vention
+[Timer]
+OnCalendar=*:37:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@vouch.timer
+++ b/deploy/systemd/freehire-ingest@vouch.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest vouch
+[Timer]
+OnCalendar=*:18:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@wantapply.timer
+++ b/deploy/systemd/freehire-ingest@wantapply.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest wantapply
+[Timer]
+OnCalendar=*:59:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@wantedkr.timer
+++ b/deploy/systemd/freehire-ingest@wantedkr.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest wantedkr
+[Timer]
+OnCalendar=*:40:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@weworkremotely.timer
+++ b/deploy/systemd/freehire-ingest@weworkremotely.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest weworkremotely
+[Timer]
+OnCalendar=*:21:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-ae.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-ae.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-ae
+[Timer]
+OnCalendar=*:02:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-ar.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-ar.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-ar
+[Timer]
+OnCalendar=*:43:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-at.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-at.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-at
+[Timer]
+OnCalendar=*:24:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-au.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-au.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-au
+[Timer]
+OnCalendar=*:05:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-be.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-be.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-be
+[Timer]
+OnCalendar=*:46:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-bh.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-bh.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-bh
+[Timer]
+OnCalendar=*:27:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-br.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-br.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-br
+[Timer]
+OnCalendar=*:08:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-ca.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-ca.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-ca
+[Timer]
+OnCalendar=*:49:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-ch.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-ch.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-ch
+[Timer]
+OnCalendar=*:30:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-cl.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-cl.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-cl
+[Timer]
+OnCalendar=*:11:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-co.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-co.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-co
+[Timer]
+OnCalendar=*:52:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-de.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-de.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-de
+[Timer]
+OnCalendar=*:33:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-dk.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-dk.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-dk
+[Timer]
+OnCalendar=*:14:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-eg.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-eg.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-eg
+[Timer]
+OnCalendar=*:55:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-es.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-es.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-es
+[Timer]
+OnCalendar=*:36:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-fi.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-fi.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-fi
+[Timer]
+OnCalendar=*:17:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-fr.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-fr.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-fr
+[Timer]
+OnCalendar=*:58:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-gr.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-gr.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-gr
+[Timer]
+OnCalendar=*:39:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-hk.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-hk.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-hk
+[Timer]
+OnCalendar=*:20:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-hu.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-hu.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-hu
+[Timer]
+OnCalendar=*:01:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-id.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-id.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-id
+[Timer]
+OnCalendar=*:42:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-ie.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-ie.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-ie
+[Timer]
+OnCalendar=*:23:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-in.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-in.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-in
+[Timer]
+OnCalendar=*:04:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-it.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-it.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-it
+[Timer]
+OnCalendar=*:45:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-ke.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-ke.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-ke
+[Timer]
+OnCalendar=*:26:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-kw.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-kw.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-kw
+[Timer]
+OnCalendar=*:07:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-lu.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-lu.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-lu
+[Timer]
+OnCalendar=*:48:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-mx.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-mx.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-mx
+[Timer]
+OnCalendar=*:29:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-my.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-my.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-my
+[Timer]
+OnCalendar=*:10:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-nl.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-nl.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-nl
+[Timer]
+OnCalendar=*:51:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-no.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-no.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-no
+[Timer]
+OnCalendar=*:32:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-nz.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-nz.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-nz
+[Timer]
+OnCalendar=*:13:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-om.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-om.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-om
+[Timer]
+OnCalendar=*:54:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-pe.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-pe.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-pe
+[Timer]
+OnCalendar=*:35:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-ph.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-ph.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-ph
+[Timer]
+OnCalendar=*:16:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-pk.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-pk.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-pk
+[Timer]
+OnCalendar=*:57:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-pl.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-pl.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-pl
+[Timer]
+OnCalendar=*:38:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-pt.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-pt.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-pt
+[Timer]
+OnCalendar=*:19:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-py.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-py.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-py
+[Timer]
+OnCalendar=*:00:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-qa.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-qa.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-qa
+[Timer]
+OnCalendar=*:41:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-sa.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-sa.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-sa
+[Timer]
+OnCalendar=*:22:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-se.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-se.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-se
+[Timer]
+OnCalendar=*:03:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-sg.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-sg.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-sg
+[Timer]
+OnCalendar=*:44:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-sv.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-sv.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-sv
+[Timer]
+OnCalendar=*:25:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-th.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-th.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-th
+[Timer]
+OnCalendar=*:06:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-tr.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-tr.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-tr
+[Timer]
+OnCalendar=*:47:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-uk.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-uk.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-uk
+[Timer]
+OnCalendar=*:28:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-ve.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-ve.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-ve
+[Timer]
+OnCalendar=*:09:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-vn.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-vn.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-vn
+[Timer]
+OnCalendar=*:50:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs-za.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs-za.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs-za
+[Timer]
+OnCalendar=*:12:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@whatjobs.timer
+++ b/deploy/systemd/freehire-ingest@whatjobs.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest whatjobs
+[Timer]
+OnCalendar=*:31:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@workable.timer
+++ b/deploy/systemd/freehire-ingest@workable.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest workable
+[Timer]
+OnCalendar=*:34:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@workablemarketplace.timer
+++ b/deploy/systemd/freehire-ingest@workablemarketplace.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest workablemarketplace
+[Timer]
+OnCalendar=*:53:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@workatastartup.timer
+++ b/deploy/systemd/freehire-ingest@workatastartup.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest workatastartup
+[Timer]
+OnCalendar=*:15:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@workday.timer
+++ b/deploy/systemd/freehire-ingest@workday.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest workday
+[Timer]
+OnCalendar=*:40:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@workingnomads.timer
+++ b/deploy/systemd/freehire-ingest@workingnomads.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest workingnomads
+[Timer]
+OnCalendar=*:56:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@wpyoast.timer
+++ b/deploy/systemd/freehire-ingest@wpyoast.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest wpyoast
+[Timer]
+OnCalendar=*:37:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@zohorecruit.timer
+++ b/deploy/systemd/freehire-ingest@zohorecruit.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer ingest zohorecruit
+[Timer]
+OnCalendar=*:18:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-liveness.service
+++ b/deploy/systemd/freehire-liveness.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=freehire worker: orphan liveness probe
+After=network.target postgresql.service meilisearch.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+ExecStart=/opt/freehire/src/hire-current/liveness

--- a/deploy/systemd/freehire-liveness.timer
+++ b/deploy/systemd/freehire-liveness.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer: freehire-liveness
+[Timer]
+OnCalendar=*-*-* 05,17:50:00
+Persistent=true
+RandomizedDelaySec=300
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-logo-cache-backup.service
+++ b/deploy/systemd/freehire-logo-cache-backup.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Mirror the freehire logo cache to object storage
+
+[Service]
+Type=oneshot
+ExecStart=/opt/freehire/bin/logo-cache-backup.sh

--- a/deploy/systemd/freehire-logo-cache-backup.timer
+++ b/deploy/systemd/freehire-logo-cache-backup.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Nightly logo-cache mirror
+
+[Timer]
+# 03:30 UTC — after pg-backup at 03:00, so the two do not contend for upload bandwidth.
+OnCalendar=*-*-* 03:30:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-logo.service
+++ b/deploy/systemd/freehire-logo.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=freehire logo proxy (logo.freehire.me)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=freehire
+EnvironmentFile=/opt/freehire/.env
+ExecStart=/opt/freehire/bin/logo-proxy
+Restart=always
+RestartSec=2
+# The cache is the service's whole state and is expensive to refill (see
+# logo-cache-backup.sh), so it lives outside the swappable src tree.
+StateDirectory=freehire-logo
+ReadWritePaths=/var/cache/freehire-logo
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/freehire-mail-ingest.service
+++ b/deploy/systemd/freehire-mail-ingest.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=freehire worker: hosted-mailbox inbound (SES -> SQS -> hire.emails)
+After=network-online.target postgresql.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+# Long-lived: it long-polls SQS and blocks until SIGTERM. Restart if it dies or
+# on an SQS/transient failure; the queue redelivers un-acked messages.
+Restart=always
+RestartSec=5
+ExecStart=/opt/freehire/src/hire-current/mail-ingest
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/freehire-notify.service
+++ b/deploy/systemd/freehire-notify.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=freehire notify (saved-search digests)
+After=network.target postgresql.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+# The digest sender's own credentials, kept out of the shared .env every other worker
+# reads. Present on host-2 since 2026-07-25 and missing from this file until now, so a
+# re-provision from git would have started notify without them.
+EnvironmentFile=/opt/freehire/.env.notify
+CPUWeight=40
+ExecStart=/opt/freehire/src/hire-current/notify

--- a/deploy/systemd/freehire-notify.timer
+++ b/deploy/systemd/freehire-notify.timer
@@ -1,0 +1,7 @@
+[Unit]
+Description=timer notify
+[Timer]
+OnCalendar=*:0/5
+Persistent=true
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-nudge.service
+++ b/deploy/systemd/freehire-nudge.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=freehire worker: lifecycle nudges (follow-up, interview-prep, job-closed)
+After=network.target postgresql.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+ExecStart=/opt/freehire/src/hire-current/nudge

--- a/deploy/systemd/freehire-nudge.service.d/mail.conf
+++ b/deploy/systemd/freehire-nudge.service.d/mail.conf
@@ -1,0 +1,6 @@
+# The mail sender credentials (NOTIFY_EMAIL_FROM + SES keys) live in their own file,
+# which freehire-notify/onboarding/broadcast already read. Without it the email channel
+# never registers here, and every email reminder soft-skips forever while the run still
+# exits 0 -- 244 of them had piled up by 2026-09-01.
+[Service]
+EnvironmentFile=/opt/freehire/.env.notify

--- a/deploy/systemd/freehire-nudge.timer
+++ b/deploy/systemd/freehire-nudge.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=timer: freehire-nudge
+[Timer]
+# Every 30 min: MATCH+DELIVER over live state (like notify), not pre-scheduled
+# rows like remind, so a shorter interval keeps 'gone silent'/'entered
+# interview'/'listing closed' noticed same-day without hammering the DB.
+OnCalendar=*:0/30
+Persistent=true
+RandomizedDelaySec=120
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-onboard-contributions.service
+++ b/deploy/systemd/freehire-onboard-contributions.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=freehire: drain the board-contribution queue into a pull request
+After=network-online.target postgresql.service
+Wants=network-online.target
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire
+# Two files: the shared one carries DATABASE_URL and TELEGRAM_BOT_TOKEN, the private
+# one the GitHub and Claude credentials this worker alone holds.
+EnvironmentFile=/opt/freehire/.env
+EnvironmentFile=/opt/freehire/env/onboard-contributions.env
+ExecStart=/opt/freehire/bin/onboard-contributions.sh
+# The run is an LLM agent validating boards over the network, so it is mostly waiting.
+# It yields to the ingest fleet and the API rather than competing with them.
+CPUWeight=20
+# Generous on purpose: the agent validates every contributed board live, one HTTP
+# request at a time. A run that needs longer than two hours has gone wrong.
+TimeoutStartSec=7200

--- a/deploy/systemd/freehire-onboard-contributions.timer
+++ b/deploy/systemd/freehire-onboard-contributions.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=timer: freehire-onboard-contributions daily
+[Timer]
+# 21:17 UTC = 18:17 in Sao Paulo, where whoever reviews the pull request is.
+# Off the hour, so the run does not queue behind every other daily job.
+OnCalendar=*-*-* 21:17:00
+# Persistent because a missed day is real work left undone — the queue only grows,
+# and the next run picks up whatever the skipped one would have taken. Unlike the
+# sampling timers here, replaying a missed window publishes nothing misleading.
+Persistent=true
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-onboarding.service
+++ b/deploy/systemd/freehire-onboarding.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=freehire worker: founder signup email sequence (welcome / no-alert / open-source)
+After=network.target postgresql.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+EnvironmentFile=/opt/freehire/.env.notify
+CPUWeight=10
+IOWeight=10
+ExecStart=/opt/freehire/src/hire-current/onboarding

--- a/deploy/systemd/freehire-onboarding.timer
+++ b/deploy/systemd/freehire-onboarding.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer: freehire-onboarding hourly
+[Timer]
+OnBootSec=10min
+OnUnitActiveSec=1h
+Persistent=true
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-pg-backup.service
+++ b/deploy/systemd/freehire-pg-backup.service
@@ -1,0 +1,39 @@
+[Unit]
+Description=freehire: nightly PostgreSQL backup (hire+mail -> local + Hetzner S3)
+After=network-online.target postgresql.service
+Wants=network-online.target
+[Service]
+Type=oneshot
+
+# Pause the INGEST fleet for the duration, and only ingest.
+#
+# NOT freehire:pause:all. That key also stops cmd/migrate, which exits 0 with
+# "paused, skipping this run" — release.sh reads that as success and flips the colour
+# onto an unmigrated schema. That is the 2026-08-19 outage, 7 minutes of SQLSTATE
+# 42703 on every job read. A nightly window that silently breaks any deploy landing
+# inside it is a worse trade than the I/O it saves. The key names the BINARY, so
+# pause:ingest covers all ~140 ingest timers and nothing else.
+#
+# EX is a safety net, not the mechanism: ExecStopPost clears the key on success AND
+# on failure (+ runs even when the main process is killed), but a stateful
+# stop/start pair is exactly what the 2026-08-15 reindexw incident left dangling for
+# six hours. The TTL bounds that to one window.
+ExecStartPre=/usr/bin/redis-cli SET freehire:pause:ingest 1 EX 7200
+ExecStart=/opt/freehire/bin/pg-backup.sh
+ExecStopPost=/usr/bin/redis-cli DEL freehire:pause:ingest
+
+# UNTHROTTLED since 2026-08-20. The previous Nice=10 + idle-class I/O, together with
+# the script's own nice -n 19 / ionice -c 3, measured 5.4 MB/s and stretched the run
+# past 75 minutes. Slowness was not protection: on 2026-08-20 the dump overlapped
+# autovacuum on a 96 GB jobs table and half of all requests 500ed for 40 minutes.
+# Going slowly only widened the overlap. Finish fast, with ingest out of the way.
+#
+# The cgroup weights stay BELOW web/api (system-freehire-web.slice runs
+# CPUWeight/IOWeight=800) but leave the floor of 20 that made this unit lose every
+# contest: at 100 it is an equal of unweighted system work and still yields to the
+# site. That split is the 2026-08-05 accept-queue incident's lesson, kept.
+CPUWeight=100
+IOWeight=100
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/freehire-pg-backup.timer
+++ b/deploy/systemd/freehire-pg-backup.timer
@@ -1,0 +1,7 @@
+[Unit]
+Description=timer: nightly freehire PostgreSQL backup at 03:00 UTC
+[Timer]
+OnCalendar=*-*-* 03:00:00 UTC
+Persistent=true
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-pii-filter.service
+++ b/deploy/systemd/freehire-pii-filter.service
@@ -1,0 +1,24 @@
+[Unit]
+# freehire PII detection endpoint (openai/privacy-filter, ONNX q4 on CPU). The API and the
+# résumé-extract path call it over localhost to de-identify CV text BEFORE it reaches the LLM
+# gateway. Single instance (no blue/green): it is stateless and holds the loaded model in RAM,
+# and the API fails closed if it is down, so a brief restart just pauses fit analysis.
+Description=freehire PII detection (privacy-filter)
+After=network.target
+
+[Service]
+User=freehire
+# Stable path (not blue/green) so the unit survives an API colour swap. The venv and the
+# model weights live outside the swappable src tree (see freehire-pii-filter env), so a code
+# deploy never rebuilds them.
+WorkingDirectory=/opt/freehire/src/hire-current/services/pii-filter
+EnvironmentFile=/opt/freehire/env/pii-filter.env
+ExecStart=/opt/freehire/pii-filter/venv/bin/python server.py
+Restart=on-failure
+RestartSec=2
+# Light hardening; the service is stateless (loads the model, serves detections).
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/freehire-queue-metrics.service
+++ b/deploy/systemd/freehire-queue-metrics.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=freehire worker: pipeline queue-depth metrics for Prometheus
+After=network.target postgresql.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+# Lowest weights on the host. This worker exists to observe the pipeline, so it must
+# never be the reason a member of that pipeline waits: it is read-only, takes no locks,
+# and a run that loses a scheduling race simply reports one minute later. It does pay
+# for a full count over enrichment_outbox and semantic_outbox (~1M and ~780k rows),
+# which is why the cost is pinned to once per minute here rather than left to a
+# Prometheus scrape interval that lives in another repository.
+CPUWeight=10
+IOWeight=10
+# No ExecStartPre guard against reindex, unlike freehire-search-drain: this worker does
+# not write to Meilisearch and does not compete for the resource a swap-rebuild needs.
+# Skipping it during a reindex would blind the dashboard for exactly the hours when the
+# pipeline is most worth watching — which is the incident this whole change came from.
+ExecStart=/opt/freehire/src/hire-current/queue-metrics

--- a/deploy/systemd/freehire-queue-metrics.timer
+++ b/deploy/systemd/freehire-queue-metrics.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=timer: freehire-queue-metrics every minute
+[Timer]
+# Monotonic, not a wall-clock slot: this samples a level that moves continuously, so
+# what matters is the gap between samples, not the time of day. One minute is the
+# resolution the alert rules assume — rule 7 pages when the last run is more than 10
+# minutes old, which is ten missed ticks and therefore a real outage rather than one
+# slow run. Raising this interval means revisiting that threshold.
+OnBootSec=2min
+OnUnitActiveSec=1min
+# Deliberately NOT Persistent=true. A missed window is a gap in a graph, and replaying
+# one on boot would publish a measurement stamped now for a pipeline state that is
+# already gone.
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-recount.service
+++ b/deploy/systemd/freehire-recount.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=freehire worker: company facet recount
+After=network.target postgresql.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+ExecStart=/opt/freehire/src/hire-current/recount-companies

--- a/deploy/systemd/freehire-recount.timer
+++ b/deploy/systemd/freehire-recount.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer: freehire-recount
+[Timer]
+OnCalendar=*-*-* 00/6:45:00
+Persistent=true
+RandomizedDelaySec=300
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-reindex-companies.service
+++ b/deploy/systemd/freehire-reindex-companies.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=freehire worker: companies search reindex
+After=network.target postgresql.service meilisearch.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+# Lower weights than the API: the companies index is small (~195k description-less
+# docs) so this finishes fast, but it should still yield to live traffic. It shares
+# Meilisearch's single task queue with the jobs reindex — do NOT overlap the two
+# (the timer below sits off the every-3h reindexw cadence).
+CPUWeight=40
+IOWeight=40
+ExecStart=/opt/freehire/src/hire-current/reindex-companies

--- a/deploy/systemd/freehire-reindex-companies.service.d/10-skip-if-reindexing.conf
+++ b/deploy/systemd/freehire-reindex-companies.service.d/10-skip-if-reindexing.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecCondition=/opt/freehire/bin/skip-if-reindexing.sh

--- a/deploy/systemd/freehire-reindex-companies.timer
+++ b/deploy/systemd/freehire-reindex-companies.timer
@@ -1,0 +1,18 @@
+[Unit]
+Description=timer: freehire-reindex-companies
+
+[Timer]
+# 12:30 sits in the gap between reindexw runs (03:15/09:15/15:15/21:15, ~2.5h each),
+# with ~45 min of margin after the 09:15 one finishes.
+#
+# Why not 05:15, where this used to be: the service's ExecCondition
+# (skip-if-reindexing.sh) skips the cycle whenever reindexw is mid-flight, and on the old
+# 3h reindexw slot that was 83% of the day — 05:15 landed inside a run every single time.
+# Result: the companies index went 14+ days without a single rebuild, silently, because a
+# skip is reported as success. Keep this firing inside a reindexw gap.
+OnCalendar=*-*-* 12:30:00
+Persistent=true
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-reindex-dedup-only.service
+++ b/deploy/systemd/freehire-reindex-dedup-only.service
@@ -1,0 +1,40 @@
+[Unit]
+Description=freehire worker: duplicate-marker refresh only (no rebuild)
+# Only postgresql — unlike freehire-reindex-dedup.service, this invocation never opens a
+# Meilisearch client at all (REINDEX_DEDUP_ONLY short-circuits cmd/reindex before that),
+# so it needs no meilisearch.service ordering and no Conflicts= against freehire-reindexw:
+# there is nothing here for a concurrent rebuild to contend with.
+After=network.target postgresql.service
+# Never alongside the full marker+rebuild invocation: both write jobs.duplicate_of per
+# company in short transactions (safe to interleave, no table lock), but running both at
+# once is pure wasted CPU/IO for zero freshness gain, and the timer schedule already
+# keeps them apart — this is a backstop, not the thing making that true.
+Conflicts=freehire-reindex-dedup.service
+
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+# The only env difference from the plain freehire-reindexw invocation: REINDEX_DEDUP_ONLY
+# runs the three duplicate-marker passes (role clusters, aggregator suppression, fuzzy
+# collapse) and exits — see internal/config/reindex.go (Reindex.DedupOnly) and AGENTS.md.
+# It exists so the markers can refresh on a tighter cadence than freehire-reindex-dedup's
+# daily marker+rebuild round trip: the plain freehire-reindexw rebuild already runs every
+# 3h on its own schedule and picks up whatever markers are current at that moment, so
+# refreshing the markers alone is enough — freehire#2045.
+Environment=REINDEX_DEDUP_ONLY=1
+CPUWeight=40
+IOWeight=40
+ExecStart=/opt/freehire/src/hire-current/reindex
+# The 2026-08-16 quiet-hours measurement (freehire-reindex-dedup.service, same three
+# passes) was 18min role clusters + 23min aggregator suppression + 45min fuzzy collapse
+# ~= 86min end to end. The first real daytime run of THIS unit (2026-08-17, under normal
+# concurrent ingest/similar-backfill/autovacuum load) took 2h15m wall clock for the same
+# three passes despite only 7m50s of actual CPU time — CPUWeight=40/IOWeight=40
+# deliberately yields to that traffic, so wall time under load is not the quiet-hours
+# number. 4h keeps that a ~45min margin instead of the ~45min DEFICIT a 3h cap would have
+# left on that run — not unbounded, see the 2026-08-15 incident writeup in
+# freehire-reindexw.service for why an indefinite TimeoutStartSec is the wrong default for
+# a Type=oneshot unit.
+TimeoutStartSec=4h

--- a/deploy/systemd/freehire-reindex-dedup-only.timer
+++ b/deploy/systemd/freehire-reindex-dedup-only.timer
@@ -1,0 +1,32 @@
+[Unit]
+Description=timer: freehire-reindex-dedup-only
+
+[Timer]
+# Six times a day, OUTSIDE the 03:00-10:00 UTC block this host's other cron jobs already
+# own: freehire-pg-backup (03:00, ~77min), freehire-rollup-facets (04:15),
+# freehire-rollup-company (04:45), freehire-reindex-companies (05:15), and
+# freehire-reindex-dedup itself (06:30, ~3.5h end to end, finishing ~08:25). That last one
+# already refreshes the SAME three markers this timer refreshes, so skipping this slot
+# costs nothing — the daily run covers it.
+#
+# Outside that block, firing every 3h (01:30, 10:30, 13:30, 16:30, 19:30, 22:30) is what
+# actually shrinks the window: REINDEX_DEDUP=1 alone only refreshes markers once a day, so
+# a repost could sit undeduped in search for up to a day (freehire#2045 — a Fivetran
+# repost caught right in that window). The 3h spacing is a target, not a guarantee: the
+# first real daytime run took 2h15m under normal concurrent load (see the service's
+# TimeoutStartSec comment) against an 86min quiet-hours measurement, so some firings will
+# land while the prior run is still active. That is a silent no-op, not a stack or a
+# failure — Type=oneshot only starts a new instance if the unit isn't already active — and
+# it self-throttles to roughly run-time-plus-next-slot rather than a fixed 3h, which is
+# still a large improvement over the once-a-day floor this timer exists to beat.
+#
+# Persistent=true is safe here in a way it is explicitly NOT for
+# freehire-reindex-dedup.timer (see that file's comment on the 2026-08-17 13:17 incident):
+# this unit Conflicts= only with its own daily sibling, never with freehire-reindexw, so a
+# missed firing catching up at an arbitrary hour cannot kill an in-progress rebuild.
+OnCalendar=*-*-* 01,10,13,16,19,22:30:00
+Persistent=true
+RandomizedDelaySec=120
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-reindex-dedup.service
+++ b/deploy/systemd/freehire-reindex-dedup.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=freehire worker: duplicate-marker refresh (dedup + facet reindex)
+After=network.target postgresql.service meilisearch.service
+# Never alongside the plain reindex: same binary, same live index, and Meilisearch runs
+# ONE serial task queue — the second rebuild just queues behind the first and reads as a
+# hang.
+Conflicts=freehire-reindexw.service
+
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+# The only difference from freehire-reindexw: this invocation ALSO refreshes the three
+# duplicate markers (role clusters, aggregator suppression, fuzzy collapse) before the
+# rebuild. Those passes were part of every reindex until 2026-08-16, by which point
+# aggregator suppression alone measured ~23h and the reindex had not completed once in
+# three days — it was cancelled mid-dedup and never reached the rebuild it exists for.
+Environment=REINDEX_DEDUP=1
+CPUWeight=40
+IOWeight=40
+# Same drain pause as freehire-reindexw, and for the same reason: this run ends in a
+# rebuild that swaps the live index, and a concurrent search-drain push re-merges the
+# WHOLE index against it. ExecStopPost restores the timer on failure too.
+ExecStartPre=+/usr/bin/systemctl stop freehire-search-drain.timer
+ExecStart=/opt/freehire/src/hire-current/reindex
+ExecStopPost=+/usr/bin/systemctl start freehire-search-drain.timer
+# Deliberately larger than freehire-reindexw's 4h, because the dedup passes are what
+# make this run long — and deliberately NOT unbounded: search-drain is paused for the
+# whole run (see the 2026-08-15 incident in freehire-reindexw.service), so a run that
+# never stops takes incremental indexing down with it.
+TimeoutStartSec=8h

--- a/deploy/systemd/freehire-reindex-dedup.timer
+++ b/deploy/systemd/freehire-reindex-dedup.timer
@@ -1,0 +1,25 @@
+[Unit]
+Description=timer: freehire-reindex-dedup
+
+[Timer]
+# DAILY. It was weekly, which meant a duplicate the ingest-time coverage gate could not
+# catch stayed visible for up to 7 days; the pass costs 9m38s CPU / ~1h55m wall, so
+# running it every night is affordable and cuts that window to one day.
+#
+# The 06:30 slot is what makes this safe and it is load-bearing: it clears the 03:00 UTC
+# pg_dump (ACCESS SHARE on every table for its whole ~77-minute run) and the 04:15
+# rollup-facets / 04:45 rollup-company / 05:15 reindex-companies chain, and it finishes
+# around 08:25 — before the 09:15 freehire-reindexw firing, which shares Meilisearch's
+# single task queue and would otherwise STOP this run mid-rebuild (Conflicts= in the
+# service, and it cuts both ways).
+#
+# NO Persistent=true. It was here while this ran weekly, where skipping a whole week was
+# worth a catch-up; daily it is a hazard, and on 2026-08-17 it fired one the moment the
+# unit was reloaded — 13:17 on a weekday, which killed a freehire-reindexw that was an
+# hour into its run. A missed nightly pass is simply tomorrow's pass; a catch-up at an
+# arbitrary hour lands on the every-3h reindexw cadence this slot exists to dodge.
+OnCalendar=*-*-* 06:30:00
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-reindexw.service
+++ b/deploy/systemd/freehire-reindexw.service
@@ -1,0 +1,42 @@
+[Unit]
+Description=freehire worker: facet reindex
+After=network.target postgresql.service meilisearch.service
+[Service]
+Type=oneshot
+User=freehire
+# hire-current, not hire-blue: the release symlink is what survives a colour swap.
+# This file said hire-blue until 2026-08-15 while the DEPLOYED unit had already been
+# hand-edited to hire-current — deploying this file as it stood would have pointed the
+# reindex at whichever colour happened to be blue.
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+# search-drain pushes to the same live Meili index this rebuild swaps into; running both
+# at once is exactly the concurrent-push contention internal/searchdrain/AGENTS.md warns
+# about (each push re-merges the WHOLE index). Pause the drain TIMER (not the service —
+# an in-flight batch is left to finish naturally, not killed mid-push) before this
+# starts, and always resume it after, success or failure alike (+ExecStopPost still runs
+# on failure, unlike a plain "run after" step) — added after the 2026-08-06 incident
+# where search-drain was left off manually and forgotten.
+#
+# These two lines were added directly on host-2 and never committed back; this file
+# lacked them entirely until 2026-08-15.
+ExecStartPre=+/usr/bin/systemctl stop freehire-search-drain.timer
+ExecStart=/opt/freehire/src/hire-current/reindex
+ExecStopPost=+/usr/bin/systemctl start freehire-search-drain.timer
+# THE 2026-08-15 INCIDENT, and why this line exists.
+#
+# ExecStopPost only runs when the service STOPS. Type=oneshot defaults TimeoutStartSec
+# to *infinity*, so a run that never finishes never stops, never restores the drain
+# timer, and the live index silently stops being updated — for six hours, that day,
+# while Postgres ingested normally and nothing alerted. The stop/start pair above is
+# stateful, and an unbounded run is the state it cannot leave.
+#
+# Four hours is well above a healthy full rebuild and bounds the blast radius: a killed
+# run loses its work (the swap is atomic — a partial rebuild lands nothing) and the next
+# timer starts over, which is bad but recoverable, whereas an indefinitely stalled run
+# takes the whole search index down with it and stays there. If this fires routinely,
+# the answer is NOT a larger number: it means the dedup passes have outgrown the 3-hour
+# timer period, which the pipeline dashboard now makes visible.
+TimeoutStartSec=4h

--- a/deploy/systemd/freehire-reindexw.service.d/10-timeout.conf
+++ b/deploy/systemd/freehire-reindexw.service.d/10-timeout.conf
@@ -1,0 +1,8 @@
+# 2026-08-16: the default 4h TimeoutStartSec killed two runs in a row after the manual
+# backfill-derive (577k rows updated, 30.5k slugs moved, 1335 companies orphaned) made the
+# duplicate-recompute phases much heavier than usual. Each kill threw the whole run away and
+# the next started from scratch — a loop that also left search-drain stopped (reindexw stops
+# its timer in ExecStartPre and only restarts it in ExecStopPost), so search_outbox grew to
+# ~79k. 12h lets one run actually finish. Revisit once the catalogue-wide backfill settles.
+[Service]
+TimeoutStartSec=12h

--- a/deploy/systemd/freehire-reindexw.timer
+++ b/deploy/systemd/freehire-reindexw.timer
@@ -1,0 +1,21 @@
+[Unit]
+Description=timer: freehire-reindexw
+
+[Timer]
+# Every 6h, offset to 03:15 — NOT every 3h, and NOT on the :15 that collides with
+# freehire-reindex-dedup.timer's 06:30 (that unit rebuilds the whole index itself).
+#
+# Why 6h: a full facet rebuild is ~1.47M documents and measured 2h23m-2h30m per run
+# (2026-08-17: 18:40->21:10, 21:40->00:03). On the old 3h slot that left ~30 min of
+# free Meilisearch per cycle, and reindexw's ExecStartPre stops the search-drain timer
+# for the duration — so search_outbox drained only 17% of the day and the
+# pipeline-search-backlog alert fired continuously from 19:35 onward with a 22k backlog.
+# Meilisearch runs ONE serial task queue, so a rebuild in flight starves every
+# incremental drain batch: 200 docs took 31s under contention vs 2.6s free.
+# 6h leaves ~3.5h of clear queue between runs. Revisit if a run ever exceeds ~4h.
+OnCalendar=*-*-* 03/6:15:00
+Persistent=true
+RandomizedDelaySec=120
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-remind.service
+++ b/deploy/systemd/freehire-remind.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=freehire worker: saved-job reminders
+After=network.target postgresql.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+ExecStart=/opt/freehire/src/hire-current/remind

--- a/deploy/systemd/freehire-remind.service.d/mail.conf
+++ b/deploy/systemd/freehire-remind.service.d/mail.conf
@@ -1,0 +1,6 @@
+# The mail sender credentials (NOTIFY_EMAIL_FROM + SES keys) live in their own file,
+# which freehire-notify/onboarding/broadcast already read. Without it the email channel
+# never registers here, and every email reminder soft-skips forever while the run still
+# exits 0 -- 244 of them had piled up by 2026-09-01.
+[Service]
+EnvironmentFile=/opt/freehire/.env.notify

--- a/deploy/systemd/freehire-remind.timer
+++ b/deploy/systemd/freehire-remind.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=timer: freehire-remind
+[Timer]
+# Every 15 min — a saved-job reminder is a "come back later" nudge, so a
+# "tomorrow" reminder firing within a quarter-hour of its deadline is plenty
+# precise, and the due-scan is cheap (indexed, bounded batch).
+OnCalendar=*:0/15
+Persistent=true
+RandomizedDelaySec=120
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-rollup-company.service
+++ b/deploy/systemd/freehire-rollup-company.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=freehire worker: per-company hiring-signal rollup
+After=network.target postgresql.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+ExecStart=/opt/freehire/src/hire-current/rollup-company

--- a/deploy/systemd/freehire-rollup-company.timer
+++ b/deploy/systemd/freehire-rollup-company.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=timer: freehire-rollup-company
+[Timer]
+# Daily — per-company hiring velocity moves slowly. 04:45 UTC sits after the 03:00
+# pg-backup and the 04:15 rollup-facets, and off the every-3h rollup-stats cadence.
+OnCalendar=*-*-* 04:45:00
+Persistent=true
+RandomizedDelaySec=300
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-rollup-facets.service
+++ b/deploy/systemd/freehire-rollup-facets.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=freehire worker: daily /open facet-distribution rollup
+# Needs Meilisearch (the snapshot's source is a facet count) as well as Postgres.
+After=network.target postgresql.service meilisearch.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+ExecStart=/opt/freehire/src/hire-current/rollup-facets

--- a/deploy/systemd/freehire-rollup-facets.timer
+++ b/deploy/systemd/freehire-rollup-facets.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=timer: freehire-rollup-facets
+[Timer]
+# Daily — /open facet distributions move slowly. 04:15 UTC sits after the 03:00
+# pg-backup and off the every-3h rollup-stats/reindex cadence.
+OnCalendar=*-*-* 04:15:00
+Persistent=true
+RandomizedDelaySec=300
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-rollup-stats.service
+++ b/deploy/systemd/freehire-rollup-stats.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=freehire worker: daily job-activity rollup
+After=network.target postgresql.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+ExecStart=/opt/freehire/src/hire-current/rollup-stats

--- a/deploy/systemd/freehire-rollup-stats.timer
+++ b/deploy/systemd/freehire-rollup-stats.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer: freehire-rollup-stats
+[Timer]
+OnCalendar=*-*-* 00/3:20:00
+Persistent=true
+RandomizedDelaySec=180
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-rollup-views.service
+++ b/deploy/systemd/freehire-rollup-views.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=freehire worker: daily nginx-log view-count rollup
+After=network.target postgresql.service
+[Service]
+Type=oneshot
+User=freehire
+# nginx access logs are mode 640 www-data:adm; the freehire user needs the adm
+# group to read them. The worker reads the logs off the request path and applies
+# per-(day, job) view counts into jobs.view_count + job_daily_views.
+SupplementaryGroups=adm
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+# Daily mode processes the uncompressed rotated file (access.log.1 = yesterday,
+# kept uncompressed for a day by logrotate delaycompress). The content-signature
+# cursor skips already-applied files. One-shot --backfill (over the .gz history) is
+# run by hand, not on the timer.
+ExecStart=/opt/freehire/src/hire-current/rollup-views

--- a/deploy/systemd/freehire-rollup-views.timer
+++ b/deploy/systemd/freehire-rollup-views.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer: freehire-rollup-views
+[Timer]
+OnCalendar=*-*-* 02:30:00
+Persistent=true
+RandomizedDelaySec=300
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-search-drain.service
+++ b/deploy/systemd/freehire-search-drain.service
@@ -1,0 +1,42 @@
+[Unit]
+Description=freehire worker: incremental facet-search index drain (search_outbox)
+After=network.target postgresql.service meilisearch.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+# Lower than the other light workers (40/40): this one runs continuously — one push
+# every ~90-100s, all day (a live-index push on this catalogue costs that regardless
+# of batch size, see freehire#1596) — so even success-path operation keeps a steady
+# background IO/CPU draw. 2026-08-06: at 40/40 it coincided with ~90 nginx 504s/hour
+# (freehire-web accept-queue starvation, see AGENTS.md in internal/searchdrain) even
+# though the worker itself never failed. Dropped to 10/10 live via
+# `systemctl set-property --runtime` before this file was updated to match.
+CPUWeight=10
+IOWeight=10
+# There is deliberately NO reindex guard here any more, and the reason is worth reading
+# before adding one back.
+#
+# This file used to carry
+#     ExecStartPre=/bin/sh -c '! systemctl is-active --quiet freehire-reindexw.service'
+# meaning "skip this tick if a reindex is running". It never once did that. `systemctl
+# is-active --quiet` exits 0 only for the literal state `active`, and a Type=oneshot
+# service is **`activating`** for its entire run — exit 3 — which the `!` flips to
+# success. Measured on host-2 on 2026-08-15 with a reindex mid-run: guard exits 0, i.e.
+# "run anyway", every time. It was dead code that read like protection, and it was never
+# deployed to host-2 either, so nothing depended on it.
+#
+# What actually keeps the two apart is freehire-reindexw.service, which stops this
+# unit's TIMER on start and restarts it on stop. That is stateful and it is what failed
+# on 2026-08-15 — a run that never finished never restored the timer and the live index
+# silently stopped updating for six hours — so reindexw now carries TimeoutStartSec=4h,
+# which bounds the worst case rather than leaving it open-ended.
+#
+# If you do want a guard here, note that a CORRECT one (matching `activating` too) is a
+# behaviour change, not a bug fix: it would idle the drain for the whole of every
+# reindex, including the hours those runs spend purely in Postgres dedup passes touching
+# no Meili at all. That is the staleness this pipeline exists to catch, so weigh it
+# against the contention it prevents. The cheap mechanism already in place is the weight
+# split — 10/10 here against reindex's 40/40.
+ExecStart=/opt/freehire/src/hire-current/search-drain

--- a/deploy/systemd/freehire-search-drain.timer
+++ b/deploy/systemd/freehire-search-drain.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=timer: freehire-search-drain every 2 min
+[Timer]
+# Frequent and monotonic (not a wall-clock slot): search_outbox is fed continuously
+# by every ingest crawl, so freshness tracks how often this drains, not a fixed time
+# of day. Each run is a no-op fast exit when the queue is empty, so 2 min costs
+# nothing idle. See freehire#1594 (the incident this replaces: cmd/ingest used to
+# push straight to Meilisearch once per crawl across ~169 independent processes,
+# saturating host disk IO — this collapses that into few, fat, awaited pushes).
+OnBootSec=1min
+OnUnitActiveSec=2min
+Persistent=true
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-site-alert.service
+++ b/deploy/systemd/freehire-site-alert.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=freehire: site + memory + load alert (freehire.me/health, RAM, CPU load, Telegram)
+After=network-online.target
+Wants=network-online.target
+[Service]
+Type=oneshot
+# Runs as root: reads TELEGRAM_BOT_TOKEN + SITE_ALERT_CHAT_ID from /opt/freehire/.env (0600).
+ExecStart=/opt/freehire/bin/site-alert.sh
+Nice=15
+IOSchedulingClass=idle

--- a/deploy/systemd/freehire-site-alert.timer
+++ b/deploy/systemd/freehire-site-alert.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer: freehire site + memory alert every 2 min
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=2min
+Persistent=true
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-tg-extract.service
+++ b/deploy/systemd/freehire-tg-extract.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=freehire worker: telegram LLM extract
+After=network.target postgresql.service meilisearch.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+ExecStart=/opt/freehire/src/hire-current/tg-extract

--- a/deploy/systemd/freehire-tg-extract.timer
+++ b/deploy/systemd/freehire-tg-extract.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer: freehire-tg-extract
+[Timer]
+OnCalendar=*:45:00
+Persistent=true
+RandomizedDelaySec=120
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-tg-ingest.service
+++ b/deploy/systemd/freehire-tg-ingest.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=freehire worker: telegram crawl
+After=network.target postgresql.service meilisearch.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+CPUWeight=40
+IOWeight=40
+ExecStart=/opt/freehire/src/hire-current/tg-ingest

--- a/deploy/systemd/freehire-tg-ingest.timer
+++ b/deploy/systemd/freehire-tg-ingest.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer: freehire-tg-ingest
+[Timer]
+OnCalendar=*:40:00
+Persistent=true
+RandomizedDelaySec=120
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-web-metrics.service
+++ b/deploy/systemd/freehire-web-metrics.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=freehire: web-tier metrics (accept queue + nginx response rates) for the node_exporter textfile collector
+After=network-online.target
+Wants=network-online.target
+[Service]
+Type=oneshot
+# Runs as root to read /var/log/nginx/access.log (0640 www-data:adm) and to
+# write into the textfile directory. Low weights: this is observability, and it
+# must never be the reason the thing it observes is short of IO.
+ExecStart=/opt/freehire/bin/web-metrics.sh
+CPUWeight=20
+IOWeight=20
+Nice=10

--- a/deploy/systemd/freehire-web-metrics.timer
+++ b/deploy/systemd/freehire-web-metrics.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer: freehire web-tier metrics every 15s
+[Timer]
+OnBootSec=45s
+OnUnitActiveSec=15s
+Persistent=false
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-web-watchdog.service
+++ b/deploy/systemd/freehire-web-watchdog.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=freehire: web accept-queue watchdog (auto-restart on a wedged SSR process)
+After=network-online.target
+Wants=network-online.target
+[Service]
+Type=oneshot
+# Runs as root: needs `systemctl restart freehire-web@<color>` and reads
+# TELEGRAM_BOT_TOKEN + SITE_ALERT_CHAT_ID from /opt/freehire/.env (0600).
+ExecStart=/opt/freehire/bin/web-watchdog.sh
+Nice=0

--- a/deploy/systemd/freehire-web-watchdog.timer
+++ b/deploy/systemd/freehire-web-watchdog.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer: freehire web accept-queue watchdog every 15s
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=15s
+Persistent=false
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/freehire-web@.service
+++ b/deploy/systemd/freehire-web@.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=freehire web (%i)
+After=network.target freehire-api@%i.service
+[Service]
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-%i/web
+EnvironmentFile=/opt/freehire/env/hire-web.env
+EnvironmentFile=/opt/freehire/env/web-%i.env
+# cluster.js forks WEB_CLUSTER_WORKERS copies of the adapter-node server behind one
+# listening socket. `node build/index.js` was a single process, and Node is
+# single-threaded, so the SSR tier used one of this box's sixteen cores however
+# loaded it got: measured ceiling ~130 req/s against a 204 req/s peak on
+# 2026-08-14, which is what kept filling the accept queue below. Four workers hold
+# ~250 req/s; eight measured worse at 200 (they compete with ingest, Meili and
+# Postgres for the same cores, and each worker's ~370 MB comes out of the page
+# cache Meili lives on). See freehire/web/cluster.js and perf/k6 PROFILE=saturation.
+#
+# ORDER OF OPERATIONS: web/cluster.js must already exist in the built colour before
+# this unit starts. A colour built from a commit without it will fail to start.
+Environment=WEB_CLUSTER_WORKERS=4
+ExecStart=/usr/bin/node cluster.js
+# Interactive traffic must outweigh the batch worker pool: cgroup weights sum across
+# siblings, so ten ingest units at CPUWeight=40 add up to 400 and starve a
+# default-weight service. 2026-07-31: the SSR accept queue filled and nginx timed
+# out connecting while node itself was healthy.
+CPUWeight=500
+IOWeight=500
+Restart=on-failure
+RestartSec=2
+[Install]
+WantedBy=multi-user.target

--- a/docs/agents/notifications.md
+++ b/docs/agents/notifications.md
@@ -43,6 +43,15 @@ Telegram, and mobile push), each with its own small `Notifier`/`Router` pair:
 - **An unconfigured channel is a soft-skip, not a failure.** `Router.Send` returns
   `ErrChannelNotConfigured` (e.g. email while SES is unset) and the engine skips it. Don't
   promote that to a delivery error — it would fail every run in environments without SES.
+  **In production this makes a missing credential silent, and it has already cost a
+  channel.** The mail credentials live in their own env file
+  (`/opt/freehire/.env.notify`, not the `/opt/freehire/.env` every worker reads); the
+  `remind` and `nudge` units did not load it, so email reminders soft-skipped from the day
+  they shipped until 2026-09-01 while every run exited 0 with `failed=0`. 244 of them piled
+  up across 43 people. The health signal for these workers is therefore **`soft_skips` in
+  the run log, not the exit code**: a steady non-zero count against `delivered=0` is a dead
+  channel, not an absence of recipients. See [deploy/AGENTS.md](../../deploy/AGENTS.md) for
+  which units must read both files.
 - **A blocked Telegram bot unlinks the chat; it does not fail the delivery.** Every 403 the
   Bot API answers a send with means the chat is permanently closed (blocked, deactivated,
   bot removed), and no retry reaches it. `telegramnotify.ErrChatUnreachable` carries that up;


### PR DESCRIPTION
## What

The production host's systemd units (334 files) and operator scripts (13) now live in
`deploy/`. They existed only on host-2 until today.

## Why now

That is how `freehire-remind` and `freehire-nudge` came to read `/opt/freehire/.env` and
not `/opt/freehire/.env.notify` — the file holding `NOTIFY_EMAIL_FROM` and the SES keys.
Both lost their email channel silently: an unconfigured channel is a deliberate soft-skip,
so every run kept exiting 0 with `failed=0` while **244 email reminders piled up across 43
people**, the oldest from 20 July.

No saved-job reminder has ever been delivered by mail. The 17 that did land all went out
over Telegram or push — two of them had `email` in their channel list and were rescued by
Telegram.

## Already done on the host

- A `mail.conf` drop-in beside each unit (the spelling `freehire-api` already used).
- The 244 stuck reminders cancelled rather than mailed — one person was owed 76 letters at
  once, which is a spam complaint, not a service.
- Verified end to end: a test reminder on the `email` channel alone now reports
  `delivered=1 soft_skips=0` and stamps `delivered_at`.

## What is not here

The `.bak` files (a dozen dated copies of `release.sh` alone — what a directory without
version control grows instead of history) and the compiled binaries beside the scripts.

## Checks

- `deploy/check-drift.sh` diffs the host against this directory; nothing here deploys
  itself, so a snapshot nobody checks is fiction within a month.
- The 13 scripts are shellcheck-clean, which the `artifacts` job now enforces on them —
  every finding was style-level and is suppressed inline with its reason.
- `docs/agents/notifications.md` records the health signal these workers actually have:
  `soft_skips` in the run log, not the exit code.

## Follow-up after merge

Copy the shellcheck-annotated scripts to the host so `check-drift.sh` reads clean. The
edits are comments and two loop variables renamed to `_`; no behaviour changes.
