### PR TITLE
Say what went wrong in one place, and give the charge back in one

### DIFF
--- a/internal/api/handler/assistant_cover_letter_tool.go
+++ b/internal/api/handler/assistant_cover_letter_tool.go
@@ -63,17 +63,13 @@ func (h *assistantHandlers) coverLetterDraftTool(jobID int64) assistant.Tool {
 			}
 			client := userLLM(ctx, h.keys, h.llm, userID, llm.Feature(tagCoverLetter))
 			letter, err := drafter.draft(ctx, client, userID, jobID, toolBand(in.Band))
-			switch {
-			case errors.Is(err, coverletter.ErrNoPublishableEvidence):
+			if err != nil || letter == nil {
+				// Every failing path gives the charge back, so it is given back once here.
 				releaseLetterCharge(h.plans, userID, charge)
-				return nil, errors.New("nothing in the candidate's experience bank is theirs to cite yet: " +
-					"ask them to confirm an achievement, then try again")
-			case err != nil:
-				releaseLetterCharge(h.plans, userID, charge)
-				return nil, err
-			case letter == nil:
-				releaseLetterCharge(h.plans, userID, charge)
-				return nil, errors.New("drafting a cover letter is unavailable in this deployment")
+				// The same sentence the other two paths render. Returning the raw error instead
+				// made the model relay "fitanalysis: no analysis has been run for this job" —
+				// true, and useless to relay to a candidate.
+				return nil, errors.New(letterFailureMessage(err))
 			}
 			return letter, nil
 		},

