### PR TITLE
Give the text cap room for a listing page that renders itself whole

### DIFF
--- a/internal/ingest/sources/http.go
+++ b/internal/ingest/sources/http.go
@@ -378,10 +378,21 @@ func (c *Client) GetXML(ctx context.Context, url string, v any) error {
 
 // maxTextBody caps the raw body GetText reads — tighter than the client's own
 // maxResponseBody, because these endpoints are markup a caller slices rather than a feed
-// that inlines every posting. Careers pages can be large, but the ATS link we scan for sits
-// in the markup, not megabytes of trailing content (the largest measured in production is
-// ~880 KB); the cap keeps a runaway page from ballooning memory.
-const maxTextBody = 2 << 20 // 2 MiB
+// that inlines every posting; the cap keeps a runaway page from ballooning memory.
+//
+// The ceiling is a measurement, and the previous one (2 MiB, "the largest measured in
+// production is ~880 KB") was outgrown rather than wrong. crowd.yandex.ru/vacancies renders
+// its whole listing into one page and reached 2,109,478 bytes on 2026-09-07 — 0.6% over,
+// enough to fail every crawl of that provider since 2026-09-06 and to keep failing as the
+// listing grows. A page that inlines its listing has no natural size, so the new figure
+// carries deliberate headroom rather than tracking the current largest: 8 MiB is 4x the
+// page that broke it and still 8x tighter than the feed cap, which is the distinction this
+// constant exists to draw.
+//
+// Growing past THIS one is reported, not silent (see GetText below), so the next page to
+// outgrow it says so with its size instead of returning short markup that reads like an
+// employer with no ATS link.
+const maxTextBody = 8 << 20 // 8 MiB
 
 // GetText fetches url and returns its raw response body as a string (capped at
 // maxTextBody). It serves adapters whose endpoint is a raw page they scan or slice

--- a/internal/ingest/sources/http_test.go
+++ b/internal/ingest/sources/http_test.go
@@ -352,10 +352,10 @@ func TestClientGetJSONSurfacesOversizedBodyAsTypedError(t *testing.T) {
 	}
 }
 
-// The text path caps tighter than the client does (maxTextBody, 2 MiB) and must name its
+// The text path caps tighter than the client does (maxTextBody) and must name its
 // own cut for the same reason: an adapter that slices markup for an embedded ATS link reads
 // a truncated page as a page that does not carry one, which is a different fact about a
-// different thing. do's 64 MiB cap can never fire for a 2 MiB read, so a bare io.LimitReader
+// different thing. do's 64 MiB cap can never fire for a text-path read, so a bare io.LimitReader
 // here left the truncation with no signal at all. The bytes read come back with the error —
 // cmd/harvest-boards' Common Crawl sweep is the one caller entitled to a prefix.
 func TestClientGetTextSurfacesATruncatedPageAsTypedError(t *testing.T) {
@@ -380,7 +380,7 @@ func TestClientGetTextSurfacesATruncatedPageAsTypedError(t *testing.T) {
 }
 
 // A page at exactly the text cap is complete, not truncated — the same inclusive boundary
-// the client's own cap keeps, so a 2 MiB page is not refused for being 2 MiB.
+// the client's own cap keeps, so a page the size of the cap is not refused for being it.
 func TestClientGetTextAcceptsAPageExactlyAtTheTextCap(t *testing.T) {
 	want := strings.Repeat("y", maxTextBody)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -418,5 +418,26 @@ func TestClientGetJSONAcceptsBodyExactlyAtCap(t *testing.T) {
 	}
 	if out.Content != "acme" {
 		t.Errorf("decoded content = %q, want %q", out.Content, "acme")
+	}
+}
+
+// yandexCrowdListingBytes is the size crowd.yandex.ru/vacancies had reached on 2026-09-07,
+// measured live. It is here as a regression floor, not as a target: that page renders its
+// whole listing inline, so it has no natural size, and it silently outgrew the previous
+// 2 MiB cap by 0.6% — enough to fail every crawl of the provider from 2026-09-06 with
+// "body exceeds 2097152 bytes" and to keep failing as the listing grew. If a future tightening
+// of maxTextBody drops below this, that provider breaks again the same way.
+const yandexCrowdListingBytes = 2_109_478
+
+func TestTextCapClearsTheListingPageThatOutgrewIt(t *testing.T) {
+	if maxTextBody <= yandexCrowdListingBytes {
+		t.Fatalf("maxTextBody = %d, must exceed the %d-byte page that broke the previous cap",
+			maxTextBody, yandexCrowdListingBytes)
+	}
+	// Headroom, not a snapshot: an inline listing only grows, and a cap that merely clears
+	// today's page buys one crawl before the next failure.
+	if maxTextBody < 2*yandexCrowdListingBytes {
+		t.Errorf("maxTextBody = %d leaves under 2x headroom over %d — a growing listing reaches it again",
+			maxTextBody, yandexCrowdListingBytes)
 	}
 }


### PR DESCRIPTION
## The bug

`crowd.yandex.ru/vacancies` reached **2,109,478 bytes** — 0.6% past the 2 MiB `maxTextBody` — and every `yandexcrowd` crawl has failed since 2026-09-06:

```
yandexcrowd: listing: sources: decode https://crowd.yandex.ru/vacancies:
  sources: GET https://crowd.yandex.ru/vacancies: body exceeds 2097152 bytes
```

The cap was not wrong, it was **outgrown**. Its own comment recorded *"the largest measured in production is ~880 KB"*, and that measurement has aged out.

## The fix

Raised to 8 MiB, with the new measurement written down beside it.

The figure carries deliberate **headroom** rather than tracking today's largest page: a page that renders its whole listing inline has no natural size, so a cap that merely clears the current one buys a single crawl before the next failure. 8 MiB is 4x the page that broke it and still 8x tighter than the 64 MiB feed cap — which is the distinction this constant exists to draw. These endpoints are markup a caller slices, not a feed that inlines every posting.

## What already worked, and is worth keeping

The failure was **loud**. `GetText` reports a truncated body as a typed `*BodyTooLargeError` with the size, rather than returning short markup — so this arrived as a named error instead of as an employer that appears to carry no ATS link. That is what made the diagnosis one log line. The test pinning it is unchanged.

## Tests

`TestTextCapClearsTheListingPageThatOutgrewIt` is a **floor, not a snapshot**: it fails if `maxTextBody` ever drops below the page that broke the old cap, and warns below 2x headroom. Verified by setting the constant back to 2 MiB — it fails with both byte counts named.

## Checks

`gofmt` clean, `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, full `go test ./...`. Pre-commit hooks passed including govulncheck, gitleaks and golangci-lint (0 issues).

## Context

Found while working through the 12 providers with no successful crawl in 24h, after the alert that reports them [became deliverable again](https://github.com/strelov1/freehire-ops/pull/71). This is the one of the twelve that was ours to fix in code; the rest are anti-bot 403s pending a residential proxy pool, or providers whose timer is deliberately disabled.
