### PR TITLE
Put the closed-posting rule where the other gate lives, and regenerate API.md

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -248,7 +248,7 @@ Combine free-text `q` with any of the filter params below. Repeated facet params
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
 | `q` | string | no | Full-text query over title, company, and description. (e.g. `golang`) |
-| `sort` | string | no | One of `created_at`, `posted_at`, `salary_min`, `salary_max`. Omit for relevance/newest. (e.g. `posted_at`) |
+| `sort` | string | no | One of `created_at`, `posted_at`, `view_count`, `salary_min`, `salary_max`. Omit for relevance/newest. (e.g. `posted_at`) |
 | `order` | string | no | `asc` or `desc` (default `desc`). (e.g. `desc`) |
 | `limit` | integer | no | Page size, 1–100. (e.g. `20`) |
 | `offset` | integer | no | Rows to skip; `offset + limit` ≤ 10000. (e.g. `0`) |
@@ -280,7 +280,7 @@ Same query and filters as `/jobs/search`, but each result carries the `descripti
 | --- | --- | --- | --- |
 | `q` | string | no | Full-text query over title, company, and description. (e.g. `golang`) |
 | `description_format` | string | no | One of `html` (default, verbatim), `text` (tags stripped), `markdown` (HTML converted to Markdown). Unknown values fall back to `html`. (e.g. `markdown`) |
-| `sort` | string | no | One of `created_at`, `posted_at`, `salary_min`, `salary_max`. Omit for relevance/newest. (e.g. `posted_at`) |
+| `sort` | string | no | One of `created_at`, `posted_at`, `view_count`, `salary_min`, `salary_max`. Omit for relevance/newest. (e.g. `posted_at`) |
 | `order` | string | no | `asc` or `desc` (default `desc`). (e.g. `desc`) |
 | `limit` | integer | no | Page size, 1–100. (e.g. `20`) |
 | `offset` | integer | no | Rows to skip; `offset + limit` ≤ 10000. (e.g. `0`) |
@@ -3664,7 +3664,7 @@ curl "https://freehire.me/api/v1/me/contributions" -H "Authorization: Bearer fhk
 ```
 
 ```json
-{ "data": [ { "url": "https://boards.greenhouse.io/acme", "source": "greenhouse", "board": "acme", "state": "onboarded", "created_at": "2026-07-20T12:00:00Z" } ] }
+{ "data": [ { "url": "https://boards.greenhouse.io/acme", "source": "greenhouse", "board": "acme", "state": "active", "created_at": "2026-07-20T12:00:00Z" } ] }
 ```
 
 ### `POST /me/jd/resolve`

--- a/openspec/changes/job-card-views-and-freshness-badges/specs/job-freshness-badges/spec.md
+++ b/openspec/changes/job-card-views-and-freshness-badges/specs/job-freshness-badges/spec.md
@@ -88,6 +88,30 @@ looks small".
   signal reports `fresh` with `fake_freshness` set
 - **THEN** no badge is returned
 
+### Requirement: A closed posting earns no badge
+
+A posting that is no longer open SHALL receive neither badge, whatever its date or
+reality signal says. Both badges urge the reader to hurry, and a closed posting is
+never worth hurrying to.
+
+This rule SHALL live in the shared rule beside the reality gate, not in each
+surface's template. It is the same KIND of statement the reality gate makes — "this
+is not a posting to hurry to" — and writing it per surface is precisely the drift a
+shared rule exists to prevent: it was briefly written twice, as `{#if !closed_at}` on
+the detail page and as a ternary on the card, and a change to one would silently have
+left the other behind.
+
+#### Scenario: A closed posting with today's date earns nothing
+
+- **WHEN** the badges are computed for a job posted today, with a fresh reality
+  signal, that has since been closed
+- **THEN** no badge is returned
+
+#### Scenario: An open posting is unaffected
+
+- **WHEN** the badges are computed for the same job with no close date
+- **THEN** both badges are returned
+
 ### Requirement: "Be an early applicant" claims only what freehire can observe
 
 The applied count behind `Be an early applicant` is the number of signed-in users

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -107,13 +107,10 @@
   const applied = $derived('applied_count' in job ? job.applied_count : 0);
   // The two freshness badges, through the card's own gate: a projection that carries no
   // reality signal earns none, because on those surfaces the posting date alone would
