### PR TITLE
Give a company page the same job count the catalogue has

### DIFF
--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -739,19 +739,6 @@
          first 32px — here, the "Filters" heading — for the whole scroll. The max-height
          is then what is left of the viewport, less the same 24px at the bottom. -->
     <div class="sticky top-20 flex max-h-[calc(100vh-6.5rem)] flex-col gap-4 overflow-y-auto">
-      {#if !standalone && jobs.status === 'ready'}
-        <!-- Company view: the (filtered) open-job count as the sidebar's lead stat.
-             The inline count above the list is hidden on desktop (shown only on
-             mobile, where there's no sidebar), so it lives here instead. -->
-        <div class="rounded-xl border border-border bg-card px-4 py-3">
-          <p class="text-3xl font-semibold leading-none tracking-tight tabular-nums">
-            {listTotal.toLocaleString()}
-          </p>
-          <p class="mt-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-            {listTotal === 1 ? 'open job' : 'open jobs'}
-          </p>
-        </div>
-      {/if}
       {@render sidebarTop?.()}
       <div class="rounded-xl border border-border bg-card p-4">
         <FilterSummary store={filters} exclude={excludeFacets} onOpen={() => (modalOpen = true)} canSave={standalone} />
@@ -764,7 +751,6 @@
       total={displayItems.length > 0 ? listTotal : null}
       unit={listTotal === 1 ? 'job' : 'jobs'}
       onSwipe={standalone ? openSwipe : undefined}
-      showDesktopTotal={standalone}
       controls={listControls}
     />
 

--- a/web/src/lib/components/ListToolbar.svelte
+++ b/web/src/lib/components/ListToolbar.svelte
@@ -12,25 +12,20 @@
   //
   // `total` is null until the list is ready (then the count appears); `unit` is the
   // already-pluralised noun ("jobs" / "companies"). `onSwipe` is optional — pass it only
-  // where a swipe deck exists (the standalone jobs list). `showDesktopTotal` is false when
-  // the desktop layout already surfaces the total elsewhere (the company page's sidebar
-  // stat), so the above-list line isn't shown twice; the mobile toolbar total is unaffected.
-  // `controls` is an optional slot for the list's own controls — however many the view
-  // passes (the jobs feed's sort and freshness selects; the company catalog's sort
-  // select) — rendered in the mobile toolbar and beside the desktop total. It shows even
-  // when `total` is null so the controls stay reachable while the list is empty or
-  // standing in a prompt.
+  // where a swipe deck exists (the standalone jobs list). `controls` is an optional slot
+  // for the list's own controls — however many the view passes (the jobs feed's sort and
+  // freshness selects; the company catalog's sort select) — rendered in the mobile toolbar
+  // and beside the desktop total. It shows even when `total` is null so the controls stay
+  // reachable while the list is empty or standing in a prompt.
   let {
     total,
     unit,
     onSwipe,
-    showDesktopTotal = true,
     controls,
   }: {
     total: number | null;
     unit: string;
     onSwipe?: () => void;
-    showDesktopTotal?: boolean;
     controls?: Snippet;
   } = $props();
 </script>
@@ -71,13 +66,11 @@
 </div>
 
 <!-- Desktop: the total (and any list controls) sit top-right above the list (filters
-     live in the sidebar). The two are gated INDEPENDENTLY: the total on `showDesktopTotal`
-     (a view that renders its own total elsewhere suppresses this one), the controls on
-     their own presence. Gating both on `showDesktopTotal` is what hid the controls
-     entirely on a company page, where the sidebar carries the count. -->
-{#if (showDesktopTotal && total !== null) || controls}
+     live in the sidebar). The two are gated INDEPENDENTLY — a list standing in a prompt
+     has no total but must keep its controls reachable. -->
+{#if total !== null || controls}
   <div class="mb-3 hidden items-center justify-end gap-3 md:flex">
-    {#if showDesktopTotal && total !== null}
+    {#if total !== null}
       <span class="text-sm text-muted-foreground" aria-live="polite">
         <span class="font-semibold tabular-nums text-foreground">{total.toLocaleString()}</span>
         {unit}


### PR DESCRIPTION
The count sat in a 3xl card in the left rail, labelled OPEN JOBS, while the
inline "N jobs" line every other list shows above its controls was suppressed
there by a `showDesktopTotal` flag. Two shapes for one number, and the loud
one was on the page where the number matters least — a company page is read
for the postings, not for how many there are.

Drop the card and let the shared toolbar carry the count, which retires the
flag with it (it existed only so the number would not appear twice).

Mobile is unchanged: the rail is `hidden md:block`, so a phone was already
reading the toolbar line.

## Verification

- `vitest run` — 121 files, 1385 tests, all pass.
- `svelte-check` — no new errors in the two touched files (the 12 in the repo
  are pre-existing, in `routes/+layout.svelte` and the discussion pages).
- Not viewed in a browser.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Job totals now appear in the desktop list toolbar whenever available, including in company views.
  * The open-job count has been removed from the company view sidebar to provide a more consistent location for job totals.
  * Mobile toolbar behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->