### PR TITLE
Pass the abort signal itself, rather than a bag holding one

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -318,13 +318,6 @@ export interface EmailBody extends EmailLinking {
   read: boolean;
 }
 
-/** Options for a read a caller may abandon. Carried by the endpoints a typeahead
- *  drives, where the next keystroke makes the request in flight the answer to a
- *  question nobody is asking any more. */
-export interface Abortable {
-  signal?: AbortSignal;
-}
-
 /** Build an API client bound to a specific fetch and base URL.
  *
  *  - Browser: the default `api` uses global fetch and an empty base, so requests
@@ -394,16 +387,6 @@ export function createApi(
    *  its payload this way, so this collapses the request+`.data` unwrap into one call. */
   async function requestData<T>(path: string, init?: RequestInit): Promise<T> {
     return (await request<{ data: T }>(path, init)).data;
-  }
-
-  /** The read endpoints a typeahead calls take this: a caller that fires a fresh
-   *  request on every settled keystroke abandons the previous one rather than waiting
-   *  for an answer to a question nobody is asking any more. Distinct from the server
-   *  client's `timeoutMs` — that guards the SSR process against a slow backend, this is
-   *  the CALLER saying the question went stale. A caller that brings a signal keeps it
-   *  (see `call`), so the two never compete for the same request. */
-  function aborting(opts?: Abortable): RequestInit | undefined {
-    return opts?.signal ? { signal: opts.signal } : undefined;
   }
 
   /** Build the request init for a JSON body (POST/PATCH/PUT). Single-sources the
@@ -507,15 +490,12 @@ export function createApi(
     facets: URLSearchParams,
     limit: number,
     offset: number,
-    opts?: Abortable,
+    signal?: AbortSignal,
   ): Promise<Slice<Job>> {
     const params = new URLSearchParams(facets);
     params.set('limit', String(limit));
     params.set('offset', String(offset));
-    return toSlice(
-      await request<Page<Job>>(`/api/v1/jobs/search?${params}`, aborting(opts)),
-      offset,
-    );
+    return toSlice(await request<Page<Job>>(`/api/v1/jobs/search?${params}`, { signal }), offset);
   }
 
   /** Complete a partly-typed query against the catalogue's own vocabulary: the
@@ -526,9 +506,13 @@ export function createApi(
    *  Engineer Google" carries the role AND the company, and applying only one of them
    *  discards what was typed. An empty query returns nothing: what an empty box offers
    *  is a curated starting point the client owns (see starterSuggestions). */
-  async function suggest(q: string, limit: number, opts?: Abortable): Promise<ApiSuggestion[]> {
+  async function suggest(
+    q: string,
+    limit: number,
+    signal?: AbortSignal,
+  ): Promise<ApiSuggestion[]> {
     const params = new URLSearchParams({ q, limit: String(limit) });
-    return requestData<ApiSuggestion[]>(`/api/v1/suggest?${params}`, aborting(opts));
+    return requestData<ApiSuggestion[]>(`/api/v1/suggest?${params}`, { signal });
   }
 
   /** Turn a written description of a job search into filter values (the AI filter).
@@ -646,14 +630,14 @@ export function createApi(
     limit: number,
     offset: number,
     facets?: URLSearchParams,
-    opts?: Abortable,
+    signal?: AbortSignal,
   ): Promise<Slice<CompanyListItem>> {
     const params = new URLSearchParams(facets);
     if (q) params.set('q', q);
     params.set('limit', String(limit));
     params.set('offset', String(offset));
     return toSlice(
-      await request<Page<CompanyListItem>>(`/api/v1/companies?${params}`, aborting(opts)),
+      await request<Page<CompanyListItem>>(`/api/v1/companies?${params}`, { signal }),
       offset,
     );
   }

--- a/web/src/lib/components/HeaderSearch.svelte
+++ b/web/src/lib/components/HeaderSearch.svelte
@@ -251,11 +251,11 @@
       companies = [];
       return;
     }
-    // One controller per settled query, aborted by this effect's own cleanup. It does
-    // two jobs a stale-response counter did only half of: the browser drops the
-    // connection instead of holding it open for an answer nobody will read, AND
-    // `signal.aborted` below is the staleness check — the request that was abandoned
-    // is exactly the one whose answer must not land.
+    // One controller per settled query, aborted by this effect's own cleanup. It
+    // replaced a stale-response counter, which dropped the ANSWER after the request had
+    // already gone out and the server had already worked for it. The signal doubles as
+    // the staleness check below: abandoned and stale are the same condition here, so a
+    // counter beside it would be a second answer to one question.
     const ac = new AbortController();
     void (async () => {
       // allSettled, not all: the three sections are independent, so one endpoint
@@ -264,12 +264,12 @@
       // a schedule — a cold or missing one must cost the box its completions, not its
       // postings.
       const [s, j, c] = await Promise.allSettled([
-        api.suggest(q, completionsLimit, { signal: ac.signal }),
-        api.searchJobs(new URLSearchParams({ q }), jobsLimit, 0, { signal: ac.signal }),
+        api.suggest(q, completionsLimit, ac.signal),
+        api.searchJobs(new URLSearchParams({ q }), jobsLimit, 0, ac.signal),
         // Over-fetch: most of what the fuzzy endpoint returns is discarded below, and
         // asking for exactly three would leave the section empty whenever the fourth
         // was the only real match.
-        api.listCompanies(q, companiesFetch, 0, undefined, { signal: ac.signal }),
+        api.listCompanies(q, companiesFetch, 0, undefined, ac.signal),
       ]);
       // An abort rejects all three, and `allSettled` would otherwise report that as
       // three empty sections — blanking the panel a fresher query is about to fill.


### PR DESCRIPTION
Quality pass over #2456. No behaviour change.

## What I over-built

#2456 gave three endpoints an optional abort signal, and wrapped it in three
things:

```ts
export interface Abortable { signal?: AbortSignal }        // to name it
function aborting(opts?: Abortable): RequestInit | undefined // to unwrap it
api.suggest(q, limit, { signal: ac.signal })                 // to pass it
```

An options bag with exactly one field, consumed by exactly one call site. That is
the seam for a second option, built before there is a second option — which
`AGENTS.md` asks not to do.

## Now

```ts
async function suggest(q: string, limit: number, signal?: AbortSignal)
// ...
api.suggest(q, completionsLimit, ac.signal)
```

The interface and the helper are gone. `−34 lines, +18`.

## Why it is still correct for the other 17 call sites

They pass no signal, so `request(path, { signal: undefined })` instead of
`request(path, undefined)`. `call` tests:

```ts
const timeout = timeoutMs != null && request.signal == null ? ... : undefined;
```

Loose `== null`, so `undefined` matches and the server client's `timeoutMs` is
applied exactly as before. This is what `call`'s own comment already documented
("A caller that brought its own signal keeps it") — so the helper's paragraph
restating it went with the helper.

## Also

The `AbortController` comment in `HeaderSearch` said "it does two jobs a
stale-response counter did only half of", which takes a re-read to parse. It now
says what the counter actually failed to do.

## Verification

- `pnpm check` — 0 errors (34 pre-existing warnings, unchanged)
- `pnpm lint` — 0 errors
- `pnpm test` — 133 files, 1505 tests, green (same counts as before the change)
