### PR TITLE
Make subscribing idempotent where the rule can be tested

### DIFF
--- a/web/src/lib/components/ProfileAlertToggle.svelte
+++ b/web/src/lib/components/ProfileAlertToggle.svelte
@@ -16,14 +16,21 @@
   // settings may list as a preferred channel without the user ever having connected
   // them — see ReminderSettings.svelte/CompanyFollowButton.svelte's `linked` gate).
   // The user can add another channel from the Search alerts tab afterward. Flipping
-  // the toggle off deletes the saved search — the ON DELETE CASCADE on
-  // subscriptions.saved_search_id takes the subscription with it, so there is nothing
-  // else to clean up here. On/off is derived from whether such a row exists, not a
-  // separate flag, so this component never drifts from the server.
+  // the toggle off deletes the saved search, and its subscriptions go with it.
+  //
+  // On/off is read from the server's rows rather than a separate flag, and it reads
+  // BOTH of them — the search and its email subscription. The Search alerts tab renders
+  // this same search's per-channel chips right below this toggle, so turning the Email
+  // chip off there must not leave this one still claiming the alert is on.
   let { profile }: { profile: UserProfile } = $props();
 
   const profileSearch = $derived(savedSearches.items.find((s) => s.derived_from_profile) ?? null);
-  const enabled = $derived(profileSearch !== null);
+  const enabled = $derived(
+    profileSearch !== null && notifications.forSavedSearch(profileSearch.id, 'email') !== undefined,
+  );
+  // Until both stores have answered, "off" would be a guess rather than a reading, and
+  // acting on a guess is how the toggle wrote past a subscription that already existed.
+  const ready = $derived(savedSearches.loaded && notifications.loaded);
 
   let saveState = $state<'idle' | 'saving' | 'saved' | 'error'>('idle');
   let saveError = $state<string | null>(null);
