### PR TITLE
Attach the candidate's own résumé to browser-use auto-apply submissions

### DIFF
--- a/internal/api/atsapply/AGENTS.md
+++ b/internal/api/atsapply/AGENTS.md
@@ -30,12 +30,21 @@ process, called only via `Client.WithBrowserUse`. Scope is deliberately narrow:
   arrives free with the ingest crawl and is written directly), so `Client.fetchSchema`
   already parks a Recruitee attempt with `errNoSchemaFetcher` before `Submit` ever reaches
   a `Plan` to hand this executor.
-- **Only an already fully-resolved `Plan`** (`Plan.FullyResolved()`), and **never one
-  containing a résumé/file field** (`browserUseEligible`) — this backend is handed exact
-  field values to type, never a CV file, and never a decision about what to answer. Every
+- **Only an already fully-resolved `Plan`** (`Plan.FullyResolved()`) — this backend is
+  handed exact field values to type and never a decision about what to answer. Every
   invariant `resolve.go`/`draft.go`/`sensitive.go`/`geography.go` already enforce (never
   guess, sensitive-keyword gate, geography park) stays entirely upstream of this backend,
-  unchanged and unbypassed — it only ever executes what they already decided.
+  unchanged and unbypassed — it only ever executes what they already decided. **A résumé
+  field no longer disqualifies a plan** (`resolve.go`'s own invariant guarantees any
+  `Kind=="file"` field reaching a fully-resolved `Plan` IS the approved résumé, never an
+  arbitrary upload — see `resolveOne`): `attachResumeIfPresent` uploads the same rendered
+  PDF `Client.attachApprovedResume` already produces for the Greenhouse path into a fresh,
+  per-attempt browser-use workspace (`CreateWorkspace`/`RequestFileUpload`/`UploadFile`,
+  deleted again once the run ends — a résumé is candidate PII and outlives no attempt it
+  was rendered for), and `buildTask` points the agent at it by field id/label rather than
+  printing the local temp path a cloud VM could never read. The agent still never decides
+  WHICH file to use or what a field's value is — it only attaches the one file this backend
+  already resolved and already rendered.
 - **Confirmation is a strict marker, never inferred from narrative text.** `buildTask`
   requires the agent's report to end in exactly one of `CONFIRMED: <text>` / `UNCONFIRMED`
   / `PARKED: <reason>`; `parseOutcome` treats anything else — including a marker not on the

--- a/internal/api/atsapply/browseruse_fill.go
+++ b/internal/api/atsapply/browseruse_fill.go
@@ -45,22 +45,31 @@ const (
 	outcomeParked      browserUseOutcome = "PARKED"
 )
 
-// browserUseEligible reports whether claimed's provider and an already-resolved plan
-// qualify for this fallback: an eligible provider, and no file-kind field anywhere in the
-// plan. Résumé/CV upload is out of scope for this executor (design.md's Non-Goals) — a
-// fully-resolved plan that happens to include a résumé field (because the attempt carries
-// an approved tailored CV) still falls through to the ordinary "no fill path" park,
-// exactly as it would if this executor did not exist.
+// browserUseEligible reports whether claimed's provider qualifies for this fallback. A
+// résumé/CV upload no longer disqualifies a plan — resumeFileValue/attachResumeIfPresent
+// below upload it to a browser-use workspace so the agent can attach it (design.md's own
+// Non-Goal on this has been closed; see the archived change for the earlier, narrower
+// scope). This is safe specifically because resolveOne's own invariant guarantees any
+// Kind=="file" field reaching a fully-resolved Plan IS the approved résumé: the only
+// branch that ever resolves a file field (ok=true) is isResumeField(f) && hasApprovedCV —
+// a non-résumé file field can only ever come back unmapped or silently skipped, never
+// resolved, so it can never appear in plan.Fields at all. plan is accepted for symmetry
+// with the eligibility checks this might grow later, though nothing here reads it yet.
 func browserUseEligible(provider string, plan Plan) bool {
-	if !browserUseProviders[provider] {
-		return false
-	}
+	return browserUseProviders[provider]
+}
+
+// resumeFileValue returns the local path Client.attachApprovedResume rendered the
+// candidate's approved CV to, and whether plan carries a résumé field at all — the same
+// invariant browserUseEligible's doc comment explains: any Kind=="file" field here is
+// guaranteed to be exactly that rendered résumé, nothing else.
+func resumeFileValue(plan Plan) (path string, ok bool) {
 	for _, f := range plan.Fields {
 		if f.Kind == "file" {
-			return false
+			return f.Value, true
 		}
 	}
-	return true
+	return "", false
 }
 
 // buildTask builds the natural-language fill instruction browser-use executes for one
