### PR TITLE
Group the application's questions by what answering one costs

### DIFF
--- a/design-system/scripts/adoption-baseline.json
+++ b/design-system/scripts/adoption-baseline.json
@@ -2,7 +2,7 @@
   "Alert": 1,
   "Avatar": 0,
   "Badge": 19,
-  "BrandMark": 1,
+  "BrandMark": 2,
   "Button": 70,
   "Card": 3,
   "Chip": 4,

--- a/openspec/changes/apply-form-effort-groups/.openspec.yaml
+++ b/openspec/changes/apply-form-effort-groups/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-03

--- a/openspec/changes/apply-form-effort-groups/design.md
+++ b/openspec/changes/apply-form-effort-groups/design.md
@@ -1,0 +1,149 @@
+## Context
+
+`web/src/lib/components/JobApplyForm.svelte` renders the served form as a caption,
+one line of standard fields, and a flat `<ul>` of questions. The served shape
+(`internal/ingest/applyform.Display`) already carries everything the new rendering
+needs — each question's text, whether it is required, and a name for the kind of
+answer it expects — drawn from a closed vocabulary in `display.go`:
+
+| `answer` value    | control kind      |
+| ----------------- | ----------------- |
+| `""` (absent)     | one-line answer   |
+| `"choose one"`    | select            |
+| `"choose any"`    | multi-select      |
+| `"yes / no"`      | boolean           |
+| `"written answer"`| textarea          |
+| `"upload"`        | file              |
+
+The absent value is deliberate on the Go side: a one-line answer is what anyone
+assumes, so naming it is noise, and a control kind the capture could not normalize
+is given no word rather than the nearest one.
+
+Two pieces this change needs already exist and are not being built: `BrandMark`
+(`design-system/src/brand-mark.svelte`), which draws a brand glyph from a path and
+a hex; and `simple-icons`, already a dependency of `web/` and already used this way
+by `web/src/lib/techmarks.ts` through `SkillIcon.svelte`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The reader learns the form's cost — how many questions, how many essays — before
+  reading any question.
+- The kind of answer is stated once per group instead of once per question, which
+  removes the trailing hint that currently wraps onto its own line.
+- The provider caption carries a recognisable mark where one exists.
+
+**Non-Goals:**
+
+- Changing `internal/ingest/applyform`, the `/api` wire shape, or `openapi.yaml`.
+- An estimate of minutes. The counts are measured; a duration would be invented.
+- Marks for every ATS. Coverage is whatever `simple-icons` verifiably carries.
+- Any change to `applyFormWorthShowing` or to which postings show the block at all.
+
+## Decisions
+
+### Group in a pure module, not in `ForDisplay` and not in the component
+
+Grouping is a pure function in a new `web/src/lib/applyFormGroups.ts`, over the
+questions as served; the component calls it from a `$derived` and does nothing but
+lay the result out.
+
+The seam is not stylistic. `web/vitest.config.ts` runs the web suite in plain Node
+with no Svelte compilation — its own comment says as much, and names `facetModel.ts`
+as the precedent: the logic worth testing lives in a module with no runes and no
+`$app/*` imports. Logic written inside a `$derived` in a `.svelte` file is
+unreachable by any test in this repo. Since the counts, the group order and the
+single-group collapse are exactly the parts with edge cases worth pinning, they
+have to live where a test can reach them.
+
+The alternative — partitioning in `ForDisplay` and serving groups — was rejected
+because `Display.Questions` is documented as "the employer's own, in the order the
+form presents them", and `web/static/openapi.yaml` is the integration contract
+other consumers read. Reordering the array to suit one reader's layout would make
+that documented promise false for everybody, to save a `reduce` in one component.
+The Go projection stays the honest record of what the employer published; the
+page decides how to read it.
+
+This also keeps the decision reversible. If grouping turns out to be the wrong
+call, it is one component's `$derived` block, not a wire change and a re-capture.
+
+### Four groups, keyed by the closed `answer` vocabulary
+
+`Short answers` (`""`), `Pick from a list` (`choose one` / `choose any` /
+`yes / no`), `Written answers` (`written answer`), `Attachments` (`upload`), in
+that order — the order is the point, since it runs cheapest to most expensive.
+
+The mapping is a total function over a closed vocabulary, with the empty string as
+its own case rather than a fallback. Any value the map does not know falls into
+`Short answers`, which is the same assumption `display.go` makes when it declines
+to name a kind: an unqualified question is assumed answerable in a line.
+
+Three groups rather than four was considered — folding `Attachments` into
+`Written answers` as "the expensive ones". Rejected: an upload is a file the
+candidate either has or does not, which is a different kind of cost from writing
+prose, and `upload` questions are rare enough that the group is usually absent
+anyway.
+
+### Headings collapse when there is only one group
+
+If exactly one group is non-empty, no headings render. A single heading reading
+`Written answers (5)` directly beneath a summary reading `5 questions · 5 written
+answers` says the same thing twice in two lines.
+
+### The mark accompanies the name; the name never leaves
+
+`simple-icons` carries `siGreenhouse` and nothing for Ashby, Workable, Lever or
+Recruitee. `siGreenhouse` was verified to be the ATS rather than a slug collision:
+its `source` is `brand.greenhouse.io/brand-portal`. `techmarks.ts` records three
+cases where an exact slug match resolved to the wrong brand (`elk`, `hive`,
+`backbone`), so the source check is the established bar here, not extra caution.
+
+With one mark in five, replacing the provider's name with its mark would leave
+four postings in five with an unattributed block. So the mark is additive, and its
+absence renders nothing at all — no placeholder glyph, matching how `SkillIcon`
+handles a skill with no mark.
+
+The map lives in a new `web/src/lib/atsmarks.ts` rather than inline in the
+component or appended to `techmarks.ts`. Inline hides the coverage reasoning
+inside a component that is about layout; `techmarks.ts` is explicitly scoped to the
+skills dictionary and mixing ATS providers into it would make its lookups
+ambiguous. A separate small named map is the shape this repo already uses for
+exactly this (`techmarks.ts`, `familymarks.ts`, `backers.ts`).
+
+### The index key stays an index key
+
+`{#each form.questions as question, i (i)}` is keyed by position on purpose:
+Greenhouse and Workable both publish the same screening question twice on some
+postings, and a duplicate key throws `each_key_duplicate` during Svelte 5
+hydration rather than warning — which took the whole job page down once.
+
+Grouping partitions the list into new arrays, so the keying question is asked
+again per group. Each group's `{#each}` is keyed by its own index, which stays
+sound for the same reason the original is: the lists are inert, rebuilt wholesale
+whenever `form` changes, never reordered or filtered in place.
+
+## Risks / Trade-offs
+
+- **The employer's ordering is lost between groups.** → Accepted, and stated in
+  the proposal. Preserved *within* each group, and the form is actually filled on
+  the platform's own site where the platform's order governs.
+
+- **A form of two questions gets three headings' worth of chrome.** → The
+  single-group collapse covers the degenerate case. A two-question form spanning
+  two groups renders two headings, which is proportionate.
+
+- **`simple-icons` removes marks on trademark request** — it has already dropped
+  AWS, Java and C#, as `techmarks.ts` records. A future version could drop
+  Greenhouse. → The absence path is the same one four of five providers already
+  take, so the block degrades to text and nothing breaks. No guard needed beyond
+  the lookup returning `undefined`.
+
+- **The summary and the list could disagree** if the counts were computed from
+  anything but the rendered questions. → Both are `$derived` from the same
+  `form.questions`, so there is no second source to drift from.
+
+## Migration Plan
+
+None. Front-end only, no schema, no stored data, no worker. Rollback is reverting
+the commit.

