### PR TITLE
Put the figures where the argument is, and stop two panels sharing one header

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -68,13 +68,21 @@
   mask-image: radial-gradient(ellipse 90% 75% at 25% 0%, #000 18%, transparent 80%);
 }
 /* The centred variant, for a hero that is one thing in the middle of the screen
-   rather than a left column beside a visual — the homepage's search box. Everything
-   the grid IS (dot size, spacing, opacity, the --muted-foreground that carries it
-   through both themes) stays above; only where the dots gather moves. Pair it with
-   `dot-grid`, which still sets the positioning context. */
+   rather than a left column beside a visual — the homepage's search box.
+   Horizontally, and ONLY horizontally: the ellipse, its stops and its anchor to the
+   top of the section are the ones above, unchanged.
+
+   It first moved the anchor down to the middle of the section as well, which read
+   worse than the original on every screen: it put the densest dots directly behind
+   the heading and the search box — the one thing the mask exists to prevent — and
+   left the top of the page bare, so the page started empty and got busy as you read
+   down. Anchored at the top the texture is a sky that fades into the copy, which is
+   what /about does and why it looks settled.
+
+   Pair it with `dot-grid`, which still sets the positioning context. */
 .dot-grid-centred::before {
-  -webkit-mask-image: radial-gradient(ellipse 75% 65% at 50% 42%, #000 15%, transparent 78%);
-  mask-image: radial-gradient(ellipse 75% 65% at 50% 42%, #000 15%, transparent 78%);
+  -webkit-mask-image: radial-gradient(ellipse 90% 75% at 50% 0%, #000 18%, transparent 80%);
+  mask-image: radial-gradient(ellipse 90% 75% at 50% 0%, #000 18%, transparent 80%);
 }
 
 /* CLI promo strip: hidden before first paint for a visitor who already closed it.

--- a/web/src/lib/components/HeaderLocationFilter.svelte
+++ b/web/src/lib/components/HeaderLocationFilter.svelte
@@ -21,6 +21,7 @@
     store,
     counts = null,
     inferred = false,
+    onOpen,
   }: {
     variant?: 'jobs' | 'companies' | 'launcher';
     store?: FacetStore;
@@ -29,6 +30,13 @@
      *  out loud, because a visitor who did not pick this scope has no other way to
      *  tell a small catalogue from a filtered one. */
     inferred?: boolean;
+    /** Fired when this popover opens, so whoever hosts it can put its own panel away.
+     *
+     *  It has to be announced rather than inferred: this trigger lives INSIDE the
+     *  search box's own element, so the box's click-away handler reads a click here as
+     *  a click on itself and keeps its dropdown open — and the trigger stops the click
+     *  propagating anyway. Both panels then hang off the same header, overlapping. */
+    onOpen?: () => void;
   } = $props();
 
   let open = $state(false);
@@ -127,6 +135,7 @@
       // would otherwise immediately re-close the just-opened popover.
       e.stopPropagation();
       open = !open;
+      if (open) onOpen?.();
     }}
     class="flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
   >

--- a/web/src/lib/components/HeaderLocationFilter.svelte
+++ b/web/src/lib/components/HeaderLocationFilter.svelte
@@ -21,7 +21,7 @@
     store,
     counts = null,
     inferred = false,
-    onOpen,
+    open = $bindable(false),
   }: {
     variant?: 'jobs' | 'companies' | 'launcher';
     store?: FacetStore;
@@ -30,16 +30,18 @@
      *  out loud, because a visitor who did not pick this scope has no other way to
      *  tell a small catalogue from a filtered one. */
     inferred?: boolean;
-    /** Fired when this popover opens, so whoever hosts it can put its own panel away.
+    /** Whether the popover is showing. Bindable, because the box that hosts it needs
+     *  BOTH directions: it must put its own dropdown away when this opens, and put
+     *  this away when it is focused.
      *
-     *  It has to be announced rather than inferred: this trigger lives INSIDE the
-     *  search box's own element, so the box's click-away handler reads a click here as
-     *  a click on itself and keeps its dropdown open — and the trigger stops the click
-     *  propagating anyway. Both panels then hang off the same header, overlapping. */
-    onOpen?: () => void;
+     *  Neither can be inferred from a click. This trigger lives INSIDE the search box's
+     *  own element, so the box's click-away handler reads a click here as a click on
+     *  itself — and the trigger stops the click propagating anyway. The other way round
+     *  there is no click at all: `/` and Cmd+K focus the input from anywhere. Left to
+     *  themselves both panels hang off the same header, overlapping. */
+    open?: boolean;
   } = $props();
 
-  let open = $state(false);
   let root = $state<HTMLElement | null>(null);
 
   // Launcher has no persisted selection, so its trigger stays the neutral label.
@@ -135,7 +137,6 @@
       // would otherwise immediately re-close the just-opened popover.
       e.stopPropagation();
       open = !open;
-      if (open) onOpen?.();
     }}
     class="flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
   >

--- a/web/src/lib/components/HeaderMenu.svelte
+++ b/web/src/lib/components/HeaderMenu.svelte
@@ -18,7 +18,6 @@
     FileText,
     SquarePlus,
     ShieldCheck,
-    Info,
     LogOut,
     LogIn,
   } from '@lucide/svelte';
@@ -74,6 +73,10 @@
   // Primary destinations pinned to the very top of the menu. Jobs is the feed at
   // /jobs — the homepage is the landing page above it, reachable via the logo.
   const primaryLinks = [NAV.jobs, NAV.companies];
+
+  // About is rendered on its own at the foot of the list, so its glyph is lifted out
+  // of NAV here rather than spelled a second time.
+  const AboutIcon = NAV.about.icon;
 
   // The rest of the site. The two feature pages here are what the product DOES beyond
   // listing jobs, and until now nothing in this menu led to either of them — the
@@ -193,8 +196,10 @@
   <!-- Desktop bar order: GitHub stars, Discord, then the visitor's OWN two controls —
        the bell and profile/sign-in — then the menu button pinned to the far right. The
        bell used to sit ahead of the project's links, which put two icons about the site
