### PR TITLE
Read a paragraph-per-item requirements section, not just a list (reqextract)

### DIFF
--- a/internal/job/reqextract/AGENTS.md
+++ b/internal/job/reqextract/AGENTS.md
@@ -95,10 +95,29 @@ section ends instead of each guessing.
 `Derive(descriptionHTML)` parses the fragment with `x/net/html` and walks it in
 document order, carrying one piece of state: the priority of the section currently
 open, or `""` for none. A recognized heading opens a section, a list closes the one it
-was found in, and an unrecognized structural heading, a closing heading, prose or a
-table close it too. Entry text is the item's plain text — markup stripped, entities
-decoded, whitespace collapsed, a space contributed at each block boundary so
+was found in, and an unrecognized structural heading, a closing heading or a table
+close it too. Entry text is the item's plain text — markup stripped, entities decoded,
+whitespace collapsed, a space contributed at each block boundary so
 `Go<ul><li>generics` does not read `Gogenerics`.
+
+**A `<p>`-per-item section is read too, via a deferred buffer.** A too-long-for-a-heading
+text block (real prose, by `isHeadingCandidate`'s own length test) no longer closes the
+section on sight — it is buffered in `pending`, because it may be this section's own
+first stated item rather than prose explaining the section away, and the two cannot be
+told apart from one paragraph alone. This closes a real gap, not a hypothetical one:
+every one of 683 real `Требования` headings sampled from `tbank.ru` is followed by a run
+of `<p>` paragraphs, never a list — before this buffer existed, the Russian vocabulary
+addition above matched the heading and extracted nothing from that source's postings.
+The buffer's fate is decided only when something resolves it. A real heading
+transition (a new section, a `closingHeadings` match, or an unrecognized h1–h6), or a
+table, both **commit** the buffer's paragraphs as the section's own items — but only
+when there are two or more of them; a single buffered line stays undecidable and is
+dropped, because a lone unmatched sentence is as likely a lead-in as an item. A list
+found afterward is decided by `pendingHasProse`: when it is set, real prose already
+closed this section on its own, so the buffer is **discarded** and the list is left
+unread — it belongs to whatever follows, not to this heading; when it is not set,
+every buffered line was a short lead-in or spacer, so the buffer is silently cleared and
+the list is read as this section's own, exactly as before this mechanism existed.
 
 The result is written to `jobs.requirements_derived` by every job write path (through
 `internal/job/job`'s `withDerived`) and folded into the served
@@ -133,6 +152,12 @@ reader something — and the two barely overlap (6,806 + 98,410 entries in the s
 union to 102,707), which is the whole bet of this package holding: the model reads the
 prose postings, the parser reads the marked-up ones.
 
+Both figures predate the `<p>`-per-item buffer described above, so they undercount —
+they were measured while every `tbank.ru`-shaped posting (list-less, paragraph-per-item)
+still yielded nothing. Re-measure with the same `TABLESAMPLE` method rather than assuming
+the delta; the walk's other behavior is unchanged, so raising the number without a fresh
+sample would be exactly the guess this section warns against.
+
 A regex sweep for a requirements-shaped heading said 23% before any of this was built.
 The shipped extractor is stricter than a regex on purpose: a missed section is a blank
 space, while a benefits list under a "Requirements" heading is a false claim the reader
@@ -150,17 +175,6 @@ cannot detect.
   Russian entries were added after counting real headings across 500 live `tbank.ru`
   postings (`git log` this file for the exact counts), which is also what surfaced the
   next limitation.
-- **A requirements section stated as `<p>`-per-item, not a `<ul>`/`<ol>` list, yields
-  nothing — regardless of language.** `Derive`'s walk (reqextract.go) only reads items
-  out of `atom.Ul`/`atom.Ol`; a `<p>` long enough to fail `isHeadingCandidate` closes the
-  open section as prose (the same rule that keeps a benefits list two paragraphs down
-  from being read as requirements) before any list is found. Measured live: every one of
-  683 real `Требования` headings sampled from `tbank.ru` is followed by a run of `<p>`
-  paragraphs, never a list — so the Russian vocabulary addition above extracts nothing
-  from that specific source today, even though the heading now matches. Closing this
-  needs `Derive` to recognize a `<p>`-per-item section as a list-shaped one, which is a
-  change to the walk itself, not to a vocabulary — a different, larger problem than the
-  language gap it was found alongside.
 - **No clustering.** Near-duplicate phrasings ("excellent written and verbal
   communication skills" vs "strong written and verbal communication skills") are stored
   as stated. Real, but a different problem.

--- a/internal/job/reqextract/reqextract.go
+++ b/internal/job/reqextract/reqextract.go
@@ -271,6 +271,11 @@ func Derive(descriptionHTML string) []enrich.Requirement {
 						pendingHasProse = true
 					}
 				}
+				// textOf already read every descendant of n, so a nested
+				// <strong>/<b>/<div> inside this block must not be visited
+				// again by the walk below — that would buffer its (shorter)
+				// text a second time as its own entry.
+				return
 			}
 		}
 		for c := n.FirstChild; c != nil; c = c.NextSibling {

--- a/internal/job/reqextract/reqextract.go
+++ b/internal/job/reqextract/reqextract.go
@@ -171,8 +171,44 @@ func Derive(descriptionHTML string) []enrich.Requirement {
 	// priority is the section currently open: the priority of the last recognized
 	// heading, or "" when none is. Three things close a section, and between them they
 	// are what stops a benefits list two elements down from being read as requirements:
-	// taking its list, an unrecognized structural heading, and prose.
+	// taking its list, an unrecognized structural heading, and a table.
 	priority := ""
+	// pending buffers candidate item texts collected since the section opened, while
+	// no list has been found yet: a text block too long to be a heading candidate
+	// (real prose, by isHeadingCandidate's own length test) and a short inline text
+	// block the heading vocabulary does not recognize (a lead-in, a spacer, or — if
+	// enough of these accumulate — one of the section's own short items). Their fate
+	// is decided later, never at the paragraph itself: reaching a list either
+	// discards them (prose was heading somewhere else) or is simply cleared in front
+	// of it (a lead-in was never content); reaching the section's natural end with
+	// two or more of them commits them as the section's items — a posting that
+	// states each requirement as its own paragraph rather than under a <ul>, which is
+	// not hypothetical: every "Требования" heading sampled from a large real source
+	// (tbank.ru, 2026-09, 25/25 postings) is followed by exactly this shape, 3 to 10
+	// paragraphs long, never a list. pendingHasProse marks whether any buffered entry
+	// was the too-long kind, which is what a list found afterward is read by — see
+	// that case below.
+	var pending []string
+	var pendingHasProse bool
+
+	resetPending := func() {
+		pending = nil
+		pendingHasProse = false
+	}
+
+	// flushPending commits the buffered paragraphs to found under the given priority
+	// when there are two or more of them — a real p-per-item section, not the single
+	// ambiguous sentence "a matching heading with prose after it yields nothing"
+	// tests for. Called whenever a section's fate is decided outside the list case:
+	// a real heading transition, a table, or the end of the document.
+	flushPending := func(forPriority string) {
+		if len(pending) >= 2 {
+			for _, text := range pending {
+				found = append(found, enrich.Requirement{Text: text, Priority: forPriority})
+			}
+		}
+		resetPending()
+	}
 
 	var walk func(*xhtml.Node)
 	walk = func(n *xhtml.Node) {
@@ -185,23 +221,56 @@ func Derive(descriptionHTML string) []enrich.Requirement {
 			case wrapsAList(n):
 
 			case isHeadingCandidate(n):
-				priority, _ = headingDecision(n, priority)
-				return // the heading's own text is never an item
+				next, recognized := headingDecision(n, priority)
+				if recognized {
+					flushPending(priority)
+					priority = next
+					return // the heading's own text is never an item
+				}
+				// Not recognized: buffered, not discarded outright — see pending's
+				// own comment for why a run of these may still become items.
+				if priority != "" {
+					if text := textOf(n); text != "" {
+						pending = append(pending, text)
+					}
+				}
+				return
 
 			case priority != "" && (n.DataAtom == atom.Ul || n.DataAtom == atom.Ol):
+				if pendingHasProse {
+					// Real prose, not a lead-in, preceded this list: the list
+					// belongs to whatever comes after it, not to this section —
+					// "prose after the heading closes the section even when a
+					// list follows" is the tested case this guards.
+					resetPending()
+					priority = ""
+					return
+				}
+				resetPending() // any buffered lead-in lines were never content
 				for _, text := range listItems(n) {
 					found = append(found, enrich.Requirement{Text: text, Priority: priority})
 				}
 				priority = "" // only the FIRST list after a heading is the section's
 				return        // nested lists were consumed by listItems
 
-			// Content, not a lead-in. A text block reaching this case has already
-			// failed isHeadingCandidate, so it is one too long to be a title — prose.
-			// Whatever list follows prose or a table is no longer the heading's, and
-			// this is what keeps "Requirements" over a paragraph from claiming the
-			// benefits list further down.
-			case isTextBlock(n), n.DataAtom == atom.Table:
+			case n.DataAtom == atom.Table:
+				flushPending(priority)
 				priority = ""
+
+			// Reached only when isHeadingCandidate already failed it on length — too
+			// long to be a title, so a genuine paragraph. Buffered rather than
+			// closing the section immediately: it may be this section's own first
+			// item (the tbank.ru shape above) rather than prose explaining the
+			// section away, and the two cannot be told apart from one paragraph
+			// alone — only from what follows it (more paragraphs, a list, or the
+			// section's end).
+			case isTextBlock(n):
+				if priority != "" {
+					if text := textOf(n); text != "" {
+						pending = append(pending, text)
+						pendingHasProse = true
+					}
+				}
 			}
 		}
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
@@ -209,6 +278,7 @@ func Derive(descriptionHTML string) []enrich.Requirement {
 		}
 	}
 	walk(doc)
+	flushPending(priority)
 
 	return enrich.BoundRequirements(found)
 }

