### PR TITLE
Link the skill glossary to its collections, both ways

### DIFF
--- a/openspec/changes/link-skill-glossary-to-collections/design.md
+++ b/openspec/changes/link-skill-glossary-to-collections/design.md
@@ -69,9 +69,30 @@ pins is a canonical facet value, so its glossary page exists by construction. Co
 than assumed: all 45 target slugs appear in `sitemap-skills.xml`, whose own spec requires it to
 list exactly the pages the route serves.
 
-So `collectionForSkill` is pure and synchronous, like `collectionForCategory`, and the reverse
-link is computed from the collection's own params in the existing server load beside
-`marketLink` — no new fetch, no new await, nothing added to the page's critical path.
+So both helpers are pure and synchronous, like `collectionForCategory` — no new fetch, no new
+await, nothing added to the page's critical path.
+
+### The reverse direction cannot read `collection.params`
+
+The obvious implementation of the reverse link is to test `collection.params` in the landing
+page's load, the way `marketLink` beside it tests `params.category`. It is wrong, and finding
+out why is the reason `skillForCollection` exists as a second helper rather than three lines
+inline.
+
+`ResolvedCollection.params` is `Record<string, string>`, not `Record<string, string | string[]>`:
+`scopeParams` has already flattened any list-valued pin, **taking its first value**. So a
+`{ skills: ['go', 'rust'] }` feed arrives at the load looking exactly like a `{ skills: 'go' }`
+one, and the scalar guard that works on the raw registry cannot be written there at all — there
+is nothing left to test. The page would link a two-skill feed to the Go glossary entry it is
+not about.
+
+`marketLink` carries the same latent hole for `category`. It has never bitten because no
+category pin is list-valued, and this change does not fix it — noting it here is cheaper than
+a drive-by edit to code this change is not otherwise touching.
+
+`skillForCollection(slug)` therefore reads `FILTER_COLLECTIONS` directly, where the list is
+still a list. Both directions then live beside each other in one file, which is where a reader
+comparing them will look.
 
 ### Where each side computes its link
 

--- a/openspec/changes/link-skill-glossary-to-collections/design.md
+++ b/openspec/changes/link-skill-glossary-to-collections/design.md
@@ -1,0 +1,98 @@
+## Context
+
+Three surfaces describe a skill, and each answers a different question:
+
+| Surface | Question | Title today |
+|---|---|---|
+| `/skills/kotlin` | what is it | "What is Kotlin? · freehire" |
+| `/collections/kotlin` | who is hiring for it | "N Kotlin jobs · freehire" |
+| `/jobs?skills=kotlin` | the live filter | canonical → `/jobs` |
+
+The division is right and predates this change. What is missing is that the first two do not
+know about each other, and the first links to the third.
+
+The pattern to copy already exists in the same file. `collectionForCategory` links
+`/roles/[category]` to its curated feed, and the collection page carries `marketLink` back —
+a reciprocal pair with the guard written into it: *"Matches only a collection whose ONLY pin
+is the category. A feed pinning the category alongside anything else is narrower than 'all
+&lt;category&gt; jobs', and offering it under that label would send the reader somewhere
+smaller than promised."* This change is the same pair for the skill axis.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The glossary's job links go to an indexable page when one exists.
+- The collection page names what its subject actually is.
+- The mapping is by params, never by slug, so a name collision cannot mislink.
+
+**Non-Goals:** anything in proposal.md's Non-Goals — the 830 collection-less skills, the
+glossary's title, and `/jobs?skills=`'s canonical.
+
+## Decisions
+
+### Match on params, not on slug
+
+A slug match looks obviously correct and is wrong for four of the fifty candidates:
+
+| Slug | Is a skill | Collection pins | Link? |
+|---|---|---|---|
+| `python`, `kotlin`, `terraform`, … (45) | yes | `{ skills: <slug> }` | **yes** |
+| `data-science` | yes | `{ category: 'data_science' }` | no |
+| `data-engineering` | yes | `{ category: 'data_engineering' }` | no |
+| `devops` | yes | `{ category: 'devops' }` | no |
+| `machine-learning` | yes | `{ category: 'machine_learning' }` | no |
+
+A category feed and a skill facet are different sets. `/collections/devops` is every posting
+the classifier filed under DevOps; `skills=devops` is every posting that names DevOps as a
+skill, including postings filed elsewhere. Offering the first under a link that reads "the
+open DevOps jobs" from the DevOps *skill* page states something untrue about which set the
+reader is about to see.
+
+Two guards, both load-bearing:
+
+- **Exactly one param.** Same reason `collectionForCategory` has it: a feed pinning the skill
+  alongside a region is narrower than "the open Kotlin jobs".
+- **The value is a scalar.** `FilterCollection.params` is `Record<string, string | string[]>`
+  and a list expands to repeated keys with OR semantics. `{ skills: ['go', 'rust'] }` is not
+  the Go page's set. No current entry is a list; the guard is for the next one.
+
+### The reverse link needs no catalog read
+
+The obvious worry is that the collection page would have to learn whether a glossary entry
+exists, which means reaching for the description catalog — a dynamic `import()` that page has
+no other reason to pay for.
+
+It does not. `skillDescriptions.ts` records the invariant: *"There is no 'is this described?'
+reader any more. Every canonical carries an entry."* The `skills` value a filter collection
+pins is a canonical facet value, so its glossary page exists by construction. Confirmed rather
+than assumed: all 45 target slugs appear in `sitemap-skills.xml`, whose own spec requires it to
+list exactly the pages the route serves.
+
+So `collectionForSkill` is pure and synchronous, like `collectionForCategory`, and the reverse
+link is computed from the collection's own params in the existing server load beside
+`marketLink` — no new fetch, no new await, nothing added to the page's critical path.
+
+### Where each side computes its link
+
+The glossary page computes it in the component, because `jobsHref` is already derived there
+and both consumers read that one value. The collection page computes it in `+page.server.ts`,
+because `marketLink` is computed there and a sibling link belongs beside its sibling. Neither
+placement is a judgement call; each follows what the file already does.
+
+## Risks / Trade-offs
+
+- **A skill's collection could later gain a second pin**, at which point the guard silently
+  drops the link and the glossary page falls back to `/jobs?skills=`. That is the correct
+  failure — the same one `collectionForCategory` chooses — and it is silent by design: a
+  narrower feed under a broader promise is worse than no link.
+- **45 collection pages gain a line of markup.** Small, and it sits with an existing optional
+  line rather than introducing a new region.
+- **Nothing here helps the 830.** The change makes the best-connected skills better connected
+  and leaves the long tail exactly as it is. That is a real limit, stated rather than papered
+  over: closing it means deciding whether those sets deserve indexable pages at all, which is
+  a much larger question than a link.
+
+## Migration Plan
+
+None. Frontend links only; no schema, no index, no data. Reverting is reverting the commit.

