### PR TITLE
Say the setup card's anchor rule once, and stop the header claiming too much

### DIFF
--- a/web/src/lib/accountCompleteness.ts
+++ b/web/src/lib/accountCompleteness.ts
@@ -23,12 +23,11 @@ export interface CompletenessStep {
   id: string;
   label: string;
   href: SetupHref;
-  /** The id of the element on `href`'s page to land on, for a step whose page holds more
-   *  than the step asks for. Both steps that land on /my/profile need one: that page is
-   *  where this card is itself rendered, so without an anchor the link goes to where the
-   *  reader already stands and nothing appears to happen. An opaque string rather than a type shared
-   *  with the page — this module stays free of any SvelteKit import (see `SetupHref`) — so
-   *  it must be kept in sync by hand with that element's `id`. */
+  /** Where on `href`'s page to land. Required for `/my/profile`, which is the page this
+   *  card is itself rendered on: without an anchor the link goes to where the reader
+   *  already stands and nothing appears to happen. An opaque string rather than a type
+   *  shared with the page — this module stays free of any SvelteKit import (see
+   *  `SetupHref`) — so it is kept in sync by hand with that element's `id`. */
   hash?: string;
   done: boolean;
 }

--- a/web/src/lib/components/AccountSetupCard.svelte
+++ b/web/src/lib/components/AccountSetupCard.svelte
@@ -4,8 +4,9 @@
   import { outstandingOf, type CompletenessStep } from '$lib/accountCompleteness';
   import { ensureAccountSetupLoaded, setupSteps } from '$lib/accountSetup.svelte';
 
-  // "How complete is my account", above the profile page's section tabs — the page
-  // where every one of these fields is actually edited.
+  // "How complete is my account", above the profile page's section tabs. Two of its steps
+  // are done on that very page, which is why a step may carry an anchor (see stepHref);
+  // the rest point at other routes.
   //
   // A funnel beats a choose-your-own-adventure: the onboarding wizard asks these same
   // questions once, and this is what remains of them afterwards for anyone who skipped a


### PR DESCRIPTION
Say the setup card's anchor rule once, and stop the header claiming too much

Quality pass over the two anchor fixes, comments only.

The `hash` doc said the same thing twice - once as "for a step whose page
holds more than the step asks for", once as the concrete /my/profile
reason - and one line ran past the file's wrap.

The card's header comment called its page "where every one of these fields
is actually edited", which stopped being true when skills and location
became their own routes; alerts never was. It now says what the anchor is
for instead.

No behavior change: 1609 web tests green, svelte-check 0 errors.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified account setup guidance for navigating to relevant profile-page sections using anchors.
  * Updated setup-step documentation to reflect that some steps are completed directly on the profile page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->