### PR TITLE
Fix the four live errors Sentry is reporting, and guard two of the classes

### DIFF
--- a/internal/api/handler/me_searches.go
+++ b/internal/api/handler/me_searches.go
@@ -71,6 +71,10 @@ func toSavedSearchResponse(s savedsearch.SavedSearch) savedSearchResponse {
 // savedSearchError maps the saved-search sentinels onto HTTP statuses: a bad name is a
 // 400, a duplicate name or the per-user cap is a 409, a missing/non-owned row is a 404.
 // Anything else falls through to RenderError as a 500.
+//
+// Every sentinel the package declares belongs here, and a test walks the list: one left
+// out does not merely render the wrong status, it tells the caller their own mistake was
+// our fault and files a fault report for ordinary traffic.
 func savedSearchError(err error) error {
 	switch {
 	case errors.Is(err, savedsearch.ErrInvalidName):
@@ -83,6 +87,8 @@ func savedSearchError(err error) error {
 		return fiber.NewError(fiber.StatusNotFound, "saved search not found")
 	case errors.Is(err, savedsearch.ErrInvalidAuthorLabel):
 		return fiber.NewError(fiber.StatusBadRequest, "author label must be at most 60 characters")
+	case errors.Is(err, savedsearch.ErrQueryTooLong):
+		return fiber.NewError(fiber.StatusBadRequest, "query is too long")
 	case errors.Is(err, savedsearch.ErrProfileSearchExists):
 		return fiber.NewError(fiber.StatusConflict, "a profile-derived search already exists")
 	default:

--- a/internal/api/handler/me_searches_test.go
+++ b/internal/api/handler/me_searches_test.go
@@ -1,0 +1,43 @@
+package handler
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/search/savedsearch"
+)
+
+// Every saved-search sentinel the service can return to a handler must map to the
+// status its own documentation promises. One that falls through reaches RenderError,
+// which has no name for it: the caller gets "internal server error" for something
+// they can fix, and the error inbox gets a fault report for ordinary traffic. That is
+// how ErrQueryTooLong — documented "(mapped to 400)" and mapped nowhere — reached
+// production as a 500.
+func TestSavedSearchError_MapsEverySentinel(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"invalid name", savedsearch.ErrInvalidName, fiber.StatusBadRequest},
+		{"invalid author label", savedsearch.ErrInvalidAuthorLabel, fiber.StatusBadRequest},
+		{"query too long", savedsearch.ErrQueryTooLong, fiber.StatusBadRequest},
+		{"duplicate name", savedsearch.ErrDuplicateName, fiber.StatusConflict},
+		{"cap exceeded", savedsearch.ErrCapExceeded, fiber.StatusConflict},
+		{"profile search exists", savedsearch.ErrProfileSearchExists, fiber.StatusConflict},
+		{"not found", savedsearch.ErrNotFound, fiber.StatusNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var fe *fiber.Error
+			if !errors.As(savedSearchError(tc.err), &fe) {
+				t.Fatalf("savedSearchError(%v) did not map to a *fiber.Error; it would render as a 500", tc.err)
+			}
+			if fe.Code != tc.want {
+				t.Errorf("status = %d, want %d", fe.Code, tc.want)
+			}
+		})
+	}
+}

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -49,13 +49,13 @@ export default ts.config(
     },
   },
 
