### PR TITLE
Onboard five contributed boards, and stop Eightfold reading as Radancy

### DIFF
--- a/internal/ingest/atsdetect/atsdetect.go
+++ b/internal/ingest/atsdetect/atsdetect.go
@@ -54,14 +54,20 @@ var selfHosted = []struct {
 	{"teamtailor", regexp.MustCompile(`(?i)teamtailor`)},
 }
 
-// vendorDomains are the ATS vendors' own domains. Their marketing sites naturally carry their
-// own marker, and a tenant hosted on the vendor's domain is URL-derivable without fetching
-// anything — either way the fetched host is not an employer board.
+// vendorDomains are ATS vendors' own domains, which a self-hosted board never sits on. For the
+// four fingerprinted vendors that covers both their marketing sites (which naturally carry
+// their own marker) and their hosted tenants (URL-derivable without fetching anything).
+// eightfold.ai is here for a different reason: an Eightfold tenant is NOT URL-derivable (the
+// board is "<host>/<domain>" and the domain key is configured per board, see sources/eightfold.yml),
+// so such a host reaches this last resort — and a site that moved to Eightfold off another ATS
+// keeps the old vendor's tags for a while. johndeere.eightfold.ai still says "talentbrew" six
+// times, which is enough to have it recorded as a radancy board.
 var vendorDomains = []string{
 	"radancy.com", "talentbrew.com",
 	"phenom.com", "phenompeople.com",
 	"jibe.com", "jibeapply.com",
 	"teamtailor.com",
+	"eightfold.ai",
 }
 
 // DetectSelfHosted reports the board for a career site served from the employer's own domain:

--- a/internal/ingest/atsdetect/atsdetect_test.go
+++ b/internal/ingest/atsdetect/atsdetect_test.go
@@ -142,6 +142,9 @@ func TestDetectSelfHosted(t *testing.T) {
 		// tenant hosted on the vendor's domain — atsboard resolves that one from the URL alone.
 		{name: "vendor marketing site", host: "www.phenom.com", html: `phenompeople`, ok: false},
 		{name: "tenant on the vendor domain", host: "bryter.teamtailor.com", html: `Teamtailor`, ok: false},
+		// A tenant that moved to Eightfold keeps the previous ATS's tags for a while; the host is
+		// the vendor's, so the page is not a self-hosted board of whatever marker it still carries.
+		{name: "eightfold tenant still tagged talentbrew", host: "johndeere.eightfold.ai", html: `talentbrew`, ok: false},
 		// Another ATS's page must not be claimed.
 		{name: "greenhouse embed page", host: "acme.com", html: `<script src="https://boards.greenhouse.io/embed/job_board/js?for=acme"></script>`, ok: false},
 		{name: "plain careers page", host: "acme.com", html: `<h1>Join us</h1>`, ok: false},

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -7615,3 +7615,9 @@
   board: zingroup.teamtailor.com
 - company: Zuno Tech Group
   board: zunogroup.teamtailor.com
+
+# link contributions, validated live 2026-09-02
+- company: Entain NCE
+  board: careers.entainnce.com
+- company: Glass Atlas
+  board: careers.glassatlas.com

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -3849,3 +3849,9 @@
   board: zifo
 - company: Zipwater
   board: zipwater
+
+# link contributions, validated live 2026-09-02
+- company: Kuda Technologies Ltd
+  board: kuda
+- company: Tighten
+  board: tgtn

--- a/sources/zohorecruit.yml
+++ b/sources/zohorecruit.yml
@@ -5094,3 +5094,7 @@
   board: zyeta.zohorecruit.com
 - company: Zylu
   board: zylu.zohorecruit.in
+
+# link contribution, validated live 2026-09-02
+- company: MigrationIT
+  board: migrationit.zohorecruit.com


### PR DESCRIPTION
Onboard five contributed boards, and stop Eightfold reading as Radancy

Drains the pending link_contributions queue (7 rows, 7 boards).

Onboarded, each validated live before adding:

- teamtailor careers.entainnce.com (Entain NCE, 4 jobs) and
  careers.glassatlas.com (Glass Atlas, 1 job) - custom-domain career
  sites, listing served, og:site_name gave both names.
- workable kuda (Kuda Technologies Ltd, 15 jobs) and tgtn (Tighten,
  1 job) - the widget account API returned both boards with postings.
- zohorecruit migrationit.zohorecruit.com (MigrationIT) - /jobs/Careers
  answered 200 with postings.

Rejected: hibob slevomatczsro. The tenant exists (/api/career-site
answers) but /api/job-ad returns an empty jobAdDetails, so there is
nothing to crawl. Rejecting releases the board, so it can be
contributed again when the employer resumes posting.

The seventh row is a recognizer defect rather than a contribution.
johndeere.eightfold.ai was recorded as a radancy board: an Eightfold
tenant is not URL-derivable (the board is "<host>/<domain>" and the
domain key is configured per board), so the URL reaches
DetectSelfHosted, and John Deere's Eightfold site still carries
"talentbrew" six times from the ATS it moved off. Adding eightfold.ai
to vendorDomains ends that - a vendor's own hosting domain is never an
employer's self-hosted board, whatever tags the page still carries.
The board itself is already tracked as
eightfold johndeere.eightfold.ai/johndeere.com, so the row is promoted
to it on prod rather than rejected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added career board coverage for two Teamtailor sites, two Workable sites, and one Zoho Recruit site.
  - Improved career site detection to avoid incorrectly classifying Eightfold-hosted pages as self-hosted boards.

- **Bug Fixes**
  - Prevented Eightfold tenant pages with legacy vendor markers from being recorded as Radancy boards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->