@@ -31,6 +38,7 @@
 
   $effect(() => {
     void savedSearches.ensureLoaded();
+    void notifications.ensureLoaded();
   });
 
   function flash() {
@@ -44,21 +52,28 @@
   async function enable() {
     saveState = 'saving';
     saveError = null;
-    let search: SavedSearch | undefined;
+    // Only a search THIS call created may be rolled back below; an existing one is the
+    // user's, and re-enabling after they turned the Email chip off must not delete it.
+    let created: SavedSearch | undefined;
     try {
-      const query = filtersToParams(filtersFromProfile(profile)).toString();
-      search = await savedSearches.create('My profile', query, true);
+      // Reuse the profile search when there is one — the server's partial unique index
+      // permits exactly one, so re-creating it would conflict rather than re-subscribe.
+      let search = profileSearch;
+      if (!search) {
+        const query = filtersToParams(filtersFromProfile(profile)).toString();
+        search = created = await savedSearches.create('My profile', query, true);
+      }
       // Through the store, not api.createSubscription: this page also renders this
       // search's per-channel chips (AlertChannels), which read the store. Writing past
       // it drew the Email chip "off" over a live subscription — tapping it 409'd.
       await notifications.subscribe(search.id, 'email');
       flash();
     } catch (e) {
-      // The search may have been created before the subscribe call failed — clean it
-      // up so the toggle doesn't end up "on" (search exists) while showing an error.
-      if (search) {
+      // The search may have been created before the subscribe call failed — clean it up
+      // so a half-done enable leaves no saved search the user never asked for.
+      if (created) {
         try {
-          await savedSearches.remove(search.id);
+          await savedSearches.remove(created.id);
         } catch {
           // best-effort; the toggle's error state still surfaces the original failure.
         }
@@ -106,7 +121,7 @@
       <span class="text-xs text-destructive">{saveError}</span>
     {/if}
 
-    {@render toggleSwitch(enabled, 'Notify me about jobs matching my profile', toggle, saveState === 'saving')}
+    {@render toggleSwitch(enabled, 'Notify me about jobs matching my profile', toggle, saveState === 'saving' || !ready)}
   </div>
 </section>
 

--- a/web/src/lib/components/filters/AlertChannels.svelte
+++ b/web/src/lib/components/filters/AlertChannels.svelte
@@ -17,6 +17,11 @@
   //
   // A chip is "on" when a subscription exists for that channel; tapping an on chip turns
   // it off. Telegram hides itself when the feature isn't configured server-side.
+  //
+  // No handler here special-cases a 409: subscribing is idempotent in the store (see
+  // notifications.subscribe), which is where the spec's "already subscribed is success"
+  // belongs. Holding it per-chip is what let email and push render the server's
+  // conflict string at the user while telegram and webhook quietly ignored it.
   let { savedSearchId, showLabel = true }: { savedSearchId: number; showLabel?: boolean } = $props();
 
   let busy = $state<'telegram' | 'email' | 'push' | 'webhook' | null>(null);
@@ -39,9 +44,7 @@
       if (tgSub) await notifications.unsubscribe(tgSub.id);
       else await notifications.subscribe(savedSearchId, 'telegram');
     } catch (e) {
-      if (!(e instanceof ApiError) || e.status !== 409) {
-        error = e instanceof ApiError ? e.message : 'Could not update the Telegram alert. Please try again.';
-      }
+      error = e instanceof ApiError ? e.message : 'Could not update the Telegram alert. Please try again.';
     } finally {
       busy = null;
     }
@@ -89,9 +92,7 @@
       if (webhookSub) await notifications.unsubscribe(webhookSub.id);
       else await notifications.subscribe(savedSearchId, 'webhook');
     } catch (e) {
-      if (!(e instanceof ApiError) || e.status !== 409) {
-        error = e instanceof ApiError ? e.message : 'Could not update the webhook alert. Please try again.';
-      }
+      error = e instanceof ApiError ? e.message : 'Could not update the webhook alert. Please try again.';
     } finally {
       busy = null;
     }

--- a/web/src/lib/notifications.svelte.ts
+++ b/web/src/lib/notifications.svelte.ts
@@ -8,6 +8,7 @@
 // and leaves empty/disabled state for signed-out users.
 
 import { api } from '$lib/api';
+import { ensureSubscribed } from '$lib/saveSearchAlert';
 import { UserResource } from '$lib/userResource.svelte';
 import type { Subscription, TelegramStatus, WebhookConfig } from '$lib/types';
 
@@ -54,10 +55,25 @@ class Notifications extends UserResource<[TelegramStatus, Subscription[], Webhoo
     this.#webhook = null;
   }
 
-  /** Subscribe a saved search to a channel (telegram by default); prepend it. */
-  async subscribe(savedSearchId: number, channel = 'telegram'): Promise<void> {
-    const sub = await api.createSubscription(savedSearchId, channel);
-    this.#subs = [sub, ...this.#subs];
+  /** Subscribe a saved search to a channel (telegram by default); prepend it.
+   *
+   *  The idempotence rule lives in ensureSubscribed, beside ensureSaved — the same rule
+   *  for the other half of the same flow, and the half a plain-Node test can reach (a
+   *  runes store cannot; see vitest.config.ts). This wires the singleton to its port;
+   *  callers get "an 'already subscribed' conflict is treated as success" for free
+   *  instead of each holding its own answer, which is how two chips ended up rendering
+   *  the server's 409 string while two others quietly ignored it. */
+  subscribe(savedSearchId: number, channel = 'telegram'): Promise<void> {
+    return ensureSubscribed(savedSearchId, channel, {
+      ensureLoaded: () => this.ensureLoaded(),
+      find: (id, ch) => this.forSavedSearch(id, ch),
+      add: async (id, ch) => {
+        this.#subs = [await api.createSubscription(id, ch), ...this.#subs];
+      },
+      refresh: async () => {
+        this.#subs = await api.listSubscriptions();
+      },
+    });
   }
 
   /** Pause/resume a subscription in place. */

--- a/web/src/lib/saveSearchAlert.test.ts
+++ b/web/src/lib/saveSearchAlert.test.ts
@@ -1,14 +1,16 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { ApiError } from './api';
-import type { SavedSearch } from './types';
+import type { SavedSearch, Subscription } from './types';
 import {
   alertName,
   matchedSavedSearch,
   ensureSaved,
+  ensureSubscribed,
   setPendingAlert,
   consumePendingAlert,
   PENDING_ALERT_KEY,
   type SavedSearchesPort,
+  type SubscriptionsPort,
 } from './saveSearchAlert';
 import { must } from './utils';
 
@@ -135,6 +137,103 @@ describe('ensureSaved', () => {
     expect(set.id).toBe(9);
     expect(createCalls).toHaveLength(2);
     expect(must(createCalls[1]).name).not.toBe(must(createCalls[0]).name);
+  });
+});
+
+const sub = (id: number, savedSearchId: number, channel: string): Subscription =>
+  ({ id, saved_search_id: savedSearchId, channel, active: true }) as Subscription;
+
+// A SubscriptionsPort double. `held` is what the caller currently has; `server` is what
+// a refresh() would read back. Seeding them differently is how a stale list is staged.
+function makeSubs(opts: {
+  held?: Subscription[];
+  server?: Subscription[];
+  addImpl?: () => Promise<void>;
+}): {
+  port: SubscriptionsPort;
+  held: Subscription[];
+  calls: { ensureLoaded: number; add: number; refresh: number };
+} {
+  let held = [...(opts.held ?? [])];
+  const calls = { ensureLoaded: 0, add: 0, refresh: 0 };
+  return {
+    calls,
+    get held() {
+      return held;
+    },
+    port: {
+      ensureLoaded: async () => {
+        calls.ensureLoaded++;
+      },
+      find: (id, ch) => held.find((s) => s.saved_search_id === id && s.channel === ch),
+      add: async (id, ch) => {
+        calls.add++;
+        if (opts.addImpl) return opts.addImpl();
+        held = [sub(held.length + 100, id, ch), ...held];
+      },
+      refresh: async () => {
+        calls.refresh++;
+        held = [...(opts.server ?? [])];
+      },
+    },
+  };
+}
+
+describe('ensureSubscribed', () => {
+  it('creates the subscription when the channel is not yet subscribed', async () => {
+    const s = makeSubs({ held: [] });
+    await ensureSubscribed(5, 'email', s.port);
+    expect(s.calls.add).toBe(1);
+    expect(s.calls.refresh).toBe(0);
+    expect(s.held).toHaveLength(1);
+  });
+
+  it('does not re-POST a channel it already holds', async () => {
+    const s = makeSubs({ held: [sub(1, 5, 'email')] });
+    await ensureSubscribed(5, 'email', s.port);
+    expect(s.calls.add).toBe(0);
+  });
+
+  it('subscribes per channel, not per saved search', async () => {
+    const s = makeSubs({ held: [sub(1, 5, 'email')] });
+    await ensureSubscribed(5, 'telegram', s.port);
+    expect(s.calls.add).toBe(1);
+  });
+
+  // The reported bug: the list was stale, so the pre-check found nothing, the POST
+  // conflicted, and the caller was left still not holding the row — drawing the channel
+  // "off" over a live subscription, so the next tap conflicted again. Treating the
+  // conflict as success means ending up holding it, not merely not throwing.
+  it('adopts the server row on a 409 rather than surfacing it', async () => {
+    const s = makeSubs({
+      held: [],
+      server: [sub(42, 5, 'email')],
+      addImpl: async () => {
+        throw new ApiError(409, 'already subscribed to this saved search on this channel');
+      },
+    });
+    await ensureSubscribed(5, 'email', s.port);
+    expect(s.calls.refresh).toBe(1);
+    expect(s.port.find(5, 'email')?.id).toBe(42);
+  });
+
+  it('rethrows anything that is not a 409', async () => {
+    const s = makeSubs({
+      held: [],
+      addImpl: async () => {
+        throw new ApiError(500, 'boom');
+      },
+    });
+    await expect(ensureSubscribed(5, 'email', s.port)).rejects.toThrow('boom');
+    expect(s.calls.refresh).toBe(0);
+  });
+
+  // A write racing an in-flight load is discarded by the snapshot that lands after it,
+  // so the load has to settle before the pre-check reads the list.
+  it('waits for the load before deciding whether to POST', async () => {
+    const s = makeSubs({ held: [sub(1, 5, 'email')] });
+    await ensureSubscribed(5, 'email', s.port);
+    expect(s.calls.ensureLoaded).toBe(1);
   });
 });
 

--- a/web/src/lib/saveSearchAlert.ts
+++ b/web/src/lib/saveSearchAlert.ts
@@ -9,7 +9,7 @@
 import { ApiError } from './api';
 import { canonicalQuery, filtersFromParams } from './facetModel';
 import { FACETS, dynamicLabel } from './facets';
-import type { SavedSearch } from './types';
+import type { SavedSearch, Subscription } from './types';
 
 // ---- auto-name ----
 
@@ -71,6 +71,43 @@ export async function ensureSaved(query: string, ss: SavedSearchesPort): Promise
     const raced = matchedSavedSearch(query, ss.items);
     if (raced) return raced;
     return ss.create(`${base.slice(0, 90)} (${ss.items.length + 1})`, query);
+  }
+}
+
+// ---- the subscribe ----
+
+export interface SubscriptionsPort {
+  ensureLoaded(): Promise<void>;
+  /** The held subscription for this saved search and channel, if any. */
+  find(savedSearchId: number, channel: string): Subscription | undefined;
+  /** Create the subscription and keep the row the server returns. */
+  add(savedSearchId: number, channel: string): Promise<void>;
+  /** Re-read every subscription and replace what is held. */
+  refresh(): Promise<void>;
+}
+
+/** Subscribe a saved search to a channel, tolerating a 409 the way the spec asks:
+ *  "an 'already subscribed' conflict is treated as success". The save half's rule
+ *  (ensureSaved, above) written for the other half of the same flow.
+ *
+ *  A conflict is repaired by re-reading rather than ignored. Ignoring it leaves the
+ *  caller holding a list without the row the server has, so whatever renders from that
+ *  list still draws the channel "off" and the next tap conflicts again — which is how
+ *  this reached a user as a raw "already subscribed to this saved search on this
+ *  channel". The load is awaited first for the same reason: a write racing an in-flight
+ *  load is discarded by the snapshot that lands after it. */
+export async function ensureSubscribed(
+  savedSearchId: number,
+  channel: string,
+  subs: SubscriptionsPort,
+): Promise<void> {
+  await subs.ensureLoaded();
+  if (subs.find(savedSearchId, channel)) return;
+  try {
+    await subs.add(savedSearchId, channel);
+  } catch (e) {
+    if (!(e instanceof ApiError) || e.status !== 409) throw e;
+    await subs.refresh();
   }
 }
 


