### PR TITLE
Resolve Ashby's system-field Name/Email and label-match LinkedIn in auto-apply

### DIFF
--- a/internal/api/atsapply/resolve.go
+++ b/internal/api/atsapply/resolve.go
@@ -32,7 +32,12 @@ func (p Plan) FullyResolved() bool {
 // answers map (internal/candidateprofile.Profile.Fields()). Greenhouse happens to name its
 // own standard identity fields (first_name, last_name, email, phone) the same as the answer
 // keys already, so most of this map is the identity case; candidate-location is the one
-// alias the 2026-09-02 spike measured.
+// alias the 2026-09-02 spike measured. Ashby names its standard name/email controls
+// "_systemfield_name" / "_systemfield_email" (internal/ingest/applyform/ashby.go's own
+// vocabulary) rather than Greenhouse's ids — measured live 2026-09-07: a Singular posting on
+// Ashby parked with "no known answer source" for both, even though the candidate's name and
+// email were already known. "_systemfield_resume" needs no entry here — isResumeField below
+// matches it by label ("Resume") already.
 //
 // NOT covered here, deliberately: "country" has no answer key at all — the candidate
 // profile carries one combined `location` string, not a separate country. On Greenhouse,
@@ -57,6 +62,8 @@ var answerKeyFor = map[string]string{
 	"notice_period":           "notice_period",
 	"willing_to_relocate":     "willing_to_relocate",
 	"age_18_or_older":         "age_18_or_older",
+	"_systemfield_name":       "full_name",
+	"_systemfield_email":      "email",
 }
 
 // Resolve matches every merged field against the candidate's known answers. A required
@@ -107,6 +114,10 @@ var labelAnswerKeyFor = []struct {
 	keywords  []string // ALL must appear (case-insensitive) for the rule to fire
 }{
 	{"visa_sponsorship_needed", []string{"visa", "sponsor"}},
+	// Measured live 2026-09-07: a Singular posting on Ashby asks for LinkedIn as a custom
+	// question carrying a random uuid id (not the "linkedin" id answerKeyFor already
+	// covers), so only a label rule can match it.
+	{"linkedin", []string{"linkedin"}},
 }
 
 // matchLabelAnswerKey returns the answer key a field's label matches, if any.

--- a/internal/api/atsapply/resolve_test.go
+++ b/internal/api/atsapply/resolve_test.go
@@ -58,6 +58,43 @@ func TestResolve_AppliesTheDOMToAnswerKeyAlias(t *testing.T) {
 	}
 }
 
+// Ashby names its standard identity controls "_systemfield_name" / "_systemfield_email"
+// rather than Greenhouse's ids — measured live 2026-09-07 against a Singular posting, which
+// parked with "no known answer source" for both despite the candidate's name and email
+// already being known.
+func TestResolve_AppliesTheAshbySystemFieldAliases(t *testing.T) {
+	fields := []MergedField{
+		{ID: "_systemfield_name", Kind: "text", Required: true},
+		{ID: "_systemfield_email", Kind: "text", Required: true},
+	}
+	answers := map[string]string{"full_name": "Ada Lovelace", "email": "ada@example.test"}
+
+	plan := Resolve(fields, answers, false)
+
+	if len(plan.Unmapped) != 0 {
+		t.Fatalf("unmapped = %+v, want both Ashby system fields resolved", plan.Unmapped)
+	}
+	if len(plan.Fields) != 2 || plan.Fields[0].Value != "Ada Lovelace" || plan.Fields[1].Value != "ada@example.test" {
+		t.Fatalf("plan.Fields = %+v, want _systemfield_name=Ada Lovelace and _systemfield_email=ada@example.test", plan.Fields)
+	}
+}
+
+// Ashby's LinkedIn question carries a random uuid id rather than "linkedin" — the id
+// answerKeyFor already covers — so only the label rule can match it.
+func TestResolve_MatchesLinkedInByLabelWhenTheIDIsOpaque(t *testing.T) {
+	fields := []MergedField{{ID: "6810b294-be01-4bf4-bd4a-d056ddd0d6da", Label: "LinkedIn ", Kind: "text", Required: true}}
+	answers := map[string]string{"linkedin": "https://linkedin.com/in/ada"}
+
+	plan := Resolve(fields, answers, false)
+
+	if len(plan.Unmapped) != 0 {
+		t.Fatalf("unmapped = %+v, want the LinkedIn field resolved via its label", plan.Unmapped)
+	}
+	if len(plan.Fields) != 1 || plan.Fields[0].Value != "https://linkedin.com/in/ada" {
+		t.Fatalf("plan.Fields = %+v, want the LinkedIn field filled from the linkedin answer", plan.Fields)
+	}
+}
+
 // A select/checkbox field's answer must match one of the platform's own offered options —
 // never a value the widget does not offer, per the "never guess" rule the whole design rests
 // on.


### PR DESCRIPTION
## Summary
- `answerKeyFor` in `internal/api/atsapply/resolve.go` only carried Greenhouse's own identity-field ids, so an Ashby posting's standard Name/Email controls (`_systemfield_name`/`_systemfield_email`) always parked as unmapped even though the candidate's name and email were already known — measured live against a real Singular posting on Ashby during an auto-apply verification session.
- Added a label rule for LinkedIn alongside the existing visa-sponsorship one: Ashby's LinkedIn question carries a random uuid id rather than one `answerKeyFor` recognizes, so only a label match can catch it.

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` — all passing, including two new cases: `TestResolve_AppliesTheAshbySystemFieldAliases`, `TestResolve_MatchesLinkedInByLabelWhenTheIDIsOpaque`
- [ ] Re-run auto-apply against a live Ashby posting to confirm the fields resolve end-to-end in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ashby application forms now correctly recognize standard name and email fields.
  - LinkedIn questions with opaque field IDs are now matched by their labels, improving answer resolution.

- **Tests**
  - Added coverage for Ashby name, email, and LinkedIn field resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->