### PR TITLE
Give the profile a Level field, and point the checklist step at it

### DIFF
--- a/web/src/lib/accountCompleteness.test.ts
+++ b/web/src/lib/accountCompleteness.test.ts
@@ -55,6 +55,17 @@ describe('accountSteps', () => {
     });
   });
 
+  // The card itself is rendered on /my/profile, so the role step's link would otherwise
+  // point at the page the reader is already looking at — the anchor is what makes it move.
+  it('anchors the role step, since its own card shares that page', () => {
+    const byId = Object.fromEntries(accountSteps(empty).map((s) => [s.id, s.hash]));
+    expect(byId.role).toBe('account-role');
+    expect(byId.cv).toBeUndefined();
+    expect(byId.skills).toBeUndefined();
+    expect(byId.location).toBeUndefined();
+    expect(byId.alerts).toBeUndefined();
+  });
+
   it('counts a CV once one is stored', () => {
     expect(doneIds({ ...empty, hasCv: true })).toEqual(['cv']);
   });

--- a/web/src/lib/accountCompleteness.ts
+++ b/web/src/lib/accountCompleteness.ts
@@ -23,6 +23,12 @@ export interface CompletenessStep {
   id: string;
   label: string;
   href: SetupHref;
+  /** The id of the element on `href`'s page to land on, for a step whose page holds more
+   *  than the step asks for. Without it, the role step links to the page it is already
+   *  rendered on and nothing appears to happen. An opaque string rather than a type shared
+   *  with the page — this module stays free of any SvelteKit import (see `SetupHref`) — so
+   *  it must be kept in sync by hand with that element's `id`. */
+  hash?: string;
   done: boolean;
 }
 
@@ -71,6 +77,10 @@ export function accountSteps({ hasCv, profile, alertCount }: CompletenessInput):
       id: 'role',
       label: 'Say what you do, and at what level',
       href: '/my/profile',
+      // The card that carries this step is rendered on /my/profile itself, above two other
+      // blocks — so the link has to name the Role card or it is a link to where you already
+      // stand.
+      hash: 'account-role',
       done: Boolean(profile?.specializations.length && profile?.seniorities.length),
     },
     {

--- a/web/src/lib/components/AccountSetupCard.svelte
+++ b/web/src/lib/components/AccountSetupCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Check, ArrowRight } from '@lucide/svelte';
   import { resolve } from '$app/paths';
-  import { outstandingOf } from '$lib/accountCompleteness';
+  import { outstandingOf, type CompletenessStep } from '$lib/accountCompleteness';
   import { ensureAccountSetupLoaded, setupSteps } from '$lib/accountSetup.svelte';
 
   // "How complete is my account", above the profile page's section tabs — the page
@@ -20,6 +20,12 @@
   $effect(() => {
     ensureAccountSetupLoaded();
   });
+
+  // resolve()'s own base plus the step's anchor, when it names one — there is no dynamic
+  // route segment to resolve, so this is a plain suffix rather than a second resolve().
+  function stepHref(step: CompletenessStep): string {
+    return `${resolve(step.href)}${step.hash ? `#${step.hash}` : ''}`;
+  }
 </script>
 
 {#if outstanding.length > 0}
@@ -49,7 +55,8 @@
               <span class="line-through decoration-border">{step.label}</span>
             </p>
           {:else}
-            <a href={resolve(step.href)} class="group flex items-center gap-2 rounded-lg px-1 py-1.5 text-sm transition-colors hover:bg-accent">
+            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- stepHref() wraps resolve(step.href); the rule can't see through the appended #hash -->
+            <a href={stepHref(step)} class="group flex items-center gap-2 rounded-lg px-1 py-1.5 text-sm transition-colors hover:bg-accent">
               <span
                 class="size-4 shrink-0 rounded-full border border-dashed border-muted-foreground"
                 aria-hidden="true"

--- a/web/src/lib/components/profile/RoleCard.svelte
+++ b/web/src/lib/components/profile/RoleCard.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  // Role: specializations, editable inline — no separate "Role" tab to click into (it's
-  // the one piece of the old identity header that doesn't carry enough content to earn
-  // its own view, unlike Contacts/Location which do). Autosaves straight to profileStore
-  // on every change, the same way the Skills view does.
-  import { CATEGORY_OPTIONS } from '$lib/facets';
+  // Role: specializations and level, editable inline — no separate "Role" tab to click
+  // into (it's the one piece of the old identity header that doesn't carry enough content
+  // to earn its own view, unlike Contacts/Location which do). Autosaves straight to
+  // profileStore on every change, the same way the Skills view does.
+  import { CATEGORY_OPTIONS, SENIORITY_OPTIONS } from '$lib/facets';
   import { profileStore } from '$lib/profile.svelte';
   import { MAX_SPECIALIZATIONS } from '$lib/profileLimits';
   import type { UserProfile } from '$lib/types';
@@ -22,6 +22,8 @@
 
   let specError = $state<string | null>(null);
   let specBusy = $state(false);
+  let levelError = $state<string | null>(null);
+  let levelBusy = $state(false);
 
   async function toggleSpecialization(value: string) {
     if (specBusy) return;
@@ -48,25 +50,83 @@
       specBusy = false;
     }
   }
+
+  // Level is a free multi-select with no floor, unlike the specializations above: someone
+  // who is between levels ("senior or lead") is stating both, and someone who wants to stop
+  // stating one at all must be able to — a profile that cannot go back to silent would make
+  // the wizard's answer permanent. The account-setup card simply re-opens its step when the
+  // list empties, which is the honest reading of "no level stated".
+  async function toggleSeniority(value: string) {
+    if (levelBusy) return;
+    levelError = null;
+    levelBusy = true;
+    const next = profile.seniorities.includes(value)
+      ? profile.seniorities.filter((s) => s !== value)
+      : [...profile.seniorities, value];
+    try {
+      await profileStore.updateSeniorities(next);
+      onProfileChanged?.();
+    } catch {
+      levelError = 'Could not update your level. Try again.';
+    } finally {
+      levelBusy = false;
+    }
+  }
 </script>
 
