### PR TITLE
Prefill the mentor-profile create form and let mentors opt in to a public photo

### DIFF
--- a/internal/api/handler/handler.go
+++ b/internal/api/handler/handler.go
@@ -710,7 +710,15 @@ func Register(app *fiber.App, cfg Config) {
 	mentorshipH := newMentorshipHandlers(mentorship.New(
 		mentorship.NewQueriesRepository(queries, cfg.Pool),
 		mentorship.Config{Notifier: mentorshipNotifier, Cache: cfg.Cache},
-	))
+	), photoStore)
+	// The mentor-profile create form's prefill. Composed from four unrelated blocks'
+	// own services (résumé, user profile, account, experience bank) plus the company
+	// catalog — never from mentorship itself, see the mentor-profile-prefill spec.
+	mentorSuggestionsH := newMentorSuggestionsHandlers(
+		resumeStore, profileSvc,
+		accounts.New(accounts.NewQueriesRepository(queries, cfg.Pool), authHasher{}),
+		bank, queries,
+	)
 
 	// Allow the canonical frontend origin plus every served domain's https apex,
 	// so a cross-origin (non-credentialed) read works from either domain during a
@@ -831,6 +839,7 @@ func Register(app *fiber.App, cfg Config) {
 
 	// The mentorship marketplace (see mentorshipHandlers).
 	mentorshipH.register(api, mw)
+	mentorSuggestionsH.register(api, mw)
 
 	// Job reports + review queue (see reportHandlers).
 	reportsH.register(api, mw)

--- a/internal/api/handler/handler.go
+++ b/internal/api/handler/handler.go
@@ -714,10 +714,14 @@ func Register(app *fiber.App, cfg Config) {
 	// The mentor-profile create form's prefill. Composed from four unrelated blocks'
 	// own services (résumé, user profile, account, experience bank) plus the company
 	// catalog — never from mentorship itself, see the mentor-profile-prefill spec.
+	//
+	// The account read is the bare repository, not a second accounts.Service: the
+	// only thing this handler needs is UserByID, which accounts.Repository already
+	// exposes, and newAuthHandlers already builds the one Service this process
+	// needs. A constructor that builds a shared service is the bug this package's
+	// AGENTS.md calls out by name — hoist, don't duplicate.
 	mentorSuggestionsH := newMentorSuggestionsHandlers(
-		resumeStore, profileSvc,
-		accounts.New(accounts.NewQueriesRepository(queries, cfg.Pool), authHasher{}),
-		bank, queries,
+		resumeStore, profileSvc, accounts.NewQueriesRepository(queries, cfg.Pool), bank, queries,
 	)
 
 	// Allow the canonical frontend origin plus every served domain's https apex,

--- a/internal/api/handler/mentorship.go
+++ b/internal/api/handler/mentorship.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/strelov1/freehire/internal/api/ratelimit"
+	"github.com/strelov1/freehire/internal/candidate/headshot"
 	"github.com/strelov1/freehire/internal/engage/mentorship"
 )
 
@@ -15,10 +17,14 @@ import (
 // slots, the seeker's bookings, the mentor's own cabinet, and the moderation queue.
 type mentorshipHandlers struct {
 	mentorship *mentorship.Service
+	// photos is nil-safe (headshot.Store.Enabled() reports false on a nil receiver), so
+	// an unconfigured object store degrades GetMentorPhoto to "not found" rather than a
+	// server error.
+	photos *headshot.Store
 }
 
-func newMentorshipHandlers(svc *mentorship.Service) *mentorshipHandlers {
-	return &mentorshipHandlers{mentorship: svc}
+func newMentorshipHandlers(svc *mentorship.Service, photos *headshot.Store) *mentorshipHandlers {
+	return &mentorshipHandlers{mentorship: svc, photos: photos}
 }
 
 // slotReadsPerMinute is this endpoint's own budget, separate from the shared public-read
@@ -77,6 +83,7 @@ func (h *mentorshipHandlers) registerPublic(api fiber.Router, mw middleware) {
 	api.Get("/mentors", readLimit, h.ListMentors)
 	api.Get("/mentors/:slug", readLimit, h.GetMentor)
 	api.Get("/mentors/:slug/slots", slotLimit, h.GetMentorSlots)
+	api.Get("/mentors/:slug/photo", readLimit, h.GetMentorPhoto)
 }
 
 // mentorResponse is the public shape of a mentor. user_id is not in it: it is ownership,
@@ -98,9 +105,13 @@ type mentorResponse struct {
 	SessionMinutes int     `json:"session_minutes"`
 	RatingCount    int64   `json:"rating_count"`
 	RatingAvg      float64 `json:"rating_avg"`
-	Status         string  `json:"status,omitempty"`
-	Paused         bool    `json:"paused,omitempty"`
-	MeetingURL     string  `json:"meeting_url,omitempty"`
+	// ShowPhoto is the mentor's own opt-in to serve their account's stored CV headshot
+	// publicly (see GetMentorPhoto). Present in every view — the directory card needs it
+	// to decide whether to render an avatar at all.
+	ShowPhoto  bool   `json:"show_photo"`
+	Status     string `json:"status,omitempty"`
+	Paused     bool   `json:"paused,omitempty"`
+	MeetingURL string `json:"meeting_url,omitempty"`
 
 	// The rest of the session parameters, for the OWNER alone. Pointers rather than plain
 	// ints because a zero buffer is a real setting, and `omitempty` cannot tell "no buffer"
@@ -126,6 +137,7 @@ func toMentorResponse(p mentorship.Profile) mentorResponse {
 		Timezone:       p.Timezone,
 		SessionMinutes: int(p.Session.Duration / time.Minute),
 		RatingCount:    p.RatingCount, RatingAvg: p.RatingAvg,
+		ShowPhoto: p.ShowPhoto,
 	}
 }
 
@@ -220,6 +232,44 @@ func (h *mentorshipHandlers) GetMentor(c *fiber.Ctx) error {
 		return mentorshipError(err)
 	}
 	return c.JSON(fiber.Map{"data": toMentorResponse(profile)})
+}
+
+// errMentorPhotoNotFound is what every reason a mentor's public photo may not be served
+// collapses to: not opted in, no stored headshot, or storage unconfigured. They are
+// deliberately indistinguishable from outside — a response that told them apart would
+// leak whether an opted-out mentor has a CV photo at all, the narrower version of the
+// privacy concern the opt-in itself exists to address.
+var errMentorPhotoNotFound = errors.New("mentor photo not available")
+
+// mentorPhoto resolves an already-public mentor's photo bytes, given their opt-in and
+// the account's stored headshot. It does not itself resolve the profile or check
+// publication status — GetMentorPhoto reuses PublicProfile for that, the same
+// resolution and predicate GetMentor uses, so the two routes cannot drift on what
+// "publicly readable" means.
+func mentorPhoto(ctx context.Context, profile mentorship.Profile, photos *headshot.Store) ([]byte, error) {
+	if !profile.ShowPhoto {
+		return nil, errMentorPhotoNotFound
+	}
+	data, err := photos.Get(ctx, profile.UserID)
+	if err != nil {
+		return nil, errMentorPhotoNotFound
+	}
+	return data, nil
+}
+
+// GetMentorPhoto serves a published mentor's account headshot, only when that mentor has
+// opted in via show_photo. An unpublished profile answers 404 exactly as GetMentor does.
+func (h *mentorshipHandlers) GetMentorPhoto(c *fiber.Ctx) error {
+	profile, err := h.mentorship.PublicProfile(c.Context(), c.Params("slug"))
+	if err != nil {
+		return fiber.NewError(fiber.StatusNotFound)
+	}
+	data, err := mentorPhoto(c.Context(), profile, h.photos)
+	if err != nil {
+		return fiber.NewError(fiber.StatusNotFound)
+	}
+	c.Set(fiber.HeaderContentType, "image/jpeg")
+	return c.Send(data)
 }
 
 // slotResponse is one offerable hour.

--- a/internal/api/handler/mentorship_photo_test.go
+++ b/internal/api/handler/mentorship_photo_test.go
@@ -1,0 +1,78 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/candidate/headshot"
+	"github.com/strelov1/freehire/internal/engage/mentorship"
+)
+
+func TestToMentorResponseCarriesShowPhoto(t *testing.T) {
+	p := mentorship.Profile{ShowPhoto: true}
+	if !toMentorResponse(p).ShowPhoto {
+		t.Error("show_photo = false in public response, want true")
+	}
+	if toMentorResponse(mentorship.Profile{ShowPhoto: false}).ShowPhoto {
+		t.Error("show_photo = true in public response, want false")
+	}
+}
+
+func TestToOwnAndModeratorMentorResponseCarryShowPhoto(t *testing.T) {
+	p := mentorship.Profile{ShowPhoto: true}
+	if !toOwnMentorResponse(p).ShowPhoto {
+		t.Error("owner view: show_photo = false, want true")
+	}
+	if !toModeratorMentorResponse(p).ShowPhoto {
+		t.Error("moderator view: show_photo = false, want true")
+	}
+}
+
+// The four fixtures below reuse fakePhotoBlobs/fakePhotoRepo/newFakePhotoBlobs from
+// photo_test.go rather than redeclaring them.
+
+func TestMentorPhoto_ApprovedOptedInWithStoredHeadshot_ServesBytes(t *testing.T) {
+	blobs := newFakePhotoBlobs()
+	blobs.objs["headshots/7"] = []byte("jpeg-bytes")
+	repo := &fakePhotoRepo{key: "headshots/7", set: true}
+	store := headshot.New(blobs, repo)
+
+	data, err := mentorPhoto(context.Background(), mentorship.Profile{UserID: 7, ShowPhoto: true}, store)
+	if err != nil {
+		t.Fatalf("mentorPhoto: %v", err)
+	}
+	if string(data) != "jpeg-bytes" {
+		t.Errorf("data = %q, want the stored bytes", data)
+	}
+}
+
+func TestMentorPhoto_NotOptedIn_NotFoundEvenWithAStoredHeadshot(t *testing.T) {
+	blobs := newFakePhotoBlobs()
+	blobs.objs["headshots/7"] = []byte("jpeg-bytes")
+	repo := &fakePhotoRepo{key: "headshots/7", set: true}
+	store := headshot.New(blobs, repo)
+
+	_, err := mentorPhoto(context.Background(), mentorship.Profile{UserID: 7, ShowPhoto: false}, store)
+	if !errors.Is(err, errMentorPhotoNotFound) {
+		t.Errorf("err = %v, want errMentorPhotoNotFound", err)
+	}
+}
+
+func TestMentorPhoto_OptedInButNoStoredHeadshot_NotFound(t *testing.T) {
+	store := headshot.New(newFakePhotoBlobs(), &fakePhotoRepo{})
+
+	_, err := mentorPhoto(context.Background(), mentorship.Profile{UserID: 7, ShowPhoto: true}, store)
+	if !errors.Is(err, errMentorPhotoNotFound) {
+		t.Errorf("err = %v, want errMentorPhotoNotFound", err)
+	}
+}
+
+func TestMentorPhoto_StorageUnconfigured_NotFound(t *testing.T) {
+	store := headshot.New(nil, &fakePhotoRepo{})
+
+	_, err := mentorPhoto(context.Background(), mentorship.Profile{UserID: 7, ShowPhoto: true}, store)
+	if !errors.Is(err, errMentorPhotoNotFound) {
+		t.Errorf("err = %v, want errMentorPhotoNotFound", err)
+	}
+}

--- a/internal/api/handler/mentorship_suggestions.go
+++ b/internal/api/handler/mentorship_suggestions.go
@@ -1,0 +1,169 @@
+package handler
+
+import (
+	"context"
+	"log"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/candidate/experience"
+	"github.com/strelov1/freehire/internal/candidate/resumeextract"
+	"github.com/strelov1/freehire/internal/dict/normalize"
+	"github.com/strelov1/freehire/internal/identity/accounts"
+	"github.com/strelov1/freehire/internal/identity/userprofile"
+)
+
+// mentorSuggestionResume is the one read a mentor-profile suggestion needs from the
+// résumé store: StructureForSeed, the same identity-plus-body composition cv_seed.go
+// uses to seed a new document from the candidate's CV — owned overrides applied over
+// the current extract, both identity fields (name included) and body fields alike.
+// Structured+CandidateOwned alone would miss identity: ApplyBody only ever touches the
+// five BODY fields, never FullName/Email/Phone/Location/Links.
+type mentorSuggestionResume interface {
+	StructureForSeed(ctx context.Context, userID int64) (resumeextract.Structured, bool, error)
+}
+
+// mentorSuggestionUserProfile is the one read a suggestion needs from the user's
+// profile: its specializations.
+type mentorSuggestionUserProfile interface {
+	Get(ctx context.Context, userID int64) (userprofile.Profile, error)
+}
+
+// mentorSuggestionAccount is the one read a suggestion needs from the account: its
+// timezone.
+type mentorSuggestionAccount interface {
+	UserByID(ctx context.Context, id int64) (accounts.User, error)
+}
+
+// mentorSuggestionExperience is the one read a suggestion needs from the experience
+// bank: the candidate's current employer.
+type mentorSuggestionExperience interface {
+	ListEmployments(ctx context.Context, userID int64) ([]experience.Employment, error)
+}
+
+// mentorSuggestionCompanies checks a candidate's current employer against the company
+// catalog, the same existence check the create flow's foreign key would enforce.
+type mentorSuggestionCompanies interface {
+	CompanyExists(ctx context.Context, slug string) (bool, error)
+}
+
+// mentorProfileSuggestions is a best-effort, per-field starting point for the
+// mentor-profile create form. Every field is independent and omitted (rather than an
+// empty string or slice) when its source has nothing to offer — see the
+// mentor-profile-prefill spec. It reads only the candidate's résumé, user profile,
+// account and experience bank; it never reads the mentor profile itself.
+type mentorProfileSuggestions struct {
+	Name        *string  `json:"name,omitempty"`
+	Headline    *string  `json:"headline,omitempty"`
+	Bio         *string  `json:"bio,omitempty"`
+	Languages   []string `json:"languages,omitempty"`
+	Topics      []string `json:"topics,omitempty"`
+	Timezone    *string  `json:"timezone,omitempty"`
+	CompanySlug *string  `json:"company_slug,omitempty"`
+}
+
+// mentorSuggestionsHandlers composes the mentor-profile create form's prefill from four
+// unrelated blocks' own services. It depends on none of their concrete types beyond
+// what it reads, so it needs no database to test.
+type mentorSuggestionsHandlers struct {
+	resume      mentorSuggestionResume
+	userProfile mentorSuggestionUserProfile
+	account     mentorSuggestionAccount
+	experience  mentorSuggestionExperience
+	companies   mentorSuggestionCompanies
+}
+
+func newMentorSuggestionsHandlers(
+	resume mentorSuggestionResume,
+	userProfile mentorSuggestionUserProfile,
+	account mentorSuggestionAccount,
+	exp mentorSuggestionExperience,
+	companies mentorSuggestionCompanies,
+) *mentorSuggestionsHandlers {
+	return &mentorSuggestionsHandlers{
+		resume: resume, userProfile: userProfile, account: account,
+		experience: exp, companies: companies,
+	}
+}
+
+func (h *mentorSuggestionsHandlers) register(api fiber.Router, mw middleware) {
+	api.Get("/me/mentorship/profile/suggestions", mw.key, h.GetSuggestions)
+}
+
+// GetSuggestions answers with the caller's best-effort mentor-profile prefill. It never
+// fails on missing or unreadable source data — every field simply degrades to absent —
+// so the only failure this route can report is an unauthenticated caller.
+func (h *mentorSuggestionsHandlers) GetSuggestions(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	return c.JSON(fiber.Map{"data": h.suggest(c.Context(), userID)})
+}
+
+func (h *mentorSuggestionsHandlers) suggest(ctx context.Context, userID int64) mentorProfileSuggestions {
+	var out mentorProfileSuggestions
+
+	// Name, headline, bio and languages: StructureForSeed's identity-plus-body
+	// composition — the current résumé extract, overlaid by whatever the candidate
+	// owns, identity fields included.
+	var structured resumeextract.Structured
+	if stored, ok, err := h.resume.StructureForSeed(ctx, userID); err == nil && ok {
+		structured = stored
+	}
+	if structured.FullName != "" {
+		out.Name = &structured.FullName
+	}
+	if structured.Headline != "" {
+		out.Headline = &structured.Headline
+	}
+	if structured.Summary != "" {
+		out.Bio = &structured.Summary
+	}
+	if len(structured.Languages) > 0 {
+		out.Languages = structured.Languages
+	}
+
+	if profile, err := h.userProfile.Get(ctx, userID); err == nil && len(profile.Specializations) > 0 {
+		out.Topics = profile.Specializations
+	}
+
+	if user, err := h.account.UserByID(ctx, userID); err == nil && user.Timezone != nil && *user.Timezone != "" {
+		out.Timezone = user.Timezone
+	}
+
+	if slug := h.currentEmployerSlug(ctx, userID); slug != "" {
+		out.CompanySlug = &slug
+	}
+
+	return out
+}
+
+// currentEmployerSlug resolves the candidate's current job in the experience bank to a
+// company slug, but only on an EXACT catalog match — the same normalization the
+// mentor-profile create flow's company_slug foreign key would accept. An employer that
+// does not resolve is not guessed at further; it is simply absent from the suggestion.
+func (h *mentorSuggestionsHandlers) currentEmployerSlug(ctx context.Context, userID int64) string {
+	employments, err := h.experience.ListEmployments(ctx, userID)
+	if err != nil {
+		return ""
+	}
+	for _, e := range employments {
+		if e.Kind != experience.KindJob || !e.Current || e.Company == "" {
+			continue
+		}
+		slug := normalize.CompanySlug(e.Company)
+		if slug == "" {
+			continue
+		}
+		exists, err := h.companies.CompanyExists(ctx, slug)
+		if err != nil {
+			log.Printf("mentor suggestions: user %d: company lookup for %q: %v", userID, slug, err)
+			continue
+		}
+		if exists {
+			return slug
+		}
+	}
+	return ""
+}

--- a/internal/api/handler/mentorship_suggestions_test.go
+++ b/internal/api/handler/mentorship_suggestions_test.go
@@ -1,0 +1,152 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/candidate/experience"
+	"github.com/strelov1/freehire/internal/candidate/resumeextract"
+	"github.com/strelov1/freehire/internal/identity/accounts"
+	"github.com/strelov1/freehire/internal/identity/userprofile"
+)
+
+// fakeSuggestionResume is a mentorSuggestionResume returning a canned StructureForSeed
+// result, so the composition can be exercised without a database.
+type fakeSuggestionResume struct {
+	structured resumeextract.Structured
+	structOK   bool
+	structErr  error
+}
+
+func (f fakeSuggestionResume) StructureForSeed(context.Context, int64) (resumeextract.Structured, bool, error) {
+	return f.structured, f.structOK, f.structErr
+}
+
+type fakeSuggestionUserProfile struct {
+	profile userprofile.Profile
+	err     error
+}
+
+func (f fakeSuggestionUserProfile) Get(context.Context, int64) (userprofile.Profile, error) {
+	return f.profile, f.err
+}
+
+type fakeSuggestionAccount struct {
+	user accounts.User
+	err  error
+}
+
+func (f fakeSuggestionAccount) UserByID(context.Context, int64) (accounts.User, error) {
+	return f.user, f.err
+}
+
+type fakeSuggestionExperience struct {
+	employments []experience.Employment
+	err         error
+}
+
+func (f fakeSuggestionExperience) ListEmployments(context.Context, int64) ([]experience.Employment, error) {
+	return f.employments, f.err
+}
+
+type fakeSuggestionCompanies struct {
+	exists map[string]bool
+	err    error
+}
+
+func (f fakeSuggestionCompanies) CompanyExists(_ context.Context, slug string) (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	return f.exists[slug], nil
+}
+
+func strPtr(s string) *string { return &s }
+
+func TestMentorSuggestions_FullData_EveryFieldPresent(t *testing.T) {
+	h := &mentorSuggestionsHandlers{
+		resume: fakeSuggestionResume{
+			structured: resumeextract.Structured{
+				FullName: "Jane Doe", Headline: "Staff Engineer", Summary: "Ten years of Go.",
+				Languages: []string{"English", "German"},
+			},
+			structOK: true,
+		},
+		userProfile: fakeSuggestionUserProfile{
+			profile: userprofile.Profile{Specializations: []string{"backend"}},
+		},
+		account: fakeSuggestionAccount{
+			user: accounts.User{Timezone: strPtr("Europe/Berlin")},
+		},
+		experience: fakeSuggestionExperience{
+			employments: []experience.Employment{
+				{Kind: experience.KindJob, Company: "Acme Inc", Current: true},
+			},
+		},
+		companies: fakeSuggestionCompanies{exists: map[string]bool{"acme": true}},
+	}
+
+	got := h.suggest(context.Background(), 1)
+
+	if got.Name == nil || *got.Name != "Jane Doe" {
+		t.Errorf("Name = %v, want \"Jane Doe\"", got.Name)
+	}
+	if got.Headline == nil || *got.Headline != "Staff Engineer" {
+		t.Errorf("Headline = %v, want \"Staff Engineer\"", got.Headline)
+	}
+	if got.Bio == nil || *got.Bio != "Ten years of Go." {
+		t.Errorf("Bio = %v, want the summary", got.Bio)
+	}
+	if len(got.Languages) != 2 {
+		t.Errorf("Languages = %v, want 2", got.Languages)
+	}
+	if len(got.Topics) != 1 || got.Topics[0] != "backend" {
+		t.Errorf("Topics = %v, want [backend]", got.Topics)
+	}
+	if got.Timezone == nil || *got.Timezone != "Europe/Berlin" {
+		t.Errorf("Timezone = %v, want Europe/Berlin", got.Timezone)
+	}
+	if got.CompanySlug == nil || *got.CompanySlug != "acme" {
+		t.Errorf("CompanySlug = %v, want acme", got.CompanySlug)
+	}
+}
+
+func TestMentorSuggestions_NoData_SucceedsWithEveryFieldAbsent(t *testing.T) {
+	h := &mentorSuggestionsHandlers{
+		resume:      fakeSuggestionResume{structErr: errors.New("no résumé")},
+		userProfile: fakeSuggestionUserProfile{err: userprofile.ErrNotFound},
+		account:     fakeSuggestionAccount{err: errors.New("no account")},
+		experience:  fakeSuggestionExperience{},
+		companies:   fakeSuggestionCompanies{},
+	}
+
+	got := h.suggest(context.Background(), 1)
+
+	if got.Name != nil || got.Headline != nil || got.Bio != nil || got.Timezone != nil || got.CompanySlug != nil {
+		t.Errorf("expected every scalar field absent, got %+v", got)
+	}
+	if len(got.Languages) != 0 || len(got.Topics) != 0 {
+		t.Errorf("expected every list field empty, got %+v", got)
+	}
+}
+
+func TestMentorSuggestions_UnmatchedEmployer_CompanyFieldAbsent(t *testing.T) {
+	h := &mentorSuggestionsHandlers{
+		resume:      fakeSuggestionResume{},
+		userProfile: fakeSuggestionUserProfile{},
+		account:     fakeSuggestionAccount{},
+		experience: fakeSuggestionExperience{
+			employments: []experience.Employment{
+				{Kind: experience.KindJob, Company: "Some Unknown Startup", Current: true},
+			},
+		},
+		companies: fakeSuggestionCompanies{exists: map[string]bool{}},
+	}
+
+	got := h.suggest(context.Background(), 1)
+
+	if got.CompanySlug != nil {
+		t.Errorf("CompanySlug = %v, want nil for an unmatched employer", got.CompanySlug)
+	}
+}

