### PR TITLE
Ask the index for the attribute it has, not the parameter it takes

### DIFF
--- a/cmd/build-suggestions/facets_test.go
+++ b/cmd/build-suggestions/facets_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/strelov1/freehire/internal/search/search"
+)
+
+// The first production build failed here, and nothing in the unit suite could have
+// caught it: the builder asks a live Meilisearch for a facet distribution, and the
+// engine refused with
+//
+//	Attribute `role` is not filterable
+//
+// because the filter PARAMETER is `role` while the index ATTRIBUTE is `roles`. Two
+// names for one concept, and the builder had the wrong one written out as a literal.
+//
+// This does not need an engine. It only has to assert that the three names the
+// builder asks for come from the table the filter builder already uses — so a
+// renamed attribute breaks the build rather than the 06:46 timer.
+func TestFacetNamesComeFromTheFilterTable(t *testing.T) {
+	for _, param := range []string{"role", "skills", "category"} {
+		attr, ok := search.StringFacets[param]
+		if !ok {
+			t.Fatalf("%q is not a known facet — the builder asks for a distribution nothing serves", param)
+		}
+		if attr == "" {
+			t.Errorf("%q maps to an empty attribute", param)
+		}
+	}
+
+	// The one that actually bit, named explicitly: it is the whole reason this test
+	// exists, and a reader deserves to see the difference rather than infer it.
+	if got := search.StringFacets["role"]; got == "role" {
+		t.Errorf("role maps to %q — if the attribute ever equals the param, this test has stopped proving anything", got)
+	}
+}

--- a/cmd/build-suggestions/main.go
+++ b/cmd/build-suggestions/main.go
@@ -130,8 +130,14 @@ func gather(ctx context.Context, q *db.Queries, client *search.Client, floors co
 		firms = append(firms, suggest.Company{Slug: c.Slug, Name: c.Name, Jobs: int(c.JobCount)})
 	}
 
+	// The INDEX attribute names, not the query-parameter names. They differ — the
+	// `role` filter reads the `roles` attribute — and asking for the parameter name is
+	// a 400 from the engine, which is how the first production build failed. Reading
+	// them out of the same table the filter builder uses is what stops the two drifting
+	// again.
+	roleAttr, skillAttr, categoryAttr := search.StringFacets["role"], search.StringFacets["skills"], search.StringFacets["category"]
 	counts, err := client.FacetCounts(ctx, search.FacetParams{
-		Facets: []string{"role", "skills", "enrichment.category"},
+		Facets: []string{roleAttr, skillAttr, categoryAttr},
 	})
 	if err != nil {
 		return suggest.Input{}, err
@@ -152,12 +158,12 @@ func gather(ctx context.Context, q *db.Queries, client *search.Client, floors co
 	return suggest.Input{
 		Titles:     raw,
 		TitleFloor: floors.TitleFloor,
-		Roles:      ints(counts.Facets["role"]),
+		Roles:      ints(counts.Facets[roleAttr]),
 		// The catalogue's own slug→label map, so a suggestion reads exactly as the
 		// filter chip it applies. A second label table would drift from the picker's.
 		RoleLabels: roletag.Catalog(),
-		Skills:     ints(counts.Facets["skills"]),
-		Categories: ints(counts.Facets["enrichment.category"]),
+		Skills:     ints(counts.Facets[skillAttr]),
+		Categories: ints(counts.Facets[categoryAttr]),
 		Companies:  firms,
 		Searches:   demand,
 	}, nil


### PR DESCRIPTION
The first production build of the suggestion dictionary failed at the first thing
it did:

```
gather: search: facet query: bad query: 400
  Attribute `role` is not filterable.
  Available filterable attributes patterns are: ... roles ...
```

The filter **parameter** is `role`; the index **attribute** is `roles`. Two names
for one concept, and the builder had the wrong one written out as a literal beside
two that happened to match — so `skills` and `enrichment.category` worked and
`role` did not.

Nothing in the unit suite could have caught it: the call goes to a live engine.
So the names now come from `search.StringFacets`, the table the filter builder
already translates through, and a test asserts they do. A renamed attribute now
breaks the build rather than the 06:46 timer.

Found by running the worker against production after #2358 and #2362 shipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed suggestion generation to use the correct search attributes for roles, skills, and categories.
  * Improved consistency between filter parameters and indexed search fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->