### PR TITLE
Let an Ultra subscriber read their own subscription, and an operator set the auto-apply ceiling

### DIFF
--- a/internal/ai/plan/AGENTS.md
+++ b/internal/ai/plan/AGENTS.md
@@ -97,6 +97,14 @@ transaction. `store.go` is the transaction around it and nothing else.
   names the features whose refusal is on (`match,tailor` or `all`), so the run ends one
   feature at a time without a deploy.
 
+  **A `PLAN_*_DAILY_<F>` suffix writes a dashed feature with an UNDERSCORE**
+  (`PLAN_PRO_DAILY_AUTO_APPLY`), while `PLAN_ENFORCE` names the feature exactly as the
+  ledger stores it (`auto-apply`). The two spellings differ because only one of them is an
+  environment variable NAME: systemd's `EnvironmentFile=` will not parse a dash in one, so a
+  suffix taken verbatim from the feature would put the lever out of reach on the only host
+  it exists for. The values themselves cannot change — they are in `usage_ledger` and in the
+  idempotency index.
+
 - **The fair-use guard belongs to the PRO plan and ignores the enforcement switch.** A free
   account is already bounded by its daily allowance, so reaching the guard there would mean
   the allowance was configured above it — a misconfiguration to fix, not a caller to accuse

--- a/internal/ai/plan/env.go
+++ b/internal/ai/plan/env.go
@@ -38,7 +38,7 @@ func ConfigFromEnv() Config {
 		if enforced[f] {
 			fc.enforce = true
 		}
-		suffix := strings.ToUpper(string(f))
+		suffix := envSuffix(f)
 		if n, ok := envPositive("PLAN_FREE_DAILY_" + suffix); ok {
 			fc.free.daily = n
 		}
@@ -54,6 +54,20 @@ func ConfigFromEnv() Config {
 		cfg.TailorTurnsPerSession = n
 	}
 	return cfg
+}
+
+// envSuffix is the variable-name half of a feature: upper case, with the dash a name may
+// carry written as an underscore.
+//
+// The dash is not cosmetic. "cover-letter" and "auto-apply" are persisted in the ledger and
+// matched by the idempotency index, so those values cannot change — but systemd's
+// EnvironmentFile= will not accept a variable whose name holds a dash, so a suffix taken
+// verbatim asks for PLAN_PRO_DAILY_AUTO-APPLY, which is unsettable on the host it has to be
+// set on. Reading the underscored spelling is what makes the documented lever exist for the
+// two features that need it most: auto-apply is the one feature that ships enforcing, and
+// pro's ceiling on it is what the tier above is sold on.
+func envSuffix(f Feature) string {
+	return strings.ToUpper(strings.ReplaceAll(string(f), "-", "_"))
 }
 
 // enforcedFeatures reads the enforcement list. A name that matches no feature is ignored

--- a/internal/ai/plan/env_test.go
+++ b/internal/ai/plan/env_test.go
@@ -1,6 +1,9 @@
 package plan
 
