### PR TITLE
Bring the view count and the freshness badges to the job card

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -44,7 +44,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@storybook/addon-themes": "10.5.4",
+        "@storybook/addon-themes": "10.5.10",
         "@storybook/svelte": "10.5.8",
         "@storybook/svelte-vite": "10.5.8",
         "@sveltejs/vite-plugin-svelte": "^7.3.0",

--- a/internal/api/handler/search.go
+++ b/internal/api/handler/search.go
@@ -115,9 +115,10 @@ var searchSortable = map[string]string{
 	"created_at": "created_at",
 	"posted_at":  "posted_at",
 	// The "Most viewed" ordering. This entry must NEVER ship ahead of the live index
-	// declaring view_count sortable (see facetSettings): Meilisearch rejects the entire
-	// query for an undeclared sort attribute, and search.go maps any Meili error to a
-	// 500 — so the wrong deploy order breaks the page rather than ignoring the param.
+	// declaring view_count sortable (see search.facetSettings, and "Adding a sortable
+	// attribute" in internal/search/search/AGENTS.md): Meilisearch rejects the entire
+	// query for an undeclared sort attribute, and that package maps any Meili error to
+	// a 500 — so the wrong deploy order breaks the page rather than ignoring the param.
 	"view_count": "view_count",
 	"salary_min": "enrichment.salary_min",
 	"salary_max": "enrichment.salary_max",

--- a/internal/api/handler/search.go
+++ b/internal/api/handler/search.go
@@ -114,6 +114,11 @@ func ignoredParams(c *fiber.Ctx, own []string) []search.UnknownParam {
 var searchSortable = map[string]string{
 	"created_at": "created_at",
 	"posted_at":  "posted_at",
+	// The "Most viewed" ordering. This entry must NEVER ship ahead of the live index
+	// declaring view_count sortable (see facetSettings): Meilisearch rejects the entire
+	// query for an undeclared sort attribute, and search.go maps any Meili error to a
+	// 500 — so the wrong deploy order breaks the page rather than ignoring the param.
+	"view_count": "view_count",
 	"salary_min": "enrichment.salary_min",
 	"salary_max": "enrichment.salary_max",
 }

--- a/internal/api/handler/search_test.go
+++ b/internal/api/handler/search_test.go
@@ -241,3 +241,37 @@ func TestSearchJobs_CleanQueryReportsNothingIgnored(t *testing.T) {
 		t.Errorf("meta.ignored_params = %v, want the key absent", meta["ignored_params"])
 	}
 }
+
+// The "Most viewed" ordering. It is a plain attribute sort like the dates, so what is
+// worth pinning is that the bare `view_count` name is accepted at all — an unlisted
+// value is silently ignored, which would leave the feed date-ordered while the control
+// claimed otherwise — and that it defaults to descending, since most-viewed-first is
+// the whole point and needing `&order=desc` to reach it would be a trap.
+func TestSearchJobs_ViewCountSortDefaultsToDescending(t *testing.T) {
+	fake := &fakeSearcher{}
+	app := searchApp(fake)
+
+	if status, _ := doGet(t, app, "/jobs/search?sort=view_count"); status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if len(fake.got.Sort) != 1 || fake.got.Sort[0] != "view_count:desc" {
+		t.Errorf("Sort = %v, want [view_count:desc] — an ignored sort value would leave the feed date-ordered", fake.got.Sort)
+	}
+
+	// Ascending is reachable, so "least viewed first" needs no separate parameter.
+	if status, _ := doGet(t, app, "/jobs/search?sort=view_count&order=asc"); status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if len(fake.got.Sort) != 1 || fake.got.Sort[0] != "view_count:asc" {
+		t.Errorf("Sort = %v, want [view_count:asc]", fake.got.Sort)
+	}
+
+	// It ranks by a stored figure, so it survives query text rather than yielding to
+	// relevance the way an unrecognised value would.
+	if status, _ := doGet(t, app, "/jobs/search?q=golang&sort=view_count"); status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if len(fake.got.Sort) != 1 || fake.got.Sort[0] != "view_count:desc" {
+		t.Errorf("Sort = %v, want [view_count:desc] under query text", fake.got.Sort)
+	}
+}

--- a/internal/search/search/AGENTS.md
+++ b/internal/search/search/AGENTS.md
@@ -111,6 +111,30 @@ for the ingest-time coverage gate and was dropped when that gate moved to Postgr
 stops asking for it first, and the live index keeps a harmless declaration until the next
 rebuild. Only a binary that asks for an attribute the live index has not declared breaks.
 
+## Adding a sortable attribute
+
+Same window, same rule, one worse detail. Meili answers `invalid_search_sort`, which the
+handler maps to 500 the same way — so a binary whose `searchSortable` accepts a value the
+live index has not declared does not fall back to the default ordering, it breaks the page.
+Settings first, binary second.
+
+**A hand patch must send the COMPLETE `sortableAttributes` list.** Meili replaces that
+setting wholesale rather than merging it, so a patch naming only the new attribute silently
+drops `posted_at` — and `posted_at` is what the feed's DEFAULT ordering uses, so the blast
+radius is every caller, not just the one who picked the new sort. There is no operator
+script for this: `EnsureIndex` runs only in tests, and settings otherwise reach production
+when `cmd/reindex` swaps a freshly built index in. Read the setting back afterwards; a 200
+on the patch only means the task was accepted.
+
+`view_count` (the "Most viewed" ordering) is the easy case of this and worth contrasting
+with the match embedder below: the counter rides the embedded job projection, so it is
+already on every document. Declaring it sortable is the whole change, and the ordering is
+correct the moment the setting applies — no rebuild to wait for, no dark flag. What the
+counter does NOT get is outbox plumbing: `cmd/rollup-views` moves it daily without touching
+indexed content, so the incremental push never fires, but the scheduled rebuild reads it
+from Postgres more often than the rollup writes it. The indexed figure is never staler than
+the source figure.
+
 ## Skill vectors and the match sort
 
 The facet index carries ONE embedder, named `skills` and sourced `userProvided`. No

--- a/internal/search/search/client.go
+++ b/internal/search/search/client.go
@@ -635,7 +635,13 @@ func facetSettings() *meilisearch.Settings {
 			"reality.class",
 		},
 		// posted_at / created_at are RFC3339 UTC strings and sort chronologically as text.
-		SortableAttributes: []string{"posted_at", "created_at", "enrichment.salary_min", "enrichment.salary_max"},
+		// view_count backs the "Most viewed" ordering. It needs no document change: the
+		// document embeds the public job projection, which has carried the counter since
+		// the counter existed — declaring it sortable is the whole index-side change.
+		// The settings-before-binary warning above applies to it as well, and here it is
+		// the SORT that breaks: Meilisearch rejects the whole query for an undeclared
+		// sort attribute, so a binary accepting ?sort=view_count first 500s the page.
+		SortableAttributes: []string{"posted_at", "created_at", "view_count", "enrichment.salary_min", "enrichment.salary_max"},
 		// posted_ts:desc is a freshness tie-breaker appended AFTER exactness: relevance
 		// (and any explicit sort) always decides first, and among results otherwise tied
 		// on every relevance rule the fresher posting wins. It uses the numeric

--- a/internal/search/search/settings_test.go
+++ b/internal/search/search/settings_test.go
@@ -120,3 +120,26 @@ func TestFacetSettingsSkipsExpensiveProximityIndexing(t *testing.T) {
 		t.Errorf("facetSettings().PrefixSearch = %v, want nil (prefix search stays enabled for live query-as-you-type)", *s.PrefixSearch)
 	}
 }
+
+func TestViewCountIsSortable(t *testing.T) {
+	// The "Most viewed" ordering sorts on a bare top-level `view_count`. The counter
+	// rides the embedded job projection, so it is already on every document and needs
+	// no new field; declaring it sortable is the whole index-side change.
+	//
+	// This must reach the LIVE index BEFORE a binary that accepts `sort=view_count`:
+	// Meilisearch rejects the whole query for an undeclared sort attribute, and this
+	// package maps any Meili error to a 500, so the wrong order breaks search rather
+	// than ignoring a parameter.
+	s := facetSettings()
+	if !contains(s.SortableAttributes, "view_count") {
+		t.Errorf("view_count must be sortable for the most-viewed ordering, got %v", s.SortableAttributes)
+	}
+	// The other orderings must survive the addition. A settings patch replaces this
+	// list wholesale, so dropping posted_at here would break the feed's DEFAULT
+	// ordering rather than just this one sort.
+	for _, want := range []string{"posted_at", "created_at"} {
+		if !contains(s.SortableAttributes, want) {
+			t.Errorf("%s must stay sortable, got %v", want, s.SortableAttributes)
+		}
+	}
+}

--- a/openspec/changes/job-card-views-and-freshness-badges/.openspec.yaml
+++ b/openspec/changes/job-card-views-and-freshness-badges/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-03

