### PR TITLE
Three skills reach 82% of the market, and the fourth barely helps

### DIFF
--- a/docs/superpowers/plans/measurements/04-skill-coverage-curve.md
+++ b/docs/superpowers/plans/measurements/04-skill-coverage-curve.md
@@ -1,0 +1,162 @@
+# 04 — How fast the skill-coverage curve flattens
+
+Measured against production (`hire`) on **2026-09-09**. Read-only.
+
+For the second article to land traffic on `/roast`. The question: adding a skill to a CV
+opens some number of additional postings — how does that number fall off?
+
+## Method, and the denominator that matters
+
+Every figure is against **open, tech-classified postings in one category** that carry at
+least one tagged skill. The last clause is not decoration: `internal/job/verdict`'s own
+comment gives the reason — "skill frequency is measured against this, not the raw role
+total, so postings the tagger left skill-less don't deflate frequencies." For backend that
+is 41,712 of 45,453 open postings (91.8%); measuring against 45,453 would report the
+tagger's coverage as if it were the market's.
+
+Coverage uses PostgreSQL's array-overlap operator (`skills && ARRAY[...]`), so a posting
+counts once no matter how many of the listed skills it names. That is the whole point:
+frequencies add up to more than 100% and unions do not, which is why "api appears in 51% of
+postings" cannot be read as "knowing api reaches 51%".
+
+Each query took 50–65 s. The host is saturated (a bare `count(*)` on this predicate takes
+57 s), so these were run one at a time rather than widened.
+
+## Query A — top skills, open backend postings
+
+```sql
+SELECT s, count(*) FROM jobs, unnest(skills) s
+WHERE closed_at IS NULL AND is_tech IS TRUE AND category = 'backend'
+GROUP BY 1 ORDER BY 2 DESC LIMIT 25;
+```
+
+```
+api|23167
+java|17964
+cloud|17096
+aws|13378
+ci-cd|13289
+ai|12681
+python|11962
+sql|10742
+docker|10476
+kubernetes|10283
+spring|10166
+microservices|9710
+postgresql|9538
+rest|9531
+agile|8014
+git|7491
+kafka|7422
+distributed-systems|6624
+devops|6507
+azure|6506
+nodejs|5846
+gcp|5294
+observability|5257
+typescript|4861
+nosql|4710
+Time: 61051.529 ms (01:01.052)
+```
+
+Worth noting for a future piece rather than this one: `ai` sits at 12,681 in *backend*
+postings — above sql, docker and kubernetes.
+
+## Query B — the coverage curve, backend
+
+```sql
+SELECT count(*) AS all_open,
+       count(*) FILTER (WHERE cardinality(skills) > 0) AS with_skills,
+       count(*) FILTER (WHERE skills && ARRAY['api']) AS top1,
+       count(*) FILTER (WHERE skills && ARRAY['api','java','cloud']) AS top3,
+       count(*) FILTER (WHERE skills && ARRAY['api','java','cloud','aws','ci-cd']) AS top5,
+       count(*) FILTER (WHERE skills && ARRAY['api','java','cloud','aws','ci-cd','ai','python','sql','docker','kubernetes']) AS top10
+FROM jobs
+WHERE closed_at IS NULL AND is_tech IS TRUE AND category = 'backend';
+```
+
+```
+ all_open | with_skills | top1  | top3  | top5  | top10 
+----------+-------------+-------+-------+-------+-------
+    45453 |       41712 | 23168 | 34198 | 35958 | 38742
+(1 row)
+
+Time: 64644.523 ms (01:04.645)
+```
+
+Against 41,712 skill-bearing postings: **55.5% → 82.0% → 86.2% → 92.9%**.
+
+The second and third skills buy 26.5 points. The fourth and fifth buy 4.2. The sixth
+through tenth buy 6.7 between them.
+
+## Query C — the same shape in three other categories
+
+Top five per category first:
+
+```sql
+WITH r AS (
+  SELECT category, s, count(*) n,
+         row_number() OVER (PARTITION BY category ORDER BY count(*) DESC) rn
+  FROM jobs, unnest(skills) s
+  WHERE closed_at IS NULL AND is_tech IS TRUE
+    AND category IN ('frontend','data','devops','mobile')
+  GROUP BY 1, 2
+)
+SELECT category, string_agg(s, ', ' ORDER BY rn) AS top5 FROM r WHERE rn <= 5 GROUP BY 1;
+```
+
+```
+ category |                     top5                     
+----------+----------------------------------------------
+ devops   | cloud, devops, ci-cd, kubernetes, automation
+ frontend | react, typescript, api, css, javascript
+ mobile   | android, ios, api, kotlin, swift
+(3 rows)
+
+Time: 50247.030 ms (00:50.247)
+```
+
+`data` returned no rows — it is not a category slug this catalogue uses. Not chased; four
+categories is enough to answer whether the shape is a backend accident.
+
+Then the curve, each category against its own top skills:
+
+```
+ category | with_skills | top1  | top3  | top5  
+----------+-------------+-------+-------+-------
+ devops   |       74060 | 45836 | 60051 | 62363
+ frontend |       15361 | 10310 | 12774 | 13655
+ mobile   |       15425 |  9341 | 12737 | 12845
+(3 rows)
+
+Time: 51156.894 ms (00:51.157)
+```
+
+## The finding
+
+| category | 1 skill | 3 skills | 5 skills |
+| --- | --- | --- | --- |
+| backend | 55.5% | **82.0%** | 86.2% |
+| devops | 61.9% | **81.1%** | 84.2% |
+| frontend | 67.1% | **83.2%** | 88.9% |
+| mobile | 60.6% | **82.6%** | 83.3% |
+
+**Three skills reach 81–83% of every category measured.** Four independent fields, entirely
+different skills in each, and the three-skill figure lands inside a two-point band.
+
+The flattening is sharpest in mobile: three skills to five adds **0.7 points**. Two more
+skills, less than one percent of the market.
+
+## What this does not support
+
+- **It is not advice about which three skills.** The top three differ per field and shift
+  with the market; the finding is the shape of the curve, not its contents.
+- **Coverage is not a shortlist.** A posting "reached" by a skill still asks for everything
+  else on it. This measures which postings you are legible to, not which you would get.
+- **The tagger's vocabulary bounds it.** `internal/dict/skilltag` is dictionary-only and
+  emits nothing for a term it does not know, so a skill absent from the dictionary is absent
+  from these counts — that is why the denominator is skill-bearing postings.
+- **Categories are dictionary-resolved from titles.** A posting whose title resolves to no
+  category is not in any of these four populations.
+- **One employer can be many postings.** A company with 3,000 open roles pushes its stack up
+  these counts. These are per-posting figures, not per-employer ones.

