### PR TITLE
Ask the same question once, in the three places yesterday's review fixes asked it twice

### DIFF
--- a/internal/application/mailrecall/mailrecall.go
+++ b/internal/application/mailrecall/mailrecall.go
@@ -400,14 +400,16 @@ func userPrompt(app Application, messages []Message) string {
 		// bounded from the start; the headers were the half nobody capped.
 		fmt.Fprintf(&b, "\n%s %d\nFrom: %s <%s>\nDate: %s\nSubject: %s\n\n%s\n",
 			delimiter, i+1,
-			llm.TruncateRunes(m.FromName, maxHeaderRunes),
-			llm.TruncateRunes(m.FromAddr, maxHeaderRunes),
+			boundedHeader(m.FromName), boundedHeader(m.FromAddr),
 			m.ReceivedAt.Format(time.DateOnly),
-			llm.TruncateRunes(m.Subject, maxHeaderRunes),
-			body(m))
+			boundedHeader(m.Subject), body(m))
 	}
 	return b.String()
 }
+
+// boundedHeader caps one header field. See maxHeaderRunes for why the headers need it as
+// much as the body does.
+func boundedHeader(s string) string { return llm.TruncateRunes(s, maxHeaderRunes) }
 
 // body renders one message for the prompt: the readable part, bounded, with any line
 // forging the batch delimiter neutralised.

--- a/internal/candidate/hardconstraint/credentials/credentials.go
+++ b/internal/candidate/hardconstraint/credentials/credentials.go
@@ -163,9 +163,7 @@ func ScanLine(text string) []string { return scan(text, true) }
 // space-delimited word boundaries (the leaf package does its own boundary check to avoid a
 // dependency), so "PMP" resolves but "pmp" inside another token does not.
 //
