### PR TITLE
Give a suggestion an identifier the engine will accept

### DIFF
--- a/internal/search/suggest/build.go
+++ b/internal/search/suggest/build.go
@@ -1,6 +1,7 @@
 package suggest
 
 import (
+	"encoding/hex"
 	"sort"
 	"strings"
 
@@ -92,7 +93,7 @@ func Build(in Input) []Document {
 			return
 		}
 		docs = append(docs, Document{
-			ID: string(kind) + ":" + slug, Text: text, Kind: kind, Slug: slug, Jobs: jobs,
+			ID: documentID(kind, slug), Text: text, Kind: kind, Slug: slug, Jobs: jobs,
 			Searches: in.Searches[Title(text)],
 		})
 	}
@@ -105,7 +106,12 @@ func Build(in Input) []Document {
 		}
 	}
 	for text, n := range merged {
-		if n < in.TitleFloor || !Offerable(text) {
+		// Two gates, and they refuse different things. `Recordable` asks whether this is
+		// a search PHRASE at all — the same question the demand path asks of typed text,
+		// and the answer that keeps a runaway title out of an id (hex doubles the value,
+		// so the engine's 511-byte ceiling is a ~255-byte one here). `Offerable` asks
+		// whether the phrase names a craft.
+		if n < in.TitleFloor || !Recordable(text) || !Offerable(text) {
 			continue
 		}
 		// A title names no facet, so its slug is empty and its id is the normalised
@@ -113,7 +119,7 @@ func Build(in Input) []Document {
 		// lowercase is what merges the spellings, and "product owner" sitting in a
 		// dropdown between "Backend Engineer" and "Google" reads as a bug.
 		docs = append(docs, Document{
-			ID: string(KindTitle) + ":" + text, Text: displayTitle(text), Kind: KindTitle, Jobs: n,
+			ID: documentID(KindTitle, text), Text: displayTitle(text), Kind: KindTitle, Jobs: n,
 			Searches: in.Searches[text],
 		})
 	}
@@ -156,6 +162,25 @@ func Build(in Input) []Document {
 	// same sequence — which is what makes a diff of two builds readable.
 	sort.Slice(docs, func(i, j int) bool { return docs[i].ID < docs[j].ID })
 	return docs
+}
+
+// documentID builds the identifier Meilisearch dedupes on.
+//
+// The engine accepts letters, digits, hyphens and underscores and nothing else, up to
+// 511 bytes. That rules out the readable separator this used to carry: the first
+// production build failed on its very first document, `company:01-tech`. It also rules
+// out characters the VALUES legitimately hold — `node.js`, `c++`, `at&t` — so the id
+// cannot simply be the value with a prefix glued on.
+//
+// So it is hex, which is legal by construction rather than by a list of the characters
+// seen so far. That costs readability in the engine's own UI and buys an id that
+// cannot be broken by a company registering a name nobody anticipated.
+//
+// The kind stays in front, unencoded, because it is a closed vocabulary of plain
+// words: `backend` is a plausible role, skill AND category, and the whole reason an id
+// is namespaced is that those three must not collide.
+func documentID(kind Kind, value string) string {
+	return string(kind) + "_" + hex.EncodeToString([]byte(value))
 }
 
 // categoryText and skillText render a slug as a person would write it. Neither

--- a/internal/search/suggest/build_test.go
+++ b/internal/search/suggest/build_test.go
@@ -2,6 +2,7 @@ package suggest
 
 import (
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -220,5 +221,85 @@ func TestBuild_DemandJoinsAMinedTitle(t *testing.T) {
 	})
 	if len(docs) != 1 || docs[0].Searches != 99 {
 		t.Errorf("a typed query must reach the title it names, got %+v", docs)
+	}
+}
+
+// Meilisearch accepts only letters, digits, hyphens and underscores in a document
+// identifier. The first production build got as far as writing and then failed on the
+// very first document:
+//
+//	Document identifier `"company:01-tech"` is invalid.
+//
+// The colon was a readable namespace separator and an illegal character, and the
+// existing tests could not see it: they asserted ids were UNIQUE, which is a property
+// of the set, while validity is a property the engine alone defines. This asserts the
+// engine's rule against every kind, including the two that produced it — a company
+// slug and a mined title, which carry the widest characters of anything here.
+func TestBuild_IdsAreAcceptableToTheEngine(t *testing.T) {
+	docs := Build(Input{
+		Titles:     map[string]int{"Node.js Developer (m/f/d)": 50, "C++ Engineer": 50},
+		TitleFloor: 1,
+		Roles:      map[string]int{"senior_backend": 10},
+		RoleLabels: map[string]string{"senior_backend": "Senior Backend Engineer"},
+		Categories: map[string]int{"ml_ai": 10},
+		Skills:     map[string]int{"ci-cd": 10, "node.js": 10},
+		Companies: []Company{
+			{Slug: "01-tech", Name: "01 Tech", Jobs: 5},
+			{Slug: "at&t", Name: "AT&T", Jobs: 5},
+		},
+	})
+	if len(docs) == 0 {
+		t.Fatal("nothing built")
+	}
+	for _, d := range docs {
+		for _, r := range d.ID {
+			ok := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+				(r >= '0' && r <= '9') || r == '-' || r == '_'
+			if !ok {
+				t.Errorf("id %q carries %q, which Meilisearch refuses", d.ID, r)
+				break
+			}
+		}
+		if len(d.ID) > 511 {
+			t.Errorf("id %q is %d bytes, over the 511 the engine allows", d.ID, len(d.ID))
+		}
+	}
+}
+
+// Namespacing is what the id is FOR — `backend` is a plausible role, skill and
+// category — so whatever encoding keeps it legal must keep it distinct too.
+func TestBuild_IdsStayDistinctAcrossKindsAfterEncoding(t *testing.T) {
+	docs := Build(Input{
+		Roles:      map[string]int{"backend": 100},
+		RoleLabels: map[string]string{"backend": "Backend"},
+		Skills:     map[string]int{"backend": 200},
+		Categories: map[string]int{"backend": 300},
+		Titles:     map[string]int{"backend": 400},
+		TitleFloor: 1,
+	})
+	seen := map[string]bool{}
+	for _, d := range docs {
+		if seen[d.ID] {
+			t.Fatalf("duplicate id %q", d.ID)
+		}
+		seen[d.ID] = true
+	}
+}
+
+// Hex doubles the length, so the engine's 511-byte id ceiling becomes a ~255-byte
+// ceiling on the value. A mined title has no such bound of its own — `Title` cuts at
+// the first separator, so a long run without one survives whole — and the id would be
+// rejected at write time, killing the build over one absurd posting.
+//
+// The judgement is the same one the demand path already makes: what is worth offering
+// is a search PHRASE, and a phrase is short. So `Recordable` gates both.
+func TestBuild_ARunawayTitleIsNotVocabulary(t *testing.T) {
+	long := strings.Repeat("engineering ", 40) // no separator, ~480 bytes
+	docs := Build(Input{
+		Titles:     map[string]int{long: 500, "Data Engineer": 500},
+		TitleFloor: 1,
+	})
+	if len(docs) != 1 || docs[0].Text != "Data Engineer" {
+		t.Fatalf("got %v", texts(docs))
 	}
 }


### PR DESCRIPTION
The first production build of the dictionary got as far as writing, then failed on
its very first document:

```
write index: task 681200 failed: Document identifier `"company:01-tech"` is invalid.
A document identifier can be of type integer or string, only composed of
alphanumeric characters (a-z A-Z 0-9), hyphens (-) and underscores (_)
```

The colon was a readable namespace separator and an illegal character. The
existing tests could not see it: they asserted ids were **unique**, which is a
property of the set, while validity is a property the engine alone defines.

**Writing the test found more than production did.** `node.js`, `c++` and `ci-cd`
all carry characters an id may not, so no prefix-plus-value scheme survives the
values this dictionary legitimately holds — the colon was the first failure, not
the only one.

The id is hex now: legal by construction rather than by a list of the characters
seen so far. It costs readability in the engine's own UI and buys an id that
cannot be broken by a company registering a name nobody anticipated. The kind
stays in front, unencoded — `backend` is a plausible role, skill AND category,
and that collision is the whole reason the id is namespaced.

Hex doubles the length, which turns the engine's 511-byte ceiling into a
~255-byte one on the value — and a mined title had no bound of its own, since
`Title` only cuts at the first separator. It is now gated by `Recordable`, the
same "is this a search phrase" judgement the demand path already makes, so one
absurd posting can no longer kill a build.