--- a/openspec/changes/job-card-views-and-freshness-badges/design.md
+++ b/openspec/changes/job-card-views-and-freshness-badges/design.md
@@ -1,0 +1,296 @@
+## Context
+
+The card (`web/src/lib/components/JobRow.svelte`) is the single source of truth
+for how a job appears in every list — browse, search, company detail, tracking,
+the assistant deck. It already renders a relative posting timestamp, a
+reality/ghost chip, facet chips, credentials, country flags, skills, salary and a
+client-computed profile-match bar. What it renders nothing of is attention or
+freshness-as-a-signal.
+
+Almost everything this change needs already exists:
+
+- `jobs.view_count` — maintained offline by `cmd/rollup-views` from nginx access
+  logs, exposed as `view_count` on the public job projection
+  (`internal/job/jobview/jobview.go`), generated into
+  `web/src/lib/generated/contracts.ts`.
+- `web/src/lib/freshness.ts` — `freshnessBadges(postedAt, reality, appliedCount)`
+  already computes the `New` / `Be an early applicant` pair, with three named
+  thresholds, a reality gate, honest tooltips, and 12 tests. Its only caller is
+  `JobView.svelte` (the job detail page).
+- `formatCount` in `web/src/lib/activityChart.ts` — already abbreviates counts as
+  `697K` / `3.4M`.
+- `JobDocument` (`internal/search/search/document.go:41`) embeds `jobview.Job`, so
+  every indexed document already holds `view_count` as a top-level numeric field.
+
+So the work is mostly wiring, and the design decisions are about *not* building
+second copies of things.
+
+Constraints that shape it:
+
+- The card is shared by two wire shapes. `Job` carries `view_count`,
+  `applied_count` and `reality`. `Card` (the tracking/assistant projection)
+  carries `posted_at` and nothing else from that list — so the card must degrade,
+  not assume.
+- `reality` is served by `/jobs/search` hits (it is on the index document, and
+  backs the `reality.class` facet) but NOT by the `/jobs` list: `attachGhostToRows`
+  computes reality locally and assigns only `views[i].Ghost`, never
+  `views[i].Reality`.
+- The header rail is narrow, shares its width with a truncating company name, and
+  reserves a `pr-9` gutter for the save button.
+- Meilisearch runs one serial task queue, and a settings update is a task on it.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Show `view_count` on the card without a second request, a new column, or a new
+  index field.
+- Bring the existing freshness badges to the card, computed by the existing rule.
+- Add a `Most viewed` ordering with the smallest possible backend surface.
+- Keep every threshold and every abbreviation rule in exactly one place.
+
+**Non-Goals:**
+
+- Changing any badge threshold, or the badge rule itself. `NEW_DAYS`,
+  `EARLY_DAYS` and `EARLY_APPLIES` keep their current values and their reasoning.
+- Changing `JobView.svelte`. The detail page renders exactly what it renders
+  today.
+- Any change to how `view_count` is *produced*. `cmd/rollup-views`, the nginx log
+  format, the bot filter and the `Sec-Purpose` rule are untouched.
+- A `view_count` filter (`min_views=`). Ordering answers "what is popular"; a
+  filter would need a facet and a control nobody asked for.
+- Backfill or migration of any kind.
+
+## Decisions
+
+### Reuse `freshnessBadges` rather than writing a card-specific rule
+
+*Why:* it exists, it is tested, and it already solves a problem a fresh
+implementation would have missed. Its reality gate catches the source that
+rewrites its posting date on every crawl (`fake_freshness`) — without it the card
+would print `New` on the oldest job in the catalogue. Its tooltips already name
+what was counted rather than implying knowledge of the employer's inbox.
+
+The stronger reason is consistency: the card and the detail page are two views of
+one posting, and a threshold copied into the card would eventually drift from the
+one in `freshness.ts`, so the same job would read `New` in the list and not on its
+own page. One function, two callers.
+
+*Alternative considered — a new `jobSignals.ts` keyed on `view_count < 25`
+instead of the applied count.* This was the initial direction and was dropped on
+finding the existing module. The critique behind it is real — `applied_count` is
+near zero catalogue-wide, so it discriminates weakly, while `view_count` spans
+zero to thousands. But `freshness.ts` already answers it: the threshold is
+deliberately small (3) so the claim "survives being wrong by an order of
+magnitude", and the tooltip states the basis. Switching the shared rule to
+`view_count` would change the detail page too, rewrite half the existing tests,
+and overturn a documented argument — for a signal that is better but not
+obviously enough better to justify that. Retuning is cheap and reversible later;
+shipping two disagreeing rules is not.
+
+### The card requires the reality signal; the shared rule still does not
+
+`freshnessBadges` lets the date stand alone when `reality` is absent — documented
+as "the ordinary case for a job we have only just met". That is right on the
+detail page, where the signal is always computed. It is wrong on a card, because
+of where cards get their data: the browse feed comes from `/jobs/search` (hits
+carry `reality`), but the `/jobs` list does not attach it, and the `Card`
+projection has no such field at all. On those surfaces the gate would pass
+blindly and the badges would appear on exactly the postings the gate exists to
+suppress — on the surface people scan fastest and least critically.
+
+*Decision:* add one exported wrapper in `freshness.ts` that returns nothing when
+the signal is absent and delegates otherwise. The card calls the wrapper; the
+detail page keeps calling `freshnessBadges`.
+
+*Why a wrapper and not a guard in the template:* the rule "a card without the
+signal shows no badges" is a rule, and a rule inside a Svelte template cannot be
+tested. This is the same argument `facetModel.ts` makes for holding the sort
+resolution ("in the component nothing could test it").
+
+*Why not change `freshnessBadges` to require the signal outright:* that would
+change the detail page's behaviour for a job with no signal, which is not what
+this change is for, and would invalidate an existing tested case.
+
+*Accepted consequence:* the company detail page and the tracking board show no
+badges. They are fed by projections that cannot support the claim honestly, and
+an absent badge is a smaller cost than a false one.
+
+### `formatCount` moves to `utils.ts`
+
+The card needs count abbreviation; `formatCount` already implements it, in
+`activityChart.ts`.
+
+*Why move it rather than import it where it is:* a card importing a chart module
+for a string helper is a coupling that reads as an accident. `utils.ts` already
+holds `timeAgo`, which the card already imports for the very same rail, so the
+two rail helpers end up in one place. `activityChart.ts` imports it from the new
+home.
+
+*Why not a third copy:* there is already a second k-formatter in
+`github.svelte.ts`. That one is not orphaned by this change so it is left alone,
+but it is precisely the drift a third copy would extend.
+
+### The eye glyph moves to the count; the personal marker becomes a check
+
+The rail renders `Eye` for "you have viewed this". The count also wants an eye.
+
+*Why swap rather than pick another icon for the count:* the eye is the
+conventional glyph for a view count, and the count is the new, public,
+information-bearing thing. The personal marker is a private annotation, and a
+check reads as "seen by you" at least as well. Keeping the eye on the personal
+marker would push the count onto a less legible glyph to protect an earlier
+choice.
+
+*Why not two eyes differentiated by fill or weight:* two same-shaped glyphs in
+one narrow rail meaning different things is exactly the ambiguity worth an icon
+change to avoid.
+
+This is a visible change to existing behaviour, which is why it is recorded as a
+`web-frontend` spec modification rather than slipped in as an implementation
+detail.
+
+### Thousands abbreviate on the card, not on the detail page
+
+*Why:* the rail is narrow and shares it with a truncating company name; `12403 ·
+2d` crowds the name out. The detail page has room and keeps the exact figure, so
+the precise number is always reachable.
+
+### `view_count` gets no search-outbox plumbing
+
+*Why:* the incremental push is gated on indexed content changing, and
+`cmd/rollup-views` moves the counter without touching that content — so the
+counter genuinely does drift between rebuilds. But the scheduled full rebuild
+reads from Postgres every few hours, while the rollup that *produces* the counter
+runs daily. The indexed figure is therefore never staler than the source figure,
+and outbox plumbing would add write volume to a queue whose backlog has already
+caused incidents, in exchange for no freshness.
+
+*Alternative considered — have `cmd/rollup-views` enqueue the jobs it touched.*
+Rejected on that arithmetic: it would enqueue a large fraction of the catalogue
+daily to reach an ordering the rebuild already provides.
+
+### `Most viewed` is always on offer
+
+*Why:* it depends on neither query text (unlike `relevance`) nor a signed-in
+profile (unlike `match`). Gating it would be inventing a precondition.
+
+*Consequence handled deliberately:* the sort control renders only when it holds
+more than one option, and `newest` was previously the only unconditional one.
+With `views` also unconditional the control renders on every listing, including a
+signed-out browse with no query — which shows no control today. That is an
+intended improvement, but it makes an existing spec scenario false, so that
+scenario is rewritten rather than left to contradict the new rule.
+
+### The backend change is two allowlist entries that must land in order
+
+`searchSortable` in `internal/api/handler/search.go` and `SortableAttributes` in
+`internal/search/search/client.go`.
+
+*Why the order is load-bearing:* `searchSortable` is what stops an unknown `sort`
+from reaching Meilisearch. If the handler accepts `view_count` while the live
+index has not declared it sortable, Meilisearch rejects the **whole query** and
+this package's error mapping turns that into a 500 — a broken search, not an
+ignored parameter. `internal/search/search/AGENTS.md` records this same
+one-directional hazard twice already (for filterable attributes and for the match
+embedder): settings first, binary second.
+
+*How settings actually reach production:* there is no operator script for it.
+`EnsureIndex` is called only from tests, and settings otherwise arrive when
+`cmd/reindex` builds a fresh index and swaps it in. So either the rebuild carries
+the setting, or it is patched by hand — and a hand patch must send the
+**complete** `sortableAttributes` list, because Meilisearch replaces that setting
+wholesale. Sending only `view_count` would silently drop `posted_at` and break
+the feed's default ordering for every caller.
+
+*Why this is a better position than the match sort was in:* declaring the
+embedder did not retro-fill 1.36M documents, so that control shipped dark behind
+a flag until a rebuild landed. Here the values are already in every document, so
+the ordering is correct the moment the setting applies. No flag, no dark period.
+
+`searchSort` already resolves `order` and defaults to `desc`, so no handler logic
+changes — only the map.
+
+`GET /api/v1/jobs` accepts no `sort` and is hardcoded `created_at DESC`. Since
+the browse feed calls `/jobs/search`, nothing is needed there; adding a sort to
+the DB list would build a second ordering path for no caller.
+
+### The signal row's render guard has to widen
+
+The row is conditional on there being a reality chip, a facet tag, a country or a
+credential. A badge-earning posting with none of those would compute a badge and
+have no row to draw it in.
+
+## Risks / Trade-offs
+
+**[The handler accepts `view_count` before the index declares it sortable]** →
+Meilisearch rejects the entire query, breaking search rather than degrading the
+sort. Mitigation: the setting is applied and *confirmed* before the handler
+change rolls out; the ordering is recorded in the migration plan rather than
+remembered.
+
+**[A hand patch of `sortableAttributes` sends a partial list]** → `posted_at`
+stops being sortable and the feed's default ordering breaks for everyone, which
+looks nothing like the change that caused it. Mitigation: the patch sends all
+five attributes, and the task is verified by re-reading the setting back, not by
+a 200 on the patch.
+
+**[The `SortableAttributes` update queues behind an in-flight rebuild]** → Meili
+runs one serial task queue, so the settings task waits and the sort keeps
+answering under the old settings — a deploy that appears to have done nothing.
+Mitigation: check the queue is clear first; do not apply during a rebuild window.
+
+**[A rebuild silently refuses below the free-disk floor]** → if the rebuild is
+what carries the setting, it never applies, quietly. Mitigation: verify disk, and
+confirm the setting is live by reading it back. As of 2026-09-03 a rebuild is in
+flight with the floor temporarily lowered.
+
+**[Badges disappear from the company page and tracking board]** → surfaces whose
+projections carry no reality signal now show no badges. This is the chosen
+trade-off (an absent badge beats a false one), but it is a visible reduction on
+surfaces that never had the badges to begin with, so nothing regresses for users
+— it only bounds where the feature reaches.
+
+**[Sorting by views entrenches what is already popular]** → the ordering feeds
+attention to postings that already have it, and a good fresh posting can never
+top it. Accepted: it is one ordering of four, never the default, and the
+freshness badges are the counterweight inside every other ordering.
+
+**[`view_count` counts readers while the badge speaks of applicants]** → the two
+signals now sit in the same card and could be conflated. Mitigation: the badge's
+tooltip states its own basis, and the badge is not derived from the count, so
+neither number is presented as evidence for the other.
+
+**[The sort control now appears where it never did]** → signed-out visitors
+browsing with no query previously saw no control. Accepted as an improvement (the
+ordering was unreachable for them), and recorded as a spec change so it reads as
+a decision rather than a regression.
+
+**[Two badges plus existing chips can push the signal row to a second line on a
+phone]** → the row already wraps by design and the badges are short, so this is a
+layout cost, not a break. Worth checking on a narrow viewport during
+verification.
+
+## Migration Plan
+
+No data migration. Deploy order is load-bearing:
+
+1. Make `view_count` sortable on the **live** index and confirm it by reading the
+   setting back. Either let a rebuild carry it (it builds settings from the
+   binary) or patch by hand with the complete five-attribute list. Not during a
+   rebuild window.
+2. Ship the Go change (`searchSortable`) — safe only after step 1 is confirmed.
+3. Ship the frontend change. The card additions (count, glyph, badges) are
+   independent of steps 1-2 and could ship first; the `Most viewed` option must
+   not ship before step 2, or selecting it breaks search for that caller.
+
+Rollback: remove the `views` option from the client vocabulary. The URL parameter
+degrades on its own — an unrecognised `sort` resolves to the contextual default —
+so a stale link or saved search never errors. Leaving the sortable attribute
+declared is harmless.
+
+## Open Questions
+
+None. The badge thresholds are deliberately unchanged; retuning them is a
+separate, one-line decision that can be taken after the badges are live on the
+card and their frequency can be observed.

--- a/openspec/changes/job-card-views-and-freshness-badges/design.md
+++ b/openspec/changes/job-card-views-and-freshness-badges/design.md
@@ -275,19 +275,37 @@ verification.
 
 No data migration. Deploy order is load-bearing:
 
-1. Make `view_count` sortable on the **live** index and confirm it by reading the
-   setting back. Either let a rebuild carry it (it builds settings from the
-   binary) or patch by hand with the complete five-attribute list. Not during a
-   rebuild window.
-2. Ship the Go change (`searchSortable`) — safe only after step 1 is confirmed.
-3. Ship the frontend change. The card additions (count, glyph, badges) are
-   independent of steps 1-2 and could ship first; the `Most viewed` option must
-   not ship before step 2, or selecting it breaks search for that caller.
+**There are two deploys, not three.** `deploy/bin/release.sh` builds `cmd/server`
+and the SvelteKit app in the same blue/green flip, so the handler's new
+`searchSortable` entry and the visible `Most viewed` option go live together.
+Treating them as separately shippable would be planning against a release path
+that does not exist.
 
-Rollback: remove the `views` option from the client vocabulary. The URL parameter
-degrades on its own — an unrecognised `sort` resolves to the contextual default —
-so a stale link or saved search never errors. Leaving the sortable attribute
-declared is harmless.
+1. Make `view_count` sortable on the **live** index, and confirm it by reading
+   `sortableAttributes` back and seeing all five. Either let a rebuild carry it
+   (a rebuild builds settings from the binary) or patch by hand with the complete
+   list. Not during a rebuild window — Meili's queue is serial, so the task would
+   wait behind it and the setting would appear not to have applied. A 200 on the
+   patch means the task was accepted, not that it ran.
+2. Only once step 1 is confirmed, run the release. It carries the handler entry
+   and the card together.
+
+The card additions (count, glyph, badges) depend on neither step and cannot fail
+this way; they are simply carried by the same release.
+
+**No feature flag.** `sort=match` shipped dark behind `PUBLIC_MATCH_SORT` because
+declaring its embedder did not retro-fill 1.36M documents — the ordering was
+genuinely thin until a rebuild landed, a window nothing could shorten. There is no
+equivalent window here: the counter is already on every document, so the ordering
+is correct the instant the setting applies. The only exposure is step 1 not having
+been done, which is a single verifiable read rather than a condition to wait out.
+A permanent runtime flag to guard a one-time ordering would be complexity that
+outlives its reason.
+
+Rollback: remove the `views` option from the client vocabulary and release. The URL
+parameter degrades on its own — an unrecognised `sort` resolves to the contextual
+default — so a stale link or saved search never errors. Leaving the sortable
+attribute declared is harmless.
 
 ## Open Questions
 

--- a/openspec/changes/job-card-views-and-freshness-badges/proposal.md
+++ b/openspec/changes/job-card-views-and-freshness-badges/proposal.md
@@ -87,6 +87,14 @@ breaking changes.
   / `match`. It gains `views`, serialized as `sort=view_count`, always offered.
 - `job-search`: the endpoint's accepted `sort` values and the index's sortable
   attributes both gain `view_count`.
+- `saved-searches`: the canonical query that identifies a saved set stops
+  carrying the ordering. This closes a pre-existing hole that this change would
+  otherwise make routine: `savedSearchQuery` included `sort` while the comment
+  above its call site said it did not and the digest matcher ignored it, so
+  choosing an ordering marked a saved search dirty and saving again created a
+  duplicate set that mailed identical jobs. `views` is never a contextual
+  default, so it always serializes — and the sort control, previously hidden on
+  a signed-out browse, is now always rendered.
 
 ## Impact
 

