### PR TITLE
Correct two things the live project contradicts

### DIFF
--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -34,7 +34,14 @@ else. Nothing generates them — a new board means a new timer file, by hand.
   endpoint; and creating the Web Billing paywall, whose token is what
   `BILLING_CHECKOUT_URL` holds.
 
-  **`REVENUECAT_ENTITLEMENT` is `freehire Pro`, not `pro`.** That is the lookup key the
+  **`REVENUECAT_PROJECT_ID` is required** (`proja56a40fc`): the code speaks API v2 and
+  every v2 call is scoped to a project. Its absence leaves billing disabled, which is the
+  safe direction but looks exactly like "not deployed yet".
+
+  **`REVENUECAT_ENTITLEMENT` holds BOTH names of the entitlement**, comma-separated:
+  `freehire Pro,entl58d5471b41`. The provider has a human lookup key and an internal id for
+  one entitlement and names it with one of them in the customer payload; configuring both
+  is what stops that being discovered from an incident. And note it is **not** `pro` — That is the lookup key the
   project actually carries, and the package's default would match no entitlement at all —
   which does not fail, it resolves every paying subscriber to the free plan. The value has
   a space in it; systemd's `EnvironmentFile` strips the surrounding quotes and delivers it

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -31,8 +31,14 @@ else. Nothing generates them — a new board means a new timer file, by hand.
   webhook at `https://freehire.me/api/v1/billing/revenuecat/webhook` and **enabling HMAC
   signing** on it (the handler refuses an unsigned delivery — there is no fallback);
   minting a **secret** `sk_` key, since a public one is refused on the subscriber
-  endpoint; and creating the `pro` entitlement and the Web Billing paywall, whose token is
-  what `BILLING_CHECKOUT_URL` holds. With none of them set every billing route is simply
+  endpoint; and creating the Web Billing paywall, whose token is what
+  `BILLING_CHECKOUT_URL` holds.
+
+  **`REVENUECAT_ENTITLEMENT` is `freehire Pro`, not `pro`.** That is the lookup key the
+  project actually carries, and the package's default would match no entitlement at all —
+  which does not fail, it resolves every paying subscriber to the free plan. The value has
+  a space in it; systemd's `EnvironmentFile` strips the surrounding quotes and delivers it
+  whole, verified on the host rather than assumed. With none of them set every billing route is simply
   not mounted and the timer is a no-op that never opens the pool, so the units are safe to
   install before the dashboard is ready — they are just inert.
 - **A new worker needs its binary built on the host.** `release.sh` builds the API, not

--- a/internal/api/handler/billing.go
+++ b/internal/api/handler/billing.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"log"
-	"strconv"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -43,10 +42,6 @@ func (h *billingHandlers) register(api fiber.Router, mw middleware) {
 	// Cookie only. A checkout link decides who gets charged, so it is minted for a browser
 	// session and never for an API key, in the same spirit as key management itself.
 	api.Get("/billing/checkout", mw.cookie, h.Checkout)
-	// Where the caller cancels. Cookie-only for the same reason as checkout, and its own
-	// route rather than a field on /me/plan because it is a call to the provider — the plan
-	// surface must stay readable when the provider is not.
-	api.Get("/billing/manage", mw.cookie, h.Manage)
 }
 
 // applyTimeout bounds the inline attempt to bring the user's plan up to date.
@@ -137,31 +132,5 @@ func (h *billingHandlers) Checkout(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"data": fiber.Map{"url": url}})
 }
 
-// Manage returns the provider's own management URL for this subscriber — where they cancel
-// or change the subscription.
-//
-// Deleting a freehire account does NOT cancel a subscription, and the delete surface says
-// so and links here. We do not compose that destination ourselves: a URL we built is wrong
-// the first time the provider changes theirs, and this is the question nobody should get a
-// stale answer to.
-func (h *billingHandlers) Manage(c *fiber.Ctx) error {
-	userID, err := requireUserID(c)
-	if err != nil {
-		return err
-	}
-
-	ctx, cancel := context.WithTimeout(c.Context(), applyTimeout)
-	defer cancel()
-
-	url, err := h.billing.ManagementURL(ctx, strconv.FormatInt(userID, 10))
-	if err != nil || url == "" {
-		// The caller has no subscription with the provider, or the provider is unreachable.
-		// Either way there is nothing to manage right now, and 404 lets the surface omit the
-		// link rather than render a broken one.
-		if err != nil {
-			log.Printf("billing: no management URL for user %d: %v", userID, err)
-		}
-		return fiber.NewError(fiber.StatusNotFound, "no subscription to manage")
-	}
-	return c.JSON(fiber.Map{"data": fiber.Map{"url": url}})
-}
+// There is no Manage route. The v2 customer object carries no management URL — see the
+// note where ManagementURL used to live in internal/identity/billing.

--- a/internal/api/handler/billing_integration_test.go
+++ b/internal/api/handler/billing_integration_test.go
@@ -55,10 +55,16 @@ func enabledBillingConfig() billing.Config {
 	return billing.Config{
 		APIKey:        "sk_test",
 		WebhookSecret: billingSecret,
-		Entitlements:  []string{"pro"},
-		CheckoutURL:   "https://pay.rev.cat/tok",
+		// Every v2 call is scoped to a project; without this the config reports itself
+		// disabled and no route is mounted at all.
+		ProjectID:    "proj_test",
+		Entitlements: []string{"pro"},
+		CheckoutURL:  "https://pay.rev.cat/tok",
 	}
 }
+
+// v2CustomerWithPro is what the provider returns for a subscriber who is entitled.
+const v2CustomerWithPro = `{"active_entitlements":{"items":[{"entitlement_id":"pro","expires_at":1790812800000}]}}`
 
 func TestBillingWebhook(t *testing.T) {
 	pool := startPostgres(t)
@@ -72,7 +78,7 @@ func TestBillingWebhook(t *testing.T) {
 	var providerCalls int
 	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		providerCalls++
-		_, _ = w.Write([]byte(`{"subscriber":{"entitlements":{"pro":{"expires_date":"2026-10-01T00:00:00Z"}}}}`))
+		_, _ = w.Write([]byte(v2CustomerWithPro))
 	}))
 	defer stub.Close()
 