@@ -90,6 +99,13 @@ func buildTask(plan Plan, merged []MergedField, applyURL string) string {
 		label := labelByID[f.ID]
 		if label == "" {
 			label = f.ID
+		}
+		if f.Kind == "file" {
+			// f.Value is a local filesystem path here (set by Client.attachApprovedResume,
+			// meaningless off this machine) — never print it. attachResumeIfPresent has
+			// already uploaded the same bytes into this run's own workspace instead.
+			fmt.Fprintf(&b, "- %q (id %q): a résumé/CV file is attached to this run's workspace — use it for this field's upload control, exactly as it is, and do not type a value into it or use any other file.\n", label, f.ID)
+			continue
 		}
 		fmt.Fprintf(&b, "- %q (id %q): %s\n", label, f.ID, f.Value)
 	}
@@ -256,8 +272,18 @@ func (e *BrowserUseExecutor) submit(ctx context.Context, plan Plan, merged []Mer
 		return autoapply.SidecarResult{}, false, nil
 	}
 
+	runOpts, cleanupWorkspace, err := e.attachResumeIfPresent(ctx, plan)
+	if err != nil {
+		// Nothing has touched the live form yet — an ordinary retryable error, the same
+		// as CreateRun's own failure just below.
+		return autoapply.SidecarResult{}, true, fmt.Errorf("browser-use: attach resume: %w", err)
+	}
+	if cleanupWorkspace != nil {
+		defer cleanupWorkspace()
+	}
+
 	task := buildTask(plan, merged, applyURL)
-	runID, err := e.client.CreateRun(ctx, task, e.perRunCapUSD)
+	runID, err := e.client.CreateRun(ctx, task, e.perRunCapUSD, runOpts)
 	if err != nil {
 		// Nothing has touched the live form yet — an ordinary retryable error.
 		return autoapply.SidecarResult{}, true, fmt.Errorf("browser-use: create run: %w", err)
@@ -295,6 +321,56 @@ func (e *BrowserUseExecutor) submit(ctx context.Context, plan Plan, merged []Mer
 	default:
 		return autoapply.SidecarResult{Status: autoapply.StatusUnconfirmed}, true, nil
 	}
+}
+
+// attachResumeIfPresent uploads plan's résumé file (already rendered to a local temp path
+// by Client.attachApprovedResume, exactly as the chromedp path does before this executor
+// ever sees the plan) to a fresh browser-use workspace, so the agent can select it from a
+// native file picker instead of this executor typing a path no cloud VM can read. A plan
+// with no file field is a no-op: zero RunOptions, nil cleanup, nil error.
+//
+// A workspace per attempt, never reused: this executor never learns which user's résumé it
+// just uploaded (Plan carries no candidate identity), so there is no key to look up an
+// existing workspace by even if reuse were wanted, and creating one is one cheap extra call
+// against uploading a candidate's résumé into a container another attempt could still see
+// it in. cleanup deletes it once the run is done, successful or not — a résumé is candidate
+// PII, and nothing here needs it to outlive the one attempt it was rendered for.
+func (e *BrowserUseExecutor) attachResumeIfPresent(ctx context.Context, plan Plan) (opts browseruse.RunOptions, cleanup func(), err error) {
+	path, ok := resumeFileValue(plan)
+	if !ok {
+		return browseruse.RunOptions{}, nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return browseruse.RunOptions{}, nil, fmt.Errorf("read rendered resume %s: %w", path, err)
+	}
+
+	workspaceID, err := e.client.CreateWorkspace(ctx)
+	if err != nil {
+		return browseruse.RunOptions{}, nil, fmt.Errorf("create workspace: %w", err)
+	}
+	cleanup = func() {
+		// A best-effort deletion on a context of its own, for the same reason
+		// recordSpendBestEffort below uses one: by the time this defer runs, ctx (the
+		// caller's own, whatever its origin) may already be past its deadline.
+		delCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if delErr := e.client.DeleteWorkspace(delCtx, workspaceID); delErr != nil {
+			log.Printf("atsapply: browser-use could not delete workspace %s: %v", workspaceID, delErr)
+		}
+	}
+
+	upload, err := e.client.RequestFileUpload(ctx, workspaceID, "resume.pdf", "application/pdf", int64(len(data)))
+	if err != nil {
+		cleanup()
+		return browseruse.RunOptions{}, nil, fmt.Errorf("request file upload: %w", err)
+	}
+	if err := e.client.UploadFile(ctx, upload.UploadURL, "application/pdf", data); err != nil {
+		cleanup()
+		return browseruse.RunOptions{}, nil, fmt.Errorf("upload resume: %w", err)
+	}
+
+	return browseruse.RunOptions{WorkspaceID: workspaceID, AttachedFileIDs: []string{upload.ID}}, cleanup, nil
 }
 
 // recordSpendBestEffort fetches and records a run's cost after Wait itself failed to

