### PR TITLE
Stop auto-apply tailoring runs from wedging their own session

### DIFF
--- a/internal/api/handler/assistant_turns.go
+++ b/internal/api/handler/assistant_turns.go
@@ -88,6 +88,28 @@ func (r *turnRegistry) claim(session uuid.UUID, cancel context.CancelFunc) (*tur
 	return nil, &turnWaiter{registry: r, session: session}, nil
 }
 
+// tryClaim asks for the session's slot on behalf of a turn that will NOT wait for it: it
+// hands back the slot of an idle session, and simply reports a busy one as busy.
+//
+// It exists because claim's waiter is a RESERVATION — a place in line the caller is then
+// obliged to give back, by entering it or by leaving it. A caller that refuses instead of
+// waiting has no natural place to do either, and PostAutoApplyTailor duly did neither: in
+// production it took a place in line on every refusal and never released one, so the
+// session answered errTurnQueueFull to every later call for the life of the process, with
+// nobody waiting. Three auto-apply entries sat unprocessed behind that.
+//
+// So this is not claim-with-a-flag: the point is that a synchronous caller cannot reserve
+// anything, and therefore cannot forget to release it.
+func (r *turnRegistry) tryClaim(session uuid.UUID, cancel context.CancelFunc) (*turnSlot, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, running := r.turns[session]; running {
+		return nil, false
+	}
+	return r.take(session, cancel), true
+}
+
 // take records a turn as running. The caller holds the lock.
 func (r *turnRegistry) take(session uuid.UUID, cancel context.CancelFunc) *turnSlot {
 	if r.turns == nil {

--- a/internal/api/handler/assistant_turns_test.go
+++ b/internal/api/handler/assistant_turns_test.go
@@ -220,3 +220,56 @@ func TestTurnRegistryCancelReachesAQueuedTurn(t *testing.T) {
 		t.Fatalf("registry holds %d entries, want 0", n)
 	}
 }
+
+// A synchronous caller — one that refuses rather than waits, as PostAutoApplyTailor does —
+// must not leave a place in line behind it.
+//
+// This is not hypothetical. In production the auto-apply orchestrator's own tailor call
+// took a place in line every time it was refused and never gave it back, so the session
+// answered errTurnQueueFull ("this session already has a message waiting") to every later
+// call for the life of the process — with nobody actually waiting. Three queue entries sat
+// unprocessed behind it, and the log recorded the refusal for one of them verbatim.
+func TestTurnRegistryLeavesNoPlaceInLineForACallerThatWillNotWait(t *testing.T) {
+	var reg turnRegistry
+	session := uuid.New()
+
+	running, _, err := reg.claim(session, func() {})
+	if err != nil || running == nil {
+		t.Fatalf("the first turn did not get the slot: %v, %v", running, err)
+	}
+
+	// Two callers in a row that decline to wait. The SECOND is the whole point: if the
+	// first quietly held a place, this one is refused for the wrong reason — "somebody is
+	// already waiting" rather than "the session is busy" — and every later one with it.
+	for i := 1; i <= 2; i++ {
+		slot, ok := reg.tryClaim(session, func() {})
+		if ok || slot != nil {
+			t.Fatalf("attempt %d took the slot of a busy session: %v", i, slot)
+		}
+	}
+
+	// A caller that WILL wait must still be able to queue: the line was never occupied.
+	_, waiter, err := reg.claim(session, func() {})
+	if err != nil {
+		t.Fatalf("claim after two refused non-waiting callers: %v — a place in line was left behind", err)
+	}
+	if waiter == nil {
+		t.Fatal("no waiter for a busy session, want a place in line")
+	}
+}
+
+// The other half: tryClaim on an idle session behaves exactly like claim's own happy path,
+// so a caller that uses it is not quietly refused work it could have done.
+func TestTurnRegistryTryClaimTakesTheSlotOfAnIdleSession(t *testing.T) {
+	var reg turnRegistry
+	session := uuid.New()
+
+	slot, ok := reg.tryClaim(session, func() {})
+	if !ok || slot == nil {
+		t.Fatalf("tryClaim on an idle session = %v, %v; want the slot", slot, ok)
+	}
+	reg.release(session, slot)
+	if n := reg.len(); n != 0 {
+		t.Fatalf("registry holds %d entries after the turn ended, want 0", n)
+	}
+}

--- a/internal/api/handler/auto_apply_tailor.go
+++ b/internal/api/handler/auto_apply_tailor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
@@ -72,6 +73,26 @@ func (h *assistantHandlers) resolveAutoApplyEntry(c *fiber.Ctx, queueID int64) (
 	})
 	return autoApplyEntry(row), err
 }
