### PR TITLE
Stop reading Greenhouse's AI opt-out form as a company board

### DIFF
--- a/internal/ingest/atsboard/board.go
+++ b/internal/ingest/atsboard/board.go
@@ -355,6 +355,14 @@ var noBoardFirstSegments = map[string][]string{
 	// boards "api/geo" and "_next/static" — and boardresolve, which takes the first recognized ATS
 	// URL in a fetched page, would meet them before any real one.
 	"jobs.dayforcehcm.com": {"api", "_next"},
+	// Greenhouse's AI-screening opt-out form is ONE shared endpoint
+	// (app4.greenhouse.io/ai_opt_out_request/job_post/<id>/ai_opt_out), served identically to
+	// every customer, and a career page carries its URL in markup that names the employer's own
+	// board nowhere else. It belongs here rather than in reservedSegments because the segment
+	// behind it is the platform's own "job_post": skipping would move the false board one
+	// segment along, not decline it. Two unrelated employers resolving to the same board is what
+	// surfaced it (2026-09-08).
+	"greenhouse.io": {"ai_opt_out_request"},
 }
 
 var reservedSegments = map[string][]string{

--- a/internal/ingest/atsboard/board_test.go
+++ b/internal/ingest/atsboard/board_test.go
@@ -305,6 +305,21 @@ func TestRecognize(t *testing.T) {
 		// "help". Before this guard was wired into modeSubdomain, both resolved as false boards.
 		{"recruitee platform app host not a tenant", "https://app.recruitee.com/", "", "", "", false},
 		{"bamboohr platform help host not a tenant", "https://help.bamboohr.com/s/article/x", "", "", "", false},
+		// "embed" READS like platform machinery and is not: embed.bamboohr.com is the board of a
+		// company actually called Embed, serving live postings, and BambooHR's widget is a PATH on
+		// each tenant's own host (<board>.bamboohr.com/jobs/embed2.php) rather than a host of its
+		// own. Pinned because adding "embed" to platformLabels on that misreading would silently
+		// drop a real board — a guard whose name sounds like machinery needs the host checked, not
+		// assumed (2026-09-08).
+		{"bamboohr tenant named like machinery still resolves", "https://embed.bamboohr.com/careers/605", "bamboohr", "embed", "https://embed.bamboohr.com", true},
+		// Greenhouse's AI-screening opt-out form is one shared endpoint, identical for every
+		// customer, and its URL sits in the markup of a career page whose employer board may be
+		// named nowhere else. Read as a path board it yields "ai_opt_out_request" — the SAME board
+		// for two unrelated employers, which is the tell. It carries no board behind it either:
+		// the segment after it is the platform's "job_post", so skipping (reservedSegments) would
+		// only move the false board one segment along.
+		{"greenhouse ai opt-out form carries no board", "http://app4.greenhouse.io/ai_opt_out_request/job_post/6178374004/ai_opt_out", "", "", "", false},
+		{"greenhouse ai opt-out form bare", "https://my.greenhouse.io/ai_opt_out_request", "", "", "", false},
 		{"unknown host", "https://example.com/careers/1", "", "", "", false},
 		{"not http", "ftp://acme.recruitee.com", "", "", "", false},
 		{"garbage", "not a url", "", "", "", false},


### PR DESCRIPTION
## What

`app4.greenhouse.io/ai_opt_out_request/job_post/<id>/ai_opt_out` is Greenhouse's AI-screening opt-out form — one shared endpoint, served identically to every customer. Its URL sits in the markup of career pages that name the employer's own board nowhere else, and `boardresolve` accepts the first recognized ATS URL in a page. The path rule therefore handed back the board `ai_opt_out_request`.

## How it surfaced

While collecting ATS boards from a public AI-jobs listing, two unrelated employers — Cribl and Nebius — resolved to the **same** board. A company-to-board relation must be unique, so an equal pair is a broken measurement rather than a finding. Reading the pages confirmed the shared endpoint.

## Why `noBoardFirstSegments`

The segment behind the form is the platform's own `job_post`, so `reservedSegments` would skip one segment and hand back `job_post` — moving the false board along rather than declining it. Declining is the package's stated fail-safe direction: an unrecognized link costs a 422, a false board costs a crawl nobody asked for.

## The near-miss this also pins

Auditing prod's `boards` for the same defect class turned up an active `bamboohr` board named `embed`, which reads exactly like platform machinery. It is not. `embed.bamboohr.com` is the board of a company **called** Embed — its live API returns 7 open postings across Singapore and Quezon City — and BambooHR's widget is a path on each tenant's own host (`<board>.bamboohr.com/jobs/embed2.php`), not a host of its own. Adding `embed` to `platformLabels` on that misreading would have silently dropped a real board, so a test now pins it: a label that sounds like machinery is precisely where this guard is most likely to delete something real.

## Verification

The opt-out cases were red first, for the expected reason, then green. Beyond the unit tests, the recognizer and `boardresolve` were re-run against the live Cribl and Nebius pages — both now decline rather than returning a wrong board — while `job-boards.greenhouse.io/cribl/...`, `acme.bamboohr.com/careers/42` and `embed.bamboohr.com/careers/605` still resolve.

`go test ./...`, `go vet ./...` and `go vet -tags=integration ./...` are clean.

## No data fix needed

Prod carries no `ai_opt_out_request` board, so this closes the hole before it was paid for. The `bamboohr/embed` row is correct and stays.
