### PR TITLE
Retry a 2xx response whose body decodes as empty, like a 5xx

### DIFF
--- a/internal/ingest/sources/http.go
+++ b/internal/ingest/sources/http.go
@@ -718,15 +718,16 @@ func (c *Client) do(ctx context.Context, r request) error {
 			err := r.decode(resp)
 			resp.Body.Close()
 			if err != nil {
+				decodeErr := fmt.Errorf("sources: decode %s: %w", r.url, err)
 				// An exactly-empty body is Go's json/xml decoders' own signal for "no
 				// content at all" — indistinguishable from a dropped connection, and
 				// never returned for a malformed-but-present body — so it gets the same
 				// retry chance a 5xx does instead of failing the request outright.
 				if errors.Is(err, io.EOF) {
-					lastErr = fmt.Errorf("sources: decode %s: %w", r.url, err)
+					lastErr = decodeErr
 					continue
 				}
-				return fmt.Errorf("sources: decode %s: %w", r.url, err)
+				return decodeErr
 			}
 			return nil
 		case resp.StatusCode == http.StatusTooManyRequests:

--- a/internal/ingest/sources/http.go
+++ b/internal/ingest/sources/http.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -717,6 +718,14 @@ func (c *Client) do(ctx context.Context, r request) error {
 			err := r.decode(resp)
 			resp.Body.Close()
 			if err != nil {
+				// An exactly-empty body is Go's json/xml decoders' own signal for "no
+				// content at all" — indistinguishable from a dropped connection, and
+				// never returned for a malformed-but-present body — so it gets the same
+				// retry chance a 5xx does instead of failing the request outright.
+				if errors.Is(err, io.EOF) {
+					lastErr = fmt.Errorf("sources: decode %s: %w", r.url, err)
+					continue
+				}
 				return fmt.Errorf("sources: decode %s: %w", r.url, err)
 			}
 			return nil

--- a/internal/ingest/sources/http_test.go
+++ b/internal/ingest/sources/http_test.go
@@ -277,6 +277,83 @@ func TestClientRetriesOn429ThenSucceeds(t *testing.T) {
 	}
 }
 
+func TestClientRetriesOnEmptyBodyThenSucceeds(t *testing.T) {
+	// A 2xx with a genuinely empty body decodes as io.EOF — the same shape a dropped
+	// connection produces — so it must be retried like a 5xx rather than failing outright.
+	var attempts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 2 {
+			return // 200 with no body written at all
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	c := &Client{httpClient: srv.Client(), maxRetries: 2}
+
+	var out struct {
+		OK bool `json:"ok"`
+	}
+	if err := c.GetJSON(context.Background(), srv.URL, &out); err != nil {
+		t.Fatalf("GetJSON: %v", err)
+	}
+	if !out.OK {
+		t.Error("expected ok=true after an empty-body retry")
+	}
+	if attempts != 2 {
+		t.Errorf("attempts = %d, want 2 (empty body then 200)", attempts)
+	}
+}
+
+func TestClientEmptyBodyExhaustsRetryBudget(t *testing.T) {
+	var attempts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++ // every attempt answers 200 with no body
+	}))
+	defer srv.Close()
+
+	c := &Client{httpClient: srv.Client(), maxRetries: 2}
+
+	var out struct {
+		OK bool `json:"ok"`
+	}
+	err := c.GetJSON(context.Background(), srv.URL, &out)
+	if err == nil {
+		t.Fatal("expected error when every attempt returns an empty body")
+	}
+	if attempts != 3 {
+		t.Errorf("attempts = %d, want 3 (maxRetries=2 + initial)", attempts)
+	}
+	if !strings.Contains(err.Error(), srv.URL) {
+		t.Errorf("error %q does not name the URL %q", err.Error(), srv.URL)
+	}
+}
+
+func TestClientMalformedBodyIsNotRetried(t *testing.T) {
+	// A non-empty but malformed body is a real, persistent parse failure (e.g. a genuine XML
+	// syntax error) — never the "dropped mid-stream" shape an empty body is, so it must fail
+	// immediately rather than spending the retry budget on a document that will not change.
+	var attempts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		_, _ = w.Write([]byte(`{"ok": tru`)) // present, non-empty, invalid JSON
+	}))
+	defer srv.Close()
+
+	c := &Client{httpClient: srv.Client(), maxRetries: 2}
+
+	var out struct {
+		OK bool `json:"ok"`
+	}
+	if err := c.GetJSON(context.Background(), srv.URL, &out); err == nil {
+		t.Fatal("expected error on a malformed body")
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1 (malformed body must not be retried)", attempts)
+	}
+}
+
 func TestClientGetHTMLSurfacesWAFChallengeAsTypedError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// AWS-WAF Challenge action: a 202 carrying the challenge marker header and a

