### PR TITLE
Wait for the CV's background parse instead of asking once, too early

### DIFF
--- a/web/src/lib/components/onboarding/ConfirmStep.svelte
+++ b/web/src/lib/components/onboarding/ConfirmStep.svelte
@@ -15,6 +15,7 @@
   import SeniorityPills from '$lib/components/profile/SeniorityPills.svelte';
   import { MAX_SPECIALIZATIONS } from '$lib/profileLimits';
   import ProfileLinksFields from './ProfileLinksFields.svelte';
+  import type { CvParseState } from '$lib/onboardingResumeWait';
   import type { ProfileLinks } from '$lib/profileLinks';
 
   interface Props {
@@ -24,6 +25,9 @@
     /** True when at least one link arrived from the CV or the LinkedIn import rather than
      *  being typed here — the only reason to explain where the text came from. */
     linksPrefilled: boolean;
+    /** Where the CV's background parse has got to. Passed straight through to the link
+     *  fields, since those are the boxes that parse fills. */
+    cvParse: CvParseState;
     onSpecializationsChange: (next: string[]) => void;
     onSenioritiesChange: (next: string[]) => void;
     onLinksChange: (next: ProfileLinks) => void;
@@ -34,6 +38,7 @@
     seniorities,
     links,
     linksPrefilled,
+    cvParse,
     onSpecializationsChange,
     onSenioritiesChange,
     onLinksChange,
@@ -176,5 +181,5 @@
 <SeniorityPills selected={seniorities} onToggle={toggleSeniority} />
 
 <div class="mt-6">
-  <ProfileLinksFields value={links} onChange={onLinksChange} prefilled={linksPrefilled} />
+  <ProfileLinksFields value={links} onChange={onLinksChange} prefilled={linksPrefilled} {cvParse} />
 </div>

--- a/web/src/lib/components/onboarding/CvStep.svelte
+++ b/web/src/lib/components/onboarding/CvStep.svelte
@@ -30,9 +30,17 @@
      *  the extract endpoint returns facets only, and the links a résumé carries reach the
      *  wizard through GET /me/resume instead. */
     onLinkedInUrl: (url: string) => void;
+    /** A CV has just been stored, so its background parse has just started. Fired from here
+     *  rather than from the wizard's Continue because the two are seconds apart, and those
+     *  are seconds of a wait the candidate would otherwise spend on the next step for
+     *  nothing. */
+    onCvUploaded: () => void;
+    /** Leave this step for the next one, saving it the way Continue would. */
+    onAdvance: () => void;
   }
 
-  let { staged, onExtracted, onDerivedLocation, onLinkedInUrl }: Props = $props();
+  let { staged, onExtracted, onDerivedLocation, onLinkedInUrl, onCvUploaded, onAdvance }: Props =
+    $props();
 
   let cvState = $state<'idle' | 'parsing' | 'error'>('idle');
   let cvError = $state<string | null>(null);
@@ -62,6 +70,18 @@
     return 'Filled in what we found — review on the next step.';
   }
 
