### PR TITLE
Let the job page's match card clear the site header

### DIFF
--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -420,7 +420,12 @@
   </header>
 
   <aside class="w-full shrink-0 lg:col-start-1 lg:row-span-3 lg:row-start-1">
-    <div class="sticky top-6 flex flex-col gap-4 rounded-xl border border-border bg-card p-4">
+    <!-- `top-20`, not `top-6`: the site header is `sticky top-0 h-14` and opaque, so a
+         card pinned 24px from the viewport spends the whole read with its first 32px —
+         the border, the padding, and the top of the match score — behind it. 80px is
+         the header's 56 plus the same 24 of air the card was asking for. Same offset
+         DocsNav's rail already uses. -->
+    <div class="sticky top-20 flex flex-col gap-4 rounded-xl border border-border bg-card p-4">
       <JobMatch {job} />
 
       {#if salary}


### PR DESCRIPTION
Let the job page's match card clear the site header

The card in the left column pins at `top-6`, 24px from the viewport. The site
header is `sticky top-0 h-14` and opaque, so for the whole read the card's
first 32px — its top border, its padding, and the top of the match score —
sat behind the header. It read as a card clipped by the edge of the page.

`top-20` is that 56px plus the same 24px of air the card was already asking
for; measured, the card's top edge now lands at y=80 with the header ending
at 56. It is also the offset DocsNav's rail already uses for the same reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the job view sidebar position so it remains fully visible below the sticky site header while scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->