### PR TITLE
Attribute BairesDev's and Alignerr's outbound links too

### DIFF
--- a/internal/ingest/sources/alignerr.go
+++ b/internal/ingest/sources/alignerr.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -12,12 +13,46 @@ import (
 // __NEXT_DATA__ script: the /jobs listing carries every active posting's id and title (its
 // description truncated to a preview), so the full body, dates, and structured fields come
 // from each posting's own detail page, fanned out like the other detail-fetching adapters.
+//
+// Outbound links are attributable: Alignerr pays a bounty for a referred contributor who
+// onboards and logs hours, and it is earned only when the contributor arrives carrying a
+// referral code. See applyURL.
 type alignerr struct {
 	http TextGetter
+	// referral is the Alignerr referral code outbound links are attributed to, from
+	// ALIGNERR_REFERRAL_CODE (see registry.go). Empty means unattributed: the URL stays the
+	// plain posting page, which is what an installation that is not an Alignerr referrer —
+	// including every fork of this repository — gets.
+	referral string
 }
 
-// NewAlignerr builds the Alignerr adapter over the given HTTP client.
-func NewAlignerr(c TextGetter) Source { return alignerr{http: c} }
+// NewAlignerr builds the Alignerr adapter over the given HTTP client, attributing outbound
+// links to the given referral code (empty = unattributed, see alignerr.referral).
+func NewAlignerr(c TextGetter, referral string) Source {
+	if !alignerrReferralCodePattern.MatchString(referral) {
+		referral = "" // absent or malformed: crawl unattributed rather than emit a broken link
+	}
+	return alignerr{http: c, referral: referral}
+}
+
+// alignerrReferralCodePattern is the shape of an Alignerr referral code: a UUID, as its own
+// share links carry. The code is interpolated into an outbound URL, so anything else is
+// rejected at construction rather than escaped — a code is copied from the "Refer & earn"
+// panel by hand, and a malformed one is a misconfiguration to notice.
+var alignerrReferralCodePattern = regexp.MustCompile(
+	`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// applyURL hangs the configured referral code off the posting page, which is all Alignerr needs:
+// the page reads the parameter and builds its OWN apply links from it, pointing at
+// app.alignerr.com/signin?job=<posting id>&referral-code=<code> (verified live — the id it uses
+// is the same posting id we already store, so nothing has to be looked up). An unset code leaves
+// the plain posting URL alone.
+func (a alignerr) applyURL(jobURL string) string {
+	if a.referral == "" {
+		return jobURL
+	}
+	return jobURL + "?referral-code=" + a.referral
+}
 
 func (alignerr) Provider() string { return "alignerr" }
 
@@ -120,7 +155,7 @@ func (a alignerr) detail(ctx context.Context, e CompanyEntry, it alignerrListIte
 	location := firstNonEmpty(it.Location, j.Location)
 	return Job{
 		ExternalID:     id,
-		URL:            jobURL,
+		URL:            a.applyURL(jobURL),
 		Title:          firstNonEmpty(strings.TrimSpace(j.Name), strings.TrimSpace(it.Title)),
 		Company:        e.Company,
 		Location:       location,

--- a/internal/ingest/sources/alignerr_test.go
+++ b/internal/ingest/sources/alignerr_test.go
@@ -38,7 +38,7 @@ func alignerrDetailJSON(id, name, jobType string, active bool) string {
 }
 
 func TestAlignerrProvider(t *testing.T) {
-	if got := NewAlignerr(nil).Provider(); got != "alignerr" {
+	if got := NewAlignerr(nil, "").Provider(); got != "alignerr" {
 		t.Errorf("Provider() = %q, want %q", got, "alignerr")
 	}
 }
@@ -48,7 +48,7 @@ func TestAlignerrFetchListingThenDetailAndMaps(t *testing.T) {
 		route("/jobs/aaa", alignerrDetailJSON("aaa", "Software Engineer Task Author (AI Training)", "CONTRACT", true)).
 		route("alignerr.com/jobs", alignerrListingJSON("aaa"))
 
-	jobs, err := NewAlignerr(fake).Fetch(context.Background(), CompanyEntry{Company: "Alignerr", Provider: "alignerr"})
+	jobs, err := NewAlignerr(fake, "").Fetch(context.Background(), CompanyEntry{Company: "Alignerr", Provider: "alignerr"})
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestAlignerrDropsInactiveAndMissingDetail(t *testing.T) {
 		// no route for "gone" → its detail fetch fails
 		route("alignerr.com/jobs", alignerrListingJSON("live", "closed", "gone"))
 
-	jobs, err := NewAlignerr(fake).Fetch(context.Background(), CompanyEntry{Company: "Alignerr"})
+	jobs, err := NewAlignerr(fake, "").Fetch(context.Background(), CompanyEntry{Company: "Alignerr"})
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestAlignerrSanitizesShortDescriptionFallback(t *testing.T) {
 		route("/jobs/aaa", detail).
 		route("alignerr.com/jobs", alignerrListingJSON("aaa"))
 
-	jobs, err := NewAlignerr(fake).Fetch(context.Background(), CompanyEntry{Company: "Alignerr"})
+	jobs, err := NewAlignerr(fake, "").Fetch(context.Background(), CompanyEntry{Company: "Alignerr"})
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
@@ -153,5 +153,25 @@ func TestAlignerrRegisteredInAll(t *testing.T) {
 	// Single-company boardless: redundant with the company filter, so excluded from the facet.
 	if slices.Contains(FilterableProviders(), "alignerr") {
 		t.Error("FilterableProviders() should exclude boardless alignerr")
+	}
+}
+
+func TestAlignerrApplyURLCarriesTheReferralCode(t *testing.T) {
+	// The code is fictional: the real one is an account identifier and lives in
+	// ALIGNERR_REFERRAL_CODE, never in this repository.
+	const code = "00000000-1111-2222-3333-444444444444"
+	const jobURL = "https://www.alignerr.com/jobs/0060423d-eca1-4321-a802-93fb04195a46"
+
+	// The posting page reads the parameter and builds its own apply link from it, so hanging
+	// the code off the posting URL is the whole integration — no id lookup is needed.
+	if got, want := (alignerr{referral: code}).applyURL(jobURL), jobURL+"?referral-code="+code; got != want {
+		t.Errorf("applyURL() = %q, want %q", got, want)
+	}
+	if got := (alignerr{}).applyURL(jobURL); got != jobURL {
+		t.Errorf("applyURL() = %q, want the posting URL unchanged", got)
+	}
+	// A malformed code would be interpolated into a URL, so the constructor drops it.
+	if s := NewAlignerr(nil, "nope").(alignerr); s.referral != "" {
+		t.Errorf("referral = %q, want it dropped as malformed", s.referral)
 	}
 }

--- a/internal/ingest/sources/bairesdev.go
+++ b/internal/ingest/sources/bairesdev.go
@@ -18,8 +18,17 @@ import (
 // the public per-job endpoint (/api/JobPosting?JobPostingId=<id>) — the same schema.org JSON-LD
 // the linksource adapter reads, giving a clean title, description, date, and remote flag.
 // Single-company (every posting is BairesDev) and boardless, so its config entry is a placeholder.
+//
+// Outbound links are attributable: BairesDev pays a bounty for a referred candidate who is
+// hired and stays, and it is earned only when the candidate arrives carrying a referrer code.
+// See applyURL.
 type bairesdev struct {
 	http bairesDevHTTP
+	// referral is the BairesDev referrer code outbound links are attributed to, from
+	// BAIRESDEV_REFERRER_CODE (see registry.go). Empty means unattributed: the URL stays the
+	// plain apply link, which is what an installation that is not a BairesDev referrer —
+	// including every fork of this repository — gets.
+	referral string
 }
 
 // bairesDevHTTP is the transport bairesdev needs: the talent site's raw HTML (to read the embedded
@@ -40,8 +49,32 @@ const (
 	bairesDevApplyURL     = "https://applicants.bairesdev.com/job/%s/%s/apply"
 )
 
-// NewBairesDev builds the BairesDev adapter over the given HTTP client.
-func NewBairesDev(c bairesDevHTTP) Source { return bairesdev{http: c} }
+// NewBairesDev builds the BairesDev adapter over the given HTTP client, attributing outbound
+// links to the given referrer code (empty = unattributed, see bairesdev.referral).
+func NewBairesDev(c bairesDevHTTP, referral string) Source {
+	if !bairesDevReferrerCodePattern.MatchString(referral) {
+		referral = "" // absent or malformed: crawl unattributed rather than emit a broken link
+	}
+	return bairesdev{http: c, referral: referral}
+}
+
+// bairesDevReferrerCodePattern is the shape of a BairesDev referrer code: the opaque
+// alphanumeric token its share links carry. The code is interpolated into an outbound URL, so
+// anything else is rejected at construction rather than escaped — a code is copied from the
+// referral dashboard by hand, and a malformed one is a misconfiguration to notice.
+var bairesDevReferrerCodePattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+// applyURL hangs the configured referrer code off the apply link, which is all BairesDev needs:
+// its apply flow keeps the parameter across the hop to the login/register step (verified live —
+// clicking Apply on a job carrying ?referrer=<code> lands on
+// /login?careerId=…&jobId=…&referrer=<code>), so a candidate who signs up from our link is
+// attributed. An unset code leaves the plain apply link alone.
+func (b bairesdev) applyURL(applyLink string) string {
+	if b.referral == "" {
+		return applyLink
+	}
+	return applyLink + "?referrer=" + b.referral
+}
 
 func (bairesdev) Provider() string { return "bairesdev" }
 
@@ -201,7 +234,7 @@ func (b bairesdev) detail(ctx context.Context, r bairesDevRef) (Job, bool) {
 	}
 	return Job{
 		ExternalID:  r.jobID,
-		URL:         fmt.Sprintf(bairesDevApplyURL, r.careerID, r.jobID),
+		URL:         b.applyURL(fmt.Sprintf(bairesDevApplyURL, r.careerID, r.jobID)),
 		Title:       p.Title,
 		Company:     company,
 		Location:    r.location,

--- a/internal/ingest/sources/bairesdev_test.go
+++ b/internal/ingest/sources/bairesdev_test.go
@@ -73,7 +73,7 @@ func TestBairesDevCrawlsListingDedupsAndHydrates(t *testing.T) {
 		},
 	}
 
-	jobs, err := NewBairesDev(fake).Fetch(context.Background(), CompanyEntry{})
+	jobs, err := NewBairesDev(fake, "").Fetch(context.Background(), CompanyEntry{})
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
@@ -128,7 +128,7 @@ func TestBairesDevSkipsPostingThatNoLongerResolves(t *testing.T) {
 		listing: bairesDevListingHTML([2]string{"https://applicants.bairesdev.com/job/97/999999/apply", "Ghost | Remote Work | Brazil"}),
 		jobs:    map[string]string{"999999": `{}`},
 	}
-	jobs, err := NewBairesDev(fake).Fetch(context.Background(), CompanyEntry{})
+	jobs, err := NewBairesDev(fake, "").Fetch(context.Background(), CompanyEntry{})
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
@@ -139,7 +139,26 @@ func TestBairesDevSkipsPostingThatNoLongerResolves(t *testing.T) {
 
 func TestBairesDevErrorsWhenNoWidget(t *testing.T) {
 	fake := &bairesDevFake{listing: "<html>no widget here</html>"}
-	if _, err := NewBairesDev(fake).Fetch(context.Background(), CompanyEntry{}); err == nil {
+	if _, err := NewBairesDev(fake, "").Fetch(context.Background(), CompanyEntry{}); err == nil {
 		t.Fatal("want error when the talent listing has no job widget")
+	}
+}
+
+func TestBairesDevApplyURLCarriesTheReferrerCode(t *testing.T) {
+	// The code is fictional: the real one is an account identifier and lives in
+	// BAIRESDEV_REFERRER_CODE, never in this repository.
+	const code = "AbC123xyZ_-"
+	const apply = "https://applicants.bairesdev.com/job/1001/298849/apply"
+
+	if got, want := (bairesdev{referral: code}).applyURL(apply), apply+"?referrer="+code; got != want {
+		t.Errorf("applyURL() = %q, want %q", got, want)
+	}
+	// No code configured (every fork of this repository): the plain apply link is unchanged.
+	if got := (bairesdev{}).applyURL(apply); got != apply {
+		t.Errorf("applyURL() = %q, want the apply link unchanged", got)
+	}
+	// A malformed code would be interpolated into a URL, so the constructor drops it.
+	if s := NewBairesDev(nil, "not a code&x=1").(bairesdev); s.referral != "" {
+		t.Errorf("referral = %q, want it dropped as malformed", s.referral)
 	}
 }

--- a/internal/ingest/sources/registry.go
+++ b/internal/ingest/sources/registry.go
@@ -263,10 +263,10 @@ func All(c HTTPClient) map[string]Source {
 		NewLumenalta(c),
 		NewDataArt(c),
 		NewOnstrider(c, os.Getenv("ONSTRIDER_REFERRAL_HANDLE")),
-		NewAlignerr(c),
+		NewAlignerr(c, os.Getenv("ALIGNERR_REFERRAL_CODE")),
 		NewTalentHR(c),
 		NewMicro1(c, os.Getenv("MICRO1_REFERRAL_CODE")),
-		NewBairesDev(c),
+		NewBairesDev(c, os.Getenv("BAIRESDEV_REFERRER_CODE")),
 		// RU federal open-data aggregator: board-based, sharded per region (board = OKATO code).
 		// Concurrency-limited: its gov API degrades under the pipeline's board concurrency (500s +
 		// read-timeouts), so its in-flight requests are capped to a gentle few.


### PR DESCRIPTION
## What

Two more sources that pay a referral bounty, and that earn it only when the candidate arrives carrying a code. Until now all of them went out unattributed:

| source | open postings |
|---|---|
| BairesDev | 531 |
| Alignerr | 115 |

Same shape as the micro1 (#2304) and Strider (#2299) work: `BAIRESDEV_REFERRER_CODE` / `ALIGNERR_REFERRAL_CODE` live in the environment rather than a board file this repository publishes, unset (every fork) keeps the plain link, and a malformed code is dropped at construction rather than escaped — it is interpolated into a URL, and a code is copied from a dashboard by hand.

## Neither needs the URL rewritten — but that was checked, not assumed

Strider's obvious-looking link form turned out not to attribute at all, so both of these were verified live in a browser before any code was written.

**BairesDev** keeps the parameter across the hop into its apply flow. Clicking Apply on a job page carrying `?referrer=<code>`:

```
https://applicants.bairesdev.com/job/1001/298849/apply?referrer=<code>
  → https://applicants.bairesdev.com/login?careerId=1001&jobId=298849&referrer=<code>&lang=en
```

The apply URL we already store is on `applicants.bairesdev.com` — the same host its own share links use — so one query parameter is the whole integration.

**Alignerr**'s posting page reads `?referral-code=<code>` and builds its OWN apply links from it:

```
https://app.alignerr.com/signin?job=0060423d-…&referral-code=<code>
```

The posting id it puts there is the same id we already store in the URL, so nothing has to be looked up or mapped.

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...` — pass
- `go vet -tags=integration ./...` — pass
- New tests per adapter: `applyURL` hangs the code off the stored URL; no code leaves the URL unchanged; a malformed code is dropped at construction
- Note `internal/ingest/linksource` has its own unrelated `NewBairesDev`; it is untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional referral attribution to Alignerr and BairesDev job application links.
  - Configured referral codes are included automatically when generating application URLs.
  - Referral codes can be supplied through environment settings for centralized configuration.

- **Bug Fixes**
  - Invalid or malformed referral codes are ignored, allowing application links to work without attribution.
  - Links remain unchanged when no valid referral code is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->