-       between it and the account it notifies about. On mobile all of these collapse
-       into the drawer (below), leaving just the menu button here. -->
+       between it and the account it notifies about. On mobile the two about the site
+       collapse into the drawer (below) and the two that are the visitor's stay: the
+       bell is how they learn something happened, and it cannot be a tap deeper than
+       the menu that would tell them. -->
   <GithubStars class="hidden sm:inline-flex" />
 
   <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external Discord invite, not an internal route -->
@@ -339,9 +344,16 @@
         {/each}
 
         <!-- About sits at the very bottom of the link list, just before the
-             Sign in / Log out action (the marketing landing lives at /about). -->
-        <a href={resolve('/about')} role="menuitem" onclick={() => (open = false)} class={linkClass('/about')}>
-          <Info class="size-4 shrink-0" />
+             Sign in / Log out action (the marketing landing lives at /about). Read from
+             NAV like every other destination — spelled here it would be a second copy
+             of a page the header row already draws. -->
+        <a
+          href={resolve(NAV.about.href)}
+          role="menuitem"
+          onclick={() => (open = false)}
+          class={linkClass(NAV.about.href)}
+        >
+          <AboutIcon class="size-4 shrink-0" />
           About
         </a>
 

--- a/web/src/lib/components/HeaderMenu.svelte
+++ b/web/src/lib/components/HeaderMenu.svelte
@@ -29,6 +29,7 @@
   import { cn } from '$lib/ui';
   import BrandMark from './BrandMark.svelte';
   import GithubStars from './GithubStars.svelte';
+  import NotificationBell from './NotificationBell.svelte';
   import { ProviderIcon } from '$lib/ui';
   import { NAV } from '$lib/siteNav';
 
@@ -189,9 +190,11 @@
 {/snippet}
 
 <div class="relative flex items-center gap-1" bind:this={root}>
-  <!-- Desktop bar order: GitHub stars, Discord, then profile/sign-in (second to
-       last), then the menu button pinned to the far right. On mobile all of these
-       collapse into the drawer (below), leaving just the menu button here. -->
+  <!-- Desktop bar order: GitHub stars, Discord, then the visitor's OWN two controls —
+       the bell and profile/sign-in — then the menu button pinned to the far right. The
+       bell used to sit ahead of the project's links, which put two icons about the site
+       between it and the account it notifies about. On mobile all of these collapse
+       into the drawer (below), leaving just the menu button here. -->
   <GithubStars class="hidden sm:inline-flex" />
 
   <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external Discord invite, not an internal route -->
@@ -204,6 +207,8 @@
   >
     <ProviderIcon provider="discord" />
   </a>
+
+  <NotificationBell />
 
   <!-- Desktop only: profile (signed in) or sign-in (signed out) sits before the
        menu button. -->

--- a/web/src/lib/components/HeaderMenu.svelte
+++ b/web/src/lib/components/HeaderMenu.svelte
@@ -7,8 +7,6 @@
     X,
     Sun,
     Moon,
-    Briefcase,
-    Building2,
     CircleUser,
     Activity,
     ListChecks,
@@ -20,12 +18,6 @@
     FileText,
     SquarePlus,
     ShieldCheck,
-    Layers,
-    Wand,
-    Bell,
-    ChartColumn,
-    TrendingUp,
-    MessagesSquare,
     Info,
     LogOut,
     LogIn,
@@ -38,6 +30,7 @@
   import BrandMark from './BrandMark.svelte';
   import GithubStars from './GithubStars.svelte';
   import { ProviderIcon } from '$lib/ui';
+  import { NAV } from '$lib/siteNav';
 
   // Same invite link as the footer's socials row (Footer.svelte) — no shared
   // constant exists for it yet, so it's kept inline here like GITHUB_URL's
@@ -79,10 +72,7 @@
   // authenticated). Moderation is gated on the moderator role at render time.
   // Primary destinations pinned to the very top of the menu. Jobs is the feed at
   // /jobs — the homepage is the landing page above it, reachable via the logo.
-  const primaryLinks = [
-    { href: '/jobs', label: 'Jobs', icon: Briefcase },
-    { href: '/companies', label: 'Companies', icon: Building2 },
-  ] as const;
+  const primaryLinks = [NAV.jobs, NAV.companies];
 
   // The rest of the site. The two feature pages here are what the product DOES beyond
   // listing jobs, and until now nothing in this menu led to either of them — the
@@ -93,14 +83,19 @@
   // above. Those are the app; these are what it is for, and the divider between the
   // sections is what tells them apart — so the labels here name the subject
   // ("CV tailoring") rather than the tool.
+  // How it works leads this group rather than sitting beside /about at the bottom:
+  // /about is who publishes the site, this is how the thing in front of you works, and
+  // it is the answer a first-time visitor is looking for. The homepage header names it
+  // too, but only there and only above 640px — this is where it is always reachable.
   const navLinks = [
-    { href: '/collections', label: 'Collections', icon: Layers },
-    { href: '/features/tailor', label: 'CV tailoring', icon: Wand },
-    { href: '/features/notifications', label: 'Job notifications', icon: Bell },
-    { href: '/analytics', label: 'Analytics', icon: ChartColumn },
-    { href: '/trends', label: 'Trends', icon: TrendingUp },
-    { href: '/discussions', label: 'Discussions', icon: MessagesSquare },
-  ] as const;
+    NAV.collections,
+    NAV.howItWorks,
+    NAV.cvTailoring,
+    NAV.jobNotifications,
+    NAV.analytics,
+    NAV.trends,
+    NAV.discussions,
+  ];
 
   // Personal account items — what the signed-in user owns/reads, in the same order
   // as the account sidebar (Profile is rendered separately just above these, so the

--- a/web/src/lib/components/HeaderSearch.svelte
+++ b/web/src/lib/components/HeaderSearch.svelte
@@ -6,7 +6,7 @@
   import { LayoutGrid, Search, SlidersHorizontal, Tag, X } from '@lucide/svelte';
   import { api } from '$lib/api';
   import { browseQuery, planForSuggestion } from '$lib/browseTarget';