-// bareAcronyms admits the single-word aliases of a proseAmbiguous entry. A multi-word
-// alias is never ambiguous — nobody writes "certified information systems auditor" by
-// accident — so the distinction needs no second list to drift from the first.
+// bareAcronyms admits the single-word aliases of a proseAmbiguous entry — see the loop.
 func scan(text string, bareAcronyms bool) []string {
 	norm := normalize(text)
 	if norm == "" {
@@ -174,8 +172,13 @@ func scan(text string, bareAcronyms bool) []string {
 	padded := " " + norm + " "
 	var out []string
 	for _, e := range table {
+		// A prose-ambiguous entry is read only from an alias that SPELLS the credential
+		// out, because its bare acronym is a word the text may be using for something
+		// else. Multi-word is the test: nobody writes "certified public accountant" by
+		// accident, so this needs no second list to drift from the first.
+		speltOutOnly := e.proseAmbiguous && !bareAcronyms
 		for _, a := range e.aliases {
-			if e.proseAmbiguous && !bareAcronyms && !strings.Contains(a, " ") {
+			if speltOutOnly && !strings.Contains(a, " ") {
 				continue
 			}
 			if strings.Contains(padded, " "+a+" ") {

--- a/internal/platform/migrate/migrate.go
+++ b/internal/platform/migrate/migrate.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -198,13 +199,15 @@ func splitStatements(sql string) []string {
 				}
 			}
 		case sql[i] == ';':
-			if s := sql[start:i]; strings.TrimSpace(s) != "" {
+			if s := sql[start:i]; hasStatement(s) {
 				out = append(out, s)
 			}
 			start = i + 1
 		}
 	}
-	if tail := sql[min(start, len(sql)):]; hasStatement(tail) {
+	// start never passes len(sql): the ';' branch is the only writer and runs at an index
+	// inside the string.
+	if tail := sql[start:]; hasStatement(tail) {
 		out = append(out, tail)
 	}
 	return out
@@ -251,8 +254,9 @@ func tagByte(c byte, first bool) bool {
 	return !first && c >= '0' && c <= '9'
 }
 
-// hasStatement reports whether a trailing fragment carries anything but whitespace and
-// comments — a file's closing commentary is not a statement to execute.
+// hasStatement reports whether a fragment carries anything but whitespace and comments.
+// A file's closing commentary is not a statement to execute, and neither is a stray
+// semicolon after a comment — one rule, asked in both places splitStatements cuts.
 func hasStatement(fragment string) bool {
 	for _, line := range strings.Split(fragment, "\n") {
 		line = strings.TrimSpace(line)
@@ -458,14 +462,13 @@ func invalidIndexesNamedIn(ctx context.Context, conn *pgxpool.Conn, sql string) 
 	}
 	defer rows.Close()
 
-	lower := strings.ToLower(sql)
 	var out []string
 	for rows.Next() {
 		var name string
 		if err := rows.Scan(&name); err != nil {
 			return nil, err
 		}
-		if namesIdentifier(lower, strings.ToLower(name)) {
+		if namesIdentifier(sql, name) {
 			out = append(out, name)
 		}
 	}
@@ -477,30 +480,15 @@ func invalidIndexesNamedIn(ctx context.Context, conn *pgxpool.Conn, sql string) 
 }
 
 // namesIdentifier reports whether sql mentions name as a whole identifier, so a short index
-// name is not matched inside a longer one.
+// name is not matched inside a longer one. Case-insensitive because Postgres folds an
+// unquoted identifier to lower case and a migration may spell it either way.
+//
+// A compiled regexp per call, deliberately: this runs once per invalid index per
+// no-transaction migration, so a handful of times a year. The literal-scan rule that
+// applies to the dictionary hot paths does not apply here, and reaching for it would trade
+// three lines for twenty to save nothing measurable.
 func namesIdentifier(sql, name string) bool {
-	for i := 0; ; {
-		j := strings.Index(sql[i:], name)
-		if j < 0 {
-			return false
-		}
-		j += i
-		if !identifierByte(byteAt(sql, j-1)) && !identifierByte(byteAt(sql, j+len(name))) {
-			return true
-		}
-		i = j + 1
-	}
-}
-
-func byteAt(s string, i int) byte {
-	if i < 0 || i >= len(s) {
-		return ' '
-	}
-	return s[i]
-}
-
-func identifierByte(c byte) bool {
-	return c == '_' || c == '$' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+	return regexp.MustCompile(`(?i)\b` + regexp.QuoteMeta(name) + `\b`).MatchString(sql)
 }
 
 // appliedVersions reads the recorded versions.

--- a/internal/platform/migrate/migrate_test.go
+++ b/internal/platform/migrate/migrate_test.go
@@ -175,6 +175,13 @@ func TestSplitStatementsRespectsQuotingAndComments(t *testing.T) {
 			"SELECT 1;\n-- done\n",
 			[]string{"SELECT 1"},
 		},
+		// The same rule, asked at the other place a statement can end. It used to be
+		// two rules — TrimSpace here and hasStatement on the tail — which would have
+		// sent a bare comment to the server as a statement.
+		"comment-only segment before a semicolon yields nothing": {
+			"-- a note;\n-- and another\n;\nSELECT 1;",
+			[]string{"SELECT 1"},
+		},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
A quality pass over the code the backend-review fixes added (#2547, #2553, #2554, #2557, #2558, #2562, #2564).

**No behaviour changes.** Every test that pinned those fixes still passes untouched, including the integration tests against a real Postgres.

Three findings, all the same shape: **a rule expressed more than once**.

## `splitStatements` asked "is this empty?" two ways

`TrimSpace` at a semicolon, `hasStatement` on the trailing fragment. The tail rule is the right one — a file's closing commentary is not a statement — and the two disagreed on a segment that is only a comment, which the semicolon path would have sent to the server as a statement.

One rule now, asked in both places, with the second position pinned by its own case:

```go
"comment-only segment before a semicolon yields nothing": {
    "-- a note;\n-- and another\n;\nSELECT 1;",
    []string{"SELECT 1"},
},
```

Also drops a `min(start, len(sql))` that could not bind — the `';'` branch is the only writer of `start` and runs at an index inside the string.

## `namesIdentifier` was 23 lines across three functions

A manual scan plus `byteAt` plus `identifierByte`, to answer *"does this SQL mention this index name as a whole word"*. Now one regexp.

It runs once per invalid index per no-transaction migration — a handful of times a year. The literal-scan rule that governs the dictionary hot paths has nothing to say here, and the comment says so, so nobody optimizes it back.

## `credentials.scan` re-derived a per-entry invariant per alias

`e.proseAmbiguous && !bareAcronyms && !strings.Contains(a, " ")` — three conditions, one of them per-entry, evaluated inside the alias loop and wrapped in a third negation.

The per-entry half is hoisted and named (`speltOutOnly`), and the reason moved next to the code it governs instead of living twice: once in the doc comment, once implied by the condition.

## `userPrompt` repeated one call three times

`llm.TruncateRunes(x, maxHeaderRunes)` three times in one `Fprintf` argument list. A named `boundedHeader` says what the three have in common, which is the thing worth reading there.

## Verification

`gofmt -l .` clean; `go build ./...`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`, `golangci-lint` (0 issues) all pass.

`go test -tags=integration ./internal/platform/migrate/` passes — which is what verifies the regexp swap against real `pg_index` rows rather than against a fixture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved migration processing to correctly ignore comment-only SQL fragments between statements.
  - Improved index-name matching to avoid false matches when names appear within larger identifiers or with different capitalization.

- **Refactor**
  - Streamlined internal handling of email header limits and credential alias checks without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->