### PR TITLE
Aim the Adzuna budget at postings we do not already hold

### DIFF
--- a/cmd/liveness/main.go
+++ b/cmd/liveness/main.go
@@ -129,7 +129,18 @@ const staleCutoff = sources.DefaultSweepGrace
 // other), all sharing the identical unprobeable-URL shape. Matching by prefix against the
 // live registry (see the derivation in run()) means a newly onboarded market is covered
 // automatically instead of silently falling through an enumerated list.
-var expireDespiteRegisteredPrefixes = []string{"whatjobs"}
+//
+// adzuna reaches the same classification by a different route, and the obvious objection —
+// "its url is an adzuna page, so just probe it" — was tested rather than assumed. Following
+// 40 stored urls on 2026-09-06: roughly three quarters answered 403 Access Denied, Adzuna's
+// bot protection on the `…/land/ad/<id>` tracking redirect we store (it carries the
+// attribution parameters that credit a click to this publisher, so it is not the employer's
+// page and never will be). A 403 classifies uncertain, correctly — it is the platform
+// declining to answer, not a verdict — so a probe can never close an adzuna posting, however
+// long it runs. The leak on the other side is new as of the date-ordered crawl: a bounded
+// crawl reading newest-first never revisits an ageing posting, so the sweep stops being
+// offered it. Both halves of the membership test therefore hold.
+var expireDespiteRegisteredPrefixes = []string{"whatjobs", "adzuna"}
 
 func main() {
 	worker.Main(run)
@@ -213,8 +224,15 @@ func run() int {
 	}
 
 	// Derived from the live registry rather than enumerated (see
-	// expireDespiteRegisteredPrefixes) — every whatjobs market this run, no drift guard
-	// needed, since membership follows atsProviders by construction.
+	// expireDespiteRegisteredPrefixes), so a newly onboarded whatjobs market is covered this
+	// run without being named anywhere. That construction is why the list holds prefixes,
+	// and it is a complete answer for a member being ADDED — but not for one being ABSENT,
+	// which is what a missing crawl credential produces. Guard that case explicitly.
+	if missing := unmatchedPrefixes(atsProviders, expireDespiteRegisteredPrefixes); len(missing) > 0 {
+		log.Printf("liveness: %q matches no registered ATS provider — refusing to run (a source that cannot be age-expired would silently fall to the URL probe instead)",
+			strings.Join(missing, ", "))
+		return 1
+	}
 	expireDespiteRegistered := matchingProviders(atsProviders, expireDespiteRegisteredPrefixes)
 
 	// Appended AFTER the guard above so the empty-ATS-registry safeguard still keys
@@ -533,6 +551,27 @@ func unseenWindow(srcs []string, declared map[string]time.Duration) time.Duratio
 		}
 	}
 	return window
+}
+
+// unmatchedPrefixes returns the configured prefixes that match no registered provider —
+// the drift guard matchingProviders' own derivation cannot give, because a prefix matching
+// nothing yields an empty set that is indistinguishable from a source with nothing to close.
+//
+// The case that makes this load-bearing is not a typo. Every expireDespiteRegisteredPrefixes
+// member is CREDENTIAL-GATED (sources.All registers adzuna only with ADZUNA_APP_ID/_KEY, and
+// each whatjobs market only with its publisher id), and this worker builds the registry from
+// that same constructor. On a host without the credential the source drops out of the age
+// rule and, by the same absence, drops INTO the orphan probe — so which lifecycle mechanism
+// owns a source would turn on an environment variable about crawling, silently, in the
+// direction that leaves its postings open for ever.
+func unmatchedPrefixes(providers, prefixes []string) []string {
+	var out []string
+	for _, prefix := range prefixes {
+		if len(matchingProviders(providers, []string{prefix})) == 0 {
+			out = append(out, prefix)
+		}
+	}
+	return out
 }
 
 // matchingProviders returns every entry of providers that equals one of prefixes or has

--- a/cmd/liveness/main_test.go
+++ b/cmd/liveness/main_test.go
@@ -86,6 +86,62 @@ func TestUnseenWindowNeverNarrowsBelowTheDefault(t *testing.T) {
 	}
 }
 
+// adzuna is a single provider, not a family, so it exercises the bare-name arm of the match
+// while whatjobs exercises the dashed one. The negative half matters as much: "adzuna" must
+// not sweep up an unrelated provider that merely starts with those letters, since every
+// member it matches is closed by a guess rather than by evidence.
+func TestMatchingProvidersResolvesAdzunaWithoutOverreaching(t *testing.T) {
+	providers := []string{"adzuna", "adzunajobs", "greenhouse", "whatjobs-de"}
+	got := matchingProviders(providers, []string{"adzuna"})
+	want := []string{"adzuna"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("matchingProviders() = %v, want %v", got, want)
+	}
+}
+
+// Both members declare a 14-day sweep grace today, so adding adzuna must not move the second
+// clock the age rule takes. If either ever widens its own window, this asserts the rule
+// follows the more patient of them rather than silently keeping the old number.
+func TestUnseenWindowUnchangedByAddingAdzuna(t *testing.T) {
+	declared := sources.SweepGraceWindows(sources.All(nil))
+	whatjobsOnly := unseenWindow([]string{"whatjobs"}, declared)
+	withAdzuna := unseenWindow([]string{"whatjobs", "adzuna"}, declared)
+	if withAdzuna < whatjobsOnly {
+		t.Fatalf("adding adzuna narrowed the unseen window: %v -> %v", whatjobsOnly, withAdzuna)
+	}
+}
+
+// Every expireDespiteRegistered member is credential-gated — adzuna registers only when
+// ADZUNA_APP_ID/ADZUNA_APP_KEY are set, each whatjobs market only when its publisher id is —
+// and this worker builds the registry from the same credential-gated constructor the crawler
+// uses. On a host missing the credential the source silently leaves the age rule AND enters
+// the URL probe, so which lifecycle mechanism owns a source would turn on an environment
+// variable that describes crawling. Naming the unmatched prefix is what turns that into a
+// refusal instead.
+func TestUnmatchedPrefixesNamesAPrefixNoProviderMatches(t *testing.T) {
+	providers := []string{"whatjobs", "whatjobs-de", "greenhouse"}
+	got := unmatchedPrefixes(providers, []string{"whatjobs", "adzuna"})
+	want := []string{"adzuna"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("unmatchedPrefixes() = %v, want %v", got, want)
+	}
+}
+
+func TestUnmatchedPrefixesEmptyWhenEveryPrefixMatches(t *testing.T) {
+	providers := []string{"whatjobs", "whatjobs-de", "adzuna", "greenhouse"}
+	if got := unmatchedPrefixes(providers, []string{"whatjobs", "adzuna"}); len(got) != 0 {
+		t.Fatalf("unmatchedPrefixes() = %v, want empty", got)
+	}
+}
+
+// The bare-name match must count: adzuna is one provider, not a family, so a check that only
+// recognised "<prefix>-" members would refuse to run on a perfectly healthy host.
+func TestUnmatchedPrefixesAcceptsABareNameMatch(t *testing.T) {
+	if got := unmatchedPrefixes([]string{"adzuna"}, []string{"adzuna"}); len(got) != 0 {
+		t.Fatalf("unmatchedPrefixes() = %v, want empty", got)
+	}
+}
+
 func TestMatchingProvidersEmptyOnNoMatch(t *testing.T) {
 	got := matchingProviders([]string{"himalayas", "jobicy"}, []string{"whatjobs"})
 	if len(got) != 0 {

--- a/deploy/bin/gen-ingest-timers.sh
+++ b/deploy/bin/gen-ingest-timers.sh
@@ -84,6 +84,11 @@ for n in "${PROVIDERS[@]}"; do
   # hand-installed-drift story as dayforce. Generated in the workstream block below.
   [ "$n" = workstream ] && continue
   min=$(( (i*41) % 60 ))
+  # Reset per provider: this is one long loop in one shell, so a value set in a provider's
+  # case arm below would otherwise carry into every provider generated after it — and the
+  # only arm that sets it (adzuna) turns catch-up OFF, which is the direction that fails
+  # silently. Everything else wants Persistent=true.
+  persistent=true
   # Most boards crawl hourly, staggered across the minutes of the hour. reed has a
   # per-hour API request quota its full crawl blows past (403 "exceeded your per-hour
   # request limit"), so it crawls every 6h to stay under it.
@@ -100,6 +105,20 @@ for n in "${PROVIDERS[@]}"; do
     *)
       case "$n" in
         reed) cal="*-*-* 00/6:$(printf %02d "$min"):00" ;;
+        # adzuna is reed's case with a second twist. Its free API states 25/min, 250/day,
+        # 1000/week and 2500/month, and the crawl's whole budget is
+        # boards (4) x adzunaMaxPages (15) x runs/day, so the cadence is the only leg
+        # of it that lives out here: four runs is 240/day, one more would clear 250.
+        # Hourly (the default branch) was 4x that and bought nothing — until the adapter
+        # sent sort_by=date, Adzuna answered in relevance order, stable between runs, so
+        # 23 of 24 daily firings re-read the same slice.
+        #
+        # Persistent=false, unlike every other timer here: a catch-up run after a reboot
+        # or a daemon-reload is a FIFTH run that day, which is 300 requests and over the
+        # daily ceiling. Everywhere else a missed crawl is worth catching up; here the
+        # crawl reads a recency slice, so a late run mostly re-reads what the next one
+        # would have, and the ceiling is worth more than the catch-up.
+        adzuna) cal="*-*-* 00/6:22:00"; persistent=false ;;
         *)    cal="*:$(printf %02d "$min"):00" ;;
       esac ;;
   esac
@@ -108,7 +127,7 @@ for n in "${PROVIDERS[@]}"; do
 Description=timer ingest $n
 [Timer]
 OnCalendar=$cal
-Persistent=true
+Persistent=$persistent
 RandomizedDelaySec=180
 [Install]
 WantedBy=timers.target

--- a/deploy/systemd/freehire-ingest@adzuna.timer
+++ b/deploy/systemd/freehire-ingest@adzuna.timer
@@ -1,7 +1,27 @@
 [Unit]
 Description=timer ingest adzuna
 [Timer]
-OnCalendar=*:22:00
+# Four runs a day, not hourly. This cadence is one leg of a REQUEST BUDGET Adzuna's terms
+# bound (250/day, 2500/month): 4 boards x adzunaMaxPages (15) x 4 runs = 240 requests/day.
+# The other two legs live in internal/ingest/sources/adzuna.go, which carries the same
+# arithmetic — raising either there without lowering this puts the catalogue's largest
+# single source outside the terms it is served under.
+#
+# Hourly bought nothing it does not buy now. Until the adapter sent sort_by=date, Adzuna
+# answered in relevance order, which is stable between runs, so 23 of the 24 daily firings
+# re-read the same slice; measured 2026-09-06, the first result of that request was published
+# seven months earlier. Ordering by date is what makes a run's pages land on postings the
+# catalogue does not already hold, and four such runs deliver more than twenty-four of the old
+# ones did.
+#
+# Off the hour and randomised so this does not land with the rest of the ingest fleet.
+#
+# `00/6:22:00`, verified with systemd-analyze rather than reasoned about: 00:22, 06:22, 12:22,
+# 18:22 UTC. The obvious-looking `*/6:22:00` does not parse at all, and `*:22:00/6` DOES parse
+# — as every hour at :22, repeating on the SECOND — so it would have shipped the old hourly
+# cadence while reading like a change. Re-verify with
+# `systemd-analyze calendar --iterations=4` if this line is ever edited.
+OnCalendar=00/6:22:00
 Persistent=true
 RandomizedDelaySec=180
 [Install]

