### PR TITLE
Say the search box example with a colon, not a dash

### DIFF
--- a/web/src/lib/placeholderRoles.test.ts
+++ b/web/src/lib/placeholderRoles.test.ts
@@ -46,7 +46,7 @@ describe('ROLE_PLACEHOLDER', () => {
   // wording changed. These are the words that ship.
   it('is a fixed prefix and the roles that follow it', () => {
     expect(ROLE_PLACEHOLDER).toEqual({
-      prefix: 'Search jobs — e.g. ',
+      prefix: 'Search jobs: ',
       roles: ['Backend', 'Frontend', 'DevOps', 'QA', 'Data Science', 'Product'],
     });
   });
@@ -70,8 +70,8 @@ describe('typewriterStep', () => {
     return frames;
   };
 
-  // The server renders this state, so it has to be a whole sentence: an empty tail would
-  // ship "Search jobs - e.g. " to anyone reading before hydration or with JS off.
+  // The server renders this state, so it has to read whole: an empty tail would ship
+  // "Search jobs: " to anyone reading before hydration or with JS off.
   it('starts with the first word already whole', () => {
     expect(typedTail(start, roles)).toBe('ab');
   });

--- a/web/src/lib/placeholderRoles.ts
+++ b/web/src/lib/placeholderRoles.ts
@@ -18,7 +18,7 @@ import type { Category } from './generated/contracts';
 import { categoryLabel } from './labels';
 
 /** The half of the placeholder that never changes. */
-export const ROLE_PREFIX = 'Search jobs — e.g. ';
+export const ROLE_PREFIX = 'Search jobs: ';
 
 /** The roles the box types, in order.
  *
@@ -71,7 +71,7 @@ export interface TypewriterState {
 /** Where the animation begins: the FIRST role already whole.
  *
  *  Not an empty tail. The server renders this state, and an empty tail would ship
- *  `"Search jobs — e.g. "` — a sentence that stops mid-air for anyone reading before
+ *  `"Search jobs: "` — a label that stops mid-air for anyone reading before
  *  hydration or with JavaScript off. Starting complete also means the first thing anyone
  *  reads is a whole example, and the animation's first act is to erase it rather than to
  *  correct a dangling line. */


### PR DESCRIPTION
The jobs search box's placeholder read `Search jobs — e.g. Frontend`. The em-dash-plus-"e.g." spends more characters on framing than on the example.

Now: `Search jobs: Frontend`.

One constant (`ROLE_PREFIX` in `web/src/lib/placeholderRoles.ts`) feeds both the homepage box and the header box, so they stay in step. The typing animation is untouched — only the fixed half changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the job search placeholder text to use the “Search jobs:” format instead of the previous example-based wording.
  * Updated related documentation and test expectations to match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->