### PR TITLE
Carry the mailbox through the claim, so classified mail stops dead-lettering

### DIFF
--- a/cmd/classify-mail/store.go
+++ b/cmd/classify-mail/store.go
@@ -54,19 +54,27 @@ func (s *dbStore) ClaimBatch(ctx context.Context, leaseSeconds, batchSize int) (
 	}
 	out := make([]maillink.Claimed, len(rows))
 	for i, r := range rows {
-		out[i] = maillink.Claimed{
-			OutboxID: r.ID,
-			EmailID:  r.EmailID,
-			UserID:   r.UserID,
-			ThreadID: r.ThreadID,
-			FromAddr: r.FromAddr,
-			FromName: r.FromName,
-			Subject:  r.Subject,
-			Body:     r.BodyText,
-			BodyHTML: r.BodyHtml,
-		}
+		out[i] = claimedFrom(r)
 	}
 	return out, nil
+}
+
+// claimedFrom copies one claim row into the port's shape. It is a named function rather than a
+// literal inside the loop above so that store_test.go can hold it to taking every field: this
+// mapping silently dropped Source for five weeks, which stopped the whole queue.
+func claimedFrom(r db.ClaimEmailClassificationBatchRow) maillink.Claimed {
+	return maillink.Claimed{
+		OutboxID: r.ID,
+		EmailID:  r.EmailID,
+		UserID:   r.UserID,
+		Source:   r.Source,
+		ThreadID: r.ThreadID,
+		FromAddr: r.FromAddr,
+		FromName: r.FromName,
+		Subject:  r.Subject,
+		Body:     r.BodyText,
+		BodyHTML: r.BodyHtml,
+	}
 }
 
 func (s *dbStore) Applications(ctx context.Context, userID int64) ([]maillink.Application, error) {

--- a/cmd/classify-mail/store_test.go
+++ b/cmd/classify-mail/store_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/platform/db"
+)
+
+// fullClaimRow is a claim carrying a distinct non-zero value in every field, so a field the
+// mapping drops reads as a zero value rather than as one that happens to match its neighbour.
+func fullClaimRow() db.ClaimEmailClassificationBatchRow {
+	return db.ClaimEmailClassificationBatchRow{
+		ID:       11,
+		EmailID:  22,
+		UserID:   33,
+		Source:   "hosted",
+		ThreadID: "thread-1",
+		FromAddr: "no-reply@ashbyhq.com",
+		FromName: "Ashby",
+		Subject:  "Thanks for applying to Derq",
+		BodyText: "plain part",
+		BodyHtml: "<p>html part</p>",
+	}
+}
+
+// The store is a mailbox, and the ledger event names which one observed the reply. Dropping it
+// here is not a cosmetic loss: appevent.SourceForMail refuses an empty source by design, so the
+// whole Save transaction rolls back and the message dead-letters after three attempts. That is
+// what happened between 2026-07-31 and 2026-09-05 — the field was threaded through the query,
+// the port and the ledger, and only this hand-written copy never took it.
+func TestClaimedFromCarriesTheMailSource(t *testing.T) {
+	if got := claimedFrom(fullClaimRow()).Source; got != "hosted" {
+		t.Fatalf("Source = %q, want hosted — an empty one dead-letters the message", got)
+	}
+}
+
+// The defect above is invisible to the compiler: a struct literal that omits a field gets the
+// zero value, silently. This walks the destination instead, so a field ADDED to maillink.Claimed
+// and never mapped fails here rather than in production three weeks later.
+func TestClaimedFromDropsNoField(t *testing.T) {
+	got := reflect.ValueOf(claimedFrom(fullClaimRow()))
+	for i := range got.NumField() {
+		if got.Field(i).IsZero() {
+			t.Errorf("Claimed.%s is zero — the mapping in claimedFrom never took it", got.Type().Field(i).Name)
+		}
+	}
+}

