### PR TITLE
Widen auto-apply to every ATS it can queue against, gate the button on Pro

### DIFF
--- a/internal/api/atsapply/client.go
+++ b/internal/api/atsapply/client.go
@@ -42,6 +42,20 @@ var fillProviders = map[string]bool{
 	"greenhouse": true,
 }
 
+// reasonSubmissionNotImplemented is the one park reason for two distinct gaps that both
+// mean "nothing here can ever act on this attempt, regardless of how well the form
+// resolves": fillProviders excluding a provider whose schema DID fetch (Ashby, Workable),
+// and errNoSchemaFetcher below, for a provider applyform.Fetchers never registered at all
+// (Recruitee) — the candidate has no reason to see two different-sounding permanent gaps.
+const reasonSubmissionNotImplemented = "submission not yet implemented for this provider"
+
+// errNoSchemaFetcher reports that applyform.Fetchers has no entry for a provider at all —
+// distinct from a fetcher's own call failing, which stays an ordinary retryable error.
+// fetchSchema and PreviewClient.schemaFor both return it so their callers can park honestly
+// (reasonSubmissionNotImplemented) instead of spending the ordinary retry/dead-letter budget
+// on a provider that will never gain a schema fetcher through a retry.
+var errNoSchemaFetcher = errors.New("no schema fetcher registered for this provider")
+
 // Client drives a headless browser to resolve and, where possible, submit one application
 // attempt. It implements autoapply.SidecarClient — the in-process replacement for the
 // Python/Patchright sidecar the design originally proposed (see design.md's "chromedp, not
