### PR TITLE
An ASCII byte is not a word boundary in any language but English

### DIFF
--- a/internal/candidate/cv/align.go
+++ b/internal/candidate/cv/align.go
@@ -4,10 +4,9 @@ import (
 	"cmp"
 	"slices"
 	"strings"
-	"unicode"
-	"unicode/utf8"
 
 	"github.com/strelov1/freehire/internal/dict/skilltag"
+	"github.com/strelov1/freehire/internal/dict/wordmatch"
 )
 
 // Align rewrites doc so skill wording matches the spellings the vacancy used (canonical →
@@ -173,7 +172,7 @@ func replaceProse(text string, rules []proseRule) string {
 func ruleAt(text, lower string, i int, rules []proseRule) (proseRule, bool) {
 	for _, r := range rules {
 		end := i + len(r.from)
-		if end <= len(text) && lower[i:end] == r.from && proseBoundary(text, i, end) {
+		if end <= len(text) && lower[i:end] == r.from && wordmatch.TechTermBoundary(text, i, end) {
 			return r, true
 		}
 	}
@@ -194,24 +193,6 @@ func asciiLower(s string) string {
 		}
 	}
 	return string(b)
-}
-
-// proseBoundary mirrors wordmatch.ASCIIBoundary but also treats non-ASCII letters
-// as word runes so Cyrillic neighbours do not get false hits.
-func proseBoundary(s string, start, end int) bool {
-	if start > 0 {
-		r, _ := utf8.DecodeLastRuneInString(s[:start])
-		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '.' || r == '-' {
-			return false
-		}
-	}
-	if end < len(s) {
-		r, _ := utf8.DecodeRuneInString(s[end:])
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			return false
-		}
-	}
-	return true
 }
 
 func documentsEqualForAlign(a, b Document) bool {

--- a/internal/dict/skilltag/AGENTS.md
+++ b/internal/dict/skilltag/AGENTS.md
@@ -46,6 +46,34 @@ through `Parse`.
   that render it must not print a placeholder — but no canonical reaches that path any
   more, which is why the chip's reveal is unconditional.
 
+## What a word boundary is, and why it is not ASCII
+
+Every alias here is ASCII, which is exactly what made it tempting to test a boundary
+by looking at ASCII bytes — and that is a statement about the TERM, not about its
+NEIGHBOURS. Both places a boundary is decided read Unicode:
+`wordmatch.TechTermBoundary` (the phrase pass) and `wordTokenRE` (the word pass).
+
+A byte-level test reads any letter outside ASCII as a separator, so a curated alias
+becomes a whole word inside every accented or non-Latin one. Measured over 4,800 live
+prod descriptions from eight sources (2026-09-03), fixing it removed **89 tags across
+74 postings (1.5%) and added none** — widening the class can only ever lengthen a
+token, so it removes fragment matches and can never lose a term the text states:
+
+| False tag | Came from |
+|---|---|
+| `typescript` ×51 | the `ts` alias inside Swedish `möts` |
+| `elk` | Hungarian `elkészítése` — 18 of 110 postings on a live Hungarian IT crawl |
+| `express` / `nim` / `vue` | Portuguese `expressão`, Catalan `mínim`, French `prévue` |
+
+Some of the removals are second-order and correct: an ambiguous single word (`ai`,
+`erp`, `networking`) tags only when a strong match corroborates it, so a posting whose
+only strong match was the false `typescript` loses both.
+
+The one thing it gives up: an English tech word inflected with a foreign suffix —
+Russian `devopsа` — used to match by the same accident that caused the false
+positives. That was 1 posting in 4,800, and the Russian sources lost essentially
+nothing, because Russian postings write the term with a space or a hyphen.
+
 ## Convention
 
 - `internal/dict/skilltag/` owns the dictionary parser and canonical vocabulary.

--- a/internal/dict/skilltag/skilltag.go
+++ b/internal/dict/skilltag/skilltag.go
@@ -35,7 +35,14 @@ var htmlTagRE = regexp.MustCompile(`<[^>]*>`)
 
 // wordTokenRE splits normalized text into bare alphanumeric tokens for the word
 // pass. Punctuated terms (c++, node.js) are handled separately by the phrase pass.
-var wordTokenRE = regexp.MustCompile(`[a-z0-9]+`)
+//
+// The class is Unicode, not [a-z0-9], even though every alias it is looked up
+// against is ASCII: an ASCII-only class ends a token at the first accented letter,
+// so an inflected foreign word DECOMPOSES into ASCII fragments and a fragment can
+// be an alias — Hungarian "elkészítése" tokenized to elk/sz/t/se and tagged ELK.
+// Widening the class only ever makes a token longer, so it removes fragment
+// matches and can never lose a term the text really states.
+var wordTokenRE = regexp.MustCompile(`[\p{L}\p{N}]+`)
 
 // sepRE matches a run of the word-joiners '-'/'_' and whitespace. It is used to
 // split a multi-word alias into its segments; the text itself is NOT rewritten, so
@@ -78,14 +85,14 @@ type phraseMatcher struct {
 }
 
 // matches reports whether the alias occurs in norm as a standalone term. Regex
-// hits are boundary-checked with the same ASCIIBoundary rule as the substring
+// hits are boundary-checked with the same TechTermBoundary rule as the substring
 // path, so a leading '-' (e.g. the "c" in "objective-c") is not a word start.
 func (m phraseMatcher) matches(norm string) bool {
 	if m.re == nil {
-		return wordmatch.Contains(norm, m.token, wordmatch.ASCIIBoundary)
+		return wordmatch.Contains(norm, m.token, wordmatch.TechTermBoundary)
 	}
 	for _, loc := range m.re.FindAllStringIndex(norm, -1) {
-		if wordmatch.ASCIIBoundary(norm, loc[0], loc[1]) {
+		if wordmatch.TechTermBoundary(norm, loc[0], loc[1]) {
 			return true
 		}
 	}
@@ -184,9 +191,10 @@ func Parse(text string, opts ...Option) []string {
 	standalone := map[string]struct{}{}
 
 	// Acronym pass: case-sensitive whole-word match over case-preserved text, so an
-	// UPPERCASE acronym resolves while its ambiguous lowercase form does not. Uses a
-	// Unicode word boundary because the text is not lowercased here (ASCIIBoundary's
-	// word test is lowercase-only and would misjudge uppercase neighbours).
+	// UPPERCASE acronym resolves while its ambiguous lowercase form does not. It takes
+	// the plain word boundary rather than TechTermBoundary because an acronym surface
+	// carries no punctuation, so the dotted/hyphenated-suffix guard has nothing to
+	// protect here.
 	cased := stripMarkup(text)
 	matchAcronyms(cased, sharedAcronyms, strong)
 	if o.resumeAcronyms {

--- a/internal/dict/skilltag/skilltag_test.go
+++ b/internal/dict/skilltag/skilltag_test.go
@@ -108,6 +108,33 @@ func TestParse_BoilerplateSectionsAreNotSkills(t *testing.T) {
 	}
 }
 
+// TestParse_AccentedWordsAreNotSkills pins the two places a word boundary is
+// decided — the phrase pass (wordmatch) and the word pass (wordTokens) — against
+// text whose letters are not ASCII. Both read a curated alias out of the middle of
+// an inflected foreign word before this: the Hungarian "elkészítése" ("preparing
+// it") yielded elk, on 18 of 110 postings sampled from a live Hungarian IT crawl.
+// The failure is not Hungarian-specific — any diacritic or non-Latin script ends an
+// ASCII-only token the same way.
+func TestParse_AccentedWordsAreNotSkills(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"hungarian inflection yields no elk", "A dokumentáció elkészítése a feladatod.", nil},
+		{"hungarian inflection beside a real stack", "Rendszertervek elkészítése Python nyelven.", []string{"python"}},
+		{"a real ELK mention still tags", "ELK stack üzemeltetése", []string{"elk"}},
+		{"lowercase elk as a whole word still tags", "we run elk for logging", []string{"elk"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Parse(tc.in); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("Parse(%q) = %#v, want %#v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestParse_SeparatorInsensitive(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/dict/wordmatch/wordmatch.go
+++ b/internal/dict/wordmatch/wordmatch.go
@@ -1,8 +1,8 @@
 // Package wordmatch reports whether a term occurs as a standalone token in a
 // string. The scan is shared; the notion of a token boundary is supplied by the
-// caller (Unicode letters/digits for title classification, ASCII alphanumerics —
-// with a leading dot/hyphen guard — for skill tags), so the two dictionaries that need
-// whole-word matching no longer hand-roll the same loop.
+// caller (plain Unicode letters/digits for title classification, the same plus a
+// leading dot/hyphen guard for curated technology terms), so the dictionaries that
+// need whole-word matching no longer hand-roll the same loop.
 package wordmatch
 
 import (
@@ -64,26 +64,22 @@ func isWordRune(r rune) bool {
 	return unicode.IsLetter(r) || unicode.IsDigit(r)
 }
 
-// ASCIIBoundary treats ASCII alphanumerics as word bytes, with one asymmetry: a
-// LEADING '.' or '-' is not a valid left boundary (the term is the suffix of a
-// larger punctuated token — "asp.net" must not match ".net", "objective-c" must not
-// match "c developer"), while a TRAILING '.' is a sentence period and is a valid
-// right boundary ("We use C#.").
-func ASCIIBoundary(s string, start, end int) bool {
-	if alnumAt(s, start-1) || byteAt(s, start-1) == '.' || byteAt(s, start-1) == '-' {
-		return false
+// TechTermBoundary is UnicodeBoundary plus one asymmetry the curated technology
+// vocabularies need: a LEADING '.' or '-' is not a valid left boundary (the term is
+// the suffix of a larger punctuated token — "asp.net" must not match ".net",
+// "objective-c" must not match "c developer"), while a TRAILING '.' is a sentence
+// period and is a valid right boundary ("We use C#.").
+//
+// The word test is Unicode, not ASCII, even though every curated spelling is ASCII.
+// A byte-level test reads a letter outside ASCII as a separator, which makes a
+// curated term a "whole word" inside any accented or non-Latin one — "elk" inside
+// the Hungarian "elkészítése", because the byte after it is the first of "é". The
+// term being ASCII says nothing about its NEIGHBOURS.
+func TechTermBoundary(s string, start, end int) bool {
+	if start > 0 {
+		if r, _ := utf8.DecodeLastRuneInString(s[:start]); r == '.' || r == '-' {
+			return false
+		}
 	}
-	return !alnumAt(s, end)
-}
-
-func byteAt(s string, i int) byte {
-	if i < 0 || i >= len(s) {
-		return 0
-	}
-	return s[i]
-}
-
-func alnumAt(s string, i int) bool {
-	c := byteAt(s, i)
-	return c >= 'a' && c <= 'z' || c >= '0' && c <= '9'
+	return UnicodeBoundary(s, start, end)
 }

--- a/internal/dict/wordmatch/wordmatch_test.go
+++ b/internal/dict/wordmatch/wordmatch_test.go
@@ -16,22 +16,45 @@ func TestContainsUnicode(t *testing.T) {
 	}
 }
 
-func TestContainsASCIIDot(t *testing.T) {
+func TestContainsTechTermDot(t *testing.T) {
 	// A leading '.' is not a valid left boundary: ".net" must not match "asp.net".
-	if Contains("we use asp.net here", ".net", ASCIIBoundary) {
+	if Contains("we use asp.net here", ".net", TechTermBoundary) {
 		t.Error("matched a dotted suffix")
 	}
 	// A trailing '.' (sentence period) is a valid right boundary.
-	if !Contains("we use c#.", "c#", ASCIIBoundary) {
+	if !Contains("we use c#.", "c#", TechTermBoundary) {
 		t.Error("missed a term before a period")
 	}
-	if !Contains("react native app", "react native", ASCIIBoundary) {
+	if !Contains("react native app", "react native", TechTermBoundary) {
 		t.Error("missed a multi-word phrase")
 	}
 }
 
+// TestTechTermBoundaryNonASCIINeighbour pins the boundary rule that a byte-level
+// ASCII test got wrong: a letter outside ASCII is still a letter, so a term
+// sitting inside an accented or Cyrillic word is not a standalone term. Reading
+// only ASCII bytes made "elk" a whole word inside the Hungarian "elkészítése"
+// (the byte after "elk" is the first of "é"), which tagged ELK/Elasticsearch on
+// 16% of a live Hungarian IT crawl.
+func TestTechTermBoundaryNonASCIINeighbour(t *testing.T) {
+	for _, tc := range []struct{ text, term string }{
+		{"a dokumentáció elkészítése a feladatod", "elk"},
+		{"münchen", "m"},
+		{"разработка", "раз"},
+		{"señor developer", "se"},
+	} {
+		if Contains(tc.text, tc.term, TechTermBoundary) {
+			t.Errorf("%q matched inside %q", tc.term, tc.text)
+		}
+	}
+	// The rule cuts only fragments: a whole term beside non-ASCII text still matches.
+	if !Contains("elk stack üzemeltetése", "elk", TechTermBoundary) {
+		t.Error("missed a whole term next to non-ASCII text")
+	}
+}
+
 func TestEmptyTermNeverMatches(t *testing.T) {
-	if Contains("anything", "", UnicodeBoundary) || Contains("anything", "", ASCIIBoundary) {
+	if Contains("anything", "", UnicodeBoundary) || Contains("anything", "", TechTermBoundary) {
 		t.Error("empty term must never match")
 	}
 }


### PR DESCRIPTION
Found while validating the Profession.hu source in #2341, which reported it as a Hungarian-language problem. It is not — it affects every language whose letters are not ASCII.

## What was wrong

The skill tagger decided "is this alias a standalone word?" by reading the bytes either side of it and asking whether they are `a-z` or `0-9`. Every alias in the dictionary is ASCII, so that looked safe. But it is a fact about the **term**, not about its **neighbours**: a letter outside ASCII reads as a separator, so a curated alias becomes a whole word inside every accented or non-Latin one.

| False tag | Came from |
|---|---|
| `elk` | Hungarian `elkészítése` — **18 of 110 postings** on a live Hungarian IT crawl, the 7th most common "skill" |
| `typescript` ×51 | the `ts` alias inside Swedish `möts` |
| `express` / `nim` / `vue` | Portuguese `expressão`, Catalan `mínim`, French `prévue` |

## The fix

Both places a boundary is decided now read Unicode:

- `wordmatch.ASCIIBoundary` → `TechTermBoundary`, built on `UnicodeBoundary`. The rename is the point: its distinguishing rule was never the ASCII test but the leading dot/hyphen guard that keeps `.net` out of `asp.net`.
- the word pass's token class widens from `[a-z0-9]` to `[\p{L}\p{N}]`. Widening it can only lengthen a token, so it removes fragment matches and cannot lose a term the text really states.
- `internal/candidate/cv/align.go` had already hit this and hand-rolled a corrected copy as `proseBoundary`; it now calls the shared one.

## Measured, not asserted

4,800 live prod descriptions across eight sources (trudvsem, gupy, infojobs, jobtech, personio, hh, nofluffjobs, greenhouse):

- **74 postings changed (1.5%), 89 tags removed, 0 added.**
- Every removal was inspected. All are fragment matches inside accented words, or ambiguous single words (`ai`, `erp`, `networking`) correctly losing corroboration once their only strong match — the false `typescript` — went.
- One genuine loss: an English tech word inflected with a foreign suffix (Russian `devopsа`) used to match by the same accident. 1 posting in 4,800; the Russian sources lost essentially nothing, because Russian postings write the term with a space or a hyphen.

## After merge

`cmd/backfill-derive` to reach the stored rows, then a reindex — the fix only reaches new crawls otherwise.