--- a/internal/api/atsapply/browseruse_fill_test.go
+++ b/internal/api/atsapply/browseruse_fill_test.go
@@ -1,6 +1,10 @@
 package atsapply
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 )
@@ -37,6 +41,97 @@ func TestBuildTask_FallsBackToIDWhenNoLabelKnown(t *testing.T) {
 	task := buildTask(plan, nil, "https://example.com/apply")
 	if !strings.Contains(task, `"custom_field" (id "custom_field"): 42`) {
 		t.Errorf("task = %s, want it to fall back to the id as the label", task)
+	}
+}
+
+// A file-kind field's Value is a local filesystem path (attachApprovedResume's own
+// output), meaningless on browser-use's cloud VM and never to be printed. The task must
+// instead point the agent at the file already attached to the run's own workspace.
+func TestBuildTask_NeverPrintsAFileFieldsLocalPathValue(t *testing.T) {
+	plan := Plan{Fields: []ResolvedField{{ID: "resume", Kind: "file", Value: "/tmp/auto-apply-resume-12345.pdf"}}}
+	merged := []MergedField{{ID: "resume", Label: "Resume/CV"}}
+
+	task := buildTask(plan, merged, "https://example.com/apply")
+
+	if strings.Contains(task, "/tmp/") {
+		t.Errorf("task leaked the local temp file path:\n%s", task)
+	}
+	if !strings.Contains(task, `"Resume/CV" (id "resume")`) || !strings.Contains(task, "attached to this run's workspace") {
+		t.Errorf("task = %s, want it to reference the attached file for the resume field", task)
+	}
+}
+
+func TestResumeFileValue_NoFileFieldReturnsFalse(t *testing.T) {
+	plan := Plan{Fields: []ResolvedField{{ID: "email", Kind: "text", Value: "ada@example.com"}}}
+	if _, ok := resumeFileValue(plan); ok {
+		t.Error("resumeFileValue ok = true, want false — no file field in this plan")
+	}
+}
+
+func TestResumeFileValue_ReturnsTheFileFieldsValue(t *testing.T) {
+	plan := Plan{Fields: []ResolvedField{
+		{ID: "email", Kind: "text", Value: "ada@example.com"},
+		{ID: "resume", Kind: "file", Value: "/tmp/rendered.pdf"},
+	}}
+	path, ok := resumeFileValue(plan)
+	if !ok || path != "/tmp/rendered.pdf" {
+		t.Errorf("resumeFileValue = (%q, %v), want (/tmp/rendered.pdf, true)", path, ok)
+	}
+}
+
+func TestAttachResumeIfPresent_NoFileFieldIsANoOp(t *testing.T) {
+	e := newTestBrowserUseExecutor("http://unused.example.test")
+	plan := Plan{Fields: []ResolvedField{{ID: "email", Kind: "text", Value: "ada@example.com"}}}
+
+	opts, cleanup, err := e.attachResumeIfPresent(context.Background(), plan)
+	if err != nil || cleanup != nil || opts.WorkspaceID != "" || len(opts.AttachedFileIDs) != 0 {
+		t.Fatalf("attachResumeIfPresent = (%+v, cleanup!=nil:%v, %v), want zero value, nil, nil", opts, cleanup != nil, err)
+	}
+}
+
+func TestAttachResumeIfPresent_UnreadableFileIsAPlainError(t *testing.T) {
+	e := newTestBrowserUseExecutor("http://unused.example.test")
+	plan := Plan{Fields: []ResolvedField{{ID: "resume", Kind: "file", Value: "/no/such/file.pdf"}}}
+
+	if _, _, err := e.attachResumeIfPresent(context.Background(), plan); err == nil {
+		t.Fatal("want an error for a résumé path that cannot be read")
+	}
+}
+
+func TestAttachResumeIfPresent_UploadFailureCleansUpTheWorkspace(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "resume-*.pdf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tmp.WriteString("%PDF-1.4 fake"); err != nil {
+		t.Fatal(err)
+	}
+	_ = tmp.Close()
+
+	deleted := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/workspaces":
+			_, _ = w.Write([]byte(`{"id":"ws-1","archived":false,"createdAt":"2026-09-07T00:00:00Z","updatedAt":"2026-09-07T00:00:00Z"}`))
+		case r.Method == http.MethodDelete && r.URL.Path == "/workspaces/ws-1":
+			deleted = true
+			w.WriteHeader(http.StatusNoContent)
+		case r.URL.Path == "/workspaces/ws-1/files/upload":
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	e := newTestBrowserUseExecutor(srv.URL)
+	plan := Plan{Fields: []ResolvedField{{ID: "resume", Kind: "file", Value: tmp.Name()}}}
+
+	if _, _, err := e.attachResumeIfPresent(context.Background(), plan); err == nil {
+		t.Fatal("want an error when the upload-reservation request fails")
+	}
+	if !deleted {
+		t.Error("workspace was never deleted after the upload failed — a résumé must not be left behind")
 	}
 }
 
