### PR TITLE
Make the drain's batch size one answer instead of two

### DIFF
--- a/internal/platform/config/search_drain.go
+++ b/internal/platform/config/search_drain.go
@@ -21,7 +21,18 @@ type SearchDrain struct {
 // cmd/embed), so this never fails.
 func LoadSearchDrain() SearchDrain {
 	c := SearchDrain{
-		BatchSize:    envInt("SEARCH_DRAIN_BATCH_SIZE", 500),
+		// 2500, measured rather than guessed. A push costs what it costs almost
+		// regardless of size (see CallTimeout below), so the batch is throughput:
+		// on prod 2026-09-04, with a 136k backlog, 200 rows per push drained a NET
+		// 38/min and the queue grew; 1000 drained 1234/min and it fell. The backlog
+		// had reached 136k with entries two days old, and no new vacancy was
+		// reaching search — a batch of 200 was most of why.
+		//
+		// The 200 was not a considered value either. It was set on the host on
+		// 2026-08-05 as "generous timeout + small batch while re-validating" after
+		// an incident whose actual cause was the client timeout (below), and it
+		// stayed a month after the re-validating ended.
+		BatchSize:    envInt("SEARCH_DRAIN_BATCH_SIZE", 2500),
 		LeaseSeconds: envInt("SEARCH_DRAIN_LEASE_SECONDS", 180),
 		MaxAttempts:  envInt("SEARCH_DRAIN_MAX_ATTEMPTS", 3),
 		// Prod measurement (2026-08-05, ~2.7M-doc jobs index): a single push costs


### PR DESCRIPTION
The code said `500`. The host said `200`, then `2500` while I was measuring. Whoever read the code next would have seen neither.

## 2500 is measured, not guessed

The `CallTimeout` comment right below the setting already says why batch size is throughput:

> a single push costs 90-180s+, dominated by Meilisearch's whole-index re-merge, **almost independent of batch size**

Measured on prod today against a 136k backlog:

| batch | net drain rate | queue |
|---|---|---|
| 200 | **38/min** | grew |
| 1000 | **1234/min** | fell |

The backlog had reached 136k with entries **two days old**, and no new vacancy was reaching search. A batch of 200 was most of why.

## The 200 was not a considered value either

It went onto the host on 2026-08-05 as *"generous timeout + small batch while re-validating"*, after an incident whose actual cause was the **client timeout** beside it. It outlived the re-validating by a month.

## What changed where

- Code default `500 → 2500`, with the measurement recorded next to it.
- The **host override is removed**, not updated, so the code default is the answer.
- `SEARCH_DRAIN_CALL_TIMEOUT_SECONDS=1800` **stays** on the host: it is the backstop that same incident earned, and it is a backstop, not a tripwire.

## Verified

Host `.env` diffed variable-by-variable against a backup before and after — the only setting removed is `SEARCH_DRAIN_BATCH_SIZE`. (I clipped the timeout line on the first attempt and put it back; the diff is how I know it is the only one.) Drain restarted and running clean: `failed=0`, queue 7.2k and falling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Increased the default search drain batch size from 500 to 2,500.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->