### PR TITLE
Move hh detail hydration off the burned proxy IP onto Firecrawl

### DIFF
--- a/internal/ingest/sources/AGENTS.md
+++ b/internal/ingest/sources/AGENTS.md
@@ -392,3 +392,15 @@ fingerprint transport exactly as before.
 Neither adapter changed: `baytHTTP` is `HTMLGetter` and `gulftalentHTTP` is `XMLGetter` +
 `HTMLGetter`, and a test asserts the hosted client satisfies both. What is wrong with these
 providers is the address a request leaves from, not how the response is read.
+
+**`hh` is a different shape: only detail hydration is hosted, not the whole crawl** (like
+`wantapply`, whose sitemap enumeration is hosted while the pages it lists stay free). hh's
+listing (`hh.ru/search/vacancy`) works fine on the plain direct IP — measured 2026-09-08 — while
+its detail pages (`hh.ru/vacancy/<id>`) redirect through the proxy to an interactive DDoS-Guard
+image CAPTCHA (`/account/captcha`) that no transport this repository controls can solve. So `hh`
+is removed from `proxiedProviders` entirely (proxy.go) and its `firecrawlProviders` build
+function hands `NewHHWithDetailGetter` a fresh, always-unproxied `NewClient()` for listing and
+the hosted client for detail — deliberately NOT the `direct` parameter `ApplyFirecrawlEgress`
+passes in, since that value is the PROXIED client whenever `SOURCES_PROXY_URL` is set for any
+other provider (eightfold, djinni, 2gis, …), which would put hh's listing right back on the
+proxy this exists to stop using.

