### PR TITLE
Let the four timestamp formatters share their parse and their date parts

### DIFF
--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -613,9 +613,6 @@
           {#if job.manually_added}
             <Badge variant="secondary">Manually added</Badge>
           {/if}
-          <!-- The posting date used to close this row; it now rides the header's provenance
-               line beside the freshness badges, which is where the rest of the "how old is
-               this?" answer already lives. -->
         </div>
         {#if views > 0 || applies > 0}
           <div class="flex flex-wrap items-center justify-center gap-3 text-xs leading-none text-muted-foreground">

--- a/web/src/lib/utils.test.ts
+++ b/web/src/lib/utils.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { formatCount, formatDate, formatDateOrAgo } from './utils';
 
 // formatCount lives here rather than in activityChart because its callers share nothing
@@ -54,15 +54,13 @@ describe('formatDateOrAgo', () => {
   const at = (hoursAgo: number) =>
     new Date(NOW.getTime() - hoursAgo * 3600 * 1000).toISOString();
 
-  afterEach(() => vi.useRealTimers());
-
-  function freeze() {
+  beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);
-  }
+  });
+  afterEach(() => vi.useRealTimers());
 
   it('reads as an age inside the last day', () => {
-    freeze();
     expect(formatDateOrAgo(at(0.5))).toBe('30 minutes ago');
     expect(formatDateOrAgo(at(3))).toBe('3 hours ago');
   });
@@ -70,7 +68,6 @@ describe('formatDateOrAgo', () => {
   // The switch is at exactly 24h: "yesterday" is where the relative form stops
   // beating the date, so the date must already be showing when it would be said.
   it('switches to the date at the day boundary', () => {
-    freeze();
     expect(formatDateOrAgo(at(23))).toBe('23 hours ago');
     expect(formatDateOrAgo(at(24))).toBe(formatDate(at(24)));
     expect(formatDateOrAgo(at(72))).toBe(formatDate(at(72)));
@@ -79,7 +76,6 @@ describe('formatDateOrAgo', () => {
   // Clock skew between a source's stated date and ours would otherwise print
   // "in 2 hours" as a posting's age.
   it('gives a future timestamp the date, not an age', () => {
-    freeze();
     expect(formatDateOrAgo(at(-2))).toBe(formatDate(at(-2)));
   });
 

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -19,28 +19,31 @@ export function assertNever(x: never): never {
   throw new Error(`Unreachable case: ${JSON.stringify(x)}`);
 }
 
-/** Format an RFC3339 timestamp as a short local date; '' for null/invalid. */
-export function formatDate(ts: string | null | undefined): string {
-  if (!ts) return '';
+/** The Date behind an RFC3339 string, or null when there is nothing to format —
+ *  missing and unparseable are one case here, because every formatter below answers
+ *  both with ''. Nothing else in this file needs to tell them apart. */
+function parseTs(ts: string | null | undefined): Date | null {
+  if (!ts) return null;
   const d = new Date(ts);
-  if (Number.isNaN(d.getTime())) return '';
-  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+  return Number.isNaN(d.getTime()) ? null : d;
 }
 
-/** The same instant with the clock time, for a `title` behind a formatDate label:
- *  the visible line stays a date, and a reader who cares about the hour gets it on
- *  hover rather than in a second column. '' for null/invalid, like formatDate. */
+// Shared so the date a reader sees and the one in the tooltip behind it cannot come
+// to disagree about how a month is spelled.
+const DATE_PARTS = { year: 'numeric', month: 'short', day: 'numeric' } as const;
+
+/** Format an RFC3339 timestamp as a short local date; '' for null/invalid. */
+export function formatDate(ts: string | null | undefined): string {
+  const d = parseTs(ts);
+  return d ? d.toLocaleDateString(undefined, DATE_PARTS) : '';
+}
+
+/** The same instant with the clock time, for a `title` behind a formatDate or
+ *  formatDateOrAgo label: the visible line stays short, and a reader who cares about
+ *  the hour gets it on hover rather than in a second column. '' for null/invalid. */
 export function formatDateTime(ts: string | null | undefined): string {
-  if (!ts) return '';
-  const d = new Date(ts);
-  if (Number.isNaN(d.getTime())) return '';
-  return d.toLocaleString(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+  const d = parseTs(ts);
+  return d ? d.toLocaleString(undefined, { ...DATE_PARTS, hour: '2-digit', minute: '2-digit' }) : '';
 }
 
 /** Whether s is a LinkedIn personal-profile URL: an http(s) link on linkedin.com (or a
@@ -94,9 +97,8 @@ let relativeTime: Intl.RelativeTimeFormat | undefined;
  *  ago", "2 days ago"); '' for null/invalid. How recently a job was posted is a
  *  key signal, so the list card shows it relative rather than as a bare date. */
 export function timeAgo(ts: string | null | undefined): string {
-  if (!ts) return '';
-  const d = new Date(ts);
-  if (Number.isNaN(d.getTime())) return '';
+  const d = parseTs(ts);
+  if (!d) return '';
   const seconds = Math.round((Date.now() - d.getTime()) / 1000);
   const rtf = (relativeTime ??= new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' }));
   for (const [unit, span] of TIME_UNITS) {
@@ -117,9 +119,8 @@ const RECENT_MS = 86400 * 1000;
  *  branch: "in 2 hours" on a posting date is a clock-skew artefact, and reading it
  *  as an age would be worse than reading it as a date. */
 export function formatDateOrAgo(ts: string | null | undefined): string {
-  if (!ts) return '';
-  const d = new Date(ts);
-  if (Number.isNaN(d.getTime())) return '';
+  const d = parseTs(ts);
+  if (!d) return '';
   const age = Date.now() - d.getTime();
   return age >= 0 && age < RECENT_MS ? timeAgo(ts) : formatDate(ts);
 }


### PR DESCRIPTION
## What

A quality pass over the timestamp formatters in `web/src/lib/utils.ts`, with
no behaviour change. Same strings for the same inputs; the tests that pin the
day boundary are untouched apart from moving their clock-freezing into a
`beforeEach`.

## Why

`formatDateOrAgo` and `formatDateTime` (#2444) each arrived carrying their own
copy of the "reject missing, reject unparseable" preamble `formatDate` and
`timeAgo` already had, so the file held it four times. `parseTs` holds it once
and returns `null` for both cases — which is all any caller here needs, since
every one of them answers both with `''`.

The `year/month/day` options were written twice, once for the visible label
and once for the tooltip meant to be the same instant spelled out. One
`DATE_PARTS` const now, so the two cannot come to disagree about how a month
is abbreviated.

`JobView.svelte` kept a comment in the sidebar saying the posting date used to
close that row. A comment about what a file no longer contains is a thing to
maintain and nothing to read; git has it.

## Verified

- `svelte-check` 0 errors, `pnpm lint` clean, 1498 web tests pass.
- Job page driven in a browser against the live API: the header renders the
  identical `<time>` elements — same `datetime`, same `title`, same label.
- CodeRabbit: 0 findings.
