### PR TITLE
Recognise the six ATS platforms crawled since today

### DIFF
--- a/internal/ingest/atsboard/AGENTS.md
+++ b/internal/ingest/atsboard/AGENTS.md
@@ -19,15 +19,22 @@ nothing but the URL. No network, no database.
   exist, while one adapter serves both domains as `factorial`.
 - **Adding an ATS is one row plus one test case.** Extraction modes say where the tenant sits:
   `path` (first path segment), `pathlocale` (same, skipping a leading `xx-XX` locale),
-  `pathportal` (the segment before the posting, for SmartRecruiters' portal URLs — plus its
+  `pathlocalepair` (the first TWO segments after that locale — Dayforce's board is
+  `<tenant>/<site>` and one tenant runs several sites), `pathportal` (the segment before the
+  posting, for SmartRecruiters' portal URLs — plus its
   one-click apply form, `/oneclick-ui/company/<board>/publication/<uuid>`, which names the
   employer mid-path and would otherwise be read as a board called `oneclick-ui`),
   `pathnumeric` (like `path`, but the segment must be an all-digit id — PageUp's board is a
   numeric institution id, so localisation/section segments like `/cw/en/search` are not
-  boards), `subdomain`
+  boards), `query` (a named query parameter, because Paycor serves every board from one path
+  under `?clientId=<board>`; `queryBoards` names the parameter, and it is the one mode that
+  needs a second row — a test fails if it is missing), `subdomain`
   (leftmost DNS label), `subdomainchain` (every label under the apex, for a tenant nested under a
   regional instance like `<tenant>.global.huntflow.io`), `host` (the whole careers host IS the
-  tenant), `hostpath` (host + first path segment, for Workday).
+  tenant), `hostpath` (host + first path segment, for Workday), `hostcareers`
+  (`<host>/<tenant>` from `<host>/ta/<tenant>.careers`, for UKG Ready, whose host selects the
+  environment its tenant lives in), `hosttenantboard` (`<host>/<tenant>/<guid>`, for UKG Pro
+  Recruiting — a different product from UKG Ready, on different hosts).
 - **The mode must match how the ingest adapter addresses the board**, not how the URL reads. The
   board string is copied verbatim into `sources/<provider>.yml` and into the `external_id`
   namespace, so a truncated one is a board that 404s every crawl: Huntflow's adapter fetches
@@ -35,9 +42,16 @@ nothing but the URL. No network, no database.
 - **Fail-safe by construction.** A wrong or missing entry makes a link *unrecognised*, never a
   false board: a bad apex or mode yields an empty board, which is declined. So a best-guess
   host is safe to add.
+- **A white-labelled ATS is one row per reseller domain.** HiringThing serves one application
+  from ~25 domains and its board IS the careers host, so a slug names nothing on its own — the
+  rows are copied from the domains `sources/hiringthing.yml` is actually on, and an unlisted one
+  is simply unrecognised.
 - **A platform's own hosts are declined** (`platformHost`). In `host` and `subdomain` mode the
   host IS the board, so a vendor's console (`app.teamtailor.com`, which every Teamtailor career
-  site links to) would otherwise be recorded as an employer.
+  site links to) would otherwise be recorded as an employer. `platformLabels` holds the labels
+  no ATS gives a tenant; `platformLabelsByApex` holds the ones only ONE platform keeps —
+  `apply` is HRM Direct's application host **and** a recruitee board we crawl, so declining it
+  everywhere would drop a real board.
 
 ## Limitations
 - **Vanity domains are invisible here.** Recognition keys on host, so a supported ATS behind a

--- a/internal/ingest/atsboard/AGENTS.md
+++ b/internal/ingest/atsboard/AGENTS.md
@@ -27,8 +27,9 @@ nothing but the URL. No network, no database.
   `pathnumeric` (like `path`, but the segment must be an all-digit id — PageUp's board is a
   numeric institution id, so localisation/section segments like `/cw/en/search` are not
   boards), `query` (a named query parameter, because Paycor serves every board from one path
-  under `?clientId=<board>`; `queryBoards` names the parameter, and it is the one mode that
-  needs a second row — a test fails if it is missing), `subdomain`
+  under `?clientId=<board>`; `queryBoards` names the parameter and the shape its value must
+  have, since a parameter is a weaker signal than a path segment — and it is the one mode that
+  needs a second row, so a test fails if it is missing), `subdomain`
   (leftmost DNS label), `subdomainchain` (every label under the apex, for a tenant nested under a
   regional instance like `<tenant>.global.huntflow.io`), `host` (the whole careers host IS the
   tenant), `hostpath` (host + first path segment, for Workday), `hostcareers`

--- a/internal/ingest/atsboard/board.go
+++ b/internal/ingest/atsboard/board.go
@@ -62,6 +62,25 @@ const (
 	// three (internal/ingest/sources/ukg.go), so anything less is not a shorter board id — it is one the
 	// crawl rejects outright.
 	modeHostTenantBoard = "hosttenantboard"
+	// pathlocalepair: like pathlocale, but the board is the first TWO segments after the optional
+	// locale. Dayforce serves every career site from one host under "<culture?>/<tenant>/<site>"
+	// and a board is "<tenant>/<site>": one tenant may run several sites and each is its own
+	// board, so the tenant alone is not a shorter board id but one the crawl rejects. The culture
+	// stays out — a posting keeps the same id in every culture it is translated into, which is
+	// why the ingest adapter folds it off too (sources.boardIdentity).
+	modePathLocalePair = "pathlocalepair"
+	// query: board = a named query parameter, because the platform addresses a tenant by
+	// parameter rather than by path or host — Paycor serves every board from one path under
+	// "?clientId=<board>". queryBoards names the parameter per host, and the listing path the
+	// canonical collapses to.
+	modeQuery = "query"
+	// hostcareers: board = "<host>/<tenant>" from <host>/ta/<tenant>.careers. UKG Ready's host
+	// selects the environment its tenant is hosted in and is not derivable from the tenant id, so
+	// the adapter needs both (internal/ingest/sources/ukgready.go) — the same self-describing shape
+	// hostpath and hosttenantboard carry. It is named after the career-page path rather than after
+	// its parts, so it cannot be misread as a variant of hosttenantboard above: that one is UKG
+	// PRO Recruiting, a different product on different hosts with a different board shape.
+	modeHostCareers = "hostcareers"
 )
 
 // atsBoards lists the supported multi-tenant ATS: a host (exact or subdomain-suffix match) →
