### PR TITLE
Give the job page one loud button, and let auto-apply be it

### DIFF
--- a/openspec/changes/job-page-cta-hierarchy/.openspec.yaml
+++ b/openspec/changes/job-page-cta-hierarchy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/job-page-cta-hierarchy/design.md
+++ b/openspec/changes/job-page-cta-hierarchy/design.md
@@ -1,0 +1,134 @@
+## Context
+
+`web/src/lib/components/JobView.svelte` lays its tab row out as
+`flex items-end justify-between`: the content `TabStrip` takes `min-w-0 flex-1` on the
+left, and the `actionStrip` snippet sits `shrink-0` on the right. The strip is the only
+half that cannot give ground, so every control added to it has been taken out of the tabs.
+It now holds six: a Discussion link, Report, Save, Add-to-list, Auto-apply and Apply. On a
+desktop column that leaves the TabStrip a scrolling sliver — the component handles the
+overflow correctly (it scrolls and fades rather than wrapping), so the failure is silent
+and reads as tabs sliding under the actions.
+
+The rank on that row is also wrong. `autoApplyCta` renders `variant="secondary"` and the
+external `applyCta` renders `variant="primary"`, so the page's loudest button is the one
+that hands the reader off to somebody else's site, and the Pro feature this page exists to
+sell is the quiet grey one beside it.
+
+`autoApplyButtonState` (`web/src/lib/autoApplyButton.ts`) already reduces the posting's
+source and the caller's attempt status to a six-way `kind`. It is a pure function with its
+own unit test and no Svelte dependency — the convention that file states for itself.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give the content tabs their width back by moving the two CTAs off the tab row.
+- Make auto-apply the page's primary CTA wherever it can actually be started, and say in
+  the button that it needs Pro.
+- Never put two primary CTAs on the page, and keep one in every state where the reader
+  still has an action left — including the states where auto-apply will not act and they
+  must apply by hand.
+
+**Non-Goals:**
+
+- Client-side Pro eligibility. It is still not known without new plumbing; the `Pro` marker
+  names a requirement, it does not gate the click. The backend's 402 remains the answer.
+- Any change to auto-apply's behaviour: the POST, the statuses, the worker, the error
+  surface. Only the button's rank, label and place move.
+- The sub-`lg` layout. The sticky bottom bar and the under-title strip stay as they are.
+- Bringing auto-apply to mobile. It is desktop-only today and stays that way here.
+
+## Decisions
+
+### The five-way CTA rank lives in `autoApplyButton.ts`, not in the template
+
+A second exported pure function, `jobCtaPlan(state: AutoApplyButtonState)`, maps the
+existing `kind` to what the two buttons look like:
+
+```ts
+export type JobCtaPlan = {
+  autoApply: { label: string; primary: boolean; pro: boolean; disabled: boolean } | null;
+  external: { label: 'Apply' | 'Show origin'; primary: boolean };
+};
+```
+
+`autoApply` is nullable rather than carrying a `shown` flag: `hidden` renders no button, so
+a label, a loudness and a disabled state for it would be four fields describing nothing.
+
+| `kind`     | auto-apply                              | external                 |
+| ---------- | --------------------------------------- | ------------------------ |
+| `hidden`   | not rendered                            | `Apply`, primary         |
+| `idle`     | `Auto-apply` + `Pro`, primary, enabled  | `Show origin`, outline   |
+| `queued`   | `Auto-apply queued`, quiet, disabled    | `Show origin`, outline   |
+| `applied`  | `Already applied`, quiet, disabled      | `Show origin`, outline   |
+| `declined` | `Auto-apply declined`, quiet, disabled  | `Apply`, primary         |
+| `failed`   | `Auto-apply couldn't complete`, quiet, disabled | `Apply`, primary |
+
+**Why a function and not `{#if}` chains.** The interesting part of this change is the
+table, not the markup: six states, two buttons, and a rule about how loud they may be that
+is easy to break silently in a template. A pure function unit-tests the whole table without
+mounting Svelte, which is precisely the seam `autoApplyButtonState` was extracted for.
+Putting it in the same file keeps one place that knows what the auto-apply button is. The
+rule is worth writing down twice — the invariant tests are what caught that `queued` and
+`applied` fall out of it, below.
+
+**Why `queued` and `applied` have no primary CTA at all.** Both are states where the reader
+has nothing left to do: the submission is in flight or already made. The obvious invariant
+("exactly one primary, always") would force a loud `Show origin` there, which reads as an
+invitation to apply a second time. The rule is therefore two-sided — never two primaries,
+and one wherever an action remains — with those two states the only place it yields none.
+
+**Why `declined`/`failed` re-promote the external button.** The naive reading of the ask —
+"Apply becomes Show origin whenever auto-apply is shown" — leaves a page with no primary
+CTA in the two states where the robot has given up and applying by hand is the reader's
+only way forward. Demoting there would hide the one action still available. The rule is
+therefore "demote while an attempt stands or can be started", not "demote whenever the
+button exists".
+
+**Alternative considered:** keeping the mapping inline in `JobView.svelte`. Rejected — the
+component is already 800 lines, and the rule that matters would be untestable without a
+mount.
+
+### CTAs move into the existing `<header>` block, right-aligned against the title
+
+The header block (`lg:col-start-2 lg:row-start-2`) already holds the title and the
+`Applied` chip in a `flex flex-wrap items-center gap-2.5` row. The CTA group joins that row
+with `ml-auto`, matching how `postingDates` already claims the right edge of the provenance
+line above it. It renders `hidden lg:flex`, so the sub-`lg` path is untouched.
+
+**Alternative considered:** a separate full-width action row above the tabs. Rejected —
+it leaves a wide, near-empty band on the page and still separates the primary action from
+the thing it acts on.
+
+### The `Pro` marker is a span inside the button, not the `Badge` primitive
+
+`Badge`'s variants carry their own background and foreground colours, none of which are
+legible on `bg-brand`. The marker is a small inline pill styled from the button's own
+foreground token (`bg-brand-foreground/15 text-brand-foreground`), so it inherits the
+button's colour scheme in both themes instead of fighting it.
+
+### The demoted button uses `outline`, not `ghost`
+
+`Show origin` is still a real action and still needs a hit target that reads as a button
+beside the filled one. `ghost` would flatten it into the quiet strip's vocabulary, which is
+where Save and Report live.
+
+## Risks / Trade-offs
+
+- **A non-Pro reader now meets a loud green button that refuses them.** → Deliberate: the
+  refusal is a 402 carrying the upgrade path, and this is the page where that offer belongs.
+  The `Pro` marker in the button is what keeps it from being a surprise.
+- **`Show origin` is a weaker word than `Apply` and may cost external-apply clicks on
+  Greenhouse postings.** → Accepted, and bounded: Greenhouse is a small slice of the
+  catalogue, and the tracking on that click is unchanged, so the effect is measurable after
+  the fact rather than guessed at now.
+- **The apply-intent event and the "Did you apply?" prompt still fire under a button that
+  no longer says "Apply".** → Kept on purpose: clicking through to the posting is still the
+  funnel step, and splitting the event would break the comparison with every other posting.
+  Noted in the spec so it is a decision rather than an oversight.
+- **The header row gets crowded on a long job title.** → It is already `flex-wrap`; the CTA
+  group wraps to its own line rather than truncating the title.
+
+## Open Questions
+
+None.

--- a/openspec/changes/job-page-cta-hierarchy/design.md
+++ b/openspec/changes/job-page-cta-hierarchy/design.md
@@ -60,7 +60,7 @@ a label, a loudness and a disabled state for it would be four fields describing 
 | `hidden`   | not rendered                            | `Apply`, primary         |
 | `idle`     | `Auto-apply` + `Pro`, primary, enabled  | `Show origin`, outline   |
 | `queued`   | `Auto-apply queued`, quiet, disabled    | `Show origin`, outline   |
-| `applied`  | `Already applied`, quiet, disabled      | `Show origin`, outline   |
+| `applied`  | `Already applied`, quiet, disabled      | `Apply`, primary         |
 | `declined` | `Auto-apply declined`, quiet, disabled  | `Apply`, primary         |
 | `failed`   | `Auto-apply couldn't complete`, quiet, disabled | `Apply`, primary |
 
@@ -69,14 +69,23 @@ table, not the markup: six states, two buttons, and a rule about how loud they m
 is easy to break silently in a template. A pure function unit-tests the whole table without
 mounting Svelte, which is precisely the seam `autoApplyButtonState` was extracted for.
 Putting it in the same file keeps one place that knows what the auto-apply button is. The
-rule is worth writing down twice — the invariant tests are what caught that `queued` and
-`applied` fall out of it, below.
+rule is worth writing down twice — the invariant tests are what caught that `queued` falls
+out of it, below.
 
-**Why `queued` and `applied` have no primary CTA at all.** Both are states where the reader
-has nothing left to do: the submission is in flight or already made. The obvious invariant
-("exactly one primary, always") would force a loud `Show origin` there, which reads as an
-invitation to apply a second time. The rule is therefore two-sided — never two primaries,
-and one wherever an action remains — with those two states the only place it yields none.
+**Why `queued` has no primary CTA at all.** The submission is in flight and the reader has
+nothing to do but wait. The obvious invariant ("exactly one primary, always") would force a
+loud button there, which reads as an invitation to apply a second time. The rule is
+therefore two-sided — never two primaries, and one wherever an action remains — with
+`queued` the only place it yields none.
+
+**Why `applied` does NOT demote.** It looks like the same case, and it is not. `applied`
+comes from `alreadyApplied` — the "Did you apply?" prompt after a manual click-through —
+which is true of a posting from any source, while this table only runs on the ones
+auto-apply can drive. Demoting on it would make a Greenhouse posting read differently from
+an identical Lever one for a reader in the identical situation: an artefact of routing a
+source-independent question through the auto-apply state machine, not a decision anybody
+made. Whether a page should quiet down for a reader who already applied is a real question,
+and it belongs to every source at once — not to this change.
 
 **Why `declined`/`failed` re-promote the external button.** The naive reading of the ask —
 "Apply becomes Show origin whenever auto-apply is shown" — leaves a page with no primary
@@ -88,6 +97,22 @@ button exists".
 **Alternative considered:** keeping the mapping inline in `JobView.svelte`. Rejected — the
 component is already 800 lines, and the rule that matters would be untestable without a
 mount.
+
+### The pinned header carries the same pair, the mobile sticky bar does not
+
+Three bars render the external link: the title row, the pinned desktop header, and the
+mobile sticky bar. The first two take the plan; only the third overrides it.
+
+The pinned header IS the title row for most of a several-screen description, so a
+brand-filled `Apply` there for the link the title row calls a quiet `Show origin` would put
+one link at two ranks on one page — and the argument against a loud button beside a queued
+attempt applies with full force to the bar the reader actually has in front of them. It
+therefore gains an auto-apply button it did not have before.
+
+The mobile sticky bar keeps `undemotedExternalCta`: auto-apply has no button below `lg` on
+any device, so a demoted label there would step aside for nothing the reader can reach.
+That constant is exported from `autoApplyButton.ts` rather than written out again, so the
+words these buttons say still have exactly one home.
 
 ### CTAs move into the existing `<header>` block, right-aligned against the title
 
@@ -102,10 +127,12 @@ the thing it acts on.
 
 ### The `Pro` marker is a span inside the button, not the `Badge` primitive
 
-`Badge`'s variants carry their own background and foreground colours, none of which are
-legible on `bg-brand`. The marker is a small inline pill styled from the button's own
-foreground token (`bg-brand-foreground/15 text-brand-foreground`), so it inherits the
-button's colour scheme in both themes instead of fighting it.
+`Badge`'s variants carry their own background and foreground colours, none of which read as
+a plan marker on `bg-brand`. The marker is a small inline pill taking the PAGE's own
+`foreground` for its fill and `background` for its text — near-black on white in the light
+theme, near-white on black in the dark one — so it is the highest-contrast thing on a
+brand-green button in either. A tint of the button's own foreground
+(`bg-brand-foreground/15`) was the first attempt and dissolved into the fill.
 
 ### The demoted button uses `outline`, not `ghost`
 
@@ -118,6 +145,13 @@ where Save and Report live.
 - **A non-Pro reader now meets a loud green button that refuses them.** → Deliberate: the
   refusal is a 402 carrying the upgrade path, and this is the page where that offer belongs.
   The `Pro` marker in the button is what keeps it from being a surprise.
+- **A SIGNED-OUT reader meets the same loud green button, and it only opens the sign-in
+  prompt** — while the link that does what they came for reads `Show origin`, a phrase that
+  does not say "apply". Signed-out traffic is most of the job page's traffic, so this is the
+  common case rather than an edge one. → Kept, because the page is where the Pro feature is
+  advertised and a visitor who cannot see it will not sign up for it; but it is the change's
+  weakest point and the first thing to measure. Making the plan fall back to `hidden` while
+  `!isAuthenticated()` is a one-line change if the funnel says so.
 - **`Show origin` is a weaker word than `Apply` and may cost external-apply clicks on
   Greenhouse postings.** → Accepted, and bounded: Greenhouse is a small slice of the
   catalogue, and the tracking on that click is unchanged, so the effect is measurable after