+
+// autoApplyTailorBudget bounds ONE unattended tailoring run, end to end.
+//
+// Nothing bounded it before, and the ceiling that appeared to — autopilotMaxSteps (30) at
+// assistantLLMTimeout (180s) a call — allows an hour and a half. What actually ended these
+// runs was the orchestrator hanging up at five minutes, which is the worst way for one to
+// end: the run kept going, the CV edits it had already made were kept, and the queue entry
+// was never told, so it sat unclaimable and read as "tailoring" indefinitely. Three
+// production entries did exactly that (freehire, 2026-09-08).
+//
+// Ten minutes is deliberately shorter than the caller's own patience
+// (autoapplyorchestrate.hireRequestTimeout, 12 minutes), so a run that overruns is ended
+// HERE, where the tailored CV can still be recorded and the entry can move on to review.
+// The runner already treats an ended context as a cancellation rather than a failure
+// (assistant.Runner.Run's StopCancelled), so the pass stops between rounds with its work
+// committed rather than unwinding it.
+//
+// A var so a test can shorten it — the path it guards is a run that spends the whole
+// budget, which a test cannot otherwise reach without spending it too.
+var autoApplyTailorBudget = 10 * time.Minute
 
 // autoApplyTailorResponse is what starting a tailoring run reports: the tailored CV id and
 // its per-requirement account of itself, the same report shape the interactive workspace
@@ -162,17 +183,16 @@ func (h *assistantHandlers) PostAutoApplyTailor(c *fiber.Ctx) error {
 		return mapAssistantError(err)
 	}
 
-	ctx, cancel := context.WithCancel(c.Context())
+	ctx, cancel := context.WithTimeout(c.Context(), autoApplyTailorBudget)
 	defer cancel()
-	slot, waiter, err := h.turns.claim(sess.ID, cancel)
-	if err != nil {
-		return fiber.NewError(fiber.StatusConflict, err.Error())
-	}
-	if waiter != nil {
-		// Unlike streamSSE (a human watching a live stream, worth a queued wait), this is
-		// a synchronous API-key call: refusing immediately lets the caller retry later
-		// rather than holding the connection open for up to a minute against a run it
-		// cannot observe anyway.
+	// tryClaim, not claim: unlike streamSSE (a human watching a live stream, worth a queued
+	// wait), this is a synchronous API-key call — refusing immediately lets the caller retry
+	// later rather than holding the connection open for up to a minute against a run it
+	// cannot observe anyway. claim would hand back a place in LINE for that wait, which this
+	// handler has no way to give back; doing exactly that is what wedged the session in
+	// production (see tryClaim's own doc comment).
+	slot, ok := h.turns.tryClaim(sess.ID, cancel)
+	if !ok {
 		return fiber.NewError(fiber.StatusConflict, "this tailoring session is busy with another run")
 	}
 	defer h.turns.release(sess.ID, slot)

--- a/internal/api/handler/auto_apply_tailor_integration_test.go
+++ b/internal/api/handler/auto_apply_tailor_integration_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/strelov1/freehire/internal/candidate/matchanalysis"
 	"github.com/strelov1/freehire/internal/identity/auth"
 	"github.com/strelov1/freehire/internal/platform/db"
+	"github.com/strelov1/freehire/internal/platform/llm"
 )
 
 // newAutoApplyTailorApp wires the assistant routes (which carry PostAutoApplyTailor/
