### PR TITLE
Stop the mask re-escaping the requirement it was protecting

### DIFF
--- a/internal/job/jobfacts/jobfacts.go
+++ b/internal/job/jobfacts/jobfacts.go
@@ -93,10 +93,15 @@ func EmploymentType(title, description string) string {
 // "MS SQL" and "bs"/"b.s" with everyday text — and bare "master" is excluded because
 // "scrum master" is not a degree. The "'s" possessive, an explicit "<level> degree",
 // or the -Sc/MBA/PhD tokens are required instead.
+//
+// The possessive admits BOTH apostrophes. A description written in a rich-text editor
+// carries the typographic one, and an ASCII-only spelling read "Bachelor’s degree
+// required" as no degree at all — every one of the five most recent prod postings
+// naming a degree spelled it that way (checked 2026-09-06).
 var (
 	rePhD      = regexp.MustCompile(`\b(ph\.?\s?d|phd|doctorate|doctoral)\b`)
-	reMaster   = regexp.MustCompile(`\b(master'?s|master degree|m\.?sc|mba|graduate degree)\b`)
-	reBachelor = regexp.MustCompile(`\b(bachelor'?s|bachelor degree|b\.?sc|undergraduate degree)\b`)
+	reMaster   = regexp.MustCompile(`\b(master['’]?s|master degree|m\.?sc|mba|graduate degree)\b`)
+	reBachelor = regexp.MustCompile(`\b(bachelor['’]?s|bachelor degree|b\.?sc|undergraduate degree)\b`)
 	reNoDegree = regexp.MustCompile(`\b(no (?:degree|diploma)|degree not required|without a degree|no degree required)\b`)
 )
 

--- a/internal/job/jobfacts/jobfacts_test.go
+++ b/internal/job/jobfacts/jobfacts_test.go
@@ -57,6 +57,8 @@ func TestEducationLevel(t *testing.T) {
 		{"phd dotted", "Ph.D. or equivalent research experience.", "phd"},
 		{"phd beats bachelor", "Bachelor's or PhD in a quantitative field.", "phd"},
 		{"bachelor degree no apostrophe", "A bachelor degree in CS is required.", "bachelor"},
+		{"typographic apostrophe", "Bachelor’s degree required.", "bachelor"},
+		{"typographic apostrophe, master", "Master’s degree required.", "master"},
 		{"explicit none", "No degree required for this role.", "none"},
 		{"degree word alone not enough", "This is a degree of difficulty.", ""},
 		{"MS Office is not a master's", "Proficiency in MS Office and MS SQL Server.", ""},

--- a/internal/job/jobfacts/optional_clause_test.go
+++ b/internal/job/jobfacts/optional_clause_test.go
@@ -98,3 +98,18 @@ func TestACoordinatedRequirementIsLostWithItsClause(t *testing.T) {
 		t.Errorf("RequiredCertifications = %v, want [cisa]", got)
 	}
 }
+
+// The whole point of the fix is a posting whose preferred section sits beside a real
+// requirement — which is also the only shape that gets re-rendered. If the re-render
+// re-escapes the requirement's text, the fix silently costs the fact it was meant to
+// protect. Prod rows found this; nothing here did.
+func TestARequirementSurvivesTheRenderItsPreferredSectionForces(t *testing.T) {
+	const preferred = `<h3>Nice to have</h3><ul><li>Kubernetes, a PMP</li></ul>`
+	if got := EducationLevel(`<h3>Requirements</h3><p>Bachelor's degree required.</p>` + preferred); got != "bachelor" {
+		t.Errorf("EducationLevel = %q, want %q", got, "bachelor")
+	}
+	got := RequiredCertifications(`<h3>Requirements</h3><p>A commercial driver's license.</p>` + preferred)
+	if len(got) != 1 || got[0] != "cdl" {
+		t.Errorf("RequiredCertifications = %v, want [cdl]", got)
+	}
+}

--- a/internal/job/reqextract/AGENTS.md
+++ b/internal/job/reqextract/AGENTS.md
@@ -47,6 +47,13 @@ section ends instead of each guessing.
   spaces (`BlankWords`) leaves every boundary where the posting put it, and a
   description with no preferred section comes back **byte-identical**, re-render
   skipped.
+- **A re-render is not a no-op on the TEXT, and `restoreLiterals` is why.** `x/net/html`
+  escapes an apostrophe, a quote and a bare `>` on the way out, all three of which a
+  description carries literally. `bachelor&#39;s` matches no vocabulary, so the escape
+  cost the requirement on exactly the postings this masker exists for — only a posting
+  WITH a preferred section is re-rendered at all. Every unit test stayed green; a query
+  against prod rows found it. `&amp;` and `&lt;` are NOT restored: the source wrote
+  those, so re-emitting them is the round trip, and undoing them would be a change.
 - **`MaskPreferred` closes a section only on a heading; `Derive` also closes on prose.**
   The difference is deliberate and is the whole reason they are two walks over one
   vocabulary. `Derive` wants the LIST under a heading, so prose between the two means

--- a/internal/job/reqextract/mask.go
+++ b/internal/job/reqextract/mask.go
@@ -93,8 +93,25 @@ func MaskPreferred(descriptionHTML string) string {
 	if err := xhtml.Render(&b, doc); err != nil {
 		return descriptionHTML
 	}
-	return b.String()
+	return restoreLiterals.Replace(b.String())
 }
+
+// restoreLiterals undoes the escaping the re-render ADDS. A description carries an
+// apostrophe, a quote and often a bare ">" as literal characters; x/net/html escapes
+// all three on the way out, and the matchers reading this text see `bachelor&#39;s`,
+// which their vocabulary does not contain. That broke exactly the postings this masker
+// exists for — only a posting WITH a preferred section is re-rendered at all — and
+// every unit test stayed green, because none of them spelled a degree with an
+// apostrophe inside a document that had a preferred section.
+//
+// `&amp;` and `&lt;` are deliberately not here: those are escapes the SOURCE already
+// wrote, which the parser decoded and the renderer restored. Undoing them would not be
+// a round trip, it would be a change.
+var restoreLiterals = strings.NewReplacer(
+	"&#39;", "'",
+	"&#34;", `"`,
+	"&gt;", ">",
+)
 
 // openSection expresses the walk's boolean state in headingDecision's vocabulary, so
 // the two callers share one decision function rather than one of them re-deciding

--- a/internal/job/reqextract/mask_test.go
+++ b/internal/job/reqextract/mask_test.go
@@ -85,3 +85,37 @@ func TestMaskPreferredLeavesAnUnaffectedDescriptionByteIdentical(t *testing.T) {
 		}
 	}
 }