--- a/openspec/changes/apply-form-effort-groups/proposal.md
+++ b/openspec/changes/apply-form-effort-groups/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+The application-form block already carries the one fact that decides whether a
+candidate applies — how much work the form is — and then hides it. Every question
+renders as an identical row, so a form of four one-line fields and a form
+demanding five essays look the same until the reader has read all fifteen rows.
+
+The answer-kind hint that would carry that fact is pinned to the end of the
+question text, where a long question pushes it onto a second line and it reads as
+a separate list item rather than as a note about the line above it.
+
+## What Changes
+
+- The block states its own size up front: the number of questions, and the number
+  demanding a written answer when there are any.
+- Questions are grouped by what answering costs — short answers, then choices from
+  a list, then written answers, then attachments — cheapest first, so the reader
+  meets the cheap questions before the expensive ones and can stop reading as soon
+  as the total is more than they will spend.
+- The answer kind moves off each row and into its group's heading, which states it
+  once for the whole group. What is left beside a question is whether it is
+  optional.
+- The provider caption carries the platform's own brand mark where one is
+  available, so the source of the questions is recognisable before it is read.
+- Not a breaking change: the served form's shape and ordering are untouched. Every
+  change here is in how the job page reads what it is already served.
+
+## Capabilities
+
+### New Capabilities
+
+None. The block already exists and is already specified; what changes is how it
+presents what it is served.
+
+### Modified Capabilities
+
+- `apply-form-display`: the job page's rendering of the served form gains
+  requirements — a stated size, grouping by answering cost, the answer kind named
+  once per group rather than per question, and the provider's brand mark. The
+  served projection itself (`internal/ingest/applyform`) is unchanged, including
+  its promise that questions arrive in the employer's order.
+
+## Impact
+
+- `web/src/lib/components/JobApplyForm.svelte` — the whole of the change's
+  rendering. Its `applyFormWorthShowing` export and its index-keyed `{#each}` are
+  deliberately untouched; the latter guards against a duplicate-key crash real ATS
+  forms have caused.
+- `web/src/lib/applyFormGroups.ts` (new, with its test) — the pure grouping and
+  counting the component renders. Pure and separate because the web suite runs
+  without Svelte compilation, so logic left inside a `$derived` cannot be tested.
+- `web/src/lib/atsmarks.ts` (new) — provider slug to brand mark, mirroring the
+  existing `web/src/lib/techmarks.ts`. Sourced from `simple-icons`, already a
+  dependency of `web/`.
+- No Go change, no API change, no migration. `openapi.yaml` and
+  `internal/ingest/applyform` are out of scope: the wire contract states that
+  questions arrive in the employer's order, and reordering them for one reader's
+  convenience would make that statement false for every other consumer.
+
+### Known limits accepted
+
+- `simple-icons` carries a mark for Greenhouse only; Ashby, Workable, Lever and
+  Recruitee have none. The mark therefore sits *beside* the provider's name rather
+  than replacing it, and a provider without a mark renders as text alone — the
+  same partial-coverage fallback `techmarks.ts` already documents for skills.
+- Grouping discards the employer's ordering *between* groups. Accepted: the block
+  answers "is this worth applying to", and the form itself is filled on the
+  platform's own site, where its order is whatever the platform shows.

--- a/openspec/changes/apply-form-effort-groups/specs/apply-form-display/spec.md
+++ b/openspec/changes/apply-form-effort-groups/specs/apply-form-display/spec.md
@@ -43,9 +43,34 @@ Each group's heading SHALL name the kind of answer its questions expect and how
 many there are, so that the kind is stated once for the group rather than once per
 question.
 
-A group no question falls into SHALL NOT be shown. Where every question falls into
-a single group the headings SHALL be omitted entirely, because a lone heading
-would only repeat the count already stated above it.
+A group no question falls into SHALL NOT be shown.
+
+Where every question falls into a single group, that group's heading SHALL be
+omitted only where the kind it names is already known to the reader without it:
+where the summary above has already counted that kind, or where the kind is the
+one nothing has ever named — the one-line answer everybody assumes. In every other
+case the lone heading SHALL be shown, because the kind moved out of the questions'
+own rows and into the heading, so suppressing it would not repeat a fact but delete
+it.
+
+#### Scenario: A lone group the summary already counts
+
+- **WHEN** the page renders a form every question of which demands a written answer
+- **THEN** the questions are listed without a heading, the summary above having
+  already said how many written answers there are
+
+#### Scenario: A lone group of one-line questions
+
+- **WHEN** the page renders a form every question of which is answerable in a line
+- **THEN** the questions are listed without a heading, no kind having been named for
+  them anywhere before this change either
+
+#### Scenario: A lone group whose kind nothing else names
+
+- **WHEN** the page renders a form every question of which is answered by choosing
+  from a list
+- **THEN** the heading is shown, being the only place the reader is told these
+  questions are answered by choosing rather than by writing
 
 Within a group the questions SHALL keep the order the employer put them in. The
 served order is not reordered — only partitioned — so that the employer's sequence
