### PR TITLE
Move the assistant's history window in blocks, so the replayed prefix can be cached

### DIFF
--- a/internal/ai/assistant/runner.go
+++ b/internal/ai/assistant/runner.go
@@ -137,6 +137,20 @@ func (r *Runner) With(m Model) *Runner {
 const (
 	defaultMaxSteps     = 8
 	defaultHistoryLimit = 60
+	// historyBlock caps how far the replayed window's OLDEST message moves at a time.
+	//
+	// A window of "the newest HistoryLimit messages" slides by one every turn, so the
+	// bytes the model is sent after the system prompt differ on every request. Prompt
+	// caching is a prefix match, so that costs the whole conversation at full price on
+	// every turn: measured on production the assistant read 30,848 input tokens a
+	// request and only 10,868 of them came from cache — the size of the static head
+	// (system prompt plus tool schemas), with the conversation itself never hit.
+	//
+	// Quantising the window's start to a multiple of the block keeps that prefix
+	// byte-identical for a block's worth of turns and breaks it once, rather than
+	// breaking it every turn. The cost is carrying up to one block of extra history —
+	// cached tokens, roughly a tenth the price of the uncached ones this avoids.
+	historyBlock = 20
 	// persistTimeout bounds one transcript write. The writes run on a context
 	// detached from the caller's, so they need a deadline of their own.
 	persistTimeout = 5 * time.Second
@@ -421,12 +435,18 @@ func (r *Runner) persist(ctx context.Context, sessionID uuid.UUID, msg Message) 
 // by its most recent messages.
 //
 // Fetches only the tail via RecentTranscript rather than the whole transcript via
-// Transcript — trim() below only ever keeps the last HistoryLimit messages anyway, so
-// fetching everything first paid a cost proportional to the session's total length
-// (autopilot runs and long-lived chats can accumulate hundreds of rows) on every single
-// turn, for a window whose size never changes.
+// Transcript — trim() below only ever keeps a bounded window anyway, so fetching
+// everything first paid a cost proportional to the session's total length (autopilot
+// runs and long-lived chats can accumulate hundreds of rows) on every single turn, for
+// a window whose size is bounded.
+//
+// It asks for HistoryLimit+historyBlock rows, not HistoryLimit: trim cuts at a block
+// boundary, and the widest window that boundary can leave is one block past the limit.
+// Fetching exactly HistoryLimit would silently cap the window at the limit again and
+// put the cut back on every turn — the fetch size is part of the cache fix, not an
+// optimisation beside it.
 func (r *Runner) history(ctx context.Context, sessionID uuid.UUID, system string) ([]llms.MessageContent, error) {
-	stored, err := r.store.RecentTranscript(ctx, sessionID, r.cfg.HistoryLimit)
+	stored, err := r.store.RecentTranscript(ctx, sessionID, r.cfg.HistoryLimit+historyBlock)
 	if err != nil {
 		return nil, err
 	}
@@ -441,21 +461,63 @@ func (r *Runner) history(ctx context.Context, sessionID uuid.UUID, system string
 	return append(out, msgs...), nil
 }
 
-// trim keeps the most recent limit messages, then drops any leading tool results
-// whose originating call was trimmed away. Providers reject a tool result that
-// answers no call in the conversation, so an orphan at the head would fail the
-// whole turn rather than merely losing context. It then closes any tool_use that
-// still has no matching tool_result — a turn that died after persisting the
-// calls but before their results leaves exactly that shape, and Bedrock rejects
-// the whole next turn for it.
+// trim keeps roughly the most recent limit messages, cutting at a block boundary
+// rather than at "newest limit" so the replayed prefix survives the provider's prompt
+// cache (see historyBlock). It then drops any leading tool results whose originating
+// call was cut away. Providers reject a tool result that answers no call in the
+// conversation, so an orphan at the head would fail the whole turn rather than merely
+// losing context. It finally closes any tool_use that still has no matching
+// tool_result — a turn that died after persisting the calls but before their results
+// leaves exactly that shape, and Bedrock rejects the whole next turn for it.
+//
+// The caller must hand it limit+historyBlock messages, which is the widest window a
+// block boundary can produce; fewer and the cut is a no-op and the window is whatever
+// arrived.
 func trim(msgs []Message, limit int) []Message {
-	if limit > 0 && len(msgs) > limit {
-		msgs = msgs[len(msgs)-limit:]
+	if limit > 0 && len(msgs) > 0 {
+		anchor := blockAnchor(int(msgs[len(msgs)-1].Seq), limit)
+		cut := 0
+		for cut < len(msgs) && int(msgs[cut].Seq) < anchor {
+			cut++
+		}
+		msgs = msgs[cut:]
 	}
 	for len(msgs) > 0 && msgs[0].Role == RoleTool {
 		msgs = msgs[1:]
 	}
 	return closeDanglingToolCalls(msgs)
+}
+
+// blockAnchor is the oldest seq the replayed window keeps: the start of the newest
+// `limit` messages, rounded DOWN to a multiple of the block. Rounding down is what makes
+// it stand still while newest advances, which is the whole point — the same anchor for a
+// block's worth of turns means the same replayed prefix for that many turns.
+//
+// A session shorter than the window answers 0, which keeps everything.
+func blockAnchor(newestSeq, limit int) int {
+	block := historyBlockFor(limit)
+	anchor := ((newestSeq - limit + 1) / block) * block
+	if anchor < 0 {
+		return 0
+	}
+	return anchor
+}
+
+// historyBlockFor is the block for a given window: a third of it, capped at
+// historyBlock. Proportional rather than fixed because the quantisation is paid for in
+// overshoot, and the overshoot has to stay a fraction of the window at ANY limit — a
+// flat block of 20 turns a 4-message window into a 20-message one, which is not a
+// caching tweak but a different bound. At the production limit of 60 this is the 20 the
+// constant names; at a limit of 3 or less it is 1, which is the old behaviour exactly.
+func historyBlockFor(limit int) int {
+	block := limit / 3
+	if block > historyBlock {
+		return historyBlock
+	}
+	if block < 1 {
+		return 1
+	}
+	return block
 }
 
 // closeDanglingToolCalls inserts synthetic error tool results for any assistant

--- a/internal/ai/assistant/runner_test.go
+++ b/internal/ai/assistant/runner_test.go
@@ -709,3 +709,59 @@ func TestContinueWithEmptyTranscriptIsRefused(t *testing.T) {
 		t.Fatalf("Continue on empty session: %v, want ErrNothingToContinue", err)
 	}
 }
+
+// replayWindow is the transcript as the store hands it to trim on one turn: the
+// newest `fetch` messages, oldest first, with seq running up to maxSeq.
+func replayWindow(maxSeq, fetch int32) []Message {
+	start := maxSeq - fetch + 1
+	if start < 1 {
+		start = 1
+	}
+	out := make([]Message, 0, maxSeq-start+1)
+	for seq := start; seq <= maxSeq; seq++ {
+		out = append(out, Message{Seq: seq, Role: RoleUser, Content: json.RawMessage(`{"text":"x"}`)})
+	}
+	return out
+}
+
+// Prompt caching is a PREFIX match, so the oldest message in the replayed window
+// decides whether any of the history can be served from cache. A window that keeps
+// "the newest N" moves that head by one on every single turn, which is why the
+// assistant's measured cache-hit rate sat at the size of its static head (system
+// prompt plus tool schemas) and the conversation itself was re-read at full price
+// every turn.
+func TestReplayedHistoryHeadMovesInBlocksSoTheCacheSurvives(t *testing.T) {
+	const (
+		limit = 60
+		turns = 25
+	)
+
+	heads := make(map[int32]struct{})
+	for i := int32(0); i < turns; i++ {
+		got := trim(replayWindow(200+i, limit+historyBlock), limit)
+		if len(got) == 0 {
+			t.Fatalf("turn %d: empty window", i)
+		}
+		heads[got[0].Seq] = struct{}{}
+	}
+
+	// 25 turns span at most two block boundaries.
+	if len(heads) > 2 {
+		t.Fatalf("window head took %d distinct values over %d turns, want at most 2 — "+
+			"a head that moves every turn means the replayed history never caches", len(heads), turns)
+	}
+}
+
+// The block quantisation must not let the window grow without bound: it buys prefix
+// stability with up to one extra block of history, never more.
+func TestReplayedHistoryWindowStaysBounded(t *testing.T) {
+	const limit = 60
+
+	for i := int32(0); i < 200; i++ {
+		got := trim(replayWindow(200+i, limit+historyBlock), limit)
+		if len(got) < limit || len(got) >= limit+historyBlockFor(limit) {
+			t.Fatalf("maxSeq=%d: window is %d messages, want it in [%d, %d)",
+				200+i, len(got), limit, limit+historyBlockFor(limit))
+		}
+	}
+}

--- a/internal/platform/db/assistant.sql.go
+++ b/internal/platform/db/assistant.sql.go
@@ -273,12 +273,17 @@ type ListRecentAssistantMessagesParams struct {
 
 // The session's most recent messages, newest first — the bounded counterpart of
 // ListAssistantMessages, for rebuilding the model's own history every turn. Runner.trim()
-// only ever keeps the tail (HistoryLimit, default 60) of what ListAssistantMessages
-// returns; fetching and JSON-decoding the WHOLE transcript first, only to discard
-// everything but the tail, cost time and memory proportional to total session length
-// (autopilot runs, long-lived chat/tailoring sessions can accumulate hundreds of rows)
-// instead of the fixed window actually used. The caller reverses these rows back to
-// ascending seq order before handing them to trim()/Conversation().
+// only ever keeps a bounded window of what ListAssistantMessages returns; fetching and
+// JSON-decoding the WHOLE transcript first, only to discard everything but that window,
+// cost time and memory proportional to total session length (autopilot runs, long-lived
+// chat/tailoring sessions can accumulate hundreds of rows) instead of the bounded window
+// actually used. The caller reverses these rows back to ascending seq order before
+// handing them to trim()/Conversation().
+//
+// The LIMIT the caller passes is HistoryLimit PLUS one block (Runner.history), not
+// HistoryLimit: trim cuts the window at a block boundary so the replayed prefix stays
+// byte-identical between turns and the provider's prompt cache can hit it, and the widest
+// window such a boundary leaves is just under one block past the limit.
 func (q *Queries) ListRecentAssistantMessages(ctx context.Context, arg ListRecentAssistantMessagesParams) ([]AssistantMessage, error) {
 	rows, err := q.db.Query(ctx, listRecentAssistantMessages, arg.SessionID, arg.Limit)
 	if err != nil {

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -3358,12 +3358,17 @@ type Querier interface {
 	ListPushTokensForUser(ctx context.Context, userID int64) ([]UserPushToken, error)
 	// The session's most recent messages, newest first — the bounded counterpart of
 	// ListAssistantMessages, for rebuilding the model's own history every turn. Runner.trim()
-	// only ever keeps the tail (HistoryLimit, default 60) of what ListAssistantMessages
-	// returns; fetching and JSON-decoding the WHOLE transcript first, only to discard
-	// everything but the tail, cost time and memory proportional to total session length
-	// (autopilot runs, long-lived chat/tailoring sessions can accumulate hundreds of rows)
-	// instead of the fixed window actually used. The caller reverses these rows back to
-	// ascending seq order before handing them to trim()/Conversation().
+	// only ever keeps a bounded window of what ListAssistantMessages returns; fetching and
+	// JSON-decoding the WHOLE transcript first, only to discard everything but that window,
+	// cost time and memory proportional to total session length (autopilot runs, long-lived
+	// chat/tailoring sessions can accumulate hundreds of rows) instead of the bounded window
+	// actually used. The caller reverses these rows back to ascending seq order before
+	// handing them to trim()/Conversation().
+	//
+	// The LIMIT the caller passes is HistoryLimit PLUS one block (Runner.history), not
+	// HistoryLimit: trim cuts the window at a block boundary so the replayed prefix stays
+	// byte-identical between turns and the provider's prompt cache can hit it, and the widest
+	// window such a boundary leaves is just under one block past the limit.
 	ListRecentAssistantMessages(ctx context.Context, arg ListRecentAssistantMessagesParams) ([]AssistantMessage, error)
 	// Keyset continuation of the global feed: rows strictly older than the cursor.
 	ListRecentOpenThreadsAfter(ctx context.Context, arg ListRecentOpenThreadsAfterParams) ([]ListRecentOpenThreadsAfterRow, error)

--- a/internal/platform/db/queries/assistant.sql
+++ b/internal/platform/db/queries/assistant.sql
@@ -89,12 +89,17 @@ ORDER BY seq;
 -- name: ListRecentAssistantMessages :many
 -- The session's most recent messages, newest first — the bounded counterpart of
 -- ListAssistantMessages, for rebuilding the model's own history every turn. Runner.trim()
--- only ever keeps the tail (HistoryLimit, default 60) of what ListAssistantMessages
--- returns; fetching and JSON-decoding the WHOLE transcript first, only to discard
--- everything but the tail, cost time and memory proportional to total session length
--- (autopilot runs, long-lived chat/tailoring sessions can accumulate hundreds of rows)
--- instead of the fixed window actually used. The caller reverses these rows back to
--- ascending seq order before handing them to trim()/Conversation().
+-- only ever keeps a bounded window of what ListAssistantMessages returns; fetching and
+-- JSON-decoding the WHOLE transcript first, only to discard everything but that window,
+-- cost time and memory proportional to total session length (autopilot runs, long-lived
+-- chat/tailoring sessions can accumulate hundreds of rows) instead of the bounded window
+-- actually used. The caller reverses these rows back to ascending seq order before
+-- handing them to trim()/Conversation().
+--
+-- The LIMIT the caller passes is HistoryLimit PLUS one block (Runner.history), not
+-- HistoryLimit: trim cuts the window at a block boundary so the replayed prefix stays
+-- byte-identical between turns and the provider's prompt cache can hit it, and the widest
+-- window such a boundary leaves is just under one block past the limit.
 SELECT session_id, seq, role, content, created_at
 FROM assistant_messages
 WHERE session_id = $1


### PR DESCRIPTION
The assistant re-reads its whole conversation at full price on every turn. This is why.

## The measurement

From the gateway's own counters, 16 days, `feature="assistant"`:

| | per request |
|---|---|
| input tokens | 30,848 |
| of which cache reads | 10,868 (**35%**) |

10,868 is about the size of the **static head alone** — the system prompt plus the tool schemas. The conversation itself, roughly 20k tokens a turn, never hits the cache once.

Time to first token, same window:

| model | streamed turns | avg TTFT |
|---|---|---|
| glm-4.7 | 311 | **5.0 s** |
| gemini-3-flash | 175 | **10.9 s** |

Someone types into the chat and watches nothing happen for 5–11 seconds. Most of that is prefill the cache should have absorbed.

## The cause

Prompt caching is a **prefix** match — one changed byte and everything after it is re-read. The replayed window was "the newest `HistoryLimit` messages":

```sql
ORDER BY seq DESC
LIMIT $2;   -- 60
```

That slides by one every turn. Turn N replays `[10…70]`, turn N+1 replays `[11…71]`. The system prompt and tool list are identical — those are the 10,868 tokens that do cache. Everything after them shifts by one message each turn, so none of it ever matches.

Worth noting the sliding is in the **SQL**, not in `trim()`'s slice. `RecentTranscript` already returns at most `HistoryLimit` rows, so `len(msgs) > limit` inside `trim` was never true and that branch never fired.

## The change

`trim` cuts at a block boundary instead. The window's oldest seq is rounded **down** to a multiple of the block, so it stands still while the newest advances:

```go
anchor := ((newestSeq - limit + 1) / block) * block
```

The prefix stays byte-identical for a block's worth of turns and breaks once, instead of breaking every turn.

**The block is a third of the window capped at 20, not a flat 20.** A fixed block turns a 4-message window into a 20-message one — that is not a caching tweak, it is a different bound. `TestHistoryIsBoundedToTheMostRecentMessages` caught exactly that when I first wrote it flat. At the production limit of 60 the block is 20; at 3 or less it is 1, which is the old behaviour exactly, so the existing test passes unchanged.

`Runner.history` now asks for `HistoryLimit+block` rows. That is part of the fix, not an optimisation beside it: fetching exactly `HistoryLimit` would cap the window at the limit again and put the cut back on every turn.

## Cost and what this does not fix

The window is now 60–79 messages instead of exactly 60. Those extra tokens are cached ones, roughly a tenth the price of the uncached tokens this avoids.

It does nothing for **gaps**. Provider caches expire in minutes, so someone who leaves for half an hour still pays full price on their next message. This fixes an active conversation, not a resumed one.

## Tests

Two new, written red first — against the old window the first one reported *25 distinct heads over 25 turns*, which is the bug stated as a number:

- `TestReplayedHistoryHeadMovesInBlocksSoTheCacheSurvives` — the window's head takes at most 2 distinct values over 25 turns.
- `TestReplayedHistoryWindowStaysBounded` — the window stays in `[limit, limit+block)` over 200 turns, so the quantisation cannot grow it without bound.

## Verifying after deploy

Both counters already exist, so before/after is a direct comparison:

- `bifrost_cache_read_input_tokens_total{feature="assistant"}` — 35% today, expecting 70–80%.
- `bifrost_stream_first_token_latency_seconds{feature="assistant"}` — 5.0 s / 10.9 s today.

If neither moves, the hypothesis was wrong and this reverts cleanly — it is one function and a fetch size.

## Checks

- `go build ./...`, `go vet ./...`, `go test ./...` — green
- `go vet -tags=integration ./...` — green
- `make sqlc` — regenerated (comment-only change to the query)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved assistant conversation replay to preserve stable history windows across turns, helping prompt caching remain effective.
  - History remains bounded while allowing a small additional block of context when needed.

- **Documentation**
  - Clarified how assistant message history limits and block-based trimming work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->