### PR TITLE
Stop one oversized invitation from stalling every hosted mailbox, and let a curated vacancy reach search before the next rebuild

### DIFF
--- a/cmd/tg-extract/store.go
+++ b/cmd/tg-extract/store.go
@@ -19,9 +19,9 @@ const maxAttempts = 2
 
 // extractStore adapts the generated queries + pool to telegram.ExtractStore.
 // Complete writes every extracted job through the canonical UpsertJob (which
-// upserts the company and gates on the dedup key) plus the enrichment enqueue,
-// and marks the post extracted — all in one transaction, so a crash never
-// half-persists a post.
+// upserts the company and gates on the dedup key) plus the enrichment and search
+// enqueues, and marks the post extracted — all in one transaction, so a crash
+// never half-persists a post.
 type extractStore struct {
 	pool *pgxpool.Pool
 	q    *db.Queries
@@ -77,8 +77,8 @@ func (s *extractStore) CompleteLinks(ctx context.Context, post telegram.PendingP
 }
 
 // write persists every job through the canonical UpsertJob (which upserts the company and
-// gates on the dedup key), enqueues enrichment for each, and marks the post extracted — all in
-// one transaction, so a crash never half-persists a post.
+// gates on the dedup key), enqueues each for enrichment and for the live facet index, and
+// marks the post extracted — all in one transaction, so a crash never half-persists a post.
 //
 // It maps and nothing else. Building the aggregate, and refusing a mis-extraction that has no
 // title or identity, is the runner's — which is what lets a run report how many it refused
@@ -102,6 +102,13 @@ func (s *extractStore) write(ctx context.Context, post telegram.PendingPost, job
 			JobID:         saved.Job.ID,
 		}); err != nil {
 			return fmt.Errorf("enqueue enrichment %s/%s: %w", f.Source, f.ExternalID, err)
+		}
+		// And for the live facet index, in the same transaction — otherwise an extracted
+		// vacancy reaches /jobs/search and the facet counts only on the next full
+		// rebuild-and-swap. This is a stream, not the occasional curated write: every
+		// other write path (cmd/ingest, cmd/hydrate-adzuna-description) queues here too.
+		if err := qtx.EnqueueSearchOutbox(ctx, saved.Job.ID); err != nil {
+			return fmt.Errorf("enqueue search outbox %s/%s: %w", f.Source, f.ExternalID, err)
 		}
 	}
 

--- a/cmd/tg-extract/store_integration_test.go
+++ b/cmd/tg-extract/store_integration_test.go
@@ -1,0 +1,67 @@
+//go:build integration
+
+// Integration test for the extraction worker's store adapter: an extracted vacancy is
+// queued for the live facet index atomically with its row, like every other write path.
+// Run with: go test -tags=integration ./cmd/tg-extract/
+// Requires Docker (testcontainers spins up a throwaway Postgres with the migrations).
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/strelov1/freehire/internal/ingest/telegram"
+	"github.com/strelov1/freehire/internal/job/job"
+	"github.com/strelov1/freehire/internal/job/jobderive"
+	"github.com/strelov1/freehire/internal/platform/testdb"
+)
+
+// Telegram extraction is a stream, not the occasional curated write, and it wrote jobs
+// without queueing them: they reached /jobs/search and the facet counts only on the next
+// full rebuild-and-swap. cmd/ingest and cmd/hydrate-adzuna-description both queue here.
+func TestWriteQueuesEachExtractedJobForTheLiveIndex(t *testing.T) {
+	pool := testdb.Pool(t)
+	ctx := context.Background()
+	store := newExtractStore(pool)
+
+	post := telegram.PendingPost{
+		Channel:  "devjobs",
+		MsgID:    4242,
+		Text:     "Backend Engineer at Acme",
+		PostedAt: time.Now(),
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO telegram_posts (channel, msg_id, text, posted_at) VALUES ($1, $2, $3, $4)`,
+		post.Channel, post.MsgID, post.Text, post.PostedAt); err != nil {
+		t.Fatalf("seed post: %v", err)
+	}
+
+	j, err := job.New(job.Draft{Input: jobderive.Input{
+		Source:      "telegram",
+		ExternalID:  "devjobs:4242:0",
+		Title:       "Backend Engineer",
+		Company:     "Acme",
+		Location:    "Berlin, Germany",
+		Description: "We are hiring a backend engineer to work on Go services.",
+	}})
+	if err != nil {
+		t.Fatalf("build job: %v", err)
+	}
+
+	if err := store.Complete(ctx, post, []job.Job{j}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	var queued int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM search_outbox o
+		   JOIN jobs jb ON jb.id = o.job_id
+		  WHERE jb.source = $1 AND jb.external_id = $2`,
+		"telegram", "devjobs:4242:0").Scan(&queued); err != nil {
+		t.Fatalf("count search_outbox: %v", err)
+	}
+	if queued != 1 {
+		t.Errorf("search_outbox holds %d entries for the extracted job, want 1", queued)
+	}
+}

