### PR TITLE
Point the Rippling adapter at the host that still answers

### DIFF
--- a/internal/ingest/sources/rippling.go
+++ b/internal/ingest/sources/rippling.go
@@ -5,9 +5,13 @@ import (
 	"fmt"
 )
 
-// ripplingBaseURL is the Rippling public ATS board API root.
+// ripplingBaseURL is the Rippling public ATS board API root. The `ats.rippling.com`
+// host is the live one and a superset: it serves every board the legacy
+// `api.rippling.com/platform/api/ats/v1` host did, plus boards created on Rippling's
+// newer ATS (e.g. `whitehatgaming`) that the legacy host answers 404 for. The path
+// shape and JSON are identical across both, so this is a host swap and nothing more.
 const (
-	ripplingBaseURL = "https://api.rippling.com/platform/api/ats/v1/board"
+	ripplingBaseURL = "https://ats.rippling.com/api/v1/board"
 )
 
 // rippling adapts the Rippling public ATS board API. Its list endpoint carries no


### PR DESCRIPTION
The legacy `api.rippling.com` board host 404s for boards created on Rippling's newer ATS (e.g. `whitehatgaming`), so those boards could not be harvested or crawled. `ats.rippling.com/api/v1/board` is a superset — identical path shape and JSON, plus the newer boards — verified against several existing boards (200/200) and `whitehatgaming` (legacy 404, new 200).

Host swap only; adapter mapping and tests unchanged.