@@ -104,7 +199,7 @@ func TestBrowserUseEligible(t *testing.T) {
 		// implementation — see browserUseProviders' own doc comment), so Client.Submit
 		// never even reaches browserUseEligible for it; excluded here for the same reason.
 		{"recruitee is never eligible", "recruitee", Plan{}, false},
-		{"a resume file field disqualifies the plan", "ashby", Plan{Fields: []ResolvedField{{ID: "resume", Kind: "file"}}}, false},
+		{"a resume file field no longer disqualifies the plan", "ashby", Plan{Fields: []ResolvedField{{ID: "resume", Kind: "file"}}}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/api/atsapply/browseruse_submit_test.go
+++ b/internal/api/atsapply/browseruse_submit_test.go
@@ -3,11 +3,15 @@ package atsapply
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/google/uuid"
+
 	"github.com/strelov1/freehire/internal/application/autoapply"
+	"github.com/strelov1/freehire/internal/candidate/cv"
 	"github.com/strelov1/freehire/internal/ingest/applyform"
 	"github.com/strelov1/freehire/internal/platform/browseruse"
 )
@@ -32,6 +36,104 @@ func (fakeAshbyFetcherWithCustomQuestion) Fetch(ctx context.Context, c applyform
 		{ID: "email", Label: "Email", Type: applyform.TypeText, Required: true},
 		{ID: "custom_1", Label: "Why do you want to work here?", Type: applyform.TypeText, Required: true},
 	}}, nil
+}
+
+// fakeAshbyFetcherWithResume adds Ashby's own résumé field (real id/label convention —
+// see internal/ingest/applyform/ashby.go and internal/ingest/applyform/ashby_test.go's own
+// fixture) to the minimal schema, so the resulting plan needs a rendered CV to resolve.
+type fakeAshbyFetcherWithResume struct{}
+
+func (fakeAshbyFetcherWithResume) Fetch(ctx context.Context, c applyform.Claimed) (applyform.Form, error) {
+	return applyform.Form{Provider: "ashby", Fields: []applyform.Field{
+		{ID: "email", Label: "Email", Type: applyform.TypeText, Required: true},
+		{ID: "_systemfield_resume", Label: "Resume", Type: applyform.TypeFile, Required: true},
+	}}, nil
+}
+
+// newFakeBrowserUseServerWithWorkspace extends newFakeBrowserUseServer's shape with the
+// workspace/file-upload endpoints attachResumeIfPresent calls, and captures the run
+// creation body plus the uploaded file's bytes so a test can assert on both.
+func newFakeBrowserUseServerWithWorkspace(t *testing.T, resultText string) (url string, runBody *map[string]any, uploadedBytes *[]byte, workspaceDeleted *bool) {
+	t.Helper()
+	runBody = &map[string]any{}
+	uploadedBytes = &[]byte{}
+	workspaceDeleted = new(bool)
+	var uploadServerURL string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/workspaces", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method for /workspaces: %s", r.Method)
+		}
+		_, _ = w.Write([]byte(`{"id":"ws-1","archived":false,"createdAt":"2026-09-07T00:00:00Z","updatedAt":"2026-09-07T00:00:00Z"}`))
+	})
+	mux.HandleFunc("/workspaces/ws-1", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("unexpected method for /workspaces/ws-1: %s", r.Method)
+		}
+		*workspaceDeleted = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/workspaces/ws-1/files/upload", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"files":[{"id":"file-1","name":"resume.pdf","storedName":"resume.pdf","path":"uploads/resume.pdf","willOverride":false,"uploadUrl":"` + uploadServerURL + `"}]}`))
+	})
+	mux.HandleFunc("/upload-target", func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		*uploadedBytes = b
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/runs", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(runBody)
+		_, _ = w.Write([]byte(`{"id":"run-1","status":"queued"}`))
+	})
+	mux.HandleFunc("/runs/run-1/status", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"completed"}`))
+	})
+	mux.HandleFunc("/runs/run-1", func(w http.ResponseWriter, r *http.Request) {
+		encoded, _ := json.Marshal(resultText)
+		_, _ = w.Write([]byte(`{"id":"run-1","status":"completed","result":` + string(encoded) + `,"totalCostUsd":"0.01"}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	uploadServerURL = srv.URL + "/upload-target"
+	return srv.URL, runBody, uploadedBytes, workspaceDeleted
+}
+
+// A résumé/CV field no longer disqualifies Ashby/Workable from the browser-use fallback:
+// the rendered PDF (attachApprovedResume — the same rendering the chromedp/Greenhouse path
+// already uses) is uploaded into a fresh browser-use workspace and attached to the run,
+// which is then deleted once the run is done.
+func TestSubmit_BrowserUseFallback_UploadsAndAttachesTheApprovedResume(t *testing.T) {
+	t.Setenv("AUTO_APPLY_BROWSERUSE_ENFORCE", "1")
+	url, runBody, uploadedBytes, workspaceDeleted := newFakeBrowserUseServerWithWorkspace(t, "All done.\nCONFIRMED: Thanks for applying!")
+
+	c := (&Client{
+		fetchers: map[string]applyform.Fetcher{"ashby": fakeAshbyFetcherWithResume{}},
+		cvs:      fakeCVReader{rec: cv.Record{}},
+		renderer: fakeCVRenderer{pdf: []byte("%PDF-1.4 fake resume")},
+	}).WithBrowserUse(newTestBrowserUseExecutor(url))
+
+	result, err := c.Submit(context.Background(), autoapply.Claimed{
+		Provider: "ashby", JobURL: "https://jobs.ashbyhq.com/example/123", TailoredCVID: uuid.New(),
+	}, map[string]string{"email": "ada@example.com"})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if result.Status != autoapply.StatusApplied {
+		t.Fatalf("result = %+v, want applied", result)
+	}
+	if (*runBody)["workspaceId"] != "ws-1" {
+		t.Errorf("run body workspaceId = %v, want ws-1", (*runBody)["workspaceId"])
+	}
+	ids, _ := (*runBody)["attachedFileIds"].([]any)
+	if len(ids) != 1 || ids[0] != "file-1" {
+		t.Errorf("run body attachedFileIds = %v, want [file-1]", (*runBody)["attachedFileIds"])
+	}
+	if string(*uploadedBytes) != "%PDF-1.4 fake resume" {
+		t.Errorf("uploaded bytes = %q, want the rendered PDF's own bytes", *uploadedBytes)
+	}
+	if !*workspaceDeleted {
+		t.Error("workspace was never deleted after the run — a résumé must not outlive its one attempt")
+	}
 }
 
 // newFakeBrowserUseServer starts an httptest.Server implementing just enough of the v4

