### PR TITLE
Refuse auto-apply enqueue on a known work-auth or location mismatch

### DIFF
--- a/internal/api/atsapply/AGENTS.md
+++ b/internal/api/atsapply/AGENTS.md
@@ -87,6 +87,21 @@ decision for the measurements and its caveats.
   call, sensitive-keyword gate, never an agentic loop). A drafted answer is still checked
   against the field's own offered options (`matchOption`, shared with the deterministic
   path) before it is used.
+- **A geography/residency question (`geography.go`) parks before drafting too, for a
+  different reason than the sensitive gate.** `sensitiveTerms` (`sensitive.go`) parks a
+  question on POLICY grounds — compensation, EEO/demographic, work authorization/visa —
+  regardless of how confident a draft would be. `geographyTerms` exists because the
+  pipeline cannot VERIFY an answer: `candidateprofile` carries one free-text `location`
+  string, never a discrete country/state-of-residence fact matching a platform's own
+  enumerated dropdown options, so a drafted answer here would be invented, not reported.
+  Found live: a Garner Health Greenhouse posting's "Current State of Residence" (a
+  US-states-only dropdown) reached the drafter and was saved from a wrong submission only
+  because the candidate's non-US address happened to match none of the offered options —
+  `isGeographyLabel` makes that a designed park instead of an accident of one form's own
+  option list (`openspec/changes/add-auto-apply-eligibility-gate`). Checked in
+  `draftable` (`draft.go`) alongside `isSensitiveLabel`, before the drafter is ever
+  invoked; a geography-labeled field already resolvable from a known answer (e.g.
+  `location`) is unaffected and fills exactly as before.
 - **The sensitive-keyword gate (`sensitive.go`) runs before the model is ever called, and
   wins absolutely.** A question whose label matches — compensation, work authorization/visa
   sponsorship, or an EEO/demographic category — is never drafted, regardless of how

