### PR TITLE
Say the Hungarian trap once, and let the web test pin the entry it names

### DIFF
--- a/internal/dict/classify/classify_test.go
+++ b/internal/dict/classify/classify_test.go
@@ -373,10 +373,11 @@ func TestParse_ITCompanyRoles(t *testing.T) {
 	}
 }
 
-// TestParse_ITTitlesFallingToBareAnalyst pins the IT roles that resolved a category
-// only by reaching the table's bare "analyst" fall-through, which reads every
-// remaining analyst as data_analytics. Each names its own discipline outright.
-func TestParse_ITTitlesFallingToBareAnalyst(t *testing.T) {
+// TestParse_ITRolesTheTableDidNotName pins the IT roles that reached a category
+// only through one of the table's bare fall-throughs — "analyst" reads every
+// remaining analyst as data_analytics — so they resolved confidently WRONG rather
+// than not at all. Each now names its own discipline.
+func TestParse_ITRolesTheTableDidNotName(t *testing.T) {
 	cases := []struct{ title, wantCategory string }{
 		{"Lead Service Desk Analyst", "support"},
 		{"IT Service Desk Specialist Level II", "support"},
@@ -385,7 +386,6 @@ func TestParse_ITTitlesFallingToBareAnalyst(t *testing.T) {
 		{"IT Infrastructure Analyst (Networks and Telecoms)", "devops"},
 		{"MES Developer (Delmia Apriso)", "software_engineering"},
 		// Unchanged: the bare nouns keep falling through as before.
-		{"Data Analyst", "data_analytics"},
 		{"Business Analyst", "business_analysis"},
 		{"Infrastructure Project Manager", "project_management"},
 	}
@@ -396,12 +396,11 @@ func TestParse_ITTitlesFallingToBareAnalyst(t *testing.T) {
 	}
 }
 
-// TestParse_HungarianSoftwareTitles pins the Hungarian software vocabulary added
-// after auditing a general-population Hungarian board, where the two IT sitemaps
-// are not where every technical posting is filed. The negatives are the point:
-// "fejlesztő" is Hungarian for "developer" and the catalogue uses it for materials,
-// supplier, process, product, business and training development, so only the
-// anchored compounds may resolve.
+// TestParse_HungarianSoftwareTitles pins the Hungarian software vocabulary, added
+// after auditing a general-population Hungarian board where the IT sections are not
+// where every technical posting is filed. The negatives are the point: "fejlesztő"
+// is the bare "developer" noun, and the table's comment lists the non-software
+// senses the catalogue uses it for.
 func TestParse_HungarianSoftwareTitles(t *testing.T) {
 	cases := []struct{ title, wantCategory string }{
 		{"Szoftverfejlesztő - ERP terület", "software_engineering"},
@@ -419,7 +418,7 @@ func TestParse_HungarianSoftwareTitles(t *testing.T) {
 		{"SAP ABAP fejlesztő (LJK)", "software_engineering"},
 		{"Senior PEGA fejlesztő", "software_engineering"},
 		{"Odoo-fejlesztő", "software_engineering"},
-		{"Full-Stack Webfejlesztő", "fullstack"},
+		{"Webfejlesztő", "software_engineering"},
 		{"Adattárház fejlesztő", "data_engineering"},
 		{"BI fejlesztő", "data_analytics"},
 		{"BI riportfejlesztő", "data_analytics"},

--- a/internal/dict/classify/dictionaries.go
+++ b/internal/dict/classify/dictionaries.go
@@ -931,15 +931,14 @@ var categoryTable = []aliasEntry{
 	// every language's gendered and inclusive spellings is future work, not done
 	// here.
 	//
-	// Hungarian. "fejlesztő" is the bare noun and prod titles show it is the most
-	// dangerous one yet: on the open catalogue it names materials, supplier,
-	// process, product, business, operations and training development
-	// ("Anyagfejlesztő", "Beszállítófejlesztő mérnök", "Folyamatfejlesztő",
-	// "Termékfejlesztő szakértő", "Üzletfejlesztési menedzser", "Működésfejlesztési
-	// szakértő", "Képzés-fejlesztési gyakornok") alongside the software roles. Every
-	// entry below therefore carries a software or language anchor. Hungarian writes
-	// closed compounds where English writes two words, so a compound spelling never
-	// contains its spaced twin on a word boundary and both are listed.
+	// Hungarian. The bare noun is "fejlesztő", and on the open catalogue it names
+	// materials, supplier, process, product, business, operations and training
+	// development ("Anyagfejlesztő", "Beszállítófejlesztő mérnök",
+	// "Folyamatfejlesztő", "Termékfejlesztő szakértő", "Üzletfejlesztési menedzser",
+	// "Működésfejlesztési szakértő", "Képzés-fejlesztési gyakornok") alongside the
+	// software roles. Hungarian also writes closed compounds where English writes two
+	// words, so a compound never contains its spaced twin on a word boundary and both
+	// spellings are listed.
 	{"szoftverfejlesztő", "software_engineering"},
 	{"szoftver fejlesztő", "software_engineering"},
 	{"szoftvermérnök", "software_engineering"},

--- a/internal/dict/classify/tech.go
+++ b/internal/dict/classify/tech.go
@@ -66,8 +66,7 @@ var techTitleTerms = []string{
 	// — reactive, ticket-driven — and wrong about the craft: a help desk runs an IT
 	// estate. The bare nouns stay out. "support" alone is the whole customer-service
 	// population (226k open postings), and only "desk" and the IT-anchored analyst
-	// form are specific enough to carry the claim. Spaced and closed spellings are
-	// separate terms for the same reason the category table lists both.
+	// form are specific enough to carry the claim.
 	"service desk", "help desk", "helpdesk", "technical support analyst",
 	// Architects (never bare "architect")
 	"software architect", "solutions architect", "cloud architect", "data architect",


### PR DESCRIPTION
Polish pass over #2422. **Comments and tests only** — no alias was added, removed or moved, so `web/src/lib/generated/contracts.ts` is unchanged and `go test ./...` is green without touching it.

Four things:

- The Hungarian block opened by restating the non-English doctrine written directly above it, then ranked its own trap ("the most dangerous one yet"), which the evidence cannot order. Trimmed to what only Hungarian needs: the non-software senses the catalogue spends `fejlesztő` on, and the closed-compound spelling rule.
- The service-desk term in `tech.go` carried a third copy of the spaced/closed spelling rule this file already states twice.
- `TestParse_ITTitlesFallingToBareAnalyst` was named for one of the two fall-throughs it covers — half its cases are specialists, directors and managers, not analysts — and re-asserted `Data Analyst`, which the test directly above it already pins. Renamed `TestParse_ITRolesTheTableDidNotName`; duplicate case dropped.
- The Hungarian test claimed to cover `webfejlesztő` via "Full-Stack Webfejlesztő", but the existing `full-stack` entry decides that title before the new entry is reached, so the case pinned nothing. Now the bare form.

While auditing I also checked every alias #2422 added for reachability: dropping each one in turn and re-parsing 4342 live prod titles, none is shadowed by an earlier entry, and the load-bearing ones are `service desk` (1167 titles), `it infrastructure` (568) and `soc analyst` (158). The eight with no live hit yet are all spelling variants of an evidenced term or came from the reporter's audit of postings this catalogue has not crawled, so they stay.