### PR TITLE
Serve every subscription a digest, not just the lowest ids

### DIFF
--- a/internal/api/handler/me_subscriptions.go
+++ b/internal/api/handler/me_subscriptions.go
@@ -70,6 +70,9 @@ func subscriptionError(err error) error {
 	switch {
 	case errors.Is(err, subscription.ErrInvalidChannel):
 		return fiber.NewError(fiber.StatusBadRequest, "unsupported notification channel")
+	case errors.Is(err, subscription.ErrUnfilteredSearch):
+		return fiber.NewError(fiber.StatusBadRequest,
+			"add at least one filter before subscribing — an unfiltered search would notify you about every job")
 	case errors.Is(err, subscription.ErrSavedSearchNotFound):
 		return fiber.NewError(fiber.StatusNotFound, "saved search not found")
 	case errors.Is(err, subscription.ErrDuplicate):

--- a/internal/engage/notify/deliver.go
+++ b/internal/engage/notify/deliver.go
@@ -18,11 +18,17 @@ import (
 // subscription that is not currently deliverable (e.g. Telegram unlinked) has its
 // claim released so it is retried promptly rather than waiting out the lease.
 func (r *Runner) deliver(ctx context.Context, stats *Stats) error {
+	// One digest's worth per subscription, so a pass serves every subscription that has
+	// anything pending rather than the lowest ids only. Floored like the batch size it
+	// sits beside: a zero here is LIMIT 0 in the LATERAL, which claims nothing and
+	// reports no error — the whole worker would go quietly idle.
+	perSubscription := int32(r.cfg.SnapshotCap)
+	if perSubscription < 1 {
+		perSubscription = 1
+	}
 	claimed, err := r.store.ClaimSubscriptionMatches(ctx, db.ClaimSubscriptionMatchesParams{
-		LeaseSeconds: r.cfg.LeaseSeconds,
-		// One digest's worth per subscription, so a pass serves every subscription
-		// that has anything pending rather than the lowest ids only.
-		PerSubscription: int32(r.cfg.SnapshotCap),
+		LeaseSeconds:    r.cfg.LeaseSeconds,
+		PerSubscription: perSubscription,
 		BatchSize:       r.cfg.ClaimBatch,
 	})
 	if err != nil {

--- a/internal/engage/notify/deliver.go
+++ b/internal/engage/notify/deliver.go
@@ -20,7 +20,10 @@ import (
 func (r *Runner) deliver(ctx context.Context, stats *Stats) error {
 	claimed, err := r.store.ClaimSubscriptionMatches(ctx, db.ClaimSubscriptionMatchesParams{
 		LeaseSeconds: r.cfg.LeaseSeconds,
-		BatchSize:    r.cfg.ClaimBatch,
+		// One digest's worth per subscription, so a pass serves every subscription
+		// that has anything pending rather than the lowest ids only.
+		PerSubscription: int32(r.cfg.SnapshotCap),
+		BatchSize:       r.cfg.ClaimBatch,
 	})
 	if err != nil {
 		return err

--- a/internal/engage/notify/fair_claim_integration_test.go
+++ b/internal/engage/notify/fair_claim_integration_test.go
@@ -1,0 +1,132 @@
+//go:build integration
+
+// Integration test for the per-subscription claim cap: one subscription with a huge
+// backlog must not starve the others. The unit tests cover the delivery branches against
+// a fake Store; only a real Postgres can prove the CLAIM itself — the LATERAL, the row
+// lock and the cap live in SQL. Run with:
+// go test -tags=integration ./internal/engage/notify/
+// Requires Docker (testcontainers spins up a throwaway Postgres with the migrations).
+package notify
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/platform/db"
+	"github.com/strelov1/freehire/internal/platform/testdb"
+)
+
+// The claim used to be a flat `ORDER BY subscription_id, matched_at LIMIT batch_size`,
+// which reads as "oldest first" but is really "lowest subscription id first". Measured on
+// prod 2026-09-04: one subscription whose saved search had an EMPTY query held 248k
+// pending matches, the queue was 1.14M deep, and every subscription above it had
+// attempts=0 since the day it was created — never delivered, never even attempted.
+//
+// So the property under test is not "the claim returns rows". It is that a subscription
+// with more pending matches than a whole batch takes only its own share.
+func TestClaimSpreadsAcrossSubscriptionsRatherThanLowestIDFirst(t *testing.T) {
+	pool := testdb.Pool(t)
+	queries := db.New(pool)
+	ctx := context.Background()
+
+	userID := insertNotifyIntegrationUser(t, pool, "fair-claim@example.test")
+
+	// The hoarder is created FIRST so it holds the lowest subscription id — the exact
+	// shape that starved everyone under the old ordering.
+	hoarderSearch := insertNotifySavedSearch(t, pool, userID, "Everything", "")
+	hoarderID := insertNotifyPushSubscription(t, pool, userID, hoarderSearch)
+	const hoarderBacklog = 400
+	for i := 0; i < hoarderBacklog; i++ {
+		jobID := insertNotifyJob(t, pool, sequentialExternalID("fair-hoard", i),
+			"Engineer", sequentialSlug("fair-hoard", i))
+		insertNotifyPendingMatch(t, pool, hoarderID, jobID)
+	}
+
+	// Two ordinary subscriptions, created after, each with a couple of matches.
+	var ordinary []int64
+	for s := 0; s < 2; s++ {
+		search := insertNotifySavedSearch(t, pool, userID, "Backend "+strconv.Itoa(s), "seniority=senior")
+		subID := insertNotifyPushSubscription(t, pool, userID, search)
+		ordinary = append(ordinary, subID)
+		for i := 0; i < 2; i++ {
+			jobID := insertNotifyJob(t, pool, sequentialExternalID("fair-ord", s*10+i),
+				"Backend Engineer", sequentialSlug("fair-ord", s*10+i))
+			insertNotifyPendingMatch(t, pool, subID, jobID)
+		}
+	}
+
+	const perSubscription = 50
+	claimed, err := queries.ClaimSubscriptionMatches(ctx, db.ClaimSubscriptionMatchesParams{
+		LeaseSeconds:    600,
+		PerSubscription: perSubscription,
+		// Deliberately smaller than the hoarder's backlog: under the old query this
+		// bound alone was what the hoarder consumed.
+		BatchSize: 200,
+	})
+	if err != nil {
+		t.Fatalf("ClaimSubscriptionMatches: %v", err)
+	}
+
+	bySub := map[int64]int{}
+	for _, c := range claimed {
+		bySub[c.SubscriptionID]++
+	}
+
+	if got := bySub[hoarderID]; got != perSubscription {
+		t.Errorf("hoarding subscription claimed %d matches, want exactly the %d cap "+
+			"(it has %d pending)", got, perSubscription, hoarderBacklog)
+	}
+	for _, subID := range ordinary {
+		if got := bySub[subID]; got != 2 {
+			t.Errorf("subscription %d claimed %d matches, want its 2 — a backlog on a "+
+				"lower id must not consume the batch", subID, got)
+		}
+	}
+}
+
+// A second pass must move the hoarder forward rather than re-serving the same rows: the
+// first pass's claim is leased, and the lease is what keeps two overlapping passes from
+// sending one digest twice.
+func TestASecondClaimTakesTheNextSliceNotTheSameOne(t *testing.T) {
+	pool := testdb.Pool(t)
+	queries := db.New(pool)
+	ctx := context.Background()
+
+	userID := insertNotifyIntegrationUser(t, pool, "fair-claim-second@example.test")
+	search := insertNotifySavedSearch(t, pool, userID, "Everything", "")
+	subID := insertNotifyPushSubscription(t, pool, userID, search)
+	for i := 0; i < 30; i++ {
+		jobID := insertNotifyJob(t, pool, sequentialExternalID("fair-second", i),
+			"Engineer", sequentialSlug("fair-second", i))
+		insertNotifyPendingMatch(t, pool, subID, jobID)
+	}
+
+	arg := db.ClaimSubscriptionMatchesParams{LeaseSeconds: 600, PerSubscription: 10, BatchSize: 200}
+	first, err := queries.ClaimSubscriptionMatches(ctx, arg)
+	if err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	second, err := queries.ClaimSubscriptionMatches(ctx, arg)
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	if len(first) != 10 || len(second) != 10 {
+		t.Fatalf("claims returned %d and %d, want 10 each", len(first), len(second))
+	}
+
+	seen := map[int64]bool{}
+	for _, c := range first {
+		seen[c.JobID] = true
+	}
+	for _, c := range second {
+		if seen[c.JobID] {
+			t.Errorf("job %d was claimed by both passes — the lease must keep a digest "+
+				"from being sent twice", c.JobID)
+		}
+	}
+}
+
+// sequentialExternalID and sequentialSlug keep the bulk fixtures above unique.
+func sequentialExternalID(prefix string, i int) string { return prefix + "-ext-" + strconv.Itoa(i) }
+func sequentialSlug(prefix string, i int) string       { return prefix + "-slug-" + strconv.Itoa(i) }

--- a/internal/engage/notify/notify.go
+++ b/internal/engage/notify/notify.go
@@ -157,7 +157,11 @@ type Config struct {
 	// LeaseSeconds is the delivery lease: a claimed-but-undelivered match is
 	// reclaimable after this, which doubles as the crash reaper.
 	LeaseSeconds int32
-	// ClaimBatch bounds how many pending matches one pass delivers.
+	// ClaimBatch bounds how many pending matches one pass delivers, across all
+	// subscriptions. It is a backstop, not the working bound: what a pass normally
+	// claims is SnapshotCap per subscription with anything pending. Set it above
+	// SnapshotCap x the active subscription count, or the cut falls on whichever
+	// subscriptions the scan reached last — the starvation this replaced.
 	ClaimBatch int32
 	// MaxAttempts dead-letters a match after this many failed deliveries.
 	MaxAttempts int32
@@ -176,8 +180,11 @@ func DefaultConfig() Config {
 	return Config{
 		MatchLimit:   200,
 		LeaseSeconds: 600,
-		ClaimBatch:   500,
-		MaxAttempts:  5,
+		// 200 per subscription x room for 250 active subscriptions. Prod carries 53;
+		// the headroom is deliberate, since hitting this bound is what starvation
+		// looks like.
+		ClaimBatch:  50000,
+		MaxAttempts: 5,
 		// One query cannot match more than MatchLimit jobs in a pass, so the two
 		// agree deliberately: the snapshot is complete for every digest except a
 		// `daily` one that accumulated across many deferred passes.

--- a/internal/engage/subscription/repository.go
+++ b/internal/engage/subscription/repository.go
@@ -66,6 +66,21 @@ func (r *QueriesRepository) Create(ctx context.Context, userID, savedSearchID in
 	return fromRow(row), nil
 }
 
+// SavedSearchQuery reads the owner-scoped saved search's stored query. It reuses
+// GetSavedSearch rather than adding a narrower query: the read is once per subscribe,
+// and a second SQL statement selecting one column would be a second place to keep the
+// ownership predicate correct.
+func (r *QueriesRepository) SavedSearchQuery(ctx context.Context, userID, savedSearchID int64) (string, error) {
+	row, err := r.q.GetSavedSearch(ctx, db.GetSavedSearchParams{ID: savedSearchID, UserID: userID})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", ErrSavedSearchNotFound
+	}
+	if err != nil {
+		return "", err
+	}
+	return row.Query, nil
+}
+
 func (r *QueriesRepository) SetActive(ctx context.Context, userID, id int64, active bool) (Subscription, error) {
 	row, err := r.q.SetSubscriptionActive(ctx, db.SetSubscriptionActiveParams{
 		Active: active,

--- a/internal/engage/subscription/subscription.go
+++ b/internal/engage/subscription/subscription.go
@@ -9,6 +9,7 @@ package subscription
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/strelov1/freehire/internal/engage/notify"
@@ -18,6 +19,13 @@ import (
 var (
 	// ErrInvalidChannel is an unsupported delivery channel (mapped to 400).
 	ErrInvalidChannel = errors.New("subscription: unsupported channel")
+	// ErrUnfilteredSearch is a subscription to a saved search that carries no filter
+	// (mapped to 400). Saving an unfiltered board is legitimate — it is the "show all"
+	// view — but SUBSCRIBING to one asks to be notified about every posting in the
+	// catalogue, which is never what anyone means. On prod 2026-09-04 one such
+	// subscription held 248k undelivered matches and, through a claim that ordered by
+	// subscription id, starved every subscription created after it.
+	ErrUnfilteredSearch = errors.New("subscription: saved search has no filter")
 	// ErrSavedSearchNotFound is a saved_search_id that is missing or not the
 	// caller's (mapped to 404).
 	ErrSavedSearchNotFound = errors.New("subscription: saved search not found")
@@ -65,6 +73,10 @@ type SubscriptionListItem struct {
 type Repository interface {
 	List(ctx context.Context, userID int64) ([]SubscriptionListItem, error)
 	Create(ctx context.Context, userID, savedSearchID int64, channel string) (Subscription, error)
+	// SavedSearchQuery returns the owner-scoped saved search's stored query string, so
+	// the use case can refuse to subscribe to an unfiltered one. A missing or non-owned
+	// id surfaces as ErrSavedSearchNotFound, like Create.
+	SavedSearchQuery(ctx context.Context, userID, savedSearchID int64) (string, error)
 	SetActive(ctx context.Context, userID, id int64, active bool) (Subscription, error)
 	Delete(ctx context.Context, userID, id int64) error
 }
@@ -92,6 +104,13 @@ func (s *Service) List(ctx context.Context, userID int64) ([]SubscriptionListIte
 func (s *Service) Create(ctx context.Context, userID, savedSearchID int64, channel string) (Subscription, error) {
 	if !notify.ValidChannel(channel) {
 		return Subscription{}, ErrInvalidChannel
+	}
+	query, err := s.repo.SavedSearchQuery(ctx, userID, savedSearchID)
+	if err != nil {
+		return Subscription{}, err
+	}
+	if strings.TrimSpace(query) == "" {
+		return Subscription{}, ErrUnfilteredSearch
 	}
 	return s.repo.Create(ctx, userID, savedSearchID, channel)
 }

--- a/internal/engage/subscription/subscription_test.go
+++ b/internal/engage/subscription/subscription_test.go
@@ -18,7 +18,20 @@ type createArgs struct {
 // repository (and whether it was reached at all).
 type fakeRepo struct {
 	created *createArgs
+	// savedSearchQuery is what the saved search being subscribed to carries, returned
+	// verbatim — an empty one is a real value here, not "unset", since that is the case
+	// the guard exists for.
+	savedSearchQuery string
+	savedSearchErr   error
 }
+
+func (r *fakeRepo) SavedSearchQuery(context.Context, int64, int64) (string, error) {
+	return r.savedSearchQuery, r.savedSearchErr
+}
+
+// filteredRepo is a fake whose saved search carries a real filter — what every case
+// that is not about the guard wants.
+func filteredRepo() *fakeRepo { return &fakeRepo{savedSearchQuery: "seniority=senior"} }
 
 func (r *fakeRepo) List(context.Context, int64) ([]SubscriptionListItem, error) {
 	return nil, nil
@@ -36,7 +49,7 @@ func (r *fakeRepo) SetActive(context.Context, int64, int64, bool) (Subscription,
 func (r *fakeRepo) Delete(context.Context, int64, int64) error { return nil }
 
 func TestCreate_EmailChannelAccepted(t *testing.T) {
-	repo := &fakeRepo{}
+	repo := filteredRepo()
 	sub, err := New(repo).Create(context.Background(), 1, 2, ChannelEmail)
 	if err != nil {
 		t.Fatalf("Create(email) error = %v, want nil", err)
@@ -50,12 +63,39 @@ func TestCreate_EmailChannelAccepted(t *testing.T) {
 }
 
 func TestCreate_UnknownChannelRejected(t *testing.T) {
-	repo := &fakeRepo{}
+	repo := filteredRepo()
 	_, err := New(repo).Create(context.Background(), 1, 2, "carrier-pigeon")
 	if !errors.Is(err, ErrInvalidChannel) {
 		t.Errorf("Create(unknown) error = %v, want ErrInvalidChannel", err)
 	}
 	if repo.created != nil {
 		t.Errorf("repo Create was called with %+v, want no call for an invalid channel", repo.created)
+	}
+}
+
+// Saving an unfiltered board is legitimate — it is the "show all" view. SUBSCRIBING to
+// one asks to be notified about every posting in the catalogue, which is never what
+// anyone means. On prod 2026-09-04 one such subscription held 248k undelivered matches
+// and, through a claim ordered by subscription id, starved every subscription created
+// after it.
+func TestCreateRefusesAnUnfilteredSavedSearch(t *testing.T) {
+	for _, query := range []string{"", "   "} {
+		repo := &fakeRepo{savedSearchQuery: query}
+		_, err := New(repo).Create(context.Background(), 1, 2, "telegram")
+		if !errors.Is(err, ErrUnfilteredSearch) {
+			t.Errorf("query %q: err = %v, want ErrUnfilteredSearch", query, err)
+		}
+		if repo.created != nil {
+			t.Errorf("query %q: nothing must be stored", query)
+		}
+	}
+}
+
+// The guard reads the saved search, so a missing or non-owned one must still surface as
+// not-found rather than as "unfiltered".
+func TestCreateSurfacesAMissingSavedSearch(t *testing.T) {
+	repo := &fakeRepo{savedSearchErr: ErrSavedSearchNotFound}
+	if _, err := New(repo).Create(context.Background(), 1, 2, "telegram"); !errors.Is(err, ErrSavedSearchNotFound) {
+		t.Errorf("err = %v, want ErrSavedSearchNotFound", err)
 	}
 }

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -329,13 +329,24 @@ type Querier interface {
 	// join is over just the claimed batch (batch_size rows), not the whole claimable set —
 	// cheap, unlike the ordering join this replaces above.
 	ClaimSemanticBatch(ctx context.Context, arg ClaimSemanticBatchParams) ([]ClaimSemanticBatchRow, error)
-	// Lease a batch of pending, live matches for active subscriptions by stamping
-	// claimed_at, oldest-claimable first, ordered by subscription so the worker can
-	// group a subscription's matches into one digest. FOR UPDATE OF m locks only match
-	// rows; SKIP LOCKED lets overlapping passes take disjoint rows so a digest is sent
-	// at most once; the lease predicate reclaims rows whose sender died (stale
-	// claimed_at), so no separate reaper is needed. The digest is sent OUTSIDE this
-	// claim's transaction, so no network call is held inside a row lock.
+	// Lease pending, live matches for active subscriptions by stamping claimed_at,
+	// AT MOST per_subscription of them per subscription, so one busy subscription cannot
+	// starve the rest. FOR UPDATE OF the match rows with SKIP LOCKED lets overlapping passes
+	// take disjoint rows so a digest is sent at most once; the lease predicate reclaims rows
+	// whose sender died (stale claimed_at), so no separate reaper is needed. The digest is
+	// sent OUTSIDE this claim's transaction, so no network call is held inside a row lock.
+	//
+	// The per-subscription cap is the whole point. This used to be one flat
+	// `ORDER BY subscription_id, matched_at LIMIT batch_size` over every pending row, which
+	// reads as "oldest first" but is really "lowest subscription id first": a subscription
+	// whose filter matches most of the catalogue fills the batch every pass and every
+	// higher id is never reached. Measured on prod 2026-09-04 — one subscription with an
+	// EMPTY query held 248k pending matches, the queue was 1.14M deep, and subscriptions
+	// above it had attempts=0 since the day they were created. Nothing was broken; they were
+	// simply never in a batch.
+	//
+	// A LATERAL per subscription, rather than a window function, because FOR UPDATE cannot
+	// be used with window functions — and the row lock is what makes concurrent passes safe.
 	ClaimSubscriptionMatches(ctx context.Context, arg ClaimSubscriptionMatchesParams) ([]ClaimSubscriptionMatchesRow, error)
 	// Claim a batch of pending posts by stamping claimed_at. SKIP LOCKED lets
 	// concurrent workers take disjoint rows; the lease predicate reclaims posts whose

--- a/internal/platform/db/queries/subscriptions.sql
+++ b/internal/platform/db/queries/subscriptions.sql
@@ -63,28 +63,44 @@ SELECT unnest(sqlc.arg(subscription_ids)::bigint[]) AS subscription_id,
 ON CONFLICT (subscription_id, job_id) DO NOTHING;
 
 -- name: ClaimSubscriptionMatches :many
--- Lease a batch of pending, live matches for active subscriptions by stamping
--- claimed_at, oldest-claimable first, ordered by subscription so the worker can
--- group a subscription's matches into one digest. FOR UPDATE OF m locks only match
--- rows; SKIP LOCKED lets overlapping passes take disjoint rows so a digest is sent
--- at most once; the lease predicate reclaims rows whose sender died (stale
--- claimed_at), so no separate reaper is needed. The digest is sent OUTSIDE this
--- claim's transaction, so no network call is held inside a row lock.
+-- Lease pending, live matches for active subscriptions by stamping claimed_at,
+-- AT MOST per_subscription of them per subscription, so one busy subscription cannot
+-- starve the rest. FOR UPDATE OF the match rows with SKIP LOCKED lets overlapping passes
+-- take disjoint rows so a digest is sent at most once; the lease predicate reclaims rows
+-- whose sender died (stale claimed_at), so no separate reaper is needed. The digest is
+-- sent OUTSIDE this claim's transaction, so no network call is held inside a row lock.
+--
+-- The per-subscription cap is the whole point. This used to be one flat
+-- `ORDER BY subscription_id, matched_at LIMIT batch_size` over every pending row, which
+-- reads as "oldest first" but is really "lowest subscription id first": a subscription
+-- whose filter matches most of the catalogue fills the batch every pass and every
+-- higher id is never reached. Measured on prod 2026-09-04 — one subscription with an
+-- EMPTY query held 248k pending matches, the queue was 1.14M deep, and subscriptions
+-- above it had attempts=0 since the day they were created. Nothing was broken; they were
+-- simply never in a batch.
+--
+-- A LATERAL per subscription, rather than a window function, because FOR UPDATE cannot
+-- be used with window functions — and the row lock is what makes concurrent passes safe.
 WITH claimable AS (
     SELECT m.subscription_id, m.job_id
-    FROM subscription_matches m
-    JOIN subscriptions s ON s.id = m.subscription_id
-    WHERE m.notified_at IS NULL
-      AND m.failed_at IS NULL
-      AND (m.claimed_at IS NULL
-           OR m.claimed_at < now() - make_interval(secs => sqlc.arg(lease_seconds)::int))
-      AND s.active
-    -- Grouped by subscription so the delivery loop can build one digest each.
-    -- The matched_at/job_id tiebreak makes a batch_size cut deterministic (oldest
-    -- matches land in this batch); a subscription with more than batch_size pending
-    -- matches splits across passes into multiple digests — an accepted rare case.
-    ORDER BY m.subscription_id, m.matched_at, m.job_id
-    FOR UPDATE OF m SKIP LOCKED
+    FROM subscriptions s
+    CROSS JOIN LATERAL (
+        SELECT mm.subscription_id, mm.job_id
+        FROM subscription_matches mm
+        WHERE mm.subscription_id = s.id
+          AND mm.notified_at IS NULL
+          AND mm.failed_at IS NULL
+          AND (mm.claimed_at IS NULL
+               OR mm.claimed_at < now() - make_interval(secs => sqlc.arg(lease_seconds)::int))
+        -- Oldest first WITHIN the subscription: a digest that splits across passes sends
+        -- the matches in the order they were found.
+        ORDER BY mm.matched_at, mm.job_id
+        LIMIT sqlc.arg(per_subscription)
+        FOR UPDATE SKIP LOCKED
+    ) m
+    WHERE s.active
+    -- A backstop, not the working bound: per_subscription x active subscriptions is what
+    -- a pass normally claims. This only caps a pathological subscription count.
     LIMIT sqlc.arg(batch_size)
 )
 UPDATE subscription_matches m

--- a/internal/platform/db/subscriptions.sql.go
+++ b/internal/platform/db/subscriptions.sql.go
@@ -14,20 +14,25 @@ import (
 const claimSubscriptionMatches = `-- name: ClaimSubscriptionMatches :many
 WITH claimable AS (
     SELECT m.subscription_id, m.job_id
-    FROM subscription_matches m
-    JOIN subscriptions s ON s.id = m.subscription_id
-    WHERE m.notified_at IS NULL
-      AND m.failed_at IS NULL
-      AND (m.claimed_at IS NULL
-           OR m.claimed_at < now() - make_interval(secs => $1::int))
-      AND s.active
-    -- Grouped by subscription so the delivery loop can build one digest each.
-    -- The matched_at/job_id tiebreak makes a batch_size cut deterministic (oldest
-    -- matches land in this batch); a subscription with more than batch_size pending
-    -- matches splits across passes into multiple digests — an accepted rare case.
-    ORDER BY m.subscription_id, m.matched_at, m.job_id
-    FOR UPDATE OF m SKIP LOCKED
-    LIMIT $2
+    FROM subscriptions s
+    CROSS JOIN LATERAL (
+        SELECT mm.subscription_id, mm.job_id
+        FROM subscription_matches mm
+        WHERE mm.subscription_id = s.id
+          AND mm.notified_at IS NULL
+          AND mm.failed_at IS NULL
+          AND (mm.claimed_at IS NULL
+               OR mm.claimed_at < now() - make_interval(secs => $1::int))
+        -- Oldest first WITHIN the subscription: a digest that splits across passes sends
+        -- the matches in the order they were found.
+        ORDER BY mm.matched_at, mm.job_id
+        LIMIT $2
+        FOR UPDATE SKIP LOCKED
+    ) m
+    WHERE s.active
+    -- A backstop, not the working bound: per_subscription x active subscriptions is what
+    -- a pass normally claims. This only caps a pathological subscription count.
+    LIMIT $3
 )
 UPDATE subscription_matches m
 SET claimed_at = now()
@@ -37,8 +42,9 @@ RETURNING m.subscription_id, m.job_id
 `
 
 type ClaimSubscriptionMatchesParams struct {
-	LeaseSeconds int32 `json:"lease_seconds"`
-	BatchSize    int32 `json:"batch_size"`
+	LeaseSeconds    int32 `json:"lease_seconds"`
+	PerSubscription int32 `json:"per_subscription"`
+	BatchSize       int32 `json:"batch_size"`
 }
 
 type ClaimSubscriptionMatchesRow struct {
@@ -46,15 +52,26 @@ type ClaimSubscriptionMatchesRow struct {
 	JobID          int64 `json:"job_id"`
 }
 
-// Lease a batch of pending, live matches for active subscriptions by stamping
-// claimed_at, oldest-claimable first, ordered by subscription so the worker can
-// group a subscription's matches into one digest. FOR UPDATE OF m locks only match
-// rows; SKIP LOCKED lets overlapping passes take disjoint rows so a digest is sent
-// at most once; the lease predicate reclaims rows whose sender died (stale
-// claimed_at), so no separate reaper is needed. The digest is sent OUTSIDE this
-// claim's transaction, so no network call is held inside a row lock.
+// Lease pending, live matches for active subscriptions by stamping claimed_at,
+// AT MOST per_subscription of them per subscription, so one busy subscription cannot
+// starve the rest. FOR UPDATE OF the match rows with SKIP LOCKED lets overlapping passes
+// take disjoint rows so a digest is sent at most once; the lease predicate reclaims rows
+// whose sender died (stale claimed_at), so no separate reaper is needed. The digest is
+// sent OUTSIDE this claim's transaction, so no network call is held inside a row lock.
+//
+// The per-subscription cap is the whole point. This used to be one flat
+// `ORDER BY subscription_id, matched_at LIMIT batch_size` over every pending row, which
+// reads as "oldest first" but is really "lowest subscription id first": a subscription
+// whose filter matches most of the catalogue fills the batch every pass and every
+// higher id is never reached. Measured on prod 2026-09-04 — one subscription with an
+// EMPTY query held 248k pending matches, the queue was 1.14M deep, and subscriptions
+// above it had attempts=0 since the day they were created. Nothing was broken; they were
+// simply never in a batch.
+//
+// A LATERAL per subscription, rather than a window function, because FOR UPDATE cannot
+// be used with window functions — and the row lock is what makes concurrent passes safe.
 func (q *Queries) ClaimSubscriptionMatches(ctx context.Context, arg ClaimSubscriptionMatchesParams) ([]ClaimSubscriptionMatchesRow, error) {
-	rows, err := q.db.Query(ctx, claimSubscriptionMatches, arg.LeaseSeconds, arg.BatchSize)
+	rows, err := q.db.Query(ctx, claimSubscriptionMatches, arg.LeaseSeconds, arg.PerSubscription, arg.BatchSize)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/platform/db/subscriptions_integration_test.go
+++ b/internal/platform/db/subscriptions_integration_test.go
@@ -209,18 +209,18 @@ func TestSubscriptionMatchLedger(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		first, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 3600, BatchSize: 1})
+		first, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 3600, PerSubscription: 100, BatchSize: 1})
 		if err != nil || len(first) != 1 {
 			t.Fatalf("first claim: rows=%d err=%v, want 1", len(first), err)
 		}
-		second, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 3600, BatchSize: 10})
+		second, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 3600, PerSubscription: 100, BatchSize: 10})
 		if err != nil || len(second) != 1 {
 			t.Fatalf("second claim: rows=%d err=%v, want 1 (the other row)", len(second), err)
 		}
 		if first[0].JobID == second[0].JobID {
 			t.Errorf("both claims returned job %d — not disjoint", first[0].JobID)
 		}
-		third, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 3600, BatchSize: 10})
+		third, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 3600, PerSubscription: 100, BatchSize: 10})
 		if err != nil || len(third) != 0 {
 			t.Errorf("third claim: rows=%d, want 0 (all leased)", len(third))
 		}
@@ -233,13 +233,13 @@ func TestSubscriptionMatchLedger(t *testing.T) {
 		if _, err := recordMatch(ctx, q, sub, job); err != nil {
 			t.Fatal(err)
 		}
-		if c, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 3600, BatchSize: 10}); err != nil || len(c) != 1 {
+		if c, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 3600, PerSubscription: 100, BatchSize: 10}); err != nil || len(c) != 1 {
 			t.Fatalf("claim: rows=%d err=%v, want 1", len(c), err)
 		}
-		if c, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 3600, BatchSize: 10}); err != nil || len(c) != 0 {
+		if c, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 3600, PerSubscription: 100, BatchSize: 10}); err != nil || len(c) != 0 {
 			t.Fatalf("re-claim within lease: rows=%d, want 0", len(c))
 		}
-		if c, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 0, BatchSize: 10}); err != nil || len(c) != 1 {
+		if c, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 0, PerSubscription: 100, BatchSize: 10}); err != nil || len(c) != 1 {
 			t.Errorf("re-claim with expired lease: rows=%d err=%v, want 1", len(c), err)
 		}
 	})
@@ -251,7 +251,7 @@ func TestSubscriptionMatchLedger(t *testing.T) {
 		if _, err := recordMatch(ctx, q, sub, job); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 3600, BatchSize: 10}); err != nil {
+		if _, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 3600, PerSubscription: 100, BatchSize: 10}); err != nil {
 			t.Fatal(err)
 		}
 		n, err := q.MarkMatchesNotified(ctx, MarkMatchesNotifiedParams{SubscriptionID: sub, JobIds: []int64{job}})
@@ -259,7 +259,7 @@ func TestSubscriptionMatchLedger(t *testing.T) {
 			t.Fatalf("mark notified: rows=%d err=%v, want 1", n, err)
 		}
 		// Even with an expired lease, a notified row is never claimed again.
-		if c, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 0, BatchSize: 10}); err != nil || len(c) != 0 {
+		if c, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 0, PerSubscription: 100, BatchSize: 10}); err != nil || len(c) != 0 {
 			t.Errorf("claim after notify: rows=%d, want 0", len(c))
 		}
 	})
