### PR TITLE
An unbuilt suggestion dictionary is no suggestions, not a 500

### DIFF
--- a/internal/search/search/suggest_index.go
+++ b/internal/search/search/suggest_index.go
@@ -2,7 +2,9 @@ package search
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/meilisearch/meilisearch-go"
 )
@@ -115,6 +117,16 @@ func AllSuggestions[T any](ctx context.Context, c *Client) ([]T, error) {
 	return SearchSuggestions[T](ctx, c, "", "", maxDictionary)
 }
 
+// isIndexMissing reports whether the dictionary index does not exist.
+//
+// By status rather than by the engine's error code: the SDK keeps that code in an
+// unexported type, so a check written against it could never be tested. A 404 from a
+// search against this one index has a single meaning anyway.
+func isIndexMissing(err error) bool {
+	var me *meilisearch.Error
+	return errors.As(err, &me) && me.StatusCode == http.StatusNotFound
+}
+
 // SearchSuggestions runs a query against the dictionary and decodes the hits into the
 // caller's document type.
 //
@@ -130,6 +142,14 @@ func SearchSuggestions[T any](ctx context.Context, c *Client, query, filter stri
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, fmt.Errorf("search: suggest: %w", ctxErr)
+		}
+		// A dictionary that has not been built yet is "no suggestions", not a fault.
+		// Between a deploy and the first cmd/build-suggestions run the index does not
+		// exist, and the box asks for a completion on every settled keystroke — so
+		// surfacing this as an error made that whole window a broken-looking dropdown
+		// and a stream of 500s. Found in production, not in a test.
+		if isIndexMissing(err) {
+			return nil, nil
 		}
 		if isBadRequest(err) {
 			return nil, fmt.Errorf("search: suggest: %w: %v", ErrBadQuery, err)

--- a/internal/search/search/suggest_index_test.go
+++ b/internal/search/search/suggest_index_test.go
@@ -1,0 +1,40 @@
+package search
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/meilisearch/meilisearch-go"
+)
+
+// A dictionary that has not been built yet is "no suggestions", not a server fault.
+//
+// Found on production: the endpoint answered 500 to every completion between the
+// deploy and the first cmd/build-suggestions run, because the index did not exist yet.
+// The box fires one of those per settled keystroke, so the whole window would have
+// been a broken-looking dropdown and a stream of errors in the tracker — for a state
+// that is simply "not built".
+func TestIsIndexMissing(t *testing.T) {
+	// A 404 from a search against this index has one meaning. The status is the whole
+	// test rather than the API's error code because the SDK keeps that code in an
+	// unexported type, so no caller can construct one — a check written against it
+	// could never be tested.
+	if !isIndexMissing(&meilisearch.Error{StatusCode: http.StatusNotFound}) {
+		t.Error("a missing index must read as an empty dictionary")
+	}
+
+	// Everything else stays a real failure. Swallowing those would turn an outage into
+	// a box that quietly offers nothing.
+	for name, err := range map[string]error{
+		"bad request":       &meilisearch.Error{StatusCode: http.StatusBadRequest},
+		"engine error":      &meilisearch.Error{StatusCode: http.StatusInternalServerError},
+		"wrong key":         &meilisearch.Error{StatusCode: http.StatusForbidden},
+		"transport failure": errors.New("connection refused"),
+		"nil":               nil,
+	} {
+		if isIndexMissing(err) {
+			t.Errorf("%s must not read as a missing index", name)
+		}
+	}
+}


### PR DESCRIPTION
Found by verifying #2358 on production, which is the only place it could be found.

Between the deploy and the first `cmd/build-suggestions` run the `suggestions`
index does not exist, so `GET /api/v1/suggest?q=…` answered **500**. The search
box asks for a completion on every settled keystroke, so that whole window — a
day, until the timer first fires — is a broken-looking dropdown and a stream of
errors in the tracker, for a state that is simply "not built yet".

```
$ curl -s -o /dev/null -w '%{http_code}' 'https://freehire.me/api/v1/suggest?q=product+own'
500
```

Detected by HTTP status rather than by the engine's error code: the SDK keeps
that code in an unexported type, so no caller can construct one and a check
written against it could never be tested. A 404 from a search against this one
index has a single meaning anyway.

Every other failure stays a failure — an unreachable engine, a rejected filter, a
wrong key. Swallowing those would turn an outage into a box that quietly offers
nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Search suggestions now return an empty result when the suggestion index is unavailable, instead of displaying an error.
  - Other search service errors continue to be handled normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->