### PR TITLE
Delete what nothing calls, and give the mail path the reminder cancellation every other caller gets

### DIFF
--- a/cmd/prune/plan.go
+++ b/cmd/prune/plan.go
@@ -23,8 +23,10 @@ type plan struct {
 	byRule   map[string]int
 	bySource map[string]int
 	samples  []string
-	// refused counts rows a company-scoped rule matched but the guard turned down,
-	// per reason. They are not deletions and not errors: they are the guard working.
+	// refused counts rows a guard turned down, per reason. They are not deletions and
+	// not errors: they are the guard working. Today the only live refusal is the source
+	// gate (main.go) — "the company-scoped rules" is what this said, and matchRule
+	// structurally cannot reach those on a crawled board anyway.
 	refused map[string]int
 	// matched is every row the rule matched, including those past the cap, so the
 	// report can say how much of the work this run is doing.

--- a/cmd/prune/rule.go
+++ b/cmd/prune/rule.go
@@ -117,14 +117,3 @@ func isBusinessCategory(category string) bool {
 	}
 	return slices.Contains(vocab.NonTechCategories, category)
 }
-
-// companyScoped reports whether a rule depends on the company's history rather than on
-// the posting alone. It matters because boards are re-crawled hourly on an unchanged
-// dedup key: the title rule is mirrored by the ingest filter, so what it deletes stays
-// deleted, but nothing at crawl time knows a company's bucket. A company-scoped
-// deletion whose board is still live in the catalog undoes itself within the hour,
-// which is why the worker refuses to run one without retiring the board in the same
-// step.
-func companyScoped(rule string) bool {
-	return rule == ruleBusiness || rule == ruleUnknown
-}

--- a/cmd/prune/rule_test.go
+++ b/cmd/prune/rule_test.go
@@ -172,18 +172,3 @@ func TestMatchRule(t *testing.T) {
 		})
 	}
 }
-
-// The title rule is self-sufficient because ingest applies the same dictionary, but
-// the company-scoped rules have no ingest counterpart: the bucket does not exist at
-// crawl time. Deleting under them without retiring the board undoes itself within the
-// hour, so the worker has to be able to tell the two classes apart.
-func TestCompanyScopedRulesAreIdentifiable(t *testing.T) {
-	if companyScoped(ruleTitle) {
-		t.Error("the title rule is enforced at ingest, so it needs no board retirement")
-	}
-	for _, rule := range []string{ruleBusiness, ruleUnknown} {
-		if !companyScoped(rule) {
-			t.Errorf("%q depends on the company bucket and has no ingest counterpart, so it requires board retirement", rule)
-		}
-	}
-}

--- a/internal/api/atsapply/client.go
+++ b/internal/api/atsapply/client.go
@@ -191,7 +191,7 @@ func (c *Client) Submit(ctx context.Context, claimed autoapply.Claimed, answers 
 		defer cleanup()
 	}
 