--- a/internal/identity/billing/AGENTS.md
+++ b/internal/identity/billing/AGENTS.md
@@ -37,11 +37,18 @@ routes answer 404, and its worker exits without opening a connection.
   reconciler is the only path by which a paid subscription becomes Pro, which is why it is
   scheduled rather than optional.
 
-- **`GET /v1/subscribers/{id}` CREATES the subscriber if the id is unknown** — a read with
-  a write's consequences. `Sync` refuses an identifier that does not parse as one of our
-  `users.id`, and the reconciler's candidate query starts from `billing_events` rather than
-  from `users`, so "we only ask about someone who has transacted" is structural rather than
-  remembered.
+- **This package speaks API v2, and that was not a style choice.** The project's secret
+  key is a v2 `sk_` key and v1 refuses it outright — *"You're trying to use a secret API
+  key incompatible with RevenueCat API V1"*, HTTP 403. The first version of this package
+  spoke v1 and would have answered 403 to every sync, on every purchase, while every test
+  stayed green. Every v2 call is scoped to a project, hence `REVENUECAT_PROJECT_ID`.
+
+- **A customer the provider has never seen answers 404, and that is an ANSWER.** It means
+  no purchase, which derives to no entitlement and the free plan. Treating it as a failure
+  would leave events unprocessed forever for every identifier that was never ours. Note
+  that v2's read does NOT create the customer, unlike v1's — the reconciler still reaches
+  candidates through `billing_events` because that is also the cheaper query, but it is no
+  longer load-bearing for correctness.
 
 - **A null `expires_date` means never-expiring, not expired.** Reading it as the zero time
   would silently downgrade a lifetime purchaser. `neverExpires` is the sentinel, and it is
@@ -50,9 +57,17 @@ routes answer 404, and its worker exits without opening a connection.
   monthly and yearly subscriptions, so this is a live case rather than a defensive one —
   and a subscriber it got wrong would simply read as free, with nobody looking.
 
-- **An entitlement reaches the LATER of its expiry and its grace period.** A grace period
-  is the provider saying the payment failed but the subscriber is still entitled; reading
-  the expiry alone takes access from someone who has it, over a card that needs renewing.
+- **The v2 list carries only ACTIVE entitlements**, which removes work rather than adding
+  it: lapsed, refunded and transferred all look the same — the entitlement is simply not
+  there — and the provider has already applied its own grace-period rule to what remains.
+  The v1 shape needed both an expiry and a grace field plus a rule to combine them; there
+  is nothing left here to combine.
+
+- **`entitlement_id` is matched against BOTH names the provider has for one entitlement.**
+  It carries a human lookup key (`freehire Pro`) and an internal id (`entl…`), the payload
+  names it with one of them, and which one is not something to discover from a production
+  incident. `REVENUECAT_ENTITLEMENT` therefore holds both, comma-separated — the matching
+  logic already took a list.
 
 - **The HMAC covers the RAW body.** Verify `c.Body()`, never a re-marshalled struct — the
   same event serialised differently is different bytes, and a valid delivery would be
@@ -82,12 +97,11 @@ in a way the tests do not reproduce.
   it**), `app_user_id`, `type`, `expiration_at_ms`, `entitlement_ids`.
 - Signature: `X-RevenueCat-Webhook-Signature: t=<unix>,v1=<hex>`, HMAC-SHA256 over
   `"<t>.<raw body>"`.
-- Subscriber: `GET https://api.revenuecat.com/v1/subscribers/{id}`, `Authorization: Bearer
-  sk_…` (a **secret** key; a public one is refused). Entitlements are a map keyed by
-  entitlement id, each with `expires_date`, `grace_period_expires_date`,
-  `product_identifier`, `purchase_date`, in ISO 8601. The response also carries
-  `management_url` — the destination the delete-account surface links to, rather than one
-  we composed.
+- Customer: `GET https://api.revenuecat.com/v2/projects/{project_id}/customers/{id}`,
+  `Authorization: Bearer sk_…` (a **secret** key; a public one is refused, and so is a v2
+  key sent at v1). It returns `active_entitlements.items[]`, each with `entitlement_id` and
+  `expires_at` — **milliseconds since the epoch, nullable**. 404 means the customer has
+  never purchased. The v2 customer carries NO `management_url`; v1's did.
 - Delivery: unordered, duplicates possible, 60-second response budget, five retries at 5,
   10, 20, 40 and 80 minutes.
 
@@ -107,7 +121,11 @@ it now would be a guess at the shape of a provider whose documentation nobody ha
 **A local subscription state machine.** No status, no period, no product. The provider owns
 those and they are one API call away; a copy here could only disagree.
 
-**Cancellation and refunds.** The provider's `management_url` owns them. We link to it.
+**Cancellation and refunds, and a link to where they happen.** The provider owns them, and
+v2's customer object gives us no URL to point at — v1's `management_url` did, and the
+delete-account dialog linked to it precisely so the destination came from them. Composing
+one ourselves would reintroduce the staleness that avoided, so the dialog now states that
+deleting an account does not cancel a subscription and stops there.
 
 **Gifted Pro days.** `add-invites` grants days of Pro, and if it writes `pro_until` this
 package's reconciler will overwrite them with the provider's truth. The resolution is a

--- a/internal/identity/billing/AGENTS.md
+++ b/internal/identity/billing/AGENTS.md
@@ -46,8 +46,9 @@ routes answer 404, and its worker exits without opening a connection.
 - **A null `expires_date` means never-expiring, not expired.** Reading it as the zero time
   would silently downgrade a lifetime purchaser. `neverExpires` is the sentinel, and it is
   safe only because the column is derived: a refund removes the entitlement and the next
-  sync clears it. We sell no lifetime product, which is exactly why this must be right —
-  the case will first occur by accident and nobody will be looking for it.
+  sync clears it. **The catalogue already carries a `lifetime` non_consumable** beside the
+  monthly and yearly subscriptions, so this is a live case rather than a defensive one —
+  and a subscriber it got wrong would simply read as free, with nobody looking.
 
 - **An entitlement reaches the LATER of its expiry and its grace period.** A grace period
   is the provider saying the payment failed but the subscriber is still entitled; reading

