### PR TITLE
Keep a build's chunks reachable after the flip, so an open tab survives a release

### DIFF
--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -4,14 +4,23 @@ The production host's systemd units and operator scripts, as they run on host-2.
 not built, not imported by anything — this directory is a **record**, and the only reason
 it exists is that the machine was the sole copy.
 
-Snapshot taken 2026-09-01 from `/etc/systemd/system/freehire-*` and `/opt/freehire/bin/*.sh`.
+Snapshot taken 2026-09-05 from `/etc/systemd/system/freehire-*`, `/opt/freehire/bin/*.sh` and
+`/etc/nginx/snippets/freehire-app.conf`.
 
 ## What is here
 
 ```
 systemd/   337 files — 46 .service, 286 .timer, 5 drop-in directories
-bin/        14 operator scripts (release, autodeploy, backups, alerting, ingest slotting)
+bin/        16 operator scripts (release, autodeploy, backups, alerting, ingest slotting)
+nginx/       1 snippet — snippets/freehire-app.conf, hand-edited, not generated
 ```
+
+`nginx/` holds one file on purpose. `freehire-app.conf` decides how `/_app/immutable/` is
+served, which is roughly three quarters of all requests and where the asset attic below
+lives; it was the last load-bearing thing on this host whose only copy was the machine.
+The other `freehire-*` snippets are left out because `freehire-upstream-active.conf` is
+the symlink the flip repoints, so tracking it would report drift after every release and
+teach the reader to ignore the tool.
 
 `systemd/freehire-ingest@.service` is one template; the `freehire-ingest@<provider>.timer`
 files beside it are per-provider schedules, which is why the timer count dwarfs everything
@@ -103,9 +112,53 @@ a scheduled Dependabot run made every deploy stop, silently, at exit 0.
   `meilisearch`, `rollup-views`, `seed-from-nginx` are compiled artifacts, and a committed
   binary breaks `git pull` on the host.
 - **The scripts are shellcheck-clean and CI enforces it.** The `artifacts` job runs
-  shellcheck over every tracked `*.sh`, so these 13 are covered the moment they are
+  shellcheck over every tracked `*.sh`, so these 16 are covered the moment they are
   committed. The findings that came with them were all style-level and are suppressed
   inline with the reason beside them — none was a defect.
+
+## The asset attic
+
+`/opt/freehire/asset-attic/_app/immutable/` holds the client chunks of recent builds, and
+nginx falls back to it when the live build does not have the file (`location @attic` in
+`nginx/snippets/freehire-app.conf`). `release.sh` copies each build in and drops what no
+build has shipped for three days; about 39 MB a build.
+
+It exists because `/_app/immutable/` is served off `hire-current`, the symlink the flip
+repoints in one step — so before this, every chunk of the outgoing build stopped existing
+the instant traffic moved, and a tab open across the release 404'd on its next navigation,
+which SvelteKit draws as the 500 page over an HTTP 200. Keeping the files is safe by
+construction: every name under `_app/immutable` carries a content hash, so a kept copy can
+never disagree with a live build about what it contains.
+
+It is the second half of a fix, not a replacement for the first.
+`web/src/routes/+layout.svelte` leaves through a full page load once `updated` reports a
+new build, which took these from 265 a day to about 22; what it cannot catch is a reader
+navigating inside the five-minute version poll, and no client-side guard can. Neither half
+is redundant: the client one also covers a stale tab older than the attic's three days.
+
+**An empty attic protects nobody for one release.** `release.sh` banks the build it is
+about to make live, so the build going *warm* was only ever banked by the release before
+it. The first run after this shipped had nothing behind it, and the same hole opens after
+any hand-wipe of the directory. Seeding it costs one command per colour, and both were run
+on 2026-09-05 when this went in:
+
+```bash
+install -d -o freehire -g freehire /opt/freehire/asset-attic/_app/immutable
+for c in blue green; do
+  cp -rf "/opt/freehire/src/hire-$c/web/build/client/_app/immutable/." \
+         /opt/freehire/asset-attic/_app/immutable/
+done
+chown -R freehire:freehire /opt/freehire/asset-attic
+```
+
+**To undo it**, restore the snippet and reload — the directory can then be deleted at
+leisure, since nothing but that `location` block reads it:
+
+```bash
+ls /etc/nginx/snippets/freehire-app.conf.bak.*   # release.sh never writes these; they are hand-made
+cp /etc/nginx/snippets/freehire-app.conf.bak.<stamp> /etc/nginx/snippets/freehire-app.conf
+nginx -t && systemctl reload nginx
+```
 
 ## Checking for drift
 