--- a/internal/api/atsapply/client.go
+++ b/internal/api/atsapply/client.go
@@ -193,10 +193,18 @@ func (c *Client) Submit(ctx context.Context, claimed autoapply.Claimed, answers 
 		// browser-use fallback (openspec/changes/add-browseruse-atsapply-fallback): for
 		// Ashby/Workable, whose schema-only Reconcile already produced this
 		// fully-resolved plan, execute it through the cloud agent instead of parking —
-		// unless the plan needs a résumé upload (out of scope for this backend) or the
-		// daily spend guard refuses, either of which falls through to the same park this
-		// provider has always gotten.
+		// unless the daily spend guard refuses, which falls through to the same park this
+		// provider has always gotten. A résumé field renders the same way the Greenhouse
+		// path does (attachApprovedResume) before reaching the executor, which uploads
+		// those same bytes into browser-use's own workspace rather than a local path.
 		if c.browserUse != nil && browserUseEligible(claimed.Provider, plan) {
+			cleanup, parked := c.attachApprovedResume(ctx, claimed, &plan)
+			if parked != nil {
+				return *parked, nil
+			}
+			if cleanup != nil {
+				defer cleanup()
+			}
 			if !browserUseEnforce() {
 				log.Printf("atsapply: browser-use fallback would attempt job %d (%s) — shadow mode, still parking", claimed.JobID, claimed.Provider)
 			} else if result, handled, err := c.browserUse.submit(ctx, plan, merged, claimed.JobURL); handled {

--- a/internal/platform/browseruse/client.go
+++ b/internal/platform/browseruse/client.go
@@ -1,5 +1,6 @@
 // Package browseruse is a thin HTTP client for the browser-use.com cloud API (v4):
-// create a run, poll its status, fetch its result. It knows nothing about ATS forms,
+// create a run, poll its status, fetch its result, and manage the workspace/file-upload
+// endpoints a run's own attached files come from. It knows nothing about ATS forms,
 // resolved application plans, or any other domain — the same "transport, not domain"
 // split internal/platform/llm keeps for its own provider-agnostic wrapper.
 package browseruse
@@ -52,14 +53,26 @@ type RunResult struct {
 // documents besides queued/dispatching/running.
 var terminalStatuses = map[string]bool{"completed": true, "failed": true, "cancelled": true}
 
+// RunOptions carries CreateRun's optional per-run settings beyond the task text and cost
+// cap. The zero value (no workspace, no attached files) is every caller's need before
+// file-upload support existed, so it stays a valid, common argument.
+type RunOptions struct {
+	// WorkspaceID and AttachedFileIDs both come from CreateWorkspace/RequestFileUpload —
+	// a run can only see files already uploaded into the workspace it names here.
+	WorkspaceID     string
+	AttachedFileIDs []string
+}
+
 // CreateRun starts one run with the given task instruction and returns its id.
 // maxCostUSD is the v4 API's own per-run spend cap (0 omits it, leaving the account's
 // default in effect).
-func (c *Client) CreateRun(ctx context.Context, task string, maxCostUSD float64) (runID string, err error) {
+func (c *Client) CreateRun(ctx context.Context, task string, maxCostUSD float64, opts RunOptions) (runID string, err error) {
 	body := struct {
-		Task       string  `json:"task"`
-		MaxCostUSD float64 `json:"maxCostUsd,omitempty"`
-	}{Task: task, MaxCostUSD: maxCostUSD}
+		Task            string   `json:"task"`
+		MaxCostUSD      float64  `json:"maxCostUsd,omitempty"`
+		WorkspaceID     string   `json:"workspaceId,omitempty"`
+		AttachedFileIDs []string `json:"attachedFileIds,omitempty"`
+	}{Task: task, MaxCostUSD: maxCostUSD, WorkspaceID: opts.WorkspaceID, AttachedFileIDs: opts.AttachedFileIDs}
 
 	var resp struct {
 		ID string `json:"id"`
@@ -71,6 +84,88 @@ func (c *Client) CreateRun(ctx context.Context, task string, maxCostUSD float64)
 		return "", fmt.Errorf("browseruse: create run: response carried no id")
 	}
 	return resp.ID, nil
+}
+
+// CreateWorkspace creates a new, empty workspace and returns its id — the container a
+// run's attached files live in. A fresh workspace per attempt keeps one candidate's résumé
+// from ever being reachable from another's run.
+func (c *Client) CreateWorkspace(ctx context.Context) (workspaceID string, err error) {
+	var resp struct {
+		ID string `json:"id"`
+	}
+	if err := c.doJSON(ctx, http.MethodPost, "/workspaces", struct{}{}, &resp); err != nil {
+		return "", err
+	}
+	if resp.ID == "" {
+		return "", fmt.Errorf("browseruse: create workspace: response carried no id")
+	}
+	return resp.ID, nil
+}
+
+// DeleteWorkspace permanently removes a workspace and everything uploaded into it. Callers
+// that create a workspace to attach a candidate's résumé should delete it once the run is
+// done — nothing here needs that file to outlive the one attempt it was rendered for.
+func (c *Client) DeleteWorkspace(ctx context.Context, workspaceID string) error {
+	return c.doJSON(ctx, http.MethodDelete, "/workspaces/"+workspaceID, nil, nil)
+}
+
+// FileUpload is one file's presigned upload target, returned by RequestFileUpload.
+type FileUpload struct {
+	ID        string // pass in RunOptions.AttachedFileIDs to attach this file to a run
+	UploadURL string // PUT the file's bytes here directly (5 min expiry) — see UploadFile
+}
+
+// RequestFileUpload reserves storage for one file in workspaceID and returns a presigned
+// PUT url for it — the v4 API's own two-step upload: reserve here, then PUT the bytes
+// straight to storage (UploadFile) rather than through this API. size must be the file's
+// exact byte count; the presigned URL is pinned to it.
+func (c *Client) RequestFileUpload(ctx context.Context, workspaceID, name, contentType string, size int64) (FileUpload, error) {
+	type item struct {
+		Name        string `json:"name"`
+		ContentType string `json:"contentType,omitempty"`
+		Size        int64  `json:"size"`
+	}
+	body := struct {
+		Files []item `json:"files"`
+	}{Files: []item{{Name: name, ContentType: contentType, Size: size}}}
+
+	var resp struct {
+		Files []struct {
+			ID        string `json:"id"`
+			UploadURL string `json:"uploadUrl"`
+		} `json:"files"`
+	}
+	if err := c.doJSON(ctx, http.MethodPost, "/workspaces/"+workspaceID+"/files/upload", body, &resp); err != nil {
+		return FileUpload{}, err
+	}
+	if len(resp.Files) != 1 || resp.Files[0].ID == "" || resp.Files[0].UploadURL == "" {
+		return FileUpload{}, fmt.Errorf("browseruse: request file upload: unexpected response shape")
+	}
+	return FileUpload{ID: resp.Files[0].ID, UploadURL: resp.Files[0].UploadURL}, nil
+}
+
+// UploadFile PUTs data to a presigned upload URL from RequestFileUpload. This bypasses
+// doJSON deliberately: a presigned URL points at object storage, not this API's own base
+// URL, needs no X-Browser-Use-API-Key (the URL itself is the credential, valid 5 minutes),
+// and answers with no JSON body to decode.
+func (c *Client) UploadFile(ctx context.Context, uploadURL, contentType string, data []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("browseruse: build upload request: %w", err)
+	}
+	req.Header.Set("Content-Type", contentType)
+	req.ContentLength = int64(len(data))
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("browseruse: upload file: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("browseruse: upload file: status %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
 }
 
 // PollStatus reads a run's current status — the cheap, indexed poll target the v4 API

--- a/internal/platform/browseruse/client_test.go
+++ b/internal/platform/browseruse/client_test.go
@@ -43,7 +43,7 @@ func TestCreateRun_HappyPath(t *testing.T) {
 
 func TestCreateRun_NonEmptyIDRequired(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"id":"","status":"queued"}`))
+		_, _ = w.Write([]byte(`{"id":"","status":"queued"}`))
 	}))
 	defer srv.Close()
 
@@ -110,15 +110,15 @@ func TestDoJSON_NonSuccessStatusIsAnError(t *testing.T) {
 func TestWait_ReturnsResultOnceTerminal(t *testing.T) {
 	calls := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/runs/run-123/status":
+		switch r.URL.Path {
+		case "/runs/run-123/status":
 			calls++
 			if calls < 3 {
 				_, _ = w.Write([]byte(`{"status":"running"}`))
 			} else {
 				_, _ = w.Write([]byte(`{"status":"completed"}`))
 			}
-		case r.URL.Path == "/runs/run-123":
+		case "/runs/run-123":
 			_, _ = w.Write([]byte(`{"id":"run-123","status":"completed","result":"CONFIRMED: ok","totalCostUsd":"0.01"}`))
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)

--- a/internal/platform/browseruse/client_test.go
+++ b/internal/platform/browseruse/client_test.go
@@ -3,6 +3,7 @@ package browseruse
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -31,7 +32,7 @@ func TestCreateRun_HappyPath(t *testing.T) {
 	defer srv.Close()
 
 	c := New("test-key", srv.URL, nil)
-	id, err := c.CreateRun(context.Background(), "do the thing", 0.5)
+	id, err := c.CreateRun(context.Background(), "do the thing", 0.5, RunOptions{})
 	if err != nil {
 		t.Fatalf("CreateRun: %v", err)
 	}
@@ -42,12 +43,12 @@ func TestCreateRun_HappyPath(t *testing.T) {
 
 func TestCreateRun_NonEmptyIDRequired(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"id":"","status":"queued"}`))
+		w.Write([]byte(`{"id":"","status":"queued"}`))
 	}))
 	defer srv.Close()
 
 	c := New("test-key", srv.URL, nil)
