### PR TITLE
Let the search box take the caret, and keep its rows off the keyboard

### DIFF
--- a/web/src/app.html
+++ b/web/src/app.html
@@ -2,7 +2,15 @@
 <html lang="%lang%">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <!-- `interactive-widget=resizes-content` asks the browser to SHRINK the page when the
+    on-screen keyboard opens, rather than leave it full height and cover the bottom of it.
+    Without it a `bottom: 0` panel — the search box's suggestions on a phone — sits behind
+    the keys with its last rows unreachable. Chrome honours it; Safari ignores it, which is
+    why the panel also measures `visualViewport` for itself (see HeaderSearch). -->
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"
+    />
     <!-- Warm the company-logo origin: every job row and company header renders an
     <img> from it (CompanyLogo → $lib/logo), so a listing opens a connection to it
     within the first paint, on every page that matters. Its handshake is otherwise

--- a/web/src/lib/components/HeaderSearch.svelte
+++ b/web/src/lib/components/HeaderSearch.svelte
@@ -271,6 +271,51 @@
   const suggestOpen = $derived(rows.length > 0 && !dismissed);
   const rowCount = $derived(suggestOpen ? rows.length : 0);
 
+  /** How much of the screen's bottom the on-screen keyboard is covering, in pixels.
+   *
+   *  Neither mobile browser shrinks the PAGE for the keyboard on its own — it is drawn
+   *  over the bottom of a viewport that stays full height — so the panel below, pinned
+   *  from the header to `bottom: 0`, ran under the keys with its last rows unreachable.
+   *  Which is the worst place to lose: the visitor has just typed, and the rows they are
+   *  reading are the ones the typing produced.
+   *
+   *  `visualViewport` is the part of the page actually left visible, so the difference
+   *  between it and the window is the keyboard. `app.html` also asks Chrome to shrink the
+   *  page itself (`interactive-widget=resizes-content`), and the two do not double up:
+   *  where the browser honours that, the window shrinks with it and this measures 0.
+   *
+   *  Held here rather than in a shared store because this panel is the only thing that
+   *  reaches the bottom edge today; a second one (a composer, a sheet) is when it earns
+   *  a module of its own. */
+  let keyboardInset = $state(0);
+
+  $effect(() => {
+    // Nothing to lift while the panel is shut, and no listener to keep either.
+    if (!suggestOpen) return;
+    const viewport = window.visualViewport;
+    if (!viewport) return;
+    const measure = () => {
+      // Only the phone-width panel has a bottom edge to lift: at `sm` and up it hangs off
+      // the box and is sized by `max-height`. Read the breakpoint the same way the
+      // autofocus check above reads it, so there is one answer to "is this a phone".
+      const wide = window.matchMedia('(min-width: 640px)').matches;
+      keyboardInset = wide
+        ? 0
+        : Math.max(0, window.innerHeight - viewport.height - viewport.offsetTop);
+    };
+    measure();
+    // `scroll` as well as `resize`: iOS scrolls the visual viewport inside the layout one
+    // to keep the focused field visible, which moves the keyboard's top edge without
+    // changing its height.
+    viewport.addEventListener('resize', measure);
+    viewport.addEventListener('scroll', measure);
+    return () => {
+      viewport.removeEventListener('resize', measure);
+      viewport.removeEventListener('scroll', measure);
+      keyboardInset = 0;
+    };
+  });
+
   function close() {
     dismissed = true;
     activeIndex = -1;
@@ -422,6 +467,19 @@
           // than the bar that grows.
           'h-12 gap-2 rounded-md px-3 text-sm',
     )}
+    onpointerdown={(e) => {
+      // The whole box takes the caret, not just the field inside it. Probed at 390px: the
+      // field is 175px of a 278px box, and the other 103 — the rule, the magnifier, the
+      // `/` hint, the padding — landed on nothing at all. That reads as a search box that
+      // ignored the first tap and answered the second, better-aimed one.
+      //
+      // Only what is NOT itself a control: the scope prefix, the clear button and the
+      // All-filters trigger keep their own taps. `preventDefault` because the default for
+      // a press on a non-focusable box is to take focus AWAY from the field.
+      if ((e.target as HTMLElement | null)?.closest('button, input, a')) return;
+      e.preventDefault();
+      inputEl?.focus();
+    }}
   >
     <!-- List pages expose a filter scope: surface the Location quick-filter as a
          scope-prefix, divided from the search icon. `variant` picks the popover body
@@ -542,6 +600,7 @@
     <ul
       id="role-suggestions"
       role="listbox"
+      style:bottom={keyboardInset > 0 ? `${keyboardInset}px` : null}
       aria-label="Search suggestions"
       class={cn(
         'inset-x-0 z-50 max-h-[70vh] overflow-y-auto border border-border bg-background py-1 shadow-lg',


### PR DESCRIPTION
Two things a thumb ran into in the phone header, reported as "I have to tap the search box twice" and "the keyboard hides the suggestions".

### The box ignored the first tap

Probed with `elementFromPoint` across the box at 390px: the field is 175px of a 278px box. The other 103 — the divider, the magnifier, the `/` hint, the padding — hit the container, which was not a target for anything. Aim slightly off and the box did nothing; aim again and it worked.

A press anywhere in the box that is not itself a control now puts the caret in the field. The scope prefix, the clear button and the All-filters trigger keep their own taps (`closest('button, input, a')` is the guard). `preventDefault` on the press, because the default for a press on a non-focusable box is to take focus *away* from the field.

Verified: taps at x=125 (the magnifier), x=133 (between the rule and the field) and x=320 (the right padding) all leave `document.activeElement` as the combobox; the Location trigger still opens its popover.

### The keyboard covered the rows

Neither mobile browser shrinks the page when the on-screen keyboard opens — the keys are drawn over a viewport that stays full height. So the suggestion panel, pinned from the header down to `bottom: 0` since #2424, ran underneath them, losing its last rows at exactly the moment they matter: the visitor has just typed, and those rows are what the typing produced.

Two mechanisms, deliberately not one:

- `app.html` adds `interactive-widget=resizes-content` to the viewport meta, which asks the browser to shrink the page itself. **Chrome honours it, Safari ignores it.**
- The panel measures `window.visualViewport` while it is open and lifts its bottom edge by `innerHeight - viewport.height - viewport.offsetTop`, which is the keyboard's height. This is what covers iOS.

They do not double up: where the browser honours the meta, the window shrinks with the visual viewport and the measurement is zero. The `scroll` listener is there because iOS scrolls the visual viewport inside the layout one to keep the focused field visible, which moves the keyboard's top edge without changing its height.

Phone-only by construction: the inset is measured only below `sm` (read through the same `matchMedia('(min-width: 640px)')` the autofocus check uses), and it is applied as an inline `style:bottom` that is `null` whenever there is no keyboard — so the desktop panel keeps hanging off the box with no inline style at all, and the mobile class `max-sm:bottom-0` stays the answer whenever nothing is covering the screen.

### Verification

Headless at 390px: with no keyboard the panel is unchanged (`fixed`, 0→390, 56→844, no inline bottom); at 1280px it is `absolute` with no inline bottom. The dev server's "Failed to hydrate" warning is present on unmodified `main` too — checked by stashing.

`pnpm test` — 1409 passing. eslint, gitleaks, doc-links, design-system adoption and the token ratchet all pass.

**What I could not verify here:** an actual on-screen keyboard. There is none in a headless browser, so the lift needs one look on a real phone — the failure mode if the formula is wrong is a panel that stops short, not one that breaks.