-  // The change-array-by-copy methods reach the browser untranspiled — they are
-  // runtime methods, so no build target polyfills them, and Safari only grew them
-  // in 16.4. One `.toSorted()` evaluated while `facets.ts` was initialising threw
-  // on iOS 15, which takes the module down and with it the whole page — not the
-  // one sorted list. Every call we had ran on an array a `.map`/`.filter`/spread
-  // had just produced, so `.sort()` in place is the same thing without the floor
-  // on who can open the site. Lift this once the analytics say iOS 15 is gone.
+  // Built-ins newer than our floor reach the browser untranspiled — they are runtime
+  // methods, so no build target polyfills them. One `.toSorted()` evaluated while
+  // `facets.ts` was initialising threw on iOS 15, which takes the module down and with
+  // it the whole page — not the one sorted list. `Object.hasOwn` then did the same to
+  // the header search's suggestions, which is why the rule names a class rather than
+  // the one method that got us. Add to it when the next one is found in the wild, and
+  // lift the whole block once the analytics say iOS 15 is gone.
   {
     files: ['**/*.{ts,svelte,svelte.ts}'],
     ignores: ['**/*.test.ts', 'scripts/**', 'src/lib/server/**'],
@@ -63,10 +63,20 @@ export default ts.config(
       'no-restricted-syntax': [
         'error',
         {
+          // Change-array-by-copy: Safari 16.4. Every call we had ran on an array a
+          // `.map`/`.filter`/spread had just produced, so sorting in place is the
+          // same thing without the floor on who can open the site.
           selector:
             "MemberExpression[property.name=/^(toSorted|toReversed|toSpliced)$/][computed=false]",
           message:
             'Not in Safari before 16.4, and a throw here kills the whole module. Use [...x].sort() — or .sort() when the array is already a fresh copy.',
+        },
+        {
+          // Safari 15.4. Every use we had asked about decoded JSON, where a present
+          // key always holds a value, so reading the value answers the same question.
+          selector: "MemberExpression[object.name='Object'][property.name='hasOwn']",
+          message:
+            'Not in Safari before 15.4, and a throw here kills the whole module. Use `obj[k] !== undefined`, or `Object.prototype.hasOwnProperty.call(obj, k)` when a key holding undefined must still count.',
         },
       ],
     },

--- a/web/src/lib/components/IntegrationsView.svelte
+++ b/web/src/lib/components/IntegrationsView.svelte
@@ -5,6 +5,7 @@
   import { api, ApiError } from '$lib/api';
   import type { GmailStatus } from '$lib/api';
   import { notifications } from '$lib/notifications.svelte';
+  import { onRouterReady } from '$lib/routerReady';
   import { Badge, Button, ConfirmDialog, ProviderIcon } from '$lib/ui';
   import { Mail, CalendarDays } from '@lucide/svelte';
   import { errorMessage } from '$lib/utils';
@@ -151,8 +152,13 @@
     }
   }
 
+  // The verdict is read through onRouterReady, not onMount: it ends in a shallow
+  // `replaceState` to scrub the OAuth result out of the address bar, and the router
+  // is not ready for one while this component is mounting. Returning from Google is
+  // a full page load onto this exact URL, so that was every single time.
+  onRouterReady(readGoogleVerdict);
+
   onMount(() => {
-    readGoogleVerdict();
     void loadGmail();
     void notifications.ensureLoaded();
   });

--- a/web/src/lib/components/facets/RemoteSearchSelect.svelte
+++ b/web/src/lib/components/facets/RemoteSearchSelect.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { X } from '@lucide/svelte';
   import type { FacetOption } from '$lib/facets';
+  import { dedupeByKey } from '$lib/paginated.svelte';
   import { Input } from '$lib/ui';
   import SkillIcon from '../SkillIcon.svelte';
   import { SvelteMap } from 'svelte/reactivity';
@@ -75,7 +76,12 @@
       const opts = await search(q);
       if (mine !== gen) return;
       for (const o of opts) seen.set(o.value, o.label);