+  // Whether an import should carry the candidate onward by itself. It should when the note it
+  // would leave behind says nothing they need to act on: "review on the next step" is a
+  // promise best kept by going there, and staying put after a successful import reads as the
+  // upload not having registered.
+  //
+  // The two notes that DO say something — an import that recognised nothing, and one whose
+  // roles the specialization cap trimmed — keep the candidate here to read them. Both are
+  // about this step, and neither survives the screen it was written for.
+  function shouldAdvanceAfter(merged: MergedFacets): boolean {
+    return merged.resolved && merged.specializationsDropped === 0;
+  }
+
   async function onCvFile(e: Event) {
     const input = e.target as HTMLInputElement;
     const file = input.files?.[0];
@@ -79,10 +99,15 @@
       // next steps.
       resumeStore.noteUpload();
       if (gen !== cvGen) return; // superseded by another pick or a page reset
+      // The CV is stored by now, so its structured parse is already running server-side.
+      // Telling the wizard here rather than on Continue is what gives that parse the seconds
+      // it needs before the links step asks for its result.
+      onCvUploaded();
       const merged = mergeFacets(staged, cv);
       onExtracted(merged);
       cvState = 'idle';
       cvNote = importNote(merged, 'that CV');
+      if (shouldAdvanceAfter(merged)) onAdvance();
     } catch (err) {
       track('cv_upload', {
         ok: false,
@@ -122,6 +147,10 @@
       onLinkedInUrl(url);
       liState = 'idle';
       liNote = importNote(merged, 'that profile');
+      // The same rule as the upload above, deliberately: the two entry points are co-equal
+      // and leave the same note, so one of them moving on while the other sits still would
+      // make that one sentence mean two different things.
+      if (shouldAdvanceAfter(merged)) onAdvance();
     } catch (err) {
       track('linkedin_import', { ok: false, origin: 'onboarding_gate' });
       if (gen !== liGen) return;

--- a/web/src/lib/components/onboarding/ProfileLinksFields.svelte
+++ b/web/src/lib/components/onboarding/ProfileLinksFields.svelte
@@ -8,6 +8,7 @@
   //
   // A link the classifier did not recognise is neither shown nor lost: it rides along in
   // `other` and is written back untouched.
+  import type { CvParseState } from '$lib/onboardingResumeWait';
   import type { ProfileLinks } from '$lib/profileLinks';
 
   interface Props {
@@ -16,15 +17,27 @@
     /** True when at least one of the two arrived from the CV rather than being typed, which
      *  is the only reason to explain where the text came from. */
     prefilled: boolean;
+    /** Where the CV's background parse has got to. These two boxes are the only place in the
+     *  wizard where that parse is visible as an absence, so they are where it is explained:
+     *  an empty box under a CV still being read means something different from an empty box
+     *  under a CV we could not read, and both differ from a CV that simply listed no links. */
+    cvParse: CvParseState;
   }
 
-  let { value, onChange, prefilled }: Props = $props();
+  let { value, onChange, prefilled, cvParse }: Props = $props();
 </script>
 
 <div class="mb-2 flex min-h-6 items-center justify-between gap-2">
   <span class="text-sm font-medium">Profile links</span>
-  {#if prefilled}
+  <!-- One slot, and the states are ordered by what the candidate can act on. A link already
+       found needs no caveat about the parse it came from; a failed parse is worth saying even
+       once something has been found, because the rest of it is not coming. -->
+  {#if cvParse === 'failed'}
+    <span class="text-xs text-muted-foreground">Couldn't read your CV — add them here</span>
+  {:else if prefilled}
     <span class="text-xs text-muted-foreground">Found on your CV</span>
+  {:else if cvParse === 'waiting'}
+    <span class="text-xs text-muted-foreground">Still reading your CV…</span>
   {/if}
 </div>
 <div class="flex flex-col gap-2">

--- a/web/src/lib/onboardingResumeWait.test.ts
+++ b/web/src/lib/onboardingResumeWait.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { nextResumePollDelayMs, RESUME_POLL_BUDGET_MS } from './onboardingResumeWait';
+
+describe('nextResumePollDelayMs', () => {
+  it('starts under a second, so a parse that lands quickly is picked up on the next step', () => {
+    expect(nextResumePollDelayMs(0)).toBeLessThan(1000);
+  });
+
+  it('never goes backwards, so the reads spread out rather than bunching up', () => {
+    let previous = 0;
+    for (let attempt = 0; ; attempt++) {
+      const delay = nextResumePollDelayMs(attempt);
+      if (delay === null) break;
+      expect(delay).toBeGreaterThanOrEqual(previous);
+      previous = delay;
+    }
+  });
+
+  it('gives up, so a parse that never lands cannot poll for as long as the tab is open', () => {
+    // The table's own length is what bounds this; the loop finds it rather than restating it.
+    let attempt = 0;
+    while (nextResumePollDelayMs(attempt) !== null) {
+      attempt++;
+      expect(attempt).toBeLessThan(1000); // a table that never ends would hang the test, not fail it
+    }
+    expect(attempt).toBeGreaterThan(0);
+  });
+
+  it('waits about a minute in total — long enough to outlast the wizard, short of forever', () => {
+    expect(RESUME_POLL_BUDGET_MS).toBeGreaterThan(30_000);
+    expect(RESUME_POLL_BUDGET_MS).toBeLessThan(180_000);
+  });
+
+  it('reports the same budget the table adds up to', () => {
+    let total = 0;
+    for (let attempt = 0; ; attempt++) {
+      const delay = nextResumePollDelayMs(attempt);
+      if (delay === null) break;
+      total += delay;
+    }
+    expect(total).toBe(RESUME_POLL_BUDGET_MS);
+  });
+});

--- a/web/src/lib/onboardingResumeWait.ts
+++ b/web/src/lib/onboardingResumeWait.ts
@@ -1,0 +1,41 @@
+// How long the onboarding wizard keeps asking whether the background CV parse has landed.
+//
+// A CV upload answers immediately with the dictionary-derived facets — skills, categories,
+// seniority, no model involved. Everything the MODEL reads out of the same file, the profile
+// links and the total years among it, is written afterwards by a background job that takes
+// seconds. The wizard used to read the résumé back exactly once, the instant the CV step was
+// left, which is reliably BEFORE that job has finished: the links step therefore opened empty
+// for everybody, and the "review on the next step" the CV step promises was never kept.
+//
+// Waiting is a policy, not a mechanism, so it lives here on its own — a table that can be
+// read, tested and argued about without opening the wizard.
+//
+// The shape is a short head and a flat tail. The head is tight because a parse that is going
+// to be quick is quick, and the candidate is looking at the very next step within a second or
+// two. The tail is flat and long because they have six more steps to walk through, and a link
+// that arrives while they are on the salary step still reaches the box it belongs in — the
+// fill only ever touches a box they have not typed in themselves.
+
+/** What the wizard currently knows about the background CV parse.
+ *
+ *  'idle' covers three situations the candidate cannot tell apart and does not need to: no
+ *  CV, a parse that landed, and a parse still running after the wizard stopped waiting. Only
+ *  'failed' is a thing we owe them an explanation for. */
+export type CvParseState = 'idle' | 'waiting' | 'failed';
+
+/** The waits, in order, between one read of `GET /me/resume` and the next. */
+const DELAYS_MS = [800, 1200, 2000, 3000, 5000, 8000, 8000, 8000, 8000, 8000, 8000, 8000];
+
+/** The wait before poll number `attempt` (0-based), or null when the wizard should stop
+ *  asking.
+ *
+ *  Giving up is not the same as failing. The résumé goes on being parsed server-side and its
+ *  links are there on the candidate's next visit; the wizard has simply stopped holding the
+ *  door open for a run that is taking longer than the wizard itself lasts. */
+export function nextResumePollDelayMs(attempt: number): number | null {
+  return DELAYS_MS[attempt] ?? null;
+}
+
+/** The whole wait, so the comment above, the test, and anyone tuning the table read one
+ *  number rather than adding the array up by hand. */
+export const RESUME_POLL_BUDGET_MS = DELAYS_MS.reduce((total, ms) => total + ms, 0);

--- a/web/src/routes/onboarding/+page.svelte
+++ b/web/src/routes/onboarding/+page.svelte
@@ -16,12 +16,14 @@
   // to the store that already owns its fact — the search profile, the screening answers,
   // the candidate-owned résumé overlay, the survey — so a failure in one cannot corrupt
   // another, and no store here exists only to serve this page.
+  import { onDestroy } from 'svelte';
   import { goto } from '$app/navigation';
   import { page } from '$app/state';
   import { ArrowLeft, ArrowRight, LoaderCircle, X } from '@lucide/svelte';
   import { api, ApiError } from '$lib/api';
   import { completeOnboarding, isAuthenticated } from '$lib/auth.svelte';
   import { onboardingGate } from '$lib/onboardingGate.svelte';
+  import { nextResumePollDelayMs, type CvParseState } from '$lib/onboardingResumeWait';
   import { ORDERED_STEPS, plannedSteps, type OnboardingAnswered, type StepKind } from '$lib/onboardingSteps';
   import { persistStep, type SaveDeps, type WizardAnswers } from '$lib/onboardingSave';
   import { splitProfileLinks, type ProfileLinks } from '$lib/profileLinks';
@@ -29,7 +31,7 @@
   import { safeRedirect } from '$lib/safeRedirect';
   import { signinUrl } from '$lib/signin';
   import { focusTrap } from '$lib/actions/focusTrap';
-  import type { CandidateContacts, DerivedLocation, LocationPreferences } from '$lib/types';
+  import type { CandidateContacts, DerivedLocation, LocationPreferences, ResumeMeta } from '$lib/types';
   import type { MergedFacets } from '$lib/onboardingImport';
   import ChallengeStep from '$lib/components/onboarding/ChallengeStep.svelte';
   import ConfirmStep from '$lib/components/onboarding/ConfirmStep.svelte';
@@ -230,11 +232,12 @@
       saving = false;
       return;
     }
-    // A CV uploaded on the first step is parsed in the background, so what it yields is not
-    // readable until after the step is left. Re-reading here is what lets the experience and
-    // links steps open pre-filled for the account this whole wizard exists for — a brand new
-    // one, which had no résumé at all when the page first loaded.
-    if (kind === 'cv') await refreshFromResume();
+    // An account that arrived here with a CV already stored gets one wait started on its
+    // behalf, since nothing was uploaded on this run to start one. A run that DID upload is
+    // already waiting (CvStep calls onCvUploaded the moment the upload lands, which is
+    // seconds earlier than this), and must not be restarted — that would throw away a
+    // backoff already several steps in.
+    if (kind === 'cv' && cvParse !== 'waiting') void waitForResumeStructure();
     saving = false;
     if (isLast) await leave();
     else index += 1;
@@ -254,14 +257,17 @@
 
   /** Re-read the résumé and take anything it now offers that the candidate has not answered
    *  themselves. Best-effort and non-destructive: a value the candidate set always wins, and
-   *  a parse still in flight simply yields nothing rather than blocking the wizard. */
-  async function refreshFromResume() {
+   *  a parse still in flight simply yields nothing rather than blocking the wizard.
+   *
+   *  Returns what the server said about the résumé, so the caller can tell a parse that is
+   *  still running from one that has landed or given up. Null when the read itself failed. */
+  async function refreshFromResume(): Promise<ResumeMeta | null> {
     const resume = await api.getResume().catch(() => null);
-    if (!resume) return;
+    if (!resume) return null;
     contacts = resume.contacts ?? contacts;
     derivedTotalYears = resume.structured?.total_years ?? derivedTotalYears;
     const storedLinks = resume.contacts?.links ?? resume.structured?.links ?? [];
-    if (storedLinks.length === 0) return;
+    if (storedLinks.length === 0) return resume;
     const found = splitProfileLinks(storedLinks);
     // Fill only the boxes the candidate has left empty, and keep every link we did not
     // recognise so a round trip cannot lose one.
@@ -271,7 +277,65 @@
       other: [...new Set([...links.other, ...found.other])],
     };
     linksPrefilled = linksPrefilled || links.linkedin !== '' || links.github !== '';
+    return resume;
   }
+
+  /** Whether the CV's background parse is still being waited on, and how it ended.
+   *  'failed' is shown to the candidate — a CV we could not read is the one case where the
+   *  empty link boxes in front of them are our doing and not theirs. */
+  let cvParse = $state<CvParseState>('idle');
+  // Supersedes an in-flight wait: bumped by a newer upload and by leaving the page, so a
+  // resolved poll can tell whether it is still the one anybody is waiting for.
+  let waitToken = 0;
+
+  /** Keep asking for the CV's structured parse until it lands, filling in what it offers
+   *  each time round.
+   *
+   *  Runs in the BACKGROUND on purpose. The parse takes seconds and the candidate has steps
+   *  to answer meanwhile, so blocking Continue on it would trade an empty box for a spinner
+   *  and make an optional step feel mandatory. A link that arrives late still lands: every
+   *  step reads `links` live, and refreshFromResume never touches a box already typed in.
+   *
+   *  `structure_pending` is deliberately NOT the signal read here. The server sets it for a
+   *  parse that FAILED as well as one still running (see resume.go's GetResume), so waiting
+   *  on it would wait forever for the third of uploads whose extraction times out. The
+   *  three-valued `parse_status` is what tells those apart. */
+  async function waitForResumeStructure() {
+    const token = ++waitToken;
+    cvParse = 'waiting';
+    for (let attempt = 0; ; attempt++) {
+      // oxlint-disable-next-line no-await-in-loop -- a backoff poll IS sequential: each read decides whether there is a next one, so there is no set of promises to run together
+      const resume = await refreshFromResume();
+      if (token !== waitToken) return; // a newer upload, or the wizard is gone
+      // Storage off, or nothing stored: there is no parse to wait for and never will be.
+      if (resume && (!resume.enabled || !resume.present)) {
+        cvParse = 'idle';
+        return;
+      }
+      if (resume && resume.parse_status !== 'pending') {
+        cvParse = resume.parse_status === 'failed' ? 'failed' : 'idle';
+        return;
+      }
+      // A read that failed outright (resume === null) is treated as still pending: one
+      // dropped request during a wizard is far likelier than a parse that finished in the
+      // same instant, and the table below bounds the retrying either way.
+      const delay = nextResumePollDelayMs(attempt);
+      if (delay === null) {
+        cvParse = 'idle';
+        return;
+      }
+      // oxlint-disable-next-line no-await-in-loop -- the wait between reads is the point; running these together would be no backoff at all
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      if (token !== waitToken) return;
+    }
+  }
+
+  // Stop waiting when the wizard goes away. Without this the loop outlives the page for up
+  // to a minute, re-reading a résumé for a wizard nobody is looking at — and, after a
+  // sign-out, for an account that is no longer the caller.
+  onDestroy(() => {
+    waitToken++;
+  });
 
   function back() {
     if (index > 0) index -= 1;
@@ -380,6 +444,8 @@
               {onExtracted}
               onDerivedLocation={(loc) => (importedLocation = loc)}
               {onLinkedInUrl}
+              onCvUploaded={() => void waitForResumeStructure()}
+              onAdvance={() => void advance()}
             />
           {:else if currentKind === 'confirm'}
             <ConfirmStep
@@ -387,6 +453,7 @@
               {seniorities}
               {links}
               {linksPrefilled}
+              {cvParse}
               onSpecializationsChange={(next) => (specializations = next)}
               onSenioritiesChange={(next) => (seniorities = next)}
               onLinksChange={(next) => (links = next)}


### PR DESCRIPTION
## What people were complaining about

Two of the three onboarding complaints traced to the same place, and prod logs
confirm both.

**The links step opens empty.** A CV upload answers immediately with the
dictionary-derived facets — skills, categories, seniority, no model involved.
Everything the *model* reads out of the same file, the profile links and the
total years among it, is written afterwards by a background job. The wizard read
the résumé back exactly once, the instant the CV step was left
(`+page.svelte:237`), which is reliably *before* that job has finished. So the
GitHub and LinkedIn boxes were empty for everybody, including the two thirds
whose parse landed a moment later.

The server already publishes the fact that would have prevented this —
`structure_pending`, and the three-valued `parse_status` beside it. The frontend
never read either: the only mention anywhere in `web/` was the type declaration
in `types.ts:1381`.

**A third of CV parses never finish at all.** In five hours of journal on prod:
48 successful `POST /me/resume/extract`, and 16 `resume structured: ... llm:
generate: request timeout: API call exceeded deadline`. Nothing was ever shown
to those candidates — the failure exists only in the log.

## What this does

- **Waits.** The wizard now polls `GET /me/resume` on a bounded backoff instead
  of asking once. The policy is a table in `onboardingResumeWait.ts`, kept
  Svelte-free so it can be read, tested and tuned without opening the wizard;
  the whole wait is about a minute, which outlasts a wizard run without
  outlasting the tab.
- **Never blocks.** The wait runs in the background and starts the moment the
  upload lands, not on Continue — those are seconds the candidate would
  otherwise spend on the next step for nothing. Every step reads `links` live,
  and the fill only ever touches a box they have not typed in, so a link that
  arrives while they are on the salary step still gets there.
- **Reads `parse_status`, not `structure_pending`.** The server sets the latter
  for a parse that FAILED as well as one still running (`resume.go:387`), so
  waiting on it would wait forever for exactly the third of uploads that time
  out.
- **Says so when the parse failed.** The links step is the one place that
  failure is visible as an absence, so it is where it is explained. An empty box
  under a CV still being read, an empty box under a CV we could not read, and a
  CV that simply listed no links are three different things and now read as
  three different things.
- **Moves on by itself after a successful import.** Staying put read as the
  upload not having registered, and "review on the next step" is a promise best
  kept by going there. Both entry points follow the same rule, deliberately —
  they leave the same note, so one of them moving while the other sat still
  would make one sentence mean two things. The two notes that *do* say something
  (nothing recognised; roles trimmed by the specialization cap) still hold the
  candidate there to read it.

## Not in this PR

`POST /me/linkedin/import` is returning **502 for 78% of calls** (25 of 32 over
two days). Root cause is separate and is not a code fix: the production egress
proxy is a single static IP, and LinkedIn answers it with `999` after roughly
ten requests — reproduced from the host, 9×`200` then `999`/`429`, and `999`
every time without the proxy. That needs a rotating egress or an honest decision
about the step, not a change here.

The LLM timeouts behind the 33% failure rate are also out of scope — this PR
makes them visible rather than silent.

## Checks

`vitest run` 1687 pass · `svelte-check` 0 errors · `pnpm --dir web lint` clean.
