### PR TITLE
Stop a company's public page publishing private job descriptions, and stop a rejection reading as an offer

### DIFF
--- a/internal/api/handler/companies_integration_test.go
+++ b/internal/api/handler/companies_integration_test.go
@@ -627,3 +627,80 @@ func TestListCompaniesYCStageFlags(t *testing.T) {
 		}
 	})
 }
+
+// A company's public page must not list the jd-tailor-intake private postings that name
+// it. InsertPrivateJob derives a company_slug from whatever employer the pasted text
+// names, the route is anonymous, and the list is ordered newest-first — so a private JD
+// naming a company the catalogue already knows arrived at the TOP of that company's page,
+// with its full pasted body. The page also contradicted itself: RefreshCompanyFacets
+// already leaves private rows out of companies.job_count.
+func TestGetCompanyOmitsPrivateJobs(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO companies (slug, name, job_count) VALUES ('stealthco', 'Stealth Co', 1)`); err != nil {
+		t.Fatalf("seed company: %v", err)
+	}
+	var submitterID int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (email) VALUES ('paster@example.test') RETURNING id`).Scan(&submitterID); err != nil {
+		t.Fatalf("seed submitter: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO jobs (source, external_id, url, title, company, company_slug, description, public_slug)
+		 VALUES ('greenhouse', 'gh:stealth:1', 'http://ats.test/s1', 'Public Role', 'Stealth Co', 'stealthco',
+		         'Public body', 'public-role-stealthco-cccc3333')`); err != nil {
+		t.Fatalf("seed public job: %v", err)
+	}
+	// Written after the public one, so newest-first ordering would put it first.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO jobs (source, external_id, url, title, company, company_slug, description, public_slug,
+		                   created_by, is_private)
+		 VALUES ('pasted', 'private:stealth:1', '', 'Private Role', 'Stealth Co', 'stealthco',
+		         'Confidential body', 'private-role-stealthco-dddd4444', $1, true)`, submitterID); err != nil {
+		t.Fatalf("seed private job: %v", err)
+	}
+
+	h := &companiesHandlers{queries: db.New(pool)}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/companies/:slug", h.GetCompany)
+
+	resp, err := app.Test(httptest.NewRequestWithContext(ctx, "GET", "/api/v1/companies/stealthco", nil))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, body)
+	}
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var body struct {
+		Data struct {
+			Jobs []struct {
+				PublicSlug string `json:"public_slug"`
+			} `json:"jobs"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	var slugs []string
+	for _, j := range body.Data.Jobs {
+		slugs = append(slugs, j.PublicSlug)
+	}
+	sort.Strings(slugs)
+	if strings.Join(slugs, ",") != "public-role-stealthco-cccc3333" {
+		t.Errorf("company jobs = %v, want only the public posting", slugs)
+	}
+	// Belt and braces on the leak that matters: the pasted body must not be on the wire
+	// under any key, whatever the projection is shaped like.
+	if strings.Contains(string(raw), "Confidential body") {
+		t.Error("the private posting's pasted description reached the anonymous company page")
+	}
+}

--- a/internal/api/handler/jobs_moderation_integration_test.go
+++ b/internal/api/handler/jobs_moderation_integration_test.go
@@ -237,4 +237,47 @@ func TestModeratorJobsEndToEnd(t *testing.T) {
 			t.Errorf("status = %d, want 404", resp.StatusCode)
 		}
 	})
+
+	// A private job is the jd-tailor-intake path: one user's pasted JD, kept out of reach
+	// by an unguessable slug. It stamps created_by with the SUBMITTER, so the
+	// created_by IS NOT NULL scope that keeps this endpoint off crawled vacancies matched
+	// it too — a moderator holding the slug could read one user's private text and rewrite
+	// it, and the edit's company_upsert CTE would mint a public companies row from the
+	// employer that InsertPrivateJob deliberately refuses to register.
+	t.Run("editing a private job is a 404 and mints no company", func(t *testing.T) {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO jobs (source, external_id, url, title, company, company_slug, description,
+			                   public_slug, created_by, is_private)
+			 VALUES ('weblink', 'private:1', 'http://stealth.test/1', 'Private Role', 'Stealthworks', 'stealthworks',
+			         'Confidential body', 'private-role-stealthworks-bbbb2222', $1, true)`, userID); err != nil {
+			t.Fatalf("seed private job: %v", err)
+		}
+
+		resp, err := app.Test(req(fiber.MethodPatch, "/api/v1/jobs/private-role-stealthworks-bbbb2222", modCookie, `{"title":"Hijacked","company":"Stealthworks"}`))
+		if err != nil {
+			t.Fatalf("edit private: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != fiber.StatusNotFound {
+			t.Errorf("status = %d, want 404", resp.StatusCode)
+		}
+
+		var title string
+		if err := pool.QueryRow(ctx,
+			"SELECT title FROM jobs WHERE public_slug = 'private-role-stealthworks-bbbb2222'").Scan(&title); err != nil {
+			t.Fatalf("read back private job: %v", err)
+		}
+		if title != "Private Role" {
+			t.Errorf("title = %q, want the private job left untouched", title)
+		}
+
+		var companies int
+		if err := pool.QueryRow(ctx,
+			"SELECT count(*) FROM companies WHERE slug = 'stealthworks'").Scan(&companies); err != nil {
+			t.Fatalf("count companies: %v", err)
+		}
+		if companies != 0 {
+			t.Errorf("companies rows for the private JD's employer = %d, want 0", companies)
+		}
+	})
 }

--- a/internal/application/mailclassify/keyword.go
+++ b/internal/application/mailclassify/keyword.go
@@ -22,17 +22,39 @@ type keywordRule struct {
 	phrases []string
 }
 
+// rejectionPhrases is named separately from the rule that carries it because
+// KeywordStatus reads it twice: once in list order, and once more to settle a
+// contradiction — see the rule there.
+//
+// "unfortunately" alone is intentionally excluded: too weak to skip the LLM on
+// (it appears in some acknowledgements) — those emails defer to the LLM instead.
+//
+// The last two entries are the standard rejections that QUOTE offer vocabulary
+// ("we are unable to extend an offer at this time", "we have decided to extend an
+// offer to another candidate"). Both were measured against KeywordStatus resolving
+// to `offer`, because the phrase "extend an offer" is really in them; they are
+// listed here so the contradiction rule below has something to see.
+var rejectionPhrases = []string{
+	"we regret", "regret to inform", "not to proceed", "not moving forward", "not be moving forward",
+	"won't be moving forward", "won’t be moving forward", "decided not to move", "decided not to proceed",
+	"other candidates", "not be progressing", "will not be progressing", "not selected",
+	"move forward with other", "not the right fit", "not a fit for", "decided to move forward with",
+	"unable to extend an offer", "another candidate",
+}
+
 // keywordRules is precision-first: only strong, unambiguous phrases. Rejection is
 // checked before acknowledgement so a "thank you for applying … unfortunately …"
 // email resolves to rejection, and ambiguous openers ("thank you for your
 // interest" alone) match nothing and defer to the LLM.
