### PR TITLE
Tidy the curated-alias pass without changing what it plans

### DIFF
--- a/cmd/merge-companies/curated.go
+++ b/cmd/merge-companies/curated.go
@@ -1,7 +1,5 @@
 package main
 
-import "github.com/strelov1/freehire/internal/dict/normalize"
-
 // curatedAliases records slugs a human has decided are one employer where
 // normalize.CompanyKey cannot reach that conclusion on its own. Key is the slug retiring,
 // value is the slug that survives.
@@ -111,14 +109,3 @@ func curatedCanons(aliases map[string]string) map[string]bool {
 // normalize.CompanyKey can never emit, so a curated group can never collide with a folded
 // one — CompanyKey strips everything but letters and digits.
 func curatedGroupKey(canon string) string { return "\x00curated\x1e" + canon }
-
-// curatedCanonIsFixedPoint reports whether a canonical slug survives the slug rule unchanged.
-//
-// It has to. Every future posting from the surviving board derives its slug through
-// CompanySlug, so a canon the rule would rewrite could never be reached by an ordinary
-// crawl — the company would depend on an alias row forever to name itself. The same
-// requirement is why electCanonical derives the canon from a name rather than reusing a
-// stored slug.
-func curatedCanonIsFixedPoint(canon string) bool {
-	return normalize.CompanySlug(canon) == canon
-}

--- a/cmd/merge-companies/curated_test.go
+++ b/cmd/merge-companies/curated_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/strelov1/freehire/internal/dict/normalize"
+)
 
 // TestCuratedAliasesAreWellFormed is the guard that replaces reviewing the list by eye. Every
 // property here is one a wrong entry would break silently: the plan would still print, --apply
@@ -23,7 +27,12 @@ func TestCuratedAliasesAreWellFormed(t *testing.T) {
 			t.Errorf("%q -> %q, but %q is itself retiring: the registry resolves one hop, so "+
 				"%q would land on a slug with no jobs", aliasSlug, canon, canon, aliasSlug)
 		}
