### PR TITLE
Treat a prefix of a longer phrase as still being typed

### DIFF
--- a/internal/search/suggest/parse.go
+++ b/internal/search/suggest/parse.go
@@ -1,6 +1,7 @@
 package suggest
 
 import (
+	"sort"
 	"strings"
 	"sync"
 )
@@ -92,6 +93,10 @@ func rank(k Kind) int {
 type Phrases struct {
 	mu     sync.RWMutex
 	byText map[string]Part
+	// sorted holds the same phrases in order, so a binary search can answer "does any
+	// phrase START with this?" — the question that decides whether the visitor is still
+	// typing one phrase or has finished it and begun another.
+	sorted []string
 	// longest is the word count of the longest phrase, which bounds how far the parse
 	// looks ahead. Without it every position would try every possible length.
 	longest int
@@ -131,9 +136,23 @@ func (p *Phrases) Replace(docs []Document) {
 			longest = n
 		}
 	}
+	sorted := make([]string, 0, len(byText))
+	for text := range byText {
+		sorted = append(sorted, text)
+	}
+	sort.Strings(sorted)
+
 	p.mu.Lock()
-	p.byText, p.longest = byText, longest
+	p.byText, p.sorted, p.longest = byText, sorted, longest
 	p.mu.Unlock()
+}
+
+// beginsAPhrase reports whether any known phrase starts with this text — which means
+// the visitor may still be typing that phrase rather than having finished a shorter
+// one.
+func beginsAPhrase(sorted []string, text string) bool {
+	i := sort.SearchStrings(sorted, text)
+	return i < len(sorted) && strings.HasPrefix(sorted[i], text)
 }
 
 // Len reports how many phrases are recognised, for the caller that logs a refresh.
@@ -152,7 +171,7 @@ func (p *Phrases) Len() int {
 // `data engineer`.
 func (p *Phrases) Parse(query string) Parsed {
 	p.mu.RLock()
-	byText, longest := p.byText, p.longest
+	byText, sorted, longest := p.byText, p.sorted, p.longest
 	p.mu.RUnlock()
 
 	normalised := Title(query)
@@ -169,6 +188,20 @@ func (p *Phrases) Parse(query string) Parsed {
 	recognisable := len(words)
 	if normalised != "" && !strings.HasSuffix(query, " ") {
 		recognisable--
+
+		// And if everything typed so far is the BEGINNING of a longer phrase, the
+		// visitor is still typing THAT — so nothing is recognised at all.
+		//
+		// Observed on production: `java dev` recognised `java` as a finished title and
+		// completed `dev` against employers, offering "Java Dev.Pro" (49) where "Java
+		// Developer" (5,480) is the obvious answer. Refusing to consume a prefix of a
+		// longer phrase is what keeps the longer one reachable.
+		//
+		// Only while the last word is unfinished: once a space follows, `java ` IS the
+		// phrase Java, however many longer ones happen to start with it.
+		if beginsAPhrase(sorted, normalised) {
+			recognisable = 0
+		}
 	}
 
 	var out Parsed

--- a/internal/search/suggest/parse_test.go
+++ b/internal/search/suggest/parse_test.go
@@ -201,3 +201,39 @@ func TestParse_OneUnfinishedWordIsAllFragment(t *testing.T) {
 		t.Errorf("recognised=%v fragment=%q", got.Recognised, got.Fragment)
 	}
 }
+
+// If what has been typed so far is the BEGINNING of a longer phrase the dictionary
+// knows, the visitor is still typing that phrase — so nothing is recognised yet.
+//
+// Observed on production: `java dev` recognised `java` as a finished title and
+// completed `dev` against employers, offering "Java Dev.Pro" (49) where "Java
+// Developer" (5,480) is the obvious answer. Refusing to consume a prefix of a longer
+// phrase is what keeps the longer one reachable.
+func TestParse_APrefixOfALongerPhraseIsStillBeingTyped(t *testing.T) {
+	ph := phrases("Java", "Java Developer", "Senior Software Engineer")
+
+	got := ph.Parse("java dev")
+	if len(got.Recognised) != 0 {
+		t.Errorf("recognised = %v, want none — this is the start of Java Developer", got.Recognised)
+	}
+	if got.Fragment != "java dev" {
+		t.Errorf("fragment = %q, want the whole thing", got.Fragment)
+	}
+
+	// Not a prefix of anything longer, so the finished phrase IS recognised and the
+	// trailing word gets completed. This is the composition the feature exists for.
+	other := ph.Parse("senior software engineer go")
+	if len(other.Recognised) != 1 || other.Fragment != "go" {
+		t.Errorf("recognised=%v fragment=%q", other.Recognised, other.Fragment)
+	}
+}
+
+// The exact phrase is not "still being typed" merely because a longer one starts with
+// it — that is only true while the LAST word is unfinished.
+func TestParse_AFinishedPhraseIsRecognisedEvenIfLongerOnesExist(t *testing.T) {
+	ph := phrases("Java", "Java Developer")
+	got := ph.Parse("java ")
+	if len(got.Recognised) != 1 {
+		t.Errorf("recognised = %v, want Java once the word is finished", got.Recognised)
+	}
+}


### PR DESCRIPTION
Observed on production after #2375 landed.

```
java dev  →  Java Dev.Pro    49     title:Java + company:dev-pro
```

`java` was recognised as a finished title and `dev` completed against employers —
where **Java Developer (5,480)** is the obvious answer.

Excluding kinds was never going to fix that: the better completion is a longer
TITLE, the same axis the prefix just consumed. The problem is the recognition, not
the completion.

So: if everything typed so far **begins** a phrase the dictionary knows, the
visitor is still typing that one, and nothing is recognised. Only while the last
word is unfinished — once a space follows, `java ` is the phrase Java, however
many longer ones start with it.

The compositions #2375 fixed still work, because neither is a prefix of anything:

```
senior software engineer go  →  Senior Software Engineer Go   7,571
product owner goo            →  Product Owner Google          3,343
```

Answered by binary search over the phrases in order, which is why `Replace` now
keeps a sorted copy beside the map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search suggestions no longer recognize a phrase while the final word is still an unfinished prefix of a longer known phrase.
  * Completed phrases continue to be recognized correctly, including when longer phrases begin with the same text.

* **Tests**
  * Added coverage for unfinished phrase prefixes and exact completed phrase matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->