### PR TITLE
Give the four account tab strips one rule for which tab is active

### DIFF
--- a/design-system/src/tab-strip.svelte
+++ b/design-system/src/tab-strip.svelte
@@ -145,6 +145,13 @@
   }
 </script>
 
+<!-- The label and its optional glyph, shared by both elements a tab can be. -->
+{#snippet body(t: (typeof tabs)[number])}
+  {@const Icon = t.icon}
+  {#if Icon}<Icon class="size-4" aria-hidden="true" />{/if}
+  {t.label}
+{/snippet}
+
 <div class={cn('relative', extra)}>
   <div
     bind:this={strip}
@@ -155,12 +162,12 @@
     class="flex gap-4 overflow-x-auto border-b border-border sm:gap-5 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
   >
     {#each tabs as t, i (t.id)}
-      {@const Icon = t.icon}
-      {@const cls =
-        `-mb-px flex shrink-0 items-center gap-1.5 whitespace-nowrap border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors ` +
-        (t.id === active
+      {@const cls = cn(
+        '-mb-px flex shrink-0 items-center gap-1.5 whitespace-nowrap border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors',
+        t.id === active
           ? 'border-brand text-foreground'
-          : 'border-transparent text-muted-foreground hover:text-foreground')}
+          : 'border-transparent text-muted-foreground hover:text-foreground',
+      )}
       {#if t.href !== undefined}
         <a
           bind:this={buttons[i]}
@@ -173,8 +180,7 @@
           onkeydown={onKeydown}
           class={cls}
         >
-          {#if Icon}<Icon class="size-4" aria-hidden="true" />{/if}
-          {t.label}
+          {@render body(t)}
         </a>
       {:else}
         <button
@@ -189,8 +195,7 @@
           onkeydown={onKeydown}
           class={cls}
         >
-          {#if Icon}<Icon class="size-4" aria-hidden="true" />{/if}
-          {t.label}
+          {@render body(t)}
         </button>
       {/if}
     {/each}

--- a/web/src/lib/notificationCenterTabs.test.ts
+++ b/web/src/lib/notificationCenterTabs.test.ts
@@ -1,30 +1,17 @@
 import { describe, it, expect } from 'vitest';
-import { activeNotificationTab, NOTIFICATION_TABS } from './notificationCenterTabs';
-
-describe('activeNotificationTab', () => {
-  it('is history on the landing route', () => {
-    expect(activeNotificationTab('/my/notifications')).toBe('history');
-  });
-
-  it('is searches on the search-alerts route', () => {
-    expect(activeNotificationTab('/my/notifications/searches')).toBe('searches');
-  });
-
-  it('is settings on the settings route', () => {
-    expect(activeNotificationTab('/my/notifications/settings')).toBe('settings');
-  });
-
-  it('falls back to history on the digest detail sub-route', () => {
-    expect(activeNotificationTab('/my/notifications/42/jobs')).toBe('history');
-  });
-
-  it('falls back to history on an unrelated path', () => {
-    expect(activeNotificationTab('/my/profile')).toBe('history');
-  });
-});
+import { NOTIFICATION_TABS } from './notificationCenterTabs';
 
 describe('NOTIFICATION_TABS', () => {
   it('has one entry per tab id in display order', () => {
     expect(NOTIFICATION_TABS.map((t) => t.id)).toEqual(['history', 'searches', 'settings']);
+  });
+
+  // History is the index route, so it is a path-prefix of the other two — the case
+  // activeRouteTab's longest-match rule exists for. Asserted against the real tabs
+  // because the rule is only interesting over data shaped like this.
+  it('nests the other tabs under the history route', () => {
+    for (const tab of NOTIFICATION_TABS.filter((t) => t.id !== 'history')) {
+      expect(tab.href.startsWith('/my/notifications/')).toBe(true);
+    }
   });
 });

--- a/web/src/lib/notificationCenterTabs.ts
+++ b/web/src/lib/notificationCenterTabs.ts
@@ -1,6 +1,6 @@
 // The notification center's tab structure: three real routes sharing one strip
-// (`/my/notifications/+layout.svelte`). Kept free of Svelte imports so the
-// active-tab rule stays pure and unit-testable, mirroring accountNav.ts.
+// (`/my/notifications/+layout.svelte`). Which one a pathname is on is the shared
+// rule in routeTabs.ts.
 
 export type NotificationTabId = 'history' | 'searches' | 'settings';
 
@@ -11,20 +11,3 @@ export const NOTIFICATION_TABS = [
   { id: 'searches', label: 'Search alerts', href: '/my/notifications/searches' },
   { id: 'settings', label: 'Settings', href: '/my/notifications/settings' },
 ] as const satisfies readonly { id: NotificationTabId; label: string; href: string }[];
-
-// The longest matching tab route wins, since '/my/notifications' (history) is a
-// path-prefix of every other tab. A path that matches none (e.g. the digest
-// detail page, /my/notifications/:id/jobs) falls back to history — the closest
-// ancestor a reader would expect to land back on.
-export function activeNotificationTab(pathname: string): NotificationTabId {
-  let best: NotificationTabId = 'history';
-  let bestLen = -1;
-  for (const tab of NOTIFICATION_TABS) {
-    const matches = pathname === tab.href || pathname.startsWith(`${tab.href}/`);
-    if (matches && tab.href.length > bestLen) {
-      best = tab.id;
-      bestLen = tab.href.length;
-    }
-  }
-  return best;
-}

--- a/web/src/lib/routeTabs.test.ts
+++ b/web/src/lib/routeTabs.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { activeRouteTab } from './routeTabs';
+
+const TABS = [
+  { id: 'board', href: '/my/tracking' },
+  { id: 'list', href: '/my/tracking/list' },
+  { id: 'pipeline', href: '/my/tracking/pipeline' },
+] as const;
+
+const on = (pathname: string) => activeRouteTab(pathname, TABS, 'board');
+
+describe('activeRouteTab', () => {
+  it('is the index tab on the index route', () => {
+    expect(on('/my/tracking')).toBe('board');
+  });
+
+  it('is the tab whose own route it is', () => {
+    expect(on('/my/tracking/list')).toBe('list');
+  });
+
+  // The index route is a prefix of every other tab's, so a bare startsWith would
+  // report the index as active everywhere.
+  it('prefers the longest matching route over the index', () => {
+    expect(on('/my/tracking/pipeline')).toBe('pipeline');
+  });
+
+  it('stays on a tab through its own sub-routes', () => {
+    expect(on('/my/tracking/list/archived')).toBe('list');
+  });
+
+  // The regression the shared helper exists for: a sibling route that merely starts
+  // with a tab's path is not that tab.
+  it('does not match a route that only shares a prefix with a tab', () => {
+    expect(on('/my/tracking/listing')).toBe('board');
+  });
+
+  it('falls back on a sub-route no tab owns', () => {
+    expect(on('/my/tracking/42/notes')).toBe('board');
+  });
+
+  it('falls back on an unrelated path', () => {
+    expect(on('/my/profile')).toBe('board');
+  });
+});

--- a/web/src/lib/routeTabs.ts
+++ b/web/src/lib/routeTabs.ts
@@ -1,0 +1,28 @@
+// Which tab of a routed tab strip a pathname is on. Shared because the three account
+// sections that navigate with one (`/my/activity`, `/my/notifications`, `/my/tracking`)
+// each had their own copy of the same rule, and two of the copies matched on a bare
+// prefix — which also makes `/my/tracking/listing` the List tab.
+//
+// The longest matching route wins, since a section's index route is a path-prefix of
+// every other tab in it. A tab matches its own route or something under it, nothing
+// else, and a path matching none falls back to the index — the closest ancestor a
+// reader would expect to land back on.
+//
+// Kept free of Svelte imports so the rule stays pure and unit-testable, mirroring
+// accountNav.ts.
+export function activeRouteTab<T extends string>(
+  pathname: string,
+  tabs: readonly { id: T; href: string }[],
+  fallback: T,
+): T {
+  let best = fallback;
+  let bestLength = -1;
+  for (const tab of tabs) {
+    const matches = pathname === tab.href || pathname.startsWith(`${tab.href}/`);
+    if (matches && tab.href.length > bestLength) {
+      best = tab.id;
+      bestLength = tab.href.length;
+    }
+  }
+  return best;
+}

--- a/web/src/routes/my/activity/+layout.svelte
+++ b/web/src/routes/my/activity/+layout.svelte
@@ -4,6 +4,7 @@
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
   import { TabStrip, tabStripId } from '$lib/ui';
+  import { activeRouteTab } from '$lib/routeTabs';
   import { messages } from '$lib/components/activity.messages';
   import { locale } from '$lib/i18n/currentLocale.svelte';
   import { t } from '$lib/i18n/t';
@@ -17,29 +18,20 @@
   // so it is linkable, bookmarkable, and survives a reload. Saved is the index
   // route; History/Matches/Hidden get their own paths.
   //
-  // The strip is the same underline `TabStrip` every other `/my/*` section navigates
+  // The strip is the same underline `TabStrip` every other account section navigates
   // with, icons included — a sibling section of one account area reading differently
   // looks like a bug rather than a choice.
   const SECTIONS = [
-    { id: 'saved', path: '/my/activity', icon: Bookmark },
-    { id: 'history', path: '/my/activity/history', icon: History },
-    { id: 'matches', path: '/my/activity/matches', icon: Sparkles },
-    { id: 'hidden', path: '/my/activity/hidden', icon: EyeOff },
+    { id: 'saved', href: '/my/activity', icon: Bookmark },
+    { id: 'history', href: '/my/activity/history', icon: History },
+    { id: 'matches', href: '/my/activity/matches', icon: Sparkles },
+    { id: 'hidden', href: '/my/activity/hidden', icon: EyeOff },
   ] as const;
   const PANEL_ID = 'activity-tabpanel';
 
-  const path = $derived(page.url.pathname);
-  // Saved (index) matches exactly so it is not also active on the child routes.
-  const active = $derived(
-    SECTIONS.find((sec) => sec.path !== '/my/activity' && path.startsWith(sec.path))?.id ?? 'saved',
-  );
+  const active = $derived(activeRouteTab(page.url.pathname, SECTIONS, 'saved'));
   const tabs = $derived(
-    SECTIONS.map((sec) => ({
-      id: sec.id,
-      label: s.tabs[sec.id],
-      icon: sec.icon,
-      href: resolve(sec.path),
-    })),
+    SECTIONS.map((sec) => ({ ...sec, label: s.tabs[sec.id], href: resolve(sec.href) })),
   );
 </script>
 

--- a/web/src/routes/my/notifications/+layout.svelte
+++ b/web/src/routes/my/notifications/+layout.svelte
@@ -5,8 +5,9 @@
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import { TabStrip, tabStripId } from '$lib/ui';
-  import { activeNotificationTab, NOTIFICATION_TABS } from '$lib/notificationCenterTabs';
+  import { NOTIFICATION_TABS } from '$lib/notificationCenterTabs';
   import type { NotificationTabId } from '$lib/notificationCenterTabs';
+  import { activeRouteTab } from '$lib/routeTabs';
 
   // The notification center's shared chrome: history, search alerts, and settings
   // are three real routes (not a client-side view switch), so the strip's tabs carry
@@ -15,24 +16,19 @@
 
   let { children }: { children: Snippet } = $props();
 
-  // Kept here rather than in notificationCenterTabs.ts, which stays Svelte-free so the
-  // active-tab rule can be unit-tested — the same split accountNav/accountNavIcons makes.
+  // Kept here rather than in notificationCenterTabs.ts, which stays Svelte-free — the
+  // same split accountNav/accountNavIcons makes.
   const ICONS: Record<NotificationTabId, LucideIcon> = {
     history: Bell,
     searches: SearchCheck,
     settings: Settings,
   };
 
-  const active = $derived(activeNotificationTab(page.url.pathname));
   const PANEL_ID = 'notification-center-panel';
 
+  const active = $derived(activeRouteTab(page.url.pathname, NOTIFICATION_TABS, 'history'));
   const tabs = $derived(
-    NOTIFICATION_TABS.map((tab) => ({
-      id: tab.id,
-      label: tab.label,
-      icon: ICONS[tab.id],
-      href: resolve(tab.href),
-    })),
+    NOTIFICATION_TABS.map((tab) => ({ ...tab, icon: ICONS[tab.id], href: resolve(tab.href) })),
   );
 </script>
 

--- a/web/src/routes/my/profile/+layout.svelte
+++ b/web/src/routes/my/profile/+layout.svelte
@@ -13,6 +13,7 @@
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
   import { TabStrip, tabStripId } from '$lib/ui';
+  import { activeRouteTab } from '$lib/routeTabs';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { locale } from '$lib/i18n/currentLocale.svelte';
   import { t } from '$lib/i18n/t';
@@ -56,15 +57,9 @@
   const s = $derived(t(messages, locale()));
   const profile = $derived(profileStore.profile);
   const resumeMeta = $derived(resumeStore.meta);
-  const path = $derived(page.url.pathname);
-  const activeSectionId = $derived(SECTIONS.find((sec) => sec.href === path)?.id ?? 'profile');
+  const activeSectionId = $derived(activeRouteTab(page.url.pathname, SECTIONS, 'profile'));
   const tabs = $derived(
-    SECTIONS.map((sec) => ({
-      id: sec.id,
-      label: s.tabs[sec.id],
-      icon: sec.icon,
-      href: resolve(sec.href),
-    })),
+    SECTIONS.map((sec) => ({ ...sec, label: s.tabs[sec.id], href: resolve(sec.href) })),
   );
 
   let status = $state<'loading' | 'error' | 'ready'>('loading');

--- a/web/src/routes/my/tracking/+layout.svelte
+++ b/web/src/routes/my/tracking/+layout.svelte
@@ -4,6 +4,7 @@
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
   import { TabStrip, tabStripId } from '$lib/ui';
+  import { activeRouteTab } from '$lib/routeTabs';
 
   let { children }: { children: Snippet } = $props();
 
@@ -12,29 +13,18 @@
   // so it is linkable, bookmarkable, and survives a reload. Board is the index
   // route; Pipeline gets its own path. History and Matches live under Activity.
   //
-  // The strip is the same underline `TabStrip` every other `/my/*` section navigates
+  // The strip is the same underline `TabStrip` every other account section navigates
   // with, icons included.
   const SECTIONS = [
-    { id: 'board', label: 'Board', path: '/my/tracking', icon: Columns3 },
-    { id: 'list', label: 'List', path: '/my/tracking/list', icon: List },
-    { id: 'pipeline', label: 'Pipeline', path: '/my/tracking/pipeline', icon: Workflow },
-    { id: 'calendar', label: 'Calendar', path: '/my/tracking/calendar', icon: Calendar },
+    { id: 'board', label: 'Board', href: '/my/tracking', icon: Columns3 },
+    { id: 'list', label: 'List', href: '/my/tracking/list', icon: List },
+    { id: 'pipeline', label: 'Pipeline', href: '/my/tracking/pipeline', icon: Workflow },
+    { id: 'calendar', label: 'Calendar', href: '/my/tracking/calendar', icon: Calendar },
   ] as const;
   const PANEL_ID = 'tracking-tabpanel';
 
-  const path = $derived(page.url.pathname);
-  // Board (index) matches exactly so it is not also active on the child routes.
-  const active = $derived(
-    SECTIONS.find((sec) => sec.path !== '/my/tracking' && path.startsWith(sec.path))?.id ?? 'board',
-  );
-  const tabs = $derived(
-    SECTIONS.map((sec) => ({
-      id: sec.id,
-      label: sec.label,
-      icon: sec.icon,
-      href: resolve(sec.path),
-    })),
-  );
+  const active = $derived(activeRouteTab(page.url.pathname, SECTIONS, 'board'));
+  const tabs = $derived(SECTIONS.map((sec) => ({ ...sec, href: resolve(sec.href) })));
 </script>
 
 <svelte:head>


### PR DESCRIPTION
A quality pass over #2507, no behaviour change.

## One rule instead of four

The four routed strips each carried their own answer to "which tab is this pathname on". Profile matched exactly, notifications matched longest-first, and activity and tracking matched on a bare prefix — which also makes `/my/tracking/listing` the List tab, latent only because no such sibling route exists.

`activeRouteTab` in `web/src/lib/routeTabs.ts` is now the only copy: longest match wins, a tab matches its own route or something under it, anything else falls back to the section's index.

`activeNotificationTab` was the same rule already spelled correctly, so it is gone rather than kept as a one-line delegate; its cases moved into the shared test, which additionally pins the prefix case the two other copies got wrong.

Every real route in these four sections resolves to the tab it resolved to before — I walked the four route trees and there are no sibling-prefix pairs.

The three call sites lose their hand-written `find`/`startsWith`, and their `tabs` derivation collapses to a spread now that the section list and the tab list differ only in the resolved `href`.

## TabStrip

The icon-and-label body is a snippet instead of the same two lines in both the anchor and the button branch, and the tab class goes through `cn` like the wrapper above it rather than string concatenation.

## Checks

- `pnpm check` — 0 errors in both packages
- `pnpm lint`, `pnpm test` — green (web 1622, design-system 154)
- `validate:docs`, `check:adoption` — green
- The rendered strip compared against a screenshot of the same story before the refactor: unchanged, so `cn`'s merge dropped nothing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved tab navigation across Activity, Notifications, Profile, and Tracking sections.
  * Tabs now remain correctly selected when viewing nested pages and sub-routes.
  * Added consistent fallback behavior for routes that do not match a specific tab.
  * Ensured notification sub-tabs use consistent URL structures.
  * Improved tab rendering consistency for tabs displayed as links or buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->