### PR TITLE
Finish the IT-support family the desk terms started

### DIFF
--- a/internal/dict/classify/AGENTS.md
+++ b/internal/dict/classify/AGENTS.md
@@ -50,19 +50,21 @@ so a match between them is not the accidental kind the veto was built for.
 
 ## The one place category and `is_tech` disagree on purpose
 
-The IT service desk (`service desk`, `help desk`, `helpdesk`, `technical support
-analyst`) resolves the `support` category — a `vocab.NonTechCategories` member — and is
-*also* a `techTitleTerms` entry, so `jobderive.deriveIsTech` reads it as `is_tech = true`.
+IT support (`service desk`, `help desk`, `helpdesk`, `it support`, `it supporter`,
+`desktop support`, `deskside support`, `end user support`, `technical support
+analyst`) resolves the `support` category — a `vocab.NonTechCategories` member — and is *also* a
+`techTitleTerms` entry, so `jobderive.deriveIsTech` reads it as `is_tech = true`.
 That is deliberate, not drift: the category is right about the FUNCTION (reactive,
 ticket-driven, alongside customer service) and wrong about the CRAFT, and only the title
 list can say the second thing. `tech.go` carries the argument and the measurements
 beside the terms; do not restate them here, or the two copies will drift.
 
-**The exception is the DESK, not IT support at large.** `IT Support Specialist` and
-`Desktop Support Technician` are equally IT and stay `is_tech = false`, because
-extending the claim to them is a separate, larger decision (~5.5k more open postings
-into the enrichment gate) that has not been taken. Read the boundary as "not yet",
-not as a ruling that those roles are non-technical.
+**A term earns its place by naming the ESTATE, not the mood of the work.** That is why
+bare `technical support` has no entry — live titles give AGV, automotive, controls,
+logistics and instructional support under that phrase — while `desktop support` does.
+If you are tempted to widen this family, sample the phrase against live titles first;
+every term here was admitted that way, and the whole exception depends on none of them
+being loose.
 
 ## Serving: dict-only
 

