### PR TITLE
Let a corrected link move the interview event with it, instead of leaving it with the wrong employer forever

### DIFF
--- a/internal/application/calsync/calendarapi.go
+++ b/internal/application/calsync/calendarapi.go
@@ -150,6 +150,9 @@ func (r *APIReader) ListEvents(ctx context.Context, from, to time.Time) ([]Meeti
 			// day to show it on.
 			continue
 		}
+		// No Cancelled here: this is the live branch, reached only when the cancelled
+		// branch above did not `continue`, so the expression it used to carry
+		// (it.Status == "cancelled") was provably always false.
 		out = append(out, Meeting{
 			UID:        it.ICalUID,
 			ProviderID: it.ID,
@@ -157,7 +160,6 @@ func (r *APIReader) ListEvents(ctx context.Context, from, to time.Time) ([]Meeti
 			StartsAt:   start,
 			EndsAt:     it.End.parse(),
 			JoinURL:    it.HangoutLink,
-			Cancelled:  it.Status == "cancelled",
 		})
 	}
 	return out, nil

--- a/internal/application/calsync/dbstore.go
+++ b/internal/application/calsync/dbstore.go
@@ -59,6 +59,26 @@ func (s *DBStore) Candidates(ctx context.Context, userID int64) ([]calmatch.Cand
 }
 
 func (s *DBStore) UpsertInterview(ctx context.Context, in StoredInterview) error {
+	// Retract first, upsert second — the two-statement shape the mail reconcile uses, and
+	// for the same reason it documents: data-modifying CTEs read one pre-statement
+	// snapshot, so folding these together would leave the insert conflicting with the row
+	// being retracted and silently recording nothing.
+	//
+	// A meeting CAN move between applications: its identifier reaches the application
+	// through emails.application_id, and a link correction rewrites that column. Without
+	// this the old employer kept the "Interview scheduled" entry forever and the right one
+	// never got it, because the upsert's DO NOTHING fired against the correct application
+	// too. A meeting that has not moved matches nothing here, so a re-sync is untouched.
+	if _, err := s.q.RetractMovedInterviewEvent(ctx, db.RetractMovedInterviewEventParams{
+		UserID:  in.UserID,
+		IcalUid: in.UID,
+		// pgtype.Int8 because application_events.application_id is nullable — the
+		// comparison is IS DISTINCT FROM, so a ledger row with no application also counts
+		// as moved.
+		ApplicationID: pgtype.Int8{Int64: in.ApplicationID, Valid: true},
+	}); err != nil {
+		return err
+	}
 	_, err := s.q.UpsertApplicationInterview(ctx, db.UpsertApplicationInterviewParams{
 		UserID:          in.UserID,
 		ApplicationID:   in.ApplicationID,

--- a/internal/platform/db/application_interviews.sql.go
+++ b/internal/platform/db/application_interviews.sql.go
@@ -212,6 +212,59 @@ func (q *Queries) RecordGrantScopes(ctx context.Context, arg RecordGrantScopesPa
 	return err
 }
 
+const retractMovedInterviewEvent = `-- name: RetractMovedInterviewEvent :execrows
+UPDATE application_events ae
+SET retracted_at = now()
+FROM application_interviews ai
+WHERE ai.user_id        = $1
+  AND ai.ical_uid       = $2
+  AND ae.user_id        = ai.user_id
+  AND ae.kind           = 'interview_scheduled'
+  AND ae.source_ref     = ai.id
+  AND ae.retracted_at IS NULL
+  -- Only when it actually moved. A re-sync of an unmoved meeting must leave the ledger
+  -- alone: the scheduling happened once, and re-recording it would date the same fact
+  -- twice.
+  AND ae.application_id IS DISTINCT FROM $3
+`
+
+type RetractMovedInterviewEventParams struct {
+	UserID        int64       `json:"user_id"`
+	IcalUid       string      `json:"ical_uid"`
+	ApplicationID pgtype.Int8 `json:"application_id"`
+}
+
+// Step 1 of recording a meeting: retract the live `interview_scheduled` event when the
+// meeting has moved to a DIFFERENT application since it was written.
+//
+// UpsertApplicationInterview used to argue this could not happen — "an invitation belongs
+// to one application, so the application under a given meeting cannot move" — and that
+// premise is false. ListCalendarMatchCandidates reaches a meeting's identifier through
+// `emails.application_id`, and LinkEmailToJob rewrites that column; it is reachable from
+// POST /me/emails/:id/link and from the assistant's inbox_link tool. docs/agents/mail-stack.md
+// records one company auto-collecting 23 acknowledgements belonging to 23 other employers,
+// so mis-links are a documented, real condition, not a hypothetical one.
+//
+// The damage was two-sided. The old event could not be corrected (RetractSupersededEmailEvent
+// is scoped to kind = 'employer_reply'), and the RIGHT one was never created either, because
+// the interview's source_ref never changed and the upsert's DO NOTHING therefore fired
+// against the correct application too. A month view drew the meeting under the right
+// employer and "Interview scheduled" under the wrong one, with the right application showing
+// no interview at all. migrations/0062 already states the rule this broke: retracted_at is
+// "Set when a link correction moves the fact to another employer".
+//
+// Separate from the upsert, and run first, for the same snapshot reason
+// RetractSupersededEmailEvent documents: data-modifying CTEs all read the pre-statement
+// snapshot, so an insert folded in beside this would still conflict with the row being
+// retracted and silently record nothing.
+func (q *Queries) RetractMovedInterviewEvent(ctx context.Context, arg RetractMovedInterviewEventParams) (int64, error) {
+	result, err := q.db.Exec(ctx, retractMovedInterviewEvent, arg.UserID, arg.IcalUid, arg.ApplicationID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const upsertApplicationInterview = `-- name: UpsertApplicationInterview :one
 WITH saved AS (
     INSERT INTO application_interviews (
@@ -243,12 +296,17 @@ WITH saved AS (
     SELECT s.user_id, s.application_id, a.job_id, a.company_slug,
            'interview_scheduled', '', now(), $11::text, s.id
       FROM saved s JOIN applications a ON a.id = s.application_id
-     WHERE s.status = 'confirmed' 
-    -- DO NOTHING rather than a correction. An interview is only ever attached by the
-    -- invitation's own identifier, and an invitation belongs to one application — so the
-    -- application under a given meeting cannot move, and there is nothing to correct.
-    -- Were a weaker tier ever added, this would need the retract-and-re-record treatment
-    -- the mail reconcile uses; it is not a DO NOTHING that would still be right.
+     WHERE s.status = 'confirmed'
+    -- DO NOTHING is right only because RetractMovedInterviewEvent ran first. A re-sync of
+    -- an unmoved meeting must add no second event — the scheduling happened once — and the
+    -- source_ref does not change when a meeting is rescheduled, so this conflict is exactly
+    -- that case.
+    --
+    -- It used to be justified by "the application under a given meeting cannot move", which
+    -- was false: the identifier reaches the application through emails.application_id, a
+    -- column a link correction rewrites. That made this DO NOTHING suppress the CORRECT
+    -- event too. The retract above is what removes the stale row from this partial index,
+    -- so the corrected event can be written.
     ON CONFLICT (user_id, kind, source_ref) WHERE source_ref IS NOT NULL AND retracted_at IS NULL
     DO NOTHING
 )

--- a/internal/platform/db/application_interviews_integration_test.go
+++ b/internal/platform/db/application_interviews_integration_test.go
@@ -10,6 +10,8 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 // seedApplication records an application the real way, so the row under test hangs off
@@ -271,6 +273,80 @@ func TestUpsertApplicationInterview_NotesTheSchedulingOnceInTheLedger(t *testing
 	// itself is in August 2026; this row must not be.
 	if occurred.After(time.Now().Add(time.Minute)) {
 		t.Errorf("the ledger event is dated %v, in the future — occurred_at means when it happened", occurred)
+	}
+}
+
+// A meeting CAN move between applications, which the upsert used to argue it could not.
+// Its identifier reaches the application through emails.application_id, and LinkEmailToJob
+// rewrites that column — reachable from POST /me/emails/:id/link and from the assistant's
+// inbox_link tool. A mis-link is documented as real: docs/agents/mail-stack.md records one
+// company auto-collecting 23 acknowledgements belonging to 23 other employers.
+//
+// The old behaviour was wrong twice over. The stale event could not be corrected
+// (RetractSupersededEmailEvent is scoped to kind = 'employer_reply'), and the correct event
+// was never created either, because source_ref does not change and the upsert's DO NOTHING
+// therefore fired against the right application too. One month view showed the meeting
+// under the right employer and "Interview scheduled" under the wrong one.
+func TestInterviewEventFollowsTheApplicationWhenTheLinkIsCorrected(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	user := seedResponseUser(t, q, "iv-relink@example.test", true)
+	_, wrongApp := seedApplication(t, q, user, "iv-relink-wrong", "wrongco")
+	_, rightApp := seedApplication(t, q, user, "iv-relink-right", "derq")
+	const uid = "relink@ashbyhq.com"
+
+	record := func(appID int64) {
+		t.Helper()
+		if _, err := q.RetractMovedInterviewEvent(ctx, RetractMovedInterviewEventParams{
+			UserID: user, IcalUid: uid, ApplicationID: pgtype.Int8{Int64: appID, Valid: true},
+		}); err != nil {
+			t.Fatalf("retract: %v", err)
+		}
+		if _, err := q.UpsertApplicationInterview(ctx, UpsertApplicationInterviewParams{
+			UserID: user, ApplicationID: appID, IcalUid: uid,
+			StartsAt: ts(time.Date(2026, 8, 13, 9, 0, 0, 0, time.UTC)), Status: "confirmed",
+			Source: "calendar_google", EventSource: "calendar_google",
+		}); err != nil {
+			t.Fatalf("upsert: %v", err)
+		}
+	}
+
+	record(wrongApp)
+	record(wrongApp) // a re-sync of an unmoved meeting must change nothing
+	record(rightApp) // the link correction
+
+	live := func(appID int64) int {
+		t.Helper()
+		var n int
+		if err := q.db.QueryRow(ctx,
+			`SELECT count(*) FROM application_events
+			  WHERE user_id = $1 AND kind = 'interview_scheduled'
+			    AND application_id = $2 AND retracted_at IS NULL`, user, appID).Scan(&n); err != nil {
+			t.Fatalf("count live events: %v", err)
+		}
+		return n
+	}
+
+	if got := live(rightApp); got != 1 {
+		t.Errorf("the corrected application has %d live interview_scheduled events, want 1", got)
+	}
+	if got := live(wrongApp); got != 0 {
+		t.Errorf("the former application kept %d live interview_scheduled events, want 0", got)
+	}
+	// The retraction marks; it never deletes. migrations/0062 defines retracted_at as
+	// "Set when a link correction moves the fact to another employer", and the row stays
+	// as the record that the correction happened.
+	var retracted int
+	if err := q.db.QueryRow(ctx,
+		`SELECT count(*) FROM application_events
+		  WHERE user_id = $1 AND kind = 'interview_scheduled' AND retracted_at IS NOT NULL`,
+		user).Scan(&retracted); err != nil {
+		t.Fatalf("count retracted: %v", err)
+	}
+	if retracted != 1 {
+		t.Errorf("%d retracted events, want exactly the one the correction superseded", retracted)
 	}
 }
 

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -4639,6 +4639,30 @@ type Querier interface {
 	// Withdraw a live claim. Scoped to a non-retracted row so a second retraction affects
 	// nothing and surfaces as not-found, rather than silently re-stamping the date.
 	RetractGhostReport(ctx context.Context, arg RetractGhostReportParams) (GhostReport, error)
+	// Step 1 of recording a meeting: retract the live `interview_scheduled` event when the
+	// meeting has moved to a DIFFERENT application since it was written.
+	//
+	// UpsertApplicationInterview used to argue this could not happen — "an invitation belongs
+	// to one application, so the application under a given meeting cannot move" — and that
+	// premise is false. ListCalendarMatchCandidates reaches a meeting's identifier through
+	// `emails.application_id`, and LinkEmailToJob rewrites that column; it is reachable from
+	// POST /me/emails/:id/link and from the assistant's inbox_link tool. docs/agents/mail-stack.md
+	// records one company auto-collecting 23 acknowledgements belonging to 23 other employers,
+	// so mis-links are a documented, real condition, not a hypothetical one.
+	//
+	// The damage was two-sided. The old event could not be corrected (RetractSupersededEmailEvent
+	// is scoped to kind = 'employer_reply'), and the RIGHT one was never created either, because
+	// the interview's source_ref never changed and the upsert's DO NOTHING therefore fired
+	// against the correct application too. A month view drew the meeting under the right
+	// employer and "Interview scheduled" under the wrong one, with the right application showing
+	// no interview at all. migrations/0062 already states the rule this broke: retracted_at is
+	// "Set when a link correction moves the fact to another employer".
+	//
+	// Separate from the upsert, and run first, for the same snapshot reason
+	// RetractSupersededEmailEvent documents: data-modifying CTEs all read the pre-statement
+	// snapshot, so an insert folded in beside this would still conflict with the row being
+	// retracted and silently record nothing.
+	RetractMovedInterviewEvent(ctx context.Context, arg RetractMovedInterviewEventParams) (int64, error)
 	// Step 1 of reconciling one email with the ledger: retract the live event when the
 	// message is no longer linked, or is now linked to a different application.
 	//

--- a/internal/platform/db/queries/application_interviews.sql
+++ b/internal/platform/db/queries/application_interviews.sql
@@ -1,3 +1,41 @@
+-- name: RetractMovedInterviewEvent :execrows
+-- Step 1 of recording a meeting: retract the live `interview_scheduled` event when the
+-- meeting has moved to a DIFFERENT application since it was written.
+--
+-- UpsertApplicationInterview used to argue this could not happen — "an invitation belongs
+-- to one application, so the application under a given meeting cannot move" — and that
+-- premise is false. ListCalendarMatchCandidates reaches a meeting's identifier through
+-- `emails.application_id`, and LinkEmailToJob rewrites that column; it is reachable from
+-- POST /me/emails/:id/link and from the assistant's inbox_link tool. docs/agents/mail-stack.md
+-- records one company auto-collecting 23 acknowledgements belonging to 23 other employers,
+-- so mis-links are a documented, real condition, not a hypothetical one.
+--
+-- The damage was two-sided. The old event could not be corrected (RetractSupersededEmailEvent
+-- is scoped to kind = 'employer_reply'), and the RIGHT one was never created either, because
+-- the interview's source_ref never changed and the upsert's DO NOTHING therefore fired
+-- against the correct application too. A month view drew the meeting under the right
+-- employer and "Interview scheduled" under the wrong one, with the right application showing
+-- no interview at all. migrations/0062 already states the rule this broke: retracted_at is
+-- "Set when a link correction moves the fact to another employer".
+--
+-- Separate from the upsert, and run first, for the same snapshot reason
+-- RetractSupersededEmailEvent documents: data-modifying CTEs all read the pre-statement
+-- snapshot, so an insert folded in beside this would still conflict with the row being
+-- retracted and silently record nothing.
+UPDATE application_events ae
+SET retracted_at = now()
+FROM application_interviews ai
+WHERE ai.user_id        = sqlc.arg(user_id)
+  AND ai.ical_uid       = sqlc.arg(ical_uid)
+  AND ae.user_id        = ai.user_id
+  AND ae.kind           = 'interview_scheduled'
+  AND ae.source_ref     = ai.id
+  AND ae.retracted_at IS NULL
+  -- Only when it actually moved. A re-sync of an unmoved meeting must leave the ledger
+  -- alone: the scheduling happened once, and re-recording it would date the same fact
+  -- twice.
+  AND ae.application_id IS DISTINCT FROM sqlc.arg(application_id);
+
 -- name: UpsertApplicationInterview :one
 -- Record a meeting the sync attached to an application, or move the one already recorded,
 -- and note in the ledger that the scheduling was observed.
@@ -57,12 +95,17 @@ WITH saved AS (
     SELECT s.user_id, s.application_id, a.job_id, a.company_slug,
            'interview_scheduled', '', now(), sqlc.arg(event_source)::text, s.id
       FROM saved s JOIN applications a ON a.id = s.application_id
-     WHERE s.status = 'confirmed' 
-    -- DO NOTHING rather than a correction. An interview is only ever attached by the
-    -- invitation's own identifier, and an invitation belongs to one application — so the
-    -- application under a given meeting cannot move, and there is nothing to correct.
-    -- Were a weaker tier ever added, this would need the retract-and-re-record treatment
-    -- the mail reconcile uses; it is not a DO NOTHING that would still be right.
+     WHERE s.status = 'confirmed'
+    -- DO NOTHING is right only because RetractMovedInterviewEvent ran first. A re-sync of
+    -- an unmoved meeting must add no second event — the scheduling happened once — and the
+    -- source_ref does not change when a meeting is rescheduled, so this conflict is exactly
+    -- that case.
+    --
+    -- It used to be justified by "the application under a given meeting cannot move", which
+    -- was false: the identifier reaches the application through emails.application_id, a
+    -- column a link correction rewrites. That made this DO NOTHING suppress the CORRECT
+    -- event too. The retract above is what removes the stale row from this partial index,
+    -- so the corrected event can be written.
     ON CONFLICT (user_id, kind, source_ref) WHERE source_ref IS NOT NULL AND retracted_at IS NULL
     DO NOTHING
 )


### PR DESCRIPTION
From the third backend-review pass.

## The premise was false

`UpsertApplicationInterview` wrote its `interview_scheduled` ledger event with `ON CONFLICT DO NOTHING`, justified like this:

> An interview is only ever attached by the invitation's own identifier, and an invitation belongs to one application — so the application under a given meeting cannot move, and there is nothing to correct.

It can move. `ListCalendarMatchCandidates` reaches a meeting's identifier through `emails.application_id`, and `LinkEmailToJob` **rewrites that column** — reachable from `POST /me/emails/:id/link` and from the assistant's `inbox_link` tool. The same statement already moves `application_id = EXCLUDED.application_id` on the interview row itself.

Mis-links are documented as real, not hypothetical: `docs/agents/mail-stack.md` records one company auto-collecting **23 acknowledgements belonging to 23 other employers**.

## The damage was two-sided, which is what hid it

- The stale event **could not be corrected** — `RetractSupersededEmailEvent` is hard-scoped to `kind = 'employer_reply'`.
- The right event was **never created** either, because `source_ref` is the interview's own id and does not change, so the `DO NOTHING` fired against the correct application too.

One month view drew the meeting under the right employer and "Interview scheduled" under the wrong one, while the correct application's panel showed no interview at all.

`migrations/0062` already states the rule this broke: `retracted_at` is *"Set when a link correction moves the fact to another employer"*.

## The fix

`RetractMovedInterviewEvent` is the retract-and-re-record pattern this repository already uses for mail — in its two-statement form, and for the reason that file documents: data-modifying CTEs all read one pre-statement snapshot, so an insert folded in beside the retract would still conflict with the row being retracted and silently record nothing.

It fires only on `IS DISTINCT FROM` the incoming application, so a re-sync of an unmoved meeting leaves the ledger alone — the scheduling happened once.

The `DO NOTHING` stays, and is now right for the reason it was always meant to have: it suppresses a duplicate of the **same** fact, not a correction of a wrong one.

## Also

`calendarapi.go` set `Cancelled: it.Status == "cancelled"` on the live-event branch, which is reached only when the cancelled branch above did not `continue` — so the expression was provably always `false`.

## Verification

- `gofmt -l .` clean; `go build ./...`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`, `golangci-lint` all pass.
- `go test -tags=integration ./internal/platform/db/ ./internal/application/calsync/` passes.
- Confirmed to **fail** without the fix, with exactly the reported symptom:

```
the corrected application has 0 live interview_scheduled events, want 1
the former application kept 1 live interview_scheduled events, want 0
```
