### PR TITLE
Restore the Pro badge on the auto-apply button, link its queued state to the tracking board

### DIFF
--- a/web/src/lib/autoApplyButton.test.ts
+++ b/web/src/lib/autoApplyButton.test.ts
@@ -64,16 +64,16 @@ describe('jobCtaPlan', () => {
     });
   });
 
-  it('makes a startable auto-apply the primary CTA', () => {
+  it('makes a startable auto-apply the primary CTA and names the plan it needs', () => {
     expect(plan('idle')).toEqual({
-      autoApply: { label: 'Auto-apply', primary: true, disabled: false },
+      autoApply: { label: 'Auto-apply', primary: true, pro: true, disabled: false },
       external: { label: 'Show origin', primary: false },
     });
   });
 
   it('keeps a standing attempt quiet and the apply button demoted', () => {
     expect(plan('queued')).toEqual({
-      autoApply: { label: 'Auto-apply queued', primary: false, disabled: true },
+      autoApply: { label: 'Auto-apply queued', primary: false, pro: false, disabled: true },
       external: { label: 'Show origin', primary: false },
     });
   });
@@ -83,18 +83,18 @@ describe('jobCtaPlan', () => {
   // the identical situation.
   it('leaves the apply button alone for a reader who already applied by hand', () => {
     expect(plan('applied')).toEqual({
-      autoApply: { label: 'Already applied', primary: false, disabled: true },
+      autoApply: { label: 'Already applied', primary: false, pro: false, disabled: true },
       external: { label: 'Apply', primary: true },
     });
   });
 
   it('promotes the apply button back when auto-apply will not act', () => {
     expect(plan('declined')).toEqual({
-      autoApply: { label: 'Auto-apply declined', primary: false, disabled: true },
+      autoApply: { label: 'Auto-apply declined', primary: false, pro: false, disabled: true },
       external: { label: 'Apply', primary: true },
     });
     expect(plan('failed')).toEqual({
-      autoApply: { label: "Auto-apply couldn't complete", primary: false, disabled: true },
+      autoApply: { label: "Auto-apply couldn't complete", primary: false, pro: false, disabled: true },
       external: { label: 'Apply', primary: true },
     });
   });
@@ -117,6 +117,15 @@ describe('jobCtaPlan', () => {
       const p = plan(kind);
       const hasPrimary = Boolean(p.autoApply?.primary) || p.external.primary;
       expect(hasPrimary, `state ${kind}`).toBe(kind !== 'queued');
+    }
+  });
+
+  // The Pro marker states a requirement of the action. On a button nobody can press it
+  // would state it about nothing.
+  it('marks Pro only on a button that can be pressed', () => {
+    for (const kind of kinds) {
+      const { autoApply } = plan(kind);
+      if (autoApply?.pro) expect(autoApply.disabled, `state ${kind}`).toBe(false);
     }
   });
 });

--- a/web/src/lib/autoApplyButton.ts
+++ b/web/src/lib/autoApplyButton.ts
@@ -49,10 +49,7 @@ export function autoApplyButtonState(
 }
 
 /** What the job page's two call-to-action buttons look like, given the auto-apply state.
- *  Never two loud buttons at once, and one wherever the reader still has something to do.
- *  Carries no Pro marker: `autoApplyButtonState` already gates the whole button on Pro, so
- *  by the time any of these states renders at all the requirement is already met — a badge
- *  naming it here would state a fact about nothing left to decide. */
+ *  Never two loud buttons at once, and one wherever the reader still has something to do. */
 export type JobCtaPlan = {
   /** `null` where auto-apply cannot drive the posting's ATS, or the caller is not Pro: no
    *  button is rendered either way — see autoApplyButtonState's own `hidden` doc comment. */
@@ -60,6 +57,8 @@ export type JobCtaPlan = {
     label: string;
     /** Carries the brand fill — the page's primary call to action. */
     primary: boolean;
+    /** Renders the `Pro` marker naming the plan the action requires. */
+    pro: boolean;
     disabled: boolean;
   } | null;
   /** The link out to the posting's own site. Demoted to an outline `Show origin` while
@@ -68,10 +67,11 @@ export type JobCtaPlan = {
 };
 
 /** A rendered-but-unpressable auto-apply button: it reports where the attempt stands and
- *  takes no brand fill. */
+ *  takes neither the brand fill nor the `Pro` marker. */
 const quiet = (label: string): NonNullable<JobCtaPlan['autoApply']> => ({
   label,
   primary: false,
+  pro: false,
   disabled: true,
 });
 
@@ -93,14 +93,17 @@ const apply = { label: 'Apply', primary: true } as const;
  *  differently from an identical Lever one for a reader in the identical situation, which
  *  is an artefact of routing the question through the auto-apply state machine rather than
  *  a decision anybody made. `queued` is the one state that genuinely leaves no primary CTA,
- *  and it is genuinely auto-apply's own. */
+ *  and it is genuinely auto-apply's own.
+ *
+ *  `pro` rides only the clickable state for the same reason the brand fill does: a marker
+ *  naming what an action requires says nothing on a button nobody can press. */
 export function jobCtaPlan(state: AutoApplyButtonState): JobCtaPlan {
   switch (state.kind) {
     case 'hidden':
       return { autoApply: null, external: apply };
     case 'idle':
       return {
-        autoApply: { label: 'Auto-apply', primary: true, disabled: false },
+        autoApply: { label: 'Auto-apply', primary: true, pro: true, disabled: false },
         external: showOrigin,
       };
     case 'queued':

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -384,9 +384,13 @@
      button only starts the tailor-then-review sequence. What it says and how loud it is
      both come from the CTA plan; the only thing decided here is that a submission already
      in flight also disables it, which is a fact about THIS component's request rather than
-     about the posting. No `Pro` marker: only a Pro (or above) caller ever sees this button
-     at all (autoApplyState above), so labelling the requirement here would state a fact
-     about nothing left to decide. -->
+     about the posting.
+     The `Pro` marker is a span, not the `Badge` primitive: Badge's variants carry their own
+     background and foreground, none of which read as a plan marker on `bg-brand`. It takes
+     the PAGE's `foreground` for its fill and `background` for its text — near-black on
+     white in the light theme, near-white on black in the dark one — so it stays the highest
+     contrast thing on a brand-green button in either. A tint of the button's own foreground
+     was the first try and it dissolved into the fill. -->
 {#snippet autoApplyCta(size: 'md' | 'lg', className: string)}
   {#if cta.autoApply}
     {@const autoApply = cta.autoApply}
@@ -398,6 +402,13 @@
       class={className}
     >
       {autoApply.label}
+      {#if autoApply.pro}
+        <span
+          class="rounded-sm bg-foreground px-1.5 py-0.5 text-xs font-semibold uppercase leading-none tracking-wide text-background"
+        >
+          Pro
+        </span>
+      {/if}
     </Button>
   {/if}
 {/snippet}
@@ -963,6 +974,12 @@
           <CheckCircle2 class="size-4 shrink-0" aria-hidden="true" /> We're preparing a tailored CV — you'll get
           a notification to review it.
         </span>
+        <a
+          href={resolve('/my/tracking/[id]', { id: job.public_slug })}
+          class="text-sm font-medium text-brand-strong underline underline-offset-4"
+        >
+          Track progress →
+        </a>
       </div>
     {/if}
     {#if autoApplyError}


### PR DESCRIPTION
## Summary
- Restores the `Pro` badge on the auto-apply button — removed yesterday (#2543) as redundant since only Pro/Ultra callers see the button at all, but it still reads as a plan marker worth keeping for those readers. Visibility gating (hidden for non-Pro) is unchanged.
- Adds a "Track progress →" deep link to `/my/tracking/[id]` in the `queued`-state confirmation banner, matching the existing "Added to your board" banner right above it, so clicking auto-apply gives the reader somewhere to go instead of no feedback at all.

## Test plan
- [x] `npx vitest run src/lib/autoApplyButton.test.ts` — 16 tests pass
- [x] `npx svelte-check` — 0 errors
- [x] `npx eslint` on the three changed files — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional browser-based fallback for eligible, fully resolved auto-apply submissions.
  - Added configurable eligibility checks for work authorization and location/work-mode requirements before queueing.
  - Added a “Pro” label to applicable auto-apply actions.
  - Added a “Track progress” link after auto-apply is queued.

- **Safety Improvements**
  - Geography and residency questions that cannot be confidently resolved are parked instead of guessed.
  - Browser-based submissions use explicit outcomes and spending limits, with shadow mode available before enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->