### PR TITLE
Delete a board's board_health row when it is retired

### DIFF
--- a/cmd/prune/boards_test.go
+++ b/cmd/prune/boards_test.go
@@ -18,6 +18,9 @@ type fakeCatalog struct {
 	listErr error
 	// retired records every (provider, board, region) the run retired, in order.
 	retired []db.RetireBoardParams
+	// healthDeleted records every (provider, board, region) whose board_health row the
+	// run deleted, in order.
+	healthDeleted []db.DeleteBoardHealthParams
 }
 
 func (f *fakeCatalog) ListLiveBoards(context.Context) ([]db.ListLiveBoardsRow, error) {
@@ -26,6 +29,11 @@ func (f *fakeCatalog) ListLiveBoards(context.Context) ([]db.ListLiveBoardsRow, e
 
 func (f *fakeCatalog) RetireBoard(_ context.Context, arg db.RetireBoardParams) (int64, error) {
 	f.retired = append(f.retired, arg)
+	return 1, nil
+}
+
+func (f *fakeCatalog) DeleteBoardHealth(_ context.Context, arg db.DeleteBoardHealthParams) (int64, error) {
+	f.healthDeleted = append(f.healthDeleted, arg)
 	return 1, nil
 }
 

--- a/cmd/prune/retire.go
+++ b/cmd/prune/retire.go
@@ -11,6 +11,10 @@ import (
 // boardRetirer is the write cmd/prune needs from the catalog.
 type boardRetirer interface {
 	RetireBoard(ctx context.Context, arg db.RetireBoardParams) (int64, error)
+	// DeleteBoardHealth drops a retired board's health row — see the query's own doc
+	// comment: left in place it would show as permanently unhealthy on /status forever,
+	// since a retired board is never crawled again to clear it the normal way.
+	DeleteBoardHealth(ctx context.Context, arg db.DeleteBoardHealthParams) (int64, error)
 }
 
 // retireBoards flips the named boards to status='retired' in the catalog — the status
@@ -58,6 +62,14 @@ func retireBoards(ctx context.Context, q boardRetirer, brd boards, retire []boar
 				return retired, heldNames, fmt.Errorf("prune: retire %s/%s: %w", k.Provider, k.Board, err)
 			}
 			retired += int(n)
+			if n == 0 {
+				continue
+			}
+			if _, err := q.DeleteBoardHealth(ctx, db.DeleteBoardHealthParams{
+				Provider: k.Provider, Board: k.Board, Region: region,
+			}); err != nil {
+				return retired, heldNames, fmt.Errorf("prune: delete board_health %s/%s: %w", k.Provider, k.Board, err)
+			}
 		}
 	}
 	return retired, heldNames, nil

--- a/cmd/prune/retire_test.go
+++ b/cmd/prune/retire_test.go
@@ -39,6 +39,9 @@ func TestRetireBoardsNamesEveryRegionOfABoard(t *testing.T) {
 			t.Errorf("retired %+v, want only the dead board", got)
 		}
 	}
+	if len(cat.healthDeleted) != 2 {
+		t.Errorf("healthDeleted = %+v, want a board_health delete for both regional rows", cat.healthDeleted)
+	}
 }
 
 // The one-way door: a provider with no live board is never crawled again, and the

--- a/internal/ingest/boardcatalog/repository.go
+++ b/internal/ingest/boardcatalog/repository.go
@@ -207,7 +207,16 @@ func (r *QueriesRepository) Retire(ctx context.Context, provider, board, region 
 	if err != nil {
 		return false, err
 	}
-	return n > 0, nil
+	if n == 0 {
+		return false, nil
+	}
+	// A retired board is never crawled again, so its board_health row could never clear
+	// the normal way (a successful crawl) — left in place it shows as permanently
+	// unhealthy on the public /status page. The catalog retirement above already
+	// persisted regardless of what happens here; a failure just surfaces to the caller
+	// as found=true, err!=nil rather than silently leaving stale health behind.
+	_, err = r.q.DeleteBoardHealth(ctx, db.DeleteBoardHealthParams{Provider: provider, Board: board, Region: region})
+	return true, err
 }
 
 func (r *QueriesRepository) Rename(ctx context.Context, provider, board, region, company string) (bool, error) {

--- a/internal/ingest/boardcatalog/repository_integration_test.go
+++ b/internal/ingest/boardcatalog/repository_integration_test.go
@@ -140,6 +140,41 @@ func TestInsertAcceptsResubmissionAfterRetirement(t *testing.T) {
 	}
 }
 
