### PR TITLE
Build the discussions index without CONCURRENTLY, and clear the carcass it left

### DIFF
--- a/migrations/0126_threads_open_created_idx.sql
+++ b/migrations/0126_threads_open_created_idx.sql
@@ -1,5 +1,3 @@
--- migrate: no-transaction
---
 -- The global discussions feed (GET /api/v1/threads/recent, /discussions): every open
 -- thread across every subject, newest first, keyset-paged on (created_at, id).
 --
@@ -11,9 +9,35 @@
 -- Partial on status = 'open' for the same reason as the subject index: a closed thread
 -- is hidden from every default listing, so it never belongs in the hot index.
 --
--- CONCURRENTLY (hence the no-transaction marker) is the convention this repo settled on
--- for an index a running prod will build — it costs a second pass and no exclusive lock.
--- The table is tiny today, so the cost is nil either way and the habit is what matters.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS threads_open_created_idx
+-- NOT concurrently, and the DROP above it is why. The first version of this file used
+-- CREATE INDEX CONCURRENTLY — the shape this repo settled on for an index a running
+-- prod builds — and it failed the release on 2026-09-03 with SQLSTATE 55P03, a lock
+-- timeout. CONCURRENTLY does not merely take a weaker lock: before building, it WAITS
+-- for every transaction holding an older snapshot to finish, and migrate's 5s
+-- lock_timeout applies to that wait. Two similar-jobs backfill transactions were six
+-- minutes into their run, so the wait could never complete inside five seconds. The
+-- release aborted correctly and left the live colour untouched, but a failed
+-- CONCURRENTLY leaves the index behind with indisvalid = false, and prod is carrying
+-- exactly that carcass now.
+--
+-- `threads` holds three rows. A plain CREATE INDEX takes ACCESS EXCLUSIVE on it for as
+-- long as indexing three rows takes, and nothing else contends for that table — which
+-- makes CONCURRENTLY here pure cost: it buys no availability worth having and imports
+-- a dependency on how long an unrelated backfill's transaction happens to be. The
+-- concurrent shape is right for jobs (7.4M rows, read on every request); it is the
+-- wrong reflex on a table this size, and reaching for it out of habit is what cost a
+-- release. Revisit if this table ever grows.
+--
+-- No `migrate: no-transaction` marker, so the two statements are one transaction: the
+-- invalid index cannot be dropped without its replacement landing.
+
+-- Drops the invalid index the failed CONCURRENTLY left on prod. Unconditional rather
+-- than guarded, because an IF NOT EXISTS on the CREATE alone would find that carcass,
+-- skip, and leave an index nothing can use. A no-op on a fresh volume.
+-- squawk-ignore require-concurrent-index-deletion -- three rows, and a concurrent drop cannot run inside this file's transaction
+DROP INDEX IF EXISTS threads_open_created_idx;
+
+-- squawk-ignore require-concurrent-index-creation -- three rows; CONCURRENTLY here is what failed the 2026-09-03 release, see above
+CREATE INDEX IF NOT EXISTS threads_open_created_idx
     ON public.threads (created_at DESC, id DESC)
     WHERE status = 'open';


### PR DESCRIPTION
Follow-up to #2364. The release that shipped it failed applying its migration.

## What happened

```
migrate: apply 0126_threads_open_created_idx.sql:
  ERROR: canceling statement due to lock timeout (SQLSTATE 55P03)
[release:freehire] migrations FAILED — not touching blue or the live color
```

`release.sh` did the right thing: it aborted before flipping, and the live
colour never moved.

## Why CONCURRENTLY failed on a three-row table

It isn't about the lock strength. Before building, `CREATE INDEX CONCURRENTLY`
**waits for every transaction holding an older snapshot to finish**, and
`migrate`'s 5s `lock_timeout` applies to that wait. At the time, two
similar-jobs backfill transactions were six minutes into their runs:

```
   pid   | state  |    xact_age     | query
 2470369 | active | 00:06:08.55     | SelectJobsNeedingSimilarBackfill
 2610512 | active | 00:06:08.55     | SelectJobsNeedingSimilarBackfill
```

The wait could never complete inside five seconds, on any retry, for as long as
that worker keeps a transaction open that long.

## The second problem it left behind

A failed `CREATE INDEX CONCURRENTLY` leaves the index in place, invalid — and
prod is carrying exactly that:

```
 threads_open_created_idx | indisvalid = f
```

A re-run's `IF NOT EXISTS` would find that carcass, skip, and leave an index
nothing can use. So the file now drops it unconditionally first.

## The fix

`threads` holds three rows. A plain `CREATE INDEX` holds ACCESS EXCLUSIVE for
as long as indexing three rows takes, and nothing else contends for that table.
CONCURRENTLY bought no availability worth having here and imported a dependency
on how long an unrelated backfill's transaction happens to be. The concurrent
shape stays right for `jobs`; it was the wrong reflex at this size, and the
file's own comment said "the habit is what matters" — which is precisely the
reasoning that cost the release.

Dropping the `migrate: no-transaction` marker makes the drop and the create one
transaction, so the invalid index cannot be removed without its replacement
landing.

**This edits the file rather than adding another because it is NOT applied** —
`schema_migrations` has no row for it, the run failed before recording. The
"never edit an applied migration" rule is intact.

## Verification

Run twice against a real Postgres, including from the invalid-index state:
both passes clean, `indisvalid = t` after. squawk reports 0 issues, with two
suppressions each carrying its reason on the line above the statement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a database migration that could fail or leave behind an incomplete index during deployment.
  * Improved index creation reliability by ensuring cleanup and creation occur together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->