@@ -61,12 +86,6 @@ survives wherever grouping does not override it.
 
 - **WHEN** the page renders a form no question of which demands a file
 - **THEN** no heading for attachments appears
-
-#### Scenario: A form of one kind only
-
-- **WHEN** the page renders a form every question of which expects the same kind of
-  answer
-- **THEN** the questions are listed without any group heading
 
 #### Scenario: The employer's order within a group
 

--- a/openspec/changes/apply-form-effort-groups/specs/apply-form-display/spec.md
+++ b/openspec/changes/apply-form-effort-groups/specs/apply-form-display/spec.md
@@ -1,0 +1,124 @@
+## ADDED Requirements
+
+### Requirement: The block states how much work the form is before it lists it
+
+The job page SHALL state, above the questions, how many questions the form asks.
+Where any of them demand a written answer, it SHALL state how many do.
+
+The count of written answers SHALL be omitted where none are demanded, because a
+stated zero reads as a measurement of something absent rather than as the absence
+of the thing measured, and the reader is being told what the form will cost — not
+what it will not.
+
+These figures SHALL be derived from the questions the page was served, so that a
+figure can never disagree with the list beneath it.
+
+#### Scenario: A form demanding written answers
+
+- **WHEN** the page renders a form whose questions include some demanding a
+  written answer
+- **THEN** the block states both the total number of questions and how many demand
+  a written answer
+
+#### Scenario: A form demanding none
+
+- **WHEN** the page renders a form no question of which demands a written answer
+- **THEN** the block states the total number of questions and says nothing about
+  written answers
+
+#### Scenario: A form of standard fields alone
+
+- **WHEN** the page renders a form carrying no employer questions at all
+- **THEN** the block states no count, and still shows what the application
+  collects
+
+### Requirement: Questions are grouped by what answering one costs
+
+The job page SHALL group the served questions by the kind of answer each expects,
+and SHALL present the groups cheapest first: the questions answerable in a line,
+then those answered by choosing from what the employer offers, then those
+demanding written answers, then those demanding a file.
+
+Each group's heading SHALL name the kind of answer its questions expect and how
+many there are, so that the kind is stated once for the group rather than once per
+question.
+
+A group no question falls into SHALL NOT be shown. Where every question falls into
+a single group the headings SHALL be omitted entirely, because a lone heading
+would only repeat the count already stated above it.
+
+Within a group the questions SHALL keep the order the employer put them in. The
+served order is not reordered — only partitioned — so that the employer's sequence
+survives wherever grouping does not override it.
+
+#### Scenario: A form spanning several kinds
+
+- **WHEN** the page renders a form whose questions expect several kinds of answer
+- **THEN** each kind appears as its own group, headed by that kind and its count,
+  and the groups run from the cheapest kind to the most expensive
+
+#### Scenario: A kind no question expects
+
+- **WHEN** the page renders a form no question of which demands a file
+- **THEN** no heading for attachments appears
+
+#### Scenario: A form of one kind only
+
+- **WHEN** the page renders a form every question of which expects the same kind of
+  answer
+- **THEN** the questions are listed without any group heading
+
+#### Scenario: The employer's order within a group
+
+- **WHEN** a group holds more than one question
+- **THEN** they appear in the order the served form listed them
+
+#### Scenario: A question whose kind was not named
+
+- **WHEN** the page renders a question the projection named no answer kind for
+- **THEN** it appears among the questions answerable in a line, which is what a
+  reader assumes of an unqualified question
+
+### Requirement: A question's row carries only what its group does not
+
+Where a question is shown under a group heading, the page SHALL NOT repeat the
+kind of answer on the question's own row; the heading has already said it.
+
+The page SHALL continue to mark a question the platform will accept the
+application without, and SHALL mark nothing on a question it requires — a required
+question is the ordinary case, and marking it would put a word on nearly every
+row to say that nothing unusual is true of it.
+
+#### Scenario: An optional written answer
+
+- **WHEN** an optional question demanding a written answer is shown under its
+  group's heading
+- **THEN** its row is marked optional and says nothing about expecting a written
+  answer
+
+#### Scenario: A required question
+
+- **WHEN** a required question is shown
+- **THEN** its row carries no mark
+
+### Requirement: The provider is shown with its own mark where one is known
+
+The page SHALL show the platform the form was read from, and SHALL show that
+platform's brand mark alongside its name where a mark is known for it.
+
+The mark SHALL accompany the name rather than replace it. Marks are known for some
+platforms and not others, and a block identified by a mark alone would name its
+source for some postings and leave it unnamed for the rest.
+
+A platform no mark is known for SHALL be shown by name alone, with no placeholder
+in the mark's place.
+
+#### Scenario: A platform with a known mark
+
+- **WHEN** the page renders a form read from a platform a mark is known for
+- **THEN** the mark appears beside the platform's name
+
+#### Scenario: A platform with no known mark
+
+- **WHEN** the page renders a form read from a platform no mark is known for
+- **THEN** the platform's name appears alone, and the line is otherwise unchanged

--- a/openspec/changes/apply-form-effort-groups/tasks.md
+++ b/openspec/changes/apply-form-effort-groups/tasks.md
@@ -30,24 +30,24 @@
 
 ## 3. The rendering
 
-- [ ] 3.1 Render the caption line in `JobApplyForm.svelte`: the provider's mark via
+- [x] 3.1 Render the caption line in `JobApplyForm.svelte`: the provider's mark via
       `BrandMark` where `atsmarks` knows one and nothing where it does not, the
       provider's name, and the summary figures from `applyFormGroups`.
-- [ ] 3.2 Render the groups: a heading per group carrying its name and count, the
+- [x] 3.2 Render the groups: a heading per group carrying its name and count, the
       headings omitted entirely when the model says so, and the standard-fields
       line kept as its own group so it is not orphaned once headings exist.
-- [ ] 3.3 Drop the per-question answer-kind hint, leaving `optional` alone on the
+- [x] 3.3 Drop the per-question answer-kind hint, leaving `optional` alone on the
       row; key each group's `{#each}` by index, and carry forward the comment
       explaining why (the `each_key_duplicate` crash).
-- [ ] 3.4 Confirm `applyFormWorthShowing` and its exported contract are untouched,
+- [x] 3.4 Confirm `applyFormWorthShowing` and its exported contract are untouched,
       since `JobView.svelte` gates the whole tab on it.
 
 ## 4. Verification
 
