### PR TITLE
Answer the product review: a role to type, an AI filter a phone can reach, a board a bookmark lands on

### DIFF
--- a/openspec/changes/onboarding-feedback-pass/.openspec.yaml
+++ b/openspec/changes/onboarding-feedback-pass/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/onboarding-feedback-pass/design.md
+++ b/openspec/changes/onboarding-feedback-pass/design.md
@@ -1,0 +1,117 @@
+# Design
+
+## Decision 1: the placeholder list is keys, not strings
+
+`web/src/lib/placeholderRoles.ts` holds a `Category[]` drawn from the generated
+`CATEGORY_VALUES` contract; labels resolve through `categoryLabel()`.
+
+A hand-written `['QA', 'DevOps']` would be a second copy of a vocabulary the backend
+already owns, and it would rot silently — a category renamed or retired upstream leaves
+the placeholder confidently offering a value the feed can no longer filter on. Typing the
+array as `Category[]` turns that into a build failure, which is the same guard
+`CATEGORY_LABELS` already uses (`satisfies Record<Category, string>`), for the same
+reason. AGENTS.md is explicit about the cost of the alternative: one vocabulary existed in
+four copies, they disagreed, and every resulting miss was silent.
+
+The module composes whole placeholder strings (`Search jobs — e.g. Backend`) rather than
+exposing bare labels and letting the component interpolate. The phrasing is then testable
+and lives in one place, and `HeaderSearch` stays a box that renders what it is handed —
+it does not learn that one of its callers is about jobs.
+
+Order: `backend → frontend → devops → qa → data_science → product`. Busiest first, because
+under `prefers-reduced-motion` the first entry is the only one anyone sees.
+
+## Decision 2: three guards, all required
+
+**Rotation stops at the first interaction and never restarts.** Text moving under the
+cursor while someone composes a query is the failure mode an animated placeholder invites.
+Once stopped the placeholder freezes on the entry currently shown rather than reverting to
+a static string — reverting would be a visible jump at the exact moment the visitor's
+attention is on the field.
+
+**`prefers-reduced-motion` disables it.** Renders the first entry and holds. Fifteen
+components in `web/` already honour this; the detection follows the existing
+`window.matchMedia('(prefers-reduced-motion: reduce)')` pattern
+(`AuthBrandPanel.svelte`, `SourcesField.svelte`) rather than inventing a switch.
+
+**The accessible name stays still.** `HeaderSearch.svelte` passes one prop to both
+`placeholder` and `aria-label`, so a rotating placeholder would rotate the field's *name*
+— a screen reader would announce the input as `Search jobs — e.g. QA`. The prop splits
+into `placeholder` (the example, may move) and `label` (the honest, static name). `label`
+is required rather than defaulting to `placeholder`: a default would silently reinstate
+the trap at the next call site, and there are only two.
+
+The fade is a `::placeholder` colour transition. An absolutely-positioned overlay span
+would give finer control and would also put a second element inside the box's flex row,
+where the real input, the location prefix, the clear button and the filters trigger
+already negotiate width — a layout risk taken for a cosmetic gain.
+
+## Decision 3: saved-on-the-board is a read-side change
+
+`JobBoard.svelte`'s `build()` drops rows whose `columnOf` returns null, and saved-only
+rows are exactly those. Mapping them to `preparing` is one line and needs no migration, no
+dual write, and no backfill: it applies retroactively to every bookmark, and the rollback
+is the same line.
+
+The alternative — having the new button write `stage='preparing'` explicitly — would leave
+old bookmarks and new ones behaving differently forever, and would put the same fact in two
+places (a `saved_at` and a stage that merely restates it).
+
+**Accepted risk.** The board fetches at most 500 rows and saved rows count toward that cap.
+`JobBoard.svelte`'s own comment already records this. Rendering the rows makes an existing
+consequence visible rather than creating it: a user with hundreds of bookmarks may push
+older applications outside the window. That comment is updated in place — a second note
+elsewhere would be a second answer to one question. The escape hatch it already names is a
+server-side board-minus-saved filter, and that stays the fix if this bites.
+
+## Decision 4: the completeness card lives on /my/tracking
+
+`/my` is a 308 redirect to `/my/tracking`, not a page. The card goes where people already
+land; inventing an account home to host it would be building infrastructure ahead of a
+need, and the redirect exists precisely because there was nothing to put there.
+
+Five steps, all readable from stores that already exist — **no new endpoint**:
+
+| Step | Source |
+|---|---|
+| CV uploaded | `resumeStore` |
+| Specialization and seniority | `profileStore` |
+| Skills | `profileStore` |
+| Location and work mode | `profileStore` |
+| A saved search with an alert | `api.savedSearches()` |
+
+The first four are the onboarding wizard's own steps (`cv`, `confirm`, `skills`,
+`location`), so the card measures the same thing the funnel asked for and cannot drift
+from it. The fifth is what makes the product act on its own — jobs arriving without a
+visit — and is the one step the reviewer did not name. It is included because a
+completeness meter that ends at a filled-in form measures paperwork, not activation.
+
+The calculation is a pure module (`web/src/lib/accountCompleteness.ts`) taking the three
+inputs and returning the step list with a done flag each, so it is unit-testable in plain
+Node like `facetModel.ts` and `suggestions.ts` beside it.
+
+The dot sits on the avatar, beside the notification bell. Two signals compete for that
+corner; the bell wins on urgency, so the completeness dot never carries a count and is the
+quieter of the two.
+
+## Testing
+
+Pure modules carry unit tests, matching how `facetModel.ts` and `suggestions.ts` are
+covered:
+
+- `placeholderRoles.ts` — the list is non-empty and unique, every key resolves to a
+  non-empty label, and every composed string carries its label.
+- `accountCompleteness.ts` — each step's predicate, a fully-populated account reporting
+  complete, and an empty account reporting every step open.
+- `columnOf` — a saved row with no stage lands in `preparing`; an explicit stage still
+  wins.
+
+The rotation timer, the button and the card are component-level and are verified in the
+browser rather than with tests that would only restate the implementation.
+
+## Out of scope
+
+- `PUBLIC_MATCH_SORT` on production — an ops check, recorded so it is not lost.
+- Any change to what `save` means on the server. Saving still writes `saved_at` and
+  nothing else.
+- The companies search placeholder. It is not a role box.

--- a/openspec/changes/onboarding-feedback-pass/proposal.md
+++ b/openspec/changes/onboarding-feedback-pass/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+An outside reviewer walked the product and left five notes. Four describe surfaces that
+already exist but cannot be reached, or reach only one hand:
+
+1. Search is not prominent enough, and the default feed is not relevant until a visitor
+   sets filters.
+2. The search box gives no example of what to type.
+3. Navigation is confusing; the AI filter eats the last column.
+4. There is no "how complete is my account" funnel after onboarding.
+5. There is no way to track a job *before* applying to it.
+
+Note 5 is the instructive one: the state it asks for already exists. `preparing` is a
+real stage and the board's first column (`internal/application/userjob/groups.go`),
+added for CV tailoring. Nothing in the jobs feed can put a posting into it.
+
+Note 3 hides a second defect. `AiFilterButton` renders inside the filters sidebar, and
+that sidebar is `<aside class="hidden w-72 shrink-0 md:block">` — so the AI filter does
+not exist on a phone at all today. Moving it into the modal frees the column the note
+asks about *and* gives the feature to mobile for the first time.
+
+Note 1 splits in two. The homepage search already IS the hero, full-bleed and
+autofocused. What remains is the default ordering: `defaultSortFor('')` returns `newest`
+for everyone. The match sort that would fix it is written and gated behind
+`PUBLIC_MATCH_SORT`. Flipping that flag is an operational question, not a code change,
+and is deliberately out of scope here.
+
+## What Changes
+
+- **A rotating role placeholder.** The jobs search box shows `Search jobs — e.g. Backend`
+  and cycles the trailing word. The rotation stops permanently at the first focus or
+  keystroke, is disabled under `prefers-reduced-motion`, and never moves the field's
+  accessible name — `HeaderSearch` currently passes one prop to both `placeholder` and
+  `aria-label`, so the props split.
+- **The AI filter moves into the filter modal** and leaves the sidebar.
+- **Saving a job puts it on the tracking board.** The board's client-side `build()` is
+  what discards saved-only rows today, so this is a read-side change: no migration, no
+  new write, and it applies to every bookmark ever made. The card's icon-only bookmark
+  becomes a labelled primary button.
+- **An account-completeness card** at the top of `/my/tracking`, plus a quiet dot on the
+  header avatar while any step is open. Five steps, all readable from stores that already
+  exist — no new API endpoint.
+
+## Impact
+
+- Affected specs: `search-role-placeholder` (new), `ai-filter-entry`,
+  `user-job-tracking`, `account-completeness` (new)
+- Affected code: `web/src/lib/components/HeaderSearch.svelte`, `TopBar.svelte`,
+  `HomeLandingView.svelte`, `JobRow.svelte`, `JobBoard.svelte`,
+  `filters/FilterSummary.svelte`, `filters/FilterModal.svelte`, `HeaderMenu.svelte`,
+  `web/src/routes/my/tracking/`, plus two new pure modules under `web/src/lib/`
+- No backend, no schema, no new endpoint

--- a/openspec/changes/onboarding-feedback-pass/specs/account-completeness/spec.md
+++ b/openspec/changes/onboarding-feedback-pass/specs/account-completeness/spec.md
@@ -36,10 +36,18 @@ endpoint.
 
 ### Requirement: A quiet dot marks incomplete setup from anywhere
 
-While any setup step is outstanding, the header account control SHALL carry a dot.
+While any setup step is outstanding, the header menu button SHALL carry a dot.
+
+The menu button, not the profile icon beside it: that icon is hidden below the `sm`
+breakpoint, so on a phone it is not there to carry anything, and the menu button is the
+one account control present at every width.
 
 The dot SHALL NOT carry a count. The notification bell sits in the same corner and wins on
 urgency; a second counted badge beside it would make two signals compete for one glance.
+
+Its screen-reader equivalent SHALL be part of the button's own accessible name. An
+aria-label replaces an element's contents as its name, so a visually-hidden span inside
+the button would never be read.
 
 #### Scenario: The dot marks an incomplete account
 

--- a/openspec/changes/onboarding-feedback-pass/specs/account-completeness/spec.md
+++ b/openspec/changes/onboarding-feedback-pass/specs/account-completeness/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: The account area shows what is left to set up
+
+The account area SHALL show a card listing the setup steps an account has not yet
+completed, with a link to each, and SHALL stop showing it once every step is done.
+
+The card SHALL be rendered at the top of the tracking section — the page a bare `/my`
+already redirects to — rather than on an account landing page created to host it.
+
+The steps SHALL be: a CV uploaded, a specialization and seniority, skills, location and
+work mode, and one saved search with an alert.
+
+The first four are the onboarding wizard's own steps, so the card measures the same thing
+the funnel asked for and cannot drift from it. The fifth is what makes the product act
+without a visit; a completeness meter that ends at a filled-in form measures paperwork
+rather than activation.
+
+The calculation SHALL read only state the client already holds, and SHALL NOT require a new
+endpoint.
+
+#### Scenario: A new account sees every step open
+
+- **WHEN** a user who has completed no setup opens the tracking section
+- **THEN** the card lists all five steps as outstanding, each linking to where it is done
+
+#### Scenario: The card disappears when complete
+
+- **WHEN** the last outstanding step is completed
+- **THEN** the card is no longer rendered
+
+#### Scenario: Completed steps are not re-asked
+
+- **WHEN** a user has uploaded a CV but set no skills
+- **THEN** the CV step reads as done and the skills step reads as outstanding
+
+### Requirement: A quiet dot marks incomplete setup from anywhere
+
+While any setup step is outstanding, the header account control SHALL carry a dot.
+
+The dot SHALL NOT carry a count. The notification bell sits in the same corner and wins on
+urgency; a second counted badge beside it would make two signals compete for one glance.
+
+#### Scenario: The dot marks an incomplete account
+
+- **WHEN** a signed-in user with outstanding steps is on any page
+- **THEN** the header account control shows a dot with no number
+
+#### Scenario: The dot clears on completion
+
+- **WHEN** the account's last outstanding step is completed
+- **THEN** the dot is no longer shown

--- a/openspec/changes/onboarding-feedback-pass/specs/ai-filter-entry/spec.md
+++ b/openspec/changes/onboarding-feedback-pass/specs/ai-filter-entry/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: The AI filter is entered from the filter modal at every viewport width
+
+The "describe your filters in words" entry point SHALL be rendered inside the filters
+modal, and SHALL NOT be rendered in the desktop filters sidebar.
+
+The sidebar is hidden below the `md` breakpoint, so an entry point that lives only there
+does not exist on a phone. The modal opens at every width, so hosting the entry there both
+frees the sidebar column and gives the feature to mobile.
+
+The entry point SHALL remain visible to signed-out visitors, with activation prompting
+sign-in — hiding it from them would hide the feature from exactly the people who have not
+yet been given a reason to sign in.
+
+#### Scenario: A phone reaches the AI filter
+
+- **WHEN** a visitor on a sub-`md` viewport opens the filters modal
+- **THEN** the AI filter entry point is present and activates the same dialog desktop uses
+
+#### Scenario: The sidebar no longer carries it
+
+- **WHEN** a visitor on a desktop viewport views the filters sidebar
+- **THEN** the AI filter entry point is not there, and the column it occupied is free
+
+#### Scenario: A signed-out visitor is prompted rather than hidden from
+
+- **WHEN** a signed-out visitor activates the AI filter entry point
+- **THEN** the sign-in prompt opens, rather than the entry point having been absent

--- a/openspec/changes/onboarding-feedback-pass/specs/ai-filter-entry/spec.md
+++ b/openspec/changes/onboarding-feedback-pass/specs/ai-filter-entry/spec.md
@@ -13,6 +13,14 @@ The entry point SHALL remain visible to signed-out visitors, with activation pro
 sign-in — hiding it from them would hide the feature from exactly the people who have not
 yet been given a reason to sign in.
 
+It SHALL appear only where the modal edits a LIVE filter store — every surface that
+carried it in the sidebar, and no more. Two modals are therefore without it, both
+correctly: the profile editor, where a facet value is a plain choice rather than a search,
+and the homepage, which composes a query to navigate with instead of narrowing a list in
+front of the visitor. Giving the homepage one would mean inventing a second way for the
+interpretation to be applied; that is a feature, not this change, and it was not in the
+sidebar either.
+
 #### Scenario: A phone reaches the AI filter
 
 - **WHEN** a visitor on a sub-`md` viewport opens the filters modal

