### PR TITLE
Lift undici off the nine advisories fixed in 8.10.2

### DIFF
--- a/design-system/pnpm-lock.yaml
+++ b/design-system/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   postcss@<8.5.23: 8.5.23
+  undici@<8.10.2: 8.10.2
 
 importers:
 
@@ -2725,8 +2726,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici@8.10.0:
-    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+  undici@8.10.2:
+    resolution: {integrity: sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==}
     engines: {node: '>=22.19.0'}
 
   unplugin@2.3.11:
@@ -4546,7 +4547,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 8.10.0
+      undici: 8.10.2
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -5272,7 +5273,7 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  undici@8.10.0: {}
+  undici@8.10.2: {}
 
   unplugin@2.3.11:
     dependencies:

--- a/design-system/pnpm-workspace.yaml
+++ b/design-system/pnpm-workspace.yaml
@@ -13,3 +13,11 @@ strictDepBuilds: false
 # arbitrary local .map files. Pulled in transitively by vite (Storybook builder).
 overrides:
   postcss@<8.5.23: 8.5.23
+  # The same floor web/pnpm-workspace.yaml carries and for the same nine
+  # advisories, two critical — see that file for which ones and why the bump is
+  # a floor inside jsdom's own ^8.9.0 range rather than a version it has not
+  # seen. Reached here through vitest's jsdom environment, so it is a test-time
+  # dependency; the pin is here anyway because snyk scans this package
+  # separately and a dependency this component ships with should not read as
+  # vulnerable on its own terms.
+  undici@<8.10.2: 8.10.2

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   postcss@<8.5.23: 8.5.23
   nanoid@<3.3.18: 3.3.18
   dompurify@<3.4.13: 3.4.13
+  undici@<8.10.2: 8.10.2
 
 importers:
 
@@ -2861,6 +2862,7 @@ packages:
   isomorphic-dompurify@3.22.0:
     resolution: {integrity: sha512-cz/BkSODnQir4IV2quqbuEHhAGz4MAYGvhoemsxuwMpY/oZbRHlNjPLPyIQ0fdULiwDPUE+OHPwWb6XTEiNk1A==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    deprecated: Raised the minimum Node.js version (breaking) without a major bump. Use 4.x for the same code with correct semver, or pin 3.19.0 for Node < 22.22.2.
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -3810,8 +3812,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@8.10.0:
-    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+  undici@8.10.2:
+    resolution: {integrity: sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==}
     engines: {node: '>=22.19.0'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -6938,7 +6940,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 8.10.0
+      undici: 8.10.2
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -7936,7 +7938,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@8.10.0: {}
+  undici@8.10.2: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -26,3 +26,14 @@ overrides:
   # subtree with executable content, allowing XSS despite sanitization.
   # isomorphic-dompurify is used directly for XSS sanitization in this app.
   dompurify@<3.4.13: 3.4.13
+  # Nine advisories fixed in 8.10.2, two of them critical: BalancedPool drops
+  # function-valued connection options, so a custom checkServerIdentity is
+  # silently stripped and a malicious certificate passes validation
+  # (SNYK-JS-UNDICI-19635218); and an interceptor trusts caller-controlled
+  # request metadata over the dispatcher's own origin (SNYK-JS-UNDICI-19635224).
+  # Reached transitively as isomorphic-dompurify > jsdom > undici, whose own
+  # range is ^8.9.0 — so this is a floor inside what jsdom already accepts, not
+  # a version it has never seen. The alternative Snyk proposes, a major bump of
+  # isomorphic-dompurify to 4.x, moves nothing: 4.1.0 declares the same
+  # jsdom ^30.0.0 and dompurify ^3.4.12, and differs only in its Node engines.
+  undici@<8.10.2: 8.10.2


### PR DESCRIPTION
Snyk has been red on `main` — this is that, not a regression from any recent change.

`undici` arrives transitively as `isomorphic-dompurify > jsdom > undici`, and both lockfiles pinned `8.10.0`. Nine advisories are fixed in `8.10.2`, two of them **critical**:

- **`BalancedPool` drops function-valued connection options** — a custom `checkServerIdentity` is silently stripped during serialization, so a malicious certificate passes validation (`SNYK-JS-UNDICI-19635218`).
- **An interceptor trusts caller-controlled request metadata** over the dispatcher's own origin (`SNYK-JS-UNDICI-19635224`).

Seven more ride with them: cache poisoning, `Set-Cookie` stored in a shared cache, an unbounded decompression interceptor, a WebSocket subprotocol path that terminates the process.

### Why it matters here

Not a dev-only tree in `web/`. `isomorphic-dompurify` is a **runtime** dependency, and `web/src/lib/markdown.ts` is the XSS guard over untrusted model prose before it reaches `{@html}` — the isomorphic build is chosen precisely so that guard also holds in SSR. In `design-system/` it is test-time (vitest's jsdom environment); pinned there anyway, because snyk scans that package on its own terms and a component library should not ship reading as vulnerable.

### Why not Snyk's own suggestion

It advises a major bump of `isomorphic-dompurify` to 4.x. That moves nothing: `4.1.0` declares the same `jsdom ^30.0.0` and the same `dompurify ^3.4.12`, and differs from `3.22.0` only in its Node `engines`. What fixes the finding is `undici` itself — and `8.10.2` sits inside jsdom's own `^8.9.0` range, so this is a floor within what jsdom already accepts rather than a version it has never seen.

### Why an override rather than a lockfile bump

`pnpm update undici --depth Infinity` also carried a dozen unrelated patch bumps (csstools, browserslist, electron-to-chromium), and left nothing recording *why* undici may not drift back down. The override goes in the file that already holds four of them, each beside the advisory it answers.

Both lockfiles move `undici` and nothing else.

### Checks

`web`: 142 test files / 1614 tests green — including the 18 that pin the sanitizer's allowlist. `design-system`: 19 / 156 green. `pnpm lint` clean (pre-existing warnings only). Both installs verified with `--frozen-lockfile`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Updated a transitive networking component to version 8.10.2 or later.
  - Addresses multiple reported vulnerabilities, including critical issues affecting server identity checks and request handling.

- **Maintenance**
  - Applied the security update consistently across web and design-system workspace environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->