### PR TITLE
Open a pull request for the contributor snapshot instead of pushing at main

### DIFF
--- a/.github/scripts/commit-contributors.sh
+++ b/.github/scripts/commit-contributors.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Commits a refreshed contributor snapshot onto the branch the pull request tracks.
+# Called by .github/workflows/contributors.yml, and only when the file actually changed.
+#
+# The branch is recreated from the checked-out main on every run rather than added to,
+# so the pull request is always one commit against current main — a chain of daily
+# "refresh" commits would be a worse record of the same single fact. That is what makes
+# the force-push safe and necessary: nothing but this job ever writes this branch, and
+# what it force-pushes over is its own superseded version of the same file.
+set -euo pipefail
+
+: "${BRANCH:?BRANCH must be set}"
+: "${SNAPSHOT:?SNAPSHOT must be set}"
+
+git config user.name 'github-actions[bot]'
+git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+git checkout -B "$BRANCH"
+git add "$SNAPSHOT"
+git commit -m 'Refresh the contributor snapshot'
+git push --force origin "$BRANCH"

--- a/.github/scripts/open-contributors-pr.sh
+++ b/.github/scripts/open-contributors-pr.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Opens the pull request carrying a refreshed contributor snapshot, or leaves the open
+# one to pick up the push that just happened. Called by
+# .github/workflows/contributors.yml after commit-contributors.sh.
+#
+# `gh pr create` fails outright when a pull request is already open for the branch, and
+# that is the ordinary case rather than the exceptional one: a second day's change
+# arrives before the first has merged. So the branch is asked about first.
+#
+# Auto-merge is (re-)requested either way. It is not a no-op on an existing pull
+# request — a merge that was queued and then invalidated by a red run needs asking for
+# again, and asking twice costs nothing.
+set -euo pipefail
+
+: "${BRANCH:?BRANCH must be set}"
+
+if [ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
+  gh pr create \
+    --base main \
+    --head "$BRANCH" \
+    --title 'Refresh the contributor snapshot' \
+    --body 'Opened by the contributors workflow. The snapshot behind /contributors changed: someone merged a pull request, opened an issue, or contributed for the first time.
+
+Nothing here is hand-written — the file is whatever web/scripts/build-contributors.mjs collected from the GitHub API. Reviewing it means checking the diff is people, not a shape change.'
+fi
+
+gh pr merge "$BRANCH" --auto --squash

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -4,49 +4,68 @@ name: contributors
 # read. Runs here rather than at request time because the pages need per-person pull
 # request lists, and assembling those needs roughly thirty API calls: far past the 60
 # an unauthenticated IP gets in an hour, a budget the site already spends on the header
-# star badge and /open. This job's own GITHUB_TOKEN carries 5000/hour.
+# star badge and /open.
 #
-# COMMITS ONLY WHEN THE DATA CHANGED. The host polls this repository every ten minutes
-# and deploys a green main, so an unconditional daily commit would be a daily production
-# deploy that changed nothing. `git diff --quiet` is what keeps the deploys to the days
-# a contributor actually did something.
+# IT OPENS A PULL REQUEST; IT DOES NOT PUSH TO MAIN. The first version pushed, and the
+# first real run is what said otherwise: main requires three green checks and enforces
+# them on admins too, so a direct push is rejected for everyone, workflow or human.
+#
+# Which is also why this cannot use the workflow's own GITHUB_TOKEN. A branch pushed
+# with it triggers no workflows — GitHub blocks that to stop a workflow looping on
+# itself — so the pull request would sit with its three required checks forever
+# "expected", unmergeable by anyone. CONTRIBUTORS_TOKEN is a fine-grained personal
+# access token scoped to this repository (contents + pull-requests, write), and a push
+# carrying it runs CI like any other.
+#
+# ONE BRANCH, REUSED. A dated branch per run would leave a trail of stale pull requests
+# every time a day's collection changed nothing anyone merged. Pushing the same branch
+# updates the open pull request in place instead.
 #
 # A run that could not finish its collection fails instead of committing what it has:
 # the script exits non-zero on any API error and refuses outright to write a snapshot
 # with no humans in it. The committed file then keeps serving, which is the right
 # outcome — a stale list of real people beats a fresh empty one.
 #
-# WORTH KNOWING ABOUT THE PUSH: a commit pushed with the workflow's own GITHUB_TOKEN
-# does not trigger other workflows — GitHub blocks that to stop a workflow looping on
-# itself. So the CI run this repository's auto-deploy gate looks for never appears for
-# this commit, and the snapshot reaches production on the next ordinary commit rather
-# than on its own. That is the intended trade: the alternative is a personal access
-# token stored as a secret, which is a standing credential with write access to main in
-# exchange for a page being current a day sooner. If the gate ever needs to treat these
-# commits as deployable, that belongs in the gate, not in a token kept here.
+# WITHOUT THE SECRET THIS IS A CLEAN NO-OP. A fork, or this repository before the token
+# is created, skips the whole job rather than failing a scheduled run every night with
+# an error nobody can act on.
 
 on:
   schedule:
-    # 04:20 UTC: clear of the nightly pg_dump window (from 03:00 UTC) that DDL
-    # migrations have to dodge, so a deploy this triggers does not queue behind it.
     - cron: '20 4 * * *'
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: contributors
   cancel-in-progress: false
 
+env:
+  BRANCH: chore/refresh-contributors
+  SNAPSHOT: web/src/lib/data/contributors.json
+
 jobs:
   collect:
     runs-on: ubuntu-latest
     steps:
+      - name: Check the token is configured
+        id: token
+        env:
+          CONTRIBUTORS_TOKEN: ${{ secrets.CONTRIBUTORS_TOKEN }}
+        run: '[ -n "$CONTRIBUTORS_TOKEN" ] && echo "present=true" >> "$GITHUB_OUTPUT" || echo "present=false" >> "$GITHUB_OUTPUT"'
+
       - name: Checkout
+        if: steps.token.outputs.present == 'true'
         uses: actions/checkout@v7
+        with:
+          # The token the later push carries. Without it the push would go out as
+          # GITHUB_TOKEN and the pull request would never get its checks.
+          token: ${{ secrets.CONTRIBUTORS_TOKEN }}
 
       - name: Set up Node
+        if: steps.token.outputs.present == 'true'
         uses: actions/setup-node@v7
         with:
           node-version: 22
@@ -55,22 +74,27 @@ jobs:
       # plain .mjs rather than TypeScript. Its assembly is unit-tested in the web
       # package (scripts/build-contributors.test.mjs); what runs here is the fetching.
       - name: Collect contributors
+        if: steps.token.outputs.present == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node web/scripts/build-contributors.mjs
 
-      # `git diff --quiet` exits 1 when the file changed, which is the signal to commit.
-      # Everything hangs off that one comparison, so the collector writes its people in
-      # a stable order — otherwise the same data would serialise differently every run
-      # and every run would commit.
-      - name: Commit when the data changed
-        run: |
-          if git diff --quiet -- web/src/lib/data/contributors.json; then
-            echo 'No change in the contributor data. Nothing to commit.'
-            exit 0
-          fi
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add web/src/lib/data/contributors.json
-          git commit -m 'Refresh the contributor snapshot'
-          git push
+      - name: Stop here when nothing changed
+        if: steps.token.outputs.present == 'true'
+        id: changed
+        run: 'git diff --quiet -- "$SNAPSHOT" && echo "any=false" >> "$GITHUB_OUTPUT" || echo "any=true" >> "$GITHUB_OUTPUT"'
+
+      - name: Commit the refreshed snapshot
+        if: steps.changed.outputs.any == 'true'
+        run: .github/scripts/commit-contributors.sh
+
+      # `gh pr create` fails when one is already open for the branch, which is the
+      # ordinary case on a second change before the first merged — so the branch is
+      # asked about first and the pull request is only opened when there is none.
+      # Auto-merge does the rest: the three required checks run because the push
+      # carried a real token, and a green run merges it without anyone looking.
+      - name: Open or update the pull request
+        if: steps.changed.outputs.any == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CONTRIBUTORS_TOKEN }}
+        run: .github/scripts/open-contributors-pr.sh

