### PR TITLE
Offer the match sort to everyone, and say what it needs

### DIFF
--- a/internal/search/search/AGENTS.md
+++ b/internal/search/search/AGENTS.md
@@ -154,12 +154,13 @@ indexers (`cmd/reindex`, `cmd/search-drain`, `internal/ingest/linkimport`).
    retro-fill 1.36M documents; until the rebuild lands, the match sort returns only
    what has been re-indexed since. It is a thin feed, not an error, so nothing alerts.
 
-That second hazard is why the SPA ships the control dark, behind `PUBLIC_MATCH_SORT`
-(default OFF, read at runtime — see `web/src/lib/features.ts`). The API honours
-`?sort=match` from the moment the binary rolls out whether or not that flag is set,
-which is exactly how the ordering gets verified on production before anyone can click
-it. Reveal order: deploy → settings → rebuild → verify by hand → flip the flag and
-restart web.
+That second hazard used to be handled by shipping the control dark behind a
+`PUBLIC_MATCH_SORT` flag. The rebuild has long since landed and the flag is gone; the
+control is offered to every visitor, and a caller with no skills to rank against is told
+so by the feed rather than having the ordering hidden from them. What survives is the
+ORDER the hazard implies, and it still binds any future change to the vectors: deploy →
+settings → rebuild → verify by hand with `?sort=match`. Rolling out a binary that queries
+an embedder the live settings do not yet declare is still the first hazard above.
 
 `skillvec.Dimensions` is baked into the live settings. **Changing it requires a full
 rebuild**, and until that rebuild finishes the index rejects every document carrying

--- a/openspec/changes/onboarding-feedback-pass/design.md
+++ b/openspec/changes/onboarding-feedback-pass/design.md
@@ -112,6 +112,8 @@ browser rather than with tests that would only restate the implementation.
 ## Out of scope
 
 - `PUBLIC_MATCH_SORT` on production — an ops check, recorded so it is not lost.
+  (Answered since: the flag was set, and a later change retired it altogether — the match
+  sort is now offered to everyone and the feed explains what it needs.)
 - Any change to what `save` means on the server. Saving still writes `saved_at` and
   nothing else.
 - The companies search placeholder. It is not a role box.

--- a/web/.env.example
+++ b/web/.env.example
@@ -15,18 +15,6 @@ VITE_API_URL=http://localhost:8080
 # Vite proxy handles it).
 # API_INTERNAL_URL=http://app:8080
 
-# Reveals the profile-match sort control in the jobs feed. Default OFF.
-#
-# The feature ships dark on purpose: the API accepts `?sort=match` as soon as the
-# binary is out, but it ranks against skill vectors that only exist once a FULL
-# Meilisearch rebuild has written them. Before that the sort returns the handful of
-# postings re-indexed since — a near-empty feed that reads as broken, not as new.
-#
-# So: deploy, run the rebuild, verify by hand with `?sort=match` (the param is honoured
-# whether or not this flag is set), then set this and restart the web server. Read at
-# runtime, so flipping it needs no rebuild of the SPA.
-# PUBLIC_MATCH_SORT=1
-
 # Reveals the "Open within" bound — how long a posting has been in the catalogue, as
 # opposed to the date its source states. Default OFF. It also decides which of the two
 # the select above the list writes: with this on it bounds the open date and reads

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -208,7 +208,17 @@
 
   // Whether that notice is showing: match is the ordering in force and there are no
   // skills to rank against, so the server has quietly served newest instead.
-  const matchNeedsSkills = $derived(matchSortNeedsSkills(filters.value, matchFilterAvailable));
+  //
+  // Three states, not two — "has skills", "has none", and "we do not know yet".
+  // `matchFilterAvailable` folds the third into the second, and the profile arrives one
+  // round trip after the page does, so asking it alone would put this notice in the
+  // server-rendered HTML for a signed-in user WITH skills and take it away a moment
+  // later. `loaded` exists for exactly this (see userResource.svelte.ts). Signed out
+  // there is nothing to wait for: no account means no profile, and that is known at once.
+  const skillsSettled = $derived(!isAuthenticated() || profileStore.loaded);
+  const matchNeedsSkills = $derived(
+    skillsSettled && matchSortNeedsSkills(filters.value, matchFilterAvailable),
+  );
 
   // Which date the above-list select bounds. Not $derived: the flag is a runtime env
   // value read once at module load, and it cannot change while the page is mounted.
