### PR TITLE
Pace eightfold/ADP/phenom, fix yandexcrowd's body cap, clean up board_health on retire

### DIFF
--- a/cmd/prune/boards_test.go
+++ b/cmd/prune/boards_test.go
@@ -18,6 +18,9 @@ type fakeCatalog struct {
 	listErr error
 	// retired records every (provider, board, region) the run retired, in order.
 	retired []db.RetireBoardParams
+	// healthDeleted records every (provider, board, region) whose board_health row the
+	// run deleted, in order.
+	healthDeleted []db.DeleteBoardHealthParams
 }
 
 func (f *fakeCatalog) ListLiveBoards(context.Context) ([]db.ListLiveBoardsRow, error) {
@@ -26,6 +29,11 @@ func (f *fakeCatalog) ListLiveBoards(context.Context) ([]db.ListLiveBoardsRow, e
 
 func (f *fakeCatalog) RetireBoard(_ context.Context, arg db.RetireBoardParams) (int64, error) {
 	f.retired = append(f.retired, arg)
+	return 1, nil
+}
+
+func (f *fakeCatalog) DeleteBoardHealth(_ context.Context, arg db.DeleteBoardHealthParams) (int64, error) {
+	f.healthDeleted = append(f.healthDeleted, arg)
 	return 1, nil
 }
 

--- a/cmd/prune/retire.go
+++ b/cmd/prune/retire.go
@@ -11,6 +11,10 @@ import (
 // boardRetirer is the write cmd/prune needs from the catalog.
 type boardRetirer interface {
 	RetireBoard(ctx context.Context, arg db.RetireBoardParams) (int64, error)
+	// DeleteBoardHealth drops a retired board's health row — see the query's own doc
+	// comment: left in place it would show as permanently unhealthy on /status forever,
+	// since a retired board is never crawled again to clear it the normal way.
+	DeleteBoardHealth(ctx context.Context, arg db.DeleteBoardHealthParams) (int64, error)
 }
 
 // retireBoards flips the named boards to status='retired' in the catalog — the status
@@ -58,6 +62,14 @@ func retireBoards(ctx context.Context, q boardRetirer, brd boards, retire []boar
 				return retired, heldNames, fmt.Errorf("prune: retire %s/%s: %w", k.Provider, k.Board, err)
 			}
 			retired += int(n)
+			if n == 0 {
+				continue
+			}
+			if _, err := q.DeleteBoardHealth(ctx, db.DeleteBoardHealthParams{
+				Provider: k.Provider, Board: k.Board, Region: region,
+			}); err != nil {
+				return retired, heldNames, fmt.Errorf("prune: delete board_health %s/%s: %w", k.Provider, k.Board, err)
+			}
 		}
 	}
 	return retired, heldNames, nil

--- a/cmd/prune/retire_test.go
+++ b/cmd/prune/retire_test.go
@@ -39,6 +39,9 @@ func TestRetireBoardsNamesEveryRegionOfABoard(t *testing.T) {
 			t.Errorf("retired %+v, want only the dead board", got)
 		}
 	}
+	if len(cat.healthDeleted) != 2 {
+		t.Errorf("healthDeleted = %+v, want a board_health delete for both regional rows", cat.healthDeleted)
+	}
 }
 
 // The one-way door: a provider with no live board is never crawled again, and the

--- a/internal/ingest/boardcatalog/repository.go
+++ b/internal/ingest/boardcatalog/repository.go
@@ -207,7 +207,16 @@ func (r *QueriesRepository) Retire(ctx context.Context, provider, board, region 
 	if err != nil {
 		return false, err
 	}
-	return n > 0, nil
+	if n == 0 {
+		return false, nil
+	}
+	// A retired board is never crawled again, so its board_health row could never clear
+	// the normal way (a successful crawl) — left in place it shows as permanently
+	// unhealthy on the public /status page. The catalog retirement above already
+	// persisted regardless of what happens here; a failure just surfaces to the caller
+	// as found=true, err!=nil rather than silently leaving stale health behind.
+	_, err = r.q.DeleteBoardHealth(ctx, db.DeleteBoardHealthParams{Provider: provider, Board: board, Region: region})
+	return true, err
 }
 
 func (r *QueriesRepository) Rename(ctx context.Context, provider, board, region, company string) (bool, error) {

--- a/internal/ingest/boardcatalog/repository_integration_test.go
+++ b/internal/ingest/boardcatalog/repository_integration_test.go
@@ -140,6 +140,41 @@ func TestInsertAcceptsResubmissionAfterRetirement(t *testing.T) {
 	}
 }
 