-	if _, err := c.CreateRun(context.Background(), "task", 0); err == nil {
+	if _, err := c.CreateRun(context.Background(), "task", 0, RunOptions{}); err == nil {
 		t.Fatal("want an error for an empty run id")
 	}
 }
@@ -101,7 +102,7 @@ func TestDoJSON_NonSuccessStatusIsAnError(t *testing.T) {
 	defer srv.Close()
 
 	c := New("test-key", srv.URL, nil)
-	if _, err := c.CreateRun(context.Background(), "task", 0); err == nil {
+	if _, err := c.CreateRun(context.Background(), "task", 0, RunOptions{}); err == nil {
 		t.Fatal("want an error for a non-2xx response")
 	}
 }
@@ -109,15 +110,15 @@ func TestDoJSON_NonSuccessStatusIsAnError(t *testing.T) {
 func TestWait_ReturnsResultOnceTerminal(t *testing.T) {
 	calls := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/runs/run-123/status":
+		switch {
+		case r.URL.Path == "/runs/run-123/status":
 			calls++
 			if calls < 3 {
 				_, _ = w.Write([]byte(`{"status":"running"}`))
 			} else {
 				_, _ = w.Write([]byte(`{"status":"completed"}`))
 			}
-		case "/runs/run-123":
+		case r.URL.Path == "/runs/run-123":
 			_, _ = w.Write([]byte(`{"id":"run-123","status":"completed","result":"CONFIRMED: ok","totalCostUsd":"0.01"}`))
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
@@ -148,5 +149,133 @@ func TestWait_TimesOutOnAStuckRun(t *testing.T) {
 	_, err := c.Wait(context.Background(), "run-123", 5*time.Millisecond, 30*time.Millisecond)
 	if err == nil {
 		t.Fatal("want a timeout error for a run stuck running")
+	}
+}
+
+func TestCreateRun_PassesWorkspaceAndAttachedFileIDs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body["workspaceId"] != "ws-1" {
+			t.Errorf("workspaceId = %v, want ws-1", body["workspaceId"])
+		}
+		ids, _ := body["attachedFileIds"].([]any)
+		if len(ids) != 1 || ids[0] != "file-1" {
+			t.Errorf("attachedFileIds = %v, want [file-1]", body["attachedFileIds"])
+		}
+		_, _ = w.Write([]byte(`{"id":"run-1","status":"queued"}`))
+	}))
+	defer srv.Close()
+
+	c := New("test-key", srv.URL, nil)
+	if _, err := c.CreateRun(context.Background(), "task", 0, RunOptions{WorkspaceID: "ws-1", AttachedFileIDs: []string{"file-1"}}); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+}
+
+func TestCreateWorkspace_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/workspaces" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"id":"ws-123","archived":false,"createdAt":"2026-09-07T00:00:00Z","updatedAt":"2026-09-07T00:00:00Z"}`))
+	}))
+	defer srv.Close()
+
+	c := New("test-key", srv.URL, nil)
+	id, err := c.CreateWorkspace(context.Background())
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	if id != "ws-123" {
+		t.Errorf("id = %q, want ws-123", id)
+	}
+}
+
+func TestDeleteWorkspace_HappyPath(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/workspaces/ws-123" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := New("test-key", srv.URL, nil)
+	if err := c.DeleteWorkspace(context.Background(), "ws-123"); err != nil {
+		t.Fatalf("DeleteWorkspace: %v", err)
+	}
+	if !called {
+		t.Error("delete request was never sent")
+	}
+}
+
+func TestRequestFileUpload_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/workspaces/ws-123/files/upload" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		files, _ := body["files"].([]any)
+		if len(files) != 1 {
+			t.Fatalf("files = %v, want exactly one entry", body["files"])
+		}
+		f := files[0].(map[string]any)
+		if f["name"] != "resume.pdf" || f["contentType"] != "application/pdf" || f["size"] != float64(1234) {
+			t.Errorf("file entry = %+v, want name=resume.pdf contentType=application/pdf size=1234", f)
+		}
+		_, _ = w.Write([]byte(`{"files":[{"id":"file-1","name":"resume.pdf","storedName":"resume.pdf","path":"uploads/resume.pdf","willOverride":false,"uploadUrl":"https://storage.example.test/upload-1"}]}`))
+	}))
+	defer srv.Close()
+
+	c := New("test-key", srv.URL, nil)
+	upload, err := c.RequestFileUpload(context.Background(), "ws-123", "resume.pdf", "application/pdf", 1234)
+	if err != nil {
+		t.Fatalf("RequestFileUpload: %v", err)
+	}
+	if upload.ID != "file-1" || upload.UploadURL != "https://storage.example.test/upload-1" {
+		t.Errorf("upload = %+v, want id=file-1 uploadUrl=https://storage.example.test/upload-1", upload)
+	}
+}
+
+func TestUploadFile_PUTsBytesWithNoAPIKeyHeader(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("method = %s, want PUT", r.Method)
+		}
+		if got := r.Header.Get("X-Browser-Use-API-Key"); got != "" {
+			t.Errorf("api key header = %q, want empty — a presigned URL carries its own credential", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/pdf" {
+			t.Errorf("content-type = %q, want application/pdf", got)
+		}
+		b, _ := io.ReadAll(r.Body)
+		gotBody = b
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New("test-key", "https://unused.example.test", nil)
+	if err := c.UploadFile(context.Background(), srv.URL, "application/pdf", []byte("%PDF-1.4 fake")); err != nil {
+		t.Fatalf("UploadFile: %v", err)
+	}
+	if string(gotBody) != "%PDF-1.4 fake" {
+		t.Errorf("uploaded body = %q, want %q", gotBody, "%PDF-1.4 fake")
+	}
+}
+
+func TestUploadFile_NonSuccessStatusIsAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	c := New("test-key", "https://unused.example.test", nil)
+	if err := c.UploadFile(context.Background(), srv.URL, "application/pdf", []byte("data")); err == nil {
+		t.Fatal("want an error for a non-2xx response")
 	}
 }