--- a/openspec/changes/job-page-cta-hierarchy/proposal.md
+++ b/openspec/changes/job-page-cta-hierarchy/proposal.md
@@ -47,6 +47,7 @@ strip already rides under the title.
 - `web/src/lib/components/JobView.svelte` — the `applyCta`, `autoApplyCta` and
   `actionStrip` snippets, and the two rows that render them (the `<header>` block and the
   tab row).
-- `web/src/lib/autoApplyButton.ts` — read-only; the
-  `kind` it already returns is what decides both the CTA rank and the `Show origin` label.
+- `web/src/lib/autoApplyButton.ts` — gains `JobCtaPlan` and `jobCtaPlan`, the six-state
+  table that maps the `kind` it already returns onto what each of the two buttons says and
+  how loud it is, plus the `undemotedExternalCta` constant the mobile sticky bar renders.
 - No backend, API, or schema change. No new dependency.

--- a/openspec/changes/job-page-cta-hierarchy/proposal.md
+++ b/openspec/changes/job-page-cta-hierarchy/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+The job page's action strip has grown from three controls to six — Discussion, Report,
+Save, Add-to-list, Auto-apply, Apply — and it shares one row with the content TabStrip.
+The strip does not shrink, so every pixel it gained came out of the tabs: on a standard
+desktop column the tab row is squeezed to a scrolling sliver, and "Applications" reads as
+"Applicat…" with the Discussion link fading over it. The row cannot hold both halves any
+more.
+
+The same row also states the wrong priority. Auto-apply is the feature this page is meant
+to sell — it is Pro-only and it does the work for the reader — yet it renders as a quiet
+grey `secondary` button beside a loud green `Apply` that only opens someone else's site.
+
+## What Changes
+
+- Move the two call-to-action buttons (Auto-apply, Apply) off the tab row and up beside
+  the job title, where the page's primary actions belong. The tab row keeps only the quiet
+  actions — Discussion, Report, Save, Add-to-list — and the tabs get their width back.
+- Promote Auto-apply to the page's primary CTA when it is offered and clickable: the brand
+  green fill, plus a small `Pro` marker inside the button naming the plan it needs.
+  Non-clickable states (queued, declined, failed, already applied) stay quiet and disabled
+  — a green button nobody can press is a lie.
+- Demote the external-apply button to `Show origin` with an outline treatment whenever
+  Auto-apply is offered for the posting. It keeps its destination, its `nofollow` rel, its
+  new-tab target, and its apply-intent tracking — only its rank on the page changes.
+- Where Auto-apply is not offered (every non-Greenhouse posting, which is most of the
+  catalogue), the title row carries the unchanged green `Apply` alone.
+
+Below `lg` nothing moves: the sticky bottom bar already carries Apply there, and the quiet
+strip already rides under the title.
+
+## Capabilities
+
+### New Capabilities
+
+- `job-page-actions`: how the job detail page ranks and places what a reader can do with a
+  posting — which control is the primary CTA, where the CTAs sit relative to the title and
+  the content tabs, and how the CTA pair changes when auto-apply is available.
+
+### Modified Capabilities
+
+<!-- None. The auto-apply submit trigger's own behaviour (eligibility, statuses, the POST)
+     is unchanged; this change only re-ranks and re-places its button. -->
+
+## Impact
+
+- `web/src/lib/components/JobView.svelte` — the `applyCta`, `autoApplyCta` and
+  `actionStrip` snippets, and the two rows that render them (the `<header>` block and the
+  tab row).
+- `web/src/lib/autoApplyButton.ts` — read-only; the
+  `kind` it already returns is what decides both the CTA rank and the `Show origin` label.
+- No backend, API, or schema change. No new dependency.

--- a/openspec/changes/job-page-cta-hierarchy/proposal.md
+++ b/openspec/changes/job-page-cta-hierarchy/proposal.md
@@ -29,6 +29,13 @@ grey `secondary` button beside a loud green `Apply` that only opens someone else
 Below `lg` nothing moves: the sticky bottom bar already carries Apply there, and the quiet
 strip already rides under the title.
 
+The same header states the posting's date three times — the reality badge's age chip, the
+contrast note beside it, and the dates group — and two of those three are the identical
+phrase. The contrast note goes (the chip and the date sit on one line, so the contrast is
+already there to read), and the dates group trades the words "Posted" and "Updated" for a
+clock and a refresh icon with the short relative time beside each, keeping the words in the
+accessible name and the exact instant in the tooltip.
+
 ## Capabilities
 
 ### New Capabilities
@@ -36,6 +43,8 @@ strip already rides under the title.
 - `job-page-actions`: how the job detail page ranks and places what a reader can do with a
   posting — which control is the primary CTA, where the CTAs sit relative to the title and
   the content tabs, and how the CTA pair changes when auto-apply is available.
+- `job-page-provenance`: how the same header states the facts ABOUT the posting — how
+  compactly its dates read, and the rule that its date is stated once per page.
 
 ### Modified Capabilities
 
@@ -50,4 +59,9 @@ strip already rides under the title.
 - `web/src/lib/autoApplyButton.ts` — gains `JobCtaPlan` and `jobCtaPlan`, the six-state
   table that maps the `kind` it already returns onto what each of the two buttons says and
   how loud it is, plus the `undemotedExternalCta` constant the mobile sticky bar renders.
+- `web/src/lib/utils.ts` — `timeAgo`/`formatDateOrAgo` gain an optional short style, passed
+  through to `Intl.RelativeTimeFormat` so the compact form stays locale-aware.
+- `web/src/lib/reality.ts` — `postingContrast` and its test are removed; `JobView` was its
+  only caller and the phrase it produced is what now reads twice.
+- `web/src/lib/components/RealityBadge.svelte` — loses the `postedAt` prop that fed it.
 - No backend, API, or schema change. No new dependency.

--- a/openspec/changes/job-page-cta-hierarchy/specs/job-page-actions/spec.md
+++ b/openspec/changes/job-page-cta-hierarchy/specs/job-page-actions/spec.md
@@ -1,0 +1,112 @@
+## ADDED Requirements
+
+### Requirement: Primary CTAs sit beside the title, not on the tab row
+
+The job detail page SHALL render its call-to-action buttons (the external apply link and,
+where offered, auto-apply) in the header block beside the job title, and SHALL NOT render
+them on the row that carries the content tabs. The tab row SHALL carry only the quiet
+per-posting actions — Discussion, Report, Save, Add-to-list — so that the content TabStrip
+keeps enough width to show its labels without scrolling on a desktop column.
+
+This applies from the `lg` breakpoint up. Below `lg` the page's existing arrangement is
+unchanged: the quiet strip rides under the title and the sticky bottom bar carries the
+apply CTA.
+
+#### Scenario: Desktop tab row is not starved by the actions
+
+- **WHEN** a signed-in reader opens a Greenhouse posting on a desktop-width viewport
+- **THEN** the tab row shows every content tab label in full
+- **AND** neither the auto-apply button nor the external apply button appears on that row
+
+#### Scenario: Quiet actions stay on the tab row
+
+- **WHEN** the job detail page renders at `lg` or wider
+- **THEN** Discussion, Report, Save and Add-to-list render to the right of the content tabs
+- **AND** they share the single rule drawn under the tab row
+
+#### Scenario: Below lg the arrangement is unchanged
+
+- **WHEN** the job detail page renders narrower than `lg`
+- **THEN** the quiet action strip renders under the job title as before
+- **AND** the apply CTA renders only in the sticky bottom bar
+
+### Requirement: Auto-apply is the primary CTA when it can be started
+
+When auto-apply is offered for a posting and is in its clickable state, the job detail page
+SHALL render it as the page's primary call to action — the brand fill that the external
+apply button otherwise carries — and SHALL render a `Pro` marker inside the button naming
+the plan the action requires.
+
+Every non-clickable auto-apply state SHALL keep the quiet, disabled treatment it has today
+and SHALL NOT carry the `Pro` marker: a filled button that cannot be pressed misstates what
+the reader can do.
+
+Eligibility is deliberately not pre-empted client-side. A reader without Pro still sees the
+primary button and learns why the action is unavailable from the backend's own refusal
+after clicking.
+
+#### Scenario: Clickable auto-apply is the primary CTA
+
+- **WHEN** a Greenhouse posting has no prior auto-apply attempt and the reader has not applied
+- **THEN** the auto-apply button renders with the primary (brand fill) treatment
+- **AND** it carries a `Pro` marker
+- **AND** it is enabled
+
+#### Scenario: A queued attempt is not a primary CTA
+
+- **WHEN** the reader already has a live auto-apply attempt for the posting
+- **THEN** the auto-apply button renders quiet and disabled, reading `Auto-apply queued`
+- **AND** it carries no `Pro` marker
+
+#### Scenario: Auto-apply is absent where it is not offered
+
+- **WHEN** the posting did not come from a source auto-apply can drive
+- **THEN** no auto-apply button renders anywhere on the page
+
+### Requirement: The external apply button yields its rank to auto-apply
+
+The external apply button SHALL be demoted to an outline treatment labelled `Show origin`
+whenever auto-apply is the posting's primary CTA or an auto-apply attempt is already
+standing (queued, or already submitted). In every other case it SHALL keep its primary
+(brand fill) treatment and its `Apply` label.
+
+The page SHALL NOT render two primary CTAs at once, and SHALL render one in every state
+where the reader still has an action left to take. The two states where none is rendered
+are exactly those where they do not: a submission already in flight, and a submission
+already made. A loud button in either would only invite a duplicate application.
+
+Demotion changes only the button's label and treatment. Its destination, its
+`nofollow noopener noreferrer` rel, its new-tab target, and the apply-intent tracking and
+"Did you apply?" prompt its click raises SHALL be unchanged.
+
+#### Scenario: Demoted beside a clickable auto-apply
+
+- **WHEN** auto-apply is offered and clickable for the posting
+- **THEN** the external button reads `Show origin` with an outline treatment
+
+#### Scenario: Demoted while an attempt stands
+
+- **WHEN** an auto-apply attempt for the posting is queued, or auto-apply already submitted it
+- **THEN** the external button reads `Show origin` with an outline treatment
+
+#### Scenario: Promoted when auto-apply will not act
+
+- **WHEN** the posting's auto-apply attempt was declined by the reader or failed
+- **THEN** the external button reads `Apply` with the primary (brand fill) treatment
+- **AND** it is the only primary CTA on the page
+
+#### Scenario: No primary CTA while a submission stands
+
+- **WHEN** an auto-apply attempt for the posting is queued, or auto-apply already submitted it
+- **THEN** no button on the page carries the primary (brand fill) treatment
+
+#### Scenario: Unchanged where auto-apply is not offered
+
+- **WHEN** the posting did not come from a source auto-apply can drive
+- **THEN** the external button reads `Apply` with the primary (brand fill) treatment
+
+#### Scenario: Demotion does not change what the click does
+
+- **WHEN** the reader clicks the external button while it reads `Show origin`
+- **THEN** the posting's own URL opens in a new tab with `nofollow noopener noreferrer`
+- **AND** the apply-intent event fires and the "Did you apply?" prompt is raised, exactly as for `Apply`

--- a/openspec/changes/job-page-cta-hierarchy/specs/job-page-actions/spec.md
+++ b/openspec/changes/job-page-cta-hierarchy/specs/job-page-actions/spec.md
@@ -52,7 +52,7 @@ after clicking.
 - **AND** it carries a `Pro` marker
 - **AND** it is enabled
 
-#### Scenario: A queued attempt is not a primary CTA
+#### Scenario: A standing or spent attempt is not a primary CTA
 
 - **WHEN** the reader already has a live auto-apply attempt for the posting
 - **THEN** the auto-apply button renders quiet and disabled, reading `Auto-apply queued`
@@ -66,14 +66,22 @@ after clicking.
 ### Requirement: The external apply button yields its rank to auto-apply
 
 The external apply button SHALL be demoted to an outline treatment labelled `Show origin`
-whenever auto-apply is the posting's primary CTA or an auto-apply attempt is already
-standing (queued, or already submitted). In every other case it SHALL keep its primary
-(brand fill) treatment and its `Apply` label.
+whenever auto-apply is the posting's primary CTA or an auto-apply attempt is queued. In
+every other case it SHALL keep its primary (brand fill) treatment and its `Apply` label.
+
+Every bar on the page that renders the external button beside an auto-apply button SHALL
+give it the same treatment the title row does. One link SHALL NOT read at two ranks on one
+page.
 
 The page SHALL NOT render two primary CTAs at once, and SHALL render one in every state
