### PR TITLE
Add a Status link to the footer

### DIFF
--- a/web/src/lib/components/Footer.svelte
+++ b/web/src/lib/components/Footer.svelte
@@ -59,6 +59,7 @@
         { label: 'For companies', href: resolve('/for-companies') },
         { label: 'Contribute', href: resolve('/contribute') },
         { label: 'Submit a job', href: resolve('/submit') },
+        { label: 'Status', href: resolve('/status') },
         { label: 'Privacy', href: resolve('/privacy') },
         { label: 'Terms', href: resolve('/terms') },
       ],


### PR DESCRIPTION
## Summary
- Adds a "Status" link (`/status`, resolves to freehire.me/status) to the footer's Company link group, next to the other policy/info pages.

## Test plan
- [ ] Visually check the footer renders the new link in the Company column and it navigates to `/status`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Status” link to the Company section in the footer, providing direct access to the service status page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->