### PR TITLE
Let cmd/ingest resync one board by hand via --board/--region

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -56,8 +56,10 @@ func run() int {
 	// provider name) or via INGEST_PROVIDER. An optional --shard=i/n (or the SHARD env)
 	// crawls only a round-robin slice of that provider's boards, so a provider with too
 	// many boards to finish in one timeout (workday) is spread across several staggered
-	// runs.
-	var provider, shardSpec string
+	// runs. --board=<id> (optionally narrowed further by --region=<code>) is the operator's
+	// hand-run equivalent: resync one company/keyword — e.g. one jobleads keyword, one
+	// workday tenant — without waiting for or disturbing the rest of the provider's crawl.
+	var provider, shardSpec, boardFilter, regionFilter string
 	for _, a := range os.Args[1:] {
 		switch {
 		case strings.HasPrefix(a, "--shard="):
@@ -66,6 +68,16 @@ func run() int {
 			// The value must be attached (--shard=i/n); a space-separated form would
 			// otherwise swallow the next arg (the provider name) as the selector's value.
 			log.Print("config: --shard needs an attached value, e.g. --shard=2/6")
+			return 1
+		case strings.HasPrefix(a, "--board="):
+			boardFilter = strings.TrimPrefix(a, "--board=")
+		case a == "--board":
+			log.Print(`config: --board needs an attached value, e.g. --board="Frontend Developer"`)
+			return 1
+		case strings.HasPrefix(a, "--region="):
+			regionFilter = strings.TrimPrefix(a, "--region=")
+		case a == "--region":
+			log.Print("config: --region needs an attached value, e.g. --region=IT")
 			return 1
 		case a != "" && !strings.HasPrefix(a, "-") && provider == "":
 			provider = a
@@ -129,6 +141,21 @@ func run() int {
 	// why sharding (below) can otherwise hide a region-ambiguous board from the board-scoped
 	// close's per-run safety check.
 	crossShardAmbiguousBoards := pipeline.AmbiguousBoardNames(boards)
+
+	// Narrow to one board (optionally one region), if requested. A typo here must not look
+	// like a legitimate empty targeted run (see the sweep's own note on those below) — an
+	// operator who asked for a specific board and got zero boards back needs to see why.
+	if boardFilter != "" || regionFilter != "" {
+		full := len(sourceCfg.Sources)
+		sourceCfg = sourceCfg.FilterBoard(boardFilter, regionFilter)
+		if len(sourceCfg.Sources) == 0 {
+			log.Printf("config: --board=%q --region=%q matched none of %s's %d board(s)",
+				boardFilter, regionFilter, provider, full)
+			return 1
+		}
+		log.Printf("ingest: board filter — crawling %d of %d boards for %s (board=%q region=%q)",
+			len(sourceCfg.Sources), full, provider, boardFilter, regionFilter)
+	}
 
 	// Narrow to this shard's slice, if requested.
 	if shardSpec != "" {

--- a/internal/ingest/sources/shard.go
+++ b/internal/ingest/sources/shard.go
@@ -60,3 +60,26 @@ func (c Config) Shard(i, n int) Config {
 	}
 	return Config{Provider: c.Provider, Sources: picked}
 }
+
+// FilterBoard returns a copy of the config holding only the entries matching board (skipped
+// when board == "") and region (skipped when region == "") — an operator-driven narrow for
+// resyncing one company/keyword (or one region's boards) by hand, without waiting for or
+// disturbing the rest of the provider's crawl. Board matching is exact: a board id is an
+// opaque platform identifier (or, for a keyword-as-board provider, the literal keyword), not
+// display text to fuzz-match. Both empty returns c unchanged.
+func (c Config) FilterBoard(board, region string) Config {
+	if board == "" && region == "" {
+		return c
+	}
+	var picked []CompanyEntry
+	for _, e := range c.Sources {
+		if board != "" && e.Board != board {
+			continue
+		}
+		if region != "" && e.Region != region {
+			continue
+		}
+		picked = append(picked, e)
+	}
+	return Config{Provider: c.Provider, Sources: picked}
+}

--- a/internal/ingest/sources/shard_test.go
+++ b/internal/ingest/sources/shard_test.go
@@ -120,3 +120,56 @@ func TestConfigShard_SingleShardIsFullConfig(t *testing.T) {
 		t.Error("Shard must preserve the file's default provider")
 	}
 }
+
+func TestConfigFilterBoard_MatchesOneBoardExactly(t *testing.T) {
+	cfg := Config{Provider: "jobleads", Sources: []CompanyEntry{
+		{Company: "JobLeads — Frontend Developer", Provider: "jobleads", Board: "Frontend Developer", Region: "IT"},
+		{Company: "JobLeads — Backend Developer", Provider: "jobleads", Board: "Backend Developer", Region: "IT"},
+	}}
+	got := cfg.FilterBoard("Frontend Developer", "")
+	if len(got.Sources) != 1 || got.Sources[0].Board != "Frontend Developer" {
+		t.Errorf("FilterBoard(%q, \"\") = %+v, want exactly the Frontend Developer entry", "Frontend Developer", got.Sources)
+	}
+	if got.Provider != "jobleads" {
+		t.Error("FilterBoard must preserve the config's default provider")
+	}
+}
+
+func TestConfigFilterBoard_RegionDisambiguatesARepeatedBoardID(t *testing.T) {
+	// A board id can repeat across independent regional slices (e.g. Adzuna's it-jobs).
+	cfg := Config{Provider: "adzuna", Sources: []CompanyEntry{
+		{Company: "Adzuna UK", Provider: "adzuna", Board: "it-jobs", Region: "GB"},
+		{Company: "Adzuna DE", Provider: "adzuna", Board: "it-jobs", Region: "DE"},
+	}}
+	got := cfg.FilterBoard("it-jobs", "DE")
+	if len(got.Sources) != 1 || got.Sources[0].Region != "DE" {
+		t.Errorf("FilterBoard(%q, %q) = %+v, want only the DE entry", "it-jobs", "DE", got.Sources)
+	}
+}
+
+func TestConfigFilterBoard_RegionAloneNarrowsWithoutABoard(t *testing.T) {
+	cfg := Config{Provider: "adzuna", Sources: []CompanyEntry{
+		{Company: "Adzuna UK", Provider: "adzuna", Board: "it-jobs", Region: "GB"},
+		{Company: "Adzuna DE", Provider: "adzuna", Board: "it-jobs", Region: "DE"},
+		{Company: "Adzuna DE eng", Provider: "adzuna", Board: "engineering-jobs", Region: "DE"},
+	}}
+	got := cfg.FilterBoard("", "DE")
+	if len(got.Sources) != 2 {
+		t.Errorf("FilterBoard(\"\", %q) matched %d entries, want 2", "DE", len(got.Sources))
+	}
+}
+
+func TestConfigFilterBoard_NoMatchReturnsEmptyNotFullConfig(t *testing.T) {
+	cfg := mkConfig("a", "b", "c")
+	got := cfg.FilterBoard("nonexistent", "")
+	if len(got.Sources) != 0 {
+		t.Errorf("FilterBoard on an unknown board = %d entries, want 0 — a typo must not silently crawl everything", len(got.Sources))
+	}
+}
+
+func TestConfigFilterBoard_BothEmptyReturnsConfigUnchanged(t *testing.T) {
+	cfg := mkConfig("a", "b", "c")
+	if got := companiesOf(cfg.FilterBoard("", "")); !reflect.DeepEqual(got, []string{"a", "b", "c"}) {
+		t.Errorf("FilterBoard(\"\", \"\") = %v, want the full config", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `--board=<id>` (optionally narrowed by `--region=<code>`) to `cmd/ingest`, alongside the existing `--shard=i/n`. It filters the provider's loaded boards down to an exact match before crawling — useful for resyncing one company/keyword by hand (e.g. one jobleads keyword while spot-checking the new adapter, or one workday tenant while debugging it) without waiting for or disturbing the rest of the provider's boards.

- Board matching is exact (case-sensitive) — a board id is an opaque platform identifier or, for a keyword-as-board provider, the literal keyword, not display text to fuzz-match.
- `--region` alone (no `--board`) also works, narrowing to one region's boards.
- A filter that matches nothing FAILS the run (exit 1) rather than silently crawling zero boards — a typo in the board name must not look like a legitimate empty targeted run. The sweep code already anticipated "a targeted run" as a case its company-scoped close handles correctly; this is that case's actual entry point.
- Applied before `--shard`, against the same unsharded board list `pipeline.AmbiguousBoardNames` already computes.

## Verified

- `gofmt -l` clean
- `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` clean
- `go test ./internal/ingest/sources/... ./cmd/ingest/...` passes (new `Config.FilterBoard` tests mirror the existing `Config.Shard` ones: exact match, region disambiguating a repeated board id, region-only narrowing, no-match-is-empty-not-full, both-empty-is-unchanged)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...` / `go vet -tags=integration ./...`
- [x] `go test ./internal/ingest/sources/... ./cmd/ingest/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to resync ingestion for a specific board and optionally filter by region.
  * Added validation for missing or invalid filter values.
  * Targeted runs now report the number of matching boards and stop with an error when no matches are found.

* **Tests**
  * Added coverage for board and region filtering, unknown boards, empty filters, and provider preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->