### PR TITLE
Surface the freshness and sort controls the backend already served

### DIFF
--- a/openspec/changes/surface-freshness-and-sort-controls/.openspec.yaml
+++ b/openspec/changes/surface-freshness-and-sort-controls/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-02

--- a/openspec/changes/surface-freshness-and-sort-controls/design.md
+++ b/openspec/changes/surface-freshness-and-sort-controls/design.md
@@ -66,6 +66,30 @@ absence of a parameter already expresses exactly.
 `newest`. Rejected: relevance becomes unreachable, so every text search is
 ordered by date and quality drops for the common case.
 
+### The stored ordering is nullable: chosen, or not yet chosen
+
+**Chosen:** `sort: JobSort | null`, with `null` meaning "no choice made" and the
+default applied at read time.
+
+The first draft stored the resolved default (`sort: 'newest'` for a fresh browse
+feed). Code review caught what that costs: `setQuery` spreads the state and
+overwrites only `q`, so nothing distinguishes "the browse feed defaulted to
+newest" from "the caller asked for newest". Typing into the header search box
+therefore produced `q=golang&sort=posted_at` — the primary search path, date-
+ordered, which is the outcome the alternative below is rejected for. The AI filter
+dialog reached the same state by the same route.
+
+The second cost is quieter. `savedSearchQuery` is `filtersToParams(...)`, so
+`sort` is part of the key that decides whether the live filters ARE the saved
+search they came from (`SavedSearches.svelte`, `saveSearchAlert.ts`). A stored
+query `q=go` parses to no ordering and serializes clean, but the typed state
+serialized as `q=go&sort=posted_at` — so the saved search read as dirty, and
+saving again created a duplicate saved search and a duplicate digest
+subscription that would deliver byte-identical mail.
+
+Nullability closes both directions with one rule instead of patching each entry
+point that can change `q`.
+
 ### Collapse `relevance` → `newest` purely, not via an effect
 
 `relevance` has nothing to rank against once the query is cleared. `JobsView`
@@ -86,6 +110,22 @@ This falls out of the option rules rather than restating them: `newest` always,
 visitor on a bare list sees no select — correct, since the feed is already newest
 and there is nothing to choose — and the same visitor with a query sees two.
 
+The option list and the selected value are pure functions in `facetModel.ts`
+(`sortOptionsFor`, `selectedSortFor`), not `$derived` in the view. Review made the
+case: the first draft left them in `JobsView.svelte`, where `web/` has no
+component-test harness, and both of the sort bugs review found were inside that
+untestable region. The same argument that put `effectiveSort` in the model applies
+to every rule that decides what the user sees.
+
+`selectedSortFor` also answers a case the option rules alone do not. A shared
+`?sort=match` link opened signed out resolves to an ordering that is not on offer,
+and a `<select>` whose value matches no option renders **blank** — an empty control
+over a live ordering. It names the ordering the endpoint will actually serve that
+caller instead, which is honest rather than merely non-blank, because the endpoint
+degrades `match` to exactly that. The same shape of bug applies to the freshness
+select, where a day count from a shared link or the AI dialog need not be a preset;
+`freshnessOptions` offers the live bound as a stop of its own.
+
 ### A toggle for evergreen, not a third select
 
 The row already carries the total, two selects and (on the jobs list) the Swipe
@@ -93,6 +133,14 @@ entry; on a narrow phone a third select crowds it out. The `reality` facet's own
 comment (`facets.ts:421`) states the common use is the single exclusion of
 `likely-evergreen`, so a two-state toggle covers it. The full three-class facet
 stays available in the modal, which is where a less common selection belongs.
+
+Measured at a 390px viewport the toggle's WORD was wider than the select it
+replaced, and the row ran 49px past the edge — the sort select clipped off-screen.
+The toggle drops its word below `sm` and the icon carries it, which is what the
+Swipe entry beside it already does and what `ListToolbar`'s own comment argues for.
+`flex-wrap` on that row is the safety net under both: the children are sized by
+their content (a longer count, a translated label, a future fourth control), and a
+row that runs out of width must break rather than clip.
 
 ### `setNow`, not `setSoon`, for the freshness select
 

--- a/openspec/changes/surface-freshness-and-sort-controls/design.md
+++ b/openspec/changes/surface-freshness-and-sort-controls/design.md
@@ -1,0 +1,155 @@
+# Design
+
+## Context
+
+`GET /api/v1/jobs/search` already accepts everything this change surfaces:
+`sort=posted_at`, `sort=created_at`, the two salary bounds, `sort=match`,
+`posted_within_days`, and the `reality` facet. The gap is entirely in the web
+client, in three different shapes:
+
+1. **A control gated on the wrong thing.** `JobsView` computes
+   `sortControlVisible = matchFilterAvailable && matchSortEnabled(env)`. The gate
+   is correct for the `match` option — a "Best match" that ranks against no
+   profile is worse than an absent option, which the code comment argues well —
+   but it was applied to the whole select, taking `Newest` down with it.
+
+2. **A control that misreports what the server does.** `newest` is
+   `DEFAULT_JOB_SORT`, and `filtersToParams` omits the default. So under query
+   text the request carries no `sort`, `searchSort` returns `nil`, and the engine
+   ranks by relevance while the select reads "Newest".
+
+3. **Controls that exist but are unreachable.** `posted` sits last in the rail's
+   third section; `reality` has no rail entry at all.
+
+The reporter's message — postings "years old" that "aren't in any particular
+order" — is the visible surface of (1) and (2) together.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- A signed-out visitor searching by text can order the feed by posting date.
+- The sort control's label matches the ordering the server actually applies.
+- Freshness and the evergreen exclusion are reachable without opening a modal.
+- A facet cannot again be declared, served, and unreachable without a test
+  failing.
+
+**Non-Goals**
+
+- No endpoint, index, schema, or settings change. The API's behaviour is already
+  what `job-search` specifies; only the client's model of it was wrong.
+- No sort by salary. The two bounds are sortable and the reporter asked for it by
+  name ("stipend"), but `enrichment.salary_min` is stored in the posting's own
+  currency with no conversion. A descending sort would rank 90 000 JPY above
+  80 000 USD — a control that looks authoritative and is not. It becomes viable
+  paired with a currency filter or a normalised column; neither is in scope.
+- No `updated_at` filter or sort. See "Deferred" below.
+
+## Decisions
+
+### Contextual default over a fourth sort value
+
+**Chosen:** `defaultSortFor(q) = q ? 'relevance' : 'newest'`, and serialize only
+when the selection differs from that default.
+
+The endpoint's defaults are already contextual in exactly this way
+(`search.go:212`: unknown/absent `sort` yields `posted_at:desc` when `q` is
+empty, and no directive otherwise). Mirroring them means `relevance` never needs
+a wire value the backend does not know — the client simply omits `sort`, and the
+existing "omit the default" rule in `filtersToParams` does the work unchanged.
+
+*Alternative considered:* teach the backend a literal `sort=relevance`. Rejected:
+it adds a wire value, a handler branch and a spec change to express something the
+absence of a parameter already expresses exactly.
+
+*Alternative considered:* keep two options and always emit `sort=posted_at` for
+`newest`. Rejected: relevance becomes unreachable, so every text search is
+ordered by date and quality drops for the common case.
+
+### Collapse `relevance` → `newest` purely, not via an effect
+
+`relevance` has nothing to rank against once the query is cleared. `JobsView`
+already handles an analogous case with an effect (`minMatch` is reset when the
+match slider disappears), but an effect is the wrong tool here: the serializer
+needs the same answer, and two readers of one rule invite drift.
+
+**Chosen:** one exported pure function in `facetModel.ts` that resolves a filter
+state to its effective sort. The select's `value` and `filtersToParams` both call
+it. Testable without a component harness, and it cannot disagree with itself.
+
+### Visibility by option count, not by role
+
+**Chosen:** render the select when it holds more than one option.
+
+This falls out of the option rules rather than restating them: `newest` always,
+`relevance` under query text, `match` under the existing gate. A signed-out
+visitor on a bare list sees no select — correct, since the feed is already newest
+and there is nothing to choose — and the same visitor with a query sees two.
+
+### A toggle for evergreen, not a third select
+
+The row already carries the total, two selects and (on the jobs list) the Swipe
+entry; on a narrow phone a third select crowds it out. The `reality` facet's own
+comment (`facets.ts:421`) states the common use is the single exclusion of
+`likely-evergreen`, so a two-state toggle covers it. The full three-class facet
+stays available in the modal, which is where a less common selection belongs.
+
+### `setNow`, not `setSoon`, for the freshness select
+
+`setPostedWithinDays` debounces via `setSoon` because the modal control is a
+dragged slider crossing intermediate stops. A select is a discrete commit and
+must not sit behind a debounce, for the same reason `setSort` uses `setNow`. The
+change adds a second setter rather than switching the existing one, so the
+slider's behaviour is untouched.
+
+## Risks / Trade-offs
+
+- **[A shared link that predates this change reads differently.]** No link the
+  client has ever produced carries `sort=posted_at` (the default was never
+  serialized), so there is nothing to reinterpret. `sort=match` round-trips
+  unchanged. → Covered by a deserialization scenario in the spec.
+
+- **[The freshness value now has three writers: modal slider, page select, AI
+  filter dialog.]** All three already write through the same store method, so the
+  value cannot fork; the risk is only that a user misses one of them updating. →
+  The filter summary already renders the active freshness chip, so the state is
+  visible wherever it was set from.
+
+- **[`ListToolbar`'s prop rename touches the company catalog.]** `CompaniesView`
+  passes `sortControl` too. → Both call sites change in the same commit;
+  `svelte-check` fails on a missed one rather than silently dropping the slot.
+
+- **[Relaxing the desktop-row condition could double the total on a company
+  page.]** The condition guards two things at once today. → The relaxed condition
+  keeps the total gated on `showDesktopTotal` and gates only the controls on
+  their own presence, which the spec's third scenario pins.
+
+## Deferred: filtering or sorting on `updated_at`
+
+Worth recording, because the column recently became meaningful and the reason it
+still cannot be used is not obvious.
+
+`RefreshUnchangedJob` (`internal/platform/db/queries/jobs.sql:368`) made a
+re-crawl of an unchanged posting write `last_seen_at` and nothing else, so
+`updated_at` now means "content last changed" rather than "last crawled" — the
+comment at line 381 says so explicitly, and the jobs sitemap already serves it as
+`<lastmod>` on that basis.
+
+It is nonetheless absent from the Meilisearch document (`document.go` carries
+`posted_ts`, `posted_at`, `created_at` and no more), so exposing it needs a
+document field, a `FilterableAttributes`/`SortableAttributes` entry, a full
+reindex, and a two-step release — settings live before the binary that queries
+them, per the warning in `client.go`. A reindex is not cheap here: it is blocked
+below a 45 GB disk floor and writes roughly 10 GB of skill vectors.
+
+There is also a product question worth settling first. "Updated yesterday" is not
+"posted yesterday": an evergreen posting whose description was edited would
+surface as fresh, which is the ghost-posting problem the reporter described
+rather than a fix for it. The `reality` facet this change surfaces answers that
+question directly and needs no reindex, so it should be observed in use before
+`updated_at` is added on top.
+
+## Open Questions
+
+None. Scope, control shapes and the deferred item were settled with the user
+before this change was written.

--- a/openspec/changes/surface-freshness-and-sort-controls/proposal.md
+++ b/openspec/changes/surface-freshness-and-sort-controls/proposal.md
@@ -1,0 +1,83 @@
+## Why
+
+A user wrote in asking for a way to sort by date, because the postings they hit
+"aren't in any particular order" and read as stale. Every capability they asked
+for already exists in the backend and is unreachable with a mouse:
+
+- `sort=posted_at` is an accepted, sortable attribute — but the client's sort
+  select is hidden behind `matchFilterAvailable && matchSortEnabled(env)`, so a
+  signed-out visitor never sees it at all.
+- The select lies when it is visible. `newest` is `DEFAULT_JOB_SORT`, and
+  `filtersToParams` omits the default — so with query text the request carries no
+  `sort`, the engine keeps relevance order, and the control still reads "Newest".
+- `posted_within_days` has a control, buried as the last entry of the modal's
+  third rail section, under the heading `REQUIREMENTS & ELIGIBILITY` — where a
+  posting's age is not a requirement of the candidate.
+- The `reality` facet (`fresh` / `stale` / `likely-evergreen`) is defined in
+  `FACETS` and understood by the backend, but has **no rail entry at all**. It is
+  reachable only by hand-editing the URL. Nothing caught this: the company rail
+  has a completeness test, the jobs rail does not.
+
+Two of these are the same defect the reporter described — the catalogue can
+already answer "show me recent postings" and never offered to.
+
+## What Changes
+
+- The feed's sort vocabulary gains an explicit `relevance` value, and its default
+  becomes contextual: `relevance` with query text, `newest` without. `newest`
+  under a query now genuinely emits `sort=posted_at` instead of silently serving
+  relevance. This makes the client match the behaviour `job-search` already
+  specifies for the endpoint; no endpoint change.
+- The sort select is shown whenever it holds more than one option, rather than
+  only to a signed-in user with profile skills. `relevance` is offered only under
+  query text; `match` keeps its existing profile-and-flag gate.
+- A **Posted** select joins the sort control above the list, over the existing
+  `FRESHNESS_PRESETS`. Same store as the modal slider, so the two stay in step.
+- A **Hide evergreen** toggle joins them, writing
+  `reality_exclude=likely-evergreen` — the use the facet's own comment names as
+  the common one.
+- `ListToolbar` renames `sortControl` to `controls` (it now hosts three) and stops
+  suppressing the whole desktop row when the total is rendered elsewhere, which is
+  what hides these controls on a company page.
+- The modal rail moves `Posted` into `ROLE` after `Experience`, and gains a
+  `Posting reality` entry.
+- A completeness test asserts every `FACETS` param has a rail entry or is on a
+  documented exception list, so the next facet cannot fall out silently.
+
+Deferred to its own change, deliberately: filtering or sorting on `updated_at`.
+The column became meaningful when `RefreshUnchangedJob` stopped stamping it on
+every crawl, but it is absent from the Meilisearch document, so it needs a schema
+field, settings change, full reindex, and a two-step release. See design.md.
+
+## Capabilities
+
+### New Capabilities
+
+- `jobs-list-controls`: the control row above the jobs list — the sort select's
+  vocabulary, its contextual default and visibility rule, the freshness select,
+  and the evergreen toggle, plus how each is mirrored into the URL.
+
+### Modified Capabilities
+
+- `web-frontend`: the "Jobs browse sort control" requirement is removed. It
+  describes a **Date posted** / **Recently added** pair that no longer exists in
+  the code, and `jobs-list-controls` supersedes it.
+- `filter-modal`: the rail's section membership changes (`Posted` moves to
+  `ROLE`), the rail gains a `Posting reality` entry, and the rail acquires a
+  completeness rule against `FACETS`.
+- `header-filter-trigger`: the toolbar requirement's wording covers one sort
+  control; it now hosts three list controls.
+
+## Impact
+
+Client only. No Go, no SQL, no Meilisearch settings, no reindex, no migration.
+
+- `web/src/lib/facetModel.ts` — `JobSort`, the contextual default, serialization
+- `web/src/lib/filters.ts` — a `setNow` freshness setter beside the slider's
+- `web/src/lib/components/JobsView.svelte` — the three controls
+- `web/src/lib/components/ListToolbar.svelte` — prop rename, desktop-row condition
+- `web/src/lib/components/CompaniesView.svelte` — prop rename at the call site
+- `web/src/lib/filterSections.ts` — rail membership
+- `web/src/lib/facetModel.test.ts`, `web/src/lib/filterSections.test.ts` — tests
+
+Shared links and saved searches carrying `sort=match` keep working unchanged.

