### PR TITLE
Fix false unchanged-rendering claim in structured-experience-dates docs

### DIFF
--- a/docs/superpowers/specs/2026-09-04-structured-experience-dates-design.md
+++ b/docs/superpowers/specs/2026-09-04-structured-experience-dates-design.md
@@ -1,0 +1,199 @@
+# Structured dates for work-history/CV periods
+
+## Problem
+
+`internal/candidate/experience.Employment`, `internal/candidate/resumeextract.Experience`,
+and `internal/candidate/cv.ExperienceItem` (plus their `Education`/`Certification`
+siblings) all store a period's start/end as free-form strings ("October 2018",
+"2024", "Present") by deliberate, documented design — no parsing is attempted at
+write time. This has a real, already-documented cost: `experience_employments`'
+own SQL index sorts `period_start` lexicographically, which is wrong whenever a
+user's roles mix formats (a bare year sorts as if it were January, month names
+sort by letter not calendar order), and `internal/candidate/experience/period_sort.go`
+exists purely to re-sort the SQL's wrong-order result in Go afterward.
+
+The same free-text convention is intentionally shared across all three types (per
+migration `0047_experience_bank.sql`'s own comment), and repeated as three
+independent Go struct definitions and three independent frontend type
+declarations (two generated via `cmd/gen-contracts`, one hand-maintained in
+`web/src/lib/types.ts`). This change replaces the convention everywhere it
+appears with one shared structured type, and gives `/my/profile`'s Work history
+editor a real date-picker.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One shared value type for a CV/work-history period boundary, used by all three
+  Go packages and reflected in all three frontend type declarations.
+- `experience_employments` (the only *accumulating* store among the three) gets
+  real structured columns, sortable natively in SQL — `period_sort.go` is deleted.
+- `resumeextract`'s LLM extraction returns the structured shape directly
+  (schema-constrained output), not a string for the model to format itself.
+- `/my/profile`'s Work history editor gets a real month/year picker that also
+  accepts direct keyboard entry.
+- Existing stored data (the `experience_employments` text columns; already-stored
+  `resume_structured`/`cv_documents` JSON) keeps working — no user-visible data
+  loss beyond the explicitly-approved backfill fallback below.
+
+**Non-Goals:**
+- No day-of-month precision — CVs never carry one, and none of the three existing
+  free-text conventions or their tests ever show one.
+- No new free-text precision beyond year/month (no quarters, seasons, or custom
+  ranges) — confirmed absent from real data via `period_sort_test.go`'s fixtures
+  and every doc comment describing the convention.
+- No change to the 9 typst CV templates — see Decisions.
+- No change to how `Current`/`is_current` ("Present") is modeled — it stays a
+  separate boolean, as it already is in `experience.Employment` and
+  `cv.ExperienceItem` (this change only adds the same field to
+  `resumeextract.Experience`, which lacks it today).
+
+## Decisions
+
+### A shared `PeriodDate` type, one new package
+
+```go
+// internal/candidate/perioddate
+type PeriodDate struct {
+    Year  int
+    Month int // 0 = year-only
+}
+```
+
+Used as `*PeriodDate` wherever the field may be entirely absent (an employment
+with no dates at all). A new package rather than putting it in any one of
+`experience`/`resumeextract`/`cv` — all three are peers in the same layer
+(`candidate`) and none should own a type the other two also need; a small shared
+package one import away from each is the same shape as the layering doc's own
+`internal/dict` sitting below packages that all need normalization helpers.
+`perioddate` exports the type, `Parse` (the free-text best-effort parser — see
+Migration Plan), `Format` (renders back to display text, e.g. "Mar 2021" /
+"2018"), and validation (`Sanitize`/range-check, 1900–2100 matching
+`period_sort.go`'s existing bound).
+
+**Alternative considered:** keep three independent structs (status quo) and only
+add a derived, database-only sort key column. Rejected: it satisfies the sorting
+bug but not the actual ask — the API/storage layer would still expose free text,
+and the date-picker would have nothing structured to bind to.
+
+### `experience_employments`: real columns, not jsonb
+
+New migration replaces `period_start text` / `period_end text` with
+`period_start_year int`, `period_start_month smallint` (nullable),
+`period_end_year int` (nullable), `period_end_month smallint` (nullable). Plain
+integer columns rather than a `date` type: a SQL `date` cannot represent
+"year-only" without an arbitrary day-of-month placeholder that would lie about
+precision. `ORDER BY period_start_year DESC NULLS LAST, period_start_month DESC
+NULLS LAST` replaces the lexicographic index; `period_sort.go` and its test file
+are deleted, and `ListEmployments`'s Go-side re-sort goes with them.
+
+### `resumeextract`/`cv`: same type, JSON-native, self-healing on read
+
+`resume_structured` and `cv_documents` are jsonb blobs (migrations `0011`,
+`0024`) — no schema migration needed there, only the Go struct's field type
+changes (`Start *perioddate.PeriodDate` instead of `Start string`). Backward
+compatibility for rows already stored in the OLD (free-text) shape is handled by
+`PeriodDate.UnmarshalJSON` accepting **either** a JSON string (parsed via the
+same best-effort parser as the backfill, falling back to `nil` on failure) or the
+new `{"year":2018,"month":3}` object; `MarshalJSON` always emits the new object
+shape. A user's next resume upload or next tailored CV open/save naturally
+upgrades their stored JSON — no bulk rewrite migration needed, consistent with
+these two stores being regenerated/thrown-away snapshots rather than
+accumulating records (per `internal/candidate/experience/AGENTS.md`'s own
+boundary table).
+
+### `resumeextract`'s LLM contract changes shape, not just prompt wording
+
+The extraction schema (`internal/platform/llm`'s schema-constrained output,
+already used for `resumeextract`) requires `start`/`end` as `{year, month?}`
+objects instead of free strings, and the system prompt instruction changes from
+"keep dates as written" to: interpret the CV's printed range into year/(optional)
+month, and signal an ongoing role via `current: true` rather than a special `end`
+string. `resumeextract.Experience` gains a `Current bool` field (mirroring
+`experience.Employment`/`cv.ExperienceItem`, which already have one) so this is
+expressible.
+
+### Typst templates: untouched
+
+All 9 `.typ` files' `daterange(a, b)` helper takes two already-formatted display
+strings; `internal/candidate/cv/renderer.go` builds `data.json` for typst today
+by passing `ExperienceItem.Start`/`End` straight through. This change makes
+`renderer.go` call `perioddate.Format` on the structured field when building that
+JSON, so `data.json`'s shape — and therefore every template — is byte-for-byte
+unchanged. The structured type is a storage/API-layer change; the render-time
+projection to typst stays string-formatted.
+
+### Frontend: `<input type="month">` plus a "year only" toggle
+
+The native month picker gives both click-to-pick and type-to-enter for free;
+checking "I don't remember the month" swaps it for a plain year number input.
+One shared Svelte component (`PeriodDateInput.svelte` or similar), used by
+`ExperienceBankView.svelte`'s employment start/end fields and
+`CvSectionForm.svelte`'s experience/education date fields — replacing today's
+plain `<Input>` text fields at `ExperienceBankView.svelte:191-192,209-210` and
+`CvSectionForm.svelte:88-89,124-125`.
+
+**Alternative considered:** a fully custom picker component (own dropdowns for
+month and year). Rejected: `<input type="month">` already satisfies "pick or
+type" natively, with less code and free OS-level accessibility, at the cost of
+needing the small year-only toggle for one edge case native month inputs cannot
+express.
+
+### Frontend types: fix all three, generated ones follow the Go change
+
+`resumeextract.Experience` and `cv.ExperienceItem` are both in `cmd/gen-contracts`
+already — their generated `start`/`end` fields become whatever shape
+`cmd/gen-contracts` emits for `perioddate.PeriodDate` (a nested
+`{year: number; month?: number}` interface) once the Go field type changes; `make
+gen-contracts` regenerates `contracts.ts` mechanically. `experience.Employment`
+is NOT in `gen-contracts` (confirmed) — its hand-maintained mirror in
+`web/src/lib/types.ts:1277-1293` is edited by hand to match.
+
+## Migration Plan
+
+Deploy order (schema before code, per this repo's `migrate` convention):
+
+1. New migration adds the four new nullable columns to `experience_employments`
+   alongside the existing `period_start`/`period_end text` (additive, no data
+   loss yet).
+2. A one-off backfill (`cmd/backfill-experience-dates`, following the
+   `cmd/backfill-*` conventions already in this repo) walks every row: parse
+   `period_start`/`period_end` with `perioddate.Parse` (the same logic
+   `period_sort.go` has today); on success, write the parsed year/month into the
+   new columns. **On failure** (confirmed rare — real data is "2024"/"October
+   2018"-shaped, per `period_sort_test.go`'s fixtures — but a free-text field
+   accepts anything): fall back to the **year of the row's own `created_at`** as
+   the approved lossy default, rather than leaving the row null — an
+   approximate date reads better to the row's owner than an empty one, and nulls
+   would otherwise sort ambiguously against real dates. `is_current` rows with no
+   parseable end are left with `period_end` unset (already the existing
+   convention — `end` is meaningless when `current=true`).
+3. Deploy the code that reads/writes the new columns (`experience.Employment`,
+   its repository/store, the API wire shape, the frontend).
+4. A follow-up migration drops the old `period_start`/`period_end text` columns
+   once the backfill and the new code have both landed and been verified in
+   production (kept as a separate migration file, not squashed into step 1, so
+   the drop is reviewable and reversible independently of the additive step).
+
+`resume_structured`/`cv_documents` need no equivalent backfill — see Decisions
+("self-healing on read").
+
+## Risks / Trade-offs
+
+- [The LLM extraction contract change (free string → structured object) could
+  degrade extraction quality if the model handles the new schema worse than the
+  old "copy the string" instruction] → mitigated by keeping the ask conceptually
+  simple (year + optional month + a boolean, which is easier for a model to
+  reason about than reproducing arbitrary CV formatting verbatim); verify with a
+  manual pass over a handful of real CVs before considering `resumeextract` done.
+- [Backfilling unparseable dates to `created_at`'s year is a lossy default] →
+  explicitly approved; the row was already free text of unknown reliability, and
+  `created_at` is a real, non-arbitrary date about that row.
+- [Three independent consumers (experience/resumeextract/cv) all changing
+  together is a wide, easy-to-partially-miss diff] → the task list (below, once
+  written) sequences one consumer at a time with its own tests green before
+  moving to the next, rather than one giant cross-cutting commit.
+
+## Open Questions
+
+None — every ambiguous point (UI widget shape, backfill fallback, migration
+scope) was resolved with the user before writing this doc.

--- a/openspec/changes/structured-experience-dates/.openspec.yaml
+++ b/openspec/changes/structured-experience-dates/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/structured-experience-dates/design.md
+++ b/openspec/changes/structured-experience-dates/design.md
@@ -1,0 +1,116 @@
+## Context
+
+See `proposal.md` for motivation. Full file-level design (every touched file,
+per-consumer detail) was worked out and approved with the user beforehand at
+`docs/superpowers/specs/2026-09-04-structured-experience-dates-design.md`; this
+document summarizes the decisions in OpenSpec's format and is the source the
+task list is built from.
+
+Confirmed by direct code inspection: `experience.Employment`,
+`resumeextract.Experience`, and `cv.ExperienceItem` are three independent Go
+struct definitions sharing one documented convention (migration
+`0047_experience_bank.sql`'s own comment: "matching resumeextract.Experience and
+cv.ExperienceItem"). `experience_employments` is the only *accumulating* store of
+the three (`resume_structured`/`cv_documents` are regenerated/thrown-away
+snapshots per `internal/candidate/experience/AGENTS.md`'s boundary table) and the
+only one with real columns rather than a jsonb blob.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One shared `perioddate.PeriodDate{Year, Month}` type used by all three Go
+  packages and reflected in all three frontend type declarations.
+- `experience_employments` gets structured, natively-sortable columns;
+  `period_sort.go` is deleted.
+- `resumeextract`'s LLM extraction returns the structured shape directly.
+- A real month/year picker (pick or type) on `/my/profile`'s Work history editor
+  and the CV section form.
+- Existing stored data keeps working: a backfill for `experience_employments`, a
+  self-healing decoder for the jsonb stores — no user-visible data loss beyond
+  the approved backfill fallback.
+
+**Non-Goals:**
+- No day-of-month precision, no free-text precision beyond year/month (no
+  quarters/seasons) — confirmed absent from real data via
+  `period_sort_test.go`'s fixtures.
+- No change to any of the 9 typst CV templates.
+- No change to how "Present"/ongoing is modeled (`is_current`/`Current` stays a
+  separate boolean) beyond adding that same field where it's missing today
+  (`resumeextract.Experience`).
+
+## Decisions
+
+- **A new package, `internal/candidate/perioddate`, not a field added to one of
+  the three existing packages.** All three (`experience`, `resumeextract`, `cv`)
+  are peers in the same layer (`candidate`); none should own a type the other
+  two also depend on. Exports the type, a best-effort free-text `Parse` (reused
+  by both the backfill and the jsonb self-healing decode), `Format` (back to
+  display text), and range validation (1900–2100, matching `period_sort.go`'s
+  existing bound).
+- **`experience_employments`: four plain nullable integer columns**
+  (`period_start_year`, `period_start_month`, `period_end_year`,
+  `period_end_month`), not a SQL `date` type — a `date` cannot represent
+  "year-only" without lying about precision via an arbitrary day. Native
+  `ORDER BY ... NULLS LAST` replaces the lexicographic index and
+  `period_sort.go`'s Go-side re-sort, which is deleted along with its test file.
+- **`resume_structured`/`cv_documents`: no bulk migration.** Only the Go field
+  type changes; `PeriodDate.UnmarshalJSON` accepts either the legacy free-text
+  string (parsed via the same `perioddate.Parse` as the backfill, falling back
+  to `nil` on failure) or the new `{"year":..,"month":..}` object.
+  `MarshalJSON` always emits the new shape, so a row upgrades itself the next
+  time it's read and re-saved (upload / tailor / save) — consistent with these
+  two stores being regenerated snapshots rather than accumulating records.
+- **`resumeextract`'s LLM contract changes shape, not just prompt wording**: the
+  schema-constrained output (`internal/platform/llm`) requires `{year, month?}`
+  objects for `start`/`end` instead of free strings, and the prompt asks the
+  model to interpret the CV's printed range rather than "keep dates as
+  written". `resumeextract.Experience` gains `Current bool`.
+- **Typst stays untouched.** `internal/candidate/cv/renderer.go` formats the
+  structured field to the same display string it produces today when building
+  `data.json`; the render-time projection to typst is a plain string wire, same
+  as before this change, in both directions verified against the "structured
+  résumé" and "CV document" delta specs' scenarios above.
+- **Frontend: `<input type="month">` + a "year only" toggle**, one shared
+  component replacing the plain text inputs at `ExperienceBankView.svelte` and
+  `CvSectionForm.svelte`. Rejected alternative: a fully custom picker — more
+  code and its own accessibility work for no capability the native control
+  lacks beyond the single year-only case, which the toggle covers.
+- **Frontend types**: `resumeextract.Experience`/`cv.ExperienceItem` are both in
+  `cmd/gen-contracts` — regenerated mechanically once the Go field type changes.
+  `experience.Employment` is NOT in `gen-contracts` (confirmed) — its
+  hand-maintained mirror in `web/src/lib/types.ts` is edited by hand to match.
+
+## Risks / Trade-offs
+
+- [The LLM extraction contract change could degrade extraction quality if the
+  model handles the new schema worse than "copy the string verbatim"] →
+  mitigated by keeping the ask conceptually simple (year + optional month + a
+  boolean); verify with a manual pass over real CVs before considering
+  `resumeextract` done, per its own task below.
+- [Backfilling unparseable employment dates to `created_at`'s year is a lossy
+  default] → explicitly approved by the user; the row was already free text of
+  unknown reliability, and `created_at` is a real, non-arbitrary date about
+  that row, confirmed rare in practice (`period_sort_test.go`'s real-world
+  fixtures are all cleanly parseable).
+- [Three independent consumers changing together is a wide diff] → the task
+  list sequences one consumer at a time (bank → resumeextract → cv →
+  frontend), each with its own tests green before moving to the next.
+
+## Migration Plan
+
+1. New migration adds the four new nullable columns to `experience_employments`
+   alongside the existing free-text ones (additive).
+2. `cmd/backfill-experience-dates` (one-off, following this repo's
+   `cmd/backfill-*` conventions) parses every row's existing free text into the
+   new columns; unparseable rows fall back to `created_at`'s year.
+3. Deploy the code that reads/writes the new columns.
+4. A follow-up migration drops the old free-text columns once the backfill and
+   new code have both landed and been verified.
+
+`resume_structured`/`cv_documents` need no equivalent step (self-healing, see
+Decisions).
+
+## Open Questions
+
+None — every ambiguous point (UI widget shape, backfill fallback, migration
+scope) was resolved with the user before writing this document.

--- a/openspec/changes/structured-experience-dates/design.md
+++ b/openspec/changes/structured-experience-dates/design.md
@@ -65,11 +65,18 @@ only one with real columns rather than a jsonb blob.
   objects for `start`/`end` instead of free strings, and the prompt asks the
   model to interpret the CV's printed range rather than "keep dates as
   written". `resumeextract.Experience` gains `Current bool`.
-- **Typst stays untouched.** `internal/candidate/cv/renderer.go` formats the
-  structured field to the same display string it produces today when building
-  `data.json`; the render-time projection to typst is a plain string wire, same
-  as before this change, in both directions verified against the "structured
-  résumé" and "CV document" delta specs' scenarios above.
+- **Typst stays untouched as an interface; the rendered text is
+  canonicalized, not preserved verbatim.** `internal/candidate/cv/renderer.go`
+  formats the structured field via `perioddate.Format` when building
+  `data.json`; typst still receives a plain string, unchanged as a wire shape.
+  The string's content is NOT guaranteed byte-identical to an existing entry's
+  original free text: `Format` emits one canonical style ("Mar 2021"), so a
+  pre-existing entry stored as "October 2018" renders as "Oct 2018" after this
+  change. This is a one-time cosmetic normalization on first read after the
+  backfill, not a functional regression — the "CV document" delta spec's own
+  scenario for this compares against an already-canonical value rather than
+  claiming universal byte-identical output, and a second scenario there covers
+  the canonicalization explicitly.
 - **Frontend: `<input type="month">` + a "year only" toggle**, one shared
   component replacing the plain text inputs at `ExperienceBankView.svelte` and
   `CvSectionForm.svelte`. Rejected alternative: a fully custom picker — more
@@ -92,6 +99,15 @@ only one with real columns rather than a jsonb blob.
   unknown reliability, and `created_at` is a real, non-arbitrary date about
   that row, confirmed rare in practice (`period_sort_test.go`'s real-world
   fixtures are all cleanly parseable).
+- [`perioddate.Format`'s canonical style ("Mar 2021") does not reproduce every
+  existing entry's original free-text wording (e.g. "October 2018"), so any
+  CV or CV/experience-bank display rendered after this change can show
+  different text for the same date than it did before, for entries that were
+  never edited or re-rendered before now] → accepted as a one-time, purely
+  cosmetic normalization: the underlying year/month is unchanged, only the
+  formatting is; earlier drafts of this document and the delta specs
+  overstated this as "no external behavior change" / "rendered output is
+  unchanged", which was inaccurate and has been corrected.
 - [Three independent consumers changing together is a wide diff] → the task
   list sequences one consumer at a time (bank → resumeextract → cv →
   frontend), each with its own tests green before moving to the next.

--- a/openspec/changes/structured-experience-dates/proposal.md
+++ b/openspec/changes/structured-experience-dates/proposal.md
@@ -1,0 +1,83 @@
+## Why
+
+`experience.Employment`, `resumeextract.Experience`, and `cv.ExperienceItem` each
+store a work-history period's start/end as a free-form string ("October 2018",
+"2024", "Present") by deliberate design — no parsing at write time, the same
+convention repeated three times. This has a real, already-documented cost:
+`experience_employments`' own database index sorts these strings
+lexicographically, which is wrong whenever a candidate's roles mix formats (a
+bare year sorts as if it were January; month names sort alphabetically, not
+calendar order) — `internal/candidate/experience/period_sort.go` exists purely
+to re-sort the database's wrong-order result in application code afterward. The
+same free-text fields are also plain, unstructured text inputs on `/my/profile`'s
+Work history editor and the CV section form, with no date-picker.
+
+## What Changes
+
+- New shared value type `internal/candidate/perioddate.PeriodDate{Year, Month}`
+  (`Month == 0` means year-only), replacing the free-text `string` fields
+  wherever the free-form convention is used today: `experience.Employment`,
+  `resumeextract.Experience`, `cv.ExperienceItem`, and their `Education`/
+  `Certification` siblings' year fields.
+- `experience_employments` gets real structured columns
+  (`period_start_year`/`period_start_month`/`period_end_year`/`period_end_month`)
+  replacing the free-text `period_start`/`period_end`, sorted natively in SQL.
+  `period_sort.go` and its Go-side re-sort are deleted.
+- A one-off backfill (`cmd/backfill-experience-dates`) parses every existing
+  employment's free text into the new columns; a row that fails to parse falls
+  back to the year of its own `created_at` rather than being left null.
+- `resumeextract`'s LLM extraction schema changes from a free string to a
+  `{year, month?}` object, with `current: true` for an ongoing role (a field
+  `resumeextract.Experience` gains, matching `experience.Employment`/
+  `cv.ExperienceItem`, which already have one).
+- `resume_structured`/`cv_documents` (jsonb) need no bulk data migration —
+  `PeriodDate.UnmarshalJSON` accepts either the old free-text string (best-effort
+  parsed) or the new object shape, self-healing on the next read/write of each
+  row; `MarshalJSON` always emits the new shape.
+- **BREAKING (internal only, no external behavior change for typst)**: the CV
+  renderer (`internal/candidate/cv/renderer.go`) formats the structured date
+  into the same display string it produces today before building `data.json` —
+  the 9 typst templates are unchanged.
+- `/my/profile`'s Work history editor and the CV section form get a real
+  month/year picker (`<input type="month">` plus a "year only" toggle) in place
+  of a plain text input.
+- **BREAKING (internal only)**: `experience.Employment`'s hand-maintained
+  frontend mirror (`web/src/lib/types.ts`) and the two `cmd/gen-contracts`-
+  generated interfaces (`resumeextract.Experience`, `cv.ExperienceItem`) all
+  change from `start?: string` to a structured `start?: { year: number; month?:
+  number }`.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `experience-bank`: adds a requirement that an employment's period boundaries
+  are a structured year/(optional)month value rather than free text, and that
+  listing sorts on it natively rather than via an application-side re-sort.
+- `resume-structured-profile`: the "work-experience entries (... dates ...)"
+  requirement's `dates` becomes the same structured `{year, month?}` value
+  (plus `current`), replacing today's implicit free-text string.
+- `cv-builder`: the CV document's experience/education entries carry the same
+  structured date value; rendering to PDF is unaffected (the renderer formats
+  it to display text before the typst template ever sees it, same as today).
+
+## Impact
+
+- Schema: new migration adding structured columns to `experience_employments`
+  (additive), a follow-up migration dropping the old free-text columns once the
+  backfill and new code have both landed. No schema change to
+  `resume_structured`/`cv_documents` (jsonb, self-healing on read).
+- Backend: `internal/candidate/perioddate` (new), `internal/candidate/experience`,
+  `internal/candidate/resumeextract`, `internal/candidate/cv` (struct fields,
+  repository/store queries, `Sanitize`/`Validate`), `internal/candidate/cv/renderer.go`
+  (format-before-render), `internal/platform/db` (sqlc regeneration),
+  `cmd/backfill-experience-dates` (new one-off worker).
+- Frontend: `web/src/lib/types.ts` (hand-maintained mirror), `cmd/gen-contracts`
+  output (`web/src/lib/generated/contracts.ts`, regenerated, not hand-edited), a
+  new shared date-picker component, `ExperienceBankView.svelte` and
+  `CvSectionForm.svelte` (consumers of the new component).
+- No change to any of the 9 typst templates in `internal/candidate/cv/templates/`.

--- a/openspec/changes/structured-experience-dates/proposal.md
+++ b/openspec/changes/structured-experience-dates/proposal.md
@@ -34,10 +34,16 @@ Work history editor and the CV section form, with no date-picker.
   `PeriodDate.UnmarshalJSON` accepts either the old free-text string (best-effort
   parsed) or the new object shape, self-healing on the next read/write of each
   row; `MarshalJSON` always emits the new shape.
-- **BREAKING (internal only, no external behavior change for typst)**: the CV
-  renderer (`internal/candidate/cv/renderer.go`) formats the structured date
-  into the same display string it produces today before building `data.json` —
-  the 9 typst templates are unchanged.
+- **BREAKING (internal only for the typst interface; a one-time cosmetic
+  change for existing data)**: the CV renderer
+  (`internal/candidate/cv/renderer.go`) formats the structured date into
+  display text via `perioddate.Format` before building `data.json` — the 9
+  typst templates still receive a plain string and are unchanged. `Format`
+  emits one canonical style ("Mar 2021"); an existing entry whose stored free
+  text used a different style (e.g. "October 2018") renders in the canonical
+  style after this change, not its original wording — a one-time
+  normalization, not a functional regression or a change to what information
+  is shown.
 - `/my/profile`'s Work history editor and the CV section form get a real
   month/year picker (`<input type="month">` plus a "year only" toggle) in place
   of a plain text input.
@@ -62,8 +68,10 @@ Work history editor and the CV section form, with no date-picker.
   requirement's `dates` becomes the same structured `{year, month?}` value
   (plus `current`), replacing today's implicit free-text string.
 - `cv-builder`: the CV document's experience/education entries carry the same
-  structured date value; rendering to PDF is unaffected (the renderer formats
-  it to display text before the typst template ever sees it, same as today).
+  structured date value; the renderer still formats it to a plain display
+  string before the typst template ever sees it, but that string is now the
+  renderer's one canonical style, which can differ from an existing entry's
+  original free-text wording (see What Changes above).
 
 ## Impact
 

--- a/openspec/changes/structured-experience-dates/specs/cv-builder/spec.md
+++ b/openspec/changes/structured-experience-dates/specs/cv-builder/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: A CV document's period dates are structured, not free text
+An experience or education entry's start/end period within a CV document SHALL
+be a structured year/(optional month) value plus a boolean marking an ongoing
+entry, matching the same representation used by the structured résumé and the
+experience bank — not a free-form string. Rendering a CV to PDF SHALL format
+this structured value into display text (e.g. "Mar 2021", "2018", "Mar 2021 –
+Present") before it reaches the template layer, so no template needs to know
+the underlying value is structured, and the rendered output is unchanged from
+before this value became structured.
+
+#### Scenario: A structured period renders identically to the prior free-text output
+- **WHEN** a CV document has an experience entry with a structured start of
+  {year: 2018, month: 3} and no end (current)
+- **THEN** the rendered PDF shows the same "Mar 2018 – Present" text a
+  free-text field carrying that exact value would have rendered
+
+#### Scenario: A year-only period renders without a fabricated month
+- **WHEN** a CV document has an entry whose period carries only a year
+- **THEN** the rendered PDF shows only the year for that boundary, not a
+  month the candidate never specified

--- a/openspec/changes/structured-experience-dates/specs/cv-builder/spec.md
+++ b/openspec/changes/structured-experience-dates/specs/cv-builder/spec.md
@@ -7,14 +7,26 @@ entry, matching the same representation used by the structured résumé and the
 experience bank — not a free-form string. Rendering a CV to PDF SHALL format
 this structured value into display text (e.g. "Mar 2021", "2018", "Mar 2021 –
 Present") before it reaches the template layer, so no template needs to know
-the underlying value is structured, and the rendered output is unchanged from
-before this value became structured.
+the underlying value is structured. This display text is canonical — one
+fixed style regardless of how the original free text was worded — so an
+entry whose period was previously stored as free text in a different style
+(e.g. "October 2018") SHALL render in the canonical style ("Oct 2018") after
+this change, not its original wording; the boundary's year and month are
+unchanged, only the display style is.
 
-#### Scenario: A structured period renders identically to the prior free-text output
+#### Scenario: A value already in canonical style renders unchanged
 - **WHEN** a CV document has an experience entry with a structured start of
   {year: 2018, month: 3} and no end (current)
-- **THEN** the rendered PDF shows the same "Mar 2018 – Present" text a
-  free-text field carrying that exact value would have rendered
+- **THEN** the rendered PDF shows "Mar 2018 – Present" — the same text a
+  free-text field already written in that exact style would have rendered
+
+#### Scenario: A pre-existing entry's display text is canonicalized, not preserved verbatim
+- **WHEN** an entry's period was originally stored as free text in a style
+  different from the renderer's canonical format (e.g. "October 2018", where
+  the canonical style is "Oct 2018")
+- **THEN** the rendered PDF shows the canonical style, not the original
+  wording — the boundary's year and month are unchanged, only the display
+  style is
 
 #### Scenario: A year-only period renders without a fabricated month
 - **WHEN** a CV document has an entry whose period carries only a year

--- a/openspec/changes/structured-experience-dates/specs/experience-bank/spec.md
+++ b/openspec/changes/structured-experience-dates/specs/experience-bank/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: An employment's period is a structured date, not free text
+Each employment's start and end period boundary SHALL be stored as a structured
+year/(optional month) value rather than a free-form string, plus the existing
+`is_current` flag for an ongoing role (unchanged — an ongoing role has no end
+date, and `is_current` is never inferred or overwritten by import once a role
+has ended). Listing an owner's employments SHALL sort chronologically using
+these structured values directly (a native database ordering), not by
+re-sorting a lexicographically-ordered free-text column in application code
+afterward.
+
+#### Scenario: Employments with mixed date precision sort chronologically
+- **WHEN** an owner's employments include one with only a year ("2024") and
+  others with a month and year ("October 2018", "Mar 2021")
+- **THEN** listing the owner's employments orders them by actual chronological
+  date, not by the lexicographic order of their original text
+
+#### Scenario: A year-only employment keeps its precision
+- **WHEN** a candidate records an employment with only a start year, no month
+- **THEN** the stored period carries that year with no month, and it is not
+  displayed or exported as if a specific month were known
+
+#### Scenario: An ongoing employment has no end date
+- **WHEN** a candidate marks an employment as current (`is_current`)
+- **THEN** its end period is absent, and listing treats it as ongoing for
+  sorting purposes without requiring a fabricated end date

--- a/openspec/changes/structured-experience-dates/specs/resume-structured-profile/spec.md
+++ b/openspec/changes/structured-experience-dates/specs/resume-structured-profile/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: The structured résumé is a typed, sanitized contract
+
+The structured résumé SHALL be a typed value covering the candidate's contact basics, a professional summary, work-experience entries (title, company, location, a structured start/end period, a one-line context summary, achievement highlights, and per-role technology stack), education entries, languages, links, a flat skills list, portfolio projects (name, link, highlights), and an estimated total years of experience. A work-experience or education entry's period boundary SHALL be a structured year/(optional month) value plus a boolean marking an ongoing entry, not a free-form string — the system SHALL interpret whatever the CV prints (a bare year, a month and year, or an "ongoing" phrasing) into that structure rather than reproducing the source text verbatim. Before it is persisted or served, the system SHALL sanitize all model output to the contract: every string length is bounded, every array cardinality is capped, every date's year is bounded to a plausible range and its month (when present) to 1–12, the total-years estimate is coerced to a non-negative bounded integer, and empty entries are dropped. The system MUST NOT persist or serve a value outside these bounds, so untrusted CV text cannot inject unbounded or malformed content.
+
+#### Scenario: Out-of-bounds model output is coerced before persistence
+
+- **WHEN** the LLM returns over-long strings, an oversized list of entries, an implausible years value, or a date with an out-of-range year or month
+- **THEN** the sanitized structured résumé has bounded strings, a capped number of entries, a coerced years value, and any invalid date cleared rather than persisted as given, and only the sanitized value is persisted and served
+
+#### Scenario: Fields not present in the CV are omitted, not invented
+
+- **WHEN** the CV does not state a field (e.g. no education section)
+- **THEN** that part of the structured résumé is empty rather than fabricated
+
+#### Scenario: Rich work-history detail is captured
+
+- **WHEN** a role in the CV lists a location, achievement bullets, and a technology stack, and the CV has a skills section and portfolio projects
+- **THEN** the structured résumé captures that role's location, highlights, and stack (alongside title/company/period), and populates the top-level skills list and projects entries — so a CV seeded from it is complete
+
+#### Scenario: A year-only date is captured without a fabricated month
+
+- **WHEN** a CV states only a year for a role's start or end (e.g. "2024"), with no month
+- **THEN** the structured résumé's period for that boundary carries the year with no month, rather than defaulting to January or any other assumed month
+
+#### Scenario: An ongoing role is marked current, not given a fabricated end date
+
+- **WHEN** a CV describes a role as ongoing ("Present", "Current", or the role has no end stated)
+- **THEN** the structured résumé marks that entry's period as current with no end date, rather than inventing an end year

--- a/openspec/changes/structured-experience-dates/tasks.md
+++ b/openspec/changes/structured-experience-dates/tasks.md
@@ -1,0 +1,55 @@
+## 1. Shared `perioddate` package
+
+- [ ] 1.1 Create `internal/candidate/perioddate/perioddate.go`: `type PeriodDate struct { Year, Month int }` (`Month == 0` = year-only), `Sanitize()` (year clamped 1900–2100, month clamped 0/1–12 else 0), `Format() string` (e.g. "Mar 2021", "2018").
+- [ ] 1.2 Add `Parse(s string) (*PeriodDate, bool)` to the same package: port `period_sort.go`'s existing `parsePeriodLabel`/`parseYearMonth`/`parseMonthYear`/`monthNumber` logic (currently returning a sortable int) to instead return a `*PeriodDate`. Recognize the same formats it does today (`YYYY-MM`/`YYYY/MM`, `Month YYYY`/`Mon YYYY`, bare `YYYY`).
+- [ ] 1.3 Add `IsPresentLabel(s string) bool` to the same package: port `period_sort.go`'s existing `isPresentLabel`.
+- [ ] 1.4 `PeriodDate.MarshalJSON`/`UnmarshalJSON`: marshal always emits `{"year":Y,"month":M}` (omit `month` key when 0); unmarshal accepts that object shape OR a legacy JSON string (delegates to `Parse`, `nil` on failure — never errors on unparseable legacy input).
+- [ ] 1.5 Unit tests: port every case from `internal/candidate/experience/period_sort_test.go`'s `TestParsePeriodLabel` (`"2024"`, `"2023-09"`, `"2023/09"`, `"Jan 2018"` .. `"October 2018"`, plus `"Present"`/`""`/`"sometime"` failing to parse as a date) as `perioddate.Parse` tests; add `UnmarshalJSON` tests for both the object and legacy-string shapes, and for genuinely garbage legacy strings (must decode to `nil`, not error).
+- [ ] 1.6 Add `internal/candidate/perioddate` to the layering table (`internal/platform/arch/layering/blocks.go`), same layer as `experience`/`resumeextract`/`cv`.
+
+## 2. `experience_employments`: schema + backend
+
+- [ ] 2.1 New migration: add `period_start_year int`, `period_start_month smallint`, `period_end_year int`, `period_end_month smallint` (all nullable) to `experience_employments`, additive alongside the existing `period_start`/`period_end text`. Replace `experience_employments_user_idx` with one ordering on the new columns (`user_id, is_current DESC, period_start_year DESC NULLS LAST, period_start_month DESC NULLS LAST`).
+- [ ] 2.2 Update `internal/platform/db/queries/experience.sql`: employment insert/update/select statements read/write the four new columns instead of the two text ones; `ListEmployments`'s `ORDER BY` uses the new columns natively. Run `make sqlc`.
+- [ ] 2.3 `internal/candidate/experience/experience.go`: `Employment.Start`/`End` become `*perioddate.PeriodDate`; update `Sanitize()` to call `PeriodDate.Sanitize()` on each instead of `clip()`-ing a string.
+- [ ] 2.4 `internal/candidate/experience/repository.go`: adapt `CreateEmployment`/`FillEmploymentBlanks`/read paths to the new sqlc-generated column shape (four nullable ints in, `*PeriodDate` out).
+- [ ] 2.5 `internal/candidate/experience/import_resume.go` (`EntriesFromResume`): copy the now-structured `Start`/`End` straight from `resumeextract.Experience` (both are `*perioddate.PeriodDate` after task 3); `Current` derivation (`role.End == "" || isPresentLabel(role.End)`) becomes `role.Current` read directly (see task 3.3).
+- [ ] 2.6 Delete `internal/candidate/experience/period_sort.go` and `period_sort_test.go`; remove `store.go`'s call to `sortEmploymentsChronological` in `ListEmployments` (now just what the SQL `ORDER BY` returns, verify a still-needed stability tie-break if `period_sort_test.go`'s fixtures had one beyond the date itself).
+- [ ] 2.7 `internal/api/handler/assistant_experience_tools.go:637`: replace the `Start + " – " + End` string concatenation with `perioddate.Format` on each side (matching the `daterange`-style " – " join only when both are present).
+- [ ] 2.8 `cmd/backfill-experience-dates` (new, following `cmd/backfill-*` conventions — idempotent, chunked, needs only `DATABASE_URL`): for every employment row with the new columns still null, parse `period_start`/`period_end` via `perioddate.Parse`; on failure, use the year of `created_at`. Add its entry to `AGENTS.md`'s worker table.
+- [ ] 2.9 Follow-up migration (separate file, applied only after 2.8 has run and the new code is deployed): drop `period_start`/`period_end text` and the now-superseded index, if any remains.
+- [ ] 2.10 Go tests for 2.3–2.7 green (`go test ./internal/candidate/experience/...`).
+
+## 3. `resumeextract`
+
+- [ ] 3.1 `internal/candidate/resumeextract/structured.go`: `Experience.Start`/`End` become `*perioddate.PeriodDate`; add `Current bool`; do the same for `Education.Year` (mirror the reasoning — a bare year is already what that field holds, now typed) if a same-shaped change applies cleanly, else leave `Education.Year` as-is and note why in the task's own commit.
+- [ ] 3.2 Update `sanitizeExperience()` or its replacement to call `PeriodDate.Sanitize()`.
+- [ ] 3.3 Update the LLM extraction schema (wherever `internal/platform/llm`'s schema-constrained output for `resumeextract` is declared) so `start`/`end` are `{year, month?}` objects and `current` is a boolean field, not a string sentinel.
+- [ ] 3.4 Update `resumeextract.go`'s `systemPrompt` (currently: "keep dates as written, e.g. '2021-03' or 'Present'") to instruct the model to interpret the CV's printed range into year/(optional month), and to use `current: true` for an ongoing role instead of a special `end` value.
+- [ ] 3.5 Go tests green (`go test ./internal/candidate/resumeextract/...`); manually spot-check extraction against a handful of real/sample CVs for date-quality regressions (per design.md's Risk) before calling this task done.
+
+## 4. `cv` (document model + renderer)
+
+- [ ] 4.1 `internal/candidate/cv/cv.go`: `ExperienceItem.Start`/`End` become `*perioddate.PeriodDate` (keep `Current bool`, unchanged); same for `EducationItem.Start`/`End` and `Certification.Year` where they hold the same free-text convention.
+- [ ] 4.2 Update `cv.go`'s `sanitizeExperience()` (and education/certification equivalents) to call `PeriodDate.Sanitize()`.
+- [ ] 4.3 `internal/candidate/cv/seed.go` (`Seed()`): copy the now-structured fields straight from `resumeextract.Experience`/`Education` instead of string-copying.
+- [ ] 4.4 `internal/candidate/cv/renderer.go`: when building `data.json` for typst, format each structured date via `perioddate.Format` into the same plain string the templates already expect — no `.typ` file changes. Add a test asserting the JSON payload's `start`/`end` fields are still plain strings, byte-for-byte matching what the old free-text field would have produced for an equivalent value.
+- [ ] 4.5 Go tests green (`go test ./internal/candidate/cv/...`), including a render-output snapshot/comparison test for at least one template confirming PDF text is unchanged for a representative experience entry.
+
+## 5. Frontend
+
+- [ ] 5.1 Regenerate `web/src/lib/generated/contracts.ts` (`make gen-contracts`) — `Experience`/`ExperienceItem`'s `start`/`end` become the generated `PeriodDate`-shaped interface.
+- [ ] 5.2 Hand-edit `web/src/lib/types.ts`'s `ExperienceEmployment` (`experience.Employment` is not in `gen-contracts`) to match: `start`/`end` become `{ year: number; month?: number } | undefined`.
+- [ ] 5.3 New shared component (e.g. `web/src/lib/components/PeriodDateInput.svelte`): `<input type="month">` bound to the structured value, plus a "I don't remember the month" toggle that swaps in a plain year `<input type="number">`; emits/accepts the `{year, month?}` shape (or `undefined`).
+- [ ] 5.4 `web/src/lib/components/ExperienceBankView.svelte`: replace the plain text start/end inputs (employment add/edit form) with `PeriodDateInput`; update the display line that concatenates `employment.start`/`end` to format the structured value instead.
+- [ ] 5.5 `web/src/lib/components/cv/CvSectionForm.svelte`: replace the plain text start/end inputs (experience and education entries) with `PeriodDateInput`.
+- [ ] 5.6 `web/src/lib/api.ts` (and any other call site constructing/reading `ExperienceEmployment`/`Experience`/`ExperienceItem` start/end as a plain string) updated to the structured shape.
+- [ ] 5.7 `pnpm --dir web check` (svelte-check) passes; `pnpm --dir web test` (vitest) passes.
+
+## 6. Verification
+
+- [ ] 6.1 `go build ./... && go vet ./...` and `go vet -tags=integration ./...` pass.
+- [ ] 6.2 `go test ./...` passes; run `go test -tags=integration ./internal/platform/db/...` if the sqlc/query changes touch anything that suite covers.
+- [ ] 6.3 Manual pass against the running dev stack: create an employment with a year-only start, one with month+year, one marked current; confirm they list in correct chronological order and the picker round-trips each precision correctly.
+- [ ] 6.4 Manual pass: render a CV to PDF (or its HTML preview) for a profile with mixed-precision dates; confirm the rendered text is unchanged from before this change for an equivalent value.
+- [ ] 6.5 Run `cmd/backfill-experience-dates` against a copy of representative existing data (or the dev stack's seeded data) and confirm every row gets a non-null structured date, with the `created_at`-year fallback exercised for at least one deliberately-unparseable row.


### PR DESCRIPTION
## Summary
- Code review of the (still in-progress, unmerged) `structured-experience-dates` OpenSpec change found that `proposal.md`, `design.md`, and the `cv-builder` spec delta all claimed the CV renderer's output stays byte-identical after the change.
- That claim is contradicted by the plan's own `perioddate.Format` canonicalization: a pre-existing entry stored as free text in a non-canonical style (e.g. "October 2018") will render in the canonical style ("Oct 2018") after the change, not its original wording.
- Corrected the claim in all three documents, and added the spec scenario that was missing to cover the canonicalization case.

This is a documentation-only fix to planning artifacts under `openspec/changes/`; no application code is touched.

## Test plan
- [x] `openspec validate structured-experience-dates --strict` passes
- N/A — no Go/web code changed