### PR TITLE
Stop telling a candidate they lack a certification their résumé lists, and name it in words they can read

### DIFF
--- a/internal/candidate/hardconstraint/credentials/credentials.go
+++ b/internal/candidate/hardconstraint/credentials/credentials.go
@@ -1,65 +1,109 @@
 // Package credentials is the shared curated vocabulary that maps free-text
 // certification/license names to canonical slugs. It is a leaf package with no
-// freehire dependencies so the enrichment extractor, the résumé extractor, and
-// the hard-constraint evaluator can all normalize to comparable slugs without an
-// import cycle. Dict-only discipline: an unrecognized credential resolves to
-// nothing (never guessed).
+// freehire dependencies, so callers on either side of a comparison normalize to
+// comparable slugs without an import cycle. Dict-only discipline: an unrecognized
+// credential resolves to nothing (never guessed).
 //
 // The set is IT-first (cloud, Kubernetes, security, PM) plus a few genuinely
 // global professional licenses; it is deliberately small and curated, not a
 // dump of every credential in existence.
+//
+// It has two consumers, and they read two different kinds of text — which is why there
+// are two scanners rather than one:
+//
+//   - internal/job/jobfacts calls Scan on a job DESCRIPTION. That is prose, so a bare
+//     two- or three-letter acronym is a word the text may be using for something else
+//     entirely, and the ambiguous ones are suppressed.
+//   - internal/candidate/hardconstraint calls ScanLine on ONE line of a résumé's
+//     certification list. That is a deliberate field where a bare acronym IS the
+//     credential, so nothing is suppressed.
+//
+// The asymmetry is deliberate and it runs the safe way. On the job side a spurious hit
+// becomes a FALSE requirement, which caps a candidate's score and is stated to the model
+// as established fact; on the résumé side a missed hit becomes a false blocker and a
+// spurious one merely fails to block.
 package credentials
 
 import "strings"
 
-// entry pairs a canonical slug with the normalized aliases that resolve to it.
+// entry pairs a canonical slug with the normalized aliases that resolve to it, plus the
+// label a person reads.
+//
 // Aliases are already in normalized form (see normalize): lowercase, apostrophes
 // dropped, and every other non-alphanumeric run collapsed to a single space, with
 // '+' preserved so "security+" stays distinct.
+//
+// label exists because slug is an identifier and Reason/Action are sentences. They are
+// rendered verbatim on the job page and go verbatim into all three stages of the analysis
+// prompt, so without this a candidate read "Requires the
+// gcp-professional-cloud-architect certification." The label cannot be recovered from an
+// alias — aliases are folded to lower case. internal/dict/skilltag/labels.go is the same
+// shape for the same reason.
+//
+// proseAmbiguous marks a credential whose BARE acronym is also an ordinary word or a
+// different initialism, so Scan requires a multi-word alias for it. The suppression is on
+// the acronym, never on the credential: a posting that spells the certification out is
+// still read.
 type entry struct {
-	slug    string
-	aliases []string
+	slug           string
+	label          string
+	aliases        []string
+	proseAmbiguous bool
 }
 
