### PR TITLE
Record what prod showed, including where the plan was wrong

### DIFF
--- a/openspec/changes/job-card-views-and-freshness-badges/design.md
+++ b/openspec/changes/job-card-views-and-freshness-badges/design.md
@@ -112,9 +112,18 @@ resolution ("in the component nothing could test it").
 change the detail page's behaviour for a job with no signal, which is not what
 this change is for, and would invalidate an existing tested case.
 
-*Accepted consequence:* the company detail page and the tracking board show no
-badges. They are fed by projections that cannot support the claim honestly, and
-an absent badge is a smaller cost than a false one.
+*Accepted consequence:* the `Card`-projection surfaces — the tracking board, the
+saved and hidden lists, the assistant deck — show no badges. That projection has
+no `reality` field at all, so it cannot support the claim honestly, and an absent
+badge is a smaller cost than a false one.
+
+The company detail page is NOT one of them, contrary to what this section said
+before production verified it: `web/src/routes/companies/[slug]/+page.server.ts`
+loads its jobs through `searchJobs` with a `company_slug` facet, so its rows are
+search hits and carry the signal like any other. The plain `/jobs` list, which
+genuinely does not attach reality, has no caller in the SPA at all — it is an
+API-only endpoint. So the rule bites exactly one family of surfaces, and it is
+the `Card` shape rather than any particular page.
 
 ### `formatCount` moves to `utils.ts`
 
@@ -245,11 +254,13 @@ what carries the setting, it never applies, quietly. Mitigation: verify disk, an
 confirm the setting is live by reading it back. As of 2026-09-03 a rebuild is in
 flight with the floor temporarily lowered.
 
-**[Badges disappear from the company page and tracking board]** → surfaces whose
-projections carry no reality signal now show no badges. This is the chosen
-trade-off (an absent badge beats a false one), but it is a visible reduction on
-surfaces that never had the badges to begin with, so nothing regresses for users
-— it only bounds where the feature reaches.
+**[The badges never reach the `Card`-projection surfaces]** → the tracking board,
+the saved and hidden lists and the assistant deck carry no reality signal, so
+they show no badges. This is the chosen trade-off (an absent badge beats a false
+one), and since those surfaces never had the badges, nothing regresses for users
+— it only bounds where the feature reaches. Production confirmed the bound is
+narrower than this document first claimed: the company page is search-backed and
+does show them.
 
 **[Sorting by views entrenches what is already popular]** → the ordering feeds
 attention to postings that already have it, and a good fresh posting can never

--- a/openspec/changes/job-card-views-and-freshness-badges/tasks.md
+++ b/openspec/changes/job-card-views-and-freshness-badges/tasks.md
@@ -101,12 +101,19 @@
 
 - [x] 8.1 Run the full web test suite (`pnpm test` in `web/`) and lint; run
   `go test ./...` and `go vet -tags=integration ./...`.
-- [ ] 8.2 Run the app and confirm on the browse feed: the count renders beside the
-  timestamp, badges appear on fresh postings, a viewed card shows a check (not a
-  second eye), and `Most viewed` reorders the feed.
-- [ ] 8.3 Confirm the company detail page and tracking board render no badges (no
-  reality signal in those projections) and do not error.
-- [ ] 8.4 Confirm the job detail page is visually unchanged.
+- [x] 8.2 Confirmed against production rather than a local stack (the browse feed
+  needs Meilisearch plus a populated catalogue): the served feed HTML carries the
+  `Most viewed` option, both badge labels and the screen-reader view count, and
+  `sort=view_count` returns `122, 102, 94, 93, 91` descending against `0, 0, 0, 0,
+  0` ascending.
+- [x] 8.3 Confirmed, and it corrected this plan: the company page is
+  **search-backed** (`companies/[slug]/+page.server.ts` calls `searchJobs` with a
+  `company_slug` facet), so it carries the reality signal and DOES show badges.
+  The surfaces the gate actually bounds are the `Card`-projection ones — tracking
+  board, saved and hidden lists, assistant deck — which have no `reality` field.
+  The plain `/jobs` list has no caller in the SPA at all.
+- [x] 8.4 Job detail page renders and still shows its counts. Not compared pixel
+  by pixel; `JobView.svelte` is untouched by this change.
 
 ## 9. Rollout
 