-		if !curatedCanonIsFixedPoint(canon) {
+		// A canon has to survive the slug rule unchanged. Every future posting from the
+		// surviving board derives its slug through CompanySlug, so a canon the rule would
+		// rewrite could never be reached by an ordinary crawl — the company would depend on
+		// an alias row forever to name itself. The same requirement is why electCanonical
+		// derives the canon from a name rather than reusing a stored slug.
+		if normalize.CompanySlug(canon) != canon {
 			t.Errorf("canonical %q is not a fixed point of CompanySlug: every future posting "+
 				"derives a different slug, so the company could never name itself", canon)
 		}

--- a/cmd/merge-companies/plan.go
+++ b/cmd/merge-companies/plan.go
@@ -98,13 +98,13 @@ func planMerges(companies []company, frozen map[string]bool, minJobs int, curate
 			continue
 		}
 		key := normalize.CompanyKey(c.Name)
+		if key == "" {
+			continue
+		}
 		// Two canons folding the same way would make the result depend on slice order, so the
 		// smaller slug wins and the outcome is stable. It is a mistake either way — the guard
 		// in curated_test.go rejects one canon retiring into another — but a deterministic
 		// plan is what makes a dry run worth reading.
-		if key == "" {
-			continue
-		}
 		if prev, ok := curatedFold[key]; !ok || c.Slug < prev {
 			curatedFold[key] = c.Slug
 		}
@@ -122,14 +122,19 @@ func planMerges(companies []company, frozen map[string]bool, minJobs int, curate
 			continue
 		}
 		// A curated member joins its canon's group; the canon joins its own; and so does
-		// anything the RULE would have grouped with the canon.
-		if canon, ok := curated[c.Slug]; ok {
-			key = curatedGroupKey(canon)
-			curatedWinner[key] = canon
-		} else if canons[c.Slug] {
-			key = curatedGroupKey(c.Slug)
-			curatedWinner[key] = c.Slug
-		} else if canon, ok := curatedFold[key]; ok {
+		// anything the RULE would have grouped with the canon. Three ways in, one canon out,
+		// and the key and the winner are set together — they have to agree, and setting them
+		// per branch is how they would come to disagree.
+		var canon string
+		switch {
+		case curated[c.Slug] != "":
+			canon = curated[c.Slug]
+		case canons[c.Slug]:
+			canon = c.Slug
+		default:
+			canon = curatedFold[key] // "" unless a curated canon owns this fold
+		}
+		if canon != "" {
 			key = curatedGroupKey(canon)
 			curatedWinner[key] = canon
 		}

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -2531,15 +2531,15 @@ type Querier interface {
 	// fail.
 	//
 	// The day in progress is EXCLUDED, and that predicate is the point of this query
-	// rather than a refinement of it. A plain max(day) reads TODAY: the 02:30 UTC rollup
-	// reaches past midnight into the log it is rotating and lands a few dozen rows on the
-	// current day, so by 13:00 UTC — when the digest runs — the freshest day is a stub
-	// whose best posting has one view. Nothing clears MinPageUniques, the run reports a
-	// quiet day and exits 0, and the completed day beside it is never published, because
-	// tomorrow's max(day) is fresher still. Measured on 2026-09-06: day 09-05 held 207020
-	// rows and 38 postings above the floor, day 09-06 held 34 rows and a maximum of one
-	// view; three digests had been lost this way. The failure is invisible from outside —
-	// a silent exit 0 is indistinguishable from a genuinely quiet day.
+	// rather than a refinement of it. A plain max(day) reads TODAY: that same run reaches
+	// past midnight into the log it is rotating and lands a few dozen rows on the current
+	// day, so by 13:00 UTC — when the digest runs — the freshest day is a stub whose best
+	// posting has one view. Nothing clears MinPageUniques, the run reports a quiet day and
+	// exits 0, and the completed day beside it is never published, because tomorrow's
+	// max(day) is fresher still. Measured on 2026-09-06: day 09-05 held 207020 rows and 38
+	// postings above the floor, day 09-06 held 34 rows and a maximum of one view; three
+	// digests had been lost this way, and a silent exit 0 is indistinguishable from a
+	// genuinely quiet day.
 	//
 	// The boundary is UTC because the column is: internal/application/viewlog/aggregate.go
 	// buckets each access-log record by rec.Time.UTC(). A bare CURRENT_DATE would follow

--- a/internal/platform/db/queries/social_digest.sql
+++ b/internal/platform/db/queries/social_digest.sql
@@ -16,15 +16,15 @@
 -- fail.
 --
 -- The day in progress is EXCLUDED, and that predicate is the point of this query
--- rather than a refinement of it. A plain max(day) reads TODAY: the 02:30 UTC rollup
--- reaches past midnight into the log it is rotating and lands a few dozen rows on the
--- current day, so by 13:00 UTC — when the digest runs — the freshest day is a stub
--- whose best posting has one view. Nothing clears MinPageUniques, the run reports a
--- quiet day and exits 0, and the completed day beside it is never published, because
--- tomorrow's max(day) is fresher still. Measured on 2026-09-06: day 09-05 held 207020
--- rows and 38 postings above the floor, day 09-06 held 34 rows and a maximum of one
--- view; three digests had been lost this way. The failure is invisible from outside —
--- a silent exit 0 is indistinguishable from a genuinely quiet day.
+-- rather than a refinement of it. A plain max(day) reads TODAY: that same run reaches
+-- past midnight into the log it is rotating and lands a few dozen rows on the current
+-- day, so by 13:00 UTC — when the digest runs — the freshest day is a stub whose best
+-- posting has one view. Nothing clears MinPageUniques, the run reports a quiet day and
+-- exits 0, and the completed day beside it is never published, because tomorrow's
+-- max(day) is fresher still. Measured on 2026-09-06: day 09-05 held 207020 rows and 38
+-- postings above the floor, day 09-06 held 34 rows and a maximum of one view; three
+-- digests had been lost this way, and a silent exit 0 is indistinguishable from a
+-- genuinely quiet day.
 --
 -- The boundary is UTC because the column is: internal/application/viewlog/aggregate.go
 -- buckets each access-log record by rec.Time.UTC(). A bare CURRENT_DATE would follow

--- a/internal/platform/db/social_digest.sql.go
+++ b/internal/platform/db/social_digest.sql.go
@@ -56,15 +56,15 @@ WHERE day < (now() AT TIME ZONE 'utc')::date
 // fail.
 //
 // The day in progress is EXCLUDED, and that predicate is the point of this query
-// rather than a refinement of it. A plain max(day) reads TODAY: the 02:30 UTC rollup
-// reaches past midnight into the log it is rotating and lands a few dozen rows on the
-// current day, so by 13:00 UTC — when the digest runs — the freshest day is a stub
-// whose best posting has one view. Nothing clears MinPageUniques, the run reports a
-// quiet day and exits 0, and the completed day beside it is never published, because
-// tomorrow's max(day) is fresher still. Measured on 2026-09-06: day 09-05 held 207020
-// rows and 38 postings above the floor, day 09-06 held 34 rows and a maximum of one
-// view; three digests had been lost this way. The failure is invisible from outside —
-// a silent exit 0 is indistinguishable from a genuinely quiet day.
+// rather than a refinement of it. A plain max(day) reads TODAY: that same run reaches
+// past midnight into the log it is rotating and lands a few dozen rows on the current
+// day, so by 13:00 UTC — when the digest runs — the freshest day is a stub whose best
+// posting has one view. Nothing clears MinPageUniques, the run reports a quiet day and
+// exits 0, and the completed day beside it is never published, because tomorrow's
+// max(day) is fresher still. Measured on 2026-09-06: day 09-05 held 207020 rows and 38
+// postings above the floor, day 09-06 held 34 rows and a maximum of one view; three
+// digests had been lost this way, and a silent exit 0 is indistinguishable from a
+// genuinely quiet day.
 //
 // The boundary is UTC because the column is: internal/application/viewlog/aggregate.go
 // buckets each access-log record by rec.Time.UTC(). A bare CURRENT_DATE would follow


### PR DESCRIPTION
Quality pass over the code the curated-alias work left behind. **No behaviour changes** — the existing tests pin the behaviour and stay green, untouched.

## Four things

**`planMerges` set the group key and the winning canon in each of three branches.** They have to agree, and setting them per branch is precisely how they would come to disagree. One `switch` now yields the canon, one block consumes it.

```go
var canon string
switch {
case curated[c.Slug] != "":
    canon = curated[c.Slug]
case canons[c.Slug]:
    canon = c.Slug
default:
    canon = curatedFold[key] // "" unless a curated canon owns this fold
}
if canon != "" {
    key = curatedGroupKey(canon)
    curatedWinner[key] = canon
}
```

**A comment sat above the wrong line** — the paragraph about two canons folding the same way explained the `curatedFold` write but was parked above the `key == ""` guard.

**`curatedCanonIsFixedPoint` lived in the production file and only the test called it.** Its body is one comparison, so the test makes it directly and carries the paragraph explaining why the invariant holds — which is the part worth keeping. `curated.go` no longer imports `normalize`.

**The `LatestJobViewDay` comment introduced `cmd/rollup-views`' 02:30 UTC run twice**, once per paragraph.

## Verification

`go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, and the unit tests for both touched packages. `make sqlc` re-run for the comment edit.
