### PR TITLE
Let the account page know the third tier, and stop the docs contradicting the code

### DIFF
--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -64,7 +64,8 @@ a scheduled Dependabot run made every deploy stop, silently, at exit 0.
   half is copying it to the host and running `systemctl daemon-reload`. Treat git as the
   truth and the host as the copy, not the other way round, or this snapshot rots into
   fiction within a month.
-- **Billing reads four variables from `/opt/freehire/.env`, and is inert without them.**
+- **Billing reads four required variables from `/opt/freehire/.env`, and is inert without
+  them.**
   `STRIPE_SECRET_KEY` (`sk_…`), `STRIPE_WEBHOOK_SECRET` (`whsec_…`), `STRIPE_PRICE_IDS`, and
   `FRONTEND_ORIGIN` — which the fleet already sets, and which is reused rather than given a
   billing-specific twin that would disagree with it the first time one was changed. With any missing, every billing route is simply not mounted and the timer is a
@@ -76,6 +77,15 @@ a scheduled Dependabot run made every deploy stop, silently, at exit 0.
   plan. An empty list is not a default that sells the obvious thing — it confers Pro on
   nobody, deliberately, because the alternative to refusing a misconfiguration is granting
   one.
+
+  **`STRIPE_ULTRA_PRICE_IDS` is the fifth, and it is OPTIONAL** — the same list shape, for
+  the prices that confer the Ultra tier rather than Pro. Unset, nobody is ever resolved to
+  ultra, the pricing page shows two plans instead of three, and Pro and Free behave exactly
+  as they did before it existed; that is what makes it safe to deploy the code before the
+  price is created. Which tier a subscription confers is decided by which of these two lists
+  its price appears in, so a price named in neither confers nothing, and a price named in
+  both confers Ultra — a misconfiguration, but one that fails toward the plan the customer
+  paid more for.
 
   Two steps happen in the provider's dashboard and nowhere else: registering the webhook at
   `https://freehire.me/api/v1/billing/stripe/webhook` (its `whsec_` secret is shown once,

--- a/internal/ai/plan/AGENTS.md
+++ b/internal/ai/plan/AGENTS.md
@@ -1,7 +1,10 @@
 # Plan and allowance conventions
 
 ## Scope
-The plan a user is on and the per-day allowance each metered AI feature draws from. One
+The plan a user is on and the per-day allowance each metered feature draws from. Five of the
+six are AI features whose cost is a model call; the sixth, auto-apply, is a headless browser
+submitting an application, and it is shaped differently for that reason wherever it differs.
+One
 question in, yes or no out: `Consume(user, feature, ref)`. Which plan, what it allows, how
 much is left and whether a refusal is switched on are all this package's business.
 
@@ -124,10 +127,18 @@ transaction. `store.go` is the transaction around it and nothing else.
   reconnect are work already paid for; refusing one charges the candidate for looking at
   their own result twice.
 
-- **Every meter fails open.** A counter that cannot be read logs and lets the action
-  through uncharged. Bookkeeping must never refuse a legitimate request, and an uncharged
-  turn is a smaller wrong than a candidate stopped by our accounting. The atomic
+- **Every meter fails open — EXCEPT auto-apply.** A counter that cannot be read logs and
+  lets the action through uncharged. Bookkeeping must never refuse a legitimate request, and
+  an uncharged turn is a smaller wrong than a candidate stopped by our accounting. The atomic
   consumption is the real ceiling, not the pre-checks in front of it.
+
+  The exception is auto-apply, and the rule above is why it is one. Everywhere else the
+  action is a model call whose cost we absorb, so an unmeasured one is a rounding error.
+  auto-apply drives a browser and submits a REAL application to a REAL employer under
+  somebody's name — an unmeasured one is not ours to absorb, and it is not undoable. The
+  honest answer to "we could not tell whether you may" is to say so, so `chargeAutoApply`
+  answers 503 both when the charge errors and when the meter is absent. Nothing else in this
+  package may copy that without an argument of the same shape.
 
 - **A refusal is 402 and must precede the stream.** Writing it after the headers are out
   makes it an event inside a 200 — invisible to anything checking status codes. Note that

--- a/internal/api/handler/me_plan.go
+++ b/internal/api/handler/me_plan.go
@@ -36,9 +36,14 @@ func (h *planHandlers) register(api fiber.Router, mw middleware) {
 type planResponse struct {
 	Plan     string    `json:"plan"`
 	ResetsAt time.Time `json:"resets_at"`
-	// ProUntil is when the Pro plan lapses, absent on the free plan. It is read from the
-	// stored column, never from the billing provider — this endpoint must keep answering
-	// when the provider does not.
+	// ProUntil is when the caller's PAID plan lapses, absent on the free plan. It is read
+	// from the stored column, never from the billing provider — this endpoint must keep
+	// answering when the provider does not.
+	//
+	// It carries whichever tier the caller is actually on: an ultra subscriber gets their
+	// ultra entitlement here, not a NULL taken from the pro columns they do not hold. The
+	// field keeps its `pro_` spelling because clients read it and a rename buys nothing —
+	// what it has always meant is "when does the plan you are paying for run out".
 	ProUntil *time.Time `json:"pro_until,omitempty"`
 	// ProSource is where the plan was bought: "stripe", "revenuecat" or "granted". Absent on
 	// the free plan, alongside ProUntil.
@@ -59,19 +64,21 @@ type planResponse struct {
 // first, so the answer is stable across deployments. A tie means two origins reach the same
 // instant, which is rare and harmless; naming Stripe first points a client's cancellation
 // advice at the surface the subscriber most likely bought through.
-func proSourceOf(row db.GetProUntilSourcesRow) string {
-	if !row.ProUntil.Valid {
+// It takes the derived instant and this tier's three sources rather than the whole row, so
+// that adding a tier cannot leave it silently answering about the wrong one.
+func planSourceOf(derived, stripe, revenuecat, granted pgtype.Timestamptz) string {
+	if !derived.Valid {
 		return ""
 	}
 	for _, c := range []struct {
 		name  string
 		value pgtype.Timestamptz
 	}{
-		{"stripe", row.ProUntilStripe},
-		{"revenuecat", row.ProUntilRevenuecat},
-		{"granted", row.ProUntilGranted},
+		{"stripe", stripe},
+		{"revenuecat", revenuecat},
+		{"granted", granted},
 	} {
-		if c.value.Valid && c.value.Time.Equal(row.ProUntil.Time) {
+		if c.value.Valid && c.value.Time.Equal(derived.Time) {
 			return c.name
 		}
 	}
@@ -112,10 +119,21 @@ func (h *planHandlers) GetMyPlan(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	if sources.ProUntil.Valid && sources.ProUntil.Time.After(time.Now()) {
-		when := sources.ProUntil.Time
+	// The columns of the tier the caller is ACTUALLY on. Reading the pro ones unconditionally
+	// answered "ultra" with no until and no source — and pro_source is behavioural, so a
+	// client deciding whether to offer an in-app purchase from an empty one would sell Ultra
+	// to somebody already paying for it. That is the exact double-charge this field exists to
+	// prevent, produced by the endpoint meant to prevent it.
+	derived, stripe, revenuecat, granted := sources.ProUntil, sources.ProUntilStripe,
+		sources.ProUntilRevenuecat, sources.ProUntilGranted
+	if tier == plan.TierUltra {
+		derived, stripe, revenuecat, granted = sources.UltraUntil, sources.UltraUntilStripe,
+			sources.UltraUntilRevenuecat, sources.UltraUntilGranted
+	}
+	if derived.Valid && derived.Time.After(time.Now()) {
+		when := derived.Time
 		out.ProUntil = &when
-		out.ProSource = proSourceOf(sources)
+		out.ProSource = planSourceOf(derived, stripe, revenuecat, granted)
 	}
 	for _, u := range usage {
 		out.Allowances = append(out.Allowances, view(u.Feature, u.Used, u.Limit, u.Unlimited, u.Enforced, resets))

--- a/internal/api/handler/plans_public.go
+++ b/internal/api/handler/plans_public.go
@@ -27,10 +27,15 @@ func (h *plansHandlers) register(api fiber.Router) {
 	api.Get("/plans", h.GetPlans)
 }
 
-// planTierView is what one tier allows for one feature in a day. Unlimited makes Daily the
+// planTierView is what one tier allows for one feature in a day. Unlimited makes Limit the
 // fair-use guard behind it rather than a ceiling, exactly as the allowance itself does.
+//
+// The field names are allowanceView's, deliberately. This endpoint and every allowance
+// response describe the same idea, and shipping it as `daily` here and `limit` there would
+// make a page learn a second vocabulary for one thing — the objection env.go raises about
+// two names for one field, in the place a customer reads.
 type planTierView struct {
-	Daily     int  `json:"daily"`
+	Limit     int  `json:"limit"`
 	Unlimited bool `json:"unlimited"`
 }
 
@@ -95,5 +100,5 @@ func (h *plansHandlers) GetPlans(c *fiber.Ctx) error {
 // most expensive place, since a promise on a pricing page is one a customer can hold us to.
 func tierView(cfg plan.Config, tier plan.Tier, f plan.Feature) planTierView {
 	a := cfg.Allowance(tier, f)
-	return planTierView{Daily: a.Limit, Unlimited: a.Unlimited}
+	return planTierView{Limit: a.Limit, Unlimited: a.Unlimited}
 }

--- a/internal/identity/billing/ultra_integration_test.go
+++ b/internal/identity/billing/ultra_integration_test.go
@@ -10,15 +10,18 @@ package billing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/strelov1/freehire/internal/platform/db"
+	"github.com/strelov1/freehire/internal/platform/testdb"
 )
 
 const ultraPrice = "price_ultra_monthly"
@@ -163,5 +166,33 @@ func TestWithNoUltraPricesNobodyIsEverUltra(t *testing.T) {
 	}
 	if ultra.Valid {
 		t.Fatalf("ultra_until = %v with no Ultra price configured, want NULL", ultra.Time)
+	}
+}
+
+// TestUltraUntilRefusesAssignment is the Pro column's twin, and it exists for the same
+// reason: the guarantee lives in the schema rather than in a convention, so it is worth one
+// test that a hand-written UPDATE cannot quietly grant somebody a plan.
+func TestUltraUntilRefusesAssignment(t *testing.T) {
+	pool := testdb.Pool(t)
+	ctx := context.Background()
+
+	var id int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (email) VALUES ('ultra-generated@example.test') RETURNING id`).Scan(&id); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	at := time.Now().UTC().Add(24 * time.Hour)
+	_, err := pool.Exec(ctx, `UPDATE users SET ultra_until = $1 WHERE id = $2`, at, id)
+	if err == nil {
+		t.Fatal("assigning ultra_until succeeded; the column must be generated, not writable")
+	}
+
+	// 428C9 is ERRCODE_GENERATED_ALWAYS. Asserting the code rather than the message keeps the
+	// test from breaking on a Postgres release that rewords the sentence, and from passing on
+	// an unrelated error that merely happens to be an error.
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != "428C9" {
+		t.Fatalf("assigning ultra_until failed with %v, want SQLSTATE 428C9 (generated column)", err)
 	}
 }

--- a/openspec/changes/add-ultra-plan/design.md
+++ b/openspec/changes/add-ultra-plan/design.md
@@ -103,10 +103,40 @@ This is the reshape `AGENTS.md` asks for over an awkward special case: the curre
 is not load-bearing legacy, and a third tier is exactly the new feature that does not fit
 cleanly into it.
 
-Environment knobs follow the existing naming: `PLAN_FREE_DAILY_<F>` and `PLAN_FAIR_USE_<F>`
-keep their meanings, and `PLAN_PRO_DAILY_<F>` and `PLAN_ULTRA_DAILY_<F>` join them. The pro
-auto-apply number in particular must move without a deploy, because it is a ceiling under a
-plan people already bought.
+Environment knobs follow the existing naming: `PLAN_FREE_DAILY_<F>`, `PLAN_PRO_DAILY_<F>` and
+`PLAN_ULTRA_DAILY_<F>`, one per tier. The pro auto-apply number in particular must move
+without a deploy, because it is a ceiling under a plan people already bought.
+
+**Amended during implementation.** This section originally kept `PLAN_FAIR_USE_<F>` alongside
+`PLAN_PRO_DAILY_<F>`. Both wrote the same field — a tier's figure is its ceiling where it has
+one and its fair-use guard where it does not — so keeping both meant two names for one thing,
+which the same paragraph argues against elsewhere. Nothing had ever set the older name (no
+`PLAN_*` variable is set on the production host at all), so it was removed rather than
+carried. Recorded here rather than left as a silent deviation from the spec.
+
+### A refusal offers an upgrade to anybody who is not on the top tier
+
+Added during implementation, and it reaches all six features rather than auto-apply alone.
+
+The 402 offered its upgrade link to the free tier only, which was correct while pro was the
+top of the range: there was nothing to sell a subscriber. With Ultra above it that rule
+withholds the link from exactly the person it is worth something to — a pro subscriber
+refused for auto-apply — and the refusal is the moment it is worth it. Written as "not the
+top tier" so that adding a fourth does not silently stop offering it to the one it displaced.
+
+Wider than the spec asked for, and deliberately: leaving the other five features on the old
+rule would mean two upgrade rules differing by feature, which is a thing to discover rather
+than a thing to read.
+
+### The account plan surface reads the tier the caller is on
+
+`GET /me/plan` filled `pro_until` and `pro_source` from the pro columns unconditionally, so
+an ultra subscriber was answered `plan: "ultra"` with neither. `pro_source` is behavioural —
+it exists so a client does not offer an in-app purchase to somebody already paying through
+Stripe — so an empty one on a paying account is the exact double-charge the field prevents,
+produced by the endpoint meant to prevent it. The fields keep their `pro_` spelling, which
+clients read; what they have always meant is "when does the plan you are paying for run out,
+and where did you buy it".
 
 ### Tier resolution is Ultra > Pro > Free
 

--- a/web/src/lib/components/PlanView.messages.ts
+++ b/web/src/lib/components/PlanView.messages.ts
@@ -13,6 +13,7 @@ export const messages = defineMessages(
       'Every AI feature is available on every plan. What changes is how much of each you can do in a day — and it starts over every night.',
     planStrip: {
       pro: 'Pro',
+      ultra: 'Ultra',
       free: 'Free',
       runsUntilPrefix: 'Runs until',
       freeSubtitle: 'Same features, daily limits',
@@ -75,6 +76,7 @@ export const messages = defineMessages(
         'Все AI-функции доступны на любом тарифе. Отличается только то, сколько каждой можно сделать за день — и каждую ночь счётчик обнуляется.',
       planStrip: {
         pro: 'Pro',
+        ultra: 'Ultra',
         free: 'Free',
         runsUntilPrefix: 'Действует до',
         freeSubtitle: 'Те же функции, дневные лимиты',

--- a/web/src/lib/components/PlanView.svelte
+++ b/web/src/lib/components/PlanView.svelte
@@ -19,6 +19,12 @@
   // balance said "you own 12 of something", this says "1 of today's 3 analyses". Nothing
   // here accumulates and nothing is a currency.
   let plan = $state<PlanState | null>(null);
+
+  // The plan's own name, from the strings rather than from a ternary that can only know two
+  // of them. A tier the strings have no label for falls back to what the API called it,
+  // which is wrong-looking rather than silently reading as "Free".
+  const planLabel = (tier: PlanState['plan']) =>
+    tier === 'ultra' ? s.planStrip.ultra : tier === 'pro' ? s.planStrip.pro : s.planStrip.free;
   let history = $state<UsageHistoryEntry[]>([]);
   let status = $state<'loading' | 'error' | 'ready'>('loading');
 
@@ -57,11 +63,14 @@
   // a reload — leaving it there shows one person's invoices and receipt links to the next.
   // `live` drops a slow response from a plan we have since moved off, which is the same
   // leak arriving late.
+  // Any PAID plan, not pro specifically. Asking `=== 'pro'` left an Ultra subscriber with no
+  // receipts and no link to the provider's portal — and that portal is the only place a
+  // subscription can be changed or cancelled, which is why we write no flow of our own.
   $effect(() => {
-    const pro = plan?.plan === 'pro';
+    const paid = plan?.plan === 'pro' || plan?.plan === 'ultra';
     billing = null;
     manageUrl = null;
-    if (!pro) return;
+    if (!paid) return;
 
     let live = true;
     api
@@ -118,9 +127,9 @@
       >
         <div class="flex flex-col gap-0.5">
           <span class="text-sm font-semibold">
-            {plan.plan === 'pro' ? s.planStrip.pro : s.planStrip.free}
+            {planLabel(plan.plan)}
           </span>
-          {#if plan.plan === 'pro' && plan.pro_until}
+          {#if plan.plan !== 'free' && plan.pro_until}
             <span class="text-xs text-muted-foreground">
               {s.planStrip.runsUntilPrefix}
               {fmtDate(plan.pro_until)}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -182,10 +182,13 @@ export interface BillingOverview {
 export interface PlanState {
   plan: 'free' | 'pro' | 'ultra';
   resets_at: string;
-  /** When the Pro plan lapses. Absent on the free plan, and absent once it has lapsed —
-   *  the server omits a past value, so a date here is always still in force. Read from the
-   *  stored column, never from the billing provider, so this endpoint keeps answering when
-   *  the provider does not. */
+  /** When the caller's PAID plan lapses — whichever tier they are on, Pro or Ultra. Absent
+   *  on the free plan, and absent once it has lapsed: the server omits a past value, so a
+   *  date here is always still in force. Read from the stored column, never from the billing
+   *  provider, so this endpoint keeps answering when the provider does not.
+   *
+   *  The `pro_` spelling is historical and stays because clients read it; what it has always
+   *  meant is "when does the plan you are paying for run out". */
   pro_until?: string;
   allowances: Allowance[];
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -123,6 +123,15 @@ export interface InviteSummary {
   percent_off: number;
 }
 
+/** What one tier allows for one feature in a day. `unlimited` makes `limit` the fair-use
+ *  guard behind it rather than a ceiling — the same two field names, in the same meaning,
+ *  that every allowance response uses, so a page never has to learn a second vocabulary for
+ *  one idea. */
+export interface PlanTierAllowance {
+  limit: number;
+  unlimited: boolean;
+}
+
 /** What each plan allows and what Pro costs (`GET /api/v1/plans`). Public and
  *  unauthenticated — a pricing page that needs an account cannot do a pricing page's job.
  *
@@ -130,13 +139,6 @@ export interface InviteSummary {
  *  cannot drift from the limits actually enforced. `enforced` names the features whose
  *  ceiling really refuses today; while the shadow run is on it is empty, and a page claiming
  *  otherwise would be selling a limit nobody meets. */
-/** What one tier allows for one feature in a day. `unlimited` makes `daily` the fair-use
- *  guard behind it rather than a ceiling — the same convention the allowance itself uses,
- *  so a page never has to decide which of the two a number is. */
-export interface PlanTierAllowance {
-  daily: number;
-  unlimited: boolean;
-}
 
 export interface PlansMatrix {
   features: { feature: string; free: PlanTierAllowance; pro: PlanTierAllowance; ultra: PlanTierAllowance }[];
@@ -178,7 +180,7 @@ export interface BillingOverview {
 }
 
 export interface PlanState {
-  plan: 'free' | 'pro';
+  plan: 'free' | 'pro' | 'ultra';
   resets_at: string;
   /** When the Pro plan lapses. Absent on the free plan, and absent once it has lapsed —
    *  the server omits a past value, so a date here is always still in force. Read from the

--- a/web/src/routes/pricing/+page.svelte
+++ b/web/src/routes/pricing/+page.svelte
@@ -27,7 +27,15 @@
   // One toggle drives both plans, so the two columns can never show different intervals.
   let interval = $state<'month' | 'year'>('month');
   const chosen = $derived(interval === 'year' ? annual : monthly);
-  const ultraChosen = $derived(interval === 'year' ? ultraAnnual : ultraMonthly);
+  // Falls back to whichever Ultra price exists, because the column's presence must depend on
+  // whether Ultra is SOLD and not on which toggle is showing. Without it, a deployment
+  // offering only a monthly Ultra loses the whole column the moment a reader flips to
+  // Yearly — the plan vanishing as a side effect of looking at the other one. The interval
+  // shown is read off the price itself, so a fallback says "$19 / month" rather than
+  // implying an annual price that does not exist.
+  const ultraChosen = $derived(
+    (interval === 'year' ? ultraAnnual : ultraMonthly) ?? ultraMonthly ?? ultraAnnual,
+  );
 
   const money = (p: PublicPrice) => formatMinorUnits(p.amount_cents, p.currency);
 
@@ -35,7 +43,7 @@
   // than a ceiling, so it is not shown — quoting a guard as a limit would promise less than
   // the plan gives. Zero is "not on this plan" rather than "nothing today".
   const allowanceText = (a: PlanTierAllowance) =>
-    a.unlimited ? 'Unlimited' : a.daily > 0 ? `${a.daily} / day` : '—';
+    a.unlimited ? 'Unlimited' : a.limit > 0 ? `${a.limit} / day` : '—';
 
   // What the annual price saves against twelve monthly ones, as a whole percentage. Shown
   // only when both prices exist and the saving is real — a "save 0%" badge is worse than


### PR DESCRIPTION
Follow-up to #2499. A two-axis `/code-review` of that change found seven things; this fixes
them. One is live on production right now.

## Live bug: an Ultra subscriber sees the Free plan

`PlanView.svelte` asked `plan === 'pro'`, so an Ultra subscriber got the **Free** strip — and
the effect that fetches their receipts and the provider's management link skipped them
entirely. That portal is the only place a subscription can be changed or cancelled, and
leaning on it is precisely why we write no switching flow of our own.

Its backend twin is worse than cosmetic. `GET /me/plan` filled `pro_until` and `pro_source`
from the pro columns unconditionally, so an Ultra caller was answered `plan: "ultra"` with
neither. `pro_source` is behavioural — it exists so a client does not offer an in-app
purchase to somebody already paying through Stripe — so an empty one on a paying account is
the exact double-charge the field prevents, produced by the endpoint meant to prevent it.

Both now read the tier the caller is actually on. The wire fields keep their `pro_` spelling,
which clients read; what they have always meant is "when does the plan you are paying for run
out, and where did you buy it".

## Documents that contradicted the code they shipped with

- `internal/ai/plan/AGENTS.md` still stated **"every meter fails open"** absolutely, while
  `chargeAutoApply` refuses. The exception is argued there now, with the reason it is the
  only one this package allows: everywhere else the action is a model call we absorb; this
  one submits a real application to a real employer under somebody's name.
- Its Scope line still called every metered feature an **AI** feature. auto-apply is a
  headless browser.
- `deploy/AGENTS.md` still enumerated **four** billing variables, on the page whose stated
  purpose is being the only copy of the host's configuration. `STRIPE_ULTRA_PRICE_IDS` is
  recorded, with its optionality and its unset behaviour.

## One idea, two names

`/plans` shipped `daily` where every allowance response ships `limit` — in the place a
customer reads, and three files from the comment in `env.go` arguing against exactly that.
Now `limit` on both.

## The Ultra column vanished on a toggle

It was keyed to the selected interval rather than to whether Ultra is sold, so a deployment
offering only a monthly price lost the whole column the moment a reader flipped to Yearly.

## Missing coverage

`ultra_until` refuses assignment (SQLSTATE 428C9) like its Pro twin, and now has the test its
Pro twin has.

## Two deviations, recorded rather than left silent

`design.md` now carries both: `PLAN_FAIR_USE_<F>` was removed during implementation (two
names for one field, and nothing had ever set it), and the 402's upgrade link now reaches
every tier that has something above it rather than the free tier alone — wider than the spec
asked, because two upgrade rules differing by feature is a thing to discover rather than to
read.

## Verification

`gofmt`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`,
`golangci-lint run --new-from-rev=origin/main` (0 issues), `pnpm check:links`,
`pnpm --dir web lint`, `pnpm --dir web check` (0 errors), `pnpm --dir web test`
(1619 passing), and the tagged suites for `internal/ai/plan`, `internal/identity/billing` and
`internal/api/handler` — all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Ultra subscription tier across plan pages and billing.
  * Ultra subscriptions now display the correct tier, entitlements, source, and expiry information.
  * Pricing pages show Ultra pricing with available billing intervals and appropriate fallback behavior.
  * Added localized Ultra labels in English and Russian.
  * Users below the top tier can receive upgrade links when access is limited.

* **Updates**
  * Renamed the plan allowance field from `daily` to `limit`.
  * Clarified required and optional billing configuration documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->