-  // vouch for a job the signal was written to distrust. Thresholds and wording are the
-  // shared rule's — the same one the job's own page renders, closed-job rule included.
-  // No listing can currently serve a closed job WITH a reality signal, so that arm is
-  // stated rather than needed; the two surfaces must not disagree if one ever does.
-  const freshness = $derived(
-    job.closed_at ? [] : cardFreshnessBadges(job.posted_at, reality, applied),
-  );
+  // vouch for a job the signal was written to distrust. Everything else — the
+  // thresholds, the wording, the closed-posting rule — is the shared rule's, so the card
+  // and the job's own page cannot tell different stories about one posting.
+  const freshness = $derived(cardFreshnessBadges(job.posted_at, reality, applied, job.closed_at));
 
   const MAX_SKILLS = 5;
   const shownSkills = $derived(skills.slice(0, MAX_SKILLS));

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -83,7 +83,7 @@
   const applies = $derived(job.applied_count ?? 0);
   // "New" / "Be an early applicant" — see freshness.ts for why the posting date alone
   // does not earn either.
-  const freshness = $derived(freshnessBadges(job.posted_at, job.reality, applies));
+  const freshness = $derived(freshnessBadges(job.posted_at, job.reality, applies, job.closed_at));
 
   // The content column is tabbed so "who are these people?" and "what will they ask
   // me?" are answerable without leaving the posting. Page state, not a route: the
@@ -428,18 +428,17 @@
 
       <!-- Freshness rides the same provenance line: like the backer and the reality
            badge it describes the POSTING, not the role, so the title keeps a single