--- a/internal/api/handler/mentorship_write.go
+++ b/internal/api/handler/mentorship_write.go
@@ -249,6 +249,9 @@ type profileRequest struct {
 	NoticeMinutes       int      `json:"notice_minutes"`
 	HorizonDays         int      `json:"horizon_days"`
 	MeetingURL          string   `json:"meeting_url"`
+	// ShowPhoto is the mentor's own opt-in to publish their account's CV headshot. Off
+	// by default; see mentorship.Profile.ShowPhoto.
+	ShowPhoto bool `json:"show_photo"`
 }
 
 func (r profileRequest) toInput(userID int64) mentorship.ProfileInput {
@@ -270,6 +273,7 @@ func (r profileRequest) toInput(userID int64) mentorship.ProfileInput {
 			Horizon:       time.Duration(r.HorizonDays) * 24 * time.Hour,
 		},
 		MeetingURL: r.MeetingURL,
+		ShowPhoto:  r.ShowPhoto,
 	}
 }
 

--- a/internal/engage/mentorship/fake_repo_test.go
+++ b/internal/engage/mentorship/fake_repo_test.go
@@ -80,6 +80,7 @@ func (r *fakeRepo) CreateProfile(_ context.Context, in ProfileInput) (Profile, e
 		Timezone:    in.Timezone,
 		Session:     in.Session,
 		MeetingURL:  in.MeetingURL,
+		ShowPhoto:   in.ShowPhoto,
 		Status:      StatusPending,
 	}
 	r.profiles[p.ID] = p
