### PR TITLE
Read djinni's applicant region, not only its country

### DIFF
--- a/internal/ingest/sources/djinni.go
+++ b/internal/ingest/sources/djinni.go
@@ -96,7 +96,8 @@ func (s djinni) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
 
 // djinniPosting is one schema.org JobPosting from the listing. identifier is a bare integer;
 // jobLocationType (TELECOMMUTE/ON_SITE) is the work-arrangement signal; the applicant location
-// requirement carries only a country.
+// requirement carries the candidate-residence rule Djinni renders as "Countries where we consider
+// candidates", as EITHER a country or a macro-region — see toJob.
 type djinniPosting struct {
 	Title              string `json:"title"`
 	Description        string `json:"description"`
@@ -111,23 +112,43 @@ type djinniPosting struct {
 	ApplicantLocationRequirements struct {
 		Address struct {
 			AddressCountry string `json:"addressCountry"`
+			AddressRegion  string `json:"addressRegion"`
 		} `json:"address"`
 	} `json:"applicantLocationRequirements"`
 }
 
 // toJob maps a posting to a Job, returning ok=false for a posting with no identifier (no dedup
 // key), no url (no canonical address), or no company (which would break the company slug).
+//
+// The applicant area states one of three things, and each must be carried differently. A country
+// ("UA", and sometimes the alpha-3 "POL") goes into the structured Countries field, since an
+// alpha-3 code resolves through NormalizeCountry but not through the free-text location line. A
+// macro-region with a null country ("Europe", which Djinni renders as "Countries of Europe or
+// Ukraine") has no structured field to go into, so it rides the location line, where the
+// dictionary resolves it to the eu region. An ABSENT applicant area is Djinni's "Worldwide", and
+// the bare-remote line correctly lands in the global bucket.
+//
+// Leaving a stated area unread is not neutral: the served facet falls back to the enrichment
+// guess whenever the dictionary pins nothing (see internal/job/jobview.geoFacet), and the LLM
+// reads "work ... from any part of the world" out of a benefits paragraph, publishing a
+// Europe-only role as open worldwide (1012 open postings at the time of the fix).
 func (p djinniPosting) toJob() (Job, bool) {
 	if p.Identifier == 0 || p.URL == "" || p.HiringOrganization.Name == "" {
 		return Job{}, false
 	}
 	remote := strings.EqualFold(p.JobLocationType, "TELECOMMUTE")
+	addr := p.ApplicantLocationRequirements.Address
+	loc := addr.AddressCountry
+	if loc == "" {
+		loc = addr.AddressRegion
+	}
 	return Job{
 		ExternalID:     strconv.FormatInt(p.Identifier, 10),
 		URL:            p.URL,
 		Title:          p.Title,
 		Company:        p.HiringOrganization.Name,
-		Location:       p.ApplicantLocationRequirements.Address.AddressCountry,
+		Location:       loc,
+		Countries:      countryFromCode(addr.AddressCountry),
 		Description:    sanitizeHTML(plainTextToHTML(p.Description)),
 		Remote:         remote,
 		WorkMode:       workModeFromRemote(remote),

--- a/internal/ingest/sources/djinni_test.go
+++ b/internal/ingest/sources/djinni_test.go
@@ -54,6 +54,28 @@ const djinniSingleHTML = `<html><head>
 </script>
 </head><body></body></html>`
 
+// djinniApplicantAreaHTML carries the two applicant-area shapes the country-only reading missed.
+// Djinni states a posting's candidate residence rule in applicantLocationRequirements, and about
+// a third of the live listing states it as a macro-REGION with a null country ("Countries of
+// Europe or Ukraine" renders as addressRegion "Europe"). Reading only addressCountry left those
+// postings geography-less, which handed the facet to the LLM's enrichment guess and published a
+// Europe-only role as open worldwide. The second posting states an alpha-3 country code, which a
+// free-text location line does not resolve — only the structured Countries field does.
+const djinniApplicantAreaHTML = `<html><head>
+<script type="application/ld+json">
+[{"@context":"https://schema.org/","@type":"JobPosting",
+"title":"Senior .NET Developer","url":"https://djinni.co/jobs/846790-senior-net/","identifier":846790,
+"jobLocationType":"TELECOMMUTE",
+"hiringOrganization":{"@type":"Organization","name":"Devart"},
+"applicantLocationRequirements":{"@type":"AdministrativeArea","address":{"@type":"PostalAddress","addressCountry":null,"addressRegion":"Europe"}}},
+{"@context":"https://schema.org/","@type":"JobPosting",
+"title":"QA Engineer","url":"https://djinni.co/jobs/846791-qa/","identifier":846791,
+"jobLocationType":"TELECOMMUTE",
+"hiringOrganization":{"@type":"Organization","name":"Beta"},
+"applicantLocationRequirements":{"@type":"AdministrativeArea","address":{"@type":"PostalAddress","addressCountry":"POL"}}}]
+</script>
+</head><body></body></html>`
+
 const djinniEmptyHTML = `<html><head></head><body></body></html>`
 
 func init() { djinniPageDelay = 0 } // don't pace the crawl in unit tests
@@ -147,6 +169,32 @@ func TestDjinniFetchMapsListingArray(t *testing.T) {
 	}
 	if j.PostedAt == nil {
 		t.Errorf("PostedAt = nil, want the zone-less datePosted parsed")
+	}
+}
+
+// TestDjinniMapsApplicantArea is the regression guard for the "remote worldwide" misreport: a
+// posting whose applicant area names only a macro-region must carry that region into the location
+// line (where the dictionary resolves "Europe" to the eu region), and one whose area names a
+// country must carry it as a structured country code — an alpha-3 that the free-text line alone
+// would not resolve. Geography left empty here is not neutral: the served facet then falls back
+// to the LLM's guess, which reads "work from any part of the world" out of a benefits paragraph.
+func TestDjinniMapsApplicantArea(t *testing.T) {
+	fake := &djinniPagedHTTP{bodies: map[int]string{1: djinniApplicantAreaHTML}}
+	jobs, err := NewDjinni(fake).Fetch(context.Background(), CompanyEntry{Provider: "djinni"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2", len(jobs))
+	}
+	if got := jobs[0].Location; got != "Europe" {
+		t.Errorf("region-only posting: Location = %q, want the addressRegion", got)
+	}
+	if got := jobs[0].Countries; len(got) != 0 {
+		t.Errorf("region-only posting: Countries = %v, want none — a region is not a country", got)
+	}
+	if got := jobs[1].Countries; len(got) != 1 || got[0] != "pl" {
+		t.Errorf("country posting: Countries = %v, want [pl] from the alpha-3 code", got)
 	}
 }
 


### PR DESCRIPTION
## What users saw

A [Devart .NET role](https://freehire.me/jobs/senior-net-developer-ai-integrations-devart-w5ozqmpb) shows as **Remote worldwide**. [Its djinni page](https://djinni.co/jobs/846790-senior-net-developer-ai-integrations/) says "Countries of Europe or Ukraine".

## Why

Two steps, and the second is the one that publishes the wrong thing.

1. Djinni states the candidate-residence rule in JSON-LD's `applicantLocationRequirements`. About a third of the live listing states it as a macro-REGION with a null country — measured on 3 listing pages: 15 of 45 postings carry `addressRegion: "Europe"`, 11 carry a country, 19 carry no area at all. The adapter read only `addressCountry`, so those 15 reached the pipeline geography-less.
2. `jobview.geoFacet` falls back wholesale to the LLM's `enrichment` guess whenever the dictionary pinned nothing — and the LLM read this posting's *benefits* paragraph ("work remotely ... from any part of the world") as open-anywhere. The stored row is `regions={} countries={} location=''`; `enrichment->'regions'` is `["global"]`.

**1012 open djinni postings** are in that state on prod right now (`cardinality(regions)=0 AND cardinality(countries)=0 AND enrichment->'regions' @> '["global"]'`).

## The fix

- `addressRegion` rides the location line, where `location.Parse` already resolves `"Europe"` → the `eu` region. No structured `Regions` field on `sources.Job` exists, and one source does not justify inventing one.
- `addressCountry` additionally goes into the structured `Countries` field via `countryFromCode`, which resolves the alpha-3 codes djinni sometimes emits (`"POL"`) that the free-text line does not.
- An **absent** applicant area is untouched: that is djinni's own "Worldwide" (verified against a posting whose page renders exactly that), and the bare-remote line correctly lands in the global bucket.

Once the dictionary pins `eu`, `geoPinned` is true and the LLM guess can no longer override it.

## After deploy

Needs `INGEST_REFETCH_ALL=1 ingest djinni` — the fix changes what the LISTING yields, so it reaches new postings only (~7.4k open djinni rows, no detail request per posting since djinni's listing carries the full posting).