### PR TITLE
Split /status into tabs, adopt the design-system Tabs primitive

### DIFF
--- a/design-system/scripts/adoption-baseline.json
+++ b/design-system/scripts/adoption-baseline.json
@@ -22,7 +22,7 @@
   "SettingRow": 3,
   "Skeleton": 2,
   "Table": 8,
-  "Tabs": 0,
+  "Tabs": 1,
   "TabStrip": 9,
   "Tooltip": 2
 }

--- a/design-system/scripts/web-token-baseline.json
+++ b/design-system/scripts/web-token-baseline.json
@@ -76,7 +76,7 @@
   "web/src/lib/components/SavedSearches.svelte": 1,
   "web/src/lib/components/SavedSearchesView.svelte": 1,
   "web/src/lib/components/SkillDeltaBadge.svelte": 6,
-  "web/src/lib/components/StatusBoard.svelte": 14,
+  "web/src/lib/components/StatusBoard.svelte": 12,
   "web/src/lib/components/SwipeDeck.svelte": 8,
   "web/src/lib/components/TailorLandingView.svelte": 13,
   "web/src/lib/components/TrackingLandingView.svelte": 2,

--- a/web/src/lib/components/StatusBoard.svelte
+++ b/web/src/lib/components/StatusBoard.svelte
@@ -4,6 +4,7 @@
   // other surface uses: a provider must not be "WhatJobs" on the filter panel and
   // "Whatjobs" here.
   import { sourceLabel } from '$lib/facets';
+  import { Tabs } from '$lib/ui';
   import type { HealthStatus, IngestStatus, ProviderKind } from '$lib/types';
 
   // The presentational half of the /status page: given the status read (or null
@@ -88,6 +89,15 @@
 
   const nf = new Intl.NumberFormat('en');
 