-import "testing"
+import (
+	"regexp"
+	"testing"
+)
 
 func TestConfigFromEnvDefaultsToTheShippedConfig(t *testing.T) {
 	cfg := ConfigFromEnv()
@@ -70,6 +73,39 @@ func TestFreeAllowanceOverride(t *testing.T) {
 	}
 	if got := cfg.FreeDaily(FeatureTailor); got != DefaultConfig().FreeDaily(FeatureTailor) {
 		t.Errorf("overriding one feature changed another (tailor = %d)", got)
+	}
+}
+
+func TestADashedFeatureIsOverriddenByItsUnderscoredName(t *testing.T) {
+	// The two features whose ledger value carries a dash. A suffix taken verbatim from it
+	// asks for PLAN_PRO_DAILY_AUTO-APPLY, a name systemd's EnvironmentFile= will not parse,
+	// so the documented lever would be unsettable on the host it exists for — and this one
+	// is a ceiling under a plan people have already bought.
+	t.Setenv("PLAN_PRO_DAILY_AUTO_APPLY", "9")
+	t.Setenv("PLAN_FREE_DAILY_COVER_LETTER", "5")
+	t.Setenv("PLAN_ULTRA_DAILY_AUTO_APPLY", "250")
+	cfg := ConfigFromEnv()
+
+	if got := cfg.Allowance(TierPro, FeatureAutoApply).Limit; got != 9 {
+		t.Errorf("pro daily allowance for auto-apply = %d, want 9", got)
+	}
+	if got := cfg.Allowance(TierUltra, FeatureAutoApply).Limit; got != 250 {
+		t.Errorf("ultra daily allowance for auto-apply = %d, want 250", got)
+	}
+	if got := cfg.FreeDaily(FeatureCoverLetter); got != 5 {
+		t.Errorf("free daily allowance for cover-letter = %d, want 5", got)
+	}
+}
+
+func TestEveryFeatureHasASettableOverrideName(t *testing.T) {
+	// The guard for the next feature named with a dash: an override an operator cannot set
+	// is indistinguishable from one that was ignored.
+	settable := regexp.MustCompile(`^[A-Z0-9_]+$`)
+	for _, f := range AllFeatures() {
+		if suffix := envSuffix(f); !settable.MatchString(suffix) {
+			t.Errorf("%q overrides PLAN_*_DAILY_%s, which is not a legal environment "+
+				"variable name", f, suffix)
+		}
 	}
 }
 

--- a/internal/identity/billing/AGENTS.md
+++ b/internal/identity/billing/AGENTS.md
@@ -43,6 +43,15 @@ answer 404, and its worker exits without opening a connection.
   that would put the tier definition in a dashboard nothing here can test, where one mis-click
   upgrades everybody.
 
+- **The billing section describes the subscription the PLAN came from, across every tier.**
+  `billedSubscription` asks each configured price list through the same `bestEntitling` the
+  derivation uses and then resolves between the answers the way `plan.TierOf` resolves the
+  tier — ultra while it is live, then pro. Reading only the Pro list left an Ultra subscriber
+  looking at a 404; picking the furthest reach out of a merged list is the same bug wearing a
+  union, since both tiers stand at once during an upgrade and the Pro one can reach further.
+  When neither is live the furthest still shows: `past_due` entitles by status with its period
+  already run out, and that is the state a subscriber most needs to see.
+
 - **The source column is derived whole, never adjusted.** That is what makes a repeat free, an
   out-of-order delivery harmless, and refunds, cancellations and failed cards need no code
   of their own — they are already reflected in what we re-read.

--- a/internal/identity/billing/AGENTS.md
+++ b/internal/identity/billing/AGENTS.md
@@ -50,7 +50,12 @@ answer 404, and its worker exits without opening a connection.
   looking at a 404; picking the furthest reach out of a merged list is the same bug wearing a
   union, since both tiers stand at once during an upgrade and the Pro one can reach further.
   When neither is live the furthest still shows: `past_due` entitles by status with its period
-  already run out, and that is the state a subscriber most needs to see.
+  already run out, and that is the state a subscriber most needs to see. It hands the chosen
+  list back with the subscription, because one subscription can carry an item of each tier
+  after an upgrade — then both lists answer with the same row and `priceOf` would otherwise
+  read whichever item the provider listed first, putting Pro's amount under Ultra's status.
+  `tierFirst` ORDERS the ids and never filters them: a price we no longer sell is still the
+  price somebody is being charged.
 
 - **The source column is derived whole, never adjusted.** That is what makes a repeat free, an
   out-of-order delivery harmless, and refunds, cancellations and failed cards need no code

--- a/internal/identity/billing/entitlement.go
+++ b/internal/identity/billing/entitlement.go
@@ -107,6 +107,35 @@ func entitlementFrom(sub subscriber, proPrices, ultraPrices []string) entitlemen
 	}
 }
 
