### PR TITLE
Let a source that states education and English level say so

### DIFF
--- a/cmd/ingest/store.go
+++ b/cmd/ingest/store.go
@@ -121,6 +121,7 @@ func persist(ctx context.Context, qtx *db.Queries, p db.UpsertJobParams) (writte
 		SalaryMaxSource:      p.SalaryMaxSource,
 		SalaryCurrencySource: p.SalaryCurrencySource,
 		SalaryPeriodSource:   p.SalaryPeriodSource,
+		EnglishLevel:         p.EnglishLevel,
 	})
 	if err == nil {
 		return cheapWrite(cheap), nil

--- a/internal/ingest/pipeline/pipeline.go
+++ b/internal/ingest/pipeline/pipeline.go
@@ -1052,6 +1052,8 @@ func normalizeJob(e sources.CompanyEntry, j sources.Job, canon companyCanonical)
 			EmploymentType:     j.EmploymentType,
 			Skills:             j.Skills,
 			ExperienceYearsMin: j.ExperienceYearsMin,
+			EducationLevel:     j.EducationLevel,
+			EnglishLevel:       j.EnglishLevel,
 			SalaryMin:          j.SalaryMin,
 			SalaryMax:          j.SalaryMax,
 			SalaryCurrency:     j.SalaryCurrency,

--- a/internal/ingest/sources/profession.go
+++ b/internal/ingest/sources/profession.go
@@ -113,6 +113,7 @@ type professionLDPosting struct {
 	DatePosted         string `json:"datePosted"`
 	EmploymentType     string `json:"employmentType"`
 	ExperienceReqs     string `json:"experienceRequirements"`
+	EducationReqs      string `json:"educationRequirements"`
 	HiringOrganization struct {
 		Name string `json:"name"`
 	} `json:"hiringOrganization"`
@@ -200,6 +201,7 @@ func (s profession) detail(ctx context.Context, loc, externalID string) (Job, bo
 		return Job{}, false
 	}
 	workMode, place := professionPlace(professionAddressLine(root))
+	education, english := professionEducationAndLanguage(ld.EducationReqs)
 	return Job{
 		ExternalID:         externalID,
 		URL:                loc,
@@ -212,6 +214,8 @@ func (s profession) detail(ctx context.Context, loc, externalID string) (Job, bo
 		Countries:          professionCountries(ld),
 		EmploymentType:     professionEmploymentType(ld.EmploymentType),
 		ExperienceYearsMin: professionExperienceYears(ld.ExperienceReqs),
+		EducationLevel:     education,
+		EnglishLevel:       english,
 		PostedAt:           parseDate(ld.DatePosted),
 	}, true
 }
@@ -390,4 +394,66 @@ func professionAddressLine(root *html.Node) string {
 		return ""
 	}
 	return textContent(n)
+}
+
+// professionSchoolLevels maps the platform's school picklist onto freehire's education
+// vocabulary. The Hungarian pair is the load-bearing part: főiskola (a three-to-four year
+// college programme) is the bachelor's-equivalent and egyetem (the five-year university
+// programme) the master's-equivalent — the distinction the picklist preserves from before
+// Bologna. Everything below them is the platform stating that no degree is required.
+//
+// "Felsőoktatási szakképzés" is deliberately absent. It is a two-year tertiary programme,
+// above secondary school and below a bachelor's, and freehire's four-value vocabulary has
+// no member for it — so it yields nothing rather than rounding to a neighbour, on the
+// jobfacts doctrine that a wrong value in a faceted field is worse than a missing one. It
+// is 28 of the 709 live postings.
+var professionSchoolLevels = map[string]string{
+	"Általános iskola":              "none",
+	"Szakiskola / szakmunkás képző": "none",
+	"Középiskola":                   "none",
+	"Főiskola":                      "bachelor",
+	"Egyetem":                       "master",
+}
+
+// professionEnglishLevels maps the platform's language picklist onto CEFR, for English.
+//
+// THE LEVELS ARE NOT "basic/medium/advanced". alapfok/középfok/felsőfok are Hungary's
+// state-recognised language-exam levels and are defined as B1/B2/C1 (Government Decree
+// 137/2008; the same equivalence every accredited exam centre publishes). Reading them by
+// their everyday sense puts each posting a level off — and the trio has no name for C2 at
+// all, which is why "felsőfok" is so often rendered as one.
+var professionEnglishLevels = map[string]string{
+	"Angol alapfok":          "b1",
+	"Angol középfok":         "b2",
+	"Angol felsőfok":         "c1",
+	"Angol anyanyelvi szint": "native",
+}
+
+// professionNoLanguageRequired is the platform's own way of stating that the posting asks
+// for no language at all — which is a statement about English, unlike naming some other
+// language and staying silent about it.
+const professionNoLanguageRequired = "Nem kell nyelvtudás"
+
+// professionEducationAndLanguage reads the educationRequirements picklist, which
+// comma-joins two different things: zero or more LANGUAGE levels and one SCHOOL level
+// ("Angol középfok, Német középfok, Egyetem"). Each half is resolved independently and a
+// token outside the closed vocabulary — read off all 709 live postings — yields nothing,
+// so a change on the platform's side reads as silence rather than as a wrong facet.
+//
+// Only English answers the English facet. A posting requiring German and saying nothing
+// about English states no English level; a posting requiring no language at all states
+// "none".
+func professionEducationAndLanguage(field string) (education, english string) {
+	for _, token := range strings.Split(field, ",") {
+		token = strings.TrimSpace(token)
+		switch {
+		case token == professionNoLanguageRequired:
+			english = "none"
+		case professionEnglishLevels[token] != "":
+			english = professionEnglishLevels[token]
+		case professionSchoolLevels[token] != "":
+			education = professionSchoolLevels[token]
+		}
+	}
+	return education, english
 }

--- a/internal/ingest/sources/profession_test.go
+++ b/internal/ingest/sources/profession_test.go
@@ -45,6 +45,7 @@ type professionPostingOpts struct {
 	locationRequirement    string
 	employmentType         string
 	experienceRequirements string
+	educationRequirements  string
 	// sections are the body sections the page renders, in order, as (id, heading, inner HTML).
 	sections [][3]string
 }
@@ -62,6 +63,7 @@ func professionPostingHTML(o professionPostingOpts) string {
 		"validThrough":           "2026-10-03T17:04:20",
 		"employmentType":         o.employmentType,
 		"experienceRequirements": o.experienceRequirements,
+		"educationRequirements":  o.educationRequirements,
 		"occupationalCategory":   "IT programozás, Fejlesztés - Programozó, Fejlesztő",
 		// The block's own description: the same text as the sections below with its list
 		// markup flattened, which is why the adapter must not read it.
@@ -121,6 +123,8 @@ func professionHybridPosting() string {
 		employmentType:      "Teljes munkaidő, Alkalmazotti jogviszony",
 		// The picklist's own spelling; the adapter reads the low end of the band.
 		experienceRequirements: "3-5 év tapasztalat",
+		// English at B2 and a college degree — the platform's two commonest answers.
+		educationRequirements: "Angol középfok, Főiskola",
 		sections: [][3]string{
 			{"tasks", "Feladatok", "<ul><li>Microservice-ek fejlesztése</li></ul>"},
 			{"requirements", "Elvárások", "<ul><li>Minimum 3 éves NodeJs tapasztalat</li></ul>"},
@@ -227,6 +231,11 @@ func TestProfessionFetch(t *testing.T) {
 	}
 	if hybrid.ExperienceYearsMin == nil || *hybrid.ExperienceYearsMin != 3 {
 		t.Errorf("experience = %v, want 3", hybrid.ExperienceYearsMin)
+	}
+	// The platform states both as a picklist, so neither is left to the English-prose
+	// matchers — which would find nothing at all in a Hungarian body.
+	if hybrid.EducationLevel != "bachelor" || hybrid.EnglishLevel != "b2" {
+		t.Errorf("education/english = %q/%q, want bachelor/b2", hybrid.EducationLevel, hybrid.EnglishLevel)
 	}
 	if hybrid.PostedAt == nil || hybrid.PostedAt.Format("2006-01-02") != "2026-09-02" {
 		t.Errorf("posted at = %v", hybrid.PostedAt)
@@ -403,5 +412,51 @@ func TestProfessionExperienceYears(t *testing.T) {
 		case want != nil && (got == nil || *got != *want):
 			t.Errorf("professionExperienceYears(%q) = %v, want %d", level, got, *want)
 		}
+	}
+}
+
+// TestProfessionEducationAndLanguage pins the platform's educationRequirements picklist,
+// which states two different things in one comma-joined field: zero or more LANGUAGE
+// levels and exactly one SCHOOL level. The whole closed vocabulary — 28 tokens — was read
+// off all 709 live postings, so a value outside it is a change on the platform's side and
+// must yield nothing rather than a guess.
+func TestProfessionEducationAndLanguage(t *testing.T) {
+	cases := []struct {
+		name, field, wantEdu, wantEng string
+	}{
+		// The two commonest values, together 46% of the slice.
+		{"intermediate english, secondary school", "Angol középfok, Középiskola", "none", "b2"},
+		{"intermediate english, college", "Angol középfok, Főiskola", "bachelor", "b2"},
+		// Hungary's exam levels are NOT "basic/medium/high": alapfok/középfok/felsőfok are
+		// the state-recognised levels and map to B1/B2/C1 (Gov. Decree 137/2008). The trio
+		// has no name for C2, which is why felsőfok is so often mistranslated as one.
+		{"basic english is B1, not A-something", "Angol alapfok, Középiskola", "none", "b1"},
+		{"advanced english is C1, not C2", "Angol felsőfok, Egyetem", "master", "c1"},
+		{"native english", "Angol anyanyelvi szint, Egyetem", "master", "native"},
+		// The platform's own way of saying no language is required.
+		{"no language needed", "Nem kell nyelvtudás, Középiskola", "none", "none"},
+		// A posting may require several languages; only English answers this facet, and a
+		// posting naming other languages says nothing about English.
+		{"english alongside german", "Angol középfok, Német középfok, Középiskola", "none", "b2"},
+		{"german only states no english level", "Német felsőfok, Egyetem", "master", ""},
+		{"hungarian native alongside english", "Angol felsőfok, Magyar anyanyelvi szint, Egyetem", "master", "c1"},
+		// School levels below a degree are the platform stating that no degree is needed.
+		{"primary school", "Nem kell nyelvtudás, Általános iskola", "none", "none"},
+		{"vocational school", "Angol alapfok, Szakiskola / szakmunkás képző", "none", "b1"},
+		// Felsőoktatási szakképzés is a two-year tertiary programme, below a bachelor's and
+		// above secondary — freehire's four-value vocabulary has no member for it, so it
+		// yields nothing rather than rounding to a neighbour.
+		{"higher vocational maps to neither", "Angol középfok, Felsőoktatási szakképzés", "", "b2"},
+		{"empty field", "", "", ""},
+		{"a value the platform has not published before", "Angol mesterfok, Doktori", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			edu, eng := professionEducationAndLanguage(tc.field)
+			if edu != tc.wantEdu || eng != tc.wantEng {
+				t.Errorf("professionEducationAndLanguage(%q) = %q/%q, want %q/%q",
+					tc.field, edu, eng, tc.wantEdu, tc.wantEng)
+			}
+		})
 	}
 }

--- a/internal/ingest/sources/source.go
+++ b/internal/ingest/sources/source.go
@@ -73,6 +73,15 @@ type Job struct {
 	EmploymentType     string
 	Skills             []string
 	ExperienceYearsMin *int
+	// EducationLevel and EnglishLevel follow the same structured-only contract, for the
+	// platforms that state them as a picklist instead of leaving them in prose
+	// (profession.hu publishes both on every posting, as "Angol középfok, Egyetem").
+	// Members of vocab.EducationLevelValues / vocab.EnglishLevelValues. They matter more
+	// than the other scalars on a non-English board: the fallback matchers
+	// (internal/job/jobfacts) read English prose only, so without a structured value a
+	// Hungarian or Polish posting yields nothing at all rather than something weaker.
+	EducationLevel string
+	EnglishLevel   string
 	// Countries mirrors the same contract for geography: an adapter sets it only when
 	// the platform states the country in a STRUCTURED field (not the free-text location
 	// the description/location string carries), normalized through

--- a/internal/job/job/job_test.go
+++ b/internal/job/job/job_test.go
@@ -395,10 +395,13 @@ func TestUpdateManualParams_ContentHashUsesThePersistedSlugNotTheRederivedOne(t 
 // difference — a column that moves without moving the key is one the cheap path would
 // silently leave stale.
 //
-// The key is content_hash AND cities, and this test is the authority on why it needs both.
-// cities is the one column UpsertJob writes that jobhash.Of does not read: a caller's
-// structured city list overrides the location-derived one (jobderive.Derive), so it can move
-// while every hashed field stands still. Folding cities into Of instead would change every
+// The key is content_hash plus the columns UpsertJob writes that jobhash.Of does not read, and
+// this test is the authority on why it needs them. cities is one: a caller's structured city
+// list overrides the location-derived one (jobderive.Derive), so it can move while every hashed
+// field stands still. english_level is another, and became one the day it gained a structured
+// tier of its own — until then it was read out of the hashed description and so could not move
+// on its own. Note that education_level sits on the OTHER side of the same choice: it is hashed,
+// because it was hashed before either had a structured tier. Folding cities into Of instead would change every
 // stored hash at once and make the first crawl after deploy rewrite and re-index the whole
 // catalogue — the write storm this change exists to remove. So the predicate carries it.
 //
@@ -431,8 +434,9 @@ func TestUpsertParams_CheapWriteMatchKeyCoversEveryColumnItWrites(t *testing.T) 
 			}
 			if matchKeyHeld(baseParams, got) {
 				t.Errorf("Input.%s moved %v but left RefreshUnchangedJob's match key "+
-					"(content_hash, cities) unchanged: an unchanged re-ingest would skip the "+
-					"row and leave those columns stale", field.Name, moved)
+					"(content_hash, cities, salary_*_source, english_level) unchanged: an "+
+					"unchanged re-ingest would skip the row and leave those columns stale",
+					field.Name, moved)
 			}
 		})
 	}