--- a/openspec/changes/add-contributors-page/design.md
+++ b/openspec/changes/add-contributors-page/design.md
@@ -47,12 +47,30 @@ unlike root `scripts/` — sits beside a test runner. `web/` runs vitest.
 
 ## Decisions
 
-### The snapshot is a committed JSON file, collected by a scheduled Action
+### The snapshot is a committed JSON file, refreshed by a scheduled Action
 
 **Chosen:** `.github/workflows/contributors.yml` runs daily, executes
-`node web/scripts/build-contributors.mjs`, and commits `web/src/lib/data/contributors.json` when
-it differs. The workflow's own `GITHUB_TOKEN` carries a 5000-requests-per-hour budget and
-`contents: write` permission for the commit.
+`node web/scripts/build-contributors.mjs`, and — when the file differs — pushes one branch
+and opens a pull request with auto-merge enabled.
+
+**It opens a pull request rather than pushing, and that was not the first design.** The
+first version pushed to main and the first real run said otherwise: main requires three
+green checks and enforces them on administrators too, so a direct push is rejected for
+everyone, workflow or human. Nothing in the code showed this; only running it did.
+
+**Which also decides the credential.** A branch pushed with the workflow's own
+`GITHUB_TOKEN` triggers no workflows — GitHub blocks that to stop a workflow looping on
+itself — so the pull request would sit with its three required checks permanently
+"expected" and unmergeable by anyone, `enforce_admins` being on. The push therefore
+carries `CONTRIBUTORS_TOKEN`, a fine-grained personal access token scoped to this
+repository alone (contents and pull-requests, write). That is a standing credential, and
+it is the price of the page staying current without a human remembering to refresh it.
+
+Without the secret the job is a clean no-op rather than a nightly failure: a fork, or
+this repository before the token exists, skips every step.
+
+One branch is reused rather than one per run, so a second day's change updates the open
+pull request instead of leaving a trail of stale ones.
 
 **Alternatives considered:**
 
