### PR TITLE
Make a suggestion's id independent of how long its value is

### DIFF
--- a/internal/search/suggest/build.go
+++ b/internal/search/suggest/build.go
@@ -1,6 +1,7 @@
 package suggest
 
 import (
+	"crypto/sha256"
 	"encoding/hex"
 	"sort"
 	"strings"
@@ -167,20 +168,28 @@ func Build(in Input) []Document {
 // documentID builds the identifier Meilisearch dedupes on.
 //
 // The engine accepts letters, digits, hyphens and underscores and nothing else, up to
-// 511 bytes. That rules out the readable separator this used to carry: the first
-// production build failed on its very first document, `company:01-tech`. It also rules
-// out characters the VALUES legitimately hold — `node.js`, `c++`, `at&t` — so the id
-// cannot simply be the value with a prefix glued on.
+// 511 bytes, and two production builds failed here in turn:
 //
-// So it is hex, which is legal by construction rather than by a list of the characters
-// seen so far. That costs readability in the engine's own UI and buys an id that
-// cannot be broken by a company registering a name nobody anticipated.
+//   - `company:01-tech` — the readable separator was an illegal character, and so are
+//     characters the VALUES legitimately hold (`node.js`, `c++`, `at&t`), so no
+//     prefix-plus-value scheme survives this dictionary's own vocabulary;
+//   - then a 340-byte company slug — a transliterated college name — which the hex
+//     encoding that fixed the first failure doubled past the ceiling.
+//
+// So: a fixed-width hash. Legal by construction, and its length does not follow the
+// value at all — which is the property the second failure was really about. A slug
+// arrives from a feed and nobody promised its length; bounding the values we mine
+// ourselves could never have covered that.
 //
 // The kind stays in front, unencoded, because it is a closed vocabulary of plain
 // words: `backend` is a plausible role, skill AND category, and the whole reason an id
 // is namespaced is that those three must not collide.
+//
+// Readability in the engine's own UI is the cost. The document carries `kind`, `slug`
+// and `text` as fields, so nothing that has to be looked up is only in the id.
 func documentID(kind Kind, value string) string {
-	return string(kind) + "_" + hex.EncodeToString([]byte(value))
+	sum := sha256.Sum256([]byte(value))
+	return string(kind) + "_" + hex.EncodeToString(sum[:])
 }
 
 // categoryText and skillText render a slug as a person would write it. Neither

--- a/internal/search/suggest/build_test.go
+++ b/internal/search/suggest/build_test.go
@@ -303,3 +303,24 @@ func TestBuild_ARunawayTitleIsNotVocabulary(t *testing.T) {
 		t.Fatalf("got %v", texts(docs))
 	}
 }
+
+// The id must not depend on how long the VALUE is.
+//
+// Hex was legal but proportional, and the second production build failed on a company
+// slug 340 bytes long — a transliterated Russian college name — which hex doubled past
+// the engine's 511-byte ceiling. Bounding titles was not enough: a slug arrives from a
+// feed, and nobody promised its length.
+func TestBuild_IdLengthIsIndependentOfTheValue(t *testing.T) {
+	short := Build(Input{Companies: []Company{{Slug: "ibm", Name: "IBM", Jobs: 5}}})
+	long := Build(Input{Companies: []Company{{Slug: strings.Repeat("a-very-long-transliterated-name", 20), Name: "Long", Jobs: 5}}})
+
+	if len(short) != 1 || len(long) != 1 {
+		t.Fatalf("built %d and %d", len(short), len(long))
+	}
+	if len(short[0].ID) != len(long[0].ID) {
+		t.Errorf("ids are %d and %d bytes — length must not follow the value", len(short[0].ID), len(long[0].ID))
+	}
+	if len(long[0].ID) > 511 {
+		t.Errorf("id is %d bytes, over the engine's ceiling", len(long[0].ID))
+	}
+}


### PR DESCRIPTION
Second production failure at the same line, for a different reason.

```
Document identifier `"company_61726b68616e67656c2d736b69692d6b6f6c6c65647a68..."`
is invalid ... can not be more than 511 bytes.
```

Hex was legal, which fixed #2370's failure, but **proportional** — and a 340-byte
company slug (a transliterated Russian college name, `Архангельский колледж
телекоммуникаций им. Б.Л. Розинга, филиал СПбГУТ`) doubled past the ceiling.

Bounding what we mine was never going to cover this. #2370 added a length gate to
mined titles, which is where I had already been looking; a company slug arrives
from a **feed**, and nobody promised its length.

So the id is a fixed-width hash: legal by construction AND constant, which is the
property the failure was really about. Readability in the engine's own UI is the
cost, and it is affordable — the document carries `kind`, `slug` and `text` as
fields, so nothing that has to be looked up lives only in the id.