### PR TITLE
Answer the review: point 0126 at 0127, and record what shipped unrecorded

### DIFF
--- a/internal/api/handler/community.go
+++ b/internal/api/handler/community.go
@@ -178,7 +178,9 @@ func (h *communityHandlers) ListThreads(c *fiber.Ctx) error {
 // type parameter in Go.
 func pageMeta[T interface{ Position() community.Cursor }](items []T, pageSize int32) fiber.Map {
 	meta := fiber.Map{}
-	if n := len(items); n > 0 && int32(n) == pageSize {
+	// >= not ==: a page longer than asked for is still a full one, and equality would
+	// drop the cursor on it — the same silence, from the other side.
+	if n := len(items); n > 0 && int32(n) >= pageSize {
 		pos := items[n-1].Position()
 		meta["next_cursor"] = encodeCursor(pos.CreatedAt, pos.ID)
 	}

--- a/internal/engage/community/service_test.go
+++ b/internal/engage/community/service_test.go
@@ -8,6 +8,11 @@ import (
 	"time"
 )
 
+// subjectRow is what the feed query's two LEFT JOINs would have resolved for one
+// subject: the display title and the employer, which are separate columns and are
+// separately absent.
+type subjectRow struct{ title, company string }
+
 // fakeRepo is an in-memory Repository for exercising the service without a DB.
 type fakeRepo struct {
 	personas    map[int64]Persona
@@ -20,7 +25,11 @@ type fakeRepo struct {
 	replyTimes  []time.Time
 	// subjectNames stands in for the jobs/companies joins in the feed query, keyed
 	// "<subject_type>:<subject_ref>". A missing key is a subject that no longer exists.
-	subjectNames map[string]string
+	// Title and company are held APART because the query resolves them from different
+	// columns (jobs.title vs jobs.company) and they genuinely diverge — a posting whose
+	// employer column is empty has a title and no company. A fake that fills both from
+	// one string cannot express the case its consumer exists to handle.
+	subjectNames map[string]subjectRow
 
 	failHandleOnce bool // simulate one handle collision then succeed
 }
@@ -29,7 +38,7 @@ func newFakeRepo() *fakeRepo {
 	return &fakeRepo{
 		personas: map[int64]Persona{}, handles: map[string]int64{},
 		threads: map[int64]Thread{}, replies: map[int64][]Reply{},
-		subjectNames: map[string]string{},
+		subjectNames: map[string]subjectRow{},
 	}
 }
 
@@ -92,10 +101,11 @@ func (f *fakeRepo) ListRecentOpenThreads(_ context.Context, _ Cursor, limit int3
 		if t.Status != StatusOpen {
 			continue
 		}
+		row := f.subjectNames[t.SubjectType+":"+t.SubjectRef]
 		out = append(out, ThreadWithSubject{
 			Thread:         t,
-			SubjectTitle:   f.subjectNames[t.SubjectType+":"+t.SubjectRef],
-			SubjectCompany: f.subjectNames[t.SubjectType+":"+t.SubjectRef],
+			SubjectTitle:   row.title,
+			SubjectCompany: row.company,
 		})
 	}
 	// The map iteration above is unordered; the real query orders by (created_at DESC,
@@ -354,8 +364,8 @@ func TestListRecentThreadsEmpty(t *testing.T) {
 // The feed spans subject types — that is its whole point — and names each subject.
 func TestListRecentThreadsSpansSubjectTypes(t *testing.T) {
 	repo := newFakeRepo()
-	repo.subjectNames["company:acme"] = "Acme Inc."
-	repo.subjectNames["job:senior-go-acme-abc123"] = "Senior Go Engineer"
+	repo.subjectNames["company:acme"] = subjectRow{title: "Acme Inc.", company: "Acme Inc."}
+	repo.subjectNames["job:senior-go-acme-abc123"] = subjectRow{title: "Senior Go Engineer", company: "Acme Inc."}
 	svc := newService(repo, "company/acme", "job/senior-go-acme-abc123")
 	ctx := context.Background()
 
@@ -418,7 +428,7 @@ func TestListRecentThreadsKeepsThreadWithMissingSubject(t *testing.T) {
 // A closed thread is hidden from every default listing, the feed included.
 func TestListRecentThreadsExcludesClosed(t *testing.T) {
 	repo := newFakeRepo()
-	repo.subjectNames["company:acme"] = "Acme Inc."
+	repo.subjectNames["company:acme"] = subjectRow{title: "Acme Inc.", company: "Acme Inc."}
 	svc := newService(repo, "company/acme")
 	ctx := context.Background()
 	th, err := svc.CreateThread(ctx, CreateThreadInput{
@@ -436,5 +446,35 @@ func TestListRecentThreadsExcludesClosed(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Fatalf("want closed thread excluded, got %d rows", len(got))
+	}
+}
+
+// A posting whose employer column is empty still RESOLVED — the vacancy is there, only
+// its company name is missing. The feed must report the title it found and the absent
+// company separately, because the client decides "is the subject gone?" from the title:
+// keying that on the company would call a live posting pruned.
+func TestListRecentThreadsSeparatesTitleFromCompany(t *testing.T) {
+	repo := newFakeRepo()
+	repo.subjectNames["job:platform-eng-k8s-e9"] = subjectRow{title: "Platform Engineer", company: ""}
+	svc := newService(repo, "job/platform-eng-k8s-e9")
+	ctx := context.Background()
+	if _, err := svc.CreateThread(ctx, CreateThreadInput{
+		UserID: 1, SubjectType: SubjectJob, SubjectSlug: "platform-eng-k8s-e9",
+		Title: "Who is hiring for this?", Body: "No company name at all.",
+	}); err != nil {
+		t.Fatalf("CreateThread: %v", err)
+	}
+	got, err := svc.ListRecentThreads(ctx, Cursor{})
+	if err != nil {
+		t.Fatalf("ListRecentThreads: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 thread, got %d", len(got))
+	}
+	if got[0].SubjectTitle != "Platform Engineer" {
+		t.Fatalf("want the title the join found, got %q", got[0].SubjectTitle)
+	}
+	if got[0].SubjectCompany != "" {
+		t.Fatalf("want the absent company reported absent, got %q", got[0].SubjectCompany)
 	}
 }

--- a/migrations/0126_threads_open_created_idx.sql
+++ b/migrations/0126_threads_open_created_idx.sql
@@ -1,3 +1,13 @@
+-- SUPERSEDED ON ANY DATABASE THAT RECORDED THIS FILE — see 0127.
+--
+-- This file was rewritten after it had already been recorded as applied on prod, which
+-- is the one thing the migration rule forbids. The rewrite is honest about what went
+-- wrong and useless where it matters: a recorded version row means this file is never
+-- read again, so everything below about dropping a carcass fixes only databases that
+-- never had one. 0127 is what actually repaired prod, and it carries the full account.
+-- Read this file for the index's shape and the CONCURRENTLY reasoning; read 0127 for
+-- what ran.
+--
 -- The global discussions feed (GET /api/v1/threads/recent, /discussions): every open
 -- thread across every subject, newest first, keyset-paged on (created_at, id).
 --

--- a/openspec/changes/add-discussions-feed/proposal.md
+++ b/openspec/changes/add-discussions-feed/proposal.md
@@ -41,9 +41,15 @@ listing code, so they ship together.
 
 ## Impact
 
-- **New migration**: a partial index on `threads (created_at DESC, id DESC)
-  WHERE status = 'open'`. The existing index leads with the subject, so it
-  cannot serve an unfiltered newest-first scan.
+- **Two migrations**, both building the same partial index on
+  `threads (created_at DESC, id DESC) WHERE status = 'open'` — the existing
+  index leads with the subject, so it cannot serve an unfiltered newest-first
+  scan. Each is a `DROP INDEX IF EXISTS` followed by a **plain** `CREATE INDEX`,
+  in one transaction. Not `CONCURRENTLY`: on a three-row table it buys no
+  availability and waits for unrelated transactions' snapshots, which is what
+  failed the first release. There are two because the first (0126) was recorded
+  as applied on prod while the index it left was invalid, so the repair had to
+  be its own file (0127). Both files carry the full account.
 - **New sqlc queries** in `internal/platform/db/queries/community.sql` — the
   unfiltered keyset pair, each LEFT JOINing `jobs` and `companies` to resolve
   the subject's display name.
@@ -53,8 +59,14 @@ listing code, so they ship together.
 - **`internal/api/handler/community.go`**: `GET /api/v1/threads/recent`
   (public), registered before `/threads/:id`; the cursor fix in `ListThreads`
   and `GetThread`.
-- **Frontend** (`web/`): a `/discussions` route, a `DiscussionFeed` component, a
-  footer link, and the page added to `sitemap-pages.xml`.
+- **Frontend** (`web/`): a `/discussions` route, a `DiscussionFeed` component,
+  a footer and header-menu link, and the page added to `sitemap-pages.xml`.
+- **Frontend, added after the feed shipped**: a `SubjectHeader` on every
+  subject-scoped discussion page (`web/src/lib/components/community/`), with
+  `discussionSubject.ts` mapping a `Job`/`Company` to what the header prints and
+  `server/discussionSubject.ts` fetching it. It replaces the bare breadcrumbs
+  those pages carried; the company ones had been printing a raw slug where the
+  company's name belongs.
 - Reuses the existing thread-detail routes: a feed row links to the subject's
   own thread page, so no new thread-reading surface is added.
 - **Not in this change**: `web/static/openapi.yaml` documents no discussion

--- a/openspec/changes/add-discussions-feed/specs/community-threads/spec.md
+++ b/openspec/changes/add-discussions-feed/specs/community-threads/spec.md
@@ -43,6 +43,48 @@ empty rather than removing the thread from the listing.
 - **WHEN** an unauthenticated client requests the cross-subject listing
 - **THEN** the request succeeds and no response field identifies any author beyond their persona handle
 
+### Requirement: A discussion page names the subject it is about
+
+Every discussion surface scoped to one subject — the thread list and a single
+thread, on both subject kinds — SHALL open with that subject: its logo, its
+name, and for a vacancy its employer and whether the posting has closed. The
+header SHALL be the way back to the subject, replacing any separate breadcrumb.
+
+The subject SHALL be resolved independently of the threads, since a subject
+with no threads still has a header to draw. When it cannot be resolved the page
+SHALL still render the discussion, and SHALL distinguish a subject that is gone
+from one it merely failed to read.
+
+#### Scenario: A vacancy's discussion names the posting
+
+- **WHEN** a reader opens a vacancy's thread list or one of its threads
+- **THEN** the page opens with the vacancy's title, its employer and its logo, as a single link to the posting
+
+#### Scenario: A closed vacancy says so
+
+- **WHEN** the vacancy the discussion hangs off has closed
+- **THEN** the header marks it closed, without the reader having to follow the link
+
+#### Scenario: A company's discussion names the company
+
+- **WHEN** a reader opens a company's thread list or one of its threads
+- **THEN** the page opens with the company's name and logo, as a single link to the company, and does not print its slug
+
+#### Scenario: An absent subject is stated, not linked
+
+- **WHEN** the subject cannot be resolved
+- **THEN** the header renders the stored slug as an identifier and is NOT a link, since the destination is the page that could not be read
+
+#### Scenario: Unreachable is not reported as gone
+
+- **WHEN** the subject could not be fetched for a reason other than it being absent
+- **THEN** the header says it could not be loaded, distinctly from saying it is no longer listed
+
+#### Scenario: A merged company slug still names its company
+
+- **WHEN** the subject is a company whose slug a merge has retired
+- **THEN** the header names the company that absorbed it, and the discussion stays at the url it is under — threads record the retired slug, so the canonical url would not resolve them
+
 ### Requirement: A discussions section on the web client
 
 The web client SHALL serve a `/discussions` page rendering the cross-subject
@@ -93,10 +135,16 @@ topic, which requires a subject.
 The system SHALL return the threads attached to a given subject, newest first,
 each carrying its persona handle, title, reply count, and timestamps.
 
-Paged listings SHALL signal a further page only when one exists: a
-continuation cursor SHALL be returned only when the page returned is full, and
-SHALL be absent on the final page. This applies to both the subject thread
-listing and a thread's reply listing.
+Paged listings SHALL return a continuation cursor only when the page came back
+full, and SHALL omit it on a partial page. This applies to both the subject
+thread listing and a thread's reply listing.
+
+A full page is not proof that another exists: a listing holding exactly a
+multiple of the page size still ends on a full one. That residue is deliberate
+and bounded — see the design note — and closing it needs a fetch-ahead the
+domain's listing methods do not do. The requirement is therefore stated as
+"full page", not as "a further page exists"; the two differ only in that case,
+and stating the stronger one would describe behaviour nothing implements.
 
 #### Scenario: List a company's threads
 

--- a/openspec/changes/add-discussions-feed/tasks.md
+++ b/openspec/changes/add-discussions-feed/tasks.md
@@ -13,6 +13,10 @@
   `threads (created_at DESC, id DESC) WHERE status = 'open'`, with a comment
   saying why the existing subject-prefixed index cannot serve the feed
 - [x] 2.2 `pnpm check:sql` passes on the new file
+- [x] 2.3 Migration `0127_repair_threads_open_created_idx.sql`: repairs any
+  database that recorded 0126 while the index it built was invalid. Needed
+  because the host's autodeploy recorded 0126 between its failed release and
+  the fix, so the edited 0126 can never run there
 
 ## 3. SQL queries (sqlc)
 
@@ -68,3 +72,24 @@
   resolved subject names and logos, and the single-thread subject page no
   longer draws "Load more". Took three releases — see 0126/0127 for the
   CONCURRENTLY lock timeout and the invalid index it left behind.
+
+## 8. Subject header (added after the feed shipped, on request)
+
+- [x] 8.1 `discussionSubject.ts`: the pure mapping from a `Job`/`Company` to
+  what the header prints — title, logo key, employer label, closed state
+- [x] 8.2 `server/discussionSubject.ts`: fetch it, never throw, and tell a gone
+  subject apart from an unreachable one; follow a merged company slug by hand
+- [x] 8.3 `SubjectHeader.svelte`: one link when the subject resolved, a plain
+  box when it did not
+- [x] 8.4 Wire into all four subject-scoped discussion pages, replacing the
+  breadcrumbs (the company ones printed a raw slug)
+- [x] 8.5 `loadDiscussionIndex` shared by both index routes, as `loadThread`
+  already was by both thread routes
+- [x] 8.6 Unit tests for the mapping, including the employerless vacancy
+
+## 9. Closing out
+
+- [ ] 9.1 Archive the change (`opsx:archive`) and sync the delta into
+  `openspec/specs/community-threads/spec.md`. Deliberately last: the header in
+  section 8 arrived after the rest had shipped, so archiving earlier would have
+  closed a change that was still growing

--- a/web/src/lib/server/threadSubject.test.ts
+++ b/web/src/lib/server/threadSubject.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vitest';
+import type { CommunityThread } from '$lib/types';
 import { threadMatchesSubject } from './threadSubject';
+
+/** Exactly what the function reads off a thread. Annotated rather than inferred so the
+ *  stubs carry the wire type's `subject_type` union instead of widening it to string. */
+type Subject = Pick<CommunityThread, 'subject_type' | 'subject_slug'>;
 
 describe('threadMatchesSubject', () => {
   it('matches when both the subject kind and slug agree with the URL', () => {
-    const thread = { subject_type: 'company', subject_slug: 'acme' };
+    const thread: Subject = { subject_type: 'company', subject_slug: 'acme' };
     expect(threadMatchesSubject(thread, 'company', 'acme')).toBe(true);
   });
 
@@ -11,14 +16,14 @@ describe('threadMatchesSubject', () => {
     // A syntactically valid threadId can name a real thread that belongs to a
     // DIFFERENT company than the one in the URL — getThread(id) alone has no way
     // to know that.
-    const thread = { subject_type: 'company', subject_slug: 'other-co' };
+    const thread: Subject = { subject_type: 'company', subject_slug: 'other-co' };
     expect(threadMatchesSubject(thread, 'company', 'acme')).toBe(false);
   });
 
   it('rejects a thread that resolves under the other subject kind entirely', () => {
     // Thread ids are not namespaced per subject kind, so a job's thread id can
     // collide with a company detail page's [threadId] param.
-    const thread = { subject_type: 'job', subject_slug: 'acme' };
+    const thread: Subject = { subject_type: 'job', subject_slug: 'acme' };
     expect(threadMatchesSubject(thread, 'company', 'acme')).toBe(false);
   });
 });

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1119,7 +1119,11 @@ export interface PhotoMeta {
  *  is a pseudonymous persona handle — the backend never sends the real user id. */
 export interface CommunityThread {
   id: number;
-  subject_type: string;
+  /** The schema's own discriminator, and a closed set: the CHECK constraint on
+   *  `threads.subject_type` admits exactly these two. Typed as the union rather than
+   *  `string` because every consumer narrows to it anyway, and one that forgot would
+   *  have compiled. */
+  subject_type: 'company' | 'job';
   subject_slug: string;
   title: string;
   body: string;


### PR DESCRIPTION
A two-axis review of the **whole** discussions work as it now stands on main
(#2364, #2365, #2366, #2367, #2373, #2376), rather than of any one PR — so it
could see drift across them that the per-PR reviews could not. Six findings
acted on.

## The two that matter

**`0126` was rewritten after prod had recorded it** — the one thing the
migration rule forbids — and `0127` diagnosed that without repairing the reading
experience. The edited 0126 still opened by asserting it drops a carcass, on a
database it can never run on, with nothing pointing at the file that actually
did. It now says so in its first line.

**The subject header was in no spec artifact at all**, while `tasks.md` read
complete through 7.4. The change *looked closed* while a whole later feature had
ridden in under it. It now has a requirement, six scenarios, and its own task
section — and the archive step is written down as the one box still open rather
than left implicit.

## The rest

- **The cursor requirement contradicted itself.** It opened with "signal a
  further page only when one exists" and closed with "only when the page
  returned is full". Those differ at exactly a multiple of the page size — the
  residue `design.md` already records. The normative sentence now states what is
  implemented, and says why the stronger form would be a lie.
- **The proposal claimed one migration and no `DROP`.** It describes both, and
  why neither is `CONCURRENTLY`.
- **`pageMeta` compared with `==`**, so a page longer than asked for would have
  silently dropped the cursor — the same silence, from the other side. Now `>=`.
- **The fake repository filled `SubjectTitle` and `SubjectCompany` from one
  string**, so they could never diverge — precisely the case the resolution rule
  exists for. It holds them apart now, with a test for that shape.

Narrowing `CommunityThread.subject_type` from `string` to its union found the
same looseness in `threadSubject.test.ts`, whose stubs had widened back.

## Declined, with reasons

- **Fetch-ahead (`limit+1`)** to close the exact-multiple residue and retire
  `Service.PageSize()`. Real, and already recorded in `design.md` as a seam: it
  changes what the domain's three listing methods return. Its own change.
- **Merging `feedSubject.ts` into `discussionSubject.ts`.** Different inputs (a
  wire row vs a `Job`/`Company`) and different outputs (a row rail with a kind
  badge vs a page header with a closed state). One type would carry fields empty
  on each side — the argument that kept `ThreadWithSubject` off `Thread`.
- **Extracting the row→`Thread` mapping in `repository.go`.** The alternatives
  are a twelve-argument helper or a struct conversion between two generated
  types that only happen to match — a clever shim the repo warns against.
- **`DiscussionIndex.svelte`'s hand-rolled `<style>`.** Pre-existing, not
  orphaned by this work.

## Verification

`gofmt` clean · `go vet ./...` · `go vet -tags=integration ./...` · `go test
./...` · `golangci-lint run --new-from-merge-base=origin/main` 0 issues ·
`pnpm check` 0 errors · eslint clean · squawk 0 issues · `check-doc-links` 280
links · govulncheck clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added subject-aware headers to discussion pages, including job titles, company names, and vacancy status.
  - Added navigation from the header menu to the discussions feed.

- **Bug Fixes**
  - Improved discussion listings with more reliable “Load more” pagination when pages contain additional results.
  - Corrected subject details so job titles and company names are displayed separately, including when company information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->