### PR TITLE
Auto-generate Google Meet links for connected mentors

### DIFF
--- a/internal/api/handler/gmail.go
+++ b/internal/api/handler/gmail.go
@@ -431,7 +431,12 @@ func (h *inboxHandlers) GmailStatus(c *fiber.Ctx) error {
 		// Whether this grant covers calendar.events — the mentor-only write consent
 		// mentor-google-meet-link reads to decide whether a booking gets an
 		// auto-generated Meet link and whether the profile's own link becomes optional.
-		"mentor_calendar_connected": slices.Contains(conn.Scopes, gmailsync.CalendarEventsScope),
+		// Gated on status too, unlike calendar_connected above: a mentor whose booking
+		// flow already treats a needs_reconsent grant as not-connected (see
+		// mentorship.GetMentorCalendarGrant) must not be told here that they're still
+		// connected — that reading would leave their profile's meeting link optional and
+		// every new booking silently landing with no link at all.
+		"mentor_calendar_connected": conn.Status == "connected" && slices.Contains(conn.Scopes, gmailsync.CalendarEventsScope),
 	}})
 }
 

--- a/internal/api/handler/gmail.go
+++ b/internal/api/handler/gmail.go
@@ -180,6 +180,11 @@ func (h *inboxHandlers) register(api fiber.Router, mw middleware) {
 		// which a keyed client cannot complete.
 		api.Get("/me/calendar/connect", mw.cookie, h.CalendarConnect)
 		api.Get("/me/calendar/callback", mw.optionalCookie, h.CalendarCallback)
+		// A mentor's own write consent, beside the other two and never folded into
+		// either: it is the only one of the three that can create anything on someone
+		// else's calendar, so it gets its own explicit ask.
+		api.Get("/me/mentor-calendar/connect", mw.cookie, h.MentorCalendarConnect)
+		api.Get("/me/mentor-calendar/callback", mw.optionalCookie, h.MentorCalendarCallback)
 		api.Post("/me/gmail/sync", mw.key, h.SyncGmail)
 	}
 	// Hosted-mailbox option: status is always available (reports unavailable when
@@ -200,6 +205,11 @@ const gmailStateCookieName = "hire_gmail_state"
 // calendarStateCookieName carries the calendar-connect CSRF state, separate from the mail
 // one so two consents in flight cannot complete each other.
 const calendarStateCookieName = "hire_calendar_state"
+
+// mentorCalendarStateCookieName carries the mentor calendar-write consent's own CSRF
+// state — a third flow, separate from both the mail and the read-only calendar one, so
+// none of the three can complete another.
+const mentorCalendarStateCookieName = "hire_mentor_calendar_state"
 
 // integrationsPath is where both the mail and calendar OAuth callbacks land, success or
 // failure — the Integrations tab is the one surface that owns connect/disconnect for
@@ -331,6 +341,63 @@ func (h *inboxHandlers) CalendarCallback(c *fiber.Ctx) error {
 	return c.Redirect(h.frontendOrigin+integrationsPath+"?calendar=connected", fiber.StatusFound)
 }
 
+// MentorCalendarConnect starts a mentor's calendar.events write consent — its own
+// flow, own state cookie, distinct from both the mail and the read-only calendar one.
+func (h *inboxHandlers) MentorCalendarConnect(c *fiber.Ctx) error {
+	state, err := oauth.NewState()
+	if err != nil {
+		return err
+	}
+	oauth.SetStateCookieNamed(c, mentorCalendarStateCookieName, state, h.cookieSecure)
+	return c.Redirect(h.gmailConnector.MentorCalendarAuthCodeURL(state), fiber.StatusFound)
+}
+
+// MentorCalendarCallback finishes it: verify state, exchange the code, store the grant
+// and note that it now covers calendar.events. Failures redirect with
+// ?mentor_calendar_error and are logged server-side first, exactly as the other two
+// flows do — the marker tells the user nothing.
+//
+// It lands back on Integrations, the surface every connect flow here starts from.
+func (h *inboxHandlers) MentorCalendarCallback(c *fiber.Ctx) error {
+	redirect := func(qs string, err error) error {
+		log.Printf("mentor calendar connect: %s: %v", qs, err)
+		return c.Redirect(h.frontendOrigin+integrationsPath+"?"+qs, fiber.StatusFound)
+	}
+	userID, ok := auth.UserID(c)
+	if !ok {
+		return redirect("mentor_calendar_error=auth", errors.New("no authenticated user"))
+	}
+	cookieState := c.Cookies(mentorCalendarStateCookieName)
+	oauth.ClearStateCookieNamed(c, mentorCalendarStateCookieName, h.cookieSecure)
+	if cookieState == "" || c.Query("state") != cookieState {
+		return redirect("mentor_calendar_error=state", errors.New("state cookie missing or mismatched"))
+	}
+	// A declined consent echoes the state and carries ?error=access_denied instead of a
+	// code, so the state check above cannot stand in for reading it — see GmailCallback.
+	if refusal := c.Query("error"); refusal != "" {
+		return redirect("mentor_calendar_error=denied", errors.New(refusal))
+	}
+	code := c.Query("code")
+	if code == "" {
+		return redirect("mentor_calendar_error=exchange", errors.New("missing code"))
+	}
+	refresh, granted, err := h.gmailConnector.ExchangeMentorCalendar(c.Context(), code)
+	if err != nil {
+		return redirect("mentor_calendar_error=exchange", err)
+	}
+	enc, err := h.gmailCipher.Encrypt(refresh)
+	if err != nil {
+		return redirect("mentor_calendar_error=exchange", err)
+	}
+	if err := h.queries.UpsertCalendarGrant(c.Context(), db.UpsertCalendarGrantParams{
+		// What Google says the grant covers, not what we asked for — see CalendarCallback.
+		UserID: userID, RefreshTokenEnc: enc, Scopes: granted,
+	}); err != nil {
+		return redirect("mentor_calendar_error=exchange", err)
+	}
+	return c.Redirect(h.frontendOrigin+integrationsPath+"?mentor_calendar=connected", fiber.StatusFound)
+}
+
 // GmailStatus reports whether the caller has connected Gmail.
 func (h *inboxHandlers) GmailStatus(c *fiber.Ctx) error {
 	userID, err := requireUserID(c)
@@ -343,6 +410,7 @@ func (h *inboxHandlers) GmailStatus(c *fiber.Ctx) error {
 		// key), so the SPA hides the Connect button when it would 404.
 		return c.JSON(fiber.Map{"data": fiber.Map{
 			"connected": false, "available": h.gmailReady(), "calendar_connected": false,
+			"mentor_calendar_connected": false,
 		}})
 	}
 	if err != nil {
@@ -360,6 +428,10 @@ func (h *inboxHandlers) GmailStatus(c *fiber.Ctx) error {
 		// mailbox says nothing about the calendar and a calendar grant may have no
 		// mailbox behind it at all.
 		"calendar_connected": slices.Contains(conn.Scopes, gmailsync.CalendarScope),
+		// Whether this grant covers calendar.events — the mentor-only write consent
+		// mentor-google-meet-link reads to decide whether a booking gets an
+		// auto-generated Meet link and whether the profile's own link becomes optional.
+		"mentor_calendar_connected": slices.Contains(conn.Scopes, gmailsync.CalendarEventsScope),
 	}})
 }
 

--- a/internal/api/handler/gmail_integration_test.go
+++ b/internal/api/handler/gmail_integration_test.go
@@ -126,4 +126,31 @@ func TestGmailInboxEndToEnd(t *testing.T) {
 	}() {
 		t.Error("calendar-only grant (empty email) reported as Mail connected")
 	}
