### PR TITLE
Split API traffic by the route it matched, not the path it asked for

### DIFF
--- a/internal/platform/observability/AGENTS.md
+++ b/internal/platform/observability/AGENTS.md
@@ -53,11 +53,36 @@ so the whole endpoint failed rather than degrading. `methodLabel` returns packag
 that share nothing with the request. It also bounds the label: the method is CLIENT-SUPPLIED, so
 an unbounded passthrough would let any caller mint series at will.
 
-**No route label, deliberately.** The app registers ~700 routes; route x status x method is tens
-of thousands of series on a single-target Prometheus. "Which endpoint" is already answered by the
-per-request log line. If a future need justifies the cardinality, add a SEPARATE metric scoped to
-5xx rather than widening this one — `TestHTTPMetricsLabelsAreBounded` fails if a path label
-creeps in.
+**No route label on THIS counter, deliberately.** The app registers ~700 routes; route x status x
+method is tens of thousands of series on a single-target Prometheus. Widening it is guarded by
+`TestHTTPMetricsLabelsAreBounded`, which fails if a path label creeps in. The route lives in a
+separate metric instead — below.
+
+## Per-route traffic
+
+`freehire_http_route_requests_total{route}` counts every response by the route PATTERN it matched,
+and by nothing else. It is the separate metric the paragraph above reserves: route alone is ~700
+series, which is affordable; route joined by a status or a method is not, and
+`TestRouteMetricLabelsAreBounded` fails if either arrives. The two metrics answer two questions —
+"is the error rate rising" is `freehire_http_requests_total`, "where is the traffic going" is this
+one. Counted from the same two places, for the same reason.
+
+**The label is the pattern, never the path.** `/api/v1/jobs/:id`, not
+`/api/v1/jobs/senior-go-engineer-42`. A pattern is a string the router built at registration, so
+it is bounded by the app rather than by the caller, and it shares nothing with the recycled request
+buffer — the two properties `methodLabel` has to construct by hand.
+
+**Both are lost for an unmatched request, which is the one case `routeLabel` guards.** Fiber's
+`Ctx.Route()` synthesises a `Route` when nothing matched, and its `Path` is `c.pathOriginal` — the
+caller's raw path, aliasing the request buffer. Passing that through would let any caller mint a
+series per request AND repeat the label corruption that answered `/metrics` with a 500 on
+2026-08-20. The synthetic route is identifiable by an empty `Handlers` slice (a registered route
+cannot have one; Fiber panics at registration), and those requests are counted as `unmatched`.
+A 404 that still passed a middleware lands on `/` instead, because Fiber leaves `c.route` at the
+last middleware that ran and `app.Use` registers at `/` — bounded and counted, just coarser.
+
+Grafana reads it as a top-K, since a full ~700-series legend is unreadable:
+`topk(15, sum by (route) (rate(freehire_http_route_requests_total[5m])))`.
 
 **This does not replace the site-alert watchdog and does not overlap it.** `site-alert.sh` polls
 a real endpoint every two minutes and pages to Telegram on two consecutive failures; it caught
@@ -65,6 +90,10 @@ the 2026-08-19 schema outage at 11:37 and paged at 11:39, which no scrape interv
 What a poll cannot see is a RATE — 0.5% of requests failing while the poll keeps succeeding.
 That is this counter's job, and the two answer different questions.
 
-**Not yet reachable on prod.** `METRICS_PORT` is unset there, and `StartMetricsServer` is a no-op
-without it, so `/metrics` is not served. Setting the port and scoping a firewall rule to the
-scraper is an ops change (`freehire-ops`), as is the alert rule itself.
+**Live on prod, scraped per colour.** `METRICS_PORT` is 9091 (blue) / 9092 (green) in
+`/opt/freehire/env/api-{blue,green}.env`, firewalled to the scraper at both ufw and the Hetzner
+firewall; `StartMetricsServer` is still a no-op without the port, so a local run serves nothing.
+Prometheus scrapes BOTH colours unconditionally with a `color` label — the standby slot simply
+reads `down`, which is how you tell which slot is cold. That is also why every dashboard query
+aggregates (`sum by (...)`) rather than reading a raw series: a release flips which colour carries
+the traffic. The scrape job, the firewall rules and the alert rules live in `freehire-ops`.