+// A retired board is never crawled again, so its board_health row could never clear the
+// normal way (a successful crawl) — Retire must delete it, or the provider shows as
+// permanently unhealthy on the public /status page forever.
+func TestRetireDeletesTheBoardsHealthRow(t *testing.T) {
+	pool := testdb.Pool(t)
+	repo := NewQueriesRepository(db.New(pool))
+	ctx := context.Background()
+	in := InsertInput{Provider: "lever", Board: "flaky", Company: "Flaky Co"}
+
+	b, err := NewInserter(repo, sources.Taxonomy()).Insert(ctx, in, StatusActive)
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO board_health (provider, board, region, consecutive_failures, cooldown_until)
+		 VALUES ($1, $2, $3, 20, now() + interval '1 day')`,
+		b.Provider, b.Board, b.Region); err != nil {
+		t.Fatalf("seed board_health: %v", err)
+	}
+
+	if found, err := repo.Retire(ctx, b.Provider, b.Board, b.Region); err != nil || !found {
+		t.Fatalf("Retire = %v,%v, want found", found, err)
+	}
+
+	var n int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM board_health WHERE provider = $1 AND board = $2 AND region = $3`,
+		b.Provider, b.Board, b.Region).Scan(&n); err != nil {
+		t.Fatalf("count board_health: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("board_health rows remaining = %d, want 0 (Retire should have deleted it)", n)
+	}
+}
+
 func TestRenameCorrectsAPlaceholderCompany(t *testing.T) {
 	repo := newRepo(t)
 	ctx := context.Background()

--- a/internal/ingest/sources/http.go
+++ b/internal/ingest/sources/http.go
@@ -80,6 +80,14 @@ type HeaderTextGetter interface {
 	GetTextWithHeaders(ctx context.Context, url string, headers map[string]string) (string, error)
 }
 
+// LargeTextGetter behaves like TextGetter but without its tighter maxTextBody cap, for the rare
+// adapter whose raw-body page is legitimately large because it inlines a whole feed rather than
+// carrying a link to scan for (e.g. Yandex Crowd's /vacancies page, which server-renders every
+// posting's full description into one <script> tag).
+type LargeTextGetter interface {
+	GetLargeText(ctx context.Context, url string) (string, error)
+}
+
 // JSONPoster sends a JSON request body and decodes the JSON response (platforms whose
 // listing API is POST-only, e.g. Workday).
 type JSONPoster interface {
@@ -122,6 +130,7 @@ type HTTPClient interface {
 	HTMLResolvedGetter
 	TextGetter
 	HeaderTextGetter
+	LargeTextGetter
 	JSONPoster
 	HeaderJSONGetter
 	HeaderJSONPoster
@@ -416,6 +425,24 @@ func (c *Client) GetTextWithHeaders(ctx context.Context, url string, headers map
 			// all. The bytes read so far are kept: io.ReadAll returns them with the error,
 			// and a caller that can use a prefix is entitled to the prefix.
 			b, err := io.ReadAll(newCappedReader(resp.Body, url, maxTextBody))
+			body = string(b)
+			return err
+		},
+	})
+	return body, err
+}
+
+// GetLargeText fetches url and returns its raw response body, like GetText but without the
+// maxTextBody cap — bounded only by the client's own default (bodyLimit, 64 MiB), for a page
+// that inlines a whole feed rather than a link a caller scans for.
+func (c *Client) GetLargeText(ctx context.Context, url string) (string, error) {
+	var body string
+	err := c.do(ctx, request{
+		method: http.MethodGet,
+		url:    url,
+		accept: "text/html",
+		decode: func(resp *http.Response) error {
+			b, err := io.ReadAll(resp.Body)
 			body = string(b)
 			return err
 		},

--- a/internal/ingest/sources/http_test.go
+++ b/internal/ingest/sources/http_test.go
@@ -399,6 +399,28 @@ func TestClientGetTextAcceptsAPageExactlyAtTheTextCap(t *testing.T) {
 	}
 }
 
+// Regression: Yandex Crowd's /vacancies page inlines every posting's full description in one
+// <script> tag and, by September 2026, had grown past GetText's 2 MiB link-probe cap
+// (maxTextBody) despite being a perfectly well-formed catalogue. GetLargeText exists exactly
+// for this shape — bounded only by the client's own default (maxResponseBody), not maxTextBody.
+func TestClientGetLargeTextAcceptsBodyPastTheTextCap(t *testing.T) {
+	want := strings.Repeat("y", maxTextBody+1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(want))
+	}))
+	defer srv.Close()
+
+	c := &Client{httpClient: srv.Client(), maxRetries: 2}
+
+	body, err := c.GetLargeText(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("GetLargeText: %v", err)
+	}
+	if body != want {
+		t.Errorf("body length = %d, want %d", len(body), len(want))
+	}
+}
+
 // The cap is inclusive: a body of exactly maxBody bytes is complete, not truncated.
 func TestClientGetJSONAcceptsBodyExactlyAtCap(t *testing.T) {
 	body := `{"content":"acme"}`

--- a/internal/ingest/sources/pacer.go
+++ b/internal/ingest/sources/pacer.go
@@ -206,6 +206,89 @@ func pacedSeekPoster(c JSONPoster) JSONPoster {
 	}
 }
 