--- a/openspec/changes/onboarding-feedback-pass/specs/search-role-placeholder/spec.md
+++ b/openspec/changes/onboarding-feedback-pass/specs/search-role-placeholder/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: The jobs search box offers rotating role examples
+
+The jobs search box SHALL show an example of what to type, phrased as
+`Search jobs — e.g. <role>`, and SHALL cycle the trailing role on a fixed interval.
+
+The roles SHALL be drawn from the generated category vocabulary as typed keys, never as
+hand-written display strings, so that a category renamed or retired on the backend fails
+the build rather than leaving the box offering a value the feed can no longer filter on.
+Their labels SHALL resolve through the one existing category-label map.
+
+The rotation order SHALL place the busiest role first, because under reduced motion the
+first entry is the only one shown.
+
+The companies search box SHALL keep its static placeholder — it is not a role box.
+
+#### Scenario: The box cycles roles while untouched
+
+- **WHEN** a visitor loads a page carrying the jobs search box and does not interact with it
+- **THEN** the placeholder's trailing role advances on each interval, fading between entries
+
+#### Scenario: A retired category fails the build
+
+- **WHEN** a category named in the placeholder list is removed from the backend vocabulary
+      and the contracts are regenerated
+- **THEN** the type check fails naming that key, rather than the box continuing to offer it
+
+### Requirement: Rotation stops at the first interaction and never restarts
+
+The rotation SHALL stop permanently for the remainder of the visit at the first focus or
+keystroke on the field, and SHALL freeze on the entry currently displayed rather than
+reverting to a static string.
+
+Text moving under the cursor while a query is being composed is the failure an animated
+placeholder invites; reverting on stop would be a visible jump at the moment the visitor's
+attention is on the field.
+
+#### Scenario: Focus stops the rotation
+
+- **WHEN** a visitor focuses the search field while it is empty
+- **THEN** the placeholder stops advancing, holds the entry it was showing, and does not
+      resume when focus leaves
+
+#### Scenario: Typing stops the rotation
+
+- **WHEN** a visitor types into the field
+- **THEN** the placeholder stops advancing for the rest of the visit
+
+### Requirement: Reduced motion disables the rotation
+
+Where the user agent reports `prefers-reduced-motion: reduce`, the box SHALL render the
+first entry and SHALL NOT start a rotation timer.
+
+#### Scenario: Reduced motion holds the first entry
+
+- **WHEN** a visitor with `prefers-reduced-motion: reduce` loads the box
+- **THEN** the placeholder shows the first role and never changes
+
+### Requirement: The field's accessible name does not move
+
+The search field's accessible name SHALL be a static string describing the field, and SHALL
+NOT be derived from the rotating placeholder.
+
+The search component SHALL take the visible example and the accessible name as separate
+inputs, and the accessible name SHALL be required of every caller rather than defaulting to
+the example — a default would silently reinstate the coupling at the next call site.
+
+#### Scenario: A screen reader announces a stable field name
+
+- **WHEN** a screen-reader user reaches the jobs search field at any point in the rotation
+- **THEN** the field is announced by its static name, not by the currently shown example

--- a/openspec/changes/onboarding-feedback-pass/specs/search-role-placeholder/spec.md
+++ b/openspec/changes/onboarding-feedback-pass/specs/search-role-placeholder/spec.md
@@ -50,12 +50,23 @@ attention is on the field.
 ### Requirement: Reduced motion disables the rotation
 
 Where the user agent reports `prefers-reduced-motion: reduce`, the box SHALL render the
-first entry and SHALL NOT start a rotation timer.
+first entry and SHALL NOT start a rotation timer. The preference SHALL be re-read while
+the page is open, not sampled once.
+
+A visitor who enables the preference mid-visit SHALL keep the entry then displayed rather
+than being returned to the first one. Snapping back is itself a movement, and it would
+arrive at the exact moment somebody asked for less of it; the rule matches the freeze that
+already applies when the rotation is stopped by an interaction.
 
 #### Scenario: Reduced motion holds the first entry
 
 - **WHEN** a visitor with `prefers-reduced-motion: reduce` loads the box
 - **THEN** the placeholder shows the first role and never changes
+
+#### Scenario: Enabling reduced motion mid-visit stops without a jump
+
+- **WHEN** a visitor enables the preference while the box has already advanced
+- **THEN** the rotation stops on the entry then shown, and no further entry appears
 
 ### Requirement: The field's accessible name does not move
 

--- a/openspec/changes/onboarding-feedback-pass/specs/user-job-tracking/spec.md
+++ b/openspec/changes/onboarding-feedback-pass/specs/user-job-tracking/spec.md
@@ -33,7 +33,14 @@ An explicit stage SHALL continue to decide the column — a saved row that has b
 ### Requirement: Saving is a primary, labelled action on a job card
 
 The save control on a job card SHALL be a labelled button rather than an icon-only overlay,
-and SHALL read as the card's primary action.
+and SHALL read as the card's primary action. The label SHALL name the state the job is in
+rather than the action performed, since a long feed has to answer "is this one already
+mine" at a glance.
+
+The narrow-column card — the one the assistant chat renders, at roughly 360px — is
+exempt and keeps the icon-only overlay. That card drops the blurb and shortens the title
+for the same reason; a control that earns a word on a full card has to give it back
+there. The exemption is by card width, not by surface, so no caller opts into it.
 
 The control SHALL remain outside the card's link element so that activating it never
 navigates to the posting.

--- a/openspec/changes/onboarding-feedback-pass/specs/user-job-tracking/spec.md
+++ b/openspec/changes/onboarding-feedback-pass/specs/user-job-tracking/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: A saved job appears on the tracking board as Preparing
+
+A tracked row that carries a saved mark and no application stage SHALL be presented on the
+tracking board in the `preparing` column.
+
+This is a presentation rule, not a write: saving a job SHALL continue to record only the
+saved mark, and no stage SHALL be written on the visitor's behalf. The board previously
+discarded these rows when laying out its columns; placing them costs no migration, no
+backfill and no second write, and applies to every job saved before the change as well as
+after.
+
+An explicit stage SHALL continue to decide the column — a saved row that has been moved to
+`interview` stays in `interview`.
+
+#### Scenario: An existing bookmark appears on the board
+
+- **WHEN** a user who saved jobs before this change opens the tracking board
+- **THEN** those jobs appear as cards in the Preparing column, without any migration having
+      run
+
+#### Scenario: An explicit stage still wins
+
+- **WHEN** a saved job also carries an application stage
+- **THEN** the board places it by that stage, not in Preparing
+
+#### Scenario: Saving writes no stage
+
+- **WHEN** a user saves a job
+- **THEN** only the saved mark is recorded, and no application stage is written
+
+### Requirement: Saving is a primary, labelled action on a job card
+
+The save control on a job card SHALL be a labelled button rather than an icon-only overlay,
+and SHALL read as the card's primary action.
+
+The control SHALL remain outside the card's link element so that activating it never
+navigates to the posting.
+
+#### Scenario: The control is legible without hovering
+
+- **WHEN** a visitor sees a job card in the feed
+- **THEN** the save action is a labelled button, not an unlabelled glyph
+
+#### Scenario: Saving does not navigate
+
+- **WHEN** a visitor activates the save control on a card
+- **THEN** the job is saved and the browser does not navigate to the posting

--- a/openspec/changes/onboarding-feedback-pass/tasks.md
+++ b/openspec/changes/onboarding-feedback-pass/tasks.md
@@ -8,7 +8,10 @@
 - [x] 1.3 Split `HeaderSearch.svelte`'s `placeholder` prop into `placeholder` (may move)
       and required `label` (static `aria-label`); update both call sites (`TopBar.svelte`,
       `HomeLandingView.svelte`) so the accessible name stops tracking the example.
-- [x] 1.4 Add the `rotating?: string[]` prop and the timer: advance every 2.5s, stop
+- [x] 1.4 (revised in review) Add the timer. The planned `rotating?: string[]` prop became a
+      union on `placeholder` (`string | string[]`) instead: a separate override always won,
+      leaving the static prop dead at every rotating call site. Advance every 2.5s, stop
+      permanently on first focus or input: advance every 2.5s, stop
       permanently on first focus or input, hold at index 0 under `prefers-reduced-motion`,
       fade via a `::placeholder` colour transition.
 - [x] 1.5 Pass `rolePlaceholders()` from the jobs call sites only; `/companies` keeps its
@@ -18,48 +21,51 @@
 
 ## 2. AI filter moves into the filter modal
 
-- [ ] 2.1 Remove `AiFilterButton` from `filters/FilterSummary.svelte` (its `beforeButton`
+- [x] 2.1 Remove `AiFilterButton` from `filters/FilterSummary.svelte` (its `beforeButton`
       snippet) and drop the now-unused import.
-- [ ] 2.2 Render it inside `filters/FilterModal.svelte` so it is reachable at every
+- [x] 2.2 Render it inside `filters/FilterModal.svelte` so it is reachable at every
       viewport width, including sub-`md` where the sidebar does not exist.
-- [ ] 2.3 Verify the sidebar has no orphaned wrapper/snippet left behind.
-- [ ] 2.4 simplify → tests green → `requesting-code-review` + `/code-review` → fix
+- [x] 2.3 Verify the sidebar has no orphaned wrapper/snippet left behind.
+- [x] 2.4 simplify → tests green → `requesting-code-review` + `/code-review` → fix
       Critical/Important.
 
 ## 3. Save-to-board as the primary CTA
 
-- [ ] 3.1 Test first: `columnOf` maps a saved row with no stage to `preparing`, and an
+- [x] 3.1 Test first: `columnOf` maps a saved row with no stage to `preparing`, and an
       explicit stage still wins.
-- [ ] 3.2 Change `columnOf` in `JobBoard.svelte` accordingly; remove the `continue` that
+- [x] 3.2 Change `columnOf` in `JobBoard.svelte` accordingly; remove the `continue` that
       dropped saved-only rows in `build()`.
-- [ ] 3.3 Update the existing 500-row-cap comment in `JobBoard.svelte` in place — do not
+- [x] 3.3 Update the existing 500-row-cap comment in `JobBoard.svelte` in place — do not
       add a second note elsewhere.
-- [ ] 3.4 Replace `JobRow.svelte`'s icon-only bookmark overlay with a labelled button in
+- [x] 3.4 Replace `JobRow.svelte`'s icon-only bookmark overlay with a labelled button in
       the card footer, keeping it outside the `<a>` so it never navigates.
-- [ ] 3.5 Check the surfaces that reuse `JobRow` without the feed's affordances (saved
+- [x] 3.5 Check the surfaces that reuse `JobRow` without the feed's affordances (saved
       list, hidden list, tracking views) still render correctly.
-- [ ] 3.6 simplify → tests green → `requesting-code-review` + `/code-review` → fix
+- [x] 3.6 simplify → tests green → `requesting-code-review` + `/code-review` → fix
       Critical/Important.
 
 ## 4. Account-completeness card
 
-- [ ] 4.1 Add `web/src/lib/accountCompleteness.ts`: a pure function taking the résumé,
+- [x] 4.1 Add `web/src/lib/accountCompleteness.ts`: a pure function taking the résumé,
       profile and saved-search inputs and returning the five steps with a done flag and a
       link each.
-- [ ] 4.2 Unit tests: each step's predicate, a full account reporting complete, an empty
+- [x] 4.2 Unit tests: each step's predicate, a full account reporting complete, an empty
       account reporting every step open.
-- [ ] 4.3 Render the card at the top of `/my/tracking`; it disappears when complete.
-- [ ] 4.4 Add the quiet dot on the header avatar in `HeaderMenu.svelte` while any step is
+- [x] 4.3 Render the card at the top of `/my/tracking`; it disappears when complete.
+- [x] 4.4 Add the quiet dot on the header avatar in `HeaderMenu.svelte` while any step is
       open — no count, so it never competes with the notification bell.
-- [ ] 4.5 simplify → tests green → `requesting-code-review` + `/code-review` → fix
+- [x] 4.5 simplify → tests green → `requesting-code-review` + `/code-review` → fix
       Critical/Important.
 
 ## 5. Ship
 
-- [ ] 5.1 `pnpm --dir web lint`, `pnpm --dir web check`, `pnpm --dir web test` all green.
+- [x] 5.1 `pnpm --dir web lint`, `pnpm --dir web check`, `pnpm --dir web test` all green.
 - [ ] 5.2 Verify in a browser: rotation and its three guards, the AI filter on a narrow
       viewport, save-to-board round trip, the card and dot appearing and clearing.
 - [ ] 5.3 PR → CI green → merge.
 - [ ] 5.4 Deploy and verify on production.
-- [ ] 5.5 Check whether `PUBLIC_MATCH_SORT` is set on the host and report — out of scope
-      to change, in scope to answer.
+- [x] 5.5 `PUBLIC_MATCH_SORT=1` IS set on production — in `/opt/freehire/env/hire-web.env`,
+      not `/opt/freehire/.env` (the two-file env split). So the match sort is live and
+      selectable; what remains unaddressed from the reviewer's first note is that
+      `defaultSortFor('')` still returns `newest`, so it is never the DEFAULT ordering.
+      Changing that default is a separate decision, deliberately not taken here.

