### PR TITLE
Let the remaining pinned sidebars clear the site header

### DIFF
--- a/web/src/lib/components/AnalyticsView.svelte
+++ b/web/src/lib/components/AnalyticsView.svelte
@@ -93,7 +93,11 @@
 
 <div class="flex gap-6">
   <aside class="hidden w-72 shrink-0 md:block">
-    <div class="sticky top-6 max-h-[calc(100vh-5rem)] overflow-y-auto rounded-xl border border-border bg-card p-4">
+    <!-- `top-20` is the site header's own `h-14` plus 24px of air. At `top-6` the card
+         pinned 24px from the VIEWPORT, so the opaque header (`sticky top-0`) covered its
+         top border and first row of controls for the whole scroll. The max-height is
+         then what is left of the viewport, less the same 24px at the bottom. -->
+    <div class="sticky top-20 max-h-[calc(100vh-6.5rem)] overflow-y-auto rounded-xl border border-border bg-card p-4">
       <FilterSummary store={filters} onOpen={() => (modalOpen = true)} />
     </div>
   </aside>

--- a/web/src/lib/components/CompaniesView.svelte
+++ b/web/src/lib/components/CompaniesView.svelte
@@ -153,7 +153,11 @@
 
 <div class="flex gap-6">
   <aside class="hidden w-72 shrink-0 md:block">
-    <div class="sticky top-6 max-h-[calc(100vh-5rem)] overflow-y-auto rounded-xl border border-border bg-card p-4">
+    <!-- `top-20` is the site header's own `h-14` plus 24px of air. At `top-6` the card
+         pinned 24px from the VIEWPORT, so the opaque header (`sticky top-0`) covered its
+         top border and first row of controls for the whole scroll. The max-height is
+         then what is left of the viewport, less the same 24px at the bottom. -->
+    <div class="sticky top-20 max-h-[calc(100vh-6.5rem)] overflow-y-auto rounded-xl border border-border bg-card p-4">
       <CompanyFilterSummary store={filters} onOpen={() => (modalOpen = true)} />
     </div>
   </aside>

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -793,7 +793,11 @@
 
 <div class="flex gap-6">
   <aside class="hidden w-72 shrink-0 md:block">
-    <div class="sticky top-6 flex max-h-[calc(100vh-5rem)] flex-col gap-4 overflow-y-auto">
+    <!-- `top-20` is the site header's own `h-14` plus 24px of air. At `top-6` the rail
+         pinned 24px from the VIEWPORT, so the opaque header (`sticky top-0`) covered its
+         first 32px — here, the "Filters" heading — for the whole scroll. The max-height
+         is then what is left of the viewport, less the same 24px at the bottom. -->
+    <div class="sticky top-20 flex max-h-[calc(100vh-6.5rem)] flex-col gap-4 overflow-y-auto">
       {#if !standalone && jobs.status === 'ready'}
         <!-- Company view: the (filtered) open-job count as the sidebar's lead stat.
              The inline count above the list is hidden on desktop (shown only on

--- a/web/src/lib/components/ModerationView.svelte
+++ b/web/src/lib/components/ModerationView.svelte
@@ -128,7 +128,11 @@
 
     <div class="lg:flex lg:gap-8">
       <aside aria-label="Moderation sections" class="hidden shrink-0 lg:block lg:w-56">
-        <nav class="sticky top-6 flex flex-col gap-1">
+        <!-- `top-20` is the site header's own `h-14` plus 24px of air. At `top-6` the nav
+             pinned 24px from the VIEWPORT, so the opaque header (`sticky top-0`) covered
+             its first entry for the whole scroll. No max-height: this list is short
+             enough that it never reaches the fold. -->
+        <nav class="sticky top-20 flex flex-col gap-1">
           {@render navButtons()}
         </nav>
       </aside>


### PR DESCRIPTION
Let the remaining pinned sidebars clear the site header

Same defect the job page's match card had, in the four rails that were left:
the site header is `sticky top-0 h-14` and opaque, so a rail pinned at
`top-6` — 24px from the viewport — spends the whole scroll with its first
32px behind it. On the home feed that is the word "Filters", cut in half.

`top-20` is the header's 56px plus the same 24px of air the rails were
already asking for. The three that cap their height get `calc(100vh-6.5rem)`
in place of `calc(100vh-5rem)`, which is what is left of the viewport with a
matching 24px at the bottom; measured at a 900px viewport the rail now runs
80 to 876. The moderation nav has no cap and needs none — the list is short.

Verified on the home feed, /companies and /analytics: every rail's top edge
now lands at 80 with the header ending at 57. The moderation page is behind
auth and was not checked in a browser; it is the same one-line change.