@@ -89,6 +108,13 @@ var atsBoards = []struct{ host, source, mode string }{
 	// not a tenant subdomain, and its source is manatal: careerspage.yml is deliberately empty
 	// because every careers-page.com tenant is served by the Manatal adapter.
 	{"careers-page.com", "manatal", modePath},
+	// Gusto Hiring serves a board at /boards/<board>, where the board is the WHOLE
+	// "<company-slug>-<company-uuid>" segment — neither half resolves alone. "boards" is the
+	// platform's own path word (reservedSegments), so it is skipped to reach the board behind it.
+	// A /postings/<…> URL is declined (noBoardFirstSegments): its segment ends in the POSTING's
+	// uuid and carries the job's title slug, so it names no board at all — the only link back to
+	// one is the breadcrumb the posting page renders, which is boardresolve's job, not a URL's.
+	{"jobs.gusto.com", "gusto", modePath},
 
 	// --- pathportal: board = the segment before the posting segment ---
 	{"jobs.smartrecruiters.com", "smartrecruiters", modePathPortal},
@@ -96,6 +122,12 @@ var atsBoards = []struct{ host, source, mode string }{
 
 	// --- pathlocale: like path, skipping a leading xx-XX locale segment ---
 	{"ats.rippling.com", "rippling", modePathLocale},
+
+	// --- pathlocalepair: board = the two path segments after an optional leading locale ---
+	{"jobs.dayforcehcm.com", "dayforce", modePathLocalePair},
+
+	// --- query: board = a named query parameter (see queryBoards) ---
+	{"recruitingbypaycor.com", "paycor", modeQuery},
 
 	// --- subdomain: board = leftmost DNS label under the apex ---
 	{"recruitee.com", "recruitee", modeSubdomain},
@@ -127,6 +159,10 @@ var atsBoards = []struct{ host, source, mode string }{
 	// softgarden.io alone, a .de tenant hid behind a second DNS label and was declined.
 	{"career.softgarden.de", "softgarden", modeSubdomain},
 	{"careers.hibob.com", "hibob", modeSubdomain}, // HiBob's careers module: <tenant>.careers.hibob.com
+	// HRM Direct's career site is <board>.hrmdirect.com, exactly what hrmdirect.yml stores. Its
+	// application forms live on the platform's own apply.hrmdirect.com — see this apex's entry
+	// in platformLabelsByApex, without which every apply link on the platform names a board.
+	{"hrmdirect.com", "hrmdirect", modeSubdomain},
 
 	// --- subdomainchain: board = every label under the apex (tenant nested under a region) ---
 	{"huntflow.io", "huntflow", modeSubdomainChain},
@@ -145,6 +181,39 @@ var atsBoards = []struct{ host, source, mode string }{
 	// (deloittecm.avature.net). Only tenants on the platform's own domain are derivable; a
 	// vanity host (jobs.ea.com) is not, like every other custom-domain ATS here.
 	{"avature", "avature", modeHost},
+	// HiringThing is white-labelled: one application serves a tenant under the vendor's own
+	// domain (<tenant>.hiringthing.com) and under each reseller's, and a slug alone names
+	// nothing — nothing in it says which domain answers for it, and the same slug can exist
+	// under two resellers. So the board is the whole careers host, the shape hiringthing.yml
+	// stores, and every reseller domain needs its own row: an unlisted one is simply
+	// unrecognised. These 25 are the domains that file is actually on. ("rippling-ats" is a
+	// reseller of THIS platform and is unrelated to ats.rippling.com above, which is Rippling's
+	// own ATS on a different host and a different adapter.)
+	{"alignhrsolutions", "hiringthing", modeHost},
+	{"alphastaff-hiring", "hiringthing", modeHost},
+	{"atsmodule", "hiringthing", modeHost},
+	{"checkwritersrecruit", "hiringthing", modeHost},
+	{"deltahire-ats", "hiringthing", modeHost},
+	{"edistoats", "hiringthing", modeHost},
+	{"elevate-ats", "hiringthing", modeHost},
+	{"esi-hire", "hiringthing", modeHost},
+	{"exponentats", "hiringthing", modeHost},
+	{"ezhiregov", "hiringthing", modeHost},
+	{"gnahiring", "hiringthing", modeHost},
+	{"hiringthing", "hiringthing", modeHost},
+	{"iconnecthire", "hiringthing", modeHost},
+	{"lumberhiring", "hiringthing", modeHost},
+	{"nexstarrecruiter", "hiringthing", modeHost},
+	{"oasisrecruit", "hiringthing", modeHost},
+	{"primepay-recruit", "hiringthing", modeHost},
+	{"prismhr-hire", "hiringthing", modeHost},
+	{"rippling-ats", "hiringthing", modeHost},
+	{"tcr-hire", "hiringthing", modeHost},
+	{"teammemberhire-recruit", "hiringthing", modeHost},
+	{"topdoghrrecruiting", "hiringthing", modeHost},
+	{"topgradinghire", "hiringthing", modeHost},
+	{"verahr-hiring", "hiringthing", modeHost},
+	{"viewpointhr-ats", "hiringthing", modeHost},
 
 	// --- hostpath: board = "<host>/<site>" (Workday tenant host + first-path-segment site) ---
 	{"myworkdayjobs.com", "workday", modeHostPath},
@@ -157,6 +226,37 @@ var atsBoards = []struct{ host, source, mode string }{
 	{"ultipro.com", "ukg", modeHostTenantBoard},
 	{"ultipro.ca", "ukg", modeHostTenantBoard},
 	{"rec.pro.ukg.net", "ukg", modeHostTenantBoard},
+
+	// --- hostcareers: board = "<host>/<tenant>" (UKG Ready — a DIFFERENT product from ukg above) ---
+	// One environment is fronted by several white-label hosts that all serve its tenants, so the
+	// host in a pasted link is by construction one that answers for that tenant — which is what
+	// makes it safe to keep. It cannot be dropped: a tenant lives in exactly one environment,
+	// every other host answers "Company not found" for it, and the environment is not derivable
+	// from the tenant id. The regional workforceready hosts are listed per TLD because a host
+	// entry keys on a full domain here; an unlisted TLD is unrecognised, never a false board.
+	//
+	// One board of the 2,230 is stored with a "www." host, which hostname() strips package-wide,
+	// so a link to it resolves to the same tenant on the bare host. That board is crawlable too,
+	// and boardIdentity folds the pair onto the tenant, so the cost is one duplicate contribution
+	// — cheaper than teaching one mode to keep a label the rest of the package normalizes away.
+	{"saashr.com", "ukgready", modeHostCareers},
+	{"entertimeonline.com", "ukgready", modeHostCareers},
+	{"yourpayrollhr.com", "ukgready", modeHostCareers},
+	{"mykronos.com", "ukgready", modeHostCareers},
+	{"workforceready.com.au", "ukgready", modeHostCareers},
+	{"workforceready.eu", "ukgready", modeHostCareers},
+}
+
+// queryBoards holds, per matched host entry in modeQuery, the query parameter that names the
+// board and the path its listing is served from. The canonical collapses to that listing, so a
+// posting URL and the board's own career home map to one board — the same collapse the host and
+// pathlocale modes make.
+var queryBoards = map[string]struct{ param, listingPath string }{
+	// Paycor Recruiting addresses an employer's portal by a 32-hex clientId: the listing is
+	// /career/CareerHome.action?clientId=<board> and a posting is
+	// /career/JobIntroduction.action?clientId=<board>&id=<posting>. Nothing but the parameter
+	// names the board — the path is the same for every employer on the platform.
+	"recruitingbypaycor.com": {param: "clientId", listingPath: "/career/CareerHome.action"},
 }
 
 // apiBoards lists each ATS's OWN API host, where the board sits behind a fixed path prefix
@@ -190,11 +290,23 @@ var apiBoards = []struct{ host, source, prefix string }{
 // company slug, which is worse than declining.
 var noBoardFirstSegments = map[string][]string{
 	"apply.workable.com": {"j"},
+	// Gusto's "/postings/<company-slug>-<job-slug>-<posting-uuid>" names a posting, not a board:
+	// the uuid it ends with is the POSTING's, and the board is "<company-slug>-<company-uuid>",
+	// which appears nowhere in it. Taking the segment would file a board no crawl can resolve.
+	"jobs.gusto.com": {"postings"},
+	// Dayforce serves every career site from one host, so its own machinery shares that host with
+	// the tenants: "/api/…" is the listing API the site loads over XHR and "/_next/…" is the app's
+	// static bundle, which every page on the platform links. Read as a career site they yield the
+	// boards "api/geo" and "_next/static" — and boardresolve, which takes the first recognized ATS
+	// URL in a fetched page, would meet them before any real one.
+	"jobs.dayforcehcm.com": {"api", "_next"},
 }
 
 var reservedSegments = map[string][]string{
 	"jobs.jobvite.com": {"careers"},
 	"greenhouse.io":    {"embed", "job_app", "job_board", "js"},
+	// Gusto's board listing is /boards/<board>; "boards" is the platform's word, never a tenant.
+	"jobs.gusto.com": {"boards"},
 }
 
 // Recognize parses a pasted job link into the company board it belongs to: the source
@@ -222,7 +334,7 @@ func Recognize(rawURL string) (source, board, canonical string, ok bool) {
 		// in that exact position for a subdomain tenant just as much as for a bare-host one —
 		// e.g. app.recruitee.com and help.bamboohr.com are the vendor's own login/support hosts,
 		// not a company named "app" or "help".
-		if platformHost(host) {
+		if platformHost(host, apex) {
 			return "", "", "", false
 		}
 		switch mode {
@@ -278,6 +390,55 @@ func Recognize(rawURL string) (source, board, canonical string, ok bool) {
 		board = strings.ToLower(host + "/" + tenant + "/" + guid)
 		u.RawQuery, u.Fragment = "", ""
 		u.Path = "/" + tenant + "/JobBoard/" + guid
+		return src, board, u.String(), true
+
+	case modeHostCareers:
+		// UKG Ready: <host>/ta/<tenant>.careers[?ShowJob=…] → board "<host>/<tenant>". Lower-cased
+		// because tenant ids are case-insensitive at the platform and ukgready.yml holds them
+		// lower-case, so keeping a link's own spelling would file a board we already crawl as new.
+		tenant, ok := ukgReadyTenant(u)
+		if !ok {
+			return "", "", "", false
+		}
+		u.RawQuery, u.Fragment = "", ""
+		u.Path = "/ta/" + tenant + ".careers"
+		return src, host + "/" + tenant, u.String(), true
+
+	case modeQuery:
+		// Paycor: the board is a query parameter, and the canonical is the board's own listing —
+		// so a posting and the career home collapse to one. Lower-cased for the same reason as
+		// UKG Ready: the platform serves either spelling of the hex client id and paycor.yml
+		// holds it lower-case.
+		q, configured := queryBoards[apex]
+		if !configured {
+			return "", "", "", false
+		}
+		board = strings.ToLower(u.Query().Get(q.param))
+		if board == "" {
+			return "", "", "", false
+		}
+		u.Fragment = ""
+		u.Path = q.listingPath
+		u.RawQuery = url.Values{q.param: {board}}.Encode()
+		return src, board, u.String(), true
+
+	case modePathLocalePair:
+		// Dayforce: <host>/<culture?>/<tenant>/<site>/… → board "<tenant>/<site>". The culture is
+		// dropped, not kept: it selects which translations of a site's postings to read and a
+		// posting keeps one id across them, which is why the ingest adapter folds it off too. The
+		// canonical collapses to the culture-free site root (verified live: it answers 200 with and
+		// without one). Lower-cased — tenant and site are case-insensitive at the platform and
+		// dayforce.yml holds them lower-case.
+		segs := segmentsAfterLocale(u)
+		// The no-board check reads the segment the board would START at, not the URL's first —
+		// the platform's own paths take a locale prefix too, and "/en-US/api/geo/…" would
+		// otherwise walk past the guard and name the board "api/geo".
+		if len(segs) < 2 || segs[0] == "" || segs[1] == "" || slices.Contains(noBoardFirstSegments[apex], segs[0]) {
+			return "", "", "", false // bare host, locale-only, a tenant with no site, or machinery
+		}
+		board = strings.ToLower(segs[0] + "/" + segs[1])
+		u.RawQuery, u.Fragment = "", ""
+		u.Path = "/" + board
 		return src, board, u.String(), true
 
 	case modePathPortal:
@@ -413,10 +574,23 @@ var platformLabels = map[string]bool{
 	"tt": true,
 }
 
-// platformHost reports whether host is the ATS's own product host rather than a tenant's.
-func platformHost(host string) bool {
+// platformLabelsByApex lists the labels that are ONE platform's own hosts — the per-platform
+// companion to platformLabels, for a label another platform legitimately lets a tenant have.
+// "apply" is both: HRM Direct serves every tenant's application form from apply.hrmdirect.com,
+// which a bare subdomain rule reads as a company called "apply", while apply.recruitee.com is a
+// board recruitee.yml actually tracks. Declining it everywhere would drop a board we crawl.
+var platformLabelsByApex = map[string][]string{
+	"hrmdirect.com": {"apply"},
+}
+
+// platformHost reports whether host is the ATS's own product host rather than a tenant's —
+// either a label no multi-tenant ATS gives a tenant, or one this platform in particular keeps.
+func platformHost(host, apex string) bool {
 	label, _, ok := strings.Cut(host, ".")
-	return ok && platformLabels[label]
+	if !ok {
+		return false
+	}
+	return platformLabels[label] || slices.Contains(platformLabelsByApex[apex], label)
 }
 
 // smartrecruitersPosting matches a SmartRecruiters posting segment: the posting id (numeric or a
@@ -452,9 +626,6 @@ func segmentBeforePosting(u *url.URL, isPosting *regexp.Regexp) string {
 // record as new and pay for.
 var localeSegment = regexp.MustCompile(`^[a-z]{2}-[A-Za-z]{2}$`)
 
-// firstSegmentAfterLocale returns the first path segment that isn't a leading xx-XX locale — the
-// tenant board in ats.rippling.com/<locale?>/<board>/… (Rippling) or the site in a Workday
-// host/<locale?>/<site> URL. "" when the path is empty or carries only a locale.
 // ukgTenantBoard pulls the tenant and board guid out of a UKG path,
 // "<tenant>/JobBoard/<guid>[/…]". ok is false unless all three parts are present and in that
 // order: the "JobBoard" marker is the only thing that distinguishes a board URL from the rest
@@ -470,19 +641,45 @@ func ukgTenantBoard(u *url.URL) (tenant, guid string, ok bool) {
 	return segs[0], segs[2], true
 }
 
+// firstSegmentAfterLocale returns the first path segment that isn't a leading xx-XX locale — the
+// tenant board in ats.rippling.com/<locale?>/<board>/… (Rippling) or the site in a Workday
+// host/<locale?>/<site> URL. "" when the path is empty or carries only a locale.
 func firstSegmentAfterLocale(u *url.URL) string {
+	if segs := segmentsAfterLocale(u); len(segs) > 0 {
+		return segs[0]
+	}
+	return ""
+}
+
+// segmentsAfterLocale returns u's path segments with a leading xx-XX locale dropped, nil for an
+// empty path. Rippling and Workday need only the first of them; Dayforce's board is the first two.
+func segmentsAfterLocale(u *url.URL) []string {
 	p := strings.Trim(u.Path, "/")
 	if p == "" {
-		return ""
+		return nil
 	}
 	segs := strings.Split(p, "/")
 	if localeSegment.MatchString(segs[0]) {
 		segs = segs[1:]
 	}
-	if len(segs) == 0 {
-		return ""
+	return segs
+}
+
+// ukgReadyTenant returns the lower-cased tenant a UKG Ready career-page path addresses,
+// "/ta/<tenant>.careers[/…]". ok is false unless the path leads with the platform's "ta" segment
+// AND the one after it carries the ".careers" suffix: that suffix is what proves the segment
+// names a career site at all. Everything else under /ta is the tenant's own application — the
+// SPA's REST API lives at /ta/rest/… — and carries no board.
+func ukgReadyTenant(u *url.URL) (string, bool) {
+	segs := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(segs) < 2 || !strings.EqualFold(segs[0], "ta") {
+		return "", false
 	}
-	return segs[0]
+	tenant, found := strings.CutSuffix(strings.ToLower(segs[1]), ".careers")
+	if !found || tenant == "" {
+		return "", false
+	}
+	return tenant, true
 }
 
 // hostname is u's lowercased hostname with a leading "www." stripped.

--- a/internal/ingest/atsboard/board.go
+++ b/internal/ingest/atsboard/board.go
@@ -248,15 +248,28 @@ var atsBoards = []struct{ host, source, mode string }{
 }
 
 // queryBoards holds, per matched host entry in modeQuery, the query parameter that names the
-// board and the path its listing is served from. The canonical collapses to that listing, so a
-// posting URL and the board's own career home map to one board — the same collapse the host and
-// pathlocale modes make.
-var queryBoards = map[string]struct{ param, listingPath string }{
+// board, the shape its value must have to BE one, and the path the board's listing is served
+// from. The canonical collapses to that listing, so a posting URL and the board's own career
+// home map to one board — the same collapse the host and pathlocale modes make.
+//
+// The shape is required, not optional, for the reason pathnumeric exists: a parameter is a much
+// weaker signal than a path segment on a board-only host, so without it any value on the host
+// reads as a board — and a board that does not exist is the expensive direction, recorded by the
+// contribution flow and paid for.
+var queryBoards = map[string]struct {
+	param, listingPath string
+	boardPattern       *regexp.Regexp
+}{
 	// Paycor Recruiting addresses an employer's portal by a 32-hex clientId: the listing is
 	// /career/CareerHome.action?clientId=<board> and a posting is
 	// /career/JobIntroduction.action?clientId=<board>&id=<posting>. Nothing but the parameter
-	// names the board — the path is the same for every employer on the platform.
-	"recruitingbypaycor.com": {param: "clientId", listingPath: "/career/CareerHome.action"},
+	// names the board — the path is the same for every employer on the platform. All 2,442
+	// boards in paycor.yml carry that exact shape.
+	"recruitingbypaycor.com": {
+		param:        "clientId",
+		listingPath:  "/career/CareerHome.action",
+		boardPattern: regexp.MustCompile(`^[0-9a-f]{32}$`),
+	},
 }
 
 // apiBoards lists each ATS's OWN API host, where the board sits behind a fixed path prefix
@@ -410,11 +423,12 @@ func Recognize(rawURL string) (source, board, canonical string, ok bool) {
 		// UKG Ready: the platform serves either spelling of the hex client id and paycor.yml
 		// holds it lower-case.
 		q, configured := queryBoards[apex]
-		if !configured {
+		if !configured || q.boardPattern == nil {
 			return "", "", "", false
 		}
-		board = strings.ToLower(u.Query().Get(q.param))
-		if board == "" {
+		// The pattern rejects an absent or empty parameter along with a malformed one, so a link
+		// on the host that names no board is declined rather than turned into one.
+		if board = strings.ToLower(u.Query().Get(q.param)); !q.boardPattern.MatchString(board) {
 			return "", "", "", false
 		}
 		u.Fragment = ""

--- a/internal/ingest/atsboard/board_test.go
+++ b/internal/ingest/atsboard/board_test.go
@@ -38,6 +38,17 @@ func TestRecognize(t *testing.T) {
 		{"manatal careers-page posting", "https://www.careers-page.com/nearshore-business-solutions/job/5W939XW3", "manatal", "nearshore-business-solutions", "https://www.careers-page.com/nearshore-business-solutions/job/5W939XW3", true},
 		{"manatal careers-page listing", "https://www.careers-page.com/hiretidal", "manatal", "hiretidal", "https://www.careers-page.com/hiretidal", true},
 
+		// Gusto: the board is the whole "<company-slug>-<company-uuid>" segment behind the
+		// platform's own "boards" word. A /postings/ URL names no board at all — the uuid it ends
+		// with is the POSTING's — so it is declined rather than turned into a board no crawl can
+		// resolve.
+		{"gusto board listing", "https://jobs.gusto.com/boards/100-degrees-consulting-ec8f0e9c-d6b4-4a32-8544-9c213ca6bc90?page=2", "gusto", "100-degrees-consulting-ec8f0e9c-d6b4-4a32-8544-9c213ca6bc90", "https://jobs.gusto.com/boards/100-degrees-consulting-ec8f0e9c-d6b4-4a32-8544-9c213ca6bc90", true},
+		{"gusto board listing trailing slash", "https://jobs.gusto.com/boards/121g-consulting-llc-f41b3691-0c93-4406-acb7-6b28c2c69601/", "gusto", "121g-consulting-llc-f41b3691-0c93-4406-acb7-6b28c2c69601", "https://jobs.gusto.com/boards/121g-consulting-llc-f41b3691-0c93-4406-acb7-6b28c2c69601", true},
+		{"gusto posting carries the posting uuid, not the board", "https://jobs.gusto.com/postings/grupo-ei-el-paso-warehouse-team-lead-dc55dd36-ff48-49d3-9904-9a2c5746286d", "", "", "", false},
+		{"gusto bare postings path", "https://jobs.gusto.com/postings", "", "", "", false},
+		{"gusto bare boards path", "https://jobs.gusto.com/boards", "", "", "", false},
+		{"gusto bare host", "https://jobs.gusto.com", "", "", "", false},
+
 		// pathprefix — the ATS's OWN API host. A careers page on the employer's domain loads its
 		// listing over XHR, so the board is named in that API URL and nowhere else in the page.
 		{"ashby posting API", "https://api.ashbyhq.com/posting-api/job-board/phantom?includeCompensation=false", "ashby", "phantom", "https://api.ashbyhq.com/posting-api/job-board/phantom", true},
@@ -65,6 +76,58 @@ func TestRecognize(t *testing.T) {
 		{"rippling board listing", "https://ats.rippling.com/satomic", "rippling", "satomic", "https://ats.rippling.com/satomic", true},
 		{"rippling locale only no tenant", "https://ats.rippling.com/en-GB", "", "", "", false},
 
+		// pathlocalepair — Dayforce: every career site is on one host under
+		// "<culture?>/<tenant>/<site>" and the board is the two segments after the culture. The
+		// culture is dropped: a posting keeps one id across the cultures it is translated into,
+		// which is why the ingest adapter folds it off the board too. Tenant and site are
+		// case-insensitive at the platform, so the board is folded to the lower case the board
+		// file holds.
+		{"dayforce locale-prefixed vacancy", "https://jobs.dayforcehcm.com/en-US/dcrusa/join-us/jobs/12345?utm=x#top", "dayforce", "dcrusa/join-us", "https://jobs.dayforcehcm.com/dcrusa/join-us", true},
+		{"dayforce vacancy with no locale", "https://jobs.dayforcehcm.com/dcrusa/join-us/jobs/12345", "dayforce", "dcrusa/join-us", "https://jobs.dayforcehcm.com/dcrusa/join-us", true},
+		{"dayforce site listing", "https://jobs.dayforcehcm.com/en-US/4refuel/candidateportal", "dayforce", "4refuel/candidateportal", "https://jobs.dayforcehcm.com/4refuel/candidateportal", true},
+		{"dayforce site listing trailing slash", "https://jobs.dayforcehcm.com/en-US/4refuel/candidateportal/", "dayforce", "4refuel/candidateportal", "https://jobs.dayforcehcm.com/4refuel/candidateportal", true},
+		{"dayforce mixed-case board folds", "https://jobs.dayforcehcm.com/en-US/DCRUSA/Join-Us/jobs/1", "dayforce", "dcrusa/join-us", "https://jobs.dayforcehcm.com/dcrusa/join-us", true},
+		// A site that publishes in no English culture is entered in dayforce.yml WITH its culture
+		// ("agfgroup/employeereferralposting/fr-CA"), so this board is a prefix of the stored one
+		// rather than equal to it — the contribution flow will see such a link as a new board.
+		// Keeping the culture instead would break the other 3,029 entries, whose links carry
+		// en-US and whose stored board has no culture segment at all.
+		{"dayforce non-english culture stays out of the board", "https://jobs.dayforcehcm.com/fr-CA/agfgroup/employeereferralposting", "dayforce", "agfgroup/employeereferralposting", "https://jobs.dayforcehcm.com/agfgroup/employeereferralposting", true},
+		{"dayforce tenant with no site", "https://jobs.dayforcehcm.com/en-US/dcrusa", "", "", "", false},
+		{"dayforce locale only", "https://jobs.dayforcehcm.com/en-US", "", "", "", false},
+		{"dayforce bare host", "https://jobs.dayforcehcm.com", "", "", "", false},
+		// The platform's own machinery shares the tenants' host, and both shapes are linked from
+		// every page on it — read as career sites they name the boards "_next/static" and "api/geo".
+		{"dayforce app bundle is not a board", "https://jobs.dayforcehcm.com/_next/static/chunks/main.js", "", "", "", false},
+		{"dayforce listing api is not a board", "https://jobs.dayforcehcm.com/api/geo/dcrusa/jobposting/search", "", "", "", false},
+		// The platform's own paths take a locale prefix too, so the guard has to read the segment
+		// the BOARD would start at rather than the URL's first one.
+		{"dayforce locale-prefixed app bundle is not a board", "https://jobs.dayforcehcm.com/en-US/_next/data/build/dcrusa.json", "", "", "", false},
+		{"dayforce locale-prefixed api is not a board", "https://jobs.dayforcehcm.com/en-US/api/geo/dcrusa/jobposting/search", "", "", "", false},
+
+		// query — Paycor: nothing but the clientId parameter names the board, since the path is
+		// the same for every employer on the platform. The canonical collapses to the board's own
+		// career home, so a posting and the listing are one board.
+		{"paycor posting", "https://recruitingbypaycor.com/career/JobIntroduction.action?clientId=4028f88b24c330a20124eb33b4ad1653&id=8a7883a6&source=&lang=en", "paycor", "4028f88b24c330a20124eb33b4ad1653", "https://recruitingbypaycor.com/career/CareerHome.action?clientId=4028f88b24c330a20124eb33b4ad1653", true},
+		{"paycor career home", "https://recruitingbypaycor.com/career/CareerHome.action?clientId=8a29a018478a87e70147a7588a6343cf", "paycor", "8a29a018478a87e70147a7588a6343cf", "https://recruitingbypaycor.com/career/CareerHome.action?clientId=8a29a018478a87e70147a7588a6343cf", true},
+		{"paycor upper-case client id folds", "https://www.recruitingbypaycor.com/career/JobIntroduction.action?clientId=8A29A018478A87E70147A7588A6343CF&id=1", "paycor", "8a29a018478a87e70147a7588a6343cf", "https://www.recruitingbypaycor.com/career/CareerHome.action?clientId=8a29a018478a87e70147a7588a6343cf", true},
+		{"paycor without a client id", "https://recruitingbypaycor.com/career/CareerHome.action", "", "", "", false},
+		{"paycor empty client id", "https://recruitingbypaycor.com/career/JobIntroduction.action?clientId=&id=1", "", "", "", false},
+
+		// hosttenant — UKG Ready: the host selects the environment the tenant is hosted in and is
+		// not derivable from the tenant id, so the board carries both. The ".careers" suffix is
+		// what proves the segment names a career site; the SPA's own REST API lives under the same
+		// /ta prefix and names no board.
+		{"ukgready vacancy", "https://secure.entertimeonline.com/ta/10284.careers?ShowJob=123456", "ukgready", "secure.entertimeonline.com/10284", "https://secure.entertimeonline.com/ta/10284.careers", true},
+		{"ukgready board listing", "https://secure7.saashr.com/ta/6010265.careers", "ukgready", "secure7.saashr.com/6010265", "https://secure7.saashr.com/ta/6010265.careers", true},
+		{"ukgready regional host", "https://secure.workforceready.com.au/ta/6162382.careers?ApplyToJob=1", "ukgready", "secure.workforceready.com.au/6162382", "https://secure.workforceready.com.au/ta/6162382.careers", true},
+		{"ukgready mykronos host", "https://prd01-hcm01.npr.mykronos.com/ta/6042637.careers", "ukgready", "prd01-hcm01.npr.mykronos.com/6042637", "https://prd01-hcm01.npr.mykronos.com/ta/6042637.careers", true},
+		{"ukgready bare apex host", "https://saashr.com/ta/6199997.careers", "ukgready", "saashr.com/6199997", "https://saashr.com/ta/6199997.careers", true},
+		{"ukgready upper-case tenant folds", "https://secure3.yourpayrollhr.com/ta/IHR0568.Careers", "ukgready", "secure3.yourpayrollhr.com/ihr0568", "https://secure3.yourpayrollhr.com/ta/ihr0568.careers", true},
+		{"ukgready rest api names no board", "https://secure7.saashr.com/ta/rest/ui/recruitment/companies/%7C6010265/job-requisitions", "", "", "", false},
+		{"ukgready tenant without the careers suffix", "https://secure7.saashr.com/ta/6010265", "", "", "", false},
+		{"ukgready bare host", "https://secure7.saashr.com/", "", "", "", false},
+
 		// subdomain — canonical collapses to the bare host
 		{"recruitee vacancy strips path", "https://acme.recruitee.com/o/senior-go/apply?utm=x", "recruitee", "acme", "https://acme.recruitee.com", true},
 		{"recruitee board listing", "https://acme.recruitee.com", "recruitee", "acme", "https://acme.recruitee.com", true},
@@ -79,6 +142,19 @@ func TestRecognize(t *testing.T) {
 		{"softgarden regional career host", "https://agilitaschweiz.career.softgarden.de/jobs/65679426/sap-consultant/", "softgarden", "agilitaschweiz", "https://agilitaschweiz.career.softgarden.de", true},
 		{"hibob careers subdomain", "https://qogita.careers.hibob.com/jobs/ceb6c947-c906-44d1-a56b-bb33ae5599fa", "hibob", "qogita", "https://qogita.careers.hibob.com", true},
 		{"hibob apply tail collapses to the same board", "https://unique.careers.hibob.com/jobs/f8d9a0bc/apply", "hibob", "unique", "https://unique.careers.hibob.com", true},
+		// HRM Direct: the board is the tenant subdomain. Its APPLICATION forms are served from the
+		// platform's own apply.hrmdirect.com, which without the platform-label guard reads as a
+		// company called "apply" — and that host is linked from every posting on the platform.
+		{"hrmdirect posting", "https://123loadboard.hrmdirect.com/employment/job-opening.php?req=3456&req_loc=1029#apply", "hrmdirect", "123loadboard", "https://123loadboard.hrmdirect.com", true},
+		{"hrmdirect listing", "https://1aautoinc.hrmdirect.com/employment/job-openings.php?search=true", "hrmdirect", "1aautoinc", "https://1aautoinc.hrmdirect.com", true},
+		{"hrmdirect listing trailing slash", "https://4air.hrmdirect.com/employment/", "hrmdirect", "4air", "https://4air.hrmdirect.com", true},
+		{"hrmdirect upper-case host folds", "https://500DegreesStudio.HRMDirect.com/employment/job-opening.php?req=1", "hrmdirect", "500degreesstudio", "https://500DegreesStudio.HRMDirect.com", true},
+		{"hrmdirect apply host is the platform's, not a board", "https://apply.hrmdirect.com/resumes/click2apply.php?req=1", "", "", "", false},
+		{"hrmdirect bare apex no tenant", "https://hrmdirect.com/", "", "", "", false},
+		// "apply" is HRM Direct's own host and a REAL recruitee board (recruitee.yml tracks it),
+		// so the guard is scoped to the apex that needs it. Declining it everywhere would drop a
+		// board the catalogue already crawls.
+		{"recruitee apply is a tenant, not a platform host", "https://apply.recruitee.com/o/senior-go", "recruitee", "apply", "https://apply.recruitee.com", true},
 
 		// subdomainchain — Huntflow nests its international tenants under a "global" label, and
 		// the adapter fetches <board>.huntflow.io, so the board must carry that label too;
@@ -116,6 +192,19 @@ func TestRecognize(t *testing.T) {
 		// the vanity ones (jobs.ea.com) stay out, like every other custom-domain ATS here.
 		{"avature vacancy", "https://koch.avature.net/en_us/careers/jobdetail/sr-engineer/186706", "avature", "koch.avature.net", "https://koch.avature.net", true},
 		{"avature board listing", "https://deloittecm.avature.net/careers", "avature", "deloittecm.avature.net", "https://deloittecm.avature.net", true},
+
+		// HiringThing is white-labelled across ~25 reseller domains, so the board is the whole
+		// careers host: a slug alone does not say which domain answers for it, and the same slug
+		// can exist under two resellers. Only the domains hiringthing.yml is actually on are
+		// listed; an unlisted one is unrecognised, never a false board.
+		{"hiringthing vendor domain", "https://4mindsai.hiringthing.com/job/12345/senior-engineer", "hiringthing", "4mindsai.hiringthing.com", "https://4mindsai.hiringthing.com", true},
+		{"hiringthing reseller domain", "https://10federal-partners-inc.prismhr-hire.com/job/98765/technician", "hiringthing", "10federal-partners-inc.prismhr-hire.com", "https://10federal-partners-inc.prismhr-hire.com", true},
+		{"hiringthing second reseller domain", "https://1440-by-the-bay.oasisrecruit.com/", "hiringthing", "1440-by-the-bay.oasisrecruit.com", "https://1440-by-the-bay.oasisrecruit.com", true},
+		// The BOARD folds to lower case (DNS is case-insensitive, and the board file holds the
+		// lower-case spelling); the canonical keeps the link's own, as it does in every host mode.
+		{"hiringthing upper-case host folds", "https://A-M-Crawford.HiringThing.com/job/1", "hiringthing", "a-m-crawford.hiringthing.com", "https://A-M-Crawford.HiringThing.com", true},
+		{"hiringthing bare reseller apex is not a board", "https://prismhr-hire.com/", "", "", "", false},
+		{"hiringthing platform app host is not a tenant", "https://app.hiringthing.com/", "", "", "", false},
 
 		// host+tenant+board mode — UKG: the board is "<host>/<tenant>/<guid>", the three parts
 		// the adapter needs to reach LoadSearchResults. The old rule took the first path segment
@@ -214,6 +303,17 @@ func TestVacancyAndListingSameBoard(t *testing.T) {
 		{"https://acme.bamboohr.com/careers/42/detail", "https://acme.bamboohr.com/careers/list"},
 		// host+path (Workday): a vacancy and the site landing collapse to one board
 		{"https://gm.wd5.myworkdayjobs.com/Careers_GM/job/x/Eng_JR-1", "https://gm.wd5.myworkdayjobs.com/Careers_GM"},
+		// pathlocalepair (Dayforce): a culture-prefixed vacancy and the bare site landing
+		{"https://jobs.dayforcehcm.com/en-US/dcrusa/join-us/jobs/12345", "https://jobs.dayforcehcm.com/dcrusa/join-us"},
+		// query (Paycor): a posting and the board's career home, which differ in path AND query
+		{"https://recruitingbypaycor.com/career/JobIntroduction.action?clientId=4028f88b24c330a20124eb33b4ad1653&id=8a7883a6", "https://recruitingbypaycor.com/career/CareerHome.action?clientId=4028f88b24c330a20124eb33b4ad1653"},
+		// hosttenant (UKG Ready): a vacancy and its board's career page
+		{"https://secure.entertimeonline.com/ta/10284.careers?ShowJob=123456", "https://secure.entertimeonline.com/ta/10284.careers"},
+		// host (HiringThing) and subdomain (HRM Direct): a posting and the board root
+		{"https://4mindsai.hiringthing.com/job/12345/senior-engineer", "https://4mindsai.hiringthing.com/"},
+		{"https://123loadboard.hrmdirect.com/employment/job-opening.php?req=3456&req_loc=1029", "https://123loadboard.hrmdirect.com/employment/job-openings.php?search=true"},
+		// path (Gusto): a paged listing and the bare board
+		{"https://jobs.gusto.com/boards/100-degrees-consulting-ec8f0e9c-d6b4-4a32-8544-9c213ca6bc90?page=3", "https://jobs.gusto.com/boards/100-degrees-consulting-ec8f0e9c-d6b4-4a32-8544-9c213ca6bc90"},
 	}
 	for _, p := range pairs {
 		sa, ba, _, oka := Recognize(p[0])
@@ -243,5 +343,76 @@ func TestRecognizeMapsHostsToTheIngestProviderName(t *testing.T) {
 		if !ok || src != c.wantSource {
 			t.Errorf("Recognize(%q) source = %q (ok %v), want %q", c.raw, src, ok, c.wantSource)
 		}
+	}
+}
+
+// TestQueryModeRowsAreConfigured guards the one mode whose row is not self-contained: a query
+// entry needs a second row in queryBoards naming the parameter, and without it the host matches
+// and then declines every link on it — a platform that looks supported and recognises nothing.
+// The rest of the table keeps the "one row plus one test case" promise on its own.
+func TestQueryModeRowsAreConfigured(t *testing.T) {
+	for _, a := range atsBoards {
+		if a.mode != modeQuery {
+			continue
+		}
+		if q, ok := queryBoards[a.host]; !ok || q.param == "" || q.listingPath == "" {
+			t.Errorf("atsBoards entry %q (%s) is %s mode but queryBoards has no complete entry for it",
+				a.host, a.source, modeQuery)
+		}
+	}
+}
+
+// TestRecognizeReturnsTheBoardTheBoardFileStores pins the extraction of the six platforms added
+// most recently against boards copied VERBATIM out of the shipped sources/<provider>.yml, one
+// per board-id shape each file contains.
+//
+// A rule that disagrees with the board file is worse than no rule at all. The board string is
+// what the contribution flow records and pays for, and what board coverage hands to the ingest
+// adapter — so a near-miss files an employer under a board no crawl can resolve, while looking
+// exactly like a successful recognition. The board files are the only authority on the shape: a
+// provider's crawl is built around it.
+func TestRecognizeReturnsTheBoardTheBoardFileStores(t *testing.T) {
+	cases := []struct{ name, raw, source, board string }{
+		// paycor: the 32-hex clientId, lower-case in the file (the platform serves either).
+		{"paycor Day Kimball Health", "https://recruitingbypaycor.com/career/JobIntroduction.action?clientId=4028f88b24c330a20124eb33b4ad1653&id=1", "paycor", "4028f88b24c330a20124eb33b4ad1653"},
+		{"paycor Clark Hill", "https://recruitingbypaycor.com/career/CareerHome.action?clientId=8a29a018478a87e70147a7588a6343cf", "paycor", "8a29a018478a87e70147a7588a6343cf"},
+
+		// dayforce: "<tenant>/<site>", the two segments after the culture.
+		{"dayforce 4Refuel", "https://jobs.dayforcehcm.com/en-US/4refuel/candidateportal", "dayforce", "4refuel/candidateportal"},
+		{"dayforce 99 Cents Only Stores", "https://jobs.dayforcehcm.com/en-US/99cents/candidateportal/jobs/1", "dayforce", "99cents/candidateportal"},
+		{"dayforce DCR USA", "https://jobs.dayforcehcm.com/dcrusa/join-us", "dayforce", "dcrusa/join-us"},
+
+		// gusto: the whole "<company-slug>-<company-uuid>" segment.
+		{"gusto 100 Degrees Consulting", "https://jobs.gusto.com/boards/100-degrees-consulting-ec8f0e9c-d6b4-4a32-8544-9c213ca6bc90", "gusto", "100-degrees-consulting-ec8f0e9c-d6b4-4a32-8544-9c213ca6bc90"},
+		{"gusto 121G", "https://jobs.gusto.com/boards/121g-consulting-llc-f41b3691-0c93-4406-acb7-6b28c2c69601?page=1", "gusto", "121g-consulting-llc-f41b3691-0c93-4406-acb7-6b28c2c69601"},
+
+		// hiringthing: the full careers host, on the vendor's domain and on three resellers'.
+		{"hiringthing 4Minds", "https://4mindsai.hiringthing.com/job/1", "hiringthing", "4mindsai.hiringthing.com"},
+		{"hiringthing 10 Federal", "https://10federal-partners-inc.prismhr-hire.com/job/1", "hiringthing", "10federal-partners-inc.prismhr-hire.com"},
+		{"hiringthing Integral Senior Living", "https://1440-by-the-bay.oasisrecruit.com/job/1", "hiringthing", "1440-by-the-bay.oasisrecruit.com"},
+		{"hiringthing BASH", "https://1235-keystone-way-llc.gnahiring.com/job/1", "hiringthing", "1235-keystone-way-llc.gnahiring.com"},
+
+		// ukgready: "<host>/<tenant>", one per host family in the file (including the bare apex
+		// and the alphanumeric tenant ids, which are not all numeric).
+		{"ukgready Rapid Robert's", "https://secure.entertimeonline.com/ta/10284.careers?ShowJob=1", "ukgready", "secure.entertimeonline.com/10284"},
+		{"ukgready Phoenix Zoo", "https://secure7.saashr.com/ta/6010265.careers", "ukgready", "secure7.saashr.com/6010265"},
+		{"ukgready TotalTec", "https://saashr.com/ta/6199997.careers", "ukgready", "saashr.com/6199997"},
+		{"ukgready Copper State Bolt & Nut", "https://secure3.yourpayrollhr.com/ta/ihr0568.careers", "ukgready", "secure3.yourpayrollhr.com/ihr0568"},
+		{"ukgready SPC Global", "https://secure.workforceready.com.au/ta/6162382.careers", "ukgready", "secure.workforceready.com.au/6162382"},
+		{"ukgready C. Caswell Engineering", "https://secure.workforceready.eu/ta/6121944.careers", "ukgready", "secure.workforceready.eu/6121944"},
+		{"ukgready General Health System", "https://prd01-hcm01.npr.mykronos.com/ta/6042637.careers", "ukgready", "prd01-hcm01.npr.mykronos.com/6042637"},
+
+		// hrmdirect: the tenant subdomain alone.
+		{"hrmdirect 123Loadboard", "https://123loadboard.hrmdirect.com/employment/job-opening.php?req=1&req_loc=2", "hrmdirect", "123loadboard"},
+		{"hrmdirect 1A Auto", "https://1aautoinc.hrmdirect.com/employment/job-openings.php?search=true", "hrmdirect", "1aautoinc"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			src, board, _, ok := Recognize(c.raw)
+			if !ok || src != c.source || board != c.board {
+				t.Errorf("Recognize(%q) = (%q, %q, ok=%v), want (%q, %q) — the board sources/%s.yml stores",
+					c.raw, src, board, ok, c.source, c.board, c.source)
+			}
+		})
 	}
 }

--- a/internal/ingest/atsboard/board_test.go
+++ b/internal/ingest/atsboard/board_test.go
@@ -113,6 +113,10 @@ func TestRecognize(t *testing.T) {
 		{"paycor upper-case client id folds", "https://www.recruitingbypaycor.com/career/JobIntroduction.action?clientId=8A29A018478A87E70147A7588A6343CF&id=1", "paycor", "8a29a018478a87e70147a7588a6343cf", "https://www.recruitingbypaycor.com/career/CareerHome.action?clientId=8a29a018478a87e70147a7588a6343cf", true},
 		{"paycor without a client id", "https://recruitingbypaycor.com/career/CareerHome.action", "", "", "", false},
 		{"paycor empty client id", "https://recruitingbypaycor.com/career/JobIntroduction.action?clientId=&id=1", "", "", "", false},
+		// A parameter is a weaker signal than a path segment on a board-only host, so the value
+		// must have the shape of a client key — the same guard pageup's pathnumeric mode carries.
+		{"paycor malformed client id is not a board", "https://recruitingbypaycor.com/career/CareerHome.action?clientId=not-a-board", "", "", "", false},
+		{"paycor truncated client id is not a board", "https://recruitingbypaycor.com/career/JobIntroduction.action?clientId=4028f88b24c330a2&id=1", "", "", "", false},
 
 		// hosttenant — UKG Ready: the host selects the environment the tenant is hosted in and is
 		// not derivable from the tenant id, so the board carries both. The ".careers" suffix is
@@ -355,7 +359,7 @@ func TestQueryModeRowsAreConfigured(t *testing.T) {
 		if a.mode != modeQuery {
 			continue
 		}
-		if q, ok := queryBoards[a.host]; !ok || q.param == "" || q.listingPath == "" {
+		if q, ok := queryBoards[a.host]; !ok || q.param == "" || q.listingPath == "" || q.boardPattern == nil {
 			t.Errorf("atsBoards entry %q (%s) is %s mode but queryBoards has no complete entry for it",
 				a.host, a.source, modeQuery)
 		}


### PR DESCRIPTION
Six source adapters shipped with live board files — `paycor`, `dayforce`, `gusto`,
`hiringthing`, `ukgready` and `hrmdirect`, 10,891 boards between them — and none of their
domains was in `internal/ingest/atsboard`. A pasted link on any of them resolved to nothing,
so link import could not read it and the crowdsourced board-contribution flow could not
onboard it. Every one of the six PRs named this as the follow-up.

## Three needed a new extraction mode

None of the existing modes says where these platforms put the tenant, so each got a mode in
the table's own idiom rather than an inline special case:

| mode | platform | board |
|---|---|---|
| `pathlocalepair` | dayforce | the first **two** path segments after an optional leading culture — `jobs.dayforcehcm.com/en-US/dcrusa/join-us` → `dcrusa/join-us` |
| `query` | paycor | a named query parameter — the path is identical for every employer, so only `?clientId=<board>` names the board |
| `hostcareers` | ukgready | `<host>/<tenant>` read from `<host>/ta/<tenant>.careers` |

- **dayforce**: one tenant runs several career sites and each is its own board, so the tenant
  alone is not a shorter board id but one the crawl rejects. The culture stays **out**: a
  posting keeps the same id in every culture it is translated into, which is exactly why the
  ingest adapter folds it off the board too (`sources.boardIdentity`). The canonical collapses
  to the culture-free site root — verified live, `jobs.dayforcehcm.com/dcrusa/join-us` answers
  200 with and without a culture segment.
- **paycor**: `queryBoards` holds the parameter name and the listing path per host, so the
  canonical collapses a posting and the career home onto one board.
- **ukgready**: the host selects the environment a tenant is hosted in and is not derivable
  from the tenant id, so the board carries both — the same self-describing shape `hostpath`
  and `hosttenantboard` already use. The host in a pasted link is by construction one that
  answers for that tenant, which is what makes it safe to keep.

The other three fit existing modes: **gusto** is `path` with `boards` reserved, **hiringthing**
is `host` across the 25 white-label domains its board file is actually on, and **hrmdirect** is
`subdomain`.

## What each rule declines

A false board is the expensive direction — the contribution flow records and pays for it — so
each platform's known board-less shapes are declined outright:

- `apply.hrmdirect.com` serves every tenant's application form, and read as a subdomain it is
  a company called "apply". The guard is scoped to that apex (`platformLabelsByApex`) and
  **not** global — `apply.recruitee.com` is a board `recruitee.yml` actually tracks, so
  declining the label everywhere would have dropped a board the catalogue already crawls.
  Review caught this; there is now a test for it.
- A gusto `/postings/…` URL ends in the **posting's** uuid and carries the job's title slug;
  the board (`<company-slug>-<company-uuid>`) appears nowhere in it, so the URL is declined
  rather than turned into a board no crawl can resolve. The only link back is the breadcrumb
  the posting page renders, which is `boardresolve`'s job, not a URL's.
- Dayforce's own machinery shares the tenants' host: `/api/…` is the listing API and `/_next/…`
  the app bundle, both linked from every page on the platform, and both would otherwise read
  as the career sites `api/geo` and `_next/static`. `boardresolve` takes the *first* recognised
  ATS URL in a fetched page, so it would meet them before any real one. The check runs on the
  segment the board would **start** at, not the URL's first — the platform's own paths take a
  culture prefix too, so `/en-US/api/geo/…` would otherwise walk straight past it.

## Cross-checked against the board files

`TestRecognizeReturnsTheBoardTheBoardFileStores` pins the extraction against boards copied
**verbatim** out of each shipped `sources/<provider>.yml`, one per board-id shape those files
contain — including ukgready's bare-apex host (`saashr.com/6199997`), its alphanumeric tenant
ids (`secure3.yourpayrollhr.com/ihr0568`) and each of its six host families, and four of
hiringthing's reseller domains. A rule that disagrees with the board file is worse than no
rule: it files an employer under a board no adapter can crawl while looking exactly like a
successful recognition.

On top of the sampled table test, every board in all six files was replayed through
`Recognize` while reviewing this. **10,837 of 10,891 agree exactly** — paycor 2442/2442,
gusto 790/790, hiringthing 1457/1457, hrmdirect 890/890 — and the 54 that do not are two
known, documented shapes:

- **53 dayforce sites** (of 3,082) publish in no English culture and are entered in
  `dayforce.yml` **with** their culture, so this recogniser returns a prefix of the stored
  board and a link to one of them reads as a new board. Keeping the culture instead would
  break the other 3,029, whose links carry `en-US` and whose stored board has no culture
  segment at all. Called out in a test comment beside the case that pins it.
- **1 ukgready board** is stored with a `www.` host, which `hostname()` strips package-wide.
  The bare host is crawlable and `boardIdentity` folds the pair onto the tenant, so the cost is
  one duplicate contribution — cheaper than teaching one mode to keep a label the rest of the
  package normalises away. Noted beside the rows.

The replay was a throwaway; it is not committed, because it would need a hard-coded allowlist
for those two the moment either file grows, and the verbatim samples already carry the intent.

## paycom stays out

Not an oversight. `internal/ingest/atsdetect` owns that shape as one of six the shared table
**deliberately** excludes, and `TestLocalShapesStayOutsideTheSharedTable` pins the split in
both directions. The reason is in that test: `atsboard` is the accept-set the contribution flow
**pays** from, so widening it to a platform is a money-affecting decision that needs its own
proposal — not a tidy-up folded into a follow-up to six other changes. The harvest path, which
is what `atsdetect` serves, already reaches paycom and validates every candidate against the
platform before committing it.

## Notes

- No `sources/*.yml`, no source adapter, no `registry.go`, no generated contracts touched —
  the change is three files inside `internal/ingest/atsboard`.
- `query` is the one mode whose row is not self-contained (it needs a second row in
  `queryBoards`), so `TestQueryModeRowsAreConfigured` fails if a future one is added without
  it — otherwise the host would match and then decline every link on it, looking supported and
  recognising nothing.
- One drive-by: a doc comment for `firstSegmentAfterLocale` had come to sit above
  `ukgTenantBoard`, which this change moved back onto the function it describes because it
  refactored that function.
- `gofmt -l .` silent; `go vet ./...`, `go test ./...` and `go vet -tags=integration ./...`
  all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recognition support for additional applicant tracking platforms, including Gusto, Dayforce, Paycor, HRM Direct, UKG Ready, and HiringThing.
  * Improved board identification across localized URLs, query parameters, tenant-based paths, and reseller domains.
  * Added support for platform-specific labels and board configurations.

* **Documentation**
  * Documented the new extraction modes, supported platforms, and white-labeled ATS handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->