### PR TITLE
Move theme toggle into the header menu, default site to light

### DIFF
--- a/web/src/app.html
+++ b/web/src/app.html
@@ -30,15 +30,13 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="freehire" />
     <script>
-      // No flash of the wrong theme: apply the persisted (or OS) choice before
-      // first paint. Mirrors theme.svelte.ts; the toggle re-syncs on mount.
+      // No flash of the wrong theme: apply the persisted choice before first
+      // paint. Defaults to light (no OS sniffing) — mirrors theme.svelte.ts;
+      // the toggle re-syncs on mount.
       (function () {
         try {
-          var m = localStorage.getItem('hire.theme');
-          var dark =
-            m === 'dark' ||
-            ((!m || m === 'system') && matchMedia('(prefers-color-scheme: dark)').matches);
-          if (dark) document.documentElement.classList.add('dark');
+          if (localStorage.getItem('hire.theme') === 'dark')
+            document.documentElement.classList.add('dark');
         } catch (e) {}
       })();
       // Same trick for the Product Hunt strip: it renders on the server (so it never

--- a/web/src/lib/components/HeaderMenu.svelte
+++ b/web/src/lib/components/HeaderMenu.svelte
@@ -46,8 +46,8 @@
   //
   // Two layouts from one markup: on mobile the panel is a full-screen drawer
   // (own top bar · scrollable sectioned links · pinned bottom action bar); on
-  // desktop it stays the small anchored dropdown. The theme+auth actions live in
-  // one snippet, rendered in the mobile bottom bar and inline for desktop.
+  // desktop it stays the small anchored dropdown. The theme toggle lives inside
+  // the dropdown for both layouts — the bar itself only carries profile/sign-in.
 
   let open = $state(false);
   let root = $state<HTMLElement | null>(null);
@@ -61,7 +61,8 @@
     'flex items-center gap-2 rounded-md px-4 min-h-11 text-base transition-colors hover:bg-accent hover:text-accent-foreground sm:min-h-0 sm:rounded-none sm:px-3 sm:py-2 sm:text-sm';
   const linkClass = (href: string) =>
     cn(rowBase, isActive(href) ? 'font-medium text-foreground' : 'text-muted-foreground');
-  // Shared icon-button treatment for the bar controls (menu + theme toggle).
+  // Shared icon-button treatment for the bar controls (Discord, profile/sign-in,
+  // menu).
   const iconButton =
     'size-9 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
 
@@ -137,10 +138,9 @@
   onkeydown={(e) => e.key === 'Escape' && (open = false)}
 />
 