-	confirmed, err := fillAndSubmit(browserCtx, claimed.JobURL, plan)
+	confirmed, err := fillAndSubmit(browserCtx, plan)
 	if err != nil {
 		// A fill action failing, or the board EXPLICITLY refusing the submit click
 		// (SUBMIT_REFUSED_MARKERS in fill.go), both mean no submission happened — safe

--- a/internal/api/atsapply/fill.go
+++ b/internal/api/atsapply/fill.go
@@ -57,7 +57,7 @@ var submitRefusedMarkers = []string{
 // This is the least-verified part of the package — see design.md's Testing section and
 // task 7.1: correctness here rests on the 2026-09-02 spike's single live posting and the
 // reference implementation's own measured rules, not on this package's own live testing.
-func fillAndSubmit(ctx context.Context, jobURL string, plan Plan) (bool, error) {
+func fillAndSubmit(ctx context.Context, plan Plan) (bool, error) {
 	for _, f := range plan.Fields {
 		if err := fillOne(ctx, f); err != nil {
 			return false, fmt.Errorf("fill %q: %w", f.ID, err)
@@ -148,7 +148,7 @@ func fieldSelector(id string) string {
 // moment earlier or later would have hit the ordinary ctx.Done() branch instead, and this
 // must report identically either way. Found by code review: this check did not exist, so a
 // deadline firing mid-call surfaced as a plain retryable error.
-func classifyPollError(ctx context.Context, err error) (unconfirmed bool) {
+func pollEndedByDeadline(ctx context.Context) bool {
 	return ctx.Err() != nil
 }
 
@@ -160,11 +160,13 @@ func verifySubmission(parent context.Context) (bool, error) {
 	ctx, cancel := context.WithTimeout(parent, submitVerifyTimeout)
 	defer cancel()
 
-	deadline := time.Now().Add(submitVerifyTimeout)
-	for time.Now().Before(deadline) {
+	// One deadline, the context's. The loop used to carry a second time.Now()-based one
+	// computed from the same timeout, which could never be the binding limit — ctx is
+	// derived from it above and cancels first or together.
+	for ctx.Err() == nil {
 		var bodyText string
 		if err := chromedp.Run(ctx, chromedp.Text("body", &bodyText, chromedp.ByQuery)); err != nil {
-			if classifyPollError(ctx, err) {
+			if pollEndedByDeadline(ctx) {
 				return false, nil
 			}
 			return false, err

--- a/internal/api/atsapply/fill_poll_test.go
+++ b/internal/api/atsapply/fill_poll_test.go
@@ -2,7 +2,6 @@ package atsapply
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 )
@@ -15,32 +14,34 @@ import (
 // path in internal/autoapply's runner, risking a second real submit click on a form whose
 // first click may already have gone through — precisely what StatusUnconfirmed exists to
 // prevent.
-func TestClassifyPollError_ADeadlineFiringMidCallIsUnconfirmedNotAnError(t *testing.T) {
+func TestPollEndedByDeadline_ADeadlineFiringMidCallIsUnconfirmedNotAnError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
 	<-ctx.Done() // the deadline has now fired, same as it firing while chromedp.Run was in flight
 
-	if !classifyPollError(ctx, errors.New("context deadline exceeded")) {
+	if !pollEndedByDeadline(ctx) {
 		t.Error("want a context-deadline error classified as unconfirmed (not a real failure)")
 	}
 }
 
-func TestClassifyPollError_ACancelledParentIsUnconfirmedNotAnError(t *testing.T) {
+func TestPollEndedByDeadline_ACancelledParentIsUnconfirmedNotAnError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	if !classifyPollError(ctx, errors.New("context canceled")) {
+	if !pollEndedByDeadline(ctx) {
 		t.Error("want a cancelled-context error classified as unconfirmed (not a real failure)")
 	}
 }
 
 // An ordinary chromedp failure — the target element genuinely not found, say — with a
-// still-live context must stay a real, reportable error.
-func TestClassifyPollError_AnOrdinaryFailureOnALiveContextIsARealError(t *testing.T) {
+// still-live context must stay a real, reportable error. The error value never decided
+// this: the question is only whether the deadline fired, which is why the parameter is
+// gone and the name now says what is asked.
+func TestPollEndedByDeadline_AnOrdinaryFailureOnALiveContextIsARealError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
 	defer cancel()
 
-	if classifyPollError(ctx, errors.New("no node found for selector")) {
+	if pollEndedByDeadline(ctx) {
 		t.Error("want an ordinary failure on a live context classified as a real error, not unconfirmed")
 	}
 }

--- a/internal/api/handler/auth_v2.go
+++ b/internal/api/handler/auth_v2.go
@@ -433,16 +433,16 @@ func (h *authHandlers) AppleExchangeV2(c *fiber.Ctx) error {
 			return authError(401, "reauth_session_mismatch", "session changed")
 		}
 	}
-	grant, err := h.appleNative.Exchange(c.Context(), in.AuthorizationCode, clientID, attempt.NonceChallenge, claims.Subject)
+	refreshToken, err := h.appleNative.Exchange(c.Context(), in.AuthorizationCode, clientID, attempt.NonceChallenge, claims.Subject)
 	if err != nil {
 		return authError(401, "apple_exchange_failed", "Apple sign-in failed")
 	}
-	compensationID, err := h.mobileAuth.CreateAppleCompensation(c.Context(), h.appleGrantKeys, claims.Subject, clientID, grant.RefreshToken)
+	compensationID, err := h.mobileAuth.CreateAppleCompensation(c.Context(), h.appleGrantKeys, claims.Subject, clientID, refreshToken)
 	if err != nil {
 		// If durable custody is unavailable, revoke while the only plaintext copy
 		// is still in memory. Joining errors preserves the operational failure
 		// without ever including the token value.
-		if revokeErr := h.appleNative.Revoke(c.Context(), grant.RefreshToken, clientID); revokeErr != nil {
+		if revokeErr := h.appleNative.Revoke(c.Context(), refreshToken, clientID); revokeErr != nil {
 			return errors.Join(err, revokeErr)
 		}
 		return err

--- a/internal/api/handler/gmail.go
+++ b/internal/api/handler/gmail.go
@@ -16,6 +16,7 @@ import (
 	"github.com/strelov1/freehire/internal/application/inbox"
 	"github.com/strelov1/freehire/internal/application/jobtracking"
 	"github.com/strelov1/freehire/internal/application/mailrecall"
+	"github.com/strelov1/freehire/internal/engage/reminder"
 	"github.com/strelov1/freehire/internal/identity/accounts"
 	"github.com/strelov1/freehire/internal/identity/auth"
 	"github.com/strelov1/freehire/internal/identity/auth/oauth"
@@ -40,10 +41,6 @@ type inboxHandlers struct {
 	frontendOrigin string
 	cookieSecure   bool
 	mailDomain     string
-	// tracking records an application reconstructed from mail. The mail surface
-	// borrows the tracking use case rather than writing its own apply, so the
-	// applied_count guarantee stays in one place (see CreateApplicationFromEmail).
-	tracking *jobtracking.Service
 	// inbox holds the mail use cases these handlers render. The in-app assistant's
 	// mail tools call the same service, so a rule can never hold for one reader and
 	// not the other.
@@ -98,11 +95,19 @@ func (t trackingApplications) MarkAppliedAt(ctx context.Context, userID int64, s
 }
 
 func newInboxHandlers(queries *db.Queries, pool *pgxpool.Pool, gmailConnector *gmailsync.Connector, gmailCipher *tokencrypt.Cipher, frontendOrigin string, cookieSecure bool, mailDomain string) *inboxHandlers {
-	tracking := jobtracking.New(jobtracking.NewQueriesRepository(queries, pool))
+	// WithReminders, like every other construction of this service. Without it the
+	// "and now cancels" half of jobtracking's saved-job reminder contract was a no-op on
+	// the mail path — commit e27aaf14 added the port in user_jobs.go and did not reach
+	// here. The consequence was bounded (reminder.Runner.validate re-reads
+	// still_actionable and cancels on firing) but it is a rule stated in one place and
+	// enforced in one of two.
+	tracking := jobtracking.New(
+		jobtracking.NewQueriesRepository(queries, pool),
+		jobtracking.WithReminders(reminder.New(reminder.NewQueriesRepository(queries))),
+	)
 	return &inboxHandlers{
 		queries:        queries,
 		pool:           pool,
-		tracking:       tracking,
 		inbox:          inbox.New(queries, trackingApplications{tracking}, inbox.WithIngester(inbox.NewQueriesIngester(pool, queries))),
 		timeline:       apptimeline.New(queries),
 		gmailConnector: gmailConnector,

--- a/internal/api/handler/telegram.go
+++ b/internal/api/handler/telegram.go
@@ -102,11 +102,7 @@ func (h *telegramHandlers) LinkTelegram(c *fiber.Ctx) error {
 	if !h.telegramEnabled() {
 		return fiber.NewError(fiber.StatusServiceUnavailable, "telegram notifications are not configured")
 	}
-	token, err := h.telegramLinks.Issue(userID)
-	if err != nil {
-		return err
-	}
-	url := "https://t.me/" + h.telegramBotUsername + "?start=" + token
+	url := "https://t.me/" + h.telegramBotUsername + "?start=" + h.telegramLinks.Issue(userID)
 	return c.JSON(fiber.Map{"data": fiber.Map{"url": url}})
 }
 

--- a/internal/application/appevent/appevent.go
+++ b/internal/application/appevent/appevent.go
@@ -29,16 +29,6 @@ const (
 // Kinds is the canonical, ordered kind vocabulary.
 var Kinds = []string{KindApplied, KindEmployerReply, KindFollowUpSent, KindStageSet, KindInterviewScheduled}
 
-// ValidKind reports whether k is a known event kind.
-func ValidKind(k string) bool {
-	for _, kind := range Kinds {
-		if kind == k {
-			return true
-		}
-	}
-	return false
-}
-
 // The event sources, mirroring the three mail stores in internal/application/inbox plus the two ways
 // a candidate records something themselves.
 const (
@@ -69,16 +59,6 @@ var Sources = []string{SourceMailGmail, SourceMailHosted, SourceMailExternal, So
 // rather than a description. Spelling the three into a query would put the vocabulary in
 // two places, which is the failure the pin test next door already guards against.
 var MailSources = []string{SourceMailGmail, SourceMailHosted, SourceMailExternal}
-
-// ValidSource reports whether s is a known event source.
-func ValidSource(s string) bool {
-	for _, src := range Sources {
-		if src == s {
-			return true
-		}
-	}
-	return false
-}
 
 // TrustedForDayMath reports whether events from this source may enter timing
 // calculations.

--- a/internal/application/appevent/appevent_test.go
+++ b/internal/application/appevent/appevent_test.go
@@ -2,40 +2,6 @@ package appevent
 
 import "testing"
 
-func TestValidKindAcceptsTheVocabularyAndNothingElse(t *testing.T) {
-	for _, k := range Kinds {
-		if !ValidKind(k) {
-			t.Errorf("ValidKind(%q) = false, want true", k)
-		}
-	}
-	for _, k := range []string{"", "reply", "APPLIED", "employer-reply"} {
-		if ValidKind(k) {
-			t.Errorf("ValidKind(%q) = true, want false", k)
-		}
-	}
-}
-
-func TestValidSourceAcceptsTheVocabularyAndNothingElse(t *testing.T) {
-	for _, s := range Sources {
-		if !ValidSource(s) {
-			t.Errorf("ValidSource(%q) = false, want true", s)
-		}
-	}
-	for _, s := range []string{"", "gmail", "mail", "gmail_mail"} {
-		if ValidSource(s) {
-			t.Errorf("ValidSource(%q) = true, want false", s)
-		}
-	}
-}
-
-// A manually-recorded event dates from when the candidate got around to updating their
-// board, not from when the thing happened. Letting one into day arithmetic would measure
-// diligence and report it as market behaviour, so the split is asserted in both
-// directions: a future edit cannot quietly promote a manual source.
-//
-// The line is "did somebody other than the candidate set this date", not "did it come
-// from mail". A meeting read out of the candidate's calendar was arranged by an
-// organiser and observed by us, so it belongs on the trusted side beside the mail.
 func TestOnlyObservedSourcesAreTrustedForDayMath(t *testing.T) {
 	trusted := map[string]bool{
 		SourceMailGmail:      true,

--- a/internal/engage/telegramnotify/token.go
+++ b/internal/engage/telegramnotify/token.go
@@ -39,8 +39,12 @@ func NewLinkTokens(secret string, ttl time.Duration) *LinkTokens {
 
 // Issue returns a deep-link token for userID, expiring after the configured TTL.
 // The result is base64url (no padding) so it is safe as a Telegram start param.
-func (l *LinkTokens) Issue(userID int64) (string, error) {
-	return l.tokens.Issue(userID), nil
+//
+// It returns no error, because there was never one to return: linktoken.Tokens.Issue
+// cannot fail, and the second result was hard-coded nil. The shape was parity with
+// discordbot.DiscordLinkTokens, removed from main in 937ed92f.
+func (l *LinkTokens) Issue(userID int64) string {
+	return l.tokens.Issue(userID)
 }
 
 // Parse verifies a token's signature and expiry and returns its user id.

--- a/internal/engage/telegramnotify/token_test.go
+++ b/internal/engage/telegramnotify/token_test.go
@@ -9,10 +9,7 @@ import (
 
 func TestLinkTokens_RoundTrip(t *testing.T) {
 	lt := NewLinkTokens("secret", 10*time.Minute)
-	tok, err := lt.Issue(42)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tok := lt.Issue(42)
 	uid, err := lt.Parse(tok)
 	if err != nil || uid != 42 {
 		t.Errorf("Parse = %d, %v; want 42, nil", uid, err)
@@ -23,10 +20,7 @@ func TestLinkTokens_RoundTrip(t *testing.T) {
 // a JWT token exceeded Telegram's deep-link `start` limit (1–64 chars,
 // [A-Za-z0-9_-]) and was silently dropped. The token MUST fit that constraint.
 func TestLinkTokens_TelegramStartParamSafe(t *testing.T) {
-	tok, err := NewLinkTokens("secret", 10*time.Minute).Issue(9223372036854775807) // max int64
-	if err != nil {
-		t.Fatal(err)
-	}
+	tok := NewLinkTokens("secret", 10*time.Minute).Issue(9223372036854775807) // max int64
 	if len(tok) < 1 || len(tok) > 64 {
 		t.Errorf("token length = %d, want 1..64 (Telegram start-param limit)", len(tok))
 	}
@@ -37,20 +31,14 @@ func TestLinkTokens_TelegramStartParamSafe(t *testing.T) {
 
 func TestLinkTokens_Expired(t *testing.T) {
 	lt := NewLinkTokens("secret", -time.Minute) // already expired
-	tok, err := lt.Issue(1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tok := lt.Issue(1)
 	if _, err := lt.Parse(tok); !errors.Is(err, ErrInvalidToken) {
 		t.Errorf("Parse(expired) err = %v, want ErrInvalidToken", err)
 	}
 }
 
 func TestLinkTokens_WrongSecretRejected(t *testing.T) {
-	tok, err := NewLinkTokens("real", time.Minute).Issue(1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tok := NewLinkTokens("real", time.Minute).Issue(1)
 	if _, err := NewLinkTokens("forged", time.Minute).Parse(tok); !errors.Is(err, ErrInvalidToken) {
 		t.Errorf("Parse with wrong secret err = %v, want ErrInvalidToken", err)
 	}

--- a/internal/identity/auth/apple/client.go
+++ b/internal/identity/auth/apple/client.go
@@ -73,11 +73,6 @@ func (c Claims) VerifiedEmail() (string, bool) {
 	return c.Email, verified && c.Email != ""
 }
 
-type Grant struct {
-	Subject, ClientID, RefreshToken string
-	Claims                          Claims
-}
-
 type jwk struct{ Kty, Use, Kid, Alg, N, E string }
 type cachedKeys struct {
 	keys    map[string]*rsa.PublicKey
@@ -134,7 +129,6 @@ func New(cfg Config) (*Client, error) {
 	return &Client{cfg: cfg, key: key, now: time.Now}, nil
 }
 
-func (c *Client) Enabled() bool       { return c != nil }
 func (c *Client) ClientIDs() []string { return append([]string(nil), c.cfg.ClientIDs...) }
 
 func (c *Client) clientAllowed(aud string) bool {
@@ -327,33 +321,38 @@ func (c *Client) postForm(ctx context.Context, endpoint string, form url.Values,
 	return resp.StatusCode, nil
 }
 
-func (c *Client) Exchange(ctx context.Context, code, clientID, expectedNonce, submittedSubject string) (Grant, error) {
+// Exchange trades an authorization code for the refresh token that keeps custody of the
+// Apple identity, verifying the returned id token against the nonce, the subject the
+// caller submitted, and the client id.
+//
+// It returns the token alone. It used to return a Grant carrying Subject, ClientID and
+// Claims beside it, and nothing outside this package ever read any of the three — the
+// caller (handler.exchangeApple) takes the refresh token and gets the identity from its
+// own Verify, because the identity has to be established BEFORE the exchange to decide
+// whether to attempt one at all.
+func (c *Client) Exchange(ctx context.Context, code, clientID, expectedNonce, submittedSubject string) (string, error) {
 	if code == "" || submittedSubject == "" {
-		return Grant{}, ErrExchange
+		return "", ErrExchange
 	}
 	secret, err := c.clientSecret(clientID)
 	if err != nil {
-		return Grant{}, err
+		return "", err
 	}
 	var tr tokenResponse
 	status, err := c.postForm(ctx, c.cfg.TokenURL, url.Values{"grant_type": {"authorization_code"}, "code": {code}, "client_id": {clientID}, "client_secret": {secret}}, &tr)
 	if err != nil || status != http.StatusOK || tr.Error != "" || tr.IDToken == "" || tr.RefreshToken == "" {
-		return Grant{}, ErrExchange
+		return "", ErrExchange
 	}
 	claims, err := c.Verify(ctx, tr.IDToken, expectedNonce)
 	if err != nil || claims.Subject != submittedSubject {
-		return Grant{}, ErrExchange
+		return "", ErrExchange
 	}
-	audOK := false
 	for _, aud := range claims.Audience {
 		if aud == clientID {
-			audOK = true
+			return tr.RefreshToken, nil
 		}
 	}
-	if !audOK {
-		return Grant{}, ErrExchange
-	}
-	return Grant{Subject: claims.Subject, ClientID: clientID, RefreshToken: tr.RefreshToken, Claims: claims}, nil
+	return "", ErrExchange
 }
 
 func (c *Client) Revoke(ctx context.Context, refreshToken, clientID string) error {

--- a/internal/identity/auth/apple/client_test.go
+++ b/internal/identity/auth/apple/client_test.go
@@ -93,14 +93,14 @@ func TestVerifyExchangeAndRevoke(t *testing.T) {
 	if claims.Subject != "apple-subject" {
 		t.Fatal(claims.Subject)
 	}
-	grant, err := client.Exchange(context.Background(), "good", "me.freehire.mobile", nonce, "apple-subject")
+	refreshToken, err := client.Exchange(context.Background(), "good", "me.freehire.mobile", nonce, "apple-subject")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if grant.RefreshToken != "refresh-secret" {
+	if refreshToken != "refresh-secret" {
 		t.Fatal("refresh token missing")
 	}
-	if err = client.Revoke(context.Background(), grant.RefreshToken, grant.ClientID); err != nil {
+	if err = client.Revoke(context.Background(), refreshToken, "me.freehire.mobile"); err != nil {
 		t.Fatal(err)
 	}
 	if _, err = client.Verify(context.Background(), raw, "wrong"); err == nil {


### PR DESCRIPTION
The cleanup half of the second and third backend-review passes. Every deletion was checked for callers **with the integration build tag** — 187 tagged files are invisible to a plain grep — and `deadcode ./...` named several of them independently.

## One behaviour fix rides along

`newInboxHandlers` built its own `jobtracking.Service` **without** `WithReminders`, while `newTrackingHandlers` builds one **with** it and comments that *"every caller of it gets the same side effect"*.

So `jobtracking`'s "and now cancels" half was a no-op on the mail path — commit `e27aaf14` added the port in `user_jobs.go` and did not reach `gmail.go`. The consequence was bounded (`reminder.Runner.validate` re-reads `still_actionable` and cancels on firing, so the cost is one wasted lease and an inflated `Stats.Cancelled`) but it is a rule stated in one place and enforced in one of two.

It is also why the dead field below existed.

## Deleted

| symbol | why it is safe |
|---|---|
| `inboxHandlers.tracking` | assigned, never read — only the **value** is used, to build `trackingApplications` for `inbox.New` |
| `apple.Client.Enabled()` | zero callers in the module; the client is held as a concrete `*appleauth.Client` everywhere and the only nil guard is hand-written in `auth_v2.go` |
| `apple.Grant` | `Exchange` now returns the refresh token alone — 3 of its 4 fields had no reader outside the package |
| `cmd/prune`'s `companyScoped` | named by `deadcode`; two callers, both in its own test |
| `appevent.ValidKind`, `ValidSource` | named by `deadcode`; one test caller each |
| `atsapply` `fillAndSubmit(jobURL)` | declared, never read (checked against `61f06983` and `3c190ea1`) |
| `classifyPollError`'s `err` | never decided anything — renamed `pollEndedByDeadline(ctx)`, the question it actually asks |
| `verifySubmission`'s second deadline | derived from the same timeout as the context above it, so the context always cancels first or together |
| `LinkTokens.Issue`'s `error` | hard-coded `nil`, and the delegate cannot fail |

Notes on two of them:

- **`apple.Grant`.** The caller takes `RefreshToken` and gets the identity from its own `Verify`, because the identity has to be established **before** deciding whether to exchange at all — so `Subject`/`ClientID`/`Claims` were always redundant.
- **`companyScoped`.** The rule it declares is enforced structurally by `matchRule`, which returns `("", false)` on a crawled board before `ruleBusiness`/`ruleUnknown` are reachable — and `rule_test` already checks that property against `matchRule`. `plan.go`'s `refused` comment described it as a company-scoped counter; the one live refusal is the source gate.
- **`LinkTokens.Issue`.** The two-result shape was parity with `discordbot.DiscordLinkTokens`, removed from main in `937ed92f`. Takes a dead branch in `handler/telegram.go` and four `t.Fatal(err)` pairs with it.

## Verification

`gofmt -l .` clean; `go build ./...`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`, `golangci-lint` (0 issues on every touched package) all pass.

**−148 / +65.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Saved-job reminders are now properly connected to the email workflow, ensuring reminder rules are applied consistently.
  - Apple sign-in exchanges now continue using refresh tokens correctly during account authentication.
  - Application and job-submission flows now rely on more consistent timeout and completion handling.

- **Refactor**
  - Simplified internal handling for Telegram sign-in links and authentication data without changing the user-facing flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->