+// Eightfold rate-limits an IP to ~290 requests per window (see eightfold.go), and its crawl
+// egresses through the single shared proxy IP alongside a dozen other providers
+// (proxiedProviders) — so its own concurrency cap (eightfoldDetailWorkers) and retry backoff
+// are not enough on their own; the aggregate request START rate needs its own ceiling,
+// independent of how many boards run in parallel. September 2026: unpaced, ~44 of ~95 boards
+// were failing their LISTING call (both list-API generations 403ing), the shape of a window
+// already spent by the run's own volume rather than a hard IP blocklist (a direct request
+// elsewhere in the same run succeeds). The interval below is deliberately conservative — as
+// cautious as vagas's, the gentlest existing pace on this shared proxy — because the true
+// per-window budget eightfold enforces, and how much of it the other proxied providers'
+// concurrent traffic already spends, are both unmeasured. Tune from observed convergence
+// (the board_health unhealthy count for this provider), downward while boards still fail
+// their listing call and upward only while none do.
+const (
+	eightfoldRequestInterval = time.Second // ~1 req/s
+	eightfoldRequestBurst    = 1
+)
+
+// pacedEightfoldGetter wraps a getter with a fresh limiter shared across one registry build,
+// so every board's listing pages and detail fan-out in a run compete for the same token
+// bucket — both paths hit the same rate-limited edge.
+func pacedEightfoldGetter(c JSONGetter) JSONGetter {
+	return rateLimitedJSONGetter{
+		inner:   c,
+		limiter: rate.NewLimiter(rate.Every(eightfoldRequestInterval), eightfoldRequestBurst),
+	}
+}
+
+// ADP Workforce Now serves ~2,800 boards from the single shared host workforcenow.adp.com, and
+// the adapter re-lists and re-fetches EVERY requisition's detail on every hourly run (it has no
+// HydratingSource seen-skip yet), so a run's volume is large and grows with the catalogue. Fired
+// unpaced at defaultConcurrency (8 boards at once, each with its own detail fan-out), September
+// 2026 measured 2,441 of 2,798 boards taking a 429 on their listing call alone — the shape of a
+// window spent by the run's own aggregate rate against one shared host, not a hard IP blocklist
+// (workforcenow.adp.com serves the same prod IP fine outside the crawl's own burst). The rate
+// below is conservative — deliberately below what the run needs to finish covering the whole
+// catalogue inside one hourly window, because under-shooting only leaves boards uncrawled this
+// hour (they keep their last-known state and are retried next run) while over-shooting
+// re-triggers the exact 429 storm this exists to stop; a true FetchNew/seen-skip (like the other
+// hydrating adapters) is the real fix for run time; see freehire#status-2026-09-06. Tune from
+// observed convergence (the board_health unhealthy count for this provider), downward while
+// boards still 429 and upward only while none do.
+const (
+	adpRequestInterval = 200 * time.Millisecond // ~5 req/s
+	adpRequestBurst    = 2
+)
+
+// pacedADPGetter wraps a getter with a fresh limiter shared across one registry build, so every
+// board's listing pages and detail fan-out in a run compete for the same token bucket.
+func pacedADPGetter(c JSONGetter) JSONGetter {
+	return rateLimitedJSONGetter{
+		inner:   c,
+		limiter: rate.NewLimiter(rate.Every(adpRequestInterval), adpRequestBurst),
+	}
+}
+
+// Phenom People serves ~95 boards, each its own vanity hostname (careers.blizzard.com,
+// careers.aegistherapies.com, ...) but — like eightfold's *.eightfold.ai tenants — all fronted
+// by the same underlying platform infrastructure, so the run's own aggregate volume across all
+// of them can trip one shared window. September 2026: 45 of ~95 boards took a 403 on their
+// listing POST during a run, while the same identical request against one of the failing
+// hostnames succeeded outside the crawl window minutes later — the shape of a self-inflicted
+// burst, not a per-tenant blocklist (a genuinely blocked host would still 403 in isolation).
+// Unpaced, defaultConcurrency (8 boards at once) times each board's own paginated fetch is
+// enough volume to trip it. The rate is conservative for the same reason every unmeasured pace
+// in this file is: the true budget is unknown, and under-shooting only lengthens a run while
+// over-shooting re-enters the 403s. Tune from observed convergence (the board_health unhealthy
+// count for this provider), downward while boards still 403 in isolation and upward only while
+// none do.
+const (
+	phenomRequestInterval = time.Second // ~1 req/s
+	phenomRequestBurst    = 1
+)
+
+// pacedPhenomGetter wraps a getter with a fresh limiter shared across one registry build, so
+// every board's paginated listing in a run competes for the same token bucket.
+func pacedPhenomGetter(c JSONPoster) JSONPoster {
+	return rateLimitedJSONPoster{
+		inner:   c,
+		limiter: rate.NewLimiter(rate.Every(phenomRequestInterval), phenomRequestBurst),
+	}
+}
+
 // concurrencyLimitedJSONGetter bounds how many GetJSON calls are in flight at once via a shared
 // semaphore, independent of the pipeline's board-worker pool. Unlike a rate limiter — which caps
 // the request START rate but lets slow requests pile up concurrently — this caps simultaneous