--- a/openspec/changes/retry-empty-body-decode/.openspec.yaml
+++ b/openspec/changes/retry-empty-body-decode/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/retry-empty-body-decode/design.md
+++ b/openspec/changes/retry-empty-body-decode/design.md
@@ -1,0 +1,90 @@
+## Context
+
+See proposal.md - Why for the live reproduction. The relevant code is `Client.do` in
+`internal/ingest/sources/http.go`, specifically the `switch` on `resp.StatusCode` around lines
+709-754: a `2xx` response runs `r.decode(resp)` and, on error, returns immediately via
+`fmt.Errorf("sources: decode %s: %w", r.url, err)`. The neighboring `429`/`5xx` cases instead
+set `lastErr` and `continue` the attempt loop, which already has a retry budget
+(`c.maxRetries`, default 2) and backoff (`c.retryDelay`, `retryAfter` for `429`).
+
+`decode` is a caller-supplied closure (`request.decode func(*http.Response) error`). The two
+call sites this change targets are `GetXML` (`xml.NewDecoder(resp.Body).Decode(v)`) and
+`GetJSON`/`PostJSON*` (`json.NewDecoder(resp.Body).Decode(v)`). Both of Go's stdlib decoders
+return exactly `io.EOF` — not a wrapped or annotated variant — when `Decode` is called on a
+reader that yields zero bytes before any token is read. Verified locally: `html.Parse` (used
+by `GetHTML`/`PostFormWithHeaders`) returns `nil` error on an empty reader, so it never
+produces this signal — confirming the fix has no reach into HTML-decoding call sites without
+needing to special-case them.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Retry an empty-bodied `2xx` exactly like a `5xx`, reusing the existing budget/backoff state
+  machine rather than adding a parallel one.
+- Leave every other branch of `Client.do` (WAF challenge, `429`, `5xx`, `403` refusal-egress,
+  other `4xx`, non-empty decode failure) behaviorally untouched.
+
+**Non-Goals:**
+- Distinguishing WHY the body was empty (rate-limiting vs. a genuine CDN glitch vs. something
+  else) — out of scope, and not observable from this side regardless.
+- Retrying decode failures that are not `io.EOF` (a present-but-malformed body). Widening the
+  net there risks masking a real, persistent adapter/format bug (e.g. jackhenry.avature.net's
+  known XML syntax error) behind a few extra seconds of retries before it surfaces the same way
+  it does today.
+- Touching `GetText`/`GetTextWithHeaders`'s `cappedReader`-based truncation handling — that
+  path already has its own typed signal (`BodyTooLargeError`) for a different failure shape
+  (oversized, not empty) and is unaffected by this change.
+
+## Decisions
+
+**Detect via `errors.Is(err, io.EOF)` at the point `decode` fails, not a new response
+wrapper.** Go's decoders already surface this precisely — `io.EOF` and only `io.EOF` for a
+truly empty input — so no extra body-peeking (e.g. reading and checking `len() == 0` before
+handing the reader to `decode`) is needed. Peeking would also require buffering the whole body
+up front, undoing the streaming decode `xml.NewDecoder`/`json.NewDecoder` do today.
+
+Alternative considered: check `resp.ContentLength == 0` instead of the decode error. Rejected
+— `ContentLength` is `-1` for chunked/unknown-length responses (common behind a CDN), so it is
+not a reliable signal, whereas the decoder's own `io.EOF` is authoritative regardless of
+whether the length was advertised.
+
+**Apply uniformly to every method (`GET` and `POST`), not gated by verb.** The two `POST`
+call sites (`PostJSON*`, `PostFormWithHeaders`) are read-only queries against search/listing
+APIs (Workday-style POST-as-query platforms), never mutations, so retrying one that came back
+empty carries the same safety as retrying a `GET`. Gating by method would add a branch with no
+adapter that currently needs the distinction.
+
+**No new error type.** Unlike `BodyTooLargeError` (which callers match with `errors.As` to
+distinguish "this board is genuinely oversized" from a transient failure), an empty body that
+survives every retry is, from the caller's perspective, indistinguishable from any other
+exhausted-retry failure — nothing downstream needs to branch on it specifically. The final
+error keeps today's shape: `fmt.Errorf("sources: decode %s: %w", r.url, err)`, still wrapping
+`io.EOF` so a future caller could `errors.Is` it if a need arises.
+
+**Where in the switch:** inside the existing `case resp.StatusCode >= 200 && resp.StatusCode <
+300:` branch, after `err := r.decode(resp)`, branch on `errors.Is(err, io.EOF)` before the
+current unconditional `return`. On the EOF path: close the body (already done before the
+branch), set `lastErr = fmt.Errorf(...)`, `continue`. On any other decode error: return exactly
+as today.
+
+## Risks / Trade-offs
+
+- **A source whose feed is legitimately, permanently empty (zero postings) now costs up to
+  `maxRetries` extra requests before returning.** Mitigation: `maxRetries` is 2, so this is 2
+  extra requests with backoff (≤ ~1s at the default `retryDelay`) per affected board per crawl
+  — negligible against the run-once-and-exit cron model, and no adapter treats "zero postings,
+  no error" as a failure today (an empty `urlset`/`sitemapindex` decodes successfully with zero
+  entries; this branch only fires when the body couldn't be decoded AT ALL because it was
+  empty, which is a different, always-erroneous shape for a well-formed feed).
+- **Masking a platform that has started permanently serving empty responses (a real outage on
+  their side) behind a slightly longer failure loop.** Mitigation: unchanged end state — after
+  `maxRetries` is exhausted the board still fails and `board_health.consecutive_failures` still
+  increments toward cooldown exactly as before; this only changes whether a single unlucky
+  empty response fails the run outright versus getting the existing retry chance every other
+  transient class already gets.
+
+## Migration Plan
+
+Pure code change to a shared, already-deployed client; no data migration, no config, no
+feature flag. Ships on the next regular deploy. Rollback is a plain revert if needed — no
+state to unwind.

