### PR TITLE
Stop the horizontal strips from drawing a rail over their own content

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -30,6 +30,19 @@
   }
 }
 
+/* Scroll a strip without the browser drawing a rail across it. The tracking board's
+   columns, a tab bar, a row of cards: each has to stay scrollable on a viewport too
+   narrow to hold it, but a scrollbar set to "always show" sits ON the content and
+   covers the bottom of whatever it overlays. This hides the rail only — the element
+   still scrolls, so it goes alongside an `overflow-*`, never instead of one. The two
+   declarations are the same rule for two engines, not a fallback pair. */
+@utility no-scrollbar {
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 /* Shiki dual-theme code highlighting for the API docs. One SSR render emits both
    palettes as CSS vars; the light values apply by default and the dark values
    swap in under the .dark theme class. The block chrome (padding, scroll) is

--- a/web/src/lib/components/JobBoard.svelte
+++ b/web/src/lib/components/JobBoard.svelte
@@ -378,7 +378,7 @@
   {#if view === 'list'}
     <BoardList items={listItems} onopen={openDrawer} onsetstage={applyStage} />
   {:else}
-    <div class="flex gap-3 overflow-x-auto pb-2">
+    <div class="no-scrollbar flex gap-3 overflow-x-auto pb-2">
       {#each BOARD_COLUMNS as col (col.id)}
         <BoardColumn
           id={col.id}

--- a/web/src/lib/components/JobDrawer.svelte
+++ b/web/src/lib/components/JobDrawer.svelte
@@ -709,14 +709,3 @@
     </div>
   </div>
 </div>
-
-<style>
-  /* Tab rail scrolls horizontally on narrow screens without a visible scrollbar. */
-  .no-scrollbar {
-    scrollbar-width: none;
-    -ms-overflow-style: none;
-  }
-  .no-scrollbar::-webkit-scrollbar {
-    display: none;
-  }
-</style>

--- a/web/src/lib/components/JobSeeAlso.svelte
+++ b/web/src/lib/components/JobSeeAlso.svelte
@@ -35,9 +35,7 @@
 {#if cards.length > 0}
   <section class="mt-8">
     <h2 class="mb-3 text-sm font-semibold text-muted-foreground">See also</h2>
-    <div
-      class="flex gap-3 overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-    >
+    <div class="no-scrollbar flex gap-3 overflow-x-auto pb-1">
       {#each cards as card (card.slug)}
         <a
           href={resolve('/collections/[slug]', { slug: card.slug })}

--- a/web/src/routes/my/+layout.svelte
+++ b/web/src/routes/my/+layout.svelte
@@ -116,7 +116,10 @@
       {/snippet}
 
       <!-- Below lg: a horizontal, scrollable strip above the content. -->
-      <nav aria-label={s.shell.accountSections} class="mb-4 flex gap-1 overflow-x-auto lg:hidden">
+      <nav
+        aria-label={s.shell.accountSections}
+        class="no-scrollbar mb-4 flex gap-1 overflow-x-auto lg:hidden"
+      >
         {@render navLinks('shrink-0 whitespace-nowrap')}
       </nav>
 

--- a/web/src/routes/my/profile/+page.svelte
+++ b/web/src/routes/my/profile/+page.svelte
@@ -218,7 +218,11 @@
        way collapsed; the row scrolls horizontally on narrow viewports rather than wrapping,
        same as the account nav's own mobile strip in my/+layout.svelte. -->
   <div class="mb-6 flex items-end justify-between gap-4 border-b border-border text-sm">
-    <div class="flex min-w-0 gap-4 overflow-x-auto" role="tablist" aria-label="Profile sections">
+    <div
+      class="no-scrollbar flex min-w-0 gap-4 overflow-x-auto"
+      role="tablist"
+      aria-label="Profile sections"
+    >
       {#each VIEWS as v (v.id)}
         {@const Icon = v.icon}
         <button

--- a/web/src/routes/onboarding/+page.svelte
+++ b/web/src/routes/onboarding/+page.svelte
@@ -588,15 +588,3 @@
     </div>
   </div>
 {/if}
-
-<style>
-  /* Step content scrolls without a visible scrollbar (same pattern as JobDrawer's tab
-     rail) — the full-screen steps read as a page, not a scroll pane with a rail. */
-  .no-scrollbar {
-    scrollbar-width: none;
-    -ms-overflow-style: none;
-  }
-  .no-scrollbar::-webkit-scrollbar {
-    display: none;
-  }
-</style>


### PR DESCRIPTION
## What

Four horizontal strips scroll sideways on a viewport too narrow to hold them:
the tracking board's columns, the profile tab bar, the account nav's mobile
strip, and the see-also card row. On a machine set to always show scrollbars,
the rail the browser draws sits ON the content and covers the bottom of
whatever it overlays.

This hides the rail. The scrolling itself is untouched — wheel and trackpad
work exactly as before.

## The consolidation

The rule already existed three ways, none of which knew about the others:

- a component-scoped `<style>` copy in `JobDrawer.svelte`
- an identical copy in `onboarding/+page.svelte`
- an inline arbitrary-variant triplet in `JobSeeAlso.svelte`

One `@utility no-scrollbar` in `app.css` now; the three spellings collapse
into it. Second appearance of a rule is the moment to centralise it, and this
was the fourth.

`-ms-overflow-style` did not come along: it targets IE10/Edge Legacy, and
Tailwind v4 itself requires Chrome 111+ / Safari 16.4+, so the two never
overlap.

## Verification

Checked in a real browser (`/my/profile` at a 700px viewport), on the element
that was overflowing:

```
overflows: true          ← content is wider, so it still scrolls
scrollbarWidth: none     ← rail hidden
offsetHeight === clientHeight  ← rail no longer eats height
```

Also confirmed the generated CSS carries exactly one global rule (no
Svelte scope hash), so the old per-component copies are genuinely gone.

`pnpm test` 1404 passed · `pnpm check` 0 errors · `pnpm lint` no new issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Added a shared utility to hide scrollbar rails while preserving scrolling.
  - Horizontal scrolling areas in the job board, “See also” cards, account navigation, and profile tabs now scroll without visible scrollbars.
  - Consolidated scrollbar styling for a more consistent experience across supported browsers.
  - The onboarding step-content area now displays its scrollbar instead of hiding it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->