### PR TITLE
Wait out the vendor's rate limit instead of breaking on it

### DIFF
--- a/internal/platform/firecrawl/firecrawl.go
+++ b/internal/platform/firecrawl/firecrawl.go
@@ -31,6 +31,23 @@ const DefaultBaseURL = "https://api.firecrawl.dev"
 // waiting for once we have already paid for it.
 const requestTimeout = 90 * time.Second
 
+// ErrRateLimited is returned when the vendor's own per-minute limit never lifted within the
+// retry window. It is a sentinel so a caller can tell "we were throttled" from "the page is
+// not there" — the first says nothing about the target and must never be read as a posting
+// having gone away.
+var ErrRateLimited = errors.New("firecrawl: vendor rate limit did not lift")
+
+// defaultRetryWait is how long to wait before re-asking after the vendor says the minute's
+// allowance is gone. Its published window is a minute, and the free tier's ten requests in one
+// are easy for a crawl to exhaust, so the wait is measured in tens of seconds rather than the
+// milliseconds an ordinary backoff would use.
+const defaultRetryWait = 20 * time.Second
+
+// maxRateLimitRetries bounds the waiting. Three waits covers a minute-long window from any
+// point inside it; past that the limit is not a burst but the plan, and a crawl should say so
+// rather than sit there.
+const maxRateLimitRetries = 3
+
 // ErrBudgetSpent is returned once a run has fetched as many pages as it was allowed. It is a
 // sentinel so a caller can tell "we chose to stop spending" from "the fetch failed" — the
 // first is a healthy run hitting its bound, the second is a problem.
@@ -43,7 +60,10 @@ type Config struct {
 	BaseURL string // defaults to DefaultBaseURL when empty
 	// MaxPagesPerRun bounds how many pages ONE process may fetch. Must be positive.
 	MaxPagesPerRun int64
-	HTTP           *http.Client // defaults to a client with requestTimeout
+	// RetryWait is how long to wait before re-asking after a vendor rate limit. Defaults to
+	// defaultRetryWait; tests set it small so they do not sleep through a real window.
+	RetryWait time.Duration
+	HTTP      *http.Client // defaults to a client with requestTimeout
 }
 
 // Client fetches pages through the vendor, counting every one against the run's budget.
@@ -52,8 +72,9 @@ type Client struct {
 	baseURL string
 	http    *http.Client
 
-	budget int64
-	spent  atomic.Int64
+	budget    int64
+	retryWait time.Duration
+	spent     atomic.Int64
 }
 
 // New builds a client, refusing the two configurations that could only end badly: no key (a
@@ -75,7 +96,11 @@ func New(cfg Config) (*Client, error) {
 	if hc == nil {
 		hc = &http.Client{Timeout: requestTimeout}
 	}
-	return &Client{apiKey: cfg.APIKey, baseURL: base, http: hc, budget: cfg.MaxPagesPerRun}, nil
+	wait := cfg.RetryWait
+	if wait <= 0 {
+		wait = defaultRetryWait
+	}
+	return &Client{apiKey: cfg.APIKey, baseURL: base, http: hc, budget: cfg.MaxPagesPerRun, retryWait: wait}, nil
 }
 
 // scrapeResponse is the vendor's envelope. The distinction that matters is that IT answers
