### PR TITLE
Pin the job's company and title while the description scrolls

### DIFF
--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -110,6 +110,38 @@
     contentTab = 'description';
   });
 
+  // The pinned header. Once the posting's own header has scrolled under the top bar,
+  // a one-line copy of it — company, title, apply — takes its place, so "who is this
+  // for?" and the button stay a glance away through a description that routinely runs
+  // several screens.
+  //
+  // It rides a zero-height sticky rail inside an absolutely-positioned overlay, so the
+  // bar occupies no space in the flow and appearing can never shift the text under it.
+  // The obvious alternative — pinning the real header and collapsing it — cannot say
+  // that: its flow box loses ~90px the instant it pins, jerking the paragraph the
+  // reader is mid-sentence in, and again in reverse on the way back up.
+  const PINNED_HEADER_TOP = 56; // `top-14` on the rail below, and the top bar's own `h-14`.
+  let headerSentinel: HTMLElement | undefined = $state();
+  let headerPinned = $state(false);
+  $effect(() => {
+    const el = headerSentinel;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (!entry) return;
+        // `isIntersecting` alone also reads false while the sentinel is BELOW the fold,
+        // which is where it sits on a short viewport before anything has been scrolled.
+        // The rect settles which edge it left by.
+        headerPinned =
+          !entry.isIntersecting && entry.boundingClientRect.top < PINNED_HEADER_TOP;
+      },
+      { rootMargin: `-${PINNED_HEADER_TOP}px 0px 0px 0px` },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  });
+
   // Funnel view — captured for everyone (unlike the authed-only server record
   // below). Keyed on the slug alone so it fires once per job and never re-emits
   // when an unrelated dependency (e.g. auth state) changes mid-view.
@@ -514,7 +546,60 @@
     </div>
   </aside>
 
-  <div class="flex min-w-0 flex-col gap-6 lg:col-start-2 lg:row-start-3">
+  <div class="relative flex min-w-0 flex-col gap-6 lg:col-start-2 lg:row-start-3">
+    <!-- The pinned header (see PINNED_HEADER_TOP). The overlay spans this column, which
+         is what gives the rail inside it something to travel: a `sticky` element is
+         clamped to its containing block, and the column is exactly the stretch the bar
+         should stay pinned over — it releases at the end of the posting, not over the
+         related jobs below. The `bottom-14` inset is the bar's own height: the rail is
+         zero-height, so without it the bar hangs a further ~52px past the end of the
+         overlay and spills over the "See also" strip on the last screen.
+         `pointer-events-none` on the overlay keeps the description selectable through
+         it; the bar itself takes them back.
+         `invisible` rather than a conditional block: keeping the bar mounted lets it
+         fade, and visibility:hidden takes it out of the focus order and the a11y tree
+         while it is away, so the duplicate apply button is not tabbable from the top
+         of the page. -->
+    <div class="pointer-events-none absolute inset-x-0 top-0 bottom-14">
+      <div bind:this={headerSentinel} aria-hidden="true" class="h-px w-full"></div>
+      <div class="sticky top-14 z-20 h-0">
+        <div
+          class={[
+            // Opaque, not frosted: the description slides directly under this and a
+            // translucent bar leaves a blurred ghost of the text inside it, which reads
+            // as a rendering fault rather than as glass. The mobile apply bar below can
+            // afford the frost because nothing scrolls under it at speed.
+            'pointer-events-auto flex items-center gap-3 border-b border-border bg-background py-2.5 transition-opacity duration-150',
+            headerPinned ? 'opacity-100' : 'invisible opacity-0',
+          ]}
+        >
+          <EntityLogo
+            name={job.company || 'Unknown company'}
+            src={companyLogoUrl(job.company) ?? undefined}
+            shape="square"
+            size="sm"
+          />
+          <p class="min-w-0 flex-1 truncate text-sm">
+            {#if job.company_slug}
+              <a
+                href={resolve('/companies/[slug]', { slug: job.company_slug })}
+                class="text-muted-foreground hover:text-foreground hover:underline"
+              >
+                {job.company || 'Unknown company'}
+              </a>
+            {:else}
+              <span class="text-muted-foreground">{job.company || 'Unknown company'}</span>
+            {/if}
+            <span class="px-1 text-muted-foreground" aria-hidden="true">·</span>
+            <span class="font-semibold" lang={contentLang}>{job.title}</span>
+          </p>
+          <!-- Hidden below lg for the same reason as the header's own copy: on mobile the
+               CTA is the sticky bottom bar, and two pinned buttons would fight. -->
+          {@render applyCta('md', 'hidden shrink-0 lg:inline-flex')}
+        </div>
+      </div>
+    </div>
+
     {#if job.closed_at}
       {@const closed = formatDate(job.closed_at)}
       <div class="rounded-md border border-border bg-secondary px-4 py-3 text-sm">


### PR DESCRIPTION
Pin the job's company and title while the description scrolls

A posting's description routinely runs several screens, and its header —
company, title, apply — scrolls away on the first one. Past that point the
page no longer answers "who is this for?", and the apply button is a scroll
back up.

A one-line copy of the header now takes over once the real one goes under
the top bar: logo, company (linked), title, and the same Show button.

It rides a zero-height sticky rail inside an absolutely positioned overlay
spanning the description column, so the bar occupies no space in the flow.
The obvious alternative — pinning the real header and collapsing it — loses
~90px of flow box the instant it pins, jerking the paragraph the reader is
mid-sentence in, and again in reverse on the way back up. Measured: the
document's scrollHeight is identical with the bar shown and hidden.

The overlay's bottom inset is the bar's own height. Without it the bar hangs
past the end of a zero-height rail and spills over the See also strip on the
last screen.

The tab strip stays where it is rather than joining the bar: TabStrip builds
its button ids from panelId, so a second copy would emit duplicate ids and a
second role="tablist" pointing at the one panel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pinned job header that appears as the main job header scrolls out of view.
  * The pinned header displays the company, job title, and an apply action on larger screens.
  * Added a smooth visibility transition for the pinned header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->