--- a/internal/api/atsapply/draft.go
+++ b/internal/api/atsapply/draft.go
@@ -23,7 +23,9 @@ type Drafter interface {
 // the empty-string case slipped through isSensitiveLabel's Contains checks), a kind a
 // free-text or single-choice answer actually fits (never a file — see resolveOne's file
 // case — and never a checkbox_group, which resolveOne's own Multi note already scopes
-// out), and not sensitive.
+// out), not sensitive, and not a geography/residency question (geography.go) — a
+// different reason to park (unverifiable, not off-limits) but the same outcome: never
+// reaches the model.
 func draftable(f MergedField) bool {
 	if !f.Required || f.Label == "" {
 		return false
@@ -33,7 +35,7 @@ func draftable(f MergedField) bool {
 	default:
 		return false
 	}
-	return !isSensitiveLabel(f.Label)
+	return !isSensitiveLabel(f.Label) && !isGeographyLabel(f.Label)
 }
 
 // ResolveWithDrafting runs the deterministic Resolve pass first, then offers the drafter

--- a/internal/api/atsapply/draft_test.go
+++ b/internal/api/atsapply/draft_test.go
@@ -161,6 +161,41 @@ func TestResolveWithDrafting_ADrafterErrorPropagates(t *testing.T) {
 	}
 }
 
+func TestResolveWithDrafting_NeverDraftsAGeographyField(t *testing.T) {
+	fields := []MergedField{{ID: "question_9", Label: "Current State of Residence", Kind: "select", Required: true}}
+	drafter := &fakeDrafter{answer: "should never be used", ok: true}
+
+	plan, err := ResolveWithDrafting(context.Background(), fields, map[string]string{}, drafter, GroundingContext{}, false)
+	if err != nil {
+		t.Fatalf("ResolveWithDrafting: %v", err)
+	}
+	if len(drafter.calls) != 0 {
+		t.Fatalf("Draft calls = %v, want none — a geography field must never reach the drafter", drafter.calls)
+	}
+	if len(plan.Unmapped) != 1 || plan.Unmapped[0].ID != "question_9" {
+		t.Fatalf("unmapped = %+v, want the geography field parked", plan.Unmapped)
+	}
+}
+
+func TestResolveWithDrafting_AGeographyFieldAlreadyMappedByIDIsStillFilled(t *testing.T) {
+	// A geography-labeled field that already resolves deterministically (e.g. the
+	// candidate's known "location" answer) is filled exactly as before this rule
+	// existed — the park check only ever applies to what Resolve left unmapped.
+	fields := []MergedField{{ID: "location", Label: "Current State of Residence", Kind: "text", Required: true}}
+	drafter := &fakeDrafter{answer: "should never be used", ok: true}
+
+	plan, err := ResolveWithDrafting(context.Background(), fields, map[string]string{"location": "Florianópolis, Brazil"}, drafter, GroundingContext{}, false)
+	if err != nil {
+		t.Fatalf("ResolveWithDrafting: %v", err)
+	}
+	if len(drafter.calls) != 0 {
+		t.Errorf("Draft calls = %v, want none — the field already resolved deterministically", drafter.calls)
+	}
+	if len(plan.Fields) != 1 || plan.Fields[0].Value != "Florianópolis, Brazil" {
+		t.Fatalf("plan.Fields = %+v, want the known location answer", plan.Fields)
+	}
+}
+
 // Found by code review: isSensitiveLabel("") is unconditionally false (an empty string
 // contains no keyword), so a DOM-only field the platform's schema never labeled — exactly
 // the shape reconcile.go's own test cites an EEOC/demographic field as the canonical

--- a/internal/api/atsapply/geography.go
+++ b/internal/api/atsapply/geography.go
@@ -1,0 +1,37 @@
+package atsapply
+
+import "strings"
+
+// geographyTerms identifies a required question asking about the candidate's residency,
+// citizenship-adjacent location, or where they are based — distinct from sensitiveTerms
+// (sensitive.go), which parks on POLICY grounds (a category the model must never be
+// trusted to answer regardless of confidence). A geography question parks because the
+// pipeline cannot VERIFY an answer against it: candidateprofile carries one free-text
+// `location` string, never a discrete country/state-of-residence fact matching a
+// platform's own enumerated options, so any answer here would be the drafter inventing a
+// value rather than reporting one the candidate actually gave (see
+// openspec/changes/add-auto-apply-eligibility-gate).
+//
+// Seeded from the live Garner Health Greenhouse posting's own wording ("Current State of
+// Residence") plus the country/residency equivalents the same shape of question takes on
+// other platforms. Deliberately narrower than sensitiveTerms' "authoriz"/"visa"/"sponsor"
+// terms, which already park a work-authorization question through a different rule.
+var geographyTerms = []string{
+	"state of residence", "country of residence", "residency",
+	"currently reside", "currently located", "where are you based",
+	"must be based in", "must reside", "must be located",
+}
+
+// isGeographyLabel reports whether a question's label asks about the candidate's
+// residency or physical base — checked by draftable (draft.go) ahead of drafting, so a
+// required geography question a candidate has not answered parks instead of receiving an
+// invented value.
+func isGeographyLabel(label string) bool {
+	lower := strings.ToLower(label)
+	for _, term := range geographyTerms {
+		if strings.Contains(lower, term) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/atsapply/geography_test.go
+++ b/internal/api/atsapply/geography_test.go
@@ -1,0 +1,58 @@
+package atsapply
+
+import "testing"
+
+// The live Garner Health Greenhouse posting's own wording, the case this rule exists for.
+func TestIsGeographyLabel_CatchesTheLiveGarnerHealthWording(t *testing.T) {
+	if !isGeographyLabel("Current State of Residence") {
+		t.Error("want the live posting's residency question recognized")
+	}
+}
+
+func TestIsGeographyLabel_CatchesEveryTerm(t *testing.T) {
+	labels := []string{
+		"What is your state of residence?",
+		"What is your country of residence?",
+		"What is your residency status?",
+		"Where do you currently reside?",
+		"Where are you currently located?",
+		"Where are you based?",
+		"This role must be based in the United States.",
+		"You must reside in a state where we are registered to hire.",
+		"This position must be located in an eligible state.",
+	}
+	for _, label := range labels {
+		if !isGeographyLabel(label) {
+			t.Errorf("isGeographyLabel(%q) = false, want true", label)
+		}
+	}
+}
+
+func TestIsGeographyLabel_LeavesOrdinaryQuestionsAlone(t *testing.T) {
+	labels := []string{
+		"What is your LinkedIn profile?",
+		"Why do you want to work here?",
+		"Do you have advanced proficiency in German?",
+		"What is your phone number?",
+	}
+	for _, label := range labels {
+		if isGeographyLabel(label) {
+			t.Errorf("isGeographyLabel(%q) = true, want false", label)
+		}
+	}
+}
+
+func TestIsGeographyLabel_LeavesWorkAuthorizationToTheSensitiveGate(t *testing.T) {
+	// "Do you have work authorization..." is already parked by isSensitiveLabel's
+	// "authoriz" term; geography.go exists for the residency shape that gate misses, not
+	// as a second path to the same outcome.
+	if isGeographyLabel("Do you have legal authorization to work in this country?") {
+		t.Error("want work-authorization wording left to isSensitiveLabel, not duplicated here")
+	}
+}
+
+func TestIsGeographyLabel_IsCaseInsensitive(t *testing.T) {
+	if !isGeographyLabel("CURRENT STATE OF RESIDENCE") {
+		t.Error("want the geography check to ignore case")
+	}
+}

--- a/internal/api/handler/auto_apply_eligibility_test.go
+++ b/internal/api/handler/auto_apply_eligibility_test.go
@@ -1,0 +1,82 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/strelov1/freehire/internal/candidate/hardconstraint"
+)
+
+// A plain env read, not memoized (see autoApplyEligibilityEnforce's doc comment) — this
+// is what makes it possible to test both branches with t.Setenv in one test binary at
+// all, which a sync.OnceValue-memoized version (an earlier draft of this flag) could not.
+func TestAutoApplyEligibilityEnforce_ReadsTheEnvVarEachCall(t *testing.T) {
+	t.Setenv("AUTO_APPLY_ELIGIBILITY_ENFORCE", "")
+	if autoApplyEligibilityEnforce() {
+		t.Error("want shadow mode (false) when the env var is unset")
+	}
+	t.Setenv("AUTO_APPLY_ELIGIBILITY_ENFORCE", "1")
+	if !autoApplyEligibilityEnforce() {
+		t.Error("want enforced (true) once the env var is set to 1")
+	}
+	t.Setenv("AUTO_APPLY_ELIGIBILITY_ENFORCE", "")
+	if autoApplyEligibilityEnforce() {
+		t.Error("want shadow mode (false) again once the env var is cleared")
+	}
+}
+
+func TestFirstEligibilityBlocker_ReturnsAnUnmetWorkAuthBlocker(t *testing.T) {
+	blockers := []hardconstraint.Blocker{
+		{Category: hardconstraint.CategoryExperience, Met: false},
+		{Category: hardconstraint.CategoryWorkAuth, Met: false, Reason: "no visa sponsorship"},
+	}
+	b, ok := firstEligibilityBlocker(blockers)
+	if !ok {
+		t.Fatal("want a blocker, got none")
+	}
+	if b.Category != hardconstraint.CategoryWorkAuth || b.Reason != "no visa sponsorship" {
+		t.Errorf("blocker = %+v, want the work-authorization one", b)
+	}
+}
+
+func TestFirstEligibilityBlocker_ReturnsAnUnmetLocationBlocker(t *testing.T) {
+	blockers := []hardconstraint.Blocker{
+		{Category: hardconstraint.CategoryLocationWorkMode, Met: false, Reason: "on-site in US"},
+	}
+	b, ok := firstEligibilityBlocker(blockers)
+	if !ok || b.Category != hardconstraint.CategoryLocationWorkMode {
+		t.Fatalf("blocker = %+v, ok = %v, want the location-and-work-mode one", b, ok)
+	}
+}
+
+func TestFirstEligibilityBlocker_IgnoresIrrelevantCategories(t *testing.T) {
+	// Experience/education/certification/language bear on fit, not on whether the
+	// submission itself would misrepresent the candidate — never a gate reason.
+	blockers := []hardconstraint.Blocker{
+		{Category: hardconstraint.CategoryExperience, Met: false},
+		{Category: hardconstraint.CategoryEducation, Met: false},
+		{Category: hardconstraint.CategoryCertification, Met: false},
+		{Category: hardconstraint.CategoryLanguage, Met: false},
+	}
+	if _, ok := firstEligibilityBlocker(blockers); ok {
+		t.Error("want no gate blocker among non-eligibility categories")
+	}
+}
+
+func TestFirstEligibilityBlocker_IgnoresMetBlockers(t *testing.T) {
+	blockers := []hardconstraint.Blocker{
+		{Category: hardconstraint.CategoryWorkAuth, Met: true},
+		{Category: hardconstraint.CategoryLocationWorkMode, Met: true},
+	}
+	if _, ok := firstEligibilityBlocker(blockers); ok {
+		t.Error("want no gate blocker when every eligibility category is met")
+	}
+}
+
+func TestFirstEligibilityBlocker_NoBlockersAtAllProceeds(t *testing.T) {
+	// Missing evidence on either side means hardconstraint.Evaluate emits no blocker at
+	// all for that category — never emit a false blocker — so an empty slice must not be
+	// treated as a mismatch.
+	if _, ok := firstEligibilityBlocker(nil); ok {
+		t.Error("want no gate blocker for an empty evaluation")
+	}
+}

--- a/internal/api/handler/auto_apply_enqueue.go
+++ b/internal/api/handler/auto_apply_enqueue.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"os"
 	"strconv"
 
 	"github.com/gofiber/fiber/v2"
@@ -11,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/ai/plan"
+	"github.com/strelov1/freehire/internal/candidate/hardconstraint"
 	"github.com/strelov1/freehire/internal/platform/db"
 )
 
@@ -71,6 +73,65 @@ func autoApplyQueuedResponse(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"data": fiber.Map{"status": autoApplyStatusQueued}})
 }
 
