### PR TITLE
Put what a reader does with a posting on one strip, beside the tabs

### DIFF
--- a/design-system/scripts/web-token-baseline.json
+++ b/design-system/scripts/web-token-baseline.json
@@ -55,7 +55,7 @@
   "web/src/lib/components/JobRow.svelte": 4,
   "web/src/lib/components/JobSeeAlso.svelte": 1,
   "web/src/lib/components/JobsView.svelte": 1,
-  "web/src/lib/components/JobView.svelte": 5,
+  "web/src/lib/components/JobView.svelte": 3,
   "web/src/lib/components/MatchAnalysisFull.svelte": 15,
   "web/src/lib/components/MatchSummary.svelte": 1,
   "web/src/lib/components/MySubmissionsView.svelte": 8,

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -5,6 +5,7 @@
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import { filterHref, formatSalary, summaryFacets } from '$lib/enrichment';
+  import { freshnessBadges } from '$lib/freshness';
   import { markViewed } from '$lib/viewedJobs.svelte';
   import { markSaved, markUnsaved } from '$lib/savedJobs.svelte';
   import { track } from '$lib/analytics';
@@ -77,6 +78,9 @@
   // job. A zero metric is omitted so the line never reads as a dead "0 views".
   const views = $derived(job.view_count ?? 0);
   const applies = $derived(job.applied_count ?? 0);
+  // "New" / "Be an early applicant" — see freshness.ts for why the posting date alone
+  // does not earn either.
+  const freshness = $derived(freshnessBadges(job.posted_at, job.reality, applies));
 
   // The content column is tabbed so "who are these people?" and "what will they ask
   // me?" are answerable without leaving the posting. Page state, not a route: the
@@ -283,6 +287,69 @@
   </Button>
 {/snippet}
 
