### PR TITLE
Type the role into the search placeholder, one character at a time

### DIFF
--- a/openspec/changes/onboarding-feedback-pass/tasks.md
+++ b/openspec/changes/onboarding-feedback-pass/tasks.md
@@ -14,8 +14,10 @@
       permanently on first focus or input: advance every 2.5s, stop
       permanently on first focus or input, hold at index 0 under `prefers-reduced-motion`,
       fade via a `::placeholder` colour transition.
-- [x] 1.5 Pass `rolePlaceholders()` from the jobs call sites only; `/companies` keeps its
-      static placeholder.
+- [x] 1.5 Pass the role placeholder from the jobs call sites only; `/companies` keeps its
+      static one. (Superseded: `rolePlaceholders()` named here was replaced by the
+      `ROLE_PLACEHOLDER` constant when the crossfade became a per-character typing
+      animation — see specs/search-role-placeholder.)
 - [x] 1.6 simplify → tests green → `requesting-code-review` + `/code-review` → fix
       Critical/Important.
 

--- a/web/src/lib/components/HeaderSearch.svelte
+++ b/web/src/lib/components/HeaderSearch.svelte
@@ -19,6 +19,13 @@
   import { runLinkIntake, type LinkIntakeStep } from '$lib/linkIntake';
   import { commit, edit, emptyDraft, reconcile, type SearchDraft } from '$lib/searchDraft';
   import { starterSuggestions, type Suggestion } from '$lib/suggestions';
+  import {
+    TYPEWRITER_START,
+    completeWord,
+    typedTail,
+    typewriterStep,
+    type TypewriterState,
+  } from '$lib/placeholderRoles';
   import { cn } from '$lib/ui';
   import HeaderLocationFilter from './HeaderLocationFilter.svelte';
   import IntakeOutcome from './IntakeOutcome.svelte';
