### PR TITLE
Run the assistant model bake-off, and fix the three defects it found

### DIFF
--- a/internal/ai/assistant/AGENTS.md
+++ b/internal/ai/assistant/AGENTS.md
@@ -321,6 +321,48 @@ CV tailoring has no tag of its own on purpose: `/me/cvs/tailor` makes no model c
 mints a CV and debits credits, and the work is a turn under the `tailor` preset. A second
 tag would double-count one spend.
 
+## Choosing the turn model: the bake-off
+
+Which model answers a turn is decided by measurement, not by a price page, and the
+measurement is a `//go:build integration && llmlive` test:
+`internal/api/handler/assistant_bakeoff_run_llmlive_test.go`.
+
+```bash
+BAKEOFF_MODELS=vendor/model-a,vendor/model-b \
+LLM_BASE_URL=… LLM_API_KEY=… LLM_MODEL=… \
+  go test -tags=integration,llmlive ./internal/api/handler/ -run TestBakeoff -timeout 3h -v
+```
+
+It runs the **tailoring autopilot** — the assistant's most expensive turn shape — once per
+(candidate model, case) against a fresh Postgres, and writes a ranked table plus a JSON
+report under `.cache/`. Needs Docker, `typst` and `pdftotext`, and the local profile
+fixture (see `bakeoffProfileFixture`: a real CV, deliberately not in this repository).
+
+**Why a per-million price does not answer the question.** Two things decide what a turn
+costs here, and neither is on a price page:
+
+- **Rounds are a multiplier, not an addend.** The transcript is replayed into context every
+  round, so round N carries rounds 1..N-1 with it. A model needing fourteen rounds where
+  another needs five costs far more than its token price says.
+- **Whether the provider serves the replayed prefix from cache decides the rest.** #2633
+  measured 20k tokens a turn being re-read at full price because the history window slid by
+  one message. The bake-off reads `llm.Usage.CachedInput` per round and reports the share.
+
+The cache verdict has **three** states and not two: langchaingo writes the cached key
+unconditionally from a zero-valued struct, so "the provider reported nothing" and "nothing
+was cached" both arrive as `0`. A single-round run is therefore `inconclusive` — there was
+no earlier round for a cache to have held — and only a multi-round run all reporting zero
+is `no cache observed`.
+
+**What it does not do.** It renders no verdict on whether a tailored CV is any good, and
+calls no grader model. It ranks on `cvmatch` and `atscheck` — free, pure, and the same
+numbers the candidate already sees in the workspace — and emits every run's tailored CV
+text beside its vacancy so a reader judges the rest. See
+`openspec/changes/assistant-model-bakeoff/design.md` for why a judge model was rejected.
+
+**Only the turn model varies.** The fit chain stays pinned to `LLM_MODEL`, and the test
+asserts it: swapping both would measure two models and attribute the result to one.
+
 ## Limitations
 - **Measured, not bounded.** A turn is now attributed to the account that ran it and its
   cost is readable (`GET /me/usage`, and per-feature on the gateway), but nothing refuses

--- a/internal/api/handler/assistant_autopilot_integration_test.go
+++ b/internal/api/handler/assistant_autopilot_integration_test.go
@@ -37,12 +37,45 @@ import (
 	"github.com/strelov1/freehire/internal/platform/llm"
 )
 
+// autopilotConfig is what a caller may say about a harness beyond the two models.
+//
+// Read while the handlers are ASSEMBLED rather than applied to them afterwards: the fit
+// analyzer is built into a surface that closes over it, so replacing it after the fact
+// would leave the closure holding the old one.
+type autopilotConfig struct {
+	// fitClient overrides the client the fit chain runs on. Nil wraps fitM the plain way.
+	fitClient *llm.Client
+	// renderer and extract are the CV toolchain the deterministic scores read.
+	renderer cv.Renderer
+	extract  func([]byte) (string, error)
+	// tracking is the job-tracking surface the tool registry offers to every preset.
+	tracking *trackingHandlers
+}
+
 // autopilotOption adjusts a harness past the two models every caller names.
 //
 // Variadic rather than a widened signature: the five arguments below are what an autopilot
 // test is ABOUT, and the one caller wanting more is the bake-off. Adding a sixth parameter
 // would edit six call sites to say nil for something none of them has an opinion on.
-type autopilotOption func(*assistantHandlers)
+type autopilotOption func(*autopilotConfig)
+
+// withFitClient runs the fit chain on a client the caller built, instead of on the plain
+// wrapper around fitM.
+//
+// It exists because llm.NewWithModel — which is what the wrapper is — produces a client with
+// NO HTTP transport, and `reasoning_effort` is written BY a transport (llm.Client.transport
+// installs reasoningInjector; only llm.New does). So on a wrapped model every
+// llm.WithReasoning is silently dropped.
+//
+// Against a fake that costs nothing. Against a real gateway it is the difference between a
+// working chain and none: matchanalysis asks Stage 1 for llm.ReasoningNone (#2640), a
+// wrapped client never sends it, GLM deliberates for ~1500 reasoning tokens, and the stage
+// blows its 90s deadline — twice, since it retries — on every single analysis. Measured
+// 2026-09-08: 6 of 6 attempts, while production ran 21 analyses in the same day with no
+// Stage 1 failure at all.
+func withFitClient(c *llm.Client) autopilotOption {
+	return func(cfg *autopilotConfig) { cfg.fitClient = c }
+}
 
 // withTrackingTools wires the tracking surface the tool registry offers to EVERY preset,
 // the tailoring autopilot included (see assistantHandlers.registry).
