### PR TITLE
Let the dictionary index return the whole dictionary

### DIFF
--- a/internal/search/search/suggest_index.go
+++ b/internal/search/search/suggest_index.go
@@ -25,6 +25,15 @@ import (
 const (
 	suggestIndexUID   = "suggestions"
 	suggestRebuildUID = "suggestions_rebuild"
+
+	// maxDictionary bounds BOTH how many documents a whole-dictionary read asks for and
+	// how many the index will return — the same number, deliberately, because the two
+	// disagreeing is exactly the failure this const was introduced to fix.
+	//
+	// The dictionary is tens of thousands of rows by construction (the frequency floors
+	// keep it there), so this is a guard against a misconfigured floor rather than a
+	// paging limit.
+	maxDictionary = 200_000
 )
 
 // suggestSettings configures the dictionary index.
@@ -46,6 +55,17 @@ func suggestSettings() *meilisearch.Settings {
 		// Demand first, then supply — the endpoint's tie-breakers, applied by the
 		// engine so they cost nothing at query time.
 		SortableAttributes: []string{"searches", "jobs"},
+		// Meilisearch caps a search at `maxTotalHits` results, and its DEFAULT is 1000 —
+		// which silently truncated the recognition set the API loads at startup. The
+		// symptom read as a parsing bug: `senior software engineer` (23,643 postings)
+		// was recognised and `nodejs developer` (27) was not, because the dictionary is
+		// returned in `searches:desc, jobs:desc` order and the tail never arrived.
+		//
+		// The ceiling is well above the dictionary's own bound (the frequency floors
+		// keep it in the tens of thousands, and AllSuggestions asks for at most 200,000)
+		// so it constrains nothing that should be served — it only stops the default
+		// from doing the constraining.
+		Pagination: &meilisearch.Pagination{MaxTotalHits: maxDictionary},
 		// The default rules minus `sort` reordering, plus the two custom rules that
 		// carry the ranking this index exists to apply. `searches` leads because what
 		// people actually ask for beats what merely exists a lot of.
@@ -100,13 +120,6 @@ func (c *Client) primaryKeyFor(uid string) string {
 	}
 	return primaryKey
 }
-
-// maxDictionary bounds the whole-dictionary read behind the recognition set. The
-// dictionary is tens of thousands of rows by construction — a floor keeps it there —
-// so this is a guard against a misconfigured floor rather than a paging limit: reading
-// a dictionary that large into a long-lived process is a memory problem, and silently
-// truncating it is better than the alternative of holding all of it.
-const maxDictionary = 200_000
 
 // AllSuggestions reads the dictionary whole, for the in-process recognition set.
 //

--- a/internal/search/search/suggest_index_test.go
+++ b/internal/search/search/suggest_index_test.go
@@ -38,3 +38,22 @@ func TestIsIndexMissing(t *testing.T) {
 		}
 	}
 }
+
+// Meilisearch caps a search at the index's `maxTotalHits`, whose DEFAULT is 1000. The
+// suggestions index inherited that default, which silently truncated the recognition
+// set the API loads at startup — and the symptom read as a parsing bug: `senior
+// software engineer` (23,643 postings) was recognised while `nodejs developer` (27)
+// was not, because the dictionary comes back in `searches:desc, jobs:desc` order and
+// the tail never arrived.
+//
+// So the ceiling and the request must be the SAME number. Asking for more than the
+// index will return is the whole failure.
+func TestSuggestSettings_PaginationCoversTheWholeDictionaryRead(t *testing.T) {
+	s := suggestSettings()
+	if s.Pagination == nil {
+		t.Fatal("no pagination set — the index would use the engine's 1000 default")
+	}
+	if got := s.Pagination.MaxTotalHits; got != maxDictionary {
+		t.Errorf("MaxTotalHits = %d, but AllSuggestions asks for %d", got, maxDictionary)
+	}
+}


### PR DESCRIPTION
Meilisearch caps a search at the index's `maxTotalHits`, and its **default is
1000**. The `suggestions` index inherited that default — the jobs index sets its
own and this one did not — so the recognition set the API loads at startup held
**1,000 phrases out of 77,203**, the top of a `searches:desc, jobs:desc` ordering.

The symptom read as a parsing bug, which is why it took three passes to find:

```
java dev    →  Java Developer   5,480   ✓   (title in the top 1000)
nodejs dev  →  Nodejs Dev.Pro      49   ✗   ("nodejs developer" has 27 — cut off)
```

Same code, same query shape, different side of a cut nobody had declared. The
parse was right the whole time; it was reasoning over a truncated vocabulary.

The ceiling and the request are now one constant — asking for more than the index
will return is the entire failure — and a test asserts they cannot drift apart.

Needs a dictionary rebuild after deploy to apply the new index settings.