### PR TITLE
Bound the experience figure where all three producers meet, not in one of them

### DIFF
--- a/internal/ai/enrich/enrichment.go
+++ b/internal/ai/enrich/enrichment.go
@@ -50,32 +50,13 @@ const (
 	maxCityRunes = 100
 )
 
-// maxExperienceYears is the largest years-of-experience figure a posting is believed
-// to be stating about the CANDIDATE. Past it the value is dropped, not clamped: a
-// clamp would state a requirement the posting never made, while an absent field
-// correctly says "not stated".
+// The enrichment model is the THIRD producer of experience_years_min, after a source
+// adapter's structured field and the description parse in internal/job/jobfacts. All
+// three share one ceiling, vocab.MaxExperienceYears, which is where the reasoning
+// lives — including which real prod readings it was written for.
 //
-// The failure it guards is not hallucination. "N years of experience" in a posting can
-// describe the candidate, the employer, or the product, and the three are syntactically
-// identical — only the subject separates them, and the prompt asks for the number
-// without naming whose it is. Measured on prod 2026-09-05: 29 open postings of 207,316
-// carried a figure above 20, among them a KLA listing at 40 ("With over 40 years of
-// semiconductor process control experience, chipmakers around the world rely on KLA" —
-// the COMPANY's age) and a cluster of seven at 84 whose descriptions contain no such
-// number at all.
-//
-// 30 is deliberately generous, and the number was moved UP once already: a first
-// attempt at 20 was written and its own test caught it discarding real data. Verified
-// on prod, every one of these is a figure a posting genuinely states about the
-// candidate — "18+ years of progressively responsible experience", "Minimum of 25 years
-// progressively senior experience", "25+ years of investment management experience".
-//
-// The ceiling therefore sits ABOVE the believable range rather than at the middle of
-// it, because the two errors are not symmetric. This field is a search FILTER: keeping
-// a wrong high value makes one posting unmatchable, while dropping a true one hides a
-// posting from the very people it was written for. Only the readings no career can
-// support — 40, 60, 84 — need to fall.
-const maxExperienceYears = 30
+// Bounding it here as well is not belt-and-braces: jobderive's bound sits on the WRITE
+// path and never sees this payload, which reaches the column by its own route.
 
 // maxRequirements and maxRequirementTextRunes bound the Requirements list the same
 // free-text way: extracted from the same attacker-influenced description, served
@@ -261,9 +242,9 @@ func (e *Enrichment) Sanitize() {
 }
 
 // believableYears drops a years-of-experience figure that is negative or past
