### PR TITLE
Read the statuses the way the data actually uses them

### DIFF
--- a/cmd/backfill-link-contributions/main.go
+++ b/cmd/backfill-link-contributions/main.go
@@ -16,6 +16,9 @@
 //
 //   - review    — an unclassified URL nobody has resolved into (provider, board). Goes to
 //     board_submissions, which is exactly that inbox.
+//
+// A refusal is not carried whether or not it was ever classified: 190 of the 204 on prod
+// are refused REVIEW rows, which keep a NULL source.
 //   - pending   — a recognized board waiting to be onboarded. Goes to boards at
 //     status='pending', which is crawled, so onboarding happens by itself.
 //   - onboarded — already a catalog row, but the YAML backfill carried no attribution, so
@@ -159,14 +162,15 @@ func run() int {
 			"catalog does not carry — they are boards nothing crawls, not history. "+
 			"Resolve them before dropping link_contributions.", orphaned)
 	}
-	if !*apply {
+	if *apply {
+		log.Printf("backfill-link-contributions: %d writable rows were already carried", already)
+	} else {
 		log.Print("backfill-link-contributions: dry run, nothing written. Re-run with --apply.")
-		return 0
 	}
-	log.Printf("backfill-link-contributions: %d writable rows were already carried", already)
 	// A row the run could not place is a per-item failure, and worker/AGENTS.md wants the
 	// exit code to say so: a partially-failed run that returns 0 looks successful to cron,
-	// and this one would be followed by a DROP.
+	// and this one would be followed by a DROP. It applies to the dry run too — that is
+	// the run whose whole job is to say whether the drop is safe yet.
 	if counts[unplaceable] > 0 || orphaned > 0 {
 		return 1
 	}
@@ -176,25 +180,34 @@ func run() int {
 // destinationOf classifies one contribution. It reads the row and nothing else, so the
 // rules below are testable without a database — which matters, because they are the part
 // a mistake would silently misplace data through.
+//
+// The status decides first, and only the two that name a board need one. That order is
+// what the real data forced: 190 of the 204 refusals carry a NULL source, because a
+// refusal during triage leaves an unclassified URL exactly as it was (migration 0037 made
+// the column nullable for that case). Checking for a board first read all 190 as
+// "needs a human" when a refusal is simply not carried, classified or not.
 func destinationOf(row db.ListLinkContributionsForBackfillRow) (destination, error) {
-	// 'review' is the only status the schema lets carry a NULL source, and its
-	// destination needs no board at all.
-	if row.Status == "review" {
-		return toSubmission, nil
-	}
-	if !row.Source.Valid || !row.Board.Valid || row.Source.String == "" || row.Board.String == "" {
-		// A recognized status with no board names nothing that can be carried. Counted
-		// rather than dropped silently: a nonzero here means the schema's own assumption
-		// no longer holds and the row needs a human.
-		return unplaceable, nil
-	}
 	switch row.Status {
-	case "onboarded":
-		return toAttribution, nil
-	case "pending":
-		return toPendingBoard, nil
+	case "review":
+		// Unclassified by definition — the partial unique index on (url) WHERE source IS
+		// NULL is what makes that the status's meaning.
+		return toSubmission, nil
 	case "rejected":
 		return dropRefusal, nil
+	case "onboarded", "pending":
+		// These two mean a board WAS recognized, so a missing provider contradicts the
+		// status itself. Counted rather than dropped silently: it needs a human.
+		if !row.Source.Valid || row.Source.String == "" {
+			return unplaceable, nil
+		}
+		// An empty board is NOT missing data: a boardless provider crawls one company's
+		// own API and has no board id (prod carries one such contribution, on amazon).
+		// boardcatalog.Validate is what knows which providers those are, so the decision
+		// is left to it rather than guessed here.
+		if row.Status == "onboarded" {
+			return toAttribution, nil
+		}
+		return toPendingBoard, nil
 	}
 	return "", fmt.Errorf("unknown status %q", row.Status)
 }

--- a/cmd/backfill-link-contributions/main_test.go
+++ b/cmd/backfill-link-contributions/main_test.go
@@ -31,10 +31,17 @@ func TestDestinationOf(t *testing.T) {
 		{"recognized, not yet onboarded", row("pending", "inhire", "onsign"), toPendingBoard},
 		{"already a catalog row", row("onboarded", "greenhouse", "acme"), toAttribution},
 		{"a curator's refusal", row("rejected", "lever", "deadco"), dropRefusal},
-		// 'review' is the only status the schema lets carry a NULL source. A recognized
-		// status that carries one anyway names nothing that can be carried.
-		{"recognized with a NULL source", row("pending", "", ""), unplaceable},
-		{"recognized with an empty board", row("onboarded", "greenhouse", ""), unplaceable},
+		// A refusal during triage leaves an unclassified URL exactly as it was, so 190 of
+		// the 204 refusals on prod carry a NULL source. A refusal is not carried either
+		// way — reading these as "needs a human" was the bug the prod dry run found.
+		{"a refused unclassified URL", row("rejected", "", ""), dropRefusal},
+		// An empty board is not missing data: a boardless provider crawls one company's
+		// own API and has no board id. Prod carries one such contribution, on amazon.
+		{"boardless provider, no board", row("onboarded", "amazon", ""), toAttribution},
+		// These two statuses mean a board WAS recognized, so a missing provider
+		// contradicts the status itself.
+		{"pending with no provider", row("pending", "", ""), unplaceable},
+		{"onboarded with no provider", row("onboarded", "", ""), unplaceable},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Follow-up to #2412, found by the **prod dry run before `--apply` ever ran**.

## What the dry run said

```
404 contributions
  26  submission
   2  pendingBoard
 171  attribution
  14  refusal
 191  NEEDS A HUMAN: a recognized status carrying no board
```

Expected 26 / 2 / 172 / 204 and **zero** unplaceable. Two rules were wrong, and neither shape occurs in any fixture — only real data could show them.

## 1. A refusal is a refusal, classified or not

190 of the 204 refusals carry a **NULL source**. A refusal during triage leaves an unclassified URL exactly as it was — which is what migration 0037 made the column nullable for.

`destinationOf` checked for a board *before* reading the status, so all 190 came out "needs a human". The status now decides first, and only the two destinations that actually name a board go looking for one.

## 2. An empty board is not missing data

The 191st was an `onboarded` contribution on `amazon` — a **boardless** provider. It crawls one company's own API and has no board id; its catalog row holds `board = ''`.

Which providers are boardless is `boardcatalog.Validate`'s to know, so the check is gone rather than guessed at here.

## 3. The dry run exited 0

...while reporting 191 unplaceable rows. That is the run whose whole job is to say whether the drop is safe yet, so it now carries the same nonzero exit the apply run does.

## Testing

Both shapes are in the table test, named after what prod showed. Unit + integration suites green, full build clean.

(#2414 was the same change; CI would not trigger on that branch — it carried pre-squash history — so it is reopened clean off main.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data migration accuracy by correctly routing refused contributions and board-related submissions based on their status.
  - Contributions missing required provider information are now clearly identified as unplaceable instead of being misclassified.
  - Dry-run results now report migration issues consistently and return an appropriate failure status when unresolved records remain.

- **Tests**
  - Expanded coverage for refused, boardless, and provider-less contribution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->