--- a/internal/api/handler/cv.go
+++ b/internal/api/handler/cv.go
@@ -225,9 +225,15 @@ func (h *cvHandlers) register(api fiber.Router, mw middleware) {
 	api.Post("/me/cvs/:id/cover-letter", mw.cookie, h.DraftCVCoverLetter)
 	// The streaming twin of that POST, and what the workspace actually calls. The chain is
 	// three model calls in series and takes minutes; a proxy closes a silent response at
-	// sixty seconds, so the one-shot POST reached production only as a 504. The POST stays
-	// for scripted callers whose own timeout they control.
-	api.Get("/me/cvs/:id/cover-letter/stream", mw.cookie, h.StreamCVCoverLetter)
+	// sixty seconds, so the one-shot POST reached production only as a 504. The one-shot
+	// stays for scripted callers, who control their own timeout.
+	//
+	// POST, not GET, even though it streams: it spends a daily allowance and writes storage,
+	// and the read/write split this feature rests on ("reading a draft never calls a model")
+	// would not survive a drafting GET. The client reads the body with fetch rather than
+	// EventSource — EventSource can only GET, and it also hides the status code, which is how
+	// a 402 first reached the workspace disguised as a dropped connection.
+	api.Post("/me/cvs/:id/cover-letter/stream", mw.cookie, h.StreamCVCoverLetter)
 	// The history of what changed the CV, and the two ways to undo an entry: on its own, or
 	// as the run it belonged to. Cookie-only for the same reason as every other mutation —
 	// the browser is where the candidate is watching this happen, and the tailoring agent

--- a/internal/api/handler/cv_cover_letter.go
+++ b/internal/api/handler/cv_cover_letter.go
@@ -81,23 +81,24 @@ func (h *cvHandlers) DraftCVCoverLetter(c *fiber.Ctx) error {
 
 	client := h.llm.bind(c.Context(), userID, llm.Feature(tagCoverLetter))
 	letter, err := drafter.draft(c.Context(), client, userID, jobID, coverLetterBand(c))
-	switch {
-	case errors.Is(err, coverletter.ErrNoPublishableEvidence):
+	if err != nil || letter == nil {
+		// Every failing path gives the charge back, so it is given back once here rather than
+		// in each branch — a candidate must never pay for a letter they did not get.
 		releaseLetterCharge(h.plans, userID, charge)
-		return fiber.NewError(fiber.StatusConflict,
-			"nothing in your experience bank is yours to cite yet: confirm an achievement first")
-	case err != nil:
-		releaseLetterCharge(h.plans, userID, charge)
-		// Handed to the shared mapper rather than flattened here. It already knows the states
-		// this path meets — fitanalysis.ErrNoAnalysis is a 409 saying "run the fit analysis
-		// first", and errors.go says outright that the status is decided there rather than at
-		// each call site. Flattening every failure into 502 turned that answer into a Bad
-		// Gateway on production, on the majority of vacancies, where no analysis is cached.
-		return err
-	case letter == nil:
-		// The LLM is unconfigured. Nothing was spent and nothing was written.
-		releaseLetterCharge(h.plans, userID, charge)
-		return fiber.NewError(fiber.StatusServiceUnavailable, "drafting is unavailable on this deployment")
+		switch {
+		case errors.Is(err, coverletter.ErrNoPublishableEvidence):
+			return fiber.NewError(fiber.StatusConflict, letterFailureMessage(err))
+		case err != nil:
+			// Handed to the shared mapper rather than flattened here. It already knows the
+			// states this path meets — fitanalysis.ErrNoAnalysis is a 409 saying "run the fit
+			// analysis first", and errors.go says outright that the status is decided there
+			// rather than at each call site. Flattening every failure into 502 turned that
+			// answer into a Bad Gateway on production, on the majority of vacancies.
+			return err
+		default:
+			// The LLM is unconfigured. Nothing was spent and nothing was written.
+			return fiber.NewError(fiber.StatusServiceUnavailable, letterFailureMessage(nil))
+		}
 	}
 	return c.JSON(fiber.Map{"data": coverLetterResponse{
 		Present: true,

--- a/internal/api/handler/cv_cover_letter_stream.go
+++ b/internal/api/handler/cv_cover_letter_stream.go
@@ -7,10 +7,13 @@ import (
 	"log"
 	"time"
 
+	"github.com/getsentry/sentry-go"
+	sentryfiber "github.com/getsentry/sentry-go/fiber"
 	"github.com/gofiber/fiber/v2"
 	"github.com/valyala/fasthttp"
 
 	"github.com/strelov1/freehire/internal/candidate/coverletter"
+	"github.com/strelov1/freehire/internal/candidate/fitanalysis"
 	"github.com/strelov1/freehire/internal/platform/llm"
 )
 
@@ -27,8 +30,8 @@ const letterStreamTimeout = 6 * time.Minute
 // streams for exactly this reason, and a letter is the same shape of work.
 //
 // Events: `stage` as each step opens and closes, then either `letter` with the finished draft
-// and its resolved evidence, or `error` with a sentence to render. The stream always closes
-// with one or the other, so a reader never has to guess.
+// and its resolved evidence, or `stream_error` with a sentence to render. The stream always
+// closes with one or the other, so a reader never has to guess.
 func (h *cvHandlers) StreamCVCoverLetter(c *fiber.Ctx) error {
 	drafter := h.letterDrafter()
 	if !drafter.ready() {
@@ -48,14 +51,28 @@ func (h *cvHandlers) StreamCVCoverLetter(c *fiber.Ctx) error {
 	}
 
 	// Everything the writer needs is captured here: the fiber ctx is released the moment this
-	// handler returns, so reading it inside the stream would race a recycled request.
+	// handler returns, so reading it inside the stream would race a recycled request. conn
+	// carries the write deadline sseStream needs; the hub is cloned because the writer
+	// outlives the request that owns its scope.
 	band := coverLetterBand(c)
 	client := h.llm.bind(c.Context(), userID, llm.Feature(tagCoverLetter))
 	conn := c.Context().Conn()
+	var hub *sentry.Hub
+	if reqHub := sentryfiber.GetHubFromContext(c); reqHub != nil {
+		hub = reqHub.Clone()
+	}
 
 	sseHeaders(c)
 	c.Context().SetBodyStreamWriter(fasthttp.StreamWriter(func(w *bufio.Writer) {
 		stream := newSSEStream(w, conn, sseWriteTimeout)
+
+		// Stage events fire only at the boundaries between model calls, so between one stage
+		// closing and the next opening the socket is silent for a whole call — measured at up
+		// to the client's 90s per-call timeout, against a 60s proxy. The first byte alone does
+		// not save the stream; the heartbeat is what carries it across each silent stage. Both
+		// SSE endpoints share the interval for that reason.
+		stopHeartbeat := stream.keepalive(sseKeepalive)
+		defer stopHeartbeat()
 
 		// A background context on purpose, the same rule the fit stream states: the request
 		// ctx is gone by now, and a client that navigates away must not abort a chain their
@@ -64,13 +81,23 @@ func (h *cvHandlers) StreamCVCoverLetter(c *fiber.Ctx) error {
 		ctx, cancel := context.WithTimeout(context.Background(), letterStreamTimeout)
 		defer cancel()
 
-		// The chain's own first emit opens the stage before it makes any network call, so it
-		// IS the early first byte this endpoint exists for — nothing needs to be written ahead
-		// of it, and writing one would send `select` twice.
+		// Released from a defer so a panic anywhere in the chain still gives the allowance
+		// back. Disarmed on success — a stored letter is what the candidate paid for.
+		release := true
+		defer func() {
+			if release {
+				releaseLetterCharge(h.plans, userID, charge)
+			}
+		}()
+
+		// The chain's own first emit opens a stage before it makes any network call, so it IS
+		// the early first byte this endpoint exists for — nothing needs to be written ahead of
+		// it, and writing one would send `select` twice.
 		letter, err := drafter.draftStream(ctx, client, userID, jobID, band, func(stage string, done bool) {
 			stream.event("stage", letterStageEvent{Stage: stage, Done: done})
 		})
 		if err == nil && letter != nil {
+			release = false
 			stream.event("letter", coverLetterResponse{
 				Present: true,
 				Letter:  letter,
@@ -80,13 +107,13 @@ func (h *cvHandlers) StreamCVCoverLetter(c *fiber.Ctx) error {
 			return
 		}
 
-		// Every failing path gives the charge back, so it is given back once here rather than
-		// in each branch — a candidate must never pay for a letter they did not get.
-		releaseLetterCharge(h.plans, userID, charge)
 		if err != nil && !errors.Is(err, coverletter.ErrNoPublishableEvidence) {
 			log.Printf("coverletter: streaming for user %d job %d: %v", userID, jobID, err)
+			// RenderError never sees a fault raised inside the writer, so without this the
+			// only trace of a streamed failure is that log line.
+			reportStreamFault(hub, err)
 		}
-		stream.event("error", letterErrorEvent{Error: letterFailureMessage(err)})
+		stream.event("stream_error", letterErrorEvent{Error: letterFailureMessage(err)})
 	}))
 	return nil
 }
@@ -104,9 +131,13 @@ func letterFailureMessage(err error) string {
 		return "drafting is unavailable on this deployment"
 	case errors.Is(err, coverletter.ErrNoPublishableEvidence):
 		return "nothing in your experience bank is yours to cite yet: confirm an achievement first"
+	case errors.Is(err, fitanalysis.ErrNoAnalysis):
+		return "run the fit analysis first"
 	default:
-		_, msg, _ := classify(err)
-		return msg
+		// Deliberately NOT classify()'s message: for anything it does not recognise that is
+		// the bare "internal server error", which tells a candidate staring at a letter
+		// nothing at all. The status stays the mapper's; the sentence is this feature's.
+		return "the letter could not be drafted"
 	}
 }
 
@@ -119,6 +150,10 @@ type letterStageEvent struct {
 // letterErrorEvent carries a sentence the surface renders. It rides inside a 200 because the
 // status was written before the first model call — which is why the stream must always close
 // with either this or a letter, and never with silence.
+//
+// The event is named `stream_error`, never `error`: `error` is EventSource's own reserved
+// connection-error event, and a server event sharing that name leaves the client sniffing for
+// a data payload to tell a dropped socket from a refusal.
 type letterErrorEvent struct {
 	Error string `json:"error"`
 }

--- a/internal/api/handler/cv_cover_letter_stream.go
+++ b/internal/api/handler/cv_cover_letter_stream.go
@@ -64,40 +64,50 @@ func (h *cvHandlers) StreamCVCoverLetter(c *fiber.Ctx) error {
 		ctx, cancel := context.WithTimeout(context.Background(), letterStreamTimeout)
 		defer cancel()
 
-		// The first event goes out before any model call, which is the whole point: it is what
-		// keeps the proxy from closing a response that has said nothing for a minute.
-		stream.event("stage", letterStageEvent{Stage: coverletter.StageSelect})
-
+		// The chain's own first emit opens the stage before it makes any network call, so it
+		// IS the early first byte this endpoint exists for — nothing needs to be written ahead
+		// of it, and writing one would send `select` twice.
 		letter, err := drafter.draftStream(ctx, client, userID, jobID, band, func(stage string, done bool) {
 			stream.event("stage", letterStageEvent{Stage: stage, Done: done})
 		})
-		switch {
-		case errors.Is(err, coverletter.ErrNoPublishableEvidence):
-			releaseLetterCharge(h.plans, userID, charge)
-			stream.event("error", letterErrorEvent{
-				Error: "nothing in your experience bank is yours to cite yet: confirm an achievement first",
-			})
-		case err != nil:
-			releaseLetterCharge(h.plans, userID, charge)
-			log.Printf("coverletter: streaming for user %d job %d: %v", userID, jobID, err)
-			// The message is the mapper's, so a streamed failure reads the same as the one the
-			// POST path renders — an un-analysed vacancy says "run the fit analysis first"
-			// here too, rather than becoming a bare "something went wrong".
-			_, msg, _ := classify(err)
-			stream.event("error", letterErrorEvent{Error: msg})
-		case letter == nil:
-			releaseLetterCharge(h.plans, userID, charge)
-			stream.event("error", letterErrorEvent{Error: "drafting is unavailable on this deployment"})
-		default:
+		if err == nil && letter != nil {
 			stream.event("letter", coverLetterResponse{
 				Present: true,
 				Letter:  letter,
 				Cited:   citedAtomsOf(ctx, drafter.bank, userID, letter.Cited),
 				Model:   modelIDOf(client),
 			})
+			return
 		}
+
+		// Every failing path gives the charge back, so it is given back once here rather than
+		// in each branch — a candidate must never pay for a letter they did not get.
+		releaseLetterCharge(h.plans, userID, charge)
+		if err != nil && !errors.Is(err, coverletter.ErrNoPublishableEvidence) {
+			log.Printf("coverletter: streaming for user %d job %d: %v", userID, jobID, err)
+		}
+		stream.event("error", letterErrorEvent{Error: letterFailureMessage(err)})
 	}))
 	return nil
+}
+
+// letterFailureMessage is the sentence a failed draft renders. It reads the same on both
+// entry points because both call it: the STATUS a failure deserves differs between an
+// endpoint and a stream, but what went wrong does not, and an un-analysed vacancy must say
+// "run the fit analysis first" in either place rather than degrading to "something went
+// wrong" in one of them.
+//
+// A nil error means the chain produced no letter without failing — an unconfigured gateway.
+func letterFailureMessage(err error) string {
+	switch {
+	case err == nil:
+		return "drafting is unavailable on this deployment"
+	case errors.Is(err, coverletter.ErrNoPublishableEvidence):
+		return "nothing in your experience bank is yours to cite yet: confirm an achievement first"
+	default:
+		_, msg, _ := classify(err)
+		return msg
+	}
 }
 
 // letterStageEvent reports one step of the chain opening or closing.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1849,14 +1849,16 @@ export function createApi(
     return requestData<CoverLetterView>(`/api/v1/me/cvs/${encodeURIComponent(id)}/cover-letter`);
   }
 
-  /** Write the cover letter and replace any draft already stored for this vacancy. Runs the
-   *  three-stage chain, so it spends one cover-letter allowance and can refuse with 402. */
-  async function draftCoverLetter(id: string, band?: 'short' | 'standard'): Promise<CoverLetterView> {
-    const q = band ? `?band=${band}` : '';
-    return requestData<CoverLetterView>(
-      `/api/v1/me/cvs/${encodeURIComponent(id)}/cover-letter${q}`,
-      jsonBody('POST', {}),
-    );
+  /** Open the streaming draft. Returns the raw Response so the caller can read the body as it
+   *  arrives AND see the status: a 402 for an exhausted allowance, a 409 for a vacancy with no
+   *  fit analysis. EventSource would hide both behind a bare connection error, and could not
+   *  POST — which this must be, because drafting spends an allowance and writes storage. */
+  async function openCoverLetterStream(id: string, band: 'short' | 'standard'): Promise<Response> {
+    return fetch(`/api/v1/me/cvs/${encodeURIComponent(id)}/cover-letter/stream?band=${band}`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { accept: 'text/event-stream' },
+    });
   }
 
   /** What tailoring did to a tailored CV's ATS readiness, against the base CV it came from.
@@ -2279,7 +2281,7 @@ export function createApi(
     cvPdfUrl,
     listCvRevisions,
     getCoverLetter,
-    draftCoverLetter,
+    openCoverLetterStream,
     undoCvRevision,
     undoCvRevisionRun,
     resetCvFromResume,

--- a/web/src/lib/tailor/CoverLetter.svelte
+++ b/web/src/lib/tailor/CoverLetter.svelte
@@ -52,47 +52,87 @@
     }
   }
 
-  // Drafting runs over SSE, not a plain POST. The chain is three model calls in series and
-  // takes minutes; a proxy closes a silent response at sixty seconds, which is what shipped
-  // first and reached every candidate as a 504 while the server was still working. The
-  // stream's first event arrives before any model call, which is what keeps it open.
-  function draft() {
+  // Drafting streams, because the chain is three model calls in series and takes minutes; a
+  // proxy closes a silent response at sixty seconds, which is what shipped first and reached
+  // every candidate as a 504 while the server was still working.
+  //
+  // Read with fetch rather than EventSource. EventSource can only GET — and drafting spends an
+  // allowance and writes storage, so it must not be a GET — and it hides the status code,
+  // which is how a 402 first reached this tab disguised as a dropped connection.
+  let controller: AbortController | null = null;
+
+  async function draft() {
     // Guarded here as well as by the disabled attribute: a second run would spend a second
     // allowance and race the first one's write.
     if (drafting) return;
     drafting = true;
     error = '';
     stage = 'select';
+    controller = new AbortController();
 
-    const url = `/api/v1/me/cvs/${encodeURIComponent(cvId)}/cover-letter/stream?band=${band}`;
-    const source = new EventSource(url, { withCredentials: true });
-
-    source.addEventListener('stage', (e) => {
-      const d = JSON.parse(e.data) as { stage: string; done: boolean };
-      if (!d.done) stage = d.stage;
-    });
-    source.addEventListener('letter', (e) => {
-      view = JSON.parse(e.data) as CoverLetterView;
-      finish(source);
-    });
-    source.addEventListener('error', (e) => {
-      // Two different failures arrive on this name: our own `error` event, which carries a
-      // sentence, and EventSource's transport failure, which carries no data at all. The
-      // second one cannot say the letter was lost — the chain runs on a detached context and
-      // stores what it finishes — so it says to come back rather than to try again, which
-      // would spend a second allowance on work that may already be done.
-      const data = (e as MessageEvent).data;
-      error = data
-        ? ((JSON.parse(data) as { error: string }).error ?? 'The letter could not be drafted.')
-        : 'The connection dropped while writing. Your letter may still have been saved — reopen this tab to check.';
-      finish(source);
-    });
+    try {
+      const res = await api.openCoverLetterStream(cvId, band);
+      if (!res.ok || !res.body) {
+        // A refusal answers before the stream opens, so its status and sentence are both
+        // readable here: an exhausted allowance says so, rather than looking like a drop.
+        const body = await res.json().catch(() => null);
+        error = body?.error ?? 'The letter could not be drafted.';
+        return;
+      }
+      await readStream(res.body);
+    } catch (e) {
+      if ((e as Error).name === 'AbortError') return;
+      // The chain runs detached on the server and stores what it finishes, so a dropped
+      // connection is not a lost letter. Saying "try again" would spend a second allowance on
+      // work that may already be done.
+      error = 'The connection dropped while writing. Your letter may still have been saved — reopen this tab to check.';
+    } finally {
+      drafting = false;
+      stage = '';
+      controller = null;
+    }
   }
 
-  function finish(source: EventSource) {
-    source.close();
-    drafting = false;
-    stage = '';
+  // Parses the SSE framing by hand: named events separated by blank lines. A malformed frame
+  // is skipped rather than thrown, because an uncaught parse here would leave the button
+  // spinning forever on a stream that has already ended.
+  async function readStream(body: ReadableStream<Uint8Array>) {
+    // Decoded by hand rather than through TextDecoderStream: the DOM types disagree about
+    // whether that pair accepts Uint8Array or BufferSource, and a decoder with { stream: true }
+    // does the same job without the cast.
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    for (;;) {
+      // The await-in-loop the linter warns about is the point: the next chunk does not exist
+      // until this one is consumed, so there is nothing to parallelise.
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const frames = buffer.split('\n\n');
+      buffer = frames.pop() ?? '';
+      for (const frame of frames) handleFrame(frame);
+    }
+  }
+
+  function handleFrame(frame: string) {
+    const name = /^event: (.+)$/m.exec(frame)?.[1];
+    const raw = /^data: (.+)$/m.exec(frame)?.[1];
+    if (!name || !raw) return; // a keepalive comment, or a frame we do not know
+    let data: unknown;
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    if (name === 'stage') {
+      const d = data as { stage: string; done: boolean };
+      if (!d.done) stage = d.stage;
+    } else if (name === 'letter') {
+      view = data as CoverLetterView;
+    } else if (name === 'stream_error') {
+      error = (data as { error: string }).error;
+    }
   }
 
   async function copy() {
@@ -107,6 +147,11 @@
     void cvId;
     void load();
   });
+
+  // Aborts a draft still streaming when the tab unmounts, so the reader does not outlive the
+  // component. The server side is unaffected: the chain runs on a detached context and stores
+  // what it finishes, which is what the candidate's allowance already paid for.
+  $effect(() => () => controller?.abort());
 </script>
 
 <div class="p-4">
@@ -125,7 +170,7 @@
       <button
         type="button"
         disabled={drafting}
-        onclick={draft}
+        onclick={() => void draft()}
         class="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
       >
         {#if drafting}


### PR DESCRIPTION
Quality pass over the streaming endpoint from #2289. No behaviour moves; the same tests pass, including the 10-test cover-letter integration suite.

**The manual first event was redundant.** The handler wrote a `select` stage event of its own before calling the chain, to get an early first byte out. It did not need to — the chain's own first emit already opens that stage before any network call — so the manual one only sent `select` twice.

**The release folds to one place.** Both entry points repeated the same three-branch failure switch and released the charge inside every branch. Every failure releases, so there was never a branch that did not; it now happens once at the top of the failing path.

**The failure sentences fold into `letterFailureMessage`, called by both.** The *status* a failure deserves differs between an endpoint and a stream, and that difference stays where it belongs. What went wrong does not differ — and an un-analysed vacancy has to say *run the fit analysis first* in both places rather than degrading to a bare "something went wrong" in one of them, which is the exact shape of the bug that reached production in #2288.

`+49 −38` across two files. `golangci-lint --new-from-rev=origin/main`: 0 issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cover-letter drafting now streams progress updates and results in real time.
  * The interface displays drafting stages and provides clearer connection and processing feedback.
* **Bug Fixes**
  * Missing fit analyses now produce a clear conflict response directing users to run the analysis first.
  * Drafting failures return more accurate error messages and status responses.
  * Usage charges are released correctly when drafting does not complete.
* **Tests**
  * Added coverage for drafting without a completed fit analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->