### PR TITLE
Name the employers whose own boards disagree about their name

### DIFF
--- a/cmd/merge-companies/apply.go
+++ b/cmd/merge-companies/apply.go
@@ -9,8 +9,10 @@ import (
 // the loop below can be exercised without a database.
 type writer interface {
 	// InsertAlias records the retirement. ON CONFLICT DO NOTHING at the SQL layer, so a
-	// re-run neither errors nor moves a canon that is already frozen.
-	InsertAlias(ctx context.Context, a alias, canonical, foldedKey string) error
+	// re-run neither errors nor moves a canon that is already frozen. The folded key written
+	// is the ALIAS's own (a.FoldedKey), which for a folded group is the group's key and for a
+	// curated one is not — see the field's comment.
+	InsertAlias(ctx context.Context, a alias, canonical string) error
 	// RekeyChunk moves up to chunk of the alias's jobs onto the canonical slug and reports
 	// how many it moved. 0 means the slug is drained.
 	RekeyChunk(ctx context.Context, aliasSlug, canonical string, chunk int) (int64, error)
@@ -31,7 +33,7 @@ func applyMerges(ctx context.Context, w writer, plan []merge, chunk int) (int64,
 	var moved int64
 	for _, m := range plan {
 		for _, a := range m.Aliases {
-			if err := w.InsertAlias(ctx, a, m.Canonical, m.FoldedKey); err != nil {
+			if err := w.InsertAlias(ctx, a, m.Canonical); err != nil {
 				return moved, fmt.Errorf("record alias %s -> %s: %w", a.Slug, m.Canonical, err)
 			}
 			for {

--- a/cmd/merge-companies/apply_test.go
+++ b/cmd/merge-companies/apply_test.go
@@ -9,21 +9,26 @@ import (
 // fakeStore records the writes an apply run made, in order, so a test can prove both WHAT was
 // written and that a dry run wrote nothing at all.
 type fakeStore struct {
-	jobs      map[string]int // company_slug -> open jobs still carrying it
-	aliases   map[string]string
+	jobs    map[string]int // company_slug -> open jobs still carrying it
+	aliases map[string]string
+	// folded records the folded_key each alias row was written with. It is the column ingest
+	// resolves through, so a merge that writes the wrong one looks complete and re-mints the
+	// duplicate on the next crawl.
+	folded    map[string]string
 	rekeys    []string // canonical<-alias, one entry per chunk statement that moved rows
 	failRekey error
 }
 
 func newFakeStore(jobs map[string]int) *fakeStore {
-	return &fakeStore{jobs: jobs, aliases: map[string]string{}}
+	return &fakeStore{jobs: jobs, aliases: map[string]string{}, folded: map[string]string{}}
 }
 
-func (f *fakeStore) InsertAlias(_ context.Context, a alias, canonical, foldedKey string) error {
+func (f *fakeStore) InsertAlias(_ context.Context, a alias, canonical string) error {
 	if _, ok := f.aliases[a.Slug]; ok {
 		return nil // ON CONFLICT DO NOTHING: the canon is frozen at first merge
 	}
 	f.aliases[a.Slug] = canonical
+	f.folded[a.Slug] = a.FoldedKey
 	return nil
 }
 
@@ -47,8 +52,41 @@ func plan() []merge {
 		Canonical: "dollar-tree",
 		FoldedKey: "dollartree",
 		Jobs:      22966,
-		Aliases:   []alias{{Slug: "dollartree", Reason: reasonSpelling, JobCount: 283}},
+		Aliases: []alias{{
+			Slug: "dollartree", Reason: reasonSpelling, FoldedKey: "dollartree", JobCount: 283,
+		}},
 	}}
+}
+
+// TestApplyMerges_WritesEachAliasOwnFoldedKey is the guard for the curated case. Ingest
+// resolves company_slug_aliases by folded_key and never by alias_slug, so a curated group —
+// whose members do not share a fold, by definition — must write each row's OWN key. Writing
+// the group's key instead leaves the retiring spelling folding to a key no row holds: the
+// merge reports success, the redirect works, and the very next crawl of that board mints the
+// duplicate again.
+func TestApplyMerges_WritesEachAliasOwnFoldedKey(t *testing.T) {
+	store := newFakeStore(map[string]int{"exadel-inc-website": 50, "exadelinc": 1})
+	curated := []merge{{
+		Canonical: "exadel",
+		FoldedKey: curatedGroupKey("exadel"),
+		Jobs:      150,
+		Aliases: []alias{
+			{Slug: "exadel-inc-website", Reason: reasonSpelling, FoldedKey: "exadelincwebsite", JobCount: 50},
+			{Slug: "exadelinc", Reason: reasonSpelling, FoldedKey: "exadelinc", JobCount: 1},
+		},
+	}}
+
+	if _, err := applyMerges(context.Background(), store, curated, 100); err != nil {
+		t.Fatalf("applyMerges: %v", err)
+	}
+	for slug, want := range map[string]string{
+		"exadel-inc-website": "exadelincwebsite",
+		"exadelinc":          "exadelinc",
+	} {
+		if got := store.folded[slug]; got != want {
+			t.Errorf("alias %q written with folded_key %q, want %q", slug, got, want)
+		}
+	}
 }
 
 func TestApplyMerges_MovesEveryJobInChunks(t *testing.T) {

--- a/cmd/merge-companies/curated.go
+++ b/cmd/merge-companies/curated.go
@@ -1,0 +1,100 @@
+package main
+
+import "github.com/strelov1/freehire/internal/dict/normalize"
+
+// curatedAliases records slugs a human has decided are one employer where
+// normalize.CompanyKey cannot reach that conclusion on its own. Key is the slug retiring,
+// value is the slug that survives.
+//
+// # Why a list and not a rule
+//
+// Every entry below has the same shape — a base name with a numeric or parenthesised
+// suffix — and that shape is NOT safe to automate. Measured across the catalogue's 447,148
+// companies on 2026-09-06, folding "one folded name is a prefix of another" yields 32,880
+// pairs, and 1,206 of them differ by a trailing number. Most are board artefacts ("Pwc 1",
+// "Accenture 2", "aecom2"). Some are not:
+//
+//	Intel        (376 open jobs)  vs  intel471   — Intel 471 is a separate company
+//	Four Seasons (824 open jobs)  vs  Four Seasons Certified Home Health Agency
+//	SpaceX      (1009 open jobs)  vs  SpaceXAI
+//	Blend        (141 open jobs)  vs  Blend360
+//
+// A rule that collapsed the shape would merge those four, and a wrong merge is far more
+// expensive than a missed one: the alias is what the 301 reads, so it moves a public URL
+// onto the wrong employer and the re-key rewrites closed postings too. Naming each pair is
+// the honest cost of a judgement no name-shaped rule can make.
+//
+// # What earns an entry
+//
+// The name is the CANDIDATE and the postings are the PROOF. Every pair here was confirmed by
+// counting distinct job titles the two slugs share among their open postings, and the count
+// is recorded beside it. Twenty is the floor used when this list was seeded — below it the
+// overlap stops distinguishing one employer from two that hire for the same roles. `blend` /
+// `blend-360` scored 10 and was left out on exactly that evidence, which is also what the
+// name alone would have got wrong.
+//
+// # How to add one
+//
+//	SELECT count(*) FROM (
+//	  SELECT DISTINCT a.title FROM jobs a JOIN jobs b ON a.title = b.title
+//	  WHERE a.company_slug = '<canonical>' AND b.company_slug = '<retiring>'
+//	    AND a.closed_at IS NULL AND b.closed_at IS NULL) t;
+//
+// Then run the worker without --apply and read the plan. The invariants a new entry must
+// hold — canonical slug is a fixed point of the slug rule, and no entry points at a slug
+// that is itself retiring — are enforced by TestCuratedAliasesAreWellFormed, not by review.
+var curatedAliases = map[string]string{
+	// Exadel runs two Greenhouse boards under different display names, plus two stray
+	// artefacts. 110 shared open titles between the first pair — about half of each side's
+	// catalogue. Found because both spellings reached the same daily digest, where the
+	// per-company cap read them as two employers.
+	"exadel-inc-website": "exadel",
+	"exadelinc":          "exadel",
+	"exadel-1":           "exadel",
+
+	// Numeric board artefacts, each confirmed by shared open titles (the count follows).
+	"aecom2":                   "aecom",         // 1063
+	"nagarro1":                 "nagarro",       // 323
+	"sosi1":                    "sosi",          // 209
+	"nbcuniversal3":            "nbc-universal", // 135
+	"applusidiada1":            "applus-idiada", // 119
+	"ubisoft2":                 "ubisoft",       // 104
+	"ifs1":                     "ifs",           // 95
+	"soprasteria1":             "sopra-steria",  // 88
+	"netcompany1":              "netcompany",    // 85
+	"versant3":                 "versant",       // 85
+	"eversana1":                "eversana",      // 50
+	"inetum2":                  "inetum",        // 47
+	"bet3651":                  "bet365",        // 38
+	"questronix-corporation-2": "questronix",    // 31
+	"quadient1":                "quadient",      // 26
+	"avaloq1":                  "avaloq",        // 21
+	"flywire1":                 "flywire",       // 21
+}
+
+// curatedCanons is the set of slugs the list elects. A canonical slug joins its own curated
+// group rather than the folded group its name would otherwise land in — without that it
+// stays in the natural grouping and the curated members have no one to merge into.
+func curatedCanons(aliases map[string]string) map[string]bool {
+	out := make(map[string]bool, len(aliases))
+	for _, canon := range aliases {
+		out[canon] = true
+	}
+	return out
+}
+
+// curatedGroupKey is the grouping key for a curated decision. It is prefixed with a rune
+// normalize.CompanyKey can never emit, so a curated group can never collide with a folded
+// one — CompanyKey strips everything but letters and digits.
+func curatedGroupKey(canon string) string { return "\x00curated\x1e" + canon }
+
+// curatedCanonIsFixedPoint reports whether a canonical slug survives the slug rule unchanged.
+//
+// It has to. Every future posting from the surviving board derives its slug through
+// CompanySlug, so a canon the rule would rewrite could never be reached by an ordinary
+// crawl — the company would depend on an alias row forever to name itself. The same
+// requirement is why electCanonical derives the canon from a name rather than reusing a
+// stored slug.
+func curatedCanonIsFixedPoint(canon string) bool {
+	return normalize.CompanySlug(canon) == canon
+}

--- a/cmd/merge-companies/curated_test.go
+++ b/cmd/merge-companies/curated_test.go
@@ -1,0 +1,178 @@
+package main
+
+import "testing"
+
+// TestCuratedAliasesAreWellFormed is the guard that replaces reviewing the list by eye. Every
+// property here is one a wrong entry would break silently: the plan would still print, --apply
+// would still write, and the damage would be a public URL pointing at the wrong employer.
+func TestCuratedAliasesAreWellFormed(t *testing.T) {
+	canons := curatedCanons(curatedAliases)
+
+	for aliasSlug, canon := range curatedAliases {
+		if aliasSlug == "" || canon == "" {
+			t.Errorf("empty entry %q -> %q", aliasSlug, canon)
+			continue
+		}
+		if aliasSlug == canon {
+			// The database CHECK would reject this too, but at 3am mid-wave rather than in CI.
+			t.Errorf("%q retires into itself", aliasSlug)
+		}
+		// A chain (a -> b, b -> c) would leave `a` pointing at a slug that no longer holds
+		// jobs. The registry stores one hop and resolves one hop, so the second is never taken.
+		if _, chained := curatedAliases[canon]; chained {
+			t.Errorf("%q -> %q, but %q is itself retiring: the registry resolves one hop, so "+
+				"%q would land on a slug with no jobs", aliasSlug, canon, canon, aliasSlug)
+		}
+		if !curatedCanonIsFixedPoint(canon) {
+			t.Errorf("canonical %q is not a fixed point of CompanySlug: every future posting "+
+				"derives a different slug, so the company could never name itself", canon)
+		}
+		// A slug that is a canon for one entry and an alias in another is the same chain seen
+		// from the other end, and it makes the group membership depend on map order.
+		if canons[aliasSlug] {
+			t.Errorf("%q is both retiring and canonical", aliasSlug)
+		}
+	}
+}
+
+// exadel is the catalogue shape the curated list was built for: one employer running two
+// Greenhouse boards that disagree about the name, plus two stray artefacts. No two of these
+// four names fold to the same CompanyKey, which is exactly why the rule cannot reach them.
+func exadelCompanies() []company {
+	return []company{
+		{Slug: "exadel", Name: "Exadel", JobCount: 99},
+		{Slug: "exadel-inc-website", Name: "Exadel Inc (Website)", JobCount: 50},
+		{Slug: "exadel-1", Name: "Exadel 1", JobCount: 2},
+		{Slug: "exadelinc", Name: "exadelinc", JobCount: 1},
+	}
+}
+
+var exadelCurated = map[string]string{
+	"exadel-inc-website": "exadel",
+	"exadel-1":           "exadel",
+	"exadelinc":          "exadel",
+}
+
+func TestPlanMerges_CuratedGroupOverridesTheFold(t *testing.T) {
+	got := planMerges(exadelCompanies(), nil, 0, exadelCurated)
+
+	if len(got) != 1 {
+		t.Fatalf("planned %d merges, want 1 — the four names fold four different ways, so "+
+			"only the curated list can group them", len(got))
+	}
+	if got[0].Canonical != "exadel" {
+		t.Errorf("Canonical = %q, want exadel", got[0].Canonical)
+	}
+	if len(got[0].Aliases) != 3 {
+		t.Fatalf("retiring %d slugs, want 3", len(got[0].Aliases))
+	}
+	// The canon carries the most jobs here, but that is incidental: the list decides, not the
+	// count. See TestPlanMerges_CuratedCanonWinsAgainstTheJobCount.
+	for _, a := range got[0].Aliases {
+		if a.Slug == "exadel" {
+			t.Error("the canonical slug is retiring into itself")
+		}
+	}
+}
+
+// TestPlanMerges_CuratedAliasCarriesItsOwnFold is the whole reason folded_key moved onto the
+// alias. Ingest resolves by folded_key, so each retiring spelling has to record the fold its
+// OWN name produces — otherwise the next crawl of that board mints the duplicate again while
+// the merge reports success.
+func TestPlanMerges_CuratedAliasCarriesItsOwnFold(t *testing.T) {
+	got := planMerges(exadelCompanies(), nil, 0, exadelCurated)
+	if len(got) != 1 {
+		t.Fatalf("planned %d merges, want 1", len(got))
+	}
+
+	want := map[string]string{
+		"exadel-inc-website": "exadelincwebsite",
+		"exadel-1":           "exadel1",
+		"exadelinc":          "exadelinc",
+	}
+	for _, a := range got[0].Aliases {
+		if w, ok := want[a.Slug]; !ok {
+			t.Errorf("unexpected alias %q", a.Slug)
+		} else if a.FoldedKey != w {
+			t.Errorf("alias %q folded_key = %q, want %q", a.Slug, a.FoldedKey, w)
+		}
+	}
+}
+
+// TestPlanMerges_CuratedCanonWinsAgainstTheJobCount: the list is a judgement and outranks the
+// election. Sopra Steria is the real case — the artefact board carries 1336 open jobs against
+// the real company's 337, so an election would retire the company into its own artefact.
+func TestPlanMerges_CuratedCanonWinsAgainstTheJobCount(t *testing.T) {
+	got := planMerges([]company{
+		{Slug: "sopra-steria", Name: "Sopra Steria", JobCount: 337},
+		{Slug: "soprasteria1", Name: "SopraSteria1", JobCount: 1336},
+	}, nil, 0, map[string]string{"soprasteria1": "sopra-steria"})
+
+	if len(got) != 1 {
+		t.Fatalf("planned %d merges, want 1", len(got))
+	}
+	if got[0].Canonical != "sopra-steria" {
+		t.Errorf("Canonical = %q, want sopra-steria — the curated list decides, not the count",
+			got[0].Canonical)
+	}
+}
+
+// TestPlanMerges_CuratedGroupOfOneStillMerges: a curated entry whose canon holds no catalogue
+// row is still a merge. A slug no row holds yet is a legitimate canon (the reconcile after the
+// re-key creates it), and judging a curated group by member count would drop exactly the entry
+// somebody took the trouble to write down.
+func TestPlanMerges_CuratedGroupOfOneStillMerges(t *testing.T) {
+	got := planMerges([]company{
+		{Slug: "acme-2", Name: "Acme 2", JobCount: 7},
+	}, nil, 0, map[string]string{"acme-2": "acme"})
+
+	if len(got) != 1 {
+		t.Fatalf("planned %d merges, want 1", len(got))
+	}
+	if got[0].Canonical != "acme" || len(got[0].Aliases) != 1 {
+		t.Errorf("got canonical %q with %d aliases, want acme with 1",
+			got[0].Canonical, len(got[0].Aliases))
+	}
+}
+
+// TestPlanMerges_CuratedCanonLeavesItsFoldedGroup: the canon must join its curated group and
+// not stay in the folded one it would otherwise share. Left behind, the curated members would
+// have no one to merge into — a plan that prints and moves nothing.
+func TestPlanMerges_CuratedCanonLeavesItsFoldedGroup(t *testing.T) {
+	got := planMerges([]company{
+		{Slug: "acme", Name: "Acme", JobCount: 50},
+		{Slug: "acme-inc", Name: "Acme Inc", JobCount: 4}, // folds onto acme by the rule
+		{Slug: "acme-2", Name: "Acme 2", JobCount: 7},     // reaches acme only via the list
+	}, nil, 0, map[string]string{"acme-2": "acme"})
+
+	if len(got) != 1 {
+		t.Fatalf("planned %d merges, want 1 — the folded member and the curated one belong to "+
+			"the same employer and must not split into two groups", len(got))
+	}
+	if got[0].Canonical != "acme" {
+		t.Errorf("Canonical = %q, want acme", got[0].Canonical)
+	}
+	if len(got[0].Aliases) != 2 {
+		t.Errorf("retiring %d slugs, want 2 (acme-inc by the rule, acme-2 by the list)",
+			len(got[0].Aliases))
+	}
+}
+
+// TestPlanMerges_WithoutCuratedListNothingChanges pins that the list is additive: an ordinary
+// folded group plans exactly as it did before, and its alias records the group's own fold.
+func TestPlanMerges_WithoutCuratedListNothingChanges(t *testing.T) {
+	got := planMerges([]company{
+		{Slug: "dollar-tree", Name: "Dollar Tree", JobCount: 22683},
+		{Slug: "dollartree", Name: "DollarTree", JobCount: 283},
+	}, nil, 0, nil)
+
+	if len(got) != 1 {
+		t.Fatalf("planned %d merges, want 1", len(got))
+	}
+	if got[0].Canonical != "dollar-tree" {
+		t.Errorf("Canonical = %q, want dollar-tree", got[0].Canonical)
+	}
+	if len(got[0].Aliases) != 1 || got[0].Aliases[0].FoldedKey != "dollartree" {
+		t.Errorf("aliases = %+v, want one carrying folded_key dollartree", got[0].Aliases)
+	}
+}

--- a/cmd/merge-companies/main.go
+++ b/cmd/merge-companies/main.go
@@ -6,6 +6,11 @@
 // --min-jobs bounds a wave to the groups big enough to matter, which is how the backlog is
 // taken in reviewed passes (1000, then 100, then 10, then 1) instead of one 333k-row leap.
 //
+// Most groups it finds by folding the NAME, which covers the two duplicate classes the rule
+// can reach. The pairs it cannot — one employer whose boards disagree on the name itself, like
+// "Exadel" beside "Exadel Inc (Website)" — come from the hand-written list in curated.go, and
+// that file argues why they are a list and not another rule.
+//
 // It does NOT touch the search index. A push to the facet index costs 90-180s regardless of
 // batch size, so feeding a wave through search_outbox would be tens of hours of pushes and the
 // shape that took the site down on 2026-08-05. The scheduled reindex picks the re-key up; until
@@ -107,7 +112,7 @@ func loadPlan(ctx context.Context, q *db.Queries, minJobs int) ([]merge, error) 
 	for _, slug := range canonical {
 		frozen[slug] = true
 	}
-	return planMerges(companies, frozen, minJobs), nil
+	return planMerges(companies, frozen, minJobs, curatedAliases), nil
 }
 
 // report prints the wave. It prints every group rather than a sample: a wave is bounded by
@@ -133,11 +138,11 @@ func report(plan []merge) {
 // store is the writer applyMerges drives, over the real queries.
 type store struct{ q *db.Queries }
 
-func (s *store) InsertAlias(ctx context.Context, a alias, canonical, foldedKey string) error {
+func (s *store) InsertAlias(ctx context.Context, a alias, canonical string) error {
 	_, err := s.q.InsertCompanySlugAlias(ctx, db.InsertCompanySlugAliasParams{
 		AliasSlug:     a.Slug,
 		CanonicalSlug: canonical,
-		FoldedKey:     foldedKey,
+		FoldedKey:     a.FoldedKey,
 		Reason:        a.Reason,
 	})
 	return err

--- a/cmd/merge-companies/plan.go
+++ b/cmd/merge-companies/plan.go
@@ -32,9 +32,19 @@ type company struct {
 
 // alias is one slug retiring into a canonical one.
 type alias struct {
-	Slug     string
-	Reason   string
-	JobCount int
+	Slug   string
+	Reason string
+	// FoldedKey is CompanyKey of THIS alias's own name, and it is what ingest resolves a
+	// future posting through — ResolveCompanySlugAliases keys on folded_key, never on
+	// alias_slug, so a spelling nobody merged still lands on the canon its fold owns.
+	//
+	// It sits on the alias rather than on the group because a CURATED group's members do not
+	// share a fold: that is the definition of a curated group. Writing the group's key on
+	// every row would leave "Exadel Inc (Website)" folding to a key no row holds, so the next
+	// crawl of that board would mint the duplicate again and the merge would read as done.
+	// For a folded group this is exactly the group's key, so the two agree where they used to.
+	FoldedKey string
+	JobCount  int
 }
 
 // merge is one folded group's decision.
@@ -59,9 +69,47 @@ type merge struct {
 // its group outright, whatever the counts now say. minJobs drops groups whose combined open
 // jobs fall short, so a wave can be reviewed at a size a human can actually read.
 //
+// curated overrides the grouping for the pairs a human has named (see curated.go). Those
+// companies leave their folded groups entirely and form one group per canonical slug, where
+// the canon is the one the list names rather than the one an election would reach. A curated
+// group is the only kind whose members do not share a fold, which is why an alias carries its
+// own folded key.
+//
 // The result is deterministic — groups sorted by key, ties broken on the slug — because the
 // plan a human reviews in a dry run has to be the plan --apply then performs.
-func planMerges(companies []company, frozen map[string]bool, minJobs int) []merge {
+func planMerges(companies []company, frozen map[string]bool, minJobs int, curated map[string]string) []merge {
+	canons := curatedCanons(curated)
+	// The canon each curated group elects, so the loop below does not re-derive it from names
+	// that were grouped precisely because their names do not agree.
+	curatedWinner := make(map[string]string, len(canons))
+
+	// The folds a curated canon owns, found in a first pass because a canon is named by SLUG
+	// while a fold is computed from the NAME.
+	//
+	// This is what stops the list from breaking merges the rule already made. Naming a canon
+	// pulls it out of its folded group, and everything the rule had grouped WITH it — "Acme
+	// Inc" beside "Acme" — would be left in a group of one and silently dropped. Curating one
+	// duplicate of an employer would therefore un-merge its others. So the curated group
+	// absorbs the canon's fold whole: the rule's members and the list's members end up in the
+	// same group, which is the truth both were describing.
+	curatedFold := make(map[string]string, len(canons))
+	for _, c := range companies {
+		if c.Slug == "" || !canons[c.Slug] {
+			continue
+		}
+		key := normalize.CompanyKey(c.Name)
+		// Two canons folding the same way would make the result depend on slice order, so the
+		// smaller slug wins and the outcome is stable. It is a mistake either way — the guard
+		// in curated_test.go rejects one canon retiring into another — but a deterministic
+		// plan is what makes a dry run worth reading.
+		if key == "" {
+			continue
+		}
+		if prev, ok := curatedFold[key]; !ok || c.Slug < prev {
+			curatedFold[key] = c.Slug
+		}
+	}
+
 	groups := make(map[string][]company)
 	for _, c := range companies {
 		if c.Slug == "" {
@@ -73,12 +121,30 @@ func planMerges(companies []company, frozen map[string]bool, minJobs int) []merg
 			// on it would merge every untransliterable name into one company.
 			continue
 		}
+		// A curated member joins its canon's group; the canon joins its own; and so does
+		// anything the RULE would have grouped with the canon.
+		if canon, ok := curated[c.Slug]; ok {
+			key = curatedGroupKey(canon)
+			curatedWinner[key] = canon
+		} else if canons[c.Slug] {
+			key = curatedGroupKey(c.Slug)
+			curatedWinner[key] = c.Slug
+		} else if canon, ok := curatedFold[key]; ok {
+			key = curatedGroupKey(canon)
+			curatedWinner[key] = canon
+		}
 		groups[key] = append(groups[key], c)
 	}
 
 	var out []merge
 	for key, members := range groups {
-		if len(members) < 2 {
+		_, isCuratedGroup := curatedWinner[key]
+		// A folded group of one says nothing: the fold IS the evidence, so a lone member has
+		// nothing to be a duplicate of. A curated group of one does say something — the list
+		// names the canon, and that canon need not hold a catalogue row yet (a slug no row
+		// holds is a legitimate canon; see electCanonical). Judging it by member count would
+		// silently drop exactly the entry a human took the trouble to write down.
+		if len(members) < 2 && !isCuratedGroup {
 			continue
 		}
 		// Sort by job count descending, then by slug, so the election and the alias order
@@ -90,7 +156,10 @@ func planMerges(companies []company, frozen map[string]bool, minJobs int) []merg
 			return cmp.Compare(a.Slug, b.Slug)
 		})
 
-		winner := electCanonical(members, frozen)
+		winner := curatedWinner[key]
+		if !isCuratedGroup {
+			winner = electCanonical(members, frozen)
+		}
 		m := merge{Canonical: winner, FoldedKey: key}
 		for _, c := range members {
 			m.Jobs += c.JobCount
@@ -98,13 +167,18 @@ func planMerges(companies []company, frozen map[string]bool, minJobs int) []merg
 				continue
 			}
 			m.Aliases = append(m.Aliases, alias{
-				Slug:     c.Slug,
-				Reason:   reasonFor(c, winner),
-				JobCount: c.JobCount,
+				Slug:      c.Slug,
+				Reason:    reasonFor(c, winner),
+				FoldedKey: normalize.CompanyKey(c.Name),
+				JobCount:  c.JobCount,
 			})
 		}
-		// len(m.Aliases) is always >= 1 here: the group holds at least two companies and
-		// exactly one of them wins.
+		// A curated group whose only member IS its canon has nothing to retire — the entry has
+		// already been applied, or the duplicate has closed out of the catalogue. Reporting it
+		// as a group would put a line in the plan that moves nothing.
+		if len(m.Aliases) == 0 {
+			continue
+		}
 		if m.Jobs < minJobs {
 			continue
 		}

--- a/cmd/merge-companies/plan_test.go
+++ b/cmd/merge-companies/plan_test.go
@@ -14,7 +14,7 @@ func TestPlanMerges_ElectsTheVariantWithTheMostJobs(t *testing.T) {
 		{Slug: "domino-s", Name: "Domino's", JobCount: 1},
 		{Slug: "alfa-bank", Name: "Alfa Bank", JobCount: 1617},
 		{Slug: "al-fa-bank", Name: "Al Fa Bank", JobCount: 20},
-	}, nil, 0)
+	}, nil, 0, nil)
 
 	canon := map[string]string{}
 	for _, m := range got {
@@ -37,7 +37,7 @@ func TestPlanMerges_LabelsWhyEachAliasRetires(t *testing.T) {
 		{Slug: "ringcentral-inc", Name: "RingCentral, Inc.", JobCount: 2},
 		{Slug: "dollar-tree", Name: "Dollar Tree", JobCount: 22683},
 		{Slug: "dollartree", Name: "DollarTree", JobCount: 283},
-	}, nil, 0)
+	}, nil, 0, nil)
 
 	reasons := map[string]string{}
 	for _, m := range got {
@@ -57,7 +57,7 @@ func TestPlanMerges_RespectsAFrozenCanon(t *testing.T) {
 	got := planMerges([]company{
 		{Slug: "acme", Name: "Acme", JobCount: 3},
 		{Slug: "acme-inc", Name: "Acme Inc", JobCount: 900},
-	}, map[string]bool{"acme": true}, 0)
+	}, map[string]bool{"acme": true}, 0, nil)
 
 	if len(got) != 1 {
 		t.Fatalf("planned %d merges, want 1", len(got))
@@ -74,14 +74,14 @@ func TestPlanMerges_MinJobsBoundsTheWave(t *testing.T) {
 		{Slug: "small", Name: "Small", JobCount: 2},
 		{Slug: "small-inc", Name: "Small Inc", JobCount: 1},
 	}
-	got := planMerges(companies, nil, 1000)
+	got := planMerges(companies, nil, 1000, nil)
 	if len(got) != 1 || got[0].Canonical != "big" {
 		t.Fatalf("planned %v, want only the group whose combined jobs reach 1000", got)
 	}
 }
 
 func TestPlanMerges_IgnoresACompanyWithNoTwin(t *testing.T) {
-	if got := planMerges([]company{{Slug: "solo", Name: "Solo", JobCount: 5}}, nil, 0); len(got) != 0 {
+	if got := planMerges([]company{{Slug: "solo", Name: "Solo", JobCount: 5}}, nil, 0, nil); len(got) != 0 {
 		t.Errorf("planned %v, want nothing — a company with no other spelling is not a merge", got)
 	}
 }
@@ -93,9 +93,9 @@ func TestPlanMerges_IsDeterministic(t *testing.T) {
 		{Slug: "tie-a", Name: "Tie A", JobCount: 7},
 		{Slug: "tiea", Name: "TieA", JobCount: 7},
 	}
-	first := planMerges(companies, nil, 0)
+	first := planMerges(companies, nil, 0, nil)
 	for range 20 {
-		if !reflect.DeepEqual(planMerges(companies, nil, 0), first) {
+		if !reflect.DeepEqual(planMerges(companies, nil, 0, nil), first) {
 			t.Fatal("planMerges is not deterministic across runs")
 		}
 	}
@@ -115,7 +115,7 @@ func TestPlanMerges_CanonicalIsAFixedPointOfTheSlugRule(t *testing.T) {
 	got := planMerges([]company{
 		{Slug: "danaher-corporation", Name: "Danaher Corporation", JobCount: 900},
 		{Slug: "danaher", Name: "Danaher", JobCount: 714},
-	}, nil, 0)
+	}, nil, 0, nil)
 
 	if len(got) != 1 {
 		t.Fatalf("planned %d merges, want 1", len(got))
@@ -136,7 +136,7 @@ func TestPlanMerges_JobCountStillDecidesBetweenFixedPoints(t *testing.T) {
 	got := planMerges([]company{
 		{Slug: "dollartree", Name: "DollarTree", JobCount: 283},
 		{Slug: "dollar-tree", Name: "Dollar Tree", JobCount: 22683},
-	}, nil, 0)
+	}, nil, 0, nil)
 	if got[0].Canonical != "dollar-tree" {
 		t.Errorf("Canonical = %q, want dollar-tree", got[0].Canonical)
 	}
@@ -145,7 +145,7 @@ func TestPlanMerges_JobCountStillDecidesBetweenFixedPoints(t *testing.T) {
 	got = planMerges([]company{
 		{Slug: "dominos", Name: "Dominos", JobCount: 14396},
 		{Slug: "domino-s", Name: "Domino's", JobCount: 1},
-	}, nil, 0)
+	}, nil, 0, nil)
 	if got[0].Canonical != "dominos" {
 		t.Errorf("Canonical = %q, want dominos", got[0].Canonical)
 	}
@@ -157,7 +157,7 @@ func TestPlanMerges_FrozenCanonWinsEvenIfItCarriesAForm(t *testing.T) {
 	got := planMerges([]company{
 		{Slug: "acme-inc", Name: "Acme Inc", JobCount: 5},
 		{Slug: "acme", Name: "Acme", JobCount: 900},
-	}, map[string]bool{"acme-inc": true}, 0)
+	}, map[string]bool{"acme-inc": true}, 0, nil)
 	if got[0].Canonical != "acme-inc" {
 		t.Errorf("Canonical = %q, want acme-inc (frozen)", got[0].Canonical)
 	}
@@ -176,7 +176,7 @@ func TestPlanMerges_FallsBackToTheDerivedSlug(t *testing.T) {
 	got := planMerges([]company{
 		{Slug: "carnival-corporation", Name: "Carnival Corporation", JobCount: 300},
 		{Slug: "carnival-corporation-plc", Name: "Carnival Corporation plc", JobCount: 40},
-	}, nil, 0)
+	}, nil, 0, nil)
 
 	if len(got) != 1 {
 		t.Fatalf("planned %d merges, want 1", len(got))
@@ -208,7 +208,7 @@ func TestPlanMerges_PrefersTheSpellingTheNameIsWrittenIn(t *testing.T) {
 		got := planMerges([]company{
 			{Slug: "westerndigital", Name: "WesternDigital", JobCount: 400},
 			{Slug: "western-digital", Name: "Western Digital", JobCount: 126},
-		}, nil, 0)
+		}, nil, 0, nil)
 		if got[0].Canonical != "western-digital" {
 			t.Errorf("Canonical = %q, want western-digital — the employer writes two words",
 				got[0].Canonical)
@@ -221,7 +221,7 @@ func TestPlanMerges_PrefersTheSpellingTheNameIsWrittenIn(t *testing.T) {
 		got := planMerges([]company{
 			{Slug: "dominos", Name: "Dominos", JobCount: 14396},
 			{Slug: "domino-s", Name: "Domino's", JobCount: 1},
-		}, nil, 0)
+		}, nil, 0, nil)
 		if got[0].Canonical != "dominos" {
 			t.Errorf("Canonical = %q, want dominos", got[0].Canonical)
 		}
@@ -233,7 +233,7 @@ func TestPlanMerges_PrefersTheSpellingTheNameIsWrittenIn(t *testing.T) {
 		got := planMerges([]company{
 			{Slug: "alfa-bank", Name: "Alfa Bank", JobCount: 1617},
 			{Slug: "al-fa-bank", Name: "Al Fa Bank", JobCount: 20},
-		}, nil, 0)
+		}, nil, 0, nil)
 		if got[0].Canonical != "alfa-bank" {
 			t.Errorf("Canonical = %q, want alfa-bank", got[0].Canonical)
 		}
@@ -245,7 +245,7 @@ func TestPlanMerges_PrefersTheSpellingTheNameIsWrittenIn(t *testing.T) {
 		got := planMerges([]company{
 			{Slug: "kimberlyclark", Name: "KimberlyClark", JobCount: 300},
 			{Slug: "kimberly-clark", Name: "Kimberly-Clark", JobCount: 40},
-		}, nil, 0)
+		}, nil, 0, nil)
 		if got[0].Canonical != "kimberly-clark" {
 			t.Errorf("Canonical = %q, want kimberly-clark", got[0].Canonical)
 		}
@@ -257,7 +257,7 @@ func TestPlanMerges_PrefersTheSpellingTheNameIsWrittenIn(t *testing.T) {
 		got := planMerges([]company{
 			{Slug: "brinks", Name: "Brinks", JobCount: 200},
 			{Slug: "brink-s", Name: "Brink's", JobCount: 10},
-		}, nil, 0)
+		}, nil, 0, nil)
 		if got[0].Canonical != "brinks" {
 			t.Errorf("Canonical = %q, want brinks", got[0].Canonical)
 		}
@@ -269,7 +269,7 @@ func TestPlanMerges_PrefersTheSpellingTheNameIsWrittenIn(t *testing.T) {
 		got := planMerges([]company{
 			{Slug: "acehardware", Name: "AceHardware", JobCount: 500},
 			{Slug: "ace-hardware", Name: "Ace Hardware", JobCount: 90},
-		}, nil, 0)
+		}, nil, 0, nil)
 		if got[0].Canonical != "ace-hardware" {
 			t.Errorf("Canonical = %q, want ace-hardware", got[0].Canonical)
 		}
@@ -289,7 +289,7 @@ func TestPlanMerges_MultiWordNameWinsEvenWhenOnlyAFormedRowHasIt(t *testing.T) {
 	got := planMerges([]company{
 		{Slug: "publicstorage", Name: "PublicStorage", JobCount: 300},
 		{Slug: "public-storage-inc", Name: "Public Storage Inc", JobCount: 40},
-	}, nil, 0)
+	}, nil, 0, nil)
 
 	if got[0].Canonical != "public-storage" {
 		t.Errorf("Canonical = %q, want public-storage — the employer writes two words, and a "+
@@ -316,7 +316,7 @@ func TestPlanMerges_SeesASlugWhoseIndexCounterIsZero(t *testing.T) {
 	got := planMerges([]company{
 		{Slug: "jp-morgan-chase", Name: "JP Morgan Chase", JobCount: 0},
 		{Slug: "jpmorganchase", Name: "JPMorganChase", JobCount: 0},
-	}, nil, 0)
+	}, nil, 0, nil)
 
 	if len(got) != 1 {
 		t.Fatalf("planned %d merges, want 1 — a slug the search index has forgotten still has "+

--- a/docs/agents/company-identity.md
+++ b/docs/agents/company-identity.md
@@ -38,6 +38,12 @@ for display names, and [internal/job/collections](../../internal/job/collections
   spelling nobody ever merged still reaches the canon its folded form owns; `GET
   /companies/:slug` asks by `alias_slug` to serve a 301 — and only AFTER the company read
   misses, so a company that came back is never shadowed by the row that once retired it.
+- **`folded_key` is the ALIAS's own fold, never the group's.** For a folded group the two are
+  the same by construction, so the distinction only shows up on a curated group — whose members
+  do not share a fold, that being what makes it curated. Writing the group's key there leaves
+  the retiring spelling folding to a key no row holds: the merge reports success, the 301
+  works, and the next crawl of that board mints the duplicate again. Pinned by
+  `TestApplyMerges_WritesEachAliasOwnFoldedKey`.
 - **The canon freezes at first merge.** `InsertCompanySlugAlias` is `ON CONFLICT DO NOTHING`
   and the worker holds elected slugs out of a later election. A re-election would move a URL
   that has already been redirecting and indexing.
@@ -65,9 +71,30 @@ moment the code ships. The second cannot be: `jpmorganchase` and `jp-morgan-chas
 honest output of that rule — one source wrote "JPMorganChase", another "JP Morgan Chase" — so
 collapsing them means electing a winner, and the winner has to be remembered.
 
+There is a third class the fold cannot see at all, because the two spellings do not fold
+together: one employer whose boards disagree about the NAME. Exadel runs two Greenhouse boards
+calling themselves "Exadel" and "Exadel Inc (Website)", which key at `exadel` and
+`exadelincwebsite` — four slugs in total, 110 shared open job titles, and about half its
+catalogue duplicated. `cmd/merge-companies/curated.go` names those pairs by hand.
+
+**It is a list and not a rule on purpose.** Every entry has the same shape — a base name with
+a numeric or parenthesised suffix — and that shape is not safe to automate: of the 1,206
+prefix pairs differing by a trailing number (measured 2026-09-06 across 447,148 companies),
+`Intel`/`intel471`, `Four Seasons`/`Four Seasons Certified Home Health Agency`,
+`SpaceX`/`SpaceXAI` and `Blend`/`Blend360` are different employers. A wrong merge costs more
+than a missed one, since the alias is what the 301 reads. So the NAME proposes and the
+POSTINGS decide: an entry is confirmed by counting distinct job titles the two slugs share
+among their open postings, and the count is recorded beside it. `blend`/`blend-360` scored 10
+against a floor of 20 and was left out — on the same evidence the name alone got wrong.
+
+The invariants (canonical slug is a fixed point of `CompanySlug`, no entry points at a slug
+that is itself retiring) are enforced by `TestCuratedAliasesAreWellFormed`, not by review.
+
 `cmd/merge-companies` groups companies by `normalize.CompanyKey` of the NAME (which is what
 covers both classes in one pass), elects the highest `job_count` variant, and records the rest
-as aliases. It reports by default; `--apply` writes and `--min-jobs` bounds a wave so the plan
+as aliases. A curated group overrides that grouping: its canon is the one the list names, not
+the one an election reaches — Sopra Steria's artefact board carries 1,336 open jobs against the
+real company's 337, so an election would retire the company into its own artefact. It reports by default; `--apply` writes and `--min-jobs` bounds a wave so the plan
 stays short enough to read. Jobs move in chunks whose statement selects rows still carrying the
 retired slug, so an updated row leaves the set — the loop ends on its own, a re-run moves
 nothing, and an interrupted wave resumes. The alias row is written BEFORE its jobs move: a run


### PR DESCRIPTION
## The gap

`merge-companies` groups by `normalize.CompanyKey` of the NAME, which reaches the two duplicate classes the rule can describe. It cannot reach a third: **one employer whose own boards disagree about the name**.

Exadel runs two Greenhouse boards calling themselves "Exadel" and "Exadel Inc (Website)". Four slugs, **110 shared open job titles**, about half its catalogue duplicated:

| slug | name | open | total |
|---|---|---|---|
| `exadel` | Exadel | 99 | 345 |
| `exadel-inc-website` | Exadel Inc (Website) | 50 | 177 |
| `exadel-1` | Exadel 1 | 2 | 2 |
| `exadelinc` | exadelinc | 1 | 1 |

No two of those names fold together, so no rule over names groups them. Found because both spellings reached the same daily digest, where the cap of two postings per company read them as two employers and published the same job twice.

## Why a list and not a rule

Every entry has the same shape — a base name with a numeric or parenthesised suffix — and that shape is **not** safe to automate. Measured across the catalogue's 447,148 companies: folding "one folded name is a prefix of another" yields 32,880 pairs, 1,206 of them differing by a trailing number. Among those:

- `Intel` (376 open) vs `intel471` — Intel 471 is a separate company
- `Four Seasons` (824 open) vs `Four Seasons Certified Home Health Agency`
- `SpaceX` (1009 open) vs `SpaceXAI`
- `Blend` (141 open) vs `Blend360`

A wrong merge costs more than a missed one: the alias is what the 301 reads, and the re-key rewrites closed rows too.

So the **name proposes and the postings decide.** Each of the 20 seeded entries was confirmed by counting distinct job titles the two slugs share among their open postings, and the count sits beside it in `curated.go`. `blend`/`blend-360` scored 10 against a floor of 20 and was left out — on exactly the evidence the name alone got wrong.

## Two things the tests found that review would not have

**`folded_key` had to move from the group onto the alias.** Ingest resolves the registry by `folded_key` and never by `alias_slug`, and a curated group's members do not share a fold — that is what makes it curated. Writing the group's key leaves the retiring spelling folding to a key no row holds: the merge reports success, the redirect works, and the very next crawl of that board mints the duplicate again. For a folded group the two keys are equal by construction, so nothing else changes.

**Naming a canon pulled it out of its folded group**, stranding everything the RULE had grouped with it in a group of one — so curating one duplicate of an employer would silently un-merge its others. A curated group now absorbs the canon's fold whole. `TestPlanMerges_CuratedCanonLeavesItsFoldedGroup` failed on this before the fix.

## Other decisions

The list **outranks the election**, deliberately: Sopra Steria's artefact board carries 1,336 open jobs against the real company's 337, so an election would retire the company into its own artefact.

A curated group of one is still a merge — a canon holding no catalogue row yet is legitimate (the reconcile after the re-key creates it), and judging by member count would drop exactly the entry someone took the trouble to write down.

Invariants — canonical slug is a fixed point of `CompanySlug`, no entry points at a slug that is itself retiring — are enforced by `TestCuratedAliasesAreWellFormed`, not by review.

## Rollout

Dry run first, then `--apply`. Per `docs/agents/company-identity.md`: **no manual reindex, `REINDEX_DEDUP` stays unset** — the scheduled rebuild picks the re-key up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for curated company aliases when automated name matching cannot reliably identify the same employer.
  - Curated aliases now use the designated canonical company and preserve each company name’s own matching key.

- **Bug Fixes**
  - Fixed alias merging so company names continue resolving correctly during future data updates.
  - Prevented curated company groups from being overridden by automatic canonical selection.

- **Documentation**
  - Documented curated company matching and alias-key requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->