--- a/openspec/changes/job-card-views-and-freshness-badges/proposal.md
+++ b/openspec/changes/job-card-views-and-freshness-badges/proposal.md
@@ -1,0 +1,142 @@
+## Why
+
+A job card today tells you what the role is and how old the posting is, but
+nothing about whether it is worth being early to. Two things that answer that
+already exist and already work — `view_count`, and the `New` / `Be an early
+applicant` badge pair — and neither reaches the card. A fresh posting nobody has
+opened looks identical to a three-month-old one with four thousand views.
+
+The badges are the notable case: `web/src/lib/freshness.ts` computes them,
+`freshness.test.ts` covers them, and `JobView.svelte` renders them — on the job
+detail page only. The card, which is where jobs are actually scanned, is the one
+surface the signal never reaches.
+
+The search side is likewise nearly there: the index document already carries
+`view_count`, so ordering by it costs two allowlist entries rather than a
+pipeline.
+
+## What Changes
+
+**The card shows how many people opened the posting.** `JobRow.svelte`'s header
+rail renders an eye glyph and the count beside the existing relative timestamp
+(`231 · 2d`). Thousands abbreviate via the existing `formatCount` helper. A count
+of `0` renders nothing rather than a dead "0 views".
+
+**The rail's "you have viewed this" marker changes glyph.** It is an eye today,
+and the count is also an eye — two eyes in one rail, meaning different things, is
+unreadable. The personal marker becomes a check.
+
+**The existing freshness badges are rendered on the card.** The card calls the
+same `freshnessBadges` the detail page calls. Its rules are unchanged:
+
+- `New` — posted within 7 days.
+- `Be an early applicant` — posted within 3 days AND at most 3 users have marked
+  the job applied here.
+- Neither badge when the reality signal reports anything but `fresh`, or reports
+  `fake_freshness`.
+
+Reusing the rule rather than writing a second one is the point: the card and the
+detail page must not tell different stories about the same posting, and the rule
+already handles a case a fresh implementation would have walked into — a source
+that rewrites its posting date on every crawl would otherwise print `New` on the
+oldest job in the catalogue.
+
+**On the card, an absent reality signal suppresses the badges.** This is the one
+behavioural addition. `freshnessBadges` lets the date stand alone when the signal
+is missing, which is correct on the detail page (where the signal is always
+computed) and wrong on a card: the browse feed is served from `/jobs/search`,
+whose hits carry `reality`, but the plain `/jobs` list and the tracking/assistant
+card projection do not. Trusting the date there would print `New` on exactly the
+postings the guard exists to catch. The card therefore requires the signal, and
+surfaces that do not carry it show no badges.
+
+**These badges are captured in a spec for the first time.** No existing
+capability owns them — the rule, its thresholds and the reasoning behind them
+live only in source comments. The new capability records them alongside the card
+surface, so the next person to retune a threshold sees the argument.
+
+**The feed gains a `Most viewed` ordering.** A new `views` value in the client
+sort vocabulary, serialized as `sort=view_count`, added to the endpoint's sort
+allowlist and the index's sortable attributes. It needs neither query text nor a
+profile, so it is always on offer.
+
+No new column, no migration, no queue, no backfill, and no change to any existing
+badge rule. Nothing is removed and no wire field changes shape, so there are no
+breaking changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `job-freshness-badges`: the `New` / `Be an early applicant` pair — the existing
+  thresholds and the reality gate behind them, the honesty constraint on what
+  `Be an early applicant` may claim, the surfaces that render them, and the
+  card's stricter requirement that the reality signal be present.
+
+### Modified Capabilities
+
+- `job-engagement-counts`: the requirement covering where the SPA displays the
+  counters names the job detail page only. It gains the job card as a second
+  display surface, showing `view_count` alone, abbreviated, with the same
+  zero-omission rule.
+- `web-frontend`: the requirement marking already-viewed jobs in the browse list
+  specifies an eye glyph for the personal marker. That glyph becomes a check,
+  because the eye now carries the public view count in the same rail. The dimming
+  behaviour is unchanged.
+- `jobs-list-controls`: the feed's ordering vocabulary is `relevance` / `newest`
+  / `match`. It gains `views`, serialized as `sort=view_count`, always offered.
+- `job-search`: the endpoint's accepted `sort` values and the index's sortable
+  attributes both gain `view_count`.
+
+## Impact
+
+**Frontend** (`web/`)
+
+- `web/src/lib/components/JobRow.svelte` — the rail gains the count, the viewed
+  marker's glyph changes, the signal row gains the badges and its render guard
+  widens (a job whose only signal is a badge must still open the row).
+- `web/src/lib/freshness.ts` — one added export: the card's reality-requiring
+  wrapper. The existing `freshnessBadges` and all three thresholds are untouched.
+- `web/src/lib/utils.ts` — `formatCount` moves here from `activityChart.ts`, so
+  the card and the chart share one abbreviation rule rather than the card
+  importing a chart module. `activityChart.ts` imports it from its new home.
+- `web/src/lib/facetModel.ts` — `JobSort`, `SORT_PARAM`, `SORT_LABEL`,
+  `sortOptionsFor`.
+
+**Backend** (Go)
+
+- `internal/api/handler/search.go` — one entry in `searchSortable`. `searchSort`
+  already resolves `order` and defaults to `desc`.
+- `internal/search/search/client.go` — one entry in `SortableAttributes`.
+
+**Not touched**
+
+- No `jobs` column, no migration, no sqlc regeneration. `view_count` is already a
+  column, already on the public projection, and already in the index document —
+  `JobDocument` embeds `jobview.Job`.
+- No badge threshold, and no change to `JobView.svelte`. The detail page keeps
+  rendering exactly what it renders today.
+- No `search_outbox` plumbing. `cmd/rollup-views` bumps the counter daily without
+  enqueueing, but the scheduled full rebuild reads from Postgres every few hours,
+  so the indexed figure is fresher than the daily rollup that produces it.
+- `GET /api/v1/jobs` accepts no `sort` at all (hardcoded `created_at DESC`). The
+  sort control lives entirely on `/jobs/search`, which is what the browse feed
+  calls.
+
+**Deploy hazards**
+
+1. The handler must not accept `sort=view_count` before the live index declares
+   the attribute sortable. Meilisearch rejects the **whole query** for an
+   undeclared sort attribute, and the handler maps any Meili error to 500 — so
+   the failure is a broken search, not an ignored parameter. This is the same
+   ordering hazard `internal/search/search/AGENTS.md` records for filterable
+   attributes and for the match embedder.
+2. There is no operator script that patches live index settings — `EnsureIndex`
+   is called only from tests, and settings otherwise reach production through a
+   rebuild's swap. Patching by hand means sending the **complete**
+   `sortableAttributes` list: Meilisearch replaces that setting wholesale, so
+   sending only `view_count` would drop `posted_at` and break the feed's default
+   ordering for everyone.
+3. A rebuild silently refuses below the free-disk floor. As of 2026-09-03 one is
+   in flight with the floor temporarily lowered; confirm it has landed before
+   relying on it to carry the setting.

--- a/openspec/changes/job-card-views-and-freshness-badges/specs/job-engagement-counts/spec.md
+++ b/openspec/changes/job-card-views-and-freshness-badges/specs/job-engagement-counts/spec.md
@@ -1,0 +1,60 @@
+## MODIFIED Requirements
+
+### Requirement: SPA displays the counters on the job detail page
+
+The job detail page SHALL display the job's view and apply counts. A counter that
+is `0` SHALL be omitted so the display never reads as a dead "0 views". The counts
+are shown to every visitor, signed in or not.
+
+The job card SHALL additionally display the view count in its header rail, beside
+the relative posting timestamp, so the browse feed conveys how much attention a
+posting has drawn without opening it. The card SHALL show `view_count` only —
+`applied_count` is freehire's own tracking marker and is near zero across the
+catalogue, so it would read as a dead figure on every card. The same
+zero-omission rule applies: a card whose `view_count` is `0` SHALL render no
+count at all rather than a "0".
+
+Counts of a thousand or more SHALL be abbreviated on the card (for example
+`1.2k`), because the rail shares its width with the company name and the
+timestamp and an unabbreviated five-digit figure crowds both out. The detail
+page, which has the room, keeps the exact figure.
+
+Listing shapes that do not carry `view_count` — the tracking and assistant card
+projections — SHALL render no count, the same way they already render no salary.
+
+#### Scenario: Counts shown on a job with engagement
+
+- **WHEN** a visitor opens a job whose `view_count` is 5 and `applied_count` is 2
+- **THEN** the detail page shows both the view count and the apply count
+
+#### Scenario: Zero counters are omitted
+
+- **WHEN** a visitor opens a job whose `applied_count` is 0
+- **THEN** the apply count is not rendered
+
+#### Scenario: The card shows the view count beside the timestamp
+
+- **WHEN** a job card is rendered for a job whose `view_count` is 231
+- **THEN** the card's header rail shows the view count beside the relative
+  posting timestamp
+
+#### Scenario: The card omits a zero view count
+
+- **WHEN** a job card is rendered for a job whose `view_count` is 0
+- **THEN** no view count is rendered on the card
+
+#### Scenario: The card never shows the apply count
+
+- **WHEN** a job card is rendered for a job whose `applied_count` is 4
+- **THEN** no apply count is rendered on the card
+
+#### Scenario: Large counts are abbreviated on the card
+
+- **WHEN** a job card is rendered for a job whose `view_count` is 1240
+- **THEN** the card shows an abbreviated figure such as `1.2k`
+
+#### Scenario: A listing card projection without the counter renders nothing
+
+- **WHEN** a card is rendered from a listing projection that carries no
+  `view_count` field
+- **THEN** no view count is rendered and the card is otherwise unchanged

--- a/openspec/changes/job-card-views-and-freshness-badges/specs/job-engagement-counts/spec.md
+++ b/openspec/changes/job-card-views-and-freshness-badges/specs/job-engagement-counts/spec.md
@@ -15,7 +15,7 @@ zero-omission rule applies: a card whose `view_count` is `0` SHALL render no
 count at all rather than a "0".
 
 Counts of a thousand or more SHALL be abbreviated on the card (for example
-`1.2k`), because the rail shares its width with the company name and the
+`1.2K`), because the rail shares its width with the company name and the
 timestamp and an unabbreviated five-digit figure crowds both out. The detail
 page, which has the room, keeps the exact figure.
 
@@ -51,7 +51,7 @@ projections — SHALL render no count, the same way they already render no salar
 #### Scenario: Large counts are abbreviated on the card
 
 - **WHEN** a job card is rendered for a job whose `view_count` is 1240
-- **THEN** the card shows an abbreviated figure such as `1.2k`
+- **THEN** the card shows an abbreviated figure such as `1.2K`
 
 #### Scenario: A listing card projection without the counter renders nothing
 

--- a/openspec/changes/job-card-views-and-freshness-badges/specs/job-freshness-badges/spec.md
+++ b/openspec/changes/job-card-views-and-freshness-badges/specs/job-freshness-badges/spec.md
@@ -1,0 +1,198 @@
+## ADDED Requirements
+
+### Requirement: The freshness badge pair and its thresholds
+
+The system SHALL offer two freshness badges on a posting: `New` and `Be an early
+applicant`. Both are derived at read time from fields the posting already
+carries, and neither is stored, indexed, or served as a field of its own.
+
+`New` SHALL be shown when the posting is at most 7 days old. A posting is not
+"new" for longer than that on a board where the median role stays open for a
+month — beyond a week the word stops carrying information.
+
+`Be an early applicant` SHALL be shown when the posting is at most 3 days old AND
+at most 3 users have marked the job applied. It SHALL only ever accompany `New`,
+never appear alone, because its window is strictly inside `New`'s.
+
+The age SHALL be measured in whole days from the served `posted_at`, which is
+already the effective posting date (the source's own date, or the ingest date when
+the source gives none or gives one in the future). The measured age SHALL be
+clamped at zero: a source clock running a few hours ahead is ordinary and MUST NOT
+read as a posting from the future. A posting whose `posted_at` is missing or
+unparseable SHALL receive neither badge — an unknown age is not a fresh one.
+
+Each badge SHALL carry a tooltip stating the fact behind it rather than
+restating the label.
+
+This requirement records behaviour that already exists in the codebase and had no
+specification. The thresholds are unchanged by the change that introduces this
+spec.
+
+#### Scenario: A posting from yesterday carries both badges
+
+- **WHEN** the badges are computed for a job posted 1 day ago with 0 applied
+  marks and a fresh reality signal
+- **THEN** both `New` and `Be an early applicant` are returned
+
+#### Scenario: A five-day-old posting is new but not early
+
+- **WHEN** the badges are computed for a job posted 5 days ago with a fresh
+  reality signal
+- **THEN** only `New` is returned
+
+#### Scenario: A posting past the new window carries neither badge
+
+- **WHEN** the badges are computed for a job posted 20 days ago
+- **THEN** no badge is returned
+
+#### Scenario: A well-applied fresh posting is new but not early
+
+- **WHEN** the badges are computed for a job posted 1 day ago that 9 users have
+  marked applied, with a fresh reality signal
+- **THEN** only `New` is returned
+
+#### Scenario: A future-dated posting reads as posted today
+
+- **WHEN** the badges are computed for a job whose `posted_at` is a few hours in
+  the future
+- **THEN** its age is treated as zero days and `New` is returned
+
+#### Scenario: An unknown posting date yields no badge
+
+- **WHEN** the badges are computed for a job whose `posted_at` is absent or
+  unparseable
+- **THEN** no badge is returned
+
+### Requirement: The reality signal gates both badges
+
+When a posting carries the job-reality signal, a signal reporting anything other
+than `fresh` — or reporting `fake_freshness` — SHALL suppress both badges
+regardless of the posting date.
+
+The reality signal is the system's own reading of how long a job has actually
+been open, and it recognises the case the posting date alone cannot: a role open
+for eight months whose source rewrites its posting date on every crawl. Trusting
+`posted_at` there would print `New` on the oldest job in the catalogue. Both
+badges read as encouragement, so both are held to a higher bar than "the number
+looks small".
+
+#### Scenario: A stale posting with a fresh date gets no badge
+
+- **WHEN** the badges are computed for a job posted 1 day ago whose reality
+  signal does not report `fresh`
+- **THEN** no badge is returned
+
+#### Scenario: A fake-freshness posting gets no badge
+
+- **WHEN** the badges are computed for a job posted 1 day ago whose reality
+  signal reports `fresh` with `fake_freshness` set
+- **THEN** no badge is returned
+
+### Requirement: "Be an early applicant" claims only what freehire can observe
+
+The applied count behind `Be an early applicant` is the number of signed-in users
+who marked the job applied **on freehire**. It cannot see the employer's inbox, so
+it is a floor on the real number and never a measure of it.
+
+The badge SHALL therefore be offered as an invitation rather than a statement of
+fact, and its tooltip SHALL name who was counted, so the imprecise headline is one
+hover away from the precise basis. The wording SHALL NOT imply knowledge of the
+employer's applicant pool.
+
+The threshold SHALL be small enough that the claim survives being wrong by an
+order of magnitude. This is why the badge is bounded by a count of 3 rather than
+a larger figure that merely "looks small".
+
+#### Scenario: The tooltip names freehire as the source of the count
+
+- **WHEN** `Be an early applicant` is computed for a job that 2 users have marked
+  applied
+- **THEN** its tooltip states that 2 people have told us they applied to this job
+
+#### Scenario: The tooltip is explicit when nobody has applied
+
+- **WHEN** `Be an early applicant` is computed for a job with 0 applied marks
+- **THEN** its tooltip states that nobody has told us they applied yet
+
+#### Scenario: The tooltip carries the posting age alongside the count
+
+- **WHEN** `Be an early applicant` is computed for a job posted 2 days ago
+- **THEN** its tooltip includes how long ago the job was posted
+
+### Requirement: The badges render on the job card and the job detail page
+
+Both the job card and the job detail page SHALL render the badge pair, computed
+by one shared rule. Neither surface SHALL restate a threshold or the reality gate.
+A second copy of a threshold is a second answer, and the two would drift — the
+card and the detail page must never tell different stories about the same posting.
+
+On the card the badges SHALL render inside the existing signal row under the
+title, in this order: the reality or ghost chip first, then `New`, then `Be an
+early applicant`, then the row's existing facet chips, employer credentials and
+country flags. The reality/ghost chip leads because a warning that a posting may
+not be real outranks a note that it is fresh; the badges precede the facet chips
+because they are time-sensitive signals rather than stable attributes of the role.
+
+The badges SHALL be visually distinct from the outline facet chips beside them,
+rendered in the design system's brand-tinted badge variant.
+
+The signal row's render guard SHALL account for the badges, so a job whose only
+signal is a badge still opens the row. Without this a fresh posting carrying no
+reality chip, no facets, no countries and no credentials would compute a badge and
+then have nowhere to draw it.
+
+#### Scenario: A ghost posting shows its warning first
+
+- **WHEN** a card is rendered for a badge-earning job that also carries a ghost
+  signal
+- **THEN** the ghost chip precedes the `New` badge in the signal row
+
+#### Scenario: A badge alone opens the signal row
+
+- **WHEN** a card is rendered for a badge-earning job with no facet chips, no
+  countries and no credentials
+- **THEN** the signal row is rendered and contains the badges
+
+#### Scenario: Badges are distinguishable from facet chips
+
+- **WHEN** a card renders both badges and facet chips in the signal row
+- **THEN** the badges use the brand-tinted variant and the facet chips the
+  outline variant
+
+### Requirement: A card without the reality signal shows no badges
+
+On the job card, a posting that carries no reality signal at all SHALL receive no
+badges, even when its date would earn them. The card SHALL require the signal
+rather than letting the date stand alone.
+
+This is stricter than the shared rule's own behaviour, which permits the date to
+stand alone when the signal is absent. That permission is correct on the job
+detail page, where the signal is always computed, and wrong on a card: the browse
+feed is served from the search endpoint, whose hits carry the signal, but the
+Postgres-backed jobs list and the tracking/assistant card projection do not.
+Trusting the date on those surfaces would print `New` on precisely the postings
+the reality gate exists to catch, and it would do so on the surface where jobs
+are scanned fastest and least critically.
+
+The consequence is deliberate: surfaces fed by a projection without the signal
+show no badges rather than unverified ones. The requirement SHALL be expressed as
+a testable function rather than a condition inside a template.
+
+#### Scenario: A search-fed card earns its badges
+
+- **WHEN** a card is rendered from a search hit carrying a fresh reality signal
+  for a job posted 1 day ago
+- **THEN** both badges are shown
+
+#### Scenario: A card from a projection with no reality signal shows none
+
+- **WHEN** a card is rendered from a listing projection that carries no reality
+  signal, for a job posted 1 day ago
+- **THEN** no badge is shown
+
+#### Scenario: The detail page still lets the date stand alone
+
+- **WHEN** the job detail page computes badges for a job with no reality signal
+  posted 1 day ago
+- **THEN** the shared rule's existing behaviour is unchanged and `New` is
+  returned

