### PR TITLE
Stop refusing every Lever posting for a captcha most of them do not have

### DIFF
--- a/internal/api/atsapply/client.go
+++ b/internal/api/atsapply/client.go
@@ -26,13 +26,22 @@ import (
 // would file this spend under its own two-part label instead of alongside the others.
 const tagAutoApplyDrafting = "auto-apply-drafting"
 
-// requiresCaptcha marks providers whose form always renders a captcha, so a blind fill
-// attempt would either fail or (worse) look like it might work and then silently not
-// submit. Lever renders one on every posting — see design.md's Risks. Every attempt for
-// one of these parks before a browser is even launched.
-var requiresCaptcha = map[string]bool{
-	"lever": true,
-}
+// There is no per-provider captcha list any more, and reintroducing one would be a
+// mistake worth naming here.
+//
+// This file used to carry `requiresCaptcha{"lever": true}`, on the design's stated risk
+// that Lever "renders one on every posting". Measured against live postings on 2026-09-09,
+// that is not so: two queued Lever applications (coderio, jobgether) render NO captcha of
+// any kind, four others carry hCaptcha, and on all of them the only "recaptcha" in the page
+// is the string `.g-recaptcha div` inside a CSS rule. A captcha is a per-employer setting
+// on this platform, not a property of it — so the list decided what a page said before
+// anyone looked at the page, and it refused four postings in five for a reason that was
+// never measured.
+//
+// What replaces it is reading the page: browser.go's hasRecaptchaMarker distinguishes a
+// rendered challenge from an invisible score-based one, on the page actually being applied
+// to. That is the same lesson in the same file's history — the marker itself used to fire
+// on the mere WORD "recaptcha" and parked every Greenhouse posting there is.
 
 // fillProviders is the single source of truth for which providers Submit can actually
 // fill/submit for — today, Greenhouse alone (see fillAndSubmit/browser.go). Checked both
@@ -157,10 +166,6 @@ var _ autoapply.SidecarClient = (*Client)(nil)
 // cannot safely drive at all (a captcha board), always parks rather than risking a bad or
 // duplicate submission.
 func (c *Client) Submit(ctx context.Context, claimed autoapply.Claimed, answers map[string]string) (autoapply.SidecarResult, error) {
-	if requiresCaptcha[claimed.Provider] {
-		return autoapply.SidecarResult{Status: autoapply.StatusParked, Reason: "requires_captcha"}, nil
-	}
-
 	apiForm, err := c.fetchSchema(ctx, claimed)
 	if err != nil {
 		if errors.Is(err, errNoSchemaFetcher) {

--- a/internal/api/atsapply/client_test.go
+++ b/internal/api/atsapply/client_test.go
@@ -13,15 +13,18 @@ import (
 // Lever always parks on its captcha before any fetcher or browser is touched — a nil
 // fetchers map would panic if this short-circuit were ever removed, which is deliberate:
 // it proves nothing downstream runs for this provider.
-func TestSubmit_LeverAlwaysParksOnCaptchaWithoutTouchingFetchersOrBrowser(t *testing.T) {
+// Lever parks for the reason that is TRUE of it — no fill path exists for the provider —
+// rather than for a captcha that a live measurement found on only some of its postings
+// (see TestPreviewClient_ALeverAttemptReachesItsSchema for what was measured).
+func TestSubmit_LeverParksAsNotImplementedRatherThanOnACaptcha(t *testing.T) {
 	c := &Client{fetchers: nil}
 
 	result, err := c.Submit(context.Background(), autoapply.Claimed{Provider: "lever"}, nil)
 	if err != nil {
 		t.Fatalf("Submit: %v", err)
 	}
-	if result.Status != autoapply.StatusParked || result.Reason != "requires_captcha" {
-		t.Errorf("result = %+v, want parked/requires_captcha", result)
+	if result.Status != autoapply.StatusParked || result.Reason != reasonSubmissionNotImplemented {
+		t.Errorf("result = %+v, want parked/%s", result, reasonSubmissionNotImplemented)
 	}
 }
 

--- a/internal/api/atsapply/preview_client.go
+++ b/internal/api/atsapply/preview_client.go
@@ -54,12 +54,6 @@ func NewPreviewClient(transport applyform.Transport, forms StoredFormReader) *Pr
 // Preview resolves what an unattended submission of claimed would currently send, without
 // submitting anything. Satisfies autoapply.PreviewSidecar.
 func (p *PreviewClient) Preview(ctx context.Context, claimed autoapply.Claimed, answers map[string]string) (autoapply.PreviewResult, error) {
-	if requiresCaptcha[claimed.Provider] {
-		// Submit will always park this provider before touching a browser or a fetcher;
-		// there is nothing to preview and nothing here should pretend otherwise.
-		return autoapply.PreviewResult{Parked: true, Reason: "requires_captcha"}, nil
-	}
-
 	// Mirrors Client.resolve's own hasApprovedCV derivation: the one fact that lets the
 	// résumé field resolve at all. ClaimAutoApplyPreviewBatch's own WHERE guarantees this
 	// is never the zero value here (tailored_cv_id IS NOT NULL), the same guarantee

--- a/internal/api/atsapply/preview_test.go
+++ b/internal/api/atsapply/preview_test.go
@@ -104,20 +104,32 @@ func (r *fakeFormReader) GetStoredForm(context.Context, int64) (applyform.Form, 
 	return r.form, r.found, r.err
 }
 
-func TestPreviewClient_ALeverAttemptParksWithoutTouchingAFetcherOrFormReader(t *testing.T) {
-	fetcher := &fakeFetcher{}
-	reader := &fakeFormReader{}
-	p := &PreviewClient{fetchers: map[string]applyform.Fetcher{"lever": fetcher}, forms: reader}
+// A Lever attempt reaches its schema like any other provider — it is not refused for
+// carrying a captcha it may well not have.
+//
+// Measured against live postings on 2026-09-09, which is what retired the blanket refusal:
+// two of the candidate's own queued Lever applications (coderio, jobgether) render NO
+// captcha at all — no hCaptcha, no reCAPTCHA, nothing. Four others do carry hCaptcha, and
+// their only "recaptcha" is the string `.g-recaptcha div` inside a CSS rule. So the
+// captcha is a per-employer setting, not a property of the platform, and a provider-wide
+// refusal decided what a page said before anyone looked at the page.
+//
+// Nothing here claims a Lever application can now be submitted: fillProviders still covers
+// Greenhouse alone, so Submit parks it as not-implemented. What changes is that the
+// candidate gets an answer preview instead of a reason that was never measured.
+func TestPreviewClient_ALeverAttemptReachesItsSchema(t *testing.T) {
+	fetcher := &fakeFetcher{form: applyform.Form{Provider: "lever"}}
+	p := &PreviewClient{fetchers: map[string]applyform.Fetcher{"lever": fetcher}, forms: nil}
 
 	result, err := p.Preview(context.Background(), autoapply.Claimed{Provider: "lever"}, nil)
 	if err != nil {
 		t.Fatalf("Preview: %v", err)
 	}
-	if !result.Parked || result.Reason != "requires_captcha" {
-		t.Errorf("result = %+v, want parked/requires_captcha", result)
+	if result.Parked {
+		t.Errorf("result = %+v, want a preview rather than a park", result)
 	}
-	if fetcher.called {
-		t.Errorf("fetcher was called, want no schema fetch for a provider that always parks")
+	if !fetcher.called {
+		t.Error("the schema fetcher was never called — Lever is still being refused before it is read")
 	}
 }
 

--- a/internal/api/atsapply/resolve.go
+++ b/internal/api/atsapply/resolve.go
@@ -47,9 +47,13 @@ func (p Plan) FullyResolved() bool {
 // source (a dedicated country fact, or Tier C/LLM-drafted answers) is future work, not a bug
 // here — see design.md's Non-Goals.
 var answerKeyFor = map[string]string{
-	"first_name":              "first_name",
-	"last_name":               "last_name",
-	"full_name":               "full_name",
+	"first_name": "first_name",
+	"last_name":  "last_name",
+	"full_name":  "full_name",
+	// Recruitee's own control name for the same field. Measured on production 2026-09-09:
+	// a queued Recruitee application parked on `{"id": "name", "label": "Full name"}` for
+	// a candidate whose full name the profile had all along.
+	"name":                    "full_name",
 	"email":                   "email",
 	"phone":                   "phone",
 	"location":                "location",

--- a/internal/api/atsapply/resolve_test.go
+++ b/internal/api/atsapply/resolve_test.go
@@ -504,3 +504,24 @@ func TestPreviewAndResolveAgreeOnALabellessField(t *testing.T) {
 		t.Errorf("value = %q, want the banked answer", plan.Fields[0].Value)
 	}
 }
+
+// Recruitee calls the full-name control `name`, and the candidate's own full name went
+// unused because answerKeyFor only knew `full_name`.
+//
+// Measured on production 2026-09-09: queue entry 11 parked on eight required questions,
+// and the first was `{"id": "name", "label": "Full name", "reason": "no known answer
+// source for \"name\""}` — for a candidate whose full name the profile has always held.
+// A platform's own control name, missing from a map of platform control names.
+func TestResolve_MatchesRecruiteesFullNameControl(t *testing.T) {
+	answers := map[string]string{"full_name": "Ada Lovelace"}
+	fields := []MergedField{{ID: "name", Label: "Full name", Kind: "text", Required: true}}
+
+	plan := Resolve(fields, answers, false)
+
+	if len(plan.Unmapped) != 0 {
+		t.Fatalf("unmapped = %+v, want the full-name field answered", plan.Unmapped)
+	}
+	if len(plan.Fields) != 1 || plan.Fields[0].Value != "Ada Lovelace" {
+		t.Fatalf("plan.Fields = %+v, want the stored full name", plan.Fields)
+	}
+}


### PR DESCRIPTION
auto-apply parked **every** Lever application before touching a fetcher or a browser, on a per-provider list carrying one entry. The design's stated risk was that Lever "renders one on every posting."

## What a live measurement found (2026-09-09)

| Posting | Captcha |
|---|---|
| coderio, jobgether | **none of any kind** |
| brightbee, tsmg, epoch-ai, strategicgears | hCaptcha, loaded as an invisible one |

On all six, the only `recaptcha` in the page is the string `.g-recaptcha div` **inside a CSS rule**.

A captcha is a per-employer setting on this platform, not a property of it. The list decided what a page said before anyone looked at the page — and the two postings carrying no challenge at all are the candidate's own queued applications.

## Why the list goes rather than gaining an exception

What replaces it is reading the page. `browser.go`'s `hasRecaptchaMarker` already distinguishes a rendered challenge from an invisible score-based one, on the page actually being applied to.

That is the same lesson from the same file's own history: two days ago that marker fired on the mere *word* `recaptcha` and parked every Greenhouse posting there is (#2684). A hand-maintained per-provider list is the same mistake one level up.

## What this does not claim

A Lever application still cannot be **submitted** — `fillProviders` covers Greenhouse alone, so `Submit` parks it as not-implemented, which is what is actually true of it.

What changes is that the candidate gets an **answer preview**. `applyform`'s `leverFetcher` has always been able to read the form; the blanket refusal ran before it.

## Also in here

`answerKeyFor` gains `name` → `full_name`.

Recruitee calls the full-name control `name`. Production queue entry 11 parked on `{"id": "name", "label": "Full name", "reason": "no known answer source for \"name\""}` — for a candidate whose full name the profile had all along. A platform's own control name, missing from a map of platform control names.

## Verification

Both changes are test-first, each test carrying the measurement that motivated it. `go test ./...`, `go vet -tags=integration ./...`, `gofmt`, `golangci-lint` — clean. No `requiresCaptcha` reference survives outside the comment recording why it is gone.