### PR TITLE
Put the experience ceiling where the evidence is, and measure the field a reader sees

### DIFF
--- a/internal/dict/vocab/vocab.go
+++ b/internal/dict/vocab/vocab.go
@@ -289,11 +289,26 @@ func IsCurrencyCode(s string) bool { return currencyRE.MatchString(s) }
 // A figure past this is DROPPED, never clamped: a clamp would state a requirement the
 // posting never made, while an absent field correctly says "not stated".
 //
-// 30 is deliberately generous, and the number was moved up once during review after a
-// first attempt at 20 was caught discarding real data. Verified against prod, 18, 21
-// and 25 are all figures postings genuinely state about the candidate ("Minimum of 25
-// years progressively senior experience"). The ceiling sits ABOVE the believable range
-// rather than at the middle of it, because the two errors are not symmetric: this facet
-// is a search FILTER, so a wrong high value makes one posting unmatchable, while a
-// dropped true one hides a posting from the very people it was written for.
-const MaxExperienceYears = 30
+// 25 is where the evidence puts the line, and both sides of it were checked against
+// prod rather than guessed.
+//
+// At and below it, postings really do say this about the candidate: "18+ years of
+// progressively responsible experience", "Minimum of 25 years progressively senior
+// experience" (a Programme Director), "25+ years of investment management experience"
+// (a Senior Portfolio Manager).
+//
+// At and above 30, they do not. Every sampled row at exactly 30 — and there are 19,145
+// of them — is the EMPLOYER's age: "for the past 30 years our long-term commitment to
+// team members has been unsurpassed", "With over 30 years of expertise across Private
+// Equity", "maintained an A+ rating ... for over 30 years". Two of those postings are a
+// Dining Room Server and a Driver.
+//
+// The round-number shape of the whole tail says the same thing: 30 (19,145), 40
+// (12,043), 50 (9,437), 35 (3,194), 45 (2,446). Careers are not round; anniversaries
+// are.
+//
+// An earlier draft of this constant said 30 and cited the same 25-year postings as its
+// reason for being generous. That was measured on the enrichment BLOB, which holds the
+// model's value — 29 rows. The served facet is the COLUMN, written by two other
+// producers, and it carried 28,864. Measure the field a reader actually sees.
+const MaxExperienceYears = 25

--- a/internal/job/jobderive/jobderive_test.go
+++ b/internal/job/jobderive/jobderive_test.go
@@ -668,6 +668,24 @@ func TestDerive_DropsImplausibleExperienceYears(t *testing.T) {
 		}
 	})
 
+	// The whole tail above the ceiling is round — 30 (19,145 rows), 40, 50, 35, 45 —
+	// because careers are not round and anniversaries are. Every sampled row at 30 is
+	// the employer's age, on postings like these two.
+	t.Run("an employer's anniversary is not a server's required experience", func(t *testing.T) {
+		for _, tc := range []struct{ title, description string }{
+			{"Dining Room Server", "As a family company, we can do things differently, and for " +
+				"the past 30 years, our long-term commitment to team members has been unsurpassed."},
+			{"Account Executive", "We have maintained an A+ rating from A.M. Best, the industry's " +
+				"leading authority, for over 30 years."},
+		} {
+			d := Derive(Input{Title: tc.title, Source: "manual", ExternalID: "5", Description: tc.description})
+			if d.ExperienceYearsMin != nil {
+				t.Errorf("%s: ExperienceYearsMin = %d, want nil — that is the company's age",
+					tc.title, *d.ExperienceYearsMin)
+			}
+		}
+	})
+
 	t.Run("a believable structured signal is kept", func(t *testing.T) {
 		for _, n := range []int{0, 5, 18, 25, vocab.MaxExperienceYears} {
 			d := Derive(Input{


### PR DESCRIPTION
Follow-up to #2518, which shipped an hour ago with the ceiling at 30.

## 30 is wrong

On prod it lets **19,145 rows** through, and every sampled one is the **employer's age**:

> "for the past 30 years, our long-term commitment to team members has been unsurpassed" — on a **Dining Room Server** posting
> "maintained an A+ rating from A.M. Best … for over 30 years" — an Account Executive
> "With over 30 years of expertise across Private Equity, Credit, and Real Assets"

The shape of the tail says the same thing:

| years | open postings |
|---|---|
| 30 | 19,145 |
| 40 | 12,043 |
| 50 | 9,437 |
| 35 | 3,194 |
| 45 | 2,446 |

Careers are not round numbers. Anniversaries are.

## 25 is right, and both sides were checked

At and below it the same query finds real statements about the candidate, on roles that fit them: "Minimum of 25 years progressively senior experience" (a Programme Director), "25+ years of investment management experience" (a Senior Portfolio Manager).

## The deeper mistake

**30 was chosen from the wrong column.** I measured the enrichment BLOB — the model's value — and found 29 rows over the ceiling, so I called the bug rare and set a generous bound.

The facet a reader and the search filter actually see is the `jobs.experience_years_min` **column**, written by two other producers. It carried **28,864**.

The fix was right in shape and wrong by three orders of magnitude, because the sample described a different field than the one being fixed. Both regressions are now tests, using the real posting text.

## Effect

Existing rows keep their value until re-derived; ingest re-derives on every crawl, so open postings heal within a crawl cycle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved experience filtering to distinguish candidate experience requirements from employer history and ratings.
  * Updated the maximum recognized candidate experience threshold to 25 years, preventing incorrect requirements from being inferred from employer-related descriptions.
* **Tests**
  * Added regression coverage for descriptions referencing an employer’s 30-year history or rating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->