+// autoApplyEligibilityEnforce gates whether an eligibility mismatch (see
+// eligibilityBlocker) actually refuses enqueueing or only logs what would have been
+// refused. Ships OFF (shadow-only) by default, mirroring internal/ai/plan's PLAN_ENFORCE
+// rollout: a false positive here has an immediate, visible cost — a paying candidate who
+// cannot auto-apply to a job they are, in fact, eligible for — so it earns the same
+// observe-then-enforce caution before being flipped on.
+//
+// Reads os.Getenv on every call rather than memoizing: the read itself is a cheap map
+// lookup, and memoizing (e.g. via sync.OnceValue) would freeze whichever value the FIRST
+// call happened to see for the rest of the process — including a test binary, where
+// t.Setenv could then never make a later test see a different value.
+// See openspec/changes/add-auto-apply-eligibility-gate.
+func autoApplyEligibilityEnforce() bool {
+	return os.Getenv("AUTO_APPLY_ELIGIBILITY_ENFORCE") == "1"
+}
+
+// autoApplyEligibilityMismatchPrefix is what a caller sees when the eligibility gate
+// refuses to enqueue — distinct from a generic failure, naming the reason so the
+// candidate understands why (and does not read it as a transient error worth retrying).
+const autoApplyEligibilityMismatchPrefix = "this job's requirements do not match your profile: "
+
+// eligibilityBlocker reports the first unmet work-authorization or location-and-work-mode
+// blocker for the (userID, job) pair, reusing the same deterministic evaluator and input
+// assembly the match-analysis surface already uses (h.cv.match.jobBlockers) — see
+// internal/candidate/hardconstraint. Every other blocker category (experience, education,
+// certification, language) is irrelevant here: those bear on whether the candidate is a
+// good FIT, not on whether submitting the application would misrepresent them.
+//
+// Degrades to "no blocker" (never refuses) whenever the evaluation cannot be run at all —
+// no wired profile/résumé service, no profile, no structured résumé — the same
+// "never emit a false blocker" discipline hardconstraint itself follows: absence of
+// evidence is never treated as evidence of ineligibility.
+func (h *assistantHandlers) eligibilityBlocker(ctx context.Context, userID int64, job db.Job) (hardconstraint.Blocker, bool) {
+	if h.cv == nil || h.cv.match == nil || h.profile == nil || h.profile.userProfile == nil {
+		return hardconstraint.Blocker{}, false
+	}
+	profile, err := h.profile.userProfile.Get(ctx, userID)
+	if err != nil {
+		return hardconstraint.Blocker{}, false
+	}
+	return firstEligibilityBlocker(h.cv.match.jobBlockers(ctx, userID, job, profile))
+}
+
+// firstEligibilityBlocker is the pure decision this gate makes: the first unmet
+// work-authorization or location-and-work-mode entry among the blockers the evaluator
+// already computed. Split out from eligibilityBlocker so this filtering — the actual
+// policy — is unit-testable without a résumé store or a profile service.
+func firstEligibilityBlocker(blockers []hardconstraint.Blocker) (hardconstraint.Blocker, bool) {
+	for _, b := range blockers {
+		if b.Met {
+			continue
+		}
+		if b.Category == hardconstraint.CategoryWorkAuth || b.Category == hardconstraint.CategoryLocationWorkMode {
+			return b, true
+		}
+	}
+	return hardconstraint.Blocker{}, false
+}
+
 // PostJobAutoApply is the candidate-facing trigger auto-apply-tailored-resume and
 // auto-apply-inngest-orchestration both assumed would exist: it creates one durable
 // auto-apply attempt for the caller and the named job, starting the already-built
