### PR TITLE
Let a refused ADP listing reach the proxy

### DIFF
--- a/internal/ingest/sources/proxy.go
+++ b/internal/ingest/sources/proxy.go
@@ -106,6 +106,20 @@ var refusalRetryProviders = map[string]func(HTTPClient) Source{
 	"teamtailor": func(c HTTPClient) Source {
 		return NewTeamtailor(pacedHTMLGetter(c, teamtailorRequestInterval, teamtailorRequestBurst))
 	},
+	// ADP is the same shape as teamtailor, measured on prod 2026-09-09 after the catalogue grew
+	// from 2,798 boards to 7,890: one run logged 3,028 boards refused on their listing call, and
+	// board_health carried a consecutive failure for 1,962 of them. Asked in isolation minutes
+	// later the direct IP served two of three sampled boards 200 and refused the third, while the
+	// proxy served all three — the signature of our own burst rather than an address the platform
+	// has blocked. Pacing already holds the rate; what it cannot do is shorten a run that is now
+	// three times as long, so the same rate spends three times the window.
+	//
+	// Both ADP products are listed. They are separate platforms with separate limiters (see
+	// pacedADPMyJobsGetter), and neither can recover a refusal without this.
+	"adp": func(c HTTPClient) Source { return NewADP(pacedADPGetter(c)) },
+	"adpmyjobs": func(c HTTPClient) Source {
+		return NewADPMyJobs(pacedADPMyJobsGetter(c))
+	},
 }
 
 // ApplyProxyEgress rewires the proxiedProviders in registry to egress through the proxy

--- a/internal/ingest/sources/proxyretry_wiring_test.go
+++ b/internal/ingest/sources/proxyretry_wiring_test.go
@@ -59,3 +59,24 @@ func TestApplyProxyEgressWithoutProxyLeavesRefusalRetryProvidersAlone(t *testing
 		t.Error("workable was rewired with no proxy configured")
 	}
 }
+
+// Both ADP products must be rewired, and each must keep the pacer it was built with: the proxy
+// recovers a request the platform refused, the pacer is what stops the run producing them, and
+// an entry that dropped the pacer would trade a recoverable problem for a worse one.
+func TestApplyProxyEgressRewiresBothADPProducts(t *testing.T) {
+	t.Setenv("SOURCES_PROXY_URL", "http://user:pass@proxy.example:8080")
+	registry := All(NewClient())
+	before := map[string]Source{"adp": registry["adp"], "adpmyjobs": registry["adpmyjobs"]}
+
+	if err := ApplyProxyEgress(registry); err != nil {
+		t.Fatalf("ApplyProxyEgress: %v", err)
+	}
+	for _, name := range []string{"adp", "adpmyjobs"} {
+		if registry[name] == before[name] {
+			t.Errorf("%s was not rewired; a refused listing stays final", name)
+		}
+		if got := registry[name].Provider(); got != name {
+			t.Errorf("rewired provider = %q, want %s", got, name)
+		}
+	}
+}


### PR DESCRIPTION
## The symptom

5 092 ADP boards were added to the catalogue yesterday. Most are still `pending` — their postings have never reached the site.

## The measurement

One `freehire-ingest@adp` run on prod today:

```
3 028 boards refused on their listing call (HTTP 429)
1 962 boards carrying a consecutive failure in board_health
```

Asked **in isolation** minutes after that run, from the same host:

| board | direct IP | via proxy |
|---|---|---|
| `c10f69b1…` | **200** | 200 |
| `c11d41c0…` | **200** | 200 |
| `c1b84150…` | 429 | **200** |

The direct IP serves these boards fine when it is not competing with our own crawl. That is the signature `refusalRetryProviders` exists for, and it is the same one `teamtailor` and `workable` are already listed under — an address the platform had actually blocked would refuse in isolation too.

## Why not just lower the pace

The rate was already tuned against ADP's window and it has not changed. What changed is the **length** of the run: the catalogue went from 2 798 boards to 7 890, so the same rate now spends three times the budget per window.

Pacing bounds how fast we ask. It cannot bound how long we go on asking. Lowering it further would cut refusals by making an already-11-hour pass even longer, which trades one form of "postings never arrive" for another.

The pacer stays — it still stops most refusals from being produced at all. This adds the recovery for the ones that are.

## The change

Two entries in `refusalRetryProviders`. Both ADP products are listed: they are separate platforms on separate hosts with separate limiters (`pacedADPGetter` / `pacedADPMyJobsGetter`), and neither could recover a refusal without this.

Each entry keeps the pacer it was built with — dropping it would trade a recoverable problem for a worse one.

## Tests

One added, asserting both products are rewired by `ApplyProxyEgress` and keep their provider key. Mutation-checked: removing either entry fails it. The existing guards still hold — the two allowlists stay disjoint, and every listed name is a real provider.

## Scope

No behaviour change without `SOURCES_PROXY_URL`. Only a request the platform already refused ever reaches the proxy, so the shared exit address takes the failures rather than the traffic.
