### PR TITLE
Add GetLargeText and pace Eightfold's request rate

### DIFF
--- a/internal/ingest/sources/http.go
+++ b/internal/ingest/sources/http.go
@@ -80,6 +80,14 @@ type HeaderTextGetter interface {
 	GetTextWithHeaders(ctx context.Context, url string, headers map[string]string) (string, error)
 }
 
+// LargeTextGetter behaves like TextGetter but without its tighter maxTextBody cap, for the rare
+// adapter whose raw-body page is legitimately large because it inlines a whole feed rather than
+// carrying a link to scan for (e.g. Yandex Crowd's /vacancies page, which server-renders every
+// posting's full description into one <script> tag).
+type LargeTextGetter interface {
+	GetLargeText(ctx context.Context, url string) (string, error)
+}
+
 // JSONPoster sends a JSON request body and decodes the JSON response (platforms whose
 // listing API is POST-only, e.g. Workday).
 type JSONPoster interface {
@@ -122,6 +130,7 @@ type HTTPClient interface {
 	HTMLResolvedGetter
 	TextGetter
 	HeaderTextGetter
+	LargeTextGetter
 	JSONPoster
 	HeaderJSONGetter
 	HeaderJSONPoster
@@ -416,6 +425,24 @@ func (c *Client) GetTextWithHeaders(ctx context.Context, url string, headers map
 			// all. The bytes read so far are kept: io.ReadAll returns them with the error,
 			// and a caller that can use a prefix is entitled to the prefix.
 			b, err := io.ReadAll(newCappedReader(resp.Body, url, maxTextBody))
+			body = string(b)
+			return err
+		},
+	})
+	return body, err
+}
+
+// GetLargeText fetches url and returns its raw response body, like GetText but without the
+// maxTextBody cap — bounded only by the client's own default (bodyLimit, 64 MiB), for a page
+// that inlines a whole feed rather than a link a caller scans for.
+func (c *Client) GetLargeText(ctx context.Context, url string) (string, error) {
+	var body string
+	err := c.do(ctx, request{
+		method: http.MethodGet,
+		url:    url,
+		accept: "text/html",
+		decode: func(resp *http.Response) error {
+			b, err := io.ReadAll(resp.Body)
 			body = string(b)
 			return err
 		},

--- a/internal/ingest/sources/http_test.go
+++ b/internal/ingest/sources/http_test.go
@@ -399,6 +399,28 @@ func TestClientGetTextAcceptsAPageExactlyAtTheTextCap(t *testing.T) {
 	}
 }
 
+// Regression: Yandex Crowd's /vacancies page inlines every posting's full description in one
+// <script> tag and, by September 2026, had grown past GetText's 2 MiB link-probe cap
+// (maxTextBody) despite being a perfectly well-formed catalogue. GetLargeText exists exactly
+// for this shape — bounded only by the client's own default (maxResponseBody), not maxTextBody.
+func TestClientGetLargeTextAcceptsBodyPastTheTextCap(t *testing.T) {
+	want := strings.Repeat("y", maxTextBody+1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(want))
+	}))
+	defer srv.Close()
+
+	c := &Client{httpClient: srv.Client(), maxRetries: 2}
+
+	body, err := c.GetLargeText(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("GetLargeText: %v", err)
+	}
+	if body != want {
+		t.Errorf("body length = %d, want %d", len(body), len(want))
+	}
+}
+
 // The cap is inclusive: a body of exactly maxBody bytes is complete, not truncated.
 func TestClientGetJSONAcceptsBodyExactlyAtCap(t *testing.T) {
 	body := `{"content":"acme"}`

--- a/internal/ingest/sources/pacer.go
+++ b/internal/ingest/sources/pacer.go
@@ -206,6 +206,34 @@ func pacedSeekPoster(c JSONPoster) JSONPoster {
 	}
 }
 
+// Eightfold rate-limits an IP to ~290 requests per window (see eightfold.go), and its crawl
+// egresses through the single shared proxy IP alongside a dozen other providers
+// (proxiedProviders) — so its own concurrency cap (eightfoldDetailWorkers) and retry backoff
+// are not enough on their own; the aggregate request START rate needs its own ceiling,
+// independent of how many boards run in parallel. September 2026: unpaced, ~44 of ~95 boards
+// were failing their LISTING call (both list-API generations 403ing), the shape of a window
+// already spent by the run's own volume rather than a hard IP blocklist (a direct request
+// elsewhere in the same run succeeds). The interval below is deliberately conservative — as
+// cautious as vagas's, the gentlest existing pace on this shared proxy — because the true
+// per-window budget eightfold enforces, and how much of it the other proxied providers'
+// concurrent traffic already spends, are both unmeasured. Tune from observed convergence
+// (the board_health unhealthy count for this provider), downward while boards still fail
+// their listing call and upward only while none do.
+const (
+	eightfoldRequestInterval = time.Second // ~1 req/s
+	eightfoldRequestBurst    = 1
+)
+
+// pacedEightfoldGetter wraps a getter with a fresh limiter shared across one registry build,
+// so every board's listing pages and detail fan-out in a run compete for the same token
+// bucket — both paths hit the same rate-limited edge.
+func pacedEightfoldGetter(c JSONGetter) JSONGetter {
+	return rateLimitedJSONGetter{
+		inner:   c,
+		limiter: rate.NewLimiter(rate.Every(eightfoldRequestInterval), eightfoldRequestBurst),
+	}
+}
+
 // concurrencyLimitedJSONGetter bounds how many GetJSON calls are in flight at once via a shared
 // semaphore, independent of the pipeline's board-worker pool. Unlike a rate limiter — which caps
 // the request START rate but lets slow requests pile up concurrently — this caps simultaneous