--- a/openspec/changes/job-card-views-and-freshness-badges/specs/job-search/spec.md
+++ b/openspec/changes/job-card-views-and-freshness-badges/specs/job-search/spec.md
@@ -1,0 +1,175 @@
+## MODIFIED Requirements
+
+### Requirement: Searchable jobs index
+
+The system SHALL maintain a Meilisearch index of jobs with one document per job,
+keyed by the job's internal `id`. Each document SHALL carry the fields needed to
+both match and render a result without a follow-up database read: the searchable
+text (title, company, description, location), the filterable facets, the
+sortable fields, and the display fields returned to clients.
+
+The index SHALL declare:
+- **searchable attributes**: title, company, description, location.
+- **filterable attributes**: source, company_slug, work_mode, employment_type,
+  seniority, category, domains, regions, countries, company_type, company_size,
+  visa_sponsorship, salary_currency, salary_period, skills, salary_min,
+  salary_max, experience_years_min, and `posted_ts`. The raw `remote` flag SHALL
+  NOT be a filterable attribute (work_mode subsumes it).
+- **sortable attributes**: posted_at, created_at, view_count,
+  enrichment.salary_min, enrichment.salary_max. The endpoint's `sort` values are
+  the bare names — a request says `sort=salary_min`, which the handler maps to the
+  nested attribute. The two salary facets live under `enrichment`, the two dates
+  and the view count do not, and this list names the ATTRIBUTES rather than the
+  aliases. (`created_at` was already accepted and already declared in code; this
+  list had drifted.)
+- **one embedder**, named for the skill vector it carries, declared as
+  `userProvided` at the width `skill-match-sort` assigns. Being `userProvided`
+  means Meilisearch SHALL NOT call any model: the vectors are supplied by the
+  indexers. Binary quantization SHALL be off — the vectors are sparse (a handful of
+  non-zeros out of hundreds of dimensions), and quantizing them was measured to drop
+  recall@20 from 95% to 10%.
+
+The declared embedder width SHALL NOT change without a full index rebuild, and
+until such a rebuild completes the index rejects documents carrying the new width.
+
+Each document SHALL carry a derived numeric `posted_ts` field: the unix-seconds
+value of the job's **effective** posting date — the source's `posted_at` when
+present and not in the future, otherwise the ingest time (`created_at`) — the
+same value, in epoch form, that the document's display `posted_at` reflects.
+`posted_ts` is an index-only field: it SHALL be filterable but SHALL NOT appear
+in the public job wire shape returned by the job read endpoints. Because
+`posted_ts` is derived at index time, no Postgres column or backfill is
+required; a reindex SHALL populate it on existing jobs.
+
+Geography and work mode are filtered through the document's **top-level**
+`regions`, `countries`, and `work_mode` fields — the resolved union/precedence of
+the location-derived columns and the enrichment-derived values — not through the
+`enrichment.*` dot paths. There SHALL be no separate
+`enrichment.regions`/`enrichment.countries`/`enrichment.work_mode` facet on the
+document.
+
+Facets derived from a job's `enrichment` JSONB SHALL be absent (or empty) on the
+document when the job is not yet enriched; an unenriched job SHALL still be
+indexed and findable by its text fields, and SHALL still carry any geography
+parsed from its location.
+
+A job with no skill vector SHALL still be indexed and fully searchable: the vector's
+absence affects the match ordering alone, never that job's presence in the index or
+its matching by text or any facet.
+
+`view_count` requires no new document field and no new indexing path: the index
+document embeds the public job projection, which already carries the counter, so
+every document written since the counter existed already holds it. Declaring the
+attribute sortable is the whole of the index-side change.
+
+The counter's indexed value SHALL NOT be kept current through the search outbox.
+The offline view-count worker (see `view-count-aggregation`) updates the column
+daily without enqueueing, and the incremental push is gated on indexed content
+changing, so the counter moves without triggering one. The scheduled full rebuild
+reads the counter from Postgres on every run and runs more often than the daily
+rollup that produces it, so the indexed figure is never staler than the source
+figure. Outbox plumbing for this column would therefore add a queue path that
+buys no freshness.
+
+#### Scenario: The view count is sortable without a new document field
+
+- **WHEN** the index settings declare `view_count` sortable
+- **THEN** existing documents are orderable by it with no document rewrite,
+  because the projection they embed already carries the counter
+
+#### Scenario: A job is represented as one searchable document
+
+- **WHEN** a job with title "Senior Go Developer", company "Acme", and a
+  description is indexed
+- **THEN** the `jobs` index holds one document keyed by that job's `id` whose
+  searchable text includes the title, company, and description
+
+#### Scenario: Unenriched job is still indexed with its parsed geography
+
+- **WHEN** a job with no enrichment but location `Remote - USA` is indexed
+- **THEN** the document is present and matchable by its text, with its
+  enrichment-derived facets absent or empty and its top-level `regions`/
+  `countries` carrying the parsed geography
+
+#### Scenario: Geography is filterable via the top-level regions facet
+
+- **WHEN** a job whose unioned geography includes `eu` is indexed
+- **THEN** it is returned by a filter on `regions = "eu"`
+
+#### Scenario: Document carries the effective posting date as an epoch
+
+- **WHEN** a job whose effective posting date is a given instant is indexed
+- **THEN** its document carries `posted_ts` equal to that instant in unix
+  seconds, and a job with a null or future `posted_at` carries the `created_at`
+  instant instead — matching its display `posted_at`
+
+#### Scenario: posted_ts is filterable but not in the public job shape
+
+- **WHEN** a job document is indexed and the same job is read through a public
+  job endpoint
+- **THEN** the document is filterable by a `posted_ts` numeric range, while the
+  public job wire shape does not include a `posted_ts` field
+
+#### Scenario: The index declares a model-free embedder
+
+- **WHEN** the index settings are applied
+- **THEN** they declare exactly one embedder, sourced as `userProvided` and not
+  binary-quantized, and applying them contacts no embedding service
+
+#### Scenario: A job with no recognised skills is still fully searchable
+
+- **WHEN** a job whose skills are all unrecognised is indexed
+- **THEN** it holds no usable vector, and the job remains findable by text and
+  filterable by every facet exactly as before
+
+### Requirement: Default ordering is newest-added first
+
+A search request with no query text and no valid `sort` parameter SHALL return
+jobs ordered by the source's posting date (`posted_at`), newest first. A request
+with query text and no `sort` SHALL keep relevance order. An explicit valid
+`sort` parameter SHALL always take precedence. `posted_at`, `created_at` and
+`view_count` SHALL all be sortable attributes of the index and accepted `sort`
+values. The DB-backed jobs list keeps its own stable default (`created_at`
+descending) and is no longer required to match the search default — it accepts no
+`sort` parameter at all, so every ordering the feed offers is served by the search
+endpoint.
+
+`sort=view_count` orders by how many people have opened each posting. Like the
+other attribute sorts it honours `order` and defaults to descending, so the
+common case — the most-viewed postings first — needs no second parameter.
+
+`sort=match` is the one accepted value that is NOT an index attribute: it orders
+by the caller's own skill vector (see `skill-match-sort`). When it is served, the
+request SHALL carry no attribute sort directive at all, because an explicit sort
+directive takes precedence over vector ranking in the engine and would silently
+discard the ordering the caller asked for.
+
+#### Scenario: Browsing without a query shows freshest postings first
+
+- **WHEN** the search endpoint is called with empty `q` and no `sort`
+- **THEN** results are ordered `posted_at` descending
+
+#### Scenario: A text query keeps relevance order
+
+- **WHEN** the search endpoint is called with `q=golang` and no `sort`
+- **THEN** results are in relevance order (no sort directive)
+
+#### Scenario: Explicit sort wins
+
+- **WHEN** the search endpoint is called with `sort=created_at&order=desc`
+- **THEN** results are ordered by `created_at` descending regardless of `q`
+
+#### Scenario: Most-viewed ordering defaults to descending
+
+- **WHEN** the search endpoint is called with `sort=view_count` and no `order`
+- **THEN** results are ordered by `view_count` descending
+
+#### Scenario: Most-viewed ordering honours an ascending order
+
+- **WHEN** the search endpoint is called with `sort=view_count&order=asc`
+- **THEN** results are ordered by `view_count` ascending
+
+#### Scenario: A served match sort suppresses the attribute sort
+
+- **WHEN** the search endpoint serves `sort=match` for an eligible caller
+- **THEN** the engine request carries the caller's vector and no sort directive

--- a/openspec/changes/job-card-views-and-freshness-badges/specs/jobs-list-controls/spec.md
+++ b/openspec/changes/job-card-views-and-freshness-badges/specs/jobs-list-controls/spec.md
@@ -1,0 +1,145 @@
+## MODIFIED Requirements
+
+### Requirement: The feed's ordering vocabulary names relevance explicitly
+
+The jobs feed's client-side sort vocabulary SHALL be `relevance`, `newest`,
+`views` and `match`. `relevance` names the engine's own ranking — the order a
+request with query text and no `sort` parameter already receives — so that the
+control can report it rather than mislabel it. `views` orders by how many people
+have opened each posting, labelled `Most viewed`.
+
+The default SHALL be contextual: `relevance` when the filter state carries query
+text, `newest` when it does not. Serialization SHALL omit the `sort` parameter
+while the contextual default is selected, matching the endpoint's own defaults
+(see `job-search`, "Default ordering is newest-added first"): no `sort` with
+query text yields relevance, and no `sort` without query text yields `posted_at`
+descending.
+
+A non-default selection SHALL be serialized as the value the endpoint accepts:
+`newest` as `sort=posted_at`, `views` as `sort=view_count`, `match` as
+`sort=match`. Deserialization SHALL map `posted_at` back to `newest`,
+`view_count` back to `views`, and `match` back to `match`; an absent or
+unrecognised value SHALL resolve to the contextual default, so a hand-edited or
+shared link never leaves the control in a state it cannot render.
+
+The stored ordering SHALL distinguish "the caller chose this" from "no choice has
+been made"; the latter SHALL resolve to the contextual default at read time rather
+than being written into the state. Storing the resolved default instead would make
+a browse feed's `newest` indistinguishable from a chosen `newest`, so typing into
+the search box would carry `sort=posted_at` into a text search and date-order it —
+defeating the contextual default at the commonest entry point, and changing the
+serialization of the live filters so they no longer compare equal to the saved
+search they came from.
+
+`relevance` has nothing to rank against without query text. Resolving the
+selection SHALL therefore collapse `relevance` to `newest` whenever the query is
+empty. `views` SHALL NOT collapse — it ranks by a stored figure and is meaningful
+with or without query text. Both resolutions SHALL be one pure function shared by
+the control and the serializer so the two cannot disagree.
+
+#### Scenario: Browsing with no query omits the sort parameter
+
+- **WHEN** the filter state carries no query text and the selection is `newest`
+- **THEN** the serialized parameters carry no `sort` key
+
+#### Scenario: A text query defaults to relevance and omits the parameter
+
+- **WHEN** the filter state carries query text and the selection is `relevance`
+- **THEN** the serialized parameters carry no `sort` key
+
+#### Scenario: Newest under a query is sent explicitly
+
+- **WHEN** the filter state carries query text and the selection is `newest`
+- **THEN** the serialized parameters carry `sort=posted_at`
+
+#### Scenario: Most viewed is sent explicitly
+
+- **WHEN** the selection is `views`
+- **THEN** the serialized parameters carry `sort=view_count`
+
+#### Scenario: A shared most-viewed link resolves
+
+- **WHEN** parameters carrying `sort=view_count` are deserialized
+- **THEN** the selection is `views`
+
+#### Scenario: Most viewed survives clearing the query
+
+- **WHEN** the selection is `views` and the query text is emptied
+- **THEN** the resolved selection is still `views` and the serialized parameters
+  carry `sort=view_count`
+
+#### Scenario: A shared match link still resolves
+
+- **WHEN** parameters carrying `sort=match` are deserialized
+- **THEN** the selection is `match`
+
+#### Scenario: An unrecognised sort value falls back to the contextual default
+
+- **WHEN** parameters carrying `sort=bogus` and query text are deserialized
+- **THEN** the selection is `relevance`
+
+#### Scenario: Relevance collapses when the query is cleared
+
+- **WHEN** the selection is `relevance` and the query text is emptied
+- **THEN** the resolved selection is `newest` and the serialized parameters carry
+  no `sort` key
+
+#### Scenario: Typing a query does not pin the browse ordering
+
+- **WHEN** query text is added to a filter state whose ordering was never chosen
+- **THEN** the resolved selection is `relevance` and the serialized parameters
+  carry no `sort` key
+
+### Requirement: The sort control is shown whenever it offers a choice
+
+The jobs list SHALL render its sort control whenever the control holds more than
+one option, and SHALL omit it otherwise. Option availability SHALL be:
+
+- `newest` — always available.
+- `views` — always available. It ranks by a stored figure, so it needs neither
+  query text nor a signed-in profile.
+- `relevance` — available only when the filter state carries query text.
+- `match` — available only under the existing precondition (an authenticated
+  caller whose loaded profile names at least one skill, and the runtime flag).
+
+Because `newest` and `views` are both unconditional, the control now holds at
+least two options for every caller and is therefore rendered on every listing.
+The "omit it otherwise" clause is retained rather than dropped: it is the rule
+that makes the control's presence a consequence of what it can offer, and a
+future ordering could narrow the set again.
+
+A signed-out visitor searching by text therefore reaches the freshest-first
+ordering, which is the reachability gap this replaces: the control was previously
+rendered only under the `match` precondition, so the only ordering a signed-out
+visitor could ever receive under query text was relevance, unlabelled.
+
+The URL parameter SHALL be honoured regardless of whether the control is
+rendered, unchanged from today: the endpoint degrades an ordering it cannot serve
+rather than refusing it. When the resolved ordering is one the control does not
+offer, the control SHALL show the ordering the endpoint will actually serve that
+caller rather than an unrepresented value — a select whose value matches no option
+renders blank, which would put an empty control over a live ordering.
+
+#### Scenario: A signed-out visitor with a text query can reorder
+
+- **WHEN** a signed-out visitor searches for text
+- **THEN** the sort control is rendered offering `Relevance`, `Newest` and
+  `Most viewed`
+
+#### Scenario: A signed-out visitor browsing is offered two orderings
+
+- **WHEN** a signed-out visitor opens the list with no query text
+- **THEN** the sort control is rendered offering `Newest` and `Most viewed`
+- **AND** the feed is ordered freshest first
+
+#### Scenario: An eligible caller is offered the match sort
+
+- **WHEN** an authenticated caller whose profile names skills views the list with
+  the match flag enabled
+- **THEN** the sort control additionally offers `Best match`
+
+#### Scenario: A shared match link renders as what it will actually serve
+
+- **WHEN** a signed-out visitor opens a link carrying `q=go&sort=match`
+- **THEN** the control shows `Relevance` — the ordering the endpoint degrades to —
+  and the `sort=match` parameter is left in the URL untouched

