### PR TITLE
Let a profile hold ten specializations, and say so when it cannot

### DIFF
--- a/internal/api/handler/me_profile.go
+++ b/internal/api/handler/me_profile.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"time"
 
@@ -171,7 +172,7 @@ func profileError(err error) error {
 	case errors.Is(err, userprofile.ErrEmptySpecializations):
 		return fiber.NewError(fiber.StatusBadRequest, "at least one specialization is required")
 	case errors.Is(err, userprofile.ErrTooManySpecializations):
-		return fiber.NewError(fiber.StatusBadRequest, "too many specializations (max 5)")
+		return fiber.NewError(fiber.StatusBadRequest, fmt.Sprintf("too many specializations (max %d)", userprofile.MaxSpecializations))
 	case errors.Is(err, userprofile.ErrEmptySkills):
 		return fiber.NewError(fiber.StatusBadRequest, "at least one skill is required")
 	case errors.Is(err, userprofile.ErrTooManySkills):

--- a/internal/api/handler/me_profile_test.go
+++ b/internal/api/handler/me_profile_test.go
@@ -107,7 +107,10 @@ func TestPutProfile_ValidationErrors(t *testing.T) {
 	}{
 		{"empty specializations", `{"specializations":[],"skills":["go"]}`, fiber.StatusBadRequest},
 		{"unknown specialization", `{"specializations":["wizardry"],"skills":["go"]}`, fiber.StatusBadRequest},
-		{"too many specializations", `{"specializations":["backend","frontend","fullstack","mobile","devops","sre"],"skills":["go"]}`, fiber.StatusBadRequest},
+		// One past userprofile.MaxSpecializations. The set below the cap is exercised by
+		// TestPutProfile_AcceptsSpecializationsUpToTheCap — a cap only holds if both sides
+		// of it are checked.
+		{"too many specializations", `{"specializations":["backend","frontend","fullstack","mobile","devops","sre","qa","security","hardware","embedded","blockchain"],"skills":["go"]}`, fiber.StatusBadRequest},
 		{"empty skills", `{"specializations":["backend"],"skills":[]}`, fiber.StatusBadRequest},
 	}
 	for _, tc := range cases {
@@ -142,6 +145,30 @@ func TestPutProfile_ReturnsSpecializationsArray(t *testing.T) {
 	}
 	if strings.Join(got.Data.Specializations, ",") != "backend,devops" {
 		t.Errorf("specializations = %v, want [backend devops]", got.Data.Specializations)
+	}
+}
+
+// A profile filled from a CV routinely resolves more than a handful of categories, and the
+// cap that used to sit at 5 rejected the whole save when it did. Exactly MaxSpecializations
+// must be accepted, or the bound is really one lower than it says.
+func TestPutProfile_AcceptsSpecializationsUpToTheCap(t *testing.T) {
+	specs := []string{"backend", "frontend", "fullstack", "mobile", "devops", "sre", "qa", "security", "hardware", "embedded"}
+	if len(specs) != userprofile.MaxSpecializations {
+		t.Fatalf("test fixture holds %d specializations, want MaxSpecializations = %d", len(specs), userprofile.MaxSpecializations)
+	}
+	repo := &fakeProfileRepo{}
+	app, token := profileApp(t, repo)
+	body, err := json.Marshal(map[string]any{"specializations": specs, "skills": []string{"go"}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	resp := doProfile(t, app, fiber.MethodPut, string(body), token)
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if len(repo.upserted.Specializations) != len(specs) {
+		t.Errorf("specializations upserted = %v, want all %d", repo.upserted.Specializations, len(specs))
 	}
 }
 

--- a/internal/identity/userprofile/userprofile.go
+++ b/internal/identity/userprofile/userprofile.go
@@ -27,7 +27,7 @@ var (
 	// ErrEmptySpecializations is a profile whose specializations are empty after
 	// normalization (mapped to 400).
 	ErrEmptySpecializations = errors.New("userprofile: at least one specialization is required")
-	// ErrTooManySpecializations is a specialization set past maxSpecializations (mapped to 400).
+	// ErrTooManySpecializations is a specialization set past MaxSpecializations (mapped to 400).
 	ErrTooManySpecializations = errors.New("userprofile: too many specializations")
 	// ErrEmptySkills is a profile whose skills are empty after normalization (mapped to 400).
 	ErrEmptySkills = errors.New("userprofile: at least one skill is required")
@@ -50,9 +50,15 @@ var (
 // the right failure mode, not an unbounded retry loop.
 const mergeSkillsMaxAttempts = 3
 
-// maxSpecializations caps how many specializations one profile may combine; the
-// migration's cardinality CHECK is the backstop.
-const maxSpecializations = 5
+// MaxSpecializations caps how many specializations one profile may combine; the
+// migration's cardinality CHECK is the backstop. Exported so the HTTP layer names the
+// bound in its 400 rather than repeating the number, and so the two cannot drift.
+//
+// Raised from 5 to 10 (migration 0135): a CV resolves several categories on its own and
+// the profile form unions them into whatever is already picked, so a candidate whose work
+// genuinely spans backend, data, cloud and a few more hit the bound without ever choosing
+// to. 10 still bounds the set — it is a profile's role list, not a catalogue.
+const MaxSpecializations = 10
 
 // maxSkills caps how many skills one profile may list, wanted or avoided. The wanted set is
 // not just stored: the coverage verdict turns it into one `skills != "<skill>"` AND group per
@@ -253,7 +259,7 @@ func mergeSkills(held, additions, excluded []string) ([]string, bool) {
 // first-seen order), and checks membership in the controlled category vocabulary (the same
 // enum the rest of the app validates against). It returns ErrEmptySpecializations if nothing
 // remains, ErrInvalidSpecialization for an unknown category, and ErrTooManySpecializations
-// past maxSpecializations — mirroring normalizeSkills.
+// past MaxSpecializations — mirroring normalizeSkills.
 func normalizeSpecializations(specializations []string) ([]string, error) {
 	out := make([]string, 0, len(specializations))
 	seen := make(map[string]struct{}, len(specializations))
@@ -274,7 +280,7 @@ func normalizeSpecializations(specializations []string) ([]string, error) {
 	if len(out) == 0 {
 		return nil, ErrEmptySpecializations
 	}
-	if len(out) > maxSpecializations {
+	if len(out) > MaxSpecializations {
 		return nil, ErrTooManySpecializations
 	}
 	return out, nil

--- a/internal/identity/userprofile/userprofile_test.go
+++ b/internal/identity/userprofile/userprofile_test.go
@@ -299,13 +299,32 @@ func TestSave_RejectsEmptySpecializations(t *testing.T) {
 
 func TestSave_RejectsTooManySpecializations(t *testing.T) {
 	repo := &fakeRepo{}
-	six := []string{"backend", "frontend", "fullstack", "mobile", "devops", "sre"}
-	_, err := userprofile.New(repo).Save(context.Background(), 7, six, []string{"go"}, nil, nil, nil)
+	tooMany := []string{"backend", "frontend", "fullstack", "mobile", "devops", "sre", "qa", "security", "hardware", "embedded", "blockchain"}
+	if len(tooMany) != userprofile.MaxSpecializations+1 {
+		t.Fatalf("test fixture holds %d specializations, want MaxSpecializations + 1 = %d", len(tooMany), userprofile.MaxSpecializations+1)
+	}
+	_, err := userprofile.New(repo).Save(context.Background(), 7, tooMany, []string{"go"}, nil, nil, nil)
 	if !errors.Is(err, userprofile.ErrTooManySpecializations) {
 		t.Errorf("err = %v, want ErrTooManySpecializations", err)
 	}
 	if repo.upsertCalled {
 		t.Error("repo.Upsert should not be called past the specialization cap")
+	}
+}
+
+// The other side of the same bound: exactly MaxSpecializations saves. A cap checked only
+// from above is really a cap one lower than it says.
+func TestSave_AcceptsSpecializationsUpToTheCap(t *testing.T) {
+	repo := &fakeRepo{}
+	specs := []string{"backend", "frontend", "fullstack", "mobile", "devops", "sre", "qa", "security", "hardware", "embedded"}
+	if len(specs) != userprofile.MaxSpecializations {
+		t.Fatalf("test fixture holds %d specializations, want MaxSpecializations = %d", len(specs), userprofile.MaxSpecializations)
+	}
+	if _, err := userprofile.New(repo).Save(context.Background(), 7, specs, []string{"go"}, nil, nil, nil); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if !repo.upsertCalled {
+		t.Error("repo.Upsert should be called at exactly the specialization cap")
 	}
 }
 

--- a/migrations/0135_user_profile_specializations_cap_10.sql
+++ b/migrations/0135_user_profile_specializations_cap_10.sql
@@ -1,0 +1,29 @@
+-- Raise the user profile's specialization cardinality bound from 5 to 10, the backstop for
+-- the cap internal/identity/userprofile enforces (MaxSpecializations).
+--
+-- Why: 5 was reached without anyone choosing to reach it. A CV resolves several categories
+-- on its own and both the profile form and the onboarding wizard UNION what an import
+-- resolved into whatever is already picked, so a candidate whose work spans backend, data,
+-- cloud and a couple more simply could not save — the onboarding wizard had no cap of its
+-- own and swallowed the resulting 400, which read to the user as a wizard that does
+-- nothing. The bound still exists: this is a profile's role list, not a catalogue.
+--
+-- The constraint is replaced rather than relaxed in place (Postgres has no ALTER
+-- CONSTRAINT for a CHECK expression). Every existing row satisfies the wider bound by
+-- construction — the old one only ever admitted 5 — so the recreate cannot fail on data.
+--
+-- Added VALID rather than 0056's NOT VALID, which was written for a bound that existing
+-- rows might genuinely violate. This one cannot be violated, and the table it scans is the
+-- profile table — a few hundred rows, not the catalogue — so the validation is part of the
+-- same statement and the constraint does not carry NOT VALID forever for nothing.
+--
+-- Run BEFORE the binary that writes 6-10 specializations: the old constraint would reject
+-- such a write, and the old binary never produces one, so either order is safe for the
+-- code but only this one is safe for the user.
+ALTER TABLE public.user_profiles
+    DROP CONSTRAINT IF EXISTS user_profiles_specializations_card_chk;
+
+ALTER TABLE public.user_profiles
+    -- squawk-ignore constraint-missing-not-valid -- a few hundred profile rows, all of which already satisfy a STRICTLY tighter bound; the scan cannot fail and is not worth a permanent NOT VALID
+    ADD CONSTRAINT user_profiles_specializations_card_chk
+    CHECK ((cardinality(specializations) >= 1) AND (cardinality(specializations) <= 10));

--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -4,6 +4,7 @@
   import { cvUploadReason, track } from '$lib/analytics';
   import { CATEGORY_OPTIONS } from '$lib/facets';
   import { profileStore } from '$lib/profile.svelte';
+  import { MAX_SPECIALIZATIONS, capSpecializations } from '$lib/profileLimits';
   import { withSkills } from '$lib/profileSkills';
   import type { LocationPreferences, UserProfile } from '$lib/types';
   import { Button, ConfirmDialog } from '$lib/ui';
@@ -11,9 +12,6 @@
   import SearchSelect from './facets/SearchSelect.svelte';
   import LocationPreferencesFields from './profile/LocationPreferencesFields.svelte';
   import SkillsPicker from './profile/SkillsPicker.svelte';
-
-  // Mirror of the server's specialization cap (searchprofile.maxSpecializations).
-  const MAX_SPECIALIZATIONS = 5;
 
   // Inline editor for the single profile. `profile` seeds the fields (null = first-time
   // set-up); `hasCv` drives the CV block's uploaded/empty state. `onSaved` fires after a
@@ -106,18 +104,8 @@
       // Merge every specialization the CV resolved, respecting the cap; track how many
       // were added vs. left out by the cap so the note is accurate. Always local first —
       // `nextSpecializations` is what an editing-mode write below persists alongside skills.
-      let addedSpecs = 0;
-      let cappedSpecs = 0; // resolved but the cap left no room
-      const nextSpecializations = [...specializations];
-      for (const cat of cv.categories) {
-        if (nextSpecializations.includes(cat)) continue;
-        if (nextSpecializations.length < MAX_SPECIALIZATIONS) {
-          nextSpecializations.push(cat);
-          addedSpecs++;
-        } else {
-          cappedSpecs++;
-        }
-      }
+      const { kept: nextSpecializations, dropped: cappedSpecs } = capSpecializations(specializations, cv.categories);
+      const addedSpecs = nextSpecializations.length - specializations.length;
       specializations = nextSpecializations;
 
       let addedSkills: number;

--- a/web/src/lib/components/onboarding/ConfirmStep.svelte
+++ b/web/src/lib/components/onboarding/ConfirmStep.svelte
@@ -13,6 +13,7 @@
   import { FACETS } from '$lib/facets';
   import { CATEGORY_GROUPS } from '$lib/filterSections';
   import { pillClass, pillTitle } from '$lib/components/facets/pill';
+  import { MAX_SPECIALIZATIONS } from '$lib/profileLimits';
   import ProfileLinksFields from './ProfileLinksFields.svelte';
   import type { ProfileLinks } from '$lib/profileLinks';
 
@@ -64,12 +65,24 @@
     })).filter((g) => g.options.length > 0);
   });
 
+  // The same cap the profile form and the profile's Roles editor enforce, and for the same
+  // reason: the profile save rejects the whole set past it. This step went without one, so
+  // the wizard let an 11th role be picked, sent all 11, and turned a rejection the user
+  // could have avoided into "couldn't save that just now".
+  let specError = $state<string | null>(null);
+
   function toggleSpecialization(value: string) {
-    onSpecializationsChange(
-      specializations.includes(value)
-        ? specializations.filter((v) => v !== value)
-        : [...specializations, value],
-    );
+    if (specializations.includes(value)) {
+      specError = null;
+      onSpecializationsChange(specializations.filter((v) => v !== value));
+      return;
+    }
+    if (specializations.length >= MAX_SPECIALIZATIONS) {
+      specError = `You can pick at most ${MAX_SPECIALIZATIONS} specializations. Remove one to add another.`;
+      return;
+    }
+    specError = null;
+    onSpecializationsChange([...specializations, value]);
   }
 
   function toggleSeniority(value: string) {
@@ -82,9 +95,14 @@
 <!-- A field label with a "Clear" X — same pattern as FacetSection's section header: shown
      only once something is selected, and clearing that field's whole selection at once
      (separate from removing one pill at a time). -->
-{#snippet fieldLabel(text: string, count: number, onClear: () => void)}
+{#snippet fieldLabel(text: string, count: number, onClear: () => void, hint?: string)}
   <div class="mb-2 flex min-h-6 items-center justify-between gap-2">
-    <span class="text-sm font-medium">{text}</span>
+    <span class="text-sm font-medium">
+      {text}
+      <!-- The count sits beside the label rather than inside it, so the Clear button's
+           accessible name stays "Clear Specialization" and not "Clear Specialization 3/10". -->
+      {#if hint}<span class="ml-1 text-xs font-normal tabular-nums text-muted-foreground">{hint}</span>{/if}
+    </span>
     {#if count > 0}
       <button
         type="button"
@@ -103,8 +121,19 @@
 <p class="mt-1 text-sm text-muted-foreground">Everything's optional — pick as many as apply.</p>
 
 <div class="mt-5">
-  {@render fieldLabel('Specialization', specializations.length, () => onSpecializationsChange([]))}
+  {@render fieldLabel(
+    'Specialization',
+    specializations.length,
+    () => {
+      specError = null;
+      onSpecializationsChange([]);
+    },
+    `${specializations.length}/${MAX_SPECIALIZATIONS}`,
+  )}
 </div>
+{#if specError}
+  <p class="mb-2 text-xs text-destructive">{specError}</p>
+{/if}
 <div class="mb-4 flex items-center gap-2 rounded-lg border border-input px-3 focus-within:ring-2 focus-within:ring-ring">
   <Search class="size-4 shrink-0 text-muted-foreground" />
   <input

--- a/web/src/lib/components/onboarding/CvStep.svelte
+++ b/web/src/lib/components/onboarding/CvStep.svelte
@@ -12,6 +12,7 @@
   import { cvUploadReason, track } from '$lib/analytics';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { resumeStore } from '$lib/resume.svelte';
+  import { MAX_SPECIALIZATIONS } from '$lib/profileLimits';
   import type { DerivedLocation } from '$lib/types';
   import { mergeFacets, type MergedFacets, type StagedFacets } from '$lib/onboardingImport';
 
@@ -48,6 +49,19 @@
     cvInput?.click();
   }
 
+  // What an import says afterwards. Both entry points share it because they share the fold
+  // (mergeFacets) — including the specialization cap, which is the one part of the result
+  // the candidate cannot see for themselves: a role the cap left out simply is not on the
+  // next step, and an import that quietly kept 10 of 13 reads as one that misread the CV.
+  function importNote(merged: MergedFacets, source: string): string {
+    if (!merged.resolved) return `Couldn’t read details from ${source} — pick below.`;
+    if (merged.specializationsDropped > 0) {
+      const n = merged.specializationsDropped;
+      return `Filled in what we found — review on the next step. A profile holds ${MAX_SPECIALIZATIONS} specializations, so ${n} more we found ${n === 1 ? 'was' : 'were'} left out.`;
+    }
+    return 'Filled in what we found — review on the next step.';
+  }
+
   async function onCvFile(e: Event) {
     const input = e.target as HTMLInputElement;
     const file = input.files?.[0];
@@ -68,9 +82,7 @@
       const merged = mergeFacets(staged, cv);
       onExtracted(merged);
       cvState = 'idle';
-      cvNote = merged.resolved
-        ? 'Filled in what we found — review on the next step.'
-        : 'Couldn’t read details from that CV — pick below.';
+      cvNote = importNote(merged, 'that CV');
     } catch (err) {
       track('cv_upload', {
         ok: false,
@@ -109,9 +121,7 @@
       // they already gave us one step later reads as not having listened.
       onLinkedInUrl(url);
       liState = 'idle';
-      liNote = merged.resolved
-        ? 'Filled in what we found — review on the next step.'
-        : 'Couldn’t read details from that profile — pick below.';
+      liNote = importNote(merged, 'that profile');
     } catch (err) {
       track('linkedin_import', { ok: false, origin: 'onboarding_gate' });
       if (gen !== liGen) return;

--- a/web/src/lib/components/profile/RoleCard.svelte
+++ b/web/src/lib/components/profile/RoleCard.svelte
@@ -5,11 +5,9 @@
   // on every change, the same way the Skills view does.
   import { CATEGORY_OPTIONS } from '$lib/facets';
   import { profileStore } from '$lib/profile.svelte';
+  import { MAX_SPECIALIZATIONS } from '$lib/profileLimits';
   import type { UserProfile } from '$lib/types';
   import SearchSelect from '../facets/SearchSelect.svelte';
-
-  // Mirror of the server's specialization cap (searchprofile.maxSpecializations).
-  const MAX_SPECIALIZATIONS = 5;
 
   let {
     profile,

--- a/web/src/lib/onboardingImport.test.ts
+++ b/web/src/lib/onboardingImport.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { mergeFacets, type StagedFacets } from './onboardingImport';
+import { MAX_SPECIALIZATIONS } from './profileLimits';
 import type { ResumeProfile } from './types';
 
 function staged(over: Partial<StagedFacets> = {}): StagedFacets {
@@ -48,6 +49,33 @@ describe('mergeFacets', () => {
   it('adds a second level rather than replacing the first', () => {
     const got = mergeFacets(staged({ seniorities: ['mid'] }), imported({ seniority: 'senior' }));
     expect(got.seniorities).toEqual(['mid', 'senior']);
+  });
+
+  // The server rejects the whole save past the cap, so an uncapped union here turned a good
+  // import into a profile that could not be saved at all — the 400 a candidate hit on prod.
+  describe('the specialization cap', () => {
+    const many = (n: number) => Array.from({ length: n }, (_, i) => `category-${i}`);
+
+    it('keeps at most the cap and reports what it left out', () => {
+      const got = mergeFacets(staged(), imported({ categories: many(MAX_SPECIALIZATIONS + 3) }));
+
+      expect(got.specializations).toHaveLength(MAX_SPECIALIZATIONS);
+      expect(got.specializationsDropped).toBe(3);
+    });
+
+    it('drops the overflow from the import, never what the user already picked', () => {
+      const mine = ['backend', 'data'];
+      const got = mergeFacets(staged({ specializations: mine }), imported({ categories: many(MAX_SPECIALIZATIONS) }));
+
+      expect(got.specializations.slice(0, 2)).toEqual(mine);
+      expect(got.specializations).toHaveLength(MAX_SPECIALIZATIONS);
+      expect(got.specializationsDropped).toBe(2);
+    });
+
+    it('reports nothing dropped when the import fits', () => {
+      const got = mergeFacets(staged({ specializations: ['backend'] }), imported({ categories: ['data'] }));
+      expect(got.specializationsDropped).toBe(0);
+    });
   });
 
   describe('resolved', () => {

--- a/web/src/lib/onboardingImport.ts
+++ b/web/src/lib/onboardingImport.ts
@@ -1,3 +1,4 @@
+import { capSpecializations } from './profileLimits';
 import type { ResumeProfile } from './types';
 
 /** What the onboarding wizard is holding for the confirm step, before anything is saved. */
@@ -12,6 +13,10 @@ export interface StagedFacets {
  *  "filled in what we found" and "couldn't read details". */
 export interface MergedFacets extends StagedFacets {
   resolved: boolean;
+  /** How many resolved specializations the cap left out, so the wizard can say so. An
+   *  import that resolves more roles than a profile may hold is not an error — but a value
+   *  that vanishes without a word reads as one. */
+  specializationsDropped: number;
 }
 
 /** Folds what a CV or a LinkedIn profile resolved into what the wizard already holds.
@@ -28,11 +33,16 @@ export interface MergedFacets extends StagedFacets {
  */
 export function mergeFacets(staged: StagedFacets, incoming: ResumeProfile): MergedFacets {
   const resolved = incoming.categories.length > 0 || incoming.skills.length > 0 || !!incoming.seniority;
+  // Specializations merge under the profile's cap, unlike the other two fields: the server
+  // rejects the whole save past it, so an uncapped union here turns a good import into a
+  // profile that will not save at all.
+  const specializations = capSpecializations(staged.specializations, incoming.categories);
   return {
-    specializations: union(staged.specializations, incoming.categories),
+    specializations: specializations.kept,
     seniorities: union(staged.seniorities, incoming.seniority ? [incoming.seniority] : []),
     skills: union(staged.skills, incoming.skills),
     resolved,
+    specializationsDropped: specializations.dropped,
   };
 }
 

--- a/web/src/lib/profileLimits.ts
+++ b/web/src/lib/profileLimits.ts
@@ -1,0 +1,29 @@
+/** The profile's specialization cap, mirroring the server's userprofile.MaxSpecializations
+ *  (and the cardinality CHECK behind it, migration 0135).
+ *
+ *  One copy, because there are three surfaces that pick specializations — the profile form,
+ *  the profile's Roles card, and the onboarding wizard — and the wizard is the one that
+ *  shipped without a cap at all: it unioned whatever a CV or LinkedIn import resolved into
+ *  the staged set, sent the lot, and swallowed the server's 400. A number written out four
+ *  times is a number that goes missing in one of them.
+ */
+export const MAX_SPECIALIZATIONS = 10;
+
+/** Folds `incoming` into `current` up to the cap, keeping the order the user already sees
+ *  and reporting what the cap left out — every caller has something to say about the
+ *  remainder ("Reached the limit — nothing more added"), so dropping it silently is the one
+ *  behaviour none of them want.
+ *
+ *  Returns `current` itself when nothing was added and nothing was dropped, so a merge that
+ *  changes nothing does not churn the caller's reactive state. */
+export function capSpecializations(current: string[], incoming: string[]): { kept: string[]; dropped: number } {
+  const kept = [...current];
+  let dropped = 0;
+  for (const value of incoming) {
+    if (kept.includes(value)) continue;
+    if (kept.length < MAX_SPECIALIZATIONS) kept.push(value);
+    else dropped++;
+  }
+  if (dropped === 0 && kept.length === current.length) return { kept: current, dropped: 0 };
+  return { kept, dropped };
+}

--- a/web/src/routes/onboarding/+page.svelte
+++ b/web/src/routes/onboarding/+page.svelte
@@ -19,7 +19,7 @@
   import { goto } from '$app/navigation';
   import { page } from '$app/state';
   import { ArrowLeft, ArrowRight, LoaderCircle, X } from '@lucide/svelte';
-  import { api } from '$lib/api';
+  import { api, ApiError } from '$lib/api';
   import { completeOnboarding, isAuthenticated } from '$lib/auth.svelte';
   import { onboardingGate } from '$lib/onboardingGate.svelte';
   import { ORDERED_STEPS, plannedSteps, type OnboardingAnswered, type StepKind } from '$lib/onboardingSteps';
@@ -218,8 +218,15 @@
       // The response IS the new stored overlay, so keeping it is what stops a later contacts
       // write spreading something three screens stale — see onboardingSave.ts's header.
       contacts = await persistStep(kind, wizardAnswers, saveDeps);
-    } catch {
-      saveError = "Couldn't save that just now. Try again, or skip this step.";
+    } catch (err) {
+      // The server's own message when there is one: a rejection names the field it refused
+      // ("too many specializations (max 10)"), and that is something the candidate can act
+      // on, unlike "couldn't save that just now" — which is all a candidate on prod ever
+      // saw while the 400 went to their browser console.
+      saveError =
+        err instanceof ApiError
+          ? `${err.message}. Fix it above, or skip this step.`
+          : "Couldn't save that just now. Try again, or skip this step.";
       saving = false;
       return;
     }


### PR DESCRIPTION
## What happened

A candidate testing the site could not finish setting up his account. Every Finish on the onboarding wizard came back:

```
PUT /api/v1/me/profile 400 too many specializations (max 5)
```

Prod logs, one session: ten of these in ninety seconds. The wizard showed him nothing — the save sat in a bare `catch {}`, so the only trace was the 400 in his browser console.

## Two faults

**The cap was reached without anyone choosing to reach it.** A CV resolves several categories on its own, and both import paths (CV upload, LinkedIn) UNION what they resolved into whatever is already picked. Someone whose work spans backend, data, cloud and a couple more crossed 5 without clicking anything.

**The onboarding wizard had no cap of its own.** `ProfileForm.svelte` and `RoleCard.svelte` both refuse the extra pick and say why; the wizard let it through, sent all of them, and swallowed the rejection.

## What this does

- Raises the cap to 10 (migration 0135 widens the cardinality CHECK behind it). The bound still exists — it is a profile's role list, not a catalogue.
- Gives the number one home per side: `userprofile.MaxSpecializations` (the handler now names it in the 400 rather than repeating "5") and `$lib/profileLimits` for the three surfaces that pick specializations. It used to be written out four times, and the fifth place — the wizard — simply did not have it.
- Caps the wizard's own picks and what an import folds in, and says what the cap left out.
- Shows a failed save with the server's own message, plus a "Leave without saving" way out — the wizard must not become a room a user cannot walk out of.

## Deploy order

Migration BEFORE the binary: the old constraint rejects a 6-10 write, and the old binary never produces one.

## Verification

`go test ./...`, `go vet -tags=integration ./...`, `pnpm --dir web check` (0 errors), `pnpm --dir web vitest run` (1453 pass), `pnpm check:sql`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased the profile specialization limit from 5 to 10.
  - Added specialization count indicators and clear validation messages during onboarding.
  - Profile and CV/LinkedIn imports now respect the limit and report omitted specializations.
- **Bug Fixes**
  - Error messages now display the current specialization limit accurately.
  - Onboarding save failures show server-provided guidance when available.
- **Documentation**
  - Updated specialization limit validation and related error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->