### PR TITLE
Act on the second two-axis review of the mentorship screens

### DIFF
--- a/internal/engage/mentorship/AGENTS.md
+++ b/internal/engage/mentorship/AGENTS.md
@@ -112,5 +112,15 @@ the SQL does not return), a withdrawal that erased history (a fake has no cascad
 paused mentor served from cache. Anything that is a property of the SCHEMA belongs in
 `internal/platform/db/mentorship_integration_test.go`.
 
+There is a THIRD layer, and it exists because the first two leave a gap between them.
+`internal/platform/db`'s tests call the generated query directly: they prove the columns
+come back, not that anything reads them. The fake proves the domain struct is filled,
+because it fills it. A field the query SELECTS and the mapping forgets is invisible to
+both — which is how a seeker's session list shipped naming nobody, while the
+single-session read set the same field and looked right. `repository_integration_test.go`
+drives `QueriesRepository` against a real Postgres, so it sees the seam itself. A test
+written for that defect in `internal/platform/db` passes with the fix removed; this one
+does not, and that difference is the whole reason the file is here.
+
 Run the slot-engine tests with `-count=1`: the layering guard next door reports `ok
 (cached)` on a package it has never seen, and the habit is worth keeping here too.

--- a/openspec/changes/mentorship-marketplace/tasks.md
+++ b/openspec/changes/mentorship-marketplace/tasks.md
@@ -272,6 +272,40 @@ unit tests plus the function they drive; none of it needs Docker or Postgres.
       the form always opens blank. The PUT still replaces rather than duplicates, which is
       what the spec requires; showing the current value needs the read to widen.
 
+- [x] 8.9 Ship the whole surface behind `users.beta_tester`, and record which spec
+      scenarios that DEFERS. Every route the feature owns — the public directory, a
+      mentor's page, and all four cabinet tabs — answers 404 without the flag, and
+      `MentorBlock` renders nothing. The predicate is `web/src/lib/server/mentorshipGate`.
+
+      **Three spec scenarios are therefore not true in a browser today.** They are
+      deferrals, not violations: every one of them still holds at the API layer, which is
+      untouched and public, and they become true again when the flag is dropped. Named
+      here so the change cannot archive with specs describing a marketplace nobody can
+      reach:
+      - `mentor-profile`: "A published mentor profile SHALL show ... to any visitor, signed
+        in or not" — and its "An anonymous visitor reads a published profile" scenario.
+      - `mentor-profile`: "WHEN a visitor opens a vacancy whose `company_slug` has at least
+        one approved, unpaused mentor THEN the page offers a route to that company's
+        mentors".
+      - `mentor-availability`: "The slot listing SHALL be readable without authentication."
+
+      Not a spec requirement — a product decision taken while the marketplace has no
+      supply: mentors are onboarded by hand, and a directory that opens empty reads as a
+      broken feature rather than an unlaunched one. Gating only the CABINET was considered
+      and rejected: it would leave somebody able to book from a public profile and then
+      unable to find the session again or cancel it, and the hour a mentor is holding is
+      real. 404 rather than 403 because a 403 advertises a door.
+
+      **Dropping the beta is three edits**, and the gate's own comment lists them:
+      `mentorshipGate.ts`, `inBeta` in `MentorBlock.svelte`, `betaOnly` in `accountNav.ts`.
+
+- [x] 8.10 A seeker's session list names the mentor by HEADLINE, not by name — a wire
+      gap, recorded rather than worked around, in the same class as 8.8's `job_id`.
+      `bookingResponse` carries `headline` and `mentor_slug` and no display name, so the
+      list reads "Principal Engineer" where `mentor-profile` says "The display name SHALL
+      be a field of the PROFILE". Fixing it means widening the booking read; until then
+      the mentor is identified but not named on that one surface.
+
 ## 9. Verification
 
 - [x] 9.1 `gofmt -l .` prints nothing; `go vet ./...`, `go test ./...`,

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -70,7 +70,10 @@ production; in dev the Vite proxy (`web/vite.config.ts`) forwards `/api` to the 
 - **Mentorship ships behind `users.beta_tester`, WHOLE.** Every route it owns — the public
   directory, a mentor's page, and all four cabinet tabs — answers **404** to anybody
   without the flag, and `MentorBlock` renders nothing. The predicate is
-  `$lib/server/mentorshipGate`, stated once so the beta ends in one edit. Gating only the
+  `$lib/server/mentorshipGate`. **Ending the beta is three edits**, not one: that file,
+  `inBeta` in `MentorBlock.svelte`, and `betaOnly` on `/my/mentorship` in `accountNav.ts`
+  — a door, an offer of the door, and a menu entry, deliberately separate. Grep for
+  `beta_tester` and `betaOnly`; those three are all of it. Gating only the
   cabinet was considered and rejected: it would leave a visitor able to BOOK from a public
   profile and then unable to find the session again or cancel it, and the hour a mentor is
   holding is real. 404 rather than 403 — while the feature is unreleased the honest answer

--- a/web/e2e/mentorship.spec.ts
+++ b/web/e2e/mentorship.spec.ts
@@ -31,7 +31,8 @@ function sql(statement: string): string {
   ).trim();
 }
 