@@ -49,15 +56,17 @@
     counts = null,
     onOpenFilters,
   }: {
-    /** What an empty box shows. A single string is static; an array cycles through its
-     *  entries while the box is empty and untouched, fully composed by the caller (see
-     *  lib/placeholderRoles.ts).
+    /** What an empty box shows.
      *
-     *  One prop rather than a static one plus an override, because an override would
-     *  always win and leave the static string dead at every rotating call site — the
-     *  reader would have two candidates and no way to tell which one ships. Either way
-     *  this is never the field's accessible name; that is `label`. */
-    placeholder: string | string[];
+     *  A plain string is static. `{ prefix, roles }` types the roles one after another
+     *  into the tail of a sentence whose `prefix` never moves — see lib/placeholderRoles.ts,
+     *  which owns both the words and the stepping.
+     *
+     *  One prop rather than a static one plus an animated override, because an override
+     *  would always win and leave the static string dead at every animating call site —
+     *  the reader would have two candidates and no way to tell which one ships. Either
+     *  way this is never the field's accessible name; that is `label`. */
+    placeholder: string | { prefix: string; roles: string[] };
     /** The field's accessible name. Static, and required of every caller rather than
      *  defaulting to `placeholder`: the two were one prop until the placeholder learned
      *  to rotate, at which point a screen reader announced the input as whatever example
@@ -83,30 +92,27 @@
 
   const hero = $derived(size === 'hero');
 
-  // ---- the rotating placeholder ----
+  // ---- the typed placeholder ----
   //
   // Runs only while the box is empty and has never been touched. The first focus or
-  // keystroke stops it for the rest of the visit and freezes it on the entry then
-  // showing: text moving under the cursor while a query is being composed is the failure
-  // an animated placeholder invites, and reverting to a static string on stop would be a
-  // visible jump at the moment the visitor's attention is on the field.
+  // keystroke stops it for the rest of the visit — text moving under the cursor while a
+  // query is being composed is the failure an animated placeholder invites.
   //
-  // The list itself is composed in lib/placeholderRoles.ts, from the generated category
-  // vocabulary rather than from hand-written strings.
-  // Long enough to read the word and notice it is an example, short enough that a
-  // visitor who pauses sees it is a list rather than a typo. The fade is a fifth of it,
-  // so the box is legible for the great majority of each step.
-  const ROTATE_MS = 2500;
-  const FADE_MS = 200;
+  // Only the tail moves; `prefix` is never rewritten, so the sentence stays readable and
+  // the eye has one place to look. The words and the stepping both live in
+  // lib/placeholderRoles.ts, which is where they can be tested without a browser.
+  const typing = $derived(typeof placeholder === 'string' ? null : placeholder);
 
-  const rotation = $derived(Array.isArray(placeholder) ? placeholder : []);
+  let typewriter = $state<TypewriterState>(TYPEWRITER_START);
+  let typingStopped = $state(false);
 
-  let rotationIndex = $state(0);
-  let rotationStopped = $state(false);
-  let placeholderFading = $state(false);
-
-  function stopRotation() {
-    rotationStopped = true;
+  function stopTyping() {
+    if (typingStopped || !typing) return;
+    // Finish the word on the way out. Freezing on "Devo" reads as a typo rather than as
+    // an animation that stopped, and it would do so at the exact moment the visitor's
+    // attention arrived on the field.
+    typewriter = completeWord(typewriter, typing.roles);
+    typingStopped = true;
   }
 
   // Sampled AND subscribed: the OS-level setting can be turned on mid-visit, and reading
@@ -121,33 +127,36 @@
   });
 
   $effect(() => {
-    // Under reduced motion the first entry stands alone, so no timer is started at all.
-    if (rotationStopped || reduceMotion || rotation.length < 2) return;
+    if (typingStopped || !typing) return;
+    // Under reduced motion the first role stands whole and nothing is scheduled. Reading
+    // `typing.roles` before the return keeps this effect subscribed to the prop, so a
+    // caller that swaps its word list still restarts the animation.
+    const roles = typing.roles;
+    if (reduceMotion || roles.length === 0) return;
 
-    let swap: ReturnType<typeof setTimeout> | undefined;
-    const tick = setInterval(() => {
-      placeholderFading = true;
-      swap = setTimeout(() => {
-        rotationIndex = (rotationIndex + 1) % rotation.length;
-        placeholderFading = false;
-      }, FADE_MS);
-    }, ROTATE_MS);
-    return () => {
-      clearInterval(tick);
-      clearTimeout(swap);
-      // Every teardown path — a stop, an unmount, reduced motion switched on — can land
-      // inside the fade window, where the text is transparent and the swap that would
-      // restore it has just been cancelled. Without this the field keeps a placeholder
-      // nobody can see, which is worse than the one it was rotating away from.
-      placeholderFading = false;
+    // One chained timeout rather than an interval: every step has its own delay (a typed
+    // character, a faster deleted one, and the long hold on a finished word), so a fixed
+    // tick would have to be the shortest of them and then count its way to the others.
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const schedule = (from: TypewriterState) => {
+      const { next, delayMs } = typewriterStep(from, roles);
+      timer = setTimeout(() => {
+        typewriter = next;
+        schedule(next);
+      }, delayMs);
     };
+    schedule(typewriter);
+    return () => clearTimeout(timer);
   });
 
-  // `rotation[0]` is what server-rendered markup carries, since the effects above are
-  // client-only — so the box never paints empty and then fills in.
-  const shownPlaceholder = $derived(
-    Array.isArray(placeholder) ? (placeholder[rotationIndex] ?? placeholder[0] ?? '') : placeholder,
-  );
+  // Server-rendered markup carries the prefix with an empty tail, since the effect above
+  // is client-only — so the sentence is already there and only its last word arrives.
+  // Under reduced motion the first role is shown whole instead.
+  const shownPlaceholder = $derived.by(() => {
+    if (!typing) return placeholder as string;
+    if (reduceMotion && !typingStopped) return typing.prefix + (typing.roles[0] ?? '');
+    return typing.prefix + typedTail(typewriter, typing.roles);
+  });
 
   // How long the draft must sit still before the suggestions are refetched.
   //
@@ -197,7 +206,7 @@
     // which stops the placeholder rotation. On the homepage — where this box IS the
     // page, and the one surface the rotation exists for — that killed it before the
     // first tick. A caret nobody placed has not interrupted anything.
-    rotationStopped = false;
+    typingStopped = false;
   });
   // -1 means nothing is highlighted, which is the state the dropdown opens in: Enter
   // then falls through to the free-text search it has always run.
@@ -723,12 +732,12 @@
         // autofocused hero would stay silent when its own field is clicked.
         dismissed = false;
         activeIndex = -1;
-        stopRotation();
+        stopTyping();
       }}
       oninput={(e) => {
         dismissed = false;
         activeIndex = -1;
-        stopRotation();
+        stopTyping();
         // Editing the text asks a different question, so the last link's answer goes
         // with it — otherwise a half-corrected URL sits under a verdict on the old one.
         linkStep = null;
@@ -746,7 +755,7 @@
         // box permanently silent for the rest of the visit.
         dismissed = false;
         activeIndex = -1;
-        stopRotation();
+        stopTyping();
       }}
       onkeydown={onKeydown}
       type="text"
@@ -758,11 +767,7 @@
       aria-expanded={suggestOpen}
       aria-controls="role-suggestions"
       aria-activedescendant={activeIndex >= 0 ? `role-suggestion-${activeIndex}` : undefined}
-      style="--placeholder-fade: {FADE_MS}ms"
-      class={cn(
-        'placeholder-rotates min-w-0 flex-1 bg-transparent outline-none placeholder:text-muted-foreground',
-        placeholderFading && 'placeholder-faded',
-      )}
+      class="min-w-0 flex-1 bg-transparent outline-none placeholder:text-muted-foreground"
     />
     {#if draft.text}
       <!-- Clearing is an explicit act, not typing, so it commits at once: the visitor
@@ -970,25 +975,3 @@
     </ul>
   {/if}
 </div>
-
-<style>
-  /* The rotating placeholder's crossfade.
-     Transitioning ::placeholder colour rather than overlaying a positioned span keeps
-     the box's flex row untouched — the field, the location prefix, the clear button and
-     the filters trigger already negotiate width in there, and a second element is a
-     layout risk taken for a cosmetic gain.
-
-     The duration comes from the script's FADE_MS rather than being written twice: it is
-     the same measurement — how long the text is held invisible before it is swapped —
-     and two copies would drift into swapping the word while it was still legible.
-
-     No reduced-motion rule here: under that setting no timer is ever started, so nothing
-     ever adds the faded class and a transition that can't run needs no switching off. */
-  .placeholder-rotates::placeholder {
-    transition: color var(--placeholder-fade) ease;
-  }
-
-  .placeholder-faded::placeholder {
-    color: transparent;
-  }
-</style>

--- a/web/src/lib/components/HeaderSearch.svelte
+++ b/web/src/lib/components/HeaderSearch.svelte
@@ -20,9 +20,9 @@
   import { commit, edit, emptyDraft, reconcile, type SearchDraft } from '$lib/searchDraft';
   import { starterSuggestions, type Suggestion } from '$lib/suggestions';
   import {
-    TYPEWRITER_START,
     completeWord,
     typedTail,
+    typewriterStart,
     typewriterStep,
     type TypewriterState,
   } from '$lib/placeholderRoles';
@@ -103,7 +103,14 @@
   // lib/placeholderRoles.ts, which is where they can be tested without a browser.
   const typing = $derived(typeof placeholder === 'string' ? null : placeholder);
 
-  let typewriter = $state<TypewriterState>(TYPEWRITER_START);
+  // Capturing just the initial value is the intent: this is where the animation STARTS,
+  // and the server renders it. A caller that later swaps its word list is handled by the
+  // stepper instead — a role index the new list has no word for steps past on the next
+  // tick rather than needing this seed to be recomputed.
+  // svelte-ignore state_referenced_locally
+  let typewriter = $state<TypewriterState>(
+    typewriterStart(typeof placeholder === 'string' ? [] : placeholder.roles),
+  );
   let typingStopped = $state(false);
 
   function stopTyping() {
@@ -113,6 +120,17 @@
     // attention arrived on the field.
     typewriter = completeWord(typewriter, typing.roles);
     typingStopped = true;
+  }
+
+  /** Undo a stop that no visitor asked for — see the autofocus effect below. */
+  function resumeTyping() {
+    if (!typing) return;
+    // Both halves, not just the flag: stopTyping also FILLED IN the current word, so
+    // clearing the flag alone would leave the animation resuming from a finished word
+    // and skip typing the very first one — on the homepage hero, the one surface this
+    // exists for.
+    typewriter = typewriterStart(typing.roles);
+    typingStopped = false;
   }
 
   // Sampled AND subscribed: the OS-level setting can be turned on mid-visit, and reading
@@ -128,15 +146,19 @@
 
   $effect(() => {
     if (typingStopped || !typing) return;
-    // Under reduced motion the first role stands whole and nothing is scheduled. Reading
-    // `typing.roles` before the return keeps this effect subscribed to the prop, so a
-    // caller that swaps its word list still restarts the animation.
     const roles = typing.roles;
+    // Under reduced motion nothing is scheduled at all and the first role simply stands.
     if (reduceMotion || roles.length === 0) return;
 
     // One chained timeout rather than an interval: every step has its own delay (a typed
     // character, a faster deleted one, and the long hold on a finished word), so a fixed
     // tick would have to be the shortest of them and then count its way to the others.
+    //
+    // `untrack` is what makes that chain real. Read plainly, the seed below would
+    // subscribe this effect to the very state its own callback writes: each character
+    // would invalidate the effect, the cleanup would cancel the link already scheduled,
+    // and the animation would be driven by re-runs at the mercy of flush latency rather
+    // than by the delays computed here.
     let timer: ReturnType<typeof setTimeout> | undefined;
     const schedule = (from: TypewriterState) => {
       const { next, delayMs } = typewriterStep(from, roles);
@@ -145,7 +167,7 @@
         schedule(next);
       }, delayMs);
     };
-    schedule(typewriter);
+    schedule(untrack(() => typewriter));
     return () => clearTimeout(timer);
   });
 
