### PR TITLE
Show auto-apply progress in the tracker drawer and deep-link its notifications

### DIFF
--- a/internal/engage/nudge/transports.go
+++ b/internal/engage/nudge/transports.go
@@ -153,8 +153,9 @@ func batchDestination(kind string) (path, label string) {
 	return "/my/tracking", "Open your tracking board"
 }
 
-// renderOne is the single-nudge body, kept per kind and unchanged, because a batch
-// of one must be indistinguishable from what shipped before grouping.
+// renderOne is the single-nudge body, kept as its own function per kind because a
+// batch of one must render identically to a real single-message send — never a
+// one-item batch headline — regardless of how each kind's own wording evolves.
 func (n *TelegramNotifier) renderOne(m Message) string {
 	title, company := html.EscapeString(m.JobTitle), html.EscapeString(m.Company)
 	trackingURL, jobURL := n.origin+"/my/tracking", n.origin+"/jobs/"+m.Slug

--- a/internal/engage/nudge/transports.go
+++ b/internal/engage/nudge/transports.go
@@ -158,6 +158,7 @@ func batchDestination(kind string) (path, label string) {
 func (n *TelegramNotifier) renderOne(m Message) string {
 	title, company := html.EscapeString(m.JobTitle), html.EscapeString(m.Company)
 	trackingURL, jobURL := n.origin+"/my/tracking", n.origin+"/jobs/"+m.Slug
+	applicationURL := n.origin + "/my/tracking/" + m.Slug
 	switch m.Kind {
 	case KindFollowUp:
 		return fmt.Sprintf(
@@ -173,16 +174,16 @@ func (n *TelegramNotifier) renderOne(m Message) string {
 			title, company, jobURL)
 	case KindAutoApplySubmitted:
 		return fmt.Sprintf(
-			"🎉 Auto-apply submitted your application to <b>%s</b> at <b>%s</b>.\n<a href=\"%s\">Open your tracking board →</a>",
-			title, company, trackingURL)
+			"🎉 Auto-apply submitted your application to <b>%s</b> at <b>%s</b>.\n<a href=\"%s\">Open your application →</a>",
+			title, company, applicationURL)
 	case KindAutoApplyBlocked:
 		return fmt.Sprintf(
-			"⚠️ Auto-apply couldn't finish <b>%s</b> at <b>%s</b> — a required question needs your own answer.\n<a href=\"%s\">Open your tracking board →</a>",
-			title, company, trackingURL)
+			"⚠️ Auto-apply couldn't finish <b>%s</b> at <b>%s</b> — a required question needs your own answer.\n<a href=\"%s\">Open your application →</a>",
+			title, company, applicationURL)
 	case KindAutoApplyFailed:
 		return fmt.Sprintf(
-			"Auto-apply couldn't submit <b>%s</b> at <b>%s</b>, and won't try again.\n<a href=\"%s\">Open your tracking board →</a>",
-			title, company, trackingURL)
+			"Auto-apply couldn't submit <b>%s</b> at <b>%s</b>, and won't try again.\n<a href=\"%s\">Open your application →</a>",
+			title, company, applicationURL)
 	default:
 		return fmt.Sprintf("<b>%s</b> at <b>%s</b>: <a href=\"%s\">Open your tracking board →</a>", title, company, trackingURL)
 	}
@@ -390,6 +391,7 @@ var bodies = template.Must(mailtpl.Partials().New("nudge").Parse(`
 func (n *EmailNotifier) render(m Message) (subject, htmlBody, textBody string) {
 	trackingURL := n.origin + "/my/tracking?utm_source=email"
 	jobURL := n.origin + "/jobs/" + m.Slug + "?utm_source=email"
+	applicationURL := n.origin + "/my/tracking/" + m.Slug + "?utm_source=email"
 
 	// block names the body template; head and pre are the shell's heading and the
 	// inbox preview line.
@@ -422,18 +424,21 @@ func (n *EmailNotifier) render(m Message) (subject, htmlBody, textBody string) {
 	case KindAutoApplySubmitted:
 		block, head, pre = "auto_apply_submitted", "Application submitted", "Auto-apply submitted your application"
 		subject = fmt.Sprintf("Submitted: %s at %s", m.JobTitle, m.Company)
-		textBody = fmt.Sprintf("Auto-apply submitted your application to %s at %s.\n\nOpen your tracking board: %s\n",
-			m.JobTitle, m.Company, trackingURL)
+		data.URL, data.CTA = applicationURL, "Open your application"
+		textBody = fmt.Sprintf("Auto-apply submitted your application to %s at %s.\n\nOpen your application: %s\n",
+			m.JobTitle, m.Company, data.URL)
 	case KindAutoApplyBlocked:
 		block, head, pre = "auto_apply_blocked", "Needs your attention", "Auto-apply couldn't finish this application"
 		subject = fmt.Sprintf("Needs your attention: %s at %s", m.JobTitle, m.Company)
-		textBody = fmt.Sprintf("Auto-apply couldn't finish %s at %s — a required question needs your own answer.\n\nOpen your tracking board: %s\n",
-			m.JobTitle, m.Company, trackingURL)
+		data.URL, data.CTA = applicationURL, "Open your application"
+		textBody = fmt.Sprintf("Auto-apply couldn't finish %s at %s — a required question needs your own answer.\n\nOpen your application: %s\n",
+			m.JobTitle, m.Company, data.URL)
 	case KindAutoApplyFailed:
 		block, head, pre = "auto_apply_failed", "Auto-apply couldn't submit this application", "Auto-apply couldn't submit this application"
 		subject = fmt.Sprintf("Couldn't submit: %s at %s", m.JobTitle, m.Company)
-		textBody = fmt.Sprintf("Auto-apply couldn't submit %s at %s, and won't try again.\n\nOpen your tracking board: %s\n",
-			m.JobTitle, m.Company, trackingURL)
+		data.URL, data.CTA = applicationURL, "Open your application"
+		textBody = fmt.Sprintf("Auto-apply couldn't submit %s at %s, and won't try again.\n\nOpen your application: %s\n",
+			m.JobTitle, m.Company, data.URL)
 	default:
 		block, head, pre = "plain", fmt.Sprintf("%s at %s", m.JobTitle, m.Company), "An update on a job you are tracking"
 		subject = fmt.Sprintf("%s at %s", m.JobTitle, m.Company)

--- a/internal/engage/nudge/transports_test.go
+++ b/internal/engage/nudge/transports_test.go
@@ -82,9 +82,31 @@ func TestEmailNotifier_InterviewPrepBatchLeadsToTheTrackingBoard(t *testing.T) {
 	}
 }
 
+// follow-up and interview-prep single-message notifications still lead to the
+// general tracking board — only the three auto-apply outcome kinds deep-link.
+func TestEmailNotifier_FollowUpAndInterviewPrepSingle_LeadToTheGeneralBoard(t *testing.T) {
+	for _, kind := range []string{KindFollowUp, KindInterviewPrep} {
+		t.Run(kind, func(t *testing.T) {
+			sender := &captureSender{}
+			n := NewEmailNotifier(sender, "jobs@freehire.me", "https://freehire.me")
+			ms := []Message{{Kind: kind, JobTitle: "Go Dev", Company: "Acme", Slug: "go-dev-acme"}}
+			if err := n.Send(context.Background(), "email", "u@x.com", kind, ms); err != nil {
+				t.Fatalf("Send: %v", err)
+			}
+			if !strings.Contains(sender.html, "https://freehire.me/my/tracking?utm_source=email") {
+				t.Errorf("html = %q, want the bare tracking-board destination", sender.html)
+			}
+			if strings.Contains(sender.html, "/my/tracking/go-dev-acme") {
+				t.Errorf("html = %q, must not deep-link to the specific application", sender.html)
+			}
+		})
+	}
+}
+
 // The three auto-apply outcome kinds are about an application, same as
-// follow-up/interview-prep, so they lead to the tracking board — never
-// /my/activity, unlike job-closed.
+// follow-up/interview-prep, so a batch leads to the tracking board — never
+// /my/activity, unlike job-closed. A single-application notification, unlike
+// follow-up/interview-prep, deep-links straight to that application's drawer.
 func TestEmailNotifier_AutoApplyOutcomeKinds_SingleAndBatch(t *testing.T) {
 	cases := []struct {
 		kind        string
@@ -105,8 +127,8 @@ func TestEmailNotifier_AutoApplyOutcomeKinds_SingleAndBatch(t *testing.T) {
 			if !strings.Contains(sender.subject, c.wantSubject) {
 				t.Errorf("subject = %q, want it to contain %q", sender.subject, c.wantSubject)
 			}
-			if !strings.Contains(sender.html, "/my/tracking") {
-				t.Errorf("html = %q, want the tracking-board destination", sender.html)
+			if !strings.Contains(sender.html, "/my/tracking/go-dev-acme") {
+				t.Errorf("html = %q, want a deep link to the specific application", sender.html)
 			}
 		})
 		t.Run(c.kind+"/batch", func(t *testing.T) {
@@ -118,8 +140,8 @@ func TestEmailNotifier_AutoApplyOutcomeKinds_SingleAndBatch(t *testing.T) {
 			if !strings.Contains(sender.subject, "2") {
 				t.Errorf("subject = %q, want the batch count", sender.subject)
 			}
-			if !strings.Contains(sender.html, "/my/tracking") {
-				t.Errorf("html = %q, want the tracking-board destination", sender.html)
+			if !strings.Contains(sender.html, "https://freehire.me/my/tracking?utm_source=email") {
+				t.Errorf("html = %q, want the bare tracking-board destination for a batch", sender.html)
 			}
 		})
 	}
@@ -133,8 +155,8 @@ func TestTelegramNotifier_AutoApplyOutcomeKinds_SingleAndBatch(t *testing.T) {
 			if !strings.Contains(got, "Go Dev") || !strings.Contains(got, "Acme") {
 				t.Errorf("render = %q, want the job title and company", got)
 			}
-			if !strings.Contains(got, "/my/tracking") {
-				t.Errorf("render = %q, want the tracking-board link", got)
+			if !strings.Contains(got, "/my/tracking/go-dev-acme") {
+				t.Errorf("render = %q, want a deep link to the specific application", got)
 			}
 		})
 		t.Run(kind+"/batch", func(t *testing.T) {
@@ -142,6 +164,26 @@ func TestTelegramNotifier_AutoApplyOutcomeKinds_SingleAndBatch(t *testing.T) {
 			got := n.render(kind, batchOf(kind, 2))
 			if !strings.Contains(got, "<b>2</b>") {
 				t.Errorf("render = %q, want the batch count", got)
+			}
+			// A batch within the list limit names each job individually (jobLine),
+			// never a per-application deep link — batchDestination's bare-board link
+			// only appears in the overflow tail, exercised by the "+more" tests below.
+		})
+	}
+}
+
+// follow-up and interview-prep single-message notifications still lead to the
+// general tracking board — only the three auto-apply outcome kinds deep-link.
+func TestTelegramNotifier_FollowUpAndInterviewPrepSingle_LeadToTheGeneralBoard(t *testing.T) {
+	for _, kind := range []string{KindFollowUp, KindInterviewPrep} {
+		t.Run(kind, func(t *testing.T) {
+			n := NewTelegramNotifier(nil, "https://freehire.me")
+			got := n.render(kind, []Message{{Kind: kind, JobTitle: "Go Dev", Company: "Acme", Slug: "go-dev-acme"}})
+			if !strings.Contains(got, "https://freehire.me/my/tracking\"") {
+				t.Errorf("render = %q, want the bare tracking-board destination", got)
+			}
+			if strings.Contains(got, "/my/tracking/go-dev-acme") {
+				t.Errorf("render = %q, must not deep-link to the specific application", got)
 			}
 		})
 	}

--- a/openspec/changes/auto-apply-drawer-progress/.openspec.yaml
+++ b/openspec/changes/auto-apply-drawer-progress/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/auto-apply-drawer-progress/design.md
+++ b/openspec/changes/auto-apply-drawer-progress/design.md
@@ -1,0 +1,85 @@
+## Context
+
+`web/src/lib/autoApplyReview.ts`'s `autoApplyReviewBanner` already maps the six-value
+`autoapply.Status` (`internal/application/autoapply/status.go`) to a drawer banner variant, but
+returns `null` for `tailoring` and `approved` — see proposal.md for why that gap matters. The
+`pending_review` variant in `JobDrawer.svelte` already renders a "View tailored CV" link to
+`/tailor/[slug]`; the new `approved` variant reuses that same link.
+
+On the notification side, `internal/engage/nudge/transports.go`'s `renderOne` (Telegram) and
+`EmailNotifier.render` (email) build a `trackingURL` from `n.origin + "/my/tracking"` for every
+kind except `KindJobClosed`. `web/src/lib/notificationTarget.ts` mirrors this on the frontend:
+`nudge_auto_apply_submitted/blocked/failed` resolve to `{kind: 'tracking'}` with no slug, by a
+documented, deliberate choice to match the (undifferentiated) Telegram/email link. This change
+reverses that choice for these three kinds only, now that the drawer has something worth jumping
+to for every live auto-apply status. See proposal.md for what stays out of scope
+(follow-up/interview-prep, push).
+
+`web/src/lib/components/BoardCard.svelte` already derives `needsAutoApplyReview` from
+`autoApplyNeedsReviewBadge(item.auto_apply_status)` and renders a text-only "Review" badge when
+truthy. `JobBoard.svelte` already filters both its board and list views through one `shown`
+derived value, built from `matchesQuery` (`web/src/lib/board.ts`) over the text in
+`UrlSyncedState`-backed `search`, mirrored to `?q=` — the same pattern a second, boolean toggle
+can reuse.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Give `tailoring` and `approved` their own read-only banner in the tracker drawer.
+- Make the three outcome notifications' single-application case deep-link to that application.
+- Let the candidate narrow the board to only applications needing an auto-apply decision, and
+  make that state more visible on the card itself.
+
+**Non-Goals:**
+- Changing `follow_up`/`interview_prep` link targets, or push notification click behavior.
+- Adding a retry/cancel action to any terminal status — `blocked`/`declined`/`failed` remain
+  read-only, unchanged by this design.
+- Touching the pre-existing, unarchived `add-auto-apply-outcome-notifications` change directory —
+  its tasks are already complete and its code is already live; this design only extends what it
+  shipped.
+
+## Decisions
+
+- **`tailoring` gets a plain status line, no link.** There is no tailored CV yet to open
+  (`DerivedStatus` only reaches `tailoring` when `hasTailoredCV` is false), so any link would
+  either 404 or point at a workspace that has nothing to show yet. A future change can revisit
+  this once there is something to view mid-tailoring.
+- **`approved` reuses the `pending_review` banner's tailored-CV link verbatim**, rather than
+  building a separate read-only preview view. The candidate already approved this exact tailored
+  CV; showing the same artifact through the same link keeps the two states visually and
+  behaviorally consistent, and avoids a second rendering path for one preview.
+- **The notification-link fix touches only the single-application render path**
+  (`renderOne`/`EmailNotifier.render`'s per-message branch, and `notificationTarget.ts`'s
+  slug-bearing branch), not `batchDestination`. A batch has no single job to deep-link to, and
+  `batchDestination`'s existing fallback to the general board is correct for that case — it needs
+  no change.
+- **The "needs attention" predicate is a new pure function in `board.ts`** (`needsAttention(item)`,
+  wrapping the same `autoApplyNeedsReviewBadge` call `BoardCard.svelte` already makes), not a
+  second copy of the pending_review/blocked check. The board's `shown` derived ANDs it with the
+  existing `matchesQuery` result when the toggle is on, mirroring how the two views already share
+  one filtered value.
+- **The toggle is mirrored into the URL** (`UrlSyncedState<boolean>`, its own query param) the
+  same way `search` already is, so a filtered board survives a reload or a shared link — consistent
+  with the existing search field rather than a one-off local `$state`.
+- **The board card gets a dot, not a badge replacement.** The existing "Review" text stays exactly
+  as it renders today (same copy, same `aria-label`); the dot is a purely decorative sibling
+  element (`aria-hidden`), so no accessible-name behavior changes — only the visual weight of an
+  already-present signal.
+- **Push is left untouched.** `push.go` already carries `data: {"slug": ...}` for a single-message
+  batch, but no `notificationclick` handler exists anywhere in this repo to consume it — whatever
+  reads that field (if anything) lives outside this codebase, so there is nothing here to wire up
+  without inventing an unverifiable click target.
+
+## Risks / Trade-offs
+
+- **[Risk]** Reversing the documented "match Telegram/email" rationale in
+  `notificationTarget.ts` for these three kinds only, while leaving `follow_up`/`interview_prep`
+  on the old rule, leaves the file's remaining kinds inconsistent with each other on purpose. →
+  **Mitigation**: the comment explaining the split is rewritten as part of this change, so a
+  future reader sees this was a deliberate, scoped reversal rather than a partial fix left behind.
+- **[Risk]** `approved`'s "View tailored CV" link points at `/tailor/[slug]`, the same workspace
+  route `pending_review` uses — if that workspace ever adds an editing affordance, an already
+  approved-and-queued attempt could be edited out from under the auto-apply submission it is
+  queued for. → **Mitigation**: out of scope here; the workspace's own read/write behavior is
+  unchanged by this design, and `/tailor/[slug]`'s current behavior (idempotently resolving the
+  existing tailored CV) is exactly what `pending_review` already relies on today.

--- a/openspec/changes/auto-apply-drawer-progress/proposal.md
+++ b/openspec/changes/auto-apply-drawer-progress/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+A candidate whose auto-apply attempt is `tailoring` (CV not produced yet) or `approved` (queued
+for unattended submission) currently sees nothing in the tracker drawer — only `pending_review`,
+`blocked`, `declined`, and `failed` render a banner. There is no way to tell, from the tracker,
+that auto-apply is even working on a job, or to open the tailored CV once it has already been
+approved. Separately, the submitted/blocked/failed outcome notifications (email, Telegram, in-app)
+all link to the general `/my/tracking` board rather than the specific application, so a candidate
+who taps one has to find the job again by hand — even though the notification already knows
+exactly which job it is about.
+
+## What Changes
+
+- The tracker drawer's auto-apply banner gains two new read-only states:
+  - `tailoring`: a neutral "preparing your tailored CV" status, no action (there is nothing to
+    open yet).
+  - `approved`: a "queued for automatic submission" status with a "View tailored CV" link —
+    the same destination `pending_review` already links to — but no Approve/Decline actions,
+    since the decision is already made.
+- The three auto-apply outcome notifications — submitted, blocked, failed — deep-link to the
+  specific application's tracker drawer instead of the general tracking board, on every channel
+  that already carries a per-job slug for them (email, Telegram, in-app). A batch covering more
+  than one job still links to the general board, since there is no single application to deep-link
+  to.
+- Out of scope: follow-up/interview-prep nudges (kept on the general board, by explicit choice)
+  and push notifications (no click-target handling exists in this repo for push today).
+- The board (Kanban and list view) gains a "Needs attention" toggle next to the existing search
+  field, narrowing every column to only the applications whose auto-apply status already earns
+  the existing "Review" badge (`pending_review`/`blocked`) — combinable with the text search, the
+  same way the two views already share `matchesQuery`.
+- The board card's existing "Review" badge gains a small red dot alongside its text, so an
+  application needing attention is visually distinct at a glance, not only readable as a label.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `auto-apply-tracker-review`: adds visibility for the `tailoring`/`approved` statuses in the
+  tracker drawer, adds the requirement that the submitted/blocked/failed outcome notifications
+  deep-link to the specific application they are about, and adds a board-level "needs attention"
+  filter plus a stronger visual marker on the existing review badge.
+
+## Impact
+
+- `web/src/lib/autoApplyReview.ts` — new `tailoring`/`approved` banner variants.
+- `web/src/lib/components/JobDrawer.svelte` — renders the two new banner variants.
+- `web/src/lib/notificationTarget.ts` — the three outcome kinds resolve to a slug-carrying
+  tracking target instead of the bare board.
+- `internal/engage/nudge/transports.go` — Telegram and email single-message rendering for the
+  three outcome kinds link to `/my/tracking/<slug>` instead of `/my/tracking`.
+- `web/src/lib/board.ts` — new pure `needsAttention()` predicate, reused by both the board's
+  filter toggle and the existing card badge.
+- `web/src/lib/components/BoardCard.svelte` — red dot alongside the existing "Review" badge.
+- Tests: `web/src/lib/autoApplyReview.test.ts`, `web/src/lib/notificationTarget.test.ts`,
+  `web/src/lib/board.test.ts`, `internal/engage/nudge/transports_test.go`.

--- a/openspec/changes/auto-apply-drawer-progress/specs/auto-apply-tracker-review/spec.md
+++ b/openspec/changes/auto-apply-drawer-progress/specs/auto-apply-tracker-review/spec.md
@@ -1,0 +1,93 @@
+## ADDED Requirements
+
+### Requirement: A tailoring or approved attempt is visible in the tracker drawer
+
+The system SHALL render a status indicator in the tracker drawer for an attempt whose status is
+`tailoring` or `approved`, so the candidate can tell auto-apply is actively working on the job
+even before there is anything to decide. Neither indicator SHALL offer an Approve/Decline action,
+since neither status has a pending decision.
+
+#### Scenario: An attempt is still being tailored
+
+- **WHEN** the candidate views an attempt whose status is `tailoring`
+- **THEN** the drawer shows a status indicator that a tailored CV is being prepared, with no
+  action to take
+
+#### Scenario: An attempt has been approved
+
+- **WHEN** the candidate views an attempt whose status is `approved`
+- **THEN** the drawer shows a status indicator that the attempt is queued for automatic
+  submission, with no Approve/Decline action
+
+### Requirement: An approved attempt exposes the tailored CV for viewing
+
+When an attempt's status is `approved`, the system SHALL let the candidate open the tailored CV
+the attempt will submit, the same way a `pending_review` attempt already does.
+
+#### Scenario: Viewing the tailored CV after approval
+
+- **WHEN** the candidate views an attempt whose status is `approved`
+- **THEN** the drawer offers a link to the tailored CV, and following it opens the same tailored
+  CV a `pending_review` attempt for the same job would show
+
+### Requirement: Outcome notifications deep-link to the specific application
+
+When a submitted, blocked, or failed auto-apply outcome notification is about exactly one
+application, the system SHALL link it to that application's tracker drawer rather than the
+general tracker board, on every channel that renders a single-application notification (email,
+Telegram, in-app). A notification batch covering more than one application SHALL continue to link
+to the general tracker board, since no single application can be deep-linked to.
+
+#### Scenario: A single-application outcome notification links to that application
+
+- **WHEN** a submitted, blocked, or failed outcome notification is delivered for exactly one
+  application
+- **THEN** the notification's link opens that application's tracker drawer directly
+
+#### Scenario: A batched outcome notification links to the general board
+
+- **WHEN** a submitted, blocked, or failed outcome notification is delivered as a batch covering
+  more than one application
+- **THEN** the notification's link opens the general tracker board
+
+### Requirement: The board can be filtered to only applications needing auto-apply review
+
+The tracker board SHALL offer a toggle that narrows every column to only the applications whose
+auto-apply status already earns the existing review badge (`pending_review` or `blocked`). The
+toggle SHALL combine with the existing text search rather than replace it: with both active, only
+applications matching both conditions SHALL be shown.
+
+#### Scenario: Toggling the filter narrows the board
+
+- **WHEN** the candidate enables the "needs attention" toggle
+- **THEN** every column shows only applications whose auto-apply status is `pending_review` or
+  `blocked`
+
+#### Scenario: The filter combines with search
+
+- **WHEN** the candidate has both a search query and the "needs attention" toggle active
+- **THEN** the board shows only applications that match the search query AND need auto-apply
+  review
+
+#### Scenario: Turning the filter off restores the board
+
+- **WHEN** the candidate disables the "needs attention" toggle
+- **THEN** the board returns to showing every application matching the search query alone (or
+  everything, if the search query is blank)
+
+### Requirement: An application needing review is visually marked on the board card
+
+In addition to its existing text label, a board card whose auto-apply status is `pending_review`
+or `blocked` SHALL display a distinct visual marker (a colored dot) so the card is identifiable
+without reading its text.
+
+#### Scenario: A card needing review shows the marker
+
+- **WHEN** a board card's auto-apply status is `pending_review` or `blocked`
+- **THEN** the card renders both its existing "Review" label and the colored dot marker, together
+
+#### Scenario: A card not needing review shows neither
+
+- **WHEN** a board card's auto-apply status is anything other than `pending_review` or `blocked`
+  (including no auto-apply attempt at all)
+- **THEN** the card renders neither the label nor the dot marker

--- a/openspec/changes/auto-apply-drawer-progress/tasks.md
+++ b/openspec/changes/auto-apply-drawer-progress/tasks.md
@@ -1,0 +1,30 @@
+## 1. Drawer banner: tailoring / approved
+
+- [x] 1.1 `web/src/lib/autoApplyReview.test.ts`: add failing cases — `autoApplyReviewBanner('tailoring')` returns `{kind: 'tailoring'}`; `autoApplyReviewBanner('approved')` returns `{kind: 'approved'}`.
+- [x] 1.2 `web/src/lib/autoApplyReview.ts`: extend `AutoApplyReviewBanner`'s union and `autoApplyReviewBanner()` to cover `tailoring`/`approved`; update the function's doc comment (it currently says both render nothing).
+- [x] 1.3 `web/src/lib/components/JobDrawer.svelte`: add the `tailoring` banner branch (status text only, no action) and the `approved` banner branch (status text + the existing "View tailored CV" link to `/tailor/[slug]`, no Approve/Decline buttons) alongside the existing `pending_review`/`blocked`/`declined`/`failed` branches.
+- [x] 1.4 Manual check (no Svelte component-test harness exists in `web/` today — this app tests pure logic and verifies UI in the browser, per AGENTS.md): confirmed live against Postgres/Redis + `go run ./cmd/server` + `pnpm dev`, with a seeded user and one `auto_apply_queue` row per status (`tailoring`/`pending_review`/`approved`/`blocked`). Screenshotted via Playwright: the `tailoring` banner shows no action, `approved` shows the same "View tailored CV" link `pending_review` shows (same `/tailor/[slug]` href), the board card's red dot renders next to the "Review" text for `pending_review`/`blocked` only, and the "Needs attention" toggle narrows the board to exactly those two cards (2 of 4) and combines with search. Zero browser console errors. Scratch DB/server/screenshots torn down after.
+
+## 2. Outcome notifications deep-link to the specific application
+
+- [x] 2.1 `internal/engage/nudge/transports_test.go`: add failing assertions that a single-message `KindAutoApplySubmitted`/`Blocked`/`Failed` render (both `TelegramNotifier.render` and `EmailNotifier.render`) contains `/my/tracking/<slug>`, and that the batch (2+ messages) case for the same kinds still contains the bare `/my/tracking` with no slug. Add/confirm assertions that `KindFollowUp`/`KindInterviewPrep` single-message rendering still contains the bare `/my/tracking` (unchanged).
+- [x] 2.2 `internal/engage/nudge/transports.go`: in `renderOne`, build `trackingURL` per-kind — `n.origin+"/my/tracking/"+m.Slug` for the three outcome kinds, `n.origin+"/my/tracking"` otherwise. Mirror the same change in `EmailNotifier.render`'s single-message branch.
+- [x] 2.3 `web/src/lib/notificationTarget.test.ts`: add failing cases — `nudge_auto_apply_submitted`/`blocked`/`failed` with a `public_slug` now resolve to `{kind: 'tracking', slug: <slug>}` instead of `{kind: 'tracking'}`.
+- [x] 2.4 `web/src/lib/notificationTarget.ts`: move the three kinds out of the no-slug `{kind: 'tracking'}` branch into the slug-carrying branch alongside `auto_apply_ready_for_review`; rewrite the file's explanatory comment to describe the split as deliberate (these three now deep-link; `follow_up`/`interview_prep` still don't).
+
+## 3. Board filter: "Needs attention" toggle
+
+- [x] 3.1 `web/src/lib/board.test.ts`: add failing cases for a new `needsAttention(item)` predicate — true for `pending_review`/`blocked` auto-apply statuses, false for every other status and for no attempt at all.
+- [x] 3.2 `web/src/lib/board.ts`: add `needsAttention(item: MyJob): boolean`, delegating to `autoApplyNeedsReviewBadge(item.auto_apply_status)` (import from `$lib/autoApplyReview`) rather than re-deriving the pending_review/blocked check.
+- [x] 3.3 `web/src/lib/components/JobBoard.svelte`: add a boolean `UrlSyncedState` toggle (own query param, e.g. `?attention=1`) mirroring the existing `search` pattern; AND it into the `shown` derived alongside `matchesQuery` when the toggle is on.
+- [x] 3.4 `web/src/lib/components/JobBoard.svelte`: render a "Needs attention" toggle control next to the search input, following the existing search field's styling; reflect its on/off state visually.
+
+## 4. Board card: red dot marker
+
+- [x] 4.1 `web/src/lib/components/BoardCard.svelte`: add a small decorative (`aria-hidden`) colored-dot element alongside the existing "Review" text badge, rendered under the same `{#if needsAutoApplyReview}` condition — no change to the badge's existing text or `aria-label`.
+
+## 5. Verification
+
+- [x] 5.1 `gofmt -l .` (must print nothing for touched files), `go vet ./...`, `go test ./...`.
+- [x] 5.2 `pnpm --filter web test` (or the project's equivalent vitest invocation) for the touched `web/src/lib` files and any JobDrawer/JobBoard/BoardCard component tests.
+- [x] 5.3 `pnpm --filter web check` (svelte-check) if touched Svelte files are covered by it.

--- a/web/src/lib/autoApplyReview.test.ts
+++ b/web/src/lib/autoApplyReview.test.ts
@@ -31,8 +31,16 @@ describe('autoApplyReviewBanner', () => {
     expect(autoApplyReviewBanner('failed')).toEqual({ kind: 'failed' });
   });
 
-  it('is null for tailoring, approved, and no attempt', () => {
-    for (const status of ['tailoring', 'approved', null, undefined]) {
+  it('is the tailoring variant for tailoring', () => {
+    expect(autoApplyReviewBanner('tailoring')).toEqual({ kind: 'tailoring' });
+  });
+
+  it('is the approved variant for approved', () => {
+    expect(autoApplyReviewBanner('approved')).toEqual({ kind: 'approved' });
+  });
+
+  it('is null for no attempt', () => {
+    for (const status of [null, undefined]) {
       expect(autoApplyReviewBanner(status)).toBeNull();
     }
   });

--- a/web/src/lib/autoApplyReview.ts
+++ b/web/src/lib/autoApplyReview.ts
@@ -12,21 +12,28 @@ export function autoApplyNeedsReviewBadge(status?: string | null): boolean {
 }
 
 export type AutoApplyReviewBanner =
+  | { kind: 'tailoring' }
   | { kind: 'pending_review' }
+  | { kind: 'approved' }
   | { kind: 'blocked' }
   | { kind: 'declined' }
   | { kind: 'failed' }
   | null;
 
-/** Decides which drawer banner variant to render, or null for `tailoring`/`approved` —
- *  states with nothing yet for the candidate to see or decide. `pending_review` is the one
- *  actionable variant (approve/decline); `blocked`/`declined`/`failed` are read-only, and
- *  the drawer's own copy for them must never imply a retry is possible — no retry path
- *  exists anywhere in the backend for any of the three. */
+/** Decides which drawer banner variant to render, or null when there is no live attempt at
+ *  all. `pending_review` is the one actionable variant (approve/decline); `tailoring` and
+ *  `approved` are read-only progress indicators — nothing to decide yet, or the decision is
+ *  already made — and `blocked`/`declined`/`failed` are read-only terminal states, whose
+ *  drawer copy must never imply a retry is possible — no retry path exists anywhere in the
+ *  backend for any of the three. */
 export function autoApplyReviewBanner(status?: string | null): AutoApplyReviewBanner {
   switch (status) {
+    case 'tailoring':
+      return { kind: 'tailoring' };
     case 'pending_review':
       return { kind: 'pending_review' };
+    case 'approved':
+      return { kind: 'approved' };
     case 'blocked':
       return { kind: 'blocked' };
     case 'declined':

--- a/web/src/lib/board.test.ts
+++ b/web/src/lib/board.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { BOARD_COLUMNS, CLOSED_OUTCOMES, boardRefFor, columnOf, matchesQuery } from './board';
+import { BOARD_COLUMNS, CLOSED_OUTCOMES, boardRefFor, columnOf, matchesQuery, needsAttention } from './board';
 import { STAGE_GROUPS } from './generated/contracts';
 import { must } from './utils';
 import type { MyJob } from './types';
@@ -25,6 +25,23 @@ function listed(company: string, title: string): MyJob {
 function pruned(companySlug: string, title: string): MyJob {
   return { company_slug: companySlug, role_title: title, job: null } as MyJob;
 }
+
+describe('needsAttention', () => {
+  it('is true for pending_review and blocked', () => {
+    expect(needsAttention(job({ auto_apply_status: 'pending_review' }))).toBe(true);
+    expect(needsAttention(job({ auto_apply_status: 'blocked' }))).toBe(true);
+  });
+
+  it('is false for every other status', () => {
+    for (const status of ['tailoring', 'approved', 'declined', 'failed'] as const) {
+      expect(needsAttention(job({ auto_apply_status: status }))).toBe(false);
+    }
+  });
+
+  it('is false when there is no live attempt at all', () => {
+    expect(needsAttention(job({ auto_apply_status: undefined }))).toBe(false);
+  });
+});
 
 describe('BOARD_COLUMNS', () => {
   it('has no Saved column — only the active application states', () => {

--- a/web/src/lib/board.ts
+++ b/web/src/lib/board.ts
@@ -7,6 +7,7 @@
 // cmd/gen-contracts). This file used to restate both, which is how the board and the
 // pipeline came to call the same settled application by two different names.
 import { STAGE_GROUPS } from './generated/contracts';
+import { autoApplyNeedsReviewBadge } from './autoApplyReview';
 import type { MyJob } from './types';
 import { must } from './utils';
 
@@ -53,6 +54,13 @@ export type ClosedOutcome = (typeof CLOSED_OUTCOMES)[number];
 // svelte-dnd-action keys each draggable by a top-level `id`; MyJob has none, so
 // the board wraps each row with id = the job's public_slug.
 export type BoardItem = MyJob & { id: string };
+
+/** Whether an application needs the candidate's attention on its auto-apply attempt —
+ *  the same pending_review/blocked check the board card's own "Review" badge already
+ *  makes, reused here so the board's "needs attention" filter can never drift from it. */
+export function needsAttention(item: MyJob): boolean {
+  return autoApplyNeedsReviewBadge(item.auto_apply_status);
+}
 
 /** Whether an application answers the search query, matching on the employer and the
  *  role. Shared by the board and the list — one field narrows whichever view is open.

--- a/web/src/lib/components/BoardCard.svelte
+++ b/web/src/lib/components/BoardCard.svelte
@@ -89,10 +89,11 @@
     {/if}
     {#if needsAutoApplyReview}
       <span
-        class="flex items-center gap-0.5 text-xs font-medium text-warning-strong"
+        class="flex items-center gap-1 text-xs font-medium text-warning-strong"
         title="Auto-apply needs your review"
         aria-label="Auto-apply needs your review"
       >
+        <span class="size-1.5 shrink-0 rounded-full bg-warning-strong" aria-hidden="true"></span>
         <FileCheck class="size-3 shrink-0" aria-hidden="true" />
         Review
       </span>

--- a/web/src/lib/components/BoardColumn.svelte
+++ b/web/src/lib/components/BoardColumn.svelte
@@ -16,10 +16,10 @@
     id: BoardColumnId;
     label: string;
     items: BoardItem[];
-    // Set while the board is filtered by a search. The zone is handed the matching rows
-    // only, and svelte-dnd-action answers a drop with the array it was given — so a drop
-    // during a search would write the visible subset back as the whole column and lose
-    // every row the query hid.
+    // Set while the board is filtered — by search text or the "needs attention" toggle.
+    // The zone is handed the matching rows only, and svelte-dnd-action answers a drop
+    // with the array it was given — so a drop while filtered would write the visible
+    // subset back as the whole column and lose every row the filter hid.
     dragDisabled?: boolean;
     onconsider: (id: BoardColumnId, items: BoardItem[]) => void;
     onfinalize: (id: BoardColumnId, items: BoardItem[]) => void;

--- a/web/src/lib/components/JobBoard.svelte
+++ b/web/src/lib/components/JobBoard.svelte
@@ -426,7 +426,7 @@
           id={col.id}
           label={col.label}
           items={shown[col.id]}
-          dragDisabled={searching}
+          dragDisabled={filtering}
           {onconsider}
           {onfinalize}
           onopen={openDrawer}

--- a/web/src/lib/components/JobBoard.svelte
+++ b/web/src/lib/components/JobBoard.svelte
@@ -4,6 +4,7 @@
   import { resolve } from '$app/paths';
   import { Search, X as XIcon } from '@lucide/svelte';
   import { api } from '$lib/api';
+  import { cn } from '$lib/ui';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { UrlSyncedState, syncOnNavigation } from '$lib/urlSynced.svelte';
   import type { MyJob } from '$lib/types';
@@ -11,6 +12,7 @@
     BOARD_COLUMNS,
     columnOf,
     matchesQuery,
+    needsAttention,
     type BoardColumnId,
     type BoardItem,
     type ClosedOutcome,
@@ -123,28 +125,39 @@
     if (!preloaded && isAuthenticated()) void load();
   });
 
-  // Search, mirrored into `?q=` so a shared or reloaded link shows the same rows.
-  // UrlSyncedState owns the transport: it writes the URL synchronously on every
-  // keystroke (the structural fix for the dropped-character race) and seeds from
-  // location.search rather than page.url, which lags after a shallow-routing
-  // back/forward. Filtering is local and instant, so there is nothing to debounce —
-  // setNow writes and applies together, and the view reads `value`.
-  const search = new UrlSyncedState<string>(page.url.searchParams, {
-    parse: (p) => p.get('q') ?? '',
-    serialize: (v) => new URLSearchParams(v ? { q: v } : {}),
+  // Search + the "needs attention" toggle, mirrored into `?q=`/`?attention=1` so a
+  // shared or reloaded link shows the same rows. One UrlSyncedState over both
+  // fields — not two separate ones — because each instance's write replaces the
+  // WHOLE query string with its own serialization; two independent states on the
+  // same page would each erase the other's param on every change. It writes the
+  // URL synchronously on every keystroke/click (the structural fix for the
+  // dropped-character race) and seeds from location.search rather than page.url,
+  // which lags after a shallow-routing back/forward. Filtering is local and
+  // instant, so there is nothing to debounce — setNow writes and applies
+  // together, and the view reads `value`.
+  const filters = new UrlSyncedState<{ q: string; attention: boolean }>(page.url.searchParams, {
+    parse: (p) => ({ q: p.get('q') ?? '', attention: p.get('attention') === '1' }),
+    serialize: (v) =>
+      new URLSearchParams({
+        ...(v.q ? { q: v.q } : {}),
+        ...(v.attention ? { attention: '1' } : {}),
+      }),
   });
-  syncOnNavigation(search);
-  const query = $derived(search.value);
+  syncOnNavigation(filters);
+  const query = $derived(filters.value.q);
+  const attentionOnly = $derived(filters.value.attention);
 
   const searching = $derived(query.trim().length > 0);
+  const filtering = $derived(searching || attentionOnly);
+  const matchesFilters = (i: BoardItem) => matchesQuery(i, query) && (!attentionOnly || needsAttention(i));
   const shown = $derived<Record<BoardColumnId, BoardItem[]>>(
-    searching
+    filtering
       ? {
-          preparing: columns.preparing.filter((i) => matchesQuery(i, query)),
-          applied: columns.applied.filter((i) => matchesQuery(i, query)),
-          interview: columns.interview.filter((i) => matchesQuery(i, query)),
-          offer: columns.offer.filter((i) => matchesQuery(i, query)),
-          closed: columns.closed.filter((i) => matchesQuery(i, query)),
+          preparing: columns.preparing.filter(matchesFilters),
+          applied: columns.applied.filter(matchesFilters),
+          interview: columns.interview.filter(matchesFilters),
+          offer: columns.offer.filter(matchesFilters),
+          closed: columns.closed.filter(matchesFilters),
         }
       : columns,
   );
@@ -370,7 +383,7 @@
       <input
         type="search"
         value={query}
-        oninput={(e) => search.setNow(e.currentTarget.value)}
+        oninput={(e) => filters.setNow({ ...filters.value, q: e.currentTarget.value })}
         placeholder="Search company or role"
         aria-label="Search applications by company or role"
         class="w-full rounded-md border border-input bg-transparent py-1.5 pl-8 pr-8 text-sm"
@@ -378,7 +391,7 @@
       {#if searching}
         <button
           type="button"
-          onclick={() => search.setNow('')}
+          onclick={() => filters.setNow({ ...filters.value, q: '' })}
           aria-label="Clear search"
           class="absolute right-1.5 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
         >
@@ -386,7 +399,20 @@
         </button>
       {/if}
     </div>
-    {#if searching}
+    <button
+      type="button"
+      aria-pressed={attentionOnly}
+      onclick={() => filters.setNow({ ...filters.value, attention: !attentionOnly })}
+      class={cn(
+        'shrink-0 rounded-md border px-2.5 py-1.5 text-sm font-medium transition-colors',
+        attentionOnly
+          ? 'border-warning/50 bg-warning-muted/40 text-warning-strong'
+          : 'border-input text-muted-foreground hover:bg-accent hover:text-foreground',
+      )}
+    >
+      Needs attention
+    </button>
+    {#if filtering}
       <span class="shrink-0 text-xs tabular-nums text-muted-foreground">{matched} of {total}</span>
     {/if}
   </div>

--- a/web/src/lib/components/JobDrawer.svelte
+++ b/web/src/lib/components/JobDrawer.svelte
@@ -465,7 +465,23 @@
                (below, on the Emails tab), placed here instead because this is the tab a
                fresh mount always opens on and a pending decision is the primary reason to
                open this drawer at all. -->
-          {#if autoApplyBanner?.kind === 'pending_review'}
+          {#if autoApplyBanner?.kind === 'tailoring'}
+            <div class="rounded-md border border-border bg-muted/30 px-3 py-2">
+              <p class="text-sm text-muted-foreground">Auto-apply is preparing a tailored CV for this job.</p>
+            </div>
+          {:else if autoApplyBanner?.kind === 'approved'}
+            <div class="flex flex-col gap-2 rounded-md border border-border bg-muted/30 px-3 py-2">
+              <p class="text-sm font-medium">Auto-apply approved this application — it's queued for automatic submission.</p>
+              {#if hasPosting && item.job}
+                <a
+                  href={resolve('/tailor/[slug]', { slug: item.job.public_slug })}
+                  class="w-fit text-xs underline-offset-2 hover:underline"
+                >
+                  View tailored CV
+                </a>
+              {/if}
+            </div>
+          {:else if autoApplyBanner?.kind === 'pending_review'}
             <div class="flex flex-col gap-2 rounded-md border border-warning/50 bg-warning-muted/40 px-3 py-2">
               <p class="text-sm font-medium">Auto-apply tailored a CV for this job and is ready to send it.</p>
               {#if autoApply?.resolved_preview?.fields.length}

--- a/web/src/lib/notificationTarget.test.ts
+++ b/web/src/lib/notificationTarget.test.ts
@@ -54,13 +54,16 @@ describe('notificationTarget', () => {
     });
   });
 
-  // The three auto-apply outcome kinds follow the same rule as follow-up/interview-prep:
-  // the Go side (transports.go/push.go) points all three at the tracking board, never a
-  // per-job deep link, so web must agree.
+  // The three auto-apply outcome kinds now deep-link to the specific application's
+  // drawer, like auto_apply_ready_for_review already does — unlike follow-up/
+  // interview-prep above, which stay on the bare board.
   it.each(['nudge_auto_apply_submitted', 'nudge_auto_apply_blocked', 'nudge_auto_apply_failed'] as const)(
-    'sends a %s nudge to the tracking board, not the job',
+    'sends a %s nudge to the specific application',
     (kind) => {
-      expect(notificationTarget({ kind, public_slug: 'acme-go-engineer' })).toEqual({ kind: 'tracking' });
+      expect(notificationTarget({ kind, public_slug: 'acme-go-engineer' })).toEqual({
+        kind: 'tracking',
+        slug: 'acme-go-engineer',
+      });
     },
   );
 

--- a/web/src/lib/notificationTarget.ts
+++ b/web/src/lib/notificationTarget.ts
@@ -12,12 +12,16 @@ export type NotificationTarget =
   | { kind: 'none' };
 
 /** A card with no `public_slug` and no `jobs` snapshot has nothing to open.
- *  `nudge_follow_up`/`nudge_interview_prep` point at the tracking board on web —
- *  matching the existing Telegram/email link target for those two kinds — even
- *  though the row itself always carries a slug. The three auto-apply outcome
- *  kinds (`nudge_auto_apply_submitted`/`blocked`/`failed`) follow the same rule,
- *  for the same reason: internal/engage/nudge's transports.go/push.go point all
- *  three at the tracking board too, never a per-job deep link. `auto_apply_tailor_ready` points
+ *  `nudge_follow_up`/`nudge_interview_prep` point at the bare tracking board on
+ *  web — matching the existing Telegram/email link target for those two kinds —
+ *  even though the row itself always carries a slug: neither kind has a specific
+ *  drawer affordance worth deep-linking to today. The three auto-apply outcome
+ *  kinds (`nudge_auto_apply_submitted`/`blocked`/`failed`) used to follow that
+ *  same rule, but now deep-link to the specific application instead, like
+ *  `auto_apply_ready_for_review` below — internal/engage/nudge's
+ *  transports.go now builds a per-application link for these three kinds too,
+ *  and the drawer has a status banner for every live auto-apply state, so there
+ *  is always something worth jumping straight to. `auto_apply_tailor_ready` points
  *  at the tailoring workspace, not the job page — `/tailor/[slug]` idempotently
  *  resolves the same tailored CV a fresh tailoring bootstrap would (see
  *  openspec/changes/auto-apply-tailored-resume), so no CV id needs to travel with
@@ -32,14 +36,15 @@ export function notificationTarget(
   item: Pick<NotificationItem, 'kind' | 'public_slug'> & Partial<Pick<NotificationItem, 'id' | 'jobs'>>,
 ): NotificationTarget {
   if (item.public_slug) {
+    if (item.kind === 'nudge_follow_up' || item.kind === 'nudge_interview_prep') {
+      return { kind: 'tracking' };
+    }
     if (
-      item.kind === 'nudge_follow_up' ||
-      item.kind === 'nudge_interview_prep' ||
       item.kind === 'nudge_auto_apply_submitted' ||
       item.kind === 'nudge_auto_apply_blocked' ||
       item.kind === 'nudge_auto_apply_failed'
     ) {
-      return { kind: 'tracking' };
+      return { kind: 'tracking', slug: item.public_slug };
     }
     if (item.kind === 'auto_apply_tailor_ready') {
       return { kind: 'tailor', slug: item.public_slug };


### PR DESCRIPTION
## Summary
- Add `tailoring`/`approved` banner states to the tracker drawer's auto-apply status (previously only `pending_review`/`blocked`/`declined`/`failed` showed anything), with `approved` linking to the tailored CV the same way `pending_review` already does.
- Deep-link the three auto-apply outcome notifications (submitted/blocked/failed) to the specific application's tracker drawer instead of the general board, on email, Telegram, and the in-app notification bell — batches, follow-up/interview-prep, and push are unchanged.
- Add a "Needs attention" filter toggle to the tracking board, combinable with search, plus a small marker on the board card's existing "Review" badge.

See `openspec/changes/auto-apply-drawer-progress/` for the full proposal/design/spec.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .`, `go test ./...`
- [x] `pnpm vitest run` (153 files / 1723 tests)
- [x] `pnpm exec svelte-check` (0 errors)
- [x] Live-verified against a seeded Postgres + local server + dev frontend: all four banner states, the board card's marker, and the "Needs attention" filter render correctly with zero browser console errors
- [x] Independent code review (no Critical/Important findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added read-only progress banners for applications being tailored or queued for automatic submission.
  - Approved applications now provide a link to view the tailored CV.
  - Added a URL-synchronized “Needs attention” filter for applications awaiting review or blocked.
  - Added a visual indicator to “Review” badges.

- **Improvements**
  - Auto-apply outcome notifications now link directly to the relevant application, while follow-up, interview-prep, and batched notifications continue linking to the tracking board.
  - Board interactions are disabled while search or filtering is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->