+// billedSubscription is the subscription a subscriber's own billing section describes: the
+// one their PLAN came from, whichever tier that is.
+//
+// It asks each configured price list through the same `bestEntitling` the derivation above
+// uses, and then resolves between the two answers exactly as plan.TierOf resolves the tier
+// from the columns they become — ultra while it is live, then pro. Merging the two lists and
+// taking the furthest reach would be a different rule, and the difference is not academic:
+// both tiers can stand at once, which the provider's portal makes ordinary during an upgrade,
+// and the Ultra one need not reach furthest. Under a merged list, an account that upgraded
+// part-way through a Pro year would be shown its old Pro subscription as "your plan" — Pro's
+// price, Pro's renewal date — while every metered feature ran on Ultra's allowance.
+//
+// When NEITHER is live it falls back to the furthest of the two rather than to nothing, and
+// that case is real: `past_due` entitles by status while its period has already run out, so
+// the plan has lapsed but the subscription is the very thing the subscriber needs to see.
+func billedSubscription(sub subscriber, proPrices, ultraPrices []string, now time.Time) subscription {
+	pro, ultra := bestEntitling(sub, proPrices), bestEntitling(sub, ultraPrices)
+	switch {
+	case ultra.CurrentPeriodEnd.After(now):
+		return ultra
+	case pro.CurrentPeriodEnd.After(now):
+		return pro
+	case ultra.CurrentPeriodEnd.After(pro.CurrentPeriodEnd):
+		return ultra
+	default:
+		return pro
+	}
+}
+
 // bestEntitling is the subscription that decides the plan: of the ones that entitle, the one
 // reaching furthest. The zero subscription when none does.
 //

--- a/internal/identity/billing/entitlement.go
+++ b/internal/identity/billing/entitlement.go
@@ -122,18 +122,45 @@ func entitlementFrom(sub subscriber, proPrices, ultraPrices []string) entitlemen
 // When NEITHER is live it falls back to the furthest of the two rather than to nothing, and
 // that case is real: `past_due` entitles by status while its period has already run out, so
 // the plan has lapsed but the subscription is the very thing the subscriber needs to see.
-func billedSubscription(sub subscriber, proPrices, ultraPrices []string, now time.Time) subscription {
+// It returns the price list it selected under alongside the subscription, because one
+// provider subscription can carry an item from each tier — an upgrade that adds the new
+// price to the existing subscription rather than opening a second one — and then both
+// `bestEntitling` calls answer with that same subscription. Choosing "ultra" and then
+// reading whichever price the provider happened to list first would put Pro's amount under
+// Ultra's status, which is the contradiction this function exists to prevent.
+func billedSubscription(sub subscriber, proPrices, ultraPrices []string, now time.Time) (subscription, []string) {
 	pro, ultra := bestEntitling(sub, proPrices), bestEntitling(sub, ultraPrices)
 	switch {
 	case ultra.CurrentPeriodEnd.After(now):
-		return ultra
+		return ultra, ultraPrices
 	case pro.CurrentPeriodEnd.After(now):
-		return pro
+		return pro, proPrices
 	case ultra.CurrentPeriodEnd.After(pro.CurrentPeriodEnd):
-		return ultra
+		return ultra, ultraPrices
 	default:
-		return pro
+		return pro, proPrices
 	}
+}
+
+// tierFirst orders a subscription's price ids so the selected tier's come first.
+//
+// It ORDERS rather than filters, and the difference is the whole point: a subscriber on a
+// price we no longer sell is paying THAT price, so a tier list — which holds only what we
+// sell today — must decide which id to prefer and never which ids exist. Filtering would
+// turn a retired price into "we cannot read your bill".
+func tierFirst(ids, tier []string) []string {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if slices.Contains(tier, id) {
+			out = append(out, id)
+		}
+	}
+	for _, id := range ids {
+		if !slices.Contains(tier, id) {
+			out = append(out, id)
+		}
+	}
+	return out
 }
 
 // bestEntitling is the subscription that decides the plan: of the ones that entitle, the one

