### PR TITLE
Keep the timeout an entrypoint chose when a call is attributed to a person

### DIFF
--- a/internal/ai/llmkey/bind.go
+++ b/internal/ai/llmkey/bind.go
@@ -24,13 +24,32 @@ import (
 // ownership shape (a specific candidate's own work, not owner-less background work) but no
 // reason to import internal/api/handler — see
 // openspec/changes/auto-apply-llm-drafting/design.md.
+// Bind is for the caller that has no client of its own yet and is about to build one from
+// this one. A caller that ALREADY holds a configured client must not come through here — it
+// would be handed a different client and lose whatever that configuration was. It resolves
+// the credential with Caller below and applies it here.
 func Bind(ctx context.Context, keys *Resolver, client *llm.Client, userID int64, dims ...llm.Dimension) *llm.Client {
 	if client == nil {
 		return nil
 	}
+	return client.AsCaller(Caller(ctx, keys, userID, dims...))
+}
+
+// Caller resolves who a call spends as, and hands back only that — no client.
+//
+// It is what a component with a client of its own asks for: an extractor, an analyzer or a
+// recall service built with a deliberately chosen timeout takes on the candidate's identity
+// through its own client and keeps its own settings. Handing such a component a whole client
+// instead is what silently replaced a 120s résumé-extraction budget with the 90s default for
+// every signed-in user; see llm.Caller.
+//
+// Same contract as Bind and for the same reason: it cannot fail. An unresolvable credential
+// yields a Caller that spends on the service credential and is still tagged, because knowing
+// which feature spent is useful even when the person could not be worked out.
+func Caller(ctx context.Context, keys *Resolver, userID int64, dims ...llm.Dimension) llm.Caller {
 	secret := keys.For(ctx, userID)
 	if secret == "" {
-		return client.As("", nil, dims...)
+		return llm.NewCaller("", nil, dims...)
 	}
 	// Forgetting runs on a context detached from the caller's. A refusal is most likely
 	// to arrive exactly when someone has closed the tab (or, for a queue-triggered caller,
@@ -39,5 +58,5 @@ func Bind(ctx context.Context, keys *Resolver, client *llm.Client, userID int64,
 	// abandoned request.
 	forget := func() { keys.Forget(context.WithoutCancel(ctx), userID, secret) }
 
-	return client.As(secret, forget, dims...)
+	return llm.NewCaller(secret, forget, dims...)
 }

--- a/internal/api/handler/assistant_cover_letter_tool.go
+++ b/internal/api/handler/assistant_cover_letter_tool.go
@@ -62,8 +62,8 @@ func (h *assistantHandlers) coverLetterDraftTool(jobID int64) assistant.Tool {
 				return nil, errors.New("the candidate has used today's cover-letter allowance; " +
 					"tell them it resets tomorrow, or that Pro lifts the limit")
 			}
-			client := llmkey.Bind(ctx, h.keys, h.llm, userID, llm.Feature(tagCoverLetter))
-			letter, err := drafter.draft(ctx, client, userID, jobID, toolBand(in.Band))
+			caller := llmkey.Caller(ctx, h.keys, userID, llm.Feature(tagCoverLetter))
+			letter, err := drafter.draft(ctx, caller, userID, jobID, toolBand(in.Band))
 			if err != nil || letter == nil {
 				// Every failing path gives the charge back, so it is given back once here.
 				releaseLetterCharge(h.plans, userID, charge)

--- a/internal/api/handler/ats_report.go
+++ b/internal/api/handler/ats_report.go
@@ -87,7 +87,7 @@ func (h *resumeHandlers) PostATSReport(c *fiber.Ctx) error {
 		// asking the model to judge a document it cannot see.
 		return c.JSON(fiber.Map{"data": atsResponse{HasCV: true, Report: report}})
 	}
-	analyzer := h.atsAnalyzer.As(h.llm.bind(c.Context(), userID, llm.Feature(tagATSReview)))
+	analyzer := h.atsAnalyzer.As(h.llm.caller(c.Context(), userID, llm.Feature(tagATSReview)))
 	review, err := analyzer.Analyze(c.Context(), candidate)
 	if err != nil {
 		// Best-effort: log (never the CV text) and serve the deterministic report.

--- a/internal/api/handler/cover_letter_drafter.go
+++ b/internal/api/handler/cover_letter_drafter.go
@@ -65,16 +65,16 @@ func (d letterDrafter) ready() bool {
 // caller reads as "release whatever was charged and say so". Every other failure comes back
 // as an error, so a caller can never overwrite a stored letter with an empty one.
 func (d letterDrafter) draft(
-	ctx context.Context, client *llm.Client, userID, jobID int64, band coverletter.Band,
+	ctx context.Context, caller llm.Caller, userID, jobID int64, band coverletter.Band,
 ) (*coverletter.Letter, error) {
-	return d.draftStream(ctx, client, userID, jobID, band, func(string, bool) {})
+	return d.draftStream(ctx, caller, userID, jobID, band, func(string, bool) {})
 }
 
 // draftStream is draft with progress. The streaming endpoint needs it because the chain takes
 // minutes and a silent response is one a proxy closes at sixty seconds; every other caller
 // takes the no-op above.
 func (d letterDrafter) draftStream(
-	ctx context.Context, client *llm.Client, userID, jobID int64, band coverletter.Band, emit coverletter.Emit,
+	ctx context.Context, caller llm.Caller, userID, jobID int64, band coverletter.Band, emit coverletter.Emit,
 ) (*coverletter.Letter, error) {
 	job, err := d.jobs.GetJob(ctx, jobID)
 	if err != nil {
@@ -108,7 +108,12 @@ func (d letterDrafter) draftStream(
 
 	// The atoms go in UNFILTERED: the provenance gate lives inside Draft so that no caller can
 	// apply a weaker one, or forget to apply it at all.
-	letter, err := d.chain.As(client).DraftStream(ctx, coverletter.Input{
+	// Bound once, and the same bound chain both writes the letter and names the model it was
+	// written with. Reading the id off a separately bound client is what let the stamp and the
+	// writer drift apart in principle — they were the same model only because both happened to
+	// come from the same configuration.
+	chain := d.chain.As(caller)
+	letter, err := chain.DraftStream(ctx, coverletter.Input{
 		Context:         tailoring,
 		Candidate:       candidate,
 		Atoms:           atoms,
@@ -118,7 +123,7 @@ func (d letterDrafter) draftStream(
 	if err != nil || letter == nil {
 		return nil, err
 	}
-	if err := d.letters.Save(ctx, userID, jobID, *letter, modelIDOf(client)); err != nil {
+	if err := d.letters.Save(ctx, userID, jobID, *letter, chain.ModelID()); err != nil {
 		return nil, err
 	}
 	return letter, nil
@@ -241,14 +246,4 @@ func citedAtomsOf(ctx context.Context, bank letterBankPort, userID int64, ids []
 		out = append(out, citedAtom{ID: id.String(), Claim: claims[id]})
 	}
 	return out
-}
-
-// modelIDOf names the model a draft is stamped with. Empty on a deployment with no gateway,
-// which Stored.Stale then reads as "matches" — a letter cannot be stale against a model that
-// does not exist.
-func modelIDOf(client *llm.Client) string {
-	if client == nil {
-		return ""
-	}
-	return client.ModelID()
 }

--- a/internal/api/handler/cv_cover_letter.go
+++ b/internal/api/handler/cv_cover_letter.go
@@ -51,7 +51,7 @@ func (h *cvHandlers) GetCVCoverLetter(c *fiber.Ctx) error {
 	}
 	return c.JSON(fiber.Map{"data": coverLetterResponse{
 		Present: true,
-		Stale:   stored.Stale(modelIDOf(h.llm.client), job.PostingLanguage),
+		Stale:   stored.Stale(h.letter.chain.ModelID(), job.PostingLanguage),
 		Letter:  &stored.Letter,
 		Cited:   citedAtomsOf(c.Context(), h.letter.bank, userID, stored.Cited),
 		Model:   stored.Model,
@@ -79,8 +79,8 @@ func (h *cvHandlers) DraftCVCoverLetter(c *fiber.Ctx) error {
 		return refuse(c, decision)
 	}
 
-	client := h.llm.bind(c.Context(), userID, llm.Feature(tagCoverLetter))
-	letter, err := drafter.draft(c.Context(), client, userID, jobID, coverLetterBand(c))
+	caller := h.llm.caller(c.Context(), userID, llm.Feature(tagCoverLetter))
+	letter, err := drafter.draft(c.Context(), caller, userID, jobID, coverLetterBand(c))
 	if err != nil || letter == nil {
 		// Every failing path gives the charge back, so it is given back once here rather than
 		// in each branch — a candidate must never pay for a letter they did not get.
@@ -104,7 +104,7 @@ func (h *cvHandlers) DraftCVCoverLetter(c *fiber.Ctx) error {
 		Present: true,
 		Letter:  letter,
 		Cited:   citedAtomsOf(c.Context(), h.letter.bank, userID, letter.Cited),
-		Model:   modelIDOf(client),
+		Model:   h.letter.chain.ModelID(),
 	}})
 }
 

--- a/internal/api/handler/cv_cover_letter_stream.go
+++ b/internal/api/handler/cv_cover_letter_stream.go
@@ -60,7 +60,7 @@ func (h *cvHandlers) StreamCVCoverLetter(c *fiber.Ctx) error {
 	// carries the write deadline sseStream needs; the hub is cloned because the writer
 	// outlives the request that owns its scope.
 	band := coverLetterBand(c)
-	client := h.llm.bind(c.Context(), userID, llm.Feature(tagCoverLetter))
+	caller := h.llm.caller(c.Context(), userID, llm.Feature(tagCoverLetter))
 	conn := c.Context().Conn()
 	var hub *sentry.Hub
 	if reqHub := sentryfiber.GetHubFromContext(c); reqHub != nil {
@@ -104,7 +104,7 @@ func (h *cvHandlers) StreamCVCoverLetter(c *fiber.Ctx) error {
 		// The chain's own first emit opens a stage before it makes any network call, so it IS
 		// the early first byte this endpoint exists for — nothing needs to be written ahead of
 		// it, and writing one would send `select` twice.
-		letter, err := drafter.draftStream(ctx, client, userID, jobID, band, func(stage string, done bool) {
+		letter, err := drafter.draftStream(ctx, caller, userID, jobID, band, func(stage string, done bool) {
 			stream.event("stage", letterStageEvent{Stage: stage, Done: done})
 		})
 		if err == nil && letter != nil {
@@ -113,7 +113,7 @@ func (h *cvHandlers) StreamCVCoverLetter(c *fiber.Ctx) error {
 				Present: true,
 				Letter:  letter,
 				Cited:   citedAtomsOf(ctx, drafter.bank, userID, letter.Cited),
-				Model:   modelIDOf(client),
+				Model:   h.letter.chain.ModelID(),
 			})
 			return
 		}

--- a/internal/api/handler/cv_cover_letter_test.go
+++ b/internal/api/handler/cv_cover_letter_test.go
@@ -56,14 +56,6 @@ func TestCoverLetterRefSeparatesJobsAndAttempts(t *testing.T) {
 	}
 }
 
-// An unconfigured deployment must not be reported as a letter written by a nameless model:
-// Stale compares this against the stored stamp, and "" == "" reads as "matches".
-func TestModelIDOfIsEmptyWithoutAGateway(t *testing.T) {
-	if got := modelIDOf(nil); got != "" {
-		t.Errorf("model = %q, want empty when no gateway is configured", got)
-	}
-}
-
 // A drafter missing any dependency must refuse in its caller's own vocabulary rather than
 // panic inside it - on the tool's path that panic lands in a detached goroutine where no
 // error path is listening.

--- a/internal/api/handler/match_analysis.go
+++ b/internal/api/handler/match_analysis.go
@@ -321,7 +321,7 @@ func (h *matchHandlers) buildAnalysisInput(c *fiber.Ctx, job db.Job, userID int6
 // Binding is a network call, so a streaming caller makes it before its headers go out —
 // afterwards it would stall a stream the client is already reading.
 func (h *matchHandlers) boundAnalyzer(ctx context.Context, userID int64) *matchanalysis.Analyzer {
-	return h.matchAnalysis.As(h.llm.bind(ctx, userID, llm.Feature(tagMatchAnalysis)))
+	return h.matchAnalysis.As(h.llm.caller(ctx, userID, llm.Feature(tagMatchAnalysis)))
 }
 
 // autopilotAnalysis is one autopilot run's fit analysis: the cold-start fill the run's first

--- a/internal/api/handler/match_analysis_stream.go
+++ b/internal/api/handler/match_analysis_stream.go
@@ -183,7 +183,24 @@ func (h *matchHandlers) StreamMatchAnalysis(c *fiber.Ctx) error {
 			return
 		}
 		if analysis == nil {
-			stream.event("stream_error", map[string]string{"message": "analysis unavailable"})
+			// Two situations produce the same silence, and only one of them is the
+			// candidate's to act on. A deployment with no gateway owes them nothing but an
+			// apology; a CV whose background parse failed leaves no banked experience for
+			// the chain to reason over, and only they can fix that by uploading it again.
+			//
+			// Saying "analysis unavailable" for both is what this replaces. The stream had
+			// already told them has_cv=true — their file IS stored — so the message read as a
+			// fault on our side of a screen that said everything was fine, and there was
+			// nothing in the log either: this branch was the one path here that recorded
+			// nothing at all.
+			msg := "analysis unavailable"
+			reason := "no analysis produced"
+			if !matchanalysis.HasCandidateContext(req.Input.StructuredResume) {
+				msg = "We couldn't read your CV, so there's nothing to compare this job against. Try uploading it again."
+				reason = "no banked experience — the CV's background parse produced none"
+			}
+			log.Printf("matchanalysis: stream EMPTY user=%d job=%d dur=%s events=%d: %s", userID, job.ID, time.Since(start).Round(time.Millisecond), events, reason)
+			stream.event("stream_error", map[string]string{"message": msg})
 			return
 		}
 		log.Printf("matchanalysis: stream DONE user=%d job=%d dur=%s events=%d overall=%d", userID, job.ID, time.Since(start).Round(time.Millisecond), events, analysis.OverallScore)

--- a/internal/api/handler/resume.go
+++ b/internal/api/handler/resume.go
@@ -343,7 +343,7 @@ func (h *resumeHandlers) extractStructuredResume(userID int64, text string, uplo
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), resumeExtractLLMTimeout+30*time.Second)
 	defer cancel()
-	extractor := h.structuredExtractor.As(h.llm.bind(ctx, userID, llm.Feature(tagCVExtract)))
+	extractor := h.structuredExtractor.As(h.llm.caller(ctx, userID, llm.Feature(tagCVExtract)))
 	st, err := extractor.Extract(ctx, text)
 	if err != nil {
 		log.Printf("resume structured: user %d: %v", userID, err)

--- a/internal/api/handler/user_llm.go
+++ b/internal/api/handler/user_llm.go
@@ -37,6 +37,16 @@ type llmBinding struct {
 }
 
 // bind returns the client one call should travel on. See llmkey.Bind: it cannot fail.
+//
+// Only for a caller building something out of this client. A component that ALREADY holds a
+// client — an extractor, an analyzer, a recall service — takes `caller` below instead, so its
+// own configuration survives being attributed to a person. See llm.Caller.
 func (b llmBinding) bind(ctx context.Context, userID int64, dims ...llm.Dimension) *llm.Client {
 	return llmkey.Bind(ctx, b.keys, b.client, userID, dims...)
+}
+
+// caller returns who one call spends as, for a component to apply to its own client. See
+// llmkey.Caller: like bind, it cannot fail.
+func (b llmBinding) caller(ctx context.Context, userID int64, dims ...llm.Dimension) llm.Caller {
+	return llmkey.Caller(ctx, b.keys, userID, dims...)
 }

--- a/internal/application/mailrecall/mailrecall.go
+++ b/internal/application/mailrecall/mailrecall.go
@@ -210,8 +210,18 @@ func New(store Store, client *llm.Client) *Service { return &Service{store: stor
 
 // As returns a copy running on the caller's own gateway credential, so a recall is billed
 // to the person who pressed the button rather than to the service. It is a clone because
-// the credential is per-user and the store is not — the same seam matchanalysis, atscheck
-// and resumeextract carry.
+// the credential is per-user and the store is not.
+//
+// This one still takes a whole generator where matchanalysis, atscheck, coverletter and
+// resumeextract now take an llm.Caller, and deliberately: those four hold an *llm.Client
+// they were CONFIGURED with, so replacing it wholesale threw that configuration away — the
+// bug llm.Caller records. This service holds `gen`, a two-method consumer interface with no
+// configuration in it at all, so there is nothing here for a substitution to lose. Giving it
+// a caller instead would mean widening that interface to carry a rebind, which is a test seam
+// paying for a hazard it does not have.
+//
+// The hazard would arrive the day this service is built from a client with a timeout of its
+// own. Give it an llm.Caller then, and let `gen` grow the method to apply one.
 func (s *Service) As(client *llm.Client) *Service {
 	if s == nil || client == nil {
 		return s

--- a/internal/candidate/atscheck/analyzer.go
+++ b/internal/candidate/atscheck/analyzer.go
@@ -27,14 +27,17 @@ type Analyzer struct {
 }
 
 // NewAnalyzer wraps an llm.Client. client may be nil (LLM unconfigured).
-// As returns an analyzer that runs on a different client, so one review can be spent
-// under the caller's own gateway credential. Nil-safe both ways.
-func (a *Analyzer) As(client *llm.Client) *Analyzer {
-	if a == nil || client == nil {
+// As returns an analyzer spending as `caller`, so one review is billed to the candidate's
+// own gateway credential. Nil-safe.
+//
+// It takes a caller and not a client so this analyzer keeps whatever it was built with; see
+// llm.Caller for what the shape it replaces cost.
+func (a *Analyzer) As(caller llm.Caller) *Analyzer {
+	if a == nil {
 		return a
 	}
 	clone := *a
-	clone.client = client
+	clone.client = a.client.AsCaller(caller)
 
 	return &clone
 }

--- a/internal/candidate/coverletter/analyzer.go
+++ b/internal/candidate/coverletter/analyzer.go
@@ -55,14 +55,28 @@ type Analyzer struct {
 
 func NewAnalyzer(client *llm.Client) *Analyzer { return &Analyzer{client: client} }
 
-// As returns an analyzer running on a different client, so one draft can be spent under the
-// caller's own gateway credential. Nil-safe both ways, mirroring atscheck.Analyzer.As.
-func (a *Analyzer) As(client *llm.Client) *Analyzer {
-	if a == nil || client == nil {
+// ModelID returns the underlying model id, so a caller can stamp a stored draft with the
+// model that wrote it and later ask whether that is still the model it would get. Empty on a
+// nil analyzer or an unconfigured client, which reads as "no model" at both ends. Mirrors
+// resumeextract.Extractor.ModelID.
+func (a *Analyzer) ModelID() string {
+	if a == nil {
+		return ""
+	}
+	return a.client.ModelID()
+}
+
+// As returns an analyzer spending as `caller`, so one draft is billed to the candidate's own
+// gateway credential. Nil-safe, mirroring atscheck.Analyzer.As.
+//
+// It takes a caller and not a client so this analyzer keeps whatever it was built with; see
+// llm.Caller for what the shape it replaces cost.
+func (a *Analyzer) As(caller llm.Caller) *Analyzer {
+	if a == nil {
 		return a
 	}
 	clone := *a
-	clone.client = client
+	clone.client = a.client.AsCaller(caller)
 	return &clone
 }
 

--- a/internal/candidate/matchanalysis/analyzer.go
+++ b/internal/candidate/matchanalysis/analyzer.go
@@ -36,15 +36,20 @@ type Analyzer struct {
 
 // NewAnalyzer wraps an llm.Client; client may be nil (LLM unconfigured), in which case the
 // analysis degrades to a no-op.
-// As returns an analyzer that runs on a different client, so one analysis can be spent
-// under the caller's own gateway credential. The analyzer is one field, so cloning it per
-// request costs nothing beside the model calls it is about to make. Nil-safe both ways.
-func (a *Analyzer) As(client *llm.Client) *Analyzer {
-	if a == nil || client == nil {
+// As returns an analyzer spending as `caller`, so one analysis is billed to the candidate's
+// own gateway credential. The analyzer is one field, so cloning it per request costs nothing
+// beside the model calls it is about to make. Nil-safe.
+//
+// It takes a caller and not a client so the chain keeps the per-stage timeout it was built
+// with (matchAnalysisLLMTimeout). That figure happens to equal the client default today, so
+// the shape this replaces cost nothing here — it cost the résumé extraction beside it, and
+// would have cost this one the day somebody changed the number. See llm.Caller.
+func (a *Analyzer) As(caller llm.Caller) *Analyzer {
+	if a == nil {
 		return a
 	}
 	clone := *a
-	clone.client = client
+	clone.client = a.client.AsCaller(caller)
 
 	return &clone
 }
@@ -465,6 +470,22 @@ const maxStructuredRunes = 3000
 // does not name never reaches the prompt, including one that does not exist yet. Deleting known
 // contact keys would have sent every future addition to the model until somebody remembered to
 // extend the list.
+// HasCandidateContext reports whether there is enough banked work history for the chain to
+// reason over. False means AnalyzeStream will decline and produce nothing.
+//
+// Exported so a caller can tell the two reasons an analysis came back empty apart, and say
+// which one it was. They are the same silence and completely different situations: a
+// deployment with no gateway is nothing the candidate did, while an unreadable CV is
+// something only they can fix — and until this existed both rendered as "analysis
+// unavailable", which sent a candidate whose CV had failed to parse looking for a fault on
+// our side of a screen that said their CV was present.
+//
+// One predicate, one owner: whether the chain can run is this package's rule, and a caller
+// re-deriving it from the same field would be a second copy free to drift.
+func HasCandidateContext(candidate resumeextract.Professional) bool {
+	return candidateContext(candidate) != ""
+}
+
 func candidateContext(candidate resumeextract.Professional) string {
 	if len(candidate.Experience) == 0 {
 		return ""

--- a/internal/candidate/matchanalysis/candidate_context_test.go
+++ b/internal/candidate/matchanalysis/candidate_context_test.go
@@ -1,0 +1,52 @@
+package matchanalysis
+
+import (
+	"testing"
+
+	"github.com/strelov1/freehire/internal/candidate/resumeextract"
+)
+
+// The predicate a caller needs to say WHY an analysis came back empty.
+//
+// The chain scores the fit from banked work history and never falls back to the raw CV, so
+// a candidate whose CV failed to parse has a stored file and nothing to reason over. That
+// used to reach them as "analysis unavailable" on a screen that had just told them their CV
+// was present — a fault that looked like ours and was theirs to fix.
+func TestHasCandidateContext(t *testing.T) {
+	t.Run("false with no banked experience, whatever else the résumé carries", func(t *testing.T) {
+		// Everything but the one field the chain reads. A summary and a skill list are not
+		// evidence of having done anything, which is why they do not count.
+		full := resumeextract.Professional{
+			Headline: "Senior Salesforce Developer",
+			Summary:  "Ten years of Salesforce delivery.",
+			Skills:   []string{"salesforce", "apex"},
+		}
+		if HasCandidateContext(full) {
+			t.Error("HasCandidateContext = true with no experience; the chain would decline and the caller would say the wrong thing")
+		}
+	})
+
+	t.Run("true with one employment", func(t *testing.T) {
+		one := resumeextract.Professional{
+			Experience: []resumeextract.Experience{{Company: "Acme", Title: "Backend Engineer"}},
+		}
+		if !HasCandidateContext(one) {
+			t.Error("HasCandidateContext = false with a banked employment; the chain would have run")
+		}
+	})
+
+	t.Run("agrees with what the chain actually does", func(t *testing.T) {
+		// The predicate exists so a caller need not re-derive the rule. If it ever stopped
+		// answering the same question as the renderer the chain gates on, a caller would
+		// explain an outcome that did not happen.
+		for _, p := range []resumeextract.Professional{
+			{},
+			{Summary: "words"},
+			{Experience: []resumeextract.Experience{{Company: "Acme"}}},
+		} {
+			if got, want := HasCandidateContext(p), candidateContext(p) != ""; got != want {
+				t.Errorf("HasCandidateContext(%+v) = %v, want %v", p, got, want)
+			}
+		}
+	})
+}

--- a/internal/candidate/resumeextract/as_test.go
+++ b/internal/candidate/resumeextract/as_test.go
@@ -1,0 +1,53 @@
+package resumeextract
+
+import (
+	"testing"
+
+	"github.com/strelov1/freehire/internal/platform/llm"
+)
+
+// As must attribute the extraction to the candidate WITHOUT swapping the client this
+// extractor was built with — which is the configuration the extraction depends on, its 120s
+// budget above all.
+//
+// The model id stands in for that client's identity here: it is the one setting readable
+// from outside the llm package, and an extractor running on somebody else's client would
+// report somebody else's model. The timeout itself is asserted where it lives, in
+// llm.TestAsCallerKeepsTheTimeoutTheClientWasBuiltWith.
+func TestAsKeepsTheExtractorsOwnClient(t *testing.T) {
+	client, err := llm.New("https://gateway.example", "service-key", "the-configured-model")
+	if err != nil {
+		t.Fatalf("llm.New: %v", err)
+	}
+	e := NewExtractor(client, nil)
+
+	bound := e.As(llm.NewCaller("a-candidates-own-key", nil, llm.Feature("cv-extract")))
+
+	if got := bound.ModelID(); got != "the-configured-model" {
+		t.Errorf("ModelID after binding a caller = %q, want the extractor's own model", got)
+	}
+}
+
+// A nil extractor is the unconfigured deployment, and binding a caller to it must stay a
+// no-op rather than panic on a path that runs in a detached goroutine.
+func TestAsIsNilSafe(t *testing.T) {
+	var e *Extractor
+	if got := e.As(llm.NewCaller("k", nil)); got != nil {
+		t.Errorf("As on a nil extractor = %v, want nil", got)
+	}
+}
+
+// An extractor with no client (no gateway configured) must survive attribution too: there is
+// nothing to bind a credential to, and Extract already degrades to ErrDisabled.
+func TestAsWithoutAClientStaysDisabled(t *testing.T) {
+	e := NewExtractor(nil, nil)
+
+	bound := e.As(llm.NewCaller("k", nil, llm.Feature("cv-extract")))
+
+	if bound == nil {
+		t.Fatal("As returned nil for a client-less extractor; the caller would panic on it")
+	}
+	if got := bound.ModelID(); got != "" {
+		t.Errorf("ModelID = %q, want empty with no gateway configured", got)
+	}
+}

--- a/internal/candidate/resumeextract/resumeextract.go
+++ b/internal/candidate/resumeextract/resumeextract.go
@@ -34,15 +34,19 @@ type Extractor struct {
 
 // NewExtractor wraps an llm.Client and the PII detector; either may be nil, which disables
 // extraction (ErrDisabled).
-// As returns an extractor that runs on a different client, so one extraction can be spent
-// under the caller's own gateway credential. The PII detector travels with it: redaction
-// is not the credential's business and must hold whoever is paying. Nil-safe both ways.
-func (e *Extractor) As(client *llm.Client) *Extractor {
-	if e == nil || client == nil {
+// As returns an extractor spending as `caller`, so one extraction is billed to the
+// candidate's own gateway credential. The PII detector travels with it: redaction is not
+// the credential's business and must hold whoever is paying. Nil-safe.
+//
+// It takes a caller and not a client for the reason llm.Caller records: being handed a whole
+// client replaced the one built here — and with it the extraction's own 120s budget, which is
+// how this call came to run on the 90s default and time out on long CVs.
+func (e *Extractor) As(caller llm.Caller) *Extractor {
+	if e == nil {
 		return e
 	}
 	clone := *e
-	clone.client = client
+	clone.client = e.client.AsCaller(caller)
 
 	return &clone
 }

--- a/internal/platform/llm/caller_test.go
+++ b/internal/platform/llm/caller_test.go
@@ -1,0 +1,72 @@
+package llm
+
+import (
+	"testing"
+	"time"
+)
+
+// The regression this whole type exists for.
+//
+// Attribution used to travel as a whole *Client, so a component built with a deliberately
+// chosen timeout had that client REPLACED for every signed-in caller — and ran on the
+// default instead. On prod that turned a 120s résumé-extraction budget into 90s, which is
+// exactly long enough to fail on a long CV: the candidate ended up with no banked
+// experience, no fit analysis, and no explanation for either.
+//
+// Asserting on the field rather than on an observed request deliberately. The timeout is
+// what bounds a call, so nothing about a call that RETURNS can show it was carried; the
+// alternative is a test that sleeps.
+func TestAsCallerKeepsTheTimeoutTheClientWasBuiltWith(t *testing.T) {
+	const chosen = 120 * time.Second
+
+	base, err := New("https://gateway.example", "service-key", "model-x")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	configured := base.WithTimeout(chosen)
+	if configured.timeout != chosen {
+		t.Fatalf("precondition: configured timeout = %s, want %s", configured.timeout, chosen)
+	}
+
+	bound := configured.AsCaller(NewCaller("a-users-own-key", nil, Feature("cv-extract")))
+	if bound.timeout != chosen {
+		t.Errorf("timeout after binding a caller = %s, want %s — the entrypoint's budget was discarded", bound.timeout, chosen)
+	}
+	if bound.apiKey != "a-users-own-key" {
+		t.Errorf("credential after binding = %q, want the caller's own", bound.apiKey)
+	}
+}
+
+// A caller with no credential of its own still tags the call, and still must not disturb
+// anything else the client was built with: attribution fails open, and failing open must
+// not mean falling back to a different configuration.
+func TestAsCallerWithNoSecretKeepsTheTimeoutAndTheServiceCredential(t *testing.T) {
+	const chosen = 45 * time.Second
+
+	base, err := New("https://gateway.example", "service-key", "model-x")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	bound := base.WithTimeout(chosen).AsCaller(NewCaller("", nil, Feature("cv-extract")))
+
+	if bound.timeout != chosen {
+		t.Errorf("timeout = %s, want %s", bound.timeout, chosen)
+	}
+	if bound.apiKey != "service-key" {
+		t.Errorf("credential = %q, want the service's own when the caller has none", bound.apiKey)
+	}
+}
+
+// The zero Caller names nobody and nothing, which is what a background job hands over. It
+// must be free: no credential swap, no tags, and — the point — no change of configuration.
+func TestAsCallerWithTheZeroValueChangesNothing(t *testing.T) {
+	base, err := New("https://gateway.example", "service-key", "model-x")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	configured := base.WithTimeout(30 * time.Second)
+
+	if got := configured.AsCaller(Caller{}); got != configured {
+		t.Errorf("AsCaller(zero) returned a different client; want the receiver untouched")
+	}
+}

--- a/internal/platform/llm/credential.go
+++ b/internal/platform/llm/credential.go
@@ -53,6 +53,43 @@ func stamp(req *http.Request, dims []Dimension) {
 // carries; see the constants in internal/api/handler/user_llm.go.
 func Feature(value string) Dimension { return Dimension{Name: "feature", Value: value} }
 
+// Caller is WHO a call spends as: a gateway credential, the callback that clears it when
+// the gateway says it no longer knows it, and the dimensions the spend is filed under.
+//
+// It exists because the shape it replaces invited one specific mistake, and prod paid for
+// it. Attribution used to travel as a whole *Client, so a component holding a client
+// configured for its OWN work had that client replaced wholesale by one built for
+// attribution alone — and every setting the entrypoint had chosen went with it, the
+// timeout above all. The structured-résumé extraction declared a 120s budget
+// (resumeExtractLLMTimeout) and ran every signed-in user's call on the 90s default,
+// which is long enough to fail on a long CV and leave the candidate with no banked
+// experience, no fit analysis, and no explanation for either.
+//
+// A Caller carries who, never how. There is no client inside it to substitute, so a call
+// site cannot make that trade again — not by mistake and not on purpose.
+type Caller struct {
+	secret    string
+	onRefused func()
+	dims      []Dimension
+}
+
+// NewCaller names who a call spends as. The zero Caller is the service's own credential
+// with no dimensions, which is what an unconfigured deployment and a background job both
+// want — see AsCaller, which returns the receiver untouched for it.
+func NewCaller(secret string, onRefused func(), dims ...Dimension) Caller {
+	return Caller{secret: secret, onRefused: onRefused, dims: dims}
+}
+
+// AsCaller returns this client spending as `caller` and keeping everything else it was
+// built with — the timeout most of all.
+//
+// This is how a component that already holds a correctly configured client takes on a
+// caller's identity. Handing it somebody else's client instead is the mistake Caller's own
+// comment records; there is no longer a signature that accepts one.
+func (c *Client) AsCaller(caller Caller) *Client {
+	return c.As(caller.secret, caller.onRefused, caller.dims...)
+}
+
 // As returns a client that spends under a given credential and labels its calls.
 //
 // An empty secret keeps the client's own credential — attribution fails open, and a call


### PR DESCRIPTION
Chased from a user report of `{"message":"analysis unavailable"}` on the
match-analysis stream. It is one defect with three faces.

## The chain, as prod shows it

Taking user 1814 and the vacancy they were looking at:

| time | what happened |
|---|---|
| 22:29:00 | CV stored (`resume_uploaded_at`) |
| 22:30:33 | background extraction dies: `resume structured: user 1814: resumeextract: generate: llm: generate: request timeout: API call exceeded deadline` |
| — | `experience_employments` and `experience_atoms` for that user: **0 rows** |
| 22:31:57 … 22:32:17 | five `matchanalysis: stream start user=1814 … has_cv=true leader=true`, every one answering in **under 52 ms** |

Under 52 ms is the tell: no model call was ever made. The fit chain scores from
banked work history and never falls back to the raw CV
(`analyzer.go`, `candidateContext`), so with no experience it declines and
returns `(nil, nil)` — which the stream rendered as `analysis unavailable`.

The candidate's file *is* stored. The stream had already told them `has_cv=true`.
So the message read as a fault on our side of a screen that said everything was
fine, and there was nothing in the log either: that branch was the one path
through the writer that recorded nothing at all.

## Why the extraction timed out

Not the gateway, and not the model. Measured from the production host while
diagnosing: `/models` answers 200 in 1.0s; the PII detector answers in 1.1–1.5s;
`LLM_STRICT_SCHEMA` is off; and the served model (`glm-5.3-flash`) extracts a
28 000-character CV in **10.2s**.

The 93 seconds between upload and failure is 90s + the PII pass. And 90s is
`llm.DefaultTimeout` — not the 120s the extraction declares.

`"request timeout: API call exceeded deadline"` is langchaingo's sanitized text
for a context deadline (`openaiclient.go:223`), i.e. **our** deadline, not the
gateway's. So the question was only ever "whose 90s".

**Attribution's.** `structuredExtractor` is built with
`cfg.LLM.WithTimeout(resumeExtractLLMTimeout)` — 120s. Then, per request:

```go
h.structuredExtractor.As(h.llm.bind(ctx, userID, llm.Feature(tagCVExtract)))
```

`As` replaced the client wholesale (`clone.client = client`), and `bind` builds
from `llmBinding.client`, which is the bare `cfg.LLM`. The 120s was discarded for
every signed-in user, silently, on every upload.

## The fix

`llm.Caller` carries **who** a call spends as — credential, refusal callback,
dimensions — and nothing else. There is no client inside it to substitute, so a
call site cannot make that trade again, by mistake or on purpose.

- `resumeextract`, `matchanalysis`, `atscheck` and `coverletter` take an
  `llm.Caller` and apply it to the client they already hold.
- `llmkey.Caller` resolves the credential; `llmkey.Bind` is now expressed in
  terms of it, so there is one resolution path and two shapes.
- The entrypoints that *build* something out of the binding's client
  (`autofill`, `search-intent`, the assistant) still take a client — they have no
  configuration to lose.
- `mailrecall` deliberately keeps the client shape. It holds `gen`, a two-method
  consumer interface with no configuration in it, so there is nothing a
  substitution can lose; giving it a caller would mean widening a test seam to
  pay for a hazard it does not have. Its comment says so, and says what would
  change that.

`matchAnalysisLLMTimeout` was also being discarded — it just happens to equal the
default today, so it cost nothing yet and would have cost the next person to
change the number.

### The message, and the log

`matchanalysis.HasCandidateContext` exports the rule the chain already gates on,
so the stream can say which of the two silences it hit:

- no gateway → `analysis unavailable` (unchanged; nothing the candidate can do)
- no banked experience → *"We couldn't read your CV, so there's nothing to
  compare this job against. Try uploading it again."*

Both now log. The frontend renders `stream_error.message` verbatim
(`matchAnalysis.ts`), so no client change is needed.

### Incidental

The cover letter's model stamp now comes from the chain that writes it rather
than from a separately bound client. Same value today — because both came from
the same configuration — which is exactly the coupling worth removing. That
orphaned `modelIDOf`, whose only remaining caller was its own test; both are
gone, and `coverletter.Analyzer.ModelID` covers the nil case instead.

## What this does not fix

Whether **120s is enough** is now an open question rather than an answered one —
this restores the budget that was declared, it does not prove the figure. Worth
watching `resume structured:` failures after deploy; they should drop, and if
they do not the number is the next thing to argue about.

## Checks

`go build ./...` · `go vet ./...` · `go vet -tags=integration ./...` ·
`go test ./...` all pass · `gofmt -l .` empty · `golangci-lint run` reports 26
pre-existing issues, none in any file this touches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved match analysis errors when a résumé cannot be read, with clearer guidance to re-upload it.
  * Preserved configured AI settings, such as response time limits, when processing requests on behalf of users.
  * Improved consistency of model selection across résumé extraction, cover letters, ATS reports, and match analysis.

* **Tests**
  * Added coverage for résumé context detection, caller attribution, and preservation of AI configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->