### PR TITLE
Point the "Add your CV" step at the box that takes one

### DIFF
--- a/web/src/lib/accountCompleteness.test.ts
+++ b/web/src/lib/accountCompleteness.test.ts
@@ -42,12 +42,13 @@ describe('accountSteps', () => {
     }
   });
 
-  // skills and location are their own routes under /my/profile; role is the default
-  // section there, and cv/alerts point at other pages entirely.
+  // skills and location are their own routes under /my/profile; cv and role are both on
+  // its default section, and alerts points at another page entirely. Notably NOT /my/cvs
+  // for the CV step — that route is the per-vacancy builder and takes no upload.
   it('links each step straight to the route it is done on', () => {
     const hrefById = Object.fromEntries(accountSteps(empty).map((s) => [s.id, s.href]));
     expect(hrefById).toEqual({
-      cv: '/my/cvs',
+      cv: '/my/profile',
       role: '/my/profile',
       skills: '/my/profile/skills',
       location: '/my/profile/location',
@@ -55,15 +56,23 @@ describe('accountSteps', () => {
     });
   });
 
-  // The card itself is rendered on /my/profile, so the role step's link would otherwise
+  // The card itself is rendered on /my/profile, so a step landing there would otherwise
   // point at the page the reader is already looking at — the anchor is what makes it move.
-  it('anchors the role step, since its own card shares that page', () => {
+  it('anchors every step that lands on the page the card itself is on', () => {
     const byId = Object.fromEntries(accountSteps(empty).map((s) => [s.id, s.hash]));
+    expect(byId.cv).toBe('account-cv');
     expect(byId.role).toBe('account-role');
-    expect(byId.cv).toBeUndefined();
     expect(byId.skills).toBeUndefined();
     expect(byId.location).toBeUndefined();
     expect(byId.alerts).toBeUndefined();
+  });
+
+  // The guard for the whole class of bug this fixes: a step whose href is the page the
+  // card is rendered on has to name where on it to go, or following it changes nothing.
+  it('leaves no step pointing at /my/profile without an anchor', () => {
+    for (const step of accountSteps(empty)) {
+      if (step.href === '/my/profile') expect(step.hash).toBeTruthy();
+    }
   });
 
   it('counts a CV once one is stored', () => {

--- a/web/src/lib/accountCompleteness.ts
+++ b/web/src/lib/accountCompleteness.ts
@@ -16,7 +16,7 @@ import type { UserProfile } from './types';
  *  does not exist fails the build here, instead of rendering a link to a 404. Spelling
  *  the routes out keeps this module free of any SvelteKit import, which is what lets it
  *  be unit-tested in plain Node. */
-type SetupHref = '/my/cvs' | '/my/profile' | '/my/profile/skills' | '/my/profile/location' | '/my/searches';
+type SetupHref = '/my/profile' | '/my/profile/skills' | '/my/profile/location' | '/my/searches';
 
 export interface CompletenessStep {
   /** Stable key. Used by tests and as the list key — never shown. */
@@ -24,8 +24,9 @@ export interface CompletenessStep {
   label: string;
   href: SetupHref;
   /** The id of the element on `href`'s page to land on, for a step whose page holds more
-   *  than the step asks for. Without it, the role step links to the page it is already
-   *  rendered on and nothing appears to happen. An opaque string rather than a type shared
+   *  than the step asks for. Both steps that land on /my/profile need one: that page is
+   *  where this card is itself rendered, so without an anchor the link goes to where the
+   *  reader already stands and nothing appears to happen. An opaque string rather than a type shared
    *  with the page — this module stays free of any SvelteKit import (see `SetupHref`) — so
    *  it must be kept in sync by hand with that element's `id`. */
   hash?: string;
@@ -67,7 +68,11 @@ export function accountSteps({ hasCv, profile, alertCount }: CompletenessInput):
     {
       id: 'cv',
       label: 'Add your CV',
-      href: '/my/cvs',
+      // Not /my/cvs: that is the CV BUILDER, a list of the CVs tailored per vacancy, and it
+      // has no upload of its own. What this step measures is the stored base résumé, and
+      // the only surface under /my/ that takes one is ProfileForm's "Your CV" box.
+      href: '/my/profile',
+      hash: 'account-cv',
       done: hasCv,
     },
     {

--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -247,7 +247,11 @@
        Uploading extracts skills into the fields below during set-up; once a profile
        exists, it merges straight into the profile (Roles/Skills have their own views by
        then). -->
-  <div class="flex flex-col gap-1.5">
+  <!-- `account-cv` is the anchor the account-setup checklist's CV step links to (see
+       accountCompleteness.ts) — this box is the only place under /my/ that takes a base
+       résumé, /my/cvs being the per-vacancy builder. `scroll-mt-20` is the repo's
+       anchored-section offset. -->
+  <div id="account-cv" class="flex scroll-mt-20 flex-col gap-1.5">
     <span class="text-sm font-medium">Your CV</span>
     <input
       type="file"


### PR DESCRIPTION
Point the "Add your CV" step at the box that takes one

The step measures the stored base resume (resumeStore.present) and linked
to /my/cvs. That route is the per-vacancy CV builder - a list of tailored
CVs - and has no upload of its own, so following the step landed on a page
where the thing it asks for cannot be done. The only surface under /my/
that takes a base resume is ProfileForm's "Your CV" box, on the profile
page's default section.

It now links there, anchored on that box for the same reason the role step
is: the checklist card is itself rendered on /my/profile, so an unanchored
link goes to where the reader already stands.

A test now holds the whole class shut - any step whose href is /my/profile
must name an anchor.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