--- a/internal/application/ical/ical.go
+++ b/internal/application/ical/ical.go
@@ -15,6 +15,18 @@ import (
 	"strings"
 )
 
+// maxBody caps the body UID will parse, and it is a bound on work done for an
+// unauthenticated sender rather than a format rule. cmd/mail-ingest parses a message
+// BEFORE it resolves the recipient and before it acks the SQS entry, one at a time, in the
+// one Restart=always daemon on the host with no MemoryMax — so the time one text/calendar
+// part costs is time every hosted mailbox spends waiting for its own mail.
+//
+// A megabyte is far above anything an invitation carries (a full attendee list with a long
+// description is kilobytes) and far below SES's own 30 MB inbound ceiling, which is the
+// only other bound on this path. Over the cap reads as absence — the same answer every
+// other unreadable invitation already gets.
+const maxBody = 1 << 20
+
 // UID returns the first UID property in the body, or "" when it carries none.
 //
 // The first PROPERTY, not the first VEVENT's: a body whose VTODO precedes its VEVENT
@@ -26,6 +38,9 @@ import (
 // so a confident wrong answer would attach a meeting to an application that no
 // invitation named — and the candidate would prepare for the wrong employer.
 func UID(body []byte) string {
+	if len(body) > maxBody {
+		return ""
+	}
 	for _, line := range unfold(body) {
 		name, value, ok := splitProperty(line)
 		if !ok || !strings.EqualFold(name, "UID") {
@@ -44,20 +59,38 @@ func UID(body []byte) string {
 // leading space or tab. Real identifiers from Google and the ATS platforms are long
 // enough that this happens every time, so a line-by-line reader returns a truncated UID
 // — non-empty, well-formed, and matching no calendar event that will ever exist.
+//
+// The accumulator is a strings.Builder rather than `lines[len(lines)-1] += r[1:]`. Strings
+// are immutable, so that += reallocated and copied the whole logical line on every
+// continuation: quadratic in the number of continuations, measured at 70s on a 6.4 MB
+// body. maxBody bounds how much of that an unauthenticated sender may buy, but a cap alone
+// would still leave minutes of CPU inside it, and the daemon parses one message at a time.
 func unfold(body []byte) []string {
 	// Tolerate bare LF as well as the CRLF the format specifies: a message that has been
 	// through a gateway is not always still canonical.
 	raw := strings.Split(strings.ReplaceAll(string(bytes.TrimSpace(body)), "\r\n", "\n"), "\n")
 
-	var lines []string
+	var (
+		lines   []string
+		current strings.Builder
+		open    bool
+	)
 	for _, r := range raw {
-		if strings.HasPrefix(r, " ") || strings.HasPrefix(r, "\t") {
-			if len(lines) > 0 {
-				lines[len(lines)-1] += r[1:]
-				continue
-			}
+		// A continuation before any content line is not one — nothing precedes it to
+		// fold into, so it stands as its own line, leading whitespace and all.
+		if open && (strings.HasPrefix(r, " ") || strings.HasPrefix(r, "\t")) {
+			current.WriteString(r[1:])
+			continue
 		}
-		lines = append(lines, r)
+		if open {
+			lines = append(lines, current.String())
+			current.Reset()
+		}
+		current.WriteString(r)
+		open = true
+	}
+	if open {
+		lines = append(lines, current.String())
 	}
 	return lines
 }

--- a/internal/application/ical/ical_test.go
+++ b/internal/application/ical/ical_test.go
@@ -1,6 +1,10 @@
 package ical
 
-import "testing"
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
 
 // crlf builds a calendar body with the line endings the format actually uses. Writing
 // "\n" in a literal would test a document no mail server sends.
@@ -89,6 +93,87 @@ func TestUIDReportsAbsenceRatherThanGuessing(t *testing.T) {
 				t.Errorf("UID = %q, want empty", got)
 			}
 		})
+	}
+}
+
+// The sender of a text/calendar part is whoever mailed the hosted address, and
+// cmd/mail-ingest parses before it resolves the recipient and before it acks — one
+// message at a time, in the one Restart=always daemon on the host with no MemoryMax. So
+// the work one body may cost is a property worth pinning, not a detail.
+//
+// Over the cap reads as absence, which is what every other unparseable invitation already
+// reads as: internal/application/calmatch simply makes no automatic link.
+func TestUIDRefusesABodyTooLargeToBeAnInvitation(t *testing.T) {
+	head := crlf("BEGIN:VCALENDAR", "BEGIN:VEVENT", "UID:oversized@example.test")
+	pad := bytes.Repeat([]byte("X-PADDING:xxxxxxxxxxxxxxxxxxxx\r\n"), maxBody/32+1)
+	body := append(head, pad...)
+	if len(body) <= maxBody {
+		t.Fatalf("test body is %d bytes, want more than the %d-byte cap", len(body), maxBody)
+	}
+
+	if got := UID(body); got != "" {
+		t.Errorf("UID = %q, want empty for a body over the cap", got)
+	}
+}
+
+// The cap must not be reachable by an invitation anyone actually sends. A calendar part
+// with a long description and a full attendee list is kilobytes, so a body just under the
+// bound is still read normally.
+func TestUIDReadsABodyJustUnderTheCap(t *testing.T) {
+	head := crlf("BEGIN:VCALENDAR", "BEGIN:VEVENT", "UID:roomy@example.test")
+	pad := bytes.Repeat([]byte("X-PADDING:xxxxxxxxxxxxxxxxxxxx\r\n"), (maxBody-len(head))/32-1)
+	body := append(head, pad...)
+	if len(body) > maxBody {
+		t.Fatalf("test body is %d bytes, want at most the %d-byte cap", len(body), maxBody)
+	}
+
+	if want := "roomy@example.test"; UID(body) != want {
+		t.Errorf("UID = %q, want %q", UID(body), want)
+	}
+}
+
+// unfold used to join continuations with `lines[len(lines)-1] += r[1:]`, which reallocates
+// and copies everything accumulated so far on every continuation line — quadratic, and
+// measured at 70s on a 6.4 MB body. The cap above bounds the damage; this pins the shape,
+// because a cap alone would still leave minutes of CPU inside it.
+//
+// Doubling the input must roughly double the work, so the assertion is on ALLOCATED BYTES
+// rather than on wall time: it is the copying that grew, and a byte count is the same
+// number on a busy CI runner as on an idle laptop. Quadratic growth here was ~4x per
+// doubling; the ceiling of 3x leaves ample room for a linear implementation's slack.
+func TestUnfoldCostGrowsWithTheBodyNotItsSquare(t *testing.T) {
+	folded := func(continuations int) []byte {
+		var b strings.Builder
+		b.WriteString("BEGIN:VEVENT\r\nUID:long@example.test\r\n")
+		for i := 0; i < continuations; i++ {
+			b.WriteString(" xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\r\n")
+		}
+		b.WriteString("END:VEVENT\r\n")
+		return []byte(b.String())
+	}
+	small := testing.Benchmark(func(b *testing.B) {
+		body := folded(4000)
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = unfold(body)
+		}
+	})
+	large := testing.Benchmark(func(b *testing.B) {
+		body := folded(8000)
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = unfold(body)
+		}
+	})
+
+	smallBytes := small.AllocedBytesPerOp()
+	largeBytes := large.AllocedBytesPerOp()
+	if smallBytes == 0 {
+		t.Fatal("measured no allocation for the smaller body; the benchmark did not run")
+	}
+	if ratio := float64(largeBytes) / float64(smallBytes); ratio > 3 {
+		t.Errorf("doubling the body multiplied allocated bytes by %.1f (%d → %d); want linear growth, at most 3x",
+			ratio, smallBytes, largeBytes)
 	}
 }
 

