### PR TITLE
Record cmd/auto-apply's deploy provisioning (never actually deployed)

### DIFF
--- a/deploy/systemd/freehire-auto-apply.service
+++ b/deploy/systemd/freehire-auto-apply.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=freehire worker: drain auto_apply_queue (headless Chrome fill+submit)
+After=network.target postgresql.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+# Headless Chrome + a real page load/fill/submit per entry, so this is heavier per-item
+# than any other timer-driven drain in this fleet — AUTO_APPLY_CONCURRENCY's own default
+# (2) is deliberately conservative until real host2 volume is observed, same posture
+# capture-apply-form started from.
+CPUWeight=40
+IOWeight=40
+ExecStart=/opt/freehire/src/hire-current/auto-apply

--- a/deploy/systemd/freehire-auto-apply.timer
+++ b/deploy/systemd/freehire-auto-apply.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=timer: freehire-auto-apply
+[Timer]
+OnCalendar=*:0/5
+Persistent=true
+RandomizedDelaySec=60
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Found live on host2 while verifying the auto-apply feature end-to-end: `cmd/auto-apply` (drains `auto_apply_queue` via headless Chrome, fill+submit) was never in `release.sh`'s build list and had no systemd unit at all. An approved auto-apply entry would sit in the queue forever with nothing to claim and submit it.

Already fixed live on host2 and in `freehire-ops` (build target added, `freehire-auto-apply.service` oneshot + 5-minute timer provisioned, `google-chrome-stable` installed since `chromium-browser` on Ubuntu 24.04 is a snap-wrapped transitional package known to fight headless automation). This PR just mirrors that into `hire`'s own `deploy/` record, matching the existing convention for `auto-apply-orchestrate`.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go build ./...`
- [x] Verified live: `cmd/auto-apply` binary builds and runs on host2, Chrome launches headless under the `freehire` user, systemd timer is enabled and active

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated processing for approved queue entries.
  * Processing runs every five minutes, with missed runs recovered automatically.
  * Added a dedicated background service for headless browser-based submissions.
* **Bug Fixes**
  * Ensured the auto-apply worker is rebuilt and included in releases, preventing approved entries from remaining unprocessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->