### PR TITLE
Let one test of the subject decide the whole card

### DIFF
--- a/web/src/lib/components/community/SubjectHeader.svelte
+++ b/web/src/lib/components/community/SubjectHeader.svelte
@@ -26,25 +26,51 @@
     class?: string;
   } = $props();
 
-  const noun = $derived(subjectType === 'job' ? 'Vacancy' : 'Company');
+  const thing = $derived(subjectType === 'job' ? 'vacancy' : 'company');
+  const absentNote = $derived(
+    absence === 'unreachable'
+      ? `This ${thing} couldn't be loaded just now`
+      : `This ${thing} is no longer listed`,
+  );
+
   const box =
     'flex items-center gap-3 rounded-lg border border-border bg-card px-3.5 py-3 text-left';
 </script>
 
-{#snippet body()}
-  <!-- Keyed on the employer's real name, and empty when there is none — the proxy
+{#snippet mark(name: string)}
+  <!-- Keyed on the employer's REAL name, and empty when there is none — the proxy
        resolves by name, so a stand-in or a slug would fetch a mark for a string that is
        not a brand. Empty is the nameless tile, the honest answer here. -->
   <EntityLogo
-    name={subject?.company ?? ''}
-    src={subject?.company ? (companyLogoUrl(subject.company) ?? undefined) : undefined}
+    {name}
+    src={name ? (companyLogoUrl(name) ?? undefined) : undefined}
     shape="square"
     size="md"
     class="shrink-0"
   />
+{/snippet}
 
-  <div class="min-w-0 flex-1">
-    {#if subject}
+<!-- The whole card is the way back to the subject, so it replaces the bare crumb it
+     grew out of: that crumb was a link with no information in it.
+
+     Only when there IS a subject, though. Linking the absent case would hand the reader
+     a card that says the vacancy is gone and then sends them to the page saying so
+     again — and on the unreachable branch, to a url that may be perfectly fine but that
+     we have just failed to read. A plain box states what we know and stops.
+
+     One `subject` test decides both the element and what goes in it, rather than the
+     element here and the text again inside. -->
+{#if subject}
+  <!-- resolve() inline, not through a derived: the no-navigation-without-resolve rule
+       reads the href expression itself, as it does in DiscussionFeed. -->
+  <a
+    href={subjectType === 'company'
+      ? resolve('/companies/[slug]', { slug: subjectSlug })
+      : resolve('/jobs/[slug]', { slug: subjectSlug })}
+    class={[box, 'transition-colors hover:bg-muted/50', className]}
+  >
+    {@render mark(subject.company)}
+    <div class="min-w-0 flex-1">
       <div class="truncate font-semibold leading-snug">{subject.title}</div>
       <div class="mt-0.5 flex items-center gap-2 text-sm text-muted-foreground">
         <!-- For a company subject the name is already the title above; printing it
@@ -56,38 +82,15 @@
           <Badge variant="outline" class="shrink-0">Closed</Badge>
         {/if}
       </div>
-    {:else}
-      <div class="truncate font-mono text-sm">{subjectSlug}</div>
-      <div class="mt-0.5 text-sm text-muted-foreground">
-        {absence === 'unreachable'
-          ? `This ${noun.toLowerCase()} couldn't be loaded just now`
-          : `This ${noun.toLowerCase()} is no longer listed`}
-      </div>
-    {/if}
-  </div>
-{/snippet}
-
-<!-- The whole card is the way back to the subject, so it replaces the bare crumb it
-     grew out of: that crumb was a link with no information in it.
-
-     Only when there IS a subject, though. Linking the absent case would hand the reader
-     a card that says the vacancy is gone and then sends them to the page saying so
-     again — and on the unreachable branch, to a url that may be perfectly fine but that
-     we have just failed to read. A plain box states what we know and stops. -->
-{#if subject}
-  <!-- resolve() inline, not through a derived: the no-navigation-without-resolve rule
-       reads the href expression itself, as it does in DiscussionFeed. -->
-  <a
-    href={subjectType === 'company'
-      ? resolve('/companies/[slug]', { slug: subjectSlug })
-      : resolve('/jobs/[slug]', { slug: subjectSlug })}
-    class={[box, 'transition-colors hover:bg-muted/50', className]}
-  >
-    {@render body()}
+    </div>
     <ArrowUpRight class="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
   </a>
 {:else}
   <div class={[box, className]}>
-    {@render body()}
+    {@render mark('')}
+    <div class="min-w-0 flex-1">
+      <div class="truncate font-mono text-sm">{subjectSlug}</div>
+      <div class="mt-0.5 text-sm text-muted-foreground">{absentNote}</div>
+    </div>
   </div>
 {/if}


### PR DESCRIPTION
A `/simplify` pass over `SubjectHeader`, which took its final shape from review
feedback after the last simplify pass had already run.

## What was awkward

The component asked whether the subject resolved **twice**:

- outside, to pick an `<a>` or a plain `<div>`;
- again inside a shared `{#snippet body()}`, to pick the text.

One question answered in two places is one that can be answered differently.
The snippet also reached back out to `subject?.company` for the logo, so it
was not actually the shared part it looked like.

## What changed

One `{#if subject}` now carries both decisions. The snippet keeps only what
genuinely is identical either way — the logo — and takes the name it keys on as
a parameter rather than closing over the subject.

The absent-state sentence moves out of the markup into a derived, and the noun
it embeds is lowercase at the source instead of `.toLowerCase()`d at each of the
two places that read it.

## No behaviour change

Verified in a browser against a real Postgres, all three states, matching the
readings taken before the change:

| state | element | logo | arrow |
|---|---|---|---|
| resolved vacancy | `A` | real mark | yes |
| employer missing | `A` | nameless tile | yes |
| subject absent | `DIV` | nameless tile | **no** |

Unit tests (9) and `pnpm check` (0 errors) unchanged and green; eslint clean.
