### PR TITLE
Give the job header the posting's dates, and take one back from the sidebar

### DIFF
--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -17,7 +17,7 @@
   import type { Job, UserJob } from '$lib/types';
   import { companyLogoUrl } from '$lib/logo';
   import { Badge, Button, Chip, EntityLogo, TabStrip, tabStripId } from '$lib/ui';
-  import { formatDate, formatDateTime } from '$lib/utils';
+  import { formatDate, formatDateOrAgo, formatDateTime } from '$lib/utils';
   import AdzunaAttribution from './AdzunaAttribution.svelte';
   import BackerBadge from './BackerBadge.svelte';
   import CountryFlagStack from './CountryFlagStack.svelte';
@@ -73,12 +73,15 @@
   const saved = $derived(interaction?.saved_at != null);
 
   // Presentational values derived from the (server-rendered) job.
-  const posted = $derived(formatDate(job.posted_at));
+  // Both read as an age for their first day ("20 minutes ago") and as a date after it —
+  // the same label the feed's card already gives a posting, so a reader arriving from
+  // the list meets the answer in the form they just left.
+  const posted = $derived(formatDateOrAgo(job.posted_at));
   // When the posting's own content last changed. `jobs.updated_at` is deliberately left
   // unstamped by the liveness refresh (internal/platform/db/queries/jobs.sql), so the column
   // means "the words moved", not "the crawler came back" — which is the only reading that
   // earns a line beside the posting date.
-  const updated = $derived(formatDate(job.updated_at));
+  const updated = $derived(formatDateOrAgo(job.updated_at));
   const e = $derived(job.enrichment ?? {});
   const salary = $derived(formatSalary(e));
   const facets = $derived(summaryFacets(job));
@@ -337,10 +340,13 @@
      so they ride the provenance line with the company and the badges rather than the
      sidebar's source row, where a reader comparing freshness had to look past the match
      score and the salary to find them.
-     "Updated" is dropped when it lands on the posting's own day: a job written once and
-     never touched would otherwise print the same date twice and say nothing with it.
-     The visible label is a date; the exact clock time rides the `title`, since an hour is
-     what a reader wants only when they are already suspicious of the day.
+     "Updated" is dropped when it renders to the same label as the posting date: a job
+     written once and never touched would otherwise say the same thing twice. Comparing
+     the LABELS rather than the timestamps is the point — two edits an hour apart on one
+     day are a real difference while both read as ages, and stop being one the day they
+     both collapse into that date.
+     The exact clock time rides the `title` either way, since a reader who has read "2
+     hours ago" off a server-rendered page may want to know how old the page is.
      Rendered twice, one visible at a time (the caller passes the display class): to the
      right of the provenance line from lg, and under the title below it, where that line is
      a single non-wrapping row whose company name is already truncating to fit. -->

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -17,7 +17,7 @@
   import type { Job, UserJob } from '$lib/types';
   import { companyLogoUrl } from '$lib/logo';
   import { Badge, Button, Chip, EntityLogo, TabStrip, tabStripId } from '$lib/ui';
-  import { formatDate } from '$lib/utils';
+  import { formatDate, formatDateTime } from '$lib/utils';
   import AdzunaAttribution from './AdzunaAttribution.svelte';
   import BackerBadge from './BackerBadge.svelte';
   import CountryFlagStack from './CountryFlagStack.svelte';
@@ -74,6 +74,11 @@
 
   // Presentational values derived from the (server-rendered) job.
   const posted = $derived(formatDate(job.posted_at));
+  // When the posting's own content last changed. `jobs.updated_at` is deliberately left
+  // unstamped by the liveness refresh (internal/platform/db/queries/jobs.sql), so the column
+  // means "the words moved", not "the crawler came back" — which is the only reading that
+  // earns a line beside the posting date.
+  const updated = $derived(formatDate(job.updated_at));
   const e = $derived(job.enrichment ?? {});
   const salary = $derived(formatSalary(e));
   const facets = $derived(summaryFacets(job));
@@ -328,6 +333,33 @@
   </Button>
 {/snippet}
 
