### PR TITLE
Put the similar-jobs backfill on a timer, so migrations can get a lock

### DIFF
--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -10,7 +10,7 @@ Snapshot taken 2026-09-05 from `/etc/systemd/system/freehire-*`, `/opt/freehire/
 ## What is here
 
 ```
-systemd/   382 files — 53 .service, 324 .timer, 5 drop-in directories
+systemd/   384 files — 54 .service, 325 .timer, 5 drop-in directories
 bin/        16 operator scripts (release, autodeploy, backups, alerting, ingest slotting)
 nginx/       1 snippet — snippets/freehire-app.conf, hand-edited, not generated
 ```
@@ -24,9 +24,20 @@ teach the reader to ignore the tool.
 
 `systemd/freehire-ingest@.service` is one template; the `freehire-ingest@<provider>.timer`
 files beside it are per-provider schedules, which is why the timer count dwarfs everything
-else. `bin/gen-ingest-timers.sh` writes them from the board catalog
+else.
+
+`bin/gen-ingest-timers.sh` writes them from the board catalog
 (`SELECT provider FROM boards WHERE status IN ('pending','active')`) — it is not run by
 anything, so a new provider means running it on the host.
+
+**`freehire-similarw` is here because an unbounded worker blocks every DDL migration.**
+The similar-jobs backfill ran as a hand-started transient unit for five days; its page
+query holds ACCESS SHARE on `jobs` for ~95s at a time, so `cmd/migrate` never got the
+ACCESS EXCLUSIVE an `ALTER TABLE` needs and `release.sh` failed twice on 2026-09-05
+(55P03 on migration 0139). It is a bounded slice on a timer now — the ~5 quiet minutes in
+every 20 are what a migration gets in through. If a release still fails that way, look for
+another long reader on `jobs` before blaming the migration:
+`SELECT pid, state, now()-xact_start, query FROM pg_stat_activity WHERE xact_start IS NOT NULL ORDER BY 3 DESC;`
 
 **Both are being retired.** `freehire-ingest-scheduler.timer` runs
 `cmd/ingest-scheduler` once a minute, which reads the same catalog and starts each due run

--- a/deploy/systemd/freehire-similarw.service
+++ b/deploy/systemd/freehire-similarw.service
@@ -1,0 +1,42 @@
+[Unit]
+Description=freehire worker: similar-jobs backfill (bounded slice)
+After=network.target postgresql.service
+[Service]
+Type=oneshot
+User=freehire
+WorkingDirectory=/opt/freehire/src/hire-current
+EnvironmentFile=/opt/freehire/.env
+# Light: this is catch-up work with no deadline, and it runs beside a live API.
+CPUWeight=10
+IOWeight=10
+# THE POINT OF THIS UNIT IS THAT IT ENDS.
+#
+# This backfill used to run as one unbounded transient unit (`systemd-run`, started by
+# hand 2026-08-31). Its page query holds ACCESS SHARE on `jobs` for ~95s at a time and
+# with several workers overlapping there was, in practice, never a moment when nobody
+# held it. An ALTER TABLE needs ACCESS EXCLUSIVE, so `cmd/migrate` sat behind those
+# readers until its lock_timeout expired: on 2026-09-05 the release script failed twice
+# in a row on migration 0139 (55P03), and the only way through was stopping this worker
+# by hand. At its observed rate it had WEEKS left to run, so that was not a one-off — it
+# was every migration for the next month, including the autodeploy's.
+#
+# A bounded run ends, the connection closes, and the lock goes with it. The gap the timer
+# leaves is what a DDL migration gets in through.
+#
+# 500 is measured, not guessed: on 2026-09-05 a slice at these exact settings ran 500 jobs
+# in 9m45s on this host — about 51 a minute — so the 20-minute timer leaves roughly ten
+# quiet minutes after each one. That costs perhaps a third of the unbounded worker's
+# throughput (~36k jobs a day against ~51k measured the same afternoon), which is the
+# price of every migration in the next month not failing.
+#
+# NOT RuntimeMaxSec: systemd ignores it for Type=oneshot and says so
+# (`systemd-analyze verify`). TimeoutStartSec is the one that bounds a oneshot, and it is
+# set at nearly twice the expected run so it fires only when something is genuinely
+# stuck — a slice ending on the timeout would be marked failed, and a unit that shows red
+# in normal operation is a unit nobody reads.
+#
+# Being killed mid-slice costs nothing either way. The worker asks for jobs that still
+# NEED the backfill, so an interrupted run leaves them for the next one — the same
+# property that made stopping it by hand safe.
+TimeoutStartSec=20min
+ExecStart=/opt/freehire/src/hire-current/similar-backfill -limit 500 -batch 200 -workers 3

--- a/deploy/systemd/freehire-similarw.timer
+++ b/deploy/systemd/freehire-similarw.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=timer: freehire-similarw every 20 min
+[Timer]
+# Monotonic, and the GAP is the feature. A 500-job slice took 9m45s on this host (measured
+# 2026-09-05) and the next starts 20 minutes after the last one BEGAN, so about ten
+# minutes in every twenty nothing holds a lock on `jobs` and a DDL migration can take the
+# ACCESS EXCLUSIVE it needs.
+#
+# OnUnitActiveSec, not OnCalendar: the gap has to follow the run, and a wall-clock slot
+# would start the next slice while a slow one was still going — exactly the overlap this
+# unit exists to remove.
+OnBootSec=5min
+OnUnitActiveSec=20min
+Persistent=true
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
The similar-jobs backfill ran as one unbounded transient unit, started by hand on
2026-08-31 and still going five days later. Its page query holds ACCESS SHARE on
`jobs` for ~95s at a time and with several workers overlapping there was, in
practice, never a moment when nobody held it.

An ALTER TABLE needs ACCESS EXCLUSIVE, so `cmd/migrate` sat behind those readers
until its lock_timeout expired. `release.sh` failed twice in a row today on
migration 0139 with 55P03, and the only way through was stopping this worker by
hand.

At its observed rate it had **weeks** left. So that was not a one-off - it was
every migration for the next month, the autodeploy included, failing for a reason
that looks nothing like its cause.

## The fix is that the run ends

A bounded slice ends, the connection closes, and the lock goes with it. The gap
is the feature. No code change - `cmd/similar-backfill` already takes `-limit`.

**The numbers are measured.** A 500-job slice ran in 9m45s on this host, so a
20-minute timer leaves about ten quiet minutes after each one. That costs roughly
a third of the throughput (~36k jobs a day against ~51k measured the same
afternoon) and buys back every migration. This is catch-up work with no deadline;
a blocked deploy is not.

**Not `RuntimeMaxSec`.** systemd ignores it for `Type=oneshot` and says so under
`systemd-analyze verify` - my first draft had exactly that dead bound in it.
`TimeoutStartSec` is the one that bounds a oneshot, set at nearly twice the
expected run so it fires only on genuine trouble: a slice ending on its own
timeout would be marked failed, and a unit that shows red in normal operation is
a unit nobody reads.

## Already live

`release.sh` never touches a unit, so these were copied to the host and the timer
enabled by hand. First slice ran 15:39-15:45 UTC, went inactive cleanly, next
fired on schedule; the transient worker is stopped. This PR is the record
catching up with the machine, which is what `deploy/` is for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added scheduled background processing for similar-job backfills, starting shortly after boot and recurring every 20 minutes.
  - Runs are limited in size and duration, with reduced resource priority to support predictable system performance.
  - Missed runs can be resumed after downtime.

- **Bug Fixes**
  - Reduced prolonged database locking from backfill processing, helping schema migrations complete more reliably.

- **Documentation**
  - Updated deployment documentation with the new scheduled worker details and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->