### PR TITLE
Spell a skill one way everywhere, and hover the chip rather than a 16px ring

### DIFF
--- a/cmd/gen-skill-descriptions/main.go
+++ b/cmd/gen-skill-descriptions/main.go
@@ -86,7 +86,11 @@ func run() error {
 func printDrafts(ctx context.Context, d drafter, batch []string, demand map[string]int, concurrency int, out io.Writer) error {
 	drafts := make([]string, len(batch))
 
-	g, ctx := errgroup.WithContext(ctx)
+	// A plain group, not WithContext: nothing here fails the group. A skill the model
+	// refuses is counted and skipped, so cancelling the others on the first refusal is
+	// the opposite of what this wants — a wave is dozens of independent calls and losing
+	// the ones that worked would mean paying for them twice.
+	var g errgroup.Group
 	g.SetLimit(max(concurrency, 1))
 	var mu sync.Mutex
 	var failed int
@@ -109,28 +113,22 @@ func printDrafts(ctx context.Context, d drafter, batch []string, demand map[stri
 			return nil
 		})
 	}
-	if err := g.Wait(); err != nil {
-		return err
-	}
+	_ = g.Wait() // no goroutine returns an error; failures are counted above
 
-	// Nothing is emitted when every draft failed: a file of comments and no rows is a
-	// diff that looks like work and carries none.
-	if failed < len(batch) {
-		for i, line := range drafts {
-			if line == "" {
-				continue
-			}
-			// The count rides along as a comment so the reviewer can see what they are
-			// vouching for: a sentence about a skill on 9,000 postings deserves more of
-			// their attention than one on three.
-			//
-			// A write failure is fatal rather than counted. The whole output of this run
-			// is one wave meant to be redirected into a file, and half a wave on a closed
-			// pipe is worse than none: it looks like a complete batch.
-			if _, err := fmt.Fprintf(out, "# %s — %d open postings\n%s\t%s\n",
-				batch[i], demand[batch[i]], batch[i], line); err != nil {
-				return fmt.Errorf("writing drafts: %w", err)
-			}
+	for i, line := range drafts {
+		if line == "" {
+			continue
+		}
+		// The count rides along as a comment so the reviewer can see what they are
+		// vouching for: a sentence about a skill on 9,000 postings deserves more of
+		// their attention than one on three.
+		//
+		// A write failure is fatal rather than counted. The whole output of this run
+		// is one wave meant to be redirected into a file, and half a wave on a closed
+		// pipe is worse than none: it looks like a complete batch.
+		if _, err := fmt.Fprintf(out, "# %s — %d open postings\n%s\t%s\n",
+			batch[i], demand[batch[i]], batch[i], line); err != nil {
+			return fmt.Errorf("writing drafts: %w", err)
 		}
 	}
 	if failed == len(batch) {

--- a/design-system/scripts/adoption-baseline.json
+++ b/design-system/scripts/adoption-baseline.json
@@ -1,7 +1,7 @@
 {
   "Alert": 1,
   "Avatar": 0,
-  "Badge": 19,
+  "Badge": 17,
   "BrandMark": 1,
   "Button": 69,
   "Card": 3,

--- a/design-system/src/tooltip.svelte
+++ b/design-system/src/tooltip.svelte
@@ -87,10 +87,12 @@
   // The touch half of "dismissible": there is no pointer to move away, so the
   // next tap elsewhere is what closes it.
   //
-  // The `contains` guard is what stops the opening tap from also being the
-  // closing one. Svelte attaches this listener after the current event finishes,
-  // so the tap that opened the tooltip should never reach it — but the guard
-  // costs a line and does not depend on that ordering holding.
+  // The `contains` guard carries two things. It stops the opening tap from also
+  // being the closing one (Svelte attaches this listener after the current event
+  // finishes, so that should not happen anyway — the guard costs a line and does
+  // not depend on that ordering holding). And because the floating content is a
+  // DESCENDANT of triggerEl, it is also what keeps a tap on a link inside the
+  // tooltip from dismissing the tooltip out from under the click that follows.
   function dismissOutside(e: PointerEvent) {
     if (!triggerEl?.contains(e.target as Node)) hide();
   }

--- a/internal/dict/skilltag/AGENTS.md
+++ b/internal/dict/skilltag/AGENTS.md
@@ -28,9 +28,10 @@ through `Parse`.
 
 ### The description dictionary
 
-- A TSV, not a Go map: 863 entries whose value is a sentence, so one unquoted line per
-  skill is what a reviewer can actually read a wave of. `internal/dict/location` ships
-  `cities1000.tsv` the same way.
+- A TSV, not a Go map: the vocabulary is 863 canonicals and each value is a sentence,
+  so one unquoted line per skill is what a reviewer can actually read a wave of.
+  `internal/dict/location` ships `cities1000.tsv` the same way. **The file itself holds
+  far fewer rows than that** — see the ratchet below.
 - **The loader is strict** where location's is tolerant — a malformed row fails the
   build rather than being skipped. That file is GeoNames' output; this one is ours, so a
   bad row is a mistake in this repository.

--- a/openspec/changes/skills-glossary/proposal.md
+++ b/openspec/changes/skills-glossary/proposal.md
@@ -64,8 +64,8 @@ request-time model call.
   exposing each canonical's aliases, which the glossary page renders and the generator
   prompts with.
 - `cmd/gen-skill-descriptions` — new run-once worker (needs `LLM_BASE_URL` /
-  `LLM_API_KEY` / `LLM_MODEL`, and `DATABASE_URL` to order the vocabulary by catalogue
-  frequency).
+  `LLM_API_KEY` / `LLM_MODEL` only). Catalogue frequency comes from the public facets
+  endpoint over HTTP, so it opens no database — see design.md.
 - `cmd/gen-contracts` — emits one more generated file.
 - `web/` — new `/skills` and `/skills/<slug>` routes, `sitemap-skills.xml` and its entry
   in the sitemap index, the skill chip on `JobView`/`JobRow`, and the generated

--- a/openspec/changes/skills-glossary/specs/skill-glossary/spec.md
+++ b/openspec/changes/skills-glossary/specs/skill-glossary/spec.md
@@ -63,8 +63,8 @@ the floor constant removed, so one rule remains rather than two that can disagre
 
 A worker SHALL exist that reads the canonical vocabulary, orders it by catalogue
 frequency, prompts an LLM with each skill's slug, display label and the spellings the
-parser accepts for it, and prints a Go source map for a human to review and commit. The
-worker SHALL be run by hand, per wave.
+parser accepts for it, and prints rows in the dictionary's own format for a human to
+review and commit. The worker SHALL be run by hand, per wave.
 
 The worker's output SHALL NOT be written into the shipping dictionary automatically, and
 no serving path SHALL depend on the worker or on an LLM client.
@@ -72,8 +72,8 @@ no serving path SHALL depend on the worker or on an LLM client.
 #### Scenario: A wave is generated
 
 - **WHEN** an operator runs the worker bounded to the next wave
-- **THEN** it prints Go map entries for the undescribed skills in that wave and writes
-  nothing into `descriptions.go`
+- **THEN** it prints dictionary rows for the undescribed skills in that wave and writes
+  nothing into `descriptions.tsv`
 
 #### Scenario: The serving path has no model dependency
 
@@ -113,8 +113,15 @@ The chip's own activation SHALL keep its existing destination — the postings f
 that skill. Because that makes the chip a link, and a tap on a link navigates, the
 reveal SHALL have its OWN activation target inside the chip rather than sharing the
 chip's: a touch reader given only the chip would reach the filter and never the
-definition. The reveal SHALL carry a link to the skill's glossary page, so the longer
-read is one deliberate click away rather than in the path of the common one.
+definition. **That separate target is for TAP only** — hover and focus SHALL open the
+reveal from anywhere on the chip, because reaching for a 24px mark is not the gesture a
+pointer reader makes and the issue asks for hover on the chip. The reveal SHALL carry a
+link to the skill's glossary page, so the longer read is one deliberate click away
+rather than in the path of the common one.
+
+A chip rendered inside a surface that is itself a view of the posting — a preview card,
+a drawer — MAY omit the filter link while keeping the label and the reveal: navigating
+to a filtered list from inside a preview leaves the thing being previewed.
 
 An undescribed skill SHALL render as a plain chip, with no empty reveal and no
 affordance suggesting one. Whether a skill is described MUST therefore be answerable as
@@ -155,16 +162,36 @@ future change may revisit it; this one does not pay that risk for it.
 - **WHEN** a chip renders a canonical no wave has described
 - **THEN** no reveal affordance is shown and the chip behaves exactly as it does today
 
-### Requirement: A job's skill chips read as words, not as slugs
+### Requirement: A skill reads as words, not as a slug, on every surface that names one
 
-A posting's skill chips SHALL render the canonical's display label. Rendering the raw
-slug spells the same skill two ways on one screen — "ci-cd" on the posting and "CI/CD"
-in the filter panel beside it.
+**Every** surface that renders a canonical skill SHALL render its display label:
+the posting, the feed card, the preview, the drawer, the CV match delta and its
+tailoring dialogs, and the filter summary. Rendering the raw slug spells the same skill
+two ways on one screen — "ci-cd" on the posting and "CI/CD" in the filter panel beside
+it — which is the drift `facet-display-labels` exists to prevent.
+
+The skills facet carries no static option list, so the shared dynamic-label resolver
+MUST route it to the skill label rather than falling through to the raw value; that
+fall-through is what made the filter summary disagree with the panel above it.
+
+The candidate's own experience bank is NOT covered: those strings are what the candidate
+wrote, not values from this vocabulary, and title-casing them would edit their words.
 
 #### Scenario: A punctuated skill on a job page
 
 - **WHEN** a posting tagged `ci-cd` renders its skills
 - **THEN** the chip reads "CI/CD"
+
+#### Scenario: The same skill in the filter summary and the panel
+
+- **WHEN** a reader selects the `ci-cd` facet and sees it both as a summary chip and as
+  a panel option
+- **THEN** both read "CI/CD"
+
+#### Scenario: A missing skill in the CV match delta
+
+- **WHEN** the match delta names a skill the candidate lacks
+- **THEN** it reads as the label, not as the slug
 
 ### Requirement: Every described skill has a glossary page
 
@@ -223,6 +250,11 @@ first entry — the chip's reveal links to one — but the footer link and the s
 index entry SHALL be withheld until enough skills carry a definition, because both
 promise a glossary and a handful of words is not one. The threshold is read from the
 same catalogue everything else reads, so coverage switches it on with no second deploy.
+
+Below that threshold the glossary pages SHALL also decline indexing (`noindex, follow`).
+Withholding the sitemap only stops one route in; a crawler that arrives another way
+would otherwise index a list of a handful of words as the product's glossary, and that
+first impression outlives the fix.
 
 #### Scenario: The glossary before the waves land
 

--- a/web/src/lib/components/ConfirmTailorDialog.svelte
+++ b/web/src/lib/components/ConfirmTailorDialog.svelte
@@ -13,6 +13,7 @@
   import { partitionBlockers, toneText, haveChipClass, missingChipClass } from '$lib/jobMatch';
   import { ConfirmDialog } from '$lib/ui';
   import SkillIcon from './SkillIcon.svelte';
+  import { skillLabel } from '$lib/facets';
 
   const match = $derived(confirmTailorDialog.match);
   const blockers = $derived(partitionBlockers(match?.blockers));
@@ -76,12 +77,12 @@
         <div class="flex flex-wrap gap-1.5">
           {#each matched as skill (skill)}
             <span class={haveChipClass} aria-label="{skill} — you have this skill">
-              <SkillIcon slug={skill} />{skill}
+              <SkillIcon slug={skill} />{skillLabel(skill)}
             </span>
           {/each}
           {#each missing as skill (skill)}
             <span class={missingChipClass} aria-label="{skill} — missing">
-              <SkillIcon slug={skill} />{skill}
+              <SkillIcon slug={skill} />{skillLabel(skill)}
             </span>
           {/each}
         </div>

--- a/web/src/lib/components/JobDrawer.svelte
+++ b/web/src/lib/components/JobDrawer.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
   import { goto } from '$app/navigation';
-  import { Badge, Button, cn, EntityLogo } from '$lib/ui';
+  import { Button, cn, EntityLogo } from '$lib/ui';
   import { Trash2, X, ExternalLink, Mic, NotebookPen, Send, Target, SquarePen } from '@lucide/svelte';
   import { askConfirmTailor } from '$lib/confirmTailorDialog.svelte';
   import { groupedStages, humanizeStage, offersDebrief } from '$lib/stages';
@@ -21,7 +21,7 @@
   import { statusLabel, stageImplication } from '$lib/emailStatus';
   import { eventLabel, eventTone } from '$lib/events';
   import StatusChip from '$lib/components/StatusChip.svelte';
-  import SkillIcon from './SkillIcon.svelte';
+  import SkillChip from './SkillChip.svelte';
   import { avatarInitials, avatarColor } from '$lib/avatar';
   import type {
     Job,
@@ -681,11 +681,10 @@
             <div class="flex flex-col gap-2 border-t border-border pt-5">
               <p class={sectionLabel}>Skills</p>
               <div class="flex flex-wrap gap-1.5">
+                <!-- Unlinked: the drawer is a reading surface over a posting, and a
+                     filter link would navigate out of it. -->
                 {#each posting.skills as skill (skill)}
-                  <Badge variant="brand" class="gap-1">
-                    <SkillIcon slug={skill} />
-                    {skill}
-                  </Badge>
+                  <SkillChip slug={skill} linked={false} />
                 {/each}
               </div>
             </div>

--- a/web/src/lib/components/JobMatch.svelte
+++ b/web/src/lib/components/JobMatch.svelte
@@ -21,6 +21,7 @@
   import { Button } from '$lib/ui';
   import MatchSummary from './MatchSummary.svelte';
   import SkillIcon from './SkillIcon.svelte';
+  import { skillLabel } from '$lib/facets';
 
   // The job is server-rendered; only this personal signal hydrates client-side.
   let { job }: { job: Job } = $props();
@@ -247,7 +248,7 @@
        answer, and the row now carries two. -->
   <div class="flex flex-wrap items-center gap-1.5">
     <span class="flex items-center gap-1 text-xs font-medium text-foreground">
-      <SkillIcon slug={skill} />{skill}
+      <SkillIcon slug={skill} />{skillLabel(skill)}
     </span>
     <button
       type="button"
@@ -314,7 +315,7 @@
         <div class="flex flex-nowrap gap-1.5 overflow-hidden">
           {#each teaserSkills as skill (skill)}
             <span class={`${teaser.missing.has(skill) ? missChip : haveChip} whitespace-nowrap`}>
-              <SkillIcon slug={skill} />{skill}
+              <SkillIcon slug={skill} />{skillLabel(skill)}
             </span>
           {/each}
         </div>
@@ -369,7 +370,7 @@
           <span class="size-1.5 rounded-full bg-brand"></span>You have
         </span>
         <div class="flex flex-wrap gap-1.5">
-          {#each view.matched as skill (skill)}<span class={haveChip}><SkillIcon slug={skill} />{skill}</span>{/each}
+          {#each view.matched as skill (skill)}<span class={haveChip}><SkillIcon slug={skill} />{skillLabel(skill)}</span>{/each}
         </div>
       </div>
     {/if}
@@ -389,7 +390,7 @@
               disabled={pending}
               onclick={() => toggleClaimRow(a.name)}
             >
-              <SkillIcon slug={a.name} />{a.name} <span class="opacity-70">· you have {a.via}</span>
+              <SkillIcon slug={a.name} />{skillLabel(a.name)} <span class="opacity-70">· you have {a.via}</span>
             </button>
           {/each}
         </div>
@@ -414,7 +415,7 @@
               disabled={pending}
               onclick={() => toggleClaimRow(skill)}
             >
-              <SkillIcon slug={skill} />{skill}
+              <SkillIcon slug={skill} />{skillLabel(skill)}
             </button>
           {/each}
         </div>

--- a/web/src/lib/components/JobPreview.svelte
+++ b/web/src/lib/components/JobPreview.svelte
@@ -14,9 +14,9 @@
   } from '$lib/facets';
   import { formatSalary } from '$lib/enrichment';
   import { companyLogoUrl } from '$lib/logo';
-  import { Badge, EntityLogo } from '$lib/ui';
+  import { EntityLogo } from '$lib/ui';
   import JobDescription from './JobDescription.svelte';
-  import SkillIcon from './SkillIcon.svelte';
+  import SkillChip from './SkillChip.svelte';
 
   let {
     title,
@@ -116,10 +116,10 @@
     <ul class="flex flex-wrap gap-1.5 border-t border-border pt-4">
       {#each skills as skill (skill)}
         <li>
-          <Badge variant="brand" class="gap-1">
-            <SkillIcon slug={skill} />
-            {skill}
-          </Badge>
+          <!-- Unlinked: this is a preview of a posting, and a filter link would navigate
+               out of the thing being previewed. The label and the definition still come
+               from the dictionary. -->
+          <SkillChip slug={skill} linked={false} />
         </li>
       {/each}
     </ul>

--- a/web/src/lib/components/SkillChip.svelte
+++ b/web/src/lib/components/SkillChip.svelte
@@ -8,17 +8,21 @@
 
   // A skill chip that can say what the skill IS.
   //
-  // The chip stays a link to the postings filtered to that skill — that is what someone
-  // clicking "Go" on a posting wants, and it is the behaviour this replaces. The
-  // definition gets its own small target beside the label rather than sharing the chip's:
-  // a tap on a link navigates, so a touch reader given only the chip would reach the
-  // filter and never the glossary.
+  // Hover or focus anywhere on the chip opens the definition, which is what the reveal
+  // is for. Touch cannot share that: the chip is a link, and a tap on a link navigates,
+  // so the "?" beside the label is the tap target — without it a touch reader would
+  // reach the filter and never the glossary.
+  //
+  // `linked` exists because two callers show a posting's skills inside something that is
+  // already a surface of its own (the preview card, the drawer). Turning their chips into
+  // links would navigate out of the thing being previewed; they want the definition and
+  // the dictionary's spelling, not a new destination.
   //
   // This file has no component test: web/ runs vitest in plain Node with no DOM. Its two
   // decisions live in tested pure modules — skillDescriptions.test.ts for what is
   // described and what the text is, tooltip.test.ts for how the reveal behaves.
 
-  let { slug }: { slug: string } = $props();
+  let { slug, linked = true }: { slug: string; linked?: boolean } = $props();
 
   const label = $derived(skillLabel(slug));
 
@@ -31,18 +35,31 @@
   // a $derived that is never read is a chunk never fetched. That is the whole point of
   // the split, and it is why this is not simply awaited up front.
   const description = $derived(skillDescription(slug));
+
+  // A tap on the LABEL must not also toggle the reveal. The tooltip's toggle listens on
+  // its wrapper, which now encloses the whole chip so that hovering anywhere on it
+  // works — and that wrapper is an ancestor of this link. Stopping the touch pointerdown
+  // here keeps the two gestures apart: tap the label to filter, tap the "?" to read.
+  function keepTapOnTheLink(e: PointerEvent) {
+    if (e.pointerType === 'touch') e.stopPropagation();
+  }
 </script>
 
-<span class={badgeVariants({ variant: 'brand' })}>
-  <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal /jobs filter link from filterHref; query-only, no route to resolve -->
-  <a href={filterHref('skills', slug)} class="inline-flex items-center gap-1 transition hover:opacity-80">
-    <SkillIcon {slug} />
-    {label}
-  </a>
-  {#if described}
-    <!-- The tooltip's own max-w-xs is the width here; a narrower override would be an
-         arbitrary value where a token exists. -->
-    <Tooltip side="top">
+{#snippet chip()}
+  <span class={badgeVariants({ variant: 'brand' })}>
+    {#if linked}
+      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal /jobs filter link from filterHref; query-only, no route to resolve -->
+      <a href={filterHref('skills', slug)} class="inline-flex items-center gap-1 transition hover:opacity-80" onpointerdown={keepTapOnTheLink}>
+        <SkillIcon {slug} />
+        {label}
+      </a>
+    {:else}
+      <span class="inline-flex items-center gap-1">
+        <SkillIcon {slug} />
+        {label}
+      </span>
+    {/if}
+    {#if described}
       <!-- The button is the 24px target WCAG 2.5.8 asks for and the ring inside it is
            the 16px mark the chip can carry. They are separate elements because the
            affordance exists FOR touch: sized to the ring, it would sit a finger's width
@@ -58,27 +75,38 @@
           ?
         </span>
       </button>
-      {#snippet content()}
-        <!-- The pending line is a placeholder rather than nothing: the reveal's box is
-             already open by the time this renders, so "nothing" is a visibly empty
-             popover. `text` is empty only when the chunk could not be fetched, and
-             saying so beats the same empty box standing there for good. -->
-        {#await description}
-          <span class="block h-3 w-40 animate-pulse rounded bg-muted"></span>
-        {:then text}
-          {#if text}
-            <span class="block text-left">{text}</span>
-            <a
-              href={resolve('/skills/[slug]', { slug })}
-              class="mt-1 block text-left font-medium underline"
-            >
-              What is {label}? →
-            </a>
-          {:else}
-            <span class="block text-left">Definition unavailable right now.</span>
-          {/if}
-        {/await}
-      {/snippet}
-    </Tooltip>
-  {/if}
-</span>
+    {/if}
+  </span>
+{/snippet}
+
+{#if described}
+  <!-- The tooltip's own max-w-xs is the width here; a narrower override would be an
+       arbitrary value where a token exists. It encloses the WHOLE chip so hovering the
+       label — the obvious gesture — opens the definition, not only the "?". -->
+  <Tooltip side="top">
+    {@render chip()}
+    {#snippet content()}
+      <!-- The pending line is a placeholder rather than nothing: the reveal's box is
+           already open by the time this renders, so "nothing" is a visibly empty
+           popover. `text` is empty only when the chunk could not be fetched, and
+           saying so beats the same empty box standing there for good. -->
+      {#await description}
+        <span class="block h-3 w-40 animate-pulse rounded bg-muted"></span>
+      {:then text}
+        {#if text}
+          <span class="block text-left">{text}</span>
+          <a
+            href={resolve('/skills/[slug]', { slug })}
+            class="mt-1 block text-left font-medium underline"
+          >
+            What is {label}? →
+          </a>
+        {:else}
+          <span class="block text-left">Definition unavailable right now.</span>
+        {/if}
+      {/await}
+    {/snippet}
+  </Tooltip>
+{:else}
+  {@render chip()}
+{/if}

--- a/web/src/lib/facets.test.ts
+++ b/web/src/lib/facets.test.ts
@@ -6,6 +6,7 @@ import {
   countryFromSlug,
   countryLabel,
   countrySlug,
+  dynamicLabel,
   FACETS,
   slugifiedCountries,
 } from './facets';
@@ -196,5 +197,21 @@ describe('the country slug index', () => {
       expect(slug.endsWith('-')).toBe(false);
       expect(slug).not.toContain('--');
     }
+  });
+});
+
+describe('dynamicLabel', () => {
+  // The skills facet has no static option list, so every surface that names a selected
+  // skill — the filter summary chips above all — falls through to here. Without a
+  // branch it printed the raw slug, so one skill was spelled two ways on one screen:
+  // "ci-cd" in the summary, "CI/CD" in the panel beside it.
+  it('labels a skill the way the rest of the product does', () => {
+    expect(dynamicLabel('skills', 'ci-cd')).toBe('CI/CD');
+    expect(dynamicLabel('skills', 'nodejs')).toBe('Node.js');
+    expect(dynamicLabel('skills', 'data-engineering')).toBe('Data Engineering');
+  });
+
+  it('still passes through a facet with no label map of its own', () => {
+    expect(dynamicLabel('some_other_facet', 'raw-value')).toBe('raw-value');
   });
 });

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -245,6 +245,11 @@ export function dynamicLabel(param: string, value: string): string {
   if (param === 'company_slug') return companyLabel(value);
   if (param === 'source') return sourceLabel(value);
   if (param === 'role') return roleLabel(value);
+  // Skills have no static option list, so every surface naming a SELECTED skill — the
+  // filter summary chips above all — arrives here. Without this it fell through to the
+  // raw slug, and one skill was spelled two ways on one screen: "ci-cd" in the summary,
+  // "CI/CD" in the panel beside it.
+  if (param === 'skills') return skillLabel(value);
   return value;
 }
 

--- a/web/src/lib/tailor/JobMatch.svelte
+++ b/web/src/lib/tailor/JobMatch.svelte
@@ -10,6 +10,7 @@
   import ScoreCategoryRow from './ScoreCategoryRow.svelte';
   import type { CvJobMatch } from '$lib/cv';
   import SkillIcon from '../components/SkillIcon.svelte';
+  import { skillLabel } from '$lib/facets';
 
   let { data }: { data: CvJobMatch | null | undefined } = $props();
 
@@ -72,7 +73,7 @@
             <li
               class="flex items-center gap-1 rounded border border-warning/30 bg-background/60 px-1.5 py-0.5 text-[11px] text-warning-strong"
             >
-              <SkillIcon slug={skill} />{skill}
+              <SkillIcon slug={skill} />{skillLabel(skill)}
             </li>
           {/each}
         </ul>

--- a/web/src/routes/skills/+page.server.ts
+++ b/web/src/routes/skills/+page.server.ts
@@ -1,5 +1,6 @@
 import { skillLabel } from '$lib/facets';
 import { loadSkillDescriptions } from '$lib/skillDescriptions';
+import { isGlossaryPublished } from '$lib/skillGlossary';
 import type { PageServerLoad } from './$types';
 
 // The glossary index: every skill that has an entry, grouped by the first character of
@@ -29,6 +30,7 @@ export const load: PageServerLoad = async ({ setHeaders }) => {
 
   return {
     total: slugs.length,
+    published: isGlossaryPublished(slugs.length),
     groups: [...groups.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([letter, skills]) => ({

--- a/web/src/routes/skills/+page.svelte
+++ b/web/src/routes/skills/+page.svelte
@@ -24,7 +24,16 @@
   );
 </script>
 
-<Seo title="IT Skills Glossary · freehire" {description} {canonical} />
+<!-- Not indexable until the glossary is one. The footer link and the sitemap shard are
+     already withheld below the same threshold; without this a crawler that finds the
+     page some other way indexes a list of a handful of words as the product's glossary,
+     and that first impression outlives the fix. -->
+<Seo
+  title="IT Skills Glossary · freehire"
+  {description}
+  {canonical}
+  robots={data.published ? undefined : 'noindex, follow'}
+/>
 <svelte:head>
   <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD from jsonLdScript, which escapes `<` -->
   {@html jsonLd}

--- a/web/src/routes/skills/[slug]/+page.server.ts
+++ b/web/src/routes/skills/[slug]/+page.server.ts
@@ -2,7 +2,13 @@ import { error, redirect } from '@sveltejs/kit';
 import { SKILL_ALIASES } from '$lib/generated/skillAliases';
 import { skillLabel } from '$lib/facets';
 import { serverApi } from '$lib/server/api';
-import { MIN_SKILL_OPEN, displayAliases, showsPostings, topNeighbours } from '$lib/skillGlossary';
+import {
+  MIN_SKILL_OPEN,
+  displayAliases,
+  isGlossaryPublished,
+  showsPostings,
+  topNeighbours,
+} from '$lib/skillGlossary';
 import { hasSkillDescription, loadSkillDescriptions } from '$lib/skillDescriptions';
 import type { PageServerLoad } from './$types';
 
@@ -63,6 +69,9 @@ export const load: PageServerLoad = async ({ params, url, fetch, setHeaders }) =
     slug,
     label,
     description,
+    // Indexable only once the glossary is one — the same threshold the footer link
+    // and the sitemap shard already read.
+    published: isGlossaryPublished(Object.keys(catalog).length),
     aliases: displayAliases(aliasTable[slug] ?? [], slug, label),
     // Filtered to skills that HAVE a page: every neighbour is a link, and one to an
     // undescribed skill is a 404 published from a page whose whole claim is that it is

--- a/web/src/routes/skills/[slug]/+page.svelte
+++ b/web/src/routes/skills/[slug]/+page.svelte
@@ -38,7 +38,12 @@
   );
 </script>
 
-<Seo title={`What is ${data.label}? · freehire`} description={metaDescription} {canonical} />
+<Seo
+  title={`What is ${data.label}? · freehire`}
+  description={metaDescription}
+  {canonical}
+  robots={data.published ? undefined : 'noindex, follow'}
+/>
 <svelte:head>
   <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD from jsonLdScript, which escapes `<` -->
   {@html jsonLd}


### PR DESCRIPTION
Follow-up to #2290, from a two-axis review of that branch. Refs #1983.

The glossary shipped correctly but on **one surface out of seven**. This closes that,
plus five smaller things the review found.

## The gap that mattered

`SkillChip` was wired into `JobView` only. Six other surfaces still printed the raw
slug — including the two the issue names as its *first two* rationales:

> - Filter discovery: people skip facets they don't recognize.
> - CV match / skill-delta surfaces name skills the candidate is missing…

So a candidate met `ci-cd` in the filter summary chip and `CI/CD` in the panel directly
above it. That is exactly the drift `facet-display-labels` exists to prevent, arriving
through the one facet that module never covered.

| Surface | Before | Now |
|---|---|---|
| Filter summary | raw slug | label (`dynamicLabel` gained a `skills` branch — one line) |
| CV match delta (5 chips) | raw slug | label |
| Tailoring confirm dialog, tailor pane | raw slug | label |
| Job preview card, drawer | raw slug, no definition | full `SkillChip`, unlinked |
| Experience bank | raw string | **left alone** — the candidate's own words, not this vocabulary |

## Hover moved back onto the chip

The `?` is right for tap: a tap on a link navigates, so the reveal needs its own target.
But reaching for a 24px mark is not the gesture a pointer reader makes, and the issue
asks for hover *on the chip*. The tooltip now encloses the whole chip; the link stops the
touch `pointerdown` so the two gestures stay apart — tap the label to filter, tap the `?`
to read.

## `noindex` below the publication threshold

Withholding the sitemap shard closes one route in. A crawler arriving another way would
have indexed a list of a handful of words as the product's glossary, and that first
impression outlives the fix.

## Three things the code claimed that weren't true

- **`cmd/gen-skill-descriptions`** derived a cancellable context and checked a `Wait`
  error, but no goroutine returns one — failures are counted and skipped deliberately,
  since cancelling the rest on the first refusal is the opposite of what a wave wants.
  Plain `errgroup.Group` now; the guard around the print loop went too, because when
  every draft fails every slot is already empty.
- **`tooltip.svelte`'s `dismissOutside` comment** said its `contains` guard only stopped
  the opening tap from closing it. The floating content is a *descendant* of the wrapper,
  so that guard is also what keeps a tap on a link inside the tooltip from dismissing it.
- **`skilltag/AGENTS.md`** read "a TSV, not a Go map: 863 entries" — that describes the
  vocabulary and reads as the file, which holds one row.

Plus two in the plan: the spec said the worker prints a Go source map (it prints TSV),
and the proposal gave it a `DATABASE_URL` it never opens.

## Verification

`gofmt`, `go vet ./...`, `go vet -tags=integration ./...`, `go test ./...`,
`pnpm check:links`, web (1288) and design-system (147) tests, `svelte-check`, both lints,
and the design-system token check are green. On a production build against live data:
`/skills` and `/skills/dbt` serve and carry `noindex, follow`; a real posting still shows
the `?` for `dbt` only.

## Still deferred, unchanged

Waves 1–3 (tasks 3.1, 5.1–5.3). Coverage is 1 of 863, which is why the publication
threshold and the ratchet are still doing their jobs.
