### PR TITLE
Count what the tailor button spends, not what it doesn't

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -248,7 +248,7 @@ Combine free-text `q` with any of the filter params below. Repeated facet params
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
 | `q` | string | no | Full-text query over title, company, and description. (e.g. `golang`) |
-| `sort` | string | no | One of `created_at`, `posted_at`, `salary_min`, `salary_max`. Omit for relevance/newest. (e.g. `posted_at`) |
+| `sort` | string | no | One of `created_at`, `posted_at`, `view_count`, `salary_min`, `salary_max`. Omit for relevance/newest. (e.g. `posted_at`) |
 | `order` | string | no | `asc` or `desc` (default `desc`). (e.g. `desc`) |
 | `limit` | integer | no | Page size, 1–100. (e.g. `20`) |
 | `offset` | integer | no | Rows to skip; `offset + limit` ≤ 10000. (e.g. `0`) |
@@ -280,7 +280,7 @@ Same query and filters as `/jobs/search`, but each result carries the `descripti
 | --- | --- | --- | --- |
 | `q` | string | no | Full-text query over title, company, and description. (e.g. `golang`) |
 | `description_format` | string | no | One of `html` (default, verbatim), `text` (tags stripped), `markdown` (HTML converted to Markdown). Unknown values fall back to `html`. (e.g. `markdown`) |
-| `sort` | string | no | One of `created_at`, `posted_at`, `salary_min`, `salary_max`. Omit for relevance/newest. (e.g. `posted_at`) |
+| `sort` | string | no | One of `created_at`, `posted_at`, `view_count`, `salary_min`, `salary_max`. Omit for relevance/newest. (e.g. `posted_at`) |
 | `order` | string | no | `asc` or `desc` (default `desc`). (e.g. `desc`) |
 | `limit` | integer | no | Page size, 1–100. (e.g. `20`) |
 | `offset` | integer | no | Rows to skip; `offset + limit` ≤ 10000. (e.g. `0`) |
@@ -489,7 +489,7 @@ curl "https://freehire.me/api/v1/jobs/<slug>/match" -H "Authorization: Bearer $F
 
 The cached AI match analysis for the job (never runs the LLM).
 
-Returns the cached analysis, flagged `stale` when your CV or the job changed since it was computed, or a null analysis when none is cached. `has_cv` is false when you have no stored CV. `allowance` reports how much of today you have used against what the day allows, and when it resets.
+Returns the cached analysis, flagged `stale` when your CV or the job changed since it was computed, or a null analysis when none is cached. `has_cv` is false when you have no stored CV. `allowance` reports how much of today you have used against what the day allows, and when it resets. `tailor_allowance` reports the same for CV tailoring, which carries its own daily ceiling — the job page offers tailoring from this response.
 
 **Path parameters**
 
@@ -515,7 +515,8 @@ curl "https://freehire.me/api/v1/jobs/<slug>/match-analysis" -H "Authorization: 
       "gaps": ["..."],
       "recommendation": "..."
     },
-    "allowance": { "feature": "match", "used": 1, "limit": 3, "unlimited": false, "enforced": false, "resets_at": "2026-09-01T00:00:00Z" }
+    "allowance": { "feature": "match", "used": 1, "limit": 3, "unlimited": false, "enforced": false, "resets_at": "2026-09-01T00:00:00Z" },
+    "tailor_allowance": { "feature": "tailor", "used": 0, "limit": 2, "unlimited": false, "enforced": false, "resets_at": "2026-09-01T00:00:00Z" }
   }
 }
 ```
@@ -3664,7 +3665,7 @@ curl "https://freehire.me/api/v1/me/contributions" -H "Authorization: Bearer fhk
 ```
 
 ```json
