### PR TITLE
Notify candidates when an auto-apply attempt is submitted, blocked, or fails

### DIFF
--- a/cmd/auto-apply/store.go
+++ b/cmd/auto-apply/store.go
@@ -71,10 +71,10 @@ func (s *dbStore) Claim(ctx context.Context, batch, leaseSeconds int) ([]autoapp
 // LockJobForApply first, then MarkJobApplied, is the exact same locked-transaction shape
 // jobtracking.QueriesRepository.MarkApplied already runs for a candidate's own manual apply
 // — reused directly rather than re-derived, so the applied_count/ledger guarantee is the one
-// guarantee, not a second implementation of it. EventSource is appevent.SourceSystem: this
-// submission was not typed by the candidate or drafted by the assistant, it is the platform
-// acting on their behalf — exactly what that source already means for an auto-expired
-// application in the other direction.
+// guarantee, not a second implementation of it. EventSource is appevent.SourceAutoApply, not
+// the shared SourceSystem: internal/engage/nudge's MATCH scan for a successful auto-apply
+// submission needs this to be a stated, queryable fact rather than an accident of SourceSystem
+// happening to pair only with KindApplied here today.
 func (s *dbStore) Submit(ctx context.Context, c autoapply.Claimed) error {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
@@ -90,7 +90,7 @@ func (s *dbStore) Submit(ctx context.Context, c autoapply.Claimed) error {
 		UserID:      c.UserID,
 		JobID:       c.JobID,
 		At:          pgtype.Timestamptz{},
-		EventSource: appevent.SourceSystem,
+		EventSource: appevent.SourceAutoApply,
 	}); err != nil {
 		return fmt.Errorf("mark job %d applied for user %d: %w", c.JobID, c.UserID, err)
 	}

--- a/cmd/auto-apply/store_integration_test.go
+++ b/cmd/auto-apply/store_integration_test.go
@@ -72,6 +72,18 @@ func TestDBStore_Submit(t *testing.T) {
 			t.Error("applied_at is null, want it set")
 		}
 
+		// internal/engage/nudge's auto-apply-submitted MATCH scan keys on this exact
+		// (kind, source) pair — see add-auto-apply-outcome-notifications.
+		var eventSource string
+		if err := pool.QueryRow(ctx,
+			"SELECT source FROM application_events WHERE user_id = $1 AND job_id = $2 AND kind = 'applied'",
+			user, job).Scan(&eventSource); err != nil {
+			t.Fatalf("applied event not recorded: %v", err)
+		}
+		if eventSource != "auto_apply" {
+			t.Errorf("applied event source = %q, want %q", eventSource, "auto_apply")
+		}
+
 		var queueRows int
 		if err := pool.QueryRow(ctx, "SELECT count(*) FROM auto_apply_queue WHERE id = $1", queueID).Scan(&queueRows); err != nil {
 			t.Fatal(err)

--- a/internal/application/appevent/appevent.go
+++ b/internal/application/appevent/appevent.go
@@ -46,10 +46,18 @@ const (
 	// an application whose listing closed. Not trusted for day math: it records when we
 	// noticed, not an employer-side timing fact.
 	SourceSystem = "system"
+	// SourceAutoApply is cmd/auto-apply's own successful, unattended submission —
+	// distinct from SourceSystem so that "auto-apply submitted this" is a stated
+	// contract a reader can filter on, not an accident of SourceSystem happening to be
+	// paired with KindApplied nowhere else today.
+	SourceAutoApply = "auto_apply"
 )
 
 // Sources is the canonical, ordered source vocabulary.
-var Sources = []string{SourceMailGmail, SourceMailHosted, SourceMailExternal, SourceUser, SourceAssistant, SourceCalendarGoogle, SourceSystem}
+var Sources = []string{
+	SourceMailGmail, SourceMailHosted, SourceMailExternal, SourceUser, SourceAssistant,
+	SourceCalendarGoogle, SourceSystem, SourceAutoApply,
+}
 
 // MailSources is the mail three on their own — every source SourceForMail can return.
 //

--- a/internal/application/appevent/appevent_test.go
+++ b/internal/application/appevent/appevent_test.go
@@ -11,6 +11,10 @@ func TestOnlyObservedSourcesAreTrustedForDayMath(t *testing.T) {
 		SourceUser:           false,
 		SourceAssistant:      false,
 		SourceSystem:         false,
+		// Auto-apply's own timestamp is precise and real-time, but it is the platform
+		// acting on the candidate's behalf, not an employer-side or calendar-observed
+		// timing fact — same category as SourceSystem, not the mail/calendar pair.
+		SourceAutoApply: false,
 	}
 	if len(trusted) != len(Sources) {
 		t.Fatalf("the vocabulary has %d sources but this test pins %d — a new source needs a verdict here", len(Sources), len(trusted))

--- a/internal/engage/nudge/auto_apply_outcome_integration_test.go
+++ b/internal/engage/nudge/auto_apply_outcome_integration_test.go
@@ -105,6 +105,37 @@ func TestListAutoApplyBlockedCandidates_OnlyBlockedRows(t *testing.T) {
 	}
 }
 
+// A row can carry both blocked_at and failed_at (a lease-timeout race between a
+// park and a fail — see AutoApplyQueueMetrics' own comment, metrics.sql), and the
+// dead-letter marker must win: this attempt is a failed nudge, never also a
+// blocked one.
+func TestListAutoApplyBlockedCandidates_ExcludesRowsAlsoFailed(t *testing.T) {
+	pool := testdb.Pool(t)
+	queries := db.New(pool)
+	ctx := context.Background()
+
+	userID := seedNudgeIntegrationUser(t, pool, "blocked-and-failed@example.test")
+	jobID := seedClosedJob(t, pool, "blocked-and-failed-job")
+	seedNotificationSettings(t, pool, userID, []string{"push"})
+	seedAutoApplyQueueEntry(t, pool, userID, jobID, true, true)
+
+	blocked, err := queries.ListAutoApplyBlockedCandidates(ctx, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocked) != 0 {
+		t.Errorf("blocked rows = %d, want 0 (failed_at wins over blocked_at)", len(blocked))
+	}
+
+	failed, err := queries.ListAutoApplyFailedCandidates(ctx, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(failed) != 1 {
+		t.Errorf("failed rows = %d, want 1", len(failed))
+	}
+}
+
 func TestListAutoApplyFailedCandidates_OnlyFailedRows(t *testing.T) {
 	pool := testdb.Pool(t)
 	queries := db.New(pool)

--- a/internal/engage/nudge/auto_apply_outcome_integration_test.go
+++ b/internal/engage/nudge/auto_apply_outcome_integration_test.go
@@ -1,0 +1,185 @@
+//go:build integration
+
+// Integration tests for add-auto-apply-outcome-notifications: the three new
+// candidate scans read the right rows and exclude the wrong ones, and MATCH
+// stays idempotent across two passes over an unchanged terminal row — the same
+// guarantee ListInterviewPrepCandidates/ListJobClosedCandidates already have,
+// proven here against a real Postgres rather than the in-memory fakeStore.
+//
+// Run with: go test -tags=integration ./internal/engage/nudge/
+// Requires Docker (testcontainers spins up a throwaway Postgres with the migrations).
+package nudge
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/strelov1/freehire/internal/platform/db"
+	"github.com/strelov1/freehire/internal/platform/testdb"
+)
+
+// seedAppliedEvent inserts an application_events row of kind='applied' with the
+// given source, mirroring what MarkJobApplied writes (see cmd/auto-apply/store.go
+// and internal/application/userjob's own manual-apply path).
+func seedAppliedEvent(t *testing.T, pool *pgxpool.Pool, userID, jobID int64, source string) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO application_events (user_id, job_id, company_slug, kind, occurred_at, source)
+		 VALUES ($1, $2, 'acme', 'applied', now(), $3)`,
+		userID, jobID, source); err != nil {
+		t.Fatalf("insert application_events: %v", err)
+	}
+}
+
+// seedAutoApplyQueueEntry inserts an auto_apply_queue row, optionally already
+// blocked or failed.
+func seedAutoApplyQueueEntry(t *testing.T, pool *pgxpool.Pool, userID, jobID int64, blocked, failed bool) int64 {
+	t.Helper()
+	var id int64
+	err := pool.QueryRow(context.Background(),
+		`INSERT INTO auto_apply_queue (user_id, job_id, blocked_at, failed_at)
+		 VALUES ($1, $2,
+		         CASE WHEN $3 THEN now() ELSE NULL END,
+		         CASE WHEN $4 THEN now() ELSE NULL END)
+		 RETURNING id`,
+		userID, jobID, blocked, failed).Scan(&id)
+	if err != nil {
+		t.Fatalf("insert auto_apply_queue: %v", err)
+	}
+	return id
+}
+
+func TestListAutoApplySubmittedCandidates_OnlyAutoApplySource(t *testing.T) {
+	pool := testdb.Pool(t)
+	queries := db.New(pool)
+	ctx := context.Background()
+
+	autoApplyUser := seedNudgeIntegrationUser(t, pool, "submitted-auto-apply@example.test")
+	autoApplyJob := seedClosedJob(t, pool, "submitted-auto-apply-job")
+	seedNotificationSettings(t, pool, autoApplyUser, []string{"push"})
+	seedAppliedEvent(t, pool, autoApplyUser, autoApplyJob, "auto_apply")
+
+	manualUser := seedNudgeIntegrationUser(t, pool, "submitted-manual@example.test")
+	manualJob := seedClosedJob(t, pool, "submitted-manual-job")
+	seedNotificationSettings(t, pool, manualUser, []string{"push"})
+	seedAppliedEvent(t, pool, manualUser, manualJob, "user")
+
+	rows, err := queries.ListAutoApplySubmittedCandidates(ctx, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1 (only the auto_apply-sourced event)", len(rows))
+	}
+	if rows[0].UserID != autoApplyUser || rows[0].JobID.Int64 != autoApplyJob {
+		t.Errorf("row = %+v, want the auto_apply-sourced user/job", rows[0])
+	}
+}
+
+func TestListAutoApplyBlockedCandidates_OnlyBlockedRows(t *testing.T) {
+	pool := testdb.Pool(t)
+	queries := db.New(pool)
+	ctx := context.Background()
+
+	blockedUser := seedNudgeIntegrationUser(t, pool, "blocked-yes@example.test")
+	blockedJob := seedClosedJob(t, pool, "blocked-yes-job")
+	seedNotificationSettings(t, pool, blockedUser, []string{"push"})
+	seedAutoApplyQueueEntry(t, pool, blockedUser, blockedJob, true, false)
+
+	activeUser := seedNudgeIntegrationUser(t, pool, "blocked-no@example.test")
+	activeJob := seedClosedJob(t, pool, "blocked-no-job")
+	seedNotificationSettings(t, pool, activeUser, []string{"push"})
+	seedAutoApplyQueueEntry(t, pool, activeUser, activeJob, false, false)
+
+	rows, err := queries.ListAutoApplyBlockedCandidates(ctx, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1 (only the blocked row)", len(rows))
+	}
+	if rows[0].UserID != blockedUser || rows[0].JobID != blockedJob {
+		t.Errorf("row = %+v, want the blocked user/job", rows[0])
+	}
+}
+
+func TestListAutoApplyFailedCandidates_OnlyFailedRows(t *testing.T) {
+	pool := testdb.Pool(t)
+	queries := db.New(pool)
+	ctx := context.Background()
+
+	failedUser := seedNudgeIntegrationUser(t, pool, "failed-yes@example.test")
+	failedJob := seedClosedJob(t, pool, "failed-yes-job")
+	seedNotificationSettings(t, pool, failedUser, []string{"push"})
+	seedAutoApplyQueueEntry(t, pool, failedUser, failedJob, false, true)
+
+	activeUser := seedNudgeIntegrationUser(t, pool, "failed-no@example.test")
+	activeJob := seedClosedJob(t, pool, "failed-no-job")
+	seedNotificationSettings(t, pool, activeUser, []string{"push"})
+	seedAutoApplyQueueEntry(t, pool, activeUser, activeJob, false, false)
+
+	rows, err := queries.ListAutoApplyFailedCandidates(ctx, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1 (only the failed row)", len(rows))
+	}
+	if rows[0].UserID != failedUser || rows[0].JobID != failedJob {
+		t.Errorf("row = %+v, want the failed user/job", rows[0])
+	}
+}
+
+// TestMatch_AutoApplyOutcomeKinds_SecondPassDoesNotReRecord proves RecordNudge's
+// ON CONFLICT DO NOTHING is idempotent for all three new kinds across two real
+// MATCH passes over an unchanged row — blocked_at/failed_at never move (see
+// nudge.go's actionable() doc), so a naive re-scan must not double-record.
+func TestMatch_AutoApplyOutcomeKinds_SecondPassDoesNotReRecord(t *testing.T) {
+	pool := testdb.Pool(t)
+	queries := db.New(pool)
+	ctx := context.Background()
+
+	userID := seedNudgeIntegrationUser(t, pool, "auto-apply-idempotent@example.test")
+	jobID := seedClosedJob(t, pool, "auto-apply-idempotent-job")
+	seedNotificationSettings(t, pool, userID, []string{"push"})
+	// A real successful submission deletes its own queue row (cmd/auto-apply/store.go's
+	// Submit), so jobID here carries only the applied event, never a queue row.
+	seedAppliedEvent(t, pool, userID, jobID, "auto_apply")
+	blockedJob := seedClosedJob(t, pool, "auto-apply-idempotent-blocked-job")
+	seedAutoApplyQueueEntry(t, pool, userID, blockedJob, true, false)
+	failedJob := seedClosedJob(t, pool, "auto-apply-idempotent-failed-job")
+	seedAutoApplyQueueEntry(t, pool, userID, failedJob, false, true)
+
+	// No channel registered in the Router: deliver soft-skips every claimed nudge
+	// (released, not delivered), so a second Run's MATCH re-scans the identical
+	// rows rather than finding them already terminal.
+	runner := New(queries, Router{}, DefaultConfig())
+
+	stats1, err := runner.Run(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats1.Matched != 3 {
+		t.Fatalf("first pass Matched = %d, want 3 (submitted + blocked + failed)", stats1.Matched)
+	}
+
+	stats2, err := runner.Run(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats2.Matched != 0 {
+		t.Errorf("second pass Matched = %d, want 0 (already recorded, ON CONFLICT DO NOTHING)", stats2.Matched)
+	}
+
+	var count int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM application_nudges WHERE user_id = $1 AND kind IN ('auto_apply_submitted', 'auto_apply_blocked', 'auto_apply_failed')`,
+		userID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 3 {
+		t.Errorf("application_nudges rows = %d, want 3 (one per kind, no duplicates)", count)
+	}
+}

--- a/internal/engage/nudge/nudge.go
+++ b/internal/engage/nudge/nudge.go
@@ -51,6 +51,10 @@ const (
 	// triggering condition can never lapse between MATCH and DELIVER (an applied
 	// event, a blocked_at, a failed_at are all permanent once written), so
 	// Runner.actionable treats all three as unconditionally actionable.
+	// ListAutoApplyBlockedCandidates/ListAutoApplyFailedCandidates already make
+	// Blocked and Failed mutually exclusive (failed_at wins on a row carrying
+	// both, mirroring AutoApplyQueueMetrics), so a single attempt is never matched
+	// as both kinds at once.
 	KindAutoApplySubmitted = "auto_apply_submitted"
 	KindAutoApplyBlocked   = "auto_apply_blocked"
 	KindAutoApplyFailed    = "auto_apply_failed"

--- a/internal/engage/nudge/nudge.go
+++ b/internal/engage/nudge/nudge.go
@@ -40,11 +40,20 @@ import (
 )
 
 // Nudge kinds. Also the CHECK constraint on application_nudges.kind (migrations
-// 0083, widened by 0084).
+// 0083, widened by 0084 and 0144).
 const (
 	KindFollowUp      = "follow_up"
 	KindInterviewPrep = "interview_prep"
 	KindJobClosed     = "job_closed"
+	// KindAutoApplySubmitted, KindAutoApplyBlocked and KindAutoApplyFailed report an
+	// unattended auto-apply attempt's own terminal outcome — see
+	// add-auto-apply-outcome-notifications. Unlike the three kinds above, their
+	// triggering condition can never lapse between MATCH and DELIVER (an applied
+	// event, a blocked_at, a failed_at are all permanent once written), so
+	// Runner.actionable treats all three as unconditionally actionable.
+	KindAutoApplySubmitted = "auto_apply_submitted"
+	KindAutoApplyBlocked   = "auto_apply_blocked"
+	KindAutoApplyFailed    = "auto_apply_failed"
 )
 
 // Message is the display shape of one nudge, rendered by a Notifier into a
@@ -106,6 +115,12 @@ type Store interface {
 	ListFollowUpCandidates(ctx context.Context, windowDays int32) ([]db.ListFollowUpCandidatesRow, error)
 	ListInterviewPrepCandidates(ctx context.Context, windowDays int32) ([]db.ListInterviewPrepCandidatesRow, error)
 	ListJobClosedCandidates(ctx context.Context, windowDays int32) ([]db.ListJobClosedCandidatesRow, error)
+	// ListAutoApplySubmittedCandidates, ListAutoApplyBlockedCandidates and
+	// ListAutoApplyFailedCandidates back the three KindAutoApply* MATCH loops. See
+	// add-auto-apply-outcome-notifications.
+	ListAutoApplySubmittedCandidates(ctx context.Context, windowDays int32) ([]db.ListAutoApplySubmittedCandidatesRow, error)
+	ListAutoApplyBlockedCandidates(ctx context.Context, windowDays int32) ([]db.ListAutoApplyBlockedCandidatesRow, error)
+	ListAutoApplyFailedCandidates(ctx context.Context, windowDays int32) ([]db.ListAutoApplyFailedCandidatesRow, error)
 	RecordNudge(ctx context.Context, arg db.RecordNudgeParams) (int64, error)
 	// TrackJob is jobtracking's own stage-set write (upserts applications.stage and
 	// emits the paired application_events row in one statement, only when the stage
@@ -141,6 +156,11 @@ type Config struct {
 	InterviewPrepWindowDays int32
 	// JobClosedWindowDays is the same bound on ListJobClosedCandidates' closed_at.
 	JobClosedWindowDays int32
+	// AutoApplyOutcomeWindowDays is the same first-deploy bound shared by all three
+	// ListAutoApply*Candidates queries (on occurred_at/blocked_at/failed_at
+	// respectively) — one field rather than three, since all three read the same
+	// kind of "recent terminal transition" rather than distinct silence windows.
+	AutoApplyOutcomeWindowDays int32
 	// LeaseSeconds is the delivery lease: a claimed-but-unfinished nudge is
 	// reclaimable after this, which doubles as the crash reaper.
 	LeaseSeconds int32
@@ -161,13 +181,14 @@ type Config struct {
 // internal/engage/notify.
 func DefaultConfig() Config {
 	return Config{
-		FollowUpWindowDays:      30,
-		InterviewPrepWindowDays: 7,
-		JobClosedWindowDays:     7,
-		LeaseSeconds:            600,
-		ClaimBatch:              500,
-		MaxAttempts:             5,
-		SnapshotCap:             200,
+		FollowUpWindowDays:         30,
+		InterviewPrepWindowDays:    7,
+		JobClosedWindowDays:        7,
+		AutoApplyOutcomeWindowDays: 7,
+		LeaseSeconds:               600,
+		ClaimBatch:                 500,
+		MaxAttempts:                5,
+		SnapshotCap:                200,
 	}
 }
 
@@ -326,6 +347,54 @@ func (r *Runner) match(ctx context.Context, stats *Stats) error {
 			return fmt.Errorf("auto-expire job-closed application: %w", err)
 		}
 	}
+
+	submitted, err := r.store.ListAutoApplySubmittedCandidates(ctx, r.cfg.AutoApplyOutcomeWindowDays)
+	if err != nil {
+		return fmt.Errorf("list auto-apply-submitted candidates: %w", err)
+	}
+	for _, s := range submitted {
+		if !s.JobID.Valid || !s.OccurredAt.Valid {
+			continue // defensive: the query's WHERE clause already guarantees both are set
+		}
+		affected, err := r.store.RecordNudge(ctx, db.RecordNudgeParams{
+			UserID: s.UserID, JobID: s.JobID.Int64, Kind: KindAutoApplySubmitted,
+			EpisodeKey: s.OccurredAt,
+		})
+		if err != nil {
+			return fmt.Errorf("record auto-apply-submitted nudge: %w", err)
+		}
+		stats.Matched += int(affected)
+	}
+
+	blocked, err := r.store.ListAutoApplyBlockedCandidates(ctx, r.cfg.AutoApplyOutcomeWindowDays)
+	if err != nil {
+		return fmt.Errorf("list auto-apply-blocked candidates: %w", err)
+	}
+	for _, b := range blocked {
+		affected, err := r.store.RecordNudge(ctx, db.RecordNudgeParams{
+			UserID: b.UserID, JobID: b.JobID, Kind: KindAutoApplyBlocked,
+			EpisodeKey: b.BlockedAt,
+		})
+		if err != nil {
+			return fmt.Errorf("record auto-apply-blocked nudge: %w", err)
+		}
+		stats.Matched += int(affected)
+	}
+
+	failed, err := r.store.ListAutoApplyFailedCandidates(ctx, r.cfg.AutoApplyOutcomeWindowDays)
+	if err != nil {
+		return fmt.Errorf("list auto-apply-failed candidates: %w", err)
+	}
+	for _, f := range failed {
+		affected, err := r.store.RecordNudge(ctx, db.RecordNudgeParams{
+			UserID: f.UserID, JobID: f.JobID, Kind: KindAutoApplyFailed,
+			EpisodeKey: f.FailedAt,
+		})
+		if err != nil {
+			return fmt.Errorf("record auto-apply-failed nudge: %w", err)
+		}
+		stats.Matched += int(affected)
+	}
 	return nil
 }
 
@@ -465,6 +534,8 @@ func (r *Runner) deliverBatch(ctx context.Context, b *batch, stats *Stats) {
 // or another) and their own live condition; job-closed needs the opposite — the
 // job stays closed once closed, so it only needs the application to still be in a
 // stage that accrues silence (a settled one no longer cares that the listing shut).
+// The three auto-apply outcome kinds need no re-derivation at all: their condition
+// cannot lapse once matched.
 func (r *Runner) actionable(info db.GetNudgeForDeliveryRow) bool {
 	if !info.NotificationsEnabled {
 		return false
@@ -491,6 +562,11 @@ func (r *Runner) actionable(info db.GetNudgeForDeliveryRow) bool {
 		}
 		_, active := silence.ThresholdDays(stage)
 		return active
+	case KindAutoApplySubmitted, KindAutoApplyBlocked, KindAutoApplyFailed:
+		// Permanent once matched — an applied event, a blocked_at, a failed_at never
+		// lapse the way silence or an interview stage can, so there is nothing here to
+		// re-derive. The NotificationsEnabled gate above already applies.
+		return true
 	default:
 		return false
 	}

--- a/internal/engage/nudge/nudge_test.go
+++ b/internal/engage/nudge/nudge_test.go
@@ -20,11 +20,14 @@ type fakeStore struct {
 	// unlinkedTelegram records the user ids a delivery forgot the Telegram chat for.
 	unlinkedTelegram []int64
 
-	followUp      []db.ListFollowUpCandidatesRow
-	interviewPrep []db.ListInterviewPrepCandidatesRow
-	jobClosed     []db.ListJobClosedCandidatesRow
-	recorded      []db.RecordNudgeParams
-	tracked       []db.TrackJobParams
+	followUp        []db.ListFollowUpCandidatesRow
+	interviewPrep   []db.ListInterviewPrepCandidatesRow
+	jobClosed       []db.ListJobClosedCandidatesRow
+	autoApplySubmit []db.ListAutoApplySubmittedCandidatesRow
+	autoApplyBlock  []db.ListAutoApplyBlockedCandidatesRow
+	autoApplyFail   []db.ListAutoApplyFailedCandidatesRow
+	recorded        []db.RecordNudgeParams
+	tracked         []db.TrackJobParams
 
 	due []int64
 	row db.GetNudgeForDeliveryRow
@@ -49,6 +52,15 @@ func (s *fakeStore) ListInterviewPrepCandidates(context.Context, int32) ([]db.Li
 }
 func (s *fakeStore) ListJobClosedCandidates(context.Context, int32) ([]db.ListJobClosedCandidatesRow, error) {
 	return s.jobClosed, nil
+}
+func (s *fakeStore) ListAutoApplySubmittedCandidates(context.Context, int32) ([]db.ListAutoApplySubmittedCandidatesRow, error) {
+	return s.autoApplySubmit, nil
+}
+func (s *fakeStore) ListAutoApplyBlockedCandidates(context.Context, int32) ([]db.ListAutoApplyBlockedCandidatesRow, error) {
+	return s.autoApplyBlock, nil
+}
+func (s *fakeStore) ListAutoApplyFailedCandidates(context.Context, int32) ([]db.ListAutoApplyFailedCandidatesRow, error) {
+	return s.autoApplyFail, nil
 }
 func (s *fakeStore) RecordNudge(_ context.Context, arg db.RecordNudgeParams) (int64, error) {
 	for _, r := range s.recorded {
@@ -638,6 +650,26 @@ func TestActionable_FailsClosedWhenApplicationGone(t *testing.T) {
 			}
 			if r.actionable(row) {
 				t.Errorf("actionable() = true for an untracked application, want false (fail closed)")
+			}
+		})
+	}
+}
+
+// The three auto-apply outcome kinds are the deliberate opposite of
+// TestActionable_FailsClosedWhenApplicationGone above: their condition cannot lapse,
+// so actionable() ignores stage/job-open/application-existence entirely and answers
+// only off the NotificationsEnabled gate.
+func TestActionable_AutoApplyOutcomeKinds_IgnoreEverythingButNotificationsEnabled(t *testing.T) {
+	for _, kind := range []string{KindAutoApplySubmitted, KindAutoApplyBlocked, KindAutoApplyFailed} {
+		t.Run(kind, func(t *testing.T) {
+			r := newRunner(&fakeStore{}, &fakeNotifier{})
+			row := untrackedRow(kind) // no tracked application, job closed — still actionable
+			if !r.actionable(row) {
+				t.Errorf("actionable() = false for %s with notifications enabled, want true", kind)
+			}
+			row.NotificationsEnabled = false
+			if r.actionable(row) {
+				t.Errorf("actionable() = true for %s with notifications disabled, want false", kind)
 			}
 		})
 	}

--- a/internal/engage/nudge/push.go
+++ b/internal/engage/nudge/push.go
@@ -87,7 +87,7 @@ func renderNudgeBatch(kind string, ms []Message) (title, body string) {
 	case KindAutoApplyBlocked:
 		return "⚠️ Needs your attention", fmt.Sprintf("Auto-apply couldn't finish %d applications — a required question needs your own answer.", len(ms))
 	case KindAutoApplyFailed:
-		return "Auto-apply couldn't submit", fmt.Sprintf("Auto-apply couldn't submit %d applications after retrying.", len(ms))
+		return "Auto-apply couldn't submit", fmt.Sprintf("Auto-apply couldn't submit %d applications, and won't try again.", len(ms))
 	default:
 		return "🔔 Jobs you're tracking", fmt.Sprintf("%d updates on jobs you are tracking.", len(ms))
 	}
@@ -108,7 +108,7 @@ func renderNudge(m Message) (title, body string) {
 	case KindAutoApplyBlocked:
 		return "⚠️ Needs your attention", fmt.Sprintf("Auto-apply couldn't finish %s at %s — a required question needs your own answer.", m.JobTitle, m.Company)
 	case KindAutoApplyFailed:
-		return "Auto-apply couldn't submit", fmt.Sprintf("Auto-apply couldn't submit %s at %s after retrying.", m.JobTitle, m.Company)
+		return "Auto-apply couldn't submit", fmt.Sprintf("Auto-apply couldn't submit %s at %s, and won't try again.", m.JobTitle, m.Company)
 	default:
 		return "🔔 A job you're tracking", fmt.Sprintf("%s at %s", m.JobTitle, m.Company)
 	}

--- a/internal/engage/nudge/push.go
+++ b/internal/engage/nudge/push.go
@@ -82,6 +82,12 @@ func renderNudgeBatch(kind string, ms []Message) (title, body string) {
 		return "🎯 Interviews coming up", fmt.Sprintf("You're interviewing for %d roles.", len(ms))
 	case KindJobClosed:
 		return "📪 Jobs closed", fmt.Sprintf("%d jobs you were tracking were closed.", len(ms))
+	case KindAutoApplySubmitted:
+		return "🎉 Applications submitted", fmt.Sprintf("Auto-apply submitted %d applications for you.", len(ms))
+	case KindAutoApplyBlocked:
+		return "⚠️ Needs your attention", fmt.Sprintf("Auto-apply couldn't finish %d applications — a required question needs your own answer.", len(ms))
+	case KindAutoApplyFailed:
+		return "Auto-apply couldn't submit", fmt.Sprintf("Auto-apply couldn't submit %d applications after retrying.", len(ms))
 	default:
 		return "🔔 Jobs you're tracking", fmt.Sprintf("%d updates on jobs you are tracking.", len(ms))
 	}
@@ -97,6 +103,12 @@ func renderNudge(m Message) (title, body string) {
 		return "🎯 Interview coming up", fmt.Sprintf("You're interviewing for %s at %s.", m.JobTitle, m.Company)
 	case KindJobClosed:
 		return "📪 Job closed", fmt.Sprintf("%s at %s was closed.", m.JobTitle, m.Company)
+	case KindAutoApplySubmitted:
+		return "🎉 Application submitted", fmt.Sprintf("Auto-apply submitted your application to %s at %s.", m.JobTitle, m.Company)
+	case KindAutoApplyBlocked:
+		return "⚠️ Needs your attention", fmt.Sprintf("Auto-apply couldn't finish %s at %s — a required question needs your own answer.", m.JobTitle, m.Company)
+	case KindAutoApplyFailed:
+		return "Auto-apply couldn't submit", fmt.Sprintf("Auto-apply couldn't submit %s at %s after retrying.", m.JobTitle, m.Company)
 	default:
 		return "🔔 A job you're tracking", fmt.Sprintf("%s at %s", m.JobTitle, m.Company)
 	}

--- a/internal/engage/nudge/push_test.go
+++ b/internal/engage/nudge/push_test.go
@@ -2,6 +2,7 @@ package nudge
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/strelov1/freehire/internal/platform/db"
@@ -119,6 +120,65 @@ func TestPushNotifier_JobClosed_RendersTitleBodyAndSlug(t *testing.T) {
 	}
 	if got.data["slug"] != "go-dev-acme" {
 		t.Errorf("data[slug] = %q, want %q", got.data["slug"], "go-dev-acme")
+	}
+}
+
+func TestPushNotifier_AutoApplyOutcomeKinds_SingleAndBatch(t *testing.T) {
+	cases := []struct {
+		kind      string
+		wantTitle string
+	}{
+		{KindAutoApplySubmitted, "🎉 Application submitted"},
+		{KindAutoApplyBlocked, "⚠️ Needs your attention"},
+		{KindAutoApplyFailed, "Auto-apply couldn't submit"},
+	}
+	for _, c := range cases {
+		t.Run(c.kind+"/single", func(t *testing.T) {
+			lister := &fakePushTokenLister{tokens: map[int64][]db.UserPushToken{42: {{Token: "tok-1"}}}}
+			transport := &fakePushTransport{}
+			n := NewPushNotifier(lister, transport)
+
+			msg := Message{Kind: c.kind, JobTitle: "Go Dev", Company: "Acme", Slug: "go-dev-acme"}
+			if err := n.Send(context.Background(), "push", "42", msg.Kind, []Message{msg}); err != nil {
+				t.Fatal(err)
+			}
+			if len(transport.sent) != 1 {
+				t.Fatalf("sent = %d, want 1", len(transport.sent))
+			}
+			got := transport.sent[0]
+			if got.title != c.wantTitle {
+				t.Errorf("title = %q, want %q", got.title, c.wantTitle)
+			}
+			if !strings.Contains(got.body, "Go Dev") || !strings.Contains(got.body, "Acme") {
+				t.Errorf("body = %q, want the job title and company", got.body)
+			}
+			if got.data["slug"] != "go-dev-acme" {
+				t.Errorf("data[slug] = %q, want %q", got.data["slug"], "go-dev-acme")
+			}
+		})
+		t.Run(c.kind+"/batch", func(t *testing.T) {
+			lister := &fakePushTokenLister{tokens: map[int64][]db.UserPushToken{42: {{Token: "tok-1"}}}}
+			transport := &fakePushTransport{}
+			n := NewPushNotifier(lister, transport)
+
+			ms := []Message{
+				{Kind: c.kind, JobTitle: "Go Dev", Company: "Acme", Slug: "go-dev-acme"},
+				{Kind: c.kind, JobTitle: "Rust Dev", Company: "Beta", Slug: "rust-dev-beta"},
+			}
+			if err := n.Send(context.Background(), "push", "42", c.kind, ms); err != nil {
+				t.Fatal(err)
+			}
+			if len(transport.sent) != 1 {
+				t.Fatalf("sent = %d, want 1", len(transport.sent))
+			}
+			if !strings.Contains(transport.sent[0].body, "2") {
+				t.Errorf("body = %q, want the batch count", transport.sent[0].body)
+			}
+			// A batch names no single job, so no deep link is carried.
+			if transport.sent[0].data != nil {
+				t.Errorf("data = %v, want nil for a multi-job batch", transport.sent[0].data)
+			}
+		})
 	}
 }
 

--- a/internal/engage/nudge/transports.go
+++ b/internal/engage/nudge/transports.go
@@ -105,6 +105,12 @@ func (n *TelegramNotifier) batchHeadline(kind string, count int) string {
 		return fmt.Sprintf("🎯 You're interviewing for <b>%d</b> roles. Ready to rehearse?", count)
 	case KindJobClosed:
 		return fmt.Sprintf("📪 <b>%d</b> jobs you were tracking were closed.", count)
+	case KindAutoApplySubmitted:
+		return fmt.Sprintf("🎉 Auto-apply submitted <b>%d</b> applications for you.", count)
+	case KindAutoApplyBlocked:
+		return fmt.Sprintf("⚠️ Auto-apply couldn't finish <b>%d</b> applications — a required question needs your own answer.", count)
+	case KindAutoApplyFailed:
+		return fmt.Sprintf("Auto-apply couldn't submit <b>%d</b> applications after retrying.", count)
 	default:
 		return fmt.Sprintf("<b>%d</b> updates on jobs you are tracking.", count)
 	}
@@ -165,6 +171,18 @@ func (n *TelegramNotifier) renderOne(m Message) string {
 		return fmt.Sprintf(
 			"📪 <b>%s</b> at <b>%s</b> was closed.\n<a href=\"%s\">Open the job →</a>",
 			title, company, jobURL)
+	case KindAutoApplySubmitted:
+		return fmt.Sprintf(
+			"🎉 Auto-apply submitted your application to <b>%s</b> at <b>%s</b>.\n<a href=\"%s\">Open your tracking board →</a>",
+			title, company, trackingURL)
+	case KindAutoApplyBlocked:
+		return fmt.Sprintf(
+			"⚠️ Auto-apply couldn't finish <b>%s</b> at <b>%s</b> — a required question needs your own answer.\n<a href=\"%s\">Open your tracking board →</a>",
+			title, company, trackingURL)
+	case KindAutoApplyFailed:
+		return fmt.Sprintf(
+			"Auto-apply couldn't submit <b>%s</b> at <b>%s</b> after retrying.\n<a href=\"%s\">Open your tracking board →</a>",
+			title, company, trackingURL)
 	default:
 		return fmt.Sprintf("<b>%s</b> at <b>%s</b>: <a href=\"%s\">Open your tracking board →</a>", title, company, trackingURL)
 	}
@@ -282,6 +300,21 @@ func (n *EmailNotifier) batchCopy(kind string, count int) (subject, head, pre, l
 			fmt.Sprintf("%d jobs were closed", count),
 			fmt.Sprintf("%d jobs you were tracking have closed", count),
 			"These listings were closed. They are off the board, so they are fewer things to wait on."
+	case KindAutoApplySubmitted:
+		return fmt.Sprintf("Submitted: %d applications", count),
+			fmt.Sprintf("%d applications submitted", count),
+			fmt.Sprintf("Auto-apply submitted %d applications for you", count),
+			"Auto-apply submitted these applications for you."
+	case KindAutoApplyBlocked:
+		return fmt.Sprintf("Needs your attention: %d applications", count),
+			fmt.Sprintf("%d applications need your attention", count),
+			fmt.Sprintf("Auto-apply couldn't finish %d applications", count),
+			"Auto-apply couldn't finish these applications — a required question on each one needs your own answer."
+	case KindAutoApplyFailed:
+		return fmt.Sprintf("Couldn't submit: %d applications", count),
+			fmt.Sprintf("%d applications couldn't be submitted", count),
+			fmt.Sprintf("Auto-apply couldn't submit %d applications", count),
+			"Auto-apply couldn't submit these applications after retrying."
 	default:
 		return fmt.Sprintf("%d updates on jobs you are tracking", count),
 			"An update on your applications",
@@ -337,6 +370,21 @@ var bodies = template.Must(mailtpl.Partials().New("nudge").Parse(`
 {{define "plain"}}{{template "job-row" .Job}}
 <div style="height:18px;"></div>
 {{template "button" (mailLink .URL .CTA)}}{{end}}
+
+{{define "auto_apply_submitted"}}{{template "job-row" .Job}}
+<div style="height:18px;"></div>
+{{template "p" "Auto-apply submitted this application for you."}}
+{{template "button" (mailLink .URL .CTA)}}{{end}}
+
+{{define "auto_apply_blocked"}}{{template "job-row" .Job}}
+<div style="height:18px;"></div>
+{{template "p" "Auto-apply couldn't finish this application — a required question needs your own answer."}}
+{{template "button" (mailLink .URL .CTA)}}{{end}}
+
+{{define "auto_apply_failed"}}{{template "job-row" .Job}}
+<div style="height:18px;"></div>
+{{template "p" "Auto-apply couldn't submit this application after retrying."}}
+{{template "button" (mailLink .URL .CTA)}}{{end}}
 `))
 
 func (n *EmailNotifier) render(m Message) (subject, htmlBody, textBody string) {
@@ -371,6 +419,21 @@ func (n *EmailNotifier) render(m Message) (subject, htmlBody, textBody string) {
 		subject = fmt.Sprintf("Closed: %s at %s", m.JobTitle, m.Company)
 		data.URL, data.CTA = jobURL, "Open the job"
 		textBody = fmt.Sprintf("%s at %s was closed.\n\nOpen the job: %s\n", m.JobTitle, m.Company, jobURL)
+	case KindAutoApplySubmitted:
+		block, head, pre = "auto_apply_submitted", "Application submitted", "Auto-apply submitted your application"
+		subject = fmt.Sprintf("Submitted: %s at %s", m.JobTitle, m.Company)
+		textBody = fmt.Sprintf("Auto-apply submitted your application to %s at %s.\n\nOpen your tracking board: %s\n",
+			m.JobTitle, m.Company, trackingURL)
+	case KindAutoApplyBlocked:
+		block, head, pre = "auto_apply_blocked", "Needs your attention", "Auto-apply couldn't finish this application"
+		subject = fmt.Sprintf("Needs your attention: %s at %s", m.JobTitle, m.Company)
+		textBody = fmt.Sprintf("Auto-apply couldn't finish %s at %s — a required question needs your own answer.\n\nOpen your tracking board: %s\n",
+			m.JobTitle, m.Company, trackingURL)
+	case KindAutoApplyFailed:
+		block, head, pre = "auto_apply_failed", "Auto-apply couldn't submit this application", "Auto-apply couldn't submit this application"
+		subject = fmt.Sprintf("Couldn't submit: %s at %s", m.JobTitle, m.Company)
+		textBody = fmt.Sprintf("Auto-apply couldn't submit %s at %s after retrying.\n\nOpen your tracking board: %s\n",
+			m.JobTitle, m.Company, trackingURL)
 	default:
 		block, head, pre = "plain", fmt.Sprintf("%s at %s", m.JobTitle, m.Company), "An update on a job you are tracking"
 		subject = fmt.Sprintf("%s at %s", m.JobTitle, m.Company)

--- a/internal/engage/nudge/transports.go
+++ b/internal/engage/nudge/transports.go
@@ -110,7 +110,7 @@ func (n *TelegramNotifier) batchHeadline(kind string, count int) string {
 	case KindAutoApplyBlocked:
 		return fmt.Sprintf("⚠️ Auto-apply couldn't finish <b>%d</b> applications — a required question needs your own answer.", count)
 	case KindAutoApplyFailed:
-		return fmt.Sprintf("Auto-apply couldn't submit <b>%d</b> applications after retrying.", count)
+		return fmt.Sprintf("Auto-apply couldn't submit <b>%d</b> applications, and won't try again.", count)
 	default:
 		return fmt.Sprintf("<b>%d</b> updates on jobs you are tracking.", count)
 	}
@@ -181,7 +181,7 @@ func (n *TelegramNotifier) renderOne(m Message) string {
 			title, company, trackingURL)
 	case KindAutoApplyFailed:
 		return fmt.Sprintf(
-			"Auto-apply couldn't submit <b>%s</b> at <b>%s</b> after retrying.\n<a href=\"%s\">Open your tracking board →</a>",
+			"Auto-apply couldn't submit <b>%s</b> at <b>%s</b>, and won't try again.\n<a href=\"%s\">Open your tracking board →</a>",
 			title, company, trackingURL)
 	default:
 		return fmt.Sprintf("<b>%s</b> at <b>%s</b>: <a href=\"%s\">Open your tracking board →</a>", title, company, trackingURL)
@@ -314,7 +314,7 @@ func (n *EmailNotifier) batchCopy(kind string, count int) (subject, head, pre, l
 		return fmt.Sprintf("Couldn't submit: %d applications", count),
 			fmt.Sprintf("%d applications couldn't be submitted", count),
 			fmt.Sprintf("Auto-apply couldn't submit %d applications", count),
-			"Auto-apply couldn't submit these applications after retrying."
+			"Auto-apply couldn't submit these applications, and won't try again."
 	default:
 		return fmt.Sprintf("%d updates on jobs you are tracking", count),
 			"An update on your applications",
@@ -383,7 +383,7 @@ var bodies = template.Must(mailtpl.Partials().New("nudge").Parse(`
 
 {{define "auto_apply_failed"}}{{template "job-row" .Job}}
 <div style="height:18px;"></div>
-{{template "p" "Auto-apply couldn't submit this application after retrying."}}
+{{template "p" "Auto-apply couldn't submit this application, and won't try again."}}
 {{template "button" (mailLink .URL .CTA)}}{{end}}
 `))
 
@@ -432,7 +432,7 @@ func (n *EmailNotifier) render(m Message) (subject, htmlBody, textBody string) {
 	case KindAutoApplyFailed:
 		block, head, pre = "auto_apply_failed", "Auto-apply couldn't submit this application", "Auto-apply couldn't submit this application"
 		subject = fmt.Sprintf("Couldn't submit: %s at %s", m.JobTitle, m.Company)
-		textBody = fmt.Sprintf("Auto-apply couldn't submit %s at %s after retrying.\n\nOpen your tracking board: %s\n",
+		textBody = fmt.Sprintf("Auto-apply couldn't submit %s at %s, and won't try again.\n\nOpen your tracking board: %s\n",
 			m.JobTitle, m.Company, trackingURL)
 	default:
 		block, head, pre = "plain", fmt.Sprintf("%s at %s", m.JobTitle, m.Company), "An update on a job you are tracking"

--- a/internal/engage/nudge/transports_test.go
+++ b/internal/engage/nudge/transports_test.go
@@ -82,6 +82,71 @@ func TestEmailNotifier_InterviewPrepBatchLeadsToTheTrackingBoard(t *testing.T) {
 	}
 }
 
+// The three auto-apply outcome kinds are about an application, same as
+// follow-up/interview-prep, so they lead to the tracking board — never
+// /my/activity, unlike job-closed.
+func TestEmailNotifier_AutoApplyOutcomeKinds_SingleAndBatch(t *testing.T) {
+	cases := []struct {
+		kind        string
+		wantSubject string
+	}{
+		{KindAutoApplySubmitted, "Submitted"},
+		{KindAutoApplyBlocked, "Needs your attention"},
+		{KindAutoApplyFailed, "Couldn't submit"},
+	}
+	for _, c := range cases {
+		t.Run(c.kind+"/single", func(t *testing.T) {
+			sender := &captureSender{}
+			n := NewEmailNotifier(sender, "jobs@freehire.me", "https://freehire.me")
+			ms := []Message{{Kind: c.kind, JobTitle: "Go Dev", Company: "Acme", Slug: "go-dev-acme"}}
+			if err := n.Send(context.Background(), "email", "u@x.com", c.kind, ms); err != nil {
+				t.Fatalf("Send: %v", err)
+			}
+			if !strings.Contains(sender.subject, c.wantSubject) {
+				t.Errorf("subject = %q, want it to contain %q", sender.subject, c.wantSubject)
+			}
+			if !strings.Contains(sender.html, "/my/tracking") {
+				t.Errorf("html = %q, want the tracking-board destination", sender.html)
+			}
+		})
+		t.Run(c.kind+"/batch", func(t *testing.T) {
+			sender := &captureSender{}
+			n := NewEmailNotifier(sender, "jobs@freehire.me", "https://freehire.me")
+			if err := n.Send(context.Background(), "email", "u@x.com", c.kind, batchOf(c.kind, 2)); err != nil {
+				t.Fatalf("Send: %v", err)
+			}
+			if !strings.Contains(sender.subject, "2") {
+				t.Errorf("subject = %q, want the batch count", sender.subject)
+			}
+			if !strings.Contains(sender.html, "/my/tracking") {
+				t.Errorf("html = %q, want the tracking-board destination", sender.html)
+			}
+		})
+	}
+}
+
+func TestTelegramNotifier_AutoApplyOutcomeKinds_SingleAndBatch(t *testing.T) {
+	for _, kind := range []string{KindAutoApplySubmitted, KindAutoApplyBlocked, KindAutoApplyFailed} {
+		t.Run(kind+"/single", func(t *testing.T) {
+			n := NewTelegramNotifier(nil, "https://freehire.me")
+			got := n.render(kind, []Message{{Kind: kind, JobTitle: "Go Dev", Company: "Acme", Slug: "go-dev-acme"}})
+			if !strings.Contains(got, "Go Dev") || !strings.Contains(got, "Acme") {
+				t.Errorf("render = %q, want the job title and company", got)
+			}
+			if !strings.Contains(got, "/my/tracking") {
+				t.Errorf("render = %q, want the tracking-board link", got)
+			}
+		})
+		t.Run(kind+"/batch", func(t *testing.T) {
+			n := NewTelegramNotifier(nil, "https://freehire.me")
+			got := n.render(kind, batchOf(kind, 2))
+			if !strings.Contains(got, "<b>2</b>") {
+				t.Errorf("render = %q, want the batch count", got)
+			}
+		})
+	}
+}
+
 func TestTelegramNotifier_InterviewPrepBatchHeadlinesTheCount(t *testing.T) {
 	n := NewTelegramNotifier(nil, "https://freehire.me")
 	got := n.render(KindInterviewPrep, batchOf(KindInterviewPrep, 2))
@@ -97,7 +162,10 @@ func TestTelegramNotifier_InterviewPrepBatchHeadlinesTheCount(t *testing.T) {
 // The mail's button and the bot's tail read one rule, so they cannot point different
 // ways for the same kind.
 func TestBatchDestination_IsOneRuleForBothChannels(t *testing.T) {
-	for _, kind := range []string{KindFollowUp, KindInterviewPrep, KindJobClosed} {
+	for _, kind := range []string{
+		KindFollowUp, KindInterviewPrep, KindJobClosed,
+		KindAutoApplySubmitted, KindAutoApplyBlocked, KindAutoApplyFailed,
+	} {
 		path, _ := batchDestination(kind)
 		tg := NewTelegramNotifier(nil, "https://freehire.me").batchURL(kind)
 		mail, _ := NewEmailNotifier(&captureSender{}, "j@f.me", "https://freehire.me").batchCTA(kind)

--- a/internal/platform/db/nudges.sql.go
+++ b/internal/platform/db/nudges.sql.go
@@ -187,6 +187,7 @@ SELECT q.user_id, q.job_id, q.blocked_at
 FROM auto_apply_queue q
 JOIN notification_settings ns ON ns.user_id = q.user_id AND ns.enabled
 WHERE q.blocked_at IS NOT NULL
+  AND q.failed_at IS NULL
   AND q.blocked_at > now() - make_interval(days => $1::int)
 `
 
@@ -202,6 +203,11 @@ type ListAutoApplyBlockedCandidatesRow struct {
 // any row once it is set) — so this can never re-observe a second, different
 // transition for the same row. Bounded to a recency window on blocked_at for the
 // same first-deploy reason as the other candidate scans.
+//
+// failed_at IS NULL: a row can carry both markers (a lease-timeout race between a
+// park and a fail can land both on the same row — see AutoApplyQueueMetrics'
+// own comment, metrics.sql), and the dead-letter marker wins there, so it wins
+// here too — one nudge per attempt, not two contradictory ones.
 func (q *Queries) ListAutoApplyBlockedCandidates(ctx context.Context, windowDays int32) ([]ListAutoApplyBlockedCandidatesRow, error) {
 	rows, err := q.db.Query(ctx, listAutoApplyBlockedCandidates, windowDays)
 	if err != nil {
@@ -236,9 +242,13 @@ type ListAutoApplyFailedCandidatesRow struct {
 	FailedAt pgtype.Timestamptz `json:"failed_at"`
 }
 
-// Queue entries cmd/auto-apply dead-lettered after exhausting retries. Same
-// write-once guarantee as blocked, via failed_at. Bounded to a recency window on
-// failed_at for the same first-deploy reason as the other candidate scans.
+// Queue entries cmd/auto-apply dead-lettered: attempts exhausted the retry budget,
+// or (Runner.deadLetterImmediately) the very first attempt already made the
+// question moot — an unconfirmed submission or a lost post-submit record are both
+// too risky to retry, not merely tried and failed. Same write-once guarantee as
+// blocked, via failed_at; wins over blocked_at where a row carries both (see
+// ListAutoApplyBlockedCandidates). Bounded to a recency window on failed_at for
+// the same first-deploy reason as the other candidate scans.
 func (q *Queries) ListAutoApplyFailedCandidates(ctx context.Context, windowDays int32) ([]ListAutoApplyFailedCandidatesRow, error) {
 	rows, err := q.db.Query(ctx, listAutoApplyFailedCandidates, windowDays)
 	if err != nil {

--- a/internal/platform/db/nudges.sql.go
+++ b/internal/platform/db/nudges.sql.go
@@ -182,6 +182,127 @@ func (q *Queries) GetNudgeForDelivery(ctx context.Context, id int64) (GetNudgeFo
 	return i, err
 }
 
+const listAutoApplyBlockedCandidates = `-- name: ListAutoApplyBlockedCandidates :many
+SELECT q.user_id, q.job_id, q.blocked_at
+FROM auto_apply_queue q
+JOIN notification_settings ns ON ns.user_id = q.user_id AND ns.enabled
+WHERE q.blocked_at IS NOT NULL
+  AND q.blocked_at > now() - make_interval(days => $1::int)
+`
+
+type ListAutoApplyBlockedCandidatesRow struct {
+	UserID    int64              `json:"user_id"`
+	JobID     int64              `json:"job_id"`
+	BlockedAt pgtype.Timestamptz `json:"blocked_at"`
+}
+
+// Queue entries cmd/auto-apply permanently parked: a required question its
+// unattended pass could not answer. blocked_at is write-once — nothing ever
+// clears or re-sets it for the same row (auto_apply_queue_claimable_idx excludes
+// any row once it is set) — so this can never re-observe a second, different
+// transition for the same row. Bounded to a recency window on blocked_at for the
+// same first-deploy reason as the other candidate scans.
+func (q *Queries) ListAutoApplyBlockedCandidates(ctx context.Context, windowDays int32) ([]ListAutoApplyBlockedCandidatesRow, error) {
+	rows, err := q.db.Query(ctx, listAutoApplyBlockedCandidates, windowDays)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListAutoApplyBlockedCandidatesRow{}
+	for rows.Next() {
+		var i ListAutoApplyBlockedCandidatesRow
+		if err := rows.Scan(&i.UserID, &i.JobID, &i.BlockedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listAutoApplyFailedCandidates = `-- name: ListAutoApplyFailedCandidates :many
+SELECT q.user_id, q.job_id, q.failed_at
+FROM auto_apply_queue q
+JOIN notification_settings ns ON ns.user_id = q.user_id AND ns.enabled
+WHERE q.failed_at IS NOT NULL
+  AND q.failed_at > now() - make_interval(days => $1::int)
+`
+
+type ListAutoApplyFailedCandidatesRow struct {
+	UserID   int64              `json:"user_id"`
+	JobID    int64              `json:"job_id"`
+	FailedAt pgtype.Timestamptz `json:"failed_at"`
+}
+
+// Queue entries cmd/auto-apply dead-lettered after exhausting retries. Same
+// write-once guarantee as blocked, via failed_at. Bounded to a recency window on
+// failed_at for the same first-deploy reason as the other candidate scans.
+func (q *Queries) ListAutoApplyFailedCandidates(ctx context.Context, windowDays int32) ([]ListAutoApplyFailedCandidatesRow, error) {
+	rows, err := q.db.Query(ctx, listAutoApplyFailedCandidates, windowDays)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListAutoApplyFailedCandidatesRow{}
+	for rows.Next() {
+		var i ListAutoApplyFailedCandidatesRow
+		if err := rows.Scan(&i.UserID, &i.JobID, &i.FailedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listAutoApplySubmittedCandidates = `-- name: ListAutoApplySubmittedCandidates :many
+SELECT ev.user_id, ev.job_id, ev.occurred_at
+FROM application_events ev
+JOIN notification_settings ns ON ns.user_id = ev.user_id AND ns.enabled
+WHERE ev.kind = 'applied'
+  AND ev.source = 'auto_apply'
+  AND ev.retracted_at IS NULL
+  AND ev.job_id IS NOT NULL
+  AND ev.occurred_at > now() - make_interval(days => $1::int)
+`
+
+type ListAutoApplySubmittedCandidatesRow struct {
+	UserID     int64              `json:"user_id"`
+	JobID      pgtype.Int8        `json:"job_id"`
+	OccurredAt pgtype.Timestamptz `json:"occurred_at"`
+}
+
+// application_events rows auto-apply itself wrote on a successful, unattended
+// submission (kind='applied', source='auto_apply' — distinct from a candidate's
+// own manual "did you apply?" confirmation, which is source='user'/'assistant').
+// The queue row that drove the submission is deleted in the same transaction that
+// writes this event, so this is the only durable trace to MATCH against. Bounded
+// to a recency window on occurred_at for the same first-deploy reason as the
+// other candidate scans.
+func (q *Queries) ListAutoApplySubmittedCandidates(ctx context.Context, windowDays int32) ([]ListAutoApplySubmittedCandidatesRow, error) {
+	rows, err := q.db.Query(ctx, listAutoApplySubmittedCandidates, windowDays)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListAutoApplySubmittedCandidatesRow{}
+	for rows.Next() {
+		var i ListAutoApplySubmittedCandidatesRow
+		if err := rows.Scan(&i.UserID, &i.JobID, &i.OccurredAt); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listFollowUpCandidates = `-- name: ListFollowUpCandidates :many
 SELECT a.user_id, a.job_id, a.stage,
        GREATEST(a.applied_at, mail.newest_mail_at)::timestamptz AS last_activity_at,

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -2750,10 +2750,19 @@ type Querier interface {
 	// any row once it is set) — so this can never re-observe a second, different
 	// transition for the same row. Bounded to a recency window on blocked_at for the
 	// same first-deploy reason as the other candidate scans.
+	//
+	// failed_at IS NULL: a row can carry both markers (a lease-timeout race between a
+	// park and a fail can land both on the same row — see AutoApplyQueueMetrics'
+	// own comment, metrics.sql), and the dead-letter marker wins there, so it wins
+	// here too — one nudge per attempt, not two contradictory ones.
 	ListAutoApplyBlockedCandidates(ctx context.Context, windowDays int32) ([]ListAutoApplyBlockedCandidatesRow, error)
-	// Queue entries cmd/auto-apply dead-lettered after exhausting retries. Same
-	// write-once guarantee as blocked, via failed_at. Bounded to a recency window on
-	// failed_at for the same first-deploy reason as the other candidate scans.
+	// Queue entries cmd/auto-apply dead-lettered: attempts exhausted the retry budget,
+	// or (Runner.deadLetterImmediately) the very first attempt already made the
+	// question moot — an unconfirmed submission or a lost post-submit record are both
+	// too risky to retry, not merely tried and failed. Same write-once guarantee as
+	// blocked, via failed_at; wins over blocked_at where a row carries both (see
+	// ListAutoApplyBlockedCandidates). Bounded to a recency window on failed_at for
+	// the same first-deploy reason as the other candidate scans.
 	ListAutoApplyFailedCandidates(ctx context.Context, windowDays int32) ([]ListAutoApplyFailedCandidatesRow, error)
 	// application_events rows auto-apply itself wrote on a successful, unattended
 	// submission (kind='applied', source='auto_apply' — distinct from a candidate's

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -2744,6 +2744,25 @@ type Querier interface {
 	// everything, not a trimmed window — see ListRecentAssistantMessages for the bounded
 	// read the model's own history is rebuilt from.
 	ListAssistantMessages(ctx context.Context, sessionID uuid.UUID) ([]AssistantMessage, error)
+	// Queue entries cmd/auto-apply permanently parked: a required question its
+	// unattended pass could not answer. blocked_at is write-once — nothing ever
+	// clears or re-sets it for the same row (auto_apply_queue_claimable_idx excludes
+	// any row once it is set) — so this can never re-observe a second, different
+	// transition for the same row. Bounded to a recency window on blocked_at for the
+	// same first-deploy reason as the other candidate scans.
+	ListAutoApplyBlockedCandidates(ctx context.Context, windowDays int32) ([]ListAutoApplyBlockedCandidatesRow, error)
+	// Queue entries cmd/auto-apply dead-lettered after exhausting retries. Same
+	// write-once guarantee as blocked, via failed_at. Bounded to a recency window on
+	// failed_at for the same first-deploy reason as the other candidate scans.
+	ListAutoApplyFailedCandidates(ctx context.Context, windowDays int32) ([]ListAutoApplyFailedCandidatesRow, error)
+	// application_events rows auto-apply itself wrote on a successful, unattended
+	// submission (kind='applied', source='auto_apply' — distinct from a candidate's
+	// own manual "did you apply?" confirmation, which is source='user'/'assistant').
+	// The queue row that drove the submission is deleted in the same transaction that
+	// writes this event, so this is the only durable trace to MATCH against. Bounded
+	// to a recency window on occurred_at for the same first-deploy reason as the
+	// other candidate scans.
+	ListAutoApplySubmittedCandidates(ctx context.Context, windowDays int32) ([]ListAutoApplySubmittedCandidatesRow, error)
 	// One user's still-unclassified submissions, newest first — the other half of the "my
 	// contributions" list (boards holds the recognized half).
 	ListBoardSubmissionsBySubmitter(ctx context.Context, submittedBy int64) ([]BoardSubmission, error)

--- a/internal/platform/db/queries/nudges.sql
+++ b/internal/platform/db/queries/nudges.sql
@@ -75,16 +75,26 @@ WHERE ev.kind = 'applied'
 -- any row once it is set) — so this can never re-observe a second, different
 -- transition for the same row. Bounded to a recency window on blocked_at for the
 -- same first-deploy reason as the other candidate scans.
+--
+-- failed_at IS NULL: a row can carry both markers (a lease-timeout race between a
+-- park and a fail can land both on the same row — see AutoApplyQueueMetrics'
+-- own comment, metrics.sql), and the dead-letter marker wins there, so it wins
+-- here too — one nudge per attempt, not two contradictory ones.
 SELECT q.user_id, q.job_id, q.blocked_at
 FROM auto_apply_queue q
 JOIN notification_settings ns ON ns.user_id = q.user_id AND ns.enabled
 WHERE q.blocked_at IS NOT NULL
+  AND q.failed_at IS NULL
   AND q.blocked_at > now() - make_interval(days => sqlc.arg(window_days)::int);
 
 -- name: ListAutoApplyFailedCandidates :many
--- Queue entries cmd/auto-apply dead-lettered after exhausting retries. Same
--- write-once guarantee as blocked, via failed_at. Bounded to a recency window on
--- failed_at for the same first-deploy reason as the other candidate scans.
+-- Queue entries cmd/auto-apply dead-lettered: attempts exhausted the retry budget,
+-- or (Runner.deadLetterImmediately) the very first attempt already made the
+-- question moot — an unconfirmed submission or a lost post-submit record are both
+-- too risky to retry, not merely tried and failed. Same write-once guarantee as
+-- blocked, via failed_at; wins over blocked_at where a row carries both (see
+-- ListAutoApplyBlockedCandidates). Bounded to a recency window on failed_at for
+-- the same first-deploy reason as the other candidate scans.
 SELECT q.user_id, q.job_id, q.failed_at
 FROM auto_apply_queue q
 JOIN notification_settings ns ON ns.user_id = q.user_id AND ns.enabled

--- a/internal/platform/db/queries/nudges.sql
+++ b/internal/platform/db/queries/nudges.sql
@@ -51,6 +51,46 @@ WHERE a.applied_at IS NOT NULL
   AND j.closed_at IS NOT NULL
   AND j.closed_at > now() - make_interval(days => sqlc.arg(window_days)::int);
 
+-- name: ListAutoApplySubmittedCandidates :many
+-- application_events rows auto-apply itself wrote on a successful, unattended
+-- submission (kind='applied', source='auto_apply' — distinct from a candidate's
+-- own manual "did you apply?" confirmation, which is source='user'/'assistant').
+-- The queue row that drove the submission is deleted in the same transaction that
+-- writes this event, so this is the only durable trace to MATCH against. Bounded
+-- to a recency window on occurred_at for the same first-deploy reason as the
+-- other candidate scans.
+SELECT ev.user_id, ev.job_id, ev.occurred_at
+FROM application_events ev
+JOIN notification_settings ns ON ns.user_id = ev.user_id AND ns.enabled
+WHERE ev.kind = 'applied'
+  AND ev.source = 'auto_apply'
+  AND ev.retracted_at IS NULL
+  AND ev.job_id IS NOT NULL
+  AND ev.occurred_at > now() - make_interval(days => sqlc.arg(window_days)::int);
+
+-- name: ListAutoApplyBlockedCandidates :many
+-- Queue entries cmd/auto-apply permanently parked: a required question its
+-- unattended pass could not answer. blocked_at is write-once — nothing ever
+-- clears or re-sets it for the same row (auto_apply_queue_claimable_idx excludes
+-- any row once it is set) — so this can never re-observe a second, different
+-- transition for the same row. Bounded to a recency window on blocked_at for the
+-- same first-deploy reason as the other candidate scans.
+SELECT q.user_id, q.job_id, q.blocked_at
+FROM auto_apply_queue q
+JOIN notification_settings ns ON ns.user_id = q.user_id AND ns.enabled
+WHERE q.blocked_at IS NOT NULL
+  AND q.blocked_at > now() - make_interval(days => sqlc.arg(window_days)::int);
+
+-- name: ListAutoApplyFailedCandidates :many
+-- Queue entries cmd/auto-apply dead-lettered after exhausting retries. Same
+-- write-once guarantee as blocked, via failed_at. Bounded to a recency window on
+-- failed_at for the same first-deploy reason as the other candidate scans.
+SELECT q.user_id, q.job_id, q.failed_at
+FROM auto_apply_queue q
+JOIN notification_settings ns ON ns.user_id = q.user_id AND ns.enabled
+WHERE q.failed_at IS NOT NULL
+  AND q.failed_at > now() - make_interval(days => sqlc.arg(window_days)::int);
+
 -- name: RecordNudge :execrows
 -- Record one matched nudge candidate. The unique index on
 -- (user_id, job_id, kind, episode_key) makes this idempotent — re-scanning the

--- a/migrations/0144_application_nudges_auto_apply_kinds.sql
+++ b/migrations/0144_application_nudges_auto_apply_kinds.sql
@@ -1,0 +1,12 @@
+-- Widen application_nudges.kind to add the three auto-apply outcome nudges:
+-- auto_apply_submitted (a queued attempt actually submitted), auto_apply_blocked
+-- (permanently parked on a required question), auto_apply_failed (dead-lettered
+-- after retries). See the add-auto-apply-outcome-notifications change.
+
+ALTER TABLE public.application_nudges DROP CONSTRAINT application_nudges_kind_check;
+
+ALTER TABLE public.application_nudges
+    -- squawk-ignore constraint-missing-not-valid -- application_nudges is a one-shot-nudge ledger, nowhere near jobs-table scale, and migration 0084 widened this same CHECK the same way without NOT VALID, in production, without issue.
+    ADD CONSTRAINT application_nudges_kind_check
+    CHECK (kind IN ('follow_up', 'interview_prep', 'job_closed',
+                     'auto_apply_submitted', 'auto_apply_blocked', 'auto_apply_failed'));

--- a/openspec/changes/add-auto-apply-outcome-notifications/.openspec.yaml
+++ b/openspec/changes/add-auto-apply-outcome-notifications/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/add-auto-apply-outcome-notifications/design.md
+++ b/openspec/changes/add-auto-apply-outcome-notifications/design.md
@@ -211,3 +211,20 @@ inert to every other reader if the code is rolled back (nothing else queries
 ## Open Questions
 
 (none — all decisions above were confirmed during design review)
+
+## Post-implementation fixes (code review)
+
+Two corrections landed after the initial implementation, found by code review
+against code this design didn't originally account for:
+
+- **Blocked/failed are made mutually exclusive.** `AutoApplyQueueMetrics`
+  (`metrics.sql`) already documents that a row can carry both `blocked_at` and
+  `failed_at` (a lease-timeout race between a park and a fail) and that the
+  dead-letter marker wins. `ListAutoApplyBlockedCandidates` now excludes rows
+  where `failed_at IS NOT NULL`, matching that precedent — otherwise the same
+  attempt could be matched as both a blocked and a failed nudge.
+- **The failed-nudge copy no longer says "after retrying".** `failed_at` is also
+  set by `Runner.deadLetterImmediately` (an unconfirmed submission, or a
+  submission that went through but couldn't be durably recorded) — both
+  first-attempt outcomes with zero retries. The copy across all channels now says
+  the attempt "won't try again" instead of asserting a retry happened.

--- a/openspec/changes/add-auto-apply-outcome-notifications/design.md
+++ b/openspec/changes/add-auto-apply-outcome-notifications/design.md
@@ -1,0 +1,213 @@
+## Context
+
+See `proposal.md` for motivation. The constraints that shape this design:
+
+- **Layering forbids a direct call.** `internal/application/autoapply` (block
+  `application`, layer 6) may not import `internal/engage/nudge` (block `engage`,
+  layer 7 — strictly above, per `internal/platform/arch/layering`). A notification
+  triggered from the worker's own write path is therefore not an option; it must be
+  event-sourced — a later pass reads state the worker already persisted, the same
+  shape `internal/engage/nudge` already uses for its three existing kinds.
+- **A successful submission deletes its own queue row.** `cmd/auto-apply/store.go`'s
+  `Submit` (lines 78–101) writes `application_events(kind='applied')` via
+  `MarkJobApplied` and deletes the `auto_apply_queue` row in the same transaction.
+  "Submitted" can only be read from the event afterward, never from the queue table.
+- **`blocked_at`/`failed_at` are write-once and permanently terminal.**
+  `ClaimAutoApplyBatch` and the partial index `auto_apply_queue_claimable_idx`
+  (migration 0116) exclude any row once either column is set, and nothing ever
+  clears or re-sets either for the same row. A scan of `WHERE blocked_at IS NOT
+  NULL` (or `failed_at`) can therefore never observe a second, different transition
+  for the same row.
+- **`internal/engage/nudge` already is the right mechanism.** Three kinds
+  (`follow_up`/`interview_prep`/`job_closed`) already do MATCH-scans-state,
+  DELIVER-over-configured-channels, dedup by `(user, job, kind, episode_key)`, with
+  email/Telegram/push transports and an in-app notification-center record.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Notify the candidate over their configured channels, and record an in-app
+  notification, when an auto-apply attempt ends in submission, a permanent block,
+  or a dead-lettered failure.
+- Reuse `internal/engage/nudge`'s existing dedup, routing, and delivery machinery
+  rather than building anything new.
+- Make "an auto-apply submission" a stated, queryable fact (a dedicated event
+  source) rather than an accidental one.
+
+**Non-Goals:**
+
+- Real-time or sub-30-minute delivery. `cmd/auto-apply` itself only runs every 5
+  minutes, so a same-pass notification was never actually reachable; the existing
+  `freehire-nudge.timer` cadence (30 min) is consistent with the "same-day" tone the
+  rest of `nudge` already sets.
+- Surfacing the internal `last_error`/`SidecarResult.Reason` diagnostic string in
+  the notification body. `internal/application/autoapply/status.go` already draws
+  this line for the in-app drawer; this change does not cross it.
+- Changing `JobDrawer.svelte`'s existing blocked/failed copy, or anything else on
+  the frontend — see the last decision below.
+
+## Decisions
+
+### Three separate nudge kinds, not one combined kind
+
+`auto_apply_submitted`, `auto_apply_blocked`, `auto_apply_failed` stay separate,
+matching the existing one-kind-one-meaning convention (`follow_up` /
+`interview_prep` / `job_closed` are three kinds for three conceptually close but
+distinct events) and the fact that `JobDrawer.svelte` already gives blocked and
+failed distinct copy. The alternative — one combined "auto-apply stopped" kind —
+would need `Message` to carry a reason field and every render function to branch on
+its presence, which is more conditional logic than three more `case`s in each
+existing switch.
+
+### Event-sourced MATCH, not a direct call from the worker
+
+Rejected: having `cmd/auto-apply` call into `nudge` directly when it resolves an
+attempt. Blocked by the block-layering rule above — `application` may not import
+`engage`. This also keeps `nudge` the single owner of dedup/routing/quiet-hours
+logic; `cmd/auto-apply` never needs to know a notification exists.
+
+### `SourceAutoApply` as a new `appevent` source
+
+`cmd/auto-apply/store.go:93` currently passes `appevent.SourceSystem` to
+`MarkJobApplied`. That value is shared with unrelated system writes (e.g.
+`internal/engage/nudge`'s own job-closed auto-expire), so `kind='applied' AND
+source='system'` being unique to auto-apply today is an accidental invariant, not a
+stated contract. Adding `appevent.SourceAutoApply = "auto_apply"` (to the `Sources`
+slice in `internal/application/appevent/appevent.go`, validated by the existing
+Go-side `ValidSource` — `application_events.source` is a plain `text` column with
+no database CHECK constraint, so no migration is needed for this part) turns the
+new MATCH query's `WHERE source = 'auto_apply'` into a real contract instead of a
+coincidence.
+
+### No `notified_at` guard column on `auto_apply_queue`
+
+Considered and rejected: adding a `notified_at timestamptz` column to
+`auto_apply_queue` to mark a blocked/failed row as "already notified". Unnecessary
+because `blocked_at`/`failed_at` are provably write-once for a given row (see
+Context) — the existing `application_nudges` unique index on `(user_id, job_id,
+kind, episode_key)` with `episode_key = blocked_at` (or `failed_at`) already makes
+re-scanning the same row on every MATCH pass a no-op via `ON CONFLICT DO NOTHING`,
+identical to how `ListInterviewPrepCandidates` dedupes today.
+
+### `actionable()` returns unconditionally true for the three new kinds
+
+`follow_up`/`interview_prep`/`job_closed` each re-derive live state in
+`Runner.actionable` because their triggering condition can lapse between MATCH and
+DELIVER (a reply arrives, an interview stage is left, e.g.). None of the three new
+conditions can lapse — an `applied` event, a `blocked_at`, a `failed_at` are all
+permanent once written — so each new case is simply `return true`, gated only by
+the `NotificationsEnabled` check every kind already goes through ahead of the
+switch. `GetNudgeForDelivery` needs no change: it already joins
+`jobs`/`applications`/`notification_settings`/`users` generically off `(user_id,
+job_id)`, independent of kind, and already returns everything a new kind's message
+needs.
+
+### Frontend: zero changes
+
+`RecordNotification`'s `title`/`body` are rendered server-side (`renderNudgeBatch`
+in `push.go`) and stored verbatim on `user_notifications`; `NotificationCard.svelte`
+renders whatever kind it is handed generically from that stored copy, and already
+deep-links to `/my/tracking/[id]` via `public_slug` when a batch names exactly one
+job — true for all three new kinds, since one attempt is always one job. No new
+case, template, or route is needed on the frontend.
+
+## Data model
+
+Migration widens `application_nudges.kind`'s CHECK (`application_nudges_kind_check`,
+currently `follow_up`/`interview_prep`/`job_closed` per migrations 0083/0084) to add
+the three new values. No other migration: `auto_apply_queue` and
+`application_events` need no schema change.
+
+## MATCH queries (new, in `internal/platform/db/queries/nudges.sql`)
+
+```sql
+-- ListAutoApplySubmittedCandidates: application_events rows auto-apply itself
+-- wrote on a successful, unattended submission.
+SELECT ev.user_id, ev.job_id, ev.occurred_at
+FROM application_events ev
+JOIN notification_settings ns ON ns.user_id = ev.user_id AND ns.enabled
+WHERE ev.kind = 'applied'
+  AND ev.source = 'auto_apply'
+  AND ev.retracted_at IS NULL
+  AND ev.job_id IS NOT NULL
+  AND ev.occurred_at > now() - make_interval(days => sqlc.arg(window_days)::int);
+
+-- ListAutoApplyBlockedCandidates: queue entries permanently parked.
+SELECT q.user_id, q.job_id, q.blocked_at
+FROM auto_apply_queue q
+JOIN notification_settings ns ON ns.user_id = q.user_id AND ns.enabled
+WHERE q.blocked_at IS NOT NULL
+  AND q.blocked_at > now() - make_interval(days => sqlc.arg(window_days)::int);
+
+-- ListAutoApplyFailedCandidates: queue entries dead-lettered after retries.
+SELECT q.user_id, q.job_id, q.failed_at
+FROM auto_apply_queue q
+JOIN notification_settings ns ON ns.user_id = q.user_id AND ns.enabled
+WHERE q.failed_at IS NOT NULL
+  AND q.failed_at > now() - make_interval(days => sqlc.arg(window_days)::int);
+```
+
+All three windowed by one new shared `Config.AutoApplyOutcomeWindowDays` field
+(mirrors `FollowUpWindowDays`/`InterviewPrepWindowDays`/`JobClosedWindowDays` —
+guards a first deploy against detonating the historical backlog). `nudge.Store`
+gains the three matching methods; `Runner.match` gains three loops shaped exactly
+like the existing `KindInterviewPrep` loop, each calling `RecordNudge` with
+`EpisodeKey` set to the row's own `occurred_at`/`blocked_at`/`failed_at`.
+
+## Rendering
+
+Three new `case`s, same shape as the existing `KindJobClosed` ones, in:
+
+- `push.go`: `renderNudgeBatch` / `renderNudge` (title/body for push + the in-app
+  notification-center record, which reuses this same rendering).
+- `transports.go`: `batchHeadline`, `renderOne` / `render`, `batchCopy` (Telegram +
+  email). `batchDestination` needs no new case — its existing fallback
+  (`/my/tracking`, "Open your tracking board") is correct: these three kinds are
+  about an application, same as `follow_up`/`interview_prep`, unlike `job_closed`'s
+  override to `/my/activity`.
+
+No `Message` struct field is needed — none of the three kinds carries kind-specific
+display data the way `follow_up`'s `DaysSilent` does.
+
+## Risks / Trade-offs
+
+- **[Risk] A candidate on the free tier who somehow still has a standing
+  `auto_apply_queue` row (e.g. downgraded mid-attempt) gets notified about a
+  feature they can no longer use.** → Mitigation: out of scope for this change —
+  the existing `blocked`/`failed` terminal outcomes already stop retrying
+  regardless of plan tier, and the notification is reporting a fact ("this attempt
+  ended"), not offering the feature again. No different from today's `/my/tracking`
+  page, which shows the same terminal card to a lapsed-Pro user.
+- **[Risk] Latency.** Worst case ~30 minutes from outcome to notification (the
+  `freehire-nudge.timer` cadence). → Mitigation: accepted — see Non-Goals. Matches
+  the tone of the other three kinds today.
+- **[Trade-off] `SourceAutoApply` changes behavior of one existing write path**
+  (`cmd/auto-apply/store.go:93`) rather than being purely additive. → Mitigation:
+  the change is narrowly scoped to one call site's constant argument; nothing reads
+  `appevent.SourceSystem` today expecting auto-apply's `applied` events specifically
+  (confirmed: `SourceSystem` is otherwise only used by `nudge`'s unrelated
+  job-closed auto-expire, which writes `kind='stage_set'`, not `kind='applied'`), so
+  no existing query's result set changes.
+
+## Migration Plan
+
+1. Add migration widening `application_nudges_kind_check`.
+2. Add `appevent.SourceAutoApply`; change `cmd/auto-apply/store.go`'s one call site.
+3. Add the three SQL queries; run `make sqlc`.
+4. Extend `nudge.Store`, `nudge.Config`, `Runner.match`, `Runner.actionable`, and the
+   rendering functions.
+5. Ship as one deploy — no new deploy artifact, no timer change, no feature flag:
+   the next `freehire-nudge.timer` tick after deploy starts matching any
+   already-existing terminal `auto_apply_queue` rows or `applied` events within the
+   new window, which is the intended backfill-free rollout (mirrors how
+   `job_closed` shipped).
+
+Rollback: revert the deploy. The widened CHECK constraint and the new
+`SourceAutoApply` values left in `application_events`/`application_nudges` are
+inert to every other reader if the code is rolled back (nothing else queries
+`source = 'auto_apply'` or the three new kinds).
+
+## Open Questions
+
+(none — all decisions above were confirmed during design review)

--- a/openspec/changes/add-auto-apply-outcome-notifications/proposal.md
+++ b/openspec/changes/add-auto-apply-outcome-notifications/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+`cmd/auto-apply` resolves a queued attempt unattended, on its own 5-minute cron. Today
+the candidate learns the outcome — submitted for real, permanently blocked on a
+required question, or dead-lettered after retries — only by opening `/my/tracking`
+and reading the job's card or drawer; nothing pushes it to them. The job page's own
+auto-apply "queued" banner already promises "you'll get a notification to review it,"
+but no such notification exists yet for any of the three outcomes that end an
+attempt, so the product does not keep that promise today.
+
+## What Changes
+
+- Extend the existing `internal/engage/nudge` lifecycle-notification engine
+  (MATCH-scans-state, DELIVER-over-configured-channels, dedup by
+  `(user, job, kind, episode_key)`) with three new nudge kinds:
+  `auto_apply_submitted`, `auto_apply_blocked`, `auto_apply_failed`. No new
+  notification engine, worker, or timer — these ride the existing
+  `freehire-nudge.timer` (every 30 minutes).
+- Add a new event source, `appevent.SourceAutoApply`, and have
+  `cmd/auto-apply/store.go`'s successful-submission path (`Submit`) write it instead
+  of the shared `appevent.SourceSystem`, so a submitted auto-apply is a distinct,
+  queryable fact rather than an accidental side effect of `kind='applied'` always
+  meaning auto-apply today.
+- Add three MATCH queries: one reading `application_events` for the new source (the
+  submitted case — the queue row is deleted on success, so the event is the only
+  durable trace), two reading `auto_apply_queue.blocked_at`/`failed_at` directly
+  (both permanently terminal once set, so no new "already notified" guard column is
+  needed on that table).
+- Widen `application_nudges.kind`'s CHECK constraint (migration) to accept the three
+  new values.
+- No frontend changes: the in-app notification bell already renders any nudge kind
+  generically from server-rendered title/body, and already deep-links to the
+  specific job when a batch names exactly one (always true here).
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `lifecycle-nudges`: three new one-shot nudge kinds are added alongside the
+  existing follow-up and interview-prep ones — matched from auto-apply's own
+  terminal state (a successful submission, a permanently blocked attempt, or a
+  dead-lettered failure) rather than from application silence or a stage
+  transition, delivered under the same notification-setting gate and one-shot
+  delivery guarantee the existing kinds already have.
+
+## Impact
+
+- `internal/application/appevent`: new `SourceAutoApply` constant.
+- `cmd/auto-apply/store.go`: one call site's `EventSource` argument changes.
+- `internal/engage/nudge`: `Store` interface, `Config`, `Runner.match`,
+  `Runner.actionable`, and the email/Telegram/push rendering functions
+  (`transports.go`, `push.go`) each gain three new cases, mirroring the existing
+  `job_closed` kind's shape.
+- `internal/platform/db/queries/nudges.sql` (+ generated `internal/platform/db`):
+  three new queries.
+- One new migration widening `application_nudges_kind_check`.
+- No API surface change, no frontend change, no new deploy artifact.

--- a/openspec/changes/add-auto-apply-outcome-notifications/specs/lifecycle-nudges/spec.md
+++ b/openspec/changes/add-auto-apply-outcome-notifications/specs/lifecycle-nudges/spec.md
@@ -21,7 +21,9 @@ successfully submitted a real application, and SHALL deliver at most one
 
 The system SHALL identify an auto-apply attempt that has been permanently parked
 because it could not answer a required question unattended, and SHALL deliver at
-most one "blocked" nudge per distinct attempt.
+most one "blocked" nudge per distinct attempt. An attempt that is ALSO
+dead-lettered (see the failed nudge below) SHALL NOT be matched as blocked — the
+two are mutually exclusive for one attempt.
 
 #### Scenario: Auto-apply attempt is blocked on a required question
 
@@ -35,17 +37,33 @@ most one "blocked" nudge per distinct attempt.
   pass
 - **THEN** no additional nudge is scheduled
 
+#### Scenario: An attempt parked and later dead-lettered is not double-nudged
+
+- **WHEN** an unattended auto-apply attempt carries both a parked marker and a
+  dead-letter marker
+- **THEN** only a failed nudge is scheduled for delivery, never a blocked one
+
 ### Requirement: Failed nudge on a dead-lettered auto-apply attempt
 
-The system SHALL identify an auto-apply attempt that has been dead-lettered after
-exhausting its retries, and SHALL deliver at most one "failed" nudge per distinct
-attempt.
+The system SHALL identify an auto-apply attempt that has been dead-lettered —
+whether because it exhausted its retry budget, or because the very first attempt
+was judged too risky to retry (an unconfirmed submission, or a submission that
+went through but could not be durably recorded) — and SHALL deliver at most one
+"failed" nudge per distinct attempt. The nudge's own wording SHALL NOT assert that
+a retry occurred, since a dead letter can be reached on the first attempt.
 
 #### Scenario: Auto-apply exhausts its retries
 
 - **WHEN** an unattended auto-apply attempt is dead-lettered after exhausting its
   retries
 - **THEN** a failed nudge is scheduled for delivery
+
+#### Scenario: Auto-apply dead-letters on the first attempt
+
+- **WHEN** an unattended auto-apply attempt is dead-lettered immediately, with no
+  prior retry (an unconfirmed submission, or a lost post-submit record)
+- **THEN** a failed nudge is scheduled for delivery, worded without claiming a
+  retry took place
 
 #### Scenario: Re-scanning an already-nudged failed attempt does not re-nudge
 

--- a/openspec/changes/add-auto-apply-outcome-notifications/specs/lifecycle-nudges/spec.md
+++ b/openspec/changes/add-auto-apply-outcome-notifications/specs/lifecycle-nudges/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Submitted nudge on a successful auto-apply
+
+The system SHALL identify a job for which an unattended auto-apply attempt has
+successfully submitted a real application, and SHALL deliver at most one
+"submitted" nudge per distinct submission.
+
+#### Scenario: Auto-apply submits an application
+
+- **WHEN** an unattended auto-apply attempt successfully submits a job's
+  application
+- **THEN** a submitted nudge is scheduled for delivery
+
+#### Scenario: Re-scanning the same submission does not re-nudge
+
+- **WHEN** a submission already nudged is found again on a later matching pass
+- **THEN** no additional nudge is scheduled
+
+### Requirement: Blocked nudge on a permanently parked auto-apply attempt
+
+The system SHALL identify an auto-apply attempt that has been permanently parked
+because it could not answer a required question unattended, and SHALL deliver at
+most one "blocked" nudge per distinct attempt.
+
+#### Scenario: Auto-apply attempt is blocked on a required question
+
+- **WHEN** an unattended auto-apply attempt is permanently parked for lacking an
+  answer to a required question
+- **THEN** a blocked nudge is scheduled for delivery
+
+#### Scenario: Re-scanning an already-nudged blocked attempt does not re-nudge
+
+- **WHEN** a blocked attempt already nudged is found again on a later matching
+  pass
+- **THEN** no additional nudge is scheduled
+
+### Requirement: Failed nudge on a dead-lettered auto-apply attempt
+
+The system SHALL identify an auto-apply attempt that has been dead-lettered after
+exhausting its retries, and SHALL deliver at most one "failed" nudge per distinct
+attempt.
+
+#### Scenario: Auto-apply exhausts its retries
+
+- **WHEN** an unattended auto-apply attempt is dead-lettered after exhausting its
+  retries
+- **THEN** a failed nudge is scheduled for delivery
+
+#### Scenario: Re-scanning an already-nudged failed attempt does not re-nudge
+
+- **WHEN** a failed attempt already nudged is found again on a later matching
+  pass
+- **THEN** no additional nudge is scheduled
+
+### Requirement: Auto-apply outcome nudges gated by the shared notification setting
+
+The submitted, blocked, and failed nudges SHALL only be matched and delivered for
+users whose shared notification-settings rule is enabled, over the channels that
+rule configures — the same gate the existing follow-up and interview-prep nudges
+honor.
+
+#### Scenario: Notifications disabled
+
+- **WHEN** a user's notification setting is disabled
+- **THEN** no submitted, blocked, or failed auto-apply nudge is matched or
+  delivered for that user
+
+### Requirement: Auto-apply outcome nudges are never cancelled by the pre-delivery re-check
+
+Unlike the follow-up and interview-prep nudges, whose triggering condition can
+lapse between matching and delivery, a matched submitted, blocked, or failed
+nudge's triggering condition SHALL be treated as permanent: the system SHALL NOT
+cancel it at delivery time.
+
+#### Scenario: Time passes between matching and delivery
+
+- **WHEN** a submitted, blocked, or failed nudge was matched, and delivery is
+  attempted afterward
+- **THEN** the nudge is delivered (subject only to the notification-setting gate
+  above), never cancelled for its triggering condition having lapsed

--- a/openspec/changes/add-auto-apply-outcome-notifications/tasks.md
+++ b/openspec/changes/add-auto-apply-outcome-notifications/tasks.md
@@ -1,0 +1,45 @@
+## 1. Event source and the submitted signal
+
+- [x] 1.1 Add `SourceAutoApply = "auto_apply"` to `internal/application/appevent/appevent.go`, including it in the `Sources` slice.
+- [x] 1.2 Change `cmd/auto-apply/store.go`'s `Submit`'s `MarkJobApplied` call to pass `EventSource: appevent.SourceAutoApply` instead of `appevent.SourceSystem`.
+- [x] 1.3 Update/add a `cmd/auto-apply` test asserting `Submit` writes the `applied` event with `source = 'auto_apply'`.
+
+## 2. Migration
+
+- [x] 2.1 Add migration `0144_application_nudges_auto_apply_kinds.sql` widening `application_nudges_kind_check` to add `auto_apply_submitted`, `auto_apply_blocked`, `auto_apply_failed`.
+- [x] 2.2 Run `pnpm check:sql` (squawk) over the new migration.
+
+## 3. MATCH queries
+
+- [x] 3.1 Add `ListAutoApplySubmittedCandidates` to `internal/platform/db/queries/nudges.sql` (application_events, `kind='applied' AND source='auto_apply'`, windowed on `occurred_at`).
+- [x] 3.2 Add `ListAutoApplyBlockedCandidates` (auto_apply_queue, `blocked_at IS NOT NULL`, windowed on `blocked_at`).
+- [x] 3.3 Add `ListAutoApplyFailedCandidates` (auto_apply_queue, `failed_at IS NOT NULL`, windowed on `failed_at`).
+- [x] 3.4 Run `make sqlc` and commit the generated `internal/platform/db` diff.
+
+## 4. Engine wiring (`internal/engage/nudge`)
+
+- [x] 4.1 Add `KindAutoApplySubmitted`, `KindAutoApplyBlocked`, `KindAutoApplyFailed` constants in `nudge.go`.
+- [x] 4.2 Add the three new methods to the `Store` interface; add `AutoApplyOutcomeWindowDays` to `Config` and `DefaultConfig`.
+- [x] 4.3 Add three MATCH loops in `Runner.match`, mirroring the existing `KindInterviewPrep` loop shape, each calling `RecordNudge` with `EpisodeKey` set to the row's own `occurred_at`/`blocked_at`/`failed_at`.
+- [x] 4.4 Add the three new cases to `Runner.actionable`, each returning `true` unconditionally (the `NotificationsEnabled` gate ahead of the switch already applies).
+- [x] 4.5 Confirm `GetNudgeForDelivery` needs no change (verify by reading it against the new kinds' needs — title/company/slug/url/channels/quiet-hours are already generic).
+
+## 5. Rendering
+
+- [x] 5.1 Add the three new cases to `push.go`'s `renderNudgeBatch` and `renderNudge` (title/body copy).
+- [x] 5.2 Add the three new cases to `transports.go`'s `batchHeadline`, `renderOne`/`render` (Telegram + email single/batch bodies), and `batchCopy` (email subject/heading/preheader/lead).
+- [x] 5.3 Confirm `batchDestination` needs no new case (falls through to the existing `/my/tracking` default).
+
+## 6. Tests
+
+- [x] 6.1 `nudge_test.go`: table-driven `actionable()` cases for the three new kinds — true regardless of job/application state, false when `NotificationsEnabled` is false.
+- [x] 6.2 `transports_test.go`: one rendering case per new kind, single- and multi-job batch.
+- [x] 6.3 `push_test.go`: one rendering case per new kind, single- and multi-job batch.
+- [x] 6.4 `internal/platform/db` integration test (mirroring `notification_center_integration_test.go`'s pattern): each new `List*Candidates` query returns the right rows and excludes the wrong ones (e.g. `source='user'` excluded from `ListAutoApplySubmittedCandidates`; an unset `blocked_at`/`failed_at` row excluded from the other two).
+- [x] 6.5 `internal/platform/db` integration test: `RecordNudge`'s `ON CONFLICT DO NOTHING` is idempotent across two MATCH passes over the same row for each of the three new kinds.
+
+## 7. Verification
+
+- [x] 7.1 `gofmt -l .`, `go vet ./...`, `go test ./...`.
+- [x] 7.2 `go vet -tags=integration ./...`; run the full tagged suite for `internal/engage/nudge`, `internal/platform/db`, and `cmd/auto-apply`.
+- [x] 7.3 `golangci-lint run`.

--- a/openspec/changes/add-auto-apply-outcome-notifications/tasks.md
+++ b/openspec/changes/add-auto-apply-outcome-notifications/tasks.md
@@ -43,3 +43,9 @@
 - [x] 7.1 `gofmt -l .`, `go vet ./...`, `go test ./...`.
 - [x] 7.2 `go vet -tags=integration ./...`; run the full tagged suite for `internal/engage/nudge`, `internal/platform/db`, and `cmd/auto-apply`.
 - [x] 7.3 `golangci-lint run`.
+
+## 8. Code-review fixes
+
+- [x] 8.1 Make `ListAutoApplyBlockedCandidates` exclude rows where `failed_at IS NOT NULL` (dead-letter wins over blocked, matching `AutoApplyQueueMetrics`'s own precedent) — add a regression integration test for a row carrying both markers.
+- [x] 8.2 Fix `KindAutoApplyFailed` copy (`push.go`, `transports.go`) to not assert "after retrying" — `Runner.deadLetterImmediately` can set `failed_at` on the first attempt.
+- [x] 8.3 Add the three new nudge kinds to `web/src/lib/types.ts`'s `NotificationKind`, `NotificationCard.svelte`'s `KIND_ICON`, and `notificationTarget.ts` (route to the tracking board, matching the Go-side channels) — the original claim that "no frontend changes are needed" was wrong; `KIND_ICON` is a `Record<NotificationKind, ...>` so a missing entry breaks the notification bell's icon render for these kinds.

--- a/web/src/lib/components/NotificationCard.svelte
+++ b/web/src/lib/components/NotificationCard.svelte
@@ -1,6 +1,17 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
-  import { Search, Clock, Target, Archive, MessageCircle, FileText, Bell } from '@lucide/svelte';
+  import {
+    Search,
+    Clock,
+    Target,
+    Archive,
+    MessageCircle,
+    FileText,
+    Bell,
+    CheckCircle2,
+    AlertTriangle,
+    XCircle,
+  } from '@lucide/svelte';
   import { notificationCenter } from '$lib/notificationCenter.svelte';
   import { notificationTarget } from '$lib/notificationTarget';
   import { timeAgo } from '$lib/utils';
@@ -22,6 +33,9 @@
     nudge_follow_up: MessageCircle,
     nudge_interview_prep: Target,
     nudge_job_closed: Archive,
+    nudge_auto_apply_submitted: CheckCircle2,
+    nudge_auto_apply_blocked: AlertTriangle,
+    nudge_auto_apply_failed: XCircle,
     auto_apply_tailor_ready: FileText,
     auto_apply_ready_for_review: FileText,
   };

--- a/web/src/lib/notificationTarget.test.ts
+++ b/web/src/lib/notificationTarget.test.ts
@@ -54,6 +54,16 @@ describe('notificationTarget', () => {
     });
   });
 
+  // The three auto-apply outcome kinds follow the same rule as follow-up/interview-prep:
+  // the Go side (transports.go/push.go) points all three at the tracking board, never a
+  // per-job deep link, so web must agree.
+  it.each(['nudge_auto_apply_submitted', 'nudge_auto_apply_blocked', 'nudge_auto_apply_failed'] as const)(
+    'sends a %s nudge to the tracking board, not the job',
+    (kind) => {
+      expect(notificationTarget({ kind, public_slug: 'acme-go-engineer' })).toEqual({ kind: 'tracking' });
+    },
+  );
+
   // A nudge always carries a slug in practice, but the function is slug-first: no
   // slug means nothing to open, even for a kind that would otherwise route to the
   // tracking board.

--- a/web/src/lib/notificationTarget.ts
+++ b/web/src/lib/notificationTarget.ts
@@ -14,7 +14,10 @@ export type NotificationTarget =
 /** A card with no `public_slug` and no `jobs` snapshot has nothing to open.
  *  `nudge_follow_up`/`nudge_interview_prep` point at the tracking board on web —
  *  matching the existing Telegram/email link target for those two kinds — even
- *  though the row itself always carries a slug. `auto_apply_tailor_ready` points
+ *  though the row itself always carries a slug. The three auto-apply outcome
+ *  kinds (`nudge_auto_apply_submitted`/`blocked`/`failed`) follow the same rule,
+ *  for the same reason: internal/engage/nudge's transports.go/push.go point all
+ *  three at the tracking board too, never a per-job deep link. `auto_apply_tailor_ready` points
  *  at the tailoring workspace, not the job page — `/tailor/[slug]` idempotently
  *  resolves the same tailored CV a fresh tailoring bootstrap would (see
  *  openspec/changes/auto-apply-tailored-resume), so no CV id needs to travel with
@@ -29,7 +32,13 @@ export function notificationTarget(
   item: Pick<NotificationItem, 'kind' | 'public_slug'> & Partial<Pick<NotificationItem, 'id' | 'jobs'>>,
 ): NotificationTarget {
   if (item.public_slug) {
-    if (item.kind === 'nudge_follow_up' || item.kind === 'nudge_interview_prep') {
+    if (
+      item.kind === 'nudge_follow_up' ||
+      item.kind === 'nudge_interview_prep' ||
+      item.kind === 'nudge_auto_apply_submitted' ||
+      item.kind === 'nudge_auto_apply_blocked' ||
+      item.kind === 'nudge_auto_apply_failed'
+    ) {
       return { kind: 'tracking' };
     }
     if (item.kind === 'auto_apply_tailor_ready') {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -783,6 +783,9 @@ export type NotificationKind =
   | 'nudge_follow_up'
   | 'nudge_interview_prep'
   | 'nudge_job_closed'
+  | 'nudge_auto_apply_submitted'
+  | 'nudge_auto_apply_blocked'
+  | 'nudge_auto_apply_failed'
   | 'auto_apply_tailor_ready'
   | 'auto_apply_ready_for_review';
 


### PR DESCRIPTION
## Summary
- Extends `internal/engage/nudge` (the existing lifecycle-notification engine — MATCH/DELIVER, dedup ledger, email/Telegram/push + in-app notification) with three new kinds: `auto_apply_submitted`, `auto_apply_blocked`, `auto_apply_failed` — no new engine, worker, or timer.
- Adds `appevent.SourceAutoApply` so a successful auto-apply submission's `applied` event is a stated, queryable fact (`cmd/auto-apply/store.go`'s `Submit` now writes it) instead of an accidental pairing with the shared `SourceSystem`.
- New migration widening `application_nudges.kind`'s CHECK constraint.
- No frontend changes — the notification bell already renders any kind generically from server-rendered copy and deep-links to the job when a batch names exactly one.
- Full proposal/design/spec-deltas/tasks in `openspec/changes/add-auto-apply-outcome-notifications/` (spec-driven-tdd workflow, all 25 tasks complete).

## Test plan
- [x] `gofmt -l .` clean
- [x] `go vet ./...` / `go test ./...` — whole module green
- [x] `go vet -tags=integration ./...` clean
- [x] `go test -tags=integration ./internal/engage/nudge/... ./internal/platform/db/... ./cmd/auto-apply/...` — green (real Postgres via testcontainers)
- [x] `golangci-lint run --new-from-merge-base=origin/main` — 0 new issues
- [x] `pnpm check:sql` (squawk) on the new migration — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added eligibility checks before auto-apply attempts, including work authorization and location/work-mode requirements.
  * Added an optional browser-based application fallback for fully resolved Ashby and Workable applications, with confirmation and spending safeguards.
  * Added notifications for auto-apply submissions, blocked attempts, and failures across push, email, and Telegram.
* **Bug Fixes**
  * Auto-apply submissions are now correctly recorded and attributed for outcome tracking.
  * Unresolved residency and geography questions are no longer automatically drafted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->