### PR TITLE
Name the size the sign-in page's buttons share, instead of writing it twice

### DIFF
--- a/web/src/routes/signin/+page.svelte
+++ b/web/src/routes/signin/+page.svelte
@@ -193,6 +193,11 @@
 
   const inputClass =
     'rounded-md border border-border bg-background px-4 py-3 text-base focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+
+  // The size every full-width button in this column shares — the provider buttons
+  // and the submit button — so the choices read as equally weighted. Named once so
+  // the two cannot drift apart; only their fill and weight differ.
+  const buttonSizeClass = 'h-12 rounded-lg px-5 text-base';
 </script>
 
 <svelte:head>
@@ -236,11 +241,9 @@
       {#if providers.length > 0 && !isRecovery}
         <div class="flex flex-col gap-3">
           {#each providers as provider (provider)}
-            <!-- Sized to match the submit button below (h-12 / rounded-lg / text-base):
-                 the two stacks read as one column of equally weighted choices. -->
             <Button
               variant="outline"
-              class="h-12 rounded-lg px-5 text-base"
+              class={buttonSizeClass}
               href={`/api/v1/auth/oauth/${provider}/start?returnTo=${encodeURIComponent(returnTo)}`}
             >
               <ProviderIcon {provider} class="size-5" />
@@ -302,7 +305,10 @@
         <button
           type="submit"
           disabled={submitting}
-          class="mt-1 inline-flex h-12 items-center justify-center rounded-lg bg-brand px-5 text-base font-semibold text-brand-foreground transition-opacity hover:opacity-90 disabled:opacity-60"
+          class={[
+            buttonSizeClass,
+            'mt-1 inline-flex items-center justify-center bg-brand font-semibold text-brand-foreground transition-opacity hover:opacity-90 disabled:opacity-60',
+          ]}
         >
           {submitting ? 'Please wait…' : titles[mode]}
         </button>


### PR DESCRIPTION
Quality pass over #2438. Behavior-preserving.

The provider buttons and the submit button on `/signin` were made the same
size by two separate class strings plus a comment tying them together — the
arrangement that drifts. The size is now one const beside `inputClass`, which
this file already uses for the same reason, so the comment is redundant.

Nothing rendered changes: the submit button's remaining classes are disjoint
from the shared ones, and the provider buttons pass the same string through
the same `cn()` override as before.

### Deliberately left alone

The four `+page.server.ts` guards under `/my/tracking` are redundant with the
new layout guard, but they are not dead weight: their `await parent()` is what
defers the page load until the session is known, so an anonymous request
redirects without first firing `loadBoard` at the API. Removing them would
parallelize those loads and put a pointless authenticated fetch on every
anonymous hit.

## Verification

- `pnpm --dir web check` — 0 errors
- `pnpm --dir web test` — 1450 passed
- pre-commit: gitleaks, doc-links, web-lint, design-system tokens/adoption green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized sizing and spacing across sign-in page buttons for a more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->