@@ -124,6 +125,7 @@ func (r *fakeRepo) UpdateProfile(_ context.Context, in ProfileInput) (Profile, e
 	p.Timezone = in.Timezone
 	p.Session = in.Session
 	p.MeetingURL = in.MeetingURL
+	p.ShowPhoto = in.ShowPhoto
 	r.profiles[id] = p
 	return p, nil
 }

--- a/internal/engage/mentorship/profile.go
+++ b/internal/engage/mentorship/profile.go
@@ -69,6 +69,10 @@ type Profile struct {
 	Timezone    string
 	Session     SessionParams
 	MeetingURL  string
+	// ShowPhoto is the mentor's own opt-in to serve their account's stored CV headshot
+	// on their public directory card and profile page. Off by default: the account
+	// headshot is a job-search photo a mentor may not want reused here without asking.
+	ShowPhoto   bool
 	Status      string
 	Paused      bool
 	DecidedBy   int64
@@ -107,6 +111,7 @@ type ProfileInput struct {
 	Timezone    string
 	Session     SessionParams
 	MeetingURL  string
+	ShowPhoto   bool
 }
 
 // DirectoryFilter narrows the public directory. An empty field means unfiltered, matching

--- a/internal/engage/mentorship/profile_test.go
+++ b/internal/engage/mentorship/profile_test.go
@@ -358,6 +358,41 @@ func TestWithdrawalByAStrangerRemovesNothing(t *testing.T) {
 	}
 }
 