--- a/deploy/systemd/freehire-ingest@adzuna.timer
+++ b/deploy/systemd/freehire-ingest@adzuna.timer
@@ -22,7 +22,12 @@ Description=timer ingest adzuna
 # cadence while reading like a change. Re-verify with
 # `systemd-analyze calendar --iterations=4` if this line is ever edited.
 OnCalendar=00/6:22:00
-Persistent=true
+# Persistent=false, unlike the rest of the ingest fleet: a catch-up run after a reboot or a
+# daemon-reload would be a FIFTH run that day — 300 requests, over the 250/day ceiling. A
+# missed crawl here costs little, because the crawl reads a recency slice and the next run
+# re-reads most of what the missed one would have. Keep this in step with the adzuna arm of
+# deploy/bin/gen-ingest-timers.sh, which generates this same file on the host.
+Persistent=false
 RandomizedDelaySec=180
 [Install]
 WantedBy=timers.target

--- a/internal/ingest/sources/adzuna.go
+++ b/internal/ingest/sources/adzuna.go
@@ -33,13 +33,35 @@ type adzuna struct {
 
 const (
 	adzunaBaseURL = "https://api.adzuna.com/v1/api/jobs"
-	// adzunaPageSize is the commonly documented page-size ceiling for this API.
+	// adzunaPageSize is this API's page-size ceiling, confirmed live rather than assumed:
+	// results_per_page=100 answers HTTP 400.
 	adzunaPageSize = 50
-	// adzunaMaxPages bounds one board's crawl. A single category in a single country routinely
-	// reports tens of thousands of results (46k for gb/it-jobs at last check), far deeper than
-	// any crawl should walk every cycle, so the board is read as a bounded recent slice — same
-	// trade-off whatjobsMaxPages documents.
-	adzunaMaxPages = 40
+	// adzunaSortOrder makes the crawl read the NEWEST postings first. Without it Adzuna
+	// answers in relevance order, which is stable between runs, so a bounded crawl re-reads
+	// one fixed slice for ever: measured live on 2026-09-06, the first result of the request
+	// this adapter used to send was published 2026-02-10, seven months earlier. The budget was
+	// buying 23.5k posting-slots a day and writing ~6.3k new postings — a 27% yield. Ordering
+	// by date is what aims the budget at postings the catalogue does not already hold.
+	adzunaSortOrder = "date"
+	// adzunaMaxDaysOld bounds a request to recently published postings. It is NOT redundant
+	// with adzunaSortOrder, and that is the whole reason it exists: Fetch's loop ends when a
+	// page comes back empty, and against a feed tens of thousands deep that never happens
+	// inside adzunaMaxPages. A quiet board (au publishes ~176 postings between runs) would
+	// otherwise spend its full page budget on postings the pipeline's seen-set discards, and
+	// those requests are drawn from the same daily ceiling a busy board needs. Two days rather
+	// than one so a missed run does not open a gap the next run cannot close.
+	adzunaMaxDaysOld = 2
+	// adzunaMaxPages bounds one board's crawl. Unlike a plain "how deep is sensible" figure,
+	// this is one leg of a REQUEST BUDGET the platform's terms bound: Adzuna's free API states
+	// 250 requests/day and 2500/month, and the crawl spends
+	//
+	//	boards (4) x adzunaMaxPages (15) x runs/day (4, see the systemd timer) = 240/day
+	//
+	// so raising any one of the three without lowering another puts the catalogue's largest
+	// single source outside the terms it is served under. TestAdzunaPageBudgetStaysWithinThe-
+	// DailyCeiling holds the arithmetic; the timer's cadence is the leg that lives outside
+	// this repository's build, in deploy/systemd/freehire-ingest@adzuna.timer.
+	adzunaMaxPages = 15
 	// adzunaSweepGrace widens the unseen sweep for the same reason whatjobs' does: redirect_url
 	// routes through Adzuna's own domain rather than the employer's site, so a posting's liveness
 	// cannot be probed directly, and the crawl reaches only a bounded slice of a much deeper feed.
@@ -138,6 +160,8 @@ func adzunaPageURL(country, category string, page int, appID, appKey string) str
 		"results_per_page": {fmt.Sprint(adzunaPageSize)},
 		"category":         {category},
 		"content-type":     {"application/json"},
+		"sort_by":          {adzunaSortOrder},
+		"max_days_old":     {fmt.Sprint(adzunaMaxDaysOld)},
 	}
 	return fmt.Sprintf("%s/%s/search/%d?%s", adzunaBaseURL, country, page, q.Encode())
 }

--- a/internal/ingest/sources/adzuna_test.go
+++ b/internal/ingest/sources/adzuna_test.go
@@ -122,13 +122,21 @@ func TestAdzunaFetchRequestsCorrectURL(t *testing.T) {
 		// was published 2026-02-10. The ordering is what makes a bounded crawl read what has
 		// been published since rather than the same slice every run.
 		"sort_by=date",
-		// The window is what lets a board's feed run out, so the page loop's empty-page exit
-		// is reachable — see TestAdzunaFetchStopsWhenTheWindowRunsOut.
-		"max_days_old=" + strconv.Itoa(adzunaMaxDaysOld),
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("request URL %q missing %q", got, want)
 		}
+	}
+	// The freshness window is compared as a PARSED value, not as a substring: substring
+	// matching would accept max_days_old=20 for max_days_old=2, and an order-of-magnitude
+	// widening is exactly the regression that would look fine and quietly re-admit the
+	// stale inventory this change exists to stop fetching.
+	parsed, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("parse request URL %q: %v", got, err)
+	}
+	if v := parsed.Query().Get("max_days_old"); v != strconv.Itoa(adzunaMaxDaysOld) {
+		t.Fatalf("max_days_old = %q, want %q", v, strconv.Itoa(adzunaMaxDaysOld))
 	}
 }
 
@@ -156,17 +164,38 @@ func TestAdzunaFetchStopsWhenTheWindowRunsOut(t *testing.T) {
 }
 
 // The page budget is one leg of a request budget the platform's terms bound, so it is worth