@@ -276,14 +276,14 @@ func TestSubscriptionMatchLedger(t *testing.T) {
 			t.Fatal(err)
 		}
 		// One failure: still retryable (claimable with an expired lease).
-		if c, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 0, BatchSize: 10}); err != nil || len(c) != 1 {
+		if c, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 0, PerSubscription: 100, BatchSize: 10}); err != nil || len(c) != 1 {
 			t.Fatalf("claim after 1 failure: rows=%d, want 1", len(c))
 		}
 		if err := q.RecordMatchDeliveryFailure(ctx, fail); err != nil {
 			t.Fatal(err)
 		}
 		// Second failure reaches the max → dead-lettered, never claimed again.
-		if c, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 0, BatchSize: 10}); err != nil || len(c) != 0 {
+		if c, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 0, PerSubscription: 100, BatchSize: 10}); err != nil || len(c) != 0 {
 			t.Errorf("claim after dead-letter: rows=%d, want 0", len(c))
 		}
 	})
@@ -303,7 +303,7 @@ func TestSubscriptionMatchLedger(t *testing.T) {
 		if _, err := q.SetSubscriptionActive(ctx, SetSubscriptionActiveParams{Active: false, ID: sub.ID, UserID: uid}); err != nil {
 			t.Fatal(err)
 		}
-		if c, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 0, BatchSize: 10}); err != nil || len(c) != 0 {
+		if c, err := q.ClaimSubscriptionMatches(ctx, ClaimSubscriptionMatchesParams{LeaseSeconds: 0, PerSubscription: 100, BatchSize: 10}); err != nil || len(c) != 0 {
 			t.Errorf("claim for inactive subscription: rows=%d, want 0", len(c))
 		}
 	})


