### PR TITLE
Let one threshold decide whether the box has a query yet

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -350,6 +350,13 @@ export function createApi(
     };
     // Assigned after the spread, so a timeout is added to the init rather than
     // substituted for it. A caller that brought its own signal keeps it.
+    //
+    // `== null` is LOAD-BEARING, not a loose-equality slip: the abortable reads
+    // (searchJobs/suggest/listCompanies) pass `{ signal }` unconditionally, so a caller
+    // that named no signal arrives here with `signal: undefined` rather than with no
+    // `signal` key at all. Tighten this to `===` and those three quietly stop getting
+    // the SSR timeout above — which is the ~8 `+page.server.ts` callers, and exactly the
+    // failure that comment describes.
     const timeout = timeoutMs != null && request.signal == null ? AbortSignal.timeout(timeoutMs) : undefined;
     if (timeout) {
       request.signal = timeout;

--- a/web/src/lib/components/HeaderSearch.svelte
+++ b/web/src/lib/components/HeaderSearch.svelte
@@ -26,9 +26,9 @@
   // The header's search box — the ONE of them, on every page.
   //
   // There were two: this, which filtered the list under it, and a launcher on every
-  // other page, which navigated to the feed. They shared the debounce, the
-  // stale-response token, the arrow keys, the hotkeys, the dismissal and the row
-  // rendering, in two copies, and differed in exactly one thing: what a pick DOES. So
+  // other page, which navigated to the feed. They shared the debounce, the stale-answer
+  // guard, the arrow keys, the hotkeys, the dismissal and the row rendering, in two
+  // copies, and differed in exactly one thing: what a pick DOES. So
   // that one thing is a target now (see `target` below), and everything else is
   // written once.
   //
@@ -217,25 +217,35 @@
     return () => clearTimeout(timer);
   });
 
-  // An empty box offers the catalogue's shape; a typed one offers what matches.
+  // A box with nothing to complete offers the catalogue's shape; a typed one offers
+  // what matches.
   //
-  // The empty case is the whole point of opening on focus, and it is answered LOCALLY:
+  // The first case is the whole point of opening on focus, and it is answered LOCALLY:
   // the curated group order lives in the filter modal's own grouping, checked there
   // against the category vocabulary at compile time, so asking a server for it would
   // be a second copy of that order. The typed case is the endpoint's — it completes a
   // phrase against the catalogue's real vocabulary, which no dictionary shipped to the
   // browser can do.
+  //
+  // The threshold is SUGGEST_MIN_CHARS, the same one the fetch below gates on, and
+  // deliberately not a separate `=== ''`. Two thresholds opened a state nobody designed:
+  // at exactly one character the box was past "empty" but short of "asked", so it showed
+  // neither the starters nor completions it had not fetched — a ten-row panel collapsing
+  // to the single free-text row, then refilling on the next keystroke. One predicate
+  // answers "is there a query yet", so there is no gap for a state to fall into.
   const starters = $derived(suggest ? starterSuggestions(suggest.counts()) : []);
   let completions = $state.raw<Suggestion[]>([]);
-  const suggestions = $derived(settledQuery.trim() === '' ? starters : completions);
+  const suggestions = $derived(
+    settledQuery.trim().length < SUGGEST_MIN_CHARS ? starters : completions,
+  );
   // The parts each completion applies, by row key — kept beside the rows rather than
   // inside them because a Suggestion is what the dropdown RENDERS, and these are what
   // choosing it DOES.
   let completionParts = $state.raw(new Map<string, ApiSuggestionPart[]>());
   // Postings and companies for the typed text, fetched exactly the way the launcher
-  // dropdown (HeaderSearch) fetches them — same endpoints, same stale-response token,
-  // same row rendering below. A second implementation of "show me matching jobs" is
-  // how the two would drift.
+  // dropdown (HeaderSearch) fetches them — same endpoints, same abandonment rule, same
+  // row rendering below. A second implementation of "show me matching jobs" is how the
+  // two would drift.
   //
   // These matter MORE now than before, not less: the list below no longer narrows as
   // you type, so these rows are the only live evidence the query finds anything.
@@ -330,8 +340,9 @@
     // The box may have moved on while the intake was out: a paste over the old text, or
     // the text cleared entirely. The answer is about the URL we asked with, so applying
     // it now would navigate to a posting nobody is asking about any more — the same
-    // stale-response hazard the suggestion fetches guard with `previewToken`, answered
-    // here by the question itself rather than by a counter.
+    // stale-answer hazard the suggestion fetches guard with their AbortController, held
+    // off here by comparing the question instead, because this runs from a click rather
+    // than from an effect with a cleanup to hang the abort on.
     if (link?.url !== pasted.url) return;
     if (step.kind === 'open') {
       openPosting(step.slug);


### PR DESCRIPTION
Fixes a regression #2456 introduced, found by a two-axis code review of #2456 +
#2458. Both axes reached the main finding independently.

## The regression

#2456 added a minimum query length — but only to the **fetch** gate. The
**render** gate was left alone:

```ts
const suggestions = $derived(settledQuery.trim() === '' ? starters : completions);  // unchanged
if (q.length < SUGGEST_MIN_CHARS || !suggest) { completions = []; jobs = []; ... }  // new
```

At exactly one character the box is past `''` (so no `starters`) and short of 2
(so `completions`, `jobs` and `companies` were just cleared). `dropdownRows` then
emits only the free-text row.

**What a visitor saw:** open the box → ten rows. Type `C` → **one row**. Type `#`
→ ten rows again. And `C` / `R`, which are real queries, never got suggestions.

One threshold now answers "is there a query yet", so there is no gap for a state
to fall into. A one-character box keeps the starters and still asks the server
nothing — which is what the floor was for.

## Cleaning up what #2456 orphaned

`previewToken` was deleted; three comments still described it.

| Line | Was | Now |
|---|---|---|
| `HeaderSearch:30` | "they shared … the stale-response **token**" | "the stale-answer **guard**" |
| `HeaderSearch:236` | "same endpoints, same stale-response **token**" | "same **abandonment rule**" |
| `HeaderSearch:333` | "the hazard the suggestion fetches guard with **`previewToken`**" | names the AbortController, and says why the link intake compares the question instead: it runs from a click, with no effect cleanup to hang an abort on |

`AGENTS.md` → *Surgical changes: clean up what your change orphaned.*

## Recording a load-bearing detail

`call()`'s guard must stay loose:

```ts
const timeout = timeoutMs != null && request.signal == null ? AbortSignal.timeout(timeoutMs) : undefined;
```

The three abortable reads pass `{ signal }` **unconditionally**, so a caller that
named no signal arrives with `signal: undefined` rather than without the key.
Tightening to `===` — which is exactly what an `eqeqeq` sweep would do — silently
drops the SSR timeout for the ~8 `+page.server.ts` callers, the failure the
comment beside it already describes. Nothing recorded that dependency; now
something does.

## Known gap, deliberately not closed

The abort fires on the next settled query and on unmount. It does **not** fire when
the visitor closes the box (`close()` sets `dismissed`, which the fetch effect
does not read) or navigates (`TopBar` is mounted in the layout, so it never
unmounts). Making the effect read `dismissed` would abort on close but refetch on
every reopen — roughly a wash, plausibly worse. Left as is, on purpose.

## Verification

- `pnpm check` — 0 errors (34 pre-existing warnings, unchanged)
- `pnpm lint` — 0 errors
- `pnpm test` — 133 files, 1506 tests, green