--- a/openspec/changes/job-card-views-and-freshness-badges/specs/jobs-list-controls/spec.md
+++ b/openspec/changes/job-card-views-and-freshness-badges/specs/jobs-list-controls/spec.md
@@ -90,6 +90,13 @@ the control and the serializer so the two cannot disagree.
 - **THEN** the resolved selection is `relevance` and the serialized parameters
   carry no `sort` key
 
+#### Scenario: A typed query still matches the saved search it came from
+
+- **WHEN** the saved search `q=go` is compared against a filter state reached by
+  typing `go` with no ordering chosen
+- **THEN** the two serialize identically, so the saved search reads as active
+  rather than dirty and saving again does not create a duplicate
+
 ### Requirement: The sort control is shown whenever it offers a choice
 
 The jobs list SHALL render its sort control whenever the control holds more than

--- a/openspec/changes/job-card-views-and-freshness-badges/specs/saved-searches/spec.md
+++ b/openspec/changes/job-card-views-and-freshness-badges/specs/saved-searches/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Save a filter set
+A signed-in user SHALL be able to save the current job-search filter state under a name. The saved set captures the canonical search query string (the same serialization the filter URL and `GET /api/v1/jobs/search` use), so re-applying it reproduces the exact filters, including an empty query string which represents "show all".
+
+The canonical query SHALL NOT carry the feed's ordering. A saved search is about WHICH jobs are in the set, and the ordering does not change that: the digest matcher reads a stored query for its text and filters only and orders by its own clock, so two sets differing only by `sort` deliver identical mail. Including the ordering in the key therefore made a chosen ordering mark the saved search it came from as dirty, and saving again created a duplicate set that mailed the same jobs. Re-applying a saved search accordingly restores its filters and leaves the ordering at the contextual default.
+
+#### Scenario: Create a saved search
+- **WHEN** an authenticated user sends `POST /api/v1/me/searches` with a valid `name` and a `query` string
+- **THEN** the system stores the set scoped to that user and responds `201` with `{"data": {id, name, query, updated_at}}`
+
+#### Scenario: Empty query is valid
+- **WHEN** an authenticated user creates a saved search with `query` equal to an empty string
+- **THEN** the system stores it (it represents the unfiltered "show all" view) and responds `201`
+
+#### Scenario: Unauthenticated request is rejected
+- **WHEN** a request without a valid session cookie hits any `/api/v1/me/searches` endpoint
+- **THEN** the system responds `401` and stores nothing
+
+#### Scenario: Choosing an ordering does not fork the saved search
+- **WHEN** a filter set saved while browsing is then reordered — for example to `Most viewed` — and compared against the stored set
+- **THEN** the two canonical queries are equal, so the saved search still reads as active rather than dirty and saving again creates no duplicate
+
+#### Scenario: The ordering is absent from the stored query
+- **WHEN** a filter set carrying an explicit ordering is serialized as a saved search
+- **THEN** the resulting query string carries no `sort` key, while every filter that decides which jobs are in the set is preserved

--- a/openspec/changes/job-card-views-and-freshness-badges/specs/web-frontend/spec.md
+++ b/openspec/changes/job-card-views-and-freshness-badges/specs/web-frontend/spec.md
@@ -1,0 +1,61 @@
+## MODIFIED Requirements
+
+### Requirement: Already-viewed jobs are visually marked in the browse list
+
+The SPA SHALL visually de-emphasise job cards that the signed-in user has already
+viewed, in both the jobs list and the search results, so they can tell at a
+glance what they have already opened. The marking SHALL be driven by the set of
+viewed slugs read from `GET /api/v1/me/tracking/viewed`, loaded once when a signed-in
+user opens the browse view. A viewed card SHALL be dimmed (reduced opacity) and
+SHALL return to full strength on hover to signal it remains clickable. For
+anonymous (signed-out) visitors no card SHALL be dimmed. Surfaces where every
+listed job is by definition already viewed (the My Jobs history and board) SHALL
+NOT dim their cards.
+
+Alongside the dimming, the card's header rail carries a glyph marking the card as
+personally viewed. That glyph SHALL NOT be an eye, because the same rail now
+carries the public view count under an eye (see `job-engagement-counts`). Two eyes
+in one rail, one meaning "you opened this" and one meaning "this many people
+opened this", cannot be told apart. The personal marker SHALL therefore be a
+check — read as "seen by you" — leaving the eye to the count.
+
+#### Scenario: Signed-in user sees viewed jobs dimmed
+
+- **WHEN** a signed-in user who has viewed some jobs opens the jobs list or runs
+  a search
+- **THEN** the cards for jobs in their viewed-slug set are rendered dimmed
+- **AND** cards for jobs they have not viewed are rendered at full strength
+
+#### Scenario: Hovering a viewed card restores it
+
+- **WHEN** the user hovers a dimmed (viewed) job card
+- **THEN** the card returns to full strength while hovered
+
+#### Scenario: Anonymous visitor sees no dimming
+
+- **WHEN** a signed-out visitor opens the jobs list or runs a search
+- **THEN** no job card is dimmed
+
+#### Scenario: Opening a job marks it viewed without a reload
+
+- **WHEN** a signed-in user opens a job from the list and navigates back
+- **THEN** that job's card is shown dimmed without requiring a full reload
+
+#### Scenario: My Jobs surfaces are not dimmed
+
+- **WHEN** a signed-in user opens the My Jobs history or board, where every card
+  is already viewed
+- **THEN** no card is dimmed
+
+#### Scenario: The personal viewed marker is a check, not an eye
+
+- **WHEN** a signed-in user's already-viewed job card is rendered
+- **THEN** its personal marker is a check glyph
+- **AND** the eye glyph in the same rail carries the public view count
+
+#### Scenario: A viewed card with views shows both marks unambiguously
+
+- **WHEN** a card is rendered for a job the signed-in user has viewed and whose
+  `view_count` is 231
+- **THEN** the rail shows a check for the personal mark and an eye with 231 for
+  the count

--- a/openspec/changes/job-card-views-and-freshness-badges/tasks.md
+++ b/openspec/changes/job-card-views-and-freshness-badges/tasks.md
@@ -110,13 +110,23 @@
 
 ## 9. Rollout
 
+`release.sh` builds the Go binary and the SvelteKit app in ONE blue/green flip, so
+9.3 and 9.4 are a single release. 9.2 is therefore a hard gate, not a step to do
+"around the same time": if the release lands first, every caller who picks the new
+ordering — or opens a shared `?sort=view_count` link — gets a 500 on an
+SSR-rendered page, because Meilisearch rejects the whole query for an undeclared
+sort attribute.
+
 - [ ] 9.1 Confirm the in-flight rebuild has landed and the Meilisearch task queue
   is clear before touching index settings.
 - [ ] 9.2 Make `view_count` sortable on the live index — via a rebuild, or by
-  patching with the **complete** five-attribute list — then read the setting back
-  to confirm it applied. A partial patch would drop `posted_at` and break the
-  feed's default ordering.
-- [ ] 9.3 Deploy the Go change and verify `/jobs/search?sort=view_count` returns
-  200 with a plausibly ordered page on production.
-- [ ] 9.4 Deploy the frontend change and verify the card and the sort option on
-  production.
+  patching with the **complete** five-attribute list — then read
+  `sortableAttributes` back and confirm all five are present. A partial patch
+  would drop `posted_at` and break the feed's default ordering for everyone. A
+  200 on the patch means the task was accepted, not that it ran.
+- [ ] 9.3 Only after 9.2 reads back clean, run the release (it carries the Go
+  change and the card together). Verify `/jobs/search?sort=view_count` returns 200
+  with a plausibly ordered page on production.
+- [ ] 9.4 Verify on production: the count and badges on a browse card, no badges
+  on the company page and tracking board, the detail page unchanged, and the
+  signal row on a phone-width viewport.

--- a/openspec/changes/job-card-views-and-freshness-badges/tasks.md
+++ b/openspec/changes/job-card-views-and-freshness-badges/tasks.md
@@ -1,0 +1,122 @@
+## 1. Shared count formatting
+
+- [x] 1.1 Move `formatCount` (and its `trimZero` helper) from
+  `web/src/lib/activityChart.ts` to `web/src/lib/utils.ts`, and import it back
+  into `activityChart.ts` from its new home. No behaviour change: `697191` still
+  renders `697K` and `3354251` still renders `3.4M`.
+- [x] 1.2 Add unit tests for `formatCount` in `web/src/lib/utils.test.ts` if the
+  move left it uncovered — the card is now a second caller, so the boundaries
+  (999, 1000, 99999, 1e6) need pinning.
+- [x] 1.3 Verify no other module imported `formatCount` from `activityChart.ts`;
+  update any that did.
+
+## 2. The card's reality-requiring badge gate
+
+- [x] 2.1 In `web/src/lib/freshness.test.ts`, write failing tests for a new
+  exported wrapper: it returns no badges when the reality signal is absent, and
+  delegates to `freshnessBadges` when it is present (fresh 1-day-old job with 0
+  applies → both badges; non-fresh → none).
+- [x] 2.2 Add the wrapper to `web/src/lib/freshness.ts` with a comment naming why
+  the card is stricter than the shared rule (the `/jobs` list and the `Card`
+  projection carry no reality signal, so the date would stand alone on exactly
+  the postings the gate exists to suppress).
+- [x] 2.3 Confirm `freshnessBadges` itself is unchanged and all 12 existing tests
+  still pass — the detail page's behaviour must not move.
+
+## 3. The card: view count and glyph swap
+
+- [x] 3.1 In `web/src/lib/components/JobRow.svelte`, derive the view count from
+  `'view_count' in job ? job.view_count : undefined` so the `Card` projection
+  (which has no such field) degrades rather than throwing.
+- [x] 3.2 Render the count in the header rail to the left of the `timeAgo` stamp:
+  an `Eye` icon plus `formatCount(views)`, rendered only when the count is above
+  zero. Give it an accessible label so the glyph is not the only carrier of
+  meaning.
+- [x] 3.3 Swap the personal "you have viewed this" marker from `Eye` to `Check`
+  (update the import and the `aria-label`), so the rail's eye means the public
+  count and nothing else. Update the comment above it explaining the split.
+- [ ] 3.4 Verify the rail still respects the `pr-9` save-button gutter and that a
+  long company name plus a five-digit count still keeps the rail on one line.
+
+## 4. The card: freshness badges
+
+- [x] 4.1 In `JobRow.svelte`, compute the badges via the new wrapper, passing the
+  job's `posted_at`, its `reality` (already derived in the component) and its
+  `applied_count` where present.
+- [x] 4.2 Render each badge in the existing signal row using `Badge`
+  `variant="brand"`, positioned after the reality/ghost chip and before the facet
+  tags. Carry each badge's `tooltip` through as its `title`.
+- [x] 4.3 Widen the signal row's render guard to include the badges, so a
+  badge-earning job with no reality chip, no tags, no countries and no
+  credentials still opens the row.
+- [ ] 4.4 Check the row's wrapping on a narrow (phone-width) viewport with both
+  badges plus several facet chips present.
+
+## 5. Backend: make `view_count` sortable
+
+- [x] 5.1 Add `"view_count"` to `SortableAttributes` in
+  `internal/search/search/client.go`, extending the comment above it to say that
+  the counter rides the embedded job projection and needs no document change.
+- [x] 5.2 Add `"view_count": "view_count"` to `searchSortable` in
+  `internal/api/handler/search.go`, with a comment recording that this entry must
+  never ship before the live index declares the attribute (an undeclared sort
+  attribute makes Meilisearch reject the whole query, which the error mapping
+  turns into a 500).
+- [x] 5.3 Write/extend a handler test asserting `searchSort` resolves
+  `sort=view_count` to `view_count:desc` by default and honours
+  `order=asc`.
+- [x] 5.4 Extend the search settings test to assert `view_count` is among the
+  declared sortable attributes.
+- [x] 5.5 Run `gofmt -w` on the touched files, then `go vet ./...` and
+  `go test ./...`; run `go vet -tags=integration ./...` before pushing.
+
+## 6. Frontend: the `Most viewed` ordering
+
+- [x] 6.1 In `web/src/lib/facetModel.test.ts`, write failing tests: `views`
+  serializes to `sort=view_count`; `sort=view_count` deserializes to `views`;
+  `views` survives clearing the query text (unlike `relevance`); `sortOptionsFor`
+  offers `views` with and without query text and with and without a profile.
+- [x] 6.2 Extend `JobSort` with `'views'`, add the `SORT_PARAM` and `SORT_LABEL`
+  entries (`view_count` / `Most viewed`), and include it unconditionally in
+  `sortOptionsFor`.
+- [x] 6.3 Update the `effectiveSort` collapse rule's comment to note that `views`
+  does not collapse when the query empties, and confirm no existing
+  `facetModel.test.ts` case regresses.
+- [x] 6.4 Confirm the sort control now renders on a signed-out browse with no
+  query (two unconditional options), and that the previously-passing
+  "no control rendered" expectation is updated in whichever test asserted it.
+
+## 7. Documentation
+
+- [x] 7.1 Add `view_count` to the documented sortable values in
+  `web/static/openapi.yaml` (the integration contract) and in
+  `web/src/lib/docs/api-spec.ts` / `web/src/lib/docs/filters.ts` if either
+  enumerates the accepted `sort` values.
+- [x] 7.2 Record the settings-before-binary ordering for this attribute in
+  `internal/search/search/AGENTS.md`, beside the existing filterable-attribute
+  and embedder hazards, including that a hand patch must send the complete
+  `sortableAttributes` list.
+
+## 8. Verification
+
+- [x] 8.1 Run the full web test suite (`pnpm test` in `web/`) and lint; run
+  `go test ./...` and `go vet -tags=integration ./...`.
+- [ ] 8.2 Run the app and confirm on the browse feed: the count renders beside the
+  timestamp, badges appear on fresh postings, a viewed card shows a check (not a
+  second eye), and `Most viewed` reorders the feed.
+- [ ] 8.3 Confirm the company detail page and tracking board render no badges (no
+  reality signal in those projections) and do not error.
+- [ ] 8.4 Confirm the job detail page is visually unchanged.
+
+## 9. Rollout
+
+- [ ] 9.1 Confirm the in-flight rebuild has landed and the Meilisearch task queue
+  is clear before touching index settings.
+- [ ] 9.2 Make `view_count` sortable on the live index — via a rebuild, or by
+  patching with the **complete** five-attribute list — then read the setting back
+  to confirm it applied. A partial patch would drop `posted_at` and break the
+  feed's default ordering.
+- [ ] 9.3 Deploy the Go change and verify `/jobs/search?sort=view_count` returns
+  200 with a plausibly ordered page on production.
+- [ ] 9.4 Deploy the frontend change and verify the card and the sort option on
+  production.