-- [ ] 4.1 `pnpm --dir web test` green, `pnpm --dir web check` clean, eslint clean on
+- [x] 4.1 `pnpm --dir web test` green, `pnpm --dir web check` clean, eslint clean on
       the touched files.
-- [ ] 4.2 `pnpm check:dead` — both new modules are imported, so neither reads as a
+- [x] 4.2 `pnpm check:dead` — both new modules are imported, so neither reads as a
       dead file.
-- [ ] 4.3 Look at the block in a browser on a Greenhouse posting (mark, summary,
+- [x] 4.3 Look at the block in a browser on a Greenhouse posting (mark, summary,
       several groups) and on a posting from a provider with no mark, confirming the
       caption line degrades to text alone.

--- a/openspec/changes/apply-form-effort-groups/tasks.md
+++ b/openspec/changes/apply-form-effort-groups/tasks.md
@@ -1,0 +1,53 @@
+## 1. The grouping model
+
+- [x] 1.1 Write the failing test `web/src/lib/applyFormGroups.test.ts` covering the
+      partition: each `answer` value from the closed vocabulary lands in its group
+      (`""` and any unknown value in Short answers; `choose one` / `choose any` /
+      `yes / no` in Pick from a list; `written answer` in Written answers; `upload`
+      in Attachments), groups come back cheapest-first, and a group no question
+      falls into is absent from the result rather than present and empty.
+- [x] 1.2 Write `web/src/lib/applyFormGroups.ts` to pass it — a pure module, no
+      runes, no `$app/*` import, so the Node-only vitest config can load it.
+- [x] 1.3 Extend the test: within a group the questions keep the served order, and
+      each group carries its own count.
+- [x] 1.4 Extend the test: the summary figures — total questions, and the number
+      demanding a written answer — are derived from the same input, and the
+      written-answer figure is reported as absent (not zero) when none demand one.
+- [x] 1.5 Extend the test: the result says whether headings should render, false
+      when exactly one group is non-empty and false for an empty question list.
+
+## 2. The provider mark
+
+- [x] 2.1 Write the failing test `web/src/lib/atsmarks.test.ts`: `greenhouse`
+      resolves to a mark whose title is Greenhouse, and each of `ashby`,
+      `workable`, `lever`, `recruitee` and an unknown provider resolves to nothing
+      — asserting the absence deliberately, since silent partial coverage is the
+      behaviour being relied on.
+- [x] 2.2 Write `web/src/lib/atsmarks.ts` to pass it: a named map from provider slug
+      to a `simple-icons` mark, mirroring `web/src/lib/techmarks.ts`, carrying a
+      comment on why only one entry exists and what verified it (`siGreenhouse`'s
+      `source` is `brand.greenhouse.io/brand-portal`).
+
+## 3. The rendering
+
+- [ ] 3.1 Render the caption line in `JobApplyForm.svelte`: the provider's mark via
+      `BrandMark` where `atsmarks` knows one and nothing where it does not, the
+      provider's name, and the summary figures from `applyFormGroups`.
+- [ ] 3.2 Render the groups: a heading per group carrying its name and count, the
+      headings omitted entirely when the model says so, and the standard-fields
+      line kept as its own group so it is not orphaned once headings exist.
+- [ ] 3.3 Drop the per-question answer-kind hint, leaving `optional` alone on the
+      row; key each group's `{#each}` by index, and carry forward the comment
+      explaining why (the `each_key_duplicate` crash).
+- [ ] 3.4 Confirm `applyFormWorthShowing` and its exported contract are untouched,
+      since `JobView.svelte` gates the whole tab on it.
+
+## 4. Verification
+
+- [ ] 4.1 `pnpm --dir web test` green, `pnpm --dir web check` clean, eslint clean on
+      the touched files.
+- [ ] 4.2 `pnpm check:dead` — both new modules are imported, so neither reads as a
+      dead file.
+- [ ] 4.3 Look at the block in a browser on a Greenhouse posting (mark, summary,
+      several groups) and on a posting from a provider with no mark, confirming the
+      caption line degrades to text alone.

--- a/web/src/lib/applyFormGroups.test.ts
+++ b/web/src/lib/applyFormGroups.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+
+import { applyFormModel } from './applyFormGroups';
+import type { Question } from './generated/contracts';
+
+const ask = (text: string, answer?: string, required = true): Question => ({
+  text,
+  required,
+  ...(answer === undefined ? {} : { answer }),
+});
+
+describe('apply form groups', () => {
+  // The `answer` vocabulary is closed and lives in internal/ingest/applyform/display.go.
+  // Every word in it has to land somewhere, or a question silently vanishes from a
+  // block whose whole job is to say what the employer will ask.
+  it('sorts every answer kind in the served vocabulary into a group', () => {
+    const model = applyFormModel([
+      ask('Website', undefined),
+      ask('English level?', 'choose one'),
+      ask('Which stacks?', 'choose any'),
+      ask('Worked in fintech?', 'yes / no'),
+      ask('Why this role?', 'written answer'),
+      ask('Portfolio', 'upload'),
+    ]);
+
+    expect(model.groups.map((g) => [g.key, g.questions.map((q) => q.text)])).toEqual([
+      ['short', ['Website']],
+      ['choice', ['English level?', 'Which stacks?', 'Worked in fintech?']],
+      ['written', ['Why this role?']],
+      ['upload', ['Portfolio']],
+    ]);
+  });
+
+  // The order is the feature. A reader who meets the essays first has already been
+  // told the form is expensive before learning most of it is not.
+  it('runs the groups from the cheapest kind to the most expensive', () => {
+    const model = applyFormModel([
+      ask('Portfolio', 'upload'),
+      ask('Why this role?', 'written answer'),
+      ask('English level?', 'choose one'),
+      ask('Website', undefined),
+    ]);
+
+    expect(model.groups.map((g) => g.key)).toEqual(['short', 'choice', 'written', 'upload']);
+  });
+
+  // An empty group is not a group. Rendered, it would be a heading announcing
+  // nothing — worse than silence, because the reader stops to check.
+  it('omits a group no question falls into', () => {
+    const model = applyFormModel([ask('Why this role?', 'written answer')]);
+
+    expect(model.groups.map((g) => g.key)).toEqual(['written']);
+  });
+
+  // `display.go` withholds the word when it cannot normalize a control, and states
+  // why: an unqualified question is one anyone assumes is answerable in a line.
+  // Reading it as anything else would put a question the reader was never warned
+  // about under a heading promising cheap ones.
+  it('reads a question of unknown kind as answerable in a line', () => {
+    const model = applyFormModel([ask('Notice period', 'signature')]);
+
+    expect(model.groups.map((g) => [g.key, g.questions.map((q) => q.text)])).toEqual([
+      ['short', ['Notice period']],
+    ]);
+  });
+
+  it('has no groups when the form asks nothing', () => {
+    expect(applyFormModel([]).groups).toEqual([]);
+  });
+});
+
+describe('apply form summary', () => {
+  it('counts the questions and the written answers among them', () => {
+    const model = applyFormModel([
+      ask('Website', undefined),
+      ask('Why this role?', 'written answer'),
+      ask('Why us?', 'written answer'),
+    ]);
+
+    expect(model.total).toBe(3);
+    expect(model.written).toBe(2);
+  });
+
+  // Counted, not withheld. The rule that a zero is never PRINTED — "0 written
+  // answers" states a cost that does not exist — belongs to the page, which can
+  // ask `written` for it. A model returning undefined here would instead conflate
+  // "none demand one" with "we do not know", and only one of those is ever true.
+  it('counts no written answers when nothing demands one', () => {
+    const model = applyFormModel([ask('Website', undefined), ask('English?', 'choose one')]);
+
+    expect(model.total).toBe(2);
+    expect(model.written).toBe(0);
+  });
+});
+
+describe('apply form headings', () => {
+  it('heads the groups when there is more than one', () => {
+    const model = applyFormModel([ask('Website', undefined), ask('Why us?', 'written answer')]);
+
+    expect(model.headed).toBe(true);
+  });
+
+  // A lone heading reading "Written answers (5)" under a summary reading
+  // "5 questions · 5 written answers" says the same thing twice in two lines.
+  it('drops the headings when every question is of one kind', () => {
+    const model = applyFormModel([ask('Why us?', 'written answer'), ask('Why this role?', 'written answer')]);
+
+    expect(model.headed).toBe(false);
+  });
+
+  it('drops the headings when the form asks nothing', () => {
+    expect(applyFormModel([]).headed).toBe(false);
+  });
+});

--- a/web/src/lib/applyFormGroups.test.ts
+++ b/web/src/lib/applyFormGroups.test.ts
@@ -16,16 +16,18 @@ describe('apply form groups', () => {
   it('sorts every answer kind in the served vocabulary into a group', () => {
     const model = applyFormModel([
       ask('Website', undefined),
-      ask('English level?', 'choose one'),
+      // Deliberately counter-alphabetical, so a re-ordering regression cannot slip
+      // past by coincidence: the served order and any obvious sort disagree here.
+      ask('Zurich office?', 'choose one'),
       ask('Which stacks?', 'choose any'),
-      ask('Worked in fintech?', 'yes / no'),
+      ask('Any relocation?', 'yes / no'),
       ask('Why this role?', 'written answer'),
       ask('Portfolio', 'upload'),
     ]);
 
     expect(model.groups.map((g) => [g.key, g.questions.map((q) => q.text)])).toEqual([
       ['short', ['Website']],
-      ['choice', ['English level?', 'Which stacks?', 'Worked in fintech?']],
+      ['choice', ['Zurich office?', 'Which stacks?', 'Any relocation?']],
       ['written', ['Why this role?']],
       ['upload', ['Portfolio']],
     ]);
@@ -102,11 +104,33 @@ describe('apply form headings', () => {
 
   // A lone heading reading "Written answers (5)" under a summary reading
   // "5 questions · 5 written answers" says the same thing twice in two lines.
-  it('drops the headings when every question is of one kind', () => {
+  it('drops the lone heading when the summary already names the kind', () => {
     const model = applyFormModel([ask('Why us?', 'written answer'), ask('Why this role?', 'written answer')]);
 
     expect(model.headed).toBe(false);
   });
+
+  // Nothing was ever said about a one-line answer — display.go withholds the word
+  // on purpose — so a heading here would introduce a label, not preserve one.
+  it('drops the lone heading when there is no kind to name', () => {
+    const model = applyFormModel([ask('Website', undefined), ask('LinkedIn', undefined)]);
+
+    expect(model.headed).toBe(false);
+  });
+
+  // These two are the reason the collapse is not simply "one group, no heading".
+  // The rows used to carry `choose one` and `upload` themselves; that hint moved
+  // into the heading, so suppressing the heading would delete the fact outright —
+  // and the summary never mentions either kind. A form asking nothing but two work
+  // authorization dropdowns is an ordinary Greenhouse form, not a corner case.
+  it.each(['choose one', 'choose any', 'yes / no', 'upload'])(
+    'keeps the lone heading for %s, the only place that kind is stated',
+    (answer) => {
+      const model = applyFormModel([ask('Authorized to work?', answer)]);
+
+      expect(model.headed).toBe(true);
+    },
+  );
 
   it('drops the headings when the form asks nothing', () => {
     expect(applyFormModel([]).headed).toBe(false);

--- a/web/src/lib/applyFormGroups.ts
+++ b/web/src/lib/applyFormGroups.ts
@@ -1,0 +1,69 @@
+// What the job page reads out of a captured application form: the employer's
+// questions partitioned by what answering one costs, cheapest kind first.
+//
+// A plain module rather than a `$derived` inside JobApplyForm.svelte, because the
+// web suite runs in plain Node with no Svelte compilation (see vitest.config.ts):
+// logic written in a `.svelte` file is logic no test in this repo can reach, and
+// the counting and the collapse rules are exactly the parts worth pinning.
+import type { Question } from './generated/contracts';
+
+/** The kinds of answer a question can expect, ordered by what answering costs —
+ *  which is the order the groups are shown in, and the whole point of grouping. */
+const GROUP_ORDER = ['short', 'choice', 'written', 'upload'] as const;
+
+export type GroupKey = (typeof GROUP_ORDER)[number];
+
+/** Maps the served `answer` vocabulary onto the groups. The vocabulary is closed and
+ *  authored in internal/ingest/applyform/display.go; the empty string is a member of
+ *  it rather than a gap — that projection deliberately names no kind for a one-line
+ *  answer, since naming what everyone assumes is noise.
+ *
+ *  It also names no kind for a control it could not normalize, so an unrecognized
+ *  word resolves the same way an absent one does: to the assumption a reader makes
+ *  of any unqualified question. */
+const GROUP_BY_ANSWER: Record<string, GroupKey> = {
+  '': 'short',
+  'choose one': 'choice',
+  'choose any': 'choice',
+  'yes / no': 'choice',
+  'written answer': 'written',
+  upload: 'upload',
+};
+
+export interface QuestionGroup {
+  key: GroupKey;
+  questions: Question[];
+}
+
+export interface ApplyFormModel {
+  /** The non-empty groups, cheapest kind first. */
+  groups: QuestionGroup[];
+  /** How many questions the employer asks. */
+  total: number;
+  /** How many of them demand a written answer — the figure that decides whether
+   *  applying costs a minute or an evening. A zero is counted honestly here and
+   *  simply not printed; withholding it would say "we do not know" instead. */
+  written: number;
+  /** Whether the groups are worth heading. One group needs no heading: it would
+   *  only repeat the summary standing directly above it. */
+  headed: boolean;
+}
+
+const groupOf = (question: Question): GroupKey => GROUP_BY_ANSWER[question.answer ?? ''] ?? 'short';
+
+export function applyFormModel(questions: Question[]): ApplyFormModel {
+  // Walked once per group rather than bucketed in one pass: the order of the groups
+  // and the order within each of them both fall out of the walk, and a form holds a
+  // few dozen questions at most.
+  const groups = GROUP_ORDER.map((key) => ({
+    key,
+    questions: questions.filter((question) => groupOf(question) === key),
+  })).filter((group) => group.questions.length > 0);
+
+  return {
+    groups,
+    total: questions.length,
+    written: groups.find((group) => group.key === 'written')?.questions.length ?? 0,
+    headed: groups.length > 1,
+  };
+}

--- a/web/src/lib/applyFormGroups.ts
+++ b/web/src/lib/applyFormGroups.ts
@@ -30,7 +30,9 @@ const GROUP_BY_ANSWER: Record<string, GroupKey> = {
   upload: 'upload',
 };
 
-export interface QuestionGroup {
+/** Not exported: nothing outside needs to name it. A caller reaches a group through
+ *  `ApplyFormModel.groups` and gets the same type structurally. */
+interface QuestionGroup {
   key: GroupKey;
   questions: Question[];
 }
@@ -44,10 +46,19 @@ export interface ApplyFormModel {
    *  applying costs a minute or an evening. A zero is counted honestly here and
    *  simply not printed; withholding it would say "we do not know" instead. */
   written: number;
-  /** Whether the groups are worth heading. One group needs no heading: it would
-   *  only repeat the summary standing directly above it. */
+  /** Whether the groups are worth heading. */
   headed: boolean;
 }
+
+/** The kinds a lone group needs no heading for, because the heading would be the
+ *  second place the kind is named rather than the only one: `written` is already
+ *  counted in the summary above, and `short` was never named anywhere — display.go
+ *  withholds the word for a one-line answer on purpose.
+ *
+ *  Every other kind is named ONLY by its heading, since the hint that used to sit on
+ *  each row moved there. Suppressing it would delete the fact, and a form asking
+ *  nothing but two work-authorization dropdowns is an ordinary form to be handed. */
+const NEEDS_NO_HEADING: readonly GroupKey[] = ['short', 'written'];
 
 const groupOf = (question: Question): GroupKey => GROUP_BY_ANSWER[question.answer ?? ''] ?? 'short';
 
@@ -60,10 +71,12 @@ export function applyFormModel(questions: Question[]): ApplyFormModel {
     questions: questions.filter((question) => groupOf(question) === key),
   })).filter((group) => group.questions.length > 0);
 
+  const [only] = groups;
+
   return {
     groups,
     total: questions.length,
     written: groups.find((group) => group.key === 'written')?.questions.length ?? 0,
-    headed: groups.length > 1,
+    headed: groups.length > 1 || (only !== undefined && !NEEDS_NO_HEADING.includes(only.key)),
   };
 }

--- a/web/src/lib/atsmarks.test.ts
+++ b/web/src/lib/atsmarks.test.ts
@@ -8,7 +8,10 @@ describe('ATS brand marks', () => {
 
     expect(mark?.title).toBe('Greenhouse');
     expect(mark?.path).toBeTruthy();
-    expect(mark?.hex).toBe('24A47F');
+    // Shape, not value. The exact hex is Greenhouse's to change, and simple-icons
+    // follows a rebrand — pinning it would redden this on a dependency bump over
+    // something that is not our behaviour. What matters is that BrandMark can use it.
+    expect(mark?.hex).toMatch(/^[0-9A-F]{6}$/);
   });
 
   // Asserted rather than left implicit. The caption puts the mark BESIDE the

--- a/web/src/lib/atsmarks.test.ts
+++ b/web/src/lib/atsmarks.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { ATS_MARKS } from './atsmarks';
+
+describe('ATS brand marks', () => {
+  it('carries the Greenhouse mark, drawable and named', () => {
+    const mark = ATS_MARKS.greenhouse;
+
+    expect(mark?.title).toBe('Greenhouse');
+    expect(mark?.path).toBeTruthy();
+    expect(mark?.hex).toBe('24A47F');
+  });
+
+  // Asserted rather than left implicit. The caption puts the mark BESIDE the
+  // provider's name precisely because four of the five platforms we capture have
+  // none, and a change that quietly added a wrong mark for one of them would
+  // otherwise look like coverage improving.
+  it.each(['ashby', 'workable', 'lever', 'recruitee'])('knows no mark for %s', (provider) => {
+    expect(ATS_MARKS[provider]).toBeUndefined();
+  });
+
+  it('knows no mark for a platform it has never heard of', () => {
+    expect(ATS_MARKS.teamtailor).toBeUndefined();
+  });
+});

--- a/web/src/lib/atsmarks.ts
+++ b/web/src/lib/atsmarks.ts
@@ -1,0 +1,32 @@
+// Brand marks for the applicant-tracking systems whose application forms we
+// capture, keyed by the provider string the captured form carries. Mirrors
+// techmarks.ts — a flat, hand-maintained map to a verified source rather than an
+// auto-derived guess — and feeds the same `BrandMark` primitive.
+//
+// ONE entry, and that is the whole state of the art: `simple-icons` carries no
+// mark for Ashby, Workable, Lever or Recruitee. (`unilever` is a slug collision,
+// not Lever.) That is why the job page shows the mark BESIDE the provider's name
+// instead of in place of it — a block identified by its mark alone would name its
+// source on Greenhouse postings and leave it unnamed on the other four in five.
+//
+// `siGreenhouse` was checked to be the ATS rather than a same-named brand: its
+// `source` is https://brand.greenhouse.io/brand-portal/p/6. techmarks.ts records
+// three cases where an exact slug match resolved to the wrong identity (`elk`,
+// `hive`, `backbone`), so the source check is the bar here, not extra caution.
+// Anything added below gets the same check.
+//
+// simple-icons also REMOVES marks on a trademark request — it has already dropped
+// AWS, Java and C#. If Greenhouse ever goes the same way, the lookup returns
+// undefined and the caption degrades to text, which is the path four providers
+// already take. Nothing else needs to change.
+import { siGreenhouse } from 'simple-icons';
+
+export type AtsMark = {
+  title: string;
+  path: string;
+  hex: string;
+};
+
+export const ATS_MARKS: Record<string, AtsMark> = {
+  greenhouse: siGreenhouse,
+};

--- a/web/src/lib/components/JobApplyForm.svelte
+++ b/web/src/lib/components/JobApplyForm.svelte
@@ -21,50 +21,102 @@
   // Renders bare, with no card or heading of its own: it sits inside the job page's
   // tab panel, where the tab is the heading and a second one under it would say the
   // same thing twice.
+  import { BrandMark } from '$lib/ui';
+  import { applyFormModel, type GroupKey } from '$lib/applyFormGroups';
+  import { ATS_MARKS } from '$lib/atsmarks';
+
   let { form }: { form: Display | null } = $props();
+
+  // What each group of questions is called. Kept here rather than in the model: the
+  // model decides which questions belong together and in what order, which is logic
+  // worth testing; these are the words that decision is shown in.
+  const GROUP_LABELS: Record<GroupKey, string> = {
+    short: 'Short answers',
+    choice: 'Pick from a list',
+    written: 'Written answers',
+    upload: 'Attachments',
+  };
+
+  const model = $derived(applyFormModel(form?.questions ?? []));
+  const mark = $derived(ATS_MARKS[form?.provider ?? '']);
 </script>
 
 {#if applyFormWorthShowing(form)}
-  <section class="flex flex-col gap-3">
-    <!-- The provider is the whole caption here. It was a chip beside a heading before
-         this block moved into a tab; the tab now says what it is, so what is left worth
-         saying is whose form it is, verbatim from the ATS. -->
-    <p class="text-xs text-muted-foreground">
-      As published by <span class="capitalize">{form.provider}</span>
+  <section class="flex flex-col gap-4">
+    <!-- The caption says whose form this is and how much of it there is — the second
+         being the fact that decides whether anyone applies, and the one a flat list of
+         fifteen identical rows made the reader count for themselves.
+         The mark sits BESIDE the provider's name, never instead of it: simple-icons
+         carries one for Greenhouse and none for the other four platforms we capture
+         (see atsmarks.ts), so a mark-only caption would leave most postings unattributed. -->
+    <p class="flex items-center gap-1.5 text-xs text-muted-foreground">
+      {#if mark}
+        <BrandMark path={mark.path} hex={mark.hex} title={mark.title} class="size-3.5 shrink-0" />
+      {/if}
+      <span>
+        As published by <span class="capitalize">{form.provider}</span>
+        {#if model.total}
+          &middot; {model.total}
+          {model.total === 1 ? 'question' : 'questions'}
+          <!-- A zero is never printed. "0 written answers" states a cost that does not
+               exist; the model counts it honestly and the decision not to say it is here. -->
+          {#if model.written}
+            &middot; {model.written}
+            {model.written === 1 ? 'written answer' : 'written answers'}
+          {/if}
+        {/if}
+      </span>
     </p>
 
     {#if form.basics?.length}
       <!-- The controls every application demands, said once. Listed rather than dropped:
-           a form that does NOT want a CV is worth knowing too. -->
-      <p class="max-w-3xl text-sm text-muted-foreground">
-        {form.basics.join(', ')}
-      </p>
+           a form that does NOT want a CV is worth knowing too. Headed only when the
+           questions below are headed, so it is never the one labelled block on the page. -->
+      <div class="flex max-w-3xl flex-col gap-1">
+        {#if model.headed}
+          <h3 class="text-xs font-medium text-muted-foreground">Basics</h3>
+        {/if}
+        <p class="text-sm text-muted-foreground">{form.basics.join(', ')}</p>
+      </div>
     {/if}
 
-    {#if form.questions?.length}
-      <!-- The hint follows the question rather than being pinned to the right edge. On a
-           wide viewport that pinning left ~900px of empty space between a question and the
-           word describing its answer, which is a long way to travel to read one line. -->
-      <!-- Keyed on index, not on the question text. The text is the employer's, verbatim, and
-           real ATS forms repeat it — Greenhouse and Workable both publish the same screening
-           question twice on some postings. A duplicate key throws each_key_duplicate during
-           Svelte 5 hydration rather than warning, which took the whole job page down. The list
-           is inert (replaced wholesale when `form` changes, never reordered or filtered), so
-           position is a sound identity here. -->
-      <ul class="flex max-w-3xl flex-col gap-2">
-        {#each form.questions as question, i (i)}
-          <li class="text-sm">
-            <span>{question.text}</span>
-            {#if question.answer || !question.required}
-              <span class="ml-2 whitespace-nowrap text-xs text-muted-foreground">
-                {#if question.answer}{question.answer}{/if}
-                {#if question.answer && !question.required}&middot;{/if}
-                {#if !question.required}optional{/if}
-              </span>
-            {/if}
-          </li>
-        {/each}
-      </ul>
-    {/if}
+    <!-- Grouped by what answering one costs, cheapest first, so a reader meets the
+         one-line questions before the essays and can stop as soon as the form is more
+         than they will spend. The kind of answer is stated once by the heading instead
+         of once per row, which is what used to wrap onto a second line and read as a
+         list item of its own.
+         Ordering within a group is the employer's, as served. Between groups it is
+         ours — a deliberate trade, since the form is actually filled on the platform's
+         own site where the platform's order governs. -->
+    {#each model.groups as group (group.key)}
+      <div class="flex max-w-3xl flex-col gap-1">
+        {#if model.headed}
+          <h3 class="text-xs font-medium text-muted-foreground">
+            {GROUP_LABELS[group.key]} ({group.questions.length})
+          </h3>
+        {/if}
+        <!-- Keyed on index, not on the question text. The text is the employer's, verbatim, and
+             real ATS forms repeat it — Greenhouse and Workable both publish the same screening
+             question twice on some postings. A duplicate key throws each_key_duplicate during
+             Svelte 5 hydration rather than warning, which took the whole job page down. The list
+             is inert (rebuilt wholesale when `form` changes, never reordered or filtered in
+             place), so position is a sound identity here — in each group as it was in the one
+             list this replaced. -->
+        <ul class="flex flex-col gap-2">
+          {#each group.questions as question, i (i)}
+            <li class="text-sm">
+              <span>{question.text}</span>
+              <!-- The kind of answer is the heading's to say. What is left is whether the
+                   platform will take the application without one; a required question is
+                   the ordinary case and marking it would put a word on nearly every row
+                   to report that nothing unusual is true of it. -->
+              {#if !question.required}
+                <span class="ml-2 whitespace-nowrap text-xs text-muted-foreground">optional</span>
+              {/if}
+            </li>
+          {/each}
+        </ul>
+      </div>
+    {/each}
   </section>
 {/if}

--- a/web/src/lib/components/JobApplyForm.svelte
+++ b/web/src/lib/components/JobApplyForm.svelte
@@ -51,16 +51,20 @@
          (see atsmarks.ts), so a mark-only caption would leave most postings unattributed. -->
     <p class="flex items-center gap-1.5 text-xs text-muted-foreground">
       {#if mark}
-        <BrandMark path={mark.path} hex={mark.hex} title={mark.title} class="size-3.5 shrink-0" />
+        <!-- Hidden from the reader who is being read to: BrandMark labels itself with
+             the brand's name, which the sentence right beside it already says. -->
+        <span class="contents" aria-hidden="true">
+          <BrandMark path={mark.path} hex={mark.hex} title={mark.title} class="size-3.5 shrink-0" />
+        </span>
       {/if}
       <span>
         As published by <span class="capitalize">{form.provider}</span>
-        {#if model.total}
+        {#if model.total > 0}
           &middot; {model.total}
           {model.total === 1 ? 'question' : 'questions'}
           <!-- A zero is never printed. "0 written answers" states a cost that does not
                exist; the model counts it honestly and the decision not to say it is here. -->
-          {#if model.written}
+          {#if model.written > 0}
             &middot; {model.written}
             {model.written === 1 ? 'written answer' : 'written answers'}
           {/if}
@@ -74,7 +78,7 @@
            questions below are headed, so it is never the one labelled block on the page. -->
       <div class="flex max-w-3xl flex-col gap-1">
         {#if model.headed}
-          <h3 class="text-xs font-medium text-muted-foreground">Basics</h3>
+          <h2 class="text-xs font-medium text-muted-foreground">Basics</h2>
         {/if}
         <p class="text-sm text-muted-foreground">{form.basics.join(', ')}</p>
       </div>
@@ -91,9 +95,9 @@
     {#each model.groups as group (group.key)}
       <div class="flex max-w-3xl flex-col gap-1">
         {#if model.headed}
-          <h3 class="text-xs font-medium text-muted-foreground">
+          <h2 class="text-xs font-medium text-muted-foreground">
             {GROUP_LABELS[group.key]} ({group.questions.length})
-          </h3>
+          </h2>
         {/if}
         <!-- Keyed on index, not on the question text. The text is the employer's, verbatim, and
              real ATS forms repeat it — Greenhouse and Workable both publish the same screening


### PR DESCRIPTION
## Why

The application-form block already carried the fact that decides whether anyone applies — how much work the form is — and then hid it. Fifteen identical rows, with the answer-kind hint pinned to the end of each question, where a long question pushed it onto a second line and it read as a list item of its own.

## What changed

The caption states the form's size, and the questions are partitioned by what answering one costs — short answers, choices, written answers, attachments — cheapest first, so a reader meets the one-line questions before the essays and can stop as soon as the form is more than they will spend. The kind of answer moved into its group's heading, said once instead of once per row; what is left beside a question is whether it is optional.

Before / after, on the same posting:

| | |
|---|---|
| 15 rows, hint per row, hint wrapping | `As published by Greenhouse · 15 questions · 5 written answers`, then `Basics` / `Short answers (7)` / `Pick from a list (3)` / `Written answers (5)` |

The caption also carries the platform's brand mark, **beside** its name rather than instead of it: `simple-icons` has one for Greenhouse and none for Ashby, Workable, Lever or Recruitee, so a mark-only caption would leave four postings in five unattributed. The Greenhouse entry was checked to be the ATS and not a same-named brand — the same `source` check `techmarks.ts` records three failures of.

## Decisions worth a second look

**Nothing on the Go side moves.** `Display.Questions` is documented as the employer's own order and `openapi.yaml` is the contract other consumers read; reordering the array to suit one reader's layout would make that promise false for everybody. Grouping is derived in the web layer.

**Ordering within a group is the employer's; between groups it is ours.** A deliberate trade — the form is filled on the platform's own site, where the platform's order governs.

**The grouping is a plain module, not a rune in the component.** `web/vitest.config.ts` runs the suite in plain Node with no Svelte compilation, so logic left inside a `$derived` is logic no test in this repo can reach. The counting and the collapse rule are exactly the parts worth pinning.

**A lone group still earns its heading unless the kind is already known.** First pass suppressed the heading whenever one group held everything, which for a form of nothing but dropdowns deleted the kind outright — the caption says "6 questions" and nothing says they are answered by picking. Verified against a real Workable posting whose six employer questions are all yes/no. The collapse now applies only to `written` (counted in the summary) and `short` (never named anywhere, by design in `display.go`).

## Verification

- `pnpm --dir web test` — 122 files, 1397 tests, green
- `pnpm --dir web check` — 0 errors (33 warnings, all pre-existing)
- eslint + oxlint clean on the touched files
- Looked at in a browser against the prod API: a Greenhouse posting with all four groups and the mark, and a Workable posting with a single `yes / no` group and no mark

## Notes

- `design-system/scripts/adoption-baseline.json`: `BrandMark` 1 → 2. The ratchet fails in both directions, so recording the gain was required.
- OpenSpec change `apply-form-effort-groups` is included; the delta spec extends `apply-form-display`.
