### PR TITLE
Release main to production once CI is green on it, from a timer on the host

### DIFF
--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -9,8 +9,8 @@ Snapshot taken 2026-09-01 from `/etc/systemd/system/freehire-*` and `/opt/freehi
 ## What is here
 
 ```
-systemd/   337 files — 46 .service, 286 .timer, 5 drop-in directories
-bin/        13 operator scripts (release, backups, alerting, ingest slotting)
+systemd/   350 files — 48 .service, 297 .timer, 5 drop-in directories
+bin/        14 operator scripts (release, autodeploy, backups, alerting, ingest slotting)
 ```
 
 `systemd/freehire-ingest@.service` is one template; the 255 `freehire-ingest@<board>.timer`
@@ -38,6 +38,25 @@ else. Nothing generates them — a new board means a new timer file, by hand.
   `10-skip-if-reindexing.conf` adjust one setting. A drop-in's directives apply after the
   unit's own, which is what makes `EnvironmentFile=` ordering come out right — the later
   file wins on a key both define (`AWS_REGION` is in both).
+- **Production releases itself from a timer, and the host is the one doing the polling.**
+  `freehire-autodeploy.timer` runs `bin/autodeploy.sh` every 10 minutes: it compares
+  `origin/main` against the commit `hire-current` is serving, requires every check run on
+  that commit to have COMPLETED and passed, and then calls `release.sh`. Nothing reaches
+  in from GitHub — deliberately, because a self-hosted runner on a repository this public
+  (105 forks) would let any fork's pull request execute on this box. The only credential
+  that leaves the host is `GITHUB_STATUS_TOKEN`, a fine-grained token whose whole power is
+  writing a commit status.
+  **It is armed by `AUTODEPLOY=1` in `/opt/freehire/.env`** and does nothing but log
+  without it, so the timer can be installed and watched before it is trusted. Outcomes go
+  to the same Telegram channel as `site-alert.sh` — which is not decoration: a release
+  path with no workflow run behind it is invisible otherwise, and this project's recurring
+  failure is the thing that exits 0 unnoticed. A commit that fails twice is left alone
+  until main moves; the count lives in `/var/lib/freehire/autodeploy.state`, which survives
+  a reboot on purpose.
+- **`release.sh` now takes a file lock (`/var/lock/freehire-release.lock`) and exits 3 when
+  it cannot get it.** Until the timer existed, "a person is running it" was the only lock
+  there was. Exit 3 is distinct so `autodeploy.sh` reads a hand-run release as "not my
+  turn" rather than as a failure worth alerting on.
 - **The release fetches over SSH, and the two pieces that make that work are not in git.**
   `origin` is `git@github.com:strelov1/freehire.git` in both `/opt/freehire/src/hire-blue`
   and `hire-green`, and `~freehire/.ssh/config` (the account's home is `/var/lib/freehire`,

--- a/deploy/bin/autodeploy.sh
+++ b/deploy/bin/autodeploy.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Deploy main to production when CI has gone green on it — driven from the HOST, on a
+# timer, rather than pushed in from CI.
+#
+# Why the host polls instead of GitHub Actions pushing:
+#
+#   - A self-hosted runner is the obvious answer and is the wrong one here. This
+#     repository is PUBLIC with 105 forks, and a runner takes jobs from GitHub: a fork's
+#     pull request naming `runs-on: self-hosted` executes that fork's code on this
+#     machine. Secrets stay out of a fork's reach; the machine does not.
+#   - An SSH key in GitHub secrets works (restricted with `command=` it can only trigger
+#     a release), but it puts a production credential in a place this host does not
+#     control, and needs the inbound path to stay open.
+#
+# Polling inverts both. Nothing reaches in, GitHub cannot choose what runs here, and the
+# only credential that leaves the box is a fine-grained token whose entire power is
+# writing a commit status — a leaked one can draw a green tick and nothing else.
+#
+# What it costs, stated plainly: the release is no longer visible as a workflow run. It
+# is a commit status plus this script's journal, and — the part that is not optional —
+# a Telegram message on every outcome. A deploy path that fails silently is the failure
+# mode this project keeps meeting (the .env split that muted `remind` for weeks, the
+# ingest slots that skipped 56% of runs with exit 0), so the alert is load-bearing, not
+# a nicety.
+#
+# Installed at /opt/freehire/bin/autodeploy.sh, driven by freehire-autodeploy.timer.
+# ARMED BY `AUTODEPLOY=1` in /opt/freehire/.env — absent, it logs what it would have
+# done and exits 0, so the timer can be installed and watched before it is trusted.
+set -uo pipefail
+
+REPO=strelov1/freehire
+BRANCH=main
+APP=freehire
+RELEASE=/opt/freehire/bin/release.sh
+# The symlink release.sh repoints to the color it just flipped to, so its HEAD is the
+# commit production is SERVING — the right thing to compare against. Reading either
+# color directly would compare against whichever one happens to be warm.
+CURRENT=/opt/freehire/src/hire-current
+ENV_FILE=/opt/freehire/.env
+# Survives a reboot on purpose: it remembers which commit already failed, and a machine
+# that reboots mid-incident must not come back and retry the same doomed build.
+STATE_FILE=/var/lib/freehire/autodeploy.state
+# A release that fails twice is not going to succeed on the third try — the build is
+# broken, or the host is. Stop, keep alerting once, and let a person look. A new commit
+# on main clears the count, because it is a different build.
+MAX_ATTEMPTS=2
+# release.sh's "another release is already running" code. Not a failure: a person is
+# mid-deploy, so skip this tick silently and pick it up on the next one.
+BUSY_EXIT=3
+
+log() { printf '%s %s\n' "$(date -u +%FT%TZ)" "$*"; }
+
+# The env file is deployment state, not a checked-in script — same read as site-alert.sh.
+env_get() { grep -E "^$1=" "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2-; }
+
+armed=$(env_get AUTODEPLOY)
+gh_token=$(env_get GITHUB_STATUS_TOKEN)
+tg_token=$(env_get TELEGRAM_BOT_TOKEN)
+tg_chat=$(env_get SITE_ALERT_CHAT_ID)
+
+send() {
+	local text=$1
+	if [ -z "$tg_token" ] || [ -z "$tg_chat" ]; then
+		log "TELEGRAM (not sent, channel unset): $text"
+		return
+	fi
+	if curl -sS -m 10 -o /dev/null \
+		--data-urlencode "chat_id=${tg_chat}" \
+		--data-urlencode "text=${text}" \
+		"https://api.telegram.org/bot${tg_token}/sendMessage"; then
+		log "telegram sent: $text"
+	else
+		log "telegram send FAILED: $text"
+	fi
+}
+
+# A commit status is the whole reason the token exists. Failing to write one must never
+# fail the deploy — the release either happened or it did not, and a tick in a web UI
+# does not change which.
+status() {
+	local sha=$1 state=$2 desc=$3
+	[ -n "$gh_token" ] || return 0
+	curl -sS -m 15 -o /dev/null -X POST \
+		-H "Authorization: Bearer ${gh_token}" \
+		-H "Accept: application/vnd.github+json" \
+		-H "X-GitHub-Api-Version: 2022-11-28" \
+		"https://api.github.com/repos/${REPO}/statuses/${sha}" \
+		-d "$(jq -nc --arg s "$state" --arg d "$desc" \
+			'{state:$s, context:"deploy/prod", description:$d}')" ||
+		log "status write FAILED (${state}) — continuing, the release outcome stands"
+}
+
+deployed=$(git -C "$CURRENT" rev-parse HEAD 2>/dev/null) || {
+	log "cannot read the deployed commit from ${CURRENT}; refusing to guess"
+	exit 1
+}
+remote=$(sudo -u freehire git -C "$CURRENT" ls-remote origin "refs/heads/${BRANCH}" 2>/dev/null | cut -f1)
+if [ -z "$remote" ]; then
+	# ls-remote downloads nothing and is the request GitHub answers even when it is
+	# throttling this address for packs, so a failure here is the network or the key —
+	# not the throttle that moved this remote to SSH in the first place.
+	log "cannot reach origin/${BRANCH}; skipping this tick"
+	exit 0
+fi
+
+if [ "$remote" = "$deployed" ]; then
+	log "up to date at ${deployed:0:9}"
+	exit 0
+fi
+
+read -r state_sha state_attempts _ < <(cat "$STATE_FILE" 2>/dev/null || echo "none 0")
+attempts=0
+[ "$state_sha" = "$remote" ] && attempts=$state_attempts
+if [ "$attempts" -ge "$MAX_ATTEMPTS" ]; then
+	log "${remote:0:9} already failed ${attempts}x; not retrying until main moves"
+	exit 0
+fi
+
+# Gate on CI, not on the merge. A squash merge pushes to main and the workflows start
+# after it, so deploying on "main moved" would ship a commit whose tests are still
+# running. Anything unfinished simply waits for the next tick — which is also what makes
+# the 10-minute cadence comfortable: the wait is free.
+# An ARRAY, not `${gh_token:+-H "..."}`: unquoted, that expansion word-splits on the
+# spaces inside it and hands curl `-H`, `"Authorization:`, `Bearer`, `TOKEN"` as four
+# arguments. shellcheck does not flag it. Reading the endpoint unauthenticated works for
+# a public repository but shares the 60/hour-per-address anonymous budget, and this
+# address is already the one GitHub throttles — so the token is used when present and
+# its absence degrades rather than fails.
+auth=()
+[ -n "$gh_token" ] && auth=(-H "Authorization: Bearer ${gh_token}")
+checks=$(curl -sS -m 20 \
+	"${auth[@]}" \
+	-H "Accept: application/vnd.github+json" \
+	-H "X-GitHub-Api-Version: 2022-11-28" \
+	"https://api.github.com/repos/${REPO}/commits/${remote}/check-runs?per_page=100")
+total=$(jq -r '.total_count // empty' <<<"$checks" 2>/dev/null)
+if [ -z "$total" ]; then
+	log "cannot read check runs for ${remote:0:9}; skipping this tick"
+	exit 0
+fi
+if [ "$total" -eq 0 ]; then
+	log "${remote:0:9} has no check runs yet; waiting"
+	exit 0
+fi
+# The one race this cannot see: check runs that GitHub has not CREATED yet. "All of them
+# passed" is only as complete as the list, so a tick landing in the seconds between a
+# push and its workflows appearing would read a short list as a full one. It stays a
+# note rather than a guard because the window is a few seconds against a 10-minute
+# cadence, and a run that exists at all starts `queued`, which the pending check above
+# already waits on. If it ever does bite, the fix is a minimum commit age, not a longer
+# list of required job names — that list would drift the moment CI gains a job.
+pending=$(jq -r '[.check_runs[] | select(.status != "completed")] | length' <<<"$checks")
+if [ "$pending" -gt 0 ]; then
+	log "${remote:0:9} still has ${pending} check(s) running; waiting"
+	exit 0
+fi
+# `neutral` and `skipped` are passes: the watchdog jobs skip themselves on a merge, and
+# a skipped check is a check that decided it had nothing to say.
+failed=$(jq -r '[.check_runs[] | select(.conclusion | IN("success","neutral","skipped") | not) | .name] | join(", ")' <<<"$checks")
+if [ -n "$failed" ]; then
+	# No Telegram here on purpose. GitHub already tells whoever merged that main is red,
+	# and this script would repeat it every ten minutes until someone pushed a fix.
+	log "${remote:0:9} is red (${failed}); not deploying"
+	exit 0
+fi
+
+if [ "$armed" != "1" ]; then
+	log "WOULD DEPLOY ${deployed:0:9} -> ${remote:0:9} (AUTODEPLOY unset; set AUTODEPLOY=1 in ${ENV_FILE} to arm)"
+	exit 0
+fi
+
+log "deploying ${deployed:0:9} -> ${remote:0:9}"
+status "$remote" pending "release in progress"
+out=$(mktemp)
+"$RELEASE" "$APP" >"$out" 2>&1
+rc=$?
+
+if [ "$rc" -eq "$BUSY_EXIT" ]; then
+	log "a release is already running; skipping this tick"
+	status "$remote" pending "waiting for a release already in progress"
+	rm -f "$out"
+	exit 0
+fi
+
+subject=$(git -C "$CURRENT" log -1 --format=%s "$remote" 2>/dev/null || echo "$remote")
+if [ "$rc" -eq 0 ]; then
+	printf '%s 0\n' "$remote" >"$STATE_FILE"
+	log "released ${remote:0:9}"
+	status "$remote" success "deployed to production"
+	send "✅ freehire deployed ${remote:0:9} — ${subject}"
+else
+	printf '%s %s\n' "$remote" "$((attempts + 1))" >"$STATE_FILE"
+	log "release FAILED (exit ${rc}) for ${remote:0:9}"
+	status "$remote" failure "release failed (exit ${rc})"
+	# The tail is what a person needs to decide whether to re-run or to revert, and it
+	# is the difference between an alert and a notification that something happened.
+	send "🔴 freehire deploy FAILED (exit ${rc}) for ${remote:0:9} — ${subject}
+attempt $((attempts + 1)) of ${MAX_ATTEMPTS}; journalctl -u freehire-autodeploy
+
+$(tail -n 15 "$out")"
+fi
+rm -f "$out"
+exit "$rc"

--- a/deploy/bin/release.sh
+++ b/deploy/bin/release.sh
@@ -4,6 +4,24 @@
 # rebuilds the worker binaries, and repoints the `hire-current` symlink (workers
 # follow the active release). Old color stays warm for rollback.
 set -euo pipefail
+# One release at a time, enforced here rather than by convention.
+#
+# Until autodeploy.sh existed, "a person is running it" WAS the lock: nothing on this
+# host holds a file lock, and systemd's refusal to start a second instance of a oneshot
+# unit only ever protected the timer path. A timer that releases on its own introduces
+# the collision that could not happen before — a scheduled run starting while an
+# operator is mid-flip — and two releases sharing one inactive color would build over
+# each other's checkout and flip nginx at whichever finished first.
+#
+# `flock -n` so this fails immediately with something readable instead of a script that
+# appears to hang. Exit 3 is a distinct code on purpose: autodeploy.sh reads it as "not
+# my turn, try the next tick" rather than as a failed release, so a hand-run deploy does
+# not raise an alert. /var/lock is tmpfs, so a reboot mid-release cannot leave it held.
+exec 9>/var/lock/freehire-release.lock
+if ! flock -n 9; then
+  echo "release: another release is already running; refusing to start a second." >&2
+  exit 3
+fi
 app="${1:-freehire}"
 case "$app" in
   freehire) snip=freehire-upstream; apisvc=freehire-api; websvc=freehire-web; dir=hire; bin=hire-api; b_api=8081; b_web=8083; g_api=8082; g_web=8084 ;;

--- a/deploy/systemd/freehire-autodeploy.service
+++ b/deploy/systemd/freehire-autodeploy.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=freehire: release main to production once CI is green on it
+After=network-online.target
+Wants=network-online.target
+[Service]
+Type=oneshot
+# Runs as root, like release.sh itself, which it calls: the release drops to the freehire
+# user for every git and build step and needs root only to reload nginx and repoint the
+# color symlink. Reads AUTODEPLOY, GITHUB_STATUS_TOKEN, TELEGRAM_BOT_TOKEN and
+# SITE_ALERT_CHAT_ID from /opt/freehire/.env (0600).
+ExecStart=/opt/freehire/bin/autodeploy.sh
+# A release builds Go and the web bundle; anything under half an hour is normal, and
+# hanging forever is not. TimeoutStartSec turns a wedged release into a failed unit,
+# which is what the Telegram alert and the commit status are for.
+TimeoutStartSec=45min
+# NOT niced, unlike the alert timers: this is the release, and a release that loses the
+# CPU to a crawl fan-out just takes longer while production waits on it.

--- a/deploy/systemd/freehire-autodeploy.timer
+++ b/deploy/systemd/freehire-autodeploy.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=timer: freehire release-on-green check every 10 min
+[Timer]
+# Not on boot minute zero: the machine has just come up, the API may still be starting,
+# and a release is the last thing that should race that.
+OnBootSec=5min
+OnUnitActiveSec=10min
+# Deliberately NOT Persistent=true, unlike the alert timers. A missed tick is not work
+# to catch up on — the script reads the world fresh every run, so a downed machine that
+# comes back simply sees whatever main is at now. Replaying skipped ticks would only
+# stack releases.
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Deploying has been a person typing an ssh command. This makes it automatic, and the interesting decision is the **direction**: the host polls GitHub rather than GitHub pushing to the host.

## Why not a self-hosted runner

It is the obvious answer and it is the wrong one here. This repository is **public with 105 forks**, and a runner takes jobs from GitHub — a fork's pull request naming `runs-on: self-hosted` executes that fork's code on this machine. Secrets stay out of a fork's reach; the machine does not, and this machine is production.

An SSH key in GitHub secrets also works, and restricted with `command=` in `authorized_keys` it can only trigger a release. But it still puts a production credential somewhere the host does not control, and needs the inbound path to stay open.

Polling inverts both:

| | self-hosted runner | SSH key in Actions | this |
|---|---|---|---|
| GitHub can run arbitrary code on prod | **yes** | no | no |
| inbound path required | no | yes | no |
| production credential lives in GitHub | no | yes | **no** |
| what a leaked credential buys | — | trigger a release | draw a green tick |

## How it works

`freehire-autodeploy.timer`, every 10 minutes:

1. compare `origin/main` against the commit `hire-current` is serving
2. require **every** check run on that commit to have COMPLETED and passed
3. `release.sh`
4. commit status back to GitHub, and Telegram either way

It gates on **CI**, not on the merge: a squash merge pushes to main and the workflows start after it, so "main moved" would ship a commit whose tests are still running. Anything unfinished waits for the next tick — which is what makes ten minutes comfortable rather than slow.

Armed by `AUTODEPLOY=1` in `/opt/freehire/.env`. Without it the script logs what it *would* have done and exits 0, so the timer can be installed and watched before it is trusted — same opt-in shape as `site-alert.sh`'s channel.

## The Telegram message is load-bearing

There is no workflow run to be red here. Without the message this is one more thing that can fail unnoticed — and that is this project's recurring failure rather than a hypothetical: the `.env` split muted `remind`'s email for weeks, `INGEST_SLOTS` skipped 56% of runs, both with exit 0.

A commit that fails twice is left alone until main moves, so a broken build cannot rebuild itself every ten minutes. The count lives in `/var/lib/freehire/autodeploy.state`, which survives a reboot on purpose — a machine that reboots mid-incident must not come back and retry the same doomed build.

## release.sh takes a lock now

Until this timer existed, *"a person is running it"* was the only lock there was — nothing on this host holds one, and systemd's refusal to start a second `oneshot` instance only ever covered the timer path. A scheduled release starting while an operator is mid-flip is a collision **this change creates**, so it closes it. Exit 3 is a distinct code so `autodeploy.sh` reads a hand-run release as "not my turn" rather than as a failure worth alerting on.

## Verification

Run against the live host:

- the up-to-date path exits 0 quietly (`up to date at 67f0665b2`)
- the check-runs read parses the real API: 11 runs on the deployed commit, `pending=0`, `failed=[]`
- both scripts shellcheck-clean, `check:links` clean

Also fixed while writing it: `${gh_token:+-H "Authorization: ..."}` unquoted word-splits into four arguments and hands curl garbage. shellcheck does not flag it; it is an array now.

## Known, deliberately not guarded

A tick landing in the seconds between a push and its workflows being **created** would read a short list of check runs as a full one. The window is seconds against a ten-minute cadence, and a run that exists at all starts `queued`, which the pending check already waits on. The comment records that the fix would be a minimum commit age — not a list of required job names, which would drift the moment CI gains a job.

## Not in this PR

Installing it. The units and script have to be copied to the host (`deploy/` never deploys itself), and it needs `GITHUB_STATUS_TOKEN` — a fine-grained token with **Commit statuses: write** and **Checks: read** on this repository only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated production deployments that run every 10 minutes after startup.
  - Deployments proceed only when the latest commit passes all required checks.
  - Added safeguards to limit repeated failed attempts and provide deployment status alerts.
  - Added protection against overlapping releases to prevent conflicting deployments.

- **Documentation**
  - Updated deployment documentation with the automated deployment workflow, scheduling, safeguards, and current system inventory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->