### PR TITLE
Let the search box take a job link, not just words to search for

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -59,6 +59,7 @@ import type {
   SubmissionInput,
   PrefillResult,
   Contribution,
+  FoundJob,
   ResolvedLink,
   ReferralOffer,
   ReferralRequestInput,
@@ -1553,6 +1554,14 @@ export function createApi(
     return requestData<PrefillResult>('/api/v1/submissions/prefill', jsonBody('POST', { url }));
   }
 
+  /** Ask whether a job page in the wild is one the catalog already carries. Public and
+   *  read-only — it writes nothing, records no contribution, and fetches no page, so it is
+   *  the half of the link intake a signed-out visitor may run. `null` means the URL names
+   *  no posting we hold, which is an answer rather than an error. */
+  async function findJobByUrl(url: string): Promise<FoundJob | null> {
+    return requestData<FoundJob | null>(`/api/v1/jobs/find?url=${encodeURIComponent(url)}`);
+  }
+
   /** Hand a job link to freehire. One sequence serves every surface: the catalog is checked,
    *  the vacancy imported when anything can read it, and the board behind it recorded for
    *  onboarding either way. The outcome says which of those happened (422 for a non-URL). */
@@ -2331,6 +2340,7 @@ export function createApi(
     submitJob,
     listMySubmissions,
     prefillSubmission,
+    findJobByUrl,
     resolveJobLink,
     listMyContributions,
     createReferralRequest,

--- a/web/src/lib/components/ContributeView.svelte
+++ b/web/src/lib/components/ContributeView.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { page } from '$app/state';
   import { resolve } from '$app/paths';
   import { api, ApiError } from '$lib/api';
   import { AsyncData } from '$lib/asyncData.svelte';
@@ -6,9 +7,15 @@
   import type { Contribution, DiscordStatus, ResolvedLink } from '$lib/types';
   import { Badge, Button, Input } from '$lib/ui';
   import { timeAgo } from '$lib/utils';
+  import IntakeOutcome from './IntakeOutcome.svelte';
   import States from './States.svelte';
 
-  let url = $state('');
+  // Prefilled, not auto-submitted, when a link arrives in `?url=`. That is how the search
+  // box hands a signed-out visitor's paste across the sign-in it needed — the link would
+  // otherwise be the price of signing in. Submitting it on arrival would let any page link
+  // here and record a contribution in the visitor's name without them touching anything,
+  // so the last step stays theirs.
+  let url = $state(page.url.searchParams.get('url') ?? '');
   let submitting = $state(false);
   let formError = $state<string | null>(null);
   // What became of the last link handed in — the intake answers with one of four outcomes
@@ -108,40 +115,7 @@
 
     {#if resolved}
       <div class="rounded-lg border border-border bg-secondary/40 p-4 text-sm" role="status">
-        {#if resolved.status === 'found'}
-          We already have this one.
-        {:else if resolved.status === 'tracked'}
-          Added — and we already track this company, so the rest of its roles will follow on the
-          next crawl.
-        {:else if resolved.status === 'imported' && resolved.company_slug}
-          Added — we already carry this company, and now we'll crawl this board of theirs too.
-          <span class="font-medium">+1 AI credit.</span>
-        {:else if resolved.status === 'imported'}
-          Added, and this company is new to us — we'll start crawling its board.
-          <span class="font-medium">+1 AI credit.</span>
-        {:else if resolved.status === 'review'}
-          Added. Its careers site isn't one we can crawl yet, so we'll check by hand whether we
-          can pull the rest of its jobs. <span class="font-medium">Not credited yet.</span>
-        {:else}
-          We couldn't read that page. We'll check by hand whether we can pull its jobs — if we
-          can, we'll award you a credit. <span class="font-medium">Not credited yet.</span>
-        {/if}
-        {#if resolved.public_slug}
-          <a
-            href={resolve('/jobs/[slug]', { slug: resolved.public_slug })}
-            class="font-medium underline underline-offset-4"
-          >
-            View the job →
-          </a>
-        {/if}
-        {#if resolved.company_slug}
-          <a
-            href={resolve('/companies/[slug]', { slug: resolved.company_slug })}
-            class="font-medium underline underline-offset-4"
-          >
-            View the company →
-          </a>
-        {/if}
+        <IntakeOutcome {resolved} />
       </div>
     {/if}
 

--- a/web/src/lib/components/HeaderSearch.svelte
+++ b/web/src/lib/components/HeaderSearch.svelte
@@ -312,6 +312,12 @@
       signedIn: isAuthenticated,
     });
     linkBusy = false;
+    // The box may have moved on while the intake was out: a paste over the old text, or
+    // the text cleared entirely. The answer is about the URL we asked with, so applying
+    // it now would navigate to a posting nobody is asking about any more — the same
+    // stale-response hazard the suggestion fetches guard with `previewToken`, answered
+    // here by the question itself rather than by a counter.
+    if (link?.url !== pasted.url) return;
     if (step.kind === 'open') {
       openPosting(step.slug);
       return;

--- a/web/src/lib/components/HeaderSearch.svelte
+++ b/web/src/lib/components/HeaderSearch.svelte
@@ -3,8 +3,9 @@
   import { goto } from '$app/navigation';
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
-  import { LayoutGrid, Search, SlidersHorizontal, Tag, X } from '@lucide/svelte';
+  import { LayoutGrid, Link2, Search, SlidersHorizontal, Tag, X } from '@lucide/svelte';
   import { api } from '$lib/api';
+  import { isAuthenticated } from '$lib/auth.svelte';
   import { browseQuery, planForSuggestion } from '$lib/browseTarget';
   import { dropdownRows, namedCompanies, type DropdownRow } from '$lib/dropdownRows';
   import { companyLogoUrl } from '$lib/logo';
@@ -13,10 +14,13 @@
   import { listSearchTarget, type ListSearchTarget } from '$lib/listSearch.svelte';
   import { headerFilterTrigger } from '$lib/headerFilterTrigger';
   import { fromApi, applyParams, type ApplyPlan } from '$lib/apiSuggestions';
+  import { pastedJobLink, type PastedJobLink } from '$lib/jobLink';
+  import { runLinkIntake, type LinkIntakeStep } from '$lib/linkIntake';
   import { commit, edit, emptyDraft, reconcile, type SearchDraft } from '$lib/searchDraft';
   import { starterSuggestions, type Suggestion } from '$lib/suggestions';
   import { cn } from '$lib/ui';
   import HeaderLocationFilter from './HeaderLocationFilter.svelte';
+  import IntakeOutcome from './IntakeOutcome.svelte';
 
   // The header's search box — the ONE of them, on every page.
   //
@@ -265,8 +269,74 @@
     })();
   });
 
+  // ── A pasted link ─────────────────────────────────────────────────────────
+  //
+  // The box is one input serving two intents: almost everything typed into it is a
+  // query, and occasionally somebody drops in the URL of a vacancy they found elsewhere.
+  // Searching that URL as text finds nothing every time, so the box recognises it and
+  // offers the other thing instead — look it up, and hand it in if we don't have it.
+  //
+  // Recognition follows the DRAFT rather than the settled query: a paste is a complete
+  // thought the moment it lands, and making it wait out the suggestion debounce would
+  // show a panel of nothing first.
+  const link = $derived(pastedJobLink(draft.text, page.url.origin));
+
+  let linkBusy = $state(false);
+  // Where the last run stopped, when it stopped anywhere worth showing. Null while
+  // nothing has been asked yet — the row then offers to ask.
+  let linkStep = $state.raw<LinkIntakeStep | null>(null);
+
+  // A different link is a different question, so the previous answer goes. Reading only
+  // the URL here (not `linkStep`) is what keeps this from undoing its own writes.
+  $effect(() => {
+    link?.url;
+    linkStep = null;
+  });
+
+  /** Where a signed-out visitor goes to hand this link in. The link rides along in the
+   *  return path so it survives the round trip — otherwise signing in costs them the
+   *  paste, and the whole point was that they had it in hand. */
+  const signinHref = $derived.by(() => {
+    const back = `/my/contributions?url=${encodeURIComponent(link?.url ?? '')}`;
+    return `${resolve('/signin')}?returnTo=${encodeURIComponent(back)}`;
+  });
+
+  /** Look this link up, and hand it in if we don't have it. See $lib/linkIntake for the
+   *  order and why it is that way round. */
+  async function activateLink(pasted: PastedJobLink) {
+    // One of our own posting pages: the slug is in the path, so asking the API whether
+    // we carry a posting we are serving right now would be asking ourselves.
+    if (pasted.ownSlug) {
+      openPosting(pasted.ownSlug);
+      return;
+    }
+    if (linkBusy) return;
+    linkBusy = true;
+    linkStep = null;
+    const step = await runLinkIntake(pasted.url, {
+      find: (u) => api.findJobByUrl(u),
+      submit: (u) => api.resolveJobLink(u),
+      signedIn: isAuthenticated,
+    });
+    linkBusy = false;
+    if (step.kind === 'open') {
+      openPosting(step.slug);
+      return;
+    }
+    linkStep = step;
+  }
+
+  /** Go to a posting and leave the box empty behind us: the URL that got us there is
+   *  not a query, and leaving it sitting in the header over the vacancy it opened reads
+   *  as a search that is still running. */
+  function openPosting(slug: string) {
+    draft = commit(edit(draft, ''));
+    close();
+    void goto(resolve('/jobs/[slug]', { slug }));
+  }
+
   const rows = $derived(
-    dropdownRows({ suggestions, jobs, companies, text: draft.text }),
+    dropdownRows({ suggestions, jobs, companies, text: draft.text, link }),
   );
   const suggestOpen = $derived(rows.length > 0 && !dismissed);
   const rowCount = $derived(suggestOpen ? rows.length : 0);
@@ -284,6 +354,15 @@
    *  navigates to the feed carrying the query. The target is never null — off a list
    *  page it is the navigating one — so this path has no "nobody received it" case. */
   function runSearch() {
+    // Enter on a pasted link runs the link, not a text search for it. This sits here
+    // rather than in the keyboard handler because every path that searches free text
+    // comes through this function, and a URL is never the text somebody meant to search
+    // for — including from the dropdown's own last row, which is why that row is not
+    // offered at all while a link is recognised.
+    if (link) {
+      void activateLink(link);
+      return;
+    }
     draft = commit(draft);
     target.commitQuery(draft.committed);
     close();
@@ -296,6 +375,10 @@
     if (!row) return;
     if (row.kind === 'text') {
       runSearch();
+      return;
+    }
+    if (row.kind === 'link') {
+      void activateLink(row.link);
       return;
     }
     if (row.kind === 'job') {
@@ -369,11 +452,24 @@
    *  neighbours (postings, companies), and there "Filter by" says what picking one of
    *  these rows does rather than what it is. */
   function sectionHeading(kind: DropdownRow['kind']): string | null {
-    if (kind === 'text') return null;
+    if (kind === 'text' || kind === 'link') return null;
     if (kind === 'job') return 'Jobs';
     if (kind === 'company') return 'Companies';
     return draft.text.trim() === '' ? null : 'Filter by';
   }
+
+  /** The panel a recognised link drops.
+   *
+   *  It does NOT take the phone's screen the way the suggestions list does. That panel
+   *  goes full-bleed because it is a dozen rows that truncate at the box's width; this
+   *  one is a sentence, and a sentence stretched from the header to the bottom of the
+   *  screen reads as a page that has gone wrong. */
+  const linkPanelClass = $derived(
+    cn(
+      'absolute inset-x-0 top-full z-50 mt-2 border border-border bg-background px-3 py-2.5 text-sm shadow-lg',
+      hero ? 'rounded-2xl' : 'rounded-md',
+    ),
+  );
 
   const rowClass = (active: boolean) =>
     cn(
@@ -538,7 +634,52 @@
        Section headings ride on the row (`first`) rather than living in a second
        structure: one list means one set of indices, and the arrow keys cross a section
        boundary without knowing there was one. -->
-  {#if suggestOpen}
+  <!-- A recognised link takes the panel over. It is not a listbox: there is one thing to
+       do and no list to walk, and the states it passes through carry a link of their own
+       (sign in, view the company), which cannot live inside an option's button. -->
+  {#if link && !dismissed}
+    <div class={linkPanelClass} role="status" aria-live="polite">
+      {#if linkBusy}
+        <span class="flex items-center gap-2 text-muted-foreground">
+          <Link2 class="size-4 shrink-0" />
+          Checking whether we have this one…
+        </span>
+      {:else if linkStep?.kind === 'signin'}
+        <span class="flex flex-col gap-1">
+          <span>We don't have this one yet.</span>
+          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- query string appended to a resolved path -->
+          <a href={signinHref} class="font-medium underline underline-offset-4">
+            Sign in to send it to us →
+          </a>
+        </span>
+      {:else if linkStep?.kind === 'outcome'}
+        <IntakeOutcome resolved={linkStep.resolved} />
+      {:else if linkStep?.kind === 'error'}
+        <span class="flex flex-col gap-1">
+          <span>That didn't go through.</span>
+          <button
+            type="button"
+            onclick={() => link && activateLink(link)}
+            class="self-start font-medium underline underline-offset-4"
+          >
+            Try again
+          </button>
+        </span>
+      {:else}
+        <button
+          type="button"
+          onclick={() => link && activateLink(link)}
+          class="flex w-full items-center gap-2 text-left"
+        >
+          <Link2 class="size-4 shrink-0 text-muted-foreground" />
+          <span class="min-w-0 flex-1 truncate">Open this job link</span>
+          <kbd class="hidden shrink-0 rounded border border-border px-1.5 text-xs text-muted-foreground sm:inline">
+            ↵
+          </kbd>
+        </button>
+      {/if}
+    </div>
+  {:else if suggestOpen}
     <ul
       id="role-suggestions"
       role="listbox"
@@ -630,7 +771,7 @@
                 {row.company.job_count}
                 {row.company.job_count === 1 ? 'job' : 'jobs'}
               </span>
-            {:else}
+            {:else if row.kind === 'text'}
               <Search class="size-4 shrink-0 text-muted-foreground" />
               <span class="min-w-0 flex-1 truncate text-muted-foreground"
                 >Search “{row.text}” as text</span

--- a/web/src/lib/components/HeaderSearch.svelte
+++ b/web/src/lib/components/HeaderSearch.svelte
@@ -286,13 +286,6 @@
   // nothing has been asked yet — the row then offers to ask.
   let linkStep = $state.raw<LinkIntakeStep | null>(null);
 
-  // A different link is a different question, so the previous answer goes. Reading only
-  // the URL here (not `linkStep`) is what keeps this from undoing its own writes.
-  $effect(() => {
-    link?.url;
-    linkStep = null;
-  });
-
   /** Where a signed-out visitor goes to hand this link in. The link rides along in the
    *  return path so it survives the round trip — otherwise signing in costs them the
    *  paste, and the whole point was that they had it in hand. */
@@ -551,6 +544,9 @@
       oninput={(e) => {
         dismissed = false;
         activeIndex = -1;
+        // Editing the text asks a different question, so the last link's answer goes
+        // with it — otherwise a half-corrected URL sits under a verdict on the old one.
+        linkStep = null;
         draft = edit(draft, e.currentTarget.value);
       }}
       onfocus={() => {

--- a/web/src/lib/components/IntakeOutcome.svelte
+++ b/web/src/lib/components/IntakeOutcome.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  // What became of a link somebody handed in, rendered the same way wherever they
+  // handed it in — the contribute form and the search box both mount this. The words
+  // are in $lib/intakeOutcome (tested there); this adds the two places the outcome can
+  // send you, which only some outcomes have.
+  //
+  // Presentation is deliberately bare: no border, no padding, no background. The two
+  // callers frame an outcome very differently (a panel on a page, a row in a dropdown),
+  // and a component that brought its own box would have to be talked out of it twice.
+  import { resolve } from '$app/paths';
+  import { intakeOutcomeMessage } from '$lib/intakeOutcome';
+  import type { ResolvedLink } from '$lib/types';
+
+  let { resolved }: { resolved: ResolvedLink } = $props();
+</script>
+
+{intakeOutcomeMessage(resolved)}
+{#if resolved.public_slug}
+  <a
+    href={resolve('/jobs/[slug]', { slug: resolved.public_slug })}
+    class="font-medium underline underline-offset-4"
+  >
+    View the job →
+  </a>
+{/if}
+{#if resolved.company_slug}
+  <a
+    href={resolve('/companies/[slug]', { slug: resolved.company_slug })}
+    class="font-medium underline underline-offset-4"
+  >
+    View the company →
+  </a>
+{/if}

--- a/web/src/lib/dropdownRows.test.ts
+++ b/web/src/lib/dropdownRows.test.ts
@@ -33,6 +33,31 @@ describe('dropdownRows', () => {
       .map((r) => r.kind)).toEqual(['suggestion']);
   });
 
+  // A pasted URL is not text anybody wrote to be searched for: the sections behind it
+  // are answers to a full-text search that finds nothing, so the panel becomes one row.
+  it('replaces the whole panel with the link row when the text is a link', () => {
+    const link = { url: 'https://acme.com/jobs/1', ownSlug: null };
+    const rows = dropdownRows({
+      suggestions: [suggestion('a')],
+      jobs: [job('j')],
+      companies: [company('c')],
+      text: 'https://acme.com/jobs/1',
+      link,
+    });
+    expect(rows).toEqual([{ kind: 'link', link, key: 'l', first: true }]);
+  });
+
+  it('keeps the ordinary panel when the text is not a link', () => {
+    const rows = dropdownRows({
+      suggestions: [suggestion('a')],
+      jobs: [],
+      companies: [],
+      text: 'go',
+      link: null,
+    });
+    expect(rows.map((r) => r.kind)).toEqual(['suggestion', 'text']);
+  });
+
   it('skips a section that has nothing rather than leaving a gap', () => {
     const rows = dropdownRows({
       suggestions: [],

--- a/web/src/lib/dropdownRows.ts
+++ b/web/src/lib/dropdownRows.ts
@@ -8,6 +8,7 @@
 //
 // Pure by design: no Svelte, no DOM, no network.
 
+import type { PastedJobLink } from './jobLink';
 import type { Suggestion } from './suggestions';
 import type { Job, CompanyListItem } from './types';
 
@@ -19,6 +20,7 @@ export type DropdownRow = { key: string; first: boolean } & (
   | { kind: 'job'; job: Job }
   | { kind: 'company'; company: CompanyListItem }
   | { kind: 'text'; text: string }
+  | { kind: 'link'; link: PastedJobLink }
 );
 
 /** Keep only the companies the typed text actually NAMES.
@@ -65,6 +67,9 @@ export interface DropdownContent {
   /** What is typed in the box. Empty means no free-text row: there is nothing to
    *  offer searching for. */
   text: string;
+  /** The link recognised in `text`, when it is one. Set means the panel offers exactly
+   *  one thing — see below. */
+  link?: PastedJobLink | null;
 }
 
 /** Flatten the sections into the single list the keyboard walks.
@@ -72,6 +77,15 @@ export interface DropdownContent {
  *  A section with nothing in it contributes no rows at all, so an empty postings
  *  section leaves no gap in the numbering and no orphan heading. */
 export function dropdownRows(content: DropdownContent): DropdownRow[] {
+  // A pasted link REPLACES the panel rather than joining it. The other sections are
+  // answers to a full-text search, and a URL is not text anybody wrote to be searched
+  // for: the completions come back empty, the postings section matches on stray path
+  // fragments, and the free-text row offers to run a search that finds nothing. One row
+  // that does the one useful thing is the whole panel here.
+  if (content.link) {
+    return [{ kind: 'link', link: content.link, key: 'l', first: true }];
+  }
+
   const rows: DropdownRow[] = [];
 
   content.suggestions.forEach((suggestion, i) => {

--- a/web/src/lib/intakeOutcome.test.ts
+++ b/web/src/lib/intakeOutcome.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { intakeOutcomeMessage } from './intakeOutcome';
+import type { ResolvedLink } from './types';
+
+const link = (over: Partial<ResolvedLink>): ResolvedLink => ({
+  public_slug: null,
+  status: 'queued',
+  ...over,
+});
+
+describe('intakeOutcomeMessage', () => {
+  it('tells a known posting apart from a newly added one', () => {
+    expect(intakeOutcomeMessage(link({ status: 'found' }))).toMatch(/already have/i);
+    expect(intakeOutcomeMessage(link({ status: 'tracked' }))).toMatch(/^Added/);
+  });
+
+  it('separates a new company from a new board of a company we carry', () => {
+    const newCompany = intakeOutcomeMessage(link({ status: 'imported' }));
+    const knownCompany = intakeOutcomeMessage(
+      link({ status: 'imported', company_slug: 'acme' }),
+    );
+    expect(newCompany).toMatch(/new to us/i);
+    expect(knownCompany).toMatch(/already carry this company/i);
+  });
+
+  it('does not promise a crawl for a careers site nothing recognised', () => {
+    expect(intakeOutcomeMessage(link({ status: 'review' }))).toMatch(/by hand/i);
+  });
+
+  it('reads an unreadable page as "we will look", not as a refusal', () => {
+    const msg = intakeOutcomeMessage(link({ status: 'queued' }));
+    expect(msg).toMatch(/couldn't read/i);
+    expect(msg).toMatch(/by hand/i);
+  });
+
+  it('promises no reward — the currency it was paid in no longer exists', () => {
+    for (const status of ['found', 'tracked', 'imported', 'review', 'queued'] as const) {
+      expect(intakeOutcomeMessage(link({ status }))).not.toMatch(/credit/i);
+    }
+  });
+});

--- a/web/src/lib/intakeOutcome.ts
+++ b/web/src/lib/intakeOutcome.ts
@@ -1,0 +1,38 @@
+// What we tell somebody who handed us a job link, in words.
+//
+// The intake answers with five outcomes rather than accepted/rejected (see
+// internal/api/handler/intake.go), and every surface that accepts a link has to put the
+// same five into the same words. There are two such surfaces on the website now — the
+// contribute form and the search box — which is exactly one more than it takes for two
+// copies to drift, so the words live here and both render them.
+//
+// The message is the whole answer. A posting to go to is handled by the caller, because
+// only two of the five outcomes carry one and a sentence is not a link.
+
+import type { ResolvedLink } from './types';
+
+/** Put one intake outcome into words.
+ *
+ *  Nothing here promises a reward. Contributing a board earned an AI credit once; the
+ *  currency it was paid in no longer exists (a daily allowance is not something a
+ *  one-off act tops up), so the board is still recorded and still attributed, and the
+ *  submitter is simply not paid for it. Promising a credit that cannot arrive is worse
+ *  than promising nothing. */
+export function intakeOutcomeMessage(resolved: ResolvedLink): string {
+  switch (resolved.status) {
+    case 'found':
+      return 'We already have this one.';
+    case 'tracked':
+      return 'Added — and we already track this company, so the rest of its roles will follow on the next crawl.';
+    case 'imported':
+      return resolved.company_slug
+        ? "Added — we already carry this company, and now we'll crawl this board of theirs too."
+        : "Added, and this company is new to us — we'll start crawling its board.";
+    case 'review':
+      return "Added. Its careers site isn't one we can crawl yet, so we'll check by hand whether we can pull the rest of its jobs.";
+    default:
+      // queued: nothing could read the page. That says nothing about the board behind
+      // it, which was still recorded, so this is a "we'll look" rather than a refusal.
+      return "We couldn't read that page. We'll check by hand whether we can pull its jobs.";
+  }
+}

--- a/web/src/lib/jobLink.test.ts
+++ b/web/src/lib/jobLink.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { linkInText, pastedJobLink } from './jobLink';
+
+const ORIGIN = 'https://freehire.me';
+
+describe('linkInText', () => {
+  it('takes a URL that says so itself', () => {
+    expect(linkInText('https://job-boards.greenhouse.io/acme/jobs/123')).toBe(
+      'https://job-boards.greenhouse.io/acme/jobs/123',
+    );
+    expect(linkInText('http://acme.com/careers/1')).toBe('http://acme.com/careers/1');
+  });
+
+  // Copying from the address bar drops the scheme, so this is what a paste usually is.
+  it('takes a bare host with a path, and puts a scheme back on it', () => {
+    expect(linkInText('job-boards.greenhouse.io/acme/jobs/123')).toBe(
+      'https://job-boards.greenhouse.io/acme/jobs/123',
+    );
+    expect(linkInText('acme.com/jobs/1?src=x#top')).toBe('https://acme.com/jobs/1?src=x#top');
+  });
+
+  it('ignores the surrounding whitespace a paste brings with it', () => {
+    expect(linkInText('  https://acme.com/jobs/1  ')).toBe('https://acme.com/jobs/1');
+  });
+
+  // Every one of these is a query somebody typed on purpose. Reading one as a link would
+  // replace the whole dropdown with an offer to import it.
+  it.each([
+    'go',
+    'senior go developer',
+    'node.js',
+    'react.dev',
+    'express.js',
+    'c++',
+    'c++/cli',
+    'front end',
+    'https://',
+    '1.5/10',
+    '',
+    '   ',
+  ])('leaves %o to the search', (text) => {
+    expect(linkInText(text)).toBeNull();
+  });
+
+  it('leaves a scheme we would not fetch alone', () => {
+    expect(linkInText('mailto:jobs@acme.com')).toBeNull();
+    expect(linkInText('ftp://acme.com/jobs/1')).toBeNull();
+  });
+
+  // A domain with nothing after it is a COMPANY, and searching for the company is the
+  // better of the two answers.
+  it('leaves a bare domain to the search', () => {
+    expect(linkInText('greenhouse.io')).toBeNull();
+    expect(linkInText('acme.com')).toBeNull();
+  });
+});
+
+describe('pastedJobLink', () => {
+  it('reports nothing for a query', () => {
+    expect(pastedJobLink('senior go developer', ORIGIN)).toBeNull();
+  });
+
+  it('reports an outside link with no slug of ours', () => {
+    expect(pastedJobLink('https://acme.com/jobs/1', ORIGIN)).toEqual({
+      url: 'https://acme.com/jobs/1',
+      ownSlug: null,
+    });
+  });
+
+  // Pasting one of our own links back in is a thing people do, and there is nothing to
+  // look up: the slug is in the path.
+  it('reads the slug out of one of our own posting links', () => {
+    expect(pastedJobLink('https://freehire.me/jobs/go-dev-acme', ORIGIN)?.ownSlug).toBe(
+      'go-dev-acme',
+    );
+  });
+
+  it('judges "ours" by the running origin, so it holds on localhost too', () => {
+    expect(pastedJobLink('http://localhost:5173/jobs/go-dev-acme', 'http://localhost:5173')?.ownSlug)
+      .toBe('go-dev-acme');
+    // The same link is somebody else's site when served from production.
+    expect(pastedJobLink('http://localhost:5173/jobs/go-dev-acme', ORIGIN)?.ownSlug).toBeNull();
+  });
+
+  it('decodes a slug the path escaped', () => {
+    expect(pastedJobLink('https://freehire.me/jobs/c%2B%2B-dev', ORIGIN)?.ownSlug).toBe('c++-dev');
+  });
+
+  // Our own pages that are not postings take the ordinary path: the intake finding them
+  // uninteresting is the honest answer, and guessing a slug from them would not be.
+  it.each([
+    'https://freehire.me/companies/acme',
+    'https://freehire.me/jobs',
+    'https://freehire.me/jobs/go-dev-acme/apply',
+  ])('claims no slug for %o', (url) => {
+    expect(pastedJobLink(url, ORIGIN)?.ownSlug).toBeNull();
+  });
+});

--- a/web/src/lib/jobLink.test.ts
+++ b/web/src/lib/jobLink.test.ts
@@ -86,6 +86,13 @@ describe('pastedJobLink', () => {
     expect(pastedJobLink('https://freehire.me/jobs/c%2B%2B-dev', ORIGIN)?.ownSlug).toBe('c++-dev');
   });
 
+  // A lone `%` is a legal path and an illegal escape. This runs in a $derived on every
+  // keystroke in the header, so a throw here would take the page down, not the row.
+  it('survives a path that cannot be decoded', () => {
+    expect(() => pastedJobLink('https://freehire.me/jobs/100%', ORIGIN)).not.toThrow();
+    expect(pastedJobLink('https://freehire.me/jobs/100%', ORIGIN)?.ownSlug).toBe('100%');
+  });
+
   // Our own pages that are not postings take the ordinary path: the intake finding them
   // uninteresting is the honest answer, and guessing a slug from them would not be.
   it.each([

--- a/web/src/lib/jobLink.ts
+++ b/web/src/lib/jobLink.ts
@@ -103,5 +103,15 @@ function ownPostingSlug(url: URL, origin: string): string | null {
   // sending it to the posting would quietly drop what the visitor asked for.
   const [section, slug, ...rest] = url.pathname.split('/').filter((p) => p !== '');
   if (section !== 'jobs' || !slug || rest.length > 0) return null;
-  return decodeURIComponent(slug);
+
+  // A lone `%` is a legal path and an illegal escape, so decoding it THROWS — and this
+  // runs inside a $derived on every keystroke in the header, where a throw takes the
+  // whole page down rather than the one row. An undecodable segment is handed back as
+  // it stands: it is not a slug we issued, so it lands on our own 404 instead of a
+  // blank screen.
+  try {
+    return decodeURIComponent(slug);
+  } catch {
+    return slug;
+  }
 }

--- a/web/src/lib/jobLink.ts
+++ b/web/src/lib/jobLink.ts
@@ -1,0 +1,107 @@
+// Telling a pasted LINK apart from a typed QUERY, in the search box.
+//
+// The box is one input serving two intents now. Almost everything typed into it is a
+// query; occasionally somebody drops in the URL of a vacancy they found elsewhere and
+// wants to know whether we carry it. Running that URL as a full-text search finds
+// nothing, every time — so the box has to recognise it and offer the other thing.
+//
+// Pure by design: no Svelte, no DOM, no network. What HAPPENS to a recognised link
+// lives in linkIntake.svelte.ts; this module only answers "is this a link, and is it
+// one of ours".
+
+/** A link recognised in the search box.
+ *
+ *  `ownSlug` is set only when the URL is one of OUR OWN posting pages. Pasting a
+ *  freehire link back into freehire is a thing people do — from a chat, from their own
+ *  bookmarks — and there is nothing to look up in that case: the slug is in the path,
+ *  so the box can navigate straight there without asking the API whether we carry a
+ *  posting we are literally serving. */
+export interface PastedJobLink {
+  url: string;
+  ownSlug: string | null;
+}
+
+/** A bare host followed by a path: `boards.greenhouse.io/acme/jobs/123`.
+ *
+ *  The PATH is the load-bearing part. A vacancy always has one, and requiring it is what
+ *  keeps `node.js`, `react.dev` and `express.js` — all of them valid hostnames, all of
+ *  them things people type into this box meaning "find me jobs" — on the search side of
+ *  the line. A bare domain with no path is a company, and searching for the company is
+ *  the more useful of the two answers anyway.
+ *
+ *  The last label is letters only, so `1.5/10` and version numbers do not read as hosts. */
+const HOST_WITH_PATH = /^[a-z0-9-]+(?:\.[a-z0-9-]+)*\.[a-z]{2,}(?::\d+)?\/\S*$/i;
+
+/** Does this text name a web address? Returns the absolute URL to hand on, or null when
+ *  it is an ordinary query.
+ *
+ *  Deliberately conservative in one direction only: a paste that is not recognised still
+ *  runs as a search, which finds nothing and costs a retry. A QUERY misread as a link
+ *  would replace the panel with a row offering to import it — the box would look broken
+ *  for a word somebody typed on purpose. So the cheap mistake is the one this makes. */
+export function linkInText(text: string): string | null {
+  const trimmed = text.trim();
+  // Whitespace anywhere means a phrase. No URL survives a space, and most of what this
+  // box receives is two or three words.
+  if (trimmed === '' || /\s/.test(trimmed)) return null;
+
+  // An explicit scheme is somebody's own statement that this is an address; only http(s)
+  // is worth handing to the intake, which refuses anything else regardless.
+  if (/^https?:\/\//i.test(trimmed)) return hasHost(trimmed) ? trimmed : null;
+
+  // Browsers drop the scheme when you copy from the address bar, so a paste arrives bare
+  // more often than not.
+  if (!HOST_WITH_PATH.test(trimmed)) return null;
+  const withScheme = `https://${trimmed}`;
+  return hasHost(withScheme) ? withScheme : null;
+}
+
+/** Whether the URL parses and names a host — `https://` alone does neither. */
+function hasHost(raw: string): boolean {
+  try {
+    return new URL(raw).host !== '';
+  } catch {
+    return false;
+  }
+}
+
+/** Recognise a pasted link in the search box, and note when it is one of our own.
+ *
+ *  `origin` is the page's own origin, so a link is "ours" by the same rule in
+ *  production, in a preview deploy and on localhost — rather than by a hostname
+ *  hardcoded here, which would be right in exactly one of those three. */
+export function pastedJobLink(text: string, origin: string): PastedJobLink | null {
+  const url = linkInText(text);
+  if (url === null) return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+
+  return { url, ownSlug: ownPostingSlug(parsed, origin) };
+}
+
+/** The posting slug of one of our own job pages, or null for anything else.
+ *
+ *  Matched against the running origin rather than a hostname list: the same paste has
+ *  to behave the same way wherever the app is served from. A link to our own site that
+ *  is NOT a posting (a company page, the feed) returns null and takes the ordinary
+ *  path — the intake will find it uninteresting, which is the honest answer. */
+function ownPostingSlug(url: URL, origin: string): string | null {
+  let here: URL;
+  try {
+    here = new URL(origin);
+  } catch {
+    return null;
+  }
+  if (url.host !== here.host) return null;
+
+  // /jobs/<slug>, and nothing deeper: /jobs/<slug>/apply is a different page, and
+  // sending it to the posting would quietly drop what the visitor asked for.
+  const [section, slug, ...rest] = url.pathname.split('/').filter((p) => p !== '');
+  if (section !== 'jobs' || !slug || rest.length > 0) return null;
+  return decodeURIComponent(slug);
+}

--- a/web/src/lib/linkIntake.test.ts
+++ b/web/src/lib/linkIntake.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runLinkIntake, type LinkIntakeDeps } from './linkIntake';
+import type { ResolvedLink } from './types';
+
+function deps(over: Partial<LinkIntakeDeps> = {}): LinkIntakeDeps {
+  return {
+    find: vi.fn(async () => null),
+    submit: vi.fn(async () => ({ public_slug: null, status: 'queued' }) as ResolvedLink),
+    signedIn: () => true,
+    ...over,
+  };
+}
+
+describe('runLinkIntake', () => {
+  it('opens a posting the catalog already carries, without submitting it', async () => {
+    const d = deps({ find: vi.fn(async () => ({ public_slug: 'go-dev-acme' })) });
+    await expect(runLinkIntake('https://acme.com/jobs/1', d)).resolves.toEqual({
+      kind: 'open',
+      slug: 'go-dev-acme',
+    });
+    expect(d.submit).not.toHaveBeenCalled();
+  });
+
+  it('opens it for a signed-out visitor too — the lookup is the public half', async () => {
+    const d = deps({
+      find: vi.fn(async () => ({ public_slug: 'go-dev-acme' })),
+      signedIn: () => false,
+    });
+    await expect(runLinkIntake('https://acme.com/jobs/1', d)).resolves.toEqual({
+      kind: 'open',
+      slug: 'go-dev-acme',
+    });
+    expect(d.submit).not.toHaveBeenCalled();
+  });
+
+  it('asks a signed-out visitor to sign in only once the link turns out to be new', async () => {
+    const d = deps({ signedIn: () => false });
+    await expect(runLinkIntake('https://acme.com/jobs/1', d)).resolves.toEqual({ kind: 'signin' });
+    expect(d.submit).not.toHaveBeenCalled();
+  });
+
+  it('submits an unknown link for a signed-in visitor and reports the outcome', async () => {
+    const resolved: ResolvedLink = { public_slug: null, status: 'queued' };
+    const d = deps({ submit: vi.fn(async () => resolved) });
+    await expect(runLinkIntake('https://acme.com/jobs/1', d)).resolves.toEqual({
+      kind: 'outcome',
+      resolved,
+    });
+  });
+
+  it('opens the posting the intake imported rather than narrating the import', async () => {
+    const d = deps({
+      submit: vi.fn(async () => ({ public_slug: 'go-dev-acme', status: 'imported' }) as ResolvedLink),
+    });
+    await expect(runLinkIntake('https://acme.com/jobs/1', d)).resolves.toEqual({
+      kind: 'open',
+      slug: 'go-dev-acme',
+    });
+  });
+
+  it('falls through to the intake when the public lookup fails', async () => {
+    const d = deps({
+      find: vi.fn(async () => {
+        throw new Error('502');
+      }),
+      submit: vi.fn(async () => ({ public_slug: 'go-dev-acme', status: 'found' }) as ResolvedLink),
+    });
+    await expect(runLinkIntake('https://acme.com/jobs/1', d)).resolves.toEqual({
+      kind: 'open',
+      slug: 'go-dev-acme',
+    });
+  });
+
+  it('gives a signed-out visitor an error when the lookup fails — there is no second door for them', async () => {
+    const d = deps({
+      find: vi.fn(async () => {
+        throw new Error('502');
+      }),
+      signedIn: () => false,
+    });
+    await expect(runLinkIntake('https://acme.com/jobs/1', d)).resolves.toEqual({ kind: 'error' });
+  });
+
+  it('reports an intake failure as an error rather than a verdict on the link', async () => {
+    const d = deps({
+      submit: vi.fn(async () => {
+        throw new Error('422');
+      }),
+    });
+    await expect(runLinkIntake('not-a-url', d)).resolves.toEqual({ kind: 'error' });
+  });
+});

--- a/web/src/lib/linkIntake.ts
+++ b/web/src/lib/linkIntake.ts
@@ -1,0 +1,68 @@
+// What happens to a link pasted into the search box.
+//
+// Two doors, in order, because they cost different things. `/jobs/find` is a public
+// read: an indexed lookup of the URL against the catalog, no page fetched, nothing
+// written, and open to a signed-out visitor. `/jobs/resolve` is the intake: it goes out
+// to the page, may import the vacancy, and records the board behind it against the
+// caller — so it needs an account, and it is the slow one.
+//
+// The cheap public door therefore runs FIRST, for everybody. A visitor whose link we
+// already carry gets their vacancy without being asked to sign in, which is the common
+// case and the whole point of recognising the link at all. Only a link we do NOT carry
+// is worth an account and a page fetch.
+//
+// Pure but for the three injected dependencies, and free of Svelte and the DOM, so the
+// order above is covered by tests rather than by clicking through the box.
+
+import type { ResolvedLink } from './types';
+
+/** What the box should do next. One of these ends every intake run.
+ *
+ *  `open` is deliberately the outcome of BOTH doors: a posting found in the catalog and
+ *  a posting the intake just imported are the same thing to the visitor — a page to go
+ *  to — and telling them apart in the UI would be reporting our own plumbing. */
+export type LinkIntakeStep =
+  | { kind: 'open'; slug: string }
+  | { kind: 'signin' }
+  | { kind: 'outcome'; resolved: ResolvedLink }
+  | { kind: 'error' };
+
+export interface LinkIntakeDeps {
+  /** The public lookup. Resolves to null when the catalog holds no such posting. */
+  find: (url: string) => Promise<{ public_slug: string } | null>;
+  /** The intake. Only ever called for a signed-in visitor. */
+  submit: (url: string) => Promise<ResolvedLink>;
+  signedIn: () => boolean;
+}
+
+/** Run the intake for one pasted link and report what the box should do.
+ *
+ *  A failure of the public lookup is NOT the end of the run: it is one endpoint being
+ *  unavailable, and the intake behind it answers the same question in a slower way. So a
+ *  signed-in visitor still gets their link submitted, and only a signed-out one is left
+ *  with nothing to show. The alternative — surfacing the lookup's failure — would refuse
+ *  a link we could still have resolved. */
+export async function runLinkIntake(url: string, deps: LinkIntakeDeps): Promise<LinkIntakeStep> {
+  try {
+    const found = await deps.find(url);
+    if (found) return { kind: 'open', slug: found.public_slug };
+  } catch {
+    if (!deps.signedIn()) return { kind: 'error' };
+  }
+
+  // Not one we carry. Handing it in writes a contribution against an account, so there
+  // has to be one — and asking here, rather than before the lookup, is what keeps the
+  // find-and-open half open to everybody.
+  if (!deps.signedIn()) return { kind: 'signin' };
+
+  try {
+    const resolved = await deps.submit(url);
+    // The intake carries its own catalog check (a storefront link fronting a posting we
+    // already hold under a crawled source), so it can name a posting the public lookup
+    // could not. When it does, the page to go to wins over the story of how we got it.
+    if (resolved.public_slug) return { kind: 'open', slug: resolved.public_slug };
+    return { kind: 'outcome', resolved };
+  } catch {
+    return { kind: 'error' };
+  }
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -401,6 +401,13 @@ export interface Contribution {
  *  - `queued`   nothing could read the page, so the link went to manual triage */
 type IntakeStatus = 'found' | 'tracked' | 'imported' | 'review' | 'queued';
 
+/** A job page in the wild recognised as one the catalog already carries. The lookup that
+ *  produces it is public and read-only, so this is deliberately narrower than ResolvedLink:
+ *  nothing was imported and no board was recorded, so there is no status to report. */
+export interface FoundJob {
+  public_slug: string;
+}
+
 export interface ResolvedLink {
   public_slug: string | null;
   status: IntakeStatus;


### PR DESCRIPTION
## What

The search box now recognises a pasted job link and offers to open it — or, when we don't carry it, to hand it in.

Until now, somebody who found a vacancy elsewhere and wanted to know whether we carry it had to know that the answer lives on the contribute page. Pasting the link into the box on every page ran it as a full-text search, which finds nothing, every time.

## How

Both doors already existed and neither changes here:

- `GET /jobs/find` — the public, read-only lookup the browser extension asks when it is standing on a vacancy.
- `POST /jobs/resolve` — the intake: fetches the page, imports the vacancy, records the board.

The order between them is the whole design (`web/src/lib/linkIntake.ts`): **the public lookup runs first, for everybody.** A visitor whose link we already carry gets their vacancy without being asked to sign in — the common case. Only a link we do *not* carry is worth an account and an outbound fetch.

A signed-out visitor whose link is new goes to sign in with the link riding along in the return path, and the contribute form prefills from it. Prefills, not submits: auto-submitting from a query parameter would let any page record a contribution in a visitor's name while they merely followed a link.

## Recognising a link vs. a query

`web/src/lib/jobLink.ts`. A bare host must carry a **path** to count — which is what keeps `node.js`, `react.dev` and `express.js` (all valid hostnames, all things people type here meaning "find me jobs") on the search side of the line. A bare domain is a company, and searching for the company is the better answer anyway. Conservative in one direction only: an unrecognised paste still runs as a search, while a query misread as a link would make the box look broken for a word somebody typed on purpose.

## Drift found on the way

The five intake outcomes now have one set of words (`web/src/lib/intakeOutcome.ts`) rendered by both surfaces. Moving them turned up one that had already drifted from the server: the contribute form still promised **"+1 AI credit"** for a board, and that reward was withdrawn when the currency it was paid in stopped existing (`internal/api/handler/contributions.go:71`).

## Verified

- 1449 web tests pass (38 new), `svelte-check` clean, eslint clean.
- In a browser against the production API, signed out:
  - an external ATS link we carry → opens our posting;
  - a link we don't carry → "We don't have this one yet. Sign in to send it to us →", with the link preserved in `returnTo`;
  - `node.js` → still an ordinary search, with completions, postings and the free-text row.

No backend, migration or API change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recognizes pasted job links in search.
  * Lets users open known postings directly, sign in to submit new links, or view processing outcomes.
  * Prefills contribution links from URL query parameters.
  * Displays clear outcome messages with links to relevant jobs or companies.
* **Bug Fixes**
  * Improved handling of invalid, unsupported, and non-job URLs.
* **Tests**
  * Added coverage for link detection, search behavior, intake outcomes, and submission paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->