### PR TITLE
Pause the contributors schedule while its token cannot write

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -30,9 +30,21 @@ name: contributors
 # is created, skips the whole job rather than failing a scheduled run every night with
 # an error nobody can act on.
 
+# THE SCHEDULE IS OFF UNTIL CONTRIBUTORS_TOKEN CAN WRITE. It is not off because the
+# cadence was wrong — 04:20 UTC is deliberate, clear of the nightly pg_dump window that
+# starts at 03:00, so a deploy this triggers does not queue behind it. Restoring it is
+# uncommenting these two lines.
+#
+# It is off because the token in the secret currently has read access only, so every
+# nightly run would fail and mail a failure nobody can act on except by fixing the
+# token. A job that fails every night stops being read, and then it is not a signal at
+# all — which costs more than the days of staleness this saves.
+#
+# The preflight check below reports the token's real state in one API call, so the way
+# to find out whether this can come back is to run it by hand and read the first step.
 on:
-  schedule:
-    - cron: '20 4 * * *'
+  # schedule:
+  #   - cron: '20 4 * * *'
   workflow_dispatch:
 
 permissions:

--- a/openspec/changes/add-contributors-page/tasks.md
+++ b/openspec/changes/add-contributors-page/tasks.md
@@ -59,7 +59,9 @@
 - [x] 7.4 Trigger the workflow manually (`workflow_dispatch`) — which is what showed the push to main is rejected: main requires three checks and enforces them on admins.
 - [x] 7.5 Rework it to push a branch and open a pull request with auto-merge, carrying `CONTRIBUTORS_TOKEN` rather than `GITHUB_TOKEN` — a branch pushed with the latter triggers no checks, so its pull request could never merge.
 - [x] 7.6 Skip every step when the secret is absent, so a fork and a not-yet-configured repository are a clean no-op rather than a nightly failure.
-- [ ] 7.7 Create the fine-grained `CONTRIBUTORS_TOKEN` secret, then trigger the workflow twice: the first run opens a pull request, the second finds nothing to do.
+- [x] 7.7 Add a preflight that probes a real write and names the missing permission, after four runs whose only symptom was a 403 naming the account.
+- [x] 7.8 Comment out the schedule while the token cannot write, so a job that would fail every night does not become unread mail. Manual dispatch still works, and the preflight reports the token's state in one API call.
+- [ ] 7.9 Give `CONTRIBUTORS_TOKEN` **Contents: Read and write** (it currently reads only), uncomment the schedule, then trigger the workflow twice: the first run opens a pull request, the second finds nothing to do.
 
 ## 8. Verification
 


### PR DESCRIPTION
The token in `CONTRIBUTORS_TOKEN` has read access only, so every nightly run would fail and mail a failure nobody can act on except by fixing the token. A job that fails every night stops being read, and an unread signal is worse than no signal — it costs more than the days of staleness this saves.

**The cadence was not the problem** and is left in place, commented, with its reason intact: 04:20 UTC is clear of the nightly `pg_dump` window that starts at 03:00, so a deploy this triggers does not queue behind it. Restoring it is uncommenting two lines.

Manual dispatch still works, and the preflight from #2594 reports the token's real state in one API call — so finding out whether the schedule can come back is one run and one line of output:

```
CONTRIBUTORS_TOKEN cannot write to strelov1/freehire.
  Contents ................ Read and write   <- the one this usually is
```

## To turn it back on

1. Give the token **Contents: Read and write** (Pull requests: Read and write too).
2. Uncomment the two `schedule` lines.
3. Trigger it twice: the first run opens a pull request, the second finds nothing to do.

Nothing else in the feature depends on this. `/contributors` and every profile page are live and serving the committed snapshot; only its automatic refresh is paused. Refreshing by hand stays one command:

```
GITHUB_TOKEN=$(gh auth token) node web/scripts/build-contributors.mjs
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Nightly automated contributor updates are temporarily paused.
  - Manual runs remain available.
  - Setup guidance now includes preflight checks, permission requirements, schedule restoration steps, and verification of pull-request creation and no-op behavior on repeat runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->