--- a/web/src/lib/activityChart.test.ts
+++ b/web/src/lib/activityChart.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildActivityChart, formatCount, pickTickIndices, type ActivityBar } from './activityChart';
+import { buildActivityChart, pickTickIndices, type ActivityBar } from './activityChart';
 import { must } from './utils';
 import type { ActivityPoint } from './types';
 
@@ -66,17 +66,9 @@ describe('buildActivityChart', () => {
   });
 });
 
-describe('formatCount', () => {
-  it('leaves small numbers as-is', () => {
-    expect(formatCount(0)).toBe('0');
-    expect(formatCount(842)).toBe('842');
-  });
-  it('abbreviates thousands and millions', () => {
-    expect(formatCount(697191)).toBe('697K');
-    expect(formatCount(3354251)).toBe('3.4M');
-    expect(formatCount(3400)).toBe('3.4K');
-  });
-});
+// formatCount moved to utils.ts when the job card joined the chart surfaces as a
+// caller; its cases (including the boundaries this block never covered) are in
+// utils.test.ts.
 
 describe('pickTickIndices', () => {
   it('labels every index when there are few', () => {

--- a/web/src/lib/activityChart.ts
+++ b/web/src/lib/activityChart.ts
@@ -90,19 +90,6 @@ export function buildActivityChart(points: ActivityPoint[]): ActivityChartModel 
   return { ...frame, bars, max, barW, slot };
 }
 
-/** Compact count formatting for axis/summary labels: 3354251 → "3.4M",
- *  697191 → "697K", 842 → "842". Full precision is left to the tooltip. */
-export function formatCount(n: number): string {
-  const abs = Math.abs(n);
-  if (abs >= 1e6) return trimZero((n / 1e6).toFixed(1)) + 'M';
-  if (abs >= 1e3) return trimZero((n / 1e3).toFixed(abs >= 1e5 ? 0 : 1)) + 'K';
-  return String(n);
-}
-
-function trimZero(s: string): string {
-  return s.replace(/\.0$/, '');
-}
-
 /** Choose which period indices get an x-axis date label. Few periods → label all;
  *  a long series is thinned to at most MAX_TICKS evenly-spaced labels, always
  *  including the first and last so the time span reads correctly. */

--- a/web/src/lib/components/ActivityBars.svelte
+++ b/web/src/lib/components/ActivityBars.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { buildActivityChart, formatCount, pickTickIndices } from '$lib/activityChart';
+  import { buildActivityChart, pickTickIndices } from '$lib/activityChart';
+  import { formatCount } from '$lib/utils';
   import type { ActivityPoint } from '$lib/types';
 
   // A grouped bar chart of catalogue flow: per period, a green "added" bar and a

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -104,20 +104,15 @@
   // same way they omit salary. Zero renders nothing at all: "0 views" reads as a dead
   // figure rather than as information.
   const views = $derived('view_count' in job ? job.view_count : 0);
+  const applied = $derived('applied_count' in job ? job.applied_count : 0);
   // The two freshness badges, through the card's own gate: a projection that carries no
   // reality signal earns none, because on those surfaces the posting date alone would
   // vouch for a job the signal was written to distrust. Thresholds and wording are the
-  // shared rule's — the same one the job's own page renders.
-  //
-  // Closed jobs are excluded here as they are there: a closed posting is never worth
-  // hurrying to. Today no listing can reach this branch (every surface that serves a
-  // closed job also carries no reality), so this states the rule rather than relying on
-  // that staying true — the two surfaces must not disagree if a projection ever gains
-  // the signal.
+  // shared rule's — the same one the job's own page renders, closed-job rule included.
+  // No listing can currently serve a closed job WITH a reality signal, so that arm is
+  // stated rather than needed; the two surfaces must not disagree if one ever does.
   const freshness = $derived(
-    job.closed_at
-      ? []
-      : cardFreshnessBadges(job.posted_at, reality, 'applied_count' in job ? job.applied_count : 0),
+    job.closed_at ? [] : cardFreshnessBadges(job.posted_at, reality, applied),
   );
 
   const MAX_SKILLS = 5;
@@ -281,14 +276,12 @@
         <Check class="size-3.5" aria-label="You have viewed this" />
       {/if}
       {#if views > 0}
-        <!-- Abbreviated (1.2K), because the rail shares its width with a company name
-             that truncates — a five-digit figure spelled out crowds the name off the
-             card. The exact number is on the job's own page. -->
+        <!-- Abbreviated only because the rail shares its width with a company name that
+             truncates, and a five-digit figure spelled out crowds the name off the card.
+             A screen reader has no such constraint, so it hears the exact figure — the
+             same one the job's own page shows. -->
         <span class="flex items-center gap-1 text-xs tabular-nums">
           <Eye class="size-3.5" aria-hidden="true" />
-          <!-- The abbreviation exists only for the rail's width, which is not a
-               constraint a screen reader has — so it announces the exact figure, the
-               same one the job's own page shows. -->
           <span aria-hidden="true">{formatCount(views)}</span>
           <span class="sr-only">{views} views</span>
         </span>

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import { resolve } from '$app/paths';
-  import { Bookmark, Eye, EyeOff, FileText, Lock } from '@lucide/svelte';
+  import { Bookmark, Check, Eye, EyeOff, FileText, Lock } from '@lucide/svelte';
   import { companyLogoUrl } from '$lib/logo';
   import CountryFlagStack from './CountryFlagStack.svelte';
   import JobMatchBar from './JobMatchBar.svelte';
@@ -22,7 +22,8 @@
   import RealityBadge from './RealityBadge.svelte';
   import SkillIcon from './SkillIcon.svelte';
   import { skillLabel } from '$lib/facets';
-  import { timeAgo } from '$lib/utils';
+  import { formatCount, timeAgo } from '$lib/utils';
+  import { cardFreshnessBadges } from '$lib/freshness';
   import { hasViewed } from '$lib/viewedJobs.svelte';
   import { isSaved, markSaved, markUnsaved } from '$lib/savedJobs.svelte';
   import { markDismissed, markUndismissed } from '$lib/dismissedJobs.svelte';
@@ -97,6 +98,19 @@
   const ghost = $derived('ghost' in job ? job.ghost : undefined);
   // How recently it was posted is a key signal, so it leads the header.
   const posted = $derived(timeAgo(job.posted_at));
+  // How many people have opened the posting — the materialized counter, maintained
+  // offline from the access logs (never counted on this read). A card projection does
+  // not carry it, so the `in` narrowing is what lets those rows simply omit it, the
+  // same way they omit salary. Zero renders nothing at all: "0 views" reads as a dead
+  // figure rather than as information.
+  const views = $derived('view_count' in job ? job.view_count : 0);
+  // The two freshness badges, through the card's own gate: a projection that carries no
+  // reality signal earns none, because on those surfaces the posting date alone would
+  // vouch for a job the signal was written to distrust. Thresholds and wording are the
+  // shared rule's — the same one the job's own page renders.
+  const freshness = $derived(
+    cardFreshnessBadges(job.posted_at, reality, 'applied_count' in job ? job.applied_count : 0),
+  );
 
   const MAX_SKILLS = 5;
   const shownSkills = $derived(skills.slice(0, MAX_SKILLS));
@@ -253,8 +267,19 @@
     <div class="flex shrink-0 items-center gap-1.5 text-muted-foreground">
       {#if isViewed}
         <!-- A quiet "you've seen this" marker, paired with the lighter dim on the card
-             so viewed jobs recede without becoming hard to read. -->
-        <Eye class="size-3.5" aria-label="Viewed" />
+             so viewed jobs recede without becoming hard to read.
+             A check, not an eye: the eye beside it carries the PUBLIC view count, and
+             two eyes in one rail meaning different things cannot be told apart. -->
+        <Check class="size-3.5" aria-label="You have viewed this" />
+      {/if}
+      {#if views > 0}
+        <!-- Abbreviated (1.2K), because the rail shares its width with a company name
+             that truncates — a five-digit figure spelled out crowds the name off the
+             card. The exact number is on the job's own page. -->
+        <span class="flex items-center gap-1 text-xs tabular-nums">
+          <Eye class="size-3.5" aria-hidden="true" />
+          {formatCount(views)}<span class="sr-only"> views</span>
+        </span>
       {/if}
       {#if posted}
         <span class="text-xs tabular-nums">{posted}</span>
@@ -279,7 +304,7 @@
 
   <!-- Signal row: reality chip + the region/employment facets, grouped under the
        title as quiet outline chips so they read as metadata, not decoration. -->
-  {#if reality || tags.length > 0 || job.countries?.length || credentials.length > 0}
+  {#if reality || freshness.length > 0 || tags.length > 0 || job.countries?.length || credentials.length > 0}
     <div class="mt-2 flex flex-wrap items-center gap-1.5">
       <!-- evergreen_posting IS the reality verdict, so showing both chips states one
            fact twice, the second time louder. The ghost chip carries it inside its
@@ -289,6 +314,17 @@
       {:else}
         <RealityBadge {reality} />
       {/if}
+      <!-- Freshness before the facets: "New" is a fact about right now, the facets are
+           stable attributes of the role. Both sit behind the reality/ghost chip, because
+           a warning that a posting may not be real outranks a note that it is fresh.
+           Each badge's title is the claim's own basis, not a restatement of its label —
+           "be an early applicant" counts the people who told US they applied, and the
+           tooltip is where that limit is stated. -->
+      {#each freshness as badge (badge.label)}
+        <Badge variant="brand" class="shrink-0">
+          <span title={badge.tooltip}>{badge.label}</span>
+        </Badge>
+      {/each}
       {#each tags as tag (tag)}
         <Badge variant="outline">{tag}</Badge>
       {/each}

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -108,8 +108,16 @@
   // reality signal earns none, because on those surfaces the posting date alone would
   // vouch for a job the signal was written to distrust. Thresholds and wording are the
   // shared rule's — the same one the job's own page renders.
+  //
+  // Closed jobs are excluded here as they are there: a closed posting is never worth
+  // hurrying to. Today no listing can reach this branch (every surface that serves a
+  // closed job also carries no reality), so this states the rule rather than relying on
+  // that staying true — the two surfaces must not disagree if a projection ever gains
+  // the signal.
   const freshness = $derived(
-    cardFreshnessBadges(job.posted_at, reality, 'applied_count' in job ? job.applied_count : 0),
+    job.closed_at
+      ? []
+      : cardFreshnessBadges(job.posted_at, reality, 'applied_count' in job ? job.applied_count : 0),
   );
 
   const MAX_SKILLS = 5;
@@ -278,7 +286,11 @@
              card. The exact number is on the job's own page. -->
         <span class="flex items-center gap-1 text-xs tabular-nums">
           <Eye class="size-3.5" aria-hidden="true" />
-          {formatCount(views)}<span class="sr-only"> views</span>
+          <!-- The abbreviation exists only for the rail's width, which is not a
+               constraint a screen reader has — so it announces the exact figure, the
+               same one the job's own page shows. -->
+          <span aria-hidden="true">{formatCount(views)}</span>
+          <span class="sr-only">{views} views</span>
         </span>
       {/if}
       {#if posted}
@@ -321,9 +333,14 @@
            "be an early applicant" counts the people who told US they applied, and the
            tooltip is where that limit is stated. -->
       {#each freshness as badge (badge.label)}
-        <Badge variant="brand" class="shrink-0">
-          <span title={badge.tooltip}>{badge.label}</span>
-        </Badge>
+        <!-- The tooltip rides a wrapper, not the Badge: the primitive takes only
+             variant/class/children, so a `title` passed to it would be dropped
+             silently and the badge would state a claim with its evidence gone. The
+             wrapper (rather than a span inside) also makes the badge's own padding
+             hoverable — the same shape the job's own page uses. -->
+        <span title={badge.tooltip} class="inline-flex shrink-0">
+          <Badge variant="brand">{badge.label}</Badge>
+        </span>
       {/each}
       {#each tags as tag (tag)}
         <Badge variant="outline">{tag}</Badge>

--- a/web/src/lib/components/filters/FilterSummary.svelte
+++ b/web/src/lib/components/filters/FilterSummary.svelte
@@ -14,7 +14,8 @@
   // tab drives the same control.
   let { store, exclude = [], onOpen, canSave = false, description }: { store: FilterStore; exclude?: string[]; onOpen: () => void; canSave?: boolean; description?: string } = $props();
 
-  // The current filters as the saved-search / alert target (view-only sort dropped).
+  // The current filters as the saved-search / alert target. The ordering is view-only
+  // and savedSearchQuery drops it, so reordering the feed never marks this dirty.
   const current = $derived(savedSearchQuery(store.value));
 
   function valueLabel(param: string, value: string): string {

--- a/web/src/lib/docs/api-spec.ts
+++ b/web/src/lib/docs/api-spec.ts
@@ -235,7 +235,7 @@ export const GROUPS: Group[] = [
         filterable: true,
         query: [
           { name: 'q', type: 'string', description: 'Full-text query over title, company, and description.', example: 'golang' },
-          { name: 'sort', type: 'string', description: 'One of `created_at`, `posted_at`, `salary_min`, `salary_max`. Omit for relevance/newest.', example: 'posted_at' },
+          { name: 'sort', type: 'string', description: 'One of `created_at`, `posted_at`, `view_count`, `salary_min`, `salary_max`. Omit for relevance/newest.', example: 'posted_at' },
           { name: 'order', type: 'string', description: '`asc` or `desc` (default `desc`).', example: 'desc' },
           { name: 'limit', type: 'integer', description: 'Page size, 1–100.', example: '20' },
           { name: 'offset', type: 'integer', description: 'Rows to skip; `offset + limit` ≤ 10000.', example: '0' },
@@ -259,7 +259,7 @@ export const GROUPS: Group[] = [
         query: [
           { name: 'q', type: 'string', description: 'Full-text query over title, company, and description.', example: 'golang' },
           { name: 'description_format', type: 'string', description: 'One of `html` (default, verbatim), `text` (tags stripped), `markdown` (HTML converted to Markdown). Unknown values fall back to `html`.', example: 'markdown' },
-          { name: 'sort', type: 'string', description: 'One of `created_at`, `posted_at`, `salary_min`, `salary_max`. Omit for relevance/newest.', example: 'posted_at' },
+          { name: 'sort', type: 'string', description: 'One of `created_at`, `posted_at`, `view_count`, `salary_min`, `salary_max`. Omit for relevance/newest.', example: 'posted_at' },
           { name: 'order', type: 'string', description: '`asc` or `desc` (default `desc`).', example: 'desc' },
           { name: 'limit', type: 'integer', description: 'Page size, 1–100.', example: '20' },
           { name: 'offset', type: 'integer', description: 'Rows to skip; `offset + limit` ≤ 10000.', example: '0' },

--- a/web/src/lib/facetModel.test.ts
+++ b/web/src/lib/facetModel.test.ts
@@ -200,6 +200,31 @@ describe('canonicalQuery', () => {
   });
 });
 
+// The ordering is a view preference, not part of WHICH jobs a saved search is about.
+// The digest matcher already reads a stored query for `q` and the filter only and
+// orders by its own clock (internal/engage/notify/match.go), so two sets differing
+// only by sort deliver identical mail — they are duplicates, and the key must say so.
+describe('savedSearchQuery', () => {
+  it('drops the ordering from the saved-search key', () => {
+    expect(new URLSearchParams(savedSearchQuery(withQuery('go', 'views'))).get('sort')).toBeNull();
+    expect(new URLSearchParams(savedSearchQuery(withQuery('go', 'newest'))).get('sort')).toBeNull();
+    expect(new URLSearchParams(savedSearchQuery(withQuery('go', 'match'))).get('sort')).toBeNull();
+  });
+
+  it('keeps every filter that decides which jobs are in the set', () => {
+    const q = savedSearchQuery({ ...withSkills({ include: ['go'] }), sort: 'views' });
+    expect(new URLSearchParams(q).getAll('skills')).toEqual(['go']);
+    expect(new URLSearchParams(q).get('sort')).toBeNull();
+  });
+
+  // The point of the fix: picking an ordering must not fork the saved search it came
+  // from into a second set that mails the same jobs.
+  it('makes two orderings of one filter set the same saved search', () => {
+    expect(savedSearchQuery(withQuery('go', 'views'))).toBe(savedSearchQuery(withQuery('go', 'newest')));
+    expect(canonicalQuery('q=go&sort=view_count')).toBe(canonicalQuery('q=go'));
+  });
+});
+
 describe('activeFilterCount', () => {
   it('counts included and excluded values plus scalar filters', () => {
     const f = withSkills({ include: ['a', 'b'], exclude: ['c'] });

--- a/web/src/lib/facetModel.test.ts
+++ b/web/src/lib/facetModel.test.ts
@@ -358,16 +358,50 @@ describe('sort', () => {
   it('still sends an explicitly chosen newest under a query', () => {
     expect(filtersToParams(withQuery('go', 'newest')).get('sort')).toBe('posted_at');
   });
+
+  // Most viewed is never a contextual default, so it always serializes, and it round
+  // trips through the wire name the endpoint accepts.
+  it('round trips most-viewed through sort=view_count', () => {
+    expect(filtersToParams(withQuery('', 'views')).get('sort')).toBe('view_count');
+    expect(filtersToParams(withQuery('go', 'views')).get('sort')).toBe('view_count');
+    expect(filtersFromParams(new URLSearchParams('sort=view_count')).sort).toBe('views');
+  });
+
+  // `relevance` collapses to `newest` when the query empties because it has nothing left
+  // to rank against. `views` ranks by a stored figure, so it must survive that — the
+  // ordering the caller chose is still perfectly servable.
+  it('keeps most-viewed when the query is cleared', () => {
+    expect(effectiveSort(withQuery('', 'views'))).toBe('views');
+    expect(filtersToParams(withQuery('', 'views')).get('sort')).toBe('view_count');
+  });
 });
 
 // The option list is the sort control's visibility rule, kept pure and out of the
 // component so it can be tested at all — the same argument that put effectiveSort here.
 describe('sort options', () => {
   it('offers relevance only under a query, and match only when it can be served', () => {
-    expect(sortOptionsFor('', false).map((o) => o.value)).toEqual(['newest']);
-    expect(sortOptionsFor('go', false).map((o) => o.value)).toEqual(['relevance', 'newest']);
-    expect(sortOptionsFor('', true).map((o) => o.value)).toEqual(['newest', 'match']);
-    expect(sortOptionsFor('go', true).map((o) => o.value)).toEqual(['relevance', 'newest', 'match']);
+    expect(sortOptionsFor('', false).map((o) => o.value)).toEqual(['newest', 'views']);
+    expect(sortOptionsFor('go', false).map((o) => o.value)).toEqual(['relevance', 'newest', 'views']);
+    expect(sortOptionsFor('', true).map((o) => o.value)).toEqual(['newest', 'views', 'match']);
+    expect(sortOptionsFor('go', true).map((o) => o.value)).toEqual([
+      'relevance',
+      'newest',
+      'views',
+      'match',
+    ]);
+  });
+
+  // `views` ranks by a stored figure, so unlike `relevance` it needs no query text and
+  // unlike `match` it needs no profile. Being unconditional it joins `newest`, which
+  // means the control now holds two options for every caller and is therefore rendered
+  // on every listing — including the signed-out browse that previously showed none.
+  it('offers most-viewed unconditionally', () => {
+    for (const q of ['', 'go']) {
+      for (const matchAvailable of [false, true]) {
+        expect(sortOptionsFor(q, matchAvailable).map((o) => o.value)).toContain('views');
+      }
+    }
+    expect(sortOptionsFor('', false).length).toBeGreaterThan(1);
   });
 
   // A shared ?sort=match link opened signed out: the param survives (the server degrades

--- a/web/src/lib/facetModel.ts
+++ b/web/src/lib/facetModel.ts
@@ -331,12 +331,22 @@ export function canonicalQuery(query: string): string {
   return savedSearchQuery(filtersFromParams(new URLSearchParams(query)));
 }
 
-/** The saved-search / alert target: the filters as a canonical query string. A thin,
- *  named wrapper over filtersToParams so the saved-search call sites (SavedSearches,
- *  FilterSummary, CompanyFollowButton) express intent ("the comparable query for this
- *  filter set") rather than reaching for the raw serializer. */
+/** The saved-search / alert target: the filters as a canonical query string, WITHOUT
+ *  the ordering. A named wrapper over filtersToParams so the saved-search call sites
+ *  (SavedSearches, FilterSummary, CompanyFollowButton) express intent ("the comparable
+ *  query for this filter set") rather than reaching for the raw serializer.
+ *
+ *  The ordering is dropped because a saved search is about WHICH jobs are in the set,
+ *  and the ordering does not change that. The digest matcher agrees already: it reads a
+ *  stored query for `q` and the filter only and orders by its own clock
+ *  (internal/engage/notify/match.go), so two sets differing only by sort mail the same
+ *  jobs. Keeping the sort in the key made them compare unequal anyway, so choosing an
+ *  ordering marked the saved search it came from as dirty and saving again created a
+ *  duplicate that delivered identical digests. */
 export function savedSearchQuery(f: JobFilters): string {
-  return filtersToParams(f).toString();
+  const p = filtersToParams(f);
+  p.delete('sort');
+  return p.toString();
 }
 
 // ---- per-value sign transitions (pure: FacetState -> FacetState) ----

--- a/web/src/lib/facetModel.ts
+++ b/web/src/lib/facetModel.ts
@@ -62,10 +62,11 @@ export interface JobFilters {
   experienceYearsMax: number | null;
   /** Feed ordering, or `null` for "the caller has not chosen one".
    *
-   *  `relevance` is the engine's own ranking, `newest` is freshest first, `match` ranks
-   *  by how well a vacancy's skills overlap the signed-in caller's profile. The server
-   *  degrades `match` to its default for anyone it cannot serve it to — anonymous, no
-   *  profile, no skills — so this is never gated client-side beyond hiding the option.
+   *  `relevance` is the engine's own ranking, `newest` is freshest first, `views` is
+   *  most-opened first, and `match` ranks by how well a vacancy's skills overlap the
+   *  signed-in caller's profile. The server degrades `match` to its default for anyone
+   *  it cannot serve it to — anonymous, no profile, no skills — so this is never gated
+   *  client-side beyond hiding the option.
    *
    *  The `null` matters because the DEFAULT depends on `q` (see defaultSortFor) while
    *  `q` changes under the ordering's feet. Storing the resolved default instead would
@@ -78,8 +79,9 @@ export interface JobFilters {
 
 /** The feed's ordering vocabulary. Deliberately short: this is not a general sort
  *  control (the API also accepts created_at and the salary bounds), it is the two
- *  orderings the endpoint defaults between plus the profile-match feed. */
-export type JobSort = 'relevance' | 'newest' | 'match';
+ *  orderings the endpoint defaults between, plus the profile-match feed and the
+ *  most-opened feed. */
+export type JobSort = 'relevance' | 'newest' | 'views' | 'match';
 
 /** The ordering the endpoint applies when a request carries no `sort` at all:
  *  relevance under query text, posting date without it (see `searchSort` in
@@ -94,9 +96,12 @@ export function defaultSortFor(q: string): JobSort {
  *
  *  An unchosen ordering resolves to the contextual default, and an explicit
  *  `relevance` collapses to the browse default once the query is cleared — it has
- *  nothing left to rank against. This is a pure function, not an effect that rewrites
- *  the stored value, because BOTH the sort control and filtersToParams need the answer
- *  and a second copy of the rule is a second answer. */
+ *  nothing left to rank against. `relevance` is the ONLY ordering that collapses:
+ *  `views` ranks by a stored figure, so an emptied query leaves it perfectly
+ *  servable and discarding the caller's choice there would be a bug, not a fallback.
+ *  This is a pure function, not an effect that rewrites the stored value, because BOTH
+ *  the sort control and filtersToParams need the answer and a second copy of the rule
+ *  is a second answer. */
 export function effectiveSort(f: JobFilters): JobSort {
   const sort = f.sort ?? defaultSortFor(f.q);
   return sort === 'relevance' && !f.q ? 'newest' : sort;
@@ -106,7 +111,11 @@ export function effectiveSort(f: JobFilters): JobSort {
  *  is absent on purpose: the endpoint spells it as no `sort` parameter at all, and
  *  inventing a wire value for it would need a handler branch to mean the same thing —
  *  so a sort with no entry here is one that serializes to nothing. */
-const SORT_PARAM: Partial<Record<JobSort, string>> = { newest: 'posted_at', match: 'match' };
+const SORT_PARAM: Partial<Record<JobSort, string>> = {
+  newest: 'posted_at',
+  views: 'view_count',
+  match: 'match',
+};
 
 /** SORT_PARAM inverted, so the two directions cannot drift. */
 const SORT_FROM_PARAM: Record<string, JobSort> = Object.fromEntries(
@@ -116,6 +125,7 @@ const SORT_FROM_PARAM: Record<string, JobSort> = Object.fromEntries(
 const SORT_LABEL: Record<JobSort, string> = {
   relevance: 'Relevance',
   newest: 'Newest',
+  views: 'Most viewed',
   match: 'Best match',
 };
 
@@ -127,15 +137,24 @@ export interface SortOption {
 /** The orderings a caller can actually choose between, in display order.
  *
  *  `relevance` needs query text to rank against and `match` needs a profile the caller
- *  has (plus the runtime flag the view resolves); `newest` always applies. The rule is
- *  per OPTION rather than per control — gating the whole select on the match
- *  precondition, as it was, took `newest` down with it, so a signed-out visitor
- *  searching by text had no way to reach the freshest-first ordering.
+ *  has (plus the runtime flag the view resolves); `newest` and `views` always apply —
+ *  the latter ranks by a stored figure, so gating it on anything would be inventing a
+ *  precondition. The rule is per OPTION rather than per control — gating the whole
+ *  select on the match precondition, as it was, took `newest` down with it, so a
+ *  signed-out visitor searching by text had no way to reach the freshest-first ordering.
+ *
+ *  With two unconditional options the control now holds a choice for every caller, so
+ *  it renders on every listing — including the signed-out browse that used to show none.
  *
  *  It lives here, not in the view, for the reason effectiveSort does: it is pure, it
  *  decides what the user sees, and in the component nothing could test it. */
 export function sortOptionsFor(q: string, matchAvailable: boolean): SortOption[] {
-  const values: JobSort[] = [...(q ? (['relevance'] as const) : []), 'newest', ...(matchAvailable ? (['match'] as const) : [])];
+  const values: JobSort[] = [
+    ...(q ? (['relevance'] as const) : []),
+    'newest',
+    'views',
+    ...(matchAvailable ? (['match'] as const) : []),
+  ];
   return values.map((value) => ({ value, label: SORT_LABEL[value] }));
 }
 

--- a/web/src/lib/facetModel.ts
+++ b/web/src/lib/facetModel.ts
@@ -342,11 +342,13 @@ export function canonicalQuery(query: string): string {
  *  (internal/engage/notify/match.go), so two sets differing only by sort mail the same
  *  jobs. Keeping the sort in the key made them compare unequal anyway, so choosing an
  *  ordering marked the saved search it came from as dirty and saving again created a
- *  duplicate that delivered identical digests. */
+ *  duplicate that delivered identical digests.
+ *
+ *  It serializes with the ordering UNCHOSEN rather than deleting the key afterwards:
+ *  `null` is the type's own word for "no choice", and filtersToParams already writes
+ *  nothing for it, so this cannot drift if the wire parameter is ever renamed. */
 export function savedSearchQuery(f: JobFilters): string {
-  const p = filtersToParams(f);
-  p.delete('sort');
-  return p.toString();
+  return filtersToParams({ ...f, sort: null }).toString();
 }
 
 // ---- per-value sign transitions (pure: FacetState -> FacetState) ----

--- a/web/src/lib/freshness.test.ts
+++ b/web/src/lib/freshness.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Reality } from './generated/contracts';
-import { daysSince, freshnessBadges } from './freshness';
+import { cardFreshnessBadges, daysSince, freshnessBadges } from './freshness';
 
 const daysAgo = (n: number) => new Date(Date.now() - n * 86_400_000).toISOString();
 
@@ -73,5 +73,37 @@ describe('freshnessBadges', () => {
   it('states what the applied count actually counted', () => {
     const [, early] = freshnessBadges(daysAgo(1), reality(), 2);
     expect(early?.tooltip).toContain('2 people have told us they applied');
+  });
+});
+
+// The card's gate. Unlike the detail page, a card can be drawn from a projection that
+// carries no reality signal at all (the /jobs list does not attach it; the tracking and
+// assistant Card shape has no such field), and there the date would stand alone on
+// exactly the postings the fake-freshness gate exists to suppress.
+describe('cardFreshnessBadges', () => {
+  it('shows the pair when the signal is present and fresh', () => {
+    expect(cardFreshnessBadges(daysAgo(1), reality(), 0).map((b) => b.label)).toEqual([
+      'New',
+      'Be an early applicant',
+    ]);
+  });
+
+  it('shows nothing when no reality signal was computed, however fresh the date', () => {
+    expect(cardFreshnessBadges(daysAgo(0), null, 0)).toEqual([]);
+    expect(cardFreshnessBadges(daysAgo(0), undefined, 0)).toEqual([]);
+  });
+
+  it('still defers to the signal when it distrusts the date', () => {
+    expect(cardFreshnessBadges(daysAgo(0), reality({ fake_freshness: true }), 0)).toEqual([]);
+  });
+
+  it('still applies the shared thresholds', () => {
+    expect(cardFreshnessBadges(daysAgo(5), reality(), 0).map((b) => b.label)).toEqual(['New']);
+    expect(cardFreshnessBadges(daysAgo(20), reality(), 0)).toEqual([]);
+  });
+
+  // The wrapper must not quietly relax the applied bound the shared rule enforces.
+  it('still applies the shared applied-count bound', () => {
+    expect(cardFreshnessBadges(daysAgo(1), reality(), 9).map((b) => b.label)).toEqual(['New']);
   });
 });

--- a/web/src/lib/freshness.ts
+++ b/web/src/lib/freshness.ts
@@ -78,3 +78,26 @@ export function freshnessBadges(
   }
   return badges;
 }
+
+/** cardFreshnessBadges is the list card's stricter gate: no reality signal, no badges.
+ *
+ *  `freshnessBadges` lets the date stand alone when the signal is absent, which is right
+ *  on the job's own page — the detail read always computes one. A card is different,
+ *  because of where cards get their data: the browse feed is served from `/jobs/search`,
+ *  whose hits carry the signal, but the `/jobs` list never attaches it (it computes
+ *  reality only to derive the ghost verdict) and the tracking/assistant Card projection
+ *  has no such field at all. On those surfaces the gate would pass blindly and print
+ *  "New" on precisely the eight-month-old postings whose source rewrites its date every
+ *  crawl — on the surface people scan fastest and least critically.
+ *
+ *  So a card that cannot verify freshness claims nothing. An absent badge costs less
+ *  than a false one. Everything else — the thresholds, the tooltips — is the shared
+ *  rule's, deliberately not restated here. */
+export function cardFreshnessBadges(
+  postedAt?: string | null,
+  reality?: Reality | null,
+  appliedCount = 0,
+): FreshnessBadge[] {
+  if (!reality) return [];
+  return freshnessBadges(postedAt, reality, appliedCount);
+}

--- a/web/src/lib/utils.test.ts
+++ b/web/src/lib/utils.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { formatCount } from './utils';
+
+// formatCount lives here rather than in activityChart because its callers share nothing
+// with a chart module: two axis labels (activity bars, skill pulse) and the job card's
+// view count. The card also imports timeAgo from here for the very same header rail, so
+// the two rail helpers sit together.
+describe('formatCount', () => {
+  it('leaves counts under a thousand alone', () => {
+    expect(formatCount(0)).toBe('0');
+    expect(formatCount(842)).toBe('842');
+  });
+
+  // 999 → 1000 is the first threshold, and it is the one a view count crosses daily.
+  it('abbreviates at the thousand boundary and not before', () => {
+    expect(formatCount(999)).toBe('999');
+    expect(formatCount(1000)).toBe('1K');
+  });
+
+  it('keeps one decimal below a hundred thousand', () => {
+    expect(formatCount(1240)).toBe('1.2K');
+    expect(formatCount(3400)).toBe('3.4K');
+  });
+
+  // Above 1e5 the decimal is dropped, so 99999 rounds up into a bare 100K by the
+  // one-decimal branch and 100000 reaches the same string by the zero-decimal one.
+  // Both spellings must agree, or the label would jump backwards across the boundary.
+  it('drops the decimal from a hundred thousand up', () => {
+    expect(formatCount(99999)).toBe('100K');
+    expect(formatCount(100000)).toBe('100K');
+    expect(formatCount(697191)).toBe('697K');
+  });
+
+  it('switches to millions at a million', () => {
+    expect(formatCount(999999)).toBe('1000K');
+    expect(formatCount(1000000)).toBe('1M');
+    expect(formatCount(3354251)).toBe('3.4M');
+  });
+
+  // A trailing ".0" is trimmed rather than shown, so a round figure reads "1K" and
+  // never "1.0K".
+  it('trims a trailing zero decimal', () => {
+    expect(formatCount(2000)).toBe('2K');
+    expect(formatCount(2000000)).toBe('2M');
+  });
+});

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -43,6 +43,21 @@ export function isLinkedInUrl(s: string): boolean {
   return /^\/in\/[^/]+/.test(u.pathname);
 }
 
+/** Compact count formatting: 3354251 → "3.4M", 697191 → "697K", 842 → "842". Full
+ *  precision is left to whatever sits behind the label — a chart's tooltip, or the
+ *  job's own page. Shared by the activity chart's axis and the job card's view
+ *  count, which is why it lives here and not in either of them. */
+export function formatCount(n: number): string {
+  const abs = Math.abs(n);
+  if (abs >= 1e6) return trimZero((n / 1e6).toFixed(1)) + 'M';
+  if (abs >= 1e3) return trimZero((n / 1e3).toFixed(abs >= 1e5 ? 0 : 1)) + 'K';
+  return String(n);
+}
+
+function trimZero(s: string): string {
+  return s.replace(/\.0$/, '');
+}
+
 const TIME_UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
   ['year', 31536000],
   ['month', 2592000],

--- a/web/src/routes/my/market-pulse/[skill]/+page.svelte
+++ b/web/src/routes/my/market-pulse/[skill]/+page.svelte
@@ -6,7 +6,8 @@
   import { isAuthenticated } from '$lib/auth.svelte';
   import { skillLabel } from '$lib/facets';
   import { buildSkillDetailChart } from '$lib/skillDetailChart';
-  import { pickTickIndices, formatCount } from '$lib/activityChart';
+  import { pickTickIndices } from '$lib/activityChart';
+  import { formatCount } from '$lib/utils';
   import { Button } from '$lib/ui';
   import States from '$lib/components/States.svelte';
   import SkillDeltaBadge from '$lib/components/SkillDeltaBadge.svelte';

--- a/web/static/openapi.yaml
+++ b/web/static/openapi.yaml
@@ -793,11 +793,13 @@ components:
         enum:
           - created_at
           - posted_at
+          - view_count
           - salary_min
           - salary_max
       description: |
         Sort field. Omitted, a text query sorts by relevance and an empty query
-        by `posted_at` descending.
+        by `posted_at` descending. `view_count` orders by how many people have
+        opened each posting.
     Order:
       name: order
       in: query


### PR DESCRIPTION
A job card said what a role is and how old the posting is, but nothing about whether it was worth being early to. Both answers already existed and neither reached the card:

- `view_count` is on the public job projection and, because `JobDocument` embeds `jobview.Job`, already in every Meilisearch document.
- `web/src/lib/freshness.ts` has computed the **New** / **Be an early applicant** pair since the detail page shipped — used by `JobView.svelte` only.

## What changed

**The card shows the view count.** An eye glyph and the count beside the existing relative timestamp. Abbreviated (`1.2K`), because the rail shares its width with a company name that truncates. A count of `0` renders nothing. The rail's personal "you viewed this" marker becomes a **check**: the eye now carries the public count, and two eyes in one narrow rail meaning different things cannot be told apart.

**The freshness badges are reused, not reimplemented.** `freshnessBadges` is byte-identical and its 12 tests are untouched, so the card and the detail page cannot tell different stories about one posting — and the card inherits a guard a fresh implementation would have missed: a source that rewrites its posting date on every crawl (`fake_freshness`) would otherwise earn **New** on the oldest job in the catalogue.

**One rule is new: no reality signal, no badges.** The shared rule lets the date stand alone when the signal is absent, which is right on the detail page (it always computes one) and wrong on a card. `/jobs` never attaches the signal — `attachGhostToRows` computes reality only to derive the ghost verdict — and the tracking/assistant `Card` projection has no such field. There the gate would pass blindly on exactly the postings it exists to suppress. A card that cannot verify freshness now claims nothing, so the company page and tracking board show no badges rather than unverified ones.

**`Most viewed` joins the sort vocabulary.** No PG→Meili plumbing: the counter is already on every document, and the scheduled rebuild reads it from Postgres more often than the daily rollup writes it, so the indexed figure is never staler than the source figure. Two allowlist entries — `SortableAttributes` and `searchSortable`.

**A saved-search bug this change would have made routine.** `savedSearchQuery` carried `sort` into the key identifying a saved search, while the comment at its call site said it did not and the digest matcher ignores a stored sort entirely. Two sets differing only by ordering mail identical jobs while comparing unequal — so choosing an ordering marked the saved search dirty and saving again created a duplicate. Near-unreachable before, because the sort control was not rendered on a signed-out browse; `views` is never a contextual default, so it always serializes, and the control is now always rendered. The key drops the ordering, making the code, the comment and the matcher agree.

`formatCount` moves to `utils.ts`, beside `timeAgo`, which the same rail already uses.

## ⚠️ Deploy order is load-bearing

**`view_count` must be sortable on the LIVE index before this ships.** Meilisearch rejects the *whole query* for an undeclared sort attribute and the handler maps any Meili error to a 500 — so the wrong order breaks search on an SSR-rendered page, it does not ignore a parameter. `release.sh` builds the Go binary and the SvelteKit app in one flip, so there is no "frontend later" to fall back on.

**A hand patch must send the complete `sortableAttributes` list.** Meili replaces that setting wholesale; sending only `view_count` would drop `posted_at` and break the feed's *default* ordering for everyone. Read the setting back — a 200 on the patch means the task was accepted, not that it ran. Don't patch during a rebuild window (the queue is serial). Recorded in `internal/search/search/AGENTS.md` under a new "Adding a sortable attribute" section, beside the same hazard for filterable attributes.

No feature flag, deliberately: `sort=match` needed one because declaring its embedder did not retro-fill 1.36M documents, so the ordering was thin until a rebuild landed. Here the values are already present — there is no window to wait out, only a setting to verify.

## Verification

`+450 / −93` across 29 files. No migration, no new column, no queue, no backfill.

| Check | Result |
|---|---|
| Web tests | 1334 ✓ (baseline 1319) |
| `go test ./...`, `go vet ./...` | ✓ |
| `go vet -tags=integration ./...` | ✓ |
| `svelte-check` | 0 errors |
| `knip` (dead code) | ✓ |
| redocly (openapi) | valid |
| lint, gitleaks, golangci-lint, govulncheck | ✓ |
| `openspec validate` | ✓ |

Reviewed by a subagent against the spec; no Critical issues, and all three Important findings were verified against the source before being fixed.

**Not verified locally:** how it looks. The card lives on `/jobs/search`, which needs Meilisearch plus a populated catalogue. Visual confirmation is task 9.4 — the browse card, the absence of badges on the company page and tracking board, the unchanged detail page, and the signal row at phone width.

Spec: `openspec/changes/job-card-views-and-freshness-badges/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Job cards now show nonzero view counts with an eye icon and compact formatting.
  - Viewed jobs are marked with a check icon.
  - Freshness badges such as “New” and “Be an early applicant” now appear when applicable.
  - Added a “Most viewed” sorting option for job listings and search results.
  - Saved searches no longer change when only the listing order is adjusted.

- **Documentation**
  - Updated API documentation to include the `view_count` sorting option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->