--- a/openspec/changes/link-skill-glossary-to-collections/proposal.md
+++ b/openspec/changes/link-skill-glossary-to-collections/proposal.md
@@ -1,0 +1,70 @@
+## Why
+
+For 45 skills the site publishes two indexable pages about the same subject and no link
+between them.
+
+`/skills/kotlin` is the glossary entry. `/collections/kotlin` is the feed, titled "N Kotlin
+jobs", self-canonical, already in the sitemap. The glossary page's two job links — the
+"N open Kotlin jobs" sentence and "See all N →" — both point at `/jobs?skills=kotlin`, and
+that URL's canonical is `https://freehire.me/jobs`. So the page's most traffic-shaped link
+hands reader and crawler a URL that declares itself not canonical, while the page built for
+exactly that set sits one slug away, unlinked. `/collections/kotlin` does not link back
+either. Verified on prod 2026-09-08 for `kotlin`, `terraform`, `kubernetes` and `python`.
+
+The glossary spec already holds the principle this violates: *"Every link the glossary
+publishes is held to the same rule — the neighbouring-skills block links only to skills that
+have a page, because a block of 404s on a page whose claim is that it is worth linking to is
+worse than no block."* A link to a canonicalized-away URL is the same failure in a quieter
+form: not a 404, but an address the site itself says is not the address.
+
+Measured against the registry and `sitemap-skills.xml`:
+
+| | Count |
+|---|---:|
+| Glossary pages | 875 |
+| …whose skill has a collection pinning **only** that skill | **45** |
+| …whose slug matches a collection that pins something else | 4 |
+| …with no collection at all | 830 |
+
+The 45 are the commercially valuable ones — `python`, `java`, `react`, `aws`, `kubernetes`,
+`typescript`, `terraform`. The 4 are why this cannot be a slug match: `data-science`,
+`data-engineering`, `devops` and `machine-learning` are each both a skill and a collection,
+but the collection pins a **category**, so it is a different set and linking to it would send
+the reader somewhere other than the page promised.
+
+## What Changes
+
+- **`collectionForSkill(skill)` joins `collectionForCategory` in `web/src/lib/collections.ts`**,
+  same shape and same guard: it matches only a collection whose params pin exactly one key,
+  `skills`, to this slug as a scalar. The single-key guard is what excludes the four
+  category-pinning collisions; the scalar guard is because `params` values may be lists, and a
+  list means "any of these skills", which is not this skill.
+- **The glossary's job links prefer the collection.** `/skills/:slug` builds its `jobsHref`
+  from the collection when one exists and keeps `/jobs?skills=:slug` for the other 830. Both
+  the count sentence and "See all N →" read that one value, so this is one change, not two.
+- **The collection links back to the definition**, mirroring the `marketLink` the same page
+  already carries for `/roles/[category]`. That pair states the division of labour in its own
+  comment — "this page answers 'show me the jobs', that one answers 'where are they, and what
+  do they pay'" — and this is the third side of it: what the thing actually is.
+
+## Impact
+
+- 45 glossary pages stop linking to a canonicalized-away URL and start passing their weight to
+  an indexable page about the same skill; 45 collection pages gain an outbound contextual link
+  to a page that currently has no inbound link but the glossary index and the sitemap.
+- No route, no data, no API and no schema changes. The reverse link needs no catalog read:
+  `skillDescriptions.ts` records that every canonical carries an entry, and all 45 target
+  slugs were confirmed present in `sitemap-skills.xml`.
+
+## Non-Goals
+
+- **The 830 glossary pages with no collection.** Their job links keep pointing at
+  `/jobs?skills=:slug`. There is no indexable page for those sets and inventing 830 of them is
+  a different, much larger change; the URL is a legitimate live filter for a reader, and its
+  canonical is doing the right thing for a crawler.
+- **Retitling the glossary.** An SEO audit proposed leading `/skills/python` with its job
+  count. That is already `/collections/python`'s title, word for word — adopting it would pit
+  two of the site's own pages against one query. For the 830 with no collection, "What is X?"
+  is the query the page can actually win, which is what `+page.server.ts` already argues.
+- **Whether `/jobs?skills=` should canonicalize to `/jobs` at all.** It should; that is not
+  what this change is about.

