### PR TITLE
Stop the long crawls squatting the slots the short ones need

### DIFF
--- a/deploy/bin/gen-ingest-timers.sh
+++ b/deploy/bin/gen-ingest-timers.sh
@@ -40,6 +40,37 @@ mapfile -t PROVIDERS <<<"$providers"
 # timer on a 40-minute board only ever bought partial results. taleo was already on 3h
 # for the same reason and joins them so it shares the spread below.
 HEAVY="bamboohr icims paycom gupy mycareersfuture ukg careerplug jibe jazzhr vagas apple taleo"
+
+# SHARDED lists the providers generated as shard units further down instead of as one
+# timer here. They are heavy by definition — sharding is what a provider gets when even
+# the 3h HEAVY cadence could not finish it — so for the SLOT POOL they belong with HEAVY,
+# even though for SCHEDULING they are skipped by the `continue`s in the loop below.
+SHARDED="workday oracle paylocity eightfold join dayforce workstream"
+
+# Heavy for the POOL but not for the SCHEDULE. Measured 2026-09-07 from
+# freehire_worker_last_run_duration_seconds — the binary's own runtime, which is the only
+# figure that excludes the wait inside ingest-slot.sh: greenhouse 48min, apploi 46,
+# smartrecruiters 38, lamoda 20, trakstar 19, adp 16, teamtailor 15. Each holds a slot for
+# most of an hour, which is what starved the short tail; none was in HEAVY, so before this
+# they squatted the shared pool the split exists to protect.
+#
+# Deliberately NOT moved into HEAVY: that would also drop them to a 3h cadence, and
+# nothing measured here says their listings change slowly enough to justify that. The pool
+# and the schedule are separate decisions, and this list is the one that says so.
+HEAVY_POOL_ONLY="greenhouse apploi smartrecruiters lamoda trakstar adp teamtailor"
+
+# The roster ingest-slot.sh reads to decide which pool a run takes. Written here because
+# the list already lives here: a second copy kept in the slot script would drift from the
+# schedule silently, and a provider heavy in one file but not the other is exactly the
+# failure the split exists to prevent. Written BEFORE the timers, so a run that fires
+# mid-generation reads a complete roster rather than half of one.
+ROSTER=/opt/freehire/etc/ingest-heavy
+mkdir -p "$(dirname "$ROSTER")"
+# shellcheck disable=SC2086  # the three lists are space-separated words on purpose;
+# quoting them would print three lines, one per list, and the roster is one name per line.
+printf '%s\n' $HEAVY $SHARDED $HEAVY_POOL_ONLY | sort -u > "$ROSTER.tmp"
+mv "$ROSTER.tmp" "$ROSTER"
+
 hi=0
 for n in "${PROVIDERS[@]}"; do
   # workday (~6165 boards) 429-throttles too hard to finish in one 40-min run,

--- a/deploy/bin/ingest-slot.sh
+++ b/deploy/bin/ingest-slot.sh
@@ -18,32 +18,68 @@
 # healthy one.
 set -uo pipefail
 
-# 10, calibrated against the fleet rather than guessed. 8 was the first cut and ran
-# short: ~4 slots sit occupied by 30-50 min crawls, leaving only 4 for the ~124 boards
-# that finish in under a minute, so throughput settled near 104 runs/h against ~139/h of
-# demand and the tail kept skipping. Note the heavy boards now run to completion where
-# they used to be killed at TimeoutStartSec, so each costs more than the pre-change
-# measurement suggested. Seam if the tail still skips: give heavy boards their own small
-# pool so they cannot squat the shared one.
+# INGEST_SLOTS is the TOTAL concurrency the fleet may reach, and the heavy pool is carved
+# OUT of it rather than added beside it. That matters because the figure lives in the
+# host's /opt/freehire/.env, which overrides this default: a heavy pool ADDED to it would
+# raise real concurrency by however many slots it holds, silently, on a host where the
+# disk is the scarce resource and Postgres — not the crawl — is what pays for it.
 SLOTS=${INGEST_SLOTS:-10}
