### PR TITLE
Turn Topics and Languages into chip inputs on the mentor-profile form

### DIFF
--- a/web/src/lib/components/MentorProfileEditor.svelte
+++ b/web/src/lib/components/MentorProfileEditor.svelte
@@ -4,6 +4,7 @@
   import { browserTimezone, seedFormFromSuggestions } from '$lib/mentorship';
   import { errorMessage } from '$lib/utils';
   import { Badge, Button, Card, Input } from '$lib/ui';
+  import TokenInput from '$lib/components/facets/TokenInput.svelte';
   import type { MentorProfileInput, OwnMentorProfile } from '$lib/types';
 
   let { profile = $bindable() }: { profile: OwnMentorProfile | null } = $props();
@@ -57,8 +58,6 @@
   }
 
   let form = $state<MentorProfileInput>(profile ? fromProfile(profile) : blank());
-  let topicsText = $state(profile ? profile.topics.join(', ') : '');
-  let languagesText = $state(profile ? profile.languages.join(', ') : '');
   let saving = $state(false);
   let error = $state('');
 
@@ -70,28 +69,36 @@
     onMount(async () => {
       try {
         const suggestions = await api.mentorProfileSuggestions();
-        const seeded = seedFormFromSuggestions(form, suggestions);
-        form = seeded.form;
-        topicsText = seeded.topicsText;
-        languagesText = seeded.languagesText;
+        form = seedFormFromSuggestions(form, suggestions);
       } catch {
         // Best-effort: the form already has its ordinary blank defaults.
       }
     });
   }
 
