### PR TITLE
Answer an un-analysed vacancy with the state, not with a Bad Gateway

### DIFF
--- a/internal/api/handler/cover_letter_drafter.go
+++ b/internal/api/handler/cover_letter_drafter.go
@@ -71,9 +71,12 @@ func (d letterDrafter) draft(
 	if err != nil {
 		return nil, err
 	}
-	// Produces an analysis when none is cached, as the assistant's interview_context tool and
-	// the autopilot's run plan already do, and is not charged for it: a candidate who asks for
-	// a letter on a vacancy they never analysed gets one.
+	// REQUIRES a cached analysis; it does not produce one. Producing is Ensure's, and Ensure
+	// takes the coalescing Request the autopilot assembles — a letter has no business
+	// assembling that, and no business paying for an analysis the candidate did not ask for.
+	// An absent analysis therefore surfaces as ErrNoAnalysis, which the shared error mapper
+	// renders as "run the fit analysis first": a state the candidate can act on in the same
+	// workspace, one tab over.
 	tailoring, err := d.fit.TailoringContext(ctx, userID, job)
 	if err != nil {
 		return nil, err

--- a/internal/api/handler/cv_cover_letter.go
+++ b/internal/api/handler/cv_cover_letter.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"errors"
-	"log"
 
 	"github.com/gofiber/fiber/v2"
 
@@ -89,8 +88,12 @@ func (h *cvHandlers) DraftCVCoverLetter(c *fiber.Ctx) error {
 			"nothing in your experience bank is yours to cite yet: confirm an achievement first")
 	case err != nil:
 		releaseLetterCharge(h.plans, userID, charge)
-		log.Printf("coverletter: drafting for user %d job %d: %v", userID, jobID, err)
-		return fiber.NewError(fiber.StatusBadGateway, "the letter could not be drafted")
+		// Handed to the shared mapper rather than flattened here. It already knows the states
+		// this path meets — fitanalysis.ErrNoAnalysis is a 409 saying "run the fit analysis
+		// first", and errors.go says outright that the status is decided there rather than at
+		// each call site. Flattening every failure into 502 turned that answer into a Bad
+		// Gateway on production, on the majority of vacancies, where no analysis is cached.
+		return err
 	case letter == nil:
 		// The LLM is unconfigured. Nothing was spent and nothing was written.
 		releaseLetterCharge(h.plans, userID, charge)

--- a/internal/api/handler/cv_cover_letter_integration_test.go
+++ b/internal/api/handler/cv_cover_letter_integration_test.go
@@ -423,3 +423,33 @@ func TestCoverLetter_ExhaustedAllowanceRefusesTheWriteButNotTheRead(t *testing.T
 		t.Errorf("read after refusal = (%d, %+v), want the stored letter served", status, got)
 	}
 }
+
+// Shipped wrong once and reached production: the endpoint flattened every chain failure into a
+// 502, so the commonest state of all — a vacancy the candidate has not analysed yet — arrived
+// as a Bad Gateway instead of the 409 the shared error mapper already had an answer for.
+func TestCoverLetter_WithoutAnAnalysisSaysToRunOneRatherThanFailing(t *testing.T) {
+	pool := startPostgres(t)
+	f := newCoverLetterFixture(t, pool)
+
+	// No seedAnalysis here: this is a vacancy nobody has analysed, which on production is most
+	// of them.
+	model := chainFor(uuid.New(), "NEVER")
+	f.h.letter.chain = coverletter.NewAnalyzer(llm.NewWithModel(model))
+	f.h.llm = llmBinding{client: llm.NewWithModel(model)}
+
+	resp := doCV(t, f.app, fiber.MethodPost, "/api/v1/me/cvs/"+f.tailored.ID.String()+"/cover-letter", f.token, nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusConflict {
+		t.Fatalf("status = %d, want 409 — an un-analysed vacancy is a state the candidate can fix, not a gateway fault", resp.StatusCode)
+	}
+	var body struct {
+		Error string `json:"error"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if !strings.Contains(body.Error, "fit analysis") {
+		t.Errorf("error = %q, want it to name the fit analysis so the candidate knows what to do", body.Error)
+	}
+	if model.calls != 0 {
+		t.Errorf("model called %d times, want 0", model.calls)
+	}
+}

--- a/internal/candidate/coverletter/AGENTS.md
+++ b/internal/candidate/coverletter/AGENTS.md
@@ -87,6 +87,14 @@ caller overwrites that field regardless.
 The vacancy arrives as a `db.Job` parameter from a caller that has already loaded and
 authorized it: `candidate` is layer 4 and may never import `job` at layer 5.
 
+**A cached fit analysis is a precondition, not something drafting produces.** `Required` reads
+the cache and returns `ErrNoAnalysis` when it is empty; producing is `Ensure`'s, and `Ensure`
+takes the coalescing `Request` the autopilot assembles. A letter has no business assembling that
+and no business paying for an analysis the candidate did not ask for, so an absent analysis
+renders as "run the fit analysis first" — a state they can fix one tab over. This shipped wrong
+once: the endpoint flattened every chain failure into a 502, so the commonest state on
+production arrived as a Bad Gateway.
+
 ## Limitations
 
 - **The length bands are a decision, not a measurement.** No captured `apply_forms` field

--- a/openspec/changes/add-cover-letter-draft/design.md
+++ b/openspec/changes/add-cover-letter-draft/design.md
@@ -104,12 +104,22 @@ This inverts `matchanalysis`' rule deliberately, and the draft carries a languag
 reason the fit analysis does — so a candidate whose profile language changes does not silently keep
 a letter aimed at the wrong reader.
 
-### The fit analysis is required, and drafting will produce one if absent
+### A cached fit analysis is a precondition, and drafting does NOT produce one
 
-The chain reads `TailoringContext`, which needs an analysis. `fitanalysis.Required` already produces
-one when absent and is already used this way by the assistant's `interview_context` tool and the
-autopilot's run plan, neither of which is charged for it. The letter uses the same call, so a
-candidate who asks for a letter on a vacancy they have not analysed gets one rather than an error.
+The chain reads `TailoringContext`, which needs an analysis. This paragraph originally claimed
+`fitanalysis.Required` produces one when absent; **it does not** — it reads the cache and returns
+`ErrNoAnalysis`. Producing is `Ensure`'s, and `Ensure` takes the coalescing `Request` the autopilot
+assembles.
+
+Requiring rather than producing is also the right rule, not merely the available one. An analysis
+is its own metered action; drafting a letter must not quietly run and pay for one the candidate
+did not ask for. So an absent analysis surfaces as `ErrNoAnalysis`, which `errors.go` already
+renders as a 409 saying "run the fit analysis first" — a state the candidate fixes one tab over in
+the same workspace.
+
+This shipped wrong and reached production: the endpoint flattened every chain failure into a 502,
+so the commonest state of all arrived as a gateway fault with no hint of what to do. The handler
+now hands unknown failures to the shared mapper, which is what `errors.go` says to do.
 
 ### Storage
 

--- a/openspec/specs/cover-letter-draft/spec.md
+++ b/openspec/specs/cover-letter-draft/spec.md
@@ -1,0 +1,199 @@
+# cover-letter-draft
+
+The cover letter a vacancy's application form asks for, written from the achievement atoms the
+candidate has actually asserted.
+
+### Requirement: A cached fit analysis is a precondition of drafting
+
+Drafting SHALL require a fit analysis already cached for the (candidate, vacancy) pair, and
+SHALL NOT produce one. When none is cached the request SHALL be refused with a state the
+candidate can act on, and no model SHALL be called.
+
+#### Scenario: No analysis has been run for the vacancy
+
+- **WHEN** a candidate asks for a letter on a vacancy they have never analysed
+- **THEN** the request is refused with guidance to run the fit analysis first, and no model is called
+
+### Requirement: A cover letter is drafted by a fixed three-stage chain
+
+The system SHALL draft a cover letter for a (candidate, vacancy) pair through a fixed, typed
+prompt-chain of three stages, and SHALL NOT draft one through an autonomous tool-calling agent.
+The stages SHALL be:
+
+1. **Select** — choose the achievement atoms that answer this vacancy's requirements;
+2. **Draft** — write the letter from the selected atoms and the vacancy;
+3. **Audit** — a skeptic pass over the draft.
+
+Stage 3 SHALL merge onto the Stage 2 draft. When Stage 3's output cannot be parsed, the system
+SHALL serve the un-audited Stage 2 draft rather than failing the request, the same degradation
+`ai-fit-analysis` applies to its own audit stage.
+
+The server SHALL own every bound on the result — the length ceiling, the count of cited atoms, and
+the vocabulary of any enumerated field. The model SHALL NOT be trusted to observe them.
+
+#### Scenario: The three stages produce a letter
+
+- **WHEN** a candidate with banked experience requests a draft for a vacancy that has a cached fit analysis
+- **THEN** the three stages run in order and the response carries the audited letter body and the identifiers of the atoms it cites
+
+#### Scenario: The audit stage fails to parse
+
+- **WHEN** Stage 3 returns output that cannot be decoded
+- **THEN** the Stage 2 draft is sanitized and served, and the request does not fail
+
+#### Scenario: A model over-long body is bounded by the server
+
+- **WHEN** the chain returns a body longer than the configured ceiling
+- **THEN** the stored and served body is clipped to the ceiling
+
+### Requirement: Only evidence the candidate asserted may be cited
+
+Stage 1 SHALL select only atoms whose provenance is `manual`, `cv_import`, or `stated_in_chat`.
+An atom whose provenance is `agent_inferred`, or whose provenance is absent or unrecognised, SHALL
+NOT be offered to the chain and SHALL NOT appear in a letter's cited evidence.
+
+The filter SHALL be applied in the service, before any model call, and SHALL NOT be expressed only
+as an instruction inside a prompt.
+
+#### Scenario: An inferred atom is withheld
+
+- **WHEN** a candidate's bank holds an `agent_inferred` atom that scores highly against the vacancy
+- **THEN** the atom is not sent to the model and does not appear among the letter's cited atoms
+
+#### Scenario: An unrecognised provenance is withheld
+
+- **WHEN** an atom carries a provenance value outside the known set
+- **THEN** it is treated as not publishable and withheld
+
+#### Scenario: A candidate with no publishable evidence gets no letter
+
+- **WHEN** every atom in the candidate's bank is `agent_inferred`
+- **THEN** no chain runs, no model is called, and the response reports that there is no publishable evidence to draft from
+
+### Requirement: The letter reframes what the CV leaves implicit
+
+Stage 1 SHALL receive the fit analysis's requirement split and SHALL prioritise atoms answering
+requirements classified `missing-have` — requirements the candidate meets but whose evidence the CV
+does not surface. Requirements classified `missing-gap` SHALL NOT be answered with invented
+evidence; the letter SHALL either omit them or address them with adjacent publishable evidence,
+named as adjacent.
+
+#### Scenario: A missing-have requirement is answered
+
+- **WHEN** the fit analysis marks a requirement `missing-have` and the bank holds a publishable atom matching it
+- **THEN** the letter cites that atom against that requirement
+
+#### Scenario: A genuine gap is not invented over
+
+- **WHEN** the fit analysis marks a requirement `missing-gap` and no publishable atom answers it
+- **THEN** the letter makes no claim of experience with it
+
+### Requirement: The skeptic stage enforces support and length
+
+Stage 3 SHALL remove from the draft any sentence asserting the candidate's experience that is not
+supported by one of the atoms Stage 1 selected, and SHALL reduce the draft to the requested length
+band. Brevity SHALL be produced by this stage, not solely by an instruction in the drafting prompt.
+
+Sentences that carry no claim about the candidate's experience — the address, the statement of
+interest in the role or the employer, the closing — are not subject to the support rule.
+
+#### Scenario: An unsupported claim is cut
+
+- **WHEN** the Stage 2 draft asserts an achievement that matches no selected atom
+- **THEN** that assertion is absent from the audited letter
+
+#### Scenario: Motivation survives the audit
+
+- **WHEN** the Stage 2 draft states why the candidate is interested in the employer
+- **THEN** that statement is retained, because it asserts no experience
+
+#### Scenario: An over-long draft is shortened
+
+- **WHEN** the Stage 2 draft exceeds the requested length band
+- **THEN** the audited letter falls within the band
+
+### Requirement: The letter is written in the language of the vacancy
+
+The letter SHALL be written in the language of the vacancy, determined from the posting, and SHALL
+NOT be written in the candidate's profile language when the two differ. A stored draft SHALL record
+the language it was written in.
+
+#### Scenario: Profile language and vacancy language differ
+
+- **WHEN** a candidate whose profile language is Russian drafts a letter for a vacancy written in German
+- **THEN** the letter is written in German
+
+#### Scenario: The language is recorded
+
+- **WHEN** a draft is stored
+- **THEN** the row records the language the letter was written in
+
+### Requirement: Raw CV text never reaches the model
+
+The candidate context sent to the chain SHALL be the de-identified structured projection of the
+stored CV and nothing else. The raw CV text SHALL NOT be sent. A field absent from that projection
+SHALL NOT reach the model by any other route.
+
+#### Scenario: Only the projection is sent
+
+- **WHEN** a draft is requested for a candidate whose stored CV carries a phone number and a home address
+- **THEN** neither reaches the model, because the projection does not carry them
+
+### Requirement: One current draft is stored per candidate and vacancy
+
+The system SHALL store at most one draft per (candidate, vacancy). A new draft for the same pair
+SHALL replace the stored one. The system SHALL NOT keep a revision history and SHALL NOT offer undo.
+
+A stored draft SHALL be stamped with the model that produced it and the language it was written in,
+and SHALL be reported stale when either differs from the live value.
+
+#### Scenario: A second draft replaces the first
+
+- **WHEN** a candidate drafts a letter twice for the same vacancy
+- **THEN** the second body is stored and the first is not retained
+
+#### Scenario: A model upgrade marks a draft stale
+
+- **WHEN** the configured model changes after a draft was stored
+- **THEN** a read of that draft reports it stale
+
+### Requirement: Reading a draft never calls a model
+
+A read of a stored draft SHALL serve what is stored, or report that none exists, and SHALL NOT call
+a language model. Only an explicit request to draft SHALL run the chain.
+
+#### Scenario: A read with no stored draft
+
+- **WHEN** a candidate reads a draft for a vacancy they have never drafted for
+- **THEN** the response reports no draft and no model is called
+
+#### Scenario: A read with a stale stored draft
+
+- **WHEN** a candidate reads a draft whose model stamp is stale
+- **THEN** the stored body is served with its staleness reported, and no model is called
+
+### Requirement: The assistant tool and the endpoint share one chain
+
+The assistant SHALL offer a tool that drafts a cover letter, and that tool SHALL execute the same
+chain, the same provenance gate, and the same bounds as the endpoint. The tool SHALL act as the
+authenticated owner of the session.
+
+#### Scenario: The chat path and the button path agree
+
+- **WHEN** a candidate asks the assistant to draft a letter for a vacancy
+- **THEN** the letter is produced by the same chain the endpoint runs, and is stored as that pair's current draft
+
+#### Scenario: The tool observes the provenance gate
+
+- **WHEN** the assistant drafts a letter for a candidate whose bank holds `agent_inferred` atoms
+- **THEN** those atoms are withheld from the chain exactly as they are on the endpoint path
+
+### Requirement: A drafting failure degrades and does not corrupt
+
+An unconfigured or failing language model SHALL leave any previously stored draft untouched and
+SHALL return no letter, rather than storing a partial or empty body.
+
+#### Scenario: The gateway is unreachable
+
+- **WHEN** the model gateway fails mid-chain and a draft already exists for the pair
+- **THEN** the stored draft is unchanged and the request reports failure


### PR DESCRIPTION
## What and why

Production hotfix for #2284. First real use of the cover letter returned **502 Bad Gateway** on every attempt.

Two mistakes, one behind the other.

**`fitanalysis.Required` does not produce an analysis.** It reads the cache and returns `ErrNoAnalysis`. Producing is `Ensure`'s, and `Ensure` takes the coalescing `Request` the autopilot assembles. I had written the opposite into the design doc, the package doc and a code comment, and built the drafting path on it.

**The endpoint flattened every chain failure into `fiber.StatusBadGateway`.** That is what turned the misreading into a 502. `errors.go` already maps `ErrNoAnalysis` to a 409 saying *"run the fit analysis first"*, and it says outright:

> A state, not a fault — and one both readers of the fit service meet, so the status is decided here rather than at each call site.

The handler had gone around exactly that. So the commonest state on production — a vacancy nobody has analysed yet — reached the candidate as a gateway fault they could do nothing about, with no hint of what to do next.

### The fix

Unknown failures now go to the shared mapper. An un-analysed vacancy answers **409** naming the fit analysis, and no model is called.

Requiring rather than producing is also the right rule, not just the available one: an analysis is its own metered action, and drafting a letter must not quietly run and pay for one the candidate did not ask for. They fix it one tab over in the same workspace.

### Also in here

- `design.md`, the capability spec and `coverletter/AGENTS.md` corrected — a cached analysis is a **precondition** of drafting, stated as such.
- `openspec/specs/cover-letter-draft/spec.md` — the delta spec synced to the main specs on archive, carrying a new requirement for the precondition and its scenario.
- One integration test pinning the regression: no seeded analysis → 409, message names the fit analysis, zero model calls.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` and the cover-letter integration suite (10 tests) pass against a real Postgres.
- [x] I regenerated committed artifacts when their source changed — none changed here.
- [ ] For `design-system/` changes: not touched.
- [ ] For `web/` changes: not touched.
- [x] This stays within freehire's core/extension boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cover-letter drafting now returns a clear 409 response when fit analysis has not been run, instead of a generic 502 error.
  * Drafting failures now use consistent error handling and status mapping.
  * Prevents model calls when the required fit analysis is unavailable.

* **Documentation**
  * Clarified drafting prerequisites, evidence requirements, language handling, and safe CV data usage.
  * Added a specification describing the cover-letter drafting workflow and safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->