--- a/deploy/bin/pg-backup.sh
+++ b/deploy/bin/pg-backup.sh
@@ -22,7 +22,9 @@ BACKUP_DIR=/var/backups/freehire
 S3_REMOTE=hz
 BACKUP_BUCKET=freehire-backups
 S3_PREFIX=pg
-# Keep only the newest local dump — S3 (below) is the authoritative backup with
+# Bounds what an upload OUTAGE leaves behind. A SUCCESSFUL upload now deletes its own
+# local copy (see the verified delete after rclone copyto), so in the ordinary case this
+# directory holds nothing between runs. S3 (below) is the authoritative backup with
 # S3_MAX_AGE history. On host-2's 301G disk, Meili (~128G) + PG (~70G) + a facet
 # reindex's ~2x transient index leave no room for a stack of ~19G dumps; three of
 # them once filled the disk mid-reindex (2026-07-20), aborting it on `unexpected
@@ -178,6 +180,26 @@ for db in "${DATABASES[@]}"; do
   dest="${S3_REMOTE}:${BACKUP_BUCKET}/${S3_PREFIX}/${db}/${db}_${ts}.dump"
   log "uploading -> $dest"
   rclone copyto "$file" "$dest"
+
+  # The local copy exists to reach S3. Once it is there, keeping it costs 27G and grows
+  # about a gigabyte a day (24G on 2026-08-31, 27.6G on 2026-09-04) on a disk that has
+  # twice run a facet reindex out of room — the header above records three dumps filling
+  # it in 2026-07-20, and on 2026-09-04 free space was 42G against the reindex's own 40G
+  # floor. LOCAL_KEEP still bounds what an upload OUTAGE leaves behind; this removes what
+  # a successful upload leaves behind.
+  #
+  # Guarded by asking S3 what it actually holds, not by assuming rclone's exit code means
+  # the object is intact: this deletes the only local copy, so the check is worth one
+  # extra call. A mismatch keeps the file and says so rather than failing the run — the
+  # backup itself succeeded, and disk is the lesser problem.
+  remote_size=$(rclone size --json "$dest" 2>/dev/null | jq -r '.bytes // empty')
+  local_size=$(stat -c %s "$file")
+  if [ "$remote_size" = "$local_size" ]; then
+    rm -f -- "$file"
+    log "local copy removed; S3 holds ${remote_size} bytes"
+  else
+    log "WARNING: S3 reports '${remote_size}' bytes against ${local_size} local — keeping the local dump"
+  fi
 
   # S3 retention: drop objects older than S3_MAX_AGE.
   rclone delete --min-age "$S3_MAX_AGE" \

--- a/deploy/bin/release.sh
+++ b/deploy/bin/release.sh
@@ -4,6 +4,24 @@
 # rebuilds the worker binaries, and repoints the `hire-current` symlink (workers
 # follow the active release). Old color stays warm for rollback.
 set -euo pipefail
+# One release at a time, enforced here rather than by convention.
+#
+# Until autodeploy.sh existed, "a person is running it" WAS the lock: nothing on this
+# host holds a file lock, and systemd's refusal to start a second instance of a oneshot
+# unit only ever protected the timer path. A timer that releases on its own introduces
+# the collision that could not happen before — a scheduled run starting while an
+# operator is mid-flip — and two releases sharing one inactive color would build over
+# each other's checkout and flip nginx at whichever finished first.
+#
+# `flock -n` so this fails immediately with something readable instead of a script that
+# appears to hang. Exit 3 is a distinct code on purpose: autodeploy.sh reads it as "not
+# my turn, try the next tick" rather than as a failed release, so a hand-run deploy does
+# not raise an alert. /var/lock is tmpfs, so a reboot mid-release cannot leave it held.
+exec 9>/var/lock/freehire-release.lock
+if ! flock -n 9; then
+  echo "release: another release is already running; refusing to start a second." >&2
+  exit 3
+fi
 app="${1:-freehire}"
 case "$app" in
   freehire) snip=freehire-upstream; apisvc=freehire-api; websvc=freehire-web; dir=hire; bin=hire-api; b_api=8081; b_web=8083; g_api=8082; g_web=8084 ;;
@@ -196,13 +214,22 @@ if [ "$app" = freehire ]; then
   # never built: nudge, apple-revoke and auth-cleanup were six days old, capture-apply-form
   # sixteen. Their units were hand-installed on the box and never reached git either (#56) —
   # the same half-provisioned move, arriving here as a stale binary instead of a missing file.
