### PR TITLE
Say which permission is missing instead of naming the user

### DIFF
--- a/.github/scripts/check-contributors-token.sh
+++ b/.github/scripts/check-contributors-token.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Asks, before any work is done, whether CONTRIBUTORS_TOKEN can actually write to this
+# repository — and says what to fix when it cannot.
+#
+# This exists because the failure it replaces was unreadable. A token missing one
+# permission got all the way to `git push` and came back
+#
+#     remote: Permission to <owner>/<repo>.git denied to <user>.
+#     fatal: ... The requested URL returned error: 403
+#
+# which names the user rather than the missing permission, and reads like the account
+# is wrong when the account is fine. Everything about this job that can go wrong is a
+# credential, so the credential is checked first and reported in words someone can act
+# on. The repository's own permissions are what is read, so nothing about the token is
+# printed.
+set -euo pipefail
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+
+# `|| true`: an unusable token exits non-zero here, and under `set -e` that would kill
+# the script before it could explain itself — which is the whole failure this replaces.
+push=$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.permissions.push' 2>/dev/null || true)
+
+if [ "$push" = "true" ]; then
+  echo "CONTRIBUTORS_TOKEN can write to ${GITHUB_REPOSITORY}."
+  exit 0
+fi
+
+echo "CONTRIBUTORS_TOKEN cannot write to ${GITHUB_REPOSITORY} (repository reports push=${push:-<no answer>})."
+echo
+echo 'An empty answer means the token was rejected outright — wrong value, expired, or'
+echo 'not granted access to this repository. "false" means it was accepted and simply'
+echo 'has no write permission.'
+echo
+echo 'A fine-grained token needs all three:'
+echo '  Repository access ....... Only select repositories, including this one'
+echo '  Contents ................ Read and write'
+echo '  Pull requests ........... Read and write'
+echo
+echo 'A classic token needs the "repo" scope.'
+exit 1

--- a/.github/scripts/check-contributors-token.sh
+++ b/.github/scripts/check-contributors-token.sh
@@ -3,39 +3,58 @@
 # repository — and says what to fix when it cannot.
 #
 # This exists because the failure it replaces was unreadable. A token missing one
-# permission got all the way to `git push` and came back
+# permission got all the way to `git push`, after thirty API calls of collection, and
+# came back
 #
 #     remote: Permission to <owner>/<repo>.git denied to <user>.
 #     fatal: ... The requested URL returned error: 403
 #
-# which names the user rather than the missing permission, and reads like the account
-# is wrong when the account is fine. Everything about this job that can go wrong is a
-# credential, so the credential is checked first and reported in words someone can act
-# on. The repository's own permissions are what is read, so nothing about the token is
-# printed.
-set -euo pipefail
+# which names the user rather than the missing permission, and reads like the account is
+# wrong when the account is fine.
+#
+# IT PROBES A REAL WRITE, AND THAT IS THE WHOLE POINT. The obvious check —
+# `repos/{owner}/{repo}` and its `.permissions.push` — is a trap: that field reports the
+# ROLE OF THE USER the token belongs to, not what the token was granted. A read-only
+# fine-grained token held by an admin reports `push: true` and then cannot push, so the
+# check would print a confident green and the job would fail anyway. A false green is
+# worse than no check. Creating a ref and deleting it is the only answer that comes from
+# the token's own permissions.
+#
+# The probe is safe: the branch exists for one API call, and creating a branch triggers
+# no workflows here — CI fires on pushes to main and on pull requests, neither of which
+# this is.
+set -uo pipefail
 
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
 
-# `|| true`: an unusable token exits non-zero here, and under `set -e` that would kill
-# the script before it could explain itself — which is the whole failure this replaces.
-push=$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.permissions.push' 2>/dev/null || true)
+PROBE_REF='refs/heads/contributors-token-write-probe'
 
