### PR TITLE
Reach the two sources no address of ours is served from — behind three locks against spending

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,7 @@ Each is self-contained and can be read independently.
 | **Host configuration** (systemd units and timers, operator scripts, the two-file env split) | [deploy/AGENTS.md](deploy/AGENTS.md) |
 | **LLM client** (provider-agnostic wrapper, schema cache, streaming, attribution tags) | [internal/platform/llm/AGENTS.md](internal/platform/llm/AGENTS.md) |
 | **Headless browser** (launching Chrome, in-page fetch, the stealth flags' single home) | [internal/platform/browser/AGENTS.md](internal/platform/browser/AGENTS.md) |
+| **Hosted fetch** (the last-resort metered tier, its page budget, and the yield behind it) | [internal/platform/firecrawl/AGENTS.md](internal/platform/firecrawl/AGENTS.md) |
 | **Sentry error tracking** (backend, workers, frontend — env-gated) | [internal/platform/observability/AGENTS.md](internal/platform/observability/AGENTS.md) |
 | **`internal/dict`** — the block itself: what it is, what it may import | [internal/dict/AGENTS.md](internal/dict/AGENTS.md) |
 | **Company names** (real display names for slug-named companies) | [internal/dict/companyname/AGENTS.md](internal/dict/companyname/AGENTS.md) |

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -112,6 +112,13 @@ func run() int {
 		return 1
 	}
 	defer closeBrowser()
+	// LAST, and the order is load-bearing: the hosted tier deliberately takes gulftalent off
+	// the fingerprint transport, which ApplyProxyEgress above wired. See ApplyFirecrawlEgress.
+	// A no-op without FIRECRAWL_API_KEY, so this cannot spend anything on an ordinary run.
+	if err := sources.ApplyFirecrawlEgress(registry); err != nil {
+		log.Printf("config: %v", err)
+		return 1
+	}
 
 	// Resolved before the DB is touched, like every other config read here: a bad value should
 	// stop the run, not produce a quiet ordinary crawl where a repair was intended.

--- a/internal/ingest/sources/AGENTS.md
+++ b/internal/ingest/sources/AGENTS.md
@@ -368,3 +368,27 @@ So a hydrating adapter that listed candidates and read **none** of them returns 
 There is deliberately no threshold: "some candidates, none read" is the whole signal, and how
 many consecutive failures matter is `board_health`'s question. No candidates at all still
 succeeds — a quiet source is not a broken one.
+
+## The hosted tier (last resort, and it costs money)
+
+`firecrawlProviders` (firecrawltier.go) is the third transport, for providers that refuse
+**every** address this repository can obtain. `bayt` and `gulftalent` are `403` from the prod
+datacenter IP *and* `403` through `SOURCES_PROXY_URL`; the browser tier does not help either,
+because the refusal comes before any challenge is offered.
+
+Reach for it only after the other two are ruled out — it is the only tier billed per page.
+Before adding a provider, measure what is behind the wall: `bayt`'s own IT category passed
+**0 of 33** titles through `classify.IsTech`, and `gulftalent`'s postings **5 of 400**. See
+[internal/platform/firecrawl/AGENTS.md](../../platform/firecrawl/AGENTS.md) for the full
+numbers and the three bounds that keep it from spending by accident.
+
+**`ApplyFirecrawlEgress` must run LAST**, and `cmd/ingest` does. `gulftalent` is in
+`proxiedFingerprintProviders` too, so both write the same registry entry — here the override is
+*wanted* (that transport is measured as refused, this one as served), so it is ordered and
+pinned by a test instead of being the silent last-write-wins the browser tier's disjointness
+test exists to prevent. Without a key the override does not happen and `gulftalent` keeps the
+fingerprint transport exactly as before.
+
+Neither adapter changed: `baytHTTP` is `HTMLGetter` and `gulftalentHTTP` is `XMLGetter` +
+`HTMLGetter`, and a test asserts the hosted client satisfies both. What is wrong with these
+providers is the address a request leaves from, not how the response is read.

--- a/internal/ingest/sources/browsertier_test.go
+++ b/internal/ingest/sources/browsertier_test.go
@@ -10,13 +10,18 @@ func TestBrowserTierCarriesEchojobs(t *testing.T) {
 	}
 }
 
-// The browser tier and the plain proxy tier must be DISJOINT. Both rewire the same registry
-// entry and cmd/ingest applies them in sequence, so a provider in both would silently get
-// whichever ran last — a wiring bug with no symptom except a provider that quietly stopped
-// using the transport somebody chose for it.
+// The browser tier and the proxy tiers must be DISJOINT. Both rewire the same registry entry
+// and cmd/ingest applies them in sequence, so a provider in both would silently get whichever
+// ran last — a wiring bug with no symptom except a provider that quietly stopped using the
+// transport somebody chose for it.
 //
 // A browser-tier provider does not need proxiedProviders anyway: ApplyBrowserEgress builds
 // its session over SOURCES_PROXY_URL itself, so the browser IS the proxied transport.