@@ -100,11 +125,35 @@ type scrapeResponse struct {
 // it says nothing about the target, and a caller that mistook it for a refusal could conclude
 // a posting is gone when only the API was down.
 func (c *Client) Fetch(ctx context.Context, rawURL string) (int, []byte, error) {
-	// Claimed BEFORE the request, so a refused fetch never spends the page it refuses.
+	// Claimed BEFORE the request, so a refused fetch never spends the page it refuses. Claimed
+	// ONCE for the whole call, so waiting out a rate limit does not charge the page twice: a
+	// page fetched after a wait is still one page.
 	if spent := c.spent.Add(1); spent > c.budget {
 		return 0, nil, fmt.Errorf("%w (%d pages)", ErrBudgetSpent, c.budget)
 	}
 
+	for attempt := 0; ; attempt++ {
+		status, body, err := c.attempt(ctx, rawURL)
+		if !errors.Is(err, errVendorRateLimited) {
+			return status, body, err
+		}
+		if attempt >= maxRateLimitRetries {
+			return 0, nil, fmt.Errorf("%w after %d attempts for %s", ErrRateLimited, attempt+1, rawURL)
+		}
+		select {
+		case <-time.After(c.retryWait):
+		case <-ctx.Done():
+			return 0, nil, ctx.Err()
+		}
+	}
+}
+
+// errVendorRateLimited is the internal signal that one attempt was throttled. It never leaves
+// this package: Fetch either waits it out or converts it to ErrRateLimited.
+var errVendorRateLimited = errors.New("firecrawl: throttled")
+
+// attempt makes exactly one request.
+func (c *Client) attempt(ctx context.Context, rawURL string) (int, []byte, error) {
 	payload, err := json.Marshal(map[string]any{
 		"url":     rawURL,
 		"formats": []string{"rawHtml"},
@@ -127,6 +176,9 @@ func (c *Client) Fetch(ctx context.Context, rawURL string) (int, []byte, error) 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return 0, nil, fmt.Errorf("firecrawl: read response for %s: %w", rawURL, err)
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return 0, nil, errVendorRateLimited
 	}
 	if resp.StatusCode != http.StatusOK {
 		return 0, nil, fmt.Errorf("firecrawl: fetch %s: api status %d", rawURL, resp.StatusCode)

--- a/internal/platform/firecrawl/firecrawl_test.go
+++ b/internal/platform/firecrawl/firecrawl_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // vendor stands in for the scrape API. Everything here is exercised against it: no key, no
@@ -153,5 +154,78 @@ func TestNewRefusesANonPositiveBudget(t *testing.T) {
 		if _, err := New(Config{APIKey: "k", MaxPagesPerRun: budget}); err == nil {
 			t.Errorf("want an error for budget %d: an unbounded metered client is the failure this exists to prevent", budget)
 		}
+	}
+}
+
+// The vendor publishes a per-minute request limit and answers 429 past it. Treating that as a
+// fatal error is what starved the first live run against bayt: eight boards took their listing
+// pages, the minute's allowance ran out, and every detail fetch after that failed — so the
+// crawl reported a clean zero while the pages themselves were perfectly readable. A documented
+// limit is something to obey, not something to break on.
+func TestFetchRetriesTheVendorsRateLimit(t *testing.T) {
+	var calls atomic.Int64
+	v := newVendor(t, func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"success":false,"error":"Rate limit exceeded"}`))
+			return
+		}
+		scrapeOK(http.StatusOK, "after the wait")(w, r)
+	})
+	c, err := New(Config{APIKey: "k", BaseURL: v.URL, MaxPagesPerRun: 5, RetryWait: time.Millisecond})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	status, body, err := c.Fetch(context.Background(), "https://example.test/p")
+	if err != nil {
+		t.Fatalf("Fetch gave up on a rate limit instead of waiting: %v", err)
+	}
+	if status != http.StatusOK || string(body) != "after the wait" {
+		t.Errorf("status=%d body=%q, want the retried result", status, body)
+	}
+}
+
+// A retry must not be charged twice. The budget protects the account, and a page fetched once
+// after one wait is one page.
+func TestARetriedFetchSpendsOnePage(t *testing.T) {
+	var calls atomic.Int64
+	v := newVendor(t, func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"success":false,"error":"Rate limit exceeded"}`))
+			return
+		}
+		scrapeOK(http.StatusOK, "ok")(w, r)
+	})
+	c, err := New(Config{APIKey: "k", BaseURL: v.URL, MaxPagesPerRun: 1, RetryWait: time.Millisecond})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, _, err := c.Fetch(context.Background(), "https://example.test/p"); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if got := c.Spent(); got != 1 {
+		t.Errorf("Spent = %d after one retried fetch, want 1", got)
+	}
+}
+
+// A rate limit that never lifts must still end, and must say what it was rather than looking
+// like a page that is simply not there.
+func TestFetchGivesUpOnAPersistentRateLimit(t *testing.T) {
+	v := newVendor(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"success":false,"error":"Rate limit exceeded"}`))
+	})
+	c, err := New(Config{APIKey: "k", BaseURL: v.URL, MaxPagesPerRun: 5, RetryWait: time.Millisecond})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, _, err = c.Fetch(context.Background(), "https://example.test/p")
+	if err == nil {
+		t.Fatal("want an error when the rate limit never lifts")
+	}
+	if !errors.Is(err, ErrRateLimited) {
+		t.Errorf("error is %v, want ErrRateLimited so a caller can tell it from a missing page", err)
 	}
 }


### PR DESCRIPTION
Follow-up to #2600, found by the first live run.

`ingest bayt` on prod reported `ingested=0 failed=0` — the same clean zero that hid the echojobs outage for 19 days — while the pages themselves were **perfectly readable** (34 job links, exactly the adapter's pattern, verified by hand).

Eight boards took their listing pages, the free tier's **10 requests a minute** ran out, and every detail fetch after that failed. The client treated a vendor `429` as fatal, so the postings it had already found were dropped one at a time.

## What changes

A documented per-minute limit is something to obey. `Fetch` waits and re-asks, bounded: three waits covers a minute-long window from any point inside it, and past that the limit is the plan rather than a burst — so it says so through its own sentinel.

`ErrRateLimited` stays distinct from a missing page, for the reason every status distinction in this package exists: being throttled says nothing about the target and must never be read as a posting having gone away.

**The budget is claimed once for the whole call**, not per attempt. Waiting out a limit must not charge the page twice — a page fetched after a wait is still one page, and a test pins it.

## Verification

`gofmt`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...` — green. `golangci-lint`: 0 issues. All against the `httptest` stand-in: no network, no key, no credits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Firecrawl requests now automatically retry temporary vendor rate-limit responses.
  * Retries honor the configured wait time and request cancellation.
  * Requests that remain rate-limited after all retries now return a clear rate-limit error.
  * Retried requests consume only one page from the usage budget.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->