### PR TITLE
Invite a guest to sign in below the job card's blurred match teaser

### DIFF
--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import { resolve } from '$app/paths';
-  import { Bookmark, Eye, EyeOff } from '@lucide/svelte';
+  import { Bookmark, Eye, EyeOff, FileText, Lock } from '@lucide/svelte';
   import { companyLogoUrl } from '$lib/logo';
   import CountryFlagStack from './CountryFlagStack.svelte';
   import JobMatchBar from './JobMatchBar.svelte';
@@ -224,9 +224,9 @@
        The name truncates to a single line, so a long company (e.g. "Veterinary
        Emergency Group (VEG)") keeps the logo centred and the card rhythm even
        instead of wrapping into a ragged multi-line header. -->
-  <!-- pr-9 reserves the top-right corner for the save button (an overlay outside
+  <!-- pr-8 reserves the top-right corner for the save button (an overlay outside
        this link), so the timestamp never slides under it. -->
-  <div class="flex items-center justify-between gap-3 pr-9">
+  <div class="flex items-center justify-between gap-3 pr-8">
     <div class="flex min-w-0 items-center gap-2">
       <EntityLogo
         name={job.company || 'Unknown company'}
@@ -350,7 +350,9 @@
       {/if}
     </div>
     {#if salary}
-      <span class="shrink-0 text-base font-bold tabular-nums tracking-tight">{salary}</span>
+      <span class="self-end shrink-0 text-sm font-semibold tabular-nums tracking-tight sm:self-auto">
+        {salary}
+      </span>
     {/if}
   </div>
 
@@ -360,6 +362,26 @@
        other and render a genuine score under a blur. `gutterRight` keeps the percent
        clear of the feed's bottom-right hide control. -->
   <JobMatchBar match={match ?? teaser} blurred={!match && !!teaser} gutterRight={!!onHide} />
+  {#if teaser}
+    <!-- The sighted invitation, under the blurred strip rather than over it — the same
+         icon + line the job page's own match block uses below its teaser. `aria-hidden`
+         because the accessible equivalent is the sr-only span below, outside the <a> —
+         this text sits inside the card-wide link and must not join its accessible name.
+         No button here (unlike the job page's): a second activation target inside this
+         <a> would be invalid markup, and the card itself is already the link. -->
+    <div
+      class={['mt-1.5 flex items-center justify-center gap-1.5 text-xs text-muted-foreground', onHide && 'pr-9']}
+      aria-hidden="true"
+    >
+      {#if matchState === 'guest'}
+        <Lock class="size-3.5 shrink-0" />
+        Sign in to see your match
+      {:else}
+        <FileText class="size-3.5 shrink-0" />
+        Upload your CV to see your match
+      {/if}
+    </div>
+  {/if}
 </a>
 
 {#if teaser}
@@ -396,7 +418,7 @@
   aria-label={saved ? 'Remove from saved' : 'Save job'}
   title={saved ? 'Saved' : 'Save'}
   class={[
-    'absolute right-2.5 top-2.5 grid size-8 place-items-center rounded-lg transition hover:bg-accent hover:text-brand disabled:pointer-events-none disabled:opacity-50',
+    'absolute right-2.5 top-4 grid size-8 place-items-center rounded-lg transition hover:bg-accent hover:text-brand disabled:pointer-events-none disabled:opacity-50',
     saved ? 'text-brand' : 'text-muted-foreground',
   ]}
 >

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -136,6 +136,13 @@
       : null,
   );
 
+  // One copy of the invitation, shared by the sighted line under the blurred strip and
+  // the sr-only span that stands in for it — so the two can't drift into different
+  // wording for the same call to action.
+  const matchInvite = $derived(
+    matchState === 'guest' ? 'Sign in to see your match' : 'Upload your CV to see your match',
+  );
+
   // A chip is red when the viewer's own profile lacks the skill, or — under the teaser —
   // when the teaser marked it missing. Both tints come from the same source as the strip
   // below, so the chips and the percentage can never tell different stories.
@@ -375,11 +382,10 @@
     >
       {#if matchState === 'guest'}
         <Lock class="size-3.5 shrink-0" />
-        Sign in to see your match
       {:else}
         <FileText class="size-3.5 shrink-0" />
-        Upload your CV to see your match
       {/if}
+      {matchInvite}
     </div>
   {/if}
 </a>
@@ -390,11 +396,7 @@
        outside the card link deliberately: `sr-only` is clip-based, not display:none, so
        inside the <a> it would join the link's accessible name and every card in the feed
        would announce a sign-in instruction that the link doesn't carry out. -->
-  <span class="sr-only">
-    {matchState === 'guest'
-      ? 'Sign in to see how this job matches your profile'
-      : 'Add your skills to see how this job matches your profile'}
-  </span>
+  <span class="sr-only">{matchInvite}</span>
 {/if}
 
 {#if footer}

--- a/web/src/lib/enrichment.test.ts
+++ b/web/src/lib/enrichment.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { formatSalary } from './enrichment';
+import type { Enrichment } from './types';
+
+describe('formatSalary', () => {
+  it('returns null when neither bound is stated', () => {
+    expect(formatSalary({} as Enrichment)).toBeNull();
+  });
+
+  it('compacts a full range to K, with the currency trailing', () => {
+    expect(
+      formatSalary({ salary_min: 30_000, salary_max: 50_000, salary_currency: 'GBP' } as Enrichment),
+    ).toBe('30K – 50K £');
+  });
+
+  it('rounds a non-round thousand to the nearest K', () => {
+    expect(formatSalary({ salary_min: 45_500, salary_max: 45_500 } as Enrichment)).toBe('46K – 46K');
+  });
+
+  it('compacts millions with one decimal only when not round', () => {
+    expect(formatSalary({ salary_min: 1_200_000, salary_max: 2_000_000 } as Enrichment)).toBe(
+      '1.2M – 2M',
+    );
+  });
+
+  it('compacts billions the same way as millions', () => {
+    expect(formatSalary({ salary_min: 1_000_000_000, salary_max: 1_500_000_000 } as Enrichment)).toBe(
+      '1B – 1.5B',
+    );
+  });
+
+  it('leaves sub-thousand amounts (e.g. an hourly rate) uncompacted', () => {
+    expect(
+      formatSalary({ salary_min: 40, salary_max: 60, salary_currency: 'USD', salary_period: 'hour' } as Enrichment),
+    ).toBe('40 – 60 $ / hr');
+  });
+
+  it('renders a min-only floor as "from …"', () => {
+    expect(formatSalary({ salary_min: 100_000, salary_currency: 'USD' } as Enrichment)).toBe(
+      'from 100K $',
+    );
+  });
+
+  it('renders a max-only ceiling as "up to …"', () => {
+    expect(formatSalary({ salary_max: 80_000, salary_currency: 'EUR' } as Enrichment)).toBe(
+      'up to 80K €',
+    );
+  });
+
+  it('falls back to the raw currency code when it is not in the symbol map', () => {
+    expect(formatSalary({ salary_min: 10_000, salary_max: 20_000, salary_currency: 'PLN' } as Enrichment)).toBe(
+      '10K – 20K PLN',
+    );
+  });
+});

--- a/web/src/lib/enrichment.ts
+++ b/web/src/lib/enrichment.ts
@@ -60,9 +60,13 @@ export function filterHref(param: string, value: string): string {
   return `/?${param}=${encodeURIComponent(value)}`;
 }
 
-/** Group thousands with thin spaces, matching the salary line in the design. */
-function groupThousands(n: number): string {
-  return n.toLocaleString('en-US').replace(/,/g, ' ');
+/** Compact an amount the way companyDetails.ts's funding figures already read:
+ *  1_200_000 → "1.2M", 30_000 → "30K", below a thousand printed in full. */
+function compactAmount(n: number): string {
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(n % 1_000_000_000 ? 1 : 0)}B`;
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(n % 1_000_000 ? 1 : 0)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
+  return n.toLocaleString('en-US');
 }
 
 /**
@@ -82,11 +86,11 @@ export function formatSalary(e: Enrichment): string | null {
 
   let amount: string;
   if (salary_min != null && salary_max != null) {
-    amount = `${groupThousands(salary_min)} – ${groupThousands(salary_max)}`;
+    amount = `${compactAmount(salary_min)} – ${compactAmount(salary_max)}`;
   } else if (salary_min != null) {
-    amount = `from ${groupThousands(salary_min)}`;
+    amount = `from ${compactAmount(salary_min)}`;
   } else {
-    amount = `up to ${groupThousands(salary_max as number)}`;
+    amount = `up to ${compactAmount(salary_max as number)}`;
   }
 
   return tail ? `${amount} ${tail}` : amount;


### PR DESCRIPTION
## Summary
- The job-list card's blurred skill-match teaser had no visible invitation for sighted users (only an `sr-only` string) — add the same lock/CV icon + line the job page's own match block already uses, placed under the blurred strip.
- Compact the card's salary line to K/M/B (`30000` → `30K`, `1200000` → `1.2M`) instead of full digit strings, shared by `enrichment.ts`'s `formatSalary` (also used by the job page and preview); lighter weight and right-aligned on the phone-width stacked layout.
- Nudge the save button down 6px so it lines up with the timestamp beside it.

## Test plan
- [x] `pnpm test` — 1339 tests pass, including new `enrichment.test.ts` (previously no coverage on `formatSalary`)
- [x] `pnpm check` (svelte-check) — 0 errors
- [x] `eslint` on changed files — clean
- [x] Visually verified guest-teaser, min-only, hourly-rate, and millions salary variants on desktop and mobile viewports via a throwaway preview harness (not included in this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job listings now show an inline prompt encouraging guests and users without profiles to continue their application journey.
  * Added visual indicators for locked content and attached documents in job cards.

* **Improvements**
  * Salary ranges now use compact, readable formats such as “30K” and “1.2M,” including clear “from” and “up to” labels.
  * Updated job card spacing and typography for improved readability.
  * Adjusted the save button placement within job cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->