-  import { dropdownRows, namedCompanies } from '$lib/dropdownRows';
+  import { dropdownRows, namedCompanies, type DropdownRow } from '$lib/dropdownRows';
   import { companyLogoUrl } from '$lib/logo';
   import { EntityLogo } from '$lib/ui';
   import type { Job, CompanyListItem, ApiSuggestionPart, FacetCounts } from '$lib/types';
@@ -41,6 +41,7 @@
     size = 'header',
     autofocus = false,
     counts = null,
+    onOpenFilters,
   }: {
     placeholder: string;
     size?: 'header' | 'hero';
@@ -49,6 +50,11 @@
      *  the page before the visitor has decided to search, so the width check below is
      *  the feature rather than a fallback. */
     autofocus?: boolean;
+    /** A filter modal the HOST owns, for a page with no list of its own — the
+     *  homepage, where picking filters composes a search rather than narrowing a list.
+     *  Where a list IS registered its own modal wins, so this is never a second way to
+     *  open the same thing. */
+    onOpenFilters?: () => void;
     /** The category distribution behind the empty box, when the page has already
      *  measured it. Off a list page this is otherwise fetched here on first focus;
      *  a caller that server-rendered the same numbers passes them instead of making
@@ -174,7 +180,7 @@
   // The All-filters trigger: shown (with its active-filter badge) only on list pages
   // that published `openFilters`; the count getter is called inside this $derived so
   // the badge tracks the view's live filter state.
-  const filterTrigger = $derived(headerFilterTrigger(registered));
+  const filterTrigger = $derived(headerFilterTrigger(registered, onOpenFilters));
 
   // Roles and categories are jobs facets, so the companies list publishes no `suggest`
   // and this stays null there — the header never asks which page it is on.
@@ -346,6 +352,20 @@
     }
   }
 
+  /** The label above a section's first row, or null for a section that needs none.
+   *
+   *  An EMPTY box gets none. Its rows are the only thing in the panel — there is no
+   *  second section to tell them apart from — so the heading was a line of small caps
+   *  introducing a list nobody could confuse with anything. A typed box does have
+   *  neighbours (postings, companies), and there "Filter by" says what picking one of
+   *  these rows does rather than what it is. */
+  function sectionHeading(kind: DropdownRow['kind']): string | null {
+    if (kind === 'text') return null;
+    if (kind === 'job') return 'Jobs';
+    if (kind === 'company') return 'Companies';
+    return draft.text.trim() === '' ? null : 'Filter by';
+  }
+
   const rowClass = (active: boolean) =>
     cn(
       'flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors',
@@ -387,7 +407,11 @@
           // empty screen this is the only interactive thing, so it carries the weight
           // the header version borrows from the bar around it.
           'h-14 gap-3 rounded-2xl px-4 text-base shadow-lg shadow-foreground/5 sm:h-16 sm:px-5'
-        : 'h-11 gap-2 rounded-md px-3 text-sm',
+        : // 48px inside the bar's own 56px. The header height is `h-14` in eight other
+          // places (`top-14`, `top-20`, `PINNED_HEADER_TOP`, the full-bleed
+          // `calc(100dvh-3.5rem)`), so it is the field that grows into the bar rather
+          // than the bar that grows.
+          'h-12 gap-2 rounded-md px-3 text-sm',
     )}
   >
     <!-- List pages expose a filter scope: surface the Location quick-filter as a
@@ -406,6 +430,7 @@
       store={target.filterScope?.store}
       counts={target.filterScope?.counts() ?? null}
       inferred={target.filterScope?.inferred?.() ?? false}
+      onOpen={close}
     />
     <div class={cn('w-px shrink-0 bg-border', hero ? 'h-7' : 'h-5')}></div>
     <Search class={cn('shrink-0 text-muted-foreground', hero ? 'size-5' : 'size-4')} />
@@ -467,13 +492,14 @@
     {/if}
     <!-- All-filters trigger, mirroring the Location scope-prefix on the left: divided
          from the input and pinned to the right edge. Opens the active page's own filter