+//
+// Order alone no longer decides a rejection against a POSITIVE signal — KeywordStatus
+// settles that explicitly, because there is no order of this list that reads a
+// rejection worded in offer vocabulary correctly.
 var keywordRules = []keywordRule{
 	{SignalOffer, []string{"pleased to offer you", "we are pleased to offer", "job offer from", "offer of employment", "extend an offer"}},
 	{SignalAssessment, []string{"coding challenge", "take-home", "take home assignment", "technical assessment", "hackerrank", "codility", "online assessment", "coding test"}},
 	{SignalInterviewInvitation, []string{"invite you to interview", "invite you to an interview", "invitation to interview", "interview invitation", "like to invite you", "schedule a call", "schedule an interview", "set up a call", "set up an interview", "you're invited", "you’re invited", "invited to a call", "book a time"}},
-	// "unfortunately" alone is intentionally excluded: too weak to skip the LLM on
-	// (it appears in some acknowledgements) — those emails defer to the LLM instead.
-	{SignalRejection, []string{"we regret", "regret to inform", "not to proceed", "not moving forward", "not be moving forward", "won't be moving forward", "won’t be moving forward", "decided not to move", "decided not to proceed", "other candidates", "not be progressing", "will not be progressing", "not selected", "move forward with other", "not the right fit", "not a fit for", "decided to move forward with"}},
+	{SignalRejection, rejectionPhrases},
 	// Ordered before acknowledgement: an "…thank you for starting your application,
 	// please complete it…" email is an incomplete-application to-do, not an ack.
 	{SignalIncompleteApplication, []string{"application is incomplete", "incomplete application", "complete your application", "finish your application", "action required to complete", "to complete your application", "your application is not complete", "did not complete your application"}},
@@ -43,14 +65,48 @@ var keywordRules = []keywordRule{
 // and body, returning (signal, true) only on a strong, unambiguous phrase and
 // ("", false) otherwise — deferring the ambiguous tail (soft/multilingual
 // rejections, bare interest openers) to the LLM. Precision over recall by design.
+//
+// Contradictory evidence is settled, not raced down the list: a text that also holds a
+// rejection phrase can never come back as a signal that ADVANCES the application. A
+// rejection is written in the vocabulary of the thing it declines ("we regret to inform
+// you we cannot extend an offer", "thank you for completing the coding challenge —
+// unfortunately we are not moving forward"), so first-match-wins over an ordered list
+// answered `offer` and `assessment` for those, and Classify's keyword fast path reports
+// 0.95 confidence, over the 0.8 the stage advance needs — a rejection moved the
+// application to `offer`.
+//
+// The rejection is returned rather than deferring to the model: it is the safe direction
+// (StageFor gives it Advances:false, so nothing moves on it), it is the right answer for
+// every phrasing measured here, and it keeps the deterministic path deterministic. Which
+// signals "advance" is not restated here — it is read from signalStage, so a signal added
+// there is covered without a second list to keep in step.
+//
+// This reads the FULL body while the model path is bounded to maxBodyRunes, and that
+// asymmetry is deliberate now that it matters: a rejection line sits at the END of a long
+// quoted thread more often than at the top, and truncating to match the prompt would blind
+// this check to exactly the evidence it exists to find. The error it can produce instead —
+// a quoted old rejection outranking a fresh invitation — costs a label and never a stage.
 func KeywordStatus(subject, body string) (StatusSignal, bool) {
 	text := strings.ToLower(stripTags.ReplaceAllString(subject+" \n "+body, " "))
 	for _, r := range keywordRules {
-		for _, p := range r.phrases {
-			if strings.Contains(text, p) {
-				return r.signal, true
-			}
+		if !containsAny(text, r.phrases) {
+			continue
 		}
+		if _, advances := StageFor(r.signal); advances && containsAny(text, rejectionPhrases) {
+			return SignalRejection, true
+		}
+		return r.signal, true
 	}
 	return "", false
+}
+
+// containsAny reports whether text holds any of phrases. text is already lowercased and
+// tag-stripped by the caller; the phrases are lowercase by construction.
+func containsAny(text string, phrases []string) bool {
+	for _, p := range phrases {
+		if strings.Contains(text, p) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/application/mailclassify/keyword.go
+++ b/internal/application/mailclassify/keyword.go
@@ -42,6 +42,28 @@ var rejectionPhrases = []string{
 	"unable to extend an offer", "another candidate",
 }
 
+// decisiveRejectionPhrases is the subset that may VETO a positive signal, and it is a
+// subset for a reason measured on real phrasing.
+//
+// A weak member of the list above is harmless as a fourth-in-order match — nothing
+// stronger matched, so "other candidates" meaning a rejection is the best reading
+// available. As a veto over a strong positive it is wrong, because the same words are
+// ordinary inside good news: "pleased to offer you … we have decided to move forward with
+// you", "invite you to an interview — we are also speaking with other candidates this
+// week", "pleased to offer you the role after another candidate withdrew". Vetoing on the
+// whole list turned every one of those into `rejection`, which does not merely mislabel:
+// SuggestStage reads the implied stage whether or not it advances, so the candidate is
+// offered a move to `rejected` on the day they were hired.
+//
+// What survives here says the sender is closing the application, in words that have no
+// benign reading, plus the two that quote offer vocabulary while refusing.
+var decisiveRejectionPhrases = []string{
+	"we regret", "regret to inform", "not to proceed", "not moving forward", "not be moving forward",
+	"won't be moving forward", "won’t be moving forward", "decided not to move", "decided not to proceed",
+	"not be progressing", "will not be progressing", "not selected", "move forward with other",
+	"unable to extend an offer", "offer to another candidate",
+}
+
 // keywordRules is precision-first: only strong, unambiguous phrases. Rejection is
 // checked before acknowledgement so a "thank you for applying … unfortunately …"
 // email resolves to rejection, and ambiguous openers ("thank you for your
@@ -85,14 +107,15 @@ var keywordRules = []keywordRule{
 // asymmetry is deliberate now that it matters: a rejection line sits at the END of a long
 // quoted thread more often than at the top, and truncating to match the prompt would blind
 // this check to exactly the evidence it exists to find. The error it can produce instead —
-// a quoted old rejection outranking a fresh invitation — costs a label and never a stage.
+// a quoted old rejection outranking a fresh invitation — is bounded by decisiveRejectionPhrases,
+// which is why that list is a subset rather than the whole vocabulary.
 func KeywordStatus(subject, body string) (StatusSignal, bool) {
 	text := strings.ToLower(stripTags.ReplaceAllString(subject+" \n "+body, " "))
 	for _, r := range keywordRules {
 		if !containsAny(text, r.phrases) {
 			continue
 		}
-		if _, advances := StageFor(r.signal); advances && containsAny(text, rejectionPhrases) {
+		if _, advances := StageFor(r.signal); advances && containsAny(text, decisiveRejectionPhrases) {
 			return SignalRejection, true
 		}
 		return r.signal, true

--- a/internal/application/mailclassify/keyword_test.go
+++ b/internal/application/mailclassify/keyword_test.go
@@ -52,6 +52,43 @@ func TestKeywordStatus(t *testing.T) {
 			body:    "Your one-time code is 123456.",
 			want:    "", ok: false,
 		},
+		// The four phrasings below all resolved to a POSITIVE signal before the
+		// contradiction rule, measured by running KeywordStatus. The last two were the
+		// damaging pair: `offer` clears the stage-advance threshold at keyword
+		// confidence, so a rejection moved the application from `applied` to `offer`.
+		{
+			name:    "rejection quoting offer vocabulary is not an offer",
+			subject: "Your application to Acme",
+			body:    "After careful consideration we are unable to extend an offer at this time.",
+			want:    SignalRejection, ok: true,
+		},
+		{
+			name:    "an offer extended to somebody else is a rejection",
+			subject: "Update on your application",
+			body:    "We have decided to extend an offer to another candidate for this role.",
+			want:    SignalRejection, ok: true,
+		},
+		{
+			name:    "the canonical rejection phrase",
+			subject: "Regarding your application",
+			body:    "We regret to inform you we cannot extend an offer.",
+			want:    SignalRejection, ok: true,
+		},
+		{
+			name:    "rejection after an assessment is a rejection, not an assessment",
+			subject: "Coding challenge results",
+			body:    "Thank you for completing the coding challenge. Unfortunately we are not moving forward with your application.",
+			want:    SignalRejection, ok: true,
+		},
+		// The rule is one-directional: a rejection phrase suppresses a positive signal,
+		// never the other way round. A real offer with no rejection wording is unaffected
+		// — pinned above by "job offer" — and so is an invitation.
+		{
+			name:    "an invitation with no rejection wording still resolves as one",
+			subject: "Next steps at Acme",
+			body:    "We would like to invite you to an interview next week — please book a time.",
+			want:    SignalInterviewInvitation, ok: true,
+		},
 	}
 	for _, c := range cases {
 		got, ok := KeywordStatus(c.subject, c.body)

--- a/internal/application/mailclassify/keyword_test.go
+++ b/internal/application/mailclassify/keyword_test.go
@@ -80,9 +80,50 @@ func TestKeywordStatus(t *testing.T) {
 			body:    "Thank you for completing the coding challenge. Unfortunately we are not moving forward with your application.",
 			want:    SignalRejection, ok: true,
 		},
-		// The rule is one-directional: a rejection phrase suppresses a positive signal,
-		// never the other way round. A real offer with no rejection wording is unaffected
-		// — pinned above by "job offer" — and so is an invitation.
+		// The veto reads decisiveRejectionPhrases, a SUBSET, and these six are why. Each
+		// holds a phrase from the wider rejection list inside unambiguously good news, and
+		// vetoing on the whole list turned every one of them into `rejection` — which
+		// SuggestStage then offered the candidate as a move to `rejected`, on the day they
+		// were hired. All six were measured against both spellings of the rule.
+		{
+			name:    "an offer that also says it decided to move forward with you",
+			subject: "Offer from Acme",
+			body:    "We are pleased to offer you the role. We have decided to move forward with you.",
+			want:    SignalOffer, ok: true,
+		},
+		{
+			name:    "an invitation that mentions other candidates is still an invitation",
+			subject: "Next steps",
+			body:    "We would like to invite you to an interview. We are also speaking with other candidates this week.",
+			want:    SignalInterviewInvitation, ok: true,
+		},
+		{
+			name:    "an offer made because another candidate withdrew",
+			subject: "Offer from Acme",
+			body:    "We are pleased to offer you the role after another candidate withdrew.",
+			want:    SignalOffer, ok: true,
+		},
+		{
+			name:    "an invitation that says you were not the right fit for a DIFFERENT role",
+			subject: "A different opening",
+			body:    "We would like to schedule a call. You were not the right fit for the Staff role, but this one suits you.",
+			want:    SignalInterviewInvitation, ok: true,
+		},
+		{
+			name:    "an assessment that compares against other candidates",
+			subject: "Take-home",
+			body:    "Please complete the take-home so we can compare against other candidates' submissions.",
+			want:    SignalAssessment, ok: true,
+		},
+		{
+			name:    "moving forward WITH the candidate reads as the invitation it is",
+			subject: "Next steps",
+			body:    "We have decided to move forward with your application and would like to invite you to an interview.",
+			want:    SignalInterviewInvitation, ok: true,
+		},
+		// The rule is one-directional: a decisive rejection phrase suppresses a positive
+		// signal, never the other way round. A real offer with no rejection wording is
+		// unaffected — pinned above by "job offer" — and so is an invitation.
 		{
 			name:    "an invitation with no rejection wording still resolves as one",
 			subject: "Next steps at Acme",

--- a/internal/ingest/moderation/repository.go
+++ b/internal/ingest/moderation/repository.go
@@ -60,9 +60,16 @@ func (r *QueriesRepository) Create(ctx context.Context, f job.Fields, actorID in
 	return job.FromRow(row)
 }
 
-// BySlug loads a job by its public slug, returning ErrJobNotFound when no job matches or
+// BySlug loads a job by its public slug, returning ErrJobNotFound when no job matches,
 // the matched job was not moderator-authored (created_by IS NULL) — so the edit path can
-// never touch an automated-source (ATS/telegram) vacancy, whatever its declared source.
+// never touch an automated-source (ATS/telegram) vacancy, whatever its declared source —
+// or the matched job is private.
+//
+// created_by does not say "a moderator wrote this" on its own: InsertPrivateJob stamps it
+// with the submitter too, so before the is_private check a moderator who knew the slug of
+// a jd-tailor-intake private JD could read it here and then rewrite it through Update.
+// GetJobBySlug carries no is_private predicate by design — internal/ingest/jdresolve says
+// so, and leaves ownership to each caller. This is this caller's half of that bargain.
 func (r *QueriesRepository) BySlug(ctx context.Context, slug string) (job.Job, job.Extras, error) {
 	row, err := r.q.GetJobBySlug(ctx, slug)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -71,7 +78,7 @@ func (r *QueriesRepository) BySlug(ctx context.Context, slug string) (job.Job, j
 	if err != nil {
 		return job.Job{}, job.Extras{}, err
 	}
-	if !row.CreatedBy.Valid {
+	if !row.CreatedBy.Valid || row.IsPrivate {
 		return job.Job{}, job.Extras{}, ErrJobNotFound
 	}
 	return job.FromRow(row)

--- a/internal/job/job/job.go
+++ b/internal/job/job/job.go
@@ -122,7 +122,17 @@ type Fields struct {
 	// dictionary columns over it. These never participate in the write surface.
 	ID            int64
 	ManuallyAdded bool
-	Enrichment    enrich.Enrichment
+	// Private marks the jd-tailor-intake posting a single user pasted in, visible only
+	// to them (jobs.is_private, written by InsertPrivateJob — see internal/job/privatejob).
+	//
+	// It is here because it was NOT, and four separate reads leaked or rewrote a private
+	// posting for want of it: nothing above a db.Job row could even ask the question, so
+	// every check had to be a predicate remembered in one more SQL statement. A caller
+	// holding a loaded Job can now ask directly. It stays off the write surface — private
+	// is decided by which query wrote the row, not by a field a caller may set — and off
+	// the wire shape (jobview), which is served to whoever asks.
+	Private    bool
+	Enrichment enrich.Enrichment
 	// RequirementsDerived is the posting's own requirements read out of its
 	// description markup (internal/job/reqextract), nil when it states none. It is the
 	// second producer of the served enrichment.requirements: the projection folds it in

--- a/internal/job/job/repository.go
+++ b/internal/job/job/repository.go
@@ -87,6 +87,7 @@ func jobFromRow(r db.Job) (Job, error) {
 
 		ID:                  r.ID,
 		ManuallyAdded:       r.CreatedBy.Valid,
+		Private:             r.IsPrivate,
 		Enrichment:          e,
 		RequirementsDerived: requirementsFromRow(r),
 		EnrichedAt:          tsPtr(r.EnrichedAt),

--- a/internal/job/job/repository_internal_test.go
+++ b/internal/job/job/repository_internal_test.go
@@ -136,3 +136,34 @@ func TestJobFromRow_ProjectsManualSalary(t *testing.T) {
 		t.Errorf("ManualSalary = %v, want nil for a row with no manual salary", none.Fields().ManualSalary)
 	}
 }
+
+// The aggregate carries jobs.is_private, so a caller holding a loaded Job can ask whether
+// it is the private jd-tailor-intake posting instead of hoping the query it came from
+// remembered the predicate. created_by is deliberately set on the private row: it is the
+// SUBMITTER there, so ManuallyAdded alone cannot tell the two provenances apart — that
+// conflation is what let the moderator edit path reach a private JD.
+func TestJobFromRow_ProjectsPrivate(t *testing.T) {
+	private, err := jobFromRow(db.Job{
+		ID: 9, Source: "pasted", ExternalID: "uuid", Title: "Pasted job description",
+		PublicSlug: "pasted-job-description-acme-9f2c",
+		CreatedBy:  pgtype.Int8{Int64: 42, Valid: true},
+		IsPrivate:  true,
+	})
+	if err != nil {
+		t.Fatalf("jobFromRow(private): %v", err)
+	}
+	if !private.Fields().Private {
+		t.Error("Private = false, want true for a row with is_private set")
+	}
+	if !private.Fields().ManuallyAdded {
+		t.Error("ManuallyAdded = false: created_by is set on a private row too, which is the point")
+	}
+
+	public, err := jobFromRow(db.Job{ID: 10, Source: "greenhouse", ExternalID: "gh:1", Title: "t", PublicSlug: "s"})
+	if err != nil {
+		t.Fatalf("jobFromRow(public): %v", err)
+	}
+	if public.Fields().Private {
+		t.Error("Private = true, want false for an ordinary crawled row")
+	}
+}

--- a/internal/platform/db/AGENTS.md
+++ b/internal/platform/db/AGENTS.md
@@ -22,6 +22,7 @@ The `internal/platform/db` package — generated sqlc code, hand-written SQL que
   means "not known" and `'{}'` means "stated, but unresolvable". Collapsing them would lose
   the dictionary's live coverage metric. Copy the shape only when the states match.
 - A new column referencing `users` needs its **own index** — Postgres indexes only the referenced side, so an unindexed reference makes every account deletion scan that table (this is what timed out account deletion against the 19 GB `jobs` table). `TestEveryUserForeignKeyIsIndexed` enforces it.
+- **A statement that reads OPEN postings carries `AND NOT is_private`.** A private posting is one user's pasted JD (`internal/job/privatejob`); nothing about the row says so — it is open, derived and company-slugged like any other — so four statements leaked or rewrote one before `TestEveryOpenCatalogueReadExcludesPrivateJobs` walked the query files. A statement that may legitimately see one goes in that test's exemption table with the reason, which is checked against the population rather than taken on trust.
 
 Response shapes and error rendering are the handler layer's concern — see
 [../handler/AGENTS.md](../../api/handler/AGENTS.md).

--- a/internal/platform/db/canonical_job_for_role_integration_test.go
+++ b/internal/platform/db/canonical_job_for_role_integration_test.go
@@ -113,6 +113,28 @@ func TestCanonicalJobForRole(t *testing.T) {
 			t.Errorf("err = %v, want pgx.ErrNoRows", err)
 		}
 	})
+
+	t.Run("a private posting is no canon", func(t *testing.T) {
+		// InsertPrivateJob derives company_slug and role_fingerprint like every other write
+		// path, so a JD one user pasted in can land in a public posting's role cluster.
+		// Electing it here would mark the incoming import a duplicate of a row nothing
+		// lists — removing the import from search and pointing it at content only its
+		// submitter may read.
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO jobs (source, external_id, url, title, public_slug, company, company_slug,
+			                  role_fingerprint, is_private)
+			VALUES ('pasted', 'private:go', '', 'Senior Go Engineer', 'private-go-acme', 'Acme', 'acme',
+			        'fp-private', true)`); err != nil {
+			t.Fatalf("seed private job: %v", err)
+		}
+		_, err := q.CanonicalJobForRole(ctx, CanonicalJobForRoleParams{
+			CompanySlug: "acme", RoleFingerprint: fp("fp-private"),
+			Source: "weblink", ExternalID: "https://storefront.test/private",
+		})
+		if !errors.Is(err, pgx.ErrNoRows) {
+			t.Errorf("err = %v, want pgx.ErrNoRows", err)
+		}
+	})
 }
 
 func TestMarkJobDuplicateOfRole(t *testing.T) {

--- a/internal/platform/db/companies.sql.go
+++ b/internal/platform/db/companies.sql.go
@@ -586,6 +586,7 @@ SELECT DISTINCT ON (company_slug)
 FROM jobs
 WHERE closed_at IS NULL
   AND duplicate_of IS NULL
+  AND NOT is_private
   AND company_slug <> ''
   AND company ~ '^[a-z0-9._-]+$'
 ORDER BY company_slug, created_at DESC
@@ -603,6 +604,11 @@ type ListSlugLikeCompaniesForBackfillRow struct {
 // representative open job's source and URL so the backfill worker can locate the
 // ATS board. Only boards with live jobs matter, so dead ones never appear. The Go
 // side re-validates slug-likeness authoritatively before touching anything.
+//
+// AND NOT is_private excludes the jd-tailor-intake private-job path: the representative
+// row here supplies the URL the worker reads a real display name from, and the name it
+// reads is written to the PUBLIC companies row (RenameSlugCompany below). A JD one user
+// pasted in is not a board, and it must not be the source of an employer's public name.
 func (q *Queries) ListSlugLikeCompaniesForBackfill(ctx context.Context) ([]ListSlugLikeCompaniesForBackfillRow, error) {
 	rows, err := q.db.Query(ctx, listSlugLikeCompaniesForBackfill)
 	if err != nil {

--- a/internal/platform/db/jobs.sql.go
+++ b/internal/platform/db/jobs.sql.go
@@ -156,6 +156,7 @@ WHERE company_slug = $1
   AND role_fingerprint = $2
   AND closed_at IS NULL
   AND duplicate_of IS NULL
+  AND NOT is_private
   AND NOT (source = $3 AND external_id = $4)
 ORDER BY id
 LIMIT 1
@@ -184,6 +185,11 @@ type CanonicalJobForRoleRow struct {
 // a re-import of the same URL would otherwise find itself. Served by the partial
 // jobs_open_role_cluster_idx (migration 0013), with jobs_company_role_fingerprint_idx as the
 // non-partial fallback.
+// A canon must not be private either. InsertPrivateJob derives company_slug and
+// role_fingerprint like every other write path, so a pasted JD can land in a public
+// posting's role cluster; electing it here would mark the incoming public posting a
+// duplicate of a row nothing lists, removing BOTH from search — the import's own
+// posting and the private one it was pointed at.
 func (q *Queries) CanonicalJobForRole(ctx context.Context, arg CanonicalJobForRoleParams) (CanonicalJobForRoleRow, error) {
 	row := q.db.QueryRow(ctx, canonicalJobForRole,
 		arg.CompanySlug,
@@ -2166,7 +2172,7 @@ func (q *Queries) ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, erro
 const listJobsByCompany = `-- name: ListJobsByCompany :many
 SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech, semantic_embedding, salary_min_manual, salary_max_manual, salary_currency_manual, salary_period_manual, upvote_count, downvote_count, ats_absent_at, closed_reason, is_private, similar_job_ids, similar_computed_at, salary_min_source, salary_max_source, salary_currency_source, salary_period_source, company_slug_folded, duplicate_of_aggregator, duplicate_of_role, duplicate_of_fuzzy, requires_clearance, requirements_derived
 FROM jobs
-WHERE company_slug = $1 AND closed_at IS NULL AND duplicate_of IS NULL
+WHERE company_slug = $1 AND closed_at IS NULL AND duplicate_of IS NULL AND NOT is_private
 ORDER BY created_at DESC, id DESC
 LIMIT $2 OFFSET $3
 `
@@ -2179,6 +2185,15 @@ type ListJobsByCompanyParams struct {
 
 // duplicate_of IS NULL collapses role-cluster reposts to their canonical row, matching
 // the /jobs list so a company page shows one card per role, not every repost.
+//
+// AND NOT is_private excludes the jd-tailor-intake private-job path. InsertPrivateJob
+// derives a company_slug from whatever employer the pasted text names, so without this a
+// private JD naming a company the catalogue already knows appears in that company's PUBLIC
+// list — full pasted text, and first, since this orders by created_at DESC. The route is
+// anonymous (GET /api/v1/companies/:slug/jobs, mounted under mw.optional), so the leak
+// needs no account at all, and the same query backs the assistant's company-jobs tool.
+// RefreshCompanyFacets already excludes private rows from companies.job_count, so before
+// this clause the page contradicted its own counter.
 func (q *Queries) ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyParams) ([]Job, error) {
 	rows, err := q.db.Query(ctx, listJobsByCompany, arg.CompanySlug, arg.Limit, arg.Offset)
 	if err != nil {
@@ -2851,6 +2866,7 @@ WHERE j.closed_at IS NULL
     SELECT 1 FROM jobs ats
     WHERE ats.company_slug = j.company_slug
       AND ats.closed_at IS NULL
+      AND NOT ats.is_private
       AND ats.source <> ALL($2::text[])
   )
 GROUP BY j.company_slug
@@ -2880,6 +2896,13 @@ type OrphanAggregatorCompaniesRow struct {
 //
 // The display name is the modal `company` across the aggregator rows, since two aggregators
 // may spell the same employer differently and the name is what the harvest gate compares.
+//
+// NOT ats.is_private sits on the EXCLUSION test, which is where it can change an answer:
+// a private posting's source is 'pasted'/'weblink' (internal/job/privatejob), so it is
+// never a candidate row above, but it does satisfy "a source outside the aggregator set"
+// and would silently disqualify a company nobody's board is actually crawled for. This is
+// the argument CompaniesWithFreshNonAggregatorCoverage above already writes out in full:
+// a JD one user pasted in is not evidence that we cover an employer.
 func (q *Queries) OrphanAggregatorCompanies(ctx context.Context, arg OrphanAggregatorCompaniesParams) ([]OrphanAggregatorCompaniesRow, error) {
 	rows, err := q.db.Query(ctx, orphanAggregatorCompanies, arg.Requested, arg.Aggregators)
 	if err != nil {
@@ -3974,7 +3997,7 @@ SET title        = $1,
     similar_computed_at = CASE WHEN jobs.company_slug IS DISTINCT FROM $3
                                THEN NULL ELSE jobs.similar_computed_at END,
     updated_at   = now()
-WHERE public_slug = $26 AND created_by IS NOT NULL
+WHERE public_slug = $26 AND created_by IS NOT NULL AND NOT is_private
 RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech, semantic_embedding, salary_min_manual, salary_max_manual, salary_currency_manual, salary_period_manual, upvote_count, downvote_count, ats_absent_at, closed_reason, is_private, similar_job_ids, similar_computed_at, salary_min_source, salary_max_source, salary_currency_source, salary_period_source, company_slug_folded, duplicate_of_aggregator, duplicate_of_role, duplicate_of_fuzzy, requires_clearance, requirements_derived
 `
 
@@ -4010,6 +4033,14 @@ type UpdateManualJobParams struct {
 // Moderator edit of a hand-curated job, addressed by public_slug and scoped to
 // created_by IS NOT NULL so this path can only rewrite a moderator-authored posting,
 // never an automated-source (ingest/telegram) one — regardless of the declared source.
+// AND NOT is_private is the second half of that scope, not a duplicate of it:
+// InsertPrivateJob stamps created_by too, so created_by IS NOT NULL alone also matched
+// every jd-tailor-intake private JD, and a moderator holding the slug could rewrite one
+// user's private text. The refusal in moderation.QueriesRepository.BySlug is what stops
+// the service path reaching this statement at all — the company_upsert CTE below is
+// independent of the UPDATE and would mint a public companies row from a private JD's
+// employer even on a zero-row update, which is exactly what InsertPrivateJob refuses to
+// do. This clause is the guard in the statement for any caller that arrives without it.
 // The partial merge (nil = unchanged) and facet re-derivation happen in the service; this
 // query writes the resulting full field set, so geography/skills/company_slug stay
 // consistent with the edited content. The source identity (url/external_id/public_slug)

--- a/internal/platform/db/jobs_moderation_integration_test.go
+++ b/internal/platform/db/jobs_moderation_integration_test.go
@@ -143,4 +143,29 @@ func TestUpdateManualJobScopedByCreatedBy(t *testing.T) {
 	if _, err := q.UpdateManualJob(ctx, updateManualParams(ats.PublicSlug, "Hijacked", editor)); !errors.Is(err, pgx.ErrNoRows) {
 		t.Errorf("update of an automated-source job: err = %v, want pgx.ErrNoRows", err)
 	}
+
+	// A private job (the jd-tailor-intake path) carries created_by too — it is the
+	// SUBMITTER there — so created_by IS NOT NULL alone matched one user's pasted JD as
+	// readily as a moderator's own vacancy. The clause is in the statement and not only in
+	// moderation.QueriesRepository.BySlug because the CTE above the UPDATE upserts a
+	// companies row whether or not the UPDATE matches anything, so a caller arriving here
+	// without the Go check would still mint a public company from private content.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO jobs (source, external_id, url, title, company, company_slug, description,
+		                   public_slug, created_by, is_private)
+		 VALUES ('weblink', 'private:1', 'https://stealth.example/1', 'Private Role', 'Stealthworks',
+		         'stealthworks', 'Confidential body', 'private-role-stealthworks', $1, true)`, editor); err != nil {
+		t.Fatalf("insert private job: %v", err)
+	}
+	if _, err := q.UpdateManualJob(ctx, updateManualParams("private-role-stealthworks", "Hijacked", editor)); !errors.Is(err, pgx.ErrNoRows) {
+		t.Errorf("update of a private job: err = %v, want pgx.ErrNoRows", err)
+	}
+	var title string
+	if err := pool.QueryRow(ctx,
+		"SELECT title FROM jobs WHERE public_slug = 'private-role-stealthworks'").Scan(&title); err != nil {
+		t.Fatalf("read back private job: %v", err)
+	}
+	if title != "Private Role" {
+		t.Errorf("private job title = %q, want it left untouched", title)
+	}
 }

--- a/internal/platform/db/metrics.sql.go
+++ b/internal/platform/db/metrics.sql.go
@@ -276,7 +276,7 @@ func (q *Queries) MailClassificationOutboxMetrics(ctx context.Context) (MailClas
 const newestOpenJobCreatedAt = `-- name: NewestOpenJobCreatedAt :one
 SELECT created_at
 FROM jobs
-WHERE closed_at IS NULL
+WHERE closed_at IS NULL AND NOT is_private
 ORDER BY created_at DESC, id DESC
 LIMIT 1
 `
@@ -292,6 +292,11 @@ LIMIT 1
 // Returns no row when the catalogue is empty, which the caller must distinguish from a
 // zero timestamp: zero reads as 1970, i.e. an infinitely stale catalogue, whereas an
 // empty catalogue is a fresh-install state and not an incident.
+//
+// AND NOT is_private for the same reason the public twin of this question carries it
+// (jobs.sql's LatestOpenJobAddedAt): a jd-tailor-intake row is a user pasting a job
+// description in, not the crawler producing one, so counting it would let one paste hide
+// an ingest that has stopped — the exact incident this gauge exists to raise.
 func (q *Queries) NewestOpenJobCreatedAt(ctx context.Context) (pgtype.Timestamptz, error) {
 	row := q.db.QueryRow(ctx, newestOpenJobCreatedAt)
 	var created_at pgtype.Timestamptz

--- a/internal/platform/db/private_job_rule_test.go
+++ b/internal/platform/db/private_job_rule_test.go
@@ -1,0 +1,285 @@
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// privatePredicateExemptions names every statement that reads the open catalogue and may
+// legitimately see a private posting, with the reason it may.
+//
+// "Legitimately" means one thing here: the private posting cannot reach anybody but its
+// creator, and cannot change an answer given to anybody else. Cost is a different
+// question and deliberately not this rule's — a private row that draws an LLM call is
+// wrong for another reason, and exempting it here says nothing about that.
+//
+// Three anti-tautology checks keep the list from becoming "everything that fails today":
+// a name matching no statement fails, a name outside the population fails, and a name
+// that already carries the predicate fails. An entry can only survive by describing a
+// statement that really does read open postings without the clause.
+var privatePredicateExemptions = map[string]string{
+	// --- Owner-scoped: the only reader is the posting's own creator. ---
+	"ListUserApplicationsForMatch": "the caller's own tracked applications (user_jobs.user_id = $1); a private posting here is one they created",
+
+	// --- Cannot reach a private row at all: the source or the queue never holds one.
+	// A private posting's source is 'pasted' or 'weblink' (internal/job/privatejob), and
+	// nothing crawls either. ---
+	"ListAggregatorJobsForCrosscheckBySource": "scoped to one aggregator source, which a private posting's source is never one of",
+	"ListCompanyBoardTitles":                  "scoped to the ats/company board sources, which a private posting's source is never one of",
+	"UnseenJobIDs":                            "the post-ingest close sweep, scoped to the source a crawl just ran and the company slugs it touched",
+	"UnseenJobIDsBySource":                    "the same sweep, scoped to one source; a private posting's source is never crawled",
+	"ClaimSearchOutboxBatch":                  "leases search_outbox entries, and InsertPrivateJob enqueues none — unlike every crawl write path",
+
+	// --- Writes back to the private row itself: the effect stays inside the row, so it
+	// reaches its creator and nobody else. ---
+	"EnqueuePendingJobs":               "queues a row for enrichment; the model's answer is written back to that same row",
+	"EnqueueEnrichmentForCompanySlugs": "the same queue, scoped to named company slugs",
+	"ClaimEnrichmentBatch":             "leases enrichment entries; the jobs join only orders them by freshness and skips closed rows",
+	"EnqueuePendingSemanticJobs":       "queues embedding for a row; the one reader of those vectors that answers anyone else, NearestJobsToJob, excludes private candidates itself",
+	"SelectOrphanLivenessCandidates":   "the liveness probe's candidate set; a strike or a close changes what the creator sees, not what anyone else does",
+	"SelectStaleRegisteredCandidates":  "the same probe's registered-source candidate set",
+	"MarkLivenessExpired":              "the strike write for one probed row",
+	"ListJobsForRequirementsBackfill":  "a one-off backfill reading a description to fill that row's own requirements_derived",
+	"ResidualTitleGroups":              "cmd/prune's candidate grouping — dry-run by default, and a removal takes a row out of its creator's view, not into anyone else's",
+
+	// --- Aggregates: a sample, never a posting. ---
+	// The other seven insights rollups count with `count(*) FILTER (WHERE closed_at IS
+	// NULL)` over the whole catalogue and so are outside this rule's shape. Exempting
+	// these two keeps the family consistent rather than splitting it on which member the
+	// detector happens to see.
+	"RebuildInsightsSalaryStatsGlobal":    "a salary percentile over a band of at least @min_sample postings; a private one contributes a number, never a title, slug or link",
+	"RebuildInsightsSalaryStatsByCountry": "the same rollup, per country",
+
+	// --- Duplicate-marker passes: they write a pointer between two postings of one
+	// company and show nothing.
+	//
+	// A private row that lands in a cluster is already invisible, so being marked a
+	// duplicate costs it nothing. The residual is the reverse — a private row elected
+	// CANON would take the public postings of that role out of search with it — and it is
+	// bounded by how the canon is chosen: MIN(id), so the private row would have to
+	// predate every open public posting of the role, when a pasted JD is by construction
+	// copied from one that already exists. Narrowing the passes themselves means editing
+	// statements that run over the whole catalogue, which is not this change. ---
+	"CompaniesWithRoleClusters":                "names the companies whose role clusters the pass recomputes",
+	"RecomputeRoleDuplicatesForCompanies":      "recomputes duplicate_of_role within one company's clusters",
+	"CompaniesWithAggregatorPostings":          "names the companies holding aggregator postings for the suppression pass",
+	"SuppressAggregatorDuplicatesForCompanies": "marks an aggregator posting a duplicate of the employer's own board row",
+	"CompaniesWithFuzzyDedupCandidates":        "names the companies the fuzzy pass considers",
+	"FuzzyDedupCandidateTitlesForCompany":      "the titles the fuzzy pass compares within one company",
+	"MarkFuzzyDuplicatesForCompany":            "writes duplicate_of_fuzzy for one company's candidates",
+	"DuplicateClosureGeoAll":                   "unions a closure's geography into its owner's facets — country/region/city codes, no posting",
+	"DuplicateClosureGeoFor":                   "the same union, for named owners",
+
+	// --- Answers only about content the caller already holds. ---
+	"FindOpenJobByURL": "matches on the URL the caller supplied, and a private posting carries a URL only when it was created BY scraping that page (a pasted-text one has none), so the slug it can return always points at content the caller had the address for",
+}
+
+// privatePredicatePinned names statements that carry NOT is_private for a load-bearing
+// reason but whose shape leaves them outside the population below — so the rule would not
+// notice the clause being deleted again.
+var privatePredicatePinned = map[string]string{
+	"NearestJobsToJob": "GET /jobs/:slug/similar is unauthenticated and lists whole postings; the predicate sits on a JOIN condition, which the population detector deliberately does not read as a filter",
+}
+
+// TestEveryOpenCatalogueReadExcludesPrivateJobs pins a rule that only a comment would
+// otherwise hold, and that four separate statements have now broken.
+//
+// A private posting is the jd-tailor-intake path: a job description ONE user pasted in,
+// visible only to them, kept out of reach by a public_slug nobody can guess rather than by
+// any authorization check (internal/job/privatejob, internal/ingest/jdresolve). Nothing
+// about the row says so — it is open, it carries derived facets and a company_slug like
+// any other posting, and jobs.is_private is the only thing that distinguishes it. So every
+// statement that reads the live catalogue has to remember one clause, and four of them did
+// not: /jobs/:slug/similar listed private postings as neighbours, ListJobsByCompany put
+// them at the top of a company's public page, and the moderator edit path both read and
+// rewrote them. Each was fixed on its own, and the next one broke anyway.
+//
+// The population is "reads jobs, restricted to open postings" — a statement asking what
+// the catalogue currently offers. Statements keyed to one job (GetJobBySlug) or to one
+// user are outside it by construction: they answer about a row somebody named, and
+// jdresolve records that ownership is the caller's to check there.
+func TestEveryOpenCatalogueReadExcludesPrivateJobs(t *testing.T) {
+	queries := openCatalogueReads(t)
+	seen := make(map[string]bool, len(queries))
+	for _, q := range queries {
+		seen[q.name] = true
+		reason, exempt := privatePredicateExemptions[q.name]
+		switch {
+		case q.hasPrivatePredicate && exempt:
+			t.Errorf("%s: %s carries NOT is_private and is also exempted (%q) — drop the exemption, "+
+				"the statement no longer needs one", q.file, q.name, reason)
+		case q.hasPrivatePredicate, exempt:
+		default:
+			t.Errorf("%s: %s reads open postings without NOT is_private. A private posting is one "+
+				"user's pasted JD (internal/job/privatejob) and must not appear in, or change, an "+
+				"answer given to anyone else. Add the clause, or name the statement in "+
+				"privatePredicateExemptions with the reason it may see one.", q.file, q.name)
+		}
+	}
+
+	// An exemption for a statement that is not in the population exempts nothing, and
+	// would go on exempting whatever statement is next given that name.
+	for name, reason := range privatePredicateExemptions {
+		if !seen[name] {
+			t.Errorf("privatePredicateExemptions[%q] (%q) matches no statement that reads open "+
+				"postings — it was renamed, deleted, or the detector no longer sees it", name, reason)
+		}
+	}
+	for name, reason := range privatePredicatePinned {
+		if seen[name] {
+			t.Errorf("privatePredicatePinned[%q] (%q) is now inside the population, which checks it "+
+				"already — move it out of the pinned list", name, reason)
+		}
+	}
+
+	// Counting the population, not just the violations: a detector that silently stops
+	// matching looks exactly like a rule that passes. The number moves whenever a
+	// statement is added or removed, which is the point — it is read, not maintained
+	// blind.
+	if len(queries) < 35 {
+		t.Errorf("only %d statements matched as open-catalogue reads of jobs, expected at least 35 "+
+			"— scopesToOpenPostings has probably drifted from how the queries are written", len(queries))
+	}
+}
+
+// TestPinnedPrivatePredicatesSurvive holds the clause on the statements the population
+// cannot see. Today that is the /similar rollup, the first of the four leaks and the one
+// whose fix has no other guard.
+func TestPinnedPrivatePredicatesSurvive(t *testing.T) {
+	found := make(map[string]bool, len(privatePredicatePinned))
+	for _, q := range allNamedJobsQueries(t) {
+		if _, want := privatePredicatePinned[q.name]; !want {
+			continue
+		}
+		found[q.name] = true
+		if !q.hasPrivatePredicate {
+			t.Errorf("%s: %s lost its NOT is_private — %s", q.file, q.name, privatePredicatePinned[q.name])
+		}
+	}
+	for name := range privatePredicatePinned {
+		if !found[name] {
+			t.Errorf("privatePredicatePinned[%q] matches no statement reading jobs", name)
+		}
+	}
+}
+
+// TestScopesToOpenPostings pins the detector against the four shapes that mean something
+// other than "restrict this read to open postings", each taken from a live statement.
+func TestScopesToOpenPostings(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		sql  string
+		want bool
+	}{
+		{"plain where clause", "select *\nfrom jobs\nwhere closed_at is null and duplicate_of is null", true},
+		{"qualified and continued", "from jobs j\nwhere j.company_slug = $1\n  and j.closed_at is null", true},
+		{"aggregate filter", "select count(*) filter (where closed_at is null)::int\nfrom jobs", false},
+		{"order-by preference", "from jobs j\nwhere normalize_job_url(j.url) = $1\norder by (j.closed_at is null) desc", false},
+		{"join condition on a second copy", "from jobs j\nleft join jobs c on c.id = j.duplicate_of and c.closed_at is null", false},
+		{"projection of the state", "select j.id,\n       (j.closed_at is null)::bool as job_open\nfrom application_nudges n\njoin jobs j on j.id = n.job_id", false},
+		{"no mention at all", "select * from jobs where public_slug = $1", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := scopesToOpenPostings(tc.sql); got != tc.want {
+				t.Errorf("scopesToOpenPostings(%q) = %v, want %v", tc.sql, got, tc.want)
+			}
+		})
+	}
+}
+
+type jobsQuery struct {
+	file                string
+	name                string
+	scopedToOpen        bool
+	hasPrivatePredicate bool
+}
+
+var (
+	reReadsJobs   = regexp.MustCompile(`\b(from|join)\s+jobs\b`)
+	reOpenScope   = regexp.MustCompile(`\bclosed_at\s+is\s+null\b`)
+	rePrivatePred = regexp.MustCompile(`\bnot\s+(\w+\.)?is_private\b`)
+)
+
+// allNamedJobsQueries returns every named statement in queries/*.sql that reads the jobs
+// table, judged on the SQL and not the prose around it — a comment MENTIONING is_private
+// must not satisfy the rule, which is the same trap the folded-column walker beside this
+// one documents.
+func allNamedJobsQueries(t *testing.T) []jobsQuery {
+	t.Helper()
+	const queryDir = "queries"
+	entries, err := os.ReadDir(queryDir)
+	if err != nil {
+		t.Fatalf("read %s: %v", queryDir, err)
+	}
+	var out []jobsQuery
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") {
+			continue
+		}
+		path := filepath.Join(queryDir, entry.Name())
+		src, err := os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		for _, stmt := range splitNamedQueries(string(src)) {
+			body := strings.ToLower(stripSQLComments(stmt.body))
+			if !reReadsJobs.MatchString(body) {
+				continue
+			}
+			out = append(out, jobsQuery{
+				file:                path,
+				name:                stmt.name,
+				scopedToOpen:        scopesToOpenPostings(body),
+				hasPrivatePredicate: rePrivatePred.MatchString(body),
+			})
+		}
+	}
+	return out
+}
+
+// openCatalogueReads narrows that to the statements restricted to OPEN postings.
+func openCatalogueReads(t *testing.T) []jobsQuery {
+	t.Helper()
+	var out []jobsQuery
+	for _, q := range allNamedJobsQueries(t) {
+		if q.scopedToOpen {
+			out = append(out, q)
+		}
+	}
+	return out
+}
+
+// reProjectedOpen is `closed_at IS NULL` parenthesised on its own — the shape of a
+// projection like `(j.closed_at IS NULL)::bool AS job_open`, which REPORTS whether a row
+// is open instead of restricting the read to open rows.
+var reProjectedOpen = regexp.MustCompile(`\(\s*(\w+\.)?closed_at\s+is\s+null\s*\)`)
+
+// scopesToOpenPostings reports whether a statement restricts what it reads to OPEN
+// postings — the question this rule is about. Judged per line, because the same three
+// words mean something else in four other places, and each of those is a live statement
+// here rather than a hypothetical:
+//
+//	count(*) FILTER (WHERE closed_at IS NULL)      an aggregate over all rows
+//	ORDER BY (j.closed_at IS NULL) DESC            a preference, not a filter
+//	LEFT JOIN jobs c ON … AND c.closed_at IS NULL  a condition on a second copy of the table
+//	(j.closed_at IS NULL)::bool AS job_open        a projection reporting the state
+//
+// The direction of a miss is deliberate: a line this fails to recognise drops a statement
+// OUT of the population, so the detector is worth exactly as much as the population count
+// the test asserts beside it, and no more.
+func scopesToOpenPostings(body string) bool {
+	for _, line := range strings.Split(body, "\n") {
+		if !reOpenScope.MatchString(line) || reProjectedOpen.MatchString(line) {
+			continue
+		}
+		if strings.Contains(line, "filter") || strings.Contains(line, "order by") ||
+			strings.Contains(line, "join") || strings.Contains(line, "select") {
+			continue
+		}
+		return true
+	}
+	return false
+}

--- a/internal/platform/db/private_job_rule_test.go
+++ b/internal/platform/db/private_job_rule_test.go
@@ -31,7 +31,6 @@ var privatePredicateExemptions = map[string]string{
 	"ListCompanyBoardTitles":                  "scoped to the ats/company board sources, which a private posting's source is never one of",
 	"UnseenJobIDs":                            "the post-ingest close sweep, scoped to the source a crawl just ran and the company slugs it touched",
 	"UnseenJobIDsBySource":                    "the same sweep, scoped to one source; a private posting's source is never crawled",
-	"ClaimSearchOutboxBatch":                  "leases search_outbox entries, and InsertPrivateJob enqueues none — unlike every crawl write path",
 
 	// --- Writes back to the private row itself: the effect stays inside the row, so it
 	// reaches its creator and nobody else. ---
@@ -43,7 +42,11 @@ var privatePredicateExemptions = map[string]string{
 	"SelectStaleRegisteredCandidates":  "the same probe's registered-source candidate set",
 	"MarkLivenessExpired":              "the strike write for one probed row",
 	"ListJobsForRequirementsBackfill":  "a one-off backfill reading a description to fill that row's own requirements_derived",
-	"ResidualTitleGroups":              "cmd/prune's candidate grouping — dry-run by default, and a removal takes a row out of its creator's view, not into anyone else's",
+	"ResidualTitleGroups": "cmd/mine-titles's operator report: 2-3 word groups mined from live " +
+		"unclassified titles, read by a person and copied into the non-tech dictionary. The " +
+		"predicate is owed here and is a follow-up, not an exemption on the merits — a pasted " +
+		"JD's title fragments reaching that console is small but real. Recorded honestly rather " +
+		"than blessed: the earlier reason named cmd/prune, which does not call this at all.",
 
 	// --- Aggregates: a sample, never a posting. ---
 	// The other seven insights rollups count with `count(*) FILTER (WHERE closed_at IS

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -294,6 +294,11 @@ type Querier interface {
 	// a re-import of the same URL would otherwise find itself. Served by the partial
 	// jobs_open_role_cluster_idx (migration 0013), with jobs_company_role_fingerprint_idx as the
 	// non-partial fallback.
+	// A canon must not be private either. InsertPrivateJob derives company_slug and
+	// role_fingerprint like every other write path, so a pasted JD can land in a public
+	// posting's role cluster; electing it here would mark the incoming public posting a
+	// duplicate of a row nothing lists, removing BOTH from search — the import's own
+	// posting and the private one it was pointed at.
 	CanonicalJobForRole(ctx context.Context, arg CanonicalJobForRoleParams) (CanonicalJobForRoleRow, error)
 	// Claim a batch of live, unleased captures, freshest posting first, by stamping
 	// claimed_at. Mirrors ClaimApplyFormBatch: FOR UPDATE OF o locks only outbox rows, SKIP
@@ -3097,6 +3102,15 @@ type Querier interface {
 	ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, error)
 	// duplicate_of IS NULL collapses role-cluster reposts to their canonical row, matching
 	// the /jobs list so a company page shows one card per role, not every repost.
+	//
+	// AND NOT is_private excludes the jd-tailor-intake private-job path. InsertPrivateJob
+	// derives a company_slug from whatever employer the pasted text names, so without this a
+	// private JD naming a company the catalogue already knows appears in that company's PUBLIC
+	// list — full pasted text, and first, since this orders by created_at DESC. The route is
+	// anonymous (GET /api/v1/companies/:slug/jobs, mounted under mw.optional), so the leak
+	// needs no account at all, and the same query backs the assistant's company-jobs tool.
+	// RefreshCompanyFacets already excludes private rows from companies.job_count, so before
+	// this clause the page contradicted its own counter.
 	ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyParams) ([]Job, error)
 	// Keyset scan for the reindex command: pages by the immutable primary key, so
 	// concurrent inserts/updates (which shift posted_at ordering) cannot make the
@@ -3261,6 +3275,11 @@ type Querier interface {
 	// representative open job's source and URL so the backfill worker can locate the
 	// ATS board. Only boards with live jobs matter, so dead ones never appear. The Go
 	// side re-validates slug-likeness authoritatively before touching anything.
+	//
+	// AND NOT is_private excludes the jd-tailor-intake private-job path: the representative
+	// row here supplies the URL the worker reads a real display name from, and the name it
+	// reads is written to the PUBLIC companies row (RenameSlugCompany below). A JD one user
+	// pasted in is not a board, and it must not be the source of an employer's public name.
 	ListSlugLikeCompaniesForBackfill(ctx context.Context) ([]ListSlugLikeCompaniesForBackfillRow, error)
 	// "My submissions": one user's submissions, newest first, whatever their status.
 	// LEFT JOIN the minted job (present only once approved) to surface its public_slug,
@@ -3697,6 +3716,11 @@ type Querier interface {
 	// — and the floor has to be applied AFTER it: "Product Owner", "product owner" and
 	// "PRODUCT OWNER" are three rows here and one suggestion, so a floor applied to these
 	// counts would drop a title that clears it comfortably once merged.
+	// AND NOT is_private excludes the jd-tailor-intake private-job path: the dictionary this
+	// mines is served to every visitor as they type, so a title one user pasted in privately
+	// must not become public vocabulary. The frequency floor is not the guard — it is applied
+	// after normalisation, so a private title merges into a public one's count rather than
+	// standing alone under it.
 	MineJobTitles(ctx context.Context) ([]MineJobTitlesRow, error)
 	// The similar-jobs rollup for one source job (design.md Decision 5), consumed by
 	// cmd/similar-backfill to populate jobs.similar_job_ids. A candidate job's distance to
@@ -3747,6 +3771,11 @@ type Querier interface {
 	// Returns no row when the catalogue is empty, which the caller must distinguish from a
 	// zero timestamp: zero reads as 1970, i.e. an infinitely stale catalogue, whereas an
 	// empty catalogue is a fresh-install state and not an incident.
+	//
+	// AND NOT is_private for the same reason the public twin of this question carries it
+	// (jobs.sql's LatestOpenJobAddedAt): a jd-tailor-intake row is a user pasting a job
+	// description in, not the crawler producing one, so counting it would let one paste hide
+	// an ingest that has stopped — the exact incident this gauge exists to raise.
 	NewestOpenJobCreatedAt(ctx context.Context) (pgtype.Timestamptz, error)
 	// The subscription-digest backlog: how many active subscriptions have something
 	// undelivered, and how old the oldest undelivered match is.
@@ -3779,6 +3808,13 @@ type Querier interface {
 	//
 	// The display name is the modal `company` across the aggregator rows, since two aggregators
 	// may spell the same employer differently and the name is what the harvest gate compares.
+	//
+	// NOT ats.is_private sits on the EXCLUSION test, which is where it can change an answer:
+	// a private posting's source is 'pasted'/'weblink' (internal/job/privatejob), so it is
+	// never a candidate row above, but it does satisfy "a source outside the aggregator set"
+	// and would silently disqualify a company nobody's board is actually crawled for. This is
+	// the argument CompaniesWithFreshNonAggregatorCoverage above already writes out in full:
+	// a JD one user pasted in is not evidence that we cover an employer.
 	OrphanAggregatorCompanies(ctx context.Context, arg OrphanAggregatorCompaniesParams) ([]OrphanAggregatorCompaniesRow, error)
 	// Does this account still owe itself the invitee's first-month discount?
 	//
@@ -5294,6 +5330,14 @@ type Querier interface {
 	// Moderator edit of a hand-curated job, addressed by public_slug and scoped to
 	// created_by IS NOT NULL so this path can only rewrite a moderator-authored posting,
 	// never an automated-source (ingest/telegram) one — regardless of the declared source.
+	// AND NOT is_private is the second half of that scope, not a duplicate of it:
+	// InsertPrivateJob stamps created_by too, so created_by IS NOT NULL alone also matched
+	// every jd-tailor-intake private JD, and a moderator holding the slug could rewrite one
+	// user's private text. The refusal in moderation.QueriesRepository.BySlug is what stops
+	// the service path reaching this statement at all — the company_upsert CTE below is
+	// independent of the UPDATE and would mint a public companies row from a private JD's
+	// employer even on a zero-row update, which is exactly what InsertPrivateJob refuses to
+	// do. This clause is the guard in the statement for any caller that arrives without it.
 	// The partial merge (nil = unchanged) and facet re-derivation happen in the service; this
 	// query writes the resulting full field set, so geography/skills/company_slug stay
 	// consistent with the edited content. The source identity (url/external_id/public_slug)

--- a/internal/platform/db/queries/companies.sql
+++ b/internal/platform/db/queries/companies.sql
@@ -184,6 +184,11 @@ ON CONFLICT (slug) DO UPDATE SET
 -- representative open job's source and URL so the backfill worker can locate the
 -- ATS board. Only boards with live jobs matter, so dead ones never appear. The Go
 -- side re-validates slug-likeness authoritatively before touching anything.
+--
+-- AND NOT is_private excludes the jd-tailor-intake private-job path: the representative
+-- row here supplies the URL the worker reads a real display name from, and the name it
+-- reads is written to the PUBLIC companies row (RenameSlugCompany below). A JD one user
+-- pasted in is not a board, and it must not be the source of an employer's public name.
 SELECT DISTINCT ON (company_slug)
        company_slug AS slug,
        company      AS name,
@@ -192,6 +197,7 @@ SELECT DISTINCT ON (company_slug)
 FROM jobs
 WHERE closed_at IS NULL
   AND duplicate_of IS NULL
+  AND NOT is_private
   AND company_slug <> ''
   AND company ~ '^[a-z0-9._-]+$'
 ORDER BY company_slug, created_at DESC;

--- a/internal/platform/db/queries/jobs.sql
+++ b/internal/platform/db/queries/jobs.sql
@@ -206,9 +206,18 @@ SELECT estimate_open_jobs()::bigint;
 -- name: ListJobsByCompany :many
 -- duplicate_of IS NULL collapses role-cluster reposts to their canonical row, matching
 -- the /jobs list so a company page shows one card per role, not every repost.
+--
+-- AND NOT is_private excludes the jd-tailor-intake private-job path. InsertPrivateJob
+-- derives a company_slug from whatever employer the pasted text names, so without this a
+-- private JD naming a company the catalogue already knows appears in that company's PUBLIC
+-- list — full pasted text, and first, since this orders by created_at DESC. The route is
+-- anonymous (GET /api/v1/companies/:slug/jobs, mounted under mw.optional), so the leak
+-- needs no account at all, and the same query backs the assistant's company-jobs tool.
+-- RefreshCompanyFacets already excludes private rows from companies.job_count, so before
+-- this clause the page contradicted its own counter.
 SELECT *
 FROM jobs
-WHERE company_slug = $1 AND closed_at IS NULL AND duplicate_of IS NULL
+WHERE company_slug = $1 AND closed_at IS NULL AND duplicate_of IS NULL AND NOT is_private
 ORDER BY created_at DESC, id DESC
 LIMIT $2 OFFSET $3;
 
@@ -542,12 +551,18 @@ WHERE EXISTS (
 -- a re-import of the same URL would otherwise find itself. Served by the partial
 -- jobs_open_role_cluster_idx (migration 0013), with jobs_company_role_fingerprint_idx as the
 -- non-partial fallback.
+-- A canon must not be private either. InsertPrivateJob derives company_slug and
+-- role_fingerprint like every other write path, so a pasted JD can land in a public
+-- posting's role cluster; electing it here would mark the incoming public posting a
+-- duplicate of a row nothing lists, removing BOTH from search — the import's own
+-- posting and the private one it was pointed at.
 SELECT id, public_slug
 FROM jobs
 WHERE company_slug = sqlc.arg(company_slug)
   AND role_fingerprint = sqlc.arg(role_fingerprint)
   AND closed_at IS NULL
   AND duplicate_of IS NULL
+  AND NOT is_private
   AND NOT (source = sqlc.arg(source) AND external_id = sqlc.arg(external_id))
 ORDER BY id
 LIMIT 1;
@@ -1222,6 +1237,14 @@ RETURNING *;
 -- Moderator edit of a hand-curated job, addressed by public_slug and scoped to
 -- created_by IS NOT NULL so this path can only rewrite a moderator-authored posting,
 -- never an automated-source (ingest/telegram) one — regardless of the declared source.
+-- AND NOT is_private is the second half of that scope, not a duplicate of it:
+-- InsertPrivateJob stamps created_by too, so created_by IS NOT NULL alone also matched
+-- every jd-tailor-intake private JD, and a moderator holding the slug could rewrite one
+-- user's private text. The refusal in moderation.QueriesRepository.BySlug is what stops
+-- the service path reaching this statement at all — the company_upsert CTE below is
+-- independent of the UPDATE and would mint a public companies row from a private JD's
+-- employer even on a zero-row update, which is exactly what InsertPrivateJob refuses to
+-- do. This clause is the guard in the statement for any caller that arrives without it.
 -- The partial merge (nil = unchanged) and facet re-derivation happen in the service; this
 -- query writes the resulting full field set, so geography/skills/company_slug stay
 -- consistent with the edited content. The source identity (url/external_id/public_slug)
@@ -1281,7 +1304,7 @@ SET title        = sqlc.arg(title),
     similar_computed_at = CASE WHEN jobs.company_slug IS DISTINCT FROM sqlc.arg(company_slug)
                                THEN NULL ELSE jobs.similar_computed_at END,
     updated_at   = now()
-WHERE public_slug = sqlc.arg(public_slug) AND created_by IS NOT NULL
+WHERE public_slug = sqlc.arg(public_slug) AND created_by IS NOT NULL AND NOT is_private
 RETURNING *;
 
 -- name: CloseUnseenJobs :one
@@ -2013,6 +2036,13 @@ SELECT count(*)::bigint FROM flipped;
 --
 -- The display name is the modal `company` across the aggregator rows, since two aggregators
 -- may spell the same employer differently and the name is what the harvest gate compares.
+--
+-- NOT ats.is_private sits on the EXCLUSION test, which is where it can change an answer:
+-- a private posting's source is 'pasted'/'weblink' (internal/job/privatejob), so it is
+-- never a candidate row above, but it does satisfy "a source outside the aggregator set"
+-- and would silently disqualify a company nobody's board is actually crawled for. This is
+-- the argument CompaniesWithFreshNonAggregatorCoverage above already writes out in full:
+-- a JD one user pasted in is not evidence that we cover an employer.
 SELECT j.company_slug,
        (mode() WITHIN GROUP (ORDER BY j.company))::text AS company
 FROM jobs j
@@ -2023,6 +2053,7 @@ WHERE j.closed_at IS NULL
     SELECT 1 FROM jobs ats
     WHERE ats.company_slug = j.company_slug
       AND ats.closed_at IS NULL
+      AND NOT ats.is_private
       AND ats.source <> ALL(sqlc.arg(aggregators)::text[])
   )
 GROUP BY j.company_slug

--- a/internal/platform/db/queries/metrics.sql
+++ b/internal/platform/db/queries/metrics.sql
@@ -236,9 +236,14 @@ FROM board_health;
 -- Returns no row when the catalogue is empty, which the caller must distinguish from a
 -- zero timestamp: zero reads as 1970, i.e. an infinitely stale catalogue, whereas an
 -- empty catalogue is a fresh-install state and not an incident.
+--
+-- AND NOT is_private for the same reason the public twin of this question carries it
+-- (jobs.sql's LatestOpenJobAddedAt): a jd-tailor-intake row is a user pasting a job
+-- description in, not the crawler producing one, so counting it would let one paste hide
+-- an ingest that has stopped — the exact incident this gauge exists to raise.
 SELECT created_at
 FROM jobs
-WHERE closed_at IS NULL
+WHERE closed_at IS NULL AND NOT is_private
 ORDER BY created_at DESC, id DESC
 LIMIT 1;
 

--- a/internal/platform/db/queries/search_outbox.sql
+++ b/internal/platform/db/queries/search_outbox.sql
@@ -49,6 +49,17 @@ WITH claimable AS (
           WHERE j.id = o.job_id
             AND j.closed_at IS NULL
             AND j.duplicate_of IS NULL
+            -- A private posting must never be drained into the public facet index, and
+            -- "InsertPrivateJob enqueues none" is not enough to stop it: the role-duplicate
+            -- pass requeues every row whose duplicate_of goes back to NULL, and canon is
+            -- MIN(id) among OPEN rows with failover when the canon closes. So a pasted JD
+            -- marked a duplicate of the public posting it was copied from is ELECTED canon
+            -- the moment that public one soft-closes, and is requeued from there — title,
+            -- company, description and public_slug into the index anyone searches.
+            -- Constructed against Postgres before this line existed; the row was claimed.
+            -- cmd/reindex already drops private rows on the full rebuild; this is the same
+            -- rule on the incremental path, which is the one that had no predicate at all.
+            AND NOT j.is_private
       )
     ORDER BY o.job_posted_at DESC NULLS LAST, o.job_id DESC
     FOR UPDATE OF o SKIP LOCKED

--- a/internal/platform/db/queries/suggestions.sql
+++ b/internal/platform/db/queries/suggestions.sql
@@ -12,9 +12,15 @@
 -- — and the floor has to be applied AFTER it: "Product Owner", "product owner" and
 -- "PRODUCT OWNER" are three rows here and one suggestion, so a floor applied to these
 -- counts would drop a title that clears it comfortably once merged.
+-- AND NOT is_private excludes the jd-tailor-intake private-job path: the dictionary this
+-- mines is served to every visitor as they type, so a title one user pasted in privately
+-- must not become public vocabulary. The frequency floor is not the guard — it is applied
+-- after normalisation, so a private title merges into a public one's count rather than
+-- standing alone under it.
 SELECT title, count(*) AS count
 FROM jobs
 WHERE closed_at IS NULL
+  AND NOT is_private
   AND title <> ''
 GROUP BY title;
 

--- a/internal/platform/db/search_outbox.sql.go
+++ b/internal/platform/db/search_outbox.sql.go
@@ -23,6 +23,17 @@ WITH claimable AS (
           WHERE j.id = o.job_id
             AND j.closed_at IS NULL
             AND j.duplicate_of IS NULL
+            -- A private posting must never be drained into the public facet index, and
+            -- "InsertPrivateJob enqueues none" is not enough to stop it: the role-duplicate
+            -- pass requeues every row whose duplicate_of goes back to NULL, and canon is
+            -- MIN(id) among OPEN rows with failover when the canon closes. So a pasted JD
+            -- marked a duplicate of the public posting it was copied from is ELECTED canon
+            -- the moment that public one soft-closes, and is requeued from there — title,
+            -- company, description and public_slug into the index anyone searches.
+            -- Constructed against Postgres before this line existed; the row was claimed.
+            -- cmd/reindex already drops private rows on the full rebuild; this is the same
+            -- rule on the incremental path, which is the one that had no predicate at all.
+            AND NOT j.is_private
       )
     ORDER BY o.job_posted_at DESC NULLS LAST, o.job_id DESC
     FOR UPDATE OF o SKIP LOCKED

--- a/internal/platform/db/suggestions.sql.go
+++ b/internal/platform/db/suggestions.sql.go
@@ -15,6 +15,7 @@ const mineJobTitles = `-- name: MineJobTitles :many
 SELECT title, count(*) AS count
 FROM jobs
 WHERE closed_at IS NULL
+  AND NOT is_private
   AND title <> ''
 GROUP BY title
 `
@@ -37,6 +38,11 @@ type MineJobTitlesRow struct {
 // — and the floor has to be applied AFTER it: "Product Owner", "product owner" and
 // "PRODUCT OWNER" are three rows here and one suggestion, so a floor applied to these
 // counts would drop a title that clears it comfortably once merged.
+// AND NOT is_private excludes the jd-tailor-intake private-job path: the dictionary this
+// mines is served to every visitor as they type, so a title one user pasted in privately
+// must not become public vocabulary. The frequency floor is not the guard — it is applied
+// after normalisation, so a private title merges into a public one's count rather than
+// standing alone under it.
 func (q *Queries) MineJobTitles(ctx context.Context) ([]MineJobTitlesRow, error) {
 	rows, err := q.db.Query(ctx, mineJobTitles)
 	if err != nil {


### PR DESCRIPTION
From the third review pass. Two live privacy leaks, one user-facing misclassification, and the guard that stops the first class recurring — it has now been found **four** times by hand.

### A company's public page published private job descriptions

`ListJobsByCompany` filtered on `closed_at`/`duplicate_of` only. Five neighbouring public-read queries in the same file carry `AND NOT is_private` and say why. The route is anonymous, and `ORDER BY created_at DESC` put the leak **at the top**. The page already contradicted itself: `RefreshCompanyFacets` excludes private rows from `companies.job_count`, so the list showed what its own counter did not.

### The guard, and what it immediately found

A sweep over `queries/*.sql`: every statement reading `jobs` scoped to open postings must carry the predicate, or be named in an exception table with a reason. Modelled on `folded_slug_rule_test.go` and `blocks.go`. It carries three anti-tautology checks — an entry naming no statement fails, an entry outside the population fails, an entry for an already-predicated statement fails — plus a population floor so a blinded detector fails rather than passes.

It found **five more** unguarded statements that three review passes had missed by hand: `NewestOpenJobCreatedAt`, `MineJobTitles`, `OrphanAggregatorCompanies`, `ListSlugLikeCompaniesForBackfill`, `CanonicalJobForRole`. `job.Fields.Private` is added so the aggregate can carry the fact at all.

### A second leak, found by the reviewer refusing an exemption

The guard exempted `ClaimSearchOutboxBatch` because `InsertPrivateJob` enqueues nothing. True, and it does not follow: `RecomputeRoleDuplicatesForCompanies` requeues every row whose `duplicate_of` returns to NULL, and canon is `MIN(id)` among **open** rows with failover. So a pasted JD marked a duplicate of the public posting it was copied from becomes canon the moment that public one closes, and drains into the public facet index. Constructed against a real Postgres, then confirmed fixed.

### A moderator could rewrite a private JD and mint a public company from it

`created_by IS NOT NULL` is true for private JDs too. The unique damage is the **write**: `UpdateManualJob` opens with a `company_upsert` CTE, so it creates a public `companies` row from a private JD's employer — exactly what `InsertPrivateJob` refuses to do. Measured: with only the Go check removed, the zero-row UPDATE still minted the company.

### A rejection worded politely read as an offer

`SignalOffer` sat above `SignalRejection` in a first-match-wins list, and `"extend an offer"` is a bare phrase. Measured: *"we regret to inform you we cannot extend an offer"* → `offer`, at 0.95 confidence, over the 0.8 the stage advance needs. A candidate's tracker said they had an offer when they were rejected.

Contradictory evidence is now settled rather than raced down the list. The veto reads a **subset** — the first attempt vetoed on the whole rejection vocabulary and turned six realistic positives into rejections (*"pleased to offer you … decided to move forward with you"*), which `SuggestStage` then offered as a move to `rejected`. All ten phrasings are pinned.

### Checks

`gofmt`, `build`, `vet`, `go test ./...`, `go vet -tags=integration ./...`, `make sqlc` (no drift), `golangci-lint --new-from-rev` (0), and the tagged suites for `internal/platform/db`, `internal/api/handler`, `internal/ingest/moderation`, `internal/job/job`, `internal/application/mailclassify`. Every fix mutation-checked; the reviewer re-ran all of them and constructed both leaks independently.

### Follow-ups recorded, not silently dropped

The duplicate-marker family and `EnqueuePendingJobs` are exempted with their residual stated in the table rather than blessed; `ResidualTitleGroups` records the predicate as owed. Each is a bounded, named next step.