-// maxExperienceYears, leaving the field unstated rather than clamped.
+// vocab.MaxExperienceYears, leaving the field unstated rather than clamped.
 func believableYears(n *int) *int {
-	if n == nil || (*n >= 0 && *n <= maxExperienceYears) {
+	if n == nil || (*n >= 0 && *n <= vocab.MaxExperienceYears) {
 		return n
 	}
 	return nil

--- a/internal/ai/enrich/enrichment.go
+++ b/internal/ai/enrich/enrichment.go
@@ -50,6 +50,33 @@ const (
 	maxCityRunes = 100
 )
 
+// maxExperienceYears is the largest years-of-experience figure a posting is believed
+// to be stating about the CANDIDATE. Past it the value is dropped, not clamped: a
+// clamp would state a requirement the posting never made, while an absent field
+// correctly says "not stated".
+//
+// The failure it guards is not hallucination. "N years of experience" in a posting can
+// describe the candidate, the employer, or the product, and the three are syntactically
+// identical — only the subject separates them, and the prompt asks for the number
+// without naming whose it is. Measured on prod 2026-09-05: 29 open postings of 207,316
+// carried a figure above 20, among them a KLA listing at 40 ("With over 40 years of
+// semiconductor process control experience, chipmakers around the world rely on KLA" —
+// the COMPANY's age) and a cluster of seven at 84 whose descriptions contain no such
+// number at all.
+//
+// 30 is deliberately generous, and the number was moved UP once already: a first
+// attempt at 20 was written and its own test caught it discarding real data. Verified
+// on prod, every one of these is a figure a posting genuinely states about the
+// candidate — "18+ years of progressively responsible experience", "Minimum of 25 years
+// progressively senior experience", "25+ years of investment management experience".
+//
+// The ceiling therefore sits ABOVE the believable range rather than at the middle of
+// it, because the two errors are not symmetric. This field is a search FILTER: keeping
+// a wrong high value makes one posting unmatchable, while dropping a true one hides a
+// posting from the very people it was written for. Only the readings no career can
+// support — 40, 60, 84 — need to fall.
+const maxExperienceYears = 30
+
 // maxRequirements and maxRequirementTextRunes bound the Requirements list the same
 // free-text way: extracted from the same attacker-influenced description, served
 // verbatim, so an unbounded model response must not persist indefinitely.
@@ -227,6 +254,19 @@ func (e *Enrichment) Sanitize() {
 	if e.SalaryMin != nil && e.SalaryMax != nil && *e.SalaryMin > *e.SalaryMax {
 		e.SalaryMin, e.SalaryMax = nil, nil
 	}
+
+	// Unlike salary, this one DOES take an absolute ceiling — a career has a length,
+	// and a currency does not. See maxExperienceYears for the readings it catches.
+	e.ExperienceYearsMin = believableYears(e.ExperienceYearsMin)
+}
+
+// believableYears drops a years-of-experience figure that is negative or past
+// maxExperienceYears, leaving the field unstated rather than clamped.
+func believableYears(n *int) *int {
+	if n == nil || (*n >= 0 && *n <= maxExperienceYears) {
+		return n
+	}
+	return nil
 }
 
 // positiveOrNil drops a non-positive salary figure to nil (an absent salary), so

--- a/internal/ai/enrich/enrichment_test.go
+++ b/internal/ai/enrich/enrichment_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/strelov1/freehire/internal/dict/vocab"
 )
 
 func ptr[T any](v T) *T { return &v }
@@ -467,7 +469,7 @@ func TestSanitizeCapsImplausibleExperienceYears(t *testing.T) {
 	years := func(n int) *int { return &n }
 
 	t.Run("a figure past the ceiling is dropped, not clamped", func(t *testing.T) {
-		for _, n := range []int{maxExperienceYears + 1, 40, 60, 84} {
+		for _, n := range []int{vocab.MaxExperienceYears + 1, 40, 60, 84} {
 			e := Enrichment{ExperienceYearsMin: years(n)}
 			e.Sanitize()
 			if e.ExperienceYearsMin != nil {
@@ -479,7 +481,7 @@ func TestSanitizeCapsImplausibleExperienceYears(t *testing.T) {
 	})
 
 	t.Run("a believable figure is untouched, including at the ceiling", func(t *testing.T) {
-		for _, n := range []int{0, 1, 5, 18, 21, 25, maxExperienceYears} {
+		for _, n := range []int{0, 1, 5, 18, 21, 25, vocab.MaxExperienceYears} {
 			e := Enrichment{ExperienceYearsMin: years(n)}
 			e.Sanitize()
 			if e.ExperienceYearsMin == nil || *e.ExperienceYearsMin != n {

--- a/internal/ai/enrich/enrichment_test.go
+++ b/internal/ai/enrich/enrichment_test.go
@@ -453,3 +453,55 @@ func TestSanitizeBoundsRequirements(t *testing.T) {
 		}
 	})
 }
+
+// A stated years-of-experience figure is only believable up to a point. The failure it
+// guards is not a model that hallucinates: it is a model that reads the RIGHT number
+// off the WRONG subject, because "N years of experience" in a posting can describe the
+// candidate, the company, or the product, and the three are syntactically identical.
+//
+// Real prod examples, 2026-09-05: "With over 40 years of semiconductor process control
+// experience, chipmakers around the world rely on KLA" became experience_years_min=40,
+// and a cluster of postings carried 84. This field is a search FILTER, so such a job
+// stops matching anyone who searches honestly.
+func TestSanitizeCapsImplausibleExperienceYears(t *testing.T) {
+	years := func(n int) *int { return &n }
+
+	t.Run("a figure past the ceiling is dropped, not clamped", func(t *testing.T) {
+		for _, n := range []int{maxExperienceYears + 1, 40, 60, 84} {
+			e := Enrichment{ExperienceYearsMin: years(n)}
+			e.Sanitize()
+			if e.ExperienceYearsMin != nil {
+				t.Errorf("ExperienceYearsMin = %d for input %d, want nil — clamping to the "+
+					"ceiling would state a requirement the posting never made",
+					*e.ExperienceYearsMin, n)
+			}
+		}
+	})
+
+	t.Run("a believable figure is untouched, including at the ceiling", func(t *testing.T) {
+		for _, n := range []int{0, 1, 5, 18, 21, 25, maxExperienceYears} {
+			e := Enrichment{ExperienceYearsMin: years(n)}
+			e.Sanitize()
+			if e.ExperienceYearsMin == nil || *e.ExperienceYearsMin != n {
+				t.Errorf("ExperienceYearsMin = %v for input %d, want it kept — 18, 21 and 25 are "+
+					"all figures real postings genuinely state", e.ExperienceYearsMin, n)
+			}
+		}
+	})
+
+	t.Run("a negative figure is dropped", func(t *testing.T) {
+		e := Enrichment{ExperienceYearsMin: years(-3)}
+		e.Sanitize()
+		if e.ExperienceYearsMin != nil {
+			t.Errorf("ExperienceYearsMin = %d, want nil", *e.ExperienceYearsMin)
+		}
+	})
+
+	t.Run("an unstated figure stays unstated", func(t *testing.T) {
+		e := Enrichment{}
+		e.Sanitize()
+		if e.ExperienceYearsMin != nil {
+			t.Errorf("ExperienceYearsMin = %d, want nil", *e.ExperienceYearsMin)
+		}
+	})
+}

--- a/internal/dict/vocab/vocab.go
+++ b/internal/dict/vocab/vocab.go
@@ -271,3 +271,29 @@ var currencyRE = regexp.MustCompile(`^[A-Z]{3}$`)
 // regexp literal, which is how this repository ended up with four disagreeing copies of
 // the legal-form vocabulary.
 func IsCurrencyCode(s string) bool { return currencyRE.MatchString(s) }
+
+// MaxExperienceYears is the largest years-of-experience figure believed to be a
+// statement about the CANDIDATE. It lives here rather than beside any one parser
+// because THREE independent producers write this facet and each could exceed it on
+// its own: a source adapter's structured field, the description parse in
+// internal/job/jobfacts, and the enrichment model in internal/ai/enrich.
+//
+// The failure it bounds is not hallucination. "N years of experience" in a posting can
+// describe the candidate, the employer, or the product, and the three are syntactically
+// identical — only the subject separates them, and no producer is told whose number to
+// take. Measured on prod 2026-09-05: a KLA listing reading "With over 40 years of
+// semiconductor process control experience, chipmakers around the world rely on KLA"
+// stored 40 (the COMPANY's age), and seven smartrecruiters postings stored 84 from a
+// structured field whose descriptions contain no such number at all.
+//
+// A figure past this is DROPPED, never clamped: a clamp would state a requirement the
+// posting never made, while an absent field correctly says "not stated".
+//
+// 30 is deliberately generous, and the number was moved up once during review after a
+// first attempt at 20 was caught discarding real data. Verified against prod, 18, 21
+// and 25 are all figures postings genuinely state about the candidate ("Minimum of 25
+// years progressively senior experience"). The ceiling sits ABOVE the believable range
+// rather than at the middle of it, because the two errors are not symmetric: this facet
+// is a search FILTER, so a wrong high value makes one posting unmatchable, while a
+// dropped true one hides a posting from the very people it was written for.
+const MaxExperienceYears = 30

--- a/internal/job/jobderive/jobderive.go
+++ b/internal/job/jobderive/jobderive.go
@@ -191,10 +191,19 @@ func Derive(in Input) Derived {
 		employmentType = jobfacts.EmploymentType(in.Title, in.Description)
 	}
 	// Experience precedence: structured source signal → description text parse.
+	//
+	// The ceiling is applied AFTER the choice, to whichever source won, because both
+	// can overshoot and for different reasons: the text parse cannot tell a candidate's
+	// years from an employer's ("With over 40 years of … experience, chipmakers rely on
+	// KLA" — the company's age), and a structured field can carry a unit nobody
+	// declared (seven smartrecruiters postings stored 84, a number their descriptions
+	// never contain). One bound after the merge catches both; a bound inside either
+	// parser would leave the other open. See vocab.MaxExperienceYears.
 	experience := in.ExperienceYearsMin
 	if experience == nil {
 		experience = jobfacts.ExperienceYearsMin(in.Description)
 	}
+	experience = believableExperience(experience)
 	// Education and English precedence: structured source signal → description text
 	// parse. Both matchers read English prose only, so on a posting written in another
 	// language they are the weaker source by a wide margin, not merely the later one.
@@ -326,4 +335,14 @@ func unionSkills(source, dict []string) []string {
 		set[s] = struct{}{}
 	}
 	return stringset.Sorted(set)
+}
+
+// believableExperience drops a years-of-experience figure outside the range a posting
+// is believed to be stating about the candidate, leaving the facet unstated rather than
+// clamped: a clamp would assert a requirement the posting never made.
+func believableExperience(n *int) *int {
+	if n == nil || (*n >= 0 && *n <= vocab.MaxExperienceYears) {
+		return n
+	}
+	return nil
 }

--- a/internal/job/jobderive/jobderive_test.go
+++ b/internal/job/jobderive/jobderive_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/strelov1/freehire/internal/dict/normalize"
+	"github.com/strelov1/freehire/internal/dict/vocab"
 )
 
 func TestDerive_SlugsAndFacets(t *testing.T) {
@@ -627,4 +628,69 @@ func TestDerive_IsPure(t *testing.T) {
 	if got := fn.Out(0); got != reflect.TypeOf(Derived{}) {
 		t.Errorf("Derive returns %v, want jobderive.Derived", got)
 	}
+}
+
+// Three producers write experience_years_min and each can overshoot on its own, so the
+// bound sits where they converge rather than in any one of them. Both cases below are
+// real prod rows from 2026-09-05.
+func TestDerive_DropsImplausibleExperienceYears(t *testing.T) {
+	years := func(n int) *int { return &n }
+
+	// The description talks about the EMPLOYER's age. "N years of experience" is
+	// syntactically identical whether the subject is the candidate, the company or the
+	// product, so the text parse cannot tell them apart — only the ceiling can.
+	t.Run("a company's age in the description is not read as a requirement", func(t *testing.T) {
+		d := Derive(Input{
+			Title:  "System Engineer",
+			Source: "manual", ExternalID: "1",
+			Description: "With over 40 years of semiconductor process control experience, " +
+				"chipmakers around the world rely on KLA to solve really hard problems.",
+		})
+		if d.ExperienceYearsMin != nil {
+			t.Errorf("ExperienceYearsMin = %d, want nil — 40 is the company's age, not a requirement",
+				*d.ExperienceYearsMin)
+		}
+	})
+
+	// A source adapter's structured field normally WINS over the text parse, so an
+	// out-of-range value there reaches the column without the description saying
+	// anything at all. Seven smartrecruiters postings stored 84 this way.
+	t.Run("a structured signal past the ceiling is dropped too", func(t *testing.T) {
+		d := Derive(Input{
+			Title:  "Java Developer",
+			Source: "smartrecruiters", ExternalID: "2",
+			ExperienceYearsMin: years(84),
+			Description:        "Build services.",
+		})
+		if d.ExperienceYearsMin != nil {
+			t.Errorf("ExperienceYearsMin = %d, want nil — no career is 84 years long",
+				*d.ExperienceYearsMin)
+		}
+	})
+
+	t.Run("a believable structured signal is kept", func(t *testing.T) {
+		for _, n := range []int{0, 5, 18, 25, vocab.MaxExperienceYears} {
+			d := Derive(Input{
+				Title:  "Programme Director",
+				Source: "manual", ExternalID: "3",
+				ExperienceYearsMin: years(n),
+				Description:        "Lead the programme.",
+			})
+			if d.ExperienceYearsMin == nil || *d.ExperienceYearsMin != n {
+				t.Errorf("ExperienceYearsMin = %v for input %d, want it kept — postings really "+
+					"do state 18 and 25", d.ExperienceYearsMin, n)
+			}
+		}
+	})
+
+	t.Run("a believable figure in the description is kept", func(t *testing.T) {
+		d := Derive(Input{
+			Title:  "Backend Engineer",
+			Source: "manual", ExternalID: "4",
+			Description: "We need 5+ years of Go experience.",
+		})
+		if d.ExperienceYearsMin == nil || *d.ExperienceYearsMin != 5 {
+			t.Errorf("ExperienceYearsMin = %v, want 5", d.ExperienceYearsMin)
+		}
+	})
 }


### PR DESCRIPTION
## The bug

A KLA listing reads:

> With over **40 years** of semiconductor process control experience, chipmakers around the world rely on KLA…

and stores `experience_years_min = 40`. The match panel then tells a candidate with 14 years that the job wants 40, and the job stops matching anyone who searches honestly — this facet is a search **filter**.

## Why the first version of this PR was wrong

It capped only `enrich.Sanitize`. Checking the KLA row showed that fixes nothing: **its enrichment blob holds no `experience_years_min` at all.** The 40 is in the column, put there by a path the model never touched.

## Three producers, three reasons to overshoot

| Producer | Real failure |
|---|---|
| A source adapter's structured field | seven smartrecruiters postings store **84**, a number their descriptions never contain, from a field whose unit nobody declared |
| `internal/job/jobfacts` description parse | its own cap is 50, so a company's age passes as a requirement |
| The enrichment model | asked for the number without being told **whose** |

"N years of experience" can describe the candidate, the employer or the product, and the three are syntactically identical. Only the subject separates them, and no producer is told which to take.

## The fix

The bound goes where the first two converge — `jobderive`, after the precedence choice — and stays in `enrich.Sanitize` too, because that payload reaches the column by its own route and `jobderive` never sees it.

One constant, `vocab.MaxExperienceYears`, in the neutral package all three can import. It carries the reasoning and the prod readings it was written for.

**Dropped, never clamped**: a clamp would state a requirement the posting never made, while an absent field correctly says *not stated*.

## The ceiling is 30, and it moved

It was 20 in the first draft, and **that draft's own test caught it discarding real data**. Verified against prod, these are figures postings genuinely state about the candidate:

- "18+ years of progressively responsible experience"
- "Minimum of 25 years progressively senior experience"

The two errors are not symmetric: a wrong high value makes one posting unmatchable, while a dropped true one hides a posting from the very people it was written for. So the ceiling sits above the believable range, not at the middle of it.

## Scope

29 open postings of 207,316 carry a figure above 20 (0.014%). The prompt is deliberately left alone — rewording it to name the subject risks the 99.99% that are right.

Existing rows keep their value until re-derived; `cmd/backfill-derive` picks them up on its next pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of implausible years-of-experience requirements.
  * Values below zero or above 30 years are now omitted instead of being shown as job requirements.
  * Believable values, including zero and the 30-year maximum, continue to be preserved.
  * Consistent validation now applies whether experience requirements come from structured data or job descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->