--- a/internal/identity/billing/entitlement_test.go
+++ b/internal/identity/billing/entitlement_test.go
@@ -1,6 +1,7 @@
 package billing
 
 import (
+	"slices"
 	"testing"
 	"time"
 )
@@ -220,6 +221,19 @@ func TestBilledSubscription(t *testing.T) {
 			want: proPrice,
 		},
 		{
+			// One subscription carrying an item of each tier, which is what an upgrade that
+			// adds a price to the existing subscription leaves behind. Both price lists then
+			// answer with this same row, so choosing the tier is not enough — the amount has
+			// to be read from the tier that was chosen, not from whichever item the provider
+			// listed first. Pro's id is first here deliberately.
+			name: "one subscription holding an item of each tier",
+			sub: sub(subscription{
+				Status: "active", CurrentPeriodEnd: at(t, "2026-10-01T00:00:00Z"),
+				PriceIDs: []string{proPrice, ultraPrice},
+			}),
+			want: ultraPrice,
+		},
+		{
 			name: "no subscription at all",
 			sub:  sub(),
 			want: "",
@@ -228,17 +242,38 @@ func TestBilledSubscription(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := billedSubscription(tc.sub, []string{proPrice}, []string{ultraPrice}, now)
+			got, tier := billedSubscription(tc.sub, []string{proPrice}, []string{ultraPrice}, now)
 			if tc.want == "" {
 				if got.Status != "" {
 					t.Fatalf("want the zero subscription, got %+v", got)
 				}
 				return
 			}
-			if len(got.PriceIDs) != 1 || got.PriceIDs[0] != tc.want {
-				t.Fatalf("want the subscription for %s, got %+v", tc.want, got)
+			// What the section actually charges is the FIRST id priceOf will resolve, so
+			// assert through the same ordering it uses rather than on the raw slice.
+			ordered := tierFirst(got.PriceIDs, tier)
+			if len(ordered) == 0 || ordered[0] != tc.want {
+				t.Fatalf("want the section to bill %s, got %v (subscription %+v)", tc.want, ordered, got)
 			}
 		})
+	}
+}
+
+// TestTierFirstOrdersAndNeverDrops pins the property that makes it safe for priceOf to take a
+// tier list at all: it decides the ORDER, never the membership. A price we have stopped
+// selling is still the price somebody is being charged, and a list of what we sell today must
+// not be able to turn their bill into "we could not read it".
+func TestTierFirstOrdersAndNeverDrops(t *testing.T) {
+	retired := "price_retired_annual"
+	got := tierFirst([]string{proPrice, retired, ultraPrice}, []string{ultraPrice})
+	want := []string{ultraPrice, proPrice, retired}
+	if !slices.Equal(got, want) {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+
+	// A tier list that matches nothing must leave the order alone rather than empty it.
+	if got := tierFirst([]string{retired}, []string{ultraPrice}); !slices.Equal(got, []string{retired}) {
+		t.Fatalf("a price outside every configured list must still be tried, got %v", got)
 	}
 }
 

--- a/internal/identity/billing/entitlement_test.go
+++ b/internal/identity/billing/entitlement_test.go
@@ -5,7 +5,13 @@ import (
 	"time"
 )
 
-const proPrice = "price_pro_monthly"
+// The two tiers' prices, as the tests configure them. They live here rather than beside the
+// tests that sell Ultra because both the untagged tests and the integration ones name them,
+// and a const declared in an integration-tagged file exists only under that tag.
+const (
+	proPrice   = "price_pro_monthly"
+	ultraPrice = "price_ultra_monthly"
+)
 
 func at(t *testing.T, s string) time.Time {
 	t.Helper()
@@ -144,6 +150,93 @@ func TestProUntilFrom(t *testing.T) {
 			want := at(t, tc.want)
 			if !got.Equal(want) {
 				t.Fatalf("want %s, got %s", want.Format(time.RFC3339), got.Format(time.RFC3339))
+			}
+		})
+	}
+}
+
+// TestBilledSubscription pins which subscription a subscriber's billing section describes
+// when more than one could answer. It has to be the one their PLAN came from: a page naming
+// a price and a renewal date from a subscription other than the one their allowances run on
+// is a contradiction we published about somebody's money.
+func TestBilledSubscription(t *testing.T) {
+	now := at(t, "2026-09-05T00:00:00Z")
+	live := func(price, end string) subscription {
+		return subscription{Status: "active", CurrentPeriodEnd: at(t, end), PriceIDs: []string{price}}
+	}
+
+	cases := []struct {
+		name string
+		sub  subscriber
+		want string // the price the chosen subscription is for, or "" for no subscription
+	}{
+		{
+			name: "an Ultra subscription is found at all",
+			sub:  sub(live(ultraPrice, "2026-10-01T00:00:00Z")),
+			want: ultraPrice,
+		},
+		{
+			// The upgrade case, and the reason reach alone is the wrong rule: an annual Pro
+			// bought in March still runs when Ultra is added in September, and it reaches
+			// further. plan.TierOf resolves that account to ultra, so this section must too.
+			name: "an Ultra subscription beside a Pro one that reaches further",
+			sub: sub(
+				live(proPrice, "2027-03-01T00:00:00Z"),
+				live(ultraPrice, "2026-10-01T00:00:00Z"),
+			),
+			want: ultraPrice,
+		},
+		{
+			// Ultra has run out and Pro has not: the plan is pro, and so is the section.
+			name: "a lapsed Ultra beside a live Pro",
+			sub: sub(
+				live(proPrice, "2027-03-01T00:00:00Z"),
+				subscription{
+					Status: "past_due", CurrentPeriodEnd: at(t, "2026-08-01T00:00:00Z"),
+					PriceIDs: []string{ultraPrice},
+				},
+			),
+			want: proPrice,
+		},
+		{
+			// Neither is live, which is what a card mid-retry looks like — and it is exactly
+			// when a subscriber opens this page. The furthest of the two still shows.
+			name: "nothing live still describes the furthest subscription",
+			sub: sub(
+				subscription{
+					Status: "past_due", CurrentPeriodEnd: at(t, "2026-07-01T00:00:00Z"),
+					PriceIDs: []string{proPrice},
+				},
+				subscription{
+					Status: "past_due", CurrentPeriodEnd: at(t, "2026-08-01T00:00:00Z"),
+					PriceIDs: []string{ultraPrice},
+				},
+			),
+			want: ultraPrice,
+		},
+		{
+			name: "a Pro subscriber on a deployment that also sells Ultra",
+			sub:  sub(live(proPrice, "2026-10-01T00:00:00Z")),
+			want: proPrice,
+		},
+		{
+			name: "no subscription at all",
+			sub:  sub(),
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := billedSubscription(tc.sub, []string{proPrice}, []string{ultraPrice}, now)
+			if tc.want == "" {
+				if got.Status != "" {
+					t.Fatalf("want the zero subscription, got %+v", got)
+				}
+				return
+			}
+			if len(got.PriceIDs) != 1 || got.PriceIDs[0] != tc.want {
+				t.Fatalf("want the subscription for %s, got %+v", tc.want, got)
 			}
 		})
 	}

