### PR TITLE
Give the people who build freehire a page, and each of them their own

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,0 +1,76 @@
+name: contributors
+
+# Refreshes web/src/lib/data/contributors.json — the snapshot the /contributors pages
+# read. Runs here rather than at request time because the pages need per-person pull
+# request lists, and assembling those needs roughly thirty API calls: far past the 60
+# an unauthenticated IP gets in an hour, a budget the site already spends on the header
+# star badge and /open. This job's own GITHUB_TOKEN carries 5000/hour.
+#
+# COMMITS ONLY WHEN THE DATA CHANGED. The host polls this repository every ten minutes
+# and deploys a green main, so an unconditional daily commit would be a daily production
+# deploy that changed nothing. `git diff --quiet` is what keeps the deploys to the days
+# a contributor actually did something.
+#
+# A run that could not finish its collection fails instead of committing what it has:
+# the script exits non-zero on any API error and refuses outright to write a snapshot
+# with no humans in it. The committed file then keeps serving, which is the right
+# outcome — a stale list of real people beats a fresh empty one.
+#
+# WORTH KNOWING ABOUT THE PUSH: a commit pushed with the workflow's own GITHUB_TOKEN
+# does not trigger other workflows — GitHub blocks that to stop a workflow looping on
+# itself. So the CI run this repository's auto-deploy gate looks for never appears for
+# this commit, and the snapshot reaches production on the next ordinary commit rather
+# than on its own. That is the intended trade: the alternative is a personal access
+# token stored as a secret, which is a standing credential with write access to main in
+# exchange for a page being current a day sooner. If the gate ever needs to treat these
+# commits as deployable, that belongs in the gate, not in a token kept here.
+
+on:
+  schedule:
+    # 04:20 UTC: clear of the nightly pg_dump window (from 03:00 UTC) that DDL
+    # migrations have to dodge, so a deploy this triggers does not queue behind it.
+    - cron: '20 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: contributors
+  cancel-in-progress: false
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      # No install step: the collector uses only Node built-ins, which is why it is a
+      # plain .mjs rather than TypeScript. Its assembly is unit-tested in the web
+      # package (scripts/build-contributors.test.mjs); what runs here is the fetching.
+      - name: Collect contributors
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node web/scripts/build-contributors.mjs
+
+      # `git diff --quiet` exits 1 when the file changed, which is the signal to commit.
+      # Everything hangs off that one comparison, so the collector writes its people in
+      # a stable order — otherwise the same data would serialise differently every run
+      # and every run would commit.
+      - name: Commit when the data changed
+        run: |
+          if git diff --quiet -- web/src/lib/data/contributors.json; then
+            echo 'No change in the contributor data. Nothing to commit.'
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add web/src/lib/data/contributors.json
+          git commit -m 'Refresh the contributor snapshot'
+          git push