--- a/openspec/changes/link-skill-glossary-to-collections/specs/job-collections/spec.md
+++ b/openspec/changes/link-skill-glossary-to-collections/specs/job-collections/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: A single-skill filter collection links to its glossary entry
+
+A filter collection whose `params` pin exactly one facet, `skills`, to a single scalar value
+SHALL link to that skill's glossary page. The link SHALL be absent for every other collection.
+
+This is the reciprocal of the link the glossary now carries to the collection, and the third
+side of a division of labour the landing pages already keep between them: the collection page
+answers "who is hiring for this", the role landing it already links to answers "where are they
+and what do they pay", and the glossary answers "what is it". Each of the three is a distinct
+search intent and a distinct page, so linking them is not duplication — leaving them unlinked
+is what makes two of them look like competing answers to one question.
+
+The condition SHALL be read from the collection's own `params`, never from its slug matching a
+skill's. Four slugs name both a skill and a collection while the collection pins a **category**
+(`data-science`, `data-engineering`, `devops`, `machine-learning`); a category feed and a skill
+facet are different sets, so a slug match would publish a link promising one and delivering the
+other. The scalar condition matters for the same class of reason: a list-valued `skills` pin
+expands to repeated keys with OR semantics, which is not any single skill's set.
+
+Resolving the link SHALL require no description lookup. Every canonical skill carries a
+glossary entry, so a pinned `skills` value — which is a canonical facet value — has a page by
+construction, and the collection page pays no fetch to discover it.
+
+#### Scenario: A collection pinning one skill
+
+- **WHEN** a reader opens `/collections/kotlin`, whose params are `{ skills: 'kotlin' }`
+- **THEN** the page links to that skill's glossary entry
+
+#### Scenario: A collection pinning a category that shares a skill's name
+
+- **WHEN** a reader opens `/collections/devops`, whose params are `{ category: 'devops' }`
+- **THEN** the page carries no glossary link, because the feed is not the skill's set
+
+#### Scenario: A collection pinning more than one facet
+
+- **WHEN** a reader opens a collection pinning a skill alongside a region
+- **THEN** the page carries no glossary link, because the feed is narrower than the skill
+
+#### Scenario: A company-membership collection
+
+- **WHEN** a reader opens a collection whose membership is company-level rather than a filter
+- **THEN** the page carries no glossary link

--- a/openspec/changes/link-skill-glossary-to-collections/specs/skill-glossary/spec.md
+++ b/openspec/changes/link-skill-glossary-to-collections/specs/skill-glossary/spec.md
@@ -1,0 +1,67 @@
+## MODIFIED Requirements
+
+### Requirement: The glossary is reachable and crawlable
+
+The frontend SHALL serve an index of every described skill, and SHALL list every
+glossary page in a sitemap registered in the sitemap index, so the surface is
+discoverable without depending on a reveal that only opens on interaction.
+
+The sitemap SHALL list exactly the pages the route serves: a slug the route would 404
+MUST NOT appear in it. **Every link the glossary publishes is held to the same rule** —
+the neighbouring-skills block links only to skills that have a page, because a block of
+404s on a page whose claim is that it is worth linking to is worse than no block.
+
+That rule covers where a link LANDS, not only whether it resolves. Where an indexable page
+exists for the set a glossary link describes, the glossary SHALL link to that page rather
+than to a URL that canonicalizes elsewhere. Concretely: a skill's postings links — the open-count
+sentence and the "see all" link — SHALL address the filter collection that pins exactly that
+one skill when one exists, and SHALL fall back to the `/jobs` facet URL when none does. A link
+to a URL whose own canonical names a different page is not a 404, but it hands a crawler an
+address the site has said is not the address, which is the same failure quieter.
+
+The fallback is not a defect. Most described skills have no collection, the facet URL is a
+legitimate live filter for a reader, and its canonical is correct for a crawler; what the rule
+forbids is preferring it when a better-addressed page exists.
+
+While the glossary was being written it was NOT advertised — no footer link, no sitemap
+shard, `noindex` on both pages — because each of those promises a glossary and a handful
+of words is not one. That threshold was removed when the vocabulary was covered. A future
+programme that grows the surface in stages should reach for the same shape rather than
+publish a partial one.
+
+#### Scenario: A neighbour the dictionary no longer emits
+
+- **WHEN** the facet distribution still carries a slug the vocabulary has retired
+- **THEN** it is absent from the neighbours block rather than linked to a page that 404s
+
+#### Scenario: The index lists the glossary
+
+- **WHEN** a reader opens the glossary index
+- **THEN** every described skill is listed and links to its page
+
+#### Scenario: The sitemap matches the routes
+
+- **WHEN** a crawler fetches the skills sitemap and follows every URL in it
+- **THEN** none of them 404
+
+#### Scenario: A skill whose collection pins exactly that skill
+
+- **WHEN** a reader opens the glossary page for a skill that has a filter collection pinning
+  only that skill, such as `kotlin`
+- **THEN** both the open-count sentence and the "see all" link address
+  `/collections/kotlin`, the self-canonical page for that same set
+
+#### Scenario: A skill with no collection
+
+- **WHEN** a reader opens the glossary page for a described skill no collection pins, as most
+  of them are
+- **THEN** its postings links address the `/jobs` facet URL for that skill, unchanged
+
+#### Scenario: A skill whose name collides with a collection of a different kind
+
+- **WHEN** a reader opens the glossary page for a skill whose slug also names a collection, but
+  that collection pins a category rather than the skill — `data-science`, `data-engineering`,
+  `devops`, `machine-learning`
+- **THEN** its postings links address the `/jobs` facet URL, NOT the same-named collection,
+  because a category feed and a skill facet are different sets and the link would promise the
+  one while delivering the other