+# 4, measured. The pool's problem was never total work: a full sweep of the fleet costs
+# ~11 slot-hours against 10 of capacity, so demand sits AT the ceiling rather than far
+# past it. What starved the tail was RESIDENCY — four slots were permanently held by
+# 25-65 minute crawls (greenhouse, apploi, careerplug, smartrecruiters, the workday
+# shards), and the ~130 short runs an hour, which together cost 0.4 slot-hours, could not
+# get in edgewise. Skipping them saved nothing, which is why 42% of cycles were skipped
+# while average utilisation sat near half.
+#
+# Four is what was observed resident, so the split hands the long crawls the slots they
+# already occupied and fences the rest off for the tail. Raising this takes slots FROM
+# the tail, which is the thing being protected — measure the skip rate before moving it.
+HEAVY_SLOTS=${INGEST_HEAVY_SLOTS:-4}
 WAIT=${INGEST_SLOT_WAIT:-600}
 DIR=${INGEST_SLOT_DIR:-/run/freehire/ingest-slots}
+# The heavy roster is WRITTEN BY gen-ingest-timers.sh, which is where the list already
+# lives (its HEAVY cohort plus the sharded providers). One owner, one copy: a second list
+# maintained here would drift from the schedule silently, and a provider in one list but
+# not the other is exactly the bug this split exists to avoid. A missing file is not an
+# error — every run then takes the shared pool, which is the behaviour before this change.
+ROSTER=${INGEST_HEAVY_ROSTER:-/opt/freehire/etc/ingest-heavy}
 POLL=15
 BUSY=75 # flock --conflict-exit-code: distinguishes "slot taken" from a real failure
 
 [ $# -gt 0 ] || { echo "usage: ${0##*/} <command> [args...]" >&2; exit 64; }
+
+# The provider is the wrapped command's first argument — `ingest <provider> [--shard=N/M]`
+# — so a shard lands in the same pool as the provider it belongs to, which is the point:
+# a workday shard is a 50-minute crawl whichever unit fires it.
+provider=${2:-}
+pool=shared
+first=1
+last=$((SLOTS - HEAVY_SLOTS))
+if [ -n "$provider" ] && [ -r "$ROSTER" ] && grep -qxF -- "$provider" "$ROSTER" 2>/dev/null; then
+	pool=heavy
+	first=$((SLOTS - HEAVY_SLOTS + 1))
+	last=$SLOTS
+fi
+# A misconfigured split must not leave a pool with no slots to take — that would turn
+# every run of that pool into a skip, which reads exactly like a busy fleet.
+if ((first > last)); then
+	echo "ingest-slot: INGEST_HEAVY_SLOTS=$HEAVY_SLOTS leaves the $pool pool empty of $SLOTS; using all slots" >&2
+	first=1
+	last=$SLOTS
+fi
 mkdir -p "$DIR" 2>/dev/null || true
 
 deadline=$((SECONDS + WAIT))
 while :; do
-	for ((i = 1; i <= SLOTS; i++)); do
+	for ((i = first; i <= last; i++)); do
 		flock -n -E "$BUSY" "$DIR/$i" "$@"
 		rc=$?
 		# Anything but BUSY means we held the slot and ran: propagate the real status.
 		[ "$rc" -ne "$BUSY" ] && exit "$rc"
 	done
 	if ((SECONDS >= deadline)); then
-		echo "ingest-slot: all $SLOTS slots busy for ${WAIT}s, skipping this cycle: $*" >&2
+		echo "ingest-slot: all $((last - first + 1)) $pool slots busy for ${WAIT}s, skipping this cycle: $*" >&2
 		exit 0
 	fi
 	sleep "$POLL"

--- a/internal/ingest/ingestsched/scheduler.go
+++ b/internal/ingest/ingestsched/scheduler.go
@@ -12,6 +12,15 @@ import (
 // after 8 measured short. Carrying it over unchanged keeps this change about the MECHANISM
 // — a LIMIT instead of a flock semaphore — rather than quietly re-tuning throughput at the
 // same time.
+//
+// SEAM, measured 2026-09-07 and not built here: one flat cap is not enough, and the
+// script this replaces now splits it. The fleet's problem was never total work — a full
+// sweep costs ~11 slot-hours against 10 of capacity — but RESIDENCY: four of the ten were
+// permanently held by 25-65 minute crawls, and the ~130 short runs an hour, worth 0.4
+// slot-hours together, could not get in edgewise. 42% of cycles were skipped while
+// average utilisation sat near half, and skipping the cheap ones relieved nothing.
+// ingest-slot.sh reserves 4 of the 10 for a named heavy roster; whoever finishes this
+// cutover needs the equivalent here, or the tail starves again the day the script goes.
 const DefaultCap = 10
 
 // DefaultGrace is how long past its own timeout a claim may live before it is treated as


### PR DESCRIPTION
## The measurement

**42% of ingest cycles were skipped for want of a slot while the pool sat near half utilised.** Those two facts only look contradictory until you measure what a slot is spent on.

It was never total work: a full sweep of the fleet costs **~11 slot-hours against 10 of capacity** — demand sits *at* the ceiling, not far past it. What starved the tail was **residency**:

| | |
|---|---|
| slots permanently held by 25-65 min crawls | **4 of 10** |
| the worst squatters | greenhouse 48min, apploi 46, smartrecruiters 38, + workday shards |
| what the ~130 short runs/hour cost, together | **0.4 slot-hours** |

Skipping the cheap runs relieved nothing, which is why the skip rate held at 30-48% hour after hour rather than spiking.

## The change

`ingest-slot.sh` reserves **4 of the 10 for a named heavy roster** and leaves 6 a long crawl can never take.

**The reservation is carved OUT of `INGEST_SLOTS`, not added beside it.** That figure lives in the host's `.env`, which overrides the script's default — so a pool added on top would raise real concurrency silently, on a host where the disk is the scarce resource and Postgres, not the crawl, is what pays for it.

**The roster is written by `gen-ingest-timers.sh`, which already owns the list.** One owner, one copy: a second list kept in the slot script would drift from the schedule, and a provider heavy in one file but not the other is exactly the failure the split exists to prevent. A missing roster is not an error — every run then takes the shared pool, exactly as before.

`HEAVY_POOL_ONLY` is a third list because **pool and schedule are separate decisions**. greenhouse, apploi, smartrecruiters, lamoda, trakstar, adp and teamtailor each hold a slot for most of an hour, but nothing measured says their listings change slowly enough to earn `HEAVY`'s 3h cadence — moving them there would have made that call by accident.

## Why the durations are from the metric, not the journal

`freehire_worker_last_run_duration_seconds` is the binary's own runtime. The unit's `Starting`→`Finished` span is **not usable here**: it includes the up-to-600s wait inside `ingest-slot.sh`. Using it made a provider with **1 board look as expensive as one with 4,695** and put the median run at 224s instead of the real **15s** — 62% of runs finish under a minute, exactly as the original calibration assumed.

## Verified

Behaviour tested with a `flock` stub, since macOS has none:

| case | result |
|---|---|
| light provider (`ashby`) | slot 1 — shared pool |
| heavy provider (`greenhouse`) | slot 7 — heavy pool |
| shard of a heavy provider (`workday --shard=3/6`) | slot 7 — same pool as its provider |
| roster missing | slot 1 — shared pool, i.e. today's behaviour |
| `INGEST_HEAVY_SLOTS` ≥ `INGEST_SLOTS` | warns by name and falls back to all slots rather than emptying a pool |

`shellcheck` clean on both scripts (the one `SC2086` is the intentional word-split that builds the roster, disabled with its reason). `gofmt`, `go build`, `go vet`, full `go test`, `pnpm check:links` all pass; pre-commit hooks including govulncheck and golangci-lint pass.

## Seam recorded, not built

`ingestsched.DefaultCap` carries one flat 10 and is the mechanism that replaces this script. The same measurement is written into its comment: **the tail starves again the day the script goes, unless the split comes with it.** Not built there now — the scheduler ships in shadow mode, so there is nothing live to measure a reserved pool against yet.

## Deploy

`deploy/bin/` is a record; nothing ships it. Both scripts need copying to `/opt/freehire/bin/` and `gen-ingest-timers.sh` running once to write the roster.
