### PR TITLE
Provision the mentorship reminder worker on the host

### DIFF
--- a/deploy/bin/release.sh
+++ b/deploy/bin/release.sh
@@ -232,12 +232,23 @@ if [ "$app" = freehire ]; then
   # auto-apply joined the same day, found missing entirely: the timer-driven drain of
   # auto_apply_queue (headless Chrome fill+submit) had never actually been built or
   # provisioned on this host, so an approved entry would sit in the queue forever.
+  # discord-sync joined 2026-09-07 with migration 0144: it keeps the paid role on the
+  # community Discord in step with the subscription. Its whole feature is inert without the
+  # five DISCORD_* values, so a release that builds it on a host without them costs one
+  # binary and changes nothing — which is also why forgetting it here would have been
+  # invisible until somebody wondered why linking a Discord account never granted anything.
   # backfill-requirements joined 2026-09-05, and this list is why: the worker shipped with
   # migration 0139 and its binary simply was not here, so the operator built it by hand to
   # run the first batches. A one-off pass still needs to survive the next release — it is
   # taken in bounded runs over days, and half a backlog with no binary left to finish it is
   # the failure this line prevents.
-  for w in migrate onboarding broadcast ingest enrich embed similar-backfill search-drain reindex reindex-companies import-collections import-yc import-company-industries queue-metrics tg-ingest tg-extract liveness notify remind nudge apple-revoke auth-cleanup capture-apply-form backfill-derive backfill-company-names backfill-descriptions backfill-application-events backfill-slug-folded backfill-duplicate-marker-owner backfill-company-type-hint backfill-requirements billing-sync build-suggestions merge-companies add-board harvest-orphans recount-companies rollup-stats rollup-facets rollup-company rollup-views classify-mail resolve-url gmail-sync cal-sync mail-ingest hydrate-adzuna-description seed-adzuna-description-queue ingest-scheduler schedule-board auto-apply-orchestrate auto-apply social-digest linkedin-auth linkedin-token-refresh; do
+  # mentorship-remind joined 2026-09-08 with the mentorship marketplace. It sends the 24h
+  # and 1h reminders a booked session is due, and its unit reads .env.notify as well as
+  # .env — without the mail credentials it is a soft no-op, so a missing binary and a
+  # missing credential fail the same silent way: every run exits 0 having reminded nobody.
+  # A missed reminder costs somebody the session, which is why it is on this list rather
+  # than built by hand after the fact.
+  for w in migrate onboarding broadcast ingest enrich embed similar-backfill search-drain reindex reindex-companies import-collections import-yc import-company-industries queue-metrics tg-ingest tg-extract liveness notify remind nudge apple-revoke auth-cleanup capture-apply-form backfill-derive backfill-company-names backfill-descriptions backfill-application-events backfill-slug-folded backfill-duplicate-marker-owner backfill-company-type-hint backfill-requirements billing-sync build-suggestions merge-companies add-board harvest-orphans recount-companies rollup-stats rollup-facets rollup-company rollup-views classify-mail resolve-url gmail-sync cal-sync mail-ingest hydrate-adzuna-description seed-adzuna-description-queue ingest-scheduler schedule-board auto-apply-orchestrate auto-apply social-digest discord-sync mentorship-remind linkedin-auth linkedin-token-refresh; do
     sudo -u freehire /usr/local/bin/go build -buildvcs=false -o "$w" "./cmd/$w"
   done
   # Every binary a freehire-*.service starts from hire-current has to have just been built,

--- a/openspec/changes/mentorship-marketplace/tasks.md
+++ b/openspec/changes/mentorship-marketplace/tasks.md
@@ -158,10 +158,23 @@ unit tests plus the function they drive; none of it needs Docker or Postgres.
       credentials live only there and a worker missing them soft-skips silently forever;
       and the timer is `Persistent=false`, unlike the reconciling workers, because a
       replayed window would fire reminders for sessions that have already started
-- [ ] 6.4 On deploy: build the binary on the host (`release.sh` builds the API, not every
-      command in `cmd/`) and copy the unit and timer across by hand — `release.sh` never
-      touches a unit. Until both are done the feature works and reminders simply never
-      fire
+- [x] 6.4 On deploy: build the binary on the host and copy the unit and timer across by
+      hand — `release.sh` never touches a unit. Done 2026-09-08, and the first half turned
+      out to be a THIRD step nobody had written down: `release.sh` does build worker
+      binaries, but from a hard-coded list, and a command missing from it is simply never
+      built. `mentorship-remind` is on that list now, with the note the list keeps beside
+      every other entry.
+
+      The unit and timer are in `/etc/systemd/system/`, the timer is enabled and firing
+      every 10 minutes, and one run was taken by hand first: `sent=0 failed=0`, exit 0.
+      That figure is ambiguous on its own — a run with no mail credentials reports the
+      same — so `.env.notify` was checked to carry `NOTIFY_EMAIL_FROM` and `AWS_REGION`
+      before the timer was enabled. It does; `sent=0` means nobody was due.
+
+      `deploy/bin/release.sh` was re-synced from the host in the same pass. It had already
+      drifted before this change (missing `discord-sync` and both `linkedin-*` workers),
+      so a repo copy that gained only this entry would still have described a host it does
+      not match.
 
 ## 7. HTTP layer
 


### PR DESCRIPTION
Closes the last open task of `openspec/changes/mentorship-marketplace` — 6.4, the
two manual host steps. **Every task in that change is now `[x]`.**

## The task said two steps. It is three.

6.4 read: *build the binary on the host (`release.sh` builds the API, not every
command in `cmd/`) and copy the unit and timer across by hand.*

The first half is wrong in a way that matters. `release.sh` **does** build worker
binaries — but from a hard-coded list, and a command missing from that list is
simply never built. Following the instruction literally would have produced a
binary by hand that the next release quietly dropped, and the symptom would have
been reminders that worked for a few days and then stopped.

`mentorship-remind` is on the list now, carrying the note that list keeps beside
every other entry.

## Done on the host

- Unit and timer in `/etc/systemd/system/`, timer **enabled and firing every 10
  minutes** (next run confirmed in `systemctl list-timers`).
- One run taken by hand first: `sent=0 failed=0`, exit 0.

That figure is **ambiguous on its own** — a run with no mail credentials reports
exactly the same, which is the failure the unit's own comment calls "the worst
possible failure mode: every run would exit 0 having reminded nobody,
indefinitely". So `.env.notify` was checked to carry `NOTIFY_EMAIL_FROM` and
`AWS_REGION` *before* the timer went on. It does — `sent=0` means nobody was due,
not that nobody could be told.

## release.sh was already drifted

`deploy/bin/release.sh` is re-synced from the live host in the same pass. It had
drifted **before** this change — missing `discord-sync` and both `linkedin-*`
workers — so a repo copy that gained only this one entry would still have
described a host it does not match. That is exactly what `deploy/check-drift.sh`
exists to report.

Nothing here changes the running app: the worker was inert because it did not
exist, and it is now scheduled.
