### PR TITLE
Say what a notification is about wherever one is titled

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -3615,7 +3615,7 @@ curl "https://freehire.me/api/v1/me/notifications?limit=20" -b cookies.txt
 
 ```json
 {
-  "data": [ { "id": 5, "kind": "subscription_digest", "title": "3 new jobs match Senior Go remote", "body": "...", "public_slug": null, "jobs": [ "...": "..." ], "created_at": "2026-06-19T10:00:00Z", "read_at": null } ],
+  "data": [ { "id": 5, "kind": "subscription_digest", "title": "Senior Go remote", "body": "3 new jobs", "public_slug": null, "jobs": [ "...": "..." ], "created_at": "2026-06-19T10:00:00Z", "read_at": null } ],
   "meta": { "total": 12, "unread_count": 3, "limit": 20, "offset": 0 }
 }
 ```

--- a/internal/engage/emailnotify/notifier.go
+++ b/internal/engage/emailnotify/notifier.go
@@ -82,7 +82,7 @@ func (n *Notifier) render(d notify.Digest) renderedEmail {
 	}
 	viewAll := n.viewAllURL(d)
 
-	subject := fmt.Sprintf(`%d new job%s for "%s"`, d.Total, notify.Plural(d.Total), d.SavedSearchName)
+	subject := fmt.Sprintf(`%s for "%s"`, notify.JobCount(d.Total), d.SavedSearchName)
 
 	var b bytes.Buffer
 	// The template is a trusted constant and the data is escaped in context, so
