### PR TITLE
Scope the job sitemap to tech postings

### DIFF
--- a/internal/search/search/sitemap.go
+++ b/internal/search/search/sitemap.go
@@ -26,6 +26,35 @@ const (
 	lastmodField     = "updated_at"
 )
 
+// jobSitemapFilter narrows the JOB sitemap to what this site claims to be. The index
+// itself stays wide — a non-tech posting is a legitimate result behind an explicit
+// is_tech facet, and it keeps its page, its canonical and its place in /jobs. A
+// sitemap is a different kind of statement: it asserts what is worth crawling, and
+// two thirds of the index contradicted the assertion (measured on prod 2026-09-08:
+// 1,295,388 of 2,014,462 documents are is_tech=non_tech, against 97,222 in
+// software_engineering).
+//
+// `is_tech = "tech"`, not `!= "non_tech"`: the attribute is written
+// tech-or-non_tech-or-ABSENT, so the negation would also admit the ~48k postings
+// neither the title dictionary nor enrichment could classify. Since the sitemap
+// asserts, silence has to read as "not asserted", not as "tech".
+//
+// likely-evergreen is excluded and `stale` deliberately is NOT. The reality classes
+// are not a liveness verdict (see internal/job/jobreality): `fresh` is "at most 14
+// days old", `likely-evergreen` needs two converging ghost signals, and `stale` is
+// the classifier's own "everything else" — 461,069 ordinary open tech postings whose
+// only fault is being more than a fortnight old. Excluding it would drop them for
+// their age and churn the whole sitemap every two weeks, faster than this site's
+// crawl budget reaches it. likely-evergreen is the one class that accuses, and
+// /features/ghost-jobs publishes that accusation on the very pages the sitemap would
+// otherwise invite a crawler to; it is 1,538 documents, so it moves no number and
+// closes a contradiction.
+//
+// Both attributes are already declared in facetSettings().FilterableAttributes, so
+// this needs no settings patch and no reindex — the "settings must reach the LIVE
+// index before the binary that filters on it" hazard documented there does not apply.
+const jobSitemapFilter = `is_tech = "tech" AND reality.class != "likely-evergreen"`
+
 // sitemapPage is the shared body of the two sitemap readers: one offset-addressed
 // page of an index, projected down to a slug and a lastmod, plus the index's total
 // document count.
