### PR TITLE
Dock the Experience assistant panel on the right edge

### DIFF
--- a/web/src/lib/assistantDock.svelte.ts
+++ b/web/src/lib/assistantDock.svelte.ts
@@ -30,13 +30,13 @@ export const DOCKED_QUERY = '(min-width: 85rem)';
 
 let offset = $state(0);
 
-/** The width the shell must yield on its left, or 0 when nothing is docked. */
+/** The width the shell must yield on its right, or 0 when nothing is docked. */
 export function dockOffset(): number {
   return offset;
 }
 
 /**
- * Claim or release the shell's left margin. Called by the panel, which owns the media
+ * Claim or release the shell's right margin. Called by the panel, which owns the media
  * query and knows whether it is currently a dock or a covering overlay — an overlay takes
  * no space, so it must not move the page behind it.
  */

--- a/web/src/lib/components/ExperienceAssistantPanel.svelte
+++ b/web/src/lib/components/ExperienceAssistantPanel.svelte
@@ -97,7 +97,7 @@
       // used to be a column inside the account content area, which meant it spent the
       // bank's width — the conversation and the achievements it is about were both cramped.
       // Below the header, like the selection action bar, and under it in the stack.
-      docked ? 'fixed bottom-0 left-0 top-14 z-30' : 'fixed inset-0 z-50',
+      docked ? 'fixed bottom-0 right-0 top-14 z-30' : 'fixed inset-0 z-50',
       !open && 'hidden',
     ]}
     style:width={docked ? `${DOCK_WIDTH}px` : undefined}
@@ -111,7 +111,7 @@
         // Flush against the viewport edge now, so it is a wall rather than a card: one
         // border on the side that meets the page, and no rounding on edges that touch
         // nothing.
-        docked && 'border-r border-border',
+        docked && 'border-l border-border',
         !docked && 'bg-background',
       ]}
     >

--- a/web/src/routes/my/+layout.svelte
+++ b/web/src/routes/my/+layout.svelte
@@ -37,7 +37,7 @@
     if (browser) localStorage.setItem('hire.myNavCollapsed', collapsed ? '1' : '0');
   }
 
-  // A docked assistant takes 360px off the left of the page. Collapsing the nav for its
+  // A docked assistant takes 360px off the right of the page. Collapsing the nav for its
   // duration buys back 168 of them, which is the difference between the bank keeping the
   // width it had and losing a fifth of it — see DOCKED_QUERY for the arithmetic.
   //
@@ -79,12 +79,12 @@
   <meta name="robots" content="noindex" />
 </svelte:head>
 
-<!-- The docked assistant is fixed to the viewport's left edge, so the shell steps aside
+<!-- The docked assistant is fixed to the viewport's right edge, so the shell steps aside
      rather than sharing its width with it. Padding on a wrapper, not a margin on the shell
      itself, so `mx-auto` keeps centring the content within whatever is left. -->
 <div
-  class="transition-[padding-left] duration-200 motion-reduce:transition-none"
-  style:padding-left={dockOffset() ? `${dockOffset()}px` : undefined}
+  class="transition-[padding-right] duration-200 motion-reduce:transition-none"
+  style:padding-right={dockOffset() ? `${dockOffset()}px` : undefined}
 >
   <div class="mx-auto w-full max-w-6xl px-4 py-6">
     <!-- No signed-out branch here: +layout.server.ts redirects an anonymous visitor to


### PR DESCRIPTION
## Summary
- The docked "Experience assistant" panel on `/my/profile/experience` was pinned to the viewport's left edge; flips it to the right edge instead.
- Swaps in lockstep: fixed-position side, the wall border side, the shell's reserved padding property, and every explanatory comment referencing "left".

## Test plan
- [x] `eslint` on the three changed files — clean
- [x] `svelte-check` — 0 errors (pre-existing unrelated warnings only)
- [x] Verified real computed layout via a headless-browser check against the actual compiled Tailwind classes: panel flush against the right viewport edge at the fixed 360px dock width, border on the panel's left side, shell reserving space via `padding-right`
- [ ] Not verified against a live authenticated session (no backend running locally) — the change is pure CSS positioning with no data dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)