### PR TITLE
Make the no-transaction marker mean what its migrations say, and stop recording a version over an unusable index

### DIFF
--- a/internal/platform/db/AGENTS.md
+++ b/internal/platform/db/AGENTS.md
@@ -50,8 +50,19 @@ A pre-runner database baselines itself: an empty `schema_migrations` plus an exi
 as applied without executing it (`-baseline` forces this).
 
 A file that must run outside a transaction (e.g. `CREATE INDEX CONCURRENTLY`) opts out with
-`-- migrate: no-transaction` in its leading comment block — write those idempotently
-(`IF NOT EXISTS` / `IF EXISTS`).
+`-- migrate: no-transaction` **as the whole content of a comment line** in its leading
+comment block — a file that merely mentions the marker in a sentence is not opted out.
+Those files run one statement at a time, each in its own implicit transaction, so a
+statement that Postgres forbids inside a transaction block actually gets what the marker
+promises.
+
+Write them idempotently (`IF NOT EXISTS` / `IF EXISTS`): the record insert is not atomic
+with them, so a failure part-way leaves the file executed but unrecorded. `IF NOT EXISTS`
+used to be a hazard of its own on a CONCURRENTLY re-run — it steps silently over an index a
+timed-out build left at `indisvalid=f`, and the version is then recorded against an index
+nothing will use (`migrations/0118`, and the prod incident in `0126`/`0127`). The runner now
+checks, after a no-transaction file applies, whether any index THAT FILE NAMES is invalid,
+and fails without recording rather than stepping over it.
 
 ## Limitations
 - Historical parallel branches produced duplicate number prefixes (`0009_*`×2, `0034_*`×4, …). Harmless: initdb and the runner both order by full filename, and `schema_migrations.version` is the filename, not the number. New files take the next free number; never renumber old files (their versions are already recorded on migrated databases).

--- a/internal/platform/migrate/migrate.go
+++ b/internal/platform/migrate/migrate.go
@@ -27,12 +27,16 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// noTxMarker, placed in a migration's leading comment block, opts the file out
-// of the per-migration transaction. Needed for statements Postgres forbids
-// inside a transaction block (CREATE INDEX CONCURRENTLY, DROP INDEX
-// CONCURRENTLY). The applied-record insert then runs outside any transaction
-// too, so a failure can leave the file executed but unrecorded — re-running is
-// safe only if such files are written idempotently (IF NOT EXISTS / IF EXISTS).
+// noTxMarker, placed as the WHOLE content of a comment line in a migration's leading
+// comment block, opts the file out of the per-migration transaction. Needed for statements
+// Postgres forbids inside a transaction block (CREATE INDEX CONCURRENTLY, DROP INDEX
+// CONCURRENTLY).
+//
+// The file is then executed one statement at a time (see splitStatements) — a whole file in
+// one Exec would still be one implicit transaction, which is not what the marker promises.
+// The applied-record insert runs outside any transaction too, so a failure can leave the
+// file executed but unrecorded — re-running is safe only if such files are written
+// idempotently (IF NOT EXISTS / IF EXISTS).
 const noTxMarker = "migrate: no-transaction"
 
 // advisoryLockKey serializes concurrent migrate runs (e.g. a deploy racing a cron-triggered
@@ -108,8 +112,17 @@ func Load(dir string) ([]Migration, error) {
 	return migs, nil
 }
 
