### PR TITLE
Stop paying for deliberation the resume extraction does not use

### DIFF
--- a/internal/candidate/resumeextract/resumeextract.go
+++ b/internal/candidate/resumeextract/resumeextract.go
@@ -86,8 +86,14 @@ func (e *Extractor) Extract(ctx context.Context, cvText string) (Structured, err
 	if err != nil {
 		return Structured{}, err
 	}
+	// No deliberation: this is transcription, not judgement. The model is being asked to
+	// restate what the CV already says in a fixed shape, and measurement says it recovers
+	// exactly as much either way — the same employments, titles, dates, skills and
+	// education, with nothing invented — while reasoning costs half the wall clock and
+	// answers unpredictably enough to cross this call's timeout. See llm.ReasoningEffort
+	// for the numbers and for which providers honour it.
 	raw, err := e.client.GenerateJSON(ctx, systemPrompt, userPrompt(red.Redact(cvText)),
-		llm.WithSchema(schemaName, schema))
+		llm.WithSchema(schemaName, schema), llm.WithReasoning(llm.ReasoningNone))
 	if err != nil {
 		return Structured{}, fmt.Errorf("resumeextract: generate: %w", err)
 	}

--- a/internal/platform/llm/credential.go
+++ b/internal/platform/llm/credential.go
@@ -165,18 +165,27 @@ func (c *Client) As(secret string, onRefused func(), dims ...Dimension) *Client 
 // Schema-bound models build on top of it, so a tagged client's schema calls are tagged
 // too.
 func (c *Client) transport() http.RoundTripper {
-	if len(c.dims) == 0 && c.fallbackKey == "" {
-		return httputil.DefaultTransport
+	// next is langchaingo's own transport, which stamps the library's User-Agent. The
+	// gateway already groups spend by that, so replacing it outright would lose an axis we
+	// get for nothing.
+	next := httputil.DefaultTransport
+	if len(c.dims) > 0 || c.fallbackKey != "" {
+		next = &attribution{
+			dims:      c.dims,
+			fallback:  c.fallbackKey,
+			onRefused: c.onRefused,
+			next:      next,
+		}
 	}
-	return &attribution{
-		dims:      c.dims,
-		fallback:  c.fallbackKey,
-		onRefused: c.onRefused,
-		// next is langchaingo's own transport, which stamps the library's User-Agent.
-		// The gateway already groups spend by that, so replacing it outright would lose
-		// an axis we get for nothing.
-		next: httputil.DefaultTransport,
-	}
+	// The reasoning rewrite goes on unconditionally, because what it writes is decided per
+	// CALL rather than per client: a client cannot know at build time whether some later
+	// call will ask for it, and a transport installed only on the clients that happen to
+	// carry tags would make WithReasoning silently do nothing on the ones that do not.
+	// It costs a context lookup on a call that does not ask.
+	//
+	// Outside the attribution stamp so the body is rewritten once: a credential retry
+	// re-sends the rewritten body rather than rewriting a second time.
+	return &reasoningInjector{next: next}
 }
 
 // attribution stamps the feature tags onto an outgoing call and rescues one whose

--- a/internal/platform/llm/llm.go
+++ b/internal/platform/llm/llm.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
@@ -121,16 +122,7 @@ func WithTracer(t Tracer, source string) Option {
 // the gateway/provider, apiKey is the bearer credential, model is the model id.
 // No provider is hard-coded — any OpenAI-compatible backend works.
 func New(baseURL, apiKey, model string, opts ...Option) (*Client, error) {
-	m, err := openai.New(
-		openai.WithBaseURL(baseURL),
-		openai.WithToken(apiKey),
-		openai.WithModel(model),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("llm: build client: %w", err)
-	}
 	c := &Client{
-		model:        m,
 		modelID:      model,
 		timeout:      DefaultTimeout,
 		baseURL:      baseURL,
@@ -140,6 +132,20 @@ func New(baseURL, apiKey, model string, opts ...Option) (*Client, error) {
 	for _, o := range opts {
 		o(c)
 	}
+	// The model is built AFTER the options, because the transport it travels on is the
+	// client's own (see transport): a base client needs it for the same reason a bound one
+	// does — a per-call rewrite has to reach a client nobody has bound.
+	m, err := openai.New(
+		openai.WithBaseURL(baseURL),
+		openai.WithToken(apiKey),
+		openai.WithModel(model),
+		openai.WithHTTPClient(&http.Client{Transport: c.transport()}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("llm: build client: %w", err)
+	}
+	c.model = m
+
 	return c, nil
 }
 
@@ -222,10 +228,14 @@ func NewWithModel(m llms.Model, opts ...Option) *Client {
 // It is not a guarantee: a gateway that stops honouring a schema reports success, so
 // every existing validation stays where it is.
 func (c *Client) GenerateJSON(ctx context.Context, system, user string, opts ...GenOption) (string, error) {
-	model, err := c.modelFor(newGenConfig(opts))
+	cfg := newGenConfig(opts)
+	model, err := c.modelFor(cfg)
 	if err != nil {
 		return "", err
 	}
+	// The reasoning effort travels on the context because langchaingo's request builder
+	// cannot carry it; the transport reads it back off. See WithReasoning.
+	ctx = withReasoning(ctx, cfg.reasoning)
 
 	if c.timeout > 0 {
 		var cancel context.CancelFunc
@@ -302,10 +312,15 @@ func (c *Client) GenerateJSONStream(
 	onThinking func(string),
 	opts ...GenOption,
 ) (string, error) {
-	model, err := c.modelFor(newGenConfig(opts))
+	cfg := newGenConfig(opts)
+	model, err := c.modelFor(cfg)
 	if err != nil {
 		return "", err
 	}
+	// Same as GenerateJSON: the effort rides the context to the transport. A caller that
+	// asks a streaming call not to deliberate is asking for less to arrive on onThinking,
+	// which is the point.
+	ctx = withReasoning(ctx, cfg.reasoning)
 
 	if c.timeout > 0 {
 		var cancel context.CancelFunc

--- a/internal/platform/llm/reasoning.go
+++ b/internal/platform/llm/reasoning.go
@@ -127,6 +127,13 @@ func withReasoningEffort(body json.RawMessage, effort ReasoningEffort) (json.Raw
 	if err := json.Unmarshal(body, &fields); err != nil {
 		return body, nil //nolint:nilerr // not a JSON object: not ours to rewrite
 	}
+	// A literal `null` unmarshals into a map WITHOUT error and sets it to nil, so the
+	// error above does not catch it and the write below would panic on a nil map. In a
+	// RoundTripper that panic has no error path to land in — the extraction that reaches
+	// here runs in a bare goroutine, where it would take the process with it.
+	if fields == nil {
+		return body, nil
+	}
 
 	encoded, err := json.Marshal(string(effort))
 	if err != nil {

--- a/internal/platform/llm/reasoning.go
+++ b/internal/platform/llm/reasoning.go
@@ -1,0 +1,143 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// ReasoningEffort is how much deliberation a call asks the model for, sent as the
+// OpenAI-compatible `reasoning_effort`.
+//
+// It exists because deliberation is not free and is not always worth its price. Measured on
+// production 2026-09-08, structured-résumé extraction — a transcription task, not a
+// judgement — spent between a third and two thirds of every response on reasoning tokens
+// that changed nothing: over four paired runs, on a clean CV and on a deliberately
+// column-mangled one, both settings recovered the same 10 of 10 employments, the same
+// titles, dates, skills and education, and invented nothing extra. What the reasoning DID
+// buy was time, and unpredictably: the same input answered in 22.6s and 47.2s on one
+// provider, against a steady 15-20s with it off. That tail is what crossed the extraction's
+// timeout and left 191 candidates with an unparsed CV, no profile links, and no fit
+// analysis.
+//
+// It is per CALL and not per client on purpose. The assistant reasons for a living; the
+// extractor does not. One client serves both.
+type ReasoningEffort string
+
+const (
+	// ReasoningDefault sends nothing, leaving whatever the model or the gateway would do.
+	// The zero value, so a caller that says nothing keeps sending exactly what it sent.
+	ReasoningDefault ReasoningEffort = ""
+	// ReasoningNone asks the model not to deliberate.
+	//
+	// Honoured per provider, not universally: on the gateway's zai models it takes the
+	// reasoning tokens from ~1500 to under 30, while the gemini ones ignore it and answer
+	// fast regardless. Sending it is therefore right on both — it helps where the cost is
+	// and is inert where it is not.
+	ReasoningNone ReasoningEffort = "none"
+)
+
+// WithReasoning sets how much the model should deliberate over this one call.
+//
+// The field cannot travel through langchaingo. Its OpenAI client HAS a ReasoningEffort
+// field, but the code that would populate it from call options is commented out upstream
+// (v0.1.14 — the current release, not a version we are behind on), so nothing a caller
+// passes reaches the wire. The value therefore rides the request context down to the
+// transport, which writes it onto the body — the same seam, and for the same reason, as
+// schemaInjector next to it.
+func WithReasoning(e ReasoningEffort) GenOption {
+	return func(cfg *genConfig) { cfg.reasoning = e }
+}
+
+// reasoningKey addresses the effort a single call asked for. A private type, so nothing
+// outside this package can set or read it by guessing the key.
+type reasoningKey struct{}
+
+// withReasoning carries one call's effort to the transport. A default effort adds nothing
+// to the context, so an untouched call is untouched all the way down.
+func withReasoning(ctx context.Context, e ReasoningEffort) context.Context {
+	if e == ReasoningDefault {
+		return ctx
+	}
+	return context.WithValue(ctx, reasoningKey{}, e)
+}
+
+// reasoningOf reads the effort a call asked for, or the default when it asked for nothing.
+func reasoningOf(ctx context.Context) ReasoningEffort {
+	e, _ := ctx.Value(reasoningKey{}).(ReasoningEffort)
+	return e
+}
+
+// reasoningInjector writes `reasoning_effort` onto the outgoing chat request when the call
+// asked for one, and is a pass-through otherwise.
+//
+// On the transport rather than in the request builder because langchaingo owns that builder
+// and cannot express the field (see WithReasoning). It sits OUTSIDE the attribution stamp,
+// so the body is rewritten once and a credential retry re-sends the rewritten one.
+type reasoningInjector struct {
+	// next is whatever this client already travels on — langchaingo's own transport, or
+	// the attribution stamp wrapping it.
+	next http.RoundTripper
+}
+
+func (t *reasoningInjector) RoundTrip(req *http.Request) (*http.Response, error) {
+	next := t.next
+	if next == nil {
+		next = http.DefaultTransport
+	}
+
+	effort := reasoningOf(req.Context())
+	if effort == ReasoningDefault || req.Body == nil {
+		return next.RoundTrip(req)
+	}
+
+	// A RoundTripper must close the request body on every path, not only the one that
+	// reaches the wire.
+	defer req.Body.Close()
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, fmt.Errorf("llm: read request body: %w", err)
+	}
+
+	patched, err := withReasoningEffort(body, effort)
+	if err != nil {
+		return nil, err
+	}
+
+	clone := req.Clone(req.Context())
+	clone.Body = io.NopCloser(bytes.NewReader(patched))
+	clone.ContentLength = int64(len(patched))
+	clone.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(patched)), nil
+	}
+
+	return next.RoundTrip(clone)
+}
+
+// withReasoningEffort sets the reasoning_effort member of a chat request, leaving every
+// other member as langchaingo wrote it. A body that is not a JSON object is returned
+// unchanged — the transport is installed on every client, and nothing guarantees only chat
+// requests reach it.
+func withReasoningEffort(body json.RawMessage, effort ReasoningEffort) (json.RawMessage, error) {
+	fields := map[string]json.RawMessage{}
+	if err := json.Unmarshal(body, &fields); err != nil {
+		return body, nil //nolint:nilerr // not a JSON object: not ours to rewrite
+	}
+
+	encoded, err := json.Marshal(string(effort))
+	if err != nil {
+		return nil, fmt.Errorf("llm: encode reasoning effort: %w", err)
+	}
+	fields["reasoning_effort"] = encoded
+
+	patched, err := json.Marshal(fields)
+	if err != nil {
+		return nil, fmt.Errorf("llm: encode patched request: %w", err)
+	}
+
+	return patched, nil
+}

--- a/internal/platform/llm/reasoning_test.go
+++ b/internal/platform/llm/reasoning_test.go
@@ -1,0 +1,204 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// bodyRecorder answers any chat request with a fixed reply and keeps what it was sent.
+// The wire is the only honest place to check this: the field cannot be read back off the
+// client, because the client is not what writes it — the transport is.
+type bodyRecorder struct {
+	srv *httptest.Server
+
+	mu     sync.Mutex
+	bodies []map[string]json.RawMessage
+}
+
+func newBodyRecorder(t *testing.T) *bodyRecorder {
+	t.Helper()
+	r := &bodyRecorder{}
+	r.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		raw, _ := io.ReadAll(req.Body)
+		fields := map[string]json.RawMessage{}
+		_ = json.Unmarshal(raw, &fields)
+		r.mu.Lock()
+		r.bodies = append(r.bodies, fields)
+		r.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"role":"assistant","content":"{}"}}]}`)
+	}))
+	t.Cleanup(r.srv.Close)
+
+	return r
+}
+
+func (r *bodyRecorder) last(t *testing.T) map[string]json.RawMessage {
+	t.Helper()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.bodies) == 0 {
+		t.Fatal("the endpoint was never called")
+	}
+
+	return r.bodies[len(r.bodies)-1]
+}
+
+func (r *bodyRecorder) client(t *testing.T) *Client {
+	t.Helper()
+	c, err := New(r.srv.URL, "service-key", "model-x")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	return c
+}
+
+// The regression guard. WithReasoning must reach the WIRE, not merely a struct field:
+// langchaingo has a ReasoningEffort field and the code that would fill it from call
+// options is commented out upstream, so a caller that "sets" it there changes nothing.
+func TestWithReasoningReachesTheWire(t *testing.T) {
+	rec := newBodyRecorder(t)
+
+	if _, err := rec.client(t).GenerateJSON(context.Background(), "sys", "usr", WithReasoning(ReasoningNone)); err != nil {
+		t.Fatalf("GenerateJSON: %v", err)
+	}
+
+	got, ok := rec.last(t)["reasoning_effort"]
+	if !ok {
+		t.Fatal("reasoning_effort is absent from the request; the option changed nothing")
+	}
+	if string(got) != `"none"` {
+		t.Errorf("reasoning_effort = %s, want \"none\"", got)
+	}
+}
+
+// A caller that says nothing must send exactly what it sent before this existed. An
+// endpoint seeing an unexpected member is a behaviour change nobody asked for, and on a
+// gateway that normalises what it recognises it is one that can reroute the call.
+func TestWithoutTheOptionNothingIsAdded(t *testing.T) {
+	rec := newBodyRecorder(t)
+
+	if _, err := rec.client(t).GenerateJSON(context.Background(), "sys", "usr"); err != nil {
+		t.Fatalf("GenerateJSON: %v", err)
+	}
+
+	if _, ok := rec.last(t)["reasoning_effort"]; ok {
+		t.Error("reasoning_effort was sent by a call that never asked for it")
+	}
+}
+
+// The default effort is the zero value, so passing it explicitly must be the same as not
+// passing it at all — otherwise a caller threading a value it did not inspect would change
+// what its call sends.
+func TestTheDefaultEffortSendsNothing(t *testing.T) {
+	rec := newBodyRecorder(t)
+
+	if _, err := rec.client(t).GenerateJSON(context.Background(), "sys", "usr", WithReasoning(ReasoningDefault)); err != nil {
+		t.Fatalf("GenerateJSON: %v", err)
+	}
+
+	if _, ok := rec.last(t)["reasoning_effort"]; ok {
+		t.Error("reasoning_effort was sent for the default effort")
+	}
+}
+
+// The rewrite must leave the rest of the request as langchaingo wrote it. It edits one
+// member of a body it did not build, so the thing to prove is that it edits ONLY that one.
+func TestTheRewriteLeavesTheRestOfTheRequestAlone(t *testing.T) {
+	rec := newBodyRecorder(t)
+	c := rec.client(t)
+
+	if _, err := c.GenerateJSON(context.Background(), "sys", "usr"); err != nil {
+		t.Fatalf("plain: %v", err)
+	}
+	plain := rec.last(t)
+
+	if _, err := c.GenerateJSON(context.Background(), "sys", "usr", WithReasoning(ReasoningNone)); err != nil {
+		t.Fatalf("with reasoning: %v", err)
+	}
+	patched := rec.last(t)
+
+	for k, want := range plain {
+		got, ok := patched[k]
+		if !ok {
+			t.Errorf("member %q disappeared from the patched request", k)
+			continue
+		}
+		if string(got) != string(want) {
+			t.Errorf("member %q changed: %s -> %s", k, want, got)
+		}
+	}
+	if len(patched) != len(plain)+1 {
+		t.Errorf("patched request has %d members, want %d (the original plus reasoning_effort)", len(patched), len(plain)+1)
+	}
+}
+
+// A body that is not a JSON object is not ours to rewrite. The transport is installed on
+// every client, and nothing guarantees only chat requests reach it.
+func TestANonJSONBodyIsPassedThrough(t *testing.T) {
+	const body = "not json at all"
+
+	got, err := withReasoningEffort([]byte(body), ReasoningNone)
+	if err != nil {
+		t.Fatalf("withReasoningEffort: %v", err)
+	}
+	if string(got) != body {
+		t.Errorf("body = %q, want it untouched", got)
+	}
+}
+
+// The effort must survive being bound to a caller's credential: attribution rebuilds the
+// client, and a rebuild that dropped the transport would take the option with it — the
+// exact shape of the bug that made this necessary in the first place.
+func TestReasoningSurvivesBindingACaller(t *testing.T) {
+	rec := newBodyRecorder(t)
+	bound := rec.client(t).AsCaller(NewCaller("a-users-own-key", nil, Feature("cv-extract")))
+
+	if _, err := bound.GenerateJSON(context.Background(), "sys", "usr", WithReasoning(ReasoningNone)); err != nil {
+		t.Fatalf("GenerateJSON: %v", err)
+	}
+
+	if _, ok := rec.last(t)["reasoning_effort"]; !ok {
+		t.Error("reasoning_effort is absent after binding a caller")
+	}
+}
+
+// And it must survive a schema-bound call, which is the only kind the résumé extraction
+// makes: that path builds a SECOND client of its own, on top of this transport.
+func TestReasoningSurvivesASchemaBoundCall(t *testing.T) {
+	rec := newBodyRecorder(t)
+	schema := map[string]any{"type": "object", "properties": map[string]any{}}
+
+	if _, err := rec.client(t).GenerateJSON(context.Background(), "sys", "usr",
+		WithSchema("structured_cv", schema), WithReasoning(ReasoningNone)); err != nil {
+		t.Fatalf("GenerateJSON: %v", err)
+	}
+
+	body := rec.last(t)
+	if _, ok := body["reasoning_effort"]; !ok {
+		t.Error("reasoning_effort is absent from a schema-bound request")
+	}
+	if _, ok := body["response_format"]; !ok {
+		t.Error("response_format is absent; the two rewrites are not composing")
+	}
+}
+
+// Belt and braces on the option's own plumbing, so a failure above points at the transport
+// rather than at the config.
+func TestWithReasoningSetsTheConfig(t *testing.T) {
+	cfg := newGenConfig([]GenOption{WithReasoning(ReasoningNone)})
+	if cfg.reasoning != ReasoningNone {
+		t.Errorf("reasoning = %q, want %q", cfg.reasoning, ReasoningNone)
+	}
+	if strings.TrimSpace(string(ReasoningDefault)) != "" {
+		t.Error("the default effort must be the empty string, so the zero value sends nothing")
+	}
+}

--- a/internal/platform/llm/reasoning_test.go
+++ b/internal/platform/llm/reasoning_test.go
@@ -202,3 +202,28 @@ func TestWithReasoningSetsTheConfig(t *testing.T) {
 		t.Error("the default effort must be the empty string, so the zero value sends nothing")
 	}
 }
+
+// A literal `null` body unmarshals into a map without error and leaves it nil, so the
+// error check above it does not catch it and the write would panic. There is nowhere for a
+// panic in a RoundTripper to land: the extraction that reaches here runs in a bare
+// goroutine, so it would take the process with it rather than fail one call.
+func TestANullBodyDoesNotPanic(t *testing.T) {
+	got, err := withReasoningEffort([]byte("null"), ReasoningNone)
+	if err != nil {
+		t.Fatalf("withReasoningEffort: %v", err)
+	}
+	if string(got) != "null" {
+		t.Errorf("body = %q, want it untouched", got)
+	}
+}
+
+// The same guard on the sibling rewrite beside it, which has the identical shape.
+func TestANullBodyDoesNotPanicOnTheSchemaRewrite(t *testing.T) {
+	got, err := withResponseFormat([]byte("null"), json.RawMessage(`{"type":"json_object"}`))
+	if err != nil {
+		t.Fatalf("withResponseFormat: %v", err)
+	}
+	if string(got) != "null" {
+		t.Errorf("body = %q, want it untouched", got)
+	}
+}

--- a/internal/platform/llm/schema.go
+++ b/internal/platform/llm/schema.go
@@ -48,6 +48,9 @@ type genConfig struct {
 	schemaName  string
 	schema      llmschema.Schema
 	schemaAsked bool
+	// reasoning is how much the model should deliberate over this call; see
+	// WithReasoning. The zero value sends nothing.
+	reasoning ReasoningEffort
 }
 
 func newGenConfig(opts []GenOption) genConfig {

--- a/internal/platform/llm/schema.go
+++ b/internal/platform/llm/schema.go
@@ -253,6 +253,12 @@ func withResponseFormat(body, format json.RawMessage) (json.RawMessage, error) {
 	if err := json.Unmarshal(body, &fields); err != nil {
 		return body, nil //nolint:nilerr // not a JSON object: not ours to rewrite
 	}
+	// A literal `null` unmarshals into a map WITHOUT error and sets it to nil, so the error
+	// above does not catch it and the write below would panic. Same guard, same reason, as
+	// withReasoningEffort — see its comment for where such a panic would land.
+	if fields == nil {
+		return body, nil
+	}
 
 	fields["response_format"] = format
 


### PR DESCRIPTION
Follows the 191 candidates whose CV never parsed. The timeout that was being
discarded (#2635) was half the story; this is the other half.

## The measurement

Structured-résumé extraction is transcription, not judgement — the model
restates what the CV already says, in a fixed shape. It was spending a third to
two thirds of every response on reasoning tokens anyway.

Four paired runs against the production gateway, on a clean CV and on a
deliberately column-mangled one (two columns interleaved by `pdftotext`, six
different date formats — `Jan 2024`, `03/2022`, `Sept '20`, `11.2015`,
`Q1 2013`):

| | employments | companies | titles | skills | dated | education |
|---|---|---|---|---|---|---|
| as-is | 10/10 | 10/10 | 10/10 | 10/10 | 10 | 2/2 |
| reasoning off | 10/10 | 10/10 | 10/10 | 10/10 | 10 | 2/2 |

Identical, on both CVs, in both directions. Nothing extra invented either — the
model returned exactly the 10 employments that were there.

What reasoning bought was time, and unpredictably:

| served by | mode | wall clock | reasoning tokens |
|---|---|---|---|
| gemini-3-flash-preview | as-is | 9.9s, 11.2s | ~1210 |
| **glm-5.3-flash** | **as-is** | **22.6s, 47.2s** | 566, 1698 |
| glm-5.3-flash | reasoning off | 15.4–20.2s | 16–31 |

The same input answering in 22.6s and 47.2s is the tail that crossed the
extraction's timeout.

## Why it goes on the transport

The field cannot travel through langchaingo. Its OpenAI client *has* a
`ReasoningEffort` field, and the code that would populate it from call options is
commented out upstream in **v0.1.14 — the current release**, not a version we are
behind on. Nothing a caller passes reaches the wire.

So `WithReasoning` rides the request context down to the transport, which writes
it onto the body. That is the same seam, and the same reason, as the
`schemaInjector` sitting next to it: langchaingo owns the request builder and
cannot express what we need, so the package that owns the wire writes it.

**Per call, not per client.** The assistant reasons for a living; the extractor
does not; one client serves both. The transport is installed unconditionally
because a client cannot know at build time whether some later call will ask —
installing it only on clients that happen to carry tags would make
`WithReasoning` silently do nothing on the ones that do not, which is precisely
the class of bug #2635 was.

## The prior attempt, and why this one works

`freehire-ops/provision/bifrost/LOCAL-BUILD.md` records an attempt at exactly
this on **2026-09-01** — the same day the extraction failure rate jumped from ~5%
to 75% — which was abandoned. It sent z.ai's own nested
`{"thinking":{"type":"disabled"}}`; Bifrost applies its own normalisation to
fields it *recognises*, the official `x-bf-passthrough-extra-params` escape hatch
does not bypass it (maximhq/bifrost#4460), and two local patches to the gateway
did not recover it.

The flat, OpenAI-compatible `reasoning_effort` is a **different field** and it
passes. Measured live: reasoning tokens ~1500 → under 30. It is honoured on the
zai models and ignored by the gemini ones — which answer fast regardless — so
sending it is correct on both.

That doc is worth a note; the knowledge that the door has a different handle
should not sit only in this PR.

## Verified end to end

Built for linux, run on the production host against **user 172** — whose CV had
failed extraction twice, including once earlier tonight under the restored 120s
budget:

```
user 172: structured backfilled (23 skills, 8 experience, 2 education)
done — 1 succeeded, 0 failed
```

38 seconds.

## Checks

`go build ./...` · `go vet ./...` · `go vet -tags=integration ./...` ·
`go test ./...` all pass · `gofmt -l .` empty · `golangci-lint run` reports
nothing in any file this touches.

Seven new tests, the load-bearing ones being that the option reaches the **wire**
(a struct field would have looked set and sent nothing), that a call which does
not ask sends nothing new, and that it survives both binding a caller and a
schema-bound call — the latter being the only kind the extraction makes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added control over the model’s reasoning effort for generated responses.
  - Requests can explicitly disable additional reasoning when speed and efficiency are preferred.

- **Improvements**
  - Reasoning settings are consistently applied across standard and streaming responses.
  - Resume transcription now uses streamlined processing for more direct results.
  - Improved request handling to prevent failures with empty or non-object response bodies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->