### PR TITLE
Let the role noun outrank the estate it works on

### DIFF
--- a/internal/dict/classify/AGENTS.md
+++ b/internal/dict/classify/AGENTS.md
@@ -55,12 +55,14 @@ analyst`) resolves the `support` category — a `vocab.NonTechCategories` member
 *also* a `techTitleTerms` entry, so `jobderive.deriveIsTech` reads it as `is_tech = true`.
 That is deliberate, not drift: the category is right about the FUNCTION (reactive,
 ticket-driven, alongside customer service) and wrong about the CRAFT, and only the title
-list can say the second thing. Without the entry the enrichment gate skips ~6.6k open
-postings that are plainly IT work.
+list can say the second thing. `tech.go` carries the argument and the measurements
+beside the terms; do not restate them here, or the two copies will drift.
 
-The bare nouns stay out of both lists. `support` alone is the whole customer-service
-population (226k open postings at the time of writing); only "desk" and the IT-anchored
-analyst form are specific enough to carry the claim.
+**The exception is the DESK, not IT support at large.** `IT Support Specialist` and
+`Desktop Support Technician` are equally IT and stay `is_tech = false`, because
+extending the claim to them is a separate, larger decision (~5.5k more open postings
+into the enrichment gate) that has not been taken. Read the boundary as "not yet",
+not as a ruling that those roles are non-technical.
 
 ## Serving: dict-only
 

--- a/internal/dict/classify/classify_test.go
+++ b/internal/dict/classify/classify_test.go
@@ -373,11 +373,11 @@ func TestParse_ITCompanyRoles(t *testing.T) {
 	}
 }
 
-// TestParse_ITRolesTheTableDidNotName pins the IT roles that reached a category
-// only through one of the table's bare fall-throughs — "analyst" reads every
-// remaining analyst as data_analytics — so they resolved confidently WRONG rather
-// than not at all. Each now names its own discipline.
-func TestParse_ITRolesTheTableDidNotName(t *testing.T) {
+// TestParse_UnnamedITRoles pins the IT roles that reached a category only through
+// one of the table's bare fall-throughs — "analyst" reads every remaining analyst as
+// data_analytics — so they resolved confidently WRONG rather than not at all. Each
+// now names its own discipline.
+func TestParse_UnnamedITRoles(t *testing.T) {
 	cases := []struct{ title, wantCategory string }{
 		{"Lead Service Desk Analyst", "support"},
 		{"IT Service Desk Specialist Level II", "support"},
@@ -388,6 +388,27 @@ func TestParse_ITRolesTheTableDidNotName(t *testing.T) {
 		// Unchanged: the bare nouns keep falling through as before.
 		{"Business Analyst", "business_analysis"},
 		{"Infrastructure Project Manager", "project_management"},
+	}
+	for _, c := range cases {
+		if got := Parse(c.title).Category; got != c.wantCategory {
+			t.Errorf("Parse(%q).Category = %q, want %q", c.title, got, c.wantCategory)
+		}
+	}
+}
+
+// "IT Infrastructure" is a domain noun, so it must resolve only after every role
+// noun. These are the titles that pin the placement: move the entry back up into the
+// devops block and all three become devops, which is wrong for all three.
+func TestParse_ITInfrastructureYieldsToTheRoleNoun(t *testing.T) {
+	cases := []struct{ title, wantCategory string }{
+		{"IT Infrastructure Security Engineer", "security"},
+		{"IT Infrastructure Project Manager", "project_management"},
+		// Not sales: "Cyber Security" names a discipline outright and the security
+		// block outranks the sales one. The pin here is only that it is not devops.
+		{"Business Development Executive (IT Infrastructure/Cyber Security)", "security"},
+		// What is left once no role noun claims the title is the estate itself.
+		{"Head of IT Infrastructure", "devops"},
+		{"IT Infrastructure Manager", "devops"},
 	}
 	for _, c := range cases {
 		if got := Parse(c.title).Category; got != c.wantCategory {

--- a/internal/dict/classify/dictionaries.go
+++ b/internal/dict/classify/dictionaries.go
@@ -209,11 +209,9 @@ var categoryTable = []aliasEntry{
 	// "platform engineer" substring, so it needs its own entry.
 	{"platform engineering", "devops"},
 	{"infrastructure engineer", "devops"},
-	// The IT-anchored form of a noun this file otherwise refuses: bare
-	// "infrastructure" names civil, rail, energy and telecom work, but "IT
-	// Infrastructure" states the estate outright ("IT Infrastructure Manager",
-	// "IT Infrastructure & Projects Specialist").
-	{"it infrastructure", "devops"},
+	// "it infrastructure" belongs to this category but is NOT listed here — it names
+	// an estate, not a role, so it resolves with the other domain nouns down beside
+	// the bare "manager"/"analyst" fall-throughs. Search for it there.
 	{"cloud engineer", "devops"},
 	{"system administrator", "devops"},
 	// The plural is the far more common surface form in prod titles ("Systems
@@ -558,6 +556,19 @@ var categoryTable = []aliasEntry{
 	{"проект-менеджер", "project_management"},
 	{"скрам-мастер", "project_management"},
 	{"скрам мастер", "project_management"},
+	// "IT Infrastructure" names an ESTATE, not a role, and its slot is the whole
+	// ruling. It sits BELOW the technical role nouns, so the security engineer and the
+	// project manager who happen to work on that estate keep their own discipline
+	// ("IT Infrastructure Security Engineer", "IT Infrastructure Project Manager") —
+	// in the devops block it outran both. It sits ABOVE the business functions, so
+	// what is left over stays with the estate rather than drifting into back-office
+	// ("IT Infrastructure & Operations Manager" is devops, not operations; "IT
+	// Infrastructure Asset and Contract Manager" is devops, not legal). The residue
+	// this costs is the handful of genuine sales titles on the estate ("Pre Sales
+	// Specialist IT Infrastructure"), measured at ~4 against ~13 saved. Bare
+	// "infrastructure" gets no entry at all: it names civil, rail, energy and telecom
+	// work.
+	{"it infrastructure", "devops"},
 	{"engineering manager", "management"},
 	{"team manager", "management"},
 	{"marketing", "marketing"},
@@ -937,8 +948,13 @@ var categoryTable = []aliasEntry{
 	// "Folyamatfejlesztő", "Termékfejlesztő szakértő", "Üzletfejlesztési menedzser",
 	// "Működésfejlesztési szakértő", "Képzés-fejlesztési gyakornok") alongside the
 	// software roles. Hungarian also writes closed compounds where English writes two
-	// words, so a compound never contains its spaced twin on a word boundary and both
-	// spellings are listed.
+	// words, so a compound never contains its spaced twin on a word boundary. Where
+	// prod showed both spellings in use, both are listed; the language is
+	// agglutinative and an exhaustive sweep of its plurals, hyphenations and case
+	// endings is future work, not done here — the same stance this file takes on
+	// gendered forms above. That is why "java fejlesztők" and "odoo-fejlesztő" have
+	// entries and the other twelve entries' plurals do not: those are the surface
+	// forms the catalogue actually carries.
 	{"szoftverfejlesztő", "software_engineering"},
 	{"szoftver fejlesztő", "software_engineering"},
 	{"szoftvermérnök", "software_engineering"},

--- a/internal/dict/classify/tech.go
+++ b/internal/dict/classify/tech.go
@@ -17,9 +17,12 @@ import (
 // governing rule is the "engineer"/"developer" trap: prod titles show bare
 // "engineer" is dominated by NON-software roles (mechanical, manufacturing,
 // civil, drainage, optical, project) and bare "developer" also names non-tech
-// roles (business/real-estate developer). So every term here is SOFTWARE-ANCHORED
-// — no bare "engineer"/"developer"/"analyst"/"architect"/"administrator" — and a
-// non-software "…Engineer" stays `unknown` rather than being mislabelled tech.
+// roles (business/real-estate developer). So every term here is ANCHORED to the
+// discipline — no bare "engineer"/"developer"/"analyst"/"architect"/"administrator"
+// — and a non-software "…Engineer" stays `unknown` rather than being mislabelled
+// tech. The anchor is usually the word "software" or a language name; the IT
+// service desk below is the one family anchored on its own noun instead, and it
+// carries the argument for that beside the terms.
 var techTitleTerms = []string{
 	// Software engineer forms (never bare "engineer")
 	"software engineer", "software development engineer", "devops engineer",

--- a/internal/dict/classify/tech_test.go
+++ b/internal/dict/classify/tech_test.go
@@ -62,6 +62,14 @@ func TestIsTech(t *testing.T) {
 		{"customer support analyst", "Customer Support Analyst", false},
 		{"support specialist", "Support Specialist", false},
 		{"front desk", "Front Desk Agent", false},
+		// #2421 asked for these two as negatives. Note what the assertion can and
+		// cannot say: both resolve a category that IS in vocab.TechCategories
+		// (project_management, business_analysis), so both are already technical
+		// EVIDENCE and were before this list existed. All that is pinned here is that
+		// the title detector adds no claim of its own — which is why the IT-prefixed
+		// forms the issue proposed would have changed no outcome.
+		{"project manager", "Project Manager", false},
+		{"business analyst", "Business Analyst", false},
 		{"empty", "", false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Acts on the code review of #2421 / #2422. **No alias added or removed** — `web/src/lib/generated/contracts.ts` regenerates identical. What moves is where one entry sits.

## The finding that mattered

`{"it infrastructure", "devops"}` went into the devops block, which is high in a precedence-ordered table, so it outran every role noun below it. Measured on the live catalogue, that took **65 security engineers, 40 project managers and 28 architects** away from their own discipline, and even claimed `Business Development Executive (IT Infrastructure/Cyber Security)`.

It names an **estate, not a role**, so its slot is the whole ruling — below the technical role nouns, above the business functions:

| Slot | Result |
|---|---|
| devops block (shipped in #2422) | security engineers, PMs and architects all read as devops |
| beside the bare `manager` fall-through (first attempt here) | fixed those, but sent `IT Infrastructure & Operations Manager` → operations and `IT Infrastructure Asset and Contract Manager` → legal — 65 titles out of tech entirely |
| **between the two (this PR)** | both fixed; costs ~4 genuine sales titles on the estate against ~13 saved |

Measured over 4342 live prod titles: **150 recategorised, every one to a more specific technical discipline, and `is_tech` unchanged for all 4342.** `TestParse_ITInfrastructureYieldsToTheRoleNoun` pins the placement from both sides, so neither direction can be undone silently.

## The rest of the review

- **The `techTitleTerms` head comment stated an absolute the change had already broken**: *"every term here is SOFTWARE-ANCHORED"*. The service-desk family is desk-anchored. The exception was argued beside the terms; the governing sentence was not amended. Now it is.
- **AGENTS.md restated tech.go's argument and its 226k measurement near-verbatim** — two copies to drift, in a change whose sibling commit is titled "Say the Hungarian trap once". It now points at the code and spends its space on what the code cannot say: the exception is the *desk*, and `IT Support Specialist` staying non-technical is **"not yet"** (a separate ~5.5k-posting decision), not a ruling that the role is non-technical.
- **The Hungarian block stated the both-spellings rule and applied it to four of sixteen entries.** The rule is evidence-driven — those are the surface forms the catalogue carries — so the comment now says that instead of leaving the reader to wonder.
- **#2421 asked for `Project Manager` and `Business Analyst` as negatives and they were missing.** Added, with the caveat the review surfaced: both resolve a `TechCategories` member, so they are *already* technical evidence and the assertion pins only that the title detector adds no claim of its own.
- Renamed `TestParse_ITRolesTheTableDidNotName`, which read as prose rather than a subject.