-           voice and the reader still meets all of it in one glance. Closed jobs are
-           excluded — a closed posting is never worth hurrying to. -->
-      {#if !job.closed_at}
-        {#each freshness as badge (badge.label)}
-          <!-- The tooltip rides a wrapper, not the Chip: the primitive takes only
-               variant/class/children, so a `title` passed to it would be dropped
-               silently and the badge would state a claim with its evidence gone. -->
-          <span title={badge.tooltip} class="inline-flex">
-            <Chip variant="brand" class="font-semibold">{badge.label}</Chip>
-          </span>
-        {/each}
-      {/if}
+           voice and the reader still meets all of it in one glance. A closed posting
+           earns nothing here — that rule lives in freshnessBadges, beside the reality
+           gate, rather than as a second copy in this template. -->
+      {#each freshness as badge (badge.label)}
+        <!-- The tooltip rides a wrapper, not the Chip: the primitive takes only
+             variant/class/children, so a `title` passed to it would be dropped
+             silently and the badge would state a claim with its evidence gone. -->
+        <span title={badge.tooltip} class="inline-flex">
+          <Chip variant="brand" class="font-semibold">{badge.label}</Chip>
+        </span>
+      {/each}
     </div>
   </div>
 

--- a/web/src/lib/components/SavedSearches.svelte
+++ b/web/src/lib/components/SavedSearches.svelte
@@ -47,10 +47,15 @@
 
   // Apply a saved set: seed the staged filters from it and remember it as the base
   // (so later edits surface an "Update <name>").
+  //
+  // Through canonicalQuery, not the raw stored string: the ordering is not part of what
+  // a saved search IS (see savedSearchQuery), and sets written before that rule still
+  // carry a `sort=` they would otherwise restore. Canonicalising here makes old and new
+  // rows behave alike instead of leaving the difference visible to whoever saved first.
   function apply(set: SavedSearch) {
     error = null;
     renamingId = null;
-    store.apply(set.query);
+    store.apply(canonicalQuery(set.query));
     baseId = set.id;
   }
 

--- a/web/src/lib/freshness.test.ts
+++ b/web/src/lib/freshness.test.ts
@@ -107,3 +107,24 @@ describe('cardFreshnessBadges', () => {
     expect(cardFreshnessBadges(daysAgo(1), reality(), 9).map((b) => b.label)).toEqual(['New']);
   });
 });
+
+// A closed posting is never worth hurrying to. The rule used to live in two templates —
+// `{#if !job.closed_at}` on the detail page and a ternary on the card — which is exactly
+// the drift the shared rule exists to prevent, one layer up from where it was caught.
+describe('closed postings', () => {
+  it('earn no badge however fresh the date', () => {
+    expect(freshnessBadges(daysAgo(0), reality(), 0, daysAgo(0))).toEqual([]);
+    expect(cardFreshnessBadges(daysAgo(0), reality(), 0, daysAgo(0))).toEqual([]);
+  });
+
+  it('leave an open posting badged, whether the close date is null or absent', () => {
+    expect(freshnessBadges(daysAgo(1), reality(), 0, null).map((b) => b.label)).toEqual([
+      'New',
+      'Be an early applicant',
+    ]);
+    expect(cardFreshnessBadges(daysAgo(1), reality(), 0).map((b) => b.label)).toEqual([
+      'New',
+      'Be an early applicant',
+    ]);
+  });
+});

--- a/web/src/lib/freshness.ts
+++ b/web/src/lib/freshness.ts
@@ -65,7 +65,14 @@ export function freshnessBadges(
   postedAt?: string | null,
   reality?: Reality | null,
   appliedCount = 0,
+  closedAt?: string | null,
 ): FreshnessBadge[] {
+  // A closed posting is never worth hurrying to, whatever its date says. This sits with
+  // the reality gate rather than in each surface's template: it is the same KIND of
+  // statement ("this posting is not one to hurry to"), and it was previously written
+  // twice — `{#if !job.closed_at}` on the detail page, a ternary on the card — which is
+  // the drift a shared rule exists to prevent.
+  if (closedAt) return [];
   if (reality && (reality.class !== 'fresh' || reality.fake_freshness)) return [];
   const days = daysSince(postedAt);
   if (days === null || days > NEW_DAYS) return [];
@@ -97,7 +104,8 @@ export function cardFreshnessBadges(
   postedAt?: string | null,
   reality?: Reality | null,
   appliedCount = 0,
+  closedAt?: string | null,
 ): FreshnessBadge[] {
   if (!reality) return [];
-  return freshnessBadges(postedAt, reality, appliedCount);
+  return freshnessBadges(postedAt, reality, appliedCount, closedAt);
 }


### PR DESCRIPTION
A two-axis review of the shipped job-card change. Both axes independently landed on the same defect, which is the one worth reading about.

## The closed-posting rule was written twice, in two templates

The change's own spec says the gate "SHALL be expressed as a testable function rather than a condition inside a template", and its design doc argues that a rule inside a Svelte template cannot be tested. It then put `job.closed_at ? [] : …` in the card's derived value while the detail page kept `{#if !job.closed_at}` — two copies of one rule, in the exact shape the change was written to prevent, in a component pair whose whole point is that they must not tell different stories about one posting.

It now sits in `freshnessBadges` beside the reality gate, where it belongs: same *kind* of statement ("this is not a posting to hurry to"), covered by tests at both entry points, restated by neither template. The requirement it was missing is recorded too — the review's other finding was that the rule was implemented on both surfaces and specified on neither.

## `docs/API.md` was stale

It carries `GENERATED … Do not edit by hand — run \`pnpm run gen:api-docs\``, the sort description lives in `api-spec.ts`, and the source was edited without regenerating. **Nothing in CI or lefthook runs that generator**, so the published API reference sat contradicting `openapi.yaml` and the handler's own allowlist. Regenerated: three lines, all the `sort` enumeration.

Worth considering separately: the repo already has this ratchet for `sqlc` (regenerate + diff in CI). `gen:api-docs` has no equivalent, which is why this drifted silently.

## Legacy saved searches restored an ordering they should not have

The spec says re-applying a saved search "restores its filters and leaves the ordering at the contextual default" — true only for rows written after the key stopped carrying `sort`. `SavedSearches.apply` now goes through `canonicalQuery`, so an older row behaves like a new one instead of leaving the difference visible to whoever saved first.

## Not acted on, with reasons

- **Badge markup duplicated between card and detail page.** The two use different primitives on purpose: `Badge` is `rounded-md` to match the card's facet chips, `Chip` is `rounded-full` to match the detail page's. A shared component would need a shape parameter — the speculative generality the same smell baseline warns about, at two callers.
- **`cardFreshnessBadges` reads as surface-named.** True, but the requirement it implements is itself framed as the card's rule; renaming would desync the two.

Tests 1378 → all green; `svelte-check` 0 errors; `openspec validate` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Job search APIs now support sorting by view count.
  - Saved searches apply filters consistently, including legacy saved searches and sort settings.

- **Bug Fixes**
  - Closed job postings no longer display “New” or “Be an early applicant” badges.
  - Open postings continue to display applicable freshness badges.
  - Contribution records now report board status as `active`.

- **Documentation**
  - Updated API documentation for the new sorting option and contribution status value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->