@@ -129,9 +147,16 @@ failure mode: forgetting to add someone shows them, which is the state they were
 
 ## Risks / Trade-offs
 
-- **A daily commit triggers the host's autodeploy poller** → The workflow commits only when
-  the collected data differs. With eleven contributors that is a handful of commits a month,
-  each of them a real change worth deploying.
+- **A daily merge triggers the host's autodeploy poller** → The workflow opens a pull
+  request only when the collected data differs. With sixteen contributors that is a handful
+  of merges a month, each of them a real change worth deploying. What makes "differs"
+  trustworthy is that the file is a function of the data and nothing else, above.
+- **`CONTRIBUTORS_TOKEN` is a standing credential with write access to this repository** →
+  Fine-grained and scoped to this repository and to two permissions, so it is not an
+  account-wide token; and the only thing it is used for is a branch nothing else writes. It
+  is still the largest cost of this design, and the alternative it buys against is a page
+  that goes stale whenever nobody remembers to refresh it. Revoking it stops the refresh
+  and breaks nothing else — the job goes back to a no-op.
 - **A partial collection would silently shrink the published list** → The script fails the
   run on any incomplete page rather than writing what it has; the workflow's commit step
   never runs, and the previous snapshot keeps serving.

--- a/openspec/changes/add-contributors-page/tasks.md
+++ b/openspec/changes/add-contributors-page/tasks.md
@@ -53,10 +53,13 @@
 
 ## 7. The scheduled workflow
 
