### PR TITLE
Swap the pill Tabs for TabStrip on /status, shrink the status banners

### DIFF
--- a/design-system/scripts/adoption-baseline.json
+++ b/design-system/scripts/adoption-baseline.json
@@ -22,7 +22,7 @@
   "SettingRow": 3,
   "Skeleton": 2,
   "Table": 8,
-  "Tabs": 1,
-  "TabStrip": 9,
+  "Tabs": 0,
+  "TabStrip": 10,
   "Tooltip": 2
 }

--- a/web/src/lib/components/StatusBoard.svelte
+++ b/web/src/lib/components/StatusBoard.svelte
@@ -4,7 +4,7 @@
   // other surface uses: a provider must not be "WhatJobs" on the filter panel and
   // "Whatjobs" here.
   import { sourceLabel } from '$lib/facets';
-  import { Tabs } from '$lib/ui';
+  import { TabStrip, tabStripId } from '$lib/ui';
   import type { HealthStatus, IngestStatus, ProviderKind } from '$lib/types';
 
   // The presentational half of the /status page: given the status read (or null
@@ -92,10 +92,14 @@
   // The site/API and the ingest fleet are different concerns (see SITE_HEADLINE's
   // comment above) — tabs keep them from competing for the same screen instead of
   // stacking sections a visitor has to scroll past to reach the one they want.
+  // TabStrip (the underline style every /my/* section nav already uses), not the
+  // pill/segmented Tabs primitive — this page reads as part of the same product,
+  // not a different widget kit bolted on.
   const SECTION_TABS = [
-    { value: 'site', label: 'Site status' },
-    { value: 'fleet', label: 'Ingest fleet' },
-  ];
+    { id: 'site', label: 'Site status' },
+    { id: 'fleet', label: 'Ingest fleet' },
+  ] as const;
+  const SECTION_PANEL_ID = 'status-section-panel';
   let activeSection = $state<'site' | 'fleet'>('site');
 
   // Worst-first, then alphabetical — problem providers surface at the top.
@@ -134,14 +138,27 @@
     Status is unavailable right now. Try again in a moment.
   </div>
 {:else}
-  <Tabs tabs={SECTION_TABS} bind:value={activeSection}>
+  <TabStrip
+    tabs={SECTION_TABS}
+    active={activeSection}
+    onSelect={(id) => (activeSection = id)}
+    label="Status sections"
+    panelId={SECTION_PANEL_ID}
+  />
+
+  <div
+    id={SECTION_PANEL_ID}
+    role="tabpanel"
+    aria-labelledby={tabStripId(SECTION_PANEL_ID, activeSection)}
+    class="mt-6"
+  >
     {#if activeSection === 'site'}
       {#if site}
         <!-- Site status: is freehire.me itself working, independent of the ingest fleet tab. -->
-        <div class="flex items-center gap-4 rounded-xl border p-5 sm:p-6 {STATUS_META[site.status].pill}">
-          <span class="inline-flex h-3 w-3 shrink-0 rounded-full {STATUS_META[site.status].dot}"></span>
+        <div class="flex items-center gap-3 rounded-lg border p-4 {STATUS_META[site.status].pill}">
+          <span class="inline-flex h-2.5 w-2.5 shrink-0 rounded-full {STATUS_META[site.status].dot}"></span>
           <div>
-            <div class="text-lg font-semibold tracking-tight">{SITE_HEADLINE[site.status]}</div>
+            <div class="text-base font-semibold tracking-tight">{SITE_HEADLINE[site.status]}</div>
             <div class="text-sm opacity-80">
               Database {site.database} · {nfPercent.format(site.error_rate)} error rate over the last {site.window_minutes} min
             </div>
@@ -174,10 +191,10 @@
       {/if}
     {:else}
       <!-- Overall banner -->
-      <div class="flex items-center gap-4 rounded-xl border p-5 sm:p-6 {STATUS_META[overall].pill}">
-        <span class="inline-flex h-3 w-3 shrink-0 rounded-full {STATUS_META[overall].dot}"></span>
+      <div class="flex items-center gap-3 rounded-lg border p-4 {STATUS_META[overall].pill}">
+        <span class="inline-flex h-2.5 w-2.5 shrink-0 rounded-full {STATUS_META[overall].dot}"></span>
         <div>
-          <div class="text-lg font-semibold tracking-tight">{OVERALL_HEADLINE[overall]}</div>
+          <div class="text-base font-semibold tracking-tight">{OVERALL_HEADLINE[overall]}</div>
           <div class="text-sm opacity-80">
             {providers.length} provider{providers.length === 1 ? '' : 's'} monitored
           </div>
@@ -279,5 +296,5 @@
         {/if}
       </section>
     {/if}
-  </Tabs>
+  </div>
 {/if}


### PR DESCRIPTION
## Summary
- User feedback on #2586's tab redesign: the pill/segmented `Tabs` control looked out of place, and the "API operational" banner was too big.
- Swaps to `TabStrip` — the underline-style tab navigation every `/my/*` account section already uses — so `/status` reads as part of the same product instead of a different widget kit.
- Shrinks both status banners (site status, ingest fleet overall) from `p-5/p-6` + `text-lg` down to `p-4` + `text-base`, matching the visual weight of the provider list rows below them.

## Test plan
- [x] `svelte-check`: 0 errors
- [x] `check:dead`, `check:tokens` clean; `check:adoption` baseline updated (`Tabs` 1→0, `TabStrip` 9→10 — a deliberate swap, not a regression)
- [x] Manually verified against a real local Postgres + `cmd/server`, screenshots of both tabs: underline tabs render correctly, tab switching works, both banners are visibly more compact, history strip colors unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated the Status page to use an underline-style tab navigation.
  - Improved accessibility by associating the tab navigation with its content panel.
  - Refined status cards with more compact spacing, padding, indicators, and headlines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->