### PR TITLE
Record the auto-apply worker the release list was missing

### DIFF
--- a/deploy/bin/release.sh
+++ b/deploy/bin/release.sh
@@ -229,7 +229,10 @@ if [ "$app" = freehire ]; then
   # more of it.
   # auto-apply-orchestrate joined 2026-09-05: a long-lived Inngest function server, not a
   # cron worker, but it ships from hire-current the same way every other binary here does.
-  for w in migrate onboarding broadcast ingest enrich embed similar-backfill search-drain reindex reindex-companies import-collections import-yc import-company-industries queue-metrics tg-ingest tg-extract liveness notify remind nudge apple-revoke auth-cleanup capture-apply-form backfill-derive backfill-company-names backfill-descriptions backfill-application-events backfill-slug-folded backfill-duplicate-marker-owner backfill-company-type-hint billing-sync build-suggestions merge-companies add-board harvest-orphans recount-companies rollup-stats rollup-facets rollup-company rollup-views classify-mail resolve-url gmail-sync cal-sync mail-ingest hydrate-adzuna-description seed-adzuna-description-queue ingest-scheduler schedule-board auto-apply-orchestrate social-digest; do
+  # auto-apply joined the same day, found missing entirely: the timer-driven drain of
+  # auto_apply_queue (headless Chrome fill+submit) had never actually been built or
+  # provisioned on this host, so an approved entry would sit in the queue forever.
+  for w in migrate onboarding broadcast ingest enrich embed similar-backfill search-drain reindex reindex-companies import-collections import-yc import-company-industries queue-metrics tg-ingest tg-extract liveness notify remind nudge apple-revoke auth-cleanup capture-apply-form backfill-derive backfill-company-names backfill-descriptions backfill-application-events backfill-slug-folded backfill-duplicate-marker-owner backfill-company-type-hint billing-sync build-suggestions merge-companies add-board harvest-orphans recount-companies rollup-stats rollup-facets rollup-company rollup-views classify-mail resolve-url gmail-sync cal-sync mail-ingest hydrate-adzuna-description seed-adzuna-description-queue ingest-scheduler schedule-board auto-apply-orchestrate auto-apply social-digest; do
     sudo -u freehire /usr/local/bin/go build -buildvcs=false -o "$w" "./cmd/$w"
   done
   # Every binary a freehire-*.service starts from hire-current has to have just been built,


### PR DESCRIPTION
`cmd/auto-apply` drains `auto_apply_queue` through a headless Chrome. Its systemd unit was on the host and its binary was not, because `release.sh`'s build list had never named it — so an approved entry would sit in the queue forever, with a timer firing on a missing executable and nothing on the success path to notice.

It is exactly the arrival the comment above that list keeps describing, and this is the tenth name added to it for the same reason.

## Why this is a separate PR

The fix was made on the host by another session, on a copy of `release.sh` that predated #2461 — so applying it silently removed the asset-attic block that #2461 had just added. Both are now merged in the host's copy and verified:

```
grep -c "asset attic"          -> 2
grep -c "auto-apply social-digest" -> 1
./deploy/check-drift.sh        -> bin: in sync, nginx: in sync
```

Recording it here is what stops the next hand-edit from starting from a copy that lacks one of them.

## Verification

- `shellcheck deploy/bin/release.sh` — clean
- `bash -n` on both the repo copy and the host copy
- `./deploy/check-drift.sh` — `bin: in sync`, `nginx: in sync`