### PR TITLE
Let the profile alert toggle write through the store the chips read

### DIFF
--- a/web/src/lib/components/ProfileAlertToggle.svelte
+++ b/web/src/lib/components/ProfileAlertToggle.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { Check, User } from '@lucide/svelte';
-  import { api, ApiError } from '$lib/api';
+  import { ApiError } from '$lib/api';
   import { filtersFromProfile, filtersToParams } from '$lib/filters';
+  import { notifications } from '$lib/notifications.svelte';
   import { savedSearches } from '$lib/savedSearches.svelte';
   import { cn } from '$lib/ui';
   import type { SavedSearch, UserProfile } from '$lib/types';
@@ -47,7 +48,11 @@
     try {
       const query = filtersToParams(filtersFromProfile(profile)).toString();
       search = await savedSearches.create('My profile', query, true);
-      await api.createSubscription(search.id, 'email');
+      // Through the store, not api.createSubscription: this page also renders the
+      // per-channel chips (AlertChannels) for this very saved search, and they read
+      // the store. Writing past it left the Email chip drawing "off" over a
+      // subscription that existed, so tapping it POSTed a duplicate and 409'd.
+      await notifications.subscribe(search.id, 'email');
       flash();
     } catch (e) {
       // The search may have been created before the subscribe call failed — clean it

--- a/web/src/lib/notifications.svelte.ts
+++ b/web/src/lib/notifications.svelte.ts
@@ -66,6 +66,15 @@ class Notifications extends UserResource<[TelegramStatus, Subscription[], Webhoo
     this.#subs = this.#subs.map((s) => (s.id === id ? { ...s, active: row.active } : s));
   }
 
+  /** Drop a deleted saved search's subscriptions. Deleting a saved search takes its
+   *  subscriptions with it server-side (subscriptions.saved_search_id ON DELETE
+   *  CASCADE); mirroring that here is what stops the per-channel chips from rendering
+   *  a subscription id nothing answers for. Called by savedSearches.remove, so the
+   *  cascade is reflected in one place rather than at each delete site. */
+  forgetSavedSearch(savedSearchId: number): void {
+    this.#subs = this.#subs.filter((s) => s.saved_search_id !== savedSearchId);
+  }
+
   /** Unsubscribe and drop it from the list. */
   async unsubscribe(id: number): Promise<void> {
     await api.deleteSubscription(id);

--- a/web/src/lib/savedSearches.svelte.ts
+++ b/web/src/lib/savedSearches.svelte.ts
@@ -9,6 +9,7 @@
 // caller (a duplicate name or the per-user cap is a 409) so the UI can show them.
 
 import { api } from '$lib/api';
+import { notifications } from '$lib/notifications.svelte';
 import { UserResource } from '$lib/userResource.svelte';
 import type { SavedSearch } from '$lib/types';
 
@@ -50,10 +51,14 @@ class SavedSearches extends UserResource<SavedSearch[]> {
     return row;
   }
 
-  /** Delete a set and drop it from the list. */
+  /** Delete a set and drop it from the list, along with the subscriptions the server
+   *  cascades away with it (subscriptions.saved_search_id ON DELETE CASCADE) — the
+   *  cascade is a property of this DELETE, so it is reflected here rather than at each
+   *  of the five call sites. */
   async remove(id: number): Promise<void> {
     await api.deleteSavedSearch(id);
     this.#items = this.#items.filter((s) => s.id !== id);
+    notifications.forgetSavedSearch(id);
   }
 }
 


### PR DESCRIPTION
## The bug

`/my/notifications/searches` renders two controls over the same saved search: the **Jobs matching my profile** toggle (`ProfileAlertToggle`) and, in the list below it, that search's per-channel alert chips (`AlertChannels`).

The toggle created its email subscription with `api.createSubscription` **directly**, bypassing the `notifications` store the chips read from. The store never learned about the row, so the Email chip kept drawing "off" over a subscription that existed. Tapping it POSTed a duplicate and got a `409 already subscribed to this saved search on this channel`.

Prod evidence (nginx, `POST /api/v1/me/subscriptions`, referer `/my/notifications/searches`, one session):

```
16:51:27  201   <- the toggle created it
16:51:45  409   <- the chip, drawn "off", tried again
16:51:50  409
16:54:16  201   <- after toggling off and on again
```

## The fix

- `ProfileAlertToggle.enable` goes through `notifications.subscribe`, so the chips see the row it just created.
- The other direction of the same drift: deleting a saved search takes its subscriptions with it server-side (`subscriptions.saved_search_id ON DELETE CASCADE`), which left the store holding rows whose id nothing answers for — the chips would then draw "on" and unsubscribing would 404. That forget is a property of the DELETE, so it lives once in `savedSearches.remove` rather than at each of the five call sites.

## Verification

- `pnpm --dir web check` — 0 errors
- `pnpm --dir web lint` — exit 0
- `pnpm --dir web test` — 128 files, 1453 tests passed