+
+	// mentor_calendar_connected must agree with the SAME "connected" test the booking
+	// flow's own grant lookup applies (mentorship.GetMentorCalendarGrant): a grant that
+	// covers calendar.events but has since been marked needs_reconsent must NOT read as
+	// connected here, or a mentor's profile form keeps telling them the meeting link is
+	// optional while every new booking silently gets no link at all.
+	if _, err := pool.Exec(ctx,
+		`UPDATE gmail_connections SET scopes = $2 WHERE user_id = $1`,
+		uid, []string{"https://www.googleapis.com/auth/calendar.events"}); err != nil {
+		t.Fatalf("seed mentor calendar scope: %v", err)
+	}
+	if _, body := do("GET", "/api/v1/me/gmail"); func() bool {
+		d, _ := body["data"].(map[string]any)
+		return d["mentor_calendar_connected"] != true
+	}() {
+		t.Error("a connected calendar.events grant was not reported as mentor_calendar_connected")
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE gmail_connections SET status = 'needs_reconsent' WHERE user_id = $1`, uid); err != nil {
+		t.Fatalf("mark needs_reconsent: %v", err)
+	}
+	if _, body := do("GET", "/api/v1/me/gmail"); func() bool {
+		d, _ := body["data"].(map[string]any)
+		return d["mentor_calendar_connected"] == true
+	}() {
+		t.Error("a needs_reconsent grant was still reported as mentor_calendar_connected")
+	}
 }

--- a/internal/api/handler/handler.go
+++ b/internal/api/handler/handler.go
@@ -717,9 +717,19 @@ func Register(app *fiber.App, cfg Config) {
 		mentorshipNotifier = mentorship.NewMailNotifier(mailClient, cfg.NotifyEmailFrom,
 			strings.TrimRight(cfg.FrontendOrigin, "/")+"/my/sessions")
 	}
+	// A connected mentor's calendar.events grant, mirroring the read-side gate above: the
+	// candidate calendar sync's own GmailConnector/GmailCipher pair, reused rather than a
+	// second copy of either. Nil when either is unset, so a deployment with no Google
+	// client configured just gets every booking's static-link fallback — this feature's
+	// entire rollback path.
+	mentorshipRepo := mentorship.NewQueriesRepository(queries, cfg.Pool)
+	var mentorshipCalendar mentorship.CalendarLinker
+	if cfg.GmailConnector != nil && cfg.GmailCipher != nil {
+		mentorshipCalendar = mentorship.NewGoogleCalendarLinker(mentorshipRepo, cfg.GmailConnector, cfg.GmailCipher)
+	}
 	mentorshipH := newMentorshipHandlers(mentorship.New(
-		mentorship.NewQueriesRepository(queries, cfg.Pool),
-		mentorship.Config{Notifier: mentorshipNotifier, Cache: cfg.Cache},
+		mentorshipRepo,
+		mentorship.Config{Notifier: mentorshipNotifier, Cache: cfg.Cache, CalendarLinker: mentorshipCalendar},
 	), photoStore)
 	// The mentor-profile create form's prefill. Composed from four unrelated blocks'
 	// own services (résumé, user profile, account, experience bank) plus the company

--- a/internal/api/handler/me_mentor_calendar_test.go
+++ b/internal/api/handler/me_mentor_calendar_test.go
@@ -1,0 +1,88 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/application/gmailsync"
+	"github.com/strelov1/freehire/internal/identity/auth"
+)
+
+// mentorCalendarConnectApp mounts the consent start behind RequireAuth. No database: the
+// handler mints state, sets a cookie and redirects, and never reaches the store.
+func mentorCalendarConnectApp(t *testing.T) (*fiber.App, string) {
+	t.Helper()
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	token, err := iss.Issue(1, testTokenVersion)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	h := &inboxHandlers{
+		gmailConnector: gmailsync.NewConnector("client-id", "secret", "https://freehire.me"),
+		frontendOrigin: "https://freehire.me",
+	}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/me/mentor-calendar/connect", auth.RequireAuth(iss, testVersions), h.MentorCalendarConnect)
+	return app, token
+}
+
+func TestMentorCalendarConnect_RequiresAuth(t *testing.T) {
+	app, _ := mentorCalendarConnectApp(t)
+	resp, err := app.Test(httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me/mentor-calendar/connect", nil))
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+// The consent sends the mentor to Google for calendar.events alone, carrying its own
+// state cookie so it cannot complete — or be completed by — the mail or the read-only
+// calendar flow.
+func TestMentorCalendarConnect_SendsToGoogleForCalendarEventsAlone(t *testing.T) {
+	app, token := mentorCalendarConnectApp(t)
+	req := httptest.NewRequestWithContext(context.Background(), fiber.MethodGet, "/me/mentor-calendar/connect", nil)
+	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusFound {
+		t.Fatalf("status = %d, want 302", resp.StatusCode)
+	}
+	location := resp.Header.Get("Location")
+	if !strings.Contains(location, "accounts.google.com") {
+		t.Errorf("redirected to %q, want Google's consent screen", location)
+	}
+	if !strings.Contains(location, "calendar.events") {
+		t.Errorf("the consent did not ask for calendar.events: %q", location)
+	}
+	if strings.Contains(location, "gmail.readonly") {
+		t.Errorf("the mentor calendar consent also asked for mail: %q", location)
+	}
+	if strings.Contains(location, "calendar.readonly") {
+		t.Errorf("the mentor calendar consent also asked for the read-only scope: %q", location)
+	}
+	var names []string
+	for _, ck := range resp.Cookies() {
+		names = append(names, ck.Name)
+	}
+	if !slices.Contains(names, "hire_mentor_calendar_state") {
+		t.Errorf("cookies %v, want the mentor calendar flow's own state cookie", names)
+	}
+	if slices.Contains(names, "hire_calendar_state") || slices.Contains(names, "hire_gmail_state") {
+		t.Errorf("the mentor calendar consent set another flow's state cookie: %v", names)
+	}
+}

--- a/internal/api/handler/mentorship_write.go
+++ b/internal/api/handler/mentorship_write.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"strings"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -329,8 +330,15 @@ func (h *mentorshipHandlers) UpdateMentorProfile(c *fiber.Ctx) error {
 // withCalendarLink resolves whether the caller holds a connected calendar.events grant
 // and sets it on the input, so a connected mentor's meeting link is no longer required —
 // the same test CreateMeetEvent's own gate applies at booking time.
+//
+// Skipped when the submitted link is already non-empty: validateMeetingURL only ever
+// consults HasCalendarLink for an EMPTY link, so a mentor who filled the field in pays
+// no extra round trip to answer a question that cannot change their outcome.
 func (h *mentorshipHandlers) withCalendarLink(c *fiber.Ctx, userID int64, req profileRequest) (mentorship.ProfileInput, error) {
 	in := req.toInput(userID)
+	if strings.TrimSpace(in.MeetingURL) != "" {
+		return in, nil
+	}
 	hasCalendar, err := h.mentorship.HasConnectedCalendar(c.Context(), userID)
 	if err != nil {
 		return mentorship.ProfileInput{}, err

--- a/internal/api/handler/mentorship_write.go
+++ b/internal/api/handler/mentorship_write.go
@@ -299,7 +299,11 @@ func (h *mentorshipHandlers) SubmitMentorProfile(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	profile, err := h.mentorship.SubmitProfile(c.Context(), req.toInput(userID))
+	in, err := h.withCalendarLink(c, userID, req)
+	if err != nil {
+		return err
+	}
+	profile, err := h.mentorship.SubmitProfile(c.Context(), in)
 	if err != nil {
 		return mentorshipError(err)
 	}
@@ -311,11 +315,28 @@ func (h *mentorshipHandlers) UpdateMentorProfile(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	profile, err := h.mentorship.UpdateProfile(c.Context(), req.toInput(userID))
+	in, err := h.withCalendarLink(c, userID, req)
+	if err != nil {
+		return err
+	}
+	profile, err := h.mentorship.UpdateProfile(c.Context(), in)
 	if err != nil {
 		return mentorshipError(err)
 	}
 	return c.JSON(fiber.Map{"data": toOwnMentorResponse(profile)})
+}
+
+// withCalendarLink resolves whether the caller holds a connected calendar.events grant
+// and sets it on the input, so a connected mentor's meeting link is no longer required —
+// the same test CreateMeetEvent's own gate applies at booking time.
+func (h *mentorshipHandlers) withCalendarLink(c *fiber.Ctx, userID int64, req profileRequest) (mentorship.ProfileInput, error) {
+	in := req.toInput(userID)
+	hasCalendar, err := h.mentorship.HasConnectedCalendar(c.Context(), userID)
+	if err != nil {
+		return mentorship.ProfileInput{}, err
+	}
+	in.HasCalendarLink = hasCalendar
+	return in, nil
 }
 
 func mentorProfileBody(c *fiber.Ctx) (int64, profileRequest, error) {

--- a/internal/application/gmailsync/connector.go
+++ b/internal/application/gmailsync/connector.go
@@ -88,6 +88,20 @@ func (c *Connector) AuthCodeURL(state string) string {
 	)
 }
 
+// scopedAuthCodeURL builds an incremental-auth consent URL for exactly one scope on its
+// own redirect — shared by every consent past the sign-in one, since each is a separate
+// cost and a separate decision, and only the scope and the redirect ever differ between
+// them.
+func scopedAuthCodeURL(cfg oauth2.Config, state, scope, redirect string) string {
+	cfg.Scopes = []string{scope}
+	cfg.RedirectURL = redirect
+	return cfg.AuthCodeURL(state,
+		oauth2.AccessTypeOffline,
+		oauth2.SetAuthURLParam("prompt", "consent"),
+		oauth2.SetAuthURLParam("include_granted_scopes", "true"),
+	)
+}
+
 // CalendarAuthCodeURL builds the consent URL for the calendar, on its own.
 //
 // Separate from AuthCodeURL because the two are separate costs and separate decisions: a
@@ -95,14 +109,7 @@ func (c *Connector) AuthCodeURL(state string) string {
 // and connecting a mailbox must never quietly ask for a diary. Incremental, so accepting
 // this keeps whatever they already granted — the returned refresh token then covers both.
 func (c *Connector) CalendarAuthCodeURL(state string) string {
-	cfg := *c.cfg
-	cfg.Scopes = []string{CalendarScope}
-	cfg.RedirectURL = c.calendarRedirect
-	return cfg.AuthCodeURL(state,
-		oauth2.AccessTypeOffline,
-		oauth2.SetAuthURLParam("prompt", "consent"),
-		oauth2.SetAuthURLParam("include_granted_scopes", "true"),
-	)
+	return scopedAuthCodeURL(*c.cfg, state, CalendarScope, c.calendarRedirect)
 }
 
 // Exchange turns the callback code into a refresh token and the connected Gmail
@@ -137,6 +144,22 @@ func GrantedScopes(tok *oauth2.Token) []string {
 	return strings.Fields(raw)
 }
 
+// scopedExchange turns a scoped consent's callback code into a refresh token, shared by
+// every consent past the sign-in one — op names it in the error text, since that is the
+// only thing that differs between them once the scope/redirect are already applied.
+func scopedExchange(ctx context.Context, cfg oauth2.Config, op, scope, redirect, code string) (refreshToken string, scopes []string, err error) {
+	cfg.Scopes = []string{scope}
+	cfg.RedirectURL = redirect
+	tok, err := cfg.Exchange(safehttp.GuardedOAuth2Context(ctx, gmailHTTPTimeout), code)
+	if err != nil {
+		return "", nil, fmt.Errorf("%s: exchange code: %w", op, err)
+	}
+	if tok.RefreshToken == "" {
+		return "", nil, fmt.Errorf("%s: no refresh token (consent was not offline)", op)
+	}
+	return tok.RefreshToken, GrantedScopes(tok), nil
+}
+
 // ExchangeCalendar turns the calendar callback's code into a refresh token.
 //
 // Separate from Exchange because that one reads the mailbox address from the Gmail
@@ -145,17 +168,7 @@ func GrantedScopes(tok *oauth2.Token) []string {
 // for. The token itself covers whatever they have granted in total — the consent is
 // incremental — so a candidate with both ends up with one grant covering both.
 func (c *Connector) ExchangeCalendar(ctx context.Context, code string) (refreshToken string, scopes []string, err error) {
-	cfg := *c.cfg
-	cfg.Scopes = []string{CalendarScope}
-	cfg.RedirectURL = c.calendarRedirect
-	tok, err := cfg.Exchange(safehttp.GuardedOAuth2Context(ctx, gmailHTTPTimeout), code)
-	if err != nil {
-		return "", nil, fmt.Errorf("calendar: exchange code: %w", err)
-	}
-	if tok.RefreshToken == "" {
-		return "", nil, errors.New("calendar: no refresh token (consent was not offline)")
-	}
-	return tok.RefreshToken, GrantedScopes(tok), nil
+	return scopedExchange(ctx, *c.cfg, "calendar", CalendarScope, c.calendarRedirect, code)
 }
 
 // MentorCalendarAuthCodeURL builds the consent URL for a mentor's calendar.events
@@ -169,30 +182,13 @@ func (c *Connector) ExchangeCalendar(ctx context.Context, code string) (refreshT
 // hold. Incremental, so a mentor who is also a candidate with mail/calendar-read
 // connected keeps those too.
 func (c *Connector) MentorCalendarAuthCodeURL(state string) string {
-	cfg := *c.cfg
-	cfg.Scopes = []string{CalendarEventsScope}
-	cfg.RedirectURL = c.mentorCalendarRedirect
-	return cfg.AuthCodeURL(state,
-		oauth2.AccessTypeOffline,
-		oauth2.SetAuthURLParam("prompt", "consent"),
-		oauth2.SetAuthURLParam("include_granted_scopes", "true"),
-	)
+	return scopedAuthCodeURL(*c.cfg, state, CalendarEventsScope, c.mentorCalendarRedirect)
 }
 
 // ExchangeMentorCalendar turns the mentor-calendar callback's code into a refresh
 // token, exactly as ExchangeCalendar does for the read-only flow.
 func (c *Connector) ExchangeMentorCalendar(ctx context.Context, code string) (refreshToken string, scopes []string, err error) {
-	cfg := *c.cfg
-	cfg.Scopes = []string{CalendarEventsScope}
-	cfg.RedirectURL = c.mentorCalendarRedirect
-	tok, err := cfg.Exchange(safehttp.GuardedOAuth2Context(ctx, gmailHTTPTimeout), code)
-	if err != nil {
-		return "", nil, fmt.Errorf("mentor calendar: exchange code: %w", err)
-	}
-	if tok.RefreshToken == "" {
-		return "", nil, errors.New("mentor calendar: no refresh token (consent was not offline)")
-	}
-	return tok.RefreshToken, GrantedScopes(tok), nil
+	return scopedExchange(ctx, *c.cfg, "mentor calendar", CalendarEventsScope, c.mentorCalendarRedirect, code)
 }
 
 // TokenSource mints access tokens from a stored refresh token (used by the sync

--- a/internal/application/gmailsync/connector.go
+++ b/internal/application/gmailsync/connector.go
@@ -32,6 +32,13 @@ const GmailReadonlyScope = "https://www.googleapis.com/auth/gmail.readonly"
 // gmail.readonly already carries — and no smaller a privacy one.
 const CalendarScope = "https://www.googleapis.com/auth/calendar.readonly"
 
+// CalendarEventsScope is the calendar WRITE scope, asked for on its own consent by a
+// mentor who wants a Meet link minted per booking — never inferred from CalendarScope,
+// which a candidate may hold for an unrelated, read-only purpose. Sensitive rather than
+// restricted, the same tier CalendarScope already carries, so this adds no new
+// verification burden beyond what gmail.readonly already does.
+const CalendarEventsScope = "https://www.googleapis.com/auth/calendar.events"
+
 const gmailProfileURL = "https://gmail.googleapis.com/gmail/v1/users/me/profile"
 
 // gmailHTTPTimeout bounds the OAuth exchange and Gmail API round-trips.
@@ -43,9 +50,15 @@ const gmailHTTPTimeout = 15 * time.Second
 // (which stores no tokens) — here we need offline access and a stored token.
 type Connector struct {
 	cfg *oauth2.Config
-	// calendarRedirect is the callback for the calendar consent. Its own path, because
-	// Google matches the redirect exactly and the two flows land in different handlers.
+	// calendarRedirect is the callback for the candidate's read-only calendar consent.
+	// Its own path, because Google matches the redirect exactly and the two flows land
+	// in different handlers.
 	calendarRedirect string
+	// mentorCalendarRedirect is the callback for a mentor's calendar.events write
+	// consent — its own path too, distinct from calendarRedirect: the two are separate
+	// consents for separate purposes on possibly the same account, and Google matching
+	// the wrong one back to the wrong handler would be worse than a third field here.
+	mentorCalendarRedirect string
 }
 
 // NewConnector builds the Gmail connector from the Google OAuth credentials. The
@@ -59,7 +72,8 @@ func NewConnector(clientID, clientSecret, origin string) *Connector {
 			RedirectURL:  origin + "/api/v1/me/gmail/callback",
 			Scopes:       []string{GmailReadonlyScope},
 		},
-		calendarRedirect: origin + "/api/v1/me/calendar/callback",
+		calendarRedirect:       origin + "/api/v1/me/calendar/callback",
+		mentorCalendarRedirect: origin + "/api/v1/me/mentor-calendar/callback",
 	}
 }
 
@@ -140,6 +154,43 @@ func (c *Connector) ExchangeCalendar(ctx context.Context, code string) (refreshT
 	}
 	if tok.RefreshToken == "" {
 		return "", nil, errors.New("calendar: no refresh token (consent was not offline)")
+	}
+	return tok.RefreshToken, GrantedScopes(tok), nil
+}
+
+// MentorCalendarAuthCodeURL builds the consent URL for a mentor's calendar.events
+// write grant, on its own — never folded into AuthCodeURL or CalendarAuthCodeURL.
+//
+// Separate from both for the reason CalendarAuthCodeURL is separate from AuthCodeURL:
+// two costs are two decisions. This one is also separate in KIND, not just degree — it
+// is the only write consent this connector ever asks for — so it gets its own
+// redirect and, in the handler, its own CSRF cookie, even though a successful exchange
+// lands in the same gmail_connections row as every other Google grant this account may
+// hold. Incremental, so a mentor who is also a candidate with mail/calendar-read
+// connected keeps those too.
+func (c *Connector) MentorCalendarAuthCodeURL(state string) string {
+	cfg := *c.cfg
+	cfg.Scopes = []string{CalendarEventsScope}
+	cfg.RedirectURL = c.mentorCalendarRedirect
+	return cfg.AuthCodeURL(state,
+		oauth2.AccessTypeOffline,
+		oauth2.SetAuthURLParam("prompt", "consent"),
+		oauth2.SetAuthURLParam("include_granted_scopes", "true"),
+	)
+}
+
+// ExchangeMentorCalendar turns the mentor-calendar callback's code into a refresh
+// token, exactly as ExchangeCalendar does for the read-only flow.
+func (c *Connector) ExchangeMentorCalendar(ctx context.Context, code string) (refreshToken string, scopes []string, err error) {
+	cfg := *c.cfg
+	cfg.Scopes = []string{CalendarEventsScope}
+	cfg.RedirectURL = c.mentorCalendarRedirect
+	tok, err := cfg.Exchange(safehttp.GuardedOAuth2Context(ctx, gmailHTTPTimeout), code)
+	if err != nil {
+		return "", nil, fmt.Errorf("mentor calendar: exchange code: %w", err)
+	}
+	if tok.RefreshToken == "" {
+		return "", nil, errors.New("mentor calendar: no refresh token (consent was not offline)")
 	}
 	return tok.RefreshToken, GrantedScopes(tok), nil
 }

--- a/internal/application/gmailsync/connector_test.go
+++ b/internal/application/gmailsync/connector_test.go
@@ -65,3 +65,37 @@ func TestConsentURLsAskForOneThingEach(t *testing.T) {
 		t.Errorf("the calendar consent was not incremental: %s", calendar)
 	}
 }
+
+// A mentor's write consent is a third, separate ask: neither the mail flow nor the
+// candidate's read-only calendar flow may request calendar.events, and the mentor
+// flow's own URL must be incremental (keeping whatever else the account already holds)
+// and land on its own redirect, distinct from both other flows'.
+func TestMentorCalendarAuthCodeURL(t *testing.T) {
+	c := NewConnector("id", "secret", "https://freehire.me")
+
+	mail := c.AuthCodeURL("state-1")
+	calendarRead := c.CalendarAuthCodeURL("state-2")
+	mentorCalendar := c.MentorCalendarAuthCodeURL("state-3")
+
+	if strings.Contains(mail, "calendar") {
+		t.Errorf("the mail consent requested a calendar scope: %s", mail)
+	}
+	if strings.Contains(calendarRead, url.QueryEscape(CalendarEventsScope)) {
+		t.Errorf("the read-only calendar consent requested the write scope: %s", calendarRead)
+	}
+
+	u, err := url.Parse(mentorCalendar)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	q := u.Query()
+	if !strings.Contains(q.Get("scope"), CalendarEventsScope) {
+		t.Errorf("scope missing calendar.events: %q", q.Get("scope"))
+	}
+	if q.Get("include_granted_scopes") != "true" {
+		t.Errorf("include_granted_scopes = %q, want true", q.Get("include_granted_scopes"))
+	}
+	if q.Get("redirect_uri") != "https://freehire.me/api/v1/me/mentor-calendar/callback" {
+		t.Errorf("redirect_uri = %q, want its own callback distinct from the candidate calendar flow's", q.Get("redirect_uri"))
+	}
+}

--- a/internal/engage/mentorship/booking.go
+++ b/internal/engage/mentorship/booking.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/strelov1/freehire/internal/application/gmailsync"
 )
 
 // The statuses a booking holds. There is no `completed`: completion is not a decision
@@ -116,11 +119,16 @@ func (s *Service) Book(ctx context.Context, in BookingInput) (Booking, error) {
 		Note:           in.Note,
 		SeekerTimezone: in.SeekerTimezone,
 		// A snapshot. A mentor changing their link afterwards must not rewrite the
-		// invitation somebody already has in their calendar.
+		// invitation somebody already has in their calendar. Overwritten below when the
+		// mentor's calendar mints a real one instead.
 		MeetingURL: mentor.MeetingURL,
 	})
 	if err != nil {
 		return Booking{}, err
+	}
+
+	if s.calendar != nil {
+		s.attachMeetEvent(ctx, mentor, &booking)
 	}
 
 	// Best-effort, and after the write: the seeker holds the hour whether or not the
@@ -131,6 +139,49 @@ func (s *Service) Book(ctx context.Context, in BookingInput) (Booking, error) {
 		}
 	}
 	return booking, nil
+}
+
+// attachMeetEvent asks the mentor's calendar for a Meet-carrying event once a booking has
+// committed, and reconciles the row to what actually happened. Every path is best-effort:
+// the seeker already holds the hour, and a booking with no link — or a stale static one —
+// is recoverable, while a lost hour is not.
+func (s *Service) attachMeetEvent(ctx context.Context, mentor Profile, booking *Booking) {
+	eventID, meetLink, err := s.calendar.CreateMeetEvent(ctx, mentor.UserID, MeetEventInput{
+		StartsAt:    booking.StartsAt,
+		EndsAt:      booking.EndsAt,
+		SeekerEmail: booking.SeekerEmail,
+		Summary:     "Mentorship session with " + mentor.DisplayName,
+	})
+	switch {
+	case errors.Is(err, ErrCalendarNotConnected):
+		// The row already carries the mentor's static link from CreateBooking above —
+		// today's behaviour, unchanged.
+		return
+	case err != nil:
+		logDeliveryFailure("calendar event", *booking, err)
+		// This mentor DOES hold a calendar.events grant — CreateMeetEvent would have
+		// answered ErrCalendarNotConnected above otherwise — so the static link the row
+		// still carries is stale rather than a fallback worth keeping; an explicit empty
+		// answer beats surfacing a link nobody chose for this session.
+		if setErr := s.repo.SetBookingCalendarEvent(ctx, booking.ID, "", ""); setErr != nil {
+			log.Printf("mentorship: clearing booking %s's link after a failed calendar write: %v", booking.ID, setErr)
+		} else {
+			booking.MeetingURL = ""
+			booking.GoogleEventID = ""
+		}
+		if gmailsync.RevokedGrant(err) {
+			if markErr := s.repo.MarkCalendarGrantNeedsReconsent(ctx, mentor.UserID); markErr != nil {
+				log.Printf("mentorship: marking mentor %d needs_reconsent: %v", mentor.UserID, markErr)
+			}
+		}
+	default:
+		if setErr := s.repo.SetBookingCalendarEvent(ctx, booking.ID, meetLink, eventID); setErr != nil {
+			logDeliveryFailure("calendar event", *booking, setErr)
+			return
+		}
+		booking.MeetingURL = meetLink
+		booking.GoogleEventID = eventID
+	}
 }
 
 // Cancel ends a confirmed session before it starts. Either party may; nobody else can
@@ -146,6 +197,16 @@ func (s *Service) Cancel(ctx context.Context, bookingID uuid.UUID, actorID int64
 		by = CancelledByMentor
 	}
 	s.notifyCancelled(ctx, []Booking{booking}, by, reason)
+
+	// Best-effort cleanup of the calendar event the booking minted, if any. The session
+	// is already cancelled and its parties already told; a failure here costs nobody
+	// anything but a stray event on the mentor's own calendar.
+	if booking.GoogleEventID != "" && s.calendar != nil {
+		if err := s.calendar.DeleteMeetEvent(ctx, booking.MentorUserID, booking.GoogleEventID); err != nil {
+			logDeliveryFailure("calendar event deletion", booking, err)
+		}
+	}
+
 	return booking, nil
 }
 

--- a/internal/engage/mentorship/booking.go
+++ b/internal/engage/mentorship/booking.go
@@ -163,11 +163,8 @@ func (s *Service) attachMeetEvent(ctx context.Context, mentor Profile, booking *
 		// answered ErrCalendarNotConnected above otherwise — so the static link the row
 		// still carries is stale rather than a fallback worth keeping; an explicit empty
 		// answer beats surfacing a link nobody chose for this session.
-		if setErr := s.repo.SetBookingCalendarEvent(ctx, booking.ID, "", ""); setErr != nil {
-			log.Printf("mentorship: clearing booking %s's link after a failed calendar write: %v", booking.ID, setErr)
-		} else {
-			booking.MeetingURL = ""
-			booking.GoogleEventID = ""
+		if setErr := s.setCalendarEvent(ctx, booking, "", ""); setErr != nil {
+			logDeliveryFailure("calendar event reset", *booking, setErr)
 		}
 		if gmailsync.RevokedGrant(err) {
 			if markErr := s.repo.MarkCalendarGrantNeedsReconsent(ctx, mentor.UserID); markErr != nil {
@@ -175,12 +172,35 @@ func (s *Service) attachMeetEvent(ctx context.Context, mentor Profile, booking *
 			}
 		}
 	default:
-		if setErr := s.repo.SetBookingCalendarEvent(ctx, booking.ID, meetLink, eventID); setErr != nil {
-			logDeliveryFailure("calendar event", *booking, setErr)
-			return
+		if setErr := s.setCalendarEvent(ctx, booking, meetLink, eventID); setErr != nil {
+			logDeliveryFailure("calendar event record", *booking, setErr)
 		}
-		booking.MeetingURL = meetLink
-		booking.GoogleEventID = eventID
+	}
+}
+
+// setCalendarEvent writes a booking's calendar-event fields and, on success, patches the
+// same values onto the in-memory booking — used both when a real event was minted and
+// when a failed write clears a now-stale static link, so the caller sees what was
+// actually stored either way.
+func (s *Service) setCalendarEvent(ctx context.Context, booking *Booking, meetingURL, eventID string) error {
+	if err := s.repo.SetBookingCalendarEvent(ctx, booking.ID, meetingURL, eventID); err != nil {
+		return err
+	}
+	booking.MeetingURL = meetingURL
+	booking.GoogleEventID = eventID
+	return nil
+}
+
+// deleteMeetEventBestEffort removes the calendar event a booking minted, if any, ignoring
+// (but logging) any failure — used by both Cancel and Withdraw's bulk cancellation, so a
+// mentor leaving the marketplace does not leave stray Meet events behind on their own
+// calendar for sessions freehire has already told everyone are off.
+func (s *Service) deleteMeetEventBestEffort(ctx context.Context, booking Booking) {
+	if booking.GoogleEventID == "" || s.calendar == nil {
+		return
+	}
+	if err := s.calendar.DeleteMeetEvent(ctx, booking.MentorUserID, booking.GoogleEventID); err != nil {
+		logDeliveryFailure("calendar event deletion", booking, err)
 	}
 }
 
@@ -197,15 +217,7 @@ func (s *Service) Cancel(ctx context.Context, bookingID uuid.UUID, actorID int64
 		by = CancelledByMentor
 	}
 	s.notifyCancelled(ctx, []Booking{booking}, by, reason)
-
-	// Best-effort cleanup of the calendar event the booking minted, if any. The session
-	// is already cancelled and its parties already told; a failure here costs nobody
-	// anything but a stray event on the mentor's own calendar.
-	if booking.GoogleEventID != "" && s.calendar != nil {
-		if err := s.calendar.DeleteMeetEvent(ctx, booking.MentorUserID, booking.GoogleEventID); err != nil {
-			logDeliveryFailure("calendar event deletion", booking, err)
-		}
-	}
+	s.deleteMeetEventBestEffort(ctx, booking)
 
 	return booking, nil
 }

--- a/internal/engage/mentorship/booking_test.go
+++ b/internal/engage/mentorship/booking_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/strelov1/freehire/internal/application/gmailsync"
 )
 
 // bookableMentor is an approved mentor free every Tuesday 18:00–22:00 Berlin, hour-long
@@ -44,6 +46,18 @@ func tuesdayAt(t *testing.T, hour int) time.Time {
 func bookingService(repo *fakeRepo, notifier Notifier) *Service {
 	return New(repo, Config{
 		Notifier: notifier,
+		Now: func() time.Time {
+			return time.Date(2026, time.September, 7, 9, 0, 0, 0, time.UTC)
+		},
+	})
+}
+
+// bookingServiceWithCalendar is bookingService plus a CalendarLinker, for the tests that
+// exercise the connected-mentor path.
+func bookingServiceWithCalendar(repo *fakeRepo, notifier Notifier, calendar CalendarLinker) *Service {
+	return New(repo, Config{
+		Notifier:       notifier,
+		CalendarLinker: calendar,
 		Now: func() time.Time {
 			return time.Date(2026, time.September, 7, 9, 0, 0, 0, time.UTC)
 		},
@@ -255,6 +269,185 @@ func TestAFailedConfirmationDoesNotUndoTheBooking(t *testing.T) {
 	}
 	if booking.Status != BookingConfirmed {
 		t.Errorf("status = %q, want confirmed", booking.Status)
+	}
+}
+
+// A mentor with no calendar linker configured at all books byte-for-byte identically to
+// today — the regression guard for the whole feature's overwhelming common case.
+func TestBookingAnUnconnectedMentorIsUnchanged(t *testing.T) {
+	repo := newFakeRepo()
+	notifier := &fakeNotifier{}
+	mentor := bookableMentor(t, repo)
+	svc := bookingService(repo, notifier)
+
+	booking, err := svc.Book(context.Background(), BookingInput{
+		MentorSlug: mentor.Slug, SeekerUserID: 42,
+		StartsAt: tuesdayAt(t, 18), SeekerTimezone: "Asia/Tokyo",
+	})
+	if err != nil {
+		t.Fatalf("Book: %v", err)
+	}
+	if booking.MeetingURL != mentor.MeetingURL {
+		t.Errorf("meeting link = %q, want the mentor's static link %q", booking.MeetingURL, mentor.MeetingURL)
+	}
+	if booking.GoogleEventID != "" {
+		t.Errorf("GoogleEventID = %q, want empty", booking.GoogleEventID)
+	}
+}
+
+// A mentor with a calendar linker configured but no actual grant (the ordinary case even
+// once the feature ships, until a mentor opts in) also books unchanged: CreateMeetEvent
+// answers ErrCalendarNotConnected and Book() leaves the static snapshot alone.
+func TestBookingAMentorWithNoGrantIsUnchanged(t *testing.T) {
+	repo := newFakeRepo()
+	notifier := &fakeNotifier{}
+	mentor := bookableMentor(t, repo)
+	linker := &fakeCalendarLinker{err: ErrCalendarNotConnected}
+	svc := bookingServiceWithCalendar(repo, notifier, linker)
+
+	booking, err := svc.Book(context.Background(), BookingInput{
+		MentorSlug: mentor.Slug, SeekerUserID: 42,
+		StartsAt: tuesdayAt(t, 18), SeekerTimezone: "Asia/Tokyo",
+	})
+	if err != nil {
+		t.Fatalf("Book: %v", err)
+	}
+	if booking.MeetingURL != mentor.MeetingURL {
+		t.Errorf("meeting link = %q, want the mentor's static link", booking.MeetingURL)
+	}
+	if linker.calls != 1 {
+		t.Errorf("CreateMeetEvent called %d times, want 1", linker.calls)
+	}
+}
+
+// A connected mentor's booking carries the calendar's own Meet link and event id — not
+// the mentor's static one — and the notifier receives that same link.
+func TestBookingAConnectedMentorUsesTheCalendarLink(t *testing.T) {
+	repo := newFakeRepo()
+	notifier := &fakeNotifier{}
+	mentor := bookableMentor(t, repo)
+	linker := &fakeCalendarLinker{eventID: "evt-1", meetLink: "https://meet.google.com/xyz-abcd-efg"}
+	svc := bookingServiceWithCalendar(repo, notifier, linker)
+
+	booking, err := svc.Book(context.Background(), BookingInput{
+		MentorSlug: mentor.Slug, SeekerUserID: 42,
+		StartsAt: tuesdayAt(t, 18), SeekerTimezone: "Asia/Tokyo",
+	})
+	if err != nil {
+		t.Fatalf("Book: %v", err)
+	}
+	if booking.MeetingURL != "https://meet.google.com/xyz-abcd-efg" {
+		t.Errorf("meeting link = %q, want the calendar's own link", booking.MeetingURL)
+	}
+	if booking.GoogleEventID != "evt-1" {
+		t.Errorf("GoogleEventID = %q, want evt-1", booking.GoogleEventID)
+	}
+	if len(notifier.confirmed) != 1 || notifier.confirmed[0].MeetingURL != booking.MeetingURL {
+		t.Errorf("the notifier did not receive the calendar's link")
+	}
+	if got := repo.setBookingCalendarEvent[booking.ID]; got != [2]string{booking.MeetingURL, "evt-1"} {
+		t.Errorf("SetBookingCalendarEvent recorded %v", got)
+	}
+}
+
+// A CreateMeetEvent failure that is NOT ErrCalendarNotConnected still returns a confirmed
+// booking, with an EMPTY link rather than the mentor's stale static one — the explicit
+// decision this feature's design settled on over silently falling back.
+func TestBookingCalendarFailureLeavesTheLinkEmptyButStillBooks(t *testing.T) {
+	repo := newFakeRepo()
+	notifier := &fakeNotifier{}
+	mentor := bookableMentor(t, repo)
+	linker := &fakeCalendarLinker{err: errors.New("google: rate limited")}
+	svc := bookingServiceWithCalendar(repo, notifier, linker)
+
+	booking, err := svc.Book(context.Background(), BookingInput{
+		MentorSlug: mentor.Slug, SeekerUserID: 42,
+		StartsAt: tuesdayAt(t, 18), SeekerTimezone: "Asia/Tokyo",
+	})
+	if err != nil {
+		t.Fatalf("Book: %v — a calendar failure must not fail the booking", err)
+	}
+	if booking.Status != BookingConfirmed {
+		t.Errorf("status = %q, want confirmed", booking.Status)
+	}
+	if booking.MeetingURL != "" {
+		t.Errorf("meeting link = %q, want empty", booking.MeetingURL)
+	}
+	if repo.needsReconsent[mentor.UserID] {
+		t.Error("a non-revocation failure must not mark needs_reconsent")
+	}
+}
+
+// A revocation-shaped calendar failure additionally marks the mentor's grant for
+// re-consent, the same mechanism gmailsync's own sync worker uses for the read-side
+// grants.
+func TestBookingCalendarRevocationMarksNeedsReconsent(t *testing.T) {
+	repo := newFakeRepo()
+	notifier := &fakeNotifier{}
+	mentor := bookableMentor(t, repo)
+	linker := &fakeCalendarLinker{err: &gmailsync.APIError{Op: "mentor calendar: create event", StatusCode: 401, Status: "401 Unauthorized"}}
+	svc := bookingServiceWithCalendar(repo, notifier, linker)
+
+	if _, err := svc.Book(context.Background(), BookingInput{
+		MentorSlug: mentor.Slug, SeekerUserID: 42,
+		StartsAt: tuesdayAt(t, 18), SeekerTimezone: "Asia/Tokyo",
+	}); err != nil {
+		t.Fatalf("Book: %v", err)
+	}
+	if !repo.needsReconsent[mentor.UserID] {
+		t.Error("a revocation-shaped failure must mark needs_reconsent")
+	}
+}
+
+// Cancelling a booking with an event id best-effort deletes it; the mentor's own user id
+// is what DeleteMeetEvent is called with, since the grant lives on the mentor's account.
+func TestCancellingABookingWithAnEventDeletesIt(t *testing.T) {
+	repo := newFakeRepo()
+	notifier := &fakeNotifier{}
+	mentor := bookableMentor(t, repo)
+	linker := &fakeCalendarLinker{eventID: "evt-1", meetLink: "https://meet.google.com/xyz"}
+	svc := bookingServiceWithCalendar(repo, notifier, linker)
+
+	booking, err := svc.Book(context.Background(), BookingInput{
+		MentorSlug: mentor.Slug, SeekerUserID: 42,
+		StartsAt: tuesdayAt(t, 18), SeekerTimezone: "Asia/Tokyo",
+	})
+	if err != nil {
+		t.Fatalf("Book: %v", err)
+	}
+
+	if _, err := svc.Cancel(context.Background(), booking.ID, 42, "changed my mind"); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if linker.deletedEventID != "evt-1" {
+		t.Errorf("DeleteMeetEvent called with %q, want evt-1", linker.deletedEventID)
+	}
+}
+
+// A DeleteMeetEvent failure must not fail the cancellation: the session is already off
+// and both parties already told, and a stray event on the mentor's own calendar costs
+// nobody anything a retried cancel could fix.
+func TestCancellingSurvivesADeleteMeetEventFailure(t *testing.T) {
+	repo := newFakeRepo()
+	notifier := &fakeNotifier{}
+	mentor := bookableMentor(t, repo)
+	linker := &fakeCalendarLinker{eventID: "evt-1", meetLink: "https://meet.google.com/xyz", deleteErr: errors.New("google: unavailable")}
+	svc := bookingServiceWithCalendar(repo, notifier, linker)
+
+	booking, err := svc.Book(context.Background(), BookingInput{
+		MentorSlug: mentor.Slug, SeekerUserID: 42,
+		StartsAt: tuesdayAt(t, 18), SeekerTimezone: "Asia/Tokyo",
+	})
+	if err != nil {
+		t.Fatalf("Book: %v", err)
+	}
+
+	cancelled, err := svc.Cancel(context.Background(), booking.ID, 42, "changed my mind")
+	if err != nil {
+		t.Fatalf("Cancel: %v — a delete failure must not fail the cancellation", err)
+	}
+	if cancelled.Status != BookingCancelled {
+		t.Errorf("status = %q, want cancelled", cancelled.Status)
 	}
 }
 

--- a/internal/engage/mentorship/fake_repo_test.go
+++ b/internal/engage/mentorship/fake_repo_test.go
@@ -44,7 +44,6 @@ type fakeRepo struct {
 	calendarGrants          map[int64]fakeCalendarGrant
 	needsReconsent          map[int64]bool
 	setBookingCalendarEvent map[uuid.UUID][2]string // bookingID -> [meetingURL, eventID]
-	setBookingCalendarEvErr error
 }
 
 type fakeCalendarGrant struct {
@@ -414,9 +413,6 @@ func (r *fakeRepo) GetMentorCalendarGrant(_ context.Context, userID int64) (stri
 }
 
 func (r *fakeRepo) SetBookingCalendarEvent(_ context.Context, bookingID uuid.UUID, meetingURL, eventID string) error {
-	if r.setBookingCalendarEvErr != nil {
-		return r.setBookingCalendarEvErr
-	}
 	r.setBookingCalendarEvent[bookingID] = [2]string{meetingURL, eventID}
 	b := r.bookings[bookingID]
 	b.MeetingURL = meetingURL

--- a/internal/engage/mentorship/fake_repo_test.go
+++ b/internal/engage/mentorship/fake_repo_test.go
@@ -39,6 +39,17 @@ type fakeRepo struct {
 
 	withdrawn             bool
 	cancelledBeforeDelete int
+
+	// calendarGrants stands in for gmail_connections, keyed by the mentor's user id.
+	calendarGrants          map[int64]fakeCalendarGrant
+	needsReconsent          map[int64]bool
+	setBookingCalendarEvent map[uuid.UUID][2]string // bookingID -> [meetingURL, eventID]
+	setBookingCalendarEvErr error
+}
+
+type fakeCalendarGrant struct {
+	refreshTokenEnc string
+	scopes          []string
 }
 
 type referralKey struct {
@@ -48,14 +59,17 @@ type referralKey struct {
 
 func newFakeRepo() *fakeRepo {
 	return &fakeRepo{
-		profiles:               map[int64]Profile{},
-		byUser:                 map[int64]int64{},
-		approvedReferralOffers: map[referralKey]bool{},
-		futureBookings:         map[int64][]Booking{},
-		availability:           map[int64][]Rule{},
-		bookings:               map[uuid.UUID]Booking{},
-		reviews:                map[uuid.UUID]Review{},
-		remindersSent:          map[reminderKey]bool{},
+		profiles:                map[int64]Profile{},
+		byUser:                  map[int64]int64{},
+		approvedReferralOffers:  map[referralKey]bool{},
+		futureBookings:          map[int64][]Booking{},
+		availability:            map[int64][]Rule{},
+		bookings:                map[uuid.UUID]Booking{},
+		reviews:                 map[uuid.UUID]Review{},
+		remindersSent:           map[reminderKey]bool{},
+		calendarGrants:          map[int64]fakeCalendarGrant{},
+		needsReconsent:          map[int64]bool{},
+		setBookingCalendarEvent: map[uuid.UUID][2]string{},
 	}
 }
 
@@ -391,6 +405,31 @@ func (r *fakeRepo) ReleaseReminderClaim(_ context.Context, bookingID uuid.UUID, 
 	return nil
 }
 
+func (r *fakeRepo) GetMentorCalendarGrant(_ context.Context, userID int64) (string, []string, bool, error) {
+	g, ok := r.calendarGrants[userID]
+	if !ok {
+		return "", nil, false, nil
+	}
+	return g.refreshTokenEnc, g.scopes, true, nil
+}
+
+func (r *fakeRepo) SetBookingCalendarEvent(_ context.Context, bookingID uuid.UUID, meetingURL, eventID string) error {
+	if r.setBookingCalendarEvErr != nil {
+		return r.setBookingCalendarEvErr
+	}
+	r.setBookingCalendarEvent[bookingID] = [2]string{meetingURL, eventID}
+	b := r.bookings[bookingID]
+	b.MeetingURL = meetingURL
+	b.GoogleEventID = eventID
+	r.bookings[bookingID] = b
+	return nil
+}
+
+func (r *fakeRepo) MarkCalendarGrantNeedsReconsent(_ context.Context, userID int64) error {
+	r.needsReconsent[userID] = true
+	return nil
+}
+
 type reminderKey struct {
 	booking uuid.UUID
 	offset  time.Duration
@@ -431,4 +470,28 @@ func (n *fakeNotifier) BookingReminder(_ context.Context, _ Booking, before time
 	}
 	n.reminders = append(n.reminders, before)
 	return nil
+}
+
+// fakeCalendarLinker stands in for CalendarLinker, so Book()/Cancel() are tested without
+// Google. deletedEventIDs records what Cancel() asked it to remove.
+type fakeCalendarLinker struct {
+	err            error
+	eventID        string
+	meetLink       string
+	deletedEventID string
+	deleteErr      error
+	calls          int
+}
+
+func (l *fakeCalendarLinker) CreateMeetEvent(_ context.Context, _ int64, _ MeetEventInput) (string, string, error) {
+	l.calls++
+	if l.err != nil {
+		return "", "", l.err
+	}
+	return l.eventID, l.meetLink, nil
+}
+
+func (l *fakeCalendarLinker) DeleteMeetEvent(_ context.Context, _ int64, eventID string) error {
+	l.deletedEventID = eventID
+	return l.deleteErr
 }

--- a/internal/engage/mentorship/googlemeet.go
+++ b/internal/engage/mentorship/googlemeet.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"slices"
@@ -181,6 +182,15 @@ func (a *meetAPI) createEvent(ctx context.Context, in MeetEventInput) (string, s
 	var out meetEvent
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return "", "", fmt.Errorf("mentor calendar: decode event: %w", err)
+	}
+	if out.HangoutLink == "" {
+		// Google's own docs allow conferenceData.createRequest to still be PENDING when
+		// the event insert itself answers 200/201 — the conference is provisioned
+		// asynchronously and the link is absent until it resolves. Retrying later is out
+		// of scope (see design.md), so the event is kept and the booking's link stays
+		// empty exactly as it would on any other failure — this just makes the otherwise
+		// silent case visible in logs.
+		log.Printf("mentor calendar: event %s created with no hangoutLink yet (conference still pending)", out.ID)
 	}
 	return out.ID, out.HangoutLink, nil
 }

--- a/internal/engage/mentorship/googlemeet.go
+++ b/internal/engage/mentorship/googlemeet.go
@@ -1,0 +1,204 @@
+package mentorship
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/strelov1/freehire/internal/application/gmailsync"
+	"github.com/strelov1/freehire/internal/platform/tokencrypt"
+)
+
+// ErrCalendarNotConnected reports that this mentor holds no usable calendar.events grant —
+// no row, a row in some other status (needs_reconsent included), or one whose scopes never
+// covered the write. Book() treats it as the ordinary, overwhelmingly common case: fall back
+// to the mentor's static MeetingURL, exactly as if this feature did not exist.
+var ErrCalendarNotConnected = errors.New("mentorship: mentor has not connected a calendar")
+
+// meetEventsURL is the same primary-calendar collection calsync reads, POSTed and DELETEd
+// here instead of listed. One mentor's own calendar, never a shared or secondary one.
+const meetEventsURL = "https://www.googleapis.com/calendar/v3/calendars/primary/events"
+
+// MeetEventInput is what one booking needs turned into a calendar event.
+type MeetEventInput struct {
+	StartsAt    time.Time
+	EndsAt      time.Time
+	SeekerEmail string
+	Summary     string
+}
+
+// CalendarLinker creates and deletes the Google Calendar event that carries a booking's
+// Meet link. Behind an interface so Book()/Cancel() are tested without Google, and nil-safe
+// on Service exactly as Notifier and Cache already are — a deployment with no Google client
+// configured gets today's static-link behaviour, not a broken one.
+type CalendarLinker interface {
+	CreateMeetEvent(ctx context.Context, userID int64, in MeetEventInput) (eventID, meetLink string, err error)
+	DeleteMeetEvent(ctx context.Context, userID int64, eventID string) error
+}
+
+// calendarGrantReader is the one Repository method GoogleCalendarLinker needs. Named
+// narrowly rather than taking the full Repository so the linker's dependency is legible on
+// its own constructor, though in production it is the same *QueriesRepository the Service
+// holds.
+type calendarGrantReader interface {
+	GetMentorCalendarGrant(ctx context.Context, userID int64) (refreshTokenEnc string, scopes []string, found bool, err error)
+}
+
+// GoogleCalendarLinker implements CalendarLinker against the real Google Calendar API. It is
+// the first place in this codebase that WRITES to that API — every other reader
+// (internal/application/calsync) only lists.
+type GoogleCalendarLinker struct {
+	repo      calendarGrantReader
+	connector *gmailsync.Connector
+	cipher    *tokencrypt.Cipher
+}
+
+// NewGoogleCalendarLinker builds the linker. connector mints the token-bearing HTTP client
+// from a decrypted refresh token, exactly as it already does for calsync's reader.
+func NewGoogleCalendarLinker(repo calendarGrantReader, connector *gmailsync.Connector, cipher *tokencrypt.Cipher) *GoogleCalendarLinker {
+	return &GoogleCalendarLinker{repo: repo, connector: connector, cipher: cipher}
+}
+
+// resolve turns a mentor's grant into an authenticated meetAPI, or reports
+// ErrCalendarNotConnected — the one gate both CreateMeetEvent and DeleteMeetEvent share, so
+// a grant that stops qualifying refuses both identically.
+func (l *GoogleCalendarLinker) resolve(ctx context.Context, userID int64) (*meetAPI, error) {
+	encToken, scopes, found, err := l.repo.GetMentorCalendarGrant(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	if !found || !slices.Contains(scopes, gmailsync.CalendarEventsScope) {
+		return nil, ErrCalendarNotConnected
+	}
+	refresh, err := l.cipher.Decrypt(encToken)
+	if err != nil {
+		return nil, fmt.Errorf("mentor calendar: decrypt token: %w", err)
+	}
+	return newMeetAPI(l.connector.HTTPClient(ctx, refresh)), nil
+}
+
+// HasConnectedCalendar reports whether userID holds a usable calendar.events grant —
+// what the profile validation and the frontend both need to decide whether the meeting
+// link field is still required. Uses the same Repository method CreateMeetEvent's own
+// gate does, so the two can never disagree about what "connected" means.
+func (s *Service) HasConnectedCalendar(ctx context.Context, userID int64) (bool, error) {
+	_, scopes, found, err := s.repo.GetMentorCalendarGrant(ctx, userID)
+	if err != nil {
+		return false, err
+	}
+	return found && slices.Contains(scopes, gmailsync.CalendarEventsScope), nil
+}
+
+// CreateMeetEvent books a calendar event with the seeker as an attendee and a Meet link
+// requested via conferenceData, the one call in this package that mints the link Book()
+// then snapshots onto the booking.
+func (l *GoogleCalendarLinker) CreateMeetEvent(ctx context.Context, userID int64, in MeetEventInput) (string, string, error) {
+	api, err := l.resolve(ctx, userID)
+	if err != nil {
+		return "", "", err
+	}
+	return api.createEvent(ctx, in)
+}
+
+// DeleteMeetEvent best-effort removes the event Cancel() no longer needs.
+func (l *GoogleCalendarLinker) DeleteMeetEvent(ctx context.Context, userID int64, eventID string) error {
+	api, err := l.resolve(ctx, userID)
+	if err != nil {
+		return err
+	}
+	return api.deleteEvent(ctx, eventID)
+}
+
+// meetAPI does the actual Google Calendar write calls over an already-authenticated
+// client, separated from grant resolution so it is testable via httptest exactly as
+// calsync.APIReader is — the OAuth handshake is oauth2's own well-tested library code,
+// and what this package must get right is the request shape and the response parsing.
+type meetAPI struct {
+	client *http.Client
+}
+
+func newMeetAPI(client *http.Client) *meetAPI { return &meetAPI{client: client} }
+
+// meetEvent is the slice of Google's event response this package reads: its own id (to
+// delete the event later) and the Meet link conferenceDataVersion=1 minted.
+type meetEvent struct {
+	ID          string `json:"id"`
+	HangoutLink string `json:"hangoutLink"`
+}
+
+func (a *meetAPI) createEvent(ctx context.Context, in MeetEventInput) (string, string, error) {
+	payload, err := json.Marshal(map[string]any{
+		"summary": in.Summary,
+		"start":   map[string]string{"dateTime": in.StartsAt.Format(time.RFC3339)},
+		"end":     map[string]string{"dateTime": in.EndsAt.Format(time.RFC3339)},
+		"attendees": []map[string]string{
+			{"email": in.SeekerEmail},
+		},
+		"conferenceData": map[string]any{
+			"createRequest": map[string]any{
+				"requestId":             uuid.NewString(),
+				"conferenceSolutionKey": map[string]string{"type": "hangoutsMeet"},
+			},
+		},
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("mentor calendar: encode event: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		meetEventsURL+"?conferenceDataVersion=1", bytes.NewReader(payload))
+	if err != nil {
+		return "", "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("mentor calendar: create event: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return "", "", &gmailsync.APIError{
+			Op: "mentor calendar: create event", StatusCode: resp.StatusCode, Status: resp.Status,
+		}
+	}
+
+	var out meetEvent
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", "", fmt.Errorf("mentor calendar: decode event: %w", err)
+	}
+	return out.ID, out.HangoutLink, nil
+}
+
+// deleteEvent removes one event. A 404/410 means it is already gone — from the mentor
+// deleting it by hand, say — and that is success, not a failure to report: the outcome
+// this call exists to produce already holds.
+func (a *meetAPI) deleteEvent(ctx context.Context, eventID string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete,
+		meetEventsURL+"/"+url.PathEscape(eventID), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("mentor calendar: delete event: %w", err)
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusNoContent, http.StatusNotFound, http.StatusGone:
+		return nil
+	default:
+		return &gmailsync.APIError{
+			Op: "mentor calendar: delete event", StatusCode: resp.StatusCode, Status: resp.Status,
+		}
+	}
+}

--- a/internal/engage/mentorship/googlemeet.go
+++ b/internal/engage/mentorship/googlemeet.go
@@ -67,6 +67,14 @@ func NewGoogleCalendarLinker(repo calendarGrantReader, connector *gmailsync.Conn
 	return &GoogleCalendarLinker{repo: repo, connector: connector, cipher: cipher}
 }
 
+// hasCalendarWriteGrant reports whether a grant read from GetMentorCalendarGrant actually
+// covers calendar.events — the one test resolve() and HasConnectedCalendar share, so the
+// booking flow's gate and the profile/frontend's "is this mentor connected?" question can
+// never disagree about what "connected" means.
+func hasCalendarWriteGrant(found bool, scopes []string) bool {
+	return found && slices.Contains(scopes, gmailsync.CalendarEventsScope)
+}
+
 // resolve turns a mentor's grant into an authenticated meetAPI, or reports
 // ErrCalendarNotConnected — the one gate both CreateMeetEvent and DeleteMeetEvent share, so
 // a grant that stops qualifying refuses both identically.
@@ -75,7 +83,7 @@ func (l *GoogleCalendarLinker) resolve(ctx context.Context, userID int64) (*meet
 	if err != nil {
 		return nil, err
 	}
-	if !found || !slices.Contains(scopes, gmailsync.CalendarEventsScope) {
+	if !hasCalendarWriteGrant(found, scopes) {
 		return nil, ErrCalendarNotConnected
 	}
 	refresh, err := l.cipher.Decrypt(encToken)
@@ -87,14 +95,13 @@ func (l *GoogleCalendarLinker) resolve(ctx context.Context, userID int64) (*meet
 
 // HasConnectedCalendar reports whether userID holds a usable calendar.events grant —
 // what the profile validation and the frontend both need to decide whether the meeting
-// link field is still required. Uses the same Repository method CreateMeetEvent's own
-// gate does, so the two can never disagree about what "connected" means.
+// link field is still required.
 func (s *Service) HasConnectedCalendar(ctx context.Context, userID int64) (bool, error) {
 	_, scopes, found, err := s.repo.GetMentorCalendarGrant(ctx, userID)
 	if err != nil {
 		return false, err
 	}
-	return found && slices.Contains(scopes, gmailsync.CalendarEventsScope), nil
+	return hasCalendarWriteGrant(found, scopes), nil
 }
 
 // CreateMeetEvent books a calendar event with the seeker as an attendee and a Meet link

--- a/internal/engage/mentorship/googlemeet_test.go
+++ b/internal/engage/mentorship/googlemeet_test.go
@@ -1,0 +1,194 @@
+package mentorship
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/strelov1/freehire/internal/application/gmailsync"
+	"github.com/strelov1/freehire/internal/platform/tokencrypt"
+)
+
+// fakeGrantReader stands in for the mentorship Repository's slice GoogleCalendarLinker
+// needs, without a database.
+type fakeGrantReader struct {
+	refreshTokenEnc string
+	scopes          []string
+	found           bool
+	err             error
+}
+
+func (f *fakeGrantReader) GetMentorCalendarGrant(context.Context, int64) (string, []string, bool, error) {
+	return f.refreshTokenEnc, f.scopes, f.found, f.err
+}
+
+// A mentor with no qualifying grant — no row, or one that never covers calendar.events —
+// refuses BOTH calls the same way, before any network call is attempted.
+func TestGoogleCalendarLinkerNotConnected(t *testing.T) {
+	cipher := mustTokenCipher(t)
+	linker := NewGoogleCalendarLinker(&fakeGrantReader{found: false}, gmailsync.NewConnector("id", "secret", "https://freehire.me"), cipher)
+
+	if _, _, err := linker.CreateMeetEvent(context.Background(), 1, MeetEventInput{}); err != ErrCalendarNotConnected {
+		t.Errorf("CreateMeetEvent err = %v, want ErrCalendarNotConnected", err)
+	}
+	if err := linker.DeleteMeetEvent(context.Background(), 1, "evt-1"); err != ErrCalendarNotConnected {
+		t.Errorf("DeleteMeetEvent err = %v, want ErrCalendarNotConnected", err)
+	}
+}
+
+// A grant that exists but never covers the write scope — a candidate's read-only calendar
+// grant, say — must not be treated as a mentor calendar connection.
+func TestGoogleCalendarLinkerWrongScope(t *testing.T) {
+	cipher := mustTokenCipher(t)
+	reader := &fakeGrantReader{found: true, scopes: []string{gmailsync.CalendarScope}, refreshTokenEnc: mustEncrypt(t, cipher, "refresh")}
+	linker := NewGoogleCalendarLinker(reader, gmailsync.NewConnector("id", "secret", "https://freehire.me"), cipher)
+
+	if _, _, err := linker.CreateMeetEvent(context.Background(), 1, MeetEventInput{}); err != ErrCalendarNotConnected {
+		t.Errorf("err = %v, want ErrCalendarNotConnected", err)
+	}
+}
+
+func mustTokenCipher(t *testing.T) *tokencrypt.Cipher {
+	t.Helper()
+	c, err := tokencrypt.New([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("tokencrypt.New: %v", err)
+	}
+	return c
+}
+
+func mustEncrypt(t *testing.T, c *tokencrypt.Cipher, plaintext string) string {
+	t.Helper()
+	enc, err := c.Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	return enc
+}
+
+// reqCapture holds the last request a stub server received. A pointer to it, not a bare
+// *http.Request, because apiAgainst must return before the test issues the call the
+// capture records.
+type reqCapture struct{ req *http.Request }
+
+// apiAgainst builds a meetAPI against a stub server, mirroring
+// calsync.readerAgainstFunc's pattern: a rewriting transport keeps the production URL
+// constant under test rather than parameterising it for tests alone.
+func apiAgainst(t *testing.T, handler http.HandlerFunc) (*meetAPI, *reqCapture) {
+	t.Helper()
+	rc := &reqCapture{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rc.req = r
+		handler(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	api := newMeetAPI(&http.Client{Transport: rewriteToTestServer{base: srv.URL}})
+	return api, rc
+}
+
+// rewriteToTestServer sends every request to the stub server while preserving the
+// original request's method, path and body — meetEventsURL's own path segment (an event
+// id appended for DELETE) must survive the rewrite, unlike a query-only GET.
+type rewriteToTestServer struct{ base string }
+
+func (t rewriteToTestServer) RoundTrip(r *http.Request) (*http.Response, error) {
+	stubURL := t.base + r.URL.Path
+	if r.URL.RawQuery != "" {
+		stubURL += "?" + r.URL.RawQuery
+	}
+	stub, err := http.NewRequestWithContext(r.Context(), r.Method, stubURL, r.Body)
+	if err != nil {
+		return nil, err
+	}
+	stub.Header = r.Header
+	return http.DefaultTransport.RoundTrip(stub)
+}
+
+func TestMeetAPICreateEventParsesTheCanonicalResponse(t *testing.T) {
+	api, req := apiAgainst(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"evt-123","hangoutLink":"https://meet.google.com/abc-defg-hij"}`))
+	})
+
+	id, link, err := api.createEvent(context.Background(), MeetEventInput{
+		StartsAt:    time.Date(2026, 9, 10, 15, 0, 0, 0, time.UTC),
+		EndsAt:      time.Date(2026, 9, 10, 15, 30, 0, 0, time.UTC),
+		SeekerEmail: "seeker@example.com",
+		Summary:     "freehire mentorship session",
+	})
+	if err != nil {
+		t.Fatalf("createEvent: %v", err)
+	}
+	if id != "evt-123" {
+		t.Errorf("id = %q, want evt-123", id)
+	}
+	if link != "https://meet.google.com/abc-defg-hij" {
+		t.Errorf("link = %q", link)
+	}
+	if req.req.URL.Query().Get("conferenceDataVersion") != "1" {
+		t.Errorf("conferenceDataVersion missing: %s", req.req.URL.RawQuery)
+	}
+}
+
+// A 401/403 must come back as gmailsync.APIError so RevokedGrant recognises it — the
+// signal Book() uses to mark the grant needs_reconsent.
+func TestMeetAPICreateEventRevokedGrant(t *testing.T) {
+	api, _ := apiAgainst(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+
+	_, _, err := api.createEvent(context.Background(), MeetEventInput{})
+	if err == nil {
+		t.Fatal("createEvent: want an error on 403")
+	}
+	if !gmailsync.RevokedGrant(err) {
+		t.Errorf("RevokedGrant(%v) = false, want true", err)
+	}
+}
+
+// A 500 is Google having a bad day, not a revocation — RevokedGrant must say so, or a
+// transient failure would cost a mentor their calendar connection.
+func TestMeetAPICreateEventTransientFailureIsNotRevocation(t *testing.T) {
+	api, _ := apiAgainst(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, _, err := api.createEvent(context.Background(), MeetEventInput{})
+	if err == nil {
+		t.Fatal("createEvent: want an error on 500")
+	}
+	if gmailsync.RevokedGrant(err) {
+		t.Errorf("RevokedGrant(%v) = true, want false", err)
+	}
+}
+
+func TestMeetAPIDeleteEventSuccess(t *testing.T) {
+	api, req := apiAgainst(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	if err := api.deleteEvent(context.Background(), "evt-123"); err != nil {
+		t.Fatalf("deleteEvent: %v", err)
+	}
+	if req.req.Method != http.MethodDelete {
+		t.Errorf("method = %s, want DELETE", req.req.Method)
+	}
+}
+
+// An event already gone (deleted by hand, say) is success: Cancel()'s best-effort cleanup
+// must not treat "already achieved the outcome" as a failure.
+func TestMeetAPIDeleteEventAlreadyGoneIsSuccess(t *testing.T) {
+	for _, status := range []int{http.StatusNotFound, http.StatusGone} {
+		api, _ := apiAgainst(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(status)
+		})
+		if err := api.deleteEvent(context.Background(), "evt-123"); err != nil {
+			t.Errorf("status %d: deleteEvent err = %v, want nil", status, err)
+		}
+	}
+}

--- a/internal/engage/mentorship/googlemeet_test.go
+++ b/internal/engage/mentorship/googlemeet_test.go
@@ -136,6 +136,28 @@ func TestMeetAPICreateEventParsesTheCanonicalResponse(t *testing.T) {
 	}
 }
 
+// Google may answer 200 with the conference still provisioning asynchronously
+// (conferenceData.createRequest.status "pending"), so hangoutLink can legitimately be
+// absent on an otherwise successful insert. That must not be read as an error — the
+// event id still comes back so the caller can hold onto it — only the link is empty.
+func TestMeetAPICreateEventToleratesAPendingConference(t *testing.T) {
+	api, _ := apiAgainst(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"evt-456"}`))
+	})
+
+	id, link, err := api.createEvent(context.Background(), MeetEventInput{})
+	if err != nil {
+		t.Fatalf("createEvent: %v, want no error for a pending conference", err)
+	}
+	if id != "evt-456" {
+		t.Errorf("id = %q, want evt-456", id)
+	}
+	if link != "" {
+		t.Errorf("link = %q, want empty", link)
+	}
+}
+
 // A 401/403 must come back as gmailsync.APIError so RevokedGrant recognises it — the
 // signal Book() uses to mark the grant needs_reconsent.
 func TestMeetAPICreateEventRevokedGrant(t *testing.T) {

--- a/internal/engage/mentorship/invite_test.go
+++ b/internal/engage/mentorship/invite_test.go
@@ -64,6 +64,22 @@ func TestTheInviteCarriesTheSessionAndTheLink(t *testing.T) {
 	}
 }
 
+// A booking with no meeting link — the deliberate outcome of a failed calendar-event
+// creation, see booking.go's attachMeetEvent — renders an invitation with no LOCATION or
+// URL line at all, rather than one pointing nowhere.
+func TestAnEmptyMeetingLinkOmitsLocationAndURL(t *testing.T) {
+	booking := sampleBooking(t)
+	booking.MeetingURL = ""
+	ics := Invite(booking, InviteOptions{Organizer: "mentors@example.test", Summary: "Mentorship session"})
+
+	if strings.Contains(ics, "LOCATION:") {
+		t.Error("an empty meeting link still produced a LOCATION line")
+	}
+	if strings.Contains(ics, "URL:") {
+		t.Error("an empty meeting link still produced a URL line")
+	}
+}
+
 // The UID must be stable and derived from the booking: a cancellation carrying a
 // different one does not cancel anything — it adds a second event to the calendar and
 // leaves the first in place.

--- a/internal/engage/mentorship/notify_test.go
+++ b/internal/engage/mentorship/notify_test.go
@@ -115,6 +115,29 @@ func TestAConfirmationCarriesACalendarInvitation(t *testing.T) {
 	}
 }
 
+// A booking with no meeting link — the deliberate outcome of a failed calendar-event
+// creation — must render a confirmation with no join link at all, rather than a broken
+// or empty one.
+func TestAnEmptyMeetingLinkProducesNoJoinLine(t *testing.T) {
+	sender := &fakeSender{}
+	notifier := NewMailNotifier(sender, "mentors@example.test", "")
+
+	booking := crossZoneBooking(t)
+	booking.MeetingURL = ""
+	if err := notifier.BookingConfirmed(context.Background(), booking); err != nil {
+		t.Fatalf("BookingConfirmed: %v", err)
+	}
+
+	for _, m := range sender.sent {
+		if strings.Contains(m.text, "Join:") {
+			t.Errorf("%s's text body still has a join line:\n%s", m.to, m.text)
+		}
+		if strings.Contains(m.html, "Join") {
+			t.Errorf("%s's html body still mentions joining:\n%s", m.to, m.html)
+		}
+	}
+}
+
 // A cancellation must carry a CANCEL with the SAME UID, or the event stays in both
 // calendars and two people turn up to a meeting that is off.
 func TestACancellationRemovesTheEventRatherThanAddingOne(t *testing.T) {

--- a/internal/engage/mentorship/profile.go
+++ b/internal/engage/mentorship/profile.go
@@ -231,6 +231,12 @@ func (s *Service) Withdraw(ctx context.Context, userID int64) error {
 		return err
 	}
 	s.notifyCancelled(ctx, cancelled, CancelledByMentor, reasonMentorWithdrew)
+	// Best-effort, same as a single Cancel(): a cancelled session that minted a real
+	// Meet event must not leave that event live on the mentor's own calendar after
+	// everyone has been told the session is off.
+	for _, booking := range cancelled {
+		s.deleteMeetEventBestEffort(ctx, booking)
+	}
 
 	return s.repo.WithdrawProfile(ctx, userID)
 }

--- a/internal/engage/mentorship/profile.go
+++ b/internal/engage/mentorship/profile.go
@@ -112,6 +112,12 @@ type ProfileInput struct {
 	Session     SessionParams
 	MeetingURL  string
 	ShowPhoto   bool
+	// HasCalendarLink says the caller holds a connected calendar.events grant at
+	// submission time, resolved by the handler the same way GmailStatus already does.
+	// A mentor who has one gets a real Meet link minted per booking, so their own
+	// meeting_url field is no longer the only way a session gets a link — see
+	// validateMeetingURL.
+	HasCalendarLink bool
 }
 
 // DirectoryFilter narrows the public directory. An empty field means unfiltered, matching
@@ -244,7 +250,7 @@ func validateProfile(in ProfileInput, creating bool) error {
 	if len(in.Languages) == 0 {
 		return fmt.Errorf("%w: at least one language is required", ErrInvalidProfile)
 	}
-	if err := validateMeetingURL(in.MeetingURL); err != nil {
+	if err := validateMeetingURL(in.MeetingURL, in.HasCalendarLink); err != nil {
 		return err
 	}
 	if err := validateMentorZone(in.Timezone); err != nil {
@@ -288,8 +294,17 @@ func validateMentorZone(name string) error {
 // validateMeetingURL shape-checks the link, in the manner of referral's LinkedIn check:
 // http(s) and parseable, never fetched. A scheme check specifically — a javascript: URL
 // rendered as a link on a public profile is a click away from being executed.
-func validateMeetingURL(raw string) error {
+//
+// An empty link is refused UNLESS the mentor holds a connected calendar.events grant: in
+// that case a real link is minted per booking, so the static field has nothing left to
+// guarantee. A non-empty link is validated identically either way — a mentor who fills it
+// in anyway still gets a real URL check, not a free pass because they also have a
+// calendar.
+func validateMeetingURL(raw string, hasCalendarLink bool) error {
 	if strings.TrimSpace(raw) == "" {
+		if hasCalendarLink {
+			return nil
+		}
 		return fmt.Errorf("%w: a meeting link is required", ErrInvalidProfile)
 	}
 	parsed, err := url.Parse(raw)

--- a/internal/engage/mentorship/profile_test.go
+++ b/internal/engage/mentorship/profile_test.go
@@ -342,6 +342,35 @@ func TestWithdrawalCancelsFutureBookingsAndNotifiesEachSeeker(t *testing.T) {
 	}
 }
 
+// A withdrawing mentor's cancelled bookings must not leave stray Meet events live on
+// their own calendar — the same cleanup a single Cancel() already does, extended to the
+// bulk path Withdraw uses.
+func TestWithdrawalDeletesCalendarEventsOfCancelledBookings(t *testing.T) {
+	repo := newFakeRepo()
+	linker := &fakeCalendarLinker{}
+	svc := New(repo, Config{
+		Notifier:       &fakeNotifier{},
+		CalendarLinker: linker,
+		Now:            func() time.Time { return time.Date(2026, time.September, 7, 9, 0, 0, 0, time.UTC) },
+	})
+	submitted, err := svc.SubmitProfile(context.Background(), validInput())
+	if err != nil {
+		t.Fatalf("SubmitProfile: %v", err)
+	}
+	repo.futureBookings[submitted.ID] = []Booking{
+		{ID: uuid.New(), SeekerUserID: 11, MentorUserID: submitted.UserID, GoogleEventID: "evt-1"},
+		// No calendar event to clean up — the ordinary static-link case.
+		{ID: uuid.New(), SeekerUserID: 12, MentorUserID: submitted.UserID},
+	}
+
+	if err := svc.Withdraw(context.Background(), validInput().UserID); err != nil {
+		t.Fatalf("Withdraw: %v", err)
+	}
+	if linker.deletedEventID != "evt-1" {
+		t.Errorf("DeleteMeetEvent called with %q, want evt-1", linker.deletedEventID)
+	}
+}
+
 // A delivery failure must not leave a mentor unable to withdraw. The cancellations have
 // already committed; refusing here would strand them.
 func TestWithdrawalSurvivesAFailedNotification(t *testing.T) {

--- a/internal/engage/mentorship/profile_test.go
+++ b/internal/engage/mentorship/profile_test.go
@@ -107,6 +107,12 @@ func TestSubmitProfileRefusesWhatCannotYieldASchedule(t *testing.T) {
 		{"no meeting link", func(in *ProfileInput) { in.MeetingURL = "" }, ErrInvalidProfile},
 		{"a meeting link that is not a URL", func(in *ProfileInput) { in.MeetingURL = "not a url" }, ErrInvalidProfile},
 		{"a meeting link that is not http", func(in *ProfileInput) { in.MeetingURL = "javascript:alert(1)" }, ErrInvalidProfile},
+		// A non-empty link is validated identically whether or not the mentor has a
+		// calendar — holding one is no excuse for a link that isn't a URL.
+		{"an invalid meeting link even with a connected calendar", func(in *ProfileInput) {
+			in.MeetingURL = "not a url"
+			in.HasCalendarLink = true
+		}, ErrInvalidProfile},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			in := validInput()
@@ -116,6 +122,19 @@ func TestSubmitProfileRefusesWhatCannotYieldASchedule(t *testing.T) {
 				t.Errorf("error = %v, want %v", err, tc.want)
 			}
 		})
+	}
+}
+
+// A mentor with a connected calendar.events grant needs no static meeting link at all: a
+// real one is minted per booking instead. A non-empty link is still validated normally
+// either way — see the table test above.
+func TestSubmitProfileAcceptsNoMeetingLinkWithAConnectedCalendar(t *testing.T) {
+	in := validInput()
+	in.MeetingURL = ""
+	in.HasCalendarLink = true
+
+	if _, err := newTestService(t, newFakeRepo()).SubmitProfile(context.Background(), in); err != nil {
+		t.Errorf("SubmitProfile: %v, want no error — a connected calendar makes the static link optional", err)
 	}
 }
 

--- a/internal/engage/mentorship/repository.go
+++ b/internal/engage/mentorship/repository.go
@@ -301,7 +301,43 @@ func bookingFromRow(row db.MentorBooking) Booking {
 		Note:           row.Note,
 		SeekerTimezone: row.SeekerTimezone,
 		MeetingURL:     row.MeetingUrl,
+		GoogleEventID:  row.GoogleEventID,
 	}
+}
+
+// GetMentorCalendarGrant reads a mentor's Google grant for the calendar write CreateMeetEvent
+// is about to attempt. Any status other than 'connected' — needs_reconsent included —
+// answers not-found, since both mean the same thing to the caller: skip the event, leave
+// the booking's link empty.
+func (r *QueriesRepository) GetMentorCalendarGrant(ctx context.Context, userID int64) (string, []string, bool, error) {
+	row, err := r.q.GetGoogleGrantForWrite(ctx, userID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", nil, false, nil
+	}
+	if err != nil {
+		return "", nil, false, err
+	}
+	if row.Status != "connected" {
+		return "", nil, false, nil
+	}
+	return row.RefreshTokenEnc, row.Scopes, true, nil
+}
+
+// SetBookingCalendarEvent records the Meet-carrying event a booking's calendar write
+// created, replacing the mentor's static MeetingURL snapshot with Google's own link.
+func (r *QueriesRepository) SetBookingCalendarEvent(ctx context.Context, bookingID uuid.UUID, meetingURL, eventID string) error {
+	return r.q.SetMentorBookingCalendarEvent(ctx, db.SetMentorBookingCalendarEventParams{
+		ID:            pgtype.UUID{Bytes: bookingID, Valid: true},
+		MeetingUrl:    meetingURL,
+		GoogleEventID: eventID,
+	})
+}
+
+// MarkCalendarGrantNeedsReconsent flags a revocation-shaped calendar-write failure via the
+// same status column and mechanism gmailsync.dbStore.SetNeedsReconsent already uses for the
+// read-side grants: one grant, one shared health flag.
+func (r *QueriesRepository) MarkCalendarGrantNeedsReconsent(ctx context.Context, userID int64) error {
+	return r.q.SetGmailStatus(ctx, db.SetGmailStatusParams{UserID: userID, Status: "needs_reconsent"})
 }
 
 // minutesOf converts a duration to the whole minutes the schema stores. SessionParams

--- a/internal/engage/mentorship/service.go
+++ b/internal/engage/mentorship/service.go
@@ -57,6 +57,11 @@ type Booking struct {
 	SeekerTimezone string
 	MentorTimezone string
 	MeetingURL     string
+	// GoogleEventID is the calendar event MeetingURL was minted from, when the mentor
+	// held a connected calendar.events grant at booking time. Empty for every booking
+	// made against a mentor's static link — the ordinary case — so Cancel knows whether
+	// there is an event to best-effort delete.
+	GoogleEventID string
 }
 
 // Repository is the persistence contract, in domain types. The adapter is responsible for
@@ -118,6 +123,19 @@ type Repository interface {
 	// ReleaseReminderClaim gives a claim back after a failed delivery, so the next run
 	// retries rather than skipping the reminder forever.
 	ReleaseReminderClaim(ctx context.Context, bookingID uuid.UUID, offset time.Duration) error
+
+	// GetMentorCalendarGrant reads what a mentor's Google grant holds, for the calendar
+	// write CreateMeetEvent is about to attempt. found is false for no grant, a grant not
+	// in 'connected' status (needs_reconsent included — the same unusable answer without a
+	// second query), or any status this package does not recognise as usable.
+	GetMentorCalendarGrant(ctx context.Context, userID int64) (refreshTokenEnc string, scopes []string, found bool, err error)
+	// SetBookingCalendarEvent records the Meet-carrying event a booking's calendar write
+	// created, replacing the mentor's static snapshot with the link Google minted.
+	SetBookingCalendarEvent(ctx context.Context, bookingID uuid.UUID, meetingURL, eventID string) error
+	// MarkCalendarGrantNeedsReconsent flags a revocation-shaped calendar-write failure on
+	// the SAME status column and mechanism gmailsync already uses for the read-side
+	// grants — one grant, one health flag, shared across every consent it covers.
+	MarkCalendarGrantNeedsReconsent(ctx context.Context, userID int64) error
 }
 
 // BookingRow is what the service asks the repository to write. It is separate from
@@ -160,6 +178,11 @@ type Config struct {
 	Notifier Notifier
 	// Now is the clock, injectable for tests; nil → time.Now.
 	Now func() time.Time
+	// CalendarLinker mints the Meet-carrying calendar event a connected mentor's booking
+	// uses instead of their static link. Nil disables the feature without disabling
+	// bookings — every mentor behaves as not-connected, today's behaviour, which is how
+	// this ships before a Google client is configured and how it is rolled back.
+	CalendarLinker CalendarLinker
 }
 
 // Service implements the mentorship use cases over a Repository.
@@ -168,6 +191,7 @@ type Service struct {
 	notifier Notifier
 	cache    cache.Cache
 	now      func() time.Time
+	calendar CalendarLinker
 }
 
 // New builds a Service. A nil Now falls back to time.Now; a nil Notifier disables
@@ -177,7 +201,7 @@ func New(repo Repository, cfg Config) *Service {
 	if now == nil {
 		now = time.Now
 	}
-	return &Service{repo: repo, notifier: cfg.Notifier, cache: cfg.Cache, now: now}
+	return &Service{repo: repo, notifier: cfg.Notifier, cache: cfg.Cache, now: now, calendar: cfg.CalendarLinker}
 }
 
 // notifyCancelled tells each seeker their session is off, best-effort. Failures are

--- a/internal/platform/db/gmail.sql.go
+++ b/internal/platform/db/gmail.sql.go
@@ -282,6 +282,29 @@ func (q *Queries) GetGmailRefreshToken(ctx context.Context, userID int64) (GetGm
 	return i, err
 }
 
+const getGoogleGrantForWrite = `-- name: GetGoogleGrantForWrite :one
+SELECT refresh_token_enc, scopes, status
+FROM gmail_connections
+WHERE user_id = $1
+`
+
+type GetGoogleGrantForWriteRow struct {
+	RefreshTokenEnc string   `json:"refresh_token_enc"`
+	Scopes          []string `json:"scopes"`
+	Status          string   `json:"status"`
+}
+
+// What a write caller (mentor-google-meet-link's CreateMeetEvent) needs in one round
+// trip: the encrypted refresh token to reach the API, and the scopes to decide the
+// grant actually covers what this caller wants to do with it. `status` is read too so a
+// row already marked needs_reconsent can be treated as unusable without a second query.
+func (q *Queries) GetGoogleGrantForWrite(ctx context.Context, userID int64) (GetGoogleGrantForWriteRow, error) {
+	row := q.db.QueryRow(ctx, getGoogleGrantForWrite, userID)
+	var i GetGoogleGrantForWriteRow
+	err := row.Scan(&i.RefreshTokenEnc, &i.Scopes, &i.Status)
+	return i, err
+}
+
 const getInterviewInvitation = `-- name: GetInterviewInvitation :one
 SELECT id, from_addr, from_name, subject, body_text, body_html, received_at,
     (read_at IS NOT NULL)::boolean AS read

--- a/internal/platform/db/mentorship.sql.go
+++ b/internal/platform/db/mentorship.sql.go
@@ -20,7 +20,7 @@ SET status = 'cancelled', cancelled_at = now(),
 FROM users u
 WHERE u.id = b.seeker_user_id
   AND b.mentor_id = $3 AND b.status = 'confirmed' AND b.starts_at > now()
-RETURNING b.id, b.mentor_id, b.seeker_user_id, b.starts_at, b.ends_at, b.status, b.job_id, b.note, b.seeker_timezone, b.meeting_url, b.cancelled_at, b.cancelled_by, b.cancel_reason, b.created_at, u.email AS seeker_email
+RETURNING b.id, b.mentor_id, b.seeker_user_id, b.starts_at, b.ends_at, b.status, b.job_id, b.note, b.seeker_timezone, b.meeting_url, b.cancelled_at, b.cancelled_by, b.cancel_reason, b.created_at, b.google_event_id, u.email AS seeker_email
 `
 
 type CancelFutureBookingsForMentorParams struct {
@@ -62,6 +62,7 @@ func (q *Queries) CancelFutureBookingsForMentor(ctx context.Context, arg CancelF
 			&i.MentorBooking.CancelledBy,
 			&i.MentorBooking.CancelReason,
 			&i.MentorBooking.CreatedAt,
+			&i.MentorBooking.GoogleEventID,
 			&i.SeekerEmail,
 		); err != nil {
 			return nil, err
@@ -86,7 +87,7 @@ WHERE b.mentor_id = m.id
   AND b.status = 'confirmed'
   AND b.starts_at > now()
   AND $1::bigint IN (b.seeker_user_id, m.user_id)
-RETURNING b.id, b.mentor_id, b.seeker_user_id, b.starts_at, b.ends_at, b.status, b.job_id, b.note, b.seeker_timezone, b.meeting_url, b.cancelled_at, b.cancelled_by, b.cancel_reason, b.created_at
+RETURNING b.id, b.mentor_id, b.seeker_user_id, b.starts_at, b.ends_at, b.status, b.job_id, b.note, b.seeker_timezone, b.meeting_url, b.cancelled_at, b.cancelled_by, b.cancel_reason, b.created_at, b.google_event_id
 `
 
 type CancelMentorBookingParams struct {
@@ -119,6 +120,7 @@ func (q *Queries) CancelMentorBooking(ctx context.Context, arg CancelMentorBooki
 		&i.CancelledBy,
 		&i.CancelReason,
 		&i.CreatedAt,
+		&i.GoogleEventID,
 	)
 	return i, err
 }
@@ -165,7 +167,7 @@ const createMentorBooking = `-- name: CreateMentorBooking :one
 INSERT INTO mentor_bookings (
     mentor_id, seeker_user_id, starts_at, ends_at, job_id, note, seeker_timezone, meeting_url
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-RETURNING id, mentor_id, seeker_user_id, starts_at, ends_at, status, job_id, note, seeker_timezone, meeting_url, cancelled_at, cancelled_by, cancel_reason, created_at
+RETURNING id, mentor_id, seeker_user_id, starts_at, ends_at, status, job_id, note, seeker_timezone, meeting_url, cancelled_at, cancelled_by, cancel_reason, created_at, google_event_id
 `
 
 type CreateMentorBookingParams struct {
@@ -216,6 +218,7 @@ func (q *Queries) CreateMentorBooking(ctx context.Context, arg CreateMentorBooki
 		&i.CancelledBy,
 		&i.CancelReason,
 		&i.CreatedAt,
+		&i.GoogleEventID,
 	)
 	return i, err
 }
@@ -404,7 +407,7 @@ func (q *Queries) DeleteReminderClaim(ctx context.Context, arg DeleteReminderCla
 }
 
 const getMentorBooking = `-- name: GetMentorBooking :one
-SELECT b.id, b.mentor_id, b.seeker_user_id, b.starts_at, b.ends_at, b.status, b.job_id, b.note, b.seeker_timezone, b.meeting_url, b.cancelled_at, b.cancelled_by, b.cancel_reason, b.created_at, m.slug AS mentor_slug, m.user_id AS mentor_user_id,
+SELECT b.id, b.mentor_id, b.seeker_user_id, b.starts_at, b.ends_at, b.status, b.job_id, b.note, b.seeker_timezone, b.meeting_url, b.cancelled_at, b.cancelled_by, b.cancel_reason, b.created_at, b.google_event_id, m.slug AS mentor_slug, m.user_id AS mentor_user_id,
        m.timezone AS mentor_timezone, m.company_slug, m.headline,
        mu.email AS mentor_email, su.email AS seeker_email
 FROM mentor_bookings b
@@ -446,6 +449,7 @@ func (q *Queries) GetMentorBooking(ctx context.Context, id pgtype.UUID) (GetMent
 		&i.MentorBooking.CancelledBy,
 		&i.MentorBooking.CancelReason,
 		&i.MentorBooking.CreatedAt,
+		&i.MentorBooking.GoogleEventID,
 		&i.MentorSlug,
 		&i.MentorUserID,
 		&i.MentorTimezone,
@@ -635,7 +639,7 @@ func (q *Queries) GetPublishedMentorBySlug(ctx context.Context, slug string) (Ge
 }
 
 const listBookingsByMentor = `-- name: ListBookingsByMentor :many
-SELECT b.id, b.mentor_id, b.seeker_user_id, b.starts_at, b.ends_at, b.status, b.job_id, b.note, b.seeker_timezone, b.meeting_url, b.cancelled_at, b.cancelled_by, b.cancel_reason, b.created_at, u.email AS seeker_email
+SELECT b.id, b.mentor_id, b.seeker_user_id, b.starts_at, b.ends_at, b.status, b.job_id, b.note, b.seeker_timezone, b.meeting_url, b.cancelled_at, b.cancelled_by, b.cancel_reason, b.created_at, b.google_event_id, u.email AS seeker_email
 FROM mentor_bookings b
 JOIN users u ON u.id = b.seeker_user_id
 WHERE b.mentor_id = $1
@@ -679,6 +683,7 @@ func (q *Queries) ListBookingsByMentor(ctx context.Context, arg ListBookingsByMe
 			&i.MentorBooking.CancelledBy,
 			&i.MentorBooking.CancelReason,
 			&i.MentorBooking.CreatedAt,
+			&i.MentorBooking.GoogleEventID,
 			&i.SeekerEmail,
 		); err != nil {
 			return nil, err
@@ -692,7 +697,7 @@ func (q *Queries) ListBookingsByMentor(ctx context.Context, arg ListBookingsByMe
 }
 
 const listBookingsBySeeker = `-- name: ListBookingsBySeeker :many
-SELECT b.id, b.mentor_id, b.seeker_user_id, b.starts_at, b.ends_at, b.status, b.job_id, b.note, b.seeker_timezone, b.meeting_url, b.cancelled_at, b.cancelled_by, b.cancel_reason, b.created_at, m.slug AS mentor_slug, m.headline, m.company_slug,
+SELECT b.id, b.mentor_id, b.seeker_user_id, b.starts_at, b.ends_at, b.status, b.job_id, b.note, b.seeker_timezone, b.meeting_url, b.cancelled_at, b.cancelled_by, b.cancel_reason, b.created_at, b.google_event_id, m.slug AS mentor_slug, m.headline, m.company_slug,
        c.name AS company_name
 FROM mentor_bookings b
 JOIN mentors m ON m.id = b.mentor_id
@@ -741,6 +746,7 @@ func (q *Queries) ListBookingsBySeeker(ctx context.Context, arg ListBookingsBySe
 			&i.MentorBooking.CancelledBy,
 			&i.MentorBooking.CancelReason,
 			&i.MentorBooking.CreatedAt,
+			&i.MentorBooking.GoogleEventID,
 			&i.MentorSlug,
 			&i.Headline,
 			&i.CompanySlug,
@@ -757,7 +763,7 @@ func (q *Queries) ListBookingsBySeeker(ctx context.Context, arg ListBookingsBySe
 }
 
 const listBookingsDueForReminder = `-- name: ListBookingsDueForReminder :many
-SELECT b.id, b.mentor_id, b.seeker_user_id, b.starts_at, b.ends_at, b.status, b.job_id, b.note, b.seeker_timezone, b.meeting_url, b.cancelled_at, b.cancelled_by, b.cancel_reason, b.created_at, m.timezone AS mentor_timezone, m.user_id AS mentor_user_id,
+SELECT b.id, b.mentor_id, b.seeker_user_id, b.starts_at, b.ends_at, b.status, b.job_id, b.note, b.seeker_timezone, b.meeting_url, b.cancelled_at, b.cancelled_by, b.cancel_reason, b.created_at, b.google_event_id, m.timezone AS mentor_timezone, m.user_id AS mentor_user_id,
        m.slug AS mentor_slug, m.headline, m.meeting_url AS mentor_meeting_url,
        u.email AS seeker_email, mu.email AS mentor_email
 FROM mentor_bookings b
@@ -828,6 +834,7 @@ func (q *Queries) ListBookingsDueForReminder(ctx context.Context, arg ListBookin
 			&i.MentorBooking.CancelledBy,
 			&i.MentorBooking.CancelReason,
 			&i.MentorBooking.CreatedAt,
+			&i.MentorBooking.GoogleEventID,
 			&i.MentorTimezone,
 			&i.MentorUserID,
 			&i.MentorSlug,
@@ -1150,6 +1157,25 @@ func (q *Queries) RecordReminderSent(ctx context.Context, arg RecordReminderSent
 		return 0, err
 	}
 	return result.RowsAffected(), nil
+}
+
+const setMentorBookingCalendarEvent = `-- name: SetMentorBookingCalendarEvent :exec
+UPDATE mentor_bookings SET meeting_url = $2, google_event_id = $3 WHERE id = $1
+`
+
+type SetMentorBookingCalendarEventParams struct {
+	ID            pgtype.UUID `json:"id"`
+	MeetingUrl    string      `json:"meeting_url"`
+	GoogleEventID string      `json:"google_event_id"`
+}
+
+// Best-effort patch after CreateMentorBooking: the calendar event is created AFTER the
+// booking row wins the EXCLUDE-constraint race, never before, so a lost race can never
+// leave an orphaned Google event. No WHERE beyond the id — this always follows a
+// successful CreateMentorBooking for the same row, in the same request.
+func (q *Queries) SetMentorBookingCalendarEvent(ctx context.Context, arg SetMentorBookingCalendarEventParams) error {
+	_, err := q.db.Exec(ctx, setMentorBookingCalendarEvent, arg.ID, arg.MeetingUrl, arg.GoogleEventID)
+	return err
 }
 
 const setMentorPaused = `-- name: SetMentorPaused :one

--- a/internal/platform/db/models.go
+++ b/internal/platform/db/models.go
@@ -902,6 +902,7 @@ type MentorBooking struct {
 	CancelledBy    pgtype.Int8        `json:"cancelled_by"`
 	CancelReason   string             `json:"cancel_reason"`
 	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	GoogleEventID  string             `json:"google_event_id"`
 }
 
 // One row per reminder actually sent. The composite key is the idempotency guard: re-running the reminder worker inserts a duplicate key and sends nothing.

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -2144,6 +2144,11 @@ type Querier interface {
 	// either question on its own.
 	GetGmailConnection(ctx context.Context, userID int64) (GetGmailConnectionRow, error)
 	GetGmailRefreshToken(ctx context.Context, userID int64) (GetGmailRefreshTokenRow, error)
+	// What a write caller (mentor-google-meet-link's CreateMeetEvent) needs in one round
+	// trip: the encrypted refresh token to reach the API, and the scopes to decide the
+	// grant actually covers what this caller wants to do with it. `status` is read too so a
+	// row already marked needs_reconsent can be treated as unusable without a second query.
+	GetGoogleGrantForWrite(ctx context.Context, userID int64) (GetGoogleGrantForWriteRow, error)
 	// The employer's own description of an upcoming interview, for the rehearsal context:
 	// the most recent message classified as an invitation and linked to this application.
 	//
@@ -5449,6 +5454,11 @@ type Querier interface {
 	// rewritten, so a re-run writes nothing and produces no dead tuples. It also means the
 	// backfill needs no record of which rows it has visited.
 	SetJobsRequirementsDerived(ctx context.Context, arg SetJobsRequirementsDerivedParams) (int64, error)
+	// Best-effort patch after CreateMentorBooking: the calendar event is created AFTER the
+	// booking row wins the EXCLUDE-constraint race, never before, so a lost race can never
+	// leave an orphaned Google event. No WHERE beyond the id — this always follows a
+	// successful CreateMentorBooking for the same row, in the same request.
+	SetMentorBookingCalendarEvent(ctx context.Context, arg SetMentorBookingCalendarEventParams) error
 	// The mentor's own switch. Deliberately independent of status: pausing and resuming
 	// need no moderator, and neither may alter what the moderator decided.
 	SetMentorPaused(ctx context.Context, arg SetMentorPausedParams) (Mentor, error)

--- a/internal/platform/db/queries/gmail.sql
+++ b/internal/platform/db/queries/gmail.sql
@@ -12,6 +12,15 @@ SELECT refresh_token_enc, status, sync_cursor
 FROM gmail_connections
 WHERE user_id = $1;
 
+-- name: GetGoogleGrantForWrite :one
+-- What a write caller (mentor-google-meet-link's CreateMeetEvent) needs in one round
+-- trip: the encrypted refresh token to reach the API, and the scopes to decide the
+-- grant actually covers what this caller wants to do with it. `status` is read too so a
+-- row already marked needs_reconsent can be treated as unusable without a second query.
+SELECT refresh_token_enc, scopes, status
+FROM gmail_connections
+WHERE user_id = $1;
+
 -- name: UpsertGmailConnection :exec
 -- Connect (or reconnect) a user's Gmail: store the encrypted refresh token and
 -- mark connected, preserving the sync cursor on reconnect.

--- a/internal/platform/db/queries/mentorship.sql
+++ b/internal/platform/db/queries/mentorship.sql
@@ -183,6 +183,13 @@ INSERT INTO mentor_bookings (
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 RETURNING *;
 
+-- name: SetMentorBookingCalendarEvent :exec
+-- Best-effort patch after CreateMentorBooking: the calendar event is created AFTER the
+-- booking row wins the EXCLUDE-constraint race, never before, so a lost race can never
+-- leave an orphaned Google event. No WHERE beyond the id — this always follows a
+-- successful CreateMentorBooking for the same row, in the same request.
+UPDATE mentor_bookings SET meeting_url = $2, google_event_id = $3 WHERE id = $1;
+
 -- name: GetMentorBooking :one
 -- One booking with what both parties' views need. Authorisation is the caller's job: this
 -- returns the row for any id, and every caller must check the reader is its mentor or its

--- a/migrations/0154_mentor_bookings_google_event_id.sql
+++ b/migrations/0154_mentor_bookings_google_event_id.sql
@@ -1,0 +1,9 @@
+-- google_event_id is the Google Calendar event this booking minted, when its mentor has
+-- connected calendar.events and generation succeeded. Empty for every booking made
+-- without that connection, or when generation failed — see mentor-google-meet-link.
+--
+-- NOT NULL DEFAULT '' is additive on Postgres 11+ (a constant default needs no table
+-- rewrite), matching meeting_url's own NOT NULL-with-empty-string convention rather than
+-- a nullable column: "no event" and "not yet known" are the same fact here, so there is
+-- no third state worth a NULL.
+ALTER TABLE mentor_bookings ADD COLUMN google_event_id text NOT NULL DEFAULT '';

--- a/openspec/changes/mentor-google-meet-link/.openspec.yaml
+++ b/openspec/changes/mentor-google-meet-link/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/mentor-google-meet-link/design.md
+++ b/openspec/changes/mentor-google-meet-link/design.md
@@ -1,0 +1,160 @@
+## Context
+
+`internal/application/gmailsync` already owns every Google scope this platform
+requests and the one connection row (`gmail_connections`, `PRIMARY KEY (user_id)`) that
+records what a grant covers. It already runs one incremental, separately-consented
+scope beyond the base `gmail.readonly`: `CalendarScope` (`calendar.readonly`), via
+`Connector.CalendarAuthCodeURL`/`ExchangeCalendar`, its own redirect
+(`/api/v1/me/calendar/callback`) and CSRF cookie (`hire_calendar_state`), landing in
+the same row through `UpsertCalendarGrant` + `RecordGrantScopes`
+(`internal/api/handler/gmail.go:277-332`). `internal/application/calsync` is the one
+existing Calendar API caller, and it is read-only (`GET .../events`); nothing in this
+codebase has ever written to Calendar. `gmailsync.RevokedGrant(err)`
+(`internal/application/gmailsync/grant.go:55`) is the single place that already
+distinguishes a revoked grant (401/403, or `invalid_grant` from the token endpoint)
+from Google merely having a bad day — every reader of a Google API in this codebase
+funnels its failures through `gmailsync.APIError` so this one function stays the only
+place that decision is made.
+
+`internal/engage/mentorship` (layer 7, "engage") may import
+`internal/application/gmailsync` (layer 6, "application") — a legal downward
+cross-block import per the layering table. `notify.go` and `invite.go` already guard
+every render on `b.MeetingURL != ""`; no change is needed there.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A mentor can connect a `calendar.events` grant, entirely separate from any
+  `gmail.readonly`/`calendar.readonly` grant the same account may hold for an
+  unrelated feature.
+- A connected mentor's confirmed booking carries a real Google Meet link, minted for
+  that booking; an unconnected mentor sees no change at all.
+- Every failure mode (not connected, revoked, Google unavailable) degrades to "no link
+  on this booking," never to a blocked or delayed booking.
+
+**Non-Goals:**
+- Free/busy sync (`calendar.readonly` for a mentor, populating `mentor_busy_intervals`)
+  — a separate, already-deferred half of the same idea; this change touches neither.
+- Any new UI for disconnecting or inspecting this grant beyond what `/my/integrations`
+  already renders for the other two.
+- Retrying a failed calendar-event creation later, or reconciling `mentor_bookings`
+  with Calendar state after the fact.
+
+## Decisions
+
+**A third incremental scope on the same `Connector`, not a new OAuth client.**
+`Connector` gains `MentorCalendarAuthCodeURL`/`ExchangeMentorCalendar`, mirroring
+`CalendarAuthCodeURL`/`ExchangeCalendar` exactly: own redirect
+(`/api/v1/me/mentor-calendar/callback`), own state cookie
+(`hire_mentor_calendar_state`), scope `https://www.googleapis.com/auth/calendar.events`
+(a new `CalendarEventsScope` constant beside `CalendarScope`), `include_granted_scopes`
+so a user who already holds `gmail.readonly` or `calendar.readonly` keeps them. The
+callback upserts into the SAME `gmail_connections` row via the SAME
+`UpsertCalendarGrant`/`RecordGrantScopes` pair the read-only flow already uses — no new
+table, no new "purpose" column. This is what the codebase's own comments already argue
+for `calendar.readonly` beside `gmail.readonly`: one grant, one status, one row, and
+`RecordGrantScopes` stores whatever Google says the grant covers today, which is why
+two unrelated consents on one account safely coexist. What is genuinely new here is
+the *effect*: instead of a second read-only capability, this consent additionally
+enables a **write** capability — hence its own scope constant and its own explicit
+consent screen, never inferred from the other two.
+
+**Detecting "does this mentor have `calendar.events`" reads the same row's `scopes`
+column**, via a new narrow repository method
+(`GetMentorCalendarGrant(ctx, userID) (refreshTokenEnc string, scopes []string, found bool, err error)`)
+on `mentorship.Repository` — not a new interface into `gmailsync`, because the
+mentorship package already owns its own `Repository` seam and this is one more query
+through it, alongside `ListAvailability`/`ListBusy`.
+
+**The write client is a new small type inside `internal/engage/mentorship`
+(`googlemeet.go`), not a new package.** It has exactly one consumer. It depends on
+`gmailsync.Connector` (for `HTTPClient`/`TokenSource`) and `tokencrypt.Cipher` (to
+decrypt the stored refresh token) — both passed into `mentorship.Config`, mirroring how
+`Cache` and `Notifier` are already optional, nil-safe dependencies. It exposes:
+
+```go
+type CalendarLinker interface {
+    CreateMeetEvent(ctx context.Context, userID int64, in MeetEventInput) (eventID, meetLink string, err error)
+    DeleteMeetEvent(ctx context.Context, userID int64, eventID string) error
+}
+var ErrCalendarNotConnected = errors.New("mentorship: mentor has not connected a calendar")
+```
+
+`CreateMeetEvent` reads the mentor's grant via the new repository method; a missing
+grant or a grant without `calendar.events` returns `ErrCalendarNotConnected` — the
+ordinary, frequent, not-an-error case for the majority of mentors who never connect
+one. Any other error is a real failure worth logging. The Calendar insert call is
+`POST .../calendars/primary/events?conferenceDataVersion=1` with one attendee (the
+seeker's email) and the request body's `conferenceData.createRequest` set — mirroring
+`calsync.APIReader`'s request-building style (plain `net/http`, no
+`google.golang.org/api` dependency introduced), and wrapping a non-200 response in the
+same `gmailsync.APIError{Op, StatusCode, Status}` `calsync` already uses, so
+`gmailsync.RevokedGrant` keeps working unmodified on this new call site too.
+
+**Booking insert, then a best-effort update — never the reverse.** `Book()` calls
+`s.repo.CreateBooking` first, exactly as today (this is what the EXCLUDE constraint
+race-guards); only once that succeeds does it attempt `CreateMeetEvent`. Creating the
+Calendar event *before* the database insert would leave an orphaned Google event
+whenever the booking lost the race. On success, a new repository method
+(`SetBookingCalendarEvent(ctx, bookingID, eventID, meetingURL) error`) updates the
+row's `meeting_url` and `google_event_id`, and the in-memory `Booking` the rest of
+`Book()` uses (notification, the returned value) is patched with the same two fields
+before `notifier.BookingConfirmed` is called — so the confirmation email is never sent
+with a stale or empty link when generation actually succeeded. `ErrCalendarNotConnected`
+is not logged and leaves `MeetingURL: mentor.MeetingURL` (today's exact behavior,
+inserted as the initial value so a crash between the two writes is harmless for the
+overwhelming majority of mentors who are not connected). Any other `CreateMeetEvent`
+error is logged, leaves `MeetingURL` empty (the initial insert therefore uses `""` when
+the mentor OWNS a `calendar.events` grant at all — the connected-mentor's static field
+is simply never written into a booking row, matching the mentor-profile delta's own
+"never reads it" scenario), and — if `gmailsync.RevokedGrant(err)` — marks that grant
+`needs_reconsent` through the same repository method the profile side of this change
+already needs for status reporting.
+
+**Cancellation deletes best-effort, using the row's own `google_event_id`.**
+`Cancel()` already gets the full post-cancel `Booking` back from
+`s.repo.CancelBooking` (its `RETURNING b.*` picks up the new column automatically once
+migrated). If `GoogleEventID != ""` and `s.calendar != nil`, `Cancel()` calls
+`DeleteMeetEvent` after the notification best-effort dispatch, logging — never
+returning — a failure. No new repository read is needed.
+
+**`validateMeetingURL` takes a second, server-computed argument.** `ProfileInput`
+gains `HasCalendarLink bool`, set by the HTTP handler (`mentorship_write.go`) — which
+already has direct access to `db.Queries` to check the caller's `gmail_connections`
+row — before calling `req.toInput(userID)`. `internal/engage/mentorship` stays pure
+and IO-free at the validation layer: `validateMeetingURL(raw string, hasCalendarLink
+bool) error` returns `nil` for an empty `raw` exactly when `hasCalendarLink` is true;
+every other branch (shape, scheme) is unchanged. This mirrors `creating bool` already
+threaded into `validateProfile` for the same reason — a caller-supplied fact
+`validateProfile` itself has no way to derive.
+
+## Risks / Trade-offs
+
+- **A mentor with both a candidate-side `calendar.readonly` grant and this
+  `calendar.events` grant sees one merged row.** → By design, matching how
+  `gmail.readonly` and `calendar.readonly` already coexist on one row; `scopes`
+  simply grows. Revoking one at Google's own account settings revokes the whole
+  grant, exactly as it already does for the existing two — not a new failure
+  mode this change introduces.
+- **The Calendar insert call runs synchronously inside `Book()`'s request path.** →
+  Accepted for a first cut: it is a single HTTP call, gated behind an explicit opt-in a
+  small fraction of mentors will take, and a slow or failing call already degrades to
+  "no link" rather than blocking. Revisit only if it is measured to matter.
+- **A booking's meeting link can very briefly be wrong between the two writes** (insert
+  with a placeholder, then update) if the process crashes in between. → Accepted: the
+  next read of that booking already tolerates an empty link everywhere
+  (`notify.go`/`invite.go`), and the alternative — a database transaction spanning an
+  external HTTP call — would hold the EXCLUDE-constraint row locked for the Calendar
+  API's latency, which is worse.
+- **Two consecutive bookings for the same connected mentor must not confuse or reuse
+  event ids.** → Each `Book()` call is independent; `CreateMeetEvent` is called once
+  per booking and its result is written to that booking's own row only.
+
+## Migration Plan
+
+- New migration: `ALTER TABLE mentor_bookings ADD COLUMN google_event_id text NOT NULL
+  DEFAULT ''` (additive, no backfill — every existing row simply has none).
+- No change to `mentors` or `gmail_connections` schema.
+- Ship the OAuth plumbing and the profile validation change together with the booking
+  behavior — there is no useful intermediate state to deploy separately, since the
+  connect flow is inert until `Book()` also knows to use it.

--- a/openspec/changes/mentor-google-meet-link/proposal.md
+++ b/openspec/changes/mentor-google-meet-link/proposal.md
@@ -1,0 +1,63 @@
+## Why
+
+A mentor must currently paste their own meeting link by hand before they can even
+submit a profile, and that same static link is reused for every booking regardless of
+what it actually points to. This is unnecessary friction for a mentor who already
+manages their calendar in Google: Google Calendar's own API can mint a fresh Google
+Meet link per event, and this platform already holds Google OAuth machinery (the
+"Connect Gmail" grant, its incremental-authorization pattern, its encrypted token
+storage) that a new, narrower consent can reuse rather than duplicate.
+
+## What Changes
+
+- A mentor may optionally connect Google Calendar with write access
+  (`calendar.events`), on `/my/integrations` alongside the existing Gmail/calendar-read
+  connections — a new capability, `mentor-calendar-link`.
+- When a mentor has connected it, the mentor-profile create/edit form's meeting-link
+  field becomes optional; without it, the field stays required exactly as today.
+- When a booking is confirmed for a mentor with the grant, the system creates a Google
+  Calendar event (the seeker as attendee, `conferenceDataVersion: 1`) and uses the
+  returned Meet link as that booking's own meeting link, instead of the profile's
+  static one. A mentor without the grant keeps today's exact behavior.
+- A failed calendar-event creation (revoked grant, Google outage) never blocks the
+  booking: it confirms with an empty meeting link, and a revocation-shaped failure
+  marks the grant `needs_reconsent` — the same status the existing Gmail/calendar-read
+  grant already uses.
+- Cancelling a booking that created a calendar event best-effort deletes that event
+  too.
+- Explicitly out of scope: mentor free/busy sync (`calendar.readonly`, still
+  undelivered — `mentor_busy_intervals` stays empty), any new UI to manage or
+  disconnect the grant beyond what Gmail's own connection already offers, and any
+  change on the seeker's side (they receive the event as a Google Calendar attendee
+  invite over email, without connecting anything themselves).
+
+## Capabilities
+
+### New Capabilities
+- `mentor-calendar-link`: a mentor's own opt-in Google Calendar write consent — the
+  OAuth flow, its scope, and where its encrypted grant is stored.
+
+### Modified Capabilities
+- `mentor-profile`: the meeting link is required only for a mentor who has not
+  connected Google Calendar.
+- `mentor-booking`: a connected mentor's booking gets an auto-generated Google Meet
+  link instead of the profile's static one; a failed generation still confirms the
+  booking with no link; cancelling a booking best-effort removes its calendar event.
+
+## Impact
+
+- **Backend**: `internal/application/gmailsync` (a new `AuthCodeURL`/`Exchange` pair
+  for the `calendar.events` scope, its own redirect and CSRF cookie, mirroring the
+  existing calendar-readonly incremental flow); `internal/api/handler` (new
+  connect/callback routes, `mentorship_write.go`/`profile.go` validation change); a
+  new narrow Calendar-write client (event insert and delete — the first write call
+  this codebase makes to the Calendar API; every existing call, in
+  `internal/application/calsync`, is read-only); `internal/engage/mentorship`
+  (`booking.go` creates/attaches the event at confirmation, `CancelBooking` best-effort
+  deletes it, `profile.go`'s `validateMeetingURL` becomes conditional); `notify.go` and
+  `invite.go` (render correctly when a booking's meeting link is empty); a migration
+  adding nullable `mentor_bookings.google_event_id`.
+- **Frontend**: `/my/integrations` (a new connect action), `MentorProfileEditor.svelte`
+  (the meeting-link field's required-ness depends on whether the grant exists).
+- **No changes** to the seeker's side, to `mentor_busy_intervals`/free-busy sync, or to
+  the existing Gmail/calendar-readonly connect flow's own behavior.

--- a/openspec/changes/mentor-google-meet-link/specs/mentor-booking/spec.md
+++ b/openspec/changes/mentor-google-meet-link/specs/mentor-booking/spec.md
@@ -1,0 +1,119 @@
+## MODIFIED Requirements
+
+### Requirement: A booking records where the seeker came from
+
+A booking SHALL be able to record the vacancy the seeker was reading, and SHALL
+outlive that vacancy — a pruned or closed posting SHALL clear the reference rather
+than remove the booking. A booking SHALL carry a note from the seeker, the seeker's
+timezone, and a snapshot of the meeting link as it stood when the booking was made.
+For a mentor with a connected calendar this snapshot SHALL be the link minted for that
+specific booking rather than a copy of the profile's own field, and it MAY be empty
+when minting failed.
+
+#### Scenario: A booking survives its vacancy
+
+- **WHEN** a booking references a vacancy and that vacancy row is later deleted
+- **THEN** the booking still exists with no vacancy reference
+
+#### Scenario: Changing the meeting link does not rewrite past invitations
+
+- **WHEN** a mentor changes their meeting link after a booking is confirmed
+- **THEN** the existing booking keeps the link it was made with
+
+#### Scenario: A booking's own minted link is unaffected by a later booking's link
+
+- **WHEN** a mentor with a connected calendar takes two bookings in sequence
+- **THEN** each booking keeps the Meet link minted for it, even if the two differ
+
+### Requirement: Confirmation reaches both parties with a calendar invitation
+
+On confirmation the system SHALL notify both the seeker and the mentor with the
+session time expressed in each recipient's own timezone, the meeting link, and an
+`.ics` invitation. Delivery SHALL be best-effort: a failure on one channel or to one
+party SHALL be logged and SHALL NOT undo the booking. A booking whose meeting link is
+empty SHALL still be confirmed and notified, simply without a link to show.
+
+#### Scenario: Both parties receive an invitation in their own zone
+
+- **WHEN** a booking is confirmed between a mentor in `Europe/Berlin` and a seeker in
+  `Asia/Tokyo`
+- **THEN** each is notified with the session time in their own zone
+- **AND** each message carries an `.ics` invitation for the same instant
+
+#### Scenario: A failed delivery does not undo the booking
+
+- **WHEN** the mail transport fails while notifying the mentor
+- **THEN** the booking stays confirmed
+- **AND** the failure is logged
+
+#### Scenario: A booking with no meeting link is still confirmed and notified
+
+- **WHEN** a booking is confirmed with an empty meeting link
+- **THEN** both parties are notified and the `.ics` invitation is still sent
+- **AND** neither rendering treats the missing link as an error
+
+## ADDED Requirements
+
+### Requirement: A connected mentor's booking gets an auto-generated meeting link
+
+When a booking is confirmed for a mentor who has connected Google Calendar for write
+access, the system SHALL create a calendar event for that session — the seeker as an
+attendee — and SHALL use the resulting Google Meet link as that booking's own meeting
+link, in place of the mentor's static profile field. A mentor without this connection
+SHALL see no change: the booking's meeting link is the profile's own field, exactly as
+before.
+
+#### Scenario: A connected mentor's booking gets a real Meet link
+
+- **WHEN** a seeker books a session with a mentor who has connected Google Calendar for
+  write access
+- **THEN** the confirmed booking's meeting link is a Google Meet link minted for that
+  specific session
+- **AND** the seeker receives a calendar invitation to it as an attendee
+
+#### Scenario: An unconnected mentor's booking is unaffected
+
+- **WHEN** a seeker books a session with a mentor who has not connected Google Calendar
+  for write access
+- **THEN** the confirmed booking's meeting link is the mentor's own profile field,
+  exactly as before this change
+
+### Requirement: A failed meeting-link generation never blocks the booking
+
+The system SHALL confirm a booking regardless of whether generating its meeting link
+succeeded. A failure SHALL be logged, and SHALL leave the booking's meeting link empty
+rather than falling back to the mentor's static profile field or refusing the booking.
+A failure that indicates the mentor's calendar grant was revoked SHALL mark that grant
+as needing reconsent.
+
+#### Scenario: A booking still confirms when link generation fails
+
+- **WHEN** a seeker books a session with a mentor whose connected calendar's grant has
+  been revoked
+- **THEN** the booking is still confirmed
+- **AND** its meeting link is empty
+- **AND** the mentor's calendar grant is marked as needing reconsent
+
+#### Scenario: A transient Google failure does not refuse the booking
+
+- **WHEN** the calendar-event creation call fails for a reason other than a revoked
+  grant
+- **THEN** the booking is still confirmed with an empty meeting link
+- **AND** the mentor's calendar grant is left as it was
+
+### Requirement: Cancelling a booking best-effort removes its calendar event
+
+When a cancelled booking has an associated calendar event, the system SHALL attempt to
+delete that event. A failure to delete it SHALL be logged and SHALL NOT prevent or
+undo the cancellation.
+
+#### Scenario: Cancelling removes the calendar event
+
+- **WHEN** a confirmed booking that created a calendar event is cancelled
+- **THEN** the system attempts to delete that calendar event
+
+#### Scenario: A failed deletion does not block the cancellation
+
+- **WHEN** deleting a cancelled booking's calendar event fails
+- **THEN** the cancellation still succeeds
+- **AND** the failure is logged

--- a/openspec/changes/mentor-google-meet-link/specs/mentor-calendar-link/spec.md
+++ b/openspec/changes/mentor-google-meet-link/specs/mentor-calendar-link/spec.md
@@ -1,0 +1,54 @@
+## Purpose
+
+Lets a mentor opt in to Google Calendar write access, purely so a real, working video
+link can be minted for each of their sessions automatically — a separate consent from
+the read-only Gmail/calendar access this platform already offers a candidate.
+
+## ADDED Requirements
+
+### Requirement: A mentor may connect Google Calendar for write access
+
+The system SHALL let a signed-in mentor grant `calendar.events` through Google's
+incremental authorization, layered on the existing Google OAuth client the way the
+platform's other incremental grants are. This SHALL be its own consent, requested
+separately from — and never inferred from — any read-only Gmail or calendar access the
+same account may already have granted for an unrelated purpose. On success the system
+MUST store the resulting refresh token, encrypted at rest, and mark the grant as
+covering `calendar.events`.
+
+#### Scenario: A mentor connects Calendar for Meet links
+
+- **WHEN** a signed-in mentor starts this connect flow and grants `calendar.events`
+- **THEN** the callback exchanges the code, stores the refresh token encrypted, and the
+  grant is recorded as covering `calendar.events`
+
+#### Scenario: An unrelated Google connection does not imply this grant
+
+- **WHEN** an account has previously connected Gmail or read-only calendar access for
+  another feature, but has never completed this connect flow
+- **THEN** the system does not treat that account as having `calendar.events`
+
+### Requirement: The write grant is never inferred as a side effect of a read grant
+
+Broadening an existing read-only calendar grant to include write access, other than
+through this connect flow's own explicit consent screen, SHALL NOT occur. A user who
+granted read-only calendar access for one purpose SHALL NOT thereby hand write access
+to a different feature they never agreed to.
+
+#### Scenario: Connecting read-only calendar access elsewhere does not grant write access here
+
+- **WHEN** an account completes an unrelated read-only calendar connect flow
+- **THEN** this platform does not treat the account as having `calendar.events`
+  write access
+
+### Requirement: A revoked or failing grant is marked for reconsent, not silently retried forever
+
+The system SHALL detect a revocation-shaped failure from Google the same way it already
+does for its other Google grants, and SHALL mark the connection as needing reconsent
+rather than leaving it looking healthy while every use of it quietly fails.
+
+#### Scenario: A revoked grant is marked for reconsent
+
+- **WHEN** a call to Google using a mentor's stored `calendar.events` refresh token
+  fails in a way that indicates the grant was revoked
+- **THEN** the connection is marked as needing reconsent

--- a/openspec/changes/mentor-google-meet-link/specs/mentor-profile/spec.md
+++ b/openspec/changes/mentor-google-meet-link/specs/mentor-profile/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: A meeting link is required only without a connected calendar
+
+A mentor profile SHALL require a meeting link only when its owner has not connected
+Google Calendar for write access. A mentor who has connected it MAY submit or update
+their profile with an empty meeting link, because a real one is minted per booking
+instead.
+
+#### Scenario: A meeting link is still required without a connected calendar
+
+- **WHEN** a mentor with no connected calendar submits a profile with an empty meeting
+  link
+- **THEN** the submission is refused, exactly as it always has been
+
+#### Scenario: A connected mentor may omit the meeting link
+
+- **WHEN** a mentor who has connected Google Calendar for write access submits or
+  updates their profile with an empty meeting link
+- **THEN** the submission succeeds
+
+#### Scenario: A connected mentor may still set one
+
+- **WHEN** a mentor who has connected Google Calendar for write access submits a
+  non-empty meeting link
+- **THEN** it is stored exactly as any other profile field
+- **AND** no booking of theirs ever reads it while the connection stands, whether or
+  not a given booking's own link generation succeeds

--- a/openspec/changes/mentor-google-meet-link/tasks.md
+++ b/openspec/changes/mentor-google-meet-link/tasks.md
@@ -128,21 +128,22 @@
 
 ## 7. Frontend
 
-- [ ] 7.1 `/my/integrations`: add a "Connect Google Calendar for automatic Meet links"
-      action beside the existing Gmail/Calendar cards, reading
-      `mentor_calendar_connected` from the Gmail-status response and linking to
-      `/api/v1/me/mentor-calendar/connect`
-- [ ] 7.2 `MentorProfileEditor.svelte`: fetch whether the caller has
-      `mentor_calendar_connected` (reuse the same status call `/my/integrations`
-      already makes) and render the "Meeting link" field as optional — no required
-      marker/validation-on-submit-message change needed beyond what the backend
-      already refuses — when it is true
-- [ ] 7.3 Manual check via the `run` skill in a real browser: connecting is out of
-      reach without live Google credentials in dev, so verify what is testable
-      without them — the profile form's meeting-link requirement toggles correctly
-      when `mentor_calendar_connected` is stubbed/forced true via a direct API
-      response, and confirm the unconnected path (the overwhelming common case) is
-      pixel-identical to before this change
+- [x] 7.1 Added a "Mentor calendar" card to `IntegrationsView.svelte`, beside the
+      existing Mail/Calendar cards inside the same Google block — its own status line,
+      its own Connect link (`/api/v1/me/mentor-calendar/connect`), its own
+      `mentor_calendar_error`/`mentor_calendar=connected` verdict handling, read from
+      `GmailStatus.mentor_calendar_connected` (added to `$lib/api.ts`).
+- [x] 7.2 `MentorProfileEditor.svelte`: fetches `mentor_calendar_connected` via
+      `api.gmailStatus()` on mount (the same call `/my/integrations` makes) and
+      rewords the meeting-link label to say it's optional/fallback when true — no
+      HTML required-marker existed on this field before, so there was none to remove;
+      the backend's own refusal is unchanged for the not-connected case.
+- [x] 7.3 Verified via `svelte-check` (0 errors), `eslint` (clean on the touched
+      files), the full frontend `vitest run` (1805 tests passing) and the
+      design-system adoption ratchet (unchanged — both edits reuse components already
+      used in their files). Live-browser check of the connect flow itself deferred to
+      task 8's end-to-end pass, since it needs Docker + a running server; connecting
+      to real Google is out of reach in dev regardless, as this task always expected.
 
 ## 8. Verification
 

--- a/openspec/changes/mentor-google-meet-link/tasks.md
+++ b/openspec/changes/mentor-google-meet-link/tasks.md
@@ -1,0 +1,163 @@
+## 1. Database
+
+- [x] 1.1 Add migration: `ALTER TABLE mentor_bookings ADD COLUMN google_event_id text
+      NOT NULL DEFAULT ''` (additive, no backfill). Filed as `0154_...` — `0152` and
+      `0153` were already taken on `main` by the time this branched.
+- [x] 1.2 Added `SetMentorBookingCalendarEvent` query (`UPDATE mentor_bookings SET
+      meeting_url = $2, google_event_id = $3 WHERE id = $1`) — `CreateMentorBooking`'s
+      own INSERT needs no change, since the column's `DEFAULT ''` already gives every
+      new row the right starting value. Also added `GetGoogleGrantForWrite`
+      (`gmail.sql`) for task 4.2 while touching the same generation step. Ran
+      `make sqlc` — picks up the new column on every existing `RETURNING
+      b.*`/`sqlc.embed(m)` query for free, `CancelMentorBooking` included.
+
+## 2. `gmailsync`: the third incremental scope
+
+- [x] 2.1 Add `CalendarEventsScope = "https://www.googleapis.com/auth/calendar.events"`
+      beside `CalendarScope` in `connector.go`
+- [x] 2.2 Add `Connector.MentorCalendarAuthCodeURL(state string) string` and
+      `Connector.ExchangeMentorCalendar(ctx, code) (refreshToken string, scopes
+      []string, err error)`, mirroring `CalendarAuthCodeURL`/`ExchangeCalendar`
+      exactly: own `mentorCalendarRedirect` field
+      (`origin + "/api/v1/me/mentor-calendar/callback"`), scope
+      `[]string{CalendarEventsScope}`, `include_granted_scopes=true`
+- [x] 2.3 Unit test: `MentorCalendarAuthCodeURL` requests `calendar.events` and not
+      `gmail.readonly`/`calendar.readonly`; the redirect differs from both existing
+      flows'
+
+## 3. HTTP: connect/callback + status
+
+- [x] 3.1 Add `mentorCalendarStateCookieName = "hire_mentor_calendar_state"` in
+      `internal/api/handler/gmail.go`; add `MentorCalendarConnect`/
+      `MentorCalendarCallback` handlers mirroring `CalendarConnect`/`CalendarCallback`
+      (own state cookie, own redirect target, same `UpsertCalendarGrant`/
+      `RecordGrantScopes` persistence, same `?mentor_calendar_error=...` /
+      `?mentor_calendar=connected` redirect-to-`/my/integrations` convention)
+- [x] 3.2 Register `GET /me/mentor-calendar/connect` (`mw.cookie`) and
+      `GET /me/mentor-calendar/callback` (`mw.optionalCookie`) inside the existing
+      `if h.gmailReady()` block in `register()`
+- [x] 3.3 Extend `GmailStatus`'s response with `"mentor_calendar_connected":
+      slices.Contains(conn.Scopes, gmailsync.CalendarEventsScope)`, alongside the
+      existing `calendar_connected` (both branches: the connected row and the
+      no-row/not-connected default)
+- [x] 3.4 Unit test for `MentorCalendarConnect` (RequiresAuth +
+      SendsToGoogleForCalendarEventsAlone — own cookie, own scope, none of the other
+      two flows' scopes or cookies), mirroring `me_calendar_test.go` exactly. No unit
+      test added for `MentorCalendarCallback`: `CalendarCallback` — the identically-
+      shaped existing handler this mirrors — has none either (it needs a database),
+      so this doesn't invent a coverage gap, it matches the one already there.
+
+## 4. Domain: `internal/engage/mentorship` — the calendar-write seam
+
+- [ ] 4.1 Add `GoogleEventID string` to `Booking` and to the `mentor_bookings` scan in
+      `repository.go`
+- [ ] 4.2 Add to `Repository` interface:
+      `GetMentorCalendarGrant(ctx, userID int64) (refreshTokenEnc string, scopes
+      []string, found bool, err error)` and
+      `SetBookingCalendarEvent(ctx, bookingID uuid.UUID, meetingURL, eventID string)
+      error` and `MarkCalendarGrantNeedsReconsent(ctx, userID int64) error`
+      (the last can share the existing `needs_reconsent` status-set query if one
+      already exists at the `db.Queries` level for `gmail_connections`; otherwise add
+      one narrow query for it)
+- [ ] 4.3 Implement the three on `QueriesRepository`
+- [ ] 4.4 Add `CalendarLinker` interface and `ErrCalendarNotConnected` to a new
+      `googlemeet.go`:
+      ```go
+      type CalendarLinker interface {
+          CreateMeetEvent(ctx context.Context, userID int64, in MeetEventInput) (eventID, meetLink string, err error)
+          DeleteMeetEvent(ctx context.Context, userID int64, eventID string) error
+      }
+      ```
+      `MeetEventInput` carries what one event needs: start/end instants, the seeker's
+      email, a summary. Implementation depends on `*gmailsync.Connector` and
+      `*tokencrypt.Cipher` (both injected, both nil-safe the way `Notifier`/`Cache`
+      already are on `Config`)
+- [ ] 4.5 `CreateMeetEvent`: read the grant via `GetMentorCalendarGrant`; no row, or a
+      row whose `scopes` lacks `CalendarEventsScope`, returns `ErrCalendarNotConnected`
+      immediately (no HTTP call). Otherwise decrypt the refresh token, `POST
+      https://www.googleapis.com/calendar/v3/calendars/primary/events?conferenceDataVersion=1`
+      with one attendee (the seeker's email) and `conferenceData.createRequest` set
+      (a random request id per call), mirroring `calsync.APIReader`'s plain-`net/http`
+      style; wrap a non-200 response in `gmailsync.APIError{Op, StatusCode, Status}`;
+      parse `id` and `hangoutLink` from the response
+- [ ] 4.6 `DeleteMeetEvent`: same grant lookup, `DELETE
+      .../calendars/primary/events/{eventID}`; a 404/410 (already gone) is treated as
+      success, not an error
+- [ ] 4.7 Add `CalendarLinker CalendarLinker` to `mentorship.Config`, `calendar
+      CalendarLinker` to `Service`, wire it in `New()` — nil-safe throughout
+- [ ] 4.8 Unit tests (fake `CalendarLinker` in `fake_repo_test.go`-style): not-connected
+      → `ErrCalendarNotConnected`; connected + success → event id and Meet link parsed
+      from a canned response; connected + 401/403 → wrapped as `gmailsync.APIError`
+      and `RevokedGrant` reports true on it; a non-auth failure (500) → `RevokedGrant`
+      reports false
+
+## 5. `Book()`/`Cancel()`: use the seam
+
+- [ ] 5.1 In `Book()`: after `s.repo.CreateBooking` succeeds, if `s.calendar != nil`
+      call `CreateMeetEvent`. `ErrCalendarNotConnected` → do nothing further (the row
+      already has `mentor.MeetingURL`, today's behavior, unchanged). Success → call
+      `SetBookingCalendarEvent`, and patch the in-memory `booking.MeetingURL`/
+      `GoogleEventID` before the notifier is invoked, so the confirmation email/ICS
+      carries the real link. Any other error → log it (reusing `logDeliveryFailure`'s
+      style), leave the row's link empty (insert `MeetingURL: ""` instead of
+      `mentor.MeetingURL` whenever the mentor holds *any* `calendar.events` grant,
+      connected-or-failing — see design.md), and if `gmailsync.RevokedGrant(err)` call
+      `MarkCalendarGrantNeedsReconsent`
+- [ ] 5.2 In `Cancel()`: after the existing cancel + notify, if
+      `booking.GoogleEventID != ""` and `s.calendar != nil`, call `DeleteMeetEvent`
+      best-effort, logging (never returning) a failure
+- [ ] 5.3 Unit tests: a connected mentor's booking gets the fake `CalendarLinker`'s
+      returned link and event id, and the notifier receives a `Booking` with that
+      link (not the mentor's static one); an unconnected mentor's booking is
+      byte-for-byte identical to today (regression guard, extending the existing
+      booking tests); a `CreateMeetEvent` failure still returns a confirmed booking
+      with an empty link and calls `MarkCalendarGrantNeedsReconsent` only when the
+      fake reports a revocation-shaped error; cancelling a booking with an event id
+      calls `DeleteMeetEvent`; a `DeleteMeetEvent` failure does not fail `Cancel()`
+
+## 6. Profile: conditional meeting-link requirement
+
+- [ ] 6.1 Add `HasCalendarLink bool` to `ProfileInput`
+- [ ] 6.2 Change `validateMeetingURL(raw string, hasCalendarLink bool) error`: an empty
+      `raw` returns `nil` when `hasCalendarLink`, otherwise unchanged; thread the new
+      parameter through `validateProfile`'s one call site
+- [ ] 6.3 In `internal/api/handler/mentorship_write.go`'s `mentorProfileBody` (or
+      wherever `profileRequest.toInput(userID)` is called), look up the caller's
+      `gmail_connections` scopes the same way `GmailStatus` does and set
+      `in.HasCalendarLink` before calling `SubmitProfile`/`UpdateProfile`
+- [ ] 6.4 Unit tests: `validateProfile` — empty link + `hasCalendarLink=false` →
+      refused (regression); empty link + `hasCalendarLink=true` → accepted; a
+      non-empty link is validated identically either way
+
+## 7. Frontend
+
+- [ ] 7.1 `/my/integrations`: add a "Connect Google Calendar for automatic Meet links"
+      action beside the existing Gmail/Calendar cards, reading
+      `mentor_calendar_connected` from the Gmail-status response and linking to
+      `/api/v1/me/mentor-calendar/connect`
+- [ ] 7.2 `MentorProfileEditor.svelte`: fetch whether the caller has
+      `mentor_calendar_connected` (reuse the same status call `/my/integrations`
+      already makes) and render the "Meeting link" field as optional — no required
+      marker/validation-on-submit-message change needed beyond what the backend
+      already refuses — when it is true
+- [ ] 7.3 Manual check via the `run` skill in a real browser: connecting is out of
+      reach without live Google credentials in dev, so verify what is testable
+      without them — the profile form's meeting-link requirement toggles correctly
+      when `mentor_calendar_connected` is stubbed/forced true via a direct API
+      response, and confirm the unconnected path (the overwhelming common case) is
+      pixel-identical to before this change
+
+## 8. Verification
+
+- [ ] 8.1 `gofmt -w`, `go vet ./...`, `go test ./...` on touched Go packages; confirm
+      `internal/engage/mentorship` importing `internal/application/gmailsync` and
+      `internal/platform/tokencrypt` passes the layering guard (both are legal
+      downward imports — engage is layer 7, application and platform are 6 and 1)
+- [ ] 8.2 `go vet -tags=integration ./...`; run the full integration suite for
+      `internal/platform/db` and `internal/api/handler` if the SQL or handler
+      signatures changed
+- [ ] 8.3 `node scripts/check-migrations.mjs` on the new migration
+- [ ] 8.4 `svelte-check`, `eslint`, full frontend `vitest run`
+- [ ] 8.5 Confirm `notify.go`/`invite.go` need no change (already verified during
+      design: both already guard every render on `MeetingURL != ""`) by adding one
+      test each asserting an empty-link booking renders without a join link/URL line

--- a/openspec/changes/mentor-google-meet-link/tasks.md
+++ b/openspec/changes/mentor-google-meet-link/tasks.md
@@ -147,15 +147,21 @@
 
 ## 8. Verification
 
-- [ ] 8.1 `gofmt -w`, `go vet ./...`, `go test ./...` on touched Go packages; confirm
-      `internal/engage/mentorship` importing `internal/application/gmailsync` and
-      `internal/platform/tokencrypt` passes the layering guard (both are legal
-      downward imports — engage is layer 7, application and platform are 6 and 1)
-- [ ] 8.2 `go vet -tags=integration ./...`; run the full integration suite for
-      `internal/platform/db` and `internal/api/handler` if the SQL or handler
-      signatures changed
-- [ ] 8.3 `node scripts/check-migrations.mjs` on the new migration
-- [ ] 8.4 `svelte-check`, `eslint`, full frontend `vitest run`
-- [ ] 8.5 Confirm `notify.go`/`invite.go` need no change (already verified during
-      design: both already guard every render on `MeetingURL != ""`) by adding one
-      test each asserting an empty-link booking renders without a join link/URL line
+- [x] 8.1 `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` all green.
+      `go test -count=1 -tags=integration,llmlive ./internal/platform/arch/...`
+      confirms the layering guard passes with `internal/engage/mentorship` now
+      importing `internal/application/gmailsync` and `internal/platform/tokencrypt`
+      (both legal downward imports — engage is layer 7, application and platform are
+      6 and 1).
+- [x] 8.2 `go vet -tags=integration ./...` clean. The full tagged integration suite
+      for `internal/platform/db`/`internal/api/handler` was NOT run: no `.sql` query
+      signature changed since task 1.2's `make sqlc` (already covered there), and no
+      exported handler constructor/signature changed in a way the untagged suite
+      could not already catch — `withCalendarLink` and `HasConnectedCalendar` are
+      both new, additive, and covered by the untagged unit tests.
+- [x] 8.3 `node scripts/check-migrations.mjs`: 0 issues on the new migration.
+- [x] 8.4 `svelte-check` (0 errors), `eslint` (clean), full frontend `vitest run`
+      (1805 tests passing), design-system adoption ratchet unchanged.
+- [x] 8.5 Added `TestAnEmptyMeetingLinkOmitsLocationAndURL` (`invite_test.go`) and
+      `TestAnEmptyMeetingLinkProducesNoJoinLine` (`notify_test.go`) — both confirm the
+      existing guards need no change.

--- a/openspec/changes/mentor-google-meet-link/tasks.md
+++ b/openspec/changes/mentor-google-meet-link/tasks.md
@@ -165,3 +165,47 @@
 - [x] 8.5 Added `TestAnEmptyMeetingLinkOmitsLocationAndURL` (`invite_test.go`) and
       `TestAnEmptyMeetingLinkProducesNoJoinLine` (`notify_test.go`) — both confirm the
       existing guards need no change.
+
+## 9. Post-review fixes
+
+A `/code-review` pass after task 8 found real gaps this task list's own groups had not
+covered. Fixed rather than deferred, each with a regression test:
+
+- [x] `GmailStatus`'s `mentor_calendar_connected` was scope-only, so a grant marked
+      `needs_reconsent` still read as connected — the profile form kept telling a
+      mentor their meeting link was optional while every new booking silently landed
+      with none. Now gated on `status == 'connected'` too, agreeing with
+      `GetMentorCalendarGrant`'s own test. Covered by
+      `TestGmailInboxEndToEnd`'s new assertions (`gmail_integration_test.go`).
+- [x] `Withdraw()`'s bulk cancellation never deleted the Meet events its cancelled
+      bookings had minted, unlike the single-booking `Cancel()` path — a withdrawing
+      mentor could leave stray live events on their own calendar after every seeker
+      was told the sessions were off. Both paths now share
+      `Service.deleteMeetEventBestEffort`. Covered by
+      `TestWithdrawalDeletesCalendarEventsOfCancelledBookings`.
+- [x] `Service.HasConnectedCalendar` and `GoogleCalendarLinker.resolve` each
+      independently tested "found && covers calendar.events" — factored into one
+      shared `hasCalendarWriteGrant` so the two definitions of "connected" cannot
+      drift apart (from the earlier `/simplify` pass).
+- [x] `attachMeetEvent`'s two `SetBookingCalendarEvent`-then-patch call sites were
+      duplicated and logged failures through two different helpers; factored into
+      `Service.setCalendarEvent`, both logged through `logDeliveryFailure`.
+- [x] `withCalendarLink` queried the caller's calendar grant even when the submitted
+      meeting link was already non-empty, though `validateMeetingURL` only ever
+      consults it for an empty one — skipped now when there's nothing to decide.
+- [x] `gmailsync`'s three incremental-consent method pairs
+      (`CalendarAuthCodeURL`/`MentorCalendarAuthCodeURL`,
+      `ExchangeCalendar`/`ExchangeMentorCalendar`) duplicated their bodies near
+      verbatim; factored into shared `scopedAuthCodeURL`/`scopedExchange` (the
+      sign-in flow's own `AuthCodeURL`/`Exchange` stay separate — no scope override,
+      no cfg clone).
+- [x] `meetAPI.createEvent` treated a 200/201 response with no `hangoutLink` (Google's
+      documented "conference still pending" case) as an ordinary silent success; kept
+      the same outcome (event id kept, link empty, no retry — retrying is an
+      explicit non-goal) but added a log line so the case is visible in production.
+      Covered by `TestMeetAPICreateEventToleratesAPendingConference`.
+- [x] NOT fixed, by design: `meetAPI`'s `meetEventsURL` redeclares the same literal
+      `calsync.eventsURL` already holds. Deduping it means exporting a constant from
+      an unrelated package (`internal/application/calsync`) that file was never
+      otherwise touched by this change — out of this task's surgical scope for a
+      single literal with low drift risk.

--- a/openspec/changes/mentor-google-meet-link/tasks.md
+++ b/openspec/changes/mentor-google-meet-link/tasks.md
@@ -49,85 +49,82 @@
 
 ## 4. Domain: `internal/engage/mentorship` — the calendar-write seam
 
-- [ ] 4.1 Add `GoogleEventID string` to `Booking` and to the `mentor_bookings` scan in
-      `repository.go`
-- [ ] 4.2 Add to `Repository` interface:
-      `GetMentorCalendarGrant(ctx, userID int64) (refreshTokenEnc string, scopes
-      []string, found bool, err error)` and
-      `SetBookingCalendarEvent(ctx, bookingID uuid.UUID, meetingURL, eventID string)
-      error` and `MarkCalendarGrantNeedsReconsent(ctx, userID int64) error`
-      (the last can share the existing `needs_reconsent` status-set query if one
-      already exists at the `db.Queries` level for `gmail_connections`; otherwise add
-      one narrow query for it)
-- [ ] 4.3 Implement the three on `QueriesRepository`
-- [ ] 4.4 Add `CalendarLinker` interface and `ErrCalendarNotConnected` to a new
-      `googlemeet.go`:
-      ```go
-      type CalendarLinker interface {
-          CreateMeetEvent(ctx context.Context, userID int64, in MeetEventInput) (eventID, meetLink string, err error)
-          DeleteMeetEvent(ctx context.Context, userID int64, eventID string) error
-      }
-      ```
-      `MeetEventInput` carries what one event needs: start/end instants, the seeker's
-      email, a summary. Implementation depends on `*gmailsync.Connector` and
-      `*tokencrypt.Cipher` (both injected, both nil-safe the way `Notifier`/`Cache`
-      already are on `Config`)
-- [ ] 4.5 `CreateMeetEvent`: read the grant via `GetMentorCalendarGrant`; no row, or a
-      row whose `scopes` lacks `CalendarEventsScope`, returns `ErrCalendarNotConnected`
-      immediately (no HTTP call). Otherwise decrypt the refresh token, `POST
-      https://www.googleapis.com/calendar/v3/calendars/primary/events?conferenceDataVersion=1`
-      with one attendee (the seeker's email) and `conferenceData.createRequest` set
-      (a random request id per call), mirroring `calsync.APIReader`'s plain-`net/http`
-      style; wrap a non-200 response in `gmailsync.APIError{Op, StatusCode, Status}`;
-      parse `id` and `hangoutLink` from the response
-- [ ] 4.6 `DeleteMeetEvent`: same grant lookup, `DELETE
-      .../calendars/primary/events/{eventID}`; a 404/410 (already gone) is treated as
-      success, not an error
-- [ ] 4.7 Add `CalendarLinker CalendarLinker` to `mentorship.Config`, `calendar
-      CalendarLinker` to `Service`, wire it in `New()` — nil-safe throughout
-- [ ] 4.8 Unit tests (fake `CalendarLinker` in `fake_repo_test.go`-style): not-connected
-      → `ErrCalendarNotConnected`; connected + success → event id and Meet link parsed
-      from a canned response; connected + 401/403 → wrapped as `gmailsync.APIError`
-      and `RevokedGrant` reports true on it; a non-auth failure (500) → `RevokedGrant`
-      reports false
+- [x] 4.1 Added `GoogleEventID string` to `Booking` and to `bookingFromRow` (reads
+      `db.MentorBooking.GoogleEventID`, present on every `mentor_bookings` scan since
+      task 1.2's `make sqlc` regeneration).
+- [x] 4.2 Added to `Repository`: `GetMentorCalendarGrant`, `SetBookingCalendarEvent`,
+      `MarkCalendarGrantNeedsReconsent`. `GetMentorCalendarGrant` treats any status
+      other than `'connected'` (needs_reconsent included) as not-found, so the caller
+      never needs a second query to learn a grant is unusable.
+- [x] 4.3 Implemented the three on `QueriesRepository` (`repository.go`):
+      `GetMentorCalendarGrant` over `GetGoogleGrantForWrite`, `SetBookingCalendarEvent`
+      over `SetMentorBookingCalendarEvent`, `MarkCalendarGrantNeedsReconsent` reusing
+      `SetGmailStatus` — the same query the read-side grants already share.
+- [x] 4.4 Added `CalendarLinker`/`ErrCalendarNotConnected`/`MeetEventInput` to
+      `googlemeet.go`, plus `GoogleCalendarLinker` (depends on a narrow
+      `calendarGrantReader`, `*gmailsync.Connector`, `*tokencrypt.Cipher`).
+- [x] 4.5 `GoogleCalendarLinker.CreateMeetEvent`: `resolve()` reads the grant and
+      refuses with `ErrCalendarNotConnected` before any HTTP call when not found or
+      missing `CalendarEventsScope`; otherwise decrypts the token and POSTs via the
+      extracted `meetAPI.createEvent`, mirroring `calsync.APIReader`'s style —
+      `conferenceDataVersion=1`, one attendee, a random `requestId` per call, a non-2xx
+      wrapped in `gmailsync.APIError`, `id`/`hangoutLink` parsed from the response.
+- [x] 4.6 `DeleteMeetEvent`/`meetAPI.deleteEvent`: same grant gate, `DELETE
+      .../events/{eventID}`; 200/204/404/410 all read as success.
+- [x] 4.7 Added `CalendarLinker CalendarLinker` to `Config`, `calendar CalendarLinker`
+      to `Service`, wired in `New()` — nil-safe.
+- [x] 4.8 `googlemeet_test.go`: not-connected (no row, and a grant present but missing
+      the write scope) → `ErrCalendarNotConnected` before any network call; `meetAPI`
+      tested directly against `httptest` (mirroring `calsync`'s rewrite-transport
+      pattern, extended to preserve the DELETE path segment) — success parses
+      `id`/`hangoutLink`; 403 wraps as `gmailsync.APIError` and `RevokedGrant` reports
+      true; 500 does not; 404/410 on delete read as success.
+      Deviation from the task text: the HTTP-shape tests exercise the extracted
+      `meetAPI` directly with a plain client rather than `GoogleCalendarLinker` end to
+      end, so they need no real OAuth handshake — exactly how `calsync.APIReader`'s own
+      tests avoid it. The not-connected gate IS tested through `GoogleCalendarLinker`
+      itself, since that path needs no network call at all.
 
 ## 5. `Book()`/`Cancel()`: use the seam
 
-- [ ] 5.1 In `Book()`: after `s.repo.CreateBooking` succeeds, if `s.calendar != nil`
-      call `CreateMeetEvent`. `ErrCalendarNotConnected` → do nothing further (the row
-      already has `mentor.MeetingURL`, today's behavior, unchanged). Success → call
-      `SetBookingCalendarEvent`, and patch the in-memory `booking.MeetingURL`/
-      `GoogleEventID` before the notifier is invoked, so the confirmation email/ICS
-      carries the real link. Any other error → log it (reusing `logDeliveryFailure`'s
-      style), leave the row's link empty (insert `MeetingURL: ""` instead of
-      `mentor.MeetingURL` whenever the mentor holds *any* `calendar.events` grant,
-      connected-or-failing — see design.md), and if `gmailsync.RevokedGrant(err)` call
-      `MarkCalendarGrantNeedsReconsent`
-- [ ] 5.2 In `Cancel()`: after the existing cancel + notify, if
-      `booking.GoogleEventID != ""` and `s.calendar != nil`, call `DeleteMeetEvent`
-      best-effort, logging (never returning) a failure
-- [ ] 5.3 Unit tests: a connected mentor's booking gets the fake `CalendarLinker`'s
-      returned link and event id, and the notifier receives a `Booking` with that
-      link (not the mentor's static one); an unconnected mentor's booking is
-      byte-for-byte identical to today (regression guard, extending the existing
-      booking tests); a `CreateMeetEvent` failure still returns a confirmed booking
-      with an empty link and calls `MarkCalendarGrantNeedsReconsent` only when the
-      fake reports a revocation-shaped error; cancelling a booking with an event id
-      calls `DeleteMeetEvent`; a `DeleteMeetEvent` failure does not fail `Cancel()`
+- [x] 5.1 In `Book()`: `CreateBooking` still snapshots `mentor.MeetingURL` as before;
+      when `s.calendar != nil`, `attachMeetEvent` then calls `CreateMeetEvent`.
+      `ErrCalendarNotConnected` → leave the row as inserted (today's behaviour,
+      unchanged). Success → `SetBookingCalendarEvent` plus an in-memory patch of
+      `booking.MeetingURL`/`GoogleEventID` before the notifier fires. Any other error →
+      `logDeliveryFailure`, then `SetBookingCalendarEvent(id, "", "")` to blank the
+      stale static link (a mentor reaching this branch DOES hold a grant, by
+      construction — `ErrCalendarNotConnected` would have returned above otherwise),
+      and `MarkCalendarGrantNeedsReconsent` when `gmailsync.RevokedGrant(err)`.
+- [x] 5.2 In `Cancel()`: after the existing cancel + notify, if
+      `booking.GoogleEventID != ""` and `s.calendar != nil`, `DeleteMeetEvent`
+      best-effort (called with the mentor's user id, since the grant lives on their
+      account), logging — never returning — a failure.
+- [x] 5.3 `booking_test.go`: an unconnected mentor (`s.calendar == nil`) and a
+      connected-linker-but-no-grant mentor (`ErrCalendarNotConnected`) both book
+      byte-for-byte as today; a connected mentor's booking carries the fake linker's
+      link/event id and the notifier receives that same link; a non-`ErrCalendarNotConnected`
+      failure still returns a confirmed booking with an empty link and marks
+      `needs_reconsent` only for a `gmailsync.APIError{401}`-shaped one; cancelling
+      calls `DeleteMeetEvent` with the stored event id; a `DeleteMeetEvent` failure
+      does not fail `Cancel()`.
 
 ## 6. Profile: conditional meeting-link requirement
 
-- [ ] 6.1 Add `HasCalendarLink bool` to `ProfileInput`
-- [ ] 6.2 Change `validateMeetingURL(raw string, hasCalendarLink bool) error`: an empty
-      `raw` returns `nil` when `hasCalendarLink`, otherwise unchanged; thread the new
-      parameter through `validateProfile`'s one call site
-- [ ] 6.3 In `internal/api/handler/mentorship_write.go`'s `mentorProfileBody` (or
-      wherever `profileRequest.toInput(userID)` is called), look up the caller's
-      `gmail_connections` scopes the same way `GmailStatus` does and set
-      `in.HasCalendarLink` before calling `SubmitProfile`/`UpdateProfile`
-- [ ] 6.4 Unit tests: `validateProfile` — empty link + `hasCalendarLink=false` →
-      refused (regression); empty link + `hasCalendarLink=true` → accepted; a
-      non-empty link is validated identically either way
+- [x] 6.1 Added `HasCalendarLink bool` to `ProfileInput`.
+- [x] 6.2 Changed `validateMeetingURL(raw string, hasCalendarLink bool) error`: an
+      empty `raw` returns `nil` when `hasCalendarLink`, otherwise unchanged; threaded
+      through `validateProfile`'s one call site.
+- [x] 6.3 Added `Service.HasConnectedCalendar` (googlemeet.go), sharing
+      `GetMentorCalendarGrant` + the same scope check `CreateMeetEvent`'s gate uses, so
+      the two can never disagree about what "connected" means. Added
+      `mentorshipHandlers.withCalendarLink` (`mentorship_write.go`), called from both
+      `SubmitMentorProfile` and `UpdateMentorProfile` before `toInput`'s result reaches
+      the service.
+- [x] 6.4 `profile_test.go`: empty link + `HasCalendarLink=false` → refused
+      (regression, existing table test); empty link + `HasCalendarLink=true` →
+      accepted (`TestSubmitProfileAcceptsNoMeetingLinkWithAConnectedCalendar`); an
+      invalid non-empty link is refused identically with `HasCalendarLink=true` too.
 
 ## 7. Frontend
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -325,6 +325,10 @@ export interface GmailStatus {
    *  a connected mailbox says nothing about the calendar, and a calendar grant may have
    *  no mailbox behind it at all. */
   calendar_connected?: boolean;
+  /** Whether the same grant covers calendar.events — the mentor-only write consent that
+   *  auto-generates a Meet link per booking and makes the mentor profile's own meeting
+   *  link field optional. A third, separate consent from both fields above. */
+  mentor_calendar_connected?: boolean;
 }
 
 /** The hosted-mailbox option: the caller's address (null when none) + whether

--- a/web/src/lib/components/IntegrationsView.svelte
+++ b/web/src/lib/components/IntegrationsView.svelte
@@ -29,6 +29,7 @@
 
   const hasGmail = $derived(!!gmail?.connected);
   const hasCalendar = $derived(gmail?.calendar_connected === true);
+  const hasMentorCalendar = $derived(gmail?.mentor_calendar_connected === true);
 
   async function loadGmail() {
     gmailLoading = true;
@@ -80,12 +81,14 @@
   });
   const GMAIL_CONNECT_ERRORS = connectErrors('Gmail');
   const CALENDAR_CONNECT_ERRORS = connectErrors('Calendar');
+  const MENTOR_CALENDAR_CONNECT_ERRORS = connectErrors('Calendar');
   let googleNotice = $state<{ ok: boolean; text: string } | null>(null);
 
   function readGoogleVerdict() {
     const params = page.url.searchParams;
     const gmailFailed = params.get('gmail_error');
     const calendarFailed = params.get('calendar_error');
+    const mentorCalendarFailed = params.get('mentor_calendar_error');
     if (gmailFailed) {
       googleNotice = { ok: false, text: GMAIL_CONNECT_ERRORS[gmailFailed] ?? 'Connecting Gmail failed. Try again.' };
     } else if (calendarFailed) {
@@ -93,10 +96,20 @@
         ok: false,
         text: CALENDAR_CONNECT_ERRORS[calendarFailed] ?? 'Connecting Calendar failed. Try again.',
       };
+    } else if (mentorCalendarFailed) {
+      googleNotice = {
+        ok: false,
+        text: MENTOR_CALENDAR_CONNECT_ERRORS[mentorCalendarFailed] ?? 'Connecting Calendar failed. Try again.',
+      };
     } else if (params.get('gmail') === 'connected') {
       googleNotice = { ok: true, text: 'Gmail connected — your ATS mail will show up in the Inbox shortly.' };
     } else if (params.get('calendar') === 'connected') {
       googleNotice = { ok: true, text: 'Calendar connected — accepted interviews will show up on the Tracking calendar.' };
+    } else if (params.get('mentor_calendar') === 'connected') {
+      googleNotice = {
+        ok: true,
+        text: 'Calendar connected — your mentorship bookings will get an automatic Meet link.',
+      };
     } else {
       return;
     }
@@ -315,6 +328,34 @@
             <!-- eslint-disable svelte/no-navigation-without-resolve -- an API route the browser must navigate to so Google can redirect it back, not a SvelteKit page to resolve -->
             <a
               href="/api/v1/me/calendar/connect"
+              class="shrink-0 rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground"
+              >Connect</a
+            >
+            <!-- eslint-enable svelte/no-navigation-without-resolve -->
+          {/if}
+        </div>
+
+        <!-- Mentor calendar: a THIRD, separate write consent — never inferred from the
+             read-only Calendar grant above, which candidates connect for an unrelated
+             purpose and must not silently be handed write access over. -->
+        <div class="flex flex-wrap items-center justify-between gap-3 border-t border-border pt-3">
+          <div class="min-w-0">
+            <div class="flex items-center gap-1.5 text-sm">
+              <CalendarDays class="h-3.5 w-3.5 text-muted-foreground" /> Mentor calendar
+              {#if hasMentorCalendar}
+                <Badge variant="outline" class={CONNECTED_BADGE_CLASS}>Connected</Badge>
+              {/if}
+            </div>
+            <p class="text-xs text-muted-foreground">
+              {hasMentorCalendar
+                ? 'New mentorship bookings get an automatic Google Meet link.'
+                : 'For mentors: get an automatic Google Meet link on every booking instead of a fixed link.'}
+            </p>
+          </div>
+          {#if !hasMentorCalendar && gmail?.available}
+            <!-- eslint-disable svelte/no-navigation-without-resolve -- an API route the browser must navigate to so Google can redirect it back, not a SvelteKit page to resolve -->
+            <a
+              href="/api/v1/me/mentor-calendar/connect"
               class="shrink-0 rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground"
               >Connect</a
             >

--- a/web/src/lib/components/IntegrationsView.svelte
+++ b/web/src/lib/components/IntegrationsView.svelte
@@ -80,8 +80,9 @@
     exchange: 'Google did not finish handing over access. Try connecting again.',
   });
   const GMAIL_CONNECT_ERRORS = connectErrors('Gmail');
+  // Shared with the mentor calendar flow below: both name the same product ("Calendar")
+  // to the reader, so the same messages apply to either failing.
   const CALENDAR_CONNECT_ERRORS = connectErrors('Calendar');
-  const MENTOR_CALENDAR_CONNECT_ERRORS = connectErrors('Calendar');
   let googleNotice = $state<{ ok: boolean; text: string } | null>(null);
 
   function readGoogleVerdict() {
@@ -99,7 +100,7 @@
     } else if (mentorCalendarFailed) {
       googleNotice = {
         ok: false,
-        text: MENTOR_CALENDAR_CONNECT_ERRORS[mentorCalendarFailed] ?? 'Connecting Calendar failed. Try again.',
+        text: CALENDAR_CONNECT_ERRORS[mentorCalendarFailed] ?? 'Connecting Calendar failed. Try again.',
       };
     } else if (params.get('gmail') === 'connected') {
       googleNotice = { ok: true, text: 'Gmail connected — your ATS mail will show up in the Inbox shortly.' };

--- a/web/src/lib/components/MentorProfileEditor.svelte
+++ b/web/src/lib/components/MentorProfileEditor.svelte
@@ -39,6 +39,20 @@
   let saving = $state(false);
   let error = $state('');
 
+  // Whether the caller has connected a calendar.events grant — the same status call
+  // /my/integrations makes, not a mentorship-specific endpoint. When true, a booking
+  // gets a real Meet link automatically and the static field below has nothing left to
+  // guarantee, so the backend accepts it empty (see mentorship.validateMeetingURL).
+  let hasMentorCalendar = $state(false);
+  onMount(async () => {
+    try {
+      const status = await api.gmailStatus();
+      hasMentorCalendar = status.mentor_calendar_connected === true;
+    } catch {
+      // Best-effort: the field falls back to its ordinary required state.
+    }
+  });
+
   // A one-time prefill for a brand-new profile only: fetched once on mount, seeded into
   // the still-blank form, and never touched again — every field stays an ordinary,
   // independently editable input from here on. A failed fetch simply leaves the form at
@@ -211,7 +225,12 @@
 
     <label class="text-sm sm:col-span-2">
       <span class="text-muted-foreground">
-        Meeting link — a room you own. Only booked seekers ever see it.
+        {#if hasMentorCalendar}
+          Meeting link — optional. Your connected calendar mints a real Google Meet link
+          for every booking, so you only need this as a fallback.
+        {:else}
+          Meeting link — a room you own. Only booked seekers ever see it.
+        {/if}
       </span>
       <Input
         bind:value={form.meeting_url}


### PR DESCRIPTION
## Summary
- A mentor may optionally connect Google Calendar (`calendar.events`, a third, separate consent from the candidate-side read-only calendar flow) so each confirmed booking gets a real Google Meet link instead of the mentor's manually-typed static one.
- Falls back to today's static-link behaviour whenever the mentor isn't connected, and on any calendar-write failure a booking is still created with an empty link rather than a stale one; a revocation-shaped failure marks the grant `needs_reconsent`. Cancelling best-effort deletes the calendar event.
- The profile's meeting-link field becomes optional once a mentor is connected; `/my/integrations` gets a new "Mentor calendar" card to start the consent.

## Test plan
- [x] `gofmt`, `go vet ./...`, `go test ./...` — all green
- [x] `go vet -tags=integration ./...` — clean
- [x] `go test -count=1 -tags=integration,llmlive ./internal/platform/arch/...` — layering guard passes for the new `gmailsync`/`tokencrypt` imports
- [x] `node scripts/check-migrations.mjs` on the new migration — 0 issues
- [x] `svelte-check` / `eslint` / frontend `vitest run` (1805 tests) / design-system adoption ratchet — all clean
- [x] Live browser verification: `/my/integrations` renders the new card without regressing Mail/Calendar; an unconnected mentor's profile form is pixel-identical to before (meeting link still required, refusal unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mentors can connect Google Calendar with separate consent to generate Google Meet links for mentorship bookings.
  * The Integrations page displays mentor calendar connection status and setup errors.
  * Connected mentors may leave the profile meeting-link field empty and use booking-specific Meet links.
  * Calendar events are removed when bookings are cancelled.

* **Bug Fixes**
  * Calendar access failures no longer prevent bookings from being confirmed.
  * Revoked calendar access is flagged for reconnection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->