--- a/openspec/changes/onboarding-feedback-pass/tasks.md
+++ b/openspec/changes/onboarding-feedback-pass/tasks.md
@@ -1,0 +1,65 @@
+## 1. Rotating role placeholder
+
+- [ ] 1.1 Add `web/src/lib/placeholderRoles.ts`: a `Category[]` list (`backend`,
+      `frontend`, `devops`, `qa`, `data_science`, `product`) and `rolePlaceholders()`
+      composing `Search jobs — e.g. <label>` through `categoryLabel()`.
+- [ ] 1.2 Unit tests (`placeholderRoles.test.ts`): list non-empty and unique, every key
+      resolves to a non-empty label, every composed string carries its label.
+- [ ] 1.3 Split `HeaderSearch.svelte`'s `placeholder` prop into `placeholder` (may move)
+      and required `label` (static `aria-label`); update both call sites (`TopBar.svelte`,
+      `HomeLandingView.svelte`) so the accessible name stops tracking the example.
+- [ ] 1.4 Add the `rotating?: string[]` prop and the timer: advance every 2.5s, stop
+      permanently on first focus or input, hold at index 0 under `prefers-reduced-motion`,
+      fade via a `::placeholder` colour transition.
+- [ ] 1.5 Pass `rolePlaceholders()` from the jobs call sites only; `/companies` keeps its
+      static placeholder.
+- [ ] 1.6 simplify → tests green → `requesting-code-review` + `/code-review` → fix
+      Critical/Important.
+
+## 2. AI filter moves into the filter modal
+
+- [ ] 2.1 Remove `AiFilterButton` from `filters/FilterSummary.svelte` (its `beforeButton`
+      snippet) and drop the now-unused import.
+- [ ] 2.2 Render it inside `filters/FilterModal.svelte` so it is reachable at every
+      viewport width, including sub-`md` where the sidebar does not exist.
+- [ ] 2.3 Verify the sidebar has no orphaned wrapper/snippet left behind.
+- [ ] 2.4 simplify → tests green → `requesting-code-review` + `/code-review` → fix
+      Critical/Important.
+
+## 3. Save-to-board as the primary CTA
+
+- [ ] 3.1 Test first: `columnOf` maps a saved row with no stage to `preparing`, and an
+      explicit stage still wins.
+- [ ] 3.2 Change `columnOf` in `JobBoard.svelte` accordingly; remove the `continue` that
+      dropped saved-only rows in `build()`.
+- [ ] 3.3 Update the existing 500-row-cap comment in `JobBoard.svelte` in place — do not
+      add a second note elsewhere.
+- [ ] 3.4 Replace `JobRow.svelte`'s icon-only bookmark overlay with a labelled button in
+      the card footer, keeping it outside the `<a>` so it never navigates.
+- [ ] 3.5 Check the surfaces that reuse `JobRow` without the feed's affordances (saved
+      list, hidden list, tracking views) still render correctly.
+- [ ] 3.6 simplify → tests green → `requesting-code-review` + `/code-review` → fix
+      Critical/Important.
+
+## 4. Account-completeness card
+
+- [ ] 4.1 Add `web/src/lib/accountCompleteness.ts`: a pure function taking the résumé,
+      profile and saved-search inputs and returning the five steps with a done flag and a
+      link each.
+- [ ] 4.2 Unit tests: each step's predicate, a full account reporting complete, an empty
+      account reporting every step open.
+- [ ] 4.3 Render the card at the top of `/my/tracking`; it disappears when complete.
+- [ ] 4.4 Add the quiet dot on the header avatar in `HeaderMenu.svelte` while any step is
+      open — no count, so it never competes with the notification bell.
+- [ ] 4.5 simplify → tests green → `requesting-code-review` + `/code-review` → fix
+      Critical/Important.
+
+## 5. Ship
+
+- [ ] 5.1 `pnpm --dir web lint`, `pnpm --dir web check`, `pnpm --dir web test` all green.
+- [ ] 5.2 Verify in a browser: rotation and its three guards, the AI filter on a narrow
+      viewport, save-to-board round trip, the card and dot appearing and clearing.
+- [ ] 5.3 PR → CI green → merge.
+- [ ] 5.4 Deploy and verify on production.
+- [ ] 5.5 Check whether `PUBLIC_MATCH_SORT` is set on the host and report — out of scope
+      to change, in scope to answer.

--- a/openspec/changes/onboarding-feedback-pass/tasks.md
+++ b/openspec/changes/onboarding-feedback-pass/tasks.md
@@ -1,19 +1,19 @@
 ## 1. Rotating role placeholder
 
-- [ ] 1.1 Add `web/src/lib/placeholderRoles.ts`: a `Category[]` list (`backend`,
+- [x] 1.1 Add `web/src/lib/placeholderRoles.ts`: a `Category[]` list (`backend`,
       `frontend`, `devops`, `qa`, `data_science`, `product`) and `rolePlaceholders()`
       composing `Search jobs — e.g. <label>` through `categoryLabel()`.
-- [ ] 1.2 Unit tests (`placeholderRoles.test.ts`): list non-empty and unique, every key
+- [x] 1.2 Unit tests (`placeholderRoles.test.ts`): list non-empty and unique, every key
       resolves to a non-empty label, every composed string carries its label.
-- [ ] 1.3 Split `HeaderSearch.svelte`'s `placeholder` prop into `placeholder` (may move)
+- [x] 1.3 Split `HeaderSearch.svelte`'s `placeholder` prop into `placeholder` (may move)
       and required `label` (static `aria-label`); update both call sites (`TopBar.svelte`,
       `HomeLandingView.svelte`) so the accessible name stops tracking the example.
-- [ ] 1.4 Add the `rotating?: string[]` prop and the timer: advance every 2.5s, stop
+- [x] 1.4 Add the `rotating?: string[]` prop and the timer: advance every 2.5s, stop
       permanently on first focus or input, hold at index 0 under `prefers-reduced-motion`,
       fade via a `::placeholder` colour transition.
-- [ ] 1.5 Pass `rolePlaceholders()` from the jobs call sites only; `/companies` keeps its
+- [x] 1.5 Pass `rolePlaceholders()` from the jobs call sites only; `/companies` keeps its
       static placeholder.
-- [ ] 1.6 simplify → tests green → `requesting-code-review` + `/code-review` → fix
+- [x] 1.6 simplify → tests green → `requesting-code-review` + `/code-review` → fix
       Critical/Important.
 
 ## 2. AI filter moves into the filter modal

--- a/web/src/lib/accountCompleteness.test.ts
+++ b/web/src/lib/accountCompleteness.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { accountSteps, stepsOutstanding, type CompletenessInput } from './accountCompleteness';
+import type { UserProfile } from './types';
+
+// What the account card measures. The predicates are the whole point of the module, so
+// they are asserted one at a time: a step that silently reads as done is a funnel that
+// tells someone they have finished when they have not.
+
+const profile = (patch: Partial<UserProfile> = {}): UserProfile =>
+  ({
+    specializations: [],
+    skills: [],
+    seniorities: [],
+    excluded_skills: [],
+    location_preferences: null,
+    derived_location: null,
+    cv: null,
+    created_at: null,
+    updated_at: null,
+    ...patch,
+  }) as UserProfile;
+
+const empty: CompletenessInput = { hasCv: false, profile: null, alertCount: 0 };
+
+const doneIds = (input: CompletenessInput) =>
+  accountSteps(input)
+    .filter((s) => s.done)
+    .map((s) => s.id);
+
+describe('accountSteps', () => {
+  it('reports every step outstanding for a fresh account', () => {
+    const steps = accountSteps(empty);
+    expect(steps.length).toBeGreaterThan(0);
+    expect(steps.every((s) => !s.done)).toBe(true);
+    expect(stepsOutstanding(empty)).toBe(steps.length);
+  });
+
+  it('gives every step a label and a link to where it is done', () => {
+    for (const step of accountSteps(empty)) {
+      expect(step.label.trim()).not.toBe('');
+      expect(step.href.startsWith('/')).toBe(true);
+    }
+  });
+
+  it('counts a CV once one is stored', () => {
+    expect(doneIds({ ...empty, hasCv: true })).toEqual(['cv']);
+  });
+
+  it('wants both a specialization and a seniority before the role step is done', () => {
+    expect(doneIds({ ...empty, profile: profile({ specializations: ['backend'] }) })).toEqual([]);
+    expect(doneIds({ ...empty, profile: profile({ seniorities: ['senior'] }) })).toEqual([]);
+    expect(
+      doneIds({ ...empty, profile: profile({ specializations: ['backend'], seniorities: ['senior'] }) }),
+    ).toEqual(['role']);
+  });
+
+  it('counts skills once the profile names any', () => {
+    expect(doneIds({ ...empty, profile: profile({ skills: ['go'] }) })).toEqual(['skills']);
+  });
+
+  // An empty preferences object is what the API returns for a user who opened the step
+  // and saved nothing, so its mere presence must not read as an answer.
+  it('does not count an empty location block as a stated preference', () => {
+    expect(
+      doneIds({
+        ...empty,
+        profile: profile({
+          location_preferences: { remote: {}, base: {}, relocation: { open: false } },
+        }),
+      }),
+    ).toEqual([]);
+  });
+
+  it('counts location from a work mode, a base or a remote reach', () => {
+    const stated = (patch: Partial<UserProfile['location_preferences'] & object>) =>
+      doneIds({
+        ...empty,
+        profile: profile({
+          location_preferences: { remote: {}, base: {}, relocation: { open: false }, ...patch },
+        }),
+      });
+    expect(stated({ work_modes: ['remote'] })).toEqual(['location']);
+    expect(stated({ base: { country: 'PT' } })).toEqual(['location']);
+    expect(stated({ remote: { countries: ['PT'] } })).toEqual(['location']);
+  });
+
+  it('counts an alert once a subscription exists', () => {
+    expect(doneIds({ ...empty, alertCount: 1 })).toEqual(['alerts']);
+  });
+
+  it('reports a fully set-up account as having nothing outstanding', () => {
+    const full: CompletenessInput = {
+      hasCv: true,
+      profile: profile({
+        specializations: ['backend'],
+        seniorities: ['senior'],
+        skills: ['go'],
+        location_preferences: { work_modes: ['remote'], remote: {}, base: {}, relocation: { open: false } },
+      }),
+      alertCount: 2,
+    };
+    expect(stepsOutstanding(full)).toBe(0);
+    expect(accountSteps(full).every((s) => s.done)).toBe(true);
+  });
+});

--- a/web/src/lib/accountCompleteness.test.ts
+++ b/web/src/lib/accountCompleteness.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { accountSteps, stepsOutstanding, type CompletenessInput } from './accountCompleteness';
+import { accountSteps, outstandingOf, type CompletenessInput } from './accountCompleteness';
 import type { UserProfile } from './types';
 
 // What the account card measures. The predicates are the whole point of the module, so
@@ -32,7 +32,7 @@ describe('accountSteps', () => {
     const steps = accountSteps(empty);
     expect(steps.length).toBeGreaterThan(0);
     expect(steps.every((s) => !s.done)).toBe(true);
-    expect(stepsOutstanding(empty)).toBe(steps.length);
+    expect(outstandingOf(steps)).toHaveLength(steps.length);
   });
 
   it('gives every step a label and a link to where it is done', () => {
@@ -99,7 +99,7 @@ describe('accountSteps', () => {
       }),
       alertCount: 2,
     };
-    expect(stepsOutstanding(full)).toBe(0);
+    expect(outstandingOf(accountSteps(full))).toEqual([]);
     expect(accountSteps(full).every((s) => s.done)).toBe(true);
   });
 });

--- a/web/src/lib/accountCompleteness.ts
+++ b/web/src/lib/accountCompleteness.ts
@@ -94,7 +94,11 @@ export function accountSteps({ hasCv, profile, alertCount }: CompletenessInput):
   ];
 }
 
