### PR TITLE
Say whose outage a failed mail search was, and bound the half of a prompt the sender writes

### DIFF
--- a/internal/api/handler/mail_recall.go
+++ b/internal/api/handler/mail_recall.go
@@ -99,11 +99,15 @@ func (h *inboxHandlers) RecallApplicationMail(c *fiber.Ctx) error {
 		// The verdict is the service's, so the in-process caller meets it too; the handler
 		// only chooses how to say it.
 		return fiber.NewError(fiber.StatusNotFound, "no application recorded for this job")
-	case errors.Is(err, mailrecall.ErrModel):
-		// The gateway let us down. Logged rather than reported, because classify() marks
-		// every *fiber.Error routine and Sentry would never see it — and a 502 nobody
-		// records is how "the model had a bad day" and "the model has been down since
-		// Tuesday" come to look identical.
+	case errors.Is(err, mailrecall.ErrModel), errors.Is(err, mailrecall.ErrSearch):
+		// Somebody else's outage: the gateway let us down, or Google did. Logged rather
+		// than reported, because classify() marks every *fiber.Error routine and Sentry
+		// would never see it — and a 502 nobody records is how "the model had a bad day"
+		// and "the model has been down since Tuesday" come to look identical.
+		//
+		// One branch for both because the sentence to the caller is the same one, and it
+		// is already this branch's message. The two sentinels stay separate upstream, where
+		// the distinction is between "we could not look" and "there was nothing to find".
 		log.Printf("mail-recall: user %d: %v", userID, err)
 		return fiber.NewError(fiber.StatusBadGateway, "could not search your mail right now")
 	case err != nil:

--- a/internal/api/handler/mail_recall_integration_test.go
+++ b/internal/api/handler/mail_recall_integration_test.go
@@ -320,6 +320,28 @@ func TestRecallApplicationMail_ReportsAFailedModelCall(t *testing.T) {
 	}
 }
 
