### PR TITLE
Stop parking every Greenhouse posting on an invisible reCAPTCHA

### DIFF
--- a/internal/api/atsapply/browser.go
+++ b/internal/api/atsapply/browser.go
@@ -169,15 +169,74 @@ func classifyUnscannableForm(pageHTML string) unscannableFormReason {
 	return reasonUnrecognizedLayout
 }
 
-// hasRecaptchaMarker reports whether pageHTML contains "recaptcha" anywhere at all, a
-// deliberately unscoped substring search rather than one parsed against a specific element
-// (an injected iframe, or the script tag loading reCAPTCHA's API — both reference
-// "recaptcha" in a URL, which is what a real challenge actually leaves behind). Scoping the
-// search to those elements specifically would need DOM parsing this classification path is
-// meant to avoid (see classifyUnscannableForm's doc comment); an ordinary application page
-// mentioning the word incidentally is not a realistic false-positive risk in practice, and
-// either outcome still only ever produces a safe park (see design.md's Risks) — at most a
-// less specific Reason string, never a wrong fill/submit.
+// recaptchaChallengeFrames are the iframes Google injects for the image-grid challenge —
+// the one part of reCAPTCHA that is only ever in the DOM because a human is being asked to
+// solve something. Both URL shapes, classic and Enterprise.
+var recaptchaChallengeFrames = []string{
+	"recaptcha/api2/bframe",
+	"recaptcha/enterprise/bframe",
+}
+
+// recaptchaInvisibleBadge is the "protected by reCAPTCHA" corner badge. An invisible,
+// score-based reCAPTCHA renders it INSTEAD of asking anything, so it is the positive
+// evidence that a page's reCAPTCHA is one nobody has to pass.
+const recaptchaInvisibleBadge = "grecaptcha-badge"
+
+// recaptchaWidgetMarkers are the footprints of a reCAPTCHA widget being mounted at all: the
+// checkbox/badge iframe, and the widget element's own class before the script replaces it.
+// Matched with the class's delimiter attached so `g-recaptcha-response` — the hidden token
+// field EVERY reCAPTCHA page carries, invisible ones included — is not read as a widget.
+var recaptchaWidgetMarkers = []string{
+	"recaptcha/api2/anchor",
+	"recaptcha/enterprise/anchor",
+	`g-recaptcha"`,
+	`g-recaptcha'`,
+	"g-recaptcha ",
+}
+
+// hasRecaptchaMarker reports whether pageHTML carries a reCAPTCHA CHALLENGE — something a
+// candidate would have to pass — as opposed to merely loading reCAPTCHA at all.
+//
+// The distinction is the whole point of this function, and it is not a nicety. EVERY
+// vanilla job-boards.greenhouse.io posting ships an invisible, score-based reCAPTCHA
+// Enterprise. The earlier unscoped `strings.Contains(html, "recaptcha")` therefore matched
+// every Greenhouse posting there is, and through previewGreenhouse's own check that parked
+// the ONE provider this package can actually fill — before a single application was ever
+// attempted (freehire, 2026-09-08: 5 of the 10 entries the queue had ever held, all of them
+// on pages whose form scans fine in under two seconds).
+//
+// Presence of a widget cannot be the test, which is what a first attempt at this fix
+// assumed and a capture of the live DOM disproved: an invisible reCAPTCHA mounts an anchor
+// iframe too. What actually separates the two:
+//
+//   - a bframe iframe is the image-grid challenge itself, and is in the DOM only when one
+//     is genuinely being posed — decisive on its own;
+//   - otherwise, the corner badge means the page's reCAPTCHA is the invisible kind, which
+//     asks nothing;
+//   - otherwise, a mounted widget with no badge is a checkbox the candidate must tick.
+//
+// A page gated by a different vendor's challenge is unaffected either way: its form's own
+// selector never appears, so it still parks as reasonUnrecognizedLayout.
 func hasRecaptchaMarker(pageHTML string) bool {
-	return strings.Contains(strings.ToLower(pageHTML), "recaptcha")
+	lower := strings.ToLower(pageHTML)
+	if containsAny(lower, recaptchaChallengeFrames) {
+		return true
+	}
+	if strings.Contains(lower, recaptchaInvisibleBadge) {
+		return false
+	}
+	return containsAny(lower, recaptchaWidgetMarkers)
+}
+
+// containsAny reports whether s contains any of markers. Literal scans rather than one
+// regexp alternation, for the reason internal/dict/skilltag documents for its own
+// dictionary: alternation over a page-sized string is a fraction of the speed, and this
+// runs on every scanned posting.
+func containsAny(s string, markers []string) bool {
+	for _, marker := range markers {
+		if strings.Contains(s, marker) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/api/atsapply/browser_test.go
+++ b/internal/api/atsapply/browser_test.go
@@ -24,6 +24,44 @@ const whitelabelFormWithoutRecaptchaHTML = `
 </body></html>
 `
 
+// What EVERY vanilla job-boards.greenhouse.io posting actually renders, reduced from the
+// live DOM of three postings (garnerhealth 6181651004, exadelinc 6141005004, nimblegravity
+// 4721959005) as a headless Chrome on the production host saw them on 2026-09-08. All
+// three were byte-for-byte alike in every part reproduced here.
+//
+// This is score-based, INVISIBLE reCAPTCHA Enterprise, and every piece below is why a
+// cheaper test than this one is worthless:
+//
+//   - grecaptcha-badge — the "protected by reCAPTCHA" corner badge, which is what an
+//     invisible reCAPTCHA renders INSTEAD of asking anything.
+//   - an enterprise/ANCHOR iframe — present even though nothing is being asked. An
+//     invisible reCAPTCHA still mounts one, so "a widget exists" cannot mean "a challenge
+//     is being posed"; only a bframe (the image-grid iframe) means that, and none of the
+//     three postings had one.
+//   - g-recaptcha-RESPONSE, the hidden token field. Its name CONTAINS "g-recaptcha", so a
+//     substring test for the widget class matches every page that merely loads reCAPTCHA.
+//
+// None of it gates reading or filling the form: a live probe found #application-form
+// visible on these very pages in 0.8-1.7s from the production host. Treating it as a
+// challenge parked every Greenhouse attempt in production — 5 of the 10 entries the queue
+// had ever held — while the package's own hand-written fixtures, carrying none of this,
+// stayed green.
+const greenhouseInvisibleRecaptchaHTML = `
+<html><body>
+<form id="application-form">
+  <input id="first_name" name="first_name" type="text" required>
+</form>
+<textarea id="g-recaptcha-response-100000" name="g-recaptcha-response" class="g-recaptcha-response"></textarea>
+<div class="grecaptcha-error"></div>
+<div class="grecaptcha-badge" data-style="bottomright" style="position: fixed; right: -186px;">
+  <div class="grecaptcha-logo">
+    <iframe title="reCAPTCHA" role="presentation" src="https://www.recaptcha.net/recaptcha/enterprise/anchor?ar=1&amp;k=6LfmcbcpAAAAAChNTbhUShzUOAMj_wY9LQIvLFX0&amp;size=invisible"></iframe>
+  </div>
+</div>
+<script src="https://www.recaptcha.net/recaptcha/enterprise.js?render=6LfmcbcpAAAAAChNTbhUShzUOAMj_wY9LQIvLFX0"></script>
+</body></html>
+`
+
 func TestClassifyUnscannableForm_RecaptchaFootprintWins(t *testing.T) {
 	if got := classifyUnscannableForm(whitelabelFormWithRecaptchaHTML); got != reasonCaptchaProtected {
 		t.Errorf("classifyUnscannableForm = %q, want %q", got, reasonCaptchaProtected)
@@ -47,10 +85,31 @@ func TestClassifyUnscannableForm_VanillaFormFixtureIsNotMisclassifiedAsCaptcha(t
 }
 
 func TestHasRecaptchaMarker_CaseInsensitive(t *testing.T) {
-	if !hasRecaptchaMarker(`<script src="https://WWW.RECAPTCHA.NET/enterprise.js"></script>`) {
-		t.Error("hasRecaptchaMarker = false, want true for a differently-cased URL")
+	if !hasRecaptchaMarker(`<iframe title="reCAPTCHA" src="https://WWW.RECAPTCHA.NET/RECAPTCHA/ENTERPRISE/ANCHOR?k=abc"></iframe>`) {
+		t.Error("hasRecaptchaMarker = false, want true for a differently-cased challenge iframe")
 	}
 	if hasRecaptchaMarker(`<form id="application-form"></form>`) {
 		t.Error("hasRecaptchaMarker = true, want false for an ordinary form")
+	}
+}
+
+// The bug this whole distinction exists to prevent: every vanilla Greenhouse posting loads
+// an invisible, score-based reCAPTCHA, so a marker that fires on the mere PRESENCE of the
+// word parks the one provider this package can actually fill.
+func TestHasRecaptchaMarker_InvisibleEnterpriseIsNotAChallenge(t *testing.T) {
+	if hasRecaptchaMarker(greenhouseInvisibleRecaptchaHTML) {
+		t.Error("hasRecaptchaMarker = true for a live vanilla Greenhouse page, want false — " +
+			"an invisible score-based reCAPTCHA renders no widget and gates nothing")
+	}
+}
+
+// The other half of the same distinction, stated on its own so a marker narrowed into
+// uselessness fails here rather than silently letting a real challenge through.
+func TestHasRecaptchaMarker_RenderedChallengeWidgetIsAChallenge(t *testing.T) {
+	if !hasRecaptchaMarker(whitelabelFormWithRecaptchaHTML) {
+		t.Error("hasRecaptchaMarker = false for a rendered reCAPTCHA anchor iframe, want true")
+	}
+	if !hasRecaptchaMarker(`<div class="g-recaptcha" data-sitekey="abc"></div>`) {
+		t.Error("hasRecaptchaMarker = false for an explicit g-recaptcha widget, want true")
 	}
 }


### PR DESCRIPTION
## What

`auto-apply` has submitted **zero** applications since it shipped. Seven of the ten entries the queue has ever held are parked; five of those on `form_captcha_protected`, and every one of those five is a page whose form scans perfectly well.

## Why

`previewGreenhouse` asks `hasRecaptchaMarker`, which was `strings.Contains(html, "recaptcha")`.

Every vanilla `job-boards.greenhouse.io` posting loads an invisible, score-based reCAPTCHA Enterprise. So the marker matched every Greenhouse posting there is — and Greenhouse is the *one* provider `fillProviders` covers. Nothing could ever reach a submission.

The queue's own timings say it plainly: entry 7 was claimed at 14:50:42 and parked at 14:50:45. **Three seconds**, against a twenty-second selector wait — the scan had already succeeded when the substring test threw it away. A probe from the production host finds `#application-form` visible on these pages in 0.8–1.7s.

## The fix

Narrow the marker to a challenge somebody would actually have to pass:

- a **bframe** iframe is the image-grid challenge itself, present only when one is genuinely posed — decisive on its own;
- otherwise the **corner badge** means the invisible kind, which asks nothing;
- otherwise a **mounted widget with no badge** is a checkbox to tick.

Widget markers carry their class delimiter so `g-recaptcha-response` — the hidden token field every reCAPTCHA page has — is no longer read as a widget. It was three of the "matches" on a live page.

## What this does not claim

It does not claim submissions will now go through. An invisible reCAPTCHA *scores* the client, and a datacenter IP scores poorly. This makes that outcome reachable and observable, which it has never been. The browser egresses directly (`browser.LaunchOptions`, no proxy) — if real submissions start bouncing, that is the next thing to measure, not to guess at now.

## On the test that should have caught this

The package already had a regression guard for exactly this bug (`TestClassifyUnscannableForm_VanillaFormFixtureIsNotMisclassifiedAsCaptcha`) — but it ran against a hand-written fixture carrying no reCAPTCHA footprint at all, so it could never fire.

The new fixture is reduced from the live DOM of three postings instead. That mattered: **the first version of this fix was green against a hand-written fixture and wrong against the real page** — an invisible reCAPTCHA mounts an anchor iframe too, which only capturing the live DOM revealed.

## Verification

- Rule replayed against the live rendered DOM of all three postings on the production host: `bframe: 0`, `badge: 1` → no longer parked.
- `go test ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `gofmt`, `golangci-lint` — all clean.

Behaviour unchanged for a real challenge, for Lever (`requiresCaptcha` short-circuits before any of this), and for a page gated by another vendor, which still parks as `unrecognized_form_layout`.