### PR DESCRIPTION
Acts on the `/code-review` findings against #2494 / #2495. Three drifts of one shape, plus the test that was missing.

## 1. The reported error string was still reachable

`AlertChannels.svelte` has four channel chips, and they held three different answers to a 409:

| handler | 409 branch |
|---|---|
| `toggleTelegram` | swallow |
| `toggleWebhook` | swallow |
| `toggleEmail` | **none — renders the server string** |
| `togglePush` | **none — renders the server string** |

Email is the channel the bug report hit, so `already subscribed to this saved search on this channel` was one stale list away from a user again.

Swallowing was not right either: the caller ends up still not holding the row the server has, so the chip keeps drawing "off" over it and the next tap conflicts again. The spec asks for more than silence — *"an 'already subscribed' conflict is treated as success"* (`openspec/specs/save-search-alert/spec.md:10`), and the scenario adds *"leaves exactly one subscription"*.

**The rule now lives in one place, and it is the place a test can reach.** `saveSearchAlert.ts` already holds the same rule for the *save* half — `ensureSaved`, a pure function over a port, tested with a fake. `ensureSubscribed` sits beside it; `notifications.subscribe` wires the singleton to its port; all four per-chip 409 branches are gone.

That placement is not incidental: a runes store cannot be imported by a plain-Node test, and `vitest.config.ts` says why it stays that way. This half can be tested, so it is — six cases, including the exact stale-list-then-409 that reached prod.

