### PR TITLE
Recognise the two ATS whose adapters we have and whose links we did not

### DIFF
--- a/internal/ingest/atsboard/board.go
+++ b/internal/ingest/atsboard/board.go
@@ -94,6 +94,15 @@ const (
 	// whole — the same "board contains a dot" signal the adapter itself reads to tell the two
 	// apart, so there is nothing for the recognizer to decide beyond matching that one shape.
 	modeICIMS = "icims"
+	// querypair: board = TWO named query parameters joined by ":", because the platform needs
+	// both to address a tenant and neither alone identifies one. ADP Workforce Now serves every
+	// career centre from one path under "?cid=<tenant>&ccId=<centre>", and its ingest adapter
+	// takes the board as exactly that pair (internal/ingest/sources/adp.go splits on the colon),
+	// so a single parameter would be a board that 404s every crawl. queryPairBoards names the two
+	// parameters and the shape each value must have, for the reason modeQuery demands one: on a
+	// board-only host a parameter is a weak signal, and inventing a board is the expensive
+	// direction.
+	modeQueryPair = "querypair"
 )
 
 // atsBoards lists the supported multi-tenant ATS: a host (exact or subdomain-suffix match) →
@@ -145,6 +154,9 @@ var atsBoards = []struct{ host, source, mode string }{
 
 	// --- query: board = a named query parameter (see queryBoards) ---
 	{"recruitingbypaycor.com", "paycor", modeQuery},
+
+	// --- querypair: board = two named query parameters joined by ":" (see queryPairBoards) ---
+	{"workforcenow.adp.com", "adp", modeQueryPair},
 
 	// --- icims: board = bare slug (classic "careers-<slug>" host) or the whole vanity host ---
 	{"icims.com", "icims", modeICIMS},
@@ -294,6 +306,37 @@ var queryBoards = map[string]struct {
 	},
 }
 