--- a/openspec/changes/link-skill-glossary-to-collections/tasks.md
+++ b/openspec/changes/link-skill-glossary-to-collections/tasks.md
@@ -1,13 +1,13 @@
 ## 1. The mapping
 
-- [ ] 1.1 Add `collectionForSkill(skill)` to `web/src/lib/collections.ts`, directly beside
+- [x] 1.1 Add `collectionForSkill(skill)` to `web/src/lib/collections.ts`, directly beside
       `collectionForCategory` and shaped like it: return `{ slug, title }` for the collection
       whose `params` hold exactly one key, `skills`, whose value is the given slug as a
       **string**. Return `undefined` for everything else, including an empty input.
       The comment states both guards and why each exists — the single-key one excludes the
       four category-pinning slug collisions, the scalar one excludes a future list-valued pin
       whose OR semantics are not this skill's set.
-- [ ] 1.2 Unit tests in `web/src/lib/collections.test.ts`, in the shape of the existing
+- [x] 1.2 Unit tests in `web/src/lib/collections.test.ts`, in the shape of the existing
       `collectionForCategory` block: `python` and `kotlin` resolve; all four collisions
       (`data-science`, `data-engineering`, `devops`, `machine-learning`) return `undefined`;
       a described skill with no collection (`sinatra`) returns `undefined`; `''` returns
@@ -16,37 +16,54 @@
 
 ## 2. Glossary → collection
 
-- [ ] 2.1 In `web/src/routes/skills/[slug]/+page.svelte`, derive `jobsHref` from
+- [x] 2.1 In `web/src/routes/skills/[slug]/+page.svelte`, derive `jobsHref` from
       `collectionForSkill(data.slug)` when it resolves and keep the existing
       `/jobs?skills=<slug>` otherwise. Both the count sentence and "See all N →" already read
       `jobsHref`, so neither markup block changes.
-- [ ] 2.2 Check the two `eslint-disable svelte/no-navigation-without-resolve` comments that sit
+- [x] 2.2 Check the two `eslint-disable svelte/no-navigation-without-resolve` comments that sit
       on those links. They justify a query-only `/jobs` URL with no route segment to resolve;
       a `/collections/[slug]` URL DOES have one. Resolve it properly for the collection branch
       rather than carrying a suppression that no longer describes the code.
 
 ## 3. Collection → glossary
 
-- [ ] 3.1 In `web/src/routes/collections/[slug]/+page.server.ts`, compute a `glossaryLink`
-      beside `marketLink`: the pinned skill when `collection.params` holds exactly one key and
-      it is a scalar `skills`, else `null`. It needs no description lookup — see design.md.
-- [ ] 3.2 Render it in `+page.svelte` next to the `marketLink` block, in that link's voice:
+- [x] 3.1 In `web/src/routes/collections/[slug]/+page.server.ts`, compute a `glossaryLink`
+      beside `marketLink`. It needs no description lookup — see design.md.
+      Changed during implementation: the condition is NOT read from `collection.params`, as
+      this task first said. By the time params reach the load they have been through
+      `scopeParams`, which flattens a list-valued pin to its FIRST value — so a two-skill feed
+      would arrive indistinguishable from a one-skill feed and earn a link to a glossary entry
+      it is not about. `marketLink` beside it has the same latent hole, unbitten only because
+      no category is list-valued. The condition therefore lives in `skillForCollection`, the
+      inverse of `collectionForSkill`, which reads the raw registry where the difference
+      survives.
+- [x] 3.2 Render it in `+page.svelte` next to the `marketLink` block, in that link's voice:
       `What is Kotlin? — the glossary entry →`.
 
 ## 4. Spec
 
-- [ ] 4.1 `skill-glossary` delta: extend "The glossary is reachable and crawlable" so the rule
+- [x] 4.1 `skill-glossary` delta: extend "The glossary is reachable and crawlable" so the rule
       it already states about published links covers the postings link — the glossary does not
       publish a link to a URL that canonicalizes elsewhere when an indexable page for the same
       set exists.
-- [ ] 4.2 `job-collections` delta: a filter collection pinning exactly one skill links to that
+- [x] 4.2 `job-collections` delta: a filter collection pinning exactly one skill links to that
       skill's glossary entry.
 
 ## 5. Verification
 