### PR DESCRIPTION
## Summary
- A required résumé field used to disqualify a plan from the browser-use fallback entirely — which in practice is nearly every real posting once a candidate has an approved tailored CV, since `resolveOne` always resolves that field once one exists. This backend could therefore essentially never complete a real submission.
- `resolveOne`'s own invariant guarantees any `Kind=="file"` field reaching a fully-resolved `Plan` IS the approved résumé (the only branch that ever resolves a file field is `isResumeField(f) && hasApprovedCV`) — never an arbitrary upload. That makes closing this gap safe: the agent is never handed a choice about which file to use.
- The same rendered PDF `Client.attachApprovedResume` already produces for the chromedp/Greenhouse path is now uploaded into a fresh, per-attempt browser-use workspace via the v4 API's presigned-URL upload flow (`CreateWorkspace` → `RequestFileUpload` → `UploadFile` → `attachedFileIds` on `CreateRun`), and the workspace is deleted once the run ends — a résumé is candidate PII and outlives no attempt it was rendered for.
- `buildTask` no longer prints a file field's `Value` (a local temp path meaningless on browser-use's cloud VM) — it points the agent at the file already attached to the run's workspace instead.

## New surface (internal/platform/browseruse)
- `CreateRun` gains a `RunOptions` parameter (`WorkspaceID`, `AttachedFileIDs`).
- `CreateWorkspace`, `DeleteWorkspace`, `RequestFileUpload`, `UploadFile` — the v4 API's workspace/file-upload endpoints, verified against the live OpenAPI spec at `docs.browser-use.com/cloud/openapi/v4.json`.

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` — all passing, including a full end-to-end `TestSubmit_BrowserUseFallback_UploadsAndAttachesTheApprovedResume` (fake workspace/upload/run server) and unit coverage for `attachResumeIfPresent`'s failure paths (unreadable file, upload failure with workspace cleanup)
- [ ] Verify against a real browser-use.com run with a real résumé upload field (Singular/Ashby is a live candidate for this)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser-based applications now support résumé uploads.
  * Approved tailored résumés are rendered and attached to each browser run.
  * Temporary résumé workspaces are automatically removed after submission.

* **Bug Fixes**
  * Résumé-required applications no longer bypass browser-based submission.
  * Local résumé file paths are no longer exposed to the browser agent.
  * Failed uploads and unreadable résumé files are handled safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->