### PR TITLE
Give a digest notification a title that says which search fired

### DIFF
--- a/internal/api/handler/me_notifications_integration_test.go
+++ b/internal/api/handler/me_notifications_integration_test.go
@@ -205,7 +205,7 @@ func TestNotificationsEndToEnd_GetOne(t *testing.T) {
 	const jobsJSON = `[{"title":"Backend Engineer","company":"Acme","slug":"acme-backend-engineer"},{"title":"SRE","company":"Acme","slug":"acme-sre"}]`
 	if err := pool.QueryRow(context.Background(),
 		`INSERT INTO user_notifications (user_id, kind, title, body, jobs)
-		 VALUES ($1, 'subscription_digest', 'freehire', '2 new jobs for "Backend"', $2::jsonb)
+		 VALUES ($1, 'subscription_digest', 'Backend', '2 new jobs', $2::jsonb)
 		 RETURNING id`, aliceID, jobsJSON).Scan(&digestID); err != nil {
 		t.Fatalf("seed digest notification: %v", err)
 	}

--- a/internal/engage/notify/push.go
+++ b/internal/engage/notify/push.go
@@ -67,9 +67,17 @@ func (n *PushNotifier) Send(ctx context.Context, _ string, dest string, d Digest
 // exactly one job — that job's slug (empty otherwise). This is the single
 // source of the digest's push copy; the notification-center recording in
 // deliverOne reuses it verbatim rather than re-deriving the same wording.
+//
+// The title names the saved search that fired: it is what distinguishes one
+// digest from another, and the product name this slot used to carry said
+// nothing in either reader — a phone prints the app's name above a push banner
+// already, and the notification center is inside the app.
 func renderDigest(d Digest) (title, body, slug string) {
-	title = "freehire"
-	body = fmt.Sprintf("%d new jobs for %q", d.Total, d.SavedSearchName)
+	title = d.SavedSearchName
+	if title == "" {
+		title = "New jobs"
+	}
+	body = fmt.Sprintf("%d new job%s", d.Total, Plural(d.Total))
 	if d.Total == 1 {
 		slug = d.Jobs[0].Slug
 	}

--- a/internal/engage/notify/push_test.go
+++ b/internal/engage/notify/push_test.go
@@ -98,12 +98,56 @@ func TestPushNotifier_TitleAndBodyContent(t *testing.T) {
 		t.Fatalf("Send: %v", err)
 	}
 	call := transport.calls[0]
-	if call.title != "freehire" {
-		t.Errorf("title = %q, want %q", call.title, "freehire")
+	if want := "Backend Engineer"; call.title != want {
+		t.Errorf("title = %q, want %q", call.title, want)
 	}
-	wantBody := `3 new jobs for "Backend Engineer"`
-	if call.body != wantBody {
-		t.Errorf("body = %q, want %q", call.body, wantBody)
+	if want := "3 new jobs"; call.body != want {
+		t.Errorf("body = %q, want %q", call.body, want)
+	}
+}
+
+// renderDigest is the copy both the push channel and the notification-center
+// row read, so its wording is asserted on the renderer itself rather than once
+// per reader.
+func TestRenderDigest_Copy(t *testing.T) {
+	tests := []struct {
+		name                string
+		digest              Digest
+		wantTitle, wantBody string
+	}{
+		{
+			name:      "titles with the saved search that fired",
+			digest:    Digest{SavedSearchName: "Backend Engineer", Total: 3},
+			wantTitle: "Backend Engineer",
+			wantBody:  "3 new jobs",
+		},
+		{
+			// The same Plural the email and Telegram channels have always
+			// applied to this identical sentence.
+			name:      "one job is singular",
+			digest:    Digest{SavedSearchName: "Backend Engineer", Total: 1, Jobs: []DigestJob{{Slug: "a"}}},
+			wantTitle: "Backend Engineer",
+			wantBody:  "1 new job",
+		},
+		{
+			// The title is the only line the notification center prints in
+			// bold, so an unnamed saved search still needs a heading.
+			name:      "an unnamed saved search keeps a generic title",
+			digest:    Digest{Total: 2},
+			wantTitle: "New jobs",
+			wantBody:  "2 new jobs",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			title, body, _ := renderDigest(tt.digest)
+			if title != tt.wantTitle {
+				t.Errorf("title = %q, want %q", title, tt.wantTitle)
+			}
+			if body != tt.wantBody {
+				t.Errorf("body = %q, want %q", body, tt.wantBody)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Every row in the notification center read **freehire**, so five stacked digests differed only in their body.

The title came from `renderDigest`, written for a push banner and then reused verbatim for the in-app record. The product name says nothing in either place: a phone prints the app's name above a push already, and the notification center is inside the app.

The title now names the **saved search that fired** — the one thing that distinguishes one digest from the next — and the body drops the name it no longer needs to repeat. An unnamed saved search keeps a generic heading rather than an empty one.

| | before | after |
|---|---|---|
| title | `freehire` | `My profile` |
| body | `1 new jobs for "My profile"` | `1 new job` |

The same line also said **"1 new jobs"**: this was the one place assembling that sentence without `notify.Plural`, which the email and Telegram channels have always applied to it.

Wording is asserted on `renderDigest` itself, since both readers share it; the existing notifier test still covers that the push channel passes the rendered strings through untouched.

Rows already written keep their old title — a separate one-off `UPDATE` if we want the history to match.