@@ -203,10 +225,10 @@
     // put here", so close it back: their first click or keystroke opens it as usual.
     dismissed = true;
     // Same reasoning, and the same undo: the focus above fires the field's own handler,
-    // which stops the placeholder rotation. On the homepage — where this box IS the
-    // page, and the one surface the rotation exists for — that killed it before the
-    // first tick. A caret nobody placed has not interrupted anything.
-    typingStopped = false;
+    // which stops the placeholder animation. On the homepage — where this box IS the
+    // page, and the one surface the animation exists for — that killed it before the
+    // first character. A caret nobody placed has not interrupted anything.
+    resumeTyping();
   });
   // -1 means nothing is highlighted, which is the state the dropdown opens in: Enter
   // then falls through to the free-text search it has always run.

--- a/web/src/lib/components/HomeLandingView.svelte
+++ b/web/src/lib/components/HomeLandingView.svelte
@@ -4,7 +4,7 @@
   import { ArrowRight } from '@lucide/svelte';
   import FilterModal from './filters/FilterModal.svelte';
   import HeaderSearch from './HeaderSearch.svelte';
-  import { rolePlaceholder } from '$lib/placeholderRoles';
+  import { ROLE_PLACEHOLDER } from '$lib/placeholderRoles';
   import { api } from '$lib/api';
   import { browseQuery, planForSuggestion } from '$lib/browseTarget';
   import type { ApplyPlan } from '$lib/apiSuggestions';
