### PR TITLE
Key a filter chip by the value it removes, not by the words it prints

### DIFF
--- a/web/src/lib/components/filters/AiFilterDialog.svelte
+++ b/web/src/lib/components/filters/AiFilterDialog.svelte
@@ -18,8 +18,10 @@
   // user is not told about is indistinguishable from a value that WAS applied.
   let { store, onclose }: { store: FilterStore; onclose: () => void } = $props();
 
-  /** One previewed value. `exclude` draws it struck through, as the sidebar does. */
-  type PreviewChip = { text: string; exclude: boolean };
+  /** One previewed value. `exclude` draws it struck through, as the sidebar does; `key`
+   *  is its identity in the keyed `{#each}` — `param:value`, never the label, which two
+   *  values of one facet can share (see SummaryChip.key). */
+  type PreviewChip = { key: string; text: string; exclude: boolean };
   type PreviewGroup = { label: string; chips: PreviewChip[] };
 
   let text = $state('');
@@ -45,19 +47,20 @@
     const push = (heading: string, chips: PreviewChip[]) => {
       if (chips.length) groups.push({ label: heading, chips });
     };
-    const one = (heading: string, text: string) => push(heading, [{ text, exclude: false }]);
+    const one = (heading: string, text: string) => push(heading, [{ key: heading, text, exclude: false }]);
 
     for (const def of FACETS) {
       // Included wins over excluded, the rule filtersFromInterpretation applies when the
-      // same values become a filter. The server drops the overlap before it gets here,
-      // but the chips are keyed by text and a duplicate key does not merely look odd in
-      // Svelte — it breaks the whole each block. Cheap insurance on a rendered value.
+      // same values become a filter. The server drops the overlap before it gets here;
+      // repeating the filter keeps one value from being drawn twice, and — since the
+      // chips key on `param:value` — from keying the same chip twice, which does not
+      // merely look odd in Svelte but breaks the whole each block.
       const included = result.facets?.[def.param] ?? [];
       push(def.label, [
-        ...included.map((v) => ({ text: label(def.param, v), exclude: false })),
+        ...included.map((v) => ({ key: `${def.param}:${v}`, text: label(def.param, v), exclude: false })),
         ...(result.exclude?.[def.param] ?? [])
           .filter((v) => !included.includes(v))
-          .map((v) => ({ text: label(def.param, v), exclude: true })),
+          .map((v) => ({ key: `${def.param}:${v}`, text: label(def.param, v), exclude: true })),
       ]);
     }
     // The bounds use the SHARED labels, not wording of our own: the preview promises to
@@ -172,7 +175,7 @@
               <div>
                 <p class="text-xs font-medium text-muted-foreground">{group.label}</p>
                 <div class="mt-1 flex flex-wrap gap-1.5">