@@ -58,8 +91,8 @@ type autopilotOption func(*assistantHandlers)
 // comparable to production, and a report read as though they were would overstate how many
 // rounds a turn takes.
 func withTrackingTools(pool *pgxpool.Pool, queries *db.Queries) autopilotOption {
-	return func(h *assistantHandlers) {
-		h.tracking = &trackingHandlers{
+	return func(cfg *autopilotConfig) {
+		cfg.tracking = &trackingHandlers{
 			tracking: jobtracking.New(jobtracking.NewQueriesRepository(queries, pool)),
 		}
 	}
@@ -76,9 +109,9 @@ func withTrackingTools(pool *pgxpool.Pool, queries *db.Queries) autopilotOption 
 // Both halves together or neither: renderedCVText checks for both, and a harness carrying
 // the renderer alone would reach the extractor with nothing behind it.
 func withRenderedCVScoring(r cv.Renderer, extract func([]byte) (string, error)) autopilotOption {
-	return func(h *assistantHandlers) {
-		h.cv.cvRenderer = r
-		h.cv.extractPDFText = extract
+	return func(cfg *autopilotConfig) {
+		cfg.renderer = r
+		cfg.extract = extract
 	}
 }
 
@@ -88,6 +121,15 @@ func withRenderedCVScoring(r cv.Renderer, extract func([]byte) (string, error)) 
 // one that answers the fit chain.
 func newAutopilotHarness(t *testing.T, pool *pgxpool.Pool, iss *auth.Issuer, turnM assistant.Model, fitM llms.Model, opts ...autopilotOption) (*assistantHandlers, *fiber.App) {
 	t.Helper()
+	var cfg autopilotConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	fitClient := cfg.fitClient
+	if fitClient == nil {
+		fitClient = llm.NewWithModel(fitM)
+	}
+
 	queries := db.New(pool)
 	bank := experience.NewStore(experience.NewQueriesRepository(queries))
 	h := &assistantHandlers{
@@ -97,24 +139,22 @@ func newAutopilotHarness(t *testing.T, pool *pgxpool.Pool, iss *auth.Issuer, tur
 		experience: bank,
 		// The run plan reads the cached analysis through the service, and the tools read the
 		// vacancy through jobs — both held by the assistant itself now.
-		fit:  fitanalysis.New(queries, nil, matchanalysis.NewAnalyzer(nil)),
-		jobs: queries,
+		fit:      fitanalysis.New(queries, nil, matchanalysis.NewAnalyzer(nil)),
+		jobs:     queries,
+		tracking: cfg.tracking,
 		cv: &cvHandlers{
-			cvStore:   cv.NewStore(cv.NewQueriesRepository(queries)),
-			editor:    cvedit.NewEditor(cvedit.NewRepository(pool, queries), bankGate{bank: bank}),
-			queries:   queries,
-			jobReader: queries,
-			fit:       fitanalysis.New(queries, nil, matchanalysis.NewAnalyzer(nil)),
+			cvStore:        cv.NewStore(cv.NewQueriesRepository(queries)),
+			editor:         cvedit.NewEditor(cvedit.NewRepository(pool, queries), bankGate{bank: bank}),
+			queries:        queries,
+			jobReader:      queries,
+			cvRenderer:     cfg.renderer,
+			extractPDFText: cfg.extract,
+			fit:            fitanalysis.New(queries, nil, matchanalysis.NewAnalyzer(nil)),
 			match: fitAPI(pool, queries, iss, resume.New(nil, resume.NewQueriesRepository(queries)),
-				matchanalysis.NewAnalyzer(llm.NewWithModel(fitM))),
+				matchanalysis.NewAnalyzer(fitClient)),
 		},
 	}
 	h.runner = assistant.NewRunner(turnM, h.store, assistant.RunnerConfig{MaxSteps: 3})
-	// Applied before the routes are registered: an option that replaces a handler's
-	// dependency after register() would leave the closure holding the old one.
-	for _, opt := range opts {
-		opt(h)
-	}
 
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	api := app.Group("/api/v1")

--- a/internal/api/handler/assistant_autopilot_integration_test.go
+++ b/internal/api/handler/assistant_autopilot_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tmc/langchaingo/llms"
 
 	"github.com/strelov1/freehire/internal/ai/assistant"
+	"github.com/strelov1/freehire/internal/application/jobtracking"
 	"github.com/strelov1/freehire/internal/candidate/cv"
 	"github.com/strelov1/freehire/internal/candidate/cvedit"
 	"github.com/strelov1/freehire/internal/candidate/experience"
@@ -42,6 +43,27 @@ import (
 // test is ABOUT, and the one caller wanting more is the bake-off. Adding a sixth parameter
 // would edit six call sites to say nil for something none of them has an opinion on.
 type autopilotOption func(*assistantHandlers)
+
+// withTrackingTools wires the tracking surface the tool registry offers to EVERY preset,
+// the tailoring autopilot included (see assistantHandlers.registry).
+//
+// It matters to a live run and to nothing else: a scripted stand-in never calls a tool it
+// was not scripted to call, while a real model reaches for save_job and my_jobs mid-run and
+// gets "job tracking is not available". That refusal costs a round, and rounds are the
+// bake-off's primary measurement — the transcript is replayed into each one.
+//
+// The search surface has no equivalent option: it needs a Meilisearch, which this harness
+// does not stand. A bake-off therefore measures models whose search_jobs refuses. Every
+// candidate faces the same refusal, so the rows stay comparable to each other; they are not
+// comparable to production, and a report read as though they were would overstate how many
+// rounds a turn takes.
+func withTrackingTools(pool *pgxpool.Pool, queries *db.Queries) autopilotOption {
+	return func(h *assistantHandlers) {
+		h.tracking = &trackingHandlers{
+			tracking: jobtracking.New(jobtracking.NewQueriesRepository(queries, pool)),
+		}
+	}
+}
 
 // withRenderedCVScoring wires the CV toolchain the deterministic scores read.
 //

--- a/internal/api/handler/assistant_autopilot_integration_test.go
+++ b/internal/api/handler/assistant_autopilot_integration_test.go
@@ -36,11 +36,35 @@ import (
 	"github.com/strelov1/freehire/internal/platform/llm"
 )
 
+// autopilotOption adjusts a harness past the two models every caller names.
+//
+// Variadic rather than a widened signature: the five arguments below are what an autopilot
+// test is ABOUT, and the one caller wanting more is the bake-off. Adding a sixth parameter
+// would edit six call sites to say nil for something none of them has an opinion on.
+type autopilotOption func(*assistantHandlers)
+
+// withRenderedCVScoring wires the CV toolchain the deterministic scores read.
+//
+// cvmatch and atscheck both score the text layer of the RENDERED PDF rather than the stored
+// document (renderedCVText says why), and a handler holding neither half does not fail that
+// read — it degrades to an unavailable score. That is right for the workspace, whose panel
+// must keep loading without a toolchain, and wrong for the bake-off, which would rank a
+// column of absences and report it as a tie.
+//
+// Both halves together or neither: renderedCVText checks for both, and a harness carrying
+// the renderer alone would reach the extractor with nothing behind it.
+func withRenderedCVScoring(r cv.Renderer, extract func([]byte) (string, error)) autopilotOption {
+	return func(h *assistantHandlers) {
+		h.cv.cvRenderer = r
+		h.cv.extractPDFText = extract
+	}
+}
+
 // newAutopilotHarness wires the handlers, the app and the routes an autopilot test needs.
 // Every test here wants the same assembly — the CV tools, the editor, the experience bank and
 // a match surface — and differs only in the two models: the one that answers the turn and the
 // one that answers the fit chain.
-func newAutopilotHarness(t *testing.T, pool *pgxpool.Pool, iss *auth.Issuer, turnM assistant.Model, fitM llms.Model) (*assistantHandlers, *fiber.App) {
+func newAutopilotHarness(t *testing.T, pool *pgxpool.Pool, iss *auth.Issuer, turnM assistant.Model, fitM llms.Model, opts ...autopilotOption) (*assistantHandlers, *fiber.App) {
 	t.Helper()
 	queries := db.New(pool)
 	bank := experience.NewStore(experience.NewQueriesRepository(queries))
@@ -64,6 +88,11 @@ func newAutopilotHarness(t *testing.T, pool *pgxpool.Pool, iss *auth.Issuer, tur
 		},
 	}
 	h.runner = assistant.NewRunner(turnM, h.store, assistant.RunnerConfig{MaxSteps: 3})
+	// Applied before the routes are registered: an option that replaces a handler's
+	// dependency after register() would leave the closure holding the old one.
+	for _, opt := range opts {
+		opt(h)
+	}
 
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	api := app.Group("/api/v1")

--- a/internal/api/handler/assistant_bakeoff_profile_integration_test.go
+++ b/internal/api/handler/assistant_bakeoff_profile_integration_test.go
@@ -1,0 +1,242 @@
+//go:build integration
+
+// Seeding the bake-off's candidate: the CV document every run starts from and the
+// experience bank every edit has to cite. Behind the integration tag alone, like the case
+// seed beside it, so the half that costs no tokens is checked by the ordinary tagged suite.
+//
+//	go test -tags=integration ./internal/api/handler/ -run BakeoffProfile
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/strelov1/freehire/internal/candidate/experience"
+	"github.com/strelov1/freehire/internal/candidate/perioddate"
+	"github.com/strelov1/freehire/internal/platform/db"
+)
+
+// bakeoffBankEntry is one employment of the fixture with the achievements filed under it,
+// in the shape /me/experience returns.
+//
+// It is decoded in two passes rather than by embedding, because experience.Employment
+// implements UnmarshalJSON: Go hands an embedded Unmarshaler the WHOLE object, so a struct
+// that embedded it would decode the place correctly and silently drop every atom. That is
+// the same trap employmentWithAtoms.MarshalJSON documents from the writing side, and it
+// fails quietly in exactly the way a seed must not.
+type bakeoffBankEntry struct {
+	Employment experience.Employment
+	Atoms      []experience.Atom
+}
+
+// decodeBakeoffBankEntry reads one employment-with-atoms from the fixture.
+func decodeBakeoffBankEntry(raw json.RawMessage) (bakeoffBankEntry, error) {
+	var entry bakeoffBankEntry
+	if err := json.Unmarshal(raw, &entry.Employment); err != nil {
+		return bakeoffBankEntry{}, fmt.Errorf("employment: %w", err)
+	}
+	var atoms struct {
+		Atoms []experience.Atom `json:"atoms"`
+	}
+	if err := json.Unmarshal(raw, &atoms); err != nil {
+		return bakeoffBankEntry{}, fmt.Errorf("atoms of %q: %w", entry.Employment.Company, err)
+	}
+	entry.Atoms = atoms.Atoms
+	return entry, nil
+}
+
+// seedBakeoffProfile writes the fixture's experience bank for one account and returns how
+// many achievements it banked.
+//
+// The rows go in with raw SQL rather than through experience.Store, and that is deliberate.
+// Store DERIVES an atom's provenance from who is asserting it and ignores the value it is
+// handed — the wall the CV evidence gate stands on. There is no Author that produces
+// `cv_import`, so every route through the store would relabel most of this bank, and a
+// relabelled bank is not this candidate's bank: the gate would accept claims it refuses in
+// production, or refuse claims it accepts, and the bake-off would be measuring the gate.
+// The fixture is a recording of the store's own output, so replaying it verbatim is the
+// faithful seed and the store's rules are not being circumvented, only replayed.
+func seedBakeoffProfile(t *testing.T, pool *pgxpool.Pool, userID int64, p bakeoffProfile) int {
+	t.Helper()
+
+	var banked int
+	for _, raw := range p.Experience.Employments {
+		entry, err := decodeBakeoffBankEntry(raw)
+		if err != nil {
+			t.Fatalf("bake-off profile: %v", err)
+		}
+		id := insertBakeoffEmployment(t, pool, userID, entry.Employment)
+		for _, a := range entry.Atoms {
+			a.EmploymentID = &id
+			insertBakeoffAtom(t, pool, userID, a)
+			banked++
+		}
+	}
+	// The unplaced achievements are banked too. They are usually the ones volunteered in
+	// conversation, so dropping them would quietly remove the evidence a tailoring run is
+	// most likely to reach for.
+	for _, raw := range p.Experience.Unplaced {
+		var a experience.Atom
+		if err := json.Unmarshal(raw, &a); err != nil {
+			t.Fatalf("bake-off profile: unplaced atom: %v", err)
+		}
+		a.EmploymentID = nil
+		insertBakeoffAtom(t, pool, userID, a)
+		banked++
+	}
+	return banked
+}
+
+// insertBakeoffEmployment writes one place and returns the id its atoms must point at. The
+// fixture's own id is NOT reused: it belongs to the production row, and a seed that carried
+// it would make a report's evidence ids look like production's.
+func insertBakeoffEmployment(t *testing.T, pool *pgxpool.Pool, userID int64, e experience.Employment) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO experience_employments
+		   (user_id, kind, company, role, location,
+		    period_start_year, period_start_month, period_end_year, period_end_month,
+		    is_current, summary, stack, link)
+		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+		 RETURNING id`,
+		userID, e.Kind, e.Company, e.Role, e.Location,
+		periodPart(e.Start, func(p perioddate.PeriodDate) int { return p.Year }),
+		periodPart(e.Start, func(p perioddate.PeriodDate) int { return p.Month }),
+		periodPart(e.End, func(p perioddate.PeriodDate) int { return p.Year }),
+		periodPart(e.End, func(p perioddate.PeriodDate) int { return p.Month }),
+		e.Current, e.Summary, textArray(e.Stack), e.Link,
+	).Scan(&id); err != nil {
+		t.Fatalf("seed employment %q: %v", e.Company, err)
+	}
+	return id
+}
+
+// insertBakeoffAtom writes one achievement with the standing the fixture recorded for it.
+func insertBakeoffAtom(t *testing.T, pool *pgxpool.Pool, userID int64, a experience.Atom) {
+	t.Helper()
+	a.Sanitize()
+	if err := a.Validate(); err != nil {
+		t.Fatalf("seed atom %q: %v", a.Claim, err)
+	}
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO experience_atoms
+		   (user_id, employment_id, claim, claim_key, context, metrics, skills, provenance, source_ref)
+		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+		 ON CONFLICT (user_id, claim_key) DO NOTHING`,
+		userID, a.EmploymentID, a.Claim, experience.ClaimKey(a.Claim),
+		a.Context, textArray(a.Metrics), textArray(a.Skills), string(a.Provenance), a.SourceRef,
+	); err != nil {
+		t.Fatalf("seed atom %q: %v", a.Claim, err)
+	}
+}
+
+// textArray sends an absent list as the empty array the column holds, never as NULL: these
+// are NOT NULL text[] columns defaulting to '{}', and a nil Go slice encodes as NULL, so a
+// place with no stack line would be refused by the constraint rather than stored blank.
+func textArray(v []string) []string {
+	if v == nil {
+		return []string{}
+	}
+	return v
+}
+
+// periodPart reads one half of a period date, as the nullable column the schema holds. A
+// nil period is a real absence — "Present", or a date the source never stated — and must
+// stay NULL rather than becoming year zero.
+func periodPart(p *perioddate.PeriodDate, read func(perioddate.PeriodDate) int) *int {
+	if p == nil {
+		return nil
+	}
+	v := read(*p)
+	if v == 0 {
+		return nil
+	}
+	return &v
+}
+
+// loadBakeoffProfileOrSkip reads the local fixture, skipping the test when it has not been
+// built. Its absence is not a failure: the file is a real CV and is deliberately not in
+// this repository, so CI has no business failing over one it cannot have.
+func loadBakeoffProfileOrSkip(t *testing.T) bakeoffProfile {
+	t.Helper()
+	p, err := loadBakeoffProfile(bakeoffProfileFixture)
+	if errors.Is(err, errMissingBakeoffProfile) {
+		t.Skipf("%v", err)
+	}
+	if err != nil {
+		t.Fatalf("loadBakeoffProfile: %v", err)
+	}
+	return p
+}
+
+// The bank is read back through the store the tools themselves use, and the provenance is
+// checked rather than assumed: every candidate-asserted claim must come back
+// candidate-asserted, because the CV evidence gate reads exactly this column. A seed that
+// relabelled the bank would measure how well each model works around a gate that was never
+// this candidate's.
+func TestBakeoffProfileSeedsTheBankWithItsStandingIntact(t *testing.T) {
+	pool := startPostgres(t)
+	p := loadBakeoffProfileOrSkip(t)
+	userID := seedAccount(t, pool, "bakeoff-profile@example.test", true)
+
+	banked := seedBakeoffProfile(t, pool, userID, p)
+	if banked == 0 {
+		t.Fatal("the fixture banked no achievement; every edit would bounce off the evidence gate")
+	}
+
+	bank := experience.NewStore(experience.NewQueriesRepository(db.New(pool)))
+	atoms, err := bank.ListAtoms(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("list atoms: %v", err)
+	}
+	if len(atoms) == 0 {
+		t.Fatal("nothing came back from the bank")
+	}
+
+	want := map[experience.Provenance]int{}
+	for _, raw := range p.Experience.Employments {
+		entry, err := decodeBakeoffBankEntry(raw)
+		if err != nil {
+			t.Fatalf("re-read fixture: %v", err)
+		}
+		for _, a := range entry.Atoms {
+			want[a.Provenance]++
+		}
+	}
+	for _, raw := range p.Experience.Unplaced {
+		var a experience.Atom
+		if err := json.Unmarshal(raw, &a); err != nil {
+			t.Fatalf("re-read unplaced: %v", err)
+		}
+		want[a.Provenance]++
+	}
+
+	got := map[experience.Provenance]int{}
+	for _, a := range atoms {
+		got[a.Provenance]++
+	}
+	// Compared per label, not in total: a seed that banked every claim but relabelled them
+	// would agree on the count and disagree on the only thing the gate reads.
+	for label, n := range want {
+		if got[label] != n {
+			t.Errorf("provenance %q: banked %d, the fixture holds %d", label, got[label], n)
+		}
+	}
+
+	// Every placed achievement must still be filed under a place, or it reaches the run as
+	// unplaced and loses the role it was written about.
+	employments, err := bank.ListEmployments(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("list employments: %v", err)
+	}
+	if len(employments) != len(p.Experience.Employments) {
+		t.Errorf("employments = %d, the fixture holds %d", len(employments), len(p.Experience.Employments))
+	}
+}

--- a/internal/api/handler/assistant_bakeoff_run_llmlive_test.go
+++ b/internal/api/handler/assistant_bakeoff_run_llmlive_test.go
@@ -1,0 +1,514 @@
+//go:build integration && llmlive
+
+// The model bake-off itself: one tailoring autopilot run per (candidate model, case),
+// against a real gateway, scored by the product's own deterministic scores.
+//
+// It spends real money, so it is behind llmlive as well as integration and never runs in
+// CI. It needs Docker (testcontainers), a Typst binary and pdftotext for the scores, the
+// local profile fixture, and the gateway credentials:
+//
+//	BAKEOFF_MODELS=vendor/model-a,vendor/model-b \
+//	LLM_BASE_URL=… LLM_API_KEY=… LLM_MODEL=… \
+//	  go test -tags=integration,llmlive ./internal/api/handler/ \
+//	    -run TestBakeoff -timeout 3h -v
+//
+// LLM_MODEL is the FIT model and stays pinned across every candidate — see the pin below.
+// BAKEOFF_MODELS names the turn models being compared, and nothing else varies.
+//
+// The report lands in .cache/ (not in git) and carries every run's tailored CV, because
+// whether a CV is any good is a judgement no number here makes. See
+// openspec/changes/assistant-model-bakeoff/design.md.
+package handler
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/openai"
+
+	"github.com/strelov1/freehire/internal/ai/assistant"
+	"github.com/strelov1/freehire/internal/candidate/atscheck"
+	"github.com/strelov1/freehire/internal/candidate/cv"
+	"github.com/strelov1/freehire/internal/candidate/cvmatch"
+	"github.com/strelov1/freehire/internal/candidate/resume"
+	"github.com/strelov1/freehire/internal/dict/skilltag"
+	"github.com/strelov1/freehire/internal/identity/auth"
+	"github.com/strelov1/freehire/internal/platform/llm"
+	"github.com/strelov1/freehire/internal/platform/modroot"
+)
+
+// bakeoffModelsEnv names the turn models to compare, comma-separated, as the gateway's own
+// catalogue spells them — the same ids the price table is keyed by.
+const bakeoffModelsEnv = "BAKEOFF_MODELS"
+
+// bakeoffRunTimeout bounds ONE autopilot run's HTTP read.
+//
+// An autopilot turn may take thirty rounds and the gateway behind this is bimodal: the same
+// chain lands in 28s on one provider and 90s per stage on another. A deadline tight enough
+// to be interesting would therefore report the gateway's mood as the model's failure, which
+// is the one thing this measurement must not do. It is a runaway guard, not a bound.
+const bakeoffRunTimeout = 25 * time.Minute
+
+// countingModel counts what a turn actually cost.
+//
+// The stream cannot answer this: emitUsage fires on the runner's two terminal paths only, so
+// a thirty-round run reports the LAST call's tokens and says nothing about the other
+// twenty-nine (see bakeoffTally). The bake-off already substitutes the turn model, so it
+// counts at that seam — a measurement problem solved where it costs nothing rather than by
+// changing what every assistant turn in production streams.
+//
+// No lock: the runner drives one model call at a time within a turn, and a bake-off run is
+// one turn.
+type countingModel struct {
+	inner assistant.Model
+	tally *bakeoffTally
+}
+
+func (m *countingModel) Chat(ctx context.Context, msgs []llms.MessageContent, tools []llms.Tool, stream llm.ChatStream) (*llms.ContentChoice, error) {
+	started := time.Now()
+	choice, err := m.inner.Chat(ctx, msgs, tools, stream)
+	// A failed call is a round that happened and was billed for whatever it read before it
+	// died. Counting it with no usage records it as unmeasured — which is what it is — and
+	// keeps the round count honest, so a model that fails on round nine is not reported as
+	// having taken eight.
+	var usage *llm.Usage
+	if choice != nil {
+		usage = llm.UsageFrom(choice)
+	}
+	m.tally.observeCall(usage, time.Since(started))
+	return choice, err
+}
+
+// pinnedFitModel is the fit chain's model, carrying the id it was built for.
+//
+// The pin is the point. Swapping the fit model alongside the turn model would measure two
+// models at once and attribute the difference to one, so the bake-off asserts before every
+// pass that this is still the model LLM_MODEL named — which is what fails if a later edit
+// moves the construction inside the candidate loop.
+type pinnedFitModel struct {
+	llms.Model
+	id string
+}
+
+// bakeoffGateway builds one turn client against the configured gateway, for the named model.
+// *llm.Client is what assistant.Model wants, so this is the value the runner drives.
+func bakeoffGateway(t *testing.T, model string) (*llm.Client, func()) {
+	t.Helper()
+	s := bakeoffSettings(t, model)
+	c, flush, err := llm.NewClient(s, "bakeoff")
+	if err != nil {
+		t.Fatalf("gateway client for %q: %v", model, err)
+	}
+	return c, flush
+}
+
+// bakeoffSettings reads the gateway credentials, skipping when the run has none rather than
+// failing: a machine without them is not a broken bake-off, it is one nobody asked for.
+func bakeoffSettings(t *testing.T, model string) llm.Settings {
+	t.Helper()
+	s := llm.Settings{
+		BaseURL: os.Getenv("LLM_BASE_URL"),
+		APIKey:  os.Getenv("LLM_API_KEY"),
+		Model:   model,
+	}
+	if !s.Enabled() {
+		t.Skip("LLM_BASE_URL/LLM_API_KEY/LLM_MODEL not set")
+	}
+	return s
+}
+
+// bakeoffFitModel builds the raw langchaingo model the harness wraps for the fit chain.
+//
+// A raw model rather than an *llm.Client because newAutopilotHarness takes an llms.Model and
+// wraps it in llm.NewWithModel itself — which lands on llm.DefaultTimeout, the same 90s per
+// stage matchAnalysisLLMTimeout gives the chain in production. The bake-off's fit analysis
+// therefore runs under the deadline the product runs it under, which is the only version of
+// it worth measuring against.
+func bakeoffFitModel(t *testing.T, model string) llms.Model {
+	t.Helper()
+	s := bakeoffSettings(t, model)
+	m, err := openai.New(
+		openai.WithBaseURL(s.BaseURL),
+		openai.WithToken(s.APIKey),
+		openai.WithModel(s.Model),
+	)
+	if err != nil {
+		t.Fatalf("fit model %q: %v", model, err)
+	}
+	return m
+}
+
+// bakeoffCandidates reads the models to compare. Absent, the bake-off skips rather than
+// inventing a list: which models are worth a paid run is a decision, not a default.
+func bakeoffCandidates(t *testing.T) []string {
+	t.Helper()
+	raw := strings.TrimSpace(os.Getenv(bakeoffModelsEnv))
+	if raw == "" {
+		t.Skipf("%s not set; name the turn models to compare, comma-separated", bakeoffModelsEnv)
+	}
+	var out []string
+	seen := map[string]bool{}
+	for _, m := range strings.Split(raw, ",") {
+		m = strings.TrimSpace(m)
+		if m == "" {
+			continue
+		}
+		// A model listed twice would be two rows the report cannot tell apart, and the
+		// second would be read as a second opinion rather than a duplicate.
+		if seen[m] {
+			t.Fatalf("%s names %q twice", bakeoffModelsEnv, m)
+		}
+		seen[m] = true
+		out = append(out, m)
+	}
+	if len(out) == 0 {
+		t.Fatalf("%s is set but names no model", bakeoffModelsEnv)
+	}
+	return out
+}
+
+// bakeoffToolchain resolves the renderer and text extractor the scores read, failing rather
+// than skipping: a bake-off that spends money and reports no score is worse than one that
+// refuses to start.
+func bakeoffToolchain(t *testing.T) (cv.Renderer, func([]byte) (string, error)) {
+	t.Helper()
+	bin, err := exec.LookPath("typst")
+	if err != nil {
+		t.Fatal("typst is not installed; the scores read the RENDERED CV and cannot be computed without it")
+	}
+	if _, err := exec.LookPath("pdftotext"); err != nil {
+		t.Fatal("pdftotext is not installed; the scores read the rendered CV's text layer")
+	}
+	return cv.NewTypstRenderer(bin), resume.ExtractPDFText
+}
+
+// runBakeoffAutopilot drives one autopilot run over a real socket and feeds every streamed
+// frame to the tally.
+//
+// Not app.Test: that helper's 10-second ceiling is shorter than a single live round, so
+// every run would be reported as a failure of the model rather than of the test client.
+func runBakeoffAutopilot(t *testing.T, addr, sessionID, cookie string, tally *bakeoffTally) error {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), bakeoffRunTimeout)
+	defer cancel()
+
+	url := "http://" + addr + "/api/v1/assistant/sessions/" + sessionID + "/autopilot"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: cookie})
+
+	// No client timeout: the context already bounds the whole read, and a client timeout
+	// would additionally cap the idle gap between frames — which on this gateway is a
+	// normal long round, not a hang.
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return fmt.Errorf("open the run: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != fiber.StatusOK {
+		return fmt.Errorf("autopilot returned %d", resp.StatusCode)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	// A tool result carrying a vacancy description is far past bufio's 64 KB default, and a
+	// truncated frame reads as a stream that ended.
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		payload, ok := strings.CutPrefix(scanner.Text(), "data: ")
+		if !ok {
+			continue
+		}
+		var e assistant.Event
+		if err := json.Unmarshal([]byte(payload), &e); err != nil {
+			// A frame we cannot read is a hole in the measurement, not a failed run: the
+			// heartbeat and the open comment are not events at all, and they arrive on
+			// lines this prefix never matches.
+			continue
+		}
+		tally.observeEvent(e)
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("read the run's stream: %w", err)
+	}
+	return nil
+}
+
+// scoreBakeoffRun computes the two deterministic scores over the tailored CV, and returns
+// the rendered text the report carries.
+//
+// Both scores read the RENDERED text layer rather than the stored document, which is the
+// whole point: a bullet the active template never prints contributes nothing to either.
+func scoreBakeoffRun(t *testing.T, h *cvHandlers, userID int64, cvID uuid.UUID, base atscheck.Report, c bakeoffCase, jobSkills []string) (cvmatch.Score, atscheck.Delta, string, error) {
+	t.Helper()
+	ctx := context.Background()
+
+	rec, err := h.cvStore.Get(ctx, cvID, userID)
+	if err != nil {
+		return cvmatch.Score{}, atscheck.Delta{}, "", fmt.Errorf("read the tailored cv: %w", err)
+	}
+	tmpl, err := cv.ResolveTemplate(rec.TemplateID)
+	if err != nil {
+		return cvmatch.Score{}, atscheck.Delta{}, "", fmt.Errorf("resolve template: %w", err)
+	}
+	text, err := h.renderedCVText(ctx, rec.Document, tmpl)
+	if err != nil {
+		return cvmatch.Score{}, atscheck.Delta{}, "", fmt.Errorf("render the tailored cv: %w", err)
+	}
+
+	skills := skilltag.Parse(text, skilltag.WithResumeAcronyms())
+	match := cvmatch.Compute(cvmatch.Input{
+		CVText: text, CVSkills: skills,
+		JobTitle: c.Vacancy.Title, JobSkills: jobSkills,
+	})
+	delta := atscheck.Compare(base, atscheck.Score(text, skills, jobSkills))
+	return match, delta, text, nil
+}
+
+// bakeoffReport is what one bake-off writes out: the rows, and the two facts without which a
+// row cannot be read a week later — when its prices were captured, and whose CV it ran.
+type bakeoffReport struct {
+	Ran             string       `json:"ran"`
+	PricesCaptured  string       `json:"prices_captured"`
+	PricesSource    string       `json:"prices_source"`
+	ProfileCaptured string       `json:"profile_captured"`
+	CasesCaptured   string       `json:"cases_captured"`
+	FitModel        string       `json:"fit_model"`
+	Rows            []bakeoffRow `json:"rows"`
+}
+
+// writeBakeoffReport puts the report under .cache/, which is not in git — it carries the
+// tailored CVs, and those are the candidate's own document.
+func writeBakeoffReport(t *testing.T, rep bakeoffReport) string {
+	t.Helper()
+	root, err := modroot.Find()
+	if err != nil {
+		t.Fatalf("locate the module root: %v", err)
+	}
+	dir := filepath.Join(root, ".cache")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("make %s: %v", dir, err)
+	}
+	path := filepath.Join(dir, "bakeoff-"+time.Now().UTC().Format("20060102-150405")+".json")
+	blob, err := json.MarshalIndent(rep, "", "  ")
+	if err != nil {
+		t.Fatalf("encode the report: %v", err)
+	}
+	if err := os.WriteFile(path, blob, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+// printBakeoffTable prints the ranked rows to the test log, best first.
+func printBakeoffTable(t *testing.T, rows []bakeoffRow) {
+	t.Helper()
+	t.Log("model | case | match | ats | rounds | in/out/cached | cache | cost | outcome")
+	for _, r := range rows {
+		match, ats := "—", "—"
+		if r.Match != nil {
+			match = fmt.Sprintf("%d", r.Match.Overall)
+		}
+		if r.ATS != nil {
+			ats = fmt.Sprintf("%+d", r.ATS.Change)
+		}
+		cost := "unknown"
+		if r.Cost.Known {
+			cost = fmt.Sprintf("$%.4f", r.Cost.USD)
+			if r.Cost.Floor {
+				cost = "≥" + cost
+			}
+		}
+		outcome := r.Tally.Stop
+		if r.Failure != "" {
+			outcome = "FAILED: " + r.Failure
+		}
+		verdict := r.Tally.cacheVerdict()
+		cache := verdict.State
+		if verdict.State == cacheObserved {
+			cache = fmt.Sprintf("%s %.0f%%", verdict.State, verdict.Share*100)
+		}
+		t.Logf("%s | %s | %s | %s | %d | %d/%d/%d | %s | %s | %s",
+			r.Model, r.Case, match, ats, r.Tally.Rounds,
+			r.Tally.Input, r.Tally.Output, r.Tally.CachedInput, cache, cost, outcome)
+	}
+}
+
+// TestBakeoffRunsEveryCandidateOverEveryCase is the bake-off.
+//
+// One fresh database per MODEL, not per run: seeding once and running every model against
+// the same database would make the first model's edits the second's starting point. Per-run
+// isolation would be stricter and buys nothing — cases within one model's pass bind their
+// own CV copy and their own vacancy.
+//
+// A run that fails, is cancelled or hits the step cap becomes a row carrying that outcome
+// and the pass continues. Only failing to read the case set ends the bake-off: every model
+// running over nothing would report a clean sweep of zero rows, which reads exactly like a
+// bake-off that found no difference between them.
+func TestBakeoffRunsEveryCandidateOverEveryCase(t *testing.T) {
+	candidates := bakeoffCandidates(t)
+	renderer, extract := bakeoffToolchain(t)
+
+	set, err := loadBakeoffCases(bakeoffCaseFixture)
+	if err != nil {
+		t.Fatalf("loadBakeoffCases: %v", err)
+	}
+	profile := loadBakeoffProfileOrSkip(t)
+
+	priceBlob, err := os.ReadFile(filepath.FromSlash(bakeoffPriceFixture))
+	if err != nil {
+		t.Fatalf("read the price table: %v", err)
+	}
+	prices, err := parseBakeoffPrices(priceBlob)
+	if err != nil {
+		t.Fatalf("parseBakeoffPrices: %v", err)
+	}
+
+	// The fit model is built ONCE, outside the candidate loop, and pinned.
+	fitID := os.Getenv("LLM_MODEL")
+	fitM := &pinnedFitModel{Model: bakeoffFitModel(t, fitID), id: fitID}
+
+	var rows []bakeoffRow
+	for _, model := range candidates {
+		// The assertion task 5.2 asks for, made where it can actually fail: if a later edit
+		// rebinds the fit chain to the candidate, this is what stops the run rather than
+		// letting it publish two models measured as one.
+		if fitM.id != fitID {
+			t.Fatalf("the fit model moved to %q while measuring %q; only the turn model may vary", fitM.id, model)
+		}
+		rows = append(rows, runBakeoffPass(t, model, set, profile, prices, fitM, renderer, extract)...)
+	}
+
+	rankBakeoffRows(rows)
+	printBakeoffTable(t, rows)
+	path := writeBakeoffReport(t, bakeoffReport{
+		Ran:             time.Now().UTC().Format(time.RFC3339),
+		PricesCaptured:  prices.Captured,
+		PricesSource:    prices.Source,
+		ProfileCaptured: profile.Captured,
+		CasesCaptured:   set.Captured,
+		FitModel:        fitID,
+		Rows:            rows,
+	})
+	t.Logf("report written to %s", path)
+
+	// A bake-off whose every run failed is a report of a broken gateway wearing the shape of
+	// a model comparison, and nothing downstream could tell them apart.
+	var completed int
+	for _, r := range rows {
+		if r.Failure == "" {
+			completed++
+		}
+	}
+	if completed == 0 {
+		t.Fatalf("every one of %d runs failed; the report is a measurement of nothing", len(rows))
+	}
+}
+
+// runBakeoffPass runs one candidate model over every case, on a database of its own.
+func runBakeoffPass(
+	t *testing.T,
+	model string,
+	set bakeoffCaseSet,
+	profile bakeoffProfile,
+	prices bakeoffPriceTable,
+	fitM *pinnedFitModel,
+	renderer cv.Renderer,
+	extract func([]byte) (string, error),
+) []bakeoffRow {
+	t.Helper()
+
+	turnClient, flush := bakeoffGateway(t, model)
+	defer flush()
+
+	pool := startPostgres(t)
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	userID, cookie := assistantUser(t, pool, iss, "bakeoff@example.test", true)
+	if banked := seedBakeoffProfile(t, pool, userID, profile); banked == 0 {
+		t.Fatal("the profile banked no achievement; every edit would bounce off the evidence gate")
+	}
+
+	rows := make([]bakeoffRow, 0, len(set.Cases))
+	for _, c := range set.Cases {
+		// The tally is per RUN, and the model wrapper closes over it, so the harness is
+		// rebuilt per case rather than reused.
+		tally := &bakeoffTally{}
+		h, app := newAutopilotHarness(t, pool, iss, &countingModel{inner: turnClient, tally: tally}, fitM,
+			withRenderedCVScoring(renderer, extract))
+
+		sess, cvID, _ := seedBakeoffCase(t, pool, h, userID, c, string(profile.CV))
+
+		// The base report is taken BEFORE the run, off the same document the run starts
+		// from, so the ATS delta describes what this run changed and not what the profile
+		// already was.
+		base, err := bakeoffBaseReport(t, h.cv, userID, cvID, c)
+		if err != nil {
+			rows = append(rows, bakeoffRow{Model: model, Case: c.ID, Vacancy: c.Vacancy.Title,
+				Tally: *tally, Cost: prices.Rates.cost(model, *tally), Failure: err.Error()})
+			continue
+		}
+
+		addr := serveOnSocket(t, app)
+		runErr := runBakeoffAutopilot(t, addr, sess.ID.String(), cookie, tally)
+
+		row := bakeoffRow{
+			Model: model, Case: c.ID, Vacancy: c.Vacancy.Title,
+			Tally: *tally, Cost: prices.Rates.cost(model, *tally),
+		}
+		if runErr != nil {
+			row.Failure = runErr.Error()
+			rows = append(rows, row)
+			continue
+		}
+
+		match, delta, text, err := scoreBakeoffRun(t, h.cv, userID, cvID, base, c, bakeoffJobSkills(c))
+		if err != nil {
+			row.Failure = err.Error()
+			rows = append(rows, row)
+			continue
+		}
+		row.Match, row.ATS, row.TailoredCV = &match, &delta, text
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// bakeoffBaseReport scores the document the run STARTS from, so the ATS delta measures the
+// run rather than the profile.
+func bakeoffBaseReport(t *testing.T, h *cvHandlers, userID int64, cvID uuid.UUID, c bakeoffCase) (atscheck.Report, error) {
+	t.Helper()
+	ctx := context.Background()
+	rec, err := h.cvStore.Get(ctx, cvID, userID)
+	if err != nil {
+		return atscheck.Report{}, fmt.Errorf("read the pre-run cv: %w", err)
+	}
+	tmpl, err := cv.ResolveTemplate(rec.TemplateID)
+	if err != nil {
+		return atscheck.Report{}, fmt.Errorf("resolve template: %w", err)
+	}
+	text, err := h.renderedCVText(ctx, rec.Document, tmpl)
+	if err != nil {
+		return atscheck.Report{}, fmt.Errorf("render the pre-run cv: %w", err)
+	}
+	return atscheck.Score(text, skilltag.Parse(text, skilltag.WithResumeAcronyms()), bakeoffJobSkills(c)), nil
+}
+
+// bakeoffJobSkills reads the vacancy's own skills out of its posting with the same
+// dictionary the catalogue tags jobs with, so both scores are grounded in the posting rather
+// than in a list written for this test.
+func bakeoffJobSkills(c bakeoffCase) []string {
+	return skilltag.Parse(c.Vacancy.Title + "\n" + c.Vacancy.Description)
+}

--- a/internal/api/handler/assistant_bakeoff_run_llmlive_test.go
+++ b/internal/api/handler/assistant_bakeoff_run_llmlive_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/strelov1/freehire/internal/candidate/resume"
 	"github.com/strelov1/freehire/internal/dict/skilltag"
 	"github.com/strelov1/freehire/internal/identity/auth"
+	"github.com/strelov1/freehire/internal/platform/db"
 	"github.com/strelov1/freehire/internal/platform/llm"
 	"github.com/strelov1/freehire/internal/platform/modroot"
 )
@@ -447,7 +448,7 @@ func runBakeoffPass(
 		// rebuilt per case rather than reused.
 		tally := &bakeoffTally{}
 		h, app := newAutopilotHarness(t, pool, iss, &countingModel{inner: turnClient, tally: tally}, fitM,
-			withRenderedCVScoring(renderer, extract))
+			withRenderedCVScoring(renderer, extract), withTrackingTools(pool, db.New(pool)))
 
 		sess, cvID, _ := seedBakeoffCase(t, pool, h, userID, c, string(profile.CV))
 

--- a/internal/api/handler/assistant_bakeoff_run_llmlive_test.go
+++ b/internal/api/handler/assistant_bakeoff_run_llmlive_test.go
@@ -410,6 +410,14 @@ func runBakeoffPass(
 
 	turnClient, flush := bakeoffGateway(t, model)
 	defer flush()
+	// The deadline production gives a turn, not llm.DefaultTimeout.
+	//
+	// They differ by a factor of two — 180s against 90s — and the gap is not academic: the
+	// first full bake-off (2026-09-08) had every flagship run die on `llm: chat: context
+	// deadline exceeded` after two rounds, so all three rows reported the BASE CV, unedited,
+	// and scored identically to the other candidate's. A bake-off run under a deadline the
+	// product does not use measures the test rig.
+	turn := turnClient.WithTimeout(assistantLLMTimeout)
 
 	pool := startPostgres(t)
 	iss := auth.NewIssuer("test-secret", time.Hour)
@@ -423,7 +431,7 @@ func runBakeoffPass(
 		// The tally is per RUN, and the model wrapper closes over it, so the harness is
 		// rebuilt per case rather than reused.
 		tally := &bakeoffTally{}
-		h, app := newAutopilotHarness(t, pool, iss, &countingModel{inner: turnClient, tally: tally}, nil,
+		h, app := newAutopilotHarness(t, pool, iss, &countingModel{inner: turn, tally: tally}, nil,
 			withFitClient(fitClient), withRenderedCVScoring(renderer, extract), withTrackingTools(pool, db.New(pool)))
 
 		sess, cvID, _ := seedBakeoffCase(t, pool, h, userID, c, string(profile.CV))

--- a/internal/api/handler/assistant_bakeoff_run_llmlive_test.go
+++ b/internal/api/handler/assistant_bakeoff_run_llmlive_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 	"github.com/tmc/langchaingo/llms"
-	"github.com/tmc/langchaingo/llms/openai"
 
 	"github.com/strelov1/freehire/internal/ai/assistant"
 	"github.com/strelov1/freehire/internal/candidate/atscheck"
@@ -92,17 +91,6 @@ func (m *countingModel) Chat(ctx context.Context, msgs []llms.MessageContent, to
 	return choice, err
 }
 
-// pinnedFitModel is the fit chain's model, carrying the id it was built for.
-//
-// The pin is the point. Swapping the fit model alongside the turn model would measure two
-// models at once and attribute the difference to one, so the bake-off asserts before every
-// pass that this is still the model LLM_MODEL named — which is what fails if a later edit
-// moves the construction inside the candidate loop.
-type pinnedFitModel struct {
-	llms.Model
-	id string
-}
-
 // bakeoffGateway builds one turn client against the configured gateway, for the named model.
 // *llm.Client is what assistant.Model wants, so this is the value the runner drives.
 func bakeoffGateway(t *testing.T, model string) (*llm.Client, func()) {
@@ -128,27 +116,6 @@ func bakeoffSettings(t *testing.T, model string) llm.Settings {
 		t.Skip("LLM_BASE_URL/LLM_API_KEY/LLM_MODEL not set")
 	}
 	return s
-}
-
-// bakeoffFitModel builds the raw langchaingo model the harness wraps for the fit chain.
-//
-// A raw model rather than an *llm.Client because newAutopilotHarness takes an llms.Model and
-// wraps it in llm.NewWithModel itself — which lands on llm.DefaultTimeout, the same 90s per
-// stage matchAnalysisLLMTimeout gives the chain in production. The bake-off's fit analysis
-// therefore runs under the deadline the product runs it under, which is the only version of
-// it worth measuring against.
-func bakeoffFitModel(t *testing.T, model string) llms.Model {
-	t.Helper()
-	s := bakeoffSettings(t, model)
-	m, err := openai.New(
-		openai.WithBaseURL(s.BaseURL),
-		openai.WithToken(s.APIKey),
-		openai.WithModel(s.Model),
-	)
-	if err != nil {
-		t.Fatalf("fit model %q: %v", model, err)
-	}
-	return m
 }
 
 // bakeoffCandidates reads the models to compare. Absent, the bake-off skips rather than
@@ -379,18 +346,27 @@ func TestBakeoffRunsEveryCandidateOverEveryCase(t *testing.T) {
 	}
 
 	// The fit model is built ONCE, outside the candidate loop, and pinned.
+	// Built through llm.NewClient, never through the harness's plain wrapper: the wrapper
+	// installs no HTTP transport, and `reasoning_effort` is written by one — so Stage 1's
+	// llm.ReasoningNone is silently dropped and the stage blows its deadline on every
+	// analysis. See withFitClient.
+	//
+	// WithTimeout matches what production gives the chain, so the analysis the bake-off runs
+	// against is the one the product runs.
 	fitID := os.Getenv("LLM_MODEL")
-	fitM := &pinnedFitModel{Model: bakeoffFitModel(t, fitID), id: fitID}
+	fitBase, flushFit := bakeoffGateway(t, fitID)
+	defer flushFit()
+	fitClient := fitBase.WithTimeout(matchAnalysisLLMTimeout)
 
 	var rows []bakeoffRow
 	for _, model := range candidates {
 		// The assertion task 5.2 asks for, made where it can actually fail: if a later edit
 		// rebinds the fit chain to the candidate, this is what stops the run rather than
 		// letting it publish two models measured as one.
-		if fitM.id != fitID {
-			t.Fatalf("the fit model moved to %q while measuring %q; only the turn model may vary", fitM.id, model)
+		if got := fitClient.ModelID(); got != fitID {
+			t.Fatalf("the fit model moved to %q while measuring %q; only the turn model may vary", got, model)
 		}
-		rows = append(rows, runBakeoffPass(t, model, set, profile, prices, fitM, renderer, extract)...)
+		rows = append(rows, runBakeoffPass(t, model, set, profile, prices, fitClient, renderer, extract)...)
 	}
 
 	rankBakeoffRows(rows)
@@ -426,7 +402,7 @@ func runBakeoffPass(
 	set bakeoffCaseSet,
 	profile bakeoffProfile,
 	prices bakeoffPriceTable,
-	fitM *pinnedFitModel,
+	fitClient *llm.Client,
 	renderer cv.Renderer,
 	extract func([]byte) (string, error),
 ) []bakeoffRow {
@@ -447,8 +423,8 @@ func runBakeoffPass(
 		// The tally is per RUN, and the model wrapper closes over it, so the harness is
 		// rebuilt per case rather than reused.
 		tally := &bakeoffTally{}
-		h, app := newAutopilotHarness(t, pool, iss, &countingModel{inner: turnClient, tally: tally}, fitM,
-			withRenderedCVScoring(renderer, extract), withTrackingTools(pool, db.New(pool)))
+		h, app := newAutopilotHarness(t, pool, iss, &countingModel{inner: turnClient, tally: tally}, nil,
+			withFitClient(fitClient), withRenderedCVScoring(renderer, extract), withTrackingTools(pool, db.New(pool)))
 
 		sess, cvID, _ := seedBakeoffCase(t, pool, h, userID, c, string(profile.CV))
 

--- a/internal/api/handler/assistant_bakeoff_seed_integration_test.go
+++ b/internal/api/handler/assistant_bakeoff_seed_integration_test.go
@@ -10,6 +10,9 @@ package handler
 
 import (
 	"context"
+	"errors"
+	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +20,10 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/strelov1/freehire/internal/ai/assistant"
+	"github.com/strelov1/freehire/internal/candidate/cv"
+	"github.com/strelov1/freehire/internal/candidate/cvmatch"
+	"github.com/strelov1/freehire/internal/candidate/perioddate"
+	"github.com/strelov1/freehire/internal/candidate/resume"
 	"github.com/strelov1/freehire/internal/dict/normalize"
 	"github.com/strelov1/freehire/internal/identity/auth"
 )
@@ -102,6 +109,112 @@ func TestBakeoffSeedBindsTheSessionToItsOwnCaseAndPosting(t *testing.T) {
 	}
 	if stored != c.Vacancy.Description {
 		t.Errorf("stored description is %d chars, the case carries %d", len(stored), len(c.Vacancy.Description))
+	}
+}
+
+// scorableBakeoffCV is a document Typst renders to a page with a readable text layer: a
+// header, a summary, one employment with bullets, and a skills group. It is written here
+// rather than taken from the profile fixture because the fixture is a real CV and is not in
+// this repository — a seam guarded only by a file CI cannot have is a seam CI never checks.
+//
+// It says "Golang" and never a bare "Go", which is not stylistic: skilltag declines the bare
+// word (it is a preposition far more often than a language), so a CV written that way parses
+// with the skill missing and the test would read a working toolchain as a broken one.
+func scorableBakeoffCV() cv.Document {
+	return cv.Document{
+		Margins: cv.DefaultMargins(),
+		Header:  cv.Header{FullName: "Jane Roe", Email: "jane@example.test", Phone: "+1 415 555 0134"},
+		Summary: "Backend engineer. Core stack: Golang, Kafka, PostgreSQL.",
+		Experience: []cv.ExperienceItem{{
+			Role: "Senior Backend Engineer", Company: "Acme",
+			Start: &perioddate.PeriodDate{Year: 2019}, Current: true,
+			Bullets: []string{"Built Golang services carrying 2M requests a day.", "Ran the Kafka pipelines four teams read from."},
+		}},
+		Skills: []cv.SkillGroup{{Group: "Languages", Items: []string{"Golang", "Kafka", "PostgreSQL"}}},
+	}
+}
+
+// The bake-off ranks on cvmatch and atscheck, and BOTH read the text layer of the rendered
+// PDF rather than the stored document (see renderedCVText). A harness with no renderer does
+// not fail that read — it degrades to an unavailable score — so a bake-off run over one
+// would finish green and report a column of absences, which reads exactly like a set of
+// models that all tailored nothing.
+//
+// This is the seam the bake-off needs from newAutopilotHarness, and it is checked here under
+// the integration tag alone so a regression costs no tokens to catch.
+func TestBakeoffHarnessScoresTheRenderedTailoredCV(t *testing.T) {
+	bin, err := exec.LookPath("typst")
+	if err != nil {
+		t.Skip("typst not installed; skipping rendered-CV scoring")
+	}
+	if _, err := exec.LookPath("pdftotext"); err != nil {
+		t.Skip("pdftotext not installed; skipping rendered-CV scoring")
+	}
+	pool := startPostgres(t)
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	h, _ := newAutopilotHarness(t, pool, iss, walkedTheRequirements(), nil,
+		withRenderedCVScoring(cv.NewTypstRenderer(bin), resume.ExtractPDFText))
+	userID, _ := assistantUser(t, pool, iss, "bakeoff-score@example.test", true)
+
+	set, err := loadBakeoffCases(bakeoffCaseFixture)
+	if err != nil {
+		t.Fatalf("loadBakeoffCases: %v", err)
+	}
+	c := set.Cases[0]
+	_, cvID, _ := seedBakeoffCase(t, pool, h, userID, c, string(mustJSON(t, scorableBakeoffCV())))
+
+	rec, err := h.cv.cvStore.Get(context.Background(), cvID, userID)
+	if err != nil {
+		t.Fatalf("read seeded cv: %v", err)
+	}
+	tmpl, err := cv.ResolveTemplate(rec.TemplateID)
+	if err != nil {
+		t.Fatalf("resolve template: %v", err)
+	}
+
+	// The text layer first, and named: a score can come out positive off a title alone, so
+	// asserting only on the number would pass over a toolchain that rendered nothing.
+	text, err := h.cv.renderedCVText(context.Background(), rec.Document, tmpl)
+	if err != nil {
+		t.Fatalf("render the seeded cv: %v", err)
+	}
+	for _, want := range []string{"Jane Roe", "Kafka"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("rendered text layer is missing %q; the scores would read an empty document:\n%s", want, text)
+		}
+	}
+
+	score, err := h.cv.cvJobMatchScore(context.Background(), rec.Document, tmpl, cvmatch.Input{
+		JobTitle:  c.Vacancy.Title,
+		JobSkills: []string{"go", "kafka", "terraform"},
+	})
+	if err != nil {
+		t.Fatalf("score the rendered cv: %v", err)
+	}
+	if len(score.Contributing) == 0 {
+		t.Fatal("nothing was scored; the report would rank an absence")
+	}
+	// The document states Go and Kafka and not Terraform, so the score has to have read it —
+	// a keyword split it could not produce from the title or from an empty text layer.
+	if len(score.MissingSkills) != 1 || score.MissingSkills[0] != "terraform" {
+		t.Errorf("missing skills = %v, want [terraform] read off the rendered CV", score.MissingSkills)
+	}
+	if score.Overall <= 0 {
+		t.Errorf("overall = %d, want a positive score off the rendered text layer", score.Overall)
+	}
+}
+
+// The default is unchanged: a harness nobody asked for the toolchain has none, so the six
+// existing callers keep the handler they had. The bake-off's option is additive or it is a
+// change to every autopilot test that never asked for one.
+func TestAutopilotHarnessHasNoCVToolchainByDefault(t *testing.T) {
+	pool := startPostgres(t)
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	h, _ := newAutopilotHarness(t, pool, iss, walkedTheRequirements(), nil)
+
+	_, err := h.cv.renderedCVText(context.Background(), scorableBakeoffCV(), cv.Template{})
+	if !errors.Is(err, errNoRenderer) {
+		t.Errorf("renderedCVText err = %v, want errNoRenderer — the harness must not acquire a toolchain nobody asked it for", err)
 	}
 }
 

--- a/internal/api/handler/assistant_cv_tools.go
+++ b/internal/api/handler/assistant_cv_tools.go
@@ -30,6 +30,34 @@ import (
 // caller's strictness does not reach through it, and that strictness is load-bearing: an
 // undefined field silently dropped is how an agent once rewrote the wrong experience entry
 // while reading success back.
+// evidenceGoesOnTheOp is the refusal a misplaced evidence_id gets. It names the PLACE, which
+// is the whole point: the decoder's own `unknown field "evidence_id"` names only the field,
+// and a model that cannot tell what to change re-sends what it sent.
+const evidenceGoesOnTheOp = "evidence_id goes on each op inside `ops`, not on the call itself — " +
+	"put it beside the kind, path and value of the edit whose claim it backs"
+
+// adoptCallLevelEvidence reads a call-level evidence_id onto the op it can only have meant.
+//
+// Exactly one op with no evidence of its own: the intent is not in doubt, so the batch is
+// read through — the same leniency opBatch.UnmarshalJSON already extends to a batch packaged
+// as a string. Anything else is refused:
+//
+//   - several ops, because one achievement's evidence spread across several claims is what
+//     the provenance gate exists to stop, and it would be granted here by a typo;
+//   - an op that already names one, because which claim the id was meant to back is exactly
+//     what is unclear, and picking either is inventing an answer.
+func adoptCallLevelEvidence(ops opBatch, evidenceID string) error {
+	evidenceID = strings.TrimSpace(evidenceID)
+	if evidenceID == "" {
+		return nil
+	}
+	if len(ops) != 1 || ops[0].EvidenceID != "" {
+		return errors.New(evidenceGoesOnTheOp)
+	}
+	ops[0].EvidenceID = evidenceID
+	return nil
+}
+
 type opBatch []cvedit.Op
 
 func (b *opBatch) UnmarshalJSON(data []byte) error {
@@ -543,8 +571,10 @@ func (h *assistantHandlers) cvEditTool(cvID uuid.UUID, batchID uuid.UUID) assist
 			" bullets; when full, " +
 			"`set` an existing index or `remove` one before inserting — an insert past the cap is refused " +
 			"and no existing bullet is deleted. Anything that states what the candidate did (a bullet, a " +
-			"summary, a technology, a skill) needs `evidence_id` from experience_search; if the bank holds " +
-			"nothing on the point, ask the candidate and record their answer with experience_add first. " +
+			"summary, a technology, a skill) needs `evidence_id` from experience_search — ON THE OP, " +
+			"beside its kind, path and value, NOT on the call beside `note` and `requirement`; if the " +
+			"bank holds nothing on the point, ask the candidate and record their answer with " +
+			"experience_add first. " +
 			"Contact details are not editable here. If this batch closes a requirement from cv_context, " +
 			"pass `requirement` and `requirement_status` — the report updates in this same call, so you " +
 			"do not need a separate tailor_report call for it.",
@@ -581,8 +611,21 @@ func (h *assistantHandlers) cvEditTool(cvID uuid.UUID, batchID uuid.UUID) assist
 				Note              string  `json:"note"`
 				Requirement       string  `json:"requirement"`
 				RequirementStatus string  `json:"requirement_status"`
+				// EvidenceID is NOT part of this call — it belongs on the op whose claim it
+				// backs. It is read here so the mistake can be answered rather than met with
+				// DecodeArgs's `unknown field "evidence_id"`, which names the field and not
+				// the place: measured on prod 2026-08-25..09-08, 21 refusals, and the model
+				// answered each by re-sending the identical call.
+				//
+				// The mistake is a reasonable one. `requirement` and `requirement_status` ARE
+				// call-level and describe the batch, so "batch metadata goes at the top"
+				// generalises straight onto this.
+				EvidenceID string `json:"evidence_id"`
 			}
 			if err := assistant.DecodeArgs(raw, &in); err != nil {
+				return nil, err
+			}
+			if err := adoptCallLevelEvidence(in.Ops, in.EvidenceID); err != nil {
 				return nil, err
 			}
 			requirement := strings.TrimSpace(in.Requirement)

--- a/internal/api/handler/assistant_cv_tools_test.go
+++ b/internal/api/handler/assistant_cv_tools_test.go
@@ -894,3 +894,73 @@ func TestRequestConfirmationToolAllowsAnEmptyQuestion(t *testing.T) {
 		t.Errorf("err = %v, want a claim with no question accepted", err)
 	}
 }
+
+// A model puts evidence_id beside `ops` rather than inside the op it backs, and the mistake
+// is a reasonable one: `requirement` and `requirement_status` ARE call-level and describe the
+// batch, so "batch metadata goes at the top" generalises straight onto evidence_id.
+//
+// What it used to get back was `invalid arguments: json: unknown field "evidence_id"`, which
+// names the field and not the place, so the model re-sent the identical call and was refused
+// again. Measured on prod 2026-08-25..09-08: 21 refusals, and 20 of them carried exactly ONE
+// op — an edit whose intent was never in doubt.
+//
+// One op is therefore read through, the same leniency TestCVEditToolAcceptsOpsAsAJSONString
+// applies to packaging. The op keeps whatever it already carries; nothing is guessed.
+func TestCVEditToolReadsACallLevelEvidenceIDOntoItsOnlyOp(t *testing.T) {
+	bank := newStubBank()
+	atom := bank.add(3, experience.Atom{Claim: "Senior backend engineer", Provenance: experience.ProvenanceStatedInChat})
+	a, repo := cvToolsAPIWithBank(t, oneExperienceCV, bank)
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9, uuid.New()), "cv_edit")
+	_, err := tool.Run(context.Background(), 3, json.RawMessage(
+		`{"ops":[{"kind":"set","path":"summary","value":"Senior backend engineer"}],`+
+			`"note":"n","evidence_id":"`+atom.ID.String()+`"}`))
+	if err != nil {
+		t.Fatalf("cv_edit: %v", err)
+	}
+	if !strings.Contains(string(repo.written), "Senior backend engineer") {
+		t.Errorf("stored document = %s, want the edit to have landed", repo.written)
+	}
+}
+
+// More than one op is NOT read through. A single id spread across several edits would attach
+// one achievement's evidence to claims it may not back, which is the one thing the provenance
+// gate exists to stop — so the batch is refused, and the refusal says where the field goes so
+// the next attempt can differ from this one.
+func TestCVEditToolRefusesACallLevelEvidenceIDAcrossSeveralOps(t *testing.T) {
+	bank := newStubBank()
+	atom := bank.add(3, experience.Atom{Claim: "Senior backend engineer", Provenance: experience.ProvenanceStatedInChat})
+	a, _ := cvToolsAPIWithBank(t, oneExperienceCV, bank)
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9, uuid.New()), "cv_edit")
+	_, err := tool.Run(context.Background(), 3, json.RawMessage(
+		`{"ops":[{"kind":"set","path":"summary","value":"Senior backend engineer"},`+
+			`{"kind":"set","path":"experience[0].role","value":"Staff Engineer"}],`+
+			`"evidence_id":"`+atom.ID.String()+`"}`))
+	if err == nil {
+		t.Fatal("two ops shared one call-level evidence_id and were applied; the gate must refuse")
+	}
+	if !strings.Contains(err.Error(), "on each op") {
+		t.Errorf("refusal = %q, want it to say where evidence_id belongs", err)
+	}
+}
+
+// An op that already names its own evidence is not overwritten, and the disagreement is not
+// resolved by picking one: which claim the id was meant to back is exactly what is unclear.
+func TestCVEditToolRefusesACallLevelEvidenceIDWhenTheOpAlreadyNamesOne(t *testing.T) {
+	bank := newStubBank()
+	atom := bank.add(3, experience.Atom{Claim: "Senior backend engineer", Provenance: experience.ProvenanceStatedInChat})
+	other := bank.add(3, experience.Atom{Claim: "Ran the payments cluster", Provenance: experience.ProvenanceStatedInChat})
+	a, _ := cvToolsAPIWithBank(t, oneExperienceCV, bank)
+
+	tool := toolByName(t, a.assistantCVTools(testCVID, 9, uuid.New()), "cv_edit")
+	_, err := tool.Run(context.Background(), 3, json.RawMessage(
+		`{"ops":[{"kind":"set","path":"summary","value":"Senior backend engineer","evidence_id":"`+atom.ID.String()+`"}],`+
+			`"evidence_id":"`+other.ID.String()+`"}`))
+	if err == nil {
+		t.Fatal("two different evidence ids were reconciled silently")
+	}
+	if !strings.Contains(err.Error(), "on each op") {
+		t.Errorf("refusal = %q, want it to say where evidence_id belongs", err)
+	}
+}

--- a/internal/api/handler/assistant_profile_tool.go
+++ b/internal/api/handler/assistant_profile_tool.go
@@ -45,6 +45,13 @@ func (h *assistantHandlers) getProfileTool() assistant.Tool {
 			"themselves; read those with experience_search when you need them. Takes no arguments.",
 		Schema: map[string]any{"type": "object", "properties": map[string]any{}},
 		Run: func(ctx context.Context, userID int64, _ json.RawMessage) (any, error) {
+			// Registered for every session, so it is registered on every assembly — and the
+			// assistant's constructor takes each surface as a pointer that may be nil (it
+			// guards cvH itself). Without this the absence is a nil dereference inside the
+			// SSE stream's goroutine, which the candidate reads as a turn that died.
+			if h.profile == nil || h.profile.userProfile == nil {
+				return nil, errors.New("the saved profile is not available")
+			}
 			profile, err := h.profile.userProfile.Get(ctx, userID)
 			if errors.Is(err, userprofile.ErrNotFound) {
 				return noProfileResult{

--- a/internal/api/handler/assistant_tools.go
+++ b/internal/api/handler/assistant_tools.go
@@ -102,7 +102,7 @@ func (h *assistantHandlers) facetsTool() assistant.Tool {
 			if err := assistant.DecodeArgs(raw, &in); err != nil {
 				return nil, err
 			}
-			if h.search.facets == nil {
+			if h.search == nil || h.search.facets == nil {
 				return nil, errors.New("search is not available")
 			}
 			vals, err := in.Filters.values()
@@ -149,7 +149,7 @@ func (h *assistantHandlers) searchJobsTool() assistant.Tool {
 			if err := assistant.DecodeArgs(raw, &in); err != nil {
 				return nil, err
 			}
-			if h.search.search == nil {
+			if h.search == nil || h.search.search == nil {
 				return nil, errors.New("search is not available")
 			}
 			vals, err := in.Filters.values()
@@ -294,7 +294,7 @@ func (h *assistantHandlers) marketFitTool() assistant.Tool {
 			if err := assistant.DecodeArgs(raw, &in); err != nil {
 				return nil, err
 			}
-			if h.search.facets == nil {
+			if h.search == nil || h.search.facets == nil {
 				return nil, errors.New("search is not available")
 			}
 			skills := nonEmptyStrings(in.Skills)

--- a/internal/api/handler/assistant_tools_absent_integration_test.go
+++ b/internal/api/handler/assistant_tools_absent_integration_test.go
@@ -1,0 +1,157 @@
+//go:build integration
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/platform/db"
+)
+
+// A tool whose surface is not wired must REFUSE, and every preset is offered the discovery
+// and tracking tools — including the tailoring autopilot, which is where this was found.
+//
+// The guards read `h.search.search == nil` and `h.tracking.tracking == nil`, which
+// dereference the outer handler before testing anything. When that handler is itself nil —
+// which the assistant's own constructor permits, guarding `cvH != nil` three lines below —
+// the check panics instead of refusing. It lands in the SSE stream's goroutine, so the
+// candidate sees a turn that died mid-answer.
+//
+// Found by the model bake-off: a real model calls search_jobs during a tailoring run, which
+// no scripted stand-in in this package ever did.
+func TestAToolWithNoSurfaceRefusesInsteadOfPanicking(t *testing.T) {
+	// Everything CORE present, every OPTIONAL surface absent. That is the shape the guards
+	// claim to handle and the shape the assistant's own constructor permits: search,
+	// tracking, profile, cv and mail arrive as pointers that may be nil, and it guards cvH
+	// itself three lines below. queries is not in that set — a nil one means the handler
+	// was never assembled at all, which no deployment produces — so it is real here and
+	// the tools that read it fail on their data rather than on their wiring.
+	pool := startPostgres(t)
+	h := &assistantHandlers{queries: db.New(pool), jobs: db.New(pool)}
+
+	for _, tool := range append(h.assistantDiscoveryTools(), h.assistantTrackingTools()...) {
+		t.Run(tool.Name, func(t *testing.T) {
+			// Arguments built from the tool's OWN schema, for two reasons. A hand-written
+			// map would cover only the tools whoever wrote it remembered — the same trap
+			// that hid get_profile from the grep that found the rest. And DecodeArgs
+			// disallows unknown fields, so one superset blob refuses at every tool and the
+			// test passes having exercised nothing.
+			args := argsFromSchema(t, tool.Schema)
+			// The panic is the finding: it happens inside tool.Run, and without a recover
+			// here the whole test binary dies on the first one rather than reporting which
+			// tools are affected.
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("%s panicked with no surface wired: %v", tool.Name, r)
+				}
+			}()
+			_, err := tool.Run(context.Background(), 1, args)
+			if err == nil {
+				t.Fatalf("%s answered with no surface wired; it must refuse", tool.Name)
+			}
+			// The wording is checked only where the surface is what refused. A tool that
+			// still declined on its arguments under this blob is reported rather than
+			// asserted on: its guard was not reached, so this run says nothing about it.
+			// A refusal that is still about the ARGUMENTS never reached the guard under
+			// test, so it is a hole in this measurement and is reported as one rather than
+			// passing quietly.
+			if strings.Contains(err.Error(), badArgumentsPrefix) {
+				t.Errorf("%s refused with %q — the schema-built arguments do not satisfy it, "+
+					"so its surface guard was never reached", tool.Name, err)
+			}
+		})
+	}
+}
+
+// argsFromSchema builds one minimal valid argument object from a tool's declared JSON
+// schema: every declared property, filled with a value of the type it declares.
+//
+// It emits only DECLARED properties, which is what makes it usable at all — DecodeArgs
+// disallows unknown fields. Filling every property rather than only the required ones is
+// deliberate: `required` is absent from most of these schemas, and a tool that validates a
+// field beyond decoding it (a slug that must be non-empty) needs the value present.
+func argsFromSchema(t *testing.T, schema map[string]any) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(valueForSchema(schema))
+	if err != nil {
+		t.Fatalf("build arguments from schema: %v", err)
+	}
+	return raw
+}
+
+// valueForSchema produces one value of the type a schema fragment declares.
+func valueForSchema(schema map[string]any) any {
+	switch schema["type"] {
+	case "object":
+		props, _ := schema["properties"].(map[string]any)
+		out := make(map[string]any, len(props))
+		for name, sub := range props {
+			s, ok := sub.(map[string]any)
+			if !ok {
+				continue
+			}
+			out[name] = valueForProperty(name, s)
+		}
+		return out
+	case "array":
+		items, _ := schema["items"].(map[string]any)
+		if items == nil {
+			return []any{}
+		}
+		// Exactly one element: a tool that requires a non-empty list is satisfied, and one
+		// that does not is unaffected.
+		return []any{valueForSchema(items)}
+	case "integer", "number":
+		return 1
+	case "boolean":
+		return false
+	default:
+		return "x"
+	}
+}
+
+// valueForProperty fills one property, preferring a value the schema itself names.
+//
+// A closed enum is the case that matters: a filter or a stage validated against its own
+// vocabulary would refuse "x", and that refusal is about the argument rather than about the
+// missing surface — exactly the hole this test reports.
+func valueForProperty(name string, schema map[string]any) any {
+	if enum, ok := schema["enum"].([]string); ok && len(enum) > 0 {
+		return enum[0]
+	}
+	if enum, ok := schema["enum"].([]any); ok && len(enum) > 0 {
+		return enum[0]
+	}
+	// A description naming the accepted words is how these schemas actually spell an enum
+	// (see the tracking tools' `filter`), and a value outside it is refused as an argument.
+	if desc, ok := schema["description"].(string); ok && schema["type"] == "string" {
+		if word := firstQuotedVocabularyWord(name, desc); word != "" {
+			return word
+		}
+	}
+	return valueForSchema(schema)
+}
+
+// firstQuotedVocabularyWord reads "Which slice to list: all, viewed, saved, …" and returns
+// the first listed word. It is a narrow reader for the one shape these schemas use, and
+// returns "" when it does not recognise one — the test then reports the resulting argument
+// refusal rather than silently passing.
+func firstQuotedVocabularyWord(_ string, desc string) string {
+	_, after, ok := strings.Cut(desc, ": ")
+	if !ok {
+		return ""
+	}
+	first, _, ok := strings.Cut(after, ",")
+	if !ok {
+		return ""
+	}
+	first = strings.TrimSpace(first)
+	// One lowercase word, or it is prose rather than a vocabulary.
+	if first == "" || strings.ContainsAny(first, " .") || first != strings.ToLower(first) {
+		return ""
+	}
+	return first
+}

--- a/internal/api/handler/assistant_tracking_tools.go
+++ b/internal/api/handler/assistant_tracking_tools.go
@@ -66,7 +66,7 @@ func (h *assistantHandlers) slugActionTool(name, description string, act func(co
 			if in.Slug == "" {
 				return nil, errors.New("slug is required")
 			}
-			if h.tracking.tracking == nil {
+			if h.tracking == nil || h.tracking.tracking == nil {
 				return nil, errors.New("job tracking is not available")
 			}
 			res, err := act(ctx, userID, in.Slug)
@@ -113,7 +113,7 @@ func (h *assistantHandlers) trackJobTool() assistant.Tool {
 			if in.Stage != nil && !userjob.ValidStage(*in.Stage) {
 				return nil, fmt.Errorf("unknown stage %q — valid stages are: %s", *in.Stage, strings.Join(userjob.Stages, ", "))
 			}
-			if h.tracking.tracking == nil {
+			if h.tracking == nil || h.tracking.tracking == nil {
 				return nil, errors.New("job tracking is not available")
 			}
 			res, err := h.tracking.tracking.Track(ctx, userID, in.Slug, in.Stage, in.Note, appevent.SourceAssistant)
@@ -145,7 +145,7 @@ func (h *assistantHandlers) myJobsTool() assistant.Tool {
 			if err := assistant.DecodeArgs(raw, &in); err != nil {
 				return nil, err
 			}
-			if h.tracking.tracking == nil {
+			if h.tracking == nil || h.tracking.tracking == nil {
 				return nil, errors.New("job tracking is not available")
 			}
 			limit := in.Limit

--- a/openspec/changes/assistant-model-bakeoff/HANDOFF.md
+++ b/openspec/changes/assistant-model-bakeoff/HANDOFF.md
@@ -1,0 +1,141 @@
+# Handoff — assistant-model-bakeoff
+
+Written 2026-09-08. Twelve of twenty tasks are done and merged (#2639); the eight that
+remain are groups 5 and 6, which are the bake-off itself.
+
+## What the change is for
+
+Choosing the assistant's model has been an argument from price lists, and a price list does
+not predict what a turn costs here. Two reasons, both measured:
+
+- The transcript is replayed into context every round, so cost grows with ROUNDS as well as
+  tokens. A model needing fourteen rounds where another needs five costs far more than its
+  token price says.
+- Whether the provider serves the replayed prefix from cache decides the rest. #2633
+  measured 20k tokens a turn being re-read at full price because the window slid.
+
+Neither number is on a price page. The first thing this change touched proved the point: the
+gateway catalogue quotes `deepseek/deepseek-v4-flash-0731` at **$0.14/$0.28** per million
+where every secondhand summary said $0.05/$0.16.
+
+## What is already merged and live
+
+**One production-reachable change**, in #2639: `llm.Usage` carries `CachedInput`, read from
+the `PromptCachedTokens` langchaingo already surfaces. Langfuse receives it as `usageDetails`
+with **exclusive buckets** — the input bucket is sent net of the cache, because
+`prompt_tokens` counts the cached prefix inside itself and sending both unadjusted bills it
+twice. Dashboards read a smaller `input` from here on; that is the point.
+
+Everything else merged is test-only: the run tally, the cache verdict, cost, ranking, the
+price table, the case fixtures and the seed.
+
+## Where the code is
+
+| Piece | File |
+|---|---|
+| Tally, cache verdict, cost, ranking, price + case + profile loaders | `internal/api/handler/assistant_bakeoff.go` |
+| Their unit tests | `internal/api/handler/assistant_bakeoff_test.go` |
+| Seed helper (`//go:build integration`) | `internal/api/handler/assistant_bakeoff_seed_integration_test.go` |
+| Committed price capture | `internal/api/handler/testdata/openrouter-prices.json` |
+| Committed cases (3 real postings) | `internal/api/handler/testdata/bakeoff-cases.json` |
+
+## The one thing you must rebuild locally
+
+`internal/api/handler/testdata/bakeoff-profile.json` is **gitignored and must stay that
+way** — this repository is public and the file is a real CV: a name, a phone number, an
+address and an employment history. `.gitignore` holds a prefix rule (`bakeoff-profile*`,
+`bakeoff-resume*`), deliberately a prefix rather than two filenames, because naming each one
+let the second land untracked-but-visible until somebody noticed.
+
+Its absence is its own error (`errMissingBakeoffProfile`), so unit tests **skip** on it while
+a bake-off run must stop. CI has no business failing over a file it cannot have.
+
+Shape:
+
+```json
+{"captured":"YYYY-MM-DD", "cv":{…internal/candidate/cv.Document…}, "experience":{…/me/experience…}}
+```
+
+To rebuild it:
+
+- **experience** — `curl -H "Authorization: Bearer <key>" https://freehire.me/api/v1/me/experience`.
+  An ordinary API key reaches this.
+- **cv** — an API key does NOT reach it. `/me/resume` is `mw.cookie` (cookie-only, see
+  `resume.go`), and of the 84 CVs the account holds every one is a tailored copy — the base
+  document the tailoring flow mints them from stays behind a session. Export it from the
+  browser, or build the `cv.Document` from the PDF as was done on 2026-09-08.
+
+A fit analysis per case is also worth capturing into the fixture, so every candidate model
+sees byte-identical requirements: the analysis is INPUT to the tailoring run, not part of
+what is measured. Compute one with `GET /jobs/<slug>/match-analysis/stream` (the streaming
+route — `POST` returns 504, the chain outruns the proxy) and read it back from the free
+`GET /jobs/<slug>/match-analysis`, at `.data.analysis`.
+
+## Tasks 5.1–6.2, and what is known about each
+
+- **5.1** `newAutopilotHarness` (`assistant_autopilot_integration_test.go:43`) already stands
+  a Postgres and takes the turn model as a parameter. It hardcodes `MaxSteps: 3`, which does
+  NOT bind autopilot — that turn sets its own `TurnConfig{MaxSteps: 30}`.
+- **5.2** Tag it `integration && llmlive`. **Swap only `turnM`, never `fitM`** — varying both
+  measures two models and attributes the result to one.
+- **5.3/5.6** `cvmatch.Compute` and `atscheck.Compare` are pure and free. The report must
+  carry each run's tailored CV text: no grader model is called, and whether a CV is good is
+  read by whoever reads the report.
+- **5.5** Report to `.cache/` (not in git), naming the price table's capture date and the
+  profile the cases ran against.
+
+### The trap that will bite 5.2
+
+**Token counts are not in the event stream.** `emitUsage` is called only on the runner's two
+terminal paths (`runner.go`), so a thirty-round autopilot reports the LAST call's tokens and
+says nothing about the other twenty-nine. Nothing consumes that event today — the web client
+lists it under "ignored" (`chat.ts:76`) — so this is not a bug to work around, but it is not
+a source either. **Count tokens by wrapping the `assistant.Model` you already substitute.**
+That is what `bakeoffTally.observeCall` exists for; `observeEvent` takes the rest.
+
+## Everything else that happened on 2026-09-08
+
+The bake-off stalled because production was broken, and fixing it took the day. All of this
+is merged and live, and matters if you touch the fit analysis:
+
+| PR | What |
+|---|---|
+| #2640 | Stage 1 asks for no deliberation. It was timing out at 90s twice per analysis and failing 55% of real users' requests. |
+| #2647 | The adversarial audit gets one attempt, not two — three of three retries had burned an identical 90s to fail identically. |
+| #2649 | The audit gets twice the budget for that one attempt, which is exactly what its retry used to cost. It then landed for the first time, needing 160s. |
+| #2655 | Stage 2 scores under the evidence rule only Stage 3 knew. Measured: Stage 2 rated skills coverage 95/100/93 and the audit pulled each to 62/70/74 — same direction, same magnitude, every time. |
+| #2660 | `cmd/llm-probe` asks the gateway three questions every five minutes and publishes what came back. |
+| #2665 | `llm-probe` added to `release.sh`'s worker list. |
+
+Also: #2636/#2637 were merged but undeployed and are now out; three dead Z.ai keys
+(`zai-91`, `zai-100`, `zai-126` — 429 Fair Usage Policy) were removed from the live gateway;
+two Grafana alert rules are provisioned (`pipeline-llm-alias-refusing`,
+`pipeline-llm-probe-stopped`).
+
+**Verifying #2655 needs one more measurement.** After it deployed, two cases were re-run: on
+one the audit changed nothing at all (0 of 6 dimensions, overall 75→75, against 5 of 6 and
+77→65 before); on the other its correction shrank from −33 to −14. Two cases is two cases.
+The method is in `.cache/audit-diff.sh` — the SSE stream carries the pre-audit `dimensions`
+event and the post-audit `final` one, so diffing them needs no new instrumentation, and the
+raw streams are saved so a mistake in the query costs nothing to correct.
+
+### One measurement lesson worth repeating
+
+The first version of that diff built `from_entries` from `{key, score}` objects.
+`from_entries` reads `.value`, which those do not have, so every score compared as `null` and
+"0 of 6 moved" came out regardless of the data — which read as "the audit changes nothing,
+delete stage 3". The opposite was true.
+
+What caught it was that the number **argued with the code**: `buildAnalysis` computes the
+overall purely from the six dimension scores, so a 10-point drop with zero moved dimensions
+is impossible. A figure that contradicts the code is almost always a broken measurement.
+
+## Still open
+
+- Stage 2 completed in 1m23s against a 90s deadline in one run and 45s in another. Seven
+  seconds of headroom is not a margin.
+- The gateway is bimodal — a chain lands in 28s on Gemini and 90s per stage on Z.ai. Every
+  deadline here is a lottery until that is addressed.
+- `freehire_llm_probe_*` has alert rules but no dashboard panel.
+- Four (now five) `rules.yaml.bak-*` files have accumulated on the Grafana host; it warns
+  about each on every restart, in the same log where success is confirmed.

--- a/openspec/changes/assistant-model-bakeoff/tasks.md
+++ b/openspec/changes/assistant-model-bakeoff/tasks.md
@@ -46,27 +46,27 @@
 
 ## 5. The bake-off
 
-- [ ] 5.1 Expose the seam the bake-off needs from `newAutopilotHarness` without changing
+- [x] 5.1 Expose the seam the bake-off needs from `newAutopilotHarness` without changing
       what existing callers pass. Verify the existing autopilot integration tests still
       pass untouched.
-- [ ] 5.2 Write the `//go:build llmlive` bake-off: for each candidate model, a fresh
+- [x] 5.2 Write the `//go:build llmlive` bake-off: for each candidate model, a fresh
       database, the seeded fixtures, one autopilot run per case, the tally collected from
       the stream. Only the turn model varies; assert in the test that the fit model does
       not.
-- [ ] 5.3 Score each completed run with `cvmatch.Compute` and `atscheck.Compare` against
+- [x] 5.3 Score each completed run with `cvmatch.Compute` and `atscheck.Compare` against
       the base report, and attach both to the row.
-- [ ] 5.4 Record a failed, cancelled or step-capped run as a row carrying that outcome and
+- [x] 5.4 Record a failed, cancelled or step-capped run as a row carrying that outcome and
       continue; end the bake-off only when the case set itself cannot be read.
-- [ ] 5.5 Emit the report: a table to the test log and the full rows as JSON under
+- [x] 5.5 Emit the report: a table to the test log and the full rows as JSON under
       `.cache/`, naming the price table's capture date and the profile the cases were run
       against.
-- [ ] 5.6 Include each completed run's tailored CV text in the JSON report beside its
+- [x] 5.6 Include each completed run's tailored CV text in the JSON report beside its
       vacancy and scores, and omit it for a failed run. Verify by reading a report back
       and finding one CV per completed (model, case).
 
 ## 6. Wrap-up
 
-- [ ] 6.1 Document the bake-off in `internal/ai/assistant/AGENTS.md`: what it measures,
+- [x] 6.1 Document the bake-off in `internal/ai/assistant/AGENTS.md`: what it measures,
       how to run it, and why rounds and cache rate matter more than the price page.
 - [ ] 6.2 Run the bake-off against at least two candidate models over several vacancies,
       record the first report, and read the tailored CVs it carries.

--- a/openspec/changes/assistant-model-bakeoff/tasks.md
+++ b/openspec/changes/assistant-model-bakeoff/tasks.md
@@ -68,5 +68,5 @@
 
 - [x] 6.1 Document the bake-off in `internal/ai/assistant/AGENTS.md`: what it measures,
       how to run it, and why rounds and cache rate matter more than the price page.
-- [ ] 6.2 Run the bake-off against at least two candidate models over several vacancies,
+- [x] 6.2 Run the bake-off against at least two candidate models over several vacancies,
       record the first report, and read the tailored CVs it carries.


### PR DESCRIPTION
Finishes `openspec/changes/assistant-model-bakeoff` — 20 of 20 tasks. The measuring core,
the price table and the fixtures were merged in #2639; this is the run itself, plus the
three defects that only a live run could find.

## What the bake-off is

A `//go:build integration && llmlive` test that runs the tailoring autopilot — the
assistant's most expensive turn shape — once per (candidate model, case) against a fresh
Postgres, and writes a ranked table plus a JSON report under `.cache/`.

```bash
BAKEOFF_MODELS=a,b LLM_BASE_URL=… LLM_API_KEY=… LLM_MODEL=… \
  go test -tags=integration,llmlive ./internal/api/handler/ -run TestBakeoff -timeout 3h -v
```

It exists because a per-million price does not predict a turn's cost here. The transcript
is replayed every round, so rounds multiply rather than add; and whether the provider
serves that replayed prefix from cache decides the rest. Neither figure is on a price page.
It ranks on `cvmatch` and `atscheck`, calls no grader model, and emits every run's tailored
CV so a reader judges the rest.

## The first report

Two models, three real postings, one real profile. `flagship` (resolves to `glm-5.3-flash`)
against `gemini/fast` (`gemini-2.5-flash-lite`):

| model | case | match | ats | rounds | cache | outcome |
|---|---|---|---|---|---|---|
| flagship | full-stack | **90** | **+2** | 8 | 54% | end_turn |
| flagship | senior-software-eng | 75 | +0 | 7 | 77% | end_turn |
| gemini/fast | senior-software-eng | 75 | +0 | 2 | — | end_turn |
| gemini/fast | full-stack | 64 | +0 | 2 | — | end_turn |
| flagship | senior-backend | 50 | +0 | 2 | — | error |
| gemini/fast | senior-backend | 50 | +0 | 2 | — | end_turn |

`flagship` tailors; `gemini/fast` does not. The tailored CV lengths are the control: 6447
and 6138 against a 6034/6040 base for `flagship`, byte-identical to the base for every
`gemini/fast` row. Reading the full-stack CV, `flagship` surfaced React/Next.js, Material
UI, Tailwind, REST APIs and a video-marketplace project — through the evidence gate, or it
would have been refused.

Cost reads `unknown` for both: the price table is keyed by OpenRouter ids and this gateway
serves neither. That is the honest branch, not a gap — a missing price must never sort
first.

Caveats, all in the code beside what they qualify: three cases and one profile; `search_jobs`
has no surface in the harness, so rounds are inflated against production equally for both
candidates; one `flagship` run errored.

## The three defects a live run found

None of these were reachable by a scripted stand-in, which never calls a tool it was not
scripted to call, never builds that client, and never renders that PDF.

**The CV toolchain was missing from the harness.** `cvmatch` and `atscheck` score the text
layer of the RENDERED PDF, and a handler with no renderer does not fail that read — it
degrades to an unavailable score. A bake-off over it finishes green and reports a column of
absences, which reads exactly like a set of models that all tailored nothing.

**Seven tools panicked instead of refusing.** `h.search.search == nil` dereferences the
outer pointer before testing anything, and the assistant's constructor takes each surface as
a pointer that may be nil. Not reachable on prod today, so this is a guard that exists to
survive an absence and cannot. The test walks the REGISTRY and builds each call's arguments
from that tool's own SCHEMA — both load-bearing: a hand-written field grep found six sites
and missed `get_profile`, and empty arguments make seven tools refuse before reaching the
guard under test.

**The fit chain could not send `reasoning_effort`.** It is written by an HTTP transport that
only `llm.New` installs, and the harness wrapped its model in `llm.NewWithModel`, which has
none — so Stage 1's `ReasoningNone` (#2640) was dropped silently and the stage blew its 90s
deadline on 6 of 6 attempts, while production ran 21 analyses the same day without one
Stage 1 failure. After the fix: Stage 1 lands in 23.8s and the whole chain completes.

## And one defect found in production's own transcripts

`cv_edit` refused 21 calls in a fortnight with `invalid arguments: json: unknown field
"evidence_id"`. The model had put the field at the top of the call rather than inside the op
it backs — a reasonable generalisation, since `requirement` and `requirement_status` ARE
call-level. The refusal named the field and not the place, so the model re-sent the identical
call; the refusals arrive in pairs.

20 of the 21 carried exactly one op, where the intent is not in doubt, and those are now read
through — the same leniency `opBatch.UnmarshalJSON` extends to a batch packaged as a string.
Several ops still refuse (one achievement's evidence across several claims is what the
provenance gate exists to stop) and so does an op that already names its own (which claim the
id was meant to back is exactly what is unclear). Both refusals now say where the field goes,
and so does the tool description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved assistant stability when search, job tracking, or profile services are unavailable by returning clear errors instead of failing unexpectedly.
  - Fixed CV editing so a single edit can correctly use evidence supplied at the call level, while invalid or conflicting evidence is rejected.
  - Improved validation and scoring of rendered tailored CVs.

- **Documentation**
  - Added guidance describing model comparison results, scoring, cache behavior, and cost considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->