### PR TITLE
Report the 500s we declare, and let a worker say when it did nothing

### DIFF
--- a/cmd/notify/main.go
+++ b/cmd/notify/main.go
@@ -84,5 +84,13 @@ func run() int {
 		log.Printf("notify: %v", err)
 		return 1
 	}
+	// A single failed saved-search query is isolated by design and must not fail the
+	// pass that served the rest. Every one of them failing is not that case — it means
+	// the index or its credential is gone — and it produced no failure count at all
+	// before Stats.FailedQueries existed, so the run exited 0 having matched nothing.
+	if stats.MatchingCollapsed() {
+		log.Printf("notify: all %d saved-search queries failed — nothing was matched this pass", stats.Queries)
+		return 1
+	}
 	return worker.ExitCode(stats.Failed, 0)
 }

--- a/cmd/queue-metrics/collect.go
+++ b/cmd/queue-metrics/collect.go
@@ -17,9 +17,14 @@ import (
 // Narrow by intent, matching internal/platform/worker's FullScanQueries.
 type metricsQueries interface {
 	SearchOutboxMetrics(context.Context) (db.SearchOutboxMetricsRow, error)
+	SearchDeleteOutboxMetrics(context.Context) (db.SearchDeleteOutboxMetricsRow, error)
 	EnrichmentOutboxMetrics(context.Context) (db.EnrichmentOutboxMetricsRow, error)
 	SemanticOutboxMetrics(context.Context) (db.SemanticOutboxMetricsRow, error)
 	MailClassificationOutboxMetrics(context.Context) (db.MailClassificationOutboxMetricsRow, error)
+	ApplyFormOutboxMetrics(context.Context) (db.ApplyFormOutboxMetricsRow, error)
+	AdzunaDescriptionOutboxMetrics(context.Context) (db.AdzunaDescriptionOutboxMetricsRow, error)
+	AutoApplyQueueMetrics(context.Context) (db.AutoApplyQueueMetricsRow, error)
+	PushTicketOutboxMetrics(context.Context) (db.PushTicketOutboxMetricsRow, error)
 	AppleRevocationJobMetrics(context.Context) (db.AppleRevocationJobMetricsRow, error)
 	BoardHealthMetrics(context.Context) (db.BoardHealthMetricsRow, error)
 	NewestOpenJobCreatedAt(context.Context) (pgtype.Timestamptz, error)
@@ -36,6 +41,10 @@ func collect(ctx context.Context, q metricsQueries) (snapshot, error) {
 	if err != nil {
 		return snapshot{}, fmt.Errorf("search outbox metrics: %w", err)
 	}
+	searchDelete, err := q.SearchDeleteOutboxMetrics(ctx)
+	if err != nil {
+		return snapshot{}, fmt.Errorf("search delete outbox metrics: %w", err)
+	}
 	enrichment, err := q.EnrichmentOutboxMetrics(ctx)
 	if err != nil {
 		return snapshot{}, fmt.Errorf("enrichment outbox metrics: %w", err)
@@ -47,6 +56,22 @@ func collect(ctx context.Context, q metricsQueries) (snapshot, error) {
 	mail, err := q.MailClassificationOutboxMetrics(ctx)
 	if err != nil {
 		return snapshot{}, fmt.Errorf("mail classification outbox metrics: %w", err)
+	}
+	applyForms, err := q.ApplyFormOutboxMetrics(ctx)
+	if err != nil {
+		return snapshot{}, fmt.Errorf("apply form outbox metrics: %w", err)
+	}
+	adzunaDescriptions, err := q.AdzunaDescriptionOutboxMetrics(ctx)
+	if err != nil {
+		return snapshot{}, fmt.Errorf("adzuna description outbox metrics: %w", err)
+	}
+	autoApply, err := q.AutoApplyQueueMetrics(ctx)
+	if err != nil {
+		return snapshot{}, fmt.Errorf("auto apply queue metrics: %w", err)
+	}
+	pushTickets, err := q.PushTicketOutboxMetrics(ctx)
+	if err != nil {
+		return snapshot{}, fmt.Errorf("push ticket outbox metrics: %w", err)
 	}
 	appleRevocations, err := q.AppleRevocationJobMetrics(ctx)
 	if err != nil {
@@ -90,17 +115,31 @@ func collect(ctx context.Context, q metricsQueries) (snapshot, error) {
 	}
 
 	return snapshot{
+		// Every queue in the pipeline, because a queue this worker does not measure has
+		// no signal at all: each of these is drained by a worker that exits 0 whether it
+		// kept up or not, so the per-run family stays green through any backlog. Adding
+		// an outbox means adding it here.
 		queues: []queueMetrics{
-			{name: "search_outbox", depth: search.Depth, deadLetters: search.DeadLetters, oldestAgeSeconds: search.OldestAgeSeconds},
-			{name: "enrichment_outbox", depth: enrichment.Depth, deadLetters: enrichment.DeadLetters, oldestAgeSeconds: enrichment.OldestAgeSeconds},
-			{name: "semantic_outbox", depth: semantic.Depth, deadLetters: semantic.DeadLetters, oldestAgeSeconds: semantic.OldestAgeSeconds},
-			{name: "email_classification_outbox", depth: mail.Depth, deadLetters: mail.DeadLetters, oldestAgeSeconds: mail.OldestAgeSeconds},
+			{name: "search_outbox", depth: search.Depth, deadLetters: &search.DeadLetters, oldestAgeSeconds: search.OldestAgeSeconds},
+			{name: "search_delete_outbox", depth: searchDelete.Depth, deadLetters: &searchDelete.DeadLetters, oldestAgeSeconds: searchDelete.OldestAgeSeconds},
+			{name: "enrichment_outbox", depth: enrichment.Depth, deadLetters: &enrichment.DeadLetters, oldestAgeSeconds: enrichment.OldestAgeSeconds},
+			{name: "semantic_outbox", depth: semantic.Depth, deadLetters: &semantic.DeadLetters, oldestAgeSeconds: semantic.OldestAgeSeconds},
+			{name: "email_classification_outbox", depth: mail.Depth, deadLetters: &mail.DeadLetters, oldestAgeSeconds: mail.OldestAgeSeconds},
+			{name: "apply_form_outbox", depth: applyForms.Depth, deadLetters: &applyForms.DeadLetters, oldestAgeSeconds: applyForms.OldestAgeSeconds},
+			{name: "adzuna_description_outbox", depth: adzunaDescriptions.Depth, deadLetters: &adzunaDescriptions.DeadLetters, oldestAgeSeconds: adzunaDescriptions.OldestAgeSeconds},
+			// The only queue with a third state: a parked attempt needs new data, not
+			// another try, so it is neither depth nor a dead letter. See
+			// AutoApplyQueueMetrics for why folding it into either would misread it.
+			{name: "auto_apply_queue", depth: autoApply.Depth, deadLetters: &autoApply.DeadLetters, blocked: &autoApply.Blocked, oldestAgeSeconds: autoApply.OldestAgeSeconds},
+			// No dead letters at all — the table carries neither attempts nor failed_at.
+			// A nil says so; a zero would claim a measurement nobody took.
+			{name: "push_ticket_outbox", depth: pushTickets.Depth, oldestAgeSeconds: pushTickets.OldestAgeSeconds},
 			// Not an outbox by name, but the same thing by shape and by hazard: a queue
 			// one worker drains, whose given-up entries nothing ever claims again. A
 			// queue this worker does not measure has no signal at all — cmd/apple-revoke
 			// exits 0 either way, so the per-run family stays green through a backlog of
 			// identities stranded in revocation_pending.
-			{name: "apple_revocation_jobs", depth: appleRevocations.Depth, deadLetters: appleRevocations.DeadLetters, oldestAgeSeconds: appleRevocations.OldestAgeSeconds},
+			{name: "apple_revocation_jobs", depth: appleRevocations.Depth, deadLetters: &appleRevocations.DeadLetters, oldestAgeSeconds: appleRevocations.OldestAgeSeconds},
 		},
 		notifyPendingSubscriptions: notifyBacklog.PendingSubscriptions,
 		notifyOldestAgeSeconds:     notifyBacklog.OldestAgeSeconds,

--- a/cmd/queue-metrics/collect_test.go
+++ b/cmd/queue-metrics/collect_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -15,17 +17,22 @@ import (
 // fakeQueries answers each query from a canned value, so collect's assembly and error
 // handling are testable without a database. A non-nil err field fails that one query.
 type fakeQueries struct {
-	search    db.SearchOutboxMetricsRow
-	enrich    db.EnrichmentOutboxMetricsRow
-	semantic  db.SemanticOutboxMetricsRow
-	mail      db.MailClassificationOutboxMetricsRow
-	apple     db.AppleRevocationJobMetricsRow
-	boards    db.BoardHealthMetricsRow
-	newest    pgtype.Timestamptz
-	health    []db.ProviderIngestHealthRow
-	notify    db.NotifyBacklogMetricsRow
-	newestErr error
-	searchErr error
+	search       db.SearchOutboxMetricsRow
+	searchDelete db.SearchDeleteOutboxMetricsRow
+	enrich       db.EnrichmentOutboxMetricsRow
+	semantic     db.SemanticOutboxMetricsRow
+	mail         db.MailClassificationOutboxMetricsRow
+	applyForms   db.ApplyFormOutboxMetricsRow
+	adzuna       db.AdzunaDescriptionOutboxMetricsRow
+	autoApply    db.AutoApplyQueueMetricsRow
+	pushTickets  db.PushTicketOutboxMetricsRow
+	apple        db.AppleRevocationJobMetricsRow
+	boards       db.BoardHealthMetricsRow
+	newest       pgtype.Timestamptz
+	health       []db.ProviderIngestHealthRow
+	notify       db.NotifyBacklogMetricsRow
+	newestErr    error
+	searchErr    error
 }
 
 func (f fakeQueries) NotifyBacklogMetrics(context.Context) (db.NotifyBacklogMetricsRow, error) {
@@ -34,6 +41,26 @@ func (f fakeQueries) NotifyBacklogMetrics(context.Context) (db.NotifyBacklogMetr
 
 func (f fakeQueries) SearchOutboxMetrics(context.Context) (db.SearchOutboxMetricsRow, error) {
 	return f.search, f.searchErr
+}
+
+func (f fakeQueries) SearchDeleteOutboxMetrics(context.Context) (db.SearchDeleteOutboxMetricsRow, error) {
+	return f.searchDelete, nil
+}
+
+func (f fakeQueries) ApplyFormOutboxMetrics(context.Context) (db.ApplyFormOutboxMetricsRow, error) {
+	return f.applyForms, nil
+}
+
+func (f fakeQueries) AdzunaDescriptionOutboxMetrics(context.Context) (db.AdzunaDescriptionOutboxMetricsRow, error) {
+	return f.adzuna, nil
+}
+
+func (f fakeQueries) AutoApplyQueueMetrics(context.Context) (db.AutoApplyQueueMetricsRow, error) {
+	return f.autoApply, nil
+}
+
+func (f fakeQueries) PushTicketOutboxMetrics(context.Context) (db.PushTicketOutboxMetricsRow, error) {
+	return f.pushTickets, nil
 }
 
 func (f fakeQueries) EnrichmentOutboxMetrics(context.Context) (db.EnrichmentOutboxMetricsRow, error) {
@@ -66,19 +93,29 @@ func (f fakeQueries) ProviderIngestHealth(context.Context) ([]db.ProviderIngestH
 
 func populatedQueries() fakeQueries {
 	return fakeQueries{
-		search:   db.SearchOutboxMetricsRow{Depth: 3, DeadLetters: 2, OldestAgeSeconds: 21600.5},
-		enrich:   db.EnrichmentOutboxMetricsRow{Depth: 1049297, DeadLetters: 41, OldestAgeSeconds: 5529600},
-		semantic: db.SemanticOutboxMetricsRow{Depth: 0, DeadLetters: 0, OldestAgeSeconds: 0},
+		search: db.SearchOutboxMetricsRow{Depth: 3, DeadLetters: 2, OldestAgeSeconds: 21600.5},
+		// A removal this queue gave up on leaves a closed posting live in the facet index,
+		// and its UNIQUE (job_id) then blocks that posting from ever being re-queued.
+		searchDelete: db.SearchDeleteOutboxMetricsRow{Depth: 7, DeadLetters: 5, OldestAgeSeconds: 1800},
+		enrich:       db.EnrichmentOutboxMetricsRow{Depth: 1049297, DeadLetters: 41, OldestAgeSeconds: 5529600},
+		semantic:     db.SemanticOutboxMetricsRow{Depth: 0, DeadLetters: 0, OldestAgeSeconds: 0},
 		// The shape prod was actually in: nothing live and every entry dead-lettered, which
 		// the worker's own log reported as "done failed=0 dead-lettered=0" for five weeks.
 		mail: db.MailClassificationOutboxMetricsRow{Depth: 0, DeadLetters: 2726, OldestAgeSeconds: 0},
 		// The queue cmd/apple-revoke drains. A `failed` job is never claimed again and
 		// leaves its identity stuck in revocation_pending, so its count is the one that
 		// needs watching.
-		apple:  db.AppleRevocationJobMetricsRow{Depth: 4, DeadLetters: 9, OldestAgeSeconds: 900},
-		boards: db.BoardHealthMetricsRow{Healthy: 74894, Failing: 7002, Cooled: 1882},
-		notify: db.NotifyBacklogMetricsRow{PendingSubscriptions: 12, OldestAgeSeconds: 184.25},
-		newest: pgtype.Timestamptz{Time: time.Unix(1786821346, 0), Valid: true},
+		applyForms: db.ApplyFormOutboxMetricsRow{Depth: 185432, DeadLetters: 13, OldestAgeSeconds: 604800},
+		adzuna:     db.AdzunaDescriptionOutboxMetricsRow{Depth: 611, DeadLetters: 3, OldestAgeSeconds: 7200},
+		// The one queue with a third state: parked attempts are neither owed work nor
+		// work retried to exhaustion, so they need their own count.
+		autoApply: db.AutoApplyQueueMetricsRow{Depth: 6, DeadLetters: 1, Blocked: 22, OldestAgeSeconds: 300},
+		// No attempts and no failed_at column, so no dead-letter measurement exists.
+		pushTickets: db.PushTicketOutboxMetricsRow{Depth: 48, OldestAgeSeconds: 1200},
+		apple:       db.AppleRevocationJobMetricsRow{Depth: 4, DeadLetters: 9, OldestAgeSeconds: 900},
+		boards:      db.BoardHealthMetricsRow{Healthy: 74894, Failing: 7002, Cooled: 1882},
+		notify:      db.NotifyBacklogMetricsRow{PendingSubscriptions: 12, OldestAgeSeconds: 184.25},
+		newest:      pgtype.Timestamptz{Time: time.Unix(1786821346, 0), Valid: true},
 		health: []db.ProviderIngestHealthRow{
 			{
 				Provider:      "greenhouse",
@@ -128,18 +165,23 @@ func TestCollectAssemblesEveryQueueInOrder(t *testing.T) {
 	}
 
 	want := []queueMetrics{
-		{name: "search_outbox", depth: 3, deadLetters: 2, oldestAgeSeconds: 21600.5},
-		{name: "enrichment_outbox", depth: 1049297, deadLetters: 41, oldestAgeSeconds: 5529600},
-		{name: "semantic_outbox", depth: 0, deadLetters: 0, oldestAgeSeconds: 0},
-		{name: "email_classification_outbox", depth: 0, deadLetters: 2726, oldestAgeSeconds: 0},
-		{name: "apple_revocation_jobs", depth: 4, deadLetters: 9, oldestAgeSeconds: 900},
+		{name: "search_outbox", depth: 3, deadLetters: ptr(int64(2)), oldestAgeSeconds: 21600.5},
+		{name: "search_delete_outbox", depth: 7, deadLetters: ptr(int64(5)), oldestAgeSeconds: 1800},
+		{name: "enrichment_outbox", depth: 1049297, deadLetters: ptr(int64(41)), oldestAgeSeconds: 5529600},
+		{name: "semantic_outbox", depth: 0, deadLetters: ptr(int64(0)), oldestAgeSeconds: 0},
+		{name: "email_classification_outbox", depth: 0, deadLetters: ptr(int64(2726)), oldestAgeSeconds: 0},
+		{name: "apply_form_outbox", depth: 185432, deadLetters: ptr(int64(13)), oldestAgeSeconds: 604800},
+		{name: "adzuna_description_outbox", depth: 611, deadLetters: ptr(int64(3)), oldestAgeSeconds: 7200},
+		{name: "auto_apply_queue", depth: 6, deadLetters: ptr(int64(1)), blocked: ptr(int64(22)), oldestAgeSeconds: 300},
+		{name: "push_ticket_outbox", depth: 48, oldestAgeSeconds: 1200},
+		{name: "apple_revocation_jobs", depth: 4, deadLetters: ptr(int64(9)), oldestAgeSeconds: 900},
 	}
 	if len(got.queues) != len(want) {
 		t.Fatalf("collected %d queues, want %d", len(got.queues), len(want))
 	}
 	for i := range want {
-		if got.queues[i] != want[i] {
-			t.Errorf("queue %d = %+v, want %+v", i, got.queues[i], want[i])
+		if !sameQueue(got.queues[i], want[i]) {
+			t.Errorf("queue %d = %s, want %s", i, showQueue(got.queues[i]), showQueue(want[i]))
 		}
 	}
 	if got.healthyBoards != 74894 || got.failingBoards != 7002 || got.cooledBoards != 1882 {
@@ -165,8 +207,8 @@ func TestCollectTreatsAnEmptyCatalogueAsAbsentNotAsAFailure(t *testing.T) {
 	if !got.newestJob.IsZero() {
 		t.Errorf("newestJob = %v, want the zero time so render omits the sample", got.newestJob)
 	}
-	if len(got.queues) != 5 {
-		t.Errorf("collected %d queues, want all 5 despite the empty catalogue", len(got.queues))
+	if len(got.queues) != 10 {
+		t.Errorf("collected %d queues, want all 10 despite the empty catalogue", len(got.queues))
 	}
 }
 
@@ -182,4 +224,88 @@ func TestCollectPropagatesAQueryFailure(t *testing.T) {
 	if !errors.Is(err, q.searchErr) {
 		t.Errorf("collect error = %v, want it to wrap the underlying query error", err)
 	}
+}
+
+// ptr addresses a literal so a test can express "this queue HAS that state, and the
+// count is zero" separately from "this queue has no such state at all" — the
+// distinction queueMetrics' optional counts exist to carry.
+func ptr[T any](v T) *T { return &v }
+
+// sameQueue compares two measurements by value rather than by pointer identity, which is
+// what struct equality would compare now that two counts are optional.
+func sameQueue(a, b queueMetrics) bool {
+	return a.name == b.name && a.depth == b.depth &&
+		sameCount(a.deadLetters, b.deadLetters) && sameCount(a.blocked, b.blocked) &&
+		a.oldestAgeSeconds == b.oldestAgeSeconds
+}
+
+func sameCount(a, b *int64) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
+}
+
+func showQueue(q queueMetrics) string {
+	return fmt.Sprintf("{name:%s depth:%d dead:%s blocked:%s age:%v}",
+		q.name, q.depth, showCount(q.deadLetters), showCount(q.blocked), q.oldestAgeSeconds)
+}
+
+func showCount(n *int64) string {
+	if n == nil {
+		return "none"
+	}
+	return strconv.FormatInt(*n, 10)
+}
+
+// push_ticket_outbox carries neither attempts nor failed_at, so there is no give-up state
+// to measure. It must arrive as an ABSENT count rather than a zero: a zero would publish
+// "this queue has given up on nothing", which is a claim about a measurement nobody took,
+// and would sit in the dead-letter family looking permanently healthy.
+func TestCollectLeavesAQueueWithNoGiveUpStateUnmeasuredForDeadLetters(t *testing.T) {
+	got, err := collect(context.Background(), populatedQueries())
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	push, ok := queueByName(got.queues, "push_ticket_outbox")
+	if !ok {
+		t.Fatal("push_ticket_outbox was not measured at all")
+	}
+	if push.deadLetters != nil {
+		t.Errorf("push_ticket_outbox dead letters = %d, want no measurement", *push.deadLetters)
+	}
+	if push.depth != 48 || push.oldestAgeSeconds != 1200 {
+		t.Errorf("push_ticket_outbox = depth %d age %v, want 48/1200 — the age is its whole signal",
+			push.depth, push.oldestAgeSeconds)
+	}
+}
+
+// A parked auto-apply attempt needs new data, not another try, so it is neither depth nor
+// a dead letter. Folding it into either would misreport a population no run will ever
+// claim again as either owed work or exhausted retries.
+func TestCollectKeepsParkedAutoApplyAttemptsOutOfDepthAndDeadLetters(t *testing.T) {
+	got, err := collect(context.Background(), populatedQueries())
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	q, ok := queueByName(got.queues, "auto_apply_queue")
+	if !ok {
+		t.Fatal("auto_apply_queue was not measured at all")
+	}
+	if q.blocked == nil {
+		t.Fatal("auto_apply_queue published no parked count, so parked attempts are invisible")
+	}
+	if *q.blocked != 22 || q.depth != 6 || q.deadLetters == nil || *q.deadLetters != 1 {
+		t.Errorf("auto_apply_queue = depth %d dead %s blocked %d, want 6/1/22 as three distinct states",
+			q.depth, showCount(q.deadLetters), *q.blocked)
+	}
+}
+
+func queueByName(queues []queueMetrics, name string) (queueMetrics, bool) {
+	for _, q := range queues {
+		if q.name == name {
+			return q, true
+		}
+	}
+	return queueMetrics{}, false
 }

--- a/cmd/queue-metrics/render.go
+++ b/cmd/queue-metrics/render.go
@@ -8,10 +8,19 @@ import (
 
 // queueMetrics is one outbox queue's measurement. oldestAgeSeconds is the age of the
 // oldest LIVE entry, so a queue whose only old entries are dead-lettered reads as young.
+//
+// deadLetters and blocked are pointers because not every queue has the state they
+// measure: push_ticket_outbox carries neither attempts nor failed_at, and only
+// auto_apply_queue can park an entry. A nil omits that queue from the family rather than
+// publishing a zero — the same zero-versus-absent rule newestJob and lastSuccess follow,
+// applied to a state that does not exist rather than to one that measured empty. A
+// permanent zero would read as "given up on nothing so far", which is a claim about a
+// measurement nobody took.
 type queueMetrics struct {
 	name             string
 	depth            int64
-	deadLetters      int64
+	deadLetters      *int64
+	blocked          *int64
 	oldestAgeSeconds float64
 }
 
@@ -62,11 +71,13 @@ func render(s snapshot) string {
 	var b strings.Builder
 
 	writeFamily(&b, "freehire_queue_depth", "Live entries waiting in a pipeline outbox queue.",
-		func(q queueMetrics) string { return fmt.Sprintf("%d", q.depth) }, s.queues)
+		func(q queueMetrics) (string, bool) { return fmt.Sprintf("%d", q.depth), true }, s.queues)
 	writeFamily(&b, "freehire_queue_dead_letters", "Entries a pipeline outbox queue has given up on.",
-		func(q queueMetrics) string { return fmt.Sprintf("%d", q.deadLetters) }, s.queues)
+		func(q queueMetrics) (string, bool) { return countSample(q.deadLetters) }, s.queues)
+	writeFamily(&b, "freehire_queue_blocked", "Entries a pipeline outbox queue has parked for want of data a retry cannot supply.",
+		func(q queueMetrics) (string, bool) { return countSample(q.blocked) }, s.queues)
 	writeFamily(&b, "freehire_queue_oldest_age_seconds", "Age of the oldest live entry in a pipeline outbox queue.",
-		func(q queueMetrics) string { return fmt.Sprintf("%.3f", q.oldestAgeSeconds) }, s.queues)
+		func(q queueMetrics) (string, bool) { return fmt.Sprintf("%.3f", q.oldestAgeSeconds), true }, s.queues)
 
 	writeHeader(&b, "freehire_notify_pending_subscriptions",
 		"Active subscriptions with at least one undelivered match.")
@@ -159,13 +170,38 @@ func boardStates(healthy, failing, cooled int64) [3]boardState {
 	}
 }
 
-// writeFamily emits one metric family: its HELP and TYPE lines, then one sample per
-// queue, labelled by queue name.
-func writeFamily(b *strings.Builder, name, help string, value func(queueMetrics) string, queues []queueMetrics) {
-	writeHeader(b, name, help)
-	for _, q := range queues {
-		fmt.Fprintf(b, "%s{queue=%q} %s\n", name, q.name, value(q))
+// countSample renders an optional count, reporting whether the queue has that state at
+// all. It is the one place the nil-means-omit rule on queueMetrics is applied, so the
+// two optional families cannot answer it differently.
+func countSample(n *int64) (string, bool) {
+	if n == nil {
+		return "", false
 	}
+	return fmt.Sprintf("%d", *n), true
+}
+
+// writeFamily emits one metric family: its HELP and TYPE lines, then one sample per
+// queue that HAS the state, labelled by queue name. A queue whose value function
+// declines is left out of that family — see queueMetrics on why an absent sample and a
+// zero are different statements.
+//
+// A family no queue answers is omitted head and all, the same rule the provider
+// timestamp family follows: a bare HELP/TYPE pair with no samples is valid and says
+// nothing.
+func writeFamily(b *strings.Builder, name, help string, value func(queueMetrics) (string, bool), queues []queueMetrics) {
+	var samples strings.Builder
+	for _, q := range queues {
+		v, ok := value(q)
+		if !ok {
+			continue
+		}
+		fmt.Fprintf(&samples, "%s{queue=%q} %s\n", name, q.name, v)
+	}
+	if samples.Len() == 0 {
+		return
+	}
+	writeHeader(b, name, help)
+	b.WriteString(samples.String())
 }
 
 // writeHeader emits the HELP and TYPE lines a family must be preceded by. Every metric

--- a/cmd/queue-metrics/render_test.go
+++ b/cmd/queue-metrics/render_test.go
@@ -16,9 +16,13 @@ import (
 func fullSnapshot() snapshot {
 	return snapshot{
 		queues: []queueMetrics{
-			{name: "search_outbox", depth: 3, deadLetters: 2, oldestAgeSeconds: 21600.5},
-			{name: "enrichment_outbox", depth: 1049297, deadLetters: 41, oldestAgeSeconds: 5529600},
-			{name: "semantic_outbox", depth: 0, deadLetters: 0, oldestAgeSeconds: 0},
+			{name: "search_outbox", depth: 3, deadLetters: ptr(int64(2)), oldestAgeSeconds: 21600.5},
+			{name: "enrichment_outbox", depth: 1049297, deadLetters: ptr(int64(41)), oldestAgeSeconds: 5529600},
+			{name: "semantic_outbox", depth: 0, deadLetters: ptr(int64(0)), oldestAgeSeconds: 0},
+			// The two shapes only the newer queues have: one parked population that is
+			// neither owed nor exhausted, and one queue with no give-up state at all.
+			{name: "auto_apply_queue", depth: 6, deadLetters: ptr(int64(1)), blocked: ptr(int64(22)), oldestAgeSeconds: 300},
+			{name: "push_ticket_outbox", depth: 48, oldestAgeSeconds: 1200},
 		},
 		healthyBoards:              74894,
 		failingBoards:              7002,
@@ -38,16 +42,24 @@ const wantFullRender = `# HELP freehire_queue_depth Live entries waiting in a pi
 freehire_queue_depth{queue="search_outbox"} 3
 freehire_queue_depth{queue="enrichment_outbox"} 1049297
 freehire_queue_depth{queue="semantic_outbox"} 0
+freehire_queue_depth{queue="auto_apply_queue"} 6
+freehire_queue_depth{queue="push_ticket_outbox"} 48
 # HELP freehire_queue_dead_letters Entries a pipeline outbox queue has given up on.
 # TYPE freehire_queue_dead_letters gauge
 freehire_queue_dead_letters{queue="search_outbox"} 2
 freehire_queue_dead_letters{queue="enrichment_outbox"} 41
 freehire_queue_dead_letters{queue="semantic_outbox"} 0
+freehire_queue_dead_letters{queue="auto_apply_queue"} 1
+# HELP freehire_queue_blocked Entries a pipeline outbox queue has parked for want of data a retry cannot supply.
+# TYPE freehire_queue_blocked gauge
+freehire_queue_blocked{queue="auto_apply_queue"} 22
 # HELP freehire_queue_oldest_age_seconds Age of the oldest live entry in a pipeline outbox queue.
 # TYPE freehire_queue_oldest_age_seconds gauge
 freehire_queue_oldest_age_seconds{queue="search_outbox"} 21600.500
 freehire_queue_oldest_age_seconds{queue="enrichment_outbox"} 5529600.000
 freehire_queue_oldest_age_seconds{queue="semantic_outbox"} 0.000
+freehire_queue_oldest_age_seconds{queue="auto_apply_queue"} 300.000
+freehire_queue_oldest_age_seconds{queue="push_ticket_outbox"} 1200.000
 # HELP freehire_notify_pending_subscriptions Active subscriptions with at least one undelivered match.
 # TYPE freehire_notify_pending_subscriptions gauge
 freehire_notify_pending_subscriptions 12
@@ -93,7 +105,7 @@ func TestRenderOmitsCatalogueFreshnessWhenEmpty(t *testing.T) {
 func TestRenderPublishesExplicitZeroesForADrainedQueue(t *testing.T) {
 	s := snapshot{
 		queues: []queueMetrics{
-			{name: "search_outbox", depth: 0, deadLetters: 0, oldestAgeSeconds: 0},
+			{name: "search_outbox", depth: 0, deadLetters: ptr(int64(0)), oldestAgeSeconds: 0},
 		},
 		newestJob: time.Unix(1786821346, 0),
 	}
@@ -125,9 +137,10 @@ func TestRenderIsValidPrometheusTextFormat(t *testing.T) {
 	}
 
 	want := map[string]int{
-		"freehire_queue_depth":                            3,
-		"freehire_queue_dead_letters":                     3,
-		"freehire_queue_oldest_age_seconds":               3,
+		"freehire_queue_depth":                            5,
+		"freehire_queue_dead_letters":                     4,
+		"freehire_queue_blocked":                          1,
+		"freehire_queue_oldest_age_seconds":               5,
 		"freehire_boards_total":                           3,
 		"freehire_catalogue_newest_job_timestamp_seconds": 1,
 		"freehire_notify_pending_subscriptions":           1,
@@ -160,6 +173,7 @@ func TestRenderGroupsEachFamilyUnderOneHelpAndType(t *testing.T) {
 	for _, family := range []string{
 		"freehire_queue_depth",
 		"freehire_queue_dead_letters",
+		"freehire_queue_blocked",
 		"freehire_queue_oldest_age_seconds",
 		"freehire_boards_total",
 		"freehire_catalogue_newest_job_timestamp_seconds",
@@ -282,5 +296,66 @@ func TestRenderProviderBoardsIsOneWellFormedFamily(t *testing.T) {
 	}
 	if family.GetType() != dto.MetricType_GAUGE {
 		t.Errorf("family parsed as %v, want GAUGE", family.GetType())
+	}
+}
+
+// A queue with no give-up state must be ABSENT from the dead-letter family, not zero.
+// push_ticket_outbox carries neither attempts nor failed_at, so a zero there would
+// publish a measurement nobody took and would sit in the family looking permanently
+// healthy — the same distinction the provider timestamp family already draws.
+func TestRenderOmitsDeadLettersForAQueueThatCannotDeadLetter(t *testing.T) {
+	got := render(fullSnapshot())
+
+	if strings.Contains(got, `freehire_queue_dead_letters{queue="push_ticket_outbox"}`) {
+		t.Errorf("a queue with no give-up state must publish no dead-letter sample\ngot:\n%s", got)
+	}
+	// Its two real measurements must still be there: the age is the only thing that can
+	// report cmd/push-receipts having stopped draining.
+	for _, want := range []string{
+		`freehire_queue_depth{queue="push_ticket_outbox"} 48`,
+		`freehire_queue_oldest_age_seconds{queue="push_ticket_outbox"} 1200.000`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("render() missing %q\ngot:\n%s", want, got)
+		}
+	}
+}
+
+// The parked family carries only the queue that HAS a park state, so a dashboard reading
+// it never has to know which queues could answer. Publishing zeroes for the other nine
+// would make "nothing parked" and "cannot park" the same series.
+func TestRenderPublishesParkedOnlyForTheQueueThatCanPark(t *testing.T) {
+	got := render(fullSnapshot())
+
+	if !strings.Contains(got, `freehire_queue_blocked{queue="auto_apply_queue"} 22`) {
+		t.Errorf("render() dropped the parked count, which nothing else reports\ngot:\n%s", got)
+	}
+	for _, unwanted := range []string{
+		`freehire_queue_blocked{queue="search_outbox"}`,
+		`freehire_queue_blocked{queue="push_ticket_outbox"}`,
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("render() published %q for a queue with no park state\ngot:\n%s", unwanted, got)
+		}
+	}
+}
+
+// A family no queue answers is omitted head and all rather than left as a bare HELP/TYPE
+// pair, matching the rule the provider timestamp family already follows.
+func TestRenderOmitsAnEmptyOptionalFamilyEntirely(t *testing.T) {
+	s := snapshot{
+		queues:    []queueMetrics{{name: "push_ticket_outbox", depth: 48, oldestAgeSeconds: 1200}},
+		newestJob: time.Unix(1786821346, 0),
+	}
+
+	got := render(s)
+
+	for _, unwanted := range []string{"freehire_queue_blocked", "freehire_queue_dead_letters"} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("render() emitted %s with no samples\ngot:\n%s", unwanted, got)
+		}
+	}
+	if !strings.Contains(got, `freehire_queue_depth{queue="push_ticket_outbox"} 48`) {
+		t.Errorf("render() dropped the families that DO have samples\ngot:\n%s", got)
 	}
 }

--- a/cmd/reindex/dedup_only_test.go
+++ b/cmd/reindex/dedup_only_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/strelov1/freehire/internal/platform/db"
-	"github.com/strelov1/freehire/internal/platform/worker"
 )
 
 // failingDBTX fails every statement, which is the only seam a unit test has into the
@@ -41,9 +40,15 @@ func TestRefreshDuplicateMarkersReportsHowManyPassesFailed(t *testing.T) {
 	if failed != 3 {
 		t.Errorf("failed passes = %d, want 3", failed)
 	}
-	// The reason the count is worth having at all: it is what the marker-only mode
-	// turns into an exit code cron can see.
-	if got := worker.ExitCode(failed, 0); got != 1 {
+}
+
+// The count above is only worth having because the marker-only mode turns it into an exit
+// code cron can see. Asserting worker.ExitCode(failed, 0) beside the count would re-derive
+// the production line in the test rather than check it — and it did, which is why reverting
+// the mode to `refreshDuplicateMarkers(ctx, q); return 0` left this package green. This one
+// goes through the seam the mode actually runs.
+func TestDedupOnlyExitsNonZeroWhenThePassesFailed(t *testing.T) {
+	if got := dedupOnlyExit(context.Background(), db.New(failingDBTX{err: errors.New("statement timeout")})); got != 1 {
 		t.Errorf("exit code = %d, want 1 for a run that re-marked nothing it was asked to", got)
 	}
 }

--- a/cmd/reindex/dedup_only_test.go
+++ b/cmd/reindex/dedup_only_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/strelov1/freehire/internal/platform/db"
+	"github.com/strelov1/freehire/internal/platform/worker"
+)
+
+// failingDBTX fails every statement, which is the only seam a unit test has into the
+// marker passes: they take a concrete *db.Queries.
+type failingDBTX struct{ err error }
+
+func (f failingDBTX) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, f.err
+}
+func (f failingDBTX) Query(context.Context, string, ...any) (pgx.Rows, error) { return nil, f.err }
+func (f failingDBTX) QueryRow(context.Context, string, ...any) pgx.Row        { return errRow{cause: f.err} }
+func (f failingDBTX) SendBatch(context.Context, *pgx.Batch) pgx.BatchResults  { return nil }
+
+// errRow is the pgx.Row a failing QueryRow hands back. Its field is named apart from
+// failingDBTX's so the two are not the same shape — nothing here is a conversion.
+type errRow struct{ cause error }
+
+func (r errRow) Scan(...any) error { return r.cause }
+
+// The three passes are log-and-continue because a marker refresh failure must not stop
+// the rebuild that follows it. REINDEX_DEDUP_ONLY has no rebuild to protect, so in that
+// mode the passes ARE the run — and it short-circuited to `return 0` regardless, which
+// made a run where all three failed indistinguishable from one with nothing to re-mark.
+func TestRefreshDuplicateMarkersReportsHowManyPassesFailed(t *testing.T) {
+	q := db.New(failingDBTX{err: errors.New("statement timeout")})
+
+	failed := refreshDuplicateMarkers(context.Background(), q)
+
+	if failed != 3 {
+		t.Errorf("failed passes = %d, want 3", failed)
+	}
+	// The reason the count is worth having at all: it is what the marker-only mode
+	// turns into an exit code cron can see.
+	if got := worker.ExitCode(failed, 0); got != 1 {
+		t.Errorf("exit code = %d, want 1 for a run that re-marked nothing it was asked to", got)
+	}
+}

--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -64,9 +64,15 @@ func run() int {
 	// Marker-only mode stops here, before anything Meilisearch-related — see
 	// config.Reindex.DedupOnly for why this can run far more often than a full
 	// Dedup+rebuild invocation.
+	//
+	// It is also the one mode whose exit code can carry the passes' outcome. They are
+	// log-and-continue because "a marker refresh failure must not stop the rebuild that
+	// follows it" — and here there is no rebuild to protect, so a run in which all three
+	// passes failed used to exit 0, indistinguishable from one in which the catalogue
+	// simply had nothing to re-mark. The cancellation line forCompanyBatches assembles
+	// was thrown away with it.
 	if rcfg.DedupOnly {
-		refreshDuplicateMarkers(ctx, q)
-		return 0
+		return worker.ExitCode(refreshDuplicateMarkers(ctx, q), 0)
 	}
 
 	// Captured before anything else runs (including the duplicate-marker recompute
@@ -146,24 +152,36 @@ func run() int {
 // must not stop the rebuild that follows it, which also owns index settings and
 // compaction. Each is done per company in short transactions — never a table-wide
 // lock that would stall the ingest.
-func refreshDuplicateMarkers(ctx context.Context, q *db.Queries) {
+//
+// It returns how many of the three passes failed, so a caller with no rebuild behind it
+// can still say so in its exit code. The full-rebuild callers ignore it, which is the
+// best-effort rule above, unchanged; REINDEX_DEDUP_ONLY does not, because in that mode
+// these three passes ARE the run.
+func refreshDuplicateMarkers(ctx context.Context, q *db.Queries) int {
+	failed := 0
+
 	if n, err := recomputeRoleDuplicates(ctx, q); err != nil {
+		failed++
 		log.Printf("reindex: recompute role duplicates (continuing with prior markers): %v", err)
 	} else if n > 0 {
 		log.Printf("reindex: recomputed role duplicates (%d rows re-marked)", n)
 	}
 
 	if n, err := suppressAggregatorDuplicates(ctx, q); err != nil {
+		failed++
 		log.Printf("reindex: suppress aggregator duplicates (continuing with prior markers): %v", err)
 	} else if n > 0 {
 		log.Printf("reindex: suppressed aggregator duplicates (%d rows re-marked)", n)
 	}
 
 	if n, err := collapseFuzzyDuplicates(ctx, q); err != nil {
+		failed++
 		log.Printf("reindex: collapse fuzzy duplicates (continuing with prior markers): %v", err)
 	} else if n > 0 {
 		log.Printf("reindex: collapsed fuzzy duplicates (%d rows re-marked)", n)
 	}
+
+	return failed
 }
 
 // rebuilder builds a brand-new index out of band and atomically swaps it into

--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -72,7 +72,7 @@ func run() int {
 	// simply had nothing to re-mark. The cancellation line forCompanyBatches assembles
 	// was thrown away with it.
 	if rcfg.DedupOnly {
-		return worker.ExitCode(refreshDuplicateMarkers(ctx, q), 0)
+		return dedupOnlyExit(ctx, q)
 	}
 
 	// Captured before anything else runs (including the duplicate-marker recompute
@@ -157,6 +157,19 @@ func run() int {
 // can still say so in its exit code. The full-rebuild callers ignore it, which is the
 // best-effort rule above, unchanged; REINDEX_DEDUP_ONLY does not, because in that mode
 // these three passes ARE the run.
+// dedupOnlyExit is the whole of the marker-only mode: the three passes, and their outcome
+// as an exit code.
+//
+// It is a function rather than two lines inside run() so that the second half can be
+// tested at all. run() needs a pool, a config and a Meilisearch client before it reaches
+// the branch, so a test asserting on the exit code has to go through this seam — and
+// without one, re-introducing the swallowed outcome (`refreshDuplicateMarkers(ctx, q);
+// return 0`) leaves every test in this package green, which is how it shipped that way
+// the first time.
+func dedupOnlyExit(ctx context.Context, q *db.Queries) int {
+	return worker.ExitCode(refreshDuplicateMarkers(ctx, q), 0)
+}
+
 func refreshDuplicateMarkers(ctx context.Context, q *db.Queries) int {
 	failed := 0
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -154,7 +154,9 @@ func main() {
 	// Sentry request middleware, wired only when error reporting is configured. It
 	// sits AFTER recover.New so its deferred capture runs first on a panic (reporting
 	// it with request context); Repanic re-raises so recover.New still renders the
-	// standard 500 envelope. Non-panic 5xx are reported separately in handler.RenderError.
+	// standard 500 envelope. Non-panic 500s are reported separately in handler.RenderError
+	// — including the ones a handler declared itself; a 503 means "unconfigured here" and
+	// is deliberately not one of them.
 	if cfg.SentryDSN != "" {
 		app.Use(sentryfiber.New(sentryfiber.Options{Repanic: true}))
 	}

--- a/internal/api/handler/AGENTS.md
+++ b/internal/api/handler/AGENTS.md
@@ -201,4 +201,5 @@ empty profile the model would read as "no preferences".
 
 - Genuinely domain-specific status choices (e.g. `Me` returning 401 for a gone user token) stay in the handler.
 - Recovered panic is **not** double-reported (recover middleware marks it via `handler.LocalPanicReported`).
-- Sentry reports only fall-through unexpected 500s — routine errors never reported.
+- Sentry reports **every 500**, including one a handler declared with `fiber.NewError(500, …)` to phrase it for a human. `classify` decides on the STATUS, not the error type: a declared 500 used to report nothing, which is how thirteen call sites quietly left the error inbox. Routine 4xx and mapped 404s are never reported, and the test is an equality — the ~42 sites answering 503 mean "this deployment has no Meilisearch/LLM", which is not a fault.
+- **`fiber.NewError` cannot wrap**, so a 500 declared that way reaches Sentry as a message with no cause. When there is a cause worth keeping, return `fmt.Errorf("…: %w", err)` and let the fall-through render the generic body instead of phrasing the message and dropping the error.

--- a/internal/api/handler/api_keys.go
+++ b/internal/api/handler/api_keys.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -51,7 +52,10 @@ type createAPIKeyRequest struct {
 func (h *authHandlers) mintAPIKey(ctx context.Context, userID int64, name string, expiresAt pgtype.Timestamptz) (string, db.CreateAPIKeyRow, error) {
 	token, hash, prefix, err := auth.GenerateAPIKey()
 	if err != nil {
-		return "", db.CreateAPIKeyRow{}, fiber.NewError(fiber.StatusInternalServerError, "failed to generate key")
+		// Returned rather than phrased as fiber.NewError(500, …): the reader we need
+		// here is Sentry, and a *fiber.Error carries no cause for it to show. The
+		// caller sees the generic 500 body instead — see classify.
+		return "", db.CreateAPIKeyRow{}, fmt.Errorf("generate api key for user %d: %w", userID, err)
 	}
 	row, err := h.queries.CreateAPIKey(ctx, db.CreateAPIKeyParams{
 		UserID:      userID,

--- a/internal/api/handler/auth.go
+++ b/internal/api/handler/auth.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -473,7 +474,10 @@ func (h *authHandlers) setSessionAt(c *fiber.Ctx, userID int64, version int32) e
 func (h *authHandlers) issueSessionAt(c *fiber.Ctx, userID int64, version int32) (string, error) {
 	token, err := h.issuer.Issue(userID, version)
 	if err != nil {
-		return "", fiber.NewError(fiber.StatusInternalServerError, "failed to start session")
+		// Returned rather than phrased as fiber.NewError(500, …): a signing failure is
+		// a fault the error inbox must see with its cause, and a *fiber.Error carries
+		// none. The caller sees the generic 500 body instead — see classify.
+		return "", fmt.Errorf("issue session token for user %d: %w", userID, err)
 	}
 	auth.SetTokenCookie(c, token, h.issuer.TTL(), h.cookieSecure, auth.CookieDomainForHost(c.Hostname(), h.cookieDomains))
 	return token, nil

--- a/internal/api/handler/auto_apply_tailor.go
+++ b/internal/api/handler/auto_apply_tailor.go
@@ -185,7 +185,13 @@ func (h *assistantHandlers) PostAutoApplyTailor(c *fiber.Ctx) error {
 
 	if err := h.runAutopilotToCompletion(ctx, analysis, sess, job.Description, runner, reg, system, noop); err != nil {
 		log.Printf("auto-apply: tailoring run for queue entry %d (cv %s): %v", queueID, tailored.ID, err)
-		return fiber.NewError(fiber.StatusInternalServerError, "the tailoring run failed")
+		// The CAUSE, not fiber.NewError(500, "the tailoring run failed"): the streamed
+		// autopilot reports this same error to Sentry (reportStreamFault in
+		// assistant.go), and phrasing it here took the synchronous route's copy out of
+		// the inbox. Returned unwrapped so classify still recognises what it is — an
+		// orchestrator that hung up mid-run arrives as context.Canceled and must stay a
+		// 499 nobody is paged for, not a fault.
+		return err
 	}
 
 	affected, err := h.queries.SetAutoApplyTailoredCV(c.Context(), db.SetAutoApplyTailoredCVParams{

--- a/internal/api/handler/errors.go
+++ b/internal/api/handler/errors.go
@@ -51,8 +51,9 @@ func authError(status int, code, message string) error {
 //   - anything else is an unexpected failure: 500 with a generic message, never
 //     leaking internals.
 //
-// Only that last, unexpected case is reported to Sentry (via the request-scoped
-// hub the sentryfiber middleware installs). Routine 4xx and mapped 404s are
+// Anything that ends as a 500 is reported to Sentry (via the request-scoped hub
+// the sentryfiber middleware installs), whether the handler declared it or fell
+// through to one. Routine 4xx, mapped 404s and the deployment-shaped 503s are
 // deliberately not reported, so the error inbox reflects genuine faults rather
 // than normal client traffic. When Sentry is disabled the hub is absent and the
 // capture is skipped — panics are handled separately by the middleware itself.
@@ -86,16 +87,36 @@ func reportUnexpected(c *fiber.Ctx, err error) {
 }
 
 // classify maps an error to its HTTP status and message and reports whether it is
-// an unexpected fault worth sending to Sentry. Only the fall-through 500 is
-// unexpected; a *fiber.Error, the 404-mapped DB errors, a client disconnect, and
-// a malformed search query are all routine.
+// a server fault worth sending to Sentry. The 404-mapped DB errors, a client
+// disconnect and a malformed search query are all routine; every 500 is a fault,
+// including one a handler DECLARED with fiber.NewError to give the caller a
+// readable message.
+//
+// That last clause is the whole reason this branch tests the code instead of
+// answering false for every *fiber.Error. Thirteen call sites wrapped a genuine
+// failure — a DB read, a token mint, an autopilot run — in fiber.NewError(500,
+// "…") purely to phrase it for a human, and thereby took it out of the error
+// inbox; seven of them do not log either, so the failure left no trace anywhere.
+// The streamed autopilot already decided the other way (see reportStreamFault in
+// assistant.go), and the synchronous route sent the SAME error past it.
+//
+// It is an EQUALITY, not `code >= 500`. Forty-two sites answer 503 to mean "this
+// deployment has no Meilisearch/LLM configured" — a statement about the
+// environment, repeated on every request to that route, and not a fault anyone
+// can act on from Sentry.
+//
+// A *fiber.Error cannot wrap, so a 500 declared this way reaches Sentry as its
+// own message with no cause behind it. Call sites that have a cause worth keeping
+// should therefore return `fmt.Errorf("…: %w", err)` and let the fall-through
+// render the generic body, rather than phrasing the message and dropping the
+// error.
 func classify(err error) (status int, msg string, report bool) {
 	var fe *fiber.Error
 	var invalidValue *inbox.InvalidError
 	var badBatch *inbox.BatchError
 	switch {
 	case errors.As(err, &fe):
-		return fe.Code, fe.Message, false
+		return fe.Code, fe.Message, fe.Code == fiber.StatusInternalServerError
 	case errors.Is(err, pgx.ErrNoRows), pgerr.IsForeignKeyViolation(err), errors.Is(err, inbox.ErrNotFound):
 		return fiber.StatusNotFound, "not found", false
 	// The mail service validates against its own vocabularies and refuses to record

--- a/internal/api/handler/errors_test.go
+++ b/internal/api/handler/errors_test.go
@@ -98,6 +98,48 @@ func TestRenderError_ReturnedErrorReportedOnce(t *testing.T) {
 	}
 }
 
+// A 500 a handler declared for itself — fiber.NewError(500, "…") to give the caller
+// readable words instead of "internal server error" — must reach Sentry like any
+// other 500. It reached it never, which is how thirteen genuine faults (a failed
+// token mint, an autopilot run, a billing event that could not be recorded) left no
+// trace at all: seven of them do not log either.
+func TestRenderError_DeclaredInternalErrorIsReported(t *testing.T) {
+	app, tr := sentryApp(t, func(*fiber.Ctx) error {
+		return fiber.NewError(fiber.StatusInternalServerError, "could not record the event")
+	})
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/x", nil))
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", resp.StatusCode)
+	}
+	if got := tr.count(); got != 1 {
+		t.Errorf("sentry events = %d, want exactly 1", got)
+	}
+}
+
+// The counterpart: a 503 says this deployment has no Meilisearch or LLM, which every
+// request to that route repeats and nobody can act on from an error inbox. Reporting
+// on `code >= 500` would have made ~42 call sites into a permanent alert.
+func TestRenderError_UnconfiguredServiceIsNotReported(t *testing.T) {
+	app, tr := sentryApp(t, func(*fiber.Ctx) error {
+		return fiber.NewError(fiber.StatusServiceUnavailable, "search is not configured")
+	})
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/x", nil))
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", resp.StatusCode)
+	}
+	if got := tr.count(); got != 0 {
+		t.Errorf("sentry events = %d, want 0", got)
+	}
+}
+
 // errorApp mounts a route that returns errFn's error through RenderError, so the
 // status mapping can be asserted end to end.
 func errorApp(errFn func(*fiber.Ctx) error) *fiber.App {
@@ -139,9 +181,11 @@ func TestErrorHandler_DefaultsTo500(t *testing.T) {
 	}
 }
 
-// classify decides both the HTTP mapping and whether an error is an unexpected
-// fault worth reporting to Sentry. Only the fall-through 500 must be reported;
-// routine 4xx and mapped 404s must not, so the error inbox stays signal, not noise.
+// classify decides both the HTTP mapping and whether an error is a fault worth
+// reporting to Sentry. Every 500 must be reported — including one a handler
+// DECLARED with fiber.NewError to phrase it for a human, which used to be reported
+// as nothing at all; routine 4xx, mapped 404s and the deployment-shaped 503s must
+// not be, so the error inbox stays signal, not noise.
 func TestClassify_ReportsOnlyUnexpected500(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -151,6 +195,15 @@ func TestClassify_ReportsOnlyUnexpected500(t *testing.T) {
 	}{
 		{"generic error is an unexpected 500", errString("boom"), fiber.StatusInternalServerError, true},
 		{"fiber 4xx is routine", fiber.NewError(fiber.StatusBadRequest, "bad"), fiber.StatusBadRequest, false},
+		// A handler that wrapped a real failure in fiber.NewError purely to give the
+		// caller readable words thereby took it out of the error inbox. Thirteen call
+		// sites did, and seven of them logged nothing either.
+		{"declared 500 is still a fault", fiber.NewError(fiber.StatusInternalServerError, "could not record the event"), fiber.StatusInternalServerError, true},
+		// The equality, not `>= 500`: ~42 sites answer 503 to say this deployment has no
+		// Meilisearch or LLM configured. That is a statement about the environment,
+		// repeated on every request to the route, and nobody can act on it from Sentry.
+		{"503 means unconfigured, not broken", fiber.NewError(fiber.StatusServiceUnavailable, "search is not configured"), fiber.StatusServiceUnavailable, false},
+		{"wrapped declared 500 is still a fault", fmt.Errorf("issue session: %w", fiber.NewError(fiber.StatusInternalServerError, "failed to start session")), fiber.StatusInternalServerError, true},
 		{"no rows maps to 404", pgx.ErrNoRows, fiber.StatusNotFound, false},
 		{"foreign-key violation maps to 404", &pgconn.PgError{Code: "23503"}, fiber.StatusNotFound, false},
 		{"client disconnect is not a fault", context.Canceled, statusClientClosedRequest, false},

--- a/internal/api/handler/extension_connect.go
+++ b/internal/api/handler/extension_connect.go
@@ -131,13 +131,19 @@ func (h *authHandlers) ExtensionConnectSubmit(c *fiber.Ctx) error {
 	// Authorization: Bearer, Roy via cookie/WS-subprotocol). The token carries the
 	// account's session generation, so "sign out everywhere" evicts the extension too —
 	// re-running connect mints a fresh one.
+	//
+	// Both failures are returned rather than phrased as fiber.NewError(500, …): what
+	// has to read them is the error inbox, and a *fiber.Error carries no cause for it
+	// to show. The caller meets the generic 500 body instead — see classify. The read
+	// additionally gains the house mapping for a vanished account (pgx.ErrNoRows →
+	// 404), which is the honest answer when the session outlives its user row.
 	version, err := h.queries.GetUserTokenVersion(c.Context(), userID)
 	if err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, "failed to issue token")
+		return fmt.Errorf("read token version for the extension connect of user %d: %w", userID, err)
 	}
 	token, err := h.issuer.Issue(userID, version)
 	if err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, "failed to issue token")
+		return fmt.Errorf("issue extension connect token for user %d: %w", userID, err)
 	}
 	return redirect(url.Values{"token": {token}, "state": {state}})
 }

--- a/internal/api/handler/ghost_evidence.go
+++ b/internal/api/handler/ghost_evidence.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"log"
 	"time"
 
 	"github.com/strelov1/freehire/internal/job/ghost"
@@ -20,16 +21,23 @@ import (
 // signal rather than failing the read. That is the honest direction — a missing lookup
 // is a gap in what we know, and the signal's whole discipline is to say nothing where
 // it has not observed.
+//
+// Best-effort is not silent, though. Losing these two reads takes the whole outcome
+// tier out of the verdict — LevelLikely needs evidence and becomes unreachable — and
+// there is no QueryTracer in internal/platform/db, so a swallowed error left no trace
+// anywhere: the badge simply stopped appearing and every page still answered 200.
 func ghostEvidenceFor(ctx context.Context, q *db.Queries, jobIDs []int64) map[int64]ghost.Evidence {
 	if q == nil || len(jobIDs) == 0 {
 		return nil
 	}
 	appRows, err := q.ListGhostApplicationEvidence(ctx, jobIDs)
 	if err != nil {
+		logGhostLookup(ctx, "application evidence", len(jobIDs), err)
 		return nil
 	}
 	reportRows, err := q.ListGhostReportEvidence(ctx, jobIDs)
 	if err != nil {
+		logGhostLookup(ctx, "report evidence", len(jobIDs), err)
 		return nil
 	}
 
@@ -48,4 +56,20 @@ func ghostEvidenceFor(ctx context.Context, q *db.Queries, jobIDs []int64) map[in
 		reports[i] = ghost.Report{JobID: r.JobID, UserID: r.UserID, AppliedOn: r.AppliedOn.Time}
 	}
 	return ghost.Aggregate(time.Now(), apps, reports)
+}
+
+// logGhostLookup records a best-effort ghost-signal read that failed, saying whether
+// the page simply went away or the database did.
+//
+// It classifies on the CONTEXT, not on the error — the idiom searchdrain and embed
+// settled on. A reader who navigates away cancels the request, every in-flight query
+// fails with it, and counting those as faults would bury the one line that means
+// something under the commonest event on the site. Reading ctx.Err() answers that
+// without needing the driver to cooperate with errors.Is.
+func logGhostLookup(ctx context.Context, stage string, jobs int, err error) {
+	if cause := ctx.Err(); cause != nil {
+		log.Printf("ghost: %s for %d jobs abandoned (%v) — signal omitted", stage, jobs, cause)
+		return
+	}
+	log.Printf("ghost: %s for %d jobs failed, serving the page without the outcome tier: %v", stage, jobs, err)
 }

--- a/internal/api/handler/ghost_evidence_test.go
+++ b/internal/api/handler/ghost_evidence_test.go
@@ -1,0 +1,86 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/strelov1/freehire/internal/platform/db"
+)
+
+// failingDBTX answers every read with the same error, which is what lets the ghost
+// signal's degrade path be exercised without a database: *db.Queries is a concrete type
+// built over this interface, so this is the only seam a unit test has into it.
+type failingDBTX struct{ err error }
+
+func (f failingDBTX) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, f.err
+}
+func (f failingDBTX) Query(context.Context, string, ...any) (pgx.Rows, error) { return nil, f.err }
+func (f failingDBTX) QueryRow(context.Context, string, ...any) pgx.Row        { return errRow{cause: f.err} }
+func (f failingDBTX) SendBatch(context.Context, *pgx.Batch) pgx.BatchResults  { return nil }
+
+// errRow is the pgx.Row a failing QueryRow hands back. Its field is named apart from
+// failingDBTX's so the two are not the same shape — nothing here is a conversion.
+type errRow struct{ cause error }
+
+func (r errRow) Scan(...any) error { return r.cause }
+
+// captureLog collects what fn writes to the standard logger.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(prev)
+	fn()
+	return buf.String()
+}
+
+// Losing these two reads takes the whole outcome tier out of the ghost verdict —
+// LevelLikely needs evidence, so it becomes unreachable — and there is no QueryTracer in
+// internal/platform/db, so a swallowed error left no trace anywhere: the badge simply
+// stopped appearing while every page went on answering 200.
+func TestGhostEvidenceFor_SaysSoWhenTheLookupFails(t *testing.T) {
+	q := db.New(failingDBTX{err: errors.New("connection reset by peer")})
+
+	var evidence int
+	out := captureLog(t, func() {
+		evidence = len(ghostEvidenceFor(context.Background(), q, []int64{1, 2, 3}))
+	})
+
+	if evidence != 0 {
+		t.Errorf("evidence entries = %d, want none — the read failed", evidence)
+	}
+	if !strings.Contains(out, "connection reset by peer") {
+		t.Errorf("nothing named the failure, so it is invisible everywhere:\n%q", out)
+	}
+	if !strings.Contains(out, "ghost") {
+		t.Errorf("the log line does not name the signal it degraded:\n%q", out)
+	}
+}
+
+// A reader who navigates away cancels the request and every in-flight query fails with
+// it. That is the commonest event on the site, so it must not be logged as a fault —
+// hence the searchdrain/embed idiom: classify on the CONTEXT, not on the error, since a
+// driver's own error type need not unwrap to a context sentinel at all.
+func TestGhostEvidenceFor_TellsCancellationApartFromAFault(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	q := db.New(failingDBTX{err: errors.New("connection reset by peer")})
+
+	out := captureLog(t, func() { ghostEvidenceFor(ctx, q, []int64{1, 2, 3}) })
+
+	if strings.Contains(out, "failed") {
+		t.Errorf("an abandoned request was logged as a fault:\n%q", out)
+	}
+	if !strings.Contains(out, "abandoned") {
+		t.Errorf("the abandoned read was not reported at all:\n%q", out)
+	}
+}

--- a/internal/api/handler/oauth.go
+++ b/internal/api/handler/oauth.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"net/url"
 	"sort"
@@ -76,7 +77,10 @@ func (h *authHandlers) OAuthStart(c *fiber.Ctx) error {
 
 	state, err := oauth.NewState()
 	if err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, "failed to start sign-in")
+		// Returned rather than phrased as fiber.NewError(500, …): a failing CSPRNG is
+		// exactly the fault the error inbox exists for, and a *fiber.Error carries no
+		// cause for it to show. The caller sees the generic 500 body — see classify.
+		return fmt.Errorf("mint oauth state: %w", err)
 	}
 	oauth.SetStateCookie(c, state, h.cookieSecure)
 	// Remember where the SPA wants the user back, so sign-in from a deep page

--- a/internal/api/handler/search.go
+++ b/internal/api/handler/search.go
@@ -289,7 +289,10 @@ func buildSearchFilter(c *fiber.Ctx) any {
 // recomputed.
 //
 // Best-effort: a failed lookup leaves the signal off the page rather than failing
-// the search.
+// the search — but not silently. These stamps are a structural tier of this path,
+// so a persistent failure here is the badge disappearing from every search result
+// while the endpoint keeps answering 200; without the log there is nothing to see
+// it by (see logGhostLookup for why cancellation is told apart on the context).
 func (h *searchHandlers) attachGhost(c *fiber.Ctx, hits []search.JobDocument, views []jobview.Job) {
 	if len(hits) == 0 || h.queries == nil {
 		return
@@ -301,6 +304,7 @@ func (h *searchHandlers) attachGhost(c *fiber.Ctx, hits []search.JobDocument, vi
 
 	stampRows, err := h.queries.ListJobGhostStamps(c.Context(), ids)
 	if err != nil {
+		logGhostLookup(c.Context(), "absence stamps", len(ids), err)
 		return
 	}
 	stamps := make(map[int64]db.ListJobGhostStampsRow, len(stampRows))

--- a/internal/candidate/fitanalysis/AGENTS.md
+++ b/internal/candidate/fitanalysis/AGENTS.md
@@ -62,9 +62,18 @@ reachable only through a `*fiber.Ctx`.
   the SSE writer goroutine (fasthttp recovers no panics there) would take the process down.
 - **A follower checks the leader's success before trusting the cache.** A failed leader leaves an
   OLDER or absent row, and serving it would dress a stale analysis up as this run's live result.
-- **Best-effort where it says so:** the cache write and the debit are logged, never surfaced — the
-  analysis is already computed by then. `Balance` answers nil on any failure; the atomic `Debit`
-  is the real ceiling, not the pre-check.
+- **"Succeeded" means the CACHE WRITE, and `Run` tracks it separately from the refund.** Two
+  questions, two flags: `cached` is what `Claim.Release` publishes to followers, `produced` is
+  what decides the refund. They differ in exactly one case — the chain produced an analysis and
+  the write failed — and one boolean answered it wrongly for the follower, who was told to trust
+  a cache holding an older row or nothing. The refund must NOT switch to `cached`: the caller
+  that received the analysis got what it paid for, which is what `Follow`'s "a leader whose cache
+  write failed still returned the analysis to whoever paid for it" is about. `Ensure`/`compute`
+  keep one flag because neither is handed the result, so for them the two questions coincide.
+- **Best-effort where it says so:** the cache write and the debit are logged, never surfaced to
+  the caller — the analysis is already computed by then. `Cache` still RETURNS its error, because
+  the follower cannot see the log and the claim is the only channel to it. `Balance` answers nil
+  on any failure; the atomic `Debit` is the real ceiling, not the pre-check.
 
 ## Reading a cached analysis
 

--- a/internal/candidate/fitanalysis/cache_failure_test.go
+++ b/internal/candidate/fitanalysis/cache_failure_test.go
@@ -1,0 +1,143 @@
+package fitanalysis_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/tmc/langchaingo/llms"
+
+	"github.com/strelov1/freehire/internal/candidate/fitanalysis"
+	"github.com/strelov1/freehire/internal/candidate/jobmatch"
+	"github.com/strelov1/freehire/internal/candidate/matchanalysis"
+	"github.com/strelov1/freehire/internal/candidate/resumeextract"
+	"github.com/strelov1/freehire/internal/platform/db"
+	"github.com/strelov1/freehire/internal/platform/llm"
+)
+
+// cannedModel answers the chain's three stages in order, which is what makes Run's SUCCESS
+// branch reachable without a model — the branch where the analysis exists and the only
+// thing that can still go wrong is the cache write.
+type cannedModel struct{ resp []string }
+
+func (m *cannedModel) GenerateContent(context.Context, []llms.MessageContent, ...llms.CallOption) (*llms.ContentResponse, error) {
+	r := m.resp[0]
+	m.resp = m.resp[1:]
+	return &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: r}}}, nil
+}
+
+func (*cannedModel) Call(context.Context, string, ...llms.CallOption) (string, error) {
+	return "", nil
+}
+
+const (
+	fitStage1JSON = `{"requirements":[{"text":"Go","priority":"required","status":"covered","evidence":"5y at Acme"}]}`
+	fitStage2JSON = `{"title_alignment":{"score":80},"experience_relevance":{"score":70},"seniority_fit":{"score":60},"skills_coverage":{"score":50},"company_context":{"score":40},"location_fit":{"score":60},"strengths":["Strong Go"],"gaps":[],"recommendation":"Apply."}`
+	fitStage3JSON = `{"title_alignment":{"score":80},"experience_relevance":{"score":70},"seniority_fit":{"score":60},"skills_coverage":{"score":50},"company_context":{"score":40},"location_fit":{"score":60},"strengths":["Strong Go"],"gaps":[],"recommendation":"Apply."}`
+)
+
+// producingRequest is a request whose chain really returns an analysis.
+func producingRequest(claim *fitanalysis.Claim) fitanalysis.Request {
+	analyzer := matchanalysis.NewAnalyzer(llm.NewWithModel(
+		&cannedModel{resp: []string{fitStage1JSON, fitStage2JSON, fitStage3JSON}}))
+	return fitanalysis.Request{
+		UserID:   userID,
+		Job:      db.Job{ID: jobID},
+		Analyzer: analyzer,
+		Claim:    claim,
+		Input: matchanalysis.Input{
+			JobTitle:       "Senior Go Engineer",
+			JobDescription: "Build backends in Go.",
+			StructuredResume: resumeextract.Professional{
+				Summary:    "Backend engineer, 5y Go at Acme.",
+				Experience: []resumeextract.Experience{{Company: "Acme", Title: "Backend Engineer"}},
+				Skills:     []string{"Go"},
+			},
+			Match:    jobmatch.JobMatch{Matched: []string{"go"}, CoveragePercent: 100},
+			Language: "en",
+		},
+	}
+}
+
+// A follower reads only the cache, so what the leader publishes has to be whether the CACHE
+// WRITE landed — not merely whether the chain produced something. One flag answered both,
+// so a leader whose write failed told its followers to trust a cache holding an older row
+// or nothing at all, which Follow's whole discipline exists to prevent.
+func TestRunPublishesTheCacheWriteFailureToFollowers(t *testing.T) {
+	ctx := context.Background()
+	// A STALE row is what makes the bug visible rather than merely latent: with an empty
+	// cache a wrongly-trusting follower finds nothing and reports unavailable anyway. The
+	// live shape is a pair analysed before, whose older analysis is exactly what a failed
+	// write leaves behind for the follower to serve as this run's result.
+	store := &fakeStore{row: cachedRow(t, 40), upsertErr: errors.New("statement timeout")}
+	svc := newService(store, nil)
+
+	leader := svc.Claim(userID, jobID)
+	if !leader.IsLeader() {
+		t.Fatal("the first claimant must lead")
+	}
+	follower := svc.Claim(userID, jobID)
+	if follower.IsLeader() {
+		t.Fatal("the second claimant must follow")
+	}
+
+	analysis, err := svc.Run(ctx, producingRequest(leader), nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// The caller who ran the chain still gets what it computed — the write is best-effort
+	// towards them, and they are already holding the result.
+	if analysis == nil {
+		t.Fatal("Run returned no analysis, so the case under test was never reached")
+	}
+
+	followed, err := svc.Follow(ctx, fitanalysis.Request{UserID: userID, Job: db.Job{ID: jobID}, Claim: follower})
+	if !errors.Is(err, fitanalysis.ErrUnavailable) {
+		t.Errorf("Follow = %v, want ErrUnavailable: the cache holds nothing this run wrote", err)
+	}
+	if followed != nil {
+		t.Errorf("Follow served a score of %d, which is the STALE row dressed up as this run's result",
+			followed.OverallScore)
+	}
+}
+
+// The counterpart, and the reason the flag had to be SPLIT rather than moved: the caller
+// that received the analysis got what it paid for. Refunding on a failed cache write would
+// void a charge the returned result earned — Follow's own comment names that case.
+func TestRunKeepsTheChargeWhenOnlyTheCacheWriteFailed(t *testing.T) {
+	ctx := context.Background()
+	meter := newMeter(10)
+	store := &fakeStore{upsertErr: errors.New("statement timeout")}
+	svc := newService(store, meter)
+
+	reserved, err := svc.Reserve(ctx, userID, jobID)
+	if err != nil || !reserved {
+		t.Fatalf("Reserve = %v, %v; want a reservation", reserved, err)
+	}
+
+	req := producingRequest(nil)
+	req.Reserved = reserved
+	if _, err := svc.Run(ctx, req, nil); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(meter.releases) != 0 {
+		t.Errorf("releases = %v, want none — the candidate received the analysis they paid for", meter.releases)
+	}
+	if meter.remaining != 9 {
+		t.Errorf("remaining = %d, want 9 — the charge stands", meter.remaining)
+	}
+}
+
+// Cache is best-effort towards its caller and always was; what changed is that it reports
+// the failure at all, because the follower it strands cannot read the log.
+func TestCacheReportsAFailedWrite(t *testing.T) {
+	svc := newService(&fakeStore{upsertErr: errors.New("statement timeout")}, nil)
+
+	err := svc.Cache(context.Background(), userID, db.Job{ID: jobID}, nil, "en",
+		&matchanalysis.Analysis{OverallScore: 80, Verdict: "Strong Fit"})
+
+	if err == nil {
+		t.Error("Cache reported success on a write that failed")
+	}
+}

--- a/internal/candidate/fitanalysis/fitanalysis.go
+++ b/internal/candidate/fitanalysis/fitanalysis.go
@@ -249,21 +249,36 @@ func (s *Service) List(ctx context.Context, userID int64) ([]db.ListUserJobAnaly
 // When r.Claim leads, the claim is released here, from a defer: a panic anywhere between the
 // chain, the cache write and the debit still wakes a waiting follower instead of stranding
 // that pair behind a leader that never finishes.
+//
+// The two gates below answer DIFFERENT questions and are therefore two flags, not one. A
+// single `succeeded` was set after the cache write without looking at it, so a failed write
+// was published to followers as a success — and Follow, whose whole discipline is not to
+// trust the cache unless the leader says so, then served whatever older row was there as
+// this run's live result.
 func (s *Service) Run(ctx context.Context, r Request, emit func(matchanalysis.Event)) (*matchanalysis.Analysis, error) {
-	succeeded := false
+	// cached: did the CACHE end up holding this run's result? That is the only thing a
+	// follower can read, so it is what the claim publishes.
+	cached := false
 	if r.Claim.IsLeader() {
-		defer func() { r.Claim.Release(succeeded) }()
+		defer func() { r.Claim.Release(cached) }()
 	}
-	// Nothing produced means nothing owed — and whoever RAN THE CHAIN says so for everyone.
-	// Only a leader or a caller that is not coalescing at all reaches Run (a follower goes to
+	// produced: did the chain yield an analysis THIS caller is about to be handed? Nothing
+	// produced means nothing owed — and whoever RAN THE CHAIN says so for everyone. Only a
+	// leader or a caller that is not coalescing at all reaches Run (a follower goes to
 	// Follow), so this is exactly the caller that knows the outcome. It releases the ref
 	// rather than just its own reservation: when the leader is the free autopilot pre-run, the
 	// charge standing against that ref belongs to a follower about to be told there is nothing.
 	//
+	// It is deliberately NOT `cached`. An allowance buys having the analysis, and a caller
+	// that received one got what it paid for even if the write behind it failed — Follow's
+	// own comment names that case. Refunding on a failed write would void a charge the
+	// returned result earned.
+	//
 	// Deferred so a panic anywhere below — in the chain, the emit callback or the cache write
 	// — gives the credit back too.
+	produced := false
 	defer func() {
-		if !succeeded {
+		if !produced {
 			s.release(ctx, r.UserID, r.Job.ID)
 		}
 	}()
@@ -281,8 +296,8 @@ func (s *Service) Run(ctx context.Context, r Request, emit func(matchanalysis.Ev
 	if analysis == nil {
 		return nil, nil // LLM unconfigured — nothing to cache
 	}
-	s.Cache(ctx, r.UserID, r.Job, r.CVUploadedAt, r.Input.Language, analysis)
-	succeeded = true
+	produced = true
+	cached = s.Cache(ctx, r.UserID, r.Job, r.CVUploadedAt, r.Input.Language, analysis) == nil
 	return analysis, nil
 }
 
@@ -372,6 +387,11 @@ func (s *Service) Refresh(ctx context.Context, r Request) {
 // compute runs the chain and caches what it produced, reporting whether the cache is left
 // holding this call's own result — which is what a coalescing follower waits to learn. It
 // never charges: both callers are the autopilot's own unmetered halves.
+//
+// Unlike Run, one flag is the whole answer here. Neither caller is handed the analysis, so
+// there is no caller who got what they paid for: if the write failed, the follower gets
+// nothing and the charge standing against the ref — theirs, not this half's — is given back
+// on their behalf, which is what Ensure's defer does with this return value.
 func (s *Service) compute(ctx context.Context, r Request, stage string) bool {
 	analysis, err := r.Analyzer.Analyze(ctx, r.Input)
 	if err != nil {
@@ -381,22 +401,29 @@ func (s *Service) compute(ctx context.Context, r Request, stage string) bool {
 	if analysis == nil {
 		return false // LLM unconfigured — nothing to cache
 	}
-	s.Cache(ctx, r.UserID, r.Job, r.CVUploadedAt, r.Input.Language, analysis)
-	return true
+	return s.Cache(ctx, r.UserID, r.Job, r.CVUploadedAt, r.Input.Language, analysis) == nil
 }
 
 // Cache upserts the analysis stamped with the analysed CV's upload time, the job content
 // hash, the language it was written in, and the model that produced it. It takes a plain
 // context (never a request's) so a caller streaming over SSE can cache after its handler has
-// returned. Best-effort: a cache failure is logged, not surfaced.
+// returned. Best-effort towards the CALLER: it logs, and the caller that already holds the
+// analysis returns it regardless.
+//
+// It still reports the failure, because one other party cannot see it and has to: a
+// coalescing FOLLOWER reads what this wrote, so a leader whose write failed leaves an older
+// or absent row that the follower would otherwise serve as this run's live result. Follow
+// already refuses to trust the cache unless the leader says it succeeded — this is what
+// makes "succeeded" able to mean the write, and not merely the chain.
 //
 // What it stores is the UNCAPPED analysis. The hard-constraint ceiling is applied to the
 // served copy only, by the caller, so a dictionary change takes effect on the next read with
 // no cache invalidation.
-func (s *Service) Cache(ctx context.Context, userID int64, job db.Job, cvUploadedAt *time.Time, language string, analysis *matchanalysis.Analysis) {
+func (s *Service) Cache(ctx context.Context, userID int64, job db.Job, cvUploadedAt *time.Time, language string, analysis *matchanalysis.Analysis) error {
 	blob, err := json.Marshal(analysis)
 	if err != nil {
-		return
+		log.Printf("matchanalysis: encode analysis for user %d job %d: %v", userID, job.ID, err)
+		return err
 	}
 	if err := s.store.UpsertUserJobAnalysis(ctx, db.UpsertUserJobAnalysisParams{
 		UserID:         userID,
@@ -408,7 +435,9 @@ func (s *Service) Cache(ctx context.Context, userID int64, job db.Job, cvUploade
 		Language:       language,
 	}); err != nil {
 		log.Printf("matchanalysis: cache analysis for user %d job %d: %v", userID, job.ID, err)
+		return err
 	}
+	return nil
 }
 
 // release gives back a credit reserved for a run that produced nothing, and is best-effort:

--- a/internal/candidate/fitanalysis/fitanalysis_test.go
+++ b/internal/candidate/fitanalysis/fitanalysis_test.go
@@ -27,10 +27,14 @@ const (
 // fakeStore is the analysis cache in memory. row==nil stands for "never analysed", which the
 // real store reports as pgx.ErrNoRows.
 type fakeStore struct {
-	row      *db.GetUserJobAnalysisRow
-	readErr  error
-	upserted []db.UpsertUserJobAnalysisParams
-	list     []db.ListUserJobAnalysesRow
+	row     *db.GetUserJobAnalysisRow
+	readErr error
+	// upsertErr fails the cache WRITE, which is the one outcome a caller cannot see for
+	// itself: it already holds the analysis, while a coalescing follower has only the
+	// cache to read.
+	upsertErr error
+	upserted  []db.UpsertUserJobAnalysisParams
+	list      []db.ListUserJobAnalysesRow
 }
 
 func (f *fakeStore) GetUserJobAnalysis(context.Context, db.GetUserJobAnalysisParams) (db.GetUserJobAnalysisRow, error) {
@@ -44,6 +48,9 @@ func (f *fakeStore) GetUserJobAnalysis(context.Context, db.GetUserJobAnalysisPar
 }
 
 func (f *fakeStore) UpsertUserJobAnalysis(_ context.Context, arg db.UpsertUserJobAnalysisParams) error {
+	if f.upsertErr != nil {
+		return f.upsertErr
+	}
 	f.upserted = append(f.upserted, arg)
 	return nil
 }

--- a/internal/engage/notify/deliver.go
+++ b/internal/engage/notify/deliver.go
@@ -46,6 +46,16 @@ func (r *Runner) deliver(ctx context.Context, stats *Stats) error {
 	}
 
 	for _, subID := range order {
+		// A cancelled run stops here rather than walking the rest of the claimed
+		// subscriptions: each would fail instantly against the same dead context and be
+		// counted a delivery failure, so one SIGTERM would report as an outage across
+		// every subscription. Their claims simply expire and the next pass retries them,
+		// which is what the lease is for.
+		if ctx.Err() != nil {
+			log.Printf("notify: delivery stopped after %d of %d claimed subscriptions: %v",
+				stats.Delivered+stats.SoftSkips+stats.Deferred+stats.Failed, len(order), ctx.Err())
+			return nil
+		}
 		r.deliverOne(ctx, subID, jobsBySub[subID], stats)
 	}
 	return nil
@@ -55,8 +65,13 @@ func (r *Runner) deliver(ctx context.Context, stats *Stats) error {
 func (r *Runner) deliverOne(ctx context.Context, subID int64, jobIDs []int64, stats *Stats) {
 	info, err := r.store.GetSubscriptionForDelivery(ctx, subID)
 	if err != nil {
+		// Counted, not merely logged. This digest did not go out and nothing burned an
+		// attempt toward the dead-letter limit, so the only trace it leaves is the exit
+		// code — and a pass that failed to read every subscription it claimed used to
+		// print `delivered=0 failed=0` and exit 0, which reads as an idle queue.
 		log.Printf("notify: load subscription %d for delivery: %v", subID, err)
 		r.release(ctx, subID, jobIDs)
+		stats.Failed++
 		return
 	}
 
@@ -89,8 +104,11 @@ func (r *Runner) deliverOne(ctx context.Context, subID int64, jobIDs []int64, st
 
 	jobs, err := r.store.GetJobsForDigest(ctx, jobIDs)
 	if err != nil {
+		// Counted for the same reason as the subscription read above: the digest is not
+		// going out, and releasing the claim leaves no other record that it did not.
 		log.Printf("notify: load jobs for subscription %d: %v", subID, err)
 		r.release(ctx, subID, jobIDs)
+		stats.Failed++
 		return
 	}
 

--- a/internal/engage/notify/match.go
+++ b/internal/engage/notify/match.go
@@ -53,8 +53,15 @@ func (r *Runner) match(ctx context.Context, stats *Stats) error {
 		if err := r.matchQuery(ctx, query, gsubs, excludedByUser, stats); err != nil {
 			// `done`, not the failure count: what a cancellation has to report is how
 			// far the stage got, and this branch runs before the failure is counted.
+			//
+			// It STOPS but does not fail, the same rule and for the same reason as the
+			// delivery loop below: an unmatched query is simply matched by the next pass,
+			// so an ordinary `systemctl stop` is not an outage and must not paint the unit
+			// red. Returning an error here would also have skipped Run's summary line —
+			// losing the counters exactly when somebody wants to know how far it got.
 			if cause := ctx.Err(); cause != nil {
-				return fmt.Errorf("cancelled after %d of %d queries: %w", done, stats.Queries, cause)
+				log.Printf("notify: matching stopped after %d of %d queries: %v", done, stats.Queries, cause)
+				return nil
 			}
 			stats.FailedQueries++
 			log.Printf("notify: match query %q failed: %v", query, err)

--- a/internal/engage/notify/match.go
+++ b/internal/engage/notify/match.go
@@ -20,8 +20,17 @@ import (
 // (avoid-skills) preference, so a subscription never receives a job older than
 // it or carrying a skill its subscriber currently avoids.
 //
-// One failing query is logged and skipped, not fatal — the same isolation as the
-// per-board ingest crawl.
+// One failing query is logged, COUNTED and skipped, not fatal — the same isolation as
+// the per-board ingest crawl, which also counts its failed boards rather than only
+// logging them. Without the count a pass in which every query failed printed
+// `queries=53 matched=0 ... failed=0` and exited 0, which is byte-identical to a pass
+// with genuinely nothing new to match; Stats.MatchingCollapsed is what the worker
+// turns that into an exit code with.
+//
+// A cancelled context ends the stage instead of counting the rest as failures: the
+// remaining queries would each fail instantly against the same dead context, so one
+// SIGTERM would otherwise read as "every saved search is broken". Same reasoning, and
+// the same shape, as forCompanyBatches in cmd/reindex.
 func (r *Runner) match(ctx context.Context, stats *Stats) error {
 	subs, err := r.store.ListActiveSubscriptions(ctx)
 	if err != nil {
@@ -39,11 +48,19 @@ func (r *Runner) match(ctx context.Context, stats *Stats) error {
 	}
 
 	stats.Queries = len(groups)
+	done := 0
 	for query, gsubs := range groups {
 		if err := r.matchQuery(ctx, query, gsubs, excludedByUser, stats); err != nil {
+			// `done`, not the failure count: what a cancellation has to report is how
+			// far the stage got, and this branch runs before the failure is counted.
+			if cause := ctx.Err(); cause != nil {
+				return fmt.Errorf("cancelled after %d of %d queries: %w", done, stats.Queries, cause)
+			}
+			stats.FailedQueries++
 			log.Printf("notify: match query %q failed: %v", query, err)
 			continue
 		}
+		done++
 	}
 	return nil
 }

--- a/internal/engage/notify/notify.go
+++ b/internal/engage/notify/notify.go
@@ -209,12 +209,26 @@ func DefaultConfig() Config {
 
 // Stats is the per-pass summary logged by the worker.
 type Stats struct {
-	Queries   int // distinct queries matched this pass
-	Matched   int // newly recorded (subscription, job) matches
-	Delivered int // digests sent
-	SoftSkips int // digests skipped (e.g. Telegram not linked)
-	Deferred  int // digests held back by quiet hours or a not-yet-due daily digest time
-	Failed    int // digest deliveries that errored
+	Queries       int // distinct queries matched this pass
+	FailedQueries int // distinct queries whose search or record step errored and was skipped
+	Matched       int // newly recorded (subscription, job) matches
+	Delivered     int // digests sent
+	SoftSkips     int // digests skipped (e.g. Telegram not linked)
+	Deferred      int // digests held back by quiet hours or a not-yet-due daily digest time
+	Failed        int // digest deliveries that errored
+}
+
+// MatchingCollapsed reports whether the MATCH stage produced nothing because every
+// query it ran failed — the outcome the run has to go red on.
+//
+// It is deliberately narrower than "any query failed". Matching is isolated per query
+// exactly like the per-board ingest crawl, and one saved search whose filter Meilisearch
+// dislikes must not fail a pass that served the other fifty-two; the count in the log is
+// what makes that one visible. All of them failing is a different statement — an
+// unreachable index or a broken credential — and it is the one this worker used to print
+// as `queries=53 matched=0 ... failed=0` before exiting 0.
+func (s Stats) MatchingCollapsed() bool {
+	return s.Queries > 0 && s.FailedQueries == s.Queries
 }
 
 // Runner executes matching + delivery passes.
@@ -242,8 +256,8 @@ func (r *Runner) Run(ctx context.Context) (Stats, error) {
 	if err := r.deliver(ctx, &stats); err != nil {
 		return stats, fmt.Errorf("deliver: %w", err)
 	}
-	log.Printf("notify: queries=%d matched=%d delivered=%d soft_skips=%d deferred=%d failed=%d",
-		stats.Queries, stats.Matched, stats.Delivered, stats.SoftSkips, stats.Deferred, stats.Failed)
+	log.Printf("notify: queries=%d failed_queries=%d matched=%d delivered=%d soft_skips=%d deferred=%d failed=%d",
+		stats.Queries, stats.FailedQueries, stats.Matched, stats.Delivered, stats.SoftSkips, stats.Deferred, stats.Failed)
 	return stats, nil
 }
 

--- a/internal/engage/notify/notify.go
+++ b/internal/engage/notify/notify.go
@@ -250,14 +250,19 @@ func New(store Store, searcher Searcher, notifier Notifier, cfg Config) *Runner 
 // delivery outage loses nothing.
 func (r *Runner) Run(ctx context.Context) (Stats, error) {
 	var stats Stats
+	// Deferred so the counters land on EVERY exit, not only the clean one. A pass that
+	// stopped part-way is the pass whose figures somebody actually wants, and printing
+	// them last meant the run that ended early was also the run that said nothing.
+	defer func() {
+		log.Printf("notify: queries=%d failed_queries=%d matched=%d delivered=%d soft_skips=%d deferred=%d failed=%d",
+			stats.Queries, stats.FailedQueries, stats.Matched, stats.Delivered, stats.SoftSkips, stats.Deferred, stats.Failed)
+	}()
 	if err := r.match(ctx, &stats); err != nil {
 		return stats, fmt.Errorf("match: %w", err)
 	}
 	if err := r.deliver(ctx, &stats); err != nil {
 		return stats, fmt.Errorf("deliver: %w", err)
 	}
-	log.Printf("notify: queries=%d failed_queries=%d matched=%d delivered=%d soft_skips=%d deferred=%d failed=%d",
-		stats.Queries, stats.FailedQueries, stats.Matched, stats.Delivered, stats.SoftSkips, stats.Deferred, stats.Failed)
 	return stats, nil
 }
 

--- a/internal/engage/notify/notify_test.go
+++ b/internal/engage/notify/notify_test.go
@@ -21,12 +21,28 @@ type fakeSearcher struct {
 	// byQuery maps a query's "q" value to the hits it should return; queries are
 	// keyed by the parsed q so a test can return different hits per query.
 	results []search.SearchResult
-	calls   []search.SearchParams
+	// errs is indexed by call number like results: a non-nil entry fails that one
+	// query, which is how the per-query isolation can be exercised without failing
+	// them all. err fails every call.
+	errs  []error
+	err   error
+	calls []search.SearchParams
 }
 
-func (f *fakeSearcher) Search(_ context.Context, p search.SearchParams) (search.SearchResult, error) {
+func (f *fakeSearcher) Search(ctx context.Context, p search.SearchParams) (search.SearchResult, error) {
 	f.calls = append(f.calls, p)
+	// A real index client fails a cancelled call rather than serving it, which is what
+	// makes a cancelled pass look like every query failing.
+	if err := ctx.Err(); err != nil {
+		return search.SearchResult{}, err
+	}
 	i := len(f.calls) - 1
+	if f.err != nil {
+		return search.SearchResult{}, f.err
+	}
+	if i < len(f.errs) && f.errs[i] != nil {
+		return search.SearchResult{}, f.errs[i]
+	}
 	if i < len(f.results) {
 		return f.results[i], nil
 	}
@@ -50,6 +66,12 @@ type fakeStore struct {
 	// recordedWebhookSuccesses records the user ids a successful webhook
 	// delivery stamped last_success_at for.
 	recordedWebhookSuccesses []int64
+
+	// deliveryErr and digestJobsErr fail the two reads deliverOne makes before it can
+	// send anything. Neither burns a delivery attempt, so the counter is the only trace
+	// they leave.
+	deliveryErr   error
+	digestJobsErr error
 
 	active      []db.ListActiveSubscriptionsRow
 	recorded    []recordedMatch
@@ -118,10 +140,13 @@ func (s *fakeStore) ClaimSubscriptionMatches(context.Context, db.ClaimSubscripti
 }
 
 func (s *fakeStore) GetSubscriptionForDelivery(_ context.Context, id int64) (db.GetSubscriptionForDeliveryRow, error) {
-	return s.delivery[id], nil
+	return s.delivery[id], s.deliveryErr
 }
 
 func (s *fakeStore) GetJobsForDigest(_ context.Context, ids []int64) ([]db.GetJobsForDigestRow, error) {
+	if s.digestJobsErr != nil {
+		return nil, s.digestJobsErr
+	}
 	out := make([]db.GetJobsForDigestRow, 0, len(ids))
 	for _, id := range ids {
 		if j, ok := s.digestJobs[id]; ok {

--- a/internal/engage/notify/silent_failure_test.go
+++ b/internal/engage/notify/silent_failure_test.go
@@ -73,6 +73,10 @@ func TestMatch_OneFailedQueryDoesNotCollapseThePass(t *testing.T) {
 // context: each would fail instantly and be counted, so one SIGTERM would report as
 // "every saved search is broken" — which is also exactly what MatchingCollapsed would
 // then turn into a red exit code.
+//
+// Stopping is also not FAILING. An unmatched query is matched by the next pass, exactly
+// as an undelivered claim is redelivered by it, so an ordinary `systemctl stop` must not
+// paint the unit red — the delivery loop already had that rule and matching now shares it.
 func TestMatch_CancellationStopsInsteadOfCountingEveryQueryFailed(t *testing.T) {
 	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	store := &fakeStore{active: []db.ListActiveSubscriptionsRow{
@@ -87,8 +91,9 @@ func TestMatch_CancellationStopsInsteadOfCountingEveryQueryFailed(t *testing.T) 
 	cancel()
 	stats, err := r.Run(ctx)
 
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("Run error = %v, want it to carry context.Canceled", err)
+	if err != nil {
+		t.Fatalf("Run error = %v, want none — a stop is not an outage, and the next pass "+
+			"matches what this one did not", err)
 	}
 	if stats.FailedQueries != 0 {
 		t.Errorf("failed queries = %d, want 0 — a cancellation is one event, not %d broken searches",

--- a/internal/engage/notify/silent_failure_test.go
+++ b/internal/engage/notify/silent_failure_test.go
@@ -1,0 +1,177 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/platform/db"
+	"github.com/strelov1/freehire/internal/search/search"
+)
+
+// A pass in which every saved-search query failed printed `queries=53 matched=0 ...
+// failed=0` and exited 0 — byte-identical to a pass with nothing new to match. The
+// isolation is deliberate (one bad filter must not fail the other fifty-two), but the
+// count is what makes it reportable, and there was none.
+func TestMatch_CountsEveryFailedQuerySoACollapsedPassIsVisible(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	store := &fakeStore{active: []db.ListActiveSubscriptionsRow{
+		{ID: 1, Query: "seniority=senior", StartAt: ts(base)},
+		{ID: 2, Query: "seniority=junior", StartAt: ts(base)},
+	}}
+	searcher := &fakeSearcher{err: errors.New("meilisearch: connection refused")}
+	r := New(store, searcher, &fakeNotifier{}, DefaultConfig())
+
+	stats, err := r.Run(context.Background())
+
+	// Still not fatal: the pass goes on to DELIVER whatever was already pending.
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Queries != 2 || stats.FailedQueries != 2 {
+		t.Errorf("stats = %d queries / %d failed, want 2/2", stats.Queries, stats.FailedQueries)
+	}
+	if !stats.MatchingCollapsed() {
+		t.Error("a pass whose every query failed must report matching as collapsed, or the worker exits 0")
+	}
+}
+
+// The other half of the same rule: one broken saved search must not turn the run red for
+// the fifty-two it served. Only ALL of them failing says the index or its credential is
+// gone.
+func TestMatch_OneFailedQueryDoesNotCollapseThePass(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	store := &fakeStore{active: []db.ListActiveSubscriptionsRow{
+		{ID: 1, Query: "seniority=senior", StartAt: ts(base)},
+		{ID: 2, Query: "seniority=junior", StartAt: ts(base)},
+	}}
+	searcher := &fakeSearcher{
+		errs:    []error{errors.New("invalid filter")},
+		results: []search.SearchResult{{}, {Hits: []search.JobDocument{hit(100, base.Add(time.Hour))}}},
+	}
+	r := New(store, searcher, &fakeNotifier{}, DefaultConfig())
+
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.FailedQueries != 1 {
+		t.Errorf("failed queries = %d, want 1", stats.FailedQueries)
+	}
+	if stats.MatchingCollapsed() {
+		t.Error("one failed query out of two must not collapse the pass")
+	}
+	if stats.Matched != 1 {
+		t.Errorf("matched = %d, want 1 — the surviving query still recorded its hit", stats.Matched)
+	}
+}
+
+// A cancelled pass must stop rather than walk the remaining queries against a dead
+// context: each would fail instantly and be counted, so one SIGTERM would report as
+// "every saved search is broken" — which is also exactly what MatchingCollapsed would
+// then turn into a red exit code.
+func TestMatch_CancellationStopsInsteadOfCountingEveryQueryFailed(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	store := &fakeStore{active: []db.ListActiveSubscriptionsRow{
+		{ID: 1, Query: "seniority=senior", StartAt: ts(base)},
+		{ID: 2, Query: "seniority=junior", StartAt: ts(base)},
+		{ID: 3, Query: "seniority=lead", StartAt: ts(base)},
+	}}
+	searcher := &fakeSearcher{}
+	r := New(store, searcher, &fakeNotifier{}, DefaultConfig())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	stats, err := r.Run(ctx)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run error = %v, want it to carry context.Canceled", err)
+	}
+	if stats.FailedQueries != 0 {
+		t.Errorf("failed queries = %d, want 0 — a cancellation is one event, not %d broken searches",
+			stats.FailedQueries, stats.FailedQueries)
+	}
+	if len(searcher.calls) != 1 {
+		t.Errorf("search calls = %d, want 1: the loop must break, not run every query into the dead context",
+			len(searcher.calls))
+	}
+}
+
+// deliverOne's two reads happen before anything is sent and release the claim on
+// failure, so they burn no attempt and leave no dead letter. Without a counter a pass
+// that could not read a single subscription printed `delivered=0 failed=0` and exited 0,
+// which reads as an idle queue.
+func TestDeliver_CountsASubscriptionItCouldNotRead(t *testing.T) {
+	store := &fakeStore{
+		claimed:     []db.ClaimSubscriptionMatchesRow{{SubscriptionID: 1, JobID: 10}},
+		deliveryErr: errors.New("connection reset"),
+	}
+	r := New(store, &fakeSearcher{}, &fakeNotifier{}, DefaultConfig())
+
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Failed != 1 {
+		t.Errorf("failed = %d, want 1", stats.Failed)
+	}
+	if len(store.released) != 1 {
+		t.Errorf("released claims = %d, want 1 — the matches must stay pending for the next pass", len(store.released))
+	}
+}
+
+func TestDeliver_CountsADigestWhoseJobsCouldNotBeRead(t *testing.T) {
+	store := &fakeStore{
+		claimed: []db.ClaimSubscriptionMatchesRow{{SubscriptionID: 1, JobID: 10}},
+		delivery: map[int64]db.GetSubscriptionForDeliveryRow{
+			1: {ID: 1, Channel: ChannelTelegram, TelegramChatID: pgtype.Int8{Int64: 555, Valid: true}},
+		},
+		digestJobsErr: errors.New("statement timeout"),
+	}
+	notifier := &fakeNotifier{}
+	r := New(store, &fakeSearcher{}, notifier, DefaultConfig())
+
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Failed != 1 {
+		t.Errorf("failed = %d, want 1", stats.Failed)
+	}
+	if len(notifier.sent) != 0 {
+		t.Errorf("digests sent = %d, want 0", len(notifier.sent))
+	}
+}
+
+// The delivery half of the cancellation rule: a stopped run must not report an outage
+// across every claimed subscription. Their leases expire and the next pass retries them.
+func TestDeliver_CancellationStopsWalkingClaimedSubscriptions(t *testing.T) {
+	store := &fakeStore{
+		claimed: []db.ClaimSubscriptionMatchesRow{
+			{SubscriptionID: 1, JobID: 10},
+			{SubscriptionID: 2, JobID: 11},
+			{SubscriptionID: 3, JobID: 12},
+		},
+		delivery: map[int64]db.GetSubscriptionForDeliveryRow{
+			1: {ID: 1, Channel: ChannelTelegram, TelegramChatID: pgtype.Int8{Int64: 555, Valid: true}},
+			2: {ID: 2, Channel: ChannelTelegram, TelegramChatID: pgtype.Int8{Int64: 666, Valid: true}},
+			3: {ID: 3, Channel: ChannelTelegram, TelegramChatID: pgtype.Int8{Int64: 777, Valid: true}},
+		},
+		digestJobsErr: errors.New("connection reset"),
+	}
+	r := New(store, &fakeSearcher{}, &fakeNotifier{}, DefaultConfig())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	stats, err := r.Run(ctx)
+
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Failed != 0 {
+		t.Errorf("failed = %d, want 0 — a cancelled run has not observed any delivery failing", stats.Failed)
+	}
+}

--- a/internal/platform/db/metrics.sql.go
+++ b/internal/platform/db/metrics.sql.go
@@ -11,6 +11,33 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const adzunaDescriptionOutboxMetrics = `-- name: AdzunaDescriptionOutboxMetrics :one
+SELECT
+    count(*) FILTER (WHERE failed_at IS NULL)     AS depth,
+    count(*) FILTER (WHERE failed_at IS NOT NULL) AS dead_letters,
+    COALESCE(
+        EXTRACT(EPOCH FROM now() - min(created_at) FILTER (WHERE failed_at IS NULL)),
+        0
+    )::float8                                     AS oldest_age_seconds
+FROM adzuna_description_outbox
+`
+
+type AdzunaDescriptionOutboxMetricsRow struct {
+	Depth            int64   `json:"depth"`
+	DeadLetters      int64   `json:"dead_letters"`
+	OldestAgeSeconds float64 `json:"oldest_age_seconds"`
+}
+
+// Same shape and same reasoning as SearchOutboxMetrics. Same bounded-drain question as
+// apply_form_outbox: ADZUNA_DESCRIPTION_MAX_PER_RUN defaults to 500 and is deliberately
+// conservative, so the depth is what says whether that figure is still the right one.
+func (q *Queries) AdzunaDescriptionOutboxMetrics(ctx context.Context) (AdzunaDescriptionOutboxMetricsRow, error) {
+	row := q.db.QueryRow(ctx, adzunaDescriptionOutboxMetrics)
+	var i AdzunaDescriptionOutboxMetricsRow
+	err := row.Scan(&i.Depth, &i.DeadLetters, &i.OldestAgeSeconds)
+	return i, err
+}
+
 const appleRevocationJobMetrics = `-- name: AppleRevocationJobMetrics :one
 SELECT
     count(*) FILTER (WHERE status IN ('pending', 'retry', 'processing')) AS depth,
@@ -41,6 +68,92 @@ func (q *Queries) AppleRevocationJobMetrics(ctx context.Context) (AppleRevocatio
 	row := q.db.QueryRow(ctx, appleRevocationJobMetrics)
 	var i AppleRevocationJobMetricsRow
 	err := row.Scan(&i.Depth, &i.DeadLetters, &i.OldestAgeSeconds)
+	return i, err
+}
+
+const applyFormOutboxMetrics = `-- name: ApplyFormOutboxMetrics :one
+SELECT
+    count(*) FILTER (WHERE failed_at IS NULL)     AS depth,
+    count(*) FILTER (WHERE failed_at IS NOT NULL) AS dead_letters,
+    COALESCE(
+        EXTRACT(EPOCH FROM now() - min(created_at) FILTER (WHERE failed_at IS NULL)),
+        0
+    )::float8                                     AS oldest_age_seconds
+FROM apply_form_outbox
+`
+
+type ApplyFormOutboxMetricsRow struct {
+	Depth            int64   `json:"depth"`
+	DeadLetters      int64   `json:"dead_letters"`
+	OldestAgeSeconds float64 `json:"oldest_age_seconds"`
+}
+
+// Same shape and same reasoning as SearchOutboxMetrics. The depth here is the one that
+// carries information rather than the dead letters: cmd/capture-apply-form takes
+// APPLY_FORM_MAX_PER_RUN entries a run against a backlog that started at ~185k, so
+// whether the drain is gaining on it is a question only this gauge answers.
+func (q *Queries) ApplyFormOutboxMetrics(ctx context.Context) (ApplyFormOutboxMetricsRow, error) {
+	row := q.db.QueryRow(ctx, applyFormOutboxMetrics)
+	var i ApplyFormOutboxMetricsRow
+	err := row.Scan(&i.Depth, &i.DeadLetters, &i.OldestAgeSeconds)
+	return i, err
+}
+
+const autoApplyQueueMetrics = `-- name: AutoApplyQueueMetrics :one
+SELECT
+    count(*) FILTER (
+        WHERE failed_at IS NULL
+          AND blocked_at IS NULL
+          AND tailored_cv_id IS NOT NULL
+          AND review_decision = 'approved'
+    )                                                                AS depth,
+    count(*) FILTER (WHERE failed_at IS NOT NULL)                    AS dead_letters,
+    count(*) FILTER (WHERE failed_at IS NULL AND blocked_at IS NOT NULL) AS blocked,
+    COALESCE(
+        EXTRACT(EPOCH FROM now() - min(created_at) FILTER (
+            WHERE failed_at IS NULL
+              AND blocked_at IS NULL
+              AND tailored_cv_id IS NOT NULL
+              AND review_decision = 'approved'
+        )),
+        0
+    )::float8                                                        AS oldest_age_seconds
+FROM auto_apply_queue
+`
+
+type AutoApplyQueueMetricsRow struct {
+	Depth            int64   `json:"depth"`
+	DeadLetters      int64   `json:"dead_letters"`
+	Blocked          int64   `json:"blocked"`
+	OldestAgeSeconds float64 `json:"oldest_age_seconds"`
+}
+
+// Same idea as SearchOutboxMetrics, but this queue has THREE terminal-ish states rather
+// than two, so it cannot be a copy of it.
+//
+// Depth is ClaimAutoApplyBatch's own predicate minus the lease: a submission attempt is
+// only ever claimed once the candidate has approved a tailored CV for it, so an entry
+// still awaiting that review is deliberately NOT depth — it is waiting on a person, and
+// counting it would make ordinary candidate behaviour look like a stalled worker.
+//
+// Blocked is the third state and the reason this needs its own gauge. `Park is not a
+// retry` (internal/application/autoapply/AGENTS.md): an attempt the sidecar could not
+// fully resolve is excluded from the claim by blocked_at without touching attempts, so
+// it is neither work still owed nor work retried to exhaustion. Folding it into either
+// of the other two counts would be a wrong reading, and leaving it out entirely is how a
+// population that no run will ever pick up again becomes invisible.
+//
+// failed_at wins over blocked_at where a row somehow carries both, so the three counts
+// stay mutually exclusive and a stacked graph reads correctly.
+func (q *Queries) AutoApplyQueueMetrics(ctx context.Context) (AutoApplyQueueMetricsRow, error) {
+	row := q.db.QueryRow(ctx, autoApplyQueueMetrics)
+	var i AutoApplyQueueMetricsRow
+	err := row.Scan(
+		&i.Depth,
+		&i.DeadLetters,
+		&i.Blocked,
+		&i.OldestAgeSeconds,
+	)
 	return i, err
 }
 
@@ -279,6 +392,67 @@ func (q *Queries) ProviderIngestHealth(ctx context.Context) ([]ProviderIngestHea
 		return nil, err
 	}
 	return items, nil
+}
+
+const pushTicketOutboxMetrics = `-- name: PushTicketOutboxMetrics :one
+SELECT
+    count(*)                                                    AS depth,
+    COALESCE(EXTRACT(EPOCH FROM now() - min(created_at)), 0)::float8 AS oldest_age_seconds
+FROM push_ticket_outbox
+`
+
+type PushTicketOutboxMetricsRow struct {
+	Depth            int64   `json:"depth"`
+	OldestAgeSeconds float64 `json:"oldest_age_seconds"`
+}
+
+// Depth and age only: this queue carries neither attempts nor failed_at, because
+// DeletePushTickets removes a ticket on every terminal receipt outcome and an
+// unprocessed batch (Expo unreachable) simply stays queued for the next run. There is no
+// give-up state to measure, so the caller publishes no dead-letter sample for it rather
+// than a zero that would claim a measurement nobody took.
+//
+// That makes the AGE the whole signal here. Every row is live by construction, so a
+// depth that merely grows says the fleet is busy, while an oldest entry older than a few
+// scheduled runs says cmd/push-receipts is not draining — the one failure this queue can
+// have and the one it would otherwise report as a perfectly healthy backlog.
+func (q *Queries) PushTicketOutboxMetrics(ctx context.Context) (PushTicketOutboxMetricsRow, error) {
+	row := q.db.QueryRow(ctx, pushTicketOutboxMetrics)
+	var i PushTicketOutboxMetricsRow
+	err := row.Scan(&i.Depth, &i.OldestAgeSeconds)
+	return i, err
+}
+
+const searchDeleteOutboxMetrics = `-- name: SearchDeleteOutboxMetrics :one
+SELECT
+    count(*) FILTER (WHERE failed_at IS NULL)     AS depth,
+    count(*) FILTER (WHERE failed_at IS NOT NULL) AS dead_letters,
+    COALESCE(
+        EXTRACT(EPOCH FROM now() - min(created_at) FILTER (WHERE failed_at IS NULL)),
+        0
+    )::float8                                     AS oldest_age_seconds
+FROM search_delete_outbox
+`
+
+type SearchDeleteOutboxMetricsRow struct {
+	Depth            int64   `json:"depth"`
+	DeadLetters      int64   `json:"dead_letters"`
+	OldestAgeSeconds float64 `json:"oldest_age_seconds"`
+}
+
+// Same shape and same reasoning as SearchOutboxMetrics, over the removal side of the
+// facet index.
+//
+// Its dead letters are the sharper half of the pair. An entry this queue gives up on
+// leaves a CLOSED posting in the live index — searchable, clickable, and 404ing on
+// arrival — until the next full rebuild sweeps it out, and search_delete_outbox's
+// UNIQUE (job_id) plus the ON CONFLICT DO NOTHING every enqueue carries means that
+// posting can never be queued for removal again in the meantime.
+func (q *Queries) SearchDeleteOutboxMetrics(ctx context.Context) (SearchDeleteOutboxMetricsRow, error) {
+	row := q.db.QueryRow(ctx, searchDeleteOutboxMetrics)
+	var i SearchDeleteOutboxMetricsRow
+	err := row.Scan(&i.Depth, &i.DeadLetters, &i.OldestAgeSeconds)
+	return i, err
 }
 
 const searchOutboxMetrics = `-- name: SearchOutboxMetrics :one

--- a/internal/platform/db/metrics.sql.go
+++ b/internal/platform/db/metrics.sql.go
@@ -107,8 +107,15 @@ SELECT
           AND tailored_cv_id IS NOT NULL
           AND review_decision = 'approved'
     )                                                                AS depth,
-    count(*) FILTER (WHERE failed_at IS NOT NULL)                    AS dead_letters,
-    count(*) FILTER (WHERE failed_at IS NULL AND blocked_at IS NOT NULL) AS blocked,
+    count(*) FILTER (
+        WHERE failed_at IS NOT NULL OR preview_failed_at IS NOT NULL
+    )                                                                AS dead_letters,
+    count(*) FILTER (
+        WHERE failed_at IS NULL
+          AND preview_failed_at IS NULL
+          AND blocked_at IS NOT NULL
+          AND review_decision IS DISTINCT FROM 'declined'
+    )                                                                AS blocked,
     COALESCE(
         EXTRACT(EPOCH FROM now() - min(created_at) FILTER (
             WHERE failed_at IS NULL
@@ -143,8 +150,22 @@ type AutoApplyQueueMetricsRow struct {
 // of the other two counts would be a wrong reading, and leaving it out entirely is how a
 // population that no run will ever pick up again becomes invisible.
 //
-// failed_at wins over blocked_at where a row somehow carries both, so the three counts
-// stay mutually exclusive and a stacked graph reads correctly.
+// A dead letter here has TWO markers, not one. preview_failed_at (migration 0140,
+// written by RecordAutoApplyPreviewFailure) retires the preview pass the same way
+// failed_at retires the submit pass, and a row carrying only the first is claimed by
+// neither: ClaimAutoApplyPreviewBatch excludes it directly, and ClaimAutoApplyBatch
+// excludes it because review_decision never reaches 'approved' without a preview. Reading
+// only failed_at is therefore the exact omission the paragraph above forbids, and
+// auto_apply_review_info.go already reads both for the same reason.
+//
+// A DECLINE is not parked work. DeclineAutoApplyReview reuses MarkAutoApplyBlocked's
+// vocabulary and stamps blocked_at, nothing ever deletes the row, so counting it would
+// make the gauge grow with ordinary candidate behaviour until the sidecar population it
+// exists to publish is a rounding error inside it. Both other readers of this state guard
+// the same way and say so — autoapply/status.go and auto_apply_enqueue.go.
+//
+// The dead-letter markers win over blocked_at where a row carries both, so the three
+// counts stay mutually exclusive and a stacked graph reads correctly.
 func (q *Queries) AutoApplyQueueMetrics(ctx context.Context) (AutoApplyQueueMetricsRow, error) {
 	row := q.db.QueryRow(ctx, autoApplyQueueMetrics)
 	var i AutoApplyQueueMetricsRow

--- a/internal/platform/db/metrics_integration_test.go
+++ b/internal/platform/db/metrics_integration_test.go
@@ -10,9 +10,11 @@ package db
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -234,5 +236,87 @@ func assertRoughlyAgo(t *testing.T, ts pgtype.Timestamptz, want time.Duration) {
 	}
 	if got := time.Since(ts.Time); got < want-time.Minute || got > want+time.Minute {
 		t.Errorf("timestamp is %v old, want ~%v", got, want)
+	}
+}
+
+// queueAutoApplyEntry adds one auto_apply_queue row in a named state. Everything here is a
+// column combination rather than a call to the real writers, because the point is what the
+// AGGREGATE makes of each state, not how a row reaches it.
+func queueAutoApplyEntry(t *testing.T, pool *pgxpool.Pool, externalID string, set string) {
+	t.Helper()
+	var userID int64
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO users (email) VALUES ($1) RETURNING id`, externalID+"@example.test").Scan(&userID); err != nil {
+		t.Fatalf("insert user for %s: %v", externalID, err)
+	}
+	jobID := queueJob(t, pool, externalID)
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO auto_apply_queue (user_id, job_id) VALUES ($1, $2)`, userID, jobID); err != nil {
+		t.Fatalf("insert auto_apply_queue entry %s: %v", externalID, err)
+	}
+	if set == "" {
+		return
+	}
+	// tailored_cv_id carries a foreign key, so the states that name one need a real CV
+	// rather than a generated uuid.
+	if strings.Contains(set, "tailored_cv_id") {
+		var cvID uuid.UUID
+		if err := pool.QueryRow(context.Background(),
+			`INSERT INTO cvs (user_id, title, data) VALUES ($1, 'CV', '{}') RETURNING id`, userID).Scan(&cvID); err != nil {
+			t.Fatalf("insert cv for %s: %v", externalID, err)
+		}
+		set = strings.ReplaceAll(set, "gen_random_uuid()", "'"+cvID.String()+"'::uuid")
+	}
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE auto_apply_queue SET `+set+` WHERE user_id = $1`, userID); err != nil {
+		t.Fatalf("shape auto_apply_queue entry %s (%s): %v", externalID, set, err)
+	}
+}
+
+// TestAutoApplyQueueMetricsCountsWhatAWorkerWillActuallyPickUp is the guard for the two
+// readings this aggregate is easiest to get wrong, both of which it shipped with.
+//
+// A DECLINE is not parked work. DeclineAutoApplyReview reuses the park vocabulary and
+// stamps blocked_at, and nothing ever deletes the row — so a `blocked` count that reads
+// blocked_at alone grows with ordinary candidate behaviour until the sidecar population it
+// exists to publish is a rounding error inside it, and the alert it was created for can
+// never be set.
+//
+// A dead letter has TWO markers. preview_failed_at retires the preview pass exactly as
+// failed_at retires the submit pass, and a row carrying only the first is claimed by
+// neither batch — the definition of a population that must not be left out.
+//
+// The three counts must also stay mutually exclusive: cmd/queue-metrics publishes them as
+// a stacked reading, so an entry counted twice is a graph that does not add up.
+func TestAutoApplyQueueMetricsCountsWhatAWorkerWillActuallyPickUp(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+
+	queueAutoApplyEntry(t, pool, "aa-owed", `tailored_cv_id = gen_random_uuid(), review_decision = 'approved'`)
+	queueAutoApplyEntry(t, pool, "aa-submit-dead", `failed_at = now()`)
+	queueAutoApplyEntry(t, pool, "aa-preview-dead", `preview_failed_at = now()`)
+	queueAutoApplyEntry(t, pool, "aa-parked", `blocked_at = now()`)
+	queueAutoApplyEntry(t, pool, "aa-declined", `blocked_at = now(), review_decision = 'declined'`)
+	// Awaiting the candidate: no decision yet, nothing wrong with it. In none of the three.
+	queueAutoApplyEntry(t, pool, "aa-awaiting", `tailored_cv_id = gen_random_uuid()`)
+
+	got, err := q.AutoApplyQueueMetrics(context.Background())
+	if err != nil {
+		t.Fatalf("AutoApplyQueueMetrics: %v", err)
+	}
+	if got.Depth != 1 {
+		t.Errorf("depth = %d, want 1 — only the approved entry is work a run will pick up", got.Depth)
+	}
+	if got.DeadLetters != 2 {
+		t.Errorf("dead letters = %d, want 2 — a preview that gave up is as unclaimable as a submit that did",
+			got.DeadLetters)
+	}
+	if got.Blocked != 1 {
+		t.Errorf("blocked = %d, want 1 — a candidate's own decline is not an attempt parked for want of data",
+			got.Blocked)
+	}
+	if sum := got.Depth + got.DeadLetters + got.Blocked; sum != 4 {
+		t.Errorf("the three counts total %d over 6 rows, want 4 — they are published stacked, so an "+
+			"entry counted twice is a graph that does not add up", sum)
 	}
 }

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -154,8 +154,22 @@ type Querier interface {
 	// of the other two counts would be a wrong reading, and leaving it out entirely is how a
 	// population that no run will ever pick up again becomes invisible.
 	//
-	// failed_at wins over blocked_at where a row somehow carries both, so the three counts
-	// stay mutually exclusive and a stacked graph reads correctly.
+	// A dead letter here has TWO markers, not one. preview_failed_at (migration 0140,
+	// written by RecordAutoApplyPreviewFailure) retires the preview pass the same way
+	// failed_at retires the submit pass, and a row carrying only the first is claimed by
+	// neither: ClaimAutoApplyPreviewBatch excludes it directly, and ClaimAutoApplyBatch
+	// excludes it because review_decision never reaches 'approved' without a preview. Reading
+	// only failed_at is therefore the exact omission the paragraph above forbids, and
+	// auto_apply_review_info.go already reads both for the same reason.
+	//
+	// A DECLINE is not parked work. DeclineAutoApplyReview reuses MarkAutoApplyBlocked's
+	// vocabulary and stamps blocked_at, nothing ever deletes the row, so counting it would
+	// make the gauge grow with ordinary candidate behaviour until the sidecar population it
+	// exists to publish is a rounding error inside it. Both other readers of this state guard
+	// the same way and say so — autoapply/status.go and auto_apply_enqueue.go.
+	//
+	// The dead-letter markers win over blocked_at where a row carries both, so the three
+	// counts stay mutually exclusive and a stacked graph reads correctly.
 	AutoApplyQueueMetrics(ctx context.Context) (AutoApplyQueueMetricsRow, error)
 	// Queries over the application record — the durable half of what used to live in
 	// user_jobs. See migrations/0064_applications.sql for why it is a table of its own.

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -56,6 +56,10 @@ type Querier interface {
 	// job_id and company_slug come off the application, like TrackApplicationByID: the row is
 	// the application, and the employer is denormalised on it.
 	AdvanceUserJobStage(ctx context.Context, arg AdvanceUserJobStageParams) error
+	// Same shape and same reasoning as SearchOutboxMetrics. Same bounded-drain question as
+	// apply_form_outbox: ADZUNA_DESCRIPTION_MAX_PER_RUN defaults to 500 and is deliberately
+	// conservative, so the depth is what says whether that figure is still the right one.
+	AdzunaDescriptionOutboxMetrics(ctx context.Context) (AdzunaDescriptionOutboxMetricsRow, error)
 	// Persist an agent-produced verdict for one message, scoped to the caller (0 rows
 	// when the message is not theirs → 404). This is SetEmailClassification's sibling:
 	// the same columns, written in one update, so a message is never left classified
@@ -104,6 +108,11 @@ type Querier interface {
 	// A visitor who did both is one visitor in each, so the two do not sum with an API
 	// count; the only relation between them is page_delta <= total_delta.
 	ApplyDailyView(ctx context.Context, arg []ApplyDailyViewParams) *ApplyDailyViewBatchResults
+	// Same shape and same reasoning as SearchOutboxMetrics. The depth here is the one that
+	// carries information rather than the dead letters: cmd/capture-apply-form takes
+	// APPLY_FORM_MAX_PER_RUN entries a run against a backlog that started at ~185k, so
+	// whether the drain is gaining on it is a question only this gauge answers.
+	ApplyFormOutboxMetrics(ctx context.Context) (ApplyFormOutboxMetricsRow, error)
 	// Records an approval. Guarded by review_decision IS NULL so a second attempt at an
 	// already-reviewed entry affects zero rows rather than overwriting a recorded decision —
 	// the handler reads the row first (GetAutoApplyQueueEntryForReview) to tell "already
@@ -130,6 +139,24 @@ type Querier interface {
 	// means the key is unknown, revoked, or expired; the caller treats pgx.ErrNoRows as 401
 	// and an insufficient scope as 403.
 	AuthenticateAPIKey(ctx context.Context, tokenHash string) (AuthenticateAPIKeyRow, error)
+	// Same idea as SearchOutboxMetrics, but this queue has THREE terminal-ish states rather
+	// than two, so it cannot be a copy of it.
+	//
+	// Depth is ClaimAutoApplyBatch's own predicate minus the lease: a submission attempt is
+	// only ever claimed once the candidate has approved a tailored CV for it, so an entry
+	// still awaiting that review is deliberately NOT depth — it is waiting on a person, and
+	// counting it would make ordinary candidate behaviour look like a stalled worker.
+	//
+	// Blocked is the third state and the reason this needs its own gauge. `Park is not a
+	// retry` (internal/application/autoapply/AGENTS.md): an attempt the sidecar could not
+	// fully resolve is excluded from the claim by blocked_at without touching attempts, so
+	// it is neither work still owed nor work retried to exhaustion. Folding it into either
+	// of the other two counts would be a wrong reading, and leaving it out entirely is how a
+	// population that no run will ever pick up again becomes invisible.
+	//
+	// failed_at wins over blocked_at where a row somehow carries both, so the three counts
+	// stay mutually exclusive and a stacked graph reads correctly.
+	AutoApplyQueueMetrics(ctx context.Context) (AutoApplyQueueMetricsRow, error)
 	// Queries over the application record — the durable half of what used to live in
 	// user_jobs. See migrations/0064_applications.sql for why it is a table of its own.
 	// Point one batch of pre-existing ledger events at the application they belong to.
@@ -1104,6 +1131,25 @@ type Querier interface {
 	// Note what this does NOT reap: entries whose job row is gone. For search_outbox that is
 	// garbage, since a vanished job cannot be indexed. Here it is the whole point — cmd/prune
 	// hard-deletes jobs, and their documents still have to leave the index.
+	//
+	// **It has no Go caller, and that is the decision, not an oversight.** No outbox in this
+	// repository reaps its dead letters — there is no DeleteDead… for search_outbox,
+	// enrichment_outbox or semantic_outbox — so scheduling this one would answer the
+	// give-up question differently for one queue than for the other nine. Worse, running it
+	// would delete the only record that a removal was abandoned, which is exactly what
+	// `freehire_queue_dead_letters{queue="search_delete_outbox"}` now publishes. Reaping is
+	// how a stranded population stops being visible, not how it gets fixed.
+	//
+	// What it would ALSO not fix: every enqueue is `ON CONFLICT (job_id) DO NOTHING` against
+	// a UNIQUE key, so while a dead-lettered entry sits here that posting cannot be re-queued
+	// for removal — not by a later close, and not by cmd/prune's hard delete. Deleting the
+	// entry would re-open that door only for a posting something closes AGAIN, which a
+	// closed posting is not. The bounded harm is the reason this is left as it stands: a
+	// full `make reindex` streams only OPEN jobs into the fresh index, so the stale document
+	// leaves on the next scheduled rebuild regardless. Re-arming the row (an `ON CONFLICT …
+	// DO UPDATE` that clears failed_at where it is set) is the fix if the gauge ever shows
+	// this happening; it is ten identical CTEs across jobs.sql and pruning.sql, and worth
+	// doing on evidence rather than on the strength of the reading above.
 	DeleteDeadSearchDeleteOutbox(ctx context.Context, cutoff pgtype.Timestamptz) (int64, error)
 	// Void a debit taken as a RESERVATION for work that then produced nothing.
 	//
@@ -3806,6 +3852,17 @@ type Querier interface {
 	// The `count = 1` condition is what makes this safe: a phrase two people have searched
 	// survives however old it is, so a seasonal query does not vanish between seasons.
 	PruneSearchQueries(ctx context.Context, before pgtype.Timestamptz) (int64, error)
+	// Depth and age only: this queue carries neither attempts nor failed_at, because
+	// DeletePushTickets removes a ticket on every terminal receipt outcome and an
+	// unprocessed batch (Expo unreachable) simply stays queued for the next run. There is no
+	// give-up state to measure, so the caller publishes no dead-letter sample for it rather
+	// than a zero that would claim a measurement nobody took.
+	//
+	// That makes the AGE the whole signal here. Every row is live by construction, so a
+	// depth that merely grows says the fleet is busy, while an oldest entry older than a few
+	// scheduled runs says cmd/push-receipts is not draining — the one failure this queue can
+	// have and the one it would otherwise report as a perfectly healthy backlog.
+	PushTicketOutboxMetrics(ctx context.Context) (PushTicketOutboxMetricsRow, error)
 	// One row per company with its current open-count and the open-count as of @prev_ts,
 	// from a single scan of jobs over canonical rows only (same count(*) FILTER idiom as
 	// insights_role_stats). open_count uses closed_at IS NULL (open now); open_count_prev
@@ -4489,6 +4546,15 @@ type Querier interface {
 	// Save (bookmark) a job for a user. Idempotent and independent of a prior view:
 	// it inserts the row (viewed_at defaults) or refreshes saved_at in place.
 	SaveJob(ctx context.Context, arg SaveJobParams) (SaveJobRow, error)
+	// Same shape and same reasoning as SearchOutboxMetrics, over the removal side of the
+	// facet index.
+	//
+	// Its dead letters are the sharper half of the pair. An entry this queue gives up on
+	// leaves a CLOSED posting in the live index — searchable, clickable, and 404ing on
+	// arrival — until the next full rebuild sweeps it out, and search_delete_outbox's
+	// UNIQUE (job_id) plus the ON CONFLICT DO NOTHING every enqueue carries means that
+	// posting can never be queued for removal again in the meantime.
+	SearchDeleteOutboxMetrics(ctx context.Context) (SearchDeleteOutboxMetricsRow, error)
 	// Aggregates behind cmd/queue-metrics, the worker that publishes pipeline depth to
 	// Prometheus. Every query here is read-only and takes no locks by design: it runs once a
 	// minute alongside ingest, search-drain, and reindex, and must never be the reason one of

--- a/internal/platform/db/queries/metrics.sql
+++ b/internal/platform/db/queries/metrics.sql
@@ -143,8 +143,22 @@ FROM adzuna_description_outbox;
 -- of the other two counts would be a wrong reading, and leaving it out entirely is how a
 -- population that no run will ever pick up again becomes invisible.
 --
--- failed_at wins over blocked_at where a row somehow carries both, so the three counts
--- stay mutually exclusive and a stacked graph reads correctly.
+-- A dead letter here has TWO markers, not one. preview_failed_at (migration 0140,
+-- written by RecordAutoApplyPreviewFailure) retires the preview pass the same way
+-- failed_at retires the submit pass, and a row carrying only the first is claimed by
+-- neither: ClaimAutoApplyPreviewBatch excludes it directly, and ClaimAutoApplyBatch
+-- excludes it because review_decision never reaches 'approved' without a preview. Reading
+-- only failed_at is therefore the exact omission the paragraph above forbids, and
+-- auto_apply_review_info.go already reads both for the same reason.
+--
+-- A DECLINE is not parked work. DeclineAutoApplyReview reuses MarkAutoApplyBlocked's
+-- vocabulary and stamps blocked_at, nothing ever deletes the row, so counting it would
+-- make the gauge grow with ordinary candidate behaviour until the sidecar population it
+-- exists to publish is a rounding error inside it. Both other readers of this state guard
+-- the same way and say so — autoapply/status.go and auto_apply_enqueue.go.
+--
+-- The dead-letter markers win over blocked_at where a row carries both, so the three
+-- counts stay mutually exclusive and a stacked graph reads correctly.
 SELECT
     count(*) FILTER (
         WHERE failed_at IS NULL
@@ -152,8 +166,15 @@ SELECT
           AND tailored_cv_id IS NOT NULL
           AND review_decision = 'approved'
     )                                                                AS depth,
-    count(*) FILTER (WHERE failed_at IS NOT NULL)                    AS dead_letters,
-    count(*) FILTER (WHERE failed_at IS NULL AND blocked_at IS NOT NULL) AS blocked,
+    count(*) FILTER (
+        WHERE failed_at IS NOT NULL OR preview_failed_at IS NOT NULL
+    )                                                                AS dead_letters,
+    count(*) FILTER (
+        WHERE failed_at IS NULL
+          AND preview_failed_at IS NULL
+          AND blocked_at IS NOT NULL
+          AND review_decision IS DISTINCT FROM 'declined'
+    )                                                                AS blocked,
     COALESCE(
         EXTRACT(EPOCH FROM now() - min(created_at) FILTER (
             WHERE failed_at IS NULL

--- a/internal/platform/db/queries/metrics.sql
+++ b/internal/platform/db/queries/metrics.sql
@@ -82,6 +82,105 @@ SELECT
     )::float8                                                            AS oldest_age_seconds
 FROM apple_revocation_jobs;
 
+-- name: SearchDeleteOutboxMetrics :one
+-- Same shape and same reasoning as SearchOutboxMetrics, over the removal side of the
+-- facet index.
+--
+-- Its dead letters are the sharper half of the pair. An entry this queue gives up on
+-- leaves a CLOSED posting in the live index — searchable, clickable, and 404ing on
+-- arrival — until the next full rebuild sweeps it out, and search_delete_outbox's
+-- UNIQUE (job_id) plus the ON CONFLICT DO NOTHING every enqueue carries means that
+-- posting can never be queued for removal again in the meantime.
+SELECT
+    count(*) FILTER (WHERE failed_at IS NULL)     AS depth,
+    count(*) FILTER (WHERE failed_at IS NOT NULL) AS dead_letters,
+    COALESCE(
+        EXTRACT(EPOCH FROM now() - min(created_at) FILTER (WHERE failed_at IS NULL)),
+        0
+    )::float8                                     AS oldest_age_seconds
+FROM search_delete_outbox;
+
+-- name: ApplyFormOutboxMetrics :one
+-- Same shape and same reasoning as SearchOutboxMetrics. The depth here is the one that
+-- carries information rather than the dead letters: cmd/capture-apply-form takes
+-- APPLY_FORM_MAX_PER_RUN entries a run against a backlog that started at ~185k, so
+-- whether the drain is gaining on it is a question only this gauge answers.
+SELECT
+    count(*) FILTER (WHERE failed_at IS NULL)     AS depth,
+    count(*) FILTER (WHERE failed_at IS NOT NULL) AS dead_letters,
+    COALESCE(
+        EXTRACT(EPOCH FROM now() - min(created_at) FILTER (WHERE failed_at IS NULL)),
+        0
+    )::float8                                     AS oldest_age_seconds
+FROM apply_form_outbox;
+
+-- name: AdzunaDescriptionOutboxMetrics :one
+-- Same shape and same reasoning as SearchOutboxMetrics. Same bounded-drain question as
+-- apply_form_outbox: ADZUNA_DESCRIPTION_MAX_PER_RUN defaults to 500 and is deliberately
+-- conservative, so the depth is what says whether that figure is still the right one.
+SELECT
+    count(*) FILTER (WHERE failed_at IS NULL)     AS depth,
+    count(*) FILTER (WHERE failed_at IS NOT NULL) AS dead_letters,
+    COALESCE(
+        EXTRACT(EPOCH FROM now() - min(created_at) FILTER (WHERE failed_at IS NULL)),
+        0
+    )::float8                                     AS oldest_age_seconds
+FROM adzuna_description_outbox;
+
+-- name: AutoApplyQueueMetrics :one
+-- Same idea as SearchOutboxMetrics, but this queue has THREE terminal-ish states rather
+-- than two, so it cannot be a copy of it.
+--
+-- Depth is ClaimAutoApplyBatch's own predicate minus the lease: a submission attempt is
+-- only ever claimed once the candidate has approved a tailored CV for it, so an entry
+-- still awaiting that review is deliberately NOT depth — it is waiting on a person, and
+-- counting it would make ordinary candidate behaviour look like a stalled worker.
+--
+-- Blocked is the third state and the reason this needs its own gauge. `Park is not a
+-- retry` (internal/application/autoapply/AGENTS.md): an attempt the sidecar could not
+-- fully resolve is excluded from the claim by blocked_at without touching attempts, so
+-- it is neither work still owed nor work retried to exhaustion. Folding it into either
+-- of the other two counts would be a wrong reading, and leaving it out entirely is how a
+-- population that no run will ever pick up again becomes invisible.
+--
+-- failed_at wins over blocked_at where a row somehow carries both, so the three counts
+-- stay mutually exclusive and a stacked graph reads correctly.
+SELECT
+    count(*) FILTER (
+        WHERE failed_at IS NULL
+          AND blocked_at IS NULL
+          AND tailored_cv_id IS NOT NULL
+          AND review_decision = 'approved'
+    )                                                                AS depth,
+    count(*) FILTER (WHERE failed_at IS NOT NULL)                    AS dead_letters,
+    count(*) FILTER (WHERE failed_at IS NULL AND blocked_at IS NOT NULL) AS blocked,
+    COALESCE(
+        EXTRACT(EPOCH FROM now() - min(created_at) FILTER (
+            WHERE failed_at IS NULL
+              AND blocked_at IS NULL
+              AND tailored_cv_id IS NOT NULL
+              AND review_decision = 'approved'
+        )),
+        0
+    )::float8                                                        AS oldest_age_seconds
+FROM auto_apply_queue;
+
+-- name: PushTicketOutboxMetrics :one
+-- Depth and age only: this queue carries neither attempts nor failed_at, because
+-- DeletePushTickets removes a ticket on every terminal receipt outcome and an
+-- unprocessed batch (Expo unreachable) simply stays queued for the next run. There is no
+-- give-up state to measure, so the caller publishes no dead-letter sample for it rather
+-- than a zero that would claim a measurement nobody took.
+--
+-- That makes the AGE the whole signal here. Every row is live by construction, so a
+-- depth that merely grows says the fleet is busy, while an oldest entry older than a few
+-- scheduled runs says cmd/push-receipts is not draining — the one failure this queue can
+-- have and the one it would otherwise report as a perfectly healthy backlog.
+SELECT
+    count(*)                                                    AS depth,
+    COALESCE(EXTRACT(EPOCH FROM now() - min(created_at)), 0)::float8 AS oldest_age_seconds
+FROM push_ticket_outbox;
+
 -- name: BoardHealthMetrics :one
 -- The ingest board fleet split into three mutually exclusive states, so the published
 -- gauges sum to the fleet size and a stacked graph reads correctly.

--- a/internal/platform/db/queries/search_delete_outbox.sql
+++ b/internal/platform/db/queries/search_delete_outbox.sql
@@ -59,6 +59,25 @@ RETURNING failed_at;
 -- Note what this does NOT reap: entries whose job row is gone. For search_outbox that is
 -- garbage, since a vanished job cannot be indexed. Here it is the whole point — cmd/prune
 -- hard-deletes jobs, and their documents still have to leave the index.
+--
+-- **It has no Go caller, and that is the decision, not an oversight.** No outbox in this
+-- repository reaps its dead letters — there is no DeleteDead… for search_outbox,
+-- enrichment_outbox or semantic_outbox — so scheduling this one would answer the
+-- give-up question differently for one queue than for the other nine. Worse, running it
+-- would delete the only record that a removal was abandoned, which is exactly what
+-- `freehire_queue_dead_letters{queue="search_delete_outbox"}` now publishes. Reaping is
+-- how a stranded population stops being visible, not how it gets fixed.
+--
+-- What it would ALSO not fix: every enqueue is `ON CONFLICT (job_id) DO NOTHING` against
+-- a UNIQUE key, so while a dead-lettered entry sits here that posting cannot be re-queued
+-- for removal — not by a later close, and not by cmd/prune's hard delete. Deleting the
+-- entry would re-open that door only for a posting something closes AGAIN, which a
+-- closed posting is not. The bounded harm is the reason this is left as it stands: a
+-- full `make reindex` streams only OPEN jobs into the fresh index, so the stale document
+-- leaves on the next scheduled rebuild regardless. Re-arming the row (an `ON CONFLICT …
+-- DO UPDATE` that clears failed_at where it is set) is the fix if the gauge ever shows
+-- this happening; it is ten identical CTEs across jobs.sql and pruning.sql, and worth
+-- doing on evidence rather than on the strength of the reading above.
 DELETE FROM search_delete_outbox
 WHERE failed_at IS NOT NULL
   AND failed_at < sqlc.arg(cutoff);

--- a/internal/platform/db/search_delete_outbox.sql.go
+++ b/internal/platform/db/search_delete_outbox.sql.go
@@ -101,6 +101,25 @@ WHERE failed_at IS NOT NULL
 // Note what this does NOT reap: entries whose job row is gone. For search_outbox that is
 // garbage, since a vanished job cannot be indexed. Here it is the whole point — cmd/prune
 // hard-deletes jobs, and their documents still have to leave the index.
+//
+// **It has no Go caller, and that is the decision, not an oversight.** No outbox in this
+// repository reaps its dead letters — there is no DeleteDead… for search_outbox,
+// enrichment_outbox or semantic_outbox — so scheduling this one would answer the
+// give-up question differently for one queue than for the other nine. Worse, running it
+// would delete the only record that a removal was abandoned, which is exactly what
+// `freehire_queue_dead_letters{queue="search_delete_outbox"}` now publishes. Reaping is
+// how a stranded population stops being visible, not how it gets fixed.
+//
+// What it would ALSO not fix: every enqueue is `ON CONFLICT (job_id) DO NOTHING` against
+// a UNIQUE key, so while a dead-lettered entry sits here that posting cannot be re-queued
+// for removal — not by a later close, and not by cmd/prune's hard delete. Deleting the
+// entry would re-open that door only for a posting something closes AGAIN, which a
+// closed posting is not. The bounded harm is the reason this is left as it stands: a
+// full `make reindex` streams only OPEN jobs into the fresh index, so the stale document
+// leaves on the next scheduled rebuild regardless. Re-arming the row (an `ON CONFLICT …
+// DO UPDATE` that clears failed_at where it is set) is the fix if the gauge ever shows
+// this happening; it is ten identical CTEs across jobs.sql and pruning.sql, and worth
+// doing on evidence rather than on the strength of the reading above.
 func (q *Queries) DeleteDeadSearchDeleteOutbox(ctx context.Context, cutoff pgtype.Timestamptz) (int64, error) {
 	result, err := q.db.Exec(ctx, deleteDeadSearchDeleteOutbox, cutoff)
 	if err != nil {

--- a/internal/platform/worker/AGENTS.md
+++ b/internal/platform/worker/AGENTS.md
@@ -90,7 +90,7 @@ trailing board path if there is one, so ~140 ingest boards land in distinct seri
 answers *is the worker alive*: a hung run never stamps a completion, so last-run age
 covers both "hung" and "timer stopped".
 
-**Per pipeline, by `cmd/queue-metrics`** — `freehire_queue_{depth,dead_letters,oldest_age_seconds}`
+**Per pipeline, by `cmd/queue-metrics`** — `freehire_queue_{depth,dead_letters,blocked,oldest_age_seconds}`
 labelled by `queue`, `freehire_boards_total` labelled by `state`,
 `freehire_catalogue_newest_job_timestamp_seconds`, and
 `freehire_notify_{pending_subscriptions,oldest_pending_age_seconds}`. This answers *is the
@@ -104,6 +104,17 @@ An oldest-pending age climbing past a few passes is the signal; `failed` never m
 never claimed again, and identical to what an empty queue prints. **A queue this worker does
 not measure has no signal at all**: the per-run family above stayed green throughout, since
 the binary kept exiting 0. Adding an outbox means adding it here.
+
+All ten pipeline queues are measured, which they were not: `search_delete_outbox`,
+`apply_form_outbox`, `adzuna_description_outbox`, `auto_apply_queue` and
+`push_ticket_outbox` were unmeasured while the rule above was already written down. Two of
+them do not fit the three-gauge shape and so are the reason the counts are OPTIONAL:
+`auto_apply_queue` has a third terminal state (a parked attempt needs new data, not another
+try — `freehire_queue_blocked`), and `push_ticket_outbox` carries neither `attempts` nor
+`failed_at`, so it publishes NO dead-letter sample rather than a permanent zero. Absent and
+zero differ in the other direction too: a zero would read as "given up on nothing", a claim
+about a measurement nobody took. **`freehire_queue_blocked` is new, so nothing in
+freehire-ops graphs or alerts on it yet** — adding the gauge here does not surface it there.
 These names are a contract with the dashboard and alert rules in `freehire-ops`, which
 cannot be compiled against this repo — `cmd/queue-metrics/render_test.go` pins the exact
 exposition text so a rename is a visible edit rather than a silent breakage.


### PR DESCRIPTION
From the second review pass. One theme: work that failed without saying so — to Sentry, to the metrics, or to the exit code.

### Thirteen declared 500s never reached Sentry

`classify` returned `report=false` for **any** `*fiber.Error`, including one carrying 500. A caller who wrapped a failure in `fiber.NewError(500, …)` to give the user a readable message thereby removed it from the error inbox — and seven of the thirteen did not log either. `cmd/server/main.go` claimed the opposite in a comment.

The decisive contrast was the same function's neighbour: the assistant's stream path takes its error, logs it, and calls `reportStreamFault` with the comment "this is for us — and for Sentry, which would otherwise never hear about it". The synchronous auto-apply route sent the same error past that decision.

It now decides on the status, by **equality** and not `>= 500`: 42 sites answer 503 meaning "this deployment has no Meilisearch/LLM", and those must stay unreported. The five sites that discarded the cause now wrap it. The cost is stated rather than hidden: the response body becomes generic, and the Inngest step error that embeds it loses the specific wording.

Two ghost-signal reads that dropped their errors entirely — no log, no metric, no capture, and no QueryTracer anywhere to catch them — now log, classifying cancellation on the **context** rather than the error.

### A run where everything failed printed a clean line and exited 0

`cmd/notify` logged and skipped a failed query but carried no counter for it, so a pass where every query failed printed `queries=53 matched=0 … failed=0` and exited 0. `REINDEX_DEDUP_ONLY=1` short-circuited past its own outcome — all three passes are log-and-continue because "a marker refresh must not stop the rebuild that follows", and in that mode there is no rebuild. And five of ten queues were unmeasured, in a worker whose own AGENTS.md makes inclusion the rule and where both late-added queues arrived after incidents.

`fitanalysis` had one boolean answering two questions: a cache write that failed still set `succeeded`, and that flag is what the claim publishes to followers — so a follower was served a stale row. Split into `produced` (the credit gate) and `cached` (the follower gate).

### Review round

The second commit fixes three blockers, two of them in the gauges this PR adds. A candidate's **decline** was being published as parked work — it reuses the park vocabulary and stamps `blocked_at`, nothing deletes the row, so the gauge grew with ordinary traffic until the population it exists for was a rounding error. And **preview** dead letters were in no gauge at all: this queue has two terminal markers and a row carrying only `preview_failed_at` is claimed by neither batch. Both are SQL and unreachable from the collector's fake, so they now have an integration test that seeds all six states against a real Postgres.

The third: the marker-only mode's exit line had no test — reverting it left the package green, because the test beside it re-derived `worker.ExitCode` itself instead of calling what `run()` calls.

Also corrected: the two notify stages disagreed about a stop (one exited 1, the other 0), and the error path returned before the summary — throwing away the counters of exactly the pass somebody wants to read. Matching now follows the rule delivery already argued in place, and the summary moved into a `defer`.

### Checks

`gofmt`, `build`, `vet`, `go test ./...`, `go vet -tags=integration ./...`, `make sqlc` (no drift), `check-links`, `golangci-lint --new-from-rev` (0). Every new test mutation-checked; the reviewer independently re-ran all sixteen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Queue monitoring now covers search deletion, form application, Adzuna descriptions, auto-apply, and push-ticket processing.
  - Auto-apply monitoring distinguishes blocked work, and queue metrics omit unavailable states instead of reporting misleading zeroes.

- **Bug Fixes**
  - Notification and deduplication jobs now report failures accurately and exit unsuccessfully when processing cannot complete.
  - Cache-write failures no longer appear successful to waiting requests, preventing stale results.

- **Reliability**
  - API errors preserve more accurate status handling and diagnostics, while ghost-signal lookup failures are now logged instead of being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->