@@ -107,6 +121,9 @@ func (c *Client) Submit(ctx context.Context, claimed autoapply.Claimed, answers 
 
 	apiForm, err := c.fetchSchema(ctx, claimed)
 	if err != nil {
+		if errors.Is(err, errNoSchemaFetcher) {
+			return autoapply.SidecarResult{Status: autoapply.StatusParked, Reason: reasonSubmissionNotImplemented}, nil
+		}
 		return autoapply.SidecarResult{}, fmt.Errorf("fetch %s schema: %w", claimed.Provider, err)
 	}
 
@@ -160,7 +177,7 @@ func (c *Client) Submit(ctx context.Context, claimed autoapply.Claimed, answers 
 		// Fill/submit is only wired for Greenhouse so far — see fill.go. A form for
 		// another provider that DID fully resolve still parks rather than being
 		// submitted through a path never built or verified.
-		return autoapply.SidecarResult{Status: autoapply.StatusParked, Reason: "submission not yet implemented for this provider"}, nil
+		return autoapply.SidecarResult{Status: autoapply.StatusParked, Reason: reasonSubmissionNotImplemented}, nil
 	}
 	if browserCtx == nil {
 		return autoapply.SidecarResult{}, fmt.Errorf("internal error: no browser session for a Greenhouse submission")
@@ -305,7 +322,7 @@ func (c *Client) renderResumeToTempFile(ctx context.Context, claimed autoapply.C
 func (c *Client) fetchSchema(ctx context.Context, claimed autoapply.Claimed) (applyform.Form, error) {
 	fetcher, ok := c.fetchers[claimed.Provider]
 	if !ok {
-		return applyform.Form{}, fmt.Errorf("no schema fetcher for provider %q", claimed.Provider)
+		return applyform.Form{}, fmt.Errorf("%w: %q", errNoSchemaFetcher, claimed.Provider)
 	}
 	return fetcher.Fetch(ctx, applyform.Claimed{
 		JobID:      claimed.JobID,

--- a/internal/api/atsapply/client_test.go
+++ b/internal/api/atsapply/client_test.go
@@ -25,6 +25,23 @@ func TestSubmit_LeverAlwaysParksOnCaptchaWithoutTouchingFetchersOrBrowser(t *tes
 	}
 }
 
+// Recruitee (and any other source jobs.source can carry that internal/ingest/applyform
+// never registered a Fetcher for) has no schema fetcher at all — before this fix,
+// fetchSchema's plain error bubbled up as an ordinary retryable Fail, so an attempt for one
+// of these silently burned the whole retry budget toward a dead-letter instead of parking
+// honestly like Ashby/Workable's own "submission not yet implemented" outcome.
+func TestSubmit_ParksHonestlyWhenNoSchemaFetcherIsRegistered(t *testing.T) {
+	c := &Client{fetchers: nil}
+
+	result, err := c.Submit(context.Background(), autoapply.Claimed{Provider: "recruitee"}, nil)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if result.Status != autoapply.StatusParked || result.Reason != reasonSubmissionNotImplemented {
+		t.Errorf("result = %+v, want parked/%s", result, reasonSubmissionNotImplemented)
+	}
+}
+
 func TestUnscannableFormResult_MapsBothReasonsToParked(t *testing.T) {
 	for _, reason := range []unscannableFormReason{reasonCaptchaProtected, reasonUnrecognizedLayout} {
 		result, parked := unscannableFormResult(&unscannableFormError{reason: reason})

--- a/internal/api/atsapply/preview_client.go
+++ b/internal/api/atsapply/preview_client.go
@@ -2,6 +2,7 @@ package atsapply
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/chromedp/chromedp"
@@ -71,6 +72,9 @@ func (p *PreviewClient) Preview(ctx context.Context, claimed autoapply.Claimed, 
 
 	apiForm, err := p.schemaFor(ctx, claimed)
 	if err != nil {
+		if errors.Is(err, errNoSchemaFetcher) {
+			return autoapply.PreviewResult{Parked: true, Reason: reasonSubmissionNotImplemented}, nil
+		}
 		return autoapply.PreviewResult{}, fmt.Errorf("fetch %s schema: %w", claimed.Provider, err)
 	}
 	return autoapply.PreviewResult{Preview: PreviewAnswers(mergedFromAPIOnly(apiForm), answers, hasApprovedCV)}, nil
@@ -89,7 +93,7 @@ func (p *PreviewClient) schemaFor(ctx context.Context, claimed autoapply.Claimed
 	}
 	fetcher, ok := p.fetchers[claimed.Provider]
 	if !ok {
-		return applyform.Form{}, fmt.Errorf("no schema fetcher for provider %q", claimed.Provider)
+		return applyform.Form{}, fmt.Errorf("%w: %q", errNoSchemaFetcher, claimed.Provider)
 	}
 	return fetcher.Fetch(ctx, applyform.Claimed{
 		JobID: claimed.JobID, Provider: claimed.Provider,

--- a/internal/api/atsapply/preview_test.go
+++ b/internal/api/atsapply/preview_test.go
@@ -121,6 +121,23 @@ func TestPreviewClient_ALeverAttemptParksWithoutTouchingAFetcherOrFormReader(t *
 	}
 }
 
+// Mirrors TestSubmit_ParksHonestlyWhenNoSchemaFetcherIsRegistered: the preview pass runs
+// BEFORE Submit ever does (it is what actually reaches a Recruitee-sourced entry first, per
+// cmd/auto-apply's own run order), so it needs the same honest park — otherwise a
+// Recruitee attempt with no stored form burns the preview's own retry budget toward a
+// dead-letter before the candidate ever gets a tailored CV to review.
+func TestPreviewClient_ParksHonestlyWhenNoSchemaFetcherIsRegistered(t *testing.T) {
+	p := &PreviewClient{fetchers: nil, forms: nil}
+
+	result, err := p.Preview(context.Background(), autoapply.Claimed{Provider: "recruitee"}, nil)
+	if err != nil {
+		t.Fatalf("Preview: %v", err)
+	}
+	if !result.Parked || result.Reason != reasonSubmissionNotImplemented {
+		t.Errorf("result = %+v, want parked/%s", result, reasonSubmissionNotImplemented)
+	}
+}
+
 func TestPreviewClient_PrefersAStoredFormOverALiveFetchForANonGreenhouseProvider(t *testing.T) {
 	fetcher := &fakeFetcher{form: applyform.Form{Fields: []applyform.Field{
 		{ID: "should_not_be_used", Type: applyform.TypeText, Required: true},

--- a/internal/api/handler/auto_apply_enqueue.go
+++ b/internal/api/handler/auto_apply_enqueue.go
@@ -14,11 +14,20 @@ import (
 	"github.com/strelov1/freehire/internal/platform/db"
 )
 
-// autoApplyEnqueueSource is the only ATS this feature resolves a résumé upload field for
-// today (openspec/changes/auto-apply-tailored-resume's own scope decision) — enqueuing for
-// any other source would create an attempt that can tailor and get reviewed but can never
-// actually submit. See openspec/changes/auto-apply-submit-trigger.
-const autoApplyEnqueueSource = "greenhouse"
+// autoApplyEnqueueSources are the ATS providers auto-apply can queue an attempt against at
+// all. Only Greenhouse can currently SUBMIT one (fillProviders in internal/api/atsapply) —
+// an Ashby/Workable/Lever/Recruitee attempt still tailors and gets reviewed like any other,
+// then parks with an honest, named reason once cmd/auto-apply reaches it, rather than being
+// refused at the door. Widening this list is a product decision (a candidate spends a real
+// daily tailoring turn on an attempt that is not yet guaranteed to submit), not a technical
+// one — see openspec/changes/auto-apply-submit-trigger.
+var autoApplyEnqueueSources = map[string]bool{
+	"greenhouse": true,
+	"ashby":      true,
+	"workable":   true,
+	"lever":      true,
+	"recruitee":  true,
+}
 
 // autoApplyAlreadyDeclinedMessage is what a permanently-declined pair answers with —
 // distinct wording from autoApplyDeclineReason (auto_apply_tailor.go), which is the stored
@@ -87,8 +96,8 @@ func (h *assistantHandlers) PostJobAutoApply(c *fiber.Ctx) error {
 	if err != nil {
 		return err // pgx.ErrNoRows -> 404, per RenderError's own mapping
 	}
-	if job.Source != autoApplyEnqueueSource {
-		return fiber.NewError(fiber.StatusBadRequest, "auto-apply is only available for Greenhouse postings today")
+	if !autoApplyEnqueueSources[job.Source] {
+		return fiber.NewError(fiber.StatusBadRequest, "auto-apply cannot queue an attempt against this posting's ATS")
 	}
 
 	if h.cv == nil || h.cv.cvStore == nil {

--- a/internal/api/handler/auto_apply_enqueue_integration_test.go
+++ b/internal/api/handler/auto_apply_enqueue_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -96,7 +97,20 @@ func enqueueRequest(t *testing.T, app *fiber.App, slug, cookie string) *http.Res
 	return resp
 }
 
-func TestPostJobAutoApply_RefusesNonGreenhouseSource(t *testing.T) {
+func getJobRequest(t *testing.T, app *fiber.App, slug, cookie string) *http.Response {
+	t.Helper()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/jobs/"+slug, nil)
+	if cookie != "" {
+		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: cookie})
+	}
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	return resp
+}
+
+func TestPostJobAutoApply_RefusesAnUnsupportedSource(t *testing.T) {
 	pool := startPostgres(t)
 	truncateAutoApplyEnqueueTables(t, pool)
 	iss := auth.NewIssuer("test-secret", time.Hour)
@@ -105,12 +119,40 @@ func TestPostJobAutoApply_RefusesNonGreenhouseSource(t *testing.T) {
 	userID, cookie := autoApplyTailorUser(t, pool, iss, "nongh@example.test")
 	makePro(t, pool, userID)
 	insertBaseCV(t, pool, userID)
-	seedEnqueueJob(t, pool, "lever", "nongh-job")
+	seedEnqueueJob(t, pool, "smartrecruiters", "nongh-job")
 
 	resp := enqueueRequest(t, app, "nongh-job", cookie)
 	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusBadRequest {
-		t.Fatalf("status = %d, want 400 for a non-Greenhouse job", resp.StatusCode)
+		t.Fatalf("status = %d, want 400 for a source auto-apply cannot queue against", resp.StatusCode)
+	}
+}
+
+// TestPostJobAutoApply_AcceptsEveryQueueableSource covers every ATS auto-apply can queue an
+// attempt against today — Greenhouse is the only one that can currently SUBMIT (fillProviders
+// in internal/api/atsapply), but Ashby/Workable/Lever/Recruitee attempts still tailor and
+// review, then park honestly (see auto_apply_tailor_integration_test.go's own park-reason
+// coverage) rather than being refused at the door.
+func TestPostJobAutoApply_AcceptsEveryQueueableSource(t *testing.T) {
+	pool := startPostgres(t)
+	truncateAutoApplyEnqueueTables(t, pool)
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	app, _ := newAutoApplyEnqueueApp(pool, iss, nil)
+
+	for _, source := range []string{"greenhouse", "ashby", "workable", "lever", "recruitee"} {
+		t.Run(source, func(t *testing.T) {
+			userID, cookie := autoApplyTailorUser(t, pool, iss, source+"@example.test")
+			makePro(t, pool, userID)
+			insertBaseCV(t, pool, userID)
+			seedEnqueueJob(t, pool, source, source+"-job")
+
+			resp := enqueueRequest(t, app, source+"-job", cookie)
+			defer resp.Body.Close()
+			if resp.StatusCode != fiber.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want 200 queued for source %q: %s", resp.StatusCode, source, body)
+			}
+		})
 	}
 }
 
@@ -424,17 +466,7 @@ func TestGetJob_AutoApplyStatusOverlay(t *testing.T) {
 	insertBaseCV(t, pool, userID)
 	seedEnqueueJob(t, pool, "greenhouse", "status-job")
 
-	get := func(slug, cookie string) *http.Response {
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/jobs/"+slug, nil)
-		if cookie != "" {
-			req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: cookie})
-		}
-		resp, err := app.Test(req)
-		if err != nil {
-			t.Fatalf("request: %v", err)
-		}
-		return resp
-	}
+	get := func(slug, cookie string) *http.Response { return getJobRequest(t, app, slug, cookie) }
 
 	beforeResp := get("status-job", cookie)
 	defer beforeResp.Body.Close()
@@ -472,6 +504,35 @@ func TestGetJob_AutoApplyStatusOverlay(t *testing.T) {
 	defer declinedResp.Body.Close()
 	if got := decodeAutoApplyStatus(t, declinedResp); got == nil || *got != "declined" {
 		t.Fatalf("status after decline = %v, want \"declined\"", got)
+	}
+}
+
+// TestGetJob_AutoApplyStatusOverlay_NonGreenhouseSource guards the overlay for every source
+// auto-apply can now queue against, not only Greenhouse — the enqueue gate
+// (autoApplyEnqueueSources) and this read's own gate must name the same set, or a
+// successfully queued Ashby/Workable/Lever/Recruitee attempt would read back as no attempt
+// at all and the button would look idle forever.
+func TestGetJob_AutoApplyStatusOverlay_NonGreenhouseSource(t *testing.T) {
+	pool := startPostgres(t)
+	truncateAutoApplyEnqueueTables(t, pool)
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	app, _ := newAutoApplyEnqueueApp(pool, iss, nil)
+
+	userID, cookie := autoApplyTailorUser(t, pool, iss, "ashby-status@example.test")
+	makePro(t, pool, userID)
+	insertBaseCV(t, pool, userID)
+	seedEnqueueJob(t, pool, "ashby", "ashby-status-job")
+
+	enqueueResp := enqueueRequest(t, app, "ashby-status-job", cookie)
+	defer enqueueResp.Body.Close()
+	if enqueueResp.StatusCode != fiber.StatusOK {
+		t.Fatalf("enqueue status = %d, want 200", enqueueResp.StatusCode)
+	}
+
+	resp := getJobRequest(t, app, "ashby-status-job", cookie)
+	defer resp.Body.Close()
+	if got := decodeAutoApplyStatus(t, resp); got == nil || *got != "queued" {
+		t.Fatalf("status after enqueue for an Ashby posting = %v, want \"queued\"", got)
 	}
 }
 

--- a/internal/api/handler/jobs.go
+++ b/internal/api/handler/jobs.go
@@ -191,10 +191,10 @@ func (h *jobsHandlers) GetJob(c *fiber.Ctx) error {
 	// Caller's own auto-apply status for this job (openspec/changes/auto-apply-submit-trigger),
 	// same caller-scoped, signed-in-only overlay as MyVote above. No row is the common
 	// case (nil, omitted) and is not logged as an error; a real lookup failure also
-	// degrades to nil rather than failing the whole job read. Scoped to Greenhouse — the
-	// only source auto-apply resolves today (autoApplyEnqueueSource) — so every other
-	// job's read skips a query that could only ever come back empty.
-	if userID, ok := auth.UserID(c); ok && job.Source == autoApplyEnqueueSource {
+	// degrades to nil rather than failing the whole job read. Scoped to the same sources
+	// the enqueue endpoint accepts (autoApplyEnqueueSources) — so every other job's read
+	// skips a query that could only ever come back empty.
+	if userID, ok := auth.UserID(c); ok && autoApplyEnqueueSources[job.Source] {
 		if entry, err := h.queries.GetAutoApplyQueueEntryForJob(c.Context(), db.GetAutoApplyQueueEntryForJobParams{
 			UserID: userID, JobID: job.ID,
 		}); err == nil {

--- a/web/src/lib/autoApplyButton.test.ts
+++ b/web/src/lib/autoApplyButton.test.ts
@@ -7,31 +7,49 @@ import {
 } from './autoApplyButton';
 
 describe('autoApplyButtonState', () => {
-  it('hides the button for a non-Greenhouse posting', () => {
-    expect(autoApplyButtonState('lever', null)).toEqual({ kind: 'hidden' });
-    expect(autoApplyButtonState('workable', 'queued')).toEqual({ kind: 'hidden' });
+  it('hides the button for an ATS auto-apply cannot queue against at all', () => {
+    expect(autoApplyButtonState('linkedin', null, false, true)).toEqual({ kind: 'hidden' });
+    expect(autoApplyButtonState('smartrecruiters', 'queued', false, true)).toEqual({ kind: 'hidden' });
+  });
+
+  it('is idle for every ATS auto-apply can queue against, not just Greenhouse', () => {
+    for (const source of ['greenhouse', 'ashby', 'workable', 'lever', 'recruitee']) {
+      expect(autoApplyButtonState(source, null, false, true)).toEqual({ kind: 'idle' });
+    }
   });
 
   it('is idle for a Greenhouse posting with no attempt', () => {
-    expect(autoApplyButtonState('greenhouse', null)).toEqual({ kind: 'idle' });
-    expect(autoApplyButtonState('greenhouse', undefined)).toEqual({ kind: 'idle' });
+    expect(autoApplyButtonState('greenhouse', null, false, true)).toEqual({ kind: 'idle' });
+    expect(autoApplyButtonState('greenhouse', undefined, false, true)).toEqual({ kind: 'idle' });
   });
 
   it('is queued when the caller already has a live attempt', () => {
-    expect(autoApplyButtonState('greenhouse', 'queued')).toEqual({ kind: 'queued' });
+    expect(autoApplyButtonState('greenhouse', 'queued', false, true)).toEqual({ kind: 'queued' });
   });
 
   it('is declined when the caller already declined this attempt', () => {
-    expect(autoApplyButtonState('greenhouse', 'declined')).toEqual({ kind: 'declined' });
+    expect(autoApplyButtonState('greenhouse', 'declined', false, true)).toEqual({ kind: 'declined' });
   });
 
   it('is applied when the caller already applied, regardless of status', () => {
-    expect(autoApplyButtonState('greenhouse', null, true)).toEqual({ kind: 'applied' });
-    expect(autoApplyButtonState('greenhouse', 'queued', true)).toEqual({ kind: 'applied' });
+    expect(autoApplyButtonState('greenhouse', null, true, true)).toEqual({ kind: 'applied' });
+    expect(autoApplyButtonState('greenhouse', 'queued', true, true)).toEqual({ kind: 'applied' });
   });
 
   it('is failed when cmd/auto-apply gave up on the attempt', () => {
-    expect(autoApplyButtonState('greenhouse', 'failed')).toEqual({ kind: 'failed' });
+    expect(autoApplyButtonState('greenhouse', 'failed', false, true)).toEqual({ kind: 'failed' });
+  });
+
+  // The gate this test exists for: a non-Pro caller never sees the button at all, for any
+  // ATS or attempt state — not idle-only. Even a caller with a live queued/failed/declined
+  // attempt from when they WERE Pro sees nothing once they lapse, matching the product
+  // decision that this is a Pro feature end to end, not just to start one.
+  it('is hidden for a non-Pro caller regardless of source, status, or a standing attempt', () => {
+    expect(autoApplyButtonState('greenhouse', null, false, false)).toEqual({ kind: 'hidden' });
+    expect(autoApplyButtonState('greenhouse', 'queued', false, false)).toEqual({ kind: 'hidden' });
+    expect(autoApplyButtonState('greenhouse', 'failed', false, false)).toEqual({ kind: 'hidden' });
+    expect(autoApplyButtonState('greenhouse', 'declined', false, false)).toEqual({ kind: 'hidden' });
+    expect(autoApplyButtonState('greenhouse', null, true, false)).toEqual({ kind: 'hidden' });
   });
 });
 
@@ -46,16 +64,16 @@ describe('jobCtaPlan', () => {
     });
   });
 
-  it('makes a startable auto-apply the primary CTA and names the plan it needs', () => {
+  it('makes a startable auto-apply the primary CTA', () => {
     expect(plan('idle')).toEqual({
-      autoApply: { label: 'Auto-apply', primary: true, pro: true, disabled: false },
+      autoApply: { label: 'Auto-apply', primary: true, disabled: false },
       external: { label: 'Show origin', primary: false },
     });
   });
 
   it('keeps a standing attempt quiet and the apply button demoted', () => {
     expect(plan('queued')).toEqual({
-      autoApply: { label: 'Auto-apply queued', primary: false, pro: false, disabled: true },
+      autoApply: { label: 'Auto-apply queued', primary: false, disabled: true },
       external: { label: 'Show origin', primary: false },
     });
   });
@@ -65,18 +83,18 @@ describe('jobCtaPlan', () => {
   // the identical situation.
   it('leaves the apply button alone for a reader who already applied by hand', () => {
     expect(plan('applied')).toEqual({
-      autoApply: { label: 'Already applied', primary: false, pro: false, disabled: true },
+      autoApply: { label: 'Already applied', primary: false, disabled: true },
       external: { label: 'Apply', primary: true },
     });
   });
 
   it('promotes the apply button back when auto-apply will not act', () => {
     expect(plan('declined')).toEqual({
-      autoApply: { label: 'Auto-apply declined', primary: false, pro: false, disabled: true },
+      autoApply: { label: 'Auto-apply declined', primary: false, disabled: true },
       external: { label: 'Apply', primary: true },
     });
     expect(plan('failed')).toEqual({
-      autoApply: { label: "Auto-apply couldn't complete", primary: false, pro: false, disabled: true },
+      autoApply: { label: "Auto-apply couldn't complete", primary: false, disabled: true },
       external: { label: 'Apply', primary: true },
     });
   });
@@ -99,15 +117,6 @@ describe('jobCtaPlan', () => {
       const p = plan(kind);
       const hasPrimary = Boolean(p.autoApply?.primary) || p.external.primary;
       expect(hasPrimary, `state ${kind}`).toBe(kind !== 'queued');
-    }
-  });
-
-  // The Pro marker states a requirement of the action. On a button nobody can press it
-  // would state it about nothing.
-  it('marks Pro only on a button that can be pressed', () => {
-    for (const kind of kinds) {
-      const { autoApply } = plan(kind);
-      if (autoApply?.pro) expect(autoApply.disabled, `state ${kind}`).toBe(false);
     }
   });
 });

--- a/web/src/lib/autoApplyButton.ts
+++ b/web/src/lib/autoApplyButton.ts
@@ -1,15 +1,22 @@
-// The auto-apply button's rendered state, decided from the two fields the job detail
-// response already carries — kept out of JobView.svelte so it unit-tests without mounting
-// Svelte, mirroring notificationTarget.ts's own convention.
+// The auto-apply button's rendered state, decided from the job detail response's own
+// fields plus the caller's plan — kept out of JobView.svelte so it unit-tests without
+// mounting Svelte, mirroring notificationTarget.ts's own convention.
 //
-// PRO-eligibility and base-CV existence are NOT decided here: neither is known
-// client-side without new plumbing this change does not add (see
-// openspec/changes/auto-apply-submit-trigger/design.md's own Goals). A caller who is
-// not eligible still sees the idle button and learns why from the backend's own 402/409
-// message after clicking — JobView.svelte's error handling, not this function.
+// A non-Pro caller sees nothing at all, not an idle-but-clickable button: this is a Pro
+// feature end to end, so the gate is visibility, not just what happens on click. Base-CV
+// existence is still NOT decided here — that one caller learns about from the backend's
+// own 409 after clicking (JobView.svelte's error handling, not this function), since
+// whether a base CV exists is not plan-shaped and isn't worth a second client-side fetch
+// just to pre-empt one specific 409.
+
+// The ATS providers auto-apply can queue an attempt against at all — kept as a Set (not a
+// backend-fetched list) because the frontend only needs to decide hidden-vs-not; whether a
+// given attempt can actually SUBMIT (Greenhouse today) is the backend's own concern, not
+// this button's. Mirrors autoApplyEnqueueSources in internal/api/handler/auto_apply_enqueue.go.
+const autoApplyProviders = new Set(['greenhouse', 'ashby', 'workable', 'lever', 'recruitee']);
 
 export type AutoApplyButtonState =
-  | { kind: 'hidden' } // not a Greenhouse posting — auto-apply cannot resolve this ATS yet
+  | { kind: 'hidden' } // not Pro, or an ATS auto-apply cannot queue an attempt against at all
   | { kind: 'idle' } // no attempt yet — the button is clickable
   | { kind: 'queued' } // a live, undecided attempt already exists
   | { kind: 'declined' } // the candidate's own prior decision, permanent
@@ -17,17 +24,23 @@ export type AutoApplyButtonState =
   | { kind: 'failed' }; // cmd/auto-apply gave up on this attempt (dead-lettered or parked)
 
 /** Decides the auto-apply button's state from the job's source, the caller's own
- *  auto_apply_status (undefined/null for no attempt or an anonymous caller), and whether
- *  they already applied. `alreadyApplied` wins over `status`: a completed submission
- *  deletes the queue row that `status` reads (cmd/auto-apply/store.go's Submit), so the two
- *  never disagree in practice, but checking `alreadyApplied` first is what stops a re-click
- *  from starting a genuine second ATS submission if they ever did. */
+ *  auto_apply_status (undefined/null for no attempt or an anonymous caller), whether they
+ *  already applied, and whether they are on the Pro plan (or above). `isPro` is checked
+ *  first and wins over everything else, including a standing attempt from before a lapsed
+ *  subscription: a non-Pro caller sees no auto-apply state for this job at all, not a
+ *  frozen queued/failed/declined badge they can no longer act on.
+ *  `alreadyApplied` wins over `status`: a completed submission deletes the queue row that
+ *  `status` reads (cmd/auto-apply/store.go's Submit), so the two never disagree in
+ *  practice, but checking `alreadyApplied` first is what stops a re-click from starting a
+ *  genuine second ATS submission if they ever did. */
 export function autoApplyButtonState(
   source: string,
-  status?: string | null,
-  alreadyApplied?: boolean
+  status: string | null | undefined,
+  alreadyApplied: boolean,
+  isPro: boolean
 ): AutoApplyButtonState {
-  if (source !== 'greenhouse') return { kind: 'hidden' };
+  if (!isPro) return { kind: 'hidden' };
+  if (!autoApplyProviders.has(source)) return { kind: 'hidden' };
   if (alreadyApplied) return { kind: 'applied' };
   if (status === 'queued') return { kind: 'queued' };
   if (status === 'declined') return { kind: 'declined' };
@@ -36,15 +49,17 @@ export function autoApplyButtonState(
 }
 
 /** What the job page's two call-to-action buttons look like, given the auto-apply state.
- *  Never two loud buttons at once, and one wherever the reader still has something to do. */
+ *  Never two loud buttons at once, and one wherever the reader still has something to do.
+ *  Carries no Pro marker: `autoApplyButtonState` already gates the whole button on Pro, so
+ *  by the time any of these states renders at all the requirement is already met — a badge
+ *  naming it here would state a fact about nothing left to decide. */
 export type JobCtaPlan = {
-  /** `null` where auto-apply cannot drive the posting's ATS: no button is rendered. */
+  /** `null` where auto-apply cannot drive the posting's ATS, or the caller is not Pro: no
+   *  button is rendered either way — see autoApplyButtonState's own `hidden` doc comment. */
   autoApply: {
     label: string;
     /** Carries the brand fill — the page's primary call to action. */
     primary: boolean;
-    /** Renders the `Pro` marker naming the plan the action requires. */
-    pro: boolean;
     disabled: boolean;
   } | null;
   /** The link out to the posting's own site. Demoted to an outline `Show origin` while
@@ -53,11 +68,10 @@ export type JobCtaPlan = {
 };
 
 /** A rendered-but-unpressable auto-apply button: it reports where the attempt stands and
- *  takes neither the brand fill nor the `Pro` marker. */
+ *  takes no brand fill. */
 const quiet = (label: string): NonNullable<JobCtaPlan['autoApply']> => ({
   label,
   primary: false,
-  pro: false,
   disabled: true,
 });
 
@@ -71,9 +85,6 @@ const apply = { label: 'Apply', primary: true } as const;
  *  forward and demoting it there would leave the page with nothing loud to press. The rule
  *  is "demote while an attempt stands or can be started", not "demote whenever the
  *  auto-apply button exists" — the two read the same until you reach those two states.
- *
- *  `pro` rides only the clickable state for the same reason the brand fill does: a marker
- *  naming what an action requires says nothing on a button nobody can press.
  *
  *  `applied` does NOT demote, even though the reader has nothing left to do here. That
  *  state comes from `alreadyApplied` — the "Did you apply?" prompt after a manual
@@ -89,7 +100,7 @@ export function jobCtaPlan(state: AutoApplyButtonState): JobCtaPlan {
       return { autoApply: null, external: apply };
     case 'idle':
       return {
-        autoApply: { label: 'Auto-apply', primary: true, pro: true, disabled: false },
+        autoApply: { label: 'Auto-apply', primary: true, disabled: false },
         external: showOrigin,
       };
     case 'queued':

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -26,7 +26,7 @@
   import { track } from '$lib/analytics';
   import { foreignContentLang } from '$lib/seo';
   import type { Display } from '$lib/generated/contracts';
-  import type { Job, UserJob } from '$lib/types';
+  import type { Job, PlanState, UserJob } from '$lib/types';
   import { companyLogoUrl } from '$lib/logo';
   import { Badge, Button, Chip, EntityLogo, TabStrip, tabStripId } from '$lib/ui';
   import { formatDate, formatDateOrAgo, formatDateTime } from '$lib/utils';
@@ -62,6 +62,11 @@
   // yet loaded). `showApplyPrompt` is the post-click "Did you apply?" question.
   let interaction = $state.raw<UserJob | null>(null);
   let showApplyPrompt = $state(false);
+  // The signed-in user's own plan (null when signed out or not yet loaded), fetched
+  // alongside `interaction` below — auto-apply is the one caller-scoped feature on this
+  // page whose visibility (not just its outcome) depends on the plan tier.
+  let userPlan = $state.raw<PlanState | null>(null);
+  const isPro = $derived(userPlan?.plan === 'pro' || userPlan?.plan === 'ultra');
   // Open-thread count for the "Discussion · N" badge; loaded client-side so the
   // page renders immediately and the number fills in. Failures leave it hidden.
   let threadCount = $state<number | null>(null);
@@ -178,6 +183,26 @@
     track('job_view', { slug, source: job.source });
   });
 
+  // The caller's plan, fetched once per signed-in session rather than per job: unlike
+  // `interaction` below it does not depend on `job.public_slug`, so navigating between job
+  // pages does not re-fetch or flicker it back to null while a plan that has not changed
+  // reloads. A failed fetch leaves it null, which the auto-apply gate above already treats
+  // the same as "not Pro" — a safe, if conservative, default rather than a broken page.
+  $effect(() => {
+    if (!isAuthenticated()) {
+      userPlan = null;
+      return;
+    }
+    let alive = true;
+    api
+      .myPlan()
+      .then((p) => alive && (userPlan = p))
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  });
+
   // Record a view for signed-in users once the page hydrates (browser only).
   // Silent history that also tells us whether they
   // already applied; a failed view must not break the page. Re-runs on client
@@ -290,15 +315,16 @@
     }
   }
 
-  // Auto-apply (openspec/changes/auto-apply-submit-trigger): PRO-only, Greenhouse-only.
-  // Eligibility (plan tier, base CV) is not known client-side — the button stays
-  // clickable and the backend's own 402/409 message is what tells an ineligible
-  // caller why, surfaced below rather than pre-empted here.
+  // Auto-apply (openspec/changes/auto-apply-submit-trigger): Pro (or above) and one of the
+  // ATS providers auto-apply can queue against — both are gated on VISIBILITY (isPro above),
+  // not just what happens on click. Base-CV existence is the one eligibility fact still not
+  // known client-side — the backend's own 409 is what tells a caller with no base CV why,
+  // surfaced below rather than pre-empted here.
   let autoApplyOverrideStatus = $state<string | null>(null);
   let autoApplySubmitting = $state(false);
   let autoApplyError = $state<string | null>(null);
   const autoApplyState = $derived(
-    autoApplyButtonState(job.source, autoApplyOverrideStatus ?? job.auto_apply_status, applied),
+    autoApplyButtonState(job.source, autoApplyOverrideStatus ?? job.auto_apply_status, applied, isPro),
   );
   // How loud each of the two CTAs is, and what they say. The table and the rule it keeps
   // ("never two primaries; one wherever an action remains") live in autoApplyButton.ts,
@@ -358,13 +384,9 @@
      button only starts the tailor-then-review sequence. What it says and how loud it is
      both come from the CTA plan; the only thing decided here is that a submission already
      in flight also disables it, which is a fact about THIS component's request rather than
-     about the posting.
-     The `Pro` marker is a span, not the `Badge` primitive: Badge's variants carry their own
-     background and foreground, none of which read as a plan marker on `bg-brand`. It takes
-     the PAGE's `foreground` for its fill and `background` for its text — near-black on
-     white in the light theme, near-white on black in the dark one — so it stays the highest
-     contrast thing on a brand-green button in either. A tint of the button's own foreground
-     was the first try and it dissolved into the fill. -->
+     about the posting. No `Pro` marker: only a Pro (or above) caller ever sees this button
+     at all (autoApplyState above), so labelling the requirement here would state a fact
+     about nothing left to decide. -->
 {#snippet autoApplyCta(size: 'md' | 'lg', className: string)}
   {#if cta.autoApply}
     {@const autoApply = cta.autoApply}
@@ -376,13 +398,6 @@
       class={className}
     >
       {autoApply.label}
-      {#if autoApply.pro}
-        <span
-          class="rounded-sm bg-foreground px-1.5 py-0.5 text-xs font-semibold uppercase leading-none tracking-wide text-background"
-        >
-          Pro
-        </span>
-      {/if}
     </Button>
   {/if}
 {/snippet}


### PR DESCRIPTION
## Summary
- Ashby, Workable, Lever and Recruitee can now be enqueued for auto-apply the same as Greenhouse — the enqueue endpoint (`PostJobAutoApply`) and the job-detail status overlay (`GetJob`) both accept the wider set (`autoApplyEnqueueSources`), rather than 400ing every non-Greenhouse posting.
- Recruitee has no registered schema fetcher at all (`internal/ingest/applyform.Fetchers`), so before this it would silently burn its whole retry budget toward a confusing dead-letter instead of parking. `Client.Submit` and `PreviewClient.Preview` now both recognize that case (`errNoSchemaFetcher`) and park honestly with the same `"submission not yet implemented for this provider"` reason Ashby/Workable already get.
- The auto-apply button is now gated on the Pro plan at the **visibility** level (`autoApplyButtonState`'s new `isPro` param), not just at click time — a non-Pro caller sees nothing at all, including for a standing queued/failed/declined attempt from before a lapsed subscription. `JobView.svelte` fetches the caller's plan client-side (mirrors the existing `interaction`/`threadCount` hydration pattern). The now-redundant `Pro` badge on the button is removed along with it.

Only Greenhouse can currently SUBMIT (`fillProviders`) — an Ashby/Workable/Lever/Recruitee attempt still tailors and gets reviewed, then parks with an honest, named reason once `cmd/auto-apply` reaches it. Widening the queueable set was a deliberate product call, not a technical one.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `gofmt -l` — clean
- [x] `go test ./...` — all unit tests pass
- [x] `go test -tags=integration ./internal/api/handler/... ./internal/api/atsapply/...` — real Postgres via testcontainers, all pass
- [x] `npx vitest run` (web/) — 1615 tests pass
- [x] `npx svelte-check` — 0 errors
- [x] `npx eslint` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)