+<!-- Save, a quiet peer of the apply CTA rather than the full-width button it was in the
+     sidebar: it belongs beside "Show", because keeping a job and opening it are the two
+     things a reader does with one. The filled bookmark is the state.
+     `iconOnly` is for the pinned header, whose one line already holds the company, the
+     title and the CTA; aria-label and the tooltip name the button either way. -->
+{#snippet saveButton(className = '', iconOnly = false)}
+  <Button
+    variant="ghost"
+    size="sm"
+    onclick={onSaveClick}
+    aria-pressed={saved}
+    aria-label={saved ? 'Remove from saved' : 'Save job'}
+    title={saved ? 'Saved' : 'Save'}
+    class={`shrink-0 gap-1.5 px-2 ${saved ? 'text-brand hover:text-brand' : 'text-muted-foreground'} ${className}`}
+  >
+    <Bookmark class="size-4 shrink-0 {saved ? 'fill-current' : ''}" aria-hidden="true" />
+    {#if !iconOnly}{saved ? 'Saved' : 'Save'}{/if}
+  </Button>
+{/snippet}
+
+<!-- Report, the same shape as Save and, like it, `ghost`: complaining about a posting is
+     the rarest thing on the strip, and a filled or outlined box would give it the
+     standing of the apply CTA beside it. -->
+{#snippet reportButton()}
+  <Button
+    variant="ghost"
+    size="sm"
+    onclick={onReportClick}
+    aria-label="Report this job"
+    title="Report this job"
+    class="shrink-0 gap-1.5 px-2 text-muted-foreground"
+  >
+    <Flag class="size-4 shrink-0" aria-hidden="true" />
+    Report
+  </Button>
+{/snippet}
+
+<!-- The action strip: everything a reader does WITH the posting — talk about it, flag
+     it, keep it, open it — on one line, sharing the tab row's rule. It carries the
+     rule itself (`border-b`) rather than sitting above one, so the line reads as a
+     single edge across the column: the strip and the TabStrip beside it are aligned on
+     their bottoms, and each draws its own half of it.
+     Rendered in two places, one visible at a time (the caller passes the display class):
+     the tab row on lg, and the company line below it, where the sidebar stacks between
+     the title and the description and a strip left on the tab row would put Save a whole
+     screen away from the job it saves. Only the apply CTA drops out below lg — the sticky
+     bottom bar carries it there, which is also what leaves the phone room for the labels. -->
+{#snippet actionStrip(className: string)}
+  <div class={`shrink-0 items-center gap-1.5 ${className}`}>
+    <a
+      class="inline-flex shrink-0 items-center gap-1.5 px-1 text-sm font-medium text-primary hover:underline"
+      href={resolve('/jobs/[slug]/discussion', { slug: job.public_slug })}
+      onclick={onDiscussionClick}
+    >
+      <MessageSquare class="size-4 shrink-0" aria-hidden="true" />
+      Discussion{threadCount ? ` · ${threadCount}` : ''}
+    </a>
+    {@render reportButton()}
+    {@render saveButton()}
+    {@render applyCta('md', 'ml-1 hidden shrink-0 lg:inline-flex')}
+  </div>
+{/snippet}
+
 <!-- The posting itself. A snippet because it is rendered either inside the Description
      tab panel or, on a job whose employer we don't know, straight into the column with
      no tab strip above it at all. -->
@@ -303,9 +370,9 @@
 {/snippet}
 
 <!-- Wide layout mirroring /jobs. The company line spans the very top; below it a
-     sticky left sidebar (salary + actions + metadata) starts level with the title,
+     sticky left sidebar (match + salary + metadata) starts level with the title,
      and the description reads in the right column. On mobile everything stacks:
-     company → title + apply CTA → metadata → description. -->
+     company + actions → title → metadata → description. -->
 <!-- Explicit rows: company + header sized to content, the content row flexible so
      when the sticky sidebar (which spans all three rows) is taller than the right
      column, the slack collects below the content instead of being spread as gaps
@@ -313,8 +380,8 @@
 <article
   class="flex flex-col gap-4 lg:grid lg:grid-cols-[20rem_minmax(0,1fr)] lg:grid-rows-[auto_auto_minmax(0,1fr)] lg:gap-x-6 lg:gap-y-4"
 >
-  <div class="flex items-center justify-between gap-3 lg:col-start-2 lg:row-start-1">
-    <div class="flex items-center gap-3">
+  <div class="flex flex-wrap items-center justify-between gap-3 lg:col-start-2 lg:row-start-1">
+    <div class="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2">
       <EntityLogo
         name={job.company || 'Unknown company'}
         src={companyLogoUrl(job.company) ?? undefined}
@@ -333,32 +400,47 @@
       <!-- Who backed the employer. The page has room the feed card does not, so the
            badge carries the brand name too and links to that collection's roles. -->
       <BackerBadge collections={job.collections} withLabel />
+
+      <!-- How long this has really been open, on the provenance line rather than under
+           the title: it is a fact ABOUT the posting, like the company and the backer,
+           and a chip on its own row read as a headline. The ghost checklist stays below
+           the title — it is a disclosure with a criteria list inside, not a chip, and it
+           supersedes this badge rather than joining it. -->
+      {#if !supersedesReality(job.ghost)}
+        <RealityBadge reality={job.reality} postedAt={job.posted_at} detailed />
+      {/if}
     </div>
 
-    <a
-      class="inline-flex shrink-0 items-center gap-1.5 text-sm font-medium text-primary hover:underline"
-      href={resolve('/jobs/[slug]/discussion', { slug: job.public_slug })}
-      onclick={onDiscussionClick}
-    >
-      <MessageSquare class="size-4" aria-hidden="true" /> Discussion{threadCount
-        ? ` · ${threadCount}`
-        : ''}
-    </a>
+    <!-- Below lg the strip belongs here, not on the tab row: the sidebar stacks between
+         the title and the description on a phone, so a strip left down there would put
+         Save a full screen of match card and metadata away from the job it saves.
+         `-mr-2` cancels the last button's own padding, so the label's right edge lines
+         up with the column's rather than sitting a hair inside it. -->
+    {@render actionStrip('-mr-2 flex w-full justify-end border-b border-border pb-2 lg:hidden')}
   </div>
 
   <header class="flex flex-col gap-3 lg:col-start-2 lg:row-start-2">
-    <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
-      <div class="flex flex-wrap items-center gap-2.5">
-        <h1 class="text-2xl font-semibold tracking-tight" lang={contentLang}>{job.title}</h1>
-        {#if applied}
-          <Chip variant="brand" class="gap-1.5 border-brand/30 font-semibold">
-            <CheckCircle2 class="size-3.5" aria-hidden="true" /> Applied
-          </Chip>
-        {/if}
-      </div>
-
-      <!-- Hidden below lg: on mobile the CTA lives in the sticky bottom bar instead. -->
-      {@render applyCta('md', 'hidden shrink-0 lg:inline-flex')}
+    <div class="flex flex-wrap items-center gap-2.5">
+      <h1 class="text-2xl font-semibold tracking-tight" lang={contentLang}>{job.title}</h1>
+      <!-- Freshness sits beside the title rather than in the metadata sidebar: it is the
+           one fact that changes whether the posting is worth reading at all, so the
+           reader meets it in the same glance as the role. Closed jobs are excluded — a
+           closed posting is never worth hurrying to. -->
+      {#if !job.closed_at}
+        {#each freshness as badge (badge.label)}
+          <!-- The tooltip rides a wrapper, not the Chip: the primitive takes only
+               variant/class/children, so a `title` passed to it would be dropped
+               silently and the badge would state a claim with its evidence gone. -->
+          <span title={badge.tooltip} class="inline-flex">
+            <Chip variant="brand" class="font-semibold">{badge.label}</Chip>
+          </span>
+        {/each}
+      {/if}
+      {#if applied}
+        <Chip variant="brand" class="gap-1.5 border-brand/30 font-semibold">
+          <CheckCircle2 class="size-3.5" aria-hidden="true" /> Applied
+        </Chip>
+      {/if}
     </div>
 
     <!-- The ghost row supersedes the reality chip (see JobRow). It states the signal
@@ -370,8 +452,6 @@
          carries the ceiling on the claim ("possibly", two of four), not the essay. -->
     {#if supersedesReality(job.ghost)}
       <GhostChecklist ghost={job.ghost} />
-    {:else}
-      <RealityBadge reality={job.reality} postedAt={job.posted_at} detailed />
     {/if}
 
     {#if job.referral_available && job.company_slug}
@@ -435,19 +515,6 @@
           {salary}
         </p>
       {/if}
-
-      <div class="flex flex-col gap-2 border-t border-border pt-4 first:border-t-0 first:pt-0">
-        <Button
-          variant="outline"
-          size="lg"
-          onclick={onSaveClick}
-          aria-pressed={saved}
-          class="w-full gap-2 rounded-xl border-transparent bg-brand-muted font-semibold text-brand-strong transition hover:bg-brand-muted hover:text-brand-strong hover:opacity-80"
-        >
-          <Bookmark class={saved ? 'size-[1.1rem] fill-current' : 'size-[1.1rem]'} />
-          {saved ? 'Saved' : 'Save'}
-        </Button>
-      </div>
 
       {#if facets.length}
         <dl class="flex flex-col gap-2 border-t border-border pt-4 text-sm first:border-t-0 first:pt-0">
@@ -524,16 +591,7 @@
       </div>
 
       <div class="border-t border-border pt-4 first:border-t-0 first:pt-0">
-        <div class="flex items-center justify-between gap-2">
-          <Button
-            variant="ghost"
-            size="sm"
-            onclick={onReportClick}
-            class="text-muted-foreground"
-          >
-            <Flag class="size-4" />
-            Report this job
-          </Button>
+        <div class="flex justify-center">
           <!-- Keyed on the slug so a client-side navigation to another job remounts
                the control and re-seeds its counts/highlight (JobView itself is not
                remounted on param change). -->
@@ -598,9 +656,14 @@
             <span class="px-1 text-muted-foreground" aria-hidden="true">·</span>
             <span class="font-semibold" lang={contentLang}>{job.title}</span>
           </p>
-          <!-- Hidden below lg for the same reason as the header's own copy: on mobile the
-               CTA is the sticky bottom bar, and two pinned buttons would fight. -->
-          {@render applyCta('md', 'hidden shrink-0 lg:inline-flex')}
+          <!-- Hidden below lg for the same reason as the action strip's own copy: on
+               mobile the CTA is the sticky bottom bar, and two pinned buttons would
+               fight. Save comes along, since this bar is what a reader has in front of
+               them for most of a description several screens long. -->
+          <div class="hidden shrink-0 items-center gap-2 lg:flex">
+            {@render saveButton('size-9 rounded-md px-0', true)}
+            {@render applyCta('md', 'shrink-0')}
+          </div>
         </div>
       </div>
     </div>
@@ -613,14 +676,28 @@
       </div>
     {/if}
 
+    <!-- Tabs left, actions right, one rule under both — and no gap between the halves,
+         because each draws its own stretch of that rule and a gap here is a gap in the
+         line (the strip's own left padding separates them instead). The row is rendered
+         whether or not there are tabs to put in it: a posting from an unknown employer
+         has only the description, and the rule then simply closes the actions off. -->
+    <div class="flex items-end justify-between">
+      {#if contentTabs.length > 1}
+        <TabStrip
+          tabs={contentTabs}
+          active={contentTab}
+          onSelect={(id) => (contentTab = id)}
+          label="Job details"
+          {panelId}
+          class="min-w-0 flex-1"
+        />
+      {:else}
+        <div class="min-w-0 flex-1 border-b border-border" aria-hidden="true"></div>
+      {/if}
+      {@render actionStrip('hidden border-b border-border pb-2 lg:flex')}
+    </div>
+
     {#if contentTabs.length > 1}
-      <TabStrip
-        tabs={contentTabs}
-        active={contentTab}
-        onSelect={(id) => (contentTab = id)}
-        label="Job details"
-        {panelId}
-      />
       <!-- One panel for every tab, its contents toggled by class rather than {#if}.
            Unmounting the inactive one would throw away the company the visitor already
            waited for, and re-render the description on every switch back. It also keeps

--- a/web/src/lib/components/MatchSummary.svelte
+++ b/web/src/lib/components/MatchSummary.svelte
@@ -74,9 +74,10 @@
   }
 </script>
 
+<!-- No visible heading: the button says what it does, and a section label plus a
+     sentence of explanation above it was three lines of chrome for one action. The
+     aria-label stays — a section still has to be named for assistive tech. -->
 <section class="flex flex-col gap-3 border-t border-border pt-4" aria-label="Analyze match">
-  <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Analyze match</p>
-
   {#if data && !data.has_cv}
     <div class="flex items-center justify-between gap-2">
       <span class="flex items-center gap-1.5 text-xs text-muted-foreground"><FileText class="size-3.5 shrink-0" />Upload a CV to analyse</span>
@@ -99,7 +100,6 @@
   {:else if allowanceRefused}
     <p class="text-sm text-muted-foreground">You've used today's job analyses. More at {resetsAtLabel(allowance)}.</p>
   {:else}
-    <p class="text-sm text-muted-foreground">How your CV reads against this role — fit, gaps, and ATS flags.</p>
     <Button
       variant="primary"
       size="lg"
@@ -110,17 +110,14 @@
       Tailor my CV
       <SquarePen class="size-[1.15rem]" aria-hidden="true" />
     </Button>
-    <!-- The line under the button says what happens next: for a signed-in viewer that's
-         what today still allows, for a guest that it runs on a CV they haven't given us
-         yet. A guest has no allowance to report, so the two never both apply.
+    <!-- The one line kept under the button: what today still allows. A guest is told
+         nothing here — the button opens sign-in, which says it better than a caption.
          Nothing left and no refusal is the shadow run — the analysis still goes, so it
          says nothing rather than "0 left" beside a button that works. -->
     {#if remaining(allowance)}
       <p class="text-xs text-muted-foreground">
         {remaining(allowance)} of today's job analyses left
       </p>
-    {:else if guest}
-      <p class="text-xs text-muted-foreground">Sign in and add a CV to run it.</p>
     {/if}
   {/if}
 </section>

--- a/web/src/lib/components/cv/CvList.svelte
+++ b/web/src/lib/components/cv/CvList.svelte
@@ -85,7 +85,7 @@
           </li>
           <li class="flex items-start gap-3">
             <span class="flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold">2</span>
-            <span>Press <strong class="font-medium text-foreground">Analyze match</strong> on the job page.</span>
+            <span>Press <strong class="font-medium text-foreground">Tailor my CV</strong> on the job page.</span>
           </li>
           <li class="flex items-start gap-3">
             <span class="flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold">3</span>

--- a/web/src/lib/freshness.test.ts
+++ b/web/src/lib/freshness.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import type { Reality } from './generated/contracts';
+import { daysSince, freshnessBadges } from './freshness';
+
+const daysAgo = (n: number) => new Date(Date.now() - n * 86_400_000).toISOString();
+
+const reality = (over: Partial<Reality> = {}): Reality => ({
+  class: 'fresh',
+  age_days: 1,
+  repost_count: 1,
+  mass_posting_count: 1,
+  fake_freshness: false,
+  ...over,
+});
+
+describe('daysSince', () => {
+  it('counts whole days', () => {
+    expect(daysSince(daysAgo(3))).toBe(3);
+  });
+
+  it('is null for a missing or unparseable date', () => {
+    expect(daysSince(null)).toBeNull();
+    expect(daysSince('not a date')).toBeNull();
+  });
+
+  it('clamps a source clock running ahead to zero rather than reporting the future', () => {
+    expect(daysSince(new Date(Date.now() + 6 * 3_600_000).toISOString())).toBe(0);
+  });
+});
+
+describe('freshnessBadges', () => {
+  it('marks a today-posted job new and invites an early applicant', () => {
+    expect(freshnessBadges(daysAgo(0), reality(), 0).map((b) => b.label)).toEqual([
+      'New',
+      'Be an early applicant',
+    ]);
+  });
+
+  it('keeps New past the early window but drops the invitation', () => {
+    expect(freshnessBadges(daysAgo(5), reality(), 0).map((b) => b.label)).toEqual(['New']);
+  });
+
+  it('drops the invitation once enough people have said they applied', () => {
+    expect(freshnessBadges(daysAgo(1), reality(), 9).map((b) => b.label)).toEqual(['New']);
+  });
+
+  it('says nothing after a week', () => {
+    expect(freshnessBadges(daysAgo(30), reality(), 0)).toEqual([]);
+  });
+
+  // The reason this module reads `reality` at all: a source that rewrites its posting
+  // date every crawl would otherwise stamp "New" on the oldest job in the catalogue.
+  it('says nothing when the reality signal distrusts the posting date', () => {
+    expect(freshnessBadges(daysAgo(0), reality({ fake_freshness: true }), 0)).toEqual([]);
+  });
+
+  it('says nothing when the job has been open long enough to be classified stale', () => {
+    expect(freshnessBadges(daysAgo(0), reality({ class: 'stale', age_days: 60 }), 0)).toEqual([]);
+  });
+
+  // A projection without counts carries no reality at all; the date then stands alone.
+  it('trusts the date when no reality signal was computed', () => {
+    expect(freshnessBadges(daysAgo(1), null, 0).map((b) => b.label)).toEqual([
+      'New',
+      'Be an early applicant',
+    ]);
+  });
+
+  it('says nothing without a posting date', () => {
+    expect(freshnessBadges(null, reality(), 0)).toEqual([]);
+  });
+
+  it('states what the applied count actually counted', () => {
+    const [, early] = freshnessBadges(daysAgo(1), reality(), 2);
+    expect(early?.tooltip).toContain('2 people have told us they applied');
+  });
+});

--- a/web/src/lib/freshness.ts
+++ b/web/src/lib/freshness.ts
@@ -1,0 +1,80 @@
+import type { Reality } from './generated/contracts';
+
+/** A badge on the posting's title row: how recently it went up, and whether anyone
+ *  has beaten the reader to it. Both read as encouragement, so both are held to a
+ *  higher bar than "the number looks small" — see `freshnessBadges`. */
+export interface FreshnessBadge {
+  /** Chip text. */
+  label: string;
+  /** The fact behind it, on hover — the claim's own limits, not a restatement. */
+  tooltip: string;
+}
+
+/** A posting is "new" for a week. Longer and the word stops meaning anything on a
+ *  board where the median role is open for a month. */
+const NEW_DAYS = 7;
+/** "Early applicant" is a claim about a window, not about a count: three days is
+ *  as far as we are willing to make it. */
+const EARLY_DAYS = 3;
+/** …and only while the field is genuinely still empty. This counts the people who
+ *  told US they applied, which is a floor on the real number and never a measure of
+ *  it, so the threshold is small enough that the claim survives being wrong by an
+ *  order of magnitude. */
+const EARLY_APPLIES = 3;
+
+/** daysSince returns whole days between `iso` and now, or null when the date is
+ *  missing or unparseable. Clamped at zero: a source clock running a few hours ahead
+ *  is ordinary and must not read as a posting from the future. */
+export function daysSince(iso?: string | null): number | null {
+  if (!iso) return null;
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return null;
+  return Math.max(0, Math.floor((Date.now() - t) / 86_400_000));
+}
+
+function postedPhrase(days: number): string {
+  if (days === 0) return 'posted today';
+  if (days === 1) return 'posted yesterday';
+  return `posted ${days} days ago`;
+}
+
+/** The early-applicant tooltip. It names who was counted, because the count is our own
+ *  applied-marks and not the employer's inbox. */
+function appliedPhrase(count: number, posted: string): string {
+  if (count === 0) return `Nobody has told us they applied to this job yet (${posted}).`;
+  const who = count === 1 ? 'person has' : 'people have';
+  return `${count} ${who} told us they applied to this job (${posted}).`;
+}
+
+/** freshnessBadges renders the "New" / "Be an early applicant" pair for a posting.
+ *
+ *  The posting date alone does not earn either badge. `reality` is the system's own
+ *  reading of how long this job has actually been open, and it knows the case this
+ *  page would otherwise walk into: a role open for eight months whose source rewrites
+ *  its posting date every crawl (`fake_freshness`). Trusting `posted_at` there would
+ *  print "New" on the oldest job in the catalogue — so a posting the signal has
+ *  classified as anything but fresh gets no badge at all, and neither does one whose
+ *  date the signal distrusts. When the signal is absent (a projection that carries no
+ *  counts) the date stands on its own; that is the ordinary case for a job we have
+ *  only just met.
+ *
+ *  `appliedCount` is the number of signed-in users who marked this job applied HERE.
+ *  It cannot see the employer's own inbox, so "be an early applicant" is offered as
+ *  an invitation and the tooltip says exactly what was counted. */
+export function freshnessBadges(
+  postedAt?: string | null,
+  reality?: Reality | null,
+  appliedCount = 0,
+): FreshnessBadge[] {
+  if (reality && (reality.class !== 'fresh' || reality.fake_freshness)) return [];
+  const days = daysSince(postedAt);
+  if (days === null || days > NEW_DAYS) return [];
+
+  const posted = postedPhrase(days);
+  const badges: FreshnessBadge[] = [{ label: 'New', tooltip: posted }];
+
+  if (days <= EARLY_DAYS && appliedCount <= EARLY_APPLIES) {
+    badges.push({ label: 'Be an early applicant', tooltip: appliedPhrase(appliedCount, posted) });
+  }
+  return badges;
+}


### PR DESCRIPTION
## What

Puts the three things a reader does with a posting — discuss it, flag it, keep it — on one strip beside the content tabs, adds a freshness badge pair to the title, and takes two captions out of the match card.

## Why

Save was a full-width button in the sidebar and Report sat beside the votes at the bottom of it, so the actions were scattered down a column the reader has to leave the text to reach. They now share the tab row and draw their own half of its rule. The row renders even on a posting with no tabs — the rule then simply closes the actions off.

Below `lg` the strip rides the company line instead: the sidebar stacks between the title and the description on a phone, so a strip left on the tab row would put Save a screenful of match card and metadata away from the job it saves. The apply CTA is the one control that drops out there, because the sticky bottom bar already carries it — which is also what leaves the phone room for the labels.

The reality chip (`Open 20d`) moves up to the company line for the same reason: it is a fact *about* the posting, like the employer and the backer, and a chip alone on the row under the title read as a headline. The ghost checklist stays put — it is a disclosure with a criteria list inside, and it supersedes the chip rather than joining it.

## The badges, and what they are allowed to claim

`New` and `Be an early applicant` sit beside the title. Neither is earned by the posting date alone.

`reality` is the system's own reading of how long a job has really been open, and it knows the case this would otherwise walk straight into: a role open eight months whose source rewrites its posting date every crawl (`fake_freshness`). A posting classified anything but `fresh`, or one whose date the signal distrusts, gets no badge — so the word cannot land on the oldest rows in the catalogue. When no reality signal was computed at all the date stands on its own, which is the ordinary case for a job we have only just met.

The count behind the invitation is our own applied-marks, never the employer's inbox. It is a floor on the real number and not a measure of it, so the threshold is small (≤3 marks, ≤3 days) and the tooltip states exactly what was counted.

`web/src/lib/freshness.ts` holds the rules with 12 tests over the thresholds, the clock-skew clamp, and both refusal paths.

## Also

- The match card loses the `Analyze match` heading and its two captions; the button says what it does. The CV list's step 2 named that heading, so it now names the button.
- `JobView.svelte`'s token-coverage baseline drops 5 → 3.

## Testing

- `pnpm vitest run src/lib` — 1319 pass (12 new).
- `svelte-check`, `eslint` clean on the touched files.
- Verified in a browser at 1440px, 390px, and in the pinned header at both: no horizontal overflow, the rule reads as one edge, and the pinned bar shows Save icon-only so the label cannot collide with the CTA.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added freshness badges to job listings, including “New” and “Be an early applicant” indicators.
  * Consolidated job actions across the tab row, company details, and pinned header, including Save, Report, Discussion, and Apply controls.
  * Added an icon-only Save control to the pinned header.
* **Updates**
  * Moved the Reality indicator beside company information.
  * Updated tailored-CV onboarding instructions to reference “Tailor my CV.”
  * Simplified match-summary and guest-facing text below the Tailor button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->