### PR TITLE
Record browser-use run cost even when Wait fails mid-flight

### DIFF
--- a/internal/api/atsapply/browseruse_fill.go
+++ b/internal/api/atsapply/browseruse_fill.go
@@ -272,6 +272,7 @@ func (e *BrowserUseExecutor) submit(ctx context.Context, plan Plan, merged []Mer
 		// (RunOptions.CallTimeout) is the far more likely trigger in practice than this
 		// executor's own longer internal timeout, since the outer context cancels first.
 		log.Printf("atsapply: browser-use run %s errored mid-flight, treating as unconfirmed: %v", runID, err)
+		e.recordSpendBestEffort(runID)
 		return autoapply.SidecarResult{Status: autoapply.StatusUnconfirmed}, true, nil
 	}
 	e.spend.record(res.TotalCostUSD)
@@ -294,4 +295,25 @@ func (e *BrowserUseExecutor) submit(ctx context.Context, plan Plan, merged []Mer
 	default:
 		return autoapply.SidecarResult{Status: autoapply.StatusUnconfirmed}, true, nil
 	}
+}
+
+// recordSpendBestEffort fetches and records a run's cost after Wait itself failed to
+// return one — CreateRun already started billable work, so that cost must not simply
+// vanish from the guard's running total. Found by code review alongside the mid-flight
+// Wait-failure case just above: before this existed, a run that errored out of Wait spent
+// real money that this executor's own spend guard never learned about. Uses a context of
+// its own rather than the one Wait failed on: that one is very likely already dead (an
+// expired call-timeout is the common reason Wait fails at all), and this read is worth a
+// short, separate budget of its own. Best-effort: a failure here is logged and swallowed
+// rather than propagated, since the run's outcome (StatusUnconfirmed) is already decided
+// and does not depend on knowing its cost.
+func (e *BrowserUseExecutor) recordSpendBestEffort(runID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	res, err := e.client.GetResult(ctx, runID)
+	if err != nil {
+		log.Printf("atsapply: browser-use could not fetch cost for run %s after a wait failure: %v", runID, err)
+		return
+	}
+	e.spend.record(res.TotalCostUSD)
 }

--- a/internal/api/atsapply/browseruse_submit_test.go
+++ b/internal/api/atsapply/browseruse_submit_test.go
@@ -128,9 +128,14 @@ func TestSubmit_BrowserUseFallback_ShadowModeNeverCallsBrowserUse(t *testing.T) 
 // not an ordinary retryable error, exactly like an unconfirmed chromedp submission. The
 // caller's own context deadline (RunOptions.CallTimeout) is the realistic trigger in
 // production, since it is shorter than this executor's own internal Wait timeout.
+//
+// It must also not let the run's cost vanish from the spend guard: CreateRun already
+// started billable work, so the executor separately fetches the run's cost-so-far
+// (recordSpendBestEffort) once Wait itself has given up — the /runs/run-1 handler below is
+// that read, distinct from the /runs/run-1/status poll Wait itself fails on.
 func TestSubmit_BrowserUseFallback_ARunThatErrorsMidFlightIsUnconfirmedNotRetryable(t *testing.T) {
 	t.Setenv("AUTO_APPLY_BROWSERUSE_ENFORCE", "1")
-	calls := 0
+	calls, resultCalls := 0, 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/runs":
@@ -141,14 +146,21 @@ func TestSubmit_BrowserUseFallback_ARunThatErrorsMidFlightIsUnconfirmedNotRetrya
 			// status poll itself now fails (a transport hiccup, or the caller's own
 			// context deadline firing, which Wait surfaces the same way).
 			w.WriteHeader(http.StatusInternalServerError)
+		case r.URL.Path == "/runs/run-1":
+			// recordSpendBestEffort's own read, made with a fresh context after Wait has
+			// already failed — the run is still genuinely in flight from the API's own
+			// point of view, cost included.
+			resultCalls++
+			_, _ = w.Write([]byte(`{"id":"run-1","status":"running","totalCostUsd":"0.05"}`))
 		default:
 			t.Fatalf("unexpected browser-use request: %s %s", r.Method, r.URL.Path)
 		}
 	}))
 	t.Cleanup(srv.Close)
 
+	executor := newTestBrowserUseExecutor(srv.URL)
 	c := (&Client{fetchers: map[string]applyform.Fetcher{"ashby": fakeAshbyFetcher{}}}).
-		WithBrowserUse(newTestBrowserUseExecutor(srv.URL))
+		WithBrowserUse(executor)
 
 	result, err := c.Submit(context.Background(), autoapply.Claimed{Provider: "ashby"}, map[string]string{"email": "ada@example.com"})
 	if err != nil {
@@ -159,6 +171,12 @@ func TestSubmit_BrowserUseFallback_ARunThatErrorsMidFlightIsUnconfirmedNotRetrya
 	}
 	if calls != 1 {
 		t.Errorf("browser-use run-creation calls = %d, want exactly 1", calls)
+	}
+	if resultCalls != 1 {
+		t.Errorf("browser-use result-fetch calls = %d, want exactly 1 — the run's cost must still be looked up after Wait fails", resultCalls)
+	}
+	if executor.spend.spentUSD != 0.05 {
+		t.Errorf("spend.spentUSD = %v, want 0.05 — the run's cost must reach the spend guard even though Wait itself failed", executor.spend.spentUSD)
 	}
 }
 


### PR DESCRIPTION
## Summary
- The mid-flight `Wait` failure path already maps to `StatusUnconfirmed` rather than an ordinary retryable error (an earlier fix, already on main) — the run may already be interacting with or have submitted the live employer form, so this package never risks a second real submission.
- That path still silently dropped the run's cost from the spend guard, though: `CreateRun` already started billable work, but `e.spend.record` only ran after a successful `Wait`. Added `recordSpendBestEffort`, which fetches the run's cost-so-far with a fresh, short-lived context (the one `Wait` failed on is very likely already dead) once `Wait` has given up, and records it best-effort.
- Extended the existing `TestSubmit_BrowserUseFallback_ARunThatErrorsMidFlightIsUnconfirmedNotRetryable` test to cover this: the fake server now also answers the follow-up `GetResult` read, and the test asserts the cost actually reached the spend guard.

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` — all passing