### PR TITLE
Group same-company bursts and show a live ticking age on feed cards

### DIFF
--- a/internal/job/recentfeed/entry.go
+++ b/internal/job/recentfeed/entry.go
@@ -4,6 +4,8 @@
 // openspec/changes/add-homepage-recent-jobs-feed for the product and design context.
 package recentfeed
 
+import "time"
+
 // Kind distinguishes a feed Entry that represents one posting from one that
 // represents an aggregated burst of postings for the same role.
 type Kind string
@@ -11,25 +13,42 @@ type Kind string
 const (
 	// KindSingle is one eligible posting.
 	KindSingle Kind = "single"
-	// KindAggregate is a burst of postings for the same role, collapsed into one
-	// entry once their count reaches AggregationThreshold. It names a
-	// representative posting's title and company but must never be presented as
-	// if all counted postings came from that one company — see design.md,
-	// "Aggregated entries do not attribute a single company".
+	// KindAggregate is a burst of postings for the same role across different
+	// companies, collapsed into one entry once their count reaches
+	// AggregationThreshold. It names a representative posting's title and
+	// company but must never be presented as if all counted postings came from
+	// that one company — see design.md, "Aggregated entries do not attribute a
+	// single company".
 	KindAggregate Kind = "aggregate"
+	// KindCompanyAggregate is the other direction of burst: one company posting
+	// many DIFFERENT roles at once (a mass hiring push), collapsed into one
+	// entry once their count reaches AggregationThreshold. A posting already
+	// counted toward a KindAggregate entry is never also counted here — see
+	// Group's two-pass ordering.
+	KindCompanyAggregate Kind = "company_aggregate"
 )
 
 // Entry is one item in the live feed, ready to serialize as an SSE event.
 type Entry struct {
 	Kind Kind `json:"kind"`
-	// Title and CompanyName are always populated: on a KindAggregate entry they
-	// come from one representative posting in the group, not a synthesized label.
+	// Title and CompanyName are always populated. On a KindAggregate entry they
+	// come from one representative posting in the group, not a synthesized
+	// label. On a KindCompanyAggregate entry CompanyName is exact (the one
+	// company the whole entry is about) and Title is one representative role
+	// from the burst.
 	Title       string `json:"title"`
 	CompanyName string `json:"company_name"`
-	// JobSlug links a KindSingle entry to its posting. Empty on KindAggregate,
-	// which links to the catalogue instead (there is no single posting to link to).
+	// JobSlug links a KindSingle entry to its posting. Empty on either
+	// aggregate kind, which links to the catalogue instead (there is no single
+	// posting to link to).
 	JobSlug string `json:"job_slug,omitempty"`
-	// Count is the number of postings a KindAggregate entry represents. Unused
-	// (zero) on KindSingle, which is always exactly one posting.
+	// Count is the number of postings an aggregate entry (either kind)
+	// represents. Unused (zero) on KindSingle, which is always exactly one
+	// posting.
 	Count int `json:"count,omitempty"`
+	// ProducedAt is when the Poller emitted this entry (not when the
+	// underlying posting was ingested) — stamped once, so it stays fixed as
+	// the entry sits in the Broadcaster's backlog and a client renders a
+	// live-ticking "N seconds ago" against it.
+	ProducedAt time.Time `json:"produced_at"`
 }

--- a/internal/job/recentfeed/entry.go
+++ b/internal/job/recentfeed/entry.go
@@ -1,13 +1,16 @@
 // Package recentfeed drains recent_feed_outbox and turns it into the homepage's
-// live "recently added jobs" feed: grouping bursts of same-role postings into one
-// aggregated entry, and broadcasting the result to connected SSE clients. See
-// openspec/changes/add-homepage-recent-jobs-feed for the product and design context.
+// live "recently added jobs" feed: grouping bursts of same-role or same-company
+// postings into one aggregated entry, and broadcasting the result to connected
+// SSE clients. See openspec/changes/add-homepage-recent-jobs-feed for the
+// product and design context.
 package recentfeed
 
 import "time"
 
 // Kind distinguishes a feed Entry that represents one posting from one that
