### PR TITLE
Say "small enough" once, and let the shell hold the sign-off

### DIFF
--- a/design-system/static/email-previews/index.html
+++ b/design-system/static/email-previews/index.html
@@ -208,7 +208,7 @@ The Discord is where the rest of it happens.
 
 It is the main place to ask anything — a filter that misbehaves, a board we don&#39;t cover yet,
 a posting that smells fake, a feature you want. I read it and answer myself, and it is small
-is small enough that you will actually be heard.
+enough that you will actually be heard.
 
 It is also a community of job seekers sharing how the search actually goes: what got a reply
 and what got silence, a CV rewritten until it started landing interviews, whether a company

--- a/internal/application/mailtpl/partials.go
+++ b/internal/application/mailtpl/partials.go
@@ -43,6 +43,21 @@ func Partials() *template.Template {
 // hugging its label, and align= on the cell is the only right-alignment Outlook
 // honours reliably.
 var partials = template.Must(template.New("partials").Funcs(funcs).Parse(`
+{{define "signature"}}<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin-top:22px;">
+  <tr>
+    <td width="52" valign="top" style="width:52px;padding-right:12px;">
+      <img src="{{.PortraitURL}}" width="44" height="44" alt="Ilya" style="display:block;border:0;border-radius:22px;">
+    </td>
+    <td valign="middle">
+      <div class="m-ink" style="font-size:14px;font-weight:600;color:` + colorInk + `;">Ilya Strelov</div>
+      <div class="m-muted" style="font-size:13px;color:` + colorMuted + `;padding-top:2px;">
+        building freehire ·
+        <a href="{{.LinkedInURL}}" class="m-muted" style="color:` + colorMuted + `;text-decoration:none;"><img src="{{.LinkedInIcon}}" width="14" height="14" alt="" class="m-logo" style="vertical-align:-2px;border:0;padding-right:4px;">LinkedIn</a>
+      </div>
+    </td>
+  </tr>
+</table>{{end}}
+
 {{define "p"}}<p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:` + colorInk + `;">{{.}}</p>{{end}}
 
 {{define "muted"}}<p class="m-muted" style="margin:0 0 14px 0;font-size:14px;line-height:1.6;color:` + colorMuted + `;">{{.}}</p>{{end}}
@@ -94,6 +109,11 @@ type IconLink struct {
 	Label   string
 	IconURL string
 }
+
+// LinkedInURL is the profile the sign-off points at. It lives beside DiscordURL for
+// the same reason: the letters that carry the signature are from one person, and two
+// copies of his profile are two things that can disagree.
+const LinkedInURL = "https://www.linkedin.com/in/istrelov/"
 
 // TextLink is the argument to "p-link": a sentence that ends in a link.
 //

--- a/internal/engage/broadcast/campaign.go
+++ b/internal/engage/broadcast/campaign.go
@@ -84,20 +84,15 @@ func (m *Mailer) Send(ctx context.Context, c Campaign, to string) error {
 	return m.sender.SendWithReplyTo(ctx, m.from, m.replyTo, to, c.Subject, html, c.text(m.baseURL))
 }
 
-// assets are the absolute image URLs the templates need; they depend on the origin
-// and so cannot be baked into the copy.
+// assets is what the campaign templates render from: the image URLs, which depend on
+// the origin and so cannot be baked into the copy, and the two outward links that
+// ride beside their marks. Each link sits next to its own icon here because a
+// campaign showing one mark and linking somewhere else is the mistake worth making
+// impossible.
 type assets struct {
-	PortraitURL string
-	AlertsURL   string
-	DiscordIcon string
-	// DiscordURL is not derived from the origin, but it travels with the icon: a
-	// campaign that shows the mark and links somewhere else would be a broken invite,
-	// and keeping the pair in one struct is what stops the template from assembling
-	// them from two places.
-	DiscordURL string
-	// LinkedInIcon and LinkedInURL are the sign-off's, not a campaign's: every letter
-	// carries them, because the signature is part of the shell rather than of any one
-	// campaign's copy.
+	PortraitURL  string
+	DiscordIcon  string
+	DiscordURL   string
 	LinkedInIcon string
 	LinkedInURL  string
 }
@@ -105,11 +100,10 @@ type assets struct {
 func (m *Mailer) assets() assets {
 	return assets{
 		PortraitURL:  m.baseURL + "/ilya.jpg",
-		AlertsURL:    m.baseURL + alertsPath,
 		DiscordIcon:  m.baseURL + "/email-icon-discord.png",
 		DiscordURL:   mailtpl.DiscordURL,
 		LinkedInIcon: m.baseURL + "/email-icon-linkedin.png",
-		LinkedInURL:  linkedInURL,
+		LinkedInURL:  mailtpl.LinkedInURL,
 	}
 }
 

--- a/internal/engage/broadcast/copy.go
+++ b/internal/engage/broadcast/copy.go
@@ -6,37 +6,11 @@ import (
 	"github.com/strelov1/freehire/internal/application/mailtpl"
 )
 
-// signature is the sign-off, appended to every campaign: these are letters from a
-// person, and the portrait and the profile link are what make that read as true
-// rather than as a pose. It matches the onboarding sequence's sign-off line for
-// line — a reader who gets both should be looking at the same person, not at two
-// slightly different ones.
-const signature = `
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin-top:22px;">
-  <tr>
-    <td width="52" valign="top" style="width:52px;padding-right:12px;">
-      <img src="{{.PortraitURL}}" width="44" height="44" alt="Ilya" style="display:block;border:0;border-radius:22px;">
-    </td>
-    <td valign="middle">
-      <div class="m-ink" style="font-size:14px;font-weight:600;color:#070707;">Ilya Strelov</div>
-      <div class="m-muted" style="font-size:13px;color:#505050;padding-top:2px;">
-        building freehire ·
-        <a href="{{.LinkedInURL}}" class="m-muted" style="color:#505050;text-decoration:none;"><img src="{{.LinkedInIcon}}" width="14" height="14" alt="" class="m-logo" style="vertical-align:-2px;border:0;padding-right:4px;">LinkedIn</a>
-      </div>
-    </td>
-  </tr>
-</table>`
-
-// alertsPath is where a campaign sends someone to set a search up, matching the
-// onboarding sequence's own link so the two letters land on the same page.
-const alertsPath = "/my/notifications?utm_source=email"
-
-// linkedInURL is the profile in the sign-off, mirrored from the sequence: the
-// signature is the same person's, so it points at the same profile.
-const linkedInURL = "https://www.linkedin.com/in/istrelov/"
-
+// body parses one campaign's markup with the shell's sign-off appended: a campaign
+// is a letter from the same person the sequence's letters are from, and the two
+// signatures were byte-identical copies until the shell took the block.
 func body(name, markup string) *template.Template {
-	return template.Must(mailtpl.Partials().New(name).Parse(markup + signature))
+	return template.Must(mailtpl.Partials().New(name).Parse(markup + "\n" + `{{template "signature" .}}`))
 }
 
 // campaigns is the registry. A campaign is removed once it has been sent: the ledger
@@ -83,7 +57,7 @@ var campaigns = map[string]Campaign{
 				"Join the Discord: " + mailtpl.DiscordURL + "\n\n" +
 				"It's free, it's small, and lurking is fine. If you'd rather just tell me something, reply to\n" +
 				"this — I read every one.\n\n" +
-				"— Ilya Strelov, building freehire\n" + linkedInURL + "\n"
+				"— Ilya Strelov, building freehire\n" + mailtpl.LinkedInURL + "\n"
 		},
 	},
 }

--- a/internal/engage/broadcast/runner_test.go
+++ b/internal/engage/broadcast/runner_test.go
@@ -131,10 +131,10 @@ func TestPending_SendsNothing(t *testing.T) {
 // previews render against a relative base, and a hard-coded https://freehire.me
 // would show the production host there while still looking right.
 //
-// The assertion is run over every registered campaign, and it is a negative for the
-// bodies, because a campaign is allowed to link only outward — this is what the
-// Discord letter does. What is never allowed is naming the production origin, in
-// either body. The plain-text one is checked as closely as the HTML: it is the copy
+// Every registered campaign is checked, and the body assertion is a negative: a
+// campaign may link only outward, as the Discord letter does, so requiring a link
+// back would fail an honest letter. What is never allowed is naming the production
+// origin. The plain-text body is checked as closely as the HTML — it is the copy
 // most likely to be written by hand and the least likely to be looked at.
 func TestSend_LinksBackThroughTheConfiguredOrigin(t *testing.T) {
 	for _, name := range broadcast.Names() {
@@ -152,19 +152,11 @@ func TestSend_LinksBackThroughTheConfiguredOrigin(t *testing.T) {
 		if strings.Contains(sent.html, "https://freehire.me") || strings.Contains(sent.text, "https://freehire.me") {
 			t.Errorf("%s: a body spells the production origin out instead of taking it from the Mailer", c.Name)
 		}
-	}
-
-	sender := &fakeSender{}
-	m := broadcast.NewMailer(sender, "notifications@freehire.me", "ilya@example.test", "https://preview.test")
-	c := campaign(t, "discord-invite")
-	if err := m.Send(context.Background(), c, "someone@example.com"); err != nil {
-		t.Fatalf("Send %s: %v", c.Name, err)
-	}
-	sent := sender.sent[0]
-	if !strings.Contains(sent.from, "Ilya") {
-		t.Errorf("from = %q, want a person's name", sent.from)
-	}
-	if strings.TrimSpace(sent.text) == "" {
-		t.Error("the campaign has no plain-text body")
+		if !strings.Contains(sent.from, "Ilya") {
+			t.Errorf("%s: from = %q, want a person's name", c.Name, sent.from)
+		}
+		if strings.TrimSpace(sent.text) == "" {
+			t.Errorf("%s: the campaign has no plain-text body", c.Name)
+		}
 	}
 }

--- a/internal/engage/onboarding/copy.go
+++ b/internal/engage/onboarding/copy.go
@@ -18,33 +18,11 @@ type spec struct {
 	text func(baseURL string) string
 }
 
-// signature is the sign-off every mail in the sequence ends with. It is appended
-// once, in body(), rather than pasted into three templates: it is a property of the
-// sequence — these are letters from a person — not of any one letter.
-//
-// The portrait is a plain <img> with a border-radius rather than a pre-cut circular
-// PNG: Outlook ignores the radius and shows a square, which is a fine degradation,
-// while transparency there renders as a black box in the corners. The alt text is
-// the name, so an images-off client still shows who is writing.
-const signature = `
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin-top:22px;">
-  <tr>
-    <td width="52" valign="top" style="width:52px;padding-right:12px;">
-      <img src="{{.PortraitURL}}" width="44" height="44" alt="Ilya" style="display:block;border:0;border-radius:22px;">
-    </td>
-    <td valign="middle">
-      <div class="m-ink" style="font-size:14px;font-weight:600;color:#070707;">Ilya Strelov</div>
-      <div class="m-muted" style="font-size:13px;color:#505050;padding-top:2px;">
-        building freehire ·
-        <a href="{{.LinkedInURL}}" class="m-muted" style="color:#505050;text-decoration:none;"><img src="{{.LinkedInIcon}}" width="14" height="14" alt="" class="m-logo" style="vertical-align:-2px;border:0;padding-right:4px;">LinkedIn</a>
-      </div>
-    </td>
-  </tr>
-</table>`
-
-// body parses one mail's markup with the sign-off appended.
+// body parses one mail's markup with the shell's sign-off appended. It is appended
+// here rather than pasted into five templates: these are letters from a person, so
+// the signature is a property of the sequence, not of any one letter.
 func body(name, markup string) *template.Template {
-	return template.Must(mailtpl.Partials().New(name).Parse(markup + signature))
+	return template.Must(mailtpl.Partials().New(name).Parse(markup + "\n" + `{{template "signature" .}}`))
 }
 
 // specs is the sequence. Runner selects by Step; nothing else indexes this map.
@@ -70,7 +48,7 @@ var specs = map[Step]spec{
 				"I read every reply myself. If we don't cover your search well yet, tell me — that is usually\n" +
 				"what I work on next.\n\n" +
 				"Set up a job alert: " + base + "/my/notifications\n\n" +
-				"— Ilya Strelov, building freehire\n" + linkedInURL + "\n"
+				"— Ilya Strelov, building freehire\n" + mailtpl.LinkedInURL + "\n"
 		},
 	},
 
@@ -92,7 +70,7 @@ var specs = map[Step]spec{
 				"Save the search once, and freehire keeps running it for you — Telegram, email or push,\n" +
 				"your choice.\n\n" +
 				"See how the filters work: " + base + "/features/advanced-search\n\n" +
-				"— Ilya Strelov, building freehire\n" + linkedInURL + "\n"
+				"— Ilya Strelov, building freehire\n" + mailtpl.LinkedInURL + "\n"
 		},
 	},
 
@@ -111,7 +89,7 @@ var specs = map[Step]spec{
 				"whether we cover it well — and if we don't, I'd rather you knew now than checked an empty page\n" +
 				"for a week.\n\n" +
 				"Set up an alert: " + base + "/my/notifications\n\n" +
-				"— Ilya Strelov, building freehire\n" + linkedInURL + "\n"
+				"— Ilya Strelov, building freehire\n" + mailtpl.LinkedInURL + "\n"
 		},
 	},
 
@@ -144,7 +122,7 @@ var specs = map[Step]spec{
 				"What it does, in more detail: " + base + "/features/extension\n\n" +
 				"It is Chrome for now. If you are on Firefox or Safari, reply and say so — that is how I\n" +
 				"decide what to build next.\n\n" +
-				"— Ilya Strelov, building freehire\n" + linkedInURL + "\n"
+				"— Ilya Strelov, building freehire\n" + mailtpl.LinkedInURL + "\n"
 		},
 	},
 
@@ -170,7 +148,7 @@ var specs = map[Step]spec{
 				"The Discord is where the rest of it happens.\n\n" +
 				"It is the main place to ask anything — a filter that misbehaves, a board we don't cover yet,\n" +
 				"a posting that smells fake, a feature you want. I read it and answer myself, and it is small\n" +
-				"is small enough that you will actually be heard.\n\n" +
+				"enough that you will actually be heard.\n\n" +
 				"It is also a community of job seekers sharing how the search actually goes: what got a reply\n" +
 				"and what got silence, a CV rewritten until it started landing interviews, whether a company\n" +
 				"is really hiring or just collecting CVs, what the offer came in at. That half I can't build —\n" +
@@ -179,7 +157,7 @@ var specs = map[Step]spec{
 				"And if the project has been useful, a star is how most people end up finding it:\n" +
 				repoURL + "\n\n" +
 				"Replying to this mail reaches me too.\n\n" +
-				"— Ilya Strelov, building freehire\n" + linkedInURL + "\n"
+				"— Ilya Strelov, building freehire\n" + mailtpl.LinkedInURL + "\n"
 		},
 	},
 }

--- a/internal/engage/onboarding/mailer.go
+++ b/internal/engage/onboarding/mailer.go
@@ -104,8 +104,9 @@ type rendered struct {
 	subject, html, text string
 }
 
-// content is what the body templates render from: the absolute URLs that cannot be
-// baked into the prose because they depend on the site origin.
+// content is what the body templates render from: every URL a letter points at,
+// whether it is built from the site origin (and so cannot be baked into the prose)
+// or is one of the fixed outward links this package holds as constants.
 type content struct {
 	AlertsURL         string
 	AdvancedSearchURL string

--- a/web/src/lib/components/HeaderMenu.svelte
+++ b/web/src/lib/components/HeaderMenu.svelte
@@ -33,11 +33,7 @@
   import { ensureAccountSetupLoaded, setupOutstanding } from '$lib/accountSetup.svelte';
   import { ProviderIcon } from '$lib/ui';
   import { NAV } from '$lib/siteNav';
-
-  // Same invite link as the footer's socials row (Footer.svelte) — no shared
-  // constant exists for it yet, so it's kept inline here like GITHUB_URL's
-  // counterpart in Footer.
-  const DISCORD_URL = 'https://discord.gg/Cghjh3dA5N';
+  import { DISCORD_URL } from '$lib/socialLinks';
 
   // The single menu absorbs the site nav, the signed-in account items, the theme
   // toggle, and the auth action — the header's only control besides search.
@@ -223,8 +219,7 @@
   <GithubStars class="hidden sm:inline-flex" />
 
   <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external Discord invite, not an internal route -->
-  <a
-    href={DISCORD_URL}
+  <a href={DISCORD_URL}
     target="_blank"
     rel="noreferrer"
     aria-label="freehire on Discord"
@@ -407,8 +402,7 @@
       <div class="shrink-0 border-t border-border p-2 sm:hidden">
         <GithubStars variant="row" class={cn(rowBase, 'text-muted-foreground')} />
         <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external Discord invite, not an internal route -->
-        <a
-          href={DISCORD_URL}
+        <a href={DISCORD_URL}
           target="_blank"
           rel="noreferrer"
           role="menuitem"

--- a/web/src/lib/socialLinks.ts
+++ b/web/src/lib/socialLinks.ts
@@ -4,9 +4,14 @@ import { GITHUB_URL } from './github.svelte';
 // Telegram / Discord row (Footer, the /signin brand panel) — one place so the URLs
 // can't drift between them the way jobs.company_slug_aliases exists precisely
 // because a fact like this once lived in more than one place and disagreed.
+/** The community invite. Exported because the header menu offers the same room the
+ *  footer's socials row does, and it used to carry its own copy of the URL — the
+ *  drift this file's own comment warns about, one import away from being real. */
+export const DISCORD_URL = 'https://discord.gg/Cghjh3dA5N';
+
 export const SOCIAL_LINKS: { provider: string; label: string; href: string }[] = [
   { provider: 'github', label: 'GitHub', href: GITHUB_URL },
   { provider: 'linkedin', label: 'LinkedIn', href: 'https://linkedin.com/company/freehire-dev/' },
   { provider: 'telegram', label: 'Telegram', href: 'https://t.me/freehiredev' },
-  { provider: 'discord', label: 'Discord', href: 'https://discord.gg/Cghjh3dA5N' },
+  { provider: 'discord', label: 'Discord', href: DISCORD_URL },
 ];


### PR DESCRIPTION
Follow-up to #2576, from a two-axis review of it.

## The one that would have shipped

The open-source letter's plain-text body read:

> and it is small **is small** enough that you will actually be heard

The HTML says it once. Nothing could catch this: the golden previews compare the rendered HTML, and no test reads the plain-text body's prose. It is exactly what the campaign test's own comment says about a text body — "the copy most likely to be written by hand and the least likely to be looked at."

## The duplication #2576 argued against and then left standing

That PR moved the Discord invite into one constant, with a comment: *"a mirror is a link that can disagree with itself."* It then left four mirrors beside it.

- **The sign-off is now a shell partial** (`{{template "signature"}}`). Both letter packages held a byte-identical copy of the block — and they had already drifted: the campaigns' copy had quietly lost its LinkedIn line. No test could see that; a person saw it by looking at a rendered mail. `LinkedInURL` joins `DiscordURL` in `mailtpl`.
- **The web side takes the invite from `socialLinks.ts`**, the file that exists to stop this. `HeaderMenu.svelte` carried its own copy and its comment admitted it ("no shared constant exists for it yet"). Both anchors move `href` onto the tag's own line — that is the line `svelte/no-navigation-without-resolve` reports, and the line the existing suppression sits above.
- **`alertsPath` and `assets.AlertsURL` are gone.** Their only reader was the September campaign #2576 retired.

## Verification

`go build`, `go vet`, `go test ./internal/...`, `pnpm --dir web lint`, `pnpm --dir web check`, and every pre-commit hook. `cmd/mail-preview` re-renders every mail byte for byte identically apart from the corrected sentence — which is the proof the signature move changed nothing.

## Left alone deliberately

`migrations/0144`'s comment refers to "the reason 0135 spells out", and five files share that prefix. It is merged and about to be applied; editing an unapplied migration races the autodeploy that is about to run it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email communications now include a consistent sign-off with portrait, name, tagline, and LinkedIn link.
  * Discord links are standardized across the website and email campaigns.

* **Bug Fixes**
  * Corrected duplicated wording in the open-source onboarding email.
  * Updated campaign link validation across all available campaigns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->