--- a/internal/job/reqextract/reqextract_test.go
+++ b/internal/job/reqextract/reqextract_test.go
@@ -224,16 +224,13 @@ func TestDerive(t *testing.T) {
 			want: []enrich.Requirement{req("Опыт работы с Go от 3 лет")},
 		},
 		// The real, measured tbank.ru shape: every one of 683 "Требования" headings
-		// sampled is followed by <p> paragraphs, never a <ul>. The vocabulary now
-		// recognizes the heading, but Derive still yields nothing — the first
-		// paragraph closes the section as prose before any list is ever found. See
-		// reqextract/AGENTS.md's Limitations: closing this gap needs Derive to read a
-		// <p>-per-item section too, a structural change this vocabulary addition does
-		// not attempt.
+		// sampled is followed by <p> paragraphs, never a <ul> — and Derive now reads
+		// them: see the p-per-item mechanism this file's later cases exercise
+		// directly.
 		{
-			name: "a Russian requirements heading followed by paragraphs (the real tbank.ru shape) yields nothing yet",
+			name: "a Russian requirements heading followed by paragraphs (the real tbank.ru shape) yields its items",
 			html: `<h3>Требования</h3><p>Опыт работы с Go от 3 лет</p><p>Знание Postgres</p>`,
-			want: nil,
+			want: []enrich.Requirement{req("Опыт работы с Go от 3 лет"), req("Знание Postgres")},
 		},
 		// go-unidecode transliterates the accented ё to "io", not "e", so the
 		// grammatically correct spelling normalizes differently from the common
