### PR TITLE
Merge the micro1 duplicate, and fix the rule that would have rejected it

### DIFF
--- a/cmd/merge-companies/curated.go
+++ b/cmd/merge-companies/curated.go
@@ -27,18 +27,34 @@ import "github.com/strelov1/freehire/internal/dict/normalize"
 // # What earns an entry
 //
 // The name is the CANDIDATE and the postings are the PROOF. Every pair here was confirmed by
-// counting distinct job titles the two slugs share among their open postings, and the count
-// is recorded beside it. Twenty is the floor used when this list was seeded — below it the
-// overlap stops distinguishing one employer from two that hire for the same roles. `blend` /
-// `blend-360` scored 10 and was left out on exactly that evidence, which is also what the
-// name alone would have got wrong.
+// counting the roles the two slugs share among their open postings, and the count is recorded
+// beside it.
+//
+// Read the overlap as a SHARE of the smaller side, not as an absolute. Twenty was the floor
+// when this list was seeded and it is a sound one against a large duplicate — `blend` /
+// `blend-360` scored 10 and was left out on exactly that evidence, which is what the name
+// alone got wrong. It says nothing at all about a small one: `micro1-ai` carries nine
+// postings in total, so twenty was never reachable and the absolute number would have
+// rejected a pair the domain settles outright.
+//
+// Compare roles, not raw titles. The same posting syndicated twice is "General Counsel" on
+// one board and "General Counsel - Remote" on the other, and an equality on the title scores
+// that pair at ZERO — micro1's did, across 76 legal postings on one side and 9 on the other.
+// Strip the trailing clause first; it is the same normalisation jobhash.RoleKey applies for
+// the same reason.
+//
+// A shared DOMAIN outranks both. If the surviving slug's postings link to the employer's own
+// site and the retiring name reads as that domain (micro1's `req.micro1.ai` beside a board
+// calling itself "micro1 AI"), that is the employer naming itself, and no title count is
+// going to say it more clearly.
 //
 // # How to add one
 //
-//	SELECT count(*) FROM (
-//	  SELECT DISTINCT a.title FROM jobs a JOIN jobs b ON a.title = b.title
-//	  WHERE a.company_slug = '<canonical>' AND b.company_slug = '<retiring>'
-//	    AND a.closed_at IS NULL AND b.closed_at IS NULL) t;
+//	WITH n AS (
+//	  SELECT company_slug, lower(btrim(split_part(title, ' - ', 1))) AS role
+//	  FROM jobs WHERE company_slug IN ('<canonical>', '<retiring>') AND closed_at IS NULL)
+//	SELECT count(DISTINCT a.role) FROM n a JOIN n b ON a.role = b.role
+//	WHERE a.company_slug = '<canonical>' AND b.company_slug = '<retiring>';
 //
 // Then run the worker without --apply and read the plan. The invariants a new entry must
 // hold — canonical slug is a fixed point of the slug rule, and no entry points at a slug
@@ -51,6 +67,14 @@ var curatedAliases = map[string]string{
 	"exadel-inc-website": "exadel",
 	"exadelinc":          "exadel",
 	"exadel-1":           "exadel",
+
+	// micro1 posts from its own domain (req.micro1.ai, 336 open postings); the duplicate is an
+	// Adzuna feed calling the employer "micro1 AI" — the domain read as a name — with 9 legal
+	// postings against micro1's own 76. 3 shared roles out of those 9, and ZERO shared raw
+	// titles, because the feed suffixes every one of them with " - Remote". The pair the
+	// seeded absolute floor would have thrown away, and the reason the paragraph above now
+	// talks about shares and domains.
+	"micro1-ai": "micro1",
 
 	// Numeric board artefacts, each confirmed by shared open titles (the count follows).
 	"aecom2":                   "aecom",         // 1063


### PR DESCRIPTION
## The pair

`micro1` and `micro1-ai` are one employer. `curated.go` as seeded would have rejected them, and both halves of that were the list's fault.

| | `micro1` | `micro1-ai` |
|---|---|---|
| open postings | 795 | 9 |
| legal postings | 76 | 9 |
| job URL hosts | `req.micro1.ai` (336), powertofly, himalayas | `www.adzuna.com` only |
| name | micro1 / Micro1 | "micro1 AI" |

## Two things the floor got wrong

**Exact titles score it at zero.** The Adzuna feed suffixes every posting with `" - Remote"`, so "General Counsel" does not match "General Counsel - Remote". Strip the trailing clause — the same normalisation `jobhash.RoleKey` applies, for the same reason — and 3 roles are shared (`general counsel`, `corporate counsel`, `in-house counsel`).

**Twenty was an absolute where it should have been a share.** `micro1-ai` holds nine postings in total, so twenty was unreachable no matter how completely it duplicated the other side.

**And the strongest evidence is neither.** `micro1` posts from `req.micro1.ai`; the duplicate is a feed calling the employer "micro1 AI" — the domain read back as a name. That is the employer naming itself.

## What changed

`curated.go`'s "what earns an entry" now reads shares rather than absolutes, compares roles rather than raw titles, and says the domain outranks both. The worked query beside it does the stripping.

The `blend` / `blend-360` rejection is untouched and still correct under the new wording: 10 shared against 141 open postings is a small share of a large side, which is what the floor was always for.

## Note

`micro1-ai` is the last entry to be added this way. The list is moving into `company_slug_aliases` — the table already exists to hold exactly this kind of human decision, and a row there is the decision rather than a second copy of it. Separate PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated curated-alias guidance to describe shared-role percentages, normalized role comparisons, and domain evidence.
  * Added the `micro1-ai` to `micro1` curated alias with supporting overlap and domain details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->