### PR TITLE
Let Recruitee auto-apply attempts reach field resolution

### DIFF
--- a/cmd/auto-apply/main.go
+++ b/cmd/auto-apply/main.go
@@ -116,6 +116,14 @@ func run() int {
 	// platforms' own public job-board APIs, so its user agent, timeouts and size caps are
 	// exactly right here too.
 	sidecar := atsapply.NewClient(sources.NewClient(), llmClient, llmKeyResolver, atoms, cvStore, cvRenderer)
+	// Stored-form fallback (openspec/changes/atsapply-recruitee-stored-schema): lets a
+	// provider with no live schema fetcher (today: Recruitee) reach field resolution
+	// instead of parking before it ever runs, by reading the form cmd/capture-apply-form
+	// (or, for Recruitee, the ingest crawl itself) already captured into apply_forms. The
+	// same reader NewPreviewClient below already uses for its own, differently-ordered
+	// purpose — see fetchSchema's own comment for why Client does NOT mirror
+	// PreviewClient's storage-first order.
+	sidecar = sidecar.WithStoredFormReader(&dbApplyFormReader{q: queries})
 	// browser-use fallback (openspec/changes/add-browseruse-atsapply-fallback): empty key
 	// leaves sidecar exactly as it was before this capability existed — Ashby/Workable/
 	// Recruitee still park with reasonSubmissionNotImplemented. Its own enforce flag and

--- a/internal/api/atsapply/AGENTS.md
+++ b/internal/api/atsapply/AGENTS.md
@@ -24,12 +24,12 @@ process, called only via `Client.WithBrowserUse`. Scope is deliberately narrow:
   no `MergedField` schema to build a `Plan` from in the first place, since chromedp's own
   DOM scan is what failed there; a captcha-protected posting (Lever, or
   `reasonCaptchaProtected`) is never routed here — that would be an attempt to bypass a
-  platform's bot protection, not this backend's purpose. **Recruitee is absent for a
-  structural reason found during implementation, not a policy one**:
-  `internal/ingest/applyform.Fetchers` has no registered `Fetcher` for it at all (its form
-  arrives free with the ingest crawl and is written directly), so `Client.fetchSchema`
-  already parks a Recruitee attempt with `errNoSchemaFetcher` before `Submit` ever reaches
-  a `Plan` to hand this executor.
+  platform's bot protection, not this backend's purpose. **Recruitee reaches a `Plan` now
+  (its schema-fetch gap is closed — see `fetchSchema`'s stored-form fallback, below) but was never added
+  here**: it is in neither `fillProviders` (no live DOM-scan built for it) nor
+  `browserUseProviders`, so a fully-resolved Recruitee `Plan` still parks with
+  `reasonSubmissionNotImplemented`, the same outcome Ashby/Workable get without the spend
+  guard's approval.
 - **Only an already fully-resolved `Plan`** (`Plan.FullyResolved()`) — this backend is
   handed exact field values to type and never a decision about what to answer. Every
   invariant `resolve.go`/`draft.go`/`sensitive.go`/`geography.go` already enforce (never
@@ -81,6 +81,21 @@ process, called only via `Client.WithBrowserUse`. Scope is deliberately narrow:
   resolved form for one of them still parks rather than being submitted through a fill path
   never built or verified. Widening the live DOM-scan to another provider is a real gap to
   close, not a design decision to defend.
+- **`fetchSchema` falls back to a stored form ONLY when no live fetcher is registered for
+  the provider — not storage-first.** `Client.forms` (`WithStoredFormReader`, same
+  `StoredFormReader` port `PreviewClient` uses) closes Recruitee's own schema-fetch gap:
+  `internal/ingest/applyform.Fetchers` has no `Fetcher` for it (its form arrives free with
+  the ingest crawl and is written directly to `apply_forms`), so before this it parked with
+  `errNoSchemaFetcher` before `resolve` ever ran. This does NOT mirror
+  `PreviewClient.schemaFor`'s storage-first order — `apply_forms` also holds a row for
+  every provider `cmd/capture-apply-form` drains (Greenhouse, Ashby, Workable, Lever), so
+  preferring storage unconditionally would risk a REAL submission reading a possibly-stale,
+  display-captured row instead of a fresh fetch for providers that already work fine. A
+  live fetcher, when one is registered, is always tried first; `c.forms` is reached only
+  when `fetchSchema` would otherwise return `errNoSchemaFetcher`. **This does not make
+  Recruitee submit** — see this file's own note on `browserUseProviders`, above: reaching a
+  `Plan` is not the same as having anything to hand it to. See
+  `openspec/changes/atsapply-recruitee-stored-schema`.
 - **A Greenhouse posting whose form cannot be scanned parks with a named reason instead of
   erroring.** `ScanGreenhouseForm`'s known selector (`greenhouseFormReadySelector`,
   `#application-form`) only ever matched the vanilla `job-boards.greenhouse.io` template.

--- a/internal/api/atsapply/client.go
+++ b/internal/api/atsapply/client.go
@@ -89,6 +89,12 @@ type Client struct {
 	// reasonSubmissionNotImplemented, exactly as it did before this capability existed.
 	// See openspec/changes/add-browseruse-atsapply-fallback.
 	browserUse *BrowserUseExecutor
+	// forms reads a job's previously-captured application form — the same StoredFormReader
+	// PreviewClient already uses, wired here too so fetchSchema can reach it for a
+	// provider with no live fetcher (today: Recruitee). Nil is the unconfigured
+	// deployment: fetchSchema then behaves exactly as it did before this capability
+	// existed. See openspec/changes/atsapply-recruitee-stored-schema.
+	forms StoredFormReader
 }
 
 // WithBrowserUse attaches the browser-use fallback executor, returning c for chaining.
@@ -96,6 +102,16 @@ type Client struct {
 // NewClient's existing positional signature or any of its other call sites.
 func (c *Client) WithBrowserUse(executor *BrowserUseExecutor) *Client {
 	c.browserUse = executor
+	return c
+}
+
+// WithStoredFormReader attaches the stored-form fallback fetchSchema reads before giving
+// up on a provider with no live fetcher, returning c for chaining — the same
+// "optional dependency via a setter, not a NewClient parameter" shape WithBrowserUse
+// already established, for the same reason: this never touches NewClient's existing
+// positional signature or any of its other call sites.
+func (c *Client) WithStoredFormReader(forms StoredFormReader) *Client {
+	c.forms = forms
 	return c
 }
 
@@ -355,10 +371,25 @@ func (c *Client) renderResumeToTempFile(ctx context.Context, claimed autoapply.C
 }
 
 // fetchSchema reuses internal/applyform's own per-provider fetcher rather than
-// re-implementing Greenhouse/Ashby's API calls or Lever's page parse.
+// re-implementing Greenhouse/Ashby's API calls or Lever's page parse, live-fetching
+// whenever a fetcher is registered for the provider — deliberately NOT the storage-first
+// order PreviewClient.schemaFor uses for its own, cheaper purpose. apply_forms holds a
+// captured row for every provider cmd/capture-apply-form drains (Greenhouse, Ashby,
+// Workable, Lever — not only Recruitee, whose form arrives free with the crawl instead),
+// so preferring storage here too would risk a real submission reading a row captured for
+// the job page's own display, possibly stale, instead of a fresh fetch, for postings that
+// never needed this fallback at all. c.forms is therefore only ever reached as a fallback,
+// for the one case a live fetch cannot answer: no fetcher registered for the provider.
 func (c *Client) fetchSchema(ctx context.Context, claimed autoapply.Claimed) (applyform.Form, error) {
 	fetcher, ok := c.fetchers[claimed.Provider]
 	if !ok {
+		if c.forms != nil {
+			if form, storedOK, err := c.forms.GetStoredForm(ctx, claimed.JobID); err != nil {
+				return applyform.Form{}, err
+			} else if storedOK {
+				return form, nil
+			}
+		}
 		return applyform.Form{}, fmt.Errorf("%w: %q", errNoSchemaFetcher, claimed.Provider)
 	}
 	return fetcher.Fetch(ctx, applyform.Claimed{

--- a/internal/api/atsapply/client_test.go
+++ b/internal/api/atsapply/client_test.go
@@ -42,6 +42,89 @@ func TestSubmit_ParksHonestlyWhenNoSchemaFetcherIsRegistered(t *testing.T) {
 	}
 }
 
+// A provider with no live fetcher (Recruitee) reaches field resolution using a stored form
+// instead of parking immediately — an incomplete resolution proves the stored form was
+// actually read and used: Unmapped names the real missing field, not the generic
+// reasonSubmissionNotImplemented a provider with no schema at all would report.
+func TestSubmit_UsesAStoredFormWhenNoLiveFetcherIsRegistered(t *testing.T) {
+	reader := &fakeFormReader{found: true, form: applyform.Form{Fields: []applyform.Field{
+		{ID: "first_name", Label: "First name", Type: applyform.TypeText, Required: true},
+	}}}
+	c := &Client{fetchers: nil, forms: reader}
+
+	result, err := c.Submit(context.Background(), autoapply.Claimed{Provider: "recruitee"}, map[string]string{})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if result.Status != autoapply.StatusParked || len(result.Unmapped) != 1 || result.Unmapped[0].ID != "first_name" {
+		t.Fatalf("result = %+v, want parked with first_name named as unmapped — proves the stored form's own field reached resolution", result)
+	}
+}
+
+// The stored-form fallback still parks honestly when nothing is stored either — same
+// outcome as no fetcher at all, just reached through a live c.forms that found nothing
+// rather than a nil one.
+func TestSubmit_ParksHonestlyWhenAFormReaderFindsNothingStored(t *testing.T) {
+	reader := &fakeFormReader{found: false}
+	c := &Client{fetchers: nil, forms: reader}
+
+	result, err := c.Submit(context.Background(), autoapply.Claimed{Provider: "recruitee"}, nil)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if result.Status != autoapply.StatusParked || result.Reason != reasonSubmissionNotImplemented {
+		t.Errorf("result = %+v, want parked/%s", result, reasonSubmissionNotImplemented)
+	}
+}
+
+// A provider that already has a live fetcher must keep using it — apply_forms holds a row
+// for Ashby too (cmd/capture-apply-form captures it for the job page's own display), so a
+// stored-form-first order would silently prefer that possibly-stale row over a fresh fetch
+// for a real submission. Found by design review before this shipped: the first draft of
+// this change mirrored PreviewClient.schemaFor's storage-first order, which is right for a
+// cheap preview but wrong here.
+func TestSubmit_AProviderWithALiveFetcherIgnoresAStoredForm(t *testing.T) {
+	fetcher := &fakeFetcher{form: applyform.Form{Fields: []applyform.Field{
+		{ID: "from_live_fetch", Label: "From live fetch", Type: applyform.TypeText, Required: true},
+	}}}
+	reader := &fakeFormReader{found: true, form: applyform.Form{Fields: []applyform.Field{
+		{ID: "from_stored_form", Label: "From stored form", Type: applyform.TypeText, Required: true},
+	}}}
+	c := &Client{fetchers: map[string]applyform.Fetcher{"ashby": fetcher}, forms: reader}
+
+	result, err := c.Submit(context.Background(), autoapply.Claimed{Provider: "ashby"}, map[string]string{})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if !fetcher.called {
+		t.Error("live fetcher was not called, want it preferred over the stored form for a provider that has one")
+	}
+	if len(result.Unmapped) != 1 || result.Unmapped[0].ID != "from_live_fetch" {
+		t.Fatalf("unmapped = %+v, want the live-fetched field named, not the stored form's", result.Unmapped)
+	}
+}
+
+// A stored-form resolution that fully resolves still parks — Recruitee has no fill path
+// (fillProviders) and no browser-use fallback (browserUseProviders), so a complete plan is
+// exactly as unsubmittable as an incomplete one, just for a different reason.
+func TestSubmit_AFullyResolvedStoredFormStillParksWithNoSubmitPath(t *testing.T) {
+	reader := &fakeFormReader{found: true, form: applyform.Form{Fields: []applyform.Field{
+		{ID: "first_name", Label: "First name", Type: applyform.TypeText, Required: true},
+	}}}
+	c := &Client{fetchers: nil, forms: reader}
+
+	result, err := c.Submit(context.Background(), autoapply.Claimed{Provider: "recruitee"}, map[string]string{"first_name": "Ada"})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if result.Status != autoapply.StatusParked || result.Reason != reasonSubmissionNotImplemented {
+		t.Fatalf("result = %+v, want parked/%s — fully resolved but still no submit path for this provider", result, reasonSubmissionNotImplemented)
+	}
+	if len(result.Unmapped) != 0 {
+		t.Errorf("unmapped = %+v, want none — every required field resolved", result.Unmapped)
+	}
+}
+
 func TestUnscannableFormResult_MapsBothReasonsToParked(t *testing.T) {
 	for _, reason := range []unscannableFormReason{reasonCaptchaProtected, reasonUnrecognizedLayout} {
 		result, parked := unscannableFormResult(&unscannableFormError{reason: reason})

--- a/openspec/changes/atsapply-recruitee-stored-schema/.openspec.yaml
+++ b/openspec/changes/atsapply-recruitee-stored-schema/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/atsapply-recruitee-stored-schema/design.md
+++ b/openspec/changes/atsapply-recruitee-stored-schema/design.md
@@ -1,0 +1,43 @@
+## Context
+
+`internal/api/atsapply` already has `PreviewClient.schemaFor` (preview_client.go), which checks `p.forms` (a `StoredFormReader`) BEFORE `p.fetchers[claimed.Provider]` — storage-first, for every provider, not only one with no live fetcher. That order is right for what `Preview` is: a cheap, non-authoritative look at what an attempt would currently send, where a "rarely-stale" captured row is an acceptable trade for skipping a network round trip (`schemaFor`'s own comment).
+
+`Client.fetchSchema` (client.go) is the real submission path and has no storage fallback at all today — it only ever checks `c.fetchers[claimed.Provider]`, so a provider with no live fetcher (today: only Recruitee) parks immediately via `errNoSchemaFetcher`.
+
+**`apply_forms` is not a Recruitee-only store.** `cmd/capture-apply-form` drains a queue and writes a row there for every provider `internal/ingest/applyform.NeedsRequestCapture` says needs one — `fetcherFor` names Greenhouse, Ashby, Workable, and Lever (fetch.go). Recruitee is the one provider that reaches the same table a different way (its form arrives free with the ingest crawl and is written directly, never queued). So a live-fetcher provider's row in `apply_forms` is not hypothetical — it exists today, captured for the job page's own apply-form display (`internal/api/handler/apply_form.go`'s `GetApplyFormByJobID`), and can be older than the posting's current form. `PreviewClient`'s storage-first order accepts that staleness deliberately, for preview's own purpose; a real submission should not inherit that trade-off for free.
+
+`StoredFormReader` and its real adapter `dbApplyFormReader` (`cmd/auto-apply/apply_form_reader.go`, backed by `db.GetApplyFormByJobID`) already exist and are already in production use by `PreviewClient`. This design does not invent anything new at the data-access layer — it wires an existing, working piece into a second consumer.
+
+`Client` already has a precedent for adding an optional dependency without touching `NewClient`'s positional signature: `WithBrowserUse(executor *BrowserUseExecutor) *Client`, added specifically "so adding this optional dependency never touches `NewClient`'s existing positional signature or any of its other call sites."
+
+## Goals / Non-Goals
+
+**Goals:**
+- `Client.fetchSchema` tries a stored form before giving up on a provider with no live fetcher — matching the spec's own scope, not `PreviewClient.schemaFor`'s storage-first order (see Decisions: the two deliberately differ).
+- The existing `dbApplyFormReader` is reused as-is — no new adapter, no new query.
+- No change to `fillProviders`, `browserUseProviders`, or any park-reason string.
+- No change to `fetchSchema`'s observable behavior for a provider that already has a live fetcher (Greenhouse, Ashby, Workable, Lever) — every one of those also has a row in `apply_forms` today, so this matters, not a hypothetical to guard against.
+
+**Non-Goals:**
+- Making Recruitee (or any provider) actually submit. Out of scope, per proposal.md.
+- Touching `PreviewClient` itself — it already does this correctly; nothing here changes it.
+- Touching `autoApplyEnqueueSources` or any enqueue-time eligibility gate.
+- Deduplicating `PreviewClient.schemaFor` and `Client.fetchSchema` into one shared function. They are the same *shape* of logic but serve different callers with different signatures (`Preview` vs `Submit`) and different failure handling around them; forcing a shared helper now would be a larger refactor than this fix calls for, and nothing about this change requires it.
+
+## Decisions
+
+**Add `WithStoredFormReader(forms StoredFormReader) *Client`, mirroring `WithBrowserUse` exactly, rather than a new `NewClient` parameter.** `Client` already established this pattern for exactly this situation — an optional dependency that only one caller (`cmd/auto-apply/main.go`) needs to wire, without touching `NewClient`'s signature or any test that constructs a bare `Client`. A positional parameter would ripple through every existing `NewClient(...)` call site (production and test) for a dependency that is allowed to be nil; a setter does not.
+
+**`StoredFormReader` interface is reused unchanged from `preview_client.go`** — not duplicated, not moved. `Client` and `PreviewClient` live in the same package, so both can reference the one interface directly; no new file is needed for it.
+
+**`fetchSchema` tries `c.fetchers` FIRST, falling back to `c.forms` only when no fetcher is registered for the provider — deliberately NOT `PreviewClient.schemaFor`'s storage-first order.** The mirrored, storage-first order was the original plan here and is wrong for this caller: since `apply_forms` already holds a row for Greenhouse/Ashby/Workable/Lever too (Context, above), storage-first would silently prefer that possibly-stale, display-captured row over a fresh fetch for a REAL submission on every one of those providers — not a hypothetical, since the table demonstrably has those rows today. Live-fetcher-first, storage-as-fallback, changes nothing observable for any provider that already has a fetcher (the fetcher branch runs exactly as it did before this change), and reaches `c.forms` only for the one case a live fetch cannot answer at all: no fetcher registered — today, only Recruitee. This is also what the spec itself already says ("no registered live schema fetcher"), so this correction brings the code in line with the spec that was already scoped correctly, not the other way around.
+
+**`c.forms` may be nil**, degrading `fetchSchema` to exactly today's behavior (live-fetch-only, `errNoSchemaFetcher` when none registered) — the same optionality every other injected dependency on `Client` already has (`llmClient`, `atoms`, `cvs` are all documented as "may be nil, disables X, leaves everything else unchanged").
+
+**No change to the `Submit` control flow below `fetchSchema`.** Once `apiForm` is obtained (live or stored), everything downstream — `mergedFromAPIOnly`, `resolve`, the `fillProviders`/`browserUseProviders` branching, the park reasons — is untouched. This is deliberate: the spec's third requirement (resolvable-but-unsubmittable providers still park, with precise `Unmapped` reporting when incomplete) is already exactly what this code does today for Ashby/Workable when `browserUseEligible` returns false or the spend guard refuses; Recruitee simply starts reaching that same, already-correct logic instead of being turned away one step earlier.
+
+## Risks / Trade-offs
+
+- **[Risk]** A stored Recruitee form could be stale (the posting's form changed since capture, no re-capture has run). → **Mitigation**: not a new risk introduced by this change — `PreviewClient` already carries the identical risk today for its own preview reads, documented in its own comment ("a stored, rarely-stale row"); this change does not add a second, differently-stale copy, it reuses the same one preview already trusts.
+- **[Risk]** Someone reads "Recruitee now reaches field resolution" as "Recruitee auto-apply now works." → **Mitigation**: proposal.md states the non-outcome plainly and repeatedly; the spec's own requirements explicitly cover the still-parks case; `internal/api/atsapply/AGENTS.md` should be updated (see tasks.md) so the package's own documentation doesn't imply otherwise either.
+- **[Trade-off]** This does not close the "candidate spends a real allowance on an attempt with no submit path" concern the earlier audit raised — that remains true after this change, unchanged, and is explicitly out of scope here (see proposal.md and this session's own scoping decision).

--- a/openspec/changes/atsapply-recruitee-stored-schema/proposal.md
+++ b/openspec/changes/atsapply-recruitee-stored-schema/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+A Recruitee auto-apply attempt parks unconditionally at `Client.fetchSchema` (`internal/api/atsapply/client.go`) before any field resolution runs at all, because `internal/ingest/applyform.Fetchers` has no live fetcher for Recruitee — its form arrives free with the ingest crawl and is written directly to `apply_forms` instead. The code already names this a real gap: "Reaching Recruitee would need reading its already-captured form from storage instead of `applyform.Fetcher` — a real gap, not a decision" (`internal/api/atsapply/browseruse_fill.go`). The fix pattern already exists and is proven in production for the preview path (`PreviewClient`'s `StoredFormReader`) — it was simply never wired into the real submission path.
+
+## What Changes
+
+- `Client` (the real submission path `cmd/auto-apply` drives) gains the same `StoredFormReader`-backed fallback `PreviewClient` already has: when no live fetcher is registered for a provider, `fetchSchema` reads the job's captured form from `apply_forms` before giving up.
+- The already-existing `dbApplyFormReader` adapter (`cmd/auto-apply/apply_form_reader.go`) is wired into the `atsapply.NewClient(...)` call site in `cmd/auto-apply/main.go`, alongside its existing use in `NewPreviewClient(...)`.
+- A Recruitee attempt now reaches deterministic field resolution and, where fields are missing, LLM-drafted answers (`ResolveWithDrafting`) — the same treatment every other non-Greenhouse provider already gets — instead of parking before any of that runs.
+
+**Explicitly unchanged, stated plainly so this isn't mistaken for more than it is:** Recruitee still cannot actually submit after this change. It is in neither `fillProviders` (Greenhouse-only DOM fill) nor `browserUseProviders` (Ashby/Workable-only cloud fallback), so a fully-resolved Recruitee `Plan` still parks with the same candidate-facing `reasonSubmissionNotImplemented` ("submission not yet implemented for this provider") it already shows today. What changes is precision: an attempt that is *not* fully resolvable now reports which fields are actually `Unmapped` instead of an undifferentiated park, and the fields that *are* resolvable get resolved. Adding Recruitee to a real fill/submit path is a separate, later change.
+
+Not in scope, and not being revisited by this change: `internal/api/handler/auto_apply_enqueue.go`'s `autoApplyEnqueueSources` allowlist — which providers may be queued at all is an already-documented, deliberate product decision, unrelated to whether schema-fetch itself works.
+
+## Capabilities
+
+### New Capabilities
+- `atsapply-stored-schema-fallback`: when resolving an application form for submission and no live schema fetcher is registered for the posting's ATS provider, the system reads the form already captured into storage during ingest, when one exists, instead of parking immediately.
+
+### Modified Capabilities
+(none — `fillProviders`/`browserUseProviders` and the park reasons they produce are unchanged; this only changes whether schema resolution itself can proceed for a provider with no live fetcher)
+
+## Impact
+
+- `internal/api/atsapply/client.go`: `Client` gains a `forms StoredFormReader` field; `fetchSchema` tries it before falling through to `errNoSchemaFetcher`, mirroring `PreviewClient.schemaFor`.
+- `internal/api/atsapply/client.go` (`NewClient`): new parameter to accept a `StoredFormReader` (may be nil, degrading to today's live-fetch-only behavior — the same optionality `PreviewClient` already has).
+- `cmd/auto-apply/main.go`: passes the existing `&dbApplyFormReader{q: queries}` into `atsapply.NewClient(...)`.
+- No migration, no new table — reuses `apply_forms` and `GetApplyFormByJobID`, both already in production use via the preview path.
+- No change to `fillProviders`, `browserUseProviders`, `reasonSubmissionNotImplemented`, or `autoApplyEnqueueSources`.

--- a/openspec/changes/atsapply-recruitee-stored-schema/specs/atsapply-stored-schema-fallback/spec.md
+++ b/openspec/changes/atsapply-recruitee-stored-schema/specs/atsapply-stored-schema-fallback/spec.md
@@ -1,0 +1,47 @@
+## Purpose
+
+Lets an auto-apply attempt reach field resolution for an ATS provider whose application form was captured during ingest rather than fetched live, instead of parking before resolution ever runs.
+
+## ADDED Requirements
+
+### Requirement: A stored form is read when no live schema fetcher exists
+
+When submitting an auto-apply attempt for a posting whose ATS provider has no registered
+live schema fetcher, the system SHALL attempt to read that job's previously captured
+application form from storage before parking the attempt. When a stored form exists, it
+SHALL be used as the schema for field resolution, exactly as a live-fetched schema would be.
+
+#### Scenario: A provider with no live fetcher has a stored form
+
+- **WHEN** an auto-apply attempt is submitted for a job whose provider has no live schema fetcher, and that job's application form was already captured into storage during ingest
+- **THEN** the stored form is used as the schema, and field resolution (including any LLM-drafted answers) runs against it exactly as it would for a live-fetched schema
+
+### Requirement: Absence of both a live fetcher and a stored form still parks honestly
+
+When no live schema fetcher is registered for the provider and no form has been captured
+into storage for the job either, the attempt SHALL park with the same reason it does today
+— this requirement changes what is tried, not what happens when nothing is found.
+
+#### Scenario: Neither a live fetcher nor a stored form is available
+
+- **WHEN** an auto-apply attempt is submitted for a job whose provider has no live schema fetcher, and no form has been captured into storage for that job
+- **THEN** the attempt parks with the same reason it reports today, and no field resolution runs
+
+### Requirement: A resolved schema for a provider with no submit path still parks, but with precise diagnostics
+
+Reaching field resolution for a provider that can neither be filled via the browser DOM
+path nor submitted via the cloud fallback SHALL NOT cause a submission to be attempted.
+When such an attempt's resolved plan is incomplete, the system SHALL report exactly which
+fields could not be resolved, the same way it already does for any other provider with an
+incomplete plan. When such an attempt's resolved plan is complete, the system SHALL park it
+with the same "submission not yet implemented for this provider" reason used today.
+
+#### Scenario: A resolvable-but-unsubmittable provider's incomplete plan reports its gaps
+
+- **WHEN** field resolution runs, using a stored form, for a provider with no fill or submit path, and some required fields cannot be resolved
+- **THEN** the attempt parks and names the specific unresolved fields, rather than reporting an undifferentiated "not implemented" reason
+
+#### Scenario: A resolvable-but-unsubmittable provider's complete plan still parks
+
+- **WHEN** field resolution runs, using a stored form, for a provider with no fill or submit path, and every required field resolves
+- **THEN** the attempt still parks, with the same "submission not yet implemented for this provider" reason shown for this provider today

--- a/openspec/changes/atsapply-recruitee-stored-schema/tasks.md
+++ b/openspec/changes/atsapply-recruitee-stored-schema/tasks.md
@@ -1,0 +1,23 @@
+## 1. Client gains a stored-form fallback
+
+- [x] 1.1 Add a `forms StoredFormReader` field to `Client` (`internal/api/atsapply/client.go`), reusing the `StoredFormReader` interface already defined in `preview_client.go` — no new interface.
+- [x] 1.2 Add `WithStoredFormReader(forms StoredFormReader) *Client`, mirroring `WithBrowserUse`'s exact shape (sets the field, returns `c`), leaving `NewClient`'s signature untouched.
+- [x] 1.3 Update `fetchSchema` to try `c.fetchers[claimed.Provider]` FIRST as today, and only when no fetcher is registered, fall back to `c.forms.GetStoredForm(ctx, claimed.JobID)` when `c.forms != nil` — deliberately NOT `PreviewClient.schemaFor`'s storage-first order (design.md: `apply_forms` already holds rows for Greenhouse/Ashby/Workable/Lever too, so storage-first would risk a real submission reading a possibly-stale, display-captured row for providers that already work).
+
+## 2. Wiring
+
+- [x] 2.1 In `cmd/auto-apply/main.go`, call `.WithStoredFormReader(&dbApplyFormReader{q: queries})` on the `sidecar` Client after construction (the adapter already exists and is already used for `NewPreviewClient` two lines below).
+
+## 3. Tests for the added spec requirements
+
+- [x] 3.1 Unit test: `fetchSchema` (or `Submit`, at whichever level existing tests for `errNoSchemaFetcher` already sit) returns the stored form when `c.forms` has one and the provider has no live fetcher.
+- [x] 3.2 Unit test: with `c.forms` nil (or returning not-found), a provider with no live fetcher still parks with `errNoSchemaFetcher`/`reasonSubmissionNotImplemented`, unchanged from today.
+- [x] 3.3 Unit test: for a provider that DOES have a live fetcher, a non-nil `c.forms` returning a stored form is NOT used — the live fetcher is still preferred and called (call-counting fake), confirming this change does not alter behavior for Ashby/Workable/Greenhouse/Lever even though each has a row in `apply_forms` too.
+- [x] 3.4 Scenario test: a Recruitee attempt with a stored form and an incomplete resolution reports `Unmapped` naming the actual missing fields, not the generic `reasonSubmissionNotImplemented`.
+- [x] 3.5 Scenario test: a Recruitee attempt with a stored form and a fully-resolved plan still parks with `reasonSubmissionNotImplemented` (same message as today), asserting `plan.FullyResolved()==true` is reached and nothing further executes.
+- [x] 3.6 Run `go vet -tags=integration ./...` and the full test suite for `internal/api/atsapply` and `cmd/auto-apply`.
+
+## 4. Wrap-up
+
+- [x] 4.1 Update `internal/api/atsapply/AGENTS.md`'s Recruitee note (currently: "Reaching Recruitee would need reading its already-captured form from storage instead of `applyform.Fetcher` — a real gap, not a decision, and out of scope here") to reflect that schema resolution now does this, while stating plainly that Recruitee still has no fill/submit path.
+- [x] 4.2 `gofmt -l .`, `go vet ./...`, `go test ./...` clean before commit.


### PR DESCRIPTION
## Summary
- Recruitee has no live schema fetcher (`internal/ingest/applyform.Fetchers` never registered one — its form arrives free with the ingest crawl and is written directly to `apply_forms`), so every attempt parked at `fetchSchema` before resolution ever ran, with no diagnostic beyond "submission not yet implemented for this provider"
- `fetchSchema` now falls back to the stored `apply_forms` row **only when no live fetcher is registered** for the provider — the live fetcher is always tried first for every provider that has one
- Deliberately NOT `PreviewClient.schemaFor`'s storage-first order: `apply_forms` also holds a row for Greenhouse/Ashby/Workable/Lever (`cmd/capture-apply-form` captures those for the job page's own display), so storage-first would risk a real submission reading a possibly-stale row instead of a fresh fetch for providers that already work fine
- Recruitee still has no fill/submit path (neither `fillProviders` nor `browserUseProviders`) — this does not make Recruitee submit. A fully-resolved attempt still parks with the same reason; an incomplete one now reports precisely which fields are missing instead of an undifferentiated "not implemented"

Full OpenSpec change (proposal/specs/design/tasks) at `openspec/changes/atsapply-recruitee-stored-schema/`. design.md documents a correction made during implementation: the original plan mirrored `PreviewClient`'s storage-first order, which turned out to be wrong for the real submit path once I confirmed `apply_forms` isn't Recruitee-only.

## Test plan
- [x] `go vet ./...` and `go vet -tags=integration ./...` clean
- [x] `go test ./...` — no failures across the module
- [x] New tests: stored form used when no live fetcher exists (incomplete + fully-resolved cases), stored form NOT used when a live fetcher exists (fetcher still called), honest park when neither a fetcher nor a stored form exists
- [x] `gofmt -l .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)