### PR TITLE
Tell the candidate when a tailoring run gave up

### DIFF
--- a/internal/api/handler/auto_apply_review_info.go
+++ b/internal/api/handler/auto_apply_review_info.go
@@ -36,6 +36,10 @@ func autoApplyReviewInfoForJob(ctx context.Context, queries *db.Queries, userID,
 		// there would read as "tailoring" forever, with nothing telling the candidate
 		// anything went wrong.
 		Failed: row.FailedAt.Valid || row.PreviewFailedAt.Valid,
+		// Distinct from Failed: a tailoring run that never produced a CV (tailor_failed_at,
+		// migration 0154). Folding it into Failed would tell the candidate the submission
+		// gave up, which is a different — and, since there is no CV, a wrong — story.
+		TailorFailed: row.TailorFailedAt.Valid,
 	}
 	if len(row.Unmapped) > 0 {
 		if err := json.Unmarshal(row.Unmapped, &attempt.Unmapped); err != nil {

--- a/internal/api/handler/auto_apply_tailor.go
+++ b/internal/api/handler/auto_apply_tailor.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/ai/assistant"
@@ -205,6 +206,7 @@ func (h *assistantHandlers) PostAutoApplyTailor(c *fiber.Ctx) error {
 
 	if err := h.runAutopilotToCompletion(ctx, analysis, sess, job.Description, runner, reg, system, noop); err != nil {
 		log.Printf("auto-apply: tailoring run for queue entry %d (cv %s): %v", queueID, tailored.ID, err)
+		h.recordTailoringFailure(c, queueID, err)
 		// The CAUSE, not fiber.NewError(500, "the tailoring run failed"): the streamed
 		// autopilot reports this same error to Sentry (reportStreamFault in
 		// assistant.go), and phrasing it here took the synchronous route's copy out of
@@ -241,6 +243,57 @@ func (h *assistantHandlers) PostAutoApplyTailor(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"data": autoApplyTailorResponse{
 		TailoredCVID: tailored.ID.String(), AutopilotReport: rec.AutopilotReport,
 	}})
+}
+
+// autoApplyTailorFailedNotification is the notification kind for a tailoring run that gave
+// up. Its own kind rather than reusing autoApplyReadyForReviewNotification's: the two say
+// opposite things, and the notification centre groups by this.
+const autoApplyTailorFailedNotification = "auto_apply_tailoring_failed"
+
+// recordTailoringFailure marks an entry whose run produced no CV, and tells the candidate.
+//
+// Best-effort throughout, and deliberately so: the caller is already returning the run's
+// own failure, and nothing here is worth turning that into a different one. What it must
+// not do is fail silently in the ONE way that matters — leaving the entry looking like work
+// still in progress, which is exactly the state this exists to end.
+//
+// It runs on a context detached from the request's. This is called precisely when a run has
+// ended badly, and the most common way for that to happen is the caller giving up first —
+// so the request's own context is usually already dead, and a write on it would be dropped
+// at the moment it is most needed. The same reason runAutopilotToCompletion's own analysis
+// refresh is detached.
+//
+// The error text is stored as the diagnostic it is, never shown to the candidate:
+// ResolvedAttempt has no field to carry it for exactly that reason. What they see is the
+// status and the notification below.
+func (h *assistantHandlers) recordTailoringFailure(c *fiber.Ctx, queueID int64, cause error) {
+	ctx := context.WithoutCancel(c.Context())
+
+	row, err := h.queries.MarkAutoApplyTailorFailed(ctx, db.MarkAutoApplyTailorFailedParams{
+		ID: queueID, LastError: cause.Error(),
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// A guard fired: the entry already has a tailored CV from an earlier run, or
+			// the candidate has already decided on it. Both mean there is nothing to
+			// report — see MarkAutoApplyTailorFailed's own comment.
+			return
+		}
+		log.Printf("auto-apply: recording the tailoring failure for queue entry %d: %v", queueID, err)
+		return
+	}
+
+	if _, err := h.queries.RecordNotification(ctx, db.RecordNotificationParams{
+		UserID: row.UserID,
+		Kind:   autoApplyTailorFailedNotification,
+		Title:  "We couldn't prepare your application",
+		Body: fmt.Sprintf("Tailoring your CV for %s at %s didn't finish. Nothing was sent, and the job is still on your board.",
+			row.Title, row.Company),
+		PublicSlug: pgtype.Text{String: row.PublicSlug, Valid: true},
+	}); err != nil {
+		// Best-effort, the same convention every other RecordNotification call follows.
+		log.Printf("auto-apply: notifying the tailoring failure for queue entry %d: %v", queueID, err)
+	}
 }
 
 // autoApplyReviewRequest is the candidate's decision on one queue entry's tailored CV.

--- a/internal/api/handler/auto_apply_tailor_integration_test.go
+++ b/internal/api/handler/auto_apply_tailor_integration_test.go
@@ -542,3 +542,52 @@ func TestPostAutoApplyTailor_ASpentBudgetStillRecordsTheTailoredCV(t *testing.T)
 		t.Fatal("tailored_cv_id is still NULL — the entry cannot move on, and reads as 'tailoring' forever")
 	}
 }
