### PR TITLE
Send one notification per account, not one per saved job

### DIFF
--- a/design-system/static/email-previews/index.html
+++ b/design-system/static/email-previews/index.html
@@ -239,9 +239,29 @@ Manage your alerts: ./my/notifications
     </div>
     <iframe data-mail="saved-job-reminder" src="saved-job-reminder.light.html" title="Tracking / Saved-job reminder" sandbox="allow-same-origin" loading="lazy"></iframe>
     <div class="text">
-      <details><summary>Plain-text alternative</summary><pre>You saved Senior Backend Engineer (Go) at Fingerprint and haven&#39;t applied yet.
+      <details><summary>Plain-text alternative</summary><pre>You saved this job and haven’t applied yet.
 
-Open the job: ./jobs/senior-backend-engineer-go-fingerprint?utm_source=email
+- Senior Backend Engineer (Go) — Fingerprint
+  ./jobs/senior-backend-engineer-go-fingerprint?utm_source=email
+</pre></details>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="meta">
+      <div class="name">Tracking / Saved-job reminders (batch)</div>
+      <div class="subject">Reminder: 3 saved jobs</div>
+    </div>
+    <iframe data-mail="saved-job-reminder-batch" src="saved-job-reminder-batch.light.html" title="Tracking / Saved-job reminders (batch)" sandbox="allow-same-origin" loading="lazy"></iframe>
+    <div class="text">
+      <details><summary>Plain-text alternative</summary><pre>You saved these jobs and haven’t applied yet.
+
+- Senior Backend Engineer (Go) — Fingerprint
+  ./jobs/senior-backend-engineer-go-fingerprint?utm_source=email
+- Staff Platform Engineer — Vercel
+  ./jobs/staff-platform-engineer-vercel?utm_source=email
+- Site Reliability Engineer — Datadog
+  ./jobs/site-reliability-engineer-datadog?utm_source=email
 </pre></details>
     </div>
   </div>

--- a/design-system/static/email-previews/index.html
+++ b/design-system/static/email-previews/index.html
@@ -239,10 +239,9 @@ Manage your alerts: ./my/notifications
     </div>
     <iframe data-mail="saved-job-reminder" src="saved-job-reminder.light.html" title="Tracking / Saved-job reminder" sandbox="allow-same-origin" loading="lazy"></iframe>
     <div class="text">
-      <details><summary>Plain-text alternative</summary><pre>You saved this job and haven’t applied yet.
+      <details><summary>Plain-text alternative</summary><pre>You saved Senior Backend Engineer (Go) at Fingerprint and haven&#39;t applied yet.
 
-- Senior Backend Engineer (Go) — Fingerprint
-  ./jobs/senior-backend-engineer-go-fingerprint?utm_source=email
+Open the job: ./jobs/senior-backend-engineer-go-fingerprint?utm_source=email
 </pre></details>
     </div>
   </div>

--- a/design-system/static/email-previews/index.html
+++ b/design-system/static/email-previews/index.html
@@ -282,6 +282,27 @@ Open your tracking board: ./my/tracking?utm_source=email
 
   <div class="card">
     <div class="meta">
+      <div class="name">Tracking / Nudge: follow up (batch)</div>
+      <div class="subject">Time to follow up on 3 applications</div>
+    </div>
+    <iframe data-mail="nudge-follow-up-batch" src="nudge-follow-up-batch.light.html" title="Tracking / Nudge: follow up (batch)" sandbox="allow-same-origin" loading="lazy"></iframe>
+    <div class="text">
+      <details><summary>Plain-text alternative</summary><pre>Nothing has moved on 3 of your applications.
+
+- Staff Engineer, Platform — Speechify
+  ./jobs/staff-engineer-platform-speechify?utm_source=email
+- Backend Engineer — Monzo
+  ./jobs/backend-engineer-monzo?utm_source=email
+- Infrastructure Engineer — Grafana Labs
+  ./jobs/infrastructure-engineer-grafana-labs?utm_source=email
+
+Open your tracking board: ./my/tracking?utm_source=email
+</pre></details>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="meta">
       <div class="name">Tracking / Nudge: job closed</div>
       <div class="subject">Closed: Go Developer — Payments at Avenga</div>
     </div>