-/** A fresh account. The address is unique per run: these tests write, and a re-run must
+/** A fresh account, onboarded and inside the beta — all three, which is why the name
+ *  says so. The address is unique per run: these tests write, and a re-run must
  *  not collide with what the last one left.
  *
  *  Registered through the API rather than the form, deliberately. The session cookie lands
@@ -39,7 +40,7 @@ function sql(statement: string): string {
  *  everything after this is a real signed-in browser. The sign-in screen is somebody
  *  else's subject, and driving it here would make this test fail for reasons that have
  *  nothing to do with mentorship. The pr-smoke job in CI mints its user the same way. */
-async function register(context: BrowserContext, email: string) {
+async function registerBetaUser(context: BrowserContext, email: string) {
   const response = await context.request.post('/api/v1/auth/register', {
     data: { email, password: 'e2e-password-not-a-secret' },
   });
@@ -52,7 +53,6 @@ async function register(context: BrowserContext, email: string) {
     `UPDATE users SET onboarding_completed_at = now(), beta_tester = true WHERE email = '${email}'`,
   );
 }
-
 
 /** Open a page and wait until its Svelte handlers are actually attached.
  *
@@ -88,7 +88,7 @@ test('a mentor publishes a profile and somebody else books an hour of it', async
   const mentor = await mentorContext.newPage();
 
   await test.step('the mentor publishes a profile', async () => {
-    await register(mentorContext, mentorEmail);
+    await registerBetaUser(mentorContext, mentorEmail);
     await open(mentor, '/my/mentorship/profile');
 
     await mentor.getByLabel('Your name, as seekers will see it').fill(displayName);
@@ -144,7 +144,7 @@ test('a mentor publishes a profile and somebody else books an hour of it', async
   const seeker = await seekerContext.newPage();
 
   await test.step('a different person books an hour', async () => {
-    await register(seekerContext, seekerEmail);
+    await registerBetaUser(seekerContext, seekerEmail);
     await open(seeker, `/mentors/${slug}`);
 
     // Whichever day the calendar offers, rather than a date computed here: the offerable

--- a/web/src/lib/server/mentorshipGate.ts
+++ b/web/src/lib/server/mentorshipGate.ts
@@ -1,4 +1,4 @@
-import { error } from '@sveltejs/kit';
+import { error, redirect } from '@sveltejs/kit';
 import type { User } from '$lib/types';
 
 /** Refuse a mentorship route to somebody outside the beta.
@@ -15,7 +15,27 @@ import type { User } from '$lib/types';
  *  One function rather than a predicate plus a guard. The predicate had no second caller —
  *  `MentorBlock` spells its own copy on purpose, because the routes are what close the door
  *  and the block only stops offering a link that would 404 — so exporting it was an
- *  abstraction with nobody on the other end. Ending the beta is still one edit: this file. */
+ *  abstraction with nobody on the other end.
+ *
+ *  ENDING THE BETA IS THREE EDITS, not one: this file, `inBeta` in `MentorBlock.svelte`,
+ *  and `betaOnly` on `/my/mentorship` in `accountNav.ts`. They are deliberately separate —
+ *  a door, an offer of the door, and a menu entry are three different things — but a
+ *  comment that promised one edit would send somebody looking for a single switch that
+ *  does not exist. Grep for `beta_tester` and for `betaOnly`; those three are all of it. */
 export function requireMentorshipAccess(user: User | null | undefined): void {
   if (!user?.beta_tester) error(404, 'Not found');
+}
+
+/** Refuse a MENTOR-only pane to somebody who has no mentor profile.
+ *
+ *  A redirect rather than a 404: they are allowed in this section, just not on this pane,
+ *  and the index is the part of it that is theirs. Without it the mentor-only reads throw
+ *  for an account with no profile and the pane answers 500 — which is how two of them
+ *  greeted anybody who simply typed the address, a tab hidden from the strip being no kind
+ *  of closed door.
+ *
+ *  Beside `requireMentorshipAccess` and not inlined at each pane, because two callers with
+ *  one rule is exactly the shape that drifts. */
+export function requireMentorProfile(profile: unknown): void {
+  if (!profile) redirect(303, '/my/mentorship');
 }

--- a/web/src/routes/mentors/+page.server.ts
+++ b/web/src/routes/mentors/+page.server.ts
@@ -18,10 +18,8 @@ import type { PageServerLoad } from './$types';
 // Filtering itself stays on the endpoint rather than being redone here. The publication
 // predicate — approved, unpaused, not withdrawn — lives in one place on purpose, and a
 // second copy in the browser is the drift the mentor-profile spec warns about.
-export const load: PageServerLoad = async ({ url, fetch , parent }) => {
-  // Beta-gated, and a 404 rather than a 403: while the marketplace is unreleased the
-  // honest answer is that this page is not there, and a 403 would advertise it to
-  // every crawler that found the URL.
+export const load: PageServerLoad = async ({ url, fetch, parent }) => {
+  // Beta-gated; mentorshipGate carries the whole argument, including why it is a 404.
   requireMentorshipAccess((await parent()).user);
 
   const filters = mentorFiltersFromParams(url.searchParams);

--- a/web/src/routes/mentors/[slug]/+page.server.ts
+++ b/web/src/routes/mentors/[slug]/+page.server.ts
@@ -20,10 +20,8 @@ import type { PageServerLoad } from './$types';
 // A profile that is pending, rejected, paused or withdrawn answers as though it does not
 // exist, so the 404 below covers all of them — deliberately, since telling a visitor that
 // a mentor exists but is hidden leaks the moderation queue.
-export const load: PageServerLoad = async ({ params, fetch , parent }) => {
-  // Beta-gated, and a 404 rather than a 403: while the marketplace is unreleased the
-  // honest answer is that this page is not there, and a 403 would advertise it to
-  // every crawler that found the URL.
+export const load: PageServerLoad = async ({ params, fetch, parent }) => {
+  // Beta-gated; mentorshipGate carries the whole argument, including why it is a 404.
   requireMentorshipAccess((await parent()).user);
 
   try {

--- a/web/src/routes/my/mentorship/+layout.svelte
+++ b/web/src/routes/my/mentorship/+layout.svelte
@@ -32,7 +32,8 @@
     MENTORSHIP_TABS.map((tab) => ({ ...tab, icon: ICONS[tab.id], href: resolve(tab.href) })),
   );
 
-  // Stated once, for the whole section: every instant on every pane is read in this zone.
+  // For the subtitle only. Each pane resolves the zone itself — it is a pure call, and
+  // threading it down through context would cost more indirection than the repeat.
   const timezone = browserTimezone();
 </script>
 

--- a/web/src/routes/my/mentorship/bookings/+page.server.ts
+++ b/web/src/routes/my/mentorship/bookings/+page.server.ts
@@ -1,4 +1,4 @@
-import { redirect } from '@sveltejs/kit';
+import { requireMentorProfile } from '$lib/server/mentorshipGate';
 import { serverApi } from '$lib/server/api';
 import type { PageServerLoad } from './$types';
 
@@ -9,8 +9,7 @@ import type { PageServerLoad } from './$types';
 // note. A hidden tab is not a closed door, and this one answered 500 to anybody who
 // walked through it.
 export const load: PageServerLoad = async ({ fetch, request, parent }) => {
-  const { profile } = await parent();
-  if (!profile) redirect(303, '/my/mentorship');
+  requireMentorProfile((await parent()).profile);
 
   const api = serverApi(fetch, request.headers.get('cookie'));
   return { bookings: await api.myMentorBookings() };

--- a/web/src/routes/my/mentorship/schedule/+page.server.ts
+++ b/web/src/routes/my/mentorship/schedule/+page.server.ts
@@ -1,4 +1,4 @@
-import { redirect } from '@sveltejs/kit';
+import { requireMentorProfile } from '$lib/server/mentorshipGate';
 import { serverApi } from '$lib/server/api';
 import type { PageServerLoad } from './$types';
 
@@ -12,8 +12,7 @@ import type { PageServerLoad } from './$types';
 // and the index is the part of it that is theirs.
 export const load: PageServerLoad = async ({ fetch, request, parent }) => {
   // The layout has already read it; this costs no second call.
-  const { profile } = await parent();
-  if (!profile) redirect(303, '/my/mentorship');
+  requireMentorProfile((await parent()).profile);
 
   const api = serverApi(fetch, request.headers.get('cookie'));
   return { availability: await api.myMentorAvailability() };


### PR DESCRIPTION
Follow-up to #2642, which is already on `main` and on prod. A second two-axis
review found ten things; this is all of them. No behaviour changes except one
guard moving into a shared function.

## The worst finding on each axis was a document that had stopped being true

**Standards.** The gate's comment and `web/AGENTS.md` both promised the beta ends
in ONE edit. It is **three** — `mentorshipGate.ts`, `inBeta` in `MentorBlock`, and
`betaOnly` in `accountNav`. The duplication is deliberate and each copy argues
itself; what was wrong is the sentence sending somebody to hunt for a single
switch that does not exist. Both now name all three and say what to grep for.

The layout's *"stated once, for the whole section"* about the timezone was false
the same way: every pane resolves it, and the layout's copy only feeds the
subtitle.

**Spec.** The beta gate appeared **nowhere** in the OpenSpec change. It falsifies
three scenarios in a browser — a public profile readable *"signed in or not"*, the
vacancy entry point, and slots *"readable without authentication"* — so the change
would have archived describing a marketplace nobody can reach.

Task 8.9 records it as a **deferral** with all three scenarios quoted: each still
holds at the API layer, which is untouched and public, and they become true again
when the flag drops. Task 8.10 records the smaller gap found beside it — a
seeker's list names the mentor by headline, because the booking read carries no
display name.

## The inconsistency the review put its finger on

The gate with **one** call site got its own module while the mentor-only guard
with **two** was inlined in both — exactly the shape that drifts.
`requireMentorProfile` now sits beside `requireMentorshipAccess`, and the
404-rather-than-403 argument lives with them instead of being repeated at each
route.

## Smaller

- `register()` in the e2e registers, completes onboarding **and** grants beta. Two
  of the three hid behind a name promising one; it is `registerBetaUser`.
- The package's `AGENTS.md` gained the third test layer it had grown, with the
  reason it exists: a test for that defect written in `internal/platform/db`
  passes with the fix removed, and the repository-level one does not.
- A stray space in two destructured `load` signatures.

## Verification

1778 unit tests, the e2e, and both guards probed against a running stack: a
non-beta account 404s on `/mentors` and on a cabinet pane; a beta mentor reaches
all four panes.