-      results = opts;
+      // The option list is keyed by `value`, and a repeated key is not a duplicated
+      // row — Svelte answers it by tearing down the whole block, so one doubled entry
+      // empties the picker. `search` is a prop, so what it returns is outside this
+      // component's reach; keeping the promise is therefore this component's job, and
+      // it keeps the first of each value because that is the better-ranked one.
+      results = dedupeByKey(opts, (o) => o.value, new Set());
     } catch {
       if (mine === gen) results = [];
     } finally {

--- a/web/src/lib/routerReady.ts
+++ b/web/src/lib/routerReady.ts
@@ -1,0 +1,35 @@
+import { afterNavigate } from '$app/navigation';
+
+/** Run `fn` once, as soon as SvelteKit's router has started — which is what makes
+ *  `replaceState`/`pushState` safe to call.
+ *
+ *  Call it during component initialisation, where `afterNavigate` is allowed. It
+ *  replaces `onMount` for mount-time work that reaches for shallow routing, and only
+ *  for that: everything else an `onMount` does is already safe there.
+ *
+ *  Why `onMount` is not safe. SvelteKit hydrates with `root = new app.root({ sync:
+ *  false })` — it asks Svelte NOT to flush effects inside the call, precisely so that
+ *  nothing runs before it holds the reference. Svelte's legacy client wrapper reads
+ *  that flag as `(!options?.props?.$$host || options.sync === false)`, and the left
+ *  side is already true for a root with no custom-element host, so it calls
+ *  `flushSync()` anyway. Mount-time effects therefore run INSIDE the constructor, one
+ *  assignment too early: `replaceState` ends in `root.$set(...)` with `root` still
+ *  undefined. In dev a guard catches this first and says "before router is
+ *  initialized"; in production that guard is compiled out, so it surfaced instead as
+ *  `undefined is not an object (evaluating '$set')` from inside SvelteKit, which named
+ *  nothing about the call that caused it.
+ *
+ *  Why `afterNavigate` alone is not enough either: on the hydrating navigation it
+ *  fires a few statements BEFORE SvelteKit sets the flag that dev's guard reads, in
+ *  the same synchronous block. The microtask hop is what clears that block — so
+ *  `afterNavigate` is here to pin the work to a navigation, and the `await` is here to
+ *  make it safe. */
+export function onRouterReady(fn: () => void): void {
+  let ran = false;
+  afterNavigate(async () => {
+    if (ran) return;
+    ran = true;
+    await Promise.resolve();
+    fn();
+  });
+}

--- a/web/src/lib/suggestions.ts
+++ b/web/src/lib/suggestions.ts
@@ -62,9 +62,15 @@ export function starterSuggestions(
 
   // Each group's own options, busiest first. A category the distribution does not
   // carry is dropped rather than offered with a zero: it would lead to an empty page.
+  //
+  // Absence is read off the value, not with `Object.hasOwn`: the distribution is
+  // decoded JSON, so a key that is present always holds a number and the two say the
+  // same thing — but `Object.hasOwn` is a runtime method no build target polyfills,
+  // and Safari only grew it in 15.4. It threw for the browsers below that, which
+  // takes the header search's whole derived chain down rather than one dropdown.
   const groups = CATEGORY_GROUPS.map((section) =>
     section.options
-      .filter((o) => o.value !== catchAll && Object.hasOwn(dist, o.value))
+      .filter((o) => o.value !== catchAll && dist[o.value] !== undefined)
       .sort((a, b) => (dist[b.value] ?? 0) - (dist[a.value] ?? 0)),
   ).filter((options) => options.length > 0);
 


### PR DESCRIPTION
Four faults still firing this week, each traced to a root cause.

### `replaceState` at mount time — `FREEHIRE-WEB-11`

`IntegrationsView` scrubbed the OAuth result out of the address bar from `onMount`, and returning from Google is a full page load onto that exact URL — so it fired every time.

SvelteKit hydrates with `root = new app.root({ sync: false })`, asking Svelte *not* to flush effects inside the call, precisely so nothing runs before it holds the reference. Svelte's legacy client reads that flag as `(!props.$$host || sync === false)` — the left side is already true for a root with no custom-element host, so it calls `flushSync()` anyway. `replaceState` then reached `root.$set(...)` with `root` still undefined.

Dev catches this with a guard that says exactly what happened. That guard is `if (DEV)`, so production got `undefined is not an object (evaluating '$set')` from inside SvelteKit instead, naming nothing about the call that caused it.

`$lib/routerReady` is the one place that story is written down. Verified in a browser on a hard load:

```
onMount=THREW: Cannot call replaceState(...) before router is initialized
onRouterReady=ok
```

`InboxView` has the same call but already reaches it after an awaited `load()`, well past hydration — left alone.

### `Object.hasOwn` in the suggestion starters — `FREEHIRE-WEB-1Q`

A runtime method no build target polyfills, absent before Safari 15.4, evaluated inside a `$derived` — so it took the header search's whole derived chain down, not one dropdown.

This is the second of these; `.toSorted()` was the first, on iOS 15. The lint rule added after that one named only the three array methods that had got us. It now names a class, with the reason and the version floor per entry, and the rule was checked to actually fire.

### A duplicate key in the facet picker — `FREEHIRE-WEB-J`

`RemoteSearchSelect` keys its options by `value` and takes them from a `search` prop, so what it renders is outside its own reach. One repeated value is not a doubled row — Svelte tears the block down, so the picker goes empty. It now keeps the promise it makes, first-of-each-value, since that is the better-ranked one.

### `ErrQueryTooLong` mapped nowhere — `FREEHIRE-API-8`

Its own doc comment says "(mapped to 400)". It fell through to a 500, which told the caller their fixable mistake was our fault and filed a fault report for ordinary traffic. The new test walks the whole sentinel list, so the next one added cannot be left out quietly.

## Verification

- `gofmt -l .` clean, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...` — all pass
- `pnpm --dir web lint` (eslint + oxlint) — 0 errors
- `pnpm --dir web exec svelte-check` — 0 errors
- `pnpm --dir web test` — 1505 passed
- The `replaceState` fix confirmed against a real hard page load, not reasoned about

## Not touched, and why

Also in the inbox, deliberately left:

- `FREEHIRE-API-6` / `FREEHIRE-API-2` (LLM stream deadline / EOF) and `FREEHIRE-WEB-B` (`/jobs/search` over 10s) are latency, not defects — retuning a timeout without measuring it first is a guess.
- `FREEHIRE-WEB-6/8/1F/F` are stale chunk requests from tabs open across a deploy.
- `FREEHIRE-WEB-19/1C/1E` are browser extensions.
- `FREEHIRE-API-4`, `API-7`, `WEB-18`, `WEB-9/A/R/T`, `WEB-G/H/1J/1B`, `WEB-4`, `WEB-M` are already fixed in `main` and only need resolving in Sentry.