@@ -241,7 +241,7 @@
            this box does search companies and skills too. An example is a starting point
            rather than a boundary, and a role is what people actually type first. -->
       <HeaderSearch
-        placeholder={rolePlaceholder()}
+        placeholder={ROLE_PLACEHOLDER}
         label="Search jobs, companies and skills"
         size="hero"
         autofocus

--- a/web/src/lib/components/HomeLandingView.svelte
+++ b/web/src/lib/components/HomeLandingView.svelte
@@ -4,7 +4,7 @@
   import { ArrowRight } from '@lucide/svelte';
   import FilterModal from './filters/FilterModal.svelte';
   import HeaderSearch from './HeaderSearch.svelte';
-  import { rolePlaceholders } from '$lib/placeholderRoles';
+  import { rolePlaceholder } from '$lib/placeholderRoles';
   import { api } from '$lib/api';
   import { browseQuery, planForSuggestion } from '$lib/browseTarget';
   import type { ApplyPlan } from '$lib/apiSuggestions';
@@ -241,7 +241,7 @@
            this box does search companies and skills too. An example is a starting point
            rather than a boundary, and a role is what people actually type first. -->
       <HeaderSearch
-        placeholder={rolePlaceholders()}
+        placeholder={rolePlaceholder()}
         label="Search jobs, companies and skills"
         size="hero"
         autofocus

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -4,7 +4,7 @@
   import { afterNavigate, goto } from '$app/navigation';
   import { signinUrl } from '$lib/signin';
   import HeaderSearch from './HeaderSearch.svelte';
-  import { rolePlaceholders } from '$lib/placeholderRoles';
+  import { rolePlaceholder } from '$lib/placeholderRoles';
   import HeaderMenu from './HeaderMenu.svelte';
   import BrandMark from './BrandMark.svelte';
   import { isFullBleedRoute } from '$lib/shellLayout';
@@ -29,7 +29,7 @@
   const searchWording = $derived(
     page.url.pathname === '/companies'
       ? { placeholder: 'Search companies…', label: 'Search companies' }
-      : { placeholder: rolePlaceholders(), label: 'Search jobs' },
+      : { placeholder: rolePlaceholder(), label: 'Search jobs' },
   );
 
   // The homepage is the one exception: its whole content is a large centred copy of

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -4,7 +4,7 @@
   import { afterNavigate, goto } from '$app/navigation';
   import { signinUrl } from '$lib/signin';
   import HeaderSearch from './HeaderSearch.svelte';
-  import { rolePlaceholder } from '$lib/placeholderRoles';
+  import { ROLE_PLACEHOLDER } from '$lib/placeholderRoles';
   import HeaderMenu from './HeaderMenu.svelte';
   import BrandMark from './BrandMark.svelte';
   import { isFullBleedRoute } from '$lib/shellLayout';
@@ -29,7 +29,7 @@
   const searchWording = $derived(
     page.url.pathname === '/companies'
       ? { placeholder: 'Search companies…', label: 'Search companies' }
-      : { placeholder: rolePlaceholder(), label: 'Search jobs' },
+      : { placeholder: ROLE_PLACEHOLDER, label: 'Search jobs' },
   );
 
   // The homepage is the one exception: its whole content is a large centred copy of

--- a/web/src/lib/placeholderRoles.test.ts
+++ b/web/src/lib/placeholderRoles.test.ts
@@ -5,10 +5,10 @@ import {
   PLACEHOLDER_ROLES,
   ROLE_PREFIX,
   TYPE_MS,
-  TYPEWRITER_START,
+  ROLE_PLACEHOLDER,
   type TypewriterState,
   completeWord,
-  rolePlaceholder,
+  typewriterStart,
   typedTail,
   typewriterStep,
 } from './placeholderRoles';
@@ -40,12 +40,12 @@ describe('PLACEHOLDER_ROLES', () => {
   });
 });
 