-/** How many steps are still open. Zero means the card and its dot are done showing. */
-export function stepsOutstanding(input: CompletenessInput): number {
-  return accountSteps(input).filter((step) => !step.done).length;
+/** The steps still open. Zero of them means the card and its dot are done showing.
+ *
+ *  Takes the steps rather than the input so "what counts as outstanding" is written once
+ *  and every caller shares it — the card needs both the full list and this subset, and
+ *  would otherwise re-filter on `!done` itself. */
+export function outstandingOf(steps: CompletenessStep[]): CompletenessStep[] {
+  return steps.filter((step) => !step.done);
 }

--- a/web/src/lib/accountCompleteness.ts
+++ b/web/src/lib/accountCompleteness.ts
@@ -1,0 +1,100 @@
+// What "how complete is my account" means, decided in one place.
+//
+// The first four steps are the onboarding wizard's own (cv, confirm, skills, location),
+// so the card after the funnel measures exactly what the funnel asked for and the two
+// cannot drift. The fifth is the one the reviewer did not name and the product needs: an
+// alert is what makes jobs arrive without a visit, and a completeness meter that ends at
+// a filled-in form measures paperwork rather than activation.
+//
+// Pure by design (no Svelte, no network): the caller passes what it has already loaded,
+// which is also why this needs no endpoint of its own.
+
+import type { UserProfile } from './types';
+
+/** Where a step is completed. A literal union rather than `string` because SvelteKit's
+ *  `resolve()` is typed against the real route table — so a step pointing at a page that
+ *  does not exist fails the build here, instead of rendering a link to a 404. Spelling
+ *  the routes out keeps this module free of any SvelteKit import, which is what lets it
+ *  be unit-tested in plain Node. */
+export type SetupHref = '/my/cvs' | '/my/profile' | '/my/searches';
+
+export interface CompletenessStep {
+  /** Stable key. Used by tests and as the list key — never shown. */
+  id: string;
+  label: string;
+  href: SetupHref;
+  done: boolean;
+}
+
+export interface CompletenessInput {
+  /** Whether a CV is stored (resumeStore.present). */
+  hasCv: boolean;
+  /** The saved profile, or null when the user has none yet. */
+  profile: UserProfile | null;
+  /** How many search alerts the user has. Only "any" matters; the count is what the
+   *  caller already holds, so it is not narrowed to a boolean here. */
+  alertCount: number;
+}
+
+/** Whether the location block says anything at all.
+ *
+ *  Presence is not an answer: the API returns an empty block for a user who opened the
+ *  step and saved nothing, so testing `!== null` would mark the step done for someone
+ *  who never stated a preference. Any ONE of the three parts counts — the block is
+ *  deliberately a free combination, and demanding all of them would hold the card open
+ *  on a candidate who is simply remote-only with nowhere in particular to be. */
+function statesLocation(profile: UserProfile | null): boolean {
+  const loc = profile?.location_preferences;
+  if (!loc) return false;
+  return Boolean(
+    loc.work_modes?.length ||
+      loc.base?.country ||
+      loc.base?.city ||
+      loc.remote?.regions?.length ||
+      loc.remote?.countries?.length,
+  );
+}
+
+/** The setup steps and whether each is done, in the order they are asked for. */
+export function accountSteps({ hasCv, profile, alertCount }: CompletenessInput): CompletenessStep[] {
+  return [
+    {
+      id: 'cv',
+      label: 'Add your CV',
+      href: '/my/cvs',
+      done: hasCv,
+    },
+    {
+      // One step, not two: a specialization without a level and a level without a
+      // specialization are both halves of the same answer, and the wizard asks them on
+      // one screen.
+      id: 'role',
+      label: 'Say what you do, and at what level',
+      href: '/my/profile',
+      done: Boolean(profile?.specializations.length && profile?.seniorities.length),
+    },
+    {
+      id: 'skills',
+      label: 'List your skills',
+      href: '/my/profile',
+      done: Boolean(profile?.skills.length),
+    },
+    {
+      id: 'location',
+      label: 'Set where and how you want to work',
+      href: '/my/profile',
+      done: statesLocation(profile),
+    },
+    {
+      id: 'alerts',
+      label: 'Get new matches sent to you',
+      href: '/my/searches',
+      done: alertCount > 0,
+    },
+  ];
+}
+
+/** How many steps are still open. Zero means the card and its dot are done showing. */
+export function stepsOutstanding(input: CompletenessInput): number {
+  return accountSteps(input).filter((step) => !step.done).length;
+}

--- a/web/src/lib/accountCompleteness.ts
+++ b/web/src/lib/accountCompleteness.ts
@@ -16,7 +16,7 @@ import type { UserProfile } from './types';
  *  does not exist fails the build here, instead of rendering a link to a 404. Spelling
  *  the routes out keeps this module free of any SvelteKit import, which is what lets it
  *  be unit-tested in plain Node. */
-export type SetupHref = '/my/cvs' | '/my/profile' | '/my/searches';
+type SetupHref = '/my/cvs' | '/my/profile' | '/my/searches';
 
 export interface CompletenessStep {
   /** Stable key. Used by tests and as the list key — never shown. */

--- a/web/src/lib/accountSetup.svelte.ts
+++ b/web/src/lib/accountSetup.svelte.ts
@@ -1,0 +1,47 @@
+// Binds the completeness rules (accountCompleteness.ts) to the three per-user stores
+// that already hold their inputs, so the card on the tracking page and the dot in the
+// header ask the same question of the same data.
+//
+// No store of its own and no endpoint: every input is a UserResource singleton that
+// loads once per session and is shared, so a second reader costs nothing. Keeping the
+// rules pure next door is what lets them be unit-tested without any of this.
+
+import { accountSteps, stepsOutstanding, type CompletenessStep } from './accountCompleteness';
+import { notifications } from './notifications.svelte';
+import { profileStore } from './profile.svelte';
+import { resumeStore } from './resume.svelte';
+
+/** Start the three loads. Idempotent and safe to call from several components. */
+export function ensureAccountSetupLoaded(): void {
+  void resumeStore.ensureLoaded();
+  void profileStore.ensureLoaded();
+  void notifications.ensureLoaded();
+}
+
+/** True once all three inputs have settled.
+ *
+ *  Both surfaces wait for this rather than rendering from a partial read: every store
+ *  starts empty, so a half-loaded account looks exactly like a brand-new one — and
+ *  telling somebody who finished setting up that they have five steps left, for the
+ *  moment it takes the profile to arrive, is worse than showing nothing. */
+export function accountSetupReady(): boolean {
+  return resumeStore.loaded && profileStore.loaded && notifications.loaded;
+}
+
+function input() {
+  return {
+    hasCv: resumeStore.present,
+    profile: profileStore.profile,
+    alertCount: notifications.subscriptions.length,
+  };
+}
+
+/** The setup steps and whether each is done. Empty until the inputs have settled. */
+export function setupSteps(): CompletenessStep[] {
+  return accountSetupReady() ? accountSteps(input()) : [];
+}
+
+/** How many steps are still open, or 0 while the inputs are still loading. */
+export function setupOutstanding(): number {
+  return accountSetupReady() ? stepsOutstanding(input()) : 0;
+}

--- a/web/src/lib/accountSetup.svelte.ts
+++ b/web/src/lib/accountSetup.svelte.ts
@@ -5,14 +5,28 @@
 // No store of its own and no endpoint: every input is a UserResource singleton that
 // loads once per session and is shared, so a second reader costs nothing. Keeping the
 // rules pure next door is what lets them be unit-tested without any of this.
+//
+// The cost this DOES add, recorded because it is easy to miss: the header asks for the
+// dot on every page, so a signed-in user who never opens an account page now warms the
+// résumé, profile and notification stores anyway. That is five GETs, once per session
+// (the notification store fetches Telegram status and the webhook alongside the
+// subscriptions this needs), not five per navigation. The alternative — showing the dot
+// only where the data happened to already be loaded — is a nudge that appears on the one
+// page whose visitor least needs it.
 
-import { accountSteps, stepsOutstanding, type CompletenessStep } from './accountCompleteness';
+import { accountSteps, outstandingOf, type CompletenessStep } from './accountCompleteness';
+import { isAuthenticated } from './auth.svelte';
 import { notifications } from './notifications.svelte';
 import { profileStore } from './profile.svelte';
 import { resumeStore } from './resume.svelte';
 
-/** Start the three loads. Idempotent and safe to call from several components. */
+/** Start the three loads. Idempotent and safe to call from several components.
+ *
+ *  The signed-in check lives here rather than at each call site: there are two of them
+ *  and they had the same `if` written out twice, so a condition that later grows (a
+ *  verified address, say) would have had two places to grow in. */
 export function ensureAccountSetupLoaded(): void {
+  if (!isAuthenticated()) return;
   void resumeStore.ensureLoaded();
   void profileStore.ensureLoaded();
   void notifications.ensureLoaded();
@@ -32,7 +46,10 @@ function input() {
   return {
     hasCv: resumeStore.present,
     profile: profileStore.profile,
-    alertCount: notifications.subscriptions.length,
+    // Active ones only. A paused subscription delivers nothing, so counting it would
+    // tell someone their alerts are set up while no job is being sent to them — the
+    // exact thing this step exists to notice.
+    alertCount: notifications.subscriptions.filter((s) => s.active).length,
   };
 }
 
@@ -43,5 +60,5 @@ export function setupSteps(): CompletenessStep[] {
 
 /** How many steps are still open, or 0 while the inputs are still loading. */
 export function setupOutstanding(): number {
-  return accountSetupReady() ? stepsOutstanding(input()) : 0;
+  return outstandingOf(setupSteps()).length;
 }

--- a/web/src/lib/accountSetup.svelte.ts
+++ b/web/src/lib/accountSetup.svelte.ts
@@ -34,11 +34,13 @@ export function ensureAccountSetupLoaded(): void {
 
 /** True once all three inputs have settled.
  *
- *  Both surfaces wait for this rather than rendering from a partial read: every store
- *  starts empty, so a half-loaded account looks exactly like a brand-new one — and
- *  telling somebody who finished setting up that they have five steps left, for the
- *  moment it takes the profile to arrive, is worse than showing nothing. */
-export function accountSetupReady(): boolean {
+ *  Not exported: callers get an empty step list until this is true, which is the same
+ *  answer in the shape they already handle. Both surfaces depend on it rather than
+ *  rendering from a partial read — every store starts empty, so a half-loaded account
+ *  looks exactly like a brand-new one, and telling somebody who finished setting up that
+ *  they have five steps left, for the moment it takes the profile to arrive, is worse
+ *  than showing nothing. */
+function accountSetupReady(): boolean {
   return resumeStore.loaded && profileStore.loaded && notifications.loaded;
 }
 

--- a/web/src/lib/board.test.ts
+++ b/web/src/lib/board.test.ts
@@ -50,8 +50,20 @@ describe('columnOf', () => {
     expect(columnOf(job({ applied_at: '2026-07-12T00:00:00Z' }))).toBe('applied');
   });
 
-  it('returns null for a saved-only row (not on the board)', () => {
-    expect(columnOf(job({ saved_at: '2026-07-12T00:00:00Z' }))).toBeNull();
+  // Saving IS taking a job on, so a bookmark is a board card in the first column. This
+  // is read-side only: nothing writes a stage on the saver's behalf, which is why it
+  // applies to every job saved before the rule existed as well as after.
+  it('maps a saved-only row to preparing', () => {
+    expect(columnOf(job({ saved_at: '2026-07-12T00:00:00Z' }))).toBe('preparing');
+  });
+
+  it('keeps an explicit stage ahead of the saved mark', () => {
+    expect(columnOf(job({ saved_at: '2026-07-12T00:00:00Z', stage: 'interview' }))).toBe(
+      'interview',
+    );
+  });
+
+  it('returns null for a row that is neither saved nor tracked', () => {
     expect(columnOf(job({}))).toBeNull();
   });
 });

--- a/web/src/lib/board.ts
+++ b/web/src/lib/board.ts
@@ -1,7 +1,7 @@
 // Derives which Kanban column a tracked job belongs to. The column is NOT stored
-// — it is a view over the application's applied_at / stage. The board shows only
-// jobs in an active application state; a saved-only row (saved but never applied,
-// no stage) has no column and lives in the Activity → Saved list instead.
+// — it is a view over the application's saved_at / applied_at / stage. A row the board
+// cannot place is one the user has neither saved nor tracked; a saved job is a card in
+// the first column, because saving one is taking it on.
 //
 // The columns and their membership are the generated ones (internal/userjob →
 // cmd/gen-contracts). This file used to restate both, which is how the board and the
@@ -21,9 +21,9 @@ const STAGE_COLUMN: Record<string, BoardColumnId> = Object.fromEntries(
   STAGE_GROUPS.flatMap((g) => g.stages.map((stage) => [stage, g.id])),
 );
 
-/** The column a tracked job currently sits in, or `null` when it is saved-only and
- *  therefore not on the board. Priority: precise stage, then a legacy
- *  applied-without-stage row, else off-board. */
+/** The column a tracked job currently sits in, or `null` when it is neither saved nor
+ *  tracked and so has nothing to sit in. Priority: precise stage, then a legacy
+ *  applied-without-stage row, then the saved mark, else off-board. */
 export function columnOf(item: MyJob): BoardColumnId | null {
   const col = item.stage ? STAGE_COLUMN[item.stage] : undefined;
   if (col) return col;

--- a/web/src/lib/board.ts
+++ b/web/src/lib/board.ts
@@ -28,6 +28,14 @@ export function columnOf(item: MyJob): BoardColumnId | null {
   const col = item.stage ? STAGE_COLUMN[item.stage] : undefined;
   if (col) return col;
   if (item.applied_at) return 'applied';
+  // A bookmark is a board card. Saving a job is taking it on, and the board is where a
+  // candidate looks to see what they have taken on — a saved row that showed up nowhere
+  // there meant the product had two places to keep a job and told you about one.
+  //
+  // Read-side only, deliberately: nothing writes a stage on the saver's behalf, so this
+  // needed no migration and applies to every job saved before the rule as well as after.
+  // A stage, when there is one, still decides — this is the fallback, not an override.
+  if (item.saved_at) return 'preparing';
   return null;
 }
 

--- a/web/src/lib/components/AccountSetupCard.svelte
+++ b/web/src/lib/components/AccountSetupCard.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import { Check, ArrowRight } from '@lucide/svelte';
+  import { resolve } from '$app/paths';
+  import { isAuthenticated } from '$lib/auth.svelte';
+  import { ensureAccountSetupLoaded, setupSteps } from '$lib/accountSetup.svelte';
+
+  // "How complete is my account", at the top of the tracking page — the page a bare /my
+  // already redirects to, so the card sits where people land rather than on an account
+  // home invented to host it.
+  //
+  // A funnel beats a choose-your-own-adventure: the onboarding wizard asks these same
+  // questions once, and this is what remains of them afterwards for anyone who skipped a
+  // step or signed up before the wizard existed. It disappears the moment nothing is
+  // outstanding — a card that congratulates you forever is a permanent tax on the page.
+
+  const steps = $derived(setupSteps());
+  const outstanding = $derived(steps.filter((s) => !s.done));
+  const done = $derived(steps.length - outstanding.length);
+
+  $effect(() => {
+    if (isAuthenticated()) ensureAccountSetupLoaded();
+  });
+</script>
+
+{#if outstanding.length > 0}
+  <!-- No outer margin: every host so far is a flex column that owns its own spacing,
+       and a margin here would add to that gap rather than replace it. -->
+  <section class="rounded-xl border border-border bg-card p-4" aria-labelledby="account-setup-heading">
+    <div class="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+      <h2 id="account-setup-heading" class="text-sm font-semibold tracking-tight">
+        Finish setting up your account
+      </h2>
+      <!-- The count, not a percentage bar: five steps is few enough that "3 of 5" is the
+           more precise statement and needs no legend. `tabular-nums` keeps it from
+           twitching as steps are completed. -->
+      <p class="text-xs tabular-nums text-muted-foreground">{done} of {steps.length} done</p>
+    </div>
+
+    <ul class="mt-3 flex flex-col gap-1">
+      {#each steps as step (step.id)}
+        <li>
+          {#if step.done}
+            <!-- Completed steps stay listed rather than disappearing: a list that only
+                 shows what is left cannot show progress, and progress is the reason
+                 somebody finishes the next one. Not a link — there is nothing to go
+                 and do. -->
+            <p class="flex items-center gap-2 px-1 py-1.5 text-sm text-muted-foreground">
+              <Check class="size-4 shrink-0 text-brand" aria-hidden="true" />
+              <span class="line-through decoration-border">{step.label}</span>
+            </p>
+          {:else}
+            <a
+              href={resolve(step.href)}
+              class="group flex items-center gap-2 rounded-lg px-1 py-1.5 text-sm transition-colors hover:bg-accent"
+            >
+              <span
+                class="size-4 shrink-0 rounded-full border border-dashed border-muted-foreground"
+                aria-hidden="true"
+              ></span>
+              <span class="min-w-0 flex-1">{step.label}</span>
+              <ArrowRight
+                class="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+                aria-hidden="true"
+              />
+            </a>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+  </section>
+{/if}

--- a/web/src/lib/components/AccountSetupCard.svelte
+++ b/web/src/lib/components/AccountSetupCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Check, ArrowRight } from '@lucide/svelte';
   import { resolve } from '$app/paths';
-  import { isAuthenticated } from '$lib/auth.svelte';
+  import { outstandingOf } from '$lib/accountCompleteness';
   import { ensureAccountSetupLoaded, setupSteps } from '$lib/accountSetup.svelte';
 
   // "How complete is my account", at the top of the tracking page — the page a bare /my
@@ -14,11 +14,12 @@
   // outstanding — a card that congratulates you forever is a permanent tax on the page.
 
   const steps = $derived(setupSteps());
-  const outstanding = $derived(steps.filter((s) => !s.done));
+  const outstanding = $derived(outstandingOf(steps));
   const done = $derived(steps.length - outstanding.length);
 
+  // The signed-in check lives inside ensureAccountSetupLoaded, so both callers share it.
   $effect(() => {
-    if (isAuthenticated()) ensureAccountSetupLoaded();
+    ensureAccountSetupLoaded();
   });
 </script>
 

--- a/web/src/lib/components/HeaderMenu.svelte
+++ b/web/src/lib/components/HeaderMenu.svelte
@@ -121,10 +121,10 @@
     { href: '/my/submissions', label: 'My submissions', icon: FileText },
   ] as const;
 
-  // What the setup dot reads. The three stores behind it load once per session and are
-  // shared, so asking here costs nothing that the account pages were not going to pay.
+  // What the setup dot reads. The signed-in check is inside the call, shared with the
+  // card on the tracking page.
   $effect(() => {
-    if (isAuthenticated()) ensureAccountSetupLoaded();
+    ensureAccountSetupLoaded();
   });
 
   // Mobile only: the open panel is a full-screen overlay, so lock the page behind
@@ -259,7 +259,7 @@
 
   <button
     type="button"
-    aria-label="Menu"
+    aria-label={setupOutstanding() > 0 ? 'Menu — account setup unfinished' : 'Menu'}
     aria-haspopup="menu"
     aria-expanded={open}
     onclick={(e) => {
@@ -285,13 +285,16 @@
          No count, deliberately: the notification bell is two controls away and does carry
          one, and a second numbered badge beside it would make two signals compete for one
          glance. The bell wins on urgency; this is a nudge, and a nudge only has to be
-         noticeable. Hidden while the menu is open — by then it has been acted on. -->
+         noticeable. Hidden while the menu is open — by then it has been acted on.
+
+         The screen-reader equivalent is in this button's aria-label, not an sr-only span
+         in here: an aria-label REPLACES an element's contents as its accessible name, so
+         a span would have been silently unreadable. -->
     {#if isAuthenticated() && !open && setupOutstanding() > 0}
       <span
         class="absolute right-1.5 top-1.5 size-2 rounded-full bg-brand ring-2 ring-background"
         aria-hidden="true"
       ></span>
-      <span class="sr-only">Your account setup is unfinished</span>
     {/if}
   </button>
 

--- a/web/src/lib/components/HeaderMenu.svelte
+++ b/web/src/lib/components/HeaderMenu.svelte
@@ -30,6 +30,7 @@
   import BrandMark from './BrandMark.svelte';
   import GithubStars from './GithubStars.svelte';
   import NotificationBell from './NotificationBell.svelte';
+  import { ensureAccountSetupLoaded, setupOutstanding } from '$lib/accountSetup.svelte';
   import { ProviderIcon } from '$lib/ui';
   import { NAV } from '$lib/siteNav';
 
@@ -119,6 +120,12 @@
     { href: '/my/api-keys', label: 'API keys', icon: KeyRound },
     { href: '/my/submissions', label: 'My submissions', icon: FileText },
   ] as const;
+
+  // What the setup dot reads. The three stores behind it load once per session and are
+  // shared, so asking here costs nothing that the account pages were not going to pay.
+  $effect(() => {
+    if (isAuthenticated()) ensureAccountSetupLoaded();
+  });
 
   // Mobile only: the open panel is a full-screen overlay, so lock the page behind
   // it. Desktop keeps the small anchored dropdown and stays scrollable.
@@ -264,12 +271,27 @@
       e.stopPropagation();
       open = !open;
     }}
-    class={cn('inline-flex', iconButton)}
+    class={cn('relative inline-flex', iconButton)}
   >
     {#if open}
       <X class="size-5" />
     {:else}
       <Menu class="size-5" />
+    {/if}
+    <!-- Setup still outstanding. On the MENU button rather than the profile icon beside
+         it, because that icon is `hidden sm:inline-flex` — on a phone it is not there to
+         carry anything, and this is the one account control at every width.
+
+         No count, deliberately: the notification bell is two controls away and does carry
+         one, and a second numbered badge beside it would make two signals compete for one
+         glance. The bell wins on urgency; this is a nudge, and a nudge only has to be
+         noticeable. Hidden while the menu is open — by then it has been acted on. -->
+    {#if isAuthenticated() && !open && setupOutstanding() > 0}
+      <span
+        class="absolute right-1.5 top-1.5 size-2 rounded-full bg-brand ring-2 ring-background"
+        aria-hidden="true"
+      ></span>
+      <span class="sr-only">Your account setup is unfinished</span>
     {/if}
   </button>
 

--- a/web/src/lib/components/HeaderSearch.svelte
+++ b/web/src/lib/components/HeaderSearch.svelte
@@ -43,12 +43,25 @@
   // feed. A hero-sized second copy of this component is how the two would drift.
   let {
     placeholder,
+    label,
+    rotating = [],
     size = 'header',
     autofocus = false,
     counts = null,
     onOpenFilters,
   }: {
+    /** The example shown in an empty box. May move (see `rotating`), so it is never
+     *  the field's accessible name — that is `label`. */
     placeholder: string;
+    /** The field's accessible name. Static, and required of every caller rather than
+     *  defaulting to `placeholder`: the two were one prop until the placeholder learned
+     *  to rotate, at which point a screen reader announced the input as whatever example
+     *  happened to be on screen. A default would reinstate that at the next call site. */
+    label: string;
+    /** Placeholder strings to cycle through while the box is empty and untouched,
+     *  fully composed by the caller (see lib/placeholderRoles.ts). Empty — the default —
+     *  means no rotation, which is what a box that is not about roles wants. */
+    rotating?: string[];
     size?: 'header' | 'hero';
     /** Focus the box on mount — desktop only. A page whose whole content is this box
      *  should put the caret in it; on a phone the same call raises the keyboard over
@@ -68,6 +81,54 @@
   } = $props();
 
   const hero = $derived(size === 'hero');
+
+  // ---- the rotating placeholder ----
+  //
+  // Runs only while the box is empty and has never been touched. The first focus or
+  // keystroke stops it for the rest of the visit and freezes it on the entry then
+  // showing: text moving under the cursor while a query is being composed is the failure
+  // an animated placeholder invites, and reverting to a static string on stop would be a
+  // visible jump at the moment the visitor's attention is on the field.
+  //
+  // The list itself is composed in lib/placeholderRoles.ts, from the generated category
+  // vocabulary rather than from hand-written strings.
+  const ROTATE_MS = 2500;
+  // Must stay in step with the ::placeholder transition duration in this component's
+  // style block below: this is how long the text is held invisible before it is swapped,
+  // so a longer fade than this would swap the word while it was still legible.
+  const FADE_MS = 200;
+
+  let rotationIndex = $state(0);
+  let rotationStopped = $state(false);
+  let placeholderFading = $state(false);
+
+  function stopRotation() {
+    rotationStopped = true;
+  }
+
+  $effect(() => {
+    if (rotationStopped || rotating.length < 2) return;
+    // Reduced motion: show the first entry and never start a timer. Same switch the
+    // fifteen other animated components here read.
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    let swap: ReturnType<typeof setTimeout> | undefined;
+    const tick = setInterval(() => {
+      placeholderFading = true;
+      swap = setTimeout(() => {
+        rotationIndex = (rotationIndex + 1) % rotating.length;
+        placeholderFading = false;
+      }, FADE_MS);
+    }, ROTATE_MS);
+    return () => {
+      clearInterval(tick);
+      clearTimeout(swap);
+    };
+  });
+
+  // `rotating[0]` is what server-rendered markup carries, since the effect above is
+  // client-only — so the box never paints empty and then fills in.
+  const shownPlaceholder = $derived(rotating.length > 0 ? rotating[rotationIndex] : placeholder);
 
   // How long the draft must sit still before the suggestions are refetched.
   //
@@ -638,10 +699,12 @@
         // autofocused hero would stay silent when its own field is clicked.
         dismissed = false;
         activeIndex = -1;
+        stopRotation();
       }}
       oninput={(e) => {
         dismissed = false;
         activeIndex = -1;
+        stopRotation();
         // Editing the text asks a different question, so the last link's answer goes
         // with it — otherwise a half-corrected URL sits under a verdict on the old one.
         linkStep = null;
@@ -659,18 +722,22 @@
         // box permanently silent for the rest of the visit.
         dismissed = false;
         activeIndex = -1;
+        stopRotation();
       }}
       onkeydown={onKeydown}
       type="text"
-      {placeholder}
-      aria-label={placeholder}
+      placeholder={shownPlaceholder}
+      aria-label={label}
       autocomplete="off"
       spellcheck="false"
       role="combobox"
       aria-expanded={suggestOpen}
       aria-controls="role-suggestions"
       aria-activedescendant={activeIndex >= 0 ? `role-suggestion-${activeIndex}` : undefined}
-      class="min-w-0 flex-1 bg-transparent outline-none placeholder:text-muted-foreground"
+      class={cn(
+        'placeholder-rotates min-w-0 flex-1 bg-transparent outline-none placeholder:text-muted-foreground',
+        placeholderFading && 'placeholder-faded',
+      )}
     />
     {#if draft.text}
       <!-- Clearing is an explicit act, not typing, so it commits at once: the visitor
@@ -878,3 +945,24 @@
     </ul>
   {/if}
 </div>
+
+<style>
+  /* The rotating placeholder's crossfade.
+     Transitioning ::placeholder colour rather than overlaying a positioned span keeps
+     the box's flex row untouched — the field, the location prefix, the clear button and
+     the filters trigger already negotiate width in there, and a second element is a
+     layout risk taken for a cosmetic gain. */
+  .placeholder-rotates::placeholder {
+    transition: color 200ms ease;
+  }
+
+  .placeholder-faded::placeholder {
+    color: transparent;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .placeholder-rotates::placeholder {
+      transition: none;
+    }
+  }
+</style>

--- a/web/src/lib/components/HeaderSearch.svelte
+++ b/web/src/lib/components/HeaderSearch.svelte
@@ -44,24 +44,25 @@
   let {
     placeholder,
     label,
-    rotating = [],
     size = 'header',
     autofocus = false,
     counts = null,
     onOpenFilters,
   }: {
-    /** The example shown in an empty box. May move (see `rotating`), so it is never
-     *  the field's accessible name — that is `label`. */
-    placeholder: string;
+    /** What an empty box shows. A single string is static; an array cycles through its
+     *  entries while the box is empty and untouched, fully composed by the caller (see
+     *  lib/placeholderRoles.ts).
+     *
+     *  One prop rather than a static one plus an override, because an override would
+     *  always win and leave the static string dead at every rotating call site — the
+     *  reader would have two candidates and no way to tell which one ships. Either way
+     *  this is never the field's accessible name; that is `label`. */
+    placeholder: string | string[];
     /** The field's accessible name. Static, and required of every caller rather than
      *  defaulting to `placeholder`: the two were one prop until the placeholder learned
      *  to rotate, at which point a screen reader announced the input as whatever example
      *  happened to be on screen. A default would reinstate that at the next call site. */
     label: string;
-    /** Placeholder strings to cycle through while the box is empty and untouched,
-     *  fully composed by the caller (see lib/placeholderRoles.ts). Empty — the default —
-     *  means no rotation, which is what a box that is not about roles wants. */
-    rotating?: string[];
     size?: 'header' | 'hero';
     /** Focus the box on mount — desktop only. A page whose whole content is this box
      *  should put the caret in it; on a phone the same call raises the keyboard over
@@ -92,11 +93,13 @@
   //
   // The list itself is composed in lib/placeholderRoles.ts, from the generated category
   // vocabulary rather than from hand-written strings.
+  // Long enough to read the word and notice it is an example, short enough that a
+  // visitor who pauses sees it is a list rather than a typo. The fade is a fifth of it,
+  // so the box is legible for the great majority of each step.
   const ROTATE_MS = 2500;
-  // Must stay in step with the ::placeholder transition duration in this component's
-  // style block below: this is how long the text is held invisible before it is swapped,
-  // so a longer fade than this would swap the word while it was still legible.
   const FADE_MS = 200;
+
+  const rotation = $derived(Array.isArray(placeholder) ? placeholder : []);
 
   let rotationIndex = $state(0);
   let rotationStopped = $state(false);
@@ -106,29 +109,45 @@
     rotationStopped = true;
   }
 
+  // Sampled AND subscribed: the OS-level setting can be turned on mid-visit, and reading
+  // it once would leave that visitor with a timer already running for the rest of it.
+  let reduceMotion = $state(false);
   $effect(() => {
-    if (rotationStopped || rotating.length < 2) return;
-    // Reduced motion: show the first entry and never start a timer. Same switch the
-    // fifteen other animated components here read.
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    const query = window.matchMedia('(prefers-reduced-motion: reduce)');
+    reduceMotion = query.matches;
+    const onChange = (e: MediaQueryListEvent) => (reduceMotion = e.matches);
+    query.addEventListener('change', onChange);
+    return () => query.removeEventListener('change', onChange);
+  });
+
+  $effect(() => {
+    // Under reduced motion the first entry stands alone, so no timer is started at all.
+    if (rotationStopped || reduceMotion || rotation.length < 2) return;
 
     let swap: ReturnType<typeof setTimeout> | undefined;
     const tick = setInterval(() => {
       placeholderFading = true;
       swap = setTimeout(() => {
-        rotationIndex = (rotationIndex + 1) % rotating.length;
+        rotationIndex = (rotationIndex + 1) % rotation.length;
         placeholderFading = false;
       }, FADE_MS);
     }, ROTATE_MS);
     return () => {
       clearInterval(tick);
       clearTimeout(swap);
+      // Every teardown path — a stop, an unmount, reduced motion switched on — can land
+      // inside the fade window, where the text is transparent and the swap that would
+      // restore it has just been cancelled. Without this the field keeps a placeholder
+      // nobody can see, which is worse than the one it was rotating away from.
+      placeholderFading = false;
     };
   });
 
-  // `rotating[0]` is what server-rendered markup carries, since the effect above is
+  // `rotation[0]` is what server-rendered markup carries, since the effects above are
   // client-only — so the box never paints empty and then fills in.
-  const shownPlaceholder = $derived(rotating.length > 0 ? rotating[rotationIndex] : placeholder);
+  const shownPlaceholder = $derived(
+    Array.isArray(placeholder) ? (placeholder[rotationIndex] ?? placeholder[0] ?? '') : placeholder,
+  );
 
   // How long the draft must sit still before the suggestions are refetched.
   //
@@ -174,6 +193,11 @@
     // underneath it. A caret the visitor did not place is not the question "what can I
     // put here", so close it back: their first click or keystroke opens it as usual.
     dismissed = true;
+    // Same reasoning, and the same undo: the focus above fires the field's own handler,
+    // which stops the placeholder rotation. On the homepage — where this box IS the
+    // page, and the one surface the rotation exists for — that killed it before the
+    // first tick. A caret nobody placed has not interrupted anything.
+    rotationStopped = false;
   });
   // -1 means nothing is highlighted, which is the state the dropdown opens in: Enter
   // then falls through to the free-text search it has always run.
@@ -734,6 +758,7 @@
       aria-expanded={suggestOpen}
       aria-controls="role-suggestions"
       aria-activedescendant={activeIndex >= 0 ? `role-suggestion-${activeIndex}` : undefined}
+      style="--placeholder-fade: {FADE_MS}ms"
       class={cn(
         'placeholder-rotates min-w-0 flex-1 bg-transparent outline-none placeholder:text-muted-foreground',
         placeholderFading && 'placeholder-faded',
@@ -951,18 +976,19 @@
      Transitioning ::placeholder colour rather than overlaying a positioned span keeps
      the box's flex row untouched — the field, the location prefix, the clear button and
      the filters trigger already negotiate width in there, and a second element is a
-     layout risk taken for a cosmetic gain. */
+     layout risk taken for a cosmetic gain.
+
+     The duration comes from the script's FADE_MS rather than being written twice: it is
+     the same measurement — how long the text is held invisible before it is swapped —
+     and two copies would drift into swapping the word while it was still legible.
+
+     No reduced-motion rule here: under that setting no timer is ever started, so nothing
+     ever adds the faded class and a transition that can't run needs no switching off. */
   .placeholder-rotates::placeholder {
-    transition: color 200ms ease;
+    transition: color var(--placeholder-fade) ease;
   }
 
   .placeholder-faded::placeholder {
     color: transparent;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .placeholder-rotates::placeholder {
-      transition: none;
-    }
   }
 </style>

--- a/web/src/lib/components/HomeLandingView.svelte
+++ b/web/src/lib/components/HomeLandingView.svelte
@@ -237,13 +237,12 @@
 
     <!-- The box's root is `min-w-0 flex-1`, so this wrapper is what sets its width. -->
     <div class="flex w-full">
-      <!-- The rotating example narrows to roles while the accessible name stays broad:
-           this box does search companies and skills too, and an example is a starting
-           point rather than a boundary. Roles are what people actually type first. -->
+      <!-- The visible examples are roles; the accessible name is the broad one, because
+           this box does search companies and skills too. An example is a starting point
+           rather than a boundary, and a role is what people actually type first. -->
       <HeaderSearch
-        placeholder="Search jobs, companies, skills…"
+        placeholder={rolePlaceholders()}
         label="Search jobs, companies and skills"
-        rotating={rolePlaceholders()}
         size="hero"
         autofocus
         {counts}

--- a/web/src/lib/components/HomeLandingView.svelte
+++ b/web/src/lib/components/HomeLandingView.svelte
@@ -4,6 +4,7 @@
   import { ArrowRight } from '@lucide/svelte';
   import FilterModal from './filters/FilterModal.svelte';
   import HeaderSearch from './HeaderSearch.svelte';
+  import { rolePlaceholders } from '$lib/placeholderRoles';
   import { api } from '$lib/api';
   import { browseQuery, planForSuggestion } from '$lib/browseTarget';
   import type { ApplyPlan } from '$lib/apiSuggestions';
@@ -236,8 +237,13 @@
 
     <!-- The box's root is `min-w-0 flex-1`, so this wrapper is what sets its width. -->
     <div class="flex w-full">
+      <!-- The rotating example narrows to roles while the accessible name stays broad:
+           this box does search companies and skills too, and an example is a starting
+           point rather than a boundary. Roles are what people actually type first. -->
       <HeaderSearch
         placeholder="Search jobs, companies, skills…"
+        label="Search jobs, companies and skills"
+        rotating={rolePlaceholders()}
         size="hero"
         autofocus
         {counts}

--- a/web/src/lib/components/JobBoard.svelte
+++ b/web/src/lib/components/JobBoard.svelte
@@ -88,8 +88,8 @@
     cardCol = cols;
     status = 'ready';
     // Deep link: open the requested application's drawer once, after the board is
-    // built. A slug that isn't on the board (untracked / saved-only) just leaves
-    // the board showing.
+    // built. A slug that isn't on the board — one the user has neither saved nor
+    // tracked — just leaves the board showing.
     if (initialId && !openedInitial) {
       openedInitial = true;
       const found = Object.values(next)

--- a/web/src/lib/components/JobBoard.svelte
+++ b/web/src/lib/components/JobBoard.svelte
@@ -64,18 +64,23 @@
   let sessionError = $state<string | null>(null);
 
   // Lay the fetched rows out into the columns and open the deep-linked drawer once.
-  // The 'board' filter returns saved ∪ applied ∪ stage; saved-only rows are dropped
-  // here (they belong to Activity → Saved). Those rows still count toward the 500 cap,
-  // so a user with 500+ tracked jobs, many recently saved, could have older active
-  // applications fall outside the fetched window. Acceptable at this scale; revisit
-  // with a server-side board-minus-saved filter if it bites.
+  // The 'board' filter returns saved ∪ applied ∪ stage, and a saved-only row now lands
+  // in Preparing (see columnOf) rather than being dropped here — saving a job is taking
+  // it on, so the board is where it belongs.
+  //
+  // Those rows always counted toward the 500 cap; showing them makes an existing
+  // consequence visible rather than creating it. A user with hundreds of bookmarks can
+  // push older active applications outside the fetched window, and now sees a wide
+  // Preparing column while it happens. Still acceptable at this scale; the fix if it
+  // bites is the same one as before — a server-side filter that pages the board's
+  // columns separately, so a long backlog cannot crowd out the live applications.
   function build(rows: MyJob[]) {
     const next = emptyColumns();
     const cols: Record<string, BoardColumnId> = {};
     for (const row of rows) {
       const item: BoardItem = { ...row, id: row.id };
       const col = columnOf(item);
-      if (!col) continue; // saved-only rows live in Activity → Saved, not the board
+      if (!col) continue; // neither saved nor tracked — nothing to place
       next[col].push(item);
       cols[item.id] = col;
     }
@@ -224,11 +229,15 @@
   async function applyStage(item: BoardItem, stage: string) {
     const prevCol = cardCol[item.id];
     item.stage = stage || null;
-    if (!stage) item.applied_at = null; // "No stage" takes the job off the board (saved-only)
+    // "No stage" clears the pipeline, not the job. A SAVED job then falls back to
+    // Preparing (columnOf), which is where the board says a job you have taken on but
+    // not applied to lives — so this reads as moving the card back to the start rather
+    // than as deleting it. Only a job that was never saved leaves the board.
+    if (!stage) item.applied_at = null;
     const nextCol = columnOf(item);
     if (nextCol === null) {
-      // Off the board now: drop the card and close the drawer. The job keeps its
-      // saved mark and reappears under Activity → Saved.
+      // Never saved, and now untracked: drop the card and close the drawer. Nothing is
+      // lost — the posting is still in the catalogue, it is just not on this board.
       if (prevCol) {
         columns[prevCol] = columns[prevCol].filter((i) => i.id !== item.id);
         Reflect.deleteProperty(cardCol, item.id);

--- a/web/src/lib/components/JobMatchBar.svelte
+++ b/web/src/lib/components/JobMatchBar.svelte
@@ -5,8 +5,7 @@
   // Purely presentational — the owning JobRow computes the client-side match (exact
   // overlap of the job's skills and the signed-in viewer's profile skills) and passes it
   // in, so the chips it colours and this bar can't disagree on the score. `match` is null
-  // when there is nothing to show, in which case nothing renders. `gutterRight` reserves
-  // the feed's bottom-right hide control so the percent never slides under that icon.
+  // when there is nothing to show, in which case nothing renders.
   //
   // `blurred` renders the same strip as a teaser for a viewer who has no match yet — a
   // guest, or a signed-in viewer with no profile skills. The figures are then the job's
@@ -17,16 +16,14 @@
   // name of a card-wide link.
   let {
     match,
-    gutterRight = false,
     blurred = false,
-  }: { match: ClientMatch | null; gutterRight?: boolean; blurred?: boolean } = $props();
+  }: { match: ClientMatch | null; blurred?: boolean } = $props();
 </script>
 
 {#if match}
   <div
     class={[
       'mt-3 flex items-center gap-2 border-t border-dashed border-border pt-2.5',
-      gutterRight && 'pr-9',
       blurred && 'pointer-events-none select-none opacity-90 blur-[1.5px]',
     ]}
     aria-label={blurred

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -493,14 +493,18 @@
        should not compete with Save for attention). `pointer-coarse` keeps it visible on
        touch, which has no hover to reveal anything. -->
   <div class="flex items-center gap-2 border-t border-border px-4 py-2.5">
-    <!-- No `aria-pressed` here, unlike the compact glyph: this button's NAME already
-         changes with the state, so the toggle role would have a screen reader announce
-         "On your board, pressed" — the same fact twice, in two vocabularies. The glyph
-         needs it precisely because its name cannot say which state it is in. -->
+    <!-- No `aria-pressed`, unlike the compact glyph: this button's visible name already
+         changes with the state, so the toggle role would announce the same fact twice in
+         two vocabularies. The glyph needs it precisely because its name cannot.
+         But only half of that visible name is an action. "Save to board" says what
+         activating does; "On your board" is a state, and on its own it leaves a screen
+         reader user with a button whose effect is unstated. So the saved case — and only
+         it — overrides the name with the action, while sighted readers keep the state. -->
     <button
       type="button"
       onclick={toggleSave}
       disabled={saving}
+      aria-label={saved ? 'Remove from your board' : undefined}
       class={[
         'flex h-9 items-center gap-2 rounded-lg px-3 text-sm font-medium transition disabled:pointer-events-none disabled:opacity-50',
         saved

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -246,10 +246,11 @@
        The name truncates to a single line, so a long company (e.g. "Veterinary
        Emergency Group (VEG)") keeps the logo centred and the card rhythm even
        instead of wrapping into a ragged multi-line header. -->
-  <!-- pr-20 reserves the top-right corner for the save button AND the "Add to
-       list" button beside it (both overlays outside this link), so the timestamp
-       never slides under either. -->
-  <div class="flex items-center justify-between gap-3 pr-20">
+  <!-- Reserves the top-right corner for the overlays outside this link, so the timestamp
+       never slides under one. A compact card still keeps both Save and "Add to list" up
+       here and needs the wider gutter; a normal card has moved Save into the action row
+       at its foot, leaving only "Add to list". -->
+  <div class={['flex items-center justify-between gap-3', compact ? 'pr-20' : 'pr-11']}>
     <div class="flex min-w-0 items-center gap-2">
       <EntityLogo
         name={job.company || 'Unknown company'}
@@ -353,19 +354,15 @@
     <p class="mt-2 line-clamp-2 text-sm text-muted-foreground">{blurb}</p>
   {/if}
 
-  <!-- sm:pr-9 (when the hide control is present) reserves the bottom-right corner for
-       it — the counterpart to the header's pr-9 for the save button — so the skills
-       tail and the salary never slide under the icon. Only from `sm` up: below it the
-       salary sits on its own line, well clear of the corner.
+  <!-- No corner gutter here any more: Hide moved into the action row at the foot of the
+       card, so nothing overlays this corner and the skills tail and salary can use the
+       full width.
        On a phone the salary is ~160px of the ~360px card, so sharing a row with it
        squeezed the chips into a five-line stack. Stacking the two below `sm` gives the
        chips the full width (three lines become two); from `sm` up the original
        chips-left / salary-right row is unchanged. -->
   <div
-    class={[
-      'mt-3 flex flex-col items-start gap-1.5 sm:flex-row sm:items-end sm:justify-between sm:gap-3',
-      onHide && 'sm:pr-9',
-    ]}
+    class="mt-3 flex flex-col items-start gap-1.5 sm:flex-row sm:items-end sm:justify-between sm:gap-3"
   >
     <!-- flex-1 (not the default basis:auto) so the chips get every pixel the salary
          doesn't need. With basis:auto the row's width is derived from its max-content
@@ -411,9 +408,9 @@
   <!-- Card-level profile match: the real client-computed coverage bar for a signed-in
        viewer with a skills profile, the blurred teaser for one without. `blurred` is
        gated on there being no real match too, so the two props cannot contradict each
-       other and render a genuine score under a blur. `gutterRight` keeps the percent
-       clear of the feed's bottom-right hide control. -->
-  <JobMatchBar match={match ?? teaser} blurred={!match && !!teaser} gutterRight={!!onHide} />
+       other and render a genuine score under a blur. No `gutterRight`: the hide control
+       it used to keep clear of now lives in the action row below, not over this corner. -->
+  <JobMatchBar match={match ?? teaser} blurred={!match && !!teaser} />
   {#if teaser}
     <!-- The sighted invitation, under the blurred strip rather than over it — the same
          icon + line the job page's own match block uses below its teaser. `aria-hidden`
@@ -422,7 +419,7 @@
          No button here (unlike the job page's): a second activation target inside this
          <a> would be invalid markup, and the card itself is already the link. -->
     <div
-      class={['mt-1.5 flex items-center justify-center gap-1.5 text-xs text-muted-foreground', onHide && 'pr-9']}
+      class="mt-1.5 flex items-center justify-center gap-1.5 text-xs text-muted-foreground"
       aria-hidden="true"
     >
       {#if matchState === 'guest'}
@@ -454,44 +451,75 @@
   </div>
 {/if}
 
-<!-- Save toggle: an icon-only overlay in the card's top-right corner. It sits
-     outside the <a> (a sibling, not a descendant), so clicking it toggles the
-     bookmark without navigating to the job. -->
-<button
-  type="button"
-  onclick={toggleSave}
-  disabled={saving}
-  aria-pressed={saved}
-  aria-label={saved ? 'Remove from saved' : 'Save job'}
-  title={saved ? 'Saved' : 'Save'}
-  class={[
-    'absolute right-2.5 top-4 grid size-8 place-items-center rounded-lg transition hover:bg-accent hover:text-brand disabled:pointer-events-none disabled:opacity-50',
-    saved ? 'text-brand' : 'text-muted-foreground',
-  ]}
->
-  <Bookmark class="size-[1.05rem] {saved ? 'fill-current' : ''}" aria-hidden="true" />
-</button>
+<!-- Save toggle. Outside the <a> (a sibling, not a descendant) either way, so activating
+     it never navigates to the posting.
 
-<!-- Add-to-list: a second overlay beside Save, independent of it — a job can be
-     saved, listed, both, or neither. -->
-<AddToListButton jobSlug={job.public_slug} class="absolute right-12 top-4" />
-
-<!-- Hide control: only the browse feed passes `onHide`, so this appears there and
-     nowhere else. A quiet icon in the card's bottom-right corner, revealed on hover
-     (and on keyboard focus). Touch devices have no hover, so `pointer-coarse` keeps it
-     always visible there. It's an overlay sibling of the card link, so hiding never
-     navigates. No background plate — the bottom row reserves a pr-9 gutter for it, so
-     nothing renders underneath and it reads as a bare icon (mirrors the save button). -->
-{#if onHide}
+     Two presentations, one rule: a labelled button on a normal card, the older icon-only
+     overlay in `compact`, where the narrow chat column has no width to spend on a word.
+     The label is the point — saving now puts the job on the tracking board, and an
+     unlabelled glyph in a corner asked people to guess that. It says which of the two
+     states it is in rather than which action it performs, because the state is what a
+     card in a long feed has to answer at a glance. -->
+{#if compact}
   <button
     type="button"
-    onclick={hide}
-    disabled={hiding}
-    aria-label="Hide this job"
-    title="Not interested — hide this job"
-    class="absolute bottom-2.5 right-2.5 grid size-8 place-items-center rounded-lg text-muted-foreground opacity-0 transition hover:bg-accent hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100 pointer-coarse:opacity-100 disabled:pointer-events-none disabled:opacity-50"
+    onclick={toggleSave}
+    disabled={saving}
+    aria-pressed={saved}
+    aria-label={saved ? 'Remove from your board' : 'Save to your board'}
+    title={saved ? 'On your board' : 'Save to board'}
+    class={[
+      'absolute right-2.5 top-4 grid size-8 place-items-center rounded-lg transition hover:bg-accent hover:text-brand disabled:pointer-events-none disabled:opacity-50',
+      saved ? 'text-brand' : 'text-muted-foreground',
+    ]}
   >
-    <EyeOff class="size-3.5" aria-hidden="true" />
+    <Bookmark class="size-[1.05rem] {saved ? 'fill-current' : ''}" aria-hidden="true" />
   </button>
+{:else}
+  <!-- The card's action row. Save leads it; Hide, where the feed asked for one, sits at
+       the far end. Hide used to be an overlay pinned to the card's bottom-right corner,
+       which is exactly where this row now is — so it moves in here rather than being
+       covered by it, and it keeps its hover-reveal (a destructive-feeling gesture that
+       should not compete with Save for attention). `pointer-coarse` keeps it visible on
+       touch, which has no hover to reveal anything. -->
+  <div class="flex items-center gap-2 border-t border-border px-4 py-2.5">
+    <button
+      type="button"
+      onclick={toggleSave}
+      disabled={saving}
+      aria-pressed={saved}
+      class={[
+        'flex h-9 items-center gap-2 rounded-lg px-3 text-sm font-medium transition disabled:pointer-events-none disabled:opacity-50',
+        saved
+          ? 'bg-brand/10 text-brand hover:bg-brand/15'
+          : 'border border-border text-foreground hover:bg-accent',
+      ]}
+    >
+      <Bookmark class="size-4 {saved ? 'fill-current' : ''}" aria-hidden="true" />
+      {saved ? 'On your board' : 'Save to board'}
+    </button>
+
+    {#if onHide}
+      <button
+        type="button"
+        onclick={hide}
+        disabled={hiding}
+        aria-label="Hide this job"
+        title="Not interested — hide this job"
+        class="ml-auto grid size-8 place-items-center rounded-lg text-muted-foreground opacity-0 transition hover:bg-accent hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100 pointer-coarse:opacity-100 disabled:pointer-events-none disabled:opacity-50"
+      >
+        <EyeOff class="size-3.5" aria-hidden="true" />
+      </button>
+    {/if}
+  </div>
 {/if}
+
+<!-- Add-to-list: independent of Save — a job can be saved, listed, both, or neither.
+     It sits where Save's overlay used to on a compact card, and takes that corner itself
+     on a normal one, where Save has moved down into the action row. -->
+<AddToListButton
+  jobSlug={job.public_slug}
+  class={compact ? 'absolute right-12 top-4' : 'absolute right-2.5 top-4'}
+/>
+
 </div>

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -36,19 +36,28 @@
   // job, so the browse list shows what's been seen. The My Jobs surfaces (where
   // every card is viewed by definition) pass `dimViewed={false}` to opt out.
   // `newTab` opens the job in a new browser tab (used when the card is rendered
-  // inside the assistant chat, so the conversation stays open). `compact` tightens
-  // the card for the narrow chat column (smaller padding + title, one-line title,
-  // no blurb). Both default off so the jobs list / company pages are unchanged.
+  // inside the assistant chat, so the conversation stays open). Both default off so the
+  // jobs list / company pages are unchanged.
+  //
+  // `compact` is the narrow-chat-column card, and it decides more than density. As well
+  // as the smaller padding and title, the one-line title and the dropped blurb, it
+  // selects the card's whole control inventory: there is no action row, so Save stays
+  // the corner glyph it always was and `onHide` has nowhere to render. The two concerns
+  // are fused on purpose — the column is ~360px wide, and every control that earns a
+  // word on a full card has to give it back here. Splitting them would be a second flag
+  // whose only honest value is the same as this one's.
+  //
   // `footer` is an optional actions row rendered inside the card, below the link
   // content (a sibling of the <a>, never nested in it — so its interactive controls
-  // don't fight the card's navigation). The hidden list passes an un-hide control here.
+  // don't fight the card's navigation). The hidden list passes an un-hide control here,
+  // and gets it as a second row under the card's own Save row.
   //
-  // `onHide` is the feed's hook for the "hide this job" gesture: when set (only the
-  // browse feed passes it), the card shows a hover-revealed hide control, and after
-  // a successful dismiss it calls back with the slug so the feed can surface an undo
-  // affordance. Surfaces that reuse JobRow without it (saved/hidden lists, tracking
-  // board, assistant chat) get no hide control — leaving it out scopes the gesture
-  // to the feed.
+  // `onHide` is the feed's hook for the "hide this job" gesture: when set on a NON-compact
+  // card (only the browse feed passes it), the action row gains a hover-revealed hide
+  // control, and after a successful dismiss it calls back with the slug so the feed can
+  // surface an undo affordance. Surfaces that reuse JobRow without it (saved/hidden
+  // lists, tracking board, assistant chat) get no hide control — leaving it out scopes
+  // the gesture to the feed.
   let {
     job,
     dimViewed = true,
@@ -441,12 +450,13 @@
   <span class="sr-only">{matchInvite}</span>
 {/if}
 
-{#if footer}
-  <!-- Optional in-card actions row (e.g. the hidden list's un-hide control, the
-       assistant deck's rationale), divided from the content and rendered outside
-       the <a> so its controls stay clickable. Its inline padding tracks the card's
-       own, or the row would sit 4px out of line in a compact card. -->
-  <div class={['border-t border-border py-2.5', compact ? 'px-3' : 'px-4']}>
+{#if footer && compact}
+  <!-- Optional in-card actions row (e.g. the assistant deck's rationale), divided from
+       the content and rendered outside the <a> so its controls stay clickable. Its
+       inline padding tracks the card's own, or the row would sit 4px out of line.
+       A normal card has an action row of its own, and the caller's controls join it
+       rather than stacking a second bordered row under the first. -->
+  <div class="border-t border-border px-3 py-2.5">
     {@render footer()}
   </div>
 {/if}
@@ -483,11 +493,14 @@
        should not compete with Save for attention). `pointer-coarse` keeps it visible on
        touch, which has no hover to reveal anything. -->
   <div class="flex items-center gap-2 border-t border-border px-4 py-2.5">
+    <!-- No `aria-pressed` here, unlike the compact glyph: this button's NAME already
+         changes with the state, so the toggle role would have a screen reader announce
+         "On your board, pressed" — the same fact twice, in two vocabularies. The glyph
+         needs it precisely because its name cannot say which state it is in. -->
     <button
       type="button"
       onclick={toggleSave}
       disabled={saving}
-      aria-pressed={saved}
       class={[
         'flex h-9 items-center gap-2 rounded-lg px-3 text-sm font-medium transition disabled:pointer-events-none disabled:opacity-50',
         saved
@@ -498,6 +511,10 @@
       <Bookmark class="size-4 {saved ? 'fill-current' : ''}" aria-hidden="true" />
       {saved ? 'On your board' : 'Save to board'}
     </button>
+
+    <!-- The caller's own controls share this row rather than getting a second bordered
+         one under it — two stacked rules under one card read as a layout mistake. -->
+    {@render footer?.()}
 
     {#if onHide}
       <button

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -4,6 +4,7 @@
   import { afterNavigate, goto } from '$app/navigation';
   import { signinUrl } from '$lib/signin';
   import HeaderSearch from './HeaderSearch.svelte';
+  import { rolePlaceholders } from '$lib/placeholderRoles';
   import HeaderMenu from './HeaderMenu.svelte';
   import BrandMark from './BrandMark.svelte';
   import { isFullBleedRoute } from '$lib/shellLayout';
@@ -19,10 +20,17 @@
   // trigger; everywhere else the same box navigates to the feed carrying the same
   // filter.
   //
-  // `listKind` survives only to word the placeholder — the box asks the page nothing
-  // else. It used to select between two components that shared everything but that one
-  // behaviour and drifted apart in the parts they shared.
-  const listKind = $derived(page.url.pathname === '/companies' ? 'companies' : 'jobs');
+  // How the box words itself is all the page decides — it asks nothing else. This used
+  // to select between two components that shared everything but that one behaviour and
+  // drifted apart in the parts they shared.
+  //
+  // The companies box rotates nothing: the roles the jobs box cycles through would be
+  // answering a question it does not ask.
+  const searchWording = $derived(
+    page.url.pathname === '/companies'
+      ? { placeholder: 'Search companies…', label: 'Search companies', rotating: [] }
+      : { placeholder: 'Search jobs…', label: 'Search jobs', rotating: rolePlaceholders() },
+  );
 
   // The homepage is the one exception: its whole content is a large centred copy of
   // this same box, so the header renders none. Two identical fields on one screen make
@@ -135,9 +143,7 @@
           {/each}
         </nav>
       {:else}
-        <HeaderSearch
-          placeholder={listKind === 'companies' ? 'Search companies…' : 'Search jobs…'}
-        />
+        <HeaderSearch {...searchWording} />
       {/if}
     </div>
 

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -28,8 +28,8 @@
   // answering a question it does not ask.
   const searchWording = $derived(
     page.url.pathname === '/companies'
-      ? { placeholder: 'Search companies…', label: 'Search companies', rotating: [] }
-      : { placeholder: 'Search jobs…', label: 'Search jobs', rotating: rolePlaceholders() },
+      ? { placeholder: 'Search companies…', label: 'Search companies' }
+      : { placeholder: rolePlaceholders(), label: 'Search jobs' },
   );
 
   // The homepage is the one exception: its whole content is a large centred copy of

--- a/web/src/lib/components/filters/AiFilterButton.svelte
+++ b/web/src/lib/components/filters/AiFilterButton.svelte
@@ -8,7 +8,13 @@
   // Rendered for everyone, signed in or not. Hiding it from signed-out visitors would
   // hide the feature from exactly the people who have not yet been given a reason to
   // sign in; the gate is on activation, which sends them to /signin.
-  let { store }: { store: FilterStore } = $props();
+  //
+  // `onApplied` fires once the dialog has written its filters. It exists for the host
+  // that DEFERS its own edits — the filter modal — where the dialog's write goes
+  // straight to the live store and would then be overwritten by whatever the modal had
+  // staged. There the host closes itself, which is honest: describing the search in
+  // words replaces the filters, so there is nothing left to stage.
+  let { store, onApplied }: { store: FilterStore; onApplied?: () => void } = $props();
 
   let open = $state(false);
 
@@ -32,5 +38,5 @@
 </button>
 
 {#if open}
-  <AiFilterDialog {store} onclose={() => (open = false)} />
+  <AiFilterDialog {store} {onApplied} onclose={() => (open = false)} />
 {/if}

--- a/web/src/lib/components/filters/AiFilterDialog.svelte
+++ b/web/src/lib/components/filters/AiFilterDialog.svelte
@@ -16,7 +16,11 @@
   // canonicalised against the real dictionaries. Nothing is applied until the preview
   // is accepted, and the preview names whatever the server could not place — a drop the
   // user is not told about is indistinguishable from a value that WAS applied.
-  let { store, onclose }: { store: FilterStore; onclose: () => void } = $props();
+  let {
+    store,
+    onclose,
+    onApplied,
+  }: { store: FilterStore; onclose: () => void; onApplied?: () => void } = $props();
 
   /** One previewed value. `exclude` draws it struck through, as the sidebar does; `key`
    *  is its identity in the keyed `{#each}` — `param:value`, never the label, which two
@@ -95,6 +99,11 @@
     if (!result) return;
     store.apply(filtersToParams(filtersFromInterpretation(result)).toString());
     onclose();
+    // After this dialog, not after its host's own apply: the write above is already
+    // live, so a host that defers its edits (the filter modal) has to hear about it —
+    // otherwise it would later apply the filters it staged before this ran, silently
+    // undoing them. See AiFilterButton for why closing is the honest response.
+    onApplied?.();
   }
 </script>
 

--- a/web/src/lib/components/filters/AiFilterDialog.svelte
+++ b/web/src/lib/components/filters/AiFilterDialog.svelte
@@ -107,13 +107,26 @@
   }
 </script>
 
-<svelte:window onkeydown={(e) => e.key === 'Escape' && onclose()} />
+<!-- Moved to the body: this dialog is opened from the filter modal, and before that from
+     the filter sidebar, which is `sticky` and so opens a stacking context
+     unconditionally. Inside one, `z-50` is scoped to that layer — so the overlay painted
+     UNDER the job cards, which come later in the document. No z-index can climb out of a
+     stacking context.
 
-<!-- Moved to the body: this dialog is rendered from the filter sidebar, and that sidebar
-     is `sticky`, which opens a stacking context unconditionally. Inside one, `z-50` is
-     scoped to the sidebar's layer — so the overlay painted UNDER the job cards, which
-     come later in the document. No z-index can climb out of a stacking context. -->
-<div class="fixed inset-0 z-50 flex items-center justify-center p-4" {@attach portal()}>
+     Escape is handled HERE, on the portalled root, rather than on <svelte:window>. Its
+     host now has an Escape handler of its own (FilterModalShell), and two window
+     listeners both fire for one key — so a single press dismissed this dialog AND the
+     modal behind it. Stopping propagation at this element keeps the key from ever
+     reaching the window, and the focus trap below guarantees the press lands in here. -->
+<div
+  class="fixed inset-0 z-50 flex items-center justify-center p-4"
+  onkeydown={(e) => {
+    if (e.key !== 'Escape') return;
+    e.stopPropagation();
+    onclose();
+  }}
+  {@attach portal()}
+>
   <button type="button" aria-label="Close dialog" class="absolute inset-0 bg-black/50" onclick={onclose}></button>
 
   <div

--- a/web/src/lib/components/filters/FilterModal.svelte
+++ b/web/src/lib/components/filters/FilterModal.svelte
@@ -27,6 +27,7 @@
   import CategoryPane from './CategoryPane.svelte';
   import LocationPane from './LocationPane.svelte';
   import FilterModalShell from './FilterModalShell.svelte';
+  import AiFilterButton from './AiFilterButton.svelte';
   import SavedSearches from '../SavedSearches.svelte';
 
   // The job-search filter modal: a thin wrapper over FilterModalShell that supplies the
@@ -265,7 +266,7 @@
   {pane}
   headerAction={showProfileAction ? profileAction : undefined}
   {titleHint}
-  extra={extra ? extraStaged : undefined}
+  extra={extra || (store && !plain) ? aboveThePane : undefined}
   {footerNote}
 />
 
@@ -318,7 +319,20 @@
   {/if}
 {/snippet}
 
-{#snippet extraStaged()}
+{#snippet aboveThePane()}
+  <!-- The AI entry point lives here rather than in the filters sidebar, which is
+       `hidden md:block` — so on a phone, where the modal is the ONLY way to reach
+       filters at all, the feature did not exist. Above the pane because it is a way to
+       FILL the filters, so it reads before the controls that refine them.
+
+       `onApplied={onClose}` is not decoration: the dialog writes straight to the live
+       store, while this modal defers its own edits until Apply. Left open, it would
+       later apply what it had staged before the dialog ran and silently undo it. -->
+  {#if store && !plain}
+    <div class="mb-4">
+      <AiFilterButton {store} onApplied={onClose} />
+    </div>
+  {/if}
   {@render extra?.(staged)}
 {/snippet}
 

--- a/web/src/lib/components/filters/FilterModal.svelte
+++ b/web/src/lib/components/filters/FilterModal.svelte
@@ -221,6 +221,11 @@
 
   const applyDisabled = $derived(canApply ? !canApply(staged.value) : false);
 
+  // Whether this modal offers the "describe your filters in words" entry point. It needs
+  // a live store to write into, and it makes no sense in `plain` reuse (the profile
+  // editor), where a facet value is a plain choice rather than a search.
+  const showAiEntry = $derived(Boolean(store) && !plain);
+
   // A non-preset value (hand-edited URL) has no exact stop, so it reads as "Any"
   // (the rightmost stop) rather than snapping to "Today".
   const freshnessIndex = $derived.by(() => {
@@ -266,7 +271,7 @@
   {pane}
   headerAction={showProfileAction ? profileAction : undefined}
   {titleHint}
-  extra={extra || (store && !plain) ? aboveThePane : undefined}
+  extra={extra || showAiEntry ? aboveThePane : undefined}
   {footerNote}
 />
 
@@ -328,7 +333,7 @@
        `onApplied={onClose}` is not decoration: the dialog writes straight to the live
        store, while this modal defers its own edits until Apply. Left open, it would
        later apply what it had staged before the dialog ran and silently undo it. -->
-  {#if store && !plain}
+  {#if showAiEntry && store}
     <div class="mb-4">
       <AiFilterButton {store} onApplied={onClose} />
     </div>

--- a/web/src/lib/components/filters/FilterSummary.svelte
+++ b/web/src/lib/components/filters/FilterSummary.svelte
@@ -4,7 +4,6 @@
   import { experienceLabel, freshnessLabel } from '$lib/filterControls';
   import FilterSummaryShell, { type SummaryChip, type SummaryGroup } from './FilterSummaryShell.svelte';
   import SaveSearchAlert from './SaveSearchAlert.svelte';
-  import AiFilterButton from './AiFilterButton.svelte';
 
   // The job filters sidebar: a summary of the *applied* filters as chips grouped by
   // facet, over the reusable FilterSummaryShell. Removing a chip edits the live store
@@ -99,9 +98,6 @@
 </script>
 
 <FilterSummaryShell {groups} active={store.active} onReset={() => store.clear()} {onOpen} {description}>
-  {#snippet beforeButton()}
-    <AiFilterButton {store} />
-  {/snippet}
   {#snippet afterButton()}
     {#if canSave}
       <SaveSearchAlert query={current} variant="full" alerts="manage" />

--- a/web/src/lib/components/filters/FilterSummaryShell.svelte
+++ b/web/src/lib/components/filters/FilterSummaryShell.svelte
@@ -38,7 +38,6 @@
     onOpen,
     description,
     afterButton,
-    beforeButton,
   }: {
     groups: SummaryGroup[];
     active: number;
@@ -50,11 +49,6 @@
     /** Optional content under the All-filters button — the job summary uses it for the
      *  "Save filter" affordance; the company summary omits it. */
     afterButton?: Snippet;
-    /** Optional content ABOVE the All-filters button — the job summary uses it for the
-     *  "Describe with AI" entry point. Above rather than below because it is a way to
-     *  FILL the filters, so it reads before the controls that refine them; the company
-     *  summary omits it, since the interpretation speaks the job filter's vocabulary. */
-    beforeButton?: Snippet;
   } = $props();
 </script>
 
@@ -70,8 +64,6 @@
       <p class="text-xs text-muted-foreground">{description}</p>
     {/if}
   </div>
-
-  {@render beforeButton?.()}
 
   <button
     type="button"

--- a/web/src/lib/placeholderRoles.test.ts
+++ b/web/src/lib/placeholderRoles.test.ts
@@ -31,17 +31,18 @@ describe('PLACEHOLDER_ROLES', () => {
 });
 
 describe('rolePlaceholders', () => {
-  it('composes one placeholder per role, in list order', () => {
-    const placeholders = rolePlaceholders();
-    expect(placeholders).toEqual(
-      PLACEHOLDER_ROLES.map((role) => expect.stringContaining(categoryLabel(role))),
-    );
-  });
-
-  it('phrases each one as an example rather than a command', () => {
-    for (const text of rolePlaceholders()) {
-      expect(text).toMatch(/^Search jobs — e\.g\. /);
-    }
+  // Pinned literally rather than re-derived from PLACEHOLDER_ROLES + categoryLabel:
+  // mapping the same inputs through the same functions would restate the implementation
+  // and pass however the wording changed. These are the strings that ship.
+  it('composes the placeholders a visitor actually reads', () => {
+    expect(rolePlaceholders()).toEqual([
+      'Search jobs — e.g. Backend',
+      'Search jobs — e.g. Frontend',
+      'Search jobs — e.g. DevOps',
+      'Search jobs — e.g. QA',
+      'Search jobs — e.g. Data Science',
+      'Search jobs — e.g. Product',
+    ]);
   });
 
   // Under prefers-reduced-motion the first entry is the only one anyone sees, so it

--- a/web/src/lib/placeholderRoles.test.ts
+++ b/web/src/lib/placeholderRoles.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { PLACEHOLDER_ROLES, rolePlaceholders } from './placeholderRoles';
+import { CATEGORY_VALUES } from './generated/contracts';
+import { categoryLabel } from './labels';
+
+// The jobs search box's rotating examples. The list is category KEYS, not display
+// strings, so these tests are mostly about that guarantee holding at runtime too:
+// the type check is what catches a retired category, and a runtime assertion is what
+// catches the list being reordered into something the box would render as a blank.
+
+describe('PLACEHOLDER_ROLES', () => {
+  it('is a non-empty list', () => {
+    expect(PLACEHOLDER_ROLES.length).toBeGreaterThan(0);
+  });
+
+  it('holds no duplicates — a repeat reads as the rotation having stalled', () => {
+    expect(new Set(PLACEHOLDER_ROLES).size).toBe(PLACEHOLDER_ROLES.length);
+  });
+
+  it('names only categories the backend vocabulary carries', () => {
+    for (const role of PLACEHOLDER_ROLES) {
+      expect(CATEGORY_VALUES).toContain(role);
+    }
+  });
+
+  it('resolves every key to a non-empty label', () => {
+    for (const role of PLACEHOLDER_ROLES) {
+      expect(categoryLabel(role).trim()).not.toBe('');
+    }
+  });
+});
+
+describe('rolePlaceholders', () => {
+  it('composes one placeholder per role, in list order', () => {
+    const placeholders = rolePlaceholders();
+    expect(placeholders).toEqual(
+      PLACEHOLDER_ROLES.map((role) => expect.stringContaining(categoryLabel(role))),
+    );
+  });
+
+  it('phrases each one as an example rather than a command', () => {
+    for (const text of rolePlaceholders()) {
+      expect(text).toMatch(/^Search jobs — e\.g\. /);
+    }
+  });
+
+  // Under prefers-reduced-motion the first entry is the only one anyone sees, so it
+  // carries the whole weight of answering "what can I type here".
+  it('leads with a role rather than the catch-all category', () => {
+    expect(PLACEHOLDER_ROLES[0]).not.toBe('other');
+  });
+});

--- a/web/src/lib/placeholderRoles.ts
+++ b/web/src/lib/placeholderRoles.ts
@@ -1,0 +1,36 @@
+// The rotating examples the jobs search box offers when it is empty and untouched.
+//
+// The list is category KEYS, not display strings. A hand-written ['QA', 'DevOps'] would
+// be a second copy of a vocabulary the backend already owns, and it would rot silently —
+// a category renamed or retired upstream would leave the box confidently offering a value
+// the feed can no longer filter on. Typing the array as Category[] turns that into a
+// build failure, the same guard CATEGORY_LABELS uses for the same reason.
+//
+// The module composes whole placeholder strings rather than exposing bare labels for a
+// component to interpolate: the phrasing is then testable and lives in one place, and
+// HeaderSearch stays a box that renders what it is handed instead of learning that one of
+// its callers is about jobs.
+//
+// Pure by design (no Svelte, no DOM), like facetModel.ts and suggestions.ts beside it.
+
+import type { Category } from './generated/contracts';
+import { categoryLabel } from './labels';
+
+/** The roles the box cycles through, in rotation order.
+ *
+ *  Busiest-looking first: under prefers-reduced-motion the rotation never starts, so the
+ *  first entry is the only one anyone sees and carries the whole weight of answering
+ *  "what can I type here". Six is about what a visitor will sit through before typing. */
+export const PLACEHOLDER_ROLES: Category[] = [
+  'backend',
+  'frontend',
+  'devops',
+  'qa',
+  'data_science',
+  'product',
+];
+
+/** The full placeholder strings for the jobs search box, in rotation order. */
+export function rolePlaceholders(): string[] {
+  return PLACEHOLDER_ROLES.map((role) => `Search jobs — e.g. ${categoryLabel(role)}`);
+}

--- a/web/src/routes/my/tracking/+layout.svelte
+++ b/web/src/routes/my/tracking/+layout.svelte
@@ -3,6 +3,7 @@
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
   import { routeTabClass, tablist } from '$lib/actions/tablist';
+  import AccountSetupCard from '$lib/components/AccountSetupCard.svelte';
 
   let { children }: { children: Snippet } = $props();
 
@@ -36,6 +37,11 @@
 
 <div class="flex flex-col gap-4">
   <h1 class="text-2xl font-semibold tracking-tight">Tracking</h1>
+
+  <!-- Above the tablist, not inside the panel: what is left to set up belongs to the
+       account, not to whichever view of the board happens to be open — and a card inside
+       the panel would be re-announced on every tab switch. -->
+  <AccountSetupCard />
 
   <div role="tablist" aria-label="Tracking view" use:tablist={path} class="flex items-center gap-1">
     <a


### PR DESCRIPTION
An outside reviewer walked the product and left five notes. Four described
surfaces that already existed but could not be reached, or reached only one hand.
This is those four.

## What each note turned out to be

**"The search should have a placeholder for job roles."** It now shows one and
cycles it: Backend, Frontend, DevOps, QA, Data Science, Product. The list is
category KEYS from the generated contract, not display strings, so a category
retired on the backend fails the build instead of leaving the box offering a
value the feed can no longer filter on.

Rotating a placeholder that was also the field's accessible name would have had a
screen reader announce the input as whatever example was on screen, so the prop
split. `label` is required rather than defaulted, so the coupling cannot come
back at the next call site.

Review caught that the flagship surface was dead: the homepage passes `autofocus`,
and the mount-time focus fires the field's own handler, which stops the rotation
before the first tick. The undo now sits beside the `dismissed` one three lines
above, which exists for exactly the same reason.

**"Incorporate the AI filter into the search so it doesn't take up the last
column."** It moved into the filter modal. It also never existed on a phone: it
lived in the filters sidebar, and that aside is `hidden md:block`, so below that
breakpoint — where the modal is the only route to filters at all — the feature was
simply absent.

**"Let me track before I apply."** The state already existed. `preparing` is a
real stage and the board's first column, added for CV tailoring; nothing in the
feed could put a posting into it. Saving a job now does. This is read-side only —
the board was discarding saved rows when laying out its columns — so there is no
migration, no backfill, no stage written on anyone's behalf, and it applies to
every job saved before the change as well as after.

**"Add an activation wizard — how complete is my account."** A card at the top of
the tracking section listing what is left, plus a quiet dot on the menu button.
Four of its five steps are the onboarding wizard's own, so the card cannot drift
from the funnel it follows. The fifth is an alert: a completeness meter that ends
at a filled-in form measures paperwork rather than activation.

## The fifth note is not here

"The initial jobs listed are not relevant unless you set the filters." The match
sort is already live — `PUBLIC_MATCH_SORT=1` is set on the host, in
`env/hire-web.env` rather than `.env`. What remains is that `defaultSortFor('')`
still returns `newest`, so it is never the *default* ordering. Changing that
default is a separate decision and is deliberately not taken here.

## Review

Both axes (standards + spec) ran over every change. They found one dead feature
(the homepage rotation), two real defects (a stop mid-fade left the box with no
placeholder at all; one Escape closed the AI dialog *and* the modal behind it),
an accessibility bug (an aria-label silently swallowing the dot's screen-reader
line), and a correctness one (a paused subscription counting as a working alert).
All are fixed in the branch. Two deviations were argued into the specs rather
than reverted.

No backend, no schema, no new endpoint.

Plan and specs: `openspec/changes/onboarding-feedback-pass/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Job search now shows rotating role examples, stopping when you interact with the field and respecting reduced-motion preferences.
  - AI-assisted filtering is available inside the filters modal across screen sizes.
  - Saving a job places it in the Preparing tracking column.
  - Added account setup guidance on the tracking page, with links to incomplete steps and a header indicator.
  - Standard job cards now include a labeled Save action.

- **Bug Fixes**
  - Clearing a stage no longer removes saved jobs from tracking.
  - Improved filter modal behavior when applying AI filters or pressing Escape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->