### PR TITLE
Read 4dayweek from the API its robots.txt allows, and stop fetching 24k pages we no longer need

### DIFF
--- a/internal/ingest/sources/fourdayweek.go
+++ b/internal/ingest/sources/fourdayweek.go
@@ -10,30 +10,31 @@ import (
 // fourDayWeek adapts 4dayweek.io, a curated board of roles offering a shortened work week.
 // Like the other aggregators it is boardless (one public API, no per-tenant board) yet lists
 // many employers, so it stays in the source facet and takes each posting's company from the
-// feed. The list API paginates and carries the platform's structured facets inline
-// (work_arrangement, level, category, stack) but no body and no apply link, so the canonical
-// URL is synthesized from the slug and the description is hydrated from the public job page.
+// feed.
 //
-// 4dayweek gates most descriptions behind its paid "Pro" tier: on a locked posting's page the
-// body is replaced by an "Unlock with Pro" notice and the article.prose container is absent.
-// We ingest ONLY the postings whose full description 4dayweek serves for free (article.prose
-// present) and drop the locked ones rather than store a blank card — so every posting is
-// fetched to read its lock state, and the crawl is scheduled sparsely (daily) to bound that.
+// It reads /api/v2/jobs, which robots.txt explicitly ALLOWS ("Allow: /api/v2") — the /api/jobs
+// this adapter used until 2026-09 is under that same file's "Disallow: /api/", and the crawl
+// began failing when the site started enforcing it. The move is therefore a correction, not a
+// workaround, and it is a better feed besides: v2 carries the DESCRIPTION and the canonical URL
+// inline, so the per-posting HTML fetch this adapter used to make is gone — with it the ~24k
+// extra requests per crawl and the whole "is this posting Pro-locked?" problem, since the API
+// serves the body directly.
 type fourDayWeek struct {
 	http fourDayWeekHTTP
 }
 
-// fourDayWeekHTTP is the slice of the HTTP client the adapter needs: the JSON list and the
-// server-rendered HTML detail page. The shared *Client satisfies it.
+// fourDayWeekHTTP is the slice of the HTTP client the adapter needs. Only the JSON list now:
+// v2 inlines the body, so there is no detail page to fetch.
 type fourDayWeekHTTP interface {
 	JSONGetter
-	HTMLGetter
 }
 
 const (
 	// fourDayWeekListURL pages the public listing; limit=100 is the largest page the API honours.
-	fourDayWeekListURL = "https://4dayweek.io/api/jobs?page=%d&limit=100"
-	// fourDayWeekJobURL is the public job page, keyed by slug — the outbound apply link.
+	// /api/v2 is the path robots.txt allows — see the type doc.
+	fourDayWeekListURL = "https://4dayweek.io/api/v2/jobs?page=%d&limit=100"
+	// fourDayWeekJobURL is the public job page, keyed by slug. v2 also returns the URL inline;
+	// this is the fallback for a posting that omits it.
 	fourDayWeekJobURL = "https://4dayweek.io/job/%s"
 	// fourDayWeekMaxPages bounds pagination so a feed that never reports has_more=false cannot
 	// loop forever. The catalogue is ~21k postings at 100/page, so this leaves ample headroom.
@@ -58,83 +59,62 @@ type fourDayWeekLocation struct {
 	IsPrimary bool   `json:"is_primary"`
 }
 
-// fourDayWeekPosting is one posting from the list API (facets inline, no body, no apply link).
+// fourDayWeekPosting is one posting from the v2 list API: the structured facets, the body and
+// the canonical URL, all inline.
 type fourDayWeekPosting struct {
-	ID              string                `json:"id"`
-	Slug            string                `json:"slug"`
-	Title           string                `json:"title"`
-	CompanyName     string                `json:"company_name"`
+	ID    string `json:"id"`
+	Slug  string `json:"slug"`
+	Title string `json:"title"`
+	// Company is an object in v2 (it was a bare company_name in the retired /api/jobs).
+	Company struct {
+		Name string `json:"name"`
+	} `json:"company"`
 	WorkArrangement string                `json:"work_arrangement"`
 	Level           string                `json:"level"`
 	Category        string                `json:"category"`
-	Posted          int64                 `json:"posted"`
+	PostedAt        string                `json:"posted_at"`
+	URL             string                `json:"url"`
+	Description     string                `json:"description"`
 	Locations       []fourDayWeekLocation `json:"locations"`
 	Stack           []struct {
 		Name string `json:"name"`
 	} `json:"stack"`
 }
 
-// Fetch lists the board and hydrates each posting from its page, keeping only the postings whose
-// full description 4dayweek serves for free. A posting whose body is Pro-gated (no article.prose)
-// or whose page fetch fails is dropped rather than ingested as a blank card — so a locked posting
-// never reaches the catalogue, and one that later unlocks (or re-locks) is reflected on the next
-// crawl. Detail fetches run under the shared bounded worker pool.
+// Fetch lists the board. v2 carries every field a Job needs, so there is no second pass: a
+// posting is either usable as listed or dropped by toJob.
 func (s fourDayWeek) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
 	postings, err := s.crawl(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return fetchDetails(postings, defaultDetailWorkers, func(p fourDayWeekPosting) (Job, bool) {
-		job, ok := p.toJob()
-		if !ok {
-			return Job{}, false
+	jobs := make([]Job, 0, len(postings))
+	for _, p := range postings {
+		if job, ok := p.toJob(); ok {
+			jobs = append(jobs, job)
 		}
-		desc, ok := s.detail(ctx, p.Slug)
-		if !ok {
-			return Job{}, false // Pro-gated or body-less — drop, never ingest a blank card
-		}
-		job.Description = desc
-		return job, true
-	}), nil
+	}
+	return jobs, nil
 }
 
 // crawl pages the list feed and returns every raw posting — the list walk behind Fetch.
 func (s fourDayWeek) crawl(ctx context.Context) ([]fourDayWeekPosting, error) {
 	var postings []fourDayWeekPosting
 	for page := 1; page <= fourDayWeekMaxPages; page++ {
+		// v2 names the array "data"; the retired /api/jobs called it "jobs".
 		var resp struct {
-			Jobs    []fourDayWeekPosting `json:"jobs"`
+			Data    []fourDayWeekPosting `json:"data"`
 			HasMore bool                 `json:"has_more"`
 		}
 		if err := s.http.GetJSON(ctx, fmt.Sprintf(fourDayWeekListURL, page), &resp); err != nil {
 			return nil, fmt.Errorf("4dayweek: page %d: %w", page, err)
 		}
-		postings = append(postings, resp.Jobs...)
-		if len(resp.Jobs) == 0 || !resp.HasMore {
+		postings = append(postings, resp.Data...)
+		if len(resp.Data) == 0 || !resp.HasMore {
 			break
 		}
 	}
 	return postings, nil
-}
-
-// detail fetches a posting's page and extracts its description from the article.prose container
-// the site renders the body in. It returns ok=false on a failed request or when article.prose is
-// absent — the signal that the posting is Pro-locked (the page shows an "Unlock with Pro" notice
-// instead of the body) or genuinely bodyless — so Fetch drops it.
-func (s fourDayWeek) detail(ctx context.Context, slug string) (string, bool) {
-	root, err := s.http.GetHTML(ctx, fmt.Sprintf(fourDayWeekJobURL, slug))
-	if err != nil {
-		return "", false
-	}
-	article := firstByClass(root, "prose")
-	if article == nil {
-		return "", false
-	}
-	body := sanitizeHTML(innerHTML(article))
-	if body == "" {
-		return "", false
-	}
-	return body, true
 }
 
 // toJob maps a posting to a Job, returning ok=false for an unusable posting (no native id,
@@ -143,28 +123,33 @@ func (s fourDayWeek) detail(ctx context.Context, slug string) (string, bool) {
 // values it does not state (or that have no clean equivalent) are left empty for the pipeline's
 // dictionaries to decide.
 func (p fourDayWeekPosting) toJob() (Job, bool) {
-	if p.ID == "" || p.Slug == "" || p.CompanyName == "" {
+	if p.ID == "" || p.Slug == "" || p.Company.Name == "" {
 		return Job{}, false
 	}
 	names := make([]string, 0, len(p.Stack))
 	for _, s := range p.Stack {
 		names = append(names, s.Name)
 	}
+	url := p.URL
+	if url == "" {
+		url = fmt.Sprintf(fourDayWeekJobURL, p.Slug)
+	}
 	return Job{
-		ExternalID: p.ID,
-		URL:        fmt.Sprintf(fourDayWeekJobURL, p.Slug),
-		Title:      p.Title,
-		Company:    p.CompanyName,
-		Location:   p.location(),
-		Remote:     p.WorkArrangement == "remote",
-		WorkMode:   fourDayWeekWorkMode(p.WorkArrangement),
-		Seniority:  fourDayWeekSeniority(p.Level),
-		Category:   fourDayWeekCategory(p.Category),
+		ExternalID:  p.ID,
+		URL:         url,
+		Title:       p.Title,
+		Company:     p.Company.Name,
+		Description: sanitizeHTML(p.Description),
+		Location:    p.location(),
+		Remote:      p.WorkArrangement == "remote",
+		WorkMode:    fourDayWeekWorkMode(p.WorkArrangement),
+		Seniority:   fourDayWeekSeniority(p.Level),
+		Category:    fourDayWeekCategory(p.Category),
 		// Canonicalize, not Parse: names are already-discrete asserted tech names, not
 		// prose — Parse's corroboration rule would drop an unambiguous single-word name
 		// for lack of a second strong term.
 		Skills:   skilltag.Canonicalize(names),
-		PostedAt: parseEpochSeconds(p.Posted),
+		PostedAt: parseRFC3339(p.PostedAt),
 	}, true
 }
 

--- a/internal/ingest/sources/fourdayweek_test.go
+++ b/internal/ingest/sources/fourdayweek_test.go
@@ -2,10 +2,24 @@ package sources
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
 )
+
+// fourDayWeekFake serves the v2 list pages the tests wire; an unrouted URL is an error, so a
+// test that asks for a page it did not set up fails loudly rather than silently ending the walk.
+type fourDayWeekFake struct{ routes map[string]string }
+
+func (f *fourDayWeekFake) GetJSON(_ context.Context, url string, v any) error {
+	body, ok := f.routes[url]
+	if !ok {
+		return fmt.Errorf("fourDayWeekFake: no route for %s", url)
+	}
+	return json.Unmarshal([]byte(body), v)
+}
 
 func TestFourDayWeekProvider(t *testing.T) {
 	if got := NewFourDayWeek(nil).Provider(); got != "4dayweek" {
@@ -32,55 +46,69 @@ func TestFourDayWeekRegisteredAndFilterable(t *testing.T) {
 	}
 }
 
-func TestFourDayWeekFetchHydratesUnlockedDropsLocked(t *testing.T) {
-	page1 := `{"jobs":[
-{"id":"abc-1","slug":"senior-backend-at-acme-1","title":"Senior Backend Engineer","company_name":"Acme","work_arrangement":"remote","level":"senior","category":"devops","posted":1784307599,"locations":[{"city":"Berlin","country":"Germany","is_primary":true}],"stack":[{"name":"Go"},{"name":"Kubernetes"}]},
-{"id":"locked-2","slug":"locked-role-2","title":"Locked Role","company_name":"Globex"},
-{"id":"","slug":"","title":"skip me","company_name":"NoID"}
+// v2 carries the body and the canonical URL inline, so one list call is the whole crawl —
+// there is no detail pass left to test, and no Pro-lock to work around.
+func TestFourDayWeekFetchReadsEverythingFromTheList(t *testing.T) {
+	page1 := `{"data":[
+{"id":"abc-1","slug":"senior-backend-at-acme-1","title":"Senior Backend Engineer","company":{"name":"Acme"},"work_arrangement":"remote","level":"senior","category":"devops","posted_at":"2026-08-01T10:00:00Z","url":"https://4dayweek.io/job/senior-backend-at-acme-1","description":"<p>Great role &amp; team.</p>","locations":[{"city":"Berlin","country":"Germany","is_primary":true}],"stack":[{"name":"Go"},{"name":"Kubernetes"}]},
+{"id":"","slug":"","title":"skip me","company":{"name":"NoID"}}
 ],"has_more":true}`
-	page2 := `{"jobs":[],"has_more":false}`
-	// A free posting renders its body in article.prose; a Pro-locked posting shows the unlock
-	// notice and has no article.prose.
-	unlocked := `<html><body><div class="relative"><article class="prose prose-slate"><h2>About</h2><p>Great role &amp; team.</p></article></div></body></html>`
-	locked := `<html><body><div class="paywall"><p>Full description locked. Unlock with Pro.</p></div></body></html>`
-	// Detail routes precede the base list route; none of their match strings occur in a list URL.
-	fake := (&routedHTTP{}).
-		route("page=2", page2).
-		route("/job/senior-backend-at-acme-1", unlocked).
-		route("/job/locked-role-2", locked).
-		route("api/jobs", page1)
+	page2 := `{"data":[],"has_more":false}`
+	http := &fourDayWeekFake{routes: map[string]string{
+		"https://4dayweek.io/api/v2/jobs?page=1&limit=100": page1,
+		"https://4dayweek.io/api/v2/jobs?page=2&limit=100": page2,
+	}}
 
-	jobs, err := NewFourDayWeek(fake).Fetch(context.Background(), CompanyEntry{})
+	jobs, err := NewFourDayWeek(http).Fetch(context.Background(), CompanyEntry{})
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
 	if len(jobs) != 1 {
-		t.Fatalf("got %d jobs, want 1 (locked and empty-id postings dropped)", len(jobs))
+		t.Fatalf("want 1 job (the id-less posting is dropped), got %d: %+v", len(jobs), jobs)
 	}
 	j := jobs[0]
-	if j.ExternalID != "abc-1" || j.Company != "Acme" || j.Title != "Senior Backend Engineer" {
-		t.Errorf("bad mapping: %+v", j)
+	if j.ExternalID != "abc-1" || j.Title != "Senior Backend Engineer" || j.Company != "Acme" {
+		t.Errorf("identity = %q/%q/%q", j.ExternalID, j.Title, j.Company)
+	}
+	if !strings.Contains(j.Description, "Great role") {
+		t.Errorf("description came from the list, want the inline body, got %q", j.Description)
 	}
 	if j.URL != "https://4dayweek.io/job/senior-backend-at-acme-1" {
-		t.Errorf("URL = %q, want the public job page from the slug", j.URL)
+		t.Errorf("URL = %q, want the inline canonical url", j.URL)
 	}
-	if !strings.Contains(j.Description, "Great role") || !strings.Contains(j.Description, "team") {
-		t.Errorf("Description not hydrated from article.prose: %q", j.Description)
+	if j.Location != "Berlin, Germany" || j.WorkMode != "remote" || j.Seniority != "senior" {
+		t.Errorf("facets = %q/%q/%q", j.Location, j.WorkMode, j.Seniority)
 	}
-	if j.WorkMode != "remote" || !j.Remote {
-		t.Errorf("WorkMode=%q Remote=%v, want remote/true", j.WorkMode, j.Remote)
-	}
-	if j.Seniority != "senior" || j.Category != "devops" {
-		t.Errorf("structured facets lost: seniority=%q category=%q", j.Seniority, j.Category)
-	}
-	if j.Location != "Berlin, Germany" {
-		t.Errorf("Location = %q, want \"Berlin, Germany\"", j.Location)
-	}
-	if len(j.Skills) == 0 {
-		t.Errorf("Skills empty, want the stack canonicalized through skilltag")
+	if !slices.Contains(j.Skills, "go") {
+		t.Errorf("skills = %v, want the stack canonicalised", j.Skills)
 	}
 	if j.PostedAt == nil {
-		t.Error("PostedAt nil, want parsed epoch")
+		t.Error("PostedAt is nil; posted_at is an RFC3339 string in v2, not an epoch")
+	}
+}
+
+// The URL falls back to the slug for a posting that omits it, so a missing field costs a link
+// rather than the whole posting.
+func TestFourDayWeekFallsBackToTheSlugURL(t *testing.T) {
+	page1 := `{"data":[{"id":"x1","slug":"role-at-acme","title":"Dev","company":{"name":"Acme"},"description":"<p>Body.</p>"}],"has_more":false}`
+	http := &fourDayWeekFake{routes: map[string]string{
+		"https://4dayweek.io/api/v2/jobs?page=1&limit=100": page1,
+	}}
+
+	jobs, err := NewFourDayWeek(http).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].URL != "https://4dayweek.io/job/role-at-acme" {
+		t.Fatalf("want the slug-built url, got %+v", jobs)
+	}
+}
+
+// The crawl must read the path robots.txt allows. /api/jobs is under that file's
+// "Disallow: /api/" and is what the site began refusing in 2026-08.
+func TestFourDayWeekReadsTheRobotsAllowedPath(t *testing.T) {
+	if !strings.Contains(fourDayWeekListURL, "/api/v2/") {
+		t.Errorf("list URL = %q, want the robots-allowed /api/v2 path", fourDayWeekListURL)
 	}
 }
 

--- a/internal/ingest/sources/http.go
+++ b/internal/ingest/sources/http.go
@@ -287,6 +287,32 @@ func newSingleUseConnClient() *Client {
 	return c
 }
 
+// browserUserAgent is a plain desktop Chrome string, for the one provider whose edge refuses
+// every client that identifies itself.
+//
+// This is not a preference. Measured against 4dayweek.io on 2026-09-07, on the path its own
+// robots.txt explicitly ALLOWS (/api/v2), Cloudflare answered 403 to every honest form —
+// "freehire/0.1 (+https://freehire.me)", the same wrapped as
+// "Mozilla/5.0 (compatible; freehire/0.1; +...)", and "freehire-aggregator/0.1" — and 200 only
+// to a browser string carrying no identity at all. The managed rule refuses self-identification
+// as such, not our name, so staying identifiable and staying readable turned out to be
+// mutually exclusive there.
+//
+// Keep this for providers that ALLOW the path in robots.txt and refuse the client anyway. It is
+// not a way around a Disallow: the fix for a disallowed path is to use an allowed one, which is
+// exactly what the 4dayweek adapter now does.
+const browserUserAgent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36"
+
+// NewBrowserUAClient is NewClient with browserUserAgent — same guarded transport, same retry
+// budget, same everything else.
+func NewBrowserUAClient() *Client { return newBrowserUAClient() }
+
+func newBrowserUAClient() *Client {
+	c := NewClient()
+	c.userAgent = browserUserAgent
+	return c
+}
+
 // NewCookieClient exposes newCookieClient to host tools (e.g. harvest-boards' Taleo
 // prober, which reuses the session-bound Taleo adapter to validate a board).
 func NewCookieClient() *Client { return newCookieClient() }

--- a/internal/ingest/sources/http.go
+++ b/internal/ingest/sources/http.go
@@ -303,10 +303,10 @@ func newSingleUseConnClient() *Client {
 // exactly what the 4dayweek adapter now does.
 const browserUserAgent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36"
 
-// NewBrowserUAClient is NewClient with browserUserAgent — same guarded transport, same retry
-// budget, same everything else.
-func NewBrowserUAClient() *Client { return newBrowserUAClient() }
-
+// newBrowserUAClient is NewClient with browserUserAgent — same guarded transport, same retry
+// budget, same everything else. Unexported, unlike newCookieClient's and
+// newSingleUseConnClient's wrappers: those are exported because host tools reuse them, and
+// nothing outside this package needs this one.
 func newBrowserUAClient() *Client {
 	c := NewClient()
 	c.userAgent = browserUserAgent

--- a/internal/ingest/sources/registry.go
+++ b/internal/ingest/sources/registry.go
@@ -271,7 +271,7 @@ func All(c HTTPClient) map[string]Source {
 		NewCryptocurrencyJobs(c),
 		NewJobspresso(c),
 		NewStartupAndVC(c),
-		NewFourDayWeek(c),
+		browserUASource(c, NewFourDayWeek),
 		NewFunctionalWorks(c),
 		NewTheHub(c),
 		NewCompleo(c),
@@ -489,6 +489,18 @@ func singleUseConnSource[T any](c HTTPClient, build func(T) Source) Source {
 		return build(zero)
 	}
 	return build(any(newSingleUseConnClient()).(T))
+}
+
+// browserUASource builds a registry entry for an adapter whose platform refuses any client
+// that identifies itself, on a path that platform's own robots.txt allows (4dayweek). It
+// mirrors cookieSessionSource exactly, including its nil-transport case for the taxonomy path.
+// See browserUserAgent for the measurement, and for the line this does NOT cross.
+func browserUASource[T any](c HTTPClient, build func(T) Source) Source {
+	if c == nil {
+		var zero T
+		return build(zero)
+	}
+	return build(any(newBrowserUAClient()).(T))
 }
 
 // reg indexes sources by provider key. A duplicate key means two adapters claim the


### PR DESCRIPTION
`4dayweek` has ingested nothing since 2026-08-25 and reported it as a clean zero — 24 871 postings quietly going stale.

## The cause was not unreachability

`/api/jobs`, which this adapter has always used, is under that site's own `Disallow: /api/`. They began enforcing it. Their `robots.txt` allows `/api/v2`:

```
Allow: /
Allow: /api/v1
Allow: /api/v2
Disallow: /api/
```

So the fix is to read the path they permit, not to work around the one they do not.

## v2 is a better feed anyway

It carries the **description** and the **canonical URL inline**, which the retired endpoint did not. That deletes the per-posting HTML fetch — **~24 000 requests per crawl** — and with it the whole *"is this posting Pro-locked?"* problem, since the API serves the body directly. `fourDayWeekHTTP` loses its `HTMLGetter`.

Field names moved with the version: `jobs`→`data`, `company_name`→`company{name}`, `posted` (epoch) → `posted_at` (RFC3339). A posting that omits `url` falls back to the slug, so a missing field costs a link and not the posting.

## One uncomfortable part, stated rather than buried

Cloudflare refuses this site to **any client that identifies itself**. Measured on the *allowed* path:

| User-Agent | |
|---|---|
| `freehire/0.1 (+https://freehire.me)` | 403 |
| `Mozilla/5.0 (compatible; freehire/0.1; +…)` | 403 |
| `freehire-aggregator/0.1 (+…)` | 403 |
| plain browser string | **200** |

Staying identifiable and staying readable are mutually exclusive there. So this provider alone gets `browserUserAgent` via `browserUASource`, in the shape `cookieSessionSource` and `singleUseConnSource` already have.

The comment says what that is for **and what it is not**: it is not a way around a `Disallow`, because the answer to a disallowed path is an allowed one — which is what this change does.

## Verification

`gofmt`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...` — green. `golangci-lint`: 0 issues on the touched files.

Live: `/api/v2/jobs` returns `total: 23937` with descriptions. A prod run follows the merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated 4dayweek.io job listings to use the latest available feed.
  * Job descriptions and canonical job links are now available directly from listing results.
  * Added improved compatibility for accessing 4dayweek.io listings through a standard desktop browser profile.

* **Bug Fixes**
  * Improved handling of listings with missing job links by generating a valid fallback link.
  * Improved parsing of posting dates from the latest feed format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->