### PR TITLE
Take wantapply's enumeration from the mirror that lists all of it, and keep reading the pages for free

### DIFF
--- a/internal/ingest/sources/firecrawltier.go
+++ b/internal/ingest/sources/firecrawltier.go
@@ -6,6 +6,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -23,20 +24,40 @@ import (
 // run". This one answers "no address we can obtain is served at all" — and it is the only one
 // that costs money per page, so nothing lands here that either of the others can reach.
 //
-// Measured 2026-09-07, both providers: 403 from the production datacenter IP and 403 through
-// SOURCES_PROXY_URL, whose exit their edge classifies as datacenter too; served normally by
-// the hosted API. The browser tier does not help, because the refusal comes before any
-// challenge is offered.
+// Measured 2026-09-07 for bayt and gulftalent: 403 from the production datacenter IP and 403
+// through SOURCES_PROXY_URL, whose exit their edge classifies as datacenter too; served
+// normally by the hosted API. The browser tier does not help, because the refusal comes before
+// any challenge is offered.
 //
-// What is behind those walls is thin, and whoever changes this should know the number rather
-// than rediscover it: run through this repository's own classify.IsTech, bayt's IT category
-// passed 0 of 33 titles and gulftalent's postings 5 of 400 (1.25%). They are project managers,
-// professors, chefs and hotel electricians. This tier was built with that measured and
-// accepted, which is why every guard below exists.
-var firecrawlProviders = map[string]func(*firecrawlClient) Source{
-	"bayt":       func(c *firecrawlClient) Source { return NewBayt(c) },
-	"gulftalent": func(c *firecrawlClient) Source { return NewGulfTalent(c) },
+// What is behind those two walls is thin, and whoever changes this should know the number
+// rather than rediscover it: run through this repository's own classify.IsTech, bayt's IT
+// category passed 0 of 33 titles and gulftalent's postings 5 of 400 (1.25%). They are project
+// managers, professors, chefs and hotel electricians. That was measured and accepted, which is
+// why every guard below exists.
+//
+// A build function receives BOTH transports, because the useful shape is not always "everything
+// through the hosted client". wantapply is the case that proved it, and it is a different shape
+// from the other two: its pages are perfectly reachable on the free .cy mirror, and only the
+// ENUMERATION is missing there — .cy's sitemap lists ~605 vacancies where .com's lists 2 755,
+// and five vacancies absent from the former all answered 200 on the latter's host. So one
+// metered request buys the list and the 2 755 pages stay free. Its yield is also the best of
+// the three by a distance: 636 of 2 753 titles (23%) pass classify.IsTech.
+var firecrawlProviders = map[string]func(hosted *firecrawlClient, direct HTTPClient) Source{
+	"bayt":       func(hosted *firecrawlClient, _ HTTPClient) Source { return NewBayt(hosted) },
+	"gulftalent": func(hosted *firecrawlClient, _ HTTPClient) Source { return NewGulfTalent(hosted) },
+	// Only the enumeration is hosted: .com lists 2 755 vacancies where .cy lists ~605, and every
+	// one of them is readable on .cy. See NewWantapplyViaHostedSitemap.
+	"wantapply": func(hosted *firecrawlClient, direct HTTPClient) Source {
+		return NewWantapplyViaHostedSitemap(direct, hosted, wantapplyComSitemapURL, wantapplyComHostname)
+	},
 }
+
+const (
+	// wantapplyComSitemapURL is the fuller enumeration; wantapplyComHostname is the host its
+	// entries carry, which is not the host the pages are fetched from.
+	wantapplyComSitemapURL = "https://wantapply.com/sitemap.xml"
+	wantapplyComHostname   = "wantapply.com"
+)
 
 // defaultFirecrawlBudget is how many pages one run may fetch when nothing says otherwise.
 // Deliberately small against a site listing 60 000 postings: the difference between a bounded
@@ -129,12 +150,20 @@ func ApplyFirecrawlEgress(registry map[string]Source) error {
 	if err != nil {
 		return fmt.Errorf("sources: hosted tier: %w", err)
 	}
+	// The free transport a mixed-tier provider keeps for the bulk of its work. It is the proxied
+	// client when a proxy is configured, since the providers here are refused on the direct IP.
+	direct := HTTPClient(NewClient())
+	if raw := strings.TrimSpace(os.Getenv("SOURCES_PROXY_URL")); raw != "" {
+		if u, err := url.Parse(raw); err == nil && u.Host != "" {
+			direct = NewProxyClient(u)
+		}
+	}
 	// One client for the whole run, so the budget counts across every provider in it: what is
 	// being protected is the account, and no single adapter can know what the others spent.
 	c := &firecrawlClient{api: api}
 	for name, build := range firecrawlProviders {
 		if _, ok := registry[name]; ok {
-			registry[name] = build(c)
+			registry[name] = build(c, direct)
 		}
 	}
 	return nil

--- a/internal/ingest/sources/firecrawltier_test.go
+++ b/internal/ingest/sources/firecrawltier_test.go
@@ -36,7 +36,7 @@ func TestFirecrawlClientSatisfiesBothAdaptersTransports(t *testing.T) {
 }
 
 func TestHostedTierCarriesTheTwoUnreachableProviders(t *testing.T) {
-	for _, name := range []string{"bayt", "gulftalent"} {
+	for _, name := range []string{"bayt", "gulftalent", "wantapply"} {
 		if _, ok := firecrawlProviders[name]; !ok {
 			t.Errorf("%s is not in firecrawlProviders", name)
 		}
@@ -135,5 +135,42 @@ func TestApplyFirecrawlEgressRejectsAnUnparseableBudget(t *testing.T) {
 	registry := map[string]Source{"bayt": NewBayt(NewClient())}
 	if err := ApplyFirecrawlEgress(registry); err == nil {
 		t.Error("want an error for an unparseable page budget, got nil")
+	}
+}
+
+// wantapply is the mixed-tier case: only its sitemap is hosted, so it must still be rewired
+// (the enumeration changes) while keeping a free transport for the pages. Without a key it
+// keeps whatever ApplyProxyEgress gave it, exactly as today.
+func TestHostedTierRewiresWantapplyForItsSitemapOnly(t *testing.T) {
+	t.Setenv("SOURCES_PROXY_URL", "http://user:pass@proxy.invalid:8080")
+	t.Setenv("FIRECRAWL_API_KEY", "test-key")
+
+	registry := map[string]Source{"wantapply": NewWantapply(NewClient())}
+	if err := ApplyProxyEgress(registry); err != nil {
+		t.Fatalf("ApplyProxyEgress: %v", err)
+	}
+	viaProxy := registry["wantapply"]
+	if err := ApplyFirecrawlEgress(registry); err != nil {
+		t.Fatalf("ApplyFirecrawlEgress: %v", err)
+	}
+	if registry["wantapply"] == viaProxy {
+		t.Error("wantapply was not rewired onto the fuller .com enumeration")
+	}
+}
+
+func TestWantapplyKeepsItsProxyTransportWithoutAKey(t *testing.T) {
+	t.Setenv("SOURCES_PROXY_URL", "http://user:pass@proxy.invalid:8080")
+	t.Setenv("FIRECRAWL_API_KEY", "")
+
+	registry := map[string]Source{"wantapply": NewWantapply(NewClient())}
+	if err := ApplyProxyEgress(registry); err != nil {
+		t.Fatalf("ApplyProxyEgress: %v", err)
+	}
+	viaProxy := registry["wantapply"]
+	if err := ApplyFirecrawlEgress(registry); err != nil {
+		t.Fatalf("ApplyFirecrawlEgress: %v", err)
+	}
+	if registry["wantapply"] != viaProxy {
+		t.Error("wantapply lost its proxied transport with no hosted key configured")
 	}
 }

--- a/internal/ingest/sources/wantapply.go
+++ b/internal/ingest/sources/wantapply.go
@@ -11,7 +11,14 @@ import (
 
 // wantapply adapts the Wantapply job aggregator (wantapply.com). The .com host sits behind a WAF
 // that 403s non-browser clients, so this adapter crawls the .cy mirror, which serves identical
-// content (same backend — sitemap lastmod matches to the millisecond) without the WAF. Wantapply
+// content (same backend — sitemap lastmod matches to the millisecond) without the WAF.
+//
+// The mirroring holds for PAGES and not for the SITEMAPS, which is worth stating because the
+// difference is most of the catalogue. Measured 2026-09-07: .cy enumerates ~605 vacancies and
+// .com enumerates 2 755, yet five vacancies absent from the .cy sitemap all answered 200 on .cy.
+// So .cy can serve the whole catalogue; it just does not advertise it. NewWantapplyViaHostedSitemap
+// reads the fuller enumeration from .com and still fetches every page from .cy — one metered
+// request for the sitemap, and the 2 755 pages free. Wantapply
 // is a directApply aggregator (many employers, no per-tenant board), so the adapter is boardless
 // and stays in the source facet, taking each posting's company from the JSON-LD. Its sitemap
 // enumerates every vacancy as a single-segment slug page and each page server-renders a schema.org
@@ -21,6 +28,15 @@ import (
 // pipeline's unseen-sweep is the close signal (a vacancy that drops out of the sitemap is closed).
 type wantapply struct {
 	http wantapplyHTTP
+	// sitemap is where the enumeration comes from; it is s.http for the ordinary construction
+	// and a different transport when the fuller .com sitemap is used.
+	sitemap XMLGetter
+	// sitemapURL and sitemapHost describe that enumeration: the URL to read and the host its
+	// entries must carry. detailHost is where the pages are actually fetched from, which is not
+	// the same when the two differ.
+	sitemapURL  string
+	sitemapHost string
+	detailHost  string
 }
 
 // wantapplyHTTP is the transport wantapply needs: the XML sitemap plus HTML detail pages.
@@ -49,8 +65,32 @@ var wantapplyReserved = map[string]struct{}{
 	"privacy-policy": {}, "terms-of-service": {},
 }
 
-// NewWantapply builds the Wantapply adapter over the given HTTP client.
-func NewWantapply(c wantapplyHTTP) Source { return wantapply{http: c} }
+// NewWantapply builds the Wantapply adapter over the given HTTP client: sitemap and pages both
+// from the .cy mirror.
+func NewWantapply(c wantapplyHTTP) Source {
+	return wantapply{
+		http:        c,
+		sitemap:     c,
+		sitemapURL:  wantapplySitemapURL,
+		sitemapHost: wantapplyHostname,
+		detailHost:  wantapplyHost,
+	}
+}
+
+// NewWantapplyViaHostedSitemap reads the enumeration from sitemapURL through a separate
+// transport — the .com sitemap, which needs the hosted tier — while still fetching every page
+// through c, the ordinary proxied client on .cy. See the type doc for why that is worth doing:
+// the two hosts mirror each other's PAGES, so the only thing the metered request buys is the
+// list, and it buys 2 154 vacancies the .cy sitemap never mentions.
+func NewWantapplyViaHostedSitemap(c wantapplyHTTP, sitemap XMLGetter, sitemapURL, sitemapHost string) Source {
+	return wantapply{
+		http:        c,
+		sitemap:     sitemap,
+		sitemapURL:  sitemapURL,
+		sitemapHost: sitemapHost,
+		detailHost:  wantapplyHost,
+	}
+}
 
 func (wantapply) Provider() string { return "wantapply" }
 
@@ -100,19 +140,38 @@ func (s wantapply) FetchNew(ctx context.Context, _ CompanyEntry, seen func(exter
 // crawl reads the sitemap and returns every vacancy candidate (reserved pages, /company/*, and
 // /jobs/* excluded) — the shared enumeration behind Fetch and FetchNew.
 func (s wantapply) crawl(ctx context.Context) ([]wantapplyVacancy, error) {
-	sitemap, err := getSitemap(ctx, s.http, wantapplySitemapURL)
+	sitemap, err := getSitemap(ctx, s.sitemap, s.sitemapURL)
 	if err != nil {
 		return nil, fmt.Errorf("wantapply: sitemap: %w", err)
 	}
 	var out []wantapplyVacancy
 	for _, entry := range sitemap.URLs {
-		// Use the sitemap's canonical loc as the URL rather than rebuilding it from the slug —
-		// the slug is url.Parse-decoded, so reconstruction could diverge from the real page.
-		if slug := wantapplyVacancySlug(entry.Loc); slug != "" {
-			out = append(out, wantapplyVacancy{slug: slug, url: entry.Loc})
+		slug := wantapplyVacancySlugOn(entry.Loc, s.sitemapHost)
+		if slug == "" {
+			continue
 		}
+		// The PATH is taken from the sitemap's own loc rather than rebuilt from the slug — the
+		// slug is url.Parse-decoded, so reconstruction could diverge from the real page. Only
+		// the host is swapped, and only when the enumeration came from the other mirror.
+		out = append(out, wantapplyVacancy{slug: slug, url: s.detailURL(entry.Loc)})
 	}
 	return out, nil
+}
+
+// detailURL points a sitemap entry at the host the pages are fetched from, keeping its path
+// byte for byte. When the sitemap and the pages come from the same host this returns loc
+// unchanged, which is the ordinary case.
+func (s wantapply) detailURL(loc string) string {
+	u, err := url.Parse(loc)
+	if err != nil {
+		return loc
+	}
+	base, err := url.Parse(s.detailHost)
+	if err != nil {
+		return loc
+	}
+	u.Scheme, u.Host = base.Scheme, base.Host
+	return u.String()
 }
 
 // detail fetches one vacancy page and maps its JobPosting ld+json to a Job, returning ok=false
@@ -183,12 +242,18 @@ func wantapplyDescription(root *html.Node) string {
 	return sanitizeHTML(body)
 }
 
-// wantapplyVacancySlug returns the vacancy slug for a sitemap loc that is a single-segment,
-// non-reserved page on the wantapply.cy host, or "" for the root, a reserved static page, a
-// multi-segment path (/company/*, /jobs/*), or an unparseable/foreign URL.
+// wantapplyVacancySlug returns the vacancy slug for a sitemap loc on the default (.cy) host.
 func wantapplyVacancySlug(loc string) string {
+	return wantapplyVacancySlugOn(loc, wantapplyHostname)
+}
+
+// wantapplyVacancySlugOn returns the vacancy slug for a sitemap loc that is a single-segment,
+// non-reserved page on host, or "" for the root, a reserved static page, a multi-segment path
+// (/company/*, /jobs/*), or an unparseable/foreign URL. The host is a parameter because the
+// enumeration may come from the .com mirror while the pages are read from .cy.
+func wantapplyVacancySlugOn(loc, host string) string {
 	u, err := url.Parse(strings.TrimSpace(loc))
-	if err != nil || u.Hostname() != wantapplyHostname {
+	if err != nil || u.Hostname() != host {
 		return ""
 	}
 	seg := strings.Trim(u.Path, "/")

--- a/internal/ingest/sources/wantapply_test.go
+++ b/internal/ingest/sources/wantapply_test.go
@@ -2,9 +2,36 @@ package sources
 
 import (
 	"context"
+	"encoding/xml"
+	"fmt"
 	"strings"
 	"testing"
+
+	"golang.org/x/net/html"
 )
+
+// wantapplyFake serves the sitemap and the vacancy pages the tests wire. An unrouted URL is an
+// error, so a test that asks for a page it did not set up fails loudly.
+type wantapplyFake struct {
+	xml  map[string]string
+	html map[string]string
+}
+
+func (f *wantapplyFake) GetXML(_ context.Context, url string, v any) error {
+	body, ok := f.xml[url]
+	if !ok {
+		return fmt.Errorf("wantapplyFake: no xml route for %s", url)
+	}
+	return xml.Unmarshal([]byte(body), v)
+}
+
+func (f *wantapplyFake) GetHTML(_ context.Context, url string) (*html.Node, error) {
+	body, ok := f.html[url]
+	if !ok {
+		return nil, fmt.Errorf("wantapplyFake: no html route for %s", url)
+	}
+	return html.Parse(strings.NewReader(body))
+}
 
 func TestWantapplyVacancySlug(t *testing.T) {
 	cases := map[string]string{
@@ -301,5 +328,65 @@ func TestWantapplyRegisteredInAll(t *testing.T) {
 	reg := All(NewClient())
 	if _, ok := reg["wantapply"]; !ok {
 		t.Error("wantapply not registered in sources.All")
+	}
+}
+
+// The .com and .cy hosts are mirrors of one backend — verified 2026-09-07: five vacancies the
+// .cy sitemap does not list all return 200 on .cy. What differs is only what each SITEMAP
+// enumerates: .cy lists ~605 vacancies, .com lists 2 755.
+//
+// So the enumeration may come from .com while the pages are still read from .cy, which is the
+// whole point: the sitemap is one metered request, the 2 755 pages are free.
+func TestWantapplyRewritesSitemapHostToTheDetailHost(t *testing.T) {
+	sitemap := `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<url><loc>https://wantapply.com/senior-ios-engineer-at-opal</loc></url>
+<url><loc>https://wantapply.com/company/opal</loc></url>
+<url><loc>https://wantapply.com/sign-in</loc></url>
+</urlset>`
+	page := `<html><body><script type="application/ld+json">{"@context":"https://schema.org","@type":"JobPosting",
+"title":"Senior iOS Engineer","hiringOrganization":{"@type":"Organization","name":"Opal"},
+"description":"<p>Build things.</p>"}</script></body></html>`
+
+	http := &wantapplyFake{
+		xml:  map[string]string{"https://wantapply.com/sitemap.xml": sitemap},
+		html: map[string]string{"https://wantapply.cy/senior-ios-engineer-at-opal": page},
+	}
+	s := NewWantapplyViaHostedSitemap(http, http, "https://wantapply.com/sitemap.xml", "wantapply.com")
+
+	jobs, err := s.Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("want 1 vacancy (company/ and sign-in are not vacancies), got %d: %+v", len(jobs), jobs)
+	}
+	if jobs[0].URL != "https://wantapply.cy/senior-ios-engineer-at-opal" {
+		t.Errorf("URL = %q, want the .cy host with the sitemap's path", jobs[0].URL)
+	}
+	if jobs[0].Company != "Opal" {
+		t.Errorf("Company = %q", jobs[0].Company)
+	}
+}
+
+// The default construction is unchanged: both the sitemap and the pages come from .cy.
+func TestWantapplyDefaultStaysOnTheFreeHost(t *testing.T) {
+	sitemap := `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<url><loc>https://wantapply.cy/dev-at-acme</loc></url>
+</urlset>`
+	page := `<html><body><script type="application/ld+json">{"@context":"https://schema.org","@type":"JobPosting",
+"title":"Dev","hiringOrganization":{"@type":"Organization","name":"Acme"},"description":"<p>Body.</p>"}</script></body></html>`
+	http := &wantapplyFake{
+		xml:  map[string]string{"https://wantapply.cy/sitemap.xml": sitemap},
+		html: map[string]string{"https://wantapply.cy/dev-at-acme": page},
+	}
+
+	jobs, err := NewWantapply(http).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].URL != "https://wantapply.cy/dev-at-acme" {
+		t.Fatalf("want the .cy vacancy unchanged, got %+v", jobs)
 	}
 }


### PR DESCRIPTION
We have been ingesting about a fifth of this source without knowing it.

## The mirroring holds for pages, not for sitemaps

The adapter has always said the two hosts mirror one backend. True — for **pages**. Nobody had checked the **sitemaps**:

| | sitemap lists | pages served |
|---|---|---|
| `wantapply.cy` (free, proxied) | **~605** | all of them |
| `wantapply.com` (needs the hosted tier) | **2 755** | the same ones |

Five vacancies absent from the `.cy` sitemap were each requested directly on `.cy` — **all five returned 200**. The catalogue was reachable the whole time; it simply was not advertised.

## So the fix costs one request, not 2 755

`NewWantapplyViaHostedSitemap` reads the fuller list through the hosted tier and still fetches **every page through the ordinary proxied client**. One metered page per crawl, against a 1 000-page monthly allowance, for **2 154 vacancies we could not see**.

Only the **host** of a sitemap entry is swapped, never the path. The adapter deliberately does not rebuild a URL from its slug — the slug is `url.Parse`-decoded and reconstruction could diverge from the real page — so `detailURL` keeps the path byte for byte.

## The tier learns that not everything must be hosted

`firecrawlProviders`' build functions now receive **both** transports. `bayt` and `gulftalent` ignore the second argument and are unchanged; `wantapply` is the case that proves the shape was too narrow.

Two tests pin both directions, as they already do for `gulftalent`: with a key the enumeration moves; **without one, wantapply keeps exactly the proxied transport it has today**.

## Worth recording next to the other two

| source | titles passing `classify.IsTech` |
|---|---|
| **wantapply** | **636 / 2 753 (23%)** |
| gulftalent | 5 / 400 (1.25%) |
| bayt | 0 / 33 |

By a distance the best use of the budget of the three.

## Verification

`gofmt`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...` — green. `golangci-lint`: 0 issues. `deadcode`: clean.

Robots: both hosts `Allow: /` for vacancy pages and advertise their sitemap; only admin/auth paths and `/api/` are disallowed, and neither is touched.