### PR TITLE
Add q_fields search scoping and document q's OR/AND semantics

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -250,7 +250,7 @@ Combine free-text `q` with any of the filter params below. Repeated facet params
 
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
-| `q` | string | no | Full-text query over `title`, `company`, `description`, and `location`. Unquoted words match as an OR of stemmed tokens; quoted (`"systems engineer"`) as an order-independent AND — quoting is not a contiguous-phrase match. Narrow which fields it matches with `q_fields`. (e.g. `golang`) |
+| `q` | string | no | Full-text query over `title`, `company`, `description`, and `location`. Unquoted words match as an OR of stemmed tokens; quoted (`"systems engineer"`) as an order-independent AND — quoting is not a contiguous-phrase match. Narrow which fields it matches with `q_fields`. Exact-phrase matching is not offered, and default relevance order does not reliably rank a contiguous match above a scattered-token one. (e.g. `golang`) |
 | `q_fields` | string | no | Comma-separated subset of `title,company,description,location` to restrict `q` to, e.g. `title`. A name outside that set drops the whole parameter (reported in `meta.ignored_params`) rather than partially applying. (e.g. `title`) |
 | `sort` | string | no | One of `created_at`, `posted_at`, `view_count`, `salary_min`, `salary_max`. Omit for relevance/newest. (e.g. `posted_at`) |
 | `order` | string | no | `asc` or `desc` (default `desc`). (e.g. `desc`) |
@@ -282,7 +282,7 @@ Same query and filters as `/jobs/search`, but each result carries the `descripti
 
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
-| `q` | string | no | Full-text query over `title`, `company`, `description`, and `location`. Unquoted words match as an OR of stemmed tokens; quoted (`"systems engineer"`) as an order-independent AND — quoting is not a contiguous-phrase match. Narrow which fields it matches with `q_fields`. (e.g. `golang`) |
+| `q` | string | no | Full-text query over `title`, `company`, `description`, and `location`. Unquoted words match as an OR of stemmed tokens; quoted (`"systems engineer"`) as an order-independent AND — quoting is not a contiguous-phrase match. Narrow which fields it matches with `q_fields`. Exact-phrase matching is not offered, and default relevance order does not reliably rank a contiguous match above a scattered-token one. (e.g. `golang`) |
 | `q_fields` | string | no | Comma-separated subset of `title,company,description,location` to restrict `q` to, e.g. `title`. A name outside that set drops the whole parameter (reported in `meta.ignored_params`) rather than partially applying. (e.g. `title`) |
 | `description_format` | string | no | One of `html` (default, verbatim), `text` (tags stripped), `markdown` (HTML converted to Markdown). Unknown values fall back to `html`. (e.g. `markdown`) |
 | `sort` | string | no | One of `created_at`, `posted_at`, `view_count`, `salary_min`, `salary_max`. Omit for relevance/newest. (e.g. `posted_at`) |

--- a/docs/API.md
+++ b/docs/API.md
@@ -250,7 +250,8 @@ Combine free-text `q` with any of the filter params below. Repeated facet params
 
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
-| `q` | string | no | Full-text query over title, company, and description. (e.g. `golang`) |
+| `q` | string | no | Full-text query over `title`, `company`, `description`, and `location`. Unquoted words match as an OR of stemmed tokens; quoted (`"systems engineer"`) as an order-independent AND — quoting is not a contiguous-phrase match. Narrow which fields it matches with `q_fields`. (e.g. `golang`) |
+| `q_fields` | string | no | Comma-separated subset of `title,company,description,location` to restrict `q` to, e.g. `title`. A name outside that set drops the whole parameter (reported in `meta.ignored_params`) rather than partially applying. (e.g. `title`) |
 | `sort` | string | no | One of `created_at`, `posted_at`, `view_count`, `salary_min`, `salary_max`. Omit for relevance/newest. (e.g. `posted_at`) |
 | `order` | string | no | `asc` or `desc` (default `desc`). (e.g. `desc`) |
 | `limit` | integer | no | Page size, 1–100. (e.g. `20`) |
@@ -281,7 +282,8 @@ Same query and filters as `/jobs/search`, but each result carries the `descripti
 
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
-| `q` | string | no | Full-text query over title, company, and description. (e.g. `golang`) |
+| `q` | string | no | Full-text query over `title`, `company`, `description`, and `location`. Unquoted words match as an OR of stemmed tokens; quoted (`"systems engineer"`) as an order-independent AND — quoting is not a contiguous-phrase match. Narrow which fields it matches with `q_fields`. (e.g. `golang`) |
+| `q_fields` | string | no | Comma-separated subset of `title,company,description,location` to restrict `q` to, e.g. `title`. A name outside that set drops the whole parameter (reported in `meta.ignored_params`) rather than partially applying. (e.g. `title`) |
 | `description_format` | string | no | One of `html` (default, verbatim), `text` (tags stripped), `markdown` (HTML converted to Markdown). Unknown values fall back to `html`. (e.g. `markdown`) |
 | `sort` | string | no | One of `created_at`, `posted_at`, `view_count`, `salary_min`, `salary_max`. Omit for relevance/newest. (e.g. `posted_at`) |
 | `order` | string | no | `asc` or `desc` (default `desc`). (e.g. `desc`) |

--- a/internal/api/handler/agent_search.go
+++ b/internal/api/handler/agent_search.go
@@ -44,7 +44,7 @@ func (h *searchHandlers) AgentSearchJobs(c *fiber.Ctx) error {
 		views[i] = hit.Job
 	}
 
-	ignored := search.SortAndCap(append(dropped, ignoredParams(c, agentSearchParams)...))
+	ignored := mergedJobSearchIgnored(c, agentSearchParams, dropped)
 	return listResponseWithIgnored(c, views, res.Total, limit, offset, ignored)
 }
 

--- a/internal/api/handler/agent_search_test.go
+++ b/internal/api/handler/agent_search_test.go
@@ -126,6 +126,19 @@ func TestAgentSearchJobs_FormatApplies(t *testing.T) {
 	}
 }
 
+func TestAgentSearchJobs_QFieldsRestrictsIdenticallyToThePublicEndpoint(t *testing.T) {
+	fake := &fakeSearcher{}
+	app := agentSearchApp(fake, &fakeDescriptions{})
+
+	status, _ := doGet(t, app, "/agent/jobs/search?q=systems&q_fields=title")
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if len(fake.got.QFields) != 1 || fake.got.QFields[0] != "title" {
+		t.Errorf("QFields = %v, want [title]", fake.got.QFields)
+	}
+}
+
 func TestAgentSearchJobs_ReportsIgnoredParamsButNotItsOwn(t *testing.T) {
 	fake := &fakeSearcher{}
 	app := agentSearchApp(fake, &fakeDescriptions{})

--- a/internal/api/handler/search.go
+++ b/internal/api/handler/search.go
@@ -115,6 +115,16 @@ func ignoredParams(c *fiber.Ctx, own []string) []search.UnknownParam {
 	return search.UnknownParams(queryValues(c), own)
 }
 
+// mergedJobSearchIgnored combines runJobSearch's own value-level ignored-param
+// report — q_fields naming a field outside the searchable vocabulary, and/or any
+// filter params the Meilisearch-rejection degrade dropped — with the ordinary
+// name-level ignoredParams(c, own) report, into one sorted, capped list. The same
+// merge both job-search endpoints need, named once so neither can apply it
+// slightly differently.
+func mergedJobSearchIgnored(c *fiber.Ctx, own []string, fromSearch []search.UnknownParam) []search.UnknownParam {
+	return search.SortAndCap(append(fromSearch, ignoredParams(c, own)...))
+}
+
 // searchSortable is the allowlist of sort params mapped to their index attribute;
 // anything else is ignored so a bad param cannot make Meilisearch reject the query.
 var searchSortable = map[string]string{
@@ -178,7 +188,7 @@ func (h *searchHandlers) SearchJobs(c *fiber.Ctx) error {
 	}
 	h.attachGhost(c, res.Hits, views)
 
-	ignored := search.SortAndCap(append(dropped, ignoredParams(c, jobSearchParams)...))
+	ignored := mergedJobSearchIgnored(c, jobSearchParams, dropped)
 	return listResponseWithIgnored(c, views, res.Total, limit, offset, ignored)
 }
 

--- a/internal/api/handler/search.go
+++ b/internal/api/handler/search.go
@@ -97,9 +97,14 @@ const maxSearchWindow = 10000
 // facetsParams in facets.go, companiesParams in companies.go).
 var searchParams = []string{"q", "sort", "order", "limit", "offset"}
 
-// agentSearchParams is searchParams plus the agent endpoint's response-format
-// selector.
-var agentSearchParams = slices.Concat(searchParams, []string{"description_format"})
+// jobSearchParams is searchParams plus q_fields, the field-scoping parameter
+// only the two job-search endpoints (not the swipe deck, which shares
+// searchParams but never reads q_fields) understand.
+var jobSearchParams = slices.Concat(searchParams, []string{"q_fields"})
+
+// agentSearchParams is jobSearchParams plus the agent endpoint's
+// response-format selector.
+var agentSearchParams = slices.Concat(jobSearchParams, []string{"description_format"})
 
 // ignoredParams reports the query params of this request that neither the filter
 // nor the endpoint itself reads. They are echoed in the response meta instead of
@@ -173,7 +178,7 @@ func (h *searchHandlers) SearchJobs(c *fiber.Ctx) error {
 	}
 	h.attachGhost(c, res.Hits, views)
 
-	ignored := search.SortAndCap(append(dropped, ignoredParams(c, searchParams)...))
+	ignored := search.SortAndCap(append(dropped, ignoredParams(c, jobSearchParams)...))
 	return listResponseWithIgnored(c, views, res.Total, limit, offset, ignored)
 }
 