-<div class="flex flex-col gap-2">
-  <div class="flex items-baseline justify-between">
-    <span class="text-sm font-medium">Roles</span>
-    <span class="text-xs tabular-nums text-muted-foreground">
-      {profile.specializations.length}/{MAX_SPECIALIZATIONS}
-    </span>
+<!-- `account-role` is the anchor the account-setup checklist's role step links to (see
+     accountCompleteness.ts). It sits on the whole card, not on either half, because that
+     step asks for both together — "what you do, and at what level". `scroll-mt-20` is the
+     repo's anchored-section offset. -->
+<div id="account-role" class="flex scroll-mt-20 flex-col gap-6">
+  <div class="flex flex-col gap-2">
+    <div class="flex items-baseline justify-between">
+      <span class="text-sm font-medium">Roles</span>
+      <span class="text-xs tabular-nums text-muted-foreground">
+        {profile.specializations.length}/{MAX_SPECIALIZATIONS}
+      </span>
+    </div>
+    <div class={specBusy ? 'pointer-events-none opacity-60' : ''}>
+      <SearchSelect
+        options={CATEGORY_OPTIONS}
+        include={profile.specializations}
+        placeholder="Search specializations"
+        onToggle={toggleSpecialization}
+        clearOnSelect
+      />
+    </div>
+    {#if specError}
+      <p class="text-xs text-destructive">{specError}</p>
+    {/if}
   </div>
-  <div class={specBusy ? 'pointer-events-none opacity-60' : ''}>
-    <SearchSelect
-      options={CATEGORY_OPTIONS}
-      include={profile.specializations}
-      placeholder="Search specializations"
-      onToggle={toggleSpecialization}
-      clearOnSelect
-    />
+
+  <!-- Level lives beside Roles rather than in its own card: it was previously askable only
+       inside the onboarding wizard, so a profile whose level needed changing had no surface
+       at all. Pills rather than a SearchSelect — the vocabulary is five values, and the
+       wizard's own Level step (ConfirmStep) already reads this way. -->
+  <div class="flex flex-col gap-2">
+    <div class="flex items-baseline justify-between">
+      <span class="text-sm font-medium">Level</span>
+      <span class="text-xs text-muted-foreground">Pick every level you'd take</span>
+    </div>
+    <div class={['flex flex-wrap gap-2', levelBusy && 'pointer-events-none opacity-60']}>
+      {#each SENIORITY_OPTIONS as o (o.value)}
+        {@const selected = profile.seniorities.includes(o.value)}
+        <button
+          type="button"
+          onclick={() => toggleSeniority(o.value)}
+          aria-pressed={selected}
+          class={[
+            'rounded-full border px-3 py-1.5 text-sm font-medium transition-colors',
+            selected ? 'border-brand bg-brand text-brand-foreground' : 'border-border bg-card hover:bg-accent',
+          ]}
+        >
+          {o.label}
+        </button>
+      {/each}
+    </div>
+    {#if levelError}
+      <p class="text-xs text-destructive">{levelError}</p>
+    {/if}
   </div>
-  {#if specError}
-    <p class="text-xs text-destructive">{specError}</p>
-  {/if}
 </div>

--- a/web/src/lib/profile.svelte.ts
+++ b/web/src/lib/profile.svelte.ts
@@ -132,6 +132,16 @@ class ProfileStore extends UserResource<UserProfile | null> {
     });
   }
 
+  /** Re-save the profile with an edited seniority list — what the Roles card's Level row
+   *  writes when you add or remove one. Rejects when there is no profile. */
+  updateSeniorities(seniorities: string[]): Promise<UserProfile> {
+    return this.#queue(() => {
+      const current = this.#profile;
+      if (!current) return Promise.reject(new Error('No profile to edit.'));
+      return this.save(current.specializations, current.skills, seniorities, current.excluded_skills, current.location_preferences);
+    });
+  }
+
   /** Re-save the profile with an edited location-preferences block — what the Location
    *  view writes on every change. Rejects when there is no profile. */
   updateLocation(location: LocationPreferences | null): Promise<UserProfile> {


### PR DESCRIPTION
Give the profile a Level field, and point the checklist step at it

The account-setup step "Say what you do, and at what level" could not be
finished from the page it links to. Its predicate wants a specialization
AND a seniority, but seniority was only ever askable inside the
onboarding wizard - nothing under /my/ wrote it, and ProfileForm passed
the stored value through untouched. So the step stayed open for anyone
who skipped or half-answered that wizard screen, with nowhere to go.

The Roles card now carries a Level pill row beside its specializations,
autosaving the same way. It is a free multi-select with no floor,
unlike the specializations above it: someone between levels is stating
both, and a profile that cannot go back to silent would make the
wizard's answer permanent.

The link was the smaller half. That step targets /my/profile, which is
the page the checklist card is rendered on, so following it changed
nothing on screen - and the Role card sits below two other blocks. A
step may now name an anchor on its target page, and the role step names
the Role card.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline editing for profile seniority levels, including selecting multiple levels or clearing all selections.
  * Profile changes save automatically and provide feedback when updates fail.
  * Account setup links now take users directly to the relevant Role section when applicable.

* **Bug Fixes**
  * Improved navigation from account completeness steps to the correct location on profile pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->