@@ -778,7 +788,13 @@
          would punish someone for pressing a button we offered them. What was missing
          was only the explanation. -->
     {#if matchNeedsSkills}
-      <div class="mt-3 rounded-xl border border-brand/30 bg-brand/5 p-3 text-sm sm:p-4">
+      <!-- `role="status"` because this appears in response to changing the Sort control,
+           and a screen-reader user who just did that gets no other signal that the
+           ordering they picked was not the one served. -->
+      <div
+        role="status"
+        class="mt-3 rounded-xl border border-brand/30 bg-brand/5 p-3 text-sm sm:p-4"
+      >
         <p class="font-medium text-foreground">Sorted by match needs to know about you</p>
         <p class="mt-1 text-muted-foreground">
           We rank these against your own skills, and we don't have them yet. Showing the

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
   import { onMount, untrack, type Snippet } from 'svelte';
-  import { Layers } from '@lucide/svelte';
+  import { ArrowRight, Layers } from '@lucide/svelte';
   import { browser } from '$app/environment';
   import { afterNavigate, goto, replaceState } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import { api, type Slice } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
+  import { promptSignIn } from '$lib/signin';
   import { profileStore } from '$lib/profile.svelte';
   import { env } from '$env/dynamic/public';
-  import { matchSortEnabled, openWithinEnabled } from '$lib/features';
+  import { openWithinEnabled } from '$lib/features';
   import { computeClientMatch } from '$lib/jobMatch';
   import { ensureViewedLoaded } from '$lib/viewedJobs.svelte';
   import { ensureSavedLoaded } from '$lib/savedJobs.svelte';
@@ -21,6 +22,7 @@
   import {
     FilterStore,
     filtersToParams,
+    matchSortNeedsSkills,
     selectedSortFor,
     sortOptionsFor,
     type JobSort,
@@ -193,24 +195,20 @@
     if (!matchFilterAvailable) minMatch = null;
   });
 
-  // The match SORT rides the same profile precondition as the match slider, plus a
-  // runtime flag. It ships dark: the API accepts ?sort=match as soon as the binary is
-  // out, but it ranks against skill vectors that only exist once a full index rebuild
-  // has written them — before that the sort returns a near-empty feed, which reads as
-  // broken rather than new. The flag is what reveals the option once the rebuild has
-  // landed, and flipping it is an env change plus a restart, not a redeploy.
-  //
-  // The URL param stays honoured either way, which is deliberate: it is how the sort
-  // gets verified on production before anyone can click it.
-  const matchSortAvailable = $derived(matchFilterAvailable && matchSortEnabled(env));
-
   // The orderings this caller can choose between, and which one the control shows —
   // both pure, both in facetModel so they can be tested (see sortOptionsFor).
-  const sortOptions = $derived(sortOptionsFor(filters.value.q, matchSortAvailable));
-  const selectedSort = $derived(selectedSortFor(filters.value, matchSortAvailable));
-  // A one-option select is a label wearing a control's clothes: there is nothing to
-  // choose, and the feed already IS that ordering.
-  const sortSelectVisible = $derived(sortOptions.length > 1);
+  //
+  // Match is offered to everyone. It used to need the same profile the match SLIDER
+  // does, which meant the one ordering that answers "which of these actually suit me"
+  // was invisible to every visitor who had not filled a profile in — and nothing told
+  // them it existed. Choosing it without skills on file is now answered out loud
+  // instead, by the notice below the toolbar.
+  const sortOptions = $derived(sortOptionsFor(filters.value.q));
+  const selectedSort = $derived(selectedSortFor(filters.value));
+
+  // Whether that notice is showing: match is the ordering in force and there are no
+  // skills to rank against, so the server has quietly served newest instead.
+  const matchNeedsSkills = $derived(matchSortNeedsSkills(filters.value, matchFilterAvailable));
 
   // Which date the above-list select bounds. Not $derived: the flag is a runtime env
   // value read once at module load, and it cannot change while the page is mounted.