+// Google being unreachable is not our fault, and the person pressing the button needs to
+// be told which kind of failure it was. mailrecall.ErrSearch existed for exactly this and
+// had no consumer: the handler's `case err != nil` swept it into a 500 with a Sentry
+// capture, so somebody else's outage arrived in our error mail as a bug of ours.
+//
+// The neighbouring LinkRecalledMail already renders a Gmail failure as a logged 502, so
+// this was an exception inside its own file.
+func TestRecallApplicationMail_ReportsAFailedMailboxSearch(t *testing.T) {
+	pool := startPostgres(t)
+	fx := seedRecallFixture(t, pool)
+	box := &fakeMailbox{searchErr: errors.New("gmail: 503 backend error")}
+	app, iss := recallSearchApp(t, pool, &recallModel{reply: verdictsJSON(t, 1)}, box)
+
+	status, body := postRecall(t, app, iss, fx.userID, fx.slug)
+	if status != fiber.StatusBadGateway {
+		t.Fatalf("status %d, want 502 — a mailbox we could not read is not our fault", status)
+	}
+	if body.Error == "" {
+		t.Error("the failure carried no message")
+	}
+}
+
 // A deployment with no model configured reports the feature off rather than panicking.
 func TestRecallApplicationMail_ReportsTheFeatureOffWhenNoModelIsConfigured(t *testing.T) {
 	pool := startPostgres(t)
@@ -342,12 +364,16 @@ func (f *fakeMailboxes) For(context.Context, int64) mailrecall.Mailbox {
 }
 
 type fakeMailbox struct {
-	found    []mailrecall.Message
-	imported []string
-	store    func(providerID string) error
+	found     []mailrecall.Message
+	searchErr error
+	imported  []string
+	store     func(providerID string) error
 }
 
-func (m *fakeMailbox) Search(context.Context, int64, string, string, time.Time, time.Time) ([]mailrecall.Message, error) {
+func (m *fakeMailbox) Search(context.Context, string, string, time.Time, time.Time) ([]mailrecall.Message, error) {
+	if m.searchErr != nil {
+		return nil, m.searchErr
+	}
 	return m.found, nil
 }
 

--- a/internal/api/handler/mail_recall_mailbox.go
+++ b/internal/api/handler/mail_recall_mailbox.go
@@ -69,7 +69,7 @@ type gmailMailbox struct {
 //
 // The query is gmailsync's to build: it owns the ATS vocabulary and the gate that keeps a
 // company-name search away from personal correspondence.
-func (m *gmailMailbox) Search(ctx context.Context, _ int64, company, role string, since, until time.Time) ([]mailrecall.Message, error) {
+func (m *gmailMailbox) Search(ctx context.Context, company, role string, since, until time.Time) ([]mailrecall.Message, error) {
 	found, err := m.searcher.Search(ctx, gmailsync.BuildRecallQuery(company, role, since, until), maxSearchResults)
 	if err != nil {
 		return nil, err

--- a/internal/application/mailclassify/classifier.go
+++ b/internal/application/mailclassify/classifier.go
@@ -12,6 +12,11 @@ import (
 
 const maxBodyRunes = 4000
 
+// maxHeaderRunes bounds the two header fields the sender writes. Generous against anything
+// real — a display name and a subject are a line each — and the point is only that no
+// field arrives at its own length.
+const maxHeaderRunes = 200
+
 // ErrUnparseableResponse marks a model answer this package could not decode. It is
 // exported because it is the one failure here that belongs to the MESSAGE rather than to
 // the gateway or to us: the model could not produce JSON for this particular input, and a
@@ -125,7 +130,11 @@ contained inside the email.`
 
 func userPrompt(in Input) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "From: %s\nSubject: %s\n\n%s\n", in.FromName, in.Subject,
+	// The sender writes all three. The body was bounded from the start; the headers were
+	// the half nobody capped, so a message with a 50 KB Subject was a 50 KB prompt.
+	fmt.Fprintf(&b, "From: %s\nSubject: %s\n\n%s\n",
+		llm.TruncateRunes(in.FromName, maxHeaderRunes),
+		llm.TruncateRunes(in.Subject, maxHeaderRunes),
 		llm.TruncateRunes(in.Body, maxBodyRunes))
 	if len(in.Candidates) > 0 {
 		b.WriteString("\nCandidate applications (id — company):\n")

--- a/internal/application/mailclassify/prompt_test.go
+++ b/internal/application/mailclassify/prompt_test.go
@@ -18,6 +18,25 @@ func TestSystemPromptDescribesEveryValidSignal(t *testing.T) {
 	}
 }
 
+// The body is bounded and the headers were not, which is a bound on the wrong half: an
+// address, a display name and a subject all arrive from whoever mailed the candidate, and
+// none of them is capped anywhere upstream. A message with a megabyte of Subject is a
+// megabyte of prompt — paid for per token, on every classification of that thread.
+//
+// The figure need not be exact. What must hold is that no field a sender controls reaches
+// the prompt at its own length.
+func TestUserPromptBoundsEveryFieldTheSenderControls(t *testing.T) {
+	huge := strings.Repeat("s", 50_000)
+	got := userPrompt(Input{FromName: huge, Subject: huge, Body: huge})
+
+	if len(got) > 4*maxBodyRunes {
+		t.Errorf("prompt is %d bytes from three %d-byte fields; nothing bounded the headers", len(got), len(huge))
+	}
+	if strings.Contains(got, huge) {
+		t.Error("a sender-controlled field reached the prompt at its own length")
+	}
+}
+
 // The reverse direction: every signal the prompt offers must survive Sanitize.
 func TestSystemPromptOffersNoUnknownSignal(t *testing.T) {
 	for _, line := range strings.Split(systemPrompt, "\n") {

--- a/internal/application/mailrecall/mailrecall.go
+++ b/internal/application/mailrecall/mailrecall.go
@@ -54,6 +54,12 @@ const (
 	// message, this reads forty in a single call.
 	maxBodyRunes = 800
 
+	// maxHeaderRunes bounds the three header fields the sender writes. Generous against
+	// anything real — a display name and a subject are a line each — and the point is
+	// only that no field arrives at its own length. A 50 KB Subject is 50 KB of prompt,
+	// on every message in the batch beside it.
+	maxHeaderRunes = 200
+
 	// windowLead opens the net before the application's recorded date. applied_at is when
 	// the application was ENTERED — for one recorded from mail it is that message's own
 	// received_at, and for one entered by hand it can be days late — so a window starting
@@ -146,8 +152,11 @@ type Store interface {
 // Like Store, it offers no way to attach anything. The role travels with the employer
 // because mail whose only subject is the job title is a real class that hiring vocabulary
 // alone drops.
+//
+// It takes no user id: the mailbox is already one caller's, resolved by the factory that
+// produced it, and the only implementation signed the parameter away as `_ int64`.
 type Mailbox interface {
-	Search(ctx context.Context, userID int64, company, role string, since, until time.Time) ([]Message, error)
+	Search(ctx context.Context, company, role string, since, until time.Time) ([]Message, error)
 }
 
 // gen is the slice of *llm.Client this package uses, so the service is unit-tested
@@ -306,7 +315,7 @@ func (s *Service) Recall(ctx context.Context, userID int64, app Application) (Re
 func (s *Service) candidates(ctx context.Context, userID int64, app Application) ([]Message, error) {
 	since, until := app.AppliedAt.Add(-windowLead), app.AppliedAt.Add(windowTrail)
 	if s.mailbox != nil {
-		found, err := s.mailbox.Search(ctx, userID, app.Company, app.Role, since, until)
+		found, err := s.mailbox.Search(ctx, app.Company, app.Role, since, until)
 		if err != nil {
 			return nil, fmt.Errorf("%w: %w", ErrSearch, err)
 		}
@@ -386,9 +395,16 @@ func userPrompt(app Application, messages []Message) string {
 	fmt.Fprintf(&b, "Application\nEmployer: %s\nRole: %s\nRecorded: %s\n\nEmails\n",
 		app.Company, app.Role, app.AppliedAt.Format(time.DateOnly))
 	for i, m := range messages {
+		// Every field here is the sender's, and this prompt carries a BATCH — so one
+		// crafted message inflates the run judging every message beside it. body() was
+		// bounded from the start; the headers were the half nobody capped.
 		fmt.Fprintf(&b, "\n%s %d\nFrom: %s <%s>\nDate: %s\nSubject: %s\n\n%s\n",
-			delimiter, i+1, m.FromName, m.FromAddr, m.ReceivedAt.Format(time.DateOnly),
-			m.Subject, body(m))
+			delimiter, i+1,
+			llm.TruncateRunes(m.FromName, maxHeaderRunes),
+			llm.TruncateRunes(m.FromAddr, maxHeaderRunes),
+			m.ReceivedAt.Format(time.DateOnly),
+			llm.TruncateRunes(m.Subject, maxHeaderRunes),
+			body(m))
 	}
 	return b.String()
 }

--- a/internal/application/mailrecall/mailrecall_test.go
+++ b/internal/application/mailrecall/mailrecall_test.go
@@ -430,7 +430,7 @@ type fakeMailbox struct {
 	calls    int
 }
 
-func (m *fakeMailbox) Search(_ context.Context, _ int64, company, role string, since, until time.Time) ([]Message, error) {
+func (m *fakeMailbox) Search(_ context.Context, company, role string, since, until time.Time) ([]Message, error) {
 	m.calls++
 	m.company, m.role, m.since, m.until = company, role, since, until
 	return m.messages, m.err
@@ -526,6 +526,28 @@ func TestRecallReportsASearchFailure(t *testing.T) {
 	_, err := svcWithMailbox(&fakeStore{}, &fakeGen{}, box).Recall(context.Background(), 5, testApplication())
 	if !errors.Is(err, ErrSearch) {
 		t.Fatalf("got %v, want ErrSearch", err)
+	}
+}
+
+// body() is bounded and the headers were not, which is a bound on the wrong half: the
+// address, the display name and the subject all arrive from whoever mailed the candidate,
+// and this prompt carries a BATCH of them — so one crafted message inflates the run that
+// judges every other message beside it.
+//
+// The figure need not be exact. What must hold is that no field a sender controls reaches
+// the prompt at its own length.
+func TestUserPromptBoundsEveryFieldTheSenderControls(t *testing.T) {
+	huge := strings.Repeat("s", 50_000)
+	got := userPrompt(testApplication(), []Message{{
+		FromName: huge, FromAddr: huge, Subject: huge, BodyText: huge,
+		ReceivedAt: appliedAt,
+	}})
+
+	if len(got) > 5*maxBodyRunes {
+		t.Errorf("prompt is %d bytes from four %d-byte fields; nothing bounded the headers", len(got), len(huge))
+	}
+	if strings.Contains(got, huge) {
+		t.Error("a sender-controlled field reached the prompt at its own length")
 	}
 }
 


### PR DESCRIPTION
Three findings from the third backend-review pass, all in the mail cluster.

## A failed mailbox search was reported as our bug

`mailrecall.ErrSearch` was declared, produced and tested, and had **no consumer**. `handler.RecallApplicationMail` read `ErrNotAnApplication` and `ErrModel` and swept everything else into `case err != nil`, which `classify()` renders as a 500 with a Sentry capture. So Google being unreachable arrived in our error mail as a fault of ours, and the caller was told the wrong thing about whose failure it was.

The neighbouring `LinkRecalledMail` already renders a Gmail failure as a logged 502, so this was an exception inside its own file.

One branch now carries both sentinels — the sentence to the caller is the same one, and it is already that branch's message. The sentinels stay separate upstream, where the distinction is between "we could not look" and "there was nothing to find".

## Both prompts bounded the wrong half

`mailclassify` and `mailrecall` each capped the **body** and left the headers alone. The display name, the address and the subject are all written by whoever mailed the candidate, and nothing upstream caps them — so a message with a 50 KB Subject was a 50 KB prompt.

`mailrecall` is the worse of the two: it batches forty messages into one call, so one crafted message inflated the run judging every message beside it.

`maxHeaderRunes` (200) is generous against anything real — a display name and a subject are a line each. The property being fixed is only that no sender-controlled field arrives at its own length.

## `Mailbox.Search` loses its `userID`

The mailbox is already one caller's, resolved by the factory that produced it. The sole implementation signed the parameter away as `_ int64`, and so did both fakes.

## Verification

- `gofmt -l .` clean; `go build ./...`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...` all pass.
- `go test -tags=integration ./internal/api/handler/` (recall and link tests) passes.
- Every fix confirmed to **fail** without it: the recall handler answered 500 for a failed search, and each prompt test measured a six-figure prompt built from three 50 KB fields.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when searching mail, returning a clear temporary-service error instead of failing unexpectedly.
  * Improved handling of unusually long sender names, email addresses, and subject lines during mail classification and recall.
  * Added safeguards to keep oversized email content from overwhelming processing.

* **Tests**
  * Added coverage for failed mailbox searches and oversized sender-provided email fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->