### PR TITLE
Stop a bounded PTO/travel perk from filling work_mode=remote

### DIFF
--- a/internal/dict/location/workmode.go
+++ b/internal/dict/location/workmode.go
@@ -48,12 +48,57 @@ func WorkModeFromDescription(desc string) string {
 	lower := strings.ToLower(desc)
 	for _, wm := range descriptionWorkModePhrases {
 		for _, p := range wm.phrases {
-			if strings.Contains(lower, p) {
-				return wm.mode
+			i := strings.Index(lower, p)
+			if i < 0 {
+				continue
 			}
+			if travelPerkPhrases[p] && travelPerkQualified(lower, i, i+len(p)) {
+				continue
+			}
+			return wm.mode
 		}
 	}
 	return ""
+}
+
+// travelPerkPhrases are the remote-family phrases that are ALSO a common idiom for a
+// bounded travel/PTO allowance ("the freedom to work from anywhere in the world for up
+// to a month") rather than the posting's own work arrangement. Measured over prod
+// postings mentioning "work from anywhere" (freehire#2696): no other phrase in
+// descriptionWorkModePhrases showed this ambiguity — "100% remote"/"fully remote"/etc.
+// are not idioms for a bounded benefit ("100% remote for up to X days" is not a sentence
+// employers write), so guarding them would only cost coverage with no measured gain. The
+// same "measured evidence, not symmetry" doctrine remoteDenialPhrases' comment applies to
+// "on-site only"/"must be onsite" below.
+var travelPerkPhrases = map[string]bool{
+	"work from anywhere": true,
+	"work-from-anywhere": true,
+}
+
+// travelPerkQualifiers mark a travelPerkPhrases match as a bounded allowance rather than
+// an unconditional statement — the same "usually unambiguous but sometimes qualified"
+// shape as remoteDenialPhrases/denialQualifiers below, applied here to a phrase that FILLS
+// a blank instead of overruling a stated one. "up to" alone is a broad enough marker
+// (unlike denialQualifiers, which had to enumerate distinct scoping shapes): every
+// disqualifying prod sentence found carries it ("for up to a month", "up to 12 days",
+// "allowing up to 20 remote days"), and it is inherently a bounded-quantity phrase. Unlike
+// a denial qualifier, which only ever follows the phrase it scopes, this one appears on
+// EITHER side of the match in real postings ("work from anywhere ... for up to a month"
+// and "up to 12 days work from anywhere"), so both directions are checked.
+var travelPerkQualifiers = []string{"up to"}
+
+// travelPerkQualifierWindow reuses denialQualifierWindow's value: the observed distances
+// in production sentences are well inside it, and a second, unmeasured window constant
+// would be an invented number rather than evidence.
+const travelPerkQualifierWindow = denialQualifierWindow
+
+// travelPerkQualified reports whether a bounded-duration qualifier appears within
+// travelPerkQualifierWindow characters before or after the match spanning [start, end) in
+// text (already lowercased).
+func travelPerkQualified(text string, start, end int) bool {
+	before := text[max(0, start-travelPerkQualifierWindow):start]
+	after := text[end:min(len(text), end+travelPerkQualifierWindow)]
+	return containsAny(before, travelPerkQualifiers) || containsAny(after, travelPerkQualifiers)
 }
 
 // remoteDenialPhrases are the sentences with which a posting denies remote work outright.

--- a/internal/dict/location/workmode.go
+++ b/internal/dict/location/workmode.go
@@ -48,17 +48,36 @@ func WorkModeFromDescription(desc string) string {
 	lower := strings.ToLower(desc)
 	for _, wm := range descriptionWorkModePhrases {
 		for _, p := range wm.phrases {
-			i := strings.Index(lower, p)
-			if i < 0 {
-				continue
+			if phraseMatches(lower, p) {
+				return wm.mode
 			}
-			if travelPerkPhrases[p] && travelPerkQualified(lower, i, i+len(p)) {
-				continue
-			}
-			return wm.mode
 		}
 	}
 	return ""
+}
+
+// phraseMatches reports whether p occurs in text (already lowercased) unguarded. A
+// travelPerkPhrases match that IS qualified does not end the search for p — the same
+// "scan past a qualified match" property RemoteContradicted's loop has for denial phrases
+// (see TestRemoteContradictedReadsPastAQualifiedDenial): a description may hedge one
+// occurrence of "work from anywhere" as a bounded perk and state another, unqualified one
+// plainly, and the unqualified one still stands.
+func phraseMatches(text, p string) bool {
+	guarded := travelPerkPhrases[p]
+	rest := text
+	offset := 0
+	for {
+		i := strings.Index(rest, p)
+		if i < 0 {
+			return false
+		}
+		start, end := offset+i, offset+i+len(p)
+		if !guarded || !travelPerkQualified(text, start, end) {
+			return true
+		}
+		offset = end
+		rest = text[offset:]
+	}
 }
 
 // travelPerkPhrases are the remote-family phrases that are ALSO a common idiom for a

--- a/internal/dict/location/workmode_test.go
+++ b/internal/dict/location/workmode_test.go
@@ -35,6 +35,9 @@ func TestWorkModeFromDescription(t *testing.T) {
 			"to work from anywhere for up to a month. Otherwise, this is a fully remote position open to anyone.", "remote"},
 		{"unrelated up to near 100 percent remote unaffected", "This is a 100% remote role, with a " +
 			"signing bonus of up to $2,000.", "remote"},
+		{"scan continues past a qualified repeat to an unqualified one", "Benefits include up to 12 " +
+			"days work from anywhere per year. Separately, you can work from anywhere in the EU on a " +
+			"permanent basis.", "remote"},
 
 		// Trap negatives — incidental tokens that must NOT trigger a match.
 		{"distributed systems", "Experience building distributed systems at scale.", ""},

--- a/internal/dict/location/workmode_test.go
+++ b/internal/dict/location/workmode_test.go
@@ -24,6 +24,18 @@ func TestWorkModeFromDescription(t *testing.T) {
 		// Priority — hybrid beats remote when both appear.
 		{"hybrid beats remote", "A hybrid role with some remote days.", "hybrid"},
 
+		// "work from anywhere" qualifier guard (freehire#2696) — real prod sentences.
+		// A bounded-duration qualifier ("up to") near the phrase means it is stating a
+		// travel/PTO perk, not the posting's own arrangement, so it must not fill remote.
+		{"work from anywhere qualified after", "Flexible PTO and the freedom to work from anywhere " +
+			"in the world for up to a month — because life doesn't pause, and neither should you.", ""},
+		{"work from anywhere qualified before", "Our benefits include competitive compensation and " +
+			"flexible working arrangements, allowing you to work from anywhere for up to 45 days per year.", ""},
+		{"qualified phrase does not block unrelated remote phrase", "Our benefits include the freedom " +
+			"to work from anywhere for up to a month. Otherwise, this is a fully remote position open to anyone.", "remote"},
+		{"unrelated up to near 100 percent remote unaffected", "This is a 100% remote role, with a " +
+			"signing bonus of up to $2,000.", "remote"},
+
 		// Trap negatives — incidental tokens that must NOT trigger a match.
 		{"distributed systems", "Experience building distributed systems at scale.", ""},
 		{"hybrid cloud", "You will manage our hybrid cloud infrastructure.", ""},

--- a/openspec/changes/fix-work-from-anywhere-perk-false-positive/.openspec.yaml
+++ b/openspec/changes/fix-work-from-anywhere-perk-false-positive/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-09

--- a/openspec/changes/fix-work-from-anywhere-perk-false-positive/design.md
+++ b/openspec/changes/fix-work-from-anywhere-perk-false-positive/design.md
@@ -1,0 +1,129 @@
+## Context
+
+See proposal.md for motivation. `internal/dict/location/workmode.go` already ships
+one guard of this exact shape — `remoteDenialPhrases` / `denialQualifiers` /
+`denialQualifierWindow`, used by `RemoteContradicted` — for the opposite direction
+of the same problem: a phrase that is usually unambiguous but is qualified in
+specific, measured real-world sentences. That guard only scans forward from the
+match (`RemoteContradicted`'s loop advances `rest` past the match and checks the
+next `denialQualifierWindow` characters). Production evidence for this change
+(freehire#2696 investigation, read against the live Meilisearch `jobs` index) shows
+the qualifier for "work from anywhere" appears on **either side** of the match:
+
+- After: "the freedom to **work from anywhere** in the world **for up to** a
+  month", "**work from anywhere** within the EU **for up to** 140 days a year"
+- Before: "benefits include **up to** 12 days **work from anywhere**", "a Work from
+  Anywhere policy allowing **up to** 20 remote days"
+
+So the new guard needs a bidirectional window, not a reuse of the existing
+forward-only scan.
+
+`WorkModeFromDescription` is a flat priority loop over
+`descriptionWorkModePhrases` (hybrid family, then remote family, then onsite
+family; first phrase match anywhere in any family wins). The two phrases needing
+the guard ("work from anywhere", "work-from-anywhere") sit inside the `remote`
+family's phrase list alongside ten others that measurement showed do **not** need
+it (see proposal.md's Impact / the "not comparable" note below).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Stop "work from anywhere" from filling `work_mode=remote` when it is describing a
+  bounded travel/PTO allowance rather than the posting's actual arrangement.
+- Keep the fix scoped to exactly the phrase(s) measurement showed are ambiguous —
+  match the file's existing "measured evidence, not symmetry" doctrine
+  (`remoteDenialPhrases`'s own comment explains why `fully on-site`/`on-site only`
+  were tried and rejected on the same basis).
+
+**Non-Goals:**
+- Detecting hybrid from phrasings like "hybrid culture" or "in person 3 to 4 days a
+  week" that the current `hybrid` phrase family misses. Investigated during triage;
+  sampling production data found real false-positive risk in the most obvious
+  candidate addition ("hybrid culture" co-occurs with genuinely-remote postings that
+  merely mention a hybrid company culture in unrelated prose). Per this package's
+  "never guess" doctrine, once this change stops the wrong `remote` fill, a posting
+  with no other matching phrase correctly lands on an empty `work_mode` — that is
+  the correct output, not a gap this change needs to close.
+- Widening the guard to any other remote phrase. Checked and rejected — see
+  Decisions.
+- Any change to `jobderive.go`'s precedence chain or to `RemoteContradicted`. Both
+  are correct as-is; this change only narrows what `WorkModeFromDescription` fills.
+
+## Decisions
+
+**Bidirectional window, not a forward-only reuse of `denialQualifierWindow`/
+`containsAny`.** The existing denial-qualifier scan only needed to look forward
+because every observed denial qualifier ("for the first 90 days", "if hired")
+follows the denial phrase it qualifies. Real "work from anywhere" postings write
+the qualifier on either side, so the new check inspects a window before **and**
+after the match. Window size: reuse `denialQualifierWindow`'s value (60 chars) —
+the observed distances in production sentences are well inside it (worst case
+observed: "the freedom to **work from anywhere** in the world **for up to** a
+month", ~24 chars from the end of the phrase to the start of the qualifier), and
+reusing the constant avoids inventing an unmeasured second number.
+
+**Qualifier marker: "up to" alone**, not a longer enumerated list like
+`denialQualifiers`. Evidence: every disqualifying production sentence found during
+triage carries "up to" (`for up to`, `up to N days/weeks/a month`, `allowing up to
+N remote days`), and "up to" is inherently a bounded-quantity marker, unlike the
+denial qualifiers (`for the first`, `if hired`, ...) which needed to be enumerated
+because they describe unrelated scoping shapes (a trial period vs. a follow-on
+role). Cost of a false suppression here is low by design (see Risks) which affords
+a broader, simpler marker than the denial side needed.
+
+**Scope the guard to exactly `"work from anywhere"` and `"work-from-anywhere"`, not
+the whole `remote` family.** Checked co-occurrence of the other remote phrases
+(`100% remote`, `fully remote`, `remote-first`, `remote role`, `remote position`,
+etc.) with "for up to" in production: all far higher-volume (272–1,721 hits vs. 143
+for "work from anywhere") but inspected samples showed this is unrelated noise (a
+salary range, an unrelated benefit figure), not the same ambiguity — none of those
+phrases double as a common bounded-perk idiom the way "work from anywhere" does
+("100% remote for up to X days" is not an idiom employers write). Guarding them
+would cost real coverage (a "100% remote" posting mentioning an unrelated "up to"
+figure would wrongly lose its remote fill) for no measured benefit — the same
+reasoning `remoteDenialPhrases`'s comment already applies to `on-site only`/`must
+be onsite`.
+
+**When suppressed, continue scanning rather than returning early.** The existing
+loop structure (`for wm := range phrases { for p := range wm.phrases { if
+Contains... return wm.mode } } }`) already has this property implicitly: skipping
+a guarded match just means falling through to the next phrase check, so a
+description with both a qualified "work from anywhere" and an unrelated unqualified
+remote/hybrid/onsite phrase still resolves correctly from the other phrase. No
+special-case early-return logic is needed — the guard only changes what happens
+*at* the "work from anywhere" match, not the loop around it.
+
+## Risks / Trade-offs
+
+- **[Risk]** A genuinely fully-remote posting that also happens to mention an
+  unrelated "up to" figure within 60 characters of "work from anywhere" (e.g. "work
+  from anywhere, with a signing bonus of up to $2,000") loses its remote fill from
+  this phrase. → **Mitigation**: the cost is an empty `work_mode`, not a wrong one —
+  this package's `WorkModeFromDescription` doc comment already states that a phrase
+  it misses "costs a facet nobody had", the accepted trade-off for the whole
+  gap-filling list (unlike `RemoteContradicted`, which is held to a stricter bar
+  because it overrides a value already believed correct). A posting in this shape
+  is also likely to carry a structured or location-based remote signal already
+  (most `remote`-labeled "work from anywhere" hits in the production sample were
+  resolved by a higher-priority source, never reaching this fallback at all), so the
+  practical blast radius is small. Not testing for this edge case within
+  `workmode_test.go` beyond the general shape already covered (see tasks.md) —
+  no production evidence of it occurring was found during triage.
+- **[Trade-off]** The guard does not attempt to detect hybrid in these postings, so
+  a posting like the reported one (hybrid, `work_mode` currently wrongly `remote`)
+  moves to `work_mode=""` rather than the correct `hybrid`, until the hybrid phrase
+  family separately gains coverage (out of scope — see Non-Goals). → Accepted: empty
+  is strictly better than wrong for every downstream consumer (search facet,
+  `jobview`), and matches the project's stated dictionary doctrine.
+
+## Migration Plan
+
+Code-only change, no schema/migration. Deploys through the normal release path.
+After deploy, existing rows carrying the wrong `work_mode=remote` from this phrase
+need `cmd/backfill-derive` (re-derives all six dictionary facets in one pass) and
+then a full `cmd/reindex` to reach Meilisearch — the standard two-step propagation
+this package's `AGENTS.md` documents for any dictionary change. Not part of this
+code change's tasks; call out as a deploy follow-up in the PR description.
+Rollback: revert the code change; no data migration to undo (the backfill only ever
+narrows a previously-wrong `remote` toward empty, which is a strict improvement
+even if left in place after a revert).

--- a/openspec/changes/fix-work-from-anywhere-perk-false-positive/design.md
+++ b/openspec/changes/fix-work-from-anywhere-perk-false-positive/design.md
@@ -84,14 +84,21 @@ figure would wrongly lose its remote fill) for no measured benefit — the same
 reasoning `remoteDenialPhrases`'s comment already applies to `on-site only`/`must
 be onsite`.
 
-**When suppressed, continue scanning rather than returning early.** The existing
-loop structure (`for wm := range phrases { for p := range wm.phrases { if
-Contains... return wm.mode } } }`) already has this property implicitly: skipping
-a guarded match just means falling through to the next phrase check, so a
-description with both a qualified "work from anywhere" and an unrelated unqualified
-remote/hybrid/onsite phrase still resolves correctly from the other phrase. No
-special-case early-return logic is needed — the guard only changes what happens
-*at* the "work from anywhere" match, not the loop around it.
+**When suppressed, keep scanning for the SAME phrase before moving to the next
+one.** Falling through to the next phrase in `descriptionWorkModePhrases` handles a
+description with both a qualified "work from anywhere" and an unrelated,
+unqualified remote/hybrid/onsite phrase elsewhere — but it is not enough on its
+own: a description can also state "work from anywhere" TWICE, once qualified
+("up to 12 days work from anywhere per year") and once plainly ("you can work from
+anywhere in the EU"). A single `strings.Index` per phrase only ever sees the first
+occurrence, so a naive "skip and fall through to the next phrase" implementation
+would miss the second, unqualified occurrence of the *same* phrase entirely and
+return `""` where `"remote"` is correct. `phraseMatches` therefore re-scans forward
+past a suppressed match for more occurrences of the same phrase — the identical
+"scan past a qualified match" property `RemoteContradicted`'s loop already has for
+denial phrases (and the same one `TestRemoteContradictedReadsPastAQualifiedDenial`
+guards there). Caught in review (not in the original design) and closed with a
+matching test case before merge.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/fix-work-from-anywhere-perk-false-positive/proposal.md
+++ b/openspec/changes/fix-work-from-anywhere-perk-false-positive/proposal.md
@@ -1,0 +1,69 @@
+## Why
+
+`WorkModeFromDescription` (`internal/dict/location/workmode.go`) treats "work from
+anywhere" as an unconditional remote-work statement. In production it is also a
+common idiom for a bounded travel/PTO perk ("the freedom to work from anywhere in
+the world for up to a month", "work from anywhere for up to 12 weeks a year", "a
+Work from Anywhere policy allowing up to 20 remote days"). Because this detector is
+the lowest-priority source in the work-mode precedence chain
+(structured ATS → location marker → description phrase), the false match only
+lands when both higher-priority sources are silent — but when it lands, it fills
+`work_mode=remote` on a posting that is actually hybrid or onsite, with nothing
+downstream able to correct it (`RemoteContradicted` only overrules an explicit
+denial of remote, never a phrase-fill outcome). Reported as freehire#2696, with a
+live example (a San Francisco/New York hybrid posting whose only "remote" signal is
+a PTO line offering a month of location freedom).
+
+Confirmed against production data (read-only Meilisearch queries over the live
+`jobs` index, freehire#2696 investigation): of 143 open postings where "work from
+anywhere" co-occurs with the qualifier "for up to", 61 currently resolve to
+`work_mode=remote`; manual inspection of a sample found several genuine
+misclassifications (a Berlin-office posting offering "work from anywhere for up to
+12 weeks a year" resolving to `remote` on one source copy while an identical
+posting from the same employer correctly resolves to `hybrid` via its own
+structured signal; a UK posting with "in-office presence four days per week and a
+Work from Anywhere policy allowing up to 20 remote days" resolving to `remote`). The
+qualifying phrase appears on either side of the match in real postings, not only
+after it.
+
+## What Changes
+
+- `WorkModeFromDescription` no longer treats "work from anywhere" / "work-from-anywhere"
+  as a remote signal when a bounded-duration qualifier ("up to") appears near the
+  match (either before or after, within a measured window) — the same "usually
+  unambiguous but sometimes qualified" shape `RemoteContradicted`'s
+  `denialQualifiers` already handles for the denial side of this file, applied here
+  to the fill side.
+- When the qualifier suppresses the match and no other phrase in
+  `descriptionWorkModePhrases` matches, `WorkModeFromDescription` returns `""` (no
+  guess) rather than `"remote"` — consistent with the dictionary's existing
+  never-guess behavior elsewhere in this package.
+- No change to the other remote phrases (`100% remote`, `fully remote`,
+  `remote-first`, `remote role`, `remote position`, etc.) — measurement showed no
+  comparable ambiguity for them (see design.md).
+- No change to the hybrid phrase family, `RemoteContradicted`, or the
+  `jobderive` precedence chain.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `deterministic-facets`: the `work_mode` facet's description-derived tier gains a
+  qualifier guard on the "work from anywhere" phrase, narrowing when it may fill an
+  empty `work_mode`.
+
+## Impact
+
+- **Code:** `internal/dict/location/workmode.go` (single function,
+  `WorkModeFromDescription`), `internal/dict/location/workmode_test.go` (new
+  table-driven cases using real production sentences).
+- **No schema change, no migration, no new source files.**
+- **Data:** existing jobs already carrying the wrong `work_mode=remote` need
+  `cmd/backfill-derive` followed by a full `cmd/reindex` to reach Meilisearch — the
+  standard propagation path for any dictionary change to this facet (see
+  `internal/dict/location/AGENTS.md`). Not part of this code change; called out as a
+  deploy follow-up in design.md.

--- a/openspec/changes/fix-work-from-anywhere-perk-false-positive/specs/deterministic-facets/spec.md
+++ b/openspec/changes/fix-work-from-anywhere-perk-false-positive/specs/deterministic-facets/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: A bounded travel/PTO perk phrase does not fill the remote work mode
+
+The `work_mode` facet's description-derived tier (the lowest-priority source in the
+`countries`/`regions`/`work_mode`/`skills`/`seniority`/`category` precedence chain)
+SHALL NOT resolve `remote` from the phrase "work from anywhere" (or the hyphenated
+"work-from-anywhere") when a bounded-duration qualifier — the word pattern "up to" —
+appears near the match, on either side, within a measured window. Such a
+description is stating a bounded travel/PTO allowance (a benefit), not the
+posting's own work arrangement, and treating it as an unconditional remote
+statement produces a wrong facet on a hybrid or onsite posting that has no
+higher-priority signal to override it. The guard SHALL NOT apply to the other
+description-derived remote phrases (`fully remote`, `100% remote`, `remote-first`,
+`remote position`, `remote role`, `remote job`, `remote opportunity`,
+`remote vacancy`, "this position is remote", "role is remote", "position is
+remote") — none of those double as a common bounded-benefit idiom the way "work
+from anywhere" does, so guarding them would only cost coverage with no measured
+gain. When the guard suppresses the "work from anywhere" match and no other phrase
+in the description resolves a work mode, the facet stays empty (never guessed),
+consistent with this dictionary's existing behavior when no anchored arrangement
+phrase is present.
+
+#### Scenario: A bounded travel perk after the phrase does not resolve remote
+
+- **WHEN** a job's structured source and location marker both leave `work_mode`
+  empty, and its description reads "the freedom to work from anywhere in the world
+  for up to a month"
+- **THEN** the derived `work_mode` is empty, not `remote`
+
+#### Scenario: A bounded travel perk before the phrase does not resolve remote
+
+- **WHEN** a job's structured source and location marker both leave `work_mode`
+  empty, and its description reads "benefits include up to 12 days work from
+  anywhere"
+- **THEN** the derived `work_mode` is empty, not `remote`
+
+#### Scenario: An unqualified "work from anywhere" statement still resolves remote
+
+- **WHEN** a job's structured source and location marker both leave `work_mode`
+  empty, and its description reads "you can work from anywhere in the EU" with no
+  bounded-duration qualifier nearby
+- **THEN** the derived `work_mode` is `remote`
+
+#### Scenario: A qualified phrase does not block a genuinely remote description
+
+- **WHEN** a job's description contains both "work from anywhere ... for up to 12
+  weeks a year" and, elsewhere, an unqualified remote phrase such as "this is a
+  fully remote position"
+- **THEN** the derived `work_mode` is `remote`, from the unqualified phrase
+
+#### Scenario: The other remote phrases are unaffected by the guard
+
+- **WHEN** a job's structured source and location marker both leave `work_mode`
+  empty, and its description reads "This is a 100% remote role, with a bonus of up
+  to $5,000 for relocation"
+- **THEN** the derived `work_mode` is `remote` (the qualifier guard applies only to
+  "work from anywhere"/"work-from-anywhere", not to `100% remote`)

--- a/openspec/changes/fix-work-from-anywhere-perk-false-positive/tasks.md
+++ b/openspec/changes/fix-work-from-anywhere-perk-false-positive/tasks.md
@@ -1,0 +1,52 @@
+## 1. Failing tests first
+
+- [x] 1.1 In `internal/dict/location/workmode_test.go`, add cases to
+      `TestWorkModeFromDescription` for the qualifier guard: a qualifier after the
+      phrase ("the freedom to work from anywhere in the world for up to a month" →
+      `""`), a qualifier before the phrase ("benefits include up to 12 days work
+      from anywhere" → `""`), an unqualified phrase still resolving `remote` ("you
+      can work from anywhere in the EU" — already present, keep green), a qualified
+      "work from anywhere" alongside an unrelated unqualified remote phrase
+      elsewhere in the same description still resolving `remote`, and an unrelated
+      "up to" near `100% remote` still resolving `remote` (the guard must not widen
+      past the two scoped phrases). Use the real production sentence shapes from
+      proposal.md/design.md, not invented ones, matching this file's existing
+      convention (see `TestRemoteContradicted`'s comment on using real sentences).
+- [x] 1.2 Run `go test ./internal/dict/location/...` and confirm the new cases fail
+      (red) against the current implementation, for the right reason (phrase
+      guard not yet implemented) — not a typo in the test itself.
+
+## 2. Implementation
+
+- [x] 2.1 In `internal/dict/location/workmode.go`, add the qualifier marker and
+      window for the "work from anywhere" guard (a small var/const beside
+      `remoteDenialPhrases`/`denialQualifierWindow`, documented per design.md's
+      Decisions — bidirectional window, "up to" as the sole marker, scoped to
+      exactly the two phrases).
+- [x] 2.2 Wire the guard into `WorkModeFromDescription`'s match loop: when the
+      matched phrase is "work from anywhere" or "work-from-anywhere" and the
+      qualifier appears within the window on either side of the match, skip this
+      match (continue to the next phrase) instead of returning `"remote"`.
+- [x] 2.3 Run `go test ./internal/dict/location/...` and confirm all cases pass
+      (green), including the pre-existing ones (no regression).
+
+## 3. Verification
+
+- [x] 3.1 `gofmt -l internal/dict/location/` prints nothing.
+- [x] 3.2 `go vet ./...` and `go build ./...` are clean.
+- [x] 3.3 `go test ./...` is green (full unit suite — this package has no
+      integration-tagged tests, but confirm no other package's tests reference
+      `WorkModeFromDescription` in a way this change breaks — `jobderive_test.go`
+      was identified as a caller-side consumer during triage; confirm it still
+      passes unchanged).
+- [x] 3.4 Re-run the design.md scenarios manually against `WorkModeFromDescription`
+      (or as part of 1.1's table) to confirm every scenario in
+      `specs/deterministic-facets/spec.md`'s new requirement is covered by a test
+      case.
+
+## 4. Close-out
+
+- [ ] 4.1 Note in the PR description that reaching already-ingested jobs needs
+      `cmd/backfill-derive` followed by a full `cmd/reindex` (ops follow-up, not
+      part of this PR — per design.md's Migration Plan).
+- [ ] 4.2 Reference freehire#2696 in the PR/commit.

--- a/openspec/changes/fix-work-from-anywhere-perk-false-positive/tasks.md
+++ b/openspec/changes/fix-work-from-anywhere-perk-false-positive/tasks.md
@@ -44,9 +44,22 @@
       `specs/deterministic-facets/spec.md`'s new requirement is covered by a test
       case.
 
-## 4. Close-out
+## 4. Review fix
 
-- [ ] 4.1 Note in the PR description that reaching already-ingested jobs needs
+- [x] 4.1 Independent review (`requesting-code-review`) found an Important gap: a
+      description stating "work from anywhere" TWICE — once qualified, once plainly
+      — resolved to `""` instead of `"remote"`, because the guard skipped the first
+      (guarded) occurrence but the loop then moved to the next PHRASE rather than
+      re-scanning for another occurrence of the SAME phrase. Added a failing test
+      (`scan continues past a qualified repeat to an unqualified one`, verified red
+      against the pre-fix code), then closed the gap by re-scanning forward past a
+      suppressed match — mirroring `RemoteContradicted`'s own "scan past a qualified
+      match" loop — instead of documenting it as an accepted limitation. Verified
+      green; full `go build`/`go vet`/`go test ./...` re-run clean afterward.
+
+## 5. Close-out
+
+- [x] 5.1 Note in the PR description that reaching already-ingested jobs needs
       `cmd/backfill-derive` followed by a full `cmd/reindex` (ops follow-up, not
       part of this PR — per design.md's Migration Plan).
-- [ ] 4.2 Reference freehire#2696 in the PR/commit.
+- [x] 5.2 Reference freehire#2696 in the PR/commit.


### PR DESCRIPTION
Closes #2696.

## What the report turned out to be

`WorkModeFromDescription` (`internal/dict/location/workmode.go`) treated "work from anywhere" as an unconditional remote-work statement. In production it is also a common idiom for a bounded travel/PTO allowance ("the freedom to work from anywhere in the world for up to a month"). Since this detector is the lowest-priority work-mode source (structured ATS → location marker → description phrase), the false match only lands when both higher-priority sources are silent — but when it does, it fills `work_mode=remote` on a hybrid/onsite posting with nothing downstream able to correct it (`RemoteContradicted` only overrules an explicit denial of remote, never a phrase-fill outcome).

Confirmed against production data (read-only Meilisearch queries over the live `jobs` index): of 143 open postings where "work from anywhere" co-occurs with the qualifier "for up to", 61 currently resolve to `work_mode=remote`. Manual inspection found real, recurring misclassifications — e.g. a Berlin-office posting offering "work from anywhere for up to 12 weeks a year" resolving to `remote` on one source copy while an identical posting from the same employer correctly resolves to `hybrid` via its own structured signal; a UK posting with "in-office presence four days per week and a Work from Anywhere policy allowing up to 20 remote days" resolving to `remote`. The qualifying phrase appears on either side of the match in real postings, not only after it.

## What changed

`WorkModeFromDescription` no longer treats "work from anywhere" / "work-from-anywhere" as a remote signal when a bounded-duration qualifier ("up to") appears near the match, on either side, within a 60-character window — reusing the existing `denialQualifierWindow` this file already ships for the opposite-direction problem (`RemoteContradicted`'s `denialQualifiers`). When the guard suppresses the match, the scan re-scans forward for a later, unqualified occurrence of the *same* phrase before falling through to the next phrase — mirroring `RemoteContradicted`'s own "scan past a qualified match" loop (caught in independent review; see commit history on this branch). If nothing else matches, `work_mode` stays empty rather than guessed, consistent with this package's dictionary doctrine.

No change to the other remote phrases (`100% remote`, `fully remote`, `remote-first`, `remote role`, `remote position`, etc.) — measurement showed no comparable ambiguity for them (checked their co-occurrence with "for up to" in production; none of them double as a bounded-benefit idiom the way "work from anywhere" does). No change to `jobderive`'s precedence chain or to `RemoteContradicted`.

Full root-cause investigation, production measurements, and design rationale are in `openspec/changes/fix-work-from-anywhere-perk-false-positive/` on this branch (proposal.md, design.md, specs/deterministic-facets/spec.md, tasks.md).

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l .` — clean.
- `go test ./...` — green, no regressions.
- New table-driven cases in `internal/dict/location/workmode_test.go` using real production sentence shapes, covering: qualifier after the phrase, qualifier before the phrase, a qualified occurrence not blocking an unrelated unqualified remote phrase elsewhere, an unrelated "up to" near `100% remote` left unaffected, and (added after independent review) a qualified occurrence not blocking a later unqualified occurrence of the *same* phrase.
- Independent code review requested and acted on before this PR (see the second commit).

## Deploy

No schema change. Reaching already-ingested jobs with the wrong `work_mode=remote` needs `cmd/backfill-derive` followed by a full `cmd/reindex` — the standard propagation path for a dictionary change to this facet (see `internal/dict/location/AGENTS.md`). Not part of this PR; an ops follow-up after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved work-mode detection to avoid classifying travel or paid-time-off benefits as remote work when “work from anywhere” is limited by an “up to” qualifier.
  * Continued checking descriptions for other valid remote-work indicators after ignoring a qualified phrase.
* **Tests**
  * Added coverage for qualified phrases, unrelated qualifiers, and later unqualified remote-work indicators.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->