### PR TITLE
Fetch the release over SSH; the protocol pin lasted three hours

### DIFF
--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -38,6 +38,19 @@ else. Nothing generates them — a new board means a new timer file, by hand.
   `10-skip-if-reindexing.conf` adjust one setting. A drop-in's directives apply after the
   unit's own, which is what makes `EnvironmentFile=` ordering come out right — the later
   file wins on a key both define (`AWS_REGION` is in both).
+- **The release fetches over SSH, and the two pieces that make that work are not in git.**
+  `origin` is `git@github.com:strelov1/freehire.git` in both `/opt/freehire/src/hire-blue`
+  and `hire-green`, and `~freehire/.ssh/config` (the account's home is `/var/lib/freehire`,
+  not `/home`) points `github.com` at the `agent_deploy` key beside it. Neither a remote URL
+  nor a private key belongs in this snapshot, so `check-drift.sh` cannot see either — this
+  paragraph is the record. The reason is in `bin/release.sh` beside the `pull`: GitHub
+  throttles ANONYMOUS object fetches from this address, and the repository being public is
+  not enough, because the throttle lands on the pack download rather than on the ref list.
+  A release that dies with *"could not read Username"* is that, or the key; it is not a
+  missing credential file and not the protocol version, which was the first diagnosis and
+  held for three hours. The key is issued to `strelov1/freehire-agent` and reads this
+  repository only because this repository is public — a deploy key of its own would be
+  tidier and is not urgent.
 - **The `.bak` files on the host are not here on purpose.** There are a dozen dated copies
   of `release.sh` alone. They are what a directory without version control grows instead of
   history; this directory is the replacement, so they were dropped rather than imported.

--- a/deploy/bin/release.sh
+++ b/deploy/bin/release.sh
@@ -61,10 +61,31 @@ cd "/opt/freehire/src/${dir}-${new}"
 # has no terminal to prompt on, so the first 401 ends it.
 #
 # Why GitHub singles out the v2 POST from here is not established — this host crawls
-# hard, so a throttle on its address is the likeliest reason. Authenticating the remote
-# would be the durable fix and needs a credential provisioned; pinning the protocol costs
-# nothing and needs none. GIT_TERMINAL_PROMPT=0 keeps any future variant of this failing
-# fast instead of hanging on a prompt nobody can answer.
+# hard, so a throttle on its address is the likeliest reason.
+#
+# The pin bought about three hours. Later the same day the SAME 401 came back on v0,
+# which is the answer to what the paragraph above left open: the throttle is not on a
+# protocol version, it is on ANONYMOUS object fetches from this address. Both versions
+# POST to /git-upload-pack to download a pack; v0 merely reaches it second. What still
+# succeeded, and is the tell, was every request that downloads nothing:
+#
+#   git ls-remote  (GET  /info/refs)   -> 200, repeatedly
+#   git fetch      (POST /git-upload-pack) -> 401, 3/3
+#
+# So the durable fix the paragraph above named is the one now in place: the remote is
+# authenticated. `origin` is git@github.com:strelov1/freehire.git in BOTH colors, and
+# ~freehire/.ssh/config points github.com at the agent_deploy key already on the box
+# (provisioned 2026-07-14). No new secret was introduced — that key is issued to
+# strelov1/freehire-agent and reads this repository only because this repository is
+# public, which is worth replacing with a deploy key of its own when convenient.
+#
+# The protocol pin stays. It costs nothing, it is orthogonal to the transport, and
+# leaving it removes one variable if the fetch path is ever in question again.
+# GIT_TERMINAL_PROMPT=0 likewise stays: it keeps any future variant failing fast
+# instead of hanging on a prompt nobody can answer.
+#
+# If this fails again with a credential error, check the KEY first (`sudo -u freehire
+# ssh -T git@github.com` names the identity it authenticated as), not the protocol.
 sudo -u freehire env GIT_TERMINAL_PROMPT=0 git -c protocol.version=0 pull --ff-only
 echo "[release:$app] building api + web ..."
 sudo -u freehire /usr/local/bin/go build -buildvcs=false -o "$bin" ./cmd/server


### PR DESCRIPTION
#2325 pinned the release fetch to git protocol v0 after every release began dying on `could not read Username`. It worked, and it left one question open in its own comment: why GitHub singles out the v2 POST from this host.

Three hours later the same 401 came back on v0. That answers it. The throttle is not on a protocol version — it is on **anonymous object fetches from this address**. Both versions POST to `/git-upload-pack` to download a pack; v0 merely reaches it second.

The tell is which requests still worked:

| request | what it downloads | result |
|---|---|---|
| `git ls-remote` — `GET /info/refs` | nothing | 200, repeatedly |
| `git fetch` — `POST /git-upload-pack` | a pack | **401**, three for three |

So the durable fix #2325 named but did not take is now in place, and it needed no new secret: `origin` is `git@github.com:strelov1/freehire.git` in both colors, and `~freehire/.ssh/config` points `github.com` at the `agent_deploy` key already on the box since 2026-07-14.

That key is issued to `strelov1/freehire-agent` and reads this repository only because this repository is public. A deploy key of its own would be tidier; it is not urgent, and the note says so.

The protocol pin stays. It costs nothing, it is orthogonal to the transport, and leaving it removes a variable if the fetch path is ever in question again. `GIT_TERMINAL_PROMPT=0` likewise — it keeps any future variant failing fast rather than hanging on a prompt nobody can answer.

## What is recorded where

Neither a remote URL nor a private key belongs in `deploy/`, so `check-drift.sh` cannot see either. `deploy/AGENTS.md` carries the record instead, beside the existing note that git is the truth and the host is the copy. The comment in `release.sh` is rewritten too — it currently argues that pinning the protocol "costs nothing and needs none", which is true but no longer sufficient, and a future reader following it would re-diagnose the protocol instead of checking the key.

## Verification

The release that had failed three times in a row went green on the first run after the switch, and prod is serving #2340. `shellcheck` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified release authentication requirements and troubleshooting guidance.
  - Documented SSH-based release fetching and the use of a private deploy key.
  - Added context for anonymous fetch throttling and related credential errors.
  - Explained why protocol and non-interactive prompt settings are retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->