-  # billing-sync joined 2026-09-04, found the same way and by then eleven days stale. It is
-  # the one on this list a stale binary can cost money: the provider retries a webhook five
-  # times over ~2.5h and then stops for good, and past that window this worker is the only
-  # path by which a paid subscription becomes Pro.
-  # auto-apply-orchestrate is a long-lived Inngest function server, not a cron worker, but it
-  # ships from hire-current the same way every other binary here does.
-  for w in migrate onboarding broadcast ingest enrich embed similar-backfill search-drain reindex reindex-companies import-collections import-yc import-company-industries queue-metrics tg-ingest tg-extract liveness notify remind nudge apple-revoke auth-cleanup billing-sync capture-apply-form backfill-derive backfill-company-names backfill-descriptions backfill-application-events backfill-slug-folded backfill-duplicate-marker-owner merge-companies harvest-orphans recount-companies rollup-stats rollup-facets build-suggestions rollup-company rollup-views classify-mail resolve-url gmail-sync cal-sync mail-ingest hydrate-adzuna-description seed-adzuna-description-queue add-board backfill-company-type-hint ingest-scheduler schedule-board auto-apply-orchestrate; do
+  # backfill-company-type-hint joined 2026-09-04, ahead of its own first run, for the same
+  # reason import-collections was added: a one-off with no unit should not need a hand build
+  # on the box the first time it runs either.
+  # backfill-board-catalog left 2026-09-04: freehire#2406 deleted its cmd/ entirely (sources/,
+  # the board catalog it backfilled, was retired), and this list still tried to build it on
+  # every release — the drift this comment keeps warning about, arriving as a directory that
+  # no longer exists instead of one nothing built. No systemd unit ever referenced it (checked
+  # both /etc/systemd/system and this repo's provision/ before removing), so nothing to add
+  # back on the other side.
+  # billing-sync and build-suggestions joined 2026-09-04, found by the check below on this
+  # release: both had freehire-*.service units already installed on the box, firing whatever
+  # binary was last built by hand — the same arrival this comment keeps describing, just two
+  # more of it.
+  # auto-apply-orchestrate joined 2026-09-05: a long-lived Inngest function server, not a
+  # cron worker, but it ships from hire-current the same way every other binary here does.
+  for w in migrate onboarding broadcast ingest enrich embed similar-backfill search-drain reindex reindex-companies import-collections import-yc import-company-industries queue-metrics tg-ingest tg-extract liveness notify remind nudge apple-revoke auth-cleanup capture-apply-form backfill-derive backfill-company-names backfill-descriptions backfill-application-events backfill-slug-folded backfill-duplicate-marker-owner backfill-company-type-hint billing-sync build-suggestions merge-companies add-board harvest-orphans recount-companies rollup-stats rollup-facets rollup-company rollup-views classify-mail resolve-url gmail-sync cal-sync mail-ingest hydrate-adzuna-description seed-adzuna-description-queue ingest-scheduler schedule-board auto-apply-orchestrate; do
     sudo -u freehire /usr/local/bin/go build -buildvcs=false -o "$w" "./cmd/$w"
   done
   # Every binary a freehire-*.service starts from hire-current has to have just been built,
@@ -230,11 +257,13 @@ if [ "$app" = freehire ]; then
     echo "$stale" | sed "s/^/[release:$app]   /" >&2
     echo "[release:$app]   their timers are firing whatever an older release left. Add them to the list in $0." >&2
   fi
-  # mail-ingest and auto-apply-orchestrate are long-lived daemons (not timers): restart
-  # them so they pick up the freshly built binary from the repointed hire-current.
-  # Enabled once via provision.
+  # mail-ingest is a long-lived daemon (not a timer): restart it so it picks up the
+  # freshly built binary from the repointed hire-current. Enabled once via provision.
+  # auto-apply-orchestrate is restarted separately, AFTER the flip below — it calls
+  # hire's own API over loopback at a fixed blue/green port, so restarting it here
+  # (before $new is actually active) would have it come up pointed at whichever color
+  # is about to go warm-standby, not the one about to take traffic.
   systemctl try-restart freehire-mail-ingest.service 2>/dev/null || true
-  systemctl try-restart freehire-auto-apply-orchestrate.service 2>/dev/null || true
 fi
 # Schema BEFORE the code that reads it. This exists because on 2026-07-29 a release carried
 # a merged migration nobody had applied: sqlc reads every column of a table, so one missing
@@ -280,11 +309,60 @@ if [ "$app" = freehire ]; then
   done
   [ -n "$fok" ] || { echo "[release:$app] facet smoke FAILED on $new — a facet attr likely needs a reindex; NOT flipping"; exit 1; }
 fi
