### PR TITLE
Open the invite on a channel a stranger can read

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ![Go version](https://img.shields.io/github/go-mod/go-version/strelov1/freehire)
 ![Last commit](https://img.shields.io/github/last-commit/strelov1/freehire)
 [![Stars](https://img.shields.io/github/stars/strelov1/freehire?style=social)](https://github.com/strelov1/freehire/stargazers)
-[![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/Cghjh3dA5N)
+[![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/79cgB9RRfx)
 
 <br>
 

--- a/design-system/static/email-previews/campaign-discord-invite.dark.html
+++ b/design-system/static/email-previews/campaign-discord-invite.dark.html
@@ -42,7 +42,7 @@
 <p class="m-ink" style="margin:0 0 14px 0;font-size:17px;line-height:1.5;font-weight:600;color:#070707;">And it isn’t only me on the other end.</p>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">It is a community of job seekers, and what we do there is share how the search is actually going: what got a reply and what got silence, a CV rewritten until it started landing interviews, what a company’s interview loop really looks like, what the offer came in at. I share mine too — I am reading the same market you are.</p>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">That half I can’t build. Whether a company is really hiring or just collecting CVs, which recruiters answer and which never do — you only get that from other people running the same search. Job hunting alone is the worst way to do it, and that is really what the room is for.</p>
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="https://discord.gg/Cghjh3dA5N" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;"><img src="./email-icon-discord.png" width="18" height="18" alt="" class="m-logo" style="vertical-align:-3px;border:0;padding-right:9px;">Join the Discord</a></td></tr></table>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="https://discord.gg/79cgB9RRfx" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;"><img src="./email-icon-discord.png" width="18" height="18" alt="" class="m-logo" style="vertical-align:-3px;border:0;padding-right:9px;">Join the Discord</a></td></tr></table>
 <p class="m-muted" style="margin:0 0 14px 0;font-size:14px;line-height:1.6;color:#505050;">It’s free, it’s small, and lurking is fine. If you’d rather just tell me something, reply to this — I read every one.</p>
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin-top:22px;">
   <tr>
@@ -68,7 +68,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/campaign-discord-invite.html
+++ b/design-system/static/email-previews/campaign-discord-invite.html
@@ -42,7 +42,7 @@
 <p class="m-ink" style="margin:0 0 14px 0;font-size:17px;line-height:1.5;font-weight:600;color:#070707;">And it isn’t only me on the other end.</p>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">It is a community of job seekers, and what we do there is share how the search is actually going: what got a reply and what got silence, a CV rewritten until it started landing interviews, what a company’s interview loop really looks like, what the offer came in at. I share mine too — I am reading the same market you are.</p>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">That half I can’t build. Whether a company is really hiring or just collecting CVs, which recruiters answer and which never do — you only get that from other people running the same search. Job hunting alone is the worst way to do it, and that is really what the room is for.</p>
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="https://discord.gg/Cghjh3dA5N" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;"><img src="./email-icon-discord.png" width="18" height="18" alt="" class="m-logo" style="vertical-align:-3px;border:0;padding-right:9px;">Join the Discord</a></td></tr></table>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="https://discord.gg/79cgB9RRfx" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;"><img src="./email-icon-discord.png" width="18" height="18" alt="" class="m-logo" style="vertical-align:-3px;border:0;padding-right:9px;">Join the Discord</a></td></tr></table>
 <p class="m-muted" style="margin:0 0 14px 0;font-size:14px;line-height:1.6;color:#505050;">It’s free, it’s small, and lurking is fine. If you’d rather just tell me something, reply to this — I read every one.</p>
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin-top:22px;">
   <tr>
@@ -68,7 +68,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/campaign-discord-invite.light.html
+++ b/design-system/static/email-previews/campaign-discord-invite.light.html
@@ -29,7 +29,7 @@
 <p class="m-ink" style="margin:0 0 14px 0;font-size:17px;line-height:1.5;font-weight:600;color:#070707;">And it isn’t only me on the other end.</p>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">It is a community of job seekers, and what we do there is share how the search is actually going: what got a reply and what got silence, a CV rewritten until it started landing interviews, what a company’s interview loop really looks like, what the offer came in at. I share mine too — I am reading the same market you are.</p>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">That half I can’t build. Whether a company is really hiring or just collecting CVs, which recruiters answer and which never do — you only get that from other people running the same search. Job hunting alone is the worst way to do it, and that is really what the room is for.</p>
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="https://discord.gg/Cghjh3dA5N" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;"><img src="./email-icon-discord.png" width="18" height="18" alt="" class="m-logo" style="vertical-align:-3px;border:0;padding-right:9px;">Join the Discord</a></td></tr></table>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="https://discord.gg/79cgB9RRfx" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;"><img src="./email-icon-discord.png" width="18" height="18" alt="" class="m-logo" style="vertical-align:-3px;border:0;padding-right:9px;">Join the Discord</a></td></tr></table>
 <p class="m-muted" style="margin:0 0 14px 0;font-size:14px;line-height:1.6;color:#505050;">It’s free, it’s small, and lurking is fine. If you’d rather just tell me something, reply to this — I read every one.</p>
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin-top:22px;">
   <tr>
@@ -55,7 +55,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/index.html
+++ b/design-system/static/email-previews/index.html
@@ -72,7 +72,7 @@ That half I can&#39;t build. Whether a company is really hiring or just collecti
 recruiters answer and which never do — you only get that from other people running the same
 search. Job hunting alone is the worst way to do it, and that is really what the room is for.
 
-Join the Discord: https://discord.gg/Cghjh3dA5N
+Join the Discord: https://discord.gg/79cgB9RRfx
 
 It&#39;s free, it&#39;s small, and lurking is fine. If you&#39;d rather just tell me something, reply to
 this — I read every one.
@@ -215,7 +215,7 @@ and what got silence, a CV rewritten until it started landing interviews, whethe
 is really hiring or just collecting CVs, what the offer came in at. That half I can&#39;t build —
 it only exists because people show up.
 
-Join the Discord: https://discord.gg/Cghjh3dA5N
+Join the Discord: https://discord.gg/79cgB9RRfx
 
 And if the project has been useful, a star is how most people end up finding it:
 https://github.com/strelov1/freehire

--- a/design-system/static/email-previews/nudge-follow-up-batch.dark.html
+++ b/design-system/static/email-previews/nudge-follow-up-batch.dark.html
@@ -96,7 +96,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/nudge-follow-up-batch.html
+++ b/design-system/static/email-previews/nudge-follow-up-batch.html
@@ -96,7 +96,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/nudge-follow-up-batch.light.html
+++ b/design-system/static/email-previews/nudge-follow-up-batch.light.html
@@ -83,7 +83,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/nudge-follow-up.dark.html
+++ b/design-system/static/email-previews/nudge-follow-up.dark.html
@@ -62,7 +62,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/nudge-follow-up.html
+++ b/design-system/static/email-previews/nudge-follow-up.html
@@ -62,7 +62,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/nudge-follow-up.light.html
+++ b/design-system/static/email-previews/nudge-follow-up.light.html
@@ -49,7 +49,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/nudge-job-closed.dark.html
+++ b/design-system/static/email-previews/nudge-job-closed.dark.html
@@ -62,7 +62,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/nudge-job-closed.html
+++ b/design-system/static/email-previews/nudge-job-closed.html
@@ -62,7 +62,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/nudge-job-closed.light.html
+++ b/design-system/static/email-previews/nudge-job-closed.light.html
@@ -49,7 +49,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/onboarding-advanced-search.dark.html
+++ b/design-system/static/email-previews/onboarding-advanced-search.dark.html
@@ -65,7 +65,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/onboarding-advanced-search.html
+++ b/design-system/static/email-previews/onboarding-advanced-search.html
@@ -65,7 +65,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/onboarding-advanced-search.light.html
+++ b/design-system/static/email-previews/onboarding-advanced-search.light.html
@@ -52,7 +52,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/onboarding-extension.dark.html
+++ b/design-system/static/email-previews/onboarding-extension.dark.html
@@ -68,7 +68,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/onboarding-extension.html
+++ b/design-system/static/email-previews/onboarding-extension.html
@@ -68,7 +68,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/onboarding-extension.light.html
+++ b/design-system/static/email-previews/onboarding-extension.light.html
@@ -55,7 +55,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/onboarding-no-alert.dark.html
+++ b/design-system/static/email-previews/onboarding-no-alert.dark.html
@@ -64,7 +64,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/onboarding-no-alert.html
+++ b/design-system/static/email-previews/onboarding-no-alert.html
@@ -64,7 +64,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/onboarding-no-alert.light.html
+++ b/design-system/static/email-previews/onboarding-no-alert.light.html
@@ -51,7 +51,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/onboarding-open-source.dark.html
+++ b/design-system/static/email-previews/onboarding-open-source.dark.html
@@ -42,7 +42,7 @@
 <p class="m-ink" style="margin:0 0 14px 0;font-size:17px;line-height:1.5;font-weight:600;color:#070707;">The Discord is where the rest of it happens.</p>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">It is the main place to ask anything — a filter that misbehaves, a board we don’t cover yet, a posting that smells fake, a feature you want. I read it and answer myself, and it is small enough that you will actually be heard.</p>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">It is also a community of job seekers sharing how the search actually goes: what got a reply and what got silence, a CV rewritten until it started landing interviews, whether a company is really hiring or just collecting CVs, what the offer came in at. That half I can’t build — it only exists because people show up.</p>
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="https://discord.gg/Cghjh3dA5N" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;"><img src="./email-icon-discord.png" width="18" height="18" alt="" class="m-logo" style="vertical-align:-3px;border:0;padding-right:9px;">Join the Discord</a></td></tr></table>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="https://discord.gg/79cgB9RRfx" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;"><img src="./email-icon-discord.png" width="18" height="18" alt="" class="m-logo" style="vertical-align:-3px;border:0;padding-right:9px;">Join the Discord</a></td></tr></table>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">And if the project has been useful, a star is how most people end up finding it — <a href="https://github.com/strelov1/freehire" class="m-link" style="color:#4c5c00;text-decoration:underline;">star it on GitHub</a></p>
 <p class="m-muted" style="margin:0 0 14px 0;font-size:14px;line-height:1.6;color:#505050;">Replying to this mail reaches me too.</p>
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin-top:22px;">
@@ -69,7 +69,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/onboarding-open-source.html
+++ b/design-system/static/email-previews/onboarding-open-source.html
@@ -42,7 +42,7 @@
 <p class="m-ink" style="margin:0 0 14px 0;font-size:17px;line-height:1.5;font-weight:600;color:#070707;">The Discord is where the rest of it happens.</p>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">It is the main place to ask anything — a filter that misbehaves, a board we don’t cover yet, a posting that smells fake, a feature you want. I read it and answer myself, and it is small enough that you will actually be heard.</p>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">It is also a community of job seekers sharing how the search actually goes: what got a reply and what got silence, a CV rewritten until it started landing interviews, whether a company is really hiring or just collecting CVs, what the offer came in at. That half I can’t build — it only exists because people show up.</p>
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="https://discord.gg/Cghjh3dA5N" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;"><img src="./email-icon-discord.png" width="18" height="18" alt="" class="m-logo" style="vertical-align:-3px;border:0;padding-right:9px;">Join the Discord</a></td></tr></table>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="https://discord.gg/79cgB9RRfx" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;"><img src="./email-icon-discord.png" width="18" height="18" alt="" class="m-logo" style="vertical-align:-3px;border:0;padding-right:9px;">Join the Discord</a></td></tr></table>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">And if the project has been useful, a star is how most people end up finding it — <a href="https://github.com/strelov1/freehire" class="m-link" style="color:#4c5c00;text-decoration:underline;">star it on GitHub</a></p>
 <p class="m-muted" style="margin:0 0 14px 0;font-size:14px;line-height:1.6;color:#505050;">Replying to this mail reaches me too.</p>
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin-top:22px;">
@@ -69,7 +69,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/onboarding-open-source.light.html
+++ b/design-system/static/email-previews/onboarding-open-source.light.html
@@ -29,7 +29,7 @@
 <p class="m-ink" style="margin:0 0 14px 0;font-size:17px;line-height:1.5;font-weight:600;color:#070707;">The Discord is where the rest of it happens.</p>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">It is the main place to ask anything — a filter that misbehaves, a board we don’t cover yet, a posting that smells fake, a feature you want. I read it and answer myself, and it is small enough that you will actually be heard.</p>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">It is also a community of job seekers sharing how the search actually goes: what got a reply and what got silence, a CV rewritten until it started landing interviews, whether a company is really hiring or just collecting CVs, what the offer came in at. That half I can’t build — it only exists because people show up.</p>
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="https://discord.gg/Cghjh3dA5N" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;"><img src="./email-icon-discord.png" width="18" height="18" alt="" class="m-logo" style="vertical-align:-3px;border:0;padding-right:9px;">Join the Discord</a></td></tr></table>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 14px 0;"><tr><td class="m-btn" style="background:#5b6f00;border-radius:8px;"><a href="https://discord.gg/79cgB9RRfx" class="m-btn-a" style="display:inline-block;padding:11px 20px;font-size:15px;font-weight:600;color:#f3f6e2;text-decoration:none;"><img src="./email-icon-discord.png" width="18" height="18" alt="" class="m-logo" style="vertical-align:-3px;border:0;padding-right:9px;">Join the Discord</a></td></tr></table>
 <p class="m-ink" style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#070707;">And if the project has been useful, a star is how most people end up finding it — <a href="https://github.com/strelov1/freehire" class="m-link" style="color:#4c5c00;text-decoration:underline;">star it on GitHub</a></p>
 <p class="m-muted" style="margin:0 0 14px 0;font-size:14px;line-height:1.6;color:#505050;">Replying to this mail reaches me too.</p>
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin-top:22px;">
@@ -56,7 +56,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/onboarding-welcome.dark.html
+++ b/design-system/static/email-previews/onboarding-welcome.dark.html
@@ -67,7 +67,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/onboarding-welcome.html
+++ b/design-system/static/email-previews/onboarding-welcome.html
@@ -67,7 +67,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/onboarding-welcome.light.html
+++ b/design-system/static/email-previews/onboarding-welcome.light.html
@@ -54,7 +54,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/password-reset.dark.html
+++ b/design-system/static/email-previews/password-reset.dark.html
@@ -51,7 +51,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         
       </td></tr>
 

--- a/design-system/static/email-previews/password-reset.html
+++ b/design-system/static/email-previews/password-reset.html
@@ -51,7 +51,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         
       </td></tr>
 

--- a/design-system/static/email-previews/password-reset.light.html
+++ b/design-system/static/email-previews/password-reset.light.html
@@ -38,7 +38,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         
       </td></tr>
 

--- a/design-system/static/email-previews/referral-request.dark.html
+++ b/design-system/static/email-previews/referral-request.dark.html
@@ -49,7 +49,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/referral-request.html
+++ b/design-system/static/email-previews/referral-request.html
@@ -49,7 +49,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/referral-request.light.html
+++ b/design-system/static/email-previews/referral-request.light.html
@@ -36,7 +36,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/report-dismissed.dark.html
+++ b/design-system/static/email-previews/report-dismissed.dark.html
@@ -54,7 +54,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/report-dismissed.html
+++ b/design-system/static/email-previews/report-dismissed.html
@@ -54,7 +54,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/report-dismissed.light.html
+++ b/design-system/static/email-previews/report-dismissed.light.html
@@ -41,7 +41,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/report-job-removed.dark.html
+++ b/design-system/static/email-previews/report-job-removed.dark.html
@@ -54,7 +54,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/report-job-removed.html
+++ b/design-system/static/email-previews/report-job-removed.html
@@ -54,7 +54,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/report-job-removed.light.html
+++ b/design-system/static/email-previews/report-job-removed.light.html
@@ -41,7 +41,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/saved-job-reminder-batch.dark.html
+++ b/design-system/static/email-previews/saved-job-reminder-batch.dark.html
@@ -96,7 +96,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/saved-job-reminder-batch.html
+++ b/design-system/static/email-previews/saved-job-reminder-batch.html
@@ -96,7 +96,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/saved-job-reminder-batch.light.html
+++ b/design-system/static/email-previews/saved-job-reminder-batch.light.html
@@ -83,7 +83,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/saved-job-reminder.dark.html
+++ b/design-system/static/email-previews/saved-job-reminder.dark.html
@@ -63,7 +63,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/saved-job-reminder.html
+++ b/design-system/static/email-previews/saved-job-reminder.html
@@ -63,7 +63,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/saved-job-reminder.light.html
+++ b/design-system/static/email-previews/saved-job-reminder.light.html
@@ -50,7 +50,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/subscription-digest.dark.html
+++ b/design-system/static/email-previews/subscription-digest.dark.html
@@ -95,7 +95,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/subscription-digest.html
+++ b/design-system/static/email-previews/subscription-digest.html
@@ -95,7 +95,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/subscription-digest.light.html
+++ b/design-system/static/email-previews/subscription-digest.light.html
@@ -82,7 +82,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         <br><a href="./my/notifications" class="m-muted" style="color:#505050;text-decoration:underline;">Turn off these notifications</a>
       </td></tr>
 

--- a/design-system/static/email-previews/verify-email.dark.html
+++ b/design-system/static/email-previews/verify-email.dark.html
@@ -51,7 +51,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         
       </td></tr>
 

--- a/design-system/static/email-previews/verify-email.html
+++ b/design-system/static/email-previews/verify-email.html
@@ -51,7 +51,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         
       </td></tr>
 

--- a/design-system/static/email-previews/verify-email.light.html
+++ b/design-system/static/email-previews/verify-email.light.html
@@ -38,7 +38,7 @@
 
       <tr><td class="m-muted" style="padding:16px 8px 0 8px;font-size:12px;line-height:1.6;color:#505050;">
         <a href="." class="m-muted" style="color:#505050;text-decoration:none;">freehire.me</a> — job search without the noise.
-        <br><a href="https://discord.gg/Cghjh3dA5N" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
+        <br><a href="https://discord.gg/79cgB9RRfx" class="m-muted" style="color:#505050;text-decoration:underline;">Job hunting with us on Discord</a>
         
       </td></tr>
 

--- a/docs/superpowers/specs/2026-09-06-discord-paid-channels-design.md
+++ b/docs/superpowers/specs/2026-09-06-discord-paid-channels-design.md
@@ -5,7 +5,7 @@ Date: 2026-09-06
 ## Problem
 
 `freehire.me` sells Pro ($5) and Ultra ($19). The community Discord
-(`discord.gg/Cghjh3dA5N`) is entirely public, so a subscription buys nothing there.
+(`discord.gg/79cgB9RRfx`) is entirely public, so a subscription buys nothing there.
 We want a set of channels only paying subscribers can see, with access that appears
 when they pay and disappears when they stop.
 

--- a/internal/application/mailtpl/mailtpl.go
+++ b/internal/application/mailtpl/mailtpl.go
@@ -34,11 +34,13 @@ import (
 // two mail packages before that, and a mirror is a link that can disagree with
 // itself.
 //
-// It must be an invite that never expires and has no use cap. A mail is read weeks
-// after it is sent, and a default Discord invite dies after seven days: the letter
-// would keep going out and keep landing on "Invite Invalid", which looks exactly
-// like a project that has folded.
-const DiscordURL = "https://discord.gg/Cghjh3dA5N"
+// It must be an invite that never expires, has no use cap, and opens on a channel a
+// stranger can read. A mail is read weeks after it is sent, and a default Discord
+// invite dies after seven days: the letter would keep going out and keep landing on
+// "Invite Invalid", which looks exactly like a project that has folded. The first
+// one that went out opened on #github, where the repository's webhook posts, so
+// everyone who accepted it arrived in a stream of bot messages.
+const DiscordURL = "https://discord.gg/79cgB9RRfx"
 
 // Palette, converted from design-system/tokens/color.tokens.json. The tokens are
 // authored in oklch and mail clients cannot parse that function, so the values are

--- a/web/src/lib/socialLinks.ts
+++ b/web/src/lib/socialLinks.ts
@@ -7,7 +7,7 @@ import { GITHUB_URL } from './github.svelte';
 /** The community invite. Exported because the header menu offers the same room the
  *  footer's socials row does, and it used to carry its own copy of the URL — the
  *  drift this file's own comment warns about, one import away from being real. */
-export const DISCORD_URL = 'https://discord.gg/Cghjh3dA5N';
+export const DISCORD_URL = 'https://discord.gg/79cgB9RRfx';
 
 export const SOCIAL_LINKS: { provider: string; label: string; href: string }[] = [
   { provider: 'github', label: 'GitHub', href: GITHUB_URL },

--- a/web/src/posts/2026-08-01-launching-on-product-hunt-on-26-august.svx
+++ b/web/src/posts/2026-08-01-launching-on-product-hunt-on-26-august.svx
@@ -23,5 +23,5 @@ single day is a bad way to find out whether anything is broken. Between now and 
 we would rather hear what does not work than collect a good number. If a filter
 misses jobs you know exist, a company page looks wrong, or a source you rely on is
 missing, tell us — on [GitHub](https://github.com/strelov1/freehire),
-[Telegram](https://t.me/freehiredev), or [Discord](https://discord.gg/Cghjh3dA5N).
+[Telegram](https://t.me/freehiredev), or [Discord](https://discord.gg/79cgB9RRfx).
 Everything reported before the 26th has a chance of being fixed by it.


### PR DESCRIPTION
The invite that went out to 1601 people opened on `#github`, where the repository's webhook posts every commit and pull request. Everyone who accepted it arrived in a stream of bot messages — the opposite of what the letter promised.

The replacement opens on `#general`. Same shape otherwise: never expires, no use cap (verified against Discord's invite API). Why the channel matters is now recorded beside the constant, so the next invite isn't picked by whichever channel happened to be open.

Nobody already on the server is affected. What this fixes is the onboarding sequence and every mail's footer, which keep handing the link out daily.

Previews regenerated; `go test ./internal/...` and web lint green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Discord links across the website, email previews, blog content, documentation, and account emails now direct to the new invite URL: `https://discord.gg/79cgB9RRfx`.
  - Link text, styling, and surrounding content remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->