--- a/internal/platform/observability/httpmetrics.go
+++ b/internal/platform/observability/httpmetrics.go
@@ -28,6 +28,51 @@ var httpRequests = promauto.NewCounterVec(prometheus.CounterOpts{
 	Help: "API responses by method and HTTP status code.",
 }, []string{"method", "status"})
 
+// httpRouteRequests counts every response by the ROUTE PATTERN it matched, and by nothing else.
+//
+// This is the separate metric httpRequests' comment reserves rather than the route label it
+// refuses. Route ALONE is ~700 series; route x status x method is the tens of thousands that
+// counter exists to avoid, so the two questions stay in two metrics: "is the error rate rising"
+// is httpRequests, "where is the traffic going" is this one. Adding a second label here puts
+// the cardinality back and defeats the split — TestHTTPRouteMetricLabelsAreBounded says so.
+var httpRouteRequests = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "freehire_http_route_requests_total",
+	Help: "API responses by the route pattern they matched (not the request path).",
+}, []string{"route"})
+
+// unmatchedRoute is the label for a request no registered route claimed.
+//
+// It is a constant rather than the path the caller asked for, and that is the whole point of
+// routeLabel: see there.
+const unmatchedRoute = "unmatched"
+
+// routeLabel returns the registered PATTERN a request matched — "/api/v1/jobs/:id", never
+// "/api/v1/jobs/senior-go-engineer-42".
+//
+// The pattern is a string the app built at registration time, so it is both bounded (the router
+// decides the vocabulary, not the caller) and safe to store (it shares nothing with the recycled
+// request buffer — the two properties methodLabel had to construct by hand).
+//
+// Both properties are lost in exactly one case, which is why the guard is here. When no route
+// matched, Fiber's Ctx.Route() synthesises a Route whose Path is c.pathOriginal — the caller's
+// raw path, aliasing the request buffer. Returning it would hand any caller the power to mint a
+// series per request AND repeat the label-corruption failure that answered /metrics with a 500 on
+// prod 2026-08-20. That synthetic route is marked by an empty Handlers slice (a registered route
+// cannot have one — Fiber panics at registration), so that is what this tests.
+//
+// A request that reaches no HANDLER but does pass a middleware — a 404 — is a subtler case: Fiber
+// leaves c.route pointing at the last middleware that ran, and app.Use registers at "/". Those
+// land on the "/" series rather than on unmatchedRoute, which is correct enough (they are counted,
+// bounded, and not confusable with a real endpoint) and not worth reaching into unexported state
+// to refine.
+func routeLabel(c *fiber.Ctx) string {
+	route := c.Route()
+	if route == nil || len(route.Handlers) == 0 {
+		return unmatchedRoute
+	}
+	return route.Path
+}
+
 // methodLabel maps a request method onto one of a fixed set of package-level constants.
 //
 // It exists for two reasons, and the first one broke production. fasthttp backs c.Method() with
@@ -82,6 +127,7 @@ func HTTPMetrics() fiber.Handler {
 			return err
 		}
 		httpRequests.WithLabelValues(methodLabel(c.Method()), strconv.Itoa(c.Response().StatusCode())).Inc()
+		httpRouteRequests.WithLabelValues(routeLabel(c)).Inc()
 		return nil
 	}
 }
@@ -98,6 +144,7 @@ func CountErrors(next fiber.ErrorHandler) fiber.ErrorHandler {
 	return func(c *fiber.Ctx, err error) error {
 		rendered := next(c, err)
 		httpRequests.WithLabelValues(methodLabel(c.Method()), strconv.Itoa(c.Response().StatusCode())).Inc()
+		httpRouteRequests.WithLabelValues(routeLabel(c)).Inc()
 		return rendered
 	}
 }