--- a/internal/ingest/sources/firecrawltier.go
+++ b/internal/ingest/sources/firecrawltier.go
@@ -50,6 +50,15 @@ var firecrawlProviders = map[string]func(hosted *firecrawlClient, direct HTTPCli
 	"wantapply": func(hosted *firecrawlClient, direct HTTPClient) Source {
 		return NewWantapplyViaHostedSitemap(direct, hosted, wantapplyComSitemapURL, wantapplyComHostname)
 	},
+	// hh.ru's detail pages sit behind DDoS-Guard through the proxy (redirected to an interactive
+	// image CAPTCHA, measured 2026-09-08 — not a JS challenge, so the browser tier does not help
+	// either) while listing works fine on the direct IP. Only detail hydration is hosted; listing
+	// gets its own fresh, unproxied client rather than the `direct` parameter, which becomes the
+	// PROXIED client whenever SOURCES_PROXY_URL is set for any other provider — reusing it here
+	// would put hh's listing right back on the transport this exists to stop using.
+	"hh": func(hosted *firecrawlClient, _ HTTPClient) Source {
+		return NewHHWithDetailGetter(NewClient(), hosted)
+	},
 }
 
 const (

--- a/internal/ingest/sources/firecrawltier_test.go
+++ b/internal/ingest/sources/firecrawltier_test.go
@@ -36,10 +36,45 @@ func TestFirecrawlClientSatisfiesBothAdaptersTransports(t *testing.T) {
 }
 
 func TestHostedTierCarriesTheTwoUnreachableProviders(t *testing.T) {
-	for _, name := range []string{"bayt", "gulftalent", "wantapply"} {
+	for _, name := range []string{"bayt", "gulftalent", "wantapply", "hh"} {
 		if _, ok := firecrawlProviders[name]; !ok {
 			t.Errorf("%s is not in firecrawlProviders", name)
 		}
+	}
+}
+
+// hh is the mixed-tier case with no proxy involved at all: only detail hydration is hosted,
+// and listing keeps a fresh direct client REGARDLESS of SOURCES_PROXY_URL, because hh's own
+// detail pages are what's blocked (by DDoS-Guard, through the proxy) while listing measurably
+// isn't. Unlike wantapply, which reuses ApplyFirecrawlEgress's shared `direct` transport for
+// its non-hosted pages, hh must NOT reuse it — that value becomes the proxied client whenever
+// SOURCES_PROXY_URL is set for any OTHER provider, which would put hh's listing right back on
+// the proxy this change exists to stop using.
+func TestApplyFirecrawlEgressRewiresHHDetailWithAKey(t *testing.T) {
+	t.Setenv("FIRECRAWL_API_KEY", "test-key")
+
+	registry := map[string]Source{"hh": NewHH(NewClient())}
+	before := registry["hh"]
+
+	if err := ApplyFirecrawlEgress(registry); err != nil {
+		t.Fatalf("ApplyFirecrawlEgress: %v", err)
+	}
+	if registry["hh"] == before {
+		t.Error("hh was not rewired onto the hosted detail transport")
+	}
+}
+
+func TestHHKeepsItsCurrentTransportWithoutAKey(t *testing.T) {
+	t.Setenv("FIRECRAWL_API_KEY", "")
+
+	registry := map[string]Source{"hh": NewHH(NewClient())}
+	before := registry["hh"]
+
+	if err := ApplyFirecrawlEgress(registry); err != nil {
+		t.Fatalf("ApplyFirecrawlEgress: %v", err)
+	}
+	if registry["hh"] != before {
+		t.Error("hh was rewired with no API key configured")
 	}
 }
 

--- a/internal/ingest/sources/hhru.go
+++ b/internal/ingest/sources/hhru.go
@@ -27,8 +27,10 @@ import (
 //
 // Listing and detail are two separate transports (http, detailHTTP) because they don't need the
 // same one: hh.ru's detail pages sit behind DDoS-Guard in a way the listing page does not (see
-// registry.go's hh registration), so detail is routed through Firecrawl while listing stays on
-// the plain client.
+// firecrawltier.go's hh entry). With FIRECRAWL_API_KEY configured, ApplyFirecrawlEgress rewires
+// detail onto Firecrawl while listing stays on a plain, unproxied client; without a key (e.g.
+// local/dev), NewHH gives both fields the same caller-supplied client, exactly as before this
+// split existed.
 type hh struct {
 	http       HTMLGetter // listing (search) pages
 	detailHTTP HTMLGetter // per-vacancy detail pages

--- a/internal/ingest/sources/hhru.go
+++ b/internal/ingest/sources/hhru.go
@@ -24,12 +24,23 @@ import (
 // Caveat/seam: HH-Lux-InitialState is a frontend detail (the client-hydration state), not a
 // documented API, so a hh.ru frontend change can move the vacancy list within it. The public
 // render must carry the data somewhere; today it is this template.
+//
+// Listing and detail are two separate transports (http, detailHTTP) because they don't need the
+// same one: hh.ru's detail pages sit behind DDoS-Guard in a way the listing page does not (see
+// registry.go's hh registration), so detail is routed through Firecrawl while listing stays on
+// the plain client.
 type hh struct {
-	http HTMLGetter
+	http       HTMLGetter // listing (search) pages
+	detailHTTP HTMLGetter // per-vacancy detail pages
 }
 
-// NewHH builds the hh.ru adapter over the shared HTML-getter client.
-func NewHH(c HTMLGetter) Source { return hh{http: c} }
+// NewHH builds the hh.ru adapter over one shared HTML-getter client for both listing and detail.
+func NewHH(c HTMLGetter) Source { return NewHHWithDetailGetter(c, c) }
+
+// NewHHWithDetailGetter builds the hh.ru adapter with listing and detail on separate transports.
+func NewHHWithDetailGetter(listing, detail HTMLGetter) Source {
+	return hh{http: listing, detailHTTP: detail}
+}
 
 func (hh) Provider() string { return "hh" }
 
@@ -290,7 +301,7 @@ func hhEmploymentType(t string) string {
 // detail fetches the vacancy page and returns its sanitized JobPosting description, ok=false on a
 // failed request or a page with no JobPosting ld+json so the caller falls back to the list-only job.
 func (s hh) detail(ctx context.Context, vacancyURL string) (string, bool) {
-	root, err := s.http.GetHTML(ctx, vacancyURL)
+	root, err := s.detailHTTP.GetHTML(ctx, vacancyURL)
 	if err != nil {
 		return "", false
 	}

--- a/internal/ingest/sources/hhru_test.go
+++ b/internal/ingest/sources/hhru_test.go
@@ -223,6 +223,65 @@ func TestHHFetchNewHydratesOnlyNew(t *testing.T) {
 	}
 }
 
+// hhListingOnlyFake serves only the search/listing page, one vacancy on page 0 and an empty
+// page thereafter (so crawl() stops after confirming the end). A detail request reaching it is
+// a wiring bug (listing and detail must be on separate getters), so it records what it saw
+// rather than silently answering it.
+type hhListingOnlyFake struct {
+	hits []string
+}
+
+func (f *hhListingOnlyFake) GetHTML(_ context.Context, u string) (*html.Node, error) {
+	f.hits = append(f.hits, u)
+	pu, err := url.Parse(u)
+	if err != nil {
+		return nil, err
+	}
+	if pu.Query().Get("page") != "0" {
+		return html.Parse(strings.NewReader(hhSearchHTML(nil)))
+	}
+	return html.Parse(strings.NewReader(hhSearchHTML([]hhVacancy{hhVac(101, "New role", "Co")})))
+}
+
+// hhDetailOnlyFake serves only vacancy detail pages, recording which URLs it was asked for.
+type hhDetailOnlyFake struct {
+	hits []string
+}
+
+func (f *hhDetailOnlyFake) GetHTML(_ context.Context, u string) (*html.Node, error) {
+	f.hits = append(f.hits, u)
+	return html.Parse(strings.NewReader(hhDetailHTML("<p>Full body.</p>")))
+}
+
+func TestHHWithDetailGetterSplitsListingAndDetailTransports(t *testing.T) {
+	listing := &hhListingOnlyFake{}
+	detail := &hhDetailOnlyFake{}
+	seen := func(string) bool { return false }
+
+	jobs, err := NewHHWithDetailGetter(listing, detail).(HydratingSource).
+		FetchNew(context.Background(), CompanyEntry{Board: "96"}, seen)
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	if !strings.Contains(jobs[0].Description, "Full body") {
+		t.Errorf("job not hydrated from the detail getter: %q", jobs[0].Description)
+	}
+	for _, u := range listing.hits {
+		if !strings.Contains(u, "/search/vacancy") {
+			t.Errorf("listing getter received a non-listing request: %q (all hits = %v)", u, listing.hits)
+		}
+	}
+	if len(listing.hits) == 0 {
+		t.Error("listing getter received no requests")
+	}
+	if len(detail.hits) != 1 || !strings.Contains(detail.hits[0], "/vacancy/101") {
+		t.Errorf("detail getter hits = %v, want exactly one /vacancy/101 request", detail.hits)
+	}
+}
+
 func TestHHPaginatesAndStops(t *testing.T) {
 	full := make([]hhVacancy, hhPageSize)
 	for i := range full {

--- a/internal/ingest/sources/pacer.go
+++ b/internal/ingest/sources/pacer.go
@@ -357,18 +357,6 @@ func limitedWhatJobsGetter(c JSONGetter) JSONGetter {
 	return concurrencyLimitedJSONGetter{inner: c, sem: make(chan struct{}, whatjobsMaxInFlight)}
 }
 
-// hh.ru egresses through the single proxy IP (its detail pages 403 the direct datacenter IP), and
-// its per-vacancy detail fan-out is large — thousands of ~1 MB pages across the seeded roles. Fired
-// unpaced at defaultDetailWorkers concurrency, that burst 429s the proxy IP and ~2/3 of details
-// fall back to list-only (which never back-fill, since a seen posting skips detail). Pacing the
-// aggregate rate — not the worker pool — holds it under the proxy window so nearly every detail
-// lands. The interval is a middle ground: fast enough to finish a full role sweep inside the
-// ingest unit's TimeoutStartSec, gentle enough to stop the 429s. Tune from observed convergence.
-const (
-	hhRequestInterval = 250 * time.Millisecond // ~4 req/s
-	hhRequestBurst    = 4
-)
-
 // Teamtailor 403s the crawl in bulk, and the 403 is ours: a "failing" board answers 200 on
 // demand from the same IP, and 1207 of 1208 failures carried a timestamp inside the crawl hour.
 // The cause is the shape of the adapter — every posting's description is its own page fetch — so

--- a/internal/ingest/sources/proxy.go
+++ b/internal/ingest/sources/proxy.go
@@ -63,12 +63,6 @@ var proxiedProviders = map[string]func(HTTPClient) Source{
 	// blocked, setting SOURCES_PROXY_URL routes only this provider through the proxy with no code
 	// change; while the proxy is unset this entry is inert. A fixed, trusted host (SSRF caveat).
 	"geekjob": func(c HTTPClient) Source { return NewGeekjob(c) },
-	// hh.ru's detail pages 403 the direct datacenter IP, so on prod it egresses through the proxy;
-	// its high-volume per-vacancy detail fan-out then 429s the single proxy IP unless paced (the
-	// first prod run landed only ~34% of descriptions unpaced), so — like careerspage/vagas — it is
-	// rate-paced (pacedHTMLGetter) to hold the aggregate rate under the proxy window. While
-	// SOURCES_PROXY_URL is unset this entry is inert (direct crawl is unpaced, fine for local/dev).
-	"hh": func(c HTTPClient) Source { return NewHH(pacedHTMLGetter(c, hhRequestInterval, hhRequestBurst)) },
 	// career.habr.com sits behind Qrator, which challenges the per-vacancy detail HTML from the
 	// prod datacenter IP (the listing JSON passes, but the description parse fails, leaving jobs
 	// with empty descriptions and so no derived skills/geo/enrichment). A residential IP is served
@@ -102,7 +96,7 @@ var proxiedProviders = map[string]func(HTTPClient) Source{
 // and both grew by ~500 boards in the August harvest, so the burst is getting worse.
 //
 // Why not route them through the proxy wholesale: it is a single shared address (verified — six
-// calls, one exit IP), and it is what eightfold, djinni, 2gis and hh have INSTEAD of a direct
+// calls, one exit IP), and it is what eightfold, djinni and 2gis have INSTEAD of a direct
 // path. Moving ~3000 boards an hour onto it would concentrate the same burst on a weaker IP and
 // take the budget from the providers with nowhere else to go.
 var refusalRetryProviders = map[string]func(HTTPClient) Source{

--- a/internal/ingest/sources/proxy_test.go
+++ b/internal/ingest/sources/proxy_test.go
@@ -45,6 +45,24 @@ func TestApplyProxyEgressRewiresProxiedProviderOnly(t *testing.T) {
 	}
 }
 
+// hh's detail pages are captcha-walled through the proxy (DDoS-Guard) while working fine on the
+// direct IP; detail hydration moved to the Firecrawl tier instead (firecrawltier.go), so hh no
+// longer belongs in proxiedProviders at all — not even for listing, which was measured working
+// directly.
+func TestApplyProxyEgressLeavesHHOnTheDirectClient(t *testing.T) {
+	t.Setenv("SOURCES_PROXY_URL", "http://user:pass@proxy.example:8080")
+
+	registry := All(NewClient())
+	before := registry["hh"]
+
+	if err := ApplyProxyEgress(registry); err != nil {
+		t.Fatalf("valid proxy: %v", err)
+	}
+	if registry["hh"] != before {
+		t.Error("hh must stay on the direct client; it is no longer a proxied provider")
+	}
+}
+
 func TestApplyProxyEgressInvalidURLFailsWithoutLeakingCreds(t *testing.T) {
 	// A control character makes url.Parse fail; the password must not surface in the error.
 	t.Setenv("SOURCES_PROXY_URL", "http://user:sup3rsecret@proxy.example:8080/\x7f")

--- a/internal/platform/firecrawl/AGENTS.md
+++ b/internal/platform/firecrawl/AGENTS.md
@@ -41,6 +41,23 @@ and every page fetched costs a credit whether or not it turns out to be one of t
 This was built with that measured and accepted. The number is recorded here so the next person
 inherits it rather than rediscovering it at their own expense.
 
+## A different shape: `hh` is not IP-blocked at all
+
+`bayt`/`gulftalent` refuse **every** address outright; `hh` (headhunter.ru) doesn't. Its listing
+pages work fine on the plain direct IP, and even its detail pages aren't blocked in the ordinary
+sense — through `SOURCES_PROXY_URL` they redirect to an interactive DDoS-Guard image CAPTCHA
+(`/account/captcha`, measured 2026-09-08), which the browser tier can't solve either (it's a
+real CAPTCHA, not a JS challenge) and which this package doesn't attempt to solve. Firecrawl's
+own egress simply isn't the flagged proxy IP, so it reaches the same pages cleanly.
+
+So `hh` is a MIXED-tier provider, like `wantapply`: only the part that's actually broken (detail
+hydration) is hosted, and listing stays on a free, unproxied client — see
+[internal/ingest/sources/AGENTS.md](../../ingest/sources/AGENTS.md)'s "hosted tier" section for
+the wiring. Unlike `wantapply`, hh's free part must NOT reuse `ApplyFirecrawlEgress`'s shared
+`direct` transport — that value becomes the proxied client whenever `SOURCES_PROXY_URL` is set
+for any OTHER provider, which is exactly the (captcha-walled) transport hh's listing needs to
+avoid.
+
 ## Three bounds, none redundant
 
 - **No key, no client.** `ApplyFirecrawlEgress` is a no-op without `FIRECRAWL_API_KEY` and the

--- a/openspec/changes/fix-hh-detail-hydration-firecrawl/.openspec.yaml
+++ b/openspec/changes/fix-hh-detail-hydration-firecrawl/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-09-08
+skip_specs: true

--- a/openspec/changes/fix-hh-detail-hydration-firecrawl/design.md
+++ b/openspec/changes/fix-hh-detail-hydration-firecrawl/design.md
@@ -1,0 +1,211 @@
+## Context
+
+See proposal.md for the measured root cause. Summary of the transport facts, all
+measured live on prod on 2026-09-08 (`ssh root@89.167.94.146`, via
+`/opt/freehire/.env`'s `SOURCES_PROXY_URL`/`FIRECRAWL_API_KEY`):
+
+| path | transport | result |
+|---|---|---|
+| listing (`hh.ru/search/vacancy`) | direct datacenter IP | 200, `HH-Lux-InitialState` present |
+| listing | proxy | 200 (this is what's live today; jobs/titles/companies land fine) |
+| detail (`hh.ru/vacancy/<id>`) | direct datacenter IP | 200, 80/80 sustained at ~4 req/s, full `JobPosting` ld+json |
+| detail | proxy | 302 → `/account/captcha` (DDoS-Guard image CAPTCHA), 40/40 live prod failures |
+| detail | Firecrawl | 200 target status, 1/1, full description (~2900 chars) |
+
+`hh` (`internal/ingest/sources/hhru.go`) currently uses ONE `http HTMLGetter` field
+for both `crawl()` (listing) and `detail()`, and `proxy.go`'s `proxiedProviders["hh"]`
+routes that single field through `pacedHTMLGetter(proxiedClient, hhRequestInterval,
+hhRequestBurst)` — both paths share one transport and one rate limiter.
+
+`internal/ingest/sources/firecrawltier.go` already has the hosted-fetch plumbing:
+`firecrawlClient` implements `HTMLGetter`/`XMLGetter` over `internal/platform/firecrawl`,
+so an adapter that already takes an `HTMLGetter` needs no new client code — only a
+way to hand it a DIFFERENT getter than the one used for listing. `wantapply` is the
+existing precedent for a split transport (`NewWantapplyViaHostedSitemap(direct,
+hosted, ...)`), proving the `firecrawlProviders` build-function shape
+(`func(hosted *firecrawlClient, direct HTTPClient) Source`) already supports handing
+an adapter two transports.
+
+hh's boards were onboarded 2026-09-03 (`boards` table, 5 `professional_role` rows,
+all `active`). With `hhWithinDays = 7`, the crawl window only fully "settles" to
+steady-state (no more 7-day backlog being walked as "new") around 2026-09-10.
+Today's measured detail-fetch rate (~690/hour, 2938 in the log's ~4.26h retention
+window) is very likely inflated by that backlog and will drop once it clears — by
+how much is not yet known.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Stop hh postings from landing with a salary-only description by moving detail
+  hydration off the currently-broken proxy path.
+- Keep the change to exactly what's broken: detail hydration. Listing already
+  works and is not touched beyond removing it from the (now pointless, for hh)
+  proxy wiring.
+- Leave the adapter's observable contract (Job shape, `ExternalID`, seen/hydrate/
+  list-only-fallback behavior) unchanged — this is a transport swap, not a
+  behavior change.
+- Document the real, current transport facts in place of the stale "hh.ru's
+  detail pages 403 the direct datacenter IP" comment, so the next reader trusts
+  what's written rather than rediscovering this at their own expense (the
+  existing convention in `firecrawltier.go`'s own comments).
+
+**Non-Goals:**
+- Not building CAPTCHA-solving of any kind (not in scope, and per the spike, an
+  image CAPTCHA is not something a headless browser or a generic hosted-fetch
+  vendor bypass solves anyway — see proposal.md's "Why").
+- Not building a generic proxy-health-monitoring or automatic-tier-fallback
+  mechanism. If hh's direct IP gets reblocked in the future, that's a new
+  investigation, not something this change tries to predict or automate around.
+- Not changing `bayt`/`gulftalent`/`wantapply`'s own firecrawl usage or budgets
+  beyond raising the one shared `FIRECRAWL_MAX_PAGES_PER_RUN` ceiling they also
+  read.
+- Not committing to a specific Firecrawl paid plan tier in code — that's an
+  account-level, deploy-side decision (see Migration Plan).
+
+## Decisions
+
+**1. Split `hh`'s single `HTMLGetter` into a listing getter and a detail getter.**
+
+`hh` gets a second constructor, `NewHHWithDetailGetter(listing, detail HTMLGetter) Source`,
+alongside the existing `NewHH(c HTMLGetter) Source` (kept as `NewHHWithDetailGetter(c, c)` —
+same transport for both — so every other call site, and the default/no-firecrawl-key
+registry entry in `registry.go`, is unchanged). `firecrawltier.go` registers hh's
+build function using this new constructor.
+
+*Alternative considered:* thread a single `HTMLGetter` but branch inside `detail()`
+on some flag. Rejected — the existing wantapply precedent already establishes
+"two transports, one adapter" as a constructor-level split, and threading a
+runtime flag through one field would obscure which transport serves which path
+instead of making it a type-level fact.
+
+**2. Detail hydration moves to the Firecrawl tier; listing moves OFF the proxy
+entirely and onto the plain direct client.**
+
+`hh` is removed from `proxiedProviders` (`proxy.go`) and added to
+`firecrawlProviders` (`firecrawltier.go`) as:
+```go
+"hh": func(hosted *firecrawlClient, _ HTTPClient) Source {
+    return NewHHWithDetailGetter(NewClient(), hosted)
+},
+```
+The build function deliberately ignores the `direct` parameter `ApplyFirecrawlEgress`
+passes in — that value is ONE shared client for every mixed-tier provider in the
+loop, and it becomes the PROXIED client whenever `SOURCES_PROXY_URL` is set at
+all (which it is on prod, for eightfold/djinni/2gis/etc.), regardless of whether
+the provider being built is itself in `proxiedProviders`. Threading it through
+for hh would silently put hh's listing back on the very proxy IP this change
+exists to stop using. hh's listing gets its own fresh `NewClient()` instead —
+plain, unproxied, matching what was actually measured working (200, full
+`HH-Lux-InitialState`) — independent of whatever proxy configuration exists for
+other providers. (This is the one place `wantapply`'s existing shape — reuse the
+shared `direct` — doesn't transfer: wantapply's non-hosted pages genuinely need
+the proxy, hh's listing pages measurably don't.)
+
+*Alternative considered:* keep listing on the proxy (leave `hh` in BOTH
+`proxiedProviders` and `firecrawlProviders`). Rejected on two grounds: (a) no
+evidence listing needs the proxy — it works identically on the direct IP right
+now — so routing it through a proxy IP that's already burned for the SAME domain
+buys nothing; (b) `ApplyFirecrawlEgress` runs LAST and unconditionally overwrites
+`registry["hh"]`, so `ApplyProxyEgress`'s paced wiring would be silently discarded
+anyway — keeping hh in both maps would be dead configuration, not a real
+fallback.
+
+**3. Drop hh's dedicated pacer (`hhRequestInterval`/`hhRequestBurst`,
+`pacedHTMLGetter`).**
+
+Neither remaining path needs it: `firecrawl.Client.Fetch` already has its own
+vendor-side 429 handling (`errVendorRateLimited` + `retryWait`, shared with
+bayt/gulftalent/wantapply), and listing's own loop (`crawl()`) issues at most
+`hhMaxPages` (20) sequential requests per board — already naturally paced by
+being sequential, and already measured clean at that shape on the direct IP.
+
+*Alternative considered:* keep the pacer wrapped around the listing-only direct
+client, in case sequential-but-fast listing requests draw attention on their
+own. Rejected for now as speculative hardening with no measured need — per
+AGENTS.md's "no MVP shortcuts, no overengineering," this can be added later
+with a number attached if board_health or logs ever show listing being refused
+on the direct IP, the same way every other pacer constant in `pacer.go` was
+added after a measured failure, not ahead of one.
+
+**4. `FIRECRAWL_MAX_PAGES_PER_RUN` needs raising on prod — deploy-side, not code.**
+
+Each `cmd/ingest <provider>` invocation is its own process with its own
+`ApplyFirecrawlEgress` call, so the budget is effectively per-provider-per-run
+(one hh run never competes with a same-instant bayt run for the same budget —
+they're different processes). hh's own hourly run needs headroom for its
+current (backlog-inflated) rate of ~690 detail fetches/hour; recommend setting
+`FIRECRAWL_MAX_PAGES_PER_RUN=2000` for real headroom against both the current
+rate and any spike, high enough that a normal hh run never trips
+`ErrBudgetSpent`. Because the same env var also caps bayt/gulftalent/wantapply's
+own separate runs, raising it is a ceiling raise for them too, not a spend
+increase — their actual usage is unaffected unless their own crawl volume grows
+to need it.
+
+Real cost, from proposal.md's measurement (Firecrawl's published pricing,
+checked 2026-09-08): 1 credit/page (`formats:["rawHtml"]`). At today's
+backlog-inflated ~497K credits/month, that's at the edge of the 500K/mo
+"Growth" plan ($27.75/mo on annual billing); the 1M/mo "Scale" plan ($49.92/mo)
+gives real headroom until the steady-state rate is known. This is an operator
+decision on the Firecrawl account, not something this change can set in code —
+called out as a deploy task.
+
+## Risks / Trade-offs
+
+- **hh's steady-state volume (and therefore steady-state cost) is not yet known**
+  — today's measurement is inflated by the 7-day backlog since boards onboarded
+  2026-09-03, which only fully clears around 2026-09-10.
+  → Mitigation: size `FIRECRAWL_MAX_PAGES_PER_RUN` generously now (headroom, not
+  a tight fit), pick the Firecrawl plan tier from today's conservative number,
+  and re-check `internal/platform/firecrawl`'s spend once the backlog settles
+  before assuming the number is stable long-term.
+
+- **This introduces a real recurring paid cost where there was none before**
+  (the current proxy is "free" in that it's a flat-rate egress already paid
+  for regardless of hh).
+  → Mitigation: already surfaced to and decided by the user with real pricing
+  figures before this proposal was written (see proposal.md); `firecrawl.Client`
+  already refuses a non-positive budget outright and claims budget BEFORE each
+  request, so a misconfiguration fails loudly rather than silently overspending.
+
+- **Listing was only spot-tested on the direct IP, not sustained-volume tested**
+  (the 80/80 sustained test was for DETAIL pages; listing is at most 20
+  sequential requests per board per run, much lower volume, but genuinely
+  untested at that shape over many consecutive hourly runs).
+  → Mitigation: task list includes watching `board_health` / hh's ingest logs
+  for a few runs post-deploy; if listing ever gets refused on the direct IP,
+  the fix is the same three-tier playbook this change already follows (route
+  listing through proxy or firecrawl too) — this change doesn't foreclose that,
+  it only stops using a transport that's currently broken for no benefit.
+
+- **hh.ru's WAF posture could flip again** (it already did once, in the
+  direction the original proxy comment describes) — direct IP could get
+  reblocked for either listing or detail in the future.
+  → Mitigation: this isn't preventable in advance; the existing three-tier
+  pattern (`proxiedProviders`/`browserProviders`/`firecrawlProviders`) is
+  exactly the playbook for re-diagnosing and re-routing if it happens, the same
+  way this investigation used it.
+
+## Migration Plan
+
+1. Code change (this repo): `hhru.go`, `firecrawltier.go`, `proxy.go`, `pacer.go`
+   (remove now-dead `hhRequestInterval`/`hhRequestBurst`), doc updates. Normal
+   `gofmt`/`go vet`/`go test` gate, normal PR + `freehire-autodeploy` release —
+   no schema or migration involved.
+2. **Deploy-side, manual, AFTER the code deploys**: on host2, raise
+   `FIRECRAWL_MAX_PAGES_PER_RUN` in `/opt/freehire/.env` (recommend 2000; see
+   Decision 4) and confirm/upgrade the Firecrawl account's plan tier for the
+   added volume. Both are called out as explicit tasks so they aren't missed —
+   without them, hh's detail hydration will start hitting `ErrBudgetSpent` at
+   the current default of 25/run almost immediately, which looks identical in
+   the logs to today's captcha failures (list-only fallback), so this step is
+   easy to silently skip and get the same symptom back.
+3. Watch the next few hourly hh runs' logs (`journalctl -u
+   freehire-ingest@hh.service`) for `hh: detail ... failed` lines dropping to
+   near zero, and spot-check `/api/v1/jobs/search?source=hh` for real
+   descriptions on newly-created rows.
+
+**Rollback:** revert the code change. This returns hh to today's known (broken
+but understood) state — proxy-routed detail hydration, salary-only fallback —
+with no data migration involved either direction. Rows already hydrated via
+Firecrawl keep their real descriptions; a rollback doesn't erase already-fixed
+rows, it only stops fixing new ones.

--- a/openspec/changes/fix-hh-detail-hydration-firecrawl/proposal.md
+++ b/openspec/changes/fix-hh-detail-hydration-firecrawl/proposal.md
@@ -1,0 +1,83 @@
+## Why
+
+`hh` (headhunter.ru) job postings are landing in the catalogue without a real
+description. `internal/ingest/sources/hhru.go`'s `FetchNew` hydrates each new
+posting's description from its vacancy detail page, and that detail fetch is
+routed through `SOURCES_PROXY_URL` (`proxiedProviders` in `proxy.go`), on the
+documented assumption that "hh.ru's detail pages 403 the direct datacenter IP".
+
+That assumption is now stale. Live investigation on prod (2026-09-08) confirmed:
+the currently configured proxy egress IP is redirected by hh.ru's DDoS-Guard edge
+to an interactive image CAPTCHA (`/account/captcha`, `server: ddos-guard`) on
+essentially every detail-page request — not a JS challenge a headless browser
+could solve, an actual image CAPTCHA. A live production run (`freehire-ingest@hh`,
+16:19 UTC) failed 40/40 detail fetches in real time this way; the day's logs show
+2938/2938 failures. Each failure falls back to list-only per the adapter's existing
+design (`hhru.go`'s `detail()` comment), so the posting is stored carrying only the
+salary paragraph instead of the real body — confirmed via the public API
+(`/api/v1/jobs/search?source=hh`): roughly 45-50% of sampled hh postings hold only
+a `<p>Зарплата: ...</p>` stub.
+
+Two working alternatives were spiked and measured on the exact URLs that are
+failing in production right now:
+- The direct datacenter IP serves hh.ru detail pages cleanly today (80/80 success
+  at the adapter's own production pace, ~4 req/s sustained).
+- Firecrawl (`internal/platform/firecrawl`, already configured with
+  `FIRECRAWL_API_KEY` on prod for `bayt`/`gulftalent`) also fetches them cleanly,
+  bypassing the CAPTCHA entirely (1/1 spike success, real `JobPosting` description
+  content returned, ~2900 chars).
+
+The user has decided the fix should move `hh`'s detail hydration onto the
+Firecrawl hosted-fetch tier, since it does not depend on the reputation of any
+proxy or datacenter IP freehire controls — unlike routing back onto the direct
+IP (which is exactly the state that led to the proxy being added in the first
+place, per the adapter's own history) or the current proxy (already burned).
+
+## What Changes
+
+- `hh`'s detail-page hydration (`hh.detail()` in `internal/ingest/sources/hhru.go`)
+  moves from the proxied `HTMLGetter` to the Firecrawl hosted-fetch tier
+  (`internal/platform/firecrawl`), following the existing `bayt`/`gulftalent`
+  precedent in `firecrawltier.go`.
+- `hh`'s LISTING crawl (`hh.ru/search/vacancy`, the `HH-Lux-InitialState` blob) is
+  unaffected — it is not observed to be failing (postings, titles, companies,
+  salaries land fine today) and stays on its current transport.
+- `proxy.go`'s stale "hh.ru's detail pages 403 the direct datacenter IP" comment
+  and `hh`'s membership in `proxiedProviders` are corrected to reflect the
+  measured, current reality and the new transport split between listing and
+  detail.
+- `FIRECRAWL_MAX_PAGES_PER_RUN` (currently 25, shared across every
+  firecrawl-tier provider) is far too low for hh's volume (~690 detail
+  fetches/hour observed, still settling from the 7-day backlog since boards
+  onboarded 2026-09-03) and needs raising — an operator/deploy concern, not a
+  code default, per the existing pattern (see design.md for the sizing and cost
+  math).
+
+## Capabilities
+
+### New Capabilities
+(none)
+
+### Modified Capabilities
+(none — this is a transport-tier swap behind the existing `hh` adapter contract:
+same `Job` shape, same `ExternalID`/dedup identity, same seen/hydrate/list-only
+fallback behavior. No spec currently tracks `hh` as its own capability, and
+`source-ingest`'s existing requirement — "MAY perform per-posting detail
+requests... to obtain the description" — is unchanged; this fixes the adapter's
+compliance with it, not the requirement itself.)
+
+## Impact
+
+- `internal/ingest/sources/hhru.go` — `detail()` takes a `firecrawl`-backed
+  getter instead of `s.http` for the detail fetch; `crawl()`/listing unchanged.
+- `internal/ingest/sources/firecrawltier.go` — `hh` added alongside
+  `bayt`/`gulftalent`.
+- `internal/ingest/sources/proxy.go` — `hh` removed from `proxiedProviders`;
+  stale comment corrected.
+- `internal/ingest/sources/AGENTS.md`, `internal/platform/firecrawl/AGENTS.md` —
+  doc updates reflecting `hh` joining the firecrawl tier and why.
+- Deploy-side: `FIRECRAWL_MAX_PAGES_PER_RUN` needs raising on prod
+  (`/opt/freehire/.env`), and the Firecrawl plan/credit budget needs headroom for
+  the added volume — both are operator actions outside this repo, called out in
+  design.md and tasks.md so they aren't missed at deploy time.
+- No schema, API, or dependency changes. No effect on other adapters.

--- a/openspec/changes/fix-hh-detail-hydration-firecrawl/tasks.md
+++ b/openspec/changes/fix-hh-detail-hydration-firecrawl/tasks.md
@@ -1,0 +1,91 @@
+## 1. `hh` adapter: split listing and detail transports
+
+- [x] 1.1 In `internal/ingest/sources/hhru.go`, change `hh` to carry two
+      `HTMLGetter` fields (listing, detail), add
+      `NewHHWithDetailGetter(listing, detail HTMLGetter) Source`, and redefine
+      `NewHH(c HTMLGetter) Source` as `NewHHWithDetailGetter(c, c)` so every
+      existing call site (`registry.go`, existing tests) is unchanged.
+- [x] 1.2 Update `crawl()` to use the listing getter and `detail()` to use the
+      detail getter.
+- [x] 1.3 Write a failing test asserting a listing request goes to one fake
+      `HTMLGetter` and a detail request goes to a DIFFERENT fake, via
+      `NewHHWithDetailGetter` — then make it pass. Confirm the existing
+      `NewHH`-based tests (`hhru_test.go`) still pass unchanged.
+
+## 2. Wire `hh` onto the Firecrawl tier, off the proxy tier
+
+- [x] 2.1 In `internal/ingest/sources/firecrawltier.go`, add `hh` to
+      `firecrawlProviders`. **Revised during implementation** (design.md
+      Decision 2 updated to match): the build function does NOT reuse the
+      `direct` parameter `ApplyFirecrawlEgress` passes in — that value becomes
+      the PROXIED client whenever `SOURCES_PROXY_URL` is set for ANY provider,
+      which would put hh's listing back on the burned proxy. Instead:
+      `func(hosted *firecrawlClient, _ HTTPClient) Source { return
+      NewHHWithDetailGetter(NewClient(), hosted) }` — listing gets its own
+      fresh, always-unproxied client.
+- [x] 2.2 In `internal/ingest/sources/proxy.go`, remove `hh`'s entry from
+      `proxiedProviders`; correct the stale "hh.ru's detail pages 403 the
+      direct datacenter IP" comment (and a second stale mention in the
+      `refusalRetryProviders` comment block) to describe the current, measured
+      split (listing: direct; detail: Firecrawl) and why.
+- [x] 2.3 In `internal/ingest/sources/pacer.go`, remove the now-unused
+      `hhRequestInterval`/`hhRequestBurst` constants — no longer needed:
+      Firecrawl's own client already handles vendor-side rate limiting, and
+      listing's own loop is a handful of sequential requests. Confirmed no
+      other references via build + full package test.
+- [x] 2.4 Extended `TestHostedTierCarriesTheTwoUnreachableProviders` in
+      `firecrawltier_test.go` to cover `hh`'s inclusion, and added
+      `TestApplyProxyEgressLeavesHHOnTheDirectClient` in `proxy_test.go`
+      confirming `hh` is no longer rewired by `ApplyProxyEgress`.
+- [x] 2.5 Added `TestApplyFirecrawlEgressRewiresHHDetailWithAKey` and
+      `TestHHKeepsItsCurrentTransportWithoutAKey` in `firecrawltier_test.go`:
+      confirm `ApplyFirecrawlEgress` rewires hh with a key and leaves it alone
+      without one. (The wantapply-style "listing keeps using `direct`" case
+      does not apply to hh per the 2.1 revision — that split is instead
+      covered at the adapter level by
+      `TestHHWithDetailGetterSplitsListingAndDetailTransports` in
+      `hhru_test.go`, task 1.3.)
+
+## 3. Docs
+
+- [x] 3.1 Updated `internal/ingest/sources/AGENTS.md`'s "hosted tier" section
+      with an hh-specific callout: listing direct, detail via Firecrawl, and
+      why hh can't reuse `ApplyFirecrawlEgress`'s shared `direct` transport.
+- [x] 3.2 Updated `internal/platform/firecrawl/AGENTS.md` with a new "A
+      different shape: hh is not IP-blocked at all" section. (No existing
+      wantapply callout was actually in that doc to match — it's already
+      stale on that count, pre-existing and out of scope for this change —
+      so the new section stands on its own and cross-links to
+      `internal/ingest/sources/AGENTS.md` for the wiring detail instead.)
+
+## 4. Verify and land
+
+- [x] 4.1 `gofmt -l .` clean, `go build ./...`, `go vet ./...`,
+      `go test ./internal/ingest/sources/...` all green. Also ran the full
+      `go test ./...` — no `FAIL` anywhere in the module.
+- [x] 4.2 `go vet -tags=integration ./...` green (exit 0).
+- [x] 4.3 Ran `simplify` skill pass on the diff — already clean and
+      idiomatic, matches project conventions (dense narrative comments,
+      per-file test fakes); no changes needed.
+- [ ] 4.4 Request code review (`superpowers:requesting-code-review`); address
+      feedback per `superpowers:receiving-code-review`.
+- [ ] 4.5 Open PR; do not merge until task 5 (deploy-side prerequisites) is
+      acknowledged, since merging without raising the Firecrawl budget on prod
+      reproduces the same "hh: detail ... failed" symptom via
+      `ErrBudgetSpent` instead of the CAPTCHA.
+
+## 5. Deploy-side (outside this repo, host2 — manual, AFTER code deploys)
+
+- [ ] 5.1 Confirm/upgrade the Firecrawl account plan for the added volume (see
+      design.md's cost math — recommend at least the 1M-credit/mo "Scale"
+      tier for headroom until hh's steady-state rate is known).
+- [ ] 5.2 Raise `FIRECRAWL_MAX_PAGES_PER_RUN` in `/opt/freehire/.env` (recommend
+      2000; see design.md Decision 4) and restart/allow the next
+      `freehire-ingest@hh` timer firing to pick it up.
+- [ ] 5.3 Watch the next 2-3 hourly `freehire-ingest@hh.service` runs'
+      `journalctl` output for `hh: detail ... failed` lines dropping to near
+      zero, and spot-check `/api/v1/jobs/search?source=hh` for real
+      descriptions on newly-created rows (not just the salary paragraph).
+- [ ] 5.4 Once the 7-day backlog window settles (~2026-09-10, per design.md
+      Context), re-measure hh's steady-state detail-fetch rate and revisit
+      whether the plan tier chosen in 5.1 is still the right fit.

--- a/openspec/changes/fix-hh-detail-hydration-firecrawl/tasks.md
+++ b/openspec/changes/fix-hh-detail-hydration-firecrawl/tasks.md
@@ -67,8 +67,16 @@
 - [x] 4.3 Ran `simplify` skill pass on the diff — already clean and
       idiomatic, matches project conventions (dense narrative comments,
       per-file test fakes); no changes needed.
-- [ ] 4.4 Request code review (`superpowers:requesting-code-review`); address
-      feedback per `superpowers:receiving-code-review`.
+- [x] 4.4 Requested code review (commit b6bf0c76 vs base a3d79c13).
+      Assessment: "Ready to merge: with fixes" — no Critical/Important
+      issues. Two Minor doc-comment issues fixed (commit 87076c7d):
+      `hhru.go`'s type comment pointed at the wrong file for the
+      DDoS-Guard rationale (registry.go → firecrawltier.go), and
+      overclaimed the split as unconditional when it only holds with
+      `FIRECRAWL_API_KEY` set. Reviewer independently verified the
+      `ApplyFirecrawlEgress`-`direct`-parameter deviation (task 2.1) is
+      real and sound, ran the full verification suite itself (all green),
+      and confirmed all markdown links resolve.
 - [ ] 4.5 Open PR; do not merge until task 5 (deploy-side prerequisites) is
       acknowledged, since merging without raising the Firecrawl budget on prod
       reproduces the same "hh: detail ... failed" symptom via


### PR DESCRIPTION
## Summary

`hh` (headhunter.ru) postings were landing with only a salary-paragraph stub instead of a real description. Root cause, confirmed live on prod (2026-09-08): the configured `SOURCES_PROXY_URL` egress IP is now flagged by hh.ru's DDoS-Guard and redirected to an interactive image CAPTCHA (`/account/captcha`) on essentially every detail-page request (2938/2938 failures over one day of logs; a live `freehire-ingest@hh` run failed 40/40 detail fetches in real time).

Spiked two alternatives on the exact failing URLs:
- Direct datacenter IP: 80/80 success at production pace (~4 req/s sustained).
- Firecrawl (already configured with `FIRECRAWL_API_KEY` on prod for `bayt`/`gulftalent`): 1/1 success, full description content, bypasses the CAPTCHA entirely.

Firecrawl was chosen for detail hydration since it doesn't depend on any IP's reputation with hh.ru — unlike falling back to the direct IP, which is exactly the state that led to the proxy being added in the first place, per the adapter's own history.

- `hh`'s listing and detail now use separate transports (`NewHHWithDetailGetter`): listing stays on a plain, always-unproxied client (measured working); detail hydration moves onto the existing `firecrawlProviders` tier (`internal/ingest/sources/firecrawltier.go`), following the `bayt`/`gulftalent`/`wantapply` precedent.
- `hh` is removed entirely from `proxiedProviders` (`proxy.go`); the stale "detail pages 403 the direct datacenter IP" comment and a second stale mention are corrected.
- Now-dead pacer constants (`hhRequestInterval`/`hhRequestBurst`) are removed — no longer needed: Firecrawl has its own vendor-side rate limiting, and listing's own loop is a handful of sequential requests.
- `internal/ingest/sources/AGENTS.md` and `internal/platform/firecrawl/AGENTS.md` updated to document hh's mixed-tier shape.

Full investigation, design rationale (including a mid-implementation design revision — see design.md Decision 2 / tasks.md 2.1), and cost analysis are in `openspec/changes/fix-hh-detail-hydration-firecrawl/`.

**⚠️ Deploy-side prerequisite, not covered by this PR:** `FIRECRAWL_MAX_PAGES_PER_RUN` (currently 25, shared across all Firecrawl-tier providers) must be raised on host2 (recommend ~2000) and the Firecrawl account plan tier upgraded (recommend the 1M-credit/mo "Scale" tier, ~$49.92/mo) before/at deploy — otherwise hh's detail hydration will immediately hit `ErrBudgetSpent`, which looks identical in the logs to today's CAPTCHA failures. See `openspec/changes/fix-hh-detail-hydration-firecrawl/tasks.md` section 5.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go vet -tags=integration ./...` clean
- [x] `go test ./internal/ingest/sources/...` and full `go test ./...` green (no `FAIL` anywhere)
- [x] Independent code review (no Critical/Important issues; two Minor doc-comment issues fixed)
- [ ] Post-deploy: watch `journalctl -u freehire-ingest@hh.service` for `hh: detail ... failed` dropping to near zero, and spot-check `/api/v1/jobs/search?source=hh` for real descriptions on newly-created rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)