### PR TITLE
Give a subscriber both things they came to this page to do

### DIFF
--- a/web/src/lib/components/PlanView.messages.ts
+++ b/web/src/lib/components/PlanView.messages.ts
@@ -18,7 +18,12 @@ export const messages = defineMessages(
       runsUntilPrefix: 'Runs until',
       freeSubtitle: 'Same features, daily limits',
       upgrade: 'Upgrade to Pro',
-      manageSubscription: 'Manage subscription',
+      upgradeUltra: 'Upgrade to Ultra',
+      // The provider's portal is where a subscription is changed AND cancelled, so the label
+      // has to cover both — "Cancel" alone would hide the card change, and a separate cancel
+      // button would need a flow of our own that could disagree with what happened to the
+      // money.
+      manageSubscription: 'Manage or cancel',
     },
     subscription: {
       heading: 'Subscription',
@@ -81,7 +86,8 @@ export const messages = defineMessages(
         runsUntilPrefix: 'Действует до',
         freeSubtitle: 'Те же функции, дневные лимиты',
         upgrade: 'Перейти на Pro',
-        manageSubscription: 'Управление подпиской',
+        upgradeUltra: 'Перейти на Ultra',
+        manageSubscription: 'Изменить или отменить',
       },
       subscription: {
         heading: 'Подписка',

--- a/web/src/lib/components/PlanView.svelte
+++ b/web/src/lib/components/PlanView.svelte
@@ -138,23 +138,32 @@
             <span class="text-xs text-muted-foreground">{s.planStrip.freeSubtitle}</span>
           {/if}
         </div>
-        {#if plan.plan === 'free'}
-          <!-- To /pricing rather than straight to checkout: the choice between monthly and
-               annual belongs on a page that can explain it, and sending someone to a payment
-               form without it silently sells them the monthly one. -->
-          <a
-            class="shrink-0 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground"
-            href={resolve('/pricing')}>{s.planStrip.upgrade}</a
-          >
+        <!-- Both, not one or the other. A subscriber below the top tier has two things to do
+             here and they are different: buy the plan above, and change or cancel the one
+             they have. Showing only "Manage subscription" left a Pro subscriber with no way
+             to reach Ultra from the page that tells them what plan they are on. -->
+        <div class="flex shrink-0 flex-wrap items-center gap-2">
+          {#if plan.plan !== 'ultra'}
+            <!-- To /pricing rather than straight to checkout: the choice between monthly and
+                 annual belongs on a page that can explain it, and sending someone to a payment
+                 form without it silently sells them the monthly one. -->
+            <a
+              class="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground"
+              href={resolve('/pricing')}
+              >{plan.plan === 'free' ? s.planStrip.upgrade : s.planStrip.upgradeUltra}</a
+            >
+          {/if}
           <!-- eslint-disable svelte/no-navigation-without-resolve -- the payment provider's own page, not a SvelteKit route -->
-        {:else if manageUrl}
-          <a
-            class="shrink-0 rounded-md border border-border px-3 py-1.5 text-sm font-medium"
-            href={manageUrl}
-            target="_blank"
-            rel="noopener noreferrer">{s.planStrip.manageSubscription}</a
-          ><!-- eslint-enable svelte/no-navigation-without-resolve -->
-        {/if}
+          {#if manageUrl}
+            <a
+              class="rounded-md border border-border px-3 py-1.5 text-sm font-medium"
+              href={manageUrl}
+              target="_blank"
+              rel="noopener noreferrer">{s.planStrip.manageSubscription}</a
+            >
+          {/if}
+          <!-- eslint-enable svelte/no-navigation-without-resolve -->
+        </div>
       </div>
 
       {#if billing}


### PR DESCRIPTION
"Billing has no upgrade button and no cancel button." Both turned out to be true, for two
different reasons, and only one of them was in the code.

## The upgrade button

The plan strip showed the upgrade **or** the portal link, never both:

```svelte
{#if plan.plan === 'free'}      → Upgrade to Pro
{:else if manageUrl}            → Manage subscription
```

That was correct while Pro was the top of the range. With Ultra above it, a Pro subscriber
sees only the portal link — no way to reach Ultra from the page whose whole job is telling
them what plan they are on. Below the top tier there are two different things to do here, and
one `{:else}` was deciding you only ever want one of them.

## The cancel button

Cancelling has always lived behind the portal link. The button said **"Manage subscription"**,
which is why somebody can read this page and conclude there is no way to cancel. It now says
**"Manage or cancel"** — the label has to name both, because that one door is the card change,
the invoices and the cancellation, and a separate cancel button of our own would be a second
flow that can disagree with what actually happened to the money.

## The half that was not in the code

The Stripe portal configuration had `subscription_update` **disabled**. So even the button
that existed led somewhere a plan could not be changed — the feature was off, with no products
listed. Enabled now, for both products and all four prices, prorating on switch; cancellation
was already on and takes effect at period end.

That also makes true a premise `add-ultra-plan`'s design leaned on: *"a plan-switching flow of
our own is a non-goal — the provider's portal already changes a subscription."* It did not.
Worth recording as the shape of the miss: a non-goal justified by a capability nobody checked
was switched on.

## Verification

`pnpm --dir web check` (0 errors), `pnpm --dir web lint`, `pnpm --dir web test`
(1619 passing). The portal configuration was read back after the change and reports
`subscription_update.enabled: true`, `default_allowed_updates: ["price"]`, cancel at period
end.

**Not verified by me:** clicking through the portal as a real subscriber, which needs a
session I do not have. The two live Pro accounts are the only ones that can.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Plan controls now display upgrade and subscription-management actions independently when available.
  - Pro plans include an option to upgrade to Ultra.
  - Free plans continue to offer access to pricing and upgrade options.

- **Copy Updates**
  - Subscription-management messaging now clarifies that the provider portal also supports cancellation.
  - Added English and Russian labels for upgrading to Ultra.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->