+  // The site/API and the ingest fleet are different concerns (see SITE_HEADLINE's
+  // comment above) — tabs keep them from competing for the same screen instead of
+  // stacking sections a visitor has to scroll past to reach the one they want.
+  const SECTION_TABS = [
+    { value: 'site', label: 'Site status' },
+    { value: 'fleet', label: 'Ingest fleet' },
+  ];
+  let activeSection = $state<'site' | 'fleet'>('site');
+
   // Worst-first, then alphabetical — problem providers surface at the top.
   const providers = $derived(
     [...(status?.providers ?? [])].sort(
@@ -124,143 +134,150 @@
     Status is unavailable right now. Try again in a moment.
   </div>
 {:else}
-  {#if site}
-    <!-- Site status: is freehire.me itself working, independent of the ingest fleet below. -->
-    <section class="mb-8">
-      <p class="mb-3 font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// site status</p>
-      <div class="flex items-center gap-4 rounded-xl border p-5 sm:p-6 {STATUS_META[site.status].pill}">
-        <span class="inline-flex h-3 w-3 shrink-0 rounded-full {STATUS_META[site.status].dot}"></span>
+  <Tabs tabs={SECTION_TABS} bind:value={activeSection}>
+    {#if activeSection === 'site'}
+      {#if site}
+        <!-- Site status: is freehire.me itself working, independent of the ingest fleet tab. -->
+        <div class="flex items-center gap-4 rounded-xl border p-5 sm:p-6 {STATUS_META[site.status].pill}">
+          <span class="inline-flex h-3 w-3 shrink-0 rounded-full {STATUS_META[site.status].dot}"></span>
+          <div>
+            <div class="text-lg font-semibold tracking-tight">{SITE_HEADLINE[site.status]}</div>
+            <div class="text-sm opacity-80">
+              Database {site.database} · {nfPercent.format(site.error_rate)} error rate over the last {site.window_minutes} min
+            </div>
+          </div>
+        </div>
+
+        <!-- Daily history strip: worst status observed each day, oldest first. A gap
+             (no sample recorded) renders as a distinct neutral tile, never as if the
+             day were operational. -->
+        <div class="mt-4 rounded-xl border border-border p-4 sm:p-5">
+          <p class="text-xs text-muted-foreground">Last {HISTORY_DAYS} days</p>
+          <!-- flex-1 tiles (not a fixed width) so all 90 always fit the container —
+               a fixed width overflows on anything narrower than a wide desktop, and
+               the resulting horizontal scroll defaults to showing the OLDEST (gray)
+               end, hiding the recent, colorful end a visitor actually wants to see. -->
+          <div class="mt-3 flex h-7 gap-px">
+            {#each historyTiles as tile (tile.day)}
+              {@const meta = tile.status ? STATUS_META[tile.status] : NO_DATA_TILE_META}
+              <span
+                class="flex-1 rounded-sm {meta.dot}"
+                title="{tile.day} — {tile.status ? meta.label : 'no data recorded'}"
+              ></span>
+            {/each}
+          </div>
+        </div>
+      {:else}
+        <p class="rounded-xl border border-border p-8 text-center text-muted-foreground">
+          Site status is unavailable right now.
+        </p>
+      {/if}
+    {:else}
+      <!-- Overall banner -->
+      <div class="flex items-center gap-4 rounded-xl border p-5 sm:p-6 {STATUS_META[overall].pill}">
+        <span class="inline-flex h-3 w-3 shrink-0 rounded-full {STATUS_META[overall].dot}"></span>
         <div>
-          <div class="text-lg font-semibold tracking-tight">{SITE_HEADLINE[site.status]}</div>
+          <div class="text-lg font-semibold tracking-tight">{OVERALL_HEADLINE[overall]}</div>
           <div class="text-sm opacity-80">
-            Database {site.database} · {nfPercent.format(site.error_rate)} error rate over the last {site.window_minutes} min
+            {providers.length} provider{providers.length === 1 ? '' : 's'} monitored
           </div>
         </div>
       </div>
 
-      <!-- Daily history strip: worst status observed each day, oldest first. A gap
-           (no sample recorded) renders as a distinct neutral tile, never as if the
-           day were operational. -->
-      <div class="mt-4 flex items-center justify-between text-xs text-muted-foreground">
-        <span>Last {HISTORY_DAYS} days</span>
-      </div>
-      <div class="mt-2 flex gap-0.5 overflow-x-auto pb-1">
-        {#each historyTiles as tile (tile.day)}
-          {@const meta = tile.status ? STATUS_META[tile.status] : NO_DATA_TILE_META}
-          <span
-            class="h-6 w-1.5 shrink-0 rounded-sm {meta.dot}"
-            title="{tile.day} — {tile.status ? meta.label : 'no data recorded'}"
-          ></span>
-        {/each}
-      </div>
-    </section>
-  {/if}
-
-  <p class="mb-3 font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// ingest fleet status</p>
-
-  <!-- Overall banner -->
-  <div class="mb-10 flex items-center gap-4 rounded-xl border p-5 sm:p-6 {STATUS_META[overall].pill}">
-    <span class="inline-flex h-3 w-3 shrink-0 rounded-full {STATUS_META[overall].dot}"></span>
-    <div>
-      <div class="text-lg font-semibold tracking-tight">{OVERALL_HEADLINE[overall]}</div>
-      <div class="text-sm opacity-80">
-        {providers.length} provider{providers.length === 1 ? '' : 's'} monitored
-      </div>
-    </div>
-  </div>
-
-  <!-- Provider list -->
-  <section>
-    <div class="flex items-baseline justify-between">
-      <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// providers</p>
-      <!-- A raw JSON API endpoint, not a SvelteKit page route — there is nothing
-           for resolve() to map, so the internal-navigation rule doesn't apply. -->
-      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-      <a href="/api/v1/status" class="font-mono text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline">
-        /status ↗
-      </a>
-    </div>
-
-    {#if providers.length === 0}
-      <p class="mt-6 text-sm text-muted-foreground">No providers have run yet.</p>
-    {:else}
-      <label class="mt-6 block">
-        <span class="sr-only">Filter providers by name</span>
-        <input
-          type="search"
-          bind:value={query}
-          placeholder="Filter providers…"
-          autocomplete="off"
-          class="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus:border-foreground"
-        />
-      </label>
-
-      {#if kindCounts.length > 1}
-        <div class="mt-3 flex flex-wrap gap-2">
-          <button
-            type="button"
-            onclick={() => (kind = 'all')}
-            class="rounded-full border px-3 py-1 text-xs font-medium transition-colors {kind === 'all'
-              ? 'border-foreground bg-foreground text-background'
-              : 'border-border text-muted-foreground hover:text-foreground'}"
-          >
-            All {nf.format(providers.length)}
-          </button>
-          {#each kindCounts as kc (kc.kind)}
-            <button
-              type="button"
-              onclick={() => (kind = kc.kind)}
-              class="rounded-full border px-3 py-1 text-xs font-medium transition-colors {kind === kc.kind
-                ? 'border-foreground bg-foreground text-background'
-                : 'border-border text-muted-foreground hover:text-foreground'}"
-            >
-              {KIND_LABEL[kc.kind]} {nf.format(kc.count)}
-            </button>
-          {/each}
+      <!-- Provider list -->
+      <section class="mt-6">
+        <div class="flex items-baseline justify-between">
+          <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// providers</p>
+          <!-- A raw JSON API endpoint, not a SvelteKit page route — there is nothing
+               for resolve() to map, so the internal-navigation rule doesn't apply. -->
+          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+          <a href="/api/v1/status" class="font-mono text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline">
+            /status ↗
+          </a>
         </div>
-      {/if}
 
-      {#if filtered.length === 0}
-        <p class="mt-6 text-sm text-muted-foreground">
-          No providers match “{query.trim()}”.
-        </p>
-      {:else}
-        <ul class="mt-4 divide-y divide-border overflow-hidden rounded-xl border border-border">
-          {#each filtered as p (p.provider)}
-          {@const meta = STATUS_META[p.status]}
-          <li class="flex flex-wrap items-center gap-x-4 gap-y-1 bg-background p-4 sm:p-5">
-            <span class="h-2.5 w-2.5 shrink-0 rounded-full {meta.dot}"></span>
-            <div class="min-w-0 flex-1">
-              <div class="flex items-center gap-2">
-                <span class="font-medium">{sourceLabel(p.provider)}</span>
-                <span class="font-mono text-[10px] uppercase tracking-wide text-muted-foreground">
-                  {KIND_LABEL[p.kind]}
-                </span>
-              </div>
-              <div class="text-sm text-muted-foreground">
-                {nf.format(p.healthy_boards)} / {nf.format(p.total_boards)} boards healthy{#if p.cooled_boards > 0}<span
-                    class="text-warning-strong"
-                  >
-                    · {nf.format(p.cooled_boards)} in cooldown</span
-                  >{/if}
-              </div>
-            </div>
-            <div class="flex flex-col items-end gap-1">
-              <span
-                class="inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium {meta.pill}"
+        {#if providers.length === 0}
+          <p class="mt-6 text-sm text-muted-foreground">No providers have run yet.</p>
+        {:else}
+          <label class="mt-6 block">
+            <span class="sr-only">Filter providers by name</span>
+            <input
+              type="search"
+              bind:value={query}
+              placeholder="Filter providers…"
+              autocomplete="off"
+              class="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus:border-foreground"
+            />
+          </label>
+
+          {#if kindCounts.length > 1}
+            <div class="mt-3 flex flex-wrap gap-2">
+              <button
+                type="button"
+                onclick={() => (kind = 'all')}
+                class="rounded-full border px-3 py-1 text-xs font-medium transition-colors {kind === 'all'
+                  ? 'border-foreground bg-foreground text-background'
+                  : 'border-border text-muted-foreground hover:text-foreground'}"
               >
-                {meta.label}
-              </span>
-              {#if p.last_run}
-                <span class="text-xs text-muted-foreground" title={p.last_run}>
-                  ran {timeAgo(p.last_run)}
-                </span>
-              {/if}
+                All {nf.format(providers.length)}
+              </button>
+              {#each kindCounts as kc (kc.kind)}
+                <button
+                  type="button"
+                  onclick={() => (kind = kc.kind)}
+                  class="rounded-full border px-3 py-1 text-xs font-medium transition-colors {kind === kc.kind
+                    ? 'border-foreground bg-foreground text-background'
+                    : 'border-border text-muted-foreground hover:text-foreground'}"
+                >
+                  {KIND_LABEL[kc.kind]} {nf.format(kc.count)}
+                </button>
+              {/each}
             </div>
-          </li>
-          {/each}
-        </ul>
-      {/if}
+          {/if}
+
+          {#if filtered.length === 0}
+            <p class="mt-6 text-sm text-muted-foreground">
+              No providers match “{query.trim()}”.
+            </p>
+          {:else}
+            <ul class="mt-4 divide-y divide-border overflow-hidden rounded-xl border border-border">
+              {#each filtered as p (p.provider)}
+              {@const meta = STATUS_META[p.status]}
+              <li class="flex flex-wrap items-center gap-x-4 gap-y-1 bg-background p-4 sm:p-5">
+                <span class="h-2.5 w-2.5 shrink-0 rounded-full {meta.dot}"></span>
+                <div class="min-w-0 flex-1">
+                  <div class="flex items-center gap-2">
+                    <span class="font-medium">{sourceLabel(p.provider)}</span>
+                    <span class="font-mono text-[10px] uppercase tracking-wide text-muted-foreground">
+                      {KIND_LABEL[p.kind]}
+                    </span>
+                  </div>
+                  <div class="text-sm text-muted-foreground">
+                    {nf.format(p.healthy_boards)} / {nf.format(p.total_boards)} boards healthy{#if p.cooled_boards > 0}<span
+                        class="text-warning-strong"
+                      >
+                        · {nf.format(p.cooled_boards)} in cooldown</span
+                      >{/if}
+                  </div>
+                </div>
+                <div class="flex flex-col items-end gap-1">
+                  <span
+                    class="inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium {meta.pill}"
+                  >
+                    {meta.label}
+                  </span>
+                  {#if p.last_run}
+                    <span class="text-xs text-muted-foreground" title={p.last_run}>
+                      ran {timeAgo(p.last_run)}
+                    </span>
+                  {/if}
+                </div>
+              </li>
+              {/each}
+            </ul>
+          {/if}
+        {/if}
+      </section>
     {/if}
-  </section>
+  </Tabs>
 {/if}

--- a/web/src/routes/status/+page.svelte
+++ b/web/src/routes/status/+page.svelte
@@ -10,18 +10,17 @@
 </script>
 
 <Seo
-  title="Status — freehire ingest fleet"
-  description="Live health of the freehire ingest fleet: which ATS providers are operational, degraded, or down, rolled up from the crawl's own board-health signal."
+  title="Status — freehire"
+  description="Live status of freehire: whether the site and API are up, and the health of every source adapter crawling job boards."
   {canonical}
 />
 
 <div class="mx-auto w-full max-w-4xl px-4 py-10 sm:py-14">
   <header class="mb-10">
     <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// system status</p>
-    <h1 class="mt-4 text-4xl font-semibold tracking-tighter sm:text-5xl">Ingest fleet status.</h1>
+    <h1 class="mt-4 text-4xl font-semibold tracking-tighter sm:text-5xl">Status.</h1>
     <p class="mt-4 max-w-2xl text-lg leading-relaxed text-muted-foreground">
-      Live health of every source adapter, rolled up from the crawl's own board-health signal — how
-      recently each ATS provider ran and how many of its boards are healthy.
+      The site's own health, and the crawl fleet behind it — pick a tab below.
     </p>
   </header>
 


### PR DESCRIPTION
## Summary
- `/status` stacked three sections (site status, ingest fleet, providers) a visitor had to scroll past to reach the one they wanted. Splits it into two tabs — **Site status** and **Ingest fleet** — using the design system's `Tabs` primitive, which was previously unused anywhere in `web/` (per `check-adoption`).
- Removed the two now-redundant "// SITE STATUS" / "// INGEST FLEET STATUS" eyebrow labels — the tab labels already say this.
- The history strip gets its own bordered card, matching the page's existing card language.
- Page header/SEO copy updated ("Status." instead of "Ingest fleet status.") since the page covers both now.
- **Real bug fix found during visual verification**: fixed-width history tiles could overflow the container on narrower widths, and the resulting horizontal scroll defaults to showing the *oldest* (gray) end — hiding the recent, colorful days a visitor actually wants to see first. Tiles are now `flex-1` so all 90 always fit, no scrolling, ever.

## Test plan
- [x] `svelte-check`: 0 errors
- [x] `pnpm check:dead`, `check:tokens` (updated baseline: 14→12, an improvement — two eyebrow labels removed), `check:adoption` (updated baseline: `Tabs` now has a consumer) all clean
- [x] `design-system`: lint/build/check:dist/check:adoption all pass
- [x] Manually verified against a real local Postgres + `cmd/server`, seeded history with a mix of statuses and gaps: both tabs render correctly, tab switching works, history tiles show the right colors in the right positions with no scroll needed, keyboard arrow-key tab navigation works (native to the `Tabs` primitive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tabs to separate site/API availability from ingest-fleet status.
  - Added responsive 90-day status history and provider filtering within the status views.
- **Improvements**
  - Updated status page headings and metadata to reflect both site health and source adapter health.
  - Replaced the previous stacked layout and horizontally scrolling history tiles with a clearer tabbed experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->