### PR TITLE
Build billing-sync, which a timer has been running from an older release

### DIFF
--- a/deploy/bin/release.sh
+++ b/deploy/bin/release.sh
@@ -196,7 +196,11 @@ if [ "$app" = freehire ]; then
   # never built: nudge, apple-revoke and auth-cleanup were six days old, capture-apply-form
   # sixteen. Their units were hand-installed on the box and never reached git either (#56) —
   # the same half-provisioned move, arriving here as a stale binary instead of a missing file.
-  for w in migrate onboarding broadcast ingest enrich embed similar-backfill search-drain reindex reindex-companies import-collections import-yc import-company-industries queue-metrics tg-ingest tg-extract liveness notify remind nudge apple-revoke auth-cleanup capture-apply-form backfill-derive backfill-company-names backfill-descriptions backfill-application-events backfill-slug-folded backfill-duplicate-marker-owner merge-companies harvest-orphans recount-companies rollup-stats rollup-facets build-suggestions rollup-company rollup-views classify-mail resolve-url gmail-sync cal-sync mail-ingest hydrate-adzuna-description seed-adzuna-description-queue; do
+  # billing-sync joined 2026-09-04, found the same way and by then eleven days stale. It is
+  # the one on this list a stale binary can cost money: the provider retries a webhook five
+  # times over ~2.5h and then stops for good, and past that window this worker is the only
+  # path by which a paid subscription becomes Pro.
+  for w in migrate onboarding broadcast ingest enrich embed similar-backfill search-drain reindex reindex-companies import-collections import-yc import-company-industries queue-metrics tg-ingest tg-extract liveness notify remind nudge apple-revoke auth-cleanup billing-sync capture-apply-form backfill-derive backfill-company-names backfill-descriptions backfill-application-events backfill-slug-folded backfill-duplicate-marker-owner merge-companies harvest-orphans recount-companies rollup-stats rollup-facets build-suggestions rollup-company rollup-views classify-mail resolve-url gmail-sync cal-sync mail-ingest hydrate-adzuna-description seed-adzuna-description-queue; do
     sudo -u freehire /usr/local/bin/go build -buildvcs=false -o "$w" "./cmd/$w"
   done
   # Every binary a freehire-*.service starts from hire-current has to have just been built,


### PR DESCRIPTION
`release.sh` names every worker it builds, and `freehire-billing-sync.timer` has been starting `billing-sync` from `hire-current` without it being on the list. The check directly below that list caught it on the 2026-09-04 release:

```
WARNING: a unit starts these from hire-current, but this release did not build them:
  billing-sync
  their timers are firing whatever an older release left.
```

By then the binary was eleven days old.

## Why this one matters more than freshness

It is the only worker on that list where a stale binary can cost money. The provider retries a webhook five times over ~2.5h and then stops for good; past that window `billing-sync` is the only path by which a paid subscription becomes Pro. A build that predates a change to how that is applied would go on applying the old rule, silently, to real payments.

Currently healthy — it runs hourly and reports `applied=0 refreshed=0 failed=0` — so this is a latent fault, not an outage.

## The mechanism worked

This is the fourth half-provisioned worker that warning has found, after `nudge`, `apple-revoke`, `auth-cleanup` and `capture-apply-form` in August. It is left as a warning rather than made fatal: a unit naming a *retired* worker is a normal state during a transition (#2406 has just removed one), and a fatal check would wedge the release path on it.

## Note for the host

`release.sh` lives on the box; this file does not reach it on its own. Copied to `/opt/freehire/bin/release.sh` alongside merging.

Verified with `shellcheck`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated release builds to include billing synchronization for the freehire app.
  * Improved reliability of paid subscription upgrades to Pro when webhook delivery is delayed or retried.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->