@@ -484,5 +485,60 @@ func TestPostAutoApplyReview_DecisionCannotBeRecordedTwice(t *testing.T) {
 	}
 	if decision != "approved" {
 		t.Errorf("review_decision = %q, want the first decision to stand unchanged", decision)
+	}
+}
+
+// slowTurnModel blocks each model call until its context ends, which is how a test reaches
+// the one outcome that matters here without spending the real budget: an unattended run
+// that is still working when its time runs out.
+type slowTurnModel struct{}
+
+func (m *slowTurnModel) Chat(ctx context.Context, _ []llms.MessageContent, _ []llms.Tool, _ llm.ChatStream) (*llms.ContentChoice, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// A tailoring run that spends its whole budget still records what it produced.
+//
+// This is the second half of what left three production entries stuck with no tailored CV
+// and a status that read "tailoring" forever. autopilotMaxSteps allows thirty model calls
+// of up to assistantLLMTimeout each; the orchestrator waited five minutes for all of them
+// and hung up, and because the handler treated a cut-short run as a plain failure, the CV
+// the run had ALREADY edited was never attached to the entry. The work was done and thrown
+// away, three times over, and the queue entry looked untouched every time.
+//
+// The run's own budget is what ends it now, before any caller gives up on it, and the
+// entry moves on with the CV the run got to.
+func TestPostAutoApplyTailor_ASpentBudgetStillRecordsTheTailoredCV(t *testing.T) {
+	pool := startPostgres(t)
+	truncateAutoApplyTailorTables(t, pool)
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	app, _ := newAutoApplyTailorApp(pool, iss, &slowTurnModel{})
+
+	// Shortened so the test observes the budget elapsing rather than waiting out the real
+	// one — the same reason turnQueueWait is a var (see assistant_turns.go).
+	restore := autoApplyTailorBudget
+	autoApplyTailorBudget = 300 * time.Millisecond
+	t.Cleanup(func() { autoApplyTailorBudget = restore })
+
+	userID, cookie := autoApplyTailorUser(t, pool, iss, "budget@example.test")
+	insertBaseCV(t, pool, userID)
+	job := insertAutoApplyJob(t, pool, "tailor-budget")
+	queueID := insertAutoApplyQueueRow(t, pool, userID, job)
+
+	resp := autoApplyRequest(t, app, fiber.MethodPost,
+		"/api/v1/me/auto-apply/"+strconv.FormatInt(queueID, 10)+"/tailor", cookie, nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200 — a run that spent its budget produced a CV, not a failure", resp.StatusCode)
+	}
+
+	var stored *uuid.UUID
+	if err := pool.QueryRow(context.Background(),
+		"SELECT tailored_cv_id FROM auto_apply_queue WHERE id = $1", queueID).Scan(&stored); err != nil {
+		t.Fatalf("read stored tailored_cv_id: %v", err)
+	}
+	if stored == nil {
+		t.Fatal("tailored_cv_id is still NULL — the entry cannot move on, and reads as 'tailoring' forever")
 	}
 }

--- a/internal/application/autoapplyorchestrate/orchestrate.go
+++ b/internal/application/autoapplyorchestrate/orchestrate.go
@@ -48,11 +48,21 @@ const FunctionID = "auto-apply-tailor-and-review"
 // decide.
 const ReviewWaitTimeout = 7 * 24 * time.Hour
 
-// hireRequestTimeout bounds ONE call into hire's own API. Tailoring is a real,
-// potentially slow LLM-backed run — internal/api/handler's own assistantLLMTimeout bounds
-// a single model call at 180s, and a tailoring pass can make several; this is generous
-// past the whole run.
-const hireRequestTimeout = 5 * time.Minute
+// hireRequestTimeout bounds ONE call into hire's own API. It must sit ABOVE the tailoring
+// endpoint's own run budget (internal/api/handler's autoApplyTailorBudget, 10 minutes), so
+// that a run always ends on ITS terms rather than being cut off by the caller.
+//
+// "Generous past the whole run" was the previous reading of five minutes, and it was
+// wrong. A tailoring pass makes up to autopilotMaxSteps (30) model calls of up to
+// assistantLLMTimeout (180s) each, so five minutes was not past the run, it was inside it.
+// In production this hung up mid-pass every time: the run kept working, its CV edits were
+// already written, and the entry was never told — three queue entries sat with no tailored
+// CV, reading as "tailoring" indefinitely, while the retry this failure triggered arrived
+// to find the session still busy with the very run it had abandoned (freehire, 2026-09-08).
+//
+// The layering guard forbids importing the handler package here to state the relationship
+// in code, so it is stated here: raise the budget and this must follow.
+const hireRequestTimeout = 12 * time.Minute
 
 // SubmitEvent is EventSubmit's own data: which queue entry to run.
 //


### PR DESCRIPTION
Three auto-apply entries have sat with no tailored CV since 2026-09-07 — one for over a day — reading as **"tailoring"** in the tracker the whole time. Nothing was working on them.

Two faults put them there, and each makes the other worse.

## 1. The orchestrator hung up at five minutes

`hireRequestTimeout` called itself "generous past the whole run". But a tailoring pass makes up to `autopilotMaxSteps` (**30**) model calls of up to `assistantLLMTimeout` (**180s**) each. Five minutes is not past that run — it is *inside* it.

Production shows three consecutive passes cut at exactly that mark, each still working:

```
22:53:50 POST /me/auto-apply/13/tailor
22:57:15 llm: stream dur=24.494s  err=<nil>
22:58:24 llm: stream dur=1m9.364s err=<nil>
23:00:27 llm: stream dur=2m2.233s err=<nil>
23:00:27 500 6m36s  llm: chat: context deadline exceeded
```

The run kept going, its CV edits were **already committed**, and the queue entry was never told — `SetAutoApplyTailoredCV` is reached only on a clean return. The work was done and thrown away. Three times.

## 2. The retry then wedged the session

The retry that failure triggers arrived to find the session busy with the very run it had abandoned — and took a place in line it could never give back.

`claim`'s waiter is a *reservation* the caller must release, by entering it or leaving it. `PostAutoApplyTailor` refuses instead of waiting, so it did neither. From then on the session answered `errTurnQueueFull` to everything, with nobody waiting:

```
22:51:24 409 this session already has a message waiting
```

## The fix

**A budget of the run's own** (10 min), shorter than the caller's patience (now 12), so it ends on *its* terms with the tailored CV recorded and the entry free to move on to review. The runner already treats an ended context as `StopCancelled` rather than a failure, so a pass stops between rounds with its work committed.

**`tryClaim`** for a caller that will not wait: takes an idle session's slot, reports a busy one as busy. Not `claim`-with-a-flag — the point is that a synchronous caller has no place in line it *can* forget to release.

## Verification

Both are covered by tests that fail without them:

- the registry test reproduces the wedge in three calls and reports the production error string verbatim;
- the integration test hangs the model past the budget and asserts the entry ends up with a tailored CV rather than a 500 (confirmed failing with the budget removed, passing with it).

`go test ./...`, `go test -tags=integration ./internal/api/handler/`, `go vet -tags=integration ./...`, `gofmt`, `golangci-lint` — all clean.

## Not fixed here

A tailoring run that fails for a *real* reason still records nothing, so `DeriveStatus` falls through to `tailoring` and the candidate is told work is under way that nobody is doing. That needs its own column and its own change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Auto-tailoring now immediately reports when a session is already busy instead of waiting in line.
  - Tailoring results are preserved even when the run reaches its time limit.

- **Bug Fixes**
  - Added a 10-minute limit for unattended tailoring runs to prevent them from hanging.
  - Extended the hiring request timeout to better accommodate longer tailoring workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->