+
+// A tailoring run that fails for a real reason says so, instead of leaving the entry
+// looking like one still being worked on.
+//
+// This is the fault the candidate actually reported: an entry whose run had died recorded
+// nothing at all, so DeriveStatus fell through to StatusTailoring and the tracker kept
+// saying "Auto-apply is preparing a tailored CV for this job" — for over a day, about work
+// nobody was doing, with no notification either.
+func TestPostAutoApplyTailor_AFailedRunIsRecordedAndNotified(t *testing.T) {
+	pool := startPostgres(t)
+	truncateAutoApplyTailorTables(t, pool)
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	app, _ := newAutoApplyTailorApp(pool, iss, failingTurnModel{})
+
+	userID, cookie := autoApplyTailorUser(t, pool, iss, "tailorfail@example.test")
+	insertBaseCV(t, pool, userID)
+	job := insertAutoApplyJob(t, pool, "tailor-fail")
+	queueID := insertAutoApplyQueueRow(t, pool, userID, job)
+
+	resp := autoApplyRequest(t, app, fiber.MethodPost,
+		"/api/v1/me/auto-apply/"+strconv.FormatInt(queueID, 10)+"/tailor", cookie, nil)
+	defer resp.Body.Close()
+	if resp.StatusCode == fiber.StatusOK {
+		t.Fatalf("status = %d, want a failure — the run could not be done", resp.StatusCode)
+	}
+
+	var failedAt *time.Time
+	var lastError string
+	if err := pool.QueryRow(context.Background(),
+		"SELECT tailor_failed_at, last_error FROM auto_apply_queue WHERE id = $1", queueID).
+		Scan(&failedAt, &lastError); err != nil {
+		t.Fatalf("read the entry back: %v", err)
+	}
+	if failedAt == nil {
+		t.Error("tailor_failed_at is NULL — the entry still reads as one being prepared")
+	}
+	if lastError == "" {
+		t.Error("last_error is empty — nothing records why the run gave up")
+	}
+
+	var notifKind string
+	if err := pool.QueryRow(context.Background(),
+		"SELECT kind FROM user_notifications WHERE user_id = $1", userID).Scan(&notifKind); err != nil {
+		t.Fatalf("the candidate was told nothing: %v", err)
+	}
+	if notifKind != autoApplyTailorFailedNotification {
+		t.Errorf("notification kind = %q, want %q", notifKind, autoApplyTailorFailedNotification)
+	}
+}

