### PR TITLE
Fix auto_apply_queue.tailored_cv_id FK to SET NULL on CV delete

### DIFF
--- a/migrations/0128_auto_apply_queue_tailored_review.sql
+++ b/migrations/0128_auto_apply_queue_tailored_review.sql
@@ -6,15 +6,8 @@
 --
 -- References cvs(id), which is uuid (0045 swapped it from a bigint identity to a random
 -- UUID, per the opaque-cv-ids change) — not bigint.
---
--- ON DELETE SET NULL, matching referral_requests' own precedent for the same shape: an
--- auto_apply_queue row is the candidate's own application-tracking record (approved,
--- declined, or simply abandoned before a decision — it survives until a successful ATS
--- submission deletes it), so losing the CV that was tailored for it must not delete the
--- attempt itself, only forget which CV it was.
 ALTER TABLE public.auto_apply_queue
-    -- squawk-ignore adding-foreign-key-constraint -- 0116 created this table and nothing on main writes to it yet; the scan and lock this takes are on an empty table
-    ADD COLUMN tailored_cv_id uuid REFERENCES public.cvs (id) ON DELETE SET NULL,
+    ADD COLUMN tailored_cv_id uuid REFERENCES public.cvs (id),
     ADD COLUMN reviewed_at timestamptz,
     ADD COLUMN review_decision text
         CONSTRAINT auto_apply_queue_review_decision_check
@@ -22,5 +15,4 @@ ALTER TABLE public.auto_apply_queue
 
 -- A referencing column needs its own index (0045's own note): Postgres indexes only the
 -- referenced side, so without this, deleting a CV scans auto_apply_queue.
--- squawk-ignore require-concurrent-index-creation -- same empty table as above; CONCURRENTLY cannot run inside this file's transaction anyway
 CREATE INDEX auto_apply_queue_tailored_cv_id_idx ON public.auto_apply_queue (tailored_cv_id);

--- a/migrations/0135_auto_apply_queue_tailored_cv_id_on_delete.sql
+++ b/migrations/0135_auto_apply_queue_tailored_cv_id_on_delete.sql
@@ -1,3 +1,9 @@
+-- migrate: no-transaction
+-- Two ALTER TABLE statements, deliberately NOT in one transaction: NOT VALID + VALIDATE
+-- CONSTRAINT in the same transaction blocks reads for the whole validation scan, defeating
+-- the point of splitting them (squawk's own constraint-missing-not-valid rule catches this
+-- exact anti-pattern).
+--
 -- 0128 added auto_apply_queue.tailored_cv_id REFERENCES cvs(id) with no ON DELETE clause,
 -- which defaults to RESTRICT — the one FK to cvs(id) in the whole schema that does. 0128 is
 -- already applied (production ran it on 2026-09-04), so per this repo's own rule it is never
@@ -10,7 +16,15 @@
 -- application-tracking record — losing the CV that was tailored for it must not delete the
 -- attempt itself, only forget which CV it was. Matches referral_requests' own precedent for
 -- exactly this "record survives, pointer clears" shape.
+-- NOT VALID + a separate VALIDATE CONSTRAINT, not a plain ADD CONSTRAINT: the DROP above
+-- takes the same SHARE ROW EXCLUSIVE lock either way, but NOT VALID skips the scan that
+-- would otherwise hold it for as long as the scan takes, and the later VALIDATE only needs
+-- SHARE UPDATE EXCLUSIVE (blocks neither readers nor writers). Matches 0128_add_username's
+-- own reasoning for the identical shape.
 ALTER TABLE public.auto_apply_queue
     DROP CONSTRAINT IF EXISTS auto_apply_queue_tailored_cv_id_fkey,
     ADD CONSTRAINT auto_apply_queue_tailored_cv_id_fkey
-        FOREIGN KEY (tailored_cv_id) REFERENCES public.cvs (id) ON DELETE SET NULL;
+        FOREIGN KEY (tailored_cv_id) REFERENCES public.cvs (id) ON DELETE SET NULL NOT VALID;
+
+ALTER TABLE public.auto_apply_queue
+    VALIDATE CONSTRAINT auto_apply_queue_tailored_cv_id_fkey;

--- a/migrations/0135_auto_apply_queue_tailored_cv_id_on_delete.sql
+++ b/migrations/0135_auto_apply_queue_tailored_cv_id_on_delete.sql
@@ -1,0 +1,16 @@
+-- 0128 added auto_apply_queue.tailored_cv_id REFERENCES cvs(id) with no ON DELETE clause,
+-- which defaults to RESTRICT — the one FK to cvs(id) in the whole schema that does. 0128 is
+-- already applied (production ran it on 2026-09-04), so per this repo's own rule it is never
+-- edited in place; this is the follow-up fix instead. Idempotent by shape (DROP+ADD the same
+-- constraint), so it is safe to run against any environment regardless of exactly which
+-- version of 0128 it happened to apply.
+--
+-- SET NULL, not CASCADE: unlike cv_revisions/cv_tracer_links (which describe the CV being
+-- deleted and have no reason to survive it), an auto_apply_queue row is the candidate's own
+-- application-tracking record — losing the CV that was tailored for it must not delete the
+-- attempt itself, only forget which CV it was. Matches referral_requests' own precedent for
+-- exactly this "record survives, pointer clears" shape.
+ALTER TABLE public.auto_apply_queue
+    DROP CONSTRAINT IF EXISTS auto_apply_queue_tailored_cv_id_fkey,
+    ADD CONSTRAINT auto_apply_queue_tailored_cv_id_fkey
+        FOREIGN KEY (tailored_cv_id) REFERENCES public.cvs (id) ON DELETE SET NULL;


### PR DESCRIPTION
## Summary

Migration 0128 (merged in #2445) added `auto_apply_queue.tailored_cv_id REFERENCES cvs(id)` with no `ON DELETE` clause — the one FK to `cvs(id)` in the whole schema that defaults to RESTRICT instead of an explicit behavior. Deleting a CV that was ever tailored for an auto-apply attempt currently fails outright.

An earlier attempt to fix this edited 0128 in place, believing it had never been applied anywhere. That was wrong: production had already applied the original 0128 on 2026-09-04 (a concurrent session's own work), so per this repo's own "never edit an applied migration" rule, that edit is reverted here and replaced with a proper follow-up migration (0135).

`ON DELETE SET NULL` matches `referral_requests`' own precedent: `auto_apply_queue` is the candidate's own application-tracking record and must survive losing the CV pointer, not cascade-delete with it.

## Test plan

- [x] `pnpm check:sql` (squawk, 0 issues — `NOT VALID` + separate `VALIDATE CONSTRAINT` across a `no-transaction` migration, matching `0128_add_username.sql`'s own precedent for the identical shape)
- [x] `go build ./...` / `go vet ./...` / `go test ./...`
- [x] Verified against production's actual live schema (`\d auto_apply_queue`) that the reverted 0128 content matches exactly what's already applied, and that the table currently holds 1 row (the FK add is effectively instant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated automatic application queue handling so deleting a tailored CV clears its queue reference instead of preventing the deletion.
  * Existing queue records remain available after the associated tailored CV is removed.
  * Added validation for the updated relationship to help ensure existing data remains consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->