--- a/internal/dict/classify/tech.go
+++ b/internal/dict/classify/tech.go
@@ -20,9 +20,9 @@ import (
 // roles (business/real-estate developer). So every term here is ANCHORED to the
 // discipline — no bare "engineer"/"developer"/"analyst"/"architect"/"administrator"
 // — and a non-software "…Engineer" stays `unknown` rather than being mislabelled
-// tech. The anchor is usually the word "software" or a language name; the IT
-// service desk below is the one family anchored on its own noun instead, and it
-// carries the argument for that beside the terms.
+// tech. The anchor is usually the word "software" or a language name; IT support
+// below is the one family anchored on its own noun instead, and it carries the
+// argument for that beside the terms.
 var techTitleTerms = []string{
 	// Software engineer forms (never bare "engineer")
 	"software engineer", "software development engineer", "devops engineer",
@@ -62,15 +62,30 @@ var techTitleTerms = []string{
 	"system administrator", "systems administrator", "sysadmin", "network administrator",
 	"database administrator", "linux administrator", "windows administrator",
 	"it administrator", "devsecops",
-	// The IT service desk. These are the one family here whose CATEGORY cannot say
-	// what they are: they resolve to `support`, a vocab.NonTechCategories member, so
-	// without an entry here the derivation reads them as confidently non-technical
-	// and the enrichment gate skips them. That category is right about the function
-	// — reactive, ticket-driven — and wrong about the craft: a help desk runs an IT
-	// estate. The bare nouns stay out. "support" alone is the whole customer-service
-	// population (226k open postings), and only "desk" and the IT-anchored analyst
-	// form are specific enough to carry the claim.
+	// IT support. These are the one family here whose CATEGORY cannot say what they
+	// are: they resolve to `support`, a vocab.NonTechCategories member, so without an
+	// entry here the derivation reads them as confidently non-technical and the
+	// enrichment gate skips them. That category is right about the function —
+	// reactive, ticket-driven — and wrong about the craft: a help desk runs an IT
+	// estate.
+	//
+	// What makes a term safe here is an anchor that names the estate, not the mood of
+	// the work. "it support", "desktop support" and "deskside support" are IT by
+	// definition; sampled against live titles they are unanimous. Bare "technical
+	// support" is NOT and gets no entry: the same sample gives AGV, automotive,
+	// controls, logistics and instructional support, so only the analyst form —
+	// already the office-IT title in practice — carries the claim. Bare "support" is
+	// the whole customer-service population (226k open postings) and stays out too.
+	//
+	// "it supporter" is the German/Nordic surface form ("1st Level IT Supporter") and
+	// needs its own term: the trailing "er" breaks the word boundary, the same trap
+	// the "system administrator"/"systems administrator" pair above guards against.
+	// "end user" is an IT/product term of art and its titles read the same way
+	// ("Analyst, End User Support", "Desktop / End User Support Technician"); spaced
+	// and hyphenated are separate terms because a hyphen is a word boundary.
 	"service desk", "help desk", "helpdesk", "technical support analyst",
+	"it support", "it supporter", "desktop support", "deskside support",
+	"end user support", "end-user support",
 	// Architects (never bare "architect")
 	"software architect", "solutions architect", "cloud architect", "data architect",
 	"security architect", "enterprise architect", "technical architect",

--- a/internal/dict/classify/tech_test.go
+++ b/internal/dict/classify/tech_test.go
@@ -39,6 +39,12 @@ func TestIsTech(t *testing.T) {
 		{"help desk", "Help Desk Technician (Tier 1)", true},
 		{"helpdesk", "Mitarbeiter IT Support und Helpdesk (m/w/d)", true},
 		{"technical support analyst", "Technical Support Analyst", true},
+		{"it support", "1st Line IT Support Technician", true},
+		{"it supporter", "1st Level IT Supporter (m/w/d)", true},
+		{"desktop support", "Desktop Support Analyst - Tier 1", true},
+		{"deskside support", "Deskside Support Engineer (Osaka)", true},
+		{"end user support", "Analyst, End User Support", true},
+		{"end-user support", "Desktop Support Specialist – SCCM, Intune, End-User Support", true},
 
 		// Trap negatives — non-software engineering / non-tech that carry "engineer"
 		// or other shared words. These MUST stay unflagged (bias: leave in unknown).
@@ -62,6 +68,11 @@ func TestIsTech(t *testing.T) {
 		{"customer support analyst", "Customer Support Analyst", false},
 		{"support specialist", "Support Specialist", false},
 		{"front desk", "Front Desk Agent", false},
+		// Bare "technical support" is deliberately absent: sampled live titles give
+		// AGV, automotive, controls, logistics and instructional support alongside the
+		// office-IT ones, so only the analyst form above is anchored enough.
+		{"technical support engineer", "AGV Technical Support Engineer", false},
+		{"technical support specialist", "Automotive Technical Support Specialist", false},
 		// #2421 asked for these two as negatives. Note what the assertion can and
 		// cannot say: both resolve a category that IS in vocab.TechCategories
 		// (project_management, business_analysis), so both are already technical


### PR DESCRIPTION
Follow-up to #2422 / #2430.

#2422 admitted the IT service desk to `techTitleTerms` and left the rest of the same craft out. `Help Desk Technician` read as technical; `IT Support Specialist` did not. Same estate, same work, opposite answer — the code review called this out and the AGENTS.md note recorded it as "not yet".

**Admitted:** `it support`, `it supporter`, `desktop support`, `deskside support`, `end user support`, `end-user support`. Sampled against 3000 live titles carrying those phrases, every one is office IT.

**Still refused: bare `technical support`** — and that refusal is now the rule the family is stated in terms of. *A term earns its place by naming the ESTATE, not the mood of the work.* The same sample gives `AGV Technical Support Engineer`, `Automotive Technical Support Specialist`, `Controls Engineer Technical Support`, `Assistant Logistics and Technical Support` and `Asst Instr Technical Support` under that phrase, so only the analyst form keeps its entry. Two of those are now negative test cases, so widening it later has to argue past them.

Two boundary traps, both the file's existing kind:
- `it supporter` needs its own term — the trailing `er` breaks the word boundary, exactly what the `system administrator`/`systems administrator` pair guards against — and it is the ordinary German/Nordic spelling (`1st Level IT Supporter (m/w/d)`).
- `end-user support` is listed beside the spaced form because a hyphen is a word boundary.

**Measured:** 831 of the 3000-title sample move to `is_tech = true`, ~5.5k across the open catalogue. No category alias changed, so `web/src/lib/generated/contracts.ts` regenerates identical.