### PR TITLE
Give the phone back the width the header was spending on it

### DIFF
--- a/web/src/lib/components/HeaderSearch.svelte
+++ b/web/src/lib/components/HeaderSearch.svelte
@@ -544,8 +544,23 @@
       role="listbox"
       aria-label="Search suggestions"
       class={cn(
-        'absolute inset-x-0 top-full z-50 mt-2 max-h-[70vh] overflow-y-auto border border-border bg-background py-1 shadow-lg',
-        hero ? 'rounded-2xl' : 'rounded-md',
+        'inset-x-0 z-50 max-h-[70vh] overflow-y-auto border border-border bg-background py-1 shadow-lg',
+        hero
+          ? 'absolute top-full mt-2 rounded-2xl'
+          : // On a phone the panel leaves the box and takes the screen: full width, from
+            // under the sticky header (`top-14` is that header's own `h-14`) down to
+            // `bottom-0`. The box is 278px of a 390px screen, so at its width every row —
+            // a logo, a title, a company line — truncates; and a panel that stopped short
+            // of the bottom left the feed showing through beneath it, where a scroll moved
+            // whichever of the two the finger happened to land on. The side borders and
+            // the radius go with the edges they drew.
+            //
+            // `fixed` rather than an outward margin, because the box does not start at the
+            // viewport edge — the brand sits to its left and the menu to its right, so no
+            // margin reaches past them. It works only because the header draws no
+            // `backdrop-filter` (see TopBar): one would make the header the containing
+            // block and pin this panel to it instead of to the window.
+            'max-sm:fixed max-sm:bottom-0 max-sm:top-14 max-sm:max-h-none max-sm:border-x-0 max-sm:border-b-0 sm:absolute sm:top-full sm:mt-2 sm:rounded-md',
       )}
     >
       {#each rows as row, i (row.key)}

--- a/web/src/lib/components/HomeLandingView.svelte
+++ b/web/src/lib/components/HomeLandingView.svelte
@@ -291,7 +291,12 @@
      evidence: the CLI its install line, the extension what the panel actually does. -->
 <section class="border-t border-border py-12 sm:py-16">
   <SectionLabel text="take it with you" />
-  <div class="mt-8 grid gap-6 lg:grid-cols-2">
+  <!-- `grid-cols-1` is load-bearing, not the default written out: with no column template
+       the single track below `lg` is `auto`, which sizes to its widest content — the
+       install line in the `pre`, which does not wrap. That took the track to 416px on a
+       390px phone and gave the whole page a horizontal scrollbar. Tailwind's `grid-cols-*`
+       are `repeat(N, minmax(0, 1fr))` for exactly this, and the `pre` scrolls itself. -->
+  <div class="mt-8 grid grid-cols-1 gap-6 lg:grid-cols-2">
     <div class="flex flex-col gap-5 rounded-xl border border-border p-6 sm:p-8">
       <div class="flex flex-col gap-3">
         <h2 class="text-2xl font-semibold tracking-tight">

--- a/web/src/lib/components/ListToolbar.svelte
+++ b/web/src/lib/components/ListToolbar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Layers } from '@lucide/svelte';
   import type { Snippet } from 'svelte';
+  import { formatCount } from '$lib/utils';
 
   // The mobile controls for a list page (jobs, companies, …): an inline toolbar at the
   // top of the list — the results total on the left, and (on the jobs list) a Swipe entry
