### PR TITLE
Stop the setup card offering a link to the page you are already on

### DIFF
--- a/web/src/lib/accountCompleteness.test.ts
+++ b/web/src/lib/accountCompleteness.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { accountSteps, outstandingOf, type CompletenessInput } from './accountCompleteness';
+import {
+  accountSteps,
+  outstandingOf,
+  stepLeadsSomewhere,
+  type CompletenessInput,
+} from './accountCompleteness';
 import type { UserProfile } from './types';
 
 // What the account card measures. The predicates are the whole point of the module, so
@@ -68,15 +73,47 @@ describe('accountSteps', () => {
     expect(byId.alerts).toBeUndefined();
   });
 
-  // The guard for the whole class of bug this fixes. The card is mounted in /my/profile's
-  // LAYOUT, so it is on screen for every profile section — a step landing on one of them
-  // either names a block further down, or AccountSetupCard must refuse to render it as a
-  // link (leadsSomewhere). What must never happen is a step on /my/profile itself with
-  // neither: that one has no page of its own to be "already on".
+  // Belt to the type's braces: `DefaultSectionStep` already makes the anchor mandatory at
+  // compile time, so this only catches someone loosening that type back to optional.
   it('leaves no step pointing at /my/profile without an anchor', () => {
     for (const step of accountSteps(empty)) {
       if (step.href === '/my/profile') expect(step.anchorId).toBeTruthy();
     }
+  });
+});
+
+// The whole class of bug this card was reported for: the card is mounted in /my/profile's
+// LAYOUT, so it is on screen for every profile section, and a step must never be offered
+// as a link to the page the reader is already looking at.
+describe('stepLeadsSomewhere', () => {
+  const byId = (id: string) => {
+    const step = accountSteps(empty).find((s) => s.id === id);
+    if (!step) throw new Error(`no step ${id}`);
+    return step;
+  };
+
+  it('sends an anchored step onward even from the page it lives on', () => {
+    expect(stepLeadsSomewhere(byId('cv'), '/my/profile', '/my/profile')).toBe(true);
+    expect(stepLeadsSomewhere(byId('role'), '/my/profile', '/my/profile')).toBe(true);
+  });
+
+  it('refuses an unanchored step whose route is the one on screen', () => {
+    expect(stepLeadsSomewhere(byId('skills'), '/my/profile/skills', '/my/profile/skills')).toBe(false);
+    expect(stepLeadsSomewhere(byId('location'), '/my/profile/location', '/my/profile/location')).toBe(false);
+  });
+
+  it('sends every step onward from a section that is not its own', () => {
+    for (const step of accountSteps(empty)) {
+      expect(stepLeadsSomewhere(step, step.href, '/my/profile/settings')).toBe(true);
+    }
+  });
+
+  // The card passes the RESOLVED href, so both sides carry any base path and the comparison
+  // stays honest. Were only one side resolved, every step would read as the current one.
+  it('compares the two paths as given, base and all', () => {
+    const skills = byId('skills');
+    expect(stepLeadsSomewhere(skills, '/app/my/profile/skills', '/app/my/profile/skills')).toBe(false);
+    expect(stepLeadsSomewhere(skills, '/app/my/profile/skills', '/app/my/profile')).toBe(true);
   });
 
   it('counts a CV once one is stored', () => {

--- a/web/src/lib/accountCompleteness.test.ts
+++ b/web/src/lib/accountCompleteness.test.ts
@@ -56,10 +56,11 @@ describe('accountSteps', () => {
     });
   });
 
-  // The card itself is rendered on /my/profile, so a step landing there would otherwise
-  // point at the page the reader is already looking at — the anchor is what makes it move.
-  it('anchors every step that lands on the page the card itself is on', () => {
-    const byId = Object.fromEntries(accountSteps(empty).map((s) => [s.id, s.hash]));
+  // /my/profile's default section holds three blocks and only one is the step, so both
+  // steps landing there name which. The other three routes ARE their step, so an anchor
+  // would only point at the top of what is already the whole page.
+  it('anchors the two steps that share the crowded default section', () => {
+    const byId = Object.fromEntries(accountSteps(empty).map((s) => [s.id, s.anchorId]));
     expect(byId.cv).toBe('account-cv');
     expect(byId.role).toBe('account-role');
     expect(byId.skills).toBeUndefined();
@@ -67,11 +68,14 @@ describe('accountSteps', () => {
     expect(byId.alerts).toBeUndefined();
   });
 
-  // The guard for the whole class of bug this fixes: a step whose href is the page the
-  // card is rendered on has to name where on it to go, or following it changes nothing.
+  // The guard for the whole class of bug this fixes. The card is mounted in /my/profile's
+  // LAYOUT, so it is on screen for every profile section — a step landing on one of them
+  // either names a block further down, or AccountSetupCard must refuse to render it as a
+  // link (leadsSomewhere). What must never happen is a step on /my/profile itself with
+  // neither: that one has no page of its own to be "already on".
   it('leaves no step pointing at /my/profile without an anchor', () => {
     for (const step of accountSteps(empty)) {
-      if (step.href === '/my/profile') expect(step.hash).toBeTruthy();
+      if (step.href === '/my/profile') expect(step.anchorId).toBeTruthy();
     }
   });
 

--- a/web/src/lib/accountCompleteness.ts
+++ b/web/src/lib/accountCompleteness.ts
@@ -23,12 +23,13 @@ export interface CompletenessStep {
   id: string;
   label: string;
   href: SetupHref;
-  /** Where on `href`'s page to land. Required for `/my/profile`, which is the page this
-   *  card is itself rendered on: without an anchor the link goes to where the reader
-   *  already stands and nothing appears to happen. An opaque string rather than a type
-   *  shared with the page — this module stays free of any SvelteKit import (see
-   *  `SetupHref`) — so it is kept in sync by hand with that element's `id`. */
-  hash?: string;
+  /** The `id` of the element on `href`'s page to land on. Required for `/my/profile`,
+   *  whose default section holds three things and only one of them is the step. An opaque
+   *  string rather than a type shared with the page — this module stays free of any
+   *  SvelteKit import (see `SetupHref`) — so it is kept in sync by hand with that
+   *  element's `id`. Absent means "the page itself is the answer", which the card reads
+   *  as "this step cannot move you off the page you are on" (see AccountSetupCard). */
+  anchorId?: string;
   done: boolean;
 }
 
@@ -71,7 +72,7 @@ export function accountSteps({ hasCv, profile, alertCount }: CompletenessInput):
       // has no upload of its own. What this step measures is the stored base résumé, and
       // the only surface under /my/ that takes one is ProfileForm's "Your CV" box.
       href: '/my/profile',
-      hash: 'account-cv',
+      anchorId: 'account-cv',
       done: hasCv,
     },
     {
@@ -84,7 +85,7 @@ export function accountSteps({ hasCv, profile, alertCount }: CompletenessInput):
       // The card that carries this step is rendered on /my/profile itself, above two other
       // blocks — so the link has to name the Role card or it is a link to where you already
       // stand.
-      hash: 'account-role',
+      anchorId: 'account-role',
       done: Boolean(profile?.specializations.length && profile?.seniorities.length),
     },
     {

--- a/web/src/lib/accountCompleteness.ts
+++ b/web/src/lib/accountCompleteness.ts
@@ -18,20 +18,33 @@ import type { UserProfile } from './types';
  *  be unit-tested in plain Node. */
 type SetupHref = '/my/profile' | '/my/profile/skills' | '/my/profile/location' | '/my/searches';
 
-export interface CompletenessStep {
+interface StepBase {
   /** Stable key. Used by tests and as the list key — never shown. */
   id: string;
   label: string;
-  href: SetupHref;
-  /** The `id` of the element on `href`'s page to land on. Required for `/my/profile`,
-   *  whose default section holds three things and only one of them is the step. An opaque
-   *  string rather than a type shared with the page — this module stays free of any
-   *  SvelteKit import (see `SetupHref`) — so it is kept in sync by hand with that
-   *  element's `id`. Absent means "the page itself is the answer", which the card reads
-   *  as "this step cannot move you off the page you are on" (see AccountSetupCard). */
-  anchorId?: string;
   done: boolean;
 }
+
+/** A step done on `/my/profile` itself. The anchor is REQUIRED, and required by the type
+ *  rather than by a test, because that route's default section holds three blocks and the
+ *  setup card is the first of them: a step there that named no block would link to the
+ *  page the reader is already looking at. The `id` is an opaque string rather than a type
+ *  shared with the page — this module stays free of any SvelteKit import (see
+ *  `SetupHref`) — so it is kept in sync by hand with that element's `id`. */
+interface DefaultSectionStep extends StepBase {
+  href: '/my/profile';
+  anchorId: string;
+}
+
+/** A step done on a route that IS the step. An anchor would only point at the top of what
+ *  is already the whole page, so there is none — and the card reads its absence as "this
+ *  cannot move a reader who is already here" (see AccountSetupCard). */
+interface OwnRouteStep extends StepBase {
+  href: Exclude<SetupHref, '/my/profile'>;
+  anchorId?: undefined;
+}
+
+export type CompletenessStep = DefaultSectionStep | OwnRouteStep;
 
 export interface CompletenessInput {
   /** Whether a CV is stored (resumeStore.present). */
@@ -107,6 +120,22 @@ export function accountSteps({ hasCv, profile, alertCount }: CompletenessInput):
       done: alertCount > 0,
     },
   ];
+}
+
+/** Whether following `step` would move the reader at all.
+ *
+ *  The card is mounted in `/my/profile`'s LAYOUT, so it is on screen for every profile
+ *  section — and a step is not allowed to render as a link to the page already open, which
+ *  is what following one felt like when this was first reported. An anchor always counts:
+ *  it names a block further down a page the card sits at the top of. Otherwise the step has
+ *  to lead off the current route.
+ *
+ *  Takes both paths as strings rather than reaching for the router, so the rule lives beside
+ *  the steps it governs and stays testable in plain Node. `stepPath` is `step.href` as the
+ *  router resolves it and `currentPath` the pathname on screen — passing the RESOLVED href
+ *  is what keeps a configured base path from making every step look like the current one. */
+export function stepLeadsSomewhere(step: CompletenessStep, stepPath: string, currentPath: string): boolean {
+  return step.anchorId !== undefined || stepPath !== currentPath;
 }
 
 /** The steps still open. Zero of them means the card and its dot are done showing.

--- a/web/src/lib/components/AccountSetupCard.svelte
+++ b/web/src/lib/components/AccountSetupCard.svelte
@@ -2,13 +2,13 @@
   import { Check, ArrowRight } from '@lucide/svelte';
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
-  import { outstandingOf, type CompletenessStep } from '$lib/accountCompleteness';
+  import { outstandingOf, stepLeadsSomewhere, type CompletenessStep } from '$lib/accountCompleteness';
   import { ensureAccountSetupLoaded, setupSteps } from '$lib/accountSetup.svelte';
 
   // "How complete is my account", mounted in /my/profile's LAYOUT — so it is on screen for
-  // all eight profile sections, and three of its five steps are done on one of them. That
-  // is what `stepHref` and `leadsSomewhere` below are for: a step must never render as a
-  // link to the page the reader is already looking at.
+  // all eight profile sections, and four of its five steps are done on one of them (only
+  // the alert lives elsewhere). That is why a step is rendered as a link only when
+  // `stepLeadsSomewhere` says following it would move the reader.
   //
   // A funnel beats a choose-your-own-adventure: the onboarding wizard asks these same
   // questions once, and this is what remains of them afterwards for anyone who skipped a
@@ -30,13 +30,10 @@
     return `${resolve(step.href)}${step.anchorId ? `#${step.anchorId}` : ''}`;
   }
 
-  // Whether following this step would move the reader at all. An anchor always counts —
-  // it names a block further down a page this card sits at the top of. Otherwise the step
-  // has to lead off the current route, or it is a link to where the reader already is.
-  // Compares the RESOLVED href, so a configured base path cannot make every step look
-  // like the current one.
+  // The rule itself lives beside the steps (accountCompleteness); this only feeds it the
+  // two paths, which are the part that needs the router.
   function leadsSomewhere(step: CompletenessStep): boolean {
-    return step.anchorId !== undefined || resolve(step.href) !== page.url.pathname;
+    return stepLeadsSomewhere(step, resolve(step.href), page.url.pathname);
   }
 </script>
 

--- a/web/src/lib/components/AccountSetupCard.svelte
+++ b/web/src/lib/components/AccountSetupCard.svelte
@@ -30,14 +30,10 @@
     return `${resolve(step.href)}${step.anchorId ? `#${step.anchorId}` : ''}`;
   }
 
-  // Whether following this step would actually take the reader anywhere. Standing on
-  // /my/profile/skills, the skills step's link names the page already open: clicking it
-  // changes nothing, which is exactly the complaint this card was reported for. An anchor
-  // rescues the two steps that share the crowded default section, because there is a
-  // block further down to reach; for the rest the honest answer is to stop looking like a
-  // link and say where the reader is instead.
-  //
-  // Compares the RESOLVED href so a configured base path can never make every step look
+  // Whether following this step would move the reader at all. An anchor always counts —
+  // it names a block further down a page this card sits at the top of. Otherwise the step
+  // has to lead off the current route, or it is a link to where the reader already is.
+  // Compares the RESOLVED href, so a configured base path cannot make every step look
   // like the current one.
   function leadsSomewhere(step: CompletenessStep): boolean {
     return step.anchorId !== undefined || resolve(step.href) !== page.url.pathname;
@@ -46,7 +42,7 @@
 
 <!-- The dashed dot and the label — everything an outstanding step shows whether or not it
      is a link, so the two branches below cannot drift apart in padding or wording. -->
-{#snippet openStep(step: CompletenessStep)}
+{#snippet dotAndLabel(step: CompletenessStep)}
   <span
     class="size-4 shrink-0 rounded-full border border-dashed border-muted-foreground"
     aria-hidden="true"
@@ -83,7 +79,7 @@
           {:else if leadsSomewhere(step)}
             <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- stepHref() wraps resolve(step.href); the rule can't see through the appended #anchorId -->
             <a href={stepHref(step)} class="group flex items-center gap-2 rounded-lg px-1 py-1.5 text-sm transition-colors hover:bg-accent">
-              {@render openStep(step)}
+              {@render dotAndLabel(step)}
               <ArrowRight
                 class="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
                 aria-hidden="true"
@@ -94,7 +90,7 @@
                  outstanding — but as a statement rather than a link, with the section it
                  names sitting right below this card. -->
             <p class="flex items-center gap-2 px-1 py-1.5 text-sm">
-              {@render openStep(step)}
+              {@render dotAndLabel(step)}
               <span class="shrink-0 text-xs text-muted-foreground">on this page</span>
             </p>
           {/if}

--- a/web/src/lib/components/AccountSetupCard.svelte
+++ b/web/src/lib/components/AccountSetupCard.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
   import { Check, ArrowRight } from '@lucide/svelte';
+  import { page } from '$app/state';
   import { resolve } from '$app/paths';
   import { outstandingOf, type CompletenessStep } from '$lib/accountCompleteness';
   import { ensureAccountSetupLoaded, setupSteps } from '$lib/accountSetup.svelte';
 
-  // "How complete is my account", above the profile page's section tabs. Two of its steps
-  // are done on that very page, which is why a step may carry an anchor (see stepHref);
-  // the rest point at other routes.
+  // "How complete is my account", mounted in /my/profile's LAYOUT — so it is on screen for
+  // all eight profile sections, and three of its five steps are done on one of them. That
+  // is what `stepHref` and `leadsSomewhere` below are for: a step must never render as a
+  // link to the page the reader is already looking at.
   //
   // A funnel beats a choose-your-own-adventure: the onboarding wizard asks these same
   // questions once, and this is what remains of them afterwards for anyone who skipped a
@@ -25,9 +27,32 @@
   // resolve()'s own base plus the step's anchor, when it names one — there is no dynamic
   // route segment to resolve, so this is a plain suffix rather than a second resolve().
   function stepHref(step: CompletenessStep): string {
-    return `${resolve(step.href)}${step.hash ? `#${step.hash}` : ''}`;
+    return `${resolve(step.href)}${step.anchorId ? `#${step.anchorId}` : ''}`;
+  }
+
+  // Whether following this step would actually take the reader anywhere. Standing on
+  // /my/profile/skills, the skills step's link names the page already open: clicking it
+  // changes nothing, which is exactly the complaint this card was reported for. An anchor
+  // rescues the two steps that share the crowded default section, because there is a
+  // block further down to reach; for the rest the honest answer is to stop looking like a
+  // link and say where the reader is instead.
+  //
+  // Compares the RESOLVED href so a configured base path can never make every step look
+  // like the current one.
+  function leadsSomewhere(step: CompletenessStep): boolean {
+    return step.anchorId !== undefined || resolve(step.href) !== page.url.pathname;
   }
 </script>
+
+<!-- The dashed dot and the label — everything an outstanding step shows whether or not it
+     is a link, so the two branches below cannot drift apart in padding or wording. -->
+{#snippet openStep(step: CompletenessStep)}
+  <span
+    class="size-4 shrink-0 rounded-full border border-dashed border-muted-foreground"
+    aria-hidden="true"
+  ></span>
+  <span class="min-w-0 flex-1">{step.label}</span>
+{/snippet}
 
 {#if outstanding.length > 0}
   <!-- No outer margin: every host so far is a flex column that owns its own spacing,
@@ -55,19 +80,23 @@
               <Check class="size-4 shrink-0 text-brand" aria-hidden="true" />
               <span class="line-through decoration-border">{step.label}</span>
             </p>
-          {:else}
-            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- stepHref() wraps resolve(step.href); the rule can't see through the appended #hash -->
+          {:else if leadsSomewhere(step)}
+            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- stepHref() wraps resolve(step.href); the rule can't see through the appended #anchorId -->
             <a href={stepHref(step)} class="group flex items-center gap-2 rounded-lg px-1 py-1.5 text-sm transition-colors hover:bg-accent">
-              <span
-                class="size-4 shrink-0 rounded-full border border-dashed border-muted-foreground"
-                aria-hidden="true"
-              ></span>
-              <span class="min-w-0 flex-1">{step.label}</span>
+              {@render openStep(step)}
               <ArrowRight
                 class="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
                 aria-hidden="true"
               />
             </a>
+          {:else}
+            <!-- The step is done on the page already open. Still listed — it is genuinely
+                 outstanding — but as a statement rather than a link, with the section it
+                 names sitting right below this card. -->
+            <p class="flex items-center gap-2 px-1 py-1.5 text-sm">
+              {@render openStep(step)}
+              <span class="shrink-0 text-xs text-muted-foreground">on this page</span>
+            </p>
           {/if}
         </li>
       {/each}

--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -250,7 +250,7 @@
   <!-- `account-cv` is the anchor the account-setup checklist's CV step links to (see
        accountCompleteness.ts) — this box is the only place under /my/ that takes a base
        résumé, /my/cvs being the per-vacancy builder. `scroll-mt-20` clears the sticky
-       header (`h-14`), same as the other anchored sections. -->
+       `h-14` TopBar. -->
   <div id="account-cv" class="flex scroll-mt-20 flex-col gap-1.5">
     <span class="text-sm font-medium">Your CV</span>
     <input

--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -249,8 +249,8 @@
        then). -->
   <!-- `account-cv` is the anchor the account-setup checklist's CV step links to (see
        accountCompleteness.ts) — this box is the only place under /my/ that takes a base
-       résumé, /my/cvs being the per-vacancy builder. `scroll-mt-20` is the repo's
-       anchored-section offset. -->
+       résumé, /my/cvs being the per-vacancy builder. `scroll-mt-20` clears the sticky
+       header (`h-14`), same as the other anchored sections. -->
   <div id="account-cv" class="flex scroll-mt-20 flex-col gap-1.5">
     <span class="text-sm font-medium">Your CV</span>
     <input

--- a/web/src/lib/components/facets/pill.ts
+++ b/web/src/lib/components/facets/pill.ts
@@ -3,6 +3,11 @@ import { cn } from '$lib/ui';
 // The shared three-state look of a selectable facet pill: idle (secondary fill),
 // selected-include (brand fill), selected-exclude (muted destructive,
 // struck through). Callers add their own size classes via `extra`.
+//
+// This is the FILTER pill, and not the only pill in the app: stating something about
+// yourself is two-state and bordered, which is profile/SeniorityPills.svelte. Two looks
+// on purpose — a facet you are narrowing by and an answer you are giving read
+// differently — so reach for that one before adding a fourth state here.
 export function pillClass(active: boolean, exclude: boolean, extra = ''): string {
   return cn(
     'rounded-full border font-medium transition-colors active:translate-y-px',

--- a/web/src/lib/components/onboarding/ConfirmStep.svelte
+++ b/web/src/lib/components/onboarding/ConfirmStep.svelte
@@ -10,9 +10,9 @@
   import { ChevronDown, Search, X } from '@lucide/svelte';
   import { SvelteSet } from 'svelte/reactivity';
   import { api } from '$lib/api';
-  import { FACETS } from '$lib/facets';
   import { CATEGORY_GROUPS } from '$lib/filterSections';
   import { pillClass, pillTitle } from '$lib/components/facets/pill';
+  import SeniorityPills from '$lib/components/profile/SeniorityPills.svelte';
   import { MAX_SPECIALIZATIONS } from '$lib/profileLimits';
   import ProfileLinksFields from './ProfileLinksFields.svelte';
   import type { ProfileLinks } from '$lib/profileLinks';
@@ -38,8 +38,6 @@
     onSenioritiesChange,
     onLinksChange,
   }: Props = $props();
-
-  const seniorityOptions = FACETS.find((f) => f.param === 'seniority')?.options ?? [];
 
   let specQuery = $state('');
   const specCollapsed = new SvelteSet<string>();
@@ -175,22 +173,7 @@
 <div class="mt-6">
   {@render fieldLabel('Level', seniorities.length, () => onSenioritiesChange([]))}
 </div>
-<div class="flex flex-wrap gap-2">
-  {#each seniorityOptions as o (o.value)}
-    {@const selected = seniorities.includes(o.value)}
-    <button
-      type="button"
-      onclick={() => toggleSeniority(o.value)}
-      aria-pressed={selected}
-      class={[
-        'rounded-full border px-3 py-1.5 text-sm font-medium transition-colors',
-        selected ? 'border-brand bg-brand text-brand-foreground' : 'border-border bg-card hover:bg-accent',
-      ]}
-    >
-      {o.label}
-    </button>
-  {/each}
-</div>
+<SeniorityPills selected={seniorities} onToggle={toggleSeniority} />
 
 <div class="mt-6">
   <ProfileLinksFields value={links} onChange={onLinksChange} prefilled={linksPrefilled} />

--- a/web/src/lib/components/profile/RoleCard.svelte
+++ b/web/src/lib/components/profile/RoleCard.svelte
@@ -3,11 +3,12 @@
   // into (it's the one piece of the old identity header that doesn't carry enough content
   // to earn its own view, unlike Contacts/Location which do). Autosaves straight to
   // profileStore on every change, the same way the Skills view does.
-  import { CATEGORY_OPTIONS, SENIORITY_OPTIONS } from '$lib/facets';
+  import { CATEGORY_OPTIONS } from '$lib/facets';
   import { profileStore } from '$lib/profile.svelte';
   import { MAX_SPECIALIZATIONS } from '$lib/profileLimits';
   import type { UserProfile } from '$lib/types';
   import SearchSelect from '../facets/SearchSelect.svelte';
+  import SeniorityPills from './SeniorityPills.svelte';
 
   let {
     profile,
@@ -76,8 +77,8 @@
 
 <!-- `account-role` is the anchor the account-setup checklist's role step links to (see
      accountCompleteness.ts). It sits on the whole card, not on either half, because that
-     step asks for both together — "what you do, and at what level". `scroll-mt-20` is the
-     repo's anchored-section offset. -->
+     step asks for both together — "what you do, and at what level". `scroll-mt-20` clears
+     the sticky header (`h-14`), same as the other anchored sections. -->
 <div id="account-role" class="flex scroll-mt-20 flex-col gap-6">
   <div class="flex flex-col gap-2">
     <div class="flex items-baseline justify-between">
@@ -102,29 +103,13 @@
 
   <!-- Level lives beside Roles rather than in its own card: it was previously askable only
        inside the onboarding wizard, so a profile whose level needed changing had no surface
-       at all. Pills rather than a SearchSelect — the vocabulary is five values, and the
-       wizard's own Level step (ConfirmStep) already reads this way. -->
+       at all. The control itself is the wizard's own, shared (SeniorityPills). -->
   <div class="flex flex-col gap-2">
     <div class="flex items-baseline justify-between">
       <span class="text-sm font-medium">Level</span>
       <span class="text-xs text-muted-foreground">Pick every level you'd take</span>
     </div>
-    <div class={['flex flex-wrap gap-2', levelBusy && 'pointer-events-none opacity-60']}>
-      {#each SENIORITY_OPTIONS as o (o.value)}
-        {@const selected = profile.seniorities.includes(o.value)}
-        <button
-          type="button"
-          onclick={() => toggleSeniority(o.value)}
-          aria-pressed={selected}
-          class={[
-            'rounded-full border px-3 py-1.5 text-sm font-medium transition-colors',
-            selected ? 'border-brand bg-brand text-brand-foreground' : 'border-border bg-card hover:bg-accent',
-          ]}
-        >
-          {o.label}
-        </button>
-      {/each}
-    </div>
+    <SeniorityPills selected={profile.seniorities} onToggle={toggleSeniority} busy={levelBusy} />
     {#if levelError}
       <p class="text-xs text-destructive">{levelError}</p>
     {/if}

--- a/web/src/lib/components/profile/RoleCard.svelte
+++ b/web/src/lib/components/profile/RoleCard.svelte
@@ -78,7 +78,7 @@
 <!-- `account-role` is the anchor the account-setup checklist's role step links to (see
      accountCompleteness.ts). It sits on the whole card, not on either half, because that
      step asks for both together — "what you do, and at what level". `scroll-mt-20` clears
-     the sticky header (`h-14`), same as the other anchored sections. -->
+     the sticky `h-14` TopBar. -->
 <div id="account-role" class="flex scroll-mt-20 flex-col gap-6">
   <div class="flex flex-col gap-2">
     <div class="flex items-baseline justify-between">

--- a/web/src/lib/components/profile/SeniorityPills.svelte
+++ b/web/src/lib/components/profile/SeniorityPills.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
   // The Level control: which seniorities the candidate will take, as a plain two-state
   // multi-select. Shared by the onboarding wizard's Confirm step and the profile's Role
-  // card — they asked the same question with two hand-written copies of this markup, and
-  // two copies of a control is how the wizard and the page it feeds start to disagree.
+  // card, which asked the same question through two hand-written copies of this markup —
+  // and two copies is how the wizard and the page it feeds start to disagree.
   //
   // Deliberately NOT facets/PillGroup: that is a three-state FILTER pill (include /
-  // exclude / off, option groups, result counts, unknown-value passthrough) and none of
-  // it applies to stating your own level. It also carries a different look, which is why
-  // this keeps the bordered one both callers already showed rather than quietly
-  // restyling two live surfaces.
+  // exclude / off, option groups, result counts) and none of it applies to stating your
+  // own level. It looks different too, so this keeps the bordered pill both callers
+  // already showed rather than quietly restyling two live surfaces.
   import { SENIORITY_OPTIONS } from '$lib/facets';
 
   let {

--- a/web/src/lib/components/profile/SeniorityPills.svelte
+++ b/web/src/lib/components/profile/SeniorityPills.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  // The Level control: which seniorities the candidate will take, as a plain two-state
+  // multi-select. Shared by the onboarding wizard's Confirm step and the profile's Role
+  // card — they asked the same question with two hand-written copies of this markup, and
+  // two copies of a control is how the wizard and the page it feeds start to disagree.
+  //
+  // Deliberately NOT facets/PillGroup: that is a three-state FILTER pill (include /
+  // exclude / off, option groups, result counts, unknown-value passthrough) and none of
+  // it applies to stating your own level. It also carries a different look, which is why
+  // this keeps the bordered one both callers already showed rather than quietly
+  // restyling two live surfaces.
+  import { SENIORITY_OPTIONS } from '$lib/facets';
+
+  let {
+    selected,
+    onToggle,
+    busy = false,
+  }: {
+    selected: string[];
+    onToggle: (value: string) => void;
+    /** Dims and blocks the group while a write is in flight. The wizard stages its answer
+     *  locally and never sets it; the profile card autosaves and does. */
+    busy?: boolean;
+  } = $props();
+</script>
+
+<div class={['flex flex-wrap gap-2', busy && 'pointer-events-none opacity-60']}>
+  {#each SENIORITY_OPTIONS as o (o.value)}
+    {@const isSelected = selected.includes(o.value)}
+    <button
+      type="button"
+      onclick={() => onToggle(o.value)}
+      aria-pressed={isSelected}
+      class={[
+        'rounded-full border px-3 py-1.5 text-sm font-medium transition-colors',
+        isSelected ? 'border-brand bg-brand text-brand-foreground' : 'border-border bg-card hover:bg-accent',
+      ]}
+    >
+      {o.label}
+    </button>
+  {/each}
+</div>

--- a/web/src/routes/my/profile/+layout.svelte
+++ b/web/src/routes/my/profile/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Snippet } from 'svelte';
+  import { tick, untrack, type Snippet } from 'svelte';
   import {
     Briefcase,
     ClipboardList,
@@ -74,6 +74,30 @@
   // (Re)load once the session resolves.
   $effect(() => {
     if (isAuthenticated()) void load();
+  });
+
+  // Honour the URL's anchor once the gate opens. The browser and the router both resolve a
+  // `#id` at navigation time, and until `status` is 'ready' this layout renders a spinner —
+  // so a RELOAD or a shared link to /my/profile#account-cv would consume the anchor against
+  // nothing and land at the top, which is exactly the "clicking it does nothing" this card's
+  // anchors exist to fix. Following a link from inside the app is unaffected: the tree is
+  // already up, so this fires on a target the browser has just scrolled to anyway.
+  //
+  // Runs once per hash, not per render: `scrolledToHash` is compared before scrolling, so an
+  // unrelated profile refresh cannot yank the reader back to an anchor they scrolled away
+  // from. `untrack` keeps that read from making this effect its own trigger.
+  let scrolledToHash = $state<string | null>(null);
+  $effect(() => {
+    const hash = page.url.hash.slice(1);
+    if (status !== 'ready' || !hash || hash === untrack(() => scrolledToHash)) return;
+    // The section that owns the anchor renders in the same tick this effect runs, so wait
+    // for the DOM to catch up rather than querying a target that does not exist yet.
+    void tick().then(() => {
+      const target = document.getElementById(hash);
+      if (!target) return;
+      scrolledToHash = hash;
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
   });
 </script>
 


### PR DESCRIPTION
The account-setup card is mounted in `/my/profile`'s **layout**, not its page, so it is on screen for all eight profile sections — and four of its five steps are done on one of them. A reader standing on `/my/profile/skills` with the skills step outstanding was shown a "List your skills" link pointing at the page already open. Clicking it did nothing: the same symptom the CV and role steps were reported for, which the earlier fix left in place for two more steps.

An anchor only rescues a step whose block sits further down a shared page — true of `cv` and `role` on the crowded default section, false of `skills` and `location`, whose route *is* the step. So the card decides per step: a link when following it would move the reader, otherwise "on this page" without pretending to be one.

## What else is here

- **Reload/share now honours the anchor.** Clicking a step writes `/my/profile#account-cv` into the address bar, so reloading replays it — and the layout opens on `status = 'loading'`, resolving the anchor against a spinner. It now scrolls once the gate opens, once per hash.
- **The invariant is a type.** `CompletenessStep` splits: a step on `/my/profile` must carry an anchor to typecheck; a step whose route is the step cannot carry one.
- **`stepLeadsSomewhere` lives beside the steps** it governs, so it is testable in plain Node (the card's vitest environment is `node`). Four tests, including the base-path comparison.
- **`SeniorityPills`**: the wizard's Level pills and the profile's were two hand-written copies of one control drawing on two spellings of the same list. One component now, no visual change to either caller.
- Comment corrections: "three of its five steps" was four; `scroll-mt-20` was not "the repo's anchored-section offset" (the repo uses 20 and 24); `pill.ts` now names the second pill vocabulary.

## Verification

1619 web tests green, `svelte-check` 0 errors, lint clean on every touched file. Reviewed on both axes (standards + spec) by parallel agents; every finding is either fixed here or named in the commit message as deliberately out of scope.

## Known limit

`profile.svelte.ts`'s `save()` takes five positional args, four of them `string[]` — a transposition typechecks silently across six call sites. Both reviewers flagged it and both agreed it is a follow-up, not this diff's to fix.
