### PR TITLE
Give every account section the same tab strip, and a title above it

### DIFF
--- a/design-system/.storybook/demos/TabStripDemo.svelte
+++ b/design-system/.storybook/demos/TabStripDemo.svelte
@@ -3,7 +3,9 @@
   // selection, scroll-into-view and the fade mask actually move.
   import TabStrip from '../../src/tab-strip.svelte';
 
-  let { tabs }: { tabs: readonly { id: string; label: string }[] } = $props();
+  import type { LucideIcon } from '@lucide/svelte';
+
+  let { tabs }: { tabs: readonly { id: string; label: string; icon?: LucideIcon }[] } = $props();
   let active = $state(tabs[0]?.id ?? '');
 </script>
 

--- a/design-system/docs/dsds/components.json
+++ b/design-system/docs/dsds/components.json
@@ -849,14 +849,14 @@
       "id": "component.tab-strip",
       "type": "component",
       "name": "TabStrip",
-      "description": "Horizontally-scrolling, fade-masked underline tab strip with roving-tabindex arrow-key navigation. Distinct from Tabs (a pill/segmented control with no overflow handling) — for a row that can outgrow its container. Also exports the tabStripId(panelId, tab) helper.",
+      "description": "Horizontally-scrolling, fade-masked underline tab strip with roving-tabindex arrow-key navigation. A tab carrying an href renders as an anchor (so a strip of routes stays middle-clickable and openable in a new tab) and then the arrows move focus only, since activating a link navigates. Distinct from Tabs (a pill/segmented control with no overflow handling) — for a row that can outgrow its container. Also exports the tabStripId(panelId, tab) helper.",
       "source": {
         "file": "../../src/tab-strip.svelte"
       },
       "props": [
         {
           "name": "tabs",
-          "type": "readonly { id: T; label: string }[]",
+          "type": "readonly { id: T; label: string; icon?: LucideIcon; href?: string }[]",
           "required": true
         },
         {
@@ -867,7 +867,7 @@
         {
           "name": "onSelect",
           "type": "(id: T) => void",
-          "required": true
+          "description": "Commits a selection. Unused by a strip of href tabs — there the navigation is the selection."
         },
         {
           "name": "label",

--- a/design-system/scripts/adoption-baseline.json
+++ b/design-system/scripts/adoption-baseline.json
@@ -23,6 +23,6 @@
   "Skeleton": 2,
   "Table": 8,
   "Tabs": 0,
-  "TabStrip": 4,
+  "TabStrip": 8,
   "Tooltip": 2
 }

--- a/design-system/src/tab-strip.stories.ts
+++ b/design-system/src/tab-strip.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { Briefcase, GraduationCap, Tags, User } from '@lucide/svelte';
 import TabStripDemo from '../.storybook/demos/TabStripDemo.svelte';
 
 const meta = {
@@ -16,6 +17,19 @@ export const Fitting: Story = {
       { id: 'overview', label: 'Overview' },
       { id: 'experience', label: 'Experience' },
       { id: 'skills', label: 'Skills' },
+    ],
+  },
+};
+
+// The treatment every `/my/*` section navigation uses: a leading glyph per tab, so the
+// row stays scannable once it is long enough that the labels alone blur together.
+export const WithIcons: Story = {
+  args: {
+    tabs: [
+      { id: 'profile', label: 'Profile', icon: User },
+      { id: 'skills', label: 'Skills', icon: Tags },
+      { id: 'experience', label: 'Experience', icon: Briefcase },
+      { id: 'education', label: 'Education', icon: GraduationCap },
     ],
   },
 };

--- a/design-system/src/tab-strip.svelte
+++ b/design-system/src/tab-strip.svelte
@@ -10,6 +10,7 @@
 </script>
 
 <script lang="ts" generics="T extends string">
+  import type { LucideIcon } from '@lucide/svelte';
   import { cn } from './cn.js';
 
   // A horizontal tab strip that survives a narrow viewport. Past its own width the row
@@ -25,6 +26,10 @@
   // Distinct from `Tabs`: that primitive is a pill/segmented control with no overflow
   // handling, for a small fixed set of options. This one is for a row that can outgrow its
   // container.
+  //
+  // A tab carrying an `href` renders as an anchor rather than a button, because a strip whose
+  // tabs ARE routes (every account-section navigation) should be middle-clickable, openable in
+  // a new tab and preloadable — a button plus `goto` looks identical and is none of those.
   let {
     tabs,
     active,
@@ -33,9 +38,13 @@
     panelId,
     class: extra,
   }: {
-    tabs: readonly { id: T; label: string }[];
+    tabs: readonly { id: T; label: string; icon?: LucideIcon; href?: string }[];
     active: T;
-    onSelect: (id: T) => void;
+    /**
+     * Commits a selection. Optional, and unused by a strip of `href` tabs — there the
+     * navigation is the selection, and this component never owns the route.
+     */
+    onSelect?: (id: T) => void;
     /** Names the strip for assistive tech, e.g. "Profile sections". */
     label: string;
     /** id of the `role="tabpanel"` element these tabs drive. */
@@ -106,6 +115,10 @@
   // which suits panels that are already rendered client-side and cost nothing to show.
   // Home/End jump to the ends. Focus follows, since a roving tabindex leaves only the
   // selected tab reachable by Tab.
+  //
+  // A link tab is the exception: arrows move focus only, and Enter (the anchor's own
+  // activation) navigates. Activating on the arrow itself would fire a navigation per
+  // keypress while the reader is still scanning the row for the section they want.
   function onKeydown(event: KeyboardEvent) {
     let next: number;
     switch (event.key) {
@@ -127,7 +140,7 @@
     const target = tabs[next];
     if (!target) return; // only reachable with an empty `tabs`, where there is nothing to move to.
     event.preventDefault();
-    onSelect(target.id);
+    if (target.href === undefined) onSelect?.(target.id);
     buttons[next]?.focus();
   }
 </script>
@@ -142,23 +155,44 @@
     class="flex gap-4 overflow-x-auto border-b border-border sm:gap-5 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
   >
     {#each tabs as t, i (t.id)}
-      <button
-        bind:this={buttons[i]}
-        type="button"
-        role="tab"
-        id={tabStripId(panelId, t.id)}
-        aria-selected={t.id === active}
-        aria-controls={panelId}
-        tabindex={t.id === active ? 0 : -1}
-        onclick={() => onSelect(t.id)}
-        onkeydown={onKeydown}
-        class="-mb-px shrink-0 whitespace-nowrap border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {t.id ===
-        active
+      {@const Icon = t.icon}
+      {@const cls =
+        `-mb-px flex shrink-0 items-center gap-1.5 whitespace-nowrap border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors ` +
+        (t.id === active
           ? 'border-brand text-foreground'
-          : 'border-transparent text-muted-foreground hover:text-foreground'}"
-      >
-        {t.label}
-      </button>
+          : 'border-transparent text-muted-foreground hover:text-foreground')}
+      {#if t.href !== undefined}
+        <a
+          bind:this={buttons[i]}
+          role="tab"
+          href={t.href}
+          id={tabStripId(panelId, t.id)}
+          aria-selected={t.id === active}
+          aria-controls={panelId}
+          tabindex={t.id === active ? 0 : -1}
+          onkeydown={onKeydown}
+          class={cls}
+        >
+          {#if Icon}<Icon class="size-4" aria-hidden="true" />{/if}
+          {t.label}
+        </a>
+      {:else}
+        <button
+          bind:this={buttons[i]}
+          type="button"
+          role="tab"
+          id={tabStripId(panelId, t.id)}
+          aria-selected={t.id === active}
+          aria-controls={panelId}
+          tabindex={t.id === active ? 0 : -1}
+          onclick={() => onSelect?.(t.id)}
+          onkeydown={onKeydown}
+          class={cls}
+        >
+          {#if Icon}<Icon class="size-4" aria-hidden="true" />{/if}
+          {t.label}
+        </button>
+      {/if}
     {/each}
   </div>
 </div>

--- a/design-system/src/tab-strip.test.ts
+++ b/design-system/src/tab-strip.test.ts
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/svelte';
 import { describe, expect, it, vi } from 'vitest';
+import { House } from '@lucide/svelte';
 import TabStrip, { tabStripId } from './tab-strip.svelte';
 import { must } from './test-utils';
 
@@ -89,6 +90,58 @@ describe('TabStrip', () => {
     });
 
     expect(getByRole('tablist').getAttribute('aria-label')).toBe('Profile sections');
+  });
+
+  // A strip whose tabs ARE routes has to be middle-clickable and openable in a new tab;
+  // a button plus a programmatic navigation looks identical and is neither.
+  it('renders a tab carrying an href as an anchor', () => {
+    const { getAllByRole } = render(TabStrip, {
+      tabs: [
+        { id: 'one', label: 'One', href: '/one' },
+        { id: 'two', label: 'Two', href: '/two' },
+      ],
+      active: 'one',
+      label: 'Demo sections',
+      panelId: 'demo-panel',
+    });
+
+    const tabs = getAllByRole('tab');
+    expect(must(tabs[0]).tagName).toBe('A');
+    expect(must(tabs[1]).getAttribute('href')).toBe('/two');
+  });
+
+  // Automatic activation is right for panes already rendered client-side and wrong for
+  // links: it would fire a navigation per keypress while the reader is still scanning.
+  it('moves focus without navigating when the tabs are links', async () => {
+    const onSelect = vi.fn();
+    const { getAllByRole } = render(TabStrip, {
+      tabs: [
+        { id: 'one', label: 'One', href: '/one' },
+        { id: 'two', label: 'Two', href: '/two' },
+      ],
+      active: 'one',
+      onSelect,
+      label: 'Demo sections',
+      panelId: 'demo-panel',
+    });
+
+    const tabs = getAllByRole('tab');
+    await fireArrow(must(tabs[0]), 'ArrowRight');
+
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(tabs[1]);
+  });
+
+  it('renders a tab icon when one is given', () => {
+    const { container } = render(TabStrip, {
+      tabs: [{ id: 'one', label: 'One', icon: House }],
+      active: 'one',
+      onSelect: vi.fn(),
+      label: 'Demo sections',
+      panelId: 'demo-panel',
+    });
+
+    expect(container.querySelectorAll('svg').length).toBe(1);
   });
 
   // The regression: the ResizeObserver effect only tracked `strip`, so a tab added

--- a/web/src/lib/actions/tablist.ts
+++ b/web/src/lib/actions/tablist.ts
@@ -63,21 +63,3 @@ export const tablist: Action<HTMLElement, unknown> = (node) => {
     destroy: () => node.removeEventListener('keydown', onKeydown),
   };
 };
-
-/**
- * The pill treatment for a routed `/my/*` tab — the two segment strips over the tracking
- * board and the activity lists. It lives beside the behaviour rather than in either layout
- * because both had it, byte for byte, and a pill that drifts between two sibling sections
- * of the same account area reads as a bug rather than as a choice.
- *
- * It is NOT the underline strip (`TabStrip`) or the design system's `Tabs`: those weld the
- * list to a panel, and these tabs are anchors driving a route.
- */
-export function routeTabClass(active: boolean): string {
-  return [
-    'rounded-md px-3 py-1.5 text-sm transition-colors',
-    active
-      ? 'bg-secondary font-medium text-secondary-foreground'
-      : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
-  ].join(' ');
-}

--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -19,7 +19,17 @@
   import InboxSettings from './InboxSettings.svelte';
   import ApplicationLinkPicker from './ApplicationLinkPicker.svelte';
   import InfiniteScroll from './InfiniteScroll.svelte';
-  import { Mail, Search, RefreshCw, ChevronLeft, CheckCheck, Trash2 } from '@lucide/svelte';
+  import {
+    Mail,
+    Search,
+    RefreshCw,
+    ChevronLeft,
+    CheckCheck,
+    Trash2,
+    Inbox,
+    Settings,
+  } from '@lucide/svelte';
+  import { TabStrip, tabStripId } from '$lib/ui';
   import { timeAgo, errorMessage, must } from '$lib/utils';
   import { avatarInitials, avatarColor } from '$lib/avatar';
 
@@ -76,8 +86,14 @@
   // The message just soft-deleted, for a one-click Undo (per-email, like unlink).
   let lastDeleted = $state<{ id: number; subject: string } | null>(null);
 
-  // Which pane: the mail list ('inbox') or the account setup ('settings').
+  // Which pane: the mail list ('inbox') or the account setup ('settings'). Both are
+  // local state rather than routes, so the strip's tabs are buttons — see TabStrip.
   let tab = $state<'inbox' | 'settings'>('inbox');
+  const PANEL_ID = 'inbox-panel';
+  const TABS = [
+    { id: 'inbox', label: 'Inbox', icon: Inbox },
+    { id: 'settings', label: 'Settings', icon: Settings },
+  ] as const;
 
   // The selected message and its loaded body (reading pane).
   let selectedId = $state<number | null>(null);
@@ -424,333 +440,333 @@
   <p class="text-sm text-destructive">{error}</p>
 {:else}
   <div class="flex flex-col gap-4">
-    <!-- Tabs: keep the mail list and the account setup on separate panes. -->
-    <div class="flex gap-4 border-b border-border text-sm">
-      {#each [{ id: 'inbox', label: 'Inbox' }, { id: 'settings', label: 'Settings' }] as t (t.id)}
-        <button
-          type="button"
-          onclick={() => (tab = t.id as 'inbox' | 'settings')}
-          class="-mb-px border-b-2 px-1 py-2 transition-colors {tab === t.id
-            ? 'border-brand font-medium text-foreground'
-            : 'border-transparent text-muted-foreground hover:text-foreground'}"
-        >
-          {t.label}
-        </button>
-      {/each}
-    </div>
+    <TabStrip
+      tabs={TABS}
+      active={tab}
+      onSelect={(id) => (tab = id)}
+      label="Inbox sections"
+      panelId={PANEL_ID}
+    />
 
-    {#if tab === 'settings'}
-      <InboxSettings {gmail} bind:mailbox onSourceChanged={onSourceChanged} onError={(m) => (error = m)} />
-    {:else if !hasAnySource}
-      <p class="py-8 text-center text-sm text-muted-foreground">
-        No mail source yet —
-        <button type="button" class="font-medium text-primary hover:underline" onclick={() => (tab = 'settings')}>set one up in Settings</button>.
-      </p>
-    {:else}
-      <!-- Toolbar: account switcher + label filter + search on the left; a compact
-           icon cluster (unread filter, mark-all-read, refresh) on the right. -->
-      <div class="flex flex-wrap items-center gap-2">
-        {#if presentSources.length > 1}
-          <div class="flex gap-1 rounded-lg border border-border p-1 text-sm">
-            {#each sourceOptions as opt (opt.value)}
-              <button
-                type="button"
-                onclick={() => setSource(opt.value as InboxSource)}
-                class="rounded px-3 py-1 transition-colors {source === opt.value
-                  ? 'bg-secondary font-medium text-foreground'
-                  : 'text-muted-foreground hover:text-foreground'}"
-              >
-                {opt.label}
-              </button>
+    <div
+      id={PANEL_ID}
+      role="tabpanel"
+      aria-labelledby={tabStripId(PANEL_ID, tab)}
+      class="flex flex-col gap-4"
+    >
+      {#if tab === 'settings'}
+        <InboxSettings {gmail} bind:mailbox onSourceChanged={onSourceChanged} onError={(m) => (error = m)} />
+      {:else if !hasAnySource}
+        <p class="py-8 text-center text-sm text-muted-foreground">
+          No mail source yet —
+          <button type="button" class="font-medium text-primary hover:underline" onclick={() => (tab = 'settings')}>set one up in Settings</button>.
+        </p>
+      {:else}
+        <!-- Toolbar: account switcher + label filter + search on the left; a compact
+             icon cluster (unread filter, mark-all-read, refresh) on the right. -->
+        <div class="flex flex-wrap items-center gap-2">
+          {#if presentSources.length > 1}
+            <div class="flex gap-1 rounded-lg border border-border p-1 text-sm">
+              {#each sourceOptions as opt (opt.value)}
+                <button
+                  type="button"
+                  onclick={() => setSource(opt.value as InboxSource)}
+                  class="rounded px-3 py-1 transition-colors {source === opt.value
+                    ? 'bg-secondary font-medium text-foreground'
+                    : 'text-muted-foreground hover:text-foreground'}"
+                >
+                  {opt.label}
+                </button>
+              {/each}
+            </div>
+          {/if}
+
+          <select
+            bind:value={label}
+            onchange={reloadList}
+            aria-label="Filter by label"
+            class="rounded-lg border border-border bg-background py-2 pl-3 pr-8 text-sm outline-none transition focus:border-brand focus:ring-2 focus:ring-brand-ring/40 {label
+              ? 'font-medium text-foreground'
+              : 'text-muted-foreground'}"
+          >
+            <option value="">All labels</option>
+            {#each LABEL_OPTIONS as [value, text] (value)}
+              <option {value}>{text}</option>
             {/each}
+          </select>
+
+          <div class="relative min-w-[11rem] flex-1">
+            <Search class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <input
+              type="search"
+              placeholder="Search subject, sender, or body…"
+              bind:value={search}
+              oninput={onSearchInput}
+              class="w-full rounded-lg border border-border bg-background py-2 pl-9 pr-3 text-sm outline-none transition focus:border-brand focus:ring-2 focus:ring-brand-ring/40"
+            />
+          </div>
+
+          <!-- Compact icon actions, grouped: unread toggle · mark all read · refresh. -->
+          <div class="flex items-center gap-1">
+            <button
+              type="button"
+              onclick={toggleUnread}
+              aria-pressed={unread}
+              title="Unread only"
+              aria-label="Unread only"
+              class="rounded-lg border p-2 transition-colors {unread
+                ? 'border-brand-ring bg-brand-muted/60 text-foreground'
+                : 'border-border text-muted-foreground hover:text-foreground'}"
+            >
+              <Mail class="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onclick={markAllRead}
+              disabled={markingAll}
+              title="Mark all read"
+              aria-label="Mark all read"
+              class="rounded-lg border border-border p-2 text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+            >
+              <CheckCheck class="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onclick={refreshInbox}
+              disabled={refreshing}
+              title="Refresh"
+              aria-label="Refresh"
+              class="rounded-lg border border-border p-2 text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+            >
+              <RefreshCw class="h-4 w-4 {refreshing ? 'animate-spin' : ''}" />
+            </button>
+          </div>
+        </div>
+
+        {#if lastDeleted}
+          <div class="flex items-center gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+            Deleted “{lastDeleted.subject || '(no subject)'}”
+            <span aria-hidden="true">·</span>
+            <button type="button" onclick={undoDelete} class="font-medium text-brand-strong hover:underline">Undo</button>
           </div>
         {/if}
 
-        <select
-          bind:value={label}
-          onchange={reloadList}
-          aria-label="Filter by label"
-          class="rounded-lg border border-border bg-background py-2 pl-3 pr-8 text-sm outline-none transition focus:border-brand focus:ring-2 focus:ring-brand-ring/40 {label
-            ? 'font-medium text-foreground'
-            : 'text-muted-foreground'}"
-        >
-          <option value="">All labels</option>
-          {#each LABEL_OPTIONS as [value, text] (value)}
-            <option {value}>{text}</option>
-          {/each}
-        </select>
-
-        <div class="relative min-w-[11rem] flex-1">
-          <Search class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-          <input
-            type="search"
-            placeholder="Search subject, sender, or body…"
-            bind:value={search}
-            oninput={onSearchInput}
-            class="w-full rounded-lg border border-border bg-background py-2 pl-9 pr-3 text-sm outline-none transition focus:border-brand focus:ring-2 focus:ring-brand-ring/40"
-          />
-        </div>
-
-        <!-- Compact icon actions, grouped: unread toggle · mark all read · refresh. -->
-        <div class="flex items-center gap-1">
-          <button
-            type="button"
-            onclick={toggleUnread}
-            aria-pressed={unread}
-            title="Unread only"
-            aria-label="Unread only"
-            class="rounded-lg border p-2 transition-colors {unread
-              ? 'border-brand-ring bg-brand-muted/60 text-foreground'
-              : 'border-border text-muted-foreground hover:text-foreground'}"
-          >
-            <Mail class="h-4 w-4" />
-          </button>
-          <button
-            type="button"
-            onclick={markAllRead}
-            disabled={markingAll}
-            title="Mark all read"
-            aria-label="Mark all read"
-            class="rounded-lg border border-border p-2 text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
-          >
-            <CheckCheck class="h-4 w-4" />
-          </button>
-          <button
-            type="button"
-            onclick={refreshInbox}
-            disabled={refreshing}
-            title="Refresh"
-            aria-label="Refresh"
-            class="rounded-lg border border-border p-2 text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
-          >
-            <RefreshCw class="h-4 w-4 {refreshing ? 'animate-spin' : ''}" />
-          </button>
-        </div>
-      </div>
-
-      {#if lastDeleted}
-        <div class="flex items-center gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
-          Deleted “{lastDeleted.subject || '(no subject)'}”
-          <span aria-hidden="true">·</span>
-          <button type="button" onclick={undoDelete} class="font-medium text-brand-strong hover:underline">Undo</button>
-        </div>
-      {/if}
-
-      <!-- The number the default cost them, where they are already looking. It appears only
-           when something was hidden, so a clean mailbox says nothing at all. -->
-      {#if hidden > 0 && !includeOther}
-        <p class="pb-3 text-sm text-muted-foreground">
-          {hidden} message{hidden === 1 ? '' : 's'} not about an application {hidden === 1 ? 'is' : 'are'} hidden.
-          <button
-            type="button"
-            class="font-medium text-brand-strong underline-offset-2 hover:underline"
-            onclick={() => {
-              includeOther = true;
-              void fetchFirstPage('Could not load the hidden mail.');
-            }}
-          >
-            Show
-          </button>
-        </p>
-      {:else if includeOther}
-        <p class="pb-3 text-sm text-muted-foreground">
-          Showing mail that is not about an application.
-          <button
-            type="button"
-            class="font-medium text-brand-strong underline-offset-2 hover:underline"
-            onclick={() => {
-              includeOther = false;
-              void fetchFirstPage('Could not reload the inbox.');
-            }}
-          >
-            Hide
-          </button>
-        </p>
-      {/if}
-
-      {#if pager.items.length === 0}
-        <p class="py-12 text-center text-sm text-muted-foreground">
-          {filterActive ? 'No mail matches your filters.' : 'No mail yet — it appears here as it arrives.'}
-        </p>
-      {:else}
-        <!-- Fixed-height two-pane so the page itself never scrolls: each pane scrolls
-             internally, and the list infinite-loads in place. On md+ side by side; below
-             md a master-detail (open a message → the reading pane replaces the list). -->
-        <div class="grid h-[calc(100dvh-12rem)] min-h-[26rem] gap-5 md:grid-cols-[minmax(0,19rem)_1fr]">
-          <div
-            class="min-h-0 flex-col gap-1 overflow-y-auto pr-1 {selectedId === null ? 'flex' : 'hidden md:flex'}"
-          >
-            <ul class="flex flex-col gap-1">
-              {#each pager.items as m, i (m.id)}
-                <li class="row-in" style="animation-delay: {Math.min(i, 14) * 15}ms">
-                  <button
-                    type="button"
-                    onclick={() => openMessage(m.id)}
-                    aria-current={selectedId === m.id}
-                    class="flex w-full items-start gap-3 rounded-xl border p-3 text-left transition-colors {selectedId === m.id
-                      ? 'border-brand-ring bg-brand-muted/60'
-                      : 'border-transparent hover:border-border hover:bg-accent'}"
-                  >
-                    <div
-                      class="mt-0.5 flex h-9 w-9 shrink-0 select-none items-center justify-center rounded-full text-xs font-semibold text-white"
-                      style="background-color: {avatarColor(m.from_addr || m.from_name)}"
-                    >
-                      {avatarInitials(m.from_name, m.from_addr)}
-                    </div>
-                    <div class="min-w-0 flex-1">
-                      <div class="flex items-baseline gap-2">
-                        {#if !m.read}
-                          <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-brand" aria-label="unread"></span>
-                        {/if}
-                        <span class="min-w-0 flex-1 truncate text-sm {m.read ? 'font-medium text-foreground/90' : 'font-semibold text-foreground'}">
-                          {m.from_name || m.from_addr}
-                        </span>
-                        <span class="shrink-0 text-[11px] text-muted-foreground">{timeAgo(m.received_at)}</span>
-                      </div>
-                      <div class="mt-0.5 truncate text-sm {m.read ? 'text-muted-foreground' : 'text-foreground'}">
-                        {m.subject || '(no subject)'}
-                      </div>
-                      {#if m.snippet}
-                        <div class="mt-0.5 truncate text-xs text-muted-foreground/80">{m.snippet}</div>
-                      {/if}
-                      {#if statusLabel(m.status_signal) || m.linked_slug}
-                        <div class="mt-1 flex items-center gap-1">
-                          <StatusChip signal={m.status_signal} class="text-[10px] leading-4" />
-                          {#if m.linked_slug}
-                            <span class="truncate text-[10px] text-muted-foreground/70">· {m.linked_company}</span>
-                          {:else if m.suggested_slug}
-                            <span class="text-[10px] text-brand-strong">· suggested</span>
-                          {/if}
-                        </div>
-                      {/if}
-                    </div>
-                  </button>
-                </li>
-              {/each}
-            </ul>
-
-            {#if pager.hasMore}
-              <!-- Scroll-to-bottom auto-load (inside the list's own scroll pane). -->
-              <InfiniteScroll
-                onLoad={loadMore}
-                enabled={!pager.loadingMore && !pager.loadMoreError && !reloading}
-              />
-            {/if}
-            {#if pager.loadingMore}
-              <p class="py-3 text-center text-xs text-muted-foreground">Loading…</p>
-            {/if}
-          </div>
-
-          <!-- Reading pane — borderless, flush, fills the pane height and scrolls
-               internally. On mobile it replaces the list once a message is open. -->
-          <div class="flex min-h-0 flex-col {selectedId === null ? 'hidden md:flex' : 'flex'}">
+        <!-- The number the default cost them, where they are already looking. It appears only
+             when something was hidden, so a clean mailbox says nothing at all. -->
+        {#if hidden > 0 && !includeOther}
+          <p class="pb-3 text-sm text-muted-foreground">
+            {hidden} message{hidden === 1 ? '' : 's'} not about an application {hidden === 1 ? 'is' : 'are'} hidden.
             <button
               type="button"
-              onclick={backToList}
-              class="mb-3 -ml-1 flex shrink-0 items-center gap-1 rounded-md px-1 py-1 text-sm text-muted-foreground hover:text-foreground md:hidden"
+              class="font-medium text-brand-strong underline-offset-2 hover:underline"
+              onclick={() => {
+                includeOther = true;
+                void fetchFirstPage('Could not load the hidden mail.');
+              }}
             >
-              <ChevronLeft class="h-4 w-4" /> Inbox
+              Show
             </button>
-            {#if bodyLoading}
-              <p class="py-16 text-center text-sm text-muted-foreground">Loading…</p>
-            {:else if !selected}
-              <div class="flex h-full flex-col items-center justify-center gap-2 py-16 text-center">
-                <Mail class="h-7 w-7 text-muted-foreground/50" />
-                <p class="text-sm text-muted-foreground">Select a message to read it.</p>
-              </div>
-            {:else}
-              {@const s = selected}
-              <div class="flex shrink-0 items-start gap-3">
-                <div
-                  class="flex h-10 w-10 shrink-0 select-none items-center justify-center rounded-full text-sm font-semibold text-white"
-                  style="background-color: {avatarColor(s.from_addr || s.from_name)}"
-                >
-                  {avatarInitials(s.from_name, s.from_addr)}
-                </div>
-                <div class="min-w-0 flex-1">
-                  <h2 class="text-base font-semibold leading-snug tracking-tight">{s.subject || '(no subject)'}</h2>
-                  <div class="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
-                    <span class="font-medium text-foreground/80">{s.from_name || s.from_addr}</span>
-                    {#if s.from_name}
-                      <span aria-hidden="true">·</span>
-                      <span class="truncate">{s.from_addr}</span>
-                    {/if}
-                    <span class="ml-auto shrink-0">{timeAgo(s.received_at)}</span>
-                  </div>
-                </div>
-                <button
-                  type="button"
-                  onclick={deleteSelected}
-                  title="Delete"
-                  aria-label="Delete message"
-                  class="shrink-0 rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
-                >
-                  <Trash2 class="h-4 w-4" />
-                </button>
-              </div>
+          </p>
+        {:else if includeOther}
+          <p class="pb-3 text-sm text-muted-foreground">
+            Showing mail that is not about an application.
+            <button
+              type="button"
+              class="font-medium text-brand-strong underline-offset-2 hover:underline"
+              onclick={() => {
+                includeOther = false;
+                void fetchFirstPage('Could not reload the inbox.');
+              }}
+            >
+              Hide
+            </button>
+          </p>
+        {/if}
 
-              {@const linkState = inboxLinkState(s, lastUnlinked)}
-              <div class="mt-3 flex shrink-0 flex-wrap items-center gap-2">
-                <StatusChip signal={s.status_signal} />
-                {#if linkState === 'linked' && s.linked_slug}
-                  <a
-                    href={resolve('/my/tracking/[id]', { id: s.linked_slug })}
-                    class="inline-flex items-center gap-1 rounded-full border border-border px-2.5 py-0.5 text-xs text-muted-foreground transition-colors hover:border-brand-ring hover:text-foreground"
-                  >
-                    Linked to {s.linked_company || 'application'} ↗
-                  </a>
-                  <button type="button" onclick={unlink} class="text-xs text-muted-foreground hover:text-destructive">Unlink</button>
-                {:else if linkState === 'suggested'}
-                  <span class="inline-flex items-center gap-2 rounded-full border border-brand-ring/50 bg-brand-muted/40 px-2.5 py-0.5 text-xs">
-                    Looks like <span class="font-medium">{s.suggested_company || 'an application'}</span>
-                    <button type="button" onclick={confirmLink} class="font-medium text-brand-strong hover:underline">Link</button>
-                    <span aria-hidden="true">·</span>
-                    <button type="button" onclick={rejectLink} class="text-muted-foreground hover:text-foreground">Not this</button>
-                  </span>
-                {:else}
-                  {#if linkState === 'undo'}
-                    <span class="inline-flex items-center gap-2 text-xs text-muted-foreground">
-                      Unlinked
-                      <span aria-hidden="true">·</span>
-                      <button type="button" onclick={undoUnlink} class="font-medium text-brand-strong hover:underline">Undo</button>
-                    </span>
-                  {/if}
-                  <ApplicationLinkPicker applications={trackedApps} loading={trackedLoading} onpick={linkTo} />
-                {/if}
-              </div>
+        {#if pager.items.length === 0}
+          <p class="py-12 text-center text-sm text-muted-foreground">
+            {filterActive ? 'No mail matches your filters.' : 'No mail yet — it appears here as it arrives.'}
+          </p>
+        {:else}
+          <!-- Fixed-height two-pane so the page itself never scrolls: each pane scrolls
+               internally, and the list infinite-loads in place. On md+ side by side; below
+               md a master-detail (open a message → the reading pane replaces the list). -->
+          <div class="grid h-[calc(100dvh-12rem)] min-h-[26rem] gap-5 md:grid-cols-[minmax(0,19rem)_1fr]">
+            <div
+              class="min-h-0 flex-col gap-1 overflow-y-auto pr-1 {selectedId === null ? 'flex' : 'hidden md:flex'}"
+            >
+              <ul class="flex flex-col gap-1">
+                {#each pager.items as m, i (m.id)}
+                  <li class="row-in" style="animation-delay: {Math.min(i, 14) * 15}ms">
+                    <button
+                      type="button"
+                      onclick={() => openMessage(m.id)}
+                      aria-current={selectedId === m.id}
+                      class="flex w-full items-start gap-3 rounded-xl border p-3 text-left transition-colors {selectedId === m.id
+                        ? 'border-brand-ring bg-brand-muted/60'
+                        : 'border-transparent hover:border-border hover:bg-accent'}"
+                    >
+                      <div
+                        class="mt-0.5 flex h-9 w-9 shrink-0 select-none items-center justify-center rounded-full text-xs font-semibold text-white"
+                        style="background-color: {avatarColor(m.from_addr || m.from_name)}"
+                      >
+                        {avatarInitials(m.from_name, m.from_addr)}
+                      </div>
+                      <div class="min-w-0 flex-1">
+                        <div class="flex items-baseline gap-2">
+                          {#if !m.read}
+                            <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-brand" aria-label="unread"></span>
+                          {/if}
+                          <span class="min-w-0 flex-1 truncate text-sm {m.read ? 'font-medium text-foreground/90' : 'font-semibold text-foreground'}">
+                            {m.from_name || m.from_addr}
+                          </span>
+                          <span class="shrink-0 text-[11px] text-muted-foreground">{timeAgo(m.received_at)}</span>
+                        </div>
+                        <div class="mt-0.5 truncate text-sm {m.read ? 'text-muted-foreground' : 'text-foreground'}">
+                          {m.subject || '(no subject)'}
+                        </div>
+                        {#if m.snippet}
+                          <div class="mt-0.5 truncate text-xs text-muted-foreground/80">{m.snippet}</div>
+                        {/if}
+                        {#if statusLabel(m.status_signal) || m.linked_slug}
+                          <div class="mt-1 flex items-center gap-1">
+                            <StatusChip signal={m.status_signal} class="text-[10px] leading-4" />
+                            {#if m.linked_slug}
+                              <span class="truncate text-[10px] text-muted-foreground/70">· {m.linked_company}</span>
+                            {:else if m.suggested_slug}
+                              <span class="text-[10px] text-brand-strong">· suggested</span>
+                            {/if}
+                          </div>
+                        {/if}
+                      </div>
+                    </button>
+                  </li>
+                {/each}
+              </ul>
 
-              {#if s.source === 'gmail'}
-                <div class="mt-2 flex shrink-0 justify-end">
-                  <!-- eslint-disable svelte/no-navigation-without-resolve -- external Gmail deep-link, not an internal route -->
-                  <a
-                    href={gmailUrl(s.external_id)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="text-xs font-medium text-brand-strong hover:underline"
-                  ><!-- eslint-enable svelte/no-navigation-without-resolve -->
-                    Open in Gmail ↗
-                  </a>
-                </div>
+              {#if pager.hasMore}
+                <!-- Scroll-to-bottom auto-load (inside the list's own scroll pane). -->
+                <InfiniteScroll
+                  onLoad={loadMore}
+                  enabled={!pager.loadingMore && !pager.loadMoreError && !reloading}
+                />
               {/if}
+              {#if pager.loadingMore}
+                <p class="py-3 text-center text-xs text-muted-foreground">Loading…</p>
+              {/if}
+            </div>
 
-              <hr class="my-4 shrink-0 border-border" />
-
-              {#if s.body_html}
-                <!-- Untrusted sender HTML isolated in a sandboxed iframe (no scripts/forms/navigation). -->
-                <iframe
-                  title="Message body"
-                  sandbox=""
-                  srcdoc={s.body_html}
-                  class="min-h-0 w-full flex-1 rounded-md border border-border bg-white"
-                ></iframe>
+            <!-- Reading pane — borderless, flush, fills the pane height and scrolls
+                 internally. On mobile it replaces the list once a message is open. -->
+            <div class="flex min-h-0 flex-col {selectedId === null ? 'hidden md:flex' : 'flex'}">
+              <button
+                type="button"
+                onclick={backToList}
+                class="mb-3 -ml-1 flex shrink-0 items-center gap-1 rounded-md px-1 py-1 text-sm text-muted-foreground hover:text-foreground md:hidden"
+              >
+                <ChevronLeft class="h-4 w-4" /> Inbox
+              </button>
+              {#if bodyLoading}
+                <p class="py-16 text-center text-sm text-muted-foreground">Loading…</p>
+              {:else if !selected}
+                <div class="flex h-full flex-col items-center justify-center gap-2 py-16 text-center">
+                  <Mail class="h-7 w-7 text-muted-foreground/50" />
+                  <p class="text-sm text-muted-foreground">Select a message to read it.</p>
+                </div>
               {:else}
-                <pre class="min-h-0 flex-1 overflow-y-auto whitespace-pre-wrap font-sans text-sm leading-relaxed">{s.body_text}</pre>
+                {@const s = selected}
+                <div class="flex shrink-0 items-start gap-3">
+                  <div
+                    class="flex h-10 w-10 shrink-0 select-none items-center justify-center rounded-full text-sm font-semibold text-white"
+                    style="background-color: {avatarColor(s.from_addr || s.from_name)}"
+                  >
+                    {avatarInitials(s.from_name, s.from_addr)}
+                  </div>
+                  <div class="min-w-0 flex-1">
+                    <h2 class="text-base font-semibold leading-snug tracking-tight">{s.subject || '(no subject)'}</h2>
+                    <div class="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
+                      <span class="font-medium text-foreground/80">{s.from_name || s.from_addr}</span>
+                      {#if s.from_name}
+                        <span aria-hidden="true">·</span>
+                        <span class="truncate">{s.from_addr}</span>
+                      {/if}
+                      <span class="ml-auto shrink-0">{timeAgo(s.received_at)}</span>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onclick={deleteSelected}
+                    title="Delete"
+                    aria-label="Delete message"
+                    class="shrink-0 rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                  >
+                    <Trash2 class="h-4 w-4" />
+                  </button>
+                </div>
+
+                {@const linkState = inboxLinkState(s, lastUnlinked)}
+                <div class="mt-3 flex shrink-0 flex-wrap items-center gap-2">
+                  <StatusChip signal={s.status_signal} />
+                  {#if linkState === 'linked' && s.linked_slug}
+                    <a
+                      href={resolve('/my/tracking/[id]', { id: s.linked_slug })}
+                      class="inline-flex items-center gap-1 rounded-full border border-border px-2.5 py-0.5 text-xs text-muted-foreground transition-colors hover:border-brand-ring hover:text-foreground"
+                    >
+                      Linked to {s.linked_company || 'application'} ↗
+                    </a>
+                    <button type="button" onclick={unlink} class="text-xs text-muted-foreground hover:text-destructive">Unlink</button>
+                  {:else if linkState === 'suggested'}
+                    <span class="inline-flex items-center gap-2 rounded-full border border-brand-ring/50 bg-brand-muted/40 px-2.5 py-0.5 text-xs">
+                      Looks like <span class="font-medium">{s.suggested_company || 'an application'}</span>
+                      <button type="button" onclick={confirmLink} class="font-medium text-brand-strong hover:underline">Link</button>
+                      <span aria-hidden="true">·</span>
+                      <button type="button" onclick={rejectLink} class="text-muted-foreground hover:text-foreground">Not this</button>
+                    </span>
+                  {:else}
+                    {#if linkState === 'undo'}
+                      <span class="inline-flex items-center gap-2 text-xs text-muted-foreground">
+                        Unlinked
+                        <span aria-hidden="true">·</span>
+                        <button type="button" onclick={undoUnlink} class="font-medium text-brand-strong hover:underline">Undo</button>
+                      </span>
+                    {/if}
+                    <ApplicationLinkPicker applications={trackedApps} loading={trackedLoading} onpick={linkTo} />
+                  {/if}
+                </div>
+
+                {#if s.source === 'gmail'}
+                  <div class="mt-2 flex shrink-0 justify-end">
+                    <!-- eslint-disable svelte/no-navigation-without-resolve -- external Gmail deep-link, not an internal route -->
+                    <a
+                      href={gmailUrl(s.external_id)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="text-xs font-medium text-brand-strong hover:underline"
+                    ><!-- eslint-enable svelte/no-navigation-without-resolve -->
+                      Open in Gmail ↗
+                    </a>
+                  </div>
+                {/if}
+
+                <hr class="my-4 shrink-0 border-border" />
+
+                {#if s.body_html}
+                  <!-- Untrusted sender HTML isolated in a sandboxed iframe (no scripts/forms/navigation). -->
+                  <iframe
+                    title="Message body"
+                    sandbox=""
+                    srcdoc={s.body_html}
+                    class="min-h-0 w-full flex-1 rounded-md border border-border bg-white"
+                  ></iframe>
+                {:else}
+                  <pre class="min-h-0 flex-1 overflow-y-auto whitespace-pre-wrap font-sans text-sm leading-relaxed">{s.body_text}</pre>
+                {/if}
               {/if}
-            {/if}
+            </div>
           </div>
-        </div>
+        {/if}
       {/if}
-    {/if}
+    </div>
   </div>
 {/if}
 

--- a/web/src/lib/components/cv/CvList.svelte
+++ b/web/src/lib/components/cv/CvList.svelte
@@ -55,7 +55,7 @@
 <div class="space-y-6">
   <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
     <div>
-      <h1 class="text-2xl font-semibold">Tailored CVs</h1>
+      <h1 class="text-2xl font-semibold tracking-tight">Tailored CVs</h1>
       <p class="text-sm text-muted-foreground">
         CVs you tailored for specific roles. Open one to resume its tailoring session, or start a
         new one by opening the tailoring workspace from any vacancy.

--- a/web/src/routes/my/activity/+layout.svelte
+++ b/web/src/routes/my/activity/+layout.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
+  import { Bookmark, EyeOff, History, Sparkles } from '@lucide/svelte';
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
-  import { routeTabClass, tablist } from '$lib/actions/tablist';
+  import { TabStrip, tabStripId } from '$lib/ui';
   import { messages } from '$lib/components/activity.messages';
   import { locale } from '$lib/i18n/currentLocale.svelte';
   import { t } from '$lib/i18n/t';
@@ -14,24 +15,32 @@
   // The account shell (my/+layout) owns the container, auth gate, and noindex;
   // this layout adds only Activity's own sub-navigation. Each view is its own URL
   // so it is linkable, bookmarkable, and survives a reload. Saved is the index
-  // route; History/Matches get their own paths.
+  // route; History/Matches/Hidden get their own paths.
+  //
+  // The strip is the same underline `TabStrip` every other `/my/*` section navigates
+  // with, icons included — a sibling section of one account area reading differently
+  // looks like a bug rather than a choice.
+  const SECTIONS = [
+    { id: 'saved', path: '/my/activity', icon: Bookmark },
+    { id: 'history', path: '/my/activity/history', icon: History },
+    { id: 'matches', path: '/my/activity/matches', icon: Sparkles },
+    { id: 'hidden', path: '/my/activity/hidden', icon: EyeOff },
+  ] as const;
+  const PANEL_ID = 'activity-tabpanel';
+
   const path = $derived(page.url.pathname);
   // Saved (index) matches exactly so it is not also active on the child routes.
-  const savedActive = $derived(path === '/my/activity');
-  const historyActive = $derived(path.startsWith('/my/activity/history'));
-  const matchesActive = $derived(path.startsWith('/my/activity/matches'));
-  const hiddenActive = $derived(path.startsWith('/my/activity/hidden'));
-  // The id of the active tab, so the routed panel can point back at it (aria-labelledby).
-  const activeTabId = $derived(
-    historyActive
-      ? 'activity-tab-history'
-      : matchesActive
-        ? 'activity-tab-matches'
-        : hiddenActive
-          ? 'activity-tab-hidden'
-          : 'activity-tab-saved',
+  const active = $derived(
+    SECTIONS.find((sec) => sec.path !== '/my/activity' && path.startsWith(sec.path))?.id ?? 'saved',
   );
-
+  const tabs = $derived(
+    SECTIONS.map((sec) => ({
+      id: sec.id,
+      label: s.tabs[sec.id],
+      icon: sec.icon,
+      href: resolve(sec.path),
+    })),
+  );
 </script>
 
 <svelte:head>
@@ -42,50 +51,9 @@
 <div class="flex flex-col gap-4">
   <h1 class="text-2xl font-semibold tracking-tight">{s.title}</h1>
 
-  <div role="tablist" aria-label={s.tablistLabel} use:tablist={path} class="flex items-center gap-1">
-    <a
-      role="tab"
-      id="activity-tab-saved"
-      aria-selected={savedActive}
-      aria-controls="activity-tabpanel"
-      href={resolve('/my/activity')}
-      class={routeTabClass(savedActive)}
-    >
-      {s.tabs.saved}
-    </a>
-    <a
-      role="tab"
-      id="activity-tab-history"
-      aria-selected={historyActive}
-      aria-controls="activity-tabpanel"
-      href={resolve('/my/activity/history')}
-      class={routeTabClass(historyActive)}
-    >
-      {s.tabs.history}
-    </a>
-    <a
-      role="tab"
-      id="activity-tab-matches"
-      aria-selected={matchesActive}
-      aria-controls="activity-tabpanel"
-      href={resolve('/my/activity/matches')}
-      class={routeTabClass(matchesActive)}
-    >
-      {s.tabs.matches}
-    </a>
-    <a
-      role="tab"
-      id="activity-tab-hidden"
-      aria-selected={hiddenActive}
-      aria-controls="activity-tabpanel"
-      href={resolve('/my/activity/hidden')}
-      class={routeTabClass(hiddenActive)}
-    >
-      {s.tabs.hidden}
-    </a>
-  </div>
+  <TabStrip {tabs} {active} label={s.tablistLabel} panelId={PANEL_ID} />
 
-  <div role="tabpanel" id="activity-tabpanel" aria-labelledby={activeTabId} tabindex="0">
+  <div role="tabpanel" id={PANEL_ID} aria-labelledby={tabStripId(PANEL_ID, active)} tabindex="0">
     {@render children()}
   </div>
 </div>

--- a/web/src/routes/my/inbox/+page.svelte
+++ b/web/src/routes/my/inbox/+page.svelte
@@ -9,5 +9,14 @@
 <!-- The account shell (my/+layout) owns the container, auth gate, and noindex. A
      touch wider than the single-column pages so the two-pane inbox has room. -->
 <div class="max-w-4xl">
+  <!-- The title sits here rather than inside InboxView so it is present while the view
+       is still loading, the way every other /my/* section titles itself. -->
+  <div class="mb-6 flex flex-col gap-1">
+    <h1 class="text-2xl font-semibold tracking-tight">Inbox</h1>
+    <p class="text-sm text-muted-foreground">
+      The mail your applications generate, linked back to the application it belongs to.
+    </p>
+  </div>
+
   <InboxView />
 </div>

--- a/web/src/routes/my/invite/+page.svelte
+++ b/web/src/routes/my/invite/+page.svelte
@@ -39,7 +39,7 @@
   <header class="flex flex-col gap-2">
     <h1 class="text-2xl font-semibold tracking-tight">Invite a friend</h1>
     {#if summary}
-      <p class="text-muted-foreground">
+      <p class="text-sm text-muted-foreground">
         They get {summary.percent_off}% off their first month. You get {summary.percent_off}%
         off your next one, once they have actually paid.
       </p>

--- a/web/src/routes/my/market-pulse/+page.svelte
+++ b/web/src/routes/my/market-pulse/+page.svelte
@@ -10,6 +10,7 @@
   import FilterEdgeTab from '$lib/components/FilterEdgeTab.svelte';
   import MarketPulseView from '$lib/components/MarketPulseView.svelte';
   import States from '$lib/components/States.svelte';
+  import { Gauge, TrendingUp } from '@lucide/svelte';
   import { TabStrip, tabStripId } from '$lib/ui';
   import VerdictView from '$lib/components/VerdictView.svelte';
   import { profileStore } from '$lib/profile.svelte';
@@ -23,8 +24,8 @@
   const excludeFacets = ['skills'];
 
   const TABS = [
-    { id: 'coverage', label: 'Coverage' },
-    { id: 'trend', label: 'Skill trend' },
+    { id: 'coverage', label: 'Coverage', icon: Gauge },
+    { id: 'trend', label: 'Skill trend', icon: TrendingUp },
   ] as const;
   const PANEL_ID = 'market-pulse-panel';
   let tab = $state<'coverage' | 'trend'>('coverage');

--- a/web/src/routes/my/notifications/+layout.svelte
+++ b/web/src/routes/my/notifications/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
-  import { goto } from '$app/navigation';
+  import type { LucideIcon } from '@lucide/svelte';
+  import { Bell, Settings, SearchCheck } from '@lucide/svelte';
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import { TabStrip, tabStripId } from '$lib/ui';
@@ -8,30 +9,47 @@
   import type { NotificationTabId } from '$lib/notificationCenterTabs';
 
   // The notification center's shared chrome: history, search alerts, and settings
-  // are three real routes (not a client-side view switch), so the strip navigates
-  // rather than only swapping local state — unlike every other TabStrip call site
-  // in this codebase (/my/profile, /my/market-pulse).
+  // are three real routes (not a client-side view switch), so the strip's tabs carry
+  // their own `href` and navigate as links — same as /my/profile, /my/activity and
+  // /my/tracking, and unlike the local view switch at /my/market-pulse.
 
   let { children }: { children: Snippet } = $props();
+
+  // Kept here rather than in notificationCenterTabs.ts, which stays Svelte-free so the
+  // active-tab rule can be unit-tested — the same split accountNav/accountNavIcons makes.
+  const ICONS: Record<NotificationTabId, LucideIcon> = {
+    history: Bell,
+    searches: SearchCheck,
+    settings: Settings,
+  };
 
   const active = $derived(activeNotificationTab(page.url.pathname));
   const PANEL_ID = 'notification-center-panel';
 
-  function onSelect(id: NotificationTabId) {
-    const tab = NOTIFICATION_TABS.find((t) => t.id === id);
-    if (tab) void goto(resolve(tab.href));
-  }
+  const tabs = $derived(
+    NOTIFICATION_TABS.map((tab) => ({
+      id: tab.id,
+      label: tab.label,
+      icon: ICONS[tab.id],
+      href: resolve(tab.href),
+    })),
+  );
 </script>
 
 <!-- The account shell (my/+layout) owns the container, auth gate, and noindex. -->
 <div class="flex flex-col gap-6">
-  <TabStrip
-    tabs={NOTIFICATION_TABS}
-    {active}
-    {onSelect}
-    label="Notification center sections"
-    panelId={PANEL_ID}
-  />
+  <!-- The section's title belongs to the layout, above the strip, the way /my/activity
+       and /my/tracking title theirs — in the History pane it was the only one of the
+       three routes that had a heading at all. -->
+  <div class="flex flex-col gap-1">
+    <h1 class="text-2xl font-semibold tracking-tight">Notifications</h1>
+    <p class="text-sm text-muted-foreground">
+      Every new-job match, reminder and application nudge you've been sent — and what you
+      get next.
+    </p>
+  </div>
+
+  <TabStrip {tabs} {active} label="Notification center sections" panelId={PANEL_ID} />
 
   <div id={PANEL_ID} role="tabpanel" aria-labelledby={tabStripId(PANEL_ID, active)}>
     {@render children()}

--- a/web/src/routes/my/notifications/+page.svelte
+++ b/web/src/routes/my/notifications/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { resolve } from '$app/paths';
   import { api } from '$lib/api';
   import { notificationCenter } from '$lib/notificationCenter.svelte';
   import { Paginator } from '$lib/paginated.svelte';
@@ -55,18 +54,10 @@
 </svelte:head>
 
 <div class="max-w-2xl">
-  <div class="mb-4 flex items-center justify-between">
-    <div>
-      <h1 class="text-lg font-semibold">Notification history</h1>
-      <p class="text-sm text-muted-foreground">
-        Every new-job match, reminder, and application nudge you've been sent — see
-        <a href={resolve('/my/notifications/settings')} class="underline underline-offset-2 hover:text-foreground">
-          Settings
-        </a>
-        to change what you get.
-      </p>
-    </div>
-    {#if hasUnread}
+  <!-- The section heading lives in the layout, above the tab strip; this pane keeps only
+       its own action, and nothing at all when there is none. -->
+  {#if hasUnread}
+    <div class="mb-4 flex items-center justify-end">
       <button
         type="button"
         onclick={markAllRead}
@@ -74,8 +65,8 @@
       >
         Mark all read
       </button>
-    {/if}
-  </div>
+    </div>
+  {/if}
 
   {#if pager.status === 'loading'}
     <States state="loading" rows={6} />

--- a/web/src/routes/my/profile/+layout.svelte
+++ b/web/src/routes/my/profile/+layout.svelte
@@ -12,7 +12,7 @@
   } from '@lucide/svelte';
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
-  import { tablist } from '$lib/actions/tablist';
+  import { TabStrip, tabStripId } from '$lib/ui';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { locale } from '$lib/i18n/currentLocale.svelte';
   import { t } from '$lib/i18n/t';
@@ -36,9 +36,8 @@
   let { children }: { children: Snippet } = $props();
 
   // Icons match the account sidebar's convention (see accountNavIcons.ts) so the row
-  // scans the same way collapsed; the row scrolls horizontally on narrow viewports
-  // rather than wrapping, same as the account nav's own mobile strip in
-  // my/+layout.svelte. CV readiness is deliberately not one of these — it's not
+  // scans the same way collapsed; `TabStrip` owns the overflow behaviour on a narrow
+  // viewport. CV readiness is deliberately not one of these — it's not
   // published yet; it still works at /my/profile/cv-readiness for anyone who holds
   // the link, nothing here links to it.
   const SECTIONS = [
@@ -52,11 +51,21 @@
     { id: 'settings', href: '/my/profile/settings', icon: SettingsIcon },
   ] as const;
 
+  const PANEL_ID = 'profile-panel';
+
   const s = $derived(t(messages, locale()));
   const profile = $derived(profileStore.profile);
   const resumeMeta = $derived(resumeStore.meta);
   const path = $derived(page.url.pathname);
   const activeSectionId = $derived(SECTIONS.find((sec) => sec.href === path)?.id ?? 'profile');
+  const tabs = $derived(
+    SECTIONS.map((sec) => ({
+      id: sec.id,
+      label: s.tabs[sec.id],
+      icon: sec.icon,
+      href: resolve(sec.href),
+    })),
+  );
 
   let status = $state<'loading' | 'error' | 'ready'>('loading');
 
@@ -139,38 +148,28 @@
     <AccountSetupCard />
   </div>
 
-  <!-- Underline tabs, same style as the Inbox page's Inbox/Settings switch. -->
-  <div class="mb-6 flex items-end justify-between gap-4 border-b border-border text-sm">
-    <div
-      class="no-scrollbar flex min-w-0 gap-4 overflow-x-auto"
-      role="tablist"
-      aria-label="Profile sections"
-      use:tablist={path}
-    >
-      {#each SECTIONS as sec (sec.id)}
-        {@const Icon = sec.icon}
-        {@const active = path === sec.href}
-        <a
-          role="tab"
-          id="profile-tab-{sec.id}"
-          aria-selected={active}
-          aria-controls="profile-panel"
-          href={resolve(sec.href)}
-          class="-mb-px flex shrink-0 items-center gap-1.5 whitespace-nowrap border-b-2 px-1 py-2 transition-colors {active
-            ? 'border-brand font-medium text-foreground'
-            : 'border-transparent text-muted-foreground hover:text-foreground'}"
-        >
-          <Icon class="size-4" aria-hidden="true" />
-          {s.tabs[sec.id]}
-        </a>
-      {/each}
-    </div>
+  <!-- Same heading the set-up branch above renders, so the page does not lose its title
+       the moment a profile exists — and so this section is titled like every other
+       /my/* one. -->
+  <div class="mb-6 flex flex-col gap-1">
+    <h1 class="text-2xl font-semibold tracking-tight">Profile</h1>
+    <p class="text-sm text-muted-foreground">
+      Your CV, skills and role — measured against live market demand.
+    </p>
   </div>
 
+  <TabStrip
+    {tabs}
+    active={activeSectionId}
+    label="Profile sections"
+    panelId={PANEL_ID}
+    class="mb-6"
+  />
+
   <div
-    id="profile-panel"
+    id={PANEL_ID}
     role="tabpanel"
-    aria-labelledby="profile-tab-{activeSectionId}"
+    aria-labelledby={tabStripId(PANEL_ID, activeSectionId)}
     tabindex="0"
   >
     {@render children()}

--- a/web/src/routes/my/referrals/+page.svelte
+++ b/web/src/routes/my/referrals/+page.svelte
@@ -13,6 +13,6 @@
 
 <!-- The account shell (my/+layout) owns the container, auth gate, and noindex. -->
 <div class="max-w-3xl">
-  <h1 class="mb-4 text-lg font-semibold tracking-tight">{s.title}</h1>
+  <h1 class="mb-4 text-2xl font-semibold tracking-tight">{s.title}</h1>
   <ReferralsView />
 </div>

--- a/web/src/routes/my/security/+page.svelte
+++ b/web/src/routes/my/security/+page.svelte
@@ -77,7 +77,7 @@
 
 <svelte:head><title>{s.headTitle}</title></svelte:head>
 
-<h1 class="mb-1 text-lg font-semibold tracking-tight">{s.title}</h1>
+<h1 class="mb-1 text-2xl font-semibold tracking-tight">{s.title}</h1>
 <p class="mb-6 text-sm text-muted-foreground">{s.subtitle}</p>
 
 <section class="mb-8 rounded-lg border border-border p-4">

--- a/web/src/routes/my/talent-network/+page.svelte
+++ b/web/src/routes/my/talent-network/+page.svelte
@@ -87,7 +87,7 @@
 <div class="flex max-w-2xl flex-col gap-4">
   <div class="flex flex-col items-start gap-4 sm:flex-row sm:items-start sm:justify-between">
     <div class="flex flex-col gap-1">
-      <h1 class="text-lg font-semibold tracking-tight">Talent Network</h1>
+      <h1 class="text-2xl font-semibold tracking-tight">Talent Network</h1>
       <p class="text-sm text-muted-foreground">
         Get discovered without applying anywhere: publish a read-only profile page you control.
       </p>

--- a/web/src/routes/my/tracking/+layout.svelte
+++ b/web/src/routes/my/tracking/+layout.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
+  import { Calendar, Columns3, List, Workflow } from '@lucide/svelte';
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
-  import { routeTabClass, tablist } from '$lib/actions/tablist';
+  import { TabStrip, tabStripId } from '$lib/ui';
 
   let { children }: { children: Snippet } = $props();
 
@@ -10,23 +11,30 @@
   // this layout adds only Tracking's own sub-navigation. Each view is its own URL
   // so it is linkable, bookmarkable, and survives a reload. Board is the index
   // route; Pipeline gets its own path. History and Matches live under Activity.
+  //
+  // The strip is the same underline `TabStrip` every other `/my/*` section navigates
+  // with, icons included.
+  const SECTIONS = [
+    { id: 'board', label: 'Board', path: '/my/tracking', icon: Columns3 },
+    { id: 'list', label: 'List', path: '/my/tracking/list', icon: List },
+    { id: 'pipeline', label: 'Pipeline', path: '/my/tracking/pipeline', icon: Workflow },
+    { id: 'calendar', label: 'Calendar', path: '/my/tracking/calendar', icon: Calendar },
+  ] as const;
+  const PANEL_ID = 'tracking-tabpanel';
+
   const path = $derived(page.url.pathname);
   // Board (index) matches exactly so it is not also active on the child routes.
-  const boardActive = $derived(path === '/my/tracking');
-  const listActive = $derived(path.startsWith('/my/tracking/list'));
-  const pipelineActive = $derived(path.startsWith('/my/tracking/pipeline'));
-  const calendarActive = $derived(path.startsWith('/my/tracking/calendar'));
-  // The id of the active tab, so the routed panel can point back at it (aria-labelledby).
-  const activeTabId = $derived(
-    calendarActive
-      ? 'tracking-tab-calendar'
-      : pipelineActive
-        ? 'tracking-tab-pipeline'
-        : listActive
-          ? 'tracking-tab-list'
-          : 'tracking-tab-board',
+  const active = $derived(
+    SECTIONS.find((sec) => sec.path !== '/my/tracking' && path.startsWith(sec.path))?.id ?? 'board',
   );
-
+  const tabs = $derived(
+    SECTIONS.map((sec) => ({
+      id: sec.id,
+      label: sec.label,
+      icon: sec.icon,
+      href: resolve(sec.path),
+    })),
+  );
 </script>
 
 <svelte:head>
@@ -37,50 +45,9 @@
 <div class="flex flex-col gap-4">
   <h1 class="text-2xl font-semibold tracking-tight">Tracking</h1>
 
-  <div role="tablist" aria-label="Tracking view" use:tablist={path} class="flex items-center gap-1">
-    <a
-      role="tab"
-      id="tracking-tab-board"
-      aria-selected={boardActive}
-      aria-controls="tracking-tabpanel"
-      href={resolve('/my/tracking')}
-      class={routeTabClass(boardActive)}
-    >
-      Board
-    </a>
-    <a
-      role="tab"
-      id="tracking-tab-list"
-      aria-selected={listActive}
-      aria-controls="tracking-tabpanel"
-      href={resolve('/my/tracking/list')}
-      class={routeTabClass(listActive)}
-    >
-      List
-    </a>
-    <a
-      role="tab"
-      id="tracking-tab-pipeline"
-      aria-selected={pipelineActive}
-      aria-controls="tracking-tabpanel"
-      href={resolve('/my/tracking/pipeline')}
-      class={routeTabClass(pipelineActive)}
-    >
-      Pipeline
-    </a>
-    <a
-      role="tab"
-      id="tracking-tab-calendar"
-      aria-selected={calendarActive}
-      aria-controls="tracking-tabpanel"
-      href={resolve('/my/tracking/calendar')}
-      class={routeTabClass(calendarActive)}
-    >
-      Calendar
-    </a>
-  </div>
+  <TabStrip {tabs} {active} label="Tracking view" panelId={PANEL_ID} />
 
-  <div role="tabpanel" id="tracking-tabpanel" aria-labelledby={activeTabId} tabindex="0">
+  <div role="tabpanel" id={PANEL_ID} aria-labelledby={tabStripId(PANEL_ID, active)} tabindex="0">
     {@render children()}
   </div>
 </div>


### PR DESCRIPTION
Four different tab treatments shared `/my/*`: an underline row with icons hand-rolled in the profile layout, pill anchors in activity and tracking, a second hand-rolled underline row in the inbox, and the design system's own `TabStrip` in the notification center and market pulse. Each was a copy of a row that already exists, so each could drift, and all four had.

`TabStrip` is now the only one. Two things it could not do before:

- a tab may carry an `icon`, the leading glyph the profile row already had and the reason the other three could not adopt it;
- a tab may carry an `href`, and then renders as an anchor. A strip whose tabs ARE routes should be middle-clickable, openable in a new tab and preloadable; a button plus `goto` looks identical and is none of those, which is what the notification center shipped. Arrows move focus only on a link strip — automatic activation would fire a navigation per keypress while the reader is still scanning the row.

`routeTabClass` is deleted with its last two callers. The `tablist` action stays: the submit, referrals and job-drawer strips still use it.

## Headings

The second half of the same drift. `text-2xl font-semibold tracking-tight` over a `text-sm text-muted-foreground` line was already the pattern on ten of these pages; security, talent network, referrals and the notification history used `text-lg`, invite's subtitle skipped `text-sm`, and profile (once a profile exists), inbox and the notification center had no heading at all. The notification center's now lives in the layout, above the strip, so Search alerts and Settings are titled too rather than only History.

## Checks

- `pnpm check` — 0 errors in both packages
- `pnpm lint`, `pnpm test` — green in both (web 1619, design-system 154 incl. 3 new TabStrip cases)
- `pnpm build` (web) — green
- TabStrip's icon row eyeballed in Storybook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional icons and link-based navigation to tab strips.
  - Updated Activity, Profile, Tracking, Inbox, Notifications, and Market Pulse sections with the shared tab experience.
  - Added clearer tab and panel accessibility support.
  - Added an Inbox page title and improved loading-state visibility.
- **Bug Fixes**
  - Arrow-key navigation between linked tabs no longer triggers selection callbacks.
- **Style**
  - Updated several page headings and supporting text for improved sizing and spacing.
- **Documentation**
  - Expanded tab component documentation and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->