--- a/openspec/changes/surface-freshness-and-sort-controls/specs/filter-modal/spec.md
+++ b/openspec/changes/surface-freshness-and-sort-controls/specs/filter-modal/spec.md
@@ -1,0 +1,89 @@
+## MODIFIED Requirements
+
+### Requirement: The job filters are edited in a two-pane modal grouped into sections
+
+The web client SHALL provide a filter modal opened from an **All filters** control.
+The modal SHALL present two panes: a left rail listing every filter facet grouped
+under section headings (`ROLE`, `PAY & BENEFITS`, `REQUIREMENTS & ELIGIBILITY`), and
+a right pane rendering the controls of the facet selected in the rail. Each rail
+entry SHALL show a count of how many values are currently staged for that facet, and
+selecting a rail entry SHALL switch the right pane to that facet without closing the
+modal or applying anything. Related facets MAY be consolidated into one rail entry
+whose pane renders each as its own labelled chip group (e.g. work format + employment
+type; industry + company type + collection; salary currency + minimum; English level +
+job language; relocation + visa).
+
+The seniority pills SHALL NOT be consolidated into the specialization pane. They
+belong to the `Experience` rail entry (see "The rail carries an Experience pane"),
+because seniority states how much experience a posting wants, not which role it is.
+
+The `Posted` (freshness) entry SHALL belong to the `ROLE` section, adjacent to
+`Experience`. It states how old a posting is, which is a property of the posting
+and not a requirement placed on the candidate, so `REQUIREMENTS & ELIGIBILITY` —
+where it sat as the rail's last entry — both misdescribed it and buried it.
+
+The rail SHALL carry a `Posting reality` entry rendering the `reality` facet's
+three classes as excludable chips. The facet was defined and served but had no
+rail entry, making it reachable only by hand-editing the URL.
+
+#### Scenario: Opening the modal shows the sectioned rail and the first facet
+
+- **WHEN** the user activates **All filters**
+- **THEN** the modal opens with the facets grouped under `ROLE` / `PAY & BENEFITS` /
+  `REQUIREMENTS & ELIGIBILITY` in the left rail and the first facet's controls in the
+  right pane
+
+#### Scenario: Selecting a rail entry switches the pane without applying
+
+- **WHEN** the user clicks a different facet in the rail
+- **THEN** the right pane renders that facet's controls and no change is applied to
+  the job list
+
+#### Scenario: The rail shows staged counts per facet
+
+- **WHEN** two values are staged for a facet (or a consolidated entry)
+- **THEN** that facet's rail entry shows the count `2`
+
+#### Scenario: The specialization pane no longer carries seniority
+
+- **WHEN** the user opens the specialization (`Role`) pane
+- **THEN** it renders the role picker, the specialization chips and the AI
+  specialization facet, and does NOT render the seniority pills
+
+#### Scenario: Freshness sits beside Experience under ROLE
+
+- **WHEN** the user opens the modal
+- **THEN** the `Posted` entry appears in the `ROLE` section adjacent to
+  `Experience`, and not under `REQUIREMENTS & ELIGIBILITY`
+
+#### Scenario: The reality facet is reachable from the rail
+
+- **WHEN** the user selects the `Posting reality` rail entry
+- **THEN** the right pane renders the `fresh`, `stale` and `likely-evergreen`
+  chips with the facet's Exclude affordance
+
+## ADDED Requirements
+
+### Requirement: Every job facet is reachable from the rail
+
+Every facet declared in the job filter vocabulary SHALL either have a rail entry
+of its own or be named in a documented exception list, and this SHALL be enforced
+by a test. An exception SHALL exist only where the facet's controls are rendered
+inside another entry's pane, and SHALL record which pane hosts it.
+
+The company catalog's rail already carries this guarantee. The job rail did not,
+and the `reality` facet was declared, served, and unreachable in the interface as
+a result — a facet that is defined but has no entry fails silently, in the one
+direction no test was watching.
+
+#### Scenario: A facet with no entry and no exception fails the test
+
+- **WHEN** a facet is added to the job filter vocabulary with neither a rail entry
+  nor an exception-list membership
+- **THEN** the rail completeness test fails
+
+#### Scenario: A facet hosted inside another pane is a documented exception
+
+- **WHEN** a facet's controls are rendered inside another entry's pane
+- **THEN** it appears on the exception list with the hosting pane recorded, and
+  the test passes

--- a/openspec/changes/surface-freshness-and-sort-controls/specs/header-filter-trigger/spec.md
+++ b/openspec/changes/surface-freshness-and-sort-controls/specs/header-filter-trigger/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: The list toolbar no longer hosts a filter trigger
+
+The list toolbar (`ListToolbar`) SHALL NOT render a filter trigger in either its inline
+sort row or its scroll-revealed floating edge variant; the All-filters trigger is hosted
+solely by the header search box. The toolbar's list controls and Swipe affordance SHALL
+remain.
+
+The toolbar's control slot SHALL carry however many list controls the hosting view
+passes — on the jobs list, the sort select, the freshness select and the evergreen
+toggle (see `jobs-list-controls`); on the company catalog, its own sort select. The
+slot SHALL render on desktop whenever controls are passed, including on a view that
+renders its result total elsewhere and therefore suppresses the toolbar's own total.
+Tying the controls' visibility to the total is what hid them on a company page.
+
+#### Scenario: No filter button in the toolbar row
+
+- **WHEN** a user views the jobs or companies list
+- **THEN** the toolbar row shows the list controls and, where applicable, the Swipe
+  affordance, but no filter button
+
+#### Scenario: No floating filter button on scroll
+
+- **WHEN** the user scrolls the list so the toolbar leaves the viewport
+- **THEN** no floating filter edge button appears; the header search box's trigger
+  remains the way to open filters
+
+#### Scenario: Controls render where the total is hosted elsewhere
+
+- **WHEN** a view passes list controls but renders its result total outside the
+  toolbar
+- **THEN** the desktop toolbar row renders the controls and omits only the total

--- a/openspec/changes/surface-freshness-and-sort-controls/specs/jobs-list-controls/spec.md
+++ b/openspec/changes/surface-freshness-and-sort-controls/specs/jobs-list-controls/spec.md
@@ -20,9 +20,18 @@ A non-default selection SHALL be serialized as the value the endpoint accepts:
 unrecognised value SHALL resolve to the contextual default, so a hand-edited or
 shared link never leaves the control in a state it cannot render.
 
+The stored ordering SHALL distinguish "the caller chose this" from "no choice has
+been made"; the latter SHALL resolve to the contextual default at read time rather
+than being written into the state. Storing the resolved default instead would make
+a browse feed's `newest` indistinguishable from a chosen `newest`, so typing into
+the search box would carry `sort=posted_at` into a text search and date-order it —
+defeating the contextual default at the commonest entry point, and changing the
+serialization of the live filters so they no longer compare equal to the saved
+search they came from.
+
 `relevance` has nothing to rank against without query text. Resolving the
 selection SHALL therefore collapse `relevance` to `newest` whenever the query is
-empty, and this collapse SHALL be a pure function shared by the control and the
+empty. Both resolutions SHALL be one pure function shared by the control and the
 serializer so the two cannot disagree.
 
 #### Scenario: Browsing with no query omits the sort parameter
@@ -56,6 +65,19 @@ serializer so the two cannot disagree.
 - **THEN** the resolved selection is `newest` and the serialized parameters carry
   no `sort` key
 
+#### Scenario: Typing a query does not pin the browse ordering
+
+- **WHEN** query text is added to a filter state whose ordering was never chosen
+- **THEN** the resolved selection is `relevance` and the serialized parameters
+  carry no `sort` key
+
+#### Scenario: A typed query still matches the saved search it came from
+
+- **WHEN** the saved search `q=go` is compared against a filter state reached by
+  typing `go` with no ordering chosen
+- **THEN** the two serialize identically, so the saved search reads as active
+  rather than dirty and saving again does not create a duplicate
+
 ### Requirement: The sort control is shown whenever it offers a choice
 
 The jobs list SHALL render its sort control whenever the control holds more than
@@ -73,7 +95,10 @@ visitor could ever receive under query text was relevance, unlabelled.
 
 The URL parameter SHALL be honoured regardless of whether the control is
 rendered, unchanged from today: the endpoint degrades an ordering it cannot serve
-rather than refusing it.
+rather than refusing it. When the resolved ordering is one the control does not
+offer, the control SHALL show the ordering the endpoint will actually serve that
+caller rather than an unrepresented value — a select whose value matches no option
+renders blank, which would put an empty control over a live ordering.
 
 #### Scenario: A signed-out visitor with a text query can reorder
 
