### PR TITLE
Make a starved subscription visible without someone reporting it

### DIFF
--- a/cmd/queue-metrics/collect.go
+++ b/cmd/queue-metrics/collect.go
@@ -22,6 +22,7 @@ type metricsQueries interface {
 	BoardHealthMetrics(context.Context) (db.BoardHealthMetricsRow, error)
 	NewestOpenJobCreatedAt(context.Context) (pgtype.Timestamptz, error)
 	ProviderIngestHealth(context.Context) ([]db.ProviderIngestHealthRow, error)
+	NotifyBacklogMetrics(context.Context) (db.NotifyBacklogMetricsRow, error)
 }
 
 // collect runs one measurement pass. Any query failure aborts the pass: a partial
@@ -49,6 +50,11 @@ func collect(ctx context.Context, q metricsQueries) (snapshot, error) {
 	newestJob, err := newestJobTime(ctx, q)
 	if err != nil {
 		return snapshot{}, err
+	}
+
+	notifyBacklog, err := q.NotifyBacklogMetrics(ctx)
+	if err != nil {
+		return snapshot{}, fmt.Errorf("notify backlog metrics: %w", err)
 	}
 
 	health, err := q.ProviderIngestHealth(ctx)
@@ -79,11 +85,13 @@ func collect(ctx context.Context, q metricsQueries) (snapshot, error) {
 			{name: "enrichment_outbox", depth: enrichment.Depth, deadLetters: enrichment.DeadLetters, oldestAgeSeconds: enrichment.OldestAgeSeconds},
 			{name: "semantic_outbox", depth: semantic.Depth, deadLetters: semantic.DeadLetters, oldestAgeSeconds: semantic.OldestAgeSeconds},
 		},
-		healthyBoards: boards.Healthy,
-		failingBoards: boards.Failing,
-		cooledBoards:  boards.Cooled,
-		newestJob:     newestJob,
-		providers:     providers,
+		notifyPendingSubscriptions: notifyBacklog.PendingSubscriptions,
+		notifyOldestAgeSeconds:     notifyBacklog.OldestAgeSeconds,
+		healthyBoards:              boards.Healthy,
+		failingBoards:              boards.Failing,
+		cooledBoards:               boards.Cooled,
+		newestJob:                  newestJob,
+		providers:                  providers,
 	}, nil
 }
 