-describe('rolePlaceholder', () => {
+describe('ROLE_PLACEHOLDER', () => {
   // Pinned literally rather than re-derived through the same functions: mapping the same
   // inputs through the same code would restate the implementation and pass however the
   // wording changed. These are the words that ship.
   it('is a fixed prefix and the roles that follow it', () => {
-    expect(rolePlaceholder()).toEqual({
+    expect(ROLE_PLACEHOLDER).toEqual({
       prefix: 'Search jobs — e.g. ',
       roles: ['Backend', 'Frontend', 'DevOps', 'QA', 'Data Science', 'Product'],
     });
@@ -58,6 +58,7 @@ describe('rolePlaceholder', () => {
 
 describe('typewriterStep', () => {
   const roles = ['ab', 'c'];
+  const start = typewriterStart(roles);
   const run = (from: TypewriterState, times: number) => {
     const frames: { tail: string; delayMs: number }[] = [];
     let state = from;
@@ -69,28 +70,26 @@ describe('typewriterStep', () => {
     return frames;
   };
 
-  it('starts with nothing typed', () => {
-    expect(typedTail(TYPEWRITER_START, roles)).toBe('');
+  // The server renders this state, so it has to be a whole sentence: an empty tail would
+  // ship "Search jobs - e.g. " to anyone reading before hydration or with JS off.
+  it('starts with the first word already whole', () => {
+    expect(typedTail(start, roles)).toBe('ab');
   });
 
-  it('types the word one character at a time', () => {
-    const [first, second] = run(TYPEWRITER_START, 2);
-    expect(first).toEqual({ tail: 'a', delayMs: TYPE_MS });
-    expect(second).toEqual({ tail: 'ab', delayMs: TYPE_MS });
-  });
-
-  it('holds the finished word before it starts deleting', () => {
+  it('holds that finished word, then erases it a character at a time', () => {
     // The pause is the delay attached to the step that BEGINS the deletion, so the whole
     // word stays on screen for it.
-    const frames = run(TYPEWRITER_START, 3);
-    expect(frames[2]).toEqual({ tail: 'a', delayMs: HOLD_MS });
+    const frames = run(start, 3);
+    expect(frames.map((f) => f.tail)).toEqual(['a', '', 'c']);
+    expect(frames[0]?.delayMs).toBe(HOLD_MS);
+    expect(frames[1]?.delayMs).toBe(DELETE_MS);
+    expect(frames[2]?.delayMs).toBe(TYPE_MS);
   });
 
-  it('deletes back to nothing, then types the next role', () => {
-    const frames = run(TYPEWRITER_START, 5);
-    expect(frames.map((f) => f.tail)).toEqual(['a', 'ab', 'a', '', 'c']);
-    expect(frames[3]?.delayMs).toBe(DELETE_MS);
-    expect(frames[4]?.delayMs).toBe(TYPE_MS);
+  it('types the next word one character at a time', () => {
+    const frames = run({ role: 0, chars: 0, deleting: false }, 2);
+    expect(frames[0]).toEqual({ tail: 'a', delayMs: TYPE_MS });
+    expect(frames[1]).toEqual({ tail: 'ab', delayMs: TYPE_MS });
   });
 
   it('wraps from the last role back to the first', () => {

--- a/web/src/lib/placeholderRoles.test.ts
+++ b/web/src/lib/placeholderRoles.test.ts
@@ -1,19 +1,29 @@
 import { describe, it, expect } from 'vitest';
-import { PLACEHOLDER_ROLES, rolePlaceholders } from './placeholderRoles';
+import {
+  DELETE_MS,
+  HOLD_MS,
+  PLACEHOLDER_ROLES,
+  ROLE_PREFIX,
+  TYPE_MS,
+  TYPEWRITER_START,
+  type TypewriterState,
+  completeWord,
+  rolePlaceholder,
+  typedTail,
+  typewriterStep,
+} from './placeholderRoles';
 import { CATEGORY_VALUES } from './generated/contracts';
 import { categoryLabel } from './labels';
 
-// The jobs search box's rotating examples. The list is category KEYS, not display
-// strings, so these tests are mostly about that guarantee holding at runtime too:
-// the type check is what catches a retired category, and a runtime assertion is what
-// catches the list being reordered into something the box would render as a blank.
+// The jobs search box's typed examples. The list is category KEYS, so these tests are
+// partly about that guarantee holding at runtime too; the rest is the little state
+// machine that types and deletes the trailing word, which has exactly the edge cases a
+// hand-rolled typewriter always has — wrapping, an empty word, and being interrupted
+// halfway through one.
 
 describe('PLACEHOLDER_ROLES', () => {
-  it('is a non-empty list', () => {
+  it('is a non-empty list with no duplicates', () => {
     expect(PLACEHOLDER_ROLES.length).toBeGreaterThan(0);
-  });
-
-  it('holds no duplicates — a repeat reads as the rotation having stalled', () => {
     expect(new Set(PLACEHOLDER_ROLES).size).toBe(PLACEHOLDER_ROLES.length);
   });
 
@@ -30,24 +40,91 @@ describe('PLACEHOLDER_ROLES', () => {
   });
 });
 
-describe('rolePlaceholders', () => {
-  // Pinned literally rather than re-derived from PLACEHOLDER_ROLES + categoryLabel:
-  // mapping the same inputs through the same functions would restate the implementation
-  // and pass however the wording changed. These are the strings that ship.
-  it('composes the placeholders a visitor actually reads', () => {
-    expect(rolePlaceholders()).toEqual([
-      'Search jobs — e.g. Backend',
-      'Search jobs — e.g. Frontend',
-      'Search jobs — e.g. DevOps',
-      'Search jobs — e.g. QA',
-      'Search jobs — e.g. Data Science',
-      'Search jobs — e.g. Product',
-    ]);
+describe('rolePlaceholder', () => {
+  // Pinned literally rather than re-derived through the same functions: mapping the same
+  // inputs through the same code would restate the implementation and pass however the
+  // wording changed. These are the words that ship.
+  it('is a fixed prefix and the roles that follow it', () => {
+    expect(rolePlaceholder()).toEqual({
+      prefix: 'Search jobs — e.g. ',
+      roles: ['Backend', 'Frontend', 'DevOps', 'QA', 'Data Science', 'Product'],
+    });
   });
 
-  // Under prefers-reduced-motion the first entry is the only one anyone sees, so it
-  // carries the whole weight of answering "what can I type here".
-  it('leads with a role rather than the catch-all category', () => {
-    expect(PLACEHOLDER_ROLES[0]).not.toBe('other');
+  it('ends the prefix with a space, so the typed word is not glued to it', () => {
+    expect(ROLE_PREFIX.endsWith(' ')).toBe(true);
+  });
+});
+
+describe('typewriterStep', () => {
+  const roles = ['ab', 'c'];
+  const run = (from: TypewriterState, times: number) => {
+    const frames: { tail: string; delayMs: number }[] = [];
+    let state = from;
+    for (let i = 0; i < times; i++) {
+      const { next, delayMs } = typewriterStep(state, roles);
+      state = next;
+      frames.push({ tail: typedTail(state, roles), delayMs });
+    }
+    return frames;
+  };
+
+  it('starts with nothing typed', () => {
+    expect(typedTail(TYPEWRITER_START, roles)).toBe('');
+  });
+
+  it('types the word one character at a time', () => {
+    const [first, second] = run(TYPEWRITER_START, 2);
+    expect(first).toEqual({ tail: 'a', delayMs: TYPE_MS });
+    expect(second).toEqual({ tail: 'ab', delayMs: TYPE_MS });
+  });
+
+  it('holds the finished word before it starts deleting', () => {
+    // The pause is the delay attached to the step that BEGINS the deletion, so the whole
+    // word stays on screen for it.
+    const frames = run(TYPEWRITER_START, 3);
+    expect(frames[2]).toEqual({ tail: 'a', delayMs: HOLD_MS });
+  });
+
+  it('deletes back to nothing, then types the next role', () => {
+    const frames = run(TYPEWRITER_START, 5);
+    expect(frames.map((f) => f.tail)).toEqual(['a', 'ab', 'a', '', 'c']);
+    expect(frames[3]?.delayMs).toBe(DELETE_MS);
+    expect(frames[4]?.delayMs).toBe(TYPE_MS);
+  });
+
+  it('wraps from the last role back to the first', () => {
+    const frames = run({ role: 1, chars: 0, deleting: true }, 1);
+    expect(frames[0]?.tail).toBe('a');
+  });
+
+  // A category whose label resolved to nothing would otherwise drive `chars` negative and
+  // render `slice(0, -1)` — the previous word minus a letter, which reads as a glitch
+  // rather than as a missing label.
+  it('skips a role with no label instead of counting past zero', () => {
+    const withEmpty = ['', 'c'];
+    const { next } = typewriterStep({ role: 0, chars: 0, deleting: false }, withEmpty);
+    expect(next.role).toBe(1);
+    expect(next.chars).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('completeWord', () => {
+  // Freezing on "Devo" would read as a typo, so an interruption finishes the word first.
+  it('fills in a half-typed word and stops deleting', () => {
+    const state = completeWord({ role: 0, chars: 2, deleting: false }, ['Backend']);
+    expect(state).toEqual({ role: 0, chars: 7, deleting: false });
+    expect(typedTail(state, ['Backend'])).toBe('Backend');
+  });
+
+  it('fills in a word caught mid-deletion', () => {
+    expect(typedTail(completeWord({ role: 0, chars: 1, deleting: true }, ['QA']), ['QA'])).toBe(
+      'QA',
+    );
+  });
+
+  it('leaves an already-complete word alone', () => {
+    const done: TypewriterState = { role: 0, chars: 2, deleting: false };
+    expect(completeWord(done, ['QA'])).toEqual(done);
   });
 });

--- a/web/src/lib/placeholderRoles.ts
+++ b/web/src/lib/placeholderRoles.ts
@@ -34,10 +34,16 @@ export const PLACEHOLDER_ROLES: Category[] = [
   'product',
 ];
 
-/** The fixed prefix and the words that follow it, for the jobs search box. */
-export function rolePlaceholder(): { prefix: string; roles: string[] } {
-  return { prefix: ROLE_PREFIX, roles: PLACEHOLDER_ROLES.map(categoryLabel) };
-}
+/** The fixed prefix and the words that follow it, for the jobs search box.
+ *
+ *  A constant, not a factory. The labels are a pure lookup over a frozen list, so every
+ *  call would return an equal object with a new identity — and a caller that recomputes
+ *  it (the header re-derives its wording on every navigation) would hand the box a
+ *  "changed" prop, restarting the animation's pending delay on each page change. */
+export const ROLE_PLACEHOLDER: { prefix: string; roles: string[] } = {
+  prefix: ROLE_PREFIX,
+  roles: PLACEHOLDER_ROLES.map(categoryLabel),
+};
 
 // ---- the typing animation ----------------------------------------------------------
 //
@@ -62,8 +68,16 @@ export interface TypewriterState {
   deleting: boolean;
 }
 
-/** Nothing typed yet, on the first role. */
-export const TYPEWRITER_START: TypewriterState = { role: 0, chars: 0, deleting: false };
+/** Where the animation begins: the FIRST role already whole.
+ *
+ *  Not an empty tail. The server renders this state, and an empty tail would ship
+ *  `"Search jobs — e.g. "` — a sentence that stops mid-air for anyone reading before
+ *  hydration or with JavaScript off. Starting complete also means the first thing anyone
+ *  reads is a whole example, and the animation's first act is to erase it rather than to
+ *  correct a dangling line. */
+export function typewriterStart(roles: string[]): TypewriterState {
+  return { role: 0, chars: (roles[0] ?? '').length, deleting: false };
+}
 
 /** The visible tail for a state: the current role, cut to the characters typed so far. */
 export function typedTail(state: TypewriterState, roles: string[]): string {

--- a/web/src/lib/placeholderRoles.ts
+++ b/web/src/lib/placeholderRoles.ts
@@ -1,4 +1,4 @@
-// The rotating examples the jobs search box offers when it is empty and untouched.
+// The examples the jobs search box types into its own placeholder while it sits empty.
 //
 // The list is category KEYS, not display strings. A hand-written ['QA', 'DevOps'] would
 // be a second copy of a vocabulary the backend already owns, and it would rot silently —
@@ -6,21 +6,25 @@
 // the feed can no longer filter on. Typing the array as Category[] turns that into a
 // build failure, the same guard CATEGORY_LABELS uses for the same reason.
 //
-// The module composes whole placeholder strings rather than exposing bare labels for a
-// component to interpolate: the phrasing is then testable and lives in one place, and
-// HeaderSearch stays a box that renders what it is handed instead of learning that one of
-// its callers is about jobs.
+// Only the TAIL moves. The prefix is a fixed string the component never touches, so the
+// sentence stays readable throughout and the eye has one place to look. That is why this
+// module hands over the two parts rather than composed strings: the animation needs to
+// know where the fixed half ends.
 //
-// Pure by design (no Svelte, no DOM), like facetModel.ts and suggestions.ts beside it.
+// Pure by design (no Svelte, no DOM), like facetModel.ts and suggestions.ts beside it —
+// the stepping below is the whole animation, and it is testable without a browser.
 
 import type { Category } from './generated/contracts';
 import { categoryLabel } from './labels';
 
-/** The roles the box cycles through, in rotation order.
+/** The half of the placeholder that never changes. */
+export const ROLE_PREFIX = 'Search jobs — e.g. ';
+
+/** The roles the box types, in order.
  *
- *  Busiest-looking first: under prefers-reduced-motion the rotation never starts, so the
- *  first entry is the only one anyone sees and carries the whole weight of answering
- *  "what can I type here". Six is about what a visitor will sit through before typing. */
+ *  Busiest-looking first: under prefers-reduced-motion nothing is animated, so the first
+ *  entry is the only one anyone sees and carries the whole weight of answering "what can
+ *  I type here". Six is about what a visitor will sit through before typing. */
 export const PLACEHOLDER_ROLES: Category[] = [
   'backend',
   'frontend',
@@ -30,7 +34,79 @@ export const PLACEHOLDER_ROLES: Category[] = [
   'product',
 ];
 
-/** The full placeholder strings for the jobs search box, in rotation order. */
-export function rolePlaceholders(): string[] {
-  return PLACEHOLDER_ROLES.map((role) => `Search jobs — e.g. ${categoryLabel(role)}`);
+/** The fixed prefix and the words that follow it, for the jobs search box. */
+export function rolePlaceholder(): { prefix: string; roles: string[] } {
+  return { prefix: ROLE_PREFIX, roles: PLACEHOLDER_ROLES.map(categoryLabel) };
+}
+
+// ---- the typing animation ----------------------------------------------------------
+//
+// Per-character, because that is what reads as "you type here" rather than as a banner
+// cycling at you. Deleting runs faster than typing: a person backspaces faster than they
+// compose, and matching the two makes the erase feel like a stall.
+
+/** How long one typed character is on screen before the next arrives. */
+export const TYPE_MS = 55;
+/** …and one deleted character. */
+export const DELETE_MS = 28;
+/** How long the finished word stays whole before it is erased. Long enough to read it
+ *  and to notice the box is showing an example rather than holding a stale query. */
+export const HOLD_MS = 1500;
+
+export interface TypewriterState {
+  /** Index into the roles list. */
+  role: number;
+  /** How many of that role's characters are shown. */
+  chars: number;
+  /** Whether the next character is removed rather than added. */
+  deleting: boolean;
+}
+
+/** Nothing typed yet, on the first role. */
+export const TYPEWRITER_START: TypewriterState = { role: 0, chars: 0, deleting: false };
+
+/** The visible tail for a state: the current role, cut to the characters typed so far. */
+export function typedTail(state: TypewriterState, roles: string[]): string {
+  return (roles[state.role] ?? '').slice(0, state.chars);
+}
+
+/** The next state, and how long to wait before applying it.
+ *
+ *  The delay belongs to the step it precedes rather than the one that produced it, which
+ *  is what lets the finished word hold: the step that removes its first character is the
+ *  one that waits HOLD_MS, so the whole word stays on screen for that long. */
+export function typewriterStep(
+  state: TypewriterState,
+  roles: string[],
+): { next: TypewriterState; delayMs: number } {
+  const word = roles[state.role] ?? '';
+  const nextRole = (state.role + 1) % Math.max(roles.length, 1);
+
+  // A role whose label resolved to nothing has no characters to type or delete. Stepping
+  // past it beats decrementing below zero, which would render `slice(0, -1)` — the
+  // previous word minus a letter, which reads as a glitch rather than a missing label.
+  if (word.length === 0) {
+    return { next: { role: nextRole, chars: 0, deleting: false }, delayMs: TYPE_MS };
+  }
+
+  if (!state.deleting) {
+    if (state.chars < word.length) {
+      return { next: { ...state, chars: state.chars + 1 }, delayMs: TYPE_MS };
+    }
+    return { next: { ...state, chars: word.length - 1, deleting: true }, delayMs: HOLD_MS };
+  }
+
+  if (state.chars > 0) {
+    return { next: { ...state, chars: state.chars - 1 }, delayMs: DELETE_MS };
+  }
+  return { next: { role: nextRole, chars: 1, deleting: false }, delayMs: TYPE_MS };
+}
+
+/** The same word, finished.
+ *
+ *  What an interruption lands on. Freezing mid-word would leave "Devo" sitting in the
+ *  box, which reads as a typo rather than as an animation that stopped — and it stops at
+ *  the exact moment the visitor's attention is on the field. */
+export function completeWord(state: TypewriterState, roles: string[]): TypewriterState {
+  return { role: state.role, chars: (roles[state.role] ?? '').length, deleting: false };
 }


### PR DESCRIPTION
Only the last word of the sentence moves now. `Search jobs - e.g. ` is a fixed
string the component never rewrites, so the eye has one place to look and the box
reads as something you type into rather than a banner cycling at you.

Deleting runs at half the typing delay - a person backspaces faster than they
compose, and matching the two makes the erase feel like a stall.

An interruption finishes the word before it stops. Freezing on "Devo" reads as a
typo rather than as an animation that ended, and it would do so at the exact
moment the visitor attention arrived on the field.

The stepping is a pure function beside the word list, so the whole animation is
testable without a browser - including the cases a hand-rolled typewriter always
gets wrong: wrapping past the last word, and a label that resolved to nothing,
which would otherwise count below zero and render the previous word minus a
letter.

## Review found two defects, both fixed here

The effect seeded itself by reading the state its own callback writes, so Svelte
tracked it: every character invalidated the effect and cancelled the link already
scheduled. The animation ran on effect re-runs at the mercy of flush latency
rather than on the delays the module computes.

And the autofocus trap again, one layer deeper than last time. Stopping does two
things - finishes the word and sets the flag - and the undo cleared only the
flag, so the homepage hero showed "Backend" whole from the first frame and never
typed it.

Also: the animation starts with the first word already whole, which is what the
server renders - an empty tail shipped a sentence that stopped mid-air to anyone
reading before hydration. And the word list is a constant rather than a factory,
so a navigation no longer restarts the pending delay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated search placeholders with a per-character typewriter animation for role suggestions.
  - Search placeholders now display a consistent prefix while cycling through role labels.
  - Animation completes when users interact with the search field.
  - Added reduced-motion support and preserved autofocus behavior when returning to the search field.
  - Search placeholders remain compatible with server-side rendering.
- **Tests**
  - Expanded coverage for typing, deletion, timing, wrapping, empty labels, and interaction completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->