+# Keep this build reachable after the next flip, for the tabs still running it.
+#
+# nginx serves /_app/immutable/ off hire-current (snippets/freehire-app.conf), the
+# symlink the flip below repoints in one step -- so without this, every chunk of
+# the outgoing build stops existing the instant traffic moves, and a tab that was
+# open across the release 404s on its next navigation. SvelteKit draws that as the
+# 500 page over an HTTP 200. The client-side guard in web/src/routes/+layout.svelte
+# rescues the tab that has already noticed a new build; it cannot rescue the one
+# navigating inside the five-minute version-poll window, and this is that half.
+#
+# Safe because every name under _app/immutable carries a content hash: a copy kept
+# from an older build can never disagree with a live one about what it contains.
+#
+# That is also why this OVERWRITES rather than skipping what is already there. The
+# bytes are identical either way, so the only thing rewriting them buys is a fresh
+# timestamp -- which is what makes a file's age in here mean "since the last build
+# that shipped this chunk" instead of "since it was first seen". Skipping would
+# evict a chunk that had been stable all week on the day before the build that
+# finally replaced it, leaving that hash in neither directory: precisely the 404
+# this exists to prevent, arriving only for the chunks that actually changed.
+#
+# The prune runs whether or not the copy did, because a copy fails on a full disk
+# and that is the one time reclaiming matters. Neither step is fatal: a release
+# that cannot fill the attic is still a good release, and refusing to ship over it
+# would trade a rare stale-tab 404 for a stuck deploy.
+if [ "$app" = freehire ]; then
+  attic=/opt/freehire/asset-attic/_app/immutable
+  install -d -o freehire -g freehire "$attic" 2>/dev/null || true
+  if cp -rf "/opt/freehire/src/hire-${new}/web/build/client/_app/immutable/." "$attic/"; then
+    chown -R freehire:freehire /opt/freehire/asset-attic 2>/dev/null || true
+  else
+    echo "[release:$app] WARNING: could not refill the asset attic; tabs open across the NEXT flip may 404 on this build's chunks" >&2
+  fi
+  # `-mtime +3` is "older than three full days", so a chunk outlives by at least
+  # three days the last build that shipped it.
+  find "$attic" -type f -mtime +3 -delete 2>/dev/null || true
+  find "$attic" -type d -empty -delete 2>/dev/null || true
+  echo "[release:$app] asset attic holds $(find "$attic" -type f | wc -l) files ($(du -sh "$attic" | cut -f1))"
+fi
+
 ln -sf "$S/${snip}-${new}.conf" "$S/${snip}-active.conf"
 nginx -t && nginx -s reload
 if [ "$app" = freehire ]; then
   ln -sfn "/opt/freehire/src/hire-${new}" /opt/freehire/src/hire-current
   echo "[release:$app] workers now follow hire-${new} (hire-current repointed)"
+  # auto-apply-orchestrate calls hire's own API over loopback at a fixed blue/green
+  # port (internal/platform/config's own PORT default, 8080, matches neither — found
+  # 2026-09-05 the hard way: every call failed with connection refused until this
+  # existed). Regenerated on every release, after $new is the color nginx just sent
+  # traffic to, so a restart now always picks up the currently-active port rather
+  # than whichever color is about to go warm-standby.
+  echo "HIRE_BASE_URL=http://127.0.0.1:${aport}/api/v1" > /opt/freehire/env/auto-apply-orchestrate.env
+  chown freehire:freehire /opt/freehire/env/auto-apply-orchestrate.env
+  systemctl try-restart freehire-auto-apply-orchestrate.service 2>/dev/null || true
 fi
 echo "[release:$app] flipped to $new; previous color warm for rollback"
 

