### PR TITLE
Stop the removal pass starving behind an indexing pass that never ends

### DIFF
--- a/cmd/search-drain/main.go
+++ b/cmd/search-drain/main.go
@@ -60,18 +60,29 @@ func run() int {
 		LeaseSeconds: dcfg.LeaseSeconds,
 		MaxAttempts:  dcfg.MaxAttempts,
 		CallTimeout:  dcfg.CallTimeout,
+		MaxPerRun:    dcfg.MaxPerRun,
 	}
 
-	stats, err := runner.Run(ctx, opt)
-	if err != nil {
-		log.Printf("search-drain: %v", err)
-		return 1
-	}
-
-	// Removals run after the pushes, in the same pass. Both waves touch the same index and
-	// are paused together by freehire-reindexw, so they belong to one worker rather than two
-	// units that would each need their own copy of that coupling. Indexing goes first so a
-	// fault in the newer path cannot delay the established one.
+	// Removals run BEFORE the pushes, and the order is the whole point. Both waves touch the
+	// same index and are paused together by freehire-reindexw, so they belong to one worker
+	// rather than two units that would each need their own copy of that coupling — but one
+	// worker means one of them goes second, and going second here is not a delay, it is
+	// starvation.
+	//
+	// This used to be the other way round, so "a fault in the newer path cannot delay the
+	// established one". The reasoning inverted in practice: the indexing pass drains until the
+	// queue is EMPTY, and on this fleet the queue need never be empty. Measured on prod
+	// 2026-09-06, after a 5h reindex had paused this unit: arrivals 2504/min against a drain of
+	// 2614/min, so the pass hovered at a 9-11k depth and did not return for over two hours.
+	// Type=oneshot means no second instance starts, so removals had not run once in that window
+	// and 134k closed postings stayed visible in search. Indexing was healthy throughout —
+	// failed=0, dead=0, 200k+ pushed. The established path did not fault; it simply never
+	// finished, which the old ordering had no answer for.
+	//
+	// Removals cannot starve pushes the same way: a wave is ONE index task for the whole batch,
+	// its queue is fed only by closures rather than by every content change, and its own
+	// CallTimeout plus dead-lettering bound a wave that goes wrong. What bounds each pass
+	// against the other is MaxPerRun (see config.SearchDrain).
 	deletions := searchdrain.DeletionRunner{
 		Store:   newDeletionStore(pool),
 		Deleter: facetDeleter{client: client},
@@ -79,6 +90,12 @@ func run() int {
 	del, err := deletions.Run(ctx, opt)
 	if err != nil {
 		log.Printf("search-drain: deletions: %v", err)
+		return 1
+	}
+
+	stats, err := runner.Run(ctx, opt)
+	if err != nil {
+		log.Printf("search-drain: %v", err)
 		return 1
 	}
 

--- a/internal/platform/config/search_drain.go
+++ b/internal/platform/config/search_drain.go
@@ -11,6 +11,18 @@ type SearchDrain struct {
 	LeaseSeconds int           // how long a claim is held before it can be reclaimed
 	MaxAttempts  int           // failed attempts before an entry is dead-lettered
 	CallTimeout  time.Duration // bounds a single batch's index operation
+	// MaxPerRun bounds how much of EITHER queue one run takes; 0 is unbounded and is
+	// the default. It exists because each pass drains until its queue is empty, and on
+	// this fleet a queue need never be empty — see the ordering note in
+	// cmd/search-drain/main.go for the run that measured it. Reordering the passes is
+	// what stopped removals starving; this is the lever for the case where one pass has
+	// to yield the process to the other on a schedule rather than on exhaustion.
+	//
+	// Left unbounded by default deliberately. A cap is not free: the run ends, the
+	// timer waits its interval, and a new process pays startup again, so a cap set below
+	// the arrival rate turns a queue that was draining into one that grows. Set it only
+	// against a measured arrival rate, and measure again after.
+	MaxPerRun int
 }
 
 // LoadSearchDrain reads the worker's tuning from the environment, all optional with
@@ -43,6 +55,7 @@ func LoadSearchDrain() SearchDrain {
 		// caused a real outage. This is a genuine backstop against a truly hung call,
 		// not a normal-operation tripwire — set it generously.
 		CallTimeout: time.Duration(envInt("SEARCH_DRAIN_CALL_TIMEOUT_SECONDS", 600)) * time.Second,
+		MaxPerRun:   envInt("SEARCH_DRAIN_MAX_PER_RUN", 0),
 	}
 	// A non-positive batch size would make the claim's LIMIT 0 (silently no-op) or
 	// feed a negative LIMIT to Postgres; floor it so the worker always makes progress.
@@ -55,6 +68,12 @@ func LoadSearchDrain() SearchDrain {
 	// Floor it to the per-call timeout — the longest one batch can hold the lease.
 	if floor := int(c.CallTimeout.Seconds()); c.LeaseSeconds < floor {
 		c.LeaseSeconds = floor
+	}
+	// A negative cap would read as "unbounded" through outbox's `<= 0` check, which is the
+	// right behaviour but the wrong reason to arrive at it; normalise so the field says what
+	// it means to anything that logs or reports it.
+	if c.MaxPerRun < 0 {
+		c.MaxPerRun = 0
 	}
 	return c
 }

--- a/internal/search/searchdrain/AGENTS.md
+++ b/internal/search/searchdrain/AGENTS.md
@@ -20,8 +20,30 @@ Incremental facet-search indexing via the `search_outbox` queue, mirroring `inte
 ## The removal queue
 
 `search_delete_outbox` is the mirror of `search_outbox`: that one says "index this job", this
-one says "drop this job's document". `cmd/search-drain` drains both in one pass — indexing
-first, then removals.
+one says "drop this job's document". `cmd/search-drain` drains both in one pass — **removals
+first, then indexing**, and that order is load-bearing rather than incidental.
+
+It used to be the other way round, so that "a fault in the newer path cannot delay the
+established one". The reasoning inverted in practice, because each pass drains **until its
+queue is empty** and on this fleet the index queue need never be empty. Measured on prod
+2026-09-06, after a 5h `reindex` had paused this unit and left both queues five hours deep:
+arrivals into `search_outbox` ran at 2504/min against a drain of 2614/min, so the indexing
+pass hovered at a 9-11k depth and did not return for over two hours. `Type=oneshot` means no
+second instance starts, so removals had not run once in that window and **134k closed
+postings stayed visible in search**. Indexing was healthy throughout — `failed=0`, `dead=0`,
+200k+ pushed. Going second was not a delay, it was starvation, and nothing in the old
+ordering could end it.
+
+Removals cannot starve pushes symmetrically: a wave is ONE index task for the whole batch,
+the queue is fed only by closures rather than by every content change, and a wave that goes
+wrong is bounded by the same `CallTimeout` and dead-lettering as an index wave.
+
+**`SEARCH_DRAIN_MAX_PER_RUN` bounds how much of EITHER queue one run takes; 0 (the default)
+is unbounded.** It is the lever for handing the process back on a schedule rather than on
+exhaustion, and it is deliberately off by default: a cap is not free — the run ends, the
+timer waits its interval, and a new process pays startup again, so a cap set below the
+arrival rate turns a queue that was draining into one that grows. Set it against a measured
+arrival rate, and measure again after.
 
 It exists because nothing removed documents incrementally. `ClaimSearchOutboxBatch` filters
 `closed_at IS NULL`, so a job that closes is never claimed again and its document simply

--- a/internal/search/searchdrain/deletion.go
+++ b/internal/search/searchdrain/deletion.go
@@ -56,6 +56,7 @@ func (r DeletionRunner) Run(ctx context.Context, opt RunOptions) (DeletionStats,
 	_, err := outbox.RunBatch(ctx, claimFunc(r.Store.Claim), outbox.RunOptions{
 		BatchSize:    opt.BatchSize,
 		LeaseSeconds: opt.LeaseSeconds,
+		MaxPerRun:    opt.MaxPerRun,
 		OnWave: func(outbox.Stats) {
 			log.Printf("search-drain: progress deleted=%d failed=%d dead=%d",
 				rn.stats.Deleted, rn.stats.Failed, rn.stats.DeadLettered)

--- a/internal/search/searchdrain/deletion_test.go
+++ b/internal/search/searchdrain/deletion_test.go
@@ -222,3 +222,24 @@ func TestDeletionRunnerSkipsTheWaveWhenTheRunIsCancelled(t *testing.T) {
 		t.Errorf("completed %d entries, want 0 — the lease must retry them", len(store.completed))
 	}
 }
+
+// The removal pass honours the same bound as the indexing one, so a bounded run splits its
+// budget between the two rather than letting whichever goes first spend the whole process.
+func TestDeletionRunnerStopsAtMaxPerRun(t *testing.T) {
+	store := newFakeDeleteStore(10, 11, 12, 13, 14)
+	deleter := &fakeDeleter{}
+
+	opts := deleteOptions()
+	opts.BatchSize = 2
+	opts.MaxPerRun = 4
+	stats, err := DeletionRunner{Store: store, Deleter: deleter}.Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Deleted != 4 {
+		t.Fatalf("Deleted = %d, want 4 — the run took the whole queue", stats.Deleted)
+	}
+	if len(store.completed) != 4 {
+		t.Errorf("completed = %d, want 4", len(store.completed))
+	}
+}

--- a/internal/search/searchdrain/runner.go
+++ b/internal/search/searchdrain/runner.go
@@ -86,6 +86,11 @@ type RunOptions struct {
 	// CallTimeout bounds a single batch's (or fallback item's) index operation; 0
 	// means no per-call timeout.
 	CallTimeout time.Duration
+	// MaxPerRun bounds how many entries one Run takes; 0 is unbounded. Both this
+	// runner and DeletionRunner honour it, and cmd/search-drain passes the same value
+	// to each, so a bounded run splits its budget between the two passes rather than
+	// letting whichever goes first spend the whole process. See config.SearchDrain.
+	MaxPerRun int
 }
 
 // Stats reports what a run did.
@@ -130,6 +135,7 @@ func (r Runner) Run(ctx context.Context, opt RunOptions) (Stats, error) {
 	_, err := outbox.RunBatch(ctx, r.Store, outbox.RunOptions{
 		BatchSize:    opt.BatchSize,
 		LeaseSeconds: opt.LeaseSeconds,
+		MaxPerRun:    opt.MaxPerRun,
 		OnWave: func(outbox.Stats) {
 			// A heartbeat per wave so a long drain shows running totals instead of
 			// going silent for hours.

--- a/internal/search/searchdrain/runner_test.go
+++ b/internal/search/searchdrain/runner_test.go
@@ -553,3 +553,52 @@ func TestRunnerDoesNotChargeAnAttemptWhenTheFallbackMeetsTheSameUnbuildableWave(
 		t.Fatalf("stats = %+v, want all zero — every entry is left claimed for its lease to expire", stats)
 	}
 }
+
+// MaxPerRun bounds one run so the process is handed back rather than held until the queue
+// happens to be empty. Prod 2026-09-06: with no bound the indexing pass ran for over two
+// hours against a queue arrivals kept refilling, and the removal pass sharing the process
+// never got a turn. The leftovers must stay claimable, not be dropped.
+func TestRunnerStopsAtMaxPerRunAndLeavesTheRestQueued(t *testing.T) {
+	store := newFakeStore()
+	ix := newFakeIndexer()
+	for id := int64(1); id <= 6; id++ {
+		store.jobs[id] = db.Job{ID: id}
+		store.pending = append(store.pending, Claimed{OutboxID: id * 10, JobID: id})
+	}
+
+	opts := opt()
+	opts.BatchSize = 2
+	opts.MaxPerRun = 4
+	stats, err := Runner{Store: store, Indexer: ix}.Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Indexed != 4 {
+		t.Fatalf("stats = %+v, want indexed=4 — the run took the whole queue", stats)
+	}
+	if len(store.pending) != 2 {
+		t.Errorf("pending = %d, want 2 still claimable for the next run", len(store.pending))
+	}
+}
+
+// The default has to stay unbounded: a cap set below the arrival rate turns a queue that was
+// draining into one that grows, so it is opt-in and zero must not read as "take nothing".
+func TestRunnerZeroMaxPerRunDrainsEverything(t *testing.T) {
+	store := newFakeStore()
+	ix := newFakeIndexer()
+	for id := int64(1); id <= 5; id++ {
+		store.jobs[id] = db.Job{ID: id}
+		store.pending = append(store.pending, Claimed{OutboxID: id * 10, JobID: id})
+	}
+
+	opts := opt()
+	opts.BatchSize = 2
+	opts.MaxPerRun = 0
+	stats, err := Runner{Store: store, Indexer: ix}.Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Indexed != 5 || len(store.pending) != 0 {
+		t.Errorf("stats = %+v, pending = %d, want the whole queue drained", stats, len(store.pending))
+	}
+}


### PR DESCRIPTION
## The bug

`cmd/search-drain` runs two passes in one process. Each drains **until its queue is empty**, and removals went second, on the reasoning that "a fault in the newer path cannot delay the established one".

That reasoning inverted in practice. On this fleet the index queue need never be empty, so going second was not a delay — it was starvation, and nothing in that ordering could end it.

## Measured on prod, 2026-09-06

A 5h `reindex` had paused this unit (`freehire-reindexw` stops the drain's timer for its whole run), leaving both queues five hours deep. When the drain resumed:

| | |
|---|---|
| arrivals into `search_outbox` | **2504/min** |
| drain rate | **2614/min** |
| net | −110/min, and bursts pushed it back up |

The indexing pass hovered at a 9–11k depth and **did not return for over two hours**. `Type=oneshot` means no second instance starts, so **removals had not run once in that window and 134k closed postings stayed visible in search**.

Indexing was healthy throughout — `failed=0`, `dead=0`, 200k+ pushed, no lease-expiry retries. The established path did not fault. It simply never finished, which is the case the old ordering had no answer for.

## The fix

**Removals run first.** They cannot starve pushes symmetrically:

- a wave is ONE index task for the whole batch,
- the queue is fed only by closures rather than by every content change,
- a wave that goes wrong is bounded by the same `CallTimeout` and dead-lettering as an index wave.

## The knob, and why it is not the fix

Also adds `SEARCH_DRAIN_MAX_PER_RUN`, wired through both passes. The mechanism already existed — `outbox.RunOptions.MaxPerRun`, *"bounds how much of the backlog one Run takes; 0 is unbounded"* — and this worker was simply the caller that never set it.

**It ships unbounded, i.e. today's behaviour, on purpose.** A cap is not free: the run ends, the timer waits its interval, and a new process pays startup again. A cap set below the arrival rate turns a queue that was draining into one that grows — at the arrivals measured above, a naive 20k cap works out to ~909/min against 2504/min incoming, which would have made things worse, not better.

So: reordering is what fixes the starvation. The knob is a lever for tuning against a **measured** arrival rate, not a second guess at one. It is env-tunable so a value can be tried on the host without a deploy, like every other knob on this worker.

## Tests

- `TestRunnerStopsAtMaxPerRunAndLeavesTheRestQueued` — the bound holds and the leftovers stay **claimable**, not dropped.
- `TestRunnerZeroMaxPerRunDrainsEverything` — zero must not read as "take nothing"; a default that quietly drained nothing would be the worse failure.
- `TestDeletionRunnerStopsAtMaxPerRun` — the removal pass honours the same bound, so a bounded run splits its budget between the passes instead of letting whichever goes first spend the process.

All three verified to fail with the wiring removed.

**Not tested:** the ordering itself. It is a statement swap in `run()`, which builds both runners from a pool and has no seam to inject them through. Left untested rather than restructured for it — flagging it rather than claiming coverage I did not add.

## Checks

`gofmt` clean, `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, full `go test ./...`, `pnpm check:links` (307 resolve), `golangci-lint` 0 issues. Pre-commit hooks passed including govulncheck and gitleaks.

## Note for after merge

The current prod run has been going since 20:22 UTC and still holds the process. It has to end (or be restarted) before the new ordering takes effect, and the 134k removal backlog then drains on the next run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional per-run limit for search indexing and deletion processing through `SEARCH_DRAIN_MAX_PER_RUN`.
  - A value of `0` keeps processing unlimited by default.

- **Bug Fixes**
  - Search deletions are now processed before indexing, helping prevent closed or removed content from remaining searchable.
  - Processing can continue across multiple runs when the configured limit is reached, rather than consuming the entire queue at once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->