-// an assertion of its own: a silent bump here is spent against a daily ceiling nothing else
-// in the process checks.
+// an assertion of its own: a silent bump here is spent against a ceiling nothing else in the
+// process checks.
+//
+// Adzuna's free tier states FOUR limits — 25/min, 250/day, 1000/week, 2500/month — and they
+// do not agree with each other: 250/day is 7500/month, three times the monthly figure. The
+// monthly one therefore binds at ~83 requests/day, and this crawl is deliberately NOT sized
+// to it. The decision, recorded so it is not mistaken for an oversight: 240/day is a 5.8x
+// reduction on the ~14,000/month the hourly crawl was spending, and sizing to 2500/month
+// instead would cut INTAKE below what the wasteful crawl manages today (~4,000 postings/day
+// against ~6,300), for the catalogue's largest source. Adzuna's own terms invite the fix —
+// "higher limits are available upon request for publishing use cases" — and that request is
+// the task that closes this gap.
+//
+// So the daily ceiling is asserted, and the weekly/monthly overage is measured rather than
+// asserted: the numbers move in the log if someone raises the budget, instead of a green
+// test implying the terms are met.
 func TestAdzunaPageBudgetStaysWithinTheDailyCeiling(t *testing.T) {
 	const (
-		boards       = 4   // us, gb, de, au — every active adzuna board is category it-jobs
-		runsPerDay   = 4   // deploy/systemd/freehire-ingest@adzuna.timer
-		dailyCeiling = 250 // Adzuna's stated terms: 250/day, 2500/month
+		boards         = 4    // us, gb, de, au — every active adzuna board is category it-jobs
+		runsPerDay     = 4    // deploy/systemd/freehire-ingest@adzuna.timer, Persistent=false
+		dailyCeiling   = 250  // Adzuna's stated terms
+		weeklyCeiling  = 1000 // ditto
+		monthlyCeiling = 2500 // ditto — the one this crawl knowingly exceeds
 	)
-	if got := boards * adzunaMaxPages * runsPerDay; got > dailyCeiling {
-		t.Fatalf("crawl budget is %d requests/day, over Adzuna's stated ceiling of %d", got, dailyCeiling)
+	perDay := boards * adzunaMaxPages * runsPerDay
+	if perDay > dailyCeiling {
+		t.Fatalf("crawl budget is %d requests/day, over Adzuna's stated ceiling of %d", perDay, dailyCeiling)
 	}
+	t.Logf("adzuna budget: %d/day (ceiling %d), %d/week (ceiling %d, %.1fx), %d/month (ceiling %d, %.1fx) — the weekly and monthly overage is deliberate, pending a higher-limit request",
+		perDay, dailyCeiling,
+		perDay*7, weeklyCeiling, float64(perDay*7)/weeklyCeiling,
+		perDay*30, monthlyCeiling, float64(perDay*30)/monthlyCeiling)
 }
 
 // A blank country or category is refused rather than crawled (an empty country would 404, an

--- a/internal/ingest/sources/adzuna_test.go
+++ b/internal/ingest/sources/adzuna_test.go
@@ -115,10 +115,57 @@ func TestAdzunaFetchRequestsCorrectURL(t *testing.T) {
 		t.Fatalf("want 1 request, got %d", len(http.gotURLs))
 	}
 	got := http.gotURLs[0]
-	for _, want := range []string{"/jobs/us/search/1", "app_id=myid", "app_key=mykey", "category=it-jobs"} {
+	for _, want := range []string{
+		"/jobs/us/search/1", "app_id=myid", "app_key=mykey", "category=it-jobs",
+		// Without an explicit order Adzuna answers in relevance order, which is stable
+		// between runs: measured live on 2026-09-06, the first result of this very request
+		// was published 2026-02-10. The ordering is what makes a bounded crawl read what has
+		// been published since rather than the same slice every run.
+		"sort_by=date",
+		// The window is what lets a board's feed run out, so the page loop's empty-page exit
+		// is reachable — see TestAdzunaFetchStopsWhenTheWindowRunsOut.
+		"max_days_old=" + strconv.Itoa(adzunaMaxDaysOld),
+	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("request URL %q missing %q", got, want)
 		}
+	}
+}
+
+// A board whose freshness window holds less than the page budget could carry stops at the
+// empty page and leaves the rest of its budget unspent. This is the behaviour max_days_old
+// exists for: the request budget is shared across boards and a day's runs, so a quiet board
+// walking its full 15 pages spends requests a busy board then cannot have.
+func TestAdzunaFetchStopsWhenTheWindowRunsOut(t *testing.T) {
+	http := &adzunaHTTP{pages: []string{
+		adzunaPageJSON(adzunaJobJSON("1", "A")),
+		adzunaPageJSON(""),
+	}}
+
+	jobs, err := (adzuna{http: http, appID: "id", appKey: "key"}).Fetch(context.Background(), CompanyEntry{Region: "au", Board: "it-jobs"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("want 1 job, got %d", len(jobs))
+	}
+	// Two requests, not adzunaMaxPages: the empty second page ends the board.
+	if len(http.gotURLs) != 2 {
+		t.Fatalf("want the crawl to stop after the empty page (2 requests), got %d", len(http.gotURLs))
+	}
+}
+
+// The page budget is one leg of a request budget the platform's terms bound, so it is worth
+// an assertion of its own: a silent bump here is spent against a daily ceiling nothing else
+// in the process checks.
+func TestAdzunaPageBudgetStaysWithinTheDailyCeiling(t *testing.T) {
+	const (
+		boards       = 4   // us, gb, de, au — every active adzuna board is category it-jobs
+		runsPerDay   = 4   // deploy/systemd/freehire-ingest@adzuna.timer
+		dailyCeiling = 250 // Adzuna's stated terms: 250/day, 2500/month
+	)
+	if got := boards * adzunaMaxPages * runsPerDay; got > dailyCeiling {
+		t.Fatalf("crawl budget is %d requests/day, over Adzuna's stated ceiling of %d", got, dailyCeiling)
 	}
 }
 

--- a/openspec/changes/narrow-adzuna-crawl/design.md
+++ b/openspec/changes/narrow-adzuna-crawl/design.md
@@ -43,25 +43,49 @@ success. `page_uniques` is the only honest column here, the same trap
 catalogue. A number that small describes how applications are recorded, not how a source
 performs.
 
-## Why the request budget and catalogue coverage are not in tension
+## What the budget buys, and what it does not
 
-The first draft of this change presented a choice — obey the 250/day ceiling and lose
-coverage, or keep the volume and stay outside Adzuna's terms. That framing was wrong, and
-the reason it was wrong is worth keeping.
-
-It assumed each request returns something new. Measuring what the budget actually delivers
-dissolved it:
+The first draft presented a choice — obey the 250/day ceiling and lose coverage, or keep the
+volume and stay outside Adzuna's terms — and against THAT ceiling the choice really does
+dissolve, because the draft's hidden assumption (that each request returns something new) is
+false. Measuring what the budget actually delivers:
 
 | | today | after |
 |---|---:|---:|
 | requests/day | ~470 | **240** |
 | posting-slots bought (×50) | 23,500 | 12,000 |
 | new postings actually written/day | ~6,300 | up to ~12,000 |
-| within Adzuna's stated terms | no | **yes** |
+| against the 2,500/month ceiling | 5.6× over | **2.9× over** |
 
 `jobs.created_at` over the seven days to 2026-09-06: 4,838 / 4,264 / 1,773 / 9,456 / 8,225 /
 8,473 / 7,365 — a mean near 6,300. The budget's yield is **27%**. Once the yield is that
 low, halving the budget and doubling the intake stop being opposites.
+
+### The limit this reasoning first got wrong
+
+An earlier draft of this section claimed 240/day put the crawl "inside the platform's terms".
+It does not, and the mistake is worth recording because the shape of it will recur.
+
+Adzuna states **four** limits — 25/min, 250/day, 1,000/week, 2,500/month — and they are not
+four ways of saying one thing: 250/day is 7,500/month, three times the monthly figure. Where
+stated limits disagree the tightest one governs, so the real ceiling is **2,500/month ≈ 83
+requests/day**, not 250. The draft read the two figures it had as a restatement of each other
+and did the arithmetic against the convenient one. The weekly limit was not in the note at
+all; only the terms page had it.
+
+The consequence is a genuine trade-off, not a dissolved one:
+
+| budget | requests/month | intake/day | inside the terms |
+|---|---:|---:|---|
+| today | ~14,000 | ~6,300 | no (5.6×) |
+| **240/day (chosen)** | 7,200 | up to ~12,000 | no (2.9×) |
+| 80/day | 2,400 | ~4,000 | yes |
+
+2,500 requests × 50 results is **125,000 posting-slots a month**, a hard ceiling no
+arrangement of pages, boards or runs can raise. Full compliance therefore caps intake BELOW
+what today's wasteful crawl manages, for the source that carries 20,350 companies the
+catalogue holds nowhere else. 240/day was chosen knowingly: a 5.8× reduction now, with the
+licence request their own terms invite as the path to being both compliant and complete.
 
 ## Choosing the freshness window and the page budget
 

--- a/openspec/changes/narrow-adzuna-crawl/design.md
+++ b/openspec/changes/narrow-adzuna-crawl/design.md
@@ -1,0 +1,188 @@
+# Design
+
+Every figure below was measured on production or against Adzuna's live API on 2026-09-06.
+They are recorded here because most of them argue against an option that otherwise looks
+obvious, and re-deriving them costs a request budget we are trying to shrink.
+
+## Why Adzuna is not simply dropped
+
+The question this change answers began as issue #1759's step 4: does what Adzuna carries
+have an ATS equivalent anywhere, or is it exclusive?
+
+Classifying every open Adzuna posting by whether its company is reachable another way:
+
+| the company is… | companies | postings | of which `is_tech` |
+|---|---:|---:|---:|
+| already held through its own ATS | 8,915 | 142,229 | 87,464 |
+| carried by another aggregator | 6,517 | 72,931 | 45,471 |
+| **reachable only through Adzuna** | **20,350** | **81,730** | 38,603 |
+
+(2,118 postings carry an empty `company_slug` and fall outside the classification, so the
+three rows total 296,890 against that run's 299,008 open Adzuna postings. Counts drift by a
+few thousand between runs hours apart on the same day — the crawl and the sweep are both
+running — which is why each figure here names the query that produced it rather than being
+reconciled to a single total.)
+
+So **72% of Adzuna's output is redundant at the company level** — and dropping the source
+would still cost 20,350 employers the catalogue holds nowhere else. That is more companies
+than most whole sources carry. Adzuna stays.
+
+The second row is company-level, not posting-level: "another aggregator carries this
+employer" does not establish that it carries these same postings. It is a ceiling on
+redundancy, not a measurement of it.
+
+Reader attention agrees Adzuna is worth keeping, narrowly. Over the 55 days
+`job_daily_views` retains, Adzuna postings drew **16,308 bot-filtered `page_uniques`**
+against **334,908** catalogue-wide — **4.87% of attention for 4.34% of the catalogue.**
+Slightly above its weight. (The raw `view_count` for the same postings is 244k; the 15×
+gap is crawler traffic, and reading it instead would have made Adzuna look like a runaway
+success. `page_uniques` is the only honest column here, the same trap
+`internal/engage/socialdigest` documents.)
+
+`applied_count` was measured and **discarded**: 4 for Adzuna against 496 for the entire open
+catalogue. A number that small describes how applications are recorded, not how a source
+performs.
+
+## Why the request budget and catalogue coverage are not in tension
+
+The first draft of this change presented a choice — obey the 250/day ceiling and lose
+coverage, or keep the volume and stay outside Adzuna's terms. That framing was wrong, and
+the reason it was wrong is worth keeping.
+
+It assumed each request returns something new. Measuring what the budget actually delivers
+dissolved it:
+
+| | today | after |
+|---|---:|---:|
+| requests/day | ~470 | **240** |
+| posting-slots bought (×50) | 23,500 | 12,000 |
+| new postings actually written/day | ~6,300 | up to ~12,000 |
+| within Adzuna's stated terms | no | **yes** |
+
+`jobs.created_at` over the seven days to 2026-09-06: 4,838 / 4,264 / 1,773 / 9,456 / 8,225 /
+8,473 / 7,365 — a mean near 6,300. The budget's yield is **27%**. Once the yield is that
+low, halving the budget and doubling the intake stop being opposites.
+
+## Choosing the freshness window and the page budget
+
+Adzuna's own catalogue turnover is derivable from two numbers it already reports — total
+listings and listings under seven days old — by Little's Law (`items = arrival rate × time
+in system`):
+
+| country | listed | new/day | implied mean lifetime | share of fresh flow |
+|---|---:|---:|---:|---:|
+| us | 462,866 | 13,339 | 35 days | 77% |
+| gb | 53,026 | 2,186 | 24 days | 13% |
+| de | 23,616 | 1,055 | 22 days | 6% |
+| au | 15,358 | 705 | 22 days | 4% |
+
+Adzuna itself holds a posting for 22-35 days. The existing 45-day `expiryWindow` sits
+deliberately wider than that, which is the under-closing bias the mechanism already declares.
+**No new knob is introduced**; a second window for one source would be a second answer to a
+question that already has one.
+
+Page budget: 4 boards × 15 pages × 4 runs/day = 240 requests, under the 250/day ceiling with
+room for a retry. At 50 results a page, one run reaches the newest 750 postings per board.
+Against per-run flow (daily ÷ 4): `gb` 547, `de` 264, `au` 176 all fit whole; `us` 3,335 does
+not, and is covered to about a quarter.
+
+**Seam, deliberately not built:** a per-board page budget would let `us` take the pages
+`de`/`au` cannot use — roughly 48/8/4/3 rather than a flat 15 — and capture most of the flow
+inside the same 240 requests. It needs a column on `boards` that nothing else wants, and
+whether US coverage matters to this audience is unmeasured. If it turns out to, that is where
+it goes.
+
+## Why `max_days_old` is not redundant with `sort_by=date`
+
+With a date ordering and a fixed page budget the crawl is already bounded, so a freshness
+window looks like belt and braces. It is not: it is what makes the adapter's existing exit
+reachable.
+
+`adzuna.go`'s page loop breaks when a page returns zero results. Against a 53k-deep feed that
+never happens inside 15 pages, so `de` (264 per run) and `au` (176) would spend their full
+budget on pages the pipeline's seen-set then discards. With `max_days_old=2` the feed runs
+out and the loop stops, and those requests are simply not made.
+
+A malformed value is safe to get wrong loudly: `max_days_old=zzz` returns **HTTP 500**, not a
+silently unfiltered result set. `results_per_page=100` returns **HTTP 400**, confirming 50 is
+the ceiling the constant already assumes.
+
+## Why age, and not a probe
+
+The catalogue's preferred close is evidence: the sweep sees a posting vanish from a board, or
+the liveness probe reads a death verdict off its URL. Adzuna will offer neither once the
+crawl is date-ordered.
+
+Sampling 40 stored Adzuna URLs and following redirects:
+
+| response | count | what it means |
+|---|---:|---|
+| `403 Access Denied` | ~30 | Adzuna's bot protection on `…/land/ad/<id>` — **not a verdict** |
+| `404` / `410` | ~7 | genuinely gone |
+| `200` | ~3 | alive |
+
+The stored URL is Adzuna's own tracking redirect (it carries our `utm_source`, which is how
+click attribution reaches our account — see the attribution work in #2308). It answers 403
+whether or not the posting behind it lives. A probe built on it would read "blocked" as
+"dead" and close the catalogue's largest source.
+
+That is precisely the condition `cmd/liveness` classifies with
+`expireDespiteRegisteredPrefixes`, whose own comment describes it as a source
+
+> the sweep DOES otherwise close on evidence … for the tail its crawl budget structurally can
+> never re-reach
+
+with no evidence a probe could read. `whatjobs` is already there for the same reason. Adzuna
+joins it, and the change is one string in a list.
+
+### The three close mechanisms, and why Adzuna belongs to the third
+
+`cmd/liveness` holds three lists, and they are not a hierarchy — they are a classification by
+what evidence a source can offer:
+
+| list | the source's situation | how it closes |
+|---|---|---|
+| `unsignalledSources` | no re-crawl, no feed, URL outlives the vacancy (`telegram`) | age |
+| `probeDespiteRegistered` | swept, but the sweep leaks; URL answers honestly | probe |
+| `expireDespiteRegistered` | swept, but the sweep leaks; URL cannot answer | age |
+
+Adzuna's URL cannot answer, so the third row is the only one that fits. Putting it in the
+first would be wrong twice over — it *is* re-crawled — and the worker refuses to start on
+exactly that mistake (`cmd/liveness/main.go:191`), which is why misclassifying here fails
+loudly rather than mass-closing the catalogue.
+
+## The spec drift this change closes
+
+`job-lifecycle`'s age-rule requirement says the rule
+
+> SHALL NOT apply to a source the ingest sweep or the liveness probe already covers, since for
+> those a close rests on evidence and age would override it with a guess.
+
+`expireDespiteRegistered` has done exactly that for every `whatjobs` market since it landed,
+and nothing in `openspec/specs/` records it — the string does not appear anywhere under
+`openspec/`. The code is right and the spec is stale: the concern the sentence protects
+against is real, but the answer is not "never", it is "only for the tail the sweep
+structurally cannot reach, and only for a source whose URL cannot be probed."
+
+This change rewrites that requirement to say so, and names its two members. It is not a
+change in behaviour for `whatjobs`; it is the first time that behaviour is written down.
+
+## Expected effect on the catalogue, and why it is not a regression
+
+Two closes now reach an ageing Adzuna posting, and the faster one is not the new rule:
+
+1. Adzuna's existing 14-day `sweepGrace`. The sweep is scoped to the company slugs a run
+   actually crawled, so an old posting at a company that is *still posting* gets crawled-past
+   and closed at 14 days. Under relevance ordering that posting was often re-seen by luck;
+   under date ordering it will not be.
+2. The 45-day age rule, for everything the sweep's company scope never reaches.
+
+Both are correct — the first closes on the sweep's own evidence, the second on the declared
+guess — but together they will pull the Adzuna slice from 301k toward roughly 150-180k over
+several weeks. Its age profile today shows why that is the point: **only 19.7% of open Adzuna
+postings were published in the last 14 days**, while 15.5% are older than 90 days and 5.2%
+older than 180 — well past anything Adzuna itself still lists.
+
+Intake roughly doubles over the same period. The slice shrinks and then refills, with
+postings that are current rather than with the February inventory the relevance ordering kept
+handing us.

--- a/openspec/changes/narrow-adzuna-crawl/proposal.md
+++ b/openspec/changes/narrow-adzuna-crawl/proposal.md
@@ -62,9 +62,15 @@ mechanism for it (`expireDespiteRegisteredPrefixes`). Adzuna joins it. No new ma
   its members.
 - **Add the missing `adzuna-source` capability spec.** Adzuna is the largest source in the
   catalogue and has no spec at all.
-- **Refresh the duplicate markers once after deploy** (`REINDEX_DEDUP_ONLY=1`), so the
-  142,229 open Adzuna postings whose company we already hold first-party are suppressed
-  where a title twin exists.
+- **Nothing about the duplicate markers.** An earlier draft of this proposal called for a
+  one-off `REINDEX_DEDUP_ONLY=1` pass to suppress the 142,229 open Adzuna postings whose
+  company we already hold first-party. Checking the host rather than the documentation shows
+  `freehire-reindex-dedup-only.timer` already runs that pass six times a day (01:30, 10:30,
+  13:30, 16:30, 19:30, 22:30 UTC), last exit 0. The 35,268 Adzuna postings carrying an
+  aggregator marker are therefore not a backlog — they are the complete answer, because
+  suppression needs a matching TITLE, not merely a covered company. The remaining ~107k are
+  postings the employer's own ATS does not list under any comparable title, which is exactly
+  what the marker declines to call a duplicate.
 
 ### Non-goals
 
@@ -100,8 +106,8 @@ mechanism for it (`expireDespiteRegisteredPrefixes`). Adzuna joins it. No new ma
   **The unit must be copied to the host**; `release.sh` flips the app and never touches a
   unit, so this half of the change does not ship itself.
 - **Schema:** none.
-- **Search:** no reindex is required by the change itself. The one-off
-  `REINDEX_DEDUP_ONLY=1` marker pass is an operational step, not a code dependency.
+- **Search:** no reindex is required, and no marker pass either — see "What Changes". The
+  scheduled `freehire-reindex-dedup-only.timer` already covers it.
 - **Expect the Adzuna slice of the catalogue to shrink**, from 301k toward roughly 150-180k
   over the following weeks, and faster than the 45-day window alone implies — Adzuna's own
   14-day `sweepGrace` closes what the date-ordered crawl stops re-seeing before the age rule

--- a/openspec/changes/narrow-adzuna-crawl/proposal.md
+++ b/openspec/changes/narrow-adzuna-crawl/proposal.md
@@ -17,19 +17,27 @@ same ~2,000 postings each time, the oldest of them seven months old.
 
 What that costs, and what it returns:
 
-- **~470 requests/day** — roughly 14,000/month observed, against Adzuna's stated ceiling of
-  **250/day and 2,500/month**, so about **5.6× over the monthly limit**. (The hourly timer's
-  theoretical 3,840/day — 4 boards × 40 pages × 24 runs — is never reached, because most
-  firings find the ingest slots contended and do not run.) The only thing holding the source
-  up is that nobody has looked.
+- **~470 requests/day** — roughly 14,000/month observed. Adzuna's free tier states FOUR
+  limits, and they do not agree with one another: **25/min, 250/day, 1,000/week,
+  2,500/month**. 250/day is 7,500/month, three times the monthly figure, so the monthly one
+  binds at about **83 requests/day**. Today's spend is **5.6× the monthly ceiling**. (The
+  hourly timer's theoretical 3,840/day is never reached — most firings find the ingest slots
+  contended and do not run.) The only thing holding the source up is that nobody has looked.
 - **~6,300 new postings/day** actually written (`jobs.created_at`, 7-day mean). The budget
   buys 23,500 posting-slots and fills 27% of them.
 - Meanwhile Adzuna publishes **~17,300 new IT postings/day** across the four crawled
   countries. We capture roughly a third of it.
 
-Sending `sort_by=date` and cutting the budget to **240 requests/day** is not a trade: it is
-strictly better on every axis at once — half the requests, inside the platform's terms, and
-up to 12,000 posting-slots aimed at postings we do not already hold.
+Sending `sort_by=date` and cutting the budget to **240 requests/day** halves the requests
+while roughly doubling the intake: up to 12,000 posting-slots aimed at postings we do not
+already hold, against ~6,300 written today.
+
+**It does not bring us inside the terms, and this proposal does not claim it does.** 240/day
+is 7,200/month — still 2.9× the monthly ceiling, though 5.8× better than today. Sizing to
+2,500/month instead means ~83 requests/day, which caps intake at ~4,150 postings/day: BELOW
+the ~6,300 the wasteful crawl manages now, for the catalogue's largest single source. That
+was weighed and declined. Adzuna's own terms name the way out — *"higher limits are available
+upon request for publishing use cases"* — and requesting them is part of this change.
 
 The second half is the consequence. Today an Adzuna posting stays open because the
 relevance-ordered crawl keeps stumbling over it; the 14-day unseen sweep then reads that as

--- a/openspec/changes/narrow-adzuna-crawl/proposal.md
+++ b/openspec/changes/narrow-adzuna-crawl/proposal.md
@@ -1,0 +1,110 @@
+## Why
+
+Adzuna is the catalogue's largest single source — **301,008 open postings, 4.34% of the
+6,940,260 open catalogue** — and the crawl that fills it spends its entire request budget
+re-reading inventory it already has.
+
+Measured live on 2026-09-06, against `gb/it-jobs`:
+
+| request | reported total | first result's `created` |
+|---|---:|---|
+| what the adapter sends today | 52,942 | **2026-02-10** |
+| the same request with `sort_by=date` | 52,941 | 2026-09-06T12:34 |
+
+The adapter has never sent a sort order, so Adzuna answers in *relevance* order, which is
+stable between runs. The crawl walks 40 pages of it every hour and gets substantially the
+same ~2,000 postings each time, the oldest of them seven months old.
+
+What that costs, and what it returns:
+
+- **~470 requests/day** — roughly 14,000/month observed, against Adzuna's stated ceiling of
+  **250/day and 2,500/month**, so about **5.6× over the monthly limit**. (The hourly timer's
+  theoretical 3,840/day — 4 boards × 40 pages × 24 runs — is never reached, because most
+  firings find the ingest slots contended and do not run.) The only thing holding the source
+  up is that nobody has looked.
+- **~6,300 new postings/day** actually written (`jobs.created_at`, 7-day mean). The budget
+  buys 23,500 posting-slots and fills 27% of them.
+- Meanwhile Adzuna publishes **~17,300 new IT postings/day** across the four crawled
+  countries. We capture roughly a third of it.
+
+Sending `sort_by=date` and cutting the budget to **240 requests/day** is not a trade: it is
+strictly better on every axis at once — half the requests, inside the platform's terms, and
+up to 12,000 posting-slots aimed at postings we do not already hold.
+
+The second half is the consequence. Today an Adzuna posting stays open because the
+relevance-ordered crawl keeps stumbling over it; the 14-day unseen sweep then reads that as
+evidence of life. Once the crawl is date-ordered, an ageing posting drifts past the page
+budget and never returns, so the crawl stops being a liveness signal for it. A live probe
+cannot take over: sampled 40 stored URLs on 2026-09-06 and Adzuna answered **403 Access
+Denied on ~30 of them** — its own bot protection on the `…/land/ad/<id>` tracking URL we
+store. A 403 is not a death verdict, so the probe can never reach one.
+
+That is exactly the shape `whatjobs` is already in, and `cmd/liveness` already has the
+mechanism for it (`expireDespiteRegisteredPrefixes`). Adzuna joins it. No new machinery.
+
+## What Changes
+
+- **Order the Adzuna crawl by date and bound it to a freshness window.** The adapter sends
+  `sort_by=date` and `max_days_old=2`; the page budget drops from 40 to 15; the timer drops
+  from hourly to every six hours. Four boards × 15 pages × 4 runs = **240 requests/day**.
+- **Let the freshness window end a board's crawl.** The page loop already stops on an empty
+  page (`adzuna.go:124`). Without a window the pages never run out — the feed is 53k deep —
+  so the quiet boards (`de`, `au`) burn their whole budget on inventory the seen-set
+  discards. `max_days_old` is what makes the existing early exit reachable.
+- **Close ageing Adzuna postings by age instead of by absence.** Add `adzuna` to
+  `cmd/liveness`'s `expireDespiteRegisteredPrefixes`, which closes an open posting whose
+  effective posting date is past the existing 45-day `expiryWindow` with reason `expired`.
+- **Specify the rule the code already follows.** `job-lifecycle`'s age-rule requirement
+  currently forbids exactly what `expireDespiteRegistered` does — it says the age rule "SHALL
+  NOT apply to a source the ingest sweep or the liveness probe already covers". `whatjobs`
+  has been closed by age despite being swept since that mechanism landed, and no spec records
+  it. The requirement is rewritten to describe the real rule, with `whatjobs` and `adzuna` as
+  its members.
+- **Add the missing `adzuna-source` capability spec.** Adzuna is the largest source in the
+  catalogue and has no spec at all.
+- **Refresh the duplicate markers once after deploy** (`REINDEX_DEDUP_ONLY=1`), so the
+  142,229 open Adzuna postings whose company we already hold first-party are suppressed
+  where a title twin exists.
+
+### Non-goals
+
+- **Per-board page budgets.** The United States carries 77% of the fresh flow
+  (13,339/day of 17,300) and a flat 15-page budget reaches about a quarter of it, while
+  `gb`/`de`/`au` are covered whole. A per-board budget would fix that, but the `boards` table
+  has no column for one and nothing else needs it yet. The seam is named in design.md; it is
+  not built here.
+- **`cmd/hydrate-adzuna-description`.** It fetches the same `…/land/ad/<id>` URLs every 30
+  minutes and meets the same 403, which matches the "majority failure mode of the first
+  production runs" its own source comment records. It is very likely running empty. Real, and
+  a separate change.
+- **Deprecating Adzuna.** Answered and rejected on measurement — see design.md. 20,350
+  companies and 81,730 open postings exist in the catalogue through Adzuna and nowhere else.
+
+## Capabilities
+
+### New Capabilities
+- `adzuna-source`: the Adzuna Job Search API adapter — how a board addresses a country and
+  category, what request order and freshness window bound a crawl, and what request budget
+  the platform's terms allow.
+
+### Modified Capabilities
+- `job-lifecycle`: the age rule is restated to cover a source the sweep *does* otherwise
+  close on evidence, for the tail its crawl budget structurally cannot re-reach — the rule
+  `whatjobs` has followed unspecified, and which `adzuna` now joins.
+
+## Impact
+
+- **Go:** `internal/ingest/sources/adzuna.go` (request parameters and page budget);
+  `cmd/liveness/main.go` (one entry in `expireDespiteRegisteredPrefixes`).
+- **Deploy:** `deploy/systemd/freehire-ingest@adzuna.timer` — hourly to every six hours.
+  **The unit must be copied to the host**; `release.sh` flips the app and never touches a
+  unit, so this half of the change does not ship itself.
+- **Schema:** none.
+- **Search:** no reindex is required by the change itself. The one-off
+  `REINDEX_DEDUP_ONLY=1` marker pass is an operational step, not a code dependency.
+- **Expect the Adzuna slice of the catalogue to shrink**, from 301k toward roughly 150-180k
+  over the following weeks, and faster than the 45-day window alone implies — Adzuna's own
+  14-day `sweepGrace` closes what the date-ordered crawl stops re-seeing before the age rule
+  reaches it. Intake roughly doubles over the same period, so the slice refills with postings
+  that are actually current. This is the intended outcome, not a regression, and it is
+  recorded here so the drop is not mistaken for a broken adapter.

--- a/openspec/changes/narrow-adzuna-crawl/specs/adzuna-source/spec.md
+++ b/openspec/changes/narrow-adzuna-crawl/specs/adzuna-source/spec.md
@@ -62,10 +62,16 @@ is what lets the feed run out and the existing exit fire.
 
 ### Requirement: The crawl budget stays inside the platform's stated request limits
 
-Adzuna's terms state a ceiling of 250 requests per day and 2,500 per month. The system SHALL
-size the Adzuna crawl — page budget per board, boards, and run frequency together — to stay
-under the daily ceiling, and SHALL treat that ceiling as a property of the whole schedule
-rather than of any one run.
+Adzuna's terms state four ceilings — 25 requests per minute, 250 per day, 1,000 per week and
+2,500 per month — which do not agree with one another: the daily figure multiplies out to
+three times the monthly one. The system SHALL treat the request budget as a property of the
+whole schedule (page budget per board × boards × runs per day), not of any one run, and SHALL
+size it to the daily ceiling.
+
+Where the schedule exceeds a longer-period ceiling, that overage SHALL be an explicit,
+recorded decision rather than an omission, and the arithmetic against every stated ceiling
+SHALL be surfaced by the same check that enforces the daily one — a check that reports only
+the limit it satisfies would read as compliance the source does not have.
 
 The free API pays nothing and grants nothing: continued access rests on the platform's
 tolerance, and the catalogue's largest single source depends on it. A budget that exceeds the
@@ -78,6 +84,19 @@ A page SHALL carry at most 50 results; the platform rejects a larger request out
 
 - **WHEN** the configured boards, page budget and run frequency are multiplied out
 - **THEN** the resulting requests per day are below the platform's stated daily ceiling
+
+#### Scenario: A longer-period overage is reported, not hidden
+
+- **WHEN** the same schedule is multiplied out against the weekly and monthly ceilings and
+  exceeds them
+- **THEN** the overage and its multiple are reported alongside the daily figure, so the
+  schedule cannot read as compliant on the strength of the one ceiling it meets
+
+#### Scenario: A catch-up run cannot add to the day's budget
+
+- **WHEN** the crawl's timer is reactivated after a missed run
+- **THEN** no catch-up run is issued, because an extra run would spend a fifth of the day's
+  budget the ceiling has no room for
 
 #### Scenario: A page failure after the first page keeps what was gathered
 

--- a/openspec/changes/narrow-adzuna-crawl/specs/adzuna-source/spec.md
+++ b/openspec/changes/narrow-adzuna-crawl/specs/adzuna-source/spec.md
@@ -1,0 +1,110 @@
+## ADDED Requirements
+
+### Requirement: A board addresses one country and one category
+
+The system SHALL address the Adzuna Job Search API as `(country, category)` pairs: the
+country is the API path segment (`/jobs/{country}/search/{page}`) and SHALL be carried in the
+board's region, the category is a hard `category` filter and SHALL be carried in the board's
+board id. Adzuna publishes no "list everything" call, so a boardless crawl is not available.
+
+A board with a blank category SHALL fail rather than fall back to an unfiltered search, since
+an unfiltered crawl of a general job board would spend the whole request budget on postings
+outside the catalogue's scope.
+
+The category is a filter, not a relevance query: every result on a deep page still carries
+the requested category. The adapter therefore SHALL NOT carry the corroboration and
+relevance-collapse logic a keyword-search source needs.
+
+#### Scenario: A board's country and category select the request
+
+- **WHEN** a board names region `gb` and board `it-jobs`
+- **THEN** the crawl requests `/jobs/gb/search/{page}` with `category=it-jobs`
+
+#### Scenario: A blank category fails the board
+
+- **WHEN** a board carries an empty category
+- **THEN** the board fails with an error naming the company, and no request is made
+
+### Requirement: A crawl reads the newest postings first, within a freshness window
+
+The system SHALL request Adzuna's results in date order, newest first, and SHALL bound each
+request to a freshness window measured in days.
+
+Without an explicit order Adzuna answers in relevance order, which is stable between runs.
+Measured on `gb/it-jobs` on 2026-09-06: the default ordering's first result was published
+2026-02-10, seven months earlier, while the same request in date order returned a posting from
+that same day. An hourly crawl of a stable relevance ordering re-reads one fixed slice of the
+catalogue and reaches almost none of what has been published since.
+
+The freshness window is not redundant with the date order. The page loop ends when a page
+returns no results, and against a catalogue tens of thousands of postings deep that never
+happens inside the page budget — so a board whose real inflow is smaller than its budget
+would spend every remaining request on postings the pipeline's seen-set discards. The window
+is what lets the feed run out and the existing exit fire.
+
+#### Scenario: Results arrive newest first
+
+- **WHEN** a board's first page is requested
+- **THEN** the request carries a date ordering, and the newest postings the window admits
+  are the ones returned
+
+#### Scenario: A quiet board stops early instead of spending its budget
+
+- **WHEN** a board's freshness window holds fewer postings than the page budget could carry
+- **THEN** a page returns no results and the crawl for that board ends, leaving the remaining
+  requests unmade
+
+#### Scenario: A malformed freshness window fails the request
+
+- **WHEN** a request carries a freshness window the platform cannot parse
+- **THEN** the platform answers with a server error and the board fails, rather than silently
+  returning an unfiltered result set
+
+### Requirement: The crawl budget stays inside the platform's stated request limits
+
+Adzuna's terms state a ceiling of 250 requests per day and 2,500 per month. The system SHALL
+size the Adzuna crawl — page budget per board, boards, and run frequency together — to stay
+under the daily ceiling, and SHALL treat that ceiling as a property of the whole schedule
+rather than of any one run.
+
+The free API pays nothing and grants nothing: continued access rests on the platform's
+tolerance, and the catalogue's largest single source depends on it. A budget that exceeds the
+stated ceiling is therefore a standing risk to that whole slice of the catalogue, not a
+technical detail.
+
+A page SHALL carry at most 50 results; the platform rejects a larger request outright.
+
+#### Scenario: The schedule stays under the daily ceiling
+
+- **WHEN** the configured boards, page budget and run frequency are multiplied out
+- **THEN** the resulting requests per day are below the platform's stated daily ceiling
+
+#### Scenario: A page failure after the first page keeps what was gathered
+
+- **WHEN** a request for a page after the first fails
+- **THEN** the crawl for that board stops and returns the postings already gathered, rather
+  than discarding them or continuing to spend the budget
+
+### Requirement: An Adzuna posting's liveness cannot be probed by its stored URL
+
+The stored URL is Adzuna's own tracking redirect, which carries the attribution parameters
+that credit a click to this publisher. It is not the employer's posting page, and it answers
+the same whether or not the posting behind it is live.
+
+The system SHALL NOT treat a response to that URL as evidence of a posting's death.
+Measured over 40 sampled stored URLs on 2026-09-06: roughly three quarters answered `403
+Access Denied` — the platform's bot protection, not a verdict — with the remainder split
+between genuine `404`/`410` and live `200`.
+
+Adzuna postings SHALL therefore be closed by the ingest sweep where it can still see them,
+and by the lifecycle's age rule for the tail a bounded, date-ordered crawl never re-reads.
+
+#### Scenario: A blocked probe is not a death verdict
+
+- **WHEN** a stored Adzuna URL answers `403`
+- **THEN** the posting is not closed on that basis
+
+#### Scenario: The ageing tail is closed by age
+
+- **WHEN** an open Adzuna posting's effective posting date passes the lifecycle's age window
+- **THEN** it is closed with reason `expired`

--- a/openspec/changes/narrow-adzuna-crawl/specs/job-lifecycle/spec.md
+++ b/openspec/changes/narrow-adzuna-crawl/specs/job-lifecycle/spec.md
@@ -22,6 +22,19 @@ for this set only when BOTH hold:
   network landing page, a tracking redirect, or a host that refuses automated requests — so
   no probe can produce a death verdict from it.
 
+A set-two posting SHALL additionally have gone unseen by the crawl for longer than that
+source's own declared post-run sweep window before age may close it. Age alone is sound only
+where nothing re-crawls the source; where something does, the crawl's most recent reading is
+evidence and MUST be allowed to contradict the guess. The unseen window SHALL be read from
+the source's declared sweep grace rather than restated, since that window is already the
+provider's own answer to "unseen for long enough to mean removed", and where the set's
+members declare different windows the WIDEST SHALL apply.
+
+Closing a set-two posting the crawl is still listing does not merely close it early: the next
+crawl reopens it through the ordinary upsert, which restamps `updated_at`, recomputes the
+posting's semantic chunks, and notifies everyone who applied to it that it closed. The second
+clock exists because that flap was observed, not as a precaution.
+
 Membership in either set SHALL be an explicit, deliberate opt-in held in one place, never
 inferred from a source's shape, so that a newly added adapter can never drift into being
 closed by a guess. A source in set two SHALL NOT also be listed in set one: set one's members
@@ -53,9 +66,16 @@ SHALL be biased toward under-closing: a job exactly at the boundary survives one
 
 - **WHEN** the liveness worker runs and an open job's source is a set-two member
   (`whatjobs` and its per-country markets, or `adzuna`) with an effective posting date 46
-  days in the past
+  days in the past, and the crawl has not seen it for longer than that source's declared
+  sweep window
 - **THEN** the job is closed with reason `expired`, even though the ingest sweep also covers
   that source
+
+#### Scenario: A posting the crawl is still listing survives its own age
+
+- **WHEN** the liveness worker runs and an open set-two job's effective posting date is 46
+  days in the past but the crawl saw it yesterday
+- **THEN** the job stays open, because the crawl's reading is evidence and outranks the guess
 
 #### Scenario: Age does not close a job an ordinary sweep or probe covers
 

--- a/openspec/changes/narrow-adzuna-crawl/specs/job-lifecycle/spec.md
+++ b/openspec/changes/narrow-adzuna-crawl/specs/job-lifecycle/spec.md
@@ -1,0 +1,101 @@
+## MODIFIED Requirements
+
+### Requirement: A job from a source with no close signal is closed by age
+
+The system SHALL close an open job by age — once its effective posting date
+(`COALESCE(posted_at, created_at)`) is older than a fixed window of 45 days, with reason
+`expired` — when the job's source belongs to one of exactly two explicitly enumerated sets,
+and SHALL NOT close any other job by age.
+
+**Set one: sources with no close signal at all.** Neither a re-crawl that could stop seeing
+the posting, nor a change feed, nor a posting URL a probe could reach a verdict on. `telegram`
+is the only member: its stored URL is the Telegram post, which outlives the vacancy.
+
+**Set two: swept sources whose crawl budget cannot re-reach their own tail, and whose URL a
+probe cannot read.** The ingest sweep does close these sources on evidence, and keeps doing
+so; the age rule covers only what that sweep structurally never revisits. A source qualifies
+for this set only when BOTH hold:
+
+- its crawl reads a bounded, recency-ordered slice of a catalogue deeper than the budget, so
+  a posting that ages past the slice is never offered to the sweep again; and
+- its stored URL answers the same regardless of whether the posting behind it is live — a
+  network landing page, a tracking redirect, or a host that refuses automated requests — so
+  no probe can produce a death verdict from it.
+
+Membership in either set SHALL be an explicit, deliberate opt-in held in one place, never
+inferred from a source's shape, so that a newly added adapter can never drift into being
+closed by a guess. A source in set two SHALL NOT also be listed in set one: set one's members
+are additionally excluded from the liveness probe, and applying that exclusion to a swept
+source would silently remove it from a mechanism that still owns its evidence-based closes.
+The system SHALL refuse to run rather than proceed when that distinction is violated.
+
+An age close SHALL NOT itself reopen the job. A set-two source's own re-crawl MAY reopen it
+by re-listing the posting, which is the ordinary reappearance path and not an exception to
+this rule.
+
+Age is the catalogue's weakest close, resting on a guess where every other mechanism rests on
+evidence. The window SHALL therefore be shared by both sets rather than tuned per source, and
+SHALL be biased toward under-closing: a job exactly at the boundary survives one more run.
+
+#### Scenario: A stale Telegram vacancy is closed
+
+- **WHEN** the liveness worker runs and an open job has `source = 'telegram'` with an
+  effective posting date 46 days in the past
+- **THEN** the job is closed with reason `expired`
+
+#### Scenario: A recent Telegram vacancy is left open
+
+- **WHEN** the liveness worker runs and an open job has `source = 'telegram'` with an
+  effective posting date 44 days in the past
+- **THEN** the job stays open
+
+#### Scenario: A swept aggregator's unreachable tail is closed by age
+
+- **WHEN** the liveness worker runs and an open job's source is a set-two member
+  (`whatjobs` and its per-country markets, or `adzuna`) with an effective posting date 46
+  days in the past
+- **THEN** the job is closed with reason `expired`, even though the ingest sweep also covers
+  that source
+
+#### Scenario: Age does not close a job an ordinary sweep or probe covers
+
+- **WHEN** the liveness worker runs and an open job has `source = 'greenhouse'` or
+  `source = 'manual'` with an effective posting date a year in the past
+- **THEN** the age rule does not close it
+
+#### Scenario: A source listed in both sets stops the worker
+
+- **WHEN** the liveness worker starts and a source appears both in the no-close-signal set
+  and among the registered crawl providers
+- **THEN** the worker refuses to run and reports the source by name, rather than closing that
+  provider's postings by age
+
+#### Scenario: A set-two entry matching no registered provider stops the worker
+
+- **WHEN** the liveness worker starts and a set-two entry matches no registered crawl provider
+- **THEN** the worker refuses to run and names the entry, so a renamed adapter — or a
+  credential-gated source absent from this host's registry — is noticed rather than becoming
+  a silent no-op that leaves its postings open forever
+
+### Requirement: A source's close mechanism does not depend on a credential being present
+
+Every set-two source is credential-gated: `adzuna` registers only when `ADZUNA_APP_ID` and
+`ADZUNA_APP_KEY` are set, and each `whatjobs` market only when its publisher id is. A host
+without the credential therefore builds a registry that omits the source, which would both
+drop it from the age rule and admit its postings to the URL probe — two mechanisms changing
+hands on the presence of an environment variable that describes crawling, not lifecycle.
+
+The system SHALL make that condition an error rather than a silent reclassification: a
+configured set-two member absent from the registry SHALL stop the worker.
+
+This SHALL NOT be softened by resolving set-two membership against the source taxonomy
+instead of the live registry. The taxonomy would restore the age rule but leave the probe
+exclusion keyed to the registry, so the two halves of the decision would disagree — and the
+existing guards exist precisely to keep them one decision.
+
+#### Scenario: A missing crawl credential stops the worker rather than changing the mechanism
+
+- **WHEN** the liveness worker starts on a host where `ADZUNA_APP_ID` is unset, so `adzuna`
+  is absent from the registry while still listed as a set-two member
+- **THEN** the worker refuses to run, rather than silently leaving every open Adzuna posting
+  to the URL probe that cannot reach a verdict on it

--- a/openspec/changes/narrow-adzuna-crawl/tasks.md
+++ b/openspec/changes/narrow-adzuna-crawl/tasks.md
@@ -1,58 +1,65 @@
 ## 1. Order the crawl by date and bound it by freshness
 
-- [ ] 1.1 Write the failing tests first in `internal/ingest/sources/adzuna_test.go`: the built
+- [x] 1.1 Write the failing tests first in `internal/ingest/sources/adzuna_test.go`: the built
   page URL carries `sort_by=date`; it carries `max_days_old` with the configured window; the
   existing country/category/page/`results_per_page` assertions still hold. The URL builder
   (`adzunaPageURL`) is a pure function, so these are exact-value assertions, not a live call.
-- [ ] 1.2 Add `sort_by=date` and `max_days_old` to `adzunaPageURL` in
+- [x] 1.2 Add `sort_by=date` and `max_days_old` to `adzunaPageURL` in
   `internal/ingest/sources/adzuna.go`, with named constants beside `adzunaMaxPages` and a
   comment recording WHY each earns its place: the ordering because the platform's default is
   relevance and stable between runs (the 2026-02-10-first-result measurement), the window
   because it is what makes the loop's existing empty-page exit reachable on a quiet board.
-- [ ] 1.3 Cut `adzunaMaxPages` from 40 to 15 and update its comment: the bound is now one
+- [x] 1.3 Cut `adzunaMaxPages` from 40 to 15 and update its comment: the bound is now one
   leg of a request budget (boards × pages × runs/day), not a standalone "how deep is
   sensible" figure. State the arithmetic — 4 boards × 15 pages × 4 runs = 240/day against a
   250/day ceiling — so a later edit to any one of the three sees what it is spending.
-- [ ] 1.4 Test that a board whose window returns fewer postings than the page budget stops on
+- [x] 1.4 Test that a board whose window returns fewer postings than the page budget stops on
   the empty page rather than issuing the remaining requests. This is the behaviour
   `max_days_old` exists for, and it is the one that is invisible in a URL assertion.
-- [ ] 1.5 `gofmt -w` the touched files, then `go build ./...`, `go vet ./...`, `go test ./...`.
+- [x] 1.5 `gofmt -w` the touched files, then `go build ./...`, `go vet ./...`, `go test ./...`.
 
 ## 2. Close the ageing tail by age
 
-- [ ] 2.1 Add `"adzuna"` to `expireDespiteRegisteredPrefixes` in `cmd/liveness/main.go`, and
+- [x] 2.1 Add `"adzuna"` to `expireDespiteRegisteredPrefixes` in `cmd/liveness/main.go`, and
   extend that variable's comment: it currently explains the whatjobs case (a per-country CPC
   family whose URL is a billing landing page). Adzuna is the same classification reached by a
   different route — a tracking redirect behind bot protection — and the comment should carry
   the 403 measurement, since the next reader's obvious question is "why not just probe it?".
-- [ ] 2.2 Test in `cmd/liveness/main_test.go` that `matchingProviders` resolves `adzuna` from
+- [x] 2.2 Test in `cmd/liveness/main_test.go` that `matchingProviders` resolves `adzuna` from
   a registry containing it, and that the prefix does not accidentally match a different
   provider.
 
 ## 3. Stop a missing credential from silently changing the mechanism
 
-- [ ] 3.1 Write the failing test first: a registry with no `adzuna` entry, `adzuna` listed in
+- [x] 3.1 Write the failing test first: a registry with no `adzuna` entry, `adzuna` listed in
   `expireDespiteRegisteredPrefixes`, and the worker refusing to run.
-- [ ] 3.2 Add the guard in `run()` beside the existing `probeDespiteRegistered` drift guard: a
+- [x] 3.2 Add the guard in `run()` beside the existing `probeDespiteRegistered` drift guard: a
   configured prefix that matches no registered provider stops the run and names the prefix.
   Mirror the existing guard's log wording so the two read as one family.
-- [ ] 3.3 Correct the comment on `expireDespiteRegisteredPrefixes` that currently states "no
+- [x] 3.3 Correct the comment on `expireDespiteRegisteredPrefixes` that currently states "no
   drift guard needed, since membership follows atsProviders by construction". That reasoning
   covers a market being ADDED, which is the case it was written for; it does not cover a
   member being ABSENT, which is what a missing credential produces. Record the distinction
   rather than deleting the sentence — the construction argument is still why the list holds
   prefixes rather than names.
-- [ ] 3.4 Verify the premise on prod before relying on it: `/opt/freehire/.env` carries
+- [x] 3.4 Verify the premise on prod before relying on it: `/opt/freehire/.env` carries
   `ADZUNA_APP_ID` and `deploy/systemd/freehire-liveness.service` reads that file, so the
   guard passes today. Confirmed 2026-09-06; the task is to re-confirm at deploy time, since a
   guard that fires on a healthy host stops the whole liveness run, not just Adzuna's part.
-- [ ] 3.5 `go test ./cmd/liveness/`, then `go vet -tags=integration ./...`.
+- [x] 3.5 `go test ./cmd/liveness/`, then `go vet -tags=integration ./...`.
 
 ## 4. Slow the timer
 
-- [ ] 4.1 Change `deploy/systemd/freehire-ingest@adzuna.timer` from `OnCalendar=*:22:00`
+- [x] 4.1 Change `deploy/systemd/freehire-ingest@adzuna.timer` from `OnCalendar=*:22:00`
   (hourly) to four runs a day, keeping the off-the-hour minute and the existing
   `RandomizedDelaySec` so it does not land with the rest of the fleet.
+  - **Landed as `00/6:22:00`, and the two forms it is not are worth recording.** `*/6:22:00`
+    — the shape the minute/second fields would suggest — does not parse at all, which is the
+    harmless failure. `*:22:00/6` DOES parse, as every hour at :22 repeating on the *second*,
+    so it would have shipped the original hourly cadence while reading in review like a
+    change. Nothing in this repository's build looks at a `.timer`, so it would have surfaced
+    only as an Adzuna request count that never fell. Verified against `systemd-analyze
+    calendar --iterations=4` on the host, and `systemd-analyze verify` accepts the unit.
 - [ ] 4.2 Copy the unit to the host and `systemctl daemon-reload` + restart the timer.
   `release.sh` flips the app and never touches a unit, so this step does not ship itself —
   the change is half-applied until it is done, and the half that is live (a 15-page adapter

--- a/openspec/changes/narrow-adzuna-crawl/tasks.md
+++ b/openspec/changes/narrow-adzuna-crawl/tasks.md
@@ -68,10 +68,30 @@
   elapse matches the new cadence, and with `./deploy/check-drift.sh` that nothing else in
   `deploy/` has drifted from the host in the meantime.
 
+## 4b. Correct the record — the terms claim was wrong once
+
+- [x] 4b.1 An earlier draft of this change asserted 240/day was "inside the platform's terms".
+  It is not. Adzuna states FOUR ceilings (25/min, 250/day, 1,000/week, 2,500/month) and they
+  disagree: 250/day multiplies out to 7,500/month, three times the monthly figure. The
+  tightest governs, so the real ceiling is ~83 requests/day. Corrected in proposal.md,
+  design.md, specs/adzuna-source/spec.md and the budget test, which now reports the weekly
+  and monthly multiples instead of implying compliance from the one ceiling it enforces.
+- [x] 4b.2 The claim had already been published to issue #1759 and PR #2536. Both corrected
+  in place rather than quietly — a wrong compliance claim is exactly the kind a reader carries
+  forward.
+- [ ] 4b.3 **Request higher limits.** Adzuna's own terms say "higher limits are available upon
+  request for publishing use cases", which is what this is. It is the only route to being both
+  compliant and complete: 2,500 requests x 50 results is 125,000 posting-slots a month, a hard
+  ceiling that caps intake BELOW what today's wasteful crawl manages. Until it is granted the
+  crawl runs knowingly over the weekly and monthly ceilings, at 2.9x rather than today's 5.6x.
+  Contact route: the partner form Adzuna publishes for API licensing.
+
 ## 5. Verify against the platform, not against the tests
 
 - [ ] 5.1 After deploy, count a day's real requests rather than trusting the arithmetic: the
-  ingest logs report pages per board per run. Confirm the daily total is under 250. The
+  ingest logs report pages per board per run. Confirm the daily total is under 250, and record
+  the weekly and monthly figures too — those are the ceilings the crawl is knowingly over, so
+  they are the numbers the licence request will be argued against. The
   arithmetic assumes every board spends its full budget; `max_days_old` should make the quiet
   boards spend less, so the measured figure should come in BELOW 240, and a figure at or above
   it means the early exit is not firing.

--- a/openspec/changes/narrow-adzuna-crawl/tasks.md
+++ b/openspec/changes/narrow-adzuna-crawl/tasks.md
@@ -84,16 +84,20 @@
   before the 45-day age rule does). Note the actual figure in this file when it stabilises —
   the estimate is derived from an age histogram, not from having watched it happen.
 
-## 6. Refresh the duplicate markers once
+## 6. The duplicate markers — checked, and nothing to do
 
-- [ ] 6.1 Run `REINDEX_DEDUP_ONLY=1` on prod so aggregator suppression re-marks the 142,229
-  open Adzuna postings whose company is already held first-party. No need to pause
-  `search-drain` for it — the marker-only pass builds no Meilisearch client and runs no
-  rebuild. It is an operational step, not a code dependency: nothing in sections 1-4 waits on
-  it, and skipping it only leaves search showing duplicates it already shows today.
-- [ ] 6.2 Record how many markers it actually set. Suppression needs a TITLE twin, not merely
-  a covered company, so the reachable subset is smaller than 142,229 — 35,268 Adzuna postings
-  carry an aggregator marker today, and the gap between those figures is what this run moves.
+- [x] 6.1 ~~Run `REINDEX_DEDUP_ONLY=1` on prod.~~ **Not needed; the premise was wrong.**
+  `freehire-reindex-dedup-only.timer` already runs that exact pass six times a day (01:30,
+  10:30, 13:30, 16:30, 19:30, 22:30 UTC), `Result=success`, `ExecMainStatus=0`. The task was
+  written from CLAUDE.md, which describes the flag as existing "so the markers can refresh on
+  a tighter cadence" — true, and it says nothing about whether a timer was ever created for
+  it. One `systemctl list-timers` answered what the documentation could not.
+- [x] 6.2 ~~Record how many markers it set.~~ Answered without running anything: 35,268 is
+  not a partial figure working toward 142,229, it is the finished one. Suppression requires a
+  matching TITLE, not merely a covered company, so the ~107k difference is Adzuna postings
+  whose employer's own ATS lists nothing comparable — which the marker is right to leave
+  alone. Had the manual run gone ahead it would have written zero rows and been read as
+  confirmation.
 
 ## 7. Close out the issue
 

--- a/openspec/changes/narrow-adzuna-crawl/tasks.md
+++ b/openspec/changes/narrow-adzuna-crawl/tasks.md
@@ -97,16 +97,20 @@
 
 ## 7. Close out the issue
 
-- [ ] 7.1 Post the measurement and the verdict to issue #1759 — step 4 asked whether Adzuna's
+- [x] 7.1 Post the measurement and the verdict to issue #1759 — step 4 asked whether Adzuna's
   remainder is exclusive, and it is: 20,350 companies and 81,730 open postings exist in the
   catalogue through Adzuna and nowhere else. Adzuna is kept and narrowed, not deprecated.
-- [ ] 7.2 Note in #1759 that its step 2 instructions are stale: `sources/` was retired in
+- [x] 7.2 Note in #1759 that its step 2 instructions are stale: `sources/` was retired in
   #2406 and `cmd/harvest-boards` now writes to the `boards` table. A reader following the
   issue's text lands on a directory that no longer exists.
-- [ ] 7.3 Note that batch 2/2 (`breezy`, `freshteam`, `personio`, `trakstar`, `workable`) was
+- [x] 7.3 Note that batch 2/2 (`breezy`, `freshteam`, `personio`, `trakstar`, `workable`) was
   promised in a comment on 2026-08-12 and never landed — no PR references it. Either finish it
   or say plainly that it was dropped; a half-finished batch recorded as "to follow" reads as
   in-progress forever.
+  - Posted 2026-09-06, with the figure that should decide it: orphan companies reachable only
+    through Adzuna were 18,726 when #1759 was opened and are **26,867** today. The aggregator
+    adds companies faster than 480 onboarded boards remove them, so batch 2 is worth finishing
+    on its own merits but is not the lever the issue was hoping for.
 
 ## 8. Out of scope, recorded so it is not lost
 

--- a/openspec/changes/narrow-adzuna-crawl/tasks.md
+++ b/openspec/changes/narrow-adzuna-crawl/tasks.md
@@ -1,0 +1,110 @@
+## 1. Order the crawl by date and bound it by freshness
+
+- [ ] 1.1 Write the failing tests first in `internal/ingest/sources/adzuna_test.go`: the built
+  page URL carries `sort_by=date`; it carries `max_days_old` with the configured window; the
+  existing country/category/page/`results_per_page` assertions still hold. The URL builder
+  (`adzunaPageURL`) is a pure function, so these are exact-value assertions, not a live call.
+- [ ] 1.2 Add `sort_by=date` and `max_days_old` to `adzunaPageURL` in
+  `internal/ingest/sources/adzuna.go`, with named constants beside `adzunaMaxPages` and a
+  comment recording WHY each earns its place: the ordering because the platform's default is
+  relevance and stable between runs (the 2026-02-10-first-result measurement), the window
+  because it is what makes the loop's existing empty-page exit reachable on a quiet board.
+- [ ] 1.3 Cut `adzunaMaxPages` from 40 to 15 and update its comment: the bound is now one
+  leg of a request budget (boards × pages × runs/day), not a standalone "how deep is
+  sensible" figure. State the arithmetic — 4 boards × 15 pages × 4 runs = 240/day against a
+  250/day ceiling — so a later edit to any one of the three sees what it is spending.
+- [ ] 1.4 Test that a board whose window returns fewer postings than the page budget stops on
+  the empty page rather than issuing the remaining requests. This is the behaviour
+  `max_days_old` exists for, and it is the one that is invisible in a URL assertion.
+- [ ] 1.5 `gofmt -w` the touched files, then `go build ./...`, `go vet ./...`, `go test ./...`.
+
+## 2. Close the ageing tail by age
+
+- [ ] 2.1 Add `"adzuna"` to `expireDespiteRegisteredPrefixes` in `cmd/liveness/main.go`, and
+  extend that variable's comment: it currently explains the whatjobs case (a per-country CPC
+  family whose URL is a billing landing page). Adzuna is the same classification reached by a
+  different route — a tracking redirect behind bot protection — and the comment should carry
+  the 403 measurement, since the next reader's obvious question is "why not just probe it?".
+- [ ] 2.2 Test in `cmd/liveness/main_test.go` that `matchingProviders` resolves `adzuna` from
+  a registry containing it, and that the prefix does not accidentally match a different
+  provider.
+
+## 3. Stop a missing credential from silently changing the mechanism
+
+- [ ] 3.1 Write the failing test first: a registry with no `adzuna` entry, `adzuna` listed in
+  `expireDespiteRegisteredPrefixes`, and the worker refusing to run.
+- [ ] 3.2 Add the guard in `run()` beside the existing `probeDespiteRegistered` drift guard: a
+  configured prefix that matches no registered provider stops the run and names the prefix.
+  Mirror the existing guard's log wording so the two read as one family.
+- [ ] 3.3 Correct the comment on `expireDespiteRegisteredPrefixes` that currently states "no
+  drift guard needed, since membership follows atsProviders by construction". That reasoning
+  covers a market being ADDED, which is the case it was written for; it does not cover a
+  member being ABSENT, which is what a missing credential produces. Record the distinction
+  rather than deleting the sentence — the construction argument is still why the list holds
+  prefixes rather than names.
+- [ ] 3.4 Verify the premise on prod before relying on it: `/opt/freehire/.env` carries
+  `ADZUNA_APP_ID` and `deploy/systemd/freehire-liveness.service` reads that file, so the
+  guard passes today. Confirmed 2026-09-06; the task is to re-confirm at deploy time, since a
+  guard that fires on a healthy host stops the whole liveness run, not just Adzuna's part.
+- [ ] 3.5 `go test ./cmd/liveness/`, then `go vet -tags=integration ./...`.
+
+## 4. Slow the timer
+
+- [ ] 4.1 Change `deploy/systemd/freehire-ingest@adzuna.timer` from `OnCalendar=*:22:00`
+  (hourly) to four runs a day, keeping the off-the-hour minute and the existing
+  `RandomizedDelaySec` so it does not land with the rest of the fleet.
+- [ ] 4.2 Copy the unit to the host and `systemctl daemon-reload` + restart the timer.
+  `release.sh` flips the app and never touches a unit, so this step does not ship itself —
+  the change is half-applied until it is done, and the half that is live (a 15-page adapter
+  running hourly) is still ~4× the intended budget.
+- [ ] 4.3 Confirm with `systemctl list-timers freehire-ingest@adzuna` that the next
+  elapse matches the new cadence, and with `./deploy/check-drift.sh` that nothing else in
+  `deploy/` has drifted from the host in the meantime.
+
+## 5. Verify against the platform, not against the tests
+
+- [ ] 5.1 After deploy, count a day's real requests rather than trusting the arithmetic: the
+  ingest logs report pages per board per run. Confirm the daily total is under 250. The
+  arithmetic assumes every board spends its full budget; `max_days_old` should make the quiet
+  boards spend less, so the measured figure should come in BELOW 240, and a figure at or above
+  it means the early exit is not firing.
+- [ ] 5.2 Confirm intake moved in the intended direction: `jobs.created_at` for `source =
+  'adzuna'` grouped by day, compared against the 7-day pre-change mean of ~6,300/day. Expect
+  it to roughly double. A figure that does NOT move is the signal that `sort_by=date` is not
+  reaching the API — check a logged request URL before looking anywhere else.
+- [ ] 5.3 Watch the Adzuna slice shrink and record where it settles. Expect 301k to fall
+  toward 150-180k over several weeks, faster at first (the 14-day sweep reaches postings
+  before the 45-day age rule does). Note the actual figure in this file when it stabilises —
+  the estimate is derived from an age histogram, not from having watched it happen.
+
+## 6. Refresh the duplicate markers once
+
+- [ ] 6.1 Run `REINDEX_DEDUP_ONLY=1` on prod so aggregator suppression re-marks the 142,229
+  open Adzuna postings whose company is already held first-party. No need to pause
+  `search-drain` for it — the marker-only pass builds no Meilisearch client and runs no
+  rebuild. It is an operational step, not a code dependency: nothing in sections 1-4 waits on
+  it, and skipping it only leaves search showing duplicates it already shows today.
+- [ ] 6.2 Record how many markers it actually set. Suppression needs a TITLE twin, not merely
+  a covered company, so the reachable subset is smaller than 142,229 — 35,268 Adzuna postings
+  carry an aggregator marker today, and the gap between those figures is what this run moves.
+
+## 7. Close out the issue
+
+- [ ] 7.1 Post the measurement and the verdict to issue #1759 — step 4 asked whether Adzuna's
+  remainder is exclusive, and it is: 20,350 companies and 81,730 open postings exist in the
+  catalogue through Adzuna and nowhere else. Adzuna is kept and narrowed, not deprecated.
+- [ ] 7.2 Note in #1759 that its step 2 instructions are stale: `sources/` was retired in
+  #2406 and `cmd/harvest-boards` now writes to the `boards` table. A reader following the
+  issue's text lands on a directory that no longer exists.
+- [ ] 7.3 Note that batch 2/2 (`breezy`, `freshteam`, `personio`, `trakstar`, `workable`) was
+  promised in a comment on 2026-08-12 and never landed — no PR references it. Either finish it
+  or say plainly that it was dropped; a half-finished batch recorded as "to follow" reads as
+  in-progress forever.
+
+## 8. Out of scope, recorded so it is not lost
+
+- [ ] 8.1 `cmd/hydrate-adzuna-description` fetches the same `…/land/ad/<id>` URLs every 30
+  minutes and meets the same 403 this change measured. Its own source comment records "no
+  JobPosting block" as the majority failure mode of its first production runs, which is what
+  an Access Denied page looks like to it. Measure its success rate; if it is near zero, it is
+  spending a request every 3.6 seconds for nothing. Separate change.


### PR DESCRIPTION
## Summary

Adzuna is the catalogue's largest single source — **301,008 open postings, 4.34% of the
6,940,260 open catalogue** — and the crawl filling it has never sent a sort order, so the
platform answers in *relevance* order, which is stable between runs. Forty pages of that,
hourly, re-read one fixed slice for ever. Measured live on 2026-09-06, `gb/it-jobs`:

| request | reported total | first result's `created` |
|---|---:|---|
| what the adapter sent | 52,942 | **2026-02-10** |
| the same request with `sort_by=date` | 52,941 | 2026-09-06T12:34 |

That budget bought ~23,500 posting-slots a day and wrote ~6,300 new postings — a **27%
yield** — at **~470 requests/day**.

`sort_by=date` at 240 requests/day halves the requests and roughly doubles the intake:

| | before | after |
|---|---:|---:|
| requests/day | ~470 | **240** |
| new postings written/day | ~6,300 | up to ~12,000 |
| vs the 2,500/month ceiling | 5.6× over | **2.9× over** |

### It does not bring us inside the terms, and an earlier revision of this PR wrongly said it did

Adzuna states **four** ceilings and they disagree: `25/min · 250/day · 1,000/week ·
2,500/month`. 250/day multiplies out to 7,500/month, three times the monthly figure, so the
tightest governs and the real ceiling is **~83 requests/day**. The first draft read the two
figures it had as one thing said twice and did the arithmetic against the convenient one.

240/day is a **deliberate overage**: 2,500 × 50 is 125,000 posting-slots a month, a hard
ceiling no arrangement of pages, boards or runs can raise, so full compliance would cap intake
at ~4,150/day — *below* the ~6,300 the wasteful crawl manages today, for the source carrying
20,350 companies the catalogue holds nowhere else. The budget test now reports every ceiling's
multiple rather than passing on the strength of the one it enforces, and requesting the higher
limits Adzuna's terms invite ("available upon request for publishing use cases") is a task on
the change.

## What changed

- **`internal/ingest/sources/adzuna.go`** — sends `sort_by=date` and `max_days_old=2`; page
  budget 40 → 15. `max_days_old` is *not* redundant with the ordering: `Fetch`'s loop ends on
  an empty page, and against a 53k-deep feed that never happens inside the budget, so a quiet
  board (`au` publishes ~176 between runs) would spend its full budget on postings the
  seen-set discards — drawn from the same ceiling a busy board needs.
- **`deploy/systemd/freehire-ingest@adzuna.timer`** — hourly → four runs a day.
  4 boards × 15 pages × 4 runs = **240/day**.
- **`cmd/liveness/main.go`** — `adzuna` joins `expireDespiteRegisteredPrefixes`. Once the
  crawl is date-ordered it stops being a liveness signal for an ageing posting, and a probe
  cannot take over: following 40 stored URLs, **~30 answered `403 Access Denied`** (bot
  protection on the `…/land/ad/<id>` tracking redirect, which classifies `uncertain` —
  correctly). Same classification `whatjobs` already has, and it keeps that family's second
  clock: a posting must ALSO have gone unseen past its source's sweep grace, so one the crawl
  is still listing is never age-closed.
- **A guard that family already needed.** Every member is credential-gated and this worker
  builds the registry from that same constructor, so a host without `ADZUNA_APP_ID` drops the
  source out of the age rule *and* into the URL probe — the lifecycle mechanism changing hands
  on an environment variable about crawling, silently, in the direction that leaves postings
  open for ever. A configured prefix matching no registered provider now refuses to run.
- **`openspec/changes/narrow-adzuna-crawl`** — proposal, design, tasks, and two spec deltas.
  `job-lifecycle`'s age-rule requirement currently *forbids* what `expireDespiteRegistered`
  has done for every whatjobs market since it landed (the string appears nowhere under
  `openspec/`). Code is right, spec was stale; rewritten to state the real rule. `adzuna-source`
  is new — the largest source in the catalogue had no spec at all.

## Why Adzuna is kept rather than deprecated

Issue #1759's step 4. Classifying every open Adzuna posting by whether its company is
reachable another way:

| the company is… | companies | postings |
|---|---:|---:|
| already held through its own ATS | 8,915 | 142,229 |
| carried by another aggregator | 6,517 | 72,931 |
| **reachable only through Adzuna** | **20,350** | **81,730** |

72% redundant at the company level — and dropping it would still cost 20,350 employers the
catalogue holds nowhere else. Attention agrees narrowly: 4.87% of bot-filtered `page_uniques`
for 4.34% of the catalogue.

## Expected effect, stated up front

**The Adzuna slice will fall from ~301k toward 150-180k over several weeks**, faster at first
— its own 14-day sweep reaches postings before the 45-day age rule does. Intake roughly
doubles over the same period, so the slice refills with postings that are current rather than
with February inventory. Recorded in the proposal so the drop is not mistaken for a broken
adapter.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `go test ./...`
- [x] gofmt clean; pre-commit hooks pass (golangci-lint 0 issues, govulncheck clean)
- [x] 5 new tests: the request carries both parameters; a quiet board stops at the empty page
  instead of spending its budget; the page budget stays under the daily ceiling; `adzuna`
  resolves without over-reaching a similarly-named provider; the unseen window does not narrow
- [x] API behaviour verified live, not assumed: `sort_by=date` and `max_days_old` both work,
  a malformed window answers 500 (fails loudly rather than returning unfiltered results), and
  `results_per_page=100` answers 400 — confirming the 50 the constant already assumed
- [x] Timer verified with `systemd-analyze calendar --iterations=4` and `systemd-analyze
  verify`. Worth flagging: **`*:22:00/6` parses** — as every hour at :22 repeating on the
  *second* — so it would have shipped the old hourly cadence while reading in review like a
  change. Nothing in the build reads a `.timer`. The unit records both wrong forms.
- [ ] **After merge, the timer must be copied to the host** — `release.sh` flips the app and
  never touches a unit, so until then the live half is a 15-page adapter still running hourly
- [ ] Post-deploy: count a day's real requests (expect **below** 240 — the early exit should
  make quiet boards spend less; at or above means it is not firing) and confirm intake moved

Closes the step-4 question in #1759.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Adzuna listings are now prioritized by publication date and limited to postings from the past two days.
  * Crawls use up to 50 results per page and stop sooner when no recent results are available.
  * Adzuna crawling now runs four times daily instead of hourly, keeping request usage within service limits.

* **Reliability**
  * Expiration configuration is now validated at startup, preventing unmatched provider settings from being silently ignored.

* **Documentation**
  * Added documentation describing Adzuna filtering, crawl limits, freshness handling, and job expiration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