-// hasNoTxMarker reports whether the marker appears in the file's leading
-// comment block (blank lines and -- comments before the first statement).
+// hasNoTxMarker reports whether the file DECLARES the marker in its leading comment block
+// (blank lines and -- comments before the first statement).
+//
+// The marker must be the whole content of its comment line. It is an instruction, not a
+// topic: with strings.Contains, migrations/0126 — whose header says "No `migrate:
+// no-transaction` marker, so the two statements are one transaction" — was opted out by the
+// sentence explaining that it must not be. It survived only by accident, because a
+// multi-statement simple query is one implicit transaction anyway.
+//
+// scripts/check-migrations.mjs repeats this rule; the two must agree, or squawk lints a
+// file under a premise the runner does not share.
 func hasNoTxMarker(sql string) bool {
 	for _, line := range strings.Split(sql, "\n") {
 		line = strings.TrimSpace(line)
@@ -119,7 +132,131 @@ func hasNoTxMarker(sql string) bool {
 		if !strings.HasPrefix(line, "--") {
 			return false
 		}
-		if strings.Contains(line, noTxMarker) {
+		if strings.TrimSpace(strings.TrimPrefix(line, "--")) == noTxMarker {
+			return true
+		}
+	}
+	return false
+}
+
+// splitStatements cuts a migration into its top-level statements, on semicolons that are
+// not inside a string, a dollar-quoted body, a quoted identifier, or a comment. Whitespace
+// and comments are carried with the statement that follows them; a trailing fragment
+// containing no statement is dropped.
+//
+// It exists because the no-transaction marker did not mean what its files said. The runner
+// sent the whole file to one Exec, and pgx forces the simple protocol when a query carries
+// no arguments (conn.go), which Postgres executes as ONE implicit transaction — so the
+// marker cancelled only the runner's own BEGIN/COMMIT and bought nothing else.
+// migrations/0135 states a guarantee it was not getting: "Two ALTER TABLE statements,
+// deliberately NOT in one transaction: NOT VALID + VALIDATE CONSTRAINT in one transaction
+// holds ACCESS EXCLUSIVE for the whole scan."
+//
+// This is a splitter, not a parser: it needs to find statement boundaries, not to
+// understand SQL. The four quoting forms below are the only ones in which a semicolon can
+// hide.
+func splitStatements(sql string) []string {
+	var (
+		out   []string
+		start int
+	)
+	for i := 0; i < len(sql); i++ {
+		switch {
+		case strings.HasPrefix(sql[i:], "--"):
+			if end := strings.IndexByte(sql[i:], '\n'); end >= 0 {
+				i += end
+			} else {
+				i = len(sql)
+			}
+		case strings.HasPrefix(sql[i:], "/*"):
+			// Postgres nests block comments, so this counts depth rather than
+			// stopping at the first close.
+			depth, j := 1, i+2
+			for j < len(sql) && depth > 0 {
+				switch {
+				case strings.HasPrefix(sql[j:], "/*"):
+					depth++
+					j += 2
+				case strings.HasPrefix(sql[j:], "*/"):
+					depth--
+					j += 2
+				default:
+					j++
+				}
+			}
+			i = j - 1
+		case sql[i] == '\'':
+			i = closeQuoted(sql, i, '\'')
+		case sql[i] == '"':
+			i = closeQuoted(sql, i, '"')
+		case sql[i] == '$':
+			if tag, after, ok := dollarTag(sql, i); ok {
+				if end := strings.Index(sql[after:], tag); end >= 0 {
+					i = after + end + len(tag) - 1
+				} else {
+					i = len(sql)
+				}
+			}
+		case sql[i] == ';':
+			if s := sql[start:i]; strings.TrimSpace(s) != "" {
+				out = append(out, s)
+			}
+			start = i + 1
+		}
+	}
+	if tail := sql[min(start, len(sql)):]; hasStatement(tail) {
+		out = append(out, tail)
+	}
+	return out
+}
+
+// closeQuoted returns the index of the closing quote for the literal or identifier opening
+// at i. A doubled quote is an escaped one and does not close.
+func closeQuoted(sql string, i int, quote byte) int {
+	for j := i + 1; j < len(sql); j++ {
+		if sql[j] != quote {
+			continue
+		}
+		if j+1 < len(sql) && sql[j+1] == quote {
+			j++
+			continue
+		}
+		return j
+	}
+	return len(sql)
+}
+
+// dollarTag reads a dollar-quote opener at i ($$ or $tag$), returning the tag to look for
+// and the index just past the opener. A '$' that opens no tag (a positional parameter, or
+// a '$' inside an identifier) reports ok=false.
+func dollarTag(sql string, i int) (tag string, after int, ok bool) {
+	for j := i + 1; j < len(sql); j++ {
+		c := sql[j]
+		if c == '$' {
+			return sql[i : j+1], j + 1, true
+		}
+		if !tagByte(c, j == i+1) {
+			return "", 0, false
+		}
+	}
+	return "", 0, false
+}
+
+// tagByte reports whether c may appear in a dollar-quote tag. A tag may not START with a
+// digit, which is what separates $1 (a positional parameter) from $t1$ (a tag).
+func tagByte(c byte, first bool) bool {
+	if c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') {
+		return true
+	}
+	return !first && c >= '0' && c <= '9'
+}
+
+// hasStatement reports whether a trailing fragment carries anything but whitespace and
+// comments — a file's closing commentary is not a statement to execute.
+func hasStatement(fragment string) bool {
+	for _, line := range strings.Split(fragment, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" && !strings.HasPrefix(line, "--") {
 			return true
 		}
 	}
@@ -244,13 +381,7 @@ func (r *Runner) Run(ctx context.Context, migs []Migration, forceBaseline bool) 
 // opted out of transactions.
 func applyOne(ctx context.Context, conn *pgxpool.Conn, m Migration) error {
 	if m.NoTx {
-		if _, err := conn.Exec(ctx, m.SQL); err != nil {
-			return fmt.Errorf("apply %s: %w", m.Version, err)
-		}
-		if _, err := conn.Exec(ctx, "INSERT INTO public.schema_migrations (version) VALUES ($1)", m.Version); err != nil {
-			return fmt.Errorf("record %s: %w", m.Version, err)
-		}
-		return nil
+		return applyNoTx(ctx, conn, m)
 	}
 
 	tx, err := conn.Begin(ctx)
@@ -269,6 +400,107 @@ func applyOne(ctx context.Context, conn *pgxpool.Conn, m Migration) error {
 		return fmt.Errorf("commit %s: %w", m.Version, err)
 	}
 	return nil
+}
+
+// applyNoTx executes a no-transaction migration one statement at a time and records it.
+//
+// One statement per Exec is what makes the marker mean what its files say: a whole file in
+// one Exec goes out on the simple protocol (pgx forces it when there are no arguments) and
+// Postgres runs a multi-statement simple query as ONE implicit transaction, so the marker
+// cancelled only this runner's own BEGIN/COMMIT. Each statement still gets an implicit
+// transaction of its own, which is the point — that is what a CONCURRENTLY statement needs
+// and what keeps 0135's NOT VALID and VALIDATE CONSTRAINT from sharing an ACCESS EXCLUSIVE
+// lock across the whole scan.
+//
+// A failure part-way leaves the file executed-but-unrecorded, which is why these files must
+// be written idempotently (IF NOT EXISTS / IF EXISTS) — the same contract as before, now
+// with a finer failure granularity.
+func applyNoTx(ctx context.Context, conn *pgxpool.Conn, m Migration) error {
+	for _, stmt := range splitStatements(m.SQL) {
+		if _, err := conn.Exec(ctx, stmt); err != nil {
+			return fmt.Errorf("apply %s: %w", m.Version, err)
+		}
+	}
+
+	// A successful CREATE INDEX CONCURRENTLY is not proof of a usable index. It waits on
+	// virtual transaction locks and old snapshots with an ordinary wait, which lockTimeout
+	// aborts with 55P03, leaving the index at indisvalid=f. The FIRST run fails loudly and
+	// records nothing. The SECOND is the trap: `IF NOT EXISTS` sees the carcass, does
+	// nothing, succeeds, and the version is recorded against an index that will never be
+	// used. migrations/0126 and 0127 record that happening on 2026-09-03.
+	//
+	// So the check cannot be before-and-after — on the re-run the carcass is present in
+	// BOTH snapshots. It asks instead whether any index THIS FILE NAMES is invalid, which
+	// is also what keeps somebody else's older carcass from failing every run forever.
+	broke, err := invalidIndexesNamedIn(ctx, conn, m.SQL)
+	if err != nil {
+		return fmt.Errorf("read index validity after %s: %w", m.Version, err)
+	}
+	if len(broke) > 0 {
+		return fmt.Errorf("apply %s: %s left invalid (indisvalid=f) — DROP INDEX and re-run; the version was NOT recorded",
+			m.Version, strings.Join(broke, ", "))
+	}
+
+	if _, err := conn.Exec(ctx, "INSERT INTO public.schema_migrations (version) VALUES ($1)", m.Version); err != nil {
+		return fmt.Errorf("record %s: %w", m.Version, err)
+	}
+	return nil
+}
+
+// invalidIndexesNamedIn returns the invalid indexes whose name appears as a word in sql,
+// sorted. Matching on the file's own text is coarse but exact where it matters: a
+// CONCURRENTLY file names the index it builds, and no other file's carcass is named here.
+func invalidIndexesNamedIn(ctx context.Context, conn *pgxpool.Conn, sql string) ([]string, error) {
+	rows, err := conn.Query(ctx,
+		`SELECT c.relname FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid WHERE NOT i.indisvalid`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	lower := strings.ToLower(sql)
+	var out []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		if namesIdentifier(lower, strings.ToLower(name)) {
+			out = append(out, name)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// namesIdentifier reports whether sql mentions name as a whole identifier, so a short index
+// name is not matched inside a longer one.
+func namesIdentifier(sql, name string) bool {
+	for i := 0; ; {
+		j := strings.Index(sql[i:], name)
+		if j < 0 {
+			return false
+		}
+		j += i
+		if !identifierByte(byteAt(sql, j-1)) && !identifierByte(byteAt(sql, j+len(name))) {
+			return true
+		}
+		i = j + 1
+	}
+}
+
+func byteAt(s string, i int) byte {
+	if i < 0 || i >= len(s) {
+		return ' '
+	}
+	return s[i]
+}
+
+func identifierByte(c byte) bool {
+	return c == '_' || c == '$' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
 }
 
 // appliedVersions reads the recorded versions.

--- a/internal/platform/migrate/migrate_test.go
+++ b/internal/platform/migrate/migrate_test.go
@@ -3,6 +3,7 @@ package migrate
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -65,6 +66,146 @@ func TestLoad_NoTxMarker(t *testing.T) {
 	}
 	if migs[2].NoTx {
 		t.Errorf("%s: NoTx = true, want false (marker after the first statement does not count)", migs[2].Version)
+	}
+}
+
+// The marker is an instruction, not a topic. A file DISCUSSING it in its preamble was
+// opted out by it: hasNoTxMarker asked strings.Contains, so migrations/0126 — whose header
+// says "No `migrate: no-transaction` marker, so the two statements are one transaction" —
+// answered true, which is the exact opposite of what it says. It survived only by accident,
+// because a multi-statement simple query is one implicit transaction anyway.
+//
+// scripts/check-migrations.mjs repeats this logic, so squawk linted 0126 under the same
+// wrong premise.
+func TestNoTxMarkerMustBeTheWholeCommentLine(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "0001_discusses.sql",
+		"-- No `migrate: no-transaction` marker, so the two statements are one transaction.\n"+
+			"ALTER TABLE t ADD COLUMN c int;\n")
+	writeFile(t, dir, "0002_declares.sql", "-- migrate: no-transaction\nCREATE INDEX CONCURRENTLY i ON t (id);\n")
+	writeFile(t, dir, "0003_declares_indented.sql", "--   migrate: no-transaction  \nCREATE INDEX CONCURRENTLY i ON t (id);\n")
+
+	migs, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if migs[0].NoTx {
+		t.Error("a file that merely NAMES the marker was opted out by it")
+	}
+	if !migs[1].NoTx {
+		t.Error("a file declaring the marker was not opted out")
+	}
+	if !migs[2].NoTx {
+		t.Error("whitespace around the marker defeated it")
+	}
+}
+
+// The guard on the real catalogue, not on fixtures: this is the file the defect was found
+// in, and a fixture cannot notice the next one.
+func TestNoRealMigrationIsOptedOutByDiscussingTheMarker(t *testing.T) {
+	migs, err := Load(filepath.Join("..", "..", "..", "migrations"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	for _, m := range migs {
+		if !m.NoTx {
+			continue
+		}
+		first := ""
+		for _, line := range strings.Split(m.SQL, "\n") {
+			if line = strings.TrimSpace(line); line != "" {
+				first = line
+				break
+			}
+		}
+		if first != "-- "+noTxMarker {
+			t.Errorf("%s reads as no-transaction, but its first line is %q", m.Version, first)
+		}
+	}
+}
+
+// splitStatements is what makes the marker mean what its files say. The runner sent the
+// whole file to one Exec, and pgx forces the simple protocol when there are no arguments,
+// which Postgres runs as ONE implicit transaction — so the marker cancelled only the
+// runner's own BEGIN/COMMIT. migrations/0135's header describes a guarantee ("NOT VALID +
+// VALIDATE CONSTRAINT in one transaction holds ACCESS EXCLUSIVE for the whole scan") that
+// it was not getting.
+func TestSplitStatementsRespectsQuotingAndComments(t *testing.T) {
+	cases := map[string]struct {
+		sql  string
+		want []string
+	}{
+		"plain": {
+			"CREATE INDEX a ON t (id);\nCREATE INDEX b ON t (id);\n",
+			[]string{"CREATE INDEX a ON t (id)", "CREATE INDEX b ON t (id)"},
+		},
+		"a semicolon inside a string is not a separator": {
+			"INSERT INTO t VALUES ('a;b');\nSELECT 1;",
+			[]string{"INSERT INTO t VALUES ('a;b')", "SELECT 1"},
+		},
+		"a doubled quote does not end the string": {
+			"INSERT INTO t VALUES ('it''s; fine');",
+			[]string{"INSERT INTO t VALUES ('it''s; fine')"},
+		},
+		"a semicolon inside a dollar-quoted body is not a separator": {
+			"CREATE FUNCTION f() RETURNS int AS $$ BEGIN RETURN 1; END $$ LANGUAGE plpgsql;\nSELECT 2;",
+			[]string{"CREATE FUNCTION f() RETURNS int AS $$ BEGIN RETURN 1; END $$ LANGUAGE plpgsql", "SELECT 2"},
+		},
+		"a tagged dollar quote closes only on its own tag": {
+			"DO $mig$ BEGIN PERFORM 1; END $mig$;",
+			[]string{"DO $mig$ BEGIN PERFORM 1; END $mig$"},
+		},
+		"a semicolon inside a line comment is not a separator": {
+			"-- drop it; then rebuild\nDROP INDEX i;",
+			[]string{"-- drop it; then rebuild\nDROP INDEX i"},
+		},
+		"a semicolon inside a block comment is not a separator": {
+			"/* a; b */ SELECT 1;",
+			[]string{"/* a; b */ SELECT 1"},
+		},
+		"a semicolon inside a quoted identifier is not a separator": {
+			`CREATE INDEX "odd;name" ON t (id);`,
+			[]string{`CREATE INDEX "odd;name" ON t (id)`},
+		},
+		"a trailing statement without its semicolon still counts": {
+			"SELECT 1;\nSELECT 2",
+			[]string{"SELECT 1", "SELECT 2"},
+		},
+		"comment-only tail yields nothing": {
+			"SELECT 1;\n-- done\n",
+			[]string{"SELECT 1"},
+		},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := splitStatements(c.sql)
+			if len(got) != len(c.want) {
+				t.Fatalf("split into %d statements %q, want %d %q", len(got), got, len(c.want), c.want)
+			}
+			for i := range got {
+				if strings.TrimSpace(got[i]) != c.want[i] {
+					t.Errorf("statement %d = %q, want %q", i, strings.TrimSpace(got[i]), c.want[i])
+				}
+			}
+		})
+	}
+}
+
+// Every no-transaction file in the catalogue must split into the statements it reads as,
+// so a future one-statement rule has a number to check and the runner has the same view of
+// the file a reader does.
+func TestEveryNoTxMigrationSplitsIntoWholeStatements(t *testing.T) {
+	migs, err := Load(filepath.Join("..", "..", "..", "migrations"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	for _, m := range migs {
+		if !m.NoTx {
+			continue
+		}
+		if len(splitStatements(m.SQL)) == 0 {
+			t.Errorf("%s is no-transaction but splits into no statements", m.Version)
+		}
 	}
 }
 

--- a/internal/platform/migrate/notx_integration_test.go
+++ b/internal/platform/migrate/notx_integration_test.go
@@ -1,0 +1,159 @@
+//go:build integration
+
+// Integration tests for the no-transaction path: statements run one at a time, and an
+// index left invalid fails the migration instead of recording it. Needs Docker
+// (testcontainers); run with: go test -tags=integration ./internal/platform/migrate/
+package migrate_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/strelov1/freehire/internal/platform/migrate"
+	"github.com/strelov1/freehire/internal/platform/testdb"
+)
+
+// bootstrapped returns a pool the runner treats as already past its baseline, so a
+// migration handed to it is APPLIED rather than recorded-without-executing.
+func bootstrapped(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	pool := testdb.Pool(t)
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, `CREATE TABLE IF NOT EXISTS public.schema_migrations (
+		version text PRIMARY KEY, applied_at timestamptz NOT NULL DEFAULT now())`); err != nil {
+		t.Fatalf("ensure schema_migrations: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO public.schema_migrations (version) VALUES ('0000_bootstrap.sql') ON CONFLICT DO NOTHING`); err != nil {
+		t.Fatalf("seed schema_migrations: %v", err)
+	}
+	return pool
+}
+
+func recorded(t *testing.T, pool *pgxpool.Pool, version string) bool {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM public.schema_migrations WHERE version = $1`, version).Scan(&n); err != nil {
+		t.Fatalf("read schema_migrations: %v", err)
+	}
+	return n > 0
+}
+
+// The marker's whole purpose. Two CONCURRENTLY statements in one file used to go out as a
+// single simple query, which Postgres runs as one implicit transaction — and Postgres
+// forbids CREATE INDEX CONCURRENTLY inside a transaction block, so this file could not have
+// applied at all before the split.
+func TestNoTxRunsEachStatementSeparately(t *testing.T) {
+	pool := bootstrapped(t)
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, `CREATE TABLE split_probe (id bigint, note text)`); err != nil {
+		t.Fatalf("create probe table: %v", err)
+	}
+
+	migs := []migrate.Migration{{
+		Version: "9999_two_concurrent_indexes.sql",
+		NoTx:    true,
+		SQL: "-- migrate: no-transaction\n" +
+			"CREATE INDEX CONCURRENTLY IF NOT EXISTS split_probe_id_idx ON split_probe (id);\n" +
+			"CREATE INDEX CONCURRENTLY IF NOT EXISTS split_probe_note_idx ON split_probe (note);\n",
+	}}
+
+	if _, applied, err := migrate.NewRunner(pool).Run(ctx, migs, false); err != nil {
+		t.Fatalf("Run: %v (applied=%v)", err, applied)
+	}
+
+	for _, idx := range []string{"split_probe_id_idx", "split_probe_note_idx"} {
+		var valid bool
+		if err := pool.QueryRow(ctx,
+			`SELECT i.indisvalid FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid WHERE c.relname = $1`,
+			idx).Scan(&valid); err != nil {
+			t.Fatalf("read %s: %v", idx, err)
+		}
+		if !valid {
+			t.Errorf("%s exists but is invalid", idx)
+		}
+	}
+}
+
+// The trap this guard exists for, reproduced exactly.
+//
+// A CREATE INDEX CONCURRENTLY aborted by the runner's lock_timeout leaves the index at
+// indisvalid=f. The FIRST run fails loudly and records nothing. The SECOND is the one that
+// hurts: `IF NOT EXISTS` sees the carcass, does nothing, reports success, and the version is
+// recorded against an index that will never be used — which is what happened to prod on
+// 2026-09-03 (see migrations/0126 and 0127). A before-and-after comparison cannot catch it,
+// because on the re-run the carcass is in both snapshots.
+func TestNoTxRefusesToRecordWhenTheIndexItNamesIsInvalid(t *testing.T) {
+	pool := bootstrapped(t)
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, `CREATE TABLE carcass_probe (id bigint)`); err != nil {
+		t.Fatalf("create probe table: %v", err)
+	}
+	// A unique index CONCURRENTLY over duplicate rows fails on its second pass and leaves
+	// exactly the carcass a timed-out build leaves.
+	if _, err := pool.Exec(ctx, `INSERT INTO carcass_probe (id) VALUES (1), (1)`); err != nil {
+		t.Fatalf("seed duplicates: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`CREATE UNIQUE INDEX CONCURRENTLY carcass_probe_id_idx ON carcass_probe (id)`); err == nil {
+		t.Fatal("expected the concurrent unique build to fail on duplicate rows")
+	}
+
+	const version = "9999_recreate_carcass_probe_idx.sql"
+	migs := []migrate.Migration{{
+		Version: version,
+		NoTx:    true,
+		SQL: "-- migrate: no-transaction\n" +
+			"CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS carcass_probe_id_idx ON carcass_probe (id);\n",
+	}}
+
+	_, applied, err := migrate.NewRunner(pool).Run(ctx, migs, false)
+	if err == nil {
+		t.Fatalf("Run succeeded over an invalid index; applied=%v", applied)
+	}
+	if !strings.Contains(err.Error(), "carcass_probe_id_idx") {
+		t.Errorf("err = %v, want it to name the invalid index", err)
+	}
+	if recorded(t, pool, version) {
+		t.Error("the version was recorded even though the index it builds is unusable")
+	}
+}
+
+// Somebody else's older carcass must not fail every run forever — which is why the check
+// asks about the indexes THIS FILE names rather than about pg_index as a whole.
+func TestNoTxIgnoresAnInvalidIndexItDoesNotName(t *testing.T) {
+	pool := bootstrapped(t)
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, `CREATE TABLE unrelated_probe (id bigint)`); err != nil {
+		t.Fatalf("create unrelated table: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO unrelated_probe (id) VALUES (1), (1)`); err != nil {
+		t.Fatalf("seed duplicates: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`CREATE UNIQUE INDEX CONCURRENTLY unrelated_probe_id_idx ON unrelated_probe (id)`); err == nil {
+		t.Fatal("expected the concurrent unique build to fail on duplicate rows")
+	}
+	if _, err := pool.Exec(ctx, `CREATE TABLE clean_probe (id bigint)`); err != nil {
+		t.Fatalf("create clean table: %v", err)
+	}
+
+	const version = "9999_clean_probe_idx.sql"
+	migs := []migrate.Migration{{
+		Version: version,
+		NoTx:    true,
+		SQL: "-- migrate: no-transaction\n" +
+			"CREATE INDEX CONCURRENTLY IF NOT EXISTS clean_probe_id_idx ON clean_probe (id);\n",
+	}}
+
+	if _, applied, err := migrate.NewRunner(pool).Run(ctx, migs, false); err != nil {
+		t.Fatalf("Run failed over an unrelated carcass: %v (applied=%v)", err, applied)
+	}
+	if !recorded(t, pool, version) {
+		t.Error("the version was not recorded even though its own index built cleanly")
+	}
+}

--- a/scripts/check-migrations.mjs
+++ b/scripts/check-migrations.mjs
@@ -47,16 +47,21 @@ function noTxMarker() {
 
 /**
  * Mirrors hasNoTxMarker in the runner: the marker counts only in the LEADING comment
- * block — blank lines and `--` comments before the first statement. A marker further
- * down is prose about the mechanism, which several migrations contain, and treating it
- * as the opt-out would lint a transactional file as though it were not one.
+ * block — blank lines and `--` comments before the first statement — and only when it is
+ * the WHOLE content of its comment line. A marker further down, or named inside a
+ * sentence, is prose about the mechanism, which several migrations contain, and treating
+ * it as the opt-out would lint a transactional file as though it were not one.
+ *
+ * The whole-line rule is not a refinement: migrations/0126 opens by explaining that it
+ * carries "No `migrate: no-transaction` marker, so the two statements are one
+ * transaction", and a substring test read that sentence as the opt-out itself.
  */
 function isNoTx(file, marker) {
   for (const raw of readFileSync(file, 'utf8').split('\n')) {
     const line = raw.trim();
     if (line === '') continue;
     if (!line.startsWith('--')) return false;
-    if (line.includes(marker)) return true;
+    if (line.slice(2).trim() === marker) return true;
   }
   return false;
 }


### PR DESCRIPTION
Two findings from the third backend-review pass, both in the migration runner — the first infrastructure **seam** the review opened, and denser on defects than the domain packages around it.

## The marker bought almost nothing

`applyOne` sent the whole file to one `conn.Exec`, and pgx forces `QueryExecModeSimpleProtocol` when a query carries no arguments — which Postgres executes as **one implicit transaction**. So `migrate: no-transaction` cancelled only this runner's own `BEGIN`/`COMMIT` and left every statement in a transaction block anyway.

Six files violate the one-statement rule that paid for this understanding (`migrations/0117`), and `0128` and `0135` were written **after** it and cite each other — the pattern was propagating. `0135`'s header states a guarantee it was not getting:

> Two ALTER TABLE statements, deliberately NOT in one transaction: NOT VALID + VALIDATE CONSTRAINT in one transaction holds ACCESS EXCLUSIVE for the whole scan.

A no-transaction file now executes **one statement at a time**, through a splitter that respects string literals, dollar-quoted bodies, quoted identifiers, and line and (nesting) block comments.

The mutation check here is unusually direct. With the old whole-file `Exec` restored, a two-statement CONCURRENTLY migration fails:

```
ERROR: CREATE INDEX CONCURRENTLY cannot run inside a transaction block (SQLSTATE 25001)
```

The marker's entire purpose, unavailable.

## Detection was wrong in the other direction too

`hasNoTxMarker` asked `strings.Contains`, so `migrations/0126` — whose header explains that it carries *"No `migrate: no-transaction` marker, so the two statements are one transaction"* — was opted out **by the sentence saying it must not be**.

It survived by accident, since a multi-statement simple query was one implicit transaction anyway. With the split above that accident is gone, so this had to be fixed in the same change. The marker must now be the whole content of its comment line, and `scripts/check-migrations.mjs` carries the same rule — it repeats the logic, so squawk was linting 0126 under the runner's wrong premise.

## A successful CONCURRENTLY build is not proof of a usable index

`CREATE INDEX CONCURRENTLY` waits on virtual transaction locks and old snapshots with an ordinary wait, which the runner's 5s `lockTimeout` aborts with 55P03 — leaving the index at `indisvalid=f`.

- **First run:** fails loudly, records nothing. Fine.
- **Second run:** `IF NOT EXISTS` steps over the carcass, succeeds, and **the version is recorded against an index nothing will ever use.**

`migrations/0126` and `0127` record that happening on prod on 2026-09-03.

After a no-transaction file applies, the runner now asks whether any index **that file names** is invalid, and fails without recording. Before-and-after snapshots were the obvious design and cannot work: on the re-run the carcass is in both. Asking about the file's own identifiers is also what keeps somebody else's older carcass from failing every run forever — pinned by a test that leaves an unrelated invalid index standing and expects the migration to succeed.

`lockTimeout` is left alone. `SET lock_timeout = 0` for CONCURRENTLY is a trade, not a simplification: unbounded waiting behind a multi-hour transaction (the similar-jobs backfill, the ~15h `backfill-derive`) would hang `release.sh` and lose the fail-fast property the timeout was added for. Failing loudly on the carcass gets the correctness without giving that up.

## Docs

`internal/platform/db/AGENTS.md` said to write these files idempotently while `migrations/0118` said `IF NOT EXISTS` is precisely what makes the skip silent. Both are now true, and the contradiction is stated rather than left standing.

## Verification

- `gofmt -l .` clean; `go build ./...`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`, `golangci-lint run` all pass.
- `go test -tags=integration ./internal/platform/migrate/` passes, including three new tests against a real Postgres.
- `pnpm check:links` passes.
- Both fixes confirmed to fail without them (SQLSTATE 25001 for the split; a recorded version over an invalid index for the guard).