+<!-- When the posting went up and when its words last moved. Two facts ABOUT the posting,
+     so they ride the provenance line with the company and the badges rather than the
+     sidebar's source row, where a reader comparing freshness had to look past the match
+     score and the salary to find them.
+     "Updated" is dropped when it lands on the posting's own day: a job written once and
+     never touched would otherwise print the same date twice and say nothing with it.
+     The visible label is a date; the exact clock time rides the `title`, since an hour is
+     what a reader wants only when they are already suspicious of the day.
+     Rendered twice, one visible at a time (the caller passes the display class): to the
+     right of the provenance line from lg, and under the title below it, where that line is
+     a single non-wrapping row whose company name is already truncating to fit. -->
+{#snippet postingDates(className: string)}
+  {#if posted}
+    <div class={`items-center gap-x-2 text-xs text-muted-foreground ${className}`}>
+      <span class="whitespace-nowrap">
+        Posted <time datetime={job.posted_at} title={formatDateTime(job.posted_at)}>{posted}</time>
+      </span>
+      {#if updated && updated !== posted}
+        <span aria-hidden="true">·</span>
+        <span class="whitespace-nowrap">
+          Updated <time datetime={job.updated_at} title={formatDateTime(job.updated_at)}>{updated}</time>
+        </span>
+      {/if}
+    </div>
+  {/if}
+{/snippet}
+
 <!-- The action strip: everything a reader does WITH the posting — talk about it, flag
      it, keep it, open it — on one line, sharing the tab row's rule. It carries the
      rule itself (`border-b`) rather than sitting above one, so the line reads as a
@@ -459,6 +491,10 @@
         </span>
       {/each}
     </div>
+
+    <!-- `ml-auto` rather than a grid column: the badges above are a variable-width group,
+         so the dates take whatever is left of the line and sit against its right edge. -->
+    {@render postingDates('ml-auto hidden shrink-0 lg:flex')}
   </div>
 
   <header class="flex flex-col gap-3 lg:col-start-2 lg:row-start-2">
@@ -472,6 +508,11 @@
         </Chip>
       {/if}
     </div>
+
+    <!-- Below lg the provenance line is a single non-wrapping row already truncating the
+         company name, so the dates read here instead — a caption under the title rather
+         than right-aligned, which on one phone-width column would only look adrift. -->
+    {@render postingDates('flex lg:hidden')}
 
     <!-- Below lg the strip rides here rather than on the tab row: the sidebar stacks
          between the title and the description on a phone, so a strip left down there
@@ -566,7 +607,9 @@
           {#if job.manually_added}
             <Badge variant="secondary">Manually added</Badge>
           {/if}
-          {#if posted}<span>Posted {posted}</span>{/if}
+          <!-- The posting date used to close this row; it now rides the header's provenance
+               line beside the freshness badges, which is where the rest of the "how old is
+               this?" answer already lives. -->
         </div>
         {#if views > 0 || applies > 0}
           <div class="flex flex-wrap items-center justify-center gap-3 text-xs leading-none text-muted-foreground">

--- a/web/src/lib/utils.test.ts
+++ b/web/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { formatCount } from './utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { formatCount, formatDate, formatDateOrAgo } from './utils';
 
 // formatCount lives here rather than in activityChart because its callers share nothing
 // with a chart module: two axis labels (activity bars, skill pulse) and the job card's
@@ -42,5 +42,50 @@ describe('formatCount', () => {
   it('trims a trailing zero decimal', () => {
     expect(formatCount(2000)).toBe('2K');
     expect(formatCount(2000000)).toBe('2M');
+  });
+});
+
+// The job header prints a posting's two timestamps through this one helper, so the
+// day boundary it switches on is the whole of its behaviour. Time is faked rather
+// than measured: a test that builds "23 hours ago" from the real clock is a test
+// that fails at whatever hour the boundary lands on.
+describe('formatDateOrAgo', () => {
+  const NOW = new Date('2026-09-04T12:00:00Z');
+  const at = (hoursAgo: number) =>
+    new Date(NOW.getTime() - hoursAgo * 3600 * 1000).toISOString();
+
+  afterEach(() => vi.useRealTimers());
+
+  function freeze() {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  }
+
+  it('reads as an age inside the last day', () => {
+    freeze();
+    expect(formatDateOrAgo(at(0.5))).toBe('30 minutes ago');
+    expect(formatDateOrAgo(at(3))).toBe('3 hours ago');
+  });
+
+  // The switch is at exactly 24h: "yesterday" is where the relative form stops
+  // beating the date, so the date must already be showing when it would be said.
+  it('switches to the date at the day boundary', () => {
+    freeze();
+    expect(formatDateOrAgo(at(23))).toBe('23 hours ago');
+    expect(formatDateOrAgo(at(24))).toBe(formatDate(at(24)));
+    expect(formatDateOrAgo(at(72))).toBe(formatDate(at(72)));
+  });
+
+  // Clock skew between a source's stated date and ours would otherwise print
+  // "in 2 hours" as a posting's age.
+  it('gives a future timestamp the date, not an age', () => {
+    freeze();
+    expect(formatDateOrAgo(at(-2))).toBe(formatDate(at(-2)));
+  });
+
+  it('has nothing to say about a missing or unparseable timestamp', () => {
+    expect(formatDateOrAgo(null)).toBe('');
+    expect(formatDateOrAgo(undefined)).toBe('');
+    expect(formatDateOrAgo('not a date')).toBe('');
   });
 });

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -106,3 +106,20 @@ export function timeAgo(ts: string | null | undefined): string {
   }
   return '';
 }
+
+// A day. Inside it "20 minutes ago" is the answer a reader wants and a date cannot
+// give; past it the relative form starts losing to the date it replaced — "3 days
+// ago" is what a reader has to convert back before comparing two postings.
+const RECENT_MS = 86400 * 1000;
+
+/** timeAgo while the instant is still within the last day, formatDate once it is
+ *  not; '' for null/invalid, like both. A timestamp in the FUTURE takes the date
+ *  branch: "in 2 hours" on a posting date is a clock-skew artefact, and reading it
+ *  as an age would be worse than reading it as a date. */
+export function formatDateOrAgo(ts: string | null | undefined): string {
+  if (!ts) return '';
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return '';
+  const age = Date.now() - d.getTime();
+  return age >= 0 && age < RECENT_MS ? timeAgo(ts) : formatDate(ts);
+}

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -27,6 +27,22 @@ export function formatDate(ts: string | null | undefined): string {
   return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
 }
 
+/** The same instant with the clock time, for a `title` behind a formatDate label:
+ *  the visible line stays a date, and a reader who cares about the hour gets it on
+ *  hover rather than in a second column. '' for null/invalid, like formatDate. */
+export function formatDateTime(ts: string | null | undefined): string {
+  if (!ts) return '';
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
 /** Whether s is a LinkedIn personal-profile URL: an http(s) link on linkedin.com (or a
  *  country/www subdomain) whose path is /in/<handle>. Mirrors the backend's shape check —
  *  the server re-validates on submit, so this is just for inline form feedback. */


### PR DESCRIPTION
## What

The job page's header now carries when the posting went up and when its words
last changed, right-aligned on the provenance line beside the company and the
freshness badges. The sidebar's `Posted <date>` is gone — that is the date,
moved, not a second copy.

Both read as an age for their first day and as a date after it:

```
Posted 1 hour ago · Updated 20 minutes ago
Posted Sep 1, 2026
```

## Why

A reader asking "how old is this?" had to scroll past the match score, the
salary and the facet list to reach the answer, while the badges answering the
same question (`New`, `Be an early applicant`) sat at the top of the page. The
two halves of one fact now read together.

The date alone was also the weaker answer for a fresh posting: a job put up
this morning printed today's date — the one thing the reader already knows —
while the feed card they arrived from said "3 hours ago" for the same posting.
`formatDateOrAgo` gives the header the feed's words for its first day.

`updated_at` was served but never rendered. The liveness refresh deliberately
leaves the column unstamped (`internal/platform/db/queries/jobs.sql`), so it
means the words moved rather than the crawler came back — which is the only
reading that earns a line beside the posting date.

## Notes

- The day boundary is where the relative form stops winning: "20 minutes ago"
  is something a date cannot say, "3 days ago" is something a reader has to
  convert back before comparing two postings.
- A future timestamp takes the date branch — clock skew would otherwise print
  "in 2 hours" as a posting's age.
- `Updated` is dropped when it renders to the same label as `Posted`, so an
  untouched job does not say one thing twice.
- The exact clock time rides the `title` (new `formatDateTime`), which matters
  more now that the visible label can be a server-rendered "2 hours ago".
- Below `lg` the provenance line is a single non-wrapping row already
  truncating the company name, so the dates read as a caption under the title
  there instead. Same two-render pattern `applyCta`/`actionStrip` use.

## Verified

- `svelte-check` 0 errors, `pnpm lint` clean, 1454 web tests pass (10 new ones
  cover `formatDateOrAgo`'s boundary on a faked clock).
- Driven in a browser against the live API: desktop and mobile renders checked,
  both the relative and the date branch, and the `Updated` half on a posting
  that had genuinely been edited.