@@ -92,6 +117,12 @@ rather than refusing it.
   the match flag enabled
 - **THEN** the sort control additionally offers `Best match`
 
+#### Scenario: A shared match link renders as what it will actually serve
+
+- **WHEN** a signed-out visitor opens a link carrying `q=go&sort=match`
+- **THEN** the control shows `Relevance` — the ordering the endpoint degrades to —
+  and the `sort=match` parameter is left in the URL untouched
+
 ### Requirement: Freshness is selectable above the list
 
 The jobs list SHALL render a **Posted** control above the list, offering the same
@@ -102,6 +133,13 @@ discrete choice and not a dragged gesture.
 The control SHALL write to the same filter state the modal's freshness slider
 writes to, so the two, the filter summary and a saved search all read one value
 and cannot drift.
+
+A bound that is not one of the stops — from a shared link, a hand-edited URL, or
+the AI filter dialog, which writes whatever day count it read — SHALL be offered
+as a stop of its own, in day order, labelled for what it is. A select can only
+show a value it has an option for; without one the control renders blank while
+the bound quietly narrows the list, which is the same untruth the freshness label
+already refuses to tell.
 
 #### Scenario: Choosing a stop bounds the list
 
@@ -118,6 +156,12 @@ and cannot drift.
 
 - **WHEN** the user selects `Any`
 - **THEN** the URL carries no `posted_within_days` key
+
+#### Scenario: An off-preset bound is shown rather than left blank
+
+- **WHEN** a link carrying `posted_within_days=5` is opened
+- **THEN** the control offers a `Last 5 days` stop between `3 days` and `1 week`
+  and shows it as selected
 
 ### Requirement: Likely-evergreen postings can be hidden from the list
 

--- a/openspec/changes/surface-freshness-and-sort-controls/specs/jobs-list-controls/spec.md
+++ b/openspec/changes/surface-freshness-and-sort-controls/specs/jobs-list-controls/spec.md
@@ -1,0 +1,149 @@
+## ADDED Requirements
+
+### Requirement: The feed's ordering vocabulary names relevance explicitly
+
+The jobs feed's client-side sort vocabulary SHALL be `relevance`, `newest` and
+`match`. `relevance` names the engine's own ranking — the order a request with
+query text and no `sort` parameter already receives — so that the control can
+report it rather than mislabel it.
+
+The default SHALL be contextual: `relevance` when the filter state carries query
+text, `newest` when it does not. Serialization SHALL omit the `sort` parameter
+while the contextual default is selected, matching the endpoint's own defaults
+(see `job-search`, "Default ordering is newest-added first"): no `sort` with
+query text yields relevance, and no `sort` without query text yields `posted_at`
+descending.
+
+A non-default selection SHALL be serialized as the value the endpoint accepts:
+`newest` as `sort=posted_at`, `match` as `sort=match`. Deserialization SHALL map
+`posted_at` back to `newest` and `match` back to `match`; an absent or
+unrecognised value SHALL resolve to the contextual default, so a hand-edited or
+shared link never leaves the control in a state it cannot render.
+
+`relevance` has nothing to rank against without query text. Resolving the
+selection SHALL therefore collapse `relevance` to `newest` whenever the query is
+empty, and this collapse SHALL be a pure function shared by the control and the
+serializer so the two cannot disagree.
+
+#### Scenario: Browsing with no query omits the sort parameter
+
+- **WHEN** the filter state carries no query text and the selection is `newest`
+- **THEN** the serialized parameters carry no `sort` key
+
+#### Scenario: A text query defaults to relevance and omits the parameter
+
+- **WHEN** the filter state carries query text and the selection is `relevance`
+- **THEN** the serialized parameters carry no `sort` key
+
+#### Scenario: Newest under a query is sent explicitly
+
+- **WHEN** the filter state carries query text and the selection is `newest`
+- **THEN** the serialized parameters carry `sort=posted_at`
+
+#### Scenario: A shared match link still resolves
+
+- **WHEN** parameters carrying `sort=match` are deserialized
+- **THEN** the selection is `match`
+
+#### Scenario: An unrecognised sort value falls back to the contextual default
+
+- **WHEN** parameters carrying `sort=bogus` and query text are deserialized
+- **THEN** the selection is `relevance`
+
+#### Scenario: Relevance collapses when the query is cleared
+
+- **WHEN** the selection is `relevance` and the query text is emptied
+- **THEN** the resolved selection is `newest` and the serialized parameters carry
+  no `sort` key
+
+### Requirement: The sort control is shown whenever it offers a choice
+
+The jobs list SHALL render its sort control whenever the control holds more than
+one option, and SHALL omit it otherwise. Option availability SHALL be:
+
+- `newest` — always available.
+- `relevance` — available only when the filter state carries query text.
+- `match` — available only under the existing precondition (an authenticated
+  caller whose loaded profile names at least one skill, and the runtime flag).
+
+A signed-out visitor searching by text therefore reaches the freshest-first
+ordering, which is the reachability gap this replaces: the control was previously
+rendered only under the `match` precondition, so the only ordering a signed-out
+visitor could ever receive under query text was relevance, unlabelled.
+
+The URL parameter SHALL be honoured regardless of whether the control is
+rendered, unchanged from today: the endpoint degrades an ordering it cannot serve
+rather than refusing it.
+
+#### Scenario: A signed-out visitor with a text query can reorder
+
+- **WHEN** a signed-out visitor searches for text
+- **THEN** the sort control is rendered offering `Relevance` and `Newest`
+
+#### Scenario: A signed-out visitor browsing sees no control
+
+- **WHEN** a signed-out visitor opens the list with no query text and no other
+  option available
+- **THEN** no sort control is rendered, and the feed is ordered freshest first
+
+#### Scenario: An eligible caller is offered the match sort
+
+- **WHEN** an authenticated caller whose profile names skills views the list with
+  the match flag enabled
+- **THEN** the sort control additionally offers `Best match`
+
+### Requirement: Freshness is selectable above the list
+
+The jobs list SHALL render a **Posted** control above the list, offering the same
+freshness stops the filter modal offers, and defaulting to no bound. Selecting a
+stop SHALL apply immediately rather than on a debounce, because a select is a
+discrete choice and not a dragged gesture.
+
+The control SHALL write to the same filter state the modal's freshness slider
+writes to, so the two, the filter summary and a saved search all read one value
+and cannot drift.
+
+#### Scenario: Choosing a stop bounds the list
+
+- **WHEN** the user selects `1 week` in the Posted control
+- **THEN** the list reloads bounded to that window and the URL carries
+  `posted_within_days=7`
+
+#### Scenario: The modal reflects a stop chosen above the list
+
+- **WHEN** the user selects a stop above the list and then opens the filter modal
+- **THEN** the modal's freshness control shows the same stop
+
+#### Scenario: Clearing the bound restores the full list
+
+- **WHEN** the user selects `Any`
+- **THEN** the URL carries no `posted_within_days` key
+
+### Requirement: Likely-evergreen postings can be hidden from the list
+
+The jobs list SHALL render a toggle above the list that excludes the
+`likely-evergreen` reality class, writing the existing
+`reality_exclude=likely-evergreen` parameter. This is the exclusion the facet was
+built for; the full three-class facet remains available in the filter modal.
+
+The toggle SHALL reflect the current filter state, including a state arriving
+from a shared link or from the modal, and releasing it SHALL clear only the
+`likely-evergreen` exclusion rather than the whole facet.
+
+#### Scenario: Engaging the toggle excludes the class
+
+- **WHEN** the user engages **Hide evergreen**
+- **THEN** the URL carries `reality_exclude=likely-evergreen` and the list
+  reloads without those postings
+
+#### Scenario: The toggle reflects a shared link
+
+- **WHEN** a link carrying `reality_exclude=likely-evergreen` is opened
+- **THEN** the toggle is rendered engaged
+
+#### Scenario: Releasing the toggle leaves other reality selections alone
+
+- **WHEN** the user has `fresh` included and `likely-evergreen` excluded, and
+  releases the toggle
+- **THEN** the `likely-evergreen` exclusion is cleared and the `fresh` inclusion
+  stands

--- a/openspec/changes/surface-freshness-and-sort-controls/specs/web-frontend/spec.md
+++ b/openspec/changes/surface-freshness-and-sort-controls/specs/web-frontend/spec.md
@@ -1,0 +1,14 @@
+## REMOVED Requirements
+
+### Requirement: Jobs browse sort control
+
+**Reason**: The requirement describes a **Date posted** / **Recently added** pair
+that the client has not offered for some time — the select's vocabulary became
+`Newest` / `Best match`, and the requirement was never revised, so it documented
+a control that does not exist. `jobs-list-controls` supersedes it with the sort
+control's actual vocabulary, its contextual default, and its visibility rule.
+
+**Migration**: None for callers. `created_at` remains an accepted, sortable
+attribute of the search endpoint (`job-search`), so any link or integration
+carrying `sort=created_at` keeps working; it is simply no longer offered as a
+choice in the browse UI.

--- a/openspec/changes/surface-freshness-and-sort-controls/specs/web-frontend/spec.md
+++ b/openspec/changes/surface-freshness-and-sort-controls/specs/web-frontend/spec.md
@@ -8,7 +8,13 @@ that the client has not offered for some time — the select's vocabulary became
 a control that does not exist. `jobs-list-controls` supersedes it with the sort
 control's actual vocabulary, its contextual default, and its visibility rule.
 
-**Migration**: None for callers. `created_at` remains an accepted, sortable
-attribute of the search endpoint (`job-search`), so any link or integration
-carrying `sort=created_at` keeps working; it is simply no longer offered as a
-choice in the browse UI.
+**Migration**: None. `created_at` remains an accepted, sortable attribute of the
+search endpoint (`job-search`), so an API integration carrying `sort=created_at`
+is unaffected.
+
+A **browse-UI link** carrying it is a different matter, and was so before this
+change: the client resolved any unrecognised `sort` — `created_at` among them —
+to its default and dropped the param on the next serialization. That is why the
+requirement being removed here was already describing a control the code did not
+have. This change does not alter that behaviour, and does not undertake to
+preserve it.

--- a/openspec/changes/surface-freshness-and-sort-controls/tasks.md
+++ b/openspec/changes/surface-freshness-and-sort-controls/tasks.md
@@ -53,17 +53,41 @@
 ## 6. The completeness guard (`filterSections.test.ts`)
 
 - [x] 6.1 Add the rail completeness test over the job `FACETS` vocabulary, modelled
-      on `companyRailGroups.test.ts`, with `seniority` and `ai_archetype` on an
-      exception list recording which pane hosts each.
+      on `companyRailGroups.test.ts`, with every facet hosted in another entry's
+      pane on an exception list recording WHICH pane hosts it (17 of them, not the
+      two this task first guessed), plus `source` recorded as a deliberate refusal.
+      A second test keeps the list honest: an excepted facet must be a declared
+      facet and must not also have a row of its own.
 - [x] 6.2 Add the two placement tests the spec names: `posted` is a `ROLE` entry,
       `reality` has an entry of its own.
 
-## 7. Verification
+## 7. Review fixes
 
