### PR TITLE
Read Strider's own open/closed flag, and attribute its outbound links

### DIFF
--- a/internal/ingest/sources/onstrider.go
+++ b/internal/ingest/sources/onstrider.go
@@ -2,22 +2,36 @@ package sources
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
+
+	"golang.org/x/net/html"
 )
 
 // onstrider adapts Strider's careers site (www.onstrider.com), a HubSpot-hosted LATAM talent
-// marketplace. It is the DataArt shape — the sitemap enumerates every vacancy URL and each OPEN
+// marketplace. It is the DataArt shape — the sitemap enumerates every vacancy URL and each
 // vacancy page server-renders a schema.org JobPosting ld+json block, so this adapter enumerates
 // from the sitemap and maps per-vacancy details over the shared fetchDetails + ldJobPosting
-// helpers. A CLOSED vacancy keeps its sitemap URL (still HTTP 200) but drops the JobPosting
-// markup, so its absence is the open/closed signal — detail() returns ok=false and it is
-// dropped. The real employer is hidden (hiringOrganization is always "Strider"), so every
+// helpers. The real employer is hidden (hiringOrganization is always "Strider"), so every
 // posting maps to the single board-file company; the adapter is boardless single-company.
+//
+// Open/closed is read from the hero's data-position-open attribute, NOT from the presence of the
+// JobPosting markup. The markup was the original signal and it is far too weak: measured live
+// over the whole sitemap (308 vacancies, 2026-09-01), only 34 had dropped it while 266 of the
+// 274 readable pages were closed — so the old rule admitted a catalogue that was ~97% dead
+// links. Nothing in the visible text distinguishes them either: the page always ships BOTH the
+// "Accepting Applications" and "Closed" spans and lets CSS pick one off the same attribute, so
+// matching on the text reads "closed" for every vacancy.
 type onstrider struct {
 	http onstriderHTTP
+	// referral is the Strider referral handle outbound links are attributed to, from
+	// ONSTRIDER_REFERRAL_HANDLE (see registry.go). Empty means unattributed: URL stays the
+	// canonical vacancy page, which is what an installation that is not a Strider referral
+	// partner — including every fork of this repository — gets.
+	referral string
 }
 
 // onstriderHTTP is the transport onstrider needs: the XML sitemap plus HTML detail pages.