--- a/openspec/changes/retry-empty-body-decode/proposal.md
+++ b/openspec/changes/retry-empty-body-decode/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+Investigating GitHub issue #2079 (Avature adapter, `mantech.avature.net`) found that the
+board's actual live failure is not what the issue describes. Reproduced from the production
+host's own egress IP: three consecutive requests to the board's real listing sitemap
+(`careers.mantech.com/en_US/careers/sitemap.xml`) returned `200, 382789 bytes` then `200, 0
+bytes` twice in a row — the edge intermittently answers success with a genuinely empty body.
+The shared ingest HTTP client (`internal/ingest/sources/http.go`, `Client.do`) already retries
+network errors, `429`, and `5xx`, but a `2xx` response whose decode callback fails is returned
+immediately as a hard, non-retried error. One unlucky empty-body response therefore fails the
+whole board crawl and increments `board_health.consecutive_failures` toward cooldown, even
+though the very next request against the same URL succeeds. This is a transport-level gap, not
+specific to Avature — every adapter that calls `GetJSON*`/`GetXML`/`PostJSON*` shares this
+client.
+
+## What Changes
+
+- `Client.do` treats a `2xx` response whose `decode` callback fails with exactly `io.EOF` as
+  transient and retries it against the existing retry budget (`maxRetries`/`retryDelay`), the
+  same way the neighboring `429`/`5xx` branches already do.
+- Any other decode failure (a non-empty but malformed body — e.g. a genuine XML syntax error)
+  keeps failing immediately, exactly as today: the new behavior is scoped to Go's stdlib
+  `json`/`xml` decoders' specific signal for "the input was completely empty," which they
+  never return for a malformed-but-present body.
+- No change to `GetHTML`/`PostFormWithHeaders` (`html.Parse` does not signal an empty body as
+  `io.EOF`, so this fix has no effect on HTML-decoding call sites) and no change to the body
+  size cap, the WAF-challenge short-circuit, or the 403 refusal-egress switch.
+
+## Capabilities
+
+### New Capabilities
+
+- `ingest-http-retry`: the shared ingest HTTP client's retry policy — which response shapes
+  (network error, `429`, `5xx`, and now an empty-body `2xx`) are treated as transient and
+  retried against the client's bounded retry budget, versus which are returned immediately as
+  final. No spec previously existed for this shared transport; this proposal documents the
+  existing policy alongside the new rule rather than leaving the addition undocumented next to
+  nothing.
+
+### Modified Capabilities
+
+(none — `ingest-http-retry` is new)
+
+## Impact
+
+- `internal/ingest/sources/http.go` — `Client.do`'s response-handling switch.
+- `internal/ingest/sources/http_test.go` — new coverage: an empty-body `2xx` retried to
+  success, an empty-body `2xx` still failing after exhausting the retry budget, and a
+  non-empty malformed body (XML syntax error) still failing immediately with zero retries.
+- Every adapter registered in `internal/ingest/sources/registry.go` that goes through
+  `GetJSON*`/`GetXML`/`PostJSON*` benefits transparently; no adapter code changes.
+- `mantech.avature.net`'s current `board_health` failure is expected to self-heal once this
+  ships and the board's next scheduled crawl runs — no manual intervention needed beyond that.
+- Follow-up outside this change: comment on GitHub issue #2079 noting its own diagnosis no
+  longer matches the live cause, and that this change addresses the actual current failure.