-- [ ] 7.1 `pnpm test` and `pnpm check` (svelte-check) clean in `web/`.
-- [ ] 7.2 Drive the real page: signed out with a text query the select offers
-      Relevance/Newest and switching reorders; signed out with no query there is
-      no select; the Posted select and the evergreen toggle each move the URL and
-      the list; the modal shows the same freshness value; the controls render on a
-      company page.
-- [ ] 7.3 Confirm no Go, SQL, or Meilisearch settings file is touched by the diff.
+Raised by code review against the first implementation; each is covered by a test
+that fails without the fix.
+
+- [x] 7.1 Model the stored ordering as `JobSort | null` ("chosen" vs "not chosen")
+      so typing a query cannot carry `sort=posted_at` into a text search, and a
+      typed query still serializes equal to the saved search it came from.
+- [x] 7.2 Move the option-availability rule out of `JobsView.svelte` into pure
+      `sortOptionsFor` / `selectedSortFor`, and have the control name the ordering
+      the endpoint will actually serve when the resolved one is not on offer (a
+      signed-out `?sort=match` link rendered the select blank).
+- [x] 7.3 Offer an off-preset freshness bound as a stop of its own
+      (`freshnessOptions`), so a `posted_within_days` from a shared link or the AI
+      dialog cannot leave the select blank over a live bound.
+- [x] 7.4 Fix the mobile row: measured 49px of overflow at 390px, so the evergreen
+      toggle drops its word below `sm` and the toolbar row wraps.
+
+## 8. Verification
+
+- [x] 8.1 `pnpm test` and `pnpm check` (svelte-check) clean in `web/`, and
+      `pnpm lint` adds no new warning.
+- [x] 8.2 Drive the real page against the live API: signed out with a text query
+      the select offers Relevance/Newest; signed out with no query there is no
+      select; `?q=go&sort=posted_at` preselects Newest; `?q=go&sort=match` signed
+      out shows Relevance rather than a blank control; `?posted_within_days=7`
+      preselects `1 week` and `=5` offers `Last 5 days` in day order;
+      `?reality_exclude=likely-evergreen` renders the toggle pressed; the controls
+      render on a company page; the row fits a 390px viewport (measured).
+- [x] 8.3 Confirm no Go, SQL, or Meilisearch settings file is touched by the diff.

--- a/openspec/changes/surface-freshness-and-sort-controls/tasks.md
+++ b/openspec/changes/surface-freshness-and-sort-controls/tasks.md
@@ -1,0 +1,69 @@
+## 1. The sort model (pure, `facetModel.ts`)
+
+- [x] 1.1 Extend `JobSort` to `'relevance' | 'newest' | 'match'` and replace the
+      `DEFAULT_JOB_SORT` constant with `defaultSortFor(q)` returning `relevance`
+      under query text and `newest` without. Update the doc comment on
+      `JobFilters.sort`, which currently states there are only two values.
+- [x] 1.2 Add the exported pure resolver that collapses `relevance` to `newest`
+      when the query is empty, and route both `filtersToParams` and the control's
+      value through it.
+- [x] 1.3 Teach `filtersToParams` the wire mapping: omit `sort` at the contextual
+      default, emit `sort=posted_at` for a non-default `newest`, `sort=match` for
+      `match`.
+- [x] 1.4 Teach `filtersFromParams` the reverse: `posted_at` → `newest`, `match` →
+      `match`, absent or unrecognised → `defaultSortFor(q)`.
+- [x] 1.5 Confirm `emptyFilters()` and every other `DEFAULT_JOB_SORT` reader still
+      compile and mean the same thing (`svelte-check`).
+
+## 2. The freshness setter (`filters.ts`)
+
+- [x] 2.1 Add a `setNow`-based freshness setter beside the existing `setSoon` one,
+      documenting why the two differ (discrete select vs dragged slider), and
+      mirror it in `stagedFilters.svelte.ts` if the staged store needs it.
+
+## 3. The toolbar slot (`ListToolbar.svelte`, `CompaniesView.svelte`)
+
+- [x] 3.1 Rename the `sortControl` prop to `controls` and update its comment to
+      say the slot carries however many controls the view passes.
+- [x] 3.2 Change the desktop row's condition so the total stays gated on
+      `showDesktopTotal` while the controls render whenever they are passed.
+- [x] 3.3 Update the `CompaniesView` call site.
+
+## 4. The three controls (`JobsView.svelte`)
+
+- [x] 4.1 Replace `sortControlVisible` with per-option availability: `newest`
+      always, `relevance` under query text, `match` under the existing
+      `matchFilterAvailable && matchSortEnabled(env)` gate. Render the select only
+      when more than one option is available.
+- [x] 4.2 Add the Posted select over `FRESHNESS_PRESETS`, writing through the new
+      `setNow` freshness setter.
+- [x] 4.3 Add the Hide-evergreen toggle writing `likely-evergreen` into the
+      `reality` facet's exclude set, reflecting current state, and clearing only
+      that exclusion when released.
+- [x] 4.4 Pass all three through the renamed `controls` slot and check the row on
+      a narrow viewport.
+
+## 5. The modal rail (`filterSections.ts`)
+
+- [x] 5.1 Move the `posted` entry into the `ROLE` section, immediately after
+      `experience`.
+- [x] 5.2 Add the `reality` entry (`kind: 'facet'`, `facetParam: 'reality'`,
+      label `Posting reality`) after `posted`.
+
+## 6. The completeness guard (`filterSections.test.ts`)
+
+- [x] 6.1 Add the rail completeness test over the job `FACETS` vocabulary, modelled
+      on `companyRailGroups.test.ts`, with `seniority` and `ai_archetype` on an
+      exception list recording which pane hosts each.
+- [x] 6.2 Add the two placement tests the spec names: `posted` is a `ROLE` entry,
+      `reality` has an entry of its own.
+
+## 7. Verification
+
+- [ ] 7.1 `pnpm test` and `pnpm check` (svelte-check) clean in `web/`.
+- [ ] 7.2 Drive the real page: signed out with a text query the select offers
+      Relevance/Newest and switching reorders; signed out with no query there is
+      no select; the Posted select and the evergreen toggle each move the URL and
+      the list; the modal shows the same freshness value; the controls render on a
+      company page.
+- [ ] 7.3 Confirm no Go, SQL, or Meilisearch settings file is touched by the diff.

--- a/web/src/lib/components/CompaniesView.svelte
+++ b/web/src/lib/components/CompaniesView.svelte
@@ -162,7 +162,7 @@
     <ListToolbar
       total={companies.status === 'ready' && companies.items.length > 0 ? companies.total : null}
       unit={companies.total === 1 ? 'company' : 'companies'}
-      sortControl={sortSelect}
+      controls={sortSelect}
     />
     {#if companies.status === 'loading'}
       <States state="loading" />

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, untrack, type Snippet } from 'svelte';
-  import { Layers } from '@lucide/svelte';
+  import { EyeOff, Layers } from '@lucide/svelte';
   import { browser } from '$app/environment';
   import { afterNavigate, goto, replaceState } from '$app/navigation';
   import { resolve } from '$app/paths';
@@ -21,13 +21,14 @@
   import {
     FilterStore,
     filtersToParams,
-    effectiveSort,
+    selectedSortFor,
     signOf,
+    sortOptionsFor,
     type JobSort,
     activeFilterCount,
     generalCountsCoverRole,
   } from '$lib/filters';
