### PR TITLE
Give the search drain a window, and stop holding a dump S3 already has

### DIFF
--- a/deploy/bin/pg-backup.sh
+++ b/deploy/bin/pg-backup.sh
@@ -22,7 +22,9 @@ BACKUP_DIR=/var/backups/freehire
 S3_REMOTE=hz
 BACKUP_BUCKET=freehire-backups
 S3_PREFIX=pg
-# Keep only the newest local dump — S3 (below) is the authoritative backup with
+# Bounds what an upload OUTAGE leaves behind. A SUCCESSFUL upload now deletes its own
+# local copy (see the verified delete after rclone copyto), so in the ordinary case this
+# directory holds nothing between runs. S3 (below) is the authoritative backup with
 # S3_MAX_AGE history. On host-2's 301G disk, Meili (~128G) + PG (~70G) + a facet
 # reindex's ~2x transient index leave no room for a stack of ~19G dumps; three of
 # them once filled the disk mid-reindex (2026-07-20), aborting it on `unexpected
@@ -178,6 +180,26 @@ for db in "${DATABASES[@]}"; do
   dest="${S3_REMOTE}:${BACKUP_BUCKET}/${S3_PREFIX}/${db}/${db}_${ts}.dump"
   log "uploading -> $dest"
   rclone copyto "$file" "$dest"
+
+  # The local copy exists to reach S3. Once it is there, keeping it costs 27G and grows
+  # about a gigabyte a day (24G on 2026-08-31, 27.6G on 2026-09-04) on a disk that has
+  # twice run a facet reindex out of room — the header above records three dumps filling
+  # it in 2026-07-20, and on 2026-09-04 free space was 42G against the reindex's own 40G
+  # floor. LOCAL_KEEP still bounds what an upload OUTAGE leaves behind; this removes what
+  # a successful upload leaves behind.
+  #
+  # Guarded by asking S3 what it actually holds, not by assuming rclone's exit code means
+  # the object is intact: this deletes the only local copy, so the check is worth one
+  # extra call. A mismatch keeps the file and says so rather than failing the run — the
+  # backup itself succeeded, and disk is the lesser problem.
+  remote_size=$(rclone size --json "$dest" 2>/dev/null | jq -r '.bytes // empty')
+  local_size=$(stat -c %s "$file")
+  if [ "$remote_size" = "$local_size" ]; then
+    rm -f -- "$file"
+    log "local copy removed; S3 holds ${remote_size} bytes"
+  else
+    log "WARNING: S3 reports '${remote_size}' bytes against ${local_size} local — keeping the local dump"
+  fi
 
   # S3 retention: drop objects older than S3_MAX_AGE.
   rclone delete --min-age "$S3_MAX_AGE" \

--- a/deploy/systemd/freehire-reindexw.timer
+++ b/deploy/systemd/freehire-reindexw.timer
@@ -2,19 +2,29 @@
 Description=timer: freehire-reindexw
 
 [Timer]
-# Every 6h, offset to 03:15 — NOT every 3h, and NOT on the :15 that collides with
+# Every 12h, offset to 03:15 — and NOT on the :15 that collides with
 # freehire-reindex-dedup.timer's 06:30 (that unit rebuilds the whole index itself).
 #
-# Why 6h: a full facet rebuild is ~1.47M documents and measured 2h23m-2h30m per run
-# (2026-08-17: 18:40->21:10, 21:40->00:03). On the old 3h slot that left ~30 min of
-# free Meilisearch per cycle, and reindexw's ExecStartPre stops the search-drain timer
-# for the duration — so search_outbox drained only 17% of the day and the
-# pipeline-search-backlog alert fired continuously from 19:35 onward with a 22k backlog.
+# reindexw's ExecStartPre STOPS the search-drain timer for the whole run, and
 # Meilisearch runs ONE serial task queue, so a rebuild in flight starves every