--- a/openspec/changes/retry-empty-body-decode/specs/ingest-http-retry/spec.md
+++ b/openspec/changes/retry-empty-body-decode/specs/ingest-http-retry/spec.md
@@ -1,0 +1,79 @@
+## Purpose
+
+Defines which response shapes the shared ingest HTTP client treats as transient (worth
+retrying against a bounded budget) versus terminal (returned to the caller immediately), so a
+source adapter's crawl fails only on genuine, persistent problems rather than on a one-off
+network or edge hiccup.
+
+## ADDED Requirements
+
+### Requirement: Transient failures are retried against a bounded budget
+
+The shared ingest HTTP client SHALL retry a request up to a fixed number of additional
+attempts, with a backoff delay between attempts, when the failure is one of: a network-level
+error (the request could not be sent or the connection failed), an HTTP `429` response (delay
+honors a `Retry-After` hint when present), or an HTTP `5xx` response. Once the retry budget is
+exhausted, the client SHALL return the last such failure to the caller.
+
+#### Scenario: A transient server error recovers on retry
+
+- **WHEN** a request receives a `5xx` response and a subsequent attempt (within the retry
+  budget) receives a `2xx` response with a body that decodes successfully
+- **THEN** the client returns the decoded result with no error
+
+#### Scenario: Persistent server errors exhaust the retry budget
+
+- **WHEN** every attempt within the retry budget receives a `5xx` response
+- **THEN** the client returns an error identifying the last status received
+
+### Requirement: An empty-bodied success is treated as transient, not terminal
+
+The client SHALL treat a `2xx` response whose body decodes as exactly empty (the decoder's
+own "no content" signal, distinct from a non-empty body that fails to decode) as a transient
+failure, retried against the same bounded budget as a `5xx` response. This is scoped narrowly
+to a genuinely empty body: an edge that answers success with nothing to read is behaviorally
+indistinguishable from a dropped connection, and the client already retries that shape.
+
+#### Scenario: An empty-bodied response recovers on retry
+
+- **WHEN** a request receives a `2xx` response with an empty body, and a subsequent attempt
+  (within the retry budget) receives a `2xx` response with a body that decodes successfully
+- **THEN** the client returns the decoded result with no error
+
+#### Scenario: A persistently empty body exhausts the retry budget
+
+- **WHEN** every attempt within the retry budget receives a `2xx` response with an empty body
+- **THEN** the client returns an error, exactly as a persistently `5xx` board would
+
+#### Scenario: A non-empty but malformed body is never retried
+
+- **WHEN** a request receives a `2xx` response whose body is present but fails to decode (e.g.
+  invalid markup partway through the document, not an empty body)
+- **THEN** the client returns the decode error immediately, without spending any of the retry
+  budget
+
+### Requirement: Non-transient failures return immediately
+
+The client SHALL return certain failures to the caller on the first occurrence, without
+retrying on the same egress: an HTTP `4xx` response other than `429` (a request that will not
+succeed by being repeated unchanged against the same address), and a bot-mitigation challenge
+response (retrying only deepens a per-address penalty rather than clearing it). An HTTP `403`
+MAY be retried exactly once, but only through a distinct fallback egress when the client is
+configured with one — never by repeating the request unchanged against the same address.
+
+#### Scenario: A client error is not retried
+
+- **WHEN** a request receives an HTTP `4xx` response other than `429` or `403`
+- **THEN** the client returns immediately without attempting a retry
+
+#### Scenario: A 403 without a fallback egress is not retried
+
+- **WHEN** a request receives an HTTP `403` response and the client has no fallback egress
+  configured
+- **THEN** the client returns immediately without attempting a retry
+
+#### Scenario: A bot-mitigation challenge is not retried
+
+- **WHEN** a request receives a response identified as an automated-traffic challenge rather
+  than the requested content
+- **THEN** the client returns immediately without attempting a retry