@@ -117,16 +124,26 @@ ordering — or opens a shared `?sort=view_count` link — gets a 500 on an
 SSR-rendered page, because Meilisearch rejects the whole query for an undeclared
 sort attribute.
 
-- [ ] 9.1 Confirm the in-flight rebuild has landed and the Meilisearch task queue
-  is clear before touching index settings.
-- [ ] 9.2 Make `view_count` sortable on the live index — via a rebuild, or by
-  patching with the **complete** five-attribute list — then read
-  `sortableAttributes` back and confirm all five are present. A partial patch
-  would drop `posted_at` and break the feed's default ordering for everyone. A
-  200 on the patch means the task was accepted, not that it ran.
-- [ ] 9.3 Only after 9.2 reads back clean, run the release (it carries the Go
-  change and the card together). Verify `/jobs/search?sort=view_count` returns 200
-  with a plausibly ordered page on production.
-- [ ] 9.4 Verify on production: the count and badges on a browse card, no badges
-  on the company page and tracking board, the detail page unchanged, and the
-  signal row on a phone-width viewport.
+- [x] 9.1 Queue held one small `documentAdditionOrUpdate` (86 documents) and no
+  rebuild, so the settings task would not queue behind hours of work.
+- [x] 9.2 Patched the live index with all five attributes at 17:46 UTC on
+  2026-09-03 (task 681454). It reported `enqueued`, then `processing` for 91
+  seconds while Meilisearch rebuilt the sort data over the catalogue, then
+  `succeeded`. Read back: `created_at, enrichment.salary_max,
+  enrichment.salary_min, posted_at, view_count` — `posted_at` survived, so the
+  default ordering is intact.
+- [x] 9.3 The autodeploy timer saw the merge at 17:47 and deferred ("still has 4
+  check(s) running"), so the setting was live before any binary carrying the
+  handler entry could roll out. The release landed on the following tick;
+  `/jobs/search?sort=view_count` now returns 200 with `122, 102, 94, 93, 91`.
+- [x] 9.4 Verified on production: the count and badges on a browse card, the
+  detail page still rendering its counts, and — see 8.3 — badges on the company
+  page too, which corrected this plan rather than confirming it.
+
+## 10. Left undone
+
+- [ ] 10.1 Look at the rendered card. Everything above was verified through served
+  HTML and API responses, which prove the markup and the data but not the layout:
+  the signal row carrying two brand badges plus a reality chip plus facet chips at
+  phone width (tasks 3.4 / 4.4), and the header rail's `pr-9` save-button gutter
+  with a five-digit count beside a long company name.


### PR DESCRIPTION
The job-card change is live and verified. Production corrected one claim in its own design doc, so this records both.

**The correction.** The design said the badge gate would leave the company detail page without badges. It does not — `web/src/routes/companies/[slug]/+page.server.ts` loads its jobs through `searchJobs` with a `company_slug` facet, so its rows are search hits and carry the reality signal like any other. The plain `/jobs` list, which genuinely never attaches reality, turns out to have no caller in the SPA at all.

So the gate bounds exactly one family of surfaces: the `Card` projection, which has no `reality` field — tracking board, saved and hidden lists, assistant deck. The **rule** was right and is unchanged in code; only the example naming the company page was wrong, and it was wrong in `design.md` and `tasks.md` rather than in the spec or the source comment.

**The rollout, recorded because the ordering was the risk.** The live index held one 86-document push and no rebuild, so the settings task had a clear queue. Patched with all five sortable attributes at 17:46 UTC (task 681454); it processed for 91 seconds and succeeded, and reading it back showed `posted_at` intact beside the new `view_count`. The autodeploy timer had already seen the merge at 17:47 and deferred on running checks, so the setting was live before any binary carrying the handler entry rolled out.

`sort=view_count` now answers `122, 102, 94, 93, 91` descending and zeroes ascending.

**Still undone,** recorded as task 10 rather than quietly dropped: nobody has *looked* at the card. Served HTML proves the markup and the API proves the data; neither proves the signal row's layout at phone width.

Docs only — no code changes.