-  import { FRESHNESS_PRESETS, freshnessLabel } from '$lib/filterControls';
+  import { freshnessOptions } from '$lib/filterControls';
   import { geoScopeOffered, loadJobFilters, markGeoScopeOffered } from '$lib/filterStorage';
   import { geoScopeQuery, shouldOfferGeoScope, WORLDWIDE_REGION } from '$lib/geoScope';
   import {
@@ -242,18 +243,10 @@
   // gets verified on production before anyone can click it.
   const matchSortAvailable = $derived(matchFilterAvailable && matchSortEnabled(env));
 
-  // The orderings this caller can actually choose between, in display order.
-  //
-  // `relevance` needs query text to rank against; `match` needs the profile and the
-  // flag above; `newest` always applies. This gate is per OPTION, not per control —
-  // gating the whole select on the match precondition (as it was) took `newest` down
-  // with it, so a signed-out visitor searching by text had no way to reach the
-  // freshest-first ordering the endpoint has always served.
-  const sortOptions: { value: JobSort; label: string }[] = $derived([
-    ...(filters.value.q ? [{ value: 'relevance' as JobSort, label: 'Relevance' }] : []),
-    { value: 'newest', label: 'Newest' },
-    ...(matchSortAvailable ? [{ value: 'match' as JobSort, label: 'Best match' }] : []),
-  ]);
+  // The orderings this caller can choose between, and which one the control shows —
+  // both pure, both in facetModel so they can be tested (see sortOptionsFor).
+  const sortOptions = $derived(sortOptionsFor(filters.value.q, matchSortAvailable));
+  const selectedSort = $derived(selectedSortFor(filters.value, matchSortAvailable));
   // A one-option select is a label wearing a control's clothes: there is nothing to
   // choose, and the feed already IS that ordering.
   const sortSelectVisible = $derived(sortOptions.length > 1);
@@ -739,7 +732,7 @@
     <select
       aria-label="Sort jobs"
       class="rounded-lg border border-input bg-transparent py-2 pl-2 pr-1 text-sm text-foreground transition-colors focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 md:py-1 dark:bg-input/30"
-      value={effectiveSort(filters.value)}
+      value={selectedSort}
       onchange={(e) => filters.setSort(e.currentTarget.value as JobSort)}
     >
       {#each sortOptions as opt (opt.value)}
@@ -761,26 +754,32 @@
       value={String(filters.value.postedWithinDays ?? '')}
       onchange={(e) => filters.pickPostedWithinDays(Number(e.currentTarget.value) || null)}
     >
-      {#each FRESHNESS_PRESETS as preset (preset.label)}
-        <option value={String(preset.days ?? '')}>{freshnessLabel(preset.days)}</option>
+      {#each freshnessOptions(filters.value.postedWithinDays) as preset (preset.label)}
+        <option value={String(preset.days ?? '')}>{preset.label}</option>
       {/each}
     </select>
   </label>
 {/snippet}
 
 <!-- One-click access to the reality facet's common exclusion. `aria-pressed` rather than
-     a checkbox because it reads as a filter chip, matching the pills it mirrors. -->
+     a checkbox because it reads as a filter chip, matching the pills it mirrors.
+
+     The word is dropped below `sm` and the icon carries it, exactly as the Swipe entry
+     beside it already does: measured at 390px the four controls plus the count ran 49px
+     past the viewport, and this button was the widest of them. -->
 {#snippet evergreenToggle()}
   <button
     type="button"
     aria-pressed={evergreenHidden}
+    aria-label="Hide evergreen postings"
     title="Hide postings that look permanently open"
     onclick={() => filters.setSign('reality', 'likely-evergreen', evergreenHidden ? 'off' : 'exclude')}
-    class="shrink-0 whitespace-nowrap rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors md:py-1 {evergreenHidden
+    class="inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors md:py-1 {evergreenHidden
       ? 'border-primary bg-primary text-primary-foreground'
       : 'border-border bg-card hover:bg-accent'}"
   >
-    Hide evergreen
+    <EyeOff class="size-4 shrink-0" />
+    <span class="hidden sm:inline">Hide evergreen</span>
   </button>
 {/snippet}
 

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -21,10 +21,13 @@
   import {
     FilterStore,
     filtersToParams,
+    effectiveSort,
+    signOf,
     type JobSort,
     activeFilterCount,
     generalCountsCoverRole,
   } from '$lib/filters';
+  import { FRESHNESS_PRESETS, freshnessLabel } from '$lib/filterControls';
   import { geoScopeOffered, loadJobFilters, markGeoScopeOffered } from '$lib/filterStorage';
   import { geoScopeQuery, shouldOfferGeoScope, WORLDWIDE_REGION } from '$lib/geoScope';
   import {
@@ -232,12 +235,34 @@
   // runtime flag. It ships dark: the API accepts ?sort=match as soon as the binary is
   // out, but it ranks against skill vectors that only exist once a full index rebuild
   // has written them — before that the sort returns a near-empty feed, which reads as
-  // broken rather than new. The flag is what reveals the control once the rebuild has
+  // broken rather than new. The flag is what reveals the option once the rebuild has
   // landed, and flipping it is an env change plus a restart, not a redeploy.
   //
   // The URL param stays honoured either way, which is deliberate: it is how the sort
   // gets verified on production before anyone can click it.
-  const sortControlVisible = $derived(matchFilterAvailable && matchSortEnabled(env));
+  const matchSortAvailable = $derived(matchFilterAvailable && matchSortEnabled(env));
+
+  // The orderings this caller can actually choose between, in display order.
+  //
+  // `relevance` needs query text to rank against; `match` needs the profile and the
+  // flag above; `newest` always applies. This gate is per OPTION, not per control —
+  // gating the whole select on the match precondition (as it was) took `newest` down
+  // with it, so a signed-out visitor searching by text had no way to reach the
+  // freshest-first ordering the endpoint has always served.
+  const sortOptions: { value: JobSort; label: string }[] = $derived([
+    ...(filters.value.q ? [{ value: 'relevance' as JobSort, label: 'Relevance' }] : []),
+    { value: 'newest', label: 'Newest' },
+    ...(matchSortAvailable ? [{ value: 'match' as JobSort, label: 'Best match' }] : []),
+  ]);
+  // A one-option select is a label wearing a control's clothes: there is nothing to
+  // choose, and the feed already IS that ordering.
+  const sortSelectVisible = $derived(sortOptions.length > 1);
+
+  // `likely-evergreen` is the reality class the facet exists to exclude (see REALITY in
+  // $lib/facets), so the toggle above the list writes exactly that one sign. The full
+  // three-class facet stays in the modal for the rarer selections, and releasing this
+  // clears only this value — an `include` on another class is not ours to drop.
+  const evergreenHidden = $derived(signOf(filters.facet('reality'), 'likely-evergreen') === 'exclude');
 
   let modalOpen = $state(false);
   let started = false;
@@ -699,26 +724,72 @@
   }
 </script>
 
-<!-- The feed's ordering control, handed to ListToolbar so it sits in the shared
-     toolbar (mobile) / above the list (desktop) — same shape as the company catalog's
-     sortSelect. Rendered only under `matchFilterAvailable`: "Best match" needs profile
-     skills to rank against, and an option that silently does nothing is worse than an
-     absent one. The URL param is NOT cleared when it disappears — the server degrades
-     the ordering for a caller it cannot serve, so a shared match link stays intact and
-     starts working the moment its opener signs in. -->
+<!-- The list's own controls, handed to ListToolbar so they sit in the shared toolbar
+     (mobile) / above the list (desktop) — same shape as the company catalog's
+     sortSelect. Each is reachable without opening the filter modal, which is the whole
+     point: the endpoint has always served these orderings and bounds, and every one of
+     them used to require either a profile, a modal, or a hand-edited URL.
+
+     The URL params are NOT cleared when a control disappears — the server degrades an
+     ordering it cannot serve rather than refusing it, so a shared match link stays
+     intact and starts working the moment its opener signs in. -->
 {#snippet sortSelect()}
   <label class="flex shrink-0 items-center gap-1.5 text-sm text-muted-foreground">
     <span class="hidden sm:inline">Sort</span>
     <select
       aria-label="Sort jobs"
       class="rounded-lg border border-input bg-transparent py-2 pl-2 pr-1 text-sm text-foreground transition-colors focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 md:py-1 dark:bg-input/30"
-      value={filters.value.sort}
+      value={effectiveSort(filters.value)}
       onchange={(e) => filters.setSort(e.currentTarget.value as JobSort)}
     >
-      <option value="newest">Newest</option>
-      <option value="match">Best match</option>
+      {#each sortOptions as opt (opt.value)}
+        <option value={opt.value}>{opt.label}</option>
+      {/each}
     </select>
   </label>
+{/snippet}
+
+<!-- The freshness bound, the same one the modal's slider drags. This is the control the
+     complaint that prompted it asked for: years-old postings in the feed, with the only
+     way to bound them buried in the modal's third section. -->
+{#snippet postedSelect()}
+  <label class="flex shrink-0 items-center gap-1.5 text-sm text-muted-foreground">
+    <span class="hidden sm:inline">Posted</span>
+    <select
+      aria-label="Posted within"
+      class="rounded-lg border border-input bg-transparent py-2 pl-2 pr-1 text-sm text-foreground transition-colors focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 md:py-1 dark:bg-input/30"
+      value={String(filters.value.postedWithinDays ?? '')}
+      onchange={(e) => filters.pickPostedWithinDays(Number(e.currentTarget.value) || null)}
+    >
+      {#each FRESHNESS_PRESETS as preset (preset.label)}
+        <option value={String(preset.days ?? '')}>{freshnessLabel(preset.days)}</option>
+      {/each}
+    </select>
+  </label>
+{/snippet}
+
+<!-- One-click access to the reality facet's common exclusion. `aria-pressed` rather than
+     a checkbox because it reads as a filter chip, matching the pills it mirrors. -->
+{#snippet evergreenToggle()}
+  <button
+    type="button"
+    aria-pressed={evergreenHidden}
+    title="Hide postings that look permanently open"
+    onclick={() => filters.setSign('reality', 'likely-evergreen', evergreenHidden ? 'off' : 'exclude')}
+    class="shrink-0 whitespace-nowrap rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors md:py-1 {evergreenHidden
+      ? 'border-primary bg-primary text-primary-foreground'
+      : 'border-border bg-card hover:bg-accent'}"
+  >
+    Hide evergreen
+  </button>
+{/snippet}
+
+<!-- The three above, in one slot. Rendered as a fragment so ListToolbar keeps deciding
+     where the row sits and how it collapses on a phone. -->
+{#snippet listControls()}
+  {@render evergreenToggle()}
+  {@render postedSelect()}
+  {#if sortSelectVisible}{@render sortSelect()}{/if}
 {/snippet}
 
 <div class="flex gap-6">
@@ -750,7 +821,7 @@
       unit={listTotal === 1 ? 'job' : 'jobs'}
       onSwipe={standalone ? openSwipe : undefined}
       showDesktopTotal={standalone}
-      sortControl={sortControlVisible ? sortSelect : undefined}
+      controls={listControls}
     />
 
     <!-- Onboarding nudges sit UNDER the toolbar so the feed controls stay at the top;

--- a/web/src/lib/components/ListToolbar.svelte
+++ b/web/src/lib/components/ListToolbar.svelte
@@ -37,8 +37,13 @@
 
 <!-- Mobile inline toolbar: total on the left, controls on the right. The Swipe entry is
      icon-only here (labelled for a11y) so the row stays on one line with the count and the
-     sort control; the word would crowd it out on a narrow phone. -->
-<div class="mb-3 flex items-center gap-2 md:hidden">
+     list controls; the word would crowd it out on a narrow phone — and the jobs list's
+     evergreen toggle drops its word for the same reason.
+
+     `flex-wrap` is the safety net under that: the controls are sized by their content
+     (a long count, a translated label, a fourth control) and a row that runs out of width
+     must break onto a second line rather than clip its rightmost control off-screen. -->
+<div class="mb-3 flex flex-wrap items-center gap-2 md:hidden">
   {#if total !== null}
     <span class="shrink-0 whitespace-nowrap text-sm text-muted-foreground" aria-live="polite">
       <span class="font-semibold tabular-nums text-foreground">{total.toLocaleString()}</span>

--- a/web/src/lib/components/ListToolbar.svelte
+++ b/web/src/lib/components/ListToolbar.svelte
@@ -50,7 +50,12 @@
       {unit}
     </span>
   {/if}
-  <div class="ml-auto flex items-center gap-2">
+  <!-- Wraps too, not just the outer row. Without this the controls are one indivisible
+       block: the row can drop the whole block to a second line but the block itself
+       still overflows, so a longer control (a translated select value, a fourth entry)
+       clips exactly as before. `justify-end` keeps a wrapped line right-aligned under
+       the `ml-auto`. -->
+  <div class="ml-auto flex flex-wrap items-center justify-end gap-2">
     {@render controls?.()}
     {#if onSwipe}
       <button

--- a/web/src/lib/components/ListToolbar.svelte
+++ b/web/src/lib/components/ListToolbar.svelte
@@ -15,21 +15,23 @@
   // where a swipe deck exists (the standalone jobs list). `showDesktopTotal` is false when
   // the desktop layout already surfaces the total elsewhere (the company page's sidebar
   // stat), so the above-list line isn't shown twice; the mobile toolbar total is unaffected.
-  // `sortControl` is an optional leading control (the jobs feed's sort selector) rendered
-  // in the mobile toolbar and beside the desktop total; it shows even when `total` is null
-  // so the control stays reachable while the list is empty or standing in a prompt.
+  // `controls` is an optional slot for the list's own controls — however many the view
+  // passes (the jobs feed's sort select, freshness select and evergreen toggle; the
+  // company catalog's sort select) — rendered in the mobile toolbar and beside the
+  // desktop total. It shows even when `total` is null so the controls stay reachable
+  // while the list is empty or standing in a prompt.
   let {
     total,
     unit,
     onSwipe,
     showDesktopTotal = true,
-    sortControl,
+    controls,
   }: {
     total: number | null;
     unit: string;
     onSwipe?: () => void;
     showDesktopTotal?: boolean;
-    sortControl?: Snippet;
+    controls?: Snippet;
   } = $props();
 </script>
 
@@ -44,7 +46,7 @@
     </span>
   {/if}
   <div class="ml-auto flex items-center gap-2">
-    {@render sortControl?.()}
+    {@render controls?.()}
     {#if onSwipe}
       <button
         type="button"
@@ -59,17 +61,19 @@
   </div>
 </div>
 
-<!-- Desktop: the total (and any sort control) sit top-right above the list (filters
-     live in the sidebar). Renders when there's a total OR a sort control to show, so
-     the control stays visible on an empty/prompt list where the total is null. -->
-{#if showDesktopTotal && (total !== null || sortControl)}
+<!-- Desktop: the total (and any list controls) sit top-right above the list (filters
+     live in the sidebar). The two are gated INDEPENDENTLY: the total on `showDesktopTotal`
+     (a view that renders its own total elsewhere suppresses this one), the controls on
+     their own presence. Gating both on `showDesktopTotal` is what hid the controls
+     entirely on a company page, where the sidebar carries the count. -->
+{#if (showDesktopTotal && total !== null) || controls}
   <div class="mb-3 hidden items-center justify-end gap-3 md:flex">
-    {#if total !== null}
+    {#if showDesktopTotal && total !== null}
       <span class="text-sm text-muted-foreground" aria-live="polite">
         <span class="font-semibold tabular-nums text-foreground">{total.toLocaleString()}</span>
         {unit}
       </span>
     {/if}
-    {@render sortControl?.()}
+    {@render controls?.()}
   </div>
 {/if}

--- a/web/src/lib/facetModel.test.ts
+++ b/web/src/lib/facetModel.test.ts
@@ -18,14 +18,17 @@ import {
   filtersWithRole,
   defaultSortFor,
   effectiveSort,
+  sortOptionsFor,
+  selectedSortFor,
   type FacetState,
   type JobFilters,
   type JobSort,
 } from './facetModel';
 import { must } from './utils';
 
-// A JobFilters carrying a query and an ordering — the pair the sort default depends on.
-function withQuery(q: string, sort: JobSort): JobFilters {
+// A JobFilters carrying a query and an EXPLICITLY chosen ordering — the pair the sort
+// default depends on. Pass `null` for "the caller has not chosen one".
+function withQuery(q: string, sort: JobSort | null): JobFilters {
   return { ...emptyFilters(), q, sort };
 }
 
@@ -270,16 +273,19 @@ describe('sort', () => {
     expect(filtersFromParams(new URLSearchParams('sort=cv'))).toEqual(filtersFromParams(new URLSearchParams('')));
   });
 
-  it('reads an unknown sort value as the contextual default', () => {
-    expect(filtersFromParams(new URLSearchParams('sort=bogus')).sort).toBe('newest');
-    expect(filtersFromParams(new URLSearchParams('q=go&sort=bogus')).sort).toBe('relevance');
+  // An unrecognised value is not a choice, so it parses to `null` — "unchosen" — and
+  // resolves through the contextual default like any other link that names no ordering.
+  it('reads an unknown sort value as no choice at all', () => {
+    expect(filtersFromParams(new URLSearchParams('sort=bogus')).sort).toBeNull();
+    expect(effectiveSort(filtersFromParams(new URLSearchParams('sort=bogus')))).toBe('newest');
+    expect(effectiveSort(filtersFromParams(new URLSearchParams('q=go&sort=bogus')))).toBe('relevance');
   });
 
   it('defaults to newest while browsing and to relevance under a query', () => {
     expect(defaultSortFor('')).toBe('newest');
     expect(defaultSortFor('go')).toBe('relevance');
-    expect(filtersFromParams(new URLSearchParams('')).sort).toBe('newest');
-    expect(filtersFromParams(new URLSearchParams('q=go')).sort).toBe('relevance');
+    expect(effectiveSort(filtersFromParams(new URLSearchParams('')))).toBe('newest');
+    expect(effectiveSort(filtersFromParams(new URLSearchParams('q=go')))).toBe('relevance');
   });
 
   it('writes nothing for either contextual default', () => {
@@ -324,6 +330,65 @@ describe('sort', () => {
 
   it('serializes a stranded relevance selection as the browse default', () => {
     expect(filtersToParams(withQuery('', 'relevance')).get('sort')).toBeNull();
+  });
+
+  // The bug the review caught: storing the RESOLVED default made "the browse feed
+  // defaulted to newest" look identical to "the caller asked for newest", so typing
+  // into the search box carried sort=posted_at into a text search and date-ordered it.
+  // An unchosen ordering is null, and null follows the query.
+  it('does not pin an unchosen ordering when a query is typed', () => {
+    const browsing = filtersFromParams(new URLSearchParams(''));
+    expect(browsing.sort).toBeNull();
+    expect(effectiveSort(browsing)).toBe('newest');
+
+    const searching = { ...browsing, q: 'golang' };
+    expect(effectiveSort(searching)).toBe('relevance');
+    expect(filtersToParams(searching).get('sort')).toBeNull();
+  });
+
+  // Why that matters beyond the ordering: savedSearchQuery is filtersToParams(...),
+  // so a spurious sort param makes the live filters compare unequal to the saved
+  // search they came from — which reads as "dirty" and creates a duplicate on save.
+  it('keeps a typed query comparing equal to the saved search it came from', () => {
+    const saved = savedSearchQuery(filtersFromParams(new URLSearchParams('q=go')));
+    const typed = savedSearchQuery({ ...filtersFromParams(new URLSearchParams('')), q: 'go' });
+
+    expect(typed).toBe(saved);
+  });
+
+  it('still sends an explicitly chosen newest under a query', () => {
+    expect(filtersToParams(withQuery('go', 'newest')).get('sort')).toBe('posted_at');
+  });
+});
+
+// The option list is the sort control's visibility rule, kept pure and out of the
+// component so it can be tested at all — the same argument that put effectiveSort here.
+describe('sort options', () => {
+  it('offers relevance only under a query, and match only when it can be served', () => {
+    expect(sortOptionsFor('', false).map((o) => o.value)).toEqual(['newest']);
+    expect(sortOptionsFor('go', false).map((o) => o.value)).toEqual(['relevance', 'newest']);
+    expect(sortOptionsFor('', true).map((o) => o.value)).toEqual(['newest', 'match']);
+    expect(sortOptionsFor('go', true).map((o) => o.value)).toEqual(['relevance', 'newest', 'match']);
+  });
+
+  // A shared ?sort=match link opened signed out: the param survives (the server degrades
+  // the ordering rather than refusing it), but the control cannot show an option it does
+  // not offer. It shows what the server will actually serve — a select with nothing
+  // selected would be a blank control over a real ordering.
+  it('shows what the server will serve when the chosen ordering cannot be offered', () => {
+    expect(selectedSortFor(withQuery('go', 'match'), false)).toBe('relevance');
+    expect(selectedSortFor(withQuery('', 'match'), false)).toBe('newest');
+    expect(selectedSortFor(withQuery('go', 'match'), true)).toBe('match');
+  });
+
+  it('always names an option that exists', () => {
+    for (const q of ['', 'go']) {
+      for (const matchAvailable of [false, true]) {
+        const f = withQuery(q, 'match');
+        const values = sortOptionsFor(q, matchAvailable).map((o) => o.value);
+        expect(values).toContain(selectedSortFor(f, matchAvailable));
+      }
+    }
   });
 });
 

--- a/web/src/lib/facetModel.test.ts
+++ b/web/src/lib/facetModel.test.ts
@@ -16,11 +16,18 @@ import {
   facetAdd,
   facetRemove,
   filtersWithRole,
-  DEFAULT_JOB_SORT,
+  defaultSortFor,
+  effectiveSort,
   type FacetState,
   type JobFilters,
+  type JobSort,
 } from './facetModel';
 import { must } from './utils';
+
+// A JobFilters carrying a query and an ordering — the pair the sort default depends on.
+function withQuery(q: string, sort: JobSort): JobFilters {
+  return { ...emptyFilters(), q, sort };
+}
 
 // A JobFilters seeded with one facet's state, for serialization tests.
 function withSkills(st: Partial<FacetState>): JobFilters {
@@ -251,17 +258,42 @@ describe('sign transitions (pure)', () => {
   });
 });
 
-// `sort` came back for the profile-match feed, but only as a two-value vocabulary:
-// the default freshest-first ordering and `match`. Every other value — including the
-// retired `sort=cv` — reads as the default rather than erroring, because shared links
-// and saved searches still carry old ones.
+// The sort vocabulary is `relevance` / `newest` / `match`, and its DEFAULT depends on
+// whether there is query text — mirroring the endpoint, which orders by relevance under
+// a query and by posting date without one (internal/api/handler/search.go). Serializing
+// the default therefore means writing nothing: the absence of `sort` is exactly how the
+// backend already spells both defaults. Every unrecognised value — including the retired
+// `sort=cv` — reads as that default rather than erroring, because shared links and saved
+// searches still carry old ones.
 describe('sort', () => {
   it('ignores a legacy sort=cv param — falls back to the default feed, not an error', () => {
     expect(filtersFromParams(new URLSearchParams('sort=cv'))).toEqual(filtersFromParams(new URLSearchParams('')));
   });
 
-  it('ignores an unknown sort value', () => {
-    expect(filtersFromParams(new URLSearchParams('sort=bogus')).sort).toBe(DEFAULT_JOB_SORT);
+  it('reads an unknown sort value as the contextual default', () => {
+    expect(filtersFromParams(new URLSearchParams('sort=bogus')).sort).toBe('newest');
+    expect(filtersFromParams(new URLSearchParams('q=go&sort=bogus')).sort).toBe('relevance');
+  });
+
+  it('defaults to newest while browsing and to relevance under a query', () => {
+    expect(defaultSortFor('')).toBe('newest');
+    expect(defaultSortFor('go')).toBe('relevance');
+    expect(filtersFromParams(new URLSearchParams('')).sort).toBe('newest');
+    expect(filtersFromParams(new URLSearchParams('q=go')).sort).toBe('relevance');
+  });
+
+  it('writes nothing for either contextual default', () => {
+    expect(filtersToParams(emptyFilters()).get('sort')).toBeNull();
+    expect(filtersToParams(withQuery('go', 'relevance')).get('sort')).toBeNull();
+    expect(new URLSearchParams(savedSearchQuery(withSkills({ include: ['go'] }))).get('sort')).toBeNull();
+  });
+
+  // The bug this replaces: `newest` was the unconditional default, so it was never
+  // serialized, so a text search carried no `sort` and the server ranked by relevance
+  // while the control still read "Newest".
+  it('sends newest explicitly once it stops being the default', () => {
+    expect(filtersToParams(withQuery('go', 'newest')).get('sort')).toBe('posted_at');
+    expect(filtersFromParams(new URLSearchParams('q=go&sort=posted_at')).sort).toBe('newest');
   });
 
   it('round-trips the match sort', () => {
@@ -282,9 +314,16 @@ describe('sort', () => {
     expect(filtersToParams(f).get('sort')).toBe('match');
   });
 
-  it('never serializes the default sort', () => {
-    expect(filtersToParams(emptyFilters()).get('sort')).toBeNull();
-    expect(new URLSearchParams(savedSearchQuery(withSkills({ include: ['go'] }))).get('sort')).toBeNull();
+  // Relevance has nothing to rank against once the query goes. The collapse is a pure
+  // function rather than an effect so the control and the serializer read one rule.
+  it('collapses relevance to newest when the query is empty', () => {
+    expect(effectiveSort(withQuery('', 'relevance'))).toBe('newest');
+    expect(effectiveSort(withQuery('go', 'relevance'))).toBe('relevance');
+    expect(effectiveSort(withQuery('', 'match'))).toBe('match');
+  });
+
+  it('serializes a stranded relevance selection as the browse default', () => {
+    expect(filtersToParams(withQuery('', 'relevance')).get('sort')).toBeNull();
   });
 });
 

--- a/web/src/lib/facetModel.ts
+++ b/web/src/lib/facetModel.ts
@@ -49,13 +49,20 @@ export interface JobFilters {
    *  `0` is a real bound — the jobs stating no prior experience is required — so
    *  every read of this field must test for null, never for falsiness. */
   experienceYearsMax: number | null;
-  /** Feed ordering. `relevance` is the engine's own ranking, `newest` is freshest
-   *  first, `match` ranks by how well a vacancy's skills overlap the signed-in
-   *  caller's profile. Which of the first two is the DEFAULT depends on `q` — see
-   *  defaultSortFor. The server degrades `match` to its default for anyone it cannot
-   *  serve it to — anonymous, no profile, no skills — so this is never gated
-   *  client-side beyond hiding the option. */
-  sort: JobSort;
+  /** Feed ordering, or `null` for "the caller has not chosen one".
+   *
+   *  `relevance` is the engine's own ranking, `newest` is freshest first, `match` ranks
+   *  by how well a vacancy's skills overlap the signed-in caller's profile. The server
+   *  degrades `match` to its default for anyone it cannot serve it to — anonymous, no
+   *  profile, no skills — so this is never gated client-side beyond hiding the option.
+   *
+   *  The `null` matters because the DEFAULT depends on `q` (see defaultSortFor) while
+   *  `q` changes under the ordering's feet. Storing the resolved default instead would
+   *  make "the browse feed defaulted to newest" indistinguishable from "the caller
+   *  asked for newest", so typing into the search box would carry `sort=posted_at`
+   *  into a text search and date-order it — the exact outcome design.md rejects. Read
+   *  this through effectiveSort, never directly. */
+  sort: JobSort | null;
 }
 
 /** The feed's ordering vocabulary. Deliberately short: this is not a general sort
@@ -74,12 +81,14 @@ export function defaultSortFor(q: string): JobSort {
 
 /** The ordering a filter set actually resolves to.
  *
- *  `relevance` has nothing to rank against once the query is cleared, so it collapses
- *  to the browse default. This is a pure function, not an effect that rewrites the
- *  stored value, because BOTH the sort control and filtersToParams need the answer
+ *  An unchosen ordering resolves to the contextual default, and an explicit
+ *  `relevance` collapses to the browse default once the query is cleared — it has
+ *  nothing left to rank against. This is a pure function, not an effect that rewrites
+ *  the stored value, because BOTH the sort control and filtersToParams need the answer
  *  and a second copy of the rule is a second answer. */
 export function effectiveSort(f: JobFilters): JobSort {
-  return f.sort === 'relevance' && !f.q ? 'newest' : f.sort;
+  const sort = f.sort ?? defaultSortFor(f.q);
+  return sort === 'relevance' && !f.q ? 'newest' : sort;
 }
 
 /** The `sort` values the search endpoint accepts, keyed by our vocabulary. `relevance`
@@ -92,6 +101,46 @@ const SORT_PARAM: Partial<Record<JobSort, string>> = { newest: 'posted_at', matc
 const SORT_FROM_PARAM: Record<string, JobSort> = Object.fromEntries(
   Object.entries(SORT_PARAM).map(([sort, param]) => [param, sort as JobSort]),
 );
+
+const SORT_LABEL: Record<JobSort, string> = {
+  relevance: 'Relevance',
+  newest: 'Newest',
+  match: 'Best match',
+};
+
+export interface SortOption {
+  value: JobSort;
+  label: string;
+}
+
+/** The orderings a caller can actually choose between, in display order.
+ *
+ *  `relevance` needs query text to rank against and `match` needs a profile the caller
+ *  has (plus the runtime flag the view resolves); `newest` always applies. The rule is
+ *  per OPTION rather than per control — gating the whole select on the match
+ *  precondition, as it was, took `newest` down with it, so a signed-out visitor
+ *  searching by text had no way to reach the freshest-first ordering.
+ *
+ *  It lives here, not in the view, for the reason effectiveSort does: it is pure, it
+ *  decides what the user sees, and in the component nothing could test it. */
+export function sortOptionsFor(q: string, matchAvailable: boolean): SortOption[] {
+  const values: JobSort[] = [...(q ? (['relevance'] as const) : []), 'newest', ...(matchAvailable ? (['match'] as const) : [])];
+  return values.map((value) => ({ value, label: SORT_LABEL[value] }));
+}
+
+/** The option the control shows as selected.
+ *
+ *  Normally the effective ordering — but a shared `?sort=match` link opened by someone
+ *  it cannot be served to resolves to an ordering that is not on offer. The param stays
+ *  (the server degrades it rather than refusing, and signing in should just work), so
+ *  the control instead names what the server will ACTUALLY serve that caller. A select
+ *  whose value matches no option renders blank, which would put an empty control over a
+ *  live ordering. */
+export function selectedSortFor(f: JobFilters, matchAvailable: boolean): JobSort {
+  const sort = effectiveSort(f);
+  const offered = sortOptionsFor(f.q, matchAvailable);
+  return offered.some((o) => o.value === sort) ? sort : defaultSortFor(f.q);
+}
 
 /** Splits every raw query value on comma and flattens the result, dropping
  *  empty fragments (a stray comma) — so a repeated key (`skills=go&skills=react`)
@@ -120,7 +169,7 @@ export function emptyFilters(): JobFilters {
     salaryMin: null,
     postedWithinDays: null,
     experienceYearsMax: null,
-    sort: defaultSortFor(''),
+    sort: null,
   };
 }
 
@@ -213,7 +262,7 @@ export function filtersFromParams(p: URLSearchParams): JobFilters {
   // rule the backend applies (ignore, never refuse) has to hold here or the two would
   // disagree about what a stale link means. Reads `f.q`, so it must follow the line
   // that sets it.
-  f.sort = SORT_FROM_PARAM[p.get('sort') ?? ''] ?? defaultSortFor(f.q);
+  f.sort = SORT_FROM_PARAM[p.get('sort') ?? ''] ?? null;
   return f;
 }
 

--- a/web/src/lib/facetModel.ts
+++ b/web/src/lib/facetModel.ts
@@ -49,20 +49,49 @@ export interface JobFilters {
    *  `0` is a real bound — the jobs stating no prior experience is required — so
    *  every read of this field must test for null, never for falsiness. */
   experienceYearsMax: number | null;
-  /** Feed ordering. Only two values exist: the default freshest-first, and `match`,
-   *  which ranks by how well a vacancy's skills overlap the signed-in caller's
-   *  profile. The server degrades `match` to the default for anyone it cannot serve
-   *  it to — anonymous, no profile, no skills — so this is never gated client-side
-   *  beyond hiding the control. */
+  /** Feed ordering. `relevance` is the engine's own ranking, `newest` is freshest
+   *  first, `match` ranks by how well a vacancy's skills overlap the signed-in
+   *  caller's profile. Which of the first two is the DEFAULT depends on `q` — see
+   *  defaultSortFor. The server degrades `match` to its default for anyone it cannot
+   *  serve it to — anonymous, no profile, no skills — so this is never gated
+   *  client-side beyond hiding the option. */
   sort: JobSort;
 }
 
-/** The feed's ordering vocabulary. Deliberately two values: this is not a general
- *  sort control (the API also accepts created_at and the salary bounds), it is the
- *  profile-match feed plus its default. */
-export type JobSort = 'newest' | 'match';
+/** The feed's ordering vocabulary. Deliberately short: this is not a general sort
+ *  control (the API also accepts created_at and the salary bounds), it is the two
+ *  orderings the endpoint defaults between plus the profile-match feed. */
+export type JobSort = 'relevance' | 'newest' | 'match';
 
-export const DEFAULT_JOB_SORT: JobSort = 'newest';
+/** The ordering the endpoint applies when a request carries no `sort` at all:
+ *  relevance under query text, posting date without it (see `searchSort` in
+ *  internal/api/handler/search.go). The client mirrors it rather than restating it,
+ *  so "the default" and "what the server does with no param" cannot drift — which is
+ *  also why serializing the default means writing nothing. */
+export function defaultSortFor(q: string): JobSort {
+  return q ? 'relevance' : 'newest';
+}
+
+/** The ordering a filter set actually resolves to.
+ *
+ *  `relevance` has nothing to rank against once the query is cleared, so it collapses
+ *  to the browse default. This is a pure function, not an effect that rewrites the
+ *  stored value, because BOTH the sort control and filtersToParams need the answer
+ *  and a second copy of the rule is a second answer. */
+export function effectiveSort(f: JobFilters): JobSort {
+  return f.sort === 'relevance' && !f.q ? 'newest' : f.sort;
+}
+
+/** The `sort` values the search endpoint accepts, keyed by our vocabulary. `relevance`
+ *  is absent on purpose: the endpoint spells it as no `sort` parameter at all, and
+ *  inventing a wire value for it would need a handler branch to mean the same thing —
+ *  so a sort with no entry here is one that serializes to nothing. */
+const SORT_PARAM: Partial<Record<JobSort, string>> = { newest: 'posted_at', match: 'match' };
+
+/** SORT_PARAM inverted, so the two directions cannot drift. */
+const SORT_FROM_PARAM: Record<string, JobSort> = Object.fromEntries(
+  Object.entries(SORT_PARAM).map(([sort, param]) => [param, sort as JobSort]),
+);
 
 /** Splits every raw query value on comma and flattens the result, dropping
  *  empty fragments (a stray comma) — so a repeated key (`skills=go&skills=react`)
@@ -91,7 +120,7 @@ export function emptyFilters(): JobFilters {
     salaryMin: null,
     postedWithinDays: null,
     experienceYearsMax: null,
-    sort: DEFAULT_JOB_SORT,
+    sort: defaultSortFor(''),
   };
 }
 
@@ -115,7 +144,13 @@ export function filtersToParams(f: JobFilters): URLSearchParams {
   if (f.salaryMin != null) p.set('salary_min', String(f.salaryMin));
   if (f.postedWithinDays != null) p.set('posted_within_days', String(f.postedWithinDays));
   if (f.experienceYearsMax != null) p.set('experience_years_max', String(f.experienceYearsMax));
-  if (f.sort !== DEFAULT_JOB_SORT) p.set('sort', f.sort);
+  // The default is written as the ABSENCE of the param, which is how the endpoint
+  // spells both of its own defaults — so a browse feed and a relevance-ranked search
+  // both serialize clean, and `newest` under a query becomes explicit instead of
+  // silently meaning relevance.
+  const sort = effectiveSort(f);
+  const sortParam = SORT_PARAM[sort];
+  if (sortParam && sort !== defaultSortFor(f.q)) p.set('sort', sortParam);
   return p;
 }
 
@@ -172,11 +207,13 @@ export function filtersFromParams(p: URLSearchParams): JobFilters {
   const rawYears = p.get('experience_years_max')?.trim() ?? '';
   const years = Number(rawYears);
   f.experienceYearsMax = rawYears !== '' && Number.isInteger(years) && years >= 0 ? years : null;
-  // Anything but the one recognized value reads as the default — including the retired
-  // `sort=cv`. Shared links and saved searches still carry old sort params, and the
-  // same rule the backend applies (ignore, never refuse) has to hold here or the two
-  // would disagree about what a stale link means.
-  f.sort = p.get('sort') === 'match' ? 'match' : DEFAULT_JOB_SORT;
+  // Anything but a recognized value reads as the contextual default — including the
+  // retired `sort=cv` and the endpoint's `created_at`, which the browse UI does not
+  // offer. Shared links and saved searches still carry old sort params, and the same
+  // rule the backend applies (ignore, never refuse) has to hold here or the two would
+  // disagree about what a stale link means. Reads `f.q`, so it must follow the line
+  // that sets it.
+  f.sort = SORT_FROM_PARAM[p.get('sort') ?? ''] ?? defaultSortFor(f.q);
   return f;
 }
 

--- a/web/src/lib/filterControls.test.ts
+++ b/web/src/lib/filterControls.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { EXPERIENCE_PRESETS, experienceLabel, FRESHNESS_PRESETS, freshnessLabel } from './filterControls';
+import {
+  EXPERIENCE_PRESETS,
+  experienceLabel,
+  FRESHNESS_PRESETS,
+  freshnessLabel,
+  freshnessOptions,
+} from './filterControls';
 
 describe('EXPERIENCE_PRESETS', () => {
   it('runs least-to-most experience with Any as the rightmost stop', () => {
@@ -60,5 +66,34 @@ describe('freshnessLabel', () => {
   it('describes an off-preset bound instead of calling it Any', () => {
     expect(freshnessLabel(5)).not.toBe('Any');
     expect(freshnessLabel(5)).toContain('5');
+  });
+});
+
+// A select can only display a value it has an option for. The label above tells the
+// truth about an off-preset bound; without a matching option the CONTROL still renders
+// blank over that live bound, which is the same lie from a different direction.
+describe('freshnessOptions', () => {
+  it('is the presets, unchanged, for an unset or preset bound', () => {
+    expect(freshnessOptions(null)).toBe(FRESHNESS_PRESETS);
+    expect(freshnessOptions(7)).toBe(FRESHNESS_PRESETS);
+  });
+
+  it('offers an off-preset bound so the control can show it', () => {
+    const opts = freshnessOptions(5);
+    const match = opts.find((o) => o.days === 5);
+
+    expect(match).toBeDefined();
+    expect(match?.label).toBe(freshnessLabel(5));
+    expect(opts).toHaveLength(FRESHNESS_PRESETS.length + 1);
+  });
+
+  it('keeps the list in day order with Any still last', () => {
+    const days = freshnessOptions(5).map((o) => o.days);
+
+    expect(days).toEqual([1, 3, 5, 7, 14, 30, 90, null]);
+  });
+
+  it('places a bound past every preset before Any, not after it', () => {
+    expect(freshnessOptions(365).map((o) => o.days)).toEqual([1, 3, 7, 14, 30, 90, 365, null]);
   });
 });

--- a/web/src/lib/filterControls.ts
+++ b/web/src/lib/filterControls.ts
@@ -27,6 +27,28 @@ export function freshnessLabel(days: number | null): string {
   return `Last ${days} ${days === 1 ? 'day' : 'days'}`;
 }
 
+/** The freshness stops a SELECT offers, given the bound currently in force.
+ *
+ *  The presets, plus the current bound itself when it is not one of them. A select can
+ *  only show a value it has an option for: a bound arriving from a shared link, a
+ *  hand-edited URL or the AI filter dialog (which writes whatever day count it read)
+ *  matches nothing, leaves `selectedIndex = -1`, and renders the control BLANK while it
+ *  quietly hides every older posting — the same lie freshnessLabel exists to prevent,
+ *  told by the control instead of by the label.
+ *
+ *  The off-preset stop is inserted in day order so the list still reads oldest→newest,
+ *  and it disappears the moment the user picks a real preset. The modal's slider solves
+ *  the same input differently (it clamps the handle and labels it honestly), because a
+ *  slider has no option list to be absent from. */
+export function freshnessOptions(days: number | null): { days: number | null; label: string }[] {
+  if (days == null || FRESHNESS_PRESETS.some((p) => p.days === days)) return FRESHNESS_PRESETS;
+  const at = FRESHNESS_PRESETS.findIndex((p) => p.days != null && p.days > days);
+  const extra = { days, label: freshnessLabel(days) };
+  return at < 0
+    ? [...FRESHNESS_PRESETS.slice(0, -1), extra, ...FRESHNESS_PRESETS.slice(-1)]
+    : [...FRESHNESS_PRESETS.slice(0, at), extra, ...FRESHNESS_PRESETS.slice(at)];
+}
+
 /** Experience-ceiling presets, least→most with "Any" as the rightmost stop. Each
  *  stop is an upper bound on the years a posting asks for, so the leftmost is a
  *  real `0` — the postings stating no prior experience is required — and only the

--- a/web/src/lib/filterSections.test.ts
+++ b/web/src/lib/filterSections.test.ts
@@ -1,5 +1,66 @@
 import { describe, expect, it } from 'vitest';
+import { FACETS } from './facets';
 import { RAIL } from './filterSections';
+
+// Which pane hosts a facet that has no rail entry of its own, and why. The rail is the
+// ONLY way into a job facet from the interface: a param with no entry is still parsed
+// from the URL and still sent to the API, but nothing in the modal can select it. That
+// is exactly how `reality` sat unreachable — declared in FACETS, understood by the
+// backend, invisible. The company rail has carried this cover for a while
+// (companyRailGroups.test.ts); the job rail did not, which is why nothing caught it.
+//
+// An entry here is a claim that the facet IS reachable, just not from its own rail row.
+// `source` is the one facet that is deliberately not offered at all.
+const HOSTED_ELSEWHERE: Record<string, string> = {
+  role: 'category pane (the role picker)',
+  category: 'category pane (specialization chips)',
+  ai_archetype: 'category pane (AI specialization)',
+  seniority: 'experience pane',
+  role_type: 'experience pane',
+  regions: 'location pane (the region → country tree)',
+  countries: 'location pane',
+  cities: 'location pane',
+  work_mode: 'work pane',
+  employment_type: 'work pane',
+  domains: 'industry pane',
+  company_type: 'industry pane',
+  collections: 'industry pane, and the employer-credential subset in relocation',
+  english_level: 'language pane',
+  posting_language: 'language pane',
+  relocation: 'relocation pane',
+  salary_currency: 'salary pane, beside the minimum',
+};
+
+// Not offered anywhere, on purpose. Which job board a posting was crawled from is
+// provenance, not something a candidate filters on; the param stays URL-only.
+const NOT_OFFERED = new Set(['source']);
+
+describe('the job filter rail', () => {
+  it('reaches every job facet — by its own entry, a hosting pane, or a recorded refusal', () => {
+    const railParams = new Set(RAIL.map((e) => e.facetParam).filter((p): p is string => !!p));
+    const unreachable = FACETS.map((f) => f.param).filter(
+      (p) => !railParams.has(p) && !(p in HOSTED_ELSEWHERE) && !NOT_OFFERED.has(p),
+    );
+
+    expect(unreachable).toEqual([]);
+  });
+
+  it('keeps the exception lists honest — no entry claims a facet that has its own row', () => {
+    const railParams = new Set(RAIL.map((e) => e.facetParam).filter((p): p is string => !!p));
+    const declared = new Set(FACETS.map((f) => f.param));
+
+    for (const param of [...Object.keys(HOSTED_ELSEWHERE), ...NOT_OFFERED]) {
+      expect(declared, `${param} is excepted but is not a declared facet`).toContain(param);
+      expect(railParams, `${param} is excepted but also has its own rail entry`).not.toContain(param);
+    }
+  });
+
+  it('names each pane with a distinct key', () => {
+    const keys = RAIL.map((e) => e.key);
+
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});
 
 describe('the Experience pane', () => {
   it('is a ROLE-section rail entry of its own', () => {
@@ -22,5 +83,30 @@ describe('the ai_archetype facet', () => {
   it('has no standalone rail entry — FilterModal folds it into the Role pane instead', () => {
     expect(RAIL.find((e) => e.key === 'ai_archetype')).toBeUndefined();
     expect(RAIL.find((e) => e.facetParam === 'ai_archetype')).toBeUndefined();
+  });
+});
+
+// How old a posting is describes the POSTING, not something asked of the candidate, so
+// `REQUIREMENTS & ELIGIBILITY` — where it sat as the rail's last row — both misfiled it
+// and buried it. It belongs beside Experience, the other "how does this posting stand
+// relative to me" question.
+describe('the Posted pane', () => {
+  it('sits in ROLE, adjacent to Experience', () => {
+    const posted = RAIL.findIndex((e) => e.key === 'posted');
+    const experience = RAIL.findIndex((e) => e.key === 'experience');
+
+    expect(posted).toBeGreaterThan(-1);
+    expect(RAIL[posted]?.section).toBe('ROLE');
+    expect(posted).toBe(experience + 1);
+  });
+});
+
+describe('the Posting reality pane', () => {
+  it('has a rail entry rendering the reality facet', () => {
+    const entry = RAIL.find((e) => e.facetParam === 'reality');
+
+    expect(entry).toBeDefined();
+    expect(entry?.kind).toBe('facet');
+    expect(entry?.section).toBe('ROLE');
   });
 });

--- a/web/src/lib/filterSections.ts
+++ b/web/src/lib/filterSections.ts
@@ -178,6 +178,16 @@ export const RAIL: RailEntry[] = [
   // The two params stay independent, as they already were.
   { key: 'category', label: 'Role', section: 'ROLE', kind: 'category' },
   { key: 'experience', label: 'Experience', section: 'ROLE', kind: 'experience' },
+  // How old a posting is, and whether it looks permanently open, both describe the
+  // POSTING rather than anything asked of the candidate — so neither belongs under
+  // REQUIREMENTS & ELIGIBILITY, where `posted` sat as the rail's last row. They sit
+  // beside Experience, the other "how does this posting stand relative to me" question.
+  //
+  // `reality` had no rail entry at all until this: declared in FACETS, filterable on the
+  // index, and reachable only by hand-editing the URL. filterSections.test.ts now asserts
+  // the cover so the next facet cannot go the same way.
+  { key: 'posted', label: 'Posted', section: 'ROLE', kind: 'posted' },
+  { key: 'reality', label: 'Posting reality', section: 'ROLE', kind: 'facet', facetParam: 'reality' },
   { key: 'location', label: 'Location', section: 'ROLE', kind: 'location' },
   { key: 'work', label: 'Work & employment', section: 'ROLE', kind: 'work' },
   { key: 'skills', label: 'Skills', section: 'ROLE', kind: 'facet', facetParam: 'skills' },
@@ -186,5 +196,4 @@ export const RAIL: RailEntry[] = [
   { key: 'salary', label: 'Salary', section: 'PAY & BENEFITS', kind: 'salary' },
   { key: 'language', label: 'Language', section: 'REQUIREMENTS & ELIGIBILITY', kind: 'language' },
   { key: 'relocation', label: 'Relocation', section: 'REQUIREMENTS & ELIGIBILITY', kind: 'relocation' },
-  { key: 'posted', label: 'Posted', section: 'REQUIREMENTS & ELIGIBILITY', kind: 'posted' },
 ];

--- a/web/src/lib/filters.ts
+++ b/web/src/lib/filters.ts
@@ -89,6 +89,15 @@ export class FilterStore {
     this.#url.setSoon({ ...this.#url.value, postedWithinDays: n });
   }
 
+  /** The same freshness bound chosen from a select rather than dragged on the modal's
+   *  slider. setNow, not setSoon: a select commits one value, so there are no
+   *  intermediate stops to debounce away, and the list must reorder on the choice —
+   *  the same reasoning as setSort. Both setters write one field, so the slider, this
+   *  select and the filter summary can never disagree about the value. */
+  pickPostedWithinDays(n: number | null) {
+    this.#url.setNow({ ...this.#url.value, postedWithinDays: n });
+  }
+
   setExperienceYearsMax(n: number | null) {
     this.#url.setSoon({ ...this.#url.value, experienceYearsMax: n });
   }


### PR DESCRIPTION
A user wrote in asking for a way to sort by date: the postings they hit "aren't in any particular order" and read as stale, and they offered to implement it since the project is open source.

Nothing needed implementing. The backend has served every ordering and bound they asked for the whole time — `sort=posted_at`, `posted_within_days`, the `reality` facet. All three were unreachable with a mouse, in three different ways.

**The sort select was gated on the wrong thing.** `sortControlVisible = matchFilterAvailable && matchSortEnabled(env)`. That gate is right for `Best match` — an option that ranks against no profile is worse than an absent one, as the code comment argues — but it was applied to the whole select, taking `Newest` down with it. A signed-out visitor never saw it.

**And when it did show, it lied.** `newest` was `DEFAULT_JOB_SORT` and defaults are not serialized, so a text search sent no `sort`, the engine ranked by relevance, and the control still read "Newest".

**`posted_within_days` was buried.** Last entry of the modal's third rail section, under `REQUIREMENTS & ELIGIBILITY` — where a posting's age is not a requirement of the candidate.

**`reality` had no rail entry at all.** Declared in `FACETS`, filterable on the index, reachable only by hand-editing the URL. Nothing caught it: the company rail has a completeness test, the job rail did not. Adding that test found a second one, `source`, now recorded as a deliberate refusal rather than given a row — which board a posting was crawled from is provenance, not something to filter on.

## What changed

The sort vocabulary names `relevance` explicitly, and its default is contextual, mirroring `searchSort`: no `sort` means relevance under a query and posting date without one. `newest` under a query is sent as `sort=posted_at`. The select renders whenever it holds more than one option, so the signed-out case is covered; `match` keeps its own gate.

A **Posted** select and a **Hide evergreen** toggle join it above the list. Both write the state the modal already writes, so the modal, the filter summary and saved searches stay in step.

`posted` moves to `ROLE` beside `Experience`, `reality` gains an entry, and `ListToolbar` renames its slot to `controls` and stops gating them on the total — which is what hid them on a company page.

## The bug review caught

The first pass stored the *resolved* default, so a browse feed held `sort: 'newest'` and nothing distinguished that from a caller who chose newest. `setQuery` overwrites only `q`, so typing into the search box produced `q=golang&sort=posted_at` — the primary search path, date-ordered, the exact outcome the design doc rejects by name.

Quieter cost: `savedSearchQuery` is `filtersToParams`, so a spurious `sort` made the live filters compare unequal to the saved search they came from. It read as dirty, and saving again created a duplicate saved search plus a duplicate digest subscription delivering identical mail.

The ordering is now nullable — chosen, or not yet chosen — with the default applied at read time. One rule instead of patching every entry point that can change `q`.

Three more from the same review, each with a test that fails without it:

- The option-availability rule moved out of the component into pure `sortOptionsFor` / `selectedSortFor`. `web/` has no component-test harness and both sort bugs lived in that untestable region. `selectedSortFor` also fixes a blank control: a shared `?sort=match` link opened signed out resolved to an ordering not on offer, and a `<select>` whose value matches no option renders empty over a live ordering. It now names what the endpoint will actually serve.
- `freshnessOptions` offers an off-preset `posted_within_days` as a stop of its own, in day order — a day count from a shared link or the AI dialog left the select blank while quietly narrowing the list.
- The mobile row overflowed: measured at 390px the controls ran 49px past the edge with the sort select clipped off-screen. The toggle drops its word below `sm` and the row wraps.

## Verification

- 1307 unit tests pass; `svelte-check` 0 errors (31 warnings, all pre-existing); `pnpm lint` adds no new warning.
- Driven against the live API: signed out with a query the select offers Relevance/Newest; with no query there is no select; `?q=go&sort=posted_at` preselects Newest; `?q=go&sort=match` signed out shows Relevance rather than blank; `?posted_within_days=7` preselects `1 week` and `=5` offers `Last 5 days` in day order; `?reality_exclude=likely-evergreen` renders the toggle pressed; the controls render on a company page; the row fits 390px (measured).

**No backend change**: no Go, no SQL, no index settings, no reindex, no migration. Shared links and saved searches carrying `sort=match` are unaffected.

## Deferred

Filtering or sorting on `updated_at`. `RefreshUnchangedJob` made the column mean "content last changed" rather than "last crawled", so it is finally meaningful — but it is absent from the Meilisearch document, so it needs a field, a settings change, a full reindex and a two-step release. There is also a product question first: "updated yesterday" is not "posted yesterday", and an edited evergreen posting surfacing as fresh is the ghost-posting problem rather than a fix for it. The `reality` facet this surfaces answers that directly and needs no reindex. Reasoning is recorded in `design.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added contextual job sorting with Relevance, Newest, and Best match options.
  - Added Posted freshness controls, including custom day ranges.
  - Added a Hide evergreen toggle for job listings.
  - Added Posting reality to the filter panel.
  - Improved filter organization and toolbar responsiveness.
- **Bug Fixes**
  - Freshness selections now apply immediately.
  - Previously unavailable job facets are now accessible through the filter panel.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->