+// The three proseAmbiguous entries were each measured against a real posting: "A+
+// players", "Salesforce CSM and CRM tooling", and "our CPA firm". All three collide with an
+// ordinary phrase, and none is pinned by an existing test.
+//
+// A fourth measured collision is NOT marked: "CISA guidelines" names the US agency, which
+// security postings mention constantly — but "CISSP, CISA and CISM required" is a real
+// requirement pinned in internal/job/jobfacts, and a bare-acronym rule cannot tell the two
+// apart. Separating them needs a vocabulary of credential words near the acronym, which is
+// its own decision with its own false readings; until then CISA is knowingly left reading
+// from prose, and jobfacts already narrows the text to the requirements section.
 var table = []entry{
 	// Cloud.
-	{"aws-solutions-architect", []string{"aws certified solutions architect", "aws solutions architect", "aws sa", "saa c03"}},
-	{"aws-developer", []string{"aws certified developer", "aws developer associate", "dva c02"}},
-	{"aws-sysops", []string{"aws certified sysops administrator", "aws sysops"}},
-	{"gcp-associate-cloud-engineer", []string{"google associate cloud engineer", "gcp associate cloud engineer", "associate cloud engineer"}},
-	{"gcp-professional-cloud-architect", []string{"google professional cloud architect", "gcp professional cloud architect", "professional cloud architect"}},
-	{"azure-administrator", []string{"microsoft azure administrator", "azure administrator associate", "az 104"}},
-	{"azure-solutions-architect", []string{"azure solutions architect expert", "az 305"}},
+	{slug: "aws-solutions-architect", label: "AWS Certified Solutions Architect", aliases: []string{"aws certified solutions architect", "aws solutions architect", "aws sa", "saa c03"}},
+	{slug: "aws-developer", label: "AWS Certified Developer", aliases: []string{"aws certified developer", "aws developer associate", "dva c02"}},
+	{slug: "aws-sysops", label: "AWS Certified SysOps Administrator", aliases: []string{"aws certified sysops administrator", "aws sysops"}},
+	{slug: "gcp-associate-cloud-engineer", label: "Google Associate Cloud Engineer", aliases: []string{"google associate cloud engineer", "gcp associate cloud engineer", "associate cloud engineer"}},
+	{slug: "gcp-professional-cloud-architect", label: "Google Professional Cloud Architect", aliases: []string{"google professional cloud architect", "gcp professional cloud architect", "professional cloud architect"}},
+	{slug: "azure-administrator", label: "Microsoft Azure Administrator", aliases: []string{"microsoft azure administrator", "azure administrator associate", "az 104"}},
+	{slug: "azure-solutions-architect", label: "Azure Solutions Architect Expert", aliases: []string{"azure solutions architect expert", "az 305"}},
 	// Kubernetes / IaC.
-	{"cka", []string{"certified kubernetes administrator", "cka"}},
-	{"ckad", []string{"certified kubernetes application developer", "ckad"}},
-	{"terraform-associate", []string{"hashicorp certified terraform associate", "terraform associate"}},
+	{slug: "cka", label: "Certified Kubernetes Administrator (CKA)", aliases: []string{"certified kubernetes administrator", "cka"}},
+	{slug: "ckad", label: "Certified Kubernetes Application Developer (CKAD)", aliases: []string{"certified kubernetes application developer", "ckad"}},
+	{slug: "terraform-associate", label: "HashiCorp Certified: Terraform Associate", aliases: []string{"hashicorp certified terraform associate", "terraform associate"}},
 	// Security.
-	{"comptia-security-plus", []string{"comptia security+", "security+", "sec+"}},
-	{"comptia-network-plus", []string{"comptia network+", "network+"}},
-	{"comptia-a-plus", []string{"comptia a+", "a+"}},
-	{"cissp", []string{"certified information systems security professional", "cissp"}},
-	{"cisa", []string{"certified information systems auditor", "cisa"}},
-	{"cism", []string{"certified information security manager", "cism"}},
-	{"ceh", []string{"certified ethical hacker", "ceh"}},
-	{"oscp", []string{"offensive security certified professional", "oscp"}},
+	{slug: "comptia-security-plus", label: "CompTIA Security+", aliases: []string{"comptia security+", "security+", "sec+"}},
+	{slug: "comptia-network-plus", label: "CompTIA Network+", aliases: []string{"comptia network+", "network+"}},
+	// "A+ players" is the phrase this one kept reading as a certification.
+	{slug: "comptia-a-plus", label: "CompTIA A+", aliases: []string{"comptia a+", "a+"}, proseAmbiguous: true},
+	{slug: "cissp", label: "CISSP", aliases: []string{"certified information systems security professional", "cissp"}},
+	// CISA is also the US agency, named in most security postings.
+	{slug: "cisa", label: "CISA (Certified Information Systems Auditor)", aliases: []string{"certified information systems auditor", "cisa"}},
+	{slug: "cism", label: "CISM (Certified Information Security Manager)", aliases: []string{"certified information security manager", "cism"}},
+	{slug: "ceh", label: "Certified Ethical Hacker (CEH)", aliases: []string{"certified ethical hacker", "ceh"}},
+	{slug: "oscp", label: "OSCP (Offensive Security Certified Professional)", aliases: []string{"offensive security certified professional", "oscp"}},
 	// Delivery / process.
-	{"pmp", []string{"project management professional", "pmp"}},
-	{"csm", []string{"certified scrummaster", "certified scrum master", "csm"}},
-	{"itil", []string{"itil foundation", "itil"}},
+	{slug: "pmp", label: "PMP (Project Management Professional)", aliases: []string{"project management professional", "pmp"}},
+	// CSM is also Customer Success Manager, a role these postings hire for.
+	{slug: "csm", label: "Certified ScrumMaster (CSM)", aliases: []string{"certified scrummaster", "certified scrum master", "csm"}, proseAmbiguous: true},
+	{slug: "itil", label: "ITIL Foundation", aliases: []string{"itil foundation", "itil"}},
 	// Finance.
-	{"cpa", []string{"certified public accountant", "cpa"}},
-	{"cfa", []string{"chartered financial analyst", "cfa"}},
+	// CPA is also cost-per-acquisition, and "our CPA firm" is not a requirement.
+	{slug: "cpa", label: "CPA (Certified Public Accountant)", aliases: []string{"certified public accountant", "cpa"}, proseAmbiguous: true},
+	{slug: "cfa", label: "CFA (Chartered Financial Analyst)", aliases: []string{"chartered financial analyst", "cfa"}},
 	// Global professional licenses (non-IT but common in postings).
-	{"pe-license", []string{"professional engineer license", "pe license"}},
-	{"cdl", []string{"commercial drivers license", "cdl"}},
+	{slug: "pe-license", label: "Professional Engineer (PE) license", aliases: []string{"professional engineer license", "pe license"}},
+	{slug: "cdl", label: "commercial driver's license (CDL)", aliases: []string{"commercial drivers license", "cdl"}},
 }
 
