### PR TITLE
Close the discussions-feed change: verified on prod

### DIFF
--- a/openspec/changes/add-discussions-feed/tasks.md
+++ b/openspec/changes/add-discussions-feed/tasks.md
@@ -63,5 +63,8 @@
 - [x] 7.2 `go vet -tags=integration ./...`, then the tagged suite for the
   packages touched
 - [x] 7.3 `pnpm -C web check` / lint, `pnpm check:links`
-- [ ] 7.4 Verify the feed and the fixed "Load more" in a browser against prod
-  after deploy
+- [x] 7.4 Verify the feed and the fixed "Load more" in a browser against prod
+  after deploy. Live 2026-09-03: /discussions serves its three threads with
+  resolved subject names and logos, and the single-thread subject page no
+  longer draws "Load more". Took three releases — see 0126/0127 for the
+  CONCURRENTLY lock timeout and the invalid index it left behind.


### PR DESCRIPTION
Last open box in `openspec/changes/add-discussions-feed/tasks.md`.

Verified live on 2026-09-03:
- `/discussions` serves its three threads, each naming its subject with the real company logo
- the single-thread subject page no longer draws a `Load more` that fetches nothing
- `threads_open_created_idx` is `indisvalid = t` after #2366

Took three releases. #2365 and #2366 carry why: a `CREATE INDEX CONCURRENTLY` lock timeout, and the invalid index it left that the host's own autodeploy then recorded as applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Verified in production that the discussions feed and its “Load more” functionality work as expected.

- **Documentation**
  - Updated the verification checklist with the production validation date and results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->