-                  {#each group.chips as chip (chip.text)}
+                  {#each group.chips as chip (chip.key)}
                     <span
                       class="rounded-lg px-2 py-1 text-xs {chip.exclude
                         ? 'bg-destructive/10 text-destructive line-through'

--- a/web/src/lib/components/filters/CompanyFilterSummary.svelte
+++ b/web/src/lib/components/filters/CompanyFilterSummary.svelte
@@ -17,6 +17,7 @@
     COMPANY_FACETS.map((def) => ({
       label: def.label,
       chips: store.facet(def.param).include.map((v) => ({
+        key: `${def.param}:${v}`,
         text: valueLabel(def, v),
         exclude: false,
         remove: () => store.remove(def.param, v),

--- a/web/src/lib/components/filters/FilterSummary.svelte
+++ b/web/src/lib/components/filters/FilterSummary.svelte
@@ -36,8 +36,8 @@
       const st = f.facets[param];
       if (!st) return [];
       return [
-        ...st.include.map((v) => ({ text: valueLabel(param, v), exclude: false, remove: () => store.remove(param, v), slug: withIcon ? v : undefined })),
-        ...st.exclude.map((v) => ({ text: valueLabel(param, v), exclude: true, remove: () => store.remove(param, v), slug: withIcon ? v : undefined })),
+        ...st.include.map((v) => ({ key: `${param}:${v}`, text: valueLabel(param, v), exclude: false, remove: () => store.remove(param, v), slug: withIcon ? v : undefined })),
+        ...st.exclude.map((v) => ({ key: `${param}:${v}`, text: valueLabel(param, v), exclude: true, remove: () => store.remove(param, v), slug: withIcon ? v : undefined })),
       ];
     };
     const facetGroup = (param: string, label: string, withIcon = false) => {
@@ -47,7 +47,7 @@
 
     // The text query (from the header search on the standalone list) as a removable
     // chip, so the sidebar shows what you searched, not just the facet filters.
-    push('Search', f.q.trim() ? [{ text: f.q, exclude: false, remove: () => store.setQuery('') }] : []);
+    push('Search', f.q.trim() ? [{ key: 'q', text: f.q, exclude: false, remove: () => store.setQuery('') }] : []);
 
     facetGroup('category', 'Specialization');
     // Role had no group here at all: it counted towards the badge but drew no chip, so
@@ -73,22 +73,23 @@
 
     // Salary: currency + minimum.
     const salary: SummaryChip[] = facetChips('salary_currency');
-    if (f.salaryMin != null) salary.push({ text: `${f.salaryMin.toLocaleString('en-US')}+`, exclude: false, remove: () => store.setSalaryMin(null) });
+    if (f.salaryMin != null) salary.push({ key: 'salary_min', text: `${f.salaryMin.toLocaleString('en-US')}+`, exclude: false, remove: () => store.setSalaryMin(null) });
     push('Salary', salary);
 
-    if (f.visa) push('Visa', [{ text: 'Sponsorship', exclude: false, remove: () => store.setVisa(false) }]);
+    if (f.visa) push('Visa', [{ key: 'visa', text: 'Sponsorship', exclude: false, remove: () => store.setVisa(false) }]);
     if (f.clearance !== 'any')
       push('Clearance', [
         {
+          key: 'clearance',
           text: f.clearance === 'hide' ? 'Hidden' : 'Required only',
           exclude: false,
           remove: () => store.setClearance('any'),
         },
       ]);
-    if (f.postedWithinDays != null) push('Posted', [{ text: freshnessLabel(f.postedWithinDays), exclude: false, remove: () => store.setPostedWithinDays(null) }]);
+    if (f.postedWithinDays != null) push('Posted', [{ key: 'posted_within_days', text: freshnessLabel(f.postedWithinDays), exclude: false, remove: () => store.setPostedWithinDays(null) }]);
     // `!= null`, not truthiness: a zero bound is the entry-level filter, and hiding
     // its chip would leave the narrowest experience filter with no way to remove it.
-    if (f.experienceYearsMax != null) push('Experience', [{ text: experienceLabel(f.experienceYearsMax), exclude: false, remove: () => store.setExperienceYearsMax(null) }]);
+    if (f.experienceYearsMax != null) push('Experience', [{ key: 'experience_years_max', text: experienceLabel(f.experienceYearsMax), exclude: false, remove: () => store.setExperienceYearsMax(null) }]);
 
     return out;
   });

--- a/web/src/lib/components/filters/FilterSummaryShell.svelte
+++ b/web/src/lib/components/filters/FilterSummaryShell.svelte
@@ -1,5 +1,11 @@
 <script module lang="ts">
   export interface SummaryChip {
+    /** Identity for the keyed `{#each}`, unique by construction — `param:value` for a
+     *  facet value, a literal for the one-off chips (Search, Salary, Visa…). NOT the
+     *  label: two different values can share one, and since the skills facet started
+     *  labelling from the dictionary, `nextjs` and `next.js` both read "Next.js" — a
+     *  duplicate key, which Svelte answers by tearing down the whole block. */
+    key: string;
     text: string;
     /** Excluded value — rendered in the destructive (struck-through) style. */
     exclude: boolean;
@@ -100,7 +106,7 @@
           </button>
         </div>
         <div class="flex flex-wrap gap-1.5">
-          {#each g.chips as c (c.text)}
+          {#each g.chips as c (c.key)}
             <span
               class={[
                 'inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium',


### PR DESCRIPTION
Key a filter chip by the value it removes, not by the words it prints

The skills facet started labelling from the dictionary yesterday (#2292), which is
right — but the summary chips were keyed by that label, and the dictionary is
many-to-one: nextjs and next.js both read "Next.js", ci-cd and ci/cd both "CI/CD".
Two chips, one key. Svelte answers a duplicate key by tearing the whole block
down, so a filter set carrying both spellings took the page with it.

The key is now param:value, unique by construction and already the convention in
LocationPane. SummaryChip.key is required, so svelte-check names any surface that
tries to key on a rendered string again; the AI preview built the same shape and
gets the same treatment.

The colliding values still draw two chips. They ARE two filter values, each
removable on its own — folding them is a question for the dictionary, not for the
sidebar, which must not silently drop a filter that is applied.