-<!-- Theme toggle and auth action: defined once, reused across layouts. On mobile
-     both live deep in the drawer's bottom bar; on desktop the theme toggle is
-     pulled up to the header bar (see the inline cluster below) and only auth
-     stays in the dropdown. -->
+<!-- Theme toggle and auth action: defined once, reused across layouts. Both live
+     inside the dropdown — theme in the mobile bottom bar and, on desktop, inline
+     at the end of the link list alongside auth. -->
 {#snippet themeButton()}
   <button
     type="button"
@@ -179,9 +179,9 @@
 {/snippet}
 
 <div class="relative flex items-center gap-1" bind:this={root}>
-  <!-- Desktop bar order: GitHub stars, then the theme toggle (second), then the
-       menu button pinned to the far right. On mobile both GitHub and theme collapse
-       into the drawer (below), leaving just the menu button here. -->
+  <!-- Desktop bar order: GitHub stars, Discord, then profile/sign-in (second to
+       last), then the menu button pinned to the far right. On mobile all of these
+       collapse into the drawer (below), leaving just the menu button here. -->
   <GithubStars class="hidden sm:inline-flex" />
 
   <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external Discord invite, not an internal route -->
@@ -195,19 +195,27 @@
     <ProviderIcon provider="discord" />
   </a>
 
-  <!-- Desktop only: theme toggle sits second, before the menu button. -->
-  <button
-    type="button"
-    aria-label={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
-    onclick={() => themeStore.toggle()}
-    class={cn('hidden sm:inline-flex', iconButton)}
-  >
-    {#if isDark}
-      <Moon class="size-5" />
-    {:else}
-      <Sun class="size-5" />
-    {/if}
-  </button>
+  <!-- Desktop only: profile (signed in) or sign-in (signed out) sits before the
+       menu button. -->
+  {#if isAuthenticated()}
+    <a
+      href={resolve('/my/profile')}
+      aria-label="Profile"
+      title={email}
+      class={cn('hidden sm:inline-flex', iconButton)}
+    >
+      <CircleUser class="size-5" />
+    </a>
+  {:else}
+    <button
+      type="button"
+      aria-label="Sign in"
+      onclick={signIn}
+      class={cn('hidden sm:inline-flex', iconButton)}
+    >
+      <LogIn class="size-5" />
+    </button>
+  {/if}
 
   <button
     type="button"
@@ -322,10 +330,10 @@
           About
         </a>
 
-        <!-- Desktop-only: auth inline at the end of the dropdown (theme lives on
-             the bar). -->
+        <!-- Desktop-only: theme toggle + auth inline at the end of the dropdown. -->
         <div class="hidden sm:block">
           <div class="my-1 h-px bg-border"></div>
+          {@render themeButton()}
           {@render authButton()}
         </div>
       </div>

--- a/web/src/lib/theme.svelte.ts
+++ b/web/src/lib/theme.svelte.ts
@@ -1,6 +1,7 @@
-// Theme controller. Three modes — explicit `light` / `dark`, or `system` which
-// tracks the OS preference. Persisted in localStorage under `hire.theme`.
-// The root layout calls `initTheme()` on mount; components read `themeStore` and
+// Theme controller. Two explicit modes — `light` / `dark` — persisted in
+// localStorage under `hire.theme`. Defaults to `light` regardless of the OS
+// preference; `dark` only applies once the user explicitly toggles it. The
+// root layout calls `initTheme()` on mount; components read `themeStore` and
 // call `setMode(...)`. SSR-safe: every browser API is guarded by `browser`, so
 // importing this module on the server (via the header menu) never touches
 // window/localStorage. A no-FOUC inline script in app.html applies the class
@@ -10,30 +11,23 @@ import { browser } from '$app/environment';
 
 const STORAGE_KEY = 'hire.theme';
 
-export type ThemeMode = 'light' | 'dark' | 'system';
-
-const mq = browser ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+export type ThemeMode = 'light' | 'dark';
 
 function readStored(): ThemeMode {
-  if (!browser) return 'system';
+  if (!browser) return 'light';
   const raw = localStorage.getItem(STORAGE_KEY);
-  if (raw === 'light' || raw === 'dark' || raw === 'system') return raw;
-  return 'system';
+  return raw === 'dark' ? 'dark' : 'light';
 }
 
 function apply(mode: ThemeMode) {
-  if (!browser || !mq) return;
-  const dark = mode === 'dark' || (mode === 'system' && mq.matches);
-  document.documentElement.classList.toggle('dark', dark);
+  if (!browser) return;
+  document.documentElement.classList.toggle('dark', mode === 'dark');
 }
 
 class ThemeStore {
   mode = $state<ThemeMode>(readStored());
-  /** Live OS `prefers-color-scheme: dark` state, kept current by `initTheme`. */
-  systemDark = $state(mq ? mq.matches : false);
 
-  /** Effective dark state — explicit `dark`, or `system` resolving to the OS. */
-  isDark = $derived(this.mode === 'dark' || (this.mode === 'system' && this.systemDark));
+  isDark = $derived(this.mode === 'dark');
 
   setMode(next: ThemeMode) {
     this.mode = next;
@@ -47,8 +41,6 @@ class ThemeStore {
     apply(next);
   }
 
-  /** Binary flip: light <-> dark. `system` collapses to its effective value
-   *  first, so the first click always yields a concrete choice. */
   toggle() {
     this.setMode(this.isDark ? 'light' : 'dark');
   }
@@ -56,21 +48,11 @@ class ThemeStore {
 
 export const themeStore = new ThemeStore();
 
-/** Apply the stored theme and keep `system` mode tracking the OS preference.
- *  Browser-only (called from the layout's onMount). */
+/** Re-apply the stored theme. Browser-only (called from the layout's onMount) —
+ *  the singleton may have been first constructed on the server, where it
+ *  defaults to `light` without reading storage. */
 export function initTheme() {
-  if (!browser || !mq) return;
-  // Re-sync from storage in case the singleton was first constructed on the
-  // server (mode defaulted to 'system' there).
+  if (!browser) return;
   themeStore.mode = readStored();
-  themeStore.systemDark = mq.matches;
   apply(themeStore.mode);
-  const onChange = () => {
-    themeStore.systemDark = mq.matches;
-    if (themeStore.mode === 'system') apply('system');
-  };
-  mq.addEventListener('change', onChange);
-  if (import.meta.hot) {
-    import.meta.hot.dispose(() => mq.removeEventListener('change', onChange));
-  }
 }

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -36,8 +36,9 @@
       page.url.pathname.startsWith('/tailor/'),
   );
 
-  // Apply the persisted theme and start tracking the OS preference once mounted.
-  // A no-FOUC inline script in app.html already set the class before paint.
+  // Re-apply the persisted theme once mounted (the singleton may have been
+  // constructed on the server, defaulting to light). A no-FOUC inline script
+  // in app.html already set the class before paint.
   onMount(() => {
     initTheme();
     registerPwaServiceWorker();


### PR DESCRIPTION
## Summary
- Header bar swaps the moon/sun theme toggle for a profile icon (signed in → `/my/profile`) or a sign-in icon (signed out); the theme toggle moves into the dropdown menu, using the same spot mobile already had it.
- The site now always starts in light mode regardless of the OS `prefers-color-scheme` — dark only applies once a user explicitly picks it. Dropped the unused `system` theme mode (never exposed as an explicit UI choice) from `theme.svelte.ts` and the no-FOUC script in `app.html`.
- Fixed a bug caught in review: the bar's new "Sign in" icon now goes through the shared `signIn()` helper so it closes an already-open dropdown before opening the auth dialog.

## Test plan
- [x] `pnpm check` — 0 errors
- [x] `pnpm lint` — no new warnings in touched files
- [x] Verified live in a rebuilt Docker container (`localhost:8090`): signed-out/signed-in header rows, desktop dropdown + mobile drawer, theme toggle applies and persists across reload, default stays light even with `prefers-color-scheme: dark` emulated, profile icon navigates to `/my/profile`, bar sign-in now closes an open dropdown first

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Theme selection now supports explicit Light and Dark modes.
  - Theme controls are available in the desktop dropdown alongside profile or sign-in actions.
  - Desktop header actions now show a profile link for signed-in users or a sign-in button for signed-out users.

- **Changes**
  - The app now defaults to Light mode unless Dark mode is explicitly selected.
  - Operating system color preferences no longer automatically determine the theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->