### PR TITLE
Fix two stale comments found during code audit

### DIFF
--- a/internal/ingest/applyform/AGENTS.md
+++ b/internal/ingest/applyform/AGENTS.md
@@ -15,11 +15,14 @@ on the job page. Providers: greenhouse, ashby, workable, lever. Queue drain is
   thing is `FieldType`, the kind of control (form.go:27-54), and it follows the dict-only
   rule: a word the dictionary does not know yields no type, with `RawType` kept alongside
   so nothing is lost.
-- **The store exists for a consumer not yet built** — the one that fills a form rather than
-  describing it. display.go is the only reader today and wants almost none of it: the
-  question text plus one word about the answer. It drops hidden/info/demographic/consent
-  controls and folds the standard fields (name, email, CV) into one `basics` line, keyed on
-  the identifiers our own mappers produce, not on labels (display.go:51-90, 120-166).
+- **The store now has the consumer it was built for**: `internal/api/atsapply`'s auto-apply
+  submission path reads a captured form to resolve and fill it, and — for a provider with no
+  live schema fetcher (Recruitee) — `Client.fetchSchema`'s stored-form fallback reads it as
+  the ONLY source (`openspec/changes/atsapply-recruitee-stored-schema`). display.go remains a
+  second, display-only reader wanting almost none of the row: the question text plus one word
+  about the answer. It drops hidden/info/demographic/consent controls and folds the standard
+  fields (name, email, CV) into one `basics` line, keyed on the identifiers our own mappers
+  produce, not on labels (display.go:51-90, 120-166).
 - **One registry map sits behind both gate and drain.** `fetcherFor` (fetch.go:78-83) backs
   both the ingest enqueue gate (`NeedsRequestCapture`, fetch.go:70-73) and the worker's
   fetcher set, so the two cannot drift into a queue full of undrainable work; a test holds

--- a/internal/ingest/sources/gusto.go
+++ b/internal/ingest/sources/gusto.go
@@ -104,7 +104,8 @@ type gustoPosting struct {
 	// salary is the pay line as the board renders it ("$70,000 - $90,000 per year"), empty
 	// when the employer states no pay; applySalary is what turns it into the structured fields.
 	salary string
-	// employmentType is Gusto's own label ("Full time"), not yet mapped onto the vocabulary.
+	// employmentType is Gusto's own label ("Full time"); gustoEmploymentType maps it onto
+	// the freehire vocabulary.
 	employmentType string
 }
 


### PR DESCRIPTION
## Summary
- `internal/ingest/sources/gusto.go`: `employmentType`'s doc comment said "not yet mapped onto the vocabulary" — `gustoEmploymentType` already does this mapping and is called at the one use site
- `internal/ingest/applyform/AGENTS.md`: said the store's form-filling consumer was "not yet built" — `internal/api/atsapply` is that consumer today (auto-apply submission + the stored-form fallback for Recruitee)

Pure documentation fix, no behavior change.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/ingest/sources/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)