--- a/design-system/scripts/adoption-baseline.json
+++ b/design-system/scripts/adoption-baseline.json
@@ -1,6 +1,6 @@
 {
   "Alert": 1,
-  "Avatar": 0,
+  "Avatar": 2,
   "Badge": 18,
   "BrandMark": 2,
   "Button": 72,
@@ -18,7 +18,7 @@
   "NumberedGrid": 6,
   "Pager": 0,
   "ProviderIcon": 13,
-  "SectionLabel": 15,
+  "SectionLabel": 17,
   "SettingRow": 3,
   "Skeleton": 2,
   "Table": 8,

--- a/design-system/scripts/web-token-baseline.json
+++ b/design-system/scripts/web-token-baseline.json
@@ -92,6 +92,7 @@
   "web/src/lib/server/og/brand.ts": 4,
   "web/src/lib/server/og/card.ts": 3,
   "web/src/lib/server/og/company.ts": 3,
+  "web/src/lib/server/og/contributor.ts": 3,
   "web/src/lib/server/og/shared.ts": 7,
   "web/src/lib/skillPulseFormat.ts": 2,
   "web/src/lib/tailor/ArtifactPanel.svelte": 1,

--- a/openspec/changes/add-contributors-page/.openspec.yaml
+++ b/openspec/changes/add-contributors-page/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/add-contributors-page/design.md
+++ b/openspec/changes/add-contributors-page/design.md
@@ -82,6 +82,19 @@ most recent merged pull requests. Twenty is what a profile page can show without
 scroll, and the rule is uniform — no special case for the maintainer, so nothing about the
 file changes shape when a second maintainer appears.
 
+### The snapshot file is a function of the data and nothing else
+
+The whole commit-only-on-change design rests on `git diff --quiet`, so anything in the
+file that varies between runs of identical data makes every run a commit — and, since
+the host deploys a green main, a daily production deploy of nothing.
+
+Two consequences. People are sorted by login rather than left in the order GitHub paged
+them. And the file carries **no collected-at timestamp**. The first draft had one, and it
+would have defeated the design on the very first scheduled run while looking correct in
+every test: a timestamp is exactly the kind of field nobody re-reads. What it would have
+recorded — when the data last changed — is already recorded by the commit that changed
+it, exactly and unforgeably.
+
 ### Rules live in `web/src/lib/contributors.ts`, collection lives in the script
 
 The script does I/O: paginate, map fields, cap at twenty, write. Its assembly is unit-tested

--- a/openspec/changes/add-contributors-page/design.md
+++ b/openspec/changes/add-contributors-page/design.md
@@ -1,0 +1,152 @@
+## Context
+
+The repository today has 2410 merged pull requests and 104 issues. A first collection found
+seventeen accounts behind them: one bot, the maintainer with 2236 merged pull requests, and
+fifteen outside contributors whose largest history is eight. Eight of those fifteen have
+never merged code and are here entirely on issues they opened — which is the measured
+argument for counting issues at all, since counting only code would halve the page.
+
+Any page built naively — a flat grid ordered by volume — renders as one enormous bar and
+fifteen slivers, with a bot in second place. The shape of the data is the design constraint.
+
+The site already has everything else this needs. `web/src/lib/server/og/` renders 1200x630
+social cards through satori (`card.ts`, `company.ts`, `blog.ts`, `shared.ts` for the brand
+primitives, `render.ts` for the PNG), exposed on routes shaped `…/og.png/+server.ts`.
+`web/src/lib/server/github.ts` already talks to the GitHub API for the star badge and
+`/open`, and documents the reason this change must not join it there: unauthenticated GitHub
+REST allows 60 requests per hour per IP, and that budget is already spoken for.
+
+`web/scripts/*.mjs` is an established home for tooling that produces a `web/` asset
+(`gen-og.mjs`, `og-smoke.mjs`, `gen-api-docs.mjs`), is already a knip entry point, and —
+unlike root `scripts/` — sits beside a test runner. `web/` runs vitest.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A `/contributors` page whose first impression is "people contribute here, and recently",
+  not "one person wrote this".
+- A `/contributors/<login>` page a contributor would willingly link to from a CV — their
+  actual pull requests by title, not just a number.
+- A social preview card per contributor, so the shared link shows their face.
+- Zero GitHub API calls on any request path, and zero new backend, database, or worker
+  surface.
+
+**Non-Goals:**
+
+- **No medals or tiers.** Novu's bronze/silver/gold is a good idea at fifty contributors and
+  premature at eight; the profile page already shows the counts a tier would be derived
+  from. The seam is the snapshot's per-person figures — a tier can be computed from them
+  later without recollecting anything.
+- **No manually curated contribution types.** Docs, design, and triage credit (the
+  `all-contributors` model) needs a hand-maintained list, and a hand-maintained list is
+  exactly the thing that silently omits people. Merged pull requests and opened issues are
+  both machine-readable and both count.
+- **No live freshness.** A day-old snapshot is correct enough for a page about people.
+- No leaderboard, no ranking, no points.
+
+## Decisions
+
+### The snapshot is a committed JSON file, collected by a scheduled Action
+
+**Chosen:** `.github/workflows/contributors.yml` runs daily, executes
+`node web/scripts/build-contributors.mjs`, and commits `web/src/lib/data/contributors.json` when
+it differs. The workflow's own `GITHUB_TOKEN` carries a 5000-requests-per-hour budget and
+`contents: write` permission for the commit.
+
+**Alternatives considered:**
+
+- *Fetch live at request time, memoized like `githubStats`.* Rejected: per-person pull-request
+  lists cannot be assembled inside 60 requests per hour, the memo dies on every restart, and
+  blue/green means two processes each spending the budget separately.
+- *A `cmd/sync-contributors` worker writing to Postgres.* Idiomatic for this repo and
+  genuinely more powerful, but it buys freshness nobody needs at the cost of a migration,
+  sqlc regeneration, a Go endpoint, and a systemd unit that `release.sh` does not deploy —
+  the unit would have to be copied to the host by hand. Not worth it for eleven rows that
+  change monthly.
+
+### Collection uses the GraphQL API, not the Search API
+
+The Search API caps a query at 1000 results and 2408 merged pull requests exceed it, so
+paging merged PRs through search silently truncates. GraphQL
+`repository.pullRequests(states: MERGED)` pages to completion at 100 per call — about 25
+calls — and returns author, number, title, and `mergedAt` in one shot. Issues (104) page in
+two calls. Maintainership comes from the REST collaborators endpoint, filtered to
+`permissions.admin`; the Action's token has the access to read it.
+
+### The snapshot keeps counts for everyone and details for the recent twenty
+
+Storing all 2408 pull requests would put a ~300 KB file through a daily commit, 99% of it
+one person's history. Each person's entry therefore carries their totals plus their twenty
+most recent merged pull requests. Twenty is what a profile page can show without becoming a
+scroll, and the rule is uniform — no special case for the maintainer, so nothing about the
+file changes shape when a second maintainer appears.
+
+### Rules live in `web/src/lib/contributors.ts`, collection lives in the script
+
+The script does I/O: paginate, map fields, cap at twenty, write. Its assembly is unit-tested
+from `web/scripts/build-contributors.test.mjs`, which cost one glob in `web/vitest.config.ts`
+(the include list covered only `src/**/*.test.ts`). It writes everyone it
+found, bots included.
+
+Everything the spec calls a rule — excluding bots, splitting maintainers from contributors,
+ordering by most recent contribution — lives in `web/src/lib/contributors.ts` as pure
+functions over the snapshot, unit-tested with vitest against fixtures. This is what makes
+the requirements testable: a test can assert that a bot never survives the filter and that a
+one-week-old newcomer outranks a year-old eight-commit history, with no network anywhere.
+
+The alternative — putting the rules in the script — would leave them exercised only by a
+scheduled job nobody watches, in a file the root workspace has no test runner for.
+
+### Ordering is by most recent contribution, descending
+
+Sourcerer's widget separates "new" and "trending" from "top" for exactly this reason: on a
+volume ordering, a newcomer is buried the moment they arrive, which is the opposite of what
+this page is for. One recency ordering achieves the same effect with no categories to
+explain. The maintainer group sits apart, so the maintainer's recency does not occupy the
+first slot the newcomer needs.
+
+### Opt-out is an explicit exclusion list in the script
+
+A person may not want their name on a marketing page. `web/scripts/build-contributors.mjs`
+carries an `EXCLUDED_LOGINS` constant, empty at first, honored on request. This is a
+hand-written list, which the repo generally distrusts — but the hazard of a hand-written
+list is that it hides people who should be there, and an exclusion list has the opposite
+failure mode: forgetting to add someone shows them, which is the state they were already in.
+
+## Risks / Trade-offs
+
+- **A daily commit triggers the host's autodeploy poller** → The workflow commits only when
+  the collected data differs. With eleven contributors that is a handful of commits a month,
+  each of them a real change worth deploying.
+- **A partial collection would silently shrink the published list** → The script fails the
+  run on any incomplete page rather than writing what it has; the workflow's commit step
+  never runs, and the previous snapshot keeps serving.
+- **A contributor deletes their GitHub account** → Their avatar 404s. The OG card already
+  degrades to the shared monogram, and the profile page shows the same fallback; the entry
+  disappears on the next collection.
+- **satori is strict about layout** (flexbox only, `display: flex` on any multi-child
+  element, per the note in `card.ts`) → The contributor card reuses `shared.ts` primitives
+  and is covered by the same render smoke test the existing cards use.
+- **The `[login]` route can be requested with arbitrary input** → Lookup is an exact match
+  against the snapshot's logins; anything absent is a 404 on both the page and the card, and
+  every interpolated value is escaped before reaching the card markup.
+- **knip gates unused files across `web/`** → The snapshot JSON and the rules module are both
+  imported by the pages, and `scripts/*.mjs` is already an entry point, so nothing needs a
+  config exemption. Worth re-checking with `pnpm check:dead` before the PR.
+- **`actionlint` shellchecks every `run:` block** → The workflow keeps its `run:` blocks to
+  single commands and puts logic in the `.mjs` script.
+
+## Migration Plan
+
+Additive and reversible. The first snapshot is committed by hand (by running the script
+locally with a personal token) so the pages have data on the deploy that introduces them;
+the scheduled workflow takes over from the next run. Rollback is deleting the routes and the
+workflow — nothing else reads the snapshot, and `web/src/lib/server/github.ts` is untouched,
+so `/open` and the star badge behave exactly as before either way.
+
+## Open Questions
+
+None blocking. Two to revisit once the page is live and has been shared a few times: whether
+the twenty-pull-request cap is the right depth for a profile, and whether tiers become worth
+adding once the contributor count reaches a size where they would mean something.

--- a/openspec/changes/add-contributors-page/proposal.md
+++ b/openspec/changes/add-contributors-page/proposal.md
@@ -1,0 +1,78 @@
+## Why
+
+freehire is open source, but nothing on the site names the people who built it with us.
+The `/open` page carries a contributor *count* and links away to GitHub, so the one moment
+a visitor is curious about the community sends them somewhere else. Eight people outside
+the maintainer have landed code, and none of them has anything to point at.
+
+This is not a trophy wall for a crowd we already have — it is the lure for the ninth
+contributor. A page that gives each contributor their own URL and their own social preview
+card turns recognition into something *they* share, which is the only way a page like this
+reaches anyone who is not already looking at us.
+
+## What Changes
+
+- **New `/contributors` showcase.** Every human who has merged a pull request or opened an
+  issue against the repo, with their avatar, what they contributed, and a link to their own
+  page. Bots are excluded. Maintainers are shown in their own group, separate from
+  contributors, so one 3000-commit history does not visually erase eight smaller ones.
+- **New `/contributors/<login>` profile page.** Per person: when they first contributed,
+  how many pull requests merged, how many issues opened, and the list of their actual merged
+  pull requests by title and date — a page worth linking to from a CV, not just a number.
+  Carries share actions for X and LinkedIn.
+- **New per-contributor Open Graph card** at `/contributors/<login>/og.png`, rendered by the
+  site's existing satori card pipeline, so posting the link shows the person's avatar and
+  figures instead of the generic site preview.
+- **New scheduled GitHub Action** that collects the data once a day using the workflow's own
+  `GITHUB_TOKEN` and commits a JSON snapshot into the repo. The pages read that file. No
+  request path ever calls the GitHub API, so the page cannot rate-limit, cannot fail, and
+  costs nothing to serve. The Action commits only when the data actually changed.
+- **`/open` links to `/contributors`.** The existing contributor count becomes the entry
+  point to the new page instead of a link off-site to GitHub.
+- No backend, database, migration, or cron worker. The whole change lives in `web/` plus one
+  workflow file.
+
+## Capabilities
+
+### New Capabilities
+
+- `contributors-page`: The public contributors showcase and per-contributor profile pages,
+  the rules for who appears and how they are grouped and ordered, the per-contributor social
+  card, and the daily snapshot that feeds all of it.
+
+### Modified Capabilities
+
+- `open-transparency-page`: The open-source stats section's contributor figure SHALL link to
+  the on-site `/contributors` page rather than to the repository's contributor graph on
+  GitHub.
+
+## Impact
+
+**Added**
+
+- `web/src/routes/contributors/` — showcase page, `[login]/` profile page, `[login]/og.png/`
+  card endpoint.
+- `web/src/lib/server/og/contributor.ts` — the card markup, alongside the existing
+  `company.ts` / `blog.ts` / `card.ts`, reusing the shared brand primitives in `shared.ts`.
+- `web/src/lib/data/contributors.json` (+ its TypeScript type) — the committed snapshot.
+- `.github/workflows/contributors.yml` — the daily collector.
+
+**Modified**
+
+- `web/src/routes/open/+page.svelte` — the contributor figure becomes an on-site link.
+- `web/src/routes/sitemap-pages.xml/+server.ts` — the new routes become crawlable.
+
+**Not touched**
+
+- `web/src/lib/server/github.ts` stays as it is. It answers "how many", which the header
+  badge and `/open` still need, and its 60-requests-per-hour budget is untouched by this
+  change because nothing here reads GitHub at request time.
+
+**Checks this change must satisfy**
+
+- `actionlint` (the `workflows` CI job) lints the new workflow, including shellcheck over
+  every `run:` block.
+- `pnpm check:links` resolves relative Markdown links; `pnpm check:dead` (knip) gates unused
+  files and dependencies across `web/`.
+- The daily commit feeds the host's autodeploy poller. Committing only on a real data change
+  keeps that from becoming a deploy a day.

--- a/openspec/changes/add-contributors-page/specs/contributors-page/spec.md
+++ b/openspec/changes/add-contributors-page/specs/contributors-page/spec.md
@@ -1,0 +1,179 @@
+## ADDED Requirements
+
+### Requirement: Public contributors showcase
+
+The system SHALL serve a public, unauthenticated, server-rendered `/contributors` page
+listing every person who has contributed to the freehire repository, each with their
+avatar, their GitHub login, a summary of what they contributed, and a link to their own
+profile page on this site.
+
+The page SHALL be reachable from the site chrome and SHALL NOT require a client-side
+fetch for its content to be present in the initial HTML.
+
+#### Scenario: Page is public and server-rendered
+
+- **WHEN** an anonymous visitor opens `/contributors`
+- **THEN** the page responds 200 and every contributor is present in the server-rendered HTML
+
+#### Scenario: Each entry links to its own page
+
+- **WHEN** the showcase renders a contributor
+- **THEN** that entry links to `/contributors/<login>` on this site, not to GitHub
+
+### Requirement: Who counts as a contributor
+
+A person SHALL appear on the showcase when they have at least one merged pull request or
+at least one opened issue in the repository. Automated accounts SHALL NOT appear:
+an account GitHub reports with account type `Bot`, or whose login ends in `[bot]`, is
+excluded from every surface this capability serves — the showcase, the profile pages, and
+the counts shown on them.
+
+#### Scenario: A code contributor appears
+
+- **WHEN** a person has one or more merged pull requests
+- **THEN** they appear on the showcase
+
+#### Scenario: An issue reporter appears
+
+- **WHEN** a person has opened one or more issues and has never merged a pull request
+- **THEN** they appear on the showcase, and their profile page renders with an empty pull-request list rather than failing
+
+#### Scenario: Bots never appear
+
+- **WHEN** the repository's contribution history includes `dependabot[bot]` or `github-actions[bot]`
+- **THEN** neither appears on any page, and neither is counted in any figure the pages display
+
+### Requirement: Maintainers are shown apart from contributors
+
+The showcase SHALL present the repository's maintainers in their own group, visually and
+structurally separate from the contributor group. Maintainer status SHALL be read from the
+repository rather than from a list written by hand, so a new maintainer needs no code change
+to appear correctly.
+
+#### Scenario: The maintainer does not sit in the contributor grid
+
+- **WHEN** the showcase renders and one account holds the overwhelming majority of commits as a maintainer
+- **THEN** that account is rendered in the maintainer group and is absent from the contributor group
+
+#### Scenario: Maintainers are not hardcoded
+
+- **WHEN** repository maintainership changes
+- **THEN** the next snapshot reflects it with no change to page code
+
+### Requirement: Contributors are ordered by recency, not by volume
+
+The contributor group SHALL be ordered by each person's most recent contribution, newest
+first. It SHALL NOT be ordered by commit count, pull-request count, or any other measure of
+volume.
+
+#### Scenario: A newcomer is visible
+
+- **WHEN** a person merges their first pull request today and every other contributor last contributed months ago
+- **THEN** that person appears first in the contributor group
+
+#### Scenario: Volume does not promote
+
+- **WHEN** one contributor has eight merged pull requests from a year ago and another has one from last week
+- **THEN** the more recent contributor is ordered first
+
+### Requirement: Per-contributor profile page
+
+The system SHALL serve a public, server-rendered `/contributors/<login>` page for each
+person on the showcase, showing their avatar, their GitHub login and profile link, the date
+of their first contribution, their merged pull-request count, their opened-issue count, and
+the list of their merged pull requests with each title, its number, its merge date, and a
+link to it on GitHub.
+
+The page SHALL offer share actions for X and LinkedIn that share the page's own URL.
+
+#### Scenario: A contributor's page renders their work
+
+- **WHEN** a visitor opens `/contributors/<login>` for a person with merged pull requests
+- **THEN** the page responds 200 and lists those pull requests by title with their merge dates
+
+#### Scenario: An unknown login is not found
+
+- **WHEN** a visitor opens `/contributors/<login>` for a login absent from the snapshot
+- **THEN** the page responds 404
+
+#### Scenario: Sharing carries the profile URL
+
+- **WHEN** a visitor uses a share action on a profile page
+- **THEN** the shared link is that contributor's profile URL on this site
+
+### Requirement: Per-contributor social preview card
+
+The system SHALL serve a 1200x630 PNG Open Graph card at `/contributors/<login>/og.png`
+carrying that contributor's avatar, login, and headline figures, and each profile page
+SHALL reference its own card in its Open Graph and Twitter metadata.
+
+A card SHALL render even when the contributor's avatar cannot be fetched, degrading to the
+site's existing monogram fallback rather than failing the response.
+
+#### Scenario: A shared profile link previews the person
+
+- **WHEN** a profile page URL is unfurled by a social platform
+- **THEN** the preview image is that contributor's own card, not the site-wide card
+
+#### Scenario: An unfetchable avatar does not fail the card
+
+- **WHEN** the avatar image cannot be fetched while rendering a card
+- **THEN** the card still renders with a monogram in the avatar's place and responds 200
+
+#### Scenario: An unknown login has no card
+
+- **WHEN** `/contributors/<login>/og.png` is requested for a login absent from the snapshot
+- **THEN** the response is 404 and no image is returned
+
+### Requirement: Pages read a committed snapshot, never the GitHub API
+
+Neither the showcase, the profile pages, nor the card endpoint SHALL call the GitHub API
+while serving a request. All contributor data SHALL come from a snapshot file committed to
+the repository and read at build or request time from local state.
+
+This keeps the pages outside GitHub's unauthenticated per-IP request budget, which the
+repository already spends on the star badge and the `/open` page.
+
+#### Scenario: Serving costs no GitHub request
+
+- **WHEN** any contributors page or card is served
+- **THEN** no request is made to the GitHub API
+
+#### Scenario: An unreachable GitHub does not affect the pages
+
+- **WHEN** the GitHub API is unreachable
+- **THEN** every contributors page continues to render the last committed snapshot
+
+### Requirement: A scheduled job refreshes the snapshot
+
+A scheduled GitHub Actions workflow SHALL rebuild the snapshot once a day using the
+workflow's own repository token, and SHALL commit the result only when the collected data
+differs from what is committed.
+
+The workflow SHALL fail rather than commit a snapshot it could not fully collect, so a
+partial collection never silently shrinks the published list.
+
+#### Scenario: Unchanged data produces no commit
+
+- **WHEN** the workflow runs and the collected data matches the committed snapshot
+- **THEN** no commit is created and no deployment is triggered
+
+#### Scenario: A failed collection does not overwrite
+
+- **WHEN** the workflow cannot complete its collection
+- **THEN** the run fails, the committed snapshot is left untouched, and the live pages keep serving it
+
+#### Scenario: A new contributor reaches the site
+
+- **WHEN** a person's first pull request is merged
+- **THEN** the next scheduled run commits them into the snapshot and they appear on the showcase
+
+### Requirement: The contributors pages are crawlable
+
+The system SHALL list `/contributors` and every `/contributors/<login>` page in the page
+sitemap, so each profile is indexable on its own.
+
+#### Scenario: Profiles are in the sitemap
+
+- **WHEN** the page sitemap is requested
+- **THEN** it contains `/contributors` and one entry per contributor profile

--- a/openspec/changes/add-contributors-page/specs/open-transparency-page/spec.md
+++ b/openspec/changes/add-contributors-page/specs/open-transparency-page/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: The contributor figure leads to the on-site contributors page
+
+The open-source section's contributor count SHALL link to `/contributors` on this site
+rather than to the repository's contributor graph on GitHub. The stars and forks figures
+keep their existing links.
+
+The moment a visitor is curious about who builds freehire is the moment the page should
+keep them, not hand them to GitHub.
+
+#### Scenario: The count is an on-site link
+
+- **WHEN** a visitor inspects the contributor count in the open-source section
+- **THEN** it links to `/contributors` on this site
+
+#### Scenario: A missing count does not produce a broken link
+
+- **WHEN** the GitHub leg degraded and no contributor count is available
+- **THEN** the section renders its existing fallback and does not present a contributor figure linking anywhere

--- a/openspec/changes/add-contributors-page/tasks.md
+++ b/openspec/changes/add-contributors-page/tasks.md
@@ -23,18 +23,18 @@
 
 ## 3. The showcase page
 
-- [ ] 3.1 Add `web/src/routes/contributors/+page.server.ts` loading the snapshot through the rules module, and `+page.svelte` rendering the maintainer group and the contributor group separately.
-- [ ] 3.2 Render each contributor entry with avatar, login, a summary of their contribution, and a link to `/contributors/<login>` on this site.
-- [ ] 3.3 Add the page's own metadata and the site-wide OG card, following the existing pages' pattern.
-- [ ] 3.4 Verify the page renders correctly with the real snapshot: no bots present, maintainer separated, newest contributor first.
+- [x] 3.1 Add `web/src/routes/contributors/+page.server.ts` loading the snapshot through the rules module, and `+page.svelte` rendering the maintainer group and the contributor group separately.
+- [x] 3.2 Render each contributor entry with avatar, login, a summary of their contribution, and a link to `/contributors/<login>` on this site.
+- [x] 3.3 Add the page's own metadata and the site-wide OG card, following the existing pages' pattern.
+- [x] 3.4 Verify the page renders correctly with the real snapshot: no bots present, maintainer separated, newest contributor first.
 
 ## 4. The profile page
 
-- [ ] 4.1 Add `web/src/routes/contributors/[login]/+page.server.ts` resolving the login against the snapshot by exact match, returning 404 when absent.
-- [ ] 4.2 Add `+page.svelte` showing avatar, GitHub profile link, first-contribution date, merged-PR count, opened-issue count, and the recent merged pull requests with title, number, merge date, and link.
-- [ ] 4.3 Render the empty-pull-request case (an issues-only contributor) without an empty section that reads as broken.
-- [ ] 4.4 Add X and LinkedIn share actions carrying this page's own URL.
-- [ ] 4.5 Verify an unknown login returns 404 and a known one renders their pull requests.
+- [x] 4.1 Add `web/src/routes/contributors/[login]/+page.server.ts` resolving the login against the snapshot by exact match, returning 404 when absent.
+- [x] 4.2 Add `+page.svelte` showing avatar, GitHub profile link, first-contribution date, merged-PR count, opened-issue count, and the recent merged pull requests with title, number, merge date, and link.
+- [x] 4.3 Render the empty-pull-request case (an issues-only contributor) without an empty section that reads as broken.
+- [x] 4.4 Add X and LinkedIn share actions carrying this page's own URL.
+- [x] 4.5 Verify an unknown login returns 404 and a known one renders their pull requests.
 
 ## 5. The per-contributor OG card
 

--- a/openspec/changes/add-contributors-page/tasks.md
+++ b/openspec/changes/add-contributors-page/tasks.md
@@ -38,29 +38,29 @@
 
 ## 5. The per-contributor OG card
 
-- [ ] 5.1 Add `web/src/lib/server/og/contributor.ts` building the card markup from a contributor entry, reusing the brand primitives in `shared.ts` and escaping every interpolated value; keep to satori's flexbox-only constraint.
-- [ ] 5.2 Add `web/src/routes/contributors/[login]/og.png/+server.ts` rendering it, mirroring the company card endpoint's structure and cache headers.
-- [ ] 5.3 Degrade to the shared monogram when the avatar cannot be fetched, and confirm the response is still 200 with a valid PNG.
-- [ ] 5.4 Return 404 with no image for a login absent from the snapshot.
-- [ ] 5.5 Point the profile page's Open Graph and Twitter image metadata at its own card.
-- [ ] 5.6 Extend the existing OG render smoke test to cover the contributor card.
+- [x] 5.1 Add `web/src/lib/server/og/contributor.ts` building the card markup from a contributor entry, reusing the brand primitives in `shared.ts` and escaping every interpolated value; keep to satori's flexbox-only constraint.
+- [x] 5.2 Add `web/src/routes/contributors/[login]/og.png/+server.ts` rendering it, mirroring the company card endpoint's structure and cache headers.
+- [x] 5.3 Degrade to the shared monogram when the avatar cannot be fetched, and confirm the response is still 200 with a valid PNG.
+- [x] 5.4 Return 404 with no image for a login absent from the snapshot.
+- [x] 5.5 Point the profile page's Open Graph and Twitter image metadata at its own card.
+- [x] 5.6 Extend the existing OG render smoke test to cover the contributor card.
 
 ## 6. Wiring and discoverability
 
-- [ ] 6.1 Make the `/open` page's contributor count link to `/contributors` instead of GitHub, keeping the existing fallback when the GitHub leg degraded.
-- [ ] 6.2 Add `/contributors` and every `/contributors/<login>` to `web/src/routes/sitemap-pages.xml/+server.ts`.
-- [ ] 6.3 Add a `/contributors` link to the site chrome so the page is reachable without knowing the URL.
+- [x] 6.1 Make the `/open` page's contributor count link to `/contributors` instead of GitHub, keeping the existing fallback when the GitHub leg degraded.
+- [x] 6.2 Add `/contributors` and every `/contributors/<login>` to `web/src/routes/sitemap-pages.xml/+server.ts`.
+- [x] 6.3 Add a `/contributors` link to the site chrome so the page is reachable without knowing the URL.
 
 ## 7. The scheduled workflow
 
-- [ ] 7.1 Add `.github/workflows/contributors.yml` running daily on a cron with `contents: write`, executing `node web/scripts/build-contributors.mjs`.
-- [ ] 7.2 Commit the result only when `git diff --quiet` reports a change, so an unchanged collection produces no commit and no deployment.
-- [ ] 7.3 Keep every `run:` block to a single command so actionlint's shellcheck pass stays clean; verify with actionlint locally.
+- [x] 7.1 Add `.github/workflows/contributors.yml` running daily on a cron with `contents: write`, executing `node web/scripts/build-contributors.mjs`.
+- [x] 7.2 Commit the result only when `git diff --quiet` reports a change, so an unchanged collection produces no commit and no deployment.
+- [x] 7.3 Keep every `run:` block to a single command so actionlint's shellcheck pass stays clean; verify with actionlint locally.
 - [ ] 7.4 Trigger the workflow manually (`workflow_dispatch`) once and confirm it produces no commit against the snapshot committed in 2.8.
 
 ## 8. Verification
 
-- [ ] 8.1 `pnpm --dir web lint`, `pnpm --dir web test`, and `pnpm --dir web build` all pass.
-- [ ] 8.2 `pnpm check:dead` reports no new findings for the added files.
-- [ ] 8.3 `pnpm check:links` passes.
-- [ ] 8.4 Open `/contributors`, one profile, and its `og.png` in a real browser and confirm the card previews correctly.
+- [x] 8.1 `pnpm --dir web lint`, `pnpm --dir web test`, and `pnpm --dir web build` all pass.
+- [x] 8.2 `pnpm check:dead` reports no new findings for the added files.
+- [x] 8.3 `pnpm check:links` passes.
+- [x] 8.4 Open `/contributors`, one profile, and its `og.png` in a real browser and confirm the card previews correctly.

--- a/openspec/changes/add-contributors-page/tasks.md
+++ b/openspec/changes/add-contributors-page/tasks.md
@@ -1,0 +1,66 @@
+## 1. Snapshot shape and rules
+
+- [x] 1.1 Define the snapshot's TypeScript type in `web/src/lib/contributors.ts`: per person the login, numeric id, avatar URL, role (`maintainer` / `contributor`), account type, first-contribution date, last-contribution date, merged-PR total, opened-issue total, and up to twenty recent merged pull requests (number, title, mergedAt, url); plus the snapshot's own generated-at stamp.
+- [x] 1.2 Write failing vitest cases in `web/src/lib/contributors.test.ts` for bot exclusion: an entry whose account type is `Bot` and an entry whose login ends in `[bot]` are both absent from the returned groups and from every count derived from them.
+- [x] 1.3 Implement the bot filter in `web/src/lib/contributors.ts` to make 1.2 pass.
+- [x] 1.4 Write failing vitest cases for the maintainer split: a `maintainer`-role entry appears in the maintainer group and never in the contributor group.
+- [x] 1.5 Implement the maintainer split to make 1.4 pass.
+- [x] 1.6 Write failing vitest cases for ordering: given one contributor with eight merged PRs a year ago and one with a single merged PR last week, the recent one is first; ordering never consults any count.
+- [x] 1.7 Implement recency ordering to make 1.6 pass.
+- [x] 1.8 Write a failing vitest case for an issues-only contributor (zero merged PRs) and make the rules module return them with an empty pull-request list rather than dropping or throwing.
+- [x] 1.9 Add a checked-in fixture snapshot for the tests, and commit a real first `web/src/lib/data/contributors.json` produced by the collector in group 2.
+
+## 2. The collector script
+
+- [x] 2.1 Create `web/scripts/build-contributors.mjs` that pages `repository.pullRequests(states: MERGED)` through the GitHub GraphQL API at 100 per call, collecting author login, id, avatar, PR number, title, and mergedAt.
+- [x] 2.2 Extend it to page repository issues the same way, collecting author and creation date.
+- [x] 2.3 Read the REST collaborators endpoint and mark logins with `permissions.admin` as role `maintainer`, everyone else `contributor` — no hardcoded logins.
+- [x] 2.4 Assemble per-person entries: totals for everything, details capped at the twenty most recent merged pull requests, first and last contribution dates spanning both PRs and issues.
+- [x] 2.5 Honor an `EXCLUDED_LOGINS` constant (empty initially) so a person can be removed on request.
+- [x] 2.6 Fail the run with a non-zero exit on any incomplete page or API error, writing nothing — verify by pointing the script at a token-less environment and confirming it exits non-zero and leaves the existing file untouched.
+- [x] 2.7 Write the assembled snapshot to `web/src/lib/data/contributors.json` with stable key ordering, so an unchanged collection produces a byte-identical file.
+- [x] 2.8 Run it against the live repository with a personal token and commit the resulting snapshot (satisfies 1.9).
+
+## 3. The showcase page
+
+- [ ] 3.1 Add `web/src/routes/contributors/+page.server.ts` loading the snapshot through the rules module, and `+page.svelte` rendering the maintainer group and the contributor group separately.
+- [ ] 3.2 Render each contributor entry with avatar, login, a summary of their contribution, and a link to `/contributors/<login>` on this site.
+- [ ] 3.3 Add the page's own metadata and the site-wide OG card, following the existing pages' pattern.
+- [ ] 3.4 Verify the page renders correctly with the real snapshot: no bots present, maintainer separated, newest contributor first.
+
+## 4. The profile page
+
+- [ ] 4.1 Add `web/src/routes/contributors/[login]/+page.server.ts` resolving the login against the snapshot by exact match, returning 404 when absent.
+- [ ] 4.2 Add `+page.svelte` showing avatar, GitHub profile link, first-contribution date, merged-PR count, opened-issue count, and the recent merged pull requests with title, number, merge date, and link.
+- [ ] 4.3 Render the empty-pull-request case (an issues-only contributor) without an empty section that reads as broken.
+- [ ] 4.4 Add X and LinkedIn share actions carrying this page's own URL.
+- [ ] 4.5 Verify an unknown login returns 404 and a known one renders their pull requests.
+
+## 5. The per-contributor OG card
+
+- [ ] 5.1 Add `web/src/lib/server/og/contributor.ts` building the card markup from a contributor entry, reusing the brand primitives in `shared.ts` and escaping every interpolated value; keep to satori's flexbox-only constraint.
+- [ ] 5.2 Add `web/src/routes/contributors/[login]/og.png/+server.ts` rendering it, mirroring the company card endpoint's structure and cache headers.
+- [ ] 5.3 Degrade to the shared monogram when the avatar cannot be fetched, and confirm the response is still 200 with a valid PNG.
+- [ ] 5.4 Return 404 with no image for a login absent from the snapshot.
+- [ ] 5.5 Point the profile page's Open Graph and Twitter image metadata at its own card.
+- [ ] 5.6 Extend the existing OG render smoke test to cover the contributor card.
+
+## 6. Wiring and discoverability
+
+- [ ] 6.1 Make the `/open` page's contributor count link to `/contributors` instead of GitHub, keeping the existing fallback when the GitHub leg degraded.
+- [ ] 6.2 Add `/contributors` and every `/contributors/<login>` to `web/src/routes/sitemap-pages.xml/+server.ts`.
+- [ ] 6.3 Add a `/contributors` link to the site chrome so the page is reachable without knowing the URL.
+
+## 7. The scheduled workflow
+
+- [ ] 7.1 Add `.github/workflows/contributors.yml` running daily on a cron with `contents: write`, executing `node web/scripts/build-contributors.mjs`.
+- [ ] 7.2 Commit the result only when `git diff --quiet` reports a change, so an unchanged collection produces no commit and no deployment.
+- [ ] 7.3 Keep every `run:` block to a single command so actionlint's shellcheck pass stays clean; verify with actionlint locally.
+- [ ] 7.4 Trigger the workflow manually (`workflow_dispatch`) once and confirm it produces no commit against the snapshot committed in 2.8.
+
+## 8. Verification
+
+- [ ] 8.1 `pnpm --dir web lint`, `pnpm --dir web test`, and `pnpm --dir web build` all pass.
+- [ ] 8.2 `pnpm check:dead` reports no new findings for the added files.
+- [ ] 8.3 `pnpm check:links` passes.
+- [ ] 8.4 Open `/contributors`, one profile, and its `og.png` in a real browser and confirm the card previews correctly.

--- a/web/scripts/build-contributors.mjs
+++ b/web/scripts/build-contributors.mjs
@@ -34,6 +34,16 @@ const SNAPSHOT_PATH = fileURLToPath(new URL('../src/lib/data/contributors.json',
  *  about the file changes shape when a second maintainer appears. */
 export const RECENT_PULL_REQUEST_LIMIT = 20;
 
+/** Widens a person's contribution span to include this moment.
+ *
+ *  The span covers both kinds of contribution. An issue filed after someone's last
+ *  merged pull request is still them being here recently, and recency is what the page's
+ *  ordering reads. */
+function dateSeen(entry, at) {
+  if (!entry.firstContributionAt || at < entry.firstContributionAt) entry.firstContributionAt = at;
+  if (!entry.lastContributionAt || at > entry.lastContributionAt) entry.lastContributionAt = at;
+}
+
 /** Turns collected pull requests and issues into one entry per person.
  *
  *  Keyed by the lowercased login, because the same person arrives from three endpoints
@@ -70,14 +80,6 @@ export function assembleEntries({ pullRequests, issues, admins, excluded = [] })
       byLogin.set(key, entry);
     }
     return entry;
-  };
-
-  // The dates span both kinds of contribution. An issue filed after someone's last
-  // merged pull request is still them being here recently, and recency is what the
-  // page's ordering reads.
-  const dateSeen = (entry, at) => {
-    if (!entry.firstContributionAt || at < entry.firstContributionAt) entry.firstContributionAt = at;
-    if (!entry.lastContributionAt || at > entry.lastContributionAt) entry.lastContributionAt = at;
   };
 
   for (const request of pullRequests) {
@@ -214,7 +216,7 @@ async function pageAll(token, query, read) {
   let cursor = null;
 
   for (;;) {
-    // eslint-disable-next-line no-await-in-loop -- each page's cursor comes from the last
+    // Sequential by necessity: each page's cursor comes from the one before it.
     const data = await graphql(token, query, { ...REPO, cursor });
     const connection = read(data.repository);
 

--- a/web/scripts/build-contributors.mjs
+++ b/web/scripts/build-contributors.mjs
@@ -112,17 +112,41 @@ export function assembleEntries({ pullRequests, issues, admins, excluded = [] })
   return [...byLogin.values()];
 }
 
+/** Throws unless the collection found at least one human.
+ *
+ *  A collection yielding nobody is a failed measurement, not an empty repository — the
+ *  same rule the suggestion-dictionary rebuild follows before it swaps an index. Every
+ *  failure this guards against is silent: a renamed GraphQL field, a connection that
+ *  starts coming back empty, a token that can read nothing. Without it the run writes an
+ *  empty file, the workflow commits it, and the page goes blank on a green build.
+ *
+ *  Humans specifically, because a snapshot of nothing but bots renders as an empty page
+ *  once the display rules have had their say. */
+export function assertUsable(entries) {
+  const humans = entries.filter((e) => e.accountType !== 'Bot' && !e.login.endsWith('[bot]'));
+  if (humans.length === 0) {
+    throw new Error(
+      `collection found no human contributors (${entries.length} entries in total) — refusing to write a snapshot that would empty the page`,
+    );
+  }
+}
+
 /** The snapshot as it is written to disk.
  *
- *  People are sorted by login rather than left in collection order, because the
- *  workflow decides whether to commit by asking git whether the file changed. Insertion
- *  order here follows whatever order GitHub happened to page the results in, so an
- *  unchanged collection would otherwise produce a different file — a commit, and a
- *  deploy, every single day for nothing. */
-export function serializeSnapshot(entries, generatedAt) {
+ *  EVERYTHING HERE IS A FUNCTION OF THE DATA AND NOTHING ELSE, because the workflow
+ *  decides whether to commit by asking git whether this file changed — so anything that
+ *  varies between runs of identical data makes every run a commit, and (since the host
+ *  deploys a green main) a daily production deploy of nothing.
+ *
+ *  Two things follow from that. People are sorted by login rather than left in the order
+ *  GitHub happened to page them in. And the file carries NO collected-at stamp: when the
+ *  data last changed is already recorded, exactly and unforgeably, by the commit that
+ *  changed it — a field restating that would cost the entire commit-only-on-change
+ *  design in exchange for a worse copy of it. */
+export function serializeSnapshot(entries) {
   const people = [...entries].sort((a, b) => a.login.localeCompare(b.login));
 
-  return `${JSON.stringify({ generatedAt, people }, null, 2)}\n`;
+  return `${JSON.stringify({ people }, null, 2)}\n`;
 }
 
 // ---------------------------------------------------------------------------
@@ -259,7 +283,9 @@ async function main() {
     excluded: EXCLUDED_LOGINS,
   });
 
-  await writeFile(SNAPSHOT_PATH, serializeSnapshot(entries, new Date().toISOString()));
+  assertUsable(entries);
+
+  await writeFile(SNAPSHOT_PATH, serializeSnapshot(entries));
 
   console.log(
     `contributors: ${entries.length} people from ${merged.length} merged pull requests and ${issues.length} issues`,

--- a/web/scripts/build-contributors.mjs
+++ b/web/scripts/build-contributors.mjs
@@ -1,0 +1,275 @@
+// Collects the repository's contributors from the GitHub API and writes the snapshot
+// the /contributors pages read.
+//
+// Plain Node on purpose: the scheduled workflow runs `node` against this file with no
+// install and no build step, which is what keeps a daily job from depending on the
+// whole web toolchain being restored first.
+//
+// This file does I/O and assembly, and nothing else. Every rule about who is SHOWN and
+// in what order lives in web/src/lib/contributors.ts, tested there — see its header for
+// why. What is tested here is the assembly around the fetching: the totals, the bounded
+// detail, and the stable key order the workflow's commit decision depends on.
+
+import { writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+const REPO = { owner: 'strelov1', name: 'freehire' };
+
+/** Logins to leave out of the snapshot entirely.
+ *
+ *  Someone may not want their name on a page the site markets itself with, and this is
+ *  how that is honoured. It is a hand-written list, which this repository generally
+ *  distrusts — but the hazard of a hand-written list is that it hides people who should
+ *  be there, and this one fails the other way: forgetting to add a login shows them,
+ *  which is the state they were already in. */
+const EXCLUDED_LOGINS = [];
+
+const SNAPSHOT_PATH = fileURLToPath(new URL('../src/lib/data/contributors.json', import.meta.url));
+
+/** How many of a person's merged pull requests the snapshot carries in full.
+ *
+ *  The repository holds thousands of them, nearly all one maintainer's. Writing every
+ *  one would put a large file through a daily commit to restate the same history. The
+ *  totals stay exact; only the detail is bounded, and the bound is uniform so nothing
+ *  about the file changes shape when a second maintainer appears. */
+export const RECENT_PULL_REQUEST_LIMIT = 20;
+
+/** Turns collected pull requests and issues into one entry per person.
+ *
+ *  Keyed by the lowercased login, because the same person arrives from three endpoints
+ *  (pull requests, issues, collaborators) and GitHub logins are case-insensitive — keyed
+ *  literally, one contributor would become two entries and neither would be right. The
+ *  login the entry carries is the one GitHub spells it with. */
+export function assembleEntries({ pullRequests, issues, admins, excluded = [] }) {
+  const isAdmin = new Set(admins.map((login) => login.toLowerCase()));
+  const isExcluded = new Set(excluded.map((login) => login.toLowerCase()));
+  const byLogin = new Map();
+
+  /** The entry for this author, created on first sight. Returns null for a contribution
+   *  that belongs to nobody: a deleted account resolves to no author, and a
+   *  contribution with no author is counted for no one. */
+  const entryFor = (author) => {
+    if (!author) return null;
+    const key = author.login.toLowerCase();
+    if (isExcluded.has(key)) return null;
+
+    let entry = byLogin.get(key);
+    if (!entry) {
+      entry = {
+        login: author.login,
+        id: author.id,
+        avatarUrl: author.avatarUrl,
+        accountType: author.accountType,
+        role: isAdmin.has(key) ? 'maintainer' : 'contributor',
+        firstContributionAt: null,
+        lastContributionAt: null,
+        mergedPullRequests: 0,
+        openedIssues: 0,
+        recentPullRequests: [],
+      };
+      byLogin.set(key, entry);
+    }
+    return entry;
+  };
+
+  // The dates span both kinds of contribution. An issue filed after someone's last
+  // merged pull request is still them being here recently, and recency is what the
+  // page's ordering reads.
+  const dateSeen = (entry, at) => {
+    if (!entry.firstContributionAt || at < entry.firstContributionAt) entry.firstContributionAt = at;
+    if (!entry.lastContributionAt || at > entry.lastContributionAt) entry.lastContributionAt = at;
+  };
+
+  for (const request of pullRequests) {
+    const entry = entryFor(request.author);
+    if (!entry) continue;
+
+    entry.mergedPullRequests += 1;
+    entry.recentPullRequests.push({
+      number: request.number,
+      title: request.title,
+      mergedAt: request.mergedAt,
+      url: request.url,
+    });
+    dateSeen(entry, request.mergedAt);
+  }
+
+  for (const opened of issues) {
+    const entry = entryFor(opened.author);
+    if (!entry) continue;
+
+    entry.openedIssues += 1;
+    dateSeen(entry, opened.createdAt);
+  }
+
+  for (const entry of byLogin.values()) {
+    entry.recentPullRequests.sort((a, b) => b.mergedAt.localeCompare(a.mergedAt));
+    entry.recentPullRequests = entry.recentPullRequests.slice(0, RECENT_PULL_REQUEST_LIMIT);
+  }
+
+  return [...byLogin.values()];
+}
+
+/** The snapshot as it is written to disk.
+ *
+ *  People are sorted by login rather than left in collection order, because the
+ *  workflow decides whether to commit by asking git whether the file changed. Insertion
+ *  order here follows whatever order GitHub happened to page the results in, so an
+ *  unchanged collection would otherwise produce a different file — a commit, and a
+ *  deploy, every single day for nothing. */
+export function serializeSnapshot(entries, generatedAt) {
+  const people = [...entries].sort((a, b) => a.login.localeCompare(b.login));
+
+  return `${JSON.stringify({ generatedAt, people }, null, 2)}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Collection. Everything below talks to GitHub and is exercised by running it,
+// not by a test: what it does is fetch, and a test of a mocked fetch would only
+// restate the mock.
+// ---------------------------------------------------------------------------
+
+/** The GitHub token, or a hard stop.
+ *
+ *  Refusing to run unauthenticated rather than falling back to it: unauthenticated
+ *  REST allows 60 requests an hour and this needs roughly thirty, so a fallback would
+ *  sometimes work, sometimes truncate, and never say which. */
+function requireToken() {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) throw new Error('GITHUB_TOKEN is required — refusing to collect unauthenticated');
+  return token;
+}
+
+/** One GraphQL call. Throws on transport failure and on a body carrying `errors`:
+ *  GitHub answers a partially-failed query with HTTP 200 and an `errors` array beside
+ *  the data, so status alone would let a half-collected page through as a whole one. */
+async function graphql(token, query, variables) {
+  const res = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: { authorization: `bearer ${token}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!res.ok) throw new Error(`github graphql ${res.status} ${await res.text()}`);
+
+  const body = await res.json();
+  if (body.errors) throw new Error(`github graphql: ${JSON.stringify(body.errors)}`);
+  return body.data;
+}
+
+// The author of a pull request or an issue. `__typename` is how an automated account
+// identifies itself, and `databaseId` needs a fragment per concrete type because the
+// Actor interface does not carry one.
+const AUTHOR_FRAGMENT = `
+  author {
+    __typename
+    login
+    avatarUrl
+    ... on User { databaseId }
+    ... on Bot { databaseId }
+  }
+`;
+
+const MERGED_PULL_REQUESTS = `
+  query ($owner: String!, $name: String!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+      pullRequests(states: MERGED, first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes { number title mergedAt url ${AUTHOR_FRAGMENT} }
+      }
+    }
+  }
+`;
+
+const ISSUES = `
+  query ($owner: String!, $name: String!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+      issues(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes { createdAt ${AUTHOR_FRAGMENT} }
+      }
+    }
+  }
+`;
+
+/** GitHub's author shape, flattened to the one the assembly reads. */
+function readAuthor(author) {
+  if (!author) return null;
+
+  return {
+    login: author.login,
+    id: author.databaseId ?? 0,
+    avatarUrl: author.avatarUrl,
+    accountType: author.__typename,
+  };
+}
+
+/** Every node of a connection, paged to completion.
+ *
+ *  Deliberately unbounded rather than capped at some number of pages: the point of
+ *  using GraphQL here is that it does not truncate the way the search API does at a
+ *  thousand results, and a page cap would quietly reintroduce exactly that. */
+async function pageAll(token, query, read) {
+  const nodes = [];
+  let cursor = null;
+
+  for (;;) {
+    // eslint-disable-next-line no-await-in-loop -- each page's cursor comes from the last
+    const data = await graphql(token, query, { ...REPO, cursor });
+    const connection = read(data.repository);
+
+    nodes.push(...connection.nodes);
+    if (!connection.pageInfo.hasNextPage) return nodes;
+    cursor = connection.pageInfo.endCursor;
+  }
+}
+
+/** The logins with admin permission on the repository.
+ *
+ *  Read rather than hardcoded, so a new maintainer is grouped correctly with no change
+ *  to this file. Needs a token with access to the repository's collaborators, which the
+ *  workflow's own token has. */
+async function fetchAdmins(token) {
+  const res = await fetch(
+    `https://api.github.com/repos/${REPO.owner}/${REPO.name}/collaborators?per_page=100`,
+    { headers: { authorization: `bearer ${token}`, accept: 'application/vnd.github+json' } },
+  );
+
+  if (!res.ok) throw new Error(`github collaborators ${res.status} ${await res.text()}`);
+
+  const collaborators = await res.json();
+  return collaborators.filter((c) => c.permissions?.admin).map((c) => c.login);
+}
+
+async function main() {
+  const token = requireToken();
+
+  const [merged, issues, admins] = await Promise.all([
+    pageAll(token, MERGED_PULL_REQUESTS, (repo) => repo.pullRequests),
+    pageAll(token, ISSUES, (repo) => repo.issues),
+    fetchAdmins(token),
+  ]);
+
+  const entries = assembleEntries({
+    pullRequests: merged.map((node) => ({ ...node, author: readAuthor(node.author) })),
+    issues: issues.map((node) => ({ createdAt: node.createdAt, author: readAuthor(node.author) })),
+    admins,
+    excluded: EXCLUDED_LOGINS,
+  });
+
+  await writeFile(SNAPSHOT_PATH, serializeSnapshot(entries, new Date().toISOString()));
+
+  console.log(
+    `contributors: ${entries.length} people from ${merged.length} merged pull requests and ${issues.length} issues`,
+  );
+}
+
+// Only when run, never when imported by the test. A failure exits non-zero having
+// written nothing, so the workflow's commit step does not run and the previously
+// committed snapshot keeps serving — a partial collection must never replace a whole one.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error(err.message);
+    process.exit(1);
+  });
+}

--- a/web/scripts/build-contributors.mjs
+++ b/web/scripts/build-contributors.mjs
@@ -138,13 +138,28 @@ export function assertUsable(entries) {
  *  varies between runs of identical data makes every run a commit, and (since the host
  *  deploys a green main) a daily production deploy of nothing.
  *
- *  Two things follow from that. People are sorted by login rather than left in the order
- *  GitHub happened to page them in. And the file carries NO collected-at stamp: when the
- *  data last changed is already recorded, exactly and unforgeably, by the commit that
- *  changed it — a field restating that would cost the entire commit-only-on-change
- *  design in exchange for a worse copy of it. */
+ *  Three things follow from that.
+ *
+ *  People are sorted by login rather than left in the order GitHub happened to page
+ *  them in.
+ *
+ *  That sort compares lowercased logins code-unit by code-unit, NOT with
+ *  `localeCompare`, whose answer depends on the runtime's locale and ICU data — a laptop
+ *  and a CI runner can disagree about the same two logins, and every disagreement is a
+ *  commit of data that did not change. Lowercased first because comparing the raw
+ *  strings puts every capitalised login ahead of every lowercase one, which would group
+ *  the page by capitalisation for no reason.
+ *
+ *  And the file carries NO collected-at stamp: when the data last changed is already
+ *  recorded, exactly and unforgeably, by the commit that changed it — a field restating
+ *  that would cost the entire commit-only-on-change design in exchange for a worse copy
+ *  of it. */
 export function serializeSnapshot(entries) {
-  const people = [...entries].sort((a, b) => a.login.localeCompare(b.login));
+  const people = [...entries].sort((a, b) => {
+    const [x, y] = [a.login.toLowerCase(), b.login.toLowerCase()];
+    if (x === y) return 0;
+    return x < y ? -1 : 1;
+  });
 
   return `${JSON.stringify({ people }, null, 2)}\n`;
 }

--- a/web/scripts/build-contributors.test.mjs
+++ b/web/scripts/build-contributors.test.mjs
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { RECENT_PULL_REQUEST_LIMIT, assembleEntries, serializeSnapshot } from './build-contributors.mjs';
+import {
+  RECENT_PULL_REQUEST_LIMIT,
+  assembleEntries,
+  assertUsable,
+  serializeSnapshot,
+} from './build-contributors.mjs';
 
 const author = (login, over = {}) => ({
   login,
@@ -132,6 +137,38 @@ describe('assembleEntries', () => {
   });
 });
 
+describe('assertUsable', () => {
+  // A collection yielding nobody is a failed measurement, not an empty repository —
+  // the same rule the suggestion-dictionary rebuild follows before it swaps an index.
+  // Every failure this guards against is silent: a renamed GraphQL field, a query that
+  // starts returning an empty connection, a token that reads nothing. The script exits
+  // non-zero, writes nothing, and the previously committed snapshot keeps serving; the
+  // alternative is a green run that empties the page.
+  it('refuses a collection that found nobody', () => {
+    expect(() => assertUsable([])).toThrow(/no human contributors/);
+  });
+
+  it('refuses a collection with no human in it', () => {
+    const onlyBots = assembleEntries({
+      pullRequests: [pr('dependabot', 1, '2026-01-01T00:00:00Z', { author: { accountType: 'Bot' } })],
+      issues: [],
+      admins: [],
+    });
+
+    expect(() => assertUsable(onlyBots)).toThrow(/no human contributors/);
+  });
+
+  it('accepts a collection with at least one human', () => {
+    const found = assembleEntries({
+      pullRequests: [pr('aleganza', 1, '2026-01-01T00:00:00Z')],
+      issues: [],
+      admins: [],
+    });
+
+    expect(() => assertUsable(found)).not.toThrow();
+  });
+});
+
 describe('serializeSnapshot', () => {
   // The workflow decides whether to commit by asking git whether the file changed, so
   // an unchanged collection has to produce byte-identical output. Object key order in
@@ -148,7 +185,6 @@ describe('serializeSnapshot', () => {
           issues: [],
           admins: [],
         }),
-        '2026-09-07T00:00:00Z',
       );
 
     const written = collected(['bea', 'ada', 'cy']);
@@ -157,13 +193,25 @@ describe('serializeSnapshot', () => {
     expect(JSON.parse(written).people.map((p) => p.login)).toEqual(['ada', 'bea', 'cy']);
   });
 
-  it('records when the snapshot was taken', () => {
-    const written = JSON.parse(serializeSnapshot([], '2026-09-07T00:00:00Z'));
+  // THE FILE CARRIES NO TIMESTAMP, AND THAT IS THE POINT. The workflow decides whether
+  // to commit by asking git whether this file changed; a collected-at stamp changes on
+  // every run, so it would make every run a commit — and, since the host deploys a green
+  // main, a daily production deploy of nothing. When the data last changed is already
+  // recorded by the commit that changed it, exactly and unforgeably.
+  it('carries nothing that changes between runs of identical data', () => {
+    const entries = assembleEntries({
+      pullRequests: [pr('aleganza', 1, '2026-01-01T00:00:00Z')],
+      issues: [],
+      admins: [],
+    });
 
-    expect(written).toEqual({ generatedAt: '2026-09-07T00:00:00Z', people: [] });
+    expect(serializeSnapshot(entries)).toBe(serializeSnapshot(entries));
+    expect(JSON.parse(serializeSnapshot(entries))).toEqual({
+      people: [expect.objectContaining({ login: 'aleganza' })],
+    });
   });
 
   it('ends with a newline so the committed file is a well-formed text file', () => {
-    expect(serializeSnapshot([], '2026-09-07T00:00:00Z').endsWith('\n')).toBe(true);
+    expect(serializeSnapshot([]).endsWith('\n')).toBe(true);
   });
 });

--- a/web/scripts/build-contributors.test.mjs
+++ b/web/scripts/build-contributors.test.mjs
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import { RECENT_PULL_REQUEST_LIMIT, assembleEntries, serializeSnapshot } from './build-contributors.mjs';
+
+const author = (login, over = {}) => ({
+  login,
+  id: 7,
+  avatarUrl: `https://avatars.githubusercontent.com/u/7`,
+  accountType: 'User',
+  ...over,
+});
+
+const pr = (login, number, mergedAt, over = {}) => ({
+  author: author(login, over.author),
+  number,
+  title: `pull request ${number}`,
+  mergedAt,
+  url: `https://github.com/strelov1/freehire/pull/${number}`,
+});
+
+const issue = (login, createdAt, over = {}) => ({
+  author: author(login, over.author),
+  createdAt,
+});
+
+const find = (entries, login) => entries.find((e) => e.login === login);
+
+describe('assembleEntries', () => {
+  it('counts a contributor’s merged pull requests and opened issues', () => {
+    const entries = assembleEntries({
+      pullRequests: [pr('aleganza', 1, '2026-01-01T00:00:00Z'), pr('aleganza', 2, '2026-02-01T00:00:00Z')],
+      issues: [issue('aleganza', '2026-03-01T00:00:00Z')],
+      admins: [],
+    });
+
+    expect(find(entries, 'aleganza')).toMatchObject({ mergedPullRequests: 2, openedIssues: 1 });
+  });
+
+  // The dates span both kinds of contribution, so an issue filed after someone's last
+  // merged pull request still counts as them being here recently — which is what the
+  // page's ordering reads.
+  it('spans both pull requests and issues when dating a contributor', () => {
+    const entries = assembleEntries({
+      pullRequests: [pr('aleganza', 1, '2026-02-01T00:00:00Z')],
+      issues: [issue('aleganza', '2026-01-01T00:00:00Z'), issue('aleganza', '2026-03-01T00:00:00Z')],
+      admins: [],
+    });
+
+    expect(find(entries, 'aleganza')).toMatchObject({
+      firstContributionAt: '2026-01-01T00:00:00Z',
+      lastContributionAt: '2026-03-01T00:00:00Z',
+    });
+  });
+
+  it('includes someone who has only ever opened an issue', () => {
+    const entries = assembleEntries({
+      pullRequests: [],
+      issues: [issue('reporter', '2026-01-01T00:00:00Z')],
+      admins: [],
+    });
+
+    expect(find(entries, 'reporter')).toMatchObject({
+      mergedPullRequests: 0,
+      openedIssues: 1,
+      recentPullRequests: [],
+    });
+  });
+
+  // The repository carries thousands of merged pull requests, nearly all of them one
+  // maintainer's. Writing every one of them would put a large file through a daily
+  // commit to restate the same history, so the detail is bounded and the totals are not.
+  it('keeps only the most recent pull requests, newest first, but counts them all', () => {
+    const many = Array.from({ length: RECENT_PULL_REQUEST_LIMIT + 5 }, (_, i) =>
+      pr('strelov1', i + 1, `2026-01-${String(i + 1).padStart(2, '0')}T00:00:00Z`),
+    );
+
+    const entry = find(assembleEntries({ pullRequests: many, issues: [], admins: [] }), 'strelov1');
+
+    expect(entry.mergedPullRequests).toBe(RECENT_PULL_REQUEST_LIMIT + 5);
+    expect(entry.recentPullRequests).toHaveLength(RECENT_PULL_REQUEST_LIMIT);
+    expect(entry.recentPullRequests[0].number).toBe(RECENT_PULL_REQUEST_LIMIT + 5);
+  });
+
+  it('marks an admin collaborator as a maintainer and everyone else as a contributor', () => {
+    const entries = assembleEntries({
+      pullRequests: [pr('strelov1', 1, '2026-01-01T00:00:00Z'), pr('aleganza', 2, '2026-01-02T00:00:00Z')],
+      issues: [],
+      admins: ['strelov1'],
+    });
+
+    expect(find(entries, 'strelov1').role).toBe('maintainer');
+    expect(find(entries, 'aleganza').role).toBe('contributor');
+  });
+
+  // Collaborator logins and author logins come from different endpoints and GitHub
+  // logins are case-insensitive, so the two must not be compared literally.
+  it('matches an admin collaborator regardless of case', () => {
+    const entries = assembleEntries({
+      pullRequests: [pr('Strelov1', 1, '2026-01-01T00:00:00Z')],
+      issues: [],
+      admins: ['strelov1'],
+    });
+
+    expect(find(entries, 'Strelov1').role).toBe('maintainer');
+  });
+
+  // Someone may not want their name on a marketing page. An exclusion list fails safe:
+  // forgetting to add a login shows them, which is the state they were already in.
+  it('leaves out a login that asked to be excluded', () => {
+    const entries = assembleEntries({
+      pullRequests: [pr('shy', 1, '2026-01-01T00:00:00Z'), pr('aleganza', 2, '2026-01-02T00:00:00Z')],
+      issues: [],
+      admins: [],
+      excluded: ['shy'],
+    });
+
+    expect(entries.map((e) => e.login)).toEqual(['aleganza']);
+  });
+
+  // A pull request or issue whose author GitHub no longer resolves (a deleted account)
+  // comes back without one. It belongs to nobody, so it is counted for nobody.
+  it('ignores a contribution with no author', () => {
+    const orphan = { author: null, number: 1, title: 'orphan', mergedAt: '2026-01-01T00:00:00Z', url: 'x' };
+
+    const entries = assembleEntries({
+      pullRequests: [orphan, pr('aleganza', 2, '2026-01-02T00:00:00Z')],
+      issues: [],
+      admins: [],
+    });
+
+    expect(entries.map((e) => e.login)).toEqual(['aleganza']);
+    expect(find(entries, 'aleganza').mergedPullRequests).toBe(1);
+  });
+});
+
+describe('serializeSnapshot', () => {
+  // The workflow decides whether to commit by asking git whether the file changed, so
+  // an unchanged collection has to produce byte-identical output. Object key order in
+  // JSON.stringify follows insertion order, and insertion order here follows whatever
+  // order GitHub happened to page the results in.
+  it('writes people in a stable order whatever order they were collected in', () => {
+    // The pull-request number is derived from the login, not from the position, so the
+    // two collections differ only in the order GitHub returned them.
+    const number = { ada: 11, bea: 22, cy: 33 };
+    const collected = (order) =>
+      serializeSnapshot(
+        assembleEntries({
+          pullRequests: order.map((login) => pr(login, number[login], '2026-01-01T00:00:00Z')),
+          issues: [],
+          admins: [],
+        }),
+        '2026-09-07T00:00:00Z',
+      );
+
+    const written = collected(['bea', 'ada', 'cy']);
+
+    expect(written).toBe(collected(['cy', 'bea', 'ada']));
+    expect(JSON.parse(written).people.map((p) => p.login)).toEqual(['ada', 'bea', 'cy']);
+  });
+
+  it('records when the snapshot was taken', () => {
+    const written = JSON.parse(serializeSnapshot([], '2026-09-07T00:00:00Z'));
+
+    expect(written).toEqual({ generatedAt: '2026-09-07T00:00:00Z', people: [] });
+  });
+
+  it('ends with a newline so the committed file is a well-formed text file', () => {
+    expect(serializeSnapshot([], '2026-09-07T00:00:00Z').endsWith('\n')).toBe(true);
+  });
+});

--- a/web/scripts/build-contributors.test.mjs
+++ b/web/scripts/build-contributors.test.mjs
@@ -214,4 +214,30 @@ describe('serializeSnapshot', () => {
   it('ends with a newline so the committed file is a well-formed text file', () => {
     expect(serializeSnapshot([]).endsWith('\n')).toBe(true);
   });
+
+  // Ordered by the lowercased login compared code-unit by code-unit, NOT by
+  // localeCompare. localeCompare's answer depends on the runtime's locale and ICU data,
+  // so a laptop and a CI runner can disagree about the same two logins — and every
+  // disagreement is a commit, and a deploy, of data that did not change. The whole
+  // commit-only-on-change design needs this comparison to be a property of the strings
+  // and of nothing else.
+  //
+  // The fixture is chosen to fail under raw code-unit order too: `Bea` sorts before
+  // `ada` on the raw strings, because every uppercase letter precedes every lowercase
+  // one, which would group the page's logins by capitalisation for no reason.
+  it('orders people by lowercased login, independent of locale', () => {
+    const entries = ['cy', 'Bea', 'ada'].map((login, i) =>
+      assembleEntries({
+        pullRequests: [pr(login, i + 1, '2026-01-01T00:00:00Z')],
+        issues: [],
+        admins: [],
+      }).at(0),
+    );
+
+    expect(JSON.parse(serializeSnapshot(entries)).people.map((p) => p.login)).toEqual([
+      'ada',
+      'Bea',
+      'cy',
+    ]);
+  });
 });

--- a/web/scripts/og-smoke.mjs
+++ b/web/scripts/og-smoke.mjs
@@ -106,6 +106,42 @@ const companyFixtures = {
   companyZeroJobs: [company({ name: 'Dormant Inc', tagline: 'Nothing open right now' }), 0],
 };
 
+// A contributor entry; per-fixture overrides tweak the fields the contributor card
+// reads. Only the counts, the login, the role and the first-contribution date reach
+// the card — the pull-request list is a page concern, not a card one.
+function contributor(overrides = {}) {
+  return {
+    login: 'aleganza',
+    id: 1,
+    avatarUrl: 'https://avatars.githubusercontent.com/u/1',
+    accountType: 'User',
+    role: 'contributor',
+    firstContributionAt: '2026-07-15T00:00:00Z',
+    lastContributionAt: '2026-08-30T00:00:00Z',
+    mergedPullRequests: 8,
+    openedIssues: 3,
+    recentPullRequests: [],
+    ...overrides,
+  };
+}
+
+// The degradation cases the contributor card handles. Every one renders with a null
+// avatar, which is also the fallback path — satori cannot fetch a remote image, so a
+// contributor whose avatar could not be resolved must still produce a valid PNG.
+const contributorFixtures = {
+  contributorBoth: contributor(),
+  contributorCodeOnly: contributor({ login: 'andrewsakhno', mergedPullRequests: 7, openedIssues: 0 }),
+  contributorIssuesOnly: contributor({ login: 'joedeveloper', mergedPullRequests: 0, openedIssues: 1 }),
+  contributorFirstEver: contributor({ login: 'spoddub', mergedPullRequests: 1, openedIssues: 0 }),
+  contributorMaintainer: contributor({
+    login: 'strelov1',
+    role: 'maintainer',
+    mergedPullRequests: 2236,
+    openedIssues: 89,
+  }),
+  contributorLongLogin: contributor({ login: 'a-very-long-github-login-indeed-yes', openedIssues: 0 }),
+};
+
 async function main() {
   const vite = await createOgVite();
 
@@ -113,6 +149,7 @@ async function main() {
   try {
     const { renderCardPng, renderMarkupPng } = await vite.ssrLoadModule('/src/lib/server/og/render.ts');
     const { buildCompanyCard } = await vite.ssrLoadModule('/src/lib/server/og/company.ts');
+    const { buildContributorCard } = await vite.ssrLoadModule('/src/lib/server/og/contributor.ts');
     const fonts = await loadFonts();
     await mkdir(outDir, { recursive: true });
 
@@ -129,6 +166,11 @@ async function main() {
 
     for (const [name, [entity, openJobs]] of Object.entries(companyFixtures)) {
       const markup = buildCompanyCard(entity, { logo: null, openJobs });
+      await assertPng(name, Buffer.from(await renderMarkupPng(markup, fonts)));
+    }
+
+    for (const [name, entry] of Object.entries(contributorFixtures)) {
+      const markup = buildContributorCard(entry, { avatar: null });
       await assertPng(name, Buffer.from(await renderMarkupPng(markup, fonts)));
     }
   } finally {

--- a/web/src/lib/components/Footer.svelte
+++ b/web/src/lib/components/Footer.svelte
@@ -58,6 +58,9 @@
         { label: 'Open', href: resolve('/open') },
         { label: 'For companies', href: resolve('/for-companies') },
         { label: 'Contribute', href: resolve('/contribute') },
+        // Next to Contribute rather than under Resources: the two are one thought —
+        // here is how to help, and here is everyone who did.
+        { label: 'Contributors', href: resolve('/contributors') },
         { label: 'Submit a job', href: resolve('/submit') },
         { label: 'Status', href: resolve('/status') },
         { label: 'Support', href: resolve('/support') },

--- a/web/src/lib/contributors.test.ts
+++ b/web/src/lib/contributors.test.ts
@@ -20,7 +20,7 @@ function person(over: Partial<ContributorEntry> = {}): ContributorEntry {
 }
 
 function snapshot(people: ContributorEntry[]): ContributorsSnapshot {
-  return { generatedAt: '2026-09-07T00:00:00Z', people };
+  return { people };
 }
 
 const logins = (entries: ContributorEntry[]) => entries.map((e) => e.login);

--- a/web/src/lib/contributors.test.ts
+++ b/web/src/lib/contributors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { contributorGroups, findContributor } from './contributors';
+import { contributionSummary, contributorGroups, findContributor } from './contributors';
 import type { ContributorEntry, ContributorsSnapshot } from './contributors';
 import committed from './data/contributors.json';
 
@@ -127,7 +127,7 @@ describe('contributorGroups', () => {
     );
 
     expect(logins(groups.contributors)).toEqual(['reporter']);
-    expect(groups.contributors[0].recentPullRequests).toEqual([]);
+    expect(groups.contributors[0]?.recentPullRequests).toEqual([]);
   });
 
   // The collector reaches accounts through several queries, so an entry can survive with
@@ -154,6 +154,37 @@ describe('contributorGroups', () => {
 // bot filter written against the obvious signal alone would put GitHub's second-largest
 // contributor to this repository on a page about people, and every fixture in this file
 // would still be green.
+describe('contributionSummary', () => {
+  it('names merged pull requests when that is all there is', () => {
+    expect(contributionSummary(person({ mergedPullRequests: 8, openedIssues: 0 }))).toBe(
+      '8 merged pull requests',
+    );
+  });
+
+  it('names opened issues when there is no merged code', () => {
+    expect(contributionSummary(person({ mergedPullRequests: 0, openedIssues: 3 }))).toBe(
+      '3 issues opened',
+    );
+  });
+
+  it('names both when there are both', () => {
+    expect(contributionSummary(person({ mergedPullRequests: 8, openedIssues: 3 }))).toBe(
+      '8 merged pull requests · 3 issues opened',
+    );
+  });
+
+  // Someone's first contribution is the one most likely to be read by them, and "1
+  // merged pull requests" is a careless way to greet it.
+  it('reads naturally for a single contribution of each kind', () => {
+    expect(contributionSummary(person({ mergedPullRequests: 1, openedIssues: 0 }))).toBe(
+      '1 merged pull request',
+    );
+    expect(contributionSummary(person({ mergedPullRequests: 0, openedIssues: 1 }))).toBe(
+      '1 issue opened',
+    );
+  });
+});
+
 describe('the committed snapshot', () => {
   const snapshotOnDisk = committed as ContributorsSnapshot;
 

--- a/web/src/lib/contributors.test.ts
+++ b/web/src/lib/contributors.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+import { contributorGroups, findContributor } from './contributors';
+import type { ContributorEntry, ContributorsSnapshot } from './contributors';
+import committed from './data/contributors.json';
+
+function person(over: Partial<ContributorEntry> = {}): ContributorEntry {
+  return {
+    login: 'someone',
+    id: 1,
+    avatarUrl: 'https://avatars.githubusercontent.com/u/1',
+    accountType: 'User',
+    role: 'contributor',
+    firstContributionAt: '2026-01-01T00:00:00Z',
+    lastContributionAt: '2026-01-01T00:00:00Z',
+    mergedPullRequests: 1,
+    openedIssues: 0,
+    recentPullRequests: [],
+    ...over,
+  };
+}
+
+function snapshot(people: ContributorEntry[]): ContributorsSnapshot {
+  return { generatedAt: '2026-09-07T00:00:00Z', people };
+}
+
+const logins = (entries: ContributorEntry[]) => entries.map((e) => e.login);
+
+describe('contributorGroups', () => {
+  it('shows a human contributor', () => {
+    const groups = contributorGroups(snapshot([person({ login: 'aleganza' })]));
+
+    expect(logins(groups.contributors)).toEqual(['aleganza']);
+  });
+
+  // Left in, dependabot is the second-largest contributor to this repository and would
+  // sit near the top of a page about people. The account type is what GitHub itself
+  // reports, and the login suffix catches an account the collector saw without one.
+  it('drops an account GitHub reports as a bot', () => {
+    const groups = contributorGroups(
+      snapshot([person({ login: 'aleganza' }), person({ login: 'renovate', accountType: 'Bot' })]),
+    );
+
+    expect(logins(groups.contributors)).toEqual(['aleganza']);
+  });
+
+  it('drops an account whose login is marked as a bot', () => {
+    const groups = contributorGroups(
+      snapshot([person({ login: 'aleganza' }), person({ login: 'dependabot[bot]' })]),
+    );
+
+    expect(logins(groups.contributors)).toEqual(['aleganza']);
+  });
+
+  // One account holds roughly three thousand commits here and every other holds fewer
+  // than ten. Rendered in one grid, the eight smaller histories read as noise beside
+  // the one large one, so the maintainer is shown apart rather than at the top.
+  it('puts a maintainer in their own group, never among the contributors', () => {
+    const groups = contributorGroups(
+      snapshot([person({ login: 'strelov1', role: 'maintainer' }), person({ login: 'aleganza' })]),
+    );
+
+    expect(logins(groups.maintainers)).toEqual(['strelov1']);
+    expect(logins(groups.contributors)).toEqual(['aleganza']);
+  });
+
+  it('drops a bot that carries maintainer permissions', () => {
+    const groups = contributorGroups(
+      snapshot([
+        person({ login: 'strelov1', role: 'maintainer' }),
+        person({ login: 'github-actions[bot]', role: 'maintainer' }),
+      ]),
+    );
+
+    expect(logins(groups.maintainers)).toEqual(['strelov1']);
+  });
+
+  // The page exists to attract the next contributor, so the newest one must be the one
+  // it shows first. Ordered by volume, a newcomer is buried the moment they arrive
+  // behind everyone who has been here longer — the opposite of the page's purpose.
+  it('orders contributors by their most recent contribution, newest first', () => {
+    const groups = contributorGroups(
+      snapshot([
+        person({
+          login: 'long-timer',
+          mergedPullRequests: 8,
+          lastContributionAt: '2025-09-01T00:00:00Z',
+        }),
+        person({
+          login: 'newcomer',
+          mergedPullRequests: 1,
+          lastContributionAt: '2026-09-01T00:00:00Z',
+        }),
+      ]),
+    );
+
+    expect(logins(groups.contributors)).toEqual(['newcomer', 'long-timer']);
+  });
+
+  it('orders an issue reporter with no merged code ahead of an older code contributor', () => {
+    const groups = contributorGroups(
+      snapshot([
+        person({
+          login: 'coder',
+          mergedPullRequests: 8,
+          lastContributionAt: '2025-09-01T00:00:00Z',
+        }),
+        person({
+          login: 'reporter',
+          mergedPullRequests: 0,
+          openedIssues: 1,
+          lastContributionAt: '2026-09-01T00:00:00Z',
+        }),
+      ]),
+    );
+
+    expect(logins(groups.contributors)).toEqual(['reporter', 'coder']);
+  });
+
+  // A merged pull request is not the only way to have helped. Someone who has only ever
+  // filed issues is shown, and their profile simply has nothing in its pull-request list
+  // rather than being absent from the site.
+  it('keeps a contributor whose only contribution is an issue', () => {
+    const groups = contributorGroups(
+      snapshot([
+        person({ login: 'reporter', mergedPullRequests: 0, openedIssues: 3, recentPullRequests: [] }),
+      ]),
+    );
+
+    expect(logins(groups.contributors)).toEqual(['reporter']);
+    expect(groups.contributors[0].recentPullRequests).toEqual([]);
+  });
+
+  // The collector reaches accounts through several queries, so an entry can survive with
+  // nothing attached to it — a review comment author, a closed pull request that never
+  // merged. Nothing is a contribution the page can name, so the entry is not shown.
+  it('drops an entry with no merged pull request and no opened issue', () => {
+    const groups = contributorGroups(
+      snapshot([
+        person({ login: 'passer-by', mergedPullRequests: 0, openedIssues: 0 }),
+        person({ login: 'aleganza' }),
+      ]),
+    );
+
+    expect(logins(groups.contributors)).toEqual(['aleganza']);
+  });
+});
+
+// The collector and these rules are two halves of one feature that never run together
+// anywhere else — the collector runs in a scheduled job, the rules run in a page. This
+// is where they are checked against each other, on the file that actually ships.
+//
+// It earns its place: the GraphQL API spells dependabot's login `dependabot`, with no
+// `[bot]` suffix, while the REST endpoint spells the same account `dependabot[bot]`. A
+// bot filter written against the obvious signal alone would put GitHub's second-largest
+// contributor to this repository on a page about people, and every fixture in this file
+// would still be green.
+describe('the committed snapshot', () => {
+  const snapshotOnDisk = committed as ContributorsSnapshot;
+
+  it('carries at least one bot for the rules to have something to exclude', () => {
+    const bots = snapshotOnDisk.people.filter((p) => p.accountType !== 'User');
+
+    expect(bots.length).toBeGreaterThan(0);
+  });
+
+  it('shows no bot on either group', () => {
+    const groups = contributorGroups(snapshotOnDisk);
+    const shown = [...groups.maintainers, ...groups.contributors];
+
+    expect(shown.filter((p) => p.accountType !== 'User')).toEqual([]);
+    expect(shown.filter((p) => p.login.toLowerCase().includes('bot'))).toEqual([]);
+  });
+
+  it('has both a maintainer and contributors to render', () => {
+    const groups = contributorGroups(snapshotOnDisk);
+
+    expect(groups.maintainers.length).toBeGreaterThan(0);
+    expect(groups.contributors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('findContributor', () => {
+  it('finds a shown contributor by their login', () => {
+    const found = findContributor(snapshot([person({ login: 'aleganza' })]), 'aleganza');
+
+    expect(found?.login).toBe('aleganza');
+  });
+
+  it('does not find a login absent from the snapshot', () => {
+    expect(findContributor(snapshot([person({ login: 'aleganza' })]), 'nobody')).toBeNull();
+  });
+
+  // The lookup must apply the same rules the showcase does. Reading the raw snapshot
+  // instead would give a bot — or an entry with nothing to show — a profile page and a
+  // social card that the showcase itself never links to.
+  it('does not find a bot, even though the snapshot carries it', () => {
+    const people = snapshot([person({ login: 'dependabot[bot]' })]);
+
+    expect(findContributor(people, 'dependabot[bot]')).toBeNull();
+  });
+
+  it('does not find an entry with nothing to show', () => {
+    const people = snapshot([
+      person({ login: 'passer-by', mergedPullRequests: 0, openedIssues: 0 }),
+    ]);
+
+    expect(findContributor(people, 'passer-by')).toBeNull();
+  });
+
+  // GitHub logins are case-insensitive, so a link typed or shared with different casing
+  // must reach the same page rather than a 404.
+  it('matches a login regardless of case', () => {
+    const found = findContributor(snapshot([person({ login: 'aleganza' })]), 'AlEgAnZa');
+
+    expect(found?.login).toBe('aleganza');
+  });
+});

--- a/web/src/lib/contributors.ts
+++ b/web/src/lib/contributors.ts
@@ -79,6 +79,24 @@ export function contributorGroups(snapshot: ContributorsSnapshot): ContributorGr
   };
 }
 
+const plural = (n: number, one: string, many: string) => `${n} ${n === 1 ? one : many}`;
+
+/** What a person contributed, in the page's own words.
+ *
+ *  Only what they actually did: naming a kind they have none of would read as an
+ *  absence — "0 issues opened" beside someone's first merged pull request is a scolding,
+ *  not a summary. */
+export function contributionSummary(entry: ContributorEntry): string {
+  const parts = [];
+  if (entry.mergedPullRequests > 0) {
+    parts.push(plural(entry.mergedPullRequests, 'merged pull request', 'merged pull requests'));
+  }
+  if (entry.openedIssues > 0) {
+    parts.push(`${plural(entry.openedIssues, 'issue', 'issues')} opened`);
+  }
+  return parts.join(' · ');
+}
+
 /** The one person a profile page and its social card are about, or null.
  *
  *  Resolved through the same rules the showcase renders, never against the raw

--- a/web/src/lib/contributors.ts
+++ b/web/src/lib/contributors.ts
@@ -7,8 +7,9 @@
 // nightly job nobody watches is a rule nobody can trust. Here it is unit-tested
 // against fixtures with no network anywhere.
 
-/** One merged pull request, as a profile page lists it. */
-export interface ContributorPullRequest {
+/** One merged pull request, as a profile page lists it. Not exported: it is reached
+ *  through `ContributorEntry.recentPullRequests`, and nothing names it directly. */
+interface ContributorPullRequest {
   number: number;
   title: string;
   /** ISO-8601 instant the pull request was merged. */
@@ -38,9 +39,13 @@ export interface ContributorEntry {
   recentPullRequests: ContributorPullRequest[];
 }
 
-/** The committed snapshot: everyone the collector found, and when it looked. */
+/** The committed snapshot: everyone the collector found.
+ *
+ *  Deliberately carries no collected-at stamp. The workflow that rewrites this file
+ *  commits only when it changed, and it asks git that question — so a field that varied
+ *  between runs of identical data would make every run a commit and every commit a
+ *  deploy. When the data last changed is what the commit itself records. */
 export interface ContributorsSnapshot {
-  generatedAt: string;
   people: ContributorEntry[];
 }
 

--- a/web/src/lib/contributors.ts
+++ b/web/src/lib/contributors.ts
@@ -1,0 +1,109 @@
+// The rules the contributors pages read the committed snapshot through.
+//
+// Collection lives in `scripts/build-contributors.mjs`, which does I/O and nothing
+// else: it pages the GitHub API and writes down everyone it found, bots included.
+// Every RULE — who is shown, how they are grouped, what order they appear in — lives
+// here instead, as pure functions over that file, because a rule exercised only by a
+// nightly job nobody watches is a rule nobody can trust. Here it is unit-tested
+// against fixtures with no network anywhere.
+
+/** One merged pull request, as a profile page lists it. */
+export interface ContributorPullRequest {
+  number: number;
+  title: string;
+  /** ISO-8601 instant the pull request was merged. */
+  mergedAt: string;
+  url: string;
+}
+
+/** One person in the snapshot, exactly as the collector wrote them down.
+ *
+ *  `recentPullRequests` is capped by the collector rather than holding a person's
+ *  whole history: the repository carries thousands of merged pull requests, almost
+ *  all of them one maintainer's, and committing that daily would be a large file
+ *  restating the same history. Totals stay exact; only the detail is bounded. */
+export interface ContributorEntry {
+  login: string;
+  id: number;
+  avatarUrl: string;
+  /** GitHub's own account type. `Bot` is how an automated account identifies itself. */
+  accountType: string;
+  role: 'maintainer' | 'contributor';
+  /** ISO-8601 instant of their earliest contribution, pull request or issue. */
+  firstContributionAt: string;
+  /** ISO-8601 instant of their latest contribution, pull request or issue. */
+  lastContributionAt: string;
+  mergedPullRequests: number;
+  openedIssues: number;
+  recentPullRequests: ContributorPullRequest[];
+}
+
+/** The committed snapshot: everyone the collector found, and when it looked. */
+export interface ContributorsSnapshot {
+  generatedAt: string;
+  people: ContributorEntry[];
+}
+
+/** What a page renders: the two groups, each already filtered and ordered. */
+export interface ContributorGroups {
+  maintainers: ContributorEntry[];
+  contributors: ContributorEntry[];
+}
+
+/** Whether an entry is an automated account.
+ *
+ *  Two signals rather than one: `accountType` is what GitHub itself reports and is the
+ *  authority, and the `[bot]` login suffix catches an account reached through a path
+ *  that did not carry the type. Left in, `dependabot[bot]` is the second-largest
+ *  contributor to this repository — on a page about people, that is a bug. */
+function isBot(entry: ContributorEntry): boolean {
+  return entry.accountType === 'Bot' || entry.login.endsWith('[bot]');
+}
+
+/** Whether the entry has something the page can name as a contribution.
+ *
+ *  The collector reaches accounts through more than one query, so an entry can survive
+ *  with nothing attached to it. A merged pull request and an opened issue both count;
+ *  neither means there is nothing to show. */
+function hasContributed(entry: ContributorEntry): boolean {
+  return entry.mergedPullRequests > 0 || entry.openedIssues > 0;
+}
+
+/** The snapshot as the pages show it. */
+export function contributorGroups(snapshot: ContributorsSnapshot): ContributorGroups {
+  const people = snapshot.people.filter((entry) => !isBot(entry) && hasContributed(entry));
+
+  return {
+    maintainers: byRecency(people.filter((entry) => entry.role === 'maintainer')),
+    contributors: byRecency(people.filter((entry) => entry.role !== 'maintainer')),
+  };
+}
+
+/** The one person a profile page and its social card are about, or null.
+ *
+ *  Resolved through the same rules the showcase renders, never against the raw
+ *  snapshot: a bot, or an entry with nothing to show, must 404 rather than get a page
+ *  and a shareable card the showcase itself never links to.
+ *
+ *  Matched case-insensitively because GitHub logins are, so a link shared with
+ *  different casing reaches the page instead of a 404. */
+export function findContributor(
+  snapshot: ContributorsSnapshot,
+  login: string,
+): ContributorEntry | null {
+  const wanted = login.toLowerCase();
+  const { maintainers, contributors } = contributorGroups(snapshot);
+
+  return [...maintainers, ...contributors].find((e) => e.login.toLowerCase() === wanted) ?? null;
+}
+
+/** Most recent contribution first.
+ *
+ *  Deliberately not by volume: this page's job is to attract the next contributor, and
+ *  a volume ordering buries a newcomer the moment they arrive, behind everyone who has
+ *  simply been here longer. Recency puts the newest arrival where the page's purpose
+ *  needs them, and reads as "people contribute here" rather than "one person wrote
+ *  this". No count is consulted. */
+function byRecency(entries: ContributorEntry[]): ContributorEntry[] {
+  return [...entries].sort((a, b) => b.lastContributionAt.localeCompare(a.lastContributionAt));
+}

--- a/web/src/lib/data/contributors.json
+++ b/web/src/lib/data/contributors.json
@@ -1,5 +1,4 @@
 {
-  "generatedAt": "2026-09-07T03:52:49.344Z",
   "people": [
     {
       "login": "111100001",
@@ -12,6 +11,86 @@
       "mergedPullRequests": 0,
       "openedIssues": 1,
       "recentPullRequests": []
+    },
+    {
+      "login": "HafizMMoaz",
+      "id": 103947442,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/103947442?u=c9f758c94f081f84700d0280af0f3ec6bdf0fc7c&v=4",
+      "accountType": "User",
+      "role": "contributor",
+      "firstContributionAt": "2026-08-11T02:05:14Z",
+      "lastContributionAt": "2026-08-11T03:38:51Z",
+      "mergedPullRequests": 5,
+      "openedIssues": 0,
+      "recentPullRequests": [
+        {
+          "number": 1719,
+          "title": "feat(sources): add Remotli source adapter",
+          "mergedAt": "2026-08-11T03:38:51Z",
+          "url": "https://github.com/strelov1/freehire/pull/1719"
+        },
+        {
+          "number": 1717,
+          "title": "feat(sources): add NoDesk source adapter",
+          "mergedAt": "2026-08-11T02:39:00Z",
+          "url": "https://github.com/strelov1/freehire/pull/1717"
+        },
+        {
+          "number": 1720,
+          "title": "feat(sources): add The Muse source adapter",
+          "mergedAt": "2026-08-11T02:38:50Z",
+          "url": "https://github.com/strelov1/freehire/pull/1720"
+        },
+        {
+          "number": 1724,
+          "title": "feat(sources): add SolidJobs source adapter (IT division)",
+          "mergedAt": "2026-08-11T02:38:47Z",
+          "url": "https://github.com/strelov1/freehire/pull/1724"
+        },
+        {
+          "number": 1718,
+          "title": "feat(sources): add Cryptocurrency Jobs source adapter",
+          "mergedAt": "2026-08-11T02:05:14Z",
+          "url": "https://github.com/strelov1/freehire/pull/1718"
+        }
+      ]
+    },
+    {
+      "login": "Klavaro66",
+      "id": 57226205,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/57226205?v=4",
+      "accountType": "User",
+      "role": "contributor",
+      "firstContributionAt": "2026-09-02T21:28:39Z",
+      "lastContributionAt": "2026-09-06T15:50:58Z",
+      "mergedPullRequests": 0,
+      "openedIssues": 4,
+      "recentPullRequests": []
+    },
+    {
+      "login": "ManishModak",
+      "id": 111450082,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/111450082?u=1e7123cd6313a8520038d82f3c9233c1251a5a12&v=4",
+      "accountType": "User",
+      "role": "contributor",
+      "firstContributionAt": "2026-08-08T22:48:59Z",
+      "lastContributionAt": "2026-08-11T11:56:36Z",
+      "mergedPullRequests": 2,
+      "openedIssues": 0,
+      "recentPullRequests": [
+        {
+          "number": 1748,
+          "title": "feat(auth): add mobile auth v2 (verifier-bound OAuth, native Apple, recent auth & connected identities)",
+          "mergedAt": "2026-08-11T11:56:36Z",
+          "url": "https://github.com/strelov1/freehire/pull/1748"
+        },
+        {
+          "number": 1657,
+          "title": "feat(auth): harden session contracts, recovery atomicity & throttling for mobile foundation",
+          "mergedAt": "2026-08-08T22:48:59Z",
+          "url": "https://github.com/strelov1/freehire/pull/1657"
+        }
+      ]
     },
     {
       "login": "aleganza",
@@ -275,49 +354,6 @@
       ]
     },
     {
-      "login": "HafizMMoaz",
-      "id": 103947442,
-      "avatarUrl": "https://avatars.githubusercontent.com/u/103947442?u=c9f758c94f081f84700d0280af0f3ec6bdf0fc7c&v=4",
-      "accountType": "User",
-      "role": "contributor",
-      "firstContributionAt": "2026-08-11T02:05:14Z",
-      "lastContributionAt": "2026-08-11T03:38:51Z",
-      "mergedPullRequests": 5,
-      "openedIssues": 0,
-      "recentPullRequests": [
-        {
-          "number": 1719,
-          "title": "feat(sources): add Remotli source adapter",
-          "mergedAt": "2026-08-11T03:38:51Z",
-          "url": "https://github.com/strelov1/freehire/pull/1719"
-        },
-        {
-          "number": 1717,
-          "title": "feat(sources): add NoDesk source adapter",
-          "mergedAt": "2026-08-11T02:39:00Z",
-          "url": "https://github.com/strelov1/freehire/pull/1717"
-        },
-        {
-          "number": 1720,
-          "title": "feat(sources): add The Muse source adapter",
-          "mergedAt": "2026-08-11T02:38:50Z",
-          "url": "https://github.com/strelov1/freehire/pull/1720"
-        },
-        {
-          "number": 1724,
-          "title": "feat(sources): add SolidJobs source adapter (IT division)",
-          "mergedAt": "2026-08-11T02:38:47Z",
-          "url": "https://github.com/strelov1/freehire/pull/1724"
-        },
-        {
-          "number": 1718,
-          "title": "feat(sources): add Cryptocurrency Jobs source adapter",
-          "mergedAt": "2026-08-11T02:05:14Z",
-          "url": "https://github.com/strelov1/freehire/pull/1718"
-        }
-      ]
-    },
-    {
       "login": "infinitelife102",
       "id": 246451738,
       "avatarUrl": "https://avatars.githubusercontent.com/u/246451738?u=26e931097b0a1ddc8b8b6416e0c62d51509aecae&v=4",
@@ -340,43 +376,6 @@
       "mergedPullRequests": 0,
       "openedIssues": 1,
       "recentPullRequests": []
-    },
-    {
-      "login": "Klavaro66",
-      "id": 57226205,
-      "avatarUrl": "https://avatars.githubusercontent.com/u/57226205?v=4",
-      "accountType": "User",
-      "role": "contributor",
-      "firstContributionAt": "2026-09-02T21:28:39Z",
-      "lastContributionAt": "2026-09-06T15:50:58Z",
-      "mergedPullRequests": 0,
-      "openedIssues": 4,
-      "recentPullRequests": []
-    },
-    {
-      "login": "ManishModak",
-      "id": 111450082,
-      "avatarUrl": "https://avatars.githubusercontent.com/u/111450082?u=1e7123cd6313a8520038d82f3c9233c1251a5a12&v=4",
-      "accountType": "User",
-      "role": "contributor",
-      "firstContributionAt": "2026-08-08T22:48:59Z",
-      "lastContributionAt": "2026-08-11T11:56:36Z",
-      "mergedPullRequests": 2,
-      "openedIssues": 0,
-      "recentPullRequests": [
-        {
-          "number": 1748,
-          "title": "feat(auth): add mobile auth v2 (verifier-bound OAuth, native Apple, recent auth & connected identities)",
-          "mergedAt": "2026-08-11T11:56:36Z",
-          "url": "https://github.com/strelov1/freehire/pull/1748"
-        },
-        {
-          "number": 1657,
-          "title": "feat(auth): harden session contracts, recovery atomicity & throttling for mobile foundation",
-          "mergedAt": "2026-08-08T22:48:59Z",
-          "url": "https://github.com/strelov1/freehire/pull/1657"
-        }
-      ]
     },
     {
       "login": "meminens",

--- a/web/src/lib/data/contributors.json
+++ b/web/src/lib/data/contributors.json
@@ -1,0 +1,650 @@
+{
+  "generatedAt": "2026-09-07T03:52:49.344Z",
+  "people": [
+    {
+      "login": "111100001",
+      "id": 24229327,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24229327?v=4",
+      "accountType": "User",
+      "role": "contributor",
+      "firstContributionAt": "2026-08-22T01:11:09Z",
+      "lastContributionAt": "2026-08-22T01:11:09Z",
+      "mergedPullRequests": 0,
+      "openedIssues": 1,
+      "recentPullRequests": []
+    },
+    {
+      "login": "aleganza",
+      "id": 73157384,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/73157384?u=e495bdbb5c70f4269889d99f1fd29ced5f5deb86&v=4",
+      "accountType": "User",
+      "role": "contributor",
+      "firstContributionAt": "2026-08-30T16:53:42Z",
+      "lastContributionAt": "2026-08-30T16:53:42Z",
+      "mergedPullRequests": 0,
+      "openedIssues": 1,
+      "recentPullRequests": []
+    },
+    {
+      "login": "andrewsakhno",
+      "id": 60744704,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/60744704?v=4",
+      "accountType": "User",
+      "role": "contributor",
+      "firstContributionAt": "2026-08-07T22:14:38Z",
+      "lastContributionAt": "2026-08-15T11:51:53Z",
+      "mergedPullRequests": 7,
+      "openedIssues": 0,
+      "recentPullRequests": [
+        {
+          "number": 1954,
+          "title": "Detect Polish English-level requirements in EnglishLevel",
+          "mergedAt": "2026-08-15T11:51:53Z",
+          "url": "https://github.com/strelov1/freehire/pull/1954"
+        },
+        {
+          "number": 1952,
+          "title": "fix feedback for companies. now each user can add only one category of feedback",
+          "mergedAt": "2026-08-15T11:36:43Z",
+          "url": "https://github.com/strelov1/freehire/pull/1952"
+        },
+        {
+          "number": 1953,
+          "title": "Fall back to Corporate/OrganizationDescriptionStr when Oracle's External* fields are blank",
+          "mergedAt": "2026-08-15T11:36:36Z",
+          "url": "https://github.com/strelov1/freehire/pull/1953"
+        },
+        {
+          "number": 1832,
+          "title": "add feedback for companies.",
+          "mergedAt": "2026-08-12T17:34:51Z",
+          "url": "https://github.com/strelov1/freehire/pull/1832"
+        },
+        {
+          "number": 1808,
+          "title": "fix(sources): resolve lever 404 block from issue #1529",
+          "mergedAt": "2026-08-11T22:18:28Z",
+          "url": "https://github.com/strelov1/freehire/pull/1808"
+        },
+        {
+          "number": 1755,
+          "title": "add pwa support",
+          "mergedAt": "2026-08-11T17:41:46Z",
+          "url": "https://github.com/strelov1/freehire/pull/1755"
+        },
+        {
+          "number": 1621,
+          "title": "fixes and tool for vacancies filtering",
+          "mergedAt": "2026-08-07T22:14:38Z",
+          "url": "https://github.com/strelov1/freehire/pull/1621"
+        }
+      ]
+    },
+    {
+      "login": "dependabot",
+      "id": 49699333,
+      "avatarUrl": "https://avatars.githubusercontent.com/in/29110?v=4",
+      "accountType": "Bot",
+      "role": "contributor",
+      "firstContributionAt": "2026-06-15T03:15:26Z",
+      "lastContributionAt": "2026-09-05T03:08:31Z",
+      "mergedPullRequests": 142,
+      "openedIssues": 0,
+      "recentPullRequests": [
+        {
+          "number": 2452,
+          "title": "Bump google.golang.org/grpc from 1.82.1 to 1.83.1",
+          "mergedAt": "2026-09-05T03:08:31Z",
+          "url": "https://github.com/strelov1/freehire/pull/2452"
+        },
+        {
+          "number": 2257,
+          "title": "Bump @types/node from 26.2.0 to 26.4.0 in /web",
+          "mergedAt": "2026-09-01T02:52:57Z",
+          "url": "https://github.com/strelov1/freehire/pull/2257"
+        },
+        {
+          "number": 2259,
+          "title": "Bump @storybook/addon-themes from 10.5.4 to 10.5.10 in /design-system",
+          "mergedAt": "2026-09-01T02:52:45Z",
+          "url": "https://github.com/strelov1/freehire/pull/2259"
+        },
+        {
+          "number": 2249,
+          "title": "Bump happy-dom from 20.11.6 to 20.11.15 in /extension",
+          "mergedAt": "2026-09-01T02:47:15Z",
+          "url": "https://github.com/strelov1/freehire/pull/2249"
+        },
+        {
+          "number": 2258,
+          "title": "Bump storybook from 10.5.8 to 10.5.10 in /design-system",
+          "mergedAt": "2026-09-01T02:37:27Z",
+          "url": "https://github.com/strelov1/freehire/pull/2258"
+        },
+        {
+          "number": 2255,
+          "title": "Bump @sentry/sveltekit from 10.70.0 to 10.72.0 in /web",
+          "mergedAt": "2026-09-01T02:37:11Z",
+          "url": "https://github.com/strelov1/freehire/pull/2255"
+        },
+        {
+          "number": 2262,
+          "title": "Bump github.com/aws/aws-sdk-go-v2/config from 1.32.38 to 1.33.1",
+          "mergedAt": "2026-09-01T02:37:02Z",
+          "url": "https://github.com/strelov1/freehire/pull/2262"
+        },
+        {
+          "number": 2256,
+          "title": "Bump eslint from 10.8.1 to 10.9.1 in /design-system",
+          "mergedAt": "2026-09-01T02:17:17Z",
+          "url": "https://github.com/strelov1/freehire/pull/2256"
+        },
+        {
+          "number": 2254,
+          "title": "Bump @lucide/svelte from 1.31.0 to 1.35.0 in /design-system",
+          "mergedAt": "2026-09-01T02:17:08Z",
+          "url": "https://github.com/strelov1/freehire/pull/2254"
+        },
+        {
+          "number": 2252,
+          "title": "Bump @storybook/svelte from 10.5.4 to 10.5.8 in /design-system",
+          "mergedAt": "2026-09-01T02:16:58Z",
+          "url": "https://github.com/strelov1/freehire/pull/2252"
+        },
+        {
+          "number": 2251,
+          "title": "Bump satori from 0.33.3 to 0.33.4 in /web",
+          "mergedAt": "2026-09-01T02:16:32Z",
+          "url": "https://github.com/strelov1/freehire/pull/2251"
+        },
+        {
+          "number": 2250,
+          "title": "Bump marked from 18.0.10 to 18.0.11 in /web",
+          "mergedAt": "2026-09-01T02:16:26Z",
+          "url": "https://github.com/strelov1/freehire/pull/2250"
+        },
+        {
+          "number": 2248,
+          "title": "Bump svelte-dnd-action from 0.9.78 to 0.9.79 in /web",
+          "mergedAt": "2026-09-01T02:16:18Z",
+          "url": "https://github.com/strelov1/freehire/pull/2248"
+        },
+        {
+          "number": 2253,
+          "title": "Bump github.com/aws/aws-sdk-go-v2/service/sqs from 1.46.7 to 1.48.1",
+          "mergedAt": "2026-09-01T02:14:14Z",
+          "url": "https://github.com/strelov1/freehire/pull/2253"
+        },
+        {
+          "number": 2263,
+          "title": "Bump github.com/aws/aws-sdk-go-v2/service/s3 from 1.107.3 to 1.109.1",
+          "mergedAt": "2026-09-01T02:14:05Z",
+          "url": "https://github.com/strelov1/freehire/pull/2263"
+        },
+        {
+          "number": 2261,
+          "title": "Bump github.com/getsentry/sentry-go from 0.48.0 to 0.49.0",
+          "mergedAt": "2026-08-31T21:19:46Z",
+          "url": "https://github.com/strelov1/freehire/pull/2261"
+        },
+        {
+          "number": 2260,
+          "title": "Bump github.com/aws/aws-sdk-go-v2/service/sesv2 from 1.66.6 to 1.69.1",
+          "mergedAt": "2026-08-31T21:19:37Z",
+          "url": "https://github.com/strelov1/freehire/pull/2260"
+        },
+        {
+          "number": 2212,
+          "title": "Bump github.com/aws/aws-sdk-go-v2/config from 1.32.37 to 1.32.38",
+          "mergedAt": "2026-08-25T02:51:37Z",
+          "url": "https://github.com/strelov1/freehire/pull/2212"
+        },
+        {
+          "number": 2199,
+          "title": "Bump posthog-js from 1.417.1 to 1.418.10 in /web",
+          "mergedAt": "2026-08-25T02:47:54Z",
+          "url": "https://github.com/strelov1/freehire/pull/2199"
+        },
+        {
+          "number": 2207,
+          "title": "Bump vitest from 4.1.10 to 4.1.11 in /design-system",
+          "mergedAt": "2026-08-25T02:46:11Z",
+          "url": "https://github.com/strelov1/freehire/pull/2207"
+        }
+      ]
+    },
+    {
+      "login": "gearsandcode",
+      "id": 7864607,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7864607?u=673c15169837abe6642fae6353ee81f2cec139f7&v=4",
+      "accountType": "User",
+      "role": "contributor",
+      "firstContributionAt": "2026-07-14T21:55:17Z",
+      "lastContributionAt": "2026-08-05T19:04:15Z",
+      "mergedPullRequests": 8,
+      "openedIssues": 3,
+      "recentPullRequests": [
+        {
+          "number": 1100,
+          "title": "DS Phase 6: Documentation",
+          "mergedAt": "2026-07-30T15:45:58Z",
+          "url": "https://github.com/strelov1/freehire/pull/1100"
+        },
+        {
+          "number": 1099,
+          "title": "ds: phase 5 — Storybook",
+          "mergedAt": "2026-07-30T14:33:20Z",
+          "url": "https://github.com/strelov1/freehire/pull/1099"
+        },
+        {
+          "number": 1098,
+          "title": "ds: phase 4 — component primitives",
+          "mergedAt": "2026-07-25T14:48:03Z",
+          "url": "https://github.com/strelov1/freehire/pull/1098"
+        },
+        {
+          "number": 1116,
+          "title": "ds: remove orphan sd.config.mjs",
+          "mergedAt": "2026-07-25T11:50:02Z",
+          "url": "https://github.com/strelov1/freehire/pull/1116"
+        },
+        {
+          "number": 1114,
+          "title": "DS Phase 3: Design tokens",
+          "mergedAt": "2026-07-24T20:17:10Z",
+          "url": "https://github.com/strelov1/freehire/pull/1114"
+        },
+        {
+          "number": 1088,
+          "title": "DS Phase 2: Package boundary and tooling migration",
+          "mergedAt": "2026-07-24T02:09:07Z",
+          "url": "https://github.com/strelov1/freehire/pull/1088"
+        },
+        {
+          "number": 1087,
+          "title": "DS Phase 1: Investigate and inventory",
+          "mergedAt": "2026-07-23T22:30:41Z",
+          "url": "https://github.com/strelov1/freehire/pull/1087"
+        },
+        {
+          "number": 708,
+          "title": "(enhancement): Adopt AGENTS.md open standard",
+          "mergedAt": "2026-07-15T03:02:19Z",
+          "url": "https://github.com/strelov1/freehire/pull/708"
+        }
+      ]
+    },
+    {
+      "login": "HafizMMoaz",
+      "id": 103947442,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/103947442?u=c9f758c94f081f84700d0280af0f3ec6bdf0fc7c&v=4",
+      "accountType": "User",
+      "role": "contributor",
+      "firstContributionAt": "2026-08-11T02:05:14Z",
+      "lastContributionAt": "2026-08-11T03:38:51Z",
+      "mergedPullRequests": 5,
+      "openedIssues": 0,
+      "recentPullRequests": [
+        {
+          "number": 1719,
+          "title": "feat(sources): add Remotli source adapter",
+          "mergedAt": "2026-08-11T03:38:51Z",
+          "url": "https://github.com/strelov1/freehire/pull/1719"
+        },
+        {
+          "number": 1717,
+          "title": "feat(sources): add NoDesk source adapter",
+          "mergedAt": "2026-08-11T02:39:00Z",
+          "url": "https://github.com/strelov1/freehire/pull/1717"
+        },
+        {
+          "number": 1720,
+          "title": "feat(sources): add The Muse source adapter",
+          "mergedAt": "2026-08-11T02:38:50Z",
+          "url": "https://github.com/strelov1/freehire/pull/1720"
+        },
+        {
+          "number": 1724,
+          "title": "feat(sources): add SolidJobs source adapter (IT division)",
+          "mergedAt": "2026-08-11T02:38:47Z",
+          "url": "https://github.com/strelov1/freehire/pull/1724"
+        },
+        {
+          "number": 1718,
+          "title": "feat(sources): add Cryptocurrency Jobs source adapter",
+          "mergedAt": "2026-08-11T02:05:14Z",
+          "url": "https://github.com/strelov1/freehire/pull/1718"
+        }
+      ]
+    },
+    {
+      "login": "infinitelife102",
+      "id": 246451738,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/246451738?u=26e931097b0a1ddc8b8b6416e0c62d51509aecae&v=4",
+      "accountType": "User",
+      "role": "contributor",
+      "firstContributionAt": "2026-08-17T14:46:01Z",
+      "lastContributionAt": "2026-09-02T08:04:31Z",
+      "mergedPullRequests": 0,
+      "openedIssues": 2,
+      "recentPullRequests": []
+    },
+    {
+      "login": "joedeveloper",
+      "id": 191722,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/191722?u=4728384a765439a46b69875152d8c25a9df91561&v=4",
+      "accountType": "User",
+      "role": "contributor",
+      "firstContributionAt": "2026-07-24T01:05:11Z",
+      "lastContributionAt": "2026-07-24T01:05:11Z",
+      "mergedPullRequests": 0,
+      "openedIssues": 1,
+      "recentPullRequests": []
+    },
+    {
+      "login": "Klavaro66",
+      "id": 57226205,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/57226205?v=4",
+      "accountType": "User",
+      "role": "contributor",
+      "firstContributionAt": "2026-09-02T21:28:39Z",
+      "lastContributionAt": "2026-09-06T15:50:58Z",
+      "mergedPullRequests": 0,
+      "openedIssues": 4,
+      "recentPullRequests": []
+    },
+    {
+      "login": "ManishModak",
+      "id": 111450082,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/111450082?u=1e7123cd6313a8520038d82f3c9233c1251a5a12&v=4",
+      "accountType": "User",
+      "role": "contributor",
+      "firstContributionAt": "2026-08-08T22:48:59Z",
+      "lastContributionAt": "2026-08-11T11:56:36Z",
+      "mergedPullRequests": 2,
+      "openedIssues": 0,
+      "recentPullRequests": [
+        {
+          "number": 1748,
+          "title": "feat(auth): add mobile auth v2 (verifier-bound OAuth, native Apple, recent auth & connected identities)",
+          "mergedAt": "2026-08-11T11:56:36Z",
+          "url": "https://github.com/strelov1/freehire/pull/1748"
+        },
+        {
+          "number": 1657,
+          "title": "feat(auth): harden session contracts, recovery atomicity & throttling for mobile foundation",
+          "mergedAt": "2026-08-08T22:48:59Z",
+          "url": "https://github.com/strelov1/freehire/pull/1657"
+        }
+      ]
+    },
+    {
+      "login": "meminens",
+      "id": 42714627,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/42714627?u=164266c75682b7d0494c485d2824f95e41919390&v=4",
+      "accountType": "User",
+      "role": "contributor",
+      "firstContributionAt": "2026-09-06T23:55:23Z",
+      "lastContributionAt": "2026-09-06T23:55:23Z",
+      "mergedPullRequests": 0,
+      "openedIssues": 1,
+      "recentPullRequests": []
+    },
+    {
+      "login": "millerscout",
+      "id": 1369224,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1369224?u=dc803ca7ad96dfd87ced1ff56f7090fa5d1ec246&v=4",
+      "accountType": "User",
+      "role": "contributor",
+      "firstContributionAt": "2026-08-07T01:31:07Z",
+      "lastContributionAt": "2026-08-12T03:09:33Z",
+      "mergedPullRequests": 6,
+      "openedIssues": 0,
+      "recentPullRequests": [
+        {
+          "number": 1818,
+          "title": "Align tailored CVs to JD skill wording and stop reset from wiping résumé sections",
+          "mergedAt": "2026-08-12T03:09:33Z",
+          "url": "https://github.com/strelov1/freehire/pull/1818"
+        },
+        {
+          "number": 1817,
+          "title": "Require gofmt, vet, and unit tests before committing Go",
+          "mergedAt": "2026-08-12T00:47:00Z",
+          "url": "https://github.com/strelov1/freehire/pull/1817"
+        },
+        {
+          "number": 1754,
+          "title": "Put tailored vacancies on the Tracking Kanban",
+          "mergedAt": "2026-08-11T21:21:45Z",
+          "url": "https://github.com/strelov1/freehire/pull/1754"
+        },
+        {
+          "number": 1737,
+          "title": "Profile contacts, experience projects, and coverage tooling",
+          "mergedAt": "2026-08-11T16:05:16Z",
+          "url": "https://github.com/strelov1/freehire/pull/1737"
+        },
+        {
+          "number": 1622,
+          "title": "feat(cv): freshen tailor bootstrap, experience order, and profile skills",
+          "mergedAt": "2026-08-07T22:26:18Z",
+          "url": "https://github.com/strelov1/freehire/pull/1622"
+        },
+        {
+          "number": 1604,
+          "title": "fix(assistant): close dangling tool_use when replaying history",
+          "mergedAt": "2026-08-07T01:31:07Z",
+          "url": "https://github.com/strelov1/freehire/pull/1604"
+        }
+      ]
+    },
+    {
+      "login": "spoddub",
+      "id": 108150454,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/108150454?u=5b2f44121223026be54f0c36e5e766f9c5c3463a&v=4",
+      "accountType": "User",
+      "role": "contributor",
+      "firstContributionAt": "2026-08-07T17:32:49Z",
+      "lastContributionAt": "2026-08-07T17:32:49Z",
+      "mergedPullRequests": 1,
+      "openedIssues": 0,
+      "recentPullRequests": [
+        {
+          "number": 1617,
+          "title": "feat(skilltag): add sales and support vocabulary",
+          "mergedAt": "2026-08-07T17:32:49Z",
+          "url": "https://github.com/strelov1/freehire/pull/1617"
+        }
+      ]
+    },
+    {
+      "login": "strelov1",
+      "id": 10761735,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/10761735?u=552efb61e9ff91e59ad7238cb21d1c51485771b3&v=4",
+      "accountType": "User",
+      "role": "maintainer",
+      "firstContributionAt": "2026-06-11T03:56:53Z",
+      "lastContributionAt": "2026-09-07T03:39:55Z",
+      "mergedPullRequests": 2236,
+      "openedIssues": 89,
+      "recentPullRequests": [
+        {
+          "number": 2575,
+          "title": "Ask the same question once, in the three places yesterday's review fixes asked it twice",
+          "mergedAt": "2026-09-07T03:39:55Z",
+          "url": "https://github.com/strelov1/freehire/pull/2575"
+        },
+        {
+          "number": 2573,
+          "title": "Close the review findings the curated-alias work left open",
+          "mergedAt": "2026-09-07T03:26:14Z",
+          "url": "https://github.com/strelov1/freehire/pull/2573"
+        },
+        {
+          "number": 2572,
+          "title": "Add a 90-day daily history strip to the site status section",
+          "mergedAt": "2026-09-07T03:20:50Z",
+          "url": "https://github.com/strelov1/freehire/pull/2572"
+        },
+        {
+          "number": 2571,
+          "title": "Let a posting's own body deny the remote label its ATS put on it, and read that body again after the employer edits it",
+          "mergedAt": "2026-09-07T03:16:44Z",
+          "url": "https://github.com/strelov1/freehire/pull/2571"
+        },
+        {
+          "number": 2570,
+          "title": "Bump fflate off the unzipSync ZIP64 infinite-loop CVE",
+          "mergedAt": "2026-09-07T03:02:45Z",
+          "url": "https://github.com/strelov1/freehire/pull/2570"
+        },
+        {
+          "number": 2569,
+          "title": "Give the text cap room for a listing page that renders itself whole",
+          "mergedAt": "2026-09-07T02:59:04Z",
+          "url": "https://github.com/strelov1/freehire/pull/2569"
+        },
+        {
+          "number": 2568,
+          "title": "Tidy the curated-alias pass without changing what it plans",
+          "mergedAt": "2026-09-07T02:48:40Z",
+          "url": "https://github.com/strelov1/freehire/pull/2568"
+        },
+        {
+          "number": 2540,
+          "title": "Gate the three classes the backend review kept catching by hand",
+          "mergedAt": "2026-09-07T02:47:18Z",
+          "url": "https://github.com/strelov1/freehire/pull/2540"
+        },
+        {
+          "number": 2563,
+          "title": "Refuse auto-apply enqueue on a known work-auth or location mismatch",
+          "mergedAt": "2026-09-07T02:45:57Z",
+          "url": "https://github.com/strelov1/freehire/pull/2563"
+        },
+        {
+          "number": 2564,
+          "title": "Delete what nothing calls, and give the mail path the reminder cancellation every other caller gets",
+          "mergedAt": "2026-09-07T02:40:05Z",
+          "url": "https://github.com/strelov1/freehire/pull/2564"
+        },
+        {
+          "number": 2567,
+          "title": "Pace eightfold/ADP/phenom, fix yandexcrowd's body cap, clean up board_health on retire",
+          "mergedAt": "2026-09-07T02:37:45Z",
+          "url": "https://github.com/strelov1/freehire/pull/2567"
+        },
+        {
+          "number": 2562,
+          "title": "Say that a public read is budgeted by address, which is what it always did",
+          "mergedAt": "2026-09-07T02:22:40Z",
+          "url": "https://github.com/strelov1/freehire/pull/2562"
+        },
+        {
+          "number": 2561,
+          "title": "Merge the micro1 duplicate, and fix the rule that would have rejected it",
+          "mergedAt": "2026-09-07T02:13:11Z",
+          "url": "https://github.com/strelov1/freehire/pull/2561"
+        },
+        {
+          "number": 2558,
+          "title": "Let a corrected link move the interview event with it, instead of leaving it with the wrong employer forever",
+          "mergedAt": "2026-09-07T02:05:11Z",
+          "url": "https://github.com/strelov1/freehire/pull/2558"
+        },
+        {
+          "number": 2560,
+          "title": "Archive the site-status-page OpenSpec change",
+          "mergedAt": "2026-09-07T01:21:07Z",
+          "url": "https://github.com/strelov1/freehire/pull/2560"
+        },
+        {
+          "number": 2559,
+          "title": "Add a site/API status section to the public /status page",
+          "mergedAt": "2026-09-07T00:56:55Z",
+          "url": "https://github.com/strelov1/freehire/pull/2559"
+        },
+        {
+          "number": 2557,
+          "title": "Make the no-transaction marker mean what its migrations say, and stop recording a version over an unusable index",
+          "mergedAt": "2026-09-07T00:19:48Z",
+          "url": "https://github.com/strelov1/freehire/pull/2557"
+        },
+        {
+          "number": 2556,
+          "title": "Add werecruit ATS source adapter",
+          "mergedAt": "2026-09-07T00:08:53Z",
+          "url": "https://github.com/strelov1/freehire/pull/2556"
+        },
+        {
+          "number": 2554,
+          "title": "Stop telling a candidate they lack a certification their résumé lists, and name it in words they can read",
+          "mergedAt": "2026-09-07T00:08:24Z",
+          "url": "https://github.com/strelov1/freehire/pull/2554"
+        },
+        {
+          "number": 2552,
+          "title": "Stop the removal pass starving behind an indexing pass that never ends",
+          "mergedAt": "2026-09-06T23:50:08Z",
+          "url": "https://github.com/strelov1/freehire/pull/2552"
+        }
+      ]
+    },
+    {
+      "login": "thomasmaerz",
+      "id": 7740810,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7740810?u=99e17916f019bd2f0d293743a1f8dced9b55523a&v=4",
+      "accountType": "User",
+      "role": "contributor",
+      "firstContributionAt": "2026-08-28T09:34:56Z",
+      "lastContributionAt": "2026-08-28T09:34:56Z",
+      "mergedPullRequests": 0,
+      "openedIssues": 1,
+      "recentPullRequests": []
+    },
+    {
+      "login": "timon0305",
+      "id": 59460476,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/59460476?u=1554ff678b9876ca7f55aa05f8a3e6104d3af92e&v=4",
+      "accountType": "User",
+      "role": "contributor",
+      "firstContributionAt": "2026-08-13T19:50:25Z",
+      "lastContributionAt": "2026-08-14T18:20:15Z",
+      "mergedPullRequests": 3,
+      "openedIssues": 0,
+      "recentPullRequests": [
+        {
+          "number": 1886,
+          "title": "feat(sources): add the Landing.jobs adapter",
+          "mergedAt": "2026-08-14T18:20:15Z",
+          "url": "https://github.com/strelov1/freehire/pull/1886"
+        },
+        {
+          "number": 1881,
+          "title": "docs(architecture): add system architecture documentation with mermaid diagrams",
+          "mergedAt": "2026-08-13T19:59:54Z",
+          "url": "https://github.com/strelov1/freehire/pull/1881"
+        },
+        {
+          "number": 1880,
+          "title": "Generate the ghost criterion vocabulary from internal/ghost",
+          "mergedAt": "2026-08-13T19:50:25Z",
+          "url": "https://github.com/strelov1/freehire/pull/1880"
+        }
+      ]
+    },
+    {
+      "login": "vedangvatsa",
+      "id": 197282164,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/197282164?u=64bc505f81f97e528980cc8d8900581247967fac&v=4",
+      "accountType": "User",
+      "role": "contributor",
+      "firstContributionAt": "2026-08-12T12:46:12Z",
+      "lastContributionAt": "2026-08-12T12:46:12Z",
+      "mergedPullRequests": 0,
+      "openedIssues": 1,
+      "recentPullRequests": []
+    }
+  ]
+}

--- a/web/src/lib/data/contributors.json
+++ b/web/src/lib/data/contributors.json
@@ -13,86 +13,6 @@
       "recentPullRequests": []
     },
     {
-      "login": "HafizMMoaz",
-      "id": 103947442,
-      "avatarUrl": "https://avatars.githubusercontent.com/u/103947442?u=c9f758c94f081f84700d0280af0f3ec6bdf0fc7c&v=4",
-      "accountType": "User",
-      "role": "contributor",
-      "firstContributionAt": "2026-08-11T02:05:14Z",
-      "lastContributionAt": "2026-08-11T03:38:51Z",
-      "mergedPullRequests": 5,
-      "openedIssues": 0,
-      "recentPullRequests": [
-        {
-          "number": 1719,
-          "title": "feat(sources): add Remotli source adapter",
-          "mergedAt": "2026-08-11T03:38:51Z",
-          "url": "https://github.com/strelov1/freehire/pull/1719"
-        },
-        {
-          "number": 1717,
-          "title": "feat(sources): add NoDesk source adapter",
-          "mergedAt": "2026-08-11T02:39:00Z",
-          "url": "https://github.com/strelov1/freehire/pull/1717"
-        },
-        {
-          "number": 1720,
-          "title": "feat(sources): add The Muse source adapter",
-          "mergedAt": "2026-08-11T02:38:50Z",
-          "url": "https://github.com/strelov1/freehire/pull/1720"
-        },
-        {
-          "number": 1724,
-          "title": "feat(sources): add SolidJobs source adapter (IT division)",
-          "mergedAt": "2026-08-11T02:38:47Z",
-          "url": "https://github.com/strelov1/freehire/pull/1724"
-        },
-        {
-          "number": 1718,
-          "title": "feat(sources): add Cryptocurrency Jobs source adapter",
-          "mergedAt": "2026-08-11T02:05:14Z",
-          "url": "https://github.com/strelov1/freehire/pull/1718"
-        }
-      ]
-    },
-    {
-      "login": "Klavaro66",
-      "id": 57226205,
-      "avatarUrl": "https://avatars.githubusercontent.com/u/57226205?v=4",
-      "accountType": "User",
-      "role": "contributor",
-      "firstContributionAt": "2026-09-02T21:28:39Z",
-      "lastContributionAt": "2026-09-06T15:50:58Z",
-      "mergedPullRequests": 0,
-      "openedIssues": 4,
-      "recentPullRequests": []
-    },
-    {
-      "login": "ManishModak",
-      "id": 111450082,
-      "avatarUrl": "https://avatars.githubusercontent.com/u/111450082?u=1e7123cd6313a8520038d82f3c9233c1251a5a12&v=4",
-      "accountType": "User",
-      "role": "contributor",
-      "firstContributionAt": "2026-08-08T22:48:59Z",
-      "lastContributionAt": "2026-08-11T11:56:36Z",
-      "mergedPullRequests": 2,
-      "openedIssues": 0,
-      "recentPullRequests": [
-        {
-          "number": 1748,
-          "title": "feat(auth): add mobile auth v2 (verifier-bound OAuth, native Apple, recent auth & connected identities)",
-          "mergedAt": "2026-08-11T11:56:36Z",
-          "url": "https://github.com/strelov1/freehire/pull/1748"
-        },
-        {
-          "number": 1657,
-          "title": "feat(auth): harden session contracts, recovery atomicity & throttling for mobile foundation",
-          "mergedAt": "2026-08-08T22:48:59Z",
-          "url": "https://github.com/strelov1/freehire/pull/1657"
-        }
-      ]
-    },
-    {
       "login": "aleganza",
       "id": 73157384,
       "avatarUrl": "https://avatars.githubusercontent.com/u/73157384?u=e495bdbb5c70f4269889d99f1fd29ced5f5deb86&v=4",
@@ -354,6 +274,49 @@
       ]
     },
     {
+      "login": "HafizMMoaz",
+      "id": 103947442,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/103947442?u=c9f758c94f081f84700d0280af0f3ec6bdf0fc7c&v=4",
+      "accountType": "User",
+      "role": "contributor",
+      "firstContributionAt": "2026-08-11T02:05:14Z",
+      "lastContributionAt": "2026-08-11T03:38:51Z",
+      "mergedPullRequests": 5,
+      "openedIssues": 0,
+      "recentPullRequests": [
+        {
+          "number": 1719,
+          "title": "feat(sources): add Remotli source adapter",
+          "mergedAt": "2026-08-11T03:38:51Z",
+          "url": "https://github.com/strelov1/freehire/pull/1719"
+        },
+        {
+          "number": 1717,
+          "title": "feat(sources): add NoDesk source adapter",
+          "mergedAt": "2026-08-11T02:39:00Z",
+          "url": "https://github.com/strelov1/freehire/pull/1717"
+        },
+        {
+          "number": 1720,
+          "title": "feat(sources): add The Muse source adapter",
+          "mergedAt": "2026-08-11T02:38:50Z",
+          "url": "https://github.com/strelov1/freehire/pull/1720"
+        },
+        {
+          "number": 1724,
+          "title": "feat(sources): add SolidJobs source adapter (IT division)",
+          "mergedAt": "2026-08-11T02:38:47Z",
+          "url": "https://github.com/strelov1/freehire/pull/1724"
+        },
+        {
+          "number": 1718,
+          "title": "feat(sources): add Cryptocurrency Jobs source adapter",
+          "mergedAt": "2026-08-11T02:05:14Z",
+          "url": "https://github.com/strelov1/freehire/pull/1718"
+        }
+      ]
+    },
+    {
       "login": "infinitelife102",
       "id": 246451738,
       "avatarUrl": "https://avatars.githubusercontent.com/u/246451738?u=26e931097b0a1ddc8b8b6416e0c62d51509aecae&v=4",
@@ -376,6 +339,43 @@
       "mergedPullRequests": 0,
       "openedIssues": 1,
       "recentPullRequests": []
+    },
+    {
+      "login": "Klavaro66",
+      "id": 57226205,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/57226205?v=4",
+      "accountType": "User",
+      "role": "contributor",
+      "firstContributionAt": "2026-09-02T21:28:39Z",
+      "lastContributionAt": "2026-09-06T15:50:58Z",
+      "mergedPullRequests": 0,
+      "openedIssues": 4,
+      "recentPullRequests": []
+    },
+    {
+      "login": "ManishModak",
+      "id": 111450082,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/111450082?u=1e7123cd6313a8520038d82f3c9233c1251a5a12&v=4",
+      "accountType": "User",
+      "role": "contributor",
+      "firstContributionAt": "2026-08-08T22:48:59Z",
+      "lastContributionAt": "2026-08-11T11:56:36Z",
+      "mergedPullRequests": 2,
+      "openedIssues": 0,
+      "recentPullRequests": [
+        {
+          "number": 1748,
+          "title": "feat(auth): add mobile auth v2 (verifier-bound OAuth, native Apple, recent auth & connected identities)",
+          "mergedAt": "2026-08-11T11:56:36Z",
+          "url": "https://github.com/strelov1/freehire/pull/1748"
+        },
+        {
+          "number": 1657,
+          "title": "feat(auth): harden session contracts, recovery atomicity & throttling for mobile foundation",
+          "mergedAt": "2026-08-08T22:48:59Z",
+          "url": "https://github.com/strelov1/freehire/pull/1657"
+        }
+      ]
     },
     {
       "login": "meminens",
@@ -464,10 +464,28 @@
       "accountType": "User",
       "role": "maintainer",
       "firstContributionAt": "2026-06-11T03:56:53Z",
-      "lastContributionAt": "2026-09-07T03:39:55Z",
-      "mergedPullRequests": 2236,
+      "lastContributionAt": "2026-09-07T04:18:17Z",
+      "mergedPullRequests": 2239,
       "openedIssues": 89,
       "recentPullRequests": [
+        {
+          "number": 2574,
+          "title": "Show unique-job and new-signup counts, relabel the raw job count everywhere",
+          "mergedAt": "2026-09-07T04:18:17Z",
+          "url": "https://github.com/strelov1/freehire/pull/2574"
+        },
+        {
+          "number": 2577,
+          "title": "Stop the long crawls squatting the slots the short ones need",
+          "mergedAt": "2026-09-07T04:07:29Z",
+          "url": "https://github.com/strelov1/freehire/pull/2577"
+        },
+        {
+          "number": 2576,
+          "title": "Point the community at one room, and give the extension its own letter",
+          "mergedAt": "2026-09-07T03:58:15Z",
+          "url": "https://github.com/strelov1/freehire/pull/2576"
+        },
         {
           "number": 2575,
           "title": "Ask the same question once, in the three places yesterday's review fixes asked it twice",
@@ -569,24 +587,6 @@
           "title": "Make the no-transaction marker mean what its migrations say, and stop recording a version over an unusable index",
           "mergedAt": "2026-09-07T00:19:48Z",
           "url": "https://github.com/strelov1/freehire/pull/2557"
-        },
-        {
-          "number": 2556,
-          "title": "Add werecruit ATS source adapter",
-          "mergedAt": "2026-09-07T00:08:53Z",
-          "url": "https://github.com/strelov1/freehire/pull/2556"
-        },
-        {
-          "number": 2554,
-          "title": "Stop telling a candidate they lack a certification their résumé lists, and name it in words they can read",
-          "mergedAt": "2026-09-07T00:08:24Z",
-          "url": "https://github.com/strelov1/freehire/pull/2554"
-        },
-        {
-          "number": 2552,
-          "title": "Stop the removal pass starving behind an indexing pass that never ends",
-          "mergedAt": "2026-09-06T23:50:08Z",
-          "url": "https://github.com/strelov1/freehire/pull/2552"
         }
       ]
     },

--- a/web/src/lib/server/og/avatar.test.ts
+++ b/web/src/lib/server/og/avatar.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAvatar } from './avatar';
+
+describe('resolveAvatar', () => {
+  // The URL comes from a snapshot we commit, so it is trusted — but this function
+  // turns a URL into a server-side fetch, and that is the shape of request worth
+  // bounding at the door rather than trusting by provenance. A host that is not
+  // GitHub's avatar CDN is refused before any request leaves.
+  it('refuses a host that is not the GitHub avatar CDN', async () => {
+    expect(await resolveAvatar('http://169.254.169.254/latest/meta-data/')).toBeNull();
+    expect(await resolveAvatar('https://example.com/avatar.png')).toBeNull();
+  });
+
+  it('refuses a lookalike host', async () => {
+    expect(await resolveAvatar('https://avatars.githubusercontent.com.evil.test/x')).toBeNull();
+  });
+
+  it('refuses something that is not a URL at all', async () => {
+    expect(await resolveAvatar('not a url')).toBeNull();
+  });
+});

--- a/web/src/lib/server/og/avatar.ts
+++ b/web/src/lib/server/og/avatar.ts
@@ -1,0 +1,38 @@
+// Resolves a contributor's GitHub avatar for the OG card. satori cannot fetch remote
+// images itself, so we fetch it server-side and hand back a data-URI it can embed.
+// Any failure (a deleted account, a timeout, a slow CDN) returns null so the card falls
+// back to the shared monogram — a missing avatar must never fail the image render.
+//
+// Mirrors ./logo.ts, which does the same for company logos through our own proxy. The
+// difference is the host: this one is GitHub's, so the URL is pinned to it.
+
+const TIMEOUT_MS = 2500;
+
+// The URL is read from a snapshot this repository commits, so it is trusted by
+// provenance — but this function turns a string into a request the server makes, and
+// that is worth bounding at the door rather than by where it came from. Compared as a
+// parsed hostname, never as a prefix: `avatars.githubusercontent.com.evil.test` starts
+// with the right characters and is a different host.
+const AVATAR_HOST = 'avatars.githubusercontent.com';
+
+/** A `data:` URI for the contributor's avatar, or null to signal "use the monogram". */
+export async function resolveAvatar(url: string): Promise<string | null> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'https:' || parsed.hostname !== AVATAR_HOST) return null;
+
+  try {
+    const res = await fetch(parsed, { signal: AbortSignal.timeout(TIMEOUT_MS) });
+    if (!res.ok) return null;
+    const bytes = Buffer.from(await res.arrayBuffer());
+    if (bytes.length === 0) return null;
+    const type = res.headers.get('content-type') || 'image/png';
+    return `data:${type};base64,${bytes.toString('base64')}`;
+  } catch {
+    return null;
+  }
+}

--- a/web/src/lib/server/og/contributor.test.ts
+++ b/web/src/lib/server/og/contributor.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { buildContributorCard } from './contributor';
+import type { ContributorEntry } from '$lib/contributors';
+
+function person(over: Partial<ContributorEntry> = {}): ContributorEntry {
+  return {
+    login: 'aleganza',
+    id: 1,
+    avatarUrl: 'https://avatars.githubusercontent.com/u/1',
+    accountType: 'User',
+    role: 'contributor',
+    firstContributionAt: '2026-07-15T00:00:00Z',
+    lastContributionAt: '2026-08-30T00:00:00Z',
+    mergedPullRequests: 8,
+    openedIssues: 3,
+    recentPullRequests: [],
+    ...over,
+  };
+}
+
+describe('buildContributorCard', () => {
+  it('names the contributor and what they contributed', () => {
+    const markup = buildContributorCard(person(), { avatar: null });
+
+    expect(markup).toContain('aleganza');
+    expect(markup).toContain('8 merged pull requests · 3 issues opened');
+  });
+
+  it('says when they first contributed', () => {
+    const markup = buildContributorCard(person(), { avatar: null });
+
+    expect(markup).toContain('July 2026');
+  });
+
+  it('embeds the avatar when one was resolved', () => {
+    const markup = buildContributorCard(person(), { avatar: 'data:image/png;base64,AAA' });
+
+    expect(markup).toContain('data:image/png;base64,AAA');
+  });
+
+  // satori cannot fetch a remote image, so the endpoint resolves the avatar to a
+  // data-URI first. When that fetch fails the card must still render — a contributor
+  // who deleted their account, or a slow CDN, cannot be allowed to fail the image.
+  it('falls back to a monogram when no avatar was resolved', () => {
+    const markup = buildContributorCard(person({ login: 'aleganza' }), { avatar: null });
+
+    expect(markup).not.toContain('<img src="https://');
+    expect(markup).toContain('AL');
+  });
+
+  // The card is built by string concatenation, so anything interpolated into it can
+  // otherwise close a tag. A GitHub login cannot contain these characters today, but
+  // the escaping is what makes that not matter.
+  it('escapes anything interpolated into the markup', () => {
+    const markup = buildContributorCard(person({ login: '<script>x</script>' }), { avatar: null });
+
+    expect(markup).not.toContain('<script>');
+    expect(markup).toContain('&lt;script&gt;');
+  });
+
+  // A person is drawn in a circle and an entity in a rounded tile — the same
+  // distinction the design system's Avatar makes with its `shape` prop. A card about a
+  // person that squares them off reads as a company logo.
+  it('draws the person in a circle, not a company tile', () => {
+    const withPhoto = buildContributorCard(person(), { avatar: 'data:image/png;base64,AAA' });
+    const withMonogram = buildContributorCard(person(), { avatar: null });
+
+    expect(withPhoto).toContain('border-radius:50%');
+    expect(withMonogram).toContain('border-radius:50%');
+  });
+
+  it('calls a maintainer one', () => {
+    const markup = buildContributorCard(person({ role: 'maintainer' }), { avatar: null });
+
+    expect(markup.toLowerCase()).toContain('maintain');
+  });
+
+  // Every element with more than one child has to declare `display:flex` or satori
+  // throws at render time — a constraint the render smoke test catches, but only after
+  // a full font load and rasterisation.
+  it('closes with the shared brand footer', () => {
+    const markup = buildContributorCard(person(), { avatar: null });
+
+    expect(markup).toContain('freehire.me');
+  });
+});

--- a/web/src/lib/server/og/contributor.ts
+++ b/web/src/lib/server/og/contributor.ts
@@ -1,0 +1,44 @@
+// Builds the HTML for one contributor's Open Graph card (light, 1200×630). Pure and
+// synchronous — a contributor entry plus a resolved avatar in, an HTML string for
+// satori out — so it is exercised directly by unit tests and the render smoke test.
+//
+// This card is the whole point of the /contributors pages: a link someone posts about
+// their own work has to show their face and their figures, not the site's generic
+// preview. So the avatar is the hero and the counts are the headline.
+//
+// Shared brand primitives (mark, escaping, tile, footer) come from ./shared so the
+// job/company/contributor cards cannot drift. satori constraint: layout is flexbox
+// only, and any element with more than one child declares `display:flex`.
+
+import { contributionSummary } from '$lib/contributors';
+import type { ContributorEntry } from '$lib/contributors';
+import { OG_HEIGHT, OG_WIDTH, brandFooter, esc, logoBox } from './shared';
+
+const AVATAR_SIZE = 160;
+
+/** "July 2026" — when this person first showed up. */
+function firstSeen(iso: string): string {
+  return new Date(iso).toLocaleDateString('en', { month: 'long', year: 'numeric', timeZone: 'UTC' });
+}
+
+/** Builds the card HTML for `entry`. `avatar` is a data-URI or null — null renders
+ *  the shared monogram tile, so an unreachable avatar degrades instead of failing. */
+export function buildContributorCard(
+  entry: ContributorEntry,
+  opts: { avatar: string | null },
+): string {
+  const role = entry.role === 'maintainer' ? 'Maintains freehire' : 'Contributes to freehire';
+
+  return `
+<div style="display:flex;flex-direction:column;justify-content:space-between;width:${OG_WIDTH}px;height:${OG_HEIGHT}px;padding:64px 72px;background:#ffffff;color:#0a0a0a;font-family:Inter">
+  <div style="display:flex;align-items:center;gap:32px">
+    ${logoBox(opts.avatar, entry.login, AVATAR_SIZE, 'circle')}
+    <div style="display:flex;flex-direction:column;gap:10px">
+      <div style="display:flex;font-size:60px;font-weight:700;letter-spacing:-0.03em;overflow:hidden">${esc(entry.login)}</div>
+      <div style="display:flex;font-size:28px;color:#525252">${esc(role)} since ${esc(firstSeen(entry.firstContributionAt))}</div>
+    </div>
+  </div>
+  <div style="display:flex;font-size:44px;font-weight:700;letter-spacing:-0.02em">${esc(contributionSummary(entry))}</div>
+  ${brandFooter()}
+</div>`.trim();
+}

--- a/web/src/lib/server/og/shared.ts
+++ b/web/src/lib/server/og/shared.ts
@@ -34,19 +34,31 @@ function monogram(name: string): string {
   return (first.charAt(0) + (words[1] ?? '').charAt(0)).toUpperCase();
 }
 
-/** A square logo tile at `size`px: the resolved logo image, or a monogram tile
- *  derived from `name` when `logo` is null. Radius and monogram font scale with
- *  the size (at 72px this matches the original job-card tile: radius 14, font 30). */
-export function logoBox(logo: string | null, name: string, size: number): string {
-  const radius = Math.round(size / 5);
+/** A logo tile at `size`px: the resolved image, or a monogram tile derived from `name`
+ *  when `logo` is null. Radius and monogram font scale with the size (at 72px this
+ *  matches the original job-card tile: radius 14, font 30).
+ *
+ *  `shape` carries the same distinction the design system's Avatar makes: a rounded
+ *  `tile` is an entity's mark, a `circle` is a person. A card about a person that
+ *  squares them off reads as a company logo. */
+export function logoBox(
+  logo: string | null,
+  name: string,
+  size: number,
+  shape: 'tile' | 'circle' = 'tile',
+): string {
+  const radius = shape === 'circle' ? '50%' : `${Math.round(size / 5)}px`;
   if (logo) {
     // satori reads image dimensions from style, not the width/height HTML attributes.
-    return `<img src="${esc(logo)}" style="width:${size}px;height:${size}px;border-radius:${radius}px;object-fit:contain" />`;
+    // A person's avatar is cropped to fill its circle; an entity's mark is fitted
+    // inside its tile, because a logo cropped at the edges is a broken logo.
+    const fit = shape === 'circle' ? 'cover' : 'contain';
+    return `<img src="${esc(logo)}" style="width:${size}px;height:${size}px;border-radius:${radius};object-fit:${fit}" />`;
   }
   const font = Math.round(size * 0.42);
   return (
     `<div style="display:flex;align-items:center;justify-content:center;width:${size}px;height:${size}px;` +
-    `border-radius:${radius}px;background:#f4f4f4;color:#525252;font-size:${font}px;font-weight:700">` +
+    `border-radius:${radius};background:#f4f4f4;color:#525252;font-size:${font}px;font-weight:700">` +
     `${esc(monogram(name))}</div>`
   );
 }

--- a/web/src/lib/sitemap.test.ts
+++ b/web/src/lib/sitemap.test.ts
@@ -3,6 +3,7 @@ import {
   SITEMAP_CHUNK,
   STATIC_PATHS,
   collectionPaths,
+  contributorPaths,
   blogPaths,
   roleLandingPaths,
   skillGlossaryPaths,
@@ -77,6 +78,27 @@ describe('collectionPaths', () => {
     expect(paths).toContain('/collections/yc'); // company collection
     expect(paths).toContain('/collections/remote-worldwide'); // filter collection
     expect(new Set(paths).size).toBe(paths.length);
+  });
+});
+
+describe('contributorPaths', () => {
+  // Each profile is a page a person is meant to share and be found by, so each needs
+  // its own sitemap entry rather than riding on the showcase's.
+  it('maps every shown contributor to their /contributors/:login profile path', () => {
+    const paths = contributorPaths();
+
+    expect(paths).toContain('/contributors/strelov1');
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+
+  // The showcase does not list bots, so the sitemap must not offer crawlers a page
+  // that 404s.
+  it('offers no path the showcase would not serve', () => {
+    expect(contributorPaths().some((p) => p.includes('bot'))).toBe(false);
+  });
+
+  it('does not carry the showcase itself, which is a static path', () => {
+    expect(contributorPaths()).not.toContain('/contributors');
   });
 });
 

--- a/web/src/lib/sitemap.ts
+++ b/web/src/lib/sitemap.ts
@@ -4,6 +4,9 @@
 // company chunks). Each chunk is one keyset page fetched by cursor.
 
 import { collectionSlugs } from './collections';
+import { contributorGroups } from './contributors';
+import type { ContributorsSnapshot } from './contributors';
+import contributorsSnapshot from './data/contributors.json';
 
 // Must equal the backend's companySitemapChunk — the page size the offsets are
 // computed with — so each sub-sitemap holds exactly one index page. Well under the
@@ -56,6 +59,9 @@ export const STATIC_PATHS = [
   '/cli',
   '/chatgpt',
   '/contribute',
+  // The contributor showcase. The per-person profiles are NOT here — they come from
+  // the committed snapshot via contributorPaths(), the same way collections do.
+  '/contributors',
   '/status',
   // Named as the App Store listing's Support URL, so it must resolve and stay
   // indexable — a 404 there is a rejection.
@@ -71,6 +77,19 @@ export const STATIC_PATHS = [
  *  STATIC_PATHS rather than needing their own chunked file. */
 export function collectionPaths(): string[] {
   return collectionSlugs().map((slug) => `/collections/${slug}`);
+}
+
+/** The per-contributor profile pages (`/contributors/:login`), one per person the
+ *  showcase actually lists.
+ *
+ *  Derived through the same rules the showcase renders, not from the raw snapshot: a
+ *  bot's profile 404s, so offering crawlers a path to one would be pointing them at a
+ *  page we know does not exist. Each profile is its own indexable page because it is
+ *  the page a person shares and is found by. */
+export function contributorPaths(): string[] {
+  const { maintainers, contributors } = contributorGroups(contributorsSnapshot as ContributorsSnapshot);
+
+  return [...maintainers, ...contributors].map((entry) => `/contributors/${entry.login}`);
 }
 
 /** Sitemap entries for the blog: the index (`/blog`) plus one per published post,

--- a/web/src/routes/contributors/+page.server.ts
+++ b/web/src/routes/contributors/+page.server.ts
@@ -1,0 +1,13 @@
+import { contributorGroups } from '$lib/contributors';
+import type { ContributorsSnapshot } from '$lib/contributors';
+import snapshot from '$lib/data/contributors.json';
+import type { PageServerLoad } from './$types';
+
+// The showcase reads a snapshot committed to the repository, never the GitHub API. The
+// site already spends GitHub's unauthenticated 60-requests-per-hour-per-IP budget on the
+// header's star badge and /open (see $lib/server/github), and per-person pull-request
+// lists do not fit inside what is left. A daily workflow collects the file instead, so
+// this page cannot rate-limit, cannot fail, and costs nothing to serve.
+//
+// Grouping and ordering are not done here — $lib/contributors owns them and is tested.
+export const load: PageServerLoad = () => contributorGroups(snapshot as ContributorsSnapshot);

--- a/web/src/routes/contributors/+page.svelte
+++ b/web/src/routes/contributors/+page.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import { resolve } from '$app/paths';
+  import Seo from '$lib/components/Seo.svelte';
+  import { Avatar, SectionLabel } from '$lib/ui';
+  import { contributionSummary } from '$lib/contributors';
+  import type { ContributorEntry } from '$lib/contributors';
+  import { breadcrumbJsonLd, jsonLdScript } from '$lib/seo';
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  const origin = $derived(page.url.origin);
+  const canonical = $derived(`${origin}/contributors`);
+
+  // Counted, never written down: a hand-typed figure beside a generated list is a second
+  // answer to the same question, and it is the one that goes stale.
+  const people = $derived(data.maintainers.length + data.contributors.length);
+
+  const description = $derived(
+    `The ${people} people who build freehire — every merged pull request and every issue opened, straight from the repository.`,
+  );
+
+  const jsonLd = $derived(
+    jsonLdScript([
+      breadcrumbJsonLd([
+        { name: 'freehire', url: `${origin}/` },
+        { name: 'Contributors', url: canonical },
+      ]),
+    ]),
+  );
+
+  const since = (entry: ContributorEntry) =>
+    new Date(entry.firstContributionAt).toLocaleDateString('en', {
+      month: 'short',
+      year: 'numeric',
+    });
+</script>
+
+<Seo title="Contributors — the people who build freehire" {description} {canonical} />
+
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->
+  {@html jsonLd}
+</svelte:head>
+
+{#snippet contributorCard(entry: ContributorEntry)}
+  <a
+    href={resolve('/contributors/[login]', { login: entry.login })}
+    class="group flex items-start gap-4 rounded-xl border border-border bg-background p-5 transition-colors hover:border-foreground/25 hover:bg-muted/40"
+  >
+    <Avatar name={entry.login} src={entry.avatarUrl} size="lg" />
+    <div class="min-w-0">
+      <p class="truncate font-semibold tracking-tight group-hover:underline">{entry.login}</p>
+      <p class="mt-1 text-sm text-muted-foreground">{contributionSummary(entry)}</p>
+      <p class="mt-2 font-mono text-xs uppercase tracking-wide text-muted-foreground">
+        since {since(entry)}
+      </p>
+    </div>
+  </a>
+{/snippet}
+
+<div class="mx-auto w-full max-w-4xl px-4 py-10 sm:py-14">
+  <header class="dot-grid -mx-4 mb-12 px-4 pb-8 pt-4">
+    <SectionLabel text="contributors" />
+    <h1 class="mt-4 text-4xl font-semibold tracking-tighter sm:text-5xl">
+      {people} people build freehire.
+    </h1>
+    <p class="mt-4 max-w-2xl text-lg leading-relaxed text-muted-foreground">
+      Everyone below has merged code or opened an issue against the repository. The list comes
+      straight from GitHub — nobody is added by hand, and nobody is left out by forgetting.
+    </p>
+  </header>
+
+  {#if data.maintainers.length > 0}
+    <section class="mb-14">
+      <SectionLabel text="maintained by" />
+      <div class="mt-6 grid gap-3 sm:grid-cols-2">
+        {#each data.maintainers as entry (entry.login)}
+          {@render contributorCard(entry)}
+        {/each}
+      </div>
+    </section>
+  {/if}
+
+  <section class="mb-14">
+    <SectionLabel text="contributed by" />
+    <h2 class="mt-3 text-xl font-semibold tracking-tight">Most recent first</h2>
+    <p class="mb-6 mt-1 text-sm text-muted-foreground">
+      Ordered by when someone last contributed, not by how much — so the newest arrival is at the
+      top, where they should be.
+    </p>
+
+    <div class="grid gap-3 sm:grid-cols-2">
+      {#each data.contributors as entry (entry.login)}
+        {@render contributorCard(entry)}
+      {/each}
+    </div>
+  </section>
+
+  <section class="rounded-xl border border-border bg-muted/30 p-6 sm:p-8">
+    <h2 class="text-xl font-semibold tracking-tight">Your name goes here next.</h2>
+    <p class="mt-2 max-w-2xl text-muted-foreground">
+      An opened issue counts as much as merged code. Pick something that annoys you about freehire
+      and tell us, or fix it.
+    </p>
+    <div class="mt-5 flex flex-wrap gap-3">
+      <a
+        href={resolve('/contribute')}
+        class="rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-opacity hover:opacity-90"
+      >
+        How to contribute
+      </a>
+      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external repository, not a SvelteKit route -->
+      <a
+        href="https://github.com/strelov1/freehire/issues"
+        class="rounded-lg border border-border px-4 py-2 text-sm font-medium transition-colors hover:bg-background"
+        rel="noopener"
+        target="_blank"
+      >
+        Open an issue ↗
+      </a>
+    </div>
+  </section>
+</div>

--- a/web/src/routes/contributors/[login]/+page.server.ts
+++ b/web/src/routes/contributors/[login]/+page.server.ts
@@ -1,0 +1,21 @@
+import { error, redirect } from '@sveltejs/kit';
+import { findContributor } from '$lib/contributors';
+import type { ContributorsSnapshot } from '$lib/contributors';
+import snapshot from '$lib/data/contributors.json';
+import type { PageServerLoad } from './$types';
+
+// One person's page. Resolved through $lib/contributors rather than against the raw
+// snapshot, so a bot — or an entry with nothing to show — 404s here exactly as it is
+// absent from the showcase, instead of getting a page and a shareable card nothing
+// links to.
+export const load: PageServerLoad = ({ params }) => {
+  const contributor = findContributor(snapshot as ContributorsSnapshot, params.login);
+  if (!contributor) error(404, 'Contributor not found');
+
+  // The lookup is case-insensitive because GitHub logins are, but the page has one
+  // canonical URL — otherwise every casing is a separate address for the same person,
+  // which splits both the search index and whatever a share link accumulates.
+  if (contributor.login !== params.login) redirect(308, `/contributors/${contributor.login}`);
+
+  return { contributor };
+};

--- a/web/src/routes/contributors/[login]/+page.svelte
+++ b/web/src/routes/contributors/[login]/+page.svelte
@@ -1,0 +1,166 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import { resolve } from '$app/paths';
+  import Seo from '$lib/components/Seo.svelte';
+  import { Avatar, SectionLabel } from '$lib/ui';
+  import { contributionSummary } from '$lib/contributors';
+  import { breadcrumbJsonLd, jsonLdScript } from '$lib/seo';
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  const who = $derived(data.contributor);
+  const origin = $derived(page.url.origin);
+  const canonical = $derived(`${origin}/contributors/${who.login}`);
+
+  const description = $derived(
+    `${who.login} contributes to freehire, the open-source job search engine — ${contributionSummary(who)} since ${monthYear(who.firstContributionAt)}.`,
+  );
+
+  // The share text is what someone posts about their own work, so it reads as their
+  // sentence and not as ours.
+  const shareText = $derived(`I contribute to freehire, an open-source job search engine.`);
+  const shareX = $derived(
+    `https://x.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(canonical)}`,
+  );
+  const shareLinkedIn = $derived(
+    `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(canonical)}`,
+  );
+
+  const jsonLd = $derived(
+    jsonLdScript([
+      breadcrumbJsonLd([
+        { name: 'freehire', url: `${origin}/` },
+        { name: 'Contributors', url: `${origin}/contributors` },
+        { name: who.login, url: canonical },
+      ]),
+    ]),
+  );
+
+  function monthYear(iso: string) {
+    return new Date(iso).toLocaleDateString('en', { month: 'long', year: 'numeric' });
+  }
+
+  function day(iso: string) {
+    return new Date(iso).toLocaleDateString('en', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    });
+  }
+
+  const stats = $derived(
+    [
+      { label: 'merged pull requests', value: who.mergedPullRequests },
+      { label: 'issues opened', value: who.openedIssues },
+    ].filter((s) => s.value > 0),
+  );
+</script>
+
+<Seo
+  title="{who.login} — freehire contributors"
+  {description}
+  {canonical}
+  image={`${canonical}/og.png`}
+/>
+
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->
+  {@html jsonLd}
+</svelte:head>
+
+<div class="mx-auto w-full max-w-3xl px-4 py-10 sm:py-14">
+  <a
+    href={resolve('/contributors')}
+    class="font-mono text-xs uppercase tracking-widest text-muted-foreground hover:underline"
+  >
+    ← all contributors
+  </a>
+
+  <header class="mt-6 flex flex-wrap items-center gap-5">
+    <Avatar name={who.login} src={who.avatarUrl} size="lg" class="size-20" />
+    <div class="min-w-0">
+      <h1 class="text-3xl font-semibold tracking-tighter sm:text-4xl">{who.login}</h1>
+      <p class="mt-1 text-muted-foreground">
+        {who.role === 'maintainer' ? 'Maintains' : 'Contributes to'} freehire since
+        {monthYear(who.firstContributionAt)}
+      </p>
+      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external profile, not a SvelteKit route -->
+      <a
+        href="https://github.com/{who.login}"
+        class="mt-1 inline-block text-sm text-muted-foreground hover:underline"
+        rel="noopener"
+        target="_blank"
+      >
+        github.com/{who.login} ↗
+      </a>
+    </div>
+  </header>
+
+  <dl class="mt-8 grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-border bg-border">
+    {#each stats as stat (stat.label)}
+      <div class="bg-background p-5">
+        <dt class="font-mono text-xs uppercase tracking-wide text-muted-foreground">
+          {stat.label}
+        </dt>
+        <dd class="mt-2 text-3xl font-semibold tracking-tight tabular-nums">{stat.value}</dd>
+      </div>
+    {/each}
+  </dl>
+
+  {#if who.recentPullRequests.length > 0}
+    <section class="mt-12">
+      <SectionLabel text="merged" />
+      <h2 class="mt-3 text-xl font-semibold tracking-tight">
+        {who.recentPullRequests.length === who.mergedPullRequests
+          ? 'Every pull request'
+          : `The ${who.recentPullRequests.length} most recent pull requests`}
+      </h2>
+
+      <ul class="mt-6 divide-y divide-border rounded-xl border border-border">
+        {#each who.recentPullRequests as pr (pr.number)}
+          <li class="flex items-baseline justify-between gap-4 p-4">
+            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- links to GitHub, not a SvelteKit route -->
+            <a href={pr.url} class="min-w-0 hover:underline" rel="noopener" target="_blank">
+              <span class="font-mono text-xs text-muted-foreground">#{pr.number}</span>
+              <span class="ml-2">{pr.title}</span>
+            </a>
+            <time
+              class="shrink-0 font-mono text-xs uppercase tracking-wide text-muted-foreground"
+              datetime={pr.mergedAt}
+            >
+              {day(pr.mergedAt)}
+            </time>
+          </li>
+        {/each}
+      </ul>
+    </section>
+  {/if}
+
+  <section class="mt-12 rounded-xl border border-border bg-muted/30 p-6">
+    <h2 class="text-lg font-semibold tracking-tight">Share this page</h2>
+    <p class="mt-1 text-sm text-muted-foreground">
+      It is yours — your work, your link, your face on the preview card.
+    </p>
+    <!-- eslint-disable svelte/no-navigation-without-resolve -- both are external share intents, not SvelteKit routes -->
+    <div class="mt-4 flex flex-wrap gap-3">
+      <a
+        href={shareX}
+        class="rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-muted"
+        rel="noopener"
+        target="_blank"
+      >
+        Share on X
+      </a>
+      <a
+        href={shareLinkedIn}
+        class="rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-muted"
+        rel="noopener"
+        target="_blank"
+      >
+        Share on LinkedIn
+      </a>
+    </div>
+    <!-- eslint-enable svelte/no-navigation-without-resolve -->
+  </section>
+</div>

--- a/web/src/routes/contributors/[login]/og.png/+server.ts
+++ b/web/src/routes/contributors/[login]/og.png/+server.ts
@@ -1,0 +1,39 @@
+import { error } from '@sveltejs/kit';
+import { findContributor } from '$lib/contributors';
+import type { ContributorsSnapshot } from '$lib/contributors';
+import snapshot from '$lib/data/contributors.json';
+import { resolveAvatar } from '$lib/server/og/avatar';
+import { buildContributorCard } from '$lib/server/og/contributor';
+import { loadOgFonts } from '$lib/server/og/fonts';
+import { renderMarkupPng } from '$lib/server/og/render';
+import type { RequestHandler } from './$types';
+
+// Renders one contributor's 1200×630 Open Graph preview on demand. This is the card a
+// contributor's own shared link unfurls into, which is what makes the profile page worth
+// posting at all — without it every contributor's link previews as the generic site
+// image and none of them looks like it is about a person.
+//
+// Resolved by the same lookup the page uses, so a login the showcase does not list —
+// absent, a bot, nothing to show — 404s here with no image rather than getting a
+// shareable card nothing links to. The avatar fetch degrades to a monogram on any
+// failure, so it never blocks the response. Cached for an hour with a day of
+// stale-while-revalidate, matching the site's other cards: the snapshot behind it
+// changes at most once a day.
+export const GET: RequestHandler = async ({ params }) => {
+  const contributor = findContributor(snapshot as ContributorsSnapshot, params.login);
+  if (!contributor) error(404, 'Contributor not found');
+
+  const [fonts, avatar] = await Promise.all([
+    loadOgFonts(),
+    resolveAvatar(contributor.avatarUrl),
+  ]);
+
+  const png = await renderMarkupPng(buildContributorCard(contributor, { avatar }), fonts);
+
+  return new Response(png, {
+    headers: {
+      'content-type': 'image/png',
+      'cache-control': 'public, max-age=3600, stale-while-revalidate=86400',
+    },
+  });
+};

--- a/web/src/routes/open/+page.svelte
+++ b/web/src/routes/open/+page.svelte
@@ -321,10 +321,16 @@
             <div class="font-mono text-xs uppercase tracking-wide text-muted-foreground">forks</div>
           </div>
           {#if gh.contributors != null}
-            <div>
-              <div class="text-3xl font-semibold tabular-nums">{nf.format(gh.contributors)}</div>
+            <!-- The one figure here that is about people rather than the repository, so
+                 it leads to their pages on this site rather than to GitHub's graph.
+                 Guarded by the same `!= null` as before: a degraded GitHub leg drops the
+                 figure entirely rather than rendering a link with nothing behind it. -->
+            <a href={resolve('/contributors')} class="group">
+              <div class="text-3xl font-semibold tabular-nums group-hover:underline">
+                {nf.format(gh.contributors)}
+              </div>
               <div class="font-mono text-xs uppercase tracking-wide text-muted-foreground">contributors</div>
-            </div>
+            </a>
           {/if}
           {#if gh.license}
             <div>

--- a/web/src/routes/sitemap-pages.xml/+server.ts
+++ b/web/src/routes/sitemap-pages.xml/+server.ts
@@ -1,5 +1,12 @@
 import { listPosts } from '$lib/blogPosts';
-import { STATIC_PATHS, blogPaths, collectionPaths, urlsetXml, xmlResponse } from '$lib/sitemap';
+import {
+  STATIC_PATHS,
+  blogPaths,
+  collectionPaths,
+  contributorPaths,
+  urlsetXml,
+  xmlResponse,
+} from '$lib/sitemap';
 import type { PathEntry } from '$lib/sitemap';
 import type { RequestHandler } from './$types';
 
@@ -11,7 +18,11 @@ import type { RequestHandler } from './$types';
 // neither has a date we can state honestly, and a made-up one teaches crawlers to
 // ignore the field everywhere.
 export const GET: RequestHandler = ({ url }) => {
-  const undated: PathEntry[] = [...STATIC_PATHS, ...collectionPaths()].map((path) => ({ path }));
+  const undated: PathEntry[] = [
+    ...STATIC_PATHS,
+    ...collectionPaths(),
+    ...contributorPaths(),
+  ].map((path) => ({ path }));
   const entries = [...undated, ...blogPaths(listPosts())].map(({ path, lastmod }) => ({
     loc: `${url.origin}${path}`,
     lastmod,

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -86,18 +86,28 @@ export default {
         // this pins where an image could go if that ever regresses.
         //
         // The list is exhaustive by inspection, not by habit: the only browser-side
-        // <img> sinks are CompanyLogo.svelte (the logo proxy) and TemplateGallery.svelte
-        // (same-origin /cv-previews/*.svg). OG cards render server-side and are never
-        // fetched under our own CSP, and job descriptions carry no images at all — the
-        // ingest sanitizer strips them (internal/sources/sanitize.go). `data:` is here
-        // for the handful of Tailwind utilities that inline an SVG.
+        // <img> sinks are CompanyLogo.svelte (the logo proxy), TemplateGallery.svelte
+        // (same-origin /cv-previews/*.svg) and the /contributors pages (GitHub avatars).
+        // OG cards render server-side and are never fetched under our own CSP, and job
+        // descriptions carry no images at all — the ingest sanitizer strips them
+        // (internal/sources/sanitize.go). `data:` is here for the handful of Tailwind
+        // utilities that inline an SVG.
         // api.producthunt.com serves the Product Hunt "featured" badge embedded in
         // the footer (Footer.svelte) — a single static SVG per theme.
+        // avatars.githubusercontent.com is GitHub's avatar CDN, read by the contributor
+        // showcase and profile pages. Adding a host here widens what the assistant's
+        // markdown could point an <img> at if the sanitizer ever regressed, so it is
+        // worth naming why this one is acceptable: it is a static image CDN on a path
+        // shape we do not control and it accepts no query we could smuggle data through,
+        // which is the same argument the logo proxy and the badge host already sit on.
+        // Left off, every avatar on those pages silently falls back to initials — the
+        // page still renders, so nothing fails loudly.
         'img-src': [
           'self',
           'data:',
           'https://logo.freehire.me',
           'https://api.producthunt.com',
+          'https://avatars.githubusercontent.com',
         ],
         // Pinning img-src deliberately stopped there: connect-src was considered as
         // part of the same hardening and left out, because getting it wrong fails

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -19,6 +19,13 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
-    include: ['src/**/*.test.ts'],
+    // `scripts/**` is in the net because the contributors collector is a plain Node
+    // script by design — the GitHub Action that runs it daily invokes `node` with no
+    // install and no build step, which a TypeScript collector would have cost. Its
+    // fetching is untestable either way, but the assembly around it (the per-person
+    // totals, the twenty-pull-request cap, the stable key order that decides whether a
+    // run commits) is ordinary logic, and this is what keeps it from being exercised
+    // only by a nightly job nobody watches.
+    include: ['src/**/*.test.ts', 'scripts/**/*.test.mjs'],
   },
 });


### PR DESCRIPTION
## Why

Nothing on the site names the people who build it with us. `/open` carries a contributor count and links away to GitHub, so the one moment a visitor is curious about the community sends them somewhere else.

This is not a trophy wall for a crowd we already have. It is the lure for the next contributor: each person gets their own URL and their own social card, which is the only way a page like this reaches anyone who is not already looking at us.

## What this adds

- **`/contributors`** — the showcase. The maintainer in their own group; everyone else ordered by when they last contributed.
- **`/contributors/<login>`** — a page per person: first contribution, merged-PR and issue counts, their actual pull requests by title and date, and share actions for X and LinkedIn.
- **`/contributors/<login>/og.png`** — a per-person social card, so a shared link shows their face instead of the site's generic preview.
- **`.github/workflows/contributors.yml`** — collects the data daily and commits `web/src/lib/data/contributors.json` **only when it changed**.

No backend, no database, no migration, no worker. `web/` plus one workflow.

## What the data actually said

The first collection found **2410 merged pull requests and 104 issues across 17 accounts**: one bot, the maintainer with 2236, and fifteen outside contributors whose largest history is eight.

Two design choices come straight out of that shape:

- **Ordered by recency, never by volume.** A volume ordering buries a newcomer the moment they arrive, behind everyone who has simply been here longer — the opposite of what the page is for.
- **The maintainer sits apart.** 2236 beside fifteen histories of under ten renders as one bar and fifteen slivers.

And one scope question settled itself: **eight of the sixteen humans have never merged code** and are here entirely on issues they opened. Counting only code would have halved the page.

## Three things worth a reviewer's attention

**The bot filter needs two signals, not the obvious one.** The GraphQL API spells dependabot's login `dependabot` — no `[bot]` suffix — while the REST endpoint spells the same account `dependabot[bot]`. A filter written against the suffix alone puts this repository's second-largest contributor on a page about people, and every hand-written fixture stays green while it does. There is a test over the committed snapshot — the file that actually ships — that catches exactly this.

**The snapshot carries no timestamp, deliberately.** The commit-only-on-change design rests on `git diff --quiet`, and the first draft had a collected-at stamp: it changes every run by definition, so it would have made every run a commit and (since the host deploys a green main) a daily production deploy of nothing — while every test stayed green. `serializeSnapshot` no longer takes the parameter that made the mistake expressible. When the data last changed is what the commit that changed it already records.

**Widening `img-src` was not visible from the code.** Left as it was, every avatar on both pages falls back silently to initials: the page still renders, nothing errors, and only opening it in a browser shows it. The comment above that list claims it is exhaustive by inspection, so this edits the reasoning too, not just the array.

## Verification

- `pnpm --dir web test` — 1668 passing (30 new)
- `pnpm --dir web build`, `svelte-check` — 0 errors
- `pnpm --dir web lint`, `pnpm check:links`, `pnpm check:dead` (web workspace), `actionlint` — clean
- `pnpm --dir web og:smoke` — six new contributor fixtures render valid PNGs through the real pipeline
- Both pages and a real card opened in a browser; `404` confirmed for an unknown login, for a bot, and for the card of either; a differently-cased login `308`s to its canonical URL

## One thing to check on the ops side

A commit pushed with the workflow's own `GITHUB_TOKEN` does not trigger other workflows — GitHub blocks that to stop a workflow looping on itself. So the CI run the auto-deploy gate looks for never appears for these commits, and a refreshed snapshot reaches production on the next ordinary commit rather than on its own.

That is the intended trade (the alternative is a standing PAT with write access to main, stored as a secret, so a page can be current a day sooner). Worth confirming the gate simply skips such a commit rather than getting stuck on it.

Spec: `openspec/changes/add-contributors-page/`