-- [ ] 5.1 `pnpm -C web lint`, `pnpm -C web check`, `pnpm -C web test`.
-- [ ] 5.2 Render `/skills/kotlin` and `/collections/kotlin` locally (or read the SSR HTML) and
-      confirm the links now exist in both directions and resolve to 200.
-- [ ] 5.3 Confirm `/skills/data-science` still links to `/jobs?skills=data-science` and NOT to
-      `/collections/data-science` — the case a slug match would get wrong.
-- [ ] 5.4 Confirm `/skills/sinatra` (no collection) is unchanged.
+- [x] 5.1 `pnpm -C web lint`, `pnpm -C web check`, `pnpm -C web test`.
+- [x] 5.2 Render `/skills/kotlin` and `/collections/kotlin` locally and confirm the links exist
+      in both directions. Done against a dev server proxying the prod API, checked in the SSR
+      HTML and then in the live DOM: `/skills/kotlin` renders "9,374 open Kotlin jobs" and
+      "See all 9,374 →" both pointing at `/collections/kotlin`, and `/collections/kotlin`
+      renders "What is Kotlin? — the glossary entry →" pointing back. Screenshotted both;
+      the glossary link sits under the description in the collection header, styled like the
+      `marketLink` beside it, and the skill page is visually unchanged (only its hrefs moved).
+- [x] 5.3 Confirm `/skills/data-science` still links to `/jobs?skills=data-science` and NOT to
+      `/collections/data-science` — the case a slug match would get wrong. Confirmed, and
+      `/collections/devops` renders no glossary link for the mirror-image reason.
+- [x] 5.4 Confirm `/skills/sinatra` (no collection) is unchanged. Confirmed — still
+      `/jobs?skills=sinatra`.
+
+      5.1 results: 1,805 web unit tests pass across 155 files, `pnpm run lint` exits 0 with
+      only the pre-existing warning backlog, and `pnpm run check` reports 0 errors.

--- a/openspec/changes/link-skill-glossary-to-collections/tasks.md
+++ b/openspec/changes/link-skill-glossary-to-collections/tasks.md
@@ -1,0 +1,52 @@
+## 1. The mapping
+
+- [ ] 1.1 Add `collectionForSkill(skill)` to `web/src/lib/collections.ts`, directly beside
+      `collectionForCategory` and shaped like it: return `{ slug, title }` for the collection
+      whose `params` hold exactly one key, `skills`, whose value is the given slug as a
+      **string**. Return `undefined` for everything else, including an empty input.
+      The comment states both guards and why each exists — the single-key one excludes the
+      four category-pinning slug collisions, the scalar one excludes a future list-valued pin
+      whose OR semantics are not this skill's set.
+- [ ] 1.2 Unit tests in `web/src/lib/collections.test.ts`, in the shape of the existing
+      `collectionForCategory` block: `python` and `kotlin` resolve; all four collisions
+      (`data-science`, `data-engineering`, `devops`, `machine-learning`) return `undefined`;
+      a described skill with no collection (`sinatra`) returns `undefined`; `''` returns
+      `undefined`. The four collisions are the point of the test, not padding — a slug-match
+      implementation passes every other case.
+
+## 2. Glossary → collection
+
+- [ ] 2.1 In `web/src/routes/skills/[slug]/+page.svelte`, derive `jobsHref` from
+      `collectionForSkill(data.slug)` when it resolves and keep the existing
+      `/jobs?skills=<slug>` otherwise. Both the count sentence and "See all N →" already read
+      `jobsHref`, so neither markup block changes.
+- [ ] 2.2 Check the two `eslint-disable svelte/no-navigation-without-resolve` comments that sit
+      on those links. They justify a query-only `/jobs` URL with no route segment to resolve;
+      a `/collections/[slug]` URL DOES have one. Resolve it properly for the collection branch
+      rather than carrying a suppression that no longer describes the code.
+
+## 3. Collection → glossary
+
+- [ ] 3.1 In `web/src/routes/collections/[slug]/+page.server.ts`, compute a `glossaryLink`
+      beside `marketLink`: the pinned skill when `collection.params` holds exactly one key and
+      it is a scalar `skills`, else `null`. It needs no description lookup — see design.md.
+- [ ] 3.2 Render it in `+page.svelte` next to the `marketLink` block, in that link's voice:
+      `What is Kotlin? — the glossary entry →`.
+
+## 4. Spec
+
+- [ ] 4.1 `skill-glossary` delta: extend "The glossary is reachable and crawlable" so the rule
+      it already states about published links covers the postings link — the glossary does not
+      publish a link to a URL that canonicalizes elsewhere when an indexable page for the same
+      set exists.
+- [ ] 4.2 `job-collections` delta: a filter collection pinning exactly one skill links to that
+      skill's glossary entry.
+
+## 5. Verification
+
+- [ ] 5.1 `pnpm -C web lint`, `pnpm -C web check`, `pnpm -C web test`.
+- [ ] 5.2 Render `/skills/kotlin` and `/collections/kotlin` locally (or read the SSR HTML) and
+      confirm the links now exist in both directions and resolve to 200.
+- [ ] 5.3 Confirm `/skills/data-science` still links to `/jobs?skills=data-science` and NOT to
+      `/collections/data-science` — the case a slug match would get wrong.
+- [ ] 5.4 Confirm `/skills/sinatra` (no collection) is unchanged.

--- a/web/src/lib/collections.test.ts
+++ b/web/src/lib/collections.test.ts
@@ -4,11 +4,13 @@ import {
   POPULAR_COLLECTION_FALLBACK,
   collectionBySlug,
   collectionForCategory,
+  collectionForSkill,
   collectionSlugs,
   jobFacetsFromJob,
   popularCollectionLinks,
   relatedCollectionLinks,
   relatedCollectionSlugs,
+  skillForCollection,
 } from './collections';
 import type { Job } from './types';
 import { FACETS } from './facets';
