### PR TITLE
Give the chat's tool chips a terminal icon, and every tool a name in English

### DIFF
--- a/extension/entrypoints/sidepanel/ToolGroupList.svelte
+++ b/extension/entrypoints/sidepanel/ToolGroupList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { ChevronRight, Terminal } from '@lucide/svelte';
   import {
     groupTitle,
     isExpandable,
@@ -12,8 +13,9 @@
 
   // The tool calls of one assistant message, rendered as collapsed rows. Ported
   // from the web app's `ToolGroupList.svelte`; the formatting logic is shared
-  // verbatim through `tool-formatters`, only the markup differs — the web's
-  // version uses an icon set this panel has none of, and this one is 400px wide.
+  // verbatim through `tool-formatters` and the two draw the same icons, only the
+  // styling differs — the web has Tailwind's design tokens, this panel is 400px
+  // wide and styles itself.
   let { calls }: { calls: readonly ToolCall[] } = $props();
 
   // Fold the flat list into consecutive runs of the same tool, so a burst of
@@ -32,10 +34,17 @@
 {#each groupTools(calls) as g, t (t)}
   {@const title = groupTitle(g)}
   {#if !isExpandable(g)}
-    <div class="tool">{title}</div>
+    <div class="tool">
+      <Terminal class="size-3.5 shrink-0 opacity-60" />
+      <span class="title">{title}</span>
+    </div>
   {:else}
     <details class="tool">
-      <summary>{title}</summary>
+      <summary>
+        <Terminal class="size-3.5 shrink-0 opacity-60" />
+        <span class="title">{title}</span>
+        <ChevronRight class="chev size-3.5 shrink-0 opacity-50 transition-transform" />
+      </summary>
       <ul>
         {#each g as c, ci (ci)}
           <li>
@@ -62,35 +71,54 @@
     align-self: flex-start;
     max-width: 90%;
     font-size: 12px;
+    line-height: 18px;
     color: var(--muted-foreground);
     background: var(--muted);
     border: 1px solid var(--border);
     border-radius: 8px;
+    /* The summary's hover fill runs to the card's edge; without this it squares off
+       the two top corners. */
+    overflow: hidden;
+  }
+
+  /* The padding sits on the row rather than the card so that an expanded card's list
+     is not indented by it as well. */
+  div.tool,
+  summary {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     padding: 6px 10px;
+  }
+
+  .title {
+    font-weight: 500;
   }
 
   summary {
     cursor: pointer;
     list-style: none;
+    transition: background 120ms;
+  }
+
+  summary:hover {
+    background: var(--background);
   }
 
   summary::-webkit-details-marker {
     display: none;
   }
 
-  /* A disclosure the user can miss is a disclosure they will not open. */
-  summary::after {
-    content: ' ▸';
-    color: var(--muted-foreground);
-  }
-
-  details[open] summary::after {
-    content: ' ▾';
+  /* A disclosure the user can miss is a disclosure they will not open.
+     :global — the class is forwarded onto the icon component's own <svg>, which this
+     file's scope does not reach. */
+  details[open] :global(.chev) {
+    transform: rotate(90deg);
   }
 
   ul {
-    margin: 6px 0 0;
-    padding-left: 14px;
+    margin: 0;
+    padding: 0 10px 8px 24px;
     font-size: 11px;
     line-height: 1.5;
   }

--- a/extension/lib/assistant/tool-formatters.test.ts
+++ b/extension/lib/assistant/tool-formatters.test.ts
@@ -28,9 +28,11 @@ describe('toolLabel', () => {
     expect(toolLabel(call('cv_edit'))).toBe('Updating your CV');
   });
 
-  it('falls back to the tool name for a tool the map does not know yet', () => {
-    // A tool added on the backend must still render rather than showing blank.
-    expect(toolLabel(call('brand_new_tool'))).toBe('brand_new_tool');
+  it('reads the tool name as a sentence for a tool the map does not know yet', () => {
+    // A tool added on the backend must still render — and must not render as a raw
+    // identifier, which is what put `experience_search` in front of users lowercased
+    // and underscored while every labelled call beside it read as English.
+    expect(toolLabel(call('brand_new_tool'))).toBe('Brand new tool');
   });
 });
 

--- a/extension/lib/assistant/tool-formatters.ts
+++ b/extension/lib/assistant/tool-formatters.ts
@@ -30,21 +30,53 @@ const LABELS: Record<string, string> = {
   search_jobs: 'Searching jobs',
   get_job: 'Reading a job posting',
   get_company: 'Reading a company',
+  present_jobs: 'Showing jobs',
   market_fit: 'Analysing market fit',
+  job_match: 'Scoring the match',
   save_job: 'Saving a job',
   unsave_job: 'Removing a bookmark',
   apply_job: 'Marking as applied',
   track_job: 'Updating your board',
   my_jobs: 'Reading your tracked jobs',
+  get_profile: 'Reading your profile',
   cv_context: 'Reading the fit analysis',
   cv_get: 'Reading your CV',
   cv_edit: 'Updating your CV',
+  cv_page_count: 'Measuring your CV',
+  tailor_report: 'Updating the tailoring report',
+  cover_letter_draft: 'Drafting a cover letter',
+  check_evidence_fidelity: 'Checking the evidence',
+  screening_answers_set: 'Saving screening answers',
+  interview_context: 'Reading the interview brief',
+  request_confirmation: 'Asking you to confirm',
+  experience_search: 'Searching your experience',
+  experience_get: 'Reading an achievement',
+  experience_add: 'Banking an achievement',
+  experience_update: 'Updating an achievement',
+  experience_merge: 'Merging achievements',
+  experience_employments: 'Reading your work history',
+  experience_set_require_context: 'Flagging an achievement',
+  inbox_overview: 'Reading your inbox',
+  inbox_search: 'Searching your inbox',
+  inbox_triage: 'Triaging your inbox',
+  inbox_link: 'Linking an email to a job',
+  inbox_unlink: 'Unlinking an email',
+  inbox_record_application: 'Recording an application',
+  inbox_resolve_suggestion: 'Resolving a suggestion',
 };
 
-/** The intent label for one call, falling back to the tool's own name so a tool
- *  added on the backend still renders sensibly before this map catches up. */
+/** The intent label for one call. A tool the backend added before this map caught
+ *  up falls back to its own name made readable — `experience_search` reads as
+ *  "Experience search", never as a raw identifier in the middle of a sentence. */
 export function toolLabel(call: ToolCall): string {
-  return LABELS[call.name] ?? call.name;
+  return LABELS[call.name] ?? humanise(call.name);
+}
+
+/** `snake_case` → `Sentence case`. */
+function humanise(name: string): string {
+  const words = name.replace(/_/g, ' ').trim();
+  if (words === '') return name;
+  return words.charAt(0).toUpperCase() + words.slice(1);
 }
 
 /** Title shown in the collapsed header: the distinct intents in the group, capped

--- a/web/src/lib/assistant/ToolGroupList.svelte
+++ b/web/src/lib/assistant/ToolGroupList.svelte
@@ -44,7 +44,7 @@
   // One chip shape for both the flat card and the expandable summary, so the two never
   // drift apart by a padding step. The expandable one adds only its hover affordance.
   const chip =
-    'self-start inline-flex items-center gap-2 rounded-lg border border-border/60 bg-muted/40 px-2.5 py-1.5 text-[13px] leading-5 text-muted-foreground';
+    'self-start inline-flex items-center gap-2 rounded-lg border border-border/60 bg-muted/40 px-2.5 py-1.5 text-sm leading-5 text-muted-foreground';
 </script>
 
 {#each groupTools(calls) as g, t (t)}

--- a/web/src/lib/assistant/ToolGroupList.svelte
+++ b/web/src/lib/assistant/ToolGroupList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ChevronRight, Wrench } from '@lucide/svelte';
+  import { ChevronRight, Terminal } from '@lucide/svelte';
   import {
     groupTitle,
     isExpandable,
@@ -40,6 +40,11 @@
     }
     return groups;
   }
+
+  // One chip shape for both the flat card and the expandable summary, so the two never
+  // drift apart by a padding step. The expandable one adds only its hover affordance.
+  const chip =
+    'self-start inline-flex items-center gap-2 rounded-lg border border-border/60 bg-muted/40 px-2.5 py-1.5 text-[13px] leading-5 text-muted-foreground';
 </script>
 
 {#each groupTools(calls) as g, t (t)}
@@ -75,24 +80,22 @@
       {/if}
     {/each}
   {:else if !isExpandable(g)}
-    <div
-      class="self-start flex items-center gap-2 rounded-lg border border-border bg-muted/50 px-3 py-2 text-sm text-muted-foreground"
-    >
-      <Wrench class="size-4 shrink-0" />
-      <span>{title}</span>
+    <div class={chip}>
+      <Terminal class="size-3.5 shrink-0 opacity-60" />
+      <span class="font-medium">{title}</span>
     </div>
   {:else}
-    <details class="self-start max-w-[90%]">
+    <!-- `group` so the chevron can read the details' own open state; a variant hung on
+         the summary cannot — `[open]` sits on the <details>, never on its summary. -->
+    <details class="group self-start max-w-[90%]">
       <summary
-        class="flex cursor-pointer items-center gap-2 rounded-lg border border-border bg-muted/50 px-3 py-2 text-sm text-muted-foreground hover:bg-muted/70 [&::-webkit-details-marker]:hidden [&::marker]:hidden [&[open]>span>svg.chev]:rotate-90"
+        class="{chip} cursor-pointer transition-colors hover:border-border hover:bg-muted/70 [&::-webkit-details-marker]:hidden [&::marker]:hidden"
       >
-        <Wrench class="size-4 shrink-0" />
-        <span class="flex items-center gap-1.5">
-          {title}
-          <ChevronRight class="chev size-3.5 shrink-0 transition-transform" />
-        </span>
+        <Terminal class="size-3.5 shrink-0 opacity-60" />
+        <span class="font-medium">{title}</span>
+        <ChevronRight class="size-3.5 shrink-0 opacity-50 transition-transform group-open:rotate-90" />
       </summary>
-      <ul class="mt-2 ml-6 space-y-1 text-xs text-muted-foreground">
+      <ul class="mt-1.5 ml-5 space-y-1 text-xs text-muted-foreground">
         {#each g as c, ci (ci)}
           <li class="flex flex-wrap items-baseline gap-1.5">
             <span class={c.isError ? 'text-destructive' : ''}>{callLine(c)}</span>

--- a/web/src/lib/assistant/tool-formatters.test.ts
+++ b/web/src/lib/assistant/tool-formatters.test.ts
@@ -25,9 +25,11 @@ describe('toolLabel', () => {
     expect(toolLabel(call('cv_edit'))).toBe('Updating your CV');
   });
 
-  it('falls back to the tool name for a tool the map does not know yet', () => {
-    // A tool added on the backend must still render rather than showing blank.
-    expect(toolLabel(call('brand_new_tool'))).toBe('brand_new_tool');
+  it('reads the tool name as a sentence for a tool the map does not know yet', () => {
+    // A tool added on the backend must still render — and must not render as a raw
+    // identifier, which is what put `experience_search` in front of users lowercased
+    // and underscored while every labelled call beside it read as English.
+    expect(toolLabel(call('brand_new_tool'))).toBe('Brand new tool');
   });
 });
 

--- a/web/src/lib/assistant/tool-formatters.ts
+++ b/web/src/lib/assistant/tool-formatters.ts
@@ -28,21 +28,54 @@ const LABELS: Record<string, string> = {
   search_jobs: 'Searching jobs',
   get_job: 'Reading a job posting',
   get_company: 'Reading a company',
+  present_jobs: 'Showing jobs',
   market_fit: 'Analysing market fit',
+  job_match: 'Scoring the match',
   save_job: 'Saving a job',
   unsave_job: 'Removing a bookmark',
   apply_job: 'Marking as applied',
   track_job: 'Updating your board',
   my_jobs: 'Reading your tracked jobs',
+  get_profile: 'Reading your profile',
   cv_context: 'Reading the match analysis',
   cv_get: 'Reading your CV',
   cv_edit: 'Updating your CV',
+  cv_page_count: 'Measuring your CV',
+  tailor_report: 'Updating the tailoring report',
+  cover_letter_draft: 'Drafting a cover letter',
+  check_evidence_fidelity: 'Checking the evidence',
+  screening_answers_set: 'Saving screening answers',
+  interview_context: 'Reading the interview brief',
+  request_confirmation: 'Asking you to confirm',
+  read_current_page: 'Reading the page you are on',
+  experience_search: 'Searching your experience',
+  experience_get: 'Reading an achievement',
+  experience_add: 'Banking an achievement',
+  experience_update: 'Updating an achievement',
+  experience_merge: 'Merging achievements',
+  experience_employments: 'Reading your work history',
+  experience_set_require_context: 'Flagging an achievement',
+  inbox_overview: 'Reading your inbox',
+  inbox_search: 'Searching your inbox',
+  inbox_triage: 'Triaging your inbox',
+  inbox_link: 'Linking an email to a job',
+  inbox_unlink: 'Unlinking an email',
+  inbox_record_application: 'Recording an application',
+  inbox_resolve_suggestion: 'Resolving a suggestion',
 };
 
-/** The intent label for one call, falling back to the tool's own name so a tool
- *  added on the backend still renders sensibly before this map catches up. */
+/** The intent label for one call. A tool the backend added before this map caught
+ *  up falls back to its own name made readable — `experience_search` reads as
+ *  "Experience search", never as a raw identifier in the middle of a sentence. */
 export function toolLabel(call: ToolCall): string {
-  return LABELS[call.name] ?? call.name;
+  return LABELS[call.name] ?? humanise(call.name);
+}
+
+/** `snake_case` → `Sentence case`. */
+function humanise(name: string): string {
+  const words = name.replace(/_/g, ' ').trim();
+  if (words === '') return name;
+  return words.charAt(0).toUpperCase() + words.slice(1);
 }
 
 /** Title shown in the collapsed header: the distinct intents in the group, capped


### PR DESCRIPTION
The assistant's tool chips read as intent — "Searching jobs" — for the twelve tools the label map knew, and as raw identifiers for everything else. `experience_search` and `tailor_report` sat lowercase and underscored between two English sentences, because the fallback returned the tool's own name verbatim and the backend defines forty-odd tools against the map's twelve.

- **Labels for every tool the backend offers** — the experience bank, the inbox, the tailoring report, the CV measurements.
- **A fallback that reads as English.** A tool the map has not caught up with renders in sentence case (`brand_new_tool` → "Brand new tool") rather than as an identifier. A tool added tomorrow is legible on the day it ships.
- **A terminal glyph in place of the wrench**, a lighter border, a tighter row.
- **A chevron that turns.** It never did: the variant was hung off `summary[open]`, and `[open]` is an attribute of the `<details>`, never of its summary.

Both chat surfaces — the web app and the extension's side panel — get the same treatment. The formatting module was already shared between them verbatim; now the icons are too.

## Verification

- `pnpm vitest run src/lib/assistant` — 144 passed
- `npx vitest run lib/assistant` (extension) — 81 passed
- `pnpm check` (web) — 0 errors; `npx svelte-check` (extension) — 0 errors
- eslint clean on the changed files

Not verified in a browser — the chat sits behind sign-in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer, human-readable labels for a wider range of assistant tools.
  * Unknown tool names are now displayed in sentence case instead of technical identifiers.
  * Updated tool group cards with consistent icons, styled layouts, and rotating expand/collapse indicators across the web app and side panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->