-if [ "$push" = "true" ]; then
-  echo "CONTRIBUTORS_TOKEN can write to ${GITHUB_REPOSITORY}."
-  exit 0
+explain() {
+  echo "CONTRIBUTORS_TOKEN cannot write to ${GITHUB_REPOSITORY}."
+  echo
+  echo 'A fine-grained token needs all three:'
+  echo '  Repository access ....... Only select repositories, including this one'
+  echo '  Contents ................ Read and write   <- the one this usually is'
+  echo '  Pull requests ........... Read and write'
+  echo
+  echo 'A classic token needs the "repo" scope.'
+  echo
+  echo 'Note that the repository page reporting "push: true" for your account proves'
+  echo 'nothing about the token: that is your role, not its grant.'
+}
+
+sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${GITHUB_REF_NAME:-main}" --jq '.object.sha' 2>/dev/null || true)
+if [ -z "$sha" ]; then
+  echo "CONTRIBUTORS_TOKEN cannot even read ${GITHUB_REPOSITORY} — wrong value, expired, or not granted access to this repository."
+  echo
+  explain
+  exit 1
 fi
 
-echo "CONTRIBUTORS_TOKEN cannot write to ${GITHUB_REPOSITORY} (repository reports push=${push:-<no answer>})."
-echo
-echo 'An empty answer means the token was rejected outright — wrong value, expired, or'
-echo 'not granted access to this repository. "false" means it was accepted and simply'
-echo 'has no write permission.'
-echo
-echo 'A fine-grained token needs all three:'
-echo '  Repository access ....... Only select repositories, including this one'
-echo '  Contents ................ Read and write'
-echo '  Pull requests ........... Read and write'
-echo
-echo 'A classic token needs the "repo" scope.'
-exit 1
+if ! gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" -f ref="$PROBE_REF" -f sha="$sha" >/dev/null 2>&1; then
+  explain
+  exit 1
+fi
+
+gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/${PROBE_REF}" >/dev/null 2>&1 || true
+echo "CONTRIBUTORS_TOKEN can write to ${GITHUB_REPOSITORY}."

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -64,6 +64,15 @@ jobs:
           # GITHUB_TOKEN and the pull request would never get its checks.
           token: ${{ secrets.CONTRIBUTORS_TOKEN }}
 
+      # Before anything else, because everything that can go wrong with this job is a
+      # credential and the failure it replaces named the user rather than the missing
+      # permission. Cheap: one API call, no work done yet, nothing to undo.
+      - name: Check the token can write
+        if: steps.token.outputs.present == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CONTRIBUTORS_TOKEN }}
+        run: .github/scripts/check-contributors-token.sh
+
       - name: Set up Node
         if: steps.token.outputs.present == 'true'
         uses: actions/setup-node@v7


### PR DESCRIPTION
The contributors job fails on a credential or it does not fail at all, and the failure it produced was unreadable:

```
remote: Permission to strelov1/freehire.git denied to strelov1.
fatal: ... The requested URL returned error: 403
```

That names the account rather than the missing permission, arrives deep inside `git push` after the collection has already spent thirty API calls, and reads like the account is wrong when the account is fine. Four runs went into it and none of them said anything the next one could use.

So the credential is checked first, before any work, and reported in words someone can act on.

## It probes a real write, and that is the whole point

The obvious check — `repos/{owner}/{repo}` and its `.permissions.push` — is a trap. That field reports the **role of the user the token belongs to**, not what the token was granted. Measured against the token this repository was actually handed:

- `GET repos/strelov1/freehire` → `"push": true`
- `POST .../git/refs` with the same token → `403 Resource not accessible by personal access token`

The first version of this check read that field. It would have printed a confident green and the job would have failed anyway — worse than having no check at all.

Creating a ref and deleting it is the only answer that comes from the token's own permissions. The probe branch exists for one API call, and creating a branch triggers no workflows here: CI fires on pushes to `main` and on pull requests, neither of which this is.

The guidance names the trap as well, so the next person debugging this does not read the same misleading field and conclude the token is fine.