--- a/internal/identity/billing/overview.go
+++ b/internal/identity/billing/overview.go
@@ -86,8 +86,10 @@ func (s *Service) overviewFor(ctx context.Context, customer string) (Overview, e
 	out := Overview{Invoices: []Invoice{}}
 
 	// The same selection the plan derivation makes, called rather than repeated: this
-	// section must describe the subscription the plan came from, not another one.
-	best := bestEntitling(sub, s.cfg.Prices)
+	// section must describe the subscription the plan came from, not another one — which
+	// means asking BOTH configured price lists, since an account on Ultra has no Pro price
+	// to be found under.
+	best := billedSubscription(sub, s.cfg.Prices, s.cfg.UltraPrices, time.Now().UTC())
 
 	// No eligible subscription: a free account, or a former subscriber whose last one has
 	// ended. Both must read as "no section", not as a section full of zeroes — the surface

--- a/internal/identity/billing/overview.go
+++ b/internal/identity/billing/overview.go
@@ -89,7 +89,7 @@ func (s *Service) overviewFor(ctx context.Context, customer string) (Overview, e
 	// section must describe the subscription the plan came from, not another one — which
 	// means asking BOTH configured price lists, since an account on Ultra has no Pro price
 	// to be found under.
-	best := billedSubscription(sub, s.cfg.Prices, s.cfg.UltraPrices, time.Now().UTC())
+	best, tierPrices := billedSubscription(sub, s.cfg.Prices, s.cfg.UltraPrices, time.Now().UTC())
 
 	// No eligible subscription: a free account, or a former subscriber whose last one has
 	// ended. Both must read as "no section", not as a section full of zeroes — the surface
@@ -99,7 +99,7 @@ func (s *Service) overviewFor(ctx context.Context, customer string) (Overview, e
 		return Overview{}, ErrNoSubscription
 	}
 
-	amount, currency, interval, err := s.priceOf(ctx, best)
+	amount, currency, interval, err := s.priceOf(ctx, best, tierPrices)
 	if err != nil {
 		// We know they are subscribed but not what for. Saying nothing is the only honest
 		// answer; saying "$0" is a statement about their money that we cannot stand behind.
@@ -125,9 +125,12 @@ func (s *Service) overviewFor(ctx context.Context, customer string) (Overview, e
 // It ERRORS rather than returning zeroes when no price resolves. A zero amount is not a
 // missing value on this screen — it renders as "free", which is the one thing a paying
 // subscriber must never be told.
-func (s *Service) priceOf(ctx context.Context, sub subscription) (int64, string, string, error) {
+// The tier list decides only the ORDER it tries them in: one subscription can carry an item
+// from each tier during an upgrade, and the amount on screen has to belong to the tier the
+// status above it names.
+func (s *Service) priceOf(ctx context.Context, sub subscription, tierPrices []string) (int64, string, string, error) {
 	var lastErr error
-	for _, id := range sub.PriceIDs {
+	for _, id := range tierFirst(sub.PriceIDs, tierPrices) {
 		p, err := s.client.price(ctx, id)
 		if err == nil {
 			return p.AmountCents, p.Currency, p.Interval, nil

--- a/internal/identity/billing/overview_test.go
+++ b/internal/identity/billing/overview_test.go
@@ -3,8 +3,10 @@ package billing
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -90,5 +92,87 @@ func TestSubscriptionOverviewReadsTheSubscribedPrice(t *testing.T) {
 	// purpose: "renews on the 4th" beside "you cancelled" is a contradiction.
 	if out.RenewsAt == nil || out.EndsAt != nil {
 		t.Fatalf("want a renewal date and no end date, got renews=%v ends=%v", out.RenewsAt, out.EndsAt)
+	}
+}
+
+// subscribedTo answers the provider with one active subscription per price, and the price
+// behind each. The unix timestamps are the period ends, so a test says in one line which
+// subscriptions stand and how far each reaches.
+func subscribedTo(prices map[string]int64) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/subscriptions" {
+			items := make([]string, 0, len(prices))
+			for id, end := range prices {
+				items = append(items, fmt.Sprintf(
+					`{"status":"active","items":{"data":[{"current_period_end":%d,"price":{"id":%q}}]}}`, end, id))
+			}
+			_, _ = fmt.Fprintf(w, `{"object":"list","data":[%s]}`, strings.Join(items, ","))
+			return
+		}
+		if id, ok := strings.CutPrefix(r.URL.Path, "/prices/"); ok {
+			// The amount identifies the price on the way back, so an assertion on it says
+			// which subscription the section chose.
+			_, _ = fmt.Fprintf(w, `{"id":%q,"unit_amount":%d,"currency":"usd","recurring":{"interval":"month"}}`,
+				id, priceAmounts[id])
+			return
+		}
+		_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+	}
+}
+
+// priceAmounts is what each configured price charges, in cents — the two tiers' real
+// figures, so a wrong choice reads as the wrong plan rather than as a wrong number.
+var priceAmounts = map[string]int64{proPrice: 500, ultraPrice: 1900}
+
+// Period ends far enough apart to tell the rules apart: both are live, and the Pro one
+// reaches further.
+const (
+	endsIn2030 = 1893456000
+	endsIn2100 = 4102444800
+)
+
+// TestSubscriptionOverviewDescribesAnUltraSubscription covers the tier this section could not
+// see. Ultra's price ids live in a list of their own, so reading only the Pro one left an
+// Ultra subscriber's own billing page answering "no subscription": a 404 with no log, and no
+// status, no amount, no renewal date and no receipts for the more expensive plan.
+func TestSubscriptionOverviewDescribesAnUltraSubscription(t *testing.T) {
+	// serviceWithProvider leaves this list alone, so a test that sells Ultra sets it — the
+	// state of any deployment where the tier is actually on sale.
+	t.Setenv("STRIPE_ULTRA_PRICE_IDS", ultraPrice)
+	s := serviceWithProvider(t, subscribedTo(map[string]int64{ultraPrice: endsIn2030}))
+
+	out, err := s.overviewFor(context.Background(), "cus_9")
+	if err != nil {
+		t.Fatalf("an Ultra subscriber has no billing section: %v", err)
+	}
+	if out.Status != "active" || out.AmountCents != priceAmounts[ultraPrice] {
+		t.Fatalf("overview read wrong: %+v", out)
+	}
+	if out.RenewsAt == nil || out.RenewsAt.Unix() != endsIn2030 {
+		t.Fatalf("want the Ultra subscription's renewal date, got %v", out.RenewsAt)
+	}
+}
+
+// TestSubscriptionOverviewDescribesTheTierThePlanCameFrom is the upgrade case. Both
+// subscriptions stand — the provider's portal makes that ordinary — and the older Pro one
+// reaches further, so a rule picking by reach shows Pro's price and Pro's date to somebody
+// whose allowances are all running on Ultra.
+func TestSubscriptionOverviewDescribesTheTierThePlanCameFrom(t *testing.T) {
+	t.Setenv("STRIPE_ULTRA_PRICE_IDS", ultraPrice)
+	s := serviceWithProvider(t, subscribedTo(map[string]int64{
+		proPrice:   endsIn2100,
+		ultraPrice: endsIn2030,
+	}))
+
+	out, err := s.overviewFor(context.Background(), "cus_9")
+	if err != nil {
+		t.Fatalf("want a billing section, got %v", err)
+	}
+	if out.AmountCents != priceAmounts[ultraPrice] {
+		t.Fatalf("the section describes the %d-cent subscription; the plan is Ultra, which "+
+			"charges %d", out.AmountCents, priceAmounts[ultraPrice])
+	}
+	if out.RenewsAt == nil || out.RenewsAt.Unix() != endsIn2030 {
+		t.Fatalf("want the Ultra subscription's renewal date, got %v", out.RenewsAt)
 	}
 }

--- a/internal/identity/billing/ultra_integration_test.go
+++ b/internal/identity/billing/ultra_integration_test.go
@@ -24,8 +24,6 @@ import (
 	"github.com/strelov1/freehire/internal/platform/testdb"
 )
 
-const ultraPrice = "price_ultra_monthly"
-
 // subscriptionsFor answers the provider's subscription listing with one active subscription
 // for the given price.
 func subscriptionsFor(price string, until time.Time) http.HandlerFunc {

--- a/internal/search/search/document_writers_test.go
+++ b/internal/search/search/document_writers_test.go
@@ -43,8 +43,20 @@ func TestEveryJobDocumentWriterWidensGeography(t *testing.T) {
 			return err
 		}
 		if d.IsDir() {
+			name := d.Name()
+			// A dot- or underscore-prefixed directory is not part of this module: the go
+			// toolchain never descends into one, so `./...` cannot compile what lives there.
+			// This is a filesystem walk, not a package walk, and without the same rule it reads
+			// every git worktree checked out INSIDE the repo (.worktrees, .claude/worktrees) as
+			// another copy of every writer — so the suite goes red for anyone working in one,
+			// on a branch whose writers are none of this branch's business. It also subsumes
+			// the .git check that stood here, which never fired in a linked worktree anyway:
+			// there .git is a FILE, and this is the directory arm.
+			if path != root && (strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_")) {
+				return fs.SkipDir
+			}
 			// Vendored and generated trees hold no writers and would only slow the walk.
-			if name := d.Name(); name == "node_modules" || name == ".git" || name == "web" {
+			if name == "node_modules" || name == "web" {
 				return fs.SkipDir
 			}
 			return nil


### PR DESCRIPTION
Three defects found by a full backend review, each independently visible to somebody outside the codebase. Two of them are on the money path.

### The daily-allowance levers could not be typed

`ConfigFromEnv` upper-cased the feature verbatim, so the two features whose value carries a dash asked for `PLAN_PRO_DAILY_AUTO-APPLY` and `PLAN_FREE_DAILY_COVER-LETTER`. `EnvironmentFile=` will not accept a name with a dash, so the only spelling the code read is unsettable on the host it exists for, while the spelling documented in three places was read by nothing.

That matters most for the feature it could not reach: `auto-apply` is the one feature shipping enforcing, and pro's ceiling on it is what Ultra is sold on. `Feature` values are untouched — they are in `usage_ledger` and in the idempotency index.

### An Ultra subscriber's billing section answered 404

`overviewFor` selected over `cfg.Prices` alone, which holds the Pro price ids; Ultra's live in `cfg.UltraPrices`. Nothing entitled, `ErrNoSubscription` came back, the handler turned it into a 404 with no log, and `/my/plan` rendered no status, no amount, no renewal date and no receipts — for the more expensive plan.

Merging the two lists would have been the same bug in another shape: both tiers can stand at once during an upgrade, and an annual Pro bought in March still reaches further than an Ultra added in September, so that account would have been shown Pro's price and Pro's date while every allowance ran on Ultra. `billedSubscription` asks each list through the same `bestEntitling` the plan derivation uses, then resolves between the answers the way `plan.TierOf` resolves the tier.

### The suite was red for anyone working in a worktree

`document_writers_test.go` skipped `node_modules`, `.git` and `web`, so it descended into `.worktrees/` and `.claude/worktrees/` and reported another branch's writers as this branch's violations. The `.git` check never fired anyway — in a linked worktree `.git` is a file, and the check sat in the directory arm. It now skips dot- and underscore-prefixed directories, the idiom `pgerr_test.go` and `legal_form_rule_test.go` already carry and argue.

### Checks

`gofmt -l .` clean, `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, and `go test` over the three touched packages all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Environment-based plan overrides now support dashed feature names using underscores, such as `PLAN_PRO_DAILY_AUTO_APPLY`.
  - Billing overviews now accurately identify the subscription associated with the displayed plan, including Ultra subscriptions and accounts with multiple subscriptions.

- **Documentation**
  - Added guidance for configuring dashed feature names through environment variables.
  - Added billing guidance covering subscription selection across plan tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->