--- a/design-system/static/email-previews/nudge-follow-up-batch.dark.html
+++ b/design-system/static/email-previews/nudge-follow-up-batch.dark.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="dark">
+<meta name="supported-color-schemes" content="dark">
+<title>Worth a follow-up?</title>
+<style>
+  .m-page   { background: #0d0e0b !important; }
+  .m-card   { background: #161616 !important; border-color: #2a2a2a !important; }
+  .m-ink    { color: #fafafa !important; }
+  .m-muted  { color: #a4a4a4 !important; }
+  .m-row    { border-top-color: #2a2a2a !important; }
+  .m-quote  { color: #a4a4a4 !important; border-left-color: #2a2a2a !important; }
+  .m-code   { background: #2e3318 !important; color: #b5c478 !important; }
+  .m-tile   { background: #2e3318 !important; color: #b5c478 !important; }
+  .m-btn    { background: #9cae69 !important; }
+  .m-btn-a  { color: #101309 !important; }
+  .m-logo   { filter: invert(1); }
+</style>
+</head>
+<body class="m-page" style="margin:0;padding:0;background:#f0f0f0;">
+<div style="display:none;max-height:0;overflow:hidden;opacity:0;">3 applications have gone quiet</div>
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="m-page" style="background:#f0f0f0;">
+  <tr><td align="center" style="padding:32px 12px;">
+    <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;width:100%;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+
+      <tr><td style="padding:0 4px 16px 4px;">
+        <a href="." style="text-decoration:none;color:#070707;">
+          <img src="./email-logo.png" width="28" height="28" alt="" class="m-logo" style="vertical-align:middle;border:0;display:inline-block;">
+          <span class="m-ink" style="vertical-align:middle;padding-left:10px;font-size:17px;font-weight:700;letter-spacing:-0.01em;color:#070707;">freehire</span>
+        </a>
+      </td></tr>
+
+      <tr><td class="m-card" style="background:#ffffff;border:1px solid #e4e4e4;border-radius:12px;padding:28px;">
+        <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">Worth a follow-up?</h1>
+        
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+  
+  <tr><td class="m-row" style="padding:14px 0;"><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+<td width="44" valign="top" style="width:44px;padding-right:12px;">
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="40" style="width:40px;">
+    <tr><td align="center" valign="middle" height="40" class="m-tile" style="height:40px;background:#e5eacd;border-radius:8px;font-size:15px;font-weight:700;color:#4c5c00;">
+      <img src="https://logo.freehire.me/Speechify" width="40" height="40" alt="S" style="display:block;border:0;border-radius:8px;">
+    </td></tr>
+  </table>
+</td>
+<td valign="top">
+  <a href="./jobs/staff-engineer-platform-speechify?utm_source=email" class="m-ink" style="font-size:16px;font-weight:600;color:#070707;text-decoration:underline;">Staff Engineer, Platform</a>
+  <div class="m-muted" style="font-size:14px;line-height:1.5;color:#505050;padding-top:3px;">Speechify</div>
+</td>
+</tr></table></td></tr>
+  
+  <tr><td class="m-row" style="padding:14px 0;border-top:1px solid #e4e4e4;"><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+<td width="44" valign="top" style="width:44px;padding-right:12px;">
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="40" style="width:40px;">
+    <tr><td align="center" valign="middle" height="40" class="m-tile" style="height:40px;background:#e5eacd;border-radius:8px;font-size:15px;font-weight:700;color:#4c5c00;">
+      <img src="https://logo.freehire.me/Monzo" width="40" height="40" alt="M" style="display:block;border:0;border-radius:8px;">
+    </td></tr>
+  </table>
+</td>
+<td valign="top">
+  <a href="./jobs/backend-engineer-monzo?utm_source=email" class="m-ink" style="font-size:16px;font-weight:600;color:#070707;text-decoration:underline;">Backend Engineer</a>
+  <div class="m-muted" style="font-size:14px;line-height:1.5;color:#505050;padding-top:3px;">Monzo</div>
+</td>
+</tr></table></td></tr>
+  
+  <tr><td class="m-row" style="padding:14px 0;border-top:1px solid #e4e4e4;"><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+<td width="44" valign="top" style="width:44px;padding-right:12px;">
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="40" style="width:40px;">
+    <tr><td align="center" valign="middle" height="40" class="m-tile" style="height:40px;background:#e5eacd;border-radius:8px;font-size:15px;font-weight:700;color:#4c5c00;">
+      <img src="https://logo.freehire.me/Grafana%20Labs" width="40" height="40" alt="G" style="display:block;border:0;border-radius:8px;">
+    </td></tr>
+  </table>
+</td>
+<td valign="top">
+  <a href="./jobs/infrastructure-engineer-grafana-labs?utm_source=email" class="m-ink" style="font-size:16px;font-weight:600;color:#070707;text-decoration:underline;">Infrastructure Engineer</a>
+  <div class="m-muted" style="font-size:14px;line-height:1.5;color:#505050;padding-top:3px;">Grafana Labs</div>
+</td>
+</tr></table></td></tr>
+  
+</table>
+<div style="height:18px;"></div>
+<p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">Nothing has moved on 3 of your applications.</p>
+
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="./my/tracking?utm_source=email" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;">Open your tracking board</a></td></tr></table>
+      </td></tr>
+
+      
+      <tr><td class="m-muted" style="padding:20px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
+        You’re getting this because you are tracking these applications on freehire.
+      </td></tr>
+      
+
+      <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
+        <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
+        <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
+      </td></tr>
+
+    </table>
+  </td></tr>
+</table>
+</body>
+</html>

--- a/design-system/static/email-previews/nudge-follow-up-batch.html
+++ b/design-system/static/email-previews/nudge-follow-up-batch.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
+<title>Worth a follow-up?</title>
+<style>@media (prefers-color-scheme: dark) {
+  .m-page   { background: #0d0e0b !important; }
+  .m-card   { background: #161616 !important; border-color: #2a2a2a !important; }
+  .m-ink    { color: #fafafa !important; }
+  .m-muted  { color: #a4a4a4 !important; }
+  .m-row    { border-top-color: #2a2a2a !important; }
+  .m-quote  { color: #a4a4a4 !important; border-left-color: #2a2a2a !important; }
+  .m-code   { background: #2e3318 !important; color: #b5c478 !important; }
+  .m-tile   { background: #2e3318 !important; color: #b5c478 !important; }
+  .m-btn    { background: #9cae69 !important; }
+  .m-btn-a  { color: #101309 !important; }
+  .m-logo   { filter: invert(1); }
+}</style>
+</head>
+<body class="m-page" style="margin:0;padding:0;background:#f0f0f0;">
+<div style="display:none;max-height:0;overflow:hidden;opacity:0;">3 applications have gone quiet</div>
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="m-page" style="background:#f0f0f0;">
+  <tr><td align="center" style="padding:32px 12px;">
+    <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;width:100%;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+
+      <tr><td style="padding:0 4px 16px 4px;">
+        <a href="." style="text-decoration:none;color:#070707;">
+          <img src="./email-logo.png" width="28" height="28" alt="" class="m-logo" style="vertical-align:middle;border:0;display:inline-block;">
+          <span class="m-ink" style="vertical-align:middle;padding-left:10px;font-size:17px;font-weight:700;letter-spacing:-0.01em;color:#070707;">freehire</span>
+        </a>
+      </td></tr>
+
+      <tr><td class="m-card" style="background:#ffffff;border:1px solid #e4e4e4;border-radius:12px;padding:28px;">
+        <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">Worth a follow-up?</h1>
+        
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+  
+  <tr><td class="m-row" style="padding:14px 0;"><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+<td width="44" valign="top" style="width:44px;padding-right:12px;">
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="40" style="width:40px;">
+    <tr><td align="center" valign="middle" height="40" class="m-tile" style="height:40px;background:#e5eacd;border-radius:8px;font-size:15px;font-weight:700;color:#4c5c00;">
+      <img src="https://logo.freehire.me/Speechify" width="40" height="40" alt="S" style="display:block;border:0;border-radius:8px;">
+    </td></tr>
+  </table>
+</td>
+<td valign="top">
+  <a href="./jobs/staff-engineer-platform-speechify?utm_source=email" class="m-ink" style="font-size:16px;font-weight:600;color:#070707;text-decoration:underline;">Staff Engineer, Platform</a>
+  <div class="m-muted" style="font-size:14px;line-height:1.5;color:#505050;padding-top:3px;">Speechify</div>
+</td>
+</tr></table></td></tr>
+  
+  <tr><td class="m-row" style="padding:14px 0;border-top:1px solid #e4e4e4;"><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+<td width="44" valign="top" style="width:44px;padding-right:12px;">
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="40" style="width:40px;">
+    <tr><td align="center" valign="middle" height="40" class="m-tile" style="height:40px;background:#e5eacd;border-radius:8px;font-size:15px;font-weight:700;color:#4c5c00;">
+      <img src="https://logo.freehire.me/Monzo" width="40" height="40" alt="M" style="display:block;border:0;border-radius:8px;">
+    </td></tr>
+  </table>
+</td>
+<td valign="top">
+  <a href="./jobs/backend-engineer-monzo?utm_source=email" class="m-ink" style="font-size:16px;font-weight:600;color:#070707;text-decoration:underline;">Backend Engineer</a>
+  <div class="m-muted" style="font-size:14px;line-height:1.5;color:#505050;padding-top:3px;">Monzo</div>
+</td>
+</tr></table></td></tr>
+  
+  <tr><td class="m-row" style="padding:14px 0;border-top:1px solid #e4e4e4;"><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+<td width="44" valign="top" style="width:44px;padding-right:12px;">
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="40" style="width:40px;">
+    <tr><td align="center" valign="middle" height="40" class="m-tile" style="height:40px;background:#e5eacd;border-radius:8px;font-size:15px;font-weight:700;color:#4c5c00;">
+      <img src="https://logo.freehire.me/Grafana%20Labs" width="40" height="40" alt="G" style="display:block;border:0;border-radius:8px;">
+    </td></tr>
+  </table>
+</td>
+<td valign="top">
+  <a href="./jobs/infrastructure-engineer-grafana-labs?utm_source=email" class="m-ink" style="font-size:16px;font-weight:600;color:#070707;text-decoration:underline;">Infrastructure Engineer</a>
+  <div class="m-muted" style="font-size:14px;line-height:1.5;color:#505050;padding-top:3px;">Grafana Labs</div>
+</td>
+</tr></table></td></tr>
+  
+</table>
+<div style="height:18px;"></div>
+<p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">Nothing has moved on 3 of your applications.</p>
+
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="./my/tracking?utm_source=email" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;">Open your tracking board</a></td></tr></table>
+      </td></tr>
+
+      
+      <tr><td class="m-muted" style="padding:20px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
+        You’re getting this because you are tracking these applications on freehire.
+      </td></tr>
+      
+
+      <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
+        <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
+        <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
+      </td></tr>
+
+    </table>
+  </td></tr>
+</table>
+</body>
+</html>

--- a/design-system/static/email-previews/nudge-follow-up-batch.light.html
+++ b/design-system/static/email-previews/nudge-follow-up-batch.light.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="light">
+<meta name="supported-color-schemes" content="light">
+<title>Worth a follow-up?</title>
+
+</head>
+<body class="m-page" style="margin:0;padding:0;background:#f0f0f0;">
+<div style="display:none;max-height:0;overflow:hidden;opacity:0;">3 applications have gone quiet</div>
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="m-page" style="background:#f0f0f0;">
+  <tr><td align="center" style="padding:32px 12px;">
+    <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;width:100%;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+
+      <tr><td style="padding:0 4px 16px 4px;">
+        <a href="." style="text-decoration:none;color:#070707;">
+          <img src="./email-logo.png" width="28" height="28" alt="" class="m-logo" style="vertical-align:middle;border:0;display:inline-block;">
+          <span class="m-ink" style="vertical-align:middle;padding-left:10px;font-size:17px;font-weight:700;letter-spacing:-0.01em;color:#070707;">freehire</span>
+        </a>
+      </td></tr>
+
+      <tr><td class="m-card" style="background:#ffffff;border:1px solid #e4e4e4;border-radius:12px;padding:28px;">
+        <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">Worth a follow-up?</h1>
+        
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+  
+  <tr><td class="m-row" style="padding:14px 0;"><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+<td width="44" valign="top" style="width:44px;padding-right:12px;">
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="40" style="width:40px;">
+    <tr><td align="center" valign="middle" height="40" class="m-tile" style="height:40px;background:#e5eacd;border-radius:8px;font-size:15px;font-weight:700;color:#4c5c00;">
+      <img src="https://logo.freehire.me/Speechify" width="40" height="40" alt="S" style="display:block;border:0;border-radius:8px;">
+    </td></tr>
+  </table>
+</td>
+<td valign="top">
+  <a href="./jobs/staff-engineer-platform-speechify?utm_source=email" class="m-ink" style="font-size:16px;font-weight:600;color:#070707;text-decoration:underline;">Staff Engineer, Platform</a>
+  <div class="m-muted" style="font-size:14px;line-height:1.5;color:#505050;padding-top:3px;">Speechify</div>
+</td>
+</tr></table></td></tr>
+  
+  <tr><td class="m-row" style="padding:14px 0;border-top:1px solid #e4e4e4;"><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+<td width="44" valign="top" style="width:44px;padding-right:12px;">
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="40" style="width:40px;">
+    <tr><td align="center" valign="middle" height="40" class="m-tile" style="height:40px;background:#e5eacd;border-radius:8px;font-size:15px;font-weight:700;color:#4c5c00;">
+      <img src="https://logo.freehire.me/Monzo" width="40" height="40" alt="M" style="display:block;border:0;border-radius:8px;">
+    </td></tr>
+  </table>
+</td>
+<td valign="top">
+  <a href="./jobs/backend-engineer-monzo?utm_source=email" class="m-ink" style="font-size:16px;font-weight:600;color:#070707;text-decoration:underline;">Backend Engineer</a>
+  <div class="m-muted" style="font-size:14px;line-height:1.5;color:#505050;padding-top:3px;">Monzo</div>
+</td>
+</tr></table></td></tr>
+  
+  <tr><td class="m-row" style="padding:14px 0;border-top:1px solid #e4e4e4;"><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+<td width="44" valign="top" style="width:44px;padding-right:12px;">
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="40" style="width:40px;">
+    <tr><td align="center" valign="middle" height="40" class="m-tile" style="height:40px;background:#e5eacd;border-radius:8px;font-size:15px;font-weight:700;color:#4c5c00;">
+      <img src="https://logo.freehire.me/Grafana%20Labs" width="40" height="40" alt="G" style="display:block;border:0;border-radius:8px;">
+    </td></tr>
+  </table>
+</td>
+<td valign="top">
+  <a href="./jobs/infrastructure-engineer-grafana-labs?utm_source=email" class="m-ink" style="font-size:16px;font-weight:600;color:#070707;text-decoration:underline;">Infrastructure Engineer</a>
+  <div class="m-muted" style="font-size:14px;line-height:1.5;color:#505050;padding-top:3px;">Grafana Labs</div>
+</td>
+</tr></table></td></tr>
+  
+</table>
+<div style="height:18px;"></div>
+<p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">Nothing has moved on 3 of your applications.</p>
+
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="./my/tracking?utm_source=email" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;">Open your tracking board</a></td></tr></table>
+      </td></tr>
+
+      
+      <tr><td class="m-muted" style="padding:20px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
+        You’re getting this because you are tracking these applications on freehire.
+      </td></tr>
+      
+
+      <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
+        <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
+        <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
+      </td></tr>
+
+    </table>
+  </td></tr>
+</table>
+</body>
+</html>

--- a/design-system/static/email-previews/saved-job-reminder-batch.dark.html
+++ b/design-system/static/email-previews/saved-job-reminder-batch.dark.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="color-scheme" content="dark">
 <meta name="supported-color-schemes" content="dark">
-<title>Still interested?</title>
+<title>3 saved jobs are still open</title>
 <style>
   .m-page   { background: #0d0e0b !important; }
   .m-card   { background: #161616 !important; border-color: #2a2a2a !important; }
@@ -21,7 +21,7 @@
 </style>
 </head>
 <body class="m-page" style="margin:0;padding:0;background:#f0f0f0;">
-<div style="display:none;max-height:0;overflow:hidden;opacity:0;">A job you saved is still open</div>
+<div style="display:none;max-height:0;overflow:hidden;opacity:0;">3 jobs you saved are still open</div>
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="m-page" style="background:#f0f0f0;">
   <tr><td align="center" style="padding:32px 12px;">
     <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;width:100%;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
@@ -34,7 +34,7 @@
       </td></tr>
 
       <tr><td class="m-card" style="background:#ffffff;border:1px solid #e4e4e4;border-radius:12px;padding:28px;">
-        <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">Still interested?</h1>
+        <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">3 saved jobs are still open</h1>
         
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
   
@@ -52,11 +52,39 @@
 </td>
 </tr></table></td></tr>
   
+  <tr><td class="m-row" style="padding:14px 0;border-top:1px solid #e4e4e4;"><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+<td width="44" valign="top" style="width:44px;padding-right:12px;">
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="40" style="width:40px;">
+    <tr><td align="center" valign="middle" height="40" class="m-tile" style="height:40px;background:#e5eacd;border-radius:8px;font-size:15px;font-weight:700;color:#4c5c00;">
+      <img src="https://logo.freehire.me/Vercel" width="40" height="40" alt="V" style="display:block;border:0;border-radius:8px;">
+    </td></tr>
+  </table>
+</td>
+<td valign="top">
+  <a href="./jobs/staff-platform-engineer-vercel?utm_source=email" class="m-ink" style="font-size:16px;font-weight:600;color:#070707;text-decoration:underline;">Staff Platform Engineer</a>
+  <div class="m-muted" style="font-size:14px;line-height:1.5;color:#505050;padding-top:3px;">Vercel</div>
+</td>
+</tr></table></td></tr>
+  
+  <tr><td class="m-row" style="padding:14px 0;border-top:1px solid #e4e4e4;"><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+<td width="44" valign="top" style="width:44px;padding-right:12px;">
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="40" style="width:40px;">
+    <tr><td align="center" valign="middle" height="40" class="m-tile" style="height:40px;background:#e5eacd;border-radius:8px;font-size:15px;font-weight:700;color:#4c5c00;">
+      <img src="https://logo.freehire.me/Datadog" width="40" height="40" alt="D" style="display:block;border:0;border-radius:8px;">
+    </td></tr>
+  </table>
+</td>
+<td valign="top">
+  <a href="./jobs/site-reliability-engineer-datadog?utm_source=email" class="m-ink" style="font-size:16px;font-weight:600;color:#070707;text-decoration:underline;">Site Reliability Engineer</a>
+  <div class="m-muted" style="font-size:14px;line-height:1.5;color:#505050;padding-top:3px;">Datadog</div>
+</td>
+</tr></table></td></tr>
+  
 </table>
 <div style="height:18px;"></div>
-<p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">You saved this job and haven’t applied yet.</p>
+<p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">You saved these jobs and haven’t applied yet.</p>
 
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="./jobs/senior-backend-engineer-go-fingerprint?utm_source=email" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;">Open the job and apply</a></td></tr></table>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="./my/activity?utm_source=email" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;">Open your saved jobs</a></td></tr></table>
       </td></tr>
 
       

--- a/design-system/static/email-previews/saved-job-reminder-batch.html
+++ b/design-system/static/email-previews/saved-job-reminder-batch.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<meta name="color-scheme" content="dark">
-<meta name="supported-color-schemes" content="dark">
-<title>Still interested?</title>
-<style>
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
+<title>3 saved jobs are still open</title>
+<style>@media (prefers-color-scheme: dark) {
   .m-page   { background: #0d0e0b !important; }
   .m-card   { background: #161616 !important; border-color: #2a2a2a !important; }
   .m-ink    { color: #fafafa !important; }
@@ -18,10 +18,10 @@
   .m-btn    { background: #9cae69 !important; }
   .m-btn-a  { color: #101309 !important; }
   .m-logo   { filter: invert(1); }
-</style>
+}</style>
 </head>
 <body class="m-page" style="margin:0;padding:0;background:#f0f0f0;">
-<div style="display:none;max-height:0;overflow:hidden;opacity:0;">A job you saved is still open</div>
+<div style="display:none;max-height:0;overflow:hidden;opacity:0;">3 jobs you saved are still open</div>
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="m-page" style="background:#f0f0f0;">
   <tr><td align="center" style="padding:32px 12px;">
     <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;width:100%;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
@@ -34,7 +34,7 @@
       </td></tr>
 
       <tr><td class="m-card" style="background:#ffffff;border:1px solid #e4e4e4;border-radius:12px;padding:28px;">
-        <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">Still interested?</h1>
+        <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">3 saved jobs are still open</h1>
         
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
   
@@ -52,11 +52,39 @@
 </td>
 </tr></table></td></tr>
   
+  <tr><td class="m-row" style="padding:14px 0;border-top:1px solid #e4e4e4;"><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+<td width="44" valign="top" style="width:44px;padding-right:12px;">
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="40" style="width:40px;">
+    <tr><td align="center" valign="middle" height="40" class="m-tile" style="height:40px;background:#e5eacd;border-radius:8px;font-size:15px;font-weight:700;color:#4c5c00;">
+      <img src="https://logo.freehire.me/Vercel" width="40" height="40" alt="V" style="display:block;border:0;border-radius:8px;">
+    </td></tr>
+  </table>
+</td>
+<td valign="top">
+  <a href="./jobs/staff-platform-engineer-vercel?utm_source=email" class="m-ink" style="font-size:16px;font-weight:600;color:#070707;text-decoration:underline;">Staff Platform Engineer</a>
+  <div class="m-muted" style="font-size:14px;line-height:1.5;color:#505050;padding-top:3px;">Vercel</div>
+</td>
+</tr></table></td></tr>
+  
+  <tr><td class="m-row" style="padding:14px 0;border-top:1px solid #e4e4e4;"><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+<td width="44" valign="top" style="width:44px;padding-right:12px;">
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="40" style="width:40px;">
+    <tr><td align="center" valign="middle" height="40" class="m-tile" style="height:40px;background:#e5eacd;border-radius:8px;font-size:15px;font-weight:700;color:#4c5c00;">
+      <img src="https://logo.freehire.me/Datadog" width="40" height="40" alt="D" style="display:block;border:0;border-radius:8px;">
+    </td></tr>
+  </table>
+</td>
+<td valign="top">
+  <a href="./jobs/site-reliability-engineer-datadog?utm_source=email" class="m-ink" style="font-size:16px;font-weight:600;color:#070707;text-decoration:underline;">Site Reliability Engineer</a>
+  <div class="m-muted" style="font-size:14px;line-height:1.5;color:#505050;padding-top:3px;">Datadog</div>
+</td>
+</tr></table></td></tr>
+  
 </table>
 <div style="height:18px;"></div>
-<p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">You saved this job and haven’t applied yet.</p>
+<p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">You saved these jobs and haven’t applied yet.</p>
 
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="./jobs/senior-backend-engineer-go-fingerprint?utm_source=email" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;">Open the job and apply</a></td></tr></table>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="./my/activity?utm_source=email" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;">Open your saved jobs</a></td></tr></table>
       </td></tr>
 
       

--- a/design-system/static/email-previews/saved-job-reminder-batch.light.html
+++ b/design-system/static/email-previews/saved-job-reminder-batch.light.html
@@ -3,25 +3,13 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<meta name="color-scheme" content="dark">
-<meta name="supported-color-schemes" content="dark">
-<title>Still interested?</title>
-<style>
-  .m-page   { background: #0d0e0b !important; }
-  .m-card   { background: #161616 !important; border-color: #2a2a2a !important; }
-  .m-ink    { color: #fafafa !important; }
-  .m-muted  { color: #a4a4a4 !important; }
-  .m-row    { border-top-color: #2a2a2a !important; }
-  .m-quote  { color: #a4a4a4 !important; border-left-color: #2a2a2a !important; }
-  .m-code   { background: #2e3318 !important; color: #b5c478 !important; }
-  .m-tile   { background: #2e3318 !important; color: #b5c478 !important; }
-  .m-btn    { background: #9cae69 !important; }
-  .m-btn-a  { color: #101309 !important; }
-  .m-logo   { filter: invert(1); }
-</style>
+<meta name="color-scheme" content="light">
+<meta name="supported-color-schemes" content="light">
+<title>3 saved jobs are still open</title>
+
 </head>
 <body class="m-page" style="margin:0;padding:0;background:#f0f0f0;">
-<div style="display:none;max-height:0;overflow:hidden;opacity:0;">A job you saved is still open</div>
+<div style="display:none;max-height:0;overflow:hidden;opacity:0;">3 jobs you saved are still open</div>
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="m-page" style="background:#f0f0f0;">
   <tr><td align="center" style="padding:32px 12px;">
     <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;width:100%;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
@@ -34,7 +22,7 @@
       </td></tr>
 
       <tr><td class="m-card" style="background:#ffffff;border:1px solid #e4e4e4;border-radius:12px;padding:28px;">
-        <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">Still interested?</h1>
+        <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">3 saved jobs are still open</h1>
         
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
   
@@ -52,11 +40,39 @@
 </td>
 </tr></table></td></tr>
   
+  <tr><td class="m-row" style="padding:14px 0;border-top:1px solid #e4e4e4;"><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+<td width="44" valign="top" style="width:44px;padding-right:12px;">
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="40" style="width:40px;">
+    <tr><td align="center" valign="middle" height="40" class="m-tile" style="height:40px;background:#e5eacd;border-radius:8px;font-size:15px;font-weight:700;color:#4c5c00;">
+      <img src="https://logo.freehire.me/Vercel" width="40" height="40" alt="V" style="display:block;border:0;border-radius:8px;">
+    </td></tr>
+  </table>
+</td>
+<td valign="top">
+  <a href="./jobs/staff-platform-engineer-vercel?utm_source=email" class="m-ink" style="font-size:16px;font-weight:600;color:#070707;text-decoration:underline;">Staff Platform Engineer</a>
+  <div class="m-muted" style="font-size:14px;line-height:1.5;color:#505050;padding-top:3px;">Vercel</div>
+</td>
+</tr></table></td></tr>
+  
+  <tr><td class="m-row" style="padding:14px 0;border-top:1px solid #e4e4e4;"><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+<td width="44" valign="top" style="width:44px;padding-right:12px;">
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="40" style="width:40px;">
+    <tr><td align="center" valign="middle" height="40" class="m-tile" style="height:40px;background:#e5eacd;border-radius:8px;font-size:15px;font-weight:700;color:#4c5c00;">
+      <img src="https://logo.freehire.me/Datadog" width="40" height="40" alt="D" style="display:block;border:0;border-radius:8px;">
+    </td></tr>
+  </table>
+</td>
+<td valign="top">
+  <a href="./jobs/site-reliability-engineer-datadog?utm_source=email" class="m-ink" style="font-size:16px;font-weight:600;color:#070707;text-decoration:underline;">Site Reliability Engineer</a>
+  <div class="m-muted" style="font-size:14px;line-height:1.5;color:#505050;padding-top:3px;">Datadog</div>
+</td>
+</tr></table></td></tr>
+  
 </table>
 <div style="height:18px;"></div>
-<p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">You saved this job and haven’t applied yet.</p>
+<p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">You saved these jobs and haven’t applied yet.</p>
 
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="./jobs/senior-backend-engineer-go-fingerprint?utm_source=email" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;">Open the job and apply</a></td></tr></table>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="./my/activity?utm_source=email" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;">Open your saved jobs</a></td></tr></table>
       </td></tr>
 
       

--- a/design-system/static/email-previews/saved-job-reminder.dark.html
+++ b/design-system/static/email-previews/saved-job-reminder.dark.html
@@ -36,9 +36,7 @@
       <tr><td class="m-card" style="background:#ffffff;border:1px solid #e4e4e4;border-radius:12px;padding:28px;">
         <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">Still interested?</h1>
         
-<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
-  
-  <tr><td class="m-row" style="padding:14px 0;"><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
 <td width="44" valign="top" style="width:44px;padding-right:12px;">
   <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="40" style="width:40px;">
     <tr><td align="center" valign="middle" height="40" class="m-tile" style="height:40px;background:#e5eacd;border-radius:8px;font-size:15px;font-weight:700;color:#4c5c00;">
@@ -50,18 +48,15 @@
   <a href="./jobs/senior-backend-engineer-go-fingerprint?utm_source=email" class="m-ink" style="font-size:16px;font-weight:600;color:#070707;text-decoration:underline;">Senior Backend Engineer (Go)</a>
   <div class="m-muted" style="font-size:14px;line-height:1.5;color:#505050;padding-top:3px;">Fingerprint</div>
 </td>
-</tr></table></td></tr>
-  
-</table>
+</tr></table>
 <div style="height:18px;"></div>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">You saved this job and haven’t applied yet.</p>
-
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="./jobs/senior-backend-engineer-go-fingerprint?utm_source=email" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;">Open the job and apply</a></td></tr></table>
       </td></tr>
 
       
       <tr><td class="m-muted" style="padding:20px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
-        You’re getting this because you saved these jobs on freehire.
+        You’re getting this because you saved this job on freehire.
       </td></tr>
       
 

--- a/design-system/static/email-previews/saved-job-reminder.html
+++ b/design-system/static/email-previews/saved-job-reminder.html
@@ -36,9 +36,7 @@
       <tr><td class="m-card" style="background:#ffffff;border:1px solid #e4e4e4;border-radius:12px;padding:28px;">
         <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">Still interested?</h1>
         
-<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
-  
-  <tr><td class="m-row" style="padding:14px 0;"><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
 <td width="44" valign="top" style="width:44px;padding-right:12px;">
   <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="40" style="width:40px;">
     <tr><td align="center" valign="middle" height="40" class="m-tile" style="height:40px;background:#e5eacd;border-radius:8px;font-size:15px;font-weight:700;color:#4c5c00;">
@@ -50,18 +48,15 @@
   <a href="./jobs/senior-backend-engineer-go-fingerprint?utm_source=email" class="m-ink" style="font-size:16px;font-weight:600;color:#070707;text-decoration:underline;">Senior Backend Engineer (Go)</a>
   <div class="m-muted" style="font-size:14px;line-height:1.5;color:#505050;padding-top:3px;">Fingerprint</div>
 </td>
-</tr></table></td></tr>
-  
-</table>
+</tr></table>
 <div style="height:18px;"></div>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">You saved this job and haven’t applied yet.</p>
-
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="./jobs/senior-backend-engineer-go-fingerprint?utm_source=email" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;">Open the job and apply</a></td></tr></table>
       </td></tr>
 
       
       <tr><td class="m-muted" style="padding:20px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
-        You’re getting this because you saved these jobs on freehire.
+        You’re getting this because you saved this job on freehire.
       </td></tr>
       
 

--- a/design-system/static/email-previews/saved-job-reminder.html
+++ b/design-system/static/email-previews/saved-job-reminder.html
@@ -36,7 +36,9 @@
       <tr><td class="m-card" style="background:#ffffff;border:1px solid #e4e4e4;border-radius:12px;padding:28px;">
         <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">Still interested?</h1>
         
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+  
+  <tr><td class="m-row" style="padding:14px 0;"><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
 <td width="44" valign="top" style="width:44px;padding-right:12px;">
   <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="40" style="width:40px;">
     <tr><td align="center" valign="middle" height="40" class="m-tile" style="height:40px;background:#e5eacd;border-radius:8px;font-size:15px;font-weight:700;color:#4c5c00;">
@@ -48,15 +50,18 @@
   <a href="./jobs/senior-backend-engineer-go-fingerprint?utm_source=email" class="m-ink" style="font-size:16px;font-weight:600;color:#070707;text-decoration:underline;">Senior Backend Engineer (Go)</a>
   <div class="m-muted" style="font-size:14px;line-height:1.5;color:#505050;padding-top:3px;">Fingerprint</div>
 </td>
-</tr></table>
+</tr></table></td></tr>
+  
+</table>
 <div style="height:18px;"></div>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">You saved this job and haven’t applied yet.</p>
+
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="./jobs/senior-backend-engineer-go-fingerprint?utm_source=email" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;">Open the job and apply</a></td></tr></table>
       </td></tr>
 
       
       <tr><td class="m-muted" style="padding:20px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
-        You’re getting this because you saved this job on freehire.
+        You’re getting this because you saved these jobs on freehire.
       </td></tr>
       
 

--- a/design-system/static/email-previews/saved-job-reminder.light.html
+++ b/design-system/static/email-previews/saved-job-reminder.light.html
@@ -24,7 +24,9 @@
       <tr><td class="m-card" style="background:#ffffff;border:1px solid #e4e4e4;border-radius:12px;padding:28px;">
         <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">Still interested?</h1>
         
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+  
+  <tr><td class="m-row" style="padding:14px 0;"><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
 <td width="44" valign="top" style="width:44px;padding-right:12px;">
   <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="40" style="width:40px;">
     <tr><td align="center" valign="middle" height="40" class="m-tile" style="height:40px;background:#e5eacd;border-radius:8px;font-size:15px;font-weight:700;color:#4c5c00;">
@@ -36,15 +38,18 @@
   <a href="./jobs/senior-backend-engineer-go-fingerprint?utm_source=email" class="m-ink" style="font-size:16px;font-weight:600;color:#070707;text-decoration:underline;">Senior Backend Engineer (Go)</a>
   <div class="m-muted" style="font-size:14px;line-height:1.5;color:#505050;padding-top:3px;">Fingerprint</div>
 </td>
-</tr></table>
+</tr></table></td></tr>
+  
+</table>
 <div style="height:18px;"></div>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">You saved this job and haven’t applied yet.</p>
+
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="./jobs/senior-backend-engineer-go-fingerprint?utm_source=email" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;">Open the job and apply</a></td></tr></table>
       </td></tr>
 
       
       <tr><td class="m-muted" style="padding:20px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
-        You’re getting this because you saved this job on freehire.
+        You’re getting this because you saved these jobs on freehire.
       </td></tr>
       
 

--- a/design-system/static/email-previews/saved-job-reminder.light.html
+++ b/design-system/static/email-previews/saved-job-reminder.light.html
@@ -24,9 +24,7 @@
       <tr><td class="m-card" style="background:#ffffff;border:1px solid #e4e4e4;border-radius:12px;padding:28px;">
         <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">Still interested?</h1>
         
-<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
-  
-  <tr><td class="m-row" style="padding:14px 0;"><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
 <td width="44" valign="top" style="width:44px;padding-right:12px;">
   <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="40" style="width:40px;">
     <tr><td align="center" valign="middle" height="40" class="m-tile" style="height:40px;background:#e5eacd;border-radius:8px;font-size:15px;font-weight:700;color:#4c5c00;">
@@ -38,18 +36,15 @@
   <a href="./jobs/senior-backend-engineer-go-fingerprint?utm_source=email" class="m-ink" style="font-size:16px;font-weight:600;color:#070707;text-decoration:underline;">Senior Backend Engineer (Go)</a>
   <div class="m-muted" style="font-size:14px;line-height:1.5;color:#505050;padding-top:3px;">Fingerprint</div>
 </td>
-</tr></table></td></tr>
-  
-</table>
+</tr></table>
 <div style="height:18px;"></div>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">You saved this job and haven’t applied yet.</p>
-
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="./jobs/senior-backend-engineer-go-fingerprint?utm_source=email" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;">Open the job and apply</a></td></tr></table>
       </td></tr>
 
       
       <tr><td class="m-muted" style="padding:20px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
-        You’re getting this because you saved these jobs on freehire.
+        You’re getting this because you saved this job on freehire.
       </td></tr>
       
 

--- a/docs/agents/notifications.md
+++ b/docs/agents/notifications.md
@@ -17,9 +17,11 @@ Telegram, and mobile push), each with its own small `Notifier`/`Router` pair:
 - **All three engines deliver in GROUPS, and a group is the unit of everything.**
   `notify` groups a subscription's matched jobs; `internal/engage/reminder` groups an
   account's due reminders; `internal/engage/nudge` groups an account's due nudges **of one
-  kind**. Every `Notifier.Send` therefore takes a slice, not a message — there is no
-  per-item send path left for a channel to keep using, which is the point: eight saves in
-  a day were eight emails three days later. The kinds stay apart because "your
+  kind**, and `internal/engage/reminder` additionally splits on the CHANNEL SET (see the
+  bullet below). Every `Notifier.Send` therefore takes a whole group — a `notify.Digest`
+  for subscriptions, a slice for the other two — and none of them takes a single item, so
+  no per-item send path is left for a channel to keep using. That is the point: eight
+  saves in a day were eight emails three days later. The kinds stay apart because "your
   application went quiet" and "prepare for your interview" are different errands with
   different call-to-actions; merging them would need a mail that says neither. One send
   outcome decides the whole group: a failure records an attempt against every member and
@@ -27,6 +29,15 @@ Telegram, and mobile push), each with its own small `Notifier`/`Router` pair:
   delivery ledger to describe and nothing reads one. A group of ONE must stay
   byte-identical to the pre-grouping message — that is what makes the change invisible to
   everyone it doesn't help.
+- **A reminder's channels are a SNAPSHOT, so they are part of its batch key.**
+  `job_reminders.channels` is frozen when the reminder is scheduled — migration 0034 says
+  why: "a later rule edit never rewrites a pending reminder". So an account that changed
+  its rule between two saves has two genuinely different deliveries due, and grouping on
+  the account alone would send one of them over the other's channels and stamp it
+  delivered anyway. The key is `(user_id, sorted channel set)`; only the KEY is sorted, so
+  the send still walks the first member's own slice. `internal/engage/nudge` has no such
+  split: `GetNudgeForDelivery` reads `notification_settings.channels` live, which IS an
+  account property.
 - **A reminder's `fire_at` is rounded forward to the account's notification hour**
   (`notification_settings.digest_time` in the account's timezone; 09:00 and UTC when
   unset). Grouping alone would have bought the reminder engine almost nothing: `fire_at`

--- a/docs/agents/notifications.md
+++ b/docs/agents/notifications.md
@@ -46,6 +46,15 @@ Telegram, and mobile push), each with its own small `Notifier`/`Router` pair:
   three small, near-identical `PushNotifier`s (a few lines of message-rendering each) rather than
   three copies of anything structurally significant. Revisit if a fourth channel makes the
   per-engine cost look different.
+  **Grouping made the duplication bigger, and that is the seam to watch.** `reminder` and
+  `nudge` now each carry a near-identical `collect` + `deliverBatch` pair — claim, validate
+  per item, group, send once, finalize every member — differing only in their ledger's
+  method names and in nudge's kind in the group key. Two copies is not yet an abstraction:
+  a shared engine would have to be generic over the delivery row, the ledger's five
+  statements and the message type, which is more machinery than the ~80 duplicated lines
+  cost. What IS shared is what would silently diverge — `notify.ListLimit` and `Listed`,
+  `notify.SnapshotJob`/`JobsSnapshot`, and `telegramnotify.MaxMessageLen`/`UTF16Len`. A
+  third batching engine is the signal to extract the loop itself.
 - **Push needs no server-side credential and is therefore always registered.** Unlike Telegram
   (`TELEGRAM_BOT_TOKEN`) and email (`AWS_REGION`+`NOTIFY_EMAIL_FROM`), Expo's relay holds the
   APNs/FCM credential on its own side (set up once via `eas credentials` in `freehire-mobile`), so

--- a/docs/agents/notifications.md
+++ b/docs/agents/notifications.md
@@ -14,6 +14,26 @@ Telegram, and mobile push), each with its own small `Notifier`/`Router` pair:
 
 ## Always true
 
+- **All three engines deliver in GROUPS, and a group is the unit of everything.**
+  `notify` groups a subscription's matched jobs; `internal/engage/reminder` groups an
+  account's due reminders; `internal/engage/nudge` groups an account's due nudges **of one
+  kind**. Every `Notifier.Send` therefore takes a slice, not a message — there is no
+  per-item send path left for a channel to keep using, which is the point: eight saves in
+  a day were eight emails three days later. The kinds stay apart because "your
+  application went quiet" and "prepare for your interview" are different errands with
+  different call-to-actions; merging them would need a mail that says neither. One send
+  outcome decides the whole group: a failure records an attempt against every member and
+  the group returns whole on a later pass, because a partial result would need a second
+  delivery ledger to describe and nothing reads one. A group of ONE must stay
+  byte-identical to the pre-grouping message — that is what makes the change invisible to
+  everyone it doesn't help.
+- **A reminder's `fire_at` is rounded forward to the account's notification hour**
+  (`notification_settings.digest_time` in the account's timezone; 09:00 and UTC when
+  unset). Grouping alone would have bought the reminder engine almost nothing: `fire_at`
+  was save + 3 days exactly and `freehire-remind` ticks every 15 minutes, so two saves
+  hours apart landed in different passes. `internal/engage/nudge` needs no such rounding —
+  it has no `fire_at`, and MATCH+DELIVER share a pass, so everything an account has
+  pending is already together.
 - **A new channel is a new `Notifier` implementation — but there are THREE of them.** Each engine
   depends only on its own `Notifier` interface plus a `Router` (a `map[channel]Notifier`); the
   three interfaces share a signature and differ in payload, and `notify`/`reminder`/`nudge` each
@@ -88,12 +108,15 @@ Telegram, and mobile push), each with its own small `Notifier`/`Router` pair:
   No snooze interval, no notified-count column. `internal/engage/reminder`/`internal/engage/notify` don't need
   this — a reminder fires once from a pre-scheduled `fire_at`, a subscription match is a distinct
   `(subscription, job)` pair already.
-- **A digest is bounded twice, and the two bounds are not the same number.** `Digest.Jobs` is
-  everything the digest carries (ceiling: `Config.SnapshotCap`, 200) and is what the in-app
-  notification records — it is what `/my/notifications/:id/jobs` renders. `Digest.Listed()` is
-  the first `notify.ListLimit` (10) and is what a channel message itemizes; the "and N more"
-  tail is the difference. They were one knob until 2026-08-21, which meant lowering the email's
-  list length silently truncated the on-site page the email's own "view all" pointed at.
+- **Every grouped message is bounded twice, and the two bounds are not the same number.**
+  `Config.SnapshotCap` (200) is everything the group carries and is what the in-app
+  notification records — what `/my/notifications/:id/jobs` renders. `notify.ListLimit`
+  (10) is what a channel message itemizes; the "and N more" tail is the difference. All
+  three engines carry both, and `ListLimit` is a single exported constant shared by all of
+  them. They were one knob until 2026-08-21, which meant lowering the email's list length
+  silently truncated the on-site page the email's own "view all" pointed at. Beyond
+  `SnapshotCap` the excess is RELEASED back to the pending queue, never stamped delivered:
+  an item marked delivered while appearing in no message is gone for good.
 - **`Digest.Total` is `len(Jobs)`, and that is load-bearing.** A pass can claim more matches for
   one subscription than `SnapshotCap` allows; `deliverOne` calls `deferOverflow` to release the
   excess back to the pending queue BEFORE building the digest, so a later pass delivers it. Do
@@ -108,14 +131,22 @@ Telegram, and mobile push), each with its own small `Notifier`/`Router` pair:
   direction — the digest goes out with `NotificationID` zero and each channel's tail falls back
   to `/my/notifications`. `internal/engage/reminder` and `internal/engage/nudge` still record after delivery
   and discard the returned id.
+- **`user_notifications.jobs` is one shape owned by one package.** `notify.SnapshotJob`
+  (`{title, company, slug}`, migration 0091) is what all three engines write and what the
+  single `/my/notifications/:id/jobs` page reads. A group of MORE than one fills `jobs`
+  and leaves `public_slug` NULL; a group of one does the opposite. Three private copies of
+  the shape would each be right until one of them changed.
 - `DigestJob` deliberately carries **no internal job id** — only the public slug and URL.
 - **The Telegram link token is deliberately NOT a JWT.** Telegram's deep-link `start`
   parameter allows only 1–64 chars of `[A-Za-z0-9_-]`, which a dotted ~200-char JWT
   violates, so the token is a ~43-char base64url(payload‖truncated-HMAC) blob signed with
   `JWT_SECRET` (`internal/engage/telegramnotify`). The 4096-char message cap is measured the way
   Telegram measures it — UTF-16 code units, with the widest possible "+ N more" tail
-  reserved up front — because an oversized digest fails deterministically, every retry
-  re-fails, and the whole batch is dead-lettered.
+  reserved up front — because an oversized message fails deterministically, every retry
+  re-fails, and the whole batch is dead-lettered. `telegramnotify.MaxMessageLen` and
+  `UTF16Len` are exported together for that reason: the limit without the way to measure
+  against it invites `len()`, which counts bytes. Every engine that can build a multi-job
+  message needs both, which since grouping is all three.
 - Salary fields are projected from enrichment; zero min/max or an empty currency means
   unknown, and the renderer omits the line rather than printing a zero.
 

--- a/internal/api/handler/me_reminders_test.go
+++ b/internal/api/handler/me_reminders_test.go
@@ -32,6 +32,11 @@ func (r *stubReminderRepo) UpsertSettings(_ context.Context, _ int64, s reminder
 	r.settings = s
 	return s, nil
 }
+func (r *stubReminderRepo) GetScheduleContext(context.Context, int64) (reminder.ScheduleContext, error) {
+	// The unconfigured account: the service resolves it to its own defaults, and
+	// these tests assert that a save schedules at all, not when.
+	return reminder.ScheduleContext{}, nil
+}
 func (r *stubReminderRepo) UpsertReminder(context.Context, int64, int64, time.Time, []string) error {
 	r.upserts++
 	return nil

--- a/internal/engage/mailpreview/mailpreview.go
+++ b/internal/engage/mailpreview/mailpreview.go
@@ -91,6 +91,7 @@ var renderers = []func(string) (Sample, error){
 	savedJobReminderSample,
 	savedJobReminderBatchSample,
 	followUpNudgeSample,
+	followUpNudgeBatchSample,
 	jobClosedNudgeSample,
 	referralRequestSample,
 	reportRemovedSample,
@@ -242,12 +243,26 @@ func savedJobReminderBatchSample(baseURL string) (Sample, error) {
 func followUpNudgeSample(baseURL string) (Sample, error) {
 	return sample("nudge-follow-up", "Tracking / Nudge: follow up", func(c *capture) error {
 		return nudge.NewEmailNotifier(c, "alerts@freehire.me", baseURL).
-			Send(context.Background(), notify.ChannelEmail, "someone@example.com", nudge.Message{
+			Send(context.Background(), notify.ChannelEmail, "someone@example.com", nudge.KindFollowUp, []nudge.Message{{
 				Kind:       nudge.KindFollowUp,
 				JobTitle:   "Staff Engineer, Platform",
 				Company:    "Speechify",
 				Slug:       "staff-engineer-platform-speechify",
 				DaysSilent: 12,
+			}})
+	})
+}
+
+// followUpNudgeBatchSample is the shape a pass with several quiet applications
+// produces, and the one worth looking at: the single-nudge mail above is now the
+// special case.
+func followUpNudgeBatchSample(baseURL string) (Sample, error) {
+	return sample("nudge-follow-up-batch", "Tracking / Nudge: follow up (batch)", func(c *capture) error {
+		return nudge.NewEmailNotifier(c, "alerts@freehire.me", baseURL).
+			Send(context.Background(), notify.ChannelEmail, "someone@example.com", nudge.KindFollowUp, []nudge.Message{
+				{Kind: nudge.KindFollowUp, JobTitle: "Staff Engineer, Platform", Company: "Speechify", Slug: "staff-engineer-platform-speechify", DaysSilent: 12},
+				{Kind: nudge.KindFollowUp, JobTitle: "Backend Engineer", Company: "Monzo", Slug: "backend-engineer-monzo", DaysSilent: 24},
+				{Kind: nudge.KindFollowUp, JobTitle: "Infrastructure Engineer", Company: "Grafana Labs", Slug: "infrastructure-engineer-grafana-labs", DaysSilent: 31},
 			})
 	})
 }
@@ -255,12 +270,12 @@ func followUpNudgeSample(baseURL string) (Sample, error) {
 func jobClosedNudgeSample(baseURL string) (Sample, error) {
 	return sample("nudge-job-closed", "Tracking / Nudge: job closed", func(c *capture) error {
 		return nudge.NewEmailNotifier(c, "alerts@freehire.me", baseURL).
-			Send(context.Background(), notify.ChannelEmail, "someone@example.com", nudge.Message{
+			Send(context.Background(), notify.ChannelEmail, "someone@example.com", nudge.KindJobClosed, []nudge.Message{{
 				Kind:     nudge.KindJobClosed,
 				JobTitle: "Go Developer — Payments",
 				Company:  "Avenga",
 				Slug:     "go-developer-payments-avenga",
-			})
+			}})
 	})
 }
 

--- a/internal/engage/mailpreview/mailpreview.go
+++ b/internal/engage/mailpreview/mailpreview.go
@@ -89,6 +89,7 @@ var renderers = []func(string) (Sample, error){
 	passwordResetSample,
 	digestSample,
 	savedJobReminderSample,
+	savedJobReminderBatchSample,
 	followUpNudgeSample,
 	jobClosedNudgeSample,
 	referralRequestSample,
@@ -217,10 +218,23 @@ func digestSample(baseURL string) (Sample, error) {
 func savedJobReminderSample(baseURL string) (Sample, error) {
 	return sample("saved-job-reminder", "Tracking / Saved-job reminder", func(c *capture) error {
 		return reminder.NewEmailNotifier(c, "alerts@freehire.me", baseURL).
-			Send(context.Background(), notify.ChannelEmail, "someone@example.com", reminder.ReminderMessage{
+			Send(context.Background(), notify.ChannelEmail, "someone@example.com", []reminder.ReminderMessage{{
 				JobTitle: "Senior Backend Engineer (Go)",
 				Company:  "Fingerprint",
 				Slug:     "senior-backend-engineer-go-fingerprint",
+			}})
+	})
+}
+
+// savedJobReminderBatchSample is the shape a day of saves produces, and the one
+// worth looking at: the single-job mail above is now the special case.
+func savedJobReminderBatchSample(baseURL string) (Sample, error) {
+	return sample("saved-job-reminder-batch", "Tracking / Saved-job reminders (batch)", func(c *capture) error {
+		return reminder.NewEmailNotifier(c, "alerts@freehire.me", baseURL).
+			Send(context.Background(), notify.ChannelEmail, "someone@example.com", []reminder.ReminderMessage{
+				{JobTitle: "Senior Backend Engineer (Go)", Company: "Fingerprint", Slug: "senior-backend-engineer-go-fingerprint"},
+				{JobTitle: "Staff Platform Engineer", Company: "Vercel", Slug: "staff-platform-engineer-vercel"},
+				{JobTitle: "Site Reliability Engineer", Company: "Datadog", Slug: "site-reliability-engineer-datadog"},
 			})
 	})
 }

--- a/internal/engage/notify/digest_test.go
+++ b/internal/engage/notify/digest_test.go
@@ -88,7 +88,7 @@ func TestBuildDigest_TotalMatchesWhatItCarries(t *testing.T) {
 func TestDigestJobsSnapshot_CarriesEveryRecordedJob(t *testing.T) {
 	raw := digestJobsSnapshot(digestOf(67))
 
-	var jobs []digestJobSnapshot
+	var jobs []SnapshotJob
 	if err := json.Unmarshal(raw, &jobs); err != nil {
 		t.Fatalf("snapshot did not unmarshal: %v", err)
 	}

--- a/internal/engage/notify/notify.go
+++ b/internal/engage/notify/notify.go
@@ -57,6 +57,21 @@ func ValidChannel(c string) bool {
 // itemizes dozens of jobs is a page nobody reads to the bottom of.
 const ListLimit = 10
 
+// Listed splits a grouped message's items into the ones it itemizes — the first
+// ListLimit — and the count it only mentions as an "and N more" tail. It lives
+// beside the bound, and is generic, because all three engines apply the same rule
+// to three different message types and a private copy per engine is a copy that
+// drifts.
+//
+// The shown slice has no spare capacity, so a renderer that appends to it cannot
+// scribble over the items it left out.
+func Listed[T any](items []T) (shown []T, more int) {
+	if len(items) <= ListLimit {
+		return items, 0
+	}
+	return items[:ListLimit:ListLimit], len(items) - ListLimit
+}
+
 // Digest is one subscription's batch of new matches, rendered by a Notifier into
 // a channel-specific message. Jobs is the whole match set (bounded only by
 // Config.SnapshotCap) and is what the in-app notification records; Listed is the
@@ -74,13 +89,11 @@ type Digest struct {
 }
 
 // Listed returns the jobs a channel message should itemize: the first ListLimit,
-// or all of them when the digest is shorter. The result has no spare capacity, so
-// a renderer that appends to it cannot scribble over the rest of Jobs.
+// or all of them when the digest is shorter. The omitted count is not returned
+// here — a digest's tail counts against Total, which can exceed len(Jobs).
 func (d Digest) Listed() []DigestJob {
-	if len(d.Jobs) <= ListLimit {
-		return d.Jobs
-	}
-	return d.Jobs[:ListLimit:ListLimit]
+	shown, _ := Listed(d.Jobs)
+	return shown
 }
 
 // DigestJob is the display shape of one matched job (no internal id). The salary

--- a/internal/engage/notify/notify_test.go
+++ b/internal/engage/notify/notify_test.go
@@ -964,7 +964,7 @@ func TestDeliver_DigestRecordsEveryMatchedJob(t *testing.T) {
 		t.Errorf("Listed = %d, want %d", len(d.Listed()), ListLimit)
 	}
 
-	var recorded []digestJobSnapshot
+	var recorded []SnapshotJob
 	if err := json.Unmarshal(store.recordedNotifications[0].Jobs, &recorded); err != nil {
 		t.Fatalf("snapshot did not unmarshal: %v", err)
 	}

--- a/internal/engage/notify/push.go
+++ b/internal/engage/notify/push.go
@@ -80,30 +80,19 @@ func renderDigest(d Digest) (title, body, slug string) {
 // notification-center row — the same three fields DigestJob exposes on the
 // wire, no internal id, no salary (the notification-history "which jobs were
 // these" screen names them; it isn't a second digest render).
-type digestJobSnapshot struct {
-	Title   string `json:"title"`
-	Company string `json:"company"`
-	Slug    string `json:"slug"`
-}
-
 // digestJobsSnapshot marshals a digest's matched jobs for the notification
 // center's `jobs` column, but only when there's more than one — a single-job
-// digest already has its job identified via public_slug, and every other
-// notification kind never sets this column at all. nil (encodes to SQL NULL)
-// for a single-job (or, degenerately, zero-job) digest.
+// digest already has its job identified via public_slug. nil (encodes to SQL NULL)
+// for a single-job (or, degenerately, zero-job) digest. The shape itself is
+// SnapshotJob, shared with the reminder and nudge engines, which write the same
+// column for the same page.
 func digestJobsSnapshot(d Digest) json.RawMessage {
 	if d.Total <= 1 {
 		return nil
 	}
-	jobs := make([]digestJobSnapshot, len(d.Jobs))
+	jobs := make([]SnapshotJob, len(d.Jobs))
 	for i, j := range d.Jobs {
-		jobs[i] = digestJobSnapshot{Title: j.Title, Company: j.Company, Slug: j.Slug}
+		jobs[i] = SnapshotJob{Title: j.Title, Company: j.Company, Slug: j.Slug}
 	}
-	raw, err := json.Marshal(jobs)
-	if err != nil {
-		// Every field is a plain string; Marshal only fails on unsupported types
-		// (channels, funcs, cyclic refs), none of which digestJobSnapshot has.
-		panic(fmt.Sprintf("notify: marshal digest jobs snapshot: %v", err))
-	}
-	return raw
+	return JobsSnapshot(jobs)
 }

--- a/internal/engage/notify/snapshot.go
+++ b/internal/engage/notify/snapshot.go
@@ -1,0 +1,31 @@
+package notify
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// SnapshotJob is one entry of user_notifications.jobs: the {title, company, slug}
+// shape migration 0091 defined and /my/notifications/[id]/jobs renders.
+//
+// It lives here, in the package that already owns the channel vocabulary, because
+// all three notification engines write that column and ONE page reads it. Three
+// private copies of the shape would each be right until one of them changed.
+type SnapshotJob struct {
+	Title   string `json:"title"`
+	Company string `json:"company"`
+	Slug    string `json:"slug"`
+}
+
+// JobsSnapshot marshals the job list a multi-job notification records for its own
+// page. It applies no bound: the caller's batch is capped before it is ever sent,
+// so what was delivered and what the record holds cannot disagree.
+func JobsSnapshot(jobs []SnapshotJob) json.RawMessage {
+	raw, err := json.Marshal(jobs)
+	if err != nil {
+		// Every field is a plain string; Marshal only fails on unsupported types
+		// (channels, funcs, cyclic refs), none of which SnapshotJob has.
+		panic(fmt.Sprintf("notify: marshal jobs snapshot: %v", err))
+	}
+	return raw
+}

--- a/internal/engage/nudge/nudge.go
+++ b/internal/engage/nudge/nudge.go
@@ -58,10 +58,15 @@ type Message struct {
 	DaysSilent int
 }
 
-// Notifier delivers a nudge over a channel to a destination. The engine depends
-// only on this, so a new channel is a new implementation, not a change here.
+// Notifier delivers one account's due nudges OF ONE KIND over a channel to a
+// destination, as a single message. The engine depends only on this, so a new
+// channel is a new implementation, not a change here.
+//
+// The kind travels beside the slice rather than being read off the first message,
+// because it is a property of the group: every member shares it, and the renderer
+// switches on it before it looks at any job.
 type Notifier interface {
-	Send(ctx context.Context, channel, dest string, m Message) error
+	Send(ctx context.Context, channel, dest, kind string, ms []Message) error
 }
 
 // ErrChannelNotConfigured is returned by Router.Send for a channel with no
@@ -84,12 +89,12 @@ type Router map[string]Notifier
 var _ Notifier = (Router)(nil)
 
 // Send routes to the registered notifier, or ErrChannelNotConfigured when none is.
-func (r Router) Send(ctx context.Context, channel, dest string, m Message) error {
+func (r Router) Send(ctx context.Context, channel, dest, kind string, ms []Message) error {
 	n, ok := r[channel]
 	if !ok {
 		return fmt.Errorf("%w: %q", ErrChannelNotConfigured, channel)
 	}
-	return n.Send(ctx, channel, dest, m)
+	return n.Send(ctx, channel, dest, kind, ms)
 }
 
 // Compile-time proof that the generated *db.Queries satisfies the engine's Store.
@@ -142,6 +147,13 @@ type Config struct {
 	ClaimBatch int32
 	// MaxAttempts dead-letters a nudge after this many failed deliveries.
 	MaxAttempts int32
+	// SnapshotCap bounds how many nudges one message carries — which is how many
+	// the in-app record holds. It is NOT the message listing bound (that is
+	// notify.ListLimit): a message is short because a long list reads badly, while
+	// the record is long because it is the page the message links to. The excess is
+	// released back to the pending queue rather than stamped delivered into a
+	// message it never appeared in.
+	SnapshotCap int
 }
 
 // DefaultConfig is the production tuning, mirroring internal/engage/reminder and
@@ -154,17 +166,39 @@ func DefaultConfig() Config {
 		LeaseSeconds:            600,
 		ClaimBatch:              500,
 		MaxAttempts:             5,
+		SnapshotCap:             200,
 	}
 }
 
-// Stats is the per-pass summary logged by the worker.
+// Stats is the per-pass summary logged by the worker. Every counter except
+// Messages counts NUDGES, not deliveries, so the numbers stay comparable across
+// the change that made one message carry many.
 type Stats struct {
 	Matched   int // newly recorded nudge candidates
 	Delivered int // nudges sent
+	Messages  int // channel messages sent (one per account per kind per pass)
 	Cancelled int // nudges cancelled at fire (condition no longer holds)
 	SoftSkips int // nudges with no deliverable channel this pass
-	Deferred  int // nudges held back by the account's quiet-hours window
+	Deferred  int // nudges held back by quiet hours or by a full message
 	Failed    int // nudges whose delivery errored
+}
+
+// batch is one account's due nudges OF ONE KIND in a pass. Channels, destinations
+// and quiet hours are properties of the ACCOUNT and the kind is shared by
+// construction, so the first member's row answers for the whole batch and only the
+// messages accumulate.
+type batch struct {
+	info db.GetNudgeForDeliveryRow
+	ids  []int64
+	msgs []Message
+}
+
+// batchKey is what makes two nudges one message: the same account AND the same
+// kind. Merging the kinds would put "your application went quiet" and "prepare for
+// your interview" in one mail, which are different errands with different actions.
+type batchKey struct {
+	userID int64
+	kind   string
 }
 
 // Runner executes MATCH+DELIVER passes.
@@ -191,8 +225,8 @@ func (r *Runner) Run(ctx context.Context) (Stats, error) {
 	if err := r.deliver(ctx, &stats); err != nil {
 		return stats, fmt.Errorf("deliver: %w", err)
 	}
-	log.Printf("nudge: matched=%d delivered=%d cancelled=%d soft_skips=%d deferred=%d failed=%d",
-		stats.Matched, stats.Delivered, stats.Cancelled, stats.SoftSkips, stats.Deferred, stats.Failed)
+	log.Printf("nudge: matched=%d delivered=%d messages=%d cancelled=%d soft_skips=%d deferred=%d failed=%d",
+		stats.Matched, stats.Delivered, stats.Messages, stats.Cancelled, stats.SoftSkips, stats.Deferred, stats.Failed)
 	return stats, nil
 }
 
@@ -295,68 +329,124 @@ func (r *Runner) deliver(ctx context.Context, stats *Stats) error {
 	if err != nil {
 		return fmt.Errorf("claim: %w", err)
 	}
-	for _, id := range due {
-		r.fire(ctx, id, stats)
+	for _, b := range r.collect(ctx, due, stats) {
+		r.deliverBatch(ctx, b, stats)
 	}
 	return nil
 }
 
-// fire re-checks one claimed nudge's triggering condition and delivers or cancels
-// it. The re-check is what lets MATCH re-run freely without ever sending a nudge
-// whose reason has since gone away.
-func (r *Runner) fire(ctx context.Context, id int64, stats *Stats) {
+// collect turns the claimed ids into one batch per (account, kind), dropping the
+// nudges that must not be sent. Each is re-checked on its own — the trigger is per
+// nudge — and only the survivors group, so a lapsed nudge is cancelled without
+// taking its neighbours' message with it.
+//
+// Batches are returned in the order their first member was claimed, which
+// ClaimDueNudges orders by creation time, so the nudge that has waited longest is
+// served first and a pass is reproducible.
+func (r *Runner) collect(ctx context.Context, due []int64, stats *Stats) []*batch {
+	byKey := make(map[batchKey]*batch, len(due))
+	var order []*batch
+	for _, id := range due {
+		info, ok := r.validate(ctx, id, stats)
+		if !ok {
+			continue
+		}
+		key := batchKey{userID: info.UserID, kind: info.Kind}
+		b := byKey[key]
+		if b == nil {
+			b = &batch{info: info}
+			byKey[key] = b
+			order = append(order, b)
+		}
+		if len(b.ids) >= r.cfg.SnapshotCap {
+			// The message is full. Release rather than stamp: a nudge marked
+			// delivered while appearing in no message is gone for good.
+			r.release(ctx, id)
+			stats.Deferred++
+			continue
+		}
+		b.ids = append(b.ids, id)
+		b.msgs = append(b.msgs, r.message(info))
+	}
+	return order
+}
+
+// validate re-checks one claimed nudge's triggering condition immediately before it
+// joins a batch, and holds it back inside the account's quiet hours. The re-check is
+// what lets MATCH re-run freely without ever sending a nudge whose reason has since
+// gone away. It reports whether the nudge is deliverable this pass.
+func (r *Runner) validate(ctx context.Context, id int64, stats *Stats) (db.GetNudgeForDeliveryRow, bool) {
 	info, err := r.store.GetNudgeForDelivery(ctx, id)
 	if err != nil {
 		log.Printf("nudge: load %d for delivery: %v", id, err)
 		r.release(ctx, id)
-		return
+		return info, false
 	}
 	if !r.actionable(info) {
 		if _, err := r.store.CancelNudgeAtFire(ctx, id); err != nil {
 			log.Printf("nudge: cancel-at-fire %d: %v", id, err)
 			r.release(ctx, id)
-			return
+			return info, false
 		}
 		stats.Cancelled++
-		return
+		return info, false
 	}
 	if deliverywindow.InQuietHours(r.now(), info.Timezone.String, pgconv.DurationPtr(info.QuietHoursStart), pgconv.DurationPtr(info.QuietHoursEnd)) {
 		// A transient time-of-day condition, not a lapsed trigger: release (not
 		// cancel) so the nudge fires once quiet hours end.
 		r.release(ctx, id)
 		stats.Deferred++
-		return
+		return info, false
 	}
+	return info, true
+}
 
+// message projects one delivery row into the display shape a channel renders.
+func (r *Runner) message(info db.GetNudgeForDeliveryRow) Message {
 	msg := Message{Kind: info.Kind, JobTitle: info.Title, Company: info.Company, Slug: info.PublicSlug, URL: info.URL}
 	if info.Kind == KindFollowUp && info.LastActivityAt.Valid {
 		msg.DaysSilent = silence.Days(r.now(), info.LastActivityAt.Time)
 	}
-	delivered, failedErr := r.deliverChannels(ctx, info, msg)
+	return msg
+}
+
+// deliverBatch sends one (account, kind) batch as a single message per channel and
+// finalizes every ledger row in it. The batch is the unit: one send outcome decides
+// all of its nudges, because a partial result would need a second delivery ledger
+// to describe and nothing reads one.
+func (r *Runner) deliverBatch(ctx context.Context, b *batch, stats *Stats) {
+	delivered, failedErr := r.deliverChannels(ctx, b.info, b.msgs)
 
 	switch {
 	case delivered:
 		if failedErr != nil {
-			log.Printf("nudge: %d delivered with a co-channel error: %v", id, failedErr)
+			log.Printf("nudge: user %d %s delivered with a co-channel error: %v", b.info.UserID, b.info.Kind, failedErr)
 		}
-		if _, err := r.store.MarkNudgeDelivered(ctx, id); err != nil {
-			log.Printf("nudge: mark delivered %d: %v", id, err)
+		for _, id := range b.ids {
+			if _, err := r.store.MarkNudgeDelivered(ctx, id); err != nil {
+				log.Printf("nudge: mark delivered %d: %v", id, err)
+			}
 		}
-		r.recordNotification(ctx, id, info, msg)
-		stats.Delivered++
+		r.recordNotification(ctx, b)
+		stats.Delivered += len(b.ids)
+		stats.Messages++
 	case failedErr != nil:
-		log.Printf("nudge: deliver %d: %v", id, failedErr)
-		if err := r.store.RecordNudgeDeliveryFailure(ctx, db.RecordNudgeDeliveryFailureParams{
-			ID:          id,
-			LastError:   failedErr.Error(),
-			MaxAttempts: r.cfg.MaxAttempts,
-		}); err != nil {
-			log.Printf("nudge: record failure %d: %v", id, err)
+		log.Printf("nudge: deliver %s batch for user %d: %v", b.info.Kind, b.info.UserID, failedErr)
+		for _, id := range b.ids {
+			if err := r.store.RecordNudgeDeliveryFailure(ctx, db.RecordNudgeDeliveryFailureParams{
+				ID:          id,
+				LastError:   failedErr.Error(),
+				MaxAttempts: r.cfg.MaxAttempts,
+			}); err != nil {
+				log.Printf("nudge: record failure %d: %v", id, err)
+			}
 		}
-		stats.Failed++
+		stats.Failed += len(b.ids)
 	default:
-		r.release(ctx, id)
-		stats.SoftSkips++
+		for _, id := range b.ids {
+			r.release(ctx, id)
+		}
+		stats.SoftSkips += len(b.ids)
 	}
 }
 
@@ -402,13 +492,13 @@ func (r *Runner) actionable(info db.GetNudgeForDeliveryRow) bool {
 // channel with no destination or no notifier is a soft-skip, not an error). One
 // successful channel makes the nudge delivered — a co-channel outage just misses
 // that channel for this one-shot nudge.
-func (r *Runner) deliverChannels(ctx context.Context, info db.GetNudgeForDeliveryRow, msg Message) (delivered bool, failedErr error) {
+func (r *Runner) deliverChannels(ctx context.Context, info db.GetNudgeForDeliveryRow, msgs []Message) (delivered bool, failedErr error) {
 	for _, ch := range info.Channels {
 		dest, ok := recipient(ch, info)
 		if !ok {
 			continue
 		}
-		err := r.notifier.Send(ctx, ch, dest, msg)
+		err := r.notifier.Send(ctx, ch, dest, info.Kind, msgs)
 		if errors.Is(err, ErrChannelNotConfigured) {
 			continue
 		}
@@ -467,24 +557,32 @@ func recipient(channel string, info db.GetNudgeForDeliveryRow) (string, bool) {
 	return "", false
 }
 
-// recordNotification writes the in-app notification-center row for a delivered
-// nudge, reusing renderNudge's title/body — the same copy the push channel
-// already shows — so the in-app record never drifts from it. A nudge always
-// concerns exactly one job, so PublicSlug is always populated. A failure here
-// must not fail the delivery: the nudge was already sent and marked delivered;
-// losing the in-app record is a degraded read-side feature, not a reason to
-// treat the delivery as failed — the same posture this func's caller already
+// recordNotification writes the one in-app notification-center row for a delivered
+// batch, reusing renderNudgeBatch's title/body — the same copy the push channel
+// shows — so the in-app record never drifts from it. A batch of one keeps the shape
+// nudges have always recorded, a public slug the notification links straight to; a
+// batch of several has no single job to point at, so it carries the job list and the
+// notification center renders its own page.
+//
+// A failure here must not fail the delivery: the batch was already sent and marked
+// delivered; losing the in-app record is a degraded read-side feature, not a reason
+// to treat the delivery as failed — the same posture this func's caller already
 // takes toward MarkNudgeDelivered's own failure, just above.
-func (r *Runner) recordNotification(ctx context.Context, id int64, info db.GetNudgeForDeliveryRow, msg Message) {
-	title, body := renderNudge(msg)
-	if _, err := r.store.RecordNotification(ctx, db.RecordNotificationParams{
-		UserID:     info.UserID,
-		Kind:       "nudge_" + msg.Kind,
-		Title:      title,
-		Body:       body,
-		PublicSlug: pgtype.Text{String: msg.Slug, Valid: true},
-	}); err != nil {
-		log.Printf("nudge: record notification %d: %v", id, err)
+func (r *Runner) recordNotification(ctx context.Context, b *batch) {
+	title, body := renderNudgeBatch(b.info.Kind, b.msgs)
+	arg := db.RecordNotificationParams{
+		UserID: b.info.UserID,
+		Kind:   "nudge_" + b.info.Kind,
+		Title:  title,
+		Body:   body,
+	}
+	if len(b.msgs) == 1 {
+		arg.PublicSlug = pgtype.Text{String: b.msgs[0].Slug, Valid: true}
+	} else {
+		arg.Jobs = jobsSnapshot(b.msgs)
+	}
+	if _, err := r.store.RecordNotification(ctx, arg); err != nil {
+		log.Printf("nudge: record notification for user %d (%s): %v", b.info.UserID, b.info.Kind, err)
 	}
 }
 

--- a/internal/engage/nudge/nudge.go
+++ b/internal/engage/nudge/nudge.go
@@ -22,6 +22,7 @@ package nudge
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -584,6 +585,16 @@ func (r *Runner) recordNotification(ctx context.Context, b *batch) {
 	if _, err := r.store.RecordNotification(ctx, arg); err != nil {
 		log.Printf("nudge: record notification for user %d (%s): %v", b.info.UserID, b.info.Kind, err)
 	}
+}
+
+// jobsSnapshot is the job list a multi-job batch records for its notification's own
+// page, in the shape notify owns because one page renders every engine's rows.
+func jobsSnapshot(ms []Message) json.RawMessage {
+	jobs := make([]notify.SnapshotJob, len(ms))
+	for i, m := range ms {
+		jobs[i] = notify.SnapshotJob{Title: m.JobTitle, Company: m.Company, Slug: m.Slug}
+	}
+	return notify.JobsSnapshot(jobs)
 }
 
 // release drops the lease on a nudge so it is retried promptly on a later pass.

--- a/internal/engage/nudge/nudge.go
+++ b/internal/engage/nudge/nudge.go
@@ -177,7 +177,7 @@ func DefaultConfig() Config {
 type Stats struct {
 	Matched   int // newly recorded nudge candidates
 	Delivered int // nudges sent
-	Messages  int // channel messages sent (one per account per kind per pass)
+	Messages  int // messages that landed (one per batch PER CHANNEL, not per batch)
 	Cancelled int // nudges cancelled at fire (condition no longer holds)
 	SoftSkips int // nudges with no deliverable channel this pass
 	Deferred  int // nudges held back by quiet hours or by a full message
@@ -424,10 +424,10 @@ func (r *Runner) message(info db.GetNudgeForDeliveryRow) Message {
 // all of its nudges, because a partial result would need a second delivery ledger
 // to describe and nothing reads one.
 func (r *Runner) deliverBatch(ctx context.Context, b *batch, stats *Stats) {
-	delivered, failedErr := r.deliverChannels(ctx, b.info, b.msgs)
+	sent, failedErr := r.deliverChannels(ctx, b.info, b.msgs)
 
 	switch {
-	case delivered:
+	case sent > 0:
 		if failedErr != nil {
 			log.Printf("nudge: user %d %s delivered with a co-channel error: %v", b.info.UserID, b.info.Kind, failedErr)
 		}
@@ -438,7 +438,7 @@ func (r *Runner) deliverBatch(ctx context.Context, b *batch, stats *Stats) {
 		}
 		r.recordNotification(ctx, b)
 		stats.Delivered += len(b.ids)
-		stats.Messages++
+		stats.Messages += sent
 	case failedErr != nil:
 		log.Printf("nudge: deliver %s batch for user %d: %v", b.info.Kind, b.info.UserID, failedErr)
 		for _, id := range b.ids {
@@ -496,12 +496,14 @@ func (r *Runner) actionable(info db.GetNudgeForDeliveryRow) bool {
 	}
 }
 
-// deliverChannels attempts each configured channel that has a usable destination.
-// It reports whether at least one send succeeded and the last hard error (a
-// channel with no destination or no notifier is a soft-skip, not an error). One
-// successful channel makes the nudge delivered — a co-channel outage just misses
-// that channel for this one-shot nudge.
-func (r *Runner) deliverChannels(ctx context.Context, info db.GetNudgeForDeliveryRow, msgs []Message) (delivered bool, failedErr error) {
+// deliverChannels attempts each configured channel that has a usable destination,
+// sending the whole batch as one message per channel. It reports HOW MANY messages
+// landed — a batch on email and Telegram is two, and the pass summary would
+// undercount if this were a bool — and the last hard error (a channel with no
+// destination or no notifier is a soft-skip, not an error). One successful channel
+// makes the batch delivered — a co-channel outage just misses that channel for these
+// one-shot nudges.
+func (r *Runner) deliverChannels(ctx context.Context, info db.GetNudgeForDeliveryRow, msgs []Message) (sent int, failedErr error) {
 	for _, ch := range info.Channels {
 		dest, ok := recipient(ch, info)
 		if !ok {
@@ -522,9 +524,9 @@ func (r *Runner) deliverChannels(ctx context.Context, info db.GetNudgeForDeliver
 			failedErr = err
 			continue
 		}
-		delivered = true
+		sent++
 	}
-	return delivered, failedErr
+	return sent, failedErr
 }
 
 // unlinkTelegram forgets a user's Telegram chat after a send reported it

--- a/internal/engage/nudge/nudge.go
+++ b/internal/engage/nudge/nudge.go
@@ -211,7 +211,15 @@ type Runner struct {
 }
 
 // New builds a Runner.
+//
+// A non-positive SnapshotCap is corrected to the default rather than honoured: it
+// would make every batch full at zero members, so every claimed nudge is released
+// unsent while burning no attempt — a pass that logs no failure and delivers nothing,
+// forever. The other Config fields fail visibly when unset; this one does not.
 func New(store Store, notifier Notifier, cfg Config) *Runner {
+	if cfg.SnapshotCap <= 0 {
+		cfg.SnapshotCap = DefaultConfig().SnapshotCap
+	}
 	return &Runner{store: store, notifier: notifier, cfg: cfg, now: time.Now}
 }
 

--- a/internal/engage/nudge/nudge_test.go
+++ b/internal/engage/nudge/nudge_test.go
@@ -418,6 +418,58 @@ func TestDeliver_EachGroupRecordsItsOwnKindedNotification(t *testing.T) {
 	}
 }
 
+// Beyond SnapshotCap the excess is RELEASED, never stamped: a nudge marked delivered
+// while appearing in no message is gone for good.
+func TestDeliver_BatchOverflowIsReleasedNotDelivered(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.SnapshotCap = 2
+	store := &fakeStore{
+		due: []int64{1, 2, 3},
+		rows: map[int64]db.GetNudgeForDeliveryRow{
+			1: groupRow(1, 42, KindFollowUp),
+			2: groupRow(2, 42, KindFollowUp),
+			3: groupRow(3, 42, KindFollowUp),
+		},
+	}
+	notifier := &fakeNotifier{}
+	r := New(store, notifier, cfg)
+	r.now = func() time.Time { return fixedNow }
+
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(notifier.groups) != 1 || len(notifier.groups[0].msgs) != 2 {
+		t.Fatalf("groups = %v, want one message carrying the cap", notifier.groups)
+	}
+	if len(store.delivered) != 2 {
+		t.Errorf("delivered = %v, want only what the message carried", store.delivered)
+	}
+	if len(store.released) != 1 || len(store.failed) != 0 {
+		t.Errorf("released = %v failed = %v, want the overflow released and no attempt burnt", store.released, store.failed)
+	}
+	if stats.Deferred != 1 {
+		t.Errorf("stats.Deferred = %d, want the overflow nudge counted", stats.Deferred)
+	}
+}
+
+// A hand-built Config with no SnapshotCap would make every batch full at zero
+// members: nothing delivered, nothing failed, forever.
+func TestNew_ZeroSnapshotCapDoesNotStallDelivery(t *testing.T) {
+	store := &fakeStore{
+		due:  []int64{1},
+		rows: map[int64]db.GetNudgeForDeliveryRow{1: groupRow(1, 42, KindFollowUp)},
+	}
+	r := New(store, &fakeNotifier{}, Config{FollowUpWindowDays: 30, LeaseSeconds: 600, ClaimBatch: 500, MaxAttempts: 5})
+	r.now = func() time.Time { return fixedNow }
+	if _, err := r.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.delivered) != 1 {
+		t.Errorf("delivered = %v, want the nudge delivered despite an unset SnapshotCap", store.delivered)
+	}
+}
+
 func TestDeliver_FollowUp_DeliversWhenStillSilent(t *testing.T) {
 	chat := int64(555)
 	store := &fakeStore{due: []int64{1}, row: deliveryRow(KindFollowUp, "applied", 25, true, true, []string{"telegram"}, &chat, "")}

--- a/internal/engage/nudge/nudge_test.go
+++ b/internal/engage/nudge/nudge_test.go
@@ -3,6 +3,7 @@ package nudge
 import (
 	"context"
 	"errors"
+	"strconv"
 	"testing"
 	"time"
 
@@ -27,6 +28,9 @@ type fakeStore struct {
 
 	due []int64
 	row db.GetNudgeForDeliveryRow
+	// rows serves a distinct delivery context per claimed id, for the tests that
+	// put several nudges in one pass. When nil every id gets `row`.
+	rows map[int64]db.GetNudgeForDeliveryRow
 
 	delivered []int64
 	cancelled []int64
@@ -62,7 +66,10 @@ func (s *fakeStore) TrackJob(_ context.Context, arg db.TrackJobParams) (db.Track
 func (s *fakeStore) ClaimDueNudges(context.Context, db.ClaimDueNudgesParams) ([]int64, error) {
 	return s.due, nil
 }
-func (s *fakeStore) GetNudgeForDelivery(context.Context, int64) (db.GetNudgeForDeliveryRow, error) {
+func (s *fakeStore) GetNudgeForDelivery(_ context.Context, id int64) (db.GetNudgeForDeliveryRow, error) {
+	if s.rows != nil {
+		return s.rows[id], nil
+	}
 	return s.row, nil
 }
 func (s *fakeStore) MarkNudgeDelivered(_ context.Context, id int64) (int64, error) {
@@ -95,13 +102,21 @@ func (s *fakeStore) RecordNotification(_ context.Context, arg db.RecordNotificat
 
 type fakeNotifier struct {
 	sent []string // "channel:dest"
-	err  error
+	// groups records the kind and message list of each send, so a test can assert
+	// what a delivery carried and not only that it happened.
+	groups []sentGroup
+	err    error
 	// errByChannel fails only the named channels, so a test can model one channel
 	// dying while another lands — which a blanket err cannot express.
 	errByChannel map[string]error
 }
 
-func (n *fakeNotifier) Send(_ context.Context, channel, dest string, _ Message) error {
+type sentGroup struct {
+	kind string
+	msgs []Message
+}
+
+func (n *fakeNotifier) Send(_ context.Context, channel, dest, kind string, ms []Message) error {
 	if err, ok := n.errByChannel[channel]; ok {
 		return err
 	}
@@ -109,6 +124,7 @@ func (n *fakeNotifier) Send(_ context.Context, channel, dest string, _ Message) 
 		return n.err
 	}
 	n.sent = append(n.sent, channel+":"+dest)
+	n.groups = append(n.groups, sentGroup{kind: kind, msgs: ms})
 	return nil
 }
 
@@ -283,6 +299,123 @@ func deliveryRow(kind string, stage string, daysSilent int, notificationsEnabled
 		row.TelegramChatID = pgtype.Int8{Int64: *chatID, Valid: true}
 	}
 	return row
+}
+
+// groupRow is deliveryRow's multi-nudge variant: a deliverable row of `kind` for
+// `userID`, naming its own job, so a test can put several nudges in one pass.
+func groupRow(id, userID int64, kind string) db.GetNudgeForDeliveryRow {
+	row := deliveryRow(kind, stageFor(kind), 25, true, true, []string{"email"}, nil, "a@b.c")
+	row.ID, row.UserID, row.JobID = id, userID, id
+	row.Title = "Job " + strconv.FormatInt(id, 10)
+	row.PublicSlug = "job-" + strconv.FormatInt(id, 10)
+	return row
+}
+
+// stageFor is the stage each kind's actionable() check needs to pass.
+func stageFor(kind string) string {
+	if kind == KindInterviewPrep {
+		return "interview"
+	}
+	return "applied"
+}
+
+// Five silent applications used to be five emails in one 30-minute pass.
+func TestDeliver_GroupsOneAccountsSameKindNudgesIntoOneSend(t *testing.T) {
+	store := &fakeStore{
+		due: []int64{1, 2, 3, 4},
+		rows: map[int64]db.GetNudgeForDeliveryRow{
+			1: groupRow(1, 42, KindFollowUp),
+			2: groupRow(2, 42, KindFollowUp),
+			3: groupRow(3, 42, KindFollowUp),
+			4: groupRow(4, 42, KindFollowUp),
+		},
+	}
+	notifier := &fakeNotifier{}
+	r := newRunner(store, notifier)
+
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(notifier.groups) != 1 {
+		t.Fatalf("groups = %v, want one message for one account and one kind", notifier.groups)
+	}
+	if got := notifier.groups[0]; got.kind != KindFollowUp || len(got.msgs) != 4 {
+		t.Errorf("group = (%q, %d jobs), want (follow_up, 4)", got.kind, len(got.msgs))
+	}
+	if len(store.delivered) != 4 || stats.Delivered != 4 {
+		t.Errorf("delivered = %v (stats %d), want all four stamped", store.delivered, stats.Delivered)
+	}
+}
+
+// The kinds are different conversations and must not share a message.
+func TestDeliver_DifferentKindsStayInSeparateSends(t *testing.T) {
+	store := &fakeStore{
+		due: []int64{1, 2, 3},
+		rows: map[int64]db.GetNudgeForDeliveryRow{
+			1: groupRow(1, 42, KindFollowUp),
+			2: groupRow(2, 42, KindFollowUp),
+			3: groupRow(3, 42, KindInterviewPrep),
+		},
+	}
+	notifier := &fakeNotifier{}
+	r := newRunner(store, notifier)
+
+	if _, err := r.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(notifier.groups) != 2 {
+		t.Fatalf("groups = %v, want one message per kind", notifier.groups)
+	}
+	byKind := map[string]int{}
+	for _, g := range notifier.groups {
+		byKind[g.kind] = len(g.msgs)
+	}
+	if byKind[KindFollowUp] != 2 || byKind[KindInterviewPrep] != 1 {
+		t.Errorf("group sizes = %v, want follow_up=2 interview_prep=1", byKind)
+	}
+}
+
+// Each group records its own notification, keeping the per-kind vocabulary the
+// notification center already filters on.
+func TestDeliver_EachGroupRecordsItsOwnKindedNotification(t *testing.T) {
+	store := &fakeStore{
+		due: []int64{1, 2, 3},
+		rows: map[int64]db.GetNudgeForDeliveryRow{
+			1: groupRow(1, 42, KindFollowUp),
+			2: groupRow(2, 42, KindFollowUp),
+			3: groupRow(3, 42, KindInterviewPrep),
+		},
+	}
+	r := newRunner(store, &fakeNotifier{})
+
+	if _, err := r.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.recordedNotifications) != 2 {
+		t.Fatalf("recorded = %v, want one notification per group", store.recordedNotifications)
+	}
+	byKind := map[string]db.RecordNotificationParams{}
+	for _, rec := range store.recordedNotifications {
+		byKind[rec.Kind] = rec
+	}
+	multi, ok := byKind["nudge_"+KindFollowUp]
+	if !ok {
+		t.Fatalf("kinds recorded = %v, want a nudge_follow_up row", byKind)
+	}
+	if multi.PublicSlug.Valid {
+		t.Errorf("PublicSlug = %+v, want unset for a two-job group", multi.PublicSlug)
+	}
+	if len(multi.Jobs) == 0 {
+		t.Errorf("Jobs is empty, want the group's job list")
+	}
+	single, ok := byKind["nudge_"+KindInterviewPrep]
+	if !ok {
+		t.Fatalf("kinds recorded = %v, want a nudge_interview_prep row", byKind)
+	}
+	if !single.PublicSlug.Valid || single.PublicSlug.String != "job-3" {
+		t.Errorf("PublicSlug = %+v, want the single job's slug", single.PublicSlug)
+	}
 }
 
 func TestDeliver_FollowUp_DeliversWhenStillSilent(t *testing.T) {

--- a/internal/engage/nudge/push.go
+++ b/internal/engage/nudge/push.go
@@ -2,24 +2,12 @@ package nudge
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strconv"
 
-	"github.com/strelov1/freehire/internal/engage/notify"
 	"github.com/strelov1/freehire/internal/engage/pushnotify"
 	"github.com/strelov1/freehire/internal/platform/db"
 )
-
-// jobsSnapshot is the job list a multi-job batch records for its notification's own
-// page, in the shape notify owns because one page renders every engine's rows.
-func jobsSnapshot(ms []Message) json.RawMessage {
-	jobs := make([]notify.SnapshotJob, len(ms))
-	for i, m := range ms {
-		jobs[i] = notify.SnapshotJob{Title: m.JobTitle, Company: m.Company, Slug: m.Slug}
-	}
-	return notify.JobsSnapshot(jobs)
-}
 
 // Compile-time proof PushNotifier satisfies the engine's Notifier seam.
 var _ Notifier = (*PushNotifier)(nil)

--- a/internal/engage/nudge/push.go
+++ b/internal/engage/nudge/push.go
@@ -2,12 +2,24 @@ package nudge
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 
+	"github.com/strelov1/freehire/internal/engage/notify"
 	"github.com/strelov1/freehire/internal/engage/pushnotify"
 	"github.com/strelov1/freehire/internal/platform/db"
 )
+
+// jobsSnapshot is the job list a multi-job batch records for its notification's own
+// page, in the shape notify owns because one page renders every engine's rows.
+func jobsSnapshot(ms []Message) json.RawMessage {
+	jobs := make([]notify.SnapshotJob, len(ms))
+	for i, m := range ms {
+		jobs[i] = notify.SnapshotJob{Title: m.JobTitle, Company: m.Company, Slug: m.Slug}
+	}
+	return notify.JobsSnapshot(jobs)
+}
 
 // Compile-time proof PushNotifier satisfies the engine's Notifier seam.
 var _ Notifier = (*PushNotifier)(nil)
@@ -32,10 +44,13 @@ func NewPushNotifier(tokens PushTokenLister, transport pushnotify.Notifier) *Pus
 	return &PushNotifier{tokens: tokens, transport: transport}
 }
 
-// Send resolves dest as a user id, lists that user's registered devices, and
-// fans the rendered message out to all of them. The channel argument is
+// Send resolves dest as a user id, lists that user's registered devices, and fans
+// ONE notification for the whole batch out to all of them. The channel argument is
 // ignored — this notifier only serves the push channel.
-func (n *PushNotifier) Send(ctx context.Context, _ string, dest string, m Message) error {
+func (n *PushNotifier) Send(ctx context.Context, _ string, dest, kind string, ms []Message) error {
+	if len(ms) == 0 {
+		return nil
+	}
 	userID, err := strconv.ParseInt(dest, 10, 64)
 	if err != nil {
 		return fmt.Errorf("nudge: invalid push user id %q: %w", dest, err)
@@ -49,15 +64,38 @@ func (n *PushNotifier) Send(ctx context.Context, _ string, dest string, m Messag
 		tokens[i] = d.Token
 	}
 
-	title, body := renderNudge(m)
-	data := map[string]string{"slug": m.Slug}
+	title, body := renderNudgeBatch(kind, ms)
+	// The deep link needs one destination, so it is carried only when the batch
+	// names one job.
+	var data map[string]string
+	if len(ms) == 1 {
+		data = map[string]string{"slug": ms[0].Slug}
+	}
 	return pushnotify.SendToDevices(ctx, n.transport, tokens, title, body, data)
 }
 
-// renderNudge is the shared title/body copy for one nudge Message, used by both
-// the push channel (Send, above) and the notification-center record written by
-// Runner.fire in nudge.go — one rendering, two readers, so the in-app record
-// never drifts from what push already shows.
+// renderNudgeBatch is the shared title/body copy for one (account, kind) batch,
+// used by both the push channel (Send, above) and the notification-center record
+// written by Runner.deliverBatch in nudge.go — one rendering, two readers, so the
+// in-app record never drifts from what push already shows.
+func renderNudgeBatch(kind string, ms []Message) (title, body string) {
+	if len(ms) == 1 {
+		return renderNudge(ms[0])
+	}
+	switch kind {
+	case KindFollowUp:
+		return "👋 Follow up?", fmt.Sprintf("%d of your applications have gone quiet.", len(ms))
+	case KindInterviewPrep:
+		return "🎯 Interviews coming up", fmt.Sprintf("You're interviewing for %d roles.", len(ms))
+	case KindJobClosed:
+		return "📪 Jobs closed", fmt.Sprintf("%d jobs you were tracking were closed.", len(ms))
+	default:
+		return "freehire", fmt.Sprintf("%d updates on jobs you are tracking.", len(ms))
+	}
+}
+
+// renderNudge is the single-nudge wording, kept as its own function because it is
+// the one a batch of one must be indistinguishable from.
 func renderNudge(m Message) (title, body string) {
 	switch m.Kind {
 	case KindFollowUp:

--- a/internal/engage/nudge/push_test.go
+++ b/internal/engage/nudge/push_test.go
@@ -43,7 +43,7 @@ func TestPushNotifier_FollowUp_RendersTitleBodyAndSlug(t *testing.T) {
 	n := NewPushNotifier(lister, transport)
 
 	msg := Message{Kind: KindFollowUp, JobTitle: "Go Dev", Company: "Acme", Slug: "go-dev-acme", DaysSilent: 12}
-	if err := n.Send(context.Background(), "push", "42", msg); err != nil {
+	if err := n.Send(context.Background(), "push", "42", msg.Kind, []Message{msg}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -74,7 +74,7 @@ func TestPushNotifier_InterviewPrep_RendersTitleBodyAndSlug(t *testing.T) {
 	n := NewPushNotifier(lister, transport)
 
 	msg := Message{Kind: KindInterviewPrep, JobTitle: "Go Dev", Company: "Acme", Slug: "go-dev-acme"}
-	if err := n.Send(context.Background(), "push", "42", msg); err != nil {
+	if err := n.Send(context.Background(), "push", "42", msg.Kind, []Message{msg}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -102,7 +102,7 @@ func TestPushNotifier_JobClosed_RendersTitleBodyAndSlug(t *testing.T) {
 	n := NewPushNotifier(lister, transport)
 
 	msg := Message{Kind: KindJobClosed, JobTitle: "Go Dev", Company: "Acme", Slug: "go-dev-acme"}
-	if err := n.Send(context.Background(), "push", "42", msg); err != nil {
+	if err := n.Send(context.Background(), "push", "42", msg.Kind, []Message{msg}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -130,7 +130,7 @@ func TestPushNotifier_FansOutToEveryDevice(t *testing.T) {
 	n := NewPushNotifier(lister, transport)
 
 	msg := Message{Kind: KindJobClosed, JobTitle: "Go Dev", Company: "Acme", Slug: "go-dev-acme"}
-	if err := n.Send(context.Background(), "push", "42", msg); err != nil {
+	if err := n.Send(context.Background(), "push", "42", msg.Kind, []Message{msg}); err != nil {
 		t.Fatal(err)
 	}
 	if len(transport.sent) != 2 {
@@ -143,7 +143,7 @@ func TestPushNotifier_InvalidDestReturnsError(t *testing.T) {
 	transport := &fakePushTransport{}
 	n := NewPushNotifier(lister, transport)
 
-	err := n.Send(context.Background(), "push", "not-a-user-id", Message{Kind: KindJobClosed})
+	err := n.Send(context.Background(), "push", "not-a-user-id", KindJobClosed, []Message{{Kind: KindJobClosed}})
 	if err == nil {
 		t.Fatal("want error for a non-numeric dest")
 	}
@@ -154,7 +154,7 @@ func TestPushNotifier_NoDeviceReturnsError(t *testing.T) {
 	transport := &fakePushTransport{}
 	n := NewPushNotifier(lister, transport)
 
-	err := n.Send(context.Background(), "push", "42", Message{Kind: KindJobClosed})
+	err := n.Send(context.Background(), "push", "42", KindJobClosed, []Message{{Kind: KindJobClosed}})
 	if err == nil {
 		t.Fatal("want error when the user has no registered device")
 	}

--- a/internal/engage/nudge/transports.go
+++ b/internal/engage/nudge/transports.go
@@ -26,18 +26,6 @@ var (
 	_ Notifier = (*EmailNotifier)(nil)
 )
 
-// listed splits a batch into the nudges a message itemizes and how many it only
-// counts. The bound is notify.ListLimit, shared with the subscription digest and
-// the reminder engine so no two channels disagree about how long a list may be; the
-// batch itself is bounded separately and much higher by Config.SnapshotCap, because
-// the message is short for readability while the record behind it is long by design.
-func listed(ms []Message) (shown []Message, more int) {
-	if len(ms) <= notify.ListLimit {
-		return ms, 0
-	}
-	return ms[:notify.ListLimit:notify.ListLimit], len(ms) - notify.ListLimit
-}
-
 // TelegramNotifier delivers a nudge as a Telegram HTML message, reusing the
 // telegramnotify Bot API client. Every link stays on-platform: the tracking board
 // for kinds about the application (follow-up, interview-prep), the job's own page
@@ -90,7 +78,7 @@ func (n *TelegramNotifier) render(kind string, ms []Message) string {
 	tailReserve := telegramnotify.UTF16Len(n.moreLine(len(ms), kind))
 	used := telegramnotify.UTF16Len(b.String())
 	fitted := 0
-	shown, _ := listed(ms)
+	shown, _ := notify.Listed(ms)
 	for _, m := range shown {
 		line := n.jobLine(m)
 		lineLen := telegramnotify.UTF16Len(line)
@@ -151,6 +139,8 @@ func (n *TelegramNotifier) batchURL(kind string) string {
 	return n.origin + "/my/tracking"
 }
 
+// renderOne is the single-nudge body, kept per kind and unchanged, because a batch
+// of one must be indistinguishable from what shipped before grouping.
 func (n *TelegramNotifier) renderOne(m Message) string {
 	title, company := html.EscapeString(m.JobTitle), html.EscapeString(m.Company)
 	trackingURL, jobURL := n.origin+"/my/tracking", n.origin+"/jobs/"+m.Slug
@@ -205,12 +195,11 @@ func (n *EmailNotifier) Send(ctx context.Context, _ string, dest, kind string, m
 // batchBody is what the batch template renders from. Jobs carries the source data,
 // escaped in context by html/template.
 type batchBody struct {
-	Jobs   []mailtpl.Job
-	More   int
-	Lead   string
-	URL    string
-	CTA    string
-	Reason string
+	Jobs []mailtpl.Job
+	More int
+	Lead string
+	URL  string
+	CTA  string
 }
 
 // batchTemplate is the list body every kind's batch shares: the jobs, the one
@@ -230,7 +219,7 @@ var batchTemplate = template.Must(mailtpl.Partials().New("nudge-batch").Parse(`
 
 // renderBatch builds the multi-nudge mail for one kind.
 func (n *EmailNotifier) renderBatch(kind string, ms []Message) (subject, htmlBody, textBody string) {
-	shown, more := listed(ms)
+	shown, more := notify.Listed(ms)
 	rows := make([]mailtpl.Job, 0, len(shown))
 	for _, m := range shown {
 		rows = append(rows, mailtpl.NewJob(m.JobTitle, m.Company, "", n.jobURL(m)))

--- a/internal/engage/nudge/transports.go
+++ b/internal/engage/nudge/transports.go
@@ -130,13 +130,21 @@ func (n *TelegramNotifier) moreLine(more int, kind string) string {
 	return fmt.Sprintf("\n<a href=%q>+ %d more</a>", n.batchURL(kind), more)
 }
 
-// batchURL is where a batch sends the reader. Most kinds are about applications, so
-// the tracking board; job-closed has nothing left to track, so the saved list.
+// batchURL is where a batch sends the reader, per batchDestination.
 func (n *TelegramNotifier) batchURL(kind string) string {
+	path, _ := batchDestination(kind)
+	return n.origin + path
+}
+
+// batchDestination is the one place that decides where a batch of `kind` leads and
+// what the action is called. Most kinds are about applications, so the tracking
+// board; job-closed has nothing left to track, so the saved list. Both channels read
+// it, so the mail's button and the bot's tail can never point different ways.
+func batchDestination(kind string) (path, label string) {
 	if kind == KindJobClosed {
-		return n.origin + "/my/activity"
+		return "/my/activity", "Open your saved jobs"
 	}
-	return n.origin + "/my/tracking"
+	return "/my/tracking", "Open your tracking board"
 }
 
 // renderOne is the single-nudge body, kept per kind and unchanged, because a batch
@@ -282,14 +290,11 @@ func (n *EmailNotifier) batchCopy(kind string, count int) (subject, head, pre, l
 	}
 }
 
-// batchCTA is where the batch sends the reader: the tracking board for the kinds
-// about applications, the saved list for job-closed, which has nothing left to
-// track.
+// batchCTA is the mail's single action, per batchDestination, tagged with an email
+// UTM source so the channel's traffic is attributable.
 func (n *EmailNotifier) batchCTA(kind string) (url, label string) {
-	if kind == KindJobClosed {
-		return n.origin + "/my/activity?utm_source=email", "Open your saved jobs"
-	}
-	return n.origin + "/my/tracking?utm_source=email", "Open your tracking board"
+	path, label := batchDestination(kind)
+	return n.origin + path + "?utm_source=email", label
 }
 
 // jobURL is the on-platform freehire job page, tagged with an email UTM source.

--- a/internal/engage/nudge/transports.go
+++ b/internal/engage/nudge/transports.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/strelov1/freehire/internal/application/mailtpl"
 	"github.com/strelov1/freehire/internal/engage/emailnotify"
+	"github.com/strelov1/freehire/internal/engage/notify"
 	"github.com/strelov1/freehire/internal/engage/telegramnotify"
 )
 
@@ -24,6 +25,18 @@ var (
 	_ Notifier = (*TelegramNotifier)(nil)
 	_ Notifier = (*EmailNotifier)(nil)
 )
+
+// listed splits a batch into the nudges a message itemizes and how many it only
+// counts. The bound is notify.ListLimit, shared with the subscription digest and
+// the reminder engine so no two channels disagree about how long a list may be; the
+// batch itself is bounded separately and much higher by Config.SnapshotCap, because
+// the message is short for readability while the record behind it is long by design.
+func listed(ms []Message) (shown []Message, more int) {
+	if len(ms) <= notify.ListLimit {
+		return ms, 0
+	}
+	return ms[:notify.ListLimit:notify.ListLimit], len(ms) - notify.ListLimit
+}
 
 // TelegramNotifier delivers a nudge as a Telegram HTML message, reusing the
 // telegramnotify Bot API client. Every link stays on-platform: the tracking board
@@ -47,19 +60,98 @@ func NewTelegramNotifier(client *telegramnotify.Client, origin string) *Telegram
 // A 403 is translated to ErrRecipientGone, this engine's vocabulary for a chat
 // permanently closed to us, so the runner unlinks it instead of retrying a send
 // that cannot land. Same translation the digest and reminder notifiers do.
-func (n *TelegramNotifier) Send(ctx context.Context, _ string, dest string, m Message) error {
+func (n *TelegramNotifier) Send(ctx context.Context, _ string, dest, kind string, ms []Message) error {
+	if len(ms) == 0 {
+		return nil
+	}
 	chatID, err := strconv.ParseInt(dest, 10, 64)
 	if err != nil {
 		return fmt.Errorf("nudge: invalid telegram chat id %q: %w", dest, err)
 	}
-	err = n.client.SendMessage(ctx, chatID, n.render(m))
+	err = n.client.SendMessage(ctx, chatID, n.render(kind, ms))
 	if errors.Is(err, telegramnotify.ErrChatUnreachable) {
 		return fmt.Errorf("%w: %w", ErrRecipientGone, err)
 	}
 	return err
 }
 
-func (n *TelegramNotifier) render(m Message) string {
+// render builds the HTML body: one nudge keeps the sentence it has always been,
+// several become a headline and a list bounded twice — by notify.ListLimit for
+// readability, and by Telegram's own MaxMessageLen, because an oversized body is
+// rejected deterministically and every retry re-fails.
+func (n *TelegramNotifier) render(kind string, ms []Message) string {
+	if len(ms) == 1 {
+		return n.renderOne(ms[0])
+	}
+
+	var b strings.Builder
+	b.WriteString(n.batchHeadline(kind, len(ms)) + "\n\n")
+
+	tailReserve := telegramnotify.UTF16Len(n.moreLine(len(ms), kind))
+	used := telegramnotify.UTF16Len(b.String())
+	fitted := 0
+	shown, _ := listed(ms)
+	for _, m := range shown {
+		line := n.jobLine(m)
+		lineLen := telegramnotify.UTF16Len(line)
+		if used+lineLen+tailReserve > telegramnotify.MaxMessageLen {
+			break
+		}
+		b.WriteString(line)
+		used += lineLen
+		fitted++
+	}
+	if omitted := len(ms) - fitted; omitted > 0 {
+		b.WriteString(n.moreLine(omitted, kind))
+	}
+	return b.String()
+}
+
+// batchHeadline is the one line that says what this batch is about. It is escaped
+// nowhere because it holds no source data — only a count.
+func (n *TelegramNotifier) batchHeadline(kind string, count int) string {
+	switch kind {
+	case KindFollowUp:
+		return fmt.Sprintf("👋 <b>%d</b> of your applications have gone quiet. Worth a follow-up?", count)
+	case KindInterviewPrep:
+		return fmt.Sprintf("🎯 You're interviewing for <b>%d</b> roles. Ready to rehearse?", count)
+	case KindJobClosed:
+		return fmt.Sprintf("📪 <b>%d</b> jobs you were tracking were closed.", count)
+	default:
+		return fmt.Sprintf("<b>%d</b> updates on jobs you are tracking.", count)
+	}
+}
+
+// jobLine renders one nudged job as a bullet linking to its freehire page.
+func (n *TelegramNotifier) jobLine(m Message) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "• <a href=%q>%s</a>", n.origin+"/jobs/"+m.Slug, html.EscapeString(m.JobTitle))
+	if m.Company != "" {
+		fmt.Fprintf(&b, " — %s", html.EscapeString(m.Company))
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+// moreLine is the overflow tail, or "" when nothing is omitted. It leads where the
+// batch's own call to action leads.
+func (n *TelegramNotifier) moreLine(more int, kind string) string {
+	if more <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("\n<a href=%q>+ %d more</a>", n.batchURL(kind), more)
+}
+
+// batchURL is where a batch sends the reader. Most kinds are about applications, so
+// the tracking board; job-closed has nothing left to track, so the saved list.
+func (n *TelegramNotifier) batchURL(kind string) string {
+	if kind == KindJobClosed {
+		return n.origin + "/my/activity"
+	}
+	return n.origin + "/my/tracking"
+}
+
+func (n *TelegramNotifier) renderOne(m Message) string {
 	title, company := html.EscapeString(m.JobTitle), html.EscapeString(m.Company)
 	trackingURL, jobURL := n.origin+"/my/tracking", n.origin+"/jobs/"+m.Slug
 	switch m.Kind {
@@ -96,10 +188,124 @@ func NewEmailNotifier(sender emailnotify.Sender, from, origin string) *EmailNoti
 	return &EmailNotifier{sender: sender, from: emailnotify.From(senderName, from), origin: base, layout: mailtpl.New(base)}
 }
 
-// Send renders the nudge and delivers it to the address in dest.
-func (n *EmailNotifier) Send(ctx context.Context, _ string, dest string, m Message) error {
-	subject, htmlBody, textBody := n.render(m)
+// Send renders the batch as one mail and delivers it to the address in dest.
+func (n *EmailNotifier) Send(ctx context.Context, _ string, dest, kind string, ms []Message) error {
+	if len(ms) == 0 {
+		return nil
+	}
+	var subject, htmlBody, textBody string
+	if len(ms) == 1 {
+		subject, htmlBody, textBody = n.render(ms[0])
+	} else {
+		subject, htmlBody, textBody = n.renderBatch(kind, ms)
+	}
 	return n.sender.Send(ctx, n.from, dest, subject, htmlBody, textBody)
+}
+
+// batchBody is what the batch template renders from. Jobs carries the source data,
+// escaped in context by html/template.
+type batchBody struct {
+	Jobs   []mailtpl.Job
+	More   int
+	Lead   string
+	URL    string
+	CTA    string
+	Reason string
+}
+
+// batchTemplate is the list body every kind's batch shares: the jobs, the one
+// sentence saying what happened to them, and a single call to action. The kinds
+// differ in copy, not in layout, so one template serves all three — unlike the
+// single-nudge blocks above, whose lead sentences sit inside the markup.
+var batchTemplate = template.Must(mailtpl.Partials().New("nudge-batch").Parse(`
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+  {{range $i, $job := .Jobs}}
+  <tr><td class="m-row" style="padding:14px 0;{{if $i}}border-top:1px solid #e4e4e4;{{end}}">{{template "job-row" $job}}</td></tr>
+  {{end}}
+</table>
+<div style="height:18px;"></div>
+{{template "p" .Lead}}
+{{if gt .More 0}}{{template "muted" (printf "+ %d more not listed here." .More)}}{{end}}
+{{template "button" (mailLink .URL .CTA)}}`))
+
+// renderBatch builds the multi-nudge mail for one kind.
+func (n *EmailNotifier) renderBatch(kind string, ms []Message) (subject, htmlBody, textBody string) {
+	shown, more := listed(ms)
+	rows := make([]mailtpl.Job, 0, len(shown))
+	for _, m := range shown {
+		rows = append(rows, mailtpl.NewJob(m.JobTitle, m.Company, "", n.jobURL(m)))
+	}
+
+	subject, head, pre, lead := n.batchCopy(kind, len(ms))
+	url, cta := n.batchCTA(kind)
+
+	var content bytes.Buffer
+	// The template is a trusted constant and the data is escaped in context, so this
+	// fails only on a template bug — caught by the golden previews.
+	_ = batchTemplate.Execute(&content, batchBody{Jobs: rows, More: more, Lead: lead, URL: url, CTA: cta})
+
+	htmlBody = n.layout.Render(mailtpl.Body{
+		Preheader: pre,
+		Heading:   head,
+		Content:   template.HTML(content.String()), //nolint:gosec // rendered by the trusted template above
+		Footer:    "You’re getting this because you are tracking these applications on freehire.",
+	})
+
+	var b strings.Builder
+	b.WriteString(lead + "\n\n")
+	for _, m := range shown {
+		b.WriteString("- " + m.JobTitle)
+		if m.Company != "" {
+			b.WriteString(" — " + m.Company)
+		}
+		b.WriteString("\n  " + n.jobURL(m) + "\n")
+	}
+	if more > 0 {
+		fmt.Fprintf(&b, "\n+ %d more\n", more)
+	}
+	fmt.Fprintf(&b, "\n%s: %s\n", cta, url)
+	return subject, htmlBody, b.String()
+}
+
+// batchCopy is the per-kind wording for a batch of `count` nudges.
+func (n *EmailNotifier) batchCopy(kind string, count int) (subject, head, pre, lead string) {
+	switch kind {
+	case KindFollowUp:
+		return fmt.Sprintf("Time to follow up on %d applications", count),
+			"Worth a follow-up?",
+			fmt.Sprintf("%d applications have gone quiet", count),
+			fmt.Sprintf("Nothing has moved on %d of your applications.", count)
+	case KindInterviewPrep:
+		return fmt.Sprintf("Prepare for %d interviews", count),
+			"Ready to rehearse?",
+			fmt.Sprintf("%d interviews are coming up", count),
+			"Your interviews are coming up. A rehearsal beats a re-read."
+	case KindJobClosed:
+		return fmt.Sprintf("Closed: %d jobs you were tracking", count),
+			fmt.Sprintf("%d jobs were closed", count),
+			fmt.Sprintf("%d jobs you were tracking have closed", count),
+			"These listings were closed. They are off the board, so they are fewer things to wait on."
+	default:
+		return fmt.Sprintf("%d updates on jobs you are tracking", count),
+			"An update on your applications",
+			"An update on jobs you are tracking",
+			fmt.Sprintf("%d jobs you are tracking were updated.", count)
+	}
+}
+
+// batchCTA is where the batch sends the reader: the tracking board for the kinds
+// about applications, the saved list for job-closed, which has nothing left to
+// track.
+func (n *EmailNotifier) batchCTA(kind string) (url, label string) {
+	if kind == KindJobClosed {
+		return n.origin + "/my/activity?utm_source=email", "Open your saved jobs"
+	}
+	return n.origin + "/my/tracking?utm_source=email", "Open your tracking board"
+}
+
+// jobURL is the on-platform freehire job page, tagged with an email UTM source.
+func (n *EmailNotifier) jobURL(m Message) string {
+	return n.origin + "/jobs/" + m.Slug + "?utm_source=email"
 }
 
 // nudgeBody is what the body templates render from. Job carries the source data,

--- a/internal/engage/nudge/transports_test.go
+++ b/internal/engage/nudge/transports_test.go
@@ -1,0 +1,158 @@
+package nudge
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/engage/notify"
+	"github.com/strelov1/freehire/internal/engage/telegramnotify"
+	"github.com/strelov1/freehire/internal/platform/db"
+)
+
+// captureSender records the last email an EmailNotifier sent.
+type captureSender struct {
+	subject, html, text string
+}
+
+func (s *captureSender) Send(_ context.Context, _, _, subject, html, text string) error {
+	s.subject, s.html, s.text = subject, html, text
+	return nil
+}
+
+// batchOf builds n distinct nudges of one kind, so a test can push a message past
+// its bounds without hand-writing the list.
+func batchOf(kind string, n int) []Message {
+	ms := make([]Message, n)
+	for i := range ms {
+		id := strconv.Itoa(i)
+		ms[i] = Message{Kind: kind, JobTitle: "Job " + id, Company: "Company " + id, Slug: "job-" + id, DaysSilent: 20 + i}
+	}
+	return ms
+}
+
+func TestEmailNotifier_BatchListsEveryNudgeUnderTheListLimit(t *testing.T) {
+	sender := &captureSender{}
+	n := NewEmailNotifier(sender, "jobs@freehire.me", "https://freehire.me")
+
+	if err := n.Send(context.Background(), "email", "u@x.com", KindFollowUp, batchOf(KindFollowUp, 3)); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if !strings.Contains(sender.subject, "3 applications") {
+		t.Errorf("subject = %q, want the batch count", sender.subject)
+	}
+	for i := 0; i < 3; i++ {
+		if !strings.Contains(sender.html, "jobs/job-"+strconv.Itoa(i)) {
+			t.Errorf("html is missing job-%d: %q", i, sender.html)
+		}
+	}
+	if !strings.Contains(sender.html, "/my/tracking") {
+		t.Errorf("a follow-up batch must lead to the tracking board: %q", sender.html)
+	}
+}
+
+// job-closed has nothing left to track, so its batch leads to the saved list.
+func TestEmailNotifier_JobClosedBatchLeadsToSavedJobs(t *testing.T) {
+	sender := &captureSender{}
+	n := NewEmailNotifier(sender, "jobs@freehire.me", "https://freehire.me")
+
+	if err := n.Send(context.Background(), "email", "u@x.com", KindJobClosed, batchOf(KindJobClosed, 2)); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if !strings.Contains(sender.html, "/my/activity") {
+		t.Errorf("html = %q, want the saved-jobs destination", sender.html)
+	}
+}
+
+// The two bounds are different numbers on purpose: the message itemizes
+// notify.ListLimit and counts the rest.
+func TestEmailNotifier_BatchOverTheListLimitCountsTheRest(t *testing.T) {
+	sender := &captureSender{}
+	n := NewEmailNotifier(sender, "jobs@freehire.me", "https://freehire.me")
+
+	if err := n.Send(context.Background(), "email", "u@x.com", KindFollowUp, batchOf(KindFollowUp, notify.ListLimit+4)); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if !strings.Contains(sender.html, "4 more") {
+		t.Errorf("html = %q, want a tail counting the 4 omitted jobs", sender.html)
+	}
+	if strings.Contains(sender.html, "jobs/job-"+strconv.Itoa(notify.ListLimit)) {
+		t.Errorf("html itemized past the list limit: %q", sender.html)
+	}
+	if !strings.Contains(sender.text, "+ 4 more") {
+		t.Errorf("text = %q, want the same tail as the HTML", sender.text)
+	}
+}
+
+// A batch of one must be indistinguishable from what shipped before grouping.
+func TestEmailNotifier_SingleNudgeKeepsItsOwnWording(t *testing.T) {
+	sender := &captureSender{}
+	n := NewEmailNotifier(sender, "jobs@freehire.me", "https://freehire.me")
+
+	ms := []Message{{Kind: KindFollowUp, JobTitle: "Go Dev", Company: "Acme", Slug: "go-dev-acme", DaysSilent: 12}}
+	if err := n.Send(context.Background(), "email", "u@x.com", KindFollowUp, ms); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if sender.subject != "Time to follow up: Go Dev at Acme" {
+		t.Errorf("subject = %q, want the single-nudge line", sender.subject)
+	}
+}
+
+func TestTelegramNotifier_BatchListsJobsAndCountsTheRest(t *testing.T) {
+	n := NewTelegramNotifier(nil, "https://freehire.me")
+	got := n.render(KindFollowUp, batchOf(KindFollowUp, notify.ListLimit+2))
+
+	if !strings.Contains(got, "+ 2 more") {
+		t.Errorf("render = %q, want a tail counting the 2 omitted jobs", got)
+	}
+	if !strings.Contains(got, "jobs/job-0") {
+		t.Errorf("render = %q, want the first job listed", got)
+	}
+}
+
+// An oversized body is rejected deterministically and every retry re-fails, so the
+// message must fit whatever the batch holds.
+func TestTelegramNotifier_BatchStaysUnderTheMessageLimit(t *testing.T) {
+	n := NewTelegramNotifier(nil, "https://freehire.me")
+	ms := batchOf(KindFollowUp, notify.ListLimit)
+	long := strings.Repeat("Extremely Long Job Title ", 40)
+	for i := range ms {
+		ms[i].JobTitle = long
+		ms[i].Company = long
+	}
+
+	if got := telegramnotify.UTF16Len(n.render(KindFollowUp, ms)); got > telegramnotify.MaxMessageLen {
+		t.Errorf("rendered %d UTF-16 units, want at most %d", got, telegramnotify.MaxMessageLen)
+	}
+}
+
+func TestTelegramNotifier_BatchEscapesSourceData(t *testing.T) {
+	n := NewTelegramNotifier(nil, "https://freehire.me")
+	ms := batchOf(KindFollowUp, 2)
+	ms[0].JobTitle = "<script>x</script>"
+
+	if got := n.render(KindFollowUp, ms); strings.Contains(got, "<script>") {
+		t.Errorf("title must be HTML-escaped in the body, got %q", got)
+	}
+}
+
+func TestPushNotifier_BatchIsOneNotificationWithoutADeepLink(t *testing.T) {
+	lister := &fakePushTokenLister{tokens: map[int64][]db.UserPushToken{42: {{Token: "tok-1"}}}}
+	transport := &fakePushTransport{}
+	n := NewPushNotifier(lister, transport)
+
+	if err := n.Send(context.Background(), "push", "42", KindFollowUp, batchOf(KindFollowUp, 3)); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(transport.sent) != 1 {
+		t.Fatalf("sent = %d, want 1 for one device and one batch", len(transport.sent))
+	}
+	got := transport.sent[0]
+	if !strings.Contains(got.body, "3 of your applications") {
+		t.Errorf("body = %q, want the batch count", got.body)
+	}
+	if got.data["slug"] != "" {
+		t.Errorf("data[slug] = %q, want no deep link for a multi-job batch", got.data["slug"])
+	}
+}

--- a/internal/engage/nudge/transports_test.go
+++ b/internal/engage/nudge/transports_test.go
@@ -65,6 +65,48 @@ func TestEmailNotifier_JobClosedBatchLeadsToSavedJobs(t *testing.T) {
 	}
 }
 
+// interview-prep is about the application too, so its batch leads to the tracking
+// board — the third kind, and the one neither of the two above covers.
+func TestEmailNotifier_InterviewPrepBatchLeadsToTheTrackingBoard(t *testing.T) {
+	sender := &captureSender{}
+	n := NewEmailNotifier(sender, "jobs@freehire.me", "https://freehire.me")
+
+	if err := n.Send(context.Background(), "email", "u@x.com", KindInterviewPrep, batchOf(KindInterviewPrep, 2)); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if !strings.Contains(sender.subject, "2 interviews") {
+		t.Errorf("subject = %q, want the batch count", sender.subject)
+	}
+	if !strings.Contains(sender.html, "/my/tracking") {
+		t.Errorf("html = %q, want the tracking-board destination", sender.html)
+	}
+}
+
+func TestTelegramNotifier_InterviewPrepBatchHeadlinesTheCount(t *testing.T) {
+	n := NewTelegramNotifier(nil, "https://freehire.me")
+	got := n.render(KindInterviewPrep, batchOf(KindInterviewPrep, 2))
+
+	if !strings.Contains(got, "interviewing for <b>2</b> roles") {
+		t.Errorf("render = %q, want the interview-prep headline with a count", got)
+	}
+	if !strings.Contains(got, "jobs/job-0") {
+		t.Errorf("render = %q, want the jobs listed", got)
+	}
+}
+
+// The mail's button and the bot's tail read one rule, so they cannot point different
+// ways for the same kind.
+func TestBatchDestination_IsOneRuleForBothChannels(t *testing.T) {
+	for _, kind := range []string{KindFollowUp, KindInterviewPrep, KindJobClosed} {
+		path, _ := batchDestination(kind)
+		tg := NewTelegramNotifier(nil, "https://freehire.me").batchURL(kind)
+		mail, _ := NewEmailNotifier(&captureSender{}, "j@f.me", "https://freehire.me").batchCTA(kind)
+		if tg != "https://freehire.me"+path || !strings.HasPrefix(mail, "https://freehire.me"+path) {
+			t.Errorf("%s: telegram %q and email %q disagree with %q", kind, tg, mail, path)
+		}
+	}
+}
+
 // The two bounds are different numbers on purpose: the message itemizes
 // notify.ListLimit and counts the rest.
 func TestEmailNotifier_BatchOverTheListLimitCountsTheRest(t *testing.T) {

--- a/internal/engage/reminder/engine.go
+++ b/internal/engage/reminder/engine.go
@@ -25,10 +25,15 @@ type ReminderMessage struct {
 	URL      string
 }
 
-// Notifier delivers a reminder over a channel to a destination. The engine depends
-// only on this, so a new channel is a new implementation, not a change here.
+// Notifier delivers one account's due reminders over a channel to a destination,
+// as a single message. The engine depends only on this, so a new channel is a new
+// implementation, not a change here.
+//
+// The slice, rather than a second batch method alongside a single-reminder one, is
+// deliberate: a per-reminder send path left alive is a per-reminder send path some
+// channel keeps using, and the flood this replaced was exactly that.
 type Notifier interface {
-	Send(ctx context.Context, channel, dest string, m ReminderMessage) error
+	Send(ctx context.Context, channel, dest string, ms []ReminderMessage) error
 }
 
 // ErrChannelNotConfigured is returned by Router.Send for a channel with no
@@ -52,12 +57,12 @@ type Router map[string]Notifier
 var _ Notifier = (Router)(nil)
 
 // Send routes to the registered notifier, or ErrChannelNotConfigured when none is.
-func (r Router) Send(ctx context.Context, channel, dest string, m ReminderMessage) error {
+func (r Router) Send(ctx context.Context, channel, dest string, ms []ReminderMessage) error {
 	n, ok := r[channel]
 	if !ok {
 		return fmt.Errorf("%w: %q", ErrChannelNotConfigured, channel)
 	}
-	return n.Send(ctx, channel, dest, m)
+	return n.Send(ctx, channel, dest, ms)
 }
 
 // Compile-time proof that the generated *db.Queries satisfies the engine's Store.
@@ -89,20 +94,40 @@ type Config struct {
 	ClaimBatch int32
 	// MaxAttempts dead-letters a reminder after this many failed deliveries.
 	MaxAttempts int32
+	// SnapshotCap bounds how many reminders one message carries — which is how
+	// many the in-app record holds. It is NOT the message listing bound (that is
+	// notify.ListLimit): a message is short because a long list reads badly, while
+	// the record is long because it is the page the message links to. The excess
+	// is released back to the pending queue, so a later pass delivers it as its
+	// own message rather than stamping it delivered into a message it never
+	// appeared in.
+	SnapshotCap int
 }
 
 // DefaultConfig is the production tuning, mirroring internal/engage/notify.
 func DefaultConfig() Config {
-	return Config{LeaseSeconds: 600, ClaimBatch: 500, MaxAttempts: 5}
+	return Config{LeaseSeconds: 600, ClaimBatch: 500, MaxAttempts: 5, SnapshotCap: 200}
 }
 
-// Stats is the per-pass summary logged by the worker.
+// Stats is the per-pass summary logged by the worker. Every counter except
+// Messages counts REMINDERS, not deliveries, so the numbers stay comparable across
+// the change that made one message carry many.
 type Stats struct {
 	Delivered int // reminders sent
+	Messages  int // channel messages sent (one per account per pass)
 	Cancelled int // reminders cancelled at fire (job closed or no longer actionable)
 	SoftSkips int // reminders with no deliverable channel this pass
-	Deferred  int // reminders held back by the account's quiet-hours window
+	Deferred  int // reminders held back by quiet hours or by a full message
 	Failed    int // reminders whose delivery errored
+}
+
+// batch is one account's due reminders in a pass. Channels, destinations and quiet
+// hours are properties of the ACCOUNT, so the first member's row answers for the
+// whole batch and only the messages accumulate.
+type batch struct {
+	info db.GetReminderForDeliveryRow
+	ids  []int64
+	msgs []ReminderMessage
 }
 
 // Runner fires due reminders.
@@ -130,91 +155,143 @@ func (r *Runner) Run(ctx context.Context) (Stats, error) {
 	if err != nil {
 		return stats, fmt.Errorf("claim: %w", err)
 	}
-	for _, id := range due {
-		r.fire(ctx, id, &stats)
+	for _, b := range r.collect(ctx, due, &stats) {
+		r.deliverBatch(ctx, b, &stats)
 	}
-	log.Printf("reminder: delivered=%d cancelled=%d soft_skips=%d deferred=%d failed=%d",
-		stats.Delivered, stats.Cancelled, stats.SoftSkips, stats.Deferred, stats.Failed)
+	log.Printf("reminder: delivered=%d messages=%d cancelled=%d soft_skips=%d deferred=%d failed=%d",
+		stats.Delivered, stats.Messages, stats.Cancelled, stats.SoftSkips, stats.Deferred, stats.Failed)
 	return stats, nil
 }
 
-// fire delivers one reminder and finalizes its ledger row. It re-checks that the job
-// is still open and still saved-but-unapplied immediately before sending — a reminder
-// that lost its intent (job closed, or the user applied/unsaved) is cancelled rather
-// than delivered, which is how job-closure cancellation is enforced without hooking
-// the scattered close paths.
-func (r *Runner) fire(ctx context.Context, id int64, stats *Stats) {
+// collect turns the claimed ids into one batch per account, dropping the reminders
+// that must not be sent. Each is validated on its own — the checks are per reminder
+// — and only the survivors group, so a stale reminder is cancelled without taking
+// its neighbours' message with it.
+//
+// Batches are returned in the order their first member was claimed, which
+// ClaimDueReminders orders by fire time, so the account that has waited longest is
+// served first and a pass is reproducible.
+func (r *Runner) collect(ctx context.Context, due []int64, stats *Stats) []*batch {
+	byUser := make(map[int64]*batch, len(due))
+	var order []*batch
+	for _, id := range due {
+		info, ok := r.validate(ctx, id, stats)
+		if !ok {
+			continue
+		}
+		b := byUser[info.UserID]
+		if b == nil {
+			b = &batch{info: info}
+			byUser[info.UserID] = b
+			order = append(order, b)
+		}
+		if len(b.ids) >= r.cfg.SnapshotCap {
+			// The message is full. Release rather than stamp: a reminder marked
+			// delivered while appearing in no message is gone for good, which is
+			// the trap internal/engage/notify's deferOverflow exists to avoid.
+			r.release(ctx, id)
+			stats.Deferred++
+			continue
+		}
+		b.ids = append(b.ids, id)
+		b.msgs = append(b.msgs, ReminderMessage{
+			JobTitle: info.Title, Company: info.Company, Slug: info.PublicSlug, URL: info.URL,
+		})
+	}
+	return order
+}
+
+// validate re-checks one claimed reminder immediately before it joins a batch: the
+// job must still be open and still saved-but-unapplied, and the account must not be
+// inside its quiet hours. A reminder that lost its intent is cancelled here, which
+// is how job-closure cancellation is enforced without hooking the scattered close
+// paths. It reports whether the reminder is deliverable this pass.
+func (r *Runner) validate(ctx context.Context, id int64, stats *Stats) (db.GetReminderForDeliveryRow, bool) {
 	info, err := r.store.GetReminderForDelivery(ctx, id)
 	if err != nil {
 		log.Printf("reminder: load %d for delivery: %v", id, err)
 		r.release(ctx, id)
-		return
+		return info, false
 	}
 	if !info.JobOpen || !info.StillActionable {
 		if _, err := r.store.CancelReminderAtFire(ctx, id); err != nil {
 			log.Printf("reminder: cancel-at-fire %d: %v", id, err)
 			r.release(ctx, id)
-			return
+			return info, false
 		}
 		stats.Cancelled++
-		return
+		return info, false
 	}
 	if deliverywindow.InQuietHours(r.now(), info.Timezone.String, pgconv.DurationPtr(info.QuietHoursStart), pgconv.DurationPtr(info.QuietHoursEnd)) {
 		// A transient time-of-day condition, not a lost intent: release (not
 		// cancel) so the reminder fires once quiet hours end.
 		r.release(ctx, id)
 		stats.Deferred++
-		return
+		return info, false
 	}
+	return info, true
+}
 
-	msg := ReminderMessage{JobTitle: info.Title, Company: info.Company, Slug: info.PublicSlug, URL: info.URL}
-	delivered, failedErr := r.deliverChannels(ctx, info, msg)
+// deliverBatch sends one account's batch as a single message per channel and
+// finalizes every ledger row in it. The batch is the unit: one send outcome decides
+// all of its reminders, because a partial result would need a second delivery
+// ledger to describe and nothing reads one.
+func (r *Runner) deliverBatch(ctx context.Context, b *batch, stats *Stats) {
+	delivered, failedErr := r.deliverChannels(ctx, b.info, b.msgs)
 
 	switch {
 	case delivered:
 		if failedErr != nil {
-			// One channel delivered but another errored: the reminder is done (a
+			// One channel delivered but another errored: the batch is done (a
 			// one-shot nudge needs only one channel), but surface the broken channel
 			// so a persistently-failing one is not invisible.
-			log.Printf("reminder: %d delivered with a co-channel error: %v", id, failedErr)
+			log.Printf("reminder: user %d delivered with a co-channel error: %v", b.info.UserID, failedErr)
 		}
-		if _, err := r.store.MarkReminderDelivered(ctx, id); err != nil {
-			// Delivered but not stamped: the lease expiry re-delivers (a rare
-			// duplicate), preferable to losing the reminder.
-			log.Printf("reminder: mark delivered %d: %v", id, err)
+		for _, id := range b.ids {
+			if _, err := r.store.MarkReminderDelivered(ctx, id); err != nil {
+				// Delivered but not stamped: the lease expiry re-delivers (a rare
+				// duplicate), preferable to losing the reminder.
+				log.Printf("reminder: mark delivered %d: %v", id, err)
+			}
 		}
-		r.recordNotification(ctx, id, info, msg)
-		stats.Delivered++
+		r.recordNotification(ctx, b)
+		stats.Delivered += len(b.ids)
+		stats.Messages++
 	case failedErr != nil:
-		log.Printf("reminder: deliver %d: %v", id, failedErr)
-		if err := r.store.RecordReminderDeliveryFailure(ctx, db.RecordReminderDeliveryFailureParams{
-			ID:          id,
-			LastError:   failedErr.Error(),
-			MaxAttempts: r.cfg.MaxAttempts,
-		}); err != nil {
-			log.Printf("reminder: record failure %d: %v", id, err)
+		log.Printf("reminder: deliver batch for user %d: %v", b.info.UserID, failedErr)
+		for _, id := range b.ids {
+			if err := r.store.RecordReminderDeliveryFailure(ctx, db.RecordReminderDeliveryFailureParams{
+				ID:          id,
+				LastError:   failedErr.Error(),
+				MaxAttempts: r.cfg.MaxAttempts,
+			}); err != nil {
+				log.Printf("reminder: record failure %d: %v", id, err)
+			}
 		}
-		stats.Failed++
+		stats.Failed += len(b.ids)
 	default:
 		// No channel had a usable destination (or none is configured): soft-skip,
-		// keep the reminder pending for a later pass, burn no attempt.
-		r.release(ctx, id)
-		stats.SoftSkips++
+		// keep the reminders pending for a later pass, burn no attempt.
+		for _, id := range b.ids {
+			r.release(ctx, id)
+		}
+		stats.SoftSkips += len(b.ids)
 	}
 }
 
-// deliverChannels attempts each of the reminder's channels that has a usable
-// destination. It reports whether at least one send succeeded and the last hard
-// error (a channel with no destination or no notifier is a soft-skip, not an error).
-// One successful channel makes the reminder delivered — a co-channel outage just
-// misses that channel for this one-shot nudge.
-func (r *Runner) deliverChannels(ctx context.Context, info db.GetReminderForDeliveryRow, msg ReminderMessage) (delivered bool, failedErr error) {
+// deliverChannels attempts each of the account's channels that has a usable
+// destination, sending the whole batch as one message per channel. It reports
+// whether at least one send succeeded and the last hard error (a channel with no
+// destination or no notifier is a soft-skip, not an error). One successful channel
+// makes the batch delivered — a co-channel outage just misses that channel for
+// these one-shot nudges.
+func (r *Runner) deliverChannels(ctx context.Context, info db.GetReminderForDeliveryRow, msgs []ReminderMessage) (delivered bool, failedErr error) {
 	for _, ch := range info.Channels {
 		dest, ok := recipient(ch, info)
 		if !ok {
 			continue
 		}
-		err := r.notifier.Send(ctx, ch, dest, msg)
+		err := r.notifier.Send(ctx, ch, dest, msgs)
 		if errors.Is(err, ErrChannelNotConfigured) {
 			continue
 		}
@@ -273,22 +350,28 @@ func recipient(channel string, info db.GetReminderForDeliveryRow) (string, bool)
 	return "", false
 }
 
-// recordNotification writes the in-app notification-center record for a delivered
-// reminder. A reminder always concerns exactly one job, so the slug is always
-// populated (unlike a subscription digest, which omits it for a multi-job match).
-// A failure here must not fail the delivery it accompanies — the reminder was
-// already sent, so this is logged and dropped, not propagated.
-func (r *Runner) recordNotification(ctx context.Context, id int64, info db.GetReminderForDeliveryRow, msg ReminderMessage) {
-	title, body := renderReminder(msg)
-	_, err := r.store.RecordNotification(ctx, db.RecordNotificationParams{
-		UserID:     info.UserID,
-		Kind:       "reminder",
-		Title:      title,
-		Body:       body,
-		PublicSlug: pgtype.Text{String: msg.Slug, Valid: true},
-	})
-	if err != nil {
-		log.Printf("reminder: record notification %d: %v", id, err)
+// recordNotification writes the one in-app notification-center record for a
+// delivered batch. A batch of one keeps the shape reminders have always recorded —
+// a public slug the notification links straight to. A batch of several has no
+// single job to point at, so it carries the job list instead and the notification
+// center renders its own page, exactly as a multi-job subscription digest does.
+// A failure here must not fail the delivery it accompanies — the batch was already
+// sent, so this is logged and dropped, not propagated.
+func (r *Runner) recordNotification(ctx context.Context, b *batch) {
+	title, body := renderReminderBatch(b.msgs)
+	arg := db.RecordNotificationParams{
+		UserID: b.info.UserID,
+		Kind:   "reminder",
+		Title:  title,
+		Body:   body,
+	}
+	if len(b.msgs) == 1 {
+		arg.PublicSlug = pgtype.Text{String: b.msgs[0].Slug, Valid: true}
+	} else {
+		arg.Jobs = jobsSnapshot(b.msgs)
+	}
+	if _, err := r.store.RecordNotification(ctx, arg); err != nil {
+		log.Printf("reminder: record notification for user %d: %v", b.info.UserID, err)
 	}
 }
 

--- a/internal/engage/reminder/engine.go
+++ b/internal/engage/reminder/engine.go
@@ -2,6 +2,7 @@ package reminder
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -373,6 +374,16 @@ func (r *Runner) recordNotification(ctx context.Context, b *batch) {
 	if _, err := r.store.RecordNotification(ctx, arg); err != nil {
 		log.Printf("reminder: record notification for user %d: %v", b.info.UserID, err)
 	}
+}
+
+// jobsSnapshot is the job list a multi-job batch records for its notification's own
+// page, in the shape notify owns because one page renders every engine's rows.
+func jobsSnapshot(ms []ReminderMessage) json.RawMessage {
+	jobs := make([]notify.SnapshotJob, len(ms))
+	for i, m := range ms {
+		jobs[i] = notify.SnapshotJob{Title: m.JobTitle, Company: m.Company, Slug: m.Slug}
+	}
+	return notify.JobsSnapshot(jobs)
 }
 
 // release drops the lease on a reminder so it is retried promptly on a later pass.

--- a/internal/engage/reminder/engine.go
+++ b/internal/engage/reminder/engine.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -122,13 +124,33 @@ type Stats struct {
 	Failed    int // reminders whose delivery errored
 }
 
-// batch is one account's due reminders in a pass. Channels, destinations and quiet
-// hours are properties of the ACCOUNT, so the first member's row answers for the
-// whole batch and only the messages accumulate.
+// batch is one account's due reminders in a pass that share a channel set.
+// Destinations and quiet hours are properties of the ACCOUNT, so the first
+// member's row answers for the whole batch and only the messages accumulate.
 type batch struct {
 	info db.GetReminderForDeliveryRow
 	ids  []int64
 	msgs []ReminderMessage
+}
+
+// batchKey is what makes two reminders one message: the same account AND the same
+// channel set. The channels are NOT an account property here — job_reminders
+// snapshots them at schedule time so a later settings edit never rewrites a pending
+// reminder (migration 0034) — so an account that changed channels between two saves
+// has two genuinely different deliveries due. Grouping on the account alone would
+// send one of them over the other's channels and stamp it delivered.
+type batchKey struct {
+	userID   int64
+	channels string
+}
+
+// channelKey canonicalizes a channel set for batchKey: sorted and joined, so
+// {email,telegram} and {telegram,email} are one group. Only the KEY is sorted — the
+// send still walks the first member's own slice, preserving its order.
+func channelKey(channels []string) string {
+	sorted := slices.Clone(channels)
+	slices.Sort(sorted)
+	return strings.Join(sorted, "\x00")
 }
 
 // Runner fires due reminders.
@@ -140,7 +162,15 @@ type Runner struct {
 }
 
 // NewRunner builds a firing Runner.
+//
+// A non-positive SnapshotCap is corrected to the default rather than honoured: it
+// would make every batch full at zero members, so every claimed reminder is released
+// unsent while burning no attempt — a pass that logs no failure and delivers nothing,
+// forever. The other Config fields fail visibly when unset; this one does not.
 func NewRunner(store Store, notifier Notifier, cfg Config) *Runner {
+	if cfg.SnapshotCap <= 0 {
+		cfg.SnapshotCap = DefaultConfig().SnapshotCap
+	}
 	return &Runner{store: store, notifier: notifier, cfg: cfg, now: time.Now}
 }
 
@@ -164,26 +194,27 @@ func (r *Runner) Run(ctx context.Context) (Stats, error) {
 	return stats, nil
 }
 
-// collect turns the claimed ids into one batch per account, dropping the reminders
-// that must not be sent. Each is validated on its own — the checks are per reminder
-// — and only the survivors group, so a stale reminder is cancelled without taking
-// its neighbours' message with it.
+// collect turns the claimed ids into one batch per (account, channel set), dropping
+// the reminders that must not be sent. Each is validated on its own — the checks are
+// per reminder — and only the survivors group, so a stale reminder is cancelled
+// without taking its neighbours' message with it.
 //
 // Batches are returned in the order their first member was claimed, which
 // ClaimDueReminders orders by fire time, so the account that has waited longest is
 // served first and a pass is reproducible.
 func (r *Runner) collect(ctx context.Context, due []int64, stats *Stats) []*batch {
-	byUser := make(map[int64]*batch, len(due))
+	byKey := make(map[batchKey]*batch, len(due))
 	var order []*batch
 	for _, id := range due {
 		info, ok := r.validate(ctx, id, stats)
 		if !ok {
 			continue
 		}
-		b := byUser[info.UserID]
+		key := batchKey{userID: info.UserID, channels: channelKey(info.Channels)}
+		b := byKey[key]
 		if b == nil {
 			b = &batch{info: info}
-			byUser[info.UserID] = b
+			byKey[key] = b
 			order = append(order, b)
 		}
 		if len(b.ids) >= r.cfg.SnapshotCap {

--- a/internal/engage/reminder/engine.go
+++ b/internal/engage/reminder/engine.go
@@ -117,7 +117,7 @@ func DefaultConfig() Config {
 // the change that made one message carry many.
 type Stats struct {
 	Delivered int // reminders sent
-	Messages  int // channel messages sent (one per account per pass)
+	Messages  int // messages that landed (one per batch PER CHANNEL, not per batch)
 	Cancelled int // reminders cancelled at fire (job closed or no longer actionable)
 	SoftSkips int // reminders with no deliverable channel this pass
 	Deferred  int // reminders held back by quiet hours or by a full message
@@ -269,10 +269,10 @@ func (r *Runner) validate(ctx context.Context, id int64, stats *Stats) (db.GetRe
 // all of its reminders, because a partial result would need a second delivery
 // ledger to describe and nothing reads one.
 func (r *Runner) deliverBatch(ctx context.Context, b *batch, stats *Stats) {
-	delivered, failedErr := r.deliverChannels(ctx, b.info, b.msgs)
+	sent, failedErr := r.deliverChannels(ctx, b.info, b.msgs)
 
 	switch {
-	case delivered:
+	case sent > 0:
 		if failedErr != nil {
 			// One channel delivered but another errored: the batch is done (a
 			// one-shot nudge needs only one channel), but surface the broken channel
@@ -288,7 +288,7 @@ func (r *Runner) deliverBatch(ctx context.Context, b *batch, stats *Stats) {
 		}
 		r.recordNotification(ctx, b)
 		stats.Delivered += len(b.ids)
-		stats.Messages++
+		stats.Messages += sent
 	case failedErr != nil:
 		log.Printf("reminder: deliver batch for user %d: %v", b.info.UserID, failedErr)
 		for _, id := range b.ids {
@@ -312,12 +312,13 @@ func (r *Runner) deliverBatch(ctx context.Context, b *batch, stats *Stats) {
 }
 
 // deliverChannels attempts each of the account's channels that has a usable
-// destination, sending the whole batch as one message per channel. It reports
-// whether at least one send succeeded and the last hard error (a channel with no
+// destination, sending the whole batch as one message per channel. It reports HOW MANY
+// messages landed — a batch on email and Telegram is two, and the pass summary would
+// undercount if this were a bool — and the last hard error (a channel with no
 // destination or no notifier is a soft-skip, not an error). One successful channel
-// makes the batch delivered — a co-channel outage just misses that channel for
-// these one-shot nudges.
-func (r *Runner) deliverChannels(ctx context.Context, info db.GetReminderForDeliveryRow, msgs []ReminderMessage) (delivered bool, failedErr error) {
+// makes the batch delivered — a co-channel outage just misses that channel for these
+// one-shot nudges.
+func (r *Runner) deliverChannels(ctx context.Context, info db.GetReminderForDeliveryRow, msgs []ReminderMessage) (sent int, failedErr error) {
 	for _, ch := range info.Channels {
 		dest, ok := recipient(ch, info)
 		if !ok {
@@ -338,9 +339,9 @@ func (r *Runner) deliverChannels(ctx context.Context, info db.GetReminderForDeli
 			failedErr = err
 			continue
 		}
-		delivered = true
+		sent++
 	}
-	return delivered, failedErr
+	return sent, failedErr
 }
 
 // unlinkTelegram forgets a user's Telegram chat after a send reported it

--- a/internal/engage/reminder/engine_test.go
+++ b/internal/engage/reminder/engine_test.go
@@ -2,6 +2,8 @@ package reminder
 
 import (
 	"context"
+	"encoding/json"
+	"strconv"
 	"testing"
 	"time"
 
@@ -62,14 +64,17 @@ func (s *fakeStore) RecordNotification(_ context.Context, arg db.RecordNotificat
 // fakeNotifier records deliveries and can be told to fail.
 type fakeNotifier struct {
 	sent []string // "channel:dest"
-	err  error
+	// groups is the message list of each recorded send, so a test can assert what
+	// a delivery carried and not only that it happened.
+	groups [][]ReminderMessage
+	err    error
 	// errByChannel fails only the named channels, so a test can model one channel
 	// dying while another lands — which is the whole point of a multi-channel
 	// reminder and the case a blanket err cannot express.
 	errByChannel map[string]error
 }
 
-func (n *fakeNotifier) Send(_ context.Context, channel, dest string, _ ReminderMessage) error {
+func (n *fakeNotifier) Send(_ context.Context, channel, dest string, ms []ReminderMessage) error {
 	if err, ok := n.errByChannel[channel]; ok {
 		return err
 	}
@@ -77,6 +82,7 @@ func (n *fakeNotifier) Send(_ context.Context, channel, dest string, _ ReminderM
 		return n.err
 	}
 	n.sent = append(n.sent, channel+":"+dest)
+	n.groups = append(n.groups, ms)
 	return nil
 }
 
@@ -89,6 +95,17 @@ func actionableRow(id int64, channels []string, chatID *int64, email string) db.
 	if chatID != nil {
 		row.TelegramChatID = pgtype.Int8{Int64: *chatID, Valid: true}
 	}
+	return row
+}
+
+// ownedBy is actionableRow's multi-account variant: the same deliverable row, but
+// belonging to userID and naming its own job, so a test can put two accounts in one
+// pass.
+func ownedBy(id, userID int64, channels []string, email string) db.GetReminderForDeliveryRow {
+	row := actionableRow(id, channels, nil, email)
+	row.UserID = userID
+	row.Title = "Job " + strconv.FormatInt(id, 10)
+	row.PublicSlug = "job-" + strconv.FormatInt(id, 10)
 	return row
 }
 
@@ -197,6 +214,153 @@ func TestRun_RecordsFailureOnDeliveryError(t *testing.T) {
 	}
 	if stats.Failed != 1 {
 		t.Errorf("stats.Failed = %d, want 1", stats.Failed)
+	}
+}
+
+// The change's whole point: a day's saves become one message, not one each.
+func TestRun_GroupsOneAccountsRemindersIntoOneSend(t *testing.T) {
+	store := &fakeStore{
+		due: []int64{1, 2, 3},
+		rows: map[int64]db.GetReminderForDeliveryRow{
+			1: ownedBy(1, 42, []string{"email"}, "a@b.c"),
+			2: ownedBy(2, 42, []string{"email"}, "a@b.c"),
+			3: ownedBy(3, 42, []string{"email"}, "a@b.c"),
+		},
+	}
+	notifier := &fakeNotifier{}
+	stats := run(t, store, notifier)
+
+	if len(notifier.sent) != 1 {
+		t.Fatalf("sent = %v, want exactly one message for one account", notifier.sent)
+	}
+	if got := notifier.groups[0]; len(got) != 3 {
+		t.Errorf("the message carried %d jobs, want 3", len(got))
+	}
+	if len(store.delivered) != 3 {
+		t.Errorf("delivered = %v, want all three reminders stamped", store.delivered)
+	}
+	if stats.Delivered != 3 {
+		t.Errorf("stats.Delivered = %d, want 3 — the counter stays per reminder", stats.Delivered)
+	}
+}
+
+// Grouping must not leak one account's saved jobs into another's message.
+func TestRun_DifferentAccountsGetTheirOwnSend(t *testing.T) {
+	store := &fakeStore{
+		due: []int64{1, 2},
+		rows: map[int64]db.GetReminderForDeliveryRow{
+			1: ownedBy(1, 42, []string{"email"}, "a@b.c"),
+			2: ownedBy(2, 77, []string{"email"}, "x@y.z"),
+		},
+	}
+	notifier := &fakeNotifier{}
+	run(t, store, notifier)
+
+	if len(notifier.sent) != 2 {
+		t.Fatalf("sent = %v, want one message per account", notifier.sent)
+	}
+	for i, group := range notifier.groups {
+		if len(group) != 1 {
+			t.Errorf("group %d carried %d jobs, want 1", i, len(group))
+		}
+	}
+}
+
+// A reminder that lost its intent leaves the batch; the rest still go out together.
+func TestRun_CancelledReminderLeavesTheGroup(t *testing.T) {
+	stale := ownedBy(2, 42, []string{"email"}, "a@b.c")
+	stale.StillActionable = false
+	store := &fakeStore{
+		due: []int64{1, 2, 3},
+		rows: map[int64]db.GetReminderForDeliveryRow{
+			1: ownedBy(1, 42, []string{"email"}, "a@b.c"),
+			2: stale,
+			3: ownedBy(3, 42, []string{"email"}, "a@b.c"),
+		},
+	}
+	notifier := &fakeNotifier{}
+	stats := run(t, store, notifier)
+
+	if len(store.cancelled) != 1 || store.cancelled[0] != 2 {
+		t.Errorf("cancelled = %v, want [2]", store.cancelled)
+	}
+	if len(notifier.groups) != 1 || len(notifier.groups[0]) != 2 {
+		t.Fatalf("groups = %v, want one message carrying the two survivors", notifier.groups)
+	}
+	if stats.Delivered != 2 || stats.Cancelled != 1 {
+		t.Errorf("stats = %+v, want Delivered=2 Cancelled=1", stats)
+	}
+}
+
+// The group is the retry unit: a failed send costs every member an attempt, so the
+// whole batch comes back on a later pass rather than half of it going missing.
+func TestRun_FailedGroupRecordsFailureForEveryMember(t *testing.T) {
+	store := &fakeStore{
+		due: []int64{1, 2},
+		rows: map[int64]db.GetReminderForDeliveryRow{
+			1: ownedBy(1, 42, []string{"email"}, "a@b.c"),
+			2: ownedBy(2, 42, []string{"email"}, "a@b.c"),
+		},
+	}
+	stats := run(t, store, &fakeNotifier{err: context.DeadlineExceeded})
+
+	if len(store.failed) != 2 {
+		t.Errorf("failed = %v, want an attempt recorded against both members", store.failed)
+	}
+	if len(store.delivered) != 0 {
+		t.Errorf("delivered = %v, want none", store.delivered)
+	}
+	if stats.Failed != 2 {
+		t.Errorf("stats.Failed = %d, want 2", stats.Failed)
+	}
+}
+
+// A multi-job group has no single slug to point at, so it records the job list the
+// notification center's /jobs page renders — the shape a subscription digest uses.
+func TestRun_MultiJobGroupRecordsOneListNotification(t *testing.T) {
+	store := &fakeStore{
+		due: []int64{1, 2},
+		rows: map[int64]db.GetReminderForDeliveryRow{
+			1: ownedBy(1, 42, []string{"email"}, "a@b.c"),
+			2: ownedBy(2, 42, []string{"email"}, "a@b.c"),
+		},
+	}
+	run(t, store, &fakeNotifier{})
+
+	if len(store.recorded) != 1 {
+		t.Fatalf("recorded = %v, want exactly one notification for the group", store.recorded)
+	}
+	rec := store.recorded[0]
+	if rec.PublicSlug.Valid {
+		t.Errorf("PublicSlug = %+v, want unset for a multi-job group", rec.PublicSlug)
+	}
+	var jobs []struct {
+		Title   string `json:"title"`
+		Company string `json:"company"`
+		Slug    string `json:"slug"`
+	}
+	if err := json.Unmarshal(rec.Jobs, &jobs); err != nil {
+		t.Fatalf("Jobs is not a job list: %v (raw %s)", err, rec.Jobs)
+	}
+	if len(jobs) != 2 || jobs[0].Slug != "job-1" || jobs[1].Slug != "job-2" {
+		t.Errorf("Jobs = %+v, want both saved jobs in claim order", jobs)
+	}
+}
+
+// A group of one is the message and the record we already shipped.
+func TestRun_SingleJobGroupKeepsTheSlugRecord(t *testing.T) {
+	store := &fakeStore{
+		due:  []int64{1},
+		rows: map[int64]db.GetReminderForDeliveryRow{1: ownedBy(1, 42, []string{"email"}, "a@b.c")},
+	}
+	run(t, store, &fakeNotifier{})
+
+	rec := store.recorded[0]
+	if !rec.PublicSlug.Valid || rec.PublicSlug.String != "job-1" {
+		t.Errorf("PublicSlug = %+v, want the single job's slug", rec.PublicSlug)
+	}
+	if rec.Jobs != nil {
+		t.Errorf("Jobs = %s, want unset for a single-job group", rec.Jobs)
 	}
 }
 

--- a/internal/engage/reminder/engine_test.go
+++ b/internal/engage/reminder/engine_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/strelov1/freehire/internal/engage/notify"
 	"github.com/strelov1/freehire/internal/platform/db"
 )
 
@@ -334,11 +335,10 @@ func TestRun_MultiJobGroupRecordsOneListNotification(t *testing.T) {
 	if rec.PublicSlug.Valid {
 		t.Errorf("PublicSlug = %+v, want unset for a multi-job group", rec.PublicSlug)
 	}
-	var jobs []struct {
-		Title   string `json:"title"`
-		Company string `json:"company"`
-		Slug    string `json:"slug"`
-	}
+	// Unmarshalled into the SHARED shape, not a local copy of it: the column's
+	// contract is notify.SnapshotJob, and a private struct here would keep passing
+	// while the two drifted apart.
+	var jobs []notify.SnapshotJob
 	if err := json.Unmarshal(rec.Jobs, &jobs); err != nil {
 		t.Fatalf("Jobs is not a job list: %v (raw %s)", err, rec.Jobs)
 	}

--- a/internal/engage/reminder/engine_test.go
+++ b/internal/engage/reminder/engine_test.go
@@ -364,6 +364,111 @@ func TestRun_SingleJobGroupKeepsTheSlugRecord(t *testing.T) {
 	}
 }
 
+// job_reminders snapshots the channel set at schedule time (migration 0034), so two
+// reminders of one account can carry different sets. Merging them would send one over
+// the other's channels and stamp it delivered anyway.
+func TestRun_DifferentChannelSetsAreNotMerged(t *testing.T) {
+	both := ownedBy(2, 42, []string{"email", "telegram"}, "a@b.c")
+	both.TelegramChatID = pgtype.Int8{Int64: 555, Valid: true}
+	store := &fakeStore{
+		due: []int64{1, 2},
+		rows: map[int64]db.GetReminderForDeliveryRow{
+			1: ownedBy(1, 42, []string{"email"}, "a@b.c"),
+			2: both,
+		},
+	}
+	notifier := &fakeNotifier{}
+	run(t, store, notifier)
+
+	// One message for the email-only reminder, two for the one that also wants
+	// Telegram — three sends, and never a job in a message it did not belong to.
+	if len(notifier.sent) != 3 {
+		t.Fatalf("sent = %v, want the two channel sets kept apart", notifier.sent)
+	}
+	for i, group := range notifier.groups {
+		if len(group) != 1 {
+			t.Errorf("group %d carried %d jobs, want 1", i, len(group))
+		}
+	}
+}
+
+// The same account's reminders group even when their channel sets were stored in a
+// different order — the key is the SET, not the slice.
+func TestRun_ChannelOrderDoesNotSplitTheGroup(t *testing.T) {
+	second := ownedBy(2, 42, []string{"telegram", "email"}, "a@b.c")
+	second.TelegramChatID = pgtype.Int8{Int64: 555, Valid: true}
+	first := ownedBy(1, 42, []string{"email", "telegram"}, "a@b.c")
+	first.TelegramChatID = pgtype.Int8{Int64: 555, Valid: true}
+	store := &fakeStore{
+		due:  []int64{1, 2},
+		rows: map[int64]db.GetReminderForDeliveryRow{1: first, 2: second},
+	}
+	notifier := &fakeNotifier{}
+	run(t, store, notifier)
+
+	// One batch, delivered over both of its channels.
+	if len(notifier.groups) != 2 {
+		t.Fatalf("sent = %v, want one batch over two channels", notifier.sent)
+	}
+	for i, group := range notifier.groups {
+		if len(group) != 2 {
+			t.Errorf("group %d carried %d jobs, want both", i, len(group))
+		}
+	}
+}
+
+// Beyond SnapshotCap the excess is RELEASED, never stamped: a reminder marked
+// delivered while appearing in no message is gone for good.
+func TestRun_BatchOverflowIsReleasedNotDelivered(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.SnapshotCap = 2
+	store := &fakeStore{
+		due: []int64{1, 2, 3, 4},
+		rows: map[int64]db.GetReminderForDeliveryRow{
+			1: ownedBy(1, 42, []string{"email"}, "a@b.c"),
+			2: ownedBy(2, 42, []string{"email"}, "a@b.c"),
+			3: ownedBy(3, 42, []string{"email"}, "a@b.c"),
+			4: ownedBy(4, 42, []string{"email"}, "a@b.c"),
+		},
+	}
+	notifier := &fakeNotifier{}
+	r := NewRunner(store, notifier, cfg)
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(notifier.groups) != 1 || len(notifier.groups[0]) != 2 {
+		t.Fatalf("groups = %v, want one message carrying the cap", notifier.groups)
+	}
+	if len(store.delivered) != 2 {
+		t.Errorf("delivered = %v, want only what the message carried", store.delivered)
+	}
+	if len(store.released) != 2 || len(store.failed) != 0 {
+		t.Errorf("released = %v failed = %v, want the overflow released and no attempt burnt", store.released, store.failed)
+	}
+	if stats.Deferred != 2 {
+		t.Errorf("stats.Deferred = %d, want the 2 overflow reminders counted", stats.Deferred)
+	}
+}
+
+// A hand-built Config with no SnapshotCap would make every batch full at zero
+// members: nothing delivered, nothing failed, forever.
+func TestNewRunner_ZeroSnapshotCapDoesNotStallDelivery(t *testing.T) {
+	store := &fakeStore{
+		due:  []int64{1},
+		rows: map[int64]db.GetReminderForDeliveryRow{1: ownedBy(1, 42, []string{"email"}, "a@b.c")},
+	}
+	notifier := &fakeNotifier{}
+	r := NewRunner(store, notifier, Config{LeaseSeconds: 600, ClaimBatch: 500, MaxAttempts: 5})
+	if _, err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(store.delivered) != 1 {
+		t.Errorf("delivered = %v, want the reminder delivered despite an unset SnapshotCap", store.delivered)
+	}
+}
+
 func TestRecipient_Push(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/engage/reminder/push.go
+++ b/internal/engage/reminder/push.go
@@ -2,6 +2,7 @@ package reminder
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -32,10 +33,14 @@ func NewPushNotifier(tokens PushTokenLister, transport pushnotify.Notifier) *Pus
 	return &PushNotifier{tokens: tokens, transport: transport}
 }
 
-// Send renders the reminder and fans it out to every device registered for the
-// user encoded in dest (see recipient()'s ChannelPush case). The channel argument
-// is ignored — this notifier only serves the push channel.
-func (n *PushNotifier) Send(ctx context.Context, _ string, dest string, m ReminderMessage) error {
+// Send renders the account's batch as ONE notification and fans it out to every
+// device registered for the user encoded in dest (see recipient()'s ChannelPush
+// case). The channel argument is ignored — this notifier only serves the push
+// channel.
+func (n *PushNotifier) Send(ctx context.Context, _ string, dest string, ms []ReminderMessage) error {
+	if len(ms) == 0 {
+		return nil
+	}
 	userID, err := strconv.ParseInt(dest, 10, 64)
 	if err != nil {
 		return fmt.Errorf("reminder: invalid push user id %q: %w", dest, err)
@@ -49,18 +54,55 @@ func (n *PushNotifier) Send(ctx context.Context, _ string, dest string, m Remind
 		tokens[i] = row.Token
 	}
 
-	title, body := renderReminder(m)
-	// A reminder always concerns exactly one job, so the deep-link data is
-	// unconditional here — unlike a subscription digest, which only carries a
-	// slug when it matched a single job.
-	data := map[string]string{"slug": m.Slug}
+	title, body := renderReminderBatch(ms)
+	// The deep link needs one destination, so it is carried only when the batch
+	// names one job — the same rule a subscription digest follows.
+	var data map[string]string
+	if len(ms) == 1 {
+		data = map[string]string{"slug": ms[0].Slug}
+	}
 	return pushnotify.SendToDevices(ctx, n.transport, tokens, title, body, data)
 }
 
-// renderReminder produces the short, human-readable title/body for a reminder,
-// shared by the push channel's own copy and the notification-center record — both
-// need the identical wording for the same delivery event (see the
-// add-notification-center design).
+// renderReminderBatch produces the short, human-readable title/body for one
+// account's batch, shared by the push channel's own copy and the
+// notification-center record — both need the identical wording for the same
+// delivery event (see the add-notification-center design).
+func renderReminderBatch(ms []ReminderMessage) (title, body string) {
+	if len(ms) == 1 {
+		return renderReminder(ms[0])
+	}
+	return "⏰ Reminder", fmt.Sprintf("You saved %d jobs and haven't applied yet — still interested?", len(ms))
+}
+
+// renderReminder is the single-job wording, kept as its own function because it is
+// the one a batch of one must be indistinguishable from.
 func renderReminder(m ReminderMessage) (title, body string) {
 	return "⏰ Reminder", fmt.Sprintf("You saved %s at %s — still interested?", m.JobTitle, m.Company)
+}
+
+// jobSnapshot is the {title, company, slug} shape user_notifications.jobs holds.
+// It matches internal/engage/notify's, because one page renders both.
+type jobSnapshot struct {
+	Title   string `json:"title"`
+	Company string `json:"company"`
+	Slug    string `json:"slug"`
+}
+
+// jobsSnapshot is the job list a multi-job batch records for its notification's
+// own page. It applies no bound of its own — the batch was capped at
+// Config.SnapshotCap before it was ever sent, so what was delivered and what the
+// record holds cannot disagree.
+func jobsSnapshot(ms []ReminderMessage) json.RawMessage {
+	jobs := make([]jobSnapshot, len(ms))
+	for i, m := range ms {
+		jobs[i] = jobSnapshot{Title: m.JobTitle, Company: m.Company, Slug: m.Slug}
+	}
+	raw, err := json.Marshal(jobs)
+	if err != nil {
+		// Every field is a plain string; Marshal only fails on unsupported types
+		// (channels, funcs, cyclic refs), none of which jobSnapshot has.
+		panic(fmt.Sprintf("reminder: marshal jobs snapshot: %v", err))
+	}
+	return raw
 }

--- a/internal/engage/reminder/push.go
+++ b/internal/engage/reminder/push.go
@@ -2,11 +2,9 @@ package reminder
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strconv"
 
-	"github.com/strelov1/freehire/internal/engage/notify"
 	"github.com/strelov1/freehire/internal/engage/pushnotify"
 	"github.com/strelov1/freehire/internal/platform/db"
 )
@@ -80,14 +78,4 @@ func renderReminderBatch(ms []ReminderMessage) (title, body string) {
 // the one a batch of one must be indistinguishable from.
 func renderReminder(m ReminderMessage) (title, body string) {
 	return "⏰ Reminder", fmt.Sprintf("You saved %s at %s — still interested?", m.JobTitle, m.Company)
-}
-
-// jobsSnapshot is the job list a multi-job batch records for its notification's own
-// page, in the shape notify owns because one page renders every engine's rows.
-func jobsSnapshot(ms []ReminderMessage) json.RawMessage {
-	jobs := make([]notify.SnapshotJob, len(ms))
-	for i, m := range ms {
-		jobs[i] = notify.SnapshotJob{Title: m.JobTitle, Company: m.Company, Slug: m.Slug}
-	}
-	return notify.JobsSnapshot(jobs)
 }

--- a/internal/engage/reminder/push.go
+++ b/internal/engage/reminder/push.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/strelov1/freehire/internal/engage/notify"
 	"github.com/strelov1/freehire/internal/engage/pushnotify"
 	"github.com/strelov1/freehire/internal/platform/db"
 )
@@ -81,28 +82,12 @@ func renderReminder(m ReminderMessage) (title, body string) {
 	return "⏰ Reminder", fmt.Sprintf("You saved %s at %s — still interested?", m.JobTitle, m.Company)
 }
 
-// jobSnapshot is the {title, company, slug} shape user_notifications.jobs holds.
-// It matches internal/engage/notify's, because one page renders both.
-type jobSnapshot struct {
-	Title   string `json:"title"`
-	Company string `json:"company"`
-	Slug    string `json:"slug"`
-}
-
-// jobsSnapshot is the job list a multi-job batch records for its notification's
-// own page. It applies no bound of its own — the batch was capped at
-// Config.SnapshotCap before it was ever sent, so what was delivered and what the
-// record holds cannot disagree.
+// jobsSnapshot is the job list a multi-job batch records for its notification's own
+// page, in the shape notify owns because one page renders every engine's rows.
 func jobsSnapshot(ms []ReminderMessage) json.RawMessage {
-	jobs := make([]jobSnapshot, len(ms))
+	jobs := make([]notify.SnapshotJob, len(ms))
 	for i, m := range ms {
-		jobs[i] = jobSnapshot{Title: m.JobTitle, Company: m.Company, Slug: m.Slug}
+		jobs[i] = notify.SnapshotJob{Title: m.JobTitle, Company: m.Company, Slug: m.Slug}
 	}
-	raw, err := json.Marshal(jobs)
-	if err != nil {
-		// Every field is a plain string; Marshal only fails on unsupported types
-		// (channels, funcs, cyclic refs), none of which jobSnapshot has.
-		panic(fmt.Sprintf("reminder: marshal jobs snapshot: %v", err))
-	}
-	return raw
+	return notify.JobsSnapshot(jobs)
 }

--- a/internal/engage/reminder/push_test.go
+++ b/internal/engage/reminder/push_test.go
@@ -3,6 +3,7 @@ package reminder
 import (
 	"context"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/strelov1/freehire/internal/platform/db"
@@ -44,7 +45,7 @@ func TestPushNotifier_RendersTitleBodyAndSlugDataToEveryDevice(t *testing.T) {
 	n := NewPushNotifier(lister, transport)
 	msg := ReminderMessage{JobTitle: "Go Dev", Company: "Acme", Slug: "go-dev-acme", URL: "https://ats/x"}
 
-	if err := n.Send(context.Background(), "push", strconv.FormatInt(42, 10), msg); err != nil {
+	if err := n.Send(context.Background(), "push", strconv.FormatInt(42, 10), []ReminderMessage{msg}); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 
@@ -71,7 +72,7 @@ func TestPushNotifier_RendersTitleBodyAndSlugDataToEveryDevice(t *testing.T) {
 
 func TestPushNotifier_InvalidUserIDErrors(t *testing.T) {
 	n := NewPushNotifier(&fakePushTokenLister{}, &fakePushTransport{})
-	if err := n.Send(context.Background(), "push", "not-a-number", ReminderMessage{}); err == nil {
+	if err := n.Send(context.Background(), "push", "not-a-number", []ReminderMessage{{Slug: "s"}}); err == nil {
 		t.Error("want an error for a non-numeric user id")
 	}
 }
@@ -81,7 +82,33 @@ func TestPushNotifier_NoDevicesReturnsAnError(t *testing.T) {
 	// this is a defense-in-depth path, not the normal soft-skip — but the fan-out
 	// helper still reports it as an error (SendToDevices' empty-tokens rule).
 	n := NewPushNotifier(&fakePushTokenLister{}, &fakePushTransport{})
-	if err := n.Send(context.Background(), "push", "42", ReminderMessage{Slug: "s"}); err == nil {
+	if err := n.Send(context.Background(), "push", "42", []ReminderMessage{{Slug: "s"}}); err == nil {
 		t.Error("want an error when the user has no registered devices")
+	}
+}
+
+// A batch is one notification, not one per saved job — the whole point of the
+// grouping. The deep link is dropped because several jobs have no one destination.
+func TestPushNotifier_BatchIsOneNotificationWithoutADeepLink(t *testing.T) {
+	lister := &fakePushTokenLister{tokens: map[int64][]db.UserPushToken{42: {{Token: "tok-1"}}}}
+	transport := &fakePushTransport{}
+	n := NewPushNotifier(lister, transport)
+
+	err := n.Send(context.Background(), "push", "42", []ReminderMessage{
+		{JobTitle: "Go Dev", Company: "Acme", Slug: "go-dev-acme"},
+		{JobTitle: "SRE", Company: "Globex", Slug: "sre-globex"},
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(transport.calls) != 1 {
+		t.Fatalf("transport calls = %d, want 1 for one device and one batch", len(transport.calls))
+	}
+	call := transport.calls[0]
+	if !strings.Contains(call.body, "2 jobs") {
+		t.Errorf("body = %q, want the batch count", call.body)
+	}
+	if call.data["slug"] != "" {
+		t.Errorf("data[slug] = %q, want no deep link for a multi-job batch", call.data["slug"])
 	}
 }

--- a/internal/engage/reminder/reminder.go
+++ b/internal/engage/reminder/reminder.go
@@ -22,6 +22,12 @@ import (
 // usage check found no account other than the developer's had ever touched it).
 const DefaultDelayDays = 3
 
+// DefaultNotificationHour is the local time of day a reminder fires for an account
+// that has never chosen one. Reminders are rounded forward to this hour so that
+// everything saved on one day becomes due in a single worker pass and goes out as
+// one message — see the aggregate-reminder-and-nudge-digests change.
+const DefaultNotificationHour = 9 * time.Hour
+
 // Sentinel errors mapped to HTTP statuses by the handler.
 var (
 	// ErrInvalidChannel is an unsupported delivery channel (mapped to 400).
@@ -51,11 +57,39 @@ type Settings struct {
 	QuietHoursEnd   *time.Duration
 }
 
+// ScheduleContext is when an account wants to hear from us: the daily notification
+// hour and the timezone that hour is read in. Both are optional, and a nil is the
+// unconfigured state rather than a zero — midnight is a choosable hour, so it
+// cannot double as "never chose one".
+type ScheduleContext struct {
+	NotificationHour *time.Duration
+	Location         *time.Location
+}
+
+// hour is the configured notification hour, or the default when unset.
+func (c ScheduleContext) hour() time.Duration {
+	if c.NotificationHour == nil {
+		return DefaultNotificationHour
+	}
+	return *c.NotificationHour
+}
+
+// location is the account's timezone, or UTC when unset — the same fallback
+// internal/application/deliverywindow applies to quiet hours, so the two timing
+// rules agree about who has no timezone.
+func (c ScheduleContext) location() *time.Location {
+	if c.Location == nil {
+		return time.UTC
+	}
+	return c.Location
+}
+
 // Repository is the persistence contract. The adapter maps the generated db rows;
 // GetSettings returns the default (not an error) when no row exists.
 type Repository interface {
 	GetSettings(ctx context.Context, userID int64) (Settings, error)
 	UpsertSettings(ctx context.Context, userID int64, s Settings) (Settings, error)
+	GetScheduleContext(ctx context.Context, userID int64) (ScheduleContext, error)
 	UpsertReminder(ctx context.Context, userID, jobID int64, fireAt time.Time, channels []string) error
 	CancelReminder(ctx context.Context, userID, jobID int64) error
 }
@@ -120,7 +154,11 @@ func (s *Service) ScheduleOnSave(ctx context.Context, userID, jobID int64) error
 	if len(channels) == 0 {
 		channels = []string{notify.ChannelEmail}
 	}
-	return s.repo.UpsertReminder(ctx, userID, jobID, s.fireAt(DefaultDelayDays), channels)
+	fireAt, err := s.fireAt(ctx, userID, DefaultDelayDays)
+	if err != nil {
+		return err
+	}
+	return s.repo.UpsertReminder(ctx, userID, jobID, fireAt, channels)
 }
 
 // Cancel drops the pending reminder for a (user, job), idempotently — the eager
@@ -129,7 +167,35 @@ func (s *Service) Cancel(ctx context.Context, userID, jobID int64) error {
 	return s.repo.CancelReminder(ctx, userID, jobID)
 }
 
-// fireAt is the deadline `delayDays` out from now.
-func (s *Service) fireAt(delayDays int) time.Time {
-	return s.now().Add(time.Duration(delayDays) * 24 * time.Hour)
+// fireAt is the deadline `delayDays` out from now, rounded forward to the
+// account's notification hour. The rounding is what makes a day's saves arrive as
+// one message: two reminders scheduled hours apart land on the same instant, so
+// one worker pass claims both and the engine groups them.
+func (s *Service) fireAt(ctx context.Context, userID int64, delayDays int) (time.Time, error) {
+	deadline := s.now().Add(time.Duration(delayDays) * 24 * time.Hour)
+	sc, err := s.repo.GetScheduleContext(ctx, userID)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return nextNotificationHour(deadline, sc.hour(), sc.location()), nil
+}
+
+// nextNotificationHour is the first wall-clock occurrence of `hour` in `loc` at or
+// after `after` — never earlier, so rounding cannot pull a reminder in ahead of its
+// delay.
+//
+// Built by naming the hour to time.Date rather than by adding `hour` to local
+// midnight: on the two days a year the offset moves, midnight+18h is 17:00 or
+// 19:00, and the account asked for 18:00 on its own clock.
+func nextNotificationHour(after time.Time, hour time.Duration, loc *time.Location) time.Time {
+	y, mo, d := after.In(loc).Date()
+	h := int(hour / time.Hour)
+	m := int(hour % time.Hour / time.Minute)
+	sec := int(hour % time.Minute / time.Second)
+
+	candidate := time.Date(y, mo, d, h, m, sec, 0, loc)
+	if candidate.Before(after) {
+		candidate = time.Date(y, mo, d+1, h, m, sec, 0, loc)
+	}
+	return candidate
 }

--- a/internal/engage/reminder/reminder_test.go
+++ b/internal/engage/reminder/reminder_test.go
@@ -11,6 +11,8 @@ import (
 type fakeRepo struct {
 	settings    Settings
 	settingsErr error
+	schedule    ScheduleContext
+	scheduleErr error
 
 	upserted  []upsertCall
 	cancelled []jobKey
@@ -30,6 +32,9 @@ func (f *fakeRepo) UpsertSettings(_ context.Context, _ int64, s Settings) (Setti
 	f.settings = s
 	return s, nil
 }
+func (f *fakeRepo) GetScheduleContext(_ context.Context, _ int64) (ScheduleContext, error) {
+	return f.schedule, f.scheduleErr
+}
 func (f *fakeRepo) UpsertReminder(_ context.Context, userID, jobID int64, fireAt time.Time, channels []string) error {
 	f.upserted = append(f.upserted, upsertCall{userID, jobID, fireAt, channels})
 	return nil
@@ -38,6 +43,9 @@ func (f *fakeRepo) CancelReminder(_ context.Context, userID, jobID int64) error 
 	f.cancelled = append(f.cancelled, jobKey{userID, jobID})
 	return nil
 }
+
+// durPtr is the test-side spelling of an optional duration setting.
+func durPtr(d time.Duration) *time.Duration { return &d }
 
 // fixedClock is a deterministic now() for fire-time assertions.
 var fixedNow = time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
@@ -48,7 +56,9 @@ func newService(repo *fakeRepo) *Service {
 	return s
 }
 
-func TestScheduleOnSave_UsesFixedDelay(t *testing.T) {
+// An unconfigured account rounds to the DefaultNotificationHour in UTC: the delay
+// lands at 12:00 on 22 July, and the first 09:00 at or after that is the 23rd.
+func TestScheduleOnSave_RoundsToTheDefaultNotificationHour(t *testing.T) {
 	repo := &fakeRepo{settings: Settings{Enabled: true, Channels: []string{"telegram"}}}
 	svc := newService(repo)
 
@@ -59,12 +69,86 @@ func TestScheduleOnSave_UsesFixedDelay(t *testing.T) {
 		t.Fatalf("want 1 upsert, got %d", len(repo.upserted))
 	}
 	got := repo.upserted[0]
-	want := fixedNow.Add(DefaultDelayDays * 24 * time.Hour)
+	want := time.Date(2026, 7, 23, 9, 0, 0, 0, time.UTC)
 	if !got.fireAt.Equal(want) {
 		t.Errorf("fireAt = %v, want %v", got.fireAt, want)
 	}
 	if got.userID != 7 || got.jobID != 42 {
 		t.Errorf("upsert key = (%d,%d), want (7,42)", got.userID, got.jobID)
+	}
+}
+
+// The configured hour is read in the account's own zone, not in UTC: 12:00 UTC on
+// the 22nd is 14:00 in Berlin, so that same day's 18:00 Berlin (16:00 UTC) is the
+// first notification hour at or after the delay.
+func TestScheduleOnSave_RoundsToTheConfiguredHourInTheAccountZone(t *testing.T) {
+	berlin, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+	repo := &fakeRepo{
+		settings: Settings{Enabled: true, Channels: []string{"email"}},
+		schedule: ScheduleContext{NotificationHour: durPtr(18 * time.Hour), Location: berlin},
+	}
+	svc := newService(repo)
+
+	if err := svc.ScheduleOnSave(context.Background(), 7, 42); err != nil {
+		t.Fatalf("ScheduleOnSave: %v", err)
+	}
+	want := time.Date(2026, 7, 22, 18, 0, 0, 0, berlin)
+	if got := repo.upserted[0].fireAt; !got.Equal(want) {
+		t.Errorf("fireAt = %v, want %v", got, want)
+	}
+}
+
+// The point of the rounding: saves hours apart on one day become one delivery.
+func TestScheduleOnSave_SameDaySavesShareOneFireTime(t *testing.T) {
+	repo := &fakeRepo{settings: Settings{Enabled: true, Channels: []string{"email"}}}
+	svc := newService(repo)
+
+	svc.now = func() time.Time { return time.Date(2026, 7, 19, 10, 14, 0, 0, time.UTC) }
+	if err := svc.ScheduleOnSave(context.Background(), 7, 1); err != nil {
+		t.Fatalf("ScheduleOnSave: %v", err)
+	}
+	svc.now = func() time.Time { return time.Date(2026, 7, 19, 23, 41, 0, 0, time.UTC) }
+	if err := svc.ScheduleOnSave(context.Background(), 7, 2); err != nil {
+		t.Fatalf("ScheduleOnSave: %v", err)
+	}
+
+	if len(repo.upserted) != 2 {
+		t.Fatalf("want 2 upserts, got %d", len(repo.upserted))
+	}
+	if !repo.upserted[0].fireAt.Equal(repo.upserted[1].fireAt) {
+		t.Errorf("fire times diverged: %v vs %v", repo.upserted[0].fireAt, repo.upserted[1].fireAt)
+	}
+}
+
+// Rounding only ever moves forward — a reminder never fires before its delay.
+func TestScheduleOnSave_NeverFiresBeforeTheDelay(t *testing.T) {
+	repo := &fakeRepo{
+		settings: Settings{Enabled: true, Channels: []string{"email"}},
+		// An hour the delay lands exactly on, and one just before it: both must
+		// still be at or after now+delay.
+		schedule: ScheduleContext{NotificationHour: durPtr(12 * time.Hour), Location: time.UTC},
+	}
+	svc := newService(repo)
+	if err := svc.ScheduleOnSave(context.Background(), 7, 1); err != nil {
+		t.Fatalf("ScheduleOnSave: %v", err)
+	}
+	repo.schedule.NotificationHour = durPtr(11 * time.Hour)
+	if err := svc.ScheduleOnSave(context.Background(), 7, 2); err != nil {
+		t.Fatalf("ScheduleOnSave: %v", err)
+	}
+
+	earliest := fixedNow.Add(DefaultDelayDays * 24 * time.Hour)
+	for _, call := range repo.upserted {
+		if call.fireAt.Before(earliest) {
+			t.Errorf("fireAt %v is before the delay deadline %v", call.fireAt, earliest)
+		}
+	}
+	// The hour the delay lands exactly on is that instant, not the day after.
+	if got := repo.upserted[0].fireAt; !got.Equal(earliest) {
+		t.Errorf("fireAt = %v, want the delay deadline %v", got, earliest)
 	}
 }
 

--- a/internal/engage/reminder/repository.go
+++ b/internal/engage/reminder/repository.go
@@ -73,6 +73,24 @@ func (r *QueriesRepository) UpsertSettings(ctx context.Context, userID int64, s 
 	}, nil
 }
 
+// GetScheduleContext reads the account's notification hour and timezone. A NULL in
+// either column, and a timezone name this build's tzdata cannot resolve, are left
+// as nil for the service to read as unconfigured — a stale or misspelled zone name
+// must not stop a save from scheduling anything.
+func (r *QueriesRepository) GetScheduleContext(ctx context.Context, userID int64) (ScheduleContext, error) {
+	row, err := r.q.GetReminderScheduleContext(ctx, userID)
+	if err != nil {
+		return ScheduleContext{}, err
+	}
+	sc := ScheduleContext{NotificationHour: pgconv.DurationPtr(row.DigestTime)}
+	if row.Timezone.Valid {
+		if loc, err := time.LoadLocation(row.Timezone.String); err == nil {
+			sc.Location = loc
+		}
+	}
+	return sc, nil
+}
+
 // UpsertReminder schedules or replaces the pending reminder for a (user, job).
 func (r *QueriesRepository) UpsertReminder(ctx context.Context, userID, jobID int64, fireAt time.Time, channels []string) error {
 	_, err := r.q.UpsertJobReminder(ctx, db.UpsertJobReminderParams{

--- a/internal/engage/reminder/transports.go
+++ b/internal/engage/reminder/transports.go
@@ -26,18 +26,6 @@ var (
 	_ Notifier = (*EmailNotifier)(nil)
 )
 
-// listed splits a batch into the reminders a message itemizes and how many it only
-// counts. The bound is notify.ListLimit, shared with the subscription digest so the
-// two channels never disagree about how long a list may be; the batch itself is
-// bounded separately and much higher by Config.SnapshotCap, because the message is
-// short for readability while the record behind it is long by design.
-func listed(ms []ReminderMessage) (shown []ReminderMessage, more int) {
-	if len(ms) <= notify.ListLimit {
-		return ms, 0
-	}
-	return ms[:notify.ListLimit:notify.ListLimit], len(ms) - notify.ListLimit
-}
-
 // TelegramNotifier delivers an account's due reminders as one Telegram HTML
 // message, reusing the telegramnotify Bot API client. Links point at on-platform
 // job pages so the nudge keeps the user on freehire and never exposes a
@@ -92,7 +80,7 @@ func (n *TelegramNotifier) render(ms []ReminderMessage) string {
 
 	// The list bound picks the candidates; the length cap decides how many of them
 	// actually fit, so the tail is computed from what was written, not from it.
-	shown, _ := listed(ms)
+	shown, _ := notify.Listed(ms)
 	var b strings.Builder
 	fmt.Fprintf(&b, "⏰ You saved <b>%d</b> jobs and haven't applied yet.\n\n", len(ms))
 
@@ -196,7 +184,7 @@ func (n *EmailNotifier) Send(ctx context.Context, _ string, dest string, ms []Re
 	if len(ms) == 0 {
 		return nil
 	}
-	shown, more := listed(ms)
+	shown, more := notify.Listed(ms)
 	rows := make([]mailtpl.Job, 0, len(shown))
 	for _, m := range shown {
 		rows = append(rows, mailtpl.NewJob(m.JobTitle, m.Company, "", n.jobURL(m)))

--- a/internal/engage/reminder/transports.go
+++ b/internal/engage/reminder/transports.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/strelov1/freehire/internal/application/mailtpl"
 	"github.com/strelov1/freehire/internal/engage/emailnotify"
+	"github.com/strelov1/freehire/internal/engage/notify"
 	"github.com/strelov1/freehire/internal/engage/telegramnotify"
 )
 
@@ -25,9 +26,22 @@ var (
 	_ Notifier = (*EmailNotifier)(nil)
 )
 
-// TelegramNotifier delivers a reminder as a Telegram HTML message, reusing the
-// telegramnotify Bot API client. The link points at the on-platform job page so
-// the nudge keeps the user on freehire and never exposes a login-gated source URL.
+// listed splits a batch into the reminders a message itemizes and how many it only
+// counts. The bound is notify.ListLimit, shared with the subscription digest so the
+// two channels never disagree about how long a list may be; the batch itself is
+// bounded separately and much higher by Config.SnapshotCap, because the message is
+// short for readability while the record behind it is long by design.
+func listed(ms []ReminderMessage) (shown []ReminderMessage, more int) {
+	if len(ms) <= notify.ListLimit {
+		return ms, 0
+	}
+	return ms[:notify.ListLimit:notify.ListLimit], len(ms) - notify.ListLimit
+}
+
+// TelegramNotifier delivers an account's due reminders as one Telegram HTML
+// message, reusing the telegramnotify Bot API client. Links point at on-platform
+// job pages so the nudge keeps the user on freehire and never exposes a
+// login-gated source URL.
 type TelegramNotifier struct {
 	client     *telegramnotify.Client
 	jobBaseURL string
@@ -39,35 +53,105 @@ func NewTelegramNotifier(client *telegramnotify.Client, jobBaseURL string) *Tele
 	return &TelegramNotifier{client: client, jobBaseURL: strings.TrimRight(jobBaseURL, "/")}
 }
 
-// Send renders the reminder and posts it to the chat encoded in dest. The channel
+// Send renders the batch and posts it to the chat encoded in dest. The channel
 // argument is ignored — this notifier only serves the telegram channel.
 //
 // A 403 is translated to ErrRecipientGone, this engine's vocabulary for a chat
 // permanently closed to us, so the runner unlinks it instead of retrying a send
 // that cannot land. Same translation the digest and nudge notifiers do.
-func (n *TelegramNotifier) Send(ctx context.Context, _ string, dest string, m ReminderMessage) error {
+func (n *TelegramNotifier) Send(ctx context.Context, _ string, dest string, ms []ReminderMessage) error {
+	if len(ms) == 0 {
+		return nil
+	}
 	chatID, err := strconv.ParseInt(dest, 10, 64)
 	if err != nil {
 		return fmt.Errorf("reminder: invalid telegram chat id %q: %w", dest, err)
 	}
-	err = n.client.SendMessage(ctx, chatID, n.render(m))
+	err = n.client.SendMessage(ctx, chatID, n.render(ms))
 	if errors.Is(err, telegramnotify.ErrChatUnreachable) {
 		return fmt.Errorf("%w: %w", ErrRecipientGone, err)
 	}
 	return err
 }
 
-// render builds the HTML body. Title and company are user/source data and are
-// HTML-escaped; the freehire URL is our own and safe.
-func (n *TelegramNotifier) render(m ReminderMessage) string {
-	url := n.jobBaseURL + "/jobs/" + m.Slug
-	return fmt.Sprintf(
-		"⏰ Reminder: you saved <b>%s</b> at <b>%s</b>.\nStill interested? <a href=\"%s\">Open the job →</a>",
-		html.EscapeString(m.JobTitle), html.EscapeString(m.Company), url)
+// render builds the HTML body. Titles and companies are user/source data and are
+// HTML-escaped; the freehire URLs are our own and safe.
+//
+// A single reminder keeps the sentence it has always been. A batch becomes a list,
+// bounded twice: by notify.ListLimit for readability, and by Telegram's own
+// MaxMessageLen — lines are added only while the next one plus the widest possible
+// tail still fits, because an oversized body is rejected deterministically and
+// every retry re-fails.
+func (n *TelegramNotifier) render(ms []ReminderMessage) string {
+	if len(ms) == 1 {
+		m := ms[0]
+		return fmt.Sprintf(
+			"⏰ Reminder: you saved <b>%s</b> at <b>%s</b>.\nStill interested? <a href=%q>Open the job →</a>",
+			html.EscapeString(m.JobTitle), html.EscapeString(m.Company), n.jobURL(m))
+	}
+
+	// The list bound picks the candidates; the length cap decides how many of them
+	// actually fit, so the tail is computed from what was written, not from it.
+	shown, _ := listed(ms)
+	var b strings.Builder
+	fmt.Fprintf(&b, "⏰ You saved <b>%d</b> jobs and haven't applied yet.\n\n", len(ms))
+
+	// Reserve room for the widest possible tail up front (the whole batch is its
+	// worst-case count), so appending the actual tail can never push past the limit.
+	tailReserve := telegramnotify.UTF16Len(n.moreLine(len(ms)))
+	used := telegramnotify.UTF16Len(b.String())
+	fitted := 0
+	for _, m := range shown {
+		line := n.jobLine(m)
+		lineLen := telegramnotify.UTF16Len(line)
+		if used+lineLen+tailReserve > telegramnotify.MaxMessageLen {
+			break
+		}
+		b.WriteString(line)
+		used += lineLen
+		fitted++
+	}
+	if omitted := len(ms) - fitted; omitted > 0 {
+		b.WriteString(n.moreLine(omitted))
+	}
+	return b.String()
 }
 
-// EmailNotifier delivers a reminder as an email, reusing the emailnotify SES
-// transport. Like the Telegram notifier, its link stays on-platform.
+// jobLine renders one saved job as a bullet linking to its freehire page.
+func (n *TelegramNotifier) jobLine(m ReminderMessage) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "• <a href=%q>%s</a>", n.jobURL(m), html.EscapeString(m.JobTitle))
+	if m.Company != "" {
+		fmt.Fprintf(&b, " — %s", html.EscapeString(m.Company))
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+// moreLine is the overflow tail, or "" when nothing is omitted. It leads to the
+// saved-jobs list rather than to this delivery's own notification page: a reminder
+// records its notification AFTER it is sent, so no id exists while the message is
+// still being built.
+func (n *TelegramNotifier) moreLine(more int) string {
+	if more <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("\n<a href=%q>+ %d more in your saved jobs</a>", n.savedURL(), more)
+}
+
+// savedURL is the saved-jobs list, where a batch sends anyone who wants the jobs it
+// could not itemize.
+func (n *TelegramNotifier) savedURL() string { return n.jobBaseURL + "/my/activity" }
+
+// jobURL is the on-platform freehire job page, tagged with a telegram UTM source.
+// Slugs are our own normalized values, so the URL needs no escaping.
+func (n *TelegramNotifier) jobURL(m ReminderMessage) string {
+	return n.jobBaseURL + "/jobs/" + m.Slug + "?utm_source=telegram-bot"
+}
+
+// EmailNotifier delivers an account's due reminders as one email, reusing the
+// emailnotify SES transport. Like the Telegram notifier, its links stay
+// on-platform.
 type EmailNotifier struct {
 	sender     emailnotify.Sender
 	from       string
@@ -82,35 +166,109 @@ func NewEmailNotifier(sender emailnotify.Sender, from, jobBaseURL string) *Email
 	return &EmailNotifier{sender: sender, from: emailnotify.From(senderName, from), jobBaseURL: base, layout: mailtpl.New(base)}
 }
 
-// emailTemplate renders the body from a mailtpl.Job. The saved job leads, drawn by
-// the shared row so it looks the same here as in a digest, logo and all; the
-// sentence underneath only says why the mail arrived.
-//
-// The job's fields are source data and are escaped in context by html/template —
-// the reason this notifier no longer calls html.EscapeString by hand.
-var emailTemplate = template.Must(mailtpl.Partials().New("reminder").Parse(`
-{{template "job-row" .}}
-<div style="height:18px;"></div>
-{{template "p" "You saved this job and haven’t applied yet."}}
-{{template "button" (mailLink .URL "Open the job and apply")}}`))
+// emailData is what the body template renders. Every field is emitted in an
+// escaping context by html/template, which is the injection guard for the
+// source-derived titles and company names.
+type emailData struct {
+	Jobs   []mailtpl.Job
+	More   int
+	Reason string       // the one sentence saying why this mail arrived
+	CTA    mailtpl.Link // the single action: one job opens the job, a batch opens the list
+}
 
-// Send renders the reminder and delivers it to the address in dest.
-func (n *EmailNotifier) Send(ctx context.Context, _ string, dest string, m ReminderMessage) error {
-	url := n.jobBaseURL + "/jobs/" + m.Slug + "?utm_source=email"
-	subject := fmt.Sprintf("Reminder: %s at %s", m.JobTitle, m.Company)
+// emailTemplate renders the saved jobs as rows drawn by the shared partial, so they
+// look the same here as in a digest, logo and all; the sentence underneath only
+// says why the mail arrived. The list is a table rather than stacked divs because
+// Outlook collapses margins between block elements unpredictably.
+var emailTemplate = template.Must(mailtpl.Partials().New("reminder").Parse(`
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+  {{range $i, $job := .Jobs}}
+  <tr><td class="m-row" style="padding:14px 0;{{if $i}}border-top:1px solid #e4e4e4;{{end}}">{{template "job-row" $job}}</td></tr>
+  {{end}}
+</table>
+<div style="height:18px;"></div>
+{{template "p" .Reason}}
+{{if gt .More 0}}{{template "muted" (printf "+ %d more not listed here." .More)}}{{end}}
+{{template "button" .CTA}}`))
+
+// Send renders the batch and delivers it to the address in dest.
+func (n *EmailNotifier) Send(ctx context.Context, _ string, dest string, ms []ReminderMessage) error {
+	if len(ms) == 0 {
+		return nil
+	}
+	shown, more := listed(ms)
+	rows := make([]mailtpl.Job, 0, len(shown))
+	for _, m := range shown {
+		rows = append(rows, mailtpl.NewJob(m.JobTitle, m.Company, "", n.jobURL(m)))
+	}
+
+	subject, heading, preheader, reason := n.copy(ms)
 
 	var content bytes.Buffer
-	if err := emailTemplate.Execute(&content, mailtpl.NewJob(m.JobTitle, m.Company, "", url)); err != nil {
+	if err := emailTemplate.Execute(&content, emailData{
+		Jobs: rows, More: more, Reason: reason, CTA: n.cta(ms),
+	}); err != nil {
 		return err
 	}
 	htmlBody := n.layout.Render(mailtpl.Body{
-		Preheader: "A job you saved is still open",
-		Heading:   "Still interested?",
-		Content:   template.HTML(content.String()), //nolint:gosec // rendered by the trusted template above, which escaped both fields in context
-		Footer:    "You’re getting this because you saved this job on freehire.",
+		Preheader: preheader,
+		Heading:   heading,
+		Content:   template.HTML(content.String()), //nolint:gosec // rendered by the trusted template above, which escaped every field in context
+		Footer:    "You’re getting this because you saved these jobs on freehire.",
 	})
 
-	textBody := fmt.Sprintf("You saved %s at %s and haven't applied yet.\n\nOpen the job: %s\n",
-		m.JobTitle, m.Company, url)
-	return n.sender.Send(ctx, n.from, dest, subject, htmlBody, textBody)
+	return n.sender.Send(ctx, n.from, dest, subject, htmlBody, n.renderText(shown, more, reason))
+}
+
+// copy is the wording for a batch: one saved job still reads as the single-job mail
+// it has always been, several become a count.
+func (n *EmailNotifier) copy(ms []ReminderMessage) (subject, heading, preheader, reason string) {
+	if len(ms) == 1 {
+		m := ms[0]
+		return fmt.Sprintf("Reminder: %s at %s", m.JobTitle, m.Company),
+			"Still interested?",
+			"A job you saved is still open",
+			"You saved this job and haven’t applied yet."
+	}
+	return fmt.Sprintf("Reminder: %d saved jobs", len(ms)),
+		fmt.Sprintf("%d saved jobs are still open", len(ms)),
+		fmt.Sprintf("%d jobs you saved are still open", len(ms)),
+		"You saved these jobs and haven’t applied yet."
+}
+
+// cta is the mail's single action. One saved job still opens that job, because that
+// is the whole errand; several have no one destination, so the action becomes the
+// saved-jobs list.
+func (n *EmailNotifier) cta(ms []ReminderMessage) mailtpl.Link {
+	if len(ms) == 1 {
+		return mailtpl.Link{URL: n.jobURL(ms[0]), Label: "Open the job and apply"}
+	}
+	return mailtpl.Link{URL: n.savedURL(), Label: "Open your saved jobs"}
+}
+
+// savedURL is the saved-jobs list, tagged with an email UTM source.
+func (n *EmailNotifier) savedURL() string { return n.jobBaseURL + "/my/activity?utm_source=email" }
+
+// renderText builds the plain-text alternative, mirroring the HTML body so
+// non-HTML clients (and spam scorers) see the same content.
+func (n *EmailNotifier) renderText(shown []ReminderMessage, more int, reason string) string {
+	var b strings.Builder
+	b.WriteString(reason + "\n\n")
+	for _, m := range shown {
+		b.WriteString("- " + m.JobTitle)
+		if m.Company != "" {
+			b.WriteString(" — " + m.Company)
+		}
+		b.WriteString("\n  " + n.jobURL(m) + "\n")
+	}
+	if more > 0 {
+		fmt.Fprintf(&b, "\n+ %d more at %s\n", more, n.savedURL())
+	}
+	return b.String()
+}
+
+// jobURL is the on-platform freehire job page, tagged with an email UTM source so
+// the channel's traffic is attributable.
+func (n *EmailNotifier) jobURL(m ReminderMessage) string {
+	return n.jobBaseURL + "/jobs/" + m.Slug + "?utm_source=email"
 }

--- a/internal/engage/reminder/transports.go
+++ b/internal/engage/reminder/transports.go
@@ -72,10 +72,7 @@ func (n *TelegramNotifier) Send(ctx context.Context, _ string, dest string, ms [
 // every retry re-fails.
 func (n *TelegramNotifier) render(ms []ReminderMessage) string {
 	if len(ms) == 1 {
-		m := ms[0]
-		return fmt.Sprintf(
-			"⏰ Reminder: you saved <b>%s</b> at <b>%s</b>.\nStill interested? <a href=%q>Open the job →</a>",
-			html.EscapeString(m.JobTitle), html.EscapeString(m.Company), n.jobURL(m))
+		return n.renderOne(ms[0])
 	}
 
 	// The list bound picks the candidates; the length cap decides how many of them
@@ -103,6 +100,15 @@ func (n *TelegramNotifier) render(ms []ReminderMessage) string {
 		b.WriteString(n.moreLine(omitted))
 	}
 	return b.String()
+}
+
+// renderOne is the single-reminder body, kept verbatim — link included, which
+// carries no UTM tag — because a batch of one must be indistinguishable from what
+// shipped before grouping.
+func (n *TelegramNotifier) renderOne(m ReminderMessage) string {
+	return fmt.Sprintf(
+		"⏰ Reminder: you saved <b>%s</b> at <b>%s</b>.\nStill interested? <a href=\"%s\">Open the job →</a>",
+		html.EscapeString(m.JobTitle), html.EscapeString(m.Company), n.jobBaseURL+"/jobs/"+m.Slug)
 }
 
 // jobLine renders one saved job as a bullet linking to its freehire page.
@@ -164,11 +170,20 @@ type emailData struct {
 	CTA    mailtpl.Link // the single action: one job opens the job, a batch opens the list
 }
 
-// emailTemplate renders the saved jobs as rows drawn by the shared partial, so they
-// look the same here as in a digest, logo and all; the sentence underneath only
-// says why the mail arrived. The list is a table rather than stacked divs because
-// Outlook collapses margins between block elements unpredictably.
-var emailTemplate = template.Must(mailtpl.Partials().New("reminder").Parse(`
+// oneTemplate is the single-reminder body, unchanged since before grouping: a batch
+// of one must be byte-identical to what shipped, so it keeps its own template rather
+// than becoming a list of length one.
+var oneTemplate = template.Must(mailtpl.Partials().New("reminder").Parse(`
+{{template "job-row" .}}
+<div style="height:18px;"></div>
+{{template "p" "You saved this job and haven’t applied yet."}}
+{{template "button" (mailLink .URL "Open the job and apply")}}`))
+
+// batchTemplate renders the saved jobs as rows drawn by the shared partial, so they
+// look the same here as in a digest, logo and all; the sentence underneath only says
+// why the mail arrived. The list is a table rather than stacked divs because Outlook
+// collapses margins between block elements unpredictably.
+var batchTemplate = template.Must(mailtpl.Partials().New("reminder-batch").Parse(`
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
   {{range $i, $job := .Jobs}}
   <tr><td class="m-row" style="padding:14px 0;{{if $i}}border-top:1px solid #e4e4e4;{{end}}">{{template "job-row" $job}}</td></tr>
@@ -184,62 +199,66 @@ func (n *EmailNotifier) Send(ctx context.Context, _ string, dest string, ms []Re
 	if len(ms) == 0 {
 		return nil
 	}
+	if len(ms) == 1 {
+		return n.sendOne(ctx, dest, ms[0])
+	}
+	return n.sendBatch(ctx, dest, ms)
+}
+
+// sendOne is the pre-grouping mail, kept verbatim.
+func (n *EmailNotifier) sendOne(ctx context.Context, dest string, m ReminderMessage) error {
+	url := n.jobURL(m)
+	var content bytes.Buffer
+	if err := oneTemplate.Execute(&content, mailtpl.NewJob(m.JobTitle, m.Company, "", url)); err != nil {
+		return err
+	}
+	htmlBody := n.layout.Render(mailtpl.Body{
+		Preheader: "A job you saved is still open",
+		Heading:   "Still interested?",
+		Content:   template.HTML(content.String()), //nolint:gosec // rendered by the trusted template above, which escaped both fields in context
+		Footer:    "You’re getting this because you saved this job on freehire.",
+	})
+
+	textBody := fmt.Sprintf("You saved %s at %s and haven't applied yet.\n\nOpen the job: %s\n",
+		m.JobTitle, m.Company, url)
+	subject := fmt.Sprintf("Reminder: %s at %s", m.JobTitle, m.Company)
+	return n.sender.Send(ctx, n.from, dest, subject, htmlBody, textBody)
+}
+
+// sendBatch is the multi-reminder mail: the same job rows a digest draws, one
+// sentence saying why they arrived together, and one action.
+func (n *EmailNotifier) sendBatch(ctx context.Context, dest string, ms []ReminderMessage) error {
 	shown, more := notify.Listed(ms)
 	rows := make([]mailtpl.Job, 0, len(shown))
 	for _, m := range shown {
 		rows = append(rows, mailtpl.NewJob(m.JobTitle, m.Company, "", n.jobURL(m)))
 	}
-
-	subject, heading, preheader, reason := n.copy(ms)
+	reason := "You saved these jobs and haven’t applied yet."
 
 	var content bytes.Buffer
-	if err := emailTemplate.Execute(&content, emailData{
-		Jobs: rows, More: more, Reason: reason, CTA: n.cta(ms),
+	if err := batchTemplate.Execute(&content, emailData{
+		Jobs: rows, More: more, Reason: reason,
+		CTA: mailtpl.Link{URL: n.savedURL(), Label: "Open your saved jobs"},
 	}); err != nil {
 		return err
 	}
 	htmlBody := n.layout.Render(mailtpl.Body{
-		Preheader: preheader,
-		Heading:   heading,
+		Preheader: fmt.Sprintf("%d jobs you saved are still open", len(ms)),
+		Heading:   fmt.Sprintf("%d saved jobs are still open", len(ms)),
 		Content:   template.HTML(content.String()), //nolint:gosec // rendered by the trusted template above, which escaped every field in context
 		Footer:    "You’re getting this because you saved these jobs on freehire.",
 	})
 
-	return n.sender.Send(ctx, n.from, dest, subject, htmlBody, n.renderText(shown, more, reason))
-}
-
-// copy is the wording for a batch: one saved job still reads as the single-job mail
-// it has always been, several become a count.
-func (n *EmailNotifier) copy(ms []ReminderMessage) (subject, heading, preheader, reason string) {
-	if len(ms) == 1 {
-		m := ms[0]
-		return fmt.Sprintf("Reminder: %s at %s", m.JobTitle, m.Company),
-			"Still interested?",
-			"A job you saved is still open",
-			"You saved this job and haven’t applied yet."
-	}
-	return fmt.Sprintf("Reminder: %d saved jobs", len(ms)),
-		fmt.Sprintf("%d saved jobs are still open", len(ms)),
-		fmt.Sprintf("%d jobs you saved are still open", len(ms)),
-		"You saved these jobs and haven’t applied yet."
-}
-
-// cta is the mail's single action. One saved job still opens that job, because that
-// is the whole errand; several have no one destination, so the action becomes the
-// saved-jobs list.
-func (n *EmailNotifier) cta(ms []ReminderMessage) mailtpl.Link {
-	if len(ms) == 1 {
-		return mailtpl.Link{URL: n.jobURL(ms[0]), Label: "Open the job and apply"}
-	}
-	return mailtpl.Link{URL: n.savedURL(), Label: "Open your saved jobs"}
+	subject := fmt.Sprintf("Reminder: %d saved jobs", len(ms))
+	return n.sender.Send(ctx, n.from, dest, subject, htmlBody, n.renderBatchText(shown, more, reason))
 }
 
 // savedURL is the saved-jobs list, tagged with an email UTM source.
 func (n *EmailNotifier) savedURL() string { return n.jobBaseURL + "/my/activity?utm_source=email" }
 
-// renderText builds the plain-text alternative, mirroring the HTML body so
-// non-HTML clients (and spam scorers) see the same content.
-func (n *EmailNotifier) renderText(shown []ReminderMessage, more int, reason string) string {
+// renderBatchText builds the plain-text alternative for a batch, mirroring the HTML
+// body so non-HTML clients (and spam scorers) see the same content.
+func (n *EmailNotifier) renderBatchText(shown []ReminderMessage, more int, reason string) string {
 	var b strings.Builder
 	b.WriteString(reason + "\n\n")
 	for _, m := range shown {

--- a/internal/engage/reminder/transports_test.go
+++ b/internal/engage/reminder/transports_test.go
@@ -2,8 +2,12 @@ package reminder
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/strelov1/freehire/internal/engage/notify"
+	"github.com/strelov1/freehire/internal/engage/telegramnotify"
 )
 
 // captureSender records the last email a EmailNotifier sent.
@@ -21,7 +25,7 @@ func TestEmailNotifier_RendersSubjectAndOnPlatformLink(t *testing.T) {
 	n := NewEmailNotifier(sender, "jobs@freehire.me", "https://freehire.me/")
 	msg := ReminderMessage{JobTitle: "Go Dev", Company: "Acme", Slug: "go-dev-acme", URL: "https://ats/x"}
 
-	if err := n.Send(context.Background(), "email", "u@x.com", msg); err != nil {
+	if err := n.Send(context.Background(), "email", "u@x.com", []ReminderMessage{msg}); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 	// From carries a display name over the configured address, so a message list
@@ -48,7 +52,7 @@ func TestEmailNotifier_EscapesUserData(t *testing.T) {
 	n := NewEmailNotifier(sender, "jobs@freehire.me", "https://freehire.me")
 	msg := ReminderMessage{JobTitle: "<script>x</script>", Company: "Acme", Slug: "s", URL: "u"}
 
-	if err := n.Send(context.Background(), "email", "u@x.com", msg); err != nil {
+	if err := n.Send(context.Background(), "email", "u@x.com", []ReminderMessage{msg}); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 	if strings.Contains(sender.html, "<script>") {
@@ -58,7 +62,7 @@ func TestEmailNotifier_EscapesUserData(t *testing.T) {
 
 func TestTelegramNotifier_RendersOnPlatformLink(t *testing.T) {
 	n := NewTelegramNotifier(nil, "https://freehire.me/")
-	got := n.render(ReminderMessage{JobTitle: "Go Dev", Company: "Acme", Slug: "go-dev-acme"})
+	got := n.render([]ReminderMessage{{JobTitle: "Go Dev", Company: "Acme", Slug: "go-dev-acme"}})
 	if !strings.Contains(got, "https://freehire.me/jobs/go-dev-acme") {
 		t.Errorf("telegram render missing on-platform link: %q", got)
 	}
@@ -69,7 +73,87 @@ func TestTelegramNotifier_RendersOnPlatformLink(t *testing.T) {
 
 func TestTelegramNotifier_InvalidChatIDErrors(t *testing.T) {
 	n := NewTelegramNotifier(nil, "https://freehire.me")
-	if err := n.Send(context.Background(), "telegram", "not-a-number", ReminderMessage{}); err == nil {
+	if err := n.Send(context.Background(), "telegram", "not-a-number", []ReminderMessage{{Slug: "s"}}); err == nil {
 		t.Error("want an error for a non-numeric chat id")
+	}
+}
+
+// batchOf builds n distinct saved jobs, so a test can push a message past its
+// bounds without hand-writing the list.
+func batchOf(n int) []ReminderMessage {
+	ms := make([]ReminderMessage, n)
+	for i := range ms {
+		id := strconv.Itoa(i)
+		ms[i] = ReminderMessage{JobTitle: "Job " + id, Company: "Company " + id, Slug: "job-" + id}
+	}
+	return ms
+}
+
+func TestEmailNotifier_BatchListsEveryJobUnderTheListLimit(t *testing.T) {
+	sender := &captureSender{}
+	n := NewEmailNotifier(sender, "jobs@freehire.me", "https://freehire.me")
+
+	if err := n.Send(context.Background(), "email", "u@x.com", batchOf(4)); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if !strings.Contains(sender.subject, "4 saved jobs") {
+		t.Errorf("subject = %q, want the batch count", sender.subject)
+	}
+	for i := 0; i < 4; i++ {
+		if !strings.Contains(sender.html, "jobs/job-"+strconv.Itoa(i)) {
+			t.Errorf("html is missing job-%d: %q", i, sender.html)
+		}
+	}
+	if strings.Contains(sender.html, "View all") {
+		t.Errorf("a batch under the list limit must show no overflow tail: %q", sender.html)
+	}
+}
+
+// The two bounds are different numbers on purpose: the message itemizes
+// notify.ListLimit and counts the rest, while the record behind it holds them all.
+func TestEmailNotifier_BatchOverTheListLimitCountsTheRest(t *testing.T) {
+	sender := &captureSender{}
+	n := NewEmailNotifier(sender, "jobs@freehire.me", "https://freehire.me")
+
+	size := notify.ListLimit + 5
+	if err := n.Send(context.Background(), "email", "u@x.com", batchOf(size)); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if !strings.Contains(sender.html, "5 more") {
+		t.Errorf("html = %q, want a tail counting the 5 omitted jobs", sender.html)
+	}
+	if strings.Contains(sender.html, "jobs/job-"+strconv.Itoa(notify.ListLimit)) {
+		t.Errorf("html itemized past the list limit: %q", sender.html)
+	}
+	if !strings.Contains(sender.text, "+ 5 more") {
+		t.Errorf("text = %q, want the same tail as the HTML", sender.text)
+	}
+}
+
+func TestTelegramNotifier_BatchListsJobsAndCountsTheRest(t *testing.T) {
+	n := NewTelegramNotifier(nil, "https://freehire.me")
+	got := n.render(batchOf(notify.ListLimit + 3))
+
+	if !strings.Contains(got, "+ 3 more") {
+		t.Errorf("render = %q, want a tail counting the 3 omitted jobs", got)
+	}
+	if !strings.Contains(got, "jobs/job-0") {
+		t.Errorf("render = %q, want the first job listed", got)
+	}
+}
+
+// An oversized body is rejected deterministically and every retry re-fails, so the
+// message must fit whatever the batch holds.
+func TestTelegramNotifier_BatchStaysUnderTheMessageLimit(t *testing.T) {
+	n := NewTelegramNotifier(nil, "https://freehire.me")
+	ms := batchOf(notify.ListLimit)
+	long := strings.Repeat("Extremely Long Job Title ", 40)
+	for i := range ms {
+		ms[i].JobTitle = long
+		ms[i].Company = long
+	}
+
+	if got := telegramnotify.UTF16Len(n.render(ms)); got > telegramnotify.MaxMessageLen {
+		t.Errorf("rendered %d UTF-16 units, want at most %d", got, telegramnotify.MaxMessageLen)
 	}
 }

--- a/internal/engage/telegramnotify/notifier.go
+++ b/internal/engage/telegramnotify/notifier.go
@@ -12,8 +12,11 @@ import (
 	"github.com/strelov1/freehire/internal/engage/notify"
 )
 
-// telegramMaxLen is Telegram's sendMessage text limit, measured in UTF-16 code units.
-const telegramMaxLen = 4096
+// MaxMessageLen is Telegram's sendMessage text limit, measured in UTF-16 code
+// units. Exported because every engine that can build a multi-job message needs
+// the same number: a body over the limit is rejected deterministically, so each
+// retry re-fails and the batch is dead-lettered.
+const MaxMessageLen = 4096
 
 // Compile-time guarantee that Notifier satisfies the channel abstraction.
 var _ notify.Notifier = (*Notifier)(nil)
@@ -57,7 +60,7 @@ func (n *Notifier) Send(ctx context.Context, _ string, dest string, d notify.Dig
 //
 // The listing is bounded twice. notify.ListLimit is the product bound, shared with
 // the email channel so the two never disagree about a digest's shape. On top of it
-// the body is capped to Telegram's telegramMaxLen: job lines are added until the
+// the body is capped to Telegram's MaxMessageLen: job lines are added until the
 // next one (plus the largest possible "+ N more" tail) would overflow, then the
 // tail absorbs the remainder. Without the length cap a digest of many long-title
 // jobs exceeds the limit, Telegram rejects the send deterministically, every retry
@@ -70,13 +73,13 @@ func (n *Notifier) render(d notify.Digest) string {
 	// Reserve room for the widest possible tail up front (d.Total is its worst-case
 	// count), so appending the actual tail after the loop can never push past the limit.
 	viewAll := n.viewAllURL(d)
-	tailReserve := utf16Len(moreLine(d.Total, viewAll))
-	used := utf16Len(b.String())
+	tailReserve := UTF16Len(moreLine(d.Total, viewAll))
+	used := UTF16Len(b.String())
 	shown := 0
 	for _, j := range d.Listed() {
 		line := n.jobLine(j)
-		lineLen := utf16Len(line)
-		if used+lineLen+tailReserve > telegramMaxLen {
+		lineLen := UTF16Len(line)
+		if used+lineLen+tailReserve > MaxMessageLen {
 			break
 		}
 		b.WriteString(line)
@@ -131,8 +134,10 @@ func moreLine(more int, viewAllURL string) string {
 	return fmt.Sprintf("\n<a href=%q>+ %d more</a>", viewAllURL, more)
 }
 
-// utf16Len counts s in UTF-16 code units — the unit Telegram measures a message
-// against — so a supplementary-plane rune (e.g. the 🔔 emoji) correctly counts as two.
-func utf16Len(s string) int {
+// UTF16Len counts s in UTF-16 code units — the unit Telegram measures a message
+// against — so a supplementary-plane rune (e.g. the 🔔 emoji) correctly counts as
+// two. Exported alongside MaxMessageLen: a caller given the limit and not the way
+// to measure against it would reach for len(), which is bytes.
+func UTF16Len(s string) int {
 	return len(utf16.Encode([]rune(s)))
 }

--- a/internal/platform/db/nudges.sql.go
+++ b/internal/platform/db/nudges.sql.go
@@ -39,12 +39,14 @@ WITH claimable AS (
     ORDER BY n.created_at, n.id
     FOR UPDATE OF n SKIP LOCKED
     LIMIT $2
+), claimed AS (
+    UPDATE application_nudges n
+    SET claimed_at = now()
+    FROM claimable c
+    WHERE n.id = c.id
+    RETURNING n.id, n.created_at
 )
-UPDATE application_nudges n
-SET claimed_at = now()
-FROM claimable c
-WHERE n.id = c.id
-RETURNING n.id
+SELECT id FROM claimed ORDER BY created_at, id
 `
 
 type ClaimDueNudgesParams struct {
@@ -57,6 +59,10 @@ type ClaimDueNudgesParams struct {
 // once; the lease predicate reclaims rows whose sender died (stale claimed_at).
 // Delivery happens OUTSIDE this transaction, so no network call is held under a
 // row lock. Mirrors ClaimDueReminders.
+// Sorted OUTSIDE the UPDATE. The CTE's ORDER BY only picks WHICH rows are claimed;
+// an UPDATE ... RETURNING is not obliged to emit them in that order, and the engine
+// groups the result into one message per (account, kind), listing the jobs in the
+// order it receives them. Mirrors ClaimDueReminders.
 func (q *Queries) ClaimDueNudges(ctx context.Context, arg ClaimDueNudgesParams) ([]int64, error) {
 	rows, err := q.db.Query(ctx, claimDueNudges, arg.LeaseSeconds, arg.BatchSize)
 	if err != nil {

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -1581,6 +1581,14 @@ type Querier interface {
 	// cancel-and-skip a reminder whose job has since closed or is no longer
 	// saved-but-unapplied, closing the race between a cancel and the fire.
 	GetReminderForDelivery(ctx context.Context, id int64) (GetReminderForDeliveryRow, error)
+	// The two halves of "when should this account hear from us": the daily
+	// notification hour (notification_settings.digest_time) and the timezone to read
+	// it in (users.timezone). Both are optional and both are read here rather than
+	// from GetNotificationSettings, which knows nothing about the user row — one
+	// statement so the hour and the zone can never come from different reads and
+	// disagree. The row always exists for a real user; a NULL in either column is the
+	// unconfigured state the caller resolves to its own defaults.
+	GetReminderScheduleContext(ctx context.Context, id int64) (GetReminderScheduleContextRow, error)
 	// Load a single report by id for the review path, with the reporter's email and the
 	// reported job's slug and title — the decision notice needs them, and joining here spares
 	// the decision path a second round trip. The resolve/dismiss flow guards the status in the

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -209,6 +209,10 @@ type Querier interface {
 	// once; the lease predicate reclaims rows whose sender died (stale claimed_at).
 	// Delivery happens OUTSIDE this transaction, so no network call is held under a
 	// row lock. Mirrors ClaimDueReminders.
+	// Sorted OUTSIDE the UPDATE. The CTE's ORDER BY only picks WHICH rows are claimed;
+	// an UPDATE ... RETURNING is not obliged to emit them in that order, and the engine
+	// groups the result into one message per (account, kind), listing the jobs in the
+	// order it receives them. Mirrors ClaimDueReminders.
 	ClaimDueNudges(ctx context.Context, arg ClaimDueNudgesParams) ([]int64, error)
 	// Tickets old enough for Expo to have an answer, oldest first. Read-only
 	// (this queue has no lease/claim bookkeeping — see DeletePushTickets):
@@ -220,6 +224,10 @@ type Querier interface {
 	// rows so a reminder fires at most once; the lease predicate reclaims rows whose
 	// sender died (stale claimed_at), so no separate reaper is needed. Delivery happens
 	// OUTSIDE this transaction, so no network call is held under a row lock.
+	// Sorted OUTSIDE the UPDATE. The CTE's ORDER BY only picks WHICH rows are claimed;
+	// an UPDATE ... RETURNING is not obliged to emit them in that order, and the engine
+	// groups the result into one message per account, listing the jobs in the order it
+	// receives them. Without this the list order is whatever the join produced.
 	ClaimDueReminders(ctx context.Context, arg ClaimDueRemindersParams) ([]int64, error)
 	// Claim a wave of live, unleased entries by stamping claimed_at, newest email first,
 	// returning the email fields the matcher/classifier need. FOR UPDATE OF o locks only

--- a/internal/platform/db/queries/nudges.sql
+++ b/internal/platform/db/queries/nudges.sql
@@ -77,12 +77,18 @@ WITH claimable AS (
     ORDER BY n.created_at, n.id
     FOR UPDATE OF n SKIP LOCKED
     LIMIT sqlc.arg(batch_size)
+), claimed AS (
+    UPDATE application_nudges n
+    SET claimed_at = now()
+    FROM claimable c
+    WHERE n.id = c.id
+    RETURNING n.id, n.created_at
 )
-UPDATE application_nudges n
-SET claimed_at = now()
-FROM claimable c
-WHERE n.id = c.id
-RETURNING n.id;
+-- Sorted OUTSIDE the UPDATE. The CTE's ORDER BY only picks WHICH rows are claimed;
+-- an UPDATE ... RETURNING is not obliged to emit them in that order, and the engine
+-- groups the result into one message per (account, kind), listing the jobs in the
+-- order it receives them. Mirrors ClaimDueReminders.
+SELECT id FROM claimed ORDER BY created_at, id;
 
 -- name: GetNudgeForDelivery :one
 -- The re-check-before-send context for one nudge: the job display fields, the

--- a/internal/platform/db/queries/reminders.sql
+++ b/internal/platform/db/queries/reminders.sql
@@ -28,6 +28,20 @@ ON CONFLICT (user_id) DO UPDATE
       updated_at         = now()
 RETURNING *;
 
+-- name: GetReminderScheduleContext :one
+-- The two halves of "when should this account hear from us": the daily
+-- notification hour (notification_settings.digest_time) and the timezone to read
+-- it in (users.timezone). Both are optional and both are read here rather than
+-- from GetNotificationSettings, which knows nothing about the user row — one
+-- statement so the hour and the zone can never come from different reads and
+-- disagree. The row always exists for a real user; a NULL in either column is the
+-- unconfigured state the caller resolves to its own defaults.
+SELECT ns.digest_time AS digest_time,
+       u.timezone     AS timezone
+FROM users u
+LEFT JOIN notification_settings ns ON ns.user_id = u.id
+WHERE u.id = $1;
+
 -- name: UpsertJobReminder :one
 -- Schedule a one-shot reminder for a saved job, or replace the pending one if the
 -- job is re-saved with a new choice. The arbiter is the partial unique index on

--- a/internal/platform/db/queries/reminders.sql
+++ b/internal/platform/db/queries/reminders.sql
@@ -85,12 +85,18 @@ WITH claimable AS (
     ORDER BY r.fire_at, r.id
     FOR UPDATE OF r SKIP LOCKED
     LIMIT sqlc.arg(batch_size)
+), claimed AS (
+    UPDATE job_reminders r
+    SET claimed_at = now()
+    FROM claimable c
+    WHERE r.id = c.id
+    RETURNING r.id, r.fire_at
 )
-UPDATE job_reminders r
-SET claimed_at = now()
-FROM claimable c
-WHERE r.id = c.id
-RETURNING r.id;
+-- Sorted OUTSIDE the UPDATE. The CTE's ORDER BY only picks WHICH rows are claimed;
+-- an UPDATE ... RETURNING is not obliged to emit them in that order, and the engine
+-- groups the result into one message per account, listing the jobs in the order it
+-- receives them. Without this the list order is whatever the join produced.
+SELECT id FROM claimed ORDER BY fire_at, id;
 
 -- name: GetReminderForDelivery :one
 -- The delivery context for one reminder: the job display fields, the channel set,

--- a/internal/platform/db/reminders.sql.go
+++ b/internal/platform/db/reminders.sql.go
@@ -63,12 +63,14 @@ WITH claimable AS (
     ORDER BY r.fire_at, r.id
     FOR UPDATE OF r SKIP LOCKED
     LIMIT $2
+), claimed AS (
+    UPDATE job_reminders r
+    SET claimed_at = now()
+    FROM claimable c
+    WHERE r.id = c.id
+    RETURNING r.id, r.fire_at
 )
-UPDATE job_reminders r
-SET claimed_at = now()
-FROM claimable c
-WHERE r.id = c.id
-RETURNING r.id
+SELECT id FROM claimed ORDER BY fire_at, id
 `
 
 type ClaimDueRemindersParams struct {
@@ -81,6 +83,10 @@ type ClaimDueRemindersParams struct {
 // rows so a reminder fires at most once; the lease predicate reclaims rows whose
 // sender died (stale claimed_at), so no separate reaper is needed. Delivery happens
 // OUTSIDE this transaction, so no network call is held under a row lock.
+// Sorted OUTSIDE the UPDATE. The CTE's ORDER BY only picks WHICH rows are claimed;
+// an UPDATE ... RETURNING is not obliged to emit them in that order, and the engine
+// groups the result into one message per account, listing the jobs in the order it
+// receives them. Without this the list order is whatever the join produced.
 func (q *Queries) ClaimDueReminders(ctx context.Context, arg ClaimDueRemindersParams) ([]int64, error) {
 	rows, err := q.db.Query(ctx, claimDueReminders, arg.LeaseSeconds, arg.BatchSize)
 	if err != nil {

--- a/internal/platform/db/reminders.sql.go
+++ b/internal/platform/db/reminders.sql.go
@@ -197,6 +197,33 @@ func (q *Queries) GetReminderForDelivery(ctx context.Context, id int64) (GetRemi
 	return i, err
 }
 
+const getReminderScheduleContext = `-- name: GetReminderScheduleContext :one
+SELECT ns.digest_time AS digest_time,
+       u.timezone     AS timezone
+FROM users u
+LEFT JOIN notification_settings ns ON ns.user_id = u.id
+WHERE u.id = $1
+`
+
+type GetReminderScheduleContextRow struct {
+	DigestTime pgtype.Time `json:"digest_time"`
+	Timezone   pgtype.Text `json:"timezone"`
+}
+
+// The two halves of "when should this account hear from us": the daily
+// notification hour (notification_settings.digest_time) and the timezone to read
+// it in (users.timezone). Both are optional and both are read here rather than
+// from GetNotificationSettings, which knows nothing about the user row — one
+// statement so the hour and the zone can never come from different reads and
+// disagree. The row always exists for a real user; a NULL in either column is the
+// unconfigured state the caller resolves to its own defaults.
+func (q *Queries) GetReminderScheduleContext(ctx context.Context, id int64) (GetReminderScheduleContextRow, error) {
+	row := q.db.QueryRow(ctx, getReminderScheduleContext, id)
+	var i GetReminderScheduleContextRow
+	err := row.Scan(&i.DigestTime, &i.Timezone)
+	return i, err
+}
+
 const markReminderDelivered = `-- name: MarkReminderDelivered :execrows
 UPDATE job_reminders
 SET status = 'delivered', delivered_at = now()

--- a/openspec/changes/aggregate-reminder-and-nudge-digests/.openspec.yaml
+++ b/openspec/changes/aggregate-reminder-and-nudge-digests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/aggregate-reminder-and-nudge-digests/design.md
+++ b/openspec/changes/aggregate-reminder-and-nudge-digests/design.md
@@ -78,6 +78,20 @@ the single-item case a slice of one and removes the ability to regress. The two 
 keep their own interfaces, as they do today — the doc's reason for that (each carries its
 own payload, `ErrChannelNotConfigured` and `recipient`) is unchanged.
 
+### The reminder batch key carries the channel set; the nudge key carries the kind
+
+`job_reminders.channels` is snapshotted when the reminder is scheduled — migration 0034
+says why: "a later rule edit never rewrites a pending reminder". It is therefore a
+property of the REMINDER, not of the account, and `GetReminderForDelivery` returns it per
+row. Grouping on `user_id` alone would let the first member's row decide the channels for
+the whole batch, sending one reminder over another's channels and stamping it delivered
+anyway. The key is `(user_id, canonical channel set)`; the set is sorted only for the key,
+so the send still walks the first member's own slice in its stored order.
+
+`internal/engage/nudge` needs no such split — `GetNudgeForDelivery` reads
+`notification_settings.channels` live, which IS an account property — and instead carries
+the kind, since the three kinds must not share a message.
+
 ### Group and validate in the same order as today
 
 `Runner.Run` claims as it does now, then loads each claimed item's delivery context and

--- a/openspec/changes/aggregate-reminder-and-nudge-digests/design.md
+++ b/openspec/changes/aggregate-reminder-and-nudge-digests/design.md
@@ -1,0 +1,144 @@
+## Context
+
+Three notification engines share one channel vocabulary but not one delivery shape.
+`internal/engage/notify` (saved-search digests) already batches: it groups matched jobs
+per subscription and sends one `Digest`. `internal/engage/reminder` and
+`internal/engage/nudge` do not — each runs `for _, id := range due { fire(id) }` and each
+`fire` calls `Notifier.Send` with exactly one job.
+
+The two engines differ in how their items become due, and the difference decides the
+design:
+
+- **nudge** has no `fire_at`. `match` inserts rows and the same pass's `deliver` claims
+  them, on a 30-minute timer. Everything one account has pending is therefore already in
+  one pass — grouping alone fixes the flood.
+- **reminder** has `fire_at = save + DefaultDelayDays`, on a 15-minute timer. Two saves
+  hours apart become due in different passes, so grouping alone changes almost nothing.
+  The fire times must be made to coincide first.
+
+`docs/agents/notifications.md` records a deliberate decision not to collapse the three
+engines into one, and this change does not revisit it.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One message per account per pass for reminders; one per `(account, kind)` for nudges.
+- Same behaviour on email, Telegram and push.
+- One in-app notification row per grouped delivery, using the JSONB column that already
+  exists for exactly this.
+- No schema migration.
+
+**Non-Goals:**
+
+- Merging the reminder, nudge and notify engines, or their workers and timers.
+- Merging nudge kinds into one message.
+- Any change to `internal/engage/notify`.
+- Retro-bucketing the `fire_at` of reminders already pending at deploy time.
+
+## Decisions
+
+### Bucket `fire_at` at schedule time, not at claim time
+
+`Service.fireAt` gains a rounding step: take `now + DefaultDelayDays`, then move forward
+to the first occurrence of the account's notification hour in the account's timezone.
+The claim query is untouched.
+
+*Why over a lookahead claim* (`fire_at <= now() + window`): a lookahead makes the
+delivery hour drift with the worker's own schedule and fires reminders early by an
+arbitrary amount, so "3 days" quietly becomes "2.5 to 3 days". Bucketing keeps a single,
+explainable rule — "at your notification hour, on or after the third day" — and the
+grouping falls out of it rather than being bolted on. It also needs no new claim
+semantics, which is where the `SKIP LOCKED` lease correctness lives.
+
+*Cost:* pending rows written before deploy keep their unbucketed `fire_at` and go out
+ungrouped. They drain within `DefaultDelayDays`. Backfilling them is possible but not
+worth a migration for a three-day tail.
+
+### Reuse `notification_settings.digest_time` as the notification hour
+
+The column exists and already means "the hour I want to hear from you", but is read only
+by `notify` when frequency is `daily`. Reading it here for every account — including
+`instant` ones, who have it unset and get the 09:00 default — extends its meaning
+slightly rather than inventing a second time-of-day setting that would inevitably drift
+from it.
+
+*Data access:* `ScheduleOnSave` currently reads `GetNotificationSettings` only, which has
+no timezone. Add one sqlc query returning `digest_time` and `users.timezone` together, so
+the two halves of one decision come from one read and cannot disagree.
+
+### Make the `Notifier` seam batch-shaped
+
+`reminder.Notifier.Send(ctx, channel, dest string, ms []ReminderMessage) error` and
+`nudge.Notifier.Send(ctx, channel, dest, kind string, ms []Message) error`.
+
+*Why over adding a parallel `SendBatch`:* a second method leaves a per-item path alive,
+and the spec requires that no channel falls back to it. One batch-shaped method makes
+the single-item case a slice of one and removes the ability to regress. The two engines
+keep their own interfaces, as they do today — the doc's reason for that (each carries its
+own payload, `ErrChannelNotConfigured` and `recipient`) is unchanged.
+
+### Group and validate in the same order as today
+
+`Runner.Run` claims as it does now, then loads each claimed item's delivery context and
+runs the existing per-item checks (`job_open`, `still_actionable`, quiet hours) BEFORE
+grouping. Cancelled and deferred items leave the batch; survivors are grouped by user
+(or `(user, kind)`) and sent once.
+
+*Why check first, group second:* the checks are per-item and already correct; reordering
+them would change cancellation semantics. Quiet hours is per-account, so every survivor
+in a group answers it identically — checking per item costs nothing and keeps one code
+path.
+
+### Reuse `user_notifications.jobs` rather than a snapshot table
+
+Migration 0091 already added a JSONB array of `{title, company, slug}` for this exact
+purpose, and `/my/notifications/[id]/jobs` already renders it. A multi-item group writes
+`jobs` and leaves `public_slug` NULL; a single-item group keeps today's shape. Nothing
+new to migrate, nothing new to render.
+
+### Two bounds, deliberately different numbers
+
+10 itemized in a message, 200 carried in the record — the same split `notify` uses
+(`ListLimit` / `SnapshotCap`), for the reason recorded in `docs/agents/notifications.md`:
+they were one knob until 2026-08-21, and lowering the email's list length silently
+truncated the on-site page the email linked to. `notify.ListLimit` is an exported
+constant and is reused directly rather than copied. `SnapshotCap` is not — it is a field
+on `notify.Config`, and each engine already carries its own `Config`, so reminder and
+nudge each gain a `SnapshotCap` field defaulting to the same 200.
+
+## Risks / Trade-offs
+
+- **A group send failure now costs the whole group an attempt** → `MaxAttempts` is 5 and
+  the failure modes are channel-wide (SES down, bot token wrong), so an outage that fails
+  a group would have failed each item individually anyway. Partial-success bookkeeping
+  would buy accuracy nobody reads at the cost of a second delivery ledger.
+- **Reminders no longer land exactly 72h after the save** → this is the point of the
+  change, but it is a visible timing shift. The spec states the new rule explicitly, and
+  the settings UI already presents `digest_time` as the account's notification hour.
+- **An account with a huge backlog gets one enormous message** → the message lists 10 and
+  counts the rest; the record caps at 200. A backlog beyond 200 is bounded by
+  `ClaimBatch` (500) per pass and drains over passes.
+- **`centralize-lifecycle-notifications` is an unarchived change that modifies the same
+  `saved-job-reminders` requirements this one does** → this change's delta is written
+  against the CODE's current behaviour, which is that change's outcome. Archive
+  `centralize-lifecycle-notifications` before archiving this one, or the older delta will
+  re-introduce the per-job override text it removed.
+- **Timezone-less accounts bucket to 09:00 UTC** → a mildly odd hour for some, but the
+  same fallback `deliverywindow` already uses for quiet hours, so the two timing rules
+  agree about who has no timezone.
+
+## Migration Plan
+
+No schema migration. Deploy order is the ordinary one: `make sqlc` for the new query,
+then ship. Reminders pending at deploy keep their old `fire_at` and deliver ungrouped for
+up to `DefaultDelayDays`; nudges group from the first pass after deploy, since they carry
+no schedule.
+
+Rollback is a plain revert — nothing written by this change is unreadable by the previous
+binary: bucketed `fire_at` values are ordinary timestamps, and a multi-item
+`user_notifications` row is the shape `notify` has been writing since migration 0091.
+
+## Open Questions
+
+None.

--- a/openspec/changes/aggregate-reminder-and-nudge-digests/proposal.md
+++ b/openspec/changes/aggregate-reminder-and-nudge-digests/proposal.md
@@ -28,7 +28,12 @@ noisy ones.
   `[]Message`), so a channel renders a list and not a single job.
 
 Out of scope: merging the three notification engines into one worker, and any change to
-`internal/engage/notify` (saved-search digests already batch).
+what `internal/engage/notify` DOES — saved-search digests already batch and their
+behaviour is untouched. What this change does take from `notify` is ownership of the two
+rules all three engines now share: the list bound (`ListLimit`, plus a generic `Listed`)
+and the `user_notifications.jobs` shape (`SnapshotJob`/`JobsSnapshot`). Both are
+behaviour-preserving refactors of code `notify` already had, made because a private copy
+per engine is a copy that drifts.
 
 ## Capabilities
 
@@ -51,8 +56,17 @@ Out of scope: merging the three notification engines into one worker, and any ch
   (one new read for `digest_time` + `users.timezone`).
 - `internal/engage/nudge` — `Runner.deliver`/`fire` (grouping by `(user, kind)`),
   `Notifier`/`Router` signature, transports.
+- `internal/engage/notify` — `ListLimit`'s companion `Listed`, and `SnapshotJob`/
+  `JobsSnapshot` for the shared `user_notifications.jobs` shape.
+- `internal/engage/telegramnotify` — `MaxMessageLen` and `UTF16Len` exported, since a
+  batch built anywhere can now overflow the limit only the digest used to risk.
+- `internal/engage/mailpreview` — a batch sample per new mail shape, and the golden HTML
+  the staleness test compares against.
 - `internal/platform/db/queries/reminders.sql` — one new query for the scheduling
-  context; regenerated via `make sqlc`.
+  context, and the claim query now sorts OUTSIDE its `UPDATE … RETURNING` (same in
+  `nudges.sql`), because grouping made the claim order load-bearing and an
+  `UPDATE … RETURNING` does not preserve its CTE's `ORDER BY`. Regenerated via
+  `make sqlc`.
 - No schema migration: `user_notifications.jobs` already exists (migration 0091).
 - `docs/agents/notifications.md` — the batching rule and the two bounds belong in the
   always-true list.

--- a/openspec/changes/aggregate-reminder-and-nudge-digests/proposal.md
+++ b/openspec/changes/aggregate-reminder-and-nudge-digests/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+Saved-search subscriptions already arrive as one digest per pass, but the other two
+notification engines still send one message per item. A user who saves eight jobs in a
+day gets eight separate reminder emails three days later, and a user with five silent
+applications gets five nudges in one 30-minute pass. The flood is what makes people
+disable notifications outright, which costs us every future alert too, not just the
+noisy ones.
+
+## What Changes
+
+- Due saved-job reminders are grouped by user and delivered as **one message per user
+  per pass**, on every channel (email, Telegram, push), instead of one message per job.
+- Lifecycle nudges are grouped by `(user, kind)` and delivered as **one message per
+  group**. The three kinds (`follow_up`, `interview_prep`, `job_closed`) stay in
+  separate messages — they are different conversations and read badly merged.
+- A reminder's `fire_at` is rounded forward to the account's daily notification hour
+  (`notification_settings.digest_time` in the account timezone, defaulting to 09:00 and
+  UTC when unset), so everything saved on one day becomes due in a single pass rather
+  than scattered across the 15-minute worker cadence. **BREAKING** for exact timing: a
+  reminder now lands at the account's notification hour on or after the 3-day mark, not
+  exactly 72 hours after the save.
+- A grouped delivery records **one** in-app notification carrying the job list in
+  `user_notifications.jobs` (the existing JSONB column, already rendered by
+  `/my/notifications/[id]/jobs`) instead of one row per job. A single-item group keeps
+  today's shape: `public_slug` set, `jobs` NULL.
+- Each engine's `Notifier` seam becomes batch-shaped (`[]ReminderMessage` /
+  `[]Message`), so a channel renders a list and not a single job.
+
+Out of scope: merging the three notification engines into one worker, and any change to
+`internal/engage/notify` (saved-search digests already batch).
+
+## Capabilities
+
+### New Capabilities
+
+- `notification-digest-batching`: the grouping rule shared by the reminder and nudge
+  delivery engines — what forms a group, how many items a message itemizes versus
+  carries, what the in-app record looks like, and how a failed group send is retried.
+
+### Modified Capabilities
+
+- `saved-job-reminders`: the scheduled fire time is rounded forward to the account's
+  daily notification hour, and delivery of a due batch is one message per user rather
+  than one per reminder.
+
+## Impact
+
+- `internal/engage/reminder` — `Service.fireAt` (bucketing), `Runner.Run`/`fire`
+  (grouping), `Notifier`/`Router` signature, email/Telegram/push transports, repository
+  (one new read for `digest_time` + `users.timezone`).
+- `internal/engage/nudge` — `Runner.deliver`/`fire` (grouping by `(user, kind)`),
+  `Notifier`/`Router` signature, transports.
+- `internal/platform/db/queries/reminders.sql` — one new query for the scheduling
+  context; regenerated via `make sqlc`.
+- No schema migration: `user_notifications.jobs` already exists (migration 0091).
+- `docs/agents/notifications.md` — the batching rule and the two bounds belong in the
+  always-true list.

--- a/openspec/changes/aggregate-reminder-and-nudge-digests/proposal.md
+++ b/openspec/changes/aggregate-reminder-and-nudge-digests/proposal.md
@@ -9,8 +9,11 @@ noisy ones.
 
 ## What Changes
 
-- Due saved-job reminders are grouped by user and delivered as **one message per user
-  per pass**, on every channel (email, Telegram, push), instead of one message per job.
+- Due saved-job reminders are grouped by user **and by their snapshotted channel set**
+  and delivered as **one message per group per pass**, on every channel (email, Telegram,
+  push), instead of one message per job. The channel set is part of the key because
+  `job_reminders.channels` is frozen when the reminder is scheduled (migration 0034), so
+  an account that changed its rule between two saves has two different deliveries due.
 - Lifecycle nudges are grouped by `(user, kind)` and delivered as **one message per
   group**. The three kinds (`follow_up`, `interview_prep`, `job_closed`) stay in
   separate messages — they are different conversations and read badly merged.

--- a/openspec/changes/aggregate-reminder-and-nudge-digests/specs/notification-digest-batching/spec.md
+++ b/openspec/changes/aggregate-reminder-and-nudge-digests/specs/notification-digest-batching/spec.md
@@ -1,0 +1,113 @@
+## ADDED Requirements
+
+### Requirement: A delivery group is the unit of sending
+
+The saved-job reminder and lifecycle nudge engines SHALL deliver in groups rather than
+per item. A reminder group is every one of an account's due, still-actionable reminders
+in a worker pass. A nudge group is every one of an account's due, still-actionable
+nudges of the SAME kind in a worker pass; the kinds (`follow_up`, `interview_prep`,
+`job_closed`) SHALL NOT be merged into one message, because each carries a different
+call to action. A group of one SHALL be indistinguishable from today's single-item
+delivery.
+
+#### Scenario: Same-kind nudges are one message
+
+- **WHEN** the nudge worker delivers four `follow_up` nudges for one account in a pass
+- **THEN** that account receives one `follow_up` message listing four applications
+
+#### Scenario: Different kinds stay apart
+
+- **WHEN** one account has two `follow_up` nudges and one `interview_prep` nudge due in
+  the same pass
+- **THEN** that account receives two messages: one `follow_up` message listing two
+  applications, and one `interview_prep` message listing one
+
+#### Scenario: A single-item group reads as it does today
+
+- **WHEN** exactly one reminder is due for an account
+- **THEN** the message is the single-job message, not a list of one
+
+### Requirement: A grouped message itemizes fewer items than it carries
+
+A grouped message SHALL itemize at most the first 10 items and indicate the remainder
+as a count ("and N more"), while the in-app record for the same delivery SHALL carry up
+to 200 items. These two bounds are separate values and SHALL NOT be collapsed into one:
+lowering how much a message lists must not truncate the page that message links to.
+Items SHALL be ordered oldest-due first, so the item that has waited longest is listed
+first.
+
+#### Scenario: A long group is truncated in the message only
+
+- **WHEN** 25 reminders are delivered as one group
+- **THEN** the message lists the 10 oldest-due jobs and says 15 more
+- **AND** the in-app record carries all 25
+
+#### Scenario: A group under the list limit has no tail
+
+- **WHEN** 4 reminders are delivered as one group
+- **THEN** the message lists all 4 and shows no "more" count
+
+### Requirement: Grouping applies to every channel
+
+A group SHALL be rendered as one message on every configured channel — email, Telegram
+and mobile push alike. No channel SHALL fall back to per-item sending, because a channel
+that does not group reproduces the flood the grouping exists to remove.
+
+#### Scenario: Telegram receives one message per group
+
+- **WHEN** a group of six reminders is delivered to an account with Telegram linked
+- **THEN** the Telegram bot posts one message, not six
+
+#### Scenario: Push receives one notification per group
+
+- **WHEN** a group of six reminders is delivered to an account with a registered device
+- **THEN** one push notification is delivered, summarizing the count
+
+### Requirement: A grouped delivery records one in-app notification
+
+A delivered group SHALL write exactly one `user_notifications` row. A group of more than
+one item SHALL carry its job list in the row's `jobs` field and leave `public_slug`
+unset, so the notification center renders the list page. A group of exactly one item
+SHALL keep today's shape: `public_slug` set and `jobs` unset. A failure to record SHALL
+NOT fail the delivery it accompanies.
+
+#### Scenario: Multi-item group writes a list record
+
+- **WHEN** a group of three reminders is delivered
+- **THEN** one notification row is written whose `jobs` field holds all three jobs and
+  whose `public_slug` is unset
+
+#### Scenario: Single-item group writes a slug record
+
+- **WHEN** a group of one reminder is delivered
+- **THEN** one notification row is written whose `public_slug` is that job's slug and
+  whose `jobs` field is unset
+
+#### Scenario: Recording failure does not fail delivery
+
+- **WHEN** writing the in-app record fails after the group was sent
+- **THEN** the failure is logged and the group stays marked delivered
+
+### Requirement: The group is the retry unit
+
+A send failure SHALL be recorded against every item in the group, and the whole group
+SHALL be retried on a later pass. As today, one channel succeeding is enough for the
+group to count as delivered, and a co-channel error SHALL be logged rather than
+retried. A channel that is unconfigured, or has no destination for the recipient, SHALL
+remain a soft skip that burns no delivery attempt.
+
+#### Scenario: A failed group send retries whole
+
+- **WHEN** the only configured channel errors while sending a group of three
+- **THEN** all three items record a delivery attempt and stay pending for a later pass
+
+#### Scenario: One channel succeeding delivers the group
+
+- **WHEN** a group sends successfully over email but errors over Telegram
+- **THEN** every item in the group is marked delivered and the Telegram error is logged
+
+#### Scenario: No usable channel is a soft skip
+
+- **WHEN** a group's account has no usable destination on any configured channel
+- **THEN** the group is released unsent, no delivery attempt is burned, and the soft
+  skip is counted in the pass summary

--- a/openspec/changes/aggregate-reminder-and-nudge-digests/specs/notification-digest-batching/spec.md
+++ b/openspec/changes/aggregate-reminder-and-nudge-digests/specs/notification-digest-batching/spec.md
@@ -4,11 +4,26 @@
 
 The saved-job reminder and lifecycle nudge engines SHALL deliver in groups rather than
 per item. A reminder group is every one of an account's due, still-actionable reminders
-in a worker pass. A nudge group is every one of an account's due, still-actionable
-nudges of the SAME kind in a worker pass; the kinds (`follow_up`, `interview_prep`,
-`job_closed`) SHALL NOT be merged into one message, because each carries a different
-call to action. A group of one SHALL be indistinguishable from today's single-item
-delivery.
+in a worker pass **that share a channel set** — a reminder's channels are snapshotted
+when it is scheduled, so an account that changed its rule between two saves has two
+genuinely different deliveries due and they SHALL NOT be merged. A nudge group is every
+one of an account's due, still-actionable nudges of the SAME kind in a worker pass; the
+kinds (`follow_up`, `interview_prep`, `job_closed`) SHALL NOT be merged into one message,
+because each carries a different call to action. A group of one SHALL be
+indistinguishable from today's single-item delivery.
+
+#### Scenario: Reminders with different channel sets are not merged
+
+- **WHEN** one account has two due reminders, one scheduled for email only and one for
+  email and Telegram
+- **THEN** each is delivered over its own channel set, and neither message lists the
+  other's job
+
+#### Scenario: Channel order does not split a group
+
+- **WHEN** two of an account's due reminders carry the same two channels in a different
+  stored order
+- **THEN** they are delivered as one message
 
 #### Scenario: Same-kind nudges are one message
 
@@ -46,6 +61,13 @@ first.
 
 - **WHEN** 4 reminders are delivered as one group
 - **THEN** the message lists all 4 and shows no "more" count
+
+#### Scenario: Beyond the carried bound the excess is released, not delivered
+
+- **WHEN** more of an account's items are due than the group may carry
+- **THEN** the excess is released back to the pending queue with no delivery attempt
+  recorded, so a later pass sends it as its own message
+- **AND** nothing is marked delivered that appeared in no message
 
 ### Requirement: Grouping applies to every channel
 

--- a/openspec/changes/aggregate-reminder-and-nudge-digests/specs/saved-job-reminders/spec.md
+++ b/openspec/changes/aggregate-reminder-and-nudge-digests/specs/saved-job-reminders/spec.md
@@ -1,0 +1,101 @@
+## MODIFIED Requirements
+
+### Requirement: Scheduling a reminder on save
+
+When a user saves a job, the system SHALL schedule at most one pending reminder for
+that `(user, job)` pair, using the fixed account default delay. A reminder is
+scheduled only when the shared `notification-settings` rule is enabled for that
+user. Reminders SHALL only be scheduled for jobs that are saved and not yet applied.
+
+The scheduled fire time SHALL be rounded forward from the default delay to the
+account's daily notification hour, so that reminders scheduled on the same day for
+the same account become due in the same worker pass and can be delivered as one
+message. The notification hour is `notification_settings.digest_time` interpreted in
+the account's timezone; an account with no configured digest time SHALL use 09:00,
+and an account with no configured timezone SHALL be treated as UTC. Rounding SHALL
+only move the fire time forward, never earlier than the default delay.
+
+#### Scenario: Save schedules at the fixed default delay, rounded to the notification hour
+
+- **WHEN** a user with notifications enabled and no configured digest time saves a job
+- **THEN** a pending reminder is created whose fire time is the first 09:00 in the
+  account's timezone at or after the fixed default delay from the save
+
+#### Scenario: Two saves on the same day become due together
+
+- **WHEN** the same user saves two jobs several hours apart on one day
+- **THEN** both pending reminders carry the same fire time
+
+#### Scenario: Configured digest time is the rounding target
+
+- **WHEN** a user whose digest time is 18:00 and whose timezone is `Europe/Berlin`
+  saves a job
+- **THEN** the reminder's fire time is the first 18:00 Berlin time at or after the
+  fixed default delay from the save
+
+#### Scenario: Notifications disabled means no reminder
+
+- **WHEN** a user with notifications disabled saves a job
+- **THEN** no reminder is created
+
+### Requirement: One-shot delivery
+
+A reminder SHALL fire exactly once at or after its scheduled fire time and then be marked
+delivered. Due reminders SHALL be delivered grouped by user: all of one account's due,
+still-actionable reminders in a pass form one batch, and that batch SHALL be sent as a
+single message over each channel in the rule's channel set for which the user has a
+usable destination, reusing the existing notification delivery engine. Delivery SHALL be
+idempotent under worker retries: a reminder already marked delivered is never sent again.
+If the account's local time falls inside its configured quiet-hours window when its
+reminders become due, delivery of that account's whole batch SHALL be deferred to a later
+worker pass rather than sent or dropped.
+
+#### Scenario: Due reminders for one user arrive as one message
+
+- **WHEN** the reminder worker runs and three of one account's reminders are due
+- **THEN** the user receives exactly one reminder message per configured channel with a
+  usable destination, listing all three jobs
+- **AND** all three reminders are marked delivered
+
+#### Scenario: Due reminder is delivered once
+
+- **WHEN** the reminder worker runs after a reminder's fire time has passed
+- **THEN** the user receives one reminder message per configured channel with a usable
+  destination
+- **AND** the reminder is marked delivered
+
+#### Scenario: Reminders for different users are not merged
+
+- **WHEN** the worker runs and two different accounts each have due reminders
+- **THEN** each account receives its own message and neither message lists the other
+  account's jobs
+
+#### Scenario: Worker re-run does not resend
+
+- **WHEN** the worker runs again after a reminder was already delivered
+- **THEN** no additional message is sent for that reminder
+
+#### Scenario: Channel has no destination
+
+- **WHEN** a reminder's rule includes `telegram` but the user has not linked Telegram
+- **THEN** that channel is skipped without failing the reminder, and remaining channels
+  still deliver
+
+#### Scenario: Not yet due
+
+- **WHEN** the worker runs before a reminder's fire time
+- **THEN** the reminder is left pending and nothing is sent
+
+#### Scenario: Due reminder deferred during quiet hours
+
+- **WHEN** a reminder becomes due while the account's local time is inside
+  its configured quiet-hours window
+- **THEN** delivery is deferred (the claim is released, not marked
+  delivered or failed) and retried on a later pass
+
+#### Scenario: A cancelled reminder leaves the batch
+
+- **WHEN** one of an account's due reminders is no longer actionable (its job closed,
+  or the user applied or unsaved) while the others still are
+- **THEN** that reminder is cancelled and excluded from the message, and the remaining
+  reminders are still delivered as one message

--- a/openspec/changes/aggregate-reminder-and-nudge-digests/specs/saved-job-reminders/spec.md
+++ b/openspec/changes/aggregate-reminder-and-nudge-digests/specs/saved-job-reminders/spec.md
@@ -41,14 +41,15 @@ only move the fire time forward, never earlier than the default delay.
 ### Requirement: One-shot delivery
 
 A reminder SHALL fire exactly once at or after its scheduled fire time and then be marked
-delivered. Due reminders SHALL be delivered grouped by user: all of one account's due,
-still-actionable reminders in a pass form one batch, and that batch SHALL be sent as a
-single message over each channel in the rule's channel set for which the user has a
-usable destination, reusing the existing notification delivery engine. Delivery SHALL be
-idempotent under worker retries: a reminder already marked delivered is never sent again.
-If the account's local time falls inside its configured quiet-hours window when its
-reminders become due, delivery of that account's whole batch SHALL be deferred to a later
-worker pass rather than sent or dropped.
+delivered. Due reminders SHALL be delivered grouped by user AND by the channel set
+snapshotted on the reminder: all of one account's due, still-actionable reminders in a
+pass that share a channel set form one batch, and that batch SHALL be sent as a single
+message over each of those channels for which the user has a usable destination, reusing
+the existing notification delivery engine. One account MAY therefore produce more than one
+batch in a pass. Delivery SHALL be idempotent under worker retries: a reminder already
+marked delivered is never sent again. If the account's local time falls inside its
+configured quiet-hours window when its reminders become due, delivery of that account's
+batches SHALL be deferred to a later worker pass rather than sent or dropped.
 
 #### Scenario: Due reminders for one user arrive as one message
 

--- a/openspec/changes/aggregate-reminder-and-nudge-digests/tasks.md
+++ b/openspec/changes/aggregate-reminder-and-nudge-digests/tasks.md
@@ -1,0 +1,41 @@
+## 1. Reminder scheduling — bucket the fire time
+
+- [ ] 1.1 Add a `GetReminderScheduleContext` query to `internal/platform/db/queries/reminders.sql` returning the account's `notification_settings.digest_time` and `users.timezone` in one read; run `make sqlc`
+- [ ] 1.2 Extend `reminder.Repository` and `QueriesRepository` with a `GetScheduleContext(ctx, userID)` returning the notification hour and IANA timezone, defaulting to 09:00 and UTC when either is unset
+- [ ] 1.3 Round `Service.fireAt` forward to the first notification hour at or after `now + DefaultDelayDays` in the account's timezone, and wire `ScheduleOnSave` to it
+- [ ] 1.4 Cover the rounding with unit tests: default 09:00/UTC, a configured `digest_time` in a non-UTC zone, two saves hours apart on one day landing on the same fire time, and rounding never moving the fire time earlier than the delay
+
+## 2. Reminder delivery — group by user
+
+- [ ] 2.1 Change `reminder.Notifier`/`Router` to take `[]ReminderMessage`, and update the compile-time assertions
+- [ ] 2.2 Add `SnapshotCap` (default 200) to `reminder.Config`; reuse `notify.ListLimit` for the message list bound
+- [ ] 2.3 Split `Runner.fire` into a per-item validation step (load, `job_open`/`still_actionable`, quiet hours) and a per-group send, and make `Runner.Run` group survivors by `user_id` oldest-due first
+- [ ] 2.4 Record one in-app notification per group: `jobs` set and `public_slug` unset for a multi-item group, today's shape for a single-item group
+- [ ] 2.5 Mark every item in a delivered group delivered, and record a delivery failure against every item in a failed group
+- [ ] 2.6 Cover with tests: two jobs of one user is one `Send`, two users is two `Send`s, a cancelled item leaves the group while the rest still deliver, a failed group attempts every item, a group of one keeps the single-job record shape
+
+## 3. Reminder transports — render a list
+
+- [ ] 3.1 Render the email body as a list of `mailtpl` job rows, itemizing at most `notify.ListLimit` with an "and N more" tail, and adjust the subject and preheader for a multi-job group
+- [ ] 3.2 Render the Telegram message as a list under the existing UTF-16 length cap, reserving the widest possible tail up front
+- [ ] 3.3 Render the push notification as a single summary carrying the group's count
+- [ ] 3.4 Cover each transport with tests for a group of one, a group under the list limit, and a group over it
+
+## 4. Nudge delivery — group by (user, kind)
+
+- [ ] 4.1 Change `nudge.Notifier`/`Router` to take a kind plus `[]Message`, and update the compile-time assertions
+- [ ] 4.2 Add `SnapshotCap` (default 200) to `nudge.Config`
+- [ ] 4.3 Split `Runner.fire` the same way as the reminder engine and group survivors by `(user_id, kind)` oldest-due first in `Runner.deliver`
+- [ ] 4.4 Record one in-app notification per group, keeping the existing `nudge_<kind>` kind string
+- [ ] 4.5 Cover with tests: four same-kind nudges is one `Send`, two kinds is two `Send`s, and each kind's record keeps its own `nudge_<kind>` value
+
+## 5. Nudge transports — render a list
+
+- [ ] 5.1 Render email, Telegram and push for a group, per kind, with the same list bound and tail as the reminder transports
+- [ ] 5.2 Cover each transport and kind with a group-of-one and a group-over-the-limit test
+
+## 6. Wire-up and documentation
+
+- [ ] 6.1 Update `cmd/remind` and `cmd/nudge` for the new notifier signatures and config fields
+- [ ] 6.2 Record the batching rule in `docs/agents/notifications.md`: what forms a group, why nudge kinds stay apart, the two bounds, and that the group is the retry unit
+- [ ] 6.3 Run `gofmt -l .`, `go vet ./...`, `go test ./...` and `go vet -tags=integration ./...`; run the integration-tagged tests for `internal/engage/...`

--- a/openspec/changes/aggregate-reminder-and-nudge-digests/tasks.md
+++ b/openspec/changes/aggregate-reminder-and-nudge-digests/tasks.md
@@ -23,19 +23,19 @@
 
 ## 4. Nudge delivery — group by (user, kind)
 
-- [ ] 4.1 Change `nudge.Notifier`/`Router` to take a kind plus `[]Message`, and update the compile-time assertions
-- [ ] 4.2 Add `SnapshotCap` (default 200) to `nudge.Config`
-- [ ] 4.3 Split `Runner.fire` the same way as the reminder engine and group survivors by `(user_id, kind)` oldest-due first in `Runner.deliver`
-- [ ] 4.4 Record one in-app notification per group, keeping the existing `nudge_<kind>` kind string
-- [ ] 4.5 Cover with tests: four same-kind nudges is one `Send`, two kinds is two `Send`s, and each kind's record keeps its own `nudge_<kind>` value
+- [x] 4.1 Change `nudge.Notifier`/`Router` to take a kind plus `[]Message`, and update the compile-time assertions
+- [x] 4.2 Add `SnapshotCap` (default 200) to `nudge.Config`
+- [x] 4.3 Split `Runner.fire` the same way as the reminder engine and group survivors by `(user_id, kind)` oldest-due first in `Runner.deliver`
+- [x] 4.4 Record one in-app notification per group, keeping the existing `nudge_<kind>` kind string
+- [x] 4.5 Cover with tests: four same-kind nudges is one `Send`, two kinds is two `Send`s, and each kind's record keeps its own `nudge_<kind>` value
 
 ## 5. Nudge transports — render a list
 
-- [ ] 5.1 Render email, Telegram and push for a group, per kind, with the same list bound and tail as the reminder transports
-- [ ] 5.2 Cover each transport and kind with a group-of-one and a group-over-the-limit test
+- [x] 5.1 Render email, Telegram and push for a group, per kind, with the same list bound and tail as the reminder transports
+- [x] 5.2 Cover each transport and kind with a group-of-one and a group-over-the-limit test
 
 ## 6. Wire-up and documentation
 
-- [ ] 6.1 Update `cmd/remind` and `cmd/nudge` for the new notifier signatures and config fields
-- [ ] 6.2 Record the batching rule in `docs/agents/notifications.md`: what forms a group, why nudge kinds stay apart, the two bounds, and that the group is the retry unit
-- [ ] 6.3 Run `gofmt -l .`, `go vet ./...`, `go test ./...` and `go vet -tags=integration ./...`; run the integration-tagged tests for `internal/engage/...`
+- [x] 6.1 Update `cmd/remind` and `cmd/nudge` for the new notifier signatures and config fields
+- [x] 6.2 Record the batching rule in `docs/agents/notifications.md`: what forms a group, why nudge kinds stay apart, the two bounds, and that the group is the retry unit
+- [x] 6.3 Run `gofmt -l .`, `go vet ./...`, `go test ./...` and `go vet -tags=integration ./...`; run the integration-tagged tests for `internal/engage/...`

--- a/openspec/changes/aggregate-reminder-and-nudge-digests/tasks.md
+++ b/openspec/changes/aggregate-reminder-and-nudge-digests/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Reminder scheduling — bucket the fire time
 
-- [ ] 1.1 Add a `GetReminderScheduleContext` query to `internal/platform/db/queries/reminders.sql` returning the account's `notification_settings.digest_time` and `users.timezone` in one read; run `make sqlc`
-- [ ] 1.2 Extend `reminder.Repository` and `QueriesRepository` with a `GetScheduleContext(ctx, userID)` returning the notification hour and IANA timezone, defaulting to 09:00 and UTC when either is unset
-- [ ] 1.3 Round `Service.fireAt` forward to the first notification hour at or after `now + DefaultDelayDays` in the account's timezone, and wire `ScheduleOnSave` to it
-- [ ] 1.4 Cover the rounding with unit tests: default 09:00/UTC, a configured `digest_time` in a non-UTC zone, two saves hours apart on one day landing on the same fire time, and rounding never moving the fire time earlier than the delay
+- [x] 1.1 Add a `GetReminderScheduleContext` query to `internal/platform/db/queries/reminders.sql` returning the account's `notification_settings.digest_time` and `users.timezone` in one read; run `make sqlc`
+- [x] 1.2 Extend `reminder.Repository` and `QueriesRepository` with a `GetScheduleContext(ctx, userID)` returning the notification hour and IANA timezone, defaulting to 09:00 and UTC when either is unset
+- [x] 1.3 Round `Service.fireAt` forward to the first notification hour at or after `now + DefaultDelayDays` in the account's timezone, and wire `ScheduleOnSave` to it
+- [x] 1.4 Cover the rounding with unit tests: default 09:00/UTC, a configured `digest_time` in a non-UTC zone, two saves hours apart on one day landing on the same fire time, and rounding never moving the fire time earlier than the delay
 
 ## 2. Reminder delivery — group by user
 

--- a/openspec/changes/aggregate-reminder-and-nudge-digests/tasks.md
+++ b/openspec/changes/aggregate-reminder-and-nudge-digests/tasks.md
@@ -7,19 +7,19 @@
 
 ## 2. Reminder delivery — group by user
 
-- [ ] 2.1 Change `reminder.Notifier`/`Router` to take `[]ReminderMessage`, and update the compile-time assertions
-- [ ] 2.2 Add `SnapshotCap` (default 200) to `reminder.Config`; reuse `notify.ListLimit` for the message list bound
-- [ ] 2.3 Split `Runner.fire` into a per-item validation step (load, `job_open`/`still_actionable`, quiet hours) and a per-group send, and make `Runner.Run` group survivors by `user_id` oldest-due first
-- [ ] 2.4 Record one in-app notification per group: `jobs` set and `public_slug` unset for a multi-item group, today's shape for a single-item group
-- [ ] 2.5 Mark every item in a delivered group delivered, and record a delivery failure against every item in a failed group
-- [ ] 2.6 Cover with tests: two jobs of one user is one `Send`, two users is two `Send`s, a cancelled item leaves the group while the rest still deliver, a failed group attempts every item, a group of one keeps the single-job record shape
+- [x] 2.1 Change `reminder.Notifier`/`Router` to take `[]ReminderMessage`, and update the compile-time assertions
+- [x] 2.2 Add `SnapshotCap` (default 200) to `reminder.Config`; reuse `notify.ListLimit` for the message list bound
+- [x] 2.3 Split `Runner.fire` into a per-item validation step (load, `job_open`/`still_actionable`, quiet hours) and a per-group send, and make `Runner.Run` group survivors by `user_id` oldest-due first
+- [x] 2.4 Record one in-app notification per group: `jobs` set and `public_slug` unset for a multi-item group, today's shape for a single-item group
+- [x] 2.5 Mark every item in a delivered group delivered, and record a delivery failure against every item in a failed group
+- [x] 2.6 Cover with tests: two jobs of one user is one `Send`, two users is two `Send`s, a cancelled item leaves the group while the rest still deliver, a failed group attempts every item, a group of one keeps the single-job record shape
 
 ## 3. Reminder transports — render a list
 
-- [ ] 3.1 Render the email body as a list of `mailtpl` job rows, itemizing at most `notify.ListLimit` with an "and N more" tail, and adjust the subject and preheader for a multi-job group
-- [ ] 3.2 Render the Telegram message as a list under the existing UTF-16 length cap, reserving the widest possible tail up front
-- [ ] 3.3 Render the push notification as a single summary carrying the group's count
-- [ ] 3.4 Cover each transport with tests for a group of one, a group under the list limit, and a group over it
+- [x] 3.1 Render the email body as a list of `mailtpl` job rows, itemizing at most `notify.ListLimit` with an "and N more" tail, and adjust the subject and preheader for a multi-job group
+- [x] 3.2 Render the Telegram message as a list under the existing UTF-16 length cap, reserving the widest possible tail up front
+- [x] 3.3 Render the push notification as a single summary carrying the group's count
+- [x] 3.4 Cover each transport with tests for a group of one, a group under the list limit, and a group over it
 
 ## 4. Nudge delivery — group by (user, kind)
 


### PR DESCRIPTION
Saved-search subscriptions already arrive as one digest. The other two notification
engines still sent one message per item: save eight jobs in a day and three days later
you got eight emails; five silent applications got five nudges in one 30-minute pass.
That flood is what makes people turn notifications off, which costs every future alert
and not just the noisy ones.

## What changed

- **Reminders** group by account (and by channel set — see below) and go out as one
  message per pass, on email, Telegram and push alike.
- **Nudges** group by `(account, kind)`. The three kinds stay in separate messages:
  "your application went quiet" and "prepare for your interview" are different errands
  with different actions, and a mail that merged them would say neither.
- **A reminder's `fire_at` is rounded forward to the account's notification hour**
  (`notification_settings.digest_time` in the account timezone; 09:00 UTC when unset).
  Grouping alone bought the reminder engine almost nothing — `fire_at` was save + 3 days
  exactly and the worker ticks every 15 minutes, so two saves hours apart landed in
  different passes. This is the visible behaviour change: a reminder now lands at the
  account's hour on or after the third day, not exactly 72 hours after the save.
- **One in-app notification per grouped delivery**, carrying the job list in
  `user_notifications.jobs` — the JSONB column migration 0091 already added and
  `/my/notifications/[id]/jobs` already renders. A group of one keeps today's shape.
- Each engine's `Notifier` seam is batch-shaped, so no channel can keep a per-item send
  path alive. A group of one is byte-identical to what shipped — the single-reminder
  golden previews diff clean against `main`.

No schema migration. `cmd/remind` and `cmd/nudge` needed no wiring change.

## Things worth a reviewer's eye

- **Reminder channels are a snapshot, not an account property.** `job_reminders.channels`
  is frozen when the reminder is scheduled (migration 0034, deliberately: "a later rule
  edit never rewrites a pending reminder"). Grouping on the account alone would have sent
  one reminder over another's channels and stamped it delivered. The channel set is part
  of the batch key, canonicalized so a different stored order still groups.
- **The claim queries now sort outside their `UPDATE … RETURNING`.** The CTE's `ORDER BY`
  only picks *which* rows are claimed; Postgres does not oblige the update to emit them
  in that order. That was harmless before and is load-bearing now that the result becomes
  a list in a message.
- **Two bounds, deliberately different numbers**: `notify.ListLimit` (10) is what a
  message itemizes, `SnapshotCap` (200) is what the group carries and the record holds.
  They were one knob until 2026-08-21 and lowering the email's list silently truncated the
  page the email linked to. Beyond `SnapshotCap` the excess is *released*, never stamped —
  an item marked delivered while appearing in no message is gone for good.
- **The batch is the retry unit.** One send outcome decides all of its items; a partial
  result would need a second delivery ledger and nothing reads one.
- `notify.SnapshotJob`/`JobsSnapshot`, `notify.Listed` and
  `telegramnotify.MaxMessageLen`/`UTF16Len` are now shared rather than copied per engine —
  these are the rules that would silently diverge. The batching *loop* stays duplicated
  between the two engines; `docs/agents/notifications.md` argues why, and what the signal
  to extract it would be.

## Verification

`go build`, `go vet`, `go vet -tags=integration`, `go test ./...`, `gofmt`, and every
pre-commit hook pass. New unit tests cover: same-account grouping, per-kind separation,
different channel sets kept apart, a cancelled item leaving the group, a failed group
attempting every member, the overflow release path, both list bounds on all three
channels, the Telegram length cap, and the `fire_at` rounding (including DST-safe
wall-clock construction and same-day saves converging).

Reviewed along two axes by sub-agents before opening; three defects they found are fixed
in the last commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Saved-job reminders and follow-up notifications are now grouped into digest-style messages instead of sending one notification per job.
  - Email, Telegram, and push notifications can list multiple jobs, show additional-item counts, and link to the relevant tracking or saved-jobs page.
  - Reminder delivery is aligned with your configured notification time and timezone.
  - Added light and dark email previews for grouped reminders and follow-up nudges.

- **Documentation**
  - Documented grouped delivery, item limits, scheduling, and overflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->