### PR TITLE
Give the board harvest the proxy policy the crawl already has

### DIFF
--- a/cmd/harvest-boards/main.go
+++ b/cmd/harvest-boards/main.go
@@ -94,7 +94,15 @@ func run() int {
 	defer cleanup()
 	repo := boardcatalog.NewQueriesRepository(db.New(pool))
 
-	client := newCountingClient(paced(sources.NewClient(), *pace))
+	// The probe talks to the platform's API directly rather than through the provider's
+	// adapter, so it needs the same proxy policy cmd/ingest gets from ApplyProxyEgress —
+	// see sources.ClientFor for what a bare direct client cost workable here.
+	egress, err := sources.ClientFor(provider)
+	if err != nil {
+		log.Printf("harvest-boards: %v", err)
+		return 1
+	}
+	client := newCountingClient(paced(egress, *pace))
 	if *pace > 0 {
 		log.Printf("harvest-boards: pacing probes at %.2f req/s with %d workers", *pace, *workers)
 	}

--- a/internal/ingest/sources/clientfor_test.go
+++ b/internal/ingest/sources/clientfor_test.go
@@ -1,0 +1,74 @@
+package sources
+
+import (
+	"testing"
+)
+
+// A caller that builds its own client (cmd/harvest-boards probes a candidate board without
+// going through the provider's adapter) must get the same egress policy ApplyProxyEgress
+// gives the crawl. Without this the harvest talks to workable on exactly the direct IP the
+// workable entry in refusalRetryProviders exists to keep it off.
+func TestClientForGivesRefusalRetryProvidersTheProxyFallback(t *testing.T) {
+	t.Setenv("SOURCES_PROXY_URL", "http://user:pass@proxy.example:8080")
+
+	c, err := ClientFor("workable")
+	if err != nil {
+		t.Fatalf("ClientFor: %v", err)
+	}
+	if c.refusalClient == nil {
+		t.Error("workable got a client with no refusal fallback; a 429 from the direct IP stays final")
+	}
+}
+
+// A wholly-proxied provider's direct path never works, so its client must egress through the
+// proxy outright rather than only after a refusal.
+func TestClientForGivesProxiedProvidersTheProxiedClient(t *testing.T) {
+	t.Setenv("SOURCES_PROXY_URL", "http://user:pass@proxy.example:8080")
+
+	c, err := ClientFor("djinni")
+	if err != nil {
+		t.Fatalf("ClientFor: %v", err)
+	}
+	if c.refusalClient != nil {
+		t.Error("djinni got a refusal-retry client; its direct IP is blocked, so there is nothing to retry from")
+	}
+}
+
+// Everything else keeps the direct client: the proxy is a single shared address, and a
+// provider with no measured problem must not be moved onto it.
+func TestClientForLeavesUnlistedProvidersDirect(t *testing.T) {
+	t.Setenv("SOURCES_PROXY_URL", "http://user:pass@proxy.example:8080")
+
+	c, err := ClientFor("greenhouse")
+	if err != nil {
+		t.Fatalf("ClientFor: %v", err)
+	}
+	if c.refusalClient != nil {
+		t.Error("greenhouse got a refusal-retry client without being listed for one")
+	}
+}
+
+// With no proxy configured every provider stays direct, so a local or dev run behaves exactly
+// as it did.
+func TestClientForWithoutProxyIsDirect(t *testing.T) {
+	t.Setenv("SOURCES_PROXY_URL", "")
+
+	c, err := ClientFor("workable")
+	if err != nil {
+		t.Fatalf("ClientFor: %v", err)
+	}
+	if c.refusalClient != nil {
+		t.Error("workable got a proxy fallback with no proxy configured")
+	}
+}
+
+// A set-but-unparseable value must fail the caller rather than hand back the direct client:
+// silently crawling the blocked path is the one outcome an operator who configured a proxy
+// would never notice.
+func TestClientForFailsOnUnparseableProxy(t *testing.T) {
+	t.Setenv("SOURCES_PROXY_URL", "://not a url")
+
+	if _, err := ClientFor("workable"); err == nil {
+		t.Error("ClientFor accepted an unparseable SOURCES_PROXY_URL and fell back to the direct client")
+	}
+}

--- a/internal/ingest/sources/proxy.go
+++ b/internal/ingest/sources/proxy.go
@@ -156,6 +156,40 @@ func ApplyProxyEgress(registry map[string]Source) error {
 	return nil
 }
 
+// ClientFor returns the client the named provider's crawl would use under the configured
+// proxy policy: wholly proxied where the platform blocks the direct datacenter IP,
+// refusal-retried where it merely rate-limits it, and direct otherwise. It reads the same
+// two allowlists ApplyProxyEgress does, so a provider's policy is stated once.
+//
+// It exists because ApplyProxyEgress can only rewire a provider's ADAPTER, and not every
+// caller reaches a platform through one. cmd/harvest-boards probes a candidate board with
+// a client it builds itself, so it was crawling workable on exactly the direct IP the
+// workable entry in refusalRetryProviders exists to keep it off — measured on prod
+// 2026-09-08, where every board probed from the prod IP returned 429 while the same boards
+// through the proxy returned 200.
+//
+// Like ApplyProxyEgress it is a no-op with SOURCES_PROXY_URL unset, and fails rather than
+// quietly falling back when the variable is set but unparseable — a caller that asked for
+// the proxied policy must not be handed the blocked path instead.
+func ClientFor(provider string) (*Client, error) {
+	raw := strings.TrimSpace(os.Getenv("SOURCES_PROXY_URL"))
+	if raw == "" {
+		return NewClient(), nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return nil, fmt.Errorf("sources: invalid SOURCES_PROXY_URL %q", redactProxy(raw))
+	}
+	switch {
+	case proxiedProviders[provider] != nil:
+		return NewProxyClient(u), nil
+	case refusalRetryProviders[provider] != nil:
+		return NewRefusalRetryClient(u), nil
+	default:
+		return NewClient(), nil
+	}
+}
+
 // proxiedFingerprintProviders are the fingerprint-client providers whose edge blocks the
 // direct datacenter IP even with a correct Chrome TLS fingerprint, but serves that same
 // fingerprint through the residential proxy — so they need both, unlike proxiedProviders


### PR DESCRIPTION
## What

`cmd/harvest-boards` probed candidate boards on the bare direct IP, even for a provider `sources/proxy.go` already lists as needing the proxy.

## Why it was invisible

`sources/proxy.go` has carried `workable` in `refusalRetryProviders` since 2026-08-16 — crawl direct, fall back to the proxy only for a request the platform refused. `ApplyProxyEgress` applies that by rewiring the provider's **adapter**, so it reaches `cmd/ingest` and nothing else. `harvest-boards` never touches the adapter: its prober calls the platform's API with a client it builds itself, and that client was `sources.NewClient()`.

## The measurement

Prod, 2026-09-08, four workable boards:

| board | direct | via proxy |
|---|---|---|
| `100x` | 429 (17 B, 37 ms) | 200 (612 B) |
| `1spatial` | 429 | 200 |
| `28stone` | 429 | 200 |
| `kreyco` | 429 | 200 (13.7 MB) |

A harvest of 2 077 candidates on the direct client spent 30 minutes retrying its way through 134 MB without finishing. The same harvest on this change read **1 GB in 15 minutes** and completed: `live boards found=873 probe-failures=0 mismatches=0`.

## The change

`sources.ClientFor(provider)` — the client-level counterpart of `ApplyProxyEgress`, reading the same two allowlists so a provider's egress policy is stated once:

- `proxiedProviders` → the wholly proxied client (the direct IP is blocked, there is nothing to retry from)
- `refusalRetryProviders` → the refusal-retry client (the direct IP works until our own burst poisons it)
- anything else → direct, because the proxy is a single shared address and a provider with no measured problem must not be moved onto it

It keeps `ApplyProxyEgress`'s contract at both ends: a no-op with `SOURCES_PROXY_URL` unset, and an **error** rather than a silent fallback when the variable is set but unparseable — handing back the blocked path is the one outcome an operator who configured a proxy would never notice.

## Tests

Five, in `internal/ingest/sources/clientfor_test.go`: the refusal-retry provider gets the fallback, the wholly-proxied one does not get a refusal-retry client, an unlisted provider stays direct, an unset proxy leaves everything direct, and an unparseable value errors.

## Scope

No behaviour changes without `SOURCES_PROXY_URL`. `cmd/ingest` is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Board harvesting now follows the configured proxy policy consistently, including provider-specific proxy routing and refusal-retry behavior.
  - Providers without proxy requirements continue using direct connections.
  - Invalid proxy configuration is reported clearly, and the affected harvesting run exits instead of silently bypassing the configuration.

- **Reliability**
  - Added coverage for proxy configuration scenarios to help ensure consistent connection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->