### PR TITLE
Say the subscription cascade once, and stop counting its call sites

### DIFF
--- a/web/src/lib/components/ProfileAlertToggle.svelte
+++ b/web/src/lib/components/ProfileAlertToggle.svelte
@@ -48,10 +48,9 @@
     try {
       const query = filtersToParams(filtersFromProfile(profile)).toString();
       search = await savedSearches.create('My profile', query, true);
-      // Through the store, not api.createSubscription: this page also renders the
-      // per-channel chips (AlertChannels) for this very saved search, and they read
-      // the store. Writing past it left the Email chip drawing "off" over a
-      // subscription that existed, so tapping it POSTed a duplicate and 409'd.
+      // Through the store, not api.createSubscription: this page also renders this
+      // search's per-channel chips (AlertChannels), which read the store. Writing past
+      // it drew the Email chip "off" over a live subscription — tapping it 409'd.
       await notifications.subscribe(search.id, 'email');
       flash();
     } catch (e) {

--- a/web/src/lib/notifications.svelte.ts
+++ b/web/src/lib/notifications.svelte.ts
@@ -66,11 +66,9 @@ class Notifications extends UserResource<[TelegramStatus, Subscription[], Webhoo
     this.#subs = this.#subs.map((s) => (s.id === id ? { ...s, active: row.active } : s));
   }
 
-  /** Drop a deleted saved search's subscriptions. Deleting a saved search takes its
-   *  subscriptions with it server-side (subscriptions.saved_search_id ON DELETE
-   *  CASCADE); mirroring that here is what stops the per-channel chips from rendering
-   *  a subscription id nothing answers for. Called by savedSearches.remove, so the
-   *  cascade is reflected in one place rather than at each delete site. */
+  /** Drop a deleted saved search's subscriptions. The server takes them with it
+   *  (subscriptions.saved_search_id ON DELETE CASCADE); mirroring that here is what
+   *  stops the per-channel chips rendering a subscription id nothing answers for. */
   forgetSavedSearch(savedSearchId: number): void {
     this.#subs = this.#subs.filter((s) => s.saved_search_id !== savedSearchId);
   }

--- a/web/src/lib/savedSearches.svelte.ts
+++ b/web/src/lib/savedSearches.svelte.ts
@@ -52,9 +52,8 @@ class SavedSearches extends UserResource<SavedSearch[]> {
   }
 
   /** Delete a set and drop it from the list, along with the subscriptions the server
-   *  cascades away with it (subscriptions.saved_search_id ON DELETE CASCADE) — the
-   *  cascade is a property of this DELETE, so it is reflected here rather than at each
-   *  of the five call sites. */
+   *  cascades away with it — the cascade is a property of this DELETE, so it is
+   *  mirrored here rather than at each delete site. */
   async remove(id: number): Promise<void> {
     await api.deleteSavedSearch(id);
     this.#items = this.#items.filter((s) => s.id !== id);


### PR DESCRIPTION
Follow-up quality pass on #2494. **Comments only — no behaviour change.**

Two things the cascade fix left behind:

- **The rationale was written twice.** `forgetSavedSearch`'s doc argued why the forget lives in one place, and `savedSearches.remove`'s doc argued the same thing again — both naming `subscriptions.saved_search_id ON DELETE CASCADE`. The placement argument belongs where the decision is (the call site); the method now says only what it does and why it exists.
- **"each of the five call sites" counted something that will not stay five.** `each delete site` says the same and cannot rot.

Also trimmed `ProfileAlertToggle`'s new comment from four lines to three without dropping either half of it — the rule (write through the store another control reads) or the evidence (the chip drew "off" over a live subscription and 409'd).

## Verification

- `pnpm --dir web check` — 0 errors
- `pnpm --dir web lint` — exit 0
- `pnpm --dir web test` — 141 files, 1608 tests passed