-where the reader still has an action left to take. The two states where none is rendered
-are exactly those where they do not: a submission already in flight, and a submission
-already made. A loud button in either would only invite a duplicate application.
+where the reader still has an action left to take. A queued attempt is the one state where
+none is rendered: a submission is in flight, and a loud button would only invite a
+duplicate.
+
+A reader who already applied to the posting by hand SHALL NOT change the external button.
+That fact is true of a posting from any source, and demoting on it would make a posting
+auto-apply can drive read differently from an identical one it cannot, for a reader in the
+identical situation.
 
 Demotion changes only the button's label and treatment. Its destination, its
 `nofollow noopener noreferrer` rel, its new-tab target, and the apply-intent tracking and
@@ -86,8 +94,13 @@ Demotion changes only the button's label and treatment. Its destination, its
 
 #### Scenario: Demoted while an attempt stands
 
-- **WHEN** an auto-apply attempt for the posting is queued, or auto-apply already submitted it
+- **WHEN** an auto-apply attempt for the posting is queued
 - **THEN** the external button reads `Show origin` with an outline treatment
+
+#### Scenario: The pinned header agrees with the title row
+
+- **WHEN** the reader scrolls past the title on a posting auto-apply can drive
+- **THEN** the pinned header carries the same two buttons, with the same labels and treatments
 
 #### Scenario: Promoted when auto-apply will not act
 
@@ -95,10 +108,16 @@ Demotion changes only the button's label and treatment. Its destination, its
 - **THEN** the external button reads `Apply` with the primary (brand fill) treatment
 - **AND** it is the only primary CTA on the page
 
-#### Scenario: No primary CTA while a submission stands
+#### Scenario: No primary CTA while a submission is in flight
 
-- **WHEN** an auto-apply attempt for the posting is queued, or auto-apply already submitted it
+- **WHEN** an auto-apply attempt for the posting is queued
 - **THEN** no button on the page carries the primary (brand fill) treatment
+
+#### Scenario: Applying by hand does not demote anything
+
+- **WHEN** the reader has already applied to the posting themselves
+- **THEN** the external button reads `Apply` with the primary (brand fill) treatment
+- **AND** it reads the same way whether or not auto-apply can drive the posting
 
 #### Scenario: Unchanged where auto-apply is not offered
 

--- a/openspec/changes/job-page-cta-hierarchy/specs/job-page-actions/spec.md
+++ b/openspec/changes/job-page-cta-hierarchy/specs/job-page-actions/spec.md
@@ -8,9 +8,9 @@ and right-aligned, and SHALL NOT render them on the row that carries the content
 per-posting actions — Discussion, Report, Save, Add-to-list — so that the content TabStrip
 keeps enough width to show its labels without scrolling on a desktop column.
 
-This applies from the `lg` breakpoint up. Below `lg` the page's existing arrangement is
-unchanged: the quiet strip rides under the title and the sticky bottom bar carries the
-apply CTA.
+This applies from the `lg` breakpoint up. Below `lg` the furniture differs but the rule does
+not: the sticky bottom bar carries whichever control the page made primary, and the quiet
+strip under the title carries the other one.
 
 #### Scenario: Desktop tab row is not starved by the actions
 
@@ -30,11 +30,17 @@ apply CTA.
 - **THEN** Discussion, Report, Save and Add-to-list render to the right of the content tabs
 - **AND** they share the single rule drawn under the tab row
 
-#### Scenario: Below lg the arrangement is unchanged
+#### Scenario: The phone's sticky bar carries the primary control
 
-- **WHEN** the job detail page renders narrower than `lg`
-- **THEN** the quiet action strip renders under the job title as before
-- **AND** the apply CTA renders only in the sticky bottom bar
+- **WHEN** the page renders narrower than `lg` on a posting whose auto-apply can be started
+- **THEN** the sticky bottom bar carries the auto-apply button, with its `Pro` marker
+- **AND** the apply link renders in the quiet strip under the title instead
+
+#### Scenario: The phone falls back to the apply link
+
+- **WHEN** the page renders narrower than `lg` and auto-apply is not the primary control
+- **THEN** the sticky bottom bar carries the apply link, at whatever rank the page gave it
+- **AND** the quiet strip does not repeat it
 
 ### Requirement: Auto-apply is the primary CTA when it can be started
 

--- a/openspec/changes/job-page-cta-hierarchy/specs/job-page-actions/spec.md
+++ b/openspec/changes/job-page-cta-hierarchy/specs/job-page-actions/spec.md
@@ -1,10 +1,10 @@
 ## ADDED Requirements
 
-### Requirement: Primary CTAs sit beside the title, not on the tab row
+### Requirement: Primary CTAs sit under the title, not on the tab row
 
 The job detail page SHALL render its call-to-action buttons (the external apply link and,
-where offered, auto-apply) in the header block beside the job title, and SHALL NOT render
-them on the row that carries the content tabs. The tab row SHALL carry only the quiet
+where offered, auto-apply) in the header block, on a row of their own under the job title
+and right-aligned, and SHALL NOT render them on the row that carries the content tabs. The tab row SHALL carry only the quiet
 per-posting actions — Discussion, Report, Save, Add-to-list — so that the content TabStrip
 keeps enough width to show its labels without scrolling on a desktop column.
 
@@ -17,6 +17,12 @@ apply CTA.
 - **WHEN** a signed-in reader opens a Greenhouse posting on a desktop-width viewport
 - **THEN** the tab row shows every content tab label in full
 - **AND** neither the auto-apply button nor the external apply button appears on that row
+
+#### Scenario: The CTAs keep their own row
+
+- **WHEN** the job detail page renders at `lg` or wider
+- **THEN** the CTA buttons sit on a row between the title and the content tabs
+- **AND** they are right-aligned, whatever the length of the title above them
 
 #### Scenario: Quiet actions stay on the tab row
 

--- a/openspec/changes/job-page-cta-hierarchy/specs/job-page-provenance/spec.md
+++ b/openspec/changes/job-page-cta-hierarchy/specs/job-page-provenance/spec.md
@@ -32,6 +32,27 @@ else.
 - **WHEN** a posting's update time renders to the same label as its posting time
 - **THEN** only the posting date renders, as it does today
 
+### Requirement: The engagement counters ride the provenance line
+
+The job detail page SHALL render the posting's view and applied counts on the same line as
+its dates, and SHALL NOT render them in the sidebar. They are facts about how the posting is
+doing, like the dates, and each is one icon and one number; a reader weighing "posted 20
+minutes ago" against "3 views" should not have to hold that thought across two places.
+
+A count of zero SHALL NOT render. On a posting nobody has opened yet, "0 views" measures
+this site's own traffic rather than the job.
+
+#### Scenario: The counters sit with the dates
+
+- **WHEN** a posting has been viewed and someone has told us they applied
+- **THEN** both counts render on the dates line, each as an icon and a number
+- **AND** neither renders in the sidebar
+
+#### Scenario: A count of zero says nothing
+
+- **WHEN** a posting has no views and no recorded applications
+- **THEN** neither counter renders, and the dates line carries only the dates
+
 ### Requirement: The posting date is stated once per page
 
 The job detail page SHALL NOT restate the posting's date beside the reality badge. The

--- a/openspec/changes/job-page-cta-hierarchy/specs/job-page-provenance/spec.md
+++ b/openspec/changes/job-page-cta-hierarchy/specs/job-page-provenance/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: The posting's dates read as icons, not sentences
+
+The job detail page SHALL state when a posting went up and when its words last moved as an
+icon and a compact relative time, not as the words "Posted" and "Updated" spelled out. The
+compact form SHALL be produced by the platform's own short relative-time formatting, so it
+follows the reader's locale rather than being abbreviated by hand.
+
+Each icon SHALL carry the word it replaces in its accessible name and the exact timestamp
+in its tooltip. An icon that only a sighted reader can decode states the fact to nobody
+else.
+
+#### Scenario: The dates render compactly
+
+- **WHEN** a posting went up within the last day and has since been updated
+- **THEN** the header shows a clock icon with the compact age, and a refresh icon with the compact update age
+- **AND** neither the word "Posted" nor the word "Updated" is drawn on screen
+
+#### Scenario: The words survive for assistive tech
+
+- **WHEN** a screen reader reaches either date
+- **THEN** it announces the word the icon replaced — "Posted" or "Updated" — before the time
+
+#### Scenario: The exact instant stays reachable
+
+- **WHEN** the reader hovers either date
+- **THEN** the tooltip names the field and its full date and time
+
+#### Scenario: An unchanged posting states its date once
+
+- **WHEN** a posting's update time renders to the same label as its posting time
+- **THEN** only the posting date renders, as it does today
+
+### Requirement: The posting date is stated once per page
+
+The job detail page SHALL NOT restate the posting's date beside the reality badge. The
+badge's age chip and the posting date sit on the same line, so the contrast between them —
+a long-open role whose source rewrites its date every crawl — is already visible to the
+reader; spelling it out a second time printed the identical phrase twice on one line.
+
+#### Scenario: No duplicate phrase on the provenance line
+
+- **WHEN** a posting is long-open and its source date reads much fresher than its true age
+- **THEN** the reality badge shows only its age chip and its remaining evidence
+- **AND** the posting date appears exactly once on the line, in the dates group
+
+#### Scenario: The reality badge keeps its other evidence
+
+- **WHEN** the reality signal carries evidence beyond the posting date
+- **THEN** that evidence still renders beside the badge, and the badge's tooltip is unchanged

--- a/openspec/changes/job-page-cta-hierarchy/tasks.md
+++ b/openspec/changes/job-page-cta-hierarchy/tasks.md
@@ -1,36 +1,37 @@
 ## 1. The CTA rank table
 
-- [ ] 1.1 In `web/src/lib/autoApplyButton.test.ts`, write the failing table-driven test for
+- [x] 1.1 In `web/src/lib/autoApplyButton.test.ts`, write the failing table-driven test for
       a new `jobCtaPlan(state)` covering all six `AutoApplyButtonState` kinds: what the
       auto-apply button shows (rendered at all, label, primary, `Pro` marker, disabled) and
       what the external button shows (label, primary), per design.md's table.
-- [ ] 1.2 Add a failing test asserting the invariant the table exists to protect: for every
-      kind, exactly one of the two buttons is primary.
-- [ ] 1.3 Export `JobCtaPlan` and `jobCtaPlan` from `web/src/lib/autoApplyButton.ts` to make
+- [x] 1.2 Add a failing test asserting the invariant the table exists to protect: never two
+      primary buttons at once, and one in every kind that still leaves the reader an action
+      — which is every kind but `queued` and `applied`.
+- [x] 1.3 Export `JobCtaPlan` and `jobCtaPlan` from `web/src/lib/autoApplyButton.ts` to make
       1.1 and 1.2 pass, with a comment saying why `declined`/`failed` re-promote the
       external button.
 
 ## 2. The buttons
 
-- [ ] 2.1 Make `applyCta` take the plan's `external` half: `Apply`/`Show origin` label and
+- [x] 2.1 Make `applyCta` take the plan's `external` half: `Apply`/`Show origin` label and
       `primary`/`outline` variant. Destination, `rel`, `target`, `onApplyClick` unchanged.
-- [ ] 2.2 Make `autoApplyCta` take the plan's `autoApply` half: label from the plan instead
+- [x] 2.2 Make `autoApplyCta` take the plan's `autoApply` half: label from the plan instead
       of its own `{#if}` chain, `primary` when the plan says so, and the `Pro` marker span
-      (`bg-brand-foreground/15 text-brand-foreground`) only when `pro` is set.
+      (`bg-foreground text-background`) only when `pro` is set.
 
 ## 3. The layout
 
-- [ ] 3.1 Add a `ctaGroup` snippet rendering `autoApplyCta` then `applyCta`, and render it
+- [x] 3.1 Add a `ctaGroup` snippet rendering `autoApplyCta` then `applyCta`, and render it
       `ml-auto hidden lg:flex` inside the header block's title row in `JobView.svelte`.
-- [ ] 3.2 Remove both CTAs from the `actionStrip` snippet, leaving Discussion, Report, Save
+- [x] 3.2 Remove both CTAs from the `actionStrip` snippet, leaving Discussion, Report, Save
       and Add-to-list; confirm the tab row's shared `border-b` rule still reads as one edge
       across the column.
-- [ ] 3.3 Verify the sub-`lg` path is untouched: the quiet strip still renders under the
+- [x] 3.3 Verify the sub-`lg` path is untouched: the quiet strip still renders under the
       title and the sticky bottom bar still carries the apply CTA.
 
 ## 4. Verify
 
