### PR TITLE
Recover a board from the rejected pile, and stop a CDN host being a board

### DIFF
--- a/internal/ingest/atsboard/board.go
+++ b/internal/ingest/atsboard/board.go
@@ -288,6 +288,22 @@ var apiBoards = []struct{ host, source, prefix string }{
 	{"api.lever.co", "lever", "v0/postings"},
 }
 
+// noBoardHosts are hosts under a supported ATS's domain that serve the platform's own
+// infrastructure rather than any tenant, so no path on them names a board. platformLabels
+// cannot reach these: it reads the LEFTMOST label, and job-boards.cdn.greenhouse.io leads with
+// the same "job-boards" the real board hosts do — what makes it infrastructure sits in the
+// middle. A full-host entry is also the stabler statement: a CDN is not an employer whatever
+// it renames its asset folder to, whereas listing the folder ("assets") only holds until the
+// next bundler change.
+//
+// This matters because boardresolve takes the FIRST recognized ATS URL in a fetched page, and
+// every Greenhouse job page loads its stylesheet from this host in <head> — well before the
+// link to the board itself. A pasted vanity or grnh.se link therefore resolved to the board
+// "assets" instead of the employer (this cost lionhires, 27 postings, one rejected row).
+var noBoardHosts = map[string]bool{
+	"job-boards.cdn.greenhouse.io": true,
+}
+
 // reservedSegments lists, per matched host entry, the leading path segments that are the
 // platform's own machinery and never a tenant. They are skipped in path mode; when nothing
 // but reserved segments remains the URL is declined rather than turned into a false board.
@@ -331,6 +347,9 @@ func Recognize(rawURL string) (source, board, canonical string, ok bool) {
 		return "", "", "", false
 	}
 	host := hostname(u)
+	if noBoardHosts[host] {
+		return "", "", "", false
+	}
 	if src, board, canonical, ok := recognizeAPI(u, host); ok {
 		return src, board, canonical, true
 	}

--- a/internal/ingest/atsboard/board_test.go
+++ b/internal/ingest/atsboard/board_test.go
@@ -32,6 +32,10 @@ func TestRecognize(t *testing.T) {
 		{"jobvite portal segment skipped", "https://jobs.jobvite.com/careers/ness/jobs", "jobvite", "ness", "https://jobs.jobvite.com/careers/ness/jobs", true},
 		{"greenhouse embed app has no board", "https://job-boards.greenhouse.io/embed/job_app?token=1", "", "", "", false},
 		{"greenhouse embed script has no board", "https://boards.greenhouse.io/embed/job_board/js?for=acme", "", "", "", false},
+		// The CDN host leads with the same "job-boards" label the real board hosts do, so only a
+		// full-host rule declines it; every Greenhouse job page links it from <head>.
+		{"greenhouse CDN asset has no board", "https://job-boards.cdn.greenhouse.io/assets/entry-ZTzpC0b7.css", "", "", "", false},
+		{"greenhouse EU board still resolves", "https://job-boards.eu.greenhouse.io/lionhires/jobs/4941013101", "greenhouse", "lionhires", "https://job-boards.eu.greenhouse.io/lionhires/jobs/4941013101", true},
 
 		// Manatal's hosted career-page domain is path-based, not subdomain-based, and its boards
 		// live in manatal.yml — careerspage.yml is deliberately empty.

--- a/sources/manatal.yml
+++ b/sources/manatal.yml
@@ -1435,3 +1435,7 @@
   board: way2b1
 - company: Welocalize
   board: welocalize-4
+
+# recovered from the rejected contribution pile, validated live 2026-09-02
+- company: Murano Global
+  board: murano-global


### PR DESCRIPTION
Recover a board from the rejected pile, and stop a CDN host being a board

Re-triaged the 201 rejected contributions. Fifteen carried a recognized
board; two of them were a real employer the recognizer had mis-read.

manatal murano-global (Murano Global, 2 postings, both engineering) is
added here after validating live against the career-page API.

The other, greenhouse lionhires, turned out to be tracked already — but
finding that out exposed a live recognizer defect. boardresolve takes
the FIRST recognized ATS URL in a fetched page, and every Greenhouse job
page loads its stylesheet from job-boards.cdn.greenhouse.io in <head>,
well before it links the board. That host ends in .greenhouse.io, so the
path rule read its first segment and returned the board "assets".
platformLabels cannot catch it: it reads the leftmost DNS label, and the
CDN leads with the same "job-boards" the real board hosts do — what
makes it infrastructure sits in the middle. Hence noBoardHosts, keyed on
the whole host: a CDN is not an employer whatever it renames its asset
folder to, whereas listing the folder only holds until the next bundler
change. A pasted vanity or grnh.se link now reaches the employer.

The remaining thirteen were checked and stay rejected, each for a
measured reason rather than the recorded board's shape: cornerstone
linde and talento360 both answer rec-job-search with totalCount 0 under
the adapter's own request body; personio stealthphysicalai serves an
empty /xml; manatal solverogroup answers "Legacy career page is not
enabled"; workday osv-chegg/Chegg returns 422 to every tenant/site
spelling, from the crawl host as well as locally. The rest were already
tracked under their correct board (oracle PicPay and Fortive, gupy
Porto, teamtailor careers.arrive.com and jobs.vitecsoftware.fi).