@@ -39,8 +40,16 @@
      must break onto a second line rather than clip its rightmost control off-screen. -->
 <div class="mb-3 flex flex-wrap items-center gap-2 md:hidden">
   {#if total !== null}
-    <span class="shrink-0 whitespace-nowrap text-sm text-muted-foreground" aria-live="polite">
-      <span class="font-semibold tabular-nums text-foreground">{total.toLocaleString()}</span>
+    <!-- Rounded on this row, spelled out on the desktop one below. The row is 358px on a
+         390px phone and its contents came to 376: the count at full precision was 103px of
+         that and "2.1M" is 60, which is what puts the controls back on one line. The exact
+         figure stays in the title. -->
+    <span
+      class="shrink-0 whitespace-nowrap text-sm text-muted-foreground"
+      aria-live="polite"
+      title="{total.toLocaleString()} {unit}"
+    >
+      <span class="font-semibold tabular-nums text-foreground">{formatCount(total)}</span>
       {unit}
     </span>
   {/if}

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -31,13 +31,16 @@
   // control strip, and both have to remain reachable.
   const bareHeader = $derived(page.url.pathname === '/');
 
-  /** How many of HEADER_LINKS the bare header carries below `lg` — the first two, which
-   *  are the two catalogues. The rest wait for the width, because all five and the right
-   *  cluster do not share a row under ~800px: at 640 the last two used to be drawn ON TOP
-   *  of the stars, the Discord mark and the burger. Two is what fits at the narrow end
-   *  (33px to spare at 320px, labels only — see the nav below), and the burger lists all
-   *  five at every width regardless. */
-  const PHONE_LINKS = 2;
+  /** How many of HEADER_LINKS the bare header carries below `lg`, taken from the FRONT of
+   *  that list — so its order is the contract, and reordering it changes what a narrow
+   *  screen gets. Today that is Jobs and Companies.
+   *
+   *  Two, because that is what fits at the narrow end (33px to spare at 320px, labels
+   *  only — see the nav below). `lg` rather than a width nearer the 800px where all five
+   *  do begin to fit, because Tailwind's own breakpoints are what the rest of this header
+   *  is written in and one more arbitrary query is a second answer to the same question.
+   *  Under `lg` the burger lists all five anyway, which is where they were until now. */
+  const LINKS_BELOW_LG = 2;
 
   // On the full-viewport surfaces (the agent, the tailor workspace) the page below runs
   // edge to edge under its own icon rail, so the header drops the centered `max-w-6xl`
@@ -89,9 +92,10 @@
         class="flex items-center gap-2 text-sm font-semibold tracking-tight"
       >
         <BrandMark />
-        <!-- Dropped on a phone to leave the middle slot its width — except on the homepage,
-             which renders no search box there (its own hero is the box), so the row is a
-             mark and a burger with the whole screen between them. -->
+        <!-- Dropped on a phone to leave the middle slot its width for the search box —
+             except on the homepage, which puts no box there (its own hero is the box) and
+             so has the room. What the row spends that room on instead is the nav below,
+             and the two budgets are the same 358px: they are set together. -->
         <span class={bareHeader ? 'inline' : 'hidden sm:inline'} aria-hidden="true">freehire</span>
       </a>
     </div>
@@ -102,12 +106,12 @@
          cap then hands the rest back to the side slots, which keeps it on the axis. -->
     <div class={['flex min-w-0 flex-1', fullBleed && 'max-w-3xl basis-3xl']}>
       {#if bareHeader}
-        <!-- All five below 640px do not fit beside the brand and the burger, but the row
+        <!-- All five do not fit beside the brand and the burger on a phone, but the row
              they share is otherwise EMPTY on this route — the homepage's search box is its
-             hero, not this slot — so the first two ride along on a phone and the other
-             three wait for the width. Two is what fits, not a ranking: they are the two
-             catalogues, and the burger a thumb away still lists all five with the same
-             glyph and a full label. Bare icons would trade a legible row for guesses. -->
+             hero, not this slot — so the front of the list rides along and the rest wait
+             for `lg` (see LINKS_BELOW_LG). The cut is by width, not by rank; the burger a
+             thumb away still lists all five with the same glyph and a full label, which is
+             also why bare icons here would trade a legible row for guesses. -->
         <nav aria-label="Site" class="flex items-center gap-3 sm:gap-5 lg:gap-6">
           <!-- Divides the nav from the wordmark, the same rule the search box draws
                between its Location scope and the field. Without it the first link sat
@@ -119,7 +123,7 @@
               href={resolve(link.href)}
               class={[
                 'flex items-center gap-1.5 whitespace-nowrap text-sm text-muted-foreground transition-colors hover:text-foreground',
-                i >= PHONE_LINKS && 'hidden lg:flex',
+                i >= LINKS_BELOW_LG && 'hidden lg:flex',
               ]}
             >
               <!-- Label alone on a phone. The glyph is 22px with its gap and both links

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -31,6 +31,14 @@
   // control strip, and both have to remain reachable.
   const bareHeader = $derived(page.url.pathname === '/');
 
+  /** How many of HEADER_LINKS the bare header carries below `lg` — the first two, which
+   *  are the two catalogues. The rest wait for the width, because all five and the right
+   *  cluster do not share a row under ~800px: at 640 the last two used to be drawn ON TOP
+   *  of the stars, the Discord mark and the burger. Two is what fits at the narrow end
+   *  (33px to spare at 320px, labels only — see the nav below), and the burger lists all
+   *  five at every width regardless. */
+  const PHONE_LINKS = 2;
+
   // On the full-viewport surfaces (the agent, the tailor workspace) the page below runs
   // edge to edge under its own icon rail, so the header drops the centered `max-w-6xl`
   // and does the same: brand hard left, menu hard right. The search keeps a readable
@@ -81,7 +89,10 @@
         class="flex items-center gap-2 text-sm font-semibold tracking-tight"
       >
         <BrandMark />
-        <span class="hidden sm:inline" aria-hidden="true">freehire</span>
+        <!-- Dropped on a phone to leave the middle slot its width — except on the homepage,
+             which renders no search box there (its own hero is the box), so the row is a
+             mark and a burger with the whole screen between them. -->
+        <span class={bareHeader ? 'inline' : 'hidden sm:inline'} aria-hidden="true">freehire</span>
       </a>
     </div>
 
@@ -91,22 +102,30 @@
          cap then hands the rest back to the side slots, which keeps it on the axis. -->
     <div class={['flex min-w-0 flex-1', fullBleed && 'max-w-3xl basis-3xl']}>
       {#if bareHeader}
-        <!-- Hidden below 640px, where five labels do not fit beside the brand and the
-             burger — and where the burger is a thumb away and lists every one of these
-             with the same glyph and a full label. Shrinking them to bare icons would
-             trade a legible row for five guesses. -->
-        <nav aria-label="Site" class="hidden items-center gap-5 sm:flex lg:gap-6">
+        <!-- All five below 640px do not fit beside the brand and the burger, but the row
+             they share is otherwise EMPTY on this route — the homepage's search box is its
+             hero, not this slot — so the first two ride along on a phone and the other
+             three wait for the width. Two is what fits, not a ranking: they are the two
+             catalogues, and the burger a thumb away still lists all five with the same
+             glyph and a full label. Bare icons would trade a legible row for guesses. -->
+        <nav aria-label="Site" class="flex items-center gap-3 sm:gap-5 lg:gap-6">
           <!-- Divides the nav from the wordmark, the same rule the search box draws
                between its Location scope and the field. Without it the first link sat
                one word-gap from "freehire" and read as part of it. -->
           <div aria-hidden="true" class="h-5 w-px shrink-0 bg-border"></div>
-          {#each HEADER_LINKS as link (link.href)}
+          {#each HEADER_LINKS as link, i (link.href)}
             {@const Icon = link.icon}
             <a
               href={resolve(link.href)}
-              class="flex items-center gap-1.5 whitespace-nowrap text-sm text-muted-foreground transition-colors hover:text-foreground"
+              class={[
+                'flex items-center gap-1.5 whitespace-nowrap text-sm text-muted-foreground transition-colors hover:text-foreground',
+                i >= PHONE_LINKS && 'hidden lg:flex',
+              ]}
             >
-              <Icon class="size-4 shrink-0" aria-hidden="true" />
+              <!-- Label alone on a phone. The glyph is 22px with its gap and both links
+                   carry one, which at 320px pushed "Companies" under the burger; the word
+                   is what names the destination, so the glyph is what gives way. -->
+              <Icon class="hidden size-4 shrink-0 sm:block" aria-hidden="true" />
               {link.label}
             </a>
           {/each}

--- a/web/src/lib/siteNav.ts
+++ b/web/src/lib/siteNav.ts
@@ -60,7 +60,9 @@ export const NAV = {
  *
  *  Five, and no more: this is a shortcut to the menu's own top, not a second
  *  navigation with its own opinions about what matters. Three ways into the catalogue
- *  and two ways to find out what this is. TopBar decides when the row is drawn. */
+ *  and two ways to find out what this is. TopBar decides when the row is drawn — and,
+ *  below `lg`, how much of it: it takes entries from the FRONT of this list, so the
+ *  ORDER here is what a narrow screen gets, not just the order it reads in. */
 export const HEADER_LINKS = [
   NAV.jobs,
   NAV.companies,


### PR DESCRIPTION
Five narrow-viewport fixes in the web app, each measured on a real viewport rather than guessed at.

### The suggestion panel takes the screen on a phone

`HeaderSearch` hung its dropdown off the box. The box is 278px of a 390px screen, so every row truncated a title or a company, and the panel's `max-h-[70vh]` left the feed showing through the bottom third — where a scroll moved whichever of the two the finger landed on. Below `sm` it is now `fixed`, full width, from under the sticky header (`top-14`) to `bottom-0`.

`fixed` rather than an outward margin because the brand sits to the box's left and the menu to its right, so no margin reaches the viewport edge. It is safe only because the header draws no `backdrop-filter` — one would make the header the containing block and pin the panel to it. That is noted beside the classes.

The hero (the homepage's own box) is untouched, and so is every viewport at `sm` and up.

### The list toolbar fits on one line

`2.1M jobs` rather than `2,091,223 jobs`. The row is 358px on a 390px phone and its contents came to 376, so the controls wrapped to a second line. Rounding the count is 43px, which is the difference; trimming gaps would have been 12 and would break again on the first longer select value. The exact figure stays on the desktop row and in the `title`, and `formatCount` already existed in `$lib/utils`.

### The homepage no longer scrolls sideways

`document.scrollWidth` was 432 against a 390 viewport. The take-it-with-you grid had no column template, so its single track below `lg` was `auto` — sized to its widest content, which is the non-wrapping install line in the CLI card, 416px. `grid-cols-1` is `repeat(1, minmax(0, 1fr))`, which caps it; the `pre` scrolls itself as before. Clean at 320, 360, 390, 414 and 768.

### The homepage header says who it is

The wordmark and the first two links (Jobs, Companies) now ride in the header on a phone. That route renders no search box in the middle slot, so the row was a mark and a burger with the whole screen between them. Labels only below `sm` — the two glyphs are 44px together, which at 320px is the difference between fitting and drawing "Companies" under the burger. 33px to spare at 320.

### And a pre-existing overlap, fixed on the way past

The other three links moved from `sm` to `lg`. All five plus the right-hand cluster do not share a row under ~800px, so at 640 "How it works" and "About" were drawn on top of the stars, the Discord mark and the burger. The burger menu lists all five at every width regardless.

### Verification

Measured in a headless browser at 320 / 360 / 375 / 390 / 414 / 640 / 768 / 1024 / 1280: no element crosses the viewport, no link overlaps the menu cluster, and the panel's geometry is `fixed 0→390, 56→844` on a phone and unchanged at `sm`+.

`pnpm test` — 1404 passing. eslint, gitleaks, doc-links, the design-system adoption check and the token-coverage ratchet all pass (the ratchet caught a duplicated `max-h-[70vh]` in an early draft; the final class list holds it once).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved mobile navigation with prioritized links and responsive visibility for labels, icons, and branding.
  - Mobile search suggestions now expand from beneath the sticky header to the bottom of the screen.
  - Mobile result totals now use compact formatting while preserving the exact value in a tooltip.

- **Bug Fixes**
  - Prevented horizontal scrolling on small screens in the homepage’s “take it with you” section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->