@@ -727,7 +725,11 @@
      bound it belongs with. -->
 {#snippet listControls()}
   {@render postedSelect()}
-  {#if sortSelectVisible}{@render sortSelect()}{/if}
+  <!-- Unconditional. This used to be guarded against a one-option select - a label
+       wearing a control's clothes - which could happen when match was hidden from a
+       viewer with no profile. Every caller is now offered newest, most-viewed and match,
+       so the guard could never be false. -->
+  {@render sortSelect()}
 {/snippet}
 
 <div class="flex gap-6">
@@ -766,6 +768,41 @@
             autostart={alertBanner.autostart}
             onDismiss={() => (alertBanner = null)}
           />
+        {/if}
+      </div>
+    {/if}
+
+    <!-- Match was chosen and there is nothing to rank against. Sits with the nudges
+         above and, like them, never replaces the feed: the server degrades this request
+         to newest rather than refusing it, so there ARE jobs below — taking them away
+         would punish someone for pressing a button we offered them. What was missing
+         was only the explanation. -->
+    {#if matchNeedsSkills}
+      <div class="mt-3 rounded-xl border border-brand/30 bg-brand/5 p-3 text-sm sm:p-4">
+        <p class="font-medium text-foreground">Sorted by match needs to know about you</p>
+        <p class="mt-1 text-muted-foreground">
+          We rank these against your own skills, and we don't have them yet. Showing the
+          newest first for now.
+        </p>
+        {#if isAuthenticated()}
+          <a
+            href={resolve('/my/profile')}
+            class="mt-2.5 inline-flex items-center gap-1.5 font-medium text-brand hover:underline"
+          >
+            Add your CV or skills
+            <ArrowRight class="size-4" aria-hidden="true" />
+          </a>
+        {:else}
+          <!-- Signed out there is no profile to fill in yet, so the first step is the
+               account that would hold one. -->
+          <button
+            type="button"
+            onclick={() => promptSignIn()}
+            class="mt-2.5 inline-flex items-center gap-1.5 font-medium text-brand hover:underline"
+          >
+            Sign in to add your CV
+            <ArrowRight class="size-4" aria-hidden="true" />
+          </button>
         {/if}
       </div>
     {/if}

--- a/web/src/lib/facetModel.test.ts
+++ b/web/src/lib/facetModel.test.ts
@@ -16,6 +16,7 @@ import {
   facetRemove,
   defaultSortFor,
   effectiveSort,
+  matchSortNeedsSkills,
   sortOptionsFor,
   selectedSortFor,
   type FacetState,
@@ -397,11 +398,13 @@ describe('sort', () => {
 // The option list is the sort control's visibility rule, kept pure and out of the
 // component so it can be tested at all — the same argument that put effectiveSort here.
 describe('sort options', () => {
-  it('offers relevance only under a query, and match only when it can be served', () => {
-    expect(sortOptionsFor('', false).map((o) => o.value)).toEqual(['newest', 'views']);
-    expect(sortOptionsFor('go', false).map((o) => o.value)).toEqual(['relevance', 'newest', 'views']);
-    expect(sortOptionsFor('', true).map((o) => o.value)).toEqual(['newest', 'views', 'match']);
-    expect(sortOptionsFor('go', true).map((o) => o.value)).toEqual([
+  // Match is offered to everyone now, including a visitor with no skills on file. It
+  // used to be hidden from them, which answered "why can I not sort by fit?" with
+  // nothing at all; the feed explains what the ordering needs instead (see
+  // matchSortNeedsSkills).
+  it('offers relevance only under a query, and match always', () => {
+    expect(sortOptionsFor('').map((o) => o.value)).toEqual(['newest', 'views', 'match']);
+    expect(sortOptionsFor('go').map((o) => o.value)).toEqual([
       'relevance',
       'newest',
       'views',
@@ -409,35 +412,28 @@ describe('sort options', () => {
     ]);
   });
 
-  // `views` ranks by a stored figure, so unlike `relevance` it needs no query text and
-  // unlike `match` it needs no profile. Being unconditional it joins `newest`, which
-  // means the control now holds two options for every caller and is therefore rendered
-  // on every listing — including the signed-out browse that previously showed none.
+  // `views` ranks by a stored figure, so unlike `relevance` it needs no query text.
   it('offers most-viewed unconditionally', () => {
     for (const q of ['', 'go']) {
-      for (const matchAvailable of [false, true]) {
-        expect(sortOptionsFor(q, matchAvailable).map((o) => o.value)).toContain('views');
-      }
+      expect(sortOptionsFor(q).map((o) => o.value)).toContain('views');
     }
-    expect(sortOptionsFor('', false).length).toBeGreaterThan(1);
   });
 
-  // A shared ?sort=match link opened signed out: the param survives (the server degrades
-  // the ordering rather than refusing it), but the control cannot show an option it does
-  // not offer. It shows what the server will actually serve — a select with nothing
-  // selected would be a blank control over a real ordering.
+  // `relevance` is the one ordering that can still be asked for and not offered: it
+  // ranks against query text, and a shared link can arrive without any. The control must
+  // name what the server will actually serve — a select with nothing selected would be a
+  // blank control over a real ordering.
   it('shows what the server will serve when the chosen ordering cannot be offered', () => {
-    expect(selectedSortFor(withQuery('go', 'match'), false)).toBe('relevance');
-    expect(selectedSortFor(withQuery('', 'match'), false)).toBe('newest');
-    expect(selectedSortFor(withQuery('go', 'match'), true)).toBe('match');
+    expect(selectedSortFor(withQuery('', 'relevance'))).toBe('newest');
+    expect(selectedSortFor(withQuery('go', 'relevance'))).toBe('relevance');
+    expect(selectedSortFor(withQuery('', 'match'))).toBe('match');
   });
 
   it('always names an option that exists', () => {
     for (const q of ['', 'go']) {
-      for (const matchAvailable of [false, true]) {
-        const f = withQuery(q, 'match');
-        const values = sortOptionsFor(q, matchAvailable).map((o) => o.value);
-        expect(values).toContain(selectedSortFor(f, matchAvailable));
+      for (const sort of ['match', 'relevance', 'views', 'newest'] as const) {
+        const f = withQuery(q, sort);
+        expect(sortOptionsFor(q).map((o) => o.value)).toContain(selectedSortFor(f));
       }
     }
   });
@@ -535,5 +531,31 @@ describe('the two date bounds', () => {
     expect(activeFilterCount(f)).toBe(none + 1);
     f.postedWithinDays = 3;
     expect(activeFilterCount(f)).toBe(none + 2);
+  });
+});
+
+// The feed's answer to "I picked Match and it did not rank anything". The ordering needs
+// the viewer's own skills; without them the server degrades to newest and, told nothing,
+// the visitor reads that as the sort being broken.
+describe('matchSortNeedsSkills', () => {
+  it('asks for skills only when match is the ordering in force', () => {
+    expect(matchSortNeedsSkills(withQuery('', 'match'), false)).toBe(true);
+    expect(matchSortNeedsSkills(withQuery('', 'newest'), false)).toBe(false);
+    expect(matchSortNeedsSkills(withQuery('', 'views'), false)).toBe(false);
+  });
+
+  it('stays quiet once the viewer has skills to rank against', () => {
+    expect(matchSortNeedsSkills(withQuery('', 'match'), true)).toBe(false);
+  });
+
+  // A query plus ?sort=match still means match: `relevance` is only the DEFAULT under a
+  // query, not an override of a stated one.
+  it('asks under a query too', () => {
+    expect(matchSortNeedsSkills(withQuery('go', 'match'), false)).toBe(true);
+  });
+
+  // Nobody asked for match here, so there is nothing to explain.
+  it('says nothing when no ordering was stated', () => {
+    expect(matchSortNeedsSkills(emptyFilters(), false)).toBe(false);
   });
 });

--- a/web/src/lib/facetModel.ts
+++ b/web/src/lib/facetModel.ts
@@ -148,28 +148,36 @@ export interface SortOption {
  *
  *  It lives here, not in the view, for the reason effectiveSort does: it is pure, it
  *  decides what the user sees, and in the component nothing could test it. */
-export function sortOptionsFor(q: string, matchAvailable: boolean): SortOption[] {
-  const values: JobSort[] = [
-    ...(q ? (['relevance'] as const) : []),
-    'newest',
-    'views',
-    ...(matchAvailable ? (['match'] as const) : []),
-  ];
+export function sortOptionsFor(q: string): SortOption[] {
+  // Match is offered to everyone, including a viewer with no skills on file. Hiding it
+  // from them answered "why can I not sort by fit here?" with nothing at all — and it
+  // hid the reason to fill in a profile from exactly the people who have not. What they
+  // get instead is an explanation of what the ordering needs; see matchSortNeedsSkills.
+  const values: JobSort[] = [...(q ? (['relevance'] as const) : []), 'newest', 'views', 'match'];
   return values.map((value) => ({ value, label: SORT_LABEL[value] }));
 }
 
 /** The option the control shows as selected.
  *
- *  Normally the effective ordering — but a shared `?sort=match` link opened by someone
- *  it cannot be served to resolves to an ordering that is not on offer. The param stays
- *  (the server degrades it rather than refusing, and signing in should just work), so
- *  the control instead names what the server will ACTUALLY serve that caller. A select
- *  whose value matches no option renders blank, which would put an empty control over a
- *  live ordering. */
-export function selectedSortFor(f: JobFilters, matchAvailable: boolean): JobSort {
+ *  Normally the effective ordering. `relevance` is the one that can be asked for and not
+ *  offered — it ranks against query text, and a shared link can arrive without any — so
+ *  the control then names what the server will ACTUALLY serve. A select whose value
+ *  matches no option renders blank, which would put an empty control over a live
+ *  ordering. */
+export function selectedSortFor(f: JobFilters): JobSort {
   const sort = effectiveSort(f);
-  const offered = sortOptionsFor(f.q, matchAvailable);
+  const offered = sortOptionsFor(f.q);
   return offered.some((o) => o.value === sort) ? sort : defaultSortFor(f.q);
+}
+
+/** Whether the feed should explain that the match ordering has nothing to rank against.
+ *
+ *  Only when match is the ordering actually in force AND the viewer has no skills on
+ *  file. The server degrades such a request to newest rather than refusing it, so the
+ *  list still fills — and a visitor told nothing reads that as the sort being broken
+ *  rather than as a profile they have not filled in yet. */
+export function matchSortNeedsSkills(f: JobFilters, hasSkills: boolean): boolean {
+  return effectiveSort(f) === 'match' && !hasSkills;
 }
 
 /** Splits every raw query value on comma and flattens the result, dropping

--- a/web/src/lib/facetModel.ts
+++ b/web/src/lib/facetModel.ts
@@ -65,8 +65,9 @@ export interface JobFilters {
    *  `relevance` is the engine's own ranking, `newest` is freshest first, `views` is
    *  most-opened first, and `match` ranks by how well a vacancy's skills overlap the
    *  signed-in caller's profile. The server degrades `match` to its default for anyone
-   *  it cannot serve it to — anonymous, no profile, no skills — so this is never gated
-   *  client-side beyond hiding the option.
+   *  it cannot serve it to — anonymous, no profile, no skills — so this is not gated
+   *  client-side at all: every ordering is offered, and the feed explains the degraded
+   *  one rather than withholding it.
    *
    *  The `null` matters because the DEFAULT depends on `q` (see defaultSortFor) while
    *  `q` changes under the ordering's feet. Storing the resolved default instead would
@@ -136,15 +137,14 @@ export interface SortOption {
 
 /** The orderings a caller can actually choose between, in display order.
  *
- *  `relevance` needs query text to rank against and `match` needs a profile the caller
- *  has (plus the runtime flag the view resolves); `newest` and `views` always apply —
- *  the latter ranks by a stored figure, so gating it on anything would be inventing a
- *  precondition. The rule is per OPTION rather than per control — gating the whole
- *  select on the match precondition, as it was, took `newest` down with it, so a
- *  signed-out visitor searching by text had no way to reach the freshest-first ordering.
+ *  `relevance` is the only conditional one: it ranks against query text, so without any
+ *  there is nothing for it to rank. `newest`, `views` and `match` always apply.
  *
- *  With two unconditional options the control now holds a choice for every caller, so
- *  it renders on every listing — including the signed-out browse that used to show none.
+ *  `match` was conditional too — it needed a profile with skills. That hid the one
+ *  ordering that answers "which of these suit me" from precisely the people who had not
+ *  filled a profile in, and told them nothing. It is offered to everyone now, and the
+ *  view explains what it needs when there is nothing to rank against (see
+ *  matchSortNeedsSkills below).
  *
  *  It lives here, not in the view, for the reason effectiveSort does: it is pure, it
  *  decides what the user sees, and in the component nothing could test it. */

--- a/web/src/lib/features.test.ts
+++ b/web/src/lib/features.test.ts
@@ -1,44 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { matchSortEnabled, openWithinEnabled } from './features';
-
-// The match sort ships dark: the backend accepts ?sort=match from day one, but the
-// vectors it ranks against only exist after a full index rebuild. Until then the sort
-// returns a near-empty feed, so the control stays hidden and the flag is what reveals
-// it — no redeploy, just an env change and a restart.
-describe('matchSortEnabled', () => {
-  it('is off when the flag is absent', () => {
-    expect(matchSortEnabled({})).toBe(false);
-  });
-
-  it('is off for an empty value', () => {
-    expect(matchSortEnabled({ PUBLIC_MATCH_SORT: '' })).toBe(false);
-  });
-
-  it('is on for the documented value', () => {
-    expect(matchSortEnabled({ PUBLIC_MATCH_SORT: '1' })).toBe(true);
-  });
-
-  it('accepts the other truthy spellings an ops edit is likely to use', () => {
-    expect(matchSortEnabled({ PUBLIC_MATCH_SORT: 'true' })).toBe(true);
-    expect(matchSortEnabled({ PUBLIC_MATCH_SORT: 'TRUE' })).toBe(true);
-    expect(matchSortEnabled({ PUBLIC_MATCH_SORT: 'on' })).toBe(true);
-  });
-
-  // A flag that reads "0" or "false" as ON is how a feature ships by accident.
-  it('is off for the falsy spellings', () => {
-    expect(matchSortEnabled({ PUBLIC_MATCH_SORT: '0' })).toBe(false);
-    expect(matchSortEnabled({ PUBLIC_MATCH_SORT: 'false' })).toBe(false);
-    expect(matchSortEnabled({ PUBLIC_MATCH_SORT: 'off' })).toBe(false);
-  });
-
-  it('is off for anything unrecognized, rather than guessing', () => {
-    expect(matchSortEnabled({ PUBLIC_MATCH_SORT: 'yes please' })).toBe(false);
-  });
-
-  it('tolerates surrounding whitespace, which a .env edit leaves behind', () => {
-    expect(matchSortEnabled({ PUBLIC_MATCH_SORT: ' 1 ' })).toBe(true);
-  });
-});
+import { openWithinEnabled } from './features';
 
 // The open-within bound ships dark for the same shape of reason as the match sort: the
 // API honours ?open_within_days from the moment the binary rolls out, but it filters on
@@ -69,8 +30,10 @@ describe('openWithinEnabled', () => {
     expect(openWithinEnabled({ PUBLIC_OPEN_WITHIN: 'yes please' })).toBe(false);
   });
 
-  it('does not read the other flag', () => {
+  // Reads its OWN variable and nothing else. Worth pinning even now that it is the last
+  // flag here: a retired name left set on a host must not turn anything on.
+  it('reads only its own variable', () => {
     expect(openWithinEnabled({ PUBLIC_MATCH_SORT: '1' })).toBe(false);
-    expect(matchSortEnabled({ PUBLIC_OPEN_WITHIN: '1' })).toBe(false);
+    expect(openWithinEnabled({ SOMETHING_ELSE: '1' })).toBe(false);
   });
 });

--- a/web/src/lib/features.ts
+++ b/web/src/lib/features.ts
@@ -8,20 +8,13 @@
 // unparseable value to reveal a feature.
 const TRUTHY = new Set(['1', 'true', 'on', 'yes']);
 
-/** Whether the profile-match sort control is revealed in the jobs feed.
- *
- *  This ships DARK on purpose. The backend accepts `?sort=match` from the moment the
- *  binary rolls out, but it ranks against skill vectors that only exist once a full
- *  index rebuild has written them — before that the sort returns the handful of
- *  postings re-indexed since, which reads as a broken feed rather than a new feature.
- *  So the control stays hidden until someone confirms the rebuild landed, and the URL
- *  param stays usable throughout for exactly that check.
- *
- *  Default OFF: an unset or unrecognized value hides the control. A flag that reveals
- *  a feature when it cannot parse its own value is how one ships by accident. */
-export function matchSortEnabled(env: Record<string, string | undefined>): boolean {
-  return TRUTHY.has((env.PUBLIC_MATCH_SORT ?? '').trim().toLowerCase());
-}
+// The match sort had a flag here (PUBLIC_MATCH_SORT). It existed to hide the control
+// until a full index rebuild had written the skill vectors it ranks against — before
+// that the ordering returned almost nothing and read as broken. That rebuild has long
+// since landed, so the flag was answering a question nobody asks any more, and it was
+// also hiding the control from every visitor without a profile — the people who most
+// need to be told the ordering exists. The feed explains what it needs instead; see
+// facetModel's matchSortNeedsSkills.
 
 /** Whether the "open within N days" bound is revealed — the filter over how long a
  *  posting has been in the catalogue, as distinct from the date its source states.


### PR DESCRIPTION
The flag is gone. `PUBLIC_MATCH_SORT` existed to hide the control until a full
index rebuild had written the skill vectors it ranks against - before that the
ordering returned almost nothing and read as broken. That rebuild landed long
ago, so the flag was answering a question nobody asks any more.

It was also hiding the sort behind a profile, which meant the one ordering that
answers "which of these actually suit me" was invisible to exactly the people who
had not filled a profile in - and nothing told them it existed.

Choosing it without skills on file is now answered out loud. A notice under the
toolbar says the ranking needs their skills, that newest is being shown
meanwhile, and links to where a CV goes (or to sign-in, if there is no account to
hold one yet).

**It never replaces the feed.** The server degrades this request rather than
refusing it, so there ARE jobs below - taking them away would punish someone for
pressing a button we offered them. What was missing was only the explanation.

## Review found one real bug

The notice flashed. The precondition folds "we do not know yet" into "has no
skills", and the profile arrives a round trip after the page - so a signed-in
user WITH skills opening `?sort=match` got the notice in the server-rendered HTML
and lost it a moment later. It waits for the load to settle now.

Also from review: `role="status"` on the notice, and the documentation the change
orphaned - the reveal procedure in `web/.env.example` and
`internal/search/search/AGENTS.md`, which would have actively misled since the
flag is still set on the host.

`PUBLIC_MATCH_SORT` on the host becomes inert rather than wrong; it can be dropped
from the env at leisure.