-         modal; the badge shows the active-filter count. Hidden where no list owns a
-         modal (launcher/listless pages register no `openFilters`). -->
-    {#if filterTrigger.visible}
+         modal — or, on a page with no list, the one its host handed us. The badge shows
+         the active-filter count, and only a list can have one. Hidden where neither
+         exists. -->
+    {#if filterTrigger.open}
       <div class="h-5 w-px shrink-0 bg-border"></div>
       <button
         type="button"
-        onclick={() => registered?.openFilters?.()}
+        onclick={filterTrigger.open}
         aria-label={filterTrigger.count > 0
           ? `Filters (${filterTrigger.count} active)`
           : 'Filters'}
@@ -511,17 +537,12 @@
       )}
     >
       {#each rows as row, i (row.key)}
-        {#if row.first && row.kind !== 'text'}
+        {@const heading = row.first ? sectionHeading(row.kind) : null}
+        {#if heading}
           <li
             class="px-3 pb-1 pt-2 text-xs font-medium uppercase tracking-wide text-muted-foreground"
           >
-            {#if row.kind === 'suggestion'}
-              {draft.text.trim() === '' ? 'Where to start' : 'Filter by'}
-            {:else if row.kind === 'job'}
-              Jobs
-            {:else}
-              Companies
-            {/if}
+            {heading}
           </li>
         {/if}
         <li role="option" id="role-suggestion-{i}" aria-selected={activeIndex === i}>

--- a/web/src/lib/components/HeaderSearch.svelte
+++ b/web/src/lib/components/HeaderSearch.svelte
@@ -78,6 +78,15 @@
   // Asked for, before the relevance filter takes its cut.
   const companiesFetch = 12;
 
+  /** The Location popover's own state, held here so the two panels can take turns:
+   *  the effect below puts this box's dropdown away when the popover opens, and every
+   *  path that focuses the input puts the popover away. */
+  let locationOpen = $state(false);
+
+  $effect(() => {
+    if (locationOpen) close();
+  });
+
   let inputEl = $state<HTMLInputElement | null>(null);
   let wrapEl = $state<HTMLDivElement | null>(null);
 
@@ -430,7 +439,7 @@
       store={target.filterScope?.store}
       counts={target.filterScope?.counts() ?? null}
       inferred={target.filterScope?.inferred?.() ?? false}
-      onOpen={close}
+      bind:open={locationOpen}
     />
     <div class={cn('w-px shrink-0 bg-border', hero ? 'h-7' : 'h-5')}></div>
     <Search class={cn('shrink-0 text-muted-foreground', hero ? 'size-5' : 'size-4')} />
@@ -452,6 +461,9 @@
         // Off a list page nothing has measured the catalogue for us, so the empty
         // box's starting points are fetched here — on the first focus, never on load.
         if (!registered) loadBrowseCounts();
+        // Reached without a click by `/` and Cmd+K, which is the case the popover's own
+        // click-away handler cannot see.
+        locationOpen = false;
         // Focus is the question "what can I put here", so it reopens the dropdown —
         // including after a click-away dismissed it, which would otherwise leave the
         // box permanently silent for the rest of the visit.

--- a/web/src/lib/components/HomeLandingView.svelte
+++ b/web/src/lib/components/HomeLandingView.svelte
@@ -4,6 +4,7 @@
   import { ArrowRight } from '@lucide/svelte';
   import FilterModal from './filters/FilterModal.svelte';
   import HeaderSearch from './HeaderSearch.svelte';
+  import { api } from '$lib/api';
   import { browseQuery, planForSuggestion } from '$lib/browseTarget';
   import type { ApplyPlan } from '$lib/apiSuggestions';
   import { countryLabel } from '$lib/facets';
@@ -129,6 +130,24 @@
    *  becomes the query the feed opens with. `seed` and `onApply` are the modal's own
    *  provisions for exactly this — the same pair the profile editor uses. */
   let filtersOpen = $state(false);
+
+  /** The distribution behind the modal's controls, recomputed as the selection moves.
+   *
+   *  Not optional decoration: a DYNAMIC facet — Skills, City, Job language, Source —
+   *  has no compiled option list at all. FacetSection builds its entire list from this
+   *  map (see its `def.dynamic` branch), so without it those four panes are empty
+   *  selects with nothing to pick. The page's own `counts` cannot serve: the SSR call
+   *  asks for `category` and `countries` alone, which is all the chips need.
+   *
+   *  `disjunctive` so each facet's numbers ignore its own selection — the same call
+   *  every other host of this modal makes. */
+  const stagedCounts = (params: URLSearchParams) =>
+    api.facetCounts(params, { disjunctive: true });
+
+  /** How many postings the staged selection would open, for the footer's Apply — read
+   *  off the same count call rather than a one-row search, the way /analytics does. */
+  const previewCount = (params: URLSearchParams) =>
+    api.facetCounts(params).then((c) => c.total);
 
   function searchWithFilters(staged: StagedFilters) {
     filtersOpen = false;
@@ -346,12 +365,14 @@
 
 <!-- Seeded empty and applied by navigating: see `searchWithFilters`. `savedSearches`
      is off — that tab manages the alerts a signed-in visitor saved from a list, and
-     this modal has no list behind it. `counts` is the same distribution the chips and
-     the dropdown read, so the numbers beside a facet here are the numbers beside it
-     everywhere else on the page. -->
+     this modal has no list behind it. `counts` seeds the controls before the first
+     staged fetch answers; `stagedCounts` is what keeps them right, and what gives the
+     dynamic facets any options at all. -->
 <FilterModal
   seed={emptyFilters()}
   {counts}
+  {stagedCounts}
+  {previewCount}
   open={filtersOpen}
   onClose={() => (filtersOpen = false)}
   applyLabel="Search jobs"

--- a/web/src/lib/components/HomeLandingView.svelte
+++ b/web/src/lib/components/HomeLandingView.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
+  import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { ArrowRight } from '@lucide/svelte';
+  import FilterModal from './filters/FilterModal.svelte';
   import HeaderSearch from './HeaderSearch.svelte';
   import { browseQuery, planForSuggestion } from '$lib/browseTarget';
   import type { ApplyPlan } from '$lib/apiSuggestions';
   import { countryLabel } from '$lib/facets';
+  import { emptyFilters, filtersToParams } from '$lib/facetModel';
+  import type { StagedFilters } from '$lib/stagedFilters.svelte';
   import { CLI_INSTALL, CLI_REPO } from '$lib/cliLinks';
   import { EXTENSION_CLAIMS, EXTENSION_STORE_URL } from '$lib/extensionLinks';
   import { starterSuggestions } from '$lib/suggestions';
@@ -117,6 +121,22 @@
     ].filter((f) => f !== null),
   );
 
+  /** The All-filters modal, hosted here rather than by a list — there is no list.
+   *
+   *  Everywhere else this modal NARROWS what is already on screen, so it writes into
+   *  that page's URL-synced store as you pick. Here it COMPOSES a search: it is seeded
+   *  empty, edits nothing, and its footer hands back the staged selection, which
+   *  becomes the query the feed opens with. `seed` and `onApply` are the modal's own
+   *  provisions for exactly this — the same pair the profile editor uses. */
+  let filtersOpen = $state(false);
+
+  function searchWithFilters(staged: StagedFilters) {
+    filtersOpen = false;
+    const query = filtersToParams(staged.value).toString();
+    // eslint-disable-next-line svelte/no-navigation-without-resolve -- query appended to a resolved path
+    void goto(query ? `${resolve('/jobs')}?${query}` : resolve('/jobs'));
+  }
+
   let copied = $state(false);
   let copyTimer: ReturnType<typeof setTimeout> | undefined;
   async function copyInstall() {
@@ -174,8 +194,9 @@
      there, so the box it centres would sit noticeably below the middle of the screen.
 
      `dot-grid` is the shared backdrop from app.css that every landing hero here wears.
-     `dot-grid-centred` (also in app.css) is its one variant: the same grid with its
-     mask moved to the middle, because this hero is not a left column beside a visual. -->
+     `dot-grid-centred` (also in app.css) is its one variant: the same grid, the same
+     fade from the top, moved to the horizontal centre because this hero is not a left
+     column beside a visual. -->
 <section
   class="dot-grid dot-grid-centred -mx-4 flex min-h-[calc(100svh-8rem)] flex-col items-center justify-center px-4 pb-16 pt-12"
 >
@@ -200,6 +221,7 @@
         size="hero"
         autofocus
         {counts}
+        onOpenFilters={() => (filtersOpen = true)}
       />
     </div>
 
@@ -320,3 +342,17 @@
     </div>
   </div>
 </section>
+
+<!-- Seeded empty and applied by navigating: see `searchWithFilters`. `savedSearches`
+     is off — that tab manages the alerts a signed-in visitor saved from a list, and
+     this modal has no list behind it. `counts` is the same distribution the chips and
+     the dropdown read, so the numbers beside a facet here are the numbers beside it
+     everywhere else on the page. -->
+<FilterModal
+  seed={emptyFilters()}
+  {counts}
+  open={filtersOpen}
+  onClose={() => (filtersOpen = false)}
+  applyLabel="Search jobs"
+  onApply={searchWithFilters}
+/>

--- a/web/src/lib/components/HomeLandingView.svelte
+++ b/web/src/lib/components/HomeLandingView.svelte
@@ -43,13 +43,13 @@
     scale: CatalogScale | null;
   } = $props();
 
-  /** How many category shortcuts to draw. The dropdown offers ten; eight fills two
-   *  tidy rows under the box on a laptop without the eye giving up on the second. */
-  const CHIP_LIMIT = 8;
-
-  /** How many countries to offer beside the crafts. Four is what fits on one line next
-   *  to "Remote" without the row wrapping on a laptop. */
-  const COUNTRY_CHIP_LIMIT = 4;
+  /** How many shortcuts each row draws. The dropdown offers ten crafts; six and three
+   *  are what fit on ONE line each at 1280px, measured rather than guessed — every chip
+   *  carries a six-digit count, so eight of them wrapped to three lines and pushed the
+   *  catalogue's own figures off the first screen. Those figures are the argument this
+   *  page makes; the shortcuts are a convenience, so the shortcuts give way. */
+  const CHIP_LIMIT = 6;
+  const COUNTRY_CHIP_LIMIT = 3;
 
   type Chip = { href: string; label: string; count?: number };
 
@@ -185,10 +185,11 @@
   </a>
 {/snippet}
 
-<!-- Hero. Not quite a full viewport: `-8rem` rather than the 3.5rem header alone, so
-     the strip below shows about a line at the fold. A landing whose first screen ends
-     exactly at the fold reads as the whole page, and nobody scrolls a page they have
-     already finished.
+<!-- Hero. Deliberately shorter than the viewport: `-19rem` is the 3.5rem header plus
+     the room the figures below need, so how big the catalogue is lands on the FIRST
+     screen rather than under it. The number is the argument — a stranger deciding
+     whether to type anything into the box is answering "does this place even have my
+     job", and making them scroll to find out asks them to trust it first.
 
      `svh` rather than `vh`: on mobile Safari `100vh` counts browser chrome that is not
      there, so the box it centres would sit noticeably below the middle of the screen.
@@ -198,9 +199,9 @@
      fade from the top, moved to the horizontal centre because this hero is not a left
      column beside a visual. -->
 <section
-  class="dot-grid dot-grid-centred -mx-4 flex min-h-[calc(100svh-8rem)] flex-col items-center justify-center px-4 pb-16 pt-12"
+  class="dot-grid dot-grid-centred -mx-4 flex min-h-[calc(100svh-19rem)] flex-col items-center justify-center px-4 pb-10 pt-10"
 >
-  <div class="flex w-full max-w-2xl flex-col items-center gap-8">
+  <div class="flex w-full max-w-2xl flex-col items-center gap-6">
     <!-- No mark or wordmark here: the header carries both, three centimetres above and
          on the same screen. Repeating them made the page introduce itself twice before
          it said anything. -->
@@ -243,9 +244,9 @@
        reads, so the two pages cannot quote numbers measured at different moments —
        and a figure the snapshot could not measure is dropped rather than shown as a
        zero. `tabular-nums` keeps the row from twitching as the counts move. -->
-  <section class="border-t border-border py-12 sm:py-16">
+  <section class="border-t border-border py-10">
     <SectionLabel text="the catalogue, today" />
-    <dl class="mt-8 grid grid-cols-2 gap-x-6 gap-y-8 sm:grid-cols-4">
+    <dl class="mt-6 grid grid-cols-2 gap-x-6 gap-y-6 sm:grid-cols-4">
       {#each figures as f (f.label)}
         <!-- `flex-col-reverse` so the number reads first and the label sits under it,
              while the DOM keeps the term before its description. The label is written
@@ -259,7 +260,7 @@
         </div>
       {/each}
     </dl>
-    <div class="mt-8">
+    <div class="mt-6">
       {@render onward(resolve('/open'), 'Every number, live, with the endpoint behind it')}
     </div>
   </section>

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -10,6 +10,7 @@
   import BrandMark from './BrandMark.svelte';
   import { safeRedirect } from '$lib/safeRedirect';
   import { isFullBleedRoute } from '$lib/shellLayout';
+  import { HEADER_LINKS } from '$lib/siteNav';
 
   // The header is three slots — logo | search | menu — identical on every
   // viewport. Nav links, the account items, the theme toggle, and the auth
@@ -32,16 +33,6 @@
   // The brand, the bell and the menu stay — sign-in has to remain reachable.
   const bareHeader = $derived(page.url.pathname === '/');
 
-  // What the freed slot carries instead. The three browse surfaces, which everywhere
-  // else are one tap down inside HeaderMenu — on the page whose entire content is a
-  // search box, the visitor who arrived to LOOK rather than to search has nowhere else
-  // to be told the catalogue can also be walked. Kept to three: this is the menu's own
-  // top, not a second navigation with its own opinions.
-  const browseLinks = [
-    { href: resolve('/jobs'), label: 'Jobs' },
-    { href: resolve('/companies'), label: 'Companies' },
-    { href: resolve('/collections'), label: 'Collections' },
-  ];
 
   // On the full-viewport surfaces (the agent, the tailor workspace) the page below runs
   // edge to edge under its own icon rail, so the header drops the centered `max-w-6xl`
@@ -117,12 +108,18 @@
          cap then hands the rest back to the side slots, which keeps it on the axis. -->
     <div class={['flex min-w-0 flex-1', fullBleed && 'max-w-3xl basis-3xl']}>
       {#if bareHeader}
-        <nav aria-label="Browse" class="flex items-center gap-4 sm:gap-6">
-          {#each browseLinks as link (link.href)}
-            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- every href in browseLinks is already a resolve() result; the rule cannot see through the array -->
+        <!-- Hidden below 640px, where five labels do not fit beside the brand and the
+             burger — and where the burger is a thumb away and lists every one of these
+             with the same glyph and a full label. Shrinking them to bare icons would
+             trade a legible row for five guesses. -->
+        <nav aria-label="Site" class="hidden items-center gap-5 sm:flex lg:gap-6">
+          {#each HEADER_LINKS as link (link.href)}
+            {@const Icon = link.icon}
+            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- HEADER_LINKS holds this site's own route paths; resolve() takes a literal, not a variable -->
             <a href={link.href}
-              class="whitespace-nowrap text-sm text-muted-foreground transition-colors hover:text-foreground"
+              class="flex items-center gap-1.5 whitespace-nowrap text-sm text-muted-foreground transition-colors hover:text-foreground"
             >
+              <Icon class="size-4 shrink-0" aria-hidden="true" />
               {link.label}
             </a>
           {/each}

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -33,7 +33,6 @@
   // The brand, the bell and the menu stay — sign-in has to remain reachable.
   const bareHeader = $derived(page.url.pathname === '/');
 
-
   // On the full-viewport surfaces (the agent, the tailor workspace) the page below runs
   // edge to edge under its own icon rail, so the header drops the centered `max-w-6xl`
   // and does the same: brand hard left, menu hard right. The search keeps a readable
@@ -113,6 +112,10 @@
              with the same glyph and a full label. Shrinking them to bare icons would
              trade a legible row for five guesses. -->
         <nav aria-label="Site" class="hidden items-center gap-5 sm:flex lg:gap-6">
+          <!-- Divides the nav from the wordmark, the same rule the search box draws
+               between its Location scope and the field. Without it the first link sat
+               one word-gap from "freehire" and read as part of it. -->
+          <div aria-hidden="true" class="h-5 w-px shrink-0 bg-border"></div>
           {#each HEADER_LINKS as link (link.href)}
             {@const Icon = link.icon}
             <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- HEADER_LINKS holds this site's own route paths; resolve() takes a literal, not a variable -->

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -6,7 +6,6 @@
   import AuthDialog from './AuthDialog.svelte';
   import HeaderSearch from './HeaderSearch.svelte';
   import HeaderMenu from './HeaderMenu.svelte';
-  import NotificationBell from './NotificationBell.svelte';
   import BrandMark from './BrandMark.svelte';
   import { safeRedirect } from '$lib/safeRedirect';
   import { isFullBleedRoute } from '$lib/shellLayout';
@@ -134,8 +133,9 @@
       {/if}
     </div>
 
+    <!-- One cluster, not two: the bell lives inside HeaderMenu beside the profile it
+         notifies about, so this slot is just the menu. -->
     <div class={['flex shrink-0 items-center gap-1', fullBleed && 'flex-1 basis-0 justify-end']}>
-      <NotificationBell />
       <HeaderMenu />
     </div>
   </div>

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -29,7 +29,8 @@
   // The homepage is the one exception: its whole content is a large centred copy of
   // this same box, so the header renders none. Two identical fields on one screen make
   // the visitor choose between them for no reason, and the hero is the focused one.
-  // The brand, the bell and the menu stay — sign-in has to remain reachable.
+  // The brand and the menu stay — sign-in and notifications live in the menu's own
+  // control strip, and both have to remain reachable.
   const bareHeader = $derived(page.url.pathname === '/');
 
   // On the full-viewport surfaces (the agent, the tailor workspace) the page below runs
@@ -117,8 +118,8 @@
           <div aria-hidden="true" class="h-5 w-px shrink-0 bg-border"></div>
           {#each HEADER_LINKS as link (link.href)}
             {@const Icon = link.icon}
-            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- HEADER_LINKS holds this site's own route paths; resolve() takes a literal, not a variable -->
-            <a href={link.href}
+            <a
+              href={resolve(link.href)}
               class="flex items-center gap-1.5 whitespace-nowrap text-sm text-muted-foreground transition-colors hover:text-foreground"
             >
               <Icon class="size-4 shrink-0" aria-hidden="true" />

--- a/web/src/lib/headerFilterTrigger.test.ts
+++ b/web/src/lib/headerFilterTrigger.test.ts
@@ -10,21 +10,37 @@ function target(over: Partial<ListSearchTarget> = {}): ListSearchTarget {
 }
 
 describe('headerFilterTrigger', () => {
-  it('is hidden when there is no target (launcher/listless page)', () => {
-    expect(headerFilterTrigger(null)).toEqual({ visible: false, count: 0 });
+  it('has nothing to open with no target and no host modal', () => {
+    expect(headerFilterTrigger(null)).toEqual({ count: 0 });
   });
 
-  it('is hidden when the target owns no filter modal', () => {
-    expect(headerFilterTrigger(target())).toEqual({ visible: false, count: 0 });
+  it('has nothing to open when the target owns no filter modal', () => {
+    expect(headerFilterTrigger(target())).toEqual({ count: 0 });
   });
 
-  it('is visible with the active-filter count when the target exposes openFilters', () => {
-    const t = target({ openFilters: () => {}, activeFilters: () => 2 });
-    expect(headerFilterTrigger(t)).toEqual({ visible: true, count: 2 });
+  it("opens the list's modal, with its active-filter count", () => {
+    const openFilters = () => {};
+    const t = target({ openFilters, activeFilters: () => 2 });
+    expect(headerFilterTrigger(t)).toEqual({ open: openFilters, count: 2 });
   });
 
   it('defaults the badge count to 0 when activeFilters is absent', () => {
     const t = target({ openFilters: () => {} });
-    expect(headerFilterTrigger(t)).toEqual({ visible: true, count: 0 });
+    expect(headerFilterTrigger(t).count).toBe(0);
+  });
+
+  it("opens the host's modal on a page with no list, with no badge", () => {
+    const hostOpener = () => {};
+    expect(headerFilterTrigger(null, hostOpener)).toEqual({ open: hostOpener, count: 0 });
+  });
+
+  it("prefers the list's modal over the host's", () => {
+    // Both filter, but only one filters what is on screen. The control looks identical
+    // either way, so the wrong choice here is invisible until someone picks a facet and
+    // the list under it does not move.
+    const openFilters = () => {};
+    const hostOpener = () => {};
+    const t = target({ openFilters, activeFilters: () => 3 });
+    expect(headerFilterTrigger(t, hostOpener)).toEqual({ open: openFilters, count: 3 });
   });
 });

--- a/web/src/lib/headerFilterTrigger.ts
+++ b/web/src/lib/headerFilterTrigger.ts
@@ -1,18 +1,31 @@
 import type { ListSearchTarget } from './listSearch.svelte';
 
-// Derives whether the header search box should host the All-filters trigger, and its
-// badge count, from the active list-search target. Kept as a pure function (not inline
-// in HeaderListSearch) so the visibility gate and badge count are unit-testable without
-// a Svelte/rune runtime — the template just renders this. The trigger shows only where a
-// page owns a filter modal (it published `openFilters`); the launcher and listless pages
-// register no such target, so no trigger appears.
+// Derives whether the header search box should host the All-filters trigger, what it
+// opens, and its badge count. Kept as a pure function (not inline in the component) so
+// the gate, the precedence and the count are unit-testable without a Svelte/rune
+// runtime — the template just renders this.
 
 export interface HeaderFilterTrigger {
-  visible: boolean;
+  /** What the trigger opens, or undefined when there is nothing to open — which is the
+   *  same thing as "do not render it". One field rather than a `visible` flag beside
+   *  it: two could disagree, and only one of them can be acted on. */
+  open?: () => void;
+  /** How many filters are applied behind the box. Only a list can have any. */
   count: number;
 }
 
-export function headerFilterTrigger(target: ListSearchTarget | null): HeaderFilterTrigger {
-  if (!target?.openFilters) return { visible: false, count: 0 };
-  return { visible: true, count: target.activeFilters?.() ?? 0 };
+export function headerFilterTrigger(
+  target: ListSearchTarget | null,
+  /** A modal offered by whoever renders the box, for a page with no list to filter —
+   *  the homepage, whose modal composes a search rather than narrowing one. */
+  hostOpener?: () => void,
+): HeaderFilterTrigger {
+  // The list's own modal wins: it filters what is on screen, while the host's composes
+  // a search for somewhere else. A page that has both would otherwise offer the wrong
+  // one from a control that looks identical.
+  if (target?.openFilters) return { open: target.openFilters, count: target.activeFilters?.() ?? 0 };
+  // Nothing is applied yet on a listless page, so the badge stays off — a count of zero
+  // and "no count" render the same, and there is no list behind it to have filtered.
+  if (hostOpener) return { open: hostOpener, count: 0 };
+  return { count: 0 };
 }

--- a/web/src/lib/siteNav.ts
+++ b/web/src/lib/siteNav.ts
@@ -2,9 +2,10 @@
 //
 // Two navigations lead to them: the menu behind the header's burger (HeaderMenu),
 // which lists all of them, and the homepage header's own row (TopBar), which on that
-// one route stands in for the search box and shows a subset. Before this module they
-// were two arrays, and they had already drifted — the menu's "Jobs" still pointed at
-// `/` after the feed moved to `/jobs`, and nothing said so.
+// one route stands in for the search box and shows a subset. They were two arrays, and
+// the last time a destination moved — the feed, from `/` to `/jobs` — the menu's copy
+// went on pointing at the old one until someone read both lists side by side. One list
+// is how that stops being possible.
 //
 // A destination carries its own glyph, the way accountNavIcons pairs one to each
 // account section, so the two navigations cannot draw the same page with different
@@ -59,11 +60,7 @@ export const NAV = {
  *
  *  Five, and no more: this is a shortcut to the menu's own top, not a second
  *  navigation with its own opinions about what matters. Three ways into the catalogue
- *  and two ways to find out what this is.
- *
- *  The whole row stands down below 640px, where five labels do not fit beside the
- *  brand and the burger — and where the burger is a thumb away and lists every one of
- *  these with the same glyph and a full label. */
+ *  and two ways to find out what this is. TopBar decides when the row is drawn. */
 export const HEADER_LINKS = [
   NAV.jobs,
   NAV.companies,

--- a/web/src/lib/siteNav.ts
+++ b/web/src/lib/siteNav.ts
@@ -1,0 +1,73 @@
+// The site's top-level destinations, named once.
+//
+// Two navigations lead to them: the menu behind the header's burger (HeaderMenu),
+// which lists all of them, and the homepage header's own row (TopBar), which on that
+// one route stands in for the search box and shows a subset. Before this module they
+// were two arrays, and they had already drifted — the menu's "Jobs" still pointed at
+// `/` after the feed moved to `/jobs`, and nothing said so.
+//
+// A destination carries its own glyph, the way accountNavIcons pairs one to each
+// account section, so the two navigations cannot draw the same page with different
+// marks.
+
+import {
+  Bell,
+  Briefcase,
+  Building2,
+  ChartColumn,
+  Compass,
+  Info,
+  Layers,
+  MessagesSquare,
+  TrendingUp,
+  Wand,
+} from '@lucide/svelte';
+import type { LucideIcon } from '@lucide/svelte';
+import type { Pathname } from '$app/types';
+
+export type SiteNavItem = {
+  /** SvelteKit's own union of this app's route paths, not a string — so a destination
+   *  that stops existing, or was never spelled right, is a compile error rather than a
+   *  link that 404s. `satisfies` below checks each entry against it while keeping the
+   *  literal `resolve()` needs. */
+  href: Pathname;
+  label: string;
+  icon: LucideIcon;
+};
+
+export const NAV = {
+  // The catalogue itself — what a visitor came to walk.
+  jobs: { href: '/jobs', label: 'Jobs', icon: Briefcase },
+  companies: { href: '/companies', label: 'Companies', icon: Building2 },
+  collections: { href: '/collections', label: 'Collections', icon: Layers },
+
+  // What this is and how it works — what a first-time visitor reads.
+  howItWorks: { href: '/how-it-works', label: 'How it works', icon: Compass },
+  about: { href: '/about', label: 'About', icon: Info },
+
+  // What the product does beyond listing jobs.
+  cvTailoring: { href: '/features/tailor', label: 'CV tailoring', icon: Wand },
+  jobNotifications: { href: '/features/notifications', label: 'Job notifications', icon: Bell },
+
+  // What the catalogue says about the market.
+  analytics: { href: '/analytics', label: 'Analytics', icon: ChartColumn },
+  trends: { href: '/trends', label: 'Trends', icon: TrendingUp },
+  discussions: { href: '/discussions', label: 'Discussions', icon: MessagesSquare },
+} as const satisfies Record<string, SiteNavItem>;
+
+/** What the homepage header shows where every other page shows the search box.
+ *
+ *  Five, and no more: this is a shortcut to the menu's own top, not a second
+ *  navigation with its own opinions about what matters. Three ways into the catalogue
+ *  and two ways to find out what this is.
+ *
+ *  The whole row stands down below 640px, where five labels do not fit beside the
+ *  brand and the burger — and where the burger is a thumb away and lists every one of
+ *  these with the same glyph and a full label. */
+export const HEADER_LINKS = [
+  NAV.jobs,
+  NAV.companies,
+  NAV.collections,
+  NAV.howItWorks,
+  NAV.about,
+] as const;


### PR DESCRIPTION
Follow-up to #2396, all of it visual polish on the homepage the previous PR shipped, plus two real defects found reviewing it.

## The dots

The homepage's grid took `/about`'s mask instead of its own. Anchored at the middle of the section it put the densest dots directly behind the heading and the search box — the one thing the mask exists to prevent — and left the top bare, so the page started empty and got busy as you read down. It is now the shared `.dot-grid` with exactly one value changed: the horizontal origin.

## The header

`How it works` and `About` join the row, and every link gains the glyph the menu already draws it with. That meant the two navigations had to stop being two arrays: `$lib/siteNav` names each destination once — path, label, mark — and both read from it. The path is SvelteKit's `Pathname`, not a string, so a destination that stops existing is a compile error. When the feed moved from `/` to `/jobs`, the menu's copy went on pointing at the old one until someone read both lists side by side.

A rule divides the links from the wordmark — the one the search box already draws between its Location scope and the field. Without it "freehire Jobs" read as one phrase.

The row is `hidden sm:flex`. Five labels do not fit beside the brand and the burger, and bare icons would trade a legible row for five guesses; the burger is a thumb away and lists all of them with labels.

The bell moves next to the profile. The header's right edge is two things — what the project is (GitHub, Discord) and what the visitor has (notifications, their account) — and the bell sat ahead of both project links.

## The search box

- The empty dropdown loses its "Where to start" heading: its rows are the only thing in the panel. A typed box keeps "Filter by", where postings and companies are neighbours.
- The field grows 44px → 48px inside the bar's own 56px. The bar does not: `h-14` is baked into eight other places, from `top-20` to `PINNED_HEADER_TOP`.
- **Opening the Location popover now closes the suggestions, and focusing the box closes the popover.** Neither could be inferred from a click: the popover's trigger lives *inside* the box's own element, so the box's click-away handler read a click on it as a click on itself — and `/` and Cmd+K focus the box with no click at all. Both panels hung off the same header, overlapping.
- The hero box gains the All-filters trigger. Everywhere else that modal narrows what is on screen; here it composes a search, seeded empty, applied by opening the feed with what was picked. Which modal a trigger opens is decided in `headerFilterTrigger` and tested there — that precedence used to live in a template expression nothing could fail on.

## The figures, on the first screen

How big the catalogue is is the argument this page makes, and it sat under the fold. The hero stops reserving the screen (`100svh-19rem`).

The height was not the problem, though. A screenshot was: every chip carries a six-digit count, so eight crafts wrapped to three lines and four countries to two, and five rows of shortcuts pushed the figures off. Six and three each fit one line. The comment above them claimed "two tidy rows" while rendering three — it now names the width it was measured at.

**This removes five visible shortcuts nobody asked to remove.** It is the trade that puts the figures above the fold; say so if it is the wrong one.

## Two defects the review caught

**The homepage's filter modal opened onto empty controls.** A dynamic facet — Skills, City, Job language, Source — has no compiled option list: `FacetSection` builds its whole list from the counts map it is handed. The page passed only its own SSR `counts`, which asks for `category` and `countries` because that is all the chips need. Four panes were a search box over nothing. It now supplies `stagedCounts`/`previewCount` like every other host.

**Four comments asserted things their own code disproved** — including this branch's own `siteNav.ts`, whose stated reason to exist named a bug the previous PR had already fixed, and an eslint-disable claiming `resolve()` cannot take a variable while `HeaderMenu` did exactly that three files away. The disable is gone and the href goes through `resolve()`.

## Verified

- `svelte-check` 0 errors, eslint clean, 1404 tests
- Screenshots at 1440×900, 1280×800 and 1366×768, with the CLI promo strip up: the label, all four figures and their captions are above the fold on every one
- The modal end to end in a browser: Skills lists 40+ options with counts, and picking Python → Search jobs lands on `/jobs?skills=python`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added homepage filtering with dynamic facet counts, result previews, and navigation to filtered job results.
  - Added “How it works” to the header navigation.
  - Added notifications access to the desktop header.
  - Added support for opening filter modals from the header search.

- **Improvements**
  - Improved coordination between location filters, search suggestions, and filter modals.
  - Updated homepage spacing, sizing, and dot-grid visuals.
  - Reduced homepage shortcut limits to six crafts and three countries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->