### PR TITLE
Stop an autopilot run that has no requirement list from running anyway

### DIFF
--- a/internal/api/handler/assistant.go
+++ b/internal/api/handler/assistant.go
@@ -967,7 +967,18 @@ func (h *assistantHandlers) PostAssistantAutopilot(c *fiber.Ctx) error {
 //
 // analysis may be nil (no match surface wired) — every method on it is a no-op then.
 func (h *assistantHandlers) runAutopilotToCompletion(ctx context.Context, analysis *autopilotAnalysis, sess assistant.Session, jobDescription string, runner *assistant.Runner, reg *assistant.Registry, system string, emit func(assistant.Event)) error {
-	analysis.ensure(ctx)
+	// A run with no requirement list is not a cheaper run, it is a different one: the brief
+	// is "go through every requirement", cv_context answers that there are none, and the
+	// agent improvises a turn's worth of edits against nothing. Measured on production
+	// 2026-08-25..09-08, 36% of runs went out that way and nothing said so.
+	//
+	// Refusing costs the candidate a run they asked for. Proceeding costs them their
+	// document, edited against a vacancy nobody read — and undoing that is their work, not
+	// ours. So this stops, and says why on the stream the client is already reading.
+	if err := analysis.ensure(ctx); err != nil {
+		log.Printf("assistant: autopilot has no requirement list, session %s: %v", sess.ID, err)
+		return h.refuseAutopilotWithoutAPlan(emit)
+	}
 	h.cv.logSurfaceAlign(ctx, sess.UserID, *sess.CVID, jobDescription)
 	h.layDownRunPlan(ctx, sess)
 
@@ -979,6 +990,31 @@ func (h *assistantHandlers) runAutopilotToCompletion(ctx context.Context, analys
 	analysis.refresh(context.WithoutCancel(ctx))
 	return err
 }
+
+// refuseAutopilotWithoutAPlan ends the run before it starts, on the stream the client is
+// already reading.
+//
+// Both frames are load-bearing. The text is what the candidate sees — a run that stopped
+// with no explanation is indistinguishable from one that ran and found nothing to do. The
+// terminal result is what the CLIENT needs: the web app only calls endTurn() on a `result`,
+// so a stream that simply closes leaves the session believing a turn is still in flight and
+// queues every later message behind one that is over (see Runner.Run's own note on this).
+//
+// It returns an error so the caller logs and reports it, exactly as a failed turn does.
+func (h *assistantHandlers) refuseAutopilotWithoutAPlan(emit func(assistant.Event)) error {
+	emit(assistant.Event{
+		Kind: assistant.EventAssistantText,
+		Text: "I could not read this vacancy's requirements — the fit analysis did not " +
+			"complete, so there was nothing for the run to work through. Your CV is " +
+			"untouched. Try again in a moment.",
+	})
+	emit(assistant.Event{Kind: assistant.EventResult, StopReason: assistant.StopError, IsError: true})
+	return errNoRequirementList
+}
+
+// errNoRequirementList marks a run refused for want of a fit analysis. Distinct from the
+// chain's own error: what stopped the run is the ABSENCE of a plan, whatever produced it.
+var errNoRequirementList = errors.New("autopilot: no requirement list to walk")
 
 // prepareAutopilotAnalysis delegates to matchHandlers.prepareAutopilotRun, which assembles
 // both halves of the run's fit analysis — the fill that gives cv_context something to read,

--- a/internal/api/handler/assistant_autopilot_integration_test.go
+++ b/internal/api/handler/assistant_autopilot_integration_test.go
@@ -912,3 +912,88 @@ func seedFitAnalysis(t *testing.T, pool *pgxpool.Pool, userID int64, cvID uuid.U
 		t.Fatalf("seed analysis: %v", err)
 	}
 }
+
+// brokenFitModel fails every call, the way a stage that blows its deadline does.
+type brokenFitModel struct{ n int }
+
+func (m *brokenFitModel) GenerateContent(context.Context, []llms.MessageContent, ...llms.CallOption) (*llms.ContentResponse, error) {
+	m.n++
+	return nil, errors.New("stage timed out")
+}
+func (*brokenFitModel) Call(context.Context, string, ...llms.CallOption) (string, error) {
+	return "", nil
+}
+
+// countingTurnModel answers like walkedTheRequirements and records whether it was called at
+// all — a run that must not start is a run whose turn model never sees a request.
+type countingTurnModel struct {
+	turnModel
+	calls int
+}
+
+func (m *countingTurnModel) Chat(ctx context.Context, msgs []llms.MessageContent, tools []llms.Tool, s llm.ChatStream) (*llms.ContentChoice, error) {
+	m.calls++
+	return m.turnModel.Chat(ctx, msgs, tools, s)
+}
+
+// An autopilot run whose pre-run fit analysis produced nothing must REFUSE, not proceed.
+//
+// The run's whole brief is to walk the vacancy's requirements, and that list comes from the
+// analysis. Without one the run has no plan: cv_context answers "no analysis has been run for
+// this job", the agent improvises, and it still spends a turn's worth of tokens editing the
+// candidate's CV against nothing. Measured on prod 2026-08-25..09-08: 57 of 159 runs, 36%,
+// went out this way, and nothing anywhere said so — `ensure` discarded Ensure's outcome and
+// the run proceeded regardless.
+//
+// The refusal must reach the client as a terminal frame. The stream is already open by the
+// time this runs (opening it first is what stopped a proxy cutting cold-start runs), and a
+// stream that ends with no `result` leaves the session believing a turn is still in flight.
+func TestAutopilotRefusesToRunWithoutItsRequirementList(t *testing.T) {
+	pool := startPostgres(t)
+	queries := db.New(pool)
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	turnM := &countingTurnModel{turnModel: turnModel{replies: []*llms.ContentChoice{{Content: "Walked the requirements."}}}}
+	fitM := &brokenFitModel{}
+	h, app := newAutopilotHarness(t, pool, iss, turnM, fitM)
+
+	userID, cookie := assistantUser(t, pool, iss, "autopilot-no-plan@example.test", true)
+	seedBankedCareer(t, queries, userID)
+	sessionID, cvID := seedTailoringSession(t, pool, h, userID)
+
+	resp := assistantRequest(t, app, fiber.MethodPost,
+		"/api/v1/assistant/sessions/"+sessionID+"/autopilot", cookie, nil)
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("autopilot: status %d, want 200 — the stream is already open", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read stream: %v", err)
+	}
+	stream := string(body)
+
+	if fitM.n == 0 {
+		t.Fatal("the fit chain was never attempted; this test is not exercising the fill")
+	}
+	if turnM.calls != 0 {
+		t.Errorf("the turn model was called %d times; a run with no requirement list must not start", turnM.calls)
+	}
+	// A terminal frame, or the session stays "turn in flight" and queues every later message
+	// behind a turn that is over.
+	if !strings.Contains(stream, "event: result") {
+		t.Errorf("stream carries no terminal result:\n%s", stream)
+	}
+	// And a reason the candidate can act on, rather than a run that silently did nothing.
+	if !strings.Contains(stream, "fit analysis") {
+		t.Errorf("stream does not say why the run did not start:\n%s", stream)
+	}
+
+	// The CV is untouched: refusing costs the candidate a run, editing their document
+	// against nothing costs them the document.
+	rec, err := h.cv.cvStore.Get(context.Background(), cvID, userID)
+	if err != nil {
+		t.Fatalf("get cv: %v", err)
+	}
+	if rec.Document.Summary != "before the run" {
+		t.Errorf("summary = %q, want the document untouched", rec.Document.Summary)
+	}
+}

--- a/internal/api/handler/assistant_autopilot_integration_test.go
+++ b/internal/api/handler/assistant_autopilot_integration_test.go
@@ -969,6 +969,7 @@ func TestAutopilotRefusesToRunWithoutItsRequirementList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read stream: %v", err)
 	}