--- a/cmd/queue-metrics/collect_test.go
+++ b/cmd/queue-metrics/collect_test.go
@@ -21,8 +21,13 @@ type fakeQueries struct {
 	boards    db.BoardHealthMetricsRow
 	newest    pgtype.Timestamptz
 	health    []db.ProviderIngestHealthRow
+	notify    db.NotifyBacklogMetricsRow
 	newestErr error
 	searchErr error
+}
+
+func (f fakeQueries) NotifyBacklogMetrics(context.Context) (db.NotifyBacklogMetricsRow, error) {
+	return f.notify, nil
 }
 
 func (f fakeQueries) SearchOutboxMetrics(context.Context) (db.SearchOutboxMetricsRow, error) {
@@ -55,6 +60,7 @@ func populatedQueries() fakeQueries {
 		enrich:   db.EnrichmentOutboxMetricsRow{Depth: 1049297, DeadLetters: 41, OldestAgeSeconds: 5529600},
 		semantic: db.SemanticOutboxMetricsRow{Depth: 0, DeadLetters: 0, OldestAgeSeconds: 0},
 		boards:   db.BoardHealthMetricsRow{Healthy: 74894, Failing: 7002, Cooled: 1882},
+		notify:   db.NotifyBacklogMetricsRow{PendingSubscriptions: 12, OldestAgeSeconds: 184.25},
 		newest:   pgtype.Timestamptz{Time: time.Unix(1786821346, 0), Valid: true},
 		health: []db.ProviderIngestHealthRow{
 			{

--- a/cmd/queue-metrics/render.go
+++ b/cmd/queue-metrics/render.go
@@ -34,7 +34,14 @@ type providerHealth struct {
 // the catalogue holds no open job at all, which render treats as "publish nothing"
 // rather than as a 1970 timestamp.
 type snapshot struct {
-	queues        []queueMetrics
+	queues []queueMetrics
+	// notifyPendingSubscriptions/notifyOldestAgeSeconds are the subscription-digest
+	// backlog. The AGE is the one that catches a starved subscription: a pass runs every
+	// five minutes, so an age climbing without bound means someone is never served — and
+	// that produces no failure in the worker's own log to notice.
+	notifyPendingSubscriptions int64
+	notifyOldestAgeSeconds     float64
+
 	healthyBoards int64
 	failingBoards int64
 	cooledBoards  int64
@@ -60,6 +67,13 @@ func render(s snapshot) string {
 		func(q queueMetrics) string { return fmt.Sprintf("%d", q.deadLetters) }, s.queues)
 	writeFamily(&b, "freehire_queue_oldest_age_seconds", "Age of the oldest live entry in a pipeline outbox queue.",
 		func(q queueMetrics) string { return fmt.Sprintf("%.3f", q.oldestAgeSeconds) }, s.queues)
+
+	writeHeader(&b, "freehire_notify_pending_subscriptions",
+		"Active subscriptions with at least one undelivered match.")
+	fmt.Fprintf(&b, "freehire_notify_pending_subscriptions %d\n", s.notifyPendingSubscriptions)
+	writeHeader(&b, "freehire_notify_oldest_pending_age_seconds",
+		"Age of the oldest undelivered subscription match.")
+	fmt.Fprintf(&b, "freehire_notify_oldest_pending_age_seconds %.3f\n", s.notifyOldestAgeSeconds)
 
 	writeHeader(&b, "freehire_boards_total", "Ingest boards by health state.")
 	for _, st := range boardStates(s.healthyBoards, s.failingBoards, s.cooledBoards) {

--- a/cmd/queue-metrics/render_test.go
+++ b/cmd/queue-metrics/render_test.go
@@ -20,10 +20,12 @@ func fullSnapshot() snapshot {
 			{name: "enrichment_outbox", depth: 1049297, deadLetters: 41, oldestAgeSeconds: 5529600},
 			{name: "semantic_outbox", depth: 0, deadLetters: 0, oldestAgeSeconds: 0},
 		},
-		healthyBoards: 74894,
-		failingBoards: 7002,
-		cooledBoards:  1882,
-		newestJob:     time.Unix(1786821346, 0),
+		healthyBoards:              74894,
+		failingBoards:              7002,
+		cooledBoards:               1882,
+		newestJob:                  time.Unix(1786821346, 0),
+		notifyPendingSubscriptions: 12,
+		notifyOldestAgeSeconds:     184.25,
 	}
 }
 
@@ -46,6 +48,12 @@ freehire_queue_dead_letters{queue="semantic_outbox"} 0
 freehire_queue_oldest_age_seconds{queue="search_outbox"} 21600.500
 freehire_queue_oldest_age_seconds{queue="enrichment_outbox"} 5529600.000
 freehire_queue_oldest_age_seconds{queue="semantic_outbox"} 0.000
+# HELP freehire_notify_pending_subscriptions Active subscriptions with at least one undelivered match.
+# TYPE freehire_notify_pending_subscriptions gauge
+freehire_notify_pending_subscriptions 12
+# HELP freehire_notify_oldest_pending_age_seconds Age of the oldest undelivered subscription match.
+# TYPE freehire_notify_oldest_pending_age_seconds gauge
+freehire_notify_oldest_pending_age_seconds 184.250
 # HELP freehire_boards_total Ingest boards by health state.
 # TYPE freehire_boards_total gauge
 freehire_boards_total{state="healthy"} 74894
@@ -122,6 +130,8 @@ func TestRenderIsValidPrometheusTextFormat(t *testing.T) {
 		"freehire_queue_oldest_age_seconds":               3,
 		"freehire_boards_total":                           3,
 		"freehire_catalogue_newest_job_timestamp_seconds": 1,
+		"freehire_notify_pending_subscriptions":           1,
+		"freehire_notify_oldest_pending_age_seconds":      1,
 	}
 	for name, wantSamples := range want {
 		family, ok := families[name]

--- a/docs/agents/notifications.md
+++ b/docs/agents/notifications.md
@@ -14,6 +14,41 @@ Telegram, and mobile push), each with its own small `Notifier`/`Router` pair:
 
 ## Always true
 
+- **Every subscription with something pending gets served in a pass — the claim is capped
+  PER SUBSCRIPTION, not globally.** `ClaimSubscriptionMatches` takes at most `SnapshotCap`
+  rows per subscription through a `LATERAL`; `ClaimBatch` is a backstop above
+  `SnapshotCap x active subscriptions`, not the working bound. Set it low and the cut
+  lands on whichever subscriptions the scan reached last, which is the failure this
+  replaced: the claim used to be one flat `ORDER BY subscription_id, matched_at LIMIT
+  batch_size`, which reads as "oldest first" and is really "lowest subscription id
+  first". Measured on prod 2026-09-04, reported as "I get no Telegram notifications":
+
+  ```
+  subscription  26 ->    1 118 pending
+  subscription  95 ->  248 147   <- saved search with an EMPTY query
+  subscription  97 ->  104 069
+  the reporter's   ->    8 324    attempts = 0
+  queue total      -> 1 141 757
+  ```
+
+  Nothing failed. `notify` ran every five minutes and logged `delivered=1 failed=0` —
+  one digest, to the same low id, pass after pass, for weeks. Every subscription above it
+  had `attempts = 0` since the day it was created: not retried, not dead-lettered, never
+  in a batch. **`failed=0` is not evidence that delivery works**; `delivered` far below
+  the number of subscriptions with pending matches is what says it does not.
+
+- **A subscription must carry a filter.** An empty saved search is legitimate — it is the
+  "show all" view, and `internal/search/savedsearch` says so. SUBSCRIBING to one asks to
+  be notified about every posting in the catalogue, which is never what anyone means, and
+  is where the 248k above came from. `subscription.Service.Create` refuses it with
+  `ErrUnfilteredSearch` (400). The guard is at subscribe time, not at save time, because
+  that is where the meaning changes.
+
+- **A non-positive per-subscription cap claims nothing and reports success.** It becomes
+  `LIMIT 0` inside the `LATERAL`: no rows, no error, the worker quietly idle. It is
+  floored at the call site for the same reason `SEARCH_DRAIN_BATCH_SIZE` is — a silent
+  no-op is worse than a crash.
+
 - **All three engines deliver in GROUPS, and a group is the unit of everything.**
   `notify` groups a subscription's matched jobs; `internal/engage/reminder` groups an
   account's due reminders; `internal/engage/nudge` groups an account's due nudges **of one

--- a/internal/platform/db/metrics.sql.go
+++ b/internal/platform/db/metrics.sql.go
@@ -101,6 +101,40 @@ func (q *Queries) NewestOpenJobCreatedAt(ctx context.Context) (pgtype.Timestampt
 	return created_at, err
 }
 
+const notifyBacklogMetrics = `-- name: NotifyBacklogMetrics :one
+SELECT
+    COALESCE(count(DISTINCT m.subscription_id), 0)::bigint AS pending_subscriptions,
+    COALESCE(EXTRACT(EPOCH FROM now() - min(m.matched_at)), 0)::float8 AS oldest_age_seconds
+FROM subscription_matches m
+JOIN subscriptions s ON s.id = m.subscription_id
+WHERE m.notified_at IS NULL AND m.failed_at IS NULL AND s.active
+`
+
+type NotifyBacklogMetricsRow struct {
+	PendingSubscriptions int64   `json:"pending_subscriptions"`
+	OldestAgeSeconds     float64 `json:"oldest_age_seconds"`
+}
+
+// The subscription-digest backlog: how many active subscriptions have something
+// undelivered, and how old the oldest undelivered match is.
+//
+// The age is the signal that matters. A pass runs every five minutes, so in steady state
+// the oldest pending match is minutes old. An age that climbs without bound means some
+// subscription is never being served — which is not visible in the worker's own log,
+// because a starved subscription produces no failure: `notify` reported
+// `delivered=1 failed=0` for weeks while 1.14M matches sat undelivered and one
+// subscription's had never been claimed at all (2026-09-04, see docs/agents/notifications.md).
+//
+// Both COALESCE to 0 rather than staying NULL: a drained backlog is a real measurement
+// that must publish an explicit zero, because an absent series is how the consuming alert
+// rules recognize a dead exporter.
+func (q *Queries) NotifyBacklogMetrics(ctx context.Context) (NotifyBacklogMetricsRow, error) {
+	row := q.db.QueryRow(ctx, notifyBacklogMetrics)
+	var i NotifyBacklogMetricsRow
+	err := row.Scan(&i.PendingSubscriptions, &i.OldestAgeSeconds)
+	return i, err
+}
+
 const providerIngestHealth = `-- name: ProviderIngestHealth :many
 SELECT
     provider,

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -3110,6 +3110,20 @@ type Querier interface {
 	// zero timestamp: zero reads as 1970, i.e. an infinitely stale catalogue, whereas an
 	// empty catalogue is a fresh-install state and not an incident.
 	NewestOpenJobCreatedAt(ctx context.Context) (pgtype.Timestamptz, error)
+	// The subscription-digest backlog: how many active subscriptions have something
+	// undelivered, and how old the oldest undelivered match is.
+	//
+	// The age is the signal that matters. A pass runs every five minutes, so in steady state
+	// the oldest pending match is minutes old. An age that climbs without bound means some
+	// subscription is never being served — which is not visible in the worker's own log,
+	// because a starved subscription produces no failure: `notify` reported
+	// `delivered=1 failed=0` for weeks while 1.14M matches sat undelivered and one
+	// subscription's had never been claimed at all (2026-09-04, see docs/agents/notifications.md).
+	//
+	// Both COALESCE to 0 rather than staying NULL: a drained backlog is a real measurement
+	// that must publish an explicit zero, because an absent series is how the consuming alert
+	// rules recognize a dead exporter.
+	NotifyBacklogMetrics(ctx context.Context) (NotifyBacklogMetricsRow, error)
 	// Record one confident job-mail sighting for a sender domain, returning its running
 	// count. The classifier calls this whenever it confidently labels an email as
 	// application mail, so a recurring unknown ATS domain accrues hits toward promotion.

--- a/internal/platform/db/queries/metrics.sql
+++ b/internal/platform/db/queries/metrics.sql
@@ -132,3 +132,24 @@ SELECT
 FROM board_health
 GROUP BY provider
 ORDER BY provider;
+
+-- name: NotifyBacklogMetrics :one
+-- The subscription-digest backlog: how many active subscriptions have something
+-- undelivered, and how old the oldest undelivered match is.
+--
+-- The age is the signal that matters. A pass runs every five minutes, so in steady state
+-- the oldest pending match is minutes old. An age that climbs without bound means some
+-- subscription is never being served — which is not visible in the worker's own log,
+-- because a starved subscription produces no failure: `notify` reported
+-- `delivered=1 failed=0` for weeks while 1.14M matches sat undelivered and one
+-- subscription's had never been claimed at all (2026-09-04, see docs/agents/notifications.md).
+--
+-- Both COALESCE to 0 rather than staying NULL: a drained backlog is a real measurement
+-- that must publish an explicit zero, because an absent series is how the consuming alert
+-- rules recognize a dead exporter.
+SELECT
+    COALESCE(count(DISTINCT m.subscription_id), 0)::bigint AS pending_subscriptions,
+    COALESCE(EXTRACT(EPOCH FROM now() - min(m.matched_at)), 0)::float8 AS oldest_age_seconds
+FROM subscription_matches m
+JOIN subscriptions s ON s.id = m.subscription_id
+WHERE m.notified_at IS NULL AND m.failed_at IS NULL AND s.active;

--- a/internal/platform/worker/AGENTS.md
+++ b/internal/platform/worker/AGENTS.md
@@ -91,8 +91,13 @@ answers *is the worker alive*: a hung run never stamps a completion, so last-run
 covers both "hung" and "timer stopped".
 
 **Per pipeline, by `cmd/queue-metrics`** — `freehire_queue_{depth,dead_letters,oldest_age_seconds}`
-labelled by `queue`, `freehire_boards_total` labelled by `state`, and
-`freehire_catalogue_newest_job_timestamp_seconds`. This answers *is the worker keeping up*.
+labelled by `queue`, `freehire_boards_total` labelled by `state`,
+`freehire_catalogue_newest_job_timestamp_seconds`, and
+`freehire_notify_{pending_subscriptions,oldest_pending_age_seconds}`. This answers *is the
+worker keeping up*. The notify pair exists because a starved subscription produces no
+failure to notice: `notify` reported `delivered=1 failed=0` for weeks while 1.14M matches
+sat undelivered (2026-09-04, see [docs/agents/notifications.md](../../../docs/agents/notifications.md)).
+An oldest-pending age climbing past a few passes is the signal; `failed` never moved.
 These names are a contract with the dashboard and alert rules in `freehire-ops`, which
 cannot be compiled against this repo — `cmd/queue-metrics/render_test.go` pins the exact
 exposition text so a rename is a visible edit rather than a silent breakage.


### PR DESCRIPTION
#2425 stops the starvation. This is about **how long it took to notice**: weeks, and only because a user said *"I get no Telegram notifications"*.

Nothing in the system disagreed with them. `notify` logged `delivered=1 failed=0` every five minutes, the whole time.

## Why failure counters could not catch it

A subscription that is never **claimed** never **fails**. It has no attempts, no errors, no dead letters — it is simply absent from every batch. So the signal has to be the backlog itself, not the outcome of the work.

## Two gauges

```
freehire_notify_pending_subscriptions       active subs with anything undelivered
freehire_notify_oldest_pending_age_seconds  age of the oldest undelivered match
```

The **age** is the one that matters. A pass runs every five minutes, so in steady state the oldest pending match is minutes old. An age climbing without bound means someone is never served — on 2026-09-04 it would have read in *weeks*.

They sit alongside `freehire_queue_oldest_age_seconds`, which they deliberately mirror; both `COALESCE` to 0 rather than NULL for the same documented reason (an absent series is how the alert rules recognise a dead exporter, so a drained backlog must publish an explicit zero).

`render_test.go`'s pinned exposition is updated. That pin is the cross-repo contract with `freehire-ops`, which cannot be compiled against this repo — adding a family is meant to be a visible edit.

## The text

`docs/agents/notifications.md` gains the three invariants this incident cost, each stated with what happened when it did not hold:

- the claim is capped **per subscription**, and `ClaimBatch` is a backstop above `SnapshotCap × active subscriptions` — set it low and the cut lands on whichever subscriptions the scan reached last;
- a subscription must carry a filter (saving an unfiltered board is fine, subscribing to one is not);
- a non-positive per-subscription cap is `LIMIT 0` — no rows, no error, the worker quietly idle.

It also records the shape of the failure, including the line that should have been the tell: **`failed=0` is not evidence that delivery works.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Prometheus metrics for notification delivery backlog:
    - `freehire_notify_pending_subscriptions`
    - `freehire_notify_oldest_pending_age_seconds`
  - Metrics report the number of active subscriptions with undelivered notifications and the age of the oldest pending notification, including zero values when no backlog exists.

- **Documentation**
  - Expanded notification guidance covering delivery fairness, empty-search subscription validation, and non-positive per-subscription claim limits.
  - Documented the new notification backlog metrics and how to interpret them when monitoring delivery issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->