### PR TITLE
Gate the account section with a redirect, and even up the sign-in buttons

### DIFF
--- a/design-system/scripts/adoption-baseline.json
+++ b/design-system/scripts/adoption-baseline.json
@@ -3,7 +3,7 @@
   "Avatar": 0,
   "Badge": 18,
   "BrandMark": 2,
-  "Button": 71,
+  "Button": 70,
   "Card": 3,
   "Chip": 4,
   "ConfirmDialog": 15,

--- a/web/src/lib/components/AuthBrandPanel.svelte
+++ b/web/src/lib/components/AuthBrandPanel.svelte
@@ -103,7 +103,11 @@
       {/each}
     </ul>
 
-    <div class="relative mt-8 aspect-square w-full overflow-hidden rounded-2xl border border-background/15 bg-background/5 p-4">
+    <!-- Landscape, not square: the tallest slide is three stacked rows (~160px), so a
+         square box left the board slide with a third of its height empty. A fixed
+         height rather than an aspect ratio — the column is max-w-sm, so this is the
+         3/2 the ratio would have given, without an arbitrary Tailwind value. -->
+    <div class="relative mt-6 h-64 w-full overflow-hidden rounded-2xl border border-background/15 bg-background/5 p-4">
       {#if active === 0}
         <div class="flex h-full flex-col justify-center gap-3">
           {#each [100, 72, 85] as w (w)}

--- a/web/src/lib/i18n/shell.ts
+++ b/web/src/lib/i18n/shell.ts
@@ -22,8 +22,6 @@ export const messages = defineMessages(
       '/my/security': 'Security',
     },
     shell: {
-      signInPrompt: 'Sign in to access your account.',
-      signIn: 'Sign in',
       expandSidebar: 'Expand sidebar',
       collapseSidebar: 'Collapse sidebar',
       accountSections: 'Account sections',
@@ -51,8 +49,6 @@ export const messages = defineMessages(
       '/my/security': 'Безопасность',
     },
     shell: {
-      signInPrompt: 'Войдите, чтобы получить доступ к аккаунту.',
-      signIn: 'Войти',
       expandSidebar: 'Развернуть панель',
       collapseSidebar: 'Свернуть панель',
       accountSections: 'Разделы аккаунта',

--- a/web/src/routes/my/+layout.server.ts
+++ b/web/src/routes/my/+layout.server.ts
@@ -1,0 +1,17 @@
+import { redirect } from '@sveltejs/kit';
+import { signinUrl } from '$lib/signin';
+import type { LayoutServerLoad } from './$types';
+
+// The auth gate for the whole account section. Every /my/** page needs a session, so
+// the check lives here once rather than as an in-page "Sign in to access your account"
+// placeholder: an anonymous visitor gets a 302 to the sign-in form before any account
+// chrome renders, and comes straight back to the page they asked for.
+//
+// It also covers a sign-out that happens while sitting on one of these pages —
+// logout() calls invalidateAll(), which re-runs this load and redirects.
+export const load: LayoutServerLoad = async ({ parent, url }) => {
+  const { user } = await parent();
+  if (!user) {
+    redirect(302, signinUrl({ returnTo: url.pathname + url.search, cancelTo: '/', mode: 'login' }));
+  }
+};

--- a/web/src/routes/my/+layout.svelte
+++ b/web/src/routes/my/+layout.svelte
@@ -5,12 +5,11 @@
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
   import { PanelLeftClose, PanelLeft } from '@lucide/svelte';
-  import { isAuthenticated, currentUser } from '$lib/auth.svelte';
-  import { signinUrl } from '$lib/signin';
+  import { currentUser } from '$lib/auth.svelte';
   import { locale } from '$lib/i18n/currentLocale.svelte';
   import { messages, navLabel } from '$lib/i18n/shell';
   import { t } from '$lib/i18n/t';
-  import { Button, cn } from '$lib/ui';
+  import { cn } from '$lib/ui';
   import { visibleAccountNav, isSectionActive } from '$lib/accountNav';
   import { accountNavIcons } from '$lib/accountNavIcons';
   import { dockOffset } from '$lib/assistantDock.svelte';
@@ -88,77 +87,73 @@
   style:padding-left={dockOffset() ? `${dockOffset()}px` : undefined}
 >
   <div class="mx-auto w-full max-w-6xl px-4 py-6">
-    {#if !isAuthenticated()}
-      <div class="flex flex-col items-center gap-3 py-12 text-center">
-        <p class="text-sm text-muted-foreground">{s.shell.signInPrompt}</p>
-        <Button variant="primary" href={signinUrl({ returnTo: page.url.pathname + page.url.search, mode: 'login' })}>{s.shell.signIn}</Button>
-      </div>
-    {:else}
-      <!-- Same items, two forms; `extra` carries the per-form item tweaks. When
-           `iconOnly`, the label is dropped and the icon centres (collapsed rail). -->
-      {#snippet navLinks(extra: string, iconOnly = false)}
-        {#each navItems as item (item.href)}
-          {@const active = isSectionActive(path, item.href)}
-          {@const Icon = accountNavIcons[item.href]}
-          {@const label = navLabel(s, item.href, item.label)}
-          <a
-            href={resolve(item.href)}
-            aria-current={active ? 'page' : undefined}
-            title={iconOnly ? label : undefined}
-            class={cn(itemClass(active), iconOnly && 'justify-center', extra)}
-          >
-            <Icon class="size-4 shrink-0" />
-            {#if !iconOnly}
-              {label}
-            {/if}
-          </a>
-        {/each}
-      {/snippet}
+    <!-- No signed-out branch here: +layout.server.ts redirects an anonymous visitor to
+         /signin before this renders, so the shell only ever draws for a session. -->
 
-      <!-- Below lg: a horizontal, scrollable strip above the content. -->
-      <nav
-        aria-label={s.shell.accountSections}
-        class="no-scrollbar mb-4 flex gap-1 overflow-x-auto lg:hidden"
-      >
-        {@render navLinks('shrink-0 whitespace-nowrap')}
-      </nav>
-
-      <div class="lg:flex lg:gap-8">
-        <!-- lg and up: a collapsible vertical sidebar beside the content. -->
-        <aside
-          aria-label={s.shell.accountSections}
-          class={cn(
-            'hidden shrink-0 transition-[width] duration-200 lg:block',
-            collapsed ? 'lg:w-14' : 'lg:w-56',
-          )}
+    <!-- Same items, two forms; `extra` carries the per-form item tweaks. When
+         `iconOnly`, the label is dropped and the icon centres (collapsed rail). -->
+    {#snippet navLinks(extra: string, iconOnly = false)}
+      {#each navItems as item (item.href)}
+        {@const active = isSectionActive(path, item.href)}
+        {@const Icon = accountNavIcons[item.href]}
+        {@const label = navLabel(s, item.href, item.label)}
+        <a
+          href={resolve(item.href)}
+          aria-current={active ? 'page' : undefined}
+          title={iconOnly ? label : undefined}
+          class={cn(itemClass(active), iconOnly && 'justify-center', extra)}
         >
-          <div class="sticky top-6 flex flex-col gap-1">
-            <button
-              type="button"
-              onclick={toggleNav}
-              title={collapsed ? s.shell.expandSidebar : s.shell.collapseSidebar}
-              aria-label={collapsed ? s.shell.expandSidebar : s.shell.collapseSidebar}
-              class={cn(
-                'mb-1 flex items-center rounded-md px-3 py-2 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground',
-                collapsed && 'justify-center',
-              )}
-            >
-              {#if collapsed}
-                <PanelLeft class="size-4" />
-              {:else}
-                <PanelLeftClose class="size-4" />
-              {/if}
-            </button>
-            <nav aria-label={s.shell.accountSections} class="flex flex-col gap-1">
-              {@render navLinks('', collapsed)}
-            </nav>
-          </div>
-        </aside>
+          <Icon class="size-4 shrink-0" />
+          {#if !iconOnly}
+            {label}
+          {/if}
+        </a>
+      {/each}
+    {/snippet}
 
-        <div class="min-w-0 flex-1">
-          {@render children()}
+    <!-- Below lg: a horizontal, scrollable strip above the content. -->
+    <nav
+      aria-label={s.shell.accountSections}
+      class="no-scrollbar mb-4 flex gap-1 overflow-x-auto lg:hidden"
+    >
+      {@render navLinks('shrink-0 whitespace-nowrap')}
+    </nav>
+
+    <div class="lg:flex lg:gap-8">
+      <!-- lg and up: a collapsible vertical sidebar beside the content. -->
+      <aside
+        aria-label={s.shell.accountSections}
+        class={cn(
+          'hidden shrink-0 transition-[width] duration-200 lg:block',
+          collapsed ? 'lg:w-14' : 'lg:w-56',
+        )}
+      >
+        <div class="sticky top-6 flex flex-col gap-1">
+          <button
+            type="button"
+            onclick={toggleNav}
+            title={collapsed ? s.shell.expandSidebar : s.shell.collapseSidebar}
+            aria-label={collapsed ? s.shell.expandSidebar : s.shell.collapseSidebar}
+            class={cn(
+              'mb-1 flex items-center rounded-md px-3 py-2 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground',
+              collapsed && 'justify-center',
+            )}
+          >
+            {#if collapsed}
+              <PanelLeft class="size-4" />
+            {:else}
+              <PanelLeftClose class="size-4" />
+            {/if}
+          </button>
+          <nav aria-label={s.shell.accountSections} class="flex flex-col gap-1">
+            {@render navLinks('', collapsed)}
+          </nav>
         </div>
+      </aside>
+
+      <div class="min-w-0 flex-1">
+        {@render children()}
       </div>
-    {/if}
+    </div>
   </div>
 </div>

--- a/web/src/routes/signin/+page.svelte
+++ b/web/src/routes/signin/+page.svelte
@@ -234,13 +234,16 @@
       </div>
 
       {#if providers.length > 0 && !isRecovery}
-        <div class="flex flex-col gap-2">
+        <div class="flex flex-col gap-3">
           {#each providers as provider (provider)}
+            <!-- Sized to match the submit button below (h-12 / rounded-lg / text-base):
+                 the two stacks read as one column of equally weighted choices. -->
             <Button
               variant="outline"
+              class="h-12 rounded-lg px-5 text-base"
               href={`/api/v1/auth/oauth/${provider}/start?returnTo=${encodeURIComponent(returnTo)}`}
             >
-              <ProviderIcon {provider} />
+              <ProviderIcon {provider} class="size-5" />
               Continue with {providerLabels[provider]}
             </Button>
           {/each}


### PR DESCRIPTION
Three changes to the surface a signed-out visitor meets.

### Provider buttons match the button they sit above

The OAuth buttons on `/signin` were the design system's default size (h-9,
text-sm) while the submit button under them is h-12/text-base, so the two
stacks read as different weights of choice when they are the same one. They
now carry the submit button's height, radius and type size, with the icon
scaled to match.

### The brand panel's illustration is landscape, not square

The tallest slide is three stacked rows — about 160px — so the board slide
left a third of the square box empty. A fixed `h-64` against the `max-w-sm`
column is the 3/2 an aspect ratio would have given, without an arbitrary
Tailwind value the token ratchet would flag.

### `/my/**` redirects instead of explaining itself

Only a few pages under `/my` redirected in their own `load`; the rest fell
through to an in-page "Sign in to access your account" placeholder with a
button pointing at the very place we could have sent them. A
`+layout.server.ts` now gates the whole section, so an anonymous visitor
lands on the sign-in form directly and returns to the page they asked for.

That also covers signing out while on one of these pages: `logout()` calls
`invalidateAll()`, which re-runs the load. The placeholder, its two
now-unused shell strings (en + ru), and the imports it was the only user of
are gone — which takes the design system's `Button` adoption baseline from
71 to 70.

The per-page guards under `/my/tracking` stay: they are redundant with this
one, but they also narrow `user` for their own data load.

## Verification

- `pnpm --dir web check` — 0 errors
- `pnpm --dir web lint` — clean on the touched files
- `pnpm --dir web test` — 1404 passed
- pre-commit: gitleaks, doc-links, web-lint, design-system adoption/tokens/test all green

Not verified in a browser: the provider buttons only render when the backend
serves the OAuth provider list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication protection for account pages. Signed-out visitors are redirected to sign in and returned to their originally requested page afterward.

* **Style**
  * Updated the authentication brand panel illustration to use a wider, shorter layout.
  * Improved sign-in provider buttons with larger sizing, spacing, and icons for a more consistent appearance.

* **Changes**
  * Removed the standalone sign-in prompt and button from the account shell, as unauthenticated visitors are now redirected before the shell loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->