+//
+// The HOSTED tier is the documented exception and is checked separately (see
+// TestHostedTierDeliberatelyOverridesTheFingerprintTierForGulftalent): it may take a provider
+// off another tier, because for its two providers every other transport is measured as
+// refused. A rule with a stated exception beats a rule quietly broken.
 func TestBrowserTierAndProxyTierAreDisjoint(t *testing.T) {
 	for name := range browserProviders {
 		if _, ok := proxiedProviders[name]; ok {

--- a/internal/ingest/sources/firecrawltier.go
+++ b/internal/ingest/sources/firecrawltier.go
@@ -1,0 +1,164 @@
+package sources
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/html"
+
+	"github.com/strelov1/freehire/internal/platform/firecrawl"
+)
+
+// firecrawlProviders is the opt-in allowlist of providers that refuse EVERY address this
+// repository can egress from, so their crawl goes through a hosted scraping API.
+//
+// This is the third and last resort, and the order matters. proxiedProviders answers "our IP
+// is blocked but another one is not". browserProviders answers "the page needs JavaScript
+// run". This one answers "no address we can obtain is served at all" — and it is the only one
+// that costs money per page, so nothing lands here that either of the others can reach.
+//
+// Measured 2026-09-07, both providers: 403 from the production datacenter IP and 403 through
+// SOURCES_PROXY_URL, whose exit their edge classifies as datacenter too; served normally by
+// the hosted API. The browser tier does not help, because the refusal comes before any
+// challenge is offered.
+//
+// What is behind those walls is thin, and whoever changes this should know the number rather
+// than rediscover it: run through this repository's own classify.IsTech, bayt's IT category
+// passed 0 of 33 titles and gulftalent's postings 5 of 400 (1.25%). They are project managers,
+// professors, chefs and hotel electricians. This tier was built with that measured and
+// accepted, which is why every guard below exists.
+var firecrawlProviders = map[string]func(*firecrawlClient) Source{
+	"bayt":       func(c *firecrawlClient) Source { return NewBayt(c) },
+	"gulftalent": func(c *firecrawlClient) Source { return NewGulfTalent(c) },
+}
+
+// defaultFirecrawlBudget is how many pages one run may fetch when nothing says otherwise.
+// Deliberately small against a site listing 60 000 postings: the difference between a bounded
+// run and an unbounded one is the difference between a nightly trickle and a month's
+// allowance gone by morning. Raising it is a decision with a number attached.
+const defaultFirecrawlBudget = 500
+
+// firecrawlClient adapts the hosted fetch to the two transports the target adapters declare —
+// baytHTTP is HTMLGetter, gulftalentHTTP is XMLGetter + HTMLGetter — so NEITHER ADAPTER
+// CHANGES. What is wrong with these providers is the address a request leaves from, not how
+// the response is read.
+type firecrawlClient struct {
+	api *firecrawl.Client
+}
+
+var (
+	_ XMLGetter  = (*firecrawlClient)(nil)
+	_ HTMLGetter = (*firecrawlClient)(nil)
+)
+
+// firecrawlStatusError renders a TARGET status as the same typed error the plain client
+// produces, so detailUnreadable and isRateLimited keep reading it. The status is the target's,
+// never the vendor's: the vendor answers 200 while reporting a refusal inside.
+func firecrawlStatusError(url string, status int) error {
+	if status >= 200 && status < 300 {
+		return nil
+	}
+	return &StatusError{Method: http.MethodGet, Code: status, URL: url}
+}
+
+func (c *firecrawlClient) get(ctx context.Context, url string) ([]byte, error) {
+	status, body, err := c.api.Fetch(ctx, url)
+	if err != nil {
+		return nil, fmt.Errorf("sources: hosted GET %s: %w", url, err)
+	}
+	if err := firecrawlStatusError(url, status); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func (c *firecrawlClient) GetXML(ctx context.Context, url string, v any) error {
+	body, err := c.get(ctx, url)
+	if err != nil {
+		return err
+	}
+	if err := xml.NewDecoder(bytes.NewReader(body)).Decode(v); err != nil {
+		return fmt.Errorf("sources: hosted GET %s: decode xml: %w", url, err)
+	}
+	return nil
+}
+
+func (c *firecrawlClient) GetHTML(ctx context.Context, url string) (*html.Node, error) {
+	body, err := c.get(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	node, err := html.Parse(bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("sources: hosted GET %s: parse html: %w", url, err)
+	}
+	return node, nil
+}
+
+// ApplyFirecrawlEgress rewires the firecrawlProviders in registry onto the hosted API.
+//
+// It MUST be applied LAST, after ApplyProxyEgress and ApplyBrowserEgress. gulftalent is in
+// proxiedFingerprintProviders as well, and both write the same registry entry — the override
+// is wanted (that transport is measured as refused, this one as served) so it is ordered and
+// tested rather than left to whichever ran last. Without a key gulftalent keeps the
+// fingerprint transport exactly as today, which is what makes an unconfigured deployment
+// bit-for-bit unchanged.
+//
+// No key means no tier and no client, so merging this can spend nothing. An unusable page
+// budget is an error rather than a fallback: it is the one knob that decides what a night
+// costs, and a typo in it must not be quietly absorbed.
+func ApplyFirecrawlEgress(registry map[string]Source) error {
+	key := strings.TrimSpace(os.Getenv("FIRECRAWL_API_KEY"))
+	if key == "" {
+		return nil
+	}
+	if !anyFirecrawlProviderRegistered(registry) {
+		return nil
+	}
+	budget, err := firecrawlBudget(os.Getenv("FIRECRAWL_MAX_PAGES_PER_RUN"))
+	if err != nil {
+		return err
+	}
+	api, err := firecrawl.New(firecrawl.Config{APIKey: key, MaxPagesPerRun: budget})
+	if err != nil {
+		return fmt.Errorf("sources: hosted tier: %w", err)
+	}
+	// One client for the whole run, so the budget counts across every provider in it: what is
+	// being protected is the account, and no single adapter can know what the others spent.
+	c := &firecrawlClient{api: api}
+	for name, build := range firecrawlProviders {
+		if _, ok := registry[name]; ok {
+			registry[name] = build(c)
+		}
+	}
+	return nil
+}
+
+func anyFirecrawlProviderRegistered(registry map[string]Source) bool {
+	for name := range firecrawlProviders {
+		if _, ok := registry[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// firecrawlBudget resolves FIRECRAWL_MAX_PAGES_PER_RUN, defaulting when unset and refusing
+// anything that is not a positive number of pages.
+func firecrawlBudget(env string) (int64, error) {
+	env = strings.TrimSpace(env)
+	if env == "" {
+		return defaultFirecrawlBudget, nil
+	}
+	n, err := strconv.ParseInt(env, 10, 64)
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("sources: FIRECRAWL_MAX_PAGES_PER_RUN must be a positive number of pages, got %q", env)
+	}
+	return n, nil
+}

--- a/internal/ingest/sources/firecrawltier_test.go
+++ b/internal/ingest/sources/firecrawltier_test.go
@@ -1,0 +1,139 @@
+package sources
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+// The hosted client's errors must be the same type the plain client produces, for the reason
+// the browser client's are: detailUnreadable and isRateLimited match on *StatusError, so a
+// hosted 404 that arrived as a bare error would stop meaning "this posting is gone".
+func TestFirecrawlStatusErrorMatchesThePlainClient(t *testing.T) {
+	if err := firecrawlStatusError("https://example.test/x", http.StatusOK); err != nil {
+		t.Errorf("200 produced an error: %v", err)
+	}
+	err := firecrawlStatusError("https://example.test/x", http.StatusNotFound)
+	var se *StatusError
+	if !errors.As(err, &se) {
+		t.Fatalf("error is %T, want *StatusError", err)
+	}
+	if se.Code != http.StatusNotFound {
+		t.Errorf("Code = %d, want 404", se.Code)
+	}
+}
+
+// Both target adapters are unchanged by this tier, which only holds if the client satisfies
+// exactly what they already declare.
+func TestFirecrawlClientSatisfiesBothAdaptersTransports(t *testing.T) {
+	var c any = &firecrawlClient{}
+	if _, ok := c.(baytHTTP); !ok {
+		t.Error("firecrawlClient does not satisfy baytHTTP")
+	}
+	if _, ok := c.(gulftalentHTTP); !ok {
+		t.Error("firecrawlClient does not satisfy gulftalentHTTP")
+	}
+}
+
+func TestHostedTierCarriesTheTwoUnreachableProviders(t *testing.T) {
+	for _, name := range []string{"bayt", "gulftalent"} {
+		if _, ok := firecrawlProviders[name]; !ok {
+			t.Errorf("%s is not in firecrawlProviders", name)
+		}
+	}
+}
+
+// Without a key nothing is rewired and no client is built, so merging this change cannot
+// spend anything.
+func TestApplyFirecrawlEgressIsANoOpWithoutAKey(t *testing.T) {
+	t.Setenv("FIRECRAWL_API_KEY", "")
+	registry := map[string]Source{"bayt": NewBayt(NewClient()), "gulftalent": NewGulfTalent(NewClient())}
+	before := map[string]Source{"bayt": registry["bayt"], "gulftalent": registry["gulftalent"]}
+
+	if err := ApplyFirecrawlEgress(registry); err != nil {
+		t.Fatalf("ApplyFirecrawlEgress: %v", err)
+	}
+	for name, was := range before {
+		if registry[name] != was {
+			t.Errorf("%s was rewired with no API key configured", name)
+		}
+	}
+}
+
+func TestApplyFirecrawlEgressRewiresBothWithAKey(t *testing.T) {
+	t.Setenv("FIRECRAWL_API_KEY", "test-key")
+	registry := map[string]Source{"bayt": NewBayt(NewClient()), "gulftalent": NewGulfTalent(NewClient())}
+	before := map[string]Source{"bayt": registry["bayt"], "gulftalent": registry["gulftalent"]}
+
+	if err := ApplyFirecrawlEgress(registry); err != nil {
+		t.Fatalf("ApplyFirecrawlEgress: %v", err)
+	}
+	for name, was := range before {
+		if registry[name] == was {
+			t.Errorf("%s was not rewired onto the hosted tier", name)
+		}
+	}
+}
+
+// gulftalent sits in proxiedFingerprintProviders too, and both tiers rewire the same registry
+// entry. The override is WANTED here — the fingerprint transport is measured as refused and
+// the hosted one as served — so the order is pinned rather than left to whichever ran last.
+func TestHostedTierDeliberatelyOverridesTheFingerprintTierForGulftalent(t *testing.T) {
+	t.Setenv("SOURCES_PROXY_URL", "http://user:pass@proxy.invalid:8080")
+	t.Setenv("FIRECRAWL_API_KEY", "test-key")
+
+	registry := map[string]Source{"gulftalent": NewGulfTalent(NewClient())}
+	if err := ApplyProxyEgress(registry); err != nil {
+		t.Fatalf("ApplyProxyEgress: %v", err)
+	}
+	viaFingerprint := registry["gulftalent"]
+	if err := ApplyFirecrawlEgress(registry); err != nil {
+		t.Fatalf("ApplyFirecrawlEgress: %v", err)
+	}
+	if registry["gulftalent"] == viaFingerprint {
+		t.Error("gulftalent kept the fingerprint transport; the hosted tier must run last and win")
+	}
+}
+
+// And the fallback: with no key it keeps exactly the transport it has today, so an
+// unconfigured deployment is bit-for-bit unchanged.
+func TestGulftalentKeepsTheFingerprintTierWithoutAKey(t *testing.T) {
+	t.Setenv("SOURCES_PROXY_URL", "http://user:pass@proxy.invalid:8080")
+	t.Setenv("FIRECRAWL_API_KEY", "")
+
+	registry := map[string]Source{"gulftalent": NewGulfTalent(NewClient())}
+	if err := ApplyProxyEgress(registry); err != nil {
+		t.Fatalf("ApplyProxyEgress: %v", err)
+	}
+	viaFingerprint := registry["gulftalent"]
+	if err := ApplyFirecrawlEgress(registry); err != nil {
+		t.Fatalf("ApplyFirecrawlEgress: %v", err)
+	}
+	if registry["gulftalent"] != viaFingerprint {
+		t.Error("gulftalent lost its fingerprint transport with no hosted key configured")
+	}
+}
+
+func TestApplyFirecrawlEgressIgnoresAnUnrelatedRegistry(t *testing.T) {
+	t.Setenv("FIRECRAWL_API_KEY", "test-key")
+	registry := map[string]Source{"greenhouse": NewGreenhouse(NewClient())}
+	before := registry["greenhouse"]
+
+	if err := ApplyFirecrawlEgress(registry); err != nil {
+		t.Fatalf("ApplyFirecrawlEgress: %v", err)
+	}
+	if registry["greenhouse"] != before {
+		t.Error("an unrelated provider was rewired")
+	}
+}
+
+// A set-but-unusable budget fails the run rather than falling back to a default. This is the
+// one knob that decides how much money a night can cost, so a typo in it must not be absorbed.
+func TestApplyFirecrawlEgressRejectsAnUnparseableBudget(t *testing.T) {
+	t.Setenv("FIRECRAWL_API_KEY", "test-key")
+	t.Setenv("FIRECRAWL_MAX_PAGES_PER_RUN", "lots")
+	registry := map[string]Source{"bayt": NewBayt(NewClient())}
+	if err := ApplyFirecrawlEgress(registry); err == nil {
+		t.Error("want an error for an unparseable page budget, got nil")
+	}
+}

--- a/internal/ingest/sources/proxy.go
+++ b/internal/ingest/sources/proxy.go
@@ -180,12 +180,18 @@ func ApplyProxyEgress(registry map[string]Source) error {
 // partway through — see sources/gulftalent.yml for the measurement and why its timer is off.
 // Validate a provider here by what a whole run yields, never by one 200.
 //
-// bayt is absent, but not because it is unpassable. That was the earlier reading and it is
-// wrong: measured 2026-09-01 with this same transport, bayt's UAE listing returns 200 and
-// 251 KB of real HTML from a residential IP, so no JS challenge is involved. It is 403 from
-// the prod datacenter IP AND 403 through SOURCES_PROXY_URL, whose exit that edge classifies
-// as datacenter too — adding bayt here today would route it through an IP it already
-// refuses. It belongs here the day a genuinely residential pool exists, alongside wantedkr.
+// bayt is absent, and gulftalent's entry here is now its FALLBACK rather than its live
+// transport. Both are 403 from the prod datacenter IP AND 403 through SOURCES_PROXY_URL,
+// whose exit their edge classifies as datacenter too — no fingerprint helps, because the
+// refusal precedes any handshake we could disguise, and the browser tier does not help
+// either, because no challenge is ever offered to solve.
+//
+// What answered it was an address we do not own: see firecrawlProviders (firecrawltier.go),
+// which serves both and is applied after this, deliberately overriding gulftalent's entry
+// below. Without FIRECRAWL_API_KEY that override does not happen and gulftalent keeps the
+// fingerprint transport exactly as before — refused, but unchanged.
+//
+// wantedkr is the one still genuinely waiting for a residential pool.
 //
 // echojobs used to be named here for the same reason and no longer is: measured 2026-09-07,
 // its obstacle is a JS challenge rather than an IP classification, and the EXISTING proxy

--- a/internal/platform/arch/layering/blocks.go
+++ b/internal/platform/arch/layering/blocks.go
@@ -53,6 +53,11 @@ var blocks = map[string][]string{
 		// and ingest/sources (reads a source gated behind a JavaScript challenge), so in
 		// either one it would be an upward edge for the other.
 		"browser",
+		// firecrawl is the browseruse category, not the browser one, and the distinction is
+		// economic rather than technical: it is an HTTP client for a METERED third-party
+		// scraping API, where platform/browser launches a free process on our own host. Its
+		// caller is ingest/sources, for the two providers that refuse every address we own.
+		"firecrawl",
 		// browseruse is the HTTP half of talking to the browser-use.com cloud agent API —
 		// create/poll/fetch one run — and knows nothing about ATS forms or resolved
 		// application plans, the same "transport, not domain" category as llm and

--- a/internal/platform/firecrawl/AGENTS.md
+++ b/internal/platform/firecrawl/AGENTS.md
@@ -1,0 +1,74 @@
+# Hosted fetch
+
+An HTTP client for a third-party scraping API, for a site that refuses every address this
+repository can egress from. Transport, not a feature — the same category as
+`platform/browseruse`, which is likewise a client for somebody else's hosted browser.
+
+**Not `platform/browser`'s sibling, despite the shape.** That package launches a process on our
+own host and costs nothing per page. This one calls a metered vendor. Two things with the same
+shape and opposite economics should not be confused, which is why the budget below is part of
+the client rather than something a caller may forget.
+
+## When this is the right answer, and when it is not
+
+There are three transports, and this is the last resort:
+
+| tier | answers | cost |
+|---|---|---|
+| `proxiedProviders` | our IP is blocked, another is not | the proxy we already pay for |
+| `browserProviders` | the page needs JavaScript run | our own Chrome, free |
+| **this one** | **no address we can obtain is served at all** | **a credit per page** |
+
+Nothing belongs here that either of the others can reach. Its two providers (`bayt`,
+`gulftalent`) are `403` from the production IP *and* `403` through `SOURCES_PROXY_URL`, whose
+exit their edge classifies as datacenter too — and the browser tier does not help, because the
+refusal comes before any challenge is offered, so there is nothing to solve.
+
+## Know the yield before you widen this
+
+Measured 2026-09-07 by running the sources' own titles through `classify.IsTech`:
+
+| source | sample | passed the tech gate |
+|---|---|---|
+| `bayt`, its **IT** category | 33 | **0** |
+| `gulftalent`, real postings | 400 | **5 (1.25%)** |
+
+bayt's IT category is project managers, VPs, department directors and professors. gulftalent's
+postings are nannies, chefs, camp bosses and hotel electricians, with about one engineer in
+eighty. At ~60 000 gulftalent postings that is perhaps 750 technical ones for the entire site,
+and every page fetched costs a credit whether or not it turns out to be one of them.
+
+This was built with that measured and accepted. The number is recorded here so the next person
+inherits it rather than rediscovering it at their own expense.
+
+## Three bounds, none redundant
+
+- **No key, no client.** `ApplyFirecrawlEgress` is a no-op without `FIRECRAWL_API_KEY` and the
+  client is never constructed, so merging or deploying this spends nothing.
+- **A per-run page budget** (`FIRECRAWL_MAX_PAGES_PER_RUN`, default 500), counted **inside the
+  client** and shared across every provider in the run. An adapter cannot know what the others
+  already spent, and what is being protected is the account rather than any one crawl. The
+  count is claimed BEFORE the request, so a refused fetch never spends the page it refuses.
+  `New` rejects a non-positive budget outright — an unbounded metered client is the accident
+  this package exists to make impossible.
+- **The timer stays off.** A key alone crawls nothing until an ingest timer is enabled. Three
+  deliberate acts, not one.
+
+## The status is the target's, never the vendor's
+
+The API answers `200` while reporting the target's own status inside its envelope. Reading the
+outer one would turn every refusal into a success carrying a bot wall as though it were
+content, so `Fetch` returns `metadata.statusCode` and treats a missing one as a failed fetch
+rather than as an implied success.
+
+A non-2xx **target** status comes back as data, not an error — only some statuses may be read
+as "this resource is gone". A **vendor** failure is an error, and the difference matters: a
+caller that mistook a vendor outage for a refusal could conclude a posting is gone when only
+the API was down.
+
+## Testing
+
+Everything is exercised against an `httptest` stand-in for the vendor: no network, no key, no
+credits. Live verification is deliberately **not** automated — a test that quietly spends money
+on every CI run is a worse failure than no test. The live evidence for this tier is the
+measurement above, taken by hand and written down.

--- a/internal/platform/firecrawl/firecrawl.go
+++ b/internal/platform/firecrawl/firecrawl.go
@@ -1,0 +1,156 @@
+// Package firecrawl fetches a URL through a hosted scraping API, for a site that refuses
+// every address this repository can egress from.
+//
+// It is transport, not a feature: it knows nothing about jobs, and it is the HTTP half of
+// talking to a vendor — the same category as platform/browseruse, which is likewise a client
+// for somebody else's hosted browser.
+//
+// It is NOT platform/browser's sibling, despite the similar shape. That package launches a
+// process on our own host and costs nothing per page; this one calls a metered third party.
+// Two things with the same shape and opposite economics should not be confused, which is why
+// the budget below is part of the client rather than an afterthought a caller may forget.
+package firecrawl
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+// DefaultBaseURL is the vendor's API root.
+const DefaultBaseURL = "https://api.firecrawl.dev"
+
+// requestTimeout bounds one hosted fetch. Generous: the vendor is rendering a page behind a
+// bot wall on our behalf, which took 1.5-3.5s in every measurement, and a slow page is worth
+// waiting for once we have already paid for it.
+const requestTimeout = 90 * time.Second
+
+// ErrBudgetSpent is returned once a run has fetched as many pages as it was allowed. It is a
+// sentinel so a caller can tell "we chose to stop spending" from "the fetch failed" — the
+// first is a healthy run hitting its bound, the second is a problem.
+var ErrBudgetSpent = errors.New("firecrawl: page budget for this run is spent")
+
+// Config is what a client needs. Every field is required; there are no silent defaults for
+// the two that decide whether money is spent and how much.
+type Config struct {
+	APIKey  string
+	BaseURL string // defaults to DefaultBaseURL when empty
+	// MaxPagesPerRun bounds how many pages ONE process may fetch. Must be positive.
+	MaxPagesPerRun int64
+	HTTP           *http.Client // defaults to a client with requestTimeout
+}
+
+// Client fetches pages through the vendor, counting every one against the run's budget.
+type Client struct {
+	apiKey  string
+	baseURL string
+	http    *http.Client
+
+	budget int64
+	spent  atomic.Int64
+}
+
+// New builds a client, refusing the two configurations that could only end badly: no key (a
+// client that cannot authenticate can do nothing but fail once per page) and no positive
+// budget (an unbounded metered client is precisely the accident this package exists to make
+// impossible).
+func New(cfg Config) (*Client, error) {
+	if cfg.APIKey == "" {
+		return nil, errors.New("firecrawl: no API key")
+	}
+	if cfg.MaxPagesPerRun <= 0 {
+		return nil, fmt.Errorf("firecrawl: page budget must be positive, got %d", cfg.MaxPagesPerRun)
+	}
+	base := cfg.BaseURL
+	if base == "" {
+		base = DefaultBaseURL
+	}
+	hc := cfg.HTTP
+	if hc == nil {
+		hc = &http.Client{Timeout: requestTimeout}
+	}
+	return &Client{apiKey: cfg.APIKey, baseURL: base, http: hc, budget: cfg.MaxPagesPerRun}, nil
+}
+
+// scrapeResponse is the vendor's envelope. The distinction that matters is that IT answers
+// 200 while reporting the TARGET's own status inside: reading the outer status as the page's
+// would turn every refusal into a success carrying a bot wall as though it were content.
+type scrapeResponse struct {
+	Success bool   `json:"success"`
+	Error   string `json:"error"`
+	Data    struct {
+		RawHTML  string `json:"rawHtml"`
+		Metadata struct {
+			StatusCode int `json:"statusCode"`
+		} `json:"metadata"`
+	} `json:"data"`
+}
+
+// Fetch returns the TARGET's status and body for rawURL.
+//
+// A non-2xx target status is returned as data, not as an error, for the same reason the
+// browser tier does it: only some statuses may be read as "this resource is gone", and
+// collapsing them takes that decision away from the caller. A VENDOR failure is an error —
+// it says nothing about the target, and a caller that mistook it for a refusal could conclude
+// a posting is gone when only the API was down.
+func (c *Client) Fetch(ctx context.Context, rawURL string) (int, []byte, error) {
+	// Claimed BEFORE the request, so a refused fetch never spends the page it refuses.
+	if spent := c.spent.Add(1); spent > c.budget {
+		return 0, nil, fmt.Errorf("%w (%d pages)", ErrBudgetSpent, c.budget)
+	}
+
+	payload, err := json.Marshal(map[string]any{
+		"url":     rawURL,
+		"formats": []string{"rawHtml"},
+	})
+	if err != nil {
+		return 0, nil, fmt.Errorf("firecrawl: encode request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/scrape", bytes.NewReader(payload))
+	if err != nil {
+		return 0, nil, fmt.Errorf("firecrawl: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return 0, nil, fmt.Errorf("firecrawl: fetch %s: %w", rawURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, fmt.Errorf("firecrawl: read response for %s: %w", rawURL, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return 0, nil, fmt.Errorf("firecrawl: fetch %s: api status %d", rawURL, resp.StatusCode)
+	}
+
+	var out scrapeResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return 0, nil, fmt.Errorf("firecrawl: decode response for %s: %w", rawURL, err)
+	}
+	if !out.Success {
+		return 0, nil, fmt.Errorf("firecrawl: fetch %s: api reported failure: %s", rawURL, out.Error)
+	}
+
+	status := out.Data.Metadata.StatusCode
+	if status == 0 {
+		// The vendor succeeded but told us nothing about the target. Treating that as 200
+		// would let an empty or error page through as content, so it is a failure of the
+		// fetch rather than a status to reason about.
+		return 0, nil, fmt.Errorf("firecrawl: fetch %s: api reported no target status", rawURL)
+	}
+	return status, []byte(out.Data.RawHTML), nil
+}
+
+// Spent reports how many pages this run has claimed, for a caller that wants to log the cost
+// of a crawl. It counts claims rather than successes: a page paid for and then failed is
+// still a page paid for.
+func (c *Client) Spent() int64 { return c.spent.Load() }

--- a/internal/platform/firecrawl/firecrawl_test.go
+++ b/internal/platform/firecrawl/firecrawl_test.go
@@ -1,0 +1,157 @@
+package firecrawl
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// vendor stands in for the scrape API. Everything here is exercised against it: no key, no
+// network, no credits. A test that quietly spends money on every CI run would be a worse
+// failure than no test at all.
+type vendor struct {
+	*httptest.Server
+	calls atomic.Int64
+}
+
+// newVendor answers each request from reply, which the test supplies per case.
+func newVendor(t *testing.T, reply func(w http.ResponseWriter, r *http.Request)) *vendor {
+	t.Helper()
+	v := &vendor{}
+	v.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v.calls.Add(1)
+		reply(w, r)
+	}))
+	t.Cleanup(v.Close)
+	return v
+}
+
+// scrapeOK is the vendor's success envelope: it answers 200 and reports the TARGET's own
+// status inside.
+func scrapeOK(targetStatus int, body string) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"data": map[string]any{
+				"rawHtml":  body,
+				"metadata": map[string]any{"statusCode": targetStatus},
+			},
+		})
+	}
+}
+
+func newTestClient(t *testing.T, v *vendor, budget int64) *Client {
+	t.Helper()
+	c, err := New(Config{APIKey: "test-key", BaseURL: v.URL, MaxPagesPerRun: budget})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func TestFetchReturnsThePageBytes(t *testing.T) {
+	v := newVendor(t, scrapeOK(http.StatusOK, "<html><body>hello</body></html>"))
+	c := newTestClient(t, v, 10)
+
+	status, body, err := c.Fetch(context.Background(), "https://example.test/page")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Errorf("status = %d, want 200", status)
+	}
+	if string(body) != "<html><body>hello</body></html>" {
+		t.Errorf("body = %q", body)
+	}
+}
+
+// The vendor answers 200 even when the TARGET refused. Reporting the vendor's status would
+// turn every refusal into a success carrying a challenge page as if it were content.
+func TestFetchReportsTheTargetStatusNotTheVendors(t *testing.T) {
+	v := newVendor(t, scrapeOK(http.StatusNotFound, "not here"))
+	c := newTestClient(t, v, 10)
+
+	status, _, err := c.Fetch(context.Background(), "https://example.test/gone")
+	if err != nil {
+		t.Fatalf("Fetch returned an error for a target 404: %v", err)
+	}
+	if status != http.StatusNotFound {
+		t.Errorf("status = %d, want the target's 404", status)
+	}
+}
+
+// A vendor failure says nothing about the target and must not be mistaken for one — a caller
+// that read it as a refusal could conclude a posting is gone when only the API was down.
+func TestFetchDistinguishesAVendorFailure(t *testing.T) {
+	v := newVendor(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"success":false,"error":"internal"}`))
+	})
+	c := newTestClient(t, v, 10)
+
+	if _, _, err := c.Fetch(context.Background(), "https://example.test/x"); err == nil {
+		t.Fatal("want an error when the vendor itself fails")
+	}
+}
+
+// The budget is the whole point of this client existing rather than a bare HTTP call. Past it
+// the request is NOT made — a budget that still spends the page it refuses would be no budget.
+func TestBudgetStopsSpendingAndIssuesNoRequest(t *testing.T) {
+	v := newVendor(t, scrapeOK(http.StatusOK, "ok"))
+	c := newTestClient(t, v, 2)
+	ctx := context.Background()
+
+	for i := 0; i < 2; i++ {
+		if _, _, err := c.Fetch(ctx, "https://example.test/p"); err != nil {
+			t.Fatalf("Fetch %d within budget: %v", i, err)
+		}
+	}
+	before := v.calls.Load()
+
+	_, _, err := c.Fetch(ctx, "https://example.test/p")
+	if err == nil {
+		t.Fatal("want an error once the budget is spent")
+	}
+	if !errors.Is(err, ErrBudgetSpent) {
+		t.Errorf("error is %v, want ErrBudgetSpent so a caller can tell it from a fetch failure", err)
+	}
+	if after := v.calls.Load(); after != before {
+		t.Errorf("the refused fetch still issued %d request(s) — that spends the page it refuses", after-before)
+	}
+}
+
+// The budget counts across every provider in a run, because what is being protected is the
+// account and no single adapter can know what the others already spent.
+func TestBudgetIsSharedAcrossCallers(t *testing.T) {
+	v := newVendor(t, scrapeOK(http.StatusOK, "ok"))
+	c := newTestClient(t, v, 3)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		if _, _, err := c.Fetch(ctx, "https://example.test/a"); err != nil {
+			t.Fatalf("Fetch %d: %v", i, err)
+		}
+	}
+	if _, _, err := c.Fetch(ctx, "https://other.test/b"); !errors.Is(err, ErrBudgetSpent) {
+		t.Errorf("a different URL got a fresh budget: %v", err)
+	}
+}
+
+func TestNewRefusesWithoutAKey(t *testing.T) {
+	if _, err := New(Config{MaxPagesPerRun: 10}); err == nil {
+		t.Error("want an error with no API key: a client that cannot authenticate can only fail per request")
+	}
+}
+
+func TestNewRefusesANonPositiveBudget(t *testing.T) {
+	for _, budget := range []int64{0, -1} {
+		if _, err := New(Config{APIKey: "k", MaxPagesPerRun: budget}); err == nil {
+			t.Errorf("want an error for budget %d: an unbounded metered client is the failure this exists to prevent", budget)
+		}
+	}
+}

--- a/openspec/changes/firecrawl-tier/design.md
+++ b/openspec/changes/firecrawl-tier/design.md
@@ -1,0 +1,86 @@
+# Design
+
+## Where the client lives
+
+`internal/platform/firecrawl`, beside `browseruse`, and for the reason `browseruse`'s own entry
+in `blocks.go` gives: it is the HTTP half of talking to a vendor API and knows nothing about the
+domain. One caller today (`ingest/sources`); the category, not the caller count, is what places
+it — `browseruse` also has one.
+
+It is deliberately NOT `platform/browser`'s neighbour in behaviour. That package launches a
+process on our own host and costs nothing per page. This one calls a metered third party. Two
+things with the same shape and opposite economics should not share a name or a home, which is
+why the sources-side maps stay separate too.
+
+## The seam, again
+
+`baytHTTP` is `HTMLGetter`. `gulftalentHTTP` is `XMLGetter` + `HTMLGetter`. A hosted-fetch
+client satisfying both is a drop-in, and **neither adapter changes** — exactly as with the
+browser tier, and for the same reason: what is broken about these providers is the address the
+request leaves from, not how the response is read.
+
+Errors are `*StatusError`, the type the plain client produces, so `detailUnreadable` and
+`isRateLimited` keep working. A hosted fetch adds one failure mode the others do not have —
+the vendor answering fine while reporting that the target refused — so the target's status is
+what gets rendered, never the vendor's.
+
+## Spending is the design problem
+
+Everything above is small. The part that needs care is that this tier costs real money per
+page, against a measured 1% useful yield.
+
+Three bounds, each doing something the others cannot:
+
+**No key, no tier.** `ApplyFirecrawlEgress` is a no-op without `FIRECRAWL_API_KEY`, and the
+client is never constructed. Merging this cannot spend anything.
+
+**A per-run page budget.** `FIRECRAWL_MAX_PAGES_PER_RUN` (default 500) is counted inside the
+client, across every provider in the run. Past it, further fetches fail fast with a named error
+rather than being made. 500 is deliberately small: gulftalent alone lists 60 000 postings, and
+the difference between a bounded run and an unbounded one is the difference between a nightly
+trickle and a month's allowance gone by morning. An operator who wants a bigger pass raises it
+for that run, which is a decision with a number attached rather than an accident.
+
+The budget lives in the CLIENT, not in each adapter. An adapter cannot know what the other
+adapters in the same run have already spent, and the thing being protected is the account, not
+the crawl.
+
+**The timer stays off.** Merging this and configuring a key still crawls nothing until an
+ingest timer is enabled. Three deliberate acts, not one.
+
+## The gulftalent override
+
+`gulftalent` is in `proxiedFingerprintProviders` today. Both tiers rewire the same registry
+entry, and `cmd/ingest` applies them in sequence, so without care it would silently get
+whichever ran last — the hazard the browser tier's disjointness test exists to catch.
+
+Here the override is wanted: the fingerprint transport is measured as refused, the hosted one
+as served. So it is made explicit instead of forbidden.
+
+- `ApplyFirecrawlEgress` runs **last** in `cmd/ingest`, after the proxy and browser tiers.
+- A test pins the order's effect: with a key configured, `gulftalent` resolves to the hosted
+  client, not the fingerprint one.
+- A test pins the fallback: with no key, it resolves to the fingerprint client exactly as
+  today, so an unconfigured deployment is bit-for-bit unchanged.
+
+The browser tier's disjointness rule is narrowed rather than dropped: browser and proxy tiers
+must still not overlap (nothing wants that), while the hosted tier is allowed to override, and
+the test says which is which and why. A rule with a documented exception beats a rule quietly
+broken.
+
+## Testing
+
+- `platform/firecrawl` — the request/response mapping and the budget against an `httptest`
+  server standing in for the vendor: a page returned, a target refusal reported as the
+  TARGET's status, a vendor error distinguished from a target one, and the budget refusing the
+  (N+1)th fetch without issuing it. No network, no key, no credits.
+- `sources` — `GetXML` decodes and `GetHTML` parses what the client returned; a non-2xx target
+  status surfaces as `*StatusError` carrying that code.
+- The tier wiring — no key is a no-op; a key rewires both providers; `gulftalent` resolves to
+  hosted with a key and to fingerprint without one; an unrelated registry is untouched.
+- `bayt` and `gulftalent`'s own tests are not edited. If any of them needed editing, the seam
+  would be in the wrong place.
+
+Live verification against the real vendor is deliberately NOT automated: it costs credits per
+run, and a test that quietly spends money every time CI runs is a worse failure than no test.
+The live evidence for this change is the measurement in the proposal, taken by hand.

--- a/openspec/changes/firecrawl-tier/proposal.md
+++ b/openspec/changes/firecrawl-tier/proposal.md
@@ -1,0 +1,81 @@
+## Why
+
+Two providers are unreachable from anything this repository can egress from. `bayt` and
+`gulftalent` answer `403` to the production datacenter IP **and** to `SOURCES_PROXY_URL`,
+whose exit their edge classifies as a datacenter too. `proxy.go` has recorded that for months
+and named the remedy it was waiting for: "the day a genuinely residential pool exists".
+
+Measured 2026-09-07 against a hosted scraping API (Firecrawl), both are served normally:
+
+| source | prod IP | our proxy | hosted fetch |
+|---|---|---|---|
+| `bayt` (UAE listing) | `403` | `403` | **200, 284 KB** |
+| `gulftalent` (sitemap) | `403` | `403` | **200, 30 000 job URLs** |
+
+So the missing piece is not a better fingerprint or a better browser — the browser tier
+(freehire#2588) does not help here either, because the refusal comes before any challenge.
+The missing piece is an address we do not own.
+
+**What is behind those walls is thin, and this change is being made with that measured rather
+than assumed.** Running their own titles through this repository's own `classify.IsTech`:
+
+| source | sample | pass the tech gate |
+|---|---|---|
+| `bayt`, its **IT** category | 33 titles | **0** |
+| `gulftalent`, real postings | 400 titles | **5 (1.25%)** |
+
+bayt's IT category is project managers, VPs, department directors and professors; gulftalent's
+postings are nannies, chefs, camp bosses and hotel electricians, with about one engineer in
+eighty. At roughly 60 000 gulftalent postings that is perhaps 750 technical ones for the whole
+site, and every page fetched costs a credit.
+
+That trade was put to the owner with these numbers and the decision was to build it anyway.
+This proposal therefore optimises for the one thing that follows from those numbers: **it must
+be impossible for this tier to spend money by accident.**
+
+## What Changes
+
+- **A hosted-fetch client becomes shared transport.** A new `internal/platform/firecrawl`
+  speaks the vendor's scrape API and returns a page's raw bytes. It knows nothing about jobs —
+  the same "transport, not domain" category as `platform/browseruse`, which is likewise an HTTP
+  client for somebody else's hosted browser.
+- **`sources` gains a hosted-fetch getter** satisfying `XMLGetter` + `HTMLGetter`. Both target
+  adapters already declare exactly those (`baytHTTP` is `HTMLGetter`; `gulftalentHTTP` is both),
+  so **neither adapter changes**.
+- **`bayt` and `gulftalent` opt in per-provider**, in the shape `proxiedProviders` and
+  `browserProviders` already use.
+- **The tier is off unless `FIRECRAWL_API_KEY` is set**, and no request is ever made without it.
+- **A per-run page budget bounds one crawl** (`FIRECRAWL_MAX_PAGES_PER_RUN`). Every fetch is
+  counted; past the budget the run stops asking rather than continuing to spend. With a 1%
+  useful yield and a metered API, an unbounded crawl of a 60 000-page site is a month's
+  allowance spent in one night.
+- **`gulftalent` moves off the fingerprint tier deliberately, not accidentally.** It is in
+  `proxiedFingerprintProviders` today, and both tiers rewire the same registry entry. The
+  override is made explicit, ordered last, and pinned by a test — the alternative is the exact
+  hazard the browser tier's disjointness test exists to prevent.
+
+## Capabilities
+
+### New Capabilities
+
+- `job-source-hosted-fetch`: how a source that refuses every address this repository can egress
+  from is crawled through a third party — when the tier engages, what bounds its spending, and
+  how it interacts with the transports that would otherwise claim the same provider.
+
+### Modified Capabilities
+
+<!-- None. bayt's and gulftalent's own parsing is unchanged; only their transport is. -->
+
+## Impact
+
+- `internal/platform/firecrawl/` — new: the API client.
+- `internal/platform/arch/layering/blocks.go` — `firecrawl` joins the `platform` block.
+- `internal/ingest/sources/` — the hosted-fetch getter, the per-provider opt-in and the page
+  budget; `proxy.go`'s comment about waiting for a residential pool, which this answers.
+- `cmd/ingest` — applying the tier, after the others.
+- `internal/ingest/sources/bayt.go`, `gulftalent.go` — **unchanged**, and a test says so by
+  continuing to pass untouched.
+
+Not in scope: enabling either provider's ingest timer. Merging this changes nothing until a key
+is configured AND a timer is turned on, which are two separate deliberate acts. Also out:
+using this tier for `echojobs`, which the browser tier already serves at no per-page cost.

--- a/openspec/changes/firecrawl-tier/tasks.md
+++ b/openspec/changes/firecrawl-tier/tasks.md
@@ -1,0 +1,42 @@
+## 1. `platform/firecrawl` — the client
+
+- [ ] 1.1 Write the failing tests against an `httptest` stand-in for the vendor: a page comes
+      back with its bytes; a TARGET refusal is reported as the target's status, not the
+      vendor's 200; a VENDOR failure is a distinct error; a missing key is refused at
+      construction.
+- [ ] 1.2 Write the failing test for the budget: with a budget of N, the (N+1)th fetch fails
+      with a named error and **issues no request** (the stand-in counts).
+- [ ] 1.3 Implement `Client` + `Fetch(ctx, url) (status int, body []byte, err error)` with the
+      budget counted in the client, documenting why it lives there and not per adapter.
+- [ ] 1.4 Register `firecrawl` in the `platform` block, with the comment saying it is the
+      `browseruse` category (vendor API transport) and NOT `browser` (our own process, free).
+
+## 2. `sources` — the hosted-fetch getter
+
+- [ ] 2.1 Write the failing test: the getter satisfies `XMLGetter` + `HTMLGetter`, decodes XML,
+      parses HTML, and turns a non-2xx target status into `*StatusError` carrying that code.
+- [ ] 2.2 Implement it, reusing `browserStatusError`'s shape so the existing helpers keep
+      reading it.
+
+## 3. The tier, and the deliberate override
+
+- [ ] 3.1 Write the failing tests: no key is a no-op; a key rewires `bayt` and `gulftalent`;
+      `gulftalent` resolves to hosted WITH a key and to the fingerprint client WITHOUT one; an
+      unrelated registry is untouched; an unparseable budget fails the run.
+- [ ] 3.2 Narrow the browser tier's disjointness test to browser-vs-proxy, and add the hosted
+      tier's own rule: it MAY override, and the test states which providers it deliberately
+      takes over and why.
+- [ ] 3.3 Add `firecrawlProviders` + `ApplyFirecrawlEgress`; wire it into `cmd/ingest` LAST,
+      after the proxy and browser tiers, with the comment saying the order is load-bearing.
+- [ ] 3.4 Replace `proxy.go`'s "waiting for a genuinely residential pool" note for bayt and
+      gulftalent with what actually answered it.
+
+## 4. Ship
+
+- [ ] 4.1 `gofmt -w`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`.
+      `bayt` and `gulftalent` tests must pass **unedited**.
+- [ ] 4.2 Document the tier in `internal/ingest/sources/AGENTS.md` and the client in its own
+      AGENTS.md; add the module-file row; record the measured 1% yield so the next person
+      inherits the number and not just the switch.
+- [ ] 4.3 Open the PR on top of the browser-tier branch, stating that merging spends nothing
+      and that three separate acts are needed before it does.

--- a/openspec/changes/firecrawl-tier/tasks.md
+++ b/openspec/changes/firecrawl-tier/tasks.md
@@ -38,5 +38,5 @@
 - [x] 0 Document the tier in `internal/ingest/sources/AGENTS.md` and the client in its own
       AGENTS.md; add the module-file row; record the measured 1% yield so the next person
       inherits the number and not just the switch.
-- [ ] 4.3 Open the PR on top of the browser-tier branch, stating that merging spends nothing
+- [x] 4.3 Open the PR on top of the browser-tier branch, stating that merging spends nothing
       and that three separate acts are needed before it does.

--- a/openspec/changes/firecrawl-tier/tasks.md
+++ b/openspec/changes/firecrawl-tier/tasks.md
@@ -1,41 +1,41 @@
 ## 1. `platform/firecrawl` — the client
 
-- [ ] 1.1 Write the failing tests against an `httptest` stand-in for the vendor: a page comes
+- [x] 1.1 Write the failing tests against an `httptest` stand-in for the vendor: a page comes
       back with its bytes; a TARGET refusal is reported as the target's status, not the
       vendor's 200; a VENDOR failure is a distinct error; a missing key is refused at
       construction.
-- [ ] 1.2 Write the failing test for the budget: with a budget of N, the (N+1)th fetch fails
+- [x] 1.2 Write the failing test for the budget: with a budget of N, the (N+1)th fetch fails
       with a named error and **issues no request** (the stand-in counts).
-- [ ] 1.3 Implement `Client` + `Fetch(ctx, url) (status int, body []byte, err error)` with the
+- [x] 1.3 Implement `Client` + `Fetch(ctx, url) (status int, body []byte, err error)` with the
       budget counted in the client, documenting why it lives there and not per adapter.
-- [ ] 1.4 Register `firecrawl` in the `platform` block, with the comment saying it is the
+- [x] 1.4 Register `firecrawl` in the `platform` block, with the comment saying it is the
       `browseruse` category (vendor API transport) and NOT `browser` (our own process, free).
 
 ## 2. `sources` — the hosted-fetch getter
 
-- [ ] 2.1 Write the failing test: the getter satisfies `XMLGetter` + `HTMLGetter`, decodes XML,
+- [x] 2.1 Write the failing test: the getter satisfies `XMLGetter` + `HTMLGetter`, decodes XML,
       parses HTML, and turns a non-2xx target status into `*StatusError` carrying that code.
-- [ ] 2.2 Implement it, reusing `browserStatusError`'s shape so the existing helpers keep
+- [x] 2.2 Implement it, reusing `browserStatusError`'s shape so the existing helpers keep
       reading it.
 
 ## 3. The tier, and the deliberate override
 
-- [ ] 3.1 Write the failing tests: no key is a no-op; a key rewires `bayt` and `gulftalent`;
+- [x] 3.1 Write the failing tests: no key is a no-op; a key rewires `bayt` and `gulftalent`;
       `gulftalent` resolves to hosted WITH a key and to the fingerprint client WITHOUT one; an
       unrelated registry is untouched; an unparseable budget fails the run.
-- [ ] 3.2 Narrow the browser tier's disjointness test to browser-vs-proxy, and add the hosted
+- [x] 3.2 Narrow the browser tier's disjointness test to browser-vs-proxy, and add the hosted
       tier's own rule: it MAY override, and the test states which providers it deliberately
       takes over and why.
-- [ ] 3.3 Add `firecrawlProviders` + `ApplyFirecrawlEgress`; wire it into `cmd/ingest` LAST,
+- [x] 3.3 Add `firecrawlProviders` + `ApplyFirecrawlEgress`; wire it into `cmd/ingest` LAST,
       after the proxy and browser tiers, with the comment saying the order is load-bearing.
-- [ ] 3.4 Replace `proxy.go`'s "waiting for a genuinely residential pool" note for bayt and
+- [x] 3.4 Replace `proxy.go`'s "waiting for a genuinely residential pool" note for bayt and
       gulftalent with what actually answered it.
 
 ## 4. Ship
 
-- [ ] 4.1 `gofmt -w`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`.
+- [x] 0 `gofmt -w`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`.
       `bayt` and `gulftalent` tests must pass **unedited**.
-- [ ] 4.2 Document the tier in `internal/ingest/sources/AGENTS.md` and the client in its own
+- [x] 0 Document the tier in `internal/ingest/sources/AGENTS.md` and the client in its own
       AGENTS.md; add the module-file row; record the measured 1% yield so the next person
       inherits the number and not just the switch.
 - [ ] 4.3 Open the PR on top of the browser-tier branch, stating that merging spends nothing


### PR DESCRIPTION
Builds on #2597 (base branch: `echojobs-browser-tier`). Part of #2588.

`bayt` and `gulftalent` answer `403` to the production IP **and** `403` through `SOURCES_PROXY_URL`, whose exit their edge classifies as a datacenter too. `proxy.go` has recorded that for months and named what it was waiting for: "the day a genuinely residential pool exists". No fingerprint helps — the refusal precedes any handshake we could disguise — and the browser tier from #2597 does not help either, because no challenge is ever offered to solve.

What answered it is an address we do not own.

| source | prod IP | our proxy | hosted fetch |
|---|---|---|---|
| `bayt` (UAE listing) | `403` | `403` | **200, 284 KB** |
| `gulftalent` (sitemap) | `403` | `403` | **200, 30 000 job URLs** |

## Read this part before enabling anything

This tier is billed per page, and what is behind those walls is thin. Measured **before** building, by running these sources' own titles through this repository's own `classify.IsTech`:

| source | sample | passed the tech gate |
|---|---|---|
| `bayt`, its **IT** category | 33 titles | **0** |
| `gulftalent`, real postings | 400 titles | **5 (1.25%)** |

bayt's IT category is project managers, VPs, department directors and professors. gulftalent's postings are nannies, chefs, camp bosses and hotel electricians, roughly one engineer in eighty. At ~60 000 gulftalent postings that is perhaps **750 technical ones for the entire site**, before dedup against sources we already have — and every page costs a credit whether or not it turns out to be one of them.

That trade was put to the owner with these numbers and taken deliberately. The number is written into `internal/platform/firecrawl/AGENTS.md` so the next person inherits it rather than rediscovering it at their own expense.

## So the design optimises for one thing: it cannot spend by accident

Three bounds, none redundant:

- **No key, no tier.** `ApplyFirecrawlEgress` is a no-op without `FIRECRAWL_API_KEY` and the client is never constructed. **Merging this spends nothing.**
- **A per-run page budget** (`FIRECRAWL_MAX_PAGES_PER_RUN`, default 500), counted **inside the client** and shared across every provider in the run — an adapter cannot know what the others already spent, and what is protected is the account, not a crawl. The count is claimed *before* the request, so a refused fetch never spends the page it refuses. `New` rejects a non-positive budget outright.
- **The timer stays off.** A key alone crawls nothing until an ingest timer is enabled. Three deliberate acts, not one.

## Neither adapter changed

`baytHTTP` is `HTMLGetter`; `gulftalentHTTP` is `XMLGetter` + `HTMLGetter`. A hosted client satisfying both is a drop-in, and a test asserts it. **Their own tests pass unedited** — which is how the seam proves it is in the right place. What is wrong with these providers is the address a request leaves from, not how the response is read.

## Two traps worth naming

**The status must be the target's, never the vendor's.** The API answers `200` while reporting the target's real status inside its envelope. Reading the outer one would turn every bot wall into a success carrying a challenge page as though it were content. A *vendor* failure stays a distinct error, because a caller that mistook an outage for a refusal could conclude a posting is gone when only the API was down.

**`gulftalent` moves off the fingerprint tier deliberately.** It is in `proxiedFingerprintProviders`, and both tiers write the same registry entry — exactly the silent last-write-wins that #2597's disjointness test exists to prevent. Here the override is *wanted*, so `ApplyFirecrawlEgress` runs **last** and two tests pin both directions: with a key it wins; **without one, `gulftalent` keeps exactly the transport it has today**, so an unconfigured deployment is bit-for-bit unchanged. The browser tier's rule is narrowed and its exception stated rather than quietly broken.

## Verification

`gofmt`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...` — green. `golangci-lint`: 0 issues.

Everything is tested against an `httptest` stand-in for the vendor: **no network, no key, no credits**. Live verification is deliberately *not* automated — a test that quietly spends money on every CI run is a worse failure than no test. The live evidence is the measurement above, taken by hand.

## Not in scope

Enabling either provider's ingest timer, and using this tier for `echojobs` — the browser tier in #2597 already serves it at no per-page cost.
