### PR TITLE
Stop 40 Bertelsmann employers being filed under Arvato

### DIFF
--- a/docs/superpowers/specs/2026-09-02-successfactors-hub-design.md
+++ b/docs/superpowers/specs/2026-09-02-successfactors-hub-design.md
@@ -1,0 +1,132 @@
+# SuccessFactors hub boards
+
+**Date:** 2026-09-02
+**Status:** design approved
+
+## The problem
+
+`jobsearch.createyourowncareer.com` is a live SAP SuccessFactors career site with 973
+postings, surfaced by a link contribution (`link_contributions` row 293, a Riverty
+engineering role). It is not one employer's board: it is Bertelsmann's, and the postings
+belong to 40 different companies — Arvato, Arvato Systems, Riverty, RTL, Penguin Random
+House, Fremantle, smartclip and so on.
+
+The adapter cannot ingest it as it stands. `successfactors.detail` sets
+`Company: e.Company`, one configured name per board, so the board would file all 973
+postings under a single employer. The catalogue would gain a company with 973 jobs that no
+job seeker is actually applying to, and Riverty — which today has only aggregator coverage
+(adzuna 24, whatjobs 4) — would still have no board of its own.
+
+The site offers no way out of this by configuration alone:
+
+- There is no per-tenant sitemap. `/<tenant>/job_sitemap.xml` redirects to the site's 404
+  page for every tenant tried. Only the shared `/job_sitemap.xml` exists, and it lists all
+  973 postings across all 40 tenants.
+- The job pages' `hiringOrganization` microdata says `Bertelsmann SE & Co. KGaA` on a
+  Riverty posting — the corporate parent, not the employer — and the same markup also
+  emits `hiringOrganization` twice more with the junk values `Apply now!` and a raw
+  JavaScript fragment. It cannot be trusted.
+
+What the site does encode reliably is the tenant, in the job URL's first path segment:
+`/Riverty/job/Berlin-Software-Engineer-…/1425618633/`.
+
+## The design
+
+### 1. `CompanyEntry.Tenants`
+
+`internal/ingest/sources.CompanyEntry` gains one optional field beside the existing
+`Region` and `Hub`:
+
+```go
+Tenants map[string]string `yaml:"tenants"`
+```
+
+It maps a hub's per-posting tenant key to that employer's display name. Like `Hub`, it is
+ignored by adapters that do not implement hub resolution.
+
+`Hub` already exists and is already documented as a generic, opt-in per-entry flag —
+huntflow honours it by reading the employer out of each vacancy's division breadcrumb. This
+change adds a second honouring adapter, and the field it needs to do so.
+
+### 2. Hub resolution in the successfactors adapter
+
+When `e.Hub` is set, `detail` derives the tenant key from the job URL's first path segment
+and looks it up in `e.Tenants`. An unmapped key, or a URL with no tenant segment at all,
+falls back to `e.Company`.
+
+The fallback is deliberate and matches huntflow's `companyFromDivision(division, fallback)`:
+a posting under an unrecognised Bertelsmann brand is still a real posting, and filing it
+under the parent is accurate rather than merely tolerable. Dropping it would lose jobs
+silently; inventing a name from the slug would put a wrong employer in the catalogue, which
+is the failure `internal/dict/companyname` exists to argue against.
+
+A new helper carries the extraction:
+
+```go
+// sfTenant returns the hub tenant key from a job URL, or "" when the URL carries none.
+func sfTenant(loc string) string
+```
+
+Four of the 973 sitemap entries are `/job/<slug>/<id>/` with no tenant segment at all, so
+the literal `job` must not be read as a tenant. The helper returns `""` for that shape and
+the caller falls back.
+
+### 3. The board file entry
+
+`sources/successfactors.yml` gains:
+
+```yaml
+- company: Bertelsmann
+  board: jobsearch.createyourowncareer.com
+  hub: true
+  tenants:
+    ARVATO: Arvato
+    Arvato_Systems: Arvato Systems
+    Riverty: Riverty
+    # …
+```
+
+### Which names go in the map
+
+Only names the platform itself states, read from each tenant's landing page at
+`/<tenant>/`. That covers 23 of the 40 tenants; their titles come in four different shapes
+(`Riverty Job Search`, `Job search | Career at Arvato Systems`,
+`Careers at Arvato - We're on it!`, `Penguin Random House | Careers USA`), which is why the
+names are curated once into YAML rather than parsed at crawl time.
+
+The other 17 stay OUT of the map on purpose. Fourteen serve a landing page whose title and
+body are both empty (JS-rendered); `BCE` and `HayHouse` serve the platform's own boilerplate
+`Create Your Own Career`; and `Bertelsmann_Corporate`'s title is `Explore our Corporate
+Jobs`, a page heading rather than a company. Together they account for 112 of the 973
+postings, and each falls back to `Bertelsmann` — visible in the catalogue, and true. They
+can be added later from a source that actually names them.
+
+## Testing
+
+- `sfTenant` unit tests: a normal tenant URL, the tenant-less `/job/…` shape, a bare host,
+  and a URL whose path is only the tenant.
+- An adapter test over a fixture sitemap + two job pages under different tenants, asserting
+  the mapped employer on one, the fallback on the other, and that a non-hub board still
+  takes `e.Company` unchanged.
+
+## Risks
+
+**Crawl cost.** 973 postings each need their own detail page fetch, making this the largest
+SuccessFactors board by an order of magnitude. `fetchDetails` bounds concurrency at
+`defaultDetailWorkers`, so the run is throttled rather than abusive, but it will be
+materially longer than any existing successfactors board. Watch the first run's duration
+before adding a second hub of this size.
+
+**Stale sitemap entries.** At least one sampled posting (`PRH_US/…/1414466433`) redirects to
+the site's exception page. `detail` already returns `ok=false` on a failed fetch and the
+pipeline skips just that posting, so this needs no new handling — but it means the ingested
+count will sit below the sitemap's 973.
+
+## Out of scope
+
+- Resolving the 17 unnamed tenants (112 postings). They fall back to the parent brand
+  until a source that
+  names them turns up.
+- Any change to how `Hub` behaves for huntflow.
+- A second SuccessFactors hub. The one board is what this is for; a second one that fits the
+  same shape only needs a YAML entry.

--- a/internal/ingest/sources/config.go
+++ b/internal/ingest/sources/config.go
@@ -51,9 +51,15 @@ func ParseConfig(provider string, data []byte) (Config, error) {
 // use ParseConfig or LoadConfig.
 //
 // Decoding is strict: an unrecognized key is a parse error rather than being silently
-// dropped. A typo in Region or Hub — the two fields whose absence has no required-field
-// error to catch it — would otherwise disable the behavior it names with no symptom
-// until someone investigates why a board crawled the wrong host.
+// dropped. A typo in Region, Hub or Tenants — the three fields whose absence has no
+// required-field error to catch it — would otherwise disable the behavior it names with no
+// symptom until someone investigates why a board crawled the wrong host.
+//
+// Strictness stops at the FIELD name, which matters most for Tenants: `tenatns:` is a parse
+// error, but a typo in a tenant key INSIDE the map is a perfectly good map entry. It decodes,
+// the adapter's lookup misses, and the posting quietly takes the fallback company. Nothing can
+// catch that here or in cmd/validate-sources — neither has the board to compare against — so
+// tenant keys must be transcribed from the board's own listing, never typed from memory.
 func ParseRawEntries(provider string, data []byte) ([]CompanyEntry, error) {
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)

--- a/internal/ingest/sources/config_test.go
+++ b/internal/ingest/sources/config_test.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -26,7 +27,7 @@ func TestParseConfig(t *testing.T) {
 		t.Fatalf("len(Sources) = %d, want 2", len(cfg.Sources))
 	}
 	want := CompanyEntry{Company: "Cohere", Provider: "greenhouse", Board: "cohere"}
-	if cfg.Sources[0] != want {
+	if !reflect.DeepEqual(cfg.Sources[0], want) {
 		t.Errorf("Sources[0] = %+v, want %+v", cfg.Sources[0], want)
 	}
 }
@@ -57,7 +58,7 @@ func TestParseConfigDropsCaseInsensitiveBoardDuplicates(t *testing.T) {
 		t.Fatalf("len(Sources) = %d, want %d: %+v", len(cfg.Sources), len(want), cfg.Sources)
 	}
 	for i, w := range want {
-		if cfg.Sources[i] != w {
+		if !reflect.DeepEqual(cfg.Sources[i], w) {
 			t.Errorf("Sources[%d] = %+v, want %+v", i, cfg.Sources[i], w)
 		}
 	}
@@ -88,7 +89,7 @@ func TestParseConfigDropsBoardSpellingsAddressingTheSameSite(t *testing.T) {
 		t.Fatalf("len(Sources) = %d, want %d: %+v", len(cfg.Sources), len(want), cfg.Sources)
 	}
 	for i, w := range want {
-		if cfg.Sources[i] != w {
+		if !reflect.DeepEqual(cfg.Sources[i], w) {
 			t.Errorf("Sources[%d] = %+v, want %+v", i, cfg.Sources[i], w)
 		}
 	}
@@ -153,6 +154,37 @@ func TestParseConfigKeepsSameBoardOnDifferentRegions(t *testing.T) {
 	}
 	if len(cfg.Sources) != 2 {
 		t.Fatalf("len(Sources) = %d, want 2 (region variants kept): %+v", len(cfg.Sources), cfg.Sources)
+	}
+}
+
+// A hub whose postings name their tenant only by an opaque key carries the key→employer map
+// in the board file. The loader runs KnownFields(true), so an unmodelled `tenants:` block
+// does not decode to nothing — it fails the whole file.
+func TestParseConfigReadsHubTenants(t *testing.T) {
+	data := []byte(`
+- company: Bertelsmann
+  board: jobsearch.createyourowncareer.com
+  hub: true
+  tenants:
+    Riverty: Riverty
+    Arvato_Systems: Arvato Systems
+`)
+	cfg, err := ParseConfig("successfactors", data)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if len(cfg.Sources) != 1 {
+		t.Fatalf("len(Sources) = %d, want 1: %+v", len(cfg.Sources), cfg.Sources)
+	}
+	e := cfg.Sources[0]
+	if !e.Hub {
+		t.Error("Hub = false, want true")
+	}
+	if got := e.Tenants["Arvato_Systems"]; got != "Arvato Systems" {
+		t.Errorf("Tenants[Arvato_Systems] = %q, want %q", got, "Arvato Systems")
+	}
+	if _, ok := e.Tenants["Sonopress"]; ok {
+		t.Error("Tenants holds a key the file never listed")
 	}
 }
 
@@ -276,7 +308,7 @@ func TestParseConfigKeepsPerEntryProvider(t *testing.T) {
 		{Company: "NoProv", Provider: "custom", Board: "x"}, // fell back to the file name
 	}
 	for i, w := range want {
-		if cfg.Sources[i] != w {
+		if !reflect.DeepEqual(cfg.Sources[i], w) {
 			t.Errorf("Sources[%d] = %+v, want %+v", i, cfg.Sources[i], w)
 		}
 	}

--- a/internal/ingest/sources/dayforce_test.go
+++ b/internal/ingest/sources/dayforce_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -77,7 +78,7 @@ func TestParseConfigFoldsDayforceCultureVariants(t *testing.T) {
 		t.Fatalf("len(Sources) = %d, want %d: %+v", len(cfg.Sources), len(want), cfg.Sources)
 	}
 	for i, w := range want {
-		if cfg.Sources[i] != w {
+		if !reflect.DeepEqual(cfg.Sources[i], w) {
 			t.Errorf("Sources[%d] = %+v, want %+v", i, cfg.Sources[i], w)
 		}
 	}

--- a/internal/ingest/sources/source.go
+++ b/internal/ingest/sources/source.go
@@ -26,12 +26,19 @@ const DefaultSweepGrace = 48 * time.Hour
 // belong to many partner companies; an adapter that honours it resolves each job's employer from
 // the posting and uses Company only as the hub name and per-vacancy fallback (e.g. huntflow's
 // AlumniHub). It is ignored by adapters that do not implement hub resolution.
+// Tenants is the companion map for a hub whose postings identify their tenant only by an opaque
+// key — a URL path segment or an id — that is not itself a usable company name; it maps that key
+// to the employer's display name (e.g. successfactors' "Arvato_Systems" → "Arvato Systems").
+// A key absent from the map falls back to Company rather than being turned into a name by
+// transforming the key, because a plausible-but-wrong employer reads worse in the catalogue than
+// the parent brand. Optional and adapter-specific, exactly as Hub and Region are.
 type CompanyEntry struct {
-	Company  string `yaml:"company"`
-	Provider string `yaml:"provider"`
-	Board    string `yaml:"board"`
-	Region   string `yaml:"region"`
-	Hub      bool   `yaml:"hub"`
+	Company  string            `yaml:"company"`
+	Provider string            `yaml:"provider"`
+	Board    string            `yaml:"board"`
+	Region   string            `yaml:"region"`
+	Hub      bool              `yaml:"hub"`
+	Tenants  map[string]string `yaml:"tenants"`
 }
 
 // Job is a raw posting as an adapter yields it, before the pipeline normalizes it

--- a/internal/ingest/sources/successfactors.go
+++ b/internal/ingest/sources/successfactors.go
@@ -3,7 +3,9 @@ package sources
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"regexp"
+	"strings"
 )
 
 // successfactors adapts SAP SuccessFactors career sites. The board is the career-site
@@ -28,8 +30,8 @@ func NewSuccessFactors(c successfactorsHTTP) Source { return successfactors{http
 func (successfactors) Provider() string { return "successfactors" }
 
 func (s successfactors) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
-	url := fmt.Sprintf("https://%s/job_sitemap.xml", e.Board)
-	sitemap, err := getSitemap(ctx, s.http, url)
+	sitemapURL := fmt.Sprintf("https://%s/job_sitemap.xml", e.Board)
+	sitemap, err := getSitemap(ctx, s.http, sitemapURL)
 	if err != nil {
 		return nil, fmt.Errorf("successfactors: sitemap %s: %w", e.Board, err)
 	}
@@ -59,11 +61,21 @@ func (s successfactors) detail(ctx context.Context, e CompanyEntry, entry sitema
 		title = metaProperty(root, "og:title")
 	}
 
+	// On a hub the configured company is only the hub's own name; the employer is the tenant
+	// the job URL names, resolved through the entry's curated map. An ordinary board keeps its
+	// configured company, whatever segments its URLs happen to carry.
+	company := e.Company
+	if e.Hub {
+		if name, ok := e.Tenants[sfTenant(entry.Loc)]; ok {
+			company = name
+		}
+	}
+
 	return Job{
 		ExternalID: id,
 		URL:        entry.Loc,
 		Title:      title,
-		Company:    e.Company,
+		Company:    company,
 		// Location is intentionally empty: SuccessFactors does not expose it in the
 		// microdata, and enrichment derives it from the description.
 		Location:    "",
@@ -80,4 +92,22 @@ var sfJobIDPattern = regexp.MustCompile(`/(\d+)(?:-[^/]*)?/?$`)
 // sfJobID extracts the native numeric posting id from a job page URL.
 func sfJobID(loc string) string {
 	return firstSubmatch(sfJobIDPattern, loc)
+}
+
+// sfTenant returns the hub tenant a job URL belongs to: the first path segment, which is how a
+// SuccessFactors hub identifies the employer behind a posting when nothing else on the page
+// does. It returns "" when the URL names no tenant — a bare host or an unparseable URL, or a
+// path opening on "job", the platform's own word for a posting. That last one is the tenant-less
+// shape a hub sitemap also lists, and it is every URL on an ordinary single-tenant site, where
+// the segment follows the host instead of a tenant.
+func sfTenant(loc string) string {
+	u, err := url.Parse(loc)
+	if err != nil {
+		return ""
+	}
+	segment, _, _ := strings.Cut(strings.TrimPrefix(u.Path, "/"), "/")
+	if segment == "job" {
+		return ""
+	}
+	return segment
 }

--- a/internal/ingest/sources/successfactors_test.go
+++ b/internal/ingest/sources/successfactors_test.go
@@ -55,6 +55,31 @@ func TestSFJobID(t *testing.T) {
 	}
 }
 
+func TestSFTenant(t *testing.T) {
+	cases := map[string]string{
+		// A hub site serves every tenant from one host and names the tenant in the first
+		// path segment.
+		"https://jobsearch.createyourowncareer.com/Riverty/job/Berlin-Software-Engineer-10623/1425618633/": "Riverty",
+		"https://jobsearch.createyourowncareer.com/PRH_US/job/New-York-Assistant-Editor-10019/1414466433/": "PRH_US",
+		// The same hub sitemap also lists postings with no tenant segment at all; "job" is
+		// the platform's own word and must never read as a tenant.
+		"https://jobsearch.createyourowncareer.com/job/Dortmund-Delphi-Entwickler-44369/1431430433/": "",
+		// An ordinary single-tenant SuccessFactors site has the same shape, so it too
+		// yields no tenant and falls back to the configured company.
+		"https://jobs.tetrapak.com/job/Munich-Engineer/12345/": "",
+		"https://jobs.tetrapak.com/":                           "",
+		"https://jobs.tetrapak.com":                            "",
+		"://not a url":                                         "",
+		// A tenant's own landing page is all path and no posting; it still names the tenant.
+		"https://jobsearch.createyourowncareer.com/Riverty": "Riverty",
+	}
+	for loc, want := range cases {
+		if got := sfTenant(loc); got != want {
+			t.Errorf("sfTenant(%q) = %q, want %q", loc, got, want)
+		}
+	}
+}
+
 func TestSFItempropHelpers(t *testing.T) {
 	root := parseHTML(t, sfDetailHTML)
 	if got := itempropText(root, "title"); got != "Commissioning Engineer" {
@@ -171,6 +196,70 @@ func TestSuccessFactorsDropsJobWithNoParseableID(t *testing.T) {
 	}
 	if len(jobs) != 0 {
 		t.Fatalf("got %d jobs, want 0 (unparseable id dropped)", len(jobs))
+	}
+}
+
+// A hub site serves many employers from one host and one shared sitemap, naming the tenant
+// only in the job URL. The configured company is the hub's own name and the fallback.
+func TestSuccessFactorsHubResolvesEmployerPerPosting(t *testing.T) {
+	const host = "https://jobsearch.createyourowncareer.com"
+	mapped := host + "/Riverty/job/Berlin-Software-Engineer-10623/1425618633/"
+	unmapped := host + "/Sonopress/job/Guetersloh-Operator-33333/1400000001/"
+	tenantless := host + "/job/Dortmund-Delphi-Entwickler-44369/1431430433/"
+
+	fake := (&routedHTTP{}).
+		route("/job_sitemap.xml", sfSitemapXML(mapped, unmapped, tenantless)).
+		route("/Riverty/job/Berlin-Software-Engineer-10623/1425618633", sfDetailHTML).
+		route("/Sonopress/job/Guetersloh-Operator-33333/1400000001", sfDetailHTML).
+		route("/job/Dortmund-Delphi-Entwickler-44369/1431430433", sfDetailHTML)
+
+	jobs, err := NewSuccessFactors(fake).Fetch(context.Background(), CompanyEntry{
+		Company:  "Bertelsmann",
+		Provider: "successfactors",
+		Board:    "jobsearch.createyourowncareer.com",
+		Hub:      true,
+		Tenants:  map[string]string{"Riverty": "Riverty"},
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("got %d jobs, want 3", len(jobs))
+	}
+
+	byID := map[string]string{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j.Company
+	}
+	want := map[string]string{
+		"1425618633": "Riverty",     // mapped tenant
+		"1400000001": "Bertelsmann", // unmapped tenant falls back, never "Sonopress"
+		"1431430433": "Bertelsmann", // no tenant segment; never a company called "job"
+	}
+	for id, wantCompany := range want {
+		if byID[id] != wantCompany {
+			t.Errorf("job %s company = %q, want %q", id, byID[id], wantCompany)
+		}
+	}
+}
+
+// The hub branch must not reach an ordinary board: a single-tenant site's URLs carry path
+// segments too, and reading one as an employer would rename the company.
+func TestSuccessFactorsNonHubIgnoresTheURLPath(t *testing.T) {
+	loc := "https://jobs.tetrapak.com/Riverty/job/Munich-Engineer/12345/"
+	fake := (&routedHTTP{}).
+		route("/job_sitemap.xml", sfSitemapXML(loc)).
+		route("/Riverty/job/Munich-Engineer/12345", sfDetailHTML)
+
+	jobs, err := NewSuccessFactors(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Tetra Pak", Board: "jobs.tetrapak.com",
+		Tenants: map[string]string{"Riverty": "Riverty"}, // present but not honoured without Hub
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].Company != "Tetra Pak" {
+		t.Fatalf("company = %+v, want Tetra Pak", jobs)
 	}
 }
 

--- a/internal/ingest/sources/ukgready_test.go
+++ b/internal/ingest/sources/ukgready_test.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -59,7 +60,7 @@ func TestUKGReadyTenantFoldsThePodHost(t *testing.T) {
 		t.Fatalf("len(Sources) = %d, want %d: %+v", len(cfg.Sources), len(want), cfg.Sources)
 	}
 	for i, w := range want {
-		if cfg.Sources[i] != w {
+		if !reflect.DeepEqual(cfg.Sources[i], w) {
 			t.Errorf("Sources[%d] = %+v, want %+v", i, cfg.Sources[i], w)
 		}
 	}

--- a/openspec/changes/successfactors-hub-boards/.openspec.yaml
+++ b/openspec/changes/successfactors-hub-boards/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-02

--- a/openspec/changes/successfactors-hub-boards/design.md
+++ b/openspec/changes/successfactors-hub-boards/design.md
@@ -1,0 +1,92 @@
+## Context
+
+The full measured design, including the live probes behind every claim here, is committed at
+`docs/superpowers/specs/2026-09-02-successfactors-hub-design.md`. This is the decision record.
+
+`jobsearch.createyourowncareer.com` is a SAP SuccessFactors career site with 973 postings
+belonging to 40 Bertelsmann companies. The successfactors adapter's `detail` sets
+`Company: e.Company` — one configured name per board — and the board is already in
+`sources/successfactors.yml` under `company: Arvato`, so every one of those 40 employers'
+postings is currently filed under Arvato (989 open rows against a 973-entry sitemap).
+
+Constraints found by probing the live site:
+
+- No per-tenant sitemap exists. `/<tenant>/job_sitemap.xml` redirects to the site's 404 page
+  for every tenant tried; only the shared `/job_sitemap.xml` is served, listing all 973
+  postings.
+- The job pages' `hiringOrganization` microdata is unusable: on a Riverty posting it reads
+  `Bertelsmann SE & Co. KGaA` (the corporate parent), and the same markup emits the property
+  twice more with the values `Apply now!` and a raw JavaScript fragment.
+- The tenant IS reliably encoded as the job URL's first path segment
+  (`/Riverty/job/<slug>/<id>/`), with 4 of the 973 entries carrying no tenant segment at all
+  (`/job/<slug>/<id>/`).
+- Each tenant's landing page at `/<tenant>/` names it in `<title>` for 23 of the 40 tenants,
+  in four different title shapes. The other 17 serve an empty (JS-rendered) page, the
+  platform's boilerplate `Create Your Own Career`, or a page heading rather than a company.
+
+The board-file schema already carries a generic `hub` flag, honoured by three adapters today
+(huntflow, loxo, cleverstaff), each reading the employer out of its own platform's payload.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Ingest the board with each posting attributed to its real employer.
+- Keep the hub concept generic: a second SuccessFactors hub should need only a YAML entry.
+- Never put a wrong employer in the catalogue.
+
+**Non-Goals:**
+
+- Naming the 17 tenants the platform does not name (112 postings). They fall back to the
+  parent brand.
+- Changing how `hub` behaves for huntflow.
+- Any change to schema, API or web.
+
+## Decisions
+
+**Employer names are curated in the board file, not resolved at crawl time.**
+The alternative was fetching each tenant's landing page per run and extracting the name from
+`<title>`, the way `internal/dict/companyname`'s title resolvers work. Rejected on the
+measurement: it fails outright for 17 of 40 tenants and needs four different title extractors
+for the rest, so it would carry the complexity of live resolution AND still need the curated
+fallback. Writing 23 verified names once is the same act the repo already performs for every
+`company:` in `sources/*.yml`.
+
+**The map lives on `CompanyEntry`, not in a dict package.**
+`Tenants map[string]string` sits beside `Region` and `Hub` — optional, per-entry, ignored by
+adapters that do not implement it. A dict package would be infrastructure for one board.
+
+**An unmapped tenant falls back to the configured company; it is never humanised.**
+Deriving `Arvato_Systems` → "Arvato Systems" works, but the same rule turns `PRH_US`,
+`BFS_Health_Finance`, `GBS` and `SDSH` into noise. `internal/dict/companyname` already argues
+this: a wrong-but-plausible name reads worse than the honest fallback. The fallback matches
+huntflow's `companyFromDivision(division, fallback)`.
+
+**One board, not 41.**
+Filing each tenant as its own board entry was rejected because there is no per-tenant sitemap:
+41 boards would each download the same shared 223 KB sitemap every cycle.
+
+## Risks / Trade-offs
+
+- **The catalogue re-attributes ~570 open postings on the next crawl of this board** → the
+  rows are UPDATEd in place (`UpsertJob` conflicts on `(source, external_id)` and the board,
+  which namespaces external_id, does not change), so nothing is orphaned or double-written.
+  The post-run unseen sweep scopes itself by the slugs the run PRODUCED
+  (`distinctCompanySlugs` reads `j.Company`), not by the board file's company, so per-tenant
+  closes keep working — the same mechanism huntflow's hub already relies on.
+- **Stale sitemap entries** (a sampled `PRH_US` posting redirects to the site's exception
+  page) → `detail` already returns `ok=false` on a failed fetch and the pipeline skips just
+  that posting. The ingested count will sit below 973; that is correct, not a defect.
+- **The curated map goes stale when Bertelsmann adds a brand** → the new tenant falls back to
+  `Bertelsmann`. Visible in the catalogue and true, rather than silently wrong.
+
+## Migration Plan
+
+No schema or data migration. The board is already crawled, so the change lands on the next
+scheduled run of `sources/successfactors.yml`: postings keep their rows and move to their real
+employer. Rollback is restoring the entry to `company: Arvato`, which the following run undoes
+the same way.
+
+## Open Questions
+
+None.

--- a/openspec/changes/successfactors-hub-boards/proposal.md
+++ b/openspec/changes/successfactors-hub-boards/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+`jobsearch.createyourowncareer.com` is a live SAP SuccessFactors career site holding 973
+postings for 40 different Bertelsmann companies — Arvato Systems, Riverty, RTL, Penguin
+Random House, Fremantle, smartclip and more. The successfactors adapter attributes every job
+on a board to the one configured company, and the board is ALREADY in
+`sources/successfactors.yml` under `company: Arvato` — so the catalogue is currently filing
+all 40 employers' postings under Arvato, which is why that slug carries 989 open jobs against
+the sitemap's 973.
+
+A link contribution (a Riverty engineering role) is what surfaced the mis-attribution. This
+is a correction, not a new board.
+
+The hub concept that solves this already exists in the board-file schema and in three
+adapters (huntflow, loxo, cleverstaff); SuccessFactors needs its own way of reading the
+employer, because its hub encodes the tenant in the job URL rather than in the posting
+payload.
+
+## What Changes
+
+- `sources.CompanyEntry` gains an optional `tenants` map (tenant key → employer display
+  name), beside the existing `region` and `hub` fields. It is ignored by adapters that do
+  not implement hub resolution.
+- The successfactors adapter honours `hub`: it reads the tenant key from the job URL's
+  first path segment and resolves the employer through the entry's `tenants` map, falling
+  back to the configured company when the key is absent or unmapped.
+- `sources/successfactors.yml`'s existing `jobsearch.createyourowncareer.com` entry becomes
+  a hub entry: `company: Arvato` becomes `company: Bertelsmann` (the hub's own name and the
+  fallback employer) plus `hub: true` and a curated map of the 23 tenant names the platform
+  itself states. Arvato keeps its own postings through the `ARVATO` tenant key.
+- No breaking change: a board entry without `hub` behaves exactly as before.
+
+## Capabilities
+
+### New Capabilities
+
+None. The hub concept and the board-file schema already live in `source-ingest`.
+
+### Modified Capabilities
+
+- `source-ingest`: the generic hub requirement gains the optional `tenants` map that lets a
+  hub entry carry per-tenant employer names, and a new requirement covers how the
+  successfactors adapter resolves a hub board's employer from the job URL.
+
+## Impact
+
+- `internal/ingest/sources/source.go` — one optional field on `CompanyEntry`.
+- `internal/ingest/sources/successfactors.go` — hub branch in `detail`, plus a `sfTenant`
+  URL helper.
+- `sources/successfactors.yml` — one existing board entry converted to a hub.
+- The catalogue: on the next crawl of this board, roughly 570 of the 989 postings currently
+  filed under `arvato` re-attribute to their real employer. The rows are UPDATEd in place
+  (`UpsertJob` conflicts on `(source, external_id)`, and the board — which namespaces
+  external_id — does not change), so nothing is orphaned. The post-run unseen sweep scopes
+  itself by the slugs the run actually PRODUCED (`distinctCompanySlugs` reads `j.Company`),
+  not by the board file's company, so per-tenant closes keep working.
+- Crawl load: unchanged. The board is already crawled at this size; only the company each
+  posting is filed under moves.
+- No database, API or web change. Nothing else reads `CompanyEntry.Tenants`.

--- a/openspec/changes/successfactors-hub-boards/specs/source-ingest/spec.md
+++ b/openspec/changes/successfactors-hub-boards/specs/source-ingest/spec.md
@@ -1,0 +1,86 @@
+## MODIFIED Requirements
+
+### Requirement: A board entry MAY be marked as a community hub whose employer comes from each posting
+
+The system SHALL support an optional `hub` flag on a board-file entry that marks a board-based
+provider's board as a community/agency hub: a board that lists vacancies on behalf of many
+partner companies rather than a single employer. Unlike a boardless aggregator (one global feed,
+no board id), a hub entry still names a board id and still requires a `company` — that configured
+company is the hub's own name and the per-vacancy fallback employer. When the flag is absent or
+false, the provider's existing behaviour SHALL be unchanged and each job's company SHALL be the
+configured entry company.
+
+For a hub entry, the provider SHALL resolve each vacancy's employer from the posting itself
+rather than from the configured company, falling back to the configured company when the posting
+carries no resolvable employer (for example the hub's own internal roles).
+
+A hub entry MAY additionally carry an optional `tenants` map, from the tenant key the platform
+stamps on a posting to that tenant's employer display name. It exists for hubs whose postings
+identify the tenant only by an opaque key — a URL path segment or an id — which is not itself a
+usable company name. The map SHALL be optional and SHALL be ignored by providers that do not
+implement hub resolution, exactly as `hub` and `region` are. A tenant key absent from the map
+SHALL fall back to the configured company rather than be turned into a name by transforming the
+key, because a plausible-but-wrong employer is worse in the catalogue than the parent brand.
+
+#### Scenario: A non-hub entry attributes every job to the configured company
+
+- **WHEN** a board file lists an entry without the `hub` flag (or with `hub: false`)
+- **THEN** each crawled job's company is the entry's configured `company`, exactly as before
+
+#### Scenario: A hub entry attributes each job to the employer named in the posting
+
+- **WHEN** a board file lists an entry with `hub: true`
+- **THEN** each crawled job's company is resolved from that vacancy's own payload, and only a
+  vacancy with no resolvable employer falls back to the configured `company`
+
+#### Scenario: A hub entry maps an opaque tenant key to an employer name
+
+- **WHEN** a hub entry carries a `tenants` map and a vacancy's tenant key is present in it
+- **THEN** the job's company is that map's value
+
+#### Scenario: An unmapped tenant key falls back rather than being invented
+
+- **WHEN** a hub entry carries a `tenants` map and a vacancy's tenant key is absent from it
+- **THEN** the job's company is the configured `company`, and the key is NOT transformed into a
+  name
+
+## ADDED Requirements
+
+### Requirement: The successfactors adapter resolves a hub board's employer from the job URL
+
+For a `successfactors` board marked as a community hub, the adapter SHALL set each job's company
+from the tenant key carried in that job's URL, resolved through the entry's `tenants` map.
+SuccessFactors hub sites serve every tenant from one host and one shared `job_sitemap.xml`, and
+they identify the tenant only as the FIRST path segment of a job URL
+(`/<tenant>/job/<slug>/<id>/`). The job page's own `hiringOrganization` microdata SHALL NOT be
+used for this: on a hub it names the corporate parent rather than the employer, and the same
+markup emits the property more than once with non-company values.
+
+A job URL whose path does not begin with a tenant segment — the tenant-less
+`/job/<slug>/<id>/` shape a hub sitemap also lists — SHALL yield no tenant key, and the literal
+`job` segment SHALL NOT be read as a tenant. A missing or unmapped tenant key SHALL fall back to
+the configured entry company. A non-hub `successfactors` board's behaviour is unchanged (company
+is the configured entry company).
+
+#### Scenario: A mapped tenant becomes the job's employer
+
+- **WHEN** a hub board's job URL is `https://<host>/Riverty/job/Berlin-Software-Engineer-10623/1425618633/`
+  and the entry's `tenants` map has `Riverty: Riverty`
+- **THEN** the job's company is `Riverty`
+
+#### Scenario: An unmapped tenant falls back to the hub company
+
+- **WHEN** a hub board's job URL carries the tenant segment `Sonopress` and the entry's `tenants`
+  map has no `Sonopress` key
+- **THEN** the job's company is the entry's configured `company`
+
+#### Scenario: A tenant-less job URL is not attributed to a company called "job"
+
+- **WHEN** a hub board's job URL is `https://<host>/job/Dortmund-Delphi-Entwickler-44369/1431430433/`
+- **THEN** the job's company is the entry's configured `company`, never `job`
+
+#### Scenario: A non-hub successfactors board is unaffected
+
+- **WHEN** a `successfactors` entry has no `hub` flag
+- **THEN** every job's company is the configured `company`, whatever the job URL's path segments
+  are

--- a/openspec/changes/successfactors-hub-boards/tasks.md
+++ b/openspec/changes/successfactors-hub-boards/tasks.md
@@ -1,0 +1,32 @@
+## 1. The tenant key
+
+- [x] 1.1 Add `sfTenant(loc string) string` to `internal/ingest/sources/successfactors.go`,
+      returning the job URL's first path segment, and `""` when the path carries no tenant —
+      the tenant-less `/job/<slug>/<id>/` shape, a bare host, or an unparseable URL. Cover
+      each of those with table tests, including that the literal `job` is never a tenant.
+
+## 2. The board-file field
+
+- [x] 2.1 Add `Tenants map[string]string \`yaml:"tenants"\`` to `sources.CompanyEntry` beside
+      `Region` and `Hub`, documented as an optional per-entry map from a hub's tenant key to
+      the employer's display name, ignored by adapters that do not implement hub resolution.
+      Prove it decodes from YAML with a loader test.
+
+## 3. Hub resolution in the adapter
+
+- [x] 3.1 In `successfactors.detail`, resolve the job's company through `e.Tenants` from
+      `sfTenant(entry.Loc)` when `e.Hub` is set, falling back to `e.Company` on a missing or
+      unmapped key. Adapter tests over a fixture sitemap and job pages: a mapped tenant, an
+      unmapped tenant, a tenant-less URL, and a non-hub board whose company is unchanged.
+
+## 4. The board
+
+- [x] 4.1 Convert the existing `jobsearch.createyourowncareer.com` entry (today `company: Arvato`) into a hub entry in
+      `sources/successfactors.yml` with `hub: true`, `company: Bertelsmann` and the 23
+      curated tenant names, then run `go run ./cmd/validate-sources`.
+
+## 5. Verify against the live board
+
+- [x] 5.1 Run the adapter against the live board and confirm the employers land as intended:
+      mapped tenants carry their own name, unmapped ones read `Bertelsmann`, and no job is
+      attributed to a company called `job`.

--- a/sources/successfactors.yml
+++ b/sources/successfactors.yml
@@ -2,6 +2,10 @@
 # board = the SAP SuccessFactors career-site host (see internal/sources/successfactors.go);
 # the adapter reads https://<board>/job_sitemap.xml.
 # Each board validated live (>0 jobs in its sitemap) before adding.
+#
+# One entry is a HUB rather than a single employer: it carries `hub: true` plus a `tenants`
+# map, and the adapter reads each posting's employer from its URL's first path segment. See
+# the comment on that entry for how its names were established.
 
 - company: Tetra Pak
   board: jobs.tetrapak.com
@@ -2073,8 +2077,44 @@
   board: jobsanz.veolia.com.au
 - company: Alstom
   board: jobsearch.alstom.com
-- company: Arvato
+# A Bertelsmann hub: one host and one shared job_sitemap.xml for 40 employers, which the site
+# names only as the job URL's first path segment. Contributed as a link, validated live
+# 2026-09-02 (973 postings in the sitemap). The 17 tenants missing below are the ones the
+# platform does not name — their /<tenant>/ landing page is empty, serves the platform's own
+# "Create Your Own Career" boilerplate, or shows a page heading — so their postings fall back
+# to Bertelsmann rather than get a name invented from the key.
+#
+# Each name below is that tenant's own landing-page title, read verbatim rather than expanded
+# from the key; "Penguin Random House" is PRH_US because that is what its title says, which is
+# why its three siblings are the qualified ones. The keys are matched EXACTLY, so transcribe
+# them from the sitemap: a re-cased or mistyped key is a silent fallback, not an error.
+- company: Bertelsmann
   board: jobsearch.createyourowncareer.com
+  hub: true
+  tenants:
+    ARVATO: Arvato
+    Arvato_Systems: Arvato Systems
+    BMG: BMG
+    BertelsmannStiftung: Bertelsmann Stiftung
+    Bertelsmann_Investments: Bertelsmann Investments
+    DK_UK: Dorling Kindersley UK
+    FREMANTLE: Fremantle
+    GBS: Bertelsmann Global Business Services
+    PRH_DEU: Penguin Random House Verlagsgruppe
+    PRH_GRUPO: Penguin Random House Grupo Editorial
+    PRH_UK: Penguin Random House UK
+    PRH_US: Penguin Random House
+    PostAdress: PostAdress
+    Playaway: Playaway
+    RTL: RTL
+    Relias_Learning: Relias
+    Riverty: Riverty
+    SDSH: Stiftung Deutsche Schlaganfallhilfe
+    TERRITORY: TERRITORY
+    VIVENO_Group: VIVENO Group
+    bfs_finance: bfs finance
+    smartclip: smartclip
+    weareera: We Are Era
 - company: University of Sheffield
   board: jobsite.sheffield.ac.uk
 - company: Captrain España


### PR DESCRIPTION
Stop 40 Bertelsmann employers being filed under Arvato

sources/successfactors.yml has carried jobsearch.createyourowncareer.com
as `company: Arvato` since it was added. It is not Arvato's board: it is
Bertelsmann's, one host and one shared job_sitemap.xml for 973 postings
belonging to 40 companies — Arvato Systems, Riverty, RTL, Penguin Random
House, Fremantle, smartclip and more. Every one of them has been landing
in the catalogue as Arvato, which is why that slug carries 989 open jobs
against a 973-entry sitemap. A link contribution (a Riverty engineering
role) is what surfaced it.

The board-file schema already models this: `hub: true` marks a board
whose vacancies belong to many companies, and huntflow, loxo and
cleverstaff each honour it by reading the employer out of their own
platform's payload. SuccessFactors cannot: its job pages state
`hiringOrganization` as the corporate parent (a Riverty posting says
"Bertelsmann SE & Co. KGaA") and emit the property twice more with the
values "Apply now!" and a raw JavaScript fragment. What the site does
encode reliably is the tenant, as the job URL's first path segment.

So the entry gains a `tenants` map — an optional CompanyEntry field
beside `region` and `hub` — and the adapter resolves each posting's
employer through it. The names in the map are each read from that
tenant's own landing page at /<tenant>/; 17 of the 40 tenants have no
usable name there (14 serve an empty page, two the platform's own
"Create Your Own Career" boilerplate, one a page heading), so they are
absent from the map and their 112 postings fall back to Bertelsmann.
That is the point of the fallback: `PRH_US`, `BFS_Health_Finance`, `GBS`
and `SDSH` all humanise into noise, and a plausible-but-wrong employer
reads worse in the catalogue than the parent brand — the argument
internal/dict/companyname already makes.

Run against the live board, the 973 postings resolve to 24 companies:
Arvato 414, Arvato Systems 142, Bertelsmann 116 (the fallback), Riverty
97, RTL 49, Penguin Random House 25, and 18 more.

The re-attribution is safe without a reindex. UpsertJob conflicts on
(source, external_id), and the board — which namespaces external_id —
does not change, so the rows move in place; jobhash.Of covers Company
and CompanySlug, so the move flips content_hash and the incremental
search drain follows. The post-run sweep scopes itself by the slugs the
run PRODUCED, not by the board file's company, so per-tenant closes keep
working.

Adding a map to CompanyEntry makes it non-comparable; three tests
compared it with `!=` and now use reflect.DeepEqual. Nothing in
production did — `go vet -tags=integration` over the module is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SuccessFactors hub boards can now attribute job postings to the correct employer using tenant mappings in job URLs.
  * Unmapped or tenant-less postings fall back to the configured board company.
  * Added support for configuring hub boards and tenant-to-company mappings.

* **Bug Fixes**
  * Corrected employer attribution for postings from the Bertelsmann SuccessFactors career hub.
  * Preserved existing company attribution for non-hub boards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->