--- a/deploy/bin/semantic-drop-closed.sh
+++ b/deploy/bin/semantic-drop-closed.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# One-off, approved 2026-09-05: bulk-run the closed-job branch of the semantic
+# embed worker over the ~304k semantic_outbox rows whose job is closed or a
+# non-canonical repost.
+#
+# This is NOT a shortcut past the worker — it is exactly what Store.CompleteClosed
+# does (internal/ai/embed, queries in internal/platform/db/queries/semantic.sql),
+# in one transaction per chunk instead of one per 100-row batch:
+#   ClearSemanticEmbeddedBatch  -> null the three embed columns on jobs
+#   DeleteJobSemanticChunks     -> drop the job's job_semantic_chunks rows
+#   DeleteSemanticEntriesBatch  -> drop the outbox row
+# No TEI call is involved on this path, which is why it can run at SQL speed.
+#
+# Safe to run beside the live worker: FOR UPDATE ... SKIP LOCKED steps around any
+# row the worker has claimed, and every operation is idempotent — a row the worker
+# finishes first simply is not selected next chunk.
+#
+# Safe to stop at any time: each chunk is its own transaction, and the enqueuer
+# (EnqueuePendingSemanticJobs) re-derives outstanding work from jobs, never from
+# what this deleted.
+set -uo pipefail
+
+LOG=/opt/freehire/semantic-drop-closed.log
+CHUNK=${CHUNK:-2000}
+PAUSE=${PAUSE:-2}
+MAX_CHUNKS=${MAX_CHUNKS:-400}
+
+log() { echo "[$(date -u +%FT%TZ)] $*" >>"$LOG"; }
+psqlq() { sudo -u postgres psql -d hire -v ON_ERROR_STOP=1 -tA "$@"; }
+
+log "waiting for taxonomy-backfill-night to finish before touching an 11 GB table"
+for _ in $(seq 1 144); do
+	s=$(systemctl is-active taxonomy-backfill-night.service)
+	if [ "$s" != "active" ] && [ "$s" != "activating" ]; then
+		log "backfill state=$s -> proceeding"
+		break
+	fi
+	sleep 300
+done
+
+s=$(systemctl is-active taxonomy-backfill-night.service)
+if [ "$s" = "active" ] || [ "$s" = "activating" ]; then
+	log "GAVE UP: backfill still $s after 12h, nothing deleted"
+	exit 1
+fi
+
+before=$(psqlq -c "SELECT count(*) FROM semantic_outbox;")
+log "start: outbox=$before chunk=$CHUNK"
+
+total_rows=0
+total_chunks=0
+# Keyset cursor over semantic_outbox.id. Without it every chunk re-walks the
+# growing prefix of rows it already rejected (the ~420k OPEN entries interleaved
+# with the closed ones), turning a linear pass into a quadratic one. Rows below
+# the cursor are open-job entries we deliberately leave alone, or entries the
+# worker held locked at that moment — the worker owns those either way.
+cursor=0
+for i in $(seq 1 "$MAX_CHUNKS"); do
+	out=$(psqlq -c "
+WITH victims AS (
+    SELECT o.id AS outbox_id, o.job_id
+    FROM semantic_outbox o
+    JOIN jobs j ON j.id = o.job_id
+    WHERE o.id > $cursor
+      AND (j.closed_at IS NOT NULL OR j.duplicate_of IS NOT NULL)
+    ORDER BY o.id
+    LIMIT $CHUNK
+    FOR UPDATE OF o SKIP LOCKED
+),
+cleared AS (
+    UPDATE jobs
+    SET semantic_embedded_model = NULL,
+        semantic_embedded_hash  = NULL,
+        semantic_embedding      = NULL
+    WHERE id IN (SELECT job_id FROM victims)
+    RETURNING 1
+),
+dropped_chunks AS (
+    DELETE FROM job_semantic_chunks c
+    WHERE c.job_id IN (SELECT job_id FROM victims)
+    RETURNING 1
+),
+dropped_entries AS (
+    DELETE FROM semantic_outbox o
+    WHERE o.id IN (SELECT outbox_id FROM victims)
+    RETURNING 1
+)
+SELECT (SELECT count(*) FROM victims) || ' '
+    || (SELECT count(*) FROM dropped_chunks) || ' '
+    || (SELECT COALESCE(max(outbox_id), $cursor) FROM victims);")
+	rc=$?
+
+	if [ "$rc" -ne 0 ]; then
+		# A deadlock against a concurrent ingest write is expected occasionally:
+		# both touch jobs rows. The chunk rolled back whole; the next pass re-selects.
+		log "chunk $i failed (rc=$rc), retrying after backoff"
+		sleep 15
+		continue
+	fi
+
+	read -r victims chunks cursor <<<"$out"
+	[ "${victims:-0}" -eq 0 ] && { log "no rows left to clear (cursor=$cursor)"; break; }
+
+	total_rows=$((total_rows + victims))
+	total_chunks=$((total_chunks + chunks))
+	[ $((i % 10)) -eq 0 ] && log "progress: cleared=$total_rows outbox rows, $total_chunks chunk rows ($i chunks, cursor=$cursor)"
+	sleep "$PAUSE"
+done
+
+after=$(psqlq -c "SELECT count(*) FROM semantic_outbox;")
+left=$(psqlq -c "SELECT count(*) FROM semantic_outbox o JOIN jobs j ON j.id=o.job_id WHERE j.closed_at IS NOT NULL OR j.duplicate_of IS NOT NULL;")
+log "done: cleared=$total_rows outbox rows and $total_chunks chunk rows; outbox $before -> $after; closed rows still queued: $left"
+log "load: $(uptime)"

--- a/deploy/bin/slots-bump-once.sh
+++ b/deploy/bin/slots-bump-once.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# One-off, approved 2026-09-05: raise INGEST_SLOTS 8 -> 10 in /opt/freehire/.env
+# once the taxonomy backfill (backfill-derive) has finished, so the extra crawl
+# concurrency does not stack on a box already at load ~25.
+#
+# The value 10 is the calibrated default in deploy/bin/ingest-slot.sh; the env
+# file pinned the superseded 8, which is why the fleet skipped ~1111 cycles in
+# 24h against 1008 real runs.
+#
+# No service restart needed: every ingest reads the env file at start.
+set -uo pipefail
+
+LOG=/opt/freehire/slots-bump.log
+ENV=/opt/freehire/.env
+BAK=/opt/freehire/.env.bak-slots-$(date -u +%Y%m%d-%H%M%S)
+
+log() { echo "[$(date -u +%FT%TZ)] $*" >>"$LOG"; }
+
+log "waiting for taxonomy-backfill-night to finish"
+
+# Up to 12h, polled every 5 min. If it outlives that, do nothing and say so:
+# an unattended bump into an unknown machine state is not what was approved.
+for _ in $(seq 1 144); do
+	s=$(systemctl is-active taxonomy-backfill-night.service)
+	if [ "$s" != "active" ] && [ "$s" != "activating" ]; then
+		log "backfill state=$s -> proceeding"
+		break
+	fi
+	sleep 300
+done
+
+s=$(systemctl is-active taxonomy-backfill-night.service)
+if [ "$s" = "active" ] || [ "$s" = "activating" ]; then
+	log "GAVE UP: backfill still $s after 12h, INGEST_SLOTS left at 8"
+	exit 1
+fi
+
+if ! grep -q '^INGEST_SLOTS=8$' "$ENV"; then
+	log "SKIPPED: $ENV no longer holds INGEST_SLOTS=8 (now: $(grep '^INGEST_SLOTS=' "$ENV"))"
+	exit 0
+fi
+
+cp -p "$ENV" "$BAK"
+sed -i 's/^INGEST_SLOTS=8$/INGEST_SLOTS=10/' "$ENV"
+log "applied: $(grep '^INGEST_SLOTS=' "$ENV") (backup $BAK)"
+log "load: $(uptime)"

--- a/deploy/check-drift.sh
+++ b/deploy/check-drift.sh
@@ -16,21 +16,28 @@ here=$(cd "$(dirname "$0")" && pwd)
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 
-# The same two sets deploy/ holds: units without the host's .bak clutter, and the
-# shell scripts without the compiled binaries beside them.
-ssh -o ConnectTimeout=15 "$HOST" '
-  cd /etc/systemd/system && tar cz $(ls -d freehire-* | grep -v "\.bak") 2>/dev/null
-' > "$work/units.tgz"
-ssh -o ConnectTimeout=15 "$HOST" '
-  cd /opt/freehire/bin && tar cz $(ls *.sh | grep -v "\.bak")
-' > "$work/bin.tgz"
+# The same three sets deploy/ holds: units without the host's .bak clutter, the
+# shell scripts without the compiled binaries beside them, and the one nginx
+# snippet that is hand-edited rather than generated. Only that one:
+# freehire-upstream-active.conf is the symlink the flip repoints, so tracking it
+# would report drift after every release and teach the reader to ignore this tool.
+# One set: run a command on the host that writes a tar to stdout, unpack it under
+# the directory of the same name here. Straight through the pipe rather than via a
+# file, so an ssh that fails takes the pipeline with it instead of leaving an empty
+# archive for tar to complain about.
+fetch_set() {
+  mkdir -p "$work/$1"
+  ssh -o ConnectTimeout=15 "$HOST" "$2" | tar xz -C "$work/$1"
+}
 
-mkdir -p "$work/systemd" "$work/bin"
-tar xzf "$work/units.tgz" -C "$work/systemd"
-tar xzf "$work/bin.tgz" -C "$work/bin"
+# shellcheck disable=SC2016  # single quotes on purpose: the $( ) picks the files on the HOST
+fetch_set systemd 'cd /etc/systemd/system && tar cz $(ls -d freehire-* | grep -v "\.bak") 2>/dev/null'
+# shellcheck disable=SC2016  # as above
+fetch_set bin     'cd /opt/freehire/bin && tar cz $(ls *.sh | grep -v "\.bak")'
+fetch_set nginx   'cd /etc/nginx && tar cz snippets/freehire-app.conf'
 
 status=0
-for set in systemd bin; do
+for set in systemd bin nginx; do
   if diff -ru "$here/$set" "$work/$set" > "$work/$set.diff" 2>&1; then
     echo "$set: in sync"
   else

--- a/deploy/nginx/snippets/freehire-app.conf
+++ b/deploy/nginx/snippets/freehire-app.conf
@@ -1,0 +1,118 @@
+# Full apex body for freehire.me (and any domain that serves the app): the shared
+# API-family locations plus the web root proxied to SvelteKit. freehire.dev uses
+# freehire-dev.conf instead (same API paths, but the web root 301s here).
+
+# Log with the Sec-Purpose field so internal/viewlog can tell a hover from a visit
+# — see conf.d/freehire-logformat.conf for what it was miscounting. Set here rather
+# than per server block because this snippet IS the body of every domain that
+# serves job pages, which is the only place the distinction matters.
+#
+# A directive at this (server) level REPLACES the one inherited from http, it does
+# not add a second log — so this changes the format of these lines rather than
+# writing them twice. Other vhosts on the box keep plain `combined`, and the
+# parser's trailing field is optional, so one file holding both shapes is fine.
+access_log /var/log/nginx/access.log combined_purpose;
+
+include /etc/nginx/snippets/freehire-blocklist.conf;
+include /etc/nginx/snippets/freehire-api.conf;
+
+# The XML sitemaps, cached — the one location where a slow origin must not become an
+# absent one. Each file is built from a Postgres read that competes with the ingest for
+# the buffer cache, and that read's latency swings by more than an order of magnitude:
+# on 2026-07-29 /sitemap.xml, the boundaries endpoint and a company chunk all hit the
+# 60s read timeout inside one ten-minute window, then answered in under 5s twenty
+# minutes later. A 504 on /sitemap.xml costs every sub-sitemap it lists, since that
+# index is the only URL robots.txt advertises, and repeated 5xx take the sitemap off
+# Search Console's schedule entirely.
+#
+# `use_stale ... updating` + `background_update` is what fixes it: once a file has been
+# fetched, a crawler is served the previous copy while nginx refreshes it behind them,
+# and a slow or 5xx origin never reaches the crawler. `cache_lock` keeps the ~30 chunk
+# URLs from arriving at Postgres together on a cold cache. The raised read timeout is
+# for that cold case only, where there is no stale copy to fall back to. The app already
+# sends `cache-control: public, max-age=3600`, which nginx honours; proxy_cache_valid is
+# the floor if that header ever goes away. Same pattern as snippets/logo-app.conf.
+# Regex location → takes precedence over the `location /` prefix below.
+location ~ ^/sitemap[^/]*\.xml$ {
+    proxy_pass http://freehire_web;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_cache sitemaps;
+    proxy_cache_key "$host$request_uri";
+    proxy_cache_valid 200 1h;
+    proxy_cache_lock on;
+    proxy_cache_lock_timeout 120s;
+    proxy_cache_background_update on;
+    proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+    proxy_read_timeout 120s;
+    add_header X-Cache-Status $upstream_cache_status always;
+}
+
+# Hashed client assets, served off disk instead of through SvelteKit.
+#
+# Every filename under _app/immutable carries a content hash and goes out with
+# `cache-control: public,max-age=31536000,immutable`, so nothing here needs the
+# app to produce it -- yet routing it through `location /` made it 75% of all
+# requests (482k in the 21:00 UTC hour on 2026-08-14) queueing behind one
+# single-threaded Node process. That queue filling is what the web watchdog kept
+# restarting. hire-current is the symlink release.sh repoints at the active
+# colour, alongside freehire-upstream-active.conf; the @web fallback covers the
+# seconds where the two disagree, and any asset the build did not emit.
+# brotli_static before gzip_static: `vite build` writes a .br beside every .gz, and
+# they were dead weight until the module was installed -- a browser offering
+# `br, gzip` was answered with the gzip copy, ~25% larger (the shared CSS bundle is
+# 20 KB brotli against 26 KB gzip, off 144 KB raw). Needs
+# libnginx-mod-http-brotli-static; without it nginx will not start on this file.
+location ^~ /_app/immutable/ {
+    root /opt/freehire/src/hire-current/web/build/client;
+    brotli_static on;
+    gzip_static on;
+    add_header Cache-Control "public,max-age=31536000,immutable";
+    access_log off;
+    try_files $uri @attic;
+}
+
+# Apple requires application/json on the association file, and the path carries
+# no extension, so SvelteKit's static handler serves it with no Content-Type at
+# all — iOS then discards the association and every HTTPS auth callback fails
+# with "not associated with domain freehire.me". assetlinks.json needs no such
+# help; its .json extension already types it.
+location = /.well-known/apple-app-site-association {
+    proxy_pass http://freehire_web;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_hide_header Content-Type;
+    add_header Content-Type application/json always;
+}
+
+# Chunks from a build that is no longer live. Every name under _app/immutable
+# carries a content hash, so a file kept here can never disagree with the live
+# build about what it contains -- which is exactly why serving one is safe, and
+# why `immutable` was the wrong word for something the deploy threw away. The
+# live directory is reached through `hire-current`, the symlink release.sh
+# repoints in one step, so at the instant of a flip every chunk of the outgoing
+# build stopped existing and a tab open across the release 404d on its next
+# navigation, which SvelteKit draws as the 500 page over an HTTP 200.
+#
+# Not a replacement for the `updated`-driven full-page leave in
+# web/src/routes/+layout.svelte: that one catches the tab that has already
+# noticed a new build, and took these from 265 a day to about 22. This catches
+# the tab that has not noticed yet -- the version poll runs every five minutes
+# and a reader can navigate inside that window, which no client-side guard can
+# close. release.sh copies each build in here and prunes past three days.
+location @attic {
+    root /opt/freehire/asset-attic;
+    brotli_static on;
+    gzip_static on;
+    add_header Cache-Control "public,max-age=31536000,immutable";
+    access_log off;
+    try_files $uri @web;
+}
+
+location @web { proxy_pass http://freehire_web; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto https; }
+
+location /    { limit_req zone=freehire_web burst=50 nodelay; limit_req_status 429; limit_req_log_level error; proxy_pass http://freehire_web; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto https; }


### PR DESCRIPTION
Closes the half of the stale-chunk problem no client-side guard can reach.

### What was happening

nginx serves `/_app/immutable/` off `hire-current` — the symlink `release.sh` repoints in one step. Every filename under there carries a content hash and goes out `immutable, max-age=31536000`, and then the deploy deleted them, because the directory belonged to a *colour* rather than to the site.

So at the instant of a flip, every chunk of the outgoing build stopped existing. A tab open across the release 404'd on its next navigation, which SvelteKit draws as the 500 page over an HTTP 200.

Four chunk names taken straight from Sentry, checked against production:

```
nodes/0.Ri-AEfqs.js          404
nodes/1.5WW8_70v.js          404
nodes/47.DbqkTJw9.js         404
chunks/s-IiOAS_.js           404
```

### Not a redo of the existing fix

`web/src/routes/+layout.svelte` already leaves through a full page load once `updated` reports a new build, and that took these from 265 a day to about 22. What it cannot reach is a reader navigating inside the five-minute version poll — the tab does not yet know there is anything to know.

Both halves stay. The client one also covers a tab older than the attic's three days.

### Why keeping the files is safe

A content hash is a promise that a name and its bytes cannot come apart. A copy kept from an older build can never disagree with a live one about what it contains — which is what makes deleting them the odd act, not keeping them.

39 MB a build, pruned past three days, against 68 GB free.

### Already applied and verified on the host

The attic and the nginx change are live (this PR records them; nothing in `deploy/` deploys itself). Verified against production after the reload:

- a chunk present **only** in the attic, deleted from the live build → `200`, `cache-control: public,max-age=31536000,immutable`, `content-encoding: br` (50 KB → 13 KB)
- a chunk that never existed → still `404`
- `/`, `/jobs`, `/companies`, `/health` → `200`
- `nginx -t` passed before the reload; the previous snippet is backed up beside it

`release.sh` was patched on the host too, so the attic refills itself from the next release on. `bash -n` clean, and the copy is non-fatal by design: a release that cannot fill the attic is still a good release.

### check-drift grows a third set

`snippets/freehire-app.conf` was the last load-bearing file on that host whose only copy was the machine, and this change made it more load-bearing, not less.

Only that one file. `freehire-upstream-active.conf` is the symlink the flip repoints, so tracking it would report drift after every release and teach the reader to ignore the tool.

### Drift that arrived with it

`release.sh` had to be re-taken from the host, so it brings host-side work that never reached git: the `flock` release lock, corrections to the `cmd/` build list, and the `auto-apply-orchestrate` port env written after the flip. Recording it is what this directory is for — it is here because of how the file was obtained, not as part of this change.

`pg-backup.sh` and two host-only scripts (`semantic-drop-closed.sh`, `slots-bump-once.sh`) are synced for the same reason, so `bin` and `nginx` both report in sync.

**Left alone:** `systemd` is still 802 lines drifted. That is 337 unit files I have not read, and sweeping them in would bury this change under a diff nobody can review. Worth its own pass.

### Verification

- `shellcheck` on every changed and added script — clean
- `bash -n` on `release.sh` and `check-drift.sh`
- `./deploy/check-drift.sh` → `bin: in sync`, `nginx: in sync`
- `pnpm check:links` → 290 relative links, all resolve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved delivery of web assets with long-lived caching and fallback support for older browser sessions.
  - Added optimized sitemap handling, including caching and background refresh.
  - Added Apple App Site Association support with the correct JSON content type.

- **Bug Fixes**
  - Releases now prevent overlapping deployments and improve worker restart sequencing.
  - Backup uploads are verified before local copies are removed.

- **Chores**
  - Deployment checks now include nginx configuration to detect configuration drift.
  - Added operational tooling for maintenance and controlled capacity updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->