--- a/internal/api/handler/me_tracking.go
+++ b/internal/api/handler/me_tracking.go
@@ -48,7 +48,7 @@ type myJobResponse struct {
 	// FollowedUpAt it sits beside the silence fields and not inside them: a recruiter reading a CV
 	// is not a reply, and the card shows both — still unanswered, and read yesterday.
 	CVOpenedAt *time.Time `json:"cv_opened_at"`
-	// AutoApplyStatus is the six-value status of this job's live auto-apply attempt, null
+	// AutoApplyStatus is the seven-value status of this job's live auto-apply attempt, null
 	// when it has none (openspec/changes/auto-apply-review-tracking) — the board card's own
 	// "needs your review" badge. The full answer preview lives in the drawer's own read
 	// (GET /me/tracking/:slug), not here.

--- a/internal/application/autoapply/status.go
+++ b/internal/application/autoapply/status.go
@@ -1,6 +1,6 @@
 package autoapply
 
-// Status is the six-value candidate-facing status for a live auto-apply attempt, richer
+// Status is the seven-value candidate-facing status for a live auto-apply attempt, richer
 // than the job-detail overlay's own three-value derivation (which has its own consumers
 // and its own reasons — see internal/api/handler's autoApplyEntryStatus doc comment — and
 // is left untouched by this).
@@ -24,25 +24,58 @@ const (
 	StatusDeclined Status = "declined"
 	// StatusFailed means an unattended submission attempt exhausted its retries.
 	StatusFailed Status = "failed"
+	// StatusTailorFailed means the tailoring run itself did not produce a CV — distinct
+	// from StatusFailed, which is a SUBMISSION that gave up with a tailored CV in hand.
+	// The two are different things to be told: one attempt has a CV the candidate can
+	// look at, the other has nothing at all.
+	//
+	// Before it existed, a failed tailoring run recorded nothing, so the derivation below
+	// fell through to StatusTailoring and the candidate was told preparation was under way
+	// — indefinitely, about work nobody was doing (freehire, 2026-09-08: three entries,
+	// one of them for over a day).
+	StatusTailorFailed Status = "tailor_failed"
 )
 
-// DeriveStatus derives the six-value status from an attempt's own raw state. Mirrors
+// DerivedFrom is an attempt's own raw state, as DeriveStatus reads it.
+//
+// A struct rather than the positional parameters this replaces: they were five in a row,
+// four of them bool, and a caller had no way to be wrong loudly — the state that made this
+// type worth having would have been the sixth.
+type DerivedFrom struct {
+	HasTailoredCV      bool
+	HasResolvedPreview bool
+	ReviewDecision     string
+	Blocked            bool
+	Failed             bool
+	// TailorFailed is set when the tailoring run itself gave up (auto_apply_queue's own
+	// tailor_failed_at, migration 0154).
+	TailorFailed bool
+}
+
+// DeriveStatus derives the candidate-facing status from an attempt's own raw state. Mirrors
 // internal/api/handler's autoApplyEntryStatus precedence: declined is checked first,
 // because DeclineAutoApplyReview also sets blocked_at (it reuses MarkAutoApplyBlocked's own
 // park vocabulary) — checking blocked/failed before the review decision would misreport a
 // candidate's own decline as an operational failure.
-func DeriveStatus(hasTailoredCV, hasResolvedPreview bool, reviewDecision string, blocked, failed bool) Status {
+//
+// A tailoring failure is checked LAST of the operational states, below a tailored CV that
+// exists: a later run that succeeded supersedes an earlier one that did not, and telling
+// somebody their CV could not be prepared while it sits there ready is worse than saying
+// nothing. The write path clears the marker on success; this does not rely on it having.
+func DeriveStatus(in DerivedFrom) Status {
 	switch {
-	case reviewDecision == "declined":
+	case in.ReviewDecision == "declined":
 		return StatusDeclined
-	case blocked:
+	case in.Blocked:
 		return StatusBlocked
-	case failed:
+	case in.Failed:
 		return StatusFailed
-	case reviewDecision == "approved":
+	case in.ReviewDecision == "approved":
 		return StatusApproved
-	case hasTailoredCV && hasResolvedPreview:
+	case in.HasTailoredCV && in.HasResolvedPreview:
 		return StatusPendingReview
+	case in.TailorFailed:
+		return StatusTailorFailed
 	default:
 		return StatusTailoring
 	}
@@ -59,7 +92,9 @@ type ResolvedAttempt struct {
 	ReviewDecision  string
 	Blocked         bool
 	Failed          bool
-	Unmapped        []UnmappedField
+	// TailorFailed is set when the tailoring run gave up without producing a CV.
+	TailorFailed bool
+	Unmapped     []UnmappedField
 }
 
 // AutoApplyReviewInfo is what a tracked job's own read path surfaces about its live
@@ -85,7 +120,14 @@ func AssembleReviewInfo(hasAttempt bool, a ResolvedAttempt) *AutoApplyReviewInfo
 	if !hasAttempt {
 		return nil
 	}
-	status := DeriveStatus(a.HasTailoredCV, a.ResolvedPreview != nil, a.ReviewDecision, a.Blocked, a.Failed)
+	status := DeriveStatus(DerivedFrom{
+		HasTailoredCV:      a.HasTailoredCV,
+		HasResolvedPreview: a.ResolvedPreview != nil,
+		ReviewDecision:     a.ReviewDecision,
+		Blocked:            a.Blocked,
+		Failed:             a.Failed,
+		TailorFailed:       a.TailorFailed,
+	})
 	info := &AutoApplyReviewInfo{Status: status, QueueID: a.QueueID}
 	if status == StatusPendingReview {
 		info.ResolvedPreview = a.ResolvedPreview

--- a/internal/application/autoapply/status_test.go
+++ b/internal/application/autoapply/status_test.go
@@ -23,7 +23,13 @@ func TestDeriveStatus_SixStates(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := DeriveStatus(c.hasTailoredCV, c.hasResolvedPreview, c.reviewDecision, c.blocked, c.failed)
+			got := DeriveStatus(DerivedFrom{
+				HasTailoredCV:      c.hasTailoredCV,
+				HasResolvedPreview: c.hasResolvedPreview,
+				ReviewDecision:     c.reviewDecision,
+				Blocked:            c.blocked,
+				Failed:             c.failed,
+			})
 			if got != c.want {
 				t.Errorf("DeriveStatus(%v, %v, %q, %v, %v) = %q, want %q",
 					c.hasTailoredCV, c.hasResolvedPreview, c.reviewDecision, c.blocked, c.failed, got, c.want)
@@ -83,5 +89,39 @@ func TestAssembleReviewInfo_DeclinedCarriesNeitherPreviewNorUnmapped(t *testing.
 	}
 	if got.ResolvedPreview != nil || got.Unmapped != nil {
 		t.Errorf("got = %+v, want neither preview nor unmapped surfaced for a declined attempt", got)
+	}
+}
+
+// A tailoring run that failed for a real reason must not read as one still in progress.
+//
+// Before this state existed, a failed run recorded nothing at all, so DeriveStatus fell
+// through to its default and the candidate was told "Auto-apply is preparing a tailored CV
+// for this job" — indefinitely, about work nobody was doing. Three production entries sat
+// that way, one of them for over a day.
+func TestDeriveStatus_AFailedTailoringRunIsNotStillTailoring(t *testing.T) {
+	got := DeriveStatus(DerivedFrom{TailorFailed: true})
+	if got != StatusTailorFailed {
+		t.Errorf("DeriveStatus(tailor failed) = %q, want %q", got, StatusTailorFailed)
+	}
+}
+
+// A later run that succeeds supersedes the earlier failure: the candidate has a CV to look
+// at, and being told the preparation failed while it sits there ready would be worse than
+// saying nothing. The write path clears the marker, and the derivation does not depend on
+// it having done so.
+func TestDeriveStatus_ASucceedingRunOutranksAnEarlierTailoringFailure(t *testing.T) {
+	got := DeriveStatus(DerivedFrom{
+		HasTailoredCV: true, HasResolvedPreview: true, TailorFailed: true,
+	})
+	if got != StatusPendingReview {
+		t.Errorf("DeriveStatus(tailored, previewed, earlier failure) = %q, want %q", got, StatusPendingReview)
+	}
+}
+
+// The candidate's own decision still outranks everything, exactly as it does for blocked.
+func TestDeriveStatus_ADeclineOutranksATailoringFailure(t *testing.T) {
+	got := DeriveStatus(DerivedFrom{ReviewDecision: "declined", TailorFailed: true})
+	if got != StatusDeclined {
+		t.Errorf("DeriveStatus(declined, tailor failed) = %q, want %q", got, StatusDeclined)
 	}
 }

--- a/internal/application/jobtracking/jobtracking.go
+++ b/internal/application/jobtracking/jobtracking.go
@@ -123,7 +123,7 @@ type TrackedJob struct {
 	// the second does not soften the first. It is kept out of silence.StateFor's inputs for the same
 	// reason FollowedUpAt is — see internal/application/userjob.
 	CVOpenedAt *time.Time
-	// AutoApplyStatus is the six-value status of this job's live auto-apply attempt, nil
+	// AutoApplyStatus is the seven-value status of this job's live auto-apply attempt, nil
 	// when it has none (openspec/changes/auto-apply-review-tracking). The board's own
 	// "needs your review" badge reads only this — the full answer preview and unmapped
 	// question list are the drawer's own, richer read (GetTrackedApplication), not

--- a/internal/application/jobtracking/repository.go
+++ b/internal/application/jobtracking/repository.go
@@ -365,7 +365,7 @@ func (r *QueriesRepository) ListInteractions(
 			CVOpenedAt:           pgconv.TimePtr(row.CvOpenedAt),
 			AutoApplyStatus: autoApplyStatusFor(row.AutoApplyID.Valid, row.AutoApplyTailoredCvID,
 				row.AutoApplyHasPreview, row.AutoApplyReviewDecision, row.AutoApplyBlockedAt,
-				row.AutoApplyFailedAt, row.AutoApplyPreviewFailedAt),
+				row.AutoApplyFailedAt, row.AutoApplyPreviewFailedAt, row.AutoApplyTailorFailedAt),
 		})
 	}
 
@@ -566,14 +566,20 @@ func textPtr(t pgtype.Text) *string {
 // pair). Mirrors autoApplyReviewInfoForJob's own derivation (internal/api/handler), scoped
 // to just the status this list needs for its badge — the full preview/unmapped detail is
 // the drawer's own, richer read.
-func autoApplyStatusFor(hasAttempt bool, tailoredCVID *uuid.UUID, hasPreview bool, reviewDecision pgtype.Text, blockedAt, failedAt, previewFailedAt pgtype.Timestamptz) *autoapply.Status {
+func autoApplyStatusFor(hasAttempt bool, tailoredCVID *uuid.UUID, hasPreview bool, reviewDecision pgtype.Text, blockedAt, failedAt, previewFailedAt, tailorFailedAt pgtype.Timestamptz) *autoapply.Status {
 	if !hasAttempt {
 		return nil
 	}
-	// Either budget exhausting counts as failed — see autoApplyReviewInfoForJob's own
-	// identical reasoning (internal/api/handler/auto_apply_review_info.go).
-	failed := failedAt.Valid || previewFailedAt.Valid
-	status := autoapply.DeriveStatus(tailoredCVID != nil, hasPreview, reviewDecision.String, blockedAt.Valid, failed)
+	status := autoapply.DeriveStatus(autoapply.DerivedFrom{
+		HasTailoredCV:      tailoredCVID != nil,
+		HasResolvedPreview: hasPreview,
+		ReviewDecision:     reviewDecision.String,
+		Blocked:            blockedAt.Valid,
+		// Either budget exhausting counts as failed — see autoApplyReviewInfoForJob's own
+		// identical reasoning (internal/api/handler/auto_apply_review_info.go).
+		Failed:       failedAt.Valid || previewFailedAt.Valid,
+		TailorFailed: tailorFailedAt.Valid,
+	})
 	return &status
 }
 

--- a/internal/platform/db/auto_apply_queue.sql.go
+++ b/internal/platform/db/auto_apply_queue.sql.go
@@ -320,7 +320,7 @@ func (q *Queries) GetAutoApplyQueueEntryByID(ctx context.Context, id int64) (Get
 
 const getAutoApplyQueueEntryForJob = `-- name: GetAutoApplyQueueEntryForJob :one
 SELECT id, review_decision, failed_at, blocked_at, tailored_cv_id, unmapped, resolved_preview,
-       preview_failed_at
+       preview_failed_at, tailor_failed_at
 FROM auto_apply_queue
 WHERE user_id = $1 AND job_id = $2
 `
@@ -339,6 +339,7 @@ type GetAutoApplyQueueEntryForJobRow struct {
 	Unmapped        []byte             `json:"unmapped"`
 	ResolvedPreview []byte             `json:"resolved_preview"`
 	PreviewFailedAt pgtype.Timestamptz `json:"preview_failed_at"`
+	TailorFailedAt  pgtype.Timestamptz `json:"tailor_failed_at"`
 }
 
 // The caller's own existing auto-apply entry for one job, if any — the conflict-read path
@@ -355,7 +356,7 @@ type GetAutoApplyQueueEntryForJobRow struct {
 //
 // tailored_cv_id, unmapped, and resolved_preview (openspec/changes/auto-apply-review-tracking)
 // ride along on the same row read rather than a second query: they are exactly what the
-// tracker drawer's own auto-apply banner needs (the six-value status, the answer preview, the
+// tracker drawer's own auto-apply banner needs (the seven-value status, the answer preview, the
 // unmapped question list), and this is already "the caller's own existing auto-apply entry
 // for one job." preview_failed_at (migration 0140) is read for the same reason failed_at
 // is: without it, an entry whose preview pass permanently gave up would read forever as
@@ -372,6 +373,7 @@ func (q *Queries) GetAutoApplyQueueEntryForJob(ctx context.Context, arg GetAutoA
 		&i.Unmapped,
 		&i.ResolvedPreview,
 		&i.PreviewFailedAt,
+		&i.TailorFailedAt,
 	)
 	return i, err
 }
@@ -436,6 +438,59 @@ type MarkAutoApplyBlockedParams struct {
 func (q *Queries) MarkAutoApplyBlocked(ctx context.Context, arg MarkAutoApplyBlockedParams) error {
 	_, err := q.db.Exec(ctx, markAutoApplyBlocked, arg.LastError, arg.Unmapped, arg.ID)
 	return err
+}
+
+const markAutoApplyTailorFailed = `-- name: MarkAutoApplyTailorFailed :one
+WITH updated AS (
+    UPDATE auto_apply_queue q
+    SET tailor_failed_at = now(),
+        last_error       = $1
+    WHERE q.id = $2
+      AND q.review_decision IS NULL
+      AND q.tailored_cv_id IS NULL
+    RETURNING q.job_id, q.user_id
+)
+SELECT j.public_slug, j.title, j.company, u.user_id
+FROM jobs j
+JOIN updated u ON u.job_id = j.id
+`
+
+type MarkAutoApplyTailorFailedParams struct {
+	LastError string `json:"last_error"`
+	ID        int64  `json:"id"`
+}
+
+type MarkAutoApplyTailorFailedRow struct {
+	PublicSlug string `json:"public_slug"`
+	Title      string `json:"title"`
+	Company    string `json:"company"`
+	UserID     int64  `json:"user_id"`
+}
+
+// Records that a tailoring run gave up without producing a CV (migration 0154), so the
+// entry stops reading as one still being prepared.
+//
+// Guarded by tailored_cv_id IS NULL as well as review_decision IS NULL: a run that failed
+// AFTER an earlier one had already produced a CV has nothing to report — the candidate has
+// something to look at, and telling them preparation failed while it sits there ready is
+// worse than saying nothing. DeriveStatus ranks the same way and does not depend on this
+// guard having fired.
+//
+// Returns the job's title/company/slug for the caller's own notification, the same shape and
+// for the same reason SetAutoApplyResolvedPreview already returns them: this statement
+// already holds the job_id its own WHERE resolved, and a second round trip for exactly what
+// this write just touched would be a query with no reason to exist. pgx.ErrNoRows means a
+// guard fired, which the caller treats as "nothing to say", never as an error.
+func (q *Queries) MarkAutoApplyTailorFailed(ctx context.Context, arg MarkAutoApplyTailorFailedParams) (MarkAutoApplyTailorFailedRow, error) {
+	row := q.db.QueryRow(ctx, markAutoApplyTailorFailed, arg.LastError, arg.ID)
+	var i MarkAutoApplyTailorFailedRow
+	err := row.Scan(
+		&i.PublicSlug,
+		&i.Title,
+		&i.Company,
+		&i.UserID,
+	)
+	return i, err
 }
 
 const recordAutoApplyFailure = `-- name: RecordAutoApplyFailure :one
@@ -569,7 +624,8 @@ UPDATE auto_apply_queue
 SET tailored_cv_id    = $1,
     resolved_preview  = NULL,
     preview_attempts  = 0,
-    preview_failed_at = NULL
+    preview_failed_at = NULL,
+    tailor_failed_at  = NULL
 WHERE id = $2 AND review_decision IS NULL
 `
 

--- a/internal/platform/db/models.go
+++ b/internal/platform/db/models.go
@@ -188,6 +188,7 @@ type AutoApplyQueue struct {
 	ResolvedPreview []byte             `json:"resolved_preview"`
 	PreviewAttempts int32              `json:"preview_attempts"`
 	PreviewFailedAt pgtype.Timestamptz `json:"preview_failed_at"`
+	TailorFailedAt  pgtype.Timestamptz `json:"tailor_failed_at"`
 }
 
 type BillingEvent struct {

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -1976,7 +1976,7 @@ type Querier interface {
 	//
 	// tailored_cv_id, unmapped, and resolved_preview (openspec/changes/auto-apply-review-tracking)
 	// ride along on the same row read rather than a second query: they are exactly what the
-	// tracker drawer's own auto-apply banner needs (the six-value status, the answer preview, the
+	// tracker drawer's own auto-apply banner needs (the seven-value status, the answer preview, the
 	// unmapped question list), and this is already "the caller's own existing auto-apply entry
 	// for one job." preview_failed_at (migration 0140) is read for the same reason failed_at
 	// is: without it, an entry whose preview pass permanently gave up would read forever as
@@ -3981,6 +3981,21 @@ type Querier interface {
 	// untouched and blocked_at, not failed_at, is what excludes it from
 	// auto_apply_queue_claimable_idx from here on.
 	MarkAutoApplyBlocked(ctx context.Context, arg MarkAutoApplyBlockedParams) error
+	// Records that a tailoring run gave up without producing a CV (migration 0154), so the
+	// entry stops reading as one still being prepared.
+	//
+	// Guarded by tailored_cv_id IS NULL as well as review_decision IS NULL: a run that failed
+	// AFTER an earlier one had already produced a CV has nothing to report — the candidate has
+	// something to look at, and telling them preparation failed while it sits there ready is
+	// worse than saying nothing. DeriveStatus ranks the same way and does not depend on this
+	// guard having fired.
+	//
+	// Returns the job's title/company/slug for the caller's own notification, the same shape and
+	// for the same reason SetAutoApplyResolvedPreview already returns them: this statement
+	// already holds the job_id its own WHERE resolved, and a second round trip for exactly what
+	// this write just touched would be a query with no reason to exist. pgx.ErrNoRows means a
+	// guard fired, which the caller treats as "nothing to say", never as an error.
+	MarkAutoApplyTailorFailed(ctx context.Context, arg MarkAutoApplyTailorFailedParams) (MarkAutoApplyTailorFailedRow, error)
 	// Stamp an event as applied. Idempotent by shape: re-stamping a processed row writes the
 	// same fact, and the reconciler's own query no longer returns it.
 	MarkBillingEventProcessed(ctx context.Context, id int64) error

--- a/internal/platform/db/queries/auto_apply_queue.sql
+++ b/internal/platform/db/queries/auto_apply_queue.sql
@@ -125,6 +125,34 @@ SET preview_attempts = preview_attempts + 1,
 WHERE id = sqlc.arg(id)
 RETURNING preview_attempts, preview_failed_at;
 
+-- name: MarkAutoApplyTailorFailed :one
+-- Records that a tailoring run gave up without producing a CV (migration 0154), so the
+-- entry stops reading as one still being prepared.
+--
+-- Guarded by tailored_cv_id IS NULL as well as review_decision IS NULL: a run that failed
+-- AFTER an earlier one had already produced a CV has nothing to report — the candidate has
+-- something to look at, and telling them preparation failed while it sits there ready is
+-- worse than saying nothing. DeriveStatus ranks the same way and does not depend on this
+-- guard having fired.
+--
+-- Returns the job's title/company/slug for the caller's own notification, the same shape and
+-- for the same reason SetAutoApplyResolvedPreview already returns them: this statement
+-- already holds the job_id its own WHERE resolved, and a second round trip for exactly what
+-- this write just touched would be a query with no reason to exist. pgx.ErrNoRows means a
+-- guard fired, which the caller treats as "nothing to say", never as an error.
+WITH updated AS (
+    UPDATE auto_apply_queue q
+    SET tailor_failed_at = now(),
+        last_error       = sqlc.arg(last_error)
+    WHERE q.id = sqlc.arg(id)
+      AND q.review_decision IS NULL
+      AND q.tailored_cv_id IS NULL
+    RETURNING q.job_id, q.user_id
+)
+SELECT j.public_slug, j.title, j.company, u.user_id
+FROM jobs j
+JOIN updated u ON u.job_id = j.id;
+
 -- name: GetAutoApplyQueueEntryForReview :one
 -- One read backing both the tailoring-trigger and the review-decision endpoints
 -- (openspec/changes/auto-apply-tailored-resume): resolves ownership (a foreign or missing
@@ -170,7 +198,8 @@ UPDATE auto_apply_queue
 SET tailored_cv_id    = sqlc.arg(tailored_cv_id),
     resolved_preview  = NULL,
     preview_attempts  = 0,
-    preview_failed_at = NULL
+    preview_failed_at = NULL,
+    tailor_failed_at  = NULL
 WHERE id = sqlc.arg(id) AND review_decision IS NULL;
 
 -- name: SetAutoApplyResolvedPreview :one
@@ -252,13 +281,13 @@ RETURNING id;
 --
 -- tailored_cv_id, unmapped, and resolved_preview (openspec/changes/auto-apply-review-tracking)
 -- ride along on the same row read rather than a second query: they are exactly what the
--- tracker drawer's own auto-apply banner needs (the six-value status, the answer preview, the
+-- tracker drawer's own auto-apply banner needs (the seven-value status, the answer preview, the
 -- unmapped question list), and this is already "the caller's own existing auto-apply entry
 -- for one job." preview_failed_at (migration 0140) is read for the same reason failed_at
 -- is: without it, an entry whose preview pass permanently gave up would read forever as
 -- "tailoring" — no preview, no failure, nothing to tell the candidate anything went wrong.
 SELECT id, review_decision, failed_at, blocked_at, tailored_cv_id, unmapped, resolved_preview,
-       preview_failed_at
+       preview_failed_at, tailor_failed_at
 FROM auto_apply_queue
 WHERE user_id = sqlc.arg(user_id) AND job_id = sqlc.arg(job_id);
 

--- a/internal/platform/db/queries/user_jobs.sql
+++ b/internal/platform/db/queries/user_jobs.sql
@@ -314,6 +314,7 @@ SELECT jobs.id, jobs.public_slug, jobs.title, jobs.company, jobs.company_slug, j
        aaq.review_decision AS auto_apply_review_decision,
        aaq.blocked_at AS auto_apply_blocked_at, aaq.failed_at AS auto_apply_failed_at,
        aaq.preview_failed_at AS auto_apply_preview_failed_at,
+       aaq.tailor_failed_at AS auto_apply_tailor_failed_at,
        (aaq.resolved_preview IS NOT NULL)::boolean AS auto_apply_has_preview
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id

--- a/internal/platform/db/user_jobs.sql.go
+++ b/internal/platform/db/user_jobs.sql.go
@@ -414,6 +414,7 @@ SELECT jobs.id, jobs.public_slug, jobs.title, jobs.company, jobs.company_slug, j
        aaq.review_decision AS auto_apply_review_decision,
        aaq.blocked_at AS auto_apply_blocked_at, aaq.failed_at AS auto_apply_failed_at,
        aaq.preview_failed_at AS auto_apply_preview_failed_at,
+       aaq.tailor_failed_at AS auto_apply_tailor_failed_at,
        (aaq.resolved_preview IS NOT NULL)::boolean AS auto_apply_has_preview
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id
@@ -490,6 +491,7 @@ type ListUserJobsRow struct {
 	AutoApplyBlockedAt       pgtype.Timestamptz `json:"auto_apply_blocked_at"`
 	AutoApplyFailedAt        pgtype.Timestamptz `json:"auto_apply_failed_at"`
 	AutoApplyPreviewFailedAt pgtype.Timestamptz `json:"auto_apply_preview_failed_at"`
+	AutoApplyTailorFailedAt  pgtype.Timestamptz `json:"auto_apply_tailor_failed_at"`
 	AutoApplyHasPreview      bool               `json:"auto_apply_has_preview"`
 }
 
@@ -572,6 +574,7 @@ func (q *Queries) ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]L
 			&i.AutoApplyBlockedAt,
 			&i.AutoApplyFailedAt,
 			&i.AutoApplyPreviewFailedAt,
+			&i.AutoApplyTailorFailedAt,
 			&i.AutoApplyHasPreview,
 		); err != nil {
 			return nil, err

--- a/migrations/0154_auto_apply_queue_tailor_failed_at.sql
+++ b/migrations/0154_auto_apply_queue_tailor_failed_at.sql
@@ -1,0 +1,24 @@
+-- A tailoring run that gave up left no trace at all: SetAutoApplyTailoredCV is reached only
+-- on a clean return, and nothing else in the entry moves. autoapply.DeriveStatus therefore
+-- fell through to its default and told the candidate "Auto-apply is preparing a tailored CV
+-- for this job" — indefinitely, about work nobody was doing. Three production entries sat
+-- that way on 2026-09-08, one of them for over a day.
+--
+-- Its own column rather than reusing one that exists:
+--
+--   failed_at is the SUBMISSION pass's dead-letter (RecordAutoApplyFailure) and is what
+--   ClaimAutoApplyBatch excludes on. An entry that never produced a CV cannot be claimed by
+--   that pass anyway (its predicate requires tailored_cv_id), so setting it there would say
+--   something false about a pass that never ran.
+--
+--   preview_failed_at (0140) belongs to the answer-preview pass, which likewise only ever
+--   runs once a CV exists. Migration 0140 exists precisely BECAUSE that pass sharing the
+--   submission's own counters misreported one as the other; sharing again here would repeat
+--   the mistake one step earlier in the same sequence.
+--
+-- No attempt counter beside it: unlike the two drain passes, nothing retries a tailoring run
+-- on a schedule — the orchestrator's Inngest step either succeeds or ends the run — so a
+-- countdown would have nothing to count. Re-running one is a deliberate act (publishing the
+-- submit event again), and SetAutoApplyTailoredCV clears this marker when it lands.
+ALTER TABLE public.auto_apply_queue
+    ADD COLUMN tailor_failed_at timestamptz;

--- a/web/src/lib/autoApplyReview.test.ts
+++ b/web/src/lib/autoApplyReview.test.ts
@@ -2,9 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { autoApplyNeedsReviewBadge, autoApplyReviewBanner } from './autoApplyReview';
 
 describe('autoApplyNeedsReviewBadge', () => {
-  it('shows for pending_review and blocked', () => {
+  it('shows for pending_review, blocked and tailor_failed', () => {
     expect(autoApplyNeedsReviewBadge('pending_review')).toBe(true);
     expect(autoApplyNeedsReviewBadge('blocked')).toBe(true);
+    // A run that never produced a CV stopped just as surely as a blocked one did, and the
+    // candidate has no other way to notice: nothing on the card changes otherwise.
+    expect(autoApplyNeedsReviewBadge('tailor_failed')).toBe(true);
   });
 
   it('hides for tailoring, approved, declined, failed, and no attempt', () => {
@@ -37,6 +40,13 @@ describe('autoApplyReviewBanner', () => {
 
   it('is the approved variant for approved', () => {
     expect(autoApplyReviewBanner('approved')).toEqual({ kind: 'approved' });
+  });
+
+  // A tailoring run that gave up is its own variant, not the "still preparing" one it used
+  // to fall through to: the candidate has no CV to look at, so the copy cannot be the
+  // failed-submission one either (that one implies there was something to send).
+  it('is the tailor_failed variant for tailor_failed', () => {
+    expect(autoApplyReviewBanner('tailor_failed')).toEqual({ kind: 'tailor_failed' });
   });
 
   it('is null for no attempt', () => {

--- a/web/src/lib/autoApplyReview.ts
+++ b/web/src/lib/autoApplyReview.ts
@@ -1,14 +1,19 @@
-// Maps auto-apply's six-value status (jobtracking/AssembleReviewInfo, openspec/changes/
+// Maps auto-apply's seven-value status (jobtracking/AssembleReviewInfo, openspec/changes/
 // auto-apply-review-tracking) to the tracker's two rendering decisions — kept out of
 // BoardCard.svelte/JobDrawer.svelte so both unit-test without mounting Svelte, mirroring
 // autoApplyButton.ts's own convention.
 
 /** Whether the board card shows its "needs your review" badge — an entry the candidate
- *  must act on (pending_review) or one that stopped and needs their attention (blocked).
- *  `tailoring`, `approved` and terminal `declined`/`failed` entries show no badge: there is
- *  nothing new for the candidate to notice on the card itself. */
+ *  must act on (pending_review) or one that stopped and needs their attention (blocked,
+ *  tailor_failed). `tailoring`, `approved` and terminal `declined`/`failed` entries show no
+ *  badge: there is nothing new for the candidate to notice on the card itself.
+ *
+ *  `tailor_failed` earns one for the same reason `blocked` does — the attempt stopped and
+ *  nothing else on the card says so. It is the state that used to be indistinguishable from
+ *  `tailoring`, which is how three production entries sat for a day looking like work in
+ *  progress. */
 export function autoApplyNeedsReviewBadge(status?: string | null): boolean {
-  return status === 'pending_review' || status === 'blocked';
+  return status === 'pending_review' || status === 'blocked' || status === 'tailor_failed';
 }
 
 export type AutoApplyReviewBanner =
@@ -18,6 +23,7 @@ export type AutoApplyReviewBanner =
   | { kind: 'blocked' }
   | { kind: 'declined' }
   | { kind: 'failed' }
+  | { kind: 'tailor_failed' }
   | null;
 
 /** Decides which drawer banner variant to render, or null when there is no live attempt at
@@ -40,6 +46,8 @@ export function autoApplyReviewBanner(status?: string | null): AutoApplyReviewBa
       return { kind: 'declined' };
     case 'failed':
       return { kind: 'failed' };
+    case 'tailor_failed':
+      return { kind: 'tailor_failed' };
     default:
       return null;
   }

--- a/web/src/lib/components/JobDrawer.svelte
+++ b/web/src/lib/components/JobDrawer.svelte
@@ -545,6 +545,27 @@
                 Auto-apply could not submit this application after retrying. This attempt is final.
               </p>
             </div>
+          {:else if autoApplyBanner?.kind === 'tailor_failed'}
+            <!-- Deliberately not the 'failed' copy: nothing was submitted and there is no
+                 tailored CV to look at, so "could not submit after retrying" would describe
+                 a step this attempt never reached. Says what did NOT happen, because the
+                 state it replaces (an entry that read as 'tailoring' forever) left people
+                 believing an application was on its way. -->
+            <div class="rounded-md border border-border bg-muted/30 px-3 py-2">
+              <p class="text-sm font-medium">Auto-apply couldn't prepare a CV for this job.</p>
+              <p class="text-xs text-muted-foreground">
+                Nothing was sent, and the job is still on your board. You can tailor a CV yourself and apply
+                as usual.
+              </p>
+              {#if hasPosting && item.job}
+                <a
+                  href={resolve('/tailor/[slug]', { slug: item.job.public_slug })}
+                  class="w-fit text-xs underline-offset-2 hover:underline"
+                >
+                  Tailor a CV
+                </a>
+              {/if}
+            </div>
           {/if}
 
           {#if pendingOutcome}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -702,14 +702,17 @@ export interface MyJob {
   auto_apply_status?: AutoApplyStatus;
 }
 
-/** The six-value candidate-facing status for a live auto-apply attempt. */
+/** The seven-value candidate-facing status for a live auto-apply attempt. */
 type AutoApplyStatus =
   | 'tailoring'
   | 'pending_review'
   | 'approved'
   | 'blocked'
   | 'declined'
-  | 'failed';
+  | 'failed'
+  /** The tailoring run itself gave up without producing a CV — distinct from `failed`,
+   *  which is a submission that gave up with one in hand. */
+  | 'tailor_failed';
 
 /** One resolved question/answer pair in an auto-apply answer preview. */
 interface AutoApplyPreviewField {


### PR DESCRIPTION
An auto-apply entry whose tailoring run failed recorded **nothing at all**. `SetAutoApplyTailoredCV` is reached only on a clean return, and no other column moves, so `DeriveStatus` fell through to its default and the tracker said:

> Auto-apply is preparing a tailored CV for this job.

Indefinitely. About work nobody was doing. Three production entries sat that way on 2026-09-08, one of them for over a day, with no notification either.

The candidate's own report: *nothing happened, no notification, nothing in the interface.*

## What this adds

**A column** — migration 0154, `auto_apply_queue.tailor_failed_at`. Its own, deliberately:

- not `failed_at` — that is the SUBMISSION pass's dead-letter, and an entry with no CV can never be claimed by that pass at all (its predicate requires `tailored_cv_id`);
- not `preview_failed_at` — the preview pass's, which likewise only runs once a CV exists.

Migration 0140 exists *precisely because* that pass sharing the submission's counters misreported one as the other. Sharing again would repeat the mistake one step earlier in the same sequence.

**A guarded write** — `MarkAutoApplyTailorFailed`, guarded by `tailored_cv_id IS NULL` as well as `review_decision IS NULL`. A run that fails after an earlier one already produced a CV has nothing to report; saying preparation failed while a CV sits there ready is worse than saying nothing. `SetAutoApplyTailoredCV` clears the marker, so a later success supersedes an earlier failure.

**A status** — `StatusTailorFailed`, ranked below a tailored CV that exists and below the candidate's own decision, mirroring how `blocked` already ranks.

**A notification**, saying what did *not* happen: nothing was sent, the job is still on the board.

## Two notes on the shape

`DeriveStatus` now takes a struct. Its parameters were five in a row, four of them bool, and a caller had no way to be wrong loudly — a sixth is exactly the kind of state that makes that a real hazard rather than a tidiness point.

The write is best-effort and runs on a **context detached from the request's**. This is called precisely when a run ended badly, and the most common way for that to happen is the caller giving up first — so the request's own context is usually already dead, and a write on it would be dropped at the moment it is most needed.

## The copy

Deliberately not the failed-submission copy: nothing was submitted and there is no CV to look at, so "could not submit after retrying" would describe a step this attempt never reached. It offers the manual tailoring route instead — a real thing the candidate can do.

## Verification

The integration test fails on all three counts without the fix — no marker, no `last_error`, no notification — confirmed by removing the call and re-running.

`go test ./...`, `go test -tags=integration ./internal/api/handler/`, `go vet -tags=integration ./...`, `pnpm vitest run` (1795 tests), `pnpm lint`, `pnpm check:sql`, `gofmt`, `golangci-lint` — all clean.