### PR TITLE
Rebuild echojobs on a headless browser, because neither the browser nor the proxy works alone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,7 @@ Each is self-contained and can be read independently.
 | **Host configuration** (systemd units and timers, operator scripts, the two-file env split) | [deploy/AGENTS.md](deploy/AGENTS.md) |
 | **LLM client** (provider-agnostic wrapper, schema cache, streaming, attribution tags) | [internal/platform/llm/AGENTS.md](internal/platform/llm/AGENTS.md) |
 | **Headless browser** (launching Chrome, in-page fetch, the stealth flags' single home) | [internal/platform/browser/AGENTS.md](internal/platform/browser/AGENTS.md) |
+| **Hosted fetch** (the last-resort metered tier, its page budget, and the yield behind it) | [internal/platform/firecrawl/AGENTS.md](internal/platform/firecrawl/AGENTS.md) |
 | **Sentry error tracking** (backend, workers, frontend — env-gated) | [internal/platform/observability/AGENTS.md](internal/platform/observability/AGENTS.md) |
 | **`internal/dict`** — the block itself: what it is, what it may import | [internal/dict/AGENTS.md](internal/dict/AGENTS.md) |
 | **Company names** (real display names for slug-named companies) | [internal/dict/companyname/AGENTS.md](internal/dict/companyname/AGENTS.md) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,7 @@ Each is self-contained and can be read independently.
 | **Cron worker plumbing** (Main/Bootstrap, exit codes, heartbeat, corruption-tolerant scans) | [internal/platform/worker/AGENTS.md](internal/platform/worker/AGENTS.md) |
 | **Host configuration** (systemd units and timers, operator scripts, the two-file env split) | [deploy/AGENTS.md](deploy/AGENTS.md) |
 | **LLM client** (provider-agnostic wrapper, schema cache, streaming, attribution tags) | [internal/platform/llm/AGENTS.md](internal/platform/llm/AGENTS.md) |
+| **Headless browser** (launching Chrome, in-page fetch, the stealth flags' single home) | [internal/platform/browser/AGENTS.md](internal/platform/browser/AGENTS.md) |
 | **Sentry error tracking** (backend, workers, frontend — env-gated) | [internal/platform/observability/AGENTS.md](internal/platform/observability/AGENTS.md) |
 | **`internal/dict`** — the block itself: what it is, what it may import | [internal/dict/AGENTS.md](internal/dict/AGENTS.md) |
 | **Company names** (real display names for slug-named companies) | [internal/dict/companyname/AGENTS.md](internal/dict/companyname/AGENTS.md) |

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -112,6 +112,13 @@ func run() int {
 		return 1
 	}
 	defer closeBrowser()
+	// LAST, and the order is load-bearing: the hosted tier deliberately takes gulftalent off
+	// the fingerprint transport, which ApplyProxyEgress above wired. See ApplyFirecrawlEgress.
+	// A no-op without FIRECRAWL_API_KEY, so this cannot spend anything on an ordinary run.
+	if err := sources.ApplyFirecrawlEgress(registry); err != nil {
+		log.Printf("config: %v", err)
+		return 1
+	}
 
 	// Resolved before the DB is touched, like every other config read here: a bad value should
 	// stop the run, not produce a quiet ordinary crawl where a repair was intended.

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -102,6 +102,16 @@ func run() int {
 		log.Printf("config: %v", err)
 		return 1
 	}
+	// Rewire the providers whose pages are served only to a client that ran JavaScript onto a
+	// headless browser (see sources.ApplyBrowserEgress). Nothing starts here: the browser is
+	// built on the first fetch, so a run for any other provider — which is almost every run,
+	// since this worker crawls one — never pays for a Chrome it will not use.
+	closeBrowser, err := sources.ApplyBrowserEgress(registry)
+	if err != nil {
+		log.Printf("config: %v", err)
+		return 1
+	}
+	defer closeBrowser()
 
 	// Resolved before the DB is touched, like every other config read here: a bad value should
 	// stop the run, not produce a quiet ordinary crawl where a repair was intended.

--- a/internal/api/atsapply/browser.go
+++ b/internal/api/atsapply/browser.go
@@ -8,19 +8,20 @@ import (
 	"time"
 
 	"github.com/chromedp/chromedp"
+
+	"github.com/strelov1/freehire/internal/platform/browser"
 )
 
-// stealthAllocatorOptions are the launch options the 2026-09-02 spike measured against
-// bot.sannysoft.com: headless, plus disable-blink-features=AutomationControlled, which
-// alone flipped navigator.webdriver from true to false — matching what Patchright achieved,
-// at zero extra dependency. See design.md's "chromedp, not a Python/Patchright sidecar"
-// decision for the full comparison and its caveats (untested against real ATS bot-detection,
-// datacenter IP reputation unaddressed either way).
+// stealthAllocatorOptions are this package's launch options. The flags themselves live in
+// platform/browser, which is their single home in the repository: ingest also launches a
+// browser now (for a source behind a JavaScript challenge), and two copies of the flags would
+// mean the next anti-bot fix lands in one and silently not the other.
+//
+// What that package documents, and what still holds here: the pair is what the 2026-09-02
+// spike measured against bot.sannysoft.com, and it is not a claim of undetectability — see
+// design.md's "chromedp, not a Python/Patchright sidecar" decision for the caveats.
 func stealthAllocatorOptions() []chromedp.ExecAllocatorOption {
-	return append(chromedp.DefaultExecAllocatorOptions[:],
-		chromedp.Flag("headless", true),
-		chromedp.Flag("disable-blink-features", "AutomationControlled"),
-	)
+	return browser.LaunchOptions()
 }
 
 // pageLoadTimeout bounds how long a single navigation+render may take before this package

--- a/internal/ingest/sources/AGENTS.md
+++ b/internal/ingest/sources/AGENTS.md
@@ -322,3 +322,49 @@ Source ingest: the provider registry and its adapters, entry validation, the per
 ## Limitations
 - The ingest sweep has a trade-off: a missed run can leave an orphan open until a future reconcile; the change window is sized wide enough to absorb a skipped cron.
 - Self-closing sources: a missed `removed` event from the feed can leave a vacancy open until the next reindex.
+
+## The browser tier
+
+A provider whose pages are served only to a client that ran JavaScript is crawled through a
+headless browser instead of an HTTP client. `browserProviders` (browsertier.go) is the
+per-provider opt-in, the same shape `proxiedProviders` has, and `ApplyBrowserEgress` rewires
+them — one entry today, `echojobs`.
+
+**It requires a proxy and refuses to run without one.** Measured 2026-09-07 against echojobs,
+all four combinations: from the prod datacenter IP a plain GET *and* a headless browser both
+get `403 x-vercel-mitigated: deny`, so no challenge is offered and there is nothing for a
+browser to solve; through `SOURCES_PROXY_URL` a plain GET gets the challenge and the browser
+passes it. Neither half works alone. Without a proxy the provider stays on the plain client
+and fails as it would have anyway, which is the honest outcome.
+
+**Nothing launches at wiring time.** The session is built on the first fetch, so an ingest run
+for any other provider — which is almost every run, since `cmd/ingest` crawls one — never pays
+for a Chrome it will not use.
+
+**The tier must stay disjoint from the proxy tiers**, and a test enforces it: both rewire the
+same registry entry and `cmd/ingest` applies them in sequence, so a provider in both would
+silently get whichever ran last. A browser-tier provider needs no `proxiedProviders` entry —
+its session egresses through `SOURCES_PROXY_URL` itself.
+
+`browserClient` implements exactly `XMLGetter` + `HTMLGetter`, which is `echojobsHTTP`, so the
+adapter reads browser-fetched bytes without knowing it — **not one line of echojobs' parsing
+changed**. Its errors are `*StatusError`, the same type the plain client produces, which is
+load-bearing rather than tidy: `detailUnreadable` and `isRateLimited` match on that type, so a
+browser-fetched 404 still means "this posting is gone".
+
+See [internal/platform/browser/AGENTS.md](../../platform/browser/AGENTS.md) for the traps on
+the browser side — chiefly that the `HeadlessChrome` user agent is refused outright, and that
+retrying a refused request is what holds a rate-limit-flavoured wall UP.
+
+## A crawl that reads nothing of what it listed must fail
+
+`echojobs` published `ingested=0 failed=0`, exit 0, green unit, every four hours for 19 days
+while its pages sat behind a bot wall (freehire#2588). A dropped posting never reaches the
+pipeline — `Stats` counts `saveOne` failures, not candidates an adapter discarded — so from
+every side but the adapter's, a total outage and a source with nothing to offer are the same
+result.
+
+So a hydrating adapter that listed candidates and read **none** of them returns an error.
+There is deliberately no threshold: "some candidates, none read" is the whole signal, and how
+many consecutive failures matter is `board_health`'s question. No candidates at all still
+succeeds — a quiet source is not a broken one.

--- a/internal/ingest/sources/AGENTS.md
+++ b/internal/ingest/sources/AGENTS.md
@@ -368,3 +368,27 @@ So a hydrating adapter that listed candidates and read **none** of them returns 
 There is deliberately no threshold: "some candidates, none read" is the whole signal, and how
 many consecutive failures matter is `board_health`'s question. No candidates at all still
 succeeds — a quiet source is not a broken one.
+
+## The hosted tier (last resort, and it costs money)
+
+`firecrawlProviders` (firecrawltier.go) is the third transport, for providers that refuse
+**every** address this repository can obtain. `bayt` and `gulftalent` are `403` from the prod
+datacenter IP *and* `403` through `SOURCES_PROXY_URL`; the browser tier does not help either,
+because the refusal comes before any challenge is offered.
+
+Reach for it only after the other two are ruled out — it is the only tier billed per page.
+Before adding a provider, measure what is behind the wall: `bayt`'s own IT category passed
+**0 of 33** titles through `classify.IsTech`, and `gulftalent`'s postings **5 of 400**. See
+[internal/platform/firecrawl/AGENTS.md](../../platform/firecrawl/AGENTS.md) for the full
+numbers and the three bounds that keep it from spending by accident.
+
+**`ApplyFirecrawlEgress` must run LAST**, and `cmd/ingest` does. `gulftalent` is in
+`proxiedFingerprintProviders` too, so both write the same registry entry — here the override is
+*wanted* (that transport is measured as refused, this one as served), so it is ordered and
+pinned by a test instead of being the silent last-write-wins the browser tier's disjointness
+test exists to prevent. Without a key the override does not happen and `gulftalent` keeps the
+fingerprint transport exactly as before.
+
+Neither adapter changed: `baytHTTP` is `HTMLGetter` and `gulftalentHTTP` is `XMLGetter` +
+`HTMLGetter`, and a test asserts the hosted client satisfies both. What is wrong with these
+providers is the address a request leaves from, not how the response is read.

--- a/internal/ingest/sources/browserclient.go
+++ b/internal/ingest/sources/browserclient.go
@@ -1,0 +1,99 @@
+package sources
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+
+	"golang.org/x/net/html"
+
+	"github.com/strelov1/freehire/internal/platform/browser"
+)
+
+// browserClient fetches through a headless browser instead of an HTTP client, for a source
+// whose pages are served only to a client that ran JavaScript.
+//
+// It implements exactly XMLGetter and HTMLGetter — which together are echojobsHTTP — so an
+// adapter written against those reads browser-fetched bytes without knowing it. That is the
+// whole point of the seam: what broke at echojobs was how the bytes arrive, not how they are
+// read, and not one line of the reading changed.
+//
+// Its errors are *StatusError, the same type the plain client produces, and that is
+// load-bearing rather than tidy. detailUnreadable and isRateLimited match the status
+// structurally through that type; a browser-fetched 404 that arrived as a bare error would
+// stop meaning "this posting is gone" and the lifecycle would quietly stop closing anything.
+type browserClient struct {
+	session sessionSource
+}
+
+// sessionSource hands out the browser session, built on first use. The indirection is what
+// keeps Chrome from starting for a crawl that never reaches a browser-tier provider — see
+// lazySession.
+type sessionSource interface {
+	get(ctx context.Context) (*browser.Session, error)
+}
+
+var (
+	_ XMLGetter  = (*browserClient)(nil)
+	_ HTMLGetter = (*browserClient)(nil)
+)
+
+func newBrowserClient(s sessionSource) *browserClient { return &browserClient{session: s} }
+
+// browserStatusError renders a fetched status the way the plain client renders one, or nil
+// when the response was a success. Only 2xx is a success: a 3xx reaching here means the
+// browser did not follow the redirect, which is a fetch that did not deliver content.
+func browserStatusError(url string, status int) error {
+	if status >= 200 && status < 300 {
+		return nil
+	}
+	return &StatusError{Method: http.MethodGet, Code: status, URL: url}
+}
+
+func (c *browserClient) get(ctx context.Context, url string) ([]byte, error) {
+	session, err := c.session.get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("sources: browser GET %s: %w", url, err)
+	}
+	status, body, err := session.Fetch(ctx, url)
+	if err != nil {
+		return nil, fmt.Errorf("sources: browser GET %s: %w", url, err)
+	}
+	if err := browserStatusError(url, status); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+// GetXML fetches url through the browser and decodes its body as XML.
+func (c *browserClient) GetXML(ctx context.Context, url string, v any) error {
+	body, err := c.get(ctx, url)
+	if err != nil {
+		return err
+	}
+	if err := xml.NewDecoder(bytes.NewReader(body)).Decode(v); err != nil {
+		return fmt.Errorf("sources: browser GET %s: decode xml: %w", url, err)
+	}
+	return nil
+}
+
+// GetHTML fetches url through the browser and parses its body as HTML.
+//
+// The body is the response as the server sent it, not the DOM the browser would have built
+// from it — the fetch happens inside a page rather than by navigating to the URL. For a
+// server-rendered posting that is the same markup and a great deal cheaper; a source that
+// only assembles its content client-side would need a navigation instead, and does not have
+// one here.
+func (c *browserClient) GetHTML(ctx context.Context, url string) (*html.Node, error) {
+	body, err := c.get(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	node, err := html.Parse(bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("sources: browser GET %s: parse html: %w", url, err)
+	}
+	return node, nil
+}

--- a/internal/ingest/sources/browserclient_test.go
+++ b/internal/ingest/sources/browserclient_test.go
@@ -1,0 +1,59 @@
+package sources
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+// The browser client's errors must be indistinguishable from the plain client's, because the
+// helpers that read them — isRateLimited, the 404-means-gone check — match on *StatusError and
+// not on a message. A browser-fetched 404 that arrived as a bare error would silently stop
+// meaning "this posting is gone".
+func TestBrowserStatusErrorIsTheSameTypeThePlainClientReturns(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		want   bool // want an error
+	}{
+		{"200 is not an error", http.StatusOK, false},
+		{"204 is not an error", http.StatusNoContent, false},
+		{"299 is not an error", 299, false},
+		{"404 is an error", http.StatusNotFound, true},
+		{"403 is an error", http.StatusForbidden, true},
+		{"429 is an error", http.StatusTooManyRequests, true},
+		{"500 is an error", http.StatusInternalServerError, true},
+		{"300 is an error", http.StatusMultipleChoices, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := browserStatusError("https://example.test/x", tc.status)
+			if (err != nil) != tc.want {
+				t.Fatalf("browserStatusError(%d) = %v, want error: %v", tc.status, err, tc.want)
+			}
+			if err == nil {
+				return
+			}
+			var se *StatusError
+			if !errors.As(err, &se) {
+				t.Fatalf("error is %T, want *StatusError so the existing helpers can read it", err)
+			}
+			if se.Code != tc.status {
+				t.Errorf("StatusError.Code = %d, want %d", se.Code, tc.status)
+			}
+			if se.URL != "https://example.test/x" {
+				t.Errorf("StatusError.URL = %q, want the fetched url", se.URL)
+			}
+		})
+	}
+}
+
+// The two helpers that decide what a status MEANS are the reason the type matters, so the
+// test walks them rather than trusting that it does.
+func TestBrowserStatusErrorIsReadableByTheExistingHelpers(t *testing.T) {
+	if !isRateLimited(browserStatusError("https://example.test/x", http.StatusTooManyRequests)) {
+		t.Error("a browser-fetched 429 is not recognised as rate limiting")
+	}
+	if isRateLimited(browserStatusError("https://example.test/x", http.StatusNotFound)) {
+		t.Error("a browser-fetched 404 is being read as rate limiting")
+	}
+}

--- a/internal/ingest/sources/browsertier.go
+++ b/internal/ingest/sources/browsertier.go
@@ -1,0 +1,107 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/strelov1/freehire/internal/platform/browser"
+)
+
+// browserProviders is the opt-in allowlist of providers whose pages are served only to a
+// client that ran JavaScript, so their crawl goes through a headless browser rather than an
+// HTTP client. Membership here is the per-provider opt-in, exactly as in proxiedProviders,
+// and each value rebuilds the adapter over the browser-backed client — so adding the next
+// challenged provider is one line.
+//
+// A provider here MUST also be proxied, and a test enforces it. Measured 2026-09-07 against
+// echojobs, all four combinations: from the prod datacenter IP a plain GET and a headless
+// browser BOTH get 403 with x-vercel-mitigated: deny — no challenge is offered at all, so
+// there is nothing for a browser to solve. Through SOURCES_PROXY_URL a plain GET gets the
+// challenge (429, "Vercel Security Checkpoint") and the browser passes it. Neither half works
+// alone; only the pair does.
+var browserProviders = map[string]func(*browserClient) Source{
+	// echojobs.io moved behind Vercel's bot firewall around 2026-08-19 and every crawl since
+	// reported ingested=0 with exit 0 (freehire#2588). Its adapter is unchanged — the sitemap
+	// walk and the JobPosting parse always worked, and only the transport broke.
+	"echojobs": func(c *browserClient) Source { return NewEchoJobs(c) },
+}
+
+// browserTabs is how many pages the session fetches through at once. It follows
+// defaultDetailWorkers rather than inventing a second number: the pool exists for the same
+// reason the detail-worker pool does, and one knob is easier to reason about than two.
+const browserTabs = defaultDetailWorkers
+
+// ApplyBrowserEgress rewires the browserProviders in registry onto a headless browser that
+// egresses through SOURCES_PROXY_URL, and returns the function that shuts that browser down.
+// The returned function is always safe to call, including after an error.
+//
+// It is a no-op without a proxy: a browser on the direct IP is refused before any challenge
+// is offered, so launching one would spend seconds to fail. A set-but-unparseable proxy is an
+// error, the same fail-fast contract ApplyProxyEgress has — for a provider that cannot work
+// without it, a quiet fallback looks exactly like a crawl that found nothing, which is the
+// failure this whole tier exists to end.
+//
+// No browser starts here. The session is built on the first fetch, so an ingest run for any
+// other provider — which is almost every run, since cmd/ingest crawls one provider — never
+// pays for a Chrome it will not use.
+func ApplyBrowserEgress(registry map[string]Source) (func(), error) {
+	raw := strings.TrimSpace(os.Getenv("SOURCES_PROXY_URL"))
+	if raw == "" {
+		return func() {}, nil
+	}
+	if !anyBrowserProviderRegistered(registry) {
+		return func() {}, nil
+	}
+	// Parse now rather than on the first fetch, so a typo fails the run at startup instead of
+	// halfway through a crawl.
+	if _, err := browser.LaunchOptionsThroughProxy(raw); err != nil {
+		return func() {}, fmt.Errorf("sources: browser tier: %w", err)
+	}
+
+	lazy := &lazySession{proxyURL: raw}
+	for name, build := range browserProviders {
+		if _, ok := registry[name]; ok {
+			registry[name] = build(newBrowserClient(lazy))
+		}
+	}
+	return lazy.Close, nil
+}
+
+func anyBrowserProviderRegistered(registry map[string]Source) bool {
+	for name := range browserProviders {
+		if _, ok := registry[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// lazySession starts the browser on first use and hands the same one to every later fetch.
+// One browser per run, not per request: the clearance a tab holds is the expensive part, and
+// throwing it away between fetches would pay for it over and over.
+type lazySession struct {
+	proxyURL string
+
+	once    sync.Once
+	session *browser.Session
+	err     error
+}
+
+func (l *lazySession) get(ctx context.Context) (*browser.Session, error) {
+	l.once.Do(func() {
+		// Deliberately NOT the caller's ctx: the session outlives the one fetch that happened
+		// to start it, and tying its lifetime to that request's context would tear the browser
+		// down the moment that fetch returned.
+		l.session, l.err = browser.NewSession(context.WithoutCancel(ctx), l.proxyURL, browserTabs)
+	})
+	return l.session, l.err
+}
+
+func (l *lazySession) Close() {
+	if l.session != nil {
+		l.session.Close()
+	}
+}

--- a/internal/ingest/sources/browsertier_test.go
+++ b/internal/ingest/sources/browsertier_test.go
@@ -1,0 +1,98 @@
+package sources
+
+import "testing"
+
+// echojobs is the reason the tier exists; if it ever drops out of the map the provider goes
+// back to a plain GET and to reporting an empty success (freehire#2588).
+func TestBrowserTierCarriesEchojobs(t *testing.T) {
+	if _, ok := browserProviders["echojobs"]; !ok {
+		t.Error("echojobs is not in browserProviders")
+	}
+}
+
+// The browser tier and the plain proxy tier must be DISJOINT. Both rewire the same registry
+// entry and cmd/ingest applies them in sequence, so a provider in both would silently get
+// whichever ran last — a wiring bug with no symptom except a provider that quietly stopped
+// using the transport somebody chose for it.
+//
+// A browser-tier provider does not need proxiedProviders anyway: ApplyBrowserEgress builds
+// its session over SOURCES_PROXY_URL itself, so the browser IS the proxied transport.
+func TestBrowserTierAndProxyTierAreDisjoint(t *testing.T) {
+	for name := range browserProviders {
+		if _, ok := proxiedProviders[name]; ok {
+			t.Errorf("%s is in both browserProviders and proxiedProviders; the later rewire wins silently", name)
+		}
+		if _, ok := proxiedFingerprintProviders[name]; ok {
+			t.Errorf("%s is in both browserProviders and proxiedFingerprintProviders", name)
+		}
+		if _, ok := refusalRetryProviders[name]; ok {
+			t.Errorf("%s is in both browserProviders and refusalRetryProviders", name)
+		}
+	}
+}
+
+// With no proxy configured the tier is off and nothing is rewired: a browser alone cannot
+// pass, so launching one would spend seconds to fail.
+func TestApplyBrowserEgressIsANoOpWithoutAProxy(t *testing.T) {
+	t.Setenv("SOURCES_PROXY_URL", "")
+	registry := map[string]Source{"echojobs": NewEchoJobs(NewClient())}
+	before := registry["echojobs"]
+
+	closeBrowser, err := ApplyBrowserEgress(registry)
+	if err != nil {
+		t.Fatalf("ApplyBrowserEgress: %v", err)
+	}
+	defer closeBrowser()
+
+	if registry["echojobs"] != before {
+		t.Error("echojobs was rewired with no proxy configured")
+	}
+}
+
+// With a proxy the provider is rewired — and still no browser has started. Chrome launches on
+// the first fetch, not at wiring time, so an ingest run for any OTHER provider never pays for
+// one. This test would take seconds and need a browser installed if that were not true.
+func TestApplyBrowserEgressRewiresLazily(t *testing.T) {
+	t.Setenv("SOURCES_PROXY_URL", "http://user:pass@proxy.invalid:8080")
+	registry := map[string]Source{"echojobs": NewEchoJobs(NewClient())}
+	before := registry["echojobs"]
+
+	closeBrowser, err := ApplyBrowserEgress(registry)
+	if err != nil {
+		t.Fatalf("ApplyBrowserEgress: %v", err)
+	}
+	defer closeBrowser()
+
+	if registry["echojobs"] == before {
+		t.Error("echojobs was not rewired onto the browser tier")
+	}
+}
+
+// A set-but-unparseable proxy fails at wiring rather than leaving the provider on a transport
+// that cannot work — the same fail-fast contract ApplyProxyEgress has, and for the same
+// reason: a silent fallback here is indistinguishable from a crawl that found nothing.
+func TestApplyBrowserEgressRejectsAnUnparseableProxy(t *testing.T) {
+	t.Setenv("SOURCES_PROXY_URL", "://not a url")
+	registry := map[string]Source{"echojobs": NewEchoJobs(NewClient())}
+	if _, err := ApplyBrowserEgress(registry); err == nil {
+		t.Error("want an error for an unparseable SOURCES_PROXY_URL, got nil")
+	}
+}
+
+// A registry that does not carry a browser-tier provider is left completely alone, so an
+// ingest run for any other provider costs nothing.
+func TestApplyBrowserEgressIgnoresAnUnrelatedRegistry(t *testing.T) {
+	t.Setenv("SOURCES_PROXY_URL", "http://user:pass@proxy.invalid:8080")
+	registry := map[string]Source{"greenhouse": NewGreenhouse(NewClient())}
+	before := registry["greenhouse"]
+
+	closeBrowser, err := ApplyBrowserEgress(registry)
+	if err != nil {
+		t.Fatalf("ApplyBrowserEgress: %v", err)
+	}
+	defer closeBrowser()
+
+	if registry["greenhouse"] != before {
+		t.Error("an unrelated provider was rewired")
+	}
+}

--- a/internal/ingest/sources/browsertier_test.go
+++ b/internal/ingest/sources/browsertier_test.go
@@ -10,13 +10,18 @@ func TestBrowserTierCarriesEchojobs(t *testing.T) {
 	}
 }
 
-// The browser tier and the plain proxy tier must be DISJOINT. Both rewire the same registry
-// entry and cmd/ingest applies them in sequence, so a provider in both would silently get
-// whichever ran last — a wiring bug with no symptom except a provider that quietly stopped
-// using the transport somebody chose for it.
+// The browser tier and the proxy tiers must be DISJOINT. Both rewire the same registry entry
+// and cmd/ingest applies them in sequence, so a provider in both would silently get whichever
+// ran last — a wiring bug with no symptom except a provider that quietly stopped using the
+// transport somebody chose for it.
 //
 // A browser-tier provider does not need proxiedProviders anyway: ApplyBrowserEgress builds
 // its session over SOURCES_PROXY_URL itself, so the browser IS the proxied transport.
+//
+// The HOSTED tier is the documented exception and is checked separately (see
+// TestHostedTierDeliberatelyOverridesTheFingerprintTierForGulftalent): it may take a provider
+// off another tier, because for its two providers every other transport is measured as
+// refused. A rule with a stated exception beats a rule quietly broken.
 func TestBrowserTierAndProxyTierAreDisjoint(t *testing.T) {
 	for name := range browserProviders {
 		if _, ok := proxiedProviders[name]; ok {

--- a/internal/ingest/sources/echojobs.go
+++ b/internal/ingest/sources/echojobs.go
@@ -126,6 +126,22 @@ func (s echojobs) FetchNew(ctx context.Context, _ CompanyEntry, seen func(extern
 	if n := dropped.Load(); n > 0 {
 		log.Printf("echojobs: dropped %d/%d candidate postings this run (detail fetch failed or carried no usable JobPosting)", n, len(postings))
 	}
+	// A run that listed postings and read NONE of them is a board failure, not an empty crawl.
+	//
+	// This is the guard freehire#2588 was missing. A dropped posting never reaches the pipeline
+	// — Stats counts saveOne failures, not candidates an adapter discarded — so from every side
+	// but this one, a total outage and a source with nothing to offer produce the same line:
+	// ingested=0, failed=0, exit 0, green unit. echojobs published that line every four hours
+	// for 19 days while its pages were behind a bot firewall, and nothing anywhere noticed.
+	//
+	// Only FetchNew knows it walked the sitemap and came back empty-handed, so only FetchNew
+	// can say so. There is deliberately no threshold: "some candidates, none read" is the whole
+	// signal, and how many consecutive failures matter is board_health's question, not this
+	// function's. The converse is left alone on purpose — no candidates at all is a quiet
+	// source, not a broken one.
+	if len(postings) > 0 && len(jobs) == 0 {
+		return nil, fmt.Errorf("echojobs: listed %d postings and read none of them", len(postings))
+	}
 	return jobs, nil
 }
 

--- a/internal/ingest/sources/echojobs_test.go
+++ b/internal/ingest/sources/echojobs_test.go
@@ -100,13 +100,19 @@ func echojobsJobHTML(fields string) string {
 // one shard (freshness-window cutoff, shard-failure partial results) wires its own.
 const echojobsShard1URL = "https://echojobs.io/sitemap-jobs/1.xml"
 
-// echojobsSingleShardRoutes builds the xmlRoutes for a fake carrying one shard with one
-// freshly-dated posting — the common setup most detail-mapping tests need, so they need not
-// each repeat the sitemap index/shard plumbing.
-func echojobsSingleShardRoutes(slug string) map[string]string {
+// echojobsSingleShardRoutes builds the xmlRoutes for a fake carrying one shard with the given
+// freshly-dated postings — the common setup most detail-mapping tests need, so they need not
+// each repeat the sitemap index/shard plumbing. Variadic so a test can list several postings,
+// or none at all (a source with genuinely nothing to offer).
+func echojobsSingleShardRoutes(slugs ...string) map[string]string {
+	now := time.Now().UTC().Format(time.RFC3339)
+	entries := make([]echojobsShardEntry, 0, len(slugs))
+	for _, slug := range slugs {
+		entries = append(entries, echojobsShardEntry{slug, now})
+	}
 	return map[string]string{
 		echojobsSitemapURL: echojobsSitemapIndexXML(echojobsShard1URL),
-		echojobsShard1URL:  echojobsShardXML(echojobsShardEntry{slug, time.Now().UTC().Format(time.RFC3339)}),
+		echojobsShard1URL:  echojobsShardXML(entries...),
 	}
 }
 
@@ -181,6 +187,10 @@ func TestEchojobsFetchNewSkipsDetailForSeenPosting(t *testing.T) {
 // A failed detail request drops just that posting: unlike the old list+detail split, the
 // sitemap carries no fields a list-only Job could fall back to, so there is nothing left to
 // ingest for it this run.
+//
+// And when the dropped posting was the ONLY candidate, the run also reports an error: it
+// listed something and read none of it. See the guard's own doc for why that is a board
+// failure rather than an empty success.
 func TestEchojobsFetchNewDetailFailureDropsPosting(t *testing.T) {
 	http := &echojobsFakeHTTP{
 		xmlRoutes: echojobsSingleShardRoutes("acme-swe"),
@@ -188,8 +198,8 @@ func TestEchojobsFetchNewDetailFailureDropsPosting(t *testing.T) {
 	}
 
 	jobs, err := echojobs{http: http}.FetchNew(context.Background(), CompanyEntry{}, func(string) bool { return false })
-	if err != nil {
-		t.Fatalf("FetchNew: %v", err)
+	if err == nil {
+		t.Fatal("want an error: every candidate was listed and none was read")
 	}
 	if len(jobs) != 0 {
 		t.Fatalf("want 0 jobs (detail failed, no list-only fallback), got %+v", jobs)
@@ -207,8 +217,8 @@ func TestEchojobsFetchNewMissingJSONLDDropsPosting(t *testing.T) {
 	}
 
 	jobs, err := echojobs{http: http}.FetchNew(context.Background(), CompanyEntry{}, func(string) bool { return false })
-	if err != nil {
-		t.Fatalf("FetchNew: %v", err)
+	if err == nil {
+		t.Fatal("want an error: the only candidate carried no JobPosting, so nothing was read")
 	}
 	if len(jobs) != 0 {
 		t.Fatalf("want 0 jobs, got %+v", jobs)
@@ -445,5 +455,64 @@ func TestEchojobsFetchHydratesEveryPosting(t *testing.T) {
 func TestEchojobsProvider(t *testing.T) {
 	if got := (echojobs{}).Provider(); got != "echojobs" {
 		t.Errorf("Provider() = %q, want echojobs", got)
+	}
+}
+
+// The guard that would have caught freehire#2588 on day two rather than after 19 days. A
+// dropped posting never reaches the pipeline, so a total outage and an empty crawl are
+// otherwise the same result: ingested=0, failed=0, exit 0, green unit.
+func TestEchojobsFetchNewFailsWhenEveryCandidateIsUnreadable(t *testing.T) {
+	http := &echojobsFakeHTTP{
+		xmlRoutes: echojobsSingleShardRoutes("acme-swe", "acme-sre", "acme-pm"),
+		htmlErr: map[string]bool{
+			echojobsJobURL("acme-swe"): true,
+			echojobsJobURL("acme-sre"): true,
+			echojobsJobURL("acme-pm"):  true,
+		},
+	}
+
+	jobs, err := echojobs{http: http}.FetchNew(context.Background(), CompanyEntry{}, func(string) bool { return false })
+	if err == nil {
+		t.Fatal("want an error when the sitemap listed postings and none could be read")
+	}
+	if len(jobs) != 0 {
+		t.Errorf("want no jobs alongside the error, got %+v", jobs)
+	}
+}
+
+// One unreadable posting among several readable ones is ordinary attrition, not an outage:
+// the run keeps what it got and reports success. Getting this wrong in the other direction
+// would fail a board every time a single page happened to be malformed.
+func TestEchojobsFetchNewToleratesSomeUnreadableCandidates(t *testing.T) {
+	http := &echojobsFakeHTTP{
+		xmlRoutes: echojobsSingleShardRoutes("acme-swe", "acme-broken"),
+		htmlRoutes: map[string]string{
+			echojobsJobURL("acme-swe"): echojobsJobHTML(`"title":"Engineer",` +
+				`"hiringOrganization":{"@type":"Organization","name":"Acme"},` +
+				`"description":"<p>Role.</p>"`),
+		},
+		htmlErr: map[string]bool{echojobsJobURL("acme-broken"): true},
+	}
+
+	jobs, err := echojobs{http: http}.FetchNew(context.Background(), CompanyEntry{}, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("want the one readable posting, got %+v", jobs)
+	}
+}
+
+// A source that genuinely has nothing to offer still succeeds — there were no candidates, so
+// nothing was missed. The guard must not turn "quiet" into "broken".
+func TestEchojobsFetchNewSucceedsWithNoCandidatesAtAll(t *testing.T) {
+	http := &echojobsFakeHTTP{xmlRoutes: echojobsSingleShardRoutes()}
+
+	jobs, err := echojobs{http: http}.FetchNew(context.Background(), CompanyEntry{}, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("want no jobs, got %+v", jobs)
 	}
 }

--- a/internal/ingest/sources/firecrawltier.go
+++ b/internal/ingest/sources/firecrawltier.go
@@ -1,0 +1,164 @@
+package sources
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/html"
+
+	"github.com/strelov1/freehire/internal/platform/firecrawl"
+)
+
+// firecrawlProviders is the opt-in allowlist of providers that refuse EVERY address this
+// repository can egress from, so their crawl goes through a hosted scraping API.
+//
+// This is the third and last resort, and the order matters. proxiedProviders answers "our IP
+// is blocked but another one is not". browserProviders answers "the page needs JavaScript
+// run". This one answers "no address we can obtain is served at all" — and it is the only one
+// that costs money per page, so nothing lands here that either of the others can reach.
+//
+// Measured 2026-09-07, both providers: 403 from the production datacenter IP and 403 through
+// SOURCES_PROXY_URL, whose exit their edge classifies as datacenter too; served normally by
+// the hosted API. The browser tier does not help, because the refusal comes before any
+// challenge is offered.
+//
+// What is behind those walls is thin, and whoever changes this should know the number rather
+// than rediscover it: run through this repository's own classify.IsTech, bayt's IT category
+// passed 0 of 33 titles and gulftalent's postings 5 of 400 (1.25%). They are project managers,
+// professors, chefs and hotel electricians. This tier was built with that measured and
+// accepted, which is why every guard below exists.
+var firecrawlProviders = map[string]func(*firecrawlClient) Source{
+	"bayt":       func(c *firecrawlClient) Source { return NewBayt(c) },
+	"gulftalent": func(c *firecrawlClient) Source { return NewGulfTalent(c) },
+}
+
+// defaultFirecrawlBudget is how many pages one run may fetch when nothing says otherwise.
+// Deliberately small against a site listing 60 000 postings: the difference between a bounded
+// run and an unbounded one is the difference between a nightly trickle and a month's
+// allowance gone by morning. Raising it is a decision with a number attached.
+const defaultFirecrawlBudget = 500
+
+// firecrawlClient adapts the hosted fetch to the two transports the target adapters declare —
+// baytHTTP is HTMLGetter, gulftalentHTTP is XMLGetter + HTMLGetter — so NEITHER ADAPTER
+// CHANGES. What is wrong with these providers is the address a request leaves from, not how
+// the response is read.
+type firecrawlClient struct {
+	api *firecrawl.Client
+}
+
+var (
+	_ XMLGetter  = (*firecrawlClient)(nil)
+	_ HTMLGetter = (*firecrawlClient)(nil)
+)
+
+// firecrawlStatusError renders a TARGET status as the same typed error the plain client
+// produces, so detailUnreadable and isRateLimited keep reading it. The status is the target's,
+// never the vendor's: the vendor answers 200 while reporting a refusal inside.
+func firecrawlStatusError(url string, status int) error {
+	if status >= 200 && status < 300 {
+		return nil
+	}
+	return &StatusError{Method: http.MethodGet, Code: status, URL: url}
+}
+
+func (c *firecrawlClient) get(ctx context.Context, url string) ([]byte, error) {
+	status, body, err := c.api.Fetch(ctx, url)
+	if err != nil {
+		return nil, fmt.Errorf("sources: hosted GET %s: %w", url, err)
+	}
+	if err := firecrawlStatusError(url, status); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func (c *firecrawlClient) GetXML(ctx context.Context, url string, v any) error {
+	body, err := c.get(ctx, url)
+	if err != nil {
+		return err
+	}
+	if err := xml.NewDecoder(bytes.NewReader(body)).Decode(v); err != nil {
+		return fmt.Errorf("sources: hosted GET %s: decode xml: %w", url, err)
+	}
+	return nil
+}
+
+func (c *firecrawlClient) GetHTML(ctx context.Context, url string) (*html.Node, error) {
+	body, err := c.get(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	node, err := html.Parse(bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("sources: hosted GET %s: parse html: %w", url, err)
+	}
+	return node, nil
+}
+
+// ApplyFirecrawlEgress rewires the firecrawlProviders in registry onto the hosted API.
+//
+// It MUST be applied LAST, after ApplyProxyEgress and ApplyBrowserEgress. gulftalent is in
+// proxiedFingerprintProviders as well, and both write the same registry entry — the override
+// is wanted (that transport is measured as refused, this one as served) so it is ordered and
+// tested rather than left to whichever ran last. Without a key gulftalent keeps the
+// fingerprint transport exactly as today, which is what makes an unconfigured deployment
+// bit-for-bit unchanged.
+//
+// No key means no tier and no client, so merging this can spend nothing. An unusable page
+// budget is an error rather than a fallback: it is the one knob that decides what a night
+// costs, and a typo in it must not be quietly absorbed.
+func ApplyFirecrawlEgress(registry map[string]Source) error {
+	key := strings.TrimSpace(os.Getenv("FIRECRAWL_API_KEY"))
+	if key == "" {
+		return nil
+	}
+	if !anyFirecrawlProviderRegistered(registry) {
+		return nil
+	}
+	budget, err := firecrawlBudget(os.Getenv("FIRECRAWL_MAX_PAGES_PER_RUN"))
+	if err != nil {
+		return err
+	}
+	api, err := firecrawl.New(firecrawl.Config{APIKey: key, MaxPagesPerRun: budget})
+	if err != nil {
+		return fmt.Errorf("sources: hosted tier: %w", err)
+	}
+	// One client for the whole run, so the budget counts across every provider in it: what is
+	// being protected is the account, and no single adapter can know what the others spent.
+	c := &firecrawlClient{api: api}
+	for name, build := range firecrawlProviders {
+		if _, ok := registry[name]; ok {
+			registry[name] = build(c)
+		}
+	}
+	return nil
+}
+
+func anyFirecrawlProviderRegistered(registry map[string]Source) bool {
+	for name := range firecrawlProviders {
+		if _, ok := registry[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// firecrawlBudget resolves FIRECRAWL_MAX_PAGES_PER_RUN, defaulting when unset and refusing
+// anything that is not a positive number of pages.
+func firecrawlBudget(env string) (int64, error) {
+	env = strings.TrimSpace(env)
+	if env == "" {
+		return defaultFirecrawlBudget, nil
+	}
+	n, err := strconv.ParseInt(env, 10, 64)
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("sources: FIRECRAWL_MAX_PAGES_PER_RUN must be a positive number of pages, got %q", env)
+	}
+	return n, nil
+}

--- a/internal/ingest/sources/firecrawltier_test.go
+++ b/internal/ingest/sources/firecrawltier_test.go
@@ -1,0 +1,139 @@
+package sources
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+// The hosted client's errors must be the same type the plain client produces, for the reason
+// the browser client's are: detailUnreadable and isRateLimited match on *StatusError, so a
+// hosted 404 that arrived as a bare error would stop meaning "this posting is gone".
+func TestFirecrawlStatusErrorMatchesThePlainClient(t *testing.T) {
+	if err := firecrawlStatusError("https://example.test/x", http.StatusOK); err != nil {
+		t.Errorf("200 produced an error: %v", err)
+	}
+	err := firecrawlStatusError("https://example.test/x", http.StatusNotFound)
+	var se *StatusError
+	if !errors.As(err, &se) {
+		t.Fatalf("error is %T, want *StatusError", err)
+	}
+	if se.Code != http.StatusNotFound {
+		t.Errorf("Code = %d, want 404", se.Code)
+	}
+}
+
+// Both target adapters are unchanged by this tier, which only holds if the client satisfies
+// exactly what they already declare.
+func TestFirecrawlClientSatisfiesBothAdaptersTransports(t *testing.T) {
+	var c any = &firecrawlClient{}
+	if _, ok := c.(baytHTTP); !ok {
+		t.Error("firecrawlClient does not satisfy baytHTTP")
+	}
+	if _, ok := c.(gulftalentHTTP); !ok {
+		t.Error("firecrawlClient does not satisfy gulftalentHTTP")
+	}
+}
+
+func TestHostedTierCarriesTheTwoUnreachableProviders(t *testing.T) {
+	for _, name := range []string{"bayt", "gulftalent"} {
+		if _, ok := firecrawlProviders[name]; !ok {
+			t.Errorf("%s is not in firecrawlProviders", name)
+		}
+	}
+}
+
+// Without a key nothing is rewired and no client is built, so merging this change cannot
+// spend anything.
+func TestApplyFirecrawlEgressIsANoOpWithoutAKey(t *testing.T) {
+	t.Setenv("FIRECRAWL_API_KEY", "")
+	registry := map[string]Source{"bayt": NewBayt(NewClient()), "gulftalent": NewGulfTalent(NewClient())}
+	before := map[string]Source{"bayt": registry["bayt"], "gulftalent": registry["gulftalent"]}
+
+	if err := ApplyFirecrawlEgress(registry); err != nil {
+		t.Fatalf("ApplyFirecrawlEgress: %v", err)
+	}
+	for name, was := range before {
+		if registry[name] != was {
+			t.Errorf("%s was rewired with no API key configured", name)
+		}
+	}
+}
+
+func TestApplyFirecrawlEgressRewiresBothWithAKey(t *testing.T) {
+	t.Setenv("FIRECRAWL_API_KEY", "test-key")
+	registry := map[string]Source{"bayt": NewBayt(NewClient()), "gulftalent": NewGulfTalent(NewClient())}
+	before := map[string]Source{"bayt": registry["bayt"], "gulftalent": registry["gulftalent"]}
+
+	if err := ApplyFirecrawlEgress(registry); err != nil {
+		t.Fatalf("ApplyFirecrawlEgress: %v", err)
+	}
+	for name, was := range before {
+		if registry[name] == was {
+			t.Errorf("%s was not rewired onto the hosted tier", name)
+		}
+	}
+}
+
+// gulftalent sits in proxiedFingerprintProviders too, and both tiers rewire the same registry
+// entry. The override is WANTED here — the fingerprint transport is measured as refused and
+// the hosted one as served — so the order is pinned rather than left to whichever ran last.
+func TestHostedTierDeliberatelyOverridesTheFingerprintTierForGulftalent(t *testing.T) {
+	t.Setenv("SOURCES_PROXY_URL", "http://user:pass@proxy.invalid:8080")
+	t.Setenv("FIRECRAWL_API_KEY", "test-key")
+
+	registry := map[string]Source{"gulftalent": NewGulfTalent(NewClient())}
+	if err := ApplyProxyEgress(registry); err != nil {
+		t.Fatalf("ApplyProxyEgress: %v", err)
+	}
+	viaFingerprint := registry["gulftalent"]
+	if err := ApplyFirecrawlEgress(registry); err != nil {
+		t.Fatalf("ApplyFirecrawlEgress: %v", err)
+	}
+	if registry["gulftalent"] == viaFingerprint {
+		t.Error("gulftalent kept the fingerprint transport; the hosted tier must run last and win")
+	}
+}
+
+// And the fallback: with no key it keeps exactly the transport it has today, so an
+// unconfigured deployment is bit-for-bit unchanged.
+func TestGulftalentKeepsTheFingerprintTierWithoutAKey(t *testing.T) {
+	t.Setenv("SOURCES_PROXY_URL", "http://user:pass@proxy.invalid:8080")
+	t.Setenv("FIRECRAWL_API_KEY", "")
+
+	registry := map[string]Source{"gulftalent": NewGulfTalent(NewClient())}
+	if err := ApplyProxyEgress(registry); err != nil {
+		t.Fatalf("ApplyProxyEgress: %v", err)
+	}
+	viaFingerprint := registry["gulftalent"]
+	if err := ApplyFirecrawlEgress(registry); err != nil {
+		t.Fatalf("ApplyFirecrawlEgress: %v", err)
+	}
+	if registry["gulftalent"] != viaFingerprint {
+		t.Error("gulftalent lost its fingerprint transport with no hosted key configured")
+	}
+}
+
+func TestApplyFirecrawlEgressIgnoresAnUnrelatedRegistry(t *testing.T) {
+	t.Setenv("FIRECRAWL_API_KEY", "test-key")
+	registry := map[string]Source{"greenhouse": NewGreenhouse(NewClient())}
+	before := registry["greenhouse"]
+
+	if err := ApplyFirecrawlEgress(registry); err != nil {
+		t.Fatalf("ApplyFirecrawlEgress: %v", err)
+	}
+	if registry["greenhouse"] != before {
+		t.Error("an unrelated provider was rewired")
+	}
+}
+
+// A set-but-unusable budget fails the run rather than falling back to a default. This is the
+// one knob that decides how much money a night can cost, so a typo in it must not be absorbed.
+func TestApplyFirecrawlEgressRejectsAnUnparseableBudget(t *testing.T) {
+	t.Setenv("FIRECRAWL_API_KEY", "test-key")
+	t.Setenv("FIRECRAWL_MAX_PAGES_PER_RUN", "lots")
+	registry := map[string]Source{"bayt": NewBayt(NewClient())}
+	if err := ApplyFirecrawlEgress(registry); err == nil {
+		t.Error("want an error for an unparseable page budget, got nil")
+	}
+}

--- a/internal/ingest/sources/proxy.go
+++ b/internal/ingest/sources/proxy.go
@@ -180,12 +180,18 @@ func ApplyProxyEgress(registry map[string]Source) error {
 // partway through — see sources/gulftalent.yml for the measurement and why its timer is off.
 // Validate a provider here by what a whole run yields, never by one 200.
 //
-// bayt is absent, but not because it is unpassable. That was the earlier reading and it is
-// wrong: measured 2026-09-01 with this same transport, bayt's UAE listing returns 200 and
-// 251 KB of real HTML from a residential IP, so no JS challenge is involved. It is 403 from
-// the prod datacenter IP AND 403 through SOURCES_PROXY_URL, whose exit that edge classifies
-// as datacenter too — adding bayt here today would route it through an IP it already
-// refuses. It belongs here the day a genuinely residential pool exists, alongside wantedkr.
+// bayt is absent, and gulftalent's entry here is now its FALLBACK rather than its live
+// transport. Both are 403 from the prod datacenter IP AND 403 through SOURCES_PROXY_URL,
+// whose exit their edge classifies as datacenter too — no fingerprint helps, because the
+// refusal precedes any handshake we could disguise, and the browser tier does not help
+// either, because no challenge is ever offered to solve.
+//
+// What answered it was an address we do not own: see firecrawlProviders (firecrawltier.go),
+// which serves both and is applied after this, deliberately overriding gulftalent's entry
+// below. Without FIRECRAWL_API_KEY that override does not happen and gulftalent keeps the
+// fingerprint transport exactly as before — refused, but unchanged.
+//
+// wantedkr is the one still genuinely waiting for a residential pool.
 //
 // echojobs used to be named here for the same reason and no longer is: measured 2026-09-07,
 // its obstacle is a JS challenge rather than an IP classification, and the EXISTING proxy

--- a/internal/ingest/sources/proxy.go
+++ b/internal/ingest/sources/proxy.go
@@ -185,8 +185,13 @@ func ApplyProxyEgress(registry map[string]Source) error {
 // 251 KB of real HTML from a residential IP, so no JS challenge is involved. It is 403 from
 // the prod datacenter IP AND 403 through SOURCES_PROXY_URL, whose exit that edge classifies
 // as datacenter too — adding bayt here today would route it through an IP it already
-// refuses. It belongs here the day a genuinely residential pool exists, alongside echojobs
-// (Vercel's bot firewall, same measurement, same answer) and wantedkr.
+// refuses. It belongs here the day a genuinely residential pool exists, alongside wantedkr.
+//
+// echojobs used to be named here for the same reason and no longer is: measured 2026-09-07,
+// its obstacle is a JS challenge rather than an IP classification, and the EXISTING proxy
+// serves that challenge rather than refusing outright. What it needed was something to
+// execute the JavaScript, which is browserProviders — see browsertier.go. A fingerprint does
+// not help there; only a browser does.
 var proxiedFingerprintProviders = map[string]func(*fingerprintHTTP) Source{
 	"gulftalent": func(c *fingerprintHTTP) Source { return NewGulfTalent(c) },
 }

--- a/internal/platform/arch/layering/blocks.go
+++ b/internal/platform/arch/layering/blocks.go
@@ -53,6 +53,11 @@ var blocks = map[string][]string{
 		// and ingest/sources (reads a source gated behind a JavaScript challenge), so in
 		// either one it would be an upward edge for the other.
 		"browser",
+		// firecrawl is the browseruse category, not the browser one, and the distinction is
+		// economic rather than technical: it is an HTTP client for a METERED third-party
+		// scraping API, where platform/browser launches a free process on our own host. Its
+		// caller is ingest/sources, for the two providers that refuse every address we own.
+		"firecrawl",
 		// browseruse is the HTTP half of talking to the browser-use.com cloud agent API —
 		// create/poll/fetch one run — and knows nothing about ATS forms or resolved
 		// application plans, the same "transport, not domain" category as llm and

--- a/internal/platform/arch/layering/blocks.go
+++ b/internal/platform/arch/layering/blocks.go
@@ -45,6 +45,14 @@ var blocks = map[string][]string{
 		// an upward edge for one of them.
 		"aigateway",
 		"arch", "arch/layering", "backfillpage", "blobstore",
+		// browser is the same "transport, not domain" category one step lower down: how this
+		// repository LAUNCHES a local headless Chrome and fetches a URL through one. It is
+		// not browseruse below, which is an HTTP client for somebody else's hosted browser —
+		// this one is a process on our own host. It is here rather than in either caller
+		// because it has two, in different blocks: api/atsapply (fills an application form)
+		// and ingest/sources (reads a source gated behind a JavaScript challenge), so in
+		// either one it would be an upward edge for the other.
+		"browser",
 		// browseruse is the HTTP half of talking to the browser-use.com cloud agent API —
 		// create/poll/fetch one run — and knows nothing about ATS forms or resolved
 		// application plans, the same "transport, not domain" category as llm and

--- a/internal/platform/browser/AGENTS.md
+++ b/internal/platform/browser/AGENTS.md
@@ -1,0 +1,83 @@
+# Headless browser transport
+
+Launching a headless Chrome, and fetching URLs through one. Transport, not a feature: this
+package knows nothing about jobs, candidates or application forms, in the same sense
+`platform/llm` and `platform/aigateway` know nothing about what they carry bytes for.
+
+It is in `platform` because two blocks need it and neither may import the other —
+`api/atsapply` (block 8) drives a browser to fill an application form, `ingest/sources`
+(block 7) needs one to read a source behind a JavaScript challenge. `blocks.go` records the
+same argument for `aigateway`.
+
+**Not to be confused with `platform/browseruse`**, its neighbour: that is an HTTP client for
+somebody else's *hosted* browser (browser-use.com). This one launches a process on our own
+host.
+
+## What it owns
+
+- **`LaunchOptions` / `LaunchOptionsThroughProxy`** — the stealth launch flags, and the single
+  home for them in the repository. A second copy would mean the next anti-bot fix lands in one
+  caller and silently not the other.
+- **`Session`** — a running browser, a small pool of tabs, and `Fetch(ctx, url) (status, body,
+  error)`.
+
+What it deliberately does NOT own is what a caller then does with a page. `atsapply` scans a
+DOM and submits a form; `sources` reads a body. An abstraction over those two would be an
+abstraction over nothing.
+
+## The three things measured, not assumed
+
+Each of these was found by running against a real bot wall (echojobs.io, behind Vercel's, on
+2026-09-07 — freehire#2588), and each is a trap the obvious implementation falls into.
+
+**A browser alone is not enough, and neither is a proxy.** From the production datacenter IP
+both a plain GET and a headless browser get `403 x-vercel-mitigated: deny` — no challenge is
+offered at all, so there is nothing for a browser to solve. Through the egress proxy a plain
+GET gets the challenge and cannot pass it. Only the pair works. That is why the ingest side
+refuses to launch a browser without a proxy configured.
+
+**The user agent is the loudest tell, and no launch flag removes it.** A hand-rolled probe
+cleared the wall in eight seconds while this package sat refused for twenty, with identical
+flags, proxy and tab structure — the probe set a desktop user agent and the package did not,
+so Chrome announced `HeadlessChrome`. `hideHeadlessUserAgent` reads the running browser's own
+agent and rewrites that one word. It is read rather than written as a literal so it never
+claims a Chrome version the binary is not; for a fingerprint, a confident lie is worse than
+nothing.
+
+**Do not retry a refused request to find out whether the wall lifted.** These walls answer with
+a rate-limit-flavoured `429`, so a burst of refused fetches is what holds them up. Clearance is
+detected by WATCHING: navigate once, and wait for the main document response to turn 2xx — the
+challenge serves the document with a refusal and then reloads itself. No extra request, no
+site-specific marker, and a ceiling rather than a delay.
+
+## Why the fetch happens inside the page
+
+`Session.Fetch` evaluates `fetch()` in the cleared page rather than navigating to the URL.
+Same clearance, same cookies, same TLS identity, but only the bytes come back: 0.36s against
+4.2s for a navigation, measured.
+
+The cheaper-looking idea does not work and was measured too — the clearance cookie handed to
+`net/http` still gets the challenge back, so clearance is bound to more than the cookie and
+the request has to leave from the browser itself.
+
+A non-2xx is returned as a **status, not an error**. Only some statuses may be read as "this
+resource is gone"; collapsing them would take that decision away from the caller. `sources`
+turns them into its own `*StatusError` so a browser-fetched 404 still means what it means.
+
+## Credentials
+
+Chrome takes its proxy as a command-line argument, and a command line is readable by every
+process on the host. So the scheme and host go there and **the credentials never do** — they
+are answered over the debugging protocol (`fetch.EventAuthRequired`). A unit test scans the
+flag set for a leaked password, and the error text for a malformed proxy is redacted, because
+an error about a bad proxy must not be the thing that prints it.
+
+## Testing
+
+`session_integration_test.go` is `//go:build integration` and **skips when no Chrome is
+installed** — CI's backend job has none, and a red build there would mean nothing. It drives a
+local server that serves its content only after a JS-set cookie: the smallest thing shaped
+like the real obstacle.
+
+The clearance test asserts the challenge count **stops growing**, not that it equals one.
+Pinning the exact number would fail on a slow machine for a reason that is not a bug.

--- a/internal/platform/browser/browser.go
+++ b/internal/platform/browser/browser.go
@@ -97,18 +97,30 @@ func redactProxy(proxyURL string) string {
 	return u.String()
 }
 
-// LaunchOptions are the chromedp allocator options every caller in this repository launches
-// a browser with. Pass an empty proxyURL for a direct launch.
-func LaunchOptions(proxyURL string) ([]chromedp.ExecAllocatorOption, error) {
+// LaunchOptions are the chromedp allocator options for a browser that egresses directly.
+// It returns no error because the only thing that can fail is parsing a proxy URL, and there
+// is none — a caller that has nothing to configure should not have an error to ignore.
+func LaunchOptions() []chromedp.ExecAllocatorOption {
+	return optionsFor(stealthFlags())
+}
+
+// LaunchOptionsThroughProxy is LaunchOptions for a browser that egresses through proxyURL.
+// An empty proxyURL means direct, so this is also the shared implementation.
+func LaunchOptionsThroughProxy(proxyURL string) ([]chromedp.ExecAllocatorOption, error) {
 	flags, err := launchFlags(proxyURL)
 	if err != nil {
 		return nil, err
 	}
+	return optionsFor(flags), nil
+}
+
+// optionsFor turns the decided flag set into chromedp's options.
+func optionsFor(flags []flag) []chromedp.ExecAllocatorOption {
 	// len == cap on the package array's slice, so the first append copies rather than
 	// writing into chromedp's own defaults.
 	opts := chromedp.DefaultExecAllocatorOptions[:]
 	for _, f := range flags {
 		opts = append(opts, chromedp.Flag(f.name, f.value))
 	}
-	return opts, nil
+	return opts
 }

--- a/internal/platform/browser/browser.go
+++ b/internal/platform/browser/browser.go
@@ -1,0 +1,114 @@
+// Package browser launches a headless Chrome and fetches URLs through it. It is transport,
+// not a feature: it knows nothing about jobs, candidates or applications, in the same sense
+// platform/llm and platform/aigateway know nothing about the domain they carry bytes for.
+//
+// It exists because two blocks need a browser and neither may import the other. api/atsapply
+// drives one to fill an application form; ingest/sources needs one to read a source whose
+// pages sit behind a JavaScript challenge. api is block 8 and ingest is block 7, so a shared
+// piece in either would be an upward edge for the other — the same argument blocks.go already
+// records for aigateway.
+//
+// What is shared is deliberately narrow: how to LAUNCH a browser that does not announce
+// itself as automated, and how to fetch a URL through one. What is not shared is what either
+// caller then does with the page — atsapply scans a DOM and submits a form, sources reads a
+// body — because an abstraction over those two would be an abstraction over nothing.
+package browser
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/chromedp/chromedp"
+)
+
+// flag is one Chrome command-line switch, kept as data so the flag set can be asserted on.
+// chromedp's own ExecAllocatorOption is an opaque func over an unexported struct, so a test
+// cannot read one back — and the one thing that most needs a test here is a NEGATIVE, that a
+// proxy credential never reaches this list.
+type flag struct {
+	name  string
+	value any
+}
+
+// stealthFlags are what make a headless Chrome resemble an ordinary one. This is the single
+// home for them in the repository: a second copy would mean the next anti-bot fix lands in
+// one caller and silently not the other.
+//
+// The pair is what the 2026-09-02 auto-apply spike measured against bot.sannysoft.com:
+// disable-blink-features=AutomationControlled alone flipped navigator.webdriver from true to
+// false, matching what a dedicated stealth framework achieved, at no extra dependency. It is
+// not a claim of undetectability — see the caveats in that change's design.md.
+func stealthFlags() []flag {
+	return []flag{
+		{name: "headless", value: true},
+		{name: "disable-blink-features", value: "AutomationControlled"},
+	}
+}
+
+// launchFlags is the decision LaunchOptions makes, as inspectable data.
+//
+// A proxy contributes its scheme and host and NOTHING else. Chrome takes proxy-server as a
+// command-line argument, and a command line is world-readable on the host, so credentials
+// must not travel that way; Session answers Chrome's auth challenge over the debugging
+// protocol instead. An unparseable proxy is an error rather than a silent direct launch: for
+// the provider this exists to serve, a direct browser is refused outright, which would look
+// exactly like a working crawl that found nothing.
+func launchFlags(proxyURL string) ([]flag, error) {
+	flags := stealthFlags()
+	if proxyURL == "" {
+		return flags, nil
+	}
+	u, err := url.Parse(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("browser: parse proxy url: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("browser: proxy url %q has no scheme or host", redactProxy(proxyURL))
+	}
+	return append(flags, flag{name: "proxy-server", value: u.Scheme + "://" + u.Host}), nil
+}
+
+// proxyCredentials reads the credentials launchFlags deliberately dropped, for the caller
+// that answers Chrome's auth challenge over the protocol. Both empty means the proxy needs
+// no authentication, which is not an error.
+func proxyCredentials(proxyURL string) (user, pass string, err error) {
+	if proxyURL == "" {
+		return "", "", nil
+	}
+	u, err := url.Parse(proxyURL)
+	if err != nil {
+		return "", "", fmt.Errorf("browser: parse proxy url: %w", err)
+	}
+	if u.User == nil {
+		return "", "", nil
+	}
+	pass, _ = u.User.Password()
+	return u.User.Username(), pass, nil
+}
+
+// redactProxy renders a proxy URL for an error message without its credentials — an error
+// about a malformed proxy must not be the thing that prints the password into a log.
+func redactProxy(proxyURL string) string {
+	u, err := url.Parse(proxyURL)
+	if err != nil || u.User == nil {
+		return proxyURL
+	}
+	u.User = url.User("redacted")
+	return u.String()
+}
+
+// LaunchOptions are the chromedp allocator options every caller in this repository launches
+// a browser with. Pass an empty proxyURL for a direct launch.
+func LaunchOptions(proxyURL string) ([]chromedp.ExecAllocatorOption, error) {
+	flags, err := launchFlags(proxyURL)
+	if err != nil {
+		return nil, err
+	}
+	// len == cap on the package array's slice, so the first append copies rather than
+	// writing into chromedp's own defaults.
+	opts := chromedp.DefaultExecAllocatorOptions[:]
+	for _, f := range flags {
+		opts = append(opts, chromedp.Flag(f.name, f.value))
+	}
+	return opts, nil
+}

--- a/internal/platform/browser/browser_test.go
+++ b/internal/platform/browser/browser_test.go
@@ -109,3 +109,22 @@ func TestProxyIsRedactedInErrorText(t *testing.T) {
 		t.Errorf("password leaked into the error text: %v", err)
 	}
 }
+
+// LaunchOptions and LaunchOptionsThroughProxy("") must decide the same thing — they are one
+// launch with and without a proxy, not two. They reach chromedp by different lines, so the
+// flag set they share is what this pins; option values are opaque funcs and cannot be compared.
+func TestDirectLaunchDecidesExactlyTheStealthFlags(t *testing.T) {
+	viaProxyPath, err := launchFlags("")
+	if err != nil {
+		t.Fatalf("launchFlags: %v", err)
+	}
+	direct := stealthFlags()
+	if len(viaProxyPath) != len(direct) {
+		t.Fatalf("launchFlags(\"\") has %d flags, stealthFlags has %d", len(viaProxyPath), len(direct))
+	}
+	for _, want := range direct {
+		if !hasFlag(viaProxyPath, want) {
+			t.Errorf("launchFlags(\"\") is missing %s", rendered(want))
+		}
+	}
+}

--- a/internal/platform/browser/browser_test.go
+++ b/internal/platform/browser/browser_test.go
@@ -1,0 +1,111 @@
+package browser
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// The stealth pair is the whole point of this package existing rather than each caller
+// spelling the flags out, so the test names them rather than counting them.
+func TestLaunchFlagsCarryTheStealthPair(t *testing.T) {
+	got, err := launchFlags("")
+	if err != nil {
+		t.Fatalf("launchFlags: %v", err)
+	}
+	for _, want := range []flag{
+		{name: "headless", value: true},
+		{name: "disable-blink-features", value: "AutomationControlled"},
+	} {
+		if !hasFlag(got, want) {
+			t.Errorf("missing %s=%v in %v", want.name, want.value, got)
+		}
+	}
+}
+
+func TestLaunchFlagsAddNoProxyWhenNoneGiven(t *testing.T) {
+	got, err := launchFlags("")
+	if err != nil {
+		t.Fatalf("launchFlags: %v", err)
+	}
+	for _, f := range got {
+		if f.name == "proxy-server" {
+			t.Errorf("proxy-server=%v set with no proxy configured", f.value)
+		}
+	}
+}
+
+// The credential check is the reason this function is inspectable at all. Chrome takes its
+// proxy as a command-line argument, and a command line is readable by every process on the
+// host — so the scheme and host may go there and the credentials may not. They are answered
+// over the debugging protocol instead (see Session).
+func TestLaunchFlagsKeepProxyCredentialsOutOfTheCommandLine(t *testing.T) {
+	got, err := launchFlags("http://bob:hunter2@proxy.example:8080")
+	if err != nil {
+		t.Fatalf("launchFlags: %v", err)
+	}
+	if !hasFlag(got, flag{name: "proxy-server", value: "http://proxy.example:8080"}) {
+		t.Errorf("proxy-server flag missing or wrong, got %v", got)
+	}
+	for _, f := range got {
+		s := rendered(f)
+		for _, secret := range []string{"bob", "hunter2"} {
+			if strings.Contains(s, secret) {
+				t.Errorf("credential %q leaked into flag %s=%v", secret, f.name, f.value)
+			}
+		}
+	}
+}
+
+func TestProxyCredentialsAreReadableForTheProtocolPath(t *testing.T) {
+	user, pass, err := proxyCredentials("http://bob:hunter2@proxy.example:8080")
+	if err != nil {
+		t.Fatalf("proxyCredentials: %v", err)
+	}
+	if user != "bob" || pass != "hunter2" {
+		t.Errorf("got %q/%q, want bob/hunter2", user, pass)
+	}
+}
+
+func TestProxyCredentialsAreEmptyForAnUnauthenticatedProxy(t *testing.T) {
+	user, pass, err := proxyCredentials("http://proxy.example:8080")
+	if err != nil {
+		t.Fatalf("proxyCredentials: %v", err)
+	}
+	if user != "" || pass != "" {
+		t.Errorf("got %q/%q, want both empty", user, pass)
+	}
+}
+
+// A proxy URL that cannot be parsed fails the launch rather than silently starting a browser
+// on the direct IP — which, for the one provider that needs this, would look exactly like a
+// working crawl that finds nothing.
+func TestLaunchFlagsRejectAnUnparseableProxy(t *testing.T) {
+	if _, err := launchFlags("://not a url"); err == nil {
+		t.Error("want an error for an unparseable proxy URL, got nil")
+	}
+}
+
+func hasFlag(flags []flag, want flag) bool {
+	for _, f := range flags {
+		if f.name == want.name && f.value == want.value {
+			return true
+		}
+	}
+	return false
+}
+
+func rendered(f flag) string {
+	return fmt.Sprintf("%s=%v", f.name, f.value)
+}
+
+// An error about a malformed proxy must not be the thing that prints the password into a log.
+func TestProxyIsRedactedInErrorText(t *testing.T) {
+	_, err := launchFlags("http://bob:hunter2@")
+	if err == nil {
+		t.Fatal("want an error for a proxy URL with no host")
+	}
+	if strings.Contains(err.Error(), "hunter2") {
+		t.Errorf("password leaked into the error text: %v", err)
+	}
+}

--- a/internal/platform/browser/session.go
+++ b/internal/platform/browser/session.go
@@ -1,0 +1,344 @@
+package browser
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/chromedp/cdproto/fetch"
+	"github.com/chromedp/cdproto/runtime"
+	"github.com/chromedp/chromedp"
+)
+
+// Session is one running browser and a small pool of tabs to fetch through.
+//
+// Fetching happens INSIDE a page rather than by navigating to the URL, and that is the whole
+// design. A site that gates its content behind a JavaScript challenge issues a clearance the
+// browser then carries; a navigation would re-render the whole page for every request, while
+// an in-page fetch reuses the same cleared context and returns just the bytes. Measured
+// against the site this was built for: 4.2s a page by navigation, 0.36s by in-page fetch.
+//
+// The obvious third option does not work and was measured too: taking the browser's clearance
+// cookie and handing it to net/http still gets the challenge back. Clearance is bound to more
+// than the cookie — a TLS fingerprint is the likely other half — so the request has to leave
+// from the browser itself. That is why this package exists at all rather than a cookie jar.
+type Session struct {
+	cancel context.CancelFunc
+	tabs   chan *tab
+	closed sync.Once
+}
+
+// tab is one page context. chromedp serialises actions on a context, so a tab serves one
+// request at a time and concurrency is a matter of how many there are.
+type tab struct {
+	ctx     context.Context
+	cancel  context.CancelFunc
+	cleared map[string]bool // origins this tab has already passed the challenge for
+}
+
+// clearanceWait bounds how long a tab waits for a challenge to resolve. It is a CEILING, not
+// a delay: clear polls for the origin becoming readable and returns the moment it does, so a
+// site that clears in a second costs a second. A fixed sleep here would make every crawl pay
+// the worst case, and the clearance is the expensive half of this whole design.
+const clearanceWait = 20 * time.Second
+
+// clearancePoll is how often clear re-asks whether the origin has become readable.
+const clearancePoll = 250 * time.Millisecond
+
+// fetchTimeout bounds one in-page fetch. An order of magnitude over the measured 0.36s, so a
+// slow response is waited out and a hung one is not.
+const fetchTimeout = 45 * time.Second
+
+// NewSession launches a browser with the shared stealth options, egressing through proxyURL
+// when one is given, and opens tabs tabs. Close it when done: nothing here is pooled across
+// sessions, so one crawl's cookies can never leak into the next.
+func NewSession(ctx context.Context, proxyURL string, tabs int) (*Session, error) {
+	if tabs < 1 {
+		tabs = 1
+	}
+	opts, err := LaunchOptions(proxyURL)
+	if err != nil {
+		return nil, err
+	}
+	user, pass, err := proxyCredentials(proxyURL)
+	if err != nil {
+		return nil, err
+	}
+
+	allocCtx, cancelAlloc := chromedp.NewExecAllocator(ctx, opts...)
+	browserCtx, cancelBrowser := chromedp.NewContext(allocCtx)
+	cancel := func() {
+		cancelBrowser()
+		cancelAlloc()
+	}
+	// Start the browser process before opening tabs off it, so a launch failure is reported
+	// here rather than as a confusing error on the first fetch.
+	if err := chromedp.Run(browserCtx); err != nil {
+		cancel()
+		return nil, fmt.Errorf("browser: launch: %w", err)
+	}
+
+	s := &Session{cancel: cancel, tabs: make(chan *tab, tabs)}
+	for i := 0; i < tabs; i++ {
+		t, err := newTab(browserCtx, user, pass)
+		if err != nil {
+			s.Close()
+			return nil, err
+		}
+		s.tabs <- t
+	}
+	return s, nil
+}
+
+func newTab(browserCtx context.Context, user, pass string) (*tab, error) {
+	tabCtx, cancelTab := chromedp.NewContext(browserCtx)
+	if err := chromedp.Run(tabCtx); err != nil {
+		cancelTab()
+		return nil, fmt.Errorf("browser: open tab: %w", err)
+	}
+	if user != "" {
+		if err := enableProxyAuth(tabCtx, user, pass); err != nil {
+			cancelTab()
+			return nil, err
+		}
+	}
+	return &tab{ctx: tabCtx, cancel: cancelTab, cleared: map[string]bool{}}, nil
+}
+
+// enableProxyAuth answers Chrome's proxy authentication over the debugging protocol. The
+// credentials deliberately never reach the command line (see launchFlags), so this is the
+// only path they travel.
+//
+// Enabling Fetch means every request is paused until something continues it, so the handler
+// must answer both events — a paused request that nobody continues hangs the page.
+func enableProxyAuth(ctx context.Context, user, pass string) error {
+	chromedp.ListenTarget(ctx, func(ev any) {
+		switch e := ev.(type) {
+		case *fetch.EventAuthRequired:
+			go func() {
+				_ = chromedp.Run(ctx, fetch.ContinueWithAuth(e.RequestID, &fetch.AuthChallengeResponse{
+					Response: fetch.AuthChallengeResponseResponseProvideCredentials,
+					Username: user,
+					Password: pass,
+				}))
+			}()
+		case *fetch.EventRequestPaused:
+			go func() { _ = chromedp.Run(ctx, fetch.ContinueRequest(e.RequestID)) }()
+		}
+	})
+	if err := chromedp.Run(ctx, fetch.Enable().WithHandleAuthRequests(true)); err != nil {
+		return fmt.Errorf("browser: enable proxy auth: %w", err)
+	}
+	return nil
+}
+
+// Close tears the browser down. Safe to call more than once.
+func (s *Session) Close() {
+	s.closed.Do(func() {
+		close(s.tabs)
+		for t := range s.tabs {
+			t.cancel()
+		}
+		s.cancel()
+	})
+}
+
+// Fetch returns the response status and body for rawURL, obtaining clearance for its origin
+// first if this tab does not have it yet.
+//
+// A non-2xx is NOT an error. The caller decides what a status means — for a job catalogue,
+// only 404 and 410 may be read as "this posting is gone", while 403 and 429 mean we are
+// blocked and nothing may be concluded about the posting at all. Collapsing them here would
+// take that decision away.
+func (s *Session) Fetch(ctx context.Context, rawURL string) (int, []byte, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return 0, nil, fmt.Errorf("browser: parse url: %w", err)
+	}
+	origin := u.Scheme + "://" + u.Host
+
+	t, err := s.take(ctx)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer s.put(t)
+
+	if err := t.clear(ctx, origin); err != nil {
+		return 0, nil, err
+	}
+	return t.fetch(ctx, rawURL)
+}
+
+func (s *Session) take(ctx context.Context) (*tab, error) {
+	select {
+	case t, ok := <-s.tabs:
+		if !ok {
+			return nil, errors.New("browser: session is closed")
+		}
+		return t, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (s *Session) put(t *tab) {
+	defer func() {
+		// A put after Close races with the channel being closed; losing the tab to a closing
+		// session is fine, panicking on the way out is not.
+		_ = recover()
+	}()
+	s.tabs <- t
+}
+
+// derive builds the context a chromedp action runs under. It must descend from the TAB's
+// context, because chromedp carries the browser it belongs to in context values and an
+// action run under anything else fails with "invalid context" — deriving from the caller's
+// context instead is the obvious mistake and it compiles.
+//
+// The caller's context still cancels the work: a watcher cancels the derived one when the
+// caller's is done. Merging two contexts has no standard form, and doing it in five lines
+// here is better than dropping the caller's cancellation on the floor.
+func (t *tab) derive(caller context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(t.ctx, timeout)
+	stop := make(chan struct{})
+	go func() {
+		select {
+		case <-caller.Done():
+			cancel()
+		case <-stop:
+		}
+	}()
+	return ctx, func() {
+		close(stop)
+		cancel()
+	}
+}
+
+// clear loads the origin once so the tab holds whatever the site issues to a client that ran
+// its JavaScript. Whether that clearance is shared across the tabs of one browser profile is
+// unmeasured, and nothing here depends on the answer: each tab clears for itself, and if it
+// turns out to be shared the later tabs simply find the wait already over.
+func (t *tab) clear(ctx context.Context, origin string) error {
+	if t.cleared[origin] {
+		return nil
+	}
+	navCtx, cancel := t.derive(ctx, clearanceWait+fetchTimeout)
+	defer cancel()
+	if err := chromedp.Run(navCtx, chromedp.Navigate(origin)); err != nil {
+		return fmt.Errorf("browser: clear %s: %w", origin, err)
+	}
+
+	// Poll for the origin becoming readable rather than sleeping a fixed time. "Readable" is
+	// deliberately generic — any status below 400 — because this package knows nothing about
+	// which site it is talking to and so cannot recognise a particular challenge page. A
+	// challenge answers 4xx/5xx until it lifts, which is the only property worth relying on.
+	deadline := time.Now().Add(clearanceWait)
+	var last string
+	for {
+		status, _, err := t.fetch(ctx, origin)
+		switch {
+		case err == nil && status < 400:
+			t.cleared[origin] = true
+			return nil
+		case err != nil:
+			last = err.Error()
+		default:
+			last = fmt.Sprintf("origin answered %d", status)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("browser: clear %s: still not readable after %s (%s)", origin, clearanceWait, last)
+		}
+		select {
+		case <-time.After(clearancePoll):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// fetchResult is what the in-page script hands back. The body is base64 so a binary or
+// non-UTF-8 response survives the trip, and so a body containing the separator cannot be
+// mistaken for the framing.
+type fetchResult struct {
+	Status int    `json:"status"`
+	Body   string `json:"body"`
+	Err    string `json:"err"`
+}
+
+// fetchScript issues the request from the page's own context, so it carries the page's
+// clearance, cookies and TLS identity. Errors are returned in-band rather than thrown,
+// because a rejected promise reaches Go as an opaque evaluation failure.
+const fetchScript = `(async () => {
+  try {
+    const r = await fetch(%s, {credentials: "include"});
+    const b = await r.arrayBuffer();
+    let s = "";
+    const bytes = new Uint8Array(b);
+    const chunk = 0x8000;
+    for (let i = 0; i < bytes.length; i += chunk) {
+      s += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
+    }
+    return {status: r.status, body: btoa(s), err: ""};
+  } catch (e) {
+    return {status: 0, body: "", err: String(e)};
+  }
+})()`
+
+func (t *tab) fetch(ctx context.Context, rawURL string) (int, []byte, error) {
+	fetchCtx, cancel := t.derive(ctx, fetchTimeout)
+	defer cancel()
+
+	quoted, err := jsString(rawURL)
+	if err != nil {
+		return 0, nil, err
+	}
+	var res fetchResult
+	if err := chromedp.Run(fetchCtx, chromedp.Evaluate(
+		fmt.Sprintf(fetchScript, quoted), &res, awaitPromise,
+	)); err != nil {
+		return 0, nil, fmt.Errorf("browser: fetch %s: %w", rawURL, err)
+	}
+	if res.Err != "" {
+		return 0, nil, fmt.Errorf("browser: fetch %s: %s", rawURL, res.Err)
+	}
+	body, err := base64.StdEncoding.DecodeString(res.Body)
+	if err != nil {
+		return 0, nil, fmt.Errorf("browser: decode body of %s: %w", rawURL, err)
+	}
+	return res.Status, body, nil
+}
+
+// awaitPromise makes chromedp resolve the async expression rather than hand back a Promise.
+func awaitPromise(p *runtime.EvaluateParams) *runtime.EvaluateParams {
+	return p.WithAwaitPromise(true)
+}
+
+// jsString renders a URL as a JavaScript string literal. The URL is interpolated into a
+// script, so it is quoted rather than concatenated — a URL is attacker-adjacent input on a
+// crawl, since it comes from somebody else's sitemap.
+func jsString(s string) (string, error) {
+	if strings.ContainsAny(s, "\x00\n\r") {
+		return "", fmt.Errorf("browser: url contains a control character: %q", s)
+	}
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '<', '>', '&':
+			fmt.Fprintf(&b, `\u%04x`, r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String(), nil
+}

--- a/internal/platform/browser/session.go
+++ b/internal/platform/browser/session.go
@@ -5,12 +5,16 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/chromedp/cdproto/emulation"
 	"github.com/chromedp/cdproto/fetch"
+	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
 )
@@ -39,15 +43,53 @@ type tab struct {
 	ctx     context.Context
 	cancel  context.CancelFunc
 	cleared map[string]bool // origins this tab has already passed the challenge for
+
+	// docs records the document responses seen since the last navigation began. Clearance is
+	// detected as ANY of them succeeding, not as the last one succeeding: a challenge page can
+	// pull in frames of its own, and a frame refused after the real page loaded would otherwise
+	// look like the wall going back up. The full list rides the timeout error, so a failure
+	// says what the site actually answered instead of only that it did not work.
+	docMu   sync.Mutex
+	docSeen []int
 }
 
-// clearanceWait bounds how long a tab waits for a challenge to resolve. It is a CEILING, not
-// a delay: clear polls for the origin becoming readable and returns the moment it does, so a
-// site that clears in a second costs a second. A fixed sleep here would make every crawl pay
-// the worst case, and the clearance is the expensive half of this whole design.
+func (t *tab) resetDocuments() {
+	t.docMu.Lock()
+	t.docSeen = nil
+	t.docMu.Unlock()
+}
+
+func (t *tab) recordDocument(status int) {
+	t.docMu.Lock()
+	t.docSeen = append(t.docSeen, status)
+	t.docMu.Unlock()
+}
+
+// documentSucceeded reports whether any document response since the navigation was a success,
+// and renders what was seen for the error message.
+func (t *tab) documentSucceeded() (bool, string) {
+	t.docMu.Lock()
+	defer t.docMu.Unlock()
+	ok := false
+	parts := make([]string, 0, len(t.docSeen))
+	for _, st := range t.docSeen {
+		if st >= 200 && st < 400 {
+			ok = true
+		}
+		parts = append(parts, strconv.Itoa(st))
+	}
+	if len(parts) == 0 {
+		return ok, "no document response at all"
+	}
+	return ok, strings.Join(parts, ",")
+}
+
+// clearanceWait bounds how long a tab keeps retrying a request that still looks challenged. It
+// is a CEILING, not a delay: the request is retried and returns the moment it stops being
+// refused, so a site that clears in a second costs a second.
 const clearanceWait = 20 * time.Second
 
-// clearancePoll is how often clear re-asks whether the origin has become readable.
+// clearancePoll is how long to wait between retries of a still-challenged request.
 const clearancePoll = 250 * time.Millisecond
 
 // fetchTimeout bounds one in-page fetch. An order of magnitude over the measured 0.36s, so a
@@ -107,7 +149,57 @@ func newTab(browserCtx context.Context, user, pass string) (*tab, error) {
 			return nil, err
 		}
 	}
-	return &tab{ctx: tabCtx, cancel: cancelTab, cleared: map[string]bool{}}, nil
+	if err := hideHeadlessUserAgent(tabCtx); err != nil {
+		cancelTab()
+		return nil, err
+	}
+	t := &tab{ctx: tabCtx, cancel: cancelTab, cleared: map[string]bool{}}
+	if err := t.watchDocuments(); err != nil {
+		cancelTab()
+		return nil, err
+	}
+	return t, nil
+}
+
+// hideHeadlessUserAgent replaces the browser's own "HeadlessChrome/..." user agent with the
+// same string minus that word.
+//
+// It is the loudest tell there is, and unlike navigator.webdriver no launch flag removes it.
+// Measured against a real bot wall on 2026-09-07: with the default headless agent the site
+// answered 429 and never served a challenge at all, so there was nothing for the browser to
+// solve; with the word removed the same navigation cleared in about eight seconds. Everything
+// else — the flags, the tab structure, the proxy — was identical in both runs.
+//
+// The agent is READ from the running browser rather than written as a literal, so it never
+// claims a Chrome version this binary is not. A hardcoded string would start lying the day
+// Chrome updates, which for a fingerprint is worse than not setting one.
+func hideHeadlessUserAgent(ctx context.Context) error {
+	var ua string
+	if err := chromedp.Run(ctx, chromedp.Evaluate(`navigator.userAgent`, &ua)); err != nil {
+		return fmt.Errorf("browser: read user agent: %w", err)
+	}
+	honest := strings.ReplaceAll(ua, "HeadlessChrome", "Chrome")
+	if honest == ua {
+		return nil // not a headless build; nothing to hide
+	}
+	if err := chromedp.Run(ctx, emulation.SetUserAgentOverride(honest)); err != nil {
+		return fmt.Errorf("browser: set user agent: %w", err)
+	}
+	return nil
+}
+
+// watchDocuments records the status of every main-document response, which is what clear
+// waits on. Nothing is fetched to find out — the browser is already telling us.
+func (t *tab) watchDocuments() error {
+	chromedp.ListenTarget(t.ctx, func(ev any) {
+		if e, ok := ev.(*network.EventResponseReceived); ok && e.Type == network.ResourceTypeDocument {
+			t.recordDocument(int(e.Response.Status))
+		}
+	})
+	if err := chromedp.Run(t.ctx, network.Enable()); err != nil {
+		return fmt.Errorf("browser: enable network events: %w", err)
+	}
+	return nil
 }
 
 // enableProxyAuth answers Chrome's proxy authentication over the debugging protocol. The
@@ -168,8 +260,20 @@ func (s *Session) Fetch(ctx context.Context, rawURL string) (int, []byte, error)
 	}
 	defer s.put(t)
 
-	if err := t.clear(ctx, origin); err != nil {
+	if err := t.visit(ctx, origin, false); err != nil {
 		return 0, nil, err
+	}
+	status, body, err := t.fetch(ctx, rawURL)
+	if err != nil || !challenged(status) {
+		return status, body, err
+	}
+
+	// The wall came back mid-crawl: clearance lapsed, or this particular request tripped it.
+	// Re-clear ONCE and try again. Deliberately once and not a loop — the obstacle is a
+	// rate limit, so repeated refused requests are what keeps it up rather than what gets
+	// past it.
+	if err := t.visit(ctx, origin, true); err != nil {
+		return status, body, nil // report the refusal we have rather than the re-clear failure
 	}
 	return t.fetch(ctx, rawURL)
 }
@@ -223,35 +327,36 @@ func (t *tab) derive(caller context.Context, timeout time.Duration) (context.Con
 // its JavaScript. Whether that clearance is shared across the tabs of one browser profile is
 // unmeasured, and nothing here depends on the answer: each tab clears for itself, and if it
 // turns out to be shared the later tabs simply find the wait already over.
-func (t *tab) clear(ctx context.Context, origin string) error {
-	if t.cleared[origin] {
+func (t *tab) visit(ctx context.Context, origin string, force bool) error {
+	if t.cleared[origin] && !force {
 		return nil
 	}
 	navCtx, cancel := t.derive(ctx, clearanceWait+fetchTimeout)
 	defer cancel()
+	t.resetDocuments()
 	if err := chromedp.Run(navCtx, chromedp.Navigate(origin)); err != nil {
-		return fmt.Errorf("browser: clear %s: %w", origin, err)
+		return fmt.Errorf("browser: visit %s: %w", origin, err)
 	}
 
-	// Poll for the origin becoming readable rather than sleeping a fixed time. "Readable" is
-	// deliberately generic — any status below 400 — because this package knows nothing about
-	// which site it is talking to and so cannot recognise a particular challenge page. A
-	// challenge answers 4xx/5xx until it lifts, which is the only property worth relying on.
+	// Wait for the wall to lift, by watching the page rather than by poking the site. An
+	// earlier version retried the REQUEST every 250ms instead, and that both failed and made
+	// things worse: the obstacle is a rate-limit-flavoured 429, so a burst of refused fetches
+	// is exactly what keeps it up. Measured against the real site, hammering never cleared in
+	// 20s while simply waiting cleared in about 8.
+	//
+	// The condition is the main document turning 2xx. A challenge serves the document with a
+	// refusal and then reloads itself, so this observes the reload landing — no extra request,
+	// and no site-specific marker to recognise.
 	deadline := time.Now().Add(clearanceWait)
-	var last string
 	for {
-		status, _, err := t.fetch(ctx, origin)
-		switch {
-		case err == nil && status < 400:
+		ok, seen := t.documentSucceeded()
+		if ok {
 			t.cleared[origin] = true
 			return nil
-		case err != nil:
-			last = err.Error()
-		default:
-			last = fmt.Sprintf("origin answered %d", status)
 		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf("browser: clear %s: still not readable after %s (%s)", origin, clearanceWait, last)
+			return fmt.Errorf("browser: visit %s: no document succeeded in %s (saw %s)",
+				origin, clearanceWait, seen)
 		}
 		select {
 		case <-time.After(clearancePoll):
@@ -259,6 +364,13 @@ func (t *tab) clear(ctx context.Context, origin string) error {
 			return ctx.Err()
 		}
 	}
+}
+
+// challenged reports whether a status is what a bot wall answers with while it is still in the
+// way. Only these two: everything else — including 404 — is the site answering for real, and
+// waiting for it to change would hang on a page that is simply not there.
+func challenged(status int) bool {
+	return status == http.StatusTooManyRequests || status == http.StatusForbidden
 }
 
 // fetchResult is what the in-page script hands back. The body is base64 so a binary or

--- a/internal/platform/browser/session.go
+++ b/internal/platform/browser/session.go
@@ -61,7 +61,7 @@ func NewSession(ctx context.Context, proxyURL string, tabs int) (*Session, error
 	if tabs < 1 {
 		tabs = 1
 	}
-	opts, err := LaunchOptions(proxyURL)
+	opts, err := LaunchOptionsThroughProxy(proxyURL)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/platform/browser/session_integration_test.go
+++ b/internal/platform/browser/session_integration_test.go
@@ -1,0 +1,167 @@
+//go:build integration
+
+// Integration test for the browser session: it needs a real Chrome, so it is tagged and it
+// SKIPS when none is installed rather than failing. CI's backend job installs no browser, and
+// a test that turned "no Chrome here" into a red build would make every unrelated change look
+// broken. Same contract the CV renderer's tests have for typst.
+//
+// Run with: go test -tags=integration ./internal/platform/browser/
+package browser
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// requireChrome skips unless a browser chromedp can launch is on this machine.
+func requireChrome(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{"google-chrome", "google-chrome-stable", "chromium", "chromium-browser"} {
+		if _, err := exec.LookPath(name); err == nil {
+			return
+		}
+	}
+	// chromedp finds the macOS app bundle without it being on PATH.
+	if _, err := exec.LookPath("open"); err == nil {
+		if _, err := exec.Command("test", "-d", "/Applications/Google Chrome.app").Output(); err == nil {
+			return
+		}
+	}
+	t.Skip("chrome not installed; skipping browser session test")
+}
+
+// challengeServer is the smallest thing shaped like the real obstacle: a site that serves its
+// content only to a client that ran JavaScript. The real one is Vercel's checkpoint; what
+// matters for this test is only that a plain request cannot pass and a browser can.
+type challengeServer struct {
+	*httptest.Server
+	challenges atomic.Int64 // how many times the challenge page was served
+}
+
+func newChallengeServer(t *testing.T) *challengeServer {
+	t.Helper()
+	cs := &challengeServer{}
+	mux := http.NewServeMux()
+	cleared := func(r *http.Request) bool {
+		c, err := r.Cookie("cleared")
+		return err == nil && c.Value == "1"
+	}
+	// The origin: a challenge until the client runs its script, then a plain page.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if !cleared(r) {
+			cs.challenges.Add(1)
+			w.Header().Set("Content-Type", "text/html")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`<html><body>Checkpoint<script>
+document.cookie = "cleared=1; path=/"; location.reload();
+</script></body></html>`))
+			return
+		}
+		_, _ = w.Write([]byte("<html><body>origin ok</body></html>"))
+	})
+	mux.HandleFunc("/payload", func(w http.ResponseWriter, r *http.Request) {
+		if !cleared(r) {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte("Forbidden"))
+			return
+		}
+		_, _ = w.Write([]byte("PAYLOAD-OK"))
+	})
+	mux.HandleFunc("/missing", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("not here"))
+	})
+	cs.Server = httptest.NewServer(mux)
+	t.Cleanup(cs.Close)
+	return cs
+}
+
+func TestSessionFetchesThroughAClearedPage(t *testing.T) {
+	requireChrome(t)
+	srv := newChallengeServer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	s, err := NewSession(ctx, "", 1)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer s.Close()
+
+	status, body, err := s.Fetch(ctx, srv.URL+"/payload")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Errorf("status = %d, want 200 (the challenge should have been cleared first)", status)
+	}
+	if got := strings.TrimSpace(string(body)); got != "PAYLOAD-OK" {
+		t.Errorf("body = %q, want PAYLOAD-OK", got)
+	}
+}
+
+// The clearance is the expensive part — seconds, against milliseconds for a fetch — so it must
+// be paid once per tab and not once per request.
+//
+// The assertion is "the count stops growing", not "the count is one". Clearing polls for the
+// origin becoming readable, so the challenge may legitimately be served more than once WHILE
+// clearing; what must not happen is a fresh challenge for every later request. Pinning the
+// exact number would make this test fail on a slow machine for a reason that is not a bug.
+func TestSessionClearsOnlyOnce(t *testing.T) {
+	requireChrome(t)
+	srv := newChallengeServer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	s, err := NewSession(ctx, "", 1)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer s.Close()
+
+	if _, _, err := s.Fetch(ctx, srv.URL+"/payload"); err != nil {
+		t.Fatalf("first Fetch: %v", err)
+	}
+	afterClearing := srv.challenges.Load()
+	if afterClearing == 0 {
+		t.Fatal("the server never served a challenge; the test is not testing what it claims")
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, _, err := s.Fetch(ctx, srv.URL+"/payload"); err != nil {
+			t.Fatalf("Fetch %d: %v", i, err)
+		}
+	}
+	if n := srv.challenges.Load(); n != afterClearing {
+		t.Errorf("challenge served %d more times across three later fetches; clearance is being re-paid", n-afterClearing)
+	}
+}
+
+// A status is data, not a failure. Only some statuses may be read as "this posting is gone",
+// so collapsing them all into an error would take that decision away from the caller.
+func TestSessionReportsNotFoundAsAStatusNotAnError(t *testing.T) {
+	requireChrome(t)
+	srv := newChallengeServer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	s, err := NewSession(ctx, "", 1)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer s.Close()
+
+	status, _, err := s.Fetch(ctx, srv.URL+"/missing")
+	if err != nil {
+		t.Fatalf("Fetch returned an error for a 404: %v", err)
+	}
+	if status != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", status)
+	}
+}

--- a/internal/platform/browser/session_integration_test.go
+++ b/internal/platform/browser/session_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"os/exec"
 	"strings"
 	"sync/atomic"
@@ -27,11 +28,10 @@ func requireChrome(t *testing.T) {
 			return
 		}
 	}
-	// chromedp finds the macOS app bundle without it being on PATH.
-	if _, err := exec.LookPath("open"); err == nil {
-		if _, err := exec.Command("test", "-d", "/Applications/Google Chrome.app").Output(); err == nil {
-			return
-		}
+	// chromedp finds the macOS app bundle without it being on PATH, so look for it directly
+	// rather than shelling out — one syscall, and nothing to get wrong about quoting.
+	if _, err := os.Stat("/Applications/Google Chrome.app"); err == nil {
+		return
 	}
 	t.Skip("chrome not installed; skipping browser session test")
 }

--- a/internal/platform/browser/session_integration_test.go
+++ b/internal/platform/browser/session_integration_test.go
@@ -12,28 +12,29 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"os/exec"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 )
 
-// requireChrome skips unless a browser chromedp can launch is on this machine.
+// requireChrome skips unless a browser can actually be LAUNCHED here, which is a different
+// question from whether one is installed and the difference is not academic: GitHub's runners
+// ship Chrome and then refuse to start it without --no-sandbox. Asking the narrower question
+// (is the binary on PATH?) made this suite fail there for an environment reason.
+//
+// So the guard starts a real session and skips on the error. Production launch options are
+// deliberately NOT relaxed to make this pass — adding --no-sandbox to the shared flags would
+// weaken the sandbox for auto-apply's browser too, to fix a constraint that belongs to CI.
 func requireChrome(t *testing.T) {
 	t.Helper()
-	for _, name := range []string{"google-chrome", "google-chrome-stable", "chromium", "chromium-browser"} {
-		if _, err := exec.LookPath(name); err == nil {
-			return
-		}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	s, err := NewSession(ctx, "", 1)
+	if err != nil {
+		t.Skipf("no launchable chrome here; skipping browser session test: %v", err)
 	}
-	// chromedp finds the macOS app bundle without it being on PATH, so look for it directly
-	// rather than shelling out — one syscall, and nothing to get wrong about quoting.
-	if _, err := os.Stat("/Applications/Google Chrome.app"); err == nil {
-		return
-	}
-	t.Skip("chrome not installed; skipping browser session test")
+	s.Close()
 }
 
 // challengeServer is the smallest thing shaped like the real obstacle: a site that serves its

--- a/internal/platform/firecrawl/AGENTS.md
+++ b/internal/platform/firecrawl/AGENTS.md
@@ -1,0 +1,74 @@
+# Hosted fetch
+
+An HTTP client for a third-party scraping API, for a site that refuses every address this
+repository can egress from. Transport, not a feature — the same category as
+`platform/browseruse`, which is likewise a client for somebody else's hosted browser.
+
+**Not `platform/browser`'s sibling, despite the shape.** That package launches a process on our
+own host and costs nothing per page. This one calls a metered vendor. Two things with the same
+shape and opposite economics should not be confused, which is why the budget below is part of
+the client rather than something a caller may forget.
+
+## When this is the right answer, and when it is not
+
+There are three transports, and this is the last resort:
+
+| tier | answers | cost |
+|---|---|---|
+| `proxiedProviders` | our IP is blocked, another is not | the proxy we already pay for |
+| `browserProviders` | the page needs JavaScript run | our own Chrome, free |
+| **this one** | **no address we can obtain is served at all** | **a credit per page** |
+
+Nothing belongs here that either of the others can reach. Its two providers (`bayt`,
+`gulftalent`) are `403` from the production IP *and* `403` through `SOURCES_PROXY_URL`, whose
+exit their edge classifies as datacenter too — and the browser tier does not help, because the
+refusal comes before any challenge is offered, so there is nothing to solve.
+
+## Know the yield before you widen this
+
+Measured 2026-09-07 by running the sources' own titles through `classify.IsTech`:
+
+| source | sample | passed the tech gate |
+|---|---|---|
+| `bayt`, its **IT** category | 33 | **0** |
+| `gulftalent`, real postings | 400 | **5 (1.25%)** |
+
+bayt's IT category is project managers, VPs, department directors and professors. gulftalent's
+postings are nannies, chefs, camp bosses and hotel electricians, with about one engineer in
+eighty. At ~60 000 gulftalent postings that is perhaps 750 technical ones for the entire site,
+and every page fetched costs a credit whether or not it turns out to be one of them.
+
+This was built with that measured and accepted. The number is recorded here so the next person
+inherits it rather than rediscovering it at their own expense.
+
+## Three bounds, none redundant
+
+- **No key, no client.** `ApplyFirecrawlEgress` is a no-op without `FIRECRAWL_API_KEY` and the
+  client is never constructed, so merging or deploying this spends nothing.
+- **A per-run page budget** (`FIRECRAWL_MAX_PAGES_PER_RUN`, default 500), counted **inside the
+  client** and shared across every provider in the run. An adapter cannot know what the others
+  already spent, and what is being protected is the account rather than any one crawl. The
+  count is claimed BEFORE the request, so a refused fetch never spends the page it refuses.
+  `New` rejects a non-positive budget outright — an unbounded metered client is the accident
+  this package exists to make impossible.
+- **The timer stays off.** A key alone crawls nothing until an ingest timer is enabled. Three
+  deliberate acts, not one.
+
+## The status is the target's, never the vendor's
+
+The API answers `200` while reporting the target's own status inside its envelope. Reading the
+outer one would turn every refusal into a success carrying a bot wall as though it were
+content, so `Fetch` returns `metadata.statusCode` and treats a missing one as a failed fetch
+rather than as an implied success.
+
+A non-2xx **target** status comes back as data, not an error — only some statuses may be read
+as "this resource is gone". A **vendor** failure is an error, and the difference matters: a
+caller that mistook a vendor outage for a refusal could conclude a posting is gone when only
+the API was down.
+
+## Testing
+
+Everything is exercised against an `httptest` stand-in for the vendor: no network, no key, no
+credits. Live verification is deliberately **not** automated — a test that quietly spends money
+on every CI run is a worse failure than no test. The live evidence for this tier is the
+measurement above, taken by hand and written down.

--- a/internal/platform/firecrawl/firecrawl.go
+++ b/internal/platform/firecrawl/firecrawl.go
@@ -1,0 +1,156 @@
+// Package firecrawl fetches a URL through a hosted scraping API, for a site that refuses
+// every address this repository can egress from.
+//
+// It is transport, not a feature: it knows nothing about jobs, and it is the HTTP half of
+// talking to a vendor — the same category as platform/browseruse, which is likewise a client
+// for somebody else's hosted browser.
+//
+// It is NOT platform/browser's sibling, despite the similar shape. That package launches a
+// process on our own host and costs nothing per page; this one calls a metered third party.
+// Two things with the same shape and opposite economics should not be confused, which is why
+// the budget below is part of the client rather than an afterthought a caller may forget.
+package firecrawl
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+// DefaultBaseURL is the vendor's API root.
+const DefaultBaseURL = "https://api.firecrawl.dev"
+
+// requestTimeout bounds one hosted fetch. Generous: the vendor is rendering a page behind a
+// bot wall on our behalf, which took 1.5-3.5s in every measurement, and a slow page is worth
+// waiting for once we have already paid for it.
+const requestTimeout = 90 * time.Second
+
+// ErrBudgetSpent is returned once a run has fetched as many pages as it was allowed. It is a
+// sentinel so a caller can tell "we chose to stop spending" from "the fetch failed" — the
+// first is a healthy run hitting its bound, the second is a problem.
+var ErrBudgetSpent = errors.New("firecrawl: page budget for this run is spent")
+
+// Config is what a client needs. Every field is required; there are no silent defaults for
+// the two that decide whether money is spent and how much.
+type Config struct {
+	APIKey  string
+	BaseURL string // defaults to DefaultBaseURL when empty
+	// MaxPagesPerRun bounds how many pages ONE process may fetch. Must be positive.
+	MaxPagesPerRun int64
+	HTTP           *http.Client // defaults to a client with requestTimeout
+}
+
+// Client fetches pages through the vendor, counting every one against the run's budget.
+type Client struct {
+	apiKey  string
+	baseURL string
+	http    *http.Client
+
+	budget int64
+	spent  atomic.Int64
+}
+
+// New builds a client, refusing the two configurations that could only end badly: no key (a
+// client that cannot authenticate can do nothing but fail once per page) and no positive
+// budget (an unbounded metered client is precisely the accident this package exists to make
+// impossible).
+func New(cfg Config) (*Client, error) {
+	if cfg.APIKey == "" {
+		return nil, errors.New("firecrawl: no API key")
+	}
+	if cfg.MaxPagesPerRun <= 0 {
+		return nil, fmt.Errorf("firecrawl: page budget must be positive, got %d", cfg.MaxPagesPerRun)
+	}
+	base := cfg.BaseURL
+	if base == "" {
+		base = DefaultBaseURL
+	}
+	hc := cfg.HTTP
+	if hc == nil {
+		hc = &http.Client{Timeout: requestTimeout}
+	}
+	return &Client{apiKey: cfg.APIKey, baseURL: base, http: hc, budget: cfg.MaxPagesPerRun}, nil
+}
+
+// scrapeResponse is the vendor's envelope. The distinction that matters is that IT answers
+// 200 while reporting the TARGET's own status inside: reading the outer status as the page's
+// would turn every refusal into a success carrying a bot wall as though it were content.
+type scrapeResponse struct {
+	Success bool   `json:"success"`
+	Error   string `json:"error"`
+	Data    struct {
+		RawHTML  string `json:"rawHtml"`
+		Metadata struct {
+			StatusCode int `json:"statusCode"`
+		} `json:"metadata"`
+	} `json:"data"`
+}
+
+// Fetch returns the TARGET's status and body for rawURL.
+//
+// A non-2xx target status is returned as data, not as an error, for the same reason the
+// browser tier does it: only some statuses may be read as "this resource is gone", and
+// collapsing them takes that decision away from the caller. A VENDOR failure is an error —
+// it says nothing about the target, and a caller that mistook it for a refusal could conclude
+// a posting is gone when only the API was down.
+func (c *Client) Fetch(ctx context.Context, rawURL string) (int, []byte, error) {
+	// Claimed BEFORE the request, so a refused fetch never spends the page it refuses.
+	if spent := c.spent.Add(1); spent > c.budget {
+		return 0, nil, fmt.Errorf("%w (%d pages)", ErrBudgetSpent, c.budget)
+	}
+
+	payload, err := json.Marshal(map[string]any{
+		"url":     rawURL,
+		"formats": []string{"rawHtml"},
+	})
+	if err != nil {
+		return 0, nil, fmt.Errorf("firecrawl: encode request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/scrape", bytes.NewReader(payload))
+	if err != nil {
+		return 0, nil, fmt.Errorf("firecrawl: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return 0, nil, fmt.Errorf("firecrawl: fetch %s: %w", rawURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, fmt.Errorf("firecrawl: read response for %s: %w", rawURL, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return 0, nil, fmt.Errorf("firecrawl: fetch %s: api status %d", rawURL, resp.StatusCode)
+	}
+
+	var out scrapeResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return 0, nil, fmt.Errorf("firecrawl: decode response for %s: %w", rawURL, err)
+	}
+	if !out.Success {
+		return 0, nil, fmt.Errorf("firecrawl: fetch %s: api reported failure: %s", rawURL, out.Error)
+	}
+
+	status := out.Data.Metadata.StatusCode
+	if status == 0 {
+		// The vendor succeeded but told us nothing about the target. Treating that as 200
+		// would let an empty or error page through as content, so it is a failure of the
+		// fetch rather than a status to reason about.
+		return 0, nil, fmt.Errorf("firecrawl: fetch %s: api reported no target status", rawURL)
+	}
+	return status, []byte(out.Data.RawHTML), nil
+}
+
+// Spent reports how many pages this run has claimed, for a caller that wants to log the cost
+// of a crawl. It counts claims rather than successes: a page paid for and then failed is
+// still a page paid for.
+func (c *Client) Spent() int64 { return c.spent.Load() }

--- a/internal/platform/firecrawl/firecrawl_test.go
+++ b/internal/platform/firecrawl/firecrawl_test.go
@@ -1,0 +1,157 @@
+package firecrawl
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// vendor stands in for the scrape API. Everything here is exercised against it: no key, no
+// network, no credits. A test that quietly spends money on every CI run would be a worse
+// failure than no test at all.
+type vendor struct {
+	*httptest.Server
+	calls atomic.Int64
+}
+
+// newVendor answers each request from reply, which the test supplies per case.
+func newVendor(t *testing.T, reply func(w http.ResponseWriter, r *http.Request)) *vendor {
+	t.Helper()
+	v := &vendor{}
+	v.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v.calls.Add(1)
+		reply(w, r)
+	}))
+	t.Cleanup(v.Close)
+	return v
+}
+
+// scrapeOK is the vendor's success envelope: it answers 200 and reports the TARGET's own
+// status inside.
+func scrapeOK(targetStatus int, body string) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"data": map[string]any{
+				"rawHtml":  body,
+				"metadata": map[string]any{"statusCode": targetStatus},
+			},
+		})
+	}
+}
+
+func newTestClient(t *testing.T, v *vendor, budget int64) *Client {
+	t.Helper()
+	c, err := New(Config{APIKey: "test-key", BaseURL: v.URL, MaxPagesPerRun: budget})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func TestFetchReturnsThePageBytes(t *testing.T) {
+	v := newVendor(t, scrapeOK(http.StatusOK, "<html><body>hello</body></html>"))
+	c := newTestClient(t, v, 10)
+
+	status, body, err := c.Fetch(context.Background(), "https://example.test/page")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Errorf("status = %d, want 200", status)
+	}
+	if string(body) != "<html><body>hello</body></html>" {
+		t.Errorf("body = %q", body)
+	}
+}
+
+// The vendor answers 200 even when the TARGET refused. Reporting the vendor's status would
+// turn every refusal into a success carrying a challenge page as if it were content.
+func TestFetchReportsTheTargetStatusNotTheVendors(t *testing.T) {
+	v := newVendor(t, scrapeOK(http.StatusNotFound, "not here"))
+	c := newTestClient(t, v, 10)
+
+	status, _, err := c.Fetch(context.Background(), "https://example.test/gone")
+	if err != nil {
+		t.Fatalf("Fetch returned an error for a target 404: %v", err)
+	}
+	if status != http.StatusNotFound {
+		t.Errorf("status = %d, want the target's 404", status)
+	}
+}
+
+// A vendor failure says nothing about the target and must not be mistaken for one — a caller
+// that read it as a refusal could conclude a posting is gone when only the API was down.
+func TestFetchDistinguishesAVendorFailure(t *testing.T) {
+	v := newVendor(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"success":false,"error":"internal"}`))
+	})
+	c := newTestClient(t, v, 10)
+
+	if _, _, err := c.Fetch(context.Background(), "https://example.test/x"); err == nil {
+		t.Fatal("want an error when the vendor itself fails")
+	}
+}
+
+// The budget is the whole point of this client existing rather than a bare HTTP call. Past it
+// the request is NOT made — a budget that still spends the page it refuses would be no budget.
+func TestBudgetStopsSpendingAndIssuesNoRequest(t *testing.T) {
+	v := newVendor(t, scrapeOK(http.StatusOK, "ok"))
+	c := newTestClient(t, v, 2)
+	ctx := context.Background()
+
+	for i := 0; i < 2; i++ {
+		if _, _, err := c.Fetch(ctx, "https://example.test/p"); err != nil {
+			t.Fatalf("Fetch %d within budget: %v", i, err)
+		}
+	}
+	before := v.calls.Load()
+
+	_, _, err := c.Fetch(ctx, "https://example.test/p")
+	if err == nil {
+		t.Fatal("want an error once the budget is spent")
+	}
+	if !errors.Is(err, ErrBudgetSpent) {
+		t.Errorf("error is %v, want ErrBudgetSpent so a caller can tell it from a fetch failure", err)
+	}
+	if after := v.calls.Load(); after != before {
+		t.Errorf("the refused fetch still issued %d request(s) — that spends the page it refuses", after-before)
+	}
+}
+
+// The budget counts across every provider in a run, because what is being protected is the
+// account and no single adapter can know what the others already spent.
+func TestBudgetIsSharedAcrossCallers(t *testing.T) {
+	v := newVendor(t, scrapeOK(http.StatusOK, "ok"))
+	c := newTestClient(t, v, 3)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		if _, _, err := c.Fetch(ctx, "https://example.test/a"); err != nil {
+			t.Fatalf("Fetch %d: %v", i, err)
+		}
+	}
+	if _, _, err := c.Fetch(ctx, "https://other.test/b"); !errors.Is(err, ErrBudgetSpent) {
+		t.Errorf("a different URL got a fresh budget: %v", err)
+	}
+}
+
+func TestNewRefusesWithoutAKey(t *testing.T) {
+	if _, err := New(Config{MaxPagesPerRun: 10}); err == nil {
+		t.Error("want an error with no API key: a client that cannot authenticate can only fail per request")
+	}
+}
+
+func TestNewRefusesANonPositiveBudget(t *testing.T) {
+	for _, budget := range []int64{0, -1} {
+		if _, err := New(Config{APIKey: "k", MaxPagesPerRun: budget}); err == nil {
+			t.Errorf("want an error for budget %d: an unbounded metered client is the failure this exists to prevent", budget)
+		}
+	}
+}

--- a/openspec/changes/echojobs-browser-tier/design.md
+++ b/openspec/changes/echojobs-browser-tier/design.md
@@ -1,0 +1,132 @@
+# Design
+
+## Why the browser sits in `platform`
+
+`internal/ingest` is block 7, `internal/api` is block 8, and a block may import only blocks
+strictly below it. So `sources` cannot reach `api/atsapply`'s browser code — `depguard`
+fails the import line and `arch/layering` fails the graph.
+
+That leaves duplicating it in `ingest`, or moving what is shared down. The repository has
+already answered this exact question once, and the answer is in `blocks.go`'s own comment:
+
+> aigateway is here for the same reason as llm: it is the HTTP half of talking to the
+> OpenAI-compatible gateway and knows nothing about the domain. Its two callers sit in
+> different blocks (ai/speech and api/realtime), so anywhere else it would be an upward edge
+> for one of them.
+
+A headless browser is the same shape — transport that knows nothing about jobs, with callers
+in two different blocks. It goes in `platform`.
+
+## What moves, and what deliberately does not
+
+`platform/browser` owns two things:
+
+- **`LaunchOptions(proxyURL string)`** — the stealth flags. Today that is `headless` plus
+  `disable-blink-features=AutomationControlled`, the pair the 2026-09-02 auto-apply spike
+  measured against `bot.sannysoft.com`, plus the proxy server when one is given.
+- **`Session`** — a running browser, its proxy authentication, and `Fetch`.
+
+`api/atsapply` keeps its `newBrowserSession`, its DOM scanning, its filling and its
+screenshots. Only `stealthAllocatorOptions` becomes a call into `LaunchOptions("")`.
+
+The split is on purpose. What must not be duplicated is the *knowledge of how to look like a
+real browser*, because that is the part a future anti-bot fix will touch, and two copies mean
+the fix lands in one — the [hardcoded-list trap](../../../AGENTS.md) in another form. What
+must not be moved is atsapply's session, because it does something entirely different with
+the page (it fills a form and submits it) and a shared abstraction over both would be an
+abstraction over nothing.
+
+## Clearance, and why the fetch happens inside the page
+
+`Session.Fetch(ctx, url)` returns `(status int, body []byte, err error)`. Under it:
+
+1. On a tab's first use, navigate to the site's origin once and wait for the challenge to
+   clear. ~7.7s, paid once per tab.
+2. Every request after that is `fetch(url, {credentials:"include"})` evaluated in that page,
+   awaited, returning status and body.
+
+The third option — take the browser's cookie and use Go's `http.Client` — was measured and
+**does not work**: the `_vcrcs` cookie transfers, and a plain GET carrying it still gets the
+checkpoint. Vercel binds clearance to more than the cookie (a TLS fingerprint is the obvious
+candidate), so the request has to leave from the browser itself. In-page `fetch` is how it
+does that without paying for a render.
+
+`Fetch` returns the status rather than an error for a non-2xx, because the caller needs to
+tell `404` (the posting is gone — the only reading the job lifecycle accepts as gone) from
+`403`/`429` (we are blocked — never a reason to close anything).
+
+## Concurrency
+
+`chromedp` serialises actions on one context, so one tab is one request at a time. The
+session therefore holds a small pool of tabs, each clearing itself on first use.
+
+Whether clearance is shared across tabs of one browser profile is **unmeasured**, and the
+design does not depend on the answer: each tab clears once regardless. If it turns out to be
+shared, tabs after the first will simply find themselves already cleared and the wait
+collapses on its own — a saving, never a correctness question.
+
+Pool size follows the adapter's existing `defaultDetailWorkers` rather than inventing a
+second number.
+
+## The seam in `sources`, and why the adapter is untouched
+
+`echojobs` declares its transport as `echojobsHTTP`: `XMLGetter` + `HTMLGetter`. A type
+backed by a `browser.Session` satisfying those two is a drop-in — `GetXML` fetches and
+unmarshals, `GetHTML` fetches and parses. The sitemap walk, the shard freshness cutoff, the
+JobPosting decode, the skill canonicalisation: all unchanged, all still covered by their
+existing tests against fakes.
+
+Opt-in follows `proxiedProviders`' shape — a map keyed by provider, each value rebuilding the
+adapter over the browser-backed client — and is **gated on a proxy being configured**. The
+spike proved a browser without one gets `403` from the prod IP, so launching Chrome in that
+case would spend seconds to fail. Without `SOURCES_PROXY_URL` the provider stays on the plain
+client and fails exactly as it does today, which is the honest outcome: nothing is quietly
+working.
+
+## Making a total failure look like one
+
+The outage lasted 19 days because `ingested=0 failed=0` and a genuinely empty crawl are the
+same line. `echojobs.FetchNew` already counts what it dropped and logs a summary; nothing
+reads it.
+
+The narrow fix: **a crawl that discovered candidate postings and hydrated none of them is a
+board failure**, not an empty success.
+
+It belongs in the ADAPTER, not the pipeline, and the reason is structural: a dropped posting
+never reaches the pipeline at all. `Stats` counts `saveOne` failures, so from the pipeline's
+side an adapter that discarded everything and an adapter that found nothing return the same
+empty slice. Only `FetchNew` knows it walked 10 000 sitemap entries and yielded zero. Making
+this a pipeline-wide rule would mean every adapter reporting its drops through a new signal —
+a much larger change, for a guard that is needed where the drops happen.
+
+So `echojobs.FetchNew` returns an error when it had candidates and hydrated none of them. A
+board-level error is what `board_health` already watches, so nothing downstream needs teaching.
+
+It deliberately does not try to be a general freshness monitor — the broader "a provider whose
+`max(last_seen_at)` has not moved in N days" gauge belongs with `queue-metrics` and stays in
+freehire#2588.
+
+## Operational notes
+
+The ingest units and the auto-apply unit are identical where it matters — same `User=freehire`,
+same `EnvironmentFile`, and neither sets `PrivateTmp` or `ProtectHome`. Chrome already runs
+under that user for auto-apply, so the ingest path needs no unit change. Verified on the host
+rather than assumed.
+
+Google Chrome 152 is installed at `/usr/bin/google-chrome`.
+
+## Testing
+
+- `platform/browser` — the launch options are a pure function and unit-testable: the flags are
+  present, and a proxy URL with credentials yields a `ProxyServer` carrying the host but never
+  the credentials (those go over CDP, and a credential in an argv is a leak). The session
+  itself needs a real Chrome, so its test is `//go:build integration` and drives a local
+  `httptest` server: one that answers plainly, one that answers only after a JS-set cookie —
+  the smallest thing shaped like a challenge — plus a 404 to prove the status is reported
+  rather than swallowed.
+- `sources` browser getter — integration-tagged against the same local server, asserting that
+  `GetXML` decodes and `GetHTML` parses what the session returned.
+- `echojobs` adapter — existing tests unchanged. If any of them needed editing, the seam would
+  be in the wrong place.
+- `pipeline` — a unit test that a run which listed postings and hydrated none reports a board
+  failure, and its converse: a board that genuinely listed nothing still reports success.

--- a/openspec/changes/echojobs-browser-tier/design.md
+++ b/openspec/changes/echojobs-browser-tier/design.md
@@ -21,13 +21,15 @@ in two different blocks. It goes in `platform`.
 
 `platform/browser` owns two things:
 
-- **`LaunchOptions(proxyURL string)`** — the stealth flags. Today that is `headless` plus
-  `disable-blink-features=AutomationControlled`, the pair the 2026-09-02 auto-apply spike
-  measured against `bot.sannysoft.com`, plus the proxy server when one is given.
+- **`LaunchOptions()` / `LaunchOptionsThroughProxy(url)`** — the stealth flags. Today that is
+  `headless` plus `disable-blink-features=AutomationControlled`, the pair the 2026-09-02
+  auto-apply spike measured against `bot.sannysoft.com`, plus the proxy server when one is
+  given. Two functions rather than one with an ignorable error: only the proxy parse can
+  fail, so a caller with no proxy is handed no error to swallow.
 - **`Session`** — a running browser, its proxy authentication, and `Fetch`.
 
 `api/atsapply` keeps its `newBrowserSession`, its DOM scanning, its filling and its
-screenshots. Only `stealthAllocatorOptions` becomes a call into `LaunchOptions("")`.
+screenshots. Only `stealthAllocatorOptions` becomes a call into `LaunchOptions()`.
 
 The split is on purpose. What must not be duplicated is the *knowledge of how to look like a
 real browser*, because that is the part a future anti-bot fix will touch, and two copies mean
@@ -41,7 +43,9 @@ abstraction over nothing.
 `Session.Fetch(ctx, url)` returns `(status int, body []byte, err error)`. Under it:
 
 1. On a tab's first use, navigate to the site's origin once and wait for the challenge to
-   clear. ~7.7s, paid once per tab.
+   clear — by watching the main document's status, not by re-requesting. Paid once per tab;
+   measured at 3.9s end to end. See "What live verification changed" for why the first
+   implementation of this step was wrong.
 2. Every request after that is `fetch(url, {credentials:"include"})` evaluated in that page,
    awaited, returning status and body.
 
@@ -54,6 +58,41 @@ does that without paying for a render.
 `Fetch` returns the status rather than an error for a non-2xx, because the caller needs to
 tell `404` (the posting is gone — the only reading the job lifecycle accepts as gone) from
 `403`/`429` (we are blocked — never a reason to close anything).
+
+## What live verification changed
+
+Two things were wrong after the unit tests were green, and only running against the real wall
+from the production host found them. Both are recorded here because the obvious
+implementation falls into each.
+
+**The user agent decided everything.** A hand-rolled probe cleared in eight seconds while the
+packaged session sat refused for twenty — identical flags, identical proxy, identical tab
+structure. The probe set a desktop user agent; the package did not, so Chrome announced
+`HeadlessChrome`. Against that the site did not serve a challenge at all, it simply refused,
+and a browser cannot solve a challenge it is never given. No launch flag removes that string,
+so the session reads the running browser's own agent and rewrites that one word — read rather
+than written as a literal, so it never claims a Chrome version the binary is not.
+
+This changes `api/atsapply` too, since it shares the launch path: its browser now presents a
+non-headless agent where it previously presented a headless one. That is strictly more
+browser-like and consistent with what its stealth flags were already for, but it is a
+behaviour change to a production feature and is called out rather than slipped in.
+
+**Retrying a refused request keeps the wall up.** The first implementation polled by re-issuing
+the request every 250ms until it stopped being refused. It never cleared: the obstacle is a
+rate-limit-flavoured `429`, so a burst of refused fetches is exactly what holds it. What works
+is to navigate once and watch — the challenge answers the document with a refusal and then
+reloads itself, so the main document turning 2xx is the wall lifting. No extra request, no
+site-specific marker, and a ceiling rather than a delay: 3.9s end to end where the
+fixed-sleep probe took 11s.
+
+Clearance latches on ANY document response succeeding rather than the last one, because a
+challenge page can pull in frames of its own and a frame refused after the real page landed
+would read as the wall going back up. The statuses seen ride the timeout error — which is how
+the user-agent cause was found rather than guessed.
+
+Verified end to end against live echojobs.io through the real adapter: 59 476 postings listed
+from the sitemap, five hydrated with real titles, companies, locations and skills, in 12.9s.
 
 ## Concurrency
 

--- a/openspec/changes/echojobs-browser-tier/proposal.md
+++ b/openspec/changes/echojobs-browser-tier/proposal.md
@@ -1,0 +1,90 @@
+## Why
+
+`echojobs` ingested nothing for 19 days while every run reported success (freehire#2588).
+echojobs.io now sits behind Vercel's bot protection, and the adapter's stated premise —
+"neither needs JavaScript execution — a plain GET reaches both" — stopped being true.
+
+Measured, not assumed:
+
+| origin | plain GET | headless Chrome |
+|---|---|---|
+| prod datacenter IP | `403`, `x-vercel-mitigated: deny` | **`403`** — the challenge is never even offered |
+| `SOURCES_PROXY_URL` egress | `429` + `Vercel Security Checkpoint` | **200, real page** |
+
+Neither half works alone. The browser is useless from the prod IP, because a browser can
+only solve a challenge it is served; the proxy is useless without a browser, because the
+challenge needs JavaScript. Only the pair passes — which is why adding `echojobs` to
+`proxiedProviders`, the one-line remedy that recovered `djinni`, `enlizt` and `wantedkr`,
+was tried in a spike and rejected.
+
+Once a browser holds clearance, the cheap tier is **inside the page**, not outside it. A
+`_vcrcs` cookie carried into Go's own HTTP client still gets the checkpoint — the clearance
+is bound to more than the cookie — but `fetch()` evaluated in the cleared page is served
+normally, at roughly a tenth of a full navigation:
+
+| request | via navigation | via in-page `fetch()` |
+|---|---|---|
+| one-time clearance | 7.7s | 7.7s (once per tab) |
+| `/sitemap.xml` (27 shards) | 0.33s | **0.19s** |
+| `/sitemap-jobs/1.xml` (10 000 locs, 2.1 MB) | 6.4s | **0.37s** |
+| a posting page (JobPosting present) | 4.2s | **0.36s** |
+
+In-page `fetch()` also returns the real status code — a missing posting answers `404`, which
+the plain navigation could not distinguish from a block. That matters to the lifecycle,
+where only `404`/`410` may mean "gone".
+
+At ~0.36s a posting and 400–1500 new postings a day, a steady-state crawl costs minutes.
+
+## What Changes
+
+- **A headless-browser fetcher becomes shared transport.** A new `internal/platform/browser`
+  owns launching a stealth Chrome (optionally through an authenticating proxy) and one
+  operation over it: fetch a URL from inside a cleared page and return its status and body.
+  It knows nothing about jobs, exactly like `platform/llm` and `platform/aigateway`, and it
+  is in `platform` for the reason `aigateway`'s own comment gives — its two callers sit in
+  different blocks, so anywhere else is an upward edge for one of them.
+- **The stealth launch flags get a single home.** `api/atsapply` keeps its own session, DOM
+  scanning and form filling, and takes only its launch options from the new package. Two
+  copies of the flags would mean a future stealth fix lands in one and silently not the
+  other.
+- **`sources` gains a browser-backed getter** satisfying `XMLGetter` + `HTMLGetter`, which is
+  exactly `echojobsHTTP`. **Not one line of the adapter's reading changes** — its sitemap
+  walk, its shard freshness cutoff and its JobPosting parse already work, and what broke was
+  only how the bytes arrive. Its sole edit is the guard below, which is about reporting, not
+  about reading.
+- **`echojobs` opts in per-provider**, in the shape `proxiedProviders` already uses, and only
+  when a proxy is configured — a browser without one is proven useless, so it is never
+  launched for nothing.
+- **A crawl that lists postings and hydrates none fails its board** instead of reporting an
+  empty success. This is the narrow half of freehire#2588's second point: what let the
+  outage run for 19 days was not the block but that a total failure and an empty crawl were
+  indistinguishable. The check lives in the adapter, because a dropped posting never reaches
+  the pipeline — only `FetchNew` knows it walked the sitemap and yielded nothing.
+
+## Capabilities
+
+### New Capabilities
+
+- `job-source-browser-tier`: how a source whose pages are gated behind a JavaScript
+  challenge is crawled — what clearance is, how requests ride it, when the tier is used at
+  all, and what a crawl that reaches nothing must report.
+
+### Modified Capabilities
+
+<!-- None. The echojobs adapter's own parsing behaviour is unchanged; only its transport is. -->
+
+## Impact
+
+- `internal/platform/browser/` — new: launch options, session, in-page fetch.
+- `internal/api/atsapply/browser.go` — `stealthAllocatorOptions` delegates; nothing else moves.
+- `internal/ingest/sources/` — new browser-backed getter and the per-provider opt-in; the
+  registry wiring beside `proxiedProviders`.
+- `internal/ingest/sources/echojobs.go` — the listed-but-hydrated-none board error (its
+  only change; the sitemap walk and JobPosting parse are untouched).
+- `internal/platform/arch/layering/blocks.go` — `browser` joins the `platform` block.
+
+Not in scope: reviving the 84 605 postings closed on 2026-09-07. A working crawl re-opens
+whatever the 14-day sitemap window still lists; the rest are a month old, roughly half were
+already duplicate-suppressed, and re-opening postings nobody has verified is the thing this
+catalogue's ghost-job work exists to prevent. Also out: recovering the employer apply URL,
+which the page has not carried since the 2026-08 rewrite.

--- a/openspec/changes/echojobs-browser-tier/specs/job-source-browser-tier/spec.md
+++ b/openspec/changes/echojobs-browser-tier/specs/job-source-browser-tier/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: A source behind a JavaScript challenge is crawled through a browser
+
+A source whose pages are gated behind a JavaScript challenge SHALL be crawled through a
+headless browser session rather than a plain HTTP request, and the adapter that reads those
+pages SHALL be unchanged by the switch — the browser supplies the same fetch operations the
+adapter already declares.
+
+#### Scenario: The adapter reads a challenged page
+
+- **WHEN** a provider registered for the browser tier is crawled
+- **THEN** its sitemap and its posting pages are fetched through the browser session
+- **AND** the adapter parses them exactly as it parses plainly fetched ones
+
+### Requirement: The browser tier requires an egress proxy
+
+The browser tier SHALL be used only when an egress proxy is configured. Without one the
+provider SHALL fall back to the plain client and fail as it would have anyway.
+
+A browser and a proxy are each useless alone here: from an address the platform denies
+outright no challenge is served, so there is nothing for a browser to solve; and a challenge
+cannot be solved without executing JavaScript.
+
+#### Scenario: No proxy configured
+
+- **WHEN** a browser-tier provider is crawled and no egress proxy is configured
+- **THEN** no browser is launched
+- **AND** the crawl proceeds on the plain client
+
+#### Scenario: Proxy configured
+
+- **WHEN** a browser-tier provider is crawled and an egress proxy is configured
+- **THEN** the browser session egresses through that proxy
+
+### Requirement: A request rides a cleared page and reports its real status
+
+A browser session SHALL obtain clearance once per tab by loading the site's origin, and
+SHALL issue every subsequent request from inside that cleared page rather than by navigating
+to it.
+
+Each request SHALL report the response's own status code. A status SHALL NOT be collapsed
+into a generic failure, because only some statuses may be read as "this posting is gone".
+
+#### Scenario: Clearance is paid once, not per request
+
+- **WHEN** a session fetches several URLs from one tab
+- **THEN** the challenge is cleared on the first fetch only
+
+#### Scenario: A missing page is distinguishable from a blocked one
+
+- **WHEN** a fetch receives a `404`
+- **THEN** the caller is told the status was `404`, not merely that the fetch failed
+
+### Requirement: Proxy credentials never reach the process arguments
+
+When the egress proxy requires authentication, the credentials SHALL be supplied to the
+browser over its debugging protocol and SHALL NOT appear in the browser's command line.
+
+#### Scenario: Launching with an authenticating proxy
+
+- **WHEN** a session is launched with a proxy URL carrying a username and password
+- **THEN** the browser's arguments carry the proxy host but neither the username nor the password
+
+### Requirement: One home for the stealth launch flags
+
+The flags that make a headless browser resemble an ordinary one SHALL be defined in exactly
+one place, shared by every caller that launches a browser.
+
+#### Scenario: A second caller launches a browser
+
+- **WHEN** any package in the repository starts a headless browser
+- **THEN** it takes its launch flags from the shared definition rather than restating them
+
+### Requirement: A crawl that reads nothing of what it listed reports failure
+
+A hydrating adapter that discovered candidate postings and successfully read none of them
+SHALL report a board-level failure rather than an empty success.
+
+An adapter drops a posting it cannot read before the pipeline ever sees it, so a total
+outage and a genuinely empty crawl are otherwise the same result. This is what let one
+source publish nothing for 19 days with every run reporting success.
+
+#### Scenario: Every candidate fails to load
+
+- **WHEN** a crawl lists candidate postings and none of them can be read
+- **THEN** the board reports an error
+
+#### Scenario: The source genuinely has nothing
+
+- **WHEN** a crawl lists no candidate postings at all
+- **THEN** the board reports success with nothing ingested

--- a/openspec/changes/echojobs-browser-tier/tasks.md
+++ b/openspec/changes/echojobs-browser-tier/tasks.md
@@ -13,17 +13,17 @@
 
 ## 2. `platform/browser` — the session
 
-- [ ] 2.1 Write the failing integration test (`//go:build integration`, needs Chrome) against
+- [x] 2.1 Write the failing integration test (`//go:build integration`, needs Chrome) against
       a local `httptest` server with three routes: one plain `200`, one that serves its real
       body only after a JS-set cookie (the smallest thing shaped like a challenge), and one
       `404`. Assert: the challenged route is read, the `404` is reported **as 404 rather than
       as an error**, and a second fetch on the same tab pays no second clearance.
-- [ ] 2.2 Implement `Session`: launch via `LaunchOptions`, answer `Fetch.authRequired` over
+- [x] 2.2 Implement `Session`: launch via `LaunchOptions`, answer `Fetch.authRequired` over
       CDP with the proxy credentials, `Clear(ctx, origin)` to obtain clearance, and
       `Fetch(ctx, url) (status int, body []byte, err error)` evaluating an awaited in-page
       `fetch` — with the doc saying why the cookie cannot simply be handed to `net/http`
       (measured: it still gets the checkpoint).
-- [ ] 2.3 Add the tab pool: N tabs, each clearing on first use, `chromedp` serialising one
+- [x] 2.3 Add the tab pool: N tabs, each clearing on first use, `chromedp` serialising one
       request per tab. Document that whether clearance is shared across tabs is unmeasured
       and that the design does not depend on the answer.
 

--- a/openspec/changes/echojobs-browser-tier/tasks.md
+++ b/openspec/changes/echojobs-browser-tier/tasks.md
@@ -1,0 +1,66 @@
+## 1. `platform/browser` — the launch flags
+
+- [ ] 1.1 Write the failing test for `LaunchOptions`: the stealth pair is present; an empty
+      proxy adds no proxy flag; a proxy URL carrying credentials yields a `ProxyServer` with
+      the scheme and host and with **neither the username nor the password anywhere in the
+      option set** (a credential in argv is readable by any process on the host).
+- [ ] 1.2 Add `internal/platform/browser/browser.go` with `LaunchOptions`, documenting that
+      this is the single home for the stealth flags and naming the 2026-09-02 measurement
+      the pair came from.
+- [ ] 1.3 Register `browser` in the `platform` block in
+      `internal/platform/arch/layering/blocks.go`, with the comment saying why it is transport
+      (the `aigateway` precedent) rather than an ingest or api package.
+
+## 2. `platform/browser` — the session
+
+- [ ] 2.1 Write the failing integration test (`//go:build integration`, needs Chrome) against
+      a local `httptest` server with three routes: one plain `200`, one that serves its real
+      body only after a JS-set cookie (the smallest thing shaped like a challenge), and one
+      `404`. Assert: the challenged route is read, the `404` is reported **as 404 rather than
+      as an error**, and a second fetch on the same tab pays no second clearance.
+- [ ] 2.2 Implement `Session`: launch via `LaunchOptions`, answer `Fetch.authRequired` over
+      CDP with the proxy credentials, `Clear(ctx, origin)` to obtain clearance, and
+      `Fetch(ctx, url) (status int, body []byte, err error)` evaluating an awaited in-page
+      `fetch` — with the doc saying why the cookie cannot simply be handed to `net/http`
+      (measured: it still gets the checkpoint).
+- [ ] 2.3 Add the tab pool: N tabs, each clearing on first use, `chromedp` serialising one
+      request per tab. Document that whether clearance is shared across tabs is unmeasured
+      and that the design does not depend on the answer.
+
+## 3. `api/atsapply` takes its flags from the shared home
+
+- [ ] 3.1 Make `stealthAllocatorOptions` delegate to `browser.LaunchOptions("")`, leaving
+      `newBrowserSession`, the DOM scan, the fill and the screenshots untouched. Its existing
+      tests must stay green without edits.
+
+## 4. `sources` — the browser-backed getter
+
+- [ ] 4.1 Write the failing integration test: a `browserClient` over a real session satisfies
+      `XMLGetter` + `HTMLGetter`, decoding XML and parsing HTML served by a local server.
+- [ ] 4.2 Implement it, mapping a non-2xx status to an error that NAMES the status, so a
+      caller can still tell `404` from `403`.
+
+## 5. `echojobs` opts in
+
+- [ ] 5.1 Write the failing test for the registry: with a proxy configured, `echojobs`
+      resolves to the browser-backed adapter; with none, it resolves to the plain one and no
+      browser is constructed.
+- [ ] 5.2 Add `browserProviders` beside `proxiedProviders`, one entry, in the same shape, with
+      the doc stating the measured reason both halves are required.
+
+## 6. A crawl that reads nothing of what it listed fails
+
+- [ ] 6.1 Write the failing test in `echojobs_test.go`: a sitemap yielding candidates whose
+      every detail fetch fails returns an ERROR; a sitemap yielding no candidates at all
+      still returns success with no jobs.
+- [ ] 6.2 Implement the guard in `FetchNew`, with the comment explaining that the pipeline
+      cannot make this call because a dropped posting never reaches it.
+
+## 7. Ship
+
+- [ ] 7.1 `gofmt -w`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`;
+      `go test -tags=integration` for the packages touched.
+- [ ] 7.2 Document the tier in `internal/ingest/sources/AGENTS.md` and the new package in
+      `internal/platform/AGENTS.md`; add the module-file row for `platform/browser`.
+- [ ] 7.3 Open the PR referencing freehire#2588; state that enabling it on prod is a separate
+      step and that the 84 605 closed rows stay closed.

--- a/openspec/changes/echojobs-browser-tier/tasks.md
+++ b/openspec/changes/echojobs-browser-tier/tasks.md
@@ -29,7 +29,7 @@
 
 ## 3. `api/atsapply` takes its flags from the shared home
 
-- [ ] 3.1 Make `stealthAllocatorOptions` delegate to `browser.LaunchOptions("")`, leaving
+- [x] 3.1 Make `stealthAllocatorOptions` delegate to `browser.LaunchOptions("")`, leaving
       `newBrowserSession`, the DOM scan, the fill and the screenshots untouched. Its existing
       tests must stay green without edits.
 

--- a/openspec/changes/echojobs-browser-tier/tasks.md
+++ b/openspec/changes/echojobs-browser-tier/tasks.md
@@ -35,25 +35,25 @@
 
 ## 4. `sources` — the browser-backed getter
 
-- [ ] 4.1 Write the failing integration test: a `browserClient` over a real session satisfies
+- [x] 01 Write the failing integration test: a `browserClient` over a real session satisfies
       `XMLGetter` + `HTMLGetter`, decoding XML and parsing HTML served by a local server.
-- [ ] 4.2 Implement it, mapping a non-2xx status to an error that NAMES the status, so a
+- [x] 02 Implement it, mapping a non-2xx status to an error that NAMES the status, so a
       caller can still tell `404` from `403`.
 
 ## 5. `echojobs` opts in
 
-- [ ] 5.1 Write the failing test for the registry: with a proxy configured, `echojobs`
+- [x] 01 Write the failing test for the registry: with a proxy configured, `echojobs`
       resolves to the browser-backed adapter; with none, it resolves to the plain one and no
       browser is constructed.
-- [ ] 5.2 Add `browserProviders` beside `proxiedProviders`, one entry, in the same shape, with
+- [x] 02 Add `browserProviders` beside `proxiedProviders`, one entry, in the same shape, with
       the doc stating the measured reason both halves are required.
 
 ## 6. A crawl that reads nothing of what it listed fails
 
-- [ ] 6.1 Write the failing test in `echojobs_test.go`: a sitemap yielding candidates whose
+- [x] 01 Write the failing test in `echojobs_test.go`: a sitemap yielding candidates whose
       every detail fetch fails returns an ERROR; a sitemap yielding no candidates at all
       still returns success with no jobs.
-- [ ] 6.2 Implement the guard in `FetchNew`, with the comment explaining that the pipeline
+- [x] 02 Implement the guard in `FetchNew`, with the comment explaining that the pipeline
       cannot make this call because a dropped posting never reaches it.
 
 ## 7. Ship

--- a/openspec/changes/echojobs-browser-tier/tasks.md
+++ b/openspec/changes/echojobs-browser-tier/tasks.md
@@ -1,13 +1,13 @@
 ## 1. `platform/browser` — the launch flags
 
-- [ ] 1.1 Write the failing test for `LaunchOptions`: the stealth pair is present; an empty
+- [x] 1.1 Write the failing test for `LaunchOptions`: the stealth pair is present; an empty
       proxy adds no proxy flag; a proxy URL carrying credentials yields a `ProxyServer` with
       the scheme and host and with **neither the username nor the password anywhere in the
       option set** (a credential in argv is readable by any process on the host).
-- [ ] 1.2 Add `internal/platform/browser/browser.go` with `LaunchOptions`, documenting that
+- [x] 1.2 Add `internal/platform/browser/browser.go` with `LaunchOptions`, documenting that
       this is the single home for the stealth flags and naming the 2026-09-02 measurement
       the pair came from.
-- [ ] 1.3 Register `browser` in the `platform` block in
+- [x] 1.3 Register `browser` in the `platform` block in
       `internal/platform/arch/layering/blocks.go`, with the comment saying why it is transport
       (the `aigateway` precedent) rather than an ingest or api package.
 

--- a/openspec/changes/echojobs-browser-tier/tasks.md
+++ b/openspec/changes/echojobs-browser-tier/tasks.md
@@ -58,9 +58,9 @@
 
 ## 7. Ship
 
-- [ ] 7.1 `gofmt -w`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`;
+- [x] 7.1 `gofmt -w`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`;
       `go test -tags=integration` for the packages touched.
-- [ ] 7.2 Document the tier in `internal/ingest/sources/AGENTS.md` and the new package in
+- [x] 7.2 Document the tier in `internal/ingest/sources/AGENTS.md` and the new package in
       `internal/platform/AGENTS.md`; add the module-file row for `platform/browser`.
-- [ ] 7.3 Open the PR referencing freehire#2588; state that enabling it on prod is a separate
+- [x] 7.3 Open the PR referencing freehire#2588; state that enabling it on prod is a separate
       step and that the 84 605 closed rows stay closed.

--- a/openspec/changes/firecrawl-tier/design.md
+++ b/openspec/changes/firecrawl-tier/design.md
@@ -1,0 +1,86 @@
+# Design
+
+## Where the client lives
+
+`internal/platform/firecrawl`, beside `browseruse`, and for the reason `browseruse`'s own entry
+in `blocks.go` gives: it is the HTTP half of talking to a vendor API and knows nothing about the
+domain. One caller today (`ingest/sources`); the category, not the caller count, is what places
+it — `browseruse` also has one.
+
+It is deliberately NOT `platform/browser`'s neighbour in behaviour. That package launches a
+process on our own host and costs nothing per page. This one calls a metered third party. Two
+things with the same shape and opposite economics should not share a name or a home, which is
+why the sources-side maps stay separate too.
+
+## The seam, again
+
+`baytHTTP` is `HTMLGetter`. `gulftalentHTTP` is `XMLGetter` + `HTMLGetter`. A hosted-fetch
+client satisfying both is a drop-in, and **neither adapter changes** — exactly as with the
+browser tier, and for the same reason: what is broken about these providers is the address the
+request leaves from, not how the response is read.
+
+Errors are `*StatusError`, the type the plain client produces, so `detailUnreadable` and
+`isRateLimited` keep working. A hosted fetch adds one failure mode the others do not have —
+the vendor answering fine while reporting that the target refused — so the target's status is
+what gets rendered, never the vendor's.
+
+## Spending is the design problem
+
+Everything above is small. The part that needs care is that this tier costs real money per
+page, against a measured 1% useful yield.
+
+Three bounds, each doing something the others cannot:
+
+**No key, no tier.** `ApplyFirecrawlEgress` is a no-op without `FIRECRAWL_API_KEY`, and the
+client is never constructed. Merging this cannot spend anything.
+
+**A per-run page budget.** `FIRECRAWL_MAX_PAGES_PER_RUN` (default 500) is counted inside the
+client, across every provider in the run. Past it, further fetches fail fast with a named error
+rather than being made. 500 is deliberately small: gulftalent alone lists 60 000 postings, and
+the difference between a bounded run and an unbounded one is the difference between a nightly
+trickle and a month's allowance gone by morning. An operator who wants a bigger pass raises it
+for that run, which is a decision with a number attached rather than an accident.
+
+The budget lives in the CLIENT, not in each adapter. An adapter cannot know what the other
+adapters in the same run have already spent, and the thing being protected is the account, not
+the crawl.
+
+**The timer stays off.** Merging this and configuring a key still crawls nothing until an
+ingest timer is enabled. Three deliberate acts, not one.
+
+## The gulftalent override
+
+`gulftalent` is in `proxiedFingerprintProviders` today. Both tiers rewire the same registry
+entry, and `cmd/ingest` applies them in sequence, so without care it would silently get
+whichever ran last — the hazard the browser tier's disjointness test exists to catch.
+
+Here the override is wanted: the fingerprint transport is measured as refused, the hosted one
+as served. So it is made explicit instead of forbidden.
+
+- `ApplyFirecrawlEgress` runs **last** in `cmd/ingest`, after the proxy and browser tiers.
+- A test pins the order's effect: with a key configured, `gulftalent` resolves to the hosted
+  client, not the fingerprint one.
+- A test pins the fallback: with no key, it resolves to the fingerprint client exactly as
+  today, so an unconfigured deployment is bit-for-bit unchanged.
+
+The browser tier's disjointness rule is narrowed rather than dropped: browser and proxy tiers
+must still not overlap (nothing wants that), while the hosted tier is allowed to override, and
+the test says which is which and why. A rule with a documented exception beats a rule quietly
+broken.
+
+## Testing
+
+- `platform/firecrawl` — the request/response mapping and the budget against an `httptest`
+  server standing in for the vendor: a page returned, a target refusal reported as the
+  TARGET's status, a vendor error distinguished from a target one, and the budget refusing the
+  (N+1)th fetch without issuing it. No network, no key, no credits.
+- `sources` — `GetXML` decodes and `GetHTML` parses what the client returned; a non-2xx target
+  status surfaces as `*StatusError` carrying that code.
+- The tier wiring — no key is a no-op; a key rewires both providers; `gulftalent` resolves to
+  hosted with a key and to fingerprint without one; an unrelated registry is untouched.
+- `bayt` and `gulftalent`'s own tests are not edited. If any of them needed editing, the seam
+  would be in the wrong place.
+
+Live verification against the real vendor is deliberately NOT automated: it costs credits per
+run, and a test that quietly spends money every time CI runs is a worse failure than no test.
+The live evidence for this change is the measurement in the proposal, taken by hand.

--- a/openspec/changes/firecrawl-tier/proposal.md
+++ b/openspec/changes/firecrawl-tier/proposal.md
@@ -1,0 +1,81 @@
+## Why
+
+Two providers are unreachable from anything this repository can egress from. `bayt` and
+`gulftalent` answer `403` to the production datacenter IP **and** to `SOURCES_PROXY_URL`,
+whose exit their edge classifies as a datacenter too. `proxy.go` has recorded that for months
+and named the remedy it was waiting for: "the day a genuinely residential pool exists".
+
+Measured 2026-09-07 against a hosted scraping API (Firecrawl), both are served normally:
+
+| source | prod IP | our proxy | hosted fetch |
+|---|---|---|---|
+| `bayt` (UAE listing) | `403` | `403` | **200, 284 KB** |
+| `gulftalent` (sitemap) | `403` | `403` | **200, 30 000 job URLs** |
+
+So the missing piece is not a better fingerprint or a better browser — the browser tier
+(freehire#2588) does not help here either, because the refusal comes before any challenge.
+The missing piece is an address we do not own.
+
+**What is behind those walls is thin, and this change is being made with that measured rather
+than assumed.** Running their own titles through this repository's own `classify.IsTech`:
+
+| source | sample | pass the tech gate |
+|---|---|---|
+| `bayt`, its **IT** category | 33 titles | **0** |
+| `gulftalent`, real postings | 400 titles | **5 (1.25%)** |
+
+bayt's IT category is project managers, VPs, department directors and professors; gulftalent's
+postings are nannies, chefs, camp bosses and hotel electricians, with about one engineer in
+eighty. At roughly 60 000 gulftalent postings that is perhaps 750 technical ones for the whole
+site, and every page fetched costs a credit.
+
+That trade was put to the owner with these numbers and the decision was to build it anyway.
+This proposal therefore optimises for the one thing that follows from those numbers: **it must
+be impossible for this tier to spend money by accident.**
+
+## What Changes
+
+- **A hosted-fetch client becomes shared transport.** A new `internal/platform/firecrawl`
+  speaks the vendor's scrape API and returns a page's raw bytes. It knows nothing about jobs —
+  the same "transport, not domain" category as `platform/browseruse`, which is likewise an HTTP
+  client for somebody else's hosted browser.
+- **`sources` gains a hosted-fetch getter** satisfying `XMLGetter` + `HTMLGetter`. Both target
+  adapters already declare exactly those (`baytHTTP` is `HTMLGetter`; `gulftalentHTTP` is both),
+  so **neither adapter changes**.
+- **`bayt` and `gulftalent` opt in per-provider**, in the shape `proxiedProviders` and
+  `browserProviders` already use.
+- **The tier is off unless `FIRECRAWL_API_KEY` is set**, and no request is ever made without it.
+- **A per-run page budget bounds one crawl** (`FIRECRAWL_MAX_PAGES_PER_RUN`). Every fetch is
+  counted; past the budget the run stops asking rather than continuing to spend. With a 1%
+  useful yield and a metered API, an unbounded crawl of a 60 000-page site is a month's
+  allowance spent in one night.
+- **`gulftalent` moves off the fingerprint tier deliberately, not accidentally.** It is in
+  `proxiedFingerprintProviders` today, and both tiers rewire the same registry entry. The
+  override is made explicit, ordered last, and pinned by a test — the alternative is the exact
+  hazard the browser tier's disjointness test exists to prevent.
+
+## Capabilities
+
+### New Capabilities
+
+- `job-source-hosted-fetch`: how a source that refuses every address this repository can egress
+  from is crawled through a third party — when the tier engages, what bounds its spending, and
+  how it interacts with the transports that would otherwise claim the same provider.
+
+### Modified Capabilities
+
+<!-- None. bayt's and gulftalent's own parsing is unchanged; only their transport is. -->
+
+## Impact
+
+- `internal/platform/firecrawl/` — new: the API client.
+- `internal/platform/arch/layering/blocks.go` — `firecrawl` joins the `platform` block.
+- `internal/ingest/sources/` — the hosted-fetch getter, the per-provider opt-in and the page
+  budget; `proxy.go`'s comment about waiting for a residential pool, which this answers.
+- `cmd/ingest` — applying the tier, after the others.
+- `internal/ingest/sources/bayt.go`, `gulftalent.go` — **unchanged**, and a test says so by
+  continuing to pass untouched.
+
+Not in scope: enabling either provider's ingest timer. Merging this changes nothing until a key
+is configured AND a timer is turned on, which are two separate deliberate acts. Also out:
+using this tier for `echojobs`, which the browser tier already serves at no per-page cost.

--- a/openspec/changes/firecrawl-tier/tasks.md
+++ b/openspec/changes/firecrawl-tier/tasks.md
@@ -1,0 +1,42 @@
+## 1. `platform/firecrawl` — the client
+
+- [x] 1.1 Write the failing tests against an `httptest` stand-in for the vendor: a page comes
+      back with its bytes; a TARGET refusal is reported as the target's status, not the
+      vendor's 200; a VENDOR failure is a distinct error; a missing key is refused at
+      construction.
+- [x] 1.2 Write the failing test for the budget: with a budget of N, the (N+1)th fetch fails
+      with a named error and **issues no request** (the stand-in counts).
+- [x] 1.3 Implement `Client` + `Fetch(ctx, url) (status int, body []byte, err error)` with the
+      budget counted in the client, documenting why it lives there and not per adapter.
+- [x] 1.4 Register `firecrawl` in the `platform` block, with the comment saying it is the
+      `browseruse` category (vendor API transport) and NOT `browser` (our own process, free).
+
+## 2. `sources` — the hosted-fetch getter
+
+- [x] 2.1 Write the failing test: the getter satisfies `XMLGetter` + `HTMLGetter`, decodes XML,
+      parses HTML, and turns a non-2xx target status into `*StatusError` carrying that code.
+- [x] 2.2 Implement it, reusing `browserStatusError`'s shape so the existing helpers keep
+      reading it.
+
+## 3. The tier, and the deliberate override
+
+- [x] 3.1 Write the failing tests: no key is a no-op; a key rewires `bayt` and `gulftalent`;
+      `gulftalent` resolves to hosted WITH a key and to the fingerprint client WITHOUT one; an
+      unrelated registry is untouched; an unparseable budget fails the run.
+- [x] 3.2 Narrow the browser tier's disjointness test to browser-vs-proxy, and add the hosted
+      tier's own rule: it MAY override, and the test states which providers it deliberately
+      takes over and why.
+- [x] 3.3 Add `firecrawlProviders` + `ApplyFirecrawlEgress`; wire it into `cmd/ingest` LAST,
+      after the proxy and browser tiers, with the comment saying the order is load-bearing.
+- [x] 3.4 Replace `proxy.go`'s "waiting for a genuinely residential pool" note for bayt and
+      gulftalent with what actually answered it.
+
+## 4. Ship
+
+- [x] 0 `gofmt -w`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`.
+      `bayt` and `gulftalent` tests must pass **unedited**.
+- [x] 0 Document the tier in `internal/ingest/sources/AGENTS.md` and the client in its own
+      AGENTS.md; add the module-file row; record the measured 1% yield so the next person
+      inherits the number and not just the switch.
+- [x] 4.3 Open the PR on top of the browser-tier branch, stating that merging spends nothing
+      and that three separate acts are needed before it does.


### PR DESCRIPTION
Closes #2588 — or rather, makes it a decision instead of an outage.

`echojobs` published `ingested=0 failed=0`, exit 0, green unit, every four hours for 19 days while its pages sat behind Vercel's bot wall. This rebuilds it on a headless browser and makes that particular silence impossible.

## What the spike established, before any code

All four combinations were measured rather than reasoned about:

| origin | plain GET | headless Chrome |
|---|---|---|
| prod datacenter IP | `403 x-vercel-mitigated: deny` | **`403`** — no challenge is offered at all |
| `SOURCES_PROXY_URL` | `429` + Security Checkpoint | **200, real page** |

**Neither half works alone.** A browser cannot solve a challenge it is never given, and a challenge cannot be passed without running JavaScript. That is why adding `echojobs` to `proxiedProviders` — the one-line remedy that recovered `djinni`, `enlizt` and `wantedkr` — was tried and rejected. `proxy.go` used to name echojobs as waiting for a residential pool; that comment is now corrected rather than left to mislead the next reader.

The cheap tier was measured too. The clearance cookie handed to Go's `http.Client` **still gets the challenge**, so the request has to leave from the browser — but issuing it as an in-page `fetch()` rather than a navigation costs `0.36s` instead of `4.2s` and returns the real status code, which is what keeps a `404` distinguishable from a block.

## What this adds

**`internal/platform/browser`** — launching a stealth Chrome and fetching through one. It is in `platform` for the reason `blocks.go` already gives for `aigateway`: transport that knows nothing about the domain, with callers in two blocks that may not import each other. Only the *launch flags* are shared with auto-apply; its session, DOM scan and form filling stay where they are.

**A browser-backed getter in `sources`** implementing exactly `XMLGetter` + `HTMLGetter`, which is `echojobsHTTP`. **Not one line of the adapter's reading changed** — the sitemap walk and the JobPosting parse always worked. Its errors are `*StatusError`, the same type the plain client produces, which is load-bearing rather than tidy: `detailUnreadable` and `isRateLimited` match on that type, so a browser-fetched `404` still means "this posting is gone".

**The guard.** A crawl that listed candidates and read none of them now fails its board. It lives in the adapter because a dropped posting never reaches the pipeline — `Stats` counts `saveOne` failures, not candidates an adapter discarded — so from every side but `FetchNew`'s, a total outage and a quiet source are the same line. No threshold: "some candidates, none read" is the whole signal, and how many consecutive failures matter is `board_health`'s question.

## Two things only live verification found

Both were wrong while every unit test was green.

**The user agent decided everything.** A hand-rolled probe cleared the wall in 8s while the packaged session sat refused for 20 — identical flags, proxy and tab structure. The probe set a desktop user agent; the package did not, so Chrome announced `HeadlessChrome`, and against that the site did not serve a challenge at all. No launch flag removes that string. The session now reads the running browser's own agent and rewrites that one word — read rather than hardcoded, so it never claims a Chrome version the binary is not.

> ⚠️ **This changes auto-apply too**, since it shares the launch path: its browser now presents a non-headless agent. That is strictly more browser-like and is what its stealth flags were always for, but it is a behaviour change to a production feature and is flagged rather than slipped in.

**Retrying a refused request holds the wall UP.** The first implementation re-issued the request every 250ms until it stopped being refused, and it never cleared — the obstacle is a rate-limit-flavoured `429`. What works is to navigate once and *watch*: the challenge answers the document with a refusal and then reloads itself, so the main document turning 2xx is the wall lifting. No extra request, no site-specific marker, and a ceiling rather than a delay — `3.9s` where the fixed-sleep probe took `11s`.

Clearance latches on *any* document response succeeding rather than the last, because a challenge page can pull in frames of its own. The statuses seen ride the timeout error — which is how the user-agent cause was found rather than guessed.

## Verification

`gofmt`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...` — all green. `golangci-lint`: 0 issues.

End to end against **live echojobs.io from the production host, through the real adapter**:

```
FetchNew ok in 12.941s: 59476 postings listed, 5 hydrated with a body
  - "Quality Assurance Engineer" @ Tessera Labs | loc="Brazil, BR" | skills=[ci-cd cypress javascript kubernetes playwright python typescript]
  - "Software Engineer, AI Infrastructure" @ Harell Data | loc="Palo Alto, CA, US" | skills=[aws gcp kubernetes machine-learning python]
  ...
```

The browser integration test **skips when no Chrome is installed** — CI's backend job has none, and a red build there would mean nothing. Same contract the CV renderer's tests have for typst.

## Deploying this

Nothing turns on at merge. `echojobs`' timer is stopped and disabled on prod (2026-09-07), and the tier only engages once that timer is re-enabled. `SOURCES_PROXY_URL` is already configured, so no new secret.

The 84 605 postings closed on 2026-09-07 **stay closed**. A working crawl re-opens whatever the 14-day sitemap window still lists; the rest are a month old, roughly half were already duplicate-suppressed, and re-opening postings nobody has verified is what this catalogue's ghost-job work exists to prevent.

Still out of scope: the employer apply URL, which the page has not carried since the 2026-08 rewrite, and the broader "a provider whose `max(last_seen_at)` has not moved in N days" gauge, which belongs with `queue-metrics` and stays in #2588.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added headless-browser support for JavaScript-protected job-source pages, using configured proxy access and reusable sessions.
  - Added hosted fetching for sources that block available network routes, with configurable per-run page limits.
  - Preserved HTTP response statuses and rate-limit detection across fetching methods.

- **Bug Fixes**
  - Crawls now report an error when postings are discovered but none can be read.
  - Empty crawls continue to complete successfully.
  - Improved handling of browser challenges and proxy authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->