+
+// Re-rendering a parsed document is not a no-op on its TEXT: x/net/html escapes an
+// apostrophe, a quote and a bare ">" that the description carried literally. The
+// matchers downstream read that text, and `bachelor's` spelled `bachelor&#39;s` matches
+// nothing — which broke exactly the postings this masker exists for, since only a
+// posting WITH a preferred section is ever re-rendered. Found against prod rows, not
+// here: every unit test was green.
+func TestMaskPreferredDoesNotReescapeText(t *testing.T) {
+	const preferredSection = `<h3>Nice to have</h3><p>Kubernetes.</p>`
+	cases := []struct{ name, html, want string }{
+		{
+			name: "apostrophe",
+			html: `<h3>Requirements</h3><p>Bachelor's degree required.</p>` + preferredSection,
+			want: `Bachelor's degree required.`,
+		},
+		{
+			name: "quotes and a bare greater-than",
+			html: `<h3>Requirements</h3><p>A "senior" engineer, 5 > 3 years.</p>` + preferredSection,
+			want: `A "senior" engineer, 5 > 3 years.`,
+		},
+		{
+			name: "an ampersand the source already escaped stays escaped",
+			html: `<h3>Requirements</h3><p>R&amp;D experience.</p>` + preferredSection,
+			want: `R&amp;D experience.`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MaskPreferred(tc.html); !strings.Contains(got, tc.want) {
+				t.Errorf("MaskPreferred did not preserve %q; got %q", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to #2531. **Fixes a regression that PR shipped to prod**, plus a pre-existing defect the same investigation turned up.

## 1. The mask re-escaped the text it was protecting (regression, mine)

`MaskPreferred` re-renders the document it parsed, and `x/net/html` escapes three characters a description carries **literally**:

```
in  = <p>a'b "c" d>e f&amp;g</p>
out = <p>a&#39;b &#34;c&#34; d&gt;e f&amp;g</p>
```

The matchers downstream then read `bachelor&#39;s`, which no vocabulary contains — so the posting lost the degree, credential or years it actually **required**.

It hit precisely the postings the mask exists for: only a posting **with** a preferred section is re-rendered at all.

```go
EducationLevel(`<p>Bachelor's degree required.</p>`)                        // "bachelor"
EducationLevel(`<h3>Requirements</h3><p>Bachelor's degree required.</p>` +
               `<h3>Nice to have</h3><p>Kubernetes.</p>`)                   // ""  ← the bug
```

`restoreLiterals` undoes the three escapes the render **adds**. `&amp;` and `&lt;` are deliberately left alone: the source wrote those, so re-emitting them is the round trip, and undoing them would be a change.

**Every unit test in #2531 was green.** None of them spelled a requirement with an apostrophe inside a document that also had a preferred section. What found it was a query against prod rows written after the deploy:

```
276 rows created since 19:55Z
 38 mention a degree
  0 have education_level set
```

## 2. The degree vocabulary knew only the ASCII apostrophe (pre-existing)

Reading those rows turned up a second, older defect. All five of the most recent postings naming a degree spell it with the **typographic** apostrophe — which is what a rich-text editor writes:

```
Bachelor’s degree or equivalent combination of education and experience
Bachelor’s degree in construction management, civil engineering, …
Must have a Bachelor’s degree from an accredited university …
```

`reBachelor`/`reMaster` matched `'` only, so `Bachelor’s degree required` read as **no degree at all**. This predates #2531 — `EducationLevel("<p>Bachelor’s degree required.</p>")` returns `""` on `main` before either PR. Both spellings now match.

This one widens what gets derived, so it is the reason the backfill below matters more than it did yesterday.

## Tests

Both defects are pinned at the layer they broke, and both fail without the fix:

- `TestMaskPreferredDoesNotReescapeText` — apostrophe, quotes, bare `>`, and an `&amp;` that must stay escaped
- `TestARequirementSurvivesTheRenderItsPreferredSectionForces` — the end-to-end shape: a real requirement beside a preferred section
- two `TestEducationLevel` cases for the typographic apostrophe

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — clean
- `go vet -tags=integration ./...` — clean
- pre-commit (gofmt, gitleaks, doc-links, govulncheck, golangci-lint) — clean

## Still owed after this

Unchanged from #2531, and now carrying more: `cmd/backfill-derive` (`BACKFILL_CONCURRENCY` 2–3) followed by a **full `make reindex`**. Deliberately deferred to a chosen window.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of bachelor’s and master’s degree requirements using typographic apostrophes.
  * Preserved literal apostrophes, quotation marks, and greater-than symbols when processing job descriptions.
  * Prevented requirements from being lost when preferred sections are re-rendered.

* **Tests**
  * Added coverage for typographic apostrophes and preservation of requirement text during section masking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->