### PR TITLE
Stream the letter, because three model calls do not fit in one response

### DIFF
--- a/internal/api/handler/cover_letter_drafter.go
+++ b/internal/api/handler/cover_letter_drafter.go
@@ -71,9 +71,12 @@ func (d letterDrafter) draft(
 	if err != nil {
 		return nil, err
 	}
-	// Produces an analysis when none is cached, as the assistant's interview_context tool and
-	// the autopilot's run plan already do, and is not charged for it: a candidate who asks for
-	// a letter on a vacancy they never analysed gets one.
+	// REQUIRES a cached analysis; it does not produce one. Producing is Ensure's, and Ensure
+	// takes the coalescing Request the autopilot assembles — a letter has no business
+	// assembling that, and no business paying for an analysis the candidate did not ask for.
+	// An absent analysis therefore surfaces as ErrNoAnalysis, which the shared error mapper
+	// renders as "run the fit analysis first": a state the candidate can act on in the same
+	// workspace, one tab over.
 	tailoring, err := d.fit.TailoringContext(ctx, userID, job)
 	if err != nil {
 		return nil, err

--- a/internal/api/handler/cover_letter_drafter.go
+++ b/internal/api/handler/cover_letter_drafter.go
@@ -67,6 +67,15 @@ func (d letterDrafter) ready() bool {
 func (d letterDrafter) draft(
 	ctx context.Context, client *llm.Client, userID, jobID int64, band coverletter.Band,
 ) (*coverletter.Letter, error) {
+	return d.draftStream(ctx, client, userID, jobID, band, func(string, bool) {})
+}
+
+// draftStream is draft with progress. The streaming endpoint needs it because the chain takes
+// minutes and a silent response is one a proxy closes at sixty seconds; every other caller
+// takes the no-op above.
+func (d letterDrafter) draftStream(
+	ctx context.Context, client *llm.Client, userID, jobID int64, band coverletter.Band, emit coverletter.Emit,
+) (*coverletter.Letter, error) {
 	job, err := d.jobs.GetJob(ctx, jobID)
 	if err != nil {
 		return nil, err
@@ -93,13 +102,13 @@ func (d letterDrafter) draft(
 
 	// The atoms go in UNFILTERED: the provenance gate lives inside Draft so that no caller can
 	// apply a weaker one, or forget to apply it at all.
-	letter, err := d.chain.As(client).Draft(ctx, coverletter.Input{
+	letter, err := d.chain.As(client).DraftStream(ctx, coverletter.Input{
 		Context:         tailoring,
 		Candidate:       candidate,
 		Atoms:           atoms,
 		Band:            band,
 		PostingLanguage: job.PostingLanguage,
-	})
+	}, emit)
 	if err != nil || letter == nil {
 		return nil, err
 	}

--- a/internal/api/handler/cv.go
+++ b/internal/api/handler/cv.go
@@ -223,6 +223,11 @@ func (h *cvHandlers) register(api fiber.Router, mw middleware) {
 	// metered before this one is.
 	api.Get("/me/cvs/:id/cover-letter", mw.key, h.GetCVCoverLetter)
 	api.Post("/me/cvs/:id/cover-letter", mw.cookie, h.DraftCVCoverLetter)
+	// The streaming twin of that POST, and what the workspace actually calls. The chain is
+	// three model calls in series and takes minutes; a proxy closes a silent response at
+	// sixty seconds, so the one-shot POST reached production only as a 504. The POST stays
+	// for scripted callers whose own timeout they control.
+	api.Get("/me/cvs/:id/cover-letter/stream", mw.cookie, h.StreamCVCoverLetter)
 	// The history of what changed the CV, and the two ways to undo an entry: on its own, or
 	// as the run it belonged to. Cookie-only for the same reason as every other mutation —
 	// the browser is where the candidate is watching this happen, and the tailoring agent

--- a/internal/api/handler/cv_cover_letter.go
+++ b/internal/api/handler/cv_cover_letter.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"errors"
-	"log"
 
 	"github.com/gofiber/fiber/v2"
 
@@ -89,8 +88,12 @@ func (h *cvHandlers) DraftCVCoverLetter(c *fiber.Ctx) error {
 			"nothing in your experience bank is yours to cite yet: confirm an achievement first")
 	case err != nil:
 		releaseLetterCharge(h.plans, userID, charge)
-		log.Printf("coverletter: drafting for user %d job %d: %v", userID, jobID, err)
-		return fiber.NewError(fiber.StatusBadGateway, "the letter could not be drafted")
+		// Handed to the shared mapper rather than flattened here. It already knows the states
+		// this path meets — fitanalysis.ErrNoAnalysis is a 409 saying "run the fit analysis
+		// first", and errors.go says outright that the status is decided there rather than at
+		// each call site. Flattening every failure into 502 turned that answer into a Bad
+		// Gateway on production, on the majority of vacancies, where no analysis is cached.
+		return err
 	case letter == nil:
 		// The LLM is unconfigured. Nothing was spent and nothing was written.
 		releaseLetterCharge(h.plans, userID, charge)

--- a/internal/api/handler/cv_cover_letter_integration_test.go
+++ b/internal/api/handler/cv_cover_letter_integration_test.go
@@ -423,3 +423,33 @@ func TestCoverLetter_ExhaustedAllowanceRefusesTheWriteButNotTheRead(t *testing.T
 		t.Errorf("read after refusal = (%d, %+v), want the stored letter served", status, got)
 	}
 }
+
+// Shipped wrong once and reached production: the endpoint flattened every chain failure into a
+// 502, so the commonest state of all — a vacancy the candidate has not analysed yet — arrived
+// as a Bad Gateway instead of the 409 the shared error mapper already had an answer for.
+func TestCoverLetter_WithoutAnAnalysisSaysToRunOneRatherThanFailing(t *testing.T) {
+	pool := startPostgres(t)
+	f := newCoverLetterFixture(t, pool)
+
+	// No seedAnalysis here: this is a vacancy nobody has analysed, which on production is most
+	// of them.
+	model := chainFor(uuid.New(), "NEVER")
+	f.h.letter.chain = coverletter.NewAnalyzer(llm.NewWithModel(model))
+	f.h.llm = llmBinding{client: llm.NewWithModel(model)}
+
+	resp := doCV(t, f.app, fiber.MethodPost, "/api/v1/me/cvs/"+f.tailored.ID.String()+"/cover-letter", f.token, nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusConflict {
+		t.Fatalf("status = %d, want 409 — an un-analysed vacancy is a state the candidate can fix, not a gateway fault", resp.StatusCode)
+	}
+	var body struct {
+		Error string `json:"error"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if !strings.Contains(body.Error, "fit analysis") {
+		t.Errorf("error = %q, want it to name the fit analysis so the candidate knows what to do", body.Error)
+	}
+	if model.calls != 0 {
+		t.Errorf("model called %d times, want 0", model.calls)
+	}
+}

--- a/internal/api/handler/cv_cover_letter_stream.go
+++ b/internal/api/handler/cv_cover_letter_stream.go
@@ -1,0 +1,114 @@
+package handler
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/valyala/fasthttp"
+
+	"github.com/strelov1/freehire/internal/candidate/coverletter"
+	"github.com/strelov1/freehire/internal/platform/llm"
+)
+
+// letterStreamTimeout bounds the whole chain once the request context is gone. Three model
+// calls in series, each bounded at the client's own per-call timeout, need room for the worst
+// case without letting a wedged gateway hold a goroutine forever.
+const letterStreamTimeout = 6 * time.Minute
+
+// StreamCVCoverLetter drafts the letter over Server-Sent Events.
+//
+// This exists because the POST cannot work. The chain is three model calls in series and takes
+// minutes; a proxy holding a silent response gives up at sixty seconds, so every draft reached
+// the candidate as a 504 from the edge while the server was still working. The fit chain
+// streams for exactly this reason, and a letter is the same shape of work.
+//
+// Events: `stage` as each step opens and closes, then either `letter` with the finished draft
+// and its resolved evidence, or `error` with a sentence to render. The stream always closes
+// with one or the other, so a reader never has to guess.
+func (h *cvHandlers) StreamCVCoverLetter(c *fiber.Ctx) error {
+	drafter := h.letterDrafter()
+	if !drafter.ready() {
+		return fiber.NewError(fiber.StatusServiceUnavailable, "cover letters are not enabled on this deployment")
+	}
+	userID, jobID, err := h.coverLetterTarget(c)
+	if err != nil {
+		return err
+	}
+
+	// Charged BEFORE the stream opens, while the fiber ctx is still valid — a refused caller
+	// gets a real 402 rather than an error event inside a 200 nobody status-checks.
+	attempt := letterAttempt(c.Context(), h.letter.letters, userID, jobID)
+	charge, refused, decision := chargeLetter(c.Context(), h.plans, userID, jobID, attempt)
+	if refused {
+		return refuse(c, decision)
+	}
+
+	// Everything the writer needs is captured here: the fiber ctx is released the moment this
+	// handler returns, so reading it inside the stream would race a recycled request.
+	band := coverLetterBand(c)
+	client := h.llm.bind(c.Context(), userID, llm.Feature(tagCoverLetter))
+	conn := c.Context().Conn()
+
+	sseHeaders(c)
+	c.Context().SetBodyStreamWriter(fasthttp.StreamWriter(func(w *bufio.Writer) {
+		stream := newSSEStream(w, conn, sseWriteTimeout)
+
+		// A background context on purpose, the same rule the fit stream states: the request
+		// ctx is gone by now, and a client that navigates away must not abort a chain their
+		// allowance was just charged for. Finishing puts the letter in the store for when
+		// they come back; aborting would charge them for nothing.
+		ctx, cancel := context.WithTimeout(context.Background(), letterStreamTimeout)
+		defer cancel()
+
+		// The first event goes out before any model call, which is the whole point: it is what
+		// keeps the proxy from closing a response that has said nothing for a minute.
+		stream.event("stage", letterStageEvent{Stage: coverletter.StageSelect})
+
+		letter, err := drafter.draftStream(ctx, client, userID, jobID, band, func(stage string, done bool) {
+			stream.event("stage", letterStageEvent{Stage: stage, Done: done})
+		})
+		switch {
+		case errors.Is(err, coverletter.ErrNoPublishableEvidence):
+			releaseLetterCharge(h.plans, userID, charge)
+			stream.event("error", letterErrorEvent{
+				Error: "nothing in your experience bank is yours to cite yet: confirm an achievement first",
+			})
+		case err != nil:
+			releaseLetterCharge(h.plans, userID, charge)
+			log.Printf("coverletter: streaming for user %d job %d: %v", userID, jobID, err)
+			// The message is the mapper's, so a streamed failure reads the same as the one the
+			// POST path renders — an un-analysed vacancy says "run the fit analysis first"
+			// here too, rather than becoming a bare "something went wrong".
+			_, msg, _ := classify(err)
+			stream.event("error", letterErrorEvent{Error: msg})
+		case letter == nil:
+			releaseLetterCharge(h.plans, userID, charge)
+			stream.event("error", letterErrorEvent{Error: "drafting is unavailable on this deployment"})
+		default:
+			stream.event("letter", coverLetterResponse{
+				Present: true,
+				Letter:  letter,
+				Cited:   citedAtomsOf(ctx, drafter.bank, userID, letter.Cited),
+				Model:   modelIDOf(client),
+			})
+		}
+	}))
+	return nil
+}
+
+// letterStageEvent reports one step of the chain opening or closing.
+type letterStageEvent struct {
+	Stage string `json:"stage"`
+	Done  bool   `json:"done"`
+}
+
+// letterErrorEvent carries a sentence the surface renders. It rides inside a 200 because the
+// status was written before the first model call — which is why the stream must always close
+// with either this or a letter, and never with silence.
+type letterErrorEvent struct {
+	Error string `json:"error"`
+}

--- a/internal/candidate/coverletter/AGENTS.md
+++ b/internal/candidate/coverletter/AGENTS.md
@@ -87,6 +87,14 @@ caller overwrites that field regardless.
 The vacancy arrives as a `db.Job` parameter from a caller that has already loaded and
 authorized it: `candidate` is layer 4 and may never import `job` at layer 5.
 
+**A cached fit analysis is a precondition, not something drafting produces.** `Required` reads
+the cache and returns `ErrNoAnalysis` when it is empty; producing is `Ensure`'s, and `Ensure`
+takes the coalescing `Request` the autopilot assembles. A letter has no business assembling that
+and no business paying for an analysis the candidate did not ask for, so an absent analysis
+renders as "run the fit analysis first" — a state they can fix one tab over. This shipped wrong
+once: the endpoint flattened every chain failure into a 502, so the commonest state on
+production arrived as a Bad Gateway.
+
 ## Limitations
 
 - **The length bands are a decision, not a measurement.** No captured `apply_forms` field

--- a/internal/candidate/coverletter/analyzer.go
+++ b/internal/candidate/coverletter/analyzer.go
@@ -81,12 +81,34 @@ func LanguageOf(postingLanguage string) string {
 	return "en"
 }
 
-// Draft runs select → draft → audit and returns the audited letter.
+// Stage names a step of the chain, as a progress reader sees it.
+const (
+	StageSelect = "select"
+	StageDraft  = "draft"
+	StageAudit  = "audit"
+)
+
+// Emit reports a stage starting or finishing.
+//
+// It exists because the chain takes minutes. Three model calls in series, each bounded only by
+// the client's own per-call timeout, is far past what a proxy will hold a silent response open
+// for — this shipped without it and every draft came back as a 504 from the edge while the
+// server was still working. A reader that sees the first stage immediately is a reader whose
+// connection stays alive, which is the same reason the fit chain streams.
+type Emit func(stage string, done bool)
+
+// Draft runs the chain and returns the audited letter, reporting no progress. A thin wrapper
+// over DraftStream, mirroring matchanalysis.Analyze over AnalyzeStream.
+func (a *Analyzer) Draft(ctx context.Context, in Input) (*Letter, error) {
+	return a.DraftStream(ctx, in, func(string, bool) {})
+}
+
+// DraftStream runs select → draft → audit, calling emit as each stage opens and closes.
 //
 // Returns (nil, nil) when the LLM is unconfigured. Returns ErrNoPublishableEvidence when the
 // gate leaves nothing to write from. Any gateway failure is returned as an error with no
 // letter, so a caller can never overwrite a stored draft with an empty one.
-func (a *Analyzer) Draft(ctx context.Context, in Input) (*Letter, error) {
+func (a *Analyzer) DraftStream(ctx context.Context, in Input, emit Emit) (*Letter, error) {
 	if a == nil || a.client == nil {
 		return nil, nil
 	}
@@ -105,10 +127,12 @@ func (a *Analyzer) Draft(ctx context.Context, in Input) (*Letter, error) {
 	offered := IDs(atoms)
 	language := LanguageOf(in.PostingLanguage)
 
+	emit(StageSelect, false)
 	selected, err := a.selectEvidence(ctx, in, atoms)
 	if err != nil {
 		return nil, err
 	}
+	emit(StageSelect, true)
 	// A selection stage that names nothing leaves the drafting stage with no evidence, which
 	// is the empty-evidence case arriving one stage later. Fall back to what was offered
 	// rather than writing from nothing — but remember that nothing was CLAIMED, because the
@@ -126,10 +150,12 @@ func (a *Analyzer) Draft(ctx context.Context, in Input) (*Letter, error) {
 		l.Sanitize(in.Band, in.Bounds, offered)
 	}
 
+	emit(StageDraft, false)
 	drafted, err := a.write(ctx, in, selected, language)
 	if err != nil {
 		return nil, err
 	}
+	emit(StageDraft, true)
 	// Stage 1's selection is what the draft rests on until the audit says otherwise. When the
 	// selection was itself a fallback to everything offered, nothing has claimed to use any
 	// particular atom, and an empty list is the honest answer — listing five of thirty would
@@ -140,7 +166,9 @@ func (a *Analyzer) Draft(ctx context.Context, in Input) (*Letter, error) {
 	}
 	settle(&drafted, drafted.Cited)
 
+	emit(StageAudit, false)
 	audited, err := a.audit(ctx, in, drafted, selected)
+	emit(StageAudit, true)
 	// A gateway failure is NOT the degradation this stage is allowed. An answer that arrives
 	// and cannot be read leaves the draft standing — a third stage may improve a letter and
 	// never destroy it — but an answer that never arrived means the skeptic did not run, and

--- a/openspec/changes/add-cover-letter-draft/design.md
+++ b/openspec/changes/add-cover-letter-draft/design.md
@@ -104,12 +104,22 @@ This inverts `matchanalysis`' rule deliberately, and the draft carries a languag
 reason the fit analysis does — so a candidate whose profile language changes does not silently keep
 a letter aimed at the wrong reader.
 
-### The fit analysis is required, and drafting will produce one if absent
+### A cached fit analysis is a precondition, and drafting does NOT produce one
 
-The chain reads `TailoringContext`, which needs an analysis. `fitanalysis.Required` already produces
-one when absent and is already used this way by the assistant's `interview_context` tool and the
-autopilot's run plan, neither of which is charged for it. The letter uses the same call, so a
-candidate who asks for a letter on a vacancy they have not analysed gets one rather than an error.
+The chain reads `TailoringContext`, which needs an analysis. This paragraph originally claimed
+`fitanalysis.Required` produces one when absent; **it does not** — it reads the cache and returns
+`ErrNoAnalysis`. Producing is `Ensure`'s, and `Ensure` takes the coalescing `Request` the autopilot
+assembles.
+
+Requiring rather than producing is also the right rule, not merely the available one. An analysis
+is its own metered action; drafting a letter must not quietly run and pay for one the candidate
+did not ask for. So an absent analysis surfaces as `ErrNoAnalysis`, which `errors.go` already
+renders as a 409 saying "run the fit analysis first" — a state the candidate fixes one tab over in
+the same workspace.
+
+This shipped wrong and reached production: the endpoint flattened every chain failure into a 502,
+so the commonest state of all arrived as a gateway fault with no hint of what to do. The handler
+now hands unknown failures to the shared mapper, which is what `errors.go` says to do.
 
 ### Storage
 

--- a/openspec/specs/cover-letter-draft/spec.md
+++ b/openspec/specs/cover-letter-draft/spec.md
@@ -1,0 +1,199 @@
+# cover-letter-draft
+
+The cover letter a vacancy's application form asks for, written from the achievement atoms the
+candidate has actually asserted.
+
+### Requirement: A cached fit analysis is a precondition of drafting
+
+Drafting SHALL require a fit analysis already cached for the (candidate, vacancy) pair, and
+SHALL NOT produce one. When none is cached the request SHALL be refused with a state the
+candidate can act on, and no model SHALL be called.
+
+#### Scenario: No analysis has been run for the vacancy
+
+- **WHEN** a candidate asks for a letter on a vacancy they have never analysed
+- **THEN** the request is refused with guidance to run the fit analysis first, and no model is called
+
+### Requirement: A cover letter is drafted by a fixed three-stage chain
+
+The system SHALL draft a cover letter for a (candidate, vacancy) pair through a fixed, typed
+prompt-chain of three stages, and SHALL NOT draft one through an autonomous tool-calling agent.
+The stages SHALL be:
+
+1. **Select** — choose the achievement atoms that answer this vacancy's requirements;
+2. **Draft** — write the letter from the selected atoms and the vacancy;
+3. **Audit** — a skeptic pass over the draft.
+
+Stage 3 SHALL merge onto the Stage 2 draft. When Stage 3's output cannot be parsed, the system
+SHALL serve the un-audited Stage 2 draft rather than failing the request, the same degradation
+`ai-fit-analysis` applies to its own audit stage.
+
+The server SHALL own every bound on the result — the length ceiling, the count of cited atoms, and
+the vocabulary of any enumerated field. The model SHALL NOT be trusted to observe them.
+
+#### Scenario: The three stages produce a letter
+
+- **WHEN** a candidate with banked experience requests a draft for a vacancy that has a cached fit analysis
+- **THEN** the three stages run in order and the response carries the audited letter body and the identifiers of the atoms it cites
+
+#### Scenario: The audit stage fails to parse
+
+- **WHEN** Stage 3 returns output that cannot be decoded
+- **THEN** the Stage 2 draft is sanitized and served, and the request does not fail
+
+#### Scenario: A model over-long body is bounded by the server
+
+- **WHEN** the chain returns a body longer than the configured ceiling
+- **THEN** the stored and served body is clipped to the ceiling
+
+### Requirement: Only evidence the candidate asserted may be cited
+
+Stage 1 SHALL select only atoms whose provenance is `manual`, `cv_import`, or `stated_in_chat`.
+An atom whose provenance is `agent_inferred`, or whose provenance is absent or unrecognised, SHALL
+NOT be offered to the chain and SHALL NOT appear in a letter's cited evidence.
+
+The filter SHALL be applied in the service, before any model call, and SHALL NOT be expressed only
+as an instruction inside a prompt.
+
+#### Scenario: An inferred atom is withheld
+
+- **WHEN** a candidate's bank holds an `agent_inferred` atom that scores highly against the vacancy
+- **THEN** the atom is not sent to the model and does not appear among the letter's cited atoms
+
+#### Scenario: An unrecognised provenance is withheld
+
+- **WHEN** an atom carries a provenance value outside the known set
+- **THEN** it is treated as not publishable and withheld
+
+#### Scenario: A candidate with no publishable evidence gets no letter
+
+- **WHEN** every atom in the candidate's bank is `agent_inferred`
+- **THEN** no chain runs, no model is called, and the response reports that there is no publishable evidence to draft from
+
+### Requirement: The letter reframes what the CV leaves implicit
+
+Stage 1 SHALL receive the fit analysis's requirement split and SHALL prioritise atoms answering
+requirements classified `missing-have` — requirements the candidate meets but whose evidence the CV
+does not surface. Requirements classified `missing-gap` SHALL NOT be answered with invented
+evidence; the letter SHALL either omit them or address them with adjacent publishable evidence,
+named as adjacent.
+
+#### Scenario: A missing-have requirement is answered
+
+- **WHEN** the fit analysis marks a requirement `missing-have` and the bank holds a publishable atom matching it
+- **THEN** the letter cites that atom against that requirement
+
+#### Scenario: A genuine gap is not invented over
+
+- **WHEN** the fit analysis marks a requirement `missing-gap` and no publishable atom answers it
+- **THEN** the letter makes no claim of experience with it
+
+### Requirement: The skeptic stage enforces support and length
+
+Stage 3 SHALL remove from the draft any sentence asserting the candidate's experience that is not
+supported by one of the atoms Stage 1 selected, and SHALL reduce the draft to the requested length
+band. Brevity SHALL be produced by this stage, not solely by an instruction in the drafting prompt.
+
+Sentences that carry no claim about the candidate's experience — the address, the statement of
+interest in the role or the employer, the closing — are not subject to the support rule.
+
+#### Scenario: An unsupported claim is cut
+
+- **WHEN** the Stage 2 draft asserts an achievement that matches no selected atom
+- **THEN** that assertion is absent from the audited letter
+
+#### Scenario: Motivation survives the audit
+
+- **WHEN** the Stage 2 draft states why the candidate is interested in the employer
+- **THEN** that statement is retained, because it asserts no experience
+
+#### Scenario: An over-long draft is shortened
+
+- **WHEN** the Stage 2 draft exceeds the requested length band
+- **THEN** the audited letter falls within the band
+
+### Requirement: The letter is written in the language of the vacancy
+
+The letter SHALL be written in the language of the vacancy, determined from the posting, and SHALL
+NOT be written in the candidate's profile language when the two differ. A stored draft SHALL record
+the language it was written in.
+
+#### Scenario: Profile language and vacancy language differ
+
+- **WHEN** a candidate whose profile language is Russian drafts a letter for a vacancy written in German
+- **THEN** the letter is written in German
+
+#### Scenario: The language is recorded
+
+- **WHEN** a draft is stored
+- **THEN** the row records the language the letter was written in
+
+### Requirement: Raw CV text never reaches the model
+
+The candidate context sent to the chain SHALL be the de-identified structured projection of the
+stored CV and nothing else. The raw CV text SHALL NOT be sent. A field absent from that projection
+SHALL NOT reach the model by any other route.
+
+#### Scenario: Only the projection is sent
+
+- **WHEN** a draft is requested for a candidate whose stored CV carries a phone number and a home address
+- **THEN** neither reaches the model, because the projection does not carry them
+
+### Requirement: One current draft is stored per candidate and vacancy
+
+The system SHALL store at most one draft per (candidate, vacancy). A new draft for the same pair
+SHALL replace the stored one. The system SHALL NOT keep a revision history and SHALL NOT offer undo.
+
+A stored draft SHALL be stamped with the model that produced it and the language it was written in,
+and SHALL be reported stale when either differs from the live value.
+
+#### Scenario: A second draft replaces the first
+
+- **WHEN** a candidate drafts a letter twice for the same vacancy
+- **THEN** the second body is stored and the first is not retained
+
+#### Scenario: A model upgrade marks a draft stale
+
+- **WHEN** the configured model changes after a draft was stored
+- **THEN** a read of that draft reports it stale
+
+### Requirement: Reading a draft never calls a model
+
+A read of a stored draft SHALL serve what is stored, or report that none exists, and SHALL NOT call
+a language model. Only an explicit request to draft SHALL run the chain.
+
+#### Scenario: A read with no stored draft
+
+- **WHEN** a candidate reads a draft for a vacancy they have never drafted for
+- **THEN** the response reports no draft and no model is called
+
+#### Scenario: A read with a stale stored draft
+
+- **WHEN** a candidate reads a draft whose model stamp is stale
+- **THEN** the stored body is served with its staleness reported, and no model is called
+
+### Requirement: The assistant tool and the endpoint share one chain
+
+The assistant SHALL offer a tool that drafts a cover letter, and that tool SHALL execute the same
+chain, the same provenance gate, and the same bounds as the endpoint. The tool SHALL act as the
+authenticated owner of the session.
+
+#### Scenario: The chat path and the button path agree
+
+- **WHEN** a candidate asks the assistant to draft a letter for a vacancy
+- **THEN** the letter is produced by the same chain the endpoint runs, and is stored as that pair's current draft
+
+#### Scenario: The tool observes the provenance gate
+
+- **WHEN** the assistant drafts a letter for a candidate whose bank holds `agent_inferred` atoms
+- **THEN** those atoms are withheld from the chain exactly as they are on the endpoint path
+
+### Requirement: A drafting failure degrades and does not corrupt
+
+An unconfigured or failing language model SHALL leave any previously stored draft untouched and
+SHALL return no letter, rather than storing a partial or empty body.
+
+#### Scenario: The gateway is unreachable
+
+- **WHEN** the model gateway fails mid-chain and a draft already exists for the pair
+- **THEN** the stored draft is unchanged and the request reports failure

--- a/web/src/lib/tailor/CoverLetter.svelte
+++ b/web/src/lib/tailor/CoverLetter.svelte
@@ -24,6 +24,15 @@
   let error = $state('');
   let copied = $state(false);
   let band = $state<'short' | 'standard'>('standard');
+  // Which step the chain is on — the progress that keeps a minutes-long wait legible instead
+  // of looking hung.
+  let stage = $state('');
+
+  const stageLabels: Record<string, string> = {
+    select: 'Choosing your evidence',
+    draft: 'Writing',
+    audit: 'Cutting what it cannot support',
+  };
 
   const letter = $derived(view?.letter ?? null);
   // Resolved by the server, claim included. An optional lookup table threaded from the page
@@ -43,19 +52,47 @@
     }
   }
 
-  async function draft() {
+  // Drafting runs over SSE, not a plain POST. The chain is three model calls in series and
+  // takes minutes; a proxy closes a silent response at sixty seconds, which is what shipped
+  // first and reached every candidate as a 504 while the server was still working. The
+  // stream's first event arrives before any model call, which is what keeps it open.
+  function draft() {
     // Guarded here as well as by the disabled attribute: a second run would spend a second
     // allowance and race the first one's write.
     if (drafting) return;
     drafting = true;
     error = '';
-    try {
-      view = await api.draftCoverLetter(cvId, band);
-    } catch (e) {
-      error = e instanceof Error ? e.message : 'The letter could not be drafted.';
-    } finally {
-      drafting = false;
-    }
+    stage = 'select';
+
+    const url = `/api/v1/me/cvs/${encodeURIComponent(cvId)}/cover-letter/stream?band=${band}`;
+    const source = new EventSource(url, { withCredentials: true });
+
+    source.addEventListener('stage', (e) => {
+      const d = JSON.parse(e.data) as { stage: string; done: boolean };
+      if (!d.done) stage = d.stage;
+    });
+    source.addEventListener('letter', (e) => {
+      view = JSON.parse(e.data) as CoverLetterView;
+      finish(source);
+    });
+    source.addEventListener('error', (e) => {
+      // Two different failures arrive on this name: our own `error` event, which carries a
+      // sentence, and EventSource's transport failure, which carries no data at all. The
+      // second one cannot say the letter was lost — the chain runs on a detached context and
+      // stores what it finishes — so it says to come back rather than to try again, which
+      // would spend a second allowance on work that may already be done.
+      const data = (e as MessageEvent).data;
+      error = data
+        ? ((JSON.parse(data) as { error: string }).error ?? 'The letter could not be drafted.')
+        : 'The connection dropped while writing. Your letter may still have been saved — reopen this tab to check.';
+      finish(source);
+    });
+  }
+
+  function finish(source: EventSource) {
+    source.close();
+    drafting = false;
+    stage = '';
   }
 
   async function copy() {
@@ -88,12 +125,12 @@
       <button
         type="button"
         disabled={drafting}
-        onclick={() => void draft()}
+        onclick={draft}
         class="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
       >
         {#if drafting}
           <Loader2 class="size-3.5 animate-spin" aria-hidden="true" />
-          Writing…
+          {stageLabels[stage] ?? 'Writing'}…
         {:else}
           <FileText class="size-3.5" aria-hidden="true" />
           {letter ? 'Write again' : 'Write the letter'}


### PR DESCRIPTION
## What and why

Production hotfix for #2284. Second attempt at drafting returned **504 Gateway Time-out** from the edge.

The server log has the rest:

```
14:52:25 | 500 | 3m14s | POST .../cover-letter | coverletter: audit: llm: generate: request timeout
14:54:22 | 500 | 1m30s | POST .../cover-letter | coverletter: select: llm: generate: request timeout
```

Three model calls in series, each bounded at the client's 90s per-call deadline. One run lived 3m14s; another died in `select` at exactly 90s. The proxy closes a silent response at sixty seconds, so the candidate saw a gateway timeout while the server was still working.

**This was foreseeable and I did not foresee it.** `matchanalysis` is the same shape of work and streams for exactly this reason, with a stepper the workspace already renders. I copied its prompt-chain discipline and missed the one thing that makes it reachable over HTTP.

## The fix

`DraftStream` reports each stage as it opens and closes; `Draft` becomes a thin wrapper passing a no-op — mirroring `matchanalysis.Analyze` over `AnalyzeStream`.

`GET /me/cvs/:id/cover-letter/stream` emits its first event **before any model call**, which is what keeps the connection alive, then `stage` events, then either `letter` or `error`. It always closes with one of the two.

Three rules carried over from the fit stream, deliberately:

- **The allowance is charged before the stream opens**, while the fiber ctx is valid — a refused caller gets a real 402, not an error event inside a 200 nobody status-checks.
- **The chain runs on a detached context.** A client who navigates away must not abort work their allowance was just charged for; finishing stores the letter for when they return.
- **Transport failure says to reopen the tab, not to retry** — retrying would spend a second allowance on work that may already be done.

Error text comes from the shared mapper, so an un-analysed vacancy still says *run the fit analysis first* here too.

The POST stays for scripted callers, who control their own timeout.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` pass.
- [x] `go test ./...`, `go vet -tags=integration ./...`, and the 10-test cover-letter integration suite pass.
- [x] No generated artifacts changed.
- [ ] For `design-system/` changes: not touched.
- [x] For `web/` changes: `pnpm check` 0 errors, 1263 tests pass.
- [x] Stays within the core/extension boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streaming cover-letter generation with live progress updates across multiple drafting stages.
  * Drafting now displays the current generation phase and provides clearer completion and error feedback.
* **Bug Fixes**
  * Requests without a completed fit analysis now return a clear conflict message instead of an incorrect server error.
  * Improved handling for unavailable evidence and generation failures.
* **Documentation**
  * Documented fit-analysis requirements and cover-letter drafting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->