### PR TITLE
Build the Profession prober through a constructor — the registry shipped a zero value and the harvest panicked

### DIFF
--- a/cmd/harvest-boards/prober.go
+++ b/cmd/harvest-boards/prober.go
@@ -798,7 +798,7 @@ var probers = map[string]prober{
 	"workstream":      workstreamProber{},
 	// Not an ATS: its boards are the platform's own job categories, enumerated from its
 	// sitemap index rather than seeded. See profession_prober.go.
-	"profession":  professionProber{},
+	"profession":  newProfessionProber(),
 	"cornerstone": adapterProber{provider: "cornerstone", newSource: func() sources.Source { return sources.NewCornerstone(sources.NewClient()) }},
 	"taleo":       adapterProber{provider: "taleo", newSource: func() sources.Source { return sources.NewTaleo(sources.NewCookieClient()) }},
 	"neogov":      adapterProber{provider: "neogov", newSource: func() sources.Source { return sources.NewNeogov(sources.NewClient()) }},

--- a/cmd/harvest-boards/profession_prober.go
+++ b/cmd/harvest-boards/profession_prober.go
@@ -42,9 +42,20 @@ import (
 // precisely the failure that took the crawl down between 2026-09-04 and 2026-09-06. The
 // cost is the one adapterProber's doc comment already names for its own case: this
 // prober's requests fall outside the run's paced, counting client.
+// Build it with newProfessionProber. The zero value is NOT usable — its index is a nil
+// pointer, and the first thing discover does is take a lock through it — and a zero value
+// is exactly what a struct literal in the registry decays to when a field is dropped. That
+// is not hypothetical: it shipped, and the first harvest panicked before making a request.
 type professionProber struct {
 	index  *professionCategoryIndex
 	client sources.XMLGetter
+}
+
+func newProfessionProber() professionProber {
+	return professionProber{
+		index:  &professionCategoryIndex{},
+		client: sources.NewSingleUseConnClient(),
+	}
 }
 
 // professionCategoryIndex memoizes the category-to-sitemap map for one harvest run. Only a

--- a/cmd/harvest-boards/profession_prober_test.go
+++ b/cmd/harvest-boards/profession_prober_test.go
@@ -24,10 +24,6 @@ const professionEducationSitemapXML = `<?xml version="1.0" encoding="UTF-8"?>
 <url><loc>https://www.profession.hu/kategoria/oktatas</loc></url>
 </urlset>`
 
-func newProfessionProber() professionProber {
-	return professionProber{index: &professionCategoryIndex{}, client: professionProberFixture()}
-}
-
 func professionProberFixture() fakeGetter {
 	return fakeGetter{
 		"https://www.profession.hu/sitemap-listings-index-hu.xml":     professionIndexXML,
@@ -40,7 +36,7 @@ func professionProberFixture() fakeGetter {
 // are enumerated rather than seeded. The non-category sitemaps in the index must not
 // become boards.
 func TestProfessionProberDiscover(t *testing.T) {
-	got, err := newProfessionProber().discover(context.Background(), professionProberFixture())
+	got, err := professionProber{index: &professionCategoryIndex{}, client: professionProberFixture()}.discover(context.Background(), professionProberFixture())
 	if err != nil {
 		t.Fatalf("discover: %v", err)
 	}
@@ -54,7 +50,7 @@ func TestProfessionProberDiscover(t *testing.T) {
 // request; probing it through the adapter — which is what proberFor falls back to without
 // this type — would crawl every posting in all 23 categories.
 func TestProfessionProberProbe(t *testing.T) {
-	company, open, err := newProfessionProber().probe(context.Background(), professionProberFixture(), "education")
+	company, open, err := professionProber{index: &professionCategoryIndex{}, client: professionProberFixture()}.probe(context.Background(), professionProberFixture(), "education")
 	if err != nil {
 		t.Fatalf("probe: %v", err)
 	}
@@ -142,5 +138,41 @@ func TestProfessionProberIgnoresTheSharedClient(t *testing.T) {
 	}
 	if !slices.Equal(got, []string{"education", "itdev"}) {
 		t.Errorf("discover() = %v", got)
+	}
+}
+
+// TestProberForProfessionIsUsable exercises the prober the REGISTRY hands out, not one the
+// test built for itself.
+//
+// It exists because every other test here constructs its own professionProber, and that is
+// exactly the shape of hole that let a zero-value entry ship: `professionProber{}` carries
+// a nil index and a nil client, so the first harvest panicked on a nil mutex before making
+// a single request. Tests that build their own subject prove the type works and say nothing
+// about the wiring.
+func TestProberForProfessionIsUsable(t *testing.T) {
+	p, ok := proberFor("profession")
+	if !ok {
+		t.Fatal("no prober registered for profession")
+	}
+	d, ok := p.(discoverer)
+	if !ok {
+		t.Fatal("the registered prober does not discover; harvest-boards would demand a seed file")
+	}
+	pp, ok := p.(professionProber)
+	if !ok {
+		t.Fatalf("registry holds %T, not professionProber", p)
+	}
+	if pp.index == nil {
+		t.Error("the registered prober has no index; discover panics on a nil mutex")
+	}
+	if pp.client == nil {
+		t.Error("the registered prober has no client of its own; it would read over the pooled one")
+	}
+	// A context already cancelled proves the call REACHES the transport rather than
+	// panicking on the way — no request leaves the machine.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := d.discover(ctx, nil); err == nil {
+		t.Error("discover on a cancelled context returned no error")
 	}
 }


### PR DESCRIPTION
`harvest-boards profession` panicked on a nil mutex before making a request: the registry held `professionProber{}`, with no index and no client. Two edits meant to fill those fields never landed, and nothing caught it.

**Nothing caught it because every test in the file builds its own `professionProber`.** Those tests prove the type works and say nothing about the value `proberFor` returns — which is the only one production calls. Same shape as a hardcoded list checked against itself: internally consistent, blind in the one direction that matters.

- `newProfessionProber()` gives the registry one place to be wrong instead of a struct literal that decays to a zero value when a field goes missing; the doc comment now states the zero value is unusable.
- `TestProberForProfessionIsUsable` asks `proberFor` for the prober the way `main.go` does and drives `discover` on an already-cancelled context, so the call must reach the transport to fail — proving construction succeeded without sending a request from the suite. It reproduces the production panic against the shipped code.

`gofmt -l` clean; `go vet ./...` and `go vet -tags=integration ./...` clean; `go test ./...` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved profession data discovery reliability by ensuring the associated probing process is properly initialized before use.
  - Prevented failures that could occur when profession discovery was invoked with an already-cancelled request.
  - Added safeguards to ensure the profession probe remains usable when obtained through the application’s standard registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->