### PR TITLE
Stack the tailored-CV header on a narrow screen, instead of squeezing its title

### DIFF
--- a/web/src/lib/components/cv/CvList.svelte
+++ b/web/src/lib/components/cv/CvList.svelte
@@ -53,7 +53,7 @@
 </script>
 
 <div class="space-y-6">
-  <div class="flex items-start justify-between gap-4">
+  <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
     <div>
       <h1 class="text-2xl font-semibold">Tailored CVs</h1>
       <p class="text-sm text-muted-foreground">
@@ -61,7 +61,7 @@
         new one by opening the tailoring workspace from any vacancy.
       </p>
     </div>
-    <div class="flex shrink-0 items-center gap-2">
+    <div class="flex shrink-0 flex-wrap items-center gap-2">
       <a
         href={resolve('/my/cvs/appearance')}
         class="inline-flex items-center gap-1.5 rounded-lg border border-border px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"


### PR DESCRIPTION
The **Tailored CVs** header put the heading beside its two actions and marked the actions `shrink-0`. Flex then took the space it needed out of the only element that could give — the text. On a phone the title broke to one word per line and the description ran down the page as a ribbon.

Column on mobile, row from `sm` up — the idiom already used in `Footer.svelte` and `ReferralReviewView.svelte`. The actions may wrap, since the two of them do not fit one line at 360px.

Two class strings changed; no logic touched.

```
before (360px)          after (360px)
Tailored  [Appearance]  Tailored CVs
CVs       [Tailor for]  CVs you tailored for specific
CVs you                 roles. Open one to resume...
tailored
for                     [Appearance defaults]
specific                [Tailor for a job]
roles...
```

`pnpm --dir web test` — 1453 passed. Pre-commit hooks green (gitleaks, doc-links, design-system, web-lint).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the CV list header layout for smaller screens.
  * Action controls now wrap responsively, with horizontal alignment on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->