@@ -119,6 +180,26 @@ func (h *assistantHandlers) PostJobAutoApply(c *fiber.Ctx) error {
 		return err
 	} else if applied {
 		return fiber.NewError(fiber.StatusConflict, "already applied to this job")
+	}
+
+	// Eligibility gate (openspec/changes/add-auto-apply-eligibility-gate): refuse — or, in
+	// shadow mode, merely log — enqueueing a pair the candidate's own known
+	// work-authorization or location evidence positively conflicts with. Runs before the
+	// allowance charge, like every other gate in this handler, so a refused request costs
+	// nothing.
+	if b, mismatched := h.eligibilityBlocker(c.Context(), userID, job); mismatched {
+		enforced := autoApplyEligibilityEnforce()
+		// Logged in both modes — tagged by category — so the false-positive rate among
+		// Pro candidates can be read from shadow-mode logs before enforcement is flipped
+		// on, and stays observable afterward too (see design.md's Migration Plan).
+		verb := "would refuse"
+		if enforced {
+			verb = "refused"
+		}
+		log.Printf("auto-apply: eligibility gate %s user %d job %d (%s): %s", verb, userID, job.ID, b.Category, b.Reason)
+		if enforced {
+			return fiber.NewError(fiber.StatusConflict, autoApplyEligibilityMismatchPrefix+b.Reason)
+		}
 	}
 
 	// The allowance, and it replaces the plan-tier check this route used to make: free is

--- a/internal/application/autoapply/AGENTS.md
+++ b/internal/application/autoapply/AGENTS.md
@@ -55,6 +55,21 @@ application, and record the outcome. Pgx/Fiber-free — `Store`, `AnswerSource` 
   unresolved form field does, through its own review endpoint (`internal/api/handler`), not
   through anything in this package.
 
+- **An enqueue-time eligibility gate refuses (or, in shadow mode, only logs) a positively
+  mismatched (candidate, job) pair before it ever reaches this package's queue at all.**
+  `internal/api/handler`'s `PostJobAutoApply` (the only writer of `auto_apply_queue`, see
+  below) calls `internal/candidate/hardconstraint.Evaluate` — the same deterministic,
+  no-I/O evaluator the match-analysis surface already uses advisorily — and refuses
+  enqueueing when it reports an unmet `work-authorization` or `location-and-work-mode`
+  blocker for the pair. Gated behind `AUTO_APPLY_ELIGIBILITY_ENFORCE` (unset = shadow:
+  logs what would have been refused and enqueues anyway), mirroring `internal/ai/plan`'s
+  `PLAN_ENFORCE` rollout — a false positive here has an immediate, visible cost for a
+  paying candidate, so it earns the same observe-then-enforce caution
+  (`openspec/changes/add-auto-apply-eligibility-gate`). This is entirely upstream of this
+  package: `Run`/`process` never see a row this gate refused, and a row it lets through
+  with missing evidence on either side is not evidence of ineligibility — the gate,
+  like the evaluator it calls, never manufactures a blocker from an absent field.
+
 ## How it works
 `Run` wires `outbox.RunPool` over `Store.Claim`, mirroring `internal/applyform`'s own
 `cmd/capture-apply-form` runner shape. `process` per claimed item: assemble answers → call

--- a/internal/candidate/hardconstraint/hardconstraint.go
+++ b/internal/candidate/hardconstraint/hardconstraint.go
@@ -4,10 +4,19 @@
 // internal/candidate/jobmatch and internal/dict/classify: a category is judged only when BOTH
 // sides carry data, so a missing field is skipped, never a false blocker.
 //
