### PR TITLE
Onboard quickin prologapp, and give TRM Labs its real name

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -1415,7 +1415,7 @@
   board: tremendous
 - company: Triumph
   board: triumph-arcade
-- company: trmlabs
+- company: TRM Labs
   board: trm-labs
 - company: Trove
   board: trove

--- a/sources/quickin.yml
+++ b/sources/quickin.yml
@@ -12,3 +12,7 @@
   board: druid
 - company: koin
   board: koin
+
+# link contribution, validated live 2026-09-02
+- company: Prolog App
+  board: prologapp


### PR DESCRIPTION
Onboard quickin prologapp, and give TRM Labs its real name

Two contributions arrived while the queue was being drained.

quickin `prologapp` (Prolog App) is new: the public account API answers
with 8 published postings, several of them engineering (Desenvolvedor
Full Stack, Product Manager). Added.

The second was recorded as greenhouse `trmlabs`, and that board 404s on
both greenhouse hosts. TRM Labs is on ASHBY, board `trm-labs`, which
ashby.yml already carries (113 open postings). Their careers page is
what misled the recognizer: it still serves a stale greenhouse embed
script (`embed/job_board/js?for=trmlabs`) alongside the live Ashby
iframe, and boardresolve matches the greenhouse embed shape in step 1,
before it scans the page's links in step 2 — so the leftover wins on
position rather than on evidence. Nothing here fixes that; a page
carrying two ATS embeds cannot be told apart without probing both, which
the resolver deliberately does not do. Recorded so the next person who
meets it does not re-derive it.

What the row did surface is that the entry was named `trmlabs`, a
squished slug of exactly the kind internal/dict/companyname exists to
repair — it reads that way in the UI and breaks logo.dev's name lookup.
Fixed in place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added job board listings for Prolog App through Quickin.

* **Updates**
  * Updated the TRM Labs company name display while preserving its existing board link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->