### PR TITLE
Name 13 more Bertelsmann hub tenants

### DIFF
--- a/sources/successfactors.yml
+++ b/sources/successfactors.yml
@@ -2079,39 +2079,63 @@
   board: jobsearch.alstom.com
 # A Bertelsmann hub: one host and one shared job_sitemap.xml for 40 employers, which the site
 # names only as the job URL's first path segment. Contributed as a link, validated live
-# 2026-09-02 (973 postings in the sitemap). The 17 tenants missing below are the ones the
-# platform does not name — their /<tenant>/ landing page is empty, serves the platform's own
-# "Create Your Own Career" boilerplate, or shows a page heading — so their postings fall back
-# to Bertelsmann rather than get a name invented from the key.
+# 2026-09-02 (973 postings in the sitemap).
 #
-# Each name below is that tenant's own landing-page title, read verbatim rather than expanded
-# from the key; "Penguin Random House" is PRH_US because that is what its title says, which is
-# why its three siblings are the qualified ones. The keys are matched EXACTLY, so transcribe
-# them from the sitemap: a re-cased or mistyped key is a silent fallback, not an error.
+# Every name below is read verbatim from something the site itself states, never expanded from
+# the key, and there were two places to read it. First the tenant's own landing page at
+# /<tenant>/, whose <title> names 23 of them — that is why "Penguin Random House" is PRH_US and
+# its three siblings are the qualified ones, which is what their titles say. The rest came from
+# the postings: a recruiter often opens the body with "Unternehmen: <legal entity>", and where
+# there is no such line the entity still appears in the text (Broadcasting Center Europe, Hay
+# House LLC, RISER ID Services GmbH). Note that is prose, NOT a field — the page's structured
+# properties are title/description/date/location only, so it cannot be parsed and the map has to
+# exist.
+#
+# Four tenants are still absent and their postings fall back to Bertelsmann, which is true of
+# all of them: Bertelsmann_Corporate IS Bertelsmann SE & Co. KGaA, so a key would be a no-op;
+# Alliant and Finance say nothing beyond "part of the Bertelsmann group"; and Arvato_Financial
+# is the brand that became Riverty, so naming it either way would assert something the site does
+# not. Four sitemap entries carry no tenant segment at all and land there too.
+#
+# The keys are matched EXACTLY, so transcribe them from the sitemap: a re-cased or mistyped key
+# is a silent fallback, not an error.
 - company: Bertelsmann
   board: jobsearch.createyourowncareer.com
   hub: true
   tenants:
     ARVATO: Arvato
     Arvato_Systems: Arvato Systems
+    BCE: Broadcasting Center Europe
+    BFS_Health_Finance: BFS health finance
     BMG: BMG
     BertelsmannStiftung: Bertelsmann Stiftung
     Bertelsmann_Investments: Bertelsmann Investments
+    CHE: CHE Centrum für Hochschulentwicklung
+    Campaign: direct services Gütersloh
     DK_UK: Dorling Kindersley UK
+    Digital_Marketing_IT: direct services Gütersloh
     FREMANTLE: Fremantle
     GBS: Bertelsmann Global Business Services
+    GGP_Media: GGP Media
+    HayHouse: Hay House
+    Mohn_Media: Mohn Media
+    PRH_ANZ: Penguin Random House Australia
     PRH_DEU: Penguin Random House Verlagsgruppe
     PRH_GRUPO: Penguin Random House Grupo Editorial
     PRH_UK: Penguin Random House UK
     PRH_US: Penguin Random House
-    PostAdress: PostAdress
     Playaway: Playaway
+    PostAdress: PostAdress
     RTL: RTL
     Relias_Learning: Relias
+    Relias_Learning_DE: Relias
+    Riser: RISER ID Services
     Riverty: Riverty
     SDSH: Stiftung Deutsche Schlaganfallhilfe
+    Sonopress: Sonopress
     TERRITORY: TERRITORY
     VIVENO_Group: VIVENO Group
+    beDirect: bedirect
     bfs_finance: bfs finance
     smartclip: smartclip
     weareera: We Are Era


### PR DESCRIPTION
Name 13 more Bertelsmann hub tenants

The hub landed with 23 of its 40 tenants named, because the tenant
landing pages at /<tenant>/ were the only source consulted and 17 of
them serve an empty page, the platform's own "Create Your Own Career"
boilerplate, or a page heading. Their 116 postings all read
"Bertelsmann".

The postings themselves name most of the rest. A recruiter often opens
the body with "Unternehmen: <legal entity>" (CHE Gemeinnütziges Centrum
für Hochschulentwicklung, direct services Gütersloh GmbH, bedirect GmbH
& Co. KG), and where there is no such line the entity is still in the
text: Broadcasting Center Europe (BCE), Hay House LLC, RISER ID Services
GmbH, Mohn Media Mohndruck GmbH, GGP Media GmbH, Sonopress GmbH,
Penguin Random House Australia Pty Ltd, Relias Learning GmbH.

That is prose and not a field, so it cannot replace the map: the page's
structured properties are title, description, date and location only —
checked on a Riverty posting, which carries no company anywhere. Reading
them by hand once is still what this costs.

Relias_Learning_DE maps to Relias rather than "Relias Learning": it is
the same brand's German arm, and a near-duplicate relias-learning slug
beside relias would split one employer for nobody's benefit. The Penguin
Random House arms stay separate because they are separate publishing
houses that name themselves that way.

Four tenants remain absent, and Bertelsmann is the honest answer for
each: Bertelsmann_Corporate IS Bertelsmann SE & Co. KGaA, so a key would
be a no-op; Alliant and Finance say nothing beyond "part of the
Bertelsmann group"; and Arvato_Financial is the brand that became
Riverty, so naming it either way asserts something the site does not.
With the four tenant-less sitemap entries that leaves 54 postings on the
fallback, down from 116.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Expanded Bertelsmann tenant coverage across additional businesses and brands.
  - Updated several tenant names for clearer, more consistent display.
  - Improved tenant identification using landing-page titles and posting text.
  - Listings without a recognized tenant continue to be associated with Bertelsmann as a fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->