@@ -446,7 +450,8 @@ func matchKeyHeld(a, b db.UpsertJobParams) bool {
 		a.SalaryMinSource == b.SalaryMinSource &&
 		a.SalaryMaxSource == b.SalaryMaxSource &&
 		a.SalaryCurrencySource == b.SalaryCurrencySource &&
-		a.SalaryPeriodSource == b.SalaryPeriodSource
+		a.SalaryPeriodSource == b.SalaryPeriodSource &&
+		a.EnglishLevel == b.EnglishLevel
 }
 
 // fullDraft populates every jobderive.Input field, including the optional structured signals,

--- a/internal/job/jobderive/jobderive.go
+++ b/internal/job/jobderive/jobderive.go
@@ -53,6 +53,14 @@ type Input struct {
 	EmploymentType     string
 	Skills             []string
 	ExperienceYearsMin *int
+	// EducationLevel and EnglishLevel are the caller's structured signal for the two
+	// facets a platform states as a picklist rather than in prose (Profession.hu
+	// publishes both, on every posting). They obey the same contract as the scalars
+	// above — a member of vocab.EducationLevelValues / vocab.EnglishLevelValues, set
+	// only from a stated field and never from an adapter's own reading of the text,
+	// so an adapter with nothing to say leaves them empty and the matchers decide.
+	EducationLevel string
+	EnglishLevel   string
 	// SalaryMin/SalaryMax/SalaryCurrency/SalaryPeriod are the caller's structured
 	// salary signal — an adapter sets them only when the ATS states a salary in its
 	// own structured field (never a description-text guess: unlike the scalars
@@ -187,6 +195,17 @@ func Derive(in Input) Derived {
 	if experience == nil {
 		experience = jobfacts.ExperienceYearsMin(in.Description)
 	}
+	// Education and English precedence: structured source signal → description text
+	// parse. Both matchers read English prose only, so on a posting written in another
+	// language they are the weaker source by a wide margin, not merely the later one.
+	educationLevel := in.EducationLevel
+	if educationLevel == "" {
+		educationLevel = jobfacts.EducationLevel(in.Description)
+	}
+	englishLevel := in.EnglishLevel
+	if englishLevel == "" {
+		englishLevel = jobfacts.EnglishLevel(in.Description)
+	}
 	return Derived{
 		CompanySlug: normalize.CompanySlug(in.Company),
 		PublicSlug:  normalize.JobSlug(in.Title, in.Company, in.Source, in.ExternalID),
@@ -207,8 +226,8 @@ func Derive(in Input) Derived {
 		RequiresClearance:  deriveRequiresClearance(in.Description),
 		PostingLanguage:    lang.Detect(in.Description),
 		EmploymentType:     employmentType,
-		EducationLevel:     jobfacts.EducationLevel(in.Description),
-		EnglishLevel:       jobfacts.EnglishLevel(in.Description),
+		EducationLevel:     educationLevel,
+		EnglishLevel:       englishLevel,
 		ExperienceYearsMin: experience,
 		SalaryMin:          in.SalaryMin,
 		SalaryMax:          in.SalaryMax,

--- a/internal/job/jobderive/jobderive_test.go
+++ b/internal/job/jobderive/jobderive_test.go
@@ -103,6 +103,47 @@ func TestDerive_StructuredEmploymentTypeWins(t *testing.T) {
 	}
 }
 
+// Education and English level were the last two facets with no structured tier: both
+// were always read out of the description by English-language matchers, so a platform
+// that STATES them — Profession.hu publishes each as a closed picklist — had nowhere to
+// put the answer. They now follow the same precedence as the four facets above.
+func TestDerive_StructuredEducationAndEnglishLevelWin(t *testing.T) {
+	got := Derive(Input{
+		Title:      "Fejlesztő",
+		Company:    "Acme",
+		Source:     "profession",
+		ExternalID: "4",
+		// The description would parse to bachelor and c1 on its own.
+		Description:    "Bachelor's degree required. Fluent English.",
+		EducationLevel: "master",
+		EnglishLevel:   "b2",
+	})
+	if got.EducationLevel != "master" {
+		t.Errorf("EducationLevel = %q, want master (structured wins over the bachelor in the text)", got.EducationLevel)
+	}
+	if got.EnglishLevel != "b2" {
+		t.Errorf("EnglishLevel = %q, want b2 (structured wins over the fluent in the text)", got.EnglishLevel)
+	}
+}
+
+// The description stays the fallback: a source that states neither leaves both to the
+// matchers, which is every adapter but one.
+func TestDerive_EducationAndEnglishLevelFallBackToDescription(t *testing.T) {
+	got := Derive(Input{
+		Title:       "Developer",
+		Company:     "Acme",
+		Source:      "greenhouse",
+		ExternalID:  "5",
+		Description: "Bachelor's degree required. English at B2 level.",
+	})
+	if got.EducationLevel != "bachelor" {
+		t.Errorf("EducationLevel = %q, want bachelor from the description", got.EducationLevel)
+	}
+	if got.EnglishLevel != "b2" {
+		t.Errorf("EnglishLevel = %q, want b2 from the description", got.EnglishLevel)
+	}
+}
+
 func TestDerive_StructuredWorkModeWins(t *testing.T) {
 	got := Derive(Input{
 		Title:      "Dev",

--- a/internal/platform/db/jobs.sql.go
+++ b/internal/platform/db/jobs.sql.go
@@ -2775,6 +2775,7 @@ WHERE source = $1
   AND salary_max_source IS NOT DISTINCT FROM $6
   AND salary_currency_source = $7
   AND salary_period_source = $8
+  AND english_level = $9
   AND closed_at IS NULL
 RETURNING id, source, company_slug, duplicate_of
 `
@@ -2788,6 +2789,7 @@ type RefreshUnchangedJobParams struct {
 	SalaryMaxSource      pgtype.Int4 `json:"salary_max_source"`
 	SalaryCurrencySource string      `json:"salary_currency_source"`
 	SalaryPeriodSource   string      `json:"salary_period_source"`
+	EnglishLevel         string      `json:"english_level"`
 }
 
 type RefreshUnchangedJobRow struct {
@@ -2818,13 +2820,16 @@ type RefreshUnchangedJobRow struct {
 // and cmd/reindex has no --since flag despite what its comment says), because a column stamped
 // on every crawl selects the whole catalogue and answers nothing.
 //
-// The match key is (content_hash, cities, salary_*_source), not the hash alone. cities and the
-// four salary_*_source columns are what the upsert writes that jobhash.Of does not read — a
-// caller's structured city list overrides the location-derived one, and a structured salary
-// (Lever/Ashby/Recruitee) is a base fact, not something Of hashes, so either can move while
-// every hashed field stands still. Folding them into the hash instead would change every stored
-// content_hash at once and make the first crawl after deploy rewrite and re-index the whole
-// catalogue. IS NOT DISTINCT FROM (not =) on the nullable salary bounds so two sourceless jobs
+// The match key is (content_hash, cities, salary_*_source, english_level), not the hash alone.
+// Those are what the upsert writes that jobhash.Of does not read — a caller's structured city
+// list overrides the location-derived one, a structured salary (Lever/Ashby/Recruitee) is a
+// base fact rather than something Of hashes, and english_level gained a structured tier of its
+// own (profession.hu states it as a picklist) so it too can move while every hashed field
+// stands still. Folding them into the hash instead would change every stored content_hash at
+// once and make the first crawl after deploy rewrite and re-index the whole catalogue — 6.6M
+// rows through a queue that drains at ~9 documents a second. Note the asymmetry with
+// education_level, which IS hashed: it was hashed before either had a structured tier, and
+// moving it out now would cost exactly the storm this key exists to avoid. IS NOT DISTINCT FROM (not =) on the nullable salary bounds so two sourceless jobs
 // (both NULL) still match — a plain = would push every non-salary-bearing source off the cheap
 // path forever. Whether the key still covers every written column is enforced by
 // TestUpsertParams_CheapWriteMatchKeyCoversEveryColumnItWrites (internal/job); add a derived
@@ -2856,6 +2861,7 @@ func (q *Queries) RefreshUnchangedJob(ctx context.Context, arg RefreshUnchangedJ
 		arg.SalaryMaxSource,
 		arg.SalaryCurrencySource,
 		arg.SalaryPeriodSource,
+		arg.EnglishLevel,
 	)
 	var i RefreshUnchangedJobRow
 	err := row.Scan(

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -3589,13 +3589,16 @@ type Querier interface {
 	// and cmd/reindex has no --since flag despite what its comment says), because a column stamped
 	// on every crawl selects the whole catalogue and answers nothing.
 	//
-	// The match key is (content_hash, cities, salary_*_source), not the hash alone. cities and the
-	// four salary_*_source columns are what the upsert writes that jobhash.Of does not read — a
-	// caller's structured city list overrides the location-derived one, and a structured salary
-	// (Lever/Ashby/Recruitee) is a base fact, not something Of hashes, so either can move while
-	// every hashed field stands still. Folding them into the hash instead would change every stored
-	// content_hash at once and make the first crawl after deploy rewrite and re-index the whole
-	// catalogue. IS NOT DISTINCT FROM (not =) on the nullable salary bounds so two sourceless jobs
+	// The match key is (content_hash, cities, salary_*_source, english_level), not the hash alone.
+	// Those are what the upsert writes that jobhash.Of does not read — a caller's structured city
+	// list overrides the location-derived one, a structured salary (Lever/Ashby/Recruitee) is a
+	// base fact rather than something Of hashes, and english_level gained a structured tier of its
+	// own (profession.hu states it as a picklist) so it too can move while every hashed field
+	// stands still. Folding them into the hash instead would change every stored content_hash at
+	// once and make the first crawl after deploy rewrite and re-index the whole catalogue — 6.6M
+	// rows through a queue that drains at ~9 documents a second. Note the asymmetry with
+	// education_level, which IS hashed: it was hashed before either had a structured tier, and
+	// moving it out now would cost exactly the storm this key exists to avoid. IS NOT DISTINCT FROM (not =) on the nullable salary bounds so two sourceless jobs
 	// (both NULL) still match — a plain = would push every non-salary-bearing source off the cheap
 	// path forever. Whether the key still covers every written column is enforced by
 	// TestUpsertParams_CheapWriteMatchKeyCoversEveryColumnItWrites (internal/job); add a derived

--- a/internal/platform/db/queries/jobs.sql
+++ b/internal/platform/db/queries/jobs.sql
@@ -387,13 +387,16 @@ WHERE source = sqlc.arg(source) AND company = '' AND external_id LIKE sqlc.arg(b
 -- and cmd/reindex has no --since flag despite what its comment says), because a column stamped
 -- on every crawl selects the whole catalogue and answers nothing.
 --
--- The match key is (content_hash, cities, salary_*_source), not the hash alone. cities and the
--- four salary_*_source columns are what the upsert writes that jobhash.Of does not read — a
--- caller's structured city list overrides the location-derived one, and a structured salary
--- (Lever/Ashby/Recruitee) is a base fact, not something Of hashes, so either can move while
--- every hashed field stands still. Folding them into the hash instead would change every stored
--- content_hash at once and make the first crawl after deploy rewrite and re-index the whole
--- catalogue. IS NOT DISTINCT FROM (not =) on the nullable salary bounds so two sourceless jobs
+-- The match key is (content_hash, cities, salary_*_source, english_level), not the hash alone.
+-- Those are what the upsert writes that jobhash.Of does not read — a caller's structured city
+-- list overrides the location-derived one, a structured salary (Lever/Ashby/Recruitee) is a
+-- base fact rather than something Of hashes, and english_level gained a structured tier of its
+-- own (profession.hu states it as a picklist) so it too can move while every hashed field
+-- stands still. Folding them into the hash instead would change every stored content_hash at
+-- once and make the first crawl after deploy rewrite and re-index the whole catalogue — 6.6M
+-- rows through a queue that drains at ~9 documents a second. Note the asymmetry with
+-- education_level, which IS hashed: it was hashed before either had a structured tier, and
+-- moving it out now would cost exactly the storm this key exists to avoid. IS NOT DISTINCT FROM (not =) on the nullable salary bounds so two sourceless jobs
 -- (both NULL) still match — a plain = would push every non-salary-bearing source off the cheap
 -- path forever. Whether the key still covers every written column is enforced by
 -- TestUpsertParams_CheapWriteMatchKeyCoversEveryColumnItWrites (internal/job); add a derived
@@ -425,6 +428,7 @@ WHERE source = sqlc.arg(source)
   AND salary_max_source IS NOT DISTINCT FROM sqlc.arg(salary_max_source)
   AND salary_currency_source = sqlc.arg(salary_currency_source)
   AND salary_period_source = sqlc.arg(salary_period_source)
+  AND english_level = sqlc.arg(english_level)
   AND closed_at IS NULL
 RETURNING id, source, company_slug, duplicate_of;
 


### PR DESCRIPTION
Closes the third item of #2341 — the one I deliberately left out of #2378 and recorded as a debt.

## The gap

`education_level` and `english_level` were the last two facets with **no structured tier**. `jobderive` always read them out of the description with `jobfacts`' matchers, which are English-prose only — so on a posting written in another language they do not return something weaker, they return **nothing at all**.

The issue proposed adding Hungarian regexes to those matchers. The data is better than that: Profession.hu states both on every posting, as a closed picklist (`"Angol középfok, Egyetem"`). The whole vocabulary was read off **all 709 live postings** — 28 tokens, comma-joining zero or more LANGUAGE levels with exactly one SCHOOL level.

So both fields join `sources.Job` and `jobderive.Input` under the same structured-only contract the other four scalars already follow, and a stated value takes precedence over the matchers.

### Live coverage over the whole IT slice (n=709)

| EducationLevel | | EnglishLevel | |
|---|---|---|---|
| none | 47.1% | b2 | 60.9% |
| bachelor | 36.8% | none | 18.9% |
| master | 12.0% | c1 | 13.0% |
| *(not stated)* | **4.1%** | b1 | 5.2% |
| | | native | 0.1% |
| | | *(not stated)* | **1.8%** |

## The Hungarian levels are the part worth getting right

`alapfok`/`középfok`/`felsőfok` are **not** "basic/medium/advanced". They are Hungary's state-recognised language-exam levels, defined as **B1 / B2 / C1** ([Gov. Decree 137/2008](https://nyelvvizsga.hu/hirek/b1-b2-c1-megis-mit-jelentenek-a-nyelvvizsgaszintek-kodjai/); the same equivalence [ECL](https://ecl.hu/az-ecl-nyelvvizsga-kovetelmenyeinek-leirasa/) and [LanguageCert](https://www.languagecert.hu/mintafeladatok_felsofok) publish). Reading them by their everyday sense puts every posting a level off — and the trio has no name for C2 at all, which is why `felsőfok` is so often rendered as one.

Likewise `főiskola` is the bachelor's-equivalent and `egyetem` the master's-equivalent, the pre-Bologna distinction the picklist preserves. `Felsőoktatási szakképzés` (a two-year tertiary programme, above secondary and below a bachelor's) maps to **nothing**: the four-value vocabulary has no member for it, and a wrong value in a faceted field is worse than a missing one. That is the 4.1%.

## What the guard test caught

`TestUpsertParams_CheapWriteMatchKeyCoversEveryColumnItWrites` failed, which is exactly why it exists. `english_level` can now move **without `content_hash` moving**, so an unchanged re-ingest would take the cheap liveness refresh and leave the column stale.

It joins `RefreshUnchangedJob`'s match key beside `cities` and `salary_*_source` rather than joining the hash — the same choice those made, for the same reason. Hashing it would change every stored `content_hash` at once and push 6.6M rows through a queue that drains at ~9 documents a second. `education_level` stays hashed, because it was hashed before either had a structured tier and moving it out now would cost that same storm; the asymmetry is written down in both places.

One thing worth a reviewer's eye: `db.RefreshUnchangedJobParams` is built as a named-field literal, so adding a key column compiles fine while silently passing `""` and pushing every affected posting onto the full-upsert path forever. `cmd/ingest/store.go` passes it; there is no compile-time guard for the next one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for extracting education levels and English proficiency from Profession.hu job postings.
  - Recognizes common Hungarian education categories and language-exam levels, including native proficiency.
  - Structured posting data now takes priority over description-based detection.

- **Bug Fixes**
  - Job updates now correctly reflect changes to structured English proficiency levels instead of only refreshing the posting’s last-seen timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->