### PR TITLE
Build the daily digest from a day that has actually finished

### DIFF
--- a/internal/engage/socialdigest/repository_integration_test.go
+++ b/internal/engage/socialdigest/repository_integration_test.go
@@ -131,6 +131,53 @@ func TestLatestViewDayPicksTheNewest(t *testing.T) {
 	}
 }
 
+// The regression this query exists to prevent, and the reason it is not a plain
+// max(day). cmd/rollup-views fires at 02:30 UTC and reaches past midnight into the log
+// it is rotating, so it lands a handful of rows on the day still in progress. Reading
+// that stub as "the freshest day" makes every digest a quiet day: nothing in a few
+// hours of traffic clears MinPageUniques, the run exits 0, and the completed day beside
+// it is lost for good, because tomorrow's max(day) is fresher still.
+//
+// The days are relative to now on purpose. Fixed dates would make this test agree with
+// a plain max(day) the moment they fell into the past, which is exactly the shape of
+// the bug — it only shows on the day the rollup is writing.
+func TestLatestViewDayIgnoresTheDayInProgress(t *testing.T) {
+	pool := testdb.Pool(t)
+	id := seedJob(t, pool, seed{slug: "acme-1"})
+
+	today := truncateDay(time.Now())
+	yesterday := today.AddDate(0, 0, -1)
+	seedViews(t, pool, id, yesterday, 40, 40) // a completed day
+	seedViews(t, pool, id, today, 1, 1)       // the stub the rollup just wrote
+
+	got, ok, err := repo(pool).LatestViewDay(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || !got.Equal(yesterday) {
+		t.Errorf("got (%s, %v), want %s", got.Format(DayLayout), ok, yesterday.Format(DayLayout))
+	}
+}
+
+// A rollup holding only the day in progress has produced no publishable day at all.
+// Reporting that as "no data" is deliberate: the service turns it into ErrNoViewData
+// and the run exits non-zero. The alternative — treating it as a quiet day — is the
+// silent exit 0 that hid this bug in the first place, so the loud answer is the right
+// one even though a freshly deployed host sees it once.
+func TestLatestViewDayWithOnlyTheDayInProgress(t *testing.T) {
+	pool := testdb.Pool(t)
+	id := seedJob(t, pool, seed{slug: "acme-1"})
+	seedViews(t, pool, id, truncateDay(time.Now()), 1, 1)
+
+	got, ok, err := repo(pool).LatestViewDay(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Errorf("got (%s, true), want no completed day", got.Format(DayLayout))
+	}
+}
+
 // The headline requirement of the whole change, and a pure SQL property: a posting
 // with heavy API traffic must not outrank one with more page opens.
 func TestTopPageViewedRanksOnPageUniquesNotUniques(t *testing.T) {

--- a/internal/engage/socialdigest/socialdigest.go
+++ b/internal/engage/socialdigest/socialdigest.go
@@ -73,8 +73,9 @@ type Posting struct {
 // Digest is a finished list, ready to publish. An empty Items means the day had
 // nothing worth publishing — a quiet day, not a failure.
 type Digest struct {
-	// Day is the day the digest DESCRIBES, not the day it is sent. They always differ:
-	// the freshest day in the view rollup is a completed day.
+	// Day is the day the digest DESCRIBES, not the day it is sent. They always differ,
+	// because the day this is built from is a COMPLETED one — the rollup also holds a
+	// stub of the day in progress, and LatestViewDay is what excludes it.
 	Day   time.Time
 	Items []Posting
 }
@@ -101,8 +102,12 @@ type Publisher interface {
 // so the rules above can be tested against a fake without a database — the queries
 // themselves are covered by the integration tests that exercise real SQL.
 type Repository interface {
-	// LatestViewDay reports the freshest day the view rollup holds. The bool is false
-	// when there is none, which is a broken pipeline rather than an empty day.
+	// LatestViewDay reports the freshest COMPLETED day the view rollup holds. The bool
+	// is false when there is none, which is a broken pipeline rather than an empty day.
+	//
+	// Completed, not merely freshest: cmd/rollup-views leaves a stub of the day in
+	// progress, and a digest built from it finds nothing above the floor and reports a
+	// quiet day — losing the finished day beside it for good. See the query's comment.
 	LatestViewDay(ctx context.Context) (time.Time, bool, error)
 
 	// TopPageViewed returns the day's eligible postings ranked by page views, most

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -2523,14 +2523,30 @@ type Querier interface {
 	// postings per company, the final ten) happens in Go, where it is a pure function
 	// over a slice and can be tested without a database. Those are the rules most likely
 	// to be argued about and changed; keeping them out of SQL keeps that argument cheap.
-	// The freshest day the view rollup has produced. The digest asks for this rather than
-	// computing "yesterday" from the clock: cmd/rollup-views fires at 02:30 UTC and reads
-	// the rotated access log, so whether the freshest complete day is yesterday or the day
-	// before depends on when logrotate runs on the host. A digest that assumed the answer
-	// would fail by publishing a stale list silently, which is the worst way to fail.
+	// The freshest COMPLETED day the view rollup has produced. The digest asks for this
+	// rather than computing "yesterday" from the clock: cmd/rollup-views fires at 02:30 UTC
+	// and reads the rotated access log, so whether the freshest complete day is yesterday
+	// or the day before depends on when logrotate runs on the host. A digest that assumed
+	// the answer would fail by publishing a stale list silently, which is the worst way to
+	// fail.
 	//
-	// Returns NULL when the table is empty; the caller treats that as a broken pipeline,
-	// not as an empty day.
+	// The day in progress is EXCLUDED, and that predicate is the point of this query
+	// rather than a refinement of it. A plain max(day) reads TODAY: the 02:30 UTC rollup
+	// reaches past midnight into the log it is rotating and lands a few dozen rows on the
+	// current day, so by 13:00 UTC — when the digest runs — the freshest day is a stub
+	// whose best posting has one view. Nothing clears MinPageUniques, the run reports a
+	// quiet day and exits 0, and the completed day beside it is never published, because
+	// tomorrow's max(day) is fresher still. Measured on 2026-09-06: day 09-05 held 207020
+	// rows and 38 postings above the floor, day 09-06 held 34 rows and a maximum of one
+	// view; three digests had been lost this way. The failure is invisible from outside —
+	// a silent exit 0 is indistinguishable from a genuinely quiet day.
+	//
+	// The boundary is UTC because the column is: internal/application/viewlog/aggregate.go
+	// buckets each access-log record by rec.Time.UTC(). A bare CURRENT_DATE would follow
+	// the session's timezone instead and, east of UTC, cut off a day that had not closed.
+	//
+	// Returns NULL when there is no completed day; the caller treats that as a broken
+	// pipeline, not as an empty day.
 	LatestJobViewDay(ctx context.Context) (pgtype.Date, error)
 	// created_at of the most recently added open, public job — the "is the pipeline
 	// still writing rows" signal for the public /status endpoint. Same predicate and

--- a/internal/platform/db/queries/social_digest.sql
+++ b/internal/platform/db/queries/social_digest.sql
@@ -8,15 +8,33 @@
 -- to be argued about and changed; keeping them out of SQL keeps that argument cheap.
 
 -- name: LatestJobViewDay :one
--- The freshest day the view rollup has produced. The digest asks for this rather than
--- computing "yesterday" from the clock: cmd/rollup-views fires at 02:30 UTC and reads
--- the rotated access log, so whether the freshest complete day is yesterday or the day
--- before depends on when logrotate runs on the host. A digest that assumed the answer
--- would fail by publishing a stale list silently, which is the worst way to fail.
+-- The freshest COMPLETED day the view rollup has produced. The digest asks for this
+-- rather than computing "yesterday" from the clock: cmd/rollup-views fires at 02:30 UTC
+-- and reads the rotated access log, so whether the freshest complete day is yesterday
+-- or the day before depends on when logrotate runs on the host. A digest that assumed
+-- the answer would fail by publishing a stale list silently, which is the worst way to
+-- fail.
 --
--- Returns NULL when the table is empty; the caller treats that as a broken pipeline,
--- not as an empty day.
-SELECT max(day)::date AS day FROM job_daily_views;
+-- The day in progress is EXCLUDED, and that predicate is the point of this query
+-- rather than a refinement of it. A plain max(day) reads TODAY: the 02:30 UTC rollup
+-- reaches past midnight into the log it is rotating and lands a few dozen rows on the
+-- current day, so by 13:00 UTC — when the digest runs — the freshest day is a stub
+-- whose best posting has one view. Nothing clears MinPageUniques, the run reports a
+-- quiet day and exits 0, and the completed day beside it is never published, because
+-- tomorrow's max(day) is fresher still. Measured on 2026-09-06: day 09-05 held 207020
+-- rows and 38 postings above the floor, day 09-06 held 34 rows and a maximum of one
+-- view; three digests had been lost this way. The failure is invisible from outside —
+-- a silent exit 0 is indistinguishable from a genuinely quiet day.
+--
+-- The boundary is UTC because the column is: internal/application/viewlog/aggregate.go
+-- buckets each access-log record by rec.Time.UTC(). A bare CURRENT_DATE would follow
+-- the session's timezone instead and, east of UTC, cut off a day that had not closed.
+--
+-- Returns NULL when there is no completed day; the caller treats that as a broken
+-- pipeline, not as an empty day.
+SELECT max(day)::date AS day
+FROM job_daily_views
+WHERE day < (now() AT TIME ZONE 'utc')::date;
 
 -- name: TopPageViewedJobsForDay :many
 -- The day's candidates, most-viewed first, ranked on page_uniques — NOT on uniques.

--- a/internal/platform/db/social_digest.sql.go
+++ b/internal/platform/db/social_digest.sql.go
@@ -35,7 +35,9 @@ func (q *Queries) DigestPublishedForChannel(ctx context.Context, arg DigestPubli
 
 const latestJobViewDay = `-- name: LatestJobViewDay :one
 
-SELECT max(day)::date AS day FROM job_daily_views
+SELECT max(day)::date AS day
+FROM job_daily_views
+WHERE day < (now() AT TIME ZONE 'utc')::date
 `
 
 // Queries behind the daily social digest (internal/engage/socialdigest, cmd/social-digest).
@@ -46,14 +48,30 @@ SELECT max(day)::date AS day FROM job_daily_views
 // postings per company, the final ten) happens in Go, where it is a pure function
 // over a slice and can be tested without a database. Those are the rules most likely
 // to be argued about and changed; keeping them out of SQL keeps that argument cheap.
-// The freshest day the view rollup has produced. The digest asks for this rather than
-// computing "yesterday" from the clock: cmd/rollup-views fires at 02:30 UTC and reads
-// the rotated access log, so whether the freshest complete day is yesterday or the day
-// before depends on when logrotate runs on the host. A digest that assumed the answer
-// would fail by publishing a stale list silently, which is the worst way to fail.
+// The freshest COMPLETED day the view rollup has produced. The digest asks for this
+// rather than computing "yesterday" from the clock: cmd/rollup-views fires at 02:30 UTC
+// and reads the rotated access log, so whether the freshest complete day is yesterday
+// or the day before depends on when logrotate runs on the host. A digest that assumed
+// the answer would fail by publishing a stale list silently, which is the worst way to
+// fail.
 //
-// Returns NULL when the table is empty; the caller treats that as a broken pipeline,
-// not as an empty day.
+// The day in progress is EXCLUDED, and that predicate is the point of this query
+// rather than a refinement of it. A plain max(day) reads TODAY: the 02:30 UTC rollup
+// reaches past midnight into the log it is rotating and lands a few dozen rows on the
+// current day, so by 13:00 UTC — when the digest runs — the freshest day is a stub
+// whose best posting has one view. Nothing clears MinPageUniques, the run reports a
+// quiet day and exits 0, and the completed day beside it is never published, because
+// tomorrow's max(day) is fresher still. Measured on 2026-09-06: day 09-05 held 207020
+// rows and 38 postings above the floor, day 09-06 held 34 rows and a maximum of one
+// view; three digests had been lost this way. The failure is invisible from outside —
+// a silent exit 0 is indistinguishable from a genuinely quiet day.
+//
+// The boundary is UTC because the column is: internal/application/viewlog/aggregate.go
+// buckets each access-log record by rec.Time.UTC(). A bare CURRENT_DATE would follow
+// the session's timezone instead and, east of UTC, cut off a day that had not closed.
+//
+// Returns NULL when there is no completed day; the caller treats that as a broken
+// pipeline, not as an empty day.
 func (q *Queries) LatestJobViewDay(ctx context.Context) (pgtype.Date, error) {
 	row := q.db.QueryRow(ctx, latestJobViewDay)
 	var day pgtype.Date


### PR DESCRIPTION
## What was broken

`cmd/social-digest` asked for `max(day)` in `job_daily_views` and treated the answer as "the freshest **completed** day". It is not completed.

`cmd/rollup-views` fires at 02:30 UTC and reaches past midnight into the log it is rotating, so it leaves a few dozen rows on the day still in progress. By 13:00 UTC, when the digest runs, that stub **is** the freshest day. Nothing in a few hours of traffic clears `MinPageUniques` (10), so the run builds an empty list, reports a quiet day and exits 0 — and the completed day beside it is never published, because tomorrow's `max(day)` is fresher still.

Measured on prod today:

| day | rows | max `page_uniques` | postings over the floor |
|---|---|---|---|
| 2026-09-06 (in progress) | 34 | 1 | 0 |
| 2026-09-05 | 207020 | 62 | 38 |
| 2026-09-04 | 114416 | 48 | 14 |

`social_digest_posts` holds exactly one day: `2026-09-04`, published on 09-05 — the last run where the stub happened not to exist yet at 13:00. Three days of digests have been lost since.

What makes this worth a guard rather than a one-line edit is the failure mode: a silent `exit 0` is indistinguishable from a genuinely quiet day, both from outside and in the logs.

## The fix

`LatestJobViewDay` excludes the day in progress. The boundary is UTC because the column is — `internal/application/viewlog/aggregate.go` buckets each access-log record by `rec.Time.UTC()` — and a bare `CURRENT_DATE` would follow the session's timezone and, east of UTC, cut off a day that had already closed.

A rollup holding *only* the day in progress now reports no data, which the service raises as `ErrNoViewData` and the run exits non-zero. That is loud once on a freshly deployed host, rather than silent every day.

## Tests

Two integration tests, seeding days **relative to now** rather than at fixed dates. A fixed date agrees with the old `max(day)` the moment it falls into the past, which is the exact shape of this bug — it only shows on the day the rollup is writing.

Both were verified to fail against the old query, with prod's own symptom:

```
--- FAIL: TestLatestViewDayIgnoresTheDayInProgress
    got (2026-09-06, true), want 2026-09-05
--- FAIL: TestLatestViewDayWithOnlyTheDayInProgress
    got (2026-09-06, true), want no completed day
```

`go test -tags=integration ./internal/engage/socialdigest/` passes on the fix.

## Follow-up, not in this PR

Day `2026-09-05` is publishable and was skipped. It will be posted by hand with `social-digest -day 2026-09-05` after a `-dry-run` read.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Social digests now use the latest completed day’s data, excluding the in-progress day.
  - Prevents partial current-day data from suppressing publication of the most recent completed digest.
  - Correctly reports missing view data when no completed day is available.

- **Documentation**
  - Clarified completed-day and UTC date-boundary behavior for social digest data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->