--- a/cmd/queue-metrics/collect.go
+++ b/cmd/queue-metrics/collect.go
@@ -19,6 +19,7 @@ type metricsQueries interface {
 	SearchOutboxMetrics(context.Context) (db.SearchOutboxMetricsRow, error)
 	EnrichmentOutboxMetrics(context.Context) (db.EnrichmentOutboxMetricsRow, error)
 	SemanticOutboxMetrics(context.Context) (db.SemanticOutboxMetricsRow, error)
+	MailClassificationOutboxMetrics(context.Context) (db.MailClassificationOutboxMetricsRow, error)
 	BoardHealthMetrics(context.Context) (db.BoardHealthMetricsRow, error)
 	NewestOpenJobCreatedAt(context.Context) (pgtype.Timestamptz, error)
 	ProviderIngestHealth(context.Context) ([]db.ProviderIngestHealthRow, error)
@@ -41,6 +42,10 @@ func collect(ctx context.Context, q metricsQueries) (snapshot, error) {
 	semantic, err := q.SemanticOutboxMetrics(ctx)
 	if err != nil {
 		return snapshot{}, fmt.Errorf("semantic outbox metrics: %w", err)
+	}
+	mail, err := q.MailClassificationOutboxMetrics(ctx)
+	if err != nil {
+		return snapshot{}, fmt.Errorf("mail classification outbox metrics: %w", err)
 	}
 	boards, err := q.BoardHealthMetrics(ctx)
 	if err != nil {
@@ -84,6 +89,7 @@ func collect(ctx context.Context, q metricsQueries) (snapshot, error) {
 			{name: "search_outbox", depth: search.Depth, deadLetters: search.DeadLetters, oldestAgeSeconds: search.OldestAgeSeconds},
 			{name: "enrichment_outbox", depth: enrichment.Depth, deadLetters: enrichment.DeadLetters, oldestAgeSeconds: enrichment.OldestAgeSeconds},
 			{name: "semantic_outbox", depth: semantic.Depth, deadLetters: semantic.DeadLetters, oldestAgeSeconds: semantic.OldestAgeSeconds},
+			{name: "email_classification_outbox", depth: mail.Depth, deadLetters: mail.DeadLetters, oldestAgeSeconds: mail.OldestAgeSeconds},
 		},
 		notifyPendingSubscriptions: notifyBacklog.PendingSubscriptions,
 		notifyOldestAgeSeconds:     notifyBacklog.OldestAgeSeconds,

--- a/cmd/queue-metrics/collect_test.go
+++ b/cmd/queue-metrics/collect_test.go
@@ -18,6 +18,7 @@ type fakeQueries struct {
 	search    db.SearchOutboxMetricsRow
 	enrich    db.EnrichmentOutboxMetricsRow
 	semantic  db.SemanticOutboxMetricsRow
+	mail      db.MailClassificationOutboxMetricsRow
 	boards    db.BoardHealthMetricsRow
 	newest    pgtype.Timestamptz
 	health    []db.ProviderIngestHealthRow
@@ -42,6 +43,10 @@ func (f fakeQueries) SemanticOutboxMetrics(context.Context) (db.SemanticOutboxMe
 	return f.semantic, nil
 }
 
+func (f fakeQueries) MailClassificationOutboxMetrics(context.Context) (db.MailClassificationOutboxMetricsRow, error) {
+	return f.mail, nil
+}
+
 func (f fakeQueries) BoardHealthMetrics(context.Context) (db.BoardHealthMetricsRow, error) {
 	return f.boards, nil
 }
@@ -59,9 +64,12 @@ func populatedQueries() fakeQueries {
 		search:   db.SearchOutboxMetricsRow{Depth: 3, DeadLetters: 2, OldestAgeSeconds: 21600.5},
 		enrich:   db.EnrichmentOutboxMetricsRow{Depth: 1049297, DeadLetters: 41, OldestAgeSeconds: 5529600},
 		semantic: db.SemanticOutboxMetricsRow{Depth: 0, DeadLetters: 0, OldestAgeSeconds: 0},
-		boards:   db.BoardHealthMetricsRow{Healthy: 74894, Failing: 7002, Cooled: 1882},
-		notify:   db.NotifyBacklogMetricsRow{PendingSubscriptions: 12, OldestAgeSeconds: 184.25},
-		newest:   pgtype.Timestamptz{Time: time.Unix(1786821346, 0), Valid: true},
+		// The shape prod was actually in: nothing live and every entry dead-lettered, which
+		// the worker's own log reported as "done failed=0 dead-lettered=0" for five weeks.
+		mail:   db.MailClassificationOutboxMetricsRow{Depth: 0, DeadLetters: 2726, OldestAgeSeconds: 0},
+		boards: db.BoardHealthMetricsRow{Healthy: 74894, Failing: 7002, Cooled: 1882},
+		notify: db.NotifyBacklogMetricsRow{PendingSubscriptions: 12, OldestAgeSeconds: 184.25},
+		newest: pgtype.Timestamptz{Time: time.Unix(1786821346, 0), Valid: true},
 		health: []db.ProviderIngestHealthRow{
 			{
 				Provider:      "greenhouse",
@@ -114,6 +122,7 @@ func TestCollectAssemblesEveryQueueInOrder(t *testing.T) {
 		{name: "search_outbox", depth: 3, deadLetters: 2, oldestAgeSeconds: 21600.5},
 		{name: "enrichment_outbox", depth: 1049297, deadLetters: 41, oldestAgeSeconds: 5529600},
 		{name: "semantic_outbox", depth: 0, deadLetters: 0, oldestAgeSeconds: 0},
+		{name: "email_classification_outbox", depth: 0, deadLetters: 2726, oldestAgeSeconds: 0},
 	}
 	if len(got.queues) != len(want) {
 		t.Fatalf("collected %d queues, want %d", len(got.queues), len(want))
@@ -146,8 +155,8 @@ func TestCollectTreatsAnEmptyCatalogueAsAbsentNotAsAFailure(t *testing.T) {
 	if !got.newestJob.IsZero() {
 		t.Errorf("newestJob = %v, want the zero time so render omits the sample", got.newestJob)
 	}
-	if len(got.queues) != 3 {
-		t.Errorf("collected %d queues, want all 3 despite the empty catalogue", len(got.queues))
+	if len(got.queues) != 4 {
+		t.Errorf("collected %d queues, want all 4 despite the empty catalogue", len(got.queues))
 	}
 }
 

--- a/docs/agents/mail-stack.md
+++ b/docs/agents/mail-stack.md
@@ -211,6 +211,19 @@ the point: it is the tier that costs us nothing. See the `external` bullets belo
   order**: written as one with data-modifying CTEs, every CTE reads the same pre-statement
   snapshot, so the insert's `ON CONFLICT` still sees the row the retract just stamped and
   silently records nothing.
+- **The store rides with the claim, and dropping it stops the whole queue.**
+  `ReconcileMailEvent` needs the mailbox that observed the reply, and `appevent.SourceForMail`
+  refuses an empty one by design — so an unset `Claimed.Source` fails the transaction that
+  persisted the link, and the message dead-letters after three attempts. The field was threaded
+  through the query, the port and the ledger in one change; the only place that never took it
+  was the hand-written copy in `cmd/classify-mail/store.go`, where Go's zero value made the
+  omission legal and invisible. Every message queued between 2026-07-31 and 2026-09-05 died
+  that way (2726 of them, across every user), and nothing said so: dead entries are never
+  re-claimed, so each subsequent run truthfully logged `done failed=0 dead-lettered=0` and the
+  binary kept exiting 0. `store_test.go` now walks `maillink.Claimed` by reflection, so a field
+  added there and not mapped fails a test rather than the queue. **Recovery is not automatic** —
+  `EnqueuePendingEmailClassification` is `ON CONFLICT DO NOTHING`, so a dead row stays dead
+  until `failed_at`/`attempts`/`claimed_at` are cleared by hand.
 - **A linked message counts as a reply whether or not it is classified.** Requiring a
   classification reads as the stricter rule and is the opposite: `external` mail is never
   classified server-side by design, so that tier's replies would never count and their

--- a/internal/platform/db/metrics.sql.go
+++ b/internal/platform/db/metrics.sql.go
@@ -75,6 +75,37 @@ func (q *Queries) EnrichmentOutboxMetrics(ctx context.Context) (EnrichmentOutbox
 	return i, err
 }
 
+const mailClassificationOutboxMetrics = `-- name: MailClassificationOutboxMetrics :one
+SELECT
+    count(*) FILTER (WHERE failed_at IS NULL)     AS depth,
+    count(*) FILTER (WHERE failed_at IS NOT NULL) AS dead_letters,
+    COALESCE(
+        EXTRACT(EPOCH FROM now() - min(created_at) FILTER (WHERE failed_at IS NULL)),
+        0
+    )::float8                                     AS oldest_age_seconds
+FROM email_classification_outbox
+`
+
+type MailClassificationOutboxMetricsRow struct {
+	Depth            int64   `json:"depth"`
+	DeadLetters      int64   `json:"dead_letters"`
+	OldestAgeSeconds float64 `json:"oldest_age_seconds"`
+}
+
+// Same shape and same reasoning as SearchOutboxMetrics.
+//
+// This queue was the one of the four that nothing measured, and it is the one that failed
+// silently for five weeks: cmd/classify-mail dead-lettered every message, then logged
+// "done failed=0 dead-lettered=0" on each subsequent run — accurate, because a dead entry is
+// never claimed again, and indistinguishable from an empty queue. Dead letters here read as
+// mail nobody will ever link to an application.
+func (q *Queries) MailClassificationOutboxMetrics(ctx context.Context) (MailClassificationOutboxMetricsRow, error) {
+	row := q.db.QueryRow(ctx, mailClassificationOutboxMetrics)
+	var i MailClassificationOutboxMetricsRow
+	err := row.Scan(&i.Depth, &i.DeadLetters, &i.OldestAgeSeconds)
+	return i, err
+}
+
 const newestOpenJobCreatedAt = `-- name: NewestOpenJobCreatedAt :one
 SELECT created_at
 FROM jobs

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -3183,6 +3183,14 @@ type Querier interface {
 	// snapshot missing the other's user_jobs row, permanently undercounting the target
 	// until the next uncontended vote. Called first in the vote transaction.
 	LockJobForVote(ctx context.Context, id int64) error
+	// Same shape and same reasoning as SearchOutboxMetrics.
+	//
+	// This queue was the one of the four that nothing measured, and it is the one that failed
+	// silently for five weeks: cmd/classify-mail dead-lettered every message, then logged
+	// "done failed=0 dead-lettered=0" on each subsequent run — accurate, because a dead entry is
+	// never claimed again, and indistinguishable from an empty queue. Dead letters here read as
+	// mail nobody will ever link to an application.
+	MailClassificationOutboxMetrics(ctx context.Context) (MailClassificationOutboxMetricsRow, error)
 	// Record that this job's description is now the full text, closing the enqueue gate for
 	// good. A re-hydration is a deliberate act (drop the row, which reopens the gate), not
 	// something a crawl does by accident — mirrors apply_forms' own refresh story.

--- a/internal/platform/db/queries/metrics.sql
+++ b/internal/platform/db/queries/metrics.sql
@@ -46,6 +46,23 @@ SELECT
     )::float8                                     AS oldest_age_seconds
 FROM semantic_outbox;
 
+-- name: MailClassificationOutboxMetrics :one
+-- Same shape and same reasoning as SearchOutboxMetrics.
+--
+-- This queue was the one of the four that nothing measured, and it is the one that failed
+-- silently for five weeks: cmd/classify-mail dead-lettered every message, then logged
+-- "done failed=0 dead-lettered=0" on each subsequent run — accurate, because a dead entry is
+-- never claimed again, and indistinguishable from an empty queue. Dead letters here read as
+-- mail nobody will ever link to an application.
+SELECT
+    count(*) FILTER (WHERE failed_at IS NULL)     AS depth,
+    count(*) FILTER (WHERE failed_at IS NOT NULL) AS dead_letters,
+    COALESCE(
+        EXTRACT(EPOCH FROM now() - min(created_at) FILTER (WHERE failed_at IS NULL)),
+        0
+    )::float8                                     AS oldest_age_seconds
+FROM email_classification_outbox;
+
 -- name: BoardHealthMetrics :one
 -- The ingest board fleet split into three mutually exclusive states, so the published
 -- gauges sum to the fleet size and a stacked graph reads correctly.

--- a/internal/platform/worker/AGENTS.md
+++ b/internal/platform/worker/AGENTS.md
@@ -98,6 +98,12 @@ worker keeping up*. The notify pair exists because a starved subscription produc
 failure to notice: `notify` reported `delivered=1 failed=0` for weeks while 1.14M matches
 sat undelivered (2026-09-04, see [docs/agents/notifications.md](../../../docs/agents/notifications.md)).
 An oldest-pending age climbing past a few passes is the signal; `failed` never moved.
+`email_classification_outbox` was added for the same reason and is the worse version of it:
+`cmd/classify-mail` dead-lettered all 2726 queued messages over five weeks and then logged
+`done failed=0 dead-lettered=0` on every run afterwards — accurate, because a dead entry is
+never claimed again, and identical to what an empty queue prints. **A queue this worker does
+not measure has no signal at all**: the per-run family above stayed green throughout, since
+the binary kept exiting 0. Adding an outbox means adding it here.
 These names are a contract with the dashboard and alert rules in `freehire-ops`, which
 cannot be compiled against this repo — `cmd/queue-metrics/render_test.go` pins the exact
 exposition text so a rename is a visible edit rather than a silent breakage.


### PR DESCRIPTION
## What was wrong

`/my/inbox` has linked no mail to any application since **2026-07-31**. Five weeks, every user.

On production: **2726** queued messages, all dead-lettered; **2666** of them with
`ledger source: appevent: unknown mail source ""`. The 543 classifications the table holds
are all older than that date.

`cmd/classify-mail/store.go`'s `ClaimBatch` copied nine of the ten fields a claim row carries
into `maillink.Claimed`. The tenth — `Source` — is the one `appevent.SourceForMail` refuses to
default, by design: an unrecognised store silently mapped to a mail source would be admitted to
timings on the strength of a typo. So the empty string failed `ReconcileMailEvent`, which rolled
back the transaction that persisted the link, and the entry dead-lettered after three attempts.

The field was threaded through the query, the port and the ledger in #1344. Only this
hand-written copy never took it, and a struct literal that omits a field is legal Go.

## Why nobody noticed

A dead entry is never re-claimed, so every run since has logged `done failed=0 dead-lettered=0`
— accurate, and indistinguishable from an empty queue. The binary kept exiting 0, so
`freehire_worker_last_run_success` stayed green. And `email_classification_outbox` was the one
outbox `cmd/queue-metrics` did not measure, so there was no depth or dead-letter series either.

Same shape as the `notify` starvation this repo already documents, one level worse.

## What this changes

- **The fix**: `Source: r.Source`, one line.
- **The guard**: the mapping becomes a named `claimedFrom` so a test can reach it (`cmd/` is
  package main, which is why no domain test could). `TestClaimedFromDropsNoField` walks
  `maillink.Claimed` by reflection — a field added there and not mapped fails a test rather
  than the queue.
- **The signal**: `email_classification_outbox` joins the three outboxes `cmd/queue-metrics`
  publishes. The `freehire-pipeline` dashboard's queue panels read `freehire_queue_depth` and
  `freehire_queue_dead_letters` unfiltered, so the series appears with no dashboard edit.
- Docs in `docs/agents/mail-stack.md` and `internal/platform/worker/AGENTS.md`.

## After merge — manual step

Recovery is **not** automatic: `EnqueuePendingEmailClassification` is `ON CONFLICT (email_id) DO
NOTHING`, so a dead row stays dead. Once this is deployed, clear the markers so the queue drains:

```sql
UPDATE email_classification_outbox
   SET failed_at = NULL, attempts = 0, claimed_at = NULL, last_error = ''
 WHERE failed_at IS NOT NULL;
```

~2726 LLM calls, one-off. The 60 entries that died on transient LLM errors (429/502/timeouts)
are reset alongside the 2666 from this bug.

## Testing

`go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `go test ./...` — all clean.
Both new tests were confirmed red against the buggy mapping before the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mail classification now preserves message source information, preventing valid messages from failing during link processing.
  * Queue processing metrics now accurately reflect mail classification backlog and failed items.

* **New Features**
  * Added monitoring for the mail classification queue, including active depth, dead-letter count, and oldest pending item age.

* **Documentation**
  * Updated mail processing and monitoring guidance to document source requirements and queue visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->