-  const list = (text: string) =>
-    text
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean);
+  // Chip helpers for the two open-vocabulary lists. A duplicate (exact string match) is
+  // simply not added again rather than shown twice — the backend also dedupes on save,
+  // but a chip that visibly repeats itself while typing reads as broken.
+  function addTopic(value: string) {
+    const v = value.trim();
+    if (v && !form.topics.includes(v)) form.topics = [...form.topics, v];
+  }
+  function removeTopic(value: string) {
+    form.topics = form.topics.filter((t) => t !== value);
+  }
+  function addLanguage(value: string) {
+    const v = value.trim();
+    if (v && !form.languages.includes(v)) form.languages = [...form.languages, v];
+  }
+  function removeLanguage(value: string) {
+    form.languages = form.languages.filter((l) => l !== value);
+  }
 
   async function save() {
     saving = true;
     error = '';
     try {
-      const body = { ...form, topics: list(topicsText), languages: list(languagesText) };
-      profile = profile ? await api.updateMentorProfile(body) : await api.createMentorProfile(body);
+      profile = profile ? await api.updateMentorProfile(form) : await api.createMentorProfile(form);
     } catch (e) {
       error = errorMessage(e, 'The profile could not be saved.');
     } finally {
@@ -195,19 +202,27 @@
     </label>
 
     <label class="text-sm">
-      <span class="text-muted-foreground">Topics, comma separated</span>
-      <Input
-        bind:value={topicsText}
-        class="mt-1 w-full"
-      />
+      <span class="text-muted-foreground">Topics</span>
+      <div class="mt-1">
+        <TokenInput
+          tokens={form.topics}
+          onAdd={addTopic}
+          onRemove={removeTopic}
+          placeholder="Type a topic, press Enter"
+        />
+      </div>
     </label>
 
     <label class="text-sm">
-      <span class="text-muted-foreground">Languages, comma separated</span>
-      <Input
-        bind:value={languagesText}
-        class="mt-1 w-full"
-      />
+      <span class="text-muted-foreground">Languages</span>
+      <div class="mt-1">
+        <TokenInput
+          tokens={form.languages}
+          onAdd={addLanguage}
+          onRemove={removeLanguage}
+          placeholder="Type a language, press Enter"
+        />
+      </div>
     </label>
 
     <label class="text-sm">

--- a/web/src/lib/mentorship.test.ts
+++ b/web/src/lib/mentorship.test.ts
@@ -584,29 +584,29 @@ describe('seedFormFromSuggestions', () => {
       topics: ['backend', 'career'],
       languages: ['English', 'German'],
     };
-    const { form, topicsText, languagesText } = seedFormFromSuggestions(blankForm(), suggestions);
+    const form = seedFormFromSuggestions(blankForm(), suggestions);
 
     expect(form.name).toBe('Jane Doe');
     expect(form.headline).toBe('Staff Engineer');
     expect(form.bio).toBe('Ten years of Go.');
     expect(form.timezone).toBe('Europe/Berlin');
     expect(form.company_slug).toBe('acme');
-    expect(topicsText).toBe('backend, career');
-    expect(languagesText).toBe('English, German');
+    expect(form.topics).toEqual(['backend', 'career']);
+    expect(form.languages).toEqual(['English', 'German']);
   });
 
   test('an absent field keeps the blank default, including the browser timezone', () => {
-    const { form, topicsText, languagesText } = seedFormFromSuggestions(blankForm(), {});
+    const form = seedFormFromSuggestions(blankForm(), {});
 
     expect(form.name).toBe('');
     expect(form.company_slug).toBe('');
     expect(form.timezone).toBe('Europe/Amsterdam');
-    expect(topicsText).toBe('');
-    expect(languagesText).toBe('');
+    expect(form.topics).toEqual([]);
+    expect(form.languages).toEqual([]);
   });
 
   test('every other field is left exactly as the blank form set it', () => {
-    const { form } = seedFormFromSuggestions(blankForm(), { name: 'Jane Doe' });
+    const form = seedFormFromSuggestions(blankForm(), { name: 'Jane Doe' });
 
     expect(form.session_minutes).toBe(60);
     expect(form.buffer_after_minutes).toBe(15);

--- a/web/src/lib/mentorship.ts
+++ b/web/src/lib/mentorship.ts
@@ -239,18 +239,16 @@ export function browserTimezone(): string {
 export function seedFormFromSuggestions(
   base: MentorProfileInput,
   suggestions: MentorProfileSuggestions,
-): { form: MentorProfileInput; topicsText: string; languagesText: string } {
+): MentorProfileInput {
   return {
-    form: {
-      ...base,
-      name: suggestions.name ?? base.name,
-      headline: suggestions.headline ?? base.headline,
-      bio: suggestions.bio ?? base.bio,
-      timezone: suggestions.timezone ?? base.timezone,
-      company_slug: suggestions.company_slug ?? base.company_slug,
-    },
-    topicsText: (suggestions.topics ?? []).join(', '),
-    languagesText: (suggestions.languages ?? []).join(', '),
+    ...base,
+    name: suggestions.name ?? base.name,
+    headline: suggestions.headline ?? base.headline,
+    bio: suggestions.bio ?? base.bio,
+    timezone: suggestions.timezone ?? base.timezone,
+    company_slug: suggestions.company_slug ?? base.company_slug,
+    topics: suggestions.topics ?? base.topics,
+    languages: suggestions.languages ?? base.languages,
   };
 }
 


### PR DESCRIPTION
## Summary
- Replaces the comma-separated text fields for Topics and Languages on the mentor-profile create/edit form with the chip input (`TokenInput.svelte`) already used elsewhere in the app for the same shape of data (SubmitView's Skills/City fields).
- `form.topics`/`form.languages` are now the direct source of truth — removed the intermediate joined-text state and split/join parsing that existed only to bridge to a plain text input.

## Test plan
- [x] `npx vitest run` (1792 passed), `npx svelte-check` (0 errors), `npx eslint` on touched files — clean
- [x] Manual check in a real browser (Playwright): typed two topics, confirmed both render as removable chips, removed one via its × button, confirmed it disappears and the other stays

🤖 Generated with [Claude Code](https://claude.com/claude-code)