@@ -182,8 +187,10 @@ func (h *searchHandlers) SearchJobs(c *fiber.Ctx) error {
 // the single place the query is built, so the public and agent search endpoints
 // cannot drift. The availability and deep-pagination guards return a fiber *Error
 // the caller can return directly; on success it returns the raw hits, the applied
-// limit/offset, and any filter params dropped by the degrade below (nil in the
-// ordinary case — see its own comment).
+// limit/offset, and every value-level ignored-param report gathered while building
+// the query — q_fields naming a field outside the searchable vocabulary, plus any
+// filter params dropped by the degrade below (nil in the ordinary case) — for the
+// caller to merge into its own ignoredParams(c, own) report.
 func (h *searchHandlers) runJobSearch(c *fiber.Ctx) (search.SearchResult, int, int, []search.UnknownParam, error) {
 	if h.search == nil {
 		return search.SearchResult{}, 0, 0, nil, fiber.NewError(fiber.StatusServiceUnavailable, "search is not available")
@@ -197,16 +204,18 @@ func (h *searchHandlers) runJobSearch(c *fiber.Ctx) (search.SearchResult, int, i
 	vector := h.matchVector(c)
 	sort := searchSort(c, vector != nil)
 	filter := buildSearchFilter(c)
+	qFields, qFieldsIgnored := search.QFieldsFromValues(queryValues(c))
 	res, err := h.search.Search(c.Context(), search.SearchParams{
-		Query:  c.Query("q"),
-		Filter: filter,
-		Sort:   sort,
-		Vector: vector,
-		Limit:  limit,
-		Offset: offset,
+		Query:   c.Query("q"),
+		Filter:  filter,
+		Sort:    sort,
+		Vector:  vector,
+		QFields: qFields,
+		Limit:   limit,
+		Offset:  offset,
 	})
 
-	var dropped []search.UnknownParam
+	dropped := qFieldsIgnored
 	if err != nil {
 		// Degrade, not fail, when the filter itself is why Meilisearch refused the
 		// query — the deploy window a filterable attribute is declared in code
@@ -222,14 +231,14 @@ func (h *searchHandlers) runJobSearch(c *fiber.Ctx) (search.SearchResult, int, i
 			return search.SearchResult{}, 0, 0, nil, err
 		}
 		res, err = h.search.Search(c.Context(), search.SearchParams{
-			Query: c.Query("q"), Sort: sort, Vector: vector, Limit: limit, Offset: offset,
+			Query: c.Query("q"), Sort: sort, Vector: vector, QFields: qFields, Limit: limit, Offset: offset,
 		})
 		if err != nil {
 			return search.SearchResult{}, 0, 0, nil, err
 		}
 		// Which single param Meilisearch minded is not knowable from its own
 		// error, so every active filter param is reported rather than a guess.
-		dropped = search.ActiveFilterParams(queryValues(c))
+		dropped = append(dropped, search.ActiveFilterParams(queryValues(c))...)
 	}
 
 	h.recordQuery(c.Query("q"))

--- a/internal/api/handler/search_test.go
+++ b/internal/api/handler/search_test.go
@@ -228,6 +228,57 @@ func TestSearchJobs_ReportsIgnoredParams(t *testing.T) {
 	}
 }
 
+func TestSearchJobs_QFieldsRestrictsSearchableAttributes(t *testing.T) {
+	fake := &fakeSearcher{}
+	app := searchApp(fake)
+
+	status, body := doGet(t, app, "/jobs/search?q=systems&q_fields=title")
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if len(fake.got.QFields) != 1 || fake.got.QFields[0] != "title" {
+		t.Errorf("QFields = %v, want [title]", fake.got.QFields)
+	}
+	// q_fields is a param this endpoint reads, so a valid value must not itself
+	// be reported as ignored.
+	meta, _ := body["meta"].(map[string]any)
+	if _, present := meta["ignored_params"]; present {
+		t.Errorf("meta.ignored_params = %v, want the key absent for a valid q_fields", meta["ignored_params"])
+	}
+}
+
+func TestSearchJobs_QFieldsAbsentLeavesAllFieldsSearchable(t *testing.T) {
+	fake := &fakeSearcher{}
+	app := searchApp(fake)
+
+	doGet(t, app, "/jobs/search?q=golang")
+	if fake.got.QFields != nil {
+		t.Errorf("QFields = %v, want nil when q_fields is absent", fake.got.QFields)
+	}
+}
+
+func TestSearchJobs_UnrecognizedQFieldsIsReportedAndAppliesNoRestriction(t *testing.T) {
+	fake := &fakeSearcher{}
+	app := searchApp(fake)
+
+	status, body := doGet(t, app, "/jobs/search?q=systems&q_fields=salary")
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if fake.got.QFields != nil {
+		t.Errorf("QFields = %v, want nil — an unrecognized value must not restrict", fake.got.QFields)
+	}
+	meta, _ := body["meta"].(map[string]any)
+	ignored, _ := meta["ignored_params"].([]any)
+	if len(ignored) != 1 {
+		t.Fatalf("meta.ignored_params = %v, want one entry", meta["ignored_params"])
+	}
+	first, _ := ignored[0].(map[string]any)
+	if first["param"] != "q_fields" {
+		t.Errorf("ignored_params[0] = %v, want q_fields", first)
+	}
+}
+
 func TestSearchJobs_CleanQueryReportsNothingIgnored(t *testing.T) {
 	fake := &fakeSearcher{}
 	app := searchApp(fake)

--- a/internal/api/handler/swipe_test.go
+++ b/internal/api/handler/swipe_test.go
@@ -147,6 +147,32 @@ func TestSwipeDeck_ReportsIgnoredParams(t *testing.T) {
 	}
 }
 
+// q_fields is deliberately NOT part of the deck's vocabulary — SwipeDeck builds
+// its own SearchParams and never reads it — so unlike /jobs/search and
+// /agent/jobs/search it must keep reporting the param as unknown rather than
+// silently accepting a restriction it never applies.
+func TestSwipeDeck_QFieldsIsNotUnderstoodAndIsReported(t *testing.T) {
+	fake := &fakeSearcher{}
+	app, iss := deckApp(fake, nil)
+
+	status, body := deckGet(t, app, iss, "/api/v1/me/tracking/swipe?q=systems&q_fields=title")
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if fake.got.QFields != nil {
+		t.Errorf("QFields = %v, want nil — the deck never applies this restriction", fake.got.QFields)
+	}
+	meta, _ := body["meta"].(map[string]any)
+	ignored, _ := meta["ignored_params"].([]any)
+	if len(ignored) != 1 {
+		t.Fatalf("meta.ignored_params = %v, want one entry", meta["ignored_params"])
+	}
+	first, _ := ignored[0].(map[string]any)
+	if first["param"] != "q_fields" {
+		t.Errorf("ignored_params[0] = %v, want q_fields", first)
+	}
+}
+
 // The deck's own transport params are not filters and must not be accused of anything —
 // a warning on every well-formed request is a warning nobody reads.
 func TestSwipeDeck_CleanQueryReportsNothingIgnored(t *testing.T) {

--- a/internal/search/search/client.go
+++ b/internal/search/search/client.go
@@ -472,6 +472,9 @@ type SearchParams struct {
 	// over vector ranking in Meilisearch, so sending both silently discards the match
 	// order rather than erroring.
 	Vector []float32
+	// QFields restricts Query matching to these searchable attributes (see
+	// QFieldsFromValues). Nil means Meilisearch's default: all of them.
+	QFields []string
 }
 
 // SearchResult holds the matched documents and Meilisearch's estimated total.
@@ -522,10 +525,11 @@ func queryErr(ctx context.Context, op string, err error) error {
 // Vector sent without an embedder name is a 400, so the two must never drift apart.
 func buildSearchRequest(p SearchParams) *meilisearch.SearchRequest {
 	req := &meilisearch.SearchRequest{
-		Filter: p.Filter,
-		Sort:   p.Sort,
-		Limit:  int64(p.Limit),
-		Offset: int64(p.Offset),
+		Filter:               p.Filter,
+		Sort:                 p.Sort,
+		Limit:                int64(p.Limit),
+		Offset:               int64(p.Offset),
+		AttributesToSearchOn: p.QFields,
 	}
 	if len(p.Vector) > 0 {
 		req.Vector = p.Vector

--- a/internal/search/search/query_params.go
+++ b/internal/search/search/query_params.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"net/url"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -19,6 +20,45 @@ var scalarFilters = []string{
 	"experience_years_max",
 	"posted_within_days",
 	"open_within_days",
+}
+
+// qSearchableFields are the fields `q` matches against, in the same order as the
+// jobs index's SearchableAttributes (see facetSettings in client.go). q_fields
+// restricts `q` to a subset of this vocabulary.
+var qSearchableFields = []string{"title", "company", "description", "location"}
+
+// QFieldsFromValues resolves the q_fields query param into the
+// AttributesToSearchOn list buildSearchRequest should pass to Meilisearch. The
+// returned fields are always in qSearchableFields' canonical order regardless
+// of how the caller wrote them, because Meilisearch's ranking is sensitive to
+// attribute order and a caller-controlled order would make identical
+// restrictions rank differently for no predictable reason.
+//
+// When q_fields is absent, both return values are nil (no restriction, nothing
+// to report). When it names a field outside qSearchableFields, the ENTIRE value
+// is treated as invalid — even the names that were valid are dropped — and
+// reported via the same UnknownParam shape UnknownParams uses. Partial
+// application would silently narrow a caller's search past what a typo made
+// them ask for, with no signal beyond the report; whole-value drop keeps the
+// failure in the same class as an unrecognized facet: coarse, but honest.
+func QFieldsFromValues(v url.Values) (fields []string, ignored []UnknownParam) {
+	raw := v.Get("q_fields")
+	if raw == "" {
+		return nil, nil
+	}
+	requested := make(map[string]bool)
+	for _, name := range strings.Split(raw, ",") {
+		if !slices.Contains(qSearchableFields, name) {
+			return nil, []UnknownParam{{Param: "q_fields"}}
+		}
+		requested[name] = true
+	}
+	for _, field := range qSearchableFields {
+		if requested[field] {
+			fields = append(fields, field)
+		}
+	}
+	return fields, nil
 }
 
 // maxUnknownParamsReported bounds how many ignored params one response echoes.

--- a/internal/search/search/query_params.go
+++ b/internal/search/search/query_params.go
@@ -34,13 +34,16 @@ var qSearchableFields = []string{"title", "company", "description", "location"}
 // attribute order and a caller-controlled order would make identical
 // restrictions rank differently for no predictable reason.
 //
-// When q_fields is absent, both return values are nil (no restriction, nothing
-// to report). When it names a field outside qSearchableFields, the ENTIRE value
-// is treated as invalid — even the names that were valid are dropped — and
-// reported via the same UnknownParam shape UnknownParams uses. Partial
-// application would silently narrow a caller's search past what a typo made
-// them ask for, with no signal beyond the report; whole-value drop keeps the
-// failure in the same class as an unrecognized facet: coarse, but honest.
+// When q_fields is absent (or empty after dropping stray comma fragments —
+// the same tolerance splitFacetValues gives every facet, so `q_fields=` and
+// `q_fields=title,` behave like a bare `?skills=`), both return values are
+// nil: no restriction, nothing to report. When it names a field outside
+// qSearchableFields, the ENTIRE value is treated as invalid — even the names
+// that were valid are dropped — and reported via the same UnknownParam shape
+// UnknownParams uses. Partial application would silently narrow a caller's
+// search past what a typo made them ask for, with no signal beyond the
+// report; whole-value drop keeps the failure in the same class as an
+// unrecognized facet: coarse, but honest.
 func QFieldsFromValues(v url.Values) (fields []string, ignored []UnknownParam) {
 	raw := v.Get("q_fields")
 	if raw == "" {
@@ -48,6 +51,9 @@ func QFieldsFromValues(v url.Values) (fields []string, ignored []UnknownParam) {
 	}
 	requested := make(map[string]bool)
 	for _, name := range strings.Split(raw, ",") {
+		if name == "" {
+			continue
+		}
 		if !slices.Contains(qSearchableFields, name) {
 			return nil, []UnknownParam{{Param: "q_fields"}}
 		}

--- a/internal/search/search/query_params.go
+++ b/internal/search/search/query_params.go
@@ -34,10 +34,14 @@ var qSearchableFields = []string{"title", "company", "description", "location"}
 // attribute order and a caller-controlled order would make identical
 // restrictions rank differently for no predictable reason.
 //
-// When q_fields is absent (or empty after dropping stray comma fragments —
-// the same tolerance splitFacetValues gives every facet, so `q_fields=` and
-// `q_fields=title,` behave like a bare `?skills=`), both return values are
-// nil: no restriction, nothing to report. When it names a field outside
+// q_fields reads through splitFacetValues, the same as every other facet: a
+// repeated key (`q_fields=title&q_fields=company`) and a comma-joined value
+// (`q_fields=title,company`) resolve to the same set, and a stray comma
+// fragment (`q_fields=title,` or a bare `?q_fields=`) is dropped rather than
+// treated as a named field.
+//
+// When q_fields is absent or empty after that, both return values are nil: no
+// restriction, nothing to report. When it names a field outside
 // qSearchableFields, the ENTIRE value is treated as invalid — even the names
 // that were valid are dropped — and reported via the same UnknownParam shape
 // UnknownParams uses. Partial application would silently narrow a caller's
@@ -45,19 +49,15 @@ var qSearchableFields = []string{"title", "company", "description", "location"}
 // report; whole-value drop keeps the failure in the same class as an
 // unrecognized facet: coarse, but honest.
 func QFieldsFromValues(v url.Values) (fields []string, ignored []UnknownParam) {
-	raw := v.Get("q_fields")
-	if raw == "" {
-		return nil, nil
-	}
 	requested := make(map[string]bool)
-	for _, name := range strings.Split(raw, ",") {
-		if name == "" {
-			continue
-		}
+	for _, name := range splitFacetValues(v["q_fields"]) {
 		if !slices.Contains(qSearchableFields, name) {
 			return nil, []UnknownParam{{Param: "q_fields"}}
 		}
 		requested[name] = true
+	}
+	if len(requested) == 0 {
+		return nil, nil
 	}
 	for _, field := range qSearchableFields {
 		if requested[field] {

--- a/internal/search/search/query_params_test.go
+++ b/internal/search/search/query_params_test.go
@@ -218,10 +218,33 @@ func TestQFieldsFromValues_MultipleFieldsComeBackInCanonicalOrder(t *testing.T) 
 	}
 }
 
+func TestQFieldsFromValues_RepeatedKeyIsTheSameAsCommaJoined(t *testing.T) {
+	// Every other facet resolves a repeated key the same as a comma-joined value
+	// (splitFacetValues); q_fields must not be a silent exception that keeps only
+	// the first occurrence.
+	fields, ignored := QFieldsFromValues(url.Values{"q_fields": {"company", "title"}})
+	if !slices.Equal(fields, []string{"title", "company"}) {
+		t.Errorf("fields = %v, want [title company] from a repeated key", fields)
+	}
+	if ignored != nil {
+		t.Errorf("ignored = %v, want nil", ignored)
+	}
+}
+
 func TestQFieldsFromValues_UnrecognizedFieldIsReportedAndAppliesNoRestriction(t *testing.T) {
 	fields, ignored := QFieldsFromValues(url.Values{"q_fields": {"salary"}})
 	if fields != nil {
 		t.Errorf("fields = %v, want nil — an unrecognized value must not restrict", fields)
+	}
+	if len(ignored) != 1 || ignored[0].Param != "q_fields" {
+		t.Errorf("ignored = %v, want one entry naming q_fields", ignored)
+	}
+}
+
+func TestQFieldsFromValues_OneBadValueInARepeatedKeyInvalidatesTheWholeValue(t *testing.T) {
+	fields, ignored := QFieldsFromValues(url.Values{"q_fields": {"title", "salary"}})
+	if fields != nil {
+		t.Errorf("fields = %v, want nil — one bad value in a repeated key still drops the whole value", fields)
 	}
 	if len(ignored) != 1 || ignored[0].Param != "q_fields" {
 		t.Errorf("ignored = %v, want one entry naming q_fields", ignored)

--- a/internal/search/search/query_params_test.go
+++ b/internal/search/search/query_params_test.go
@@ -228,6 +228,18 @@ func TestQFieldsFromValues_UnrecognizedFieldIsReportedAndAppliesNoRestriction(t 
 	}
 }
 
+func TestQFieldsFromValues_TrailingCommaIsTolerated(t *testing.T) {
+	// Same tolerance splitFacetValues gives every ordinary facet: a stray comma
+	// fragment is dropped, not treated as a named (and therefore unrecognized) field.
+	fields, ignored := QFieldsFromValues(url.Values{"q_fields": {"title,"}})
+	if !slices.Equal(fields, []string{"title"}) {
+		t.Errorf("fields = %v, want [title]", fields)
+	}
+	if ignored != nil {
+		t.Errorf("ignored = %v, want nil", ignored)
+	}
+}
+
 func TestQFieldsFromValues_OneBadNameInvalidatesTheWholeValue(t *testing.T) {
 	// A caller who mistypes one of several names must not get a silently
 	// narrower-than-intended search on the names that happened to be valid.

--- a/internal/search/search/query_params_test.go
+++ b/internal/search/search/query_params_test.go
@@ -185,6 +185,61 @@ func TestUnknownParams_SuggestsThroughFacetModifiers(t *testing.T) {
 	}
 }
 
+func TestQFieldsFromValues_AbsentRestrictsNothing(t *testing.T) {
+	fields, ignored := QFieldsFromValues(url.Values{})
+	if fields != nil {
+		t.Errorf("fields = %v, want nil", fields)
+	}
+	if ignored != nil {
+		t.Errorf("ignored = %v, want nil", ignored)
+	}
+}
+
+func TestQFieldsFromValues_SingleRecognizedField(t *testing.T) {
+	fields, ignored := QFieldsFromValues(url.Values{"q_fields": {"title"}})
+	if !slices.Equal(fields, []string{"title"}) {
+		t.Errorf("fields = %v, want [title]", fields)
+	}
+	if ignored != nil {
+		t.Errorf("ignored = %v, want nil", ignored)
+	}
+}
+
+func TestQFieldsFromValues_MultipleFieldsComeBackInCanonicalOrder(t *testing.T) {
+	// The caller wrote "company,title" — Meilisearch's ranking is sensitive to
+	// attribute order, so a caller-controlled order would make identical
+	// restrictions rank differently for no reason a caller could predict.
+	fields, ignored := QFieldsFromValues(url.Values{"q_fields": {"company,title"}})
+	if !slices.Equal(fields, []string{"title", "company"}) {
+		t.Errorf("fields = %v, want [title company] regardless of the requested order", fields)
+	}
+	if ignored != nil {
+		t.Errorf("ignored = %v, want nil", ignored)
+	}
+}
+
+func TestQFieldsFromValues_UnrecognizedFieldIsReportedAndAppliesNoRestriction(t *testing.T) {
+	fields, ignored := QFieldsFromValues(url.Values{"q_fields": {"salary"}})
+	if fields != nil {
+		t.Errorf("fields = %v, want nil — an unrecognized value must not restrict", fields)
+	}
+	if len(ignored) != 1 || ignored[0].Param != "q_fields" {
+		t.Errorf("ignored = %v, want one entry naming q_fields", ignored)
+	}
+}
+
+func TestQFieldsFromValues_OneBadNameInvalidatesTheWholeValue(t *testing.T) {
+	// A caller who mistypes one of several names must not get a silently
+	// narrower-than-intended search on the names that happened to be valid.
+	fields, ignored := QFieldsFromValues(url.Values{"q_fields": {"title,salary"}})
+	if fields != nil {
+		t.Errorf("fields = %v, want nil — one bad name drops the whole value", fields)
+	}
+	if len(ignored) != 1 || ignored[0].Param != "q_fields" {
+		t.Errorf("ignored = %v, want one entry naming q_fields", ignored)
+	}
+}
+
 func TestUnknownCompanyParams(t *testing.T) {
 	// Companies filter on their own vocabulary, so the jobs facets are NOT
 	// known here — `seniority=senior` does nothing on a company search and has

--- a/internal/search/search/search_integration_test.go
+++ b/internal/search/search/search_integration_test.go
@@ -460,3 +460,63 @@ func TestIntegration_RebuildSwapsFreshIndexAndDropsOld(t *testing.T) {
 		t.Error("jobs_rebuild still exists; Promote should drop it")
 	}
 }
+
+// TestSearchQFieldsRestrictsMatchingOnRealEngine reproduces the motivating example
+// from issue #2671 against a real Meilisearch instance (not a fake): "systems"
+// appears only in a company name, not in that job's title, and an unscoped query
+// wrongly surfaces it for a caller looking for systems engineering roles.
+func TestSearchQFieldsRestrictsMatchingOnRealEngine(t *testing.T) {
+	ctx := context.Background()
+	c := startMeili(t)
+	if err := c.EnsureIndex(ctx); err != nil {
+		t.Fatalf("EnsureIndex: %v", err)
+	}
+
+	jobs := []db.Job{
+		{
+			ID: 20, Title: "Engineer – Asset Manager", Company: "STS Systems Defense", Location: "Tyndall AFB, US",
+			Description: "Asset management support role.",
+			PublicSlug:  "engineer-asset-manager-sts-aaa",
+			PostedAt:    pgtype.Timestamptz{Time: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Valid: true},
+			Enrichment:  enrichedJSON(t, enrich.Enrichment{}),
+		},
+		{
+			ID: 21, Title: "Systems Engineer", Company: "Acme", Location: "Berlin",
+			Description: "Design and operate distributed systems.",
+			PublicSlug:  "systems-engineer-acme-bbb",
+			PostedAt:    pgtype.Timestamptz{Time: time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC), Valid: true},
+			Enrichment:  enrichedJSON(t, enrich.Enrichment{}),
+		},
+	}
+	docs := make([]JobDocument, 0, len(jobs))
+	for _, j := range jobs {
+		d, err := FromJob(j)
+		if err != nil {
+			t.Fatalf("FromJob: %v", err)
+		}
+		docs = append(docs, d)
+	}
+	if err := c.IndexJobs(ctx, docs); err != nil {
+		t.Fatalf("IndexJobs: %v", err)
+	}
+
+	t.Run("unscoped query matches the company-name hit too", func(t *testing.T) {
+		res, err := c.Search(ctx, SearchParams{Query: "systems", Limit: 10})
+		if err != nil {
+			t.Fatalf("Search: %v", err)
+		}
+		if res.Total != 2 {
+			t.Fatalf("Total = %d, want 2 — both the title match and the company-name match", res.Total)
+		}
+	})
+
+	t.Run("q_fields=title excludes the company-name-only match", func(t *testing.T) {
+		res, err := c.Search(ctx, SearchParams{Query: "systems", QFields: []string{"title"}, Limit: 10})
+		if err != nil {
+			t.Fatalf("Search: %v", err)
+		}
+		if res.Total != 1 || res.Hits[0].PublicSlug != "systems-engineer-acme-bbb" {
+			t.Fatalf("hits = %+v, want only the title match", res.Hits)
+		}
+	})
+}

--- a/internal/search/search/searchrequest_test.go
+++ b/internal/search/search/searchrequest_test.go
@@ -56,3 +56,17 @@ func TestSearchRequestPassesPaginationThrough(t *testing.T) {
 		t.Errorf("limit/offset = %d/%d, want 25/400", req.Limit, req.Offset)
 	}
 }
+
+func TestSearchRequestWithoutQFieldsLeavesAttributesToSearchOnUnset(t *testing.T) {
+	req := buildSearchRequest(SearchParams{Query: "golang", Limit: 20})
+	if req.AttributesToSearchOn != nil {
+		t.Errorf("AttributesToSearchOn = %v, want nil — Meilisearch's default (all searchable attributes) must apply", req.AttributesToSearchOn)
+	}
+}
+
+func TestSearchRequestWithQFieldsSetsAttributesToSearchOn(t *testing.T) {
+	req := buildSearchRequest(SearchParams{Query: "systems", QFields: []string{"title"}, Limit: 20})
+	if len(req.AttributesToSearchOn) != 1 || req.AttributesToSearchOn[0] != "title" {
+		t.Errorf("AttributesToSearchOn = %v, want [title]", req.AttributesToSearchOn)
+	}
+}

--- a/openspec/changes/search-q-field-scoping/.openspec.yaml
+++ b/openspec/changes/search-q-field-scoping/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-09

--- a/openspec/changes/search-q-field-scoping/design.md
+++ b/openspec/changes/search-q-field-scoping/design.md
@@ -1,0 +1,137 @@
+## Context
+
+`q` is passed to Meilisearch as-is (`internal/api/handler/search.go` → `buildSearchRequest`
+in `internal/search/search/client.go`), with no field scoping — Meilisearch's
+`SearchableAttributes` for the jobs index is `["title", "company", "description",
+"location"]` (`client.go`, `facetSettings`). The index's `ProximityPrecision` is
+`byAttribute` (set in `#1637`, see `client.go`'s comment on `facetSettings`), which is
+why a quoted `q` degrades to an order-independent AND rather than a contiguous-phrase
+match — Meilisearch cannot verify word adjacency without the `byWord` word-pair
+proximity structure. See `proposal.md` for the motivating example (`STS Systems
+Defense`) and why real exact-phrase matching is out of scope for this change.
+
+Unrecognized query params are reported, never silently accepted or hard-errored, via
+`search.UnknownParams` (`internal/search/search/query_params.go`) — it checks **param
+names** against a known vocabulary (facets, their `_exclude`/`_mode` suffixes, and a
+short `scalarFilters` list) and returns unmatched ones in `meta.ignored_params`. `q`
+itself is not in that vocabulary; the handler passes it to `UnknownParams` via the
+`alsoKnown` parameter alongside `limit`/`offset`/etc. `q_fields` needs the same
+treatment, but the interesting failure mode is an unrecognized **value** inside an
+otherwise-known param name (e.g. `q_fields=salary`), which `UnknownParams` does not
+currently express — it only reports names it has never heard of.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let a caller restrict `q` matching to a subset of the four searchable fields,
+  query-time, with no index/reindex change.
+- Document `q`'s actual matching semantics so a caller can predict results.
+
+**Non-Goals:**
+- Contiguous exact-phrase matching. Confirmed out of scope by two local spikes (see
+  "Spike findings" below) — it requires `ProximityPrecision: byWord` plus a full catalog
+  reindex, and the indexing-cost regression that `byAttribute` exists to avoid (`#1637`)
+  is real and grows with corpus size. That is a separate, larger decision.
+- Changing `q`'s OR/AND token semantics. Only field scoping is added; a caller who
+  wants exact-phrase behavior still cannot get it after this change (documented as a
+  known gap, not silently implied to be fixed).
+
+## Decisions
+
+### `q_fields` is implemented via Meilisearch's query-time `AttributesToSearchOn`
+
+Meilisearch's `SearchRequest.AttributesToSearchOn` restricts which searchable
+attributes a single query matches against, without touching stored index settings —
+no reindex, no `ProximityPrecision` change, no interaction with the exact-phrase
+question. `buildSearchRequest` sets it only when `q_fields` is present; when absent,
+Meilisearch's default (all `SearchableAttributes`) applies, matching today's behavior
+exactly. This is the cheapest of the two levers the issue asked for, and it's fully
+independent of the exact-phrase decision — hence splitting it into its own change.
+
+**Alternative considered**: a `title` boolean shortcut param (`title_only=true`)
+instead of a general `q_fields`. Rejected: the issue explicitly asks for a general
+field-scoping mechanism, and a single-purpose boolean would need a second parameter
+the moment `company`-only scoping is wanted, which is a real use case for filtering
+out reposting aggregators from a company-name search.
+
+### Order of `AttributesToSearchOn` is fixed, not caller-supplied
+
+When `q_fields=company,title` is given, the fields are passed to Meilisearch in the
+index's canonical order (`title`, `company`, `description`, `location`), not the
+order the caller wrote them. Meilisearch's relevance ranking is sensitive to
+attribute order among matched fields; a caller-controlled order would make identical
+restrictions (`title,company` vs `company,title`) rank differently for no reason a
+caller could predict — directly the kind of unpredictability this change exists to
+remove.
+
+### An unrecognized field name invalidates the whole `q_fields` value
+
+`q_fields=title,salary` is treated the same as `q_fields=salary`: the entire
+parameter is dropped (falls back to unrestricted, all-fields matching) and reported
+once via `meta.ignored_params`, rather than silently applying only the valid names.
+Partial application would mean a caller who makes one typo (`titel`) alongside a
+correct name (`company`) gets a silently narrower-than-intended search with no
+signal beyond the general convention that whatever else IS restricting must be
+"working as expected" — worse than the current "params I don't understand widen and
+tell you" contract this API already keeps everywhere else (`UnknownParams`,
+`search.Narrows`, `UnknownCompanyParams`). Whole-value drop keeps the failure mode
+in the same class as an unrecognized facet: coarse, but honest and consistent.
+
+### Validation lives beside `UnknownParams`, as a value check, not a name check
+
+`query_params.go` gains a small `validQFields` set and a helper that both (a)
+returns the valid `AttributesToSearchOn` list for `buildSearchRequest` and (b)
+reports `q_fields` as an ignored param (reusing the existing `UnknownParam` /
+`SortAndCap` shape) when any named field isn't in that set. This sits next to
+`UnknownParams` rather than inside it: `UnknownParams` answers "is this param name
+one I read at all", which stays true for `q_fields` (it is read) — the new check
+answers "is what's inside it something I understood", a different question the
+existing function doesn't ask of any other param today.
+
+### Spike findings backing the exact-phrase non-goal
+
+Two local, isolated Meilisearch spikes (v1.49.0, matching prod) ran during this
+change's planning, never against prod infrastructure:
+
+1. **900 real job documents** (pulled from the live public API) indexed into an
+   empty index under `byAttribute` vs `byWord`: both completed in under 1.2s. This
+   under-counts the real cost — an empty index has no existing
+   `wordPairProximityDocids` structure to merge into, which `#1637`'s own benchmark
+   identifies as the expensive part.
+2. **60,000 synthetic documents**, bulk-loaded, then a 200-document incremental push
+   measured on the resulting "warm" index (mirroring `search-drain`'s real push
+   shape): `byWord` bulk-load was ~1.7x slower (14.0s vs 8.2s) and the warm-index
+   incremental push was ~3.3x slower (0.29s vs 0.09s, Meilisearch-reported task
+   duration) than `byAttribute`.
+
+Caveat, stated plainly: the synthetic corpus's description text draws from an ~80-word
+vocabulary, far narrower than real job postings. `#1637`'s own benchmark measured
+against a ~317k-document **real** sample and found costs an order of magnitude higher
+(~10s per 200-document batch) — a gap this spike's low lexical diversity plausibly
+explains, since `wordPairProximityDocids` size depends on vocabulary richness, not
+document count alone. The spike confirms the **direction and existence** of the cost
+(and that it grows with index size, as expected); it does not overturn `#1637`'s
+magnitude, and a decision to actually flip `ProximityPrecision` needs a measurement
+against real-scale, real-vocabulary data — not bundled into this change.
+
+## Risks / Trade-offs
+
+- **[Risk]** A caller expects `q_fields=title` combined with quoted `q` to yield an
+  exact-phrase-in-title match. → **Mitigation**: the OpenAPI doc and this proposal are
+  explicit that quoting is still order-independent AND, with or without `q_fields`.
+- **[Risk]** Whole-value-drop on `q_fields` surprises a caller who only mistyped one
+  of several field names. → **Mitigation**: `meta.ignored_params` names `q_fields`
+  explicitly, matching the existing convention callers of this API already rely on to
+  catch typos in facet params.
+- **[Trade-off]** Fixed attribute order (not caller order) means `q_fields` cannot be
+  used to express "prefer company matches over title matches" — only which fields
+  are eligible, not their relative weight. Accepted: the issue's request was for
+  restriction, not custom ranking, and custom per-call ranking is a materially bigger
+  feature.
+
+## Migration Plan
+
+No migration, no reindex, no index settings change. This is an application-code and
+documentation change: deploy `internal/api/handler` and `internal/search/search`
+changes together with the updated `web/static/openapi.yaml`. Rollback is a plain
+revert — no data or index state depends on `q_fields` existing.

--- a/openspec/changes/search-q-field-scoping/design.md
+++ b/openspec/changes/search-q-field-scoping/design.md
@@ -79,14 +79,22 @@ in the same class as an unrecognized facet: coarse, but honest and consistent.
 
 ### Validation lives beside `UnknownParams`, as a value check, not a name check
 
-`query_params.go` gains a small `validQFields` set and a helper that both (a)
-returns the valid `AttributesToSearchOn` list for `buildSearchRequest` and (b)
-reports `q_fields` as an ignored param (reusing the existing `UnknownParam` /
-`SortAndCap` shape) when any named field isn't in that set. This sits next to
-`UnknownParams` rather than inside it: `UnknownParams` answers "is this param name
-one I read at all", which stays true for `q_fields` (it is read) — the new check
-answers "is what's inside it something I understood", a different question the
-existing function doesn't ask of any other param today.
+`query_params.go` gains a small `qSearchableFields` set and a `QFieldsFromValues`
+helper that both (a) returns the valid `AttributesToSearchOn` list for
+`buildSearchRequest` and (b) reports `q_fields` as an ignored param (reusing the
+existing `UnknownParam` shape) when any named field isn't in that set. This sits
+next to `UnknownParams` rather than inside it: `UnknownParams` answers "is this
+param name one I read at all", which stays true for `q_fields` (it is read) —
+the new check answers "is what's inside it something I understood", a different
+question the existing function doesn't ask of any other param today.
+
+It reads `v["q_fields"]` through the existing `splitFacetValues`, the same
+helper every ordinary facet uses — not `url.Values.Get`, which would silently
+keep only the first occurrence of a repeated key (`q_fields=title&q_fields=
+company`) with no report, exactly the silent-narrowing failure mode this
+feature exists to avoid. A repeated key and a comma-joined value therefore
+resolve identically, matching `skills=go&skills=react` vs `skills=go,react`
+everywhere else in this filter vocabulary.
 
 ### Spike findings backing the exact-phrase non-goal
 

--- a/openspec/changes/search-q-field-scoping/proposal.md
+++ b/openspec/changes/search-q-field-scoping/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+`q` on `GET /api/v1/jobs/search` and `GET /api/v1/agent/jobs/search` is documented only
+as "full-text query over title, company, and description" — its actual matching
+semantics (unquoted is OR-of-tokens, quoted is order-independent AND-of-tokens, and it
+also reaches `location`) are undocumented and unpredictable to callers (issue #2671).
+Reproduced live against prod on 2026-09-09: `q="engineer systems"` (quoted, reversed
+word order) surfaces "Engineer – Asset Manager" at "STS Systems Defense" — a non-tech,
+security-clearance defense role — because "systems" only appears in the company name,
+not the title. A caller who wants systems-engineering roles cannot exclude this today.
+
+## What Changes
+
+- Document `q`'s actual matching semantics for both endpoints in `web/static/openapi.yaml`:
+  unquoted `q` is OR-of-stemmed-tokens, quoted `q` is AND-of-stemmed-tokens irrespective
+  of word order (**not** a contiguous-phrase match), and `q` searches `title`, `company`,
+  `description`, and `location`.
+- Add a `q_fields` parameter to both endpoints restricting which of those four fields `q`
+  matches against (e.g. `q_fields=title`), implemented via Meilisearch's query-time
+  `AttributesToSearchOn` — no reindex required, no change to stored index settings.
+- An unrecognized `q_fields` value is dropped and reported through the existing
+  `meta.ignored_params` convention (`search.UnknownParams`), consistent with how every
+  other unrecognized search param is handled — never a hard error, never a silent widen.
+- **Explicitly out of scope: exact contiguous-phrase matching.** Two local spikes (see
+  `design.md`) confirmed that enabling it requires switching Meilisearch's
+  `ProximityPrecision` from `byAttribute` to `byWord` plus a full catalog reindex, and
+  that the indexing-cost regression `byAttribute` was chosen to avoid (`#1637`) is real
+  and grows with corpus size — directionally confirmed at 60k-document scale (bulk load
+  1.7x slower, warm-index incremental push 3.3x slower). Deciding whether to pay that
+  cost needs its own change with a real-data-scale measurement, not a bundled guess here.
+
+## Capabilities
+
+### New Capabilities
+(none)
+
+### Modified Capabilities
+- `job-search`: the "Public job search endpoint" requirement gains a documented `q`
+  semantics contract and the new `q_fields` parameter.
+- `agent-jobs-search`: the "Agent job search endpoint" requirement's "runs the same
+  search" contract is made explicit for `q_fields` — it passes through identically to
+  the public endpoint.
+
+## Impact
+
+- `internal/api/handler/search.go` — read the new `q_fields` query param for both
+  `SearchJobs` and `AgentSearchJobs`.
+- `internal/search/search/client.go` (`buildSearchRequest`) — set Meilisearch's
+  `AttributesToSearchOn` when `q_fields` is present.
+- `internal/search/search/query_params.go` (`UnknownParams`) — validate `q_fields`
+  values against the four searchable fields and report unrecognized ones.
+- `web/static/openapi.yaml` — document `q` semantics and the new `q_fields` parameter
+  for both endpoints (linted by the `artifacts` CI job's OpenAPI validation).
+- No migration, no reindex, no change to Meilisearch index settings.

--- a/openspec/changes/search-q-field-scoping/proposal.md
+++ b/openspec/changes/search-q-field-scoping/proposal.md
@@ -14,7 +14,10 @@ not the title. A caller who wants systems-engineering roles cannot exclude this 
 - Document `q`'s actual matching semantics for both endpoints in `web/static/openapi.yaml`:
   unquoted `q` is OR-of-stemmed-tokens, quoted `q` is AND-of-stemmed-tokens irrespective
   of word order (**not** a contiguous-phrase match), and `q` searches `title`, `company`,
-  `description`, and `location`.
+  `description`, and `location`. Also answers issue #2671's point 4 directly: the default
+  relevance order (no `sort`) does **not** reliably rank a contiguous match above a
+  scattered-token one, since `ProximityPrecision: byAttribute` (`#1637`) gives the
+  `proximity` ranking rule only attribute-level, not word-level, distance data.
 - Add a `q_fields` parameter to both endpoints restricting which of those four fields `q`
   matches against (e.g. `q_fields=title`), implemented via Meilisearch's query-time
   `AttributesToSearchOn` — no reindex required, no change to stored index settings.

--- a/openspec/changes/search-q-field-scoping/specs/agent-jobs-search/spec.md
+++ b/openspec/changes/search-q-field-scoping/specs/agent-jobs-search/spec.md
@@ -1,0 +1,57 @@
+## MODIFIED Requirements
+
+### Requirement: Agent job search endpoint
+
+The system SHALL expose `GET /api/v1/agent/jobs/search` as a public
+(unauthenticated) endpoint that runs the same job search as `GET /api/v1/jobs/search`:
+it SHALL accept the same free-text query `q` (with the same OR-of-tokens /
+order-independent-AND-of-tokens matching semantics and the same `q_fields`
+field-scoping parameter), the same facet filters, sort, semantic ratio, and
+`limit`/`offset` pagination, and SHALL apply the same pagination-window guard.
+Ranking, faceting, pagination, and the estimated total SHALL be produced by the
+search index exactly as the public search endpoint produces them. The response
+SHALL use the standard list envelope `{"data": [...], "meta": {...}}`, where
+`data` is the matched jobs and `meta` carries at least the estimated total hit
+count and the applied `limit`/`offset`. Each result SHALL identify its job by
+`public_slug` and SHALL NOT include the internal numeric `id`.
+
+Unlike the public search endpoint, each result's `description` SHALL be the job's
+**full** description, read verbatim from Postgres and keyed by the result's
+internal id — never the truncated index preview. The hydration SHALL be
+best-effort per result: a returned hit whose id has no corresponding Postgres row
+(e.g. the index lags a just-removed job) SHALL retain whatever description the
+index served and SHALL NOT be dropped from the response.
+
+#### Scenario: Runs the same search as the public endpoint
+
+- **WHEN** a client requests
+  `GET /api/v1/agent/jobs/search?q=engineer&seniority=senior&regions=eu&limit=10`
+- **THEN** the matched, ranked, paginated results and the `meta` totals are those
+  the search index produces for the same query and filters, in the standard
+  `{"data": [...], "meta": {...}}` envelope
+
+#### Scenario: q_fields restricts matching identically to the public endpoint
+
+- **WHEN** a client requests
+  `GET /api/v1/agent/jobs/search?q=systems&q_fields=title`
+- **THEN** only jobs whose `title` matches "systems" are returned, the same
+  restriction `GET /api/v1/jobs/search?q=systems&q_fields=title` applies
+
+#### Scenario: Results carry the full description, not the preview
+
+- **WHEN** a job whose description exceeds the index preview cap is returned by
+  `GET /api/v1/agent/jobs/search`
+- **THEN** the result's `description` equals the full description that
+  `GET /api/v1/jobs/{slug}` returns for the same job, not the truncated preview
+
+#### Scenario: Results identify jobs by public slug, not internal id
+
+- **WHEN** a job is returned by `GET /api/v1/agent/jobs/search`
+- **THEN** the result carries the job's `public_slug` and omits the internal
+  numeric `id`
+
+#### Scenario: Hydration is best-effort on a stale hit
+
+- **WHEN** a returned hit's id has no matching Postgres row (the index lags a
+  just-removed job)
+- **THEN** that hit is still present in the response rather than being dropped

--- a/openspec/changes/search-q-field-scoping/specs/job-search/spec.md
+++ b/openspec/changes/search-q-field-scoping/specs/job-search/spec.md
@@ -1,0 +1,109 @@
+## MODIFIED Requirements
+
+### Requirement: Public job search endpoint
+
+The system SHALL expose `GET /api/v1/jobs/search` as a public (unauthenticated)
+endpoint. It SHALL accept a free-text query `q`, facet filters matching the
+index's filterable attributes, an optional sort, an optional semantic ratio, and
+`limit`/`offset` pagination. Facet filters SHALL include `regions` (the geography
+facet) and SHALL NOT include the removed raw `remote` filter. The response SHALL
+use the standard list envelope `{"data": [...], "meta": {...}}`, where `data` is
+the matched job documents and `meta` carries at least the estimated total hit
+count and the applied `limit`/`offset`. The separate DB-backed `GET /api/v1/jobs`
+list endpoint is governed by its own requirement (see "DB-backed jobs list is
+index-served with an approximate total").
+
+`q` matches against four fields: `title`, `company`, `description`, and
+`location`. An unquoted multi-word `q` SHALL match as an OR of its (stemmed)
+tokens: a document matching any token across those fields is a hit. A
+double-quoted `q` (e.g. `q="systems engineer"`) SHALL match as an AND of its
+(stemmed) tokens, irrespective of the tokens' order or adjacency in the matched
+field — quoting SHALL NOT be interpreted as a contiguous-phrase match.
+
+The endpoint SHALL additionally accept a `q_fields` parameter restricting which
+of the four `q`-searchable fields (`title`, `company`, `description`, `location`)
+`q` is matched against. `q_fields` SHALL accept one or more of those field names
+(comma-separated). When absent, `q` matches across all four fields as described
+above. A `q_fields` value naming no recognized field SHALL be dropped and
+reported via `meta.ignored_params`, consistent with how every other unrecognized
+search parameter is handled, and SHALL NOT restrict or widen the match.
+
+The endpoint SHALL additionally accept a `posted_within_days` parameter. When it
+is a positive integer `N`, the search SHALL be restricted to jobs whose
+`posted_ts` is at or after `now - N*86400` (i.e. posted within the last `N`
+days), where `now` is the time the request is served. When the parameter is
+absent, empty, zero, negative, or not a valid integer, it SHALL impose no date
+restriction. The filter SHALL compose with the other facet filters (AND).
+
+Each result SHALL identify its job by `public_slug` and SHALL NOT include the
+internal numeric `id`, consistent with the public-identity contract used by the
+other public job reads.
+
+#### Scenario: Keyword query returns matches
+
+- **WHEN** a client requests `GET /api/v1/jobs/search?q=golang`
+- **THEN** the response is `{"data": [...], "meta": {...}}` with jobs matching
+  "golang" in `data` and the estimated total and pagination in `meta`
+
+#### Scenario: Unquoted multi-word query is OR-of-tokens
+
+- **WHEN** a client requests `GET /api/v1/jobs/search?q=systems%20engineer`
+- **THEN** the results include jobs matching either "systems" or "engineer" (or
+  both) in any of `title`, `company`, `description`, or `location`
+
+#### Scenario: Quoted query is order-independent AND-of-tokens, not a phrase match
+
+- **WHEN** a client requests `GET /api/v1/jobs/search?q=%22engineer%20systems%22`
+  (quoted, reversed word order)
+- **THEN** the results are identical to `q=%22systems%20engineer%22`, and MAY
+  include a job whose matched field contains both tokens non-adjacently or in a
+  different attribute than the title (e.g. "systems" only in `company`)
+
+#### Scenario: q_fields restricts matching to the named field
+
+- **WHEN** a client requests `GET /api/v1/jobs/search?q=systems&q_fields=title`
+- **THEN** only jobs whose `title` matches "systems" are returned, regardless of
+  whether "systems" also appears in that job's `company`, `description`, or
+  `location`
+
+#### Scenario: Unrecognized q_fields value is reported, not applied
+
+- **WHEN** a client requests `GET /api/v1/jobs/search?q=systems&q_fields=salary`
+- **THEN** the response is unrestricted by `q_fields` (as if it were absent) and
+  `meta.ignored_params` includes `q_fields`
+
+#### Scenario: Faceted filtering by region
+
+- **WHEN** a client requests
+  `GET /api/v1/jobs/search?q=engineer&seniority=senior&regions=eu`
+- **THEN** only jobs whose facets satisfy seniority=senior AND whose top-level
+  `regions` include `eu` are returned
+
+#### Scenario: Empty query browses with filters
+
+- **WHEN** a client requests `GET /api/v1/jobs/search` with filters but no `q`
+- **THEN** the filtered jobs are returned ranked by the index defaults
+
+#### Scenario: Pagination is reflected in meta
+
+- **WHEN** a client requests `GET /api/v1/jobs/search?q=go&limit=10&offset=20`
+- **THEN** at most 10 documents are returned and `meta` reports the applied
+  `limit` 10 and `offset` 20 alongside the estimated total
+
+#### Scenario: Results identify jobs by public slug, not internal id
+
+- **WHEN** a job is returned by `GET /api/v1/jobs/search`
+- **THEN** the result carries the job's `public_slug` and omits the internal
+  numeric `id`
+
+#### Scenario: Freshness filter restricts to recent postings
+
+- **WHEN** a client requests `GET /api/v1/jobs/search?posted_within_days=7`
+- **THEN** only jobs whose effective posting date is within the last 7 days are
+  returned
+
+#### Scenario: Invalid freshness value imposes no restriction
+
+- **WHEN** a client requests `GET /api/v1/jobs/search` with `posted_within_days`
+  absent, zero, negative, or non-numeric
+- **THEN** the result is not restricted by posting date

--- a/openspec/changes/search-q-field-scoping/specs/job-search/spec.md
+++ b/openspec/changes/search-q-field-scoping/specs/job-search/spec.md
@@ -22,11 +22,16 @@ field — quoting SHALL NOT be interpreted as a contiguous-phrase match.
 
 The endpoint SHALL additionally accept a `q_fields` parameter restricting which
 of the four `q`-searchable fields (`title`, `company`, `description`, `location`)
-`q` is matched against. `q_fields` SHALL accept one or more of those field names
-(comma-separated). When absent, `q` matches across all four fields as described
-above. A `q_fields` value naming no recognized field SHALL be dropped and
-reported via `meta.ignored_params`, consistent with how every other unrecognized
-search parameter is handled, and SHALL NOT restrict or widen the match.
+`q` is matched against. `q_fields` SHALL accept one or more of those field names,
+either as a repeated query parameter or as a single comma-separated value (the
+two forms SHALL resolve identically). When absent, `q` matches across all four
+fields as described above. If `q_fields` names ANY field outside that set of
+four — whether alone or alongside otherwise-valid names — the ENTIRE parameter
+SHALL be dropped: `q` SHALL match unrestricted across all four fields, exactly
+as if `q_fields` were absent, and `q_fields` SHALL be reported via
+`meta.ignored_params`, consistent with how every other unrecognized search
+parameter is handled. Recognized names SHALL NOT be partially applied when the
+value also contains an unrecognized one.
 
 The endpoint SHALL additionally accept a `posted_within_days` parameter. When it
 is a positive integer `N`, the search SHALL be restricted to jobs whose
@@ -66,11 +71,26 @@ other public job reads.
   whether "systems" also appears in that job's `company`, `description`, or
   `location`
 
+#### Scenario: A repeated q_fields key is the same as a comma-joined value
+
+- **WHEN** a client requests
+  `GET /api/v1/jobs/search?q=systems&q_fields=title&q_fields=company`
+- **THEN** the results are identical to
+  `GET /api/v1/jobs/search?q=systems&q_fields=title,company`
+
 #### Scenario: Unrecognized q_fields value is reported, not applied
 
 - **WHEN** a client requests `GET /api/v1/jobs/search?q=systems&q_fields=salary`
 - **THEN** the response is unrestricted by `q_fields` (as if it were absent) and
   `meta.ignored_params` includes `q_fields`
+
+#### Scenario: One unrecognized name in a mixed q_fields value drops it entirely
+
+- **WHEN** a client requests
+  `GET /api/v1/jobs/search?q=systems&q_fields=title,salary`
+- **THEN** the response is unrestricted by `q_fields` (as if it were absent) —
+  `title` is NOT applied on its own — and `meta.ignored_params` includes
+  `q_fields`
 
 #### Scenario: Faceted filtering by region
 

--- a/openspec/changes/search-q-field-scoping/tasks.md
+++ b/openspec/changes/search-q-field-scoping/tasks.md
@@ -1,0 +1,68 @@
+## 1. `q_fields` validation in `internal/search/search`
+
+- [x] 1.1 Write failing tests in `query_params_test.go` for a new helper that parses
+      a comma-separated `q_fields` value against `{title, company, description,
+      location}`: valid names return the canonical-order attribute list; any
+      unrecognized name (alone or mixed with valid ones) returns no restriction and
+      reports `q_fields` via the existing `UnknownParam`/`SortAndCap` shape.
+- [x] 1.2 Implement the helper in `query_params.go` (e.g. `QFieldsFromValues`),
+      reusing `SortAndCap` for the report so it composes with the rest of
+      `UnknownParams`'s output at the handler level.
+- [x] 1.3 `go test ./internal/search/search/...` passes.
+
+## 2. Query-time field scoping in `internal/search/search/client.go`
+
+- [x] 2.1 Write failing tests exercising `buildSearchRequest` (or the nearest
+      existing test covering it) with an `AttributesToSearchOn` field set: absent
+      `q_fields` leaves it unset (today's behavior), present `q_fields` sets it to
+      the canonical-order attribute list.
+- [x] 2.2 Extend `SearchParams` with the resolved field list and set
+      `AttributesToSearchOn` on the built request when non-empty.
+- [x] 2.3 `go test ./internal/search/search/...` passes.
+
+## 3. Wire `q_fields` through both search endpoints
+
+- [x] 3.1 Write failing tests in `internal/api/handler` (`search_test.go`,
+      `agent_search_test.go`) for `SearchJobs` and `AgentSearchJobs`, using the
+      existing `fakeSearcher` — no `//go:build integration` tag needed here since
+      `searcher` is a plain interface: a `q_fields=title` request narrows
+      `SearchParams.QFields`; an unrecognized `q_fields` value is reported in
+      `meta.ignored_params` and does not restrict.
+- [x] 3.2 Read `q_fields` from the query string in the shared `runJobSearch`
+      core, resolve it via `search.QFieldsFromValues`, and merge its ignored-param
+      report into each handler's `meta.ignored_params` computation
+      (`search.SortAndCap(append(qFieldsIgnored, ignoredParams(c, own)...))`).
+- [x] 3.3 Add `q_fields` to a new `jobSearchParams` (searchParams + q_fields, used
+      by `SearchJobs` and folded into `agentSearchParams`) rather than the shared
+      `searchParams` the swipe deck also uses — the deck doesn't read `q_fields`
+      and must keep reporting it as unknown.
+- [x] 3.4 `go build ./... && go vet ./...` passes; `go test
+      ./internal/api/handler/...` passes.
+
+## 4. Documentation
+
+- [x] 4.1 Update `web/static/openapi.yaml` for both `/jobs/search` and
+      `/agent/jobs/search`: document `q`'s OR-of-tokens (unquoted) /
+      order-independent-AND-of-tokens (quoted, not a phrase match) semantics, that
+      `q` spans `title`/`company`/`description`/`location`, and the new `q_fields`
+      parameter with its whole-value-drop-on-unrecognized-name behavior. Also
+      updated `web/src/lib/docs/api-spec.ts` — the parallel source `docs/API.md`
+      is generated from (discovered via the `docs/API.md`-freshness CI step) —
+      and regenerated `docs/API.md` with `pnpm run gen:api-docs`.
+- [x] 4.2 Validated with `npx @redocly/cli@2.49.0 lint web/static/openapi.yaml
+      --extends=minimal` (the `artifacts` CI job's exact check): passes.
+
+## 5. Verification
+
+- [x] 5.1 `gofmt -l .` reports nothing for changed files.
+- [x] 5.2 `go build ./... && go vet ./...` passes.
+- [x] 5.3 `go test ./...` passes (whole module, no FAIL).
+- [x] 5.4 Verified against a **real** Meilisearch (not a fake) rather than a manual
+      curl session, so the check leaves a permanent regression test: added
+      `TestSearchQFieldsRestrictsMatchingOnRealEngine` to
+      `search_integration_test.go` (testcontainers, `//go:build integration`),
+      reproducing issue #2671's own motivating example — "Engineer – Asset
+      Manager" at "STS Systems Defense" — and confirming `q_fields=title`
+      excludes the company-name-only match while an unscoped `q=systems` still
+      surfaces it. `go test -tags=integration ./internal/search/search/...`
+      passes (31 tests); `go vet -tags=integration ./...` passes.

--- a/web/src/lib/docs/api-spec.ts
+++ b/web/src/lib/docs/api-spec.ts
@@ -244,7 +244,7 @@ export const GROUPS: Group[] = [
           'since a dropped filter otherwise looks like a broad result.',
         filterable: true,
         query: [
-          { name: 'q', type: 'string', description: 'Full-text query over `title`, `company`, `description`, and `location`. Unquoted words match as an OR of stemmed tokens; quoted (`"systems engineer"`) as an order-independent AND — quoting is not a contiguous-phrase match. Narrow which fields it matches with `q_fields`.', example: 'golang' },
+          { name: 'q', type: 'string', description: 'Full-text query over `title`, `company`, `description`, and `location`. Unquoted words match as an OR of stemmed tokens; quoted (`"systems engineer"`) as an order-independent AND — quoting is not a contiguous-phrase match. Narrow which fields it matches with `q_fields`. Exact-phrase matching is not offered, and default relevance order does not reliably rank a contiguous match above a scattered-token one.', example: 'golang' },
           { name: 'q_fields', type: 'string', description: 'Comma-separated subset of `title,company,description,location` to restrict `q` to, e.g. `title`. A name outside that set drops the whole parameter (reported in `meta.ignored_params`) rather than partially applying.', example: 'title' },
           { name: 'sort', type: 'string', description: 'One of `created_at`, `posted_at`, `view_count`, `salary_min`, `salary_max`. Omit for relevance/newest.', example: 'posted_at' },
           { name: 'order', type: 'string', description: '`asc` or `desc` (default `desc`).', example: 'desc' },
@@ -268,7 +268,7 @@ export const GROUPS: Group[] = [
           'index preview. Use `description_format` to choose how it is rendered.',
         filterable: true,
         query: [
-          { name: 'q', type: 'string', description: 'Full-text query over `title`, `company`, `description`, and `location`. Unquoted words match as an OR of stemmed tokens; quoted (`"systems engineer"`) as an order-independent AND — quoting is not a contiguous-phrase match. Narrow which fields it matches with `q_fields`.', example: 'golang' },
+          { name: 'q', type: 'string', description: 'Full-text query over `title`, `company`, `description`, and `location`. Unquoted words match as an OR of stemmed tokens; quoted (`"systems engineer"`) as an order-independent AND — quoting is not a contiguous-phrase match. Narrow which fields it matches with `q_fields`. Exact-phrase matching is not offered, and default relevance order does not reliably rank a contiguous match above a scattered-token one.', example: 'golang' },
           { name: 'q_fields', type: 'string', description: 'Comma-separated subset of `title,company,description,location` to restrict `q` to, e.g. `title`. A name outside that set drops the whole parameter (reported in `meta.ignored_params`) rather than partially applying.', example: 'title' },
           { name: 'description_format', type: 'string', description: 'One of `html` (default, verbatim), `text` (tags stripped), `markdown` (HTML converted to Markdown). Unknown values fall back to `html`.', example: 'markdown' },
           { name: 'sort', type: 'string', description: 'One of `created_at`, `posted_at`, `view_count`, `salary_min`, `salary_max`. Omit for relevance/newest.', example: 'posted_at' },

--- a/web/src/lib/docs/api-spec.ts
+++ b/web/src/lib/docs/api-spec.ts
@@ -244,7 +244,8 @@ export const GROUPS: Group[] = [
           'since a dropped filter otherwise looks like a broad result.',
         filterable: true,
         query: [
-          { name: 'q', type: 'string', description: 'Full-text query over title, company, and description.', example: 'golang' },
+          { name: 'q', type: 'string', description: 'Full-text query over `title`, `company`, `description`, and `location`. Unquoted words match as an OR of stemmed tokens; quoted (`"systems engineer"`) as an order-independent AND — quoting is not a contiguous-phrase match. Narrow which fields it matches with `q_fields`.', example: 'golang' },
+          { name: 'q_fields', type: 'string', description: 'Comma-separated subset of `title,company,description,location` to restrict `q` to, e.g. `title`. A name outside that set drops the whole parameter (reported in `meta.ignored_params`) rather than partially applying.', example: 'title' },
           { name: 'sort', type: 'string', description: 'One of `created_at`, `posted_at`, `view_count`, `salary_min`, `salary_max`. Omit for relevance/newest.', example: 'posted_at' },
           { name: 'order', type: 'string', description: '`asc` or `desc` (default `desc`).', example: 'desc' },
           { name: 'limit', type: 'integer', description: 'Page size, 1–100.', example: '20' },
@@ -267,7 +268,8 @@ export const GROUPS: Group[] = [
           'index preview. Use `description_format` to choose how it is rendered.',
         filterable: true,
         query: [
-          { name: 'q', type: 'string', description: 'Full-text query over title, company, and description.', example: 'golang' },
+          { name: 'q', type: 'string', description: 'Full-text query over `title`, `company`, `description`, and `location`. Unquoted words match as an OR of stemmed tokens; quoted (`"systems engineer"`) as an order-independent AND — quoting is not a contiguous-phrase match. Narrow which fields it matches with `q_fields`.', example: 'golang' },
+          { name: 'q_fields', type: 'string', description: 'Comma-separated subset of `title,company,description,location` to restrict `q` to, e.g. `title`. A name outside that set drops the whole parameter (reported in `meta.ignored_params`) rather than partially applying.', example: 'title' },
           { name: 'description_format', type: 'string', description: 'One of `html` (default, verbatim), `text` (tags stripped), `markdown` (HTML converted to Markdown). Unknown values fall back to `html`.', example: 'markdown' },
           { name: 'sort', type: 'string', description: 'One of `created_at`, `posted_at`, `view_count`, `salary_min`, `salary_max`. Omit for relevance/newest.', example: 'posted_at' },
           { name: 'order', type: 'string', description: '`asc` or `desc` (default `desc`).', example: 'desc' },

--- a/web/static/api-reference.openapi.json
+++ b/web/static/api-reference.openapi.json
@@ -276,7 +276,7 @@
             "name": "q",
             "in": "query",
             "required": false,
-            "description": "Full-text query over `title`, `company`, `description`, and `location`. Unquoted words match as an OR of stemmed tokens; quoted (`\"systems engineer\"`) as an order-independent AND — quoting is not a contiguous-phrase match. Narrow which fields it matches with `q_fields`.",
+            "description": "Full-text query over `title`, `company`, `description`, and `location`. Unquoted words match as an OR of stemmed tokens; quoted (`\"systems engineer\"`) as an order-independent AND — quoting is not a contiguous-phrase match. Narrow which fields it matches with `q_fields`. Exact-phrase matching is not offered, and default relevance order does not reliably rank a contiguous match above a scattered-token one.",
             "schema": {
               "type": "string"
             },
@@ -362,7 +362,7 @@
             "name": "q",
             "in": "query",
             "required": false,
-            "description": "Full-text query over `title`, `company`, `description`, and `location`. Unquoted words match as an OR of stemmed tokens; quoted (`\"systems engineer\"`) as an order-independent AND — quoting is not a contiguous-phrase match. Narrow which fields it matches with `q_fields`.",
+            "description": "Full-text query over `title`, `company`, `description`, and `location`. Unquoted words match as an OR of stemmed tokens; quoted (`\"systems engineer\"`) as an order-independent AND — quoting is not a contiguous-phrase match. Narrow which fields it matches with `q_fields`. Exact-phrase matching is not offered, and default relevance order does not reliably rank a contiguous match above a scattered-token one.",
             "schema": {
               "type": "string"
             },

--- a/web/static/api-reference.openapi.json
+++ b/web/static/api-reference.openapi.json
@@ -276,11 +276,21 @@
             "name": "q",
             "in": "query",
             "required": false,
-            "description": "Full-text query over title, company, and description.",
+            "description": "Full-text query over `title`, `company`, `description`, and `location`. Unquoted words match as an OR of stemmed tokens; quoted (`\"systems engineer\"`) as an order-independent AND — quoting is not a contiguous-phrase match. Narrow which fields it matches with `q_fields`.",
             "schema": {
               "type": "string"
             },
             "example": "golang"
+          },
+          {
+            "name": "q_fields",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated subset of `title,company,description,location` to restrict `q` to, e.g. `title`. A name outside that set drops the whole parameter (reported in `meta.ignored_params`) rather than partially applying.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "title"
           },
           {
             "name": "sort",
@@ -352,11 +362,21 @@
             "name": "q",
             "in": "query",
             "required": false,
-            "description": "Full-text query over title, company, and description.",
+            "description": "Full-text query over `title`, `company`, `description`, and `location`. Unquoted words match as an OR of stemmed tokens; quoted (`\"systems engineer\"`) as an order-independent AND — quoting is not a contiguous-phrase match. Narrow which fields it matches with `q_fields`.",
             "schema": {
               "type": "string"
             },
             "example": "golang"
+          },
+          {
+            "name": "q_fields",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated subset of `title,company,description,location` to restrict `q` to, e.g. `title`. A name outside that set drops the whole parameter (reported in `meta.ignored_params`) rather than partially applying.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "title"
           },
           {
             "name": "description_format",

--- a/web/static/openapi.yaml
+++ b/web/static/openapi.yaml
@@ -773,6 +773,13 @@ components:
         their order or adjacency in the matched field — quoting does **not**
         request a contiguous phrase match. Use `q_fields` to narrow which
         fields `q` is matched against.
+
+        Exact-phrase matching is not offered today, and the default relevance
+        order (`sort` omitted) does not reliably rank a contiguous match above
+        a scattered-token one within the same field — the index trades that
+        precision for cheaper indexing over long-form descriptions. A caller
+        that needs phrase precision must currently over-fetch and filter or
+        rank client-side.
     QFields:
       name: q_fields
       in: query

--- a/web/static/openapi.yaml
+++ b/web/static/openapi.yaml
@@ -153,6 +153,7 @@ paths:
       x-openai-isConsequential: false
       parameters:
         - $ref: "#/components/parameters/Q"
+        - $ref: "#/components/parameters/QFields"
         - $ref: "#/components/parameters/Limit"
         - $ref: "#/components/parameters/Offset"
         - $ref: "#/components/parameters/Sort"
@@ -223,6 +224,7 @@ paths:
       x-openai-isConsequential: false
       parameters:
         - $ref: "#/components/parameters/Q"
+        - $ref: "#/components/parameters/QFields"
         - $ref: "#/components/parameters/Limit"
         - $ref: "#/components/parameters/Offset"
         - $ref: "#/components/parameters/Sort"
@@ -762,7 +764,32 @@ components:
       in: query
       schema:
         type: string
-      description: Full-text query over title, company, and description.
+      description: |
+        Full-text query over `title`, `company`, `description`, and `location`.
+
+        Unquoted, multiple words match as an OR of (stemmed) tokens: any word
+        matching in any of those fields is a hit. Double-quoted (e.g.
+        `q="systems engineer"`), the words match as an AND, irrespective of
+        their order or adjacency in the matched field — quoting does **not**
+        request a contiguous phrase match. Use `q_fields` to narrow which
+        fields `q` is matched against.
+    QFields:
+      name: q_fields
+      in: query
+      schema:
+        type: string
+      description: |
+        Restrict `q` matching to a comma-separated subset of its four
+        searchable fields: `title`, `company`, `description`, `location`. For
+        example `q_fields=title` matches "systems" only in the job title, not
+        in the company name or body — the only lever `q` has to exclude a
+        posting like "STS Systems Defense" from a search for systems engineer
+        roles.
+
+        Naming any field outside that set (e.g. `q_fields=salary`) drops the
+        parameter entirely — `q` runs unrestricted, across all four fields —
+        and `q_fields` is reported in `meta.ignored_params`, the same
+        convention every other unrecognized filter follows.
     Limit:
       name: limit
       in: query


### PR DESCRIPTION
## What and why

`q` on `GET /api/v1/jobs/search` and `GET /api/v1/agent/jobs/search` was documented only as "full-text query over title, company, and description" — its actual matching semantics (unquoted is OR-of-tokens, quoted is order-independent AND-of-tokens, and it also reaches `location`) were undocumented and unpredictable to callers.

Reproduced live against prod: `q="engineer systems"` (quoted, reversed word order) surfaces "Engineer – Asset Manager" at "STS Systems Defense" — a non-tech, security-clearance defense role — because "systems" only appears in the company name, not the title. A caller who wants systems-engineering roles cannot exclude this today.

This adds `q_fields` to restrict `q` matching to a caller-chosen subset of its four searchable fields (`title`, `company`, `description`, `location`) via Meilisearch's query-time `AttributesToSearchOn` — no reindex, no index-settings change. An unrecognized `q_fields` value drops the whole parameter and is reported via `meta.ignored_params`, consistent with every other unrecognized filter. Also documents `q`'s actual OR/AND semantics in `openapi.yaml` and the parallel `api-spec.ts`/`docs/API.md` source.

Exact contiguous-phrase matching stays out of scope: two local spikes (see `openspec/changes/search-q-field-scoping/design.md`) confirmed it needs `ProximityPrecision: byWord` plus a full catalog reindex, reopening the indexing-cost trade-off `byAttribute` (#1637) exists to avoid — a decision for its own change with a real-data-scale measurement.

Full OpenSpec change (proposal/design/specs/tasks) at `openspec/changes/search-q-field-scoping/`.

Closes #2671

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l .` (prints nothing) pass.
- [x] `go test ./...` passes, and `go test -tags=integration ./internal/search/search/...` (added `TestSearchQFieldsRestrictsMatchingOnRealEngine` against a real Meilisearch via testcontainers, reproducing the issue's own motivating example).
- [x] No SQL/migrations touched — `make sqlc`/`make gen-contracts` not applicable.
- [x] `pnpm run check` and `pnpm run build` pass for `web/` (only `api-spec.ts` and `openapi.yaml` changed; `docs/API.md` regenerated via `pnpm run gen:api-docs`).
- [x] This stays within freehire's core/extension boundary — a query-param addition and documentation on existing public endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `q_fields` to public and agent job search, allowing keyword matching to be limited to title, company, description, or location.
  - Invalid field selections are ignored and reported in search metadata.
  - Agent search now supports selecting the description response format.

- **Documentation**
  - Clarified keyword matching, quoted-query behavior, searchable fields, and `q_fields` usage in API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->