+// queryPairBoards holds, per matched host entry in modeQueryPair, the two query parameters that
+// together name the board, the shape each value must have, and the path the board's listing is
+// served from. It is queryBoards one parameter wider, and exists for the same reason: on a host
+// that serves every tenant from one path, only the parameters tell them apart.
+//
+// The board is written "<first>:<second>" because that is how the ingest adapter takes it, not
+// because the URL reads that way — sources/adp.go cuts the board on the colon into the cid and
+// ccId its API needs, and the catalogue's ~2,800 adp boards are all stored in that form.
+var queryPairBoards = map[string]struct {
+	first, second, listingPath string
+	firstPattern               *regexp.Regexp
+	secondPattern              *regexp.Regexp
+}{
+	// ADP Workforce Now: the recruitment page is
+	// /mascsr/default/mdf/recruitment/recruitment.html?cid=<uuid>&ccId=<id>&jobId=<posting>.
+	// cid is the tenant, ccId the career centre within it — one tenant runs several, and the
+	// adapter's listing call sends both. The ccId is a digits-and-underscore id ("19000101_000001",
+	// "9201289910657_2"), never a uuid, so the two cannot be confused for one another.
+	//
+	// myjobs.adp.com is deliberately absent: it is a DIFFERENT ADP product (a hosted career site
+	// addressed by a name slug), our adapter cannot crawl it, and reading its slug as a board
+	// would produce exactly the silently-wrong board this package exists to avoid.
+	"workforcenow.adp.com": {
+		first:         "cid",
+		second:        "ccId",
+		listingPath:   "/mascsr/default/mdf/recruitment/recruitment.html",
+		firstPattern:  regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`),
+		secondPattern: regexp.MustCompile(`^[0-9][0-9_]*$`),
+	},
+}
+
 // apiBoards lists each ATS's OWN API host, where the board sits behind a fixed path prefix
 // rather than in the first segment. These are not links a person pastes; they are the XHR a
 // career site on the EMPLOYER's own domain makes to load its listing. That request often names
@@ -312,6 +355,12 @@ var apiBoards = []struct{ host, source, prefix string }{
 	// (apply.jobappnetwork.com/clients/<clientId>/posting/<id>/…), so a person-pasted or
 	// harvested URL resolves through the same mechanism as the XHR-only hosts above.
 	{"apply.jobappnetwork.com", "jobappnetwork", "clients"},
+	// Paylocity serves every tenant from one host, and only the LISTING names the board:
+	// /Recruiting/Jobs/All/<board>. A posting (/Recruiting/Jobs/Details/<id>) and its apply
+	// form (/Recruiting/Jobs/Apply/<id>) carry a posting id and nothing else, so they match no
+	// prefix here and are declined — which is right, since skipping the segment would take the
+	// posting id for a board, the same trap workable's "/j/<id>" shortlink carries.
+	{"recruiting.paylocity.com", "paylocity", "Recruiting/Jobs/All"},
 }
 
 // noBoardHosts are hosts under a supported ATS's domain that serve the platform's own
@@ -487,6 +536,29 @@ func Recognize(rawURL string) (source, board, canonical string, ok bool) {
 		u.Fragment = ""
 		u.Path = q.listingPath
 		u.RawQuery = url.Values{q.param: {board}}.Encode()
+		return src, board, u.String(), true
+
+	case modeQueryPair:
+		// ADP Workforce Now: the board is two parameters, and the canonical is the recruitment
+		// page carrying just those two — so a posting link and a bare career-centre link collapse
+		// to one board. The cid is lower-cased (it is a uuid the platform serves in either case
+		// and adp's catalogue holds lower-case); the ccId is left verbatim, since it is digits and
+		// underscores with no case to fold.
+		q, configured := queryPairBoards[apex]
+		if !configured || q.firstPattern == nil || q.secondPattern == nil {
+			return "", "", "", false
+		}
+		// Each pattern rejects an absent or empty parameter along with a malformed one, so a link
+		// on the host naming only one half is declined rather than turned into a truncated board.
+		first := strings.ToLower(u.Query().Get(q.first))
+		second := u.Query().Get(q.second)
+		if !q.firstPattern.MatchString(first) || !q.secondPattern.MatchString(second) {
+			return "", "", "", false
+		}
+		board = first + ":" + second
+		u.Fragment = ""
+		u.Path = q.listingPath
+		u.RawQuery = url.Values{q.first: {first}, q.second: {second}}.Encode()
 		return src, board, u.String(), true
 
 	case modePathLocalePair:

--- a/internal/ingest/atsboard/board_test.go
+++ b/internal/ingest/atsboard/board_test.go
@@ -135,6 +135,29 @@ func TestRecognize(t *testing.T) {
 		{"paycor malformed client id is not a board", "https://recruitingbypaycor.com/career/CareerHome.action?clientId=not-a-board", "", "", "", false},
 		{"paycor truncated client id is not a board", "https://recruitingbypaycor.com/career/JobIntroduction.action?clientId=4028f88b24c330a2&id=1", "", "", "", false},
 
+		// querypair — ADP Workforce Now: cid names the tenant, ccId the career centre inside it,
+		// and the adapter needs both, so the board is the pair. The canonical collapses to the
+		// recruitment page carrying only those two.
+		{"adp posting", "https://workforcenow.adp.com/mascsr/default/mdf/recruitment/recruitment.html?cid=8a680274-0b2e-46cf-b2cc-49bd2ef0c20f&ccId=9201289910657_2&jobId=123&lang=en_US", "adp", "8a680274-0b2e-46cf-b2cc-49bd2ef0c20f:9201289910657_2", "https://workforcenow.adp.com/mascsr/default/mdf/recruitment/recruitment.html?ccId=9201289910657_2&cid=8a680274-0b2e-46cf-b2cc-49bd2ef0c20f", true},
+		{"adp upper-case cid folds", "https://workforcenow.adp.com/mascsr/default/mdf/recruitment/recruitment.html?cid=8A680274-0B2E-46CF-B2CC-49BD2EF0C20F&ccId=19000101_000001", "adp", "8a680274-0b2e-46cf-b2cc-49bd2ef0c20f:19000101_000001", "https://workforcenow.adp.com/mascsr/default/mdf/recruitment/recruitment.html?ccId=19000101_000001&cid=8a680274-0b2e-46cf-b2cc-49bd2ef0c20f", true},
+		// Half a pair is not a board: the adapter splits the board on the colon and sends both
+		// halves, so a truncated one would 404 every crawl.
+		{"adp without a ccId is not a board", "https://workforcenow.adp.com/mascsr/default/mdf/recruitment/recruitment.html?cid=8a680274-0b2e-46cf-b2cc-49bd2ef0c20f", "", "", "", false},
+		{"adp without a cid is not a board", "https://workforcenow.adp.com/mascsr/default/mdf/recruitment/recruitment.html?ccId=19000101_000001", "", "", "", false},
+		{"adp with neither is not a board", "https://workforcenow.adp.com/mascsr/default/mdf/recruitment/recruitment.html", "", "", "", false},
+		{"adp malformed cid is not a board", "https://workforcenow.adp.com/mascsr/default/mdf/recruitment/recruitment.html?cid=acme&ccId=19000101_000001", "", "", "", false},
+		{"adp malformed ccId is not a board", "https://workforcenow.adp.com/mascsr/default/mdf/recruitment/recruitment.html?cid=8a680274-0b2e-46cf-b2cc-49bd2ef0c20f&ccId=main", "", "", "", false},
+		// myjobs.adp.com is a different ADP product our adapter cannot crawl, so its slug must
+		// never become an adp board.
+		{"adp hosted career site is not this platform", "https://myjobs.adp.com/stellantisexternalcx/cx/job/5001207766206", "", "", "", false},
+
+		// apiBoards — Paylocity: only the listing path names the board. A posting and its apply
+		// form carry a posting id and no tenant, so they are declined rather than read as one.
+		{"paylocity listing", "https://recruiting.paylocity.com/Recruiting/Jobs/All/7186761b-1318-47f2-b709-d7e7995cd3f3", "paylocity", "7186761b-1318-47f2-b709-d7e7995cd3f3", "https://recruiting.paylocity.com/Recruiting/Jobs/All/7186761b-1318-47f2-b709-d7e7995cd3f3", true},
+		{"paylocity posting is not a board", "https://recruiting.paylocity.com/Recruiting/Jobs/Details/4037913", "", "", "", false},
+		{"paylocity apply form is not a board", "https://recruiting.paylocity.com/Recruiting/Jobs/Apply/1471799", "", "", "", false},
+		{"paylocity bare listing path is not a board", "https://recruiting.paylocity.com/Recruiting/Jobs/All", "", "", "", false},
+
 		// icims — board IS the host (like subdomain/host modes), so the canonical collapses to
 		// the bare host: the classic "careers-<slug>.icims.com" host folds to the bare slug
 		// (matching icims.yml's usual shape); any other *.icims.com host, including one that
@@ -400,18 +423,26 @@ func TestRecognizeMapsHostsToTheIngestProviderName(t *testing.T) {
 	}
 }
 
-// TestQueryModeRowsAreConfigured guards the one mode whose row is not self-contained: a query
-// entry needs a second row in queryBoards naming the parameter, and without it the host matches
-// and then declines every link on it — a platform that looks supported and recognises nothing.
-// The rest of the table keeps the "one row plus one test case" promise on its own.
+// TestQueryModeRowsAreConfigured guards the two modes whose rows are not self-contained: a query
+// entry needs a second row in queryBoards naming the parameter, and a querypair entry a row in
+// queryPairBoards naming both. Without it the host matches and then declines every link on it —
+// a platform that looks supported and recognises nothing. The rest of the table keeps the
+// "one row plus one test case" promise on its own.
 func TestQueryModeRowsAreConfigured(t *testing.T) {
 	for _, a := range atsBoards {
-		if a.mode != modeQuery {
-			continue
-		}
-		if q, ok := queryBoards[a.host]; !ok || q.param == "" || q.listingPath == "" || q.boardPattern == nil {
-			t.Errorf("atsBoards entry %q (%s) is %s mode but queryBoards has no complete entry for it",
-				a.host, a.source, modeQuery)
+		switch a.mode {
+		case modeQuery:
+			if q, ok := queryBoards[a.host]; !ok || q.param == "" || q.listingPath == "" || q.boardPattern == nil {
+				t.Errorf("atsBoards entry %q (%s) is %s mode but queryBoards has no complete entry for it",
+					a.host, a.source, modeQuery)
+			}
+		case modeQueryPair:
+			q, ok := queryPairBoards[a.host]
+			if !ok || q.first == "" || q.second == "" || q.listingPath == "" ||
+				q.firstPattern == nil || q.secondPattern == nil {
+				t.Errorf("atsBoards entry %q (%s) is %s mode but queryPairBoards has no complete entry for it",
+					a.host, a.source, modeQueryPair)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## What

`internal/ingest/atsboard` did not recognise `adp` or `paylocity` — two platforms we have working adapters for, and two of the larger ones in the catalogue (~2,800 and ~12,900 boards).

## Why it matters

`Recognize` has three consumers: `contribution` decides which board a pasted link would onboard, `linksource` finds the adapter that can fetch a board, `boardresolve` names an ATS embedded in a company's own careers page. A link to either platform got nothing from all three.

Both gaps surfaced while mapping an external company dump onto our catalogue, where they were the two largest unmappable groups.

## Paylocity — one row, no new machinery

It fits `apiBoards` as it stands: only the listing names the board.

| URL | board |
|---|---|
| `/Recruiting/Jobs/All/<guid>` | `<guid>` |
| `/Recruiting/Jobs/Details/<id>` | declined |
| `/Recruiting/Jobs/Apply/<id>` | declined |

A posting and its apply form carry a posting id and no tenant. Declining them is right: skipping the segment would take the posting id for a board — the same trap workable's `/j/<id>` shortlink carries.

## ADP — a new mode

Its board is the **pair** `cid:ccId`, which is how `sources/adp.go` takes it (`strings.Cut` on the colon) and how all ~2,800 rows are stored: `8a680274-…-c20f:9201289910657_2`. `cid` is the tenant, `ccId` the career centre inside it, and one tenant runs several. `modeQuery`'s single parameter would have produced a truncated board that 404s every crawl — the silently-wrong board this package's doc comment warns about.

`querypair` is `modeQuery` one parameter wider, keeping its demand that each value carry the shape of an id before it counts as one:

| URL | board |
|---|---|
| `recruitment.html?cid=<uuid>&ccId=<id>&jobId=…` | `<uuid>:<id>` |
| `…?cid=<uuid>` alone | declined |
| `…?ccId=<id>` alone | declined |
| `…?cid=acme&ccId=<id>` | declined |
| `myjobs.adp.com/<slug>/cx/job/<id>` | declined |

**`myjobs.adp.com` is deliberately absent.** It is a different ADP product — hosted career sites addressed by a name slug — and our adapter reaches none of them. Reading its slug as an `adp` board would be exactly the false board the patterns are there to prevent.

## Tests

13 new cases in the recognition table, and `TestQueryModeRowsAreConfigured` extended to `querypair` so a future row without its `queryPairBoards` entry fails rather than quietly declining every link on a host that looks supported.

Mutation-checked: removing either new row, or the `queryPairBoards` entry, fails the suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recognition for ADP Workforce Now recruitment board URLs.
  * Added recognition for Paylocity job listing board URLs.
  * ADP URLs now support board identification using both required query parameters.

* **Bug Fixes**
  * Improved validation to reject incomplete or malformed ADP board URLs.
  * Excluded Paylocity posting and application URLs from board recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->