-// The blockers are advisory. They surface on the profile-match bar, cap the
-// server-owned overall_score in the LLM fit analysis (a ceiling the model cannot
-// exceed), and feed anti-hallucination guardrails into the tailor — but they
-// never hide or downrank a job.
+// The blockers are advisory at every call site that reads them for a human to act on.
+// They surface on the profile-match bar, cap the server-owned overall_score in the LLM
+// fit analysis (a ceiling the model cannot exceed), and feed anti-hallucination
+// guardrails into the tailor — but they never hide or downrank a job at any of those
+// sites.
+//
+// One caller reads them differently: internal/api/handler's auto-apply enqueue gate
+// (openspec/changes/add-auto-apply-eligibility-gate) treats an unmet work-authorization
+// or location-and-work-mode entry as a reason to refuse an UNATTENDED submission outright
+// — there is no human in that loop to see an advisory warning and decide for themselves.
+// This is a property of that caller's stakes, not a second meaning for Evaluate's output:
+// the package itself, its "never emit a false blocker" discipline, and every other
+// caller's advisory-only treatment are unchanged.
 package hardconstraint
 
 import (

--- a/openspec/changes/archive/2026-09-06-add-auto-apply-eligibility-gate/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-06-add-auto-apply-eligibility-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-06

--- a/openspec/changes/archive/2026-09-06-add-auto-apply-eligibility-gate/design.md
+++ b/openspec/changes/archive/2026-09-06-add-auto-apply-eligibility-gate/design.md
@@ -1,0 +1,117 @@
+## Context
+
+See proposal.md - Why for the motivating gap and the live Garner Health case.
+
+Two independent places in today's pipeline could, in principle, catch a
+work-authorization/residency mismatch, and neither does on purpose:
+
+- `PostJobAutoApply` (`internal/api/handler/auto_apply_enqueue.go`) gates enqueueing on
+  ATS support, Pro plan, CV presence, and "not already applied" only.
+- `internal/candidate/hardconstraint.Evaluate(JobRequirements, CVEvidence) []Blocker`
+  already compares exactly this evidence — `work-authorization` (job's
+  `enrichment.visa_sponsorship` + `job.Countries` vs. the candidate's asserted-or-derived
+  `CountryCode`) and `location-and-work-mode` (`job.WorkMode` + `job.Countries` vs.
+  `CountryCode` + `PrefersRemote`) — but every existing caller
+  (`JobMatch`, match-analysis scoring) treats its output as advisory only: per the
+  package's own doc comment, a blocker "never hides or downranks a job." The assembly
+  that builds `JobRequirements`/`CVEvidence` from a `db.Job` and a candidate's profile
+  already lives in the same package as `PostJobAutoApply`
+  (`internal/api/handler/hardconstraint_inputs.go`'s `jobBlockers` /
+  `buildHardConstraintInputs`), so the enqueue path can call the same helper rather than
+  reassembling the inputs.
+
+Separately, `internal/api/atsapply`'s field resolution (`resolve.go` → `draft.go`) has no
+concept of a geography/residency question at all. A required question is parked only if
+its label matches the existing `sensitiveTerms` list (compensation, visa/sponsorship,
+EEO/demographic) — a residency question like "Current State of Residence" matches none
+of those and reaches the LLM drafter, saved from a wrong submission today only by luck
+(the drafted value not matching one of the form's own dropdown options).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Refuse to enqueue an auto-apply attempt when the candidate's known evidence positively
+  conflicts with the job's stated work-authorization or location/work-mode requirement.
+- Stop a required, unmapped geography/residency form question from ever reaching the LLM
+  drafter, independent of whether a particular dropdown happens to save it.
+- Reuse `hardconstraint.Evaluate` and its existing input-assembly rather than building a
+  second evidence pipeline.
+
+**Non-Goals:**
+- Changing `hardconstraint`'s own contract, its "never emit a false blocker" discipline,
+  or any of its existing advisory call sites (`JobMatch`, match-analysis scoring stay
+  exactly as advisory as they are today).
+- Building a general-purpose eligibility/compliance engine, or covering every possible
+  form of residency requirement (e.g. security-clearance citizenship, which is a
+  different existing facet — `clearance-facet` — not this evaluator's concern).
+- Inferring or asking the candidate to fill in new profile fields (e.g. a discrete
+  "state of residence") — the gate works from evidence the profile already carries.
+
+## Decisions
+
+**Reuse the existing evaluator and its handler-local assembly, unchanged, as a new
+caller.** Alternative considered: give `hardconstraint.Evaluate` a "strict" mode that
+returns a distinguishable hard-stop signal. Rejected — the function is already pure and
+its output (`[]Blocker`, each with `met`) is sufficient; whether a `false` `met` on
+`work-authorization`/`location-and-work-mode` should refuse an action or only warn is a
+property of the *caller*, not the evaluator. Keeping the package itself untouched avoids
+any risk of the new caller's stricter interpretation leaking into the advisory ones.
+
+**Gate on category, not on overall score-cap.** `PostJobAutoApply` checks for an unmet
+blocker in exactly the `work-authorization` or `location-and-work-mode` categories,
+not on the evaluator's overall score-cap ceiling (which also folds in
+experience/education/language/certification — categories irrelevant to whether the
+*submission itself* would misrepresent the candidate).
+
+**Ship the enqueue refusal behind a shadow-first flag**, mirroring the existing
+`PLAN_ENFORCE` precedent (`internal/ai/plan`): log what would have been refused for a
+run before actually refusing it. An eligibility evaluator wired into a brand-new call
+site is exactly the kind of change where a false positive (refusing a Pro candidate who
+is, in fact, eligible) has an immediate, visible cost — a paying user who can no longer
+auto-apply to a job they qualify for — so it earns the same rollout caution the plan
+limits gate uses, rather than shipping directly enforced.
+
+**Add a geography/residency label list to `internal/api/atsapply`, separate from
+`sensitiveTerms`.** Alternative considered: extend `sensitiveTerms` itself. Rejected —
+`sensitiveTerms` exists to keep the model away from a category of question on policy
+grounds (compensation, demographics, visa) regardless of whether an answer is knowable;
+this new list exists because the pipeline cannot *verify* an answer, which is a
+different reason to park and should stay a separate, named rule so the two are not
+conflated in review or in the AGENTS.md narrative. It is checked ahead of the existing
+id-match → label-match → draft ordering, as a park rather than a fourth resolution tier.
+
+## Risks / Trade-offs
+
+- **The enqueue gate only catches what the job's enrichment already encodes
+  structurally** (`visa_sponsorship`, `Countries`, `WorkMode`) → most postings, including
+  the live Garner Health one, likely carry no explicit `visa_sponsorship=false`
+  enrichment, so this gate alone would not have caught that specific case; the form-level
+  park rule is the layer that would. Mitigation: ship both layers together — they cover
+  different failure shapes (structured job data vs. a platform's own custom question),
+  and neither alone is the fix this proposal is for.
+- **Over-parking**: a geography-label match could park a question the pipeline already
+  answers today (e.g. "City" from the candidate's known location) if the label list is
+  too broad. Mitigation: the park check runs only for a question left unmapped after the
+  existing id/label resolution already tried — a question with a known answer is filled
+  exactly as before and never reaches this rule.
+- **Two "blocker" meanings in one codebase**: `hardconstraint.Blocker` stays advisory
+  everywhere else, but now also drives a hard refusal at one call site. Mitigation:
+  document this explicitly in both `internal/application/autoapply/AGENTS.md` and
+  `internal/candidate/hardconstraint`'s own docs, so a future reader does not assume
+  "advisory only" is a package-wide invariant.
+
+## Migration Plan
+
+No schema or data migration. Roll out as a shadow-logged flag (see Decisions) for one
+observation period, read the log for false-positive rate among Pro candidates, then flip
+to enforced the same way `PLAN_ENFORCE` graduates a feature. No rollback beyond
+reverting the flag — the gate makes no state changes of its own (it only refuses to
+enqueue or refuses to draft).
+
+## Open Questions
+
+- The exact geography/residency label phrase list for the `atsapply` park rule (e.g.
+  "state of residence", "country of residence", "must be based in", "current location")
+  is an implementation detail to pin down against real captured `apply_forms` data during
+  implementation — it does not change the requirement itself (recognize and park such a
+  question) or the task breakdown.

--- a/openspec/changes/archive/2026-09-06-add-auto-apply-eligibility-gate/proposal.md
+++ b/openspec/changes/archive/2026-09-06-add-auto-apply-eligibility-gate/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+Nothing in the auto-apply pipeline checks whether a candidate is actually eligible —
+on work-authorization or residency grounds — for the job it is about to apply to on
+their behalf. `PostJobAutoApply` enqueues on ATS support, Pro plan, CV presence, and
+"not already applied" alone; once queued, a required residency/authorization question
+the platform's own sensitive-keyword list does not happen to recognize is handed to the
+LLM drafter, which will attempt an answer rather than parking. This was found live: a
+Garner Health Greenhouse posting required "Current State of Residence" (a US-states-only
+dropdown) for a candidate based in Brazil, not authorized to work in the US and not
+willing to relocate — the only thing that stopped a submission was that no US state
+happened to match the candidate's address, an accident of that one form, not a decision
+this system made on purpose. The codebase already has a deterministic, dict-only
+evaluator for exactly this comparison (`internal/candidate/hardconstraint`,
+`hard-constraint-matching`), but it is wired only into advisory match-score displays,
+never into anything that refuses to act.
+
+## What Changes
+
+- `PostJobAutoApply` runs `hardconstraint.Evaluate` for the (candidate, job) pair before
+  enqueueing and refuses to enqueue when it reports an unmet `work-authorization` or
+  `location-and-work-mode` blocker, with a response the caller can render as a reason
+  rather than a generic failure.
+- `internal/api/atsapply`'s field resolution treats a required, unmapped question whose
+  label matches a geography/residency pattern (state/country/residence, distinct from the
+  existing visa/sponsorship sensitive terms) as a designed park reason, evaluated before
+  the LLM drafter ever sees it — not left to depend on the drafted value accidentally
+  failing to match a dropdown option.
+- No change to `hardconstraint`'s own contract or its existing advisory call sites
+  (`JobMatch`, match-analysis scoring): those keep never hiding or downranking a job.
+  This adds a new caller with different stakes — an unattended submission has no human to
+  override an advisory warning — not a new meaning for the existing one.
+
+## Capabilities
+
+### New Capabilities
+- `auto-apply-eligibility-gate`: refuses to enqueue an auto-apply attempt, and refuses to
+  let a required unmapped geography/residency question reach the LLM drafter, whenever
+  the candidate's known work-authorization or location-and-work-mode evidence conflicts
+  with what the job requires.
+
+### Modified Capabilities
+(none — `hard-constraint-matching`'s own evaluator and existing advisory call sites are
+unchanged; this adds a new caller of `hardconstraint.Evaluate`, not a new requirement on
+it)
+
+## Impact
+
+- `internal/api/handler/auto_apply_enqueue.go` (`PostJobAutoApply`): new gate, new refusal
+  response shape.
+- `internal/candidate/hardconstraint`: new caller (`buildHardConstraintInputs`-equivalent
+  assembly reused or adapted for the enqueue path); package itself unchanged.
+- `internal/api/atsapply`: `resolve.go` / `draft.go` / `sensitive.go` gain a geography
+  park rule ahead of drafting.
+- `internal/application/autoapply` (`AGENTS.md`) and `internal/api/atsapply`
+  (`AGENTS.md`): documentation of the new gate and its rationale.
+- No schema changes expected — `job.Enrichment.VisaSponsorship`, `job.Countries`,
+  `job.WorkMode`, and the candidate's `location_preferences`/CV-derived country already
+  exist and already feed `hardconstraint.Evaluate` elsewhere.

--- a/openspec/changes/archive/2026-09-06-add-auto-apply-eligibility-gate/specs/auto-apply-eligibility-gate/spec.md
+++ b/openspec/changes/archive/2026-09-06-add-auto-apply-eligibility-gate/specs/auto-apply-eligibility-gate/spec.md
@@ -1,0 +1,72 @@
+## Purpose
+
+Stops the auto-apply pipeline from queuing or completing a submission for a
+(candidate, job) pair the candidate's own known work-authorization or location evidence
+positively conflicts with, instead of relying on an incidental drafting or form-matching
+failure to catch it.
+
+## ADDED Requirements
+
+### Requirement: Enqueueing refuses a positively mismatched pair
+
+The system SHALL evaluate the candidate's known work-authorization and
+location-and-work-mode evidence against the job's requirements before adding an
+auto-apply attempt to the queue, and SHALL refuse to enqueue when that evaluation
+reports an unmet work-authorization or location-and-work-mode blocker for the pair. The
+refusal response MUST name the blocker's reason rather than reading as a generic
+failure.
+
+This evaluation SHALL follow the same "never emit a false blocker" discipline used
+elsewhere for this comparison: when the candidate's or the job's evidence for a category
+is absent, that category MUST be treated as unevaluable and MUST NOT by itself refuse
+enqueueing.
+
+#### Scenario: A job requiring work authorization the candidate does not have is refused
+
+- **WHEN** a candidate whose known work-authorization evidence conflicts with a job's
+  stated visa-sponsorship and country requirements requests auto-apply on that job
+- **THEN** the attempt is not added to the queue
+- **AND** the response names the work-authorization mismatch as the reason
+
+#### Scenario: A job requiring a residency or work mode the candidate does not have is refused
+
+- **WHEN** a candidate whose known location evidence conflicts with a job's required
+  country or work mode requests auto-apply on that job
+- **THEN** the attempt is not added to the queue
+- **AND** the response names the location mismatch as the reason
+
+#### Scenario: Missing evidence on either side does not refuse enqueueing
+
+- **WHEN** the candidate has not stated (and none can be derived for) the evidence a
+  category needs, or the job carries no requirement for that category
+- **THEN** that category is treated as unevaluable
+- **AND** enqueueing proceeds on the strength of the pipeline's other existing checks
+
+#### Scenario: A pair with no conflicting evidence is unaffected
+
+- **WHEN** the evaluation finds no unmet work-authorization or location-and-work-mode
+  blocker for the pair
+- **THEN** enqueueing proceeds exactly as it did before this gate existed
+
+### Requirement: A required, unmapped geography or residency question never reaches automatic drafting
+
+The system SHALL recognize a required application-form question whose label identifies a
+geography, residency, or work-location requirement (distinct from the existing
+visa/sponsorship terms) as a form the pipeline cannot safely resolve on its own, before
+that question is offered to automatic drafting, and SHALL record the attempt as
+unresolved rather than submitting a drafted guess.
+
+#### Scenario: A required residency question with no known answer is parked, not drafted
+
+- **WHEN** a queued attempt's application form carries a required question whose label
+  identifies a geography or residency requirement, and the candidate's known answers do
+  not map to it
+- **THEN** the attempt is recorded as unresolved naming that question
+- **AND** no drafted answer is generated or submitted for it
+
+#### Scenario: A mapped or already-answered geography question is unaffected
+
+- **WHEN** a geography-labeled question's answer is already resolvable from the
+  candidate's known answers
+- **THEN** the question is filled from that known answer exactly as before this rule
+  existed, and drafting is not invoked for it

--- a/openspec/changes/archive/2026-09-06-add-auto-apply-eligibility-gate/tasks.md
+++ b/openspec/changes/archive/2026-09-06-add-auto-apply-eligibility-gate/tasks.md
@@ -1,0 +1,78 @@
+## 1. Enqueue-time eligibility gate
+
+- [x] 1.1 Add a shadow/enforce flag (e.g. `AUTO_APPLY_ELIGIBILITY_ENFORCE`) read once at
+      startup, mirroring the `PLAN_ENFORCE` pattern in `internal/ai/plan`
+      (`autoApplyEligibilityEnforce`, a `sync.OnceValue`-memoized env read — a plain
+      constructor-threaded flag was rejected to avoid rippling through the ~78
+      integration-test call sites `newAssistantHandlers` has, per root AGENTS.md's own
+      warning about that constructor)
+- [x] 1.2 In `internal/api/handler/auto_apply_enqueue.go`'s `PostJobAutoApply`, call the
+      existing `jobBlockers` helper for the (candidate, job) pair before enqueueing
+      (via `h.cv.match.jobBlockers`, reusing the already-wired `*matchHandlers` reachable
+      from `assistantHandlers` — no new field needed)
+- [x] 1.3 Filter the returned `[]hardconstraint.Blocker` to `work-authorization` and
+      `location-and-work-mode` entries with `met == false` (`firstEligibilityBlocker`,
+      split out as a pure function for unit testing)
+- [x] 1.4 When the flag is in shadow mode: log the would-be refusal (candidate, job,
+      blocker category, reason) and enqueue as today
+- [x] 1.5 When the flag is enforced: refuse to enqueue, returning a response that names
+      the blocker's reason (not a generic error), and do not call `EnqueueAutoApply`
+- [x] 1.6 Unit tests: unmet work-authorization blocker refuses (enforced) / logs only
+      (shadow); unmet location-and-work-mode blocker refuses; no blocker or unevaluable
+      category (missing evidence either side) proceeds unchanged in both modes
+      (`auto_apply_eligibility_test.go`, against the pure `firstEligibilityBlocker`)
+
+## 2. Form-resolution geography park rule
+
+- [x] 2.1 In `internal/api/atsapply`, add a geography/residency label-term list separate
+      from `sensitiveTerms` (`sensitive.go`) — seed it from real captured `apply_forms`
+      question labels (resolves design.md's Open Question on the exact phrase list)
+      (`geography.go`'s `geographyTerms`, seeded from the live Garner Health wording)
+- [x] 2.2 Add the recognizer function (e.g. `isGeographyLabel`) alongside the existing
+      `isSensitiveLabel`
+- [x] 2.3 Wire the check into `resolve.go`/`draft.go`'s ordering: after id-match and
+      label-match resolution fail for a required field, check `isGeographyLabel` before
+      `draftable`/`ResolveWithDrafting` is invoked; on a match, mark the field parked with
+      a named reason instead of drafting (`draftable` now also requires
+      `!isGeographyLabel(f.Label)`, so it parks with `Resolve`'s existing "no known answer
+      source" reason exactly as a sensitive field does — no separate reason string, for
+      consistency with that established pattern)
+- [x] 2.4 Unit tests: a required unmapped geography-labeled question parks and is never
+      passed to the drafter; a geography-labeled question already resolvable from known
+      answers (e.g. city) still fills normally; an unrelated required question is
+      unaffected and still reaches drafting as before
+
+## 3. Observability
+
+- [x] 3.1 Add a metric or structured log line for each shadow/enforced refusal, tagged
+      by blocker category, so the false-positive rate among Pro candidates can be read
+      before flipping the flag (per design.md's Migration Plan) (a `log.Printf` in both
+      branches, tagged "would refuse"/"refused" plus the blocker category — no metrics
+      system wired into this handler package today, so a log line is the proportionate
+      choice; a real metric can follow if the shadow log shows this is worth graphing)
+
+## 4. Documentation
+
+- [x] 4.1 Update `internal/application/autoapply/AGENTS.md` to document the enqueue-time
+      eligibility gate, its shadow/enforce rollout, and that a parked attempt from this
+      gate is not a retry candidate
+- [x] 4.2 Update `internal/api/atsapply/AGENTS.md` to document the geography park rule
+      and why it is separate from the sensitive-keyword gate
+- [x] 4.3 Update `internal/candidate/hardconstraint`'s package doc (no AGENTS.md exists
+      for this package) to note that this is a second, non-advisory caller of `Evaluate`,
+      and that the package's own "never hides or downranks" invariant still holds for
+      every other caller
+
+## 5. Verification
+
+- [x] 5.1 `go build ./...`, `go vet ./...`, `go test ./...` — all clean
+- [x] 5.2 `go vet -tags=integration ./...` — clean, including the ~78
+      `newAssistantHandlers`-calling integration test files this change deliberately did
+      not touch the signature of; `go test -tags=integration ./internal/api/handler/...
+      ./internal/api/atsapply/...` — both pass
+- [x] 5.3 Replayed as a unit test rather than a live network call (deliberately — no
+      reason to re-touch a real employer's form for this): `TestIsGeographyLabel_
+      CatchesTheLiveGarnerHealthWording` and `TestResolveWithDrafting_
+      NeverDraftsAGeographyField` use the exact live wording ("Current State of
+      Residence") and confirm it now parks via `isGeographyLabel`, not via an accidental
+      dropdown-option mismatch

--- a/openspec/specs/auto-apply-eligibility-gate/spec.md
+++ b/openspec/specs/auto-apply-eligibility-gate/spec.md
@@ -1,0 +1,74 @@
+# auto-apply-eligibility-gate Specification
+
+## Purpose
+
+Stops the auto-apply pipeline from queuing or completing a submission for a
+(candidate, job) pair the candidate's own known work-authorization or location evidence
+positively conflicts with, instead of relying on an incidental drafting or form-matching
+failure to catch it.
+
+## Requirements
+
+### Requirement: Enqueueing refuses a positively mismatched pair
+
+The system SHALL evaluate the candidate's known work-authorization and
+location-and-work-mode evidence against the job's requirements before adding an
+auto-apply attempt to the queue, and SHALL refuse to enqueue when that evaluation
+reports an unmet work-authorization or location-and-work-mode blocker for the pair. The
+refusal response MUST name the blocker's reason rather than reading as a generic
+failure.
+
+This evaluation SHALL follow the same "never emit a false blocker" discipline used
+elsewhere for this comparison: when the candidate's or the job's evidence for a category
+is absent, that category MUST be treated as unevaluable and MUST NOT by itself refuse
+enqueueing.
+
+#### Scenario: A job requiring work authorization the candidate does not have is refused
+
+- **WHEN** a candidate whose known work-authorization evidence conflicts with a job's
+  stated visa-sponsorship and country requirements requests auto-apply on that job
+- **THEN** the attempt is not added to the queue
+- **AND** the response names the work-authorization mismatch as the reason
+
+#### Scenario: A job requiring a residency or work mode the candidate does not have is refused
+
+- **WHEN** a candidate whose known location evidence conflicts with a job's required
+  country or work mode requests auto-apply on that job
+- **THEN** the attempt is not added to the queue
+- **AND** the response names the location mismatch as the reason
+
+#### Scenario: Missing evidence on either side does not refuse enqueueing
+
+- **WHEN** the candidate has not stated (and none can be derived for) the evidence a
+  category needs, or the job carries no requirement for that category
+- **THEN** that category is treated as unevaluable
+- **AND** enqueueing proceeds on the strength of the pipeline's other existing checks
+
+#### Scenario: A pair with no conflicting evidence is unaffected
+
+- **WHEN** the evaluation finds no unmet work-authorization or location-and-work-mode
+  blocker for the pair
+- **THEN** enqueueing proceeds exactly as it did before this gate existed
+
+### Requirement: A required, unmapped geography or residency question never reaches automatic drafting
+
+The system SHALL recognize a required application-form question whose label identifies a
+geography, residency, or work-location requirement (distinct from the existing
+visa/sponsorship terms) as a form the pipeline cannot safely resolve on its own, before
+that question is offered to automatic drafting, and SHALL record the attempt as
+unresolved rather than submitting a drafted guess.
+
+#### Scenario: A required residency question with no known answer is parked, not drafted
+
+- **WHEN** a queued attempt's application form carries a required question whose label
+  identifies a geography or residency requirement, and the candidate's known answers do
+  not map to it
+- **THEN** the attempt is recorded as unresolved naming that question
+- **AND** no drafted answer is generated or submitted for it
+
+#### Scenario: A mapped or already-answered geography question is unaffected
+
+- **WHEN** a geography-labeled question's answer is already resolvable from the
+  candidate's known answers
+- **THEN** the question is filled from that known answer exactly as before this rule
+  existed, and drafting is not invoked for it


### PR DESCRIPTION
## Summary
- `PostJobAutoApply` now runs a new enqueue-time eligibility gate (`internal/api/handler`) over the same deterministic `hardconstraint.Evaluate` blockers the match-analysis surface already uses advisorily, and refuses to enqueue an unattended submission when there is an unmet work-authorization or location-and-work-mode blocker. Ships shadow-only (`AUTO_APPLY_ELIGIBILITY_ENFORCE=1` to enforce), mirroring `internal/ai/plan`'s `PLAN_ENFORCE` rollout.
- A geography/residency question (`internal/api/atsapply/geography.go`) now also parks before drafting, for a different reason than the existing sensitive-keyword gate: `candidateprofile` only carries a free-text `location`, never a discrete country/state fact a platform's own dropdown options can be checked against, so a drafted answer here would be invented rather than reported. Found live against a Garner Health Greenhouse posting's US-states-only "Current State of Residence" dropdown.
- Archives the `add-auto-apply-eligibility-gate` OpenSpec change and syncs its spec into `openspec/specs/`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/api/atsapply/... ./internal/api/handler/... ./internal/candidate/hardconstraint/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added eligibility checks before auto-apply requests are queued. Requests with confirmed work-authorization or location/work-mode conflicts are refused with a reason and do not incur an allowance charge.
  * Added safeguards for unresolved geography and residency questions, preventing the system from submitting guessed answers. Questions already matched to known answers continue to be completed automatically.
  * Eligibility enforcement initially operates in shadow mode, logging potential refusals before enforcement is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->