### PR TITLE
Name the campaign for what it offers, not for what it is

### DIFF
--- a/design-system/static/email-previews/campaign-discord-invite.dark.html
+++ b/design-system/static/email-previews/campaign-discord-invite.dark.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="color-scheme" content="dark">
 <meta name="supported-color-schemes" content="dark">
-<title>There’s a Discord for this</title>
+<title>Join a community of job seekers</title>
 <style>
   .m-page   { background: #0d0e0b !important; }
   .m-card   { background: #161616 !important; border-color: #2a2a2a !important; }
@@ -22,7 +22,7 @@
 </style>
 </head>
 <body class="m-page" style="margin:0;padding:0;background:#f0f0f0;">
-<div style="display:none;max-height:0;overflow:hidden;opacity:0;">One room: ask me anything, and everyone else job hunting right now.</div>
+<div style="display:none;max-height:0;overflow:hidden;opacity:0;">A room of people job hunting right now — and me, answering.</div>
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="m-page" style="background:#f0f0f0;">
   <tr><td align="center" style="padding:32px 12px;">
     <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;width:100%;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
@@ -35,7 +35,7 @@
       </td></tr>
 
       <tr><td class="m-card" style="background:#ffffff;border:1px solid #e4e4e4;border-radius:12px;padding:28px;">
-        <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">There’s a Discord for this</h1>
+        <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">Join a community of job seekers</h1>
         
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">Hi — short one. freehire has a Discord, and I’d like you in it.</p>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">It is where the questions go now. A filter that misbehaves, a company board we don’t cover yet, a posting that smells fake, a feature you wish existed — ask there and I answer myself. The whole project is open source, so there is nothing about how it works that is off limits to ask.</p>

--- a/design-system/static/email-previews/campaign-discord-invite.html
+++ b/design-system/static/email-previews/campaign-discord-invite.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="color-scheme" content="light dark">
 <meta name="supported-color-schemes" content="light dark">
-<title>There’s a Discord for this</title>
+<title>Join a community of job seekers</title>
 <style>@media (prefers-color-scheme: dark) {
   .m-page   { background: #0d0e0b !important; }
   .m-card   { background: #161616 !important; border-color: #2a2a2a !important; }
@@ -22,7 +22,7 @@
 }</style>
 </head>
 <body class="m-page" style="margin:0;padding:0;background:#f0f0f0;">
-<div style="display:none;max-height:0;overflow:hidden;opacity:0;">One room: ask me anything, and everyone else job hunting right now.</div>
+<div style="display:none;max-height:0;overflow:hidden;opacity:0;">A room of people job hunting right now — and me, answering.</div>
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="m-page" style="background:#f0f0f0;">
   <tr><td align="center" style="padding:32px 12px;">
     <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;width:100%;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
@@ -35,7 +35,7 @@
       </td></tr>
 
       <tr><td class="m-card" style="background:#ffffff;border:1px solid #e4e4e4;border-radius:12px;padding:28px;">
-        <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">There’s a Discord for this</h1>
+        <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">Join a community of job seekers</h1>
         
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">Hi — short one. freehire has a Discord, and I’d like you in it.</p>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">It is where the questions go now. A filter that misbehaves, a company board we don’t cover yet, a posting that smells fake, a feature you wish existed — ask there and I answer myself. The whole project is open source, so there is nothing about how it works that is off limits to ask.</p>

--- a/design-system/static/email-previews/campaign-discord-invite.light.html
+++ b/design-system/static/email-previews/campaign-discord-invite.light.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="color-scheme" content="light">
 <meta name="supported-color-schemes" content="light">
-<title>There’s a Discord for this</title>
+<title>Join a community of job seekers</title>
 
 </head>
 <body class="m-page" style="margin:0;padding:0;background:#f0f0f0;">
-<div style="display:none;max-height:0;overflow:hidden;opacity:0;">One room: ask me anything, and everyone else job hunting right now.</div>
+<div style="display:none;max-height:0;overflow:hidden;opacity:0;">A room of people job hunting right now — and me, answering.</div>
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="m-page" style="background:#f0f0f0;">
   <tr><td align="center" style="padding:32px 12px;">
     <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;width:100%;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
@@ -22,7 +22,7 @@
       </td></tr>
 
       <tr><td class="m-card" style="background:#ffffff;border:1px solid #e4e4e4;border-radius:12px;padding:28px;">
-        <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">There’s a Discord for this</h1>
+        <h1 class="m-ink" style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#070707;">Join a community of job seekers</h1>
         
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">Hi — short one. freehire has a Discord, and I’d like you in it.</p>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">It is where the questions go now. A filter that misbehaves, a company board we don’t cover yet, a posting that smells fake, a feature you wish existed — ask there and I answer myself. The whole project is open source, so there is nothing about how it works that is off limits to ask.</p>

--- a/design-system/static/email-previews/index.html
+++ b/design-system/static/email-previews/index.html
@@ -50,7 +50,7 @@
   <div class="card">
     <div class="meta">
       <div class="name">Campaigns / Discord invite</div>
-      <div class="subject">There’s a Discord for this</div>
+      <div class="subject">Join a community of job seekers</div>
     </div>
     <iframe data-mail="campaign-discord-invite" src="campaign-discord-invite.light.html" title="Campaigns / Discord invite" sandbox="allow-same-origin" loading="lazy"></iframe>
     <div class="text">

--- a/internal/engage/broadcast/copy.go
+++ b/internal/engage/broadcast/copy.go
@@ -28,10 +28,12 @@ var campaigns = map[string]Campaign{
 	// deadline in a letter is a promise about behaviour, and the letter keeps going out
 	// long after the week it was written in.
 	"discord-invite": {
+		// Name is the ledger key and stays "discord-invite" whatever the subject line
+		// says: renaming it would mail the whole list a second time.
 		Name:      "discord-invite",
-		Subject:   "There’s a Discord for this",
-		Preheader: "One room: ask me anything, and everyone else job hunting right now.",
-		Heading:   "There’s a Discord for this",
+		Subject:   "Join a community of job seekers",
+		Preheader: "A room of people job hunting right now — and me, answering.",
+		Heading:   "Join a community of job seekers",
 		body: body("discord-invite", `
 {{template "p" "Hi — short one. freehire has a Discord, and I’d like you in it."}}
 {{template "p" "It is where the questions go now. A filter that misbehaves, a company board we don’t cover yet, a posting that smells fake, a feature you wish existed — ask there and I answer myself. The whole project is open source, so there is nothing about how it works that is off limits to ask."}}


### PR DESCRIPTION
"There's a Discord for this" describes the mechanism. The letter asks someone to join a room of people running the same job search, so the subject and heading now say that: **"Join a community of job seekers."**

The ledger key stays `discord-invite`. It is what makes a send idempotent, so renaming it would mail the whole list a second time — the comment now sits beside the field, not only in the type's doc.

Previews regenerated; `go test ./internal/engage/...` green; the rendered letter was read in a browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Copy Updates**
  * Updated the Discord invite campaign’s subject line, preview text, and heading to emphasize joining a community of job seekers.
  * Applied the revised messaging consistently across light and dark email previews and the campaign listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->