--- a/web/src/posts/2026-09-09-three-skills-reach-most-of-the-market.svx
+++ b/web/src/posts/2026-09-09-three-skills-reach-most-of-the-market.svx
@@ -1,0 +1,113 @@
+---
+title: Three skills reach 82% of the market, and the fourth barely helps
+date: 2026-09-09
+summary: We measured how many open postings each additional skill on a CV actually opens up. The curve flattens far earlier than the advice suggests — and it flattens at almost exactly the same place in four different fields.
+type: article
+tags:
+  - skills
+  - data
+  - job-search
+draft: false
+---
+
+The standard advice for a stalled job search is to learn something else. Another
+framework, another cloud, another line on the CV. It is offered as though the return
+were flat — as though the tenth skill opened as many doors as the second.
+
+We can check that, because we hold the postings. So: for open, technical postings in
+one field, how many does each additional skill actually reach?
+
+The answer is that the curve flattens early, and it flattens at almost exactly the same
+place in every field we looked at.
+
+## The measurement
+
+Take open backend postings. There are **45,453** of them, of which **41,712** carry at
+least one tagged skill. Everything below is against that second number, and the reason
+matters: the difference is our tagger's coverage, not the market's. Measuring against
+all 45,453 would report a gap in our dictionary as if it were a gap in demand.
+
+The most-asked-for skills in that population look like this:
+
+| skill | postings |
+| --- | --- |
+| api | 23,167 |
+| java | 17,964 |
+| cloud | 17,096 |
+| aws | 13,378 |
+| ci-cd | 13,289 |
+| ai | 12,681 |
+| python | 11,962 |
+| sql | 10,742 |
+| docker | 10,476 |
+| kubernetes | 10,283 |
+
+Those percentages cannot be added. A posting asking for both Java and AWS appears in
+both rows, so summing the top five would count it twice and produce a number over 100.
+What you want is the union: how many *distinct* postings a set of skills reaches
+between them.
+
+## The curve
+
+| skills known | postings reached | share |
+| --- | --- | --- |
+| 1 (api) | 23,168 | 55.5% |
+| 3 (+ java, cloud) | 34,198 | 82.0% |
+| 5 (+ aws, ci-cd) | 35,958 | 86.2% |
+| 10 (+ five more) | 38,742 | 92.9% |
+
+Read the increments rather than the totals. The second and third skills buy **26.5
+points**. The fourth and fifth buy **4.2**. The sixth through tenth buy **6.7 between
+the five of them**.
+
+By the third skill you are already legible to four postings in five. Everything after
+that is the long tail of the long tail.
+
+## It is not a backend accident
+
+One field proves nothing, so we ran the same measurement on three more, each against its
+own most-demanded skills.
+
+| field | 1 skill | 3 skills | 5 skills |
+| --- | --- | --- | --- |
+| Backend | 55.5% | **82.0%** | 86.2% |
+| DevOps | 61.9% | **81.1%** | 84.2% |
+| Frontend | 67.1% | **83.2%** | 88.9% |
+| Mobile | 60.6% | **82.6%** | 83.3% |
+
+Four fields. Entirely different skills in each — `react`/`typescript`/`api` against
+`cloud`/`devops`/`ci-cd` against `android`/`ios`/`api`. And the three-skill figure lands
+inside a two-point band every time.
+
+Mobile is the starkest: going from three skills to five adds **0.7 points**. Two more
+technologies, less than one percent more of the market.
+
+## What this does and does not mean
+
+It does not mean those particular three skills are the ones to learn. The top three
+differ by field and move with the market; the finding is the shape of the curve, not its
+contents.
+
+It does not mean a posting you "reach" is a posting you get. Coverage is about being
+legible to a listing at all — the posting still asks for everything else on it, and so
+does the person reading your CV afterwards.
+
+And it is bounded by our own vocabulary. Our skill tagger is dictionary-only: it emits
+nothing for a term it does not recognise, which is exactly why the denominator here is
+postings that carry a tagged skill rather than all of them. A niche technology can be in
+real demand and invisible to this count.
+
+## What it does mean
+
+The marginal skill is worth much less than the advice implies, and the useful question is
+not "what else should I learn" but "which of the three or four things that actually carry
+my field are missing from my CV". Those are very different questions. The first has no
+end; the second has an answer, and it is usually short.
+
+That second question is answerable per person, and we put it on a page you can use
+without an account: drop a CV into [freehire.me/roast](https://freehire.me/roast) and it
+will tell you how many open postings in your field your skills already reach, and which
+single missing skill would reach the most more. It stores nothing and sends your CV to no
+model.
+
+If the answer turns out to be one skill, that is the whole finding above, applied to you.


### PR DESCRIPTION
## What and why

The second article pointing at `/roast`, and the sequel the first one set up: that piece
ended on "the forms are not going to get shorter, the CV can get more readable." This one
measures which part of the CV is worth changing.

The standard advice for a stalled search is to learn something else, offered as though the
return were flat — as though the tenth skill opened as many doors as the second. We hold the
postings, so we checked.

## The finding

Across open backend postings, against the **41,712** of 45,453 that carry a tagged skill:

| skills | reached | share |
| --- | --- | --- |
| 1 | 23,168 | 55.5% |
| 3 | 34,198 | **82.0%** |
| 5 | 35,958 | 86.2% |
| 10 | 38,742 | 92.9% |

The second and third skills buy **26.5 points**. The fourth and fifth buy **4.2**. The sixth
through tenth buy **6.7 between the five of them**.

One field would be an anecdote, so the same measurement ran on three more, each against its
own most-demanded skills:

| field | 1 | 3 | 5 |
| --- | --- | --- | --- |
| Backend | 55.5% | **82.0%** | 86.2% |
| DevOps | 61.9% | **81.1%** | 84.2% |
| Frontend | 67.1% | **83.2%** | 88.9% |
| Mobile | 60.6% | **82.6%** | 83.3% |

Four fields, entirely different skills in each (`react`/`typescript`/`api` against
`cloud`/`devops`/`ci-cd` against `android`/`ios`/`api`), and the three-skill figure lands in
a two-point band every time. Mobile is starkest: three skills to five adds **0.7 points**.

## The two method decisions worth reviewing

**The denominator is skill-bearing postings, not all open ones.** `internal/job/verdict`'s
own comment gives the rule — frequency is measured against postings that list at least one
tagged skill "so postings the tagger left skill-less don't deflate frequencies." For backend
that is 41,712 of 45,453 (91.8%). Counting against the raw total would publish a gap in our
dictionary as a gap in demand.

**Coverage uses array overlap, not summed frequencies.** A posting asking for both Java and
AWS is one posting; adding the top five frequencies would count it twice and exceed 100%.
This is also the article's one piece of arithmetic teaching: "api appears in 51% of postings"
cannot be read as "knowing api reaches 51%."

Both are stated in the piece, as is the bound they imply: a niche technology can be in real
demand and invisible to a dictionary-only tagger.

## Checklist

- [x] I understand this code and can explain how it interacts with the rest of the system.
- [x] No Go, no SQL, no migrations, no generated artifacts changed.
- [x] `web/`: `pnpm test` (1881), `lint` (0 errors), `check` (0 errors) and `build` all pass.
- [x] Post verified in a production build: returns 200, all three tables render, every figure
      appears, the `/roast` link resolves.
- [x] Stays within the core boundary — one `.svx` post and one Markdown measurement file.

## How the numbers were checked

Four read-only passes over production, saved with their exact SQL, date, wall-clock time and
unedited output in `docs/superpowers/plans/measurements/04-skill-coverage-curve.md`. Every
percentage and every increment in the prose was recomputed from the raw counts rather than
trusted.

Each query took 50–65 s — a bare `count(*)` on this predicate takes 57 s on the current host
— so they were run one at a time rather than widened.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new article explaining how three skills can cover approximately 81–83% of postings across backend, DevOps, frontend, and mobile roles.
  * Included comparisons, data tables, methodology, and limitations of the analysis.
  * Added guidance directing readers to the free CV analysis page.

* **Documentation**
  * Added detailed production documentation covering skill coverage measurement, queries, results, and interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->