-{ "data": [ { "url": "https://boards.greenhouse.io/acme", "source": "greenhouse", "board": "acme", "state": "onboarded", "created_at": "2026-07-20T12:00:00Z" } ] }
+{ "data": [ { "url": "https://boards.greenhouse.io/acme", "source": "greenhouse", "board": "acme", "state": "active", "created_at": "2026-07-20T12:00:00Z" } ] }
 ```
 
 ### `POST /me/jd/resolve`

--- a/internal/api/handler/match_analysis.go
+++ b/internal/api/handler/match_analysis.go
@@ -54,6 +54,9 @@ type matchHandlers struct {
 	// bank supplies the candidate's work history. Nil when there are no queries to build
 	// it over, which reads as an empty bank — and an empty bank means no analysis.
 	bank candidateProfiler
+	// plans answers the tailoring standing reported beside the fit one. Nil in a fixture
+	// assembled without a meter.
+	plans *plan.Store
 }
 
 func newMatchHandlers(queries *db.Queries, userProfile *userprofile.Service, resumeStore *resume.Store, analyzer *matchanalysis.Analyzer, plans *plan.Store) *matchHandlers {
@@ -64,6 +67,7 @@ func newMatchHandlers(queries *db.Queries, userProfile *userprofile.Service, res
 		matchAnalysis: analyzer,
 		fit:           fitanalysis.New(queries, meterOrNil(plans), analyzer),
 		bank:          newCandidateProfiler(queries),
+		plans:         plans,
 	}
 }
 
@@ -142,11 +146,17 @@ func (h *matchHandlers) liveStamps(ctx context.Context, userID int64, job db.Job
 // recompute); Analysis is nil when none is cached or the LLM is unconfigured. Allowance is
 // set on reads (GET) so the SPA can show where the caller stands today and pre-block a
 // new-job analysis that would be refused; it is omitted on the compute responses.
+//
+// TailorAllowance rides along on the same reads because the sidebar this feeds offers
+// TAILORING off the fit summary, and the two features carry their own daily ceilings — a
+// page holding only the fit standing can do nothing but print the wrong number beside a
+// "Tailor my CV" button.
 type matchAnalysisResponse struct {
-	HasCV     bool                    `json:"has_cv"`
-	Stale     bool                    `json:"stale"`
-	Analysis  *matchanalysis.Analysis `json:"analysis"`
-	Allowance *allowanceView          `json:"allowance,omitempty"`
+	HasCV           bool                    `json:"has_cv"`
+	Stale           bool                    `json:"stale"`
+	Analysis        *matchanalysis.Analysis `json:"analysis"`
+	Allowance       *allowanceView          `json:"allowance,omitempty"`
+	TailorAllowance *allowanceView          `json:"tailor_allowance,omitempty"`
 }
 
 // GetMatchAnalysis serves the cached fit analysis for one of the caller's jobs, never calling
@@ -168,19 +178,20 @@ func (h *matchHandlers) GetMatchAnalysis(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"data": matchAnalysisResponse{HasCV: false}})
 	}
 	allowance := h.allowanceView(c.Context(), userID)
+	tailorAllowance := h.tailorAllowanceView(c.Context(), userID)
 	analysis, stored, err := h.fit.Cached(c.Context(), userID, job.ID)
 	if err != nil {
 		return err
 	}
 	if analysis == nil {
-		return c.JSON(fiber.Map{"data": matchAnalysisResponse{HasCV: true, Allowance: allowance}})
+		return c.JSON(fiber.Map{"data": matchAnalysisResponse{HasCV: true, Allowance: allowance, TailorAllowance: tailorAllowance}})
 	}
 	// Recompute the hard-constraint ceiling from the current job/résumé/dictionary and
 	// apply it to the cached analysis on read — the cap is never stored, so a dictionary
 	// change takes effect without marking the cache stale.
 	h.capServedAnalysis(c.Context(), userID, job, analysis)
 	stale := !h.liveStamps(c.Context(), userID, job, cvUploadedAt).Fresh(stored)
-	return c.JSON(fiber.Map{"data": matchAnalysisResponse{HasCV: true, Stale: stale, Analysis: analysis, Allowance: allowance}})
+	return c.JSON(fiber.Map{"data": matchAnalysisResponse{HasCV: true, Stale: stale, Analysis: analysis, Allowance: allowance, TailorAllowance: tailorAllowance}})
 }
 
 // allowanceView reports where the caller stands on the fit-analysis allowance today, or nil
@@ -193,6 +204,21 @@ func (h *matchHandlers) allowanceView(ctx context.Context, userID int64) *allowa
 		return nil
 	}
 	v := viewStanding(*st)
+	return &v
+}
+
+// tailorAllowanceView reports where the caller stands on the tailoring-session allowance
+// today, or nil when it cannot be read. Best-effort for the same reason as the fit one: a
+// metering hiccup must cost the reader a caption, not the read.
+func (h *matchHandlers) tailorAllowanceView(ctx context.Context, userID int64) *allowanceView {
+	if h.plans == nil {
+		return nil
+	}
+	st, err := h.plans.Standing(ctx, userID, plan.FeatureTailor)
+	if err != nil {
+		return nil
+	}
+	v := viewStanding(st)
 	return &v
 }
 

--- a/internal/api/handler/match_analysis.go
+++ b/internal/api/handler/match_analysis.go
@@ -177,21 +177,27 @@ func (h *matchHandlers) GetMatchAnalysis(c *fiber.Ctx) error {
 		// No CV means no analysis is possible, so usage is moot — skip the count query.
 		return c.JSON(fiber.Map{"data": matchAnalysisResponse{HasCV: false}})
 	}
-	allowance := h.allowanceView(c.Context(), userID)
-	tailorAllowance := h.tailorAllowanceView(c.Context(), userID)
+	// The standings are the same either way, so they are read once and the analysis is
+	// filled in below when there is one.
+	resp := matchAnalysisResponse{
+		HasCV:           true,
+		Allowance:       h.allowanceView(c.Context(), userID),
+		TailorAllowance: h.tailorAllowanceView(c.Context(), userID),
+	}
 	analysis, stored, err := h.fit.Cached(c.Context(), userID, job.ID)
 	if err != nil {
 		return err
 	}
 	if analysis == nil {
-		return c.JSON(fiber.Map{"data": matchAnalysisResponse{HasCV: true, Allowance: allowance, TailorAllowance: tailorAllowance}})
+		return c.JSON(fiber.Map{"data": resp})
 	}
 	// Recompute the hard-constraint ceiling from the current job/résumé/dictionary and
 	// apply it to the cached analysis on read — the cap is never stored, so a dictionary
 	// change takes effect without marking the cache stale.
 	h.capServedAnalysis(c.Context(), userID, job, analysis)
-	stale := !h.liveStamps(c.Context(), userID, job, cvUploadedAt).Fresh(stored)
-	return c.JSON(fiber.Map{"data": matchAnalysisResponse{HasCV: true, Stale: stale, Analysis: analysis, Allowance: allowance, TailorAllowance: tailorAllowance}})
+	resp.Analysis = analysis
+	resp.Stale = !h.liveStamps(c.Context(), userID, job, cvUploadedAt).Fresh(stored)
+	return c.JSON(fiber.Map{"data": resp})
 }
 
 // allowanceView reports where the caller stands on the fit-analysis allowance today, or nil

--- a/web/src/lib/components/JobSeeAlso.svelte
+++ b/web/src/lib/components/JobSeeAlso.svelte
@@ -35,7 +35,9 @@
 {#if cards.length > 0}
   <section class="mt-8">
     <h2 class="mb-3 text-sm font-semibold text-muted-foreground">See also</h2>
-    <div class="flex gap-3 overflow-x-auto pb-1">
+    <div
+      class="flex gap-3 overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+    >
       {#each cards as card (card.slug)}
         <a
           href={resolve('/collections/[slug]', { slug: card.slug })}

--- a/web/src/lib/components/MatchSummary.svelte
+++ b/web/src/lib/components/MatchSummary.svelte
@@ -48,7 +48,17 @@
   // server still runs the analysis, and hiding the CTA on the count alone would refuse
   // somebody the server was about to serve.
   const allowance = $derived(data?.allowance ?? null);
-  const allowanceRefused = $derived(refuses(allowance));
+  // The CTA starts TAILORING, which draws on its own daily ceiling — a separate feature from
+  // the fit analysis, with its own number. Both stand between the button and a result, so
+  // the block goes up when either would refuse, and the caption reports the tailoring one
+  // because that is what the button spends.
+  const tailorAllowance = $derived(data?.tailor_allowance ?? null);
+  const tailorRefused = $derived(refuses(tailorAllowance));
+  const allowanceRefused = $derived(refuses(allowance) || tailorRefused);
+  // Which ceiling the block names. Tailoring wins the tie: it is what the button spends,
+  // and the analysis only stands in front of it.
+  const refusedName = $derived(tailorRefused ? "CV tailorings" : 'job analyses');
+  const refusedAllowance = $derived(tailorRefused ? tailorAllowance : allowance);
 
   const toneText: Record<Tone, string> = {
     strong: 'text-brand-strong',
@@ -98,7 +108,9 @@
       </span>
     </a>
   {:else if allowanceRefused}
-    <p class="text-sm text-muted-foreground">You've used today's job analyses. More at {resetsAtLabel(allowance)}.</p>
+    <p class="text-sm text-muted-foreground">
+      You've used today's {refusedName}. More at {resetsAtLabel(refusedAllowance)}.
+    </p>
   {:else}
     <Button
       variant="primary"
@@ -112,11 +124,11 @@
     </Button>
     <!-- The one line kept under the button: what today still allows. A guest is told
          nothing here — the button opens sign-in, which says it better than a caption.
-         Nothing left and no refusal is the shadow run — the analysis still goes, so it
+         Nothing left and no refusal is the shadow run — the tailoring still goes, so it
          says nothing rather than "0 left" beside a button that works. -->
-    {#if remaining(allowance)}
+    {#if remaining(tailorAllowance)}
       <p class="text-xs text-muted-foreground">
-        {remaining(allowance)} of today's job analyses left
+        {remaining(tailorAllowance)} of today's CV tailorings left
       </p>
     {/if}
   {/if}

--- a/web/src/lib/components/MatchSummary.svelte
+++ b/web/src/lib/components/MatchSummary.svelte
@@ -48,16 +48,14 @@
   // server still runs the analysis, and hiding the CTA on the count alone would refuse
   // somebody the server was about to serve.
   const allowance = $derived(data?.allowance ?? null);
-  // The CTA starts TAILORING, which draws on its own daily ceiling — a separate feature from
-  // the fit analysis, with its own number. Both stand between the button and a result, so
-  // the block goes up when either would refuse, and the caption reports the tailoring one
-  // because that is what the button spends.
+  // The CTA spends a TAILORING session — a different feature from the fit analysis, with a
+  // ceiling of its own. Both stand between the button and a result, so the block goes up
+  // when either would refuse and names the one that did; tailoring wins the tie, being what
+  // the button actually spends.
   const tailorAllowance = $derived(data?.tailor_allowance ?? null);
   const tailorRefused = $derived(refuses(tailorAllowance));
   const allowanceRefused = $derived(refuses(allowance) || tailorRefused);
-  // Which ceiling the block names. Tailoring wins the tie: it is what the button spends,
-  // and the analysis only stands in front of it.
-  const refusedName = $derived(tailorRefused ? "CV tailorings" : 'job analyses');
+  const refusedName = $derived(tailorRefused ? 'CV tailorings' : 'job analyses');
   const refusedAllowance = $derived(tailorRefused ? tailorAllowance : allowance);
 
   const toneText: Record<Tone, string> = {

--- a/web/src/lib/docs/api-spec.ts
+++ b/web/src/lib/docs/api-spec.ts
@@ -412,7 +412,9 @@ export const GROUPS: Group[] = [
           'Returns the cached analysis, flagged `stale` when your CV or the job ' +
           'changed since it was computed, or a null analysis when none is cached. ' +
           '`has_cv` is false when you have no stored CV. `allowance` reports how much of ' +
-          'today you have used against what the day allows, and when it resets.',
+          'today you have used against what the day allows, and when it resets. ' +
+          '`tailor_allowance` reports the same for CV tailoring, which carries its own ' +
+          'daily ceiling — the job page offers tailoring from this response.',
         pathParams: [{ name: 'slug', type: 'string', required: true, description: 'The job `public_slug`.' }],
         curl: `curl "${BASE_URL}/jobs/<slug>/match-analysis" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
         responseExample: `{
@@ -428,7 +430,8 @@ export const GROUPS: Group[] = [
       "gaps": ["..."],
       "recommendation": "..."
     },
-    "allowance": { "feature": "match", "used": 1, "limit": 3, "unlimited": false, "enforced": false, "resets_at": "2026-09-01T00:00:00Z" }
+    "allowance": { "feature": "match", "used": 1, "limit": 3, "unlimited": false, "enforced": false, "resets_at": "2026-09-01T00:00:00Z" },
+    "tailor_allowance": { "feature": "tailor", "used": 0, "limit": 2, "unlimited": false, "enforced": false, "resets_at": "2026-09-01T00:00:00Z" }
   }
 }`,
       },

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -108,12 +108,16 @@ export interface UsageHistoryEntry {
  *  (the block prompts an upload); `analysis` is null when none is cached yet or the LLM
  *  is unconfigured; `stale` marks a cached analysis whose CV or job changed since (the
  *  block then offers a recompute); `allowance` reports where the caller stands today on
- *  reads (omitted on the no-CV read and on compute responses). */
+ *  reads (omitted on the no-CV read and on compute responses). `tailor_allowance` rides
+ *  along on the same reads because the sidebar this feeds offers TAILORING off the fit
+ *  summary, and the two features carry their own daily ceilings — reading only the fit one
+ *  puts an analysis count under a "Tailor my CV" button. */
 export interface MatchAnalysisResponse {
   has_cv: boolean;
   stale: boolean;
   analysis: MatchAnalysisContract | null;
   allowance?: Allowance;
+  tailor_allowance?: Allowance;
 }
 
 /** One row of the Activity → Matches tab: a compact projection of a cached match analysis


### PR DESCRIPTION
The caption under "Tailor my CV" on a job page read **"3 of today's job analyses left"**. The number was the fit-analysis standing; the button spends a *tailoring session*. The two are separate features with their own daily ceilings (3 and 2 on the free tier), so the line put one feature's count under the other's button — and would have kept doing so however the wording was fixed.

### What changed

- `GET /jobs/{slug}/match-analysis` now returns `tailor_allowance` beside `allowance`. A field on a response the sidebar already fetches, rather than a second request per job page.
- The caption reports the tailoring standing: **"2 of today's CV tailorings left"**.
- The exhausted-block goes up when *either* ceiling would refuse — both stand between the button and a result — and names whichever did.
- `docs/API.md` regenerated from `api-spec.ts`.

Also: hides the scrollbar on the job page's "See also" strip, the way `design-system/src/tab-strip.svelte` already does. Scrolling is unchanged.

### Verification

`go build ./...`, `go vet ./...` (and `-tags=integration`), `go test ./internal/api/handler/`, `eslint`, `svelte-check` — all clean on the touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a separate daily allowance indicator for CV tailoring in job match analysis.
  * Updated tailoring controls to reflect their own usage limit and remaining allowance.
  * Added `view_count` as a supported job-search sorting option.

* **Documentation**
  * Updated API documentation and examples to include CV-tailoring allowance details.
  * Corrected the contributions example status value.

* **Style**
  * Hidden scrollbars in horizontally scrolling “See also” cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->