--- a/internal/platform/observability/httpmetrics_test.go
+++ b/internal/platform/observability/httpmetrics_test.go
@@ -1,6 +1,7 @@
 package observability
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -142,6 +143,121 @@ func TestHTTPMetricsLabelsAreBounded(t *testing.T) {
 	if n := testutil.CollectAndCount(httpRequests); n > 24 {
 		t.Errorf("the counter holds %d series after three distinct paths — a path or route label "+
 			"has crept in, and at ~700 routes that is tens of thousands of series", n)
+	}
+}
+
+// routeCount reads one series of the route counter, or 0 when that route has never been touched.
+func routeCount(t *testing.T, route string) float64 {
+	t.Helper()
+	return testutil.ToFloat64(httpRouteRequests.WithLabelValues(route))
+}
+
+// TestRouteMetricCountsThePatternNotThePath is the property that makes a route label affordable
+// at all: three requests to three different job slugs are three increments of ONE series, because
+// the label is the registered pattern and not what the caller typed.
+func TestRouteMetricCountsThePatternNotThePath(t *testing.T) {
+	app := fiber.New()
+	app.Use(HTTPMetrics())
+	app.Get("/jobs/:slug", func(c *fiber.Ctx) error { return c.SendString("ok") })
+
+	before := routeCount(t, "/jobs/:slug")
+
+	for _, slug := range []string{"a-1", "b-2", "c-3"} {
+		resp, err := app.Test(httptest.NewRequestWithContext(t.Context(), fiber.MethodGet, "/jobs/"+slug, nil))
+		if err != nil {
+			t.Fatalf("GET /jobs/%s: %v", slug, err)
+		}
+		resp.Body.Close()
+	}
+
+	if got := routeCount(t, "/jobs/:slug") - before; got != 3 {
+		t.Errorf("/jobs/:slug counted %v, want 3 — the label is probably the request path, which "+
+			"is one series per slug and unbounded", got)
+	}
+	if got := routeCount(t, "/jobs/a-1"); got != 0 {
+		t.Errorf("a literal path minted its own series (%v) — the label is not the route pattern", got)
+	}
+}
+
+// TestRouteMetricCountsAnErrorHandlerResponse covers the half that does not pass through the
+// middleware. Fiber renders a returned error in the ErrorHandler after the chain has unwound, so
+// without CountErrors doing its own increment every failing endpoint would read as no traffic.
+func TestRouteMetricCountsAnErrorHandlerResponse(t *testing.T) {
+	app := fiber.New(fiber.Config{ErrorHandler: CountErrors(fiber.DefaultErrorHandler)})
+	app.Use(HTTPMetrics())
+	app.Get("/gone", func(c *fiber.Ctx) error { return fiber.NewError(fiber.StatusNotFound, "no") })
+
+	before := routeCount(t, "/gone")
+
+	resp, err := app.Test(httptest.NewRequestWithContext(t.Context(), fiber.MethodGet, "/gone", nil))
+	if err != nil {
+		t.Fatalf("GET /gone: %v", err)
+	}
+	resp.Body.Close()
+
+	if got := routeCount(t, "/gone") - before; got != 1 {
+		t.Errorf("/gone counted %v, want exactly 1", got)
+	}
+}
+
+// TestRouteLabelRefusesAnUnmatchedPath is the cardinality guard AND the buffer-aliasing guard in
+// one. When nothing matched, Fiber's Ctx.Route() hands back a synthetic Route carrying the
+// caller's raw path — so passing it through would let any caller mint a series per request and
+// would store a string backed by the recycled request buffer, which is what answered /metrics
+// with a 500 on prod 2026-08-20.
+func TestRouteLabelRefusesAnUnmatchedPath(t *testing.T) {
+	app := fiber.New(fiber.Config{ErrorHandler: CountErrors(fiber.DefaultErrorHandler)})
+	app.Get("/known", func(c *fiber.Ctx) error { return c.SendString("ok") })
+
+	before := routeCount(t, unmatchedRoute)
+
+	for _, path := range []string{"/nope-1", "/nope-2"} {
+		resp, err := app.Test(httptest.NewRequestWithContext(t.Context(), fiber.MethodGet, path, nil))
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != fiber.StatusNotFound {
+			t.Fatalf("fixture: GET %s answered %d, want 404", path, resp.StatusCode)
+		}
+	}
+
+	if got := routeCount(t, unmatchedRoute) - before; got != 2 {
+		t.Errorf("unmatched requests counted %v on the %q series, want 2", got, unmatchedRoute)
+	}
+	if got := routeCount(t, "/nope-1"); got != 0 {
+		t.Errorf("an unmatched path minted its own series (%v) — the caller can now grow the "+
+			"metric without bound, one request at a time", got)
+	}
+}
+
+// TestRouteMetricLabelsAreBounded pins the split between this metric and httpRequests. Route is
+// ~700 series on its own; the moment a status or method label joins it, it becomes the tens of
+// thousands that the other counter refuses a route label to avoid, and having two metrics stops
+// buying anything.
+func TestRouteMetricLabelsAreBounded(t *testing.T) {
+	app := fiber.New(fiber.Config{ErrorHandler: CountErrors(fiber.DefaultErrorHandler)})
+	app.Use(HTTPMetrics())
+	app.Get("/one", func(c *fiber.Ctx) error { return c.SendString("ok") })
+	app.Post("/one", func(c *fiber.Ctx) error { return fiber.NewError(fiber.StatusBadRequest, "no") })
+
+	before := testutil.CollectAndCount(httpRouteRequests)
+
+	for _, req := range []*http.Request{
+		httptest.NewRequestWithContext(t.Context(), fiber.MethodGet, "/one", nil),
+		httptest.NewRequestWithContext(t.Context(), fiber.MethodPost, "/one", nil),
+	} {
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("%s /one: %v", req.Method, err)
+		}
+		resp.Body.Close()
+	}
+
+	// Two methods, two statuses, one route: one new series.
+	if got := testutil.CollectAndCount(httpRouteRequests) - before; got > 1 {
+		t.Errorf("one route produced %d new series — a status or method label has crept in, and "+
+			"at ~700 routes that multiplies into the cardinality this metric was split to avoid", got)
 	}
 }
 