-// represents an aggregated burst of postings for the same role.
+// represents an aggregated burst of postings — either the same role across
+// companies (KindAggregate) or the same company across roles
+// (KindCompanyAggregate).
 type Kind string
 
 const (

--- a/internal/job/recentfeed/grouping.go
+++ b/internal/job/recentfeed/grouping.go
@@ -13,6 +13,11 @@ const AggregationThreshold = 5
 type Posting struct {
 	Title       string
 	CompanyName string
+	// CompanySlug is the canonical company identity Group's company-aggregation
+	// pass keys on — never CompanyName, which is free text and varies in
+	// spelling/punctuation for one employer (see AGENTS.md, "Company key:
+	// normalize.CompanySlug", and docs/agents/company-identity.md).
+	CompanySlug string
 	JobSlug     string
 }
 
@@ -23,10 +28,11 @@ type Posting struct {
 //     AggregationThreshold — the same role posted by several different
 //     companies — collapses into one KindAggregate entry naming a
 //     representative posting. Everything else is left over for pass 2.
-//  2. Bucket what's left by CompanyName. A bucket at or above
-//     AggregationThreshold — one company posting several different roles at
-//     once, a mass hiring push — collapses into one KindCompanyAggregate
-//     entry. Everything still left over becomes a KindSingle entry.
+//  2. Bucket what's left by CompanySlug (never CompanyName — see Posting).
+//     A bucket at or above AggregationThreshold — one company posting several
+//     different roles at once, a mass hiring push — collapses into one
+//     KindCompanyAggregate entry. Everything still left over becomes a
+//     KindSingle entry.
 //
 // Buckets in each pass are emitted in first-seen order. Because pass 2 only
 // ever sees postings pass 1 did not already aggregate, the result partitions
@@ -41,7 +47,7 @@ func Group(postings []Posting) []Entry {
 		return jobhash.NormalizedRoleTitle(p.Title)
 	})
 	companyAggregates, leftover := aggregateBy(leftover, KindCompanyAggregate, func(p Posting) string {
-		return p.CompanyName
+		return p.CompanySlug
 	})
 
 	entries := make([]Entry, 0, len(postings))

--- a/internal/job/recentfeed/grouping.go
+++ b/internal/job/recentfeed/grouping.go
@@ -16,36 +16,72 @@ type Posting struct {
 	JobSlug     string
 }
 
-// Group buckets postings by jobhash.NormalizedRoleTitle and turns each bucket into
-// one or more Entry values: a bucket below AggregationThreshold yields one
-// KindSingle Entry per posting; a bucket at or above it yields one KindAggregate
-// Entry naming a representative posting from the bucket. Buckets are emitted in
-// first-seen order, and postings within a KindSingle bucket keep their given
-// order, so the result reads in the same order postings were claimed.
+// Group runs two aggregation passes over a claimed batch, so a single posting is
+// never counted toward both:
+//
+//  1. Bucket by jobhash.NormalizedRoleTitle. A bucket at or above
+//     AggregationThreshold — the same role posted by several different
+//     companies — collapses into one KindAggregate entry naming a
+//     representative posting. Everything else becomes a candidate for pass 2.
+//  2. Bucket the remaining candidates by CompanyName. A bucket at or above
+//     AggregationThreshold — one company posting several different roles at
+//     once, a mass hiring push — collapses into one KindCompanyAggregate
+//     entry. Everything still left over becomes a KindSingle entry.
+//
+// Buckets in each pass are emitted in first-seen order. Because pass 2 only
+// ever sees postings pass 1 did not already aggregate, the result partitions
+// the input exactly — role-aggregates first, then company-aggregates and
+// remaining singles.
 func Group(postings []Posting) []Entry {
 	if len(postings) == 0 {
 		return nil
 	}
 
-	var order []string
-	buckets := make(map[string][]Posting, len(postings))
+	entries := make([]Entry, 0, len(postings))
+
+	var roleOrder []string
+	roleBuckets := make(map[string][]Posting, len(postings))
 	for _, p := range postings {
 		key := jobhash.NormalizedRoleTitle(p.Title)
-		if _, seen := buckets[key]; !seen {
-			order = append(order, key)
+		if _, seen := roleBuckets[key]; !seen {
+			roleOrder = append(roleOrder, key)
 		}
-		buckets[key] = append(buckets[key], p)
+		roleBuckets[key] = append(roleBuckets[key], p)
 	}
 
-	entries := make([]Entry, 0, len(postings))
-	for _, key := range order {
-		bucket := buckets[key]
+	var candidates []Posting
+	for _, key := range roleOrder {
+		bucket := roleBuckets[key]
 		if len(bucket) >= AggregationThreshold {
 			sample := bucket[0]
 			entries = append(entries, Entry{
 				Kind:        KindAggregate,
 				Title:       sample.Title,
 				CompanyName: sample.CompanyName,
+				Count:       len(bucket),
+			})
+			continue
+		}
+		candidates = append(candidates, bucket...)
+	}
+
+	var companyOrder []string
+	companyBuckets := make(map[string][]Posting, len(candidates))
+	for _, p := range candidates {
+		if _, seen := companyBuckets[p.CompanyName]; !seen {
+			companyOrder = append(companyOrder, p.CompanyName)
+		}
+		companyBuckets[p.CompanyName] = append(companyBuckets[p.CompanyName], p)
+	}
+
+	for _, company := range companyOrder {
+		bucket := companyBuckets[company]
+		if len(bucket) >= AggregationThreshold {
+			sample := bucket[0]
+			entries = append(entries, Entry{
+				Kind:        KindCompanyAggregate,
+				Title:       sample.Title,
+				CompanyName: company,
 				Count:       len(bucket),
 			})
 			continue

--- a/internal/job/recentfeed/grouping.go
+++ b/internal/job/recentfeed/grouping.go
@@ -22,8 +22,8 @@ type Posting struct {
 //  1. Bucket by jobhash.NormalizedRoleTitle. A bucket at or above
 //     AggregationThreshold — the same role posted by several different
 //     companies — collapses into one KindAggregate entry naming a
-//     representative posting. Everything else becomes a candidate for pass 2.
-//  2. Bucket the remaining candidates by CompanyName. A bucket at or above
+//     representative posting. Everything else is left over for pass 2.
+//  2. Bucket what's left by CompanyName. A bucket at or above
 //     AggregationThreshold — one company posting several different roles at
 //     once, a mass hiring push — collapses into one KindCompanyAggregate
 //     entry. Everything still left over becomes a KindSingle entry.
@@ -37,63 +37,57 @@ func Group(postings []Posting) []Entry {
 		return nil
 	}
 
+	roleAggregates, leftover := aggregateBy(postings, KindAggregate, func(p Posting) string {
+		return jobhash.NormalizedRoleTitle(p.Title)
+	})
+	companyAggregates, leftover := aggregateBy(leftover, KindCompanyAggregate, func(p Posting) string {
+		return p.CompanyName
+	})
+
 	entries := make([]Entry, 0, len(postings))
-
-	var roleOrder []string
-	roleBuckets := make(map[string][]Posting, len(postings))
-	for _, p := range postings {
-		key := jobhash.NormalizedRoleTitle(p.Title)
-		if _, seen := roleBuckets[key]; !seen {
-			roleOrder = append(roleOrder, key)
-		}
-		roleBuckets[key] = append(roleBuckets[key], p)
-	}
-
-	var candidates []Posting
-	for _, key := range roleOrder {
-		bucket := roleBuckets[key]
-		if len(bucket) >= AggregationThreshold {
-			sample := bucket[0]
-			entries = append(entries, Entry{
-				Kind:        KindAggregate,
-				Title:       sample.Title,
-				CompanyName: sample.CompanyName,
-				Count:       len(bucket),
-			})
-			continue
-		}
-		candidates = append(candidates, bucket...)
-	}
-
-	var companyOrder []string
-	companyBuckets := make(map[string][]Posting, len(candidates))
-	for _, p := range candidates {
-		if _, seen := companyBuckets[p.CompanyName]; !seen {
-			companyOrder = append(companyOrder, p.CompanyName)
-		}
-		companyBuckets[p.CompanyName] = append(companyBuckets[p.CompanyName], p)
-	}
-
-	for _, company := range companyOrder {
-		bucket := companyBuckets[company]
-		if len(bucket) >= AggregationThreshold {
-			sample := bucket[0]
-			entries = append(entries, Entry{
-				Kind:        KindCompanyAggregate,
-				Title:       sample.Title,
-				CompanyName: company,
-				Count:       len(bucket),
-			})
-			continue
-		}
-		for _, p := range bucket {
-			entries = append(entries, Entry{
-				Kind:        KindSingle,
-				Title:       p.Title,
-				CompanyName: p.CompanyName,
-				JobSlug:     p.JobSlug,
-			})
-		}
+	entries = append(entries, roleAggregates...)
+	entries = append(entries, companyAggregates...)
+	for _, p := range leftover {
+		entries = append(entries, Entry{
+			Kind:        KindSingle,
+			Title:       p.Title,
+			CompanyName: p.CompanyName,
+			JobSlug:     p.JobSlug,
+		})
 	}
 	return entries
+}
+
+// aggregateBy buckets postings by key(p), preserving first-seen bucket order. A
+// bucket at or above AggregationThreshold becomes one Entry of the given kind,
+// naming a representative posting from it; every posting in a smaller bucket is
+// returned as leftover instead, for the caller to aggregate further or emit as
+// KindSingle. The two Group passes differ only in kind and key — this is the
+// bucket-or-leave-for-later shape both share.
+func aggregateBy(postings []Posting, kind Kind, key func(Posting) string) (aggregates []Entry, leftover []Posting) {
+	var order []string
+	buckets := make(map[string][]Posting, len(postings))
+	for _, p := range postings {
+		k := key(p)
+		if _, seen := buckets[k]; !seen {
+			order = append(order, k)
+		}
+		buckets[k] = append(buckets[k], p)
+	}
+
+	for _, k := range order {
+		bucket := buckets[k]
+		if len(bucket) < AggregationThreshold {
+			leftover = append(leftover, bucket...)
+			continue
+		}
+		sample := bucket[0]
+		aggregates = append(aggregates, Entry{
+			Kind:        kind,
+			Title:       sample.Title,
+			CompanyName: sample.CompanyName,
+			Count:       len(bucket),
+		})
+	}
+	return aggregates, leftover
 }

--- a/internal/job/recentfeed/grouping_test.go
+++ b/internal/job/recentfeed/grouping_test.go
@@ -115,6 +115,7 @@ func TestGroup_CompanyBurstOfDifferentRolesAggregates(t *testing.T) {
 		postings[i] = Posting{
 			Title:       fmt.Sprintf("Role %d", i),
 			CompanyName: "Amyx, Inc.",
+			CompanySlug: "amyx",
 			JobSlug:     fmt.Sprintf("slug-%d", i),
 		}
 	}
@@ -140,6 +141,7 @@ func TestGroup_BelowThresholdCompanyBurstStaysIndividual(t *testing.T) {
 		postings[i] = Posting{
 			Title:       fmt.Sprintf("Role %d", i),
 			CompanyName: "Amyx, Inc.",
+			CompanySlug: "amyx",
 			JobSlug:     fmt.Sprintf("slug-%d", i),
 		}
 	}
@@ -151,6 +153,34 @@ func TestGroup_BelowThresholdCompanyBurstStaysIndividual(t *testing.T) {
 		if e.Kind != KindSingle {
 			t.Errorf("Kind = %q, want %q for a below-threshold company burst", e.Kind, KindSingle)
 		}
+	}
+}
+
+// The company key is CompanySlug, not the free-text CompanyName — two spellings
+// of one employer ("Acme, Inc." vs "Acme Inc", the exact reason
+// company_slug/company_slug_aliases exist — see docs/agents/company-identity.md)
+// must still collapse into one card, and a genuinely different company sharing
+// no slug must never merge with it just because of a coincidental name.
+func TestGroup_CompanyBurstCollapsesDespiteNameSpellingVariants(t *testing.T) {
+	postings := make([]Posting, AggregationThreshold)
+	for i := range postings {
+		name := "Acme, Inc."
+		if i%2 == 0 {
+			name = "Acme Inc"
+		}
+		postings[i] = Posting{
+			Title:       fmt.Sprintf("Role %d", i),
+			CompanyName: name,
+			CompanySlug: "acme",
+			JobSlug:     fmt.Sprintf("slug-%d", i),
+		}
+	}
+	entries := Group(postings)
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1 (same company_slug must collapse despite differing display names): %+v", len(entries), entries)
+	}
+	if entries[0].Kind != KindCompanyAggregate {
+		t.Errorf("Kind = %q, want %q", entries[0].Kind, KindCompanyAggregate)
 	}
 }
 

--- a/internal/job/recentfeed/grouping_test.go
+++ b/internal/job/recentfeed/grouping_test.go
@@ -1,6 +1,9 @@
 package recentfeed
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestGroup_SingleJobProducesSingleEntry(t *testing.T) {
 	entries := Group([]Posting{
@@ -100,5 +103,74 @@ func TestGroup_CosmeticTitleVariationStillClusters(t *testing.T) {
 func TestGroup_EmptyBatchProducesNoEntries(t *testing.T) {
 	if entries := Group(nil); len(entries) != 0 {
 		t.Errorf("got %d entries for an empty batch, want 0", len(entries))
+	}
+}
+
+// One company posting many DIFFERENT roles at once (e.g. a mass hiring push) must
+// not flood the feed with one card per posting — it should collapse the same way a
+// same-role burst across companies does, just keyed the other way round.
+func TestGroup_CompanyBurstOfDifferentRolesAggregates(t *testing.T) {
+	postings := make([]Posting, AggregationThreshold)
+	for i := range postings {
+		postings[i] = Posting{
+			Title:       fmt.Sprintf("Role %d", i),
+			CompanyName: "Amyx, Inc.",
+			JobSlug:     fmt.Sprintf("slug-%d", i),
+		}
+	}
+	entries := Group(postings)
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1 company-aggregated entry: %+v", len(entries), entries)
+	}
+	e := entries[0]
+	if e.Kind != KindCompanyAggregate {
+		t.Errorf("Kind = %q, want %q", e.Kind, KindCompanyAggregate)
+	}
+	if e.CompanyName != "Amyx, Inc." {
+		t.Errorf("CompanyName = %q, want %q", e.CompanyName, "Amyx, Inc.")
+	}
+	if e.Count != AggregationThreshold {
+		t.Errorf("Count = %d, want %d", e.Count, AggregationThreshold)
+	}
+}
+
+func TestGroup_BelowThresholdCompanyBurstStaysIndividual(t *testing.T) {
+	postings := make([]Posting, AggregationThreshold-1)
+	for i := range postings {
+		postings[i] = Posting{
+			Title:       fmt.Sprintf("Role %d", i),
+			CompanyName: "Amyx, Inc.",
+			JobSlug:     fmt.Sprintf("slug-%d", i),
+		}
+	}
+	entries := Group(postings)
+	if len(entries) != len(postings) {
+		t.Fatalf("got %d entries, want %d (one per posting, below threshold)", len(entries), len(postings))
+	}
+	for _, e := range entries {
+		if e.Kind != KindSingle {
+			t.Errorf("Kind = %q, want %q for a below-threshold company burst", e.Kind, KindSingle)
+		}
+	}
+}
+
+// A burst that already qualifies as a role-aggregate (same role, many companies)
+// must not also be counted toward company aggregation — each posting belongs to
+// exactly one entry.
+func TestGroup_RoleAggregateTakesPrecedenceOverCompanyAggregate(t *testing.T) {
+	postings := make([]Posting, AggregationThreshold)
+	for i := range postings {
+		postings[i] = Posting{
+			Title:       "Senior Backend Engineer",
+			CompanyName: fmt.Sprintf("Company %d", i),
+			JobSlug:     fmt.Sprintf("slug-%d", i),
+		}
+	}
+	entries := Group(postings)
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1 role-aggregated entry: %+v", len(entries), entries)
+	}
+	if entries[0].Kind != KindAggregate {
+		t.Errorf("Kind = %q, want %q", entries[0].Kind, KindAggregate)
 	}
 }

--- a/internal/job/recentfeed/poller.go
+++ b/internal/job/recentfeed/poller.go
@@ -61,7 +61,12 @@ func (p *Poller) Poll(ctx context.Context) error {
 	for i, r := range rows {
 		postings[i] = Posting{Title: r.Title, CompanyName: r.Company, JobSlug: r.PublicSlug}
 	}
+	// Stamped once, here, rather than inside Group: Group stays a pure function
+	// of its input, and every entry from one poll tick reports the same
+	// instant regardless of how long grouping itself took.
+	now := time.Now()
 	for _, e := range Group(postings) {
+		e.ProducedAt = now
 		p.broadcaster.Publish(e)
 	}
 	return nil

--- a/internal/job/recentfeed/poller.go
+++ b/internal/job/recentfeed/poller.go
@@ -59,7 +59,7 @@ func (p *Poller) Poll(ctx context.Context) error {
 
 	postings := make([]Posting, len(rows))
 	for i, r := range rows {
-		postings[i] = Posting{Title: r.Title, CompanyName: r.Company, JobSlug: r.PublicSlug}
+		postings[i] = Posting{Title: r.Title, CompanyName: r.Company, CompanySlug: r.CompanySlug, JobSlug: r.PublicSlug}
 	}
 	// Stamped once, here, rather than inside Group: Group stays a pure function
 	// of its input, and every entry from one poll tick reports the same

--- a/internal/job/recentfeed/poller_integration_test.go
+++ b/internal/job/recentfeed/poller_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -74,6 +75,9 @@ func TestPoller_PollDrainsOutboxAndPublishesEntries(t *testing.T) {
 	}
 	if backlog[0].Kind != KindSingle {
 		t.Errorf("Kind = %q, want %q for a single claimed job", backlog[0].Kind, KindSingle)
+	}
+	if backlog[0].ProducedAt.IsZero() || time.Since(backlog[0].ProducedAt) > time.Minute {
+		t.Errorf("ProducedAt = %v, want stamped to roughly now", backlog[0].ProducedAt)
 	}
 
 	if n := outboxRowCount(t, pool, jobID); n != 0 {

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -421,7 +421,11 @@ type Querier interface {
 	// separate reaper process is needed.
 	ClaimEnrichmentBatch(ctx context.Context, arg ClaimEnrichmentBatchParams) ([]ClaimEnrichmentBatchRow, error)
 	// Claim-and-delete a bounded batch, oldest first, joined to jobs for the fields the
-	// feed displays. Unlike search_outbox/enrichment_outbox there is no lease: a claimed
+	// feed displays. company_slug rides along beside company: recentfeed.Group buckets a
+	// same-company burst by the slug (the canonical company key — see AGENTS.md, "Company
+	// key: normalize.CompanySlug") so two spellings of one employer's name still collapse,
+	// while company (the display name) is what a card actually renders. Unlike
+	// search_outbox/enrichment_outbox there is no lease: a claimed
 	// row is deleted outright in the same statement, because a cosmetic feed has nothing
 	// to retry and nothing to reconcile if the connection holding it dies mid-drain — the
 	// row is simply gone either way, and the next poll tick picks up whatever else queued.

--- a/internal/platform/db/queries/recent_feed_outbox.sql
+++ b/internal/platform/db/queries/recent_feed_outbox.sql
@@ -11,7 +11,11 @@ ON CONFLICT (job_id) DO NOTHING;
 
 -- name: ClaimRecentFeedOutboxBatch :many
 -- Claim-and-delete a bounded batch, oldest first, joined to jobs for the fields the
--- feed displays. Unlike search_outbox/enrichment_outbox there is no lease: a claimed
+-- feed displays. company_slug rides along beside company: recentfeed.Group buckets a
+-- same-company burst by the slug (the canonical company key — see AGENTS.md, "Company
+-- key: normalize.CompanySlug") so two spellings of one employer's name still collapse,
+-- while company (the display name) is what a card actually renders. Unlike
+-- search_outbox/enrichment_outbox there is no lease: a claimed
 -- row is deleted outright in the same statement, because a cosmetic feed has nothing
 -- to retry and nothing to reconcile if the connection holding it dies mid-drain — the
 -- row is simply gone either way, and the next poll tick picks up whatever else queued.
@@ -30,6 +34,6 @@ WITH claimed AS (
     )
     RETURNING job_id
 )
-SELECT j.id AS job_id, j.title, j.company, j.public_slug
+SELECT j.id AS job_id, j.title, j.company, j.company_slug, j.public_slug
 FROM claimed c
 JOIN jobs j ON j.id = c.job_id;

--- a/internal/platform/db/recent_feed_outbox.sql.go
+++ b/internal/platform/db/recent_feed_outbox.sql.go
@@ -21,20 +21,25 @@ WITH claimed AS (
     )
     RETURNING job_id
 )
-SELECT j.id AS job_id, j.title, j.company, j.public_slug
+SELECT j.id AS job_id, j.title, j.company, j.company_slug, j.public_slug
 FROM claimed c
 JOIN jobs j ON j.id = c.job_id
 `
 
 type ClaimRecentFeedOutboxBatchRow struct {
-	JobID      int64  `json:"job_id"`
-	Title      string `json:"title"`
-	Company    string `json:"company"`
-	PublicSlug string `json:"public_slug"`
+	JobID       int64  `json:"job_id"`
+	Title       string `json:"title"`
+	Company     string `json:"company"`
+	CompanySlug string `json:"company_slug"`
+	PublicSlug  string `json:"public_slug"`
 }
 
 // Claim-and-delete a bounded batch, oldest first, joined to jobs for the fields the
-// feed displays. Unlike search_outbox/enrichment_outbox there is no lease: a claimed
+// feed displays. company_slug rides along beside company: recentfeed.Group buckets a
+// same-company burst by the slug (the canonical company key — see AGENTS.md, "Company
+// key: normalize.CompanySlug") so two spellings of one employer's name still collapse,
+// while company (the display name) is what a card actually renders. Unlike
+// search_outbox/enrichment_outbox there is no lease: a claimed
 // row is deleted outright in the same statement, because a cosmetic feed has nothing
 // to retry and nothing to reconcile if the connection holding it dies mid-drain — the
 // row is simply gone either way, and the next poll tick picks up whatever else queued.
@@ -55,6 +60,7 @@ func (q *Queries) ClaimRecentFeedOutboxBatch(ctx context.Context, batchSize int3
 			&i.JobID,
 			&i.Title,
 			&i.Company,
+			&i.CompanySlug,
 			&i.PublicSlug,
 		); err != nil {
 			return nil, err

--- a/web/src/lib/components/RecentJobsFeed.svelte
+++ b/web/src/lib/components/RecentJobsFeed.svelte
@@ -23,19 +23,23 @@
   let entries = $state<RecentFeedEntry[]>([]);
   let nextId = 0;
 
-  // Ticks once a second so the "N ago" label on each card advances live
-  // instead of freezing at whatever it read on arrival. `tick` itself is
-  // never read for its value — only its change — which is what makes every
-  // ago() call in the template below re-run on each tick.
-  let tick = $state(0);
+  // A millisecond clock, ticked once a second so the "N ago" label on each
+  // card advances live instead of freezing at whatever it read on arrival.
+  // Reading `now` from ago() below — called from the template — is what
+  // makes that call re-run on every tick; no separate signal needed.
+  let now = $state(Date.now());
   $effect(() => {
-    const interval = setInterval(() => (tick += 1), 1000);
+    const interval = setInterval(() => (now = Date.now()), 1000);
     return () => clearInterval(interval);
   });
 
   function ago(entry: RecentFeedEntry): string {
-    void tick;
-    return timeAgo(entry.produced_at, 'short');
+    const producedMs = Date.parse(entry.produced_at);
+    if (Number.isNaN(producedMs)) return '';
+    // Clamp a produced_at that reads as being in the client's future (clock
+    // skew between this browser and the server) to `now`, so the newest card
+    // never renders as "in 2 seconds" instead of "just now".
+    return timeAgo(new Date(Math.min(producedMs, now)).toISOString());
   }
 
   function headline(entry: RecentFeedEntry): string {

--- a/web/src/lib/components/RecentJobsFeed.svelte
+++ b/web/src/lib/components/RecentJobsFeed.svelte
@@ -4,8 +4,15 @@
   import { resolve } from '$app/paths';
   import { api } from '$lib/api';
   import { companyLogoUrl } from '$lib/logo';
-  import { aggregateLabel, pushFeedEntry, type RecentFeedEntry, type RecentFeedEvent } from '$lib/recentFeed';
+  import {
+    aggregateLabel,
+    companyAggregateLabel,
+    pushFeedEntry,
+    type RecentFeedEntry,
+    type RecentFeedEvent,
+  } from '$lib/recentFeed';
   import { EntityLogo, SectionLabel } from '$lib/ui';
+  import { timeAgo } from '$lib/utils';
 
   // The homepage's live "recently added jobs" feed (see
   // openspec/changes/add-homepage-recent-jobs-feed). Renders nothing until the first
@@ -15,6 +22,38 @@
 
   let entries = $state<RecentFeedEntry[]>([]);
   let nextId = 0;
+
+  // Ticks once a second so the "N ago" label on each card advances live
+  // instead of freezing at whatever it read on arrival. `tick` itself is
+  // never read for its value — only its change — which is what makes every
+  // ago() call in the template below re-run on each tick.
+  let tick = $state(0);
+  $effect(() => {
+    const interval = setInterval(() => (tick += 1), 1000);
+    return () => clearInterval(interval);
+  });
+
+  function ago(entry: RecentFeedEntry): string {
+    void tick;
+    return timeAgo(entry.produced_at, 'short');
+  }
+
+  function headline(entry: RecentFeedEntry): string {
+    // A company_aggregate has no single featured role — the company itself
+    // is the headline, mirroring how a role-aggregate headlines the role.
+    return entry.kind === 'company_aggregate' ? entry.company_name : entry.title;
+  }
+
+  function subtitle(entry: RecentFeedEntry): string {
+    switch (entry.kind) {
+      case 'single':
+        return entry.company_name;
+      case 'aggregate':
+        return aggregateLabel(entry);
+      case 'company_aggregate':
+        return companyAggregateLabel(entry);
+    }
+  }
 
   $effect(() => {
     const source = new EventSource(api.recentJobsFeedUrl());
@@ -36,8 +75,8 @@
     if (entry.kind === 'single' && entry.job_slug) {
       return resolve('/jobs/[slug]', { slug: entry.job_slug });
     }
-    // An aggregate represents several postings from different companies — there is
-    // no single job to link to, so it points at the catalogue instead.
+    // Either aggregate kind represents several postings — there is no single
+    // job to link to, so it points at the catalogue instead.
     return resolve('/jobs');
   }
 </script>
@@ -60,11 +99,10 @@
               size="sm"
             />
             <div class="min-w-0 flex-1">
-              <p class="truncate text-sm font-medium">{entry.title}</p>
-              <p class="truncate text-xs text-muted-foreground">
-                {entry.kind === 'single' ? entry.company_name : aggregateLabel(entry)}
-              </p>
+              <p class="truncate text-sm font-medium">{headline(entry)}</p>
+              <p class="truncate text-xs text-muted-foreground">{subtitle(entry)}</p>
             </div>
+            <span class="shrink-0 text-xs tabular-nums text-muted-foreground">{ago(entry)}</span>
           </a>
         </li>
       {/each}

--- a/web/src/lib/recentFeed.test.ts
+++ b/web/src/lib/recentFeed.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { aggregateLabel, pushFeedEntry, type RecentFeedEvent } from './recentFeed';
+import { aggregateLabel, companyAggregateLabel, pushFeedEntry, type RecentFeedEvent } from './recentFeed';
 
 function event(overrides: Partial<RecentFeedEvent> = {}): RecentFeedEvent {
-  return { kind: 'single', title: 'Senior Backend Engineer', company_name: 'Acme', ...overrides };
+  return {
+    kind: 'single',
+    title: 'Senior Backend Engineer',
+    company_name: 'Acme',
+    produced_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
 }
 
 describe('pushFeedEntry', () => {
@@ -36,5 +42,17 @@ describe('aggregateLabel', () => {
 
     expect(label).toContain('12');
     expect(label).toContain('other');
+  });
+});
+
+describe('companyAggregateLabel', () => {
+  // The mirror image of aggregateLabel: same company, many different roles.
+  // Nothing here should read as "N more of the one role shown" — there is no
+  // single featured role for this card.
+  it('states the count of new roles from the company', () => {
+    const label = companyAggregateLabel({ count: 6 });
+
+    expect(label).toContain('6');
+    expect(label).toContain('role');
   });
 });

--- a/web/src/lib/recentFeed.ts
+++ b/web/src/lib/recentFeed.ts
@@ -5,13 +5,20 @@
 
 /** One event as it arrives over the wire. */
 export interface RecentFeedEvent {
-  kind: 'single' | 'aggregate';
+  /** `aggregate` is a burst of the same role across different companies;
+   *  `company_aggregate` is the mirror image — one company posting several
+   *  different roles at once. A posting is never counted toward both. */
+  kind: 'single' | 'aggregate' | 'company_aggregate';
   title: string;
   company_name: string;
   /** Present on a `single` event; links the card to its posting. */
   job_slug?: string;
-  /** Present on an `aggregate` event: how many postings it represents. */
+  /** Present on either aggregate kind: how many postings it represents. */
   count?: number;
+  /** When the poller produced this entry (RFC3339) — fixed at that instant,
+   *  so a client's live "N ago" label ticks forward from a stable point even
+   *  while the entry sits in the connection's replayed backlog. */
+  produced_at: string;
 }
 
 /** A feed event plus the client-assigned id {#each} keys the card list on — the
@@ -38,4 +45,11 @@ export function pushFeedEntry(
  *  not attribute a single company"). */
 export function aggregateLabel(entry: Pick<RecentFeedEvent, 'count'>): string {
   return `+${entry.count} more at other companies`;
+}
+
+/** The card copy for a company-aggregated entry — the mirror image of
+ *  aggregateLabel: one company posted several different roles at once, so
+ *  there is no single featured role to name, only a count of new roles. */
+export function companyAggregateLabel(entry: Pick<RecentFeedEvent, 'count'>): string {
+  return `+${entry.count} new roles`;
 }


### PR DESCRIPTION
## Summary

Two follow-ups to the just-shipped homepage recently-added-jobs feed (#2579), both prompted by watching real production traffic:

- **Same-company grouping.** Observed live: "Amyx, Inc." posted 6+ distinct roles in one poll tick, flooding the feed with one card per posting despite the existing same-role aggregation. `Group` now runs a second pass over whatever survives role aggregation, collapsing a same-company burst into one `KindCompanyAggregate` entry ("+N new roles") — the mirror image of the existing same-role-across-companies aggregate. A posting is never counted toward both.
- **Live ticking age.** `Entry` now carries `ProducedAt` (stamped once by the `Poller`, not persisted anywhere — the feed itself is not stored). The frontend shows a live "N ago" label using the existing `timeAgo()` util, ticked forward once a second, instead of a label frozen at arrival time.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `gofmt -l .` clean
- [x] `go test ./...` and `go test -tags=integration ./internal/job/recentfeed/...` (real Postgres via testcontainers) green, including new tests for company-aggregation and the role-vs-company precedence rule
- [x] golangci-lint (pinned CI version) clean
- [x] Frontend: `svelte-check` 0 errors, `eslint` clean, full vitest suite green
- [x] Manual verification against an isolated Postgres+Redis+`cmd/server`+SvelteKit dev server, driven by a real headless Chromium: seeded a single posting and a 6-role same-company burst, confirmed the "Amyx, Inc. — +6 new roles" card renders and the per-card "N sec./min. ago" label visibly ticks forward over real time (26s → 29s → 32s)

No new migration, no nginx changes — `Entry` is in-memory only (the Broadcaster's ring buffer), never written to Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Recent job feeds now group bursts of different roles posted by the same company into a single company activity entry.
  - Role-based grouping remains prioritized, preventing listings from appearing in multiple grouped entries.
  - Feed entries now display relative timestamps that update live as time passes.
  - Grouped entries include clearer labels showing the number of roles or postings involved.
  - Activity timestamps are anchored to when feed entries were produced for more accurate “N ago” displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->