### PR TITLE
Give a dropdown that hangs off the box a ceiling, not a bottom it has no room for

### DIFF
--- a/web/src/lib/components/HeaderSearch.svelte
+++ b/web/src/lib/components/HeaderSearch.svelte
@@ -13,6 +13,7 @@
   import type { Job, CompanyListItem, ApiSuggestionPart, FacetCounts } from '$lib/types';
   import { listSearchTarget, type ListSearchTarget } from '$lib/listSearch.svelte';
   import { headerFilterTrigger } from '$lib/headerFilterTrigger';
+  import { keyboardFit, NO_FIT, type KeyboardFit } from '$lib/keyboardFit';
   import { openedOverlay, closedOverlay } from '$lib/headerOverlay';
   import { fromApi, applyParams, type ApplyPlan } from '$lib/apiSuggestions';
   import { pastedJobLink, type PastedJobLink } from '$lib/jobLink';
@@ -184,9 +185,14 @@
   let inputEl = $state<HTMLInputElement | null>(null);
   let wrapEl = $state<HTMLDivElement | null>(null);
 
+  /** Tailwind's `sm`. Two things below ask it — whether to place the caret on mount, and
+   *  how this box's panel is drawn — and they must get one answer, since the markup they
+   *  are reasoning about switches on the same breakpoint. */
+  const WIDE_QUERY = '(min-width: 640px)';
+
   $effect(() => {
     if (!autofocus) return;
-    if (!window.matchMedia('(min-width: 640px)').matches) return;
+    if (!window.matchMedia(WIDE_QUERY).matches) return;
     inputEl?.focus();
     // Focusing normally opens the dropdown, and on a landing page that would drop a
     // ten-row panel over the page on every load, covering the very shortcuts printed
@@ -451,48 +457,45 @@
   const suggestOpen = $derived(rows.length > 0 && !dismissed);
   const rowCount = $derived(suggestOpen ? rows.length : 0);
 
-  /** How much of the screen's bottom the on-screen keyboard is covering, in pixels.
-   *
-   *  Neither mobile browser shrinks the PAGE for the keyboard on its own — it is drawn
-   *  over the bottom of a viewport that stays full height — so the panel below, pinned
-   *  from the header to `bottom: 0`, ran under the keys with its last rows unreachable.
-   *  Which is the worst place to lose: the visitor has just typed, and the rows they are
-   *  reading are the ones the typing produced.
-   *
-   *  `visualViewport` is the part of the page actually left visible, so the difference
-   *  between it and the window is the keyboard. `app.html` also asks Chrome to shrink the
-   *  page itself (`interactive-widget=resizes-content`), and the two do not double up:
-   *  where the browser honours that, the window shrinks with it and this measures 0.
-   *
-   *  Held here rather than in a shared store because this panel is the only thing that
-   *  reaches the bottom edge today; a second one (a composer, a sheet) is when it earns
-   *  a module of its own. */
-  let keyboardInset = $state(0);
+  /** Where this panel may sit with the on-screen keyboard up: a lift for the one that is
+   *  pinned to the bottom of the screen, a ceiling for the one that hangs off the box,
+   *  and why one number cannot serve both — see $lib/keyboardFit. */
+  let fit = $state.raw<KeyboardFit>(NO_FIT);
 
   $effect(() => {
-    // Nothing to lift while the panel is shut, and no listener to keep either.
+    // Nothing to place while the panel is shut, and no listener to keep either.
     if (!suggestOpen) return;
     const viewport = window.visualViewport;
     if (!viewport) return;
+    const box = wrapEl;
+    if (!box) return;
     const measure = () => {
-      // Only the phone-width panel has a bottom edge to lift: at `sm` and up it hangs off
-      // the box and is sized by `max-height`. Read the breakpoint the same way the
-      // autofocus check above reads it, so there is one answer to "is this a phone".
-      const wide = window.matchMedia('(min-width: 640px)').matches;
-      keyboardInset = wide
-        ? 0
-        : Math.max(0, window.innerHeight - viewport.height - viewport.offsetTop);
+      fit = keyboardFit({
+        windowHeight: window.innerHeight,
+        viewportHeight: viewport.height,
+        viewportOffsetTop: viewport.offsetTop,
+        // The ceiling is measured from the bottom of the box the panel hangs off.
+        anchorBottom: box.getBoundingClientRect().bottom,
+        // Exactly the case the class list below pins to `bottom-0`: the header's box, on
+        // a phone. The hero hangs its panel off the box at every width, and so does the
+        // header at `sm` and up.
+        bottomAnchored: !hero && !window.matchMedia(WIDE_QUERY).matches,
+      });
     };
     measure();
     // `scroll` as well as `resize`: iOS scrolls the visual viewport inside the layout one
     // to keep the focused field visible, which moves the keyboard's top edge without
-    // changing its height.
+    // changing its height. The window's own scroll counts too — a ceiling is measured
+    // from where the box IS, and scrolling the page moves it under a keyboard that has
+    // not budged.
     viewport.addEventListener('resize', measure);
     viewport.addEventListener('scroll', measure);
+    window.addEventListener('scroll', measure, { passive: true });
     return () => {
       viewport.removeEventListener('resize', measure);
       viewport.removeEventListener('scroll', measure);
-      keyboardInset = 0;
+      window.removeEventListener('scroll', measure);
+      fit = NO_FIT;
     };
   });
 
@@ -869,7 +872,8 @@
     <ul
       id="role-suggestions"
       role="listbox"
-      style:bottom={keyboardInset > 0 ? `${keyboardInset}px` : null}
+      style:bottom={fit.lift > 0 ? `${fit.lift}px` : null}
+      style:max-height={fit.ceiling > 0 ? `${fit.ceiling}px` : null}
       aria-label="Search suggestions"
       class={cn(
         'inset-x-0 z-50 max-h-[70vh] overflow-y-auto border border-border bg-background py-1 shadow-lg',

--- a/web/src/lib/keyboardFit.test.ts
+++ b/web/src/lib/keyboardFit.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { keyboardFit, NO_FIT, type PanelGeometry } from './keyboardFit';
+
+/** An iPhone-shaped phone with the keyboard up: the window stays 844 tall, the visual
+ *  viewport is the 508 above the keys, and the box the panel hangs off ends 300px down. */
+const phone: PanelGeometry = {
+  windowHeight: 844,
+  viewportHeight: 508,
+  viewportOffsetTop: 0,
+  anchorBottom: 300,
+  bottomAnchored: true,
+};
+
+/** The same phone with the panel hanging off the box — the hero on the homepage, and
+ *  either size at `sm` and up. */
+const hanging: PanelGeometry = { ...phone, bottomAnchored: false };
+
+describe('keyboardFit', () => {
+  it('lifts a bottom-anchored panel by the height the keyboard covers', () => {
+    expect(keyboardFit(phone)).toEqual({ lift: 336, ceiling: 0 });
+  });
+
+  it('never lifts a hanging panel — it has no bottom edge to lift', () => {
+    // The regression: a `bottom` on a panel positioned by `top` inside a wrapper as tall
+    // as the box computes a negative height, and the browser clamps it to zero.
+    expect(keyboardFit(hanging).lift).toBe(0);
+  });
+
+  it('caps a hanging panel at the room between the box and the keyboard', () => {
+    // 508 visible − 300 to the bottom of the box − the 16px gap.
+    expect(keyboardFit(hanging).ceiling).toBe(192);
+  });
+
+  it('subtracts the visual viewport offset iOS scrolls the field into view by', () => {
+    expect(keyboardFit({ ...phone, viewportOffsetTop: 60 }).lift).toBe(276);
+    expect(keyboardFit({ ...hanging, viewportOffsetTop: 60 }).ceiling).toBe(252);
+  });
+
+  it('keeps a floor under a hanging panel when the box sits on the keys', () => {
+    expect(keyboardFit({ ...hanging, anchorBottom: 505 }).ceiling).toBe(120);
+  });
+
+  it('never raises the cap the stylesheet already put on a hanging panel', () => {
+    // 70vh of 844 is 590.8; a box 100px down leaves 728, so an inline ceiling would make
+    // the panel TALLER than the class allows. Nothing to tighten, nothing to say.
+    expect(keyboardFit({ ...hanging, viewportHeight: 844, anchorBottom: 100 })).toBe(NO_FIT);
+  });
+
+  it('reads a difference too small to be a keyboard as no keyboard', () => {
+    // Fractional visual-viewport heights and collapsing browser chrome, not keys.
+    expect(keyboardFit({ ...phone, viewportHeight: 843.5 })).toBe(NO_FIT);
+    expect(keyboardFit({ ...hanging, viewportHeight: 843.5 })).toBe(NO_FIT);
+  });
+
+  it('still lifts off a hardware keyboard accessory bar', () => {
+    // iOS leaves ~55px for it, which is a real thing to clear.
+    expect(keyboardFit({ ...phone, viewportHeight: 789 }).lift).toBe(55);
+  });
+
+  it('does nothing with no keyboard up', () => {
+    expect(keyboardFit({ ...phone, viewportHeight: 844 })).toBe(NO_FIT);
+    expect(keyboardFit({ ...hanging, viewportHeight: 844 })).toBe(NO_FIT);
+  });
+});

--- a/web/src/lib/keyboardFit.ts
+++ b/web/src/lib/keyboardFit.ts
@@ -1,0 +1,79 @@
+// Where a dropdown panel may sit while the on-screen keyboard is up.
+//
+// Neither mobile browser shrinks the PAGE for the keyboard on its own — it is drawn over
+// the bottom of a viewport that stays full height — so a panel reaching the bottom edge
+// runs under the keys with its last rows unreachable. `visualViewport` is the part of the
+// page actually left visible, so the difference between it and the window is the keyboard.
+//
+// The answer is not one number, because a panel is placed one of two ways and only one of
+// them has a bottom edge to lift. The search box's phone panel is pinned from under the
+// header to `bottom: 0`, so it moves UP. Every other way that box draws it — the hero on
+// the homepage, and both sizes at `sm` and up — hangs it off the box with a `top` and no
+// bottom, inside a wrapper as tall as the box; giving THAT a bottom makes the browser
+// compute its height as the distance between the two, a negative number clamped to zero,
+// which is a search box answering with a hairline. It gets a ceiling instead.
+
+/** The gap between the box and the panel (`mt-2`), plus the same again so the last row
+ *  does not sit flush against the keys. */
+const PANEL_GAP = 16;
+
+/** The shortest panel worth drawing — roughly two rows and the scroll that follows them.
+ *  A box sitting right on the keyboard's top edge would otherwise be given a ceiling of
+ *  nothing, which is the failure this module exists to prevent rather than a tighter fit. */
+const MIN_CEILING = 120;
+
+/** The stylesheet's own cap on the panel (`max-h-[70vh]`), as a fraction of the window.
+ *  Written twice on purpose — it is not applied here, only compared against, so that a
+ *  ceiling can never LOOSEN what the class already said. See `keyboardFit`. */
+const PANEL_CAP = 0.7;
+
+/** Below this, the difference is not a keyboard. `visualViewport.height` is fractional and
+ *  browser chrome collapsing moves it by a pixel or two; well under the ~55px iOS leaves
+ *  for a hardware keyboard's accessory bar, which IS worth lifting a panel off. */
+const KEYBOARD_FLOOR = 24;
+
+export type PanelGeometry = {
+  /** `window.innerHeight` — the layout viewport, which the keyboard does not shrink. */
+  windowHeight: number;
+  /** `visualViewport.height` — what is actually visible. */
+  viewportHeight: number;
+  /** `visualViewport.offsetTop` — iOS scrolls the visual viewport inside the layout one
+   *  to keep the focused field visible, which moves the keyboard's top edge without
+   *  changing its height. */
+  viewportOffsetTop: number;
+  /** The bottom edge of the box the panel hangs off, in layout coordinates. */
+  anchorBottom: number;
+  /** Whether the panel is pinned to the bottom of the screen, rather than hanging off the
+   *  box. The one thing that decides which of the two answers below applies — and not the
+   *  same question as "is this a phone", which is what the old measurement asked. */
+  bottomAnchored: boolean;
+};
+
+export type KeyboardFit = {
+  /** How far to lift a bottom-anchored panel off the keyboard, in px. 0 leaves it alone. */
+  lift: number;
+  /** How tall a panel hanging off the box may be, in px. 0 leaves it to the stylesheet. */
+  ceiling: number;
+};
+
+/** Leave the panel where the stylesheet put it. Exported so the caller's idle state is
+ *  this same answer rather than a second literal that could drift from it. */
+export const NO_FIT: Readonly<KeyboardFit> = { lift: 0, ceiling: 0 };
+
+export function keyboardFit(geometry: PanelGeometry): KeyboardFit {
+  const covered =
+    geometry.windowHeight - geometry.viewportHeight - geometry.viewportOffsetTop;
+  // `app.html` also asks Chrome to shrink the page itself
+  // (`interactive-widget=resizes-content`) and the two must not double up: where the
+  // browser honours that, the window shrinks with it and this measures nothing.
+  if (covered < KEYBOARD_FLOOR) return NO_FIT;
+  if (geometry.bottomAnchored) return { lift: covered, ceiling: 0 };
+
+  const room =
+    geometry.viewportOffsetTop + geometry.viewportHeight - geometry.anchorBottom - PANEL_GAP;
+  // An inline `max-height` beats the class, so a ceiling taller than the stylesheet's own
+  // cap would quietly RAISE it — the panel would grow because a keyboard appeared, which
+  // is the opposite of the point. Nothing to tighten means nothing to say.
+  if (room >= geometry.windowHeight * PANEL_CAP) return NO_FIT;
+  return { lift: 0, ceiling: Math.max(MIN_CEILING, room) };
+}


### PR DESCRIPTION
## The bug

On a phone, typing into the homepage's search box collapsed the suggestion dropdown into a hairline strip under the box. Reported from iOS Safari; reproducible on every phone search from `/`.

## Why

`HeaderSearch` renders one `<ul>` for its suggestions and places it three different ways:

| where | how | has a bottom edge? |
|---|---|---|
| header, phone | `max-sm:fixed max-sm:bottom-0` | yes |
| header, `sm`+ | `sm:absolute sm:top-full` | no |
| hero (homepage), any width | `absolute top-full` | no |

The keyboard fix in #2429 measured how much of the screen the keys cover and pushed the panel's `bottom` up by it. That is right for the first row and wrong for the other two: a `top: 100%` plus a `bottom: 336px` inside a wrapper as tall as the box makes the browser compute a negative height, which it clamps to zero.

The guard was a width check — "is this a phone" — which is not the question. Two of the three placements are not phone-shaped.

## The fix

`web/src/lib/keyboardFit.ts` takes the one input that actually decides it (`bottomAnchored`) and answers both halves: a lift for the pinned panel, a ceiling for a hanging one. The header's `sm`+ panel now gets a ceiling too, where the old code gave up.

Two bounds keep the ceiling honest:

- **Never looser than the class.** An inline `max-height` beats `max-h-[70vh]`, so a ceiling taller than that cap would quietly raise it — a panel growing *because* a keyboard appeared. Nothing to tighten, nothing to say.
- **Under 24px is not a keyboard.** `visualViewport.height` is fractional and collapsing browser chrome moves it a pixel or two. The ~55px iOS leaves for a hardware keyboard's accessory bar still counts.

## Verifying

9 unit tests over the geometry; the whole web suite (1532) and `svelte-check` are green. The visual check is a phone: open `/` on a phone, tap the box, type — the panel should fill the space above the keys and scroll, not collapse.
