### PR TITLE
Stop counting Greenhouse's hidden validation inputs as questions

### DIFF
--- a/internal/api/atsapply/domscan.go
+++ b/internal/api/atsapply/domscan.go
@@ -67,6 +67,26 @@ func scanControls(form *html.Node) []DOMField {
 	var walk func(*html.Node)
 	walk = func(n *html.Node) {
 		if n.Type == html.ElementNode {
+			// A subtree the page has explicitly hidden from assistive technology holds
+			// nothing a candidate is being asked. Greenhouse's own form components pair
+			// each custom widget with a `required` proxy input marked this way, so the
+			// browser's native validation fires for a control that is not a native form
+			// control; the widget writes the real answer through to it.
+			//
+			// Counting those as questions is not cosmetic. They carry no id and no name,
+			// so they can never reconcile against the platform's schema, never carry a
+			// label, and never resolve from a candidate's answers — they sat in
+			// Plan.Unmapped permanently, which showed the candidate blank lines where
+			// questions should be and kept Plan.FullyResolved() false forever. A vanilla
+			// Greenhouse posting rendered four, so no such attempt could ever have been
+			// submitted, however complete the profile (freehire, 2026-09-08).
+			//
+			// The whole subtree is skipped, not just this node: aria-hidden hides what is
+			// inside it too, and a wrapper carrying it means every control below is a
+			// widget's plumbing rather than its question.
+			if attr(n, "aria-hidden") == "true" {
+				return
+			}
 			switch n.Data {
 			case "input":
 				scanInput(n, &order, groups)

--- a/internal/api/atsapply/domscan_test.go
+++ b/internal/api/atsapply/domscan_test.go
@@ -143,3 +143,44 @@ func TestScanGreenhouseForm_ATextareaWithNoIDOrNameIsStillScanned(t *testing.T) 
 		t.Fatalf("fields = %d, want the id-less/name-less textarea recorded, not dropped", len(fields))
 	}
 }
+
+// The four controls a live vanilla Greenhouse posting renders that are not questions at
+// all, reproduced verbatim from the DOM of garnerhealth/jobs/6181651004 (2026-09-08).
+//
+// Greenhouse's own form components pair each custom widget — a combobox, a file picker —
+// with a hidden proxy input carrying `required`, so the browser's native form validation
+// fires for a control that is not a native form control. The candidate never sees it, can
+// never tab to it (tabindex="-1"), and assistive technology is explicitly told to ignore it
+// (aria-hidden="true"). The widget writes through to it once a real answer is chosen.
+const greenhouseRequiredProxyInputsHTML = `
+<form id="application-form">
+  <input id="first_name" name="first_name" type="text" required>
+  <div class="select">
+    <input required="" tabindex="-1" aria-hidden="true" class="remix-css-1a0ro4n-requiredInput" value="">
+  </div>
+  <div class="select">
+    <input required="" tabindex="-1" aria-hidden="true" class="remix-css-1a0ro4n-requiredInput" value="">
+  </div>
+</form>
+`
+
+// A proxy input is not a question, and counting it as one is not a cosmetic fault.
+//
+// It has no id and no name, so it can never be reconciled against the platform's own
+// schema, can never carry a label, and can never be resolved from a candidate's answers.
+// It therefore lands in Plan.Unmapped permanently: the answer preview shows a blank line
+// where a question should be, and Plan.FullyResolved() can never return true — so an
+// attempt on a vanilla Greenhouse posting could never be submitted no matter how complete
+// the candidate's profile was. Production carried four of these on every posting.
+func TestScanGreenhouseForm_SkipsAriaHiddenRequiredProxyInputs(t *testing.T) {
+	fields, err := ScanGreenhouseForm(greenhouseRequiredProxyInputsHTML)
+	if err != nil {
+		t.Fatalf("ScanGreenhouseForm: %v", err)
+	}
+	if len(fields) != 1 {
+		t.Fatalf("scanned %d fields, want 1 — the real input alone: %+v", len(fields), fields)
+	}
+	if fields[0].ID != "first_name" {
+		t.Errorf("scanned field = %+v, want the real first_name input", fields[0])
+	}
+}


### PR DESCRIPTION
A vanilla Greenhouse posting renders four controls that are not questions:

```html
<input required tabindex="-1" aria-hidden="true"
       class="remix-css-1a0ro4n-requiredInput" value="">
```

Greenhouse's own form components pair each custom widget — a combobox, a file picker — with one of these, so the browser's native form validation fires for a control that is not a native form control. The candidate never sees it, cannot tab to it, and assistive technology is told to ignore it. The widget writes the real answer through to it.

The scan counted all four as required fields. They carry no id and no name, so they can never reconcile against the platform's schema, never carry a label, and never resolve from a candidate's answers. Every one landed in `Plan.Unmapped` and stayed there.

## Two consequences

**The preview shows blank lines.** Production entry 3's stored preview has seven pending questions, and four read:

```json
{ "label": "", "will_draft_at_submission": false }
```

The candidate is shown nothing at all and asked to act on it.

**And `Plan.FullyResolved()` could never return true.** No attempt on a vanilla Greenhouse posting could ever have been submitted, however complete the candidate's profile — the four unanswerable "questions" outlive every answer they could give. Greenhouse is the only provider `fillProviders` covers, so this alone made the feature unable to submit anything.

## The fix

Skip a subtree the page has explicitly hidden from assistive technology. The whole subtree, not just the node: `aria-hidden` hides what is inside it too, so a wrapper carrying it means every control below is a widget's plumbing rather than its question.

## Verification

Replayed `ScanGreenhouseForm` over the live rendered DOM of `garnerhealth/jobs/6181651004` on the production host:

```
fields=20 nameless=0
```

The same page previously yielded four id-less, name-less required fields. The fixture in the test is those four inputs verbatim from that DOM.

`go test ./...`, `go vet -tags=integration ./...`, `gofmt`, `golangci-lint` — clean.

## Note for whoever reads the inventory next

With the proxy inputs gone, the DOM reports `required` on **nothing at all** — Greenhouse relies on them for it. That is what `Reconcile`'s union with the API schema is for, and `DOMField.Required`'s own comment already documents the gap; this change widens it from frequent to total for this provider.