### PR TITLE
Let the arrows walk a tab strip whose tabs are links

### DIFF
--- a/design-system/src/tab-strip.svelte
+++ b/design-system/src/tab-strip.svelte
@@ -119,14 +119,21 @@
   // A link tab is the exception: arrows move focus only, and Enter (the anchor's own
   // activation) navigates. Activating on the arrow itself would fire a navigation per
   // keypress while the reader is still scanning the row for the section they want.
+  //
+  // Which is why a step is measured from the tab that HAS focus, not from the selected
+  // one: on a link strip the selection does not move until the reader presses Enter, so
+  // measuring from `active` returns the same neighbour on every press and the row cannot
+  // be walked at all. On a button strip the two agree, since it activates as it goes.
   function onKeydown(event: KeyboardEvent) {
+    const focused = buttons.indexOf(document.activeElement as HTMLElement);
+    const from = focused === -1 ? activeIndex : focused;
     let next: number;
     switch (event.key) {
       case 'ArrowRight':
-        next = (activeIndex + 1) % tabs.length;
+        next = (from + 1) % tabs.length;
         break;
       case 'ArrowLeft':
-        next = (activeIndex - 1 + tabs.length) % tabs.length;
+        next = (from - 1 + tabs.length) % tabs.length;
         break;
       case 'Home':
         next = 0;

--- a/design-system/src/tab-strip.test.ts
+++ b/design-system/src/tab-strip.test.ts
@@ -10,6 +10,12 @@ const TABS = [
   { id: 'three', label: 'Three' },
 ];
 
+const LINK_TABS = [
+  { id: 'one', label: 'One', href: '/one' },
+  { id: 'two', label: 'Two', href: '/two' },
+  { id: 'three', label: 'Three', href: '/three' },
+];
+
 function setup(active = 'one') {
   const onSelect = vi.fn();
   const { getAllByRole, rerender } = render(TabStrip, {
@@ -115,10 +121,7 @@ describe('TabStrip', () => {
   it('moves focus without navigating when the tabs are links', async () => {
     const onSelect = vi.fn();
     const { getAllByRole } = render(TabStrip, {
-      tabs: [
-        { id: 'one', label: 'One', href: '/one' },
-        { id: 'two', label: 'Two', href: '/two' },
-      ],
+      tabs: LINK_TABS,
       active: 'one',
       onSelect,
       label: 'Demo sections',
@@ -129,6 +132,40 @@ describe('TabStrip', () => {
     await fireArrow(must(tabs[0]), 'ArrowRight');
 
     expect(onSelect).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(tabs[1]);
+  });
+
+  // The regression a single press could not see: a link strip does not move its selection
+  // on an arrow, so a step measured from `active` returned the same neighbour every time
+  // and the row could not be walked past its first hop.
+  it('keeps walking a link strip across successive presses', async () => {
+    const { getAllByRole } = render(TabStrip, {
+      tabs: LINK_TABS,
+      active: 'one',
+      label: 'Demo sections',
+      panelId: 'demo-panel',
+    });
+
+    const tabs = getAllByRole('tab');
+    await fireArrow(must(tabs[0]), 'ArrowRight');
+    await fireArrow(must(tabs[1]), 'ArrowRight');
+
+    expect(document.activeElement).toBe(tabs[2]);
+  });
+
+  it('walks a link strip backwards from the focused tab too', async () => {
+    const { getAllByRole } = render(TabStrip, {
+      tabs: LINK_TABS,
+      active: 'one',
+      label: 'Demo sections',
+      panelId: 'demo-panel',
+    });
+
+    const tabs = getAllByRole('tab');
+    // Off the left end of the selected tab wraps to the last, then back one.
+    await fireArrow(must(tabs[0]), 'ArrowLeft');
+    await fireArrow(must(tabs[2]), 'ArrowLeft');
+
     expect(document.activeElement).toBe(tabs[1]);
   });
 

--- a/web/src/routes/my/notifications/[id]/jobs/+page.svelte
+++ b/web/src/routes/my/notifications/[id]/jobs/+page.svelte
@@ -50,7 +50,9 @@
   {:else if status === 'error'}
     <States state="error" />
   {:else if item}
-    <h1 class="mb-1 text-lg font-semibold">{item.title}</h1>
+    <!-- An h2, not an h1: the notification center's layout titles the section above the
+         tab strip, and one digest is a heading under it rather than a second page title. -->
+    <h2 class="mb-1 text-lg font-semibold">{item.title}</h2>
     <p class="mb-4 text-sm text-muted-foreground">{item.body}</p>
 
     {#if item.jobs && item.jobs.length > 0}

--- a/web/src/routes/my/profile/+layout.svelte
+++ b/web/src/routes/my/profile/+layout.svelte
@@ -109,19 +109,20 @@
   <title>Profile — freehire</title>
 </svelte:head>
 
-<!-- The account shell (my/+layout) owns the container, auth gate, and noindex. -->
+<!-- The account shell (my/+layout) owns the container, auth gate, and noindex. The
+     heading sits above the gate so the section is titled while it is still loading and
+     whether or not a profile exists yet, the way every other /my section titles itself. -->
+<div class="mb-6 flex flex-col gap-1">
+  <h1 class="text-2xl font-semibold tracking-tight">{s.title}</h1>
+  <p class="text-sm text-muted-foreground">{s.description}</p>
+</div>
+
 {#if status === 'loading'}
   <States state="loading" />
 {:else if status === 'error'}
   <States state="error" message="Couldn't load your profile." />
 {:else if profile === null}
   <!-- Set-up: the inline form only; coverage appears once a profile exists. -->
-  <div class="mb-6 flex flex-col gap-1">
-    <h1 class="text-2xl font-semibold tracking-tight">Profile</h1>
-    <p class="text-sm text-muted-foreground">
-      Your CV, skills and role — measured against live market demand.
-    </p>
-  </div>
   <div class="w-full">
     <ProfileForm
       profile={null}
@@ -141,16 +142,6 @@
        re-announced on every tab switch. -->
   <div class="mb-6">
     <AccountSetupCard />
-  </div>
-
-  <!-- Same heading the set-up branch above renders, so the page does not lose its title
-       the moment a profile exists — and so this section is titled like every other
-       /my/* one. -->
-  <div class="mb-6 flex flex-col gap-1">
-    <h1 class="text-2xl font-semibold tracking-tight">Profile</h1>
-    <p class="text-sm text-muted-foreground">
-      Your CV, skills and role — measured against live market demand.
-    </p>
   </div>
 
   <TabStrip

--- a/web/src/routes/my/profile/messages.ts
+++ b/web/src/routes/my/profile/messages.ts
@@ -1,9 +1,11 @@
 import { defineMessages } from '$lib/i18n/t';
 
-// Only the tab-strip labels — the views themselves (ProfileForm,
+// The section heading and the tab-strip labels — the views themselves (ProfileForm,
 // ExperienceBankView, etc.) are out of scope for this pass.
 export const messages = defineMessages(
   {
+    title: 'Profile',
+    description: 'Your CV, skills and role — measured against live market demand.',
     tabs: {
       profile: 'Profile',
       contacts: 'Contacts',
@@ -17,6 +19,8 @@ export const messages = defineMessages(
   },
   {
     ru: {
+      title: 'Профиль',
+      description: 'Ваше резюме, навыки и роль — в сравнении с живым спросом рынка.',
       tabs: {
         profile: 'Профиль',
         contacts: 'Контакты',


### PR DESCRIPTION
Three findings from a review of #2507 / #2508.

## The arrows could not walk a link strip

`TabStrip.onKeydown` measured its step from `activeIndex`. A link strip deliberately does not move its selection on an arrow — activating a link navigates, so `onSelect` is skipped — so the selection never moved, every press computed the same neighbour, and the row stopped after one hop.

That hit all four strips converted to links in #2507: `/my/profile`, `/my/activity`, `/my/tracking`, `/my/notifications`.

The step now comes from the tab that **has focus**, which is what the `tablist` action it replaced did. The two agree on a button strip, which activates as it goes, so nothing there changes.

The test that missed this pressed once. Two new cases press twice, in both directions; both fail against the old code (verified by reverting the fix — 2 failed / 11 passed, then 13 passed with it back).

## The profile heading was English inside an i18n'd layout

The tab labels right below it came from the catalogue and the title did not, so a `ru` reader got an English title over Russian tabs. It moves into `messages.ts` alongside the tabs.

While there: the heading was rendered twice, once per branch of the profile gate, and in the ready branch it sat **below** the account set-up card — the only `/my` section whose title was not the first thing on the page. One copy now sits above the whole gate, so the section is also titled while it is still loading.

## Two `h1` on one page

`/my/notifications/[id]/jobs` kept its own `h1` after the notification center's layout grew one above the tab strip. The digest's own title is an `h2` under it.

## Checks

- `pnpm check` — 0 errors in both packages
- `pnpm lint`, `pnpm test` — green (web 1622, design-system 156)
- `validate:docs`, `check:adoption` — green
- **Verified in the running app**, not only in tests: signed in against a local stack, ArrowRight three times along the profile strip walks Contacts → Location → Skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved arrow-key navigation for link-based tabs, allowing users to move focus across tabs without triggering navigation.
  * Preserved automatic selection behavior for button-based tabs.
* **Accessibility**
  * Adjusted notification job digest heading hierarchy.
  * Standardized profile page headings across loading, setup, error, and ready states.
* **Localization**
  * Added localized profile title and description text in English and Russian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->