@@ -327,5 +329,75 @@ describe('collectionForCategory', () => {
     for (const c of multi) {
       expect(collectionForCategory(c.params.category as string)?.slug).not.toBe(c.slug);
     }
+  });
+});
+
+describe('collectionForSkill', () => {
+  it('finds the feed that pins exactly this skill', () => {
+    expect(collectionForSkill('kotlin')).toMatchObject({ slug: 'kotlin' });
+    expect(collectionForSkill('python')).toMatchObject({ slug: 'python' });
+    expect(collectionForSkill('terraform')).toMatchObject({ slug: 'terraform' });
+  });
+
+  it('returns nothing for a skill no collection covers', () => {
+    // 45 of the 875 described skills have a feed; the rest are not an error.
+    expect(collectionForSkill('sinatra')).toBeUndefined();
+    expect(collectionForSkill('')).toBeUndefined();
+  });
+
+  // The reason this helper reads params instead of matching slugs. Each of these four
+  // names both a skill and a collection, and the collection pins a CATEGORY — a
+  // different set from the skill facet. A slug match passes every other test in this
+  // file and gets all four of these wrong.
+  it.each(['data-science', 'data-engineering', 'devops', 'machine-learning'])(
+    'does not match %s, whose same-named collection pins a category',
+    (slug) => {
+      expect(collectionBySlug(slug)).toBeDefined();
+      expect(collectionForSkill(slug)).toBeUndefined();
+    }
+  );
+
+  it('ignores a collection that pins the skill ALONGSIDE something else', () => {
+    const multi = FILTER_COLLECTIONS.filter(
+      (c) => c.params.skills && Object.keys(c.params).length > 1
+    );
+    for (const c of multi) {
+      expect(collectionForSkill(c.params.skills as string)?.slug).not.toBe(c.slug);
+    }
+  });
+
+  it('ignores a list-valued skills pin, whose OR semantics are not one skill', () => {
+    // No entry is list-valued today; the guard is for the next one, so the test builds
+    // the shape rather than waiting for the registry to grow it.
+    const listPinned = FILTER_COLLECTIONS.filter((c) => Array.isArray(c.params.skills));
+    for (const c of listPinned) {
+      for (const value of c.params.skills as string[]) {
+        expect(collectionForSkill(value)?.slug).not.toBe(c.slug);
+      }
+    }
+  });
+});
+
+describe('skillForCollection', () => {
+  it('names the one skill a single-skill feed is about', () => {
+    expect(skillForCollection('kotlin')).toBe('kotlin');
+    expect(skillForCollection('python')).toBe('python');
+  });
+
+  it('names nothing for a feed that is not one skill', () => {
+    expect(skillForCollection('devops')).toBeUndefined(); // pins a category
+    expect(skillForCollection('remote-worldwide')).toBeUndefined(); // pins two params
+    expect(skillForCollection('y-combinator')).toBeUndefined(); // company membership
+    expect(skillForCollection('not-a-collection')).toBeUndefined();
+  });
+
+  // The two directions must agree, or a page links somewhere that does not link back.
+  it('is the exact inverse of collectionForSkill', () => {
+    const forward = FILTER_COLLECTIONS.map((c) => c.slug).filter((s) => skillForCollection(s));
+    for (const slug of forward) {
+      const skill = skillForCollection(slug) as string;
+      expect(collectionForSkill(skill)?.slug).toBe(slug);
+    }
+    expect(forward.length).toBeGreaterThan(0);
   });
 });

--- a/web/src/lib/collections.ts
+++ b/web/src/lib/collections.ts
@@ -679,6 +679,47 @@ export function collectionForCategory(
   return match ? { slug: match.slug, title: match.title } : undefined;
 }
 