@@ -90,10 +90,9 @@ func (n *Notifier) render(d notify.Digest) renderedEmail {
 	_ = htmlTemplate.Execute(&b, htmlData{Jobs: rows, More: more, ViewAllURL: viewAll})
 
 	html := n.layout.Render(mailtpl.Body{
-		Preheader: fmt.Sprintf("%d new job%s matching your %q alert", d.Total, notify.Plural(d.Total), d.SavedSearchName),
-		Heading: fmt.Sprintf("%d new job%s for “%s”",
-			d.Total, notify.Plural(d.Total), d.SavedSearchName),
-		Content: template.HTML(b.String()), //nolint:gosec // rendered by the trusted template below, which escaped every field in context
+		Preheader: fmt.Sprintf("%s matching your %q alert", notify.JobCount(d.Total), d.SavedSearchName),
+		Heading:   fmt.Sprintf("%s for “%s”", notify.JobCount(d.Total), d.SavedSearchName),
+		Content:   template.HTML(b.String()), //nolint:gosec // rendered by the trusted template below, which escaped every field in context
 		// The shell already carries the notification-settings link, so the footer
 		// only has to answer "why am I getting this".
 		Footer: "You’re getting this because you set up a job alert on freehire.",
@@ -106,7 +105,7 @@ func (n *Notifier) render(d notify.Digest) renderedEmail {
 // non-HTML clients (and spam scorers) see the same content.
 func (n *Notifier) renderText(d notify.Digest, rows []mailtpl.Job, more int, viewAllURL string) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "%d new job%s for %q\n\n", d.Total, notify.Plural(d.Total), d.SavedSearchName)
+	fmt.Fprintf(&b, "%s for %q\n\n", notify.JobCount(d.Total), d.SavedSearchName)
 	for _, l := range rows {
 		b.WriteString("- " + l.Title)
 		if l.Company != "" {

--- a/internal/engage/notify/format.go
+++ b/internal/engage/notify/format.go
@@ -1,6 +1,7 @@
 package notify
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -62,4 +63,16 @@ func Plural(n int) string {
 		return ""
 	}
 	return "s"
+}
+
+// JobCount renders the "3 new jobs" opening every digest channel builds on,
+// differing only in what it wraps around them: an email subject adds the search
+// name, the push body stands alone. Assembling it by hand is how the push body
+// came to read "1 new jobs" while the channels beside it were correct, so the
+// count and its plural travel together from here.
+//
+// Telegram is the one channel that cannot call this: it bolds the numeral alone
+// ("<b>3</b> new jobs"), so its markup falls inside the phrase.
+func JobCount(n int) string {
+	return fmt.Sprintf("%d new job%s", n, Plural(n))
 }

--- a/internal/engage/notify/push.go
+++ b/internal/engage/notify/push.go
@@ -71,13 +71,12 @@ func (n *PushNotifier) Send(ctx context.Context, _ string, dest string, d Digest
 // The title names the saved search that fired: it is what distinguishes one
 // digest from another, and the product name this slot used to carry said
 // nothing in either reader — a phone prints the app's name above a push banner
-// already, and the notification center is inside the app.
+// already, and the notification center is inside the app. The name is always
+// there to use: saved_searches.name is NOT NULL under a CHECK that it holds at
+// least one non-blank character.
 func renderDigest(d Digest) (title, body, slug string) {
 	title = d.SavedSearchName
-	if title == "" {
-		title = "New jobs"
-	}
-	body = fmt.Sprintf("%d new job%s", d.Total, Plural(d.Total))
+	body = JobCount(d.Total)
 	if d.Total == 1 {
 		slug = d.Jobs[0].Slug
 	}

--- a/internal/engage/notify/push_test.go
+++ b/internal/engage/notify/push_test.go
@@ -86,7 +86,9 @@ func TestPushNotifier_MultiJobDigestCarriesNoDeepLink(t *testing.T) {
 	}
 }
 
-func TestPushNotifier_TitleAndBodyContent(t *testing.T) {
+// The notifier's own job is to hand what renderDigest produced to the
+// transport untouched; the wording itself is asserted on the renderer below.
+func TestPushNotifier_SendsTheRenderedCopy(t *testing.T) {
 	tokens := &fakePushTokenLister{tokens: map[int64][]db.UserPushToken{
 		42: {{Token: "ExponentPushToken[abc]"}},
 	}}
@@ -94,15 +96,13 @@ func TestPushNotifier_TitleAndBodyContent(t *testing.T) {
 	n := NewPushNotifier(tokens, transport)
 
 	d := Digest{SavedSearchName: "Backend Engineer", Total: 3}
+	wantTitle, wantBody, _ := renderDigest(d)
 	if err := n.Send(context.Background(), ChannelPush, "42", d); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 	call := transport.calls[0]
-	if want := "Backend Engineer"; call.title != want {
-		t.Errorf("title = %q, want %q", call.title, want)
-	}
-	if want := "3 new jobs"; call.body != want {
-		t.Errorf("body = %q, want %q", call.body, want)
+	if call.title != wantTitle || call.body != wantBody {
+		t.Errorf("sent (%q, %q), want the rendered (%q, %q)", call.title, call.body, wantTitle, wantBody)
 	}
 }
 
@@ -128,14 +128,6 @@ func TestRenderDigest_Copy(t *testing.T) {
 			digest:    Digest{SavedSearchName: "Backend Engineer", Total: 1, Jobs: []DigestJob{{Slug: "a"}}},
 			wantTitle: "Backend Engineer",
 			wantBody:  "1 new job",
-		},
-		{
-			// The title is the only line the notification center prints in
-			// bold, so an unnamed saved search still needs a heading.
-			name:      "an unnamed saved search keeps a generic title",
-			digest:    Digest{Total: 2},
-			wantTitle: "New jobs",
-			wantBody:  "2 new jobs",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/engage/nudge/push.go
+++ b/internal/engage/nudge/push.go
@@ -66,6 +66,11 @@ func (n *PushNotifier) Send(ctx context.Context, _ string, dest, kind string, ms
 // used by both the push channel (Send, above) and the notification-center record
 // written by Runner.deliverBatch in nudge.go — one rendering, two readers, so the
 // in-app record never drifts from what push already shows.
+//
+// The default arm is not reachable today — application_nudges.kind is CHECKed
+// against exactly the three above — but it is the copy a fourth kind would ship
+// with until someone gave it its own, so it says what the notification is about
+// rather than naming the product.
 func renderNudgeBatch(kind string, ms []Message) (title, body string) {
 	if len(ms) == 1 {
 		return renderNudge(ms[0])
@@ -78,7 +83,7 @@ func renderNudgeBatch(kind string, ms []Message) (title, body string) {
 	case KindJobClosed:
 		return "📪 Jobs closed", fmt.Sprintf("%d jobs you were tracking were closed.", len(ms))
 	default:
-		return "freehire", fmt.Sprintf("%d updates on jobs you are tracking.", len(ms))
+		return "🔔 Jobs you're tracking", fmt.Sprintf("%d updates on jobs you are tracking.", len(ms))
 	}
 }
 
@@ -93,6 +98,6 @@ func renderNudge(m Message) (title, body string) {
 	case KindJobClosed:
 		return "📪 Job closed", fmt.Sprintf("%s at %s was closed.", m.JobTitle, m.Company)
 	default:
-		return "freehire", fmt.Sprintf("%s at %s", m.JobTitle, m.Company)
+		return "🔔 A job you're tracking", fmt.Sprintf("%s at %s", m.JobTitle, m.Company)
 	}
 }

--- a/internal/engage/telegramnotify/notifier.go
+++ b/internal/engage/telegramnotify/notifier.go
@@ -68,6 +68,8 @@ func (n *Notifier) Send(ctx context.Context, _ string, dest string, d notify.Dig
 // notifications.
 func (n *Notifier) render(d notify.Digest) string {
 	var b strings.Builder
+	// Not notify.JobCount: the bold wraps the numeral alone, so the markup sits
+	// inside the phrase that helper returns whole.
 	fmt.Fprintf(&b, "🔔 <b>%d</b> new job%s for %q\n\n", d.Total, notify.Plural(d.Total), html.EscapeString(d.SavedSearchName))
 
 	// Reserve room for the widest possible tail up front (d.Total is its worst-case

--- a/web/src/lib/docs/api-spec.ts
+++ b/web/src/lib/docs/api-spec.ts
@@ -2629,7 +2629,7 @@ data: {"type":"result","stop_reason":"completed"}
         ],
         curl: `curl "${BASE_URL}/me/notifications?limit=20" -b cookies.txt`,
         responseExample: `{
-  "data": [ { "id": 5, "kind": "subscription_digest", "title": "3 new jobs match Senior Go remote", "body": "...", "public_slug": null, "jobs": [ "...": "..." ], "created_at": "2026-06-19T10:00:00Z", "read_at": null } ],
+  "data": [ { "id": 5, "kind": "subscription_digest", "title": "Senior Go remote", "body": "3 new jobs", "public_slug": null, "jobs": [ "...": "..." ], "created_at": "2026-06-19T10:00:00Z", "read_at": null } ],
   "meta": { "total": 12, "unread_count": 3, "limit": 20, "offset": 0 }
 }`,
       },


### PR DESCRIPTION
Follow-ups from the review of #2514. Three findings, all in the same slot: what a notification is titled.

### `nudge` still said "freehire"

`internal/engage/nudge/push.go` titled two arms with the product name — the exact reasoning #2514 rejected, leaving the three engines that write a notification-center row following three rules between them.

Both arms are the switch's `default`, and `application_nudges.kind` is `CHECK`ed against the three kinds above them, so nothing reaches them today. They are the copy a fourth kind would ship with until someone wrote it one — reason enough not to leave the product name there.

### #2514's empty-name fallback described an impossible state

```go
title = d.SavedSearchName
if title == "" {
    title = "New jobs"   // gone
}
```

`saved_searches.name` is `NOT NULL` under `CHECK (length(TRIM(name)) BETWEEN 1 AND 100)` (`migrations/0001_init.sql:292,298`), and `GetSubscriptionForDelivery` reads it into a plain `string`. The branch could not fire, and its test case asserted coverage of nothing. Both reviewers flagged it independently.

### The count sentence had six hand-written copies

`"%d new job%s"` was assembled at six sites; the one that skipped `notify.Plural` is how the push body came to read **"1 new jobs"**. Five of the six differ only in what they wrap around the phrase, so they now call `notify.JobCount`.

Telegram is the sixth and keeps its own — it bolds the numeral alone (`<b>3</b> new jobs`), so the markup falls *inside* the phrase. Said there in a comment, so the next reader knows it was weighed rather than missed.

### Docs

The notification-center response example showed `"title": "3 new jobs match Senior Go remote"` — a string no version of this code has produced. Regenerated from `api-spec.ts`.

---

Not in scope here: the rows already in `user_notifications` still carry the old title. That is a one-off `UPDATE`, run separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated saved-search notification digests to show the saved-search name as the title and the matching job count in the message body.
  - Standardized “new jobs” wording across email and push notifications, including correct singular and plural forms.
  - Updated fallback nudge notifications to use clearer job-tracking language.

- **Documentation**
  - Updated API notification examples to reflect the revised title and body format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->