-- [ ] 4.1 `pnpm --dir web test` and `pnpm --dir web lint` green.
-- [ ] 4.2 Run the app and check the job page in the browser at desktop width: full tab
+- [x] 4.1 `pnpm --dir web test` and `pnpm --dir web lint` green.
+- [x] 4.2 Run the app and check the job page in the browser at desktop width: full tab
       labels, green `Auto-apply` with `Pro` beside an outline `Show origin` on a Greenhouse
       posting, plain green `Apply` on a non-Greenhouse one, and the phone layout unchanged.

--- a/openspec/changes/job-page-cta-hierarchy/tasks.md
+++ b/openspec/changes/job-page-cta-hierarchy/tasks.md
@@ -29,9 +29,22 @@
 - [x] 3.3 Verify the sub-`lg` path is untouched: the quiet strip still renders under the
       title and the sticky bottom bar still carries the apply CTA.
 
-## 4. Verify
+## 4. The posting's dates
 
-- [x] 4.1 `pnpm --dir web test` and `pnpm --dir web lint` green.
-- [x] 4.2 Run the app and check the job page in the browser at desktop width: full tab
+- [x] 4.1 In `web/src/lib/utils.test.ts`, write the failing test for a short style on
+      `timeAgo` and `formatDateOrAgo`; then add the optional `style` argument, passing
+      `style: 'short'` through to a second cached `Intl.RelativeTimeFormat`.
+- [x] 4.2 Rewrite the `postingDates` snippet in `JobView.svelte` as a clock icon and a
+      refresh icon, each with the short relative time, an `sr-only` label carrying the word
+      it replaced, and a `title` carrying the field name and the exact timestamp.
+- [x] 4.3 Drop the duplicate: stop passing `postedAt` to `RealityBadge` in `JobView.svelte`,
+      then remove the now-orphaned `postingContrast` (`web/src/lib/reality.ts`), its tests,
+      and `RealityBadge`'s `postedAt` prop.
+
+## 5. Verify
+
+- [x] 5.1 `pnpm --dir web test` and `pnpm --dir web lint` green.
+- [x] 5.2 Run the app and check the job page in the browser at desktop width: full tab
       labels, green `Auto-apply` with `Pro` beside an outline `Show origin` on a Greenhouse
-      posting, plain green `Apply` on a non-Greenhouse one, and the phone layout unchanged.
+      posting, plain green `Apply` on a non-Greenhouse one, the dates reading as two icons,
+      and the phone layout unchanged. Check the `Pro` marker in both themes.

--- a/openspec/changes/job-page-cta-hierarchy/tasks.md
+++ b/openspec/changes/job-page-cta-hierarchy/tasks.md
@@ -1,0 +1,36 @@
+## 1. The CTA rank table
+
+- [ ] 1.1 In `web/src/lib/autoApplyButton.test.ts`, write the failing table-driven test for
+      a new `jobCtaPlan(state)` covering all six `AutoApplyButtonState` kinds: what the
+      auto-apply button shows (rendered at all, label, primary, `Pro` marker, disabled) and
+      what the external button shows (label, primary), per design.md's table.
+- [ ] 1.2 Add a failing test asserting the invariant the table exists to protect: for every
+      kind, exactly one of the two buttons is primary.
+- [ ] 1.3 Export `JobCtaPlan` and `jobCtaPlan` from `web/src/lib/autoApplyButton.ts` to make
+      1.1 and 1.2 pass, with a comment saying why `declined`/`failed` re-promote the
+      external button.
+
+## 2. The buttons
+
+- [ ] 2.1 Make `applyCta` take the plan's `external` half: `Apply`/`Show origin` label and
+      `primary`/`outline` variant. Destination, `rel`, `target`, `onApplyClick` unchanged.
+- [ ] 2.2 Make `autoApplyCta` take the plan's `autoApply` half: label from the plan instead
+      of its own `{#if}` chain, `primary` when the plan says so, and the `Pro` marker span
+      (`bg-brand-foreground/15 text-brand-foreground`) only when `pro` is set.
+
+## 3. The layout
+
+- [ ] 3.1 Add a `ctaGroup` snippet rendering `autoApplyCta` then `applyCta`, and render it
+      `ml-auto hidden lg:flex` inside the header block's title row in `JobView.svelte`.
+- [ ] 3.2 Remove both CTAs from the `actionStrip` snippet, leaving Discussion, Report, Save
+      and Add-to-list; confirm the tab row's shared `border-b` rule still reads as one edge
+      across the column.
+- [ ] 3.3 Verify the sub-`lg` path is untouched: the quiet strip still renders under the
+      title and the sticky bottom bar still carries the apply CTA.
+
+## 4. Verify
+
+- [ ] 4.1 `pnpm --dir web test` and `pnpm --dir web lint` green.
+- [ ] 4.2 Run the app and check the job page in the browser at desktop width: full tab
+      labels, green `Auto-apply` with `Pro` beside an outline `Show origin` on a Greenhouse
+      posting, plain green `Apply` on a non-Greenhouse one, and the phone layout unchanged.