## 2. The profile toggle read "on" from the wrong row

`enabled` derived from the saved search alone, so turning the Email chip off in the list below left the toggle still claiming the alert was on — the #2494 drift, arrived at from the other side. It now reads the subscription too.

`enable()` also reuses an existing profile search rather than re-creating one the server's partial unique index forbids, so re-enabling after the chip was turned off subscribes instead of conflicting. The rollback now only removes a search *this call* created.

## 3. A write racing the load was discarded

`UserResource.apply()` replaces `#subs` wholesale, so a prepend landing mid-load was overwritten by the snapshot that resolved after it — the same "chip off over a live subscription", reached by timing. `ensureSubscribed` awaits the load before deciding, and the toggle stays disabled until both stores have answered rather than guessing "off".

## Verification

- `pnpm --dir web test` — 141 files, **1614** tests passed (was 1608; +6)
- Red-checked: breaking the 409 branch fails `adopts the server row on a 409 rather than surfacing it`, and only that test
- `pnpm --dir web check` — 0 errors, warning count unchanged (36)
- `pnpm --dir web lint` — exit 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile alert toggles now accurately reflect both saved-search and email subscription status.
  * Re-enabling alerts reuses existing saved searches when possible and avoids duplicate subscriptions.
  * Alert controls remain unavailable until subscription and saved-search data has loaded.
  * Telegram and webhook subscription errors, including conflicts, now display clear feedback.
  * Subscription updates are handled more reliably when requests overlap with initial loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->