### PR DESCRIPTION
## What

Adds `freehire_http_route_requests_total{route}` — a counter of every API response by the **route pattern** it matched, so the Grafana dashboard can finally split traffic per endpoint.

## Why a second metric instead of a label

`freehire_http_requests_total` refuses a route label on purpose (~700 routes x status x method = tens of thousands of series), and its own comment reserves the escape hatch: *"add a SEPARATE metric rather than widening this one"*. This is that metric. Route alone is ~700 series; `TestRouteMetricLabelsAreBounded` fails if a status or method label ever joins it, because that would put the cardinality straight back.

The two counters answer two questions and stay independent:
- *is the error rate rising* → `freehire_http_requests_total{method,status}`
- *where is the traffic going* → `freehire_http_route_requests_total{route}`

## The trap it guards

The label is the registered pattern (`/api/v1/jobs/:id`), never the request path. Fiber's `Ctx.Route()` breaks that in exactly one case: when nothing matched it synthesises a `Route` whose `Path` is `c.pathOriginal` — the caller's raw path, aliasing the recycled fasthttp request buffer. Passing it through would (a) let any caller mint a series per request and (b) repeat the label corruption that produced a `GETT` label and a 500 from `/metrics` on prod 2026-08-20. `routeLabel` detects the synthetic route by its empty `Handlers` slice and counts those as `unmatched`.

Counted from both `HTTPMetrics()` and `CountErrors()`, for the same reason the existing counter is: Fiber renders an error-derived response after the middleware chain has unwound.

## Also

Corrects the AGENTS.md paragraph claiming `/metrics` is unreachable on prod. `METRICS_PORT` has been 9091/9092 since the observability rollout and Prometheus scrapes both colours with a `color` label — which is why every dashboard query aggregates rather than reading a raw series.

## Dashboard

The companion panels ("Where the traffic goes" — a top-15 stacked timeseries plus a per-endpoint bar gauge) land in `freehire-ops`, which is where the provisioned dashboard JSON lives.

## Checks

`gofmt` / `go vet ./...` / `go test ./...` / `go vet -tags=integration ./...` all clean; pre-commit (golangci-lint, govulncheck, gitleaks, doc-links) green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Monitoring**
  * Added per-route HTTP response metrics, grouped by matched route pattern.
  * Unmatched requests are consolidated under a single `unmatched` category.
  * Existing HTTP request metrics remain bounded without route-specific labels.
  * Production monitoring now scrapes metrics from both deployment colours.

* **Documentation**
  * Updated observability guidance with the new route metrics and Grafana top-K query.
  * Documented production scraping and metrics access details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->