--- a/web/src/lib/autoApplyButton.test.ts
+++ b/web/src/lib/autoApplyButton.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { autoApplyButtonState } from './autoApplyButton';
+import {
+  autoApplyButtonState,
+  jobCtaPlan,
+  type AutoApplyButtonState,
+  type JobCtaPlan,
+} from './autoApplyButton';
 
 describe('autoApplyButtonState', () => {
   it('hides the button for a non-Greenhouse posting', () => {
@@ -27,5 +32,77 @@ describe('autoApplyButtonState', () => {
 
   it('is failed when cmd/auto-apply gave up on the attempt', () => {
     expect(autoApplyButtonState('greenhouse', 'failed')).toEqual({ kind: 'failed' });
+  });
+});
+
+const kinds = ['hidden', 'idle', 'queued', 'applied', 'declined', 'failed'] as const;
+const plan = (kind: AutoApplyButtonState['kind']): JobCtaPlan => jobCtaPlan({ kind });
+
+describe('jobCtaPlan', () => {
+  it('offers only the apply button where auto-apply cannot drive the ATS', () => {
+    expect(plan('hidden')).toEqual({
+      autoApply: null,
+      external: { label: 'Apply', primary: true },
+    });
+  });
+
+  it('makes a startable auto-apply the primary CTA and names the plan it needs', () => {
+    expect(plan('idle')).toEqual({
+      autoApply: { label: 'Auto-apply', primary: true, pro: true, disabled: false },
+      external: { label: 'Show origin', primary: false },
+    });
+  });
+
+  it('keeps a standing attempt quiet and the apply button demoted', () => {
+    expect(plan('queued')).toEqual({
+      autoApply: { label: 'Auto-apply queued', primary: false, pro: false, disabled: true },
+      external: { label: 'Show origin', primary: false },
+    });
+    expect(plan('applied')).toEqual({
+      autoApply: { label: 'Already applied', primary: false, pro: false, disabled: true },
+      external: { label: 'Show origin', primary: false },
+    });
+  });
+
+  it('promotes the apply button back when auto-apply will not act', () => {
+    expect(plan('declined')).toEqual({
+      autoApply: { label: 'Auto-apply declined', primary: false, pro: false, disabled: true },
+      external: { label: 'Apply', primary: true },
+    });
+    expect(plan('failed')).toEqual({
+      autoApply: { label: "Auto-apply couldn't complete", primary: false, pro: false, disabled: true },
+      external: { label: 'Apply', primary: true },
+    });
+  });
+
+  // The rule the table exists to protect: never two loud buttons competing for the same
+  // click.
+  it('never offers two primary CTAs at once', () => {
+    for (const kind of kinds) {
+      const p = plan(kind);
+      const primaries = [p.autoApply?.primary, p.external.primary].filter(Boolean).length;
+      expect(primaries, `state ${kind}`).toBeLessThanOrEqual(1);
+    }
+  });
+
+  // And the other half of it: a state where the reader still HAS something to do gets a
+  // loud button for it. `queued` and `applied` are the two where they do not — the
+  // submission is in flight or already made, and a loud button there would only invite a
+  // second one.
+  it('offers a primary CTA in every state that still has an action left', () => {
+    for (const kind of kinds) {
+      const p = plan(kind);
+      const hasPrimary = Boolean(p.autoApply?.primary) || p.external.primary;
+      expect(hasPrimary, `state ${kind}`).toBe(kind !== 'queued' && kind !== 'applied');
+    }
+  });
+
+  // The Pro marker states a requirement of the action. On a button nobody can press it
+  // would state it about nothing.
+  it('marks Pro only on a button that can be pressed', () => {
+    for (const kind of kinds) {
+      const { autoApply } = plan(kind);
+      if (autoApply?.pro) expect(autoApply.disabled, `state ${kind}`).toBe(false);
+    }
   });
 });

--- a/web/src/lib/autoApplyButton.test.ts
+++ b/web/src/lib/autoApplyButton.test.ts
@@ -58,9 +58,15 @@ describe('jobCtaPlan', () => {
       autoApply: { label: 'Auto-apply queued', primary: false, pro: false, disabled: true },
       external: { label: 'Show origin', primary: false },
     });
+  });
+
+  // Not demoted: `applied` is true of a posting from any source, and demoting on it would
+  // make a Greenhouse posting read differently from an identical Lever one for a reader in
+  // the identical situation.
+  it('leaves the apply button alone for a reader who already applied by hand', () => {
     expect(plan('applied')).toEqual({
       autoApply: { label: 'Already applied', primary: false, pro: false, disabled: true },
-      external: { label: 'Show origin', primary: false },
+      external: { label: 'Apply', primary: true },
     });
   });
 
@@ -86,14 +92,13 @@ describe('jobCtaPlan', () => {
   });
 
   // And the other half of it: a state where the reader still HAS something to do gets a
-  // loud button for it. `queued` and `applied` are the two where they do not — the
-  // submission is in flight or already made, and a loud button there would only invite a
-  // second one.
+  // loud button for it. `queued` is the one state where they do not — a submission is in
+  // flight, and a loud button there would only invite a second one.
   it('offers a primary CTA in every state that still has an action left', () => {
     for (const kind of kinds) {
       const p = plan(kind);
       const hasPrimary = Boolean(p.autoApply?.primary) || p.external.primary;
-      expect(hasPrimary, `state ${kind}`).toBe(kind !== 'queued' && kind !== 'applied');
+      expect(hasPrimary, `state ${kind}`).toBe(kind !== 'queued');
     }
   });
 

--- a/web/src/lib/autoApplyButton.ts
+++ b/web/src/lib/autoApplyButton.ts
@@ -62,14 +62,7 @@ const quiet = (label: string): NonNullable<JobCtaPlan['autoApply']> => ({
 });
 
 const showOrigin = { label: 'Show origin', primary: false } as const;
-
-/** The apply link at full rank. Exported for the one bar that renders it WITHOUT an
- *  auto-apply button beside it — the mobile sticky bar, where auto-apply has no button on
- *  any device — since a demoted label there would step aside for nothing the reader can
- *  reach, and writing the word out a second time would give these buttons a second place
- *  that decides what they say. */
-export const undemotedExternalCta = { label: 'Apply', primary: true } as const;
-const apply = undemotedExternalCta;
+const apply = { label: 'Apply', primary: true } as const;
 
 /** Ranks the two CTAs for a posting.
  *

--- a/web/src/lib/autoApplyButton.ts
+++ b/web/src/lib/autoApplyButton.ts
@@ -62,7 +62,14 @@ const quiet = (label: string): NonNullable<JobCtaPlan['autoApply']> => ({
 });
 
 const showOrigin = { label: 'Show origin', primary: false } as const;
-const apply = { label: 'Apply', primary: true } as const;
+
+/** The apply link at full rank. Exported for the one bar that renders it WITHOUT an
+ *  auto-apply button beside it — the mobile sticky bar, where auto-apply has no button on
+ *  any device — since a demoted label there would step aside for nothing the reader can
+ *  reach, and writing the word out a second time would give these buttons a second place
+ *  that decides what they say. */
+export const undemotedExternalCta = { label: 'Apply', primary: true } as const;
+const apply = undemotedExternalCta;
 
 /** Ranks the two CTAs for a posting.
  *
@@ -73,7 +80,16 @@ const apply = { label: 'Apply', primary: true } as const;
  *  auto-apply button exists" — the two read the same until you reach those two states.
  *
  *  `pro` rides only the clickable state for the same reason the brand fill does: a marker
- *  naming what an action requires says nothing on a button nobody can press. */
+ *  naming what an action requires says nothing on a button nobody can press.
+ *
+ *  `applied` does NOT demote, even though the reader has nothing left to do here. That
+ *  state comes from `alreadyApplied` — the "Did you apply?" prompt after a manual
+ *  click-through — and is true of a posting from any source, while this table only runs on
+ *  the ones auto-apply can drive. Demoting on it would make a Greenhouse posting read
+ *  differently from an identical Lever one for a reader in the identical situation, which
+ *  is an artefact of routing the question through the auto-apply state machine rather than
+ *  a decision anybody made. `queued` is the one state that genuinely leaves no primary CTA,
+ *  and it is genuinely auto-apply's own. */
 export function jobCtaPlan(state: AutoApplyButtonState): JobCtaPlan {
   switch (state.kind) {
     case 'hidden':
@@ -86,7 +102,7 @@ export function jobCtaPlan(state: AutoApplyButtonState): JobCtaPlan {
     case 'queued':
       return { autoApply: quiet('Auto-apply queued'), external: showOrigin };
     case 'applied':
-      return { autoApply: quiet('Already applied'), external: showOrigin };
+      return { autoApply: quiet('Already applied'), external: apply };
     case 'declined':
       return { autoApply: quiet('Auto-apply declined'), external: apply };
     case 'failed':

--- a/web/src/lib/autoApplyButton.ts
+++ b/web/src/lib/autoApplyButton.ts
@@ -34,3 +34,62 @@ export function autoApplyButtonState(
   if (status === 'failed') return { kind: 'failed' };
   return { kind: 'idle' };
 }
+
+/** What the job page's two call-to-action buttons look like, given the auto-apply state.
+ *  Never two loud buttons at once, and one wherever the reader still has something to do. */
+export type JobCtaPlan = {
+  /** `null` where auto-apply cannot drive the posting's ATS: no button is rendered. */
+  autoApply: {
+    label: string;
+    /** Carries the brand fill — the page's primary call to action. */
+    primary: boolean;
+    /** Renders the `Pro` marker naming the plan the action requires. */
+    pro: boolean;
+    disabled: boolean;
+  } | null;
+  /** The link out to the posting's own site. Demoted to an outline `Show origin` while
+   *  auto-apply owns the primary slot. */
+  external: { label: 'Apply' | 'Show origin'; primary: boolean };
+};
+
+/** A rendered-but-unpressable auto-apply button: it reports where the attempt stands and
+ *  takes neither the brand fill nor the `Pro` marker. */
+const quiet = (label: string): NonNullable<JobCtaPlan['autoApply']> => ({
+  label,
+  primary: false,
+  pro: false,
+  disabled: true,
+});
+
+const showOrigin = { label: 'Show origin', primary: false } as const;
+const apply = { label: 'Apply', primary: true } as const;
+
+/** Ranks the two CTAs for a posting.
+ *
+ *  `declined` and `failed` hand the primary slot BACK to the external button: auto-apply
+ *  is not going to act in either state, so applying by hand is the reader's only way
+ *  forward and demoting it there would leave the page with nothing loud to press. The rule
+ *  is "demote while an attempt stands or can be started", not "demote whenever the
+ *  auto-apply button exists" — the two read the same until you reach those two states.
+ *
+ *  `pro` rides only the clickable state for the same reason the brand fill does: a marker
+ *  naming what an action requires says nothing on a button nobody can press. */
+export function jobCtaPlan(state: AutoApplyButtonState): JobCtaPlan {
+  switch (state.kind) {
+    case 'hidden':
+      return { autoApply: null, external: apply };
+    case 'idle':
+      return {
+        autoApply: { label: 'Auto-apply', primary: true, pro: true, disabled: false },
+        external: showOrigin,
+      };
+    case 'queued':
+      return { autoApply: quiet('Auto-apply queued'), external: showOrigin };
+    case 'applied':
+      return { autoApply: quiet('Already applied'), external: showOrigin };
+    case 'declined':
+      return { autoApply: quiet('Auto-apply declined'), external: apply };
+    case 'failed':
+      return { autoApply: quiet("Auto-apply couldn't complete"), external: apply };
+  }
+}

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -5,7 +5,7 @@
   import { ArrowRight, Bookmark, Check, CheckCircle2, Eye, Flag, MessageSquare } from '@lucide/svelte';
   import { ApiError, api } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
-  import { autoApplyButtonState } from '$lib/autoApplyButton';
+  import { autoApplyButtonState, jobCtaPlan } from '$lib/autoApplyButton';
   import { onboardingUrl } from '$lib/onboardingGate.svelte';
   import { promptSignIn } from '$lib/signin';
   import { filterHref, formatSalary, requirementGroups, summaryFacets } from '$lib/enrichment';
@@ -293,6 +293,16 @@
   const autoApplyState = $derived(
     autoApplyButtonState(job.source, autoApplyOverrideStatus ?? job.auto_apply_status, applied),
   );
+  // How loud each of the two CTAs is, and what they say. The table and the rule it keeps
+  // ("never two primaries; one wherever an action remains") live in autoApplyButton.ts,
+  // where they unit-test without mounting this component.
+  const cta = $derived(jobCtaPlan(autoApplyState));
+
+  // The two bars that carry the apply link WITHOUT an auto-apply button beside it — the
+  // pinned desktop header and the mobile sticky bar — never demote it. "Show origin" steps
+  // aside for auto-apply, and in a bar that does not offer auto-apply it would step aside
+  // for nothing the reader can reach from there.
+  const undemotedExternalCta = { label: 'Apply', primary: true } as const;
 
   async function onAutoApplyClick() {
     if (!isAuthenticated()) {
@@ -313,16 +323,23 @@
   }
 </script>
 
-<!-- The apply CTA renders twice: inline in the header on desktop, and in the
-     mobile sticky bar at the end of the article. Sole difference is size + layout
-     classes, so both share this snippet.
+<!-- The link out to the posting's own site. Renders twice: beside the title on desktop,
+     and in the mobile sticky bar at the end of the article. Size, layout classes and the
+     `external` half of the CTA plan are what differ, so both share this snippet.
+     `external` decides only the word and the loudness — the destination, the target and
+     the click handler are the same button either way, which is what keeps the apply-intent
+     event comparable across postings whether or not auto-apply offered to do it instead.
      nofollow: the destination is the posting's own site, which the catalogue never
      vetted — the same stance the description sanitizer takes on in-body links
      (internal/sources/sanitize.go). Without it a submitted vacancy buys a followed
      link from every job page, which is what the SEO submissions are actually after. -->
-{#snippet applyCta(size: 'md' | 'lg', className: string)}
+{#snippet applyCta(
+  size: 'md' | 'lg',
+  className: string,
+  external: { label: string; primary: boolean },
+)}
   <Button
-    variant="primary"
+    variant={external.primary ? 'primary' : 'outline'}
     {size}
     href={job.url}
     target="_blank"
@@ -330,37 +347,36 @@
     onclick={onApplyClick}
     class={className}
   >
-    Apply <ArrowRight class="size-4" />
+    {external.label} <ArrowRight class="size-4" />
   </Button>
 {/snippet}
 
-<!-- Auto-apply (openspec/changes/auto-apply-submit-trigger): beside Apply, not a
+<!-- Auto-apply (openspec/changes/auto-apply-submit-trigger): beside the apply link, not a
      replacement for it — auto-apply still goes through the same ATS in the end, this
-     button only starts the tailor-then-review sequence. Absent entirely off
-     autoApplyButtonState's `hidden` (any source but Greenhouse today). `idle` is the only
-     clickable state; `queued`/`declined`/`applied`/`failed` render disabled (the
-     `disabled:opacity-50` the button variant already carries) so a caller who already has
-     an attempt, already applied for real, or whose attempt cmd/auto-apply gave up on, sees
-     that at a glance rather than clicking into a 200 or a 409 that changes nothing. -->
+     button only starts the tailor-then-review sequence. What it says and how loud it is
+     both come from the CTA plan; the only thing decided here is that a submission already
+     in flight also disables it, which is a fact about THIS component's request rather than
+     about the posting.
+     The `Pro` marker is a span, not the `Badge` primitive: Badge's variants carry their own
+     background and foreground, none of which are legible on `bg-brand`. Styling it from the
+     button's own foreground token instead makes it follow the button into either theme. -->
 {#snippet autoApplyCta(className: string)}
-  {#if autoApplyState.kind !== 'hidden'}
+  {#if cta.autoApply}
+    {@const button = cta.autoApply}
     <Button
-      variant="secondary"
+      variant={button.primary ? 'primary' : 'secondary'}
       size="md"
-      disabled={autoApplyState.kind !== 'idle' || autoApplySubmitting}
+      disabled={button.disabled || autoApplySubmitting}
       onclick={onAutoApplyClick}
       class={className}
     >
-      {#if autoApplyState.kind === 'queued'}
-        Auto-apply queued
-      {:else if autoApplyState.kind === 'declined'}
-        Auto-apply declined
-      {:else if autoApplyState.kind === 'applied'}
-        Already applied
-      {:else if autoApplyState.kind === 'failed'}
-        Auto-apply couldn't complete
-      {:else}
-        Auto-apply
+      {button.label}
+      {#if button.pro}
+        <span
+          class="rounded-sm bg-brand-foreground/15 px-1.5 py-0.5 text-xs font-semibold uppercase leading-none tracking-wide"
+        >
+          Pro
+        </span>
       {/if}
     </Button>
   {/if}
@@ -433,16 +449,18 @@
   {/if}
 {/snippet}
 
-<!-- The action strip: everything a reader does WITH the posting — talk about it, flag
-     it, keep it, open it — on one line, sharing the tab row's rule. It carries the
+<!-- The action strip: the QUIET things a reader does with a posting — talk about it, flag
+     it, keep it, file it — on one line, sharing the tab row's rule. It carries the
      rule itself (`border-b`) rather than sitting above one, so the line reads as a
      single edge across the column: the strip and the TabStrip beside it are aligned on
      their bottoms, and each draws its own half of it.
+     The two loud things — auto-apply and the apply link — are NOT here; they are ctaGroup,
+     up beside the title. They shared this row until there were six controls on it, at which
+     point the TabStrip, the only half that yields, had been squeezed to a scrolling sliver.
      Rendered in two places, one visible at a time (the caller passes the display class):
      the tab row on lg, and directly under the title below it, where the sidebar stacks
      between the title and the description and a strip left on the tab row would put Save
-     a whole screen away from the job it saves. Only the apply CTA drops out below lg — the sticky
-     bottom bar carries it there, which is also what leaves the phone room for the labels. -->
+     a whole screen away from the job it saves. -->
 {#snippet actionStrip(className: string)}
   <div class={`shrink-0 items-center gap-1.5 ${className}`}>
     <a
@@ -456,8 +474,20 @@
     {@render reportButton()}
     {@render saveButton()}
     <AddToListButton jobSlug={job.public_slug} />
-    {@render autoApplyCta('ml-1 hidden shrink-0 lg:inline-flex')}
-    {@render applyCta('md', 'ml-1 hidden shrink-0 lg:inline-flex')}
+  </div>
+{/snippet}
+
+<!-- The two call-to-action buttons, auto-apply first: the page's answer to "what do I do
+     with this posting". They ride the title's own row rather than the tab row below it,
+     because the tab row's other half is the content TabStrip and the strip is the half
+     that cannot shrink — every control added here used to come straight out of the tab
+     labels, which had been squeezed to a scrolling sliver by the time there were six.
+     `hidden lg:flex`: below lg the sticky bottom bar carries the apply CTA instead, and
+     auto-apply has no button there at all. -->
+{#snippet ctaGroup()}
+  <div class="ml-auto hidden shrink-0 items-center gap-2 lg:flex">
+    {@render autoApplyCta('shrink-0')}
+    {@render applyCta('md', 'shrink-0', cta.external)}
   </div>
 {/snippet}
 
@@ -606,6 +636,10 @@
           <CheckCircle2 class="size-3.5" aria-hidden="true" /> Applied
         </Chip>
       {/if}
+      <!-- `ml-auto` inside the snippet, so the buttons take the right edge of the title's
+           own row. The row wraps, so a long title pushes them onto a line of their own
+           rather than truncating either. -->
+      {@render ctaGroup()}
     </div>
 
     <!-- Below lg the provenance line is a single non-wrapping row already truncating the
@@ -791,7 +825,7 @@
                them for most of a description several screens long. -->
           <div class="hidden shrink-0 items-center gap-2 lg:flex">
             {@render saveButton('size-9 rounded-md px-0', true)}
-            {@render applyCta('md', 'shrink-0')}
+            {@render applyCta('md', 'shrink-0', undemotedExternalCta)}
           </div>
         </div>
       </div>
@@ -926,7 +960,11 @@
   <div
     class="pointer-events-none sticky bottom-0 z-30 -mx-5 border-t border-border/40 bg-background/15 px-5 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-3 backdrop-blur-lg sm:-mx-4 sm:px-4 lg:hidden"
   >
-    {@render applyCta('lg', 'pointer-events-auto w-full rounded-xl font-semibold shadow-lg')}
+    {@render applyCta(
+      'lg',
+      'pointer-events-auto w-full rounded-xl font-semibold shadow-lg',
+      undemotedExternalCta,
+    )}
   </div>
 </article>
 

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -2,7 +2,17 @@
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
-  import { ArrowRight, Bookmark, Check, CheckCircle2, Eye, Flag, MessageSquare } from '@lucide/svelte';
+  import {
+    ArrowRight,
+    Bookmark,
+    Check,
+    CheckCircle2,
+    Clock,
+    Eye,
+    Flag,
+    MessageSquare,
+    RefreshCw,
+  } from '@lucide/svelte';
   import { ApiError, api } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { autoApplyButtonState, jobCtaPlan, undemotedExternalCta } from '$lib/autoApplyButton';
@@ -78,12 +88,12 @@
   // Both read as an age for their first day ("20 minutes ago") and as a date after it —
   // the same label the feed's card already gives a posting, so a reader arriving from
   // the list meets the answer in the form they just left.
-  const posted = $derived(formatDateOrAgo(job.posted_at));
+  const posted = $derived(formatDateOrAgo(job.posted_at, 'short'));
   // When the posting's own content last changed. `jobs.updated_at` is deliberately left
   // unstamped by the liveness refresh (internal/platform/db/queries/jobs.sql), so the column
   // means "the words moved", not "the crawler came back" — which is the only reading that
   // earns a line beside the posting date.
-  const updated = $derived(formatDateOrAgo(job.updated_at));
+  const updated = $derived(formatDateOrAgo(job.updated_at, 'short'));
   const e = $derived(job.enrichment ?? {});
   const salary = $derived(formatSalary(e));
   const facets = $derived(summaryFacets(job));
@@ -436,14 +446,23 @@
      a single non-wrapping row whose company name is already truncating to fit. -->
 {#snippet postingDates(className: string)}
   {#if posted}
-    <div class={`items-center gap-x-2 text-xs text-muted-foreground ${className}`}>
-      <span class="whitespace-nowrap">
-        Posted <time datetime={job.posted_at} title={formatDateTime(job.posted_at)}>{posted}</time>
+    <div class={`items-center gap-x-3 text-xs text-muted-foreground ${className}`}>
+      <span
+        class="inline-flex items-center gap-1 whitespace-nowrap"
+        title={`Posted ${formatDateTime(job.posted_at)}`}
+      >
+        <Clock class="size-3.5 shrink-0" aria-hidden="true" />
+        <span class="sr-only">Posted</span>
+        <time datetime={job.posted_at}>{posted}</time>
       </span>
       {#if updated && updated !== posted}
-        <span aria-hidden="true">·</span>
-        <span class="whitespace-nowrap">
-          Updated <time datetime={job.updated_at} title={formatDateTime(job.updated_at)}>{updated}</time>
+        <span
+          class="inline-flex items-center gap-1 whitespace-nowrap"
+          title={`Updated ${formatDateTime(job.updated_at)}`}
+        >
+          <RefreshCw class="size-3.5 shrink-0" aria-hidden="true" />
+          <span class="sr-only">Updated</span>
+          <time datetime={job.updated_at}>{updated}</time>
         </span>
       {/if}
     </div>
@@ -604,7 +623,7 @@
            the title — it is a disclosure with a criteria list inside, not a chip, and it
            supersedes this badge rather than joining it. -->
       {#if !supersedesReality(job.ghost)}
-        <RealityBadge reality={job.reality} postedAt={job.posted_at} detailed />
+        <RealityBadge reality={job.reality} detailed />
       {/if}
 
       <!-- Freshness rides the same provenance line: like the backer and the reality

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -430,23 +430,30 @@
   </Button>
 {/snippet}
 
-<!-- When the posting went up and when its words last moved. Two facts ABOUT the posting,
-     so they ride the provenance line with the company and the badges rather than the
-     sidebar's source row, where a reader comparing freshness had to look past the match
-     score and the salary to find them.
+<!-- How this posting is doing: when it went up, when its words last moved, and how many
+     people have opened it or told us they applied. Facts ABOUT the posting rather than
+     about the role, so they ride the provenance line with the company and the badges,
+     rather than the sidebar, where a reader comparing "posted 20 minutes ago" against "3
+     views" had to hold one thought across two places — past the match score and the salary
+     to reach either.
+     Every one of them is an icon and a number, which is what lets four of them share a line
+     the words would have filled on their own. The icons carry the word they replaced in an
+     `sr-only` span, so the line reads the same to a screen reader as it did when it was
+     spelled out.
      "Updated" is dropped when it renders to the same label as the posting date: a job
      written once and never touched would otherwise say the same thing twice. Comparing
      the LABELS rather than the timestamps is the point — two edits an hour apart on one
      day are a real difference while both read as ages, and stop being one the day they
      both collapse into that date.
-     The exact clock time rides the `title` either way, since a reader who has read "2
+     The exact clock time rides the `title` on both dates, since a reader who has read "2
      hours ago" off a server-rendered page may want to know how old the page is.
      Rendered twice, one visible at a time (the caller passes the display class): to the
      right of the provenance line from lg, and under the title below it, where that line is
      a single non-wrapping row whose company name is already truncating to fit. -->
-{#snippet postingDates(className: string)}
-  {#if posted}
+{#snippet postingMeta(className: string)}
+  {#if posted || views > 0 || applies > 0}
     <div class={`items-center gap-x-3 text-xs text-muted-foreground ${className}`}>
+      {#if posted}
       <span
         class="inline-flex items-center gap-1 whitespace-nowrap"
         title={`Posted ${formatDateTime(job.posted_at)}`}
@@ -463,6 +470,22 @@
           <RefreshCw class="size-3.5 shrink-0" aria-hidden="true" />
           <span class="sr-only">Updated</span>
           <time datetime={job.updated_at}>{updated}</time>
+        </span>
+      {/if}
+      {/if}
+      <!-- A zero counter is omitted rather than drawn: "0 views" on a posting nobody has
+           opened yet measures our own traffic, not the job. -->
+      {#if views > 0}
+        <span class="inline-flex items-center gap-1 whitespace-nowrap">
+          <Eye class="size-3.5 shrink-0" aria-hidden="true" />
+          {views}
+          {views === 1 ? 'view' : 'views'}
+        </span>
+      {/if}
+      {#if applies > 0}
+        <span class="inline-flex items-center gap-1 whitespace-nowrap">
+          <Check class="size-3.5 shrink-0" aria-hidden="true" />
+          {applies} applied
         </span>
       {/if}
     </div>
@@ -505,7 +528,7 @@
      `hidden lg:flex`: below lg the sticky bottom bar carries the apply CTA instead, and
      auto-apply has no button there at all. -->
 {#snippet ctaGroup()}
-  <div class="ml-auto hidden shrink-0 items-center gap-2 lg:flex">
+  <div class="hidden shrink-0 items-center justify-end gap-2 lg:flex">
     {@render autoApplyCta('shrink-0')}
     {@render applyCta('md', 'shrink-0', cta.external)}
   </div>
@@ -643,7 +666,7 @@
 
     <!-- `ml-auto` rather than a grid column: the badges above are a variable-width group,
          so the dates take whatever is left of the line and sit against its right edge. -->
-    {@render postingDates('ml-auto hidden shrink-0 lg:flex')}
+    {@render postingMeta('ml-auto hidden shrink-0 lg:flex')}
   </div>
 
   <header class="flex flex-col gap-3 lg:col-start-2 lg:row-start-2">
@@ -656,16 +679,19 @@
           <CheckCircle2 class="size-3.5" aria-hidden="true" /> Applied
         </Chip>
       {/if}
-      <!-- `ml-auto` inside the snippet, so the buttons take the right edge of the title's
-           own row. The row wraps, so a long title pushes them onto a line of their own
-           rather than truncating either. -->
-      {@render ctaGroup()}
     </div>
+
+    <!-- The CTAs take a row of their own under the title rather than riding its right
+         edge: the title is the longest string on the page and the buttons are the widest
+         fixed thing beside it, so sharing a line meant a two-word title left them adrift in
+         the middle of the page and a long one pushed them down anyway. Right-aligned, so
+         they land above the quiet strip's own right edge on the tab row below. -->
+    {@render ctaGroup()}
 
     <!-- Below lg the provenance line is a single non-wrapping row already truncating the
          company name, so the dates read here instead — a caption under the title rather
          than right-aligned, which on one phone-width column would only look adrift. -->
-    {@render postingDates('flex lg:hidden')}
+    {@render postingMeta('flex lg:hidden')}
 
     <!-- Below lg the strip rides here rather than on the tab row: the sidebar stacks
          between the title and the description on a phone, so a strip left down there
@@ -743,33 +769,26 @@
         </dl>
       {/if}
 
-      <div class="flex flex-col gap-2 border-t border-border pt-4 first:border-t-0 first:pt-0">
-        <div class="flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 text-xs text-muted-foreground">
+      <!-- Where the posting came from. One row since the engagement counters left it for
+           the provenance line up beside the title; the `flex-col` wrapper that held the two
+           apart went with them. -->
+      <div
+        class="flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 border-t border-border pt-4 text-xs text-muted-foreground first:border-t-0 first:pt-0"
+      >
 <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal /jobs filter link from filterHref; query-only, no route to resolve -->
-          <a href={filterHref('source', job.source)} class="inline-flex">
-            <Badge variant="outline" class="transition-colors hover:bg-accent hover:text-foreground">
-              {job.source}
-            </Badge>
-          </a>
-          {#if job.source === 'adzuna'}
-            <!-- Required by Adzuna's API terms, not a courtesy credit — see the component. It
-                 sits in the provenance row beside the source chip, which is where a reader
-                 already looks to find out where a posting came from. -->
-            <AdzunaAttribution jobUrl={job.url} />
-          {/if}
-          {#if job.manually_added}
-            <Badge variant="secondary">Manually added</Badge>
-          {/if}
-        </div>
-        {#if views > 0 || applies > 0}
-          <div class="flex flex-wrap items-center justify-center gap-3 text-xs leading-none text-muted-foreground">
-            {#if views > 0}
-              <span class="inline-flex items-center gap-1"><Eye class="size-3.5 shrink-0" />{views} {views === 1 ? 'view' : 'views'}</span>
-            {/if}
-            {#if applies > 0}
-              <span class="inline-flex items-center gap-1"><Check class="size-3.5 shrink-0" />{applies} applied</span>
-            {/if}
-          </div>
+        <a href={filterHref('source', job.source)} class="inline-flex">
+          <Badge variant="outline" class="transition-colors hover:bg-accent hover:text-foreground">
+            {job.source}
+          </Badge>
+        </a>
+        {#if job.source === 'adzuna'}
+          <!-- Required by Adzuna's API terms, not a courtesy credit — see the component. It
+               sits in the provenance row beside the source chip, which is where a reader
+               already looks to find out where a posting came from. -->
+          <AdzunaAttribution jobUrl={job.url} />
+        {/if}
+        {#if job.manually_added}
+          <Badge variant="secondary">Manually added</Badge>
         {/if}
       </div>
 

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -5,7 +5,7 @@
   import { ArrowRight, Bookmark, Check, CheckCircle2, Eye, Flag, MessageSquare } from '@lucide/svelte';
   import { ApiError, api } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
-  import { autoApplyButtonState, jobCtaPlan } from '$lib/autoApplyButton';
+  import { autoApplyButtonState, jobCtaPlan, undemotedExternalCta } from '$lib/autoApplyButton';
   import { onboardingUrl } from '$lib/onboardingGate.svelte';
   import { promptSignIn } from '$lib/signin';
   import { filterHref, formatSalary, requirementGroups, summaryFacets } from '$lib/enrichment';
@@ -298,11 +298,6 @@
   // where they unit-test without mounting this component.
   const cta = $derived(jobCtaPlan(autoApplyState));
 
-  // The two bars that carry the apply link WITHOUT an auto-apply button beside it — the
-  // pinned desktop header and the mobile sticky bar — never demote it. "Show origin" steps
-  // aside for auto-apply, and in a bar that does not offer auto-apply it would step aside
-  // for nothing the reader can reach from there.
-  const undemotedExternalCta = { label: 'Apply', primary: true } as const;
 
   async function onAutoApplyClick() {
     if (!isAuthenticated()) {
@@ -323,9 +318,11 @@
   }
 </script>
 
-<!-- The link out to the posting's own site. Renders twice: beside the title on desktop,
-     and in the mobile sticky bar at the end of the article. Size, layout classes and the
-     `external` half of the CTA plan are what differ, so both share this snippet.
+<!-- The link out to the posting's own site. Renders three times: beside the title on
+     desktop, in the pinned header once that title scrolls away, and in the mobile sticky
+     bar at the end of the article. Size, layout classes and the `external` half of the CTA
+     plan are what differ, so all three share this snippet — and only the mobile bar passes
+     a plan of its own (`undemotedExternalCta`), since auto-apply has no button there.
      `external` decides only the word and the loudness — the destination, the target and
      the click handler are the same button either way, which is what keeps the apply-intent
      event comparable across postings whether or not auto-apply offered to do it instead.
@@ -358,8 +355,11 @@
      in flight also disables it, which is a fact about THIS component's request rather than
      about the posting.
      The `Pro` marker is a span, not the `Badge` primitive: Badge's variants carry their own
-     background and foreground, none of which are legible on `bg-brand`. Styling it from the
-     button's own foreground token instead makes it follow the button into either theme. -->
+     background and foreground, none of which read as a plan marker on `bg-brand`. It takes
+     the PAGE's `foreground` for its fill and `background` for its text — near-black on
+     white in the light theme, near-white on black in the dark one — so it stays the highest
+     contrast thing on a brand-green button in either. A tint of the button's own foreground
+     was the first try and it dissolved into the fill. -->
 {#snippet autoApplyCta(className: string)}
   {#if cta.autoApply}
     {@const button = cta.autoApply}
@@ -373,7 +373,7 @@
       {button.label}
       {#if button.pro}
         <span
-          class="rounded-sm bg-brand-foreground/15 px-1.5 py-0.5 text-xs font-semibold uppercase leading-none tracking-wide"
+          class="rounded-sm bg-foreground px-1.5 py-0.5 text-xs font-semibold uppercase leading-none tracking-wide text-background"
         >
           Pro
         </span>
@@ -382,9 +382,10 @@
   {/if}
 {/snippet}
 
-<!-- Save, a quiet peer of the apply CTA rather than the full-width button it was in the
-     sidebar: it belongs beside "Apply", because keeping a job and opening it are the two
-     things a reader does with one. The filled bookmark is the state.
+<!-- Save, a quiet action rather than the full-width button it was in the sidebar: keeping a
+     posting is something a reader does in passing, not the thing the page is for. It sits
+     with the other quiet ones on the tab row, and beside the apply CTA in the pinned header,
+     which has room for one bookmark and not for four. The filled bookmark is the state.
      `iconOnly` is for the pinned header, whose one line already holds the company, the
      title and the CTA; aria-label and the tooltip name the button either way. -->
 {#snippet saveButton(className = '', iconOnly = false)}
@@ -822,10 +823,14 @@
           <!-- Hidden below lg for the same reason as the action strip's own copy: on
                mobile the CTA is the sticky bottom bar, and two pinned buttons would
                fight. Save comes along, since this bar is what a reader has in front of
-               them for most of a description several screens long. -->
+               them for most of a description several screens long.
+               It carries the SAME pair as the header, plan and all — this bar is the header
+               for most of the read, and a brand-filled `Apply` here for the link the title
+               row calls a quiet `Show origin` would be one link at two ranks on one page. -->
           <div class="hidden shrink-0 items-center gap-2 lg:flex">
             {@render saveButton('size-9 rounded-md px-0', true)}
-            {@render applyCta('md', 'shrink-0', undemotedExternalCta)}
+            {@render autoApplyCta('shrink-0')}
+            {@render applyCta('md', 'shrink-0', cta.external)}
           </div>
         </div>
       </div>
@@ -860,12 +865,14 @@
       {@render actionStrip('hidden border-b border-border pb-2 lg:flex')}
     </div>
 
-    <!-- The three states of one exchange, below the action strip because that strip is
-         what raised the question: Apply was clicked there, so the answer belongs under
-         the hand that asked rather than back up beside the title. They share one slot so
-         that answering "Yes, save" replaces the question in place — split across the
-         page, the confirmation would read as a second, unrelated banner appearing
-         somewhere the reader was not looking. -->
+    <!-- The three states of one exchange. They sit at the top of the content column rather
+         than beside the CTA that raised them: the question follows a click that opened a
+         NEW TAB, so the reader meets it on returning to this one, and the first thing under
+         the tabs is what a returning eye lands on. It is also the widest slot on the page,
+         which a two-button question needs and the title row — already carrying the CTAs —
+         does not have. They share one slot so that answering "Yes, save" replaces the
+         question in place; split across the page, the confirmation would read as a second,
+         unrelated banner appearing somewhere the reader was not looking. -->
     {#if showApplyPrompt && !applied}
       <div
         class="flex flex-wrap items-center justify-between gap-3 rounded-md border border-border bg-secondary px-4 py-3"

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -8,6 +8,7 @@
     Check,
     CheckCircle2,
     Clock,
+    ExternalLink,
     Eye,
     Flag,
     MessageSquare,
@@ -15,7 +16,7 @@
   } from '@lucide/svelte';
   import { ApiError, api } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
-  import { autoApplyButtonState, jobCtaPlan, undemotedExternalCta } from '$lib/autoApplyButton';
+  import { autoApplyButtonState, jobCtaPlan, type JobCtaPlan } from '$lib/autoApplyButton';
   import { onboardingUrl } from '$lib/onboardingGate.svelte';
   import { promptSignIn } from '$lib/signin';
   import { filterHref, formatSalary, requirementGroups, summaryFacets } from '$lib/enrichment';
@@ -308,7 +309,6 @@
   // where they unit-test without mounting this component.
   const cta = $derived(jobCtaPlan(autoApplyState));
 
-
   async function onAutoApplyClick() {
     if (!isAuthenticated()) {
       promptSignIn();
@@ -340,11 +340,7 @@
      vetted — the same stance the description sanitizer takes on in-body links
      (internal/sources/sanitize.go). Without it a submitted vacancy buys a followed
      link from every job page, which is what the SEO submissions are actually after. -->
-{#snippet applyCta(
-  size: 'md' | 'lg',
-  className: string,
-  external: { label: string; primary: boolean },
-)}
+{#snippet applyCta(size: 'md' | 'lg', className: string, external: JobCtaPlan['external'])}
   <Button
     variant={external.primary ? 'primary' : 'outline'}
     {size}
@@ -370,18 +366,18 @@
      white in the light theme, near-white on black in the dark one — so it stays the highest
      contrast thing on a brand-green button in either. A tint of the button's own foreground
      was the first try and it dissolved into the fill. -->
-{#snippet autoApplyCta(className: string)}
+{#snippet autoApplyCta(size: 'md' | 'lg', className: string)}
   {#if cta.autoApply}
-    {@const button = cta.autoApply}
+    {@const autoApply = cta.autoApply}
     <Button
-      variant={button.primary ? 'primary' : 'secondary'}
-      size="md"
-      disabled={button.disabled || autoApplySubmitting}
+      variant={autoApply.primary ? 'primary' : 'secondary'}
+      {size}
+      disabled={autoApply.disabled || autoApplySubmitting}
       onclick={onAutoApplyClick}
       class={className}
     >
-      {button.label}
-      {#if button.pro}
+      {autoApply.label}
+      {#if autoApply.pro}
         <span
           class="rounded-sm bg-foreground px-1.5 py-0.5 text-xs font-semibold uppercase leading-none tracking-wide text-background"
         >
@@ -454,24 +450,24 @@
   {#if posted || views > 0 || applies > 0}
     <div class={`items-center gap-x-3 text-xs text-muted-foreground ${className}`}>
       {#if posted}
-      <span
-        class="inline-flex items-center gap-1 whitespace-nowrap"
-        title={`Posted ${formatDateTime(job.posted_at)}`}
-      >
-        <Clock class="size-3.5 shrink-0" aria-hidden="true" />
-        <span class="sr-only">Posted</span>
-        <time datetime={job.posted_at}>{posted}</time>
-      </span>
-      {#if updated && updated !== posted}
         <span
           class="inline-flex items-center gap-1 whitespace-nowrap"
-          title={`Updated ${formatDateTime(job.updated_at)}`}
+          title={`Posted ${formatDateTime(job.posted_at)}`}
         >
-          <RefreshCw class="size-3.5 shrink-0" aria-hidden="true" />
-          <span class="sr-only">Updated</span>
-          <time datetime={job.updated_at}>{updated}</time>
+          <Clock class="size-3.5 shrink-0" aria-hidden="true" />
+          <span class="sr-only">Posted</span>
+          <time datetime={job.posted_at}>{posted}</time>
         </span>
-      {/if}
+        {#if updated && updated !== posted}
+          <span
+            class="inline-flex items-center gap-1 whitespace-nowrap"
+            title={`Updated ${formatDateTime(job.updated_at)}`}
+          >
+            <RefreshCw class="size-3.5 shrink-0" aria-hidden="true" />
+            <span class="sr-only">Updated</span>
+            <time datetime={job.updated_at}>{updated}</time>
+          </span>
+        {/if}
       {/if}
       <!-- A zero counter is omitted rather than drawn: "0 views" on a posting nobody has
            opened yet measures our own traffic, not the job. -->
@@ -517,6 +513,24 @@
     {@render reportButton()}
     {@render saveButton()}
     <AddToListButton jobSlug={job.public_slug} />
+    <!-- The link out, phone only. Below lg the sticky bottom bar belongs to auto-apply
+         whenever auto-apply can be started, so the posting's own page needs a door
+         somewhere else — and this strip is where the quiet things already are. On lg the
+         same link is a button up beside the title, so this copy stays hidden rather than
+         offering it twice. Same handler as that button: one click, one apply-intent event,
+         whichever copy the reader reached. -->
+    {#if cta.autoApply?.primary}
+      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- the posting's own URL on its employer's site; there is no route to resolve --><a
+        href={job.url}
+        class="inline-flex shrink-0 items-center gap-1.5 px-2 text-sm font-medium text-muted-foreground hover:text-foreground lg:hidden"
+        target="_blank"
+        rel="nofollow noopener noreferrer"
+        onclick={onApplyClick}
+      >
+        <ExternalLink class="size-4 shrink-0" aria-hidden="true" />
+        {cta.external.label}
+      </a>
+    {/if}
   </div>
 {/snippet}
 
@@ -529,7 +543,7 @@
      auto-apply has no button there at all. -->
 {#snippet ctaGroup()}
   <div class="hidden shrink-0 items-center justify-end gap-2 lg:flex">
-    {@render autoApplyCta('shrink-0')}
+    {@render autoApplyCta('md', 'shrink-0')}
     {@render applyCta('md', 'shrink-0', cta.external)}
   </div>
 {/snippet}
@@ -701,7 +715,13 @@
          between the employer and the role. Right-aligned like the lg copy beside the
          tabs, so the strip reads the same on both; `-mr-2` cancels the last button's
          own padding, lining its right edge up with the column's. -->
-    {@render actionStrip('-mr-2 flex w-full justify-end border-b border-border pb-2 lg:hidden')}
+    <!-- `flex-wrap` only on this copy: the phone's strip carries a fifth item the tab row's
+         does not (the link out), and five labels do not fit one phone-width line — without
+         it the row simply overflowed its left edge and ate "Discussion". The lg copy shares
+         a line with the TabStrip and must not wrap. -->
+    {@render actionStrip(
+      '-mr-2 flex w-full flex-wrap justify-end border-b border-border pb-2 lg:hidden',
+    )}
 
     <!-- The ghost row supersedes the reality chip (see JobRow). It states the signal
          once for the whole page: a gauge and the hedged wording here, the criteria and
@@ -867,7 +887,7 @@
                row calls a quiet `Show origin` would be one link at two ranks on one page. -->
           <div class="hidden shrink-0 items-center gap-2 lg:flex">
             {@render saveButton('size-9 rounded-md px-0', true)}
-            {@render autoApplyCta('shrink-0')}
+            {@render autoApplyCta('md', 'shrink-0')}
             {@render applyCta('md', 'shrink-0', cta.external)}
           </div>
         </div>
@@ -1001,15 +1021,24 @@
        frosted-glass panel (semi-transparent bg + backdrop-blur), full-bleed via
        negative margins that cancel the page gutter. pointer-events-none lets the
        description scroll under the glass, with pointer-events-auto re-enabling the
-       button. Desktop uses the inline header button instead (hidden at lg). -->
+       button. Desktop uses the inline header button instead (hidden at lg).
+       It carries whichever of the two controls the plan made primary — auto-apply where
+       that can be started, the apply link everywhere else — because this bar IS the phone's
+       call to action, and naming exactly one is the plan's whole job. The other control
+       does not vanish: the quiet strip under the title picks the apply link up whenever
+       auto-apply has taken this bar. -->
   <div
     class="pointer-events-none sticky bottom-0 z-30 -mx-5 border-t border-border/40 bg-background/15 px-5 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-3 backdrop-blur-lg sm:-mx-4 sm:px-4 lg:hidden"
   >
-    {@render applyCta(
-      'lg',
-      'pointer-events-auto w-full rounded-xl font-semibold shadow-lg',
-      undemotedExternalCta,
-    )}
+    {#if cta.autoApply?.primary}
+      {@render autoApplyCta('lg', 'pointer-events-auto w-full rounded-xl font-semibold shadow-lg')}
+    {:else}
+      {@render applyCta(
+        'lg',
+        'pointer-events-auto w-full rounded-xl font-semibold shadow-lg',
+        cta.external,
+      )}
+    {/if}
   </div>
 </article>
 

--- a/web/src/lib/components/RealityBadge.svelte
+++ b/web/src/lib/components/RealityBadge.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { realityBadge, postingContrast } from '$lib/reality';
+  import { realityBadge } from '$lib/reality';
   import type { Reality } from '$lib/generated/contracts';
   import { cn } from '$lib/ui';
 
@@ -9,20 +9,19 @@
   // inline when `detailed`), never a bare accusation. `detailed` renders complementary
   // facts beside the chip on the job detail page — deliberately NOT the age, which the
   // chip already carries, so "Open N days" never reads twice in a row.
+  //
+  // Nor the posting date. It used to add a "posting dated N ago" note here, which on the
+  // detail page landed on the same line as that page's own posting date and printed the
+  // identical phrase twice; the contrast that note existed to draw — a long-open role whose
+  // source rewrites its date every crawl — is already visible in the age chip standing
+  // beside the date.
   let {
     reality,
-    postedAt = null,
     detailed = false,
-  }: { reality?: Reality | null; postedAt?: string | null; detailed?: boolean } = $props();
+  }: { reality?: Reality | null; detailed?: boolean } = $props();
 
   const badge = $derived(realityBadge(reality));
-  // The posting-date contrast (when the source's date reads fresher than the true age)
-  // followed by the remaining evidence; empty when neither applies (chip shows alone).
-  const detail = $derived(
-    badge && reality
-      ? [postingContrast(reality, postedAt), badge.evidence].filter(Boolean).join(' · ')
-      : '',
-  );
+  const detail = $derived(badge?.evidence ?? '');
 
   const toneClass: Record<'warn' | 'muted', string> = {
     warn: 'border-warning/40 bg-warning/10 text-warning-strong',

--- a/web/src/lib/reality.test.ts
+++ b/web/src/lib/reality.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { realityBadge, postingContrast } from './reality';
+import { realityBadge } from './reality';
 import type { Reality } from './generated/contracts';
 
 const base = (over: Partial<Reality>): Reality => ({
@@ -11,7 +11,6 @@ const base = (over: Partial<Reality>): Reality => ({
   ...over,
 });
 
-const daysAgo = (n: number) => new Date(Date.now() - n * 86_400_000).toISOString();
 
 describe('realityBadge', () => {
   it('returns null for a fresh job (no badge)', () => {
@@ -52,23 +51,5 @@ describe('realityBadge', () => {
   it('leaves the evidence empty when a stale job has no evidence beyond its age', () => {
     const b = realityBadge(base({ class: 'stale', age_days: 30 }));
     expect(b?.evidence).toBe('');
-  });
-});
-
-describe('postingContrast', () => {
-  it('surfaces the posting date when it reads clearly fresher than the true age', () => {
-    const note = postingContrast(base({ age_days: 30 }), daysAgo(2));
-    expect(note).toContain('posting dated');
-    expect(note.toLowerCase()).toContain('day');
-  });
-
-  it('stays silent when the posting date roughly matches the true age', () => {
-    expect(postingContrast(base({ age_days: 20 }), daysAgo(18))).toBe('');
-  });
-
-  it('stays silent without a posting date or with an unparseable one', () => {
-    expect(postingContrast(base({ age_days: 30 }), null)).toBe('');
-    expect(postingContrast(base({ age_days: 30 }), undefined)).toBe('');
-    expect(postingContrast(base({ age_days: 30 }), 'not-a-date')).toBe('');
   });
 });

--- a/web/src/lib/reality.ts
+++ b/web/src/lib/reality.ts
@@ -1,5 +1,4 @@
 import type { Reality } from './generated/contracts';
-import { timeAgo } from './utils';
 
 /** A rendered job-reality badge: a tone and a compact chip label, plus two fuller
  *  strings. `tooltip` is the complete justification (age + evidence) shown on hover;
@@ -36,20 +35,4 @@ export function realityBadge(reality?: Reality | null): RealityBadge | null {
   }
   // stale
   return { tone: 'muted', label: `Open ${reality.age_days}d`, tooltip, evidence };
-}
-
-/** postingContrast returns a "posting dated N ago" note when the source's posting date
- *  reads meaningfully fresher than the job's true age — the refreshed-date story the
- *  age label alone hides ("open 21 days, but posting dated 2 days ago"). '' when there
- *  is no posting date, it is unparseable, or the gap is too small to be worth stating. */
-export function postingContrast(reality: Reality, postedAt?: string | null): string {
-  if (!postedAt) return '';
-  const d = new Date(postedAt);
-  if (Number.isNaN(d.getTime())) return '';
-  const postedDays = Math.floor((Date.now() - d.getTime()) / 86_400_000);
-  // The badge only shows for non-fresh jobs (age > 14d); a posting reading a clear
-  // week fresher than that true age is the contrast worth surfacing.
-  if (reality.age_days - postedDays < 7) return '';
-  const ago = timeAgo(postedAt);
-  return ago ? `posting dated ${ago}` : '';
 }

--- a/web/src/lib/utils.test.ts
+++ b/web/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { formatCount, formatDate, formatDateOrAgo } from './utils';
+import { formatCount, formatDate, formatDateOrAgo, timeAgo } from './utils';
 
 // formatCount lives here rather than in activityChart because its callers share nothing
 // with a chart module: two axis labels (activity bars, skill pulse) and the job card's
@@ -83,5 +83,28 @@ describe('formatDateOrAgo', () => {
     expect(formatDateOrAgo(null)).toBe('');
     expect(formatDateOrAgo(undefined)).toBe('');
     expect(formatDateOrAgo('not a date')).toBe('');
+  });
+
+  // The short style is for a label an icon has already named, so the unit may be
+  // abbreviated but the NUMBER and the direction must survive. Asserted by shape rather
+  // than by string: `Intl` owns the abbreviation, and pinning "30 min. ago" here would be
+  // this repo asserting a CLDR spelling it does not control.
+  it('abbreviates the unit in the short style without losing the number', () => {
+    const long = formatDateOrAgo(at(0.5));
+    const short = formatDateOrAgo(at(0.5), 'short');
+    expect(short).toContain('30');
+    expect(short.length).toBeLessThan(long.length);
+    expect(timeAgo(at(3), 'short')).toContain('3');
+  });
+
+  // Past the day boundary the short style has nothing to shorten — it is a date either
+  // way, and a date the reader compares against another posting's must not be abbreviated
+  // out from under them.
+  it('leaves the date branch alone', () => {
+    expect(formatDateOrAgo(at(24), 'short')).toBe(formatDate(at(24)));
+  });
+
+  it('defaults to the long style', () => {
+    expect(formatDateOrAgo(at(3))).toBe(timeAgo(at(3)));
   });
 });

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -87,20 +87,29 @@ const TIME_UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
   ['second', 1],
 ];
 
-// Built once: constructing an Intl formatter resolves a locale and loads its
+/** How much of the unit gets spelled out. `short` is for a label something else has
+ *  already named — an icon, a column heading — where "8 min. ago" says everything
+ *  "8 minutes ago" did in half the room. Abbreviating is `Intl`'s job and not ours: a
+ *  hand-written "min" is correct in two languages and wrong in the rest. */
+export type TimeAgoStyle = 'long' | 'short';
+
+// Built once each: constructing an Intl formatter resolves a locale and loads its
 // data, which dwarfs formatting with one — and the feed calls timeAgo per job
 // card. The locale is the runtime default, which cannot change within a process
-// or a browser session, so one instance is safe to share.
-let relativeTime: Intl.RelativeTimeFormat | undefined;
+// or a browser session, so one instance per style is safe to share.
+const relativeTime: Partial<Record<TimeAgoStyle, Intl.RelativeTimeFormat>> = {};
 
 /** Format an RFC3339 timestamp as a relative "N ago" label (e.g. "13 seconds
  *  ago", "2 days ago"); '' for null/invalid. How recently a job was posted is a
  *  key signal, so the list card shows it relative rather than as a bare date. */
-export function timeAgo(ts: string | null | undefined): string {
+export function timeAgo(ts: string | null | undefined, style: TimeAgoStyle = 'long'): string {
   const d = parseTs(ts);
   if (!d) return '';
   const seconds = Math.round((Date.now() - d.getTime()) / 1000);
-  const rtf = (relativeTime ??= new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' }));
+  const rtf = (relativeTime[style] ??= new Intl.RelativeTimeFormat(undefined, {
+    numeric: 'auto',
+    style,
+  }));
   for (const [unit, span] of TIME_UNITS) {
     if (Math.abs(seconds) >= span || unit === 'second') {
       return rtf.format(-Math.round(seconds / span), unit);
@@ -117,10 +126,14 @@ const RECENT_MS = 86400 * 1000;
 /** timeAgo while the instant is still within the last day, formatDate once it is
  *  not; '' for null/invalid, like both. A timestamp in the FUTURE takes the date
  *  branch: "in 2 hours" on a posting date is a clock-skew artefact, and reading it
- *  as an age would be worse than reading it as a date. */
-export function formatDateOrAgo(ts: string | null | undefined): string {
+ *  as an age would be worse than reading it as a date.
+ *
+ *  `style` reaches only the relative branch. Past the day boundary there is nothing to
+ *  abbreviate, and a date a reader is comparing against another posting's must not be
+ *  shortened out from under them. */
+export function formatDateOrAgo(ts: string | null | undefined, style: TimeAgoStyle = 'long'): string {
   const d = parseTs(ts);
   if (!d) return '';
   const age = Date.now() - d.getTime();
-  return age >= 0 && age < RECENT_MS ? timeAgo(ts) : formatDate(ts);
+  return age >= 0 && age < RECENT_MS ? timeAgo(ts, style) : formatDate(ts);
 }


### PR DESCRIPTION
## Why

The job page's action strip had grown from three controls to six and shared one row
with the content `TabStrip`. The strip is `shrink-0`; the tabs are the half that
yields — so on a desktop column the tab row was squeezed to a scrolling sliver and
"Applications" read as "Applicat…" with the Discussion link fading over it.

The same row also stated the wrong priority: the loudest button on the page was the
one that hands the reader to somebody else's site, while auto-apply — Pro-only, and
the thing this page exists to sell — sat beside it in grey.

## What changed

**Layout.** The two CTAs leave the tab row for a row of their own under the title,
right-aligned. The tab row keeps Discussion, Report, Save and Add-to-list, and the
tabs get their width back.

**Rank.** Auto-apply takes the brand fill wherever it can be started, with a `Pro`
marker naming the plan it needs. The external link steps aside as an outline
`Show origin` — keeping its destination, its `rel`, its target and its apply-intent
tracking. Which of the two is loud is a six-state table in `autoApplyButton.ts`,
beside the state machine it reads, unit-tested without mounting the component.

Two invariants the table exists to protect, and what they caught:

- **Never two primaries; one wherever an action remains.** `declined` and `failed` —
  where the robot has given up and applying by hand is the only way forward — hand
  the primary slot BACK to the external button. `queued` is the one state with none:
  a submission is in flight and a loud button would only invite a duplicate.
- **`Pro` only on a button that can be pressed.**

**`applied` does not demote.** It comes from the "Did you apply?" prompt after a
*manual* click-through and is true of a posting from any source, while the table only
runs on the ones auto-apply can drive — so demoting on it made a Greenhouse posting
read differently from an identical Lever one for a reader in the identical situation.

**The phone gets auto-apply.** It had none. The sticky bottom bar now carries whichever
control the plan made primary, and the link it displaces joins the quiet strip beside
Save. All four render sites (title row, pinned header, mobile bar, quiet strip) read
one plan — which let the `undemotedExternalCta` exception be deleted rather than
extended.

**Provenance.** The header stated the posting's date three times; two of them were the
identical phrase. The contrast note beside the reality badge is gone (its function and
the prop feeding it removed, not left unreachable) — the age chip and the date sit on
one line, which *is* that contrast. The dates now read as a clock and a refresh icon
with a short relative time, the words kept in the accessible name and the exact instant
in the tooltip; the abbreviation is `Intl`'s, via a new optional short style on
`timeAgo`/`formatDateOrAgo`. The view and applied counters join them, leaving the
sidebar.

## Known trade-off

A signed-out reader now meets a brand-filled `Auto-apply PRO` as the page's loudest
control, and clicking it only opens the sign-in prompt — while the link that does what
they came for reads `Show origin`. Signed-out traffic is most of this page's traffic.
Kept deliberately (the page is where the Pro feature is advertised), argued in
`design.md`, and flagged as the first thing to measure. Falling back to a plain `Apply`
while signed out is a one-line change if the funnel says so.

## Verification

- `pnpm --dir web test` — 1582 pass, including 14 for the CTA table.
- `pnpm --dir web lint` and `svelte-check` — clean.
- Checked in a browser at 1440px, 1024px and iPhone 14, in both themes, on a Greenhouse
  posting and a non-Greenhouse one, plus the pinned header on scroll.

Spec: `openspec/changes/job-page-cta-hierarchy/`.