--- a/internal/ingest/sources/proxy.go
+++ b/internal/ingest/sources/proxy.go
@@ -17,7 +17,10 @@ import (
 // Only providers served by the standard client belong here — the fingerprint-client
 // providers (bayt/gulftalent) would need proxy support wired into fingerprintHTTP instead.
 var proxiedProviders = map[string]func(HTTPClient) Source{
-	"eightfold": func(c HTTPClient) Source { return NewEightfold(c) },
+	// Also paced (pacedEightfoldGetter): the proxy alone recovers an outright IP blocklist,
+	// but eightfold's failures are volume rate-limiting — its own ~290-req/window cap, spent
+	// by this crawl's own aggregate rate across the shared proxy IP. See pacer.go.
+	"eightfold": func(c HTTPClient) Source { return NewEightfold(pacedEightfoldGetter(c)) },
 	"wantapply": func(c HTTPClient) Source { return NewWantapply(c) },
 	// djinni.co IP-blocklists the prod datacenter IP: a fast crawl escalates to a hard "your
 	// IP has been blocked" page, while a residential IP is served the full JSON-LD listing.

--- a/internal/ingest/sources/smartrecruiters_test.go
+++ b/internal/ingest/sources/smartrecruiters_test.go
@@ -147,6 +147,21 @@ func (r *routedHTTP) GetText(_ context.Context, url string) (string, error) {
 	return "", fmt.Errorf("routedHTTP: no route for %s", url)
 }
 
+func (r *routedHTTP) GetLargeText(_ context.Context, url string) (string, error) {
+	r.mu.Lock()
+	r.calls++
+	r.mu.Unlock()
+	if err := r.routedErr(url); err != nil {
+		return "", err
+	}
+	for _, rt := range r.routes {
+		if strings.Contains(url, rt.match) {
+			return rt.body, nil
+		}
+	}
+	return "", fmt.Errorf("routedHTTP: no route for %s", url)
+}
+
 func (r *routedHTTP) decode(url string, unmarshal func([]byte, any) error, v any) error {
 	r.mu.Lock()
 	r.calls++

--- a/internal/ingest/sources/yandexcrowd.go
+++ b/internal/ingest/sources/yandexcrowd.go
@@ -16,11 +16,13 @@ import (
 // `available`, which still resolve. Identity is the vacancy's URL path (a stable slug such as
 // "support/finteh_chat"); the float `id` is a positional index and is ignored.
 type yandexcrowd struct {
-	http TextGetter
+	http LargeTextGetter
 }
 
-// NewYandexCrowd builds the Yandex Crowd adapter over the given HTTP client.
-func NewYandexCrowd(c TextGetter) Source { return yandexcrowd{http: c} }
+// NewYandexCrowd builds the Yandex Crowd adapter over the given HTTP client. It needs
+// GetLargeText, not GetText: the listing inlines every posting's full description, and by
+// September 2026 that page had grown past GetText's 2 MiB link-probe cap.
+func NewYandexCrowd(c LargeTextGetter) Source { return yandexcrowd{http: c} }
 
 func (yandexcrowd) Provider() string { return "yandexcrowd" }
 
@@ -54,7 +56,7 @@ type yandexCrowdVacancy struct {
 }
 
 func (y yandexcrowd) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
-	body, err := y.http.GetText(ctx, yandexCrowdListURL)
+	body, err := y.http.GetLargeText(ctx, yandexCrowdListURL)
 	if err != nil {
 		return nil, fmt.Errorf("yandexcrowd: listing: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Yandex Crowd's `/vacancies` page inlines every posting's full description into one `<script>` tag and, by September 2026, had grown past `GetText`'s 2 MiB link-probe cap (`maxTextBody`). New `LargeTextGetter`/`GetLargeText` (bounded only by the client's default body limit) replaces `GetText` for that adapter.
- Paces Eightfold's crawl to ~1 req/s (`pacedEightfoldGetter`): unpaced, ~44 of ~95 boards were failing their listing call (403), the shape of Eightfold's own ~290-req/window rate limit being spent by this crawl's aggregate volume across the shared proxy IP, not an IP blocklist the proxy alone would fix.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/ingest/sources/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)