+// ShowPhoto defaults off and round-trips through both create and update, independent
+// of every other field — a mentor's own opt-in, not a byproduct of anything else they
+// submit.
+func TestShowPhotoDefaultsOffAndRoundTripsThroughCreateAndUpdate(t *testing.T) {
+	repo := newFakeRepo()
+	svc := newTestService(t, repo)
+
+	created, err := svc.SubmitProfile(context.Background(), validInput())
+	if err != nil {
+		t.Fatalf("SubmitProfile: %v", err)
+	}
+	if created.ShowPhoto {
+		t.Error("show_photo = true on a fresh profile, want false (off by default)")
+	}
+
+	in := validInput()
+	in.ShowPhoto = true
+	updated, err := svc.UpdateProfile(context.Background(), in)
+	if err != nil {
+		t.Fatalf("UpdateProfile: %v", err)
+	}
+	if !updated.ShowPhoto {
+		t.Error("show_photo = false after opting in, want true")
+	}
+
+	in.ShowPhoto = false
+	updated, err = svc.UpdateProfile(context.Background(), in)
+	if err != nil {
+		t.Fatalf("UpdateProfile: %v", err)
+	}
+	if updated.ShowPhoto {
+		t.Error("show_photo = true after opting back out, want false")
+	}
+}
+
 // A profile with no object storage and no notifier configured must still work: the
 // feature ships before every channel exists, exactly as the referral pings do.
 func TestAServiceWithNoNotifierStillWorks(t *testing.T) {

--- a/internal/engage/mentorship/repository.go
+++ b/internal/engage/mentorship/repository.go
@@ -63,6 +63,7 @@ func (r *QueriesRepository) CreateProfile(ctx context.Context, in ProfileInput) 
 		MinNoticeMin:       minutesOf(in.Session.MinimumNotice),
 		HorizonDays:        daysOf(in.Session.Horizon),
 		MeetingUrl:         in.MeetingURL,
+		ShowPhoto:          in.ShowPhoto,
 	})
 	if err != nil {
 		if name, ok := pgerr.UniqueViolationConstraint(err); ok {
@@ -142,6 +143,7 @@ func (r *QueriesRepository) UpdateProfile(ctx context.Context, in ProfileInput) 
 		MinNoticeMin:       minutesOf(in.Session.MinimumNotice),
 		HorizonDays:        daysOf(in.Session.Horizon),
 		MeetingUrl:         in.MeetingURL,
+		ShowPhoto:          in.ShowPhoto,
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Profile{}, ErrProfileNotFound
@@ -279,6 +281,7 @@ func profileFromRow(row db.Mentor) Profile {
 			Horizon:       time.Duration(row.HorizonDays) * 24 * time.Hour,
 		},
 		MeetingURL: row.MeetingUrl,
+		ShowPhoto:  row.ShowPhoto,
 		Status:     row.Status,
 		Paused:     row.Paused,
 		DecidedBy:  row.DecidedBy.Int64,

--- a/internal/platform/db/mentorship.sql.go
+++ b/internal/platform/db/mentorship.sql.go
@@ -224,9 +224,9 @@ const createMentorProfile = `-- name: CreateMentorProfile :one
 INSERT INTO mentors (
     user_id, company_slug, slug, display_name, headline, bio, topics, languages, timezone,
     session_duration_min, buffer_before_min, buffer_after_min, min_notice_min,
-    horizon_days, meeting_url
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
-RETURNING id, user_id, company_slug, slug, display_name, headline, bio, topics, languages, timezone, session_duration_min, buffer_before_min, buffer_after_min, min_notice_min, horizon_days, meeting_url, status, paused, decided_by, decided_at, created_at, updated_at
+    horizon_days, meeting_url, show_photo
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+RETURNING id, user_id, company_slug, slug, display_name, headline, bio, topics, languages, timezone, session_duration_min, buffer_before_min, buffer_after_min, min_notice_min, horizon_days, meeting_url, status, paused, decided_by, decided_at, created_at, updated_at, show_photo
 `
 
 type CreateMentorProfileParams struct {
@@ -245,6 +245,7 @@ type CreateMentorProfileParams struct {
 	MinNoticeMin       int32    `json:"min_notice_min"`
 	HorizonDays        int32    `json:"horizon_days"`
 	MeetingUrl         string   `json:"meeting_url"`
+	ShowPhoto          bool     `json:"show_photo"`
 }
 
 // Submit a mentor profile. Starts pending, awaiting a human moderator — nothing else
@@ -268,6 +269,7 @@ func (q *Queries) CreateMentorProfile(ctx context.Context, arg CreateMentorProfi
 		arg.MinNoticeMin,
 		arg.HorizonDays,
 		arg.MeetingUrl,
+		arg.ShowPhoto,
 	)
 	var i Mentor
 	err := row.Scan(
@@ -293,6 +295,7 @@ func (q *Queries) CreateMentorProfile(ctx context.Context, arg CreateMentorProfi
 		&i.DecidedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ShowPhoto,
 	)
 	return i, err
 }
@@ -302,7 +305,7 @@ UPDATE mentors
 SET status = $1, decided_by = $2,
     decided_at = now(), updated_at = now()
 WHERE id = $3 AND status = 'pending'
-RETURNING id, user_id, company_slug, slug, display_name, headline, bio, topics, languages, timezone, session_duration_min, buffer_before_min, buffer_after_min, min_notice_min, horizon_days, meeting_url, status, paused, decided_by, decided_at, created_at, updated_at
+RETURNING id, user_id, company_slug, slug, display_name, headline, bio, topics, languages, timezone, session_duration_min, buffer_before_min, buffer_after_min, min_notice_min, horizon_days, meeting_url, status, paused, decided_by, decided_at, created_at, updated_at, show_photo
 `
 
 type DecideMentorProfileParams struct {
@@ -340,6 +343,7 @@ func (q *Queries) DecideMentorProfile(ctx context.Context, arg DecideMentorProfi
 		&i.DecidedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ShowPhoto,
 	)
 	return i, err
 }
@@ -454,7 +458,7 @@ func (q *Queries) GetMentorBooking(ctx context.Context, id pgtype.UUID) (GetMent
 }
 
 const getMentorByID = `-- name: GetMentorByID :one
-SELECT id, user_id, company_slug, slug, display_name, headline, bio, topics, languages, timezone, session_duration_min, buffer_before_min, buffer_after_min, min_notice_min, horizon_days, meeting_url, status, paused, decided_by, decided_at, created_at, updated_at FROM mentors WHERE id = $1
+SELECT id, user_id, company_slug, slug, display_name, headline, bio, topics, languages, timezone, session_duration_min, buffer_before_min, buffer_after_min, min_notice_min, horizon_days, meeting_url, status, paused, decided_by, decided_at, created_at, updated_at, show_photo FROM mentors WHERE id = $1
 `
 
 // By primary key, for the paths that already hold one (booking, moderation).
@@ -484,12 +488,13 @@ func (q *Queries) GetMentorByID(ctx context.Context, id int64) (Mentor, error) {
 		&i.DecidedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ShowPhoto,
 	)
 	return i, err
 }
 
 const getMentorByUserID = `-- name: GetMentorByUserID :one
-SELECT id, user_id, company_slug, slug, display_name, headline, bio, topics, languages, timezone, session_duration_min, buffer_before_min, buffer_after_min, min_notice_min, horizon_days, meeting_url, status, paused, decided_by, decided_at, created_at, updated_at FROM mentors WHERE user_id = $1
+SELECT id, user_id, company_slug, slug, display_name, headline, bio, topics, languages, timezone, session_duration_min, buffer_before_min, buffer_after_min, min_notice_min, horizon_days, meeting_url, status, paused, decided_by, decided_at, created_at, updated_at, show_photo FROM mentors WHERE user_id = $1
 `
 
 // The owner's own profile, whatever its status — the mentor cabinet reads this, and a
@@ -520,6 +525,7 @@ func (q *Queries) GetMentorByUserID(ctx context.Context, userID int64) (Mentor, 
 		&i.DecidedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ShowPhoto,
 	)
 	return i, err
 }
@@ -566,7 +572,7 @@ func (q *Queries) GetMentorReviewSummary(ctx context.Context, mentorID int64) (G
 }
 
 const getPublishedMentorBySlug = `-- name: GetPublishedMentorBySlug :one
-SELECT m.id, m.user_id, m.company_slug, m.slug, m.display_name, m.headline, m.bio, m.topics, m.languages, m.timezone, m.session_duration_min, m.buffer_before_min, m.buffer_after_min, m.min_notice_min, m.horizon_days, m.meeting_url, m.status, m.paused, m.decided_by, m.decided_at, m.created_at, m.updated_at, c.name AS company_name,
+SELECT m.id, m.user_id, m.company_slug, m.slug, m.display_name, m.headline, m.bio, m.topics, m.languages, m.timezone, m.session_duration_min, m.buffer_before_min, m.buffer_after_min, m.min_notice_min, m.horizon_days, m.meeting_url, m.status, m.paused, m.decided_by, m.decided_at, m.created_at, m.updated_at, m.show_photo, c.name AS company_name,
     COALESCE(r.rating_count, 0)::bigint AS rating_count,
     COALESCE(r.rating_avg, 0)::numeric  AS rating_avg
 FROM mentors m
@@ -620,6 +626,7 @@ func (q *Queries) GetPublishedMentorBySlug(ctx context.Context, slug string) (Ge
 		&i.Mentor.DecidedAt,
 		&i.Mentor.CreatedAt,
 		&i.Mentor.UpdatedAt,
+		&i.Mentor.ShowPhoto,
 		&i.CompanyName,
 		&i.RatingCount,
 		&i.RatingAvg,
@@ -960,7 +967,7 @@ func (q *Queries) ListMentorBusyIntervals(ctx context.Context, arg ListMentorBus
 }
 
 const listPendingMentorProfiles = `-- name: ListPendingMentorProfiles :many
-SELECT m.id, m.user_id, m.company_slug, m.slug, m.display_name, m.headline, m.bio, m.topics, m.languages, m.timezone, m.session_duration_min, m.buffer_before_min, m.buffer_after_min, m.min_notice_min, m.horizon_days, m.meeting_url, m.status, m.paused, m.decided_by, m.decided_at, m.created_at, m.updated_at, c.name AS company_name,
+SELECT m.id, m.user_id, m.company_slug, m.slug, m.display_name, m.headline, m.bio, m.topics, m.languages, m.timezone, m.session_duration_min, m.buffer_before_min, m.buffer_after_min, m.min_notice_min, m.horizon_days, m.meeting_url, m.status, m.paused, m.decided_by, m.decided_at, m.created_at, m.updated_at, m.show_photo, c.name AS company_name,
     EXISTS (
         SELECT 1 FROM referral_offers r
         WHERE r.user_id = m.user_id AND r.company_slug = m.company_slug
@@ -1016,6 +1023,7 @@ func (q *Queries) ListPendingMentorProfiles(ctx context.Context) ([]ListPendingM
 			&i.Mentor.DecidedAt,
 			&i.Mentor.CreatedAt,
 			&i.Mentor.UpdatedAt,
+			&i.Mentor.ShowPhoto,
 			&i.CompanyName,
 			&i.HasApprovedReferralOffer,
 		); err != nil {
@@ -1030,7 +1038,7 @@ func (q *Queries) ListPendingMentorProfiles(ctx context.Context) ([]ListPendingM
 }
 
 const listPublishedMentors = `-- name: ListPublishedMentors :many
-SELECT m.id, m.user_id, m.company_slug, m.slug, m.display_name, m.headline, m.bio, m.topics, m.languages, m.timezone, m.session_duration_min, m.buffer_before_min, m.buffer_after_min, m.min_notice_min, m.horizon_days, m.meeting_url, m.status, m.paused, m.decided_by, m.decided_at, m.created_at, m.updated_at, c.name AS company_name,
+SELECT m.id, m.user_id, m.company_slug, m.slug, m.display_name, m.headline, m.bio, m.topics, m.languages, m.timezone, m.session_duration_min, m.buffer_before_min, m.buffer_after_min, m.min_notice_min, m.horizon_days, m.meeting_url, m.status, m.paused, m.decided_by, m.decided_at, m.created_at, m.updated_at, m.show_photo, c.name AS company_name,
     COALESCE(r.rating_count, 0)::bigint AS rating_count,
     COALESCE(r.rating_avg, 0)::numeric  AS rating_avg
 FROM mentors m
@@ -1107,6 +1115,7 @@ func (q *Queries) ListPublishedMentors(ctx context.Context, arg ListPublishedMen
 			&i.Mentor.DecidedAt,
 			&i.Mentor.CreatedAt,
 			&i.Mentor.UpdatedAt,
+			&i.Mentor.ShowPhoto,
 			&i.CompanyName,
 			&i.RatingCount,
 			&i.RatingAvg,
@@ -1147,7 +1156,7 @@ const setMentorPaused = `-- name: SetMentorPaused :one
 UPDATE mentors
 SET paused = $1, updated_at = now()
 WHERE user_id = $2
-RETURNING id, user_id, company_slug, slug, display_name, headline, bio, topics, languages, timezone, session_duration_min, buffer_before_min, buffer_after_min, min_notice_min, horizon_days, meeting_url, status, paused, decided_by, decided_at, created_at, updated_at
+RETURNING id, user_id, company_slug, slug, display_name, headline, bio, topics, languages, timezone, session_duration_min, buffer_before_min, buffer_after_min, min_notice_min, horizon_days, meeting_url, status, paused, decided_by, decided_at, created_at, updated_at, show_photo
 `
 
 type SetMentorPausedParams struct {
@@ -1183,6 +1192,7 @@ func (q *Queries) SetMentorPaused(ctx context.Context, arg SetMentorPausedParams
 		&i.DecidedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ShowPhoto,
 	)
 	return i, err
 }
@@ -1201,9 +1211,10 @@ SET display_name = $1,
     min_notice_min = $10,
     horizon_days = $11,
     meeting_url = $12,
+    show_photo = $13,
     updated_at = now()
-WHERE user_id = $13
-RETURNING id, user_id, company_slug, slug, display_name, headline, bio, topics, languages, timezone, session_duration_min, buffer_before_min, buffer_after_min, min_notice_min, horizon_days, meeting_url, status, paused, decided_by, decided_at, created_at, updated_at
+WHERE user_id = $14
+RETURNING id, user_id, company_slug, slug, display_name, headline, bio, topics, languages, timezone, session_duration_min, buffer_before_min, buffer_after_min, min_notice_min, horizon_days, meeting_url, status, paused, decided_by, decided_at, created_at, updated_at, show_photo
 `
 
 type UpdateMentorProfileParams struct {
@@ -1219,6 +1230,7 @@ type UpdateMentorProfileParams struct {
 	MinNoticeMin       int32    `json:"min_notice_min"`
 	HorizonDays        int32    `json:"horizon_days"`
 	MeetingUrl         string   `json:"meeting_url"`
+	ShowPhoto          bool     `json:"show_photo"`
 	UserID             int64    `json:"user_id"`
 }
 
@@ -1243,6 +1255,7 @@ func (q *Queries) UpdateMentorProfile(ctx context.Context, arg UpdateMentorProfi
 		arg.MinNoticeMin,
 		arg.HorizonDays,
 		arg.MeetingUrl,
+		arg.ShowPhoto,
 		arg.UserID,
 	)
 	var i Mentor
@@ -1269,6 +1282,7 @@ func (q *Queries) UpdateMentorProfile(ctx context.Context, arg UpdateMentorProfi
 		&i.DecidedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ShowPhoto,
 	)
 	return i, err
 }

--- a/internal/platform/db/models.go
+++ b/internal/platform/db/models.go
@@ -870,6 +870,7 @@ type Mentor struct {
 	DecidedAt pgtype.Timestamptz `json:"decided_at"`
 	CreatedAt pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
+	ShowPhoto bool               `json:"show_photo"`
 }
 
 // A mentor's availability in two row shapes: weekly (weekday set) and dated override (on_date set). A dated row replaces its whole date; an empty dated row closes it.

--- a/internal/platform/db/queries/mentorship.sql
+++ b/internal/platform/db/queries/mentorship.sql
@@ -6,8 +6,8 @@
 INSERT INTO mentors (
     user_id, company_slug, slug, display_name, headline, bio, topics, languages, timezone,
     session_duration_min, buffer_before_min, buffer_after_min, min_notice_min,
-    horizon_days, meeting_url
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+    horizon_days, meeting_url, show_photo
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
 RETURNING *;
 
 -- name: GetMentorByUserID :one
@@ -58,6 +58,7 @@ SET display_name = sqlc.arg(display_name),
     min_notice_min = sqlc.arg(min_notice_min),
     horizon_days = sqlc.arg(horizon_days),
     meeting_url = sqlc.arg(meeting_url),
+    show_photo = sqlc.arg(show_photo),
     updated_at = now()
 -- Keyed on user_id ALONE, which UNIQUE (user_id) makes a single row. Taking an id as well
 -- would mean the caller reading the profile first just to learn one, which is a round trip

--- a/migrations/0152_mentors_show_photo.sql
+++ b/migrations/0152_mentors_show_photo.sql
@@ -1,0 +1,9 @@
+-- show_photo is the mentor's own opt-in to serve their account's stored CV headshot on
+-- their public directory card and profile page. Off by default: the mentor-profile spec
+-- originally deferred an avatar entirely because the account's headshot is a job-search
+-- photo a mentor may not want reused here, and that concern still holds — this column is
+-- what lets a mentor decide, rather than the product deciding for them.
+--
+-- NOT NULL DEFAULT false is additive on Postgres 11+ (a constant default needs no table
+-- rewrite), so this needs no backfill step.
+ALTER TABLE mentors ADD COLUMN show_photo boolean NOT NULL DEFAULT false;

--- a/openspec/changes/mentorship-profile-prefill-avatar/.openspec.yaml
+++ b/openspec/changes/mentorship-profile-prefill-avatar/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/mentorship-profile-prefill-avatar/design.md
+++ b/openspec/changes/mentorship-profile-prefill-avatar/design.md
@@ -1,0 +1,99 @@
+## Context
+
+`internal/engage/mentorship` (layer 7) already sits above `internal/candidate` (layer 4)
+and `internal/identity` (layer 3) in the layering table, so it could import either
+directly. It does not today, and its `Profile`/`ProfileInput`/`Service` know nothing
+about résumés, experience or user profiles. `internal/api/handler` (layer 8) already
+composes exactly this shape of read for an unrelated feature: `me_profile.go`'s
+`profileHandlers` reads `userprofile.Service`, a narrow `structuredResumeReader` slice
+of `*resume.Store`, and a `candidateProfiler` slice of `*experience.Store`, each
+consulted best-effort and independently, to answer `GET /me/profile`. Company existence
+is a single `db.Queries.CompanyExists(ctx, slug) (bool, error)` call — the create flow
+today instead relies on the `company_slug` foreign key rejecting an unknown company at
+insert time (`internal/engage/mentorship/repository.go`), which the read-only
+suggestions endpoint cannot reuse. Headshot bytes come from
+`headshot.Store.Get(ctx, userID) ([]byte, error)`, already used by
+`internal/api/handler/photo.go`'s `GetPhotoImage` for the caller's own photo.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Compose mentor-profile suggestions the same way `me_profile.go` composes its `cv`
+  block: narrow reader interfaces, best-effort, independent per field.
+- Serve a mentor's own headshot publicly only through their own explicit,
+  per-profile opt-in, reusing the account's single stored copy.
+
+**Non-Goals:**
+- No new photo storage, resizing, or caching layer — `show_photo` gates read access to
+  the existing `headshot.Store` object, nothing else.
+- No fuzzy or LLM-assisted company matching — only the exact slug match the create flow
+  already enforces via the foreign key.
+- No change to how `internal/engage/mentorship` validates or stores a profile beyond
+  the one new `show_photo` column; the domain package still knows nothing about résumés
+  or experience.
+
+## Decisions
+
+**Composition lives in `internal/api/handler`, not in `internal/engage/mentorship`.**
+Mirrors `me_profile.go` exactly: a new `mentorship_suggestions.go` defines a narrow
+`mentorSuggestionSources` interface (résumé, user profile, account timezone,
+experience-bank current employment, company-existence check) so the handler is
+unit-testable without a database, and keeps the mentorship domain package free of
+`candidate`/`identity` imports it would otherwise never need. Alternative considered:
+add a `SuggestProfile` method on `mentorship.Service` that takes those stores as
+arguments — rejected because it would make the domain package's constructor depend on
+four unrelated blocks' types for a feature that is pure read composition, exactly the
+shape `me_profile.go` already chose to keep out of `userprofile.Service`.
+
+**The company suggestion resolves through `normalize.CompanySlug` + `CompanyExists`,
+not a new lookup path.** `normalize.CompanySlug` is the one legal-form vocabulary the
+codebase uses for this; running a bank's free-text current employer through it and then
+checking `db.Queries.CompanyExists` matches exactly what the create flow's foreign key
+would accept, so a suggested company is guaranteed to submit successfully. No new
+company-matching logic is introduced.
+
+**`show_photo` is a profile column, not a derived flag.** It needs to survive
+independent of whether a headshot happens to exist at the moment — a mentor who opts in
+before uploading a CV photo, or removes their CV photo later, keeps their stated
+preference rather than having it silently reset. The public photo route computes "serve
+or 404" at request time from `show_photo AND status == approved AND !paused AND
+headshot exists`, so no denormalized "has photo" flag needs to stay in sync.
+
+**The photo route reuses `GetMentor`'s resolution and predicate, not a copy of it.**
+`GetMentor` already turns a slug into a `Profile` and enforces
+`approved && !paused`; the new `GET /mentors/:slug/photo` calls the same resolution
+before checking `ShowPhoto`, so the two routes cannot drift on what "publicly readable"
+means (the existing `mentor-profile` spec already calls this out as a reason the
+directory-entry-point feature reuses the directory query instead of a second
+"has a mentor?" endpoint — the same reasoning applies here).
+
+**Every non-serving reason for the photo route maps to the same 404** (no photo, not
+approved/paused, opted out, storage unconfigured) rather than distinguishing them in
+the response. A mentor's opt-out and a mentor's absent photo must be indistinguishable
+from outside — otherwise the response itself would leak whether a mentor who opted out
+has a CV photo at all, a narrower but real version of the privacy concern the opt-in
+exists to address.
+
+**Suggestions are a separate endpoint, not a query parameter on `GET
+/me/mentorship/profile`.** That existing route already means "my profile, or null" one
+way; overloading it with "or, if null, suggestions" would make the response shape
+depend on whether a profile exists, which the frontend would need to branch on anyway.
+A dedicated `GET /me/mentorship/profile/suggestions` keeps `GetMyMentorProfile`
+unchanged and the new endpoint independently cacheable/skippable by a caller that
+doesn't need it (e.g., the edit path never calls it).
+
+## Risks / Trade-offs
+
+- **A résumé/experience-bank/user-profile read failure must not block profile
+  creation.** → Every source is read independently inside the aggregator and a failing
+  or absent source simply omits its field(s), exactly as `me_profile.go`'s
+  `structuredCV`/`derivedLocation` degrade; the suggestions endpoint itself has no
+  non-2xx path tied to source data.
+- **`CompanyExists` adds one query to a form-load path.** → It is a single indexed
+  lookup on an already-normalized slug, called at most once per suggestions request,
+  which itself only fires once (on mount, before a profile exists) — negligible next to
+  the résumé/experience-bank reads already in the same request.
+- **A mentor who opts in, then deletes their CV headshot, leaves `show_photo` stuck
+  true with nothing to serve.** → Accepted: the photo route already 404s cleanly on a
+  missing headshot regardless of the flag, so this degrades to "no photo shown," not an
+  error, and re-uploading a headshot makes it reappear with no further action.

--- a/openspec/changes/mentorship-profile-prefill-avatar/proposal.md
+++ b/openspec/changes/mentorship-profile-prefill-avatar/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+Creating a mentor profile at `/my/mentorship/profile` starts from a completely blank
+form — name, headline, bio, topics, languages, timezone and company are all typed from
+scratch, even though most of that already exists on the candidate's account (résumé,
+user profile, experience bank). That friction is a plausible reason the mentor pool
+stays small. Separately, a published mentor's public card and page carry no picture at
+all — the `mentor-profile` spec deliberately deferred an avatar, noting the account's
+CV headshot is a job-search photo a mentor may not want reused here without asking.
+Both gaps are addressed together because solving the second is now cheap once we are
+already willing to compose the candidate's stored data for prefill — but the photo
+still needs the mentor's own explicit consent, since the original deferral's privacy
+concern still holds.
+
+## What Changes
+
+- New endpoint `GET /me/mentorship/profile/suggestions`, read-only, composed solely
+  from the candidate's résumé, user profile, account and experience bank — never from
+  the mentor profile itself, so it answers the same way whether or not one exists. Only
+  the create form calls it, and only before a profile exists. Best-effort, per field:
+  name, headline,
+  bio and languages from the résumé; topics from the user profile's specializations;
+  timezone from the account; and a current-employer company suggestion, included only
+  on an exact, verified company-catalog match. A missing or unmatched source simply
+  omits that field — nothing about this endpoint can fail the create flow.
+- The mentor-profile **create** form seeds itself from those suggestions instead of
+  blank defaults. Every field stays an ordinary, independently editable input — this is
+  a one-time starting point, not a live sync. Editing an already-existing profile is
+  unchanged.
+- A new `show_photo` field on the mentor profile — an explicit, off-by-default opt-in,
+  editable like any other profile field. A mentor who turns it on has their account's
+  stored CV headshot served on their public directory card and profile page, through a
+  new narrow public endpoint scoped to that one approved, opted-in profile. A mentor who
+  never opts in changes nothing about their existing CV-photo privacy, and nobody's
+  headshot becomes reachable through this endpoint without that mentor's own opt-in.
+- Public directory card and profile page render the photo when `show_photo` is true and
+  a photo exists, falling back cleanly (no broken image) otherwise.
+
+## Capabilities
+
+### New Capabilities
+- `mentor-profile-prefill`: read-only, best-effort suggestions for a mentor's own
+  not-yet-created profile, composed from their résumé, user profile, account and
+  experience bank.
+
+### Modified Capabilities
+- `mentor-profile`: adds the `show_photo` opt-in field and the public photo endpoint
+  the spec's "An avatar is NOT part of this requirement" section explicitly deferred,
+  now resolved with mentor-controlled consent rather than automatic reuse.
+
+## Impact
+
+- **Backend**: `internal/engage/mentorship` (profile fields, validation, repository
+  params), a migration adding `mentors.show_photo`, `internal/api/handler`
+  (`mentorship_write.go`/`mentorship.go` for the new field and the new public photo
+  route; a new narrow aggregator, likely `mentorship_suggestions.go`, composing
+  `internal/candidate/resume`, `internal/candidate/experience`,
+  `internal/identity/userprofile`, `internal/identity/accounts`, and the existing
+  company-lookup behind mentor-profile creation).
+- **Frontend**: `web/src/lib/components/MentorProfileEditor.svelte` (prefill + opt-in
+  checkbox), `web/src/lib/components/MentorsView.svelte` and
+  `web/src/routes/mentors/[slug]/+page.svelte` (avatar rendering), `web/src/lib/types.ts`
+  and `web/src/lib/api.ts` (new wire types and the suggestions call).
+- **No changes** to booking, availability, moderation, or the withdraw/pause flows.

--- a/openspec/changes/mentorship-profile-prefill-avatar/specs/mentor-profile-prefill/spec.md
+++ b/openspec/changes/mentorship-profile-prefill-avatar/specs/mentor-profile-prefill/spec.md
@@ -1,0 +1,67 @@
+## Purpose
+
+Gives a candidate who has not yet created a mentor profile a read-only, best-effort
+starting point drawn from data they already gave the product elsewhere, so the create
+form does not start from nothing.
+
+## ADDED Requirements
+
+### Requirement: Suggestions are composed per field, independently
+
+The system SHALL answer a suggestions request with one candidate value per mentor
+profile field, each resolved independently from its own source: display name,
+headline, bio and languages from the candidate's résumé; topics from the user
+profile's specializations; timezone from the account. A field whose source is absent
+or empty SHALL simply be omitted from the response rather than reported as an error or
+filled with an empty placeholder.
+
+#### Scenario: A candidate with a full résumé and profile gets every field suggested
+
+- **WHEN** a candidate with a complete résumé, timezone and specializations who has no
+  mentor profile requests suggestions
+- **THEN** the response carries a suggested name, headline, bio, languages, topics and
+  timezone
+
+#### Scenario: A candidate with no usable source data gets an empty, successful answer
+
+- **WHEN** a candidate with no résumé, no specializations and no account timezone
+  requests suggestions
+- **THEN** the request succeeds
+- **AND** the response carries no field suggestions
+
+### Requirement: A company suggestion requires an exact catalog match
+
+The system SHALL suggest a company only when the candidate's current employer, as held
+in their experience bank, resolves through the same slug normalization the profile
+create flow uses to a company that exists in the company catalog. An employer that
+does not resolve to an existing company SHALL be omitted from the response rather than
+guessed at or normalized further.
+
+#### Scenario: A current employer matching the catalog is suggested
+
+- **WHEN** a candidate's experience bank names a current employer whose normalized slug
+  matches an existing company
+- **THEN** the response suggests that company
+
+#### Scenario: An unmatched employer is omitted, not guessed
+
+- **WHEN** a candidate's experience bank names a current employer whose normalized slug
+  matches no existing company
+- **THEN** the response carries no company suggestion
+
+### Requirement: Suggestions never read or alter an existing mentor profile
+
+The system SHALL answer the suggestions request the same way regardless of whether the
+caller already has a mentor profile — the endpoint composes only résumé, user-profile,
+account and experience-bank data, never the mentor profile itself. The response SHALL
+NOT be used to alter an existing profile, and carries no side effect: it changes nothing
+the caller has already submitted. A caller who already has a profile gains nothing by
+calling it — the create form is the only caller, and it does so only before a profile
+exists — but the endpoint refuses no one and needs no mentor-profile lookup to answer.
+
+#### Scenario: An existing mentor's suggestions request has no effect on their profile
+
+- **WHEN** a candidate who already has a mentor profile requests suggestions
+- **THEN** the request answers with the same best-effort suggestions any caller would get
+- **AND** their existing mentor profile is not read, not altered, and not referenced in
+  the response

--- a/openspec/changes/mentorship-profile-prefill-avatar/specs/mentor-profile/spec.md
+++ b/openspec/changes/mentorship-profile-prefill-avatar/specs/mentor-profile/spec.md
@@ -1,0 +1,73 @@
+## MODIFIED Requirements
+
+### Requirement: A mentor profile is public and named
+
+A published mentor profile SHALL show the mentor's display name, headline, company and
+topics to any visitor, signed in or not. A mentor profile SHALL NOT be anonymised in the
+manner of a referral offer.
+
+The display name SHALL be a field of the PROFILE, not read from the account: `users`
+carries no name at all — only an address and a username, and a username is an address
+rather than a name.
+
+A profile SHALL carry a `show_photo` opt-in, defaulting to off, that controls whether
+the mentor's account headshot is served publicly (see the photo requirement below). A
+profile that has never opted in SHALL remain exactly as pictureless as this requirement
+originally described.
+
+#### Scenario: An anonymous visitor reads a published profile
+
+- **WHEN** a signed-out visitor opens an approved mentor's public URL
+- **THEN** the response carries the mentor's name, headline, company and topics
+
+#### Scenario: A profile without a name is refused
+
+- **WHEN** a profile is submitted with an empty or whitespace-only display name
+- **THEN** the submission is refused
+- **AND** no profile row is written
+
+#### Scenario: A pending profile is not publicly readable
+
+- **WHEN** a signed-out visitor requests the public URL of a profile whose status is
+  `pending`, `rejected` or `paused`
+- **THEN** the system responds as it would for a profile that does not exist
+- **AND** the owner and a moderator can still read it through their own routes
+
+## ADDED Requirements
+
+### Requirement: A mentor's photo is shown only with their explicit opt-in
+
+The system SHALL serve a mentor's account headshot on their public directory card and
+profile page only when that mentor's own `show_photo` field is set to true. Setting
+`show_photo` SHALL be an ordinary, mentor-controlled edit to their own profile, off by
+default for both a newly created and a pre-existing profile. Opting in SHALL NOT copy
+or duplicate the photo into mentor-specific storage — the account's existing CV
+headshot remains the single stored copy, and turning the opt-in back off SHALL stop it
+being served publicly with no further action needed.
+
+The photo SHALL be reachable only for a profile that is currently public under the
+existing publication rule (`approved` and not paused): opting in does not create a way
+to read a photo for a profile that itself is not publicly readable.
+
+#### Scenario: An opted-in, approved mentor's photo is publicly served
+
+- **WHEN** an approved, unpaused mentor with `show_photo` set to true has a stored
+  account headshot
+- **THEN** a signed-out visitor's request for that mentor's public photo succeeds
+
+#### Scenario: A mentor who has not opted in serves no photo
+
+- **WHEN** a mentor has `show_photo` set to false, whether or not they have a stored
+  account headshot
+- **THEN** a request for their public photo does not serve it
+
+#### Scenario: Opting in without a stored headshot serves no photo
+
+- **WHEN** a mentor sets `show_photo` to true but has no stored account headshot
+- **THEN** a request for their public photo does not serve it
+
+#### Scenario: A non-public profile's photo is not reachable regardless of opt-in
+
+- **WHEN** a mentor profile is `pending`, `rejected`, `paused`, or withdrawn, even with
+  `show_photo` set to true and a stored headshot
+- **THEN** a request for that mentor's public photo does not serve it

--- a/openspec/changes/mentorship-profile-prefill-avatar/tasks.md
+++ b/openspec/changes/mentorship-profile-prefill-avatar/tasks.md
@@ -1,0 +1,143 @@
+## 1. Database
+
+- [x] 1.1 Add migration `0152_mentors_show_photo.sql`: `mentors.show_photo boolean NOT
+      NULL DEFAULT false`
+- [x] 1.2 Update `CreateMentorProfile` and `UpdateMentorProfile` in
+      `internal/platform/db/queries/mentorship.sql` to read/write `show_photo`; run
+      `make sqlc`
+
+## 2. Domain: `internal/engage/mentorship`
+
+- [x] 2.1 Add `ShowPhoto bool` to `Profile` and `ProfileInput` (`profile.go`)
+- [x] 2.2 Wire `ShowPhoto` through `QueriesRepository.CreateProfile`/`UpdateProfile`
+      params and `profileFromRow` (`repository.go`)
+- [x] 2.3 Unit test: create/update round-trips `show_photo` both ways (default false,
+      explicit true), matching the `mentor-profile` spec's new requirement scenarios
+
+## 3. Backend: mentor-profile HTTP surface
+
+- [x] 3.1 Add `show_photo` to `profileRequest`/`toInput` and to `mentorResponse`/
+      `toMentorResponse`/`toOwnMentorResponse`/`toModeratorMentorResponse`
+      (`internal/api/handler/mentorship_write.go`, `internal/api/handler/mentorship.go`)
+      — present on directory, profile-read and owner/moderator views alike
+- [x] 3.2 Add `GET /mentors/:slug/photo` to `registerPublic`: resolve via the same
+      lookup `GetMentor` uses, require `status == approved && !paused && ShowPhoto`,
+      then serve `headshot.Store.Get(ctx, profile.UserID)`; map every non-serving
+      reason (no photo, not approved/paused, opted out, storage unconfigured) to the
+      same 404, per the spec's "same 404" requirement
+- [x] 3.3 Wire a `headshot.Store` dependency into `mentorshipHandlers`
+      (`newMentorshipHandlers`, `internal/api/handler/handler.go`)
+- [x] 3.4 Unit tests for the photo route: approved+opted-in+has-photo (200, image
+      bytes, `image/jpeg` content type), approved+opted-in+no-photo (404),
+      approved+opted-out (404) regardless of stored photo, pending/paused/withdrawn
+      (404) regardless of opt-in, storage unconfigured (404). The pending/paused/
+      withdrawn case is exercised at the `mentorPhoto`/`GetMentorPhoto` seam by
+      construction — it reuses `PublicProfile`'s existing predicate rather than a
+      second copy, and that predicate's own scenarios are already covered by
+      `internal/platform/db`'s mentorship integration tests
+
+## 4. Backend: mentor-profile-prefill suggestions
+
+- [x] 4.1 Define narrow, single-method `mentorSuggestion*` interfaces (mirroring
+      `structuredResumeReader` in `me_profile.go`) covering: résumé (name, headline,
+      bio, languages), user profile (`Specializations`), account (`Timezone`),
+      experience bank (`ListEmployments`, filtered in the aggregator to
+      `Kind == job && Current`), and `db.Queries.CompanyExists`. (Split into five
+      one-method interfaces rather than one `mentorSuggestionSources` — each is
+      trivially satisfied by the existing concrete service with no adapter, and each is
+      faked with one line in the test.) **Corrected during the manual `run`-skill
+      verification below**: the résumé interface first exposed `Structured` +
+      `CandidateOwned` (mirroring `structuredCV`'s own composition), but
+      `Owned.ApplyBody` only ever merges the five BODY fields (headline/summary/
+      languages/certifications/education) — never identity (`FullName` included). A
+      candidate who set their name only via the owned-contacts overlay, with no CV
+      upload, would have gotten no name suggestion at all. Switched to
+      `StructureForSeed` — the same identity-plus-body composition `cv_seed.go`
+      already uses to seed a new document from a candidate's data — which is the
+      actually-correct primitive for "seed a new form," not `structuredCV`'s.
+- [x] 4.2 Implement the composition in a new
+      `internal/api/handler/mentorship_suggestions.go`: each field independently
+      best-effort (a failing or absent source omits its field, never fails the
+      request); company suggestion included only when
+      `normalize.CompanySlug(currentEmployer)` exactly matches via `CompanyExists`
+- [x] 4.3 Add `GET /me/mentorship/profile/suggestions` (auth required, `mw.key`);
+      response omits absent fields rather than emitting empty strings/arrays for them.
+      Reads only résumé/user-profile/account/experience-bank, never the mentor profile
+      itself, so it answers the same way whether or not the caller already has one — see
+      the corrected `mentor-profile-prefill` spec (the original wording gated the
+      endpoint on "no profile yet", which contradicted its own no-side-effect scenario;
+      fixed during implementation, both proposal.md and the spec updated)
+- [x] 4.4 Unit tests, table-driven: full data → all fields present; no data → success
+      with every field absent; unmatched employer → company field absent. (The "caller
+      already has a profile" case needs no separate test: the aggregator has no
+      dependency on the mentor profile at all, so it structurally cannot see or be
+      affected by one.)
+
+## 5. Frontend: create-form prefill
+
+- [x] 5.1 Add a `MentorProfileSuggestions` type and an
+      `api.mentorProfileSuggestions()` call (`web/src/lib/types.ts`,
+      `web/src/lib/api.ts`)
+- [x] 5.2 In `MentorProfileEditor.svelte`, when `profile === null`, fetch suggestions
+      once on mount and seed `blank()` from them; each field stays independently
+      editable afterward, and a failed fetch falls back to today's empty defaults
+      (never blocks rendering the form). The merge itself is a pure, unit-tested
+      function (`seedFormFromSuggestions` in `mentorship.ts`) — the component only
+      wires the fetch and applies the result, following this codebase's convention of
+      keeping testable logic out of `.svelte` files
+- [x] 5.3 Add the `show_photo` opt-in checkbox to the form: default unchecked for a
+      new profile, reflects the stored value when editing an existing one, with copy
+      stating it publishes the account's existing CV photo
+
+## 6. Frontend: public avatar
+
+- [x] 6.1 Add `show_photo: boolean` to the `Mentor` type (`web/src/lib/types.ts`)
+- [x] 6.2 Render a circular avatar `<img src="/api/v1/mentors/{slug}/photo">` in
+      `MentorsView.svelte` (directory card) and
+      `web/src/routes/mentors/[slug]/+page.svelte` (profile page) only when
+      `mentor.show_photo` is true; `onerror`-hide as a backstop so a 404 never shows a
+      broken-image icon
+
+## 7. Verification
+
+- [x] 7.1 `gofmt -w`, `go vet ./...`, `go test ./...` on touched Go packages;
+      `golangci-lint run` for the layering guard (composition stays in
+      `internal/api/handler`, `internal/engage/mentorship` gains no new imports beyond
+      the `show_photo` field). Also ran, all clean: `go vet -tags=integration ./...`,
+      the layering test with `-tags=integration,llmlive`, `golangci-lint run
+      --new-from-rev=origin/main ./...` (0 new issues), `deadcode -test
+      -tags=integration,llmlive ./...` (nothing new), `node scripts/check-migrations.mjs`
+      on the new migration (0 issues), `make sqlc` (idempotent, no drift), `svelte-check`
+      (0 errors), `eslint` on every touched frontend file (clean), and the full frontend
+      `vitest run` (1781 passed)
+- [x] 7.2 Manual check via the `run` skill, driven live in a real Chromium browser
+      (Playwright) against `make up`-equivalent local Postgres/MinIO + `go run
+      ./cmd/server` + `vite dev`: registered a test account, seeded résumé contacts
+      (`PUT /me/resume/contacts`), a user-profile specialization (`PUT /me/profile`),
+      an account timezone (`PATCH /me/timezone`), and a current job "Acme Inc" in the
+      experience bank (`POST /me/experience/employments`), with a matching `acme`
+      company row inserted for the exact-match check.
+      - Visited `/my/mentorship/profile` with no existing profile: the create form
+        came back seeded with name "Jane Doe", headline, bio, languages, topic
+        "backend", timezone "Europe/Berlin" and company slug "acme" — confirmed by
+        DOM inspection, screenshot, and `GET .../suggestions` called directly
+        (returned all seven fields). "Your URL" and "Meeting link" correctly stayed
+        blank (never suggested); filled both and submitted — profile created
+        `pending`, form switched to edit mode with the same values retained.
+      - Approved the profile (`status='approved'`) directly in Postgres (no
+        moderator UI in this change's scope), checked `show_photo` in the edit form
+        and saved, then visited the public `/mentors` directory and
+        `/mentors/jane-doe-test`: both rendered the circular avatar
+        (`GET /api/v1/mentors/jane-doe-test/photo` → 200), zero console errors.
+      - Unchecked `show_photo` and saved: the avatar disappeared from the public
+        profile page with zero `<img src*="/photo">` elements and zero console
+        errors — no broken-image icon.
+      - Found and fixed a real bug in this pass (see task 4.1's note): the
+        suggestions aggregator originally used `Structured`+`CandidateOwned`, which
+        never merges identity fields, so `name` would have stayed unsuggested for a
+        candidate who set it only via the contacts overlay. Fixed before this
+        check's first successful run.
+      - Two infrastructure hiccups along the way, neither a code defect: OrbStack's
+        Docker daemon crashed mid-setup (waited for the user to restart it, then
+        recreated the compose containers against the same volumes); and the Vite
+        dev server's proxy briefly 502'd after that restart until relaunched fresh.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -49,6 +49,7 @@ import type {
   Mentor,
   MentorAvailabilityRule,
   MentorProfileInput,
+  MentorProfileSuggestions,
   MentorSession,
   MentorSessions,
   MentorSlot,
@@ -795,6 +796,14 @@ export function createApi(
       if (e instanceof ApiError && e.status === 404) return null;
       throw e;
     }
+  }
+
+  /** Best-effort prefill for the create form, from the candidate's résumé, user
+   *  profile, account and experience bank — never from the mentor profile itself. Only
+   *  the create form calls it, and only before a profile exists; a failure here must
+   *  not block rendering the (then blank) form. */
+  async function mentorProfileSuggestions(): Promise<MentorProfileSuggestions> {
+    return requestData<MentorProfileSuggestions>('/api/v1/me/mentorship/profile/suggestions');
   }
 
   async function createMentorProfile(body: MentorProfileInput): Promise<OwnMentorProfile> {
@@ -2650,6 +2659,7 @@ export function createApi(
     cancelMySession,
     reviewMySession,
     myMentorProfile,
+    mentorProfileSuggestions,
     createMentorProfile,
     updateMentorProfile,
     pauseMentorProfile,

--- a/web/src/lib/components/MentorProfileEditor.svelte
+++ b/web/src/lib/components/MentorProfileEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { api } from '$lib/api';
-  import { browserTimezone } from '$lib/mentorship';
+  import { browserTimezone, seedFormFromSuggestions } from '$lib/mentorship';
   import { errorMessage } from '$lib/utils';
   import { Badge, Button, Card, Input } from '$lib/ui';
   import type { MentorProfileInput, OwnMentorProfile } from '$lib/types';
@@ -28,6 +29,7 @@
       notice_minutes: 120,
       horizon_days: 30,
       meeting_url: '',
+      show_photo: false,
     };
   }
 
@@ -50,6 +52,7 @@
       notice_minutes: p.notice_minutes ?? 120,
       horizon_days: p.horizon_days ?? 30,
       meeting_url: p.meeting_url,
+      show_photo: p.show_photo,
     };
   }
 
@@ -58,6 +61,24 @@
   let languagesText = $state(profile ? profile.languages.join(', ') : '');
   let saving = $state(false);
   let error = $state('');
+
+  // A one-time prefill for a brand-new profile only: fetched once on mount, seeded into
+  // the still-blank form, and never touched again — every field stays an ordinary,
+  // independently editable input from here on. A failed fetch simply leaves the form at
+  // its ordinary blank defaults; it must never block rendering the form.
+  if (!profile) {
+    onMount(async () => {
+      try {
+        const suggestions = await api.mentorProfileSuggestions();
+        const seeded = seedFormFromSuggestions(form, suggestions);
+        form = seeded.form;
+        topicsText = seeded.topicsText;
+        languagesText = seeded.languagesText;
+      } catch {
+        // Best-effort: the form already has its ordinary blank defaults.
+      }
+    });
+  }
 
   const list = (text: string) =>
     text
@@ -214,6 +235,14 @@
         bind:value={form.meeting_url}
         class="mt-1 w-full"
       />
+    </label>
+
+    <label class="flex items-center gap-2 text-sm sm:col-span-2">
+      <input type="checkbox" bind:checked={form.show_photo} class="h-4 w-4" />
+      <span class="text-muted-foreground">
+        Show my account's CV photo on my public mentor card and profile. Off by default —
+        you decide whether that photo belongs here too.
+      </span>
     </label>
 
     <label class="text-sm sm:col-span-2">

--- a/web/src/lib/components/MentorsView.svelte
+++ b/web/src/lib/components/MentorsView.svelte
@@ -137,11 +137,24 @@
           >
             <Card class="h-full p-4">
               <div class="flex flex-col gap-2">
-                <div>
-                  <p class="font-medium">{mentor.name}</p>
-                  <p class="text-muted-foreground text-sm">
-                    {mentor.headline} · {mentor.company_name}
-                  </p>
+                <div class="flex items-center gap-3">
+                  {#if mentor.show_photo}
+                    <img
+                      src={`/api/v1/mentors/${mentor.slug}/photo`}
+                      alt=""
+                      loading="lazy"
+                      class="border-border size-10 shrink-0 rounded-full border object-cover"
+                      onerror={(e) => {
+                        (e.currentTarget as HTMLImageElement).style.display = 'none';
+                      }}
+                    />
+                  {/if}
+                  <div>
+                    <p class="font-medium">{mentor.name}</p>
+                    <p class="text-muted-foreground text-sm">
+                      {mentor.headline} · {mentor.company_name}
+                    </p>
+                  </div>
                 </div>
 
                 {#if mentor.topics.length > 0}

--- a/web/src/lib/mentorship.test.ts
+++ b/web/src/lib/mentorship.test.ts
@@ -6,6 +6,7 @@ import {
   emptyMentorFilters,
   monthGrid,
   monthOf,
+  seedFormFromSuggestions,
   slotWindowForMonth,
   todayIn,
   withSearchParams,
@@ -24,7 +25,14 @@ import {
   weekdayOrder,
   weekdayShortLabel,
 } from './mentorship';
-import type { Mentor, MentorAvailabilityRule, MentorSession, MentorSlot } from './types';
+import type {
+  Mentor,
+  MentorAvailabilityRule,
+  MentorProfileInput,
+  MentorProfileSuggestions,
+  MentorSession,
+  MentorSlot,
+} from './types';
 
 function rule(over: Partial<MentorAvailabilityRule> = {}): MentorAvailabilityRule {
   return { id: 1, weekday: 1, date: null, start: '18:00', end: '21:00', closure: false, ...over };
@@ -69,6 +77,7 @@ function mentor(over: Partial<Mentor> = {}): Mentor {
     session_minutes: 60,
     rating_count: 0,
     rating_avg: 0,
+    show_photo: false,
     ...over,
   };
 }
@@ -541,5 +550,69 @@ describe('writing the booker state back to the query', () => {
     const current = new URLSearchParams('month=2026-10');
     withSearchParams(current, { date: '2026-10-15' });
     expect(current.toString()).toBe('month=2026-10');
+  });
+});
+
+describe('seedFormFromSuggestions', () => {
+  function blankForm(): MentorProfileInput {
+    return {
+      company_slug: '',
+      slug: '',
+      name: '',
+      headline: '',
+      bio: '',
+      topics: [],
+      languages: [],
+      timezone: 'Europe/Amsterdam',
+      session_minutes: 60,
+      buffer_before_minutes: 0,
+      buffer_after_minutes: 15,
+      notice_minutes: 120,
+      horizon_days: 30,
+      meeting_url: '',
+      show_photo: false,
+    };
+  }
+
+  test('a present field overrides the blank default', () => {
+    const suggestions: MentorProfileSuggestions = {
+      name: 'Jane Doe',
+      headline: 'Staff Engineer',
+      bio: 'Ten years of Go.',
+      timezone: 'Europe/Berlin',
+      company_slug: 'acme',
+      topics: ['backend', 'career'],
+      languages: ['English', 'German'],
+    };
+    const { form, topicsText, languagesText } = seedFormFromSuggestions(blankForm(), suggestions);
+
+    expect(form.name).toBe('Jane Doe');
+    expect(form.headline).toBe('Staff Engineer');
+    expect(form.bio).toBe('Ten years of Go.');
+    expect(form.timezone).toBe('Europe/Berlin');
+    expect(form.company_slug).toBe('acme');
+    expect(topicsText).toBe('backend, career');
+    expect(languagesText).toBe('English, German');
+  });
+
+  test('an absent field keeps the blank default, including the browser timezone', () => {
+    const { form, topicsText, languagesText } = seedFormFromSuggestions(blankForm(), {});
+
+    expect(form.name).toBe('');
+    expect(form.company_slug).toBe('');
+    expect(form.timezone).toBe('Europe/Amsterdam');
+    expect(topicsText).toBe('');
+    expect(languagesText).toBe('');
+  });
+
+  test('every other field is left exactly as the blank form set it', () => {
+    const { form } = seedFormFromSuggestions(blankForm(), { name: 'Jane Doe' });
+
+    expect(form.session_minutes).toBe(60);
+    expect(form.buffer_after_minutes).toBe(15);
+    expect(form.notice_minutes).toBe(120);
+    expect(form.horizon_days).toBe(30);
+    expect(form.meeting_url).toBe('');
+    expect(form.slug).toBe('');
   });
 });

--- a/web/src/lib/mentorship.ts
+++ b/web/src/lib/mentorship.ts
@@ -4,7 +4,14 @@
 // without a browser. Mirrors the split companyFacetModel.ts holds for the company
 // catalogue and matchAnalysis.ts for the analysis stream.
 
-import type { Mentor, MentorAvailabilityRule, MentorSession, MentorSlot } from './types';
+import type {
+  Mentor,
+  MentorAvailabilityRule,
+  MentorProfileInput,
+  MentorProfileSuggestions,
+  MentorSession,
+  MentorSlot,
+} from './types';
 
 /** The mentor directory's whole vocabulary, one single-valued filter each.
  *
@@ -221,6 +228,30 @@ function part(parts: Intl.DateTimeFormatPart[], type: string): string {
  *  guess was honoured cannot tell a correct time from a wrong one. */
 export function browserTimezone(): string {
   return typeof Intl === 'undefined' ? 'UTC' : Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+
+/** Seeds a blank create-form with the candidate's best-effort suggestions, one field at
+ *  a time. A field the suggestions endpoint has nothing for keeps whatever `base` (the
+ *  ordinary blank defaults) already set — the browser timezone included — rather than
+ *  being cleared. This is a ONE-TIME starting point: called once against `blank()`
+ *  before the mentor has typed anything, never merged into an in-progress or existing
+ *  profile's form. */
+export function seedFormFromSuggestions(
+  base: MentorProfileInput,
+  suggestions: MentorProfileSuggestions,
+): { form: MentorProfileInput; topicsText: string; languagesText: string } {
+  return {
+    form: {
+      ...base,
+      name: suggestions.name ?? base.name,
+      headline: suggestions.headline ?? base.headline,
+      bio: suggestions.bio ?? base.bio,
+      timezone: suggestions.timezone ?? base.timezone,
+      company_slug: suggestions.company_slug ?? base.company_slug,
+    },
+    topicsText: (suggestions.topics ?? []).join(', '),
+    languagesText: (suggestions.languages ?? []).join(', '),
+  };
 }
 
 /** Today's date in a named zone, `YYYY-MM-DD`.

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1577,8 +1577,7 @@ export interface ApiSuggestionPart {
  *  are the same wire struct (`mentorResponse` in internal/api/handler/mentorship.go).
  *
  *  Deliberately named, unlike a referral offer: a directory of faceless cards gives a
- *  seeker nothing to choose between. There is no avatar yet, and the mentor-profile spec
- *  argues why rather than leaving the requirement half-met.
+ *  seeker nothing to choose between.
  *
  *  `meeting_url` is absent here on purpose — it is a live room, so only a booked party
  *  receives it, on their own booking. The owner's and moderator's routes add `status`,
@@ -1600,6 +1599,10 @@ export interface Mentor {
   session_minutes: number;
   rating_count: number;
   rating_avg: number;
+  /** The mentor's own opt-in to publish their account's CV headshot at
+   *  `/api/v1/mentors/{slug}/photo`. Off by default; render the avatar only when this
+   *  is true, and hide it on a load error rather than showing a broken-image icon. */
+  show_photo: boolean;
 }
 
 /** One offerable hour, carrying three views of the same moment on purpose.
@@ -1732,4 +1735,23 @@ export interface MentorProfileInput {
   notice_minutes: number;
   horizon_days: number;
   meeting_url: string;
+  /** The mentor's own opt-in to publish their account's CV headshot. Off by default —
+   *  see `Mentor.show_photo`. */
+  show_photo: boolean;
+}
+
+/** Best-effort, per-field prefill for the mentor-profile CREATE form, composed from the
+ *  candidate's résumé, user profile, account and experience bank. Every field is
+ *  independently optional — omitted, not an empty string or array, when its source has
+ *  nothing to offer — so seed only the fields that are present and leave the rest at
+ *  their ordinary blank defaults. A one-time starting point: apply it once on mount,
+ *  then treat every field as an ordinary independent input. */
+export interface MentorProfileSuggestions {
+  name?: string;
+  headline?: string;
+  bio?: string;
+  languages?: string[];
+  topics?: string[];
+  timezone?: string;
+  company_slug?: string;
 }

--- a/web/src/routes/mentors/[slug]/+page.svelte
+++ b/web/src/routes/mentors/[slug]/+page.svelte
@@ -18,7 +18,19 @@
 
 <div class="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-6">
   <header class="flex flex-col gap-2">
-    <h1 class="text-2xl font-semibold">{mentor.name}</h1>
+    <div class="flex items-center gap-4">
+      {#if mentor.show_photo}
+        <img
+          src={`/api/v1/mentors/${mentor.slug}/photo`}
+          alt=""
+          class="border-border size-16 shrink-0 rounded-full border object-cover"
+          onerror={(e) => {
+            (e.currentTarget as HTMLImageElement).style.display = 'none';
+          }}
+        />
+      {/if}
+      <h1 class="text-2xl font-semibold">{mentor.name}</h1>
+    </div>
     <p class="text-muted-foreground">{mentor.headline} · {mentor.company_name}</p>
 
     {#if mentor.rating_count > 0}


### PR DESCRIPTION
## Summary
- New `GET /me/mentorship/profile/suggestions` composes a one-time, best-effort prefill for the mentor-profile create form from the candidate's résumé, user-profile specializations, account timezone, and experience-bank current employer (matched to the company catalog only on an exact slug match). Never reads the mentor profile itself.
- New `show_photo` opt-in (off by default) lets a mentor publish their account's existing CV headshot on their public directory card and profile page, via a new `GET /mentors/:slug/photo` that reuses the existing public-profile resolution/predicate and collapses every non-serving reason to one 404.
- Companion: archives the already-shipped `mentorship-marketplace` OpenSpec change so this change's spec deltas apply against `openspec/specs/mentor-profile`.

## Test plan
- [x] `go build ./...`, `go vet ./...` (plain and `-tags=integration`), `go test ./...` — all green
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 new issues
- [x] `deadcode -test -tags=integration,llmlive ./...` — nothing new
- [x] `node scripts/check-migrations.mjs` on the new migration — 0 issues
- [x] `svelte-check`, `eslint`, full frontend `vitest run` (1781 tests) — all green
- [x] Independent code review (general-purpose reviewer agent) — one Important finding (duplicate `accounts.Service` construction) fixed
- [x] Manual live verification in a real browser (Playwright) against a local Postgres/MinIO/API/dev-server stack: created a seeded test account, confirmed the create form prefills from résumé/profile/account/experience-bank data, approved the profile, toggled `show_photo`, confirmed the avatar renders on the directory and profile page and disappears cleanly (no broken-image icon) when opted out

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Mentor profile creation now offers best-effort suggestions from existing résumé and account information.
  - Mentors can opt in to displaying their CV photo on public directory cards and profile pages.
  - Public mentor photos are shown only for eligible, opted-in profiles.
- **Improvements**
  - Mentor profile forms can be prefilled with suggested details, including name, bio, languages, topics, timezone, and company.
  - Public mentor cards and profile pages now support rounded profile photos.
- **Bug Fixes**
  - Photo loading failures are handled gracefully without disrupting the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->