@@ -243,6 +240,49 @@ func TestDerive(t *testing.T) {
 			name: "a Russian heading with the accented ё normalizes and matches too",
 			html: `<h3>Мы ждём от вас</h3><ul><li>Опыт работы с Go от 3 лет</li></ul>`,
 			want: []enrich.Requirement{req("Опыт работы с Go от 3 лет")},
+		},
+		// The p-per-item mechanism's own boundary cases, isolated from the Russian
+		// vocabulary above so each tests exactly one behavior.
+		{
+			name: "exactly two paragraph items commit",
+			html: `<h3>Requirements</h3><p>Five years of backend experience</p><p>Comfortable with distributed systems</p>`,
+			want: []enrich.Requirement{req("Five years of backend experience"), req("Comfortable with distributed systems")},
+		},
+		{
+			name: "exactly one short unmatched paragraph, nothing else, yields nothing",
+			html: `<h3>Requirements</h3><p>A single short line</p>`,
+			want: nil,
+		},
+		{
+			name: "a mix of short and long paragraph items all commit",
+			html: `<h3>Requirements</h3><p>Owns delivery end to end</p>` +
+				`<p>Five or more years of experience shipping production backend systems at scale</p>` +
+				`<p>Comfortable leading design discussions</p>`,
+			want: []enrich.Requirement{
+				req("Owns delivery end to end"),
+				req("Five or more years of experience shipping production backend systems at scale"),
+				req("Comfortable leading design discussions"),
+			},
+		},
+		{
+			name: "a preferred section made of paragraphs, not a list, still yields",
+			html: `<h3>Nice to have</h3><p>Experience with Kubernetes in production</p><p>Contributed to an open-source project before</p>`,
+			want: []enrich.Requirement{pref("Experience with Kubernetes in production"), pref("Contributed to an open-source project before")},
+		},
+		{
+			name: "a paragraph-shaped section under a non-vocabulary heading is not read as requirements",
+			html: `<h3>What we offer</h3><p>Competitive salary and equity</p><p>Flexible remote-first culture</p><p>Annual learning budget</p>`,
+			want: nil,
+		},
+		{
+			name: "a paragraph-per-item section with no trailing heading still commits at document end",
+			html: `<h3>Requirements</h3><p>Owns delivery end to end</p><p>Comfortable leading design discussions</p>`,
+			want: []enrich.Requirement{req("Owns delivery end to end"), req("Comfortable leading design discussions")},
+		},
+		{
+			name: "a paragraph run closed by a table still commits — the table is unrelated content, not part of the section's own items",
+			html: `<h3>Requirements</h3><p>Owns delivery end to end</p><p>Comfortable leading design discussions</p><table><tr><td>Grade</td><td>Senior</td></tr></table>`,
+			want: []enrich.Requirement{req("Owns delivery end to end"), req("Comfortable leading design discussions")},
 		},
 	}
 