@@ -28,8 +42,14 @@ type onstriderHTTP interface {
 
 const onstriderSitemapURL = "https://www.onstrider.com/sitemap.xml"
 
-// NewOnstrider builds the onstrider adapter over the given HTTP client.
-func NewOnstrider(c onstriderHTTP) Source { return onstrider{http: c} }
+// NewOnstrider builds the onstrider adapter over the given HTTP client, attributing outbound
+// links to the given Strider referral handle (empty = unattributed, see onstrider.referral).
+func NewOnstrider(c onstriderHTTP, referral string) Source {
+	if !onstriderReferralHandlePattern.MatchString(referral) {
+		referral = "" // absent or malformed: crawl unattributed rather than emit a broken link
+	}
+	return onstrider{http: c, referral: referral}
+}
 
 func (onstrider) Provider() string { return "onstrider" }
 
@@ -69,16 +89,19 @@ func (s onstrider) Fetch(ctx context.Context, ce CompanyEntry) ([]Job, error) {
 }
 
 // detail fetches one vacancy page and maps its JobPosting ld+json to a Job. It returns ok=false
-// when the fetch fails, the page carries no JobPosting block (a closed vacancy), or the posting
-// has no identifier.value (no dedup key) — so the caller drops just that vacancy.
+// when the fetch fails, the vacancy is closed, the page carries no JobPosting block, or the
+// posting has no identifier.value (no dedup key) — so the caller drops just that vacancy.
 func (s onstrider) detail(ctx context.Context, ce CompanyEntry, jobURL string) (Job, bool) {
 	root, err := s.http.GetHTML(ctx, jobURL)
 	if err != nil {
 		return Job{}, false
 	}
+	if !onstriderPositionOpen(root) {
+		return Job{}, false // closed vacancy, or a page shape that no longer states it
+	}
 	var p onstriderPosting
 	if !ldJobPosting(root, &p) {
-		return Job{}, false // closed vacancy: JobPosting markup dropped
+		return Job{}, false // no JobPosting markup to map
 	}
 	if p.Identifier.Value == "" {
 		return Job{}, false // no native id → would collide on the dedup key; skip it
@@ -86,7 +109,7 @@ func (s onstrider) detail(ctx context.Context, ce CompanyEntry, jobURL string) (
 	remote := strings.EqualFold(p.JobLocationType, "TELECOMMUTE")
 	return Job{
 		ExternalID:     p.Identifier.Value,
-		URL:            jobURL,
+		URL:            s.applyURL(jobURL),
 		Title:          p.Title,
 		Company:        ce.Company,
 		Location:       p.location(),
@@ -106,6 +129,59 @@ var onstriderVacancyURLPattern = regexp.MustCompile(`^https?://www\.onstrider\.c
 
 // onstriderVacancyURL reports whether u is a canonical vacancy URL.
 func onstriderVacancyURL(u string) bool { return onstriderVacancyURLPattern.MatchString(u) }
+
+// onstriderPositionOpen reports whether the vacancy page states the position is still taking
+// applications, reading the hero's data-position-open attribute ("1" open, "0" closed). It is
+// the only place the page states this: both status labels are hard-coded into the markup and
+// CSS picks one off this same attribute, so the visible text says "Closed" on an open vacancy.
+//
+// A page carrying no such attribute reads as CLOSED, because its absence means the page shape
+// moved and the status is no longer stated — admitting an unknown-status vacancy is what put a
+// year of dead links in the catalogue. Fetch already fails the board when the sitemap lists
+// vacancies and none map, so a site-wide template change stops the run loudly rather than
+// closing the catalogue behind it.
+func onstriderPositionOpen(root *html.Node) bool {
+	open, done := false, false
+	walk(root, func(n *html.Node) bool {
+		if done {
+			return false
+		}
+		if n.Type == html.ElementNode {
+			if v := attr(n, "data-position-open"); v != "" {
+				open, done = v == "1", true
+				return false
+			}
+		}
+		return true
+	})
+	return open
+}
+
+// onstriderReferralHandlePattern is the shape a Strider referral handle may take. The handle is
+// interpolated into a URL path, so anything else is rejected at construction rather than
+// escaped: a handle is copied from a Strider profile by hand, and a malformed one is a
+// misconfiguration to notice, not input to sanitise.
+var onstriderReferralHandlePattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+// applyURL wraps a canonical vacancy URL in the configured Strider referral link, the shape
+// Strider's own share links use: /r/<handle> on the app host, carrying the destination
+// base64-encoded in ?job=. Verified live — landing on it records the referral as the visit's
+// first touch. The plainer www.onstrider.com/jobs/<slug>?referral=<handle> form does NOT: that
+// page sets no attribution cookie of its own, so only the /r/ route earns the referral.
+//
+// An unset handle (or a URL this cannot take apart) leaves the canonical vacancy URL alone.
+func (s onstrider) applyURL(jobURL string) string {
+	if s.referral == "" {
+		return jobURL
+	}
+	_, slug, ok := strings.Cut(jobURL, "/jobs/")
+	slug = strings.TrimSuffix(slug, "/")
+	if !ok || slug == "" || strings.Contains(slug, "/") {
+		return jobURL
+	}
+	dest := base64.StdEncoding.EncodeToString([]byte(slug + "?referral=" + s.referral))
+	return "https://app.onstrider.com/r/" + s.referral + "?job=" + dest
+}
 
 // onstriderPosting is the schema.org JobPosting decoded from a vacancy page's ld+json. identifier
 // is a PropertyValue whose value is the vacancy UUID; applicantLocationRequirements is an array

--- a/internal/ingest/sources/onstrider_test.go
+++ b/internal/ingest/sources/onstrider_test.go
@@ -2,13 +2,16 @@ package sources
 
 import (
 	"context"
+	"encoding/base64"
+	"strings"
 	"testing"
 )
 
-// onstriderDetailHTML builds an onstrider vacancy page carrying a schema.org JobPosting ld+json
-// block in the site's real shape: identifier is a PropertyValue object (value is the UUID),
-// applicantLocationRequirements and employmentType are arrays, jobLocationType is the remote
-// signal, and the description is already HTML (not double-escaped).
+// onstriderDetailHTML builds an OPEN onstrider vacancy page carrying a schema.org JobPosting
+// ld+json block in the site's real shape: identifier is a PropertyValue object (value is the
+// UUID), applicantLocationRequirements and employmentType are arrays, jobLocationType is the
+// remote signal, and the description is already HTML (not double-escaped). The hero carries
+// data-position-open plus BOTH hard-coded status labels, as the live page does.
 func onstriderDetailHTML(id, title, description, datePosted, jobLocationType string, countries ...string) string {
 	var alr string
 	for i, c := range countries {
@@ -26,7 +29,28 @@ func onstriderDetailHTML(id, title, description, datePosted, jobLocationType str
 		`"employmentType":["PART_TIME","CONTRACTOR"],` +
 		`"jobLocationType":"` + jobLocationType + `",` +
 		`"applicantLocationRequirements":[` + alr + `]}` +
-		`</script></head><body></body></html>`
+		`</script></head><body>` + onstriderHeroHTML(true) + `</body></html>`
+}
+
+// onstriderHeroHTML is the status hero the live page renders. Both labels are always present —
+// CSS shows one of them off data-position-open — so a status read from the TEXT is always wrong.
+func onstriderHeroHTML(open bool) string {
+	flag := "0"
+	if open {
+		flag = "1"
+	}
+	return `<ul class="group/hero" data-position-open="` + flag + `"><li><span>` +
+		`<span class="hidden group-data-[position-open=1]/hero:block">Accepting Applications</span> ` +
+		`<span class="group-data-[position-open=1]/hero:hidden block">Closed</span>` +
+		`</span></li></ul>`
+}
+
+// onstriderClosedDetailHTML is the same page for a CLOSED vacancy. Strider leaves the JobPosting
+// markup in place and flips only data-position-open — the shape that let the original
+// presence-of-markup rule admit 266 dead vacancies out of 274 readable ones.
+func onstriderClosedDetailHTML(id, title, description, datePosted, jobLocationType string, countries ...string) string {
+	open := onstriderDetailHTML(id, title, description, datePosted, jobLocationType, countries...)
+	return strings.Replace(open, onstriderHeroHTML(true), onstriderHeroHTML(false), 1)
 }
 
 func onstriderSitemapXML(locs ...string) string {
@@ -85,6 +109,37 @@ func TestOnstriderDetailMapsJobPosting(t *testing.T) {
 	}
 }
 
+func TestOnstriderDropsVacancyClosedByPositionFlag(t *testing.T) {
+	// The real closed shape: full JobPosting markup, data-position-open flipped to 0. The old
+	// rule (markup present = open) admitted these, which is where the dead links came from.
+	detail := onstriderClosedDetailHTML(
+		"975f80e4-ee1e-4652-b18c-d2defecf83aa",
+		"Full-stack Engineer", "<p>x</p>", "2024-10-01", "TELECOMMUTE", "BR")
+	fake := (&routedHTTP{}).route("/jobs/full-stack-engineer-975f80e4", detail)
+
+	if _, ok := (onstrider{http: fake}).detail(context.Background(),
+		CompanyEntry{Company: "Strider"}, "https://www.onstrider.com/jobs/full-stack-engineer-975f80e4"); ok {
+		t.Error("detail returned ok=true for a vacancy whose data-position-open is 0")
+	}
+}
+
+func TestOnstriderDropsVacancyWithoutPositionFlag(t *testing.T) {
+	// A JobPosting page that states no status at all: the page shape moved, so the status is
+	// unknown and the vacancy is dropped rather than admitted. Fetch's "URLs but no jobs" guard
+	// turns a site-wide change into a failed board instead of a silently closed catalogue.
+	detail := `<html><head><script type="application/ld+json">` +
+		`{"@context":"https://schema.org/","@type":"JobPosting","title":"Ghost",` +
+		`"identifier":{"@type":"PropertyValue","value":"975f80e4-ee1e-4652-b18c-d2defecf83aa"},` +
+		`"jobLocationType":"TELECOMMUTE"}` +
+		`</script></head><body><ul><li>Accepting Applications</li></ul></body></html>`
+	fake := (&routedHTTP{}).route("/jobs/ghost-975f80e4", detail)
+
+	if _, ok := (onstrider{http: fake}).detail(context.Background(),
+		CompanyEntry{Company: "Strider"}, "https://www.onstrider.com/jobs/ghost-975f80e4"); ok {
+		t.Error("detail returned ok=true for a page carrying no data-position-open attribute")
+	}
+}
+
 func TestOnstriderDropsClosedVacancy(t *testing.T) {
 	// A closed vacancy keeps its URL but drops the JobPosting markup — only an Organization
 	// ld+json block remains, so detail() must return ok=false.
@@ -124,7 +179,7 @@ func TestOnstriderFetchFiltersSitemapToVacancies(t *testing.T) {
 			onstriderDetailHTML("975f80e4-ee1e-4652-b18c-d2defecf83aa",
 				"Full-stack Engineer", "<p>x</p>", "2024-10-01", "TELECOMMUTE", "BR"))
 
-	jobs, err := NewOnstrider(fake).Fetch(context.Background(),
+	jobs, err := NewOnstrider(fake, "").Fetch(context.Background(),
 		CompanyEntry{Company: "Strider", Provider: "onstrider"})
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
@@ -146,7 +201,7 @@ func TestOnstriderScalarEmploymentTypeIsNotDropped(t *testing.T) {
 		`"identifier":{"@type":"PropertyValue","value":"11111111-2222-3333-4444-555555555555"},` +
 		`"employmentType":"FULL_TIME","jobLocationType":"TELECOMMUTE",` +
 		`"applicantLocationRequirements":[{"@type":"Country","name":"BR"}]}` +
-		`</script></head><body></body></html>`
+		`</script></head><body>` + onstriderHeroHTML(true) + `</body></html>`
 	fake := (&routedHTTP{}).route("/jobs/solo-eng-11111111", detail)
 
 	j, ok := (onstrider{http: fake}).detail(context.Background(),
@@ -169,7 +224,7 @@ func TestOnstriderFetchFailsWhenNoVacancyMaps(t *testing.T) {
 		route("sitemap.xml", onstriderSitemapXML("https://www.onstrider.com/jobs/closed-role-0f0f72b5")).
 		route("/jobs/closed-role-0f0f72b5", closed)
 
-	if _, err := NewOnstrider(fake).Fetch(context.Background(),
+	if _, err := NewOnstrider(fake, "").Fetch(context.Background(),
 		CompanyEntry{Company: "Strider", Provider: "onstrider"}); err == nil {
 		t.Error("Fetch returned nil error when the sitemap had vacancy URLs but none mapped")
 	}
@@ -203,8 +258,60 @@ func TestOnstriderVacancyURL(t *testing.T) {
 	}
 }
 
+func TestOnstriderApplyURLCarriesTheReferralHandle(t *testing.T) {
+	s := onstrider{referral: "partner_h4nd13"}
+	got := s.applyURL("https://www.onstrider.com/jobs/full-stack-engineer-975f80e4")
+
+	// Strider's own share shape: /r/<handle> on the app host, destination base64 in ?job=.
+	want := "https://app.onstrider.com/r/partner_h4nd13?job=" +
+		base64.StdEncoding.EncodeToString([]byte("full-stack-engineer-975f80e4?referral=partner_h4nd13"))
+	if got != want {
+		t.Errorf("applyURL() = %q, want %q", got, want)
+	}
+	// The trailing-slash form the sitemap also emits must resolve to the same link, not to a
+	// slug carrying a slash — otherwise one vacancy would ship two different outbound URLs.
+	if slashed := s.applyURL("https://www.onstrider.com/jobs/full-stack-engineer-975f80e4/"); slashed != want {
+		t.Errorf("applyURL(trailing slash) = %q, want %q", slashed, want)
+	}
+}
+
+func TestOnstriderApplyURLIsCanonicalWithoutAHandle(t *testing.T) {
+	// No handle configured (every fork of this repository): the outbound link stays the
+	// canonical vacancy page rather than pointing at somebody else's referral.
+	const jobURL = "https://www.onstrider.com/jobs/full-stack-engineer-975f80e4"
+	if got := (onstrider{}).applyURL(jobURL); got != jobURL {
+		t.Errorf("applyURL() = %q, want the canonical URL unchanged", got)
+	}
+	// A malformed handle would be interpolated into a URL path, so the constructor drops it.
+	s := NewOnstrider(nil, "not a handle/../x").(onstrider)
+	if s.referral != "" {
+		t.Errorf("referral = %q, want it dropped as malformed", s.referral)
+	}
+}
+
+func TestOnstriderFetchAttributesOutboundLinks(t *testing.T) {
+	jobURL := "https://www.onstrider.com/jobs/full-stack-engineer-975f80e4"
+	fake := (&routedHTTP{}).
+		route("sitemap.xml", onstriderSitemapXML(jobURL)).
+		route("/jobs/full-stack-engineer-975f80e4",
+			onstriderDetailHTML("975f80e4-ee1e-4652-b18c-d2defecf83aa",
+				"Full-stack Engineer", "<p>x</p>", "2024-10-01", "TELECOMMUTE", "BR"))
+
+	jobs, err := NewOnstrider(fake, "partner_h4nd13").Fetch(context.Background(),
+		CompanyEntry{Company: "Strider", Provider: "onstrider"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	if !strings.HasPrefix(jobs[0].URL, "https://app.onstrider.com/r/partner_h4nd13?job=") {
+		t.Errorf("URL = %q, want the referral link", jobs[0].URL)
+	}
+}
+
 func TestOnstriderProviderBoardlessAndProxied(t *testing.T) {
-	var s = NewOnstrider(nil)
+	var s = NewOnstrider(nil, "")
 	if s.Provider() != "onstrider" {
 		t.Errorf("Provider() = %q, want onstrider", s.Provider())
 	}

--- a/internal/ingest/sources/proxy.go
+++ b/internal/ingest/sources/proxy.go
@@ -50,7 +50,9 @@ var proxiedProviders = map[string]func(HTTPClient) Source{
 	// spike ran from a residential IP). It is pre-wired here so that, if the prod IP is blocked
 	// like djinni's, setting SOURCES_PROXY_URL routes only this provider through the proxy with
 	// no code change; while the proxy is unset this entry is inert.
-	"onstrider": func(c HTTPClient) Source { return NewOnstrider(c) },
+	"onstrider": func(c HTTPClient) Source {
+		return NewOnstrider(c, os.Getenv("ONSTRIDER_REFERRAL_HANDLE"))
+	},
 	// geekjob.ru is a Russian board reached only over the prod datacenter IP in production and is
 	// untested from it (the spike ran from a residential IP). Like its RU sibling habr_career it
 	// fetches a per-vacancy detail page for the description, so a WAF challenge on the detail HTML

--- a/internal/ingest/sources/registry.go
+++ b/internal/ingest/sources/registry.go
@@ -262,7 +262,7 @@ func All(c HTTPClient) map[string]Source {
 		NewApple(c),
 		NewLumenalta(c),
 		NewDataArt(c),
-		NewOnstrider(c),
+		NewOnstrider(c, os.Getenv("ONSTRIDER_REFERRAL_HANDLE")),
 		NewAlignerr(c),
 		NewTalentHR(c),
 		NewMicro1(c),

--- a/sources/onstrider.yml
+++ b/sources/onstrider.yml
@@ -1,7 +1,10 @@
 # Strider careers (www.onstrider.com), a HubSpot-hosted LATAM talent marketplace. Boardless
-# single-company source: the sitemap enumerates every vacancy and each OPEN vacancy page renders
-# a schema.org JobPosting ld+json block (a closed vacancy drops the markup — that absence is the
-# open/closed signal). The real employer is hidden (hiringOrganization is always "Strider"), so
-# every posting maps to this entry's `company`. See internal/sources/onstrider.go.
+# single-company source: the sitemap enumerates every vacancy and each vacancy page renders a
+# schema.org JobPosting ld+json block. Open/closed is read from the hero's data-position-open
+# attribute — the markup stays on a CLOSED vacancy and both status labels ship on every page, so
+# neither the markup's presence nor the visible text tells them apart. The real employer is
+# hidden (hiringOrganization is always "Strider"), so every posting maps to this entry's
+# `company`. Outbound links carry the ONSTRIDER_REFERRAL_HANDLE referral when it is set.
+# See internal/ingest/sources/onstrider.go.
 - company: Strider
   provider: onstrider


### PR DESCRIPTION
## What

Two things for the `onstrider` source, both found by measuring the live site.

### The catalogue was ~97% dead links

The adapter took the presence of schema.org JobPosting markup as proof a vacancy was open. Measured over the whole sitemap on 2026-09-01:

| | |
|---|---|
| vacancy URLs in sitemap | 308 |
| pages read successfully | 274 |
| **actually open** | **8** |
| closed | 266 |
| JobPosting markup dropped (what the old rule caught) | 34 |

Strider keeps the JobPosting block on a closed vacancy. It states the status in the hero's `data-position-open` attribute instead.

It does **not** state it in the visible text. Both labels ship on every page and CSS picks one off that same attribute:

```html
<span class="hidden group-data-[position-open=1]/hero:block">Accepting Applications</span>
<span class="group-data-[position-open=1]/hero:hidden block">Closed</span>
```

So `detail()` reads the attribute. A page carrying no such attribute reads as **closed** — the page shape moved and the status is unknown, and admitting unknown-status vacancies is what caused this. `Fetch`'s existing "sitemap had URLs but nothing mapped" guard turns a site-wide template change into a failed board rather than a silently closed catalogue, so that direction stays safe.

### Outbound links are now attributable

`ONSTRIDER_REFERRAL_HANDLE` sets the Strider referral handle. This follows the `WHATJOBS_PUBLISHER_IDS` precedent: an account identifier belongs in the environment, not in a board file this repository publishes. Unset — which is every fork — keeps the canonical vacancy URL.

The link shape is Strider's own share link, `/r/<handle>` on the app host with the destination base64-encoded in `?job=`. Verified live in a browser: landing on it records the referral as the visit's first touch. The plainer `/jobs/<slug>?referral=<handle>` form does **not** — that page sets no attribution cookie of its own — so the wrapper is load-bearing, not cosmetic.

A malformed handle is dropped at construction rather than escaped: it is interpolated into a URL path, and a handle is copied from a profile by hand, so a bad one is a misconfiguration to notice.

## Known, not addressed here

Walking 308 detail pages at the default 8 workers earns a Cloudflare 429 — I hit it while measuring. The adapter already fails the board loudly in that case, and the real fix is fetching fewer pages, which needs a listing endpoint this source does not publish. Left alone rather than tuned by guess.

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...` — pass
- `go vet -tags=integration ./...` — pass
- New tests: closed-by-flag is dropped; a page with no flag is dropped; `applyURL` builds the referral link (and folds the trailing-slash URL form onto the same link); no handle leaves the URL canonical; a malformed handle is dropped; `Fetch` end-to-end emits the referral URL
- Existing fixtures now carry the real hero markup, both labels included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added referral attribution to vacancy links when configured, while preserving canonical links when unavailable.
  - Improved vacancy status detection using the page’s explicit open-position indicator.

- **Bug Fixes**
  - Closed vacancies are no longer included in results.
  - Vacancies without a valid open-position status are excluded.

- **Documentation**
  - Updated source documentation to reflect the revised vacancy status signals and referral-link behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->