+// A retired board is never crawled again, so its board_health row could never clear the
+// normal way (a successful crawl) — Retire must delete it, or the provider shows as
+// permanently unhealthy on the public /status page forever.
+func TestRetireDeletesTheBoardsHealthRow(t *testing.T) {
+	pool := testdb.Pool(t)
+	repo := NewQueriesRepository(db.New(pool))
+	ctx := context.Background()
+	in := InsertInput{Provider: "lever", Board: "flaky", Company: "Flaky Co"}
+
+	b, err := NewInserter(repo, sources.Taxonomy()).Insert(ctx, in, StatusActive)
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO board_health (provider, board, region, consecutive_failures, cooldown_until)
+		 VALUES ($1, $2, $3, 20, now() + interval '1 day')`,
+		b.Provider, b.Board, b.Region); err != nil {
+		t.Fatalf("seed board_health: %v", err)
+	}
+
+	if found, err := repo.Retire(ctx, b.Provider, b.Board, b.Region); err != nil || !found {
+		t.Fatalf("Retire = %v,%v, want found", found, err)
+	}
+
+	var n int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM board_health WHERE provider = $1 AND board = $2 AND region = $3`,
+		b.Provider, b.Board, b.Region).Scan(&n); err != nil {
+		t.Fatalf("count board_health: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("board_health rows remaining = %d, want 0 (Retire should have deleted it)", n)
+	}
+}
+
 func TestRenameCorrectsAPlaceholderCompany(t *testing.T) {
 	repo := newRepo(t)
 	ctx := context.Background()

--- a/internal/platform/db/board_health.sql.go
+++ b/internal/platform/db/board_health.sql.go
@@ -29,6 +29,29 @@ func (q *Queries) ClearProviderCooldowns(ctx context.Context, provider string) (
 	return result.RowsAffected(), nil
 }
 
+const deleteBoardHealth = `-- name: DeleteBoardHealth :execrows
+DELETE FROM board_health
+WHERE provider = $1 AND board = $2 AND region = $3
+`
+
+type DeleteBoardHealthParams struct {
+	Provider string `json:"provider"`
+	Board    string `json:"board"`
+	Region   string `json:"region"`
+}
+
+// Drop a board's health row entirely, for a board just retired from the catalog: it will
+// never be crawled again, so no cooldown or failure count of its own could ever clear the
+// normal way (a successful crawl), and leaving the row would show it as permanently
+// unhealthy on the public /status page (ProviderHealthRollup, ListUnhealthyBoards) forever.
+func (q *Queries) DeleteBoardHealth(ctx context.Context, arg DeleteBoardHealthParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteBoardHealth, arg.Provider, arg.Board, arg.Region)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const getBoardCooldown = `-- name: GetBoardCooldown :one
 SELECT cooldown_until
 FROM board_health

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -1164,6 +1164,11 @@ type Querier interface {
 	// but deletion states what it erases explicitly rather than relying on a constraint to
 	// mean it.
 	DeleteBillingEventsForUser(ctx context.Context, userID pgtype.Int8) error
+	// Drop a board's health row entirely, for a board just retired from the catalog: it will
+	// never be crawled again, so no cooldown or failure count of its own could ever clear the
+	// normal way (a successful crawl), and leaving the row would show it as permanently
+	// unhealthy on the public /status page (ProviderHealthRollup, ListUnhealthyBoards) forever.
+	DeleteBoardHealth(ctx context.Context, arg DeleteBoardHealthParams) (int64, error)
 	// Remove a submission once triage has resolved its (provider, board) and inserted the
 	// corresponding boards row.
 	DeleteBoardSubmission(ctx context.Context, id int64) (int64, error)

--- a/internal/platform/db/queries/board_health.sql
+++ b/internal/platform/db/queries/board_health.sql
@@ -40,6 +40,14 @@ UPDATE board_health
 SET cooldown_until = $4
 WHERE provider = $1 AND board = $2 AND region = $3;
 
+-- name: DeleteBoardHealth :execrows
+-- Drop a board's health row entirely, for a board just retired from the catalog: it will
+-- never be crawled again, so no cooldown or failure count of its own could ever clear the
+-- normal way (a successful crawl), and leaving the row would show it as permanently
+-- unhealthy on the public /status page (ProviderHealthRollup, ListUnhealthyBoards) forever.
+DELETE FROM board_health
+WHERE provider = $1 AND board = $2 AND region = $3;
+
 -- name: ListUnhealthyBoards :many
 -- The worst $1 boards currently failing or cooled down, worst first — the source of the
 -- per-run summary log. Every row also carries the FULL unhealthy count: count(*) OVER () is


### PR DESCRIPTION
## Summary
- A retired board is never crawled again, so its `board_health` row (cooldown/failure count) could never clear the normal way (a successful crawl) — left in place it showed the provider as permanently unhealthy on the public `/status` page forever.
- Adds `DeleteBoardHealth` (sqlc) and calls it from both retirement paths: `cmd/prune`'s `retireBoards` and `boardcatalog.QueriesRepository.Retire`, right after the retirement itself actually persists (a no-op retirement deletes nothing).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...` and `go vet -tags=integration ./internal/ingest/boardcatalog/...`
- [x] `go test ./cmd/prune/... ./internal/ingest/boardcatalog/... ./internal/platform/db/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)