--- a/internal/job/reqextract/reqextract_test.go
+++ b/internal/job/reqextract/reqextract_test.go
@@ -284,6 +284,16 @@ func TestDerive(t *testing.T) {
 			html: `<h3>Requirements</h3><p>Owns delivery end to end</p><p>Comfortable leading design discussions</p><table><tr><td>Grade</td><td>Senior</td></tr></table>`,
 			want: []enrich.Requirement{req("Owns delivery end to end"), req("Comfortable leading design discussions")},
 		},
+		{
+			name: "a nested <strong>/<b> inside a buffered paragraph item is not read a second time",
+			html: `<h3>Requirements</h3>` +
+				`<p>You need <strong>five years of Python experience</strong> and strong leadership skills to succeed here</p>` +
+				`<p>Comfortable working independently on distributed systems</p>`,
+			want: []enrich.Requirement{
+				req("You need five years of Python experience and strong leadership skills to succeed here"),
+				req("Comfortable working independently on distributed systems"),
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/openspec/changes/reqextract-paragraph-items/.openspec.yaml
+++ b/openspec/changes/reqextract-paragraph-items/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/reqextract-paragraph-items/design.md
+++ b/openspec/changes/reqextract-paragraph-items/design.md
@@ -1,0 +1,123 @@
+## Context
+
+See proposal.md - Why. `Derive`'s walk carries one piece of state, `priority`
+(the section currently open), and previously closed that section the moment it
+saw ANY node it could not read as a heading or a list — including a genuine
+paragraph. That rule is what protects a benefits list two elements down from
+being misread as requirements (see AGENTS.md's "Always true" bullets), so it
+cannot simply be dropped; it has to be replaced with something that still tells
+a `<p>`-per-item requirements section apart from prose that explains the
+section away, using only what a single-pass walk can see.
+
+The measurement behind this change: a `TABLESAMPLE`-based real-data check
+against `tbank.ru` (25 postings pulled live, 2026-09) found every "Требования"
+heading followed by a run of 3-10 `<p>` items, never a `<ul>`/`<ol>`, matching
+the 683-heading count already recorded in AGENTS.md's Limitations section from
+the vocabulary work that surfaced this gap.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Read a `<p>`-per-item requirements section the same way a `<ul>`/`<ol>`
+  section is read today: gated by the same heading vocabulary, same priority
+  rule, same bound.
+- Preserve every existing behavior byte-for-byte: no regression on any of the
+  pre-existing `TestDerive` cases, `MaskPreferred`, or the benefits-list
+  exclusion.
+- Resolve the genuine three-way ambiguity a single paragraph creates (is it an
+  item, a lead-in, or prose closing the section?) from structure alone, with no
+  new vocabulary and no heuristic tunable beyond the existing "≥2 items" rule.
+
+**Non-Goals:**
+- Clustering or ordering paragraph items by any signal beyond document order.
+- Reading a `<p>`-per-item PREFERRED section differently from a required one —
+  the same buffer and the same priority rule apply to both.
+- Extending this to any other repeated-inline-element shape (`<span>` runs,
+  `<br>`-separated lines within one block) — only sibling block-level text
+  blocks are in scope, because that is the shape actually measured.
+
+## Decisions
+
+**A deferred buffer, not an immediate classification.** A candidate paragraph
+cannot be classified as "item" or "not item" from its own content — the
+tbank.ru shape and a plain explanatory sentence after a heading look identical
+at the node level. The only thing that disambiguates them is what follows:
+more paragraphs (commit), a list (the list wins instead), or nothing before the
+section's natural end (commit if ≥2, drop if 1). So the walk defers the
+decision: every over-length text block under an open section goes into
+`pending`, and `pending`'s fate is decided at the next resolving event rather
+than at the paragraph itself. Considered and rejected: a two-node lookahead
+(peek at the next sibling before deciding) — this only works within one parent
+element and a posting's own markup nests paragraphs inconsistently (sometimes
+siblings, sometimes each wrapped in its own `<div>`), so a lookahead would need
+to skip wrapper boundaries anyway, which is exactly what the single-pass walk
+already does for every other case. Buffering costs nothing else — the walk stays
+single-pass and its existing state (`priority`) is unchanged in shape, just
+joined by two more decision-only fields.
+
+**The ≥2 threshold, not ≥1.** A section with exactly one over-length paragraph
+under a heading is exactly the shape the ORIGINAL negative test in this package
+existed to guard: "a heading with prose after it yields nothing" — a posting
+that states its heading and then explains the role in one sentence before
+moving on, not a requirements list. Nothing in the markup tells that sentence
+apart from the FIRST item of a genuine multi-item run; only a second paragraph
+does, by existing at all. Requiring two therefore keeps the original guarantee
+intact for the single-paragraph case while opening the multi-paragraph one —
+and it matches the real data: every sampled tbank.ru posting had 3 or more,
+comfortably clear of the boundary.
+
+**`pendingHasProse`, not "any pending buffer discards on a list".** A short
+unrecognized inline line (a lead-in like `<p>You will need:</p>`, or a bare
+spacer `<p></p>`) must NOT prevent a following list from being read — that
+behavior already existed before this change (the walk already tolerated
+lead-in lines between a heading and its list) and regressing it would break
+real postings that use exactly that shape. Only a line long enough to have
+failed the heading-length test (real prose) should cause a following list to
+be treated as belonging to a DIFFERENT section. `pendingHasProse` is the one
+bit that keeps these two apart: set only by the over-length branch, read only
+by the list-found branch.
+
+**Commit at a heading transition, a table, AND the document's end — one
+function, `flushPending`, not three inline copies.** All three are "the
+section's fate is now decided, and no list was found" — the same operation
+with a different closing priority argument (the section's own priority for a
+heading/table transition, whatever `priority` holds at `walk`'s return for the
+document's end, which is the same variable). Duplicating the ≥2 check at three
+call sites was rejected as the obvious source of a future one-off divergence
+if only two of the three were updated later.
+
+## Risks / Trade-offs
+
+- **[Risk] A posting genuinely explaining a section in exactly two long
+  sentences (not stating two requirements) now reads both as items.** →
+  [Mitigation] This is the same class of imprecision the existing dictionary
+  gate already accepts everywhere else in this package (see AGENTS.md: "a
+  missed section is a blank space, while a benefits list under a Requirements
+  heading is a false claim the reader cannot detect") — two sentences read as
+  two requirements is the same direction of error the ≥2 threshold already
+  chose to accept over the alternative (missing every real multi-paragraph
+  section). Not measured as a real occurrence in the tbank.ru sample or the
+  existing test corpus.
+- **[Risk] `internal/job/reqextract/AGENTS.md`'s "Measuring coverage" figures
+  (28.0% list-shaped, 29.3% combined with the model) now undercount, since
+  they predate this fix.** → [Mitigation] AGENTS.md is updated to flag this
+  explicitly rather than silently going stale; re-measuring with the same
+  `TABLESAMPLE` method is left as a follow-up, not guessed at here.
+- **[Risk] The stored catalogue does not benefit until re-derived.** →
+  [Mitigation] Not this change's concern to trigger — `backfill-requirements`
+  (see root AGENTS.md) is the existing one-off that re-reads `requirements_derived`
+  for open postings and is idempotent; running it is an operational follow-up,
+  same as any other `Derive` behavior change.
+
+## Migration Plan
+
+No schema change. `Derive` is called from the ordinary ingest write path
+(`internal/job/job`'s `withDerived`) and from `backfill-requirements` — both
+pick up the new behavior on deploy with no migration step. The pre-existing
+catalogue is unaffected until `backfill-requirements` is re-run by an operator,
+which is out of scope here (see Risks). No feature flag: the change is a
+strict superset of what `Derive` already read (a `<p>`-per-item section that
+previously yielded nothing now yields entries; every previously-yielding shape
+is unchanged, confirmed by the full pre-existing `TestDerive` suite passing
+unchanged). Rollback is a plain revert — no data written by this change is
+irreversible or requires cleanup.

--- a/openspec/changes/reqextract-paragraph-items/proposal.md
+++ b/openspec/changes/reqextract-paragraph-items/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+`reqextract.Derive` only reads requirement items out of a `<ul>`/`<ol>` list under a
+recognized heading; a section stated as a run of `<p>` items closes as prose before any
+list is found and yields nothing. This is not a hypothetical shape: every one of 683 real
+`Требования` headings sampled from `tbank.ru` is followed by a run of `<p>` paragraphs,
+never a list, so the Russian heading vocabulary added in `reqextract-russian-headings`
+matches the heading on that source today and still extracts nothing from it.
+
+## What Changes
+
+- `Derive`'s walk gains a deferred buffer (`pending`/`pendingHasProse`/`flushPending`):
+  a text block too long to be a heading candidate is buffered instead of closing its
+  section immediately, since it may be the section's own first stated item rather than
+  prose explaining the section away — the two cannot be told apart from one paragraph
+  alone. The buffer is discarded (and the section closed) if a list is found afterward
+  (real prose before a list means the list belongs to what follows, not this heading);
+  it is committed as the section's own items — but only when there are two or more of
+  them — when a real heading transition, a table, or the document's end resolves it. A
+  short unrecognized inline line is buffered the same way but never marks the buffer as
+  prose, and is silently cleared the moment a list appears.
+- `internal/job/reqextract/AGENTS.md` updated: the "How it works" section describes the
+  new buffering mechanism, the "Limitations" bullet documenting this exact gap is
+  removed, and the "Measuring coverage" figures (28.0% / 29.3%) are flagged as
+  predating this fix.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `posting-requirements-derivation`: a requirements section stated as a run of `<p>`
+  items (no enclosing list) is now derived, under the same heading vocabulary and
+  priority rules as the list-shaped case, instead of yielding nothing.
+
+## Impact
+
+- `internal/job/reqextract/reqextract.go` — `Derive`'s walk.
+- `internal/job/reqextract/reqextract_test.go` — new boundary-case coverage.
+- `internal/job/reqextract/AGENTS.md` — mechanism + limitation + coverage-figure notes.
+- No schema change, no new worker: the existing ingest write path and the existing
+  `backfill-requirements` one-off both call `Derive` unchanged, so a re-run of the
+  backfill (not part of this change) is what would reach the pre-existing catalogue.

--- a/openspec/changes/reqextract-paragraph-items/specs/posting-requirements-derivation/spec.md
+++ b/openspec/changes/reqextract-paragraph-items/specs/posting-requirements-derivation/spec.md
@@ -1,0 +1,87 @@
+## MODIFIED Requirements
+
+### Requirement: A posting's requirements are derived deterministically from its description markup
+
+The system SHALL derive a posting's stated requirements from its description
+markup alone, with no model call, producing the same shape the enrichment
+contract defines: an ordered list of entries each carrying a `text` and a
+`priority` of `required` or `preferred`.
+
+The derivation SHALL be gated on a controlled vocabulary of section headings
+(for example `Requirements`, `Qualifications`, `What you'll need`,
+`Nice to have`). Under a matching heading, the derivation SHALL read items from
+either shape a section is stated in: the list items of the first list that
+follows the heading, stopping at the next heading; or, when no list is found
+before the section closes, a run of two or more paragraph-shaped items stated
+directly under the heading, each becoming one entry. A single paragraph-shaped
+item alone SHALL NOT be read as a section's content, since one paragraph cannot
+be told apart from prose that merely explains the section away. A description
+with no matching heading SHALL yield no entries: there is no fallback that
+infers which list or paragraph run in a posting is the requirements content,
+because a benefits or perks section must never be read as requirements.
+
+Each entry's `priority` SHALL be decided by the heading it was found under —
+headings expressing optionality (`nice to have`, `preferred`, `bonus`, `a plus`)
+yield `preferred`, and every other heading in the vocabulary yields `required`.
+A description carrying more than one matching heading SHALL yield the entries of
+each, so a posting with both a required and an optional section produces both
+priorities.
+
+Entry text SHALL be extracted as plain text: markup inside a list item or
+paragraph is stripped, character entities are decoded, and surrounding and
+repeated whitespace is collapsed. An entry that is empty after this SHALL be
+dropped.
+
+The derivation SHALL be bounded by the same maximum entry count and maximum text
+length that the enrichment contract's sanitization enforces, read from those same
+constants rather than restated, so both producers of the field obey one ceiling.
+
+#### Scenario: A requirements heading followed by a list yields its items
+
+- **WHEN** a description contains a heading matching the vocabulary followed by a list of items
+- **THEN** the derivation returns one entry per list item, in document order, each with priority `required`
+
+#### Scenario: An optional-section heading yields preferred entries
+
+- **WHEN** a description contains a heading expressing optionality, such as "Nice to have", followed by a list
+- **THEN** the derivation returns those items with priority `preferred`
+
+#### Scenario: Both sections yield both priorities
+
+- **WHEN** a description contains a required-section heading and an optional-section heading, each followed by a list
+- **THEN** the derivation returns the items of both, each carrying the priority of the heading it appeared under
+
+#### Scenario: A benefits list is not read as requirements
+
+- **WHEN** a description's only heading-and-list pair is a benefits or perks section whose heading is outside the vocabulary
+- **THEN** the derivation returns no entries
+
+#### Scenario: A matching heading followed by two or more paragraph items yields those items
+
+- **WHEN** a description contains a heading matching the vocabulary followed by two or more paragraph-shaped items, with no list found before the section closes
+- **THEN** the derivation returns one entry per paragraph, in document order, carrying the heading's priority
+
+#### Scenario: A matching heading with no list yields nothing
+
+- **WHEN** a description contains a heading matching the vocabulary but the content that follows is neither a list nor two or more paragraph-shaped items — no content at all, or exactly one paragraph-shaped item, before the section closes
+- **THEN** the derivation returns no entries for that section
+
+#### Scenario: Genuine prose before a list closes the section instead of being read as items
+
+- **WHEN** a description contains a heading matching the vocabulary, followed by a paragraph of prose, followed by a list
+- **THEN** the derivation returns no entries for that section: the list belongs to whatever follows, not to this heading
+
+#### Scenario: A description with no markup yields nothing
+
+- **WHEN** a description is plain prose with no headings
+- **THEN** the derivation returns no entries
+
+#### Scenario: Item markup is reduced to plain text
+
+- **WHEN** a list item or paragraph item contains nested markup or character entities
+- **THEN** the derived entry's text is the item's plain text with markup stripped, entities decoded, and whitespace collapsed
+
+#### Scenario: The derivation obeys the enrichment contract's bounds
+
+- **WHEN** a description's requirements list exceeds the enrichment contract's maximum entry count, or an item's text exceeds its maximum text length
+- **THEN** the derivation truncates the list to that maximum count and clips each text to that maximum length

--- a/openspec/changes/reqextract-paragraph-items/tasks.md
+++ b/openspec/changes/reqextract-paragraph-items/tasks.md
@@ -1,0 +1,26 @@
+## 1. Implementation
+
+- [x] 1.1 Add the `pending`/`pendingHasProse` buffer state and `flushPending`/`resetPending` helpers to `Derive`'s walk in `internal/job/reqextract/reqextract.go`.
+- [x] 1.2 Buffer a too-long (real-prose) text block instead of closing the section immediately; buffer a short unrecognized inline line without marking `pendingHasProse`.
+- [x] 1.3 On a recognized heading transition and on a table, flush the buffer under the closing priority via `flushPending` (commits only when 2+ items).
+- [x] 1.4 On a list found while `pendingHasProse` is set, discard the buffer and close the section instead of reading the list; otherwise clear any buffered lead-in before reading the list as before.
+- [x] 1.5 Flush the buffer once more after the walk completes, for a section with no trailing heading/table.
+
+## 2. Tests
+
+- [x] 2.1 Update the pre-existing `tbank.ru`-shape negative test to assert the two now-derived requirements instead of `nil`.
+- [x] 2.2 Add boundary-case tests: exactly two paragraph items commit; a single unmatched paragraph yields nothing; a mix of short and long paragraphs all commit; a paragraph-shaped preferred section commits with `preferred` priority; a paragraph-shaped section under a non-vocabulary heading yields nothing; a paragraph run with no trailing heading commits at document end; a paragraph run closed by a table still commits.
+- [x] 2.3 Run `go test ./internal/job/reqextract/... -v -run TestDerive` and confirm every pre-existing case plus the new ones pass with no regressions.
+- [x] 2.4 Verify against real data: run `Derive` over 25 real `tbank.ru` posting descriptions (sampled live, `Требования` heading, paragraph-per-item shape) and confirm each yields the expected requirement items.
+
+## 3. Documentation
+
+- [x] 3.1 Update `internal/job/reqextract/AGENTS.md`'s "How it works" section to describe the buffering mechanism.
+- [x] 3.2 Remove the "Limitations" bullet documenting the now-fixed `<p>`-per-item gap.
+- [x] 3.3 Flag the "Measuring coverage" section's 28.0%/29.3% figures as predating this fix.
+
+## 4. Verification
+
+- [x] 4.1 `gofmt -l .` clean (repo-wide, excluding node_modules).
+- [x] 4.2 `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` all clean.
+- [x] 4.3 `go test ./...` (whole repo) green, 0 FAIL.


### PR DESCRIPTION
## Summary

- `reqextract.Derive` only read requirement items out of a `<ul>`/`<ol>` list under a recognized heading; a section stated as a run of `<p>` items closed as prose before any list was found and yielded nothing. Not hypothetical: every one of 683 real `Требования` headings sampled from `tbank.ru` is followed by a run of `<p>` paragraphs, never a list — so the Russian heading vocabulary added in `reqextract-russian-headings` matches the heading on that source today and still extracted nothing from it.
- Added a deferred buffer (`pending`/`pendingHasProse`/`flushPending`) to `Derive`'s walk: a too-long-for-a-heading text block is buffered instead of closing its section immediately, since it may be the section's own first stated item rather than prose explaining the section away — the two cannot be told apart from one paragraph alone. A list found afterward discards the buffer only when real prose preceded it (`pendingHasProse`); a heading transition, a table, or the document's end commits the buffer's paragraphs as the section's items, but only when there are two or more of them.
- Updated `internal/job/reqextract/AGENTS.md`: "How it works" describes the new mechanism, the now-fixed `<p>`-per-item Limitations bullet is removed, and the "Measuring coverage" figures (28.0%/29.3%) are flagged as predating this fix.
- OpenSpec artifacts under `openspec/changes/reqextract-paragraph-items/` (proposal, design, spec delta, tasks — all tasks checked off).

## Test plan

- [x] `go test ./internal/job/reqextract/... -v -run TestDerive` — every pre-existing case unchanged, the updated `tbank.ru`-shape negative test now asserts the derived requirements, and 7 new boundary-case tests (exactly-two-items commit, single-paragraph-yields-nothing, mixed short/long paragraphs, preferred-section paragraphs, non-vocabulary heading yields nothing, no-trailing-heading commit, table-closed commit) all pass.
- [x] Verified against 25 real `tbank.ru` posting descriptions (sampled live, `Требования` heading, paragraph-per-item shape) run through the actual `Derive` function — every one yielded the expected 3-10 requirement items, none yielded zero.
- [x] `gofmt -l .` clean, `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` all clean.
- [x] `go test ./...` (whole repo, 214 packages) — 0 FAIL.
- [x] `openspec validate reqextract-paragraph-items --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Requirements written as multiple paragraphs are now extracted as individual items alongside list-based requirements.
  * Required and preferred priorities are preserved for paragraph-based sections.

* **Bug Fixes**
  * Fixed paragraph-based requirement sections incorrectly producing no results.
  * Improved handling of section boundaries, tables, and document endings.
  * Prevented explanatory prose, single paragraphs, and nested formatting text from being misclassified as requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->