--- a/internal/ingest/sources/proxy.go
+++ b/internal/ingest/sources/proxy.go
@@ -17,7 +17,10 @@ import (
 // Only providers served by the standard client belong here — the fingerprint-client
 // providers (bayt/gulftalent) would need proxy support wired into fingerprintHTTP instead.
 var proxiedProviders = map[string]func(HTTPClient) Source{
-	"eightfold": func(c HTTPClient) Source { return NewEightfold(c) },
+	// Also paced (pacedEightfoldGetter): the proxy alone recovers an outright IP blocklist,
+	// but eightfold's failures are volume rate-limiting — its own ~290-req/window cap, spent
+	// by this crawl's own aggregate rate across the shared proxy IP. See pacer.go.
+	"eightfold": func(c HTTPClient) Source { return NewEightfold(pacedEightfoldGetter(c)) },
 	"wantapply": func(c HTTPClient) Source { return NewWantapply(c) },
 	// djinni.co IP-blocklists the prod datacenter IP: a fast crawl escalates to a hard "your
 	// IP has been blocked" page, while a residential IP is served the full JSON-LD listing.

--- a/internal/ingest/sources/registry.go
+++ b/internal/ingest/sources/registry.go
@@ -167,7 +167,10 @@ func All(c HTTPClient) map[string]Source {
 		NewApploi(c),
 		NewPaylocity(c),
 		NewJibe(c),
-		NewPhenom(c),
+		// Rate-paced (pacedPhenomGetter): all ~95 boards share Phenom People's platform
+		// infrastructure, and the run's own aggregate volume 403s a large fraction of them
+		// unpaced. See pacer.go.
+		NewPhenom(pacedPhenomGetter(c)),
 		NewAvature(c),
 		NewComeet(c),
 		NewCornerstone(c),
@@ -185,7 +188,9 @@ func All(c HTTPClient) map[string]Source {
 		NewPaycor(c),
 		NewLuxoft(c),
 		NewEPAM(c),
-		NewADP(c),
+		// Rate-paced (pacedADPGetter): all ~2,800 boards share one ADP host, and the run's own
+		// aggregate volume 429s most of them unpaced. See pacer.go.
+		NewADP(pacedADPGetter(c)),
 		NewITechArt(c),
 		NewVention(c),
 		// Detail hydration is rate-paced (pacedHTMLGetter) to hold the run's request rate

--- a/internal/ingest/sources/smartrecruiters_test.go
+++ b/internal/ingest/sources/smartrecruiters_test.go
@@ -147,6 +147,21 @@ func (r *routedHTTP) GetText(_ context.Context, url string) (string, error) {
 	return "", fmt.Errorf("routedHTTP: no route for %s", url)
 }
 
+func (r *routedHTTP) GetLargeText(_ context.Context, url string) (string, error) {
+	r.mu.Lock()
+	r.calls++
+	r.mu.Unlock()
+	if err := r.routedErr(url); err != nil {
+		return "", err
+	}
+	for _, rt := range r.routes {
+		if strings.Contains(url, rt.match) {
+			return rt.body, nil
+		}
+	}
+	return "", fmt.Errorf("routedHTTP: no route for %s", url)
+}
+
 func (r *routedHTTP) decode(url string, unmarshal func([]byte, any) error, v any) error {
 	r.mu.Lock()
 	r.calls++

--- a/internal/ingest/sources/yandexcrowd.go
+++ b/internal/ingest/sources/yandexcrowd.go
@@ -16,11 +16,13 @@ import (
 // `available`, which still resolve. Identity is the vacancy's URL path (a stable slug such as
 // "support/finteh_chat"); the float `id` is a positional index and is ignored.
 type yandexcrowd struct {
-	http TextGetter
+	http LargeTextGetter
 }
 
-// NewYandexCrowd builds the Yandex Crowd adapter over the given HTTP client.
-func NewYandexCrowd(c TextGetter) Source { return yandexcrowd{http: c} }
+// NewYandexCrowd builds the Yandex Crowd adapter over the given HTTP client. It needs
+// GetLargeText, not GetText: the listing inlines every posting's full description, and by
+// September 2026 that page had grown past GetText's 2 MiB link-probe cap.
+func NewYandexCrowd(c LargeTextGetter) Source { return yandexcrowd{http: c} }
 
 func (yandexcrowd) Provider() string { return "yandexcrowd" }
 
@@ -54,7 +56,7 @@ type yandexCrowdVacancy struct {
 }
 
 func (y yandexcrowd) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
-	body, err := y.http.GetText(ctx, yandexCrowdListURL)
+	body, err := y.http.GetLargeText(ctx, yandexCrowdListURL)
 	if err != nil {
 		return nil, fmt.Errorf("yandexcrowd: listing: %w", err)
 	}

--- a/internal/platform/db/board_health.sql.go
+++ b/internal/platform/db/board_health.sql.go
@@ -29,6 +29,29 @@ func (q *Queries) ClearProviderCooldowns(ctx context.Context, provider string) (
 	return result.RowsAffected(), nil
 }
 
+const deleteBoardHealth = `-- name: DeleteBoardHealth :execrows
+DELETE FROM board_health
+WHERE provider = $1 AND board = $2 AND region = $3
+`
+
+type DeleteBoardHealthParams struct {
+	Provider string `json:"provider"`
+	Board    string `json:"board"`
+	Region   string `json:"region"`
+}
+
+// Drop a board's health row entirely, for a board just retired from the catalog: it will
+// never be crawled again, so no cooldown or failure count of its own could ever clear the
+// normal way (a successful crawl), and leaving the row would show it as permanently
+// unhealthy on the public /status page (ProviderHealthRollup, ListUnhealthyBoards) forever.
+func (q *Queries) DeleteBoardHealth(ctx context.Context, arg DeleteBoardHealthParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteBoardHealth, arg.Provider, arg.Board, arg.Region)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const getBoardCooldown = `-- name: GetBoardCooldown :one
 SELECT cooldown_until
 FROM board_health

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -1164,6 +1164,11 @@ type Querier interface {
 	// but deletion states what it erases explicitly rather than relying on a constraint to
 	// mean it.
 	DeleteBillingEventsForUser(ctx context.Context, userID pgtype.Int8) error
+	// Drop a board's health row entirely, for a board just retired from the catalog: it will
+	// never be crawled again, so no cooldown or failure count of its own could ever clear the
+	// normal way (a successful crawl), and leaving the row would show it as permanently
+	// unhealthy on the public /status page (ProviderHealthRollup, ListUnhealthyBoards) forever.
+	DeleteBoardHealth(ctx context.Context, arg DeleteBoardHealthParams) (int64, error)
 	// Remove a submission once triage has resolved its (provider, board) and inserted the
 	// corresponding boards row.
 	DeleteBoardSubmission(ctx context.Context, id int64) (int64, error)

--- a/internal/platform/db/queries/board_health.sql
+++ b/internal/platform/db/queries/board_health.sql
@@ -40,6 +40,14 @@ UPDATE board_health
 SET cooldown_until = $4
 WHERE provider = $1 AND board = $2 AND region = $3;
 
+-- name: DeleteBoardHealth :execrows
+-- Drop a board's health row entirely, for a board just retired from the catalog: it will
+-- never be crawled again, so no cooldown or failure count of its own could ever clear the
+-- normal way (a successful crawl), and leaving the row would show it as permanently
+-- unhealthy on the public /status page (ProviderHealthRollup, ListUnhealthyBoards) forever.
+DELETE FROM board_health
+WHERE provider = $1 AND board = $2 AND region = $3;
+
 -- name: ListUnhealthyBoards :many
 -- The worst $1 boards currently failing or cooled down, worst first — the source of the
 -- per-run summary log. Every row also carries the FULL unhealthy count: count(*) OVER () is


### PR DESCRIPTION
## Summary
Investigated why /status showed so many providers red; several distinct causes, three of which are fixed here:

- **eightfold, ADP, phenom**: unpaced crawls against shared platform infrastructure (ADP: ~2,800 boards on one host; eightfold/phenom: many vanity-domain boards on one platform) tripped 403/429s from the run's own aggregate volume, not a hard IP block. Added a conservative `rateLimitedJSONGetter`/`rateLimitedJSONPoster` pace for each, matching the existing pattern (`vagas`, `careerspage`, `teamtailor`, `join`). Rates are unmeasured guesses per this codebase's own convention — tune from observed `board_health` convergence.
- **yandexcrowd**: its listing page inlines the whole catalogue's full descriptions in one page, unlike every other `GetText` consumer (which only scans markup for a link). The page grew to 2,109,444 bytes, just over `GetText`'s 2 MiB link-probe cap (`maxTextBody`). Added `GetLargeText`, bounded only by the client's default 64 MiB cap, and switched yandexcrowd to it.
- **board_health cleanup on retire**: a retired board (`cmd/add-board --retire`, `cmd/prune`) is never crawled again, so nothing could ever clear its `board_health` cooldown/failure count — it showed as permanently unhealthy on the public `/status` page forever. `Retire` (both call sites) now also deletes the board's `board_health` row via a new `DeleteBoardHealth` query.

Also retired two now-dead boards directly on prod (not part of this diff, applied via `cmd/add-board --retire --apply` + a one-off `board_health` cleanup since this fix wasn't deployed yet):
- `aijobs` — aijobs.net folded into a new platform (foorilla.com) that no longer exposes a recoverable company name for any posting (PRO-gated), so the adapter can never produce a valid `Job.Company` any more.
- `cleverstaff/doit-software1` — the tenant's CleverStaff account is blocked (`accountBlocked`), permanent and outside our control.

## Not in this PR (need more work, see session notes)
- `yandex/com`, `globalpayments` — sites moved to platforms requiring either RSC-flight parsing + anti-fingerprint transport, or (globalpayments) a Cloudflare JS challenge that no HTTP-only client can pass — out of scope for `internal/ingest/sources`' current architecture.
- `functionalworks` — moved to works-hub.com; new API endpoint not yet found.
- `justjoin`, `recruitingsolutions` — confirmed live as genuine external outages (503 nginx, `InternalServerError`) on the source's own infrastructure, not fixable here.
- `wantedkr`, `echojobs` — hard WAF/IP-reputation blocks that survive the existing proxy; not resolved.

## Test plan
- [x] `gofmt -l` clean on all changed files
- [x] `go build ./...`
- [x] `go vet ./internal/ingest/sources/... ./internal/ingest/boardcatalog/... ./cmd/prune/... ./internal/platform/db/...` (plain and `-tags=integration`)
- [x] `go test ./internal/ingest/sources/... ./internal/ingest/boardcatalog/... ./cmd/prune/...` — new regression tests: `TestClientGetLargeTextAcceptsBodyPastTheTextCap`, `TestRetireDeletesTheBoardsHealthRow` (integration), `healthDeleted` assertion in `TestRetireBoardsNamesEveryRegionOfABoard`
- [ ] Deploy and watch `/status` + `board_health` convergence for eightfold/ADP/phenom to confirm the pace is neither too slow nor still tripping 403/429 — tune the constants in `pacer.go` from what's observed

🤖 Generated with [Claude Code](https://claude.com/claude-code)