-// aliasIndex maps every normalized alias to its canonical slug. slugSet is the
-// controlled set for IsCanonical. Both are built once from table.
+// aliasIndex maps every normalized alias to its canonical slug; labels maps every slug to
+// the sentence-ready name. Both are built once from table.
 var (
 	aliasIndex = buildAliasIndex()
-	slugSet    = buildSlugSet()
+	labels     = buildLabels()
 )
 
 func buildAliasIndex() map[string]string {
@@ -72,10 +116,10 @@ func buildAliasIndex() map[string]string {
 	return m
 }
 
-func buildSlugSet() map[string]bool {
-	m := make(map[string]bool, len(table))
+func buildLabels() map[string]string {
+	m := make(map[string]string, len(table))
 	for _, e := range table {
-		m[e.slug] = true
+		m[e.slug] = e.label
 	}
 	return m
 }
@@ -88,18 +132,41 @@ func Canonical(raw string) (string, bool) {
 	return slug, ok
 }
 
-// IsCanonical reports whether slug is a member of the controlled set. Used by the
-// enrichment/résumé sanitize gates to drop out-of-vocabulary slugs.
-func IsCanonical(slug string) bool {
-	return slugSet[slug]
+// Label returns the sentence-ready name for a canonical slug, or the slug itself for one
+// this table does not carry. A caller interpolating an unknown slug gets a poor sentence
+// rather than a broken one.
+func Label(slug string) string {
+	if l, ok := labels[slug]; ok {
+		return l
+	}
+	return slug
 }
 
-// Scan returns the canonical slugs whose aliases appear as whole words in text,
-// in table order and deduped. It normalizes text once and matches on
-// space-delimited word boundaries (the leaf package does its own boundary check to
-// avoid a dependency), so "PMP" in prose resolves but "pmp" inside another token
-// does not. Used to derive a job's required certifications from its description.
-func Scan(text string) []string {
+// Scan returns the canonical slugs a job DESCRIPTION requires, in table order and deduped.
+//
+// It is the strict half: a proseAmbiguous credential is only read from a multi-word alias,
+// because its bare acronym is a word the description may be using for something else. See
+// the package comment for why the two directions differ.
+func Scan(text string) []string { return scan(text, false) }
+
+// ScanLine returns the canonical slugs named in ONE line of a résumé's certification list.
+//
+// It is the permissive half: the line is a deliberate field, so a bare acronym is the
+// credential and nothing is suppressed. It exists because Canonical matches the WHOLE
+// string and a résumé entry almost never is one — "CompTIA Security+ (2022)", "Certified
+// Kubernetes Administrator (CKA)" and "AWS Certified Solutions Architect – Associate" all
+// returned ("", false), which credited the candidate with none of the three and produced a
+// certification blocker for one they hold. degreeMatch already solved this next door.
+func ScanLine(text string) []string { return scan(text, true) }
+
+// scan matches aliases as whole words. It normalizes text once and matches on
+// space-delimited word boundaries (the leaf package does its own boundary check to avoid a
+// dependency), so "PMP" resolves but "pmp" inside another token does not.
+//
+// bareAcronyms admits the single-word aliases of a proseAmbiguous entry. A multi-word
+// alias is never ambiguous — nobody writes "certified information systems auditor" by
+// accident — so the distinction needs no second list to drift from the first.
+func scan(text string, bareAcronyms bool) []string {
 	norm := normalize(text)
 	if norm == "" {
 		return nil
@@ -108,6 +175,9 @@ func Scan(text string) []string {
 	var out []string
 	for _, e := range table {
 		for _, a := range e.aliases {
+			if e.proseAmbiguous && !bareAcronyms && !strings.Contains(a, " ") {
+				continue
+			}
 			if strings.Contains(padded, " "+a+" ") {
 				out = append(out, e.slug)
 				break

--- a/internal/candidate/hardconstraint/credentials/credentials_test.go
+++ b/internal/candidate/hardconstraint/credentials/credentials_test.go
@@ -1,6 +1,9 @@
 package credentials
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestCanonicalResolvesAliases(t *testing.T) {
 	cases := map[string]string{
@@ -39,15 +42,105 @@ func TestCanonicalUnknownReturnsNotOK(t *testing.T) {
 	}
 }
 
-func TestIsCanonicalGatesTheControlledSet(t *testing.T) {
-	if !IsCanonical("cissp") {
-		t.Error("IsCanonical(cissp) = false; want true")
-	}
-	if IsCanonical("not-a-real-slug") {
-		t.Error("IsCanonical(not-a-real-slug) = true; want false")
-	}
-	// A canonical slug must resolve to itself through Canonical.
+// A canonical slug must resolve to itself through Canonical.
+func TestCanonicalSlugResolvesToItself(t *testing.T) {
 	if got, ok := Canonical("cissp"); !ok || got != "cissp" {
 		t.Errorf("Canonical(canonical slug) = %q, %v; want cissp, true", got, ok)
+	}
+}
+
+// Scan reads a job DESCRIPTION, which is prose, and a two- or three-letter alias is a word
+// ordinary prose also uses. Each of these was measured against the live table: "A+ players"
+// resolved comptia-a-plus, a Salesforce CSM resolved csm, and an accountancy firm resolved
+// cpa. A fourth, "CISA guidelines", is knowingly left — see the table for why.
+//
+// The consequence was never a wrong LIST: it is a false "requires this certification",
+// which caps the candidate's score at 60 and states the false requirement in all three
+// stages of the analysis prompt as already established.
+func TestScanIgnoresAnAcronymOrdinaryProseAlsoUses(t *testing.T) {
+	cases := map[string]string{
+		"We are looking for A+ players":               "comptia-a-plus",
+		"Salesforce CSM and CRM tooling":              "csm",
+		"Work with our CPA firm on the monthly close": "cpa",
+	}
+	for text, unwanted := range cases {
+		t.Run(text, func(t *testing.T) {
+			for _, got := range Scan(text) {
+				if got == unwanted {
+					t.Errorf("Scan(%q) resolved %q from prose", text, unwanted)
+				}
+			}
+		})
+	}
+}
+
+// The suppression is on the bare acronym, not on the credential. A posting that spells the
+// certification out is stating a requirement, and that must still be read — otherwise the
+// fix trades a false blocker for a missed one.
+func TestScanStillReadsTheSpeltOutFormOfAnAmbiguousCredential(t *testing.T) {
+	cases := map[string]string{
+		"Must hold CompTIA A+":                             "comptia-a-plus",
+		"Certified ScrumMaster required":                   "csm",
+		"Certified Public Accountant (or equivalent)":      "cpa",
+		"CISSP holders preferred":                          "cissp",
+		"PMP certification required":                       "pmp",
+		"Certified Kubernetes Administrator for the infra": "cka",
+		// Not marked ambiguous, so its bare acronym still reads — see the table.
+		"CISA required": "cisa",
+	}
+	for text, want := range cases {
+		t.Run(text, func(t *testing.T) {
+			if !slices.Contains(Scan(text), want) {
+				t.Errorf("Scan(%q) = %v, want it to contain %q", text, Scan(text), want)
+			}
+		})
+	}
+}
+
+// ScanLine reads ONE deliberate field — a line off a résumé's certification list — where a
+// bare acronym IS the credential and nothing around it is prose. It is the permissive half
+// of the same table, and the asymmetry is the point: on the résumé side a missed credential
+// becomes a FALSE BLOCKER, while a spurious one merely fails to block.
+//
+// Every one of these was measured returning ("", false) from Canonical, which matches the
+// whole string — and a résumé entry is almost never exactly an alias.
+func TestScanLineReadsADecoratedResumeEntry(t *testing.T) {
+	cases := map[string]string{
+		"CompTIA Security+ (2022)":                      "comptia-security-plus",
+		"Certified Kubernetes Administrator (CKA)":      "cka",
+		"AWS Certified Solutions Architect – Associate": "aws-solutions-architect",
+		"CPA, 2019": "cpa",
+		"CISSP":     "cissp",
+	}
+	for entry, want := range cases {
+		t.Run(entry, func(t *testing.T) {
+			if !slices.Contains(ScanLine(entry), want) {
+				t.Errorf("ScanLine(%q) = %v, want it to contain %q", entry, ScanLine(entry), want)
+			}
+		})
+	}
+}
+
+// The slug is an identifier and the label is what a person reads. Reason and Action are
+// rendered verbatim on the job page and go verbatim into all three stages of the analysis
+// prompt, so a missing label would put "gcp-professional-cloud-architect" in front of a
+// candidate. The table owns the vocabulary, so walking it is completeness, not consistency.
+func TestEveryEntryCarriesAReadableLabel(t *testing.T) {
+	for _, e := range table {
+		if e.label == "" {
+			t.Errorf("entry %q carries no label", e.slug)
+			continue
+		}
+		if e.label == e.slug {
+			t.Errorf("entry %q labels itself with its own slug", e.slug)
+		}
+		if got := Label(e.slug); got != e.label {
+			t.Errorf("Label(%q) = %q, want %q", e.slug, got, e.label)
+		}
+	}
+	// An unknown slug reads as itself rather than as an empty string: a caller
+	// interpolating it produces a poor sentence, never a broken one.
+	if got := Label("not-a-real-slug"); got != "not-a-real-slug" {
+		t.Errorf("Label(unknown) = %q, want the slug back", got)
 	}
 }

--- a/internal/candidate/hardconstraint/hardconstraint.go
+++ b/internal/candidate/hardconstraint/hardconstraint.go
@@ -133,8 +133,13 @@ func appendCertifications(out []Blocker, job JobRequirements, cv CVEvidence) []B
 	}
 	for _, req := range job.RequiredCertifications {
 		met := held[req]
-		reason := fmt.Sprintf("Requires the %s certification.", req)
-		action := fmt.Sprintf("Do not claim the %s certification unless you currently hold it.", req)
+		// The label, not the slug: Reason and Action are rendered verbatim on the job
+		// page and go verbatim into all three stages of the analysis prompt, so the slug
+		// put "Requires the gcp-professional-cloud-architect certification." in front of
+		// a candidate.
+		name := credentials.Label(req)
+		reason := fmt.Sprintf("Requires the %s certification.", name)
+		action := fmt.Sprintf("Do not claim the %s certification unless you currently hold it.", name)
 		out = append(out, blocker(CategoryCertification, met, reason, action))
 	}
 	return out
@@ -207,10 +212,22 @@ func bestDegreeRank(degrees []string) (int, bool) {
 	return best, found
 }
 
+// canonicalSet resolves the résumé's certification lines to canonical slugs.
+//
+// Exact first, then whole-word containment — the shape degreeMatch (degrees.go) already
+// uses, and for the same reason. Canonical matches the WHOLE string, and a résumé entry
+// almost never is one: "CompTIA Security+ (2022)", "Certified Kubernetes Administrator
+// (CKA)" and "AWS Certified Solutions Architect – Associate" all returned ("", false).
+// With one other entry resolving, the len(held)==0 skip did not fire, and the candidate
+// got a hard blocker and a 60 score-cap for a certification they hold.
 func canonicalSet(certs []string) map[string]bool {
 	held := make(map[string]bool, len(certs))
 	for _, c := range certs {
 		if slug, ok := credentials.Canonical(c); ok {
+			held[slug] = true
+			continue
+		}
+		for _, slug := range credentials.ScanLine(c) {
 			held[slug] = true
 		}
 	}

--- a/internal/candidate/hardconstraint/hardconstraint_test.go
+++ b/internal/candidate/hardconstraint/hardconstraint_test.go
@@ -1,6 +1,9 @@
 package hardconstraint
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func intp(v int) *int    { return &v }
 func boolp(v bool) *bool { return &v }
@@ -113,6 +116,54 @@ func TestCertificationCategory(t *testing.T) {
 		bs := Evaluate(JobRequirements{RequiredCertifications: []string{"pmp"}}, CVEvidence{})
 		if _, ok := find(bs, CategoryCertification); ok {
 			t.Error("certification must be skipped when the résumé carries no recognized certification")
+		}
+	})
+	// The two sides of one dictionary read it differently: the job resolved by word, the
+	// résumé by the WHOLE string. A résumé entry is almost never exactly an alias — it
+	// carries a year, an issuer or the acronym in brackets — so the credential the
+	// candidate holds resolved to nothing while a neighbouring entry resolved fine, which
+	// meant the len(held)==0 skip did not fire and they got a hard blocker and a 60 cap
+	// for a certification they hold. Each of these returned ("", false) from Canonical.
+	t.Run("a decorated résumé entry still meets the requirement", func(t *testing.T) {
+		cases := map[string]string{
+			"comptia-security-plus":   "CompTIA Security+ (2022)",
+			"cka":                     "Certified Kubernetes Administrator (CKA)",
+			"aws-solutions-architect": "AWS Certified Solutions Architect – Associate",
+		}
+		for required, held := range cases {
+			t.Run(held, func(t *testing.T) {
+				bs := Evaluate(
+					JobRequirements{RequiredCertifications: []string{required}},
+					// A second, plainly-resolving entry, so the both-sides-present skip
+					// cannot be what hides the defect.
+					CVEvidence{Certifications: []string{held, "CISSP"}},
+				)
+				b, ok := find(bs, CategoryCertification)
+				if !ok || !b.Met {
+					t.Fatalf("want met, got %+v ok=%v", b, ok)
+				}
+			})
+		}
+	})
+	// Reason and Action are rendered verbatim on the job page and go verbatim into all
+	// three stages of the analysis prompt, so the slug reached a person's eyes.
+	t.Run("the blocker names the credential, not its slug", func(t *testing.T) {
+		bs := Evaluate(
+			JobRequirements{RequiredCertifications: []string{"gcp-professional-cloud-architect"}},
+			CVEvidence{Certifications: []string{"CISSP"}},
+		)
+		b, ok := find(bs, CategoryCertification)
+		if !ok {
+			t.Fatal("want a certification blocker")
+		}
+		if strings.Contains(b.Reason, "gcp-professional-cloud-architect") {
+			t.Errorf("Reason carries the slug: %q", b.Reason)
+		}
+		if !strings.Contains(b.Reason, "Google Professional Cloud Architect") {
+			t.Errorf("Reason does not name the credential: %q", b.Reason)
+		}
+		if strings.Contains(b.Action, "gcp-professional-cloud-architect") {
+			t.Errorf("Action carries the slug: %q", b.Action)
 		}
 	})
 }


### PR DESCRIPTION
Three findings from the third backend-review pass, all in one small leaf dictionary that two callers read with two different contracts.

## The two sides of one table resolved it differently

A job's description goes through `credentials.Scan`, which matches an alias as a **word** anywhere in the text. A résumé's certification list went through `credentials.Canonical`, which matches the **whole string** — and a résumé entry almost never is one; it carries a year, an issuer, or the acronym in brackets.

Measured against the live table, all three of these returned `("", false)`:

| résumé entry | `Canonical` | `ScanLine` (new) |
|---|---|---|
| `CompTIA Security+ (2022)` | ✗ | `comptia-security-plus` |
| `Certified Kubernetes Administrator (CKA)` | ✗ | `cka` |
| `AWS Certified Solutions Architect – Associate` | ✗ | `aws-solutions-architect` |

That is worse than a miss. With one **other** entry resolving, the `len(held)==0` "no recognized evidence" skip did not fire — so the candidate took `SeverityHard` and a **60 score-cap for a certification they hold**, and `writeBlockers` put the false sentence into all three stages of the analysis prompt under *"already established; never claim the candidate meets this"*.

`degreeMatch` next door had already solved exactly this: exact first, then whole-word containment. `canonicalSet` now falls back the same way.

The asymmetry between the two scanners runs the safe way: on the job side a spurious hit is a false **requirement**; on the résumé side a missed hit is a false **blocker** and a spurious one merely fails to block.

## `Scan` matched acronyms in ordinary prose

| text | resolved | now |
|---|---|---|
| `We are looking for A+ players` | `comptia-a-plus` | — |
| `Salesforce CSM and CRM tooling` | `csm` | — |
| `Work with our CPA firm` | `cpa` | — |

Those three are marked `proseAmbiguous`, which suppresses the **bare acronym** and keeps every spelt-out form ("Certified ScrumMaster required" still resolves).

**One measured collision is knowingly left.** `CISA guidelines` names the US agency, but `CISSP, CISA and CISM required` is a real requirement already pinned in `jobfacts` — and a bare-acronym rule cannot separate them. Doing so needs a vocabulary of credential words near the acronym, which is its own decision with its own false readings. `jobfacts` already narrows the text to the requirements section, which limits the exposure.

## The blocker named a slug, not a credential

`Reason` and `Action` are rendered verbatim on the job page (`JobMatch.svelte`, `ConfirmTailorDialog.svelte`) and go verbatim into the prompt, so a candidate was reading:

> Requires the `gcp-professional-cloud-architect` certification.

12 of 25 slugs are multi-word hyphenated identifiers. The table gains a `label` column — it cannot be recovered from an alias, since aliases are folded to lower case. `internal/dict/skilltag/labels.go` is the same shape for the same reason.

## Dead code

`IsCanonical`, `slugSet` and `buildSlugSet`: **zero callers** outside their own test, including under `//go:build integration`. The gate they promised is not needed — `design.md` rejected an LLM `required_certifications` field, and the résumé side is free text by intent.

The package doc named two consumers (`enrich`, `resumeextract`) that do not import it. It now names the two that do, and says why they read it differently.

## Verification

- `gofmt -l .` clean; `go build ./...`, `go vet ./...`, `go test ./...` pass.
- Every fix confirmed to **fail** without it: with the fallback removed all three decorated entries produced a hard blocker at cap 60, and with the label removed the slug appeared in both `Reason` and `Action`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved certification detection across job descriptions and résumé entries.
  - Résumé scans now recognize decorated certification names, including entries with dates or abbreviations.
  - Certification-related messages now display readable credential names instead of internal identifiers.
- **Bug Fixes**
  - Reduced false matches for ambiguous acronyms in ordinary job-description text while continuing to recognize fully spelled-out credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->