-- [x] 7.1 Add `.github/workflows/contributors.yml` running daily on a cron with `contents: write`, executing `node web/scripts/build-contributors.mjs`.
-- [x] 7.2 Commit the result only when `git diff --quiet` reports a change, so an unchanged collection produces no commit and no deployment.
-- [x] 7.3 Keep every `run:` block to a single command so actionlint's shellcheck pass stays clean; verify with actionlint locally.
-- [ ] 7.4 Trigger the workflow manually (`workflow_dispatch`) once and confirm it produces no commit against the snapshot committed in 2.8.
+- [x] 7.1 Add `.github/workflows/contributors.yml` running daily on a cron, executing `node web/scripts/build-contributors.mjs`.
+- [x] 7.2 Act only when `git diff --quiet` reports a change, so an unchanged collection produces nothing at all.
+- [x] 7.3 Keep every `run:` block to a single command so actionlint's shellcheck pass stays clean; put the logic in `.github/scripts/*.sh`, which the repo already shellchecks. Verify with actionlint and shellcheck locally.
+- [x] 7.4 Trigger the workflow manually (`workflow_dispatch`) — which is what showed the push to main is rejected: main requires three checks and enforces them on admins.
+- [x] 7.5 Rework it to push a branch and open a pull request with auto-merge, carrying `CONTRIBUTORS_TOKEN` rather than `GITHUB_TOKEN` — a branch pushed with the latter triggers no checks, so its pull request could never merge.
+- [x] 7.6 Skip every step when the secret is absent, so a fork and a not-yet-configured repository are a clean no-op rather than a nightly failure.
+- [ ] 7.7 Create the fine-grained `CONTRIBUTORS_TOKEN` secret, then trigger the workflow twice: the first run opens a pull request, the second finds nothing to do.
 
 ## 8. Verification
 


### PR DESCRIPTION
## What the first real run found

The contributors workflow shipped in #2581 pushed its refreshed snapshot straight at `main`. Triggering it manually is what showed that cannot work:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - 3 of 3 required status checks are expected.
```

`main` requires `backend`, `web` and `pr-smoke`, and `enforce_admins` is on — so a direct push is rejected for everyone, workflow or human. The collection itself was fine; only the last step was impossible. Nothing was pushed, so nothing needed undoing.

## What this changes

The workflow now pushes a branch and opens a pull request with auto-merge enabled.

**And that decides the credential, by a longer route.** A branch pushed with the workflow's own `GITHUB_TOKEN` triggers no workflows — GitHub blocks that to stop a workflow looping on itself — so a pull request opened from such a branch would sit with its three required checks permanently *expected*, unmergeable by anyone. The push therefore carries `CONTRIBUTORS_TOKEN`: a fine-grained token scoped to this repository and to two permissions.

That is a standing credential and the honest cost of the page staying current without a human remembering to refresh it. Revoking it stops the refresh and breaks nothing else.

Other changes:

- **Without the secret, every step is skipped.** A fork — and this repository until the token exists — gets a clean no-op instead of a scheduled run failing every night with an error nobody can act on.
- **One branch, reused.** A dated branch per run would leave a trail of stale pull requests behind whichever one merged; pushing the same branch updates the open one in place.
- **The two `run:` blocks that grew past one command moved to `.github/scripts/*.sh`**, which the `artifacts` job already shellchecks — so the logic is linted rather than merely quoted carefully. Both `actionlint` and `shellcheck` pass locally.

## Before this does anything

The secret has to exist. Until it does this PR is inert — which is the point of the guard.

1. A fine-grained personal access token, this repository only, **Contents: Read and write** + **Pull requests: Read and write**.
2. Saved as the repository secret `CONTRIBUTORS_TOKEN`.

Then two manual runs are the real test: the first opens a pull request (the snapshot has moved since #2581 merged), and the second finds nothing to do.

Spec: `openspec/changes/add-contributors-page/`