@@ -43,22 +72,38 @@ const (
 // rendering "0 open jobs" — 17 of 25 sampled pages on prod. RefreshCompanyFacets now
 // applies splitJobs' three extra predicates; if either side gains a fourth, both move.
 //
-// The engine addresses an offset directly instead of walking to it — measured on
-// prod (2026-08-16, 1.26M job documents): offset 0 and offset 1.2M both answer in
-// under 0.25s, and a full 25k page in ~2.5s. That is what replaced a Postgres
-// `row_number()` walk which had grown to 64s over 3.4M rows and was timing out the
-// SSR render of /sitemap.xml.
+// The engine addresses an offset directly instead of walking to it, which is what
+// replaced a Postgres `row_number()` walk that had grown to 64s over 3.4M rows and was
+// timing out the SSR render of /sitemap.xml.
+//
+// Re-measured on prod 2026-09-08 at 2.01M job documents, 10k-document pages, this
+// projection: the deepest unfiltered page (offset 1.9M) takes 4.43s and the deepest
+// filtered one (offset 660k) 4.07s, while the single-document request
+// CountSitemapDocuments issues takes 0.035s. An earlier note here recorded 0.25s at
+// offset 1.2M with 1.26M documents; that margin has since narrowed from ~40x to ~2.5x
+// against this route's 10s fetch timeout, and it keeps narrowing as the catalogue
+// grows. The chunk size is the lever when it runs out.
 //
 // Offset paging is not a stable cursor: documents added or removed between two page
 // requests shift later pages. That is acceptable here and nowhere else — a sitemap
 // is a crawl hint, not a contract, and both indexes are rebuilt on a timer anyway. A
 // page past the end is an empty page, never an error.
-func (c *Client) sitemapPage(ctx context.Context, idx meilisearch.IndexManager, slugField string, offset, limit int) ([]SitemapDocument, int64, error) {
+//
+// `filter` is a Meilisearch filter expression, or empty for the whole index. It is
+// assigned only when non-empty, and that guard is load-bearing rather than tidiness:
+// DocumentsQuery.Filter is an `interface{}` with `json:"filter,omitempty"`, and
+// omitempty drops an interface only when it is NIL — an interface holding "" marshals
+// to `"filter":""`. Assigning unconditionally would therefore send an empty filter
+// expression on the company path, which is not the request it sends today.
+func (c *Client) sitemapPage(ctx context.Context, idx meilisearch.IndexManager, slugField, filter string, offset, limit int) ([]SitemapDocument, int64, error) {
 	var resp meilisearch.DocumentsResult
 	q := &meilisearch.DocumentsQuery{
 		Offset: int64(offset),
 		Limit:  int64(limit),
 		Fields: []string{slugField, lastmodField},
+	}
+	if filter != "" {
+		q.Filter = filter
 	}
 	if err := idx.GetDocumentsWithContext(ctx, q, &resp); err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -93,22 +138,31 @@ func (c *Client) sitemapPage(ctx context.Context, idx meilisearch.IndexManager, 
 	return docs, resp.Total, nil
 }
 
-// ListSitemapPage returns one offset-addressed page of the live jobs index along
-// with the index's total document count. See sitemapPage.
+// ListSitemapPage returns one offset-addressed page of the live jobs index, narrowed
+// to jobSitemapFilter, along with the total number of documents matching it. See
+// sitemapPage.
 func (c *Client) ListSitemapPage(ctx context.Context, offset, limit int) ([]SitemapDocument, int64, error) {
-	return c.sitemapPage(ctx, c.facet, jobSlugField, offset, limit)
+	return c.sitemapPage(ctx, c.facet, jobSlugField, jobSitemapFilter, offset, limit)
 }
 
-// ListCompanySitemapPage is ListSitemapPage over the companies index.
+// ListCompanySitemapPage is ListSitemapPage over the companies index, unfiltered: what
+// belongs in the company sitemap is decided upstream by companies.job_count, not here,
+// and jobSitemapFilter names attributes a company document does not have.
 func (c *Client) ListCompanySitemapPage(ctx context.Context, offset, limit int) ([]SitemapDocument, int64, error) {
-	return c.sitemapPage(ctx, c.manager.Index(companyIndexUID), companySlugField, offset, limit)
+	return c.sitemapPage(ctx, c.manager.Index(companyIndexUID), companySlugField, "", offset, limit)
 }
 
-// CountSitemapDocuments returns how many documents the live jobs index holds, which
-// is what the sitemap index divides into chunks. The total rides on every documents
-// response, so this asks for the shortest page the engine will serve rather than a
-// count of its own. Not zero: DocumentsQuery.Limit is `omitempty`, so a 0 is dropped
-// from the request body and Meilisearch applies its own default of 20.
+// CountSitemapDocuments returns how many of the live jobs index's documents the job
+// sitemap names — i.e. how many match jobSitemapFilter — which is what the sitemap
+// index divides into chunks. The total rides on every documents response, so this asks
+// for the shortest page the engine will serve rather than a count of its own. Not
+// zero: DocumentsQuery.Limit is `omitempty`, so a 0 is dropped from the request body
+// and Meilisearch applies its own default of 20.
+//
+// It delegates to ListSitemapPage rather than issuing its own query, and that is the
+// structural reason the count and the chunks cannot disagree: there is one filter, in
+// one place, and a sitemap index that tiled by a wider population than its chunks
+// serve would name chunks that come back empty.
 func (c *Client) CountSitemapDocuments(ctx context.Context) (int64, error) {
 	_, total, err := c.ListSitemapPage(ctx, 0, 1)
 	return total, err

--- a/internal/search/search/sitemap_integration_test.go
+++ b/internal/search/search/sitemap_integration_test.go
@@ -1,0 +1,171 @@
+//go:build integration
+
+// Integration test for the sitemap readers' scope against a real Meilisearch: the job
+// sitemap names TECH postings only, and the company sitemap is untouched by that
+// filter. The filter expression is evaluated by the engine, so only a real one can
+// prove it selects what it claims. Run with:
+//
+//	go test -tags=integration ./internal/search/search/
+//
+// Requires Docker (reuses startMeili from search_integration_test.go).
+package search
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/job/jobreality"
+	"github.com/strelov1/freehire/internal/job/jobview"
+	"github.com/strelov1/freehire/internal/platform/db"
+)
+
+// indexJobsForSitemap maps rows through FromJob and indexes them, attaching each
+// document's reality class the way cmd/reindex does — the classifier needs a clock and
+// role-cluster counts FromJob has no access to, so the caller sets it. A row whose
+// class is empty gets no reality object at all, which is how a document indexed before
+// the signal existed looks.
+func indexJobsForSitemap(t *testing.T, c *Client, jobs []db.Job, classes []string) {
+	t.Helper()
+	ctx := context.Background()
+	docs := make([]JobDocument, 0, len(jobs))
+	for i, j := range jobs {
+		d, err := FromJob(j)
+		if err != nil {
+			t.Fatalf("FromJob(%d): %v", j.ID, err)
+		}
+		if classes[i] != "" {
+			d.Reality = &jobview.Reality{Class: classes[i]}
+		}
+		docs = append(docs, d)
+	}
+	if err := c.IndexJobs(ctx, docs); err != nil {
+		t.Fatalf("IndexJobs: %v", err)
+	}
+}
+
+// TestIntegration_JobSitemapScope locks the sitemap's scope spec scenarios against a
+// real engine: of four indexed, findable postings only the plain tech one is named.
+// The non_tech and the unclassified postings stay INDEXED and searchable — this is a
+// sitemap-scope filter, not an indexing one — which is why the assertion is about what
+// ListSitemapPage returns and not about what the index holds.
+func TestIntegration_JobSitemapScope(t *testing.T) {
+	ctx := context.Background()
+	c := startMeili(t)
+	if err := c.EnsureIndex(ctx); err != nil {
+		t.Fatalf("EnsureIndex: %v", err)
+	}
+
+	yes := pgtype.Bool{Bool: true, Valid: true}
+	no := pgtype.Bool{Bool: false, Valid: true}
+	unknown := pgtype.Bool{} // NULL — jobview omits the facet, so it filters as absent
+
+	jobs := []db.Job{
+		{ID: 1, Title: "Senior Go Engineer", Company: "Acme", PublicSlug: "tech-fresh", Category: "backend", IsTech: yes},
+		{ID: 2, Title: "Staff Platform Engineer", Company: "Acme", PublicSlug: "tech-stale", Category: "backend", IsTech: yes},
+		{ID: 3, Title: "Warehouse Cleaner", Company: "Beta", PublicSlug: "non-tech", IsTech: no},
+		{ID: 4, Title: "Yard Coordinator", Company: "Gamma", PublicSlug: "unclassified", IsTech: unknown},
+		{ID: 5, Title: "Backend Engineer", Company: "Delta", PublicSlug: "tech-evergreen", Category: "backend", IsTech: yes},
+	}
+	classes := []string{
+		jobreality.ClassFresh,
+		// stale is "everything else", not a liveness verdict — an ordinary open posting
+		// more than a fortnight old. It must still be named, which is the whole reason
+		// the filter excludes likely-evergreen and not this.
+		jobreality.ClassStale,
+		jobreality.ClassFresh,
+		jobreality.ClassFresh,
+		jobreality.ClassLikelyEvergreen,
+	}
+	indexJobsForSitemap(t, c, jobs, classes)
+
+	t.Run("names tech postings, fresh and stale alike", func(t *testing.T) {
+		docs, total, err := c.ListSitemapPage(ctx, 0, 100)
+		if err != nil {
+			t.Fatalf("ListSitemapPage: %v", err)
+		}
+		got := make(map[string]bool, len(docs))
+		for _, d := range docs {
+			got[d.Slug] = true
+		}
+		for _, want := range []string{"tech-fresh", "tech-stale"} {
+			if !got[want] {
+				t.Errorf("sitemap should name %q, got %v", want, got)
+			}
+		}
+		for _, unwanted := range []string{"non-tech", "unclassified", "tech-evergreen"} {
+			if got[unwanted] {
+				t.Errorf("sitemap should not name %q, got %v", unwanted, got)
+			}
+		}
+		if total != 2 {
+			t.Errorf("total = %d, want 2", total)
+		}
+	})
+
+	// The sitemap index tiles by this count and its chunks are served by the reader
+	// above. If the two ever disagree, /sitemap.xml names a chunk that comes back
+	// empty — so the agreement is the property under test, not the number.
+	t.Run("the count matches what the pages serve", func(t *testing.T) {
+		total, err := c.CountSitemapDocuments(ctx)
+		if err != nil {
+			t.Fatalf("CountSitemapDocuments: %v", err)
+		}
+		docs, pageTotal, err := c.ListSitemapPage(ctx, 0, 100)
+		if err != nil {
+			t.Fatalf("ListSitemapPage: %v", err)
+		}
+		if total != pageTotal || total != int64(len(docs)) {
+			t.Errorf("count = %d, page total = %d, page len = %d — all three must agree",
+				total, pageTotal, len(docs))
+		}
+	})
+
+	// An offset past the end is what a crawler holding an older sitemap index asks
+	// for, and it must be an empty page rather than an error.
+	t.Run("an offset past the end is an empty page", func(t *testing.T) {
+		docs, total, err := c.ListSitemapPage(ctx, 1000, 100)
+		if err != nil {
+			t.Fatalf("ListSitemapPage past the end: %v", err)
+		}
+		if len(docs) != 0 {
+			t.Errorf("docs past the end = %v, want none", docs)
+		}
+		if total != 2 {
+			t.Errorf("total past the end = %d, want the unchanged 2", total)
+		}
+	})
+}
+
+// TestIntegration_CompanySitemapUnfiltered proves the job filter does not reach the
+// company reader. The two share sitemapPage, so a filter applied there rather than at
+// the job caller would silently empty the company sitemap — `is_tech` is not an
+// attribute of a company document, and Meilisearch rejects a filter naming an
+// undeclared attribute, so the failure would be a 400 surfacing as a 500 on
+// /sitemap.xml rather than anything a reader would guess from this change.
+func TestIntegration_CompanySitemapUnfiltered(t *testing.T) {
+	ctx := context.Background()
+	c := startMeili(t)
+
+	buildCompanyIndex(t, c, []CompanyDocument{
+		{Slug: "acme", Name: "Acme", JobCount: 3},
+		{Slug: "beta", Name: "Beta", JobCount: 1},
+	})
+
+	docs, total, err := c.ListCompanySitemapPage(ctx, 0, 100)
+	if err != nil {
+		t.Fatalf("ListCompanySitemapPage: %v", err)
+	}
+	if total != 2 || len(docs) != 2 {
+		t.Errorf("company sitemap = %d docs (total %d), want both companies", len(docs), total)
+	}
+
+	count, err := c.CountCompanySitemapDocuments(ctx)
+	if err != nil {
+		t.Fatalf("CountCompanySitemapDocuments: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("company count = %d, want 2", count)
+	}
+}

--- a/openspec/changes/scope-job-sitemap-to-tech/design.md
+++ b/openspec/changes/scope-job-sitemap-to-tech/design.md
@@ -1,0 +1,126 @@
+## Context
+
+`/sitemap.xml` is a sitemap index whose job chunks are offset-addressed pages of the live
+Meilisearch `jobs` index. `sitemapPage`'s own comment states the reasoning: the sitemap pages
+the search index rather than the `jobs` table "because the indexes already hold exactly the sets
+worth handing a crawler — open, non-duplicate, non-private, categorized".
+
+Those four predicates are about whether a posting is *findable*. None of them is about whether
+it is what this site is for. The index serves search, where a non-tech posting is a legitimate
+result behind an explicit `is_tech` facet; the sitemap serves discovery, where it is a claim.
+The two scopes have been the same set only because nothing ever separated them.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The job sitemap names tech postings and nothing else.
+- The count the index tiles by and the pages it serves stay structurally incapable of
+  disagreeing.
+- No settings patch, no reindex, no change to what search returns.
+
+**Non-Goals:**
+
+- Changing what is *indexed*, *served* or *reachable*. Every non-tech posting keeps its page and
+  its `/jobs` listing; only the sitemap stops naming it.
+- The company sitemap, and the chunk size (see proposal.md).
+
+## Decisions
+
+### Where the predicate lives
+
+`sitemapPage` takes a `filter string`; `ListSitemapPage` passes the jobs predicate and
+`ListCompanySitemapPage` passes `""`. The alternative — a filter argument threaded from the HTTP
+handler — was rejected: the handler has no opinion about what a crawlable job is, and a
+per-request filter is a public surface nobody asked for.
+
+What makes this placement safe is that `CountSitemapDocuments` already calls `ListSitemapPage`
+with `limit 1` rather than counting on its own. The filter therefore reaches the count without
+being written twice, and the sitemap index cannot tile by one population while its chunks serve
+another. If the two had been independent readers this change would need a shared constant *and*
+a test that they still agree; as written it needs neither.
+
+### Excluding `stale` was considered and rejected
+
+The obvious reading of "the sitemap is full of dead postings" is wrong, and the numbers say so.
+`internal/job/jobreality/classify.go` is explicit that the classes are not a liveness verdict:
+`fresh` is "at most 14 days old with no evergreen signal", `likely-evergreen` needs two
+converging ghost signals, and `stale` is the comment's own "everything else".
+
+Measured on prod 2026-09-08:
+
+| Slice | Documents |
+|---|---:|
+| `tech AND reality.class = fresh` | 208,275 |
+| `tech AND reality.class = stale` | 461,069 |
+| `tech AND reality.class = likely-evergreen` | 1,542 |
+| `tech AND created_ts < now-90d` | **0** |
+| `non_tech AND created_ts < now-90d` | **0** |
+
+(The reality rows are one probe and the `tech` total in proposal.md is another, so they differ
+by a handful of documents ingested in between: 670,890 − 1,542 ≠ 669,352 by four. The index is
+live; no decision here turns on that.)
+
+No document in the index — of either kind — was first seen more than 90 days ago; the catalogue
+retires its own tail through the unseen sweep, `close-chronic-boards` and `cmd/prune`. So a
+`stale` tech posting is an ordinary open vacancy that is more than a fortnight old, and
+excluding the class would have dropped 461,069 live tech jobs for their age. It would also have
+made the sitemap churn completely every fourteen days, dropping URLs faster than a crawler of
+this site's budget can reach them.
+
+`likely-evergreen` is the only class that asserts something is wrong with a posting, and it is
+1,542 documents inside tech. It is excluded because the product publishes a ghost verdict on
+exactly these pages, not because it moves a number.
+
+### Reality is a snapshot, and that is acceptable here
+
+`jobreality` is documented as "TIME-DEPENDENT and computed at index/read time, never stored", and
+`doc.Reality` is attached by `cmd/reindex`. A document's `reality.class` is therefore as old as
+the last full rebuild, and the incremental `search-drain` will not refresh it (reality is not part
+of `content_hash` — the same trap `is_tech` and `requires_clearance` already document).
+
+For this filter that is tolerable and worth stating rather than fixing: the clause it feeds
+selects 0.2% of the set, the rebuild runs on a timer measured in hours, and a sitemap is a crawl
+hint rather than a contract — `sitemapPage` already says so where it accepts that offset paging
+is not a stable cursor. Had the design leaned on `reality` for the *primary* clause, this
+staleness would have been disqualifying.
+
+### Performance: measured, not assumed
+
+`GetDocumentsWithContext` already POSTs to `/documents/fetch`, so adding a filter changes the
+request body and not the transport. Measured on prod 2026-09-08, `fields: [public_slug,
+updated_at]`, `limit: 10000`:
+
+| Query | Time |
+|---|---:|
+| unfiltered, `offset=0` (today) | 0.65s |
+| unfiltered, `offset=1,900,000` (today's deepest) | **4.43s** |
+| filtered, `offset=0` | 1.18s |
+| filtered, `offset=300,000` | 2.19s |
+| filtered, `offset=660,000` (new deepest) | **4.07s** |
+| filtered, `limit=1` (what the count issues) | 0.035s |
+
+The deepest page gets marginally cheaper, not more expensive, and the count stays free. Both
+figures sit against the SSR route's 10s fetch timeout — which is also why the stale comment
+claiming 0.25s at 1.2M documents has to go: it would tell the next reader there is a 40x margin
+where there is a 2.5x one.
+
+## Risks / Trade-offs
+
+- **A large reported drop in Search Console.** Discovered URLs fall by two thirds within a crawl
+  cycle. Expected; the mitigation is knowing it in advance rather than reacting to it.
+- **`is_tech` unknown is excluded.** The attribute is written tech-or-non_tech-or-absent, so
+  `= "tech"` drops postings no dictionary and no enrichment could classify. That is the right
+  default for a claim: we do not assert a posting is a tech job when nothing established that.
+  It does mean an enrichment gap costs sitemap coverage, which is a reason to watch the unknown
+  bucket, not a reason to widen the filter.
+- **The margin against the fetch timeout is thin and shrinking with the catalogue.** This change
+  does not worsen it and does not fix it; the chunk size is the lever, deliberately left to its
+  own change.
+
+## Migration Plan
+
+None. No schema, no index settings, no backfill. The change is live for the next render of
+`/sitemap.xml`, and reverting it is reverting the commit — a crawler that read the narrow index
+meets the wide one again with no broken URL in between, because the retired offsets answer with
+an empty `urlset` rather than an error in either direction.

--- a/openspec/changes/scope-job-sitemap-to-tech/proposal.md
+++ b/openspec/changes/scope-job-sitemap-to-tech/proposal.md
@@ -1,0 +1,71 @@
+## Why
+
+The job sitemap offers a crawler the whole live search index. The site is "the open-source
+search engine for tech jobs"; two thirds of what the sitemap names is not a tech job.
+
+Measured on prod 2026-09-08 against the live `jobs` index (2,014,462 documents, which is
+exactly what `/sitemap.xml` enumerates today):
+
+| Slice | Documents | Share |
+|---|---:|---:|
+| Everything the sitemap names today | 2,014,462 | 100% |
+| `is_tech = non_tech` | 1,295,388 | **64.3%** |
+| `is_tech` resolved by nothing | 47,906 | 2.4% |
+| `is_tech = tech` | 670,890 | 33.3% |
+| `is_tech = tech`, minus `likely-evergreen` | **669,352** | 33.2% |
+
+(Counts come from separate probes minutes apart and the index moves under ingest — the total
+read 2,014,007 at the first and 2,014,462 at the last. Nothing here turns on the last three
+digits.)
+
+By category the non-tech mass is not a fringe: management 301,387, sales 191,969, healthcare
+181,760, support 143,699. `software_engineering` is 97,222 — 4.8% of what we ask Google to
+crawl. A sampled sitemap page returned 39 non-tech postings out of 60 (Senior Transactional
+Attorney, Community Association Manager, Dispatcher Assistant).
+
+A sitemap is a claim about what is worth crawling. Ours currently claims 1.3M pages that
+contradict what the site says it is, and spends the crawl budget of the 670k that do not.
+
+This is a sitemap-scope change only. Nothing leaves the catalogue, the API, or search: a
+non-tech posting keeps its page, its URL and its place in `/jobs`. Only the crawl invitation
+narrows.
+
+## What Changes
+
+- **`sitemapPage` gains a filter.** `internal/search/search/sitemap.go`'s shared reader takes a
+  Meilisearch filter expression. `ListSitemapPage` (jobs) passes one; `ListCompanySitemapPage`
+  passes none, unchanged.
+- **The job sitemap's scope becomes `is_tech = "tech" AND reality.class != "likely-evergreen"`.**
+  The first clause is the whole of the change's value. The second excludes the 1,538 postings
+  the catalogue's own classifier flags as perpetual listings — 0.2%, and the one reality class
+  that is an accusation rather than an age bucket. Inviting a crawler to a posting we publish a
+  ghost verdict about (`/features/ghost-jobs`) is a contradiction we can close in the same
+  clause.
+- **`CountSitemapDocuments` inherits the filter for free**, because it already delegates to
+  `ListSitemapPage`. The count the sitemap index tiles by and the pages it names cannot
+  disagree — there is no second place to keep in sync.
+- **No settings patch and no reindex.** `is_tech` and `reality.class` are already declared in
+  `facetSettings().FilterableAttributes`, so the "settings must reach the LIVE index before the
+  binary that filters on it" hazard does not apply here.
+- **One stale comment is corrected.** `sitemapPage`'s own performance note records "offset 0 and
+  offset 1.2M both answer in under 0.25s" from 2026-08-16 at 1.26M documents. Re-measured
+  2026-09-08 at 2.01M documents, the deepest unfiltered page takes 4.43s. The lines are being
+  edited anyway.
+
+## Impact
+
+- 203 job sub-sitemaps become 68. `/sitemap.xml` re-renders from the new count, so the retired
+  offsets stop being listed; a crawler holding a stale index and requesting one gets an empty
+  `<urlset>`, which is already this route's documented behaviour. Nothing 404s.
+- Search Console will report a large drop in discovered URLs. That is the intent, not a
+  regression.
+- Worst-case render is unchanged: the deepest filtered page measured 4.07s against today's
+  deepest unfiltered 4.43s, both against the SSR route's 10s fetch timeout.
+
+## Non-Goals
+
+- **The company sitemap.** Its scope is `companies.job_count`, a different predicate computed by
+  `RefreshCompanyFacets`, and narrowing it to companies with a tech role is its own change.
+- **The chunk size.** 10,000 was sized by the fetch timeout, and the margin has eroded as the
+  catalogue grew. Halving it would restore the margin, and it deserves its own measurement.
+- **Excluding `stale`.** Considered and rejected on evidence — see design.md.

--- a/openspec/changes/scope-job-sitemap-to-tech/specs/web-ssr-seo/spec.md
+++ b/openspec/changes/scope-job-sitemap-to-tech/specs/web-ssr-seo/spec.md
@@ -1,0 +1,96 @@
+## MODIFIED Requirements
+
+### Requirement: robots.txt and sitemap
+
+The site SHALL serve a real `GET /robots.txt` (a valid robots file that allows
+crawling of public pages and references the sitemap) and a `GET /sitemap.xml`
+that is a valid **sitemap index** (`<sitemapindex>`) referencing sub-sitemaps for
+the static pages, the jobs, and the companies. Neither the index nor any
+sub-sitemap SHALL return the HTML application shell, and each SHALL be valid XML.
+Every sub-sitemap SHALL hold at most 50,000 URLs (the sitemap-protocol limit).
+Every company with at least one FINDABLE role (`/companies/:slug`) SHALL be
+enumerated across keyset-cursor-paged company sub-sitemaps, and a company with
+none SHALL NOT appear. "Findable" is the job search index's own scope — open,
+non-duplicate, non-private, categorized, with a body — because the company page's
+job list is served by that index, so a company outside it has a page that renders
+its name and "0 open jobs". The scope is carried by `companies.job_count`, which
+`RefreshCompanyFacets` computes under exactly those predicates.
+
+The job sub-sitemaps SHALL enumerate the **TECH** postings of that same index
+(`/jobs/:slug`), and no others. A posting SHALL be named when `is_tech` is `tech`
+and its reality class is not `likely-evergreen`; a `non_tech` posting, a posting
+whose `is_tech` no dictionary and no enrichment resolved, and one carrying the
+perpetual-listing verdict SHALL NOT be named.
+
+This narrows the sitemap ONLY. A posting outside this scope keeps its page, its
+canonical URL, its place in `/jobs` and its search result — the sitemap is a claim
+about what is worth crawling, and this site's claim is tech jobs. The unknown
+bucket is excluded rather than admitted because the sitemap asserts; a posting
+nothing could classify is not asserted to be a tech job. `likely-evergreen` is
+excluded because the site publishes a ghost verdict on those same pages, and
+inviting a crawler to one contradicts it.
+
+The population the sitemap index tiles into chunks SHALL be the same filtered
+population the chunks serve, so that the index can never name a chunk the job
+reader would not fill.
+
+#### Scenario: robots.txt is a valid robots file
+
+- **WHEN** `GET /robots.txt` is requested
+- **THEN** the response is a `text/plain` robots file (not HTML) that references
+  the sitemap URL
+
+#### Scenario: sitemap.xml is a sitemap index
+
+- **WHEN** `GET /sitemap.xml` is requested
+- **THEN** the response is valid XML with a `<sitemapindex>` root listing
+  sub-sitemap `<loc>` URLs for the static pages, the jobs, and every company
+  chunk, and it does not contain job or company page `<url>` entries directly
+
+#### Scenario: the job sub-sitemap lists open tech jobs
+
+- **WHEN** a job sub-sitemap URL from the index is requested
+- **THEN** the response is a valid `<urlset>` of at most 50,000 open-job
+  (`/jobs/:slug`) URLs, each with a `<lastmod>`, and no closed job
+
+#### Scenario: a non-tech posting is not named in the sitemap
+
+- **WHEN** an open, findable posting is classified `is_tech = non_tech`
+- **THEN** no job sub-sitemap lists its `/jobs/:slug` URL, and the page itself is
+  still served, still canonical and still returned by `/jobs`
+
+#### Scenario: an unclassified posting is not named in the sitemap
+
+- **WHEN** an open, findable posting has no resolved `is_tech` value
+- **THEN** no job sub-sitemap lists its `/jobs/:slug` URL
+
+#### Scenario: a posting the site calls a perpetual listing is not named
+
+- **WHEN** an open tech posting's reality class is `likely-evergreen`
+- **THEN** no job sub-sitemap lists its `/jobs/:slug` URL
+
+#### Scenario: the index and its chunks count the same population
+
+- **WHEN** `/sitemap.xml` names N job sub-sitemaps of chunk size C
+- **THEN** the number of tech postings the job reader would serve is greater than
+  `C * (N - 1)` and at most `C * N`, so no named chunk is empty
+
+#### Scenario: a retired chunk offset is empty, not an error
+
+- **WHEN** a crawler holding an older sitemap index requests a job sub-sitemap at
+  an offset past the end of the filtered population
+- **THEN** the response is a valid, empty `<urlset>` — never a 404 and never an
+  error
+
+#### Scenario: company sub-sitemaps cover every company worth crawling
+
+- **WHEN** the index's company sub-sitemaps are followed in sequence by their
+  slug cursors
+- **THEN** every company holding at least one findable role appears in exactly one
+  sub-sitemap, with no artificial cap
+
+#### Scenario: a company with nothing findable is not in the sitemap
+
+- **WHEN** a company's only open postings are private, body-less, or of a category
+  no dictionary resolved — so its page's job list renders empty
+- **THEN** no company sub-sitemap lists its `/companies/:slug` URL

--- a/openspec/changes/scope-job-sitemap-to-tech/tasks.md
+++ b/openspec/changes/scope-job-sitemap-to-tech/tasks.md
@@ -1,19 +1,19 @@
 ## 1. The filter
 
-- [ ] 1.1 Give `sitemapPage` (`internal/search/search/sitemap.go`) a `filter string` parameter, and
+- [x] 1.1 Give `sitemapPage` (`internal/search/search/sitemap.go`) a `filter string` parameter, and
       assign `meilisearch.DocumentsQuery.Filter` only when it is non-empty. The guard is
       load-bearing, not tidiness: `Filter` is an `interface{}` with `json:"filter,omitempty"`, and
       `omitempty` drops an interface only when it is NIL — an interface holding `""` serializes as
       `"filter":""`. Assigning unconditionally would therefore send an empty filter expression on
       the company path, which issues a different request than the one it issues today.
-- [ ] 1.2 Add the predicate as a named constant beside the two readers, with the reasoning from
+- [x] 1.2 Add the predicate as a named constant beside the two readers, with the reasoning from
       design.md in its comment (why `is_tech`, why `likely-evergreen` and not `stale`, why the
       unknown bucket is excluded):
       `is_tech = "tech" AND reality.class != "likely-evergreen"`.
-- [ ] 1.3 Pass it from `ListSitemapPage`; pass `""` from `ListCompanySitemapPage`. Leave
+- [x] 1.3 Pass it from `ListSitemapPage`; pass `""` from `ListCompanySitemapPage`. Leave
       `CountSitemapDocuments` and `CountCompanySitemapDocuments` alone — they delegate, and that
       is what keeps the count and the pages from disagreeing.
-- [ ] 1.4 Replace the stale performance note in `sitemapPage`'s doc comment with the 2026-09-08
+- [x] 1.4 Replace the stale performance note in `sitemapPage`'s doc comment with the 2026-09-08
       measurement (2.01M documents: deepest unfiltered page 4.43s, deepest filtered 4.07s,
       count 0.035s, against the route's 10s fetch timeout). Keep the paragraph's point — the
       engine addresses an offset directly instead of walking to it — and correct only the
@@ -21,32 +21,37 @@
 
 ## 2. Tests
 
-- [ ] 2.1 Integration test in `internal/search/search` (build tag `integration`), in the shape of
-      `TestIntegration_IsTechFilter`: `startMeili(t)`, `EnsureIndex`, then four fixtures through
-      `FromJob` — a tech job, a `non_tech` job, one with `is_tech` NULL, and a tech job whose
-      `doc.Reality` is set to `likely-evergreen` (the caller attaches reality, so the fixture
-      sets it directly rather than driving `jobreality`).
-- [ ] 2.2 Assert `ListSitemapPage(ctx, 0, 10)` returns exactly the plain tech job's
-      `public_slug`, and that the `total` it returns is 1 — the same value
-      `CountSitemapDocuments` reports, which is the property the tiling depends on.
-- [ ] 2.3 Assert `ListCompanySitemapPage` over the companies index is untouched by the change:
+- [x] 2.1 Integration test in `internal/search/search` (build tag `integration`), in the shape of
+      `TestIntegration_IsTechFilter`: `startMeili(t)`, `EnsureIndex`, then FIVE fixtures through
+      `FromJob` — a `fresh` tech job, a `stale` tech job, a `non_tech` job, one with `is_tech`
+      NULL, and a tech job whose `doc.Reality` is `likely-evergreen` (the caller attaches
+      reality, so the fixture sets it directly rather than driving `jobreality`).
+      The `stale` tech fixture is the one this change most needs pinned: the design turns on
+      `stale` being an age bucket rather than a liveness verdict, so a future filter that
+      excluded it would be caught here rather than by a two-thirds drop in prod coverage.
+- [x] 2.2 Assert `ListSitemapPage` names both tech postings and none of the other three, that
+      its `total` is 2, and that `CountSitemapDocuments` reports the same 2 — the agreement
+      between the count and the pages is the property the tiling depends on. Cover the
+      past-the-end offset too, since that is what a crawler holding the old, wider index asks
+      for once the chunk count drops.
+- [x] 2.3 Assert `ListCompanySitemapPage` over the companies index is untouched by the change:
       every indexed company still comes back.
 
 ## 3. Spec and docs
 
-- [ ] 3.1 Land the `web-ssr-seo` delta: the job sub-sitemap's scope is the tech slice, and the
+- [x] 3.1 Land the `web-ssr-seo` delta: the job sub-sitemap's scope is the tech slice, and the
       requirement's superseded sentence about listing "the freshest open jobs up to the per-file
       limit, rather than the full catalogue" goes with it — that follow-up shipped when the
       sitemap moved onto the search index.
-- [ ] 3.2 Check whether `web/src/lib/sitemap.ts`'s comment ("the index already holds exactly the
+- [x] 3.2 Check whether `web/src/lib/sitemap.ts`'s comment ("the index already holds exactly the
       postings worth crawling") still reads correctly. It becomes true rather than aspirational;
       adjust only if the wording now misleads.
 
 ## 4. Verification
 
-- [ ] 4.1 `gofmt -l .` prints nothing; `go vet ./...`; `go test ./...`;
+- [x] 4.1 `gofmt -l .` prints nothing; `go vet ./...`; `go test ./...`;
       `go vet -tags=integration ./...`.
-- [ ] 4.2 `go test -tags=integration ./internal/search/search/` (needs Docker; testcontainers).
+- [x] 4.2 `go test -tags=integration ./internal/search/search/` (needs Docker; testcontainers).
 - [ ] 4.3 After deploy, confirm on prod that `/sitemap.xml` lists 68 job sub-sitemaps, that the
       first and last both return a non-empty `<urlset>`, and that a retired offset
       (e.g. `?offset=1000000`) returns an empty `<urlset>` rather than an error.

--- a/openspec/changes/scope-job-sitemap-to-tech/tasks.md
+++ b/openspec/changes/scope-job-sitemap-to-tech/tasks.md
@@ -1,0 +1,52 @@
+## 1. The filter
+
+- [ ] 1.1 Give `sitemapPage` (`internal/search/search/sitemap.go`) a `filter string` parameter, and
+      assign `meilisearch.DocumentsQuery.Filter` only when it is non-empty. The guard is
+      load-bearing, not tidiness: `Filter` is an `interface{}` with `json:"filter,omitempty"`, and
+      `omitempty` drops an interface only when it is NIL — an interface holding `""` serializes as
+      `"filter":""`. Assigning unconditionally would therefore send an empty filter expression on
+      the company path, which issues a different request than the one it issues today.
+- [ ] 1.2 Add the predicate as a named constant beside the two readers, with the reasoning from
+      design.md in its comment (why `is_tech`, why `likely-evergreen` and not `stale`, why the
+      unknown bucket is excluded):
+      `is_tech = "tech" AND reality.class != "likely-evergreen"`.
+- [ ] 1.3 Pass it from `ListSitemapPage`; pass `""` from `ListCompanySitemapPage`. Leave
+      `CountSitemapDocuments` and `CountCompanySitemapDocuments` alone — they delegate, and that
+      is what keeps the count and the pages from disagreeing.
+- [ ] 1.4 Replace the stale performance note in `sitemapPage`'s doc comment with the 2026-09-08
+      measurement (2.01M documents: deepest unfiltered page 4.43s, deepest filtered 4.07s,
+      count 0.035s, against the route's 10s fetch timeout). Keep the paragraph's point — the
+      engine addresses an offset directly instead of walking to it — and correct only the
+      figures and the margin they imply.
+
+## 2. Tests
+
+- [ ] 2.1 Integration test in `internal/search/search` (build tag `integration`), in the shape of
+      `TestIntegration_IsTechFilter`: `startMeili(t)`, `EnsureIndex`, then four fixtures through
+      `FromJob` — a tech job, a `non_tech` job, one with `is_tech` NULL, and a tech job whose
+      `doc.Reality` is set to `likely-evergreen` (the caller attaches reality, so the fixture
+      sets it directly rather than driving `jobreality`).
+- [ ] 2.2 Assert `ListSitemapPage(ctx, 0, 10)` returns exactly the plain tech job's
+      `public_slug`, and that the `total` it returns is 1 — the same value
+      `CountSitemapDocuments` reports, which is the property the tiling depends on.
+- [ ] 2.3 Assert `ListCompanySitemapPage` over the companies index is untouched by the change:
+      every indexed company still comes back.
+
+## 3. Spec and docs
+
+- [ ] 3.1 Land the `web-ssr-seo` delta: the job sub-sitemap's scope is the tech slice, and the
+      requirement's superseded sentence about listing "the freshest open jobs up to the per-file
+      limit, rather than the full catalogue" goes with it — that follow-up shipped when the
+      sitemap moved onto the search index.
+- [ ] 3.2 Check whether `web/src/lib/sitemap.ts`'s comment ("the index already holds exactly the
+      postings worth crawling") still reads correctly. It becomes true rather than aspirational;
+      adjust only if the wording now misleads.
+
+## 4. Verification
+
+- [ ] 4.1 `gofmt -l .` prints nothing; `go vet ./...`; `go test ./...`;
+      `go vet -tags=integration ./...`.
+- [ ] 4.2 `go test -tags=integration ./internal/search/search/` (needs Docker; testcontainers).
+- [ ] 4.3 After deploy, confirm on prod that `/sitemap.xml` lists 68 job sub-sitemaps, that the
+      first and last both return a non-empty `<urlset>`, and that a retired offset
+      (e.g. `?offset=1000000`) returns an empty `<urlset>` rather than an error.

--- a/web/src/lib/sitemap.ts
+++ b/web/src/lib/sitemap.ts
@@ -15,9 +15,16 @@ import contributorsSnapshot from './data/contributors.json';
 export const SITEMAP_CHUNK = 10000;
 
 // Must equal the backend's jobSitemapChunk. Job chunks are pages of the search
-// index, not of the jobs table: the index already holds exactly the postings worth
-// crawling, and it can address any offset in it directly — which is what let the
+// index, not of the jobs table: the index holds every posting the site's own search
+// can find, and it can address any offset in it directly — which is what let the
 // sitemap stop asking Postgres to number 3.4M rows on every render.
+//
+// Note the chunks page a NARROWED view of that index, not all of it: the backend's
+// jobSitemapFilter admits only tech postings that are not flagged as perpetual
+// listings, and the count these offsets are computed from is filtered the same way.
+// So the number of job chunks tracks the tech slice (~669k, 68 chunks) rather than
+// the whole index (~2.0M) — a sub-sitemap URL for a retired offset answers with an
+// empty urlset, which is what the route already promises for any offset past the end.
 //
 // 10k rather than 25k because the deepest 25k page measured 8s against this route's
 // 10s fetch timeout under load — see the backend constant for the trade.


### PR DESCRIPTION
## Why

The job sitemap offers a crawler the whole live search index. Measured on prod 2026-09-08:

| Slice | Documents | Share |
|---|---:|---:|
| Everything the sitemap names today | 2,014,462 | 100% |
| `is_tech = non_tech` | 1,295,388 | **64.3%** |
| `is_tech` resolved by nothing | 47,906 | 2.4% |
| `is_tech = tech`, minus `likely-evergreen` | **669,352** | 33.2% |

`software_engineering` is 97,222 of what we ask Google to crawl — 4.8%. The rest is management
(301,387), sales (191,969), healthcare (181,760), support (143,699).

## What

`sitemapPage` takes a filter expression. `ListSitemapPage` passes
`is_tech = "tech" AND reality.class != "likely-evergreen"`; `ListCompanySitemapPage` passes none.
`CountSitemapDocuments` already delegates to `ListSitemapPage`, so the count the sitemap index
tiles by and the pages its chunks serve go through one expression in one place and cannot
disagree.

203 job sub-sitemaps become 68. **Sitemap scope only** — every excluded posting keeps its page,
its canonical and its place in `/jobs`.

## `stale` is deliberately not excluded

This was the first design and the measurement killed it. The reality classes are not a liveness
verdict (`internal/job/jobreality`): `fresh` is "at most 14 days old", `likely-evergreen` needs
two converging ghost signals, and `stale` is the classifier's own "everything else".

| Slice | Documents |
|---|---:|
| `tech AND reality.class = stale` | 461,069 |
| `tech AND reality.class = likely-evergreen` | 1,542 |
| `tech AND created_ts < now-90d` | **0** |
| `non_tech AND created_ts < now-90d` | **0** |

No document in the index is more than 90 days old by first-seen — the catalogue retires its own
tail. So excluding `stale` would have dropped 461,069 live tech postings for being more than a
fortnight old, and churned the whole sitemap every two weeks. `likely-evergreen` is the one class
that accuses, and `/features/ghost-jobs` publishes that accusation on those same pages.

The integration test pins a `stale` tech fixture as *included*, so a future filter that quietly
excluded it fails here rather than in prod coverage.

## Cost

No settings patch, no reindex — `is_tech` and `reality.class` are already declared filterable.

| Query (10k-document pages) | Time |
|---|---:|
| unfiltered, `offset=1,900,000` (today's deepest) | 4.43s |
| filtered, `offset=660,000` (new deepest) | **4.07s** |
| filtered, `limit=1` (what the count issues) | 0.035s |

The deepest page gets marginally cheaper. This also retires the doc comment claiming 0.25s at
offset 1.2M, measured at 1.26M documents — the margin against the route's 10s fetch timeout has
narrowed from ~40x to ~2.5x as the catalogue grew.

## Expected

Search Console will report a large drop in discovered URLs. That is the intent. A crawler holding
a stale sitemap index and requesting a retired offset gets an empty `<urlset>`, already this
route's documented behaviour — nothing 404s.

## Not in this PR

The company sitemap (its scope is `companies.job_count`, a different predicate) and the chunk size
(10k was sized by the fetch timeout and the margin has eroded; it deserves its own measurement).

## Verification

`gofmt`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./...`, the layering guard,
and `go test -tags=integration ./internal/search/search/` all pass. The new integration tests were
confirmed to fail with the filter emptied before being confirmed to pass with it.

Spec: `openspec/changes/scope-job-sitemap-to-tech/`.