### PR TITLE
Let the search box wait for a real pause, and drop the answers nobody waits for

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -318,6 +318,13 @@ export interface EmailBody extends EmailLinking {
   read: boolean;
 }
 
+/** Options for a read a caller may abandon. Carried by the endpoints a typeahead
+ *  drives, where the next keystroke makes the request in flight the answer to a
+ *  question nobody is asking any more. */
+export interface Abortable {
+  signal?: AbortSignal;
+}
+
 /** Build an API client bound to a specific fetch and base URL.
  *
  *  - Browser: the default `api` uses global fetch and an empty base, so requests
@@ -387,6 +394,16 @@ export function createApi(
    *  its payload this way, so this collapses the request+`.data` unwrap into one call. */
   async function requestData<T>(path: string, init?: RequestInit): Promise<T> {
     return (await request<{ data: T }>(path, init)).data;
+  }
+
+  /** The read endpoints a typeahead calls take this: a caller that fires a fresh
+   *  request on every settled keystroke abandons the previous one rather than waiting
+   *  for an answer to a question nobody is asking any more. Distinct from the server
+   *  client's `timeoutMs` — that guards the SSR process against a slow backend, this is
+   *  the CALLER saying the question went stale. A caller that brings a signal keeps it
+   *  (see `call`), so the two never compete for the same request. */
+  function aborting(opts?: Abortable): RequestInit | undefined {
+    return opts?.signal ? { signal: opts.signal } : undefined;
   }
 
   /** Build the request init for a JSON body (POST/PATCH/PUT). Single-sources the
@@ -486,11 +503,19 @@ export function createApi(
    *  would score every job by similarity, so a query like "devops" would return the
    *  whole catalogue reordered rather than the handful that match — which reads as
    *  "search is broken". */
