### PR TITLE
Attribute micro1's outbound links to a referral code

### DIFF
--- a/internal/ingest/sources/micro1.go
+++ b/internal/ingest/sources/micro1.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -16,8 +17,17 @@ import (
 // Next.js RSC flight stream (no standalone ld+json tag). This is the dataart shape — sitemap
 // to enumerate, per-posting detail fetch — with the detail parsed out of the flight via the
 // shared decodeNextFlight/bracketSlice/nextFlightTextRows primitives (as deel does).
+//
+// Outbound links are attributable: micro1 pays a per-posting bounty for a referred candidate
+// (the amount is printed on the posting itself), and it is earned only when the candidate
+// arrives carrying a referral code. See applyURL.
 type micro1 struct {
 	http micro1HTTP
+	// referral is the micro1 referral code outbound links are attributed to, from
+	// MICRO1_REFERRAL_CODE (see registry.go). Empty means unattributed: the URL stays the
+	// canonical board posting, which is what an installation that is not a micro1 referrer —
+	// including every fork of this repository — gets.
+	referral string
 }
 
 // micro1HTTP is the transport micro1 needs: the XML sitemap plus HTML detail pages.
@@ -28,8 +38,14 @@ type micro1HTTP interface {
 
 const micro1SitemapURL = "https://jobs.micro1.ai/sitemap.xml"
 
-// NewMicro1 builds the micro1 adapter over the given HTTP client.
-func NewMicro1(c micro1HTTP) Source { return micro1{http: c} }
+// NewMicro1 builds the micro1 adapter over the given HTTP client, attributing outbound links
+// to the given micro1 referral code (empty = unattributed, see micro1.referral).
+func NewMicro1(c micro1HTTP, referral string) Source {
+	if !micro1ReferralCodePattern.MatchString(referral) {
+		referral = "" // absent or malformed: crawl unattributed rather than emit a broken link
+	}
+	return micro1{http: c, referral: referral}
+}
 
 func (micro1) Provider() string { return "micro1" }
 
@@ -97,7 +113,7 @@ func (m micro1) detail(ctx context.Context, ce CompanyEntry, jobURL string) (Job
 	location := strings.TrimSpace(d.LocationName)
 	return Job{
 		ExternalID:  d.ClientJobID,
-		URL:         jobURL,
+		URL:         m.applyURL(jobURL),
 		Title:       strings.TrimSpace(d.JobRoleName),
 		Company:     ce.Company,
 		Location:    location,
@@ -148,6 +164,45 @@ func micro1PostID(u string) string {
 		return m[1]
 	}
 	return ""
+}
+
+// micro1ReferralCodePattern is the shape of a micro1 referral code: a UUID, as micro1's own
+// share links carry. The code is interpolated into an outbound URL, so anything else is
+// rejected at construction rather than escaped — a code is copied from the referral dashboard
+// by hand, and a malformed one is a misconfiguration to notice, not input to sanitise.
+var micro1ReferralCodePattern = regexp.MustCompile(
+	`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// micro1ReferralHost is the host micro1's own share links point a referred candidate at. It is
+// NOT the board host the sitemap enumerates, but the two share one posting-id space: a posting
+// id taken from jobs.micro1.ai/post/<uuid> renders the same vacancy at req.micro1.ai/post/<uuid>
+// (verified live across several of our own stored ids). The referral host is the one micro1
+// hands out, so it is the one we hand on.
+const micro1ReferralHost = "https://req.micro1.ai/post/"
+
+// applyURL rewrites a canonical board posting URL into micro1's own referral share link, so a
+// candidate who applies is attributed to the configured referrer. micro1 sets no attribution
+// cookie of its own — the apply form sits on the posting page and reads the code straight off
+// the query — so the code has to still be in the URL at the moment the candidate applies, which
+// is exactly what carrying it on the stored outbound link achieves.
+//
+// The utm_* triple mirrors what micro1's share button emits verbatim rather than being invented
+// here: they are micro1's own campaign tags, and a link that differs from the one they generate
+// is a link whose attribution we would be guessing at.
+//
+// An unset code (or a URL that is not a canonical posting) leaves the board URL alone.
+func (m micro1) applyURL(jobURL string) string {
+	id := micro1PostID(jobURL)
+	if m.referral == "" || id == "" {
+		return jobURL
+	}
+	q := url.Values{
+		"referralCode": {m.referral},
+		"utm_source":   {"referral"},
+		"utm_medium":   {"share"},
+		"utm_campaign": {"data_referral"},
+	}
+	return micro1ReferralHost + id + "?" + q.Encode()
 }
 
 // micro1Data is the subset of a micro1 posting's RSC-flight `data` object the adapter maps.

--- a/internal/ingest/sources/micro1_test.go
+++ b/internal/ingest/sources/micro1_test.go
@@ -126,13 +126,13 @@ func TestMicro1PostID(t *testing.T) {
 }
 
 func TestMicro1Provider(t *testing.T) {
-	if got := NewMicro1(nil).Provider(); got != "micro1" {
+	if got := NewMicro1(nil, "").Provider(); got != "micro1" {
 		t.Errorf("Provider() = %q, want %q", got, "micro1")
 	}
 }
 
 func TestMicro1IsBoardless(t *testing.T) {
-	if _, ok := NewMicro1(nil).(boardless); !ok {
+	if _, ok := NewMicro1(nil, "").(boardless); !ok {
 		t.Error("micro1 adapter must be boardless (single-company, fixed host)")
 	}
 }
@@ -215,7 +215,7 @@ func TestMicro1Fetch(t *testing.T) {
 		page:       micro1ParseFixture(t, "micro1_post.html"),
 		sitemapXML: micro1Fixture(t, "micro1_sitemap.xml"),
 	}
-	jobs, err := NewMicro1(fake).Fetch(context.Background(), CompanyEntry{Company: "micro1"})
+	jobs, err := NewMicro1(fake, "").Fetch(context.Background(), CompanyEntry{Company: "micro1"})
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
@@ -227,5 +227,46 @@ func TestMicro1Fetch(t *testing.T) {
 		if j.Title != "Open Source Contributor" || j.Company != "micro1" {
 			t.Errorf("job = %+v, want fixture posting mapped under company micro1", j)
 		}
+	}
+}
+
+// micro1TestReferralCode is a well-formed but fictional referral code. The real one is an
+// account identifier and lives in MICRO1_REFERRAL_CODE, never in this repository.
+const micro1TestReferralCode = "00000000-1111-2222-3333-444444444444"
+
+func TestMicro1ApplyURLCarriesTheReferralCode(t *testing.T) {
+	m := micro1{referral: micro1TestReferralCode}
+	got := m.applyURL("https://jobs.micro1.ai/post/5b80dfdc-b737-4626-99f2-50baf207b94e")
+
+	// micro1's own share shape: the posting id moved onto the referral host, code on the query.
+	// The two hosts share one posting-id space, so the id carries across unchanged.
+	want := "https://req.micro1.ai/post/5b80dfdc-b737-4626-99f2-50baf207b94e" +
+		"?referralCode=" + micro1TestReferralCode +
+		"&utm_campaign=data_referral&utm_medium=share&utm_source=referral"
+	if got != want {
+		t.Errorf("applyURL() = %q, want %q", got, want)
+	}
+	// The trailing-slash form the sitemap also emits must fold onto the same link, else one
+	// posting would ship two different outbound URLs.
+	if slashed := m.applyURL("https://jobs.micro1.ai/post/5b80dfdc-b737-4626-99f2-50baf207b94e/"); slashed != want {
+		t.Errorf("applyURL(trailing slash) = %q, want %q", slashed, want)
+	}
+}
+
+func TestMicro1ApplyURLIsCanonicalWithoutACode(t *testing.T) {
+	// No code configured (every fork of this repository): the outbound link stays the board
+	// posting rather than pointing at somebody else's referral.
+	const jobURL = "https://jobs.micro1.ai/post/5b80dfdc-b737-4626-99f2-50baf207b94e"
+	if got := (micro1{}).applyURL(jobURL); got != jobURL {
+		t.Errorf("applyURL() = %q, want the canonical URL unchanged", got)
+	}
+	// A non-posting URL has no id to move onto the referral host, so it is left alone.
+	const listURL = "https://jobs.micro1.ai/"
+	if got := (micro1{referral: micro1TestReferralCode}).applyURL(listURL); got != listURL {
+		t.Errorf("applyURL(non-posting) = %q, want it unchanged", got)
+	}
+	// A malformed code would be interpolated into a URL, so the constructor drops it.
+	if s := NewMicro1(nil, "not-a-uuid").(micro1); s.referral != "" {
+		t.Errorf("referral = %q, want it dropped as malformed", s.referral)
 	}
 }

--- a/internal/ingest/sources/registry.go
+++ b/internal/ingest/sources/registry.go
@@ -265,7 +265,7 @@ func All(c HTTPClient) map[string]Source {
 		NewOnstrider(c, os.Getenv("ONSTRIDER_REFERRAL_HANDLE")),
 		NewAlignerr(c),
 		NewTalentHR(c),
-		NewMicro1(c),
+		NewMicro1(c, os.Getenv("MICRO1_REFERRAL_CODE")),
 		NewBairesDev(c),
 		// RU federal open-data aggregator: board-based, sharded per region (board = OKATO code).
 		// Concurrency-limited: its gov API degrades under the pipeline's board concurrency (500s +


### PR DESCRIPTION
## What

We crawl **337 open micro1 postings** and were sending every one of them out unattributed.

micro1 pays a per-posting bounty for a referred candidate — the amount is printed on the posting itself (`Refer and Earn $1500` on the one this was verified against) — and it is earned only if the candidate arrives carrying a referral code.

`MICRO1_REFERRAL_CODE` sets the code. Same precedent as `WHATJOBS_PUBLISHER_IDS` and `ONSTRIDER_REFERRAL_HANDLE`: an account identifier belongs in the environment, not in a board file this repository publishes. Unset — every fork — keeps the canonical board URL.

## The two hosts

micro1's own share button points at `req.micro1.ai`, not the `jobs.micro1.ai` our sitemap enumerates. They share one posting-id space — ids taken from our own stored URLs render the same vacancy on the referral host, checked live against three of them:

| our stored id | renders on req.micro1.ai as |
|---|---|
| `5b80dfdc-…` | Head of Communications |
| `251f01db-…` | General Counsel |
| `a58e34d6-…` | Commercial Contracts Attorney — M&A Diligence |

So `applyURL` moves the id onto the referral host and hangs the code off the query. The `utm_*` triple is copied verbatim from what micro1 generates rather than invented — a link that differs from theirs is a link whose attribution we would be guessing at.

## Why the code has to live on the stored link

micro1 sets **no attribution cookie**. The apply form sits on the posting page and reads the code straight off the query string, so the code has to still be in the URL at the moment the candidate applies. Carrying it on the stored outbound link is what makes attribution work, not a cosmetic choice.

This was checked rather than assumed, because the Strider integration (#2299) proved the obvious-looking link form is not always the one that attributes.

## Blast radius

Nothing else parses these URLs: `micro1PostID` is only ever applied to sitemap entries inside the adapter (grepped across the module, including `linksource`, `atsboard` and `internal/job`). Moving the stored host is contained to this source.

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...` — pass
- `go vet -tags=integration ./...` — pass
- New tests: `applyURL` builds the referral link and folds the trailing-slash URL form onto the same link; no code leaves the URL canonical; a non-posting URL is left alone; a malformed code is dropped at construction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional referral-code attribution for Micro1 job links.
  * Valid referral codes now generate shareable links with referral and tracking parameters.
  * Invalid or missing referral codes continue to use standard job URLs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->