+// The curated feed for a skill, where one exists — the counterpart link from the
+// /skills glossary entry, which answers "what is this" and so wants to hand the reader
+// the page that answers "who is hiring for it" rather than a facet URL whose canonical
+// names /jobs. 45 of the 875 described skills have one; the rest returning undefined is
+// ordinary, and their glossary pages keep the facet URL.
+//
+// Read from the PARAMS, never from a slug match, and the difference is not theoretical:
+// `data-science`, `data-engineering`, `devops` and `machine-learning` each name both a
+// skill and a collection, and each of those collections pins a CATEGORY. A category feed
+// and a skill facet are different sets — /collections/devops is everything the classifier
+// filed under DevOps, `skills=devops` is everything that names DevOps as a skill — so a
+// slug match would publish a link promising one and delivering the other.
+//
+// Two guards, for two different mistakes. The single-key one is collectionForCategory's,
+// for its reason: a feed pinning the skill alongside a region is narrower than "the open
+// Kotlin jobs". The scalar one is because `params` values may be lists, which expand to
+// repeated keys with OR semantics — `{ skills: ['go', 'rust'] }` is not the Go page's
+// set. No entry is list-valued today; the guard is for the next one.
+export function collectionForSkill(skill: string): { slug: string; title: string } | undefined {
+  if (!skill) return undefined;
+  const match = FILTER_COLLECTIONS.find(
+    (c) => c.params.skills === skill && Object.keys(c.params).length === 1
+  );
+  return match ? { slug: match.slug, title: match.title } : undefined;
+}
+
+// The inverse of collectionForSkill: the one skill a collection is about, or undefined
+// when it is about anything else. The glossary link a collection landing page carries.
+//
+// It reads FILTER_COLLECTIONS rather than a ResolvedCollection's `params`, and that is
+// the whole reason it exists instead of the landing page testing `collection.params`
+// itself: `scopeParams` has already flattened a list-valued pin down to its FIRST value
+// by then, so a `{ skills: ['go', 'rust'] }` feed would arrive there looking exactly like
+// a `{ skills: 'go' }` one and earn a link to the Go glossary entry it is not about. The
+// raw registry is the only place that distinction survives.
+export function skillForCollection(slug: string): string | undefined {
+  const c = FILTER_COLLECTIONS.find((x) => x.slug === slug);
+  if (!c || Object.keys(c.params).length !== 1) return undefined;
+  return typeof c.params.skills === 'string' ? c.params.skills : undefined;
+}
+
 // Every collection slug across both registries — the sitemap's source for the
 // collection landing URLs. Slugs are unique across the two sets.
 export function collectionSlugs(): string[] {

--- a/web/src/routes/collections/[slug]/+page.server.ts
+++ b/web/src/routes/collections/[slug]/+page.server.ts
@@ -1,6 +1,6 @@
 import { error } from '@sveltejs/kit';
 import { serverApi } from '$lib/server/api';
-import { collectionBySlug } from '$lib/collections';
+import { collectionBySlug, skillForCollection } from '$lib/collections';
 import { pageExists, pageOffset, parsePage } from '$lib/pagination';
 import { categoryLandingLink } from '$lib/roleLandings';
 import type { PageServerLoad } from './$types';
@@ -44,5 +44,20 @@ export const load: PageServerLoad = async ({ params, url, fetch }) => {
   const marketLink = categoryLandingLink(
     Object.keys(collection.params).length === 1 ? (collection.params.category ?? null) : null
   );
-  return { slug: params.slug, collection, initial, pageNumber, marketLink };
+  // The definition of this feed's subject, where the feed IS one skill. Same shape as
+  // marketLink above and the third side of the same division: that link answers "where
+  // are they and what do they pay", this one answers "what is it", and the page itself
+  // answers "who is hiring".
+  //
+  // No description lookup: every canonical skill carries a glossary entry (see
+  // skillDescriptions.ts), and a pinned `skills` value IS a canonical facet value, so
+  // the page exists by construction. Reaching for the catalog would cost this page a
+  // dynamic import it has no other reason to make.
+  //
+  // Resolved from the slug, NOT from `collection.params`: by the time params reach here
+  // scopeParams has flattened a list-valued pin to its first value, so a feed about two
+  // skills would be indistinguishable from one about the first of them. skillForCollection
+  // reads the raw registry, where that difference still exists.
+  const glossaryLink = skillForCollection(params.slug) ?? null;
+  return { slug: params.slug, collection, initial, pageNumber, marketLink, glossaryLink };
 };

--- a/web/src/routes/collections/[slug]/+page.svelte
+++ b/web/src/routes/collections/[slug]/+page.svelte
@@ -3,6 +3,7 @@
   import { page } from '$app/state';
   import JobsView from '$lib/components/JobsView.svelte';
   import Seo from '$lib/components/Seo.svelte';
+  import { skillLabel } from '$lib/facets';
   import {
     breadcrumbJsonLd,
     collectionHeading,
@@ -89,6 +90,19 @@
           class="text-brand-strong hover:underline"
         >
           {data.marketLink.label} jobs by country — openings, pay and top skills →
+        </a>
+      </p>
+    {/if}
+    <!-- The definition of what this feed is about, when the feed is one skill. Never
+         rendered alongside marketLink above: each needs the collection to pin exactly
+         one param, and one param cannot be both a category and a skill. -->
+    {#if data.glossaryLink}
+      <p class="mt-3 text-sm">
+        <a
+          href={resolve('/skills/[slug]', { slug: data.glossaryLink })}
+          class="text-brand-strong hover:underline"
+        >
+          What is {skillLabel(data.glossaryLink)}? — the glossary entry →
         </a>
       </p>
     {/if}

--- a/web/src/routes/skills/[slug]/+page.svelte
+++ b/web/src/routes/skills/[slug]/+page.svelte
@@ -3,6 +3,7 @@
   import { page } from '$app/state';
   import JobRow from '$lib/components/JobRow.svelte';
   import Seo from '$lib/components/Seo.svelte';
+  import { collectionForSkill } from '$lib/collections';
   import { breadcrumbJsonLd, definedTermJsonLd, jsonLdScript } from '$lib/seo';
   import { Badge } from '$lib/ui';
   import type { PageData } from './$types';
@@ -18,8 +19,19 @@
   const metaDescription = $derived(
     `${data.description} ${count(data.total)} open ${data.label} jobs on freehire.`,
   );
-  // A query string on a resolve()d base — no dynamic segment for resolve() to fill.
-  const jobsHref = $derived(`${resolve('/jobs')}?skills=${encodeURIComponent(data.slug)}`);
+  // Where "the open X jobs" goes. A collection pinning exactly this skill is the same
+  // set behind a self-canonical URL, so it wins: /jobs?skills=X answers the reader fine
+  // but its own canonical names /jobs, and this page's most-followed link should not
+  // hand a crawler an address the site says is not the address. 45 of the 875 described
+  // skills have one; for the rest the facet URL is the only page there is, and it is a
+  // legitimate live filter.
+  const feed = $derived(collectionForSkill(data.slug));
+  const jobsHref = $derived(
+    feed
+      ? resolve('/collections/[slug]', { slug: feed.slug })
+      : // A query string on a resolve()d base — no dynamic segment for resolve() to fill.
+        `${resolve('/jobs')}?skills=${encodeURIComponent(data.slug)}`,
+  );
 
   const jsonLd = $derived(
     jsonLdScript([
@@ -71,7 +83,7 @@
          fact, and a page that hid it while showing a definition would look like it had
          nothing to say about hiring. -->
     <p class="mt-4 text-sm">
-      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- query-only /jobs filter, no route segment to resolve -->
+      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- jobsHref is resolve()d on the collection branch; the rule cannot see through the variable, and the fallback branch really is a query-only /jobs URL -->
       <a href={jobsHref} class="font-medium underline"
         >{count(data.total)} open {data.label} jobs</a
       >
@@ -103,7 +115,7 @@
         {/each}
       </ul>
       <p class="mt-4 text-sm">
-        <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- query-only /jobs filter, no route segment to resolve -->
+        <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- jobsHref is resolve()d on the collection branch; the rule cannot see through the variable, and the fallback branch really is a query-only /jobs URL -->
         <a href={jobsHref} class="font-medium underline">See all {count(data.total)} →</a>
       </p>
     </section>


### PR DESCRIPTION
## Why

For 45 of the 875 described skills the site publishes **two indexable pages about the same
subject with no link between them.**

`/skills/kotlin` is the glossary entry. `/collections/kotlin` is the feed — self-canonical,
titled "9,374 Kotlin jobs", already in the sitemap. The glossary page's two job links, the
open-count sentence and "See all N →", both pointed at `/jobs?skills=kotlin`, whose canonical is
`https://freehire.me/jobs`. The page's most-followed link handed reader and crawler an address
the site itself says is not the address, while the page built for exactly that set sat one slug
away. The collection did not link back either. Verified on prod for `kotlin`, `terraform`,
`kubernetes` and `python`.

The glossary spec already holds the principle: *"Every link the glossary publishes is held to the
same rule — the neighbouring-skills block links only to skills that have a page."* A link to a
canonicalized-away URL is that failure in a quieter form.

## What

`collectionForSkill` maps a skill to the collection pinning exactly that skill;
`skillForCollection` is its inverse for the landing page. Both sit beside the existing
`collectionForCategory`, which links `/roles/[category]` to its feed the same way — this is the
third side of a division those pages already keep: *who is hiring* (collection), *where are they
and what do they pay* (role landing), *what is it* (glossary).

| | Count |
|---|---:|
| Described skills | 875 |
| …whose collection pins **only** that skill → now cross-linked | **45** |
| …whose slug matches a collection pinning something else → deliberately not linked | 4 |
| …with no collection → unchanged | 830 |

## Two guards, both load-bearing

**Not by slug.** `data-science`, `data-engineering`, `devops` and `machine-learning` each name
both a skill and a collection — and each of those collections pins a **category**.
`/collections/devops` is everything the classifier filed under DevOps; `skills=devops` is
everything that names DevOps as a skill. A slug match passes every other test and gets all four
of these wrong; there is a test named after exactly that.

**Not from `ResolvedCollection.params`.** This one was found during implementation and changed the
design. By the time params reach a landing page's load, `scopeParams` has flattened a list-valued
pin **to its first value** — so a `{ skills: ['go', 'rust'] }` feed would arrive
indistinguishable from `{ skills: 'go' }` and earn a link to a glossary entry it is not about.
`skillForCollection` reads the raw registry, the only place that difference survives.
(`marketLink` beside it has the same latent hole, unbitten only because no category pin is a
list. Noted in the design rather than fixed by a drive-by edit.)

## Not in this PR

- **The 830 skills with no collection.** They keep `/jobs?skills=<slug>`. There is no indexable
  page for those sets, and the facet URL is a legitimate live filter whose canonical is correct.
- **Retitling the glossary.** An audit finding proposed leading `/skills/python` with its job
  count. That is already `/collections/python`'s title word for word — adopting it would pit two
  of the site's own pages against one query. The finding did not survive the codebase and this
  PR replaces it.

## Verification

1,805 web unit tests pass across 155 files; `pnpm run lint` exits 0; `pnpm run check` reports 0
errors. The new tests were confirmed to fail before the helpers existed.

Rendered against a dev server proxying the prod API and checked in the live DOM:
`/skills/kotlin` renders both links pointing at `/collections/kotlin`; `/collections/kotlin`
renders "What is Kotlin? — the glossary entry →" pointing back; `/skills/data-science` still
points at `/jobs?skills=data-science` and `/collections/devops` carries no glossary link;
`/skills/sinatra` is unchanged. Screenshotted both pages — the new link sits under the
description styled like the `marketLink` beside it, and the skill page is visually identical
(only its hrefs moved).

Spec: `openspec/changes/link-skill-glossary-to-collections/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skill glossary pages now link to their matching curated collection when available.
  * Collection pages now link back to the corresponding skill glossary entry.
  * Skills without a matching collection continue linking to filtered job results.
  * Links are limited to collections representing exactly one skill, avoiding category and multi-skill collection mismatches.

* **Tests**
  * Added coverage for valid skill collections and excluded collection types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->