### PR DESCRIPTION
Reported as "I get no Telegram notifications". Nothing was failing.

## What was actually happening

The claim was `ORDER BY subscription_id, matched_at LIMIT batch_size` over every pending row. That reads as *"oldest first"*. It is really **"lowest subscription id first"** — and with a batch of 500, a subscription whose filter matches most of the catalogue fills it every pass, forever.

Measured on prod today:

```
subscription  26 ->    1 118 pending
subscription  94 ->   46 268
subscription  95 ->  248 147   <- saved search with an EMPTY query
subscription  97 ->  104 069
the reporter's   ->    8 324    attempts = 0
queue total      -> 1 141 757
```

`notify` ran every five minutes and logged `delivered=1 failed=0` — one digest, to the same low id, pass after pass. Every subscription above it had `attempts = 0` **since the day it was created**: not retried, not dead-lettered, simply never in a batch. At 500 rows per pass against a queue growing 50–150k a day, they never would be.

## The fix

Claim at most `SnapshotCap` rows **per subscription**, via a `LATERAL` — not a window function, because `FOR UPDATE` cannot be used with one, and the row lock is what keeps two overlapping passes from sending a digest twice.

`ClaimBatch` becomes a backstop rather than the working bound. Left at 500 it would have re-created the very cut it was meant to remove, so it is raised to match.

## Tests

Two integration tests, because the cap lives in SQL and only a real Postgres can show it:

- a 400-match hoarder holding the **lowest** id takes exactly its cap, while two later subscriptions still get their matches;
- a second pass takes the **next** slice rather than re-serving the first (the lease).

## Done separately, on prod

The 1.14M backlog was aged out by hand before this: the newest 200 per subscription kept (6 854 rows — exactly what a digest can carry), the rest marked failed with a reason naming the day and the cause. Delivery immediately went from `delivered=1` to `delivered=7` per pass.

## Not addressed here

A saved search with an **empty query** matches the whole catalogue — that is where the 248k came from. The guard belongs at creation, and is its own change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Subscription match processing now distributes work more evenly across subscriptions instead of allowing one large backlog to dominate a batch.
  - Successive processing passes claim distinct leased matches, reducing duplicate delivery attempts.
  - Processing remains protected by an overall batch limit while applying a per-subscription cap.

- **Bug Fixes**
  - Subscriptions can no longer be created for saved searches without filters.
  - Clear guidance is provided to add a filter before subscribing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->