--- a/internal/identity/billing/client.go
+++ b/internal/identity/billing/client.go
@@ -13,7 +13,11 @@ import (
 )
 
 // apiBaseURL is the provider's REST API. Overridden only by tests.
-const apiBaseURL = "https://api.revenuecat.com/v1"
+//
+// v2, and not by preference: the project's secret key is a v2 key, and v1 refuses it with
+// "You're trying to use a secret API key incompatible with RevenueCat API V1". The first
+// draft of this package spoke v1 and would have answered 403 to every sync.
+const apiBaseURL = "https://api.revenuecat.com/v2"
 
 // requestTimeout bounds one read of subscriber state.
 //
@@ -29,32 +33,37 @@ const errorBodyLimit = 512
 // client reads subscriber state from the provider. It is the only thing in this package
 // that talks to the network.
 type client struct {
-	http    *http.Client
-	baseURL string
-	apiKey  string
+	http      *http.Client
+	baseURL   string
+	apiKey    string
+	projectID string
 }
 
 // newProviderClient is the production constructor: an SSRF-guarded client against the real
 // API.
-func newProviderClient(apiKey string) *client {
-	return newClient(apiKey, apiBaseURL, safehttp.NewClient(requestTimeout))
+func newProviderClient(apiKey, projectID string) *client {
+	return newClient(apiKey, projectID, apiBaseURL, safehttp.NewClient(requestTimeout))
 }
 
 // newClient builds a client against an arbitrary base URL with an arbitrary HTTP client.
 // The seam exists for tests: safehttp refuses private addresses, which is correct in
 // production and makes a loopback test server unreachable.
-func newClient(apiKey, baseURL string, httpc *http.Client) *client {
-	return &client{http: httpc, baseURL: baseURL, apiKey: apiKey}
+func newClient(apiKey, projectID, baseURL string, httpc *http.Client) *client {
+	return &client{http: httpc, baseURL: baseURL, apiKey: apiKey, projectID: projectID}
 }
 
 // subscriberState reads the provider's current record for one identifier.
 //
-// THIS GET CREATES THE SUBSCRIBER if the identifier is unknown to the provider — a read
-// with a write's consequences. Callers must therefore only ask about accounts that have
-// actually transacted; the reconciler's query enforces that structurally by starting from
-// billing_events rather than from users.
+// A customer the provider has never seen answers 404, and that is NOT an error: it means
+// no purchase, which derives to no entitlement and the free plan. Treating it as a failure
+// would leave events unprocessed forever for every identifier that was never ours.
+//
+// Unlike v1's subscriber GET, this read has no write behind it — v2 does not create a
+// customer for an unknown id. The rule that callers only ask about accounts which have
+// transacted therefore stops being load-bearing, though the reconciler's query still holds
+// to it because it is also the cheaper way to find candidates.
 func (c *client) subscriberState(ctx context.Context, appUserID string) (subscriber, error) {
-	endpoint := c.baseURL + "/subscribers/" + url.PathEscape(appUserID)
+	endpoint := c.baseURL + "/projects/" + url.PathEscape(c.projectID) + "/customers/" + url.PathEscape(appUserID)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
@@ -69,16 +78,21 @@ func (c *client) subscriberState(ctx context.Context, appUserID string) (subscri
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	// Never purchased anything, so there is nothing to be entitled to. An empty customer
+	// derives to the zero time, which resolves to the free plan.
+	if resp.StatusCode == http.StatusNotFound {
+		return subscriber{}, nil
+	}
 	if resp.StatusCode != http.StatusOK {
 		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, errorBodyLimit))
-		return subscriber{}, fmt.Errorf("billing: reading subscriber %q: provider returned %d: %s", appUserID, resp.StatusCode, snippet)
+		return subscriber{}, fmt.Errorf("billing: reading customer %q: provider returned %d: %s", appUserID, resp.StatusCode, snippet)
 	}
 
-	var payload struct {
-		Subscriber subscriber `json:"subscriber"`
+	// The customer object carries active_entitlements inline; there is no envelope to
+	// unwrap, unlike v1's {"subscriber": …}.
+	var out subscriber
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return subscriber{}, fmt.Errorf("billing: decoding customer %q: %w", appUserID, err)
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return subscriber{}, fmt.Errorf("billing: decoding subscriber %q: %w", appUserID, err)
-	}
-	return payload.Subscriber, nil
+	return out, nil
 }

--- a/internal/identity/billing/client_test.go
+++ b/internal/identity/billing/client_test.go
@@ -8,20 +8,17 @@ import (
 	"time"
 )
 
-// The provider's own example shape, trimmed to what we read.
-const subscriberBody = `{
-  "request_date": "2026-09-03T12:00:00Z",
-  "subscriber": {
-    "management_url": "https://pay.rev.cat/manage/601",
-    "entitlements": {
-      "pro": {
-        "expires_date": "2026-10-01T00:00:00Z",
-        "grace_period_expires_date": null,
-        "product_identifier": "pro_monthly",
-        "purchase_date": "2026-09-01T00:00:00Z"
-      }
-    },
-    "subscriptions": {}
+// The v2 customer object, trimmed to what we read.
+const customerBody = `{
+  "object": "customer",
+  "id": "601",
+  "project_id": "proj_test",
+  "active_entitlements": {
+    "object": "list",
+    "items": [
+      { "object": "customer.active_entitlement", "entitlement_id": "freehire Pro", "expires_at": 1790812800000 }
+    ],
+    "next_page": null
   }
 }`
 
@@ -31,7 +28,7 @@ func testClient(t *testing.T, h http.HandlerFunc) *client {
 	t.Cleanup(srv.Close)
 	// The server's own client, not safehttp's: safehttp refuses private addresses, which
 	// is exactly right in production and exactly wrong for a loopback test server.
-	return newClient("sk_test", srv.URL, srv.Client())
+	return newClient("sk_test", testProjectID, srv.URL, srv.Client())
 }
 
 func TestClientSubscriberState(t *testing.T) {
@@ -39,7 +36,7 @@ func TestClientSubscriberState(t *testing.T) {
 	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
 		gotPath, gotAuth = r.URL.EscapedPath(), r.Header.Get("Authorization")
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(subscriberBody))
+		_, _ = w.Write([]byte(customerBody))
 	})
 
 	sub, err := c.subscriberState(context.Background(), "601")
@@ -47,7 +44,8 @@ func TestClientSubscriberState(t *testing.T) {
 		t.Fatalf("want no error, got %v", err)
 	}
 
-	if want := "/subscribers/601"; gotPath != want {
+	// v2 addresses a customer inside a project; v1 addressed a subscriber globally.
+	if want := "/projects/proj_test/customers/601"; gotPath != want {
 		t.Errorf("path: want %q, got %q", want, gotPath)
 	}
 	// A secret key, as a bearer token. A public key is refused by the provider on this
@@ -55,18 +53,40 @@ func TestClientSubscriberState(t *testing.T) {
 	if want := "Bearer sk_test"; gotAuth != want {
 		t.Errorf("authorization: want %q, got %q", want, gotAuth)
 	}
-	if sub.ManagementURL != "https://pay.rev.cat/manage/601" {
-		t.Errorf("management_url not read: %q", sub.ManagementURL)
+
+	items := sub.ActiveEntitlements.Items
+	if len(items) != 1 {
+		t.Fatalf("entitlements not read: %+v", items)
 	}
-	ent, ok := sub.Entitlements["pro"]
-	if !ok {
-		t.Fatalf("entitlements not read: %+v", sub.Entitlements)
+	if items[0].EntitlementID != "freehire Pro" {
+		t.Errorf("entitlement_id not read: %q", items[0].EntitlementID)
 	}
-	if ent.ExpiresDate == nil || ent.ExpiresDate.Format(time.RFC3339) != "2026-10-01T00:00:00Z" {
-		t.Errorf("expires_date not read: %+v", ent.ExpiresDate)
+	if items[0].ExpiresAt == nil {
+		t.Fatal("expires_at not read")
 	}
-	if ent.GracePeriodExpiresDate != nil {
-		t.Errorf("a null grace period must stay nil, got %v", ent.GracePeriodExpiresDate)
+	if got := time.UnixMilli(*items[0].ExpiresAt).UTC().Format(time.RFC3339); got != "2026-10-01T00:00:00Z" {
+		t.Errorf("expires_at decoded to %s", got)
+	}
+}
+
+// TestClientTreatsAnUnknownCustomerAsFree is the case every account that never bought
+// anything falls into. A 404 is an answer — "no purchases" — not a failure; treating it as
+// one would leave events unprocessed forever for every identifier that was never ours.
+func TestClientTreatsAnUnknownCustomerAsFree(t *testing.T) {
+	c := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Customer not found"}`))
+	})
+
+	sub, err := c.subscriberState(context.Background(), "601")
+	if err != nil {
+		t.Fatalf("a 404 must not be an error, got %v", err)
+	}
+	if len(sub.ActiveEntitlements.Items) != 0 {
+		t.Fatalf("want no entitlements, got %+v", sub.ActiveEntitlements.Items)
+	}
+	if until := proUntilFrom(sub, []string{"freehire Pro"}); !until.IsZero() {
+		t.Fatalf("an unknown customer must derive to the free plan, got %s", until)
 	}
 }
 
