### PR TITLE
Stop a browser that blocks site data from losing the whole app to the theme store

### DIFF
--- a/web/src/lib/theme.svelte.ts
+++ b/web/src/lib/theme.svelte.ts
@@ -2,22 +2,22 @@
 // localStorage under `hire.theme`. Defaults to `light` regardless of the OS
 // preference; `dark` only applies once the user explicitly toggles it. The
 // root layout calls `initTheme()` on mount; components read `themeStore` and
-// call `setMode(...)`. SSR-safe: every browser API is guarded by `browser`, so
-// importing this module on the server (via the header menu) never touches
-// window/localStorage. A no-FOUC inline script in app.html applies the class
-// before paint (see task 4.2).
+// call `setMode(...)`. SSR-safe: every browser API is guarded, so importing this
+// module on the server (via the header menu) never touches window/localStorage.
+// A no-FOUC inline script in app.html applies the class before paint (see task 4.2).
+//
+// The storage IO lives in $lib/themeStorage rather than here, and the split is not
+// cosmetic: `themeStore` is constructed at module scope, so anything that throws on
+// the way to it takes the whole module down — and the root layout imports this module.
+// That is what an unguarded read of `localStorage` did to visitors browsing with site
+// data blocked. The runes in this file put it beyond the plain-Node vitest env, so the
+// part that can throw now sits in a file that env can reach, with a test for it.
 
 import { browser } from '$app/environment';
 
-const STORAGE_KEY = 'hire.theme';
+import { readStoredTheme, writeStoredTheme, type ThemeMode } from '$lib/themeStorage';
 
-export type ThemeMode = 'light' | 'dark';
-
-function readStored(): ThemeMode {
-  if (!browser) return 'light';
-  const raw = localStorage.getItem(STORAGE_KEY);
-  return raw === 'dark' ? 'dark' : 'light';
-}
+export type { ThemeMode };
 
 function apply(mode: ThemeMode) {
   if (!browser) return;
@@ -25,19 +25,13 @@ function apply(mode: ThemeMode) {
 }
 
 class ThemeStore {
-  mode = $state<ThemeMode>(readStored());
+  mode = $state<ThemeMode>(readStoredTheme());
 
   isDark = $derived(this.mode === 'dark');
 
   setMode(next: ThemeMode) {
     this.mode = next;
-    if (browser) {
-      try {
-        localStorage.setItem(STORAGE_KEY, next);
-      } catch {
-        // best-effort: private mode / quota
-      }
-    }
+    writeStoredTheme(next);
     apply(next);
   }
 
@@ -49,10 +43,10 @@ class ThemeStore {
 export const themeStore = new ThemeStore();
 
 /** Re-apply the stored theme. Browser-only (called from the layout's onMount) —
- *  the singleton may have been first constructed on the server, where it
- *  defaults to `light` without reading storage. */
+ *  the singleton may have been first constructed on the server, where storage is
+ *  unreachable and the mode falls back to `light`. */
 export function initTheme() {
   if (!browser) return;
-  themeStore.mode = readStored();
+  themeStore.mode = readStoredTheme();
   apply(themeStore.mode);
 }

--- a/web/src/lib/themeStorage.test.ts
+++ b/web/src/lib/themeStorage.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { THEME_KEY, readStoredTheme, writeStoredTheme } from './themeStorage';
+
+// The node env has no localStorage at all, so each test installs the one it needs and
+// removes it afterwards (same shape as cliPromo.test.ts / filterStorage.test.ts).
+function installStorage(store: Map<string, string>) {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+    },
+  });
+}
+
+/** A document denied storage — a sandboxed iframe, or a browser set to block site
+ *  data. The throw comes from READING the `localStorage` property, which is what makes
+ *  a `typeof` guard in front of the try useless. */
+function installHostileStorage() {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    get() {
+      throw new Error('Access is denied for this document.');
+    },
+  });
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, 'localStorage');
+});
+
+describe('readStoredTheme', () => {
+  it('defaults to light with nothing stored', () => {
+    installStorage(new Map());
+    expect(readStoredTheme()).toBe('light');
+  });
+
+  it('reads a stored dark mode', () => {
+    installStorage(new Map([[THEME_KEY, 'dark']]));
+    expect(readStoredTheme()).toBe('dark');
+  });
+
+  it('treats an unrecognized value as light', () => {
+    installStorage(new Map([[THEME_KEY, 'system']]));
+    expect(readStoredTheme()).toBe('light');
+  });
+
+  // The regression this module exists for. Unguarded, the throw escaped a module-scope
+  // constructor and took the whole theme module — and with it the root layout that
+  // imports it — down for anyone browsing with site data blocked.
+  it('falls back to light when the document is denied storage', () => {
+    installHostileStorage();
+    expect(() => readStoredTheme()).not.toThrow();
+    expect(readStoredTheme()).toBe('light');
+  });
+
+  it('falls back to light when there is no storage at all (SSR)', () => {
+    expect(readStoredTheme()).toBe('light');
+  });
+});
+
+describe('writeStoredTheme', () => {
+  it('round-trips through storage', () => {
+    installStorage(new Map());
+    writeStoredTheme('dark');
+    expect(readStoredTheme()).toBe('dark');
+  });
+
+  it('does not throw when the document is denied storage', () => {
+    installHostileStorage();
+    expect(() => writeStoredTheme('dark')).not.toThrow();
+  });
+
+  it('does not throw when there is no storage at all (SSR)', () => {
+    expect(() => writeStoredTheme('dark')).not.toThrow();
+  });
+});

