### PR TITLE
Make docs/API.md fail loudly when it falls behind its source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,6 +481,30 @@ jobs:
       - name: Type check
         run: pnpm run check
 
+      # docs/API.md is generated from web/src/lib/docs/api-spec.ts and says so in its
+      # first line — and until this step nothing checked it. Adding `sort=view_count`
+      # to the endpoint updated api-spec.ts and openapi.yaml but not the generated
+      # file, so the published API reference sat contradicting the handler's own
+      # allowlist with every check green. Same ratchet as the `sqlc` and `contracts`
+      # jobs, and it lives here rather than in its own job because the generator loads
+      # the TypeScript through Vite: the toolchain is exactly this job's, already
+      # installed, and a second job would buy a clearer check name for a second full
+      # pnpm install.
+      #
+      # It runs after the type check on purpose. A broken api-spec.ts fails the
+      # generator too, but as a Vite SSR error — the type check says what is actually
+      # wrong first.
+      - name: Assert docs/API.md matches its source
+        run: |
+          pnpm run gen:api-docs
+          if [ -n "$(git status --porcelain -- ../docs/API.md)" ]; then
+            git --no-pager diff -- ../docs/API.md
+            echo
+            echo 'docs/API.md is stale. Run "pnpm run gen:api-docs" in web/ and commit the result.'
+            exit 1
+          fi
+          echo 'docs/API.md matches web/src/lib/docs/api-spec.ts.'
+
       - name: Unit tests with coverage
         run: pnpm run test:coverage
 


### PR DESCRIPTION
`docs/API.md` says `GENERATED … Do not edit by hand` in its first line, and until now nothing checked that claim.

Adding `sort=view_count` to the search endpoint updated `api-spec.ts` and `openapi.yaml` but not the generated file, so the published API reference sat contradicting the handler's own allowlist **with every check green**. That is exactly the failure the `sqlc` and `contracts` jobs already exist to prevent — on the one generated file nobody had wired up.

## What it does

Regenerate, then assert the tree is clean. Same shape as the two existing jobs. Edit the source and commit both files: silent. Forget to regenerate: red, naming the command to run.

## Two placement decisions

**Inside the `web` job, not its own.** The generator loads the TypeScript through Vite, so the toolchain is precisely this job's and already installed. A separate job would buy a clearer check name for a second full `pnpm install`.

**After the type check.** A broken `api-spec.ts` fails the generator too, but as a Vite SSR error — the type check says what is actually wrong first.

## Verified in both directions

A ratchet that only ever passes is indistinguishable from one that does nothing, so both sides were exercised:

- tree in sync → silent;
- a deliberate token added to `api-spec.ts` → `M docs/API.md`, exit 1.

The `../docs/API.md` path is deliberate and was tested from `web/`. The job sets `working-directory: web`, so a bare `docs/API.md` would resolve to `web/docs/`, match nothing, and pass forever — which is the way this check would most plausibly have been broken.

## Nothing else needs one

I checked every generated artefact in the repo:

| Generated | Ratchet |
|---|---|
| `internal/platform/db` | `sqlc` job |
| `web/src/lib/generated/` (all three files) | `contracts` job — its assert scopes to the directory, and `gen-contracts` writes all three |
| `docs/API.md` | **this PR** |
| `internal/location/cities1000.tsv` | deliberately none |

The last one stays uncovered on purpose: `cmd/gen-cities` reads an external GeoNames dump, so a ratchet there would fail CI whenever upstream data changed. That is upstream drift, not a developer forgetting to regenerate, and it wants a different answer.

`actionlint` (which also shellchecks every `run:` block) passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added an automated check to ensure API documentation stays synchronized with its source.
  - Builds now report documentation changes clearly and provide instructions for updating generated documentation.

- **Bug Fixes**
  - Improved validation order so source type errors are identified before documentation-generation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->