-  async function searchJobs(facets: URLSearchParams, limit: number, offset: number): Promise<Slice<Job>> {
+  async function searchJobs(
+    facets: URLSearchParams,
+    limit: number,
+    offset: number,
+    opts?: Abortable,
+  ): Promise<Slice<Job>> {
     const params = new URLSearchParams(facets);
     params.set('limit', String(limit));
     params.set('offset', String(offset));
-    return toSlice(await request<Page<Job>>(`/api/v1/jobs/search?${params}`), offset);
+    return toSlice(
+      await request<Page<Job>>(`/api/v1/jobs/search?${params}`, aborting(opts)),
+      offset,
+    );
   }
 
   /** Complete a partly-typed query against the catalogue's own vocabulary: the
@@ -501,9 +526,9 @@ export function createApi(
    *  Engineer Google" carries the role AND the company, and applying only one of them
    *  discards what was typed. An empty query returns nothing: what an empty box offers
    *  is a curated starting point the client owns (see starterSuggestions). */
-  async function suggest(q: string, limit: number): Promise<ApiSuggestion[]> {
+  async function suggest(q: string, limit: number, opts?: Abortable): Promise<ApiSuggestion[]> {
     const params = new URLSearchParams({ q, limit: String(limit) });
-    return requestData<ApiSuggestion[]>(`/api/v1/suggest?${params}`);
+    return requestData<ApiSuggestion[]>(`/api/v1/suggest?${params}`, aborting(opts));
   }
 
   /** Turn a written description of a job search into filter values (the AI filter).
@@ -621,12 +646,16 @@ export function createApi(
     limit: number,
     offset: number,
     facets?: URLSearchParams,
+    opts?: Abortable,
   ): Promise<Slice<CompanyListItem>> {
     const params = new URLSearchParams(facets);
     if (q) params.set('q', q);
     params.set('limit', String(limit));
     params.set('offset', String(offset));
-    return toSlice(await request<Page<CompanyListItem>>(`/api/v1/companies?${params}`), offset);
+    return toSlice(
+      await request<Page<CompanyListItem>>(`/api/v1/companies?${params}`, aborting(opts)),
+      offset,
+    );
   }
 
   async function getCompany(

--- a/web/src/lib/components/HeaderSearch.svelte
+++ b/web/src/lib/components/HeaderSearch.svelte
@@ -69,11 +69,20 @@
 
   const hero = $derived(size === 'hero');
 
-  // How long the draft must sit still before the suggestions are recomputed. A pass
-  // costs ~10 ms over the catalogue on a warm desktop, more on a phone. Short enough
-  // to read as instant, long enough that a fast typist pays for it once rather than
-  // per letter.
-  const SUGGEST_DEBOUNCE_MS = 120;
+  // How long the draft must sit still before the suggestions are refetched.
+  //
+  // A settled draft costs THREE requests (completions, postings, companies), so the
+  // window is not sized against one cheap pass — it is sized against the gap between
+  // keystrokes. At 120ms it sat inside that gap: a fast typist's 18 characters fired
+  // six rounds, eighteen requests, for one query they had not finished writing. 300ms
+  // is past the gap and is the window the filter store already debounces its reload by
+  // (see urlSynced.svelte.ts) — one answer to "how long is a pause" across the app.
+  const SUGGEST_DEBOUNCE_MS = 300;
+
+  // Below this, the box asks nothing. A single character matches a large fraction of
+  // the catalogue, so the round trip buys a list nobody can act on — and it is the one
+  // round that fires with certainty, since every query passes through its first letter.
+  const SUGGEST_MIN_CHARS = 2;
 
   // Section caps. The dropdown is a shortcut, not a results page: past a handful each
   // section stops being scannable and the whole thing stops fitting on a phone.
@@ -232,20 +241,22 @@
   // you type, so these rows are the only live evidence the query finds anything.
   let jobs = $state.raw<Job[]>([]);
   let companies = $state.raw<CompanyListItem[]>([]);
-  // Bumped on every fetch; a response for an older token is stale and dropped, so a
-  // slow request cannot overwrite a fresher one.
-  let previewToken = 0;
 
   $effect(() => {
     const q = settledQuery.trim();
-    const mine = ++previewToken;
-    if (q === '' || !suggest) {
+    if (q.length < SUGGEST_MIN_CHARS || !suggest) {
       completions = [];
       completionParts = new Map();
       jobs = [];
       companies = [];
       return;
     }
+    // One controller per settled query, aborted by this effect's own cleanup. It does
+    // two jobs a stale-response counter did only half of: the browser drops the
+    // connection instead of holding it open for an answer nobody will read, AND
+    // `signal.aborted` below is the staleness check — the request that was abandoned
+    // is exactly the one whose answer must not land.
+    const ac = new AbortController();
     void (async () => {
       // allSettled, not all: the three sections are independent, so one endpoint
       // failing still shows the sections that succeeded instead of blanking all of
@@ -253,14 +264,16 @@
       // a schedule — a cold or missing one must cost the box its completions, not its
       // postings.
       const [s, j, c] = await Promise.allSettled([
-        api.suggest(q, completionsLimit),
-        api.searchJobs(new URLSearchParams({ q }), jobsLimit, 0),
+        api.suggest(q, completionsLimit, { signal: ac.signal }),
+        api.searchJobs(new URLSearchParams({ q }), jobsLimit, 0, { signal: ac.signal }),
         // Over-fetch: most of what the fuzzy endpoint returns is discarded below, and
         // asking for exactly three would leave the section empty whenever the fourth
         // was the only real match.
-        api.listCompanies(q, companiesFetch, 0),
+        api.listCompanies(q, companiesFetch, 0, undefined, { signal: ac.signal }),
       ]);
-      if (mine !== previewToken) return;
+      // An abort rejects all three, and `allSettled` would otherwise report that as
+      // three empty sections — blanking the panel a fresher query is about to fill.
+      if (ac.signal.aborted) return;
       const rows = s.status === 'fulfilled' ? s.value : [];
       completions = fromApi(rows);
       completionParts = new Map(completions.map((row, i) => [row.slug, rows[i]?.parts ?? []]));
@@ -268,6 +281,7 @@
       companies =
         c.status === 'fulfilled' ? namedCompanies(c.value.items, q, companiesLimit) : [];
     })();
+    return () => ac.abort();
   });
 
   // ── A pasted link ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

The header's search box fired far more requests than it looked like it did.

Typing 18 characters produced **6 rounds × 3 requests = 18 requests** — and the
first round went out on a single letter:

```
suggest?q=ы&limit=5
search?q=ы&limit=5&offset=0
companies?q=ы&limit=12&offset=0
suggest?q=ыу&limit=5
...
```

## Why

`SUGGEST_DEBOUNCE_MS = 120` sits *inside* the gap between a fast typist's
keystrokes (100–250ms), so the debounce kept firing mid-word. It was sized
against one cheap local pass; a settled draft now costs three network calls, so
the multiplier is 3× per fired round.

`previewToken` masked the cost rather than removing it: it dropped a stale
*response*, but the request had already left and the server had already answered.

## Changes

| | |
|---|---|
| `SUGGEST_DEBOUNCE_MS` | 120 → **300** — past the keystroke gap, and the same window `urlSynced.svelte.ts` already debounces the filter reload by |
| `SUGGEST_MIN_CHARS` | new, **2** — the one-letter round fires with certainty and is worth least |
| `previewToken` | → **AbortController**, aborted by the effect's own cleanup. The signal doubles as the staleness check, so the counter goes rather than sitting beside it |

`api.ts` gains an optional trailing `opts?: Abortable` on `suggest`,
`searchJobs` and `listCompanies`. Every other caller is untouched, and `call`
already documented that a caller bringing its own signal keeps it — the server
client's `timeoutMs` and this never compete for the same request.

## Scope

`HeaderSearch` is one component rendered twice — the header on every page, and
the homepage hero. One fix covers both.

## Verification

- `pnpm check` — 0 errors (34 pre-existing warnings, none in the changed lines)
- `pnpm lint` — 0 errors
- `pnpm test` — 133 files, 1505 tests, all passing

No component-test harness exists in `web/`; standing one up for two constants and
a signal would be infrastructure ahead of a need. Verified in the browser's
network panel.