--- a/web/src/lib/themeStorage.ts
+++ b/web/src/lib/themeStorage.ts
@@ -1,0 +1,40 @@
+// The theme's browser-storage IO, split out of theme.svelte.ts so it can be tested.
+//
+// Self-contained on purpose, for the reason filterStorage.ts records for itself: it
+// feature-detects storage rather than importing `browser` from `$app/environment`, so
+// the unit test runs in the plain-Node vitest env. The store beside it cannot be
+// exercised there at all — its `$state` field needs a Svelte runtime the env does not
+// provide (see paginated.svelte.test.ts) — and a read that no test can reach is how the
+// unguarded one below shipped.
+//
+// Every access is wrapped, and `typeof` sits INSIDE the wrapper rather than in front of
+// it: `localStorage` is an accessor that throws `SecurityError` when the document is
+// denied storage (a sandboxed iframe, a browser set to block site data), and the throw
+// comes from reading the property, so a `typeof` guard placed outside the try throws on
+// the guard itself.
+
+export const THEME_KEY = 'hire.theme';
+
+export type ThemeMode = 'light' | 'dark';
+
+/** The stored mode, or `light` when none is recorded or storage is unreachable.
+ *  Never throws. */
+export function readStoredTheme(): ThemeMode {
+  try {
+    if (typeof localStorage === 'undefined') return 'light';
+    return localStorage.getItem(THEME_KEY) === 'dark' ? 'dark' : 'light';
+  } catch {
+    return 'light';
+  }
+}
+
+/** Persist the mode. A no-op when storage is unreachable — the choice then lasts for
+ *  this page only. Never throws. */
+export function writeStoredTheme(mode: ThemeMode): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(THEME_KEY, mode);
+  } catch {
+    // best-effort: private mode / quota / denied storage
+  }
+}


### PR DESCRIPTION
Found while going through Sentry: `FREEHIRE-WEB-1T`.

`SecurityError: Failed to read the 'localStorage' property from 'Window': Access is denied for this document.`

## What breaks

`theme.svelte.ts` read `localStorage` without a guard:

```ts
function readStored(): ThemeMode {
  if (!browser) return 'light';
  const raw = localStorage.getItem(STORAGE_KEY);   // <- unguarded
  return raw === 'dark' ? 'dark' : 'light';
}
```

In a document denied storage — a sandboxed iframe, or a browser set to block site data — reading the **property** throws, before `getItem` is called. `browser` does not help: it is true, the storage is simply forbidden.

Three things then compound:

1. The read runs inside `mode = $state<ThemeMode>(readStored())`.
2. That runs in the module-scope `export const themeStore = new ThemeStore()`.
3. `+layout.svelte` imports this module.

So the throw does not cost the visitor their theme. It costs them the module, and with it the root layout — no app at all.

## Everything around it already knew

All three of `app.html`'s no-FOUC reads are wrapped in `try {} catch {}`. `setMode` in the same file wrapped its write, with a comment naming private mode. `cliPromo.ts`, `consent.ts`, `supportToast.ts` and `filterStorage.ts` each wrap every access, and two of them name "a blocked origin" outright. One read was bare.

## Why it shipped

`theme.svelte.ts` has runes, so it cannot be imported in the plain-Node vitest env — the limitation `paginated.svelte.test.ts` records for itself. No test could reach the read.

So the storage IO moves to `$lib/themeStorage`, which imports no `$app/*` and therefore can be tested — the same split `consent.ts`/`consent.svelte.ts` and `cliPromo.ts` already use. `cliPromo.test.ts` even has the fixture for it: an `installHostileStorage()` whose *getter* throws.

Confirmed red before green — against the original unguarded code, the new test fails with the Sentry error verbatim.

## One detail worth keeping

`typeof` sits **inside** the try, not in front of it:

```ts
try {
  if (typeof localStorage === 'undefined') return 'light';
  return localStorage.getItem(THEME_KEY) === 'dark' ? 'dark' : 'light';
} catch {
  return 'light';
}
```

`typeof` only swallows `ReferenceError` for undeclared identifiers. `localStorage` is a declared accessor, so the getter runs and its `SecurityError` propagates — a guard placed outside the try throws on the guard itself. `filterStorage.ts` and `saveSearchAlert.ts` still have theirs outside; not touched here, since nothing in Sentry points at them and they throw at a call site rather than at module scope.

## Checks

- `pnpm vitest run` — 149 files, 1682 tests, green (8 new)
- `pnpm check` — 0 errors
- `pnpm lint` — nothing new
