### PR TITLE
Let the type scale carry the chip line-height, and aim the overflow rule at what needs it

### DIFF
--- a/extension/entrypoints/sidepanel/ToolGroupList.svelte
+++ b/extension/entrypoints/sidepanel/ToolGroupList.svelte
@@ -76,8 +76,11 @@
     background: var(--muted);
     border: 1px solid var(--border);
     border-radius: 8px;
-    /* The summary's hover fill runs to the card's edge; without this it squares off
-       the two top corners. */
+  }
+
+  /* The summary's hover fill runs to the card's edge; without this it squares off the
+     two top corners. Only the expandable card has a summary to fill. */
+  details.tool {
     overflow: hidden;
   }
 

--- a/web/src/lib/assistant/ToolGroupList.svelte
+++ b/web/src/lib/assistant/ToolGroupList.svelte
@@ -44,7 +44,7 @@
   // One chip shape for both the flat card and the expandable summary, so the two never
   // drift apart by a padding step. The expandable one adds only its hover affordance.
   const chip =
-    'self-start inline-flex items-center gap-2 rounded-lg border border-border/60 bg-muted/40 px-2.5 py-1.5 text-sm leading-5 text-muted-foreground';
+    'self-start inline-flex items-center gap-2 rounded-lg border border-border/60 bg-muted/40 px-2.5 py-1.5 text-sm text-muted-foreground';
 </script>
 
 {#each groupTools(calls) as g, t (t)}

--- a/web/src/lib/assistant/tool-formatters.ts
+++ b/web/src/lib/assistant/tool-formatters.ts
@@ -47,7 +47,6 @@ const LABELS: Record<string, string> = {
   screening_answers_set: 'Saving screening answers',
   interview_context: 'Reading the interview brief',
   request_confirmation: 'Asking you to confirm',
-  read_current_page: 'Reading the page you are on',
   experience_search: 'Searching your experience',
   experience_get: 'Reading an achievement',
   experience_add: 'Banking an achievement',


### PR DESCRIPTION
A quality pass over #2460. Two leftovers, no behaviour change.

- **`leading-5` restated `text-sm`.** Tailwind's `text-sm` already sets a 1.25rem line-height, so the chip carried the same number twice — and on a scale change the pair could drift apart with nothing to say which one won.
- **`overflow: hidden` was aimed wider than its reason.** It exists because the summary's hover fill reaches the card's rounded corner; only the expandable chip has a summary. The selector now matches the comment beside it.

## What I deliberately left alone

The label map is duplicated between `web/` and `extension/`, and about half the entries in the extension's copy are for tools its `browse` preset never registers (`assistant_tools.go:359` — inbox is chat-only, the CV tools are tailor-only). Both are tempting to "fix" and both are worse ideas than they look:

- Which tools a preset registers is the **backend's** business and it changes — `browse` has already gained the discovery, tracking, experience and screening sets. A map pruned to today's registry regresses the moment it gains another. A spare entry costs one line and nothing at runtime.
- Sharing one module between the two packages is an architecture change (npm vs pnpm, no shared boundary today), not a cleanup.

## Verification

- `pnpm vitest run src/lib/assistant` — 144 passed; `npx vitest run lib/assistant` — 81 passed. Neither suite reaches these two files: web/ runs vitest in plain Node with no DOM, so the `.svelte` markup is covered by `svelte-check` and the token ratchet instead, both of which pass.
- `node design-system/scripts/check-token-coverage.mjs` — clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined tool call card styling in the side panel and web interface.
  - Improved overflow handling for expandable tool cards.
  - Simplified line-height styling to use inherited values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->