--- a/openspec/changes/retry-empty-body-decode/tasks.md
+++ b/openspec/changes/retry-empty-body-decode/tasks.md
@@ -1,0 +1,33 @@
+## 1. Tests first
+
+- [x] 1.1 In `internal/ingest/sources/http_test.go`, add a test where an `httptest` server
+      answers `200` with an empty body on the first request and a valid decodable body on the
+      second; assert the call succeeds and the decoded value matches the second response.
+- [x] 1.2 Add a test where the server answers `200` with an empty body on every request across
+      the full retry budget; assert the call fails after exactly `maxRetries+1` attempts, with
+      an error that still names the URL.
+- [x] 1.3 Add a test where the server answers `200` with a non-empty but malformed body (e.g.
+      invalid XML) on every request; assert the call fails immediately after exactly 1 attempt
+      (no retry spent on a genuine parse error).
+- [x] 1.4 Run `go test ./internal/ingest/sources/...` and confirm the three new tests fail
+      against the current (pre-fix) code for the right reason (1.1 and 1.2 fail because no
+      retry happens; 1.3 already passes and stays a regression guard).
+
+## 2. Implementation
+
+- [x] 2.1 In `Client.do` (`internal/ingest/sources/http.go`), in the `resp.StatusCode >= 200
+      && resp.StatusCode < 300` branch, after `err := r.decode(resp)` fails, branch on
+      `errors.Is(err, io.EOF)`: on true, set `lastErr` to the wrapped decode error and
+      `continue` the attempt loop (same shape as the `5xx` branch); on false, keep today's
+      immediate `return fmt.Errorf("sources: decode %s: %w", r.url, err)`.
+- [x] 2.2 Confirm `io` is imported (already used elsewhere in the file) and add `errors` if not
+      already imported.
+
+## 3. Verification
+
+- [x] 3.1 `gofmt -l internal/ingest/sources/http.go internal/ingest/sources/http_test.go`
+      prints nothing.
+- [x] 3.2 `go vet ./...` passes.
+- [x] 3.3 `go test ./internal/ingest/sources/...` passes, including the three new tests from
+      section 1.
+- [x] 3.4 `go test ./...` passes (full unit suite, no external deps).


### PR DESCRIPTION
## Summary
- The shared ingest HTTP client (`internal/ingest/sources/http.go`, `Client.do`) already retries network errors, 429s, and 5xxs, but returned a decode failure on a `2xx` response immediately with no retry.
- `careers.mantech.com` (the vanity host `mantech.avature.net`'s real listing lives on) intermittently answers `200` with a genuinely empty body — reproduced live from prod's own egress IP: request 1 got the full 382KB sitemap, requests 2 and 3 immediately after got `200` with 0 bytes. That single unlucky response was failing the whole board crawl.
- Fix: when the `decode` callback fails with exactly `io.EOF` (Go's json/xml decoders' own signal for "the body was completely empty," never returned for a malformed-but-present body), treat it as transient and retry against the existing budget — same shape as the neighboring 429/5xx branches. Any other decode error (e.g. a real XML syntax error) still fails immediately with zero retries spent.
- Full OpenSpec change (proposal/design/spec/tasks) included at `openspec/changes/retry-empty-body-decode/`.

Found while investigating #2079 — that issue's own two described defects turned out to be stale/not the live cause (one already fixed, one real but not currently hit by any of the 34 live Avature boards). The board's actual current failure is this empty-body decode issue instead. Will follow up on #2079 separately once this lands.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean on changed files
- [x] `go test ./internal/ingest/sources/...` — new tests: retry-to-success on an empty body, retry-budget exhaustion (asserts attempt count and that the error names the URL), and a non-empty malformed body still failing immediately with zero retries
- [x] `go test ./...` (full unit suite)
- [x] Independent code review (general-purpose subagent) — Ready to merge: Yes, no Critical/Important issues outstanding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty successful responses are now retried, improving resilience when upstream services return temporary blank bodies.
  * Malformed non-empty responses continue to fail immediately without retries.
  * Requests now return an error after the configured retry limit is exhausted for persistently empty responses.

* **Tests**
  * Added coverage for successful retries, retry exhaustion, and non-retryable malformed responses.

* **Documentation**
  * Documented the updated retry behavior for empty response bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->