-# incremental drain batch: 200 docs took 31s under contention vs 2.6s free.
-# 6h leaves ~3.5h of clear queue between runs. Revisit if a run ever exceeds ~4h.
-OnCalendar=*-*-* 03/6:15:00
-Persistent=true
+# incremental drain batch (measured 2026-08-17: 200 docs took 31s under contention vs
+# 2.6s free). The cadence is therefore not about the rebuild — it is about how much
+# clear queue the drain gets between rebuilds.
+#
+# It was 6h, chosen when a full rebuild was ~1.47M documents and measured 2h23m-2h30m
+# (2026-08-17), leaving ~3.5h clear. That comment ended "Revisit if a run ever exceeds
+# ~4h", and it has: the index is ~4.5M documents now and a run measured 4h15m
+# (2026-09-04, 12:01->16:17). 12h leaves ~7h45m clear. Revisit again past ~8h.
+#
+# Persistent is deliberately OFF, which is the part that actually broke. With it on, a
+# run that overruns its slot leaves the slot "missed", so systemd fires it the instant
+# the unit goes inactive — on 2026-09-04 a run finished at 16:17:01 and the next started
+# at 16:17:01, the same second. ExecStopPost restarted the drain timer and the new run's
+# ExecStartPre stopped it again, so the drain's window was not merely short, it was zero:
+# search_outbox reached 136k with entries two days old and no new vacancy reached search.
+# A periodic rebuild has nothing to catch up on — the next slot is soon enough.
+OnCalendar=*-*-* 03/12:15:00
+Persistent=false
 RandomizedDelaySec=120
 
 [Install]


### PR DESCRIPTION
Two host-side causes of the same symptom: **no new vacancies reaching search**.

## 1. The reindex left the drain zero window

`reindexw`'s `ExecStartPre` stops the search-drain timer for the whole run, and Meilisearch runs **one serial task queue**, so a rebuild in flight starves every incremental batch. The cadence is therefore not about the rebuild — it is about how much clear queue the drain gets *between* rebuilds.

**The unit's own comment said when to revisit:**

> `6h leaves ~3.5h of clear queue between runs. Revisit if a run ever exceeds ~4h.`

It has. That 6h was chosen when a rebuild was ~1.47M documents at 2h23m. The index is **~4.5M** now and a run measured **4h15m** (12:01→16:17 today). Now 12h, leaving ~7h45m clear.

**`Persistent=true` is the part that actually broke**, and no comment anticipated it. A run that overruns its slot leaves the slot *missed*, so systemd fires it the instant the unit goes inactive:

```
16:17:01  run finishes   -> ExecStopPost starts the drain timer
16:17:01  next run starts -> ExecStartPre stops it again
```

Same second. The drain's window was not short — it was **zero**. `search_outbox` reached 136k with entries two days old. A periodic rebuild has nothing to catch up on, so `Persistent` is off.

## 2. The backup kept a copy S3 already had

That local dump exists to reach S3. Once there it costs **27G and grows about a gigabyte a day** (24G on 08-31, 27.6G today) on a disk that has twice run a reindex out of room — the script's own header records three dumps filling it in 2026-07-20, and free space today was 42G against the reindex's own 40G floor.

It now deletes the local copy after **asking S3 what it actually holds**, rather than trusting rclone's exit code — this is the only local copy, so one extra call is cheap. A size mismatch keeps the file and logs it rather than failing the run: the backup succeeded, and disk is the lesser problem. `LOCAL_KEEP` still bounds what an upload *outage* leaves behind.

## Verified

- `systemd-analyze verify` on the timer; next elapse `Sat 03:15 UTC`, `Persistent=no` confirmed on the host.
- `shellcheck` clean on `pg-backup.sh`; syntax checked after install.
- Both installed on the host (backup taken first), timer re-enabled.
- Drain measured after the batch size was raised: the 136k backlog is gone, batches are now 18–36 docs and the queue is flat.