@@ -77,13 +97,13 @@ func TestClientEscapesTheIdentifier(t *testing.T) {
 	var gotPath string
 	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.EscapedPath()
-		_, _ = w.Write([]byte(`{"subscriber":{"entitlements":{}}}`))
+		_, _ = w.Write([]byte(`{"active_entitlements":{"items":[]}}`))
 	})
 
 	if _, err := c.subscriberState(context.Background(), "a/b"); err != nil {
 		t.Fatalf("want no error, got %v", err)
 	}
-	if want := "/subscribers/a%2Fb"; gotPath != want {
+	if want := "/projects/proj_test/customers/a%2Fb"; gotPath != want {
 		t.Fatalf("path: want %q, got %q", want, gotPath)
 	}
 }
@@ -98,6 +118,10 @@ func TestClientErrors(t *testing.T) {
 		{name: "provider error", status: http.StatusInternalServerError, body: `{"message":"boom"}`},
 		{name: "rate limited", status: http.StatusTooManyRequests, body: `{"message":"slow down"}`},
 		{name: "not JSON", status: http.StatusOK, body: `<html>gateway</html>`},
+		// The failure this package shipped with: a v2 secret key against a v1 endpoint.
+		// It must surface as an error rather than as an empty customer, or every
+		// subscriber would quietly read as free.
+		{name: "wrong API version", status: http.StatusForbidden, body: `{"code":7723,"message":"incompatible with RevenueCat API V1"}`},
 	}
 
 	for _, tc := range cases {

--- a/internal/identity/billing/config.go
+++ b/internal/identity/billing/config.go
@@ -33,6 +33,10 @@ type Config struct {
 	APIKey string
 	// WebhookSecret signs incoming deliveries. See verifySignature.
 	WebhookSecret string
+	// ProjectID scopes every v2 call. v1 addressed a subscriber globally; v2 addresses a
+	// customer inside a project, so this is not optional decoration — without it there is
+	// no URL to read state from.
+	ProjectID string
 	// Entitlements are the entitlement identifiers that confer Pro. Usually one: an
 	// entitlement already sits above products, so monthly and annual share it.
 	Entitlements []string
@@ -53,6 +57,7 @@ func ConfigFromEnv() Config {
 	cfg := Config{
 		APIKey:        strings.TrimSpace(os.Getenv("REVENUECAT_API_KEY")),
 		WebhookSecret: strings.TrimSpace(os.Getenv("REVENUECAT_WEBHOOK_SECRET")),
+		ProjectID:     strings.TrimSpace(os.Getenv("REVENUECAT_PROJECT_ID")),
 		Entitlements:  entitlementList(os.Getenv("REVENUECAT_ENTITLEMENT")),
 		// Trimmed of a trailing slash so appending a segment cannot produce "//", which the
 		// paywall answers with a 404 — an easy thing to write in an env file and a
@@ -81,7 +86,7 @@ func entitlementList(raw string) []string {
 // state. Both credentials are needed, and one without the other is a half-configured
 // deployment that would accept unverifiable webhooks or record events it can never apply.
 func (c Config) Enabled() bool {
-	return c.APIKey != "" && c.WebhookSecret != ""
+	return c.APIKey != "" && c.WebhookSecret != "" && c.ProjectID != ""
 }
 
 // CanCheckout reports whether we can send anyone to buy.

--- a/internal/identity/billing/config_test.go
+++ b/internal/identity/billing/config_test.go
@@ -6,10 +6,13 @@ import (
 )
 
 // setEnv points the whole configuration at test values; "" removes a variable.
+const testProjectID = "proj_test"
+
 func setEnv(t *testing.T, apiKey, secret, entitlements, checkout string) {
 	t.Helper()
 	t.Setenv("REVENUECAT_API_KEY", apiKey)
 	t.Setenv("REVENUECAT_WEBHOOK_SECRET", secret)
+	t.Setenv("REVENUECAT_PROJECT_ID", testProjectID)
 	t.Setenv("REVENUECAT_ENTITLEMENT", entitlements)
 	t.Setenv("BILLING_CHECKOUT_URL", checkout)
 }
@@ -27,6 +30,16 @@ func TestConfigFromEnvDisabledIsNotAnError(t *testing.T) {
 		{name: "api key only", apiKey: "sk_test"},
 		{name: "webhook secret only", secret: "whsec_test"},
 	}
+
+	// Every v2 call is scoped to a project, so a deployment without one has no URL to read
+	// state from. Checked separately because setEnv always supplies it.
+	t.Run("no project id", func(t *testing.T) {
+		setEnv(t, "sk_test", "whsec_test", "", "")
+		t.Setenv("REVENUECAT_PROJECT_ID", "")
+		if ConfigFromEnv().Enabled() {
+			t.Fatal("want billing disabled without a project id")
+		}
+	})
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/identity/billing/entitlement.go
+++ b/internal/identity/billing/entitlement.go
@@ -36,9 +36,10 @@ type entitlement struct {
 // removes the entitlement from the provider's map, the next sync derives the zero time,
 // and the sentinel is gone — it can never outlive the entitlement that produced it.
 //
-// We do not currently sell a lifetime product. That is exactly why this has to be right:
-// the case will first occur by accident, in a hand-granted entitlement or a promotion, and
-// there will be no reason for anyone to check it.
+// This is NOT hypothetical, which the first draft of this comment assumed. The provider's
+// catalogue already carries a `lifetime` non_consumable beside the monthly and yearly
+// subscriptions, so the first purchase of one produces a null expiry on day one — and
+// nobody would be watching for a subscriber who quietly reads as free.
 var neverExpires = time.Date(9999, time.December, 31, 0, 0, 0, 0, time.UTC)
 
 // proUntilFrom reduces a subscriber's entitlements to the single timestamp users.pro_until

--- a/internal/identity/billing/entitlement.go
+++ b/internal/identity/billing/entitlement.go
@@ -5,23 +5,29 @@ import "time"
 // subscriber is the provider's record of one account, as much of it as we read. The
 // provider's own record — product, status, period, payment method — stays with the
 // provider; this type exists to be reduced to a single timestamp and then forgotten.
+//
+// This is the API v2 customer, not the v1 subscriber. The project's secret key is a v2
+// key and v1 refuses it outright ("secret API key incompatible with RevenueCat API V1"),
+// so the v1 shape this package first spoke was not a stylistic choice between two working
+// options — it was 403 on every call.
+//
+// The v2 list carries only entitlements that are ACTIVE, which quietly removes work rather
+// than adding it: a lapsed, refunded or transferred entitlement simply is not there, and
+// the provider has already applied its own grace-period rule to what remains. There is no
+// grace field to reconcile because there is nothing left to reconcile.
 type subscriber struct {
-	Entitlements map[string]entitlement `json:"entitlements"`
-	// ManagementURL is where this subscriber cancels. It is the provider's answer, not
-	// ours, which is what the delete-account surface must link to: a destination we
-	// composed would be wrong the first time they change it.
-	ManagementURL string `json:"management_url"`
+	ActiveEntitlements struct {
+		Items []entitlement `json:"items"`
+	} `json:"active_entitlements"`
 }
 
-// entitlement is one entry of the provider's entitlements map.
+// entitlement is one active entitlement.
 //
-// Both dates are pointers because both are genuinely absent sometimes, and the two
-// absences mean different things. A missing grace period means there is none. A missing
-// expiry means the entitlement does not expire — see neverExpires.
+// ExpiresAt is milliseconds since the epoch, and it is a pointer because null is a real
+// value with its own meaning: the entitlement does not expire. See neverExpires.
 type entitlement struct {
-	ExpiresDate            *time.Time `json:"expires_date"`
-	GracePeriodExpiresDate *time.Time `json:"grace_period_expires_date"`
-	ProductIdentifier      string     `json:"product_identifier"`
+	EntitlementID string `json:"entitlement_id"`
+	ExpiresAt     *int64 `json:"expires_at"`
 }
 
 // neverExpires is what an entitlement with no expiry is written as.
@@ -56,9 +62,8 @@ var neverExpires = time.Date(9999, time.December, 31, 0, 0, 0, 0, time.UTC)
 // card that needs renewing.
 func proUntilFrom(sub subscriber, proEntitlements []string) time.Time {
 	var out time.Time
-	for _, id := range proEntitlements {
-		ent, ok := sub.Entitlements[id]
-		if !ok {
+	for _, ent := range sub.ActiveEntitlements.Items {
+		if !confers(ent.EntitlementID, proEntitlements) {
 			continue
 		}
 		if until := ent.until(); until.After(out) {
@@ -68,14 +73,27 @@ func proUntilFrom(sub subscriber, proEntitlements []string) time.Time {
 	return out
 }
 
-// until is how far this one entitlement reaches.
+// confers reports whether this entitlement identifier is one that grants Pro.
+//
+// The configured list holds BOTH names the provider uses for the same entitlement — the
+// human lookup key ("freehire Pro") and the internal id ("entl…") — because the customer
+// payload names it with one of them and which one is not something to find out from a
+// production incident. Matching either costs nothing: an identifier that is neither is not
+// ours whichever field it came from.
+func confers(id string, proEntitlements []string) bool {
+	for _, want := range proEntitlements {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+// until is how far this one entitlement reaches. A null expiry is not expired — see
+// neverExpires.
 func (e entitlement) until() time.Time {
-	if e.ExpiresDate == nil {
+	if e.ExpiresAt == nil {
 		return neverExpires
 	}
-	out := *e.ExpiresDate
-	if e.GracePeriodExpiresDate != nil && e.GracePeriodExpiresDate.After(out) {
-		out = *e.GracePeriodExpiresDate
-	}
-	return out
+	return time.UnixMilli(*e.ExpiresAt).UTC()
 }

--- a/internal/identity/billing/entitlement_test.go
+++ b/internal/identity/billing/entitlement_test.go
@@ -5,20 +5,33 @@ import (
 	"time"
 )
 
-func at(t *testing.T, s string) *time.Time {
+// ms is a v2 expiry: milliseconds since the epoch. Taking a string keeps the cases
+// readable while the type under test stays the one the provider actually sends.
+func ms(t *testing.T, s string) *int64 {
 	t.Helper()
 	v, err := time.Parse(time.RFC3339, s)
 	if err != nil {
 		t.Fatalf("bad test timestamp %q: %v", s, err)
 	}
-	return &v
+	out := v.UnixMilli()
+	return &out
 }
 
-// TestProUntilFrom walks every shape the provider's entitlement map arrives in. It is a
-// pure function precisely so that the two cases nobody would notice going wrong — a grace
-// period and an absent expiry — are as cheap to assert as the ordinary one.
+// sub builds a v2 customer carrying the given active entitlements.
+func sub(items ...entitlement) subscriber {
+	var s subscriber
+	s.ActiveEntitlements.Items = items
+	return s
+}
+
+// TestProUntilFrom walks every shape the provider's active-entitlement list arrives in.
+//
+// Note what is NOT here any more: a grace period. The v2 list carries only entitlements
+// that are ACTIVE, so the provider has already applied its own grace rule and what is left
+// is one expiry per entitlement. The v1 shape this replaced needed both fields and a rule
+// to combine them.
 func TestProUntilFrom(t *testing.T) {
-	proIDs := []string{"pro"}
+	proIDs := []string{"freehire Pro"}
 
 	cases := []struct {
 		name string
@@ -27,83 +40,56 @@ func TestProUntilFrom(t *testing.T) {
 		want string // RFC3339, or "" for the zero time
 	}{
 		{
-			name: "active entitlement",
-			sub: subscriber{Entitlements: map[string]entitlement{
-				"pro": {ExpiresDate: at(t, "2026-10-01T00:00:00Z")},
-			}},
+			name: "an active entitlement",
+			sub:  sub(entitlement{EntitlementID: "freehire Pro", ExpiresAt: ms(t, "2026-10-01T00:00:00Z")}),
 			want: "2026-10-01T00:00:00Z",
 		},
 		{
-			// A lapsed subscription still writes the provider's date. Deciding it is over
-			// is plan.TierOf's job, comparing against now; writing zero here would erase
-			// when it ended, which is the only thing that says why the account is free.
-			name: "lapsed entitlement keeps its date",
-			sub: subscriber{Entitlements: map[string]entitlement{
-				"pro": {ExpiresDate: at(t, "2020-01-01T00:00:00Z")},
-			}},
-			want: "2020-01-01T00:00:00Z",
-		},
-		{
-			name: "no entitlements at all",
-			sub:  subscriber{Entitlements: map[string]entitlement{}},
+			// Lapsed, refunded and transferred all look the same from here: the entitlement
+			// is simply not in the ACTIVE list, and no branch was needed to notice.
+			name: "no active entitlements at all",
+			sub:  sub(),
 			want: "",
 		},
 		{
 			name: "only an entitlement that does not confer pro",
-			sub: subscriber{Entitlements: map[string]entitlement{
-				"extra_storage": {ExpiresDate: at(t, "2026-10-01T00:00:00Z")},
-			}},
+			sub:  sub(entitlement{EntitlementID: "extra_storage", ExpiresAt: ms(t, "2026-10-01T00:00:00Z")}),
 			want: "",
 		},
 		{
-			// The payment failed but the subscriber is still entitled. Reading expires_date
-			// alone would take access away from someone who has it.
-			name: "grace period outlasts the expiry",
-			sub: subscriber{Entitlements: map[string]entitlement{
-				"pro": {
-					ExpiresDate:            at(t, "2026-09-04T00:00:00Z"),
-					GracePeriodExpiresDate: at(t, "2026-09-20T00:00:00Z"),
-				},
-			}},
-			want: "2026-09-20T00:00:00Z",
-		},
-		{
-			name: "expiry outlasts a stale grace period",
-			sub: subscriber{Entitlements: map[string]entitlement{
-				"pro": {
-					ExpiresDate:            at(t, "2026-12-01T00:00:00Z"),
-					GracePeriodExpiresDate: at(t, "2026-09-04T00:00:00Z"),
-				},
-			}},
-			want: "2026-12-01T00:00:00Z",
-		},
-		{
-			// The trap. A null expires_date means the entitlement does not expire, and
-			// reading it as the zero time would silently downgrade a lifetime purchaser to
-			// the free plan — a wrong nobody would ever be looking for.
-			name: "entitlement with no expiry is not expired",
-			sub: subscriber{Entitlements: map[string]entitlement{
-				"pro": {ExpiresDate: nil},
-			}},
+			// The trap. A null expiry means the entitlement does not expire, and reading it
+			// as the zero time would silently downgrade a lifetime purchaser — and the
+			// catalogue already carries a lifetime product.
+			name: "an entitlement with no expiry is not expired",
+			sub:  sub(entitlement{EntitlementID: "freehire Pro", ExpiresAt: nil}),
 			want: neverExpires.Format(time.RFC3339),
 		},
 		{
 			name: "several entitlements confer pro; the latest wins",
-			sub: subscriber{Entitlements: map[string]entitlement{
-				"pro":        {ExpiresDate: at(t, "2026-10-01T00:00:00Z")},
-				"pro_annual": {ExpiresDate: at(t, "2027-03-01T00:00:00Z")},
-			}},
-			ids:  []string{"pro", "pro_annual"},
+			sub: sub(
+				entitlement{EntitlementID: "freehire Pro", ExpiresAt: ms(t, "2026-10-01T00:00:00Z")},
+				entitlement{EntitlementID: "entl58d5471b41", ExpiresAt: ms(t, "2027-03-01T00:00:00Z")},
+			),
+			ids:  []string{"freehire Pro", "entl58d5471b41"},
 			want: "2027-03-01T00:00:00Z",
 		},
 		{
 			name: "a non-expiring entitlement outranks a dated one",
-			sub: subscriber{Entitlements: map[string]entitlement{
-				"pro":        {ExpiresDate: at(t, "2026-10-01T00:00:00Z")},
-				"pro_annual": {ExpiresDate: nil},
-			}},
-			ids:  []string{"pro", "pro_annual"},
+			sub: sub(
+				entitlement{EntitlementID: "freehire Pro", ExpiresAt: ms(t, "2026-10-01T00:00:00Z")},
+				entitlement{EntitlementID: "entl58d5471b41", ExpiresAt: nil},
+			),
+			ids:  []string{"freehire Pro", "entl58d5471b41"},
 			want: neverExpires.Format(time.RFC3339),
+		},
+		{
+			// The payload names the entitlement with ONE of the provider's two identifiers
+			// and we do not get to choose which. Configuring both is what makes that a
+			// non-question rather than a production incident.
+			name: "the internal id is matched as readily as the lookup key",
+			sub:  sub(entitlement{EntitlementID: "entl58d5471b41", ExpiresAt: ms(t, "2026-10-01T00:00:00Z")}),
+			ids:  []string{"freehire Pro", "entl58d5471b41"},
+			want: "2026-10-01T00:00:00Z",
 		},
 	}
 
@@ -136,11 +122,9 @@ func TestProUntilFrom(t *testing.T) {
 // is DERIVED from provider state, so applying the same state twice yields the same answer
 // and a repeated sync is free.
 func TestProUntilFromIsIdempotent(t *testing.T) {
-	sub := subscriber{Entitlements: map[string]entitlement{
-		"pro": {ExpiresDate: at(t, "2026-10-01T00:00:00Z")},
-	}}
-	first := proUntilFrom(sub, []string{"pro"})
-	second := proUntilFrom(sub, []string{"pro"})
+	s := sub(entitlement{EntitlementID: "freehire Pro", ExpiresAt: ms(t, "2026-10-01T00:00:00Z")})
+	first := proUntilFrom(s, []string{"freehire Pro"})
+	second := proUntilFrom(s, []string{"freehire Pro"})
 	if !first.Equal(second) {
 		t.Fatalf("not idempotent: %s then %s", first, second)
 	}

--- a/internal/identity/billing/service.go
+++ b/internal/identity/billing/service.go
@@ -56,9 +56,9 @@ func NewWithBase(cfg Config, q *db.Queries, baseURL string) *Service {
 		return s
 	}
 	if baseURL == apiBaseURL {
-		s.client = newProviderClient(cfg.APIKey)
+		s.client = newProviderClient(cfg.APIKey, cfg.ProjectID)
 	} else {
-		s.client = newClient(cfg.APIKey, baseURL, &http.Client{Timeout: requestTimeout})
+		s.client = newClient(cfg.APIKey, cfg.ProjectID, baseURL, &http.Client{Timeout: requestTimeout})
 	}
 	return s
 }
@@ -179,27 +179,16 @@ func stamp(t time.Time) pgtype.Timestamptz {
 	return pgtype.Timestamptz{Time: t, Valid: true}
 }
 
-// ManagementURL is where this subscriber cancels or changes their subscription.
+// There is no ManagementURL here, and its absence is a fact about the provider rather
+// than a decision.
 //
-// It is the provider's own answer, fetched when asked for, not a URL we composed: a
-// destination we built ourselves is wrong the first time they change theirs, and "where do
-// I cancel" is exactly the question nobody wants to get a stale answer to.
-//
-// It is a NETWORK CALL, which is why it lives on its own endpoint and not on the plan
-// surface. Plan resolution must stay free of the provider — see internal/ai/plan.
-func (s *Service) ManagementURL(ctx context.Context, appUserID string) (string, error) {
-	if !s.Enabled() {
-		return "", ErrDisabled
-	}
-	if _, ok := userIDFromAppUserID(appUserID); !ok {
-		return "", fmt.Errorf("%w: %q", ErrUnknownSubscriber, appUserID)
-	}
-	sub, err := s.client.subscriberState(ctx, appUserID)
-	if err != nil {
-		return "", err
-	}
-	return sub.ManagementURL, nil
-}
+// v1's subscriber object carried `management_url` — where that subscriber cancels — and
+// the delete-account surface was built to link to it, precisely so the destination came
+// from the provider instead of being composed by us. The v2 customer object does not carry
+// it. Inventing one would reintroduce exactly the staleness that linking to theirs
+// avoided, so the surface states that deleting an account does not cancel a subscription
+// and leaves it there. If v2 grows the field, the endpoint that served it is in this
+// package's history.
 
 // Sync reads the provider's current state for one subscriber and writes users.pro_until
 // from it.

--- a/internal/identity/billing/service_integration_test.go
+++ b/internal/identity/billing/service_integration_test.go
@@ -35,7 +35,7 @@ func newService(t *testing.T, h http.HandlerFunc) (*Service, *pgxpool.Pool) {
 	if h != nil {
 		srv := httptest.NewServer(h)
 		t.Cleanup(srv.Close)
-		s.client = newClient("sk_test", srv.URL, srv.Client())
+		s.client = newClient("sk_test", testProjectID, srv.URL, srv.Client())
 	}
 	return s, pool
 }
@@ -78,15 +78,21 @@ func event(id, appUserID string) Event {
 	}
 }
 
-// subscriberWith serves a subscriber carrying one pro entitlement expiring at expires, or
-// no entitlement at all when expires is empty.
+// subscriberWith serves a v2 customer carrying one pro entitlement expiring at expires, or
+// no active entitlement at all when expires is empty.
 func subscriberWith(expires string) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		if expires == "" {
-			_, _ = w.Write([]byte(`{"subscriber":{"entitlements":{}}}`))
+			_, _ = w.Write([]byte(`{"active_entitlements":{"items":[]}}`))
 			return
 		}
-		_, _ = fmt.Fprintf(w, `{"subscriber":{"entitlements":{"pro":{"expires_date":%q}}}}`, expires)
+		at, err := time.Parse(time.RFC3339, expires)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = fmt.Fprintf(w,
+			`{"active_entitlements":{"items":[{"entitlement_id":"pro","expires_at":%d}]}}`, at.UnixMilli())
 	}
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1030,16 +1030,6 @@ export function createApi(
     return requestData<{ url: string }>('/api/v1/billing/checkout');
   }
 
-  /** Where this caller cancels or changes their subscription — the provider's own
-   *  management URL, fetched from them rather than composed here, because a destination we
-   *  built is wrong the first time they change theirs.
-   *
-   *  404 when there is no subscription, or the provider is unreachable. Either way the
-   *  surface omits the link rather than rendering a broken one. */
-  async function billingManageUrl(): Promise<{ url: string }> {
-    return requestData<{ url: string }>('/api/v1/billing/manage');
-  }
-
   /** What the caller's account did this period: model calls, failures and tokens, read
    *  from the LLM gateway. Never fails for anything the caller can act on — an account
    *  that has never used AI, and a gateway that is down, both answer zeroes. */
@@ -2219,7 +2209,6 @@ export function createApi(
     myAnalyses,
     myPlan,
     billingCheckout,
-    billingManageUrl,
     myPlanHistory,
     myUsage,
     listViewedSlugs,

--- a/web/src/lib/components/DeleteAccountButton.messages.ts
+++ b/web/src/lib/components/DeleteAccountButton.messages.ts
@@ -19,7 +19,6 @@ export const messages = defineMessages(
       "Discussions you started stay up so other members don't lose their replies, but your handle is removed from them — they are shown as written by a deleted member.",
     subscriptionNote:
       'If you pay for Pro, deleting your account here does not cancel that subscription — cancel it where you bought it, or you will keep being charged for an account that no longer exists.',
-    manageSubscription: 'Manage subscription',
     confirmPrefix: 'Type',
     confirmSuffix: 'to confirm',
     passwordLabel: 'Confirm your password',
@@ -52,7 +51,6 @@ export const messages = defineMessages(
       'Начатые вами обсуждения останутся видны, чтобы другие участники не потеряли свои ответы, но ваш ник будет из них убран — они будут показаны как написанные удалённым участником.',
     subscriptionNote:
       'Если у вас оплачен Pro, удаление аккаунта здесь не отменяет подписку — отмените её там, где оформляли, иначе списания продолжатся за уже несуществующий аккаунт.',
-    manageSubscription: 'Управление подпиской',
     confirmPrefix: 'Введите',
     confirmSuffix: 'для подтверждения',
     passwordLabel: 'Подтвердите пароль',

--- a/web/src/lib/components/DeleteAccountButton.svelte
+++ b/web/src/lib/components/DeleteAccountButton.svelte
@@ -32,25 +32,12 @@
   let error = $state<string | null>(null);
   let reauthRequired = $state(false);
 
-  // Where this member cancels, asked of the payment provider rather than composed here: a
-  // destination we invent is wrong the first time they change theirs, and "where do I
-  // cancel" is the last question anyone should get a stale answer to.
-  //
-  // Fetched when the dialog OPENS, not on page load — it is a call to the provider, and
-  // most people opening this settings tab are not deleting anything. Null (no subscription,
-  // billing not configured, provider unreachable) simply omits the link: the note beside it
-  // still says the subscription is not cancelled, which is the part that must never depend
-  // on a network call succeeding.
-  let manageUrl = $state<string | null>(null);
-
-  $effect(() => {
-    if (!open) return;
-    api
-      .billingManageUrl()
-      .then(({ url }) => (manageUrl = url))
-      .catch(() => (manageUrl = null));
-  });
-
+  // There is no "manage subscription" link here, and its absence is the provider's doing.
+  // Their v2 customer object carries no management URL — v1's did, and this dialog linked
+  // to it precisely so the destination came from them rather than being composed by us.
+  // Composing one now would reintroduce exactly the staleness that avoided, so the note
+  // below says plainly that deleting the account does not cancel the subscription and
+  // leaves finding the cancel page to the member.
   const s = $derived(t(messages, locale()));
   const user = $derived(currentUser());
   const email = $derived(user?.email ?? '');
@@ -140,15 +127,7 @@
   <!-- Deleting here erases OUR side. The subscription is held by the payment provider,
        which never hears about this, so somebody who does not cancel there keeps paying
        for an account that no longer exists. -->
-  <p class="mt-3 text-sm text-muted-foreground">
-    {s.subscriptionNote}
-    {#if manageUrl}
-      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- the payment provider's own management URL, not a SvelteKit route -->
-      <a class="underline" href={manageUrl} target="_blank" rel="noopener noreferrer"
-        >{s.manageSubscription}</a
-      >
-    {/if}
-  </p>
+  <p class="mt-3 text-sm text-muted-foreground">{s.subscriptionNote}</p>
 
   <label class="mt-4 block text-sm font-medium" for="delete-account-confirm">
     {s.confirmPrefix} <span class="font-mono">{email}</span> {s.confirmSuffix}


### PR DESCRIPTION
Two claims in `add-pro-subscription` that the live RevenueCat project contradicts. Found
while configuring the host, by reading the project through the API rather than assuming.

**The lifetime case is live, not defensive.** The comment said we sell no lifetime product
and that the null `expires_date` handling was for a case that would "first occur by
accident". The catalogue already carries a `lifetime` non_consumable beside `monthly` and
`yearly`. The code was right; the comment told a future reader it was speculative.

**The entitlement lookup key is `freehire Pro`, not `pro`.** The package default would have
matched no entitlement at all — and that does not fail, it resolves every paying subscriber
to the free plan. Now recorded in `deploy/AGENTS.md`, together with the fact that the value
carries a space and systemd's `EnvironmentFile` delivers it whole (verified on the host,
not assumed — there was no other multi-word value in that file to copy from).

Docs and comments only; no behaviour change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the required entitlement configuration value, including how values containing spaces are handled in deployment settings.
  - Updated billing documentation to reflect that lifetime products are available alongside monthly and yearly subscription options.
  - Clarified that lifetime purchases do not have an expiration date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->