--- a/internal/ingest/moderation/repository.go
+++ b/internal/ingest/moderation/repository.go
@@ -29,9 +29,15 @@ func NewQueriesRepository(q *db.Queries, pool *pgxpool.Pool, targetVersion int32
 	return &QueriesRepository{q: q, pool: pool, targetVersion: targetVersion}
 }
 
-// Create runs the manual-job upsert and the gated enrichment enqueue in one transaction,
-// so a newly created job is queued for enrichment atomically with its write (the same
-// transactional-outbox property as the ingest write path).
+// Create runs the manual-job upsert, the enrichment enqueue and the search enqueue in one
+// transaction, so a newly created job is queued for both atomically with its write (the
+// same transactional-outbox property as the ingest write path).
+//
+// The search enqueue is unconditional. cmd/ingest gates its own on "inserted or changed"
+// because it replays millions of rows a pass; a moderator write is one deliberate row, and
+// ClaimSearchOutboxBatch already skips an entry whose job has since closed or become a
+// non-canonical repost. cmd/search-drain applies the CategoryUnresolved/DescriptionMissing
+// rules on the way out, so nothing is gated here that is not gated there.
 func (r *QueriesRepository) Create(ctx context.Context, f job.Fields, actorID int64) (job.Job, job.Extras, error) {
 	tx, err := r.pool.Begin(ctx)
 	if err != nil {
@@ -53,6 +59,9 @@ func (r *QueriesRepository) Create(ctx context.Context, f job.Fields, actorID in
 		JobID:         row.ID,
 	}); err != nil {
 		return job.Job{}, job.Extras{}, fmt.Errorf("enqueue enrichment: %w", err)
+	}
+	if err := qtx.EnqueueSearchOutbox(ctx, row.ID); err != nil {
+		return job.Job{}, job.Extras{}, fmt.Errorf("enqueue search outbox: %w", err)
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return job.Job{}, job.Extras{}, err
@@ -84,17 +93,36 @@ func (r *QueriesRepository) BySlug(ctx context.Context, slug string) (job.Job, j
 	return job.FromRow(row)
 }
 
-// Update writes the full resulting row for a moderator-authored job. The query's
-// created_by scope means a missing or non-moderator-created slug affects no row
-// (ErrNoRows → ErrJobNotFound). The Fields→params mapping lives on the aggregate
-// (job.Fields.UpdateManualParams), shared with every other write path, so the derived
-// columns move with the edited content instead of being left behind here.
+// Update writes the full resulting row for a moderator-authored job and queues it for the
+// live facet index, in one transaction. The query's created_by scope means a missing or
+// non-moderator-created slug affects no row (ErrNoRows → ErrJobNotFound). The Fields→params
+// mapping lives on the aggregate (job.Fields.UpdateManualParams), shared with every other
+// write path, so the derived columns move with the edited content instead of being left
+// behind here.
+//
+// An edit changes precisely what search shows — the title, the body, the derived facets —
+// so it needs the enqueue as much as Create does. The transaction is what the enqueue is
+// for: writing the row and queueing it separately can leave the row written and unqueued,
+// which is the state this was fixing.
 func (r *QueriesRepository) Update(ctx context.Context, slug string, f job.Fields, actorID int64) (job.Job, job.Extras, error) {
-	row, err := r.q.UpdateManualJob(ctx, f.UpdateManualParams(slug, actorID))
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return job.Job{}, job.Extras{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	qtx := r.q.WithTx(tx)
+	row, err := qtx.UpdateManualJob(ctx, f.UpdateManualParams(slug, actorID))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return job.Job{}, job.Extras{}, ErrJobNotFound
 	}
 	if err != nil {
+		return job.Job{}, job.Extras{}, err
+	}
+	if err := qtx.EnqueueSearchOutbox(ctx, row.ID); err != nil {
+		return job.Job{}, job.Extras{}, fmt.Errorf("enqueue search outbox: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
 		return job.Job{}, job.Extras{}, err
 	}
 	return job.FromRow(row)

--- a/internal/ingest/moderation/repository_integration_test.go
+++ b/internal/ingest/moderation/repository_integration_test.go
@@ -1,0 +1,101 @@
+//go:build integration
+
+// Integration tests for the moderator write path's queue side effects: a created or edited
+// vacancy is queued for the live facet index atomically with its row, the same
+// transactional-outbox property cmd/ingest has. Needs a real Postgres — the outbox and the
+// slug minting live in SQL.
+// Run with: go test -tags=integration ./internal/ingest/moderation/
+// Requires Docker (testcontainers spins up a throwaway Postgres with the migrations).
+package moderation_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/strelov1/freehire/internal/ingest/moderation"
+	"github.com/strelov1/freehire/internal/platform/db"
+	"github.com/strelov1/freehire/internal/platform/testdb"
+)
+
+// liveService returns the service on the real adapter, plus the moderator id the writes
+// are stamped with — jobs.created_by is a foreign key, so the actor has to be a real row.
+func liveService(t *testing.T) (*moderation.Service, *pgxpool.Pool, int64) {
+	t.Helper()
+	pool := testdb.Pool(t)
+	var actorID int64
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO users (email) VALUES ('moderator@example.test') RETURNING id`).Scan(&actorID); err != nil {
+		t.Fatalf("insert moderator: %v", err)
+	}
+	return moderation.New(moderation.NewQueriesRepository(db.New(pool), pool, 1)), pool, actorID
+}
+
+func queuedForSearch(t *testing.T, pool *pgxpool.Pool, jobID int64) bool {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM search_outbox WHERE job_id = $1`, jobID).Scan(&n); err != nil {
+		t.Fatalf("count search_outbox: %v", err)
+	}
+	return n > 0
+}
+
+// Every other write path queues the row it wrote: cmd/ingest, cmd/hydrate-adzuna-description,
+// and linkimport (which pushes inline instead, for the same reason). The moderator path did
+// not, so a hand-curated vacancy stayed out of /jobs/search, the facet counts, and the
+// company's job count until the next full rebuild-and-swap — hours, on a 12h timer.
+//
+// The archived design justified the gap with parity ("manual jobs reach search via
+// make reindex, as ingest"); that premise expired when ingest moved onto search_outbox.
+func TestCreateQueuesTheJobForTheLiveIndex(t *testing.T) {
+	svc, pool, actorID := liveService(t)
+
+	j, _, err := svc.Create(context.Background(), actorID, moderation.CreateInput{
+		URL:         "https://example.test/jobs/moderated-1",
+		Title:       "Backend Engineer",
+		Company:     "Acme",
+		Location:    "Berlin, Germany",
+		Description: "We are hiring a backend engineer to work on Go services.",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if !queuedForSearch(t, pool, j.Fields().ID) {
+		t.Errorf("job %d is not in search_outbox after Create", j.Fields().ID)
+	}
+}
+
+// An edit changes exactly what search shows — the title, the description, the derived
+// facets — so it has to queue too. The create's own entry is cleared first: EnqueueSearchOutbox
+// keeps one live entry per job (ON CONFLICT), so a leftover row would pass this test whether
+// or not Update queues anything.
+func TestUpdateQueuesTheEditedJobForTheLiveIndex(t *testing.T) {
+	svc, pool, actorID := liveService(t)
+	ctx := context.Background()
+
+	created, _, err := svc.Create(ctx, actorID, moderation.CreateInput{
+		URL:         "https://example.test/jobs/moderated-2",
+		Title:       "Backend Engineer",
+		Company:     "Acme",
+		Description: "We are hiring a backend engineer to work on Go services.",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `DELETE FROM search_outbox WHERE job_id = $1`, created.Fields().ID); err != nil {
+		t.Fatalf("clear the create's entry: %v", err)
+	}
+
+	title := "Senior Backend Engineer"
+	edited, _, err := svc.Update(ctx, actorID, created.Fields().PublicSlug, moderation.UpdatePatch{Title: &title})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if !queuedForSearch(t, pool, edited.Fields().ID) {
+		t.Errorf("job %d is not in search_outbox after Update", edited.Fields().ID)
+	}
+}


### PR DESCRIPTION
Two findings from the third backend-review pass, both write paths that quietly did less than their neighbours.

## One oversized invitation stalled every hosted mailbox

`ical.unfold` joined RFC 5545 continuation lines with `lines[len(lines)-1] += r[1:]`. Strings are immutable, so that reallocated and copied the whole accumulated line on every continuation — quadratic.

Measured on the same bodies, before and after:

| body | before | after |
|---|---|---|
| 200 KB | 313 ms | 380 µs |
| 800 KB | 1.0 s | 1.7 ms |
| 3.2 MB | 19.7 s | 6.0 ms |
| 6.4 MB | 69.8 s | 12.4 ms |

The radius was the mail daemon, not the parser: `mailingest.Worker.handle` parses **before** it resolves the recipient and before it acks, one message at a time, in the one `Restart=always` unit on the host with no `MemoryMax`. One message to a hosted address held up everyone else's mail for as long as it took, and a resend cost the sender nothing.

A `strings.Builder` makes it linear. `maxBody` (1 MiB) additionally refuses a body no invitation carries — a cap alone still leaves minutes of CPU inside SES's own 30 MB ceiling, and linear alone still materializes whatever arrives. Over the cap reads as absence, the answer every other unreadable invitation already gets, so `calmatch` simply makes no automatic link.

The growth test asserts on **allocated bytes** rather than wall time: it is the copying that grew, and a byte count reads the same on a loaded CI runner as on an idle laptop. It failed at 3.9x per doubling before the fix.

## A curated vacancy reached search only on the next full rebuild

`moderation.Create`/`Update` and `cmd/tg-extract`'s `write` persisted jobs without `EnqueueSearchOutbox`, so a hand-curated or Telegram-extracted posting reached `/jobs/search`, the facet counts and the company's job count only on the next rebuild-and-swap (a 12h timer plus a multi-hour build).

The archived design justified the gap with parity — "manual jobs reach search via `make reindex`, as ingest" — and that premise expired when ingest moved onto `search_outbox`. Postgres-backed surfaces were never affected: `GET /jobs/:slug` and `ListJobs` read the row directly.

`Update` needed a transaction to take the enqueue: writing the row and queueing it separately can leave the row written and unqueued, which is the state being fixed. The enqueue is unconditional here — `cmd/ingest` gates its own because it replays millions of rows a pass, while `ClaimSearchOutboxBatch` already skips a closed or non-canonical entry and `cmd/search-drain` applies the `CategoryUnresolved`/`DescriptionMissing` rules on the way out.

## Verification

- `gofmt -l .` clean, `go build ./...`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...` — all pass.
- `go test -tags=integration ./internal/application/... ./internal/ingest/moderation/ ./cmd/tg-extract/` — pass.
- Both queue fixes were confirmed to **fail** with the enqueue removed; the ical growth test was confirmed to fail against the old `+=` accumulator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Newly extracted vacancies are now added to live search indexing immediately.
  - Newly created or edited moderated vacancies are also reflected in live search indexing without waiting for a full rebuild.

- **Bug Fixes**
  - Calendar feeds larger than 1 MiB are safely rejected.
  - Improved handling of long folded calendar content reduces processing overhead and prevents inefficient growth during parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->