+	_ = resp.Body.Close()
 	stream := string(body)
 
 	if fitM.n == 0 {

--- a/internal/api/handler/match_analysis.go
+++ b/internal/api/handler/match_analysis.go
@@ -368,16 +368,20 @@ func (h *matchHandlers) prepareAutopilotRun(c *fiber.Ctx, userID int64, job db.J
 }
 
 // ensure fills the cache before a cold-start autopilot run, whose first tool call reads it
-// and errors without one. Coalesced, best-effort, and never charged — the rules are
+// and errors without one. Coalesced and never charged — the rules are
 // fitanalysis.Service.Ensure's; the claim is taken here because it is per attempt, not per
 // prepared run.
-func (a *autopilotAnalysis) ensure(ctx context.Context) {
+//
+// It REPORTS the outcome. A nil analysis means the deployment has no match surface at all,
+// which is a shape rather than a failure — the fixtures run that way — so it reports nothing
+// missing and leaves the caller free to proceed.
+func (a *autopilotAnalysis) ensure(ctx context.Context) error {
 	if a == nil {
-		return
+		return nil
 	}
 	req := a.req
 	req.Claim = a.fit.Claim(req.UserID, req.Job.ID)
-	a.fit.Ensure(ctx, req)
+	return a.fit.Ensure(ctx, req)
 }
 
 // refresh recomputes the analysis after the run, unconditionally — see

--- a/internal/candidate/fitanalysis/fitanalysis.go
+++ b/internal/candidate/fitanalysis/fitanalysis.go
@@ -338,20 +338,30 @@ func (s *Service) Follow(ctx context.Context, r Request) (*matchanalysis.Analysi
 // this is what lets that run start without requiring the candidate to have produced an
 // analysis first.
 //
-// Best-effort and silent: a lookup or compute failure (no LLM configured, an analyzer error)
-// is logged and left uncached, exactly as the on-demand run already degrades. It never
-// charges — this path is unmetered, tracked only by the same LLM spend attribution every call
-// already carries (see the tailor-coldstart-autopilot design's "no new metering" decision) —
-// so r.Chargeable is ignored here rather than trusted.
+// It REPORTS whether the caller ended up with an analysis, and that is the point. The fill
+// used to be best-effort and silent, so an autopilot run whose chain failed proceeded with no
+// requirement list at all: measured on production 2026-08-25..09-08, 57 of 159 runs — 36% —
+// went out that way, spending a turn's tokens editing a CV against nothing while cv_context
+// answered "no analysis has been run for this job". Nothing anywhere said so.
+//
+// It never charges — this path is unmetered, tracked only by the same LLM spend attribution
+// every call already carries (see the tailor-coldstart-autopilot design's "no new metering"
+// decision) — so r.Chargeable is ignored here rather than trusted.
 //
 // r.Claim decides the coalescing: the tailoring workspace's visible stream starts at the same
-// cold start this runs at, so both routinely race for the identical pair. A follower waits and
-// returns without touching the LLM; whether the leader actually cached anything is not this
-// function's concern, exactly as before the coalescing existed.
-func (s *Service) Ensure(ctx context.Context, r Request) {
+// cold start this runs at, so both routinely race for the identical pair. A follower waits
+// and then reads the cache like anyone else — the leader's outcome IS this function's concern
+// now, because a follower that reported success on a failed leader would hand the run the
+// same empty plan by a quieter route.
+//
+// The answer is taken from the CACHE rather than from which branch ran, so leader, follower,
+// cache hit and unconfigured analyzer are all answered by one question: is there a row to
+// walk? A path analysis would have to be kept in step with every future branch; this cannot
+// drift.
+func (s *Service) Ensure(ctx context.Context, r Request) error {
 	if !r.Claim.IsLeader() {
 		r.Claim.wait()
-		return
+		return s.cachedAnalysisPresent(ctx, r)
 	}
 	succeeded := false
 	defer func() {
@@ -367,13 +377,32 @@ func (s *Service) Ensure(ctx context.Context, r Request) {
 	if _, err := s.store.GetUserJobAnalysis(ctx,
 		db.GetUserJobAnalysisParams{UserID: r.UserID, JobID: r.Job.ID}); err == nil {
 		succeeded = true // already cached — nothing to compute, and a good row for a follower to read
-		return
+		return nil
 	} else if !errors.Is(err, pgx.ErrNoRows) {
 		log.Printf("matchanalysis: checking cache before an autopilot run, user %d job %d: %v",
 			r.UserID, r.Job.ID, err)
-		return
+		return fmt.Errorf("%w: reading the cache: %w", ErrNoAnalysis, err)
 	}
 	succeeded = s.compute(ctx, r, "inline compute before an autopilot run")
+	if !succeeded {
+		return ErrNoAnalysis
+	}
+	return nil
+}
+
+// cachedAnalysisPresent answers whether a row a run can walk is in the cache now. It is what
+// a follower asks after its leader has finished, and it deliberately asks the STORE rather
+// than the leader: the leader reports through the claim only that it is done.
+func (s *Service) cachedAnalysisPresent(ctx context.Context, r Request) error {
+	_, err := s.store.GetUserJobAnalysis(ctx,
+		db.GetUserJobAnalysisParams{UserID: r.UserID, JobID: r.Job.ID})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrNoAnalysis
+	}
+	if err != nil {
+		return fmt.Errorf("%w: reading the cache: %w", ErrNoAnalysis, err)
+	}
+	return nil
 }
 
 // Refresh UNCONDITIONALLY recomputes the chain and overwrites the cache, even when nothing was


### PR DESCRIPTION
Measured on production, 2026-08-25..09-08: **57 of 159 autopilot runs — 36%** — had `cv_context` answer "no analysis has been run for this job" on their FIRST tool call. The run went ahead regardless: a turn's worth of tokens spent editing the candidate's CV against a vacancy whose requirements nobody had read, and nothing anywhere said so.

The autopilot's whole brief is *"go through every requirement without stopping to ask me"*. Without an analysis there are no requirements, so the agent improvises. A run with no plan was indistinguishable from a run with one — to the code, to the candidate, and to the tailoring report.

## Root cause

`ensure` discarded `Ensure`'s outcome, `Ensure` returned nothing, and `runAutopilotToCompletion` proceeded on any outcome. The fill was best-effort by contract and its failure was invisible by construction.

`Ensure` now reports whether the caller ended up with an analysis, and it answers **from the cache** rather than from which branch ran — leader, follower, cache hit and unconfigured analyzer are all one question: is there a row to walk? A path analysis would need keeping in step with every future branch; this cannot drift.

The follower path changes with it: it used to wait for its leader and report nothing, so a failed leader handed the run the same empty plan by a quieter route.

## What was ruled out first

Four hypotheses died against the data before this one survived, and two of them looked right:

| hypothesis | verdict |
|---|---|
| empty experience bank (the chain refuses a candidate with no history) | 3 of 47 |
| a race with the post-run refresh | 10 of 57 |
| something deleting the row | nothing deletes it |
| a per-user property — 29 users with zero successful analyses | **selection bias** |

The last one is worth naming: those users were selected *for having failed*, and most had run exactly once, so zero successes was arithmetic rather than evidence. Users with 120 successful analyses also go blind. The failure is per **attempt**, at the base rate.

Why the chain fails on an attempt is a separate, already-documented problem (stage deadlines — see `matchanalysis/reasoning.go`). This change does not touch it. It stops the failure being silent.

## The refusal

Two frames, both load-bearing. The text is what the candidate reads — a run that stopped with no explanation is indistinguishable from one that ran and found nothing to do. The terminal `result` is what the CLIENT needs: the web app calls `endTurn()` only on one, so a stream that simply closes leaves the session believing a turn is in flight and queues every later message behind a turn that is over — the trap `Runner.Run` already documents.

Refusing costs the candidate a run they asked for. Proceeding costs them their document, edited against a vacancy nobody read, and undoing that is their work rather than ours.

The synchronous auto-apply route shares `runAutopilotToCompletion` and already logs and returns the cause, so the same refusal reaches Sentry through `reportStreamFault` — which makes the 36% visible for the first time.