### PR TITLE
Say that a public read is budgeted by address, which is what it always did

### DIFF
--- a/internal/api/handler/handler.go
+++ b/internal/api/handler/handler.go
@@ -792,7 +792,7 @@ func Register(app *fiber.App, cfg Config) {
 	billingH.register(api, mw)
 	// Mounted whatever billing is doing: sharing an invite link and counting who came is
 	// not a purchase, and a deployment that sells nothing can still have a referral page.
-	promoH.register(api, mw, cfg.Throttler)
+	promoH.register(api, mw)
 	plansH.register(api)
 	usageH.register(api, mw)
 

--- a/internal/api/handler/promo.go
+++ b/internal/api/handler/promo.go
@@ -50,14 +50,20 @@ func newPromoHandlers(svc *promo.Service) *promoHandlers {
 	return &promoHandlers{promo: svc}
 }
 
-func (h *promoHandlers) register(api fiber.Router, mw middleware, throttler ratelimit.Throttler) {
+// register mounts the referral and promo routes.
+//
+// It takes no separate Throttler: mw already carries the same one (handler.go builds the
+// bundle with cfg.Throttler and passed cfg.Throttler here as well), and this was the only
+// register of 47 with a third parameter. internal/api/handler/AGENTS.md says the bundle
+// field exists for exactly this.
+func (h *promoHandlers) register(api fiber.Router, mw middleware) {
 	// Cookie only, like the rest of /me. A link that decides who gets credited for a
 	// referral is minted for a browser session, not for a script holding a key.
 	api.Get("/me/invite", mw.cookie, h.Invite)
 
-	perAccount := ratelimit.Middleware(throttler,
+	perAccount := ratelimit.Middleware(mw.throttler,
 		ratelimit.KeyByUserOrIP("promo"), promoPreviewPerMinute, time.Minute)
-	perAddress := ratelimit.Middleware(throttler,
+	perAddress := ratelimit.Middleware(mw.throttler,
 		ratelimit.KeyByIP("promoaddr"), promoPreviewPerAddressPerMinute, time.Minute)
 
 	api.Post("/me/promo/preview", mw.cookie, perAccount, perAddress, h.PreviewCode)

--- a/internal/api/handler/public_read_limit.go
+++ b/internal/api/handler/public_read_limit.go
@@ -44,23 +44,40 @@ const (
 	suggestPerMinute = 1200
 )
 
-// publicReadLimiter throttles the cheap public reads as one shared budget.
+// All three below are keyed by IP, and deliberately: on a PUBLIC read there is no
+// authenticated caller to key by.
 //
-// Keyed by user-or-IP rather than by IP alone. Not to grant an authenticated
-// caller a larger allowance — the ceiling is identical either way — but so that
-// callers sharing an egress address do not share an allowance.
+// They used to ask for user-or-IP and say so, and the branch was dead. Fiber runs a
+// route's handlers in registration order, and every public read registers its limiter
+// BEFORE the optional-auth gate (jobs.go, companies.go, search.go) or without a gate at
+// all (geo.go, suggest.go) — there is no group-level auth, handler.go builds /api/v1 with
+// no .Use. So `auth.UserID` read a local nothing had written yet and the key was always
+// the IP form. Fifty signed-in colleagues behind one office NAT already shared one budget;
+// the comment claiming otherwise was the only thing that changed.
+//
+// Moving the gate in front would have fixed three of the ten routes and put a database
+// lookup ahead of throttling on the hottest reads on the site — OptionalAuth answers 503
+// when a Bearer-key lookup fails, so it is not free — against a host where crawlers are
+// most of the traffic. Deleting the unreachable branch is the smaller answer, and the
+// allowance was never per-user in production anyway.
+//
+// The tests below mount the gate FIRST, so an authenticated caller really is
+// authenticated when the limiter runs. That is what makes them a guard: they fail if
+// anyone reintroduces a user-keyed budget here, whatever the ordering.
+
+// publicReadLimiter throttles the cheap public reads as one shared budget.
 func publicReadLimiter(throttler ratelimit.Throttler) fiber.Handler {
-	return ratelimit.Middleware(throttler, ratelimit.KeyByUserOrIP("publicread"), publicReadsPerMinute, time.Minute)
+	return ratelimit.Middleware(throttler, ratelimit.KeyByIP("publicread"), publicReadsPerMinute, time.Minute)
 }
 
 // agentSearchLimiter throttles the full-description search on its own budget, so
 // exhausting it leaves the ordinary search endpoints serving.
 func agentSearchLimiter(throttler ratelimit.Throttler) fiber.Handler {
-	return ratelimit.Middleware(throttler, ratelimit.KeyByUserOrIP("agentsearch"), agentSearchPerMinute, time.Minute)
+	return ratelimit.Middleware(throttler, ratelimit.KeyByIP("agentsearch"), agentSearchPerMinute, time.Minute)
 }
 
 // suggestLimiter throttles the search box's completions on their own budget, so a
 // visitor typing quickly cannot exhaust the allowance the rest of the site reads on.
 func suggestLimiter(throttler ratelimit.Throttler) fiber.Handler {
-	return ratelimit.Middleware(throttler, ratelimit.KeyByUserOrIP("suggest"), suggestPerMinute, time.Minute)
+	return ratelimit.Middleware(throttler, ratelimit.KeyByIP("suggest"), suggestPerMinute, time.Minute)
 }

--- a/internal/api/handler/public_read_limit_test.go
+++ b/internal/api/handler/public_read_limit_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/strelov1/freehire/internal/api/ratelimit"
+	"github.com/strelov1/freehire/internal/identity/auth"
 )
 
 // TestPublicReadBudgets_ClearTheMeasuredLivePeaks guards the numbers themselves.
@@ -51,6 +52,51 @@ func (o *oneShotThrottler) Allow(_ context.Context, key string, limit int, windo
 	}
 	o.seen[key] = true
 	return ratelimit.Decision{Allowed: true, Limit: limit, Remaining: limit - 1, ResetAfter: window}, nil
+}
+
+// A public read is budgeted per IP even for a signed-in caller — the decision this
+// records, in place of a comment that claimed the opposite while the code did this.
+//
+// The gate is mounted FIRST here, unlike production, so an authenticated caller really is
+// authenticated by the time the limiter runs. That is what makes this a guard rather than
+// a description: with a user-keyed budget it fails whatever the mounting order, and the
+// defect it replaces was precisely a claim that only held in one order.
+//
+// The cost is stated rather than hidden: colleagues behind one office NAT share the
+// allowance. They always did — every public read registers its limiter before the
+// optional-auth gate, or has no gate at all, so `auth.UserID` never saw a user here.
+func TestPublicReadLimiter_BudgetsBySourceAddressEvenForASignedInCaller(t *testing.T) {
+	th := newOneShotThrottler()
+
+	app := fiber.New(fiber.Config{ProxyHeader: fiber.HeaderXForwardedFor})
+	signIn := func(id int64) fiber.Handler {
+		return func(c *fiber.Ctx) error {
+			c.Locals(auth.LocalsUserID, id)
+			return c.Next()
+		}
+	}
+	ok := func(c *fiber.Ctx) error { return c.SendStatus(fiber.StatusOK) }
+	// Gate before limiter, so the limiter sees a real authenticated caller.
+	app.Get("/one", signIn(101), publicReadLimiter(th), ok)
+	app.Get("/two", signIn(202), publicReadLimiter(th), ok)
+
+	get := func(path string) int {
+		req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, path, nil)
+		req.Header.Set(fiber.HeaderXForwardedFor, "203.0.113.42")
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	if got := get("/one"); got != fiber.StatusOK {
+		t.Fatalf("first read = %d, want 200", got)
+	}
+	if got := get("/two"); got != fiber.StatusTooManyRequests {
+		t.Errorf("a different signed-in user on the same address = %d, want 429 — the public read budget is per address", got)
+	}
 }
 
 // TestPublicReadLimiters_DoNotShareABudget pins that the two classes are keyed

--- a/openspec/specs/api-rate-limiting/spec.md
+++ b/openspec/specs/api-rate-limiting/spec.md
@@ -141,9 +141,21 @@ single shared budget would have to be sized for the expensive endpoint, and
 would then throttle the cheap ones far harder than their cost justifies.
 
 Each budget SHALL be namespaced separately, so exhausting one leaves the other
-untouched, and SHALL identify an authenticated caller by user rather than by
-address — not to grant a larger allowance, which this change does not do, but so
-that callers sharing an egress address do not share an allowance.
+untouched, and SHALL identify a caller by source address.
+
+This once said "by user rather than by address … so that callers sharing an egress
+address do not share an allowance". That was never how it behaved. Fiber runs a route's
+handlers in registration order, and every public read mounts its limiter before the
+optional-auth gate or without a gate at all, so the user branch read a value nothing had
+written and the key was always the address. Moving the gate would have fixed three of ten
+routes and put a database lookup ahead of throttling on the hottest reads on the site;
+naming what actually happens is the smaller answer, and the cost — colleagues behind one
+office NAT sharing a budget — is one this endpoint has always carried.
+
+#### Scenario: A signed-in caller is budgeted by address like any other
+
+- **WHEN** two signed-in callers read a public endpoint from the same source address
+- **THEN** they draw on the same budget
 
 #### Scenario: Exhausting the agent search budget leaves ordinary search available
 


### PR DESCRIPTION
From the third backend-review pass.

## The branch was unreachable

The three public-read limiters asked `ratelimit.KeyByUserOrIP` and documented the reason — *"so that callers sharing an egress address do not share an allowance"* — and the user branch never ran.

`KeyByUserOrIP` reads `c.Locals(auth.LocalsUserID)`, which only a middleware that **ran** writes, and Fiber executes a route's handlers in registration order. Every public read mounts its limiter **before** the optional-auth gate:

| route | mounting |
|---|---|
| `jobs.go:52` | `api.Get("/jobs/:slug", readLimit, mw.optional, h.GetJob)` |
| `companies.go:39` | limiter first |
| `search.go:66` | limiter first |
| `geo.go:24`, `suggest.go:33` | **no gate at all** |

And there is no group-level auth — `handler.go` builds `/api/v1` with no `.Use`. So the key was always the address form. Fifty signed-in colleagues behind one office NAT already shared one budget, and a signed-in scraper already got exactly what an anonymous one got.

The authorized limiters (`photo.go`, `promo.go`, `jd_resolve.go`, `gmail.go`, `match_analysis.go`) mount their gate first and work — which is why the broken three were easy to miss.

## Why delete the branch rather than move the gate

Moving the gate would fix three routes of ten; the other seven have no gate to move. It would also put a database lookup ahead of throttling on the hottest reads on the site — `OptionalAuth` answers 503 when a Bearer-key lookup fails, so it is not free — on a host where crawlers are most of the traffic.

Deleting the unreachable branch removes a complexity instead of trading it for another, and the allowance was never per-user in production anyway. The cost is now **stated** rather than contradicted.

`openspec/specs/api-rate-limiting/spec.md` carried the same false claim and now carries what happens, plus a scenario for it.

## The test is the part worth reading

The existing tests mount limiters on a bare `fiber.New()` and **cannot observe ordering in principle** — which is how this survived.

The new one mounts the auth gate **first**, unlike production, so an authenticated caller really is authenticated when the limiter runs. That makes it a guard rather than a description: it fails if anyone reintroduces a user-keyed budget here, in either mounting order.

Confirmed by restoring `KeyByUserOrIP`: the second signed-in caller on the same address was served instead of refused.

## Also

`promoHandlers.register` drops its third parameter. It was the only `register` of 47 taking a `Throttler` separately, and `handler.go` passed it the same `cfg.Throttler` already in the middleware bundle — which `internal/api/handler/AGENTS.md` says the field exists for.

## Verification

`gofmt -l .` clean; `go build ./...`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`, `golangci-lint` all pass. Targeted handler integration tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Public read rate limits are now consistently applied by source IP